### PR TITLE
Adding truncated tensor printing

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -81,6 +81,7 @@ def initial_seed():
 
 
 from .serialization import save, load
+from ._tensor_str import set_printoptions
 
 ################################################################################
 # Define Storage and Tensor classes

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -3,11 +3,70 @@ import torch
 from functools import reduce
 from ._utils import _range
 
+
+class __PrinterOptions(object):
+    precision = 4
+    threshold = 1000
+    edgeitems = 3
+    linewidth = 80
+
+
+PRINT_OPTS = __PrinterOptions()
 SCALE_FORMAT = '{:.5e} *\n'
 
 
-def _number_format(tensor):
-    min_sz = 2
+# We could use **kwargs, but this will give better docs
+def set_printoptions(
+        precision=None,
+        threshold=None,
+        edgeitems=None,
+        linewidth=None,
+        profile=None,
+        ):
+    """Set options for printing. Items shamelessly taken from Numpy
+
+    Args:
+        precision: Number of digits of precision for floating point output
+            (default 8).
+        threshold: Total number of array elements which trigger summarization
+            rather than full repr (default 1000).
+        edgeitems: Number of array items in summary at beginning and end of
+            each dimension (default 3).
+        linewidth: The number of characters per line for the purpose of
+            inserting line breaks (default 80). Thresholded matricies will
+            ignore this parameter.
+        profile: Sane defaults for pretty printing. Can override with any of
+            the above options. (default, short, full)
+    """
+    if profile is not None:
+        if profile == "default":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+        elif profile == "short":
+            PRINT_OPTS.precision = 2
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 2
+            PRINT_OPTS.linewidth = 80
+        elif profile == "full":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = float('inf')
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+
+    if precision is not None:
+        PRINT_OPTS.precision = precision
+    if threshold is not None:
+        PRINT_OPTS.threshold = threshold
+    if edgeitems is not None:
+        PRINT_OPTS.edgeitems = edgeitems
+    if linewidth is not None:
+        PRINT_OPTS.linewidth = linewidth
+
+
+def _number_format(tensor, min_sz=-1):
+    min_sz = max(min_sz, 2)
     tensor = torch.DoubleTensor(tensor.nelement()).copy_(tensor).abs_()
 
     pos_inf_mask = tensor.eq(float('inf'))
@@ -20,7 +79,7 @@ def _number_format(tensor):
     example_value = tensor[invalid_value_mask.eq(0)][0]
     tensor[invalid_value_mask] = example_value
     if invalid_value_mask.any():
-        min_sz = 3
+        min_sz = max(min_sz, 3)
 
     int_mode = True
     # TODO: use fmod?
@@ -42,22 +101,23 @@ def _number_format(tensor):
 
     scale = 1
     exp_max = int(exp_max)
+    prec = PRINT_OPTS.precision
     if int_mode:
-        if exp_max > 9:
-            format = '{:11.4e}'
-            sz = max(min_sz, 11)
+        if exp_max > prec + 1:
+            format = '{{:11.{}e}}'.format(prec)
+            sz = max(min_sz, 7 + prec)
         else:
             sz = max(min_sz, exp_max + 1)
             format = '{:' + str(sz) + '.0f}'
     else:
-        if exp_max - exp_min > 4:
-            sz = 11
+        if exp_max - exp_min > prec:
+            sz = 7 + prec
             if abs(exp_max) > 99 or abs(exp_min) > 99:
                 sz = sz + 1
             sz = max(min_sz, sz)
-            format = '{:' + str(sz) + '.4e}'
+            format = '{{:{}.{}e}}'.format(sz, prec)
         else:
-            if exp_max > 5 or exp_max < 0:
+            if exp_max > prec + 1 or exp_max < 0:
                 sz = max(min_sz, 7)
                 scale = math.pow(10, exp_max-1)
             else:
@@ -66,63 +126,160 @@ def _number_format(tensor):
                 else:
                     sz = exp_max + 6
                 sz = max(min_sz, sz)
-            format = '{:' + str(sz) + '.4f}'
+            format = '{{:{}.{}f}}'.format(sz, prec)
     return format, scale, sz
 
 
 def _tensor_str(self):
