### PR TITLE
Add DataParallel container

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -564,7 +564,7 @@ class TestNN(NNTestCase):
         expected_out = l(i).data
         l.cuda(0)
         out = dp.data_parallel(l, i, (0, 1))
-        self.assertEqual(out.get_device(), 1)
+        self.assertEqual(out.get_device(), 0)
         self.assertEqual(out.data, expected_out)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
@@ -598,6 +598,15 @@ class TestNN(NNTestCase):
         gpus = range(torch.cuda.device_count())
         output = dp.data_parallel(Net(), input, gpus)
         self.assertEqual(output, fn(input))
+
+    def test_data_parallel_module(self):
+        l = nn.Linear(10, 5).float().cuda()
+        i = Variable(torch.randn(20, 10).float().cuda())
+        expected_out = l(i).data
+        net = nn.DataParallel(l)
+        out = net(i)
+        self.assertEqual(out.get_device(), 0)
+        self.assertEqual(out.data, expected_out)
 
     def test_parameter_dict(self):
         l = nn.Linear(5, 5)

--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -1,4 +1,3 @@
-
 from .modules import *
 from .parameter import Parameter
-
+from .parallel import DataParallel

--- a/torch/nn/parallel/__init__.py
+++ b/torch/nn/parallel/__init__.py
@@ -1,55 +1,7 @@
 from .parallel_apply import parallel_apply
 from .replicate import replicate
-from torch.autograd import Variable
+from .data_parallel import DataParallel, data_parallel
+from .scatter_gather import scatter, gather
 
-
-__all__ = ['replicate', 'scatter', 'parallel_apply', 'gather', 'data_parallel']
-
-
-def scatter(input, target_gpus):
-    """Slices a given variable into approximately equal chunks and distributes
-       them accross given GPUs
-    """
-    from .functions import Scatter
-    def scatter_map(obj):
-        if isinstance(obj, Variable):
-            return Scatter(target_gpus)(obj)
-        return tuple(zip(*map(scatter_map, obj)))
-    return scatter_map(input)
-
-
-def gather(outputs, target_device):
-    """Gathers variables from different GPUs on a specified device
-       (-1 means the CPU).
-    """
-    from .functions import Gather
-    def gather_map(outputs):
-        out = outputs[0]
-        if isinstance(out, Variable):
-            return Gather(target_device)(*outputs)
-        return type(out)(map(gather_map, zip(*outputs)))
-    return gather_map(outputs)
-
-
-def data_parallel(module, input, device_ids, output_device=None):
-    """Distributes replicas of module accross gpus given in device_ids,
-       slices the input and applies the copies in parallel.
-
-       Outputs are concatenated on the same device as input (or on
-       output_device if specified). Device id -1 means the CPU.
-    """
-    if not device_ids:
-        return module(input)
-
-    var_input = input
-    while not isinstance(var_input, Variable):
-        var_input = var_input[0]
-    if output_device is None:
-        output_device = -1 if not var_input.is_cuda else var_input.get_device()
-
-    replicas = replicate(module, device_ids)
-    inputs = scatter(input, device_ids)
-    replicas = replicas[:len(inputs)]
-    outputs = parallel_apply(replicas, inputs)
-    return gather(outputs, output_device)
-
+__all__ = ['replicate', 'scatter', 'parallel_apply', 'gather', 'data_parallel',
+           'DataParallel']

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -1,0 +1,85 @@
+import torch
+from torch.nn.modules import Container
+from .scatter_gather import scatter, gather
+from .replicate import replicate
+from .parallel_apply import parallel_apply
+
+
+class DataParallel(Container):
+    """Implements data parallelism at the module level.
+
+    This container parallelizes the application of the given module by
+    splitting the input across the specified devices. In the forward pass, the
+    module is replicated on each device, and each replica handles a portion of
+    the input. During the backwards pass, gradients from each replica are
+    summed into the original module.
+
+    Args:
+        module: module to be parallelized
+        device_ids: CUDA devices (default: all devices)
+        output_device: device location of output (default: device_ids[0])
+    Example:
+        >>> net = torch.nn.DataParallel(model, device_ids=[0, 1, 2])
+        >>> output = net(input)
+    """
+
+    def __init__(self, module, device_ids=None, output_device=None):
+        super(DataParallel, self).__init__()
+        if device_ids is None:
+            device_ids = list(range(torch.cuda.device_count()))
+        if output_device is None:
+            output_device = device_ids[0]
+        self.module = module
+        self.device_ids = device_ids
+        self.output_device = output_device
+        if len(self.device_ids) == 1:
+            self.module.cuda(device_ids[0])
+
+    def forward(self, input):
+        if len(self.device_ids) == 1:
+            return self.module(input.cuda(self.device_ids[0]))
+        replicas = self.replicate(self.module, self.device_ids)
+        inputs = self.scatter(input, self.device_ids)
+        replicas = replicas[:len(inputs)]
+        outputs = self.parallel_apply(replicas, inputs)
+        return self.gather(outputs, self.output_device)
+
+    def replicate(self, module, device_ids):
+        return replicate(module, device_ids)
+
+    def scatter(self, input, device_ids):
+        return scatter(input, device_ids)
+
+    def parallel_apply(self, replicas, inputs):
+        return parallel_apply(replicas, inputs)
+
+    def gather(self, outputs, output_device):
+        return gather(outputs, output_device)
+
+
+def data_parallel(module, input, device_ids, output_device=None):
+    """Evaluates module(input) in parallel across the GPUs given in device_ids.
+
+    This is the functional version of the DataParallel module.
+
+    Args:
+        module: the module to evaluate in parallel
+        input: input to the module
+        device_ids: GPU ids on which to replicate module
+        output_device: GPU location of the output  Use -1 to indicate the CPU.
+            (default: device_ids[0])
+    Returns:
+        a Variable containing the result of module(input) located on
+        output_device
+    """
+    if not device_ids:
+        return module(input)
+
+    if output_device is None:
+        output_device = device_ids[0]
+
+    replicas = replicate(module, device_ids)
+    inputs = scatter(input, device_ids)
+    replicas = replicas[:len(inputs)]
+    outputs = parallel_apply(replicas, inputs)
+    return gather(outputs, output_device)

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -1,0 +1,25 @@
+from torch.autograd import Variable
+from .functions import Scatter, Gather
+
+
+def scatter(input, target_gpus):
+    """Slices a given variable into approximately equal chunks and distributes
+       them accross given GPUs
+    """
+    def scatter_map(obj):
+        if isinstance(obj, Variable):
+            return Scatter(target_gpus)(obj)
+        return tuple(zip(*map(scatter_map, obj)))
+    return scatter_map(input)
+
+
+def gather(outputs, target_device):
+    """Gathers variables from different GPUs on a specified device
+       (-1 means the CPU).
+    """
+    def gather_map(outputs):
+        out = outputs[0]
+        if isinstance(out, Variable):
+            return Gather(target_device)(*outputs)
+        return type(out)(map(gather_map, zip(*outputs)))
+    return gather_map(outputs)


### PR DESCRIPTION
Adds a container version of the `data_parallel` function. This is a
drop-in replacement for the DataParallel class in the ImageNet example.