### PR TITLE
adding __repr__ for most modules in nn

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -36,8 +36,8 @@ class Threshold(Module):
     def __repr__(self):
         inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'threshold=' + str(self.threshold) \
-            + ', value=' + str(self.value) \
+            + str(self.threshold) \
+            + ', ' + str(self.value) \
             + inplace_str + ')'
 
 
@@ -79,8 +79,8 @@ class RReLU(Module):
     def __repr__(self):
         inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'lower=' + str(self.lower) \
-            + ', upper=' + str(self.upper) \
+            + str(self.lower) \
+            + ', ' + str(self.upper) \
             + inplace_str + ')'
 
 
@@ -244,7 +244,7 @@ class Hardshrink(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'lambda=' + str(self.lambd) + ')'
+            + str(self.lambd) + ')'
 
 
 class LeakyReLU(Module):
@@ -273,7 +273,7 @@ class LeakyReLU(Module):
     def __repr__(self):
         inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'negative slope=' + str(self.negative_slope) \
+            + str(self.negative_slope) \
             + inplace_str + ')'
 
 class LogSigmoid(Module):
@@ -355,7 +355,7 @@ class Softshrink(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'lambda=' + str(self.lambd) + ')'
+            + str(self.lambd) + ')'
 
 
 class PReLU(Module):
@@ -391,7 +391,7 @@ class PReLU(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'num_parameters=' + str(self.num_parameters) + ')'
+            + str(self.num_parameters) + ')'
 
 
 class Softsign(Module):

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -34,10 +34,10 @@ class Threshold(Module):
         return self._backend.Threshold(self.threshold, self.value, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'threshold = ' + str(self.threshold) \
-            + ', value = ' + str(self.value) \
+            + 'threshold=' + str(self.threshold) \
+            + ', value=' + str(self.value) \
             + inplace_str + ')'
 
 
@@ -60,7 +60,7 @@ class ReLU(Threshold):
         super(ReLU, self).__init__(0, 0, inplace)
 
     def __repr__(self):
-        inplace_str = 'inplace' if self.inplace else ''
+        inplace_str='inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
             + inplace_str + ')'
 
@@ -77,10 +77,10 @@ class RReLU(Module):
                 self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'lower = ' + str(self.lower) \
-            + ', upper = ' + str(self.upper) \
+            + 'lower=' + str(self.lower) \
+            + ', upper=' + str(self.upper) \
             + inplace_str + ')'
 
 
@@ -117,10 +117,10 @@ class Hardtanh(Module):
         return self._backend.Hardtanh(self.min_val, self.max_val, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'min_val = ' + str(self.min_val) \
-            + ', max_val = ' + str(self.max_val) \
+            + 'min_val=' + str(self.min_val) \
+            + ', max_val=' + str(self.max_val) \
             + inplace_str + ')'
 
 class ReLU6(Hardtanh):
@@ -142,7 +142,7 @@ class ReLU6(Hardtanh):
         super(ReLU6, self).__init__(0, 6, inplace)
 
     def __repr__(self):
-        inplace_str = 'inplace' if self.inplace else ''
+        inplace_str='inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
             + inplace_str + ')'
 
@@ -211,9 +211,9 @@ class ELU(Module):
         return self._backend.ELU(self.alpha, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'alpha = ' + str(self.alpha) \
+            + 'alpha=' + str(self.alpha) \
             + inplace_str + ')'
 
 
@@ -244,7 +244,7 @@ class Hardshrink(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'lambda = ' + str(self.lambd) + ')'
+            + 'lambda=' + str(self.lambd) + ')'
 
 
 class LeakyReLU(Module):
@@ -271,9 +271,9 @@ class LeakyReLU(Module):
         return self._backend.LeakyReLU(self.negative_slope, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'negative slope = ' + str(self.negative_slope) \
+            + 'negative slope=' + str(self.negative_slope) \
             + inplace_str + ')'
 
 class LogSigmoid(Module):
@@ -325,8 +325,8 @@ class Softplus(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'beta = ' + str(self.beta) \
-            + ', threshold = ' + str(self.threshold) + ')'
+            + 'beta=' + str(self.beta) \
+            + ', threshold=' + str(self.threshold) + ')'
 
 class Softshrink(Module):
     """Applies the soft shrinkage function elementwise
@@ -355,7 +355,7 @@ class Softshrink(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'lambda = ' + str(self.lambd) + ')'
+            + 'lambda=' + str(self.lambd) + ')'
 
 
 class PReLU(Module):
@@ -391,7 +391,7 @@ class PReLU(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'num_parameters = ' + str(self.num_parameters) + ')'
+            + 'num_parameters=' + str(self.num_parameters) + ')'
 
 
 class Softsign(Module):

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -33,6 +33,13 @@ class Threshold(Module):
     def forward(self, input):
         return self._backend.Threshold(self.threshold, self.value, self.inplace)(input)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'threshold = ' + str(self.threshold) \
+            + ', value = ' + str(self.value) \
+            + inplace_str + ')'
+
 
 class ReLU(Threshold):
     """Applies the rectified linear unit function element-wise ReLU(x)= max(0,x)
@@ -52,6 +59,11 @@ class ReLU(Threshold):
     def __init__(self, inplace=False):
         super(ReLU, self).__init__(0, 0, inplace)
 
+    def __repr__(self):
+        inplace_str = 'inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + inplace_str + ')'
+
 
 class RReLU(Module):
     def __init__(self, lower=1./8, upper=1./3, inplace=False):
@@ -63,6 +75,13 @@ class RReLU(Module):
     def forward(self, input):
         return self._backend.RReLU(self.lower, self.upper, self.training,
                 self.inplace)(input)
+
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'lower = ' + str(self.lower) \
+            + ', upper = ' + str(self.upper) \
+            + inplace_str + ')'
 
 
 class Hardtanh(Module):
@@ -97,6 +116,12 @@ class Hardtanh(Module):
     def forward(self, input):
         return self._backend.Hardtanh(self.min_val, self.max_val, self.inplace)(input)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'min_val = ' + str(self.min_val) \
+            + ', max_val = ' + str(self.max_val) \
+            + inplace_str + ')'
 
 class ReLU6(Hardtanh):
     """Applies the element-wise function ReLU6(x) = min( max(0,x), 6)
@@ -116,6 +141,10 @@ class ReLU6(Hardtanh):
     def __init__(self, inplace=False):
         super(ReLU6, self).__init__(0, 6, inplace)
 
+    def __repr__(self):
+        inplace_str = 'inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + inplace_str + ')'
 
 class Sigmoid(Module):
     """Applies the element-wise function sigmoid(x) = 1 / ( 1 + exp(-x))
@@ -132,6 +161,10 @@ class Sigmoid(Module):
     """
     def forward(self, input):
         return self._backend.Sigmoid()(input)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
+
 
 
 class Tanh(Module):
@@ -150,6 +183,8 @@ class Tanh(Module):
     def forward(self, input):
         return self._backend.Tanh()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class ELU(Module):
     """Applies element-wise, ELU(x) = max(0,x) + min(0, alpha * (exp(x) - 1))
@@ -174,6 +209,12 @@ class ELU(Module):
 
     def forward(self, input):
         return self._backend.ELU(self.alpha, self.inplace)(input)
+
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'alpha = ' + str(self.alpha) \
+            + inplace_str + ')'
 
 
 class Hardshrink(Module):
@@ -201,6 +242,10 @@ class Hardshrink(Module):
     def forward(self, input):
         return self._backend.Hardshrink(self.lambd)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'lambda = ' + str(self.lambd) + ')'
+
 
 class LeakyReLU(Module):
     """Applies element-wise, f(x) = max(0, x) + negative_slope * min(0, x)
@@ -225,6 +270,11 @@ class LeakyReLU(Module):
     def forward(self, input):
         return self._backend.LeakyReLU(self.negative_slope, self.inplace)(input)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'negative slope = ' + str(self.negative_slope) \
+            + inplace_str + ')'
 
 class LogSigmoid(Module):
     """Applies element-wise LogSigmoid(x) = log( 1 / (1 + exp(-x_i)))
@@ -242,6 +292,8 @@ class LogSigmoid(Module):
     def forward(self, input):
         return self._backend.LogSigmoid()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class Softplus(Module):
     """Applies element-wise SoftPlus(x) = 1/beta * log(1 + exp(beta * x_i))
@@ -271,6 +323,10 @@ class Softplus(Module):
     def forward(self, input):
         return self._backend.Softplus(self.beta, self.threshold)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'beta = ' + str(self.beta) \
+            + ', threshold = ' + str(self.threshold) + ')'
 
 class Softshrink(Module):
     """Applies the soft shrinkage function elementwise
@@ -296,6 +352,10 @@ class Softshrink(Module):
 
     def forward(self, input):
         return self._backend.Softshrink(self.lambd)(input)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'lambda = ' + str(self.lambd) + ')'
 
 
 class PReLU(Module):
@@ -329,6 +389,10 @@ class PReLU(Module):
     def forward(self, input):
         return self._backend.PReLU()(input, self.weight)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'num_parameters = ' + str(self.num_parameters) + ')'
+
 
 class Softsign(Module):
     """Applies element-wise, the function Softsign(x) = x / (1 + |x|)
@@ -345,6 +409,9 @@ class Softsign(Module):
     """
     def forward(self, input):
         return self._backend.Softsign()(input)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 
 class Tanhshrink(Module):
@@ -363,6 +430,8 @@ class Tanhshrink(Module):
         tanh = self._backend.Tanh()(input)
         return input - tanh
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class Softmin(Module):
     """Applies the Softmin function to an n-dimensional input Tensor
@@ -385,6 +454,8 @@ class Softmin(Module):
     def forward(self, input):
         return self._backend.Softmin()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class Softmax(Module):
     """Applies the Softmax function to an n-dimensional input Tensor
@@ -414,6 +485,8 @@ class Softmax(Module):
         assert input.dim() == 2, 'Softmax requires a 2D tensor as input'
         return self._backend.Softmax()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class Softmax2d(Module):
     """Applies SoftMax over features to each spatial location
@@ -436,6 +509,9 @@ class Softmax2d(Module):
         assert input.dim() == 4, 'Softmax2d requires a 4D tensor as input'
         return self._backend.Softmax()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
+
 class LogSoftmax(Module):
     """Applies the Log(Softmax(x)) function to an n-dimensional input Tensor.
     The LogSoftmax formulation can be simplified as
@@ -455,6 +531,8 @@ class LogSoftmax(Module):
     def forward(self, input):
         return self._backend.LogSoftmax()(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 
 # TODO: RReLU

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -44,9 +44,9 @@ class _BatchNorm(Module):
 
     def __repr__(self):
         return  self.__class__.__name__ + ' (' + str(self.weight.data.size(0)) \
-            + ', eps = ' + str(self.eps) \
-            + ', momentum = ' + str(self.momentum) \
-            + ', affine = ' + str(self.affine) + ')'
+            + ', eps=' + str(self.eps) \
+            + ', momentum=' + str(self.momentum) \
+            + ', affine=' + str(self.affine) + ')'
 
 
 class BatchNorm1d(_BatchNorm):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -42,6 +42,12 @@ class _BatchNorm(Module):
         return self._backend.BatchNorm(self.running_mean,
                 self.running_var, self.training, self.momentum, self.eps)(*args)
 
+    def __repr__(self):
+        return  self.__class__.__name__ + ' (' + str(self.weight.data.size(0)) \
+            + ', eps = ' + str(self.eps) \
+            + ', momentum = ' + str(self.momentum) \
+            + ', affine = ' + str(self.affine) + ')'
+
 
 class BatchNorm1d(_BatchNorm):
     """Applies Batch Normalization over a 2d input that is seen as a mini-batch of 1d inputs

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -1,8 +1,18 @@
 from collections import OrderedDict
-
+import string
 import torch
 from .module import Module
 
+def _addindent(s_, numSpaces):
+    s = string.split(s_, '\n')
+    # dont do anything for single-line stuff
+    if len(s) == 1:
+        return s_
+    first = s.pop(0)
+    s = [(numSpaces * ' ') + line for line in s]
+    s = string.join(s, '\n')
+    s = first + '\n' + s
+    return s
 
 class Container(Module):
     """This is the base container class for all neural networks you would define.
@@ -142,8 +152,40 @@ class Container(Module):
             module._apply(fn)
         return super(Container, self)._apply(fn)
 
+    def __repr__(self):
+        tmpstr = self.__class__.__name__ + ' (\n'
+        for key, module in self._modules.items():
+            modstr = module.__repr__()
+            modstr = _addindent(modstr, 2)
+            tmpstr = tmpstr + '  ('  + key + '): ' + modstr + '\n'
+        tmpstr = tmpstr + ')'
+        return tmpstr
+
 
 class Sequential(Container):
+    """A sequential Container. It is derived from the base nn.Container class
+    Modules will be added to it in the order they are passed in the constructor.
+    Alternatively, an ordered dict of modules can also be passed in.
+
+    To make it easier to understand, given is a small example.
+    ```
+    # Example of using Sequential
+    model = nn.Sequential(
+              nn.Conv2d(1,20,5),
+              nn.ReLU(),
+              nn.Conv2d(20,64,5),
+              nn.ReLU()
+            )
+
+    # Example of using Sequential with OrderedDict
+    model = nn.Sequential(OrderedDict([
+              ('conv1', nn.Conv2d(1,20,5)),
+              ('relu1', nn.ReLU()),
+              ('conv2', nn.Conv2d(20,64,5)),
+              ('relu2', nn.ReLU())
+            ]))
+     ```
+    """
 
     def __init__(self, *args):
         super(Sequential, self).__init__()
@@ -168,3 +210,12 @@ class Sequential(Container):
         for module in self._modules.values():
             input = module(input)
         return input
+
+    def __repr__(self):
+        tmpstr = self.__class__.__name__ + ' (\n'
+        for key, module in self._modules.items():
+            modstr = module.__repr__()
+            modstr = _addindent(modstr, 2)
+            tmpstr = tmpstr + '  ('  + key + '): ' + modstr + '\n'
+        tmpstr = tmpstr + ')'
+        return tmpstr

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -152,6 +152,12 @@ class Container(Module):
             module._apply(fn)
         return super(Container, self)._apply(fn)
 
+    def apply(self, fn):
+        for module in self.children():
+            module.apply(fn)
+        fn(self)
+        return self
+
     def __repr__(self):
         tmpstr = self.__class__.__name__ + ' (\n'
         for key, module in self._modules.items():

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -67,6 +67,12 @@ class Conv1d(Module):
                                   self.weight.size(2))
         return func(input, weight, self.bias)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + str(self.in_features) + ' -> ' + str(self.out_features) \
+            + ', size = ' + str(self.kernel_size) \
+            + ', stride = ' + str(self.stride) + ')'
 
 class Conv2d(Module):
     """Applies a 2D convolution over an input image composed of several input
@@ -150,6 +156,19 @@ class Conv2d(Module):
             return func(input, self.weight)
         else:
             return func(input, self.weight, self.bias)
+    
+    def __repr__(self):
+        padding_str = ', padding = (' + str(self.padh) + ', ' + str(self.padw) + ')' \
+                      if self.padh != 0 and self.padw !=0 else ''
+        dilation_str = (', dilation = (' + str(self.dilh) + ', ' \
+                        + str(self.dilw) + ')' if self.is_dilated else '')
+        groups_str = (', groups = ' + str(self.groups) if self.groups != 1 else '')
+        bias_str = (', bias = False' if self.bias == None else '')
+        return  self.__class__.__name__ + ' (' + str(self.in_channels) \
+            + ' -> ' + str(self.out_channels) \
+            + ', size = (' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride = (' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + padding_str + dilation_str + groups_str + bias_str + ')'
 
 
 class ConvTranspose2d(Conv2d):
@@ -189,7 +208,7 @@ class ConvTranspose2d(Conv2d):
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
                  padding=0, output_padding=0, bias=True):
         super(ConvTranspose2d, self).__init__(in_channels, out_channels, kernel_size,
-                                         stride, padding, bias)
+                                              stride=stride, padding=padding, bias=bias)
         # Conv2d uses a different weight layout than Conv2d
         self.weight.data = self.weight.data.transpose(0, 1).contiguous()
         self.out_padh, self.out_padw = _pair(output_padding)
@@ -248,6 +267,16 @@ class _Conv3dBase(Module):
         self.weight.data.uniform_(-stdv, stdv)
         if self.bias is not None:
             self.bias.data.uniform_(-stdv, stdv)
+
+    def __repr__(self):
+        padding_str = ', padding = (' + str(self.padt) \
+                      + ', ' + str(self.padh) + ', ' + str(self.padw) + ')' \
+                      if self.padt != 0 and self.padh != 0 and self.padw !=0 else ''
+        return  self.__class__.__name__ + ' (' + str(self.in_channels) \
+            + ' -> ' + str(self.out_channels) \
+            + ', size = (' + str(self.kt) + ', ' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride = (' + str(self.dt) + ', ' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + padding_str + ')'
 
 
 class Conv3d(_Conv3dBase):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -68,11 +68,11 @@ class Conv1d(Module):
         return func(input, weight, self.bias)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
             + str(self.in_features) + ' -> ' + str(self.out_features) \
-            + ', size = ' + str(self.kernel_size) \
-            + ', stride = ' + str(self.stride) + ')'
+            + ', size=' + str(self.kernel_size) \
+            + ', stride=' + str(self.stride) + ')'
 
 class Conv2d(Module):
     """Applies a 2D convolution over an input image composed of several input
@@ -158,16 +158,16 @@ class Conv2d(Module):
             return func(input, self.weight, self.bias)
     
     def __repr__(self):
-        padding_str = ', padding = (' + str(self.padh) + ', ' + str(self.padw) + ')' \
+        padding_str=', padding=(' + str(self.padh) + ', ' + str(self.padw) + ')' \
                       if self.padh != 0 and self.padw !=0 else ''
-        dilation_str = (', dilation = (' + str(self.dilh) + ', ' \
+        dilation_str=(', dilation=(' + str(self.dilh) + ', ' \
                         + str(self.dilw) + ')' if self.is_dilated else '')
-        groups_str = (', groups = ' + str(self.groups) if self.groups != 1 else '')
-        bias_str = (', bias = False' if self.bias == None else '')
+        groups_str=(', groups=' + str(self.groups) if self.groups != 1 else '')
+        bias_str=(', bias=False' if self.bias == None else '')
         return  self.__class__.__name__ + ' (' + str(self.in_channels) \
             + ' -> ' + str(self.out_channels) \
-            + ', size = (' + str(self.kh) + ', ' + str(self.kw) + ')' \
-            + ', stride = (' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + ', size=(' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride=(' + str(self.dh) + ', ' + str(self.dw) + ')' \
             + padding_str + dilation_str + groups_str + bias_str + ')'
 
 
@@ -269,13 +269,13 @@ class _Conv3dBase(Module):
             self.bias.data.uniform_(-stdv, stdv)
 
     def __repr__(self):
-        padding_str = ', padding = (' + str(self.padt) \
+        padding_str=', padding=(' + str(self.padt) \
                       + ', ' + str(self.padh) + ', ' + str(self.padw) + ')' \
                       if self.padt != 0 and self.padh != 0 and self.padw !=0 else ''
         return  self.__class__.__name__ + ' (' + str(self.in_channels) \
             + ' -> ' + str(self.out_channels) \
-            + ', size = (' + str(self.kt) + ', ' + str(self.kh) + ', ' + str(self.kw) + ')' \
-            + ', stride = (' + str(self.dt) + ', ' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + ', size=(' + str(self.kt) + ', ' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride=(' + str(self.dt) + ', ' + str(self.dh) + ', ' + str(self.dw) + ')' \
             + padding_str + ')'
 
 

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -63,9 +63,9 @@ class Dropout2d(Module):
         return self._backend.Dropout2d(self.p, self.training, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'p = ' + str(self.p) \
+            + 'p=' + str(self.p) \
             + inplace_str + ')'
 
 class Dropout3d(Module):
@@ -94,8 +94,8 @@ class Dropout3d(Module):
         return self._backend.Dropout3d(self.p, self.training, self.inplace)(input)
 
     def __repr__(self):
-        inplace_str = ', inplace' if self.inplace else ''
+        inplace_str=', inplace' if self.inplace else ''
         return self.__class__.__name__ + ' (' \
-            + 'p = ' + str(self.p) \
+            + 'p=' + str(self.p) \
             + inplace_str + ')'
 

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -22,6 +22,12 @@ class Dropout(Module):
     def forward(self, input):
         return self._backend.Dropout(self.p, self.training, self.inplace)(input)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'p = ' + str(self.p) \
+            + inplace_str + ')'
+
 
 class Dropout2d(Module):
     """Randomly zeroes whole channels of the input tensor.
@@ -56,6 +62,11 @@ class Dropout2d(Module):
     def forward(self, input):
         return self._backend.Dropout2d(self.p, self.training, self.inplace)(input)
 
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'p = ' + str(self.p) \
+            + inplace_str + ')'
 
 class Dropout3d(Module):
     """Randomly zeroes whole channels of the input tensor.
@@ -81,4 +92,10 @@ class Dropout3d(Module):
 
     def forward(self, input):
         return self._backend.Dropout3d(self.p, self.training, self.inplace)(input)
+
+    def __repr__(self):
+        inplace_str = ', inplace' if self.inplace else ''
+        return self.__class__.__name__ + ' (' \
+            + 'p = ' + str(self.p) \
+            + inplace_str + ')'
 

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -48,6 +48,11 @@ class Linear(Module):
         else:
             return self._backend.Linear()(input, self.weight, self.bias)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + str(self.in_features) + ' -> ' \
+            + str(self.out_features) + ')'
+
 
 # TODO: Bilinear
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -45,6 +45,10 @@ class Module(object):
                 self._buffers[key] = fn(buf)
         return self
 
+    def apply(self, fn):
+        fn(self)
+        return self
+
     def cuda(self, device_id=None):
         return self._apply(lambda t: t.cuda(device_id))
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -16,10 +16,10 @@ class CrossMapLRN2d(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'size = ' + str(self.threshold) \
-            + ', alpha = ' + str(self.alpha) \
-            + ', beta = ' + str(self.beta) \
-            + ', k = ' + str(self.k) \
+            + 'size=' + str(self.threshold) \
+            + ', alpha=' + str(self.alpha) \
+            + ', beta=' + str(self.beta) \
+            + ', k=' + str(self.k) \
             + ')'
 
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -14,6 +14,14 @@ class CrossMapLRN2d(Module):
         return self._backend.CrossMapLRN2d(self.size, self.alpha, self.beta,
                 self.k)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'size = ' + str(self.threshold) \
+            + ', alpha = ' + str(self.alpha) \
+            + ', beta = ' + str(self.beta) \
+            + ', k = ' + str(self.k) \
+            + ')'
+
 
 # TODO: ContrastiveNorm2d
 # TODO: DivisiveNorm2d

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -11,6 +11,8 @@ class ReflectionPad2d(Module):
     def forward(self, input):
         return self._backend.ReflectionPad2d(*self.padding)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self.padding)
 
 class ReplicationPad2d(Module):
 
@@ -21,6 +23,8 @@ class ReplicationPad2d(Module):
     def forward(self, input):
         return self._backend.ReplicationPad2d(*self.padding)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self.padding)
 
 class ReplicationPad3d(Module):
 
@@ -31,6 +35,8 @@ class ReplicationPad3d(Module):
     def forward(self, input):
         return self._backend.ReplicationPad3d(*self.padding)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self.padding)
 
 # TODO: ZeroPad2d
 

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -45,6 +45,13 @@ class MaxPool1d(Module):
                 self.padding, self.dilation, self.ceil_mode,
                 self.return_indices)(input)
 
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'size = ' + str(self.kernel_size) \
+            + ', stride = ' + str(self.stride) \
+            + ', padding = ' + str(self.padding) \
+            + ', dilation = ' + str(self.dilation) \
+            + ', ceil_mode = ' + str(self.ceil_mode) + ')'
 
 class MaxPool2d(Module):
     """Applies a 2D max pooling over an input signal composed of several input
@@ -87,6 +94,17 @@ class MaxPool2d(Module):
         return self._backend.MaxPool2d(self.kw, self.kh, self.dw, self.dh,
                 self.padw, self.padh, self.dilh, self.dilw, self.ceil_mode,
                 self.return_indices)(input)
+
+    def __repr__(self):
+        padding_str = ', padding = (' + str(self.padh) + ', ' + str(self.padw) + ')' \
+                      if self.padh != 0 and self.padw !=0 else ''
+        dilation_str = (', dilation = (' + str(self.dilh) + ', ' + str(self.dilw) + ')' \
+                        if self.dilh != 0 and self.dilw != 0 else '')
+        return  self.__class__.__name__ + ' (' \
+            + 'size = (' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride = (' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + padding_str + dilation_str + ')'
+
 
 
 class MaxUnpool2d(Module):
@@ -151,7 +169,6 @@ class MaxUnpool2d(Module):
             out_height, out_width = h, w
         return self._backend.MaxUnpool2d(out_width,
                 out_height)(input, indices)
-
 
 class AvgPool2d(Module):
     """Applies a 2D average pooling over an input signal composed of several input

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -47,11 +47,11 @@ class MaxPool1d(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + 'size = ' + str(self.kernel_size) \
-            + ', stride = ' + str(self.stride) \
-            + ', padding = ' + str(self.padding) \
-            + ', dilation = ' + str(self.dilation) \
-            + ', ceil_mode = ' + str(self.ceil_mode) + ')'
+            + 'size=' + str(self.kernel_size) \
+            + ', stride=' + str(self.stride) \
+            + ', padding=' + str(self.padding) \
+            + ', dilation=' + str(self.dilation) \
+            + ', ceil_mode=' + str(self.ceil_mode) + ')'
 
 class MaxPool2d(Module):
     """Applies a 2D max pooling over an input signal composed of several input
@@ -96,13 +96,13 @@ class MaxPool2d(Module):
                 self.return_indices)(input)
 
     def __repr__(self):
-        padding_str = ', padding = (' + str(self.padh) + ', ' + str(self.padw) + ')' \
+        padding_str=', padding=(' + str(self.padh) + ', ' + str(self.padw) + ')' \
                       if self.padh != 0 and self.padw !=0 else ''
-        dilation_str = (', dilation = (' + str(self.dilh) + ', ' + str(self.dilw) + ')' \
+        dilation_str=(', dilation=(' + str(self.dilh) + ', ' + str(self.dilw) + ')' \
                         if self.dilh != 0 and self.dilw != 0 else '')
         return  self.__class__.__name__ + ' (' \
-            + 'size = (' + str(self.kh) + ', ' + str(self.kw) + ')' \
-            + ', stride = (' + str(self.dh) + ', ' + str(self.dw) + ')' \
+            + 'size=(' + str(self.kh) + ', ' + str(self.kw) + ')' \
+            + ', stride=(' + str(self.dh) + ', ' + str(self.dw) + ')' \
             + padding_str + dilation_str + ')'
 
 


### PR DESCRIPTION
- also fixes a bug in ConvTranspose2d
- also adds .apply(func) with the same-ish semantics as in torch

printing a net will now look more informative, like this:

```
>>> print(netG) # a sequential network
Sequential {
  (0): ConvTranspose2d (100 -> 512, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (1): BatchNorm2d (nChannels: 512    eps: 1e-05 momentum: 0.1 affine: True)
  (2): ReLU (inplace)
  (3): ConvTranspose2d (512 -> 256, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (4): BatchNorm2d (nChannels: 256    eps: 1e-05 momentum: 0.1 affine: True)
  (5): ReLU (inplace)
  (6): ConvTranspose2d (256 -> 128, size: (4, 4), stride: (4, 4), padding: (2, 2))
  (7): BatchNorm2d (nChannels: 128    eps: 1e-05 momentum: 0.1 affine: True)
  (8): ReLU (inplace)
  (9): ConvTranspose2d (128 -> 64, size: (4, 4), stride: (4, 4), padding: (2, 2))
  (10): BatchNorm2d (nChannels: 64    eps: 1e-05 momentum: 0.1 affine: True)
  (11): ReLU (inplace)
  (12): ConvTranspose2d (64 -> 3, size: (4, 4), stride: (4, 4), padding: (4, 4))
  (13): Tanh ()
}

>>> print(netD) # a container with a sequential module called "main"

_netD {
  (main): Sequential {
  (0): Conv2d (3 -> 64, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (1): LeakyReLU (negative slope: 0.2, inplace)
  (2): Conv2d (64 -> 128, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (3): BatchNorm2d (nChannels: 128    eps: 1e-05 momentum: 0.1 affine: True)
  (4): LeakyReLU (negative slope: 0.2, inplace)
  (5): Conv2d (128 -> 256, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (6): BatchNorm2d (nChannels: 256    eps: 1e-05 momentum: 0.1 affine: True)
  (7): LeakyReLU (negative slope: 0.2, inplace)
  (8): Conv2d (256 -> 512, size: (4, 4), stride: (2, 2), padding: (1, 1))
  (9): BatchNorm2d (nChannels: 512    eps: 1e-05 momentum: 0.1 affine: True)
  (10): LeakyReLU (negative slope: 0.2, inplace)
  (11): Conv2d (512 -> 1, size: (4, 4), stride: (1, 1))
  (12): Sigmoid ()
}
}
```