### PR TITLE
Another documentation change, missed one in #303

### DIFF
--- a/docs/nn_container.md
+++ b/docs/nn_container.md
@@ -80,7 +80,7 @@ For example: ['conv1.weight' : Parameter(torch.FloatTensor(20x1x5x5)),
              ]
 
 
-**`load_parameter_dict(dict)`**
+**`load_state_dict(dict)`**
 
 Given a parameter dict, sets the parameters of self to be the given dict.
 It loads loads the parameters recursively.


### PR DESCRIPTION
Apparently load_parameter_dict was also renamed to load_state_dict