### PR TITLE
OSX + Python 2 build fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,12 @@ C = Extension("torch._C",
 )
 extensions.append(C)
 
+DL = Extension("torch._dl",
+    sources=["torch/csrc/dl.c"],
+    language='c',
+)
+extensions.append(DL)
+
 THNN = Extension("torch._thnn._THNN",
     libraries=['TH', 'THNN'],
     sources=['torch/csrc/nn/THNN.cpp'],

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -10,8 +10,16 @@ from ._utils import _import_dotted_name
 # modules against the _C shared object. Their missing THP symbols will be
 # automatically filled by the dynamic loader.
 import os as _dl_flags
+
+# first check if the os package has the required flags
 if not hasattr(_dl_flags, 'RTLD_GLOBAL') or not hasattr(_dl_flags, 'RTLD_NOW'):
-    import DLFCN as _dl_flags
+    try:
+        # next try if DLFCN exists
+        import DLFCN as _dl_flags
+    except ImportError:
+        # as a last attempt, use compile-time constants
+        import torch._dl as _dl_flags
+        
 old_flags = sys.getdlopenflags()
 sys.setdlopenflags(_dl_flags.RTLD_GLOBAL | _dl_flags.RTLD_NOW)
 from torch._C import *

--- a/torch/csrc/dl.c
+++ b/torch/csrc/dl.c
@@ -1,0 +1,47 @@
+#include <dlfcn.h>
+#include <Python.h>
+
+PyObject* module;
+
+static PyMethodDef TorchDlMethods[] = {
+  {NULL, NULL, 0, NULL}
+};
+
+#if PY_MAJOR_VERSION != 2
+static struct PyModuleDef torchdlmodule = {
+   PyModuleDef_HEAD_INIT,
+   "torch._dl",
+   NULL,
+   -1,
+   TorchDlMethods
+};
+#endif
+
+#if PY_MAJOR_VERSION == 2
+PyMODINIT_FUNC init_dl()
+#else
+PyMODINIT_FUNC PyInit__dl()
+#endif
+{
+
+#if PY_MAJOR_VERSION == 2
+#define ASSERT_TRUE(cmd) if (!(cmd)) {PyErr_SetString(PyExc_ImportError, "initialization error"); return;}
+#else
+#define ASSERT_TRUE(cmd) if (!(cmd)) return NULL
+#endif
+
+#if PY_MAJOR_VERSION == 2
+  ASSERT_TRUE(module = Py_InitModule("torch._dl", TorchDlMethods));
+#else
+  ASSERT_TRUE(module = PyModule_Create(&torchdlmodule));
+#endif
+  ASSERT_TRUE(PyModule_AddIntConstant(module, "RTLD_GLOBAL", (long) RTLD_GLOBAL) == 0);
+  ASSERT_TRUE(PyModule_AddIntConstant(module, "RTLD_NOW", (long) RTLD_NOW) == 0);
+
+#if PY_MAJOR_VERSION == 2
+#else
+  return module;
+#endif
+
+#undef ASSERT_TRUE
+}

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -4,23 +4,23 @@ set -e
 BASE_DIR=$(pwd)
 cd torch/lib
 INSTALL_DIR=$(pwd)/tmp_install
-BASIC_FLAGS=" -DTH_INDEX_BASE=0 -I$INSTALL_DIR/include -I$INSTALL_DIR/include/TH -I$INSTALL_DIR/include/THC "
+BASIC_C_FLAGS=" -DTH_INDEX_BASE=0 -I$INSTALL_DIR/include -I$INSTALL_DIR/include/TH -I$INSTALL_DIR/include/THC "
 LDFLAGS="-L$INSTALL_DIR/lib "
 if [[ $(uname) == 'Darwin' ]]; then
     LDFLAGS="$LDFLAGS -Wl,-rpath,@loader_path"
 else
     LDFLAGS="$LDFLAGS -Wl,-rpath,\$ORIGIN"
 fi
-FLAGS="$BASIC_FLAGS $LDFLAGS"
+C_FLAGS="$BASIC_C_FLAGS $LDFLAGS"
 function build() {
   mkdir -p build/$1
   cd build/$1
   cmake ../../$1 -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/FindCUDA" \
               -DTorch_FOUND="1" \
               -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-              -DCMAKE_C_FLAGS="$FLAGS" \
-              -DCMAKE_CXX_FLAGS="$FLAGS" \
-              -DCUDA_NVCC_FLAGS="$BASIC_FLAGS" \
+              -DCMAKE_C_FLAGS="$C_FLAGS" \
+              -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS" \
+              -DCUDA_NVCC_FLAGS="$BASIC_C_FLAGS" \
               -DTH_INCLUDE_PATH="$INSTALL_DIR/include" \
               -DTH_LIB_PATH="$INSTALL_DIR/lib"
   make install -j$(getconf _NPROCESSORS_ONLN)
@@ -39,12 +39,15 @@ function build() {
 mkdir -p tmp_install
 build TH
 build THNN
-build libshm
 
 if [[ "$1" == "--with-cuda" ]]; then
     build THC
     build THCUNN
 fi
+
+CPP_FLAGS=" -std=c++11 "
+build libshm
+
 
 cp $INSTALL_DIR/lib/* .
 cp THNN/generic/THNN.h .


### PR DESCRIPTION
if os.RTLD\* or DLFCN are not found,
as a last ditch attempt, use compile time RTLD_\* constants to dlopent torch._C

Also adds a c++11 flag when compiling libshm
