### PR TITLE
Clean up Module forward and __call__

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -171,10 +171,15 @@ for test in tests:
     def do_test(self, cls=cls, constructor_args=constructor_args, call_args=call_args):
         input = create_input(call_args)
         output = cls(*constructor_args)(*input)
+        if not isinstance(output, tuple):
+            output = (output,)
         for i, o in enumerate(output):
             analytical = get_analytical_jacobian(input, o)
             def fn(input):
-                return cls(*constructor_args)(*input)[i].data
+                tmp = cls(*constructor_args)(*input)
+                if not isinstance(tmp, tuple):
+                    tmp = (tmp,)
+                return tmp[i].data
             numerical = get_numerical_jacobian(fn, input, input)
             self.assertLessEqual(
                 max(a.add(-1, n).abs().max() for a, n in zip(analytical, numerical)),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -88,10 +88,10 @@ class TestNN(NNTestCase):
 
         def fw_hook(inc, h_module, input, output):
             self.assertIsInstance(input, tuple)
-            self.assertIsInstance(output, tuple)
+            self.assertIsInstance(output, Variable)
             self.assertTrue(h_module is module)
             self.assertEqual(input[0].data, torch.ones(5, 5))
-            self.assertEqual(output[0].data, torch.Tensor(5, 5).fill_(1 / (1 + 1 / math.e)))
+            self.assertEqual(output.data, torch.Tensor(5, 5).fill_(1 / (1 + 1 / math.e)))
             counter['forwards'] += inc
 
         def bw_hook(inc, h_module, grad_input, grad_output):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -59,6 +59,8 @@ class Function(object):
                 del self.to_save
 
         del self.input  # Remove unnecessary references to input
+        if len(output) == 1:
+            output = output[0]
         return output
 
     def _do_backward(self, *grad_output):

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -54,7 +54,7 @@ class Variable(object):
         raise AttributeError(name)
 
     def __getitem__(self, key):
-        return Index(key)(self)[0]
+        return Index(key)(self)
 
     def backward(self, gradient=None):
         if self.volatile:
@@ -90,84 +90,84 @@ class Variable(object):
 
     def type(self, t):
         if t != type(self.data):
-            return Copy(t)(self)[0]
+            return Copy(t)(self)
         return self
 
     def add(self, other, inplace=False):
         if isinstance(other, Variable):
-            return Add(inplace)(self, other)[0]
+            return Add(inplace)(self, other)
         else:
             assert not torch.isTensor(other)
-            return AddConstant(other, inplace)(self)[0]
+            return AddConstant(other, inplace)(self)
 
     def add_(self, other):
         return self.add(other, inplace=True)
 
     def sub(self, other):
         if isinstance(other, Variable):
-            return Sub()(self, other)[0]
+            return Sub()(self, other)
         else:
             assert not torch.isTensor(other)
-            return SubConstant(other)(self)[0]
+            return SubConstant(other)(self)
 
     def sub_(self, other):
         return self.add(other, inplace=True)
 
     def mul(self, other):
         if isinstance(other, Variable):
-            return Mul()(self, other)[0]
+            return Mul()(self, other)
         else:
             assert not torch.isTensor(other)
-            return MulConstant(other)(self)[0]
+            return MulConstant(other)(self)
 
     def mul_(self, other):
         if not isinstance(other, Variable) and not torch.isTensor(other):
-            return MulConstant(other, inplace=True)(self)[0]
+            return MulConstant(other, inplace=True)(self)
 
     def div(self, other):
         if isinstance(other, Variable):
-            return Div()(self, other)[0]
+            return Div()(self, other)
         else:
             assert not torch.isTensor(other)
-            return DivConstant(other)(self)[0]
+            return DivConstant(other)(self)
 
     def div_(self, other):
         if not isinstance(other, Variable) and not torch.isTensor(other):
-            return DivConstant(other, inplace=True)(self)[0]
+            return DivConstant(other, inplace=True)(self)
 
     def pow(self, other):
         if isinstance(other, Variable):
-            return Pow()(self, other)[0]
+            return Pow()(self, other)
         else:
             assert not torch.isTensor(other)
-            return PowConstant(other)(self)[0]
+            return PowConstant(other)(self)
 
     def exp(self):
-        return Exp()(self)[0]
+        return Exp()(self)
 
     def exp_(self):
-        return Exp(inplace=True)(self)[0]
+        return Exp(inplace=True)(self)
 
     def log(self):
-        return Log()(self)[0]
+        return Log()(self)
 
     def log1p(self):
-        return Log1p()(self)[0]
+        return Log1p()(self)
 
     def neg(self):
-        return Negate()(self)[0]
+        return Negate()(self)
 
     def neg_(self):
-        return Negate(inplace=True)(self)[0]
+        return Negate(inplace=True)(self)
 
     def view(self, *sizes):
-        return View(*sizes)(self)[0]
+        return View(*sizes)(self)
 
     def t(self):
-        return Transpose(0, 1)(self)[0]
+        return Transpose(0, 1)(self)
 
     def transpose(self, dim1, dim2):
-        return Transpose(dim1, dim2)(self)[0]
+        return Transpose(dim1, dim2)(self)
 
     def __add__(self, other):
         return self.add(other)
@@ -177,7 +177,7 @@ class Variable(object):
         return self.sub(other)
 
     def __rsub__(self, other):
-        return SubConstant(other, sub_tensor=True)(self)[0]
+        return SubConstant(other, sub_tensor=True)(self)
 
     def __mul__(self, other):
         return self.mul(other)
@@ -188,17 +188,17 @@ class Variable(object):
     __truediv__ = __div__
 
     def __rdiv__(self, other):
-        return DivConstant(other, div_by_tensor=True)(self)[0]
+        return DivConstant(other, div_by_tensor=True)(self)
     __rtruediv__ = __rdiv__
 
     def __pow__(self, other):
         return self.pow(other)
 
     def __rpow__(self, other):
-        return PowConstant(other, tensor_power=True)(self)[0]
+        return PowConstant(other, tensor_power=True)(self)
 
     def __neg__(self):
-        return Negate()(self)[0]
+        return Negate()(self)
 
 
 from .leaf import Leaf

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -13,7 +13,7 @@ class Threshold(Module):
         self.inplace = inplace
         # TODO: check in THNN (if inplace == True, then assert value <= threshold)
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.Threshold(self.threshold, self.value, self.inplace)(input)
 
 
@@ -32,7 +32,7 @@ class HardTanh(Module):
         self.inplace = inplace
         assert self.max_val > self.min_val
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.HardTanh(self.min_val, self.max_val, self.inplace)(input)
 
 
@@ -44,30 +44,30 @@ class ReLU6(HardTanh):
 
 class Sigmoid(Module):
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.Sigmoid()(input)
 
 
 class Tanh(Module):
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.Tanh()(input)
 
 
 class Softmax(Module):
 
-    def _forward(self, input):
+    def forward(self, input):
         assert input.dim() == 2, 'Softmax requires a 2D tensor as input'
         return self._backend.Softmax()(input)
 
 
 class Softmax2d(Module):
 
-    def _forward(self, input):
+    def forward(self, input):
         assert input.dim() == 4, 'Softmax2d requires a 4D tensor as input'
         return self._backend.Softmax()(input)
 
 class LogSoftmax(Module):
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.LogSoftmax()(input)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -39,13 +39,13 @@ class BatchNorm(Module):
         if input.size(1) != self.running_mean.nElement():
             raise RuntimeError('got {}-feature tensor, expected {}'.format(input.size(1), self.running_mean.nElement()))
 
-    def __call__(self, input):
+    def forward(self, input):
         self._checkInputDim(input)
         args = (input,)
         if self.weight is not None:
             args = args + (self.weight, self.bias)
         return self._backend.BatchNorm(self.running_mean,
-                self.running_var, self.train, self.momentum, self.eps)(*args)[0]
+                self.running_var, self.train, self.momentum, self.eps)(*args)
 
 
 class BatchNorm2d(BatchNorm):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -9,13 +9,14 @@ class Container(Module):
         super(Container, self).__init__()
         self.modules = []
         for key, value in kwargs.items():
