### PR TITLE
Make every user-visible Tensor have a Storage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
         from tools.cwrap.plugins.NullableArguments import NullableArguments
         from tools.cwrap.plugins.CuDNNPlugin import CuDNNPlugin
         cwrap('torch/csrc/generic/TensorMethods.cwrap', plugins=[
-            AutoGPU(condition='IS_CUDA'), BoolOption(), THPPlugin(),
+            BoolOption(), THPPlugin(), AutoGPU(condition='IS_CUDA'),
             ArgcountSortPlugin(), KwargsPlugin(),
         ])
         cwrap('torch/csrc/cudnn/cuDNN.cwrap', plugins=[

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -130,6 +130,18 @@ class TestTorch(TestCase):
     def test_round(self):
         self._testMath(torch.round, round)
 
+    def test_has_storage(self):
+        self.assertIsNotNone(torch.Tensor().storage())
+        self.assertIsNotNone(torch.Tensor(0).storage())
+        self.assertIsNotNone(torch.Tensor([]).storage())
+        self.assertIsNotNone(torch.Tensor().clone().storage())
+        self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_has_storage_numpy(self):
+        arr = np.array([], dtype=np.float32)
+        self.assertIsNotNone(torch.Tensor(arr).storage())
+
     def _testSelection(self, torchfn, mathfn):
         # contiguous
         m1 = torch.randn(100,100)
@@ -2477,6 +2489,11 @@ class TestTorch(TestCase):
                 for i in range(sz1):
                     for j in range(sz2):
                         self.assertEqual(x[i][j], y[i][j])
+
+            # empty
+            x = torch.Tensor().type(tp)
+            y = x.numpy()
+            self.assertEqual(y.size, 0)
 
             # contiguous 2D
             sz1 = 3

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -45,11 +45,10 @@ static PyObject * THPGenerator_getState(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
   THGenerator *generator = self->cdata;
-  THByteTensorPtr _t = THByteTensor_new();
-  THByteTensor_getRNGState(generator, _t.get());
-  PyObject *_ret =  THPByteTensor_New(_t.get());
-  _t.release();
-  return _ret;
+  THPByteTensorPtr res = (THPByteTensor *)THPByteTensor_NewEmpty();
+  if (!res) return NULL;
+  THByteTensor_getRNGState(generator, res->cdata);
+  return (PyObject *)res.release();
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -158,11 +158,10 @@ PyObject * THCPModule_getDriverVersion(PyObject *self)
 PyObject * THCPModule_getRNGState(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  THByteTensorPtr _t = THByteTensor_new();
-  THCRandom_getRNGState(state, _t.get());
-  PyObject *_ret =  THPByteTensor_New(_t.get());
-  _t.release();
-  return _ret;
+  THPByteTensorPtr res = (THPByteTensor *)THPByteTensor_NewEmpty();
+  if (!res) return NULL;
+  THCRandom_getRNGState(state, res->cdata);
+  return (PyObject *)res.release();
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/generic/Tensor.h
+++ b/torch/csrc/generic/Tensor.h
@@ -7,7 +7,19 @@ struct THPTensor {
   THTensor *cdata;
 };
 
+/**
+ * Creates a new Python Tensor object using the give THTensor. The returned
+ * PyObject* pointer can be safely casted to a THPTensor*.
+ * Note: This "steals" the THTensor* `ptr`.
+ * On error, NULL is returned and the `ptr` ref count is decremented.
+ */
 THP_API PyObject * THPTensor_(New)(THTensor *ptr);
+
+/**
+ * Creates a new empty Python Tensor object
+ */
+THP_API PyObject * THPTensor_(NewEmpty)(void);
+
 extern PyObject *THPTensorClass;
 
 #ifdef _THP_CORE

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -80,24 +80,17 @@ PyObject * THPTensor_(writeMetadata)(THPTensor *self, PyObject *args)
 PyObject * THPTensor_(newWithMetadataFile)(PyObject *_null, PyObject *args)
 {
   if (!args || PyTuple_Size(args) != 2 ||
-        !(THPStorage_(Check)(PyTuple_GET_ITEM(args, 1)) ||
-          PyTuple_GET_ITEM(args, 1) == Py_None)) {
+        !THPStorage_(Check)(PyTuple_GET_ITEM(args, 1))) {
     THPUtils_invalidArguments(args, "_new_with_metadata_file", 1, "single file object and a storage object");
     return NULL;
   }
   int fd = PyObject_AsFileDescriptor(PyTuple_GET_ITEM(args, 0));
   if (fd == -1) {
-    THPUtils_setError("write_file couln't retrieve file descriptor from given object");
+    THPUtils_setError("write_file could not retrieve file descriptor from given object");
     return NULL;
   }
-  THStorage *storage = NULL;
-  if (PyTuple_GET_ITEM(args, 1) != Py_None) {
-    storage = ((THPStorage*)PyTuple_GET_ITEM(args, 1))->cdata;
-  }
-  THTensorPtr tensor = THPTensor_(newWithMetadataFileRaw)(fd, storage);
-  PyObject *result = THPTensor_(New)(tensor);
-  tensor.release();
-  return result;
+  THStorage *storage = ((THPStorage*)PyTuple_GET_ITEM(args, 1))->cdata;
+  return THPTensor_(New)(THPTensor_(newWithMetadataFileRaw)(fd, storage));
 }
 
 
@@ -392,9 +385,9 @@ static PyObject * THPTensor_(select)(THPTensor *self, PyObject *args)
 
   int ndim = THTensor_(nDimension)(LIBRARY_STATE self->cdata);
   if(ndim > 1) {
-    THTensor *selected = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
-    THTensor_(select)(LIBRARY_STATE selected, NULL, dim, idx);
-    return THPTensor_(New)(selected);
+    THTensorPtr selected = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
+    THTensor_(select)(LIBRARY_STATE selected.get(), NULL, dim, idx);
+    return THPTensor_(New)(selected.release());
   }
   else {
     THArgCheck(ndim == 1, 1, "empty Tensor");
@@ -3767,7 +3760,6 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
   std::vector<THTensor *> item_tensors;
   PyObject *sequence;
   Py_ssize_t seq_length;
-  THTensorPtr _result;
   THPTensorPtr result;
   long dimension = -1;
 
@@ -3796,11 +3788,8 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
         THTensor_(nDimension)(LIBRARY_STATE item_tensors[0])-1);
   }
 
-  _result = THTensor_(new)(LIBRARY_STATE_NOARGS);
-  result = (THPTensor*)THPTensor_(New)(_result);
-  if (!result)
-    return NULL;
-  _result.release();
+  result = (THPTensor *)THPTensor_(NewEmpty)();
+  if (!result) return NULL;
 
   THTensor_(catArray)(LIBRARY_STATE result->cdata, item_tensors.data(),
       items.size(), dimension);

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -21,8 +21,7 @@ THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage)
   SYSCHECK(read(fd, tensor->size, sizeof(long) * tensor->nDimension));
   SYSCHECK(read(fd, tensor->stride, sizeof(long) * tensor->nDimension));
   SYSCHECK(read(fd, &tensor->storageOffset, sizeof(long)));
-  if (storage)
-    THStorage_(retain)(LIBRARY_STATE storage);
+  THStorage_(retain)(LIBRARY_STATE storage);
   tensor->storage = storage;
   return tensor.release();
 }

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -248,12 +248,9 @@ def load(f, map_location=None, pickle_module=pickle):
             for i in range(num_tensors):
                 args = pickle_module.load(f)
                 key, storage_id, original_tensor_type = args
-                storage = deserialized_objects.get(storage_id, None)
-                if storage:
-                    tensor_type = storage_to_tensor_type(storage)
-                    tensor = tensor_type._new_with_metadata_file(f, storage)
-                else:
-                    tensor = original_tensor_type._new_with_metadata_file(f, storage)
+                storage = deserialized_objects[storage_id]
+                tensor_type = storage_to_tensor_type(storage)
+                tensor = tensor_type._new_with_metadata_file(f, storage)
                 deserialized_objects[key] = tensor
 
         pickle_file = tar.extractfile('pickle')
@@ -261,4 +258,3 @@ def load(f, map_location=None, pickle_module=pickle):
         unpickler.persistent_load = persistent_load
         result = unpickler.load()
         return result
-


### PR DESCRIPTION
I changed the semantics of THPTensor_(New)(THTensor *ptr) slightly to simplify error handling in calling code. Previously, the function "stole" the reference to ptr on success but left the refcount unchanged on error. Now the refcount is decremented when NULL is returned.