+    n = PRINT_OPTS.edgeitems
+    has_hdots = self.size()[-1] > 2*n
+    has_vdots = self.size()[-2] > 2*n
+    print_full_mat = not has_hdots and not has_vdots
+    formatter = _number_format(self, min_sz=5 if not print_full_mat else 0)
+    print_dots = self.numel() >= PRINT_OPTS.threshold
+
+    dim_sz = max(2, max(len(str(x)) for x in self.size()))
+    dim_fmt = "{:^" + str(dim_sz) + "}"
+    dot_fmt = "{:^" + str(dim_sz+1) + "}"
+
     counter_dim = self.ndimension() - 2
     counter = torch.LongStorage(counter_dim).fill_(0)
     counter[0] = -1
     finished = False
     strt = ''
     while True:
+        nrestarted = [False for i in counter]
+        nskipped = [False for i in counter]
         for i in _range(counter_dim):
             counter[i] += 1
+            if print_dots and counter[i] == n and self.size(i) > 2*n:
+                counter[i] = self.size(i) - n
+                nskipped[i] = True
             if counter[i] == self.size(i):
                 if i == counter_dim-1:
                     finished = True
                 counter[i] = 0
+                nrestarted[i] = True
             else:
                 break
         if finished:
             break
+        elif print_dots:
+            if any(nskipped):
+                for hdot in nskipped:
+                    strt += dot_fmt.format('...') if hdot \
+                        else dot_fmt.format('')
+                strt += '\n'
+            if any(nrestarted):
+                line = ' '
+                for vdot in nrestarted:
+                    line += dot_fmt.format('.') if vdot else dot_fmt.format('')
+                line += '\n'
+                strt += line*3
         if strt != '':
-           strt += '\n'
-        strt += '({},.,.) = \n'.format(','.join(str(i) for i in counter))
-        submatrix = reduce(lambda t,i: t.select(0, i), counter, self)
-        strt += _matrix_str(submatrix, ' ')
+            strt += '\n'
+        strt += '({},.,.) = \n'.format(
+            ','.join(dim_fmt.format(i) for i in counter))
+        submatrix = reduce(lambda t, i: t.select(0, i), counter, self)
+        strt += _matrix_str(submatrix, ' ', formatter, print_dots)
     return strt
 
 
-def _matrix_str(self, indent=''):
-    fmt, scale, sz = _number_format(self)
-    nColumnPerLine = int(math.floor((80-len(indent))/(sz+1)))
+def __repr_row(row, indent, fmt, scale, sz, truncate=None):
+    if truncate is not None:
+        dotfmt = " {:^" + str(sz) + "} "
+        return (indent +
+                ' '.join(fmt.format(val/scale) for val in row[:truncate]) +
+                dotfmt.format('. . .') +
+                ' '.join(fmt.format(val/scale) for val in row[-truncate:]) +
+                '\n')
+    else:
+        return indent + ' '.join(fmt.format(val/scale) for val in row) + '\n'
+
+
+def _matrix_str(self, indent='', formatter=None, force_truncate=False):
+    n = PRINT_OPTS.edgeitems
+    has_hdots = self.size(1) > 2*n
+    has_vdots = self.size(0) > 2*n
+    print_full_mat = not has_hdots and not has_vdots
+
+    if formatter is None:
+        fmt, scale, sz = _number_format(self,
+                                        min_sz=5 if not print_full_mat else 0)
+    else:
+        fmt, scale, sz = formatter
+    nColumnPerLine = int(math.floor((PRINT_OPTS.linewidth-len(indent))/(sz+1)))
     strt = ''
     firstColumn = 0
-    while firstColumn < self.size(1):
-        lastColumn = min(firstColumn + nColumnPerLine - 1, self.size(1)-1)
-        if nColumnPerLine < self.size(1):
-            strt += '\n' if firstColumn != 1 else ''
-            strt += 'Columns {} to {} \n{}'.format(firstColumn, lastColumn, indent)
+
+    if not force_truncate and \
+       (self.numel() < PRINT_OPTS.threshold or print_full_mat):
+        while firstColumn < self.size(1):
+            lastColumn = min(firstColumn + nColumnPerLine - 1, self.size(1)-1)
+            if nColumnPerLine < self.size(1):
+                strt += '\n' if firstColumn != 1 else ''
+                strt += 'Columns {} to {} \n{}'.format(
+                    firstColumn, lastColumn, indent)
+            if scale != 1:
+                strt += SCALE_FORMAT.format(scale)
+            for l in _range(self.size(0)):
+                strt += indent + (' ' if scale != 1 else '')
+                row_slice = self[l, firstColumn:lastColumn+1]
+                strt += ' '.join(fmt.format(val/scale) for val in row_slice)
+                strt += '\n'
+            firstColumn = lastColumn + 1
+    else:
         if scale != 1:
             strt += SCALE_FORMAT.format(scale)
