### PR TITLE
Fix NLLLoss to take Long targets on both CPU and GPU

### DIFF
--- a/ClassNLLCriterion.cu
+++ b/ClassNLLCriterion.cu
@@ -9,7 +9,7 @@ static const int NTHREADS = 32;
 __global__ void cunn_ClassNLLCriterion_updateOutput_kernel1(float *output,
                                                            float *total_weight,
                                                            float *input,
-                                                           float *target,
+                                                           long  *target,
                                                            float *weights,
                                                            int size_average,
                                                            int n_classes) {
@@ -31,7 +31,7 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel1(float *output,
 __global__ void cunn_ClassNLLCriterion_updateOutput_kernel(float *output,
                                                            float *total_weight,
                                                            float *input,
-                                                           float *target,
+                                                           long *target,
                                                            float *weights,
                                                            int size_average,
                                                            int nframe,
@@ -70,7 +70,7 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel(float *output,
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
   float* gradInput,
   float* weights,
-  float* target,
+  long* target,
   float* total_weight,
   int size_average,
   int n_classes)
@@ -86,7 +86,7 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
 
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
   float *gradInput,
-  float *target,
+  long *target,
   float *weights,
   float *total_weight,
   int size_average,
@@ -107,8 +107,8 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
   }
 }
 
-void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
-  if (THCudaTensor_nDimension(state, target) > 1) {
+void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaLongTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
+  if (THCudaLongTensor_nDimension(state, target) > 1) {
     THError("multi-target not supported");
   }
 
@@ -134,11 +134,11 @@ void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *inpu
 
   input = THCudaTensor_newContiguous(state, input);
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
-  target = THCudaTensor_newContiguous(state, target);
+  target = THCudaLongTensor_newContiguous(state, target);
 
   float *input_data = THCudaTensor_data(state, input);
   float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
-  float *target_data = THCudaTensor_data(state, target);
+  long  *target_data = THCudaLongTensor_data(state, target);
   float *output_data = THCudaTensor_data(state, output);
   float *total_weight_data = THCudaTensor_data(state, total_weight);
 
@@ -173,12 +173,12 @@ void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *inpu
   if (weights) {
     THCudaTensor_free(state, weights);
   }
-  THCudaTensor_free(state, target);
+  THCudaLongTensor_free(state, target);
   THCudaTensor_free(state, input);
 }
 
-void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
-  if (THCudaTensor_nDimension(state, target) > 1) {
+void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaLongTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
+  if (THCudaLongTensor_nDimension(state, target) > 1) {
     THError("multi-target not supported");
   }
 
@@ -206,11 +206,11 @@ void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *i
   }
 
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
-  target = THCudaTensor_newContiguous(state, target);
+  target = THCudaLongTensor_newContiguous(state, target);
 
   float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
   float *gradInput_data = THCudaTensor_data(state, gradInput);
-  float *target_data = THCudaTensor_data(state, target);
+  long  *target_data = THCudaLongTensor_data(state, target);
   float *total_weight_data = THCudaTensor_data(state, total_weight);
 
   if (THCudaTensor_nDimension(state, input) == 1) {
@@ -241,5 +241,5 @@ void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *i
   if (weights) {
     THCudaTensor_free(state, weights);
   }
-  THCudaTensor_free(state, target);
+  THCudaLongTensor_free(state, target);
 }

--- a/SpatialClassNLLCriterion.cu
+++ b/SpatialClassNLLCriterion.cu
@@ -10,7 +10,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
           float *output,
           float *total_weight,
           float *input,
-          float *target,
+          long *target,
           float *weights,
           int size_average,
           int batch_size,
@@ -55,7 +55,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
 
 __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
           float *gradInput,
-          float *target,
+          long *target,
           float *weights,
           float *total_weight,
           int size_average,
@@ -86,13 +86,13 @@ __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
 void THNN_CudaSpatialClassNLLCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THCudaLongTensor *target,
           THCudaTensor *output,
           bool sizeAverage,
           THCudaTensor *weights,
           THCudaTensor *total_weight)
 {
-  THArgCheck(THCudaTensor_nDimension(state, target) == 3, 1,
+  THArgCheck(THCudaLongTensor_nDimension(state, target) == 3, 1,
                "only batches of spatial targets supported (3D tensors)");
   THArgCheck(THCudaTensor_nDimension(state, input) == 4, 2,
                "only batches of spatial inputs supported (4D tensors)");
@@ -107,16 +107,16 @@ void THNN_CudaSpatialClassNLLCriterion_updateOutput(
 
   input = THCudaTensor_newContiguous(state, input);
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
-  target = THCudaTensor_newContiguous(state, target);
+  target = THCudaLongTensor_newContiguous(state, target);
 
   float *input_data = THCudaTensor_data(state, input);
   float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
-  float *target_data = THCudaTensor_data(state, target);
+  long  *target_data = THCudaLongTensor_data(state, target);
   float *output_data = THCudaTensor_data(state, output);
   float *total_weight_data = THCudaTensor_data(state, total_weight);
 
-  long batch_size = THCudaTensor_size(state, target, 0);
-  long map_nelem = THCudaTensor_nElement(state, target) / batch_size;
+  long batch_size = THCudaLongTensor_size(state, target, 0);
+  long map_nelem = THCudaLongTensor_nElement(state, target) / batch_size;
   int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
   blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
   int total_blocks = blocks_per_sample * batch_size;
@@ -141,20 +141,20 @@ void THNN_CudaSpatialClassNLLCriterion_updateOutput(
 
   if (weights)
     THCudaTensor_free(state, weights);
-  THCudaTensor_free(state, target);
+  THCudaLongTensor_free(state, target);
   THCudaTensor_free(state, input);
 }
 
 void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THCudaLongTensor *target,
           THCudaTensor *gradInput,
           bool sizeAverage,
           THCudaTensor *weights,
           THCudaTensor *total_weight)
 {
-  THArgCheck(THCudaTensor_nDimension(state, target) == 3, 1,
+  THArgCheck(THCudaLongTensor_nDimension(state, target) == 3, 1,
                "only batches of spatial targets supported (3D tensors)");
   THArgCheck(THCudaTensor_nDimension(state, input) == 4, 2,
                "only batches of spatial inputs supported (4D tensors)");
@@ -171,15 +171,15 @@ void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
 
   input = THCudaTensor_newContiguous(state, input);
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
-  target = THCudaTensor_newContiguous(state, target);
+  target = THCudaLongTensor_newContiguous(state, target);
 
   float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
   float *gradInput_data = THCudaTensor_data(state, gradInput);
-  float *target_data = THCudaTensor_data(state, target);
+  long *target_data = THCudaLongTensor_data(state, target);
   float *total_weight_data = THCudaTensor_data(state, total_weight);
 
-  long batch_size = THCudaTensor_size(state, target, 0);
-  long map_nelem = THCudaTensor_nElement(state, target) / batch_size;
+  long batch_size = THCudaLongTensor_size(state, target, 0);
+  long map_nelem = THCudaLongTensor_nElement(state, target) / batch_size;
   int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
   blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
   int total_blocks = blocks_per_sample * batch_size;
@@ -200,6 +200,6 @@ void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
 
   if (weights)
     THCudaTensor_free(state, weights);
-  THCudaTensor_free(state, target);
+  THCudaLongTensor_free(state, target);
   THCudaTensor_free(state, input);
 }

--- a/THCUNN.h
+++ b/THCUNN.h
@@ -45,7 +45,7 @@ TH_API void THNN_CudaBCECriterion_updateGradInput(
 TH_API void THNN_CudaClassNLLCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THIndexTensor *target,
           THCudaTensor *output,
           bool sizeAverage,
           THCudaTensor *weights,       // [OPTIONAL]
@@ -53,7 +53,7 @@ TH_API void THNN_CudaClassNLLCriterion_updateOutput(
 TH_API void THNN_CudaClassNLLCriterion_updateGradInput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THIndexTensor *target,
           THCudaTensor *gradInput,
           bool sizeAverage,
           THCudaTensor *weights,       // [OPTIONAL]
@@ -62,7 +62,7 @@ TH_API void THNN_CudaClassNLLCriterion_updateGradInput(
 TH_API void THNN_CudaSpatialClassNLLCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THIndexTensor *target,
           THCudaTensor *output,
           bool sizeAverage,
           THCudaTensor *weights,       // [OPTIONAL]
@@ -70,7 +70,7 @@ TH_API void THNN_CudaSpatialClassNLLCriterion_updateOutput(
 TH_API void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
           THCState *state,
           THCudaTensor *input,
-          THCudaTensor *target,
+          THIndexTensor *target,
           THCudaTensor *gradInput,
           bool sizeAverage,
           THCudaTensor *weights,       // [OPTIONAL]

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -627,7 +627,7 @@ class CriterionTest(TestBase):
             cpu_input = self._get_input()
             type_map = {
                 torch.DoubleTensor: torch.cuda.FloatTensor,
-                torch.LongTensor: torch.cuda.FloatTensor
+                torch.LongTensor: torch.cuda.LongTensor
             }
             gpu_input = to_gpu(cpu_input, type_map=type_map)
 
@@ -646,4 +646,3 @@ class CriterionTest(TestBase):
             test_case.assertEqual(cpu_gradInput, gpu_gradInput, 2e-4)
         except NotImplementedError:
             pass
-

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -989,7 +989,7 @@ class TestNN(NNTestCase):
 
     def test_MultiCriterion(self):
         input = torch.rand(2, 10)
-        target = torch.Tensor((1, 8))
+        target = torch.LongTensor((1, 8))
         nll = nn.ClassNLLCriterion()
         nll2 = nn.CrossEntropyCriterion()
         mc = nn.MultiCriterion().add(nll, 0.5).add(nll2)
@@ -1006,7 +1006,7 @@ class TestNN(NNTestCase):
         mc.float()
         gradInput = gradInput.clone()
         input3 = input.float()
-        target3 = target.float()
+        target3 = target
         output3 = mc.forward(input3, target3)
         gradInput3 = mc.backward(input3, target3)
         self.assertEqual(output, output3)
@@ -1039,7 +1039,7 @@ class TestNN(NNTestCase):
 
     def test_ParallelCriterion(self):
         input = [torch.rand(2, 10), torch.randn(2, 10)]
-        target = [torch.IntTensor((1, 8)), torch.randn(2, 10)]
+        target = [torch.LongTensor((1, 8)), torch.randn(2, 10)]
         nll = nn.ClassNLLCriterion()
         mse = nn.MSECriterion()
         pc = nn.ParallelCriterion().add(nll, 0.5).add(mse)
@@ -1055,7 +1055,7 @@ class TestNN(NNTestCase):
         pc.float()
         gradInput[0], gradInput[1] = gradInput[0].clone(), gradInput[1].clone()
         input3 = [input[0].float(), input[1].float()]
-        target3 = [target[0].float(), target[1].float()]
+        target3 = [target[0], target[1].float()]
         output3 = pc.forward(input3, target3)
         gradInput3 = pc.backward(input3, target3)
         self.assertEqual(output, output3)
@@ -1077,7 +1077,7 @@ class TestNN(NNTestCase):
 
         # table input
         input = [torch.randn(2, 10), [torch.rand(2, 10), torch.randn(2, 10)]]
-        target = [torch.IntTensor((2, 5)), [torch.IntTensor((1, 8)), torch.randn(2, 10)]]
+        target = [torch.LongTensor((2, 5)), [torch.LongTensor((1, 8)), torch.randn(2, 10)]]
         nll2 = nn.ClassNLLCriterion()
         nll = nn.ClassNLLCriterion()
         mse = nn.MSECriterion()

--- a/torch/legacy/nn/ClassNLLCriterion.py
+++ b/torch/legacy/nn/ClassNLLCriterion.py
@@ -12,18 +12,12 @@ class ClassNLLCriterion(Criterion):
 
         self.output_tensor = torch.zeros(1)
         self.total_weight_tensor = torch.ones(1)
-        self.target = torch.zeros(1).long()
 
     def updateOutput(self, input, target):
-        if target.type() == 'torch.cuda.FloatTensor':
-            self.target = target
-        else:
-            self.target = target.long()
-
         self._backend.ClassNLLCriterion_updateOutput(
             self._backend.library_state,
             input,
-            self.target,
+            target,
             self.output_tensor,
             self.sizeAverage,
             self.weights,
@@ -34,17 +28,12 @@ class ClassNLLCriterion(Criterion):
 
 
     def updateGradInput(self, input, target):
-        if target.type() == 'torch.cuda.FloatTensor':
-            self.target = target
-        else:
-            self.target = target.long()
-
         self.gradInput.resize_as_(input).zero_()
 
         self._backend.ClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,
-            self.target,
+            target,
             self.gradInput,
             self.sizeAverage,
             self.weights,
@@ -52,4 +41,3 @@ class ClassNLLCriterion(Criterion):
         )
 
         return self.gradInput
-

--- a/torch/legacy/nn/SpatialClassNLLCriterion.py
+++ b/torch/legacy/nn/SpatialClassNLLCriterion.py
@@ -11,18 +11,12 @@ class SpatialClassNLLCriterion(Criterion):
 
         self.output_tensor = torch.zeros(1)
         self.total_weight_tensor = torch.ones(1)
-        self.target = torch.zeros(1).long()
 
     def updateOutput(self, input, target):
-        if target.type() == 'torch.cuda.FloatTensor':
-           self.target = target
-        else:
-           self.target = target.long()
-
         self._backend.SpatialClassNLLCriterion_updateOutput(
             self._backend.library_state,
             input,
-            self.target,
+            target,
             self.output_tensor,
             self.sizeAverage,
             self.weights,
@@ -32,20 +26,14 @@ class SpatialClassNLLCriterion(Criterion):
         return self.output
 
     def updateGradInput(self, input, target):
-        if target.type() == 'torch.cuda.FloatTensor':
-           self.target = target
-        else:
-           self.target = target.long()
-
         self.gradInput.resize_as_(input).zero_()
         self._backend.SpatialClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,
-            self.target,
+            target,
             self.gradInput,
             self.sizeAverage,
             self.weights,
             self.total_weight_tensor
         )
         return self.gradInput
-


### PR DESCRIPTION
This will implicitly fix the MNIST example, and make things consistent between CPU and GPU for NLLLoss to simply accept LongTensor on both CPU and CUDA.
Fixes torch.legacy.nn and unit tests as well.
