### PR TITLE
Batched fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ import shutil
 import sys
 import os
 
-CUDA_HOME = os.getenv('CUDA_HOME', '/usr/local/cuda')
-WITH_CUDA = os.path.exists(CUDA_HOME)
-WITH_CUDNN = WITH_CUDA
-DEBUG = False
+from tools.setup_helpers.env import check_env_flag
+from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
+from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
+DEBUG = check_env_flag('DEBUG')
 
 ################################################################################
 # Monkey-patch setuptools to compile in parallel
@@ -200,6 +200,8 @@ if WITH_CUDA:
 
 if WITH_CUDNN:
     main_libraries += ['cudnn']
+    include_dirs.append(CUDNN_INCLUDE_DIR)
+    extra_link_args.append('-L' + CUDNN_LIB_DIR)
     main_sources += [
         "torch/csrc/cudnn/Module.cpp",
         "torch/csrc/cudnn/Conv.cpp",

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -263,7 +263,7 @@ simple_pointwise_float = [
     'trunc',
     'ceil',
 ]
-    
+
 for fn in simple_pointwise_float:
     tests.append((fn, small_3d, lambda t: [], None, float_types))
 
@@ -510,6 +510,19 @@ class TestCuda(TestCase):
             self.assertEqual(copy, original)
             self.assertIs(type(copy), type(original))
             self.assertEqual(copy.get_device(), 0)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, "detected only one GPU")
+    def test_cuda_set_device(self):
+        x = torch.randn(5, 5)
+        with torch.cuda.device(1):
+            self.assertEqual(x.cuda().get_device(), 1)
+            torch.cuda.set_device(0)
+            self.assertEqual(x.cuda().get_device(), 0)
+            with torch.cuda.device(1):
+                self.assertEqual(x.cuda().get_device(), 1)
+            self.assertEqual(x.cuda().get_device(), 0)
+            torch.cuda.set_device(1)
+        self.assertEqual(x.cuda().get_device(), 0)
 
     def test_cuda_synchronize(self):
         torch.cuda.synchronize()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -364,6 +364,16 @@ class TestNN(NNTestCase):
         net.double()
         self.assertIsInstance(l.weight.data, torch.DoubleTensor)
         self.assertIsInstance(l.bias.data, torch.DoubleTensor)
+        net.type(torch.FloatTensor)
+        self.assertIsInstance(l.weight.data, torch.FloatTensor)
+        self.assertIsInstance(l.bias.data, torch.FloatTensor)
+        net.type(torch.DoubleTensor)
+        self.assertIsInstance(l.weight.data, torch.DoubleTensor)
+        self.assertIsInstance(l.bias.data, torch.DoubleTensor)
+        if TEST_CUDA:
+            net.type(torch.cuda.FloatTensor)
+            self.assertIsInstance(l.weight.data, torch.cuda.FloatTensor)
+            self.assertIsInstance(l.bias.data, torch.cuda.FloatTensor)
 
     def test_non_leaf_parameters(self):
         l1 = nn.Linear(10, 10)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1105,7 +1105,7 @@ new_module_tests = [
         module_name='Embedding',
         constructor_args=(4, 3),
         input=Variable(
-            torch.randperm(2).repeat(1, 2).long(),
+            torch.randperm(2).repeat(1, 2),
             requires_grad=False
         ),
         jacobian_input=False

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1851,17 +1851,16 @@ class TestTorch(TestCase):
         self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
         self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
 
-        self.assertRaises(RuntimeError, lambda: reference[1, 1, 1, 1])
-        self.assertRaises(RuntimeError, lambda: reference[1, 1, 1, 1:1])
-        self.assertRaises(RuntimeError, lambda: reference[3, 3, 3, 3, 3, 3, 3, 3])
+        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1])
+        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1:1])
+        self.assertRaises(IndexError, lambda: reference[3, 3, 3, 3, 3, 3, 3, 3])
 
-        self.assertRaises(RuntimeError, lambda: reference[0.0])
-        self.assertRaises(TypeError,    lambda: reference[0.0:2.0])
-        self.assertRaises(RuntimeError, lambda: reference[0.0, 0.0:2.0])
-        self.assertRaises(RuntimeError, lambda: reference[0.0, :, 0.0:2.0])
-        self.assertRaises(RuntimeError, lambda: reference[0.0, ..., 0.0:2.0])
-        self.assertRaises(RuntimeError, lambda: reference[0.0, :, 0.0])
-
+        self.assertRaises(TypeError, lambda: reference[0.0])
+        self.assertRaises(TypeError, lambda: reference[0.0:2.0])
+        self.assertRaises(TypeError, lambda: reference[0.0, 0.0:2.0])
+        self.assertRaises(TypeError, lambda: reference[0.0, :, 0.0:2.0])
+        self.assertRaises(TypeError, lambda: reference[0.0, ..., 0.0:2.0])
+        self.assertRaises(TypeError, lambda: reference[0.0, :, 0.0])
 
     def test_newindex(self):
         reference = self._consecutive((3, 3, 3))
@@ -1880,26 +1879,24 @@ class TestTorch(TestCase):
         checkPartialAssign((1, 2))
         checkPartialAssign((0, 2))
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(IndexError):
             reference[1, 1, 1, 1] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(IndexError):
             reference[1, 1, 1, (1, 1)] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(IndexError):
             reference[3, 3, 3, 3, 3, 3, 3, 3] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             reference[0.0] = 1
         with self.assertRaises(TypeError):
             reference[0.0:2.0] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             reference[0.0, 0.0:2.0] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             reference[0.0, :, 0.0:2.0] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             reference[0.0, ..., 0.0:2.0] = 1
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             reference[0.0, :, 0.0] = 1
-
-
 
     def test_index_copy(self):
         num_copy, num_dest = 3, 20
@@ -2508,6 +2505,11 @@ class TestTorch(TestCase):
         self.assertEqual(y, x.contiguous().view(2, 1, 4))
         y = x.clone().unsqueeze_(2)
         self.assertEqual(y, x.contiguous().view(2, 4, 1))
+
+    def test_iter(self):
+        x = torch.randn(5, 5)
+        for i, sub in enumerate(x):
+            self.assertEqual(sub, x[i])
 
     def test_accreal_type(self):
         x = torch.randn(2, 3, 4) * 10

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -781,7 +781,7 @@ class TestTorch(TestCase):
     def test_randperm(self):
         _RNGState = torch.get_rng_state()
         res1 = torch.randperm(100)
-        res2 = torch.Tensor()
+        res2 = torch.LongTensor()
         torch.set_rng_state(_RNGState)
         torch.randperm(res2, 100)
         self.assertEqual(res1, res2, 0)
@@ -1905,7 +1905,7 @@ class TestTorch(TestCase):
         num_copy, num_dest = 3, 20
         dest = torch.randn(num_dest, 4, 5)
         src = torch.randn(num_copy, 4, 5)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy).long()
+        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
         dest2 = dest.clone()
         dest.index_copy_(0, idx, src)
         for i in range(idx.size(0)):
@@ -1914,7 +1914,7 @@ class TestTorch(TestCase):
 
         dest = torch.randn(num_dest)
         src = torch.randn(num_copy)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy).long()
+        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
         dest2 = dest.clone()
         dest.index_copy_(0, idx, src)
         for i in range(idx.size(0)):
@@ -1925,7 +1925,7 @@ class TestTorch(TestCase):
         num_copy, num_dest = 3, 3
         dest = torch.randn(num_dest, 4, 5)
         src = torch.randn(num_copy, 4, 5)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy).long()
+        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
         dest2 = dest.clone()
         dest.index_add_(0, idx, src)
         for i in range(idx.size(0)):
@@ -1934,7 +1934,7 @@ class TestTorch(TestCase):
 
         dest = torch.randn(num_dest)
         src = torch.randn(num_copy)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy).long()
+        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
         dest2 = dest.clone()
         dest.index_add_(0, idx, src)
         for i in range(idx.size(0)):
@@ -2283,7 +2283,7 @@ class TestTorch(TestCase):
 
     def test_permute(self):
         orig = [1, 2, 3, 4, 5, 6, 7]