-        for l in _range(self.size(0)):
-            strt += indent + (' ' if scale != 1 else '')
-            row_slice = self[l, firstColumn:lastColumn+1]
-            strt += ' '.join(fmt.format(val/scale) for val in row_slice) + '\n'
-        firstColumn = lastColumn + 1
+        if has_vdots and has_hdots:
+            vdotfmt = "{:^" + str((sz+1)*n-1) + "}"
+            ddotfmt = "{:^" + str(sz) + "}"
+            ddots = ['.    ', '  .  ', '    .']
+            for row in self[:n]:
+                strt += __repr_row(row, indent, fmt, scale, sz, n)
+            for ddot in ddots:
+                strt += indent + ' '.join([vdotfmt.format('.'),
+                                           ddotfmt.format(ddot),
+                                           vdotfmt.format('.')]) + "\n"
+            for row in self[-n:]:
+                strt += __repr_row(row, indent, fmt, scale, sz, n)
+        elif not has_vdots and has_hdots:
+            for row in self:
+                strt += __repr_row(row, indent, fmt, scale, sz, n)
+        elif has_vdots and not has_hdots:
+            vdotfmt = "{:^" + \
+                    str(len(__repr_row(self[0], '', fmt, scale, sz))) + \
+                    "}\n"
+            for row in self[:n]:
+                strt += __repr_row(row, indent, fmt, scale, sz)
+            strt += 3 * vdotfmt.format('.')
+            for row in self[-n:]:
+                strt += __repr_row(row, indent, fmt, scale, sz)
+        else:
+            for row in self:
+                strt += __repr_row(row, indent, fmt, scale, sz)
     return strt
 
 
 def _vector_str(self):
-    fmt, scale, _ = _number_format(self)
+    fmt, scale, sz = _number_format(self)
     strt = ''
     ident = ''
+    n = PRINT_OPTS.edgeitems
+    dotfmt = "{:^" + str(sz) + "}\n"
     if scale != 1:
         strt += SCALE_FORMAT.format(scale)
         ident = ' '
-    return strt + '\n'.join(ident + fmt.format(val/scale) for val in self) + '\n'
+    if self.numel() < PRINT_OPTS.threshold:
+        return (strt +
+                '\n'.join(ident + fmt.format(val/scale) for val in self) +
+                '\n')
+    else:
+        return (strt +
+                '\n'.join(ident + fmt.format(val/scale) for val in self[:n]) +
+                '\n' + (ident + dotfmt.format(".")) * 3 +
+                '\n'.join(ident + fmt.format(val/scale) for val in self[-n:]) +
+                '\n')
 
 
 def _str(self):
@@ -136,8 +293,9 @@ def _str(self):
         strt = _tensor_str(self)
 
     size_str = 'x'.join(str(size) for size in self.size())
-    device_str = '' if not self.is_cuda else ' (GPU {})'.format(self.get_device())
+    device_str = '' if not self.is_cuda else \
+        ' (GPU {})'.format(self.get_device())
     strt += '[{} of size {}{}]\n'.format(torch.typename(self),
-            size_str, device_str)
+                                         size_str, device_str)
     return '\n' + strt
 

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -140,7 +140,7 @@ def _tensor_str(self):
 
     dim_sz = max(2, max(len(str(x)) for x in self.size()))
     dim_fmt = "{:^" + str(dim_sz) + "}"
-    dot_fmt = "{:^" + str(dim_sz+1) + "}"
+    dot_fmt = u"{:^" + str(dim_sz+1) + "}"
 
     counter_dim = self.ndimension() - 2
     counter = torch.LongStorage(counter_dim).fill_(0)
