### PR TITLE
Allow specifying per-parameter optimization parameters

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1,12 +1,33 @@
 from copy import copy
 from collections import defaultdict
 
+required = object()
+
 class Optimizer(object):
 
-    def __init__(self, model):
-        self.model = model
+    def __init__(self, params, defaults):
         self.state = defaultdict(dict)
-        self.parameters = list(self.model.parameters())
+        self.param_groups = list(params)
+        if not isinstance(self.param_groups[0], dict):
+            self.param_groups = [{'params': self.param_groups}]
+
+        param_set = set()
+        for group in self.param_groups:
+            group['params'] = list(group['params'])
+            group_set = set(group['params'])
+            if not param_set.isdisjoint(group_set):
+                raise ValueError("some parameters appear in more than one "
+                        "parameter group")
+            param_set.update(group_set)
+
+        for name, default in defaults.items():
+            for i, group in enumerate(self.param_groups):
+                if default is required and name not in group:
+                    raise ValueError("parameter group " + str(i) + " didn't "
+                        "specify a value of required optimization parameter "
+                        + name)
+                else:
+                    group.setdefault(name, default)
 
     def __getstate__(self):
         return {
@@ -18,7 +39,9 @@ class Optimizer(object):
         return self.__getstate__()
 
     def _forward_backward(self, forward_closure):
-        self.model.zero_grad()
+        for group in self.param_groups:
+            for p in group['params']:
+                p.grad.zero_()
         loss = forward_closure()
         loss.backward()
         return loss.data[0]

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -1,12 +1,10 @@
-from .optimizer import Optimizer
+from .optimizer import Optimizer, required
 
 class SGD(Optimizer):
 
-    def __init__(self, model, lr, momentum=0, dampening=None):
-        super(SGD, self).__init__(model)
-        self.lr = lr
-        self.momentum = momentum
-        self.dampening = dampening or 0
+    def __init__(self, params, lr=required, momentum=0, dampening=0):
+        defaults = dict(lr=lr, momentum=momentum, dampening=dampening)
+        super(SGD, self).__init__(params, defaults)
 
     def __getstate__(self):
         state = super(SGD, self).__getstate__()
@@ -20,16 +18,17 @@ class SGD(Optimizer):
     def step(self, forward_closure):
         loss = self._forward_backward(forward_closure)
 
-        for p in self.parameters:
-            if self.momentum != 0:
-                param_state = self.state[id(p)]
-                if not 'momentum_buffer' in param_state:
-                    param_state['momentum_buffer'] = p.grad.clone()
+        for group in self.param_groups:
+            for p in group['params']:
+                if group['momentum'] != 0:
+                    param_state = self.state[id(p)]
+                    if not 'momentum_buffer' in param_state:
+                        param_state['momentum_buffer'] = p.grad.clone()
+                    else:
+                        param_state['momentum_buffer'].mul_(group['momentum']).add_(1 - group['dampening'], p.grad)
+                    d_p = param_state['momentum_buffer']
                 else:
-                    param_state['momentum_buffer'].mul_(self.momentum).add_(1 - self.dampening, p.grad)
-                d_p = param_state['momentum_buffer']
-            else:
-                d_p = p.grad
-            p.data.add_(-self.lr, d_p)
+                    d_p = p.grad
+                p.data.add_(-group['lr'], d_p)
 
         return loss


### PR DESCRIPTION
If one wants to specify different optimization parameters on per-variable basis they can do it like this now:

``` python
optimizer = optim.SGD([
    {'params': model.base.parameters(), 'lr': 1e-1},
    {'params': model.classifier.parameters(), 'momentum': 0.9}
], lr=1e-3) # this lr will be the default for all groups that don't specify it
```

**Do not merge. This PR is only for review and test purposes.**
