### PR TITLE
make the CUDA-aware tests backoff if CUDA no available

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -37,16 +37,11 @@ $PYCMD test_utils.py
 echo "Running dataloader tests"
 $PYCMD test_dataloader.py
 
-if which nvcc >/dev/null 2>&1
-then
-    echo "Running cuda tests"
-    $PYCMD test_cuda.py
+echo "Running cuda tests"
+$PYCMD test_cuda.py
 
-    echo "Running NCCL tests"
-    $PYCMD test_nccl.py
-else
-    echo "nvcc not found in PATH, skipping CUDA tests"
-fi
+echo "Running NCCL tests"
+$PYCMD test_nccl.py
 
 if [ "$1" == "coverage" ];
 then

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9,6 +9,11 @@ import torch.cuda.comm as comm
 
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state
 
+if not torch.cuda.is_available():
+    print('CUDA not available, skipping tests')
+    import sys
+    sys.exit()
+
 def is_floating(t):
     return type(t) in [torch.FloatTensor, torch.DoubleTensor,
                        torch.cuda.FloatTensor, torch.cuda.DoubleTensor]

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -6,6 +6,11 @@ import torch.cuda
 
 from common import TestCase
 
+if not torch.cuda.is_available():
+    print('CUDA not available, skipping tests')
+    import sys
+    sys.exit()
+
 nGPUs = torch.cuda.device_count()
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -297,7 +297,7 @@ class TestLuaReader(TestCase):
         print('Downloading test file for TestLuaReader.')
         DATA_URL = 'https://s3.amazonaws.com/pytorch/legacy_modules.t7'
         urllib = cls._get_urllib('request')
-        data = urllib.urlopen(DATA_URL).read()
+        data = urllib.urlopen(DATA_URL, timeout=15).read()
         with open(test_file_path, 'wb') as f:
             f.write(data)
 


### PR DESCRIPTION
As suggested by Sam.
This is cleaner. if CUDA is not available, the test just exits.

Also added a timeout of 15 seconds for the legacy data loader file download