### PR TITLE
Major improvements to autograd + a couple of CUDA improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,10 @@ main_sources = [
     "torch/csrc/utils.cpp",
     "torch/csrc/allocators.cpp",
     "torch/csrc/serialization.cpp",
+    "torch/csrc/autograd/init.cpp",
+    "torch/csrc/autograd/variable.cpp",
+    "torch/csrc/autograd/function.cpp",
+    "torch/csrc/autograd/engine.cpp",
 ]
 
 try:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1,9 +1,12 @@
 import math
 import unittest
+import contextlib
 from copy import deepcopy
+from collections import OrderedDict
 
 from common import make_jacobian, TestCase, iter_tensors, get_numerical_jacobian
 from torch.autograd.functions import *
+from torch.autograd import Variable
 
 PRECISION = 1e-4
 
@@ -35,6 +38,16 @@ def get_analytical_jacobian(input, output):
 
     return jacobian
 
+
+@contextlib.contextmanager
+def backward_engine(engine):
+    _prev_engine = Variable._execution_engine
+    Variable._execution_engine = engine()
+    try:
+        yield
+    finally:
+        Variable._execution_engine = _prev_engine
+
 class TestAutograd(TestCase):
 
     def test_hooks(self):
@@ -59,7 +72,7 @@ class TestAutograd(TestCase):
         z.backward(torch.ones(5, 5), retain_variables=True)
         self.assertEqual(counter[0], 5)
 
-    def test_backward(self):
+    def _test_backward(self):
         v_t = torch.randn(5, 5)
         x_t = torch.randn(5, 5)
         y_t = torch.rand(5, 5) + 0.1
@@ -81,6 +94,13 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad, x_grad * grad_output)
         self.assertEqual(y.grad, y_grad * grad_output)
         self.assertEqual(z.grad, z_grad * grad_output)
+
+    def test_backward(self):
+        self._test_backward()
+
+    def test_backward_basic_engine(self):
+        with backward_engine(torch.autograd.engine.BasicEngine):
+            self._test_backward()
 
     def test_volatile(self):
         x = Variable(torch.ones(5, 5), requires_grad=True)
@@ -121,9 +141,13 @@ class TestAutograd(TestCase):
         def error():
             raise RuntimeError
         # Make sure backward isn't called on these
+        a.backward_hooks = OrderedDict()
+        x.backward_hooks = OrderedDict()
+        y.backward_hooks = OrderedDict()
         a.backward_hooks['test'] = error
         x.backward_hooks['test'] = error
         y.backward_hooks['test'] = error
+        b.backward(torch.ones(5, 5))
 
     def test_inplace(self):
         x = Variable(torch.ones(5, 5), requires_grad=True)
@@ -132,9 +156,9 @@ class TestAutograd(TestCase):
         z = x * y
         q = z + y
         w = z * y
-        z.dirty = True
+        z.add_(2)
         # Add doesn't need it's inputs to do backward, so it shouldn't raise
-        q.backward(torch.ones(5, 5))
+        q.backward(torch.ones(5, 5), retain_variables=True)
         # Mul saves both inputs in forward, so it should raise
         self.assertRaises(RuntimeError, lambda: w.backward(torch.ones(5, 5)))
 
@@ -154,9 +178,9 @@ class TestAutograd(TestCase):
         z = m + y / 8
         q = z * y
         r = z + y
-        prev_version = z._version[0]
+        prev_version = z._version
         w = z.exp_()
-        self.assertNotEqual(z._version[0], prev_version)
+        self.assertNotEqual(z._version, prev_version)
         r.backward(torch.ones(5, 5), retain_variables=True)
         self.assertEqual(x.grad, torch.ones(5, 5) / 2)
         w.backward(torch.ones(5, 5), retain_variables=True)
@@ -177,21 +201,21 @@ class TestAutograd(TestCase):
 
     def test_shared_storage(self):
         x = Variable(torch.ones(5, 5))
-        x_version = x._version[0]
+        x_version = x._version
         y = x.t()
         z = x[1]
-        self.assertEqual(x._version[0], x_version)
-        z_version = z._version[0]
+        self.assertEqual(x._version, x_version)
+        z_version = z._version
         y.add_(2)
-        self.assertNotEqual(x._version[0], x_version)
-        self.assertNotEqual(z._version[0], z_version)
+        self.assertNotEqual(x._version, x_version)
+        self.assertNotEqual(z._version, z_version)
 
     def _test_setitem(self, index):
         x = Variable(torch.ones(5, 5), requires_grad=True)
         y = x + 2
-        y_version = y._version[0]
+        y_version = y._version
         y[index] = 2
-        self.assertNotEqual(y._version[0], y_version)
+        self.assertNotEqual(y._version, y_version)
         y.backward(torch.ones(5, 5))
         expected_grad = torch.ones(5, 5)
         if isinstance(index, Variable):
