### PR TITLE
Call PyObject_GC_UnTrack from tp_dealloc handler

### DIFF
--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -13,6 +13,7 @@ PyObject *THPFunctionClass = NULL;
 
 static void THPFunction_dealloc(THPFunction* self)
 {
+  PyObject_GC_UnTrack(self);
   self->num_inputs = 0;
   self->num_outputs = 0;
 
@@ -603,4 +604,3 @@ bool THPFunction_initModule(PyObject *module)
   PyModule_AddObject(module, "_FunctionBase", (PyObject *)&THPFunctionType);
   return true;
 }
-

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -72,6 +72,7 @@ static int THPVariable_clear(THPVariable *self)
 
 static void THPVariable_dealloc(THPVariable* self)
 {
+  PyObject_GC_UnTrack(self);
   Py_XDECREF(self->creator);
   Py_XDECREF(self->data);
   Py_XDECREF(self->grad);
@@ -81,7 +82,6 @@ static void THPVariable_dealloc(THPVariable* self)
 
   // We don't want to cache any subclasses
   if ((PyObject*)Py_TYPE(self) == THPVariableClass && num_cached < CACHE_SIZE) {
-    PyObject_GC_UnTrack(self);
     cached_variables[num_cached++] = self;
     // Variable class is defined in Python code, and as such has a
     // Py_TPFLAGS_HEAPTYPE flag set, so python DECREFs the class at each
@@ -262,4 +262,3 @@ bool THPVariable_initModule(PyObject *module)
   PyModule_AddObject(module, "_VariableBase", (PyObject *)&THPVariableType);
   return true;
 }
-


### PR DESCRIPTION
Without the `PyObject_GC_UnTrack` call, the `tp_dealloc` handler could get
called twice if a referred to object triggers a garbage collection from
its destructor.

See http://bugs.python.org/issue28737