-            self._assign_module(key, value)
+            self.add_module(key, value)
 
-    def _assign_module(self, name, module):
-        # TODO: error message
-        assert not hasattr(self, name)
+    def add_module(self, name, module):
+        if hasattr(self, name):
+            raise KeyError("attribute already exists '{}'".format(name))
         setattr(self, name, module)
-        self.modules.append(module)
+        if module is not None:
+            self.modules.append(module)
 
     def parameters(self):
         for module in self.modules:
@@ -29,17 +30,17 @@ class Sequential(Container):
         super(Sequential, self).__init__()
         if len(args) == 1 and isinstance(args[0], OrderedDict):
             for key, module in args[0].items():
-                self._assign_module(key, module)
+                self.add_module(key, module)
         else:
             idx = 0
             for module in args:
-                self._assign_module(str(idx), module)
+                self.add_module(str(idx), module)
                 idx += 1
 
     def __getitem__(self, idx):
         return self.modules[idx]
 
-    def _forward(self, input):
+    def forward(self, input):
         for module in self.modules:
             input = module(input)
-        return (input,)
+        return input

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -26,7 +26,7 @@ class Conv2d(Module):
         self.weight.data.uniform_(-stdv, stdv)
         self.bias.data.uniform_(-stdv, stdv)
 