@@ -225,6 +249,48 @@ class TestAutograd(TestCase):
                 x2 = x2.cuda(1)
                 self.assertIs(type(x2.data), torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
+
+    def test_backward_copy(self):
+      # This tests checks backward engine for a very subtle bug that appreared
+      # in one of the initial versions of autograd. Gradients tensors were
+      # simply stored in lists while the function waited for all its gradients
+      # to be computed. However, sometimes an output was used multiple times,
+      # so the gradients needed to be summed. Engine used to keep a need_copy
+      # set of tensors that will need a clone upon next addition and removed
+      # them from the set as soon as the clone was performed. However, this
+      # could lead to incorrect results if the same gradient tensor was
+      # buffered in three places in the graph:
+      # 1. When accumulating gradients in one of these places it was cloned
+      #    and removed from need_copy set.
+      # 2. When accumulating in second place, it wasn't in the need_copy set,
+      #    so the gradients were simply accumulated in-place (which already
+      #    modified the grad in 3rd place)
+      # 3. When accumulating in the third place, it wasn't in the need_copy set
+      #    as well, so the incoming gradient was summed in-place, yielding
+      #    incorrect results in all functions, except the first one.
+      x = Variable(torch.ones(5, 5), requires_grad=True)
+      y = Variable(torch.ones(5, 5), requires_grad=True)
+      # Simulate that we're in the middle of the graph
+      a = x + 2
+      b = y + 2
+      c = x + 2
+      # This op will just return grad_output two times in backward
+      add1 = a + b
+      add2 = add1 + c
+      # Simulate a long branch, so grad_output will get buffered.
+      for i in range(4):
+        a = a * 2
+        b = b * 2
+        c = c * 2
+      branch = a + b + c
+      out = add2 + branch
+      # expected gradients are:
+      # for x: 34 (16 from final a, 16 from final c, 2 from add2)
+      # for y: 17 (16 from final b, 1 from add2)
+      grad_output = torch.ones(5, 5)
+      out.backward(grad_output)
+      self.assertEqual(x.grad, torch.ones(5, 5) * 34)
+      self.assertEqual(y.grad, torch.ones(5, 5) * 17)
 
 
 def index_variable(num_indices, max_indices):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -1,3 +1,4 @@
+import torch
 
 def _type(self, new_type=None, async=False):
     if new_type is None:
@@ -10,10 +11,7 @@ def _type(self, new_type=None, async=False):
     return new_type(self.size()).copy_(self, async)
 
 def _cuda(self, idx=None, async=False):
-    import torch.cuda
-    # This already is a CUDA tensor.
-    # Let's check if it needs to be transfered to another GPU.
-    if hasattr(self, 'get_device'):
+    if self.is_cuda:
         target_device = idx if idx else torch.cuda.current_device()
         if self.get_device() != target_device:
             with torch.cuda.device(target_device):

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -1,3 +1,6 @@
+import torch
 
 from .variable import Variable
 from .function import Function
+
+assert torch._C._autograd_init()

--- a/torch/autograd/engine.py
+++ b/torch/autograd/engine.py
@@ -1,52 +1,40 @@
-from collections import Counter, deque
-from .variable import Variable
+from collections import deque, defaultdict
+from torch._C import _ImperativeEngine as ImperativeEngine
 
-class ExecutionEngine(object):
-    def __init__(self):
-        pass
+
+class BasicEngine(object):
 
     def _compute_dependencies(self, function):
-        dependencies = {}
+        dependencies = defaultdict(int)
         seen = {function}
         queue = [function]
         while len(queue) > 0:
             fn = queue.pop()
-            for prev_fn, arg_id in fn.previous_functions:
+            for prev_fn, output_nr in fn.previous_functions:
                 if not prev_fn.requires_grad or isinstance(prev_fn, Variable):
                     continue
-                if prev_fn not in dependencies:
-                    dependencies[prev_fn] = [Counter() for _ in prev_fn.output_ids]
-                output_idx = prev_fn.output_ids[arg_id]
-                dependencies[prev_fn][output_idx][fn] += 1
+                dependencies[prev_fn] += 1
                 if prev_fn not in seen:
                     queue.append(prev_fn)
                     seen.add(prev_fn)
         return dependencies
 
-    def _free_backward_dependency(self, dependencies, prev_fn, fn, arg_id):
-        deps = dependencies[prev_fn]
-        output_idx = prev_fn.output_ids[arg_id]
-        output_deps = deps[output_idx]
-        output_deps[fn] -= 1
-        if output_deps[fn] == 0:
-            del output_deps[fn]
-        return output_idx
-
-
-    def _is_ready_for_backward(self, dependencies, function):
-        for deps in dependencies[function]:
-            if len(deps) > 0:
-                return False
-        return True
+    def _free_backward_dependency(self, dependencies, prev_fn):
+        dependencies[prev_fn] -= 1
+        if dependencies[prev_fn] == 0:
+            del dependencies[prev_fn]
+            return True
+        return False
 
     def _add_grad(self, need_copy, prev_grad, output_nr, d_prev_fn):
+        copy_id = (id(prev_grad), output_nr)
         if not prev_grad[output_nr]:
             prev_grad[output_nr] = d_prev_fn
-            need_copy.add(d_prev_fn)
+            need_copy.add(copy_id)
         else:
             grad_tensor = prev_grad[output_nr]
-            if grad_tensor in need_copy:
-                need_copy.remove(grad_tensor)
+            if copy_id in need_copy:
+                need_copy.remove(copy_id)
                 grad_tensor = grad_tensor.clone()
                 prev_grad[output_nr] = grad_tensor
             grad_tensor.add_(d_prev_fn)
@@ -64,29 +52,35 @@ class ExecutionEngine(object):
 
         while len(ready) > 0:
             fn, grad = ready.pop()
-            grad_input = fn._do_backward(grad, retain_variables)
-            for (prev_fn, arg_id), d_prev_fn in zip(fn.previous_functions, grad_input):
+            grad_input = fn._do_backward(tuple(grad), retain_variables)
+            for (prev_fn, output_nr), d_prev_fn in zip(fn.previous_functions, grad_input):
                 if not prev_fn.requires_grad:
                     # TODO: check that d_prev_fn is None and warn otherwise
                     continue
                 if isinstance(prev_fn, Variable):
                     prev_fn._do_backward((d_prev_fn,), retain_variables)
                     continue
-                output_nr = self._free_backward_dependency(dependencies, prev_fn, fn, arg_id)
-                is_ready = self._is_ready_for_backward(dependencies, prev_fn)
+                is_ready = self._free_backward_dependency(dependencies, prev_fn)
                 if is_ready:
                     if prev_fn in not_ready:
                         prev_grad = not_ready[prev_fn]
                         self._add_grad(need_copy, prev_grad, output_nr, d_prev_fn)
                     else:
-                        assert output_nr == 0
+                        if prev_fn.num_outputs != 1:
+                            raise RuntimeError("one of the function outputs "
+                                    "wasn't used - this is an error not, but "
+                                    "it's going to be fixed soon")
                         prev_grad = (d_prev_fn,)
                     ready.appendleft((prev_fn, prev_grad))
                 else:
                     if prev_fn in not_ready:
                         prev_grad = not_ready[prev_fn]
                     else:
-                        prev_grad = [None for _ in prev_fn.output_ids]
+                        prev_grad = [None for _ in range(prev_fn.num_outputs)]
 
                     self._add_grad(need_copy, prev_grad, output_nr, d_prev_fn)
                     not_ready[prev_fn] = prev_grad
+
+
+from .variable import Variable
+

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -1,126 +1,32 @@
+import torch._C as _C
 from collections import OrderedDict
 from itertools import chain
-from .variable import Variable
 
 
-class Function(object):
+class Function(_C._FunctionBase):
 
-    def __init__(self):
-        self.previous_functions = None
-        self.output_ids = None
-        self.needs_input_grad = None
-        self.saved_variables = None
-        self.to_save = None
-        self._shared_pairs = None
-        self.non_differentiable = None
-        self.backward_hooks = OrderedDict()
-
-    def __call__(self, *input):
-        return self._do_forward(*input)
+    __call__ = _C._FunctionBase._do_forward
 
     def save_for_backward(self, *tensors):
         self.to_save = tensors
 
     def mark_dirty(self, *args):
-        dirty_set = set(args)
-        for var in self.input:
-            if var.data in dirty_set:
-                var._version[0] += 1
+        self.dirty_tensors = args
 
     def mark_shared_storage(self, *pairs):
-        self._shared_pairs = pairs
+        self.shared_pairs = pairs
 
     def mark_non_differentiable(self, *args):
-        self.non_differentiable = set(args)
-
-    @property
-    def saved_tensors(self):
-        for arg, expected_version in self.saved_variables:
-            if arg._version[0] != expected_version:
-                raise RuntimeError("one of the variables needed for gradient "
-                    "computation has been modified by an inplace operation")
-        return tuple(arg.data for arg, _ in self.saved_variables)
-
-    def _do_forward(self, *input):
-        for i in input:
-            if not isinstance(i, Variable):
-                raise RuntimeError("expected a Variable argument, but got " +
-                    type(i).__name__)
-        unpacked_input = tuple(arg.data for arg in input)
-        is_volatile = any(arg.volatile for arg in input)
-        # Save the input, so _save_for_backward can access it
-        self.input = input
-        if not is_volatile:
-            self.needs_input_grad = tuple(arg._requires_grad for arg in input)
-            self.requires_grad = any(self.needs_input_grad)
-            self.previous_functions = [(arg.creator or arg, id(arg)) for arg in input]
-
-        raw_output = self.forward(*unpacked_input)
-        if not isinstance(raw_output, tuple):
-            raw_output = (raw_output,)
-
-        if is_volatile:
-            output = tuple(Variable(tensor, volatile=True)
-                           for tensor in raw_output)
-        else:
-            t2var = {var.data: var for var in input}
-            output = tuple(Variable(tensor, self, requires_grad=self.requires_grad)
-                            if tensor not in t2var
-                            else t2var[tensor]
-                            for tensor in raw_output)
-            for output_var in output:
-                output_var.creator = self
-                t2var[output_var.data] = output_var
-            self.output_ids = {id(var): i for i, var in enumerate(output)}
-            if self.to_save:
-                self.saved_variables = tuple((t2var[t], t2var[t]._version[0])
-                        for t in self.to_save)
-                del self.to_save
-            if self._shared_pairs:
-                for t1, t2 in self._shared_pairs:
-                    v1 = t2var[t1]
-                    v2 = t2var[t2]
-                    v2._version = v1._version
-                del self._shared_pairs
-            if self.non_differentiable is not None:
-                for var in output:
-                    if var.data in self.non_differentiable:
-                        var._requires_grad = False
-
-        del self.input  # Remove unnecessary references to input
-        del self.non_differentiable  # and output
-        if len(output) == 1:
-            output = output[0]
-        return output
-
-    def _do_backward(self, grad_output, retain_variables):
-        if not hasattr(self, 'saved_variables'):
-            raise RuntimeError("Trying to backward through the graph second "
-                    "time, but the buffers have already been freed. Please "
-                    "specify retain_variables=True when calling backward for "
-                    "the first time.")
-        grad_input = self.backward(*grad_output)
-        if not isinstance(grad_input, tuple):
-            grad_input = (grad_input,)
-        assert len(grad_input) == len(self.previous_functions), \
-            self.__class__.__name__ + ' returned an invalid number of gradient tensors'
-
-        self._call_hooks(grad_input, grad_output)
-        if not retain_variables:
-            del self.saved_variables
-        return grad_input
-
-    def _call_hooks(self, grad_input, grad_output):
-        for hook in self.backward_hooks.values():
-            hook(grad_input, grad_output)
+        self.non_differentiable = args
 
     def register_hook(self, name, hook):
+        self.backward_hooks = self.backward_hooks or OrderedDict()
         assert name not in self.backward_hooks, \
             "Trying to register a second hook with name {}".format(name)
         self.backward_hooks[name] = hook
 
     def remove_hook(self, name):
-        assert name in self.backward_hooks, \
+        assert self.backward_hooks and name in self.backward_hooks, \
             "Trying to remove an inexistent hook with name {}".format(name)
         del self.backward_hooks[name]
 
@@ -136,3 +42,4 @@ class InplaceFunction(Function):
     def __init__(self, inplace=False):
         super(InplaceFunction, self).__init__()
         self.inplace = inplace
+

--- a/torch/autograd/functions/pointwise.py
+++ b/torch/autograd/functions/pointwise.py
@@ -1,6 +1,5 @@
 from itertools import repeat
 
-from ..variable import Variable
 from ..function import Function, InplaceFunction
 
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -292,10 +292,10 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
   }                                                                            \
                                                                                \
 dispatch:                                                                      \
-  PyObject *methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
+  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
   THPUtils_assert(methods, "Type %s doesn't implement statless methods",       \
       Py_TYPE(tensor)->tp_name);                                               \
-  PyObject *method = PyObject_GetAttrString(methods, #name);                   \
+  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                   \
   THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
       Py_TYPE(tensor)->tp_name);                                               \
   return PyObject_Call(method, args, kwargs);                                  \
@@ -455,10 +455,10 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
   }                                                                            \
                                                                                \
 dispatch:                                                                      \
-  PyObject *methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
+  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
   THPUtils_assert(methods, "Type %s doesn't implement statless methods",       \
       Py_TYPE(tensor)->tp_name);                                               \
-  PyObject *method = PyObject_GetAttrString(methods, #name);                   \
+  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
   THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
       Py_TYPE(tensor)->tp_name);                                               \
   return PyObject_Call(method, args, kwargs);                                  \
@@ -484,10 +484,10 @@ static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args)
   else if (PyTuple_Size(args) == 2)
     tensor = PyTuple_GET_ITEM(args, 1);
 
-  PyObject *methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
+  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
   THPUtils_assert(methods, "Type %s doesn't implement statless methods",
       Py_TYPE(tensor)->tp_name);
-  PyObject *method = PyObject_GetAttrString(methods, "nonzero");
+  THPObjectPtr method = PyObject_GetAttrString(methods, "nonzero");
   THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
       Py_TYPE(tensor)->tp_name);
   return PyObject_Call(method, args, NULL);
@@ -510,10 +510,10 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
     PyErr_Clear();
   }
 
-  PyObject *methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
+  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
   THPUtils_assert(methods, "Type %s doesn't implement statless methods",
       Py_TYPE(tensor)->tp_name);
-  PyObject *method = PyObject_GetAttrString(methods, "cat");
+  THPObjectPtr method = PyObject_GetAttrString(methods, "cat");
   THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
       Py_TYPE(tensor)->tp_name);
   return PyObject_Call(method, args, NULL);
