### PR TITLE
Lots of small fixes

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -4,10 +4,15 @@ from itertools import product
 from copy import deepcopy
 
 import torch
+import torch.cuda
 from torch.autograd import Variable, Function
 
 
 torch.set_default_tensor_type('torch.DoubleTensor')
+torch.manual_seed(123)
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(123)
+
 
 TEST_NUMPY = True
 try:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -413,6 +413,13 @@ class TestCuda(TestCase):
     def test_gather_dim(self):
         self._test_gather(1)
 
+    def test_from_sequence(self):
+        seq = [list(range(i*4,i*4+4)) for i in range(5)]
+        reference = torch.range(0, 19).resize_(5, 4)
+        for t in types:
+            cuda_type = get_gpu_type(t)
+            self.assertEqual(cuda_type(seq), reference)
+
     def test_manual_seed(self):
         with freeze_rng_state():
             x = torch.zeros(4, 4).float().cuda()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,6 +9,9 @@ from itertools import product, chain
 from functools import wraps
 from common import TestCase, iter_indices, TEST_NUMPY
 
+if TEST_NUMPY:
+    import numpy as np
+
 SIZE = 100
 
 def skipIfNoLapack(fn):
@@ -2418,7 +2421,7 @@ class TestTorch(TestCase):
         self.assertEqual(pinned, x)
         self.assertNotEqual(pinned.data_ptr(), x.data_ptr())
 
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_toNumpy(self):
         types = [
             'torch.ByteTensor',
@@ -2491,6 +2494,20 @@ class TestTorch(TestCase):
             self.assertTrue(y.flags.writeable)
             y[0][1] = 3
             self.assertTrue(x[0][1] == 3)
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_from_numpy(self):
+        dtypes = [
+            np.double,
+            np.float,
+            np.int64,
+            np.int32,
+            np.uint8
+        ]
+        for dtype in dtypes:
+            array = np.array([1, 2, 3, 4], dtype=dtype)
+            self.assertEqual(torch.from_numpy(array), torch.Tensor([1, 2, 3, 4]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -3,11 +3,11 @@ import torch
 from functools import reduce
 from ._utils import _range
 
-SCALE_FORMAT = '{:.5f} *\n'
+SCALE_FORMAT = '{:.5e} *\n'
 
 
 def _number_format(tensor):
-    min_sz = 0
+    min_sz = 2
     tensor = torch.DoubleTensor(tensor.nelement()).copy_(tensor).abs_()
 
     pos_inf_mask = tensor.eq(float('inf'))
@@ -118,9 +118,11 @@ def _matrix_str(self, indent=''):
 def _vector_str(self):
     fmt, scale, _ = _number_format(self)
     strt = ''
+    ident = ''
     if scale != 1:
         strt += SCALE_FORMAT.format(scale)
-    return '\n'.join(fmt.format(val/scale) for val in self) + '\n'
+        ident = ' '
+    return strt + '\n'.join(ident + fmt.format(val/scale) for val in self) + '\n'
 
 
 def _str(self):

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -284,11 +284,11 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
                                                                                \
 dispatch:                                                                      \
   THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
-  THPUtils_assert(methods, "Type %s doesn't implement statless methods",       \
-      Py_TYPE(tensor)->tp_name);                                               \
-  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                   \
+  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",      \
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
+  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
   THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
-      Py_TYPE(tensor)->tp_name);                                               \
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
   return PyObject_Call(method, args, kwargs);                                  \
 }
 
@@ -447,11 +447,11 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
                                                                                \
 dispatch:                                                                      \
   THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
-  THPUtils_assert(methods, "Type %s doesn't implement statless methods",       \
-      Py_TYPE(tensor)->tp_name);                                               \
+  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",      \
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
   THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
   THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
-      Py_TYPE(tensor)->tp_name);                                               \
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
   return PyObject_Call(method, args, kwargs);                                  \
 }
 
@@ -476,11 +476,11 @@ static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args)
     tensor = PyTuple_GET_ITEM(args, 1);
 
   THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
