### PR TITLE
Add Storage.from_buffer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ class clean(distutils.command.clean.clean):
 
 include_dirs = []
 extra_link_args = []
-extra_compile_args = ['-std=c++11']
+extra_compile_args = ['-std=c++11', '-Wno-write-strings']
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 lib_path = os.path.join(cwd, "torch", "lib")
@@ -138,6 +138,7 @@ main_sources = [
     "torch/csrc/Generator.cpp",
     "torch/csrc/Tensor.cpp",
     "torch/csrc/Storage.cpp",
+    "torch/csrc/byte_order.cpp",
     "torch/csrc/utils.cpp",
     "torch/csrc/allocators.cpp",
     "torch/csrc/serialization.cpp",

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2238,5 +2238,19 @@ class TestTorch(TestCase):
         c[1].fill_(20)
         self.assertEqual(c[1], c[3], 0)
 
+    def test_from_buffer(self):
+        a = bytearray([1, 2, 3, 4])
+        self.assertEqual(torch.ByteStorage.from_buffer(a).tolist(), [1, 2, 3, 4])
+        shorts = torch.ShortStorage.from_buffer(a, 'big')
+        self.assertEqual(shorts.size(), 2)
+        self.assertEqual(shorts.tolist(), [258, 772])
+        ints = torch.IntStorage.from_buffer(a, 'little')
+        self.assertEqual(ints.size(), 1)
+        self.assertEqual(ints[0], 67305985)
+        f = bytearray([0x40, 0x10, 0x00, 0x00])
+        floats = torch.FloatStorage.from_buffer(f, 'big')
+        self.assertEqual(floats.size(), 1)
+        self.assertEqual(floats[0], 2.25)
+
 if __name__ == '__main__':
     unittest.main()

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -5,10 +5,10 @@
 #include <TH/TH.h>
 #include <libshm.h>
 #include "THP.h"
+#include "byte_order.h"
 
 #include "generic/Storage.cpp"
 #include <TH/THGenerateAllTypes.h>
 
 #include "generic/StorageCopy.cpp"
 #include <TH/THGenerateAllTypes.h>
-

--- a/torch/csrc/byte_order.cpp
+++ b/torch/csrc/byte_order.cpp
@@ -1,0 +1,81 @@
+#include "byte_order.h"
+
+static inline uint16_t decodeUInt16LE(const uint8_t *data) {
+  return (data[0]<<0) | (data[1]<<8);
+}
+
+static inline uint16_t decodeUInt16BE(const uint8_t *data) {
+  return (data[1]<<0) | (data[0]<<8);
+}
+
+static inline uint32_t decodeUInt32LE(const uint8_t *data) {
+  return (data[0]<<0) | (data[1]<<8) | (data[2]<<16) | (data[3]<<24);
+}
+
+static inline uint32_t decodeUInt32BE(const uint8_t *data) {
+  return (data[3]<<0) | (data[2]<<8) | (data[1]<<16) | (data[0]<<24);
+}
+
+static inline uint64_t decodeUInt64LE(const uint8_t *data) {
+  return (((uint64_t)data[0])<< 0) | (((uint64_t)data[1])<< 8) |
+         (((uint64_t)data[2])<<16) | (((uint64_t)data[3])<<24) |
+         (((uint64_t)data[4])<<32) | (((uint64_t)data[5])<<40) |
+         (((uint64_t)data[6])<<48) | (((uint64_t)data[7])<<56);
+}
+
+static inline uint64_t decodeUInt64BE(const uint8_t *data) {
+  return (((uint64_t)data[7])<< 0) | (((uint64_t)data[7])<< 8) |
+         (((uint64_t)data[5])<<16) | (((uint64_t)data[4])<<24) |
+         (((uint64_t)data[3])<<32) | (((uint64_t)data[2])<<40) |
+         (((uint64_t)data[1])<<48) | (((uint64_t)data[0])<<56);
+}
+
+THPByteOrder THP_nativeByteOrder()
+{
+  uint32_t x = 1;
+  return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;
+}
+
+void THP_decodeInt16Buffer(int16_t* dst, const uint8_t* src, THPByteOrder order, size_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    dst[i] = (int16_t) (order == THP_BIG_ENDIAN ? decodeUInt16BE(src) : decodeUInt16LE(src));
+    src += sizeof(int16_t);
+  }
+}
+
+void THP_decodeInt32Buffer(int32_t* dst, const uint8_t* src, THPByteOrder order, size_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    dst[i] = (int32_t) (order == THP_BIG_ENDIAN ? decodeUInt32BE(src) : decodeUInt32LE(src));
+    src += sizeof(int32_t);
+  }
+}
+
+void THP_decodeInt64Buffer(int64_t* dst, const uint8_t* src, THPByteOrder order, size_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    dst[i] = (int64_t) (order == THP_BIG_ENDIAN ? decodeUInt64BE(src) : decodeUInt64LE(src));
+    src += sizeof(int64_t);
+  }
+}
+
+void THP_decodeFloatBuffer(float* dst, const uint8_t* src, THPByteOrder order, size_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    union { uint32_t x; float f; };
+    x = (order == THP_BIG_ENDIAN ? decodeUInt32BE(src) : decodeUInt32LE(src));
+    dst[i] = f;
+    src += sizeof(float);
+  }
+}
+
+void THP_decodeDoubleBuffer(double* dst, const uint8_t* src, THPByteOrder order, size_t len)
+{
+  for (size_t i = 0; i < len; i++) {
+    union { uint64_t x; double d; };
+    x = (order == THP_BIG_ENDIAN ? decodeUInt64BE(src) : decodeUInt64LE(src));
+    dst[i] = d;
+    src += sizeof(double);
+  }
+}

--- a/torch/csrc/byte_order.h
+++ b/torch/csrc/byte_order.h
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <stddef.h>
+
+enum THPByteOrder {
+  THP_LITTLE_ENDIAN = 0,
+  THP_BIG_ENDIAN = 1
+};
+
+THPByteOrder THP_nativeByteOrder();
+void THP_decodeInt16Buffer(int16_t* dst, const uint8_t* src, THPByteOrder order, size_t len);
+void THP_decodeInt32Buffer(int32_t* dst, const uint8_t* src, THPByteOrder order, size_t len);
+void THP_decodeInt64Buffer(int64_t* dst, const uint8_t* src, THPByteOrder order, size_t len);
+void THP_decodeFloatBuffer(float* dst, const uint8_t* src, THPByteOrder order, size_t len);
+void THP_decodeDoubleBuffer(double* dst, const uint8_t* src, THPByteOrder order, size_t len);


### PR DESCRIPTION
The from_buffer is similar to numpy's frombuffer. It decodes a Python
buffer object into a Storage object. For byte and char storages, it
simply copies the bytes.
