### PR TITLE
Add cudnn 5.0.5 to supported versions

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -12,7 +12,7 @@ lib = None
 thisdir = path.dirname(__file__)
 libpaths = ['', path.join(thisdir, '../../lib')]
 if sys.platform.startswith('linux'):
-    libnames = ['libcudnn.so.5.1.5', 'libcudnn.so.5.1.3']
+    libnames = ['libcudnn.so.5.0.5', 'libcudnn.so.5.1.5', 'libcudnn.so.5.1.3']
 elif sys.platform == 'darwin':
     libnames = ['libcudnn.5.dylib']
 else:


### PR DESCRIPTION
I ran tests locally, only rnn do not pass because they were added in 5.1, the rest pass. Having 5.0 is very useful for:
*  reproducing lua torch results (eg fb.resnet.torch)
* as far I understand there is fused winograd which I'd like to stay away from, and there's no way to block it in the bindings right now.