### PR TITLE
Add back support for child=None in Container constructor

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -219,6 +219,21 @@ class TestNN(NNTestCase):
         self.assertEqual(num_params(n), 2)
         self.assertEqual(num_params(s), 2)
 
+    def test_add_module(self):
+        l = nn.Linear(10, 20)
+        net = nn.Container(
+            l=l,
+            l2=l,
+            empty=None,
+        )
+        self.assertEqual(net.l, l)
+        self.assertEqual(net.l2, l)
+        self.assertEqual(net.empty, None)
+        net.add_module('l3', l)
+        self.assertEqual(net.l3, l)
+        self.assertRaises(KeyError, lambda: net.add_module('l', l))
+        self.assertRaises(ValueError, lambda: net.add_module('x', 'non-module'))
+
     def test_Dropout(self):
         input = torch.Tensor(1000)
         self._test_dropout(nn.Dropout, input)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -47,7 +47,7 @@ class Container(Module):
     def add_module(self, name, module):
         if hasattr(self, name):
             raise KeyError("attribute already exists '{}'".format(name))
-        if not isinstance(module, Module):
+        if not isinstance(module, Module) and module is not None:
             raise ValueError("{} is not a Module subclass".format(
                 torch.typename(module)))
         setattr(self, name, module)


### PR DESCRIPTION
It's often useful to have optional child modules, such as the
downsampling operation in ResNets. Add a test for this case:

``` python
  nn.Container(
    child=None,
  )
```