-        perm = list(torch.randperm(7).long())
+        perm = list(torch.randperm(7))
         x = torch.Tensor(*orig).fill_(0)
         new = list(map(lambda x: x - 1, x.permute(*perm).size()))
         self.assertEqual(perm, new)

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -1,0 +1,8 @@
+import os
+
+from .env import check_env_flag
+
+CUDA_HOME = os.getenv('CUDA_HOME', '/usr/local/cuda')
+WITH_CUDA = not check_env_flag('NO_CUDA') and os.path.exists(CUDA_HOME)
+if not WITH_CUDA:
+    CUDA_HOME = None

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -1,0 +1,35 @@
+import os
+import glob
+
+from .env import check_env_flag
+from .cuda import WITH_CUDA, CUDA_HOME
+
+WITH_CUDNN = False
+CUDNN_LIB_DIR = None
+CUDNN_INCLUDE_DIR = None
+if WITH_CUDA and not check_env_flag('WITH_CUDNN'):
+    lib_paths = list(filter(bool, [
+        os.getenv('CUDNN_LIB_DIR'),
+        os.path.join(CUDA_HOME, 'lib'),
+        os.path.join(CUDA_HOME, 'lib64')
+    ]))
+    include_paths = list(filter(bool, [
+        os.getenv('CUDNN_INCLUDE_DIR'),
+        os.path.join(CUDA_HOME, 'include'),
+    ]))
+    for path in lib_paths:
+        if path is None or not os.path.exists(path):
+            continue
+        if glob.glob(os.path.join(path, 'libcudnn*')):
+            CUDNN_LIB_DIR = path
+            break
+    for path in include_paths:
+        if path is None or not os.path.exists(path):
+            continue
+        if os.path.exists((os.path.join(path, 'cudnn.h'))):
+            CUDNN_INCLUDE_DIR = path
+            break
+    if not CUDNN_LIB_DIR or not CUDNN_INCLUDE_DIR:
+        CUDNN_LIB_DIR = CUDNN_INCLUDE_DIR = None
+    else:
+        WITH_CUDNN = True

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -1,0 +1,4 @@
+import os
+
+def check_env_flag(name):
+    return os.getenv(name) in {'ON', '1', 'YES', 'TRUE', 'Y'}

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -206,3 +206,12 @@ del IntTensorBase
 del ShortTensorBase
 del CharTensorBase
 del ByteTensorBase
+
+################################################################################
+# Import most common subpackages
+################################################################################
+
+import torch.cuda
+import torch.autograd
+import torch.nn
+import torch.optim

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -189,7 +189,7 @@ def forward(fn, input, hx, weight, output, hy):
         x = input.contiguous()
         output.resize_(*output_size)
         hy.resize_(*hidden_size).zero_()
-        if cy:
+        if cy is not None:
             cy.resize_(*hidden_size).zero_()
         y = output
 
@@ -302,9 +302,9 @@ def backward_grad(fn, input, hx, weight, output, grad_output, grad_hy, grad_inpu
         w = fn.weight_buf
         dx = grad_input.resize_as_(input)
         dhy = grad_hy.resize_(*hidden_size)
-        dcy = grad_cy.resize_(*hidden_size) if grad_cy else None
+        dcy = grad_cy.resize_(*hidden_size) if grad_cy is not None else None
         dhx = grad_hx.resize_(*hidden_size)
-        dcx = grad_cx.resize_(*hidden_size) if grad_cx else None
+        dcx = grad_cx.resize_(*hidden_size) if grad_cx is not None else None
 
         if fn.dropout != 0 and cudnn.version() < 5103:
             raise RuntimeError('dropout supported only in cudnn v 5.1 and above')
@@ -316,16 +316,16 @@ def backward_grad(fn, input, hx, weight, output, grad_output, grad_hy, grad_inpu
         if tuple(output.size()) != _output_size(fn):
             raise RuntimeError('Expected output size {}, got {}'.format(
                 output_size, output.size()))
-        if hx and tuple(hx.size()) != hidden_size:
+        if hx is not None and tuple(hx.size()) != hidden_size:
             raise RuntimeError('Expected hidden size {}, got {}'.format(
                 hidden_size, hx.size()))
-        if cx and tuple(cx.size()) != hidden_size:
+        if cx is not None and tuple(cx.size()) != hidden_size:
             raise RuntimeError('Expected cell size {}, got {}'.format(
                 hidden_size, cx.size()))
-        if dhy and tuple(dhy.size()) != hidden_size:
+        if dhy is not None and tuple(dhy.size()) != hidden_size:
             raise RuntimeError('Expected d_hidden size {}, got {}'.format(
                 hidden_size, dhy.size()))
-        if dcy and tuple(dcy.size()) != hidden_size:
+        if dcy is not None and tuple(dcy.size()) != hidden_size:
             raise RuntimeError('Expected d_cell size {}, got {}'.format(
                 hidden_size, dcy.size()))
 
@@ -336,13 +336,13 @@ def backward_grad(fn, input, hx, weight, output, grad_output, grad_hy, grad_inpu
             fn.y_descs, ctypes.c_void_p(y.data_ptr()),
             fn.y_descs, ctypes.c_void_p(dy.data_ptr()),
             fn.hy_desc, ctypes.c_void_p(dhy.data_ptr()),
-            fn.cy_desc, ctypes.c_void_p(dcy.data_ptr()) if cx else None,
+            fn.cy_desc, ctypes.c_void_p(dcy.data_ptr()) if cx is not None else None,
             fn.w_desc, ctypes.c_void_p(w.data_ptr()),
             fn.hx_desc, ctypes.c_void_p(hx.data_ptr()),
-            fn.cx_desc, ctypes.c_void_p(cx.data_ptr()) if cx else None,
+            fn.cx_desc, ctypes.c_void_p(cx.data_ptr()) if cx is not None else None,
             fn.x_descs, ctypes.c_void_p(dx.data_ptr()),
             fn.hx_desc, ctypes.c_void_p(dhx.data_ptr()),
-            fn.cx_desc, ctypes.c_void_p(dcx.data_ptr()) if cx else None,
+            fn.cx_desc, ctypes.c_void_p(dcx.data_ptr()) if cx is not None else None,
             ctypes.c_void_p(fn.workspace.data_ptr()), fn.workspace.size(0),
             ctypes.c_void_p(fn.reserve.data_ptr()), fn.reserve.size(0)
         ))

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -423,7 +423,6 @@ IMPLEMENT_STATELESS(exponential)
 IMPLEMENT_STATELESS(random)
 IMPLEMENT_STATELESS(geometric)
 IMPLEMENT_STATELESS(bernoulli)
-IMPLEMENT_STATELESS(randperm)
 IMPLEMENT_STATELESS(unfold)
 IMPLEMENT_STATELESS(range)
 IMPLEMENT_STATELESS(gather)
@@ -510,6 +509,18 @@ static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args)
       tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   THPObjectPtr method = PyObject_GetAttrString(methods, "nonzero");
   THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
+  return PyObject_Call(method, args, NULL);
+}
+
+static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args)
+{
+  PyObject *tensor = THPLongTensorClass;
+  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
+  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",
+      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
+  THPObjectPtr method = PyObject_GetAttrString(methods, "randperm");
+  THPUtils_assert(method, "Type %s doesn't implement stateless method randperm",
       tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   return PyObject_Call(method, args, NULL);
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -203,6 +203,11 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     long nindex = THPUtils_unpackLong(index);
     if (nindex < 0)
       nindex += THStorage_(size)(LIBRARY_STATE self->cdata);
+    if (nindex < 0 || nindex >= self->cdata->size) {
+      PyErr_Format(PyExc_IndexError, "index %ld out of range for storage of "
+              "size %ld", nindex, self->cdata->size);
+      return NULL;
+    }
     real value = THStorage_(get)(LIBRARY_STATE self->cdata, nindex);
     return THPUtils_(newReal)(value);
   /* Slice index */
@@ -222,7 +227,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     new_storage.release();
     return _ret;
   }
-  THPUtils_setError("can't index a " THPStorageStr " with %s",
+  PyErr_Format(PyExc_TypeError, "can't index a " THPStorageStr " with %s",
       THPUtils_typename(index));
   return NULL;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -626,10 +626,17 @@ static int THPTensor_(setValue)(THPTensor *self, PyObject *index, PyObject *valu
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 
+Py_ssize_t THPTensor_(length)(THPTensor *self)
+{
+  if (self->cdata->nDimension == 0)
+    return 0;
+  return self->cdata->size[0];
+}
+
 #include "TensorMethods.cpp"
 
 static PyMappingMethods THPTensor_(mappingmethods) = {
-  NULL,
+  (lenfunc)THPTensor_(length),
   (binaryfunc)THPTensor_(getValue)<false>,
   (objobjargproc)THPTensor_(setValue)<false>
 };

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -412,9 +412,15 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
   long dimsize = THTensor_(size)(LIBRARY_STATE TENSOR_VARIABLE, DIM);          \
   idx = (idx < 0) ? dimsize + idx : idx;                                       \
                                                                                \
-  THPUtils_assertRet(false, dimsize > 0, "indexing an empty tensor");          \
-  THPUtils_assertRet(false, idx >= 0 && idx < dimsize, "index %ld is out of range for " \
-      "dimension %ld (of size %ld)", idx, DIM, dimsize);                       \
+  if (dimsize <= 0) {                                                          \
+    PyErr_SetString(PyExc_IndexError, "indexing an empty tensor");             \
+    return false;                                                              \
+  }                                                                            \
+  if (idx < 0 || idx >= dimsize) {                                             \
+    PyErr_Format(PyExc_IndexError, "index %ld is out of range for dimension "  \
+        "%ld (of size %ld)", idx, DIM, dimsize);                               \
+    return false;                                                              \
+  }                                                                            \
                                                                                \
   if(THTensor_(nDimension)(LIBRARY_STATE TENSOR_VARIABLE) == 1) {              \
     CASE_1D;                                                                   \
@@ -467,9 +473,12 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
         break;
       }
     }
-    THPUtils_assertRet(false, num_effective_index <= num_tensor_dim,
-        "trying to index %ld dimensions of a %ld dimensional tensor",
-        num_effective_index, num_tensor_dim);
+    if (num_effective_index > num_tensor_dim) {
+      PyErr_Format(PyExc_IndexError,
+          "trying to index %ld dimensions of a %ld dimensional tensor",
+          num_effective_index, num_tensor_dim);
+      return false;
+    }
 
     tresult = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
     int t_dim = 0;
@@ -509,8 +518,8 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
     }
   }
 
