### PR TITLE
Add Parameter class to nn

### DIFF
--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -94,7 +94,7 @@ static void THPVariable_dealloc(THPVariable* self)
 PyObject *THPVariable_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
   THPVariable *self;
-  if (num_cached == 0) {
+  if ((PyObject*)type != THPVariableClass || num_cached == 0) {
     self = (THPVariable*)type->tp_alloc(type, 0);
     self->version_counter = new THPVariableVersion();
   } else {

--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -1,2 +1,4 @@
 
 from .modules import *
+from .parameter import Parameter
+

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -5,7 +5,6 @@ import inspect
 from collections import OrderedDict
 
 import torch
-from torch.autograd import Variable
 from .module import Module
 
 class SourceChangeWarning(Warning):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1,8 +1,8 @@
 import math
 import torch
-from torch.autograd import Variable
 
 from .module import Module
+from ..parameter import Parameter
 
 
 class RNNBase(Module):
@@ -28,10 +28,10 @@ class RNNBase(Module):
             else:
                 gate_size = hidden_size
 
-            w_ih = Variable(torch.Tensor(gate_size, layer_input_size), requires_grad=True)
-            w_hh = Variable(torch.Tensor(gate_size, hidden_size), requires_grad=True)
-            b_ih = Variable(torch.Tensor(gate_size), requires_grad=True)
-            b_hh = Variable(torch.Tensor(gate_size), requires_grad=True)
+            w_ih = Parameter(torch.Tensor(gate_size, layer_input_size))
+            w_hh = Parameter(torch.Tensor(gate_size, hidden_size))
+            b_ih = Parameter(torch.Tensor(gate_size))
+            b_hh = Parameter(torch.Tensor(gate_size))
 
             super_weights['weight_ih_l{}'.format(layer)] = w_ih
             super_weights['weight_hh_l{}'.format(layer)] = w_hh

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -1,0 +1,7 @@
+from torch.autograd import Variable
+
+class Parameter(Variable):
+
+    def __init__(self, data, requires_grad=True):
+        super(Parameter, self).__init__(data, requires_grad=requires_grad)
+


### PR DESCRIPTION
After this change assigning Variables as attributes doesn't add them as parameters. To do so, one needs to create them as `torch.nn.Parameter` instances.