-  THPUtils_assert(methods, "Type %s doesn't implement statless methods",
-      Py_TYPE(tensor)->tp_name);
+  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   THPObjectPtr method = PyObject_GetAttrString(methods, "nonzero");
   THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
-      Py_TYPE(tensor)->tp_name);
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   return PyObject_Call(method, args, NULL);
 }
 
@@ -503,10 +503,10 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
 
   THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
   THPUtils_assert(methods, "Type %s doesn't implement statless methods",
-      Py_TYPE(tensor)->tp_name);
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   THPObjectPtr method = PyObject_GetAttrString(methods, "cat");
-  THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
-      Py_TYPE(tensor)->tp_name);
+  THPUtils_assert(method, "Type %s doesn't implement stateless method cat",
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   return PyObject_Call(method, args, NULL);
 }
 

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -354,7 +354,7 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *inputs)
       // the object and remembers which output did we use.
       PyObject *prev_fn = input_var->creator ? input_var->creator : (PyObject*)input_var;
       Py_INCREF(prev_fn);
-      self->previous_functions[i] = std::move(THPFunctionPtr(prev_fn, input_var->output_nr));
+      self->previous_functions[i] = THPFunctionPtr(prev_fn, input_var->output_nr);
     }
 
     if (!_mark_dirty(self, t2var))

--- a/torch/csrc/cuda/override_macros.h
+++ b/torch/csrc/cuda/override_macros.h
@@ -32,3 +32,7 @@
 #define LIBRARY_STATE state,
 #define TH_GENERIC_FILE THC_GENERIC_FILE
 
+#define THHostTensor TH_CONCAT_3(TH,Real,Tensor)
+#define THHostTensor_(NAME) TH_CONCAT_4(TH,Real,Tensor_,NAME)
+#define THHostStorage TH_CONCAT_3(TH,Real,Storage)
+#define THHostStorage_(NAME) TH_CONCAT_4(TH,Real,Storage_,NAME)

--- a/torch/csrc/cuda/undef_macros.h
+++ b/torch/csrc/cuda/undef_macros.h
@@ -30,3 +30,7 @@
 #undef THTensorPtr
 #undef THPTensorPtr
 
+#undef THHostTensor
+#undef THHostTensor_
+#undef THHostStorage
+#undef THHostStorage_

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -154,40 +154,6 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
 
   return array.release();
 }
