### PR TITLE
Fix Lua->Python logic in legacy.optim

### DIFF
--- a/torch/legacy/optim/adadelta.py
+++ b/torch/legacy/optim/adadelta.py
@@ -21,7 +21,7 @@ def adadelta(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("adadelta requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     rho = config.get('rho', 0.9)
     eps = config.get('eps', 1e-6)
     wd = config.get('weightDecay', 0)

--- a/torch/legacy/optim/adagrad.py
+++ b/torch/legacy/optim/adagrad.py
@@ -19,7 +19,7 @@ def adagrad(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("adagrad requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 1e-3)
     lrd = config.get('learningRateDecay', 0)
     wd = config.get('weightDecay', 0)

--- a/torch/legacy/optim/adam.py
+++ b/torch/legacy/optim/adam.py
@@ -25,7 +25,7 @@ def adam(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("adam requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 0.001)
     beta1 = config.get('beta1', 0.9)
     beta2 = config.get('beta2', 0.999)

--- a/torch/legacy/optim/adamax.py
+++ b/torch/legacy/optim/adamax.py
@@ -25,7 +25,7 @@ def adamax(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("adamax requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 0.002)
     beta1 = config.get('beta1', 0.9)
     beta2 = config.get('beta2', 0.999)

--- a/torch/legacy/optim/asgd.py
+++ b/torch/legacy/optim/asgd.py
@@ -35,7 +35,7 @@ def asgd(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("asgd requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     config['eta0'] = config.get('eta0', 1e-4)
     config['lambda'] = config.get('lambda', 1e-4)
     config['alpha'] = config.get('alpha', 0.75)

--- a/torch/legacy/optim/cg.py
+++ b/torch/legacy/optim/cg.py
@@ -44,7 +44,7 @@ def cg(opfunc, x, config, state=None):
     # parameters
     if config is None and state is None:
         raise ValueError("cg requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     rho  = config.get('rho', 0.01)
     sig  = config.get('sig', 0.5)
     _int  = config.get('int', 0.1)

--- a/torch/legacy/optim/nag.py
+++ b/torch/legacy/optim/nag.py
@@ -28,7 +28,7 @@ def nag(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("nag requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 1e-3)
     lrd = config.get('learningRateDecay', 0)
     wd = config.get('weightDecay', 0)

--- a/torch/legacy/optim/rmsprop.py
+++ b/torch/legacy/optim/rmsprop.py
@@ -26,7 +26,7 @@ def rmsprop(opfunc, x, config, state=None):
     # (0) get/update state
     if config is None and state is None:
         raise ValueError("rmsprop requires a dictionary to retain state between iterations")
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 1e-2)
     alpha = config.get('alpha', 0.99)
     epsilon = config.get('epsilon', 1e-8)

--- a/torch/legacy/optim/rprop.py
+++ b/torch/legacy/optim/rprop.py
@@ -26,7 +26,7 @@ def rprop(opfunc, x, config, state=None):
         raise ValueError("rprop requires a dictionary to retain state between iterations")
 
     # (0) get/update state
-    state = state or config
+    state = state if state is not None else config
     stepsize = config.get('stepsize', 0.1)
     etaplus = config.get('etaplus', 1.2)
     etaminus = config.get('etaminus', 0.5)

--- a/torch/legacy/optim/sgd.py
+++ b/torch/legacy/optim/sgd.py
@@ -28,7 +28,7 @@ def sgd(opfunc, x, config, state=None):
     (Clement Farabet, 2012)
     """
     # (0) get/update state
-    state = state or config
+    state = state if state is not None else config
     lr = config.get('learningRate', 1e-3)
     lrd = config.get('learningRateDecay', 0)
     wd = config.get('weightDecay', 0)


### PR DESCRIPTION
Hi, I've started using ADAM from `legacy.optim` since it's not yet implemented in `optim`. I noticed and fixed a problem with the Lua->Python logic here that might be present in other places too. The problem is that `{}` is considered falsey in Python so if `state={}` and `config` is not empty then `state or config` will evaluate to `config`.
