### PR TITLE
Fix reference cycles in autograd and relax semantics of save_for_backward and backward

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -165,7 +165,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
 
       // A shortcut for variables - there's no need to buffer gradients for them
       // as their _do_backward is super fast (and we can save memory).
-      // TODO: this might call leaf variable hooks multiple times
+      // FIXME: this might call leaf variable hooks multiple times
       if (THPVariable_Check(prev_obj)) {
         THPVariable *prev_var = (THPVariable*)prev_obj;
         if (prev_var->requires_grad) {

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -26,12 +26,15 @@ struct THPFunctionPtr: public THPObjectPtr {
 
 // (class, gpu id, sizes)
 using output_info_type = std::tuple<PyObject *, int, std::vector<long>>;
+// (tensor, version when saved, version counter)
+// or
+// (None, 0, nullptr)
+using saved_var_info_type = std::tuple<THPObjectPtr, int, std::unique_ptr<THPVariableVersion>>;
 
 struct THPFunction {
     PyObject_HEAD
 
     PyObject *needs_input_grad;
-    PyObject *saved_variables;
     PyObject *backward_hooks;
 
     PyObject *to_save;
@@ -41,6 +44,7 @@ struct THPFunction {
 
     THPFunctionPtr *previous_functions;
     std::vector<output_info_type> *output_info;
+    std::vector<saved_var_info_type> *saved_variables;
     int num_inputs;
     int num_outputs;
     char requires_grad;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -3,26 +3,38 @@
 
 struct THPVariableVersion {
   THPVariableVersion() {
-    version_block = new int[2];
-    version_block[0] = 0;
-    version_block[1] = 1;
+    saved_ref = false;
+    version_block = new int[3];
+    version_block[0] = 0; // version
+    version_block[1] = 1; // refcount
+    version_block[2] = 1; // number of variables currently using the counter
   };
 
   int operator++(int) { return version_block[0]++; }
 
   int operator*() { return *version_block; }
 
-  int refcnt() { return version_block[1]; }
+  int var_refcnt() { return version_block[2]; }
 
   void join_with(THPVariableVersion &other) {
     cleanup();
     version_block = other.version_block;
     version_block[1]++;
+    version_block[2]++;
+  }
+
+  THPVariableVersion* new_saved_ref() {
+    auto new_ver = new THPVariableVersion();
+    new_ver->cleanup();
+    new_ver->version_block = version_block;
+    version_block[1]++;
+    new_ver->saved_ref = true;
+    return new_ver;
   }
 
   void cleanup() {
-    if (--version_block[1])
-      return;
+    if (!saved_ref) --version_block[2];
+    if (--version_block[1]) return;
     delete[] version_block;
     version_block = nullptr;
   }
@@ -30,6 +42,7 @@ struct THPVariableVersion {
   ~THPVariableVersion() { cleanup(); }
 
   int *version_block;
+  bool saved_ref;
 };
 
 struct THPVariable {

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -171,6 +171,7 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
 [[
   name: multinomial
   defined_if: CUDA_FLOAT || CUDA_DOUBLE || CUDA_HALF
+  with_stateless: True
   return: argument 0
   arguments:
     - arg: THTensor* result


### PR DESCRIPTION
1. Adds `torch.multinomial` for CUDA tensors (#236)
2. Fixes reference cycles in autograd (if outputs are saved for backward) (#235)
3. `save_for_backward` now accepts `None` arguments, and `backward` can now return too many `grad_input`s, as long as the excessive values are `None` (#221)