-  THPUtils_setError("indexing a tensor with an object of type %s. The only "
-      "supported types are integers, slices"
+  PyErr_Format(PyExc_TypeError, "indexing a tensor with an object of type %s. "
+      "The only supported types are integers, slices"
 #ifdef WITH_NUMPY
       ", numpy scalars"
 #endif

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -96,6 +96,11 @@ class device_of(device):
         super(device_of, self).__init__(idx)
 
 
+def set_device(device):
+    if device >= 0:
+        torch._C._cuda_setDevice(device)
+
+
 @contextlib.contextmanager
 def stream(stream):
     if stream is None:

--- a/torch/legacy/nn/AbsCriterion.py
+++ b/torch/legacy/nn/AbsCriterion.py
@@ -9,7 +9,8 @@ class AbsCriterion(Criterion):
         self.output_tensor = torch.Tensor(1)
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.AbsCriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/Add.py
+++ b/torch/legacy/nn/Add.py
@@ -41,7 +41,7 @@ class Add(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if self.gradInput:
+        if self.gradInput is not None:
            self.gradInput.resize_as_(gradOutput).copy_(gradOutput)
            return self.gradInput
 

--- a/torch/legacy/nn/BCECriterion.py
+++ b/torch/legacy/nn/BCECriterion.py
@@ -19,7 +19,8 @@ class BCECriterion(Criterion):
         if input.nelement() != target.nelement():
             raise RuntimeError("input and target size mismatch")
 
-        self.buffer = self.buffer or input.new()
+        if self.buffer is None:
+              self.buffer = input.new()
 
         buffer = self.buffer
         weights = self.weights
@@ -61,7 +62,8 @@ class BCECriterion(Criterion):
          if input.nelement() != target.nelement():
             raise RuntimeError("input and target size mismatch")
 
-         self.buffer = self.buffer or input.new()
+         if self.buffer is None:
+              self.buffer = input.new()
 
          buffer = self.buffer
          weights = self.weights

--- a/torch/legacy/nn/BatchNormalization.py
+++ b/torch/legacy/nn/BatchNormalization.py
@@ -80,13 +80,15 @@ class BatchNormalization(Module):
 
     def _makeContiguous(self, input, gradOutput=None):
         if not input.is_contiguous():
-            self._input = self._input or input.new()
+            if self._input is None:
+                  self._input = input.new()
             self._input.resize_as_(input).copy_(input)
             input = self._input
 
         if gradOutput:
             if not gradOutput.is_contiguous():
-                self._gradOutput = self._gradOutput or gradOutput.new()
+                if self._gradOutput is None:
+                      self._gradOutput = gradOutput.new()
                 self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
                 gradOutput = self._gradOutput
 
@@ -98,9 +100,11 @@ class BatchNormalization(Module):
         input = self._makeContiguous(input)[0]
 
         self.output.resize_as_(input)
-        self.save_mean = self.save_mean or input.new()
+        if self.save_mean is None:
+              self.save_mean = input.new()
         self.save_mean.resize_as_(self.running_mean)
-        self.save_std = self.save_std or input.new()
+        if self.save_std is None:
+              self.save_std = input.new()
         self.save_std.resize_as_(self.running_var)
 
         self._backend.BatchNormalization_updateOutput(

--- a/torch/legacy/nn/Bilinear.py
+++ b/torch/legacy/nn/Bilinear.py
@@ -58,7 +58,8 @@ class Bilinear(Module):
         self._assertInput(input)
 
         # set up buffer:
-        self.buff2 = self.buff2 or input[0].new()
+        if self.buff2 is None:
+              self.buff2 = input[0].new()
         self.buff2.resize_as_(input[1])
 
         # compute output scores:
@@ -75,7 +76,7 @@ class Bilinear(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         self._assertInputGradOutput(input, gradOutput)
@@ -93,7 +94,8 @@ class Bilinear(Module):
 
         #: remaining slices of weight tensor
         if self.weight.size(0) > 1:
-            self.buff1 = self.buff1 or input[0].new()
+            if self.buff1 is None:
+                  self.buff1 = input[0].new()
             self.buff1.resize_as_(input[0])
 
             for k in range(1, self.weight.size(0)):
@@ -115,7 +117,8 @@ class Bilinear(Module):
         self._assertInputGradOutput(input, gradOutput)
 
         # make sure we have buffer:
-        self.buff1 = self.buff1 or input[0].new()
+        if self.buff1 is None:
+              self.buff1 = input[0].new()
         self.buff1.resize_as_(input[0])
 
         # accumulate parameter gradients:

--- a/torch/legacy/nn/CMul.py
+++ b/torch/legacy/nn/CMul.py
@@ -63,7 +63,7 @@ class CMul(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
            return
 
         if self._gradOutput is None:

--- a/torch/legacy/nn/CMulTable.py
+++ b/torch/legacy/nn/CMulTable.py
@@ -16,7 +16,8 @@ class CMulTable(Module):
         return self.output
 
     def updateGradInput_efficient(self, input, gradOutput):
-        self.tout = self.tout or input[0].new()
+        if self.tout is None:
+              self.tout = input[0].new()
         self.tout.resize_as_(self.output)
         for i in range(len(input)):
             if len(self.gradInput) <= i:

--- a/torch/legacy/nn/CSubTable.py
+++ b/torch/legacy/nn/CSubTable.py
@@ -13,8 +13,10 @@ class CSubTable(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        self.gradInput[0] = self.gradInput[0] or input[0].new()
-        self.gradInput[1] = self.gradInput[1] or input[1].new()
+        if self.gradInput[0] is None:
+              self.gradInput[0] = input[0].new()
+        if self.gradInput[1] is None:
+              self.gradInput[1] = input[1].new()
         self.gradInput[0].resize_as_(input[0]).copy_(gradOutput)
         self.gradInput[1].resize_as_(input[1]).copy_(gradOutput).mul_(-1)
 

--- a/torch/legacy/nn/ClassSimplexCriterion.py
+++ b/torch/legacy/nn/ClassSimplexCriterion.py
@@ -72,7 +72,8 @@ class ClassSimplexCriterion(MSECriterion):
          self._transformTarget(target)
 
          assert input.nelement() == self._target.nelement()
-         self.output_tensor = self.output_tensor or input.new(1)
+         if self.output_tensor is None:
+              self.output_tensor = input.new(1)
          self._backend.MSECriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/Cosine.py
+++ b/torch/legacy/nn/Cosine.py
@@ -31,8 +31,10 @@ class Cosine(Module):
         inputSize = self.weight.size(1)
         outputSize = self.weight.size(0)
 
-        self._weightNorm = self._weightNorm or self.weight.new()
-        self._inputNorm = self._inputNorm or self.weight.new()
+        if self._weightNorm is None:
+              self._weightNorm = self.weight.new()
+        if self._inputNorm is None:
+              self._inputNorm = self.weight.new()
 
         # y_j = (w_j * x) / ( || w_j || * || x || )
 
@@ -55,7 +57,7 @@ class Cosine(Module):
     def updateGradInput(self, input, gradOutput):
         assert input.dim() == 2
 
-        if not self.gradInput:
+        if self.gradInput is None:
            return
 
         inputSize = self.weight.size(1)
@@ -75,8 +77,10 @@ class Cosine(Module):
         inputNorm = self._inputNorm.expand_as(input)
         weightNorm = self._weightNorm.view(1, outputSize).expand_as(gradOutput)
 
-        self._gradOutput = self._gradOutput or gradOutput.new()
-        self._sum = self._sum or input.new()
+        if self._gradOutput is None:
+              self._gradOutput = gradOutput.new()
+        if self._sum is None:
+              self._sum = input.new()
 
         self.gradInput.copy_(input).div_(inputNorm)
         self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
@@ -102,11 +106,14 @@ class Cosine(Module):
         dw_ji   || w_j || * || x ||         || w_j ||^2
         """
 
-        self._weight = self._weight or self.weight.new()
-        self._sum = self._sum or input.new()
+        if self._weight is None:
+              self._weight = self.weight.new()
+        if self._sum is None:
+              self._sum = input.new()
 
         self._weight.resize_as_(self.weight).copy_(self.weight)
-        self._gradOutput = self._gradOutput or gradOutput.new()
+        if self._gradOutput is None:
+              self._gradOutput = gradOutput.new()
         self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
         self._gradOutput.mul_(self.output)
         torch.sum(self._sum, self._gradOutput, 0)

--- a/torch/legacy/nn/CosineDistance.py
+++ b/torch/legacy/nn/CosineDistance.py
@@ -19,12 +19,14 @@ class CosineDistance(Module):
 
     def _makeContiguous(self, input1, input2):
         if not input1.is_contiguous():
-           self._input1 = self._input1 or input1.new()
+           if self._input1 is None:
+                  self._input1 = input1.new()
            self._input1.resize_as_(input1).copy_(input1)
            input1 = self._input1
 
         if not input2.is_contiguous():
-           self._input2 = self._input2 or input2.new()
+           if self._input2 is None:
+                  self._input2 = input2.new()
            self._input2.resize_as_(input2).copy_(input2)
            input2 = self._input2
 
@@ -70,8 +72,10 @@ class CosineDistance(Module):
         v1, v2 = self._makeContiguous(v1, v2)
 
         if len(self.gradInput) != 2:
-           self.gradInput[0] = self.gradInput[0] or v1.new()
-           self.gradInput[1] = self.gradInput[1] or v1.new()
+           if self.gradInput[0] is None:
+                  self.gradInput[0] = v1.new()
+           if self.gradInput[1] is None:
+                  self.gradInput[1] = v1.new()
            self.gradInput = self.gradInput[:2]
 
         gw1 = self.gradInput[0]

--- a/torch/legacy/nn/DistKLDivCriterion.py
+++ b/torch/legacy/nn/DistKLDivCriterion.py
@@ -10,7 +10,8 @@ class DistKLDivCriterion(Criterion):
 
     def updateOutput(self, input, target):
         assert input.is_same_size(target)
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.DistKLDivCriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/DotProduct.py
+++ b/torch/legacy/nn/DotProduct.py
@@ -12,7 +12,7 @@ class DotProduct(Module):
     def updateOutput(self, input):
         input1, input2 = input[0], input[1]
 
-        if not self.buffer:
+        if self.buffer is None:
            self.buffer = input1.new()
 
         torch.mul(self.buffer, input1, input2)
@@ -26,8 +26,10 @@ class DotProduct(Module):
         not_batch = False
 
         if len(self.gradInput) != 2:
-          self.gradInput[0] = self.gradInput[0] or input[0].new()
-          self.gradInput[1] = self.gradInput[1] or input[1].new()
+          if self.gradInput[0] is None:
+              self.gradInput[0] = input[0].new()
+          if self.gradInput[1] is None:
+              self.gradInput[1] = input[1].new()
           self.gradInput = self.gradInput[:2]
 
         gw1 = self.gradInput[0]

--- a/torch/legacy/nn/Euclidean.py
+++ b/torch/legacy/nn/Euclidean.py
@@ -46,12 +46,18 @@ class Euclidean(Module):
 
     def updateOutput(self, input):
         # lazy initialize buffers
-        self._input = self._input or input.new()
-        self._weight = self._weight or self.weight.new()
-        self._expand = self._expand or self.output.new()
-        self._expand2 = self._expand2 or self.output.new()
-        self._repeat = self._repeat or self.output.new()
-        self._repeat2 = self._repeat2 or self.output.new()
+        if self._input is None:
+              self._input = input.new()
+        if self._weight is None:
+              self._weight = self.weight.new()
+        if self._expand is None:
+              self._expand = self.output.new()
+        if self._expand2 is None:
+              self._expand2 = self.output.new()
+        if self._repeat is None:
+              self._repeat = self.output.new()
+        if self._repeat2 is None:
+              self._repeat2 = self.output.new()
 
         inputSize, outputSize = self.weight.size(0), self.weight.size(1)
 
@@ -81,13 +87,17 @@ class Euclidean(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
            return
 
-        self._div = self._div or input.new()
-        self._output = self._output or self.output.new()
-        self._gradOutput = self._gradOutput or input.new()
-        self._expand3 = self._expand3 or input.new()
+        if self._div is None:
+              self._div = input.new()
+        if self._output is None:
+              self._output = self.output.new()
+        if self._gradOutput is None:
+              self._gradOutput = input.new()
+        if self._expand3 is None:
+              self._expand3 = input.new()
 
         if not self.fastBackward:
            self.updateOutput(input)
@@ -133,7 +143,8 @@ class Euclidean(Module):
         """
         # assumes a preceding call to updateGradInput
         assert input.dim() == 2
-        self._sum = self._sum or input.new()
+        if self._sum is None:
+              self._sum = input.new()
         torch.sum(self._sum, self._repeat2, 0)
         self._sum.resize_(inputSize, outputSize)
         self.gradWeight.add_(-scale, self._sum)

--- a/torch/legacy/nn/HingeEmbeddingCriterion.py
+++ b/torch/legacy/nn/HingeEmbeddingCriterion.py
@@ -10,7 +10,8 @@ class HingeEmbeddingCriterion(Criterion):
         self.buffer = None
 
     def updateOutput(self, input, y):
-        self.buffer = self.buffer or input.new()
+        if self.buffer is None:
+              self.buffer = input.new()
         self.buffer.resize_as_(input).copy_(input)
         self.buffer[torch.eq(y, -1.)] = 0
         self.output = self.buffer.sum()

--- a/torch/legacy/nn/L1Cost.py
+++ b/torch/legacy/nn/L1Cost.py
@@ -10,7 +10,8 @@ class L1Cost(Criterion):
 
     def updateOutput(self, input, target=None):
         assert target is None
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.L1Cost_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/Linear.py
+++ b/torch/legacy/nn/Linear.py
@@ -34,7 +34,8 @@ class Linear(Module):
 
     def _updateAddBuffer(self, input):
         nframe = input.size(0)
-        self.addBuffer = self.addBuffer or input.new()
+        if self.addBuffer is None:
+              self.addBuffer = input.new()
         if self.addBuffer.nelement() != nframe:
             self.addBuffer.resize_(nframe).fill_(1)
 
@@ -54,7 +55,7 @@ class Linear(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         nelement = self.gradInput.nelement()

--- a/torch/legacy/nn/LogSigmoid.py
+++ b/torch/legacy/nn/LogSigmoid.py
@@ -9,7 +9,8 @@ class LogSigmoid(Module):
         self.buffer = None
 
     def updateOutput(self, input):
-        self.buffer = self.buffer or input.new()
+        if self.buffer is None:
+              self.buffer = input.new()
         self._backend.LogSigmoid_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/LookupTable.py
+++ b/torch/legacy/nn/LookupTable.py
@@ -90,7 +90,8 @@ class LookupTable(Module):
             raise RuntimeError("input must be a vector or matrix")
 
         if not gradOutput.is_contiguous():
-            self._gradOutput = self._gradOutput or gradOutput.new()
+            if self._gradOutput is None:
+                self._gradOutput = gradOutput.new()
             self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
             gradOutput = self._gradOutput
 
@@ -108,7 +109,7 @@ class LookupTable(Module):
         )
 
     def renorm(self, input):
-        if not self.maxNorm:
+        if self.maxNorm is None:
            return
 
         # copy input into _input, so _input is continous.
@@ -130,7 +131,7 @@ class LookupTable(Module):
         )
 
     def type(self, type=None, tensorCache=None):
-        if not type:
+        if type is None:
             return self._type
         super(LookupTable, self).type(type, tensorCache)
 

--- a/torch/legacy/nn/MM.py
+++ b/torch/legacy/nn/MM.py
@@ -34,8 +34,10 @@ class MM(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        self.gradInput[0] = self.gradInput[0] or input[0].new()
-        self.gradInput[1] = self.gradInput[1] or input[1].new()
+        if self.gradInput[0] is None:
+              self.gradInput[0] = input[0].new()
+        if self.gradInput[1] is None:
+              self.gradInput[1] = input[1].new()
 
         assert len(input) == 2
         a, b = input

--- a/torch/legacy/nn/MSECriterion.py
+++ b/torch/legacy/nn/MSECriterion.py
@@ -9,7 +9,8 @@ class MSECriterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.MSECriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/MarginCriterion.py
+++ b/torch/legacy/nn/MarginCriterion.py
@@ -10,7 +10,8 @@ class MarginCriterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.MarginCriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/MarginRankingCriterion.py
+++ b/torch/legacy/nn/MarginRankingCriterion.py
@@ -17,7 +17,8 @@ class MarginRankingCriterion(Criterion):
         if input[0].size(0) == 1:
            self.output = max(0, -y*(input[0][0]-input[1][0]) + self.margin)
         else:
-           self._output = self._output or input[0].clone()
+           if self._output is None:
+                  self._output = input[0].clone()
            self._output.resize_as_(input[0])
            self._output.copy_(input[0])
 
@@ -44,7 +45,8 @@ class MarginRankingCriterion(Criterion):
                 self.gradInput[0][0] = -y
                 self.gradInput[1][0] = y
         else:
-            self.dist = self.dist or input[0].new()
+            if self.dist is None:
+                  self.dist = input[0].new()
             self.dist = self.dist.resize_as_(input[0]).copy_(input[0])
             dist = self.dist
 
@@ -52,7 +54,8 @@ class MarginRankingCriterion(Criterion):
             dist.mul_(-1).mul_(y)
             dist.add_(self.margin)
 
-            self.mask = self.mask or input[0].new()
+            if self.mask is None:
+                  self.mask = input[0].new()
             self.mask = self.mask.resize_as_(input[0]).copy_(dist)
             mask = self.mask
 

--- a/torch/legacy/nn/Max.py
+++ b/torch/legacy/nn/Max.py
@@ -18,8 +18,10 @@ class Max(Module):
         return dimension
 
     def _lazyInit(self):
-        self._output = self._output or self.output.new()
-        self._indices = self._indices or \
+        if self._output is None:
+              self._output = self.output.new()
+        if self._indices is None:
+              self._indices = \
            (torch.cuda.LongTensor() if torch.typename(self.output) == 'torch.cuda.FloatTensor' else torch.LongTensor())
 
     def updateOutput(self, input):

--- a/torch/legacy/nn/Min.py
+++ b/torch/legacy/nn/Min.py
@@ -18,8 +18,10 @@ class Min(Module):
         return dimension
 
     def _lazyInit(self):
-        self._output = self._output or self.output.new()
-        self._indices = self._indices or \
+        if self._output is None:
+              self._output = self.output.new()
+        if self._indices is None:
+              self._indices = \
            (torch.cuda.LongTensor() if torch.typename(self.output) == 'torch.cuda.FloatTensor' else torch.LongTensor())
 
     def updateOutput(self, input):

--- a/torch/legacy/nn/MixtureTable.py
+++ b/torch/legacy/nn/MixtureTable.py
@@ -26,9 +26,12 @@ class MixtureTable(Module):
         gaterInput, expertInputs = input
 
         # buffers
-        self._gaterView = self._gaterView or input[0].new()
-        self._expert = self._expert or input[0].new()
-        self._expertView = self._expertView or input[0].new()
+        if self._gaterView is None:
+              self._gaterView = input[0].new()
+        if self._expert is None:
+              self._expert = input[0].new()
+        if self._expertView is None:
+              self._expertView = input[0].new()
 
         self.dimG = 1
         batchSize = gaterInput.size(0)
@@ -79,9 +82,12 @@ class MixtureTable(Module):
         gaterGradInput, expertGradInputs = self.gradInput
 
         # buffers
-        self._sum = self._sum or input[0].new()
-        self._expertView2 = self._expertView2 or input[0].new()
-        self._expert2 = self._expert2 or input[0].new()
+        if self._sum is None:
+              self._sum = input[0].new()
+        if self._expertView2 is None:
+              self._expertView2 = input[0].new()
+        if self._expert2 is None:
+              self._expert2 = input[0].new()
 
         if self.table:
             if not self.backwardSetup:

--- a/torch/legacy/nn/Module.py
+++ b/torch/legacy/nn/Module.py
@@ -91,7 +91,7 @@ class Module(object):
         raise NotImplementedError
 
     def type(self, type=None, tensorCache=None):
-        if not type:
+        if type is None:
            return self._type
 
         tensorCache = tensorCache or {}

--- a/torch/legacy/nn/MulConstant.py
+++ b/torch/legacy/nn/MulConstant.py
@@ -21,7 +21,7 @@ class MulConstant(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         if self.inplace:

--- a/torch/legacy/nn/MultiLabelMarginCriterion.py
+++ b/torch/legacy/nn/MultiLabelMarginCriterion.py
@@ -10,7 +10,8 @@ class MultiLabelMarginCriterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         target = target.long()
         self._backend.MultiLabelMarginCriterion_updateOutput(
             self._backend.library_state,

--- a/torch/legacy/nn/MultiMarginCriterion.py
+++ b/torch/legacy/nn/MultiMarginCriterion.py
@@ -16,7 +16,8 @@ class MultiMarginCriterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         target = target.long()
         self._backend.MultiMarginCriterion_updateOutput(
             self._backend.library_state,

--- a/torch/legacy/nn/NarrowTable.py
+++ b/torch/legacy/nn/NarrowTable.py
@@ -26,7 +26,10 @@ class NarrowTable(Module):
 
         for i in range(len(input)):
             if i < self.offset or i >= self.offset + self.length:
-                self.gradInput[i] = recursiveResizeAs(self.gradInput[i] or torch.Tensor(), input[i])[0]
+                gi = self.gradInput[i]
+                if gi is None:
+                    gi = input[i].new()
+                self.gradInput[i] = recursiveResizeAs(gi, input[i])[0]
                 recursiveFill(self.gradInput[i], 0)
 
         return self.gradInput

--- a/torch/legacy/nn/Normalize.py
+++ b/torch/legacy/nn/Normalize.py
@@ -24,9 +24,12 @@ class Normalize(Module):
         assert input.dim() == 2
         input_size = input.size()
 
-        self._output = self._output or input.new()
-        self.norm = self.norm or input.new()
-        self.buffer = self.buffer or input.new()
+        if self._output is None:
+              self._output = input.new()
+        if self.norm is None:
+              self.norm = input.new()
+        if self.buffer is None:
+              self.buffer = input.new()
 
         self._output.resize_as_(input)
 
@@ -40,7 +43,8 @@ class Normalize(Module):
             torch.max(self.norm, self._indices, self.buffer, 1)
             self.norm.add_(self.eps)
         else:
-            self.normp = self.normp or input.new()
+            if self.normp is None:
+                  self.normp = input.new()
             if self.p % 2 != 0:
                 torch.abs(self.buffer, input).pow_(self.p)
             else:
@@ -62,8 +66,10 @@ class Normalize(Module):
         n = input.size(0) # batch size
         d = input.size(1) # dimensionality of vectors
 
-        self._gradInput = self._gradInput or input.new()
-        self.cross = self.cross or input.new()
+        if self._gradInput is None:
+              self._gradInput = input.new()
+        if self.cross is None:
+              self.cross = input.new()
         # compute diagonal term with gradOutput
         self._gradInput.resize_(n, d)
         if self.p == float('inf'):
@@ -98,7 +104,8 @@ class Normalize(Module):
         # instead of having a huge temporary matrix (b1*b2),
         #: the computations as b1*(b2*gradOutput). This avoids redundant
         # computation and also a huge buffer of size n*d^2
-        self.buffer2 = self.buffer2 or input.new() # nxd
+        if self.buffer2 is None:
+              self.buffer2 = input.new() # nxd
         torch.mul(self.buffer2, input, gradOutput)
         torch.sum(self.cross, self.buffer2, 1)
 

--- a/torch/legacy/nn/PReLU.py
+++ b/torch/legacy/nn/PReLU.py
@@ -35,8 +35,10 @@ class PReLU(Module):
         return self.gradInput
 
     def accGradParameters(self, input, gradOutput, scale=1):
-        self.gradWeightBuf = self.gradWeightBuf or input.new()
-        self.gradWeightBuf2 = self.gradWeightBuf2 or input.new()
+        if self.gradWeightBuf is None:
+              self.gradWeightBuf = input.new()
+        if self.gradWeightBuf2 is None:
+              self.gradWeightBuf2 = input.new()
         self._backend.PReLU_accGradParameters(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/PairwiseDistance.py
+++ b/torch/legacy/nn/PairwiseDistance.py
@@ -19,7 +19,8 @@ class PairwiseDistance(Module):
         self.output.resize_(1)
         assert input[0].dim() == 2
 
-        self.diff = self.diff or input[0].new()
+        if self.diff is None:
+              self.diff = input[0].new()
 
         torch.add(self.diff, input[0], -1, input[1]).abs_()
 
@@ -36,8 +37,12 @@ class PairwiseDistance(Module):
         if len(self.gradInput) != 2:
             self.gradInput[:] = [None, None]
 
-        self.gradInput[0] = (self.gradInput[0] or input[0].new()).resize_(input[0].size())
-        self.gradInput[1] = (self.gradInput[1] or input[1].new()).resize_(input[1].size())
+        if self.gradInput[0] is None:
+              self.gradInput[0] = input[0].new()
+        self.gradInput[0].resize_(input[0].size())
+        if self.gradInput[1] is None:
+              self.gradInput[1] = input[1].new()
+        self.gradInput[1].resize_(input[1].size())
         self.gradInput[0].copy_(input[0])
         self.gradInput[0].add_(-1, input[1])
 
@@ -49,7 +54,8 @@ class PairwiseDistance(Module):
             if self.norm > 2:
                 self.gradInput[0].mul_(self.gradInput[0].abs().pow_(self.norm-2))
 
-            self.outExpand = self.outExpand or self.output.new()
+            if self.outExpand is None:
+                  self.outExpand = self.output.new()
             self.outExpand.resize_(self.output.size(0), 1)
             self.outExpand.copy_(self.output)
             self.outExpand.add_(1e-6)  # Prevent divide by zero errors
@@ -57,8 +63,10 @@ class PairwiseDistance(Module):
             self.gradInput[0].mul_(self.outExpand.expand(self.gradInput[0].size(0),
                 self.gradInput[0].size(1)))
 
-        self.grad = self.grad or gradOutput.new()
-        self.ones = self.ones or gradOutput.new()
+        if self.grad is None:
+              self.grad = gradOutput.new()
+        if self.ones is None:
+              self.ones = gradOutput.new()
 
         self.grad.resize_as_(input[0]).zero_()
         self.ones.resize_(input[0].size(1)).fill_(1)

--- a/torch/legacy/nn/Reshape.py
+++ b/torch/legacy/nn/Reshape.py
@@ -22,7 +22,8 @@ class Reshape(Module):
 
     def updateOutput(self, input):
         if not input.is_contiguous():
-            self._input = self._input or input.new()
+            if self._input is None:
+                  self._input = input.new()
             self._input.resize_as_(input)
             self._input.copy_(input)
             input = self._input
@@ -34,7 +35,8 @@ class Reshape(Module):
 
     def updateGradInput(self, input, gradOutput):
         if not gradOutput.is_contiguous():
-            self._gradOutput = self._gradOutput or gradOutput.new()
+            if self._gradOutput is None:
+                  self._gradOutput = gradOutput.new()
             self._gradOutput.resize_as_(gradOutput)
             self._gradOutput.copy_(gradOutput)
             gradOutput = self._gradOutput

--- a/torch/legacy/nn/SmoothL1Criterion.py
+++ b/torch/legacy/nn/SmoothL1Criterion.py
@@ -9,7 +9,8 @@ class SmoothL1Criterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.SmoothL1Criterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/SoftMarginCriterion.py
+++ b/torch/legacy/nn/SoftMarginCriterion.py
@@ -9,7 +9,8 @@ class SoftMarginCriterion(Criterion):
         self.output_tensor = None
 
     def updateOutput(self, input, target):
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.SoftMarginCriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/SoftMin.py
+++ b/torch/legacy/nn/SoftMin.py
@@ -9,7 +9,8 @@ class SoftMin(Module):
         self.mininput = None
 
     def updateOutput(self, input):
-        self.mininput = self.mininput or input.new()
+        if self.mininput is None:
+              self.mininput = input.new()
         self.mininput.resize_as_(input).copy_(input).mul_(-1)
         self._backend.SoftMax_updateOutput(
             self._backend.library_state,
@@ -19,7 +20,8 @@ class SoftMin(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        self.mininput = self.mininput or input.new()
+        if self.mininput is None:
+              self.mininput = input.new()
         self.mininput.resize_as_(input).copy_(input).mul_(-1)
         self._backend.SoftMax_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/SoftSign.py
+++ b/torch/legacy/nn/SoftSign.py
@@ -10,13 +10,15 @@ class SoftSign(Module):
         self.tempgrad = None
 
     def updateOutput(self, input):
-        self.temp = self.temp or input.new()
+        if self.temp is None:
+              self.temp = input.new()
         self.temp.resize_as_(input).copy_(input).abs_().add_(1)
         self.output.resize_as_(input).copy_(input).div_(self.temp)
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        self.tempgrad = self.tempgrad or input.new()
+        if self.tempgrad is None:
+              self.tempgrad = input.new()
         self.tempgrad.resize_as_(self.output).copy_(input).abs_().add_(1).mul_(self.tempgrad)
         self.gradInput.resize_as_(input).copy_(gradOutput).div_(self.tempgrad)
         return self.gradInput

--- a/torch/legacy/nn/SpatialAdaptiveMaxPooling.py
+++ b/torch/legacy/nn/SpatialAdaptiveMaxPooling.py
@@ -11,7 +11,8 @@ class SpatialAdaptiveMaxPooling(Module):
         self.indices = None
 
     def updateOutput(self, input):
-        self.indices = self.indices or input.new()
+        if self.indices is None:
+              self.indices = input.new()
         self.indices = self.indices.long()
         self._backend.SpatialAdaptiveMaxPooling_updateOutput(
             self._backend.library_state,

--- a/torch/legacy/nn/SpatialAveragePooling.py
+++ b/torch/legacy/nn/SpatialAveragePooling.py
@@ -51,7 +51,7 @@ class SpatialAveragePooling(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if self.gradInput:
+        if self.gradInput is not None:
             self._backend.SpatialAveragePooling_updateGradInput(
                 self._backend.library_state,
                 input,

--- a/torch/legacy/nn/SpatialContrastiveNormalization.py
+++ b/torch/legacy/nn/SpatialContrastiveNormalization.py
@@ -11,7 +11,8 @@ class SpatialContrastiveNormalization(Module):
 
         # get args
         self.nInputPlane = nInputPlane
-        self.kernel = kernel or torch.Tensor(9, 9).fill_(1)
+        if kernel is None:
+              self.kernel = torch.Tensor(9, 9).fill_(1)
         self.threshold = threshold
         self.thresval = thresval or threshold
         kdim = self.kernel.ndimension()

--- a/torch/legacy/nn/SpatialConvolution.py
+++ b/torch/legacy/nn/SpatialConvolution.py
@@ -16,7 +16,7 @@ class SpatialConvolution(Module):
         self.dW = dW
         self.dH = dH
         self.padW = padW
-        self.padH = padH or self.padW
+        self.padH = padH if padH is not None else padW
 
         self.weight = torch.Tensor(nOutputPlane, nInputPlane, kH, kW)
         self.bias = torch.Tensor(nOutputPlane)
@@ -46,13 +46,15 @@ class SpatialConvolution(Module):
 
     def _makeContiguous(self, input, gradOutput=None):
         if not input.is_contiguous():
-           self._input = self._input or input.new()
+           if self._input is None:
+                  self._input = input.new()
            self._input.resize_as_(input).copy_(input)
            input = self._input
 
         if gradOutput is not None:
             if not gradOutput.is_contiguous():
-                self._gradOutput = self._gradOutput or gradOutput.new()
+                if self._gradOutput is None:
+                      self._gradOutput = gradOutput.new()
                 self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
                 gradOutput = self._gradOutput
             return input, gradOutput
@@ -60,9 +62,9 @@ class SpatialConvolution(Module):
         return input
 
     def _init(self):
-        if not self.finput:
+        if self.finput is None:
             self.finput = self.weight.new()
-        if not self.fgradInput:
+        if self.fgradInput is None:
             self.fgradInput = self.weight.new()
 
     # function to re-view the weight layout in a way that would make the MM ops happy
@@ -97,7 +99,7 @@ class SpatialConvolution(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         self._init()
@@ -154,7 +156,7 @@ class SpatialConvolution(Module):
             s += ', {}, {}'.format(self.padW, self.padH)
 
         s += ')'
-        if not self.bias:
+        if self.bias is None:
            s += ' without bias'
         return s
 

--- a/torch/legacy/nn/SpatialCrossMapLRN.py
+++ b/torch/legacy/nn/SpatialCrossMapLRN.py
@@ -18,7 +18,8 @@ class SpatialCrossMapLRN(Module):
     def updateOutput(self, input):
         assert input.dim() == 4
 
-        self.scale = self.scale or input.new()
+        if self.scale is None:
+              self.scale = input.new()
         if input.type() == 'torch.cuda.FloatTensor':
             self._backend.SpatialCrossMapLRN_updateOutput(
                 self._backend.library_state,
@@ -95,8 +96,10 @@ class SpatialCrossMapLRN(Module):
             inputHeight = input.size(2)
             inputWidth  = input.size(3)
 
-            self.paddedRatio = self.paddedRatio or input.new()
-            self.accumRatio = self.accumRatio or input.new()
+            if self.paddedRatio is None:
+                  self.paddedRatio = input.new()
+            if self.accumRatio is None:
+                  self.accumRatio = input.new()
             self.paddedRatio.resize_(channels + self.size - 1, inputHeight, inputWidth)
             self.accumRatio.resize_(inputHeight, inputWidth)
 

--- a/torch/legacy/nn/SpatialDilatedConvolution.py
+++ b/torch/legacy/nn/SpatialDilatedConvolution.py
@@ -7,11 +7,13 @@ class SpatialDilatedConvolution(SpatialConvolution):
         super(SpatialDilatedConvolution, self).__init__(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
 
         self.dilationH = dilationH
-        self.dilationW = dilationW or dilationH or 1
+        self.dilationW = dilationW if dilationW is not None else dilationH
 
     def updateOutput(self, input):
-        self.finput = self.finput or self.weight.new()
-        self.fgradInput = self.fgradInput or self.weight.new()
+        if self.finput is None:
+              self.finput = self.weight.new()
+        if self.fgradInput is None:
+              self.fgradInput = self.weight.new()
         input = self._makeContiguous(input)
         self._backend.SpatialDilatedConvolution_updateOutput(
             self._backend.library_state,
@@ -29,11 +31,12 @@ class SpatialDilatedConvolution(SpatialConvolution):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         input, gradOutput = self._makeContiguous(input, gradOutput)
-        self.fgradInput = self.fgradInput or self.weight.new()
+        if self.fgradInput is None:
+              self.fgradInput = self.weight.new()
         self._backend.SpatialDilatedConvolution_updateGradInput(
             self._backend.library_state,
             input,
@@ -50,7 +53,8 @@ class SpatialDilatedConvolution(SpatialConvolution):
 
     def accGradParameters(self, input, gradOutput, scale=1):
         input, gradOutput = self._makeContiguous(input, gradOutput)
-        self.fgradInput = self.fgradInput or self.weight.new()
+        if self.fgradInput is None:
+              self.fgradInput = self.weight.new()
         self._backend.SpatialDilatedConvolution_accGradParameters(
             self._backend.library_state,
             input,
@@ -78,7 +82,7 @@ class SpatialDilatedConvolution(SpatialConvolution):
         s += ', {}, {}'.format(self.dilationW, self.dilationH)
 
         s += ')'
-        if not self.bias:
+        if self.bias is None:
            s += ' without bias'
         return s
 

--- a/torch/legacy/nn/SpatialDivisiveNormalization.py
+++ b/torch/legacy/nn/SpatialDivisiveNormalization.py
@@ -20,9 +20,11 @@ class SpatialDivisiveNormalization(Module):
 
         # get args
         self.nInputPlane = nInputPlane
-        self.kernel = kernel or torch.Tensor(9, 9).fill_(1)
+        if kernel is None:
+            kernel = torch.Tensor(9, 9).fill_(1)
+        self.kernel = kernel
         self.threshold = threshold
-        self.thresval = thresval or threshold or 1e-4
+        self.thresval = thresval if thresval is not None else threshold
         kdim = self.kernel.ndimension()
 
         # check args
@@ -101,10 +103,12 @@ class SpatialDivisiveNormalization(Module):
         # compute side coefficients
         dim = input.dim()
         if self.localstds.dim() != self.coef.dim() or (input.size(dim-1) != self.coef.size(dim-1)) or (input.size(dim-2) != self.coef.size(dim-2)):
-            self.ones = self.ones or input.new()
+            if self.ones is None:
+                  self.ones = input.new()
             self.ones.resize_as_(input[0:1]).fill_(1)
             coef = self.meanestimator.updateOutput(self.ones).squeeze(0)
-            self._coef = self._coef or input.new()
+            if self._coef is None:
+              self._coef = input.new()
             self._coef.resize_as_(coef).copy_(coef) # make contiguous for view
             self.coef = self._coef.view(1, *self._coef.size()).expand_as(self.localstds)
 

--- a/torch/legacy/nn/SpatialFractionalMaxPooling.py
+++ b/torch/legacy/nn/SpatialFractionalMaxPooling.py
@@ -92,7 +92,8 @@ class SpatialFractionalMaxPooling(Module):
         return self
 
     def updateOutput(self, input):
-        self.indices = self.indices or input.new()
+        if self.indices is None:
+              self.indices = input.new()
         self.indices = self.indices.long()
         self._initSampleBuffer(input)
         outW, outH = self._getOutputSizes(input)

--- a/torch/legacy/nn/SpatialFullConvolution.py
+++ b/torch/legacy/nn/SpatialFullConvolution.py
@@ -15,7 +15,7 @@ class SpatialFullConvolution(Module):
         self.dW = dW
         self.dH = dH
         self.padW = padW
-        self.padH = padH or padW or 0
+        self.padH = padH if padH is not None else padW
         self.adjW = adjW
         self.adjH = adjH
 
@@ -54,13 +54,15 @@ class SpatialFullConvolution(Module):
 
     def _makeContiguous(self, input, gradOutput=None):
         if not input.is_contiguous():
-           self._input = self._input or input.new()
+           if self._input is None:
+                  self._input = input.new()
            self._input.resize_as_(input).copy_(input)
            input = self._input
 
         if gradOutput is not None:
             if not gradOutput.is_contiguous():
-                self._gradOutput = self._gradOutput or gradOutput.new()
+                if self._gradOutput is None:
+                      self._gradOutput = gradOutput.new()
                 self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
                 gradOutput = self._gradOutput
             return input, gradOutput
@@ -84,11 +86,15 @@ class SpatialFullConvolution(Module):
             tW = targetTensor.size(tDims-1)
             adjW = self._calculateAdj(tW, self.kW, self.padW, self.dW)
             adjH = self._calculateAdj(tH, self.kH, self.padH, self.dH)
-            self.finput = self.finput or input[0].new()
-            self.fgradInput = self.fgradInput or input[0].new()
+            if self.finput is None:
+                  self.finput = input[0].new()
+            if self.fgradInput is None:
+                  self.fgradInput = input[0].new()
         else:
-            self.finput = self.finput or input.new()
-            self.fgradInput = self.fgradInput or input.new()
+            if self.finput is None:
+                  self.finput = input.new()
+            if self.fgradInput is None:
+                  self.fgradInput = input.new()
 
 
         inputTensor = self._makeContiguous(inputTensor)
@@ -108,7 +114,7 @@ class SpatialFullConvolution(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
         inputTensor = input
         adjW, adjH = self.adjW, self.adjH
@@ -143,7 +149,8 @@ class SpatialFullConvolution(Module):
 
         if isinstance(input, list):
             # Create a zero tensor to be expanded and used as gradInput[1].
-            self.zeroScalar = self.zeroScalar or input[1].new(1).zero_()
+            if self.zeroScalar is None:
+                  self.zeroScalar = input[1].new(1).zero_()
             self.ones.resize_(input[1].dim()).fill_(1)
             zeroTensor =  self.zeroScalar.view_as(self.ones).expand_as(input[1])
             self.gradInput = [self.gradInput, zeroTensor]

--- a/torch/legacy/nn/SpatialMaxPooling.py
+++ b/torch/legacy/nn/SpatialMaxPooling.py
@@ -30,7 +30,8 @@ class SpatialMaxPooling(Module):
         return self
 
     def updateOutput(self, input):
-        self.indices = self.indices or input.new()
+        if self.indices is None:
+              self.indices = input.new()
         self.indices = self.indices.long()
 
         dims = input.dim()

--- a/torch/legacy/nn/SpatialReflectionPadding.py
+++ b/torch/legacy/nn/SpatialReflectionPadding.py
@@ -6,9 +6,9 @@ class SpatialReflectionPadding(Module):
     def __init__(self, pad_l, pad_r=None, pad_t=None, pad_b=None):
         super(SpatialReflectionPadding, self).__init__()
         self.pad_l = pad_l
-        self.pad_r = pad_r or self.pad_l
-        self.pad_t = pad_t or self.pad_l
-        self.pad_b = pad_b or self.pad_l
+        self.pad_r = pad_r if pad_r is not None else pad_l
+        self.pad_t = pad_t if pad_t is not None else pad_l
+        self.pad_b = pad_b if pad_b is not None else pad_l
 
     def updateOutput(self, input):
         assert input.dim() == 4

--- a/torch/legacy/nn/SpatialReplicationPadding.py
+++ b/torch/legacy/nn/SpatialReplicationPadding.py
@@ -6,9 +6,9 @@ class SpatialReplicationPadding(Module):
     def __init__(self, pad_l, pad_r=None, pad_t=None, pad_b=None):
         super(SpatialReplicationPadding, self).__init__()
         self.pad_l = pad_l
-        self.pad_r = pad_r or self.pad_l
-        self.pad_t = pad_t or self.pad_l
-        self.pad_b = pad_b or self.pad_l
+        self.pad_r = pad_r if pad_r is not None else pad_l
+        self.pad_t = pad_t if pad_t is not None else pad_l
+        self.pad_b = pad_b if pad_b is not None else pad_l
 
     def updateOutput(self, input):
         assert input.dim() == 4

--- a/torch/legacy/nn/SpatialSubSampling.py
+++ b/torch/legacy/nn/SpatialSubSampling.py
@@ -44,7 +44,7 @@ class SpatialSubSampling(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
 
         self._backend.SpatialSubSampling_updateGradInput(

--- a/torch/legacy/nn/SpatialSubtractiveNormalization.py
+++ b/torch/legacy/nn/SpatialSubtractiveNormalization.py
@@ -17,7 +17,9 @@ class SpatialSubtractiveNormalization(Module):
 
         # get args
         self.nInputPlane = nInputPlane
-        self.kernel = kernel or torch.Tensor(9, 9).fill_(1)
+        if kernel is None:
+            kernel = torch.Tensor(9, 9).fill_(1)
+        self.kernel = kernel
         kdim = self.kernel.ndimension()
 
         # check args
@@ -75,8 +77,10 @@ class SpatialSubtractiveNormalization(Module):
         # compute side coefficients
         dim = input.dim()
         if input.dim() + 1 != self.coef.dim() or (input.size(dim-1) != self.coef.size(dim-1)) or (input.size(dim-2) != self.coef.size(dim-2)):
-            self.ones = self.ones or input.new()
-            self._coef = self._coef or self.coef.new()
+            if self.ones is None:
+                self.ones = input.new()
+            if self._coef is None:
+                self._coef = self.coef.new()
 
             self.ones.resize_as_(input[0:1]).fill_(1)
             coef = self.meanestimator.updateOutput(self.ones).squeeze(0)

--- a/torch/legacy/nn/SpatialZeroPadding.py
+++ b/torch/legacy/nn/SpatialZeroPadding.py
@@ -6,9 +6,9 @@ class SpatialZeroPadding(Module):
     def __init__(self, pad_l, pad_r=None, pad_t=None, pad_b=None):
         super(SpatialZeroPadding, self).__init__()
         self.pad_l = pad_l
-        self.pad_r = pad_r or pad_l
-        self.pad_t = pad_t or pad_l
-        self.pad_b = pad_b or pad_l
+        self.pad_r = pad_r if pad_r is not None else pad_l
+        self.pad_t = pad_t if pad_t is not None else pad_l
+        self.pad_b = pad_b if pad_b is not None else pad_l
 
     def updateOutput(self, input):
         assert input.dim() == 4

--- a/torch/legacy/nn/SplitTable.py
+++ b/torch/legacy/nn/SplitTable.py
@@ -26,7 +26,7 @@ class SplitTable(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
         dimension = self._getPositiveDimension(input)
         slices = input.size(dimension)

--- a/torch/legacy/nn/Sum.py
+++ b/torch/legacy/nn/Sum.py
@@ -36,7 +36,8 @@ class Sum(Module):
         size = list(input.size())
         size[dimension] = 1
         if not gradOutput.is_contiguous():
-            self._gradOutput = self._gradOutput or gradOutput.new()
+            if self._gradOutput is None:
+                  self._gradOutput = gradOutput.new()
             self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
             gradOutput = self._gradOutput
 

--- a/torch/legacy/nn/TemporalConvolution.py
+++ b/torch/legacy/nn/TemporalConvolution.py
@@ -43,7 +43,7 @@ class TemporalConvolution(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
         self._backend.TemporalConvolution_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/TemporalMaxPooling.py
+++ b/torch/legacy/nn/TemporalMaxPooling.py
@@ -11,7 +11,8 @@ class TemporalMaxPooling(Module):
         self.indices = None
 
     def updateOutput(self, input):
-        self.indices = self.indices or input.new()
+        if self.indices is None:
+              self.indices = input.new()
         self._backend.TemporalMaxPooling_updateOutput(
             self._backend.library_state,
             input,
@@ -24,7 +25,7 @@ class TemporalMaxPooling(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
              return
         self._backend.TemporalMaxPooling_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/TemporalSubSampling.py
+++ b/torch/legacy/nn/TemporalSubSampling.py
@@ -42,7 +42,7 @@ class TemporalSubSampling(Module):
 
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
             return
         self._backend.TemporalSubSampling_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/Threshold.py
+++ b/torch/legacy/nn/Threshold.py
@@ -9,7 +9,7 @@ class Threshold(Module):
         self.value = value
 
         # default for inplace is False
-        self.inplace = inplace or False
+        self.inplace = inplace
         self.validateParameters()
 
     def updateOutput(self, input):

--- a/torch/legacy/nn/View.py
+++ b/torch/legacy/nn/View.py
@@ -27,13 +27,15 @@ class View(Module):
         self.resetSize(*args)
 
     def updateOutput(self, input):
-        self.output = self.output or input.new()
+        if self.output is None:
+              self.output = input.new()
         self.output = input.view(self.size)
         return self.output
 
 
     def updateGradInput(self, input, gradOutput):
-        self.gradInput = self.gradInput or gradOutput.new()
+        if self.gradInput is None:
+              self.gradInput = gradOutput.new()
         self.gradInput = gradOutput.view(input.size())
         return self.gradInput
 

--- a/torch/legacy/nn/VolumetricFullConvolution.py
+++ b/torch/legacy/nn/VolumetricFullConvolution.py
@@ -57,13 +57,15 @@ class VolumetricFullConvolution(Module):
 
     def _makeContiguous(self, input, gradOutput=None):
         if not input.is_contiguous():
-           self._input = self._input or input.new()
+           if self._input is None:
+                  self._input = input.new()
            self._input.resize_as_(input).copy_(input)
            input = self._input
 
         if gradOutput is not None:
             if not gradOutput.is_contiguous():
-                self._gradOutput = self._gradOutput or gradOutput.new()
+                if self._gradOutput is None:
+                      self._gradOutput = gradOutput.new()
                 self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
                 gradOutput = self._gradOutput
             return input, gradOutput
@@ -142,7 +144,8 @@ class VolumetricFullConvolution(Module):
 
         if isinstance(input, list):
             # Create a zero tensor to be expanded and used as gradInput[1].
-            self.zeroScalar = self.zeroScalar or input[1].new(1).zero_()
+            if self.zeroScalar is None:
+                  self.zeroScalar = input[1].new(1).zero_()
             self.ones.resize_(input[1].dim()).fill_(1)
             zeroTensor =  self.zeroScalar.view(self.ones.tolist()).expand_as(input[1])
             self.gradInput = [self.gradInput, zeroTensor]

--- a/torch/legacy/nn/VolumetricMaxPooling.py
+++ b/torch/legacy/nn/VolumetricMaxPooling.py
@@ -35,7 +35,8 @@ class VolumetricMaxPooling(Module):
         self.iheight = input.size(dims-2)
         self.iwidth = input.size(dims-1)
 
-        self.indices = self.indices or input.new()
+        if self.indices is None:
+              self.indices = input.new()
         self.indices = self.indices.long()
         self._backend.VolumetricMaxPooling_updateOutput(
             self._backend.library_state,

--- a/torch/legacy/nn/WeightedEuclidean.py
+++ b/torch/legacy/nn/WeightedEuclidean.py
@@ -51,16 +51,25 @@ class WeightedEuclidean(Module):
 
     def updateOutput(self, input):
         # lazy-initialize
-        self._diagCov = self._diagCov or self.output.new()
+        if self._diagCov is None:
+              self._diagCov = self.output.new()
 
-        self._input = self._input or input.new()
-        self._weight = self._weight or self.weight.new()
-        self._expand = self._expand or self.output.new()
-        self._expand2 = self._expand or self.output.new()
-        self._expand3 = self._expand3 or self.output.new()
-        self._repeat = self._repeat or self.output.new()
-        self._repeat2 = self._repeat2 or self.output.new()
-        self._repeat3 = self._repeat3 or self.output.new()
+        if self._input is None:
+              self._input = input.new()
+        if self._weight is None:
+              self._weight = self.weight.new()
+        if self._expand is None:
+              self._expand = self.output.new()
+        if self._expand2 is None:
+              self._expand2 = self.output.new()
+        if self._expand3 is None:
+              self._expand3 = self.output.new()
+        if self._repeat is None:
+              self._repeat = self.output.new()
+        if self._repeat2 is None:
+              self._repeat2 = self.output.new()
+        if self._repeat3 is None:
+              self._repeat3 = self.output.new()
 
         inputSize, outputSize = self.weight.size(0), self.weight.size(1)
 
@@ -106,13 +115,17 @@ class WeightedEuclidean(Module):
         return self.output
 
     def updateGradInput(self, input, gradOutput):
-        if not self.gradInput:
+        if self.gradInput is None:
            return
 
-        self._div = self._div or input.new()
-        self._output = self._output or self.output.new()
-        self._expand4 = self._expand4 or input.new()
-        self._gradOutput = self._gradOutput or input.new()
+        if self._div is None:
+              self._div = input.new()
+        if self._output is None:
+              self._output = self.output.new()
+        if self._expand4 is None:
+              self._expand4 = input.new()
+        if self._gradOutput is None:
+              self._gradOutput = input.new()
 
         if not self.fastBackward:
            self.updateOutput(input)
@@ -193,7 +206,8 @@ class WeightedEuclidean(Module):
 
             self.gradDiagCov.add_(self._repeat2)
         elif input.dim() == 2:
-            self._sum = self._sum or input.new()
+            if self._sum is None:
+                  self._sum = input.new()
             torch.sum(self._sum, self._repeat2, 0)
             self._sum.resize_(inputSize, outputSize)
             self.gradWeight.add_(-scale, self._sum)

--- a/torch/legacy/nn/WeightedMSECriterion.py
+++ b/torch/legacy/nn/WeightedMSECriterion.py
@@ -11,7 +11,8 @@ class WeightedMSECriterion(Criterion):
         self.sizeAverage = sizeAverage
 
     def updateOutput(self, input, target):
-        self.buffer = self.buffer or input.new()
+        if self.buffer is None:
+              self.buffer = input.new()
         self.buffer.resize_as_(input).copy_(target)
         if input.dim() - 1 == self.weight.dim():
             for i in range(input.size(0)):
@@ -19,7 +20,8 @@ class WeightedMSECriterion(Criterion):
         else:
             self.buffer.mul_(self.weight)
 
-        self.output_tensor = self.output_tensor or input.new(1)
+        if self.output_tensor is None:
+              self.output_tensor = input.new(1)
         self._backend.MSECriterion_updateOutput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/utils.py
+++ b/torch/legacy/nn/utils.py
@@ -110,7 +110,8 @@ def addSingletondimension(*args):
         return view.unsqueeze_(dim)
 
 def contiguousView(output, input, *args):
-    output = output or input.new()
+    if output is None:
+        output = input.new()
     if input.is_contiguous():
         output.set_(input.view(*args))
     else:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -164,9 +164,11 @@ class Module(object):
     def cuda(self, device_id=None):
         return self._apply(lambda t: t.cuda(device_id))
 
-
     def cpu(self, device_id=None):
         return self._apply(lambda t: t.cpu())
+
+    def type(self, dst_type):
+        return self._apply(lambda t: t.type(dst_type))
 
     def float(self):
         return self._apply(lambda t: t.float())

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -6,3 +6,13 @@ from .asgd import ASGD
 from .sgd import SGD
 from .rprop import Rprop
 from .rmsprop import RMSprop
+
+del adadelta
+del adagrad
+del adam
+del adamax
+del asgd
+del sgd
+del rprop
+del rmsprop
+del optimizer


### PR DESCRIPTION
* Remove `adam`, `sgd`, etc. as attributes of `torch.optim` package
* Add `torch.cuda.set_device` (#260)
* Implement `__len__` for tensors (#270)
* Implement `.type()` for `torch.nn` modules (#272)
* Make `torch.randperm` always return a `torch.LongTensor` (#267)
* Improve cuDNN detection at build time (#280)
* Raise `IndexError` in tensors' `__getitem__`. (needed in #277)
* Allow saving dynamically defined modules (#278)
* Import most common packages (cuda, autograd, nn, optim) by default (#283) 