### PR TITLE
Fix gcc-6 build on OS X

### DIFF
--- a/torch/lib/libshm/socket.h
+++ b/torch/lib/libshm/socket.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <cstring>
 
 #include "err.h"
 #include "alloc_info.h"


### PR DESCRIPTION
Ads cstring to headers.