### PR TITLE
Improve potrf error message.

### DIFF
--- a/torch/lib/TH/generic/THTensorLapack.c
+++ b/torch/lib/TH/generic/THTensorLapack.c
@@ -562,9 +562,9 @@ void THTensor_(potrf)(THTensor *ra_, THTensor *a, const char *uplo)
 
   /* Run Factorization */
   THLapack_(potrf)(uplo[0], n, THTensor_(data)(ra__), lda, &info);
-  THLapackCheckWithCleanup("Lapack Error %s : A(%d,%d) is 0, A cannot be factorized",
+  THLapackCheckWithCleanup("Lapack Error in %s : the leading minor of order %d is not positive definite",
                            THCleanup(THTensor_(free)(ra__);),
-                           "potrf", info, info);
+                           "potrf", info);
 
   THTensor_(clearUpLoTriangle)(ra__, uplo);
   THTensor_(freeCopyTo)(ra__, ra_);


### PR DESCRIPTION
Hi, a few of the other LAPACK errors may be off, I'm just quickly sending in a fix for this one that confused me for a few minutes. When the `potrf` flag is nonzero, it indicates that the leading minor of order i is not positive definite, not that the element (i,i) is 0.