### PR TITLE
Allow device=None in Tensor constructor"

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -541,6 +541,15 @@ class TestCuda(TestCase):
             self.assertEqual(torch.cuda.current_stream().device, 1)
             self.assertNotEqual(torch.cuda.current_stream(), default_stream)
 
+    @unittest.skipIf(torch.cuda.device_count() < 2, "multi-GPU not supported")
+    def test_tensor_device(self):
+        self.assertEqual(torch.cuda.FloatTensor(1).get_device(), 0)
+        self.assertEqual(torch.cuda.FloatTensor(1, device=1).get_device(), 1)
+        with torch.cuda.device(1):
+            self.assertEqual(torch.cuda.FloatTensor(1).get_device(), 1)
+            self.assertEqual(torch.cuda.FloatTensor(1, device=0).get_device(), 0)
+            self.assertEqual(torch.cuda.FloatTensor(1, device=None).get_device(), 1)
+
     def test_events(self):
         stream = torch.cuda.current_stream()
         event = torch.cuda.Event(enable_timing=True)

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -151,12 +151,14 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
   THCPAutoGPU gpu_guard;
 #endif
 
-  // Internally we allow constructing with a keywoard only argument cdata
+  // Internally we allow constructing with a keyword only argument cdata
   if (kwargs != NULL) {
     Py_ssize_t num_kwargs = PyDict_Size(kwargs);
 #ifdef THC_GENERIC_FILE
     PyObject *device_id = PyDict_GetItemString(kwargs, "device");
-    if (device_id) {
+    if (device_id == Py_None) {
+      num_kwargs--;
+    } else if (device_id) {
       THPUtils_assert(THPUtils_checkLong(device_id), "device argument "
           " has to be an int, but got %s", THPUtils_typename(device_id));
       gpu_guard.setDevice(THPUtils_unpackLong(device_id));


### PR DESCRIPTION
Setting `device=None` is the same as not specifying the device (uses the current active device).