### PR TITLE
Enable caching allocator for pinned (page-locked) memory

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -591,6 +591,7 @@ extern PyObject * THCPModule_initialSeed(PyObject *_unused);
 extern PyObject * THCPModule_cudaHostAllocator(PyObject *_unused);
 extern PyObject * THCPModule_cudaSynchronize(PyObject *_unused);
 extern PyObject * THCPModule_getLibPath(PyObject *_unused);
+extern PyObject * THCPModule_cudaSleep(PyObject *_unused, PyObject *cycles);
 #endif
 
 static PyMethodDef TorchMethods[] = {
@@ -615,6 +616,7 @@ static PyMethodDef TorchMethods[] = {
   {"_cuda_cudaHostAllocator", (PyCFunction)THCPModule_cudaHostAllocator, METH_NOARGS, NULL},
   {"_cuda_synchronize", (PyCFunction)THCPModule_cudaSynchronize, METH_NOARGS, NULL},
   {"_cuda_getLibPath", (PyCFunction)THCPModule_getLibPath, METH_NOARGS, NULL},
+  {"_cuda_sleep", (PyCFunction)THCPModule_cudaSleep, METH_O, NULL},
 #endif
   {"_safe_call",      (PyCFunction)THPModule_safeCall,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"_sendfd",         (PyCFunction)THPModule_sendfd,            METH_VARARGS, NULL},

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -233,6 +233,15 @@ PyObject * THCPModule_cudaSynchronize(PyObject *_unused)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject * THCPModule_cudaSleep(PyObject *_unused, PyObject *cycles)
+{
+  HANDLE_TH_ERRORS
+  THPUtils_assert(THPUtils_checkLong(cycles), "torch.cuda._sleep(): expected 'int'");
+  THC_sleep(LIBRARY_STATE THPUtils_unpackLong(cycles));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject * THCPModule_getLibPath(PyObject *_unused)
 {
 #define _STR(x) #x
@@ -254,6 +263,7 @@ bool THCPModule_initCuda(PyObject *module_dict) {
 #define ASSERT_TRUE(cond) if (!(cond)) { return false; }
   state = THCState_alloc();
   THCState_setDeviceAllocator(state, THCCachingAllocator_get());
+  state->cudaHostAllocator = &THCCachingHostAllocator;
   THCudaInit(state);
 
 #ifdef USE_MAGMA

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -8,9 +8,14 @@ import torch
 _initialized = False
 _cudart = None
 
+
 def is_available():
     return (hasattr(torch._C, '_cuda_isDriverSufficient') and
             torch._C._cuda_isDriverSufficient())
+
+
+def _sleep(cycles):
+    torch._C._cuda_sleep(cycles)
 
 
 def _load_cudart():

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -80,17 +80,24 @@ class Event(object):
 
         ptr = ctypes.c_void_p()
         self._cudart = cudart()
-        check_error(self._cudart.cudaEventCreateWithFlags(ctypes.byref(ptr), flags))
+        check_error(self._cudart.cudaEventCreateWithFlags(
+            ctypes.byref(ptr), ctypes.c_uint(flags)))
         self._as_parameter_ = ptr
 
     def __del__(self):
-        check_error(self._cudart.cudaEventDestroy(self._as_parameter_))
-        del self._as_parameter_
+        if hasattr(self, '_as_parameter_'):
+            check_error(self._cudart.cudaEventDestroy(self._as_parameter_))
+            del self._as_parameter_
 
     def record(self, stream=None):
         if stream is None:
             stream = torch.cuda.current_stream()
         stream.record_event(self)
+
+    def wait(self, stream=None):
+        if stream is None:
+            stream = torch.cuda.current_stream()
+        stream.wait_event(self)
 
     def query(self):
         res = cudart().cudaEventQuery(self)


### PR DESCRIPTION
Adds a caching allocator for CUDA pinned (page-locked) memory. This avoid synchronization due to cudaFreeHost or cudaHostUnregister calls.

To ensure read-after-write and write-after-read consistency, a CUDA event is recorded after every cudaMemcpyAsync between host and device involving pinned memory created by this allocator. Memory allocations are only re-used after they're freed and all associated CUDA events have completed.

Unlike the caching device allocator, allocations are never split. This means that requests for small allocations may be filled by much larger cached buffers. I think this should be OK in practice.

Also, CUDA events are processed in the order in which they're recorded, even though events may occur out-of-order between devices or streams. This does not affect correctness, but means that cached allocations may not be considered "ready" for re-use until a little later. In practice, I don't think this should matter.

I'll send a PR to cutorch soon, but I want to make sure the continuous builds pass.

I'm interested if @ngimel or @thatguymike have any comments.

See #265 