### PR TITLE
Add autograd.backward

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -4,4 +4,8 @@ from .variable import Variable
 from .function import Function, NestedIOFunction
 from .stochastic_function import StochasticFunction
 
+def backward(variables, grad_variables, retain_variables=False):
+    Variable._execution_engine.run_backward(
+            tuple(variables), tuple(grad_variables), retain_variables)
+
 assert torch._C._autograd_init()

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -87,7 +87,7 @@ class Variable(_C._VariableBase):
             if self.data.numel() != 1:
                 raise RuntimeError('backward should be called only on a scalar (i.e. 1-element tensor) or with gradient w.r.t. the variable')
             gradient = self.data.new(1).fill_(1)
-        self._execution_engine.run_backward(self, gradient, retain_variables)
+        self._execution_engine.run_backward((self,), (gradient,), retain_variables)
 
     def __repr__(self):
         return 'Variable containing:' + self.data.__repr__()


### PR DESCRIPTION
```python
autograd.backward([var1, var2], [grad_var1, grad_var2])
```
does a single backward pass through a full graph preceding var1 and var2. Implements #335.