-    def _forward(self, input):
+    def forward(self, input):
         conv2d = self._backend.Conv2d(self.kw, self.kh, self.dw, self.dh, self.padw, self.padh)
         if self.bias is None:
             return conv2d(input, self.weight)

--- a/torch/nn/modules/criterion.py
+++ b/torch/nn/modules/criterion.py
@@ -12,7 +12,7 @@ class AbsCriterion(Module):
         super(AbsCriterion, self).__init__()
         self.size_average = size_average
 
-    def _forward(self, input, target):
+    def forward(self, input, target):
         if isinstance(target, Variable):
             _assert_no_grad(target)
             target = target.data
@@ -25,9 +25,8 @@ class ClassNLLCriterion(Module):
         self.weight = weight
         self.size_average = size_average
 
-    def _forward(self, input, target):
+    def forward(self, input, target):
         if isinstance(target, Variable):
             _assert_no_grad(target)
             target = target.data
         return self._backend.ClassNLLCriterion(target, self.size_average, weight=self.weight)(input)
-

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -22,5 +22,5 @@ class Linear(Module):
         self.weight.data.uniform_(-stdv, stdv)
         self.bias.data.uniform_(-stdv, stdv)
 
-    def _forward(self, input):
+    def forward(self, input):
         return self._backend.Linear()(input, self.weight, self.bias)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -13,7 +13,7 @@ class Module(object):
         self.forward_hooks = OrderedDict()
         self.train = True
 
-    def _forward(self, *input):
+    def forward(self, *input):
         raise NotImplementedError
 
     def type(self, type, *forwarded_args):
@@ -63,14 +63,12 @@ class Module(object):
         del self.forward_hooks[name]
 
     def __call__(self, *input):
-        result = self._forward(*input)
+        result = self.forward(*input)
         for hook in self.forward_hooks.values():
             hook(self, input, result)
-        fn = result[0].creator
+        fn = result.creator
         for key, hook in self.backward_hooks.items():
             fn.register_hook(key, lambda gi,go,hook=hook: hook(self, gi, go))
-        if len(result) == 1:
-            return result[0]
         return result
 
     def parameters(self):
@@ -82,4 +80,3 @@ class Module(object):
     def zero_grad(self):
         for p in self.parameters():
             p.grad.zero_()
-

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -17,8 +17,8 @@ class MaxPool2d(Module):
         self.dilw = dilw
         self.ceil_mode = ceil_mode
 
-    def __call__(self, input):
-        return self._backend.MaxPool2d(self.kw, self.kh, self.dw, self.dh, self.padw, self.padh, self.dilh, self.dilw, self.ceil_mode)(input)[0]
+    def forward(self, input):
+        return self._backend.MaxPool2d(self.kw, self.kh, self.dw, self.dh, self.padw, self.padh, self.dilh, self.dilw, self.ceil_mode)(input)
 
 class AvgPool2d(Module):
 
@@ -33,5 +33,5 @@ class AvgPool2d(Module):
         self.ceil_mode = ceil_mode
         self.count_include_pad = count_include_pad
 
-    def __call__(self, input):
-        return self._backend.AvgPool2d(self.kw, self.kh, self.dw, self.dh, self.padw, self.padh, self.ceil_mode, self.count_include_pad)(input)[0]
+    def forward(self, input):
+        return self._backend.AvgPool2d(self.kw, self.kh, self.dw, self.dh, self.padw, self.padh, self.ceil_mode, self.count_include_pad)(input)


### PR DESCRIPTION
- _forward is renamed forward since users should override it
- some `__call__` overrides are changed to forward
- function which return a single variable are changed to return that
  variable instead of a one-element tuple
