### PR TITLE
Allow returning changed gradients from the hooks

### DIFF
--- a/docs/tensor.md
+++ b/docs/tensor.md
@@ -163,11 +163,11 @@ This magical behavior is internally obtained by good usage of the `stride()` and
 ```python
 >>> x = torch.Tensor(5).zero_()
 >>> print(x)
-0
-0
-0
-0
-0
+ 0
+ 0
+ 0
+ 0
+ 0
 [torch.FloatTensor of dimension 5]
 >>> x.narrow(0, 1, 2).fill_(1)
 >>> # narrow() returns a Tensor referencing the same Storage as x
@@ -175,7 +175,16 @@ This magical behavior is internally obtained by good usage of the `stride()` and
  0
  1
  1
- 1
+ 0
+ 0
+[torch.FloatTensor of dimension 5]
+>>> # same thing can be achieved with slice indexing
+>>> x[1:3] = 2
+>>> print(x)
+ 0
+ 2
+ 2
+ 0
  0
 [torch.FloatTensor of dimension 5]
 ```
@@ -241,7 +250,7 @@ The tensor size will be `sz1 x sz2 x sx3 x sz4 x sz5 x ...`.
 ### torch.Tensor(sizes) ###
 
 Create a tensor of any number of dimensions. `sizes` gives the size in each dimension of
-the tensor and is of type `torch.Size`. 
+the tensor and is of type `torch.Size`.
 
 ```python
 Example, create a 4D 4x4x3x2 tensor:
@@ -368,7 +377,7 @@ Returns True if the passed-in object is a `Storage` (of any type). Returns `Fals
 
 When you create a `torch.cuda.*Tensor`, it is allocated on the current GPU.
 However, you could allocate it on another GPU as well, using the `with torch.cuda.device(id)` context.
-All allocations within this context will be placed on the GPU `id`. 
+All allocations within this context will be placed on the GPU `id`.
 
 Once `Tensor`s are allocated, you can do operations on them from any GPU context, and the results
 will be placed on the same device as where the source `Tensor` is located.
@@ -403,6 +412,6 @@ with torch.cuda.device(1):
     # even within a context, you can give a GPU id to the .cuda call
     c = torch.randn(2).cuda(2)
 	# c.get_device() == 2
-	
+
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,20 @@ class build_module(Command):
 
 class build_ext(setuptools.command.build_ext.build_ext):
     def run(self):
+        # Print build options
+        if WITH_NUMPY:
+            print('-- Building with NumPy bindings')
+        else:
+            print('-- NumPy not found')
+        if WITH_CUDNN:
+            print('-- Detected cuDNN at ' + CUDNN_LIB_DIR + ', ' + CUDNN_INCLUDE_DIR)
+        else:
+            print('-- Not using cuDNN')
+        if WITH_CUDA:
+            print('-- Detected CUDA at ' + CUDA_HOME)
+        else:
+            print('-- Not using CUDA')
+
         # cwrap depends on pyyaml, so we can't import it earlier
         from tools.cwrap import cwrap
         from tools.cwrap.plugins.THPPlugin import THPPlugin
@@ -178,8 +192,9 @@ try:
     import numpy as np
     include_dirs += [np.get_include()]
     extra_compile_args += ['-DWITH_NUMPY']
+    WITH_NUMPY = True
 except ImportError:
-    pass
+    WITH_NUMPY = False
 
 if WITH_CUDA:
     cuda_lib_dirs = ['lib64', 'lib']

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -398,21 +398,32 @@ class TestAutograd(TestCase):
                                     for arg in args)
             self.assertEqual(fn(*args).data, fn(*unpacked_args))
 
-        def test_blas(fn, x, y, z):
+        def test_blas_add(fn, x, y, z):
             # Checks all signatures
             compare(fn, x, y, z)
             compare(fn, 0.5, x, y, z)
             compare(fn, 0.5, x, 0.25, y, z)
 
