### PR TITLE
Correct documentation to be in line with #237

### DIFF
--- a/docs/nn_container.md
+++ b/docs/nn_container.md
@@ -40,12 +40,12 @@ model.add_module('pool1', nn.MaxPool2d(2, 2))
 ```
 
 ```python
-# .parameter_dict()
+# .state_dict()
 ```
 
 ```python
->>> pdict = model.parameter_dict()
->>> print(pdict.keys())
+>>> pdict = model.state_dict()
+>>> print(sdict.keys())
 ['conv1.bias', 'conv1.weight']
 ```
 
@@ -72,7 +72,7 @@ The container has some important additional methods:
 returns a generator over all learnable parameters in the container instance. 
 This can typically be passed to the optimizer API
 
-**`[dict] parameter_dict()`**
+**`[dict] state_dict()`**
 
 returns a dictionary of learnable parameters of the Container.
 For example: ['conv1.weight' : Parameter(torch.FloatTensor(20x1x5x5)),


### PR DESCRIPTION
.parameter_dict was renamed to .state_dict in #237

This documentation change reflects that.