-
-THTensor* THPTensor_(fromNumpy)(PyObject *numpy_array) {
-  PyArrayObject *array = (PyArrayObject*)numpy_array;
-  THStoragePtr storage = THStorage_(newWithDataAndAllocator)(
-      (real*)PyArray_DATA(array),
-      PyArray_NBYTES(array) / sizeof(real),
-      &THNumpyArrayAllocator,
-      new NumpyArrayAllocator(numpy_array));
-
-  // Numpy and Torch disagree on empty tensors. In Torch, an empty
-  // tensor is a tensor with zero dimensions. In Numpy, an empty tensor
-  // keeps its shape, but has 0 as the size of one of the dimensions.
-  // So we'll convert all Numpy tensors of 0 elements to empty Torch tensors.
-  if (PyArray_SIZE(array) != 0) {
-    auto ndim = PyArray_NDIM(array);
-    THLongStoragePtr sizes = THLongStorage_newWithSize(ndim);
-    long *sizes_data = sizes->data;
-    for (int i = 0; i < ndim; ++i) {
-      sizes_data[i] = PyArray_DIM(array, i);
-    }
-
-    THLongStoragePtr strides = THLongStorage_newWithSize(ndim);
-    long *strides_data = strides->data;
-    for (int i = 0; i < ndim; ++i) {
-      strides_data[i] = PyArray_STRIDE(array, i) / sizeof(real);   // numpy uses bytes, torch uses elements
-    }
-
-    THTensor *result = THTensor_(newWithStorage)(storage, 0, sizes, strides);
-    return result;
-  } else {
-    THTensor *result = THTensor_(newWithStorage)(storage, 0, NULL, NULL);
-    return result;
-  }
-}
 #endif
 
 [[

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -3085,14 +3085,14 @@ static PyObject * THPTensor_(map2)(THPTensor *self, PyObject *args)
 #if !IS_CUDA
 static void THTensor_(random2__)(THTensor *self, THGenerator *gen, long a, long b)
 {
-  THArgCheck(b >= a, 2, "upper bound must be larger than lower bound");
+  THArgCheck(b >= a, 2, "upper bound must be greater or equal than lower bound");
   TH_TENSOR_APPLY(real, self, *self_data = ((THRandom_random(gen) % (b+1-a)) + a);)
 }
 
 static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
 {
-  THArgCheck(b > 0, 1, "upper bound must be strictly positive");
-  TH_TENSOR_APPLY(real, self, *self_data = (THRandom_random(gen) % b + 1);)
+  THArgCheck(b >= 0, 1, "upper bound must be positive");
+  TH_TENSOR_APPLY(real, self, *self_data = (THRandom_random(gen) % b);)
 }
 #endif
 

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -132,6 +132,7 @@ THP_API void THPUtils_invalidArguments(PyObject *given_args,
 
 #ifdef _THP_CORE
 
+#define THPUtils_classname(obj) (((PyTypeObject*)obj)->tp_name)
 THLongStorage * THPUtils_getLongStorage(PyObject *args, int ignore_first=0);
 int THPUtils_getCallable(PyObject *arg, PyObject **result);
 bool THPUtils_parseSlice(PyObject *slice, Py_ssize_t len, Py_ssize_t *ostart,

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import contextlib
+import platform
 import ctypes
 import os
 import torch
@@ -35,10 +36,8 @@ a PyTorch version that has been compiled with your version
 of the CUDA driver.""".format(str(torch._C._cuda_getDriverVersion())))
     assert torch._C._cuda_init()
     _initialized = True
-    if os.name == 'mac':
+    if platform.system() == 'Darwin':
         _cudart = ctypes.cdll.LoadLibrary('libcudart.dylib')
-    elif os.name == 'nt':
-        _cudart = ctypes.cdll.LoadLibrary('cudart.dll')
     else:
         _cudart = ctypes.cdll.LoadLibrary('libcudart.so')
     _cudart.cudaGetErrorName.restype = ctypes.c_char_p

--- a/torch/legacy/nn/Module.py
+++ b/torch/legacy/nn/Module.py
@@ -249,19 +249,19 @@ class Module(object):
 
     def apply(self, callback):
         callback(self)
-        for _, module in self.modules:
-            module.apply(callback)
+        if hasattr(self, 'modules'):
+            for _, module in self.modules:
+                module.apply(callback)
 
-    def findModules(self, typename, container=None):
+    def findModules(self, cls, container=None):
         nodes = []
         containers = []
-        mod_type = str(type(self))
-        if mod_type == typename:
+        if isinstance(self, cls):
             nodes.append(self)
             containers.append(container)
 
         # Recurse on nodes with 'modules'
-        if self.modules:
+        if hasattr(self, 'modules'):
             for child in self.modules:
                 child_nodes, child_containers = child.findModules(typename, self)
                 assert len(child_nodes) == len(child_containers)
@@ -275,7 +275,7 @@ class Module(object):
     def listModules(self):
         # include self first
         modules = [self]
-        if self.modules:
+        if hasattr(self, 'modules'):
             for child in self.modules:
                 modules.extend(child.listModules())
         return modules
@@ -286,7 +286,8 @@ class Module(object):
     def replace(self, callback):
         out = callback(self)
         # TODO: not out.modules?
-        if self.modules:
+        if hasattr(self, 'modules'):
             for i, module in self.modules:
                 self.modules[i] = module.replace(callback)
         return out
+

--- a/torch/legacy/nn/Sequential.py
+++ b/torch/legacy/nn/Sequential.py
@@ -15,7 +15,7 @@ class Sequential(Container):
         return self
 
     def insert(self, module, index):
-        self.module.insert(module, index)
+        self.modules.insert(module, index)
         self.output = self.modules[-1].output
         self.gradInput = self.modules[0].gradInput
 

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -45,15 +45,6 @@ function build_nccl() {
    make install
    cp "lib/libnccl.so" "${INSTALL_DIR}/lib/libnccl.so"
    cd ../..
-
-   if [[ $(uname) == 'Darwin' ]]; then
-     cd tmp_install/lib
-     for lib in *.dylib; do
-      echo "Updating install_name for $lib"
-      install_name_tool -id @rpath/$lib $lib
-     done
-     cd ../..
-   fi
 }
 
 mkdir -p tmp_install
@@ -63,7 +54,9 @@ build THNN
 if [[ "$1" == "--with-cuda" ]]; then
     build THC
     build THCUNN
-    build_nccl
+    if [[ $(uname) != 'Darwin' ]]; then
+        build_nccl
+    fi
 fi
 
 CPP_FLAGS=" -std=c++11 "

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -132,6 +132,18 @@ class Container(Module):
                 for m in module.modules(memo):
                     yield m
 
+    def training(self):
+        super(Container, self).training()
+        for module in self.children():
+            module.training()
+        return self
+
+    def evaluation(self):
+        super(Container, self).evaluation()
+        for module in self.children():
+            module.evaluation()
+        return self
+
     def _apply(self, fn):
         for module in self.children():
             module._apply(fn)

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -25,7 +25,7 @@ class Dropout(Module):
 
 class Dropout2d(Module):
     """Randomly zeroes whole channels of the input tensor.
-    The input is 4D (batch x channels, height, width) and each channel 
+    The input is 4D (batch x channels, height, width) and each channel
     is of size (1, height, width).
     The channels to zero are randomized on every forward call.
     Usually the input comes from Conv2d modules.
@@ -59,7 +59,7 @@ class Dropout2d(Module):
 
 class Dropout3d(Module):
     """Randomly zeroes whole channels of the input tensor.
-    The input is 5D (batch x channels, depth, height, width) and each channel 
+    The input is 5D (batch x channels, depth, height, width) and each channel
     is of size (1, depth, height, width).
     The channels to zero are randomized on every forward call.
     Usually the input comes from Conv3d modules.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -155,6 +155,20 @@ class Module(object):
             memo.add(self)
             yield self
 
+    def training(self):
+        self.train = True
+        for p in self._parameters.values():
+            if p is not None:
+                p.requires_grad = True
+        return self
+
+    def evaluation(self):
+        self.train = False
+        for p in self._parameters.values():
+            if p is not None:
+                p.requires_grad = False
+        return self
+
     def zero_grad(self):
         for p in self.parameters():
             p.grad.zero_()

--- a/torch/utils/ffi/__init__.py
+++ b/torch/utils/ffi/__init__.py
@@ -14,6 +14,11 @@ except ImportError:
     raise ImportError("torch.utils.ffi requires the cffi package")
 
 
+if cffi.__version_info__ < (1,4,0):
+    raise ImportError("torch.utils.ffi requires cffi version >= 1.4, but "
+            "got " + '.'.join(map(str, cffi.__version_info__)))
+
+
 def _generate_typedefs():
     typedefs = []
     for t in ['Double', 'Float', 'Long', 'Int', 'Short', 'Char', 'Byte']:
@@ -79,7 +84,7 @@ def _create_module_dir(fullname):
         target_dir = reduce(os.path.join, fullname.split('.'))
     try:
         os.makedirs(target_dir)
-    except FileExistsError:
+    except os.error:
         pass
     for dirname in _accumulate(fullname.split('.'), os.path.join):
         init_file = os.path.join(dirname, '__init__.py')


### PR DESCRIPTION
- python2.7 compatibility and cffi version checks in `torch.utils.ffi` (#156, #157)
- platform checks in `torch.cuda` (failed on macOS)
- don't build nccl on macOS
- bugs in `torch.legacy.nn`
- `.train()` and `.evaluate()` for modules and containers
- 0-based random (#123)
- stateless functions no longer print "type type doesn't implement stateless methods" when a method resolution fails
- added `torch.from_numpy` (#159)
- fixed clang warnings
- tests are now deterministic (#125)
- added tensor values buffering when constructing CUDA tensors from sequences (#158)
- show exponent when printing vectors (#147)
