### PR TITLE
Deterministic ordering of parameters and buffers.

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -678,7 +678,7 @@ class TestNN(NNTestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out.data, expected_out)
 
-    def test_parameter_dict(self):
+    def test_state_dict(self):
         l = nn.Linear(5, 5)
         block = nn.Container(
             conv=nn.Conv2d(3, 3, 3, bias=False)
@@ -716,7 +716,7 @@ class TestNN(NNTestCase):
         self.assertIs(state_dict['weight'], l.weight)
         self.assertIs(state_dict['bias'], l.bias)
 
-    def test_load_parameter_dict(self):
+    def test_load_state_dict(self):
         l = nn.Linear(5, 5)
         block = nn.Container(
             conv1=nn.Conv2d(3, 3, 3, bias=False),

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -1,6 +1,5 @@
 import ctypes
 import torch
-import os
 from . import cudart
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1,5 +1,5 @@
 import torch
-from torch.autograd import Variable
+from torch.nn.parameter import Parameter
 
 from .module import Module
 
@@ -382,9 +382,8 @@ class PReLU(Module):
     """
     def __init__(self, num_parameters=1, init=0.25):
         self.num_parameters = num_parameters
-        super(PReLU, self).__init__(
-            weight=torch.Tensor(num_parameters).fill_(init)
-        )
+        super(PReLU, self).__init__()
+        self.weight = Parameter(torch.Tensor(num_parameters).fill_(init))
 
     def forward(self, input):
         return self._backend.PReLU()(input, self.weight)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,22 +1,23 @@
 import torch
-from torch.autograd import Variable
-
 from .module import Module
+from torch.nn.parameter import Parameter
+
 
 # TODO: check contiguous in THNN
 # TODO: use separate backend functions?
 class _BatchNorm(Module):
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True):
+        super(_BatchNorm, self).__init__()
         self.affine = affine
         self.eps = eps
         self.momentum = momentum
-
-        weight = bias = None
         if self.affine:
-            weight = torch.Tensor(num_features)
-            bias = torch.Tensor(num_features)
-        super(_BatchNorm, self).__init__(weight=weight, bias=bias)
+            self.weight = Parameter(torch.Tensor(num_features))
+            self.bias = Parameter(torch.Tensor(num_features))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
         self.register_buffer('running_mean', torch.zeros(num_features))
         self.register_buffer('running_var', torch.ones(num_features))
         self.reset_parameters()
@@ -158,4 +159,3 @@ class BatchNorm3d(_BatchNorm):
         >>> output = m(input)
     """
     expected_dim = 5
-

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -1,7 +1,7 @@
 import math
 
 import torch
-from torch.autograd import Variable
+from torch.nn.parameter import Parameter
 
 from .module import Module
 
@@ -27,13 +27,14 @@ class Linear(Module):
         >>> print(output.size())
     """
     def __init__(self, in_features, out_features, bias=True):
+        super(Linear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
-
-        super(Linear, self).__init__(
-            weight=torch.Tensor(out_features, in_features),
-            bias=torch.Tensor(out_features) if bias else None
-        )
+        self.weight = Parameter(torch.Tensor(out_features, in_features))
+        if bias:
+            self.bias = Parameter(torch.Tensor(out_features))
+        else:
+            self.register_parameter('bias', None)
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -12,7 +12,7 @@ class CrossMapLRN2d(Module):
 
     def forward(self, input):
         return self._backend.CrossMapLRN2d(self.size, self.alpha, self.beta,
-                self.k)(input)
+                                           self.k)(input)
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
@@ -26,4 +26,3 @@ class CrossMapLRN2d(Module):
 # TODO: ContrastiveNorm2d
 # TODO: DivisiveNorm2d
 # TODO: SubtractiveNorm2d
-

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -31,7 +31,7 @@ class MaxPool1d(Module):
         >>> output = m(input)
     """
     def __init__(self, kernel_size, stride=None, padding=0, dilation=1,
-            return_indices=False, ceil_mode=False):
+                 return_indices=False, ceil_mode=False):
         super(MaxPool1d, self).__init__()
         self.kernel_size = kernel_size
         self.stride = stride or kernel_size
@@ -81,7 +81,7 @@ class MaxPool2d(Module):
         >>> output = m(input)
     """
     def __init__(self, kernel_size, stride=None, padding=0, dilation=1,
-            return_indices=False, ceil_mode=False):
+                 return_indices=False, ceil_mode=False):
         super(MaxPool2d, self).__init__()
         self.kh, self.kw = _pair(kernel_size)
         self.dh, self.dw = _pair(stride or kernel_size)
@@ -395,4 +395,3 @@ class LPPool2d(Module):
 
 
 # TODO: AdaptiveMaxPool2d
-

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -1,5 +1,5 @@
 import torch
-from torch.autograd import Variable
+from torch.nn.parameter import Parameter
 
 from .module import Module
 
@@ -30,17 +30,15 @@ class Embedding(Module):
         >>> print(embedding(input))
     """
     def __init__(self, num_embeddings, embedding_dim, padding_idx=None,
-            max_norm=None, norm_type=2, scale_grad_by_freq=False):
+                 max_norm=None, norm_type=2, scale_grad_by_freq=False):
+        super(Embedding, self).__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         self.padding_idx = padding_idx
         self.max_norm = max_norm
         self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
-
-        super(Embedding, self).__init__(
-            weight=torch.Tensor(num_embeddings, embedding_dim)
-        )
+        self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
         self.reset_parameters()
 
     def reset_parameters(self):
@@ -57,4 +55,3 @@ class Embedding(Module):
 
 
 # TODO: SparseLinear
-

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -1,5 +1,6 @@
 from torch.autograd import Variable
 
+
 class Parameter(Variable):
 
     def __init__(self, data, requires_grad=True):
@@ -7,4 +8,3 @@ class Parameter(Variable):
 
     def __repr__(self):
         return 'Parameter containing:' + self.data.__repr__()
-


### PR DESCRIPTION
Uses the assignment syntax to get deterministic ordering of parameters.
The ordering of parameters using the constructor syntax is
non-deterministic because kwargs use `dict()` in Python 3.5 and earlier.