@@ -557,6 +557,7 @@ extern PyObject * THCPModule_initialSeed(PyObject *_unused);
 
 static PyMethodDef TorchMethods[] = {
   {"_initExtension",  (PyCFunction)THPModule_initExtension,     METH_O,  NULL},
+  {"_autograd_init",  (PyCFunction)THPAutograd_initExtension,   METH_NOARGS,  NULL},
 #ifdef WITH_CUDA
   {"_cuda_init",      (PyCFunction)THCPModule_initExtension,    METH_NOARGS,  NULL},
   {"_cuda_setDevice", (PyCFunction)THCPModule_setDevice_wrap,   METH_O,       NULL},
@@ -785,6 +786,9 @@ PyMODINIT_FUNC PyInit__C()
 #endif
   ASSERT_TRUE(THPGenerator_init(module));
   ASSERT_TRUE(THPException_init(module));
+  ASSERT_TRUE(THPVariable_initModule(module));
+  ASSERT_TRUE(THPFunction_initModule(module));
+  ASSERT_TRUE(THPEngine_initModule(module));
 
   ASSERT_TRUE(THPDoubleStorage_init(module));
   ASSERT_TRUE(THPFloatStorage_init(module));

--- a/torch/csrc/Module.h
+++ b/torch/csrc/Module.h
@@ -8,6 +8,7 @@ extern THPGenerator *THPDefaultGenerator;
 
 #ifdef _THP_CORE
 bool THPModule_tensorCopy(PyObject *dst, PyObject *src);
+bool THPModule_isTensor(PyObject *obj);
 #endif
 
 #endif

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -30,6 +30,8 @@
 #ifdef _THP_CORE
 #include "serialization.h"
 #include "allocators.h"
+
+#include "autograd/autograd.h"
 #endif
 
 #endif

--- a/torch/csrc/autograd/autograd.h
+++ b/torch/csrc/autograd/autograd.h
@@ -1,0 +1,10 @@
+#ifndef THP_AUTOGRAD_H
+#define THP_AUTOGRAD_H
+
+PyObject * THPAutograd_initExtension(PyObject *_unused);
+
+#include "variable.h"
+#include "function.h"
+#include "engine.h"
+
+#endif

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1,0 +1,281 @@
+#include <Python.h>
+#include <structmember.h>
+
+#include <vector>
+#include <unordered_map>
+#include <deque>
+#include <set>
+
+#include "THP.h"
+
+PyObject *THPEngineClass = NULL;
+
+// used for topological sort
+using dependencies_type = std::unordered_map<THPFunction *, int>;
+// stores gradient buffers
+using grad_list_type = std::vector<THPObjectPtr>;
+// used for need_copy set (to ensure correct gradient buffering)
+using buffer_set_type = std::set<std::pair<size_t, int>>;
+// gradient buffer - a list of gradient tensors + id
+struct grad_buffer_type: public grad_list_type {
+  template<typename... Args>
+  grad_buffer_type(size_t buffer_id, Args&&... args):
+      grad_list_type(std::forward<Args>(args)...),
+      buffer_id(buffer_id) {};
+  grad_buffer_type(grad_buffer_type &&other):
+      grad_list_type(std::move(other)),
+      buffer_id(other.buffer_id) {};
+  grad_buffer_type& operator=(grad_buffer_type &&other) {
+      grad_list_type::operator=(std::move(other));
+      buffer_id = other.buffer_id;
+      return *this;
+  };
+
+  size_t buffer_id;
+};
+
+// Computes graph dependencies (using a super simple topological sort)
+dependencies_type THPEngine_compute_dependencies(THPFunction *function)
+{
+  dependencies_type dependencies;
+  std::set<THPFunction *> seen;
+  std::vector<THPFunction *> queue = {function};
+  while (queue.size() > 0) {
+    THPFunction *fn = queue.back(); queue.pop_back();
+    for (int i = 0; i < fn->num_inputs; i++) {
+      THPFunction *prev_fn = (THPFunction*)fn->previous_functions[i].get();
+      // We can ignore variables (their backprop is called every time we have
+      // gradient ready) and functions that don't require gradient.
+      if (THPVariable_Check((PyObject*)prev_fn) || !prev_fn->requires_grad)
+        continue;
+      dependencies[prev_fn] += 1;
+      if (seen.count(prev_fn) == 0) {
+        seen.insert(prev_fn);
+        queue.push_back(prev_fn);
+      }
+    }
+  }
+  return dependencies;
+}
+
+// Frees backward dependency and returns true if prev_fn is ready for backward
+bool THPEngine_free_backward_dependency(dependencies_type &dependencies,
+    THPFunction *prev_fn)
+{
+  if (--dependencies[prev_fn] == 0) {
+    dependencies.erase(prev_fn);
+    return true;
+  }
+  return false;
+}
+
+// Accumulates d_prev_fn gradient tensor into output_idx position of prev_grad buffer
+bool THPEngine_add_grad(buffer_set_type &need_copy, grad_buffer_type &prev_grad,
+    int output_nr, PyObject *d_prev_fn)
+{
+  // TODO: we should probably clean up need_copy, because most tensors will
+  // probably never hit the else clause
+  auto set_key = std::make_pair(prev_grad.buffer_id, output_nr);
+  if (!prev_grad[output_nr]) {
+    Py_INCREF(d_prev_fn);
+    prev_grad[output_nr] = d_prev_fn;
+    need_copy.insert(set_key);
+  } else {
+    PyObject *grad_tensor = prev_grad[output_nr];
+    if (need_copy.count(set_key) != 0) {
+      grad_tensor = PyObject_CallMethod(grad_tensor, "clone", "");
+      if (!grad_tensor)
+          return false;
+      need_copy.erase(set_key);
+      prev_grad[output_nr] = grad_tensor;
+    }
+    THPObjectPtr result = PyObject_CallMethod(grad_tensor, "add_", "O", d_prev_fn);
+    if (!result)
+        return false;
+  }
+  return true;
+}
+
+// Main backward function
+PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwargs)
+{
+  THPVariable *variable = NULL;
+  PyObject *grad_variable = NULL;
+  unsigned char retain_variables = 0;
+  size_t next_buf_id = 0;
+  const char *accepted_kwargs[] = {"variable", "grad_variable",
+      "retain_variables", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOb", (char**)accepted_kwargs,
+        &variable, &grad_variable, &retain_variables))
+    return NULL;
+  PyObject *retain_variables_obj = retain_variables ? Py_True : Py_False;
+
+  // If someone calls .backward() on a leaf, it's simple...
+  if (variable->creator == NULL) {
+    THPObjectPtr result = PyObject_CallMethod((PyObject*)variable,
+            "_do_backward", "(O)O", grad_variable, retain_variables_obj);
+    Py_RETURN_NONE;
+  }
+
+  std::deque<std::pair<THPFunction *, grad_buffer_type>> ready;
+  std::unordered_map<THPFunction *, grad_buffer_type> not_ready;
+  buffer_set_type need_copy;
+
+  // Initialize the queue
+  grad_buffer_type buf(next_buf_id++, 1);
+  Py_INCREF(grad_variable);
+  buf[0] = grad_variable;
+  ready.emplace_front((THPFunction*)variable->creator, std::move(buf));
+
+  dependencies_type dependencies = THPEngine_compute_dependencies((THPFunction*)variable->creator);
+
+  while (ready.size() > 0) {
+    std::pair<THPFunction *, grad_buffer_type> ready_pair =
+        std::move(ready.back()); ready.pop_back();
+    THPFunction *fn = ready_pair.first;
+    grad_buffer_type &fn_grad_buffer = ready_pair.second;
+
+    // Prepare a tuple for a call to _do_backward
+    THPObjectPtr grad_tuple = PyTuple_New(fn_grad_buffer.size());
+    if (!grad_tuple) return NULL;
+    for (unsigned int i = 0; i < fn_grad_buffer.size(); i++) {
+      // TODO: allocate correctly sized zero buffer
+      THPUtils_assert(fn_grad_buffer[i], "error no grad buffer - this will be "
+              "fixed in upcoming releases!");
+      PyTuple_SET_ITEM(grad_tuple.get(), i, fn_grad_buffer[i].release());
+    }
+
+    // Call _do_backward and make sure grad_input is sound
+    THPObjectPtr grad_input = PyObject_CallMethod((PyObject*)fn, "_do_backward",
+        "OO", grad_tuple.get(), retain_variables_obj);
+    if (!grad_input)
+      return NULL;
+    THPUtils_assert(PyTuple_Check(grad_input), "error, _do_backward should "
+            "return a tuple, but got %s", THPUtils_typename(grad_input));
+    int num_grads = PyTuple_GET_SIZE(grad_input.get());
+
+    // Process tensors inside grad_input
+    for (int i = 0; i < num_grads; i++) {
+      PyObject *prev_obj = fn->previous_functions[i].get();
+      PyObject *grad_prev = PyTuple_GET_ITEM(grad_input.get(), i);
+
+      // A shortcut for variables - there's no need to buffer gradients for them
+      // as their _do_backward is super fast (and we can save memory).
+      // TODO: this might call leaf variable hooks multiple times
+      if (THPVariable_Check(prev_obj)) {
+        THPVariable *prev_var = (THPVariable*)prev_obj;
+        if (prev_var->requires_grad) {
+          THPObjectPtr ret = PyObject_CallMethod(prev_obj, "_do_backward",
+              "(O)O", grad_prev, retain_variables_obj);
+          if (!ret) return NULL;
+        }
+        continue;
+      }
+
+      // No need to do any work for functions that don't require gradients
+      THPFunction *prev_fn = (THPFunction*)prev_obj;
+      if (!prev_fn->requires_grad)
+        continue;
+
+      // Check if the function is ready for backward and see if it has any
+      // buffers allocated
+      int output_idx = fn->previous_functions[i].output_nr;
+      bool is_ready = THPEngine_free_backward_dependency(dependencies, prev_fn);
+      auto not_ready_it = not_ready.find(prev_fn);
+      if (is_ready) {
+        // this is only a temporary, so no need for a correct id
+        grad_buffer_type prev_buffer(-1);
+        if (not_ready_it == not_ready.end()) {
+          // The function is ready and no buffers have been allocated for it.
+          prev_buffer = grad_buffer_type(next_buf_id++, 1);
+          Py_INCREF(grad_prev);
+          prev_buffer[output_idx] = grad_prev;
+        } else {
+          // The function is ready and it already has a buffer allocated.
+          prev_buffer = std::move(not_ready_it->second);
+          not_ready.erase(not_ready_it);
+          if (!THPEngine_add_grad(need_copy, prev_buffer, output_idx, grad_prev))
+              return NULL;
+        }
+        // Put the function into the ready queue.
+        ready.emplace_front(prev_fn, std::move(prev_grad));
+      } else {
+        // Allocate a buffer if necessary
+        if (not_ready_it == not_ready.end()) {
+          int num_prev_fn_outputs = prev_fn->num_outputs;
+          std::tie(not_ready_it, std::ignore) =
+              not_ready.emplace(prev_fn, grad_buffer_type(next_buf_id++, num_prev_fn_outputs));
+        }
+        // Accumulate the gradient into the buffer
+        grad_buffer_type &grad_buffer = not_ready_it->second;
+        if (!THPEngine_add_grad(need_copy, grad_buffer, output_idx, grad_prev))
+            return NULL;
+      }
+    }
+  }
+
+  Py_RETURN_NONE;
+}
+
+PyObject *THPEngine_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+  return type->tp_alloc(type, 0);
+}
+
+static struct PyMethodDef THPEngine_methods[] = {
+  {(char*)"run_backward", (PyCFunction)THPEngine_run_backward, METH_VARARGS | METH_KEYWORDS, NULL},
+  {NULL}
+};
+
+
+PyTypeObject THPEngineType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "torch._C._EngineBase",                /* tp_name */
+  sizeof(THPEngine),                     /* tp_basicsize */
+  0,                                     /* tp_itemsize */
+  0,                                     /* tp_dealloc */
+  0,                                     /* tp_print */
+  0,                                     /* tp_getattr */
+  0,                                     /* tp_setattr */
+  0,                                     /* tp_reserved */
+  0,                                     /* tp_repr */
+  0,                                     /* tp_as_number */
+  0,                                     /* tp_as_sequence */
+  0,                                     /* tp_as_mapping */
+  0,                                     /* tp_hash  */
+  0,                                     /* tp_call */
+  0,                                     /* tp_str */
+  0,                                     /* tp_getattro */
+  0,                                     /* tp_setattro */
+  0,                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+  NULL,                                  /* tp_doc */
+  0,                                     /* tp_traverse */
+  0,                                     /* tp_clear */
+  0,                                     /* tp_richcompare */
+  0,                                     /* tp_weaklistoffset */
+  0,                                     /* tp_iter */
+  0,                                     /* tp_iternext */
+  THPEngine_methods,                     /* tp_methods */
+  0,                                     /* tp_members */
+  0,                                     /* tp_getset */
+  0,                                     /* tp_base */
+  0,                                     /* tp_dict */
+  0,                                     /* tp_descr_get */
+  0,                                     /* tp_descr_set */
+  0,                                     /* tp_dictoffset */
+  0,                                     /* tp_init */
+  0,                                     /* tp_alloc */
+  THPEngine_new                          /* tp_new */
+};
+
+
+bool THPEngine_initModule(PyObject *module)
+{
+  if (PyType_Ready(&THPEngineType) < 0)
+    return false;
+  Py_INCREF(&THPEngineType);
+  PyModule_AddObject(module, "_ImperativeEngine", (PyObject *)&THPEngineType);
+  return true;
+}
+

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -1,0 +1,10 @@
+#ifndef THP_ENGINE_H
+#define THP_ENGINE_H
+
+struct THPEngine {
+    PyObject_HEAD
+};
+
+bool THPEngine_initModule(PyObject *module);
+
+#endif

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,0 +1,561 @@
+#include <Python.h>
+#include <structmember.h>
+
+#include <unordered_map>
+
+#include "THP.h"
+
+PyObject *THPFunctionClass = NULL;
+
+static void THPFunction_dealloc(THPFunction* self)
+{
+  self->num_inputs = 0;
+  self->num_outputs = 0;
+
+  Py_XDECREF(self->needs_input_grad);
+  Py_XDECREF(self->saved_variables);
+  Py_XDECREF(self->backward_hooks);
+
+  Py_XDECREF(self->to_save);
+  Py_XDECREF(self->shared_pairs);
+  Py_XDECREF(self->non_differentiable);
+  Py_XDECREF(self->dirty_tensors);
+
+  THPFunctionPtr *previous_functions = self->previous_functions;
+  self->previous_functions = NULL;
+  delete[] previous_functions;
+
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+// Traverse and clear are required for supporting Python's GC cycle handling.
+static int THPFunction_traverse(THPFunction *self, visitproc visit, void *arg)
+{
+  Py_VISIT(self->needs_input_grad);
+  Py_VISIT(self->saved_variables);
+  Py_VISIT(self->backward_hooks);
+  for (int i = 0; i < self->num_inputs; i++)
+      Py_VISIT(self->previous_functions[i].get());
+
+  Py_VISIT(self->to_save);
+  Py_VISIT(self->shared_pairs);
+  Py_VISIT(self->non_differentiable);
+  Py_VISIT(self->dirty_tensors);
+
+  return 0;
+}
+
+static int THPFunction_clear(THPFunction *self)
+{
+  self->num_inputs = 0;
+  self->num_outputs = 0;
+
+  Py_CLEAR(self->needs_input_grad);
+  Py_CLEAR(self->saved_variables);
+  Py_CLEAR(self->backward_hooks);
+
+  Py_CLEAR(self->to_save);
+  Py_CLEAR(self->shared_pairs);
+  Py_CLEAR(self->non_differentiable);
+  Py_CLEAR(self->dirty_tensors);
+
+  THPFunctionPtr *previous_functions = self->previous_functions;
+  self->previous_functions = NULL;
+  delete[] previous_functions;
+
+  return 0;
+}
+
+PyObject *THPFunction_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+  THPFunction *self = (THPFunction*)type->tp_alloc(type, 0);
+  if (!self)
+    return NULL;
+  self->previous_functions = NULL;
+  self->needs_input_grad = NULL;
+  self->saved_variables = NULL;
+  self->backward_hooks = NULL;
+  self->to_save = NULL;
+  self->shared_pairs = NULL;
+  self->non_differentiable = NULL;
+  self->dirty_tensors = NULL;
+  self->needs_input_grad = 0;
+  self->has_freed_buffers = 0;
+  self->num_inputs = 0;
+  self->num_outputs = -1;
+  return (PyObject*)self;
+}
+
+using t2var_type = std::unordered_map<PyObject *, THPVariable *>;
+
+static bool _mark_dirty(THPFunction *self, t2var_type &t2var)
+{
+  // Increase versions of modified tensors
+  if (self->dirty_tensors) {
+    THPUtils_assertRet(false, PyTuple_Check(self->dirty_tensors), "autograd "
+        "internal error: dirty_tensors attribute is expected to be a tuple "
+        "but is %s", THPUtils_typename(self->dirty_tensors));
+    Py_ssize_t num_dirty = PyTuple_GET_SIZE(self->dirty_tensors);
+    for (int i = 0; i < num_dirty; i++) {
+      PyObject *tensor = PyTuple_GET_ITEM(self->dirty_tensors, i);
+      THPVariable *variable;
+      try {
+        variable = t2var.at(tensor);
+      } catch (std::out_of_range &e) {
+        THPUtils_assertRet(false, THPModule_isTensor(tensor), "mark_dirty can "
+            "only accept tensors, but argument %d is of type %s", i,
+            THPUtils_typename(tensor));
+        THPUtils_setError("mark_dirty only accepts input tensors, but "
+            "argument %d isn't one", i);
+        return false;
+      }
+      (*variable->version_counter)++;
+    }
+    // We're not going to ever need this so let's remove references now
+    Py_DECREF(self->dirty_tensors);
+    self->dirty_tensors = NULL;
+  }
+  return true;
+}
+
+static bool _wrap_outputs(THPFunction *self, t2var_type &t2var,
+    PyObject *raw_output, PyObject *outputs)
+{
+  // Wrap outputs in Variables
+  Py_ssize_t num_outputs = PyTuple_GET_SIZE(raw_output);
+  for (int i = 0; i < num_outputs; i++) {
+    PyObject *output = PyTuple_GET_ITEM(raw_output, i);
+    THPVariable *output_var;
+    auto it = t2var.find(output);
+    if (it == t2var.end()) {
+      // A completely new tensor - just wrap it and continue
+      output_var = (THPVariable*)THPVariable_New(output, (PyObject*)self, self->requires_grad);
+    } else {
+      // If one of the outputs was also an input tensor it's a bit more complicated.
+      THPVariable *input_var = it->second;
+      if (input_var->creator) {
+        // If it's not a leaf we want to move it in the graph so backprop
+        // will be computed correctly:
+        // creator <- variable <- self  ==>  creator <- self <- variable
+        Py_INCREF(input_var);
+        output_var = input_var;
+        Py_DECREF(input_var->creator);
+        Py_INCREF(self);
+        input_var->creator = (PyObject*)self;
+      } else {
+        // If it's a leaf it's not as simple. Leaves will raise an error in
+        // backward if they've been changed, or they're no longer leaves. In
+        // some cases (e.g. broadcast) it's perfectly valid to return the same
+        // tensor untouched, so instead of moving it we're going to create a
+        // copy and join their version counters. This works for broadcast,
+        // and if the use wasn't valid we'll still detect an error, because
+        // the leaf will have a version != 0.
+        output_var = (THPVariable*)THPVariable_New(output, (PyObject*)self, self->requires_grad);
+        if (!output_var) return false;
+        output_var->version_counter->join_with(*input_var->version_counter);
+      }
+    }
+    if (!output_var)
+      return false;
+
+    t2var[output] = output_var;
+    output_var->output_nr = i;
+    PyTuple_SET_ITEM(outputs, i, (PyObject*)output_var);
+  }
+  return true;
+}
+
+static bool _save_variables(THPFunction*self, t2var_type &t2var)
+{
+  // TODO: this can be stored without using python types
+  if (self->to_save) {
+    THPUtils_assertRet(false, PyTuple_Check(self->to_save), "autograd internal "
+        "error: to_save attribute is expected to be a tuple but is %s",
+        THPUtils_typename(self->to_save));
+    Py_ssize_t num_saved = PyTuple_GET_SIZE(self->to_save);
+    self->saved_variables = PyTuple_New(num_saved);
+    if (!self->saved_variables) return false;
+    for (int i = 0; i < num_saved; i++) {
+      PyObject *tensor = PyTuple_GET_ITEM(self->to_save, i);
+      THPVariable *variable;
+      try {
+        variable = t2var.at(tensor);
+      } catch(std::out_of_range &e) {
+        THPUtils_assertRet(false, THPModule_isTensor(tensor),
+            "save_for_backward can only save tensors, but argument %d is of "
+            "type %s", i, THPUtils_typename(tensor));
+        THPUtils_setError("save_for_backward can only save input or output "
+            "tensors, but argument %d doesn't satisfy this condition", i);
+        return false;
+      }
+
+      PyObject *tuple = PyTuple_New(2);
+      if (!tuple)
+        return false;
+      Py_INCREF(variable);
+      PyTuple_SET_ITEM(tuple, 0, (PyObject*)variable);
+      PyTuple_SET_ITEM(tuple, 1, PyInt_FromLong(**variable->version_counter));
+      PyTuple_SET_ITEM(self->saved_variables, i, tuple);
+    }
+    // Free .to_save
+    Py_DECREF(self->to_save);
+    self->to_save = NULL;
+  }
+  return true;
+}
+
+static bool _join_version_counters(THPFunction *self, t2var_type &t2var)
+{
+  if (self->shared_pairs) {
+    THPUtils_assertRet(false, PyTuple_Check(self->shared_pairs), "autograd internal "
+        "error: shared_pairs attribute is expected to be a tuple but is %s",
+        THPUtils_typename(self->shared_pairs));
+    Py_ssize_t num_shared = PyTuple_GET_SIZE(self->shared_pairs);
+    for (int i = 0; i < num_shared; i++) {
+      PyObject *shared_tuple = PyTuple_GET_ITEM(self->shared_pairs, i);
+      THPUtils_assertRet(false, PyTuple_Check(shared_tuple), "mark_shared_storages "
+          "accepts a number of pairs, but one of the arguments is of type %s",
+          THPUtils_typename(shared_tuple));
+      THPUtils_assertRet(false, PyTuple_GET_SIZE(shared_tuple) == 2,
+          "mark_shared_storages accepts pairs, but argument %d is a tuple of "
+          "%d elements", i, PyTuple_GET_SIZE(shared_tuple));
+
+      // Now we're sure it's really a pair!
+      THPVariable *v1, *v2;
+      try {
+        v1 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 0));
+        v2 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 1));
+      } catch(std::out_of_range &e) {
+        // One tuple items wasn't present in t2var, so there are two cases:
+        // 1. it's not a tensor
+        // 2. it's not an input nor an output
+        PyObject *t1 = PyTuple_GET_ITEM(shared_tuple, 0);
+        PyObject *t2 = PyTuple_GET_ITEM(shared_tuple, 1);
+        THPUtils_assertRet(false, THPModule_isTensor(t1) && THPModule_isTensor(t2),
+          "mark_shared_storages accepts pairs of tensors, but one of them "
+          "contains %s and %s", THPUtils_typename(t1), THPUtils_typename(t2));
+        THPUtils_setError("mark_shared_storages only accepts pairs of input "
+            "and output tensors, but argument %d doesn't satify this "
+            "condition", i);
+        return false;
+      }
+      v2->version_counter->join_with(*v1->version_counter);
+    }
+    // Free .shared_pairs
+    Py_DECREF(self->shared_pairs);
+    self->shared_pairs = NULL;
+  }
+  return true;
+}
+
+static bool _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
+{
+  if (self->non_differentiable) {
+    THPUtils_assertRet(false, PyTuple_Check(self->non_differentiable), "autograd "
+        "internal error: non_differentiable attribute is expected to be a "
+        "tuple but is %s", THPUtils_typename(self->non_differentiable));
+    Py_ssize_t num_nondiff = PyTuple_GET_SIZE(self->non_differentiable);
+    for (int i = 0; i < num_nondiff; i++) {
+      PyObject *t = PyTuple_GET_ITEM(self->non_differentiable, i);
+      THPVariable *var;
+      try {
+        var = t2var.at(t);
+        THPUtils_assertRet(false, var->creator == (PyObject*)self,
+            "mark_non_differentiable only accepts output tensors, but "
+            "argument %d isn't an output", i);
+      } catch (std::out_of_range &e) {
+        THPUtils_assertRet(false, THPModule_isTensor(t), "mark_non_differentiable "
+            "only accepts tensor arguments, but got %s", THPUtils_typename(t));
+        THPUtils_setError("mark_non_differentiable only accepts function "
+            "outputs");
+        return false;
+      }
+      var->requires_grad = 0;
+    }
+    Py_DECREF(self->non_differentiable);
+    self->non_differentiable = NULL;
+  }
+  return true;
+}
+
+
+PyObject *THPFunction_do_forward(THPFunction *self, PyObject *inputs)
+{
+  Py_ssize_t num_inputs = inputs ? PyTuple_GET_SIZE(inputs) : 0;
+
+  // Unpack inputs and check if they require gradients or are volatile
+  THPObjectPtr unpacked_inputs = PyTuple_New(num_inputs);
+  self->needs_input_grad = PyTuple_New(num_inputs);
+  self->requires_grad = false;
+  bool is_volatile = false;
+  for (int i = 0; i < num_inputs; i++) {
+    PyObject *input = PyTuple_GET_ITEM(inputs, i);
+    THPUtils_assert(THPVariable_Check(input), "expected a Variable argument, "
+        "but got %s", THPUtils_typename(input));
+    THPVariable *variable = (THPVariable*)input;
+
+    // Unpack the variable - SET_ITEM steals a reference so INCREF it
+    Py_INCREF(variable->data);
+    PyTuple_SET_ITEM(unpacked_inputs.get(), i, variable->data);
+
+    // We can't move this to C, because it's going to be accessed from user code.
+    PyTuple_SET_ITEM(self->needs_input_grad, i, PyBool_FromLong(variable->requires_grad));
+
+    is_volatile = is_volatile || variable->is_volatile;
+    self->requires_grad = self->requires_grad || variable->requires_grad;
+  }
+
+
+  // Now we're ready to call a forward (implemented in Python)
+  THPObjectPtr forward_fn = PyObject_GetAttrString((PyObject*)self, "forward");
+  THPUtils_assert(forward_fn.get(), "function %s doesn't implement a required "
+      "'forward' method", THPUtils_typename((PyObject*)self));
+  THPObjectPtr raw_output = PyObject_CallObject(forward_fn, unpacked_inputs);
+  if (!raw_output)
+    return NULL;
+  // Wrap output in a tuple, if it's not one already
+  if (!PyTuple_Check(raw_output.get())) {
+    PyObject *tuple = PyTuple_New(1);
+    if (!tuple)
+      return NULL;
+    PyTuple_SET_ITEM(tuple, 0, raw_output.release());
+    raw_output = tuple;
+  }
+  int num_outputs = PyTuple_GET_SIZE(raw_output.get());
+
+
+  THPObjectPtr outputs = PyTuple_New(num_outputs);
+  if (!outputs)
+    return NULL;
+  if (is_volatile) {
+    // If one of the inputs is volatile let's take a fast path - we want
+    // minimize the overhead of inference
+    for (int i = 0; i < num_outputs; i++) {
+      PyObject *output = PyTuple_GET_ITEM(raw_output.get(), i);
+      THPVariable *output_var = (THPVariable*)THPVariable_NewVolatile(output);
+      if (!output_var)
+        return NULL;
+      output_var->output_nr = i;
+      PyTuple_SET_ITEM(outputs.get(), i, (PyObject*)output_var);
+    }
+  } else {
+    // We're not volatile, so there's a lot of bookkeeping to do...
+    self->num_inputs = num_inputs;
+    self->num_outputs = num_outputs;
+    t2var_type t2var;
+
+    // Save previous functions and initialize t2var map
+    self->previous_functions = new THPFunctionPtr[num_inputs];
+    for (int i = 0; i < num_inputs; i++) {
+      THPVariable *input_var = (THPVariable*)PyTuple_GET_ITEM(inputs, i);
+      t2var.emplace(input_var->data, input_var);
+
+      // Save previous function in a helper class (that has a smart pointer to
+      // the object and remembers which output did we use.
+      PyObject *prev_fn = input_var->creator ? input_var->creator : (PyObject*)input_var;
+      Py_INCREF(prev_fn);
+      self->previous_functions[i] = std::move(THPFunctionPtr(prev_fn, input_var->output_nr));
+    }
+
+    if (!_mark_dirty(self, t2var))
+      return NULL;
+    if (!_wrap_outputs(self, t2var, raw_output, outputs))
+      return NULL;
+    if (!_save_variables(self, t2var))
+      return NULL;
+    if (!_join_version_counters(self, t2var))
+      return NULL;
+    if (!_mark_non_differentiable(self, t2var))
+      return NULL;
+
+    // Mark non-differentiable outputs as not requiring gradients
+  }
+
+
+  if (num_outputs == 1) {
+    PyObject *output = PyTuple_GET_ITEM(outputs.get(), 0);
+    Py_INCREF(output);
+    return output;
+  }
+
+  return outputs.release();
+}
+
+PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
+{
+  Py_ssize_t num_args = args ? PyTuple_GET_SIZE(args) : 0;
+  THPUtils_assert(num_args == 2, "_do_backward expects exactly two arguments");
+  PyObject *grad_output = PyTuple_GET_ITEM(args, 0);
+  PyObject *retain_variables = PyTuple_GET_ITEM(args, 1);
+  if (!PyTuple_Check(grad_output) || !PyBool_Check(retain_variables)) {
+    THPUtils_invalidArguments(args, "_do_backward", 1, "(tuple, bool)");
+    return NULL;
+  }
+
+  THPObjectPtr backward_fn = PyObject_GetAttrString((PyObject*)self, "backward");
+  THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
+      "'backward' method", THPUtils_typename((PyObject*)self));
+  THPObjectPtr grad_input = PyObject_CallObject(backward_fn, grad_output);
+  if (!grad_input)
+    return NULL;
+
+  if (!PyTuple_Check(grad_input)) {
+    PyObject *grad_tuple = PyTuple_New(1);
+    if (!grad_tuple)
+      return NULL;
+    PyTuple_SET_ITEM(grad_tuple, 0, grad_input.release());
+    grad_input = grad_tuple;
+  }
+  int num_grads = PyTuple_GET_SIZE(grad_input.get());
+  int num_prev_fns = self->num_inputs;
+
+  THPUtils_assert(num_grads == num_prev_fns, "%s returned an invalid number of "
+      "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
+      num_prev_fns, num_grads);
+
+  if (self->backward_hooks) {
+    PyObject *key, *value;
+    Py_ssize_t pos = 0;
+
+    THPUtils_assert(PyDict_Check(self->backward_hooks), "backward_hooks "
+        "attribute has to be a dictionary");
+    while (PyDict_Next(self->backward_hooks, &pos, &key, &value)) {
+      THPObjectPtr result = PyObject_CallFunctionObjArgs(value,
+          grad_input.get(), grad_output, NULL);
+      if (!result)
+        return NULL;
+    }
+  }
+
+  if (retain_variables == Py_False) {
+    Py_XDECREF(self->saved_variables);
+    self->saved_variables = NULL;
+    self->has_freed_buffers = 1;
+  }
+
+  return grad_input.release();
+}
+
+PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
+{
+  THPUtils_assert(!self->has_freed_buffers, "Trying to backward through the "
+      "graph second time, but the buffers have already been freed. Please "
+      "specify retain_variables=True when calling backward for the first time.");
+  if (!self->saved_variables)
+    return PyTuple_New(0);
+
+  Py_ssize_t num_saved = PyTuple_GET_SIZE(self->saved_variables);
+  THPObjectPtr saved_tensors = PyTuple_New(num_saved);
+  if (!saved_tensors)
+    return NULL;
+  for (int i = 0; i < num_saved; i++) {
+    PyObject *tuple = PyTuple_GET_ITEM(self->saved_variables, i);
+    long expected_version = THPUtils_unpackLong(PyTuple_GET_ITEM(tuple, 1));
+    THPVariable *variable = (THPVariable*)PyTuple_GET_ITEM(tuple, 0);
+    int current_version = **variable->version_counter;
+    THPUtils_assert(expected_version == current_version, "one of the variables "
+        "needed for gradient computation has been modified by an "
+        "inplace operation");
+    Py_INCREF(variable->data);
+    PyTuple_SET_ITEM(saved_tensors.get(), i, variable->data);
+  }
+  return saved_tensors.release();
+}
+
+PyObject *THPFunction_previous_functions(THPFunction *self, void *_unused)
+{
+  THPObjectPtr previous_functions = PyTuple_New(self->num_inputs);
+  if (!previous_functions)
+    return NULL;
+  for (int i = 0; i < self->num_inputs; i++) {
+    THPObjectPtr fn_tuple = PyTuple_New(2);
+    if (!fn_tuple)
+      return NULL;
+    Py_INCREF(self->previous_functions[i].get());
+    PyTuple_SET_ITEM(fn_tuple.get(), 0, self->previous_functions[i].get());
+    PyTuple_SET_ITEM(fn_tuple.get(), 1, PyInt_FromLong(self->previous_functions[i].output_nr));
+    PyTuple_SET_ITEM(previous_functions.get(), i, fn_tuple.release());
+  }
+  return previous_functions.release();
+}
+
+
+typedef PyObject *(*getter)(PyObject *, void *);
+typedef int (*setter)(PyObject *, PyObject *, void *);
+
+static struct PyGetSetDef THPFunction_properties[] = {
+  {"saved_tensors", (getter)THPFunction_saved_tensors, NULL, NULL, NULL},
+  {"previous_functions", (getter)THPFunction_previous_functions, NULL, NULL, NULL},
+  {NULL}
+};
+
+static struct PyMemberDef THPFunction_members[] = {
+  {(char*)"saved_variables", T_OBJECT, offsetof(THPFunction, saved_variables), 0, NULL},
+  {(char*)"backward_hooks", T_OBJECT, offsetof(THPFunction, backward_hooks), 0, NULL},
+  {(char*)"to_save", T_OBJECT, offsetof(THPFunction, to_save), 0, NULL},
+  {(char*)"shared_pairs", T_OBJECT, offsetof(THPFunction, shared_pairs), 0, NULL},
+  {(char*)"non_differentiable", T_OBJECT, offsetof(THPFunction, non_differentiable), 0, NULL},
+  {(char*)"dirty_tensors", T_OBJECT, offsetof(THPFunction, dirty_tensors), 0, NULL},
+  {(char*)"needs_input_grad", T_OBJECT, offsetof(THPFunction, needs_input_grad), 0, NULL},
+  {(char*)"requires_grad", T_BOOL, offsetof(THPFunction, requires_grad), 0, NULL},
+  {(char*)"num_inputs", T_INT, offsetof(THPFunction, num_inputs), 0, NULL},
+  {(char*)"num_outputs", T_INT, offsetof(THPFunction, num_outputs), 0, NULL},
+  {NULL}
+};
+
+static struct PyMethodDef THPFunction_methods[] = {
+  {(char*)"_do_forward", (PyCFunction)THPFunction_do_forward, METH_VARARGS, NULL},
+  {(char*)"_do_backward", (PyCFunction)THPFunction_do_backward, METH_VARARGS, NULL},
+  {NULL}
+};
+
+PyTypeObject THPFunctionType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "torch._C._FunctionBase",              /* tp_name */
+  sizeof(THPFunction),                   /* tp_basicsize */
+  0,                                     /* tp_itemsize */
+  (destructor)THPFunction_dealloc,       /* tp_dealloc */
+  0,                                     /* tp_print */
+  0,                                     /* tp_getattr */
+  0,                                     /* tp_setattr */
+  0,                                     /* tp_reserved */
+  0,                                     /* tp_repr */
+  0,                                     /* tp_as_number */
+  0,                                     /* tp_as_sequence */
+  0,                                     /* tp_as_mapping */
+  0,                                     /* tp_hash  */
+  0,                                     /* tp_call */
+  0,                                     /* tp_str */
+  0,                                     /* tp_getattro */
+  0,                                     /* tp_setattro */
+  0,                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+  NULL,                                  /* tp_doc */
+  (traverseproc)THPFunction_traverse,    /* tp_traverse */
+  (inquiry)THPFunction_clear,            /* tp_clear */
+  0,                                     /* tp_richcompare */
+  0,                                     /* tp_weaklistoffset */
+  0,                                     /* tp_iter */
+  0,                                     /* tp_iternext */
+  THPFunction_methods,                   /* tp_methods */
+  THPFunction_members,                   /* tp_members */
+  THPFunction_properties,                /* tp_getset */
+  0,                                     /* tp_base */
+  0,                                     /* tp_dict */
+  0,                                     /* tp_descr_get */
+  0,                                     /* tp_descr_set */
+  0,                                     /* tp_dictoffset */
+  0,                                     /* tp_init */
+  0,                                     /* tp_alloc */
+  THPFunction_new                        /* tp_new */
+};
+
+bool THPFunction_initModule(PyObject *module)
+{
+  if (PyType_Ready(&THPFunctionType) < 0)
+    return false;
+  Py_INCREF(&THPFunctionType);
+  PyModule_AddObject(module, "_FunctionBase", (PyObject *)&THPFunctionType);
+  return true;
+}
+

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -1,0 +1,51 @@
+#ifndef THP_FUNCTION_H
+#define THP_FUNCTION_H
+
+struct THPFunction;
+
+struct THPFunctionPtr: public THPObjectPtr {
+    THPFunctionPtr(): THPObjectPtr(nullptr), output_nr(-1) {};
+
+    THPFunctionPtr(PyObject *fn, int output_nr):
+        THPObjectPtr(fn), output_nr(output_nr) {};
+
+    THPFunctionPtr(THPFunction *fn, int output_nr):
+        THPObjectPtr((PyObject*)fn), output_nr(output_nr) {};
+
+    THPFunctionPtr(THPFunctionPtr &&other):
+        THPObjectPtr(std::move(other)), output_nr(other.output_nr) {}
+
+    THPPointer& operator =(THPFunctionPtr &&other) {
+        output_nr = other.output_nr;
+        THPObjectPtr::operator=(std::move(other));
+        return *this;
+    }
+
+    int output_nr;
+};
+
+struct THPFunction {
+    PyObject_HEAD
+
+    PyObject *needs_input_grad;
+    PyObject *saved_variables;
+    PyObject *backward_hooks;
+
+    PyObject *to_save;
+    PyObject *shared_pairs;
+    PyObject *non_differentiable;
+    PyObject *dirty_tensors;
+
+    THPFunctionPtr *previous_functions;
+    int num_inputs;
+    int num_outputs;
+    char requires_grad;
+    char has_freed_buffers;
+};
+
+bool THPFunction_initModule(PyObject *module);
+extern PyObject *THPFunctionClass;
+
+#define THPFunction_Check(obj) PyObject_IsInstance(obj, THPFunctionClass)
+
+#endif

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1,0 +1,21 @@
+#include <Python.h>
+
+#include "THP.h"
+
+
+PyObject * THPAutograd_initExtension(PyObject *_unused)
+{
+  PyObject *autograd_module = PyImport_ImportModule("torch.autograd");
+  THPUtils_assert(autograd_module, "class loader couldn't access "
+          "torch.autograd module");
+  PyObject *autograd_dict = PyModule_GetDict(autograd_module);
+
+  THPVariableClass      = PyMapping_GetItemString(autograd_dict,(char*)"Variable");
+  THPFunctionClass      = PyMapping_GetItemString(autograd_dict,(char*)"Function");
+  THPUtils_assert(THPVariableClass, "couldn't find Variable class in "
+          "torch.autograd module");
+  THPUtils_assert(THPFunctionClass, "couldn't find Function class in "
+          "torch.autograd module");
+
+  Py_RETURN_TRUE;
+}

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -1,0 +1,262 @@
+#include <Python.h>
+#include <structmember.h>
+
+#include "THP.h"
+
+PyObject *THPVariableClass = NULL;
+
+constexpr size_t CACHE_SIZE = 100000;
+static THPVariable *cached_variables[CACHE_SIZE];
+static size_t num_cached;
+
+// This helper steals a reference to data and creator
+static inline THPVariable * pop_cache(PyObject *data, PyObject *creator, char requires_grad)
+{
+  THPVariable *self = cached_variables[--num_cached];
+  PyObject_Init((PyObject*)self, Py_TYPE(self));
+  PyObject_GC_Track(self);
+
+  self->is_volatile = 0;
+  self->version_counter = new THPVariableVersion();
+  self->grad = NULL;
+  self->backward_hooks = NULL;
+  self->requires_grad = requires_grad;
+
+  self->data = data;
+  self->creator = creator;
+  return self;
+}
+
+// This function DOES NOT steal a reference to data
+PyObject * THPVariable_NewVolatile(PyObject *data)
+{
+  THPVariable *variable;
+  if (num_cached > 0) {
+    Py_INCREF(data);
+    variable = pop_cache(data, NULL, 0);
+  } else {
+    variable = (THPVariable*)PyObject_CallFunctionObjArgs(THPVariableClass, data, NULL);
+  }
+  ((THPVariable*)variable)->is_volatile = 1;
+  return (PyObject*)variable;
+}
+
+// This function DOES NOT steal a reference to data and creator
+PyObject * THPVariable_New(PyObject *data, PyObject *creator, char requires_grad)
+{
+  if (num_cached > 0) {
+    Py_INCREF(data);
+    Py_INCREF(creator);
+    return (PyObject*)pop_cache(data, creator, requires_grad);
+  }
+  return PyObject_CallFunction(THPVariableClass, "OObb", data, creator, (char)0, requires_grad);
+}
+
+static int THPVariable_traverse(THPVariable *self, visitproc visit, void *arg)
+{
+  Py_VISIT(self->creator);
+  Py_VISIT(self->data);
+  Py_VISIT(self->grad);
+  Py_VISIT(self->backward_hooks);
+  return 0;
+}
+
+static int THPVariable_clear(THPVariable *self)
+{
+  Py_CLEAR(self->creator);
+  Py_CLEAR(self->data);
+  Py_CLEAR(self->grad);
+  Py_CLEAR(self->backward_hooks);
+  return 0;
+}
+
+static void THPVariable_dealloc(THPVariable* self)
+{
+  Py_XDECREF(self->creator);
+  Py_XDECREF(self->data);
+  Py_XDECREF(self->grad);
+  Py_XDECREF(self->backward_hooks);
+  delete self->version_counter;
+
+  // We don't want to cache any subclasses
+  if ((PyObject*)Py_TYPE(self) == THPVariableClass && num_cached < CACHE_SIZE) {
+    PyObject_GC_UnTrack(self);
+    cached_variables[num_cached++] = self;
+    // Variable class is defined in Python code, and as such has a
+    // Py_TPFLAGS_HEAPTYPE flag set, so python DECREFs the class at each
+    // object dealloc.
+    Py_INCREF(Py_TYPE(self));
+  } else {
+    Py_TYPE(self)->tp_free((PyObject*)self);
+  }
+}
+
+PyObject *THPVariable_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+  THPVariable *self;
+  if (num_cached == 0) {
+    self = (THPVariable*)type->tp_alloc(type, 0);
+    self->version_counter = new THPVariableVersion();
+  } else {
+    self = pop_cache(NULL, NULL, 0);
+  }
+  return (PyObject*)self;
+}
+
+int THPVariable_init(THPVariable *self, PyObject *args, PyObject *kwargs)
+{
+  const char *accepted_args[] = {"data", "creator", "volatile", "requires_grad", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Obb", (char**)accepted_args,
+      &self->data, &self->creator, &self->is_volatile,
+      &self->requires_grad))
+    return -1;
+  Py_INCREF(self->data);
+  if (self->creator == Py_None)
+    self->creator = NULL;
+  Py_XINCREF(self->creator);
+  if ((self->creator && !THPFunction_Check(self->creator)) || !THPModule_isTensor(self->data))
+    return -1;
+  return 0;
+}
+
+PyObject * THPVariable_getstate(THPVariable *self)
+{
+  THPUtils_assert(!self->creator, "serialization of non-leaf variables is not "
+      "implemented yet");
+  THPObjectPtr state = PyTuple_New(5);
+  if (!state)
+    return NULL;
+
+  Py_INCREF(self->data);
+  PyTuple_SET_ITEM(state.get(), 0, self->data);
+
+  PyObject *grad = self->grad ? self->grad : Py_None;
+  Py_INCREF(grad);
+  PyTuple_SET_ITEM(state.get(), 1, grad);
+
+  PyObject *backward_hooks = self->backward_hooks ? self->backward_hooks : Py_None;
+  Py_INCREF(backward_hooks);
+  PyTuple_SET_ITEM(state.get(), 2, backward_hooks);
+
+  PyTuple_SET_ITEM(state.get(), 3, PyBool_FromLong(self->requires_grad));
+  PyTuple_SET_ITEM(state.get(), 4, PyBool_FromLong(self->is_volatile));
+
+  return state.release();
+}
+
+PyObject * THPVariable_setstate(THPVariable *self, PyObject *state)
+{
+  THPUtils_assert(!self->creator, "__setstate__ can be only called on leaf "
+      "variables");
+  THPUtils_assert(PyTuple_Check(state), "__setstate__ expects state to be a "
+      "tuple");
+  Py_ssize_t size = PyTuple_GET_SIZE(state);
+  THPUtils_assert(size == 5, "__setstate__ expects state tuple to have 5 "
+      "elements, but it has %d", size);
+
+  Py_XDECREF(self->data);
+  self->data = PyTuple_GET_ITEM(state, 0);
+  Py_INCREF(self->data);
+
+#define CHECK_NONE(idx)                                                        \
+    PyTuple_GET_ITEM(state, idx) == Py_None ? NULL : PyTuple_GET_ITEM(state, idx)
+  self->grad = CHECK_NONE(1);
+  self->backward_hooks = CHECK_NONE(2);
+#undef CHECK_NONE
+
+  PyObject *requires_grad_obj = PyTuple_GET_ITEM(state, 3);
+  PyObject *is_volatile_obj = PyTuple_GET_ITEM(state, 4);
+  THPUtils_assert(PyBool_Check(requires_grad_obj), "requires_grad "
+      "found in state was expected to be a bool, but got %s",
+      THPUtils_typename(requires_grad_obj));
+  THPUtils_assert(PyBool_Check(is_volatile_obj), "is_volatile "
+      "found in state was expected to be a bool, but got %s",
+      THPUtils_typename(is_volatile_obj));
+  self->requires_grad= requires_grad_obj == Py_True ? 1 : 0;
+  self->is_volatile = is_volatile_obj == Py_True ? 1 : 0;
+
+  Py_RETURN_NONE;
+}
+
+typedef PyObject *(*getter)(PyObject *, void *);
+typedef int (*setter)(PyObject *, PyObject *, void *);
+
+PyObject *THPVariable_get_version(THPVariable *self)
+{
+  return PyInt_FromLong(**self->version_counter);
+}
+
+static struct PyGetSetDef THPVariable_properties[] = {
+  {"_version", (getter)THPVariable_get_version, NULL, NULL, NULL},
+  {NULL}
+};
+
+static struct PyMemberDef THPVariable_members[] = {
+  {(char*)"creator",        T_OBJECT,   offsetof(THPVariable, creator), 0, NULL},
+  {(char*)"data",           T_OBJECT,   offsetof(THPVariable, data), 0, NULL},
+  {(char*)"_grad",          T_OBJECT,   offsetof(THPVariable, grad), 0, NULL},
+  {(char*)"volatile",       T_BOOL,     offsetof(THPVariable, is_volatile), 0, NULL},
+  {(char*)"output_nr",      T_INT,      offsetof(THPVariable, output_nr), 0, NULL},
+  {(char*)"backward_hooks", T_OBJECT,   offsetof(THPVariable, backward_hooks), 0, NULL},
+  {(char*)"_requires_grad", T_BOOL,     offsetof(THPVariable, requires_grad), READONLY, NULL},
+  {NULL}
+};
+
+static struct PyMethodDef THPVariable_methods[] = {
+  {"__getstate__", (PyCFunction)THPVariable_getstate, METH_NOARGS, NULL},
+  {"__setstate__", (PyCFunction)THPVariable_setstate, METH_O, NULL},
+  {NULL}
+};
+
+
+PyTypeObject THPVariableType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "torch._C._VariableBase",              /* tp_name */
+  sizeof(THPVariable),                   /* tp_basicsize */
+  0,                                     /* tp_itemsize */
+  (destructor)THPVariable_dealloc,       /* tp_dealloc */
+  0,                                     /* tp_print */
+  0,                                     /* tp_getattr */
+  0,                                     /* tp_setattr */
+  0,                                     /* tp_reserved */
+  0,                                     /* tp_repr */
+  0,                                     /* tp_as_number */
+  0,                                     /* tp_as_sequence */
+  0,                                     /* tp_as_mapping */
+  0,                                     /* tp_hash  */
+  0,                                     /* tp_call */
+  0,                                     /* tp_str */
+  0,                                     /* tp_getattro */
+  0,                                     /* tp_setattro */
+  0,                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+  NULL,                                  /* tp_doc */
+  (traverseproc)THPVariable_traverse,    /* tp_traverse */
+  (inquiry)THPVariable_clear,            /* tp_clear */
+  0,                                     /* tp_richcompare */
+  0,                                     /* tp_weaklistoffset */
+  0,                                     /* tp_iter */
+  0,                                     /* tp_iternext */
+  THPVariable_methods,                   /* tp_methods */
+  THPVariable_members,                   /* tp_members */
+  THPVariable_properties,                /* tp_getset */
+  0,                                     /* tp_base */
+  0,                                     /* tp_dict */
+  0,                                     /* tp_descr_get */
+  0,                                     /* tp_descr_set */
+  0,                                     /* tp_dictoffset */
+  (initproc)THPVariable_init,            /* tp_init */
+  0,                                     /* tp_alloc */
+  THPVariable_new                        /* tp_new */
+};
+
+
+bool THPVariable_initModule(PyObject *module)
+{
+  if (PyType_Ready(&THPVariableType) < 0)
+    return false;
+  Py_INCREF(&THPVariableType);
+  PyModule_AddObject(module, "_VariableBase", (PyObject *)&THPVariableType);
+  return true;
+}
+

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -1,0 +1,52 @@
+#ifndef THP_VARIABLE_H
+#define THP_VARIABLE_H
+
+struct THPVariableVersion {
+  THPVariableVersion() {
+    version_block = new int[2];
+    version_block[0] = 0;
+    version_block[1] = 1;
+  };
+
+  int operator++(int) { return version_block[0]++; }
+
+  int operator*() { return *version_block; }
+
+  void join_with(THPVariableVersion &other) {
+    cleanup();
+    version_block = other.version_block;
+    version_block[1]++;
+  }
+
+  void cleanup() {
+    if (--version_block[1])
+      return;
+    delete[] version_block;
+    version_block = nullptr;
+  }
+
+  ~THPVariableVersion() { cleanup(); }
+
+  int *version_block;
+};
+
+struct THPVariable {
+    PyObject_HEAD
+    PyObject *creator;
+    PyObject *data;
+    PyObject *grad;
+    PyObject *backward_hooks;
+    THPVariableVersion *version_counter;
+    int output_nr;
+    char is_volatile;
+    char requires_grad;
+};
+
+bool THPVariable_initModule(PyObject *module);
+extern PyObject *THPVariableClass;
+PyObject * THPVariable_NewVolatile(PyObject *data);
+PyObject * THPVariable_New(PyObject *data, PyObject *creator, char requires_grad);
+
+#define THPVariable_Check(obj) PyObject_IsInstance(obj, THPVariableClass)
+
+#endif

