### PR TITLE
Fix multiprocess serialization with "spawn" or "forksever"

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -17,6 +17,8 @@ python test_legacy_nn.py
 
 echo "Running multiprocessing tests"
 python test_multiprocessing.py
+MULTIPROCESSING_METHOD=spawn python test_multiprocessing.py
+MULTIPROCESSING_METHOD=forkserver python test_multiprocessing.py
 
 echo "Running util tests"
 python test_utils.py

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -1,8 +1,10 @@
-import os
+import contextlib
 import gc
+import multiprocessing
+import os
+import sys
 import time
 import unittest
-import contextlib
 from sys import platform
 
 import torch
@@ -178,5 +180,12 @@ class TestMultiprocessing(TestCase):
 
 
 if __name__ == '__main__':
+    start_method = os.environ.get('MULTIPROCESSING_METHOD')
+    if start_method:
+        if sys.version_info[0] < 3:
+            print("Python 2 does not support 'multiprocessing.set_start_method'")
+            sys.exit(0)
+        else:
+            print("INFO: Using multiprocessing start method '{}'".format(start_method))
+            multiprocessing.set_start_method(start_method)
     unittest.main()
-

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -37,6 +37,14 @@ class FdQueue(Queue):
         self._fd_reader.close()
         self._fd_writer.close()
 
+    def __getstate__(self):
+        state = super(FdQueue, self).__getstate__()
+        return (state, self._fd_reader, self._fd_writer)
+
+    def __setstate__(self, state):
+        super(FdQueue, self).__setstate__(state[0])
+        self._fd_reader, self._fd_writer = state[1:]
+
     def _send(self, obj):
         buffer = BytesIO()
         pickler = ExtendedInitPickler(buffer, self._reducers)
@@ -62,4 +70,3 @@ class FdQueue(Queue):
         for new_fd in fd_map.values():
             os.close(new_fd)
         return result
-


### PR DESCRIPTION
You can test this by adding the following at the top of
test_multiprocessing.py:

```python
  if __name__ == '__main__':
     import multiprocessing
     multiprocessing.set_start_method('spawn')
```