### PR TITLE
Fix pytorch when compiling without CUDA support

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2379,10 +2379,14 @@ class TestTorch(TestCase):
 
     def test_print(self):
         for t in torch._tensor_classes:
+            if t.is_cuda and not torch.cuda.is_available():
+                continue
             obj = t(100, 100).fill_(1)
             obj.__repr__()
             str(obj)
         for t in torch._storage_classes:
+            if  t.is_cuda and not torch.cuda.is_available():
+                continue
             obj = t(100).fill_(1)
             obj.__repr__()
             str(obj)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -132,6 +132,8 @@ if not hasattr(torch._C, 'CudaDoubleStorageBase'):
         torch._C.__dict__[storage_name] = type(storage_name, (object,), {})
         torch._C.__dict__[tensor_name] = type(tensor_name, (object,), {})
 
+    torch._C.__dict__['_CudaStreamBase'] = type('CudaStreamBase', (object,), {})
+
 
 class _CudaBase(object):
     is_cuda = True


### PR DESCRIPTION
Commit https://github.com/pytorch/pytorch/pull/133 seems to have broken pytorch when compiling without CUDA support.
Importing `torch.nn` lead to errors like (full log on #133):

```
...
/usr/local/lib/python2.7/dist-packages/torch/cuda/streams.py in <module>()
     20 
     21 
---> 22 class Stream(torch._C._CudaStreamBase):
     23     def __new__(cls, device=-1, **kwargs):
     24         with torch.cuda.device(device):

AttributeError: 'module' object has no attribute '_CudaStreamBase'
```

This PR seems to fix this issue on my side, but I'm not 100% sure about it.