--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -10,25 +10,31 @@
 
 #include "override_macros.h"
 
+THCPAutoGPU::THCPAutoGPU(int device_id) {
+  setDevice(device_id);
+}
+
 THCPAutoGPU::THCPAutoGPU(PyObject *args, PyObject *self) {
-  if (self && setDevice(self))
+  if (self && setObjDevice(self))
     return;
 
   if (!args)
     return;
   for (int i = 0; i < PyTuple_Size(args); i++) {
     PyObject *arg = PyTuple_GET_ITEM(args, i);
-    if (setDevice(arg)) return;
+    if (setObjDevice(arg)) return;
   }
 }
 
-bool THCPAutoGPU::setDevice(PyObject *obj) {
+bool THCPAutoGPU::setObjDevice(PyObject *obj) {
   int new_device = -1;
   PyObject *obj_type = (PyObject*)Py_TYPE(obj);
   if (obj_type == THCPDoubleTensorClass) {
     new_device = THCudaDoubleTensor_getDevice(LIBRARY_STATE ((THCPDoubleTensor*)obj)->cdata);
   } else if (obj_type == THCPFloatTensorClass) {
     new_device = THCudaTensor_getDevice(LIBRARY_STATE ((THCPFloatTensor*)obj)->cdata);
+  } else if (obj_type == THCPHalfTensorClass) {
+    new_device = THCudaHalfTensor_getDevice(LIBRARY_STATE ((THCPHalfTensor*)obj)->cdata);
   } else if (obj_type == THCPLongTensorClass) {
     new_device = THCudaLongTensor_getDevice(LIBRARY_STATE ((THCPLongTensor*)obj)->cdata);
   } else if (obj_type == THCPIntTensorClass) {
@@ -40,12 +46,17 @@ bool THCPAutoGPU::setDevice(PyObject *obj) {
   } else if (obj_type == THCPByteTensorClass) {
     new_device = THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
   }
-  if (new_device != -1) {
+  return setDevice(new_device);
+}
+
+bool THCPAutoGPU::setDevice(int new_device) {
+  if (new_device == -1)
+    return false;
+
+  if (device == -1)
     THCudaCheck(cudaGetDevice(&device));
-    THCPModule_setDevice(new_device);
-    return true;
-  }
-  return false;
+  THCPModule_setDevice(new_device);
+  return true;
 }
 
 // This can throw... But if it does I have no idea how to recover.

--- a/torch/csrc/cuda/Tensor.h
+++ b/torch/csrc/cuda/Tensor.h
@@ -3,9 +3,11 @@
 
 class THCPAutoGPU {
 public:
+  THCPAutoGPU(int device_id=-1);
   THCPAutoGPU(PyObject *args, PyObject *self=NULL);
   ~THCPAutoGPU();
-  bool setDevice(PyObject *obj);
+  bool setObjDevice(PyObject *obj);
+  bool setDevice(int new_device);
   int device = -1;
 };
 

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -199,6 +199,21 @@ THTensor* THPTensor_(fromNumpy)(PyObject *numpy_array) {
     - THTensor* self
 ]]
 
+[[
+  name: THPTensor_(new)
+  python_name: new
+  method_flags: METH_KEYWORDS
+  defined_if: IS_CUDA
+  only_register: True
+]]
+#if IS_CUDA
+static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs);
+PyObject * THPTensor_(new)(THPTensor *self, PyObject *args, PyObject *kwargs)
+{
+  THCPAutoGPU gpu_guard(args, (PyObject*)self);
+  return THPTensor_(pynew)(Py_TYPE(self), args, kwargs);
+}
+#endif
 
 // TODO: check that there are no args
 [[

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -123,8 +123,9 @@
 #define THPByteUtils_unpackAccreal(object)    (long)THPUtils_unpackReal_INT(object)
 #define THPByteUtils_newAccreal(value)        THPUtils_newReal_INT(value)
 
-#define THPUtils_assert(cond, ...)                                             \
-if (!(cond)) { THPUtils_setError(__VA_ARGS__); return NULL; }
+#define THPUtils_assert(cond, ...) THPUtils_assertRet(NULL, cond, __VA_ARGS__)
+#define THPUtils_assertRet(value, cond, ...)                                   \
+if (__builtin_expect(!(cond), 0)) { THPUtils_setError(__VA_ARGS__); return value; }
 THP_API void THPUtils_setError(const char *format, ...);
 THP_API void THPUtils_invalidArguments(PyObject *given_args,
             const char *function_name, size_t num_options, ...);

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -95,14 +95,11 @@ class _CudaBase(object):
         with device(self.get_device()):
             return super(_CudaBase, self).type(*args, **kwargs)
 
-    def new(self, *args, **kwargs):
-        with device(kwargs.pop('device', self.get_device())):
-            return super(_CudaBase, self).new(*args, **kwargs)
-
     def __new__(cls, *args, **kwargs):
         _lazy_init()
-        with device(kwargs.pop('device', -1)):
-            return super(_CudaBase, cls).__new__(cls, *args, **kwargs)
+        # We need this method only for lazy init, so we can remove it
+        del _CudaBase.__new__
+        return super(_CudaBase, cls).__new__(cls, *args, **kwargs)
 
 
 class DoubleStorage(_CudaBase, torch._C.CudaDoubleStorageBase, _StorageBase):

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -48,7 +48,7 @@ class device(object):
 
     def __exit__(self, *args):
         if self.prev_idx != self.idx:
-            torch._C._cuda_setDevice(prev_idx)
+            torch._C._cuda_setDevice(self.prev_idx)
         return False
 
 

--- a/torch/nn/functions/thnn/sparse.py
+++ b/torch/nn/functions/thnn/sparse.py
@@ -29,7 +29,7 @@ class Embedding(Function):
 
     def forward(self, indices, weight):
         assert indices.dim() <= 2
-        assert not self.input[0].requires_grad, "Embedding doesn't " \
+        assert not self.needs_input_grad[0], "Embedding doesn't " \
             "compute the gradient w.r.t. the indices"
         self._backend = type2backend[type(weight)]
         self._weight_size = weight.size()

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -84,14 +84,13 @@ class _TensorBase(object):
         return iter(map(lambda i: self.select(0, i), _range(self.size(0))))
 
     def split(self, split_size, dim=0):
-        result = []
         dim_size = self.size(dim)
         num_splits = int(math.ceil(float(dim_size) / split_size))
         last_split_size = split_size - (split_size * num_splits - dim_size)
         def get_split_size(i):
             return split_size if i < num_splits-1 else last_split_size
-        return [self.narrow(int(dim), int(i*split_size), int(get_split_size(i))) for i
-                in _range(0, num_splits)]
+        return tuple(self.narrow(int(dim), int(i*split_size), int(get_split_size(i))) for i
+                in _range(0, num_splits))
 
     def chunk(self, n_chunks, dim=0):
         split_size = math.ceil(float(self.size(dim)) / n_chunks)


### PR DESCRIPTION
This is a huge modification to autograd. All core functions and types are moved to C (however they can still be used in python using the same interface - see `BasicEngine`). This improves RNN training speed on Penn Treebank more than 2x (and can actually saturate a GPU with a small RNN during backward).