-        test_blas(torch.addmm, Variable(torch.randn(2, 4)),
+        def test_blas(fn, x, y):
+            compare(fn, x, y)
+
+        test_blas(torch.mm, Variable(torch.randn(2, 10)),
+                Variable(torch.randn(10, 4)))
+        test_blas_add(torch.addmm, Variable(torch.randn(2, 4)),
                 Variable(torch.randn(2, 10)), Variable(torch.randn(10, 4)))
-        test_blas(torch.addbmm, Variable(torch.randn(2, 4)),
+        test_blas(torch.bmm, Variable(torch.randn(4, 2, 10)),
+                Variable(torch.randn(4, 10, 4)))
+        test_blas_add(torch.addbmm, Variable(torch.randn(2, 4)),
                 Variable(torch.randn(4, 2, 10)), Variable(torch.randn(4, 10, 4)))
-        test_blas(torch.baddbmm, Variable(torch.randn(4, 2, 4)),
+        test_blas_add(torch.baddbmm, Variable(torch.randn(4, 2, 4)),
                 Variable(torch.randn(4, 2, 10)), Variable(torch.randn(4, 10, 4)))
-        test_blas(torch.addmv, Variable(torch.randn(2)),
+        test_blas(torch.mv, Variable(torch.randn(2, 10)),
+                Variable(torch.randn(10)))
+        test_blas_add(torch.addmv, Variable(torch.randn(2)),
                 Variable(torch.randn(2, 10)), Variable(torch.randn(10)))
-        test_blas(torch.addr, Variable(torch.randn(5, 6)),
+        test_blas(torch.ger, Variable(torch.randn(5)),
+                Variable(torch.randn(6)))
+        test_blas_add(torch.addr, Variable(torch.randn(5, 6)),
                 Variable(torch.randn(5)), Variable(torch.randn(6)))
 
     def test_save_none_for_backward(self):

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -7,7 +7,7 @@ from .cuda import WITH_CUDA, CUDA_HOME
 WITH_CUDNN = False
 CUDNN_LIB_DIR = None
 CUDNN_INCLUDE_DIR = None
-if WITH_CUDA and not check_env_flag('WITH_CUDNN'):
+if WITH_CUDA and not check_env_flag('NO_CUDNN'):
     lib_paths = list(filter(bool, [
         os.getenv('CUDNN_LIB_DIR'),
         os.path.join(CUDA_HOME, 'lib'),

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -21,15 +21,15 @@ class Function(_C._FunctionBase):
         self.non_differentiable = args
 
     def register_hook(self, name, hook):
-        self.backward_hooks = self.backward_hooks or OrderedDict()
-        assert name not in self.backward_hooks, \
+        self._backward_hooks = self._backward_hooks or OrderedDict()
+        assert name not in self._backward_hooks, \
             "Trying to register a second hook with name {}".format(name)
-        self.backward_hooks[name] = hook
+        self._backward_hooks[name] = hook
 
     def remove_hook(self, name):
-        assert self.backward_hooks and name in self.backward_hooks, \
+        assert self._backward_hooks and name in self._backward_hooks, \
             "Trying to remove an inexistent hook with name {}".format(name)
-        del self.backward_hooks[name]
+        del self._backward_hooks[name]
 
     def forward(self, *input):
         raise NotImplementedError

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -402,7 +402,7 @@ class Variable(_C._VariableBase):
     def bmm(self, batch):
         output = Variable(self.data.new(self.data.size(0), self.data.size(1),
                 batch.data.size(2)))
-        return self._static_blas(Addbmm, (output, 0, 1, self, batch), False)
+        return self._static_blas(Baddbmm, (output, 0, 1, self, batch), False)
 
     def mv(self, vector):
         output = Variable(self.data.new(self.data.size(0)))

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -1,3 +1,4 @@
+import torch._C as _C
 import ctypes
 import warnings
 import torch.cuda
@@ -51,6 +52,12 @@ def is_acceptable(tensor):
                     'win32': 'PATH'
                 }.get(sys.platform, 'LD_LIBRARY_PATH')))
             return False
+    if not _C.has_cudnn:
+        warnings.warn("cuDNN library has been detected, but your pytorch "
+                "installation was compiled without support for it. You "
+                "might want to rebuild pytorch, making sure the library "
+                "is visible to the build system.")
+        return False
     return True
 
 __cudnn_version = []

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -835,7 +835,12 @@ PyMODINIT_FUNC PyInit__C()
 
 #ifdef WITH_CUDNN
   ASSERT_TRUE(THCUDNNModule_initModule(module));
+  PyObject *has_cudnn = Py_True;
+#else
+  PyObject *has_cudnn = Py_False;
 #endif
+  Py_INCREF(has_cudnn);
+  ASSERT_TRUE(PyModule_AddObject(module, "has_cudnn", has_cudnn) == 0);
 
   THPDefaultGenerator = (THPGenerator*)THPGenerator_New();
   ASSERT_TRUE(THPDefaultGenerator != nullptr);

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -533,7 +533,6 @@ static void _call_output_hooks(THPFunction *self, THPObjectPtr& grad_output)
         _ensure_correct_hook_result_single(old_grad, result, key);
 
         // Replace the old gradient
-        PyObject *old_grad = PyTuple_GET_ITEM(new_grad_output.get(), i);
         PyTuple_SET_ITEM(new_grad_output.get(), i, result.release());
         Py_XDECREF(old_grad);
         old_grad = PyTuple_GET_ITEM(new_grad_output.get(), i);

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -2,6 +2,7 @@
 #include <structmember.h>
 
 #include <unordered_map>
+#include <exception>
 
 #include "THP.h"
 
@@ -9,33 +10,15 @@
 #include "cuda/AutoGPU.h"
 #endif
 
+// Throwing this exception means that the python error flags have been already
+// set and control should be immediately returned to the interpreter.
+class python_error : public std::exception {};
+
+#define THPFunction_assert(condition, ...)                                     \
+  if (!(condition)) { THPUtils_setError(__VA_ARGS__); throw python_error(); }
+
+
 PyObject *THPFunctionClass = NULL;
-
-static void THPFunction_dealloc(THPFunction* self)
-{
-  PyObject_GC_UnTrack(self);
-  self->num_inputs = 0;
-  self->num_outputs = 0;
-
-  Py_XDECREF(self->needs_input_grad);
-  Py_XDECREF(self->backward_hooks);
-
-  Py_XDECREF(self->to_save);
-  Py_XDECREF(self->shared_pairs);
-  Py_XDECREF(self->non_differentiable);
-  Py_XDECREF(self->dirty_tensors);
-
-  THPFunctionPtr *previous_functions = self->previous_functions;
-  self->previous_functions = NULL;
-  delete[] previous_functions;
-  delete self->output_info;
-
-  auto saved_variables = self->saved_variables;
-  self->saved_variables = NULL;
-  delete saved_variables;
-
-  Py_TYPE(self)->tp_free((PyObject*)self);
-}
 
 // Traverse and clear are required for supporting Python's GC cycle handling.
 static int THPFunction_traverse(THPFunction *self, visitproc visit, void *arg)
@@ -47,6 +30,10 @@ static int THPFunction_traverse(THPFunction *self, visitproc visit, void *arg)
   if (self->saved_variables) {
     for (unsigned int i = 0; i < self->saved_variables->size(); i++)
       Py_VISIT(std::get<0>(self->saved_variables->at(i)));
+  }
+  if (self->output_backward_hooks) {
+    for (int i = 0; i < self->num_inputs; i++)
+      Py_VISIT(self->output_backward_hooks[i].get());
   }
 
   Py_VISIT(self->to_save);
@@ -78,7 +65,22 @@ static int THPFunction_clear(THPFunction *self)
   self->saved_variables = NULL;
   delete saved_variables;
 
+  auto output_backward_hooks = self->output_backward_hooks;
+  self->output_backward_hooks = NULL;
+  delete[] output_backward_hooks;
+
+  auto output_info = self->output_info;
+  self->output_info = NULL;
+  delete output_info;
+
   return 0;
+}
+
+static void THPFunction_dealloc(THPFunction* self)
+{
+  PyObject_GC_UnTrack(self);
+  THPFunction_clear(self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 PyObject *THPFunction_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
@@ -92,44 +94,46 @@ PyObject *THPFunction_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
   return (PyObject*)self;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Forward
+////////////////////////////////////////////////////////////////////////////////
+
 using t2var_type = std::unordered_map<PyObject *, THPVariable *>;
 
-static bool _mark_dirty(THPFunction *self, t2var_type &t2var)
+static void _mark_dirty(THPFunction *self, t2var_type &t2var)
 {
   // Increase versions of modified tensors
-  if (self->dirty_tensors) {
-    THPUtils_assertRet(false, PyTuple_Check(self->dirty_tensors), "autograd "
-        "internal error: dirty_tensors attribute is expected to be a tuple "
-        "but is %s", THPUtils_typename(self->dirty_tensors));
-    Py_ssize_t num_dirty = PyTuple_GET_SIZE(self->dirty_tensors);
-    for (int i = 0; i < num_dirty; i++) {
-      PyObject *tensor = PyTuple_GET_ITEM(self->dirty_tensors, i);
-      THPVariable *variable;
-      try {
-        variable = t2var.at(tensor);
-      } catch (std::out_of_range &e) {
-        THPUtils_assertRet(false, THPModule_isTensor(tensor), "mark_dirty can "
-            "only accept tensors, but argument %d is of type %s", i,
-            THPUtils_typename(tensor));
-        THPUtils_setError("mark_dirty only accepts input tensors, but "
-            "argument %d isn't one", i);
-        return false;
-      }
-      auto &v_counter = *variable->version_counter;
-      THPUtils_assert(v_counter.var_refcnt() == 1, "in-place operations can be "
-          "only used on variables that don't share storage with any other "
-          "variables, but detected that there are %d objects sharing it",
-          v_counter.var_refcnt());
-      v_counter++;
+  if (!self->dirty_tensors) return;
+
+  THPFunction_assert(PyTuple_Check(self->dirty_tensors), "autograd "
+      "internal error: dirty_tensors attribute is expected to be a tuple "
+      "but is %s", THPUtils_typename(self->dirty_tensors));
+  Py_ssize_t num_dirty = PyTuple_GET_SIZE(self->dirty_tensors);
+  for (int i = 0; i < num_dirty; i++) {
+    PyObject *tensor = PyTuple_GET_ITEM(self->dirty_tensors, i);
+    THPVariable *variable;
+    try {
+      variable = t2var.at(tensor);
+    } catch (std::out_of_range &e) {
+      THPFunction_assert(THPModule_isTensor(tensor), "mark_dirty can "
+          "only accept tensors, but argument %d is of type %s", i,
+          THPUtils_typename(tensor));
+      THPFunction_assert(false, "mark_dirty only accepts input tensors, but "
+          "argument %d isn't one", i);
     }
-    // We're not going to ever need this so let's remove references now
-    Py_DECREF(self->dirty_tensors);
-    self->dirty_tensors = NULL;
+    auto &v_counter = *variable->version_counter;
+    THPFunction_assert(v_counter.var_refcnt() == 1, "in-place operations can be "
+        "only used on variables that don't share storage with any other "
+        "variables, but detected that there are %d objects sharing it",
+        v_counter.var_refcnt());
+    v_counter++;
   }
-  return true;
+  // We're not going to ever need this so let's remove references now
+  Py_DECREF(self->dirty_tensors);
+  self->dirty_tensors = NULL;
 }
 
-static bool _wrap_outputs(THPFunction *self, t2var_type &t2var,
+static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
     PyObject *raw_output, PyObject *outputs)
 {
   // Wrap outputs in Variables
@@ -164,12 +168,11 @@ static bool _wrap_outputs(THPFunction *self, t2var_type &t2var,
         // and if the use wasn't valid we'll still detect an error, because
         // the leaf will have a version != 0.
         output_var = (THPVariable*)THPVariable_New(output, (PyObject*)self, self->requires_grad);
-        if (!output_var) return false;
+        if (!output_var) throw python_error();
         output_var->version_counter->join_with(*input_var->version_counter);
       }
     }
-    if (!output_var)
-      return false;
+    if (!output_var) throw python_error();
 
     torch::THPVoidTensor *output_obj = (torch::THPVoidTensor*)output_var->data;
     torch::THVoidTensor *output_tensor = output_obj->cdata;
@@ -179,7 +182,7 @@ static bool _wrap_outputs(THPFunction *self, t2var_type &t2var,
     if (is_cuda.get() == Py_True) {
       THPObjectPtr device_id_obj = PyObject_CallMethod(output_var->data,
           "get_device", "");
-      THPUtils_assertRet(false, THPUtils_checkLong(device_id_obj), "get_device "
+      THPFunction_assert(THPUtils_checkLong(device_id_obj), "get_device "
           "should return an int, but got %s", THPUtils_typename(device_id_obj));
       device_id = THPUtils_unpackLong(device_id_obj);
     }
@@ -192,250 +195,405 @@ static bool _wrap_outputs(THPFunction *self, t2var_type &t2var,
     output_var->output_nr = i;
     PyTuple_SET_ITEM(outputs, i, (PyObject*)output_var);
   }
-  return true;
 }
 
-static bool _save_variables(THPFunction*self, t2var_type &t2var)
+static void _save_variables(THPFunction*self, t2var_type &t2var)
 {
-  if (self->to_save) {
-    THPUtils_assertRet(false, PyTuple_Check(self->to_save), "autograd internal "
-        "error: to_save attribute is expected to be a tuple but is %s",
-        THPUtils_typename(self->to_save));
-    Py_ssize_t num_saved = PyTuple_GET_SIZE(self->to_save);
-    self->saved_variables = new std::vector<saved_var_info_type>();
-    self->saved_variables->reserve(num_saved);
-    for (int i = 0; i < num_saved; i++) {
-      PyObject *tensor = PyTuple_GET_ITEM(self->to_save, i);
-      if (tensor == Py_None) {
-        Py_INCREF(tensor);
-        self->saved_variables->emplace_back(tensor, 0, nullptr);
-        continue;
-      }
+  if (!self->to_save) return;
 
-      THPVariable *variable;
-      try {
-        variable = t2var.at(tensor);
-      } catch(std::out_of_range &e) {
-        THPUtils_assertRet(false, THPModule_isTensor(tensor),
-            "save_for_backward can only save tensors, but argument %d is of "
-            "type %s", i, THPUtils_typename(tensor));
-        THPUtils_setError("save_for_backward can only save input or output "
-            "tensors, but argument %d doesn't satisfy this condition", i);
-        return false;
-      }
-
+  THPFunction_assert(PyTuple_Check(self->to_save), "autograd internal "
+      "error: to_save attribute is expected to be a tuple but is %s",
+      THPUtils_typename(self->to_save));
+  Py_ssize_t num_saved = PyTuple_GET_SIZE(self->to_save);
+  self->saved_variables = new std::vector<saved_var_info_type>();
+  self->saved_variables->reserve(num_saved);
+  for (int i = 0; i < num_saved; i++) {
+    PyObject *tensor = PyTuple_GET_ITEM(self->to_save, i);
+    if (tensor == Py_None) {
       Py_INCREF(tensor);
-      self->saved_variables->emplace_back(
-        tensor,
-        **variable->version_counter,
-        std::unique_ptr<THPVariableVersion>(variable->version_counter->new_saved_ref())
-      );
+      self->saved_variables->emplace_back(tensor, 0, nullptr);
+      continue;
     }
-    // Free .to_save
-    Py_DECREF(self->to_save);
-    self->to_save = NULL;
+
+    THPVariable *variable;
+    try {
+      variable = t2var.at(tensor);
+    } catch(std::out_of_range &e) {
+      THPFunction_assert(THPModule_isTensor(tensor),
+          "save_for_backward can only save tensors, but argument %d is of "
+          "type %s", i, THPUtils_typename(tensor));
+      THPFunction_assert(false, "save_for_backward can only save input or output "
+          "tensors, but argument %d doesn't satisfy this condition", i);
+    }
+
+    Py_INCREF(tensor);
+    self->saved_variables->emplace_back(
+      tensor,
+      **variable->version_counter,
+      std::unique_ptr<THPVariableVersion>(variable->version_counter->new_saved_ref())
+    );
   }
-  return true;
+  // Free .to_save
+  Py_DECREF(self->to_save);
+  self->to_save = NULL;
 }
 
-static bool _join_version_counters(THPFunction *self, t2var_type &t2var)
+static void _join_version_counters(THPFunction *self, t2var_type &t2var)
 {
-  if (self->shared_pairs) {
-    THPUtils_assertRet(false, PyTuple_Check(self->shared_pairs), "autograd internal "
-        "error: shared_pairs attribute is expected to be a tuple but is %s",
-        THPUtils_typename(self->shared_pairs));
-    Py_ssize_t num_shared = PyTuple_GET_SIZE(self->shared_pairs);
-    for (int i = 0; i < num_shared; i++) {
-      PyObject *shared_tuple = PyTuple_GET_ITEM(self->shared_pairs, i);
-      THPUtils_assertRet(false, PyTuple_Check(shared_tuple), "mark_shared_storages "
-          "accepts a number of pairs, but one of the arguments is of type %s",
-          THPUtils_typename(shared_tuple));
-      THPUtils_assertRet(false, PyTuple_GET_SIZE(shared_tuple) == 2,
-          "mark_shared_storages accepts pairs, but argument %d is a tuple of "
-          "%d elements", i, PyTuple_GET_SIZE(shared_tuple));
+  if (!self->shared_pairs) return;
+  THPFunction_assert(PyTuple_Check(self->shared_pairs), "autograd internal "
+      "error: shared_pairs attribute is expected to be a tuple but is %s",
+      THPUtils_typename(self->shared_pairs));
+  Py_ssize_t num_shared = PyTuple_GET_SIZE(self->shared_pairs);
+  for (int i = 0; i < num_shared; i++) {
+    PyObject *shared_tuple = PyTuple_GET_ITEM(self->shared_pairs, i);
+    THPFunction_assert(PyTuple_Check(shared_tuple), "mark_shared_storages "
+        "accepts a number of pairs, but one of the arguments is of type %s",
+        THPUtils_typename(shared_tuple));
+    THPFunction_assert(PyTuple_GET_SIZE(shared_tuple) == 2,
+        "mark_shared_storages accepts pairs, but argument %d is a tuple of "
+        "%d elements", i, PyTuple_GET_SIZE(shared_tuple));
 
-      // Now we're sure it's really a pair!
-      THPVariable *v1, *v2;
-      try {
-        v1 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 0));
-        v2 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 1));
-      } catch(std::out_of_range &e) {
-        // One tuple items wasn't present in t2var, so there are two cases:
-        // 1. it's not a tensor
-        // 2. it's not an input nor an output
-        PyObject *t1 = PyTuple_GET_ITEM(shared_tuple, 0);
-        PyObject *t2 = PyTuple_GET_ITEM(shared_tuple, 1);
-        THPUtils_assertRet(false, THPModule_isTensor(t1) && THPModule_isTensor(t2),
-          "mark_shared_storages accepts pairs of tensors, but one of them "
-          "contains %s and %s", THPUtils_typename(t1), THPUtils_typename(t2));
-        THPUtils_setError("mark_shared_storages only accepts pairs of input "
-            "and output tensors, but argument %d doesn't satify this "
-            "condition", i);
-        return false;
-      }
-      v2->version_counter->join_with(*v1->version_counter);
+    // Now we're sure it's really a pair!
+    THPVariable *v1, *v2;
+    try {
+      v1 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 0));
+      v2 = t2var.at(PyTuple_GET_ITEM(shared_tuple, 1));
+    } catch(std::out_of_range &e) {
+      // One tuple items wasn't present in t2var, so there are two cases:
+      // 1. it's not a tensor
+      // 2. it's not an input nor an output
+      PyObject *t1 = PyTuple_GET_ITEM(shared_tuple, 0);
+      PyObject *t2 = PyTuple_GET_ITEM(shared_tuple, 1);
+      THPFunction_assert(THPModule_isTensor(t1) && THPModule_isTensor(t2),
+        "mark_shared_storages accepts pairs of tensors, but one of them "
+        "contains %s and %s", THPUtils_typename(t1), THPUtils_typename(t2));
+      THPFunction_assert(false, "mark_shared_storages only accepts pairs of input "
+          "and output tensors, but argument %d doesn't satify this "
+          "condition", i);
     }
-    // Free .shared_pairs
-    Py_DECREF(self->shared_pairs);
-    self->shared_pairs = NULL;
+    v2->version_counter->join_with(*v1->version_counter);
   }
-  return true;
+  // Free .shared_pairs
+  Py_DECREF(self->shared_pairs);
+  self->shared_pairs = NULL;
 }
 
-static bool _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
+static void _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
 {
-  if (self->non_differentiable) {
-    THPUtils_assertRet(false, PyTuple_Check(self->non_differentiable), "autograd "
-        "internal error: non_differentiable attribute is expected to be a "
-        "tuple but is %s", THPUtils_typename(self->non_differentiable));
-    Py_ssize_t num_nondiff = PyTuple_GET_SIZE(self->non_differentiable);
-    for (int i = 0; i < num_nondiff; i++) {
-      PyObject *t = PyTuple_GET_ITEM(self->non_differentiable, i);
-      THPVariable *var;
-      try {
-        var = t2var.at(t);
-        THPUtils_assertRet(false, var->creator == (PyObject*)self,
-            "mark_non_differentiable only accepts output tensors, but "
-            "argument %d isn't an output", i);
-      } catch (std::out_of_range &e) {
-        THPUtils_assertRet(false, THPModule_isTensor(t), "mark_non_differentiable "
-            "only accepts tensor arguments, but got %s", THPUtils_typename(t));
-        THPUtils_setError("mark_non_differentiable only accepts function "
-            "outputs");
-        return false;
-      }
-      var->requires_grad = 0;
+  if (!self->non_differentiable) return;
+
+  THPFunction_assert(PyTuple_Check(self->non_differentiable), "autograd "
+      "internal error: non_differentiable attribute is expected to be a "
+      "tuple but is %s", THPUtils_typename(self->non_differentiable));
+  Py_ssize_t num_nondiff = PyTuple_GET_SIZE(self->non_differentiable);
+  for (int i = 0; i < num_nondiff; i++) {
+    PyObject *t = PyTuple_GET_ITEM(self->non_differentiable, i);
+    THPVariable *var;
+    try {
+      var = t2var.at(t);
+      THPFunction_assert(var->creator == (PyObject*)self,
+          "mark_non_differentiable only accepts output tensors, but "
+          "argument %d isn't an output", i);
+    } catch (std::out_of_range &e) {
+      THPFunction_assert(THPModule_isTensor(t), "mark_non_differentiable "
+          "only accepts tensor arguments, but got %s", THPUtils_typename(t));
+      THPFunction_assert(false, "mark_non_differentiable only accepts function "
+          "outputs");
     }
-    Py_DECREF(self->non_differentiable);
-    self->non_differentiable = NULL;
+    var->requires_grad = 0;
   }
-  return true;
+  Py_DECREF(self->non_differentiable);
+  self->non_differentiable = NULL;
 }
 
+static bool _ensure_tuple(THPObjectPtr& obj)
+{
+  if (PyTuple_Check(obj.get()))
+    return false;
+
+  PyObject *tuple = PyTuple_New(1);
+  if (!tuple) throw python_error();
+  PyTuple_SET_ITEM(tuple, 0, obj.release());
+  obj = tuple;
+  return true;
+}
 
 PyObject *THPFunction_do_forward(THPFunction *self, PyObject *inputs)
 {
-  Py_ssize_t num_inputs = inputs ? PyTuple_GET_SIZE(inputs) : 0;
+  try {
+    Py_ssize_t num_inputs = inputs ? PyTuple_GET_SIZE(inputs) : 0;
 
-  // Unpack inputs and check if they require gradients or are volatile
-  THPObjectPtr unpacked_inputs = PyTuple_New(num_inputs);
-  self->needs_input_grad = PyTuple_New(num_inputs);
-  self->requires_grad = false;
-  bool is_volatile = false;
-  for (int i = 0; i < num_inputs; i++) {
-    PyObject *input = PyTuple_GET_ITEM(inputs, i);
-    THPUtils_assert(THPVariable_Check(input), "expected a Variable argument, "
-        "but got %s", THPUtils_typename(input));
-    THPVariable *variable = (THPVariable*)input;
-
-    // Unpack the variable - SET_ITEM steals a reference so INCREF it
-    Py_INCREF(variable->data);
-    PyTuple_SET_ITEM(unpacked_inputs.get(), i, variable->data);
-
-    // We can't move this to C, because it's going to be accessed from user code.
-    PyTuple_SET_ITEM(self->needs_input_grad, i, PyBool_FromLong(variable->requires_grad));
-
-    is_volatile = is_volatile || variable->is_volatile;
-    self->requires_grad = self->requires_grad || variable->requires_grad;
-  }
-
-
-  // Now we're ready to call a forward (implemented in Python)
-  THPObjectPtr forward_fn = PyObject_GetAttrString((PyObject*)self, "forward");
-  THPUtils_assert(forward_fn.get(), "function %s doesn't implement a required "
-      "'forward' method", THPUtils_typename((PyObject*)self));
-  THPObjectPtr raw_output = PyObject_CallObject(forward_fn, unpacked_inputs);
-  if (!raw_output)
-    return NULL;
-  // Wrap output in a tuple, if it's not one already
-  bool unpack_output = false;
-  if (!PyTuple_Check(raw_output.get())) {
-    unpack_output = true;
-    PyObject *tuple = PyTuple_New(1);
-    if (!tuple)
-      return NULL;
-    PyTuple_SET_ITEM(tuple, 0, raw_output.release());
-    raw_output = tuple;
-  }
-  int num_outputs = PyTuple_GET_SIZE(raw_output.get());
-
-
-  THPObjectPtr outputs = PyTuple_New(num_outputs);
-  if (!outputs)
-    return NULL;
-  if (is_volatile) {
-    // If one of the inputs is volatile let's take a fast path - we want
-    // minimize the overhead of inference
-    for (int i = 0; i < num_outputs; i++) {
-      PyObject *output = PyTuple_GET_ITEM(raw_output.get(), i);
-      THPVariable *output_var = (THPVariable*)THPVariable_NewVolatile(output);
-      if (!output_var)
-        return NULL;
-      output_var->output_nr = i;
-      PyTuple_SET_ITEM(outputs.get(), i, (PyObject*)output_var);
-    }
-  } else {
-    // We're not volatile, so there's a lot of bookkeeping to do...
-    self->num_inputs = num_inputs;
-    self->num_outputs = num_outputs;
-    t2var_type t2var;
-
-    // Save previous functions and initialize t2var map
-    self->previous_functions = new THPFunctionPtr[num_inputs];
+    // Unpack inputs and check if they require gradients or are volatile
+    THPObjectPtr unpacked_inputs = PyTuple_New(num_inputs);
+    self->needs_input_grad = PyTuple_New(num_inputs);
+    self->requires_grad = false;
+    bool is_volatile = false;
     for (int i = 0; i < num_inputs; i++) {
-      THPVariable *input_var = (THPVariable*)PyTuple_GET_ITEM(inputs, i);
-      t2var.emplace(input_var->data, input_var);
+      PyObject *input = PyTuple_GET_ITEM(inputs, i);
+      THPUtils_assert(THPVariable_Check(input), "expected a Variable argument, "
+          "but got %s", THPUtils_typename(input));
+      THPVariable *variable = (THPVariable*)input;
 
-      // Save previous function in a helper class (that has a smart pointer to
-      // the object and remembers which output did we use.
-      PyObject *prev_fn = input_var->creator ? input_var->creator : (PyObject*)input_var;
-      Py_INCREF(prev_fn);
-      self->previous_functions[i] = THPFunctionPtr(prev_fn, input_var->output_nr);
+      // Unpack the variable - SET_ITEM steals a reference so INCREF it
+      Py_INCREF(variable->data);
+      PyTuple_SET_ITEM(unpacked_inputs.get(), i, variable->data);
+
+      // We can't move this to C, because it's going to be accessed from user code.
+      PyTuple_SET_ITEM(self->needs_input_grad, i, PyBool_FromLong(variable->requires_grad));
+
+      is_volatile = is_volatile || variable->is_volatile;
+      self->requires_grad = self->requires_grad || variable->requires_grad;
     }
 
-    if (!_mark_dirty(self, t2var))
-      return NULL;
-    if (!_wrap_outputs(self, t2var, raw_output, outputs))
-      return NULL;
-    if (!_join_version_counters(self, t2var))
-      return NULL;
-    if (self->requires_grad) {
-      if (!_save_variables(self, t2var))
-        return NULL;
+
+    // Now we're ready to call a forward (implemented in Python)
+    THPObjectPtr forward_fn = PyObject_GetAttrString((PyObject*)self, "forward");
+    THPUtils_assert(forward_fn.get(), "function %s doesn't implement a required "
+        "'forward' method", THPUtils_typename((PyObject*)self));
+    THPObjectPtr raw_output = PyObject_CallObject(forward_fn, unpacked_inputs);
+    if (!raw_output) return NULL;
+    // Wrap output in a tuple, if it's not one already
+    bool unpack_output = _ensure_tuple(raw_output);
+    int num_outputs = PyTuple_GET_SIZE(raw_output.get());
+
+
+    THPObjectPtr outputs = PyTuple_New(num_outputs);
+    if (!outputs) return NULL;
+    if (is_volatile) {
+      // If one of the inputs is volatile let's take a fast path - we want
+      // minimize the overhead of inference
+      for (int i = 0; i < num_outputs; i++) {
+        PyObject *output = PyTuple_GET_ITEM(raw_output.get(), i);
+        THPVariable *output_var = (THPVariable*)THPVariable_NewVolatile(output);
+        if (!output_var) return NULL;
+        output_var->output_nr = i;
+        PyTuple_SET_ITEM(outputs.get(), i, (PyObject*)output_var);
+      }
+    } else {
+      // We're not volatile, so there's a lot of bookkeeping to do...
+      self->num_inputs = num_inputs;
+      self->num_outputs = num_outputs;
+      t2var_type t2var;
+
+      // Save previous functions and initialize t2var map
+      self->previous_functions = new THPFunctionPtr[num_inputs];
+      for (int i = 0; i < num_inputs; i++) {
+        THPVariable *input_var = (THPVariable*)PyTuple_GET_ITEM(inputs, i);
+        t2var.emplace(input_var->data, input_var);
+
+        // Save previous function in a helper class (that has a smart pointer to
+        // the object and remembers which output did we use).
+        PyObject *prev_fn = input_var->creator ? input_var->creator : (PyObject*)input_var;
+        Py_INCREF(prev_fn);
+        self->previous_functions[i] = THPFunctionPtr(prev_fn, input_var->output_nr);
+      }
+
+      _mark_dirty(self, t2var);
+      _wrap_outputs(self, t2var, raw_output, outputs);
+      _join_version_counters(self, t2var);
+      if (self->requires_grad) {
+        _save_variables(self, t2var);
+        _mark_non_differentiable(self, t2var);
+      }
     }
-    if (!_mark_non_differentiable(self, t2var))
-      return NULL;
-  }
 
-  if (unpack_output) {
-    PyObject *output = PyTuple_GET_ITEM(outputs.get(), 0);
-    Py_INCREF(output);
-    return output;
-  }
+    // Unpack the output, unless .forward() returned a tuple
+    if (unpack_output) {
+      PyObject *output = PyTuple_GET_ITEM(outputs.get(), 0);
+      Py_INCREF(output);
+      return output;
+    }
 
-  return outputs.release();
+    return outputs.release();
+
+  } catch (python_error& e) {
+    return NULL;
+  } catch (std::exception& e) {
+    THPUtils_setError(e.what());
+    return NULL;
+  }
 }
 
-PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
+////////////////////////////////////////////////////////////////////////////////
+// Backward
+////////////////////////////////////////////////////////////////////////////////
+
+// We need a reference to a smart pointer that will outlive the duration of
+// a function call, so that the char* pointer is valid even after it returns
+static char* _try_get_name(PyObject *key, THPObjectPtr& tmp) {
+#if PY_MAJOR_VERSION == 2
+  if (PyString_Check(key)) {
+    return PyString_AS_STRING(key);
+  }
+#else
+  if (PyUnicode_Check(key)) {
+    tmp = PyUnicode_AsASCIIString(key);
+    return PyBytes_AS_STRING(tmp.get());
+  }
+#endif
+  return NULL;
+}
+
+#define OPTIONAL_HOOK_NAME                                                     \
+  hook_name ? "'" : "",                                                        \
+  hook_name ? hook_name : "",                                                  \
+  hook_name ? "' " : ""
+
+static void _ensure_correct_hook_result_single(PyObject *original,
+    PyObject *returned, PyObject *key)
 {
-  Py_ssize_t num_args = args ? PyTuple_GET_SIZE(args) : 0;
-  THPUtils_assert(num_args == 2, "_do_backward expects exactly two arguments");
-  PyObject *raw_grad_output = PyTuple_GET_ITEM(args, 0);
-  PyObject *retain_variables = PyTuple_GET_ITEM(args, 1);
-  if (!PyTuple_Check(raw_grad_output) || !PyBool_Check(retain_variables)) {
-    THPUtils_invalidArguments(args, "_do_backward", 1, "(tuple, bool)");
-    return NULL;
+#if PY_MAJOR_VERSION == 2
+  static PyObject *IS_SAME_SIZE_NAME = PyString_FromString("is_same_size");
+#else
+  static PyObject *IS_SAME_SIZE_NAME = PyUnicode_FromString("is_same_size");
+#endif
+  THPObjectPtr tmp;
+  // Check that the type matches
+  if(Py_TYPE(original) != Py_TYPE(returned)) {
+    char *hook_name = _try_get_name(key, tmp);
+    THPUtils_setError("backward hook %s%s%shas changed the type of "
+        "grad_input (was %s, but got %s)",
+        OPTIONAL_HOOK_NAME,
+        THPUtils_typename(original),
+        THPUtils_typename(returned)
+    );
+    throw python_error();
   }
 
-  int num_grad_output = PyTuple_GET_SIZE(raw_grad_output);
-  THPObjectPtr grad_output = PyTuple_New(num_grad_output);
-  if (!grad_output) return NULL;
+  // Check that the size matches
+  THPObjectPtr is_same_size = PyObject_CallMethodObjArgs(original,
+      IS_SAME_SIZE_NAME, returned, NULL);
+  if(is_same_size.get() != Py_True) {
+    char *hook_name = _try_get_name(key, tmp);
+    THPUtils_setError("backward hook %s%s%shas changed the size of "
+        "grad_input",
+        OPTIONAL_HOOK_NAME
+    );
+    throw python_error();
+  }
+}
+
+static void _ensure_correct_hook_result(THPObjectPtr& grad_input,
+    THPObjectPtr& result, PyObject *key)
+{
+  THPObjectPtr tmp;
+  // Check that the tuple sizes match
+  if (PyTuple_GET_SIZE(result.get()) != PyTuple_GET_SIZE(grad_input.get())) {
+    char *hook_name = _try_get_name(key, tmp);
+    THPUtils_setError("backward hook %s%s%sreturned an incorrect number "
+        "of gradients (got %ld, but expected %ld)",
+        OPTIONAL_HOOK_NAME,
+        PyTuple_GET_SIZE(result.get()),
+        PyTuple_GET_SIZE(grad_input.get())
+    );
+    throw python_error();
+  }
+
+  Py_ssize_t size = PyTuple_GET_SIZE(grad_input.get());
+  for (int i = 0; i < size; i++) {
+    PyObject *original = PyTuple_GET_ITEM(grad_input.get(), i);
+    PyObject *returned = PyTuple_GET_ITEM(result.get(), i);
+    _ensure_correct_hook_result_single(original, returned, key);
+  }
+}
+
+static void _call_output_hooks(THPFunction *self, THPObjectPtr& grad_output)
+{
+  if (!self->output_backward_hooks) return;
+
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+  // We can't reuse the tuple we got, so allocate a new one.
+  THPObjectPtr new_grad_output = PyTuple_New(self->num_outputs);
+  if (!new_grad_output) throw python_error();
+
+  for (int i = 0; i < self->num_outputs; i++) {
+    // Copy grad to a new tuple
+    PyObject *old_grad = PyTuple_GET_ITEM(grad_output.get(), i);
+    Py_INCREF(old_grad);
+    PyTuple_SET_ITEM(new_grad_output.get(), i, old_grad);
+
+    // Make sure that we're really going to operate on a dict
+    PyObject *hook_dict = self->output_backward_hooks[i];
+    if (!hook_dict) continue;
+    THPFunction_assert(PyDict_Check(hook_dict), "backward_hooks "
+        "attribute has to be a dictionary");
+
+    while (PyDict_Next(hook_dict, &pos, &key, &value)) {
+      THPObjectPtr result = PyObject_CallFunctionObjArgs(value,
+          old_grad, NULL);
+      if (!result) throw python_error();
+
+      // If the hook returns a something else than None, we treat that as a sign
+      // to replace this grad with the return value.
+      if (result.get() != Py_None) {
+        // Check all possible inconsistencies of the output that we can detect
+        // (sizes, types, etc.)
+        _ensure_correct_hook_result_single(old_grad, result, key);
+
+        // Replace the old gradient
+        PyObject *old_grad = PyTuple_GET_ITEM(new_grad_output.get(), i);
+        PyTuple_SET_ITEM(new_grad_output.get(), i, result.release());
+        Py_XDECREF(old_grad);
+        old_grad = PyTuple_GET_ITEM(new_grad_output.get(), i);
+      }
+    }
+  }
+  grad_output = new_grad_output.release();
+}
+
+static void _call_function_hooks(THPFunction *self, THPObjectPtr& grad_input, THPObjectPtr& grad_output)
+{
+  if (!self->backward_hooks) return;
+
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+
+  THPFunction_assert(PyDict_Check(self->backward_hooks), "backward_hooks "
+      "attribute has to be a dictionary");
+  while (PyDict_Next(self->backward_hooks, &pos, &key, &value)) {
+    THPObjectPtr result = PyObject_CallFunctionObjArgs(value,
+        grad_input.get(), grad_output.get(), NULL);
+    if (!result) throw python_error();
+
+    // If the hook returns a something else than None, we treat that as a sign
+    // to replace grad_input with its return value.
+    if (result.get() != Py_None) {
+      // Make sure we're working with a tuple
+      _ensure_tuple(result);
+      // Check all possible inconsistencies of the output that we can detect
+      // (sizes, types, etc.)
+      _ensure_correct_hook_result(grad_input, result, key);
+      grad_input = result.release();
+    }
+  }
+}
+
+static void _prepare_grad_output(THPFunction *self, THPObjectPtr& raw_grad_output)
+{
 #ifdef WITH_CUDA
   THCPAutoGPU gpu_guard(-1);
 #endif
+  int num_grad_output = PyTuple_GET_SIZE(raw_grad_output.get());
+  // First, check if any of grad_outputs is None. If not, there's nothing to do
+  bool has_none = false;
   for (int i = 0; i < num_grad_output; i++) {
-    PyObject *grad = PyTuple_GET_ITEM(raw_grad_output, i);
-    // If there's no gradient we have to allocate a buffer ourselves
+    if (PyTuple_GET_ITEM(raw_grad_output.get(), i) == Py_None) {
+      has_none = true;
+      break;
+    }
+  }
+  if (!has_none)
+      return;
+
+  THPObjectPtr grad_output;
+  grad_output = PyTuple_New(num_grad_output);
+  if (!grad_output) throw python_error();
+
+  // Look for Nones and replace them with new buffers
+  for (int i = 0; i < num_grad_output; i++) {
+    PyObject *grad = PyTuple_GET_ITEM(raw_grad_output.get(), i);
     if (grad == Py_None) {
       auto &info = (*self->output_info)[i];
       PyObject *tensor_cls = std::get<0>(info);
@@ -445,72 +603,113 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
       std::vector<long> &sizes = std::get<2>(info);
       THPObjectPtr grad_size = THPSize_New(sizes.size(), sizes.data());
       THPObjectPtr new_grad = PyObject_CallFunctionObjArgs(tensor_cls, grad_size.get(), NULL);
-      if (!new_grad) return NULL;
+      if (!new_grad) throw python_error();
       THPObjectPtr result = PyObject_CallMethod(new_grad.get(), "zero_", "");
-      if (!result) return NULL;
+      if (!result) throw python_error();
       grad = new_grad.release();
     } else {
       Py_INCREF(grad);
     }
     PyTuple_SET_ITEM(grad_output.get(), i, grad);
   }
+  raw_grad_output = grad_output.release();
+}
 
-  THPObjectPtr backward_fn = PyObject_GetAttrString((PyObject*)self, "backward");
-  THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
-      "'backward' method", THPUtils_typename((PyObject*)self));
-  THPObjectPtr grad_input = PyObject_CallObject(backward_fn, grad_output.get());
-  if (!grad_input)
-    return NULL;
-
-  if (!PyTuple_Check(grad_input)) {
-    PyObject *grad_tuple = PyTuple_New(1);
-    if (!grad_tuple)
-      return NULL;
-    PyTuple_SET_ITEM(grad_tuple, 0, grad_input.release());
-    grad_input = grad_tuple;
-  }
+static void _trim_grad_input(THPFunction *self, THPObjectPtr& grad_input)
+{
   int num_grads = PyTuple_GET_SIZE(grad_input.get());
   int num_prev_fns = self->num_inputs;
-
   if (num_grads > num_prev_fns) {
+    // Check that all extra grads are none
     bool all_none = true;
     for (int i = num_prev_fns; i < num_grads; i++) {
-      all_none = all_none && (PyTuple_GET_ITEM(grad_input.get(), i) == Py_None);
+      all_none = (PyTuple_GET_ITEM(grad_input.get(), i) == Py_None);
       if (!all_none) break;
     }
+    // If yes, slice the tuple
     if (all_none) {
       num_grads = num_prev_fns;
       grad_input = PyTuple_GetSlice(grad_input.get(), 0, num_grads);
-      if (!grad_input)
-        return NULL;
+      if (!grad_input) throw python_error();
     }
   }
-  THPUtils_assert(num_grads == num_prev_fns, "%s returned an invalid number of "
-      "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
-      num_prev_fns, num_grads);
-
-  if (self->backward_hooks) {
-    PyObject *key, *value;
-    Py_ssize_t pos = 0;
-
-    THPUtils_assert(PyDict_Check(self->backward_hooks), "backward_hooks "
-        "attribute has to be a dictionary");
-    while (PyDict_Next(self->backward_hooks, &pos, &key, &value)) {
-      THPObjectPtr result = PyObject_CallFunctionObjArgs(value,
-          grad_input.get(), grad_output.get(), NULL);
-      if (!result)
-        return NULL;
-    }
-  }
-
-  if (retain_variables == Py_False) {
-    delete self->saved_variables;
-    self->saved_variables = nullptr;
-    self->has_freed_buffers = 1;
-  }
-
-  return grad_input.release();
 }
+
+PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
+{
+  try {
+    Py_ssize_t num_args = args ? PyTuple_GET_SIZE(args) : 0;
+    THPUtils_assert(num_args == 2, "_do_backward expects exactly two arguments");
+    PyObject *raw_grad_output = PyTuple_GET_ITEM(args, 0);
+    PyObject *retain_variables = PyTuple_GET_ITEM(args, 1);
+    if (!PyTuple_Check(raw_grad_output) || !PyBool_Check(retain_variables)) {
+      THPUtils_invalidArguments(args, "_do_backward", 1, "(tuple, bool)");
+      return NULL;
+    }
+
+    // Some of the output might have been unused, so we have to allocate
+    // zero-filled buffers instead
+    Py_INCREF(raw_grad_output);
+    THPObjectPtr grad_output = raw_grad_output;
+    _prepare_grad_output(self, grad_output);
+
+    // Call output hooks (this can modify grad_output!)
+    _call_output_hooks(self, grad_output);
+
+    // self.backward(*grad_output)
+    THPObjectPtr backward_fn = PyObject_GetAttrString((PyObject*)self, "backward");
+    THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
+        "'backward' method", THPUtils_typename((PyObject*)self));
+    THPObjectPtr grad_input = PyObject_CallObject(backward_fn, grad_output.get());
+    if (!grad_input) return NULL;
+    _ensure_tuple(grad_input);
+
+    // We allow functions to return more gradients, than there were outputs,
+    // if and only if the additional ones are all None
+    _trim_grad_input(self, grad_input);
+    int num_grads = PyTuple_GET_SIZE(grad_input.get());
+    int num_prev_fns = self->num_inputs;
+    THPUtils_assert(num_grads == num_prev_fns, "%s returned an invalid number of "
+        "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
+        num_prev_fns, num_grads);
+
+    // Call function hooks (this can modify grad_input!)
+    _call_function_hooks(self, grad_input, grad_output);
+
+    // Free buffers only if they're not going to be ever used again
+    if (retain_variables == Py_False) {
+      delete self->saved_variables;
+      self->saved_variables = nullptr;
+      self->has_freed_buffers = 1;
+    }
+
+    return grad_input.release();
+
+  } catch (python_error& e) {
+    return NULL;
+  } catch (std::exception& e) {
+    THPUtils_setError(e.what());
+    return NULL;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Other methods / attributes
+////////////////////////////////////////////////////////////////////////////////
+
+PyObject* THPFunction__register_hook_dict(THPFunction *self, PyObject *_var)
+{
+  THPUtils_assert(THPVariable_Check(_var), "_register_hook_dict expected a variable");
+  THPVariable *var = (THPVariable*)_var;
+
+  if (!self->output_backward_hooks)
+    self->output_backward_hooks = new THPObjectPtr[self->num_inputs];
+  Py_INCREF(var->backward_hooks);
+  self->output_backward_hooks[var->output_nr] = var->backward_hooks;
+
+  Py_RETURN_NONE;
+}
+
 
 PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 {
@@ -568,7 +767,7 @@ static struct PyGetSetDef THPFunction_properties[] = {
 };
 
 static struct PyMemberDef THPFunction_members[] = {
-  {(char*)"backward_hooks", T_OBJECT, offsetof(THPFunction, backward_hooks), 0, NULL},
+  {(char*)"_backward_hooks", T_OBJECT, offsetof(THPFunction, backward_hooks), 0, NULL},
   {(char*)"to_save", T_OBJECT, offsetof(THPFunction, to_save), 0, NULL},
   {(char*)"shared_pairs", T_OBJECT, offsetof(THPFunction, shared_pairs), 0, NULL},
   {(char*)"non_differentiable", T_OBJECT, offsetof(THPFunction, non_differentiable), 0, NULL},
@@ -583,6 +782,7 @@ static struct PyMemberDef THPFunction_members[] = {
 static struct PyMethodDef THPFunction_methods[] = {
   {(char*)"_do_forward", (PyCFunction)THPFunction_do_forward, METH_VARARGS, NULL},
   {(char*)"_do_backward", (PyCFunction)THPFunction_do_backward, METH_VARARGS, NULL},
+  {(char*)"_register_hook_dict", (PyCFunction)THPFunction__register_hook_dict, METH_O, NULL},
   {NULL}
 };
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -36,6 +36,7 @@ struct THPFunction {
 
     PyObject *needs_input_grad;
     PyObject *backward_hooks;
+    THPObjectPtr *output_backward_hooks;
 
     PyObject *to_save;
     PyObject *shared_pairs;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -204,7 +204,7 @@ static struct PyMemberDef THPVariable_members[] = {
   {(char*)"_grad",          T_OBJECT,   offsetof(THPVariable, grad), 0, NULL},
   {(char*)"volatile",       T_BOOL,     offsetof(THPVariable, is_volatile), 0, NULL},
   {(char*)"output_nr",      T_INT,      offsetof(THPVariable, output_nr), 0, NULL},
-  {(char*)"backward_hooks", T_OBJECT,   offsetof(THPVariable, backward_hooks), 0, NULL},
+  {(char*)"_backward_hooks",T_OBJECT,   offsetof(THPVariable, backward_hooks), 0, NULL},
   {(char*)"_requires_grad", T_BOOL,     offsetof(THPVariable, requires_grad), 0, NULL},
   {NULL}
 };

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -383,6 +383,9 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   with_stateless: True
   cname: newTranspose
   return: THTensor*
+  before_call: |
+    long ndim = ((THPTensor*)${arg0})->cdata->nDimension;
+    THPUtils_assert(ndim == 2, "t() expects a 2D tensor, but self is %ldD", ndim);
   arguments:
     - THTensor* self
     - CONSTANT 0
@@ -393,6 +396,9 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   name: t_
   cname: transpose
   return: self
+  before_call: |
+    long ndim = ((THPTensor*)${arg0})->cdata->nDimension;
+    THPUtils_assert(ndim == 2, "t_() expects a 2D tensor, but self is %ldD", ndim);
   arguments:
     - THTensor* self
     - THTensor* self

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -10,8 +10,15 @@ _cudart = None
 
 
 def is_available():
-    return (hasattr(torch._C, '_cuda_isDriverSufficient') and
-            torch._C._cuda_isDriverSufficient())
+    if (not hasattr(torch._C, '_cuda_isDriverSufficient') or
+            not torch._C._cuda_isDriverSufficient()):
+        return False
+    try:
+        return torch._C._cuda_getDeviceCount() > 0
+    except RuntimeError as e:
+        if 'no CUDA-capable device is detected' in e.args[0]:
+            return False
+        raise
 
 
 def _sleep(cycles):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -290,16 +290,10 @@ class Module(object):
 
     def train(self):
         self.training = True
-        for p in self._parameters.values():
-            if p is not None:
-                p.requires_grad = True
         return self
 
     def eval(self):
         self.training = False
-        for p in self._parameters.values():
-            if p is not None:
-                p.requires_grad = False
         return self
 
     def zero_grad(self):

--- a/torch/utils/serialization/read_lua_file.py
+++ b/torch/utils/serialization/read_lua_file.py
@@ -182,6 +182,28 @@ register_torch_class('Storage', make_storage_reader)
 register_torch_class('Tensor', make_tensor_reader)
 
 ################################################################################
+# Reader function for tds.Vector and tds.Hash
+################################################################################
+
+def tds_Vec_reader(reader, version):
+    length = reader.read_long()
+    return [reader.read() for i in range(length)]
+
+
+def tds_Hash_reader(reader, version):
+    length = reader.read_long()
+    obj = {}
+    for i in range(length):
+        k = reader.read()
+        v = reader.read()
+        obj[k] = v
+    return obj
+
+
+reader_registry['tds.Vec'] = tds_Vec_reader
+reader_registry['tds.Hash'] = tds_Hash_reader
+
+################################################################################
 # Reader function for nn modules
 ################################################################################
 


### PR DESCRIPTION
* Allow returning changed gradients from the hooks (#262)
* Fix bmm for variables (#299)
* Adds dimension checks for `t()` and `t_()` (#301)
* Fixes #306.
* Fixes an issue with `narrow` docs (#291)
* Adds support for loading `tds` objects (#300)
* `train()` and `eval()` no longer change `requires_grad` flags of parameters.