### PR TITLE
Allow to not use all function outputs in autograd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ if WITH_CUDA:
         "torch/csrc/cuda/Storage.cpp",
         "torch/csrc/cuda/Stream.cpp",
         "torch/csrc/cuda/Tensor.cpp",
+        "torch/csrc/cuda/AutoGPU.cpp",
         "torch/csrc/cuda/utils.cpp",
         "torch/csrc/cuda/serialization.cpp",
     ]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -281,6 +281,25 @@ class TestAutograd(TestCase):
         y.sum().backward()
         self.assertEqual(x.grad, torch.ones(5, 5) * 2)
 
+    def test_no_grad(self):
+        x = Variable(torch.randn(10, 10), requires_grad=True)
+        y = x + 2
+        y = y.no_grad()
+        z = y * 4 + 2
+        self.assertFalse(y.requires_grad)
+        self.assertFalse(z.requires_grad)
+
+        x = Variable(torch.randn(10, 10), requires_grad=True)
+        y = x * 2
+        y = y.no_grad()
+        self.assertFalse(y.requires_grad)
+        self.assertFalse(y.creator.requires_grad)
+        z = x + y
+        z.sum().backward()
+        # This is an incorrect gradient, but we assume that's what the user
+        # wanted. no_grad() is an advanced option.
+        self.assertEqual(x.grad, torch.ones(10, 10))
+
     def test_type_conversions(self):
         import torch.cuda
         x = Variable(torch.randn(5, 5))

--- a/torch/autograd/engine.py
+++ b/torch/autograd/engine.py
@@ -44,7 +44,9 @@ class BasicEngine(object):
             variable._do_backward((grad,), retain_variables)
             return
 
-        ready = deque([(variable.creator, (grad,))])
+        initial_grad = [None for _ in range(variable.creator.num_outputs)]
+        initial_grad[variable.output_nr] = grad
+        ready = deque([(variable.creator, initial_grad)])
         not_ready = {}
         need_copy = set()
 

--- a/torch/autograd/functions/tensor.py
+++ b/torch/autograd/functions/tensor.py
@@ -50,6 +50,25 @@ class SetItem(InplaceFunction):
             return grad_input
 
 
+class NoGrad(Function):
+
+    def forward(self, i):
+        result = i.new(i)
+        self.mark_non_differentiable(result)
+        self.mark_shared_storage((i, result))
+        return result
+
+    def backward(self, grad_output):
+        assert False, "backward of NoGrad should never be called"
+
+    def _do_forward(self, *args, **kwargs):
+        result = super(NoGrad, self)._do_forward(*args, **kwargs)
+        self.requires_grad = False
+        return result
+
+    __call__ = _do_forward
+
+
 class Transpose(Function):
 
     def __init__(self, *dims):

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -36,8 +36,14 @@ class Variable(_C._VariableBase):
     @requires_grad.setter
     def requires_grad(self, value):
         if self.creator is not None:
+            if value is False:
+                hint = (" If you want to use a computed variable in a subgraph "
+                    "that doesn't require differentiation use "
+                    "var_no_grad = var.no_grad().")
+            else:
+                hint = ''
             raise RuntimeError("you can only change requires_grad flags of "
-                    "leaf variables")
+                    "leaf variables." + hint)
         self._requires_grad = value
 
     def __getattr__(self, name):
@@ -120,6 +126,9 @@ class Variable(_C._VariableBase):
                 hook(grad_output[0])
         self.grad.add_(grad_output[0])
         return tuple()
+
+    def no_grad(self):
+        return NoGrad()(self)
 
     def contiguous(self):
         self.data = self.data.contiguous()

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -25,6 +25,7 @@
 #include "Tensor.h"
 #include "Size.h"
 #include "Module.h"
+#include "Types.h"
 #include "utils.h" // This requires defined Storage and Tensor types
 #include "byte_order.h"
 

--- a/torch/csrc/Types.h
+++ b/torch/csrc/Types.h
@@ -1,0 +1,40 @@
+#ifndef THP_TYPES_INC
+#define THP_TYPES_INC
+
+#include <Python.h>
+#include <cstddef>
+
+namespace torch {
+
+typedef struct THVoidStorage
+{
+  void *data;
+  ptrdiff_t size;
+  int refcount;
+  char flag;
+  void *allocator;
+  void *allocatorContext;
+  THVoidStorage *view;
+} THVoidStorage;
+
+typedef struct THVoidTensor
+{
+   long *size;
+   long *stride;
+   int nDimension;
+   THVoidStorage *storage;
+   ptrdiff_t storageOffset;
+   int refcount;
+   char flag;
+} THVoidTensor;
+
+struct THPVoidTensor {
+  PyObject_HEAD
+  THVoidTensor *cdata;
+  char device_type;
+  char data_type;
+};
+
+}  // namespace torch
+
+#endif

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -24,6 +24,9 @@ struct THPFunctionPtr: public THPObjectPtr {
     int output_nr;
 };
 
+// (class, gpu id, sizes)
+using output_info_type = std::tuple<PyObject *, int, std::vector<long>>;
+
 struct THPFunction {
     PyObject_HEAD
 
@@ -37,6 +40,7 @@ struct THPFunction {
     PyObject *dirty_tensors;
 
     THPFunctionPtr *previous_functions;
+    std::vector<output_info_type> *output_info;
     int num_inputs;
     int num_outputs;
     char requires_grad;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -198,7 +198,7 @@ static struct PyMemberDef THPVariable_members[] = {
   {(char*)"volatile",       T_BOOL,     offsetof(THPVariable, is_volatile), 0, NULL},
   {(char*)"output_nr",      T_INT,      offsetof(THPVariable, output_nr), 0, NULL},
   {(char*)"backward_hooks", T_OBJECT,   offsetof(THPVariable, backward_hooks), 0, NULL},
-  {(char*)"_requires_grad", T_BOOL,     offsetof(THPVariable, requires_grad), READONLY, NULL},
+  {(char*)"_requires_grad", T_BOOL,     offsetof(THPVariable, requires_grad), 0, NULL},
   {NULL}
 };
 

--- a/torch/csrc/cuda/AutoGPU.cpp
+++ b/torch/csrc/cuda/AutoGPU.cpp
@@ -1,0 +1,61 @@
+#include "AutoGPU.h"
+
+#include "THCP.h"
+#include <THC/THC.h>
+
+THCPAutoGPU::THCPAutoGPU(int device_id) {
+  setDevice(device_id);
+}
+
+THCPAutoGPU::THCPAutoGPU(PyObject *args, PyObject *self) {
+  if (self && setObjDevice(self))
+    return;
+
+  if (!args)
+    return;
+  for (int i = 0; i < PyTuple_Size(args); i++) {
+    PyObject *arg = PyTuple_GET_ITEM(args, i);
+    if (setObjDevice(arg)) return;
+  }
+}
+
+bool THCPAutoGPU::setObjDevice(PyObject *obj) {
+  int new_device = -1;
+  PyObject *obj_type = (PyObject*)Py_TYPE(obj);
+  if (obj_type == THCPDoubleTensorClass) {
+    new_device = THCudaDoubleTensor_getDevice(LIBRARY_STATE ((THCPDoubleTensor*)obj)->cdata);
+  } else if (obj_type == THCPFloatTensorClass) {
+    new_device = THCudaTensor_getDevice(LIBRARY_STATE ((THCPFloatTensor*)obj)->cdata);
+  } else if (obj_type == THCPHalfTensorClass) {
+    new_device = THCudaHalfTensor_getDevice(LIBRARY_STATE ((THCPHalfTensor*)obj)->cdata);
+  } else if (obj_type == THCPLongTensorClass) {
+    new_device = THCudaLongTensor_getDevice(LIBRARY_STATE ((THCPLongTensor*)obj)->cdata);
+  } else if (obj_type == THCPIntTensorClass) {
+    new_device = THCudaIntTensor_getDevice(LIBRARY_STATE ((THCPIntTensor*)obj)->cdata);
+  } else if (obj_type == THCPShortTensorClass) {
+    new_device = THCudaShortTensor_getDevice(LIBRARY_STATE ((THCPShortTensor*)obj)->cdata);
+  } else if (obj_type == THCPCharTensorClass) {
+    new_device = THCudaCharTensor_getDevice(LIBRARY_STATE ((THCPCharTensor*)obj)->cdata);
+  } else if (obj_type == THCPByteTensorClass) {
+    new_device = THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
+  }
+  return setDevice(new_device);
+}
+
+bool THCPAutoGPU::setDevice(int new_device) {
+  if (new_device == -1)
+    return false;
+
+  if (device == -1)
+    THCudaCheck(cudaGetDevice(&device));
+  if (new_device != device)
+    THCPModule_setDevice(new_device);
+  return true;
+}
+
+// This can throw... But if it does I have no idea how to recover.
+THCPAutoGPU::~THCPAutoGPU() {
+  if (device != -1)
+    THCPModule_setDevice(device);
+}
+

--- a/torch/csrc/cuda/AutoGPU.h
+++ b/torch/csrc/cuda/AutoGPU.h
@@ -1,0 +1,16 @@
+#ifndef THCP_AUTOGPU_INC
+#define THCP_AUTOGPU_INC
+
+#include <Python.h>
+
+class THCPAutoGPU {
+public:
+  THCPAutoGPU(int device_id=-1);
+  THCPAutoGPU(PyObject *args, PyObject *self=NULL);
+  ~THCPAutoGPU();
+  bool setObjDevice(PyObject *obj);
+  bool setDevice(int new_device);
+  int device = -1;
+};
+
+#endif

--- a/torch/csrc/cuda/THCP.h
+++ b/torch/csrc/cuda/THCP.h
@@ -6,6 +6,7 @@
 
 #include "torch/csrc/THP.h"
 #include "serialization.h"
+#include "AutoGPU.h"
 #include "Module.h"
 #include "Storage.h"
 #include "Tensor.h"

--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -10,61 +10,6 @@
 
 #include "override_macros.h"
 
-THCPAutoGPU::THCPAutoGPU(int device_id) {
-  setDevice(device_id);
-}
-
-THCPAutoGPU::THCPAutoGPU(PyObject *args, PyObject *self) {
-  if (self && setObjDevice(self))
-    return;
-
-  if (!args)
-    return;
-  for (int i = 0; i < PyTuple_Size(args); i++) {
-    PyObject *arg = PyTuple_GET_ITEM(args, i);
-    if (setObjDevice(arg)) return;
-  }
-}
-
-bool THCPAutoGPU::setObjDevice(PyObject *obj) {
-  int new_device = -1;
-  PyObject *obj_type = (PyObject*)Py_TYPE(obj);
-  if (obj_type == THCPDoubleTensorClass) {
-    new_device = THCudaDoubleTensor_getDevice(LIBRARY_STATE ((THCPDoubleTensor*)obj)->cdata);
-  } else if (obj_type == THCPFloatTensorClass) {
-    new_device = THCudaTensor_getDevice(LIBRARY_STATE ((THCPFloatTensor*)obj)->cdata);
-  } else if (obj_type == THCPHalfTensorClass) {
-    new_device = THCudaHalfTensor_getDevice(LIBRARY_STATE ((THCPHalfTensor*)obj)->cdata);
-  } else if (obj_type == THCPLongTensorClass) {
-    new_device = THCudaLongTensor_getDevice(LIBRARY_STATE ((THCPLongTensor*)obj)->cdata);
-  } else if (obj_type == THCPIntTensorClass) {
-    new_device = THCudaIntTensor_getDevice(LIBRARY_STATE ((THCPIntTensor*)obj)->cdata);
-  } else if (obj_type == THCPShortTensorClass) {
-    new_device = THCudaShortTensor_getDevice(LIBRARY_STATE ((THCPShortTensor*)obj)->cdata);
-  } else if (obj_type == THCPCharTensorClass) {
-    new_device = THCudaCharTensor_getDevice(LIBRARY_STATE ((THCPCharTensor*)obj)->cdata);
-  } else if (obj_type == THCPByteTensorClass) {
-    new_device = THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
-  }
-  return setDevice(new_device);
-}
-
-bool THCPAutoGPU::setDevice(int new_device) {
-  if (new_device == -1)
-    return false;
-
-  if (device == -1)
-    THCudaCheck(cudaGetDevice(&device));
-  THCPModule_setDevice(new_device);
-  return true;
-}
-
-// This can throw... But if it does I have no idea how to recover.
-THCPAutoGPU::~THCPAutoGPU() {
-  if (device != -1)
-    THCPModule_setDevice(device);
-}
-
 #define THC_GENERIC_FILE "torch/csrc/generic/Tensor.cpp"
 #include <THC/THCGenerateAllTypes.h>
 

--- a/torch/csrc/cuda/Tensor.h
+++ b/torch/csrc/cuda/Tensor.h
@@ -1,16 +1,6 @@
 #ifndef THCP_TENSOR_INC
 #define THCP_TENSOR_INC
 
-class THCPAutoGPU {
-public:
-  THCPAutoGPU(int device_id=-1);
-  THCPAutoGPU(PyObject *args, PyObject *self=NULL);
-  ~THCPAutoGPU();
-  bool setObjDevice(PyObject *obj);
-  bool setDevice(int new_device);
-  int device = -1;
-};
-
 #define THCPTensor TH_CONCAT_3(THCP,Real,Tensor)
 #define THCPTensorStr TH_CONCAT_STRING_3(torch.cuda.,Real,Tensor)
 #define THCPTensorClass TH_CONCAT_3(THCP,Real,TensorClass)

--- a/torch/csrc/cudnn/Conv.h
+++ b/torch/csrc/cudnn/Conv.h
@@ -4,7 +4,7 @@
 #include <cudnn.h>
 #include "THC/THC.h"
 
-#include "Types.h"
+#include "../Types.h"
 #include "Descriptors.h"
 
 namespace torch { namespace cudnn {

--- a/torch/csrc/cudnn/Types.h
+++ b/torch/csrc/cudnn/Types.h
@@ -7,33 +7,6 @@
 
 namespace torch { namespace cudnn {
 
-typedef struct THVoidStorage
-{
-  void *data;
-  ptrdiff_t size;
-  int refcount;
-  char flag;
-  void *allocator;
-  void *allocatorContext;
-  THVoidStorage *view;
-} THVoidStorage;
-
-typedef struct THVoidTensor
-{
-   long *size;
-   long *stride;
-   int nDimension;
-   THVoidStorage *storage;
-   ptrdiff_t storageOffset;
-   int refcount;
-   char flag;
-} THVoidTensor;
-
-struct THPVoidTensor {
-  PyObject_HEAD
-  THVoidTensor *cdata;
-};
-
 PyObject * getTensorClass(PyObject *args);
 cudnnDataType_t getCudnnDataType(PyObject *tensorClass);
 

--- a/torch/csrc/cudnn/cuDNN.cwrap
+++ b/torch/csrc/cudnn/cuDNN.cwrap
@@ -7,6 +7,7 @@
 
 
 using namespace torch::cudnn;
+using namespace torch;
 
 extern THCState* state;
 


### PR DESCRIPTION
Also, implement `variable.no_grad()` that returns a new variable with the same data, but with `requires_grad == False` (#166).