@@ -173,7 +173,7 @@ def _tensor_str(self):
             if any(nrestarted):
                 strt += ' '
                 for vdot in nrestarted:
-                    strt += dot_fmt.format(':') if vdot else dot_fmt.format('')
+                    strt += dot_fmt.format(u'\u22EE' if vdot else '')
                 strt += '\n'
         if strt != '':
             strt += '\n'
@@ -186,7 +186,7 @@ def _tensor_str(self):
 
 def __repr_row(row, indent, fmt, scale, sz, truncate=None):
     if truncate is not None:
-        dotfmt = " {:^" + str(sz) + "} "
+        dotfmt = " {:^5} "
         return (indent +
                 ' '.join(fmt.format(val/scale) for val in row[:truncate]) +
                 dotfmt.format('...') +
@@ -232,7 +232,7 @@ def _matrix_str(self, indent='', formatter=None, force_truncate=False):
             strt += SCALE_FORMAT.format(scale)
         if has_vdots and has_hdots:
             vdotfmt = "{:^" + str((sz+1)*n-1) + "}"
-            ddotfmt = "{:^" + str(sz) + "}"
+            ddotfmt = u"{:^5}"
             for row in self[:n]:
                 strt += __repr_row(row, indent, fmt, scale, sz, n)
             strt += indent + ' '.join([vdotfmt.format('...'),
@@ -244,12 +244,12 @@ def _matrix_str(self, indent='', formatter=None, force_truncate=False):
             for row in self:
                 strt += __repr_row(row, indent, fmt, scale, sz, n)
         elif has_vdots and not has_hdots:
-            vdotfmt = "{:^" + \
+            vdotfmt = u"{:^" + \
                     str(len(__repr_row(self[0], '', fmt, scale, sz))) + \
                     "}\n"
             for row in self[:n]:
                 strt += __repr_row(row, indent, fmt, scale, sz)
-            strt += vdotfmt.format('...')
+            strt += vdotfmt.format(u'\u22EE')
             for row in self[-n:]:
                 strt += __repr_row(row, indent, fmt, scale, sz)
         else:
@@ -263,7 +263,7 @@ def _vector_str(self):
     strt = ''
     ident = ''
     n = PRINT_OPTS.edgeitems
-    dotfmt = "{:^" + str(sz) + "}\n"
+    dotfmt = u"{:^" + str(sz) + "}\n"
     if scale != 1:
         strt += SCALE_FORMAT.format(scale)
         ident = ' '
@@ -274,7 +274,7 @@ def _vector_str(self):
     else:
         return (strt +
                 '\n'.join(ident + fmt.format(val/scale) for val in self[:n]) +
-                '\n' + (ident + dotfmt.format("...")) +
+                '\n' + (ident + dotfmt.format(u"\u22EE")) +
                 '\n'.join(ident + fmt.format(val/scale) for val in self[-n:]) +
                 '\n')
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -3,6 +3,7 @@ from . import _tensor_str
 from ._utils import _type, _cuda, _range
 from functools import reduce
 from itertools import chain
+import sys
 import math
 
 
@@ -90,10 +91,17 @@ class _TensorBase(object):
         return type(self), (self.tolist(),)
 
     def __repr__(self):
-        return str(self)
+        return repr(str(self))
 
     def __str__(self):
-        return _tensor_str._str(self)
+        # All strings are unicode in Python 3, while we have to encode unicode
+        # strings in Python2. If we can't, let python decide the best
+        # characters to replace unicode characters with.
+        if sys.version_info > (3,):
+            return _tensor_str._str(self)
+        else:
+            return _tensor_str._str(self).encode(
+                sys.stdout.encoding or 'UTF-8', 'replace')
 
     def __iter__(self):
         return iter(map(lambda i: self.select(0, i), _range(self.size(0))))


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/122. It prints the first and last (by default 3) items from each dimension.

Here is a preview of they look like: http://pastebin.com/xWt8ABxE

You can print out shorter tensors with `torch.set_printoptions(profile="short")`, and longer ones with `torch.set_printoptions(profile="full")`. You can also do `torch.set_printoptions(precision= , threshold= , edgeitems= , linewidth= , profile="default")`, to modify the parameters for a certain profile before setting it, or leave the profile out to modify current parameters.