### PR TITLE
Accept outputs in out argument

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -603,28 +603,28 @@ class TestTorch(TestCase):
         x = torch.rand(100, 100)
         res1 = torch.sum(x, 1)
         res2 = torch.Tensor()
-        torch.sum(res2, x, 1)
+        torch.sum(x, 1, out=res2)
         self.assertEqual(res1, res2)
 
     def test_prod(self):
         x = torch.rand(100, 100)
         res1 = torch.prod(x, 1)
         res2 = torch.Tensor()
-        torch.prod(res2, x, 1)
+        torch.prod(x, 1, out=res2)
         self.assertEqual(res1, res2)
 
     def test_cumsum(self):
         x = torch.rand(100, 100)
         res1 = torch.cumsum(x, 1)
         res2 = torch.Tensor()
-        torch.cumsum(res2, x, 1)
+        torch.cumsum(x, 1, out=res2)
         self.assertEqual(res1, res2)
 
     def test_cumprod(self):
         x = torch.rand(100, 100)
         res1 = torch.cumprod(x, 1)
         res2 = torch.Tensor()
-        torch.cumprod(res2, x, 1)
+        torch.cumprod(x, 1, out=res2)
         self.assertEqual(res1, res2)
 
     def test_cross(self):
@@ -632,13 +632,13 @@ class TestTorch(TestCase):
         y = torch.rand(100, 3, 100)
         res1 = torch.cross(x, y)
         res2 = torch.Tensor()
-        torch.cross(res2, x, y)
+        torch.cross(x, y, out=res2)
         self.assertEqual(res1, res2)
 
     def test_zeros(self):
         res1 = torch.zeros(100, 100)
         res2 = torch.Tensor()
-        torch.zeros(res2, 100, 100)
+        torch.zeros(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
     def test_histc(self):
@@ -650,20 +650,20 @@ class TestTorch(TestCase):
     def test_ones(self):
         res1 = torch.ones(100, 100)
         res2 = torch.Tensor()
-        torch.ones(res2, 100, 100)
+        torch.ones(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
     def test_diag(self):
         x = torch.rand(100, 100)
         res1 = torch.diag(x)
         res2 = torch.Tensor()
-        torch.diag(res2, x)
+        torch.diag(x, out=res2)
         self.assertEqual(res1, res2)
 
     def test_eye(self):
         res1 = torch.eye(100, 100)
         res2 = torch.Tensor()
-        torch.eye(res2, 100, 100)
+        torch.eye(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
     def test_renorm(self):
@@ -743,39 +743,39 @@ class TestTorch(TestCase):
     def test_range(self):
         res1 = torch.range(0, 1)
         res2 = torch.Tensor()
-        torch.range(res2, 0, 1)
+        torch.range(0, 1, out=res2)
         self.assertEqual(res1, res2, 0)
 
         # Check range for non-contiguous tensors.
         x = torch.zeros(2, 3)
-        torch.range(x.narrow(1, 1, 2), 0, 3)
+        torch.range(0, 3, out=x.narrow(1, 1, 2))
         res2 = torch.Tensor(((0, 0, 1), (0, 2, 3)))
         self.assertEqual(x, res2, 1e-16)
 
         # Check negative
         res1 = torch.Tensor((1, 0))
         res2 = torch.Tensor()
-        torch.range(res2, 1, 0, -1)
+        torch.range(1, 0, -1, out=res2)
         self.assertEqual(res1, res2, 0)
 
         # Equal bounds
         res1 = torch.ones(1)
         res2 = torch.Tensor()
-        torch.range(res2, 1, 1, -1)
+        torch.range(1, 1, -1, out=res2)
         self.assertEqual(res1, res2, 0)
-        torch.range(res2, 1, 1, 1)
+        torch.range(1, 1, 1, out=res2)
         self.assertEqual(res1, res2, 0)
 
         # FloatTensor
-        res1 = torch.range(torch.FloatTensor(), 0.6, 0.9, 0.1)
+        res1 = torch.range(0.6, 0.9, 0.1, out=torch.FloatTensor())
         self.assertEqual(res1.size(0), 4)
-        res1 = torch.range(torch.FloatTensor(), 1, 10, 0.3)
+        res1 = torch.range(1, 10, 0.3, out=torch.FloatTensor())
         self.assertEqual(res1.size(0), 31)
 
         # DoubleTensor
-        res1 = torch.range(torch.DoubleTensor(), 0.6, 0.9, 0.1)
+        res1 = torch.range(0.6, 0.9, 0.1, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 4)
-        res1 = torch.range(torch.DoubleTensor(), 1, 10, 0.3)
+        res1 = torch.range(1, 10, 0.3, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 31)
 
     def test_randperm(self):
@@ -783,7 +783,7 @@ class TestTorch(TestCase):
         res1 = torch.randperm(100)
         res2 = torch.LongTensor()
         torch.set_rng_state(_RNGState)
-        torch.randperm(res2, 100)
+        torch.randperm(100, out=res2)
         self.assertEqual(res1, res2, 0)
 
     def assertIsOrdered(self, order, x, mxx, ixx, task):
@@ -819,7 +819,7 @@ class TestTorch(TestCase):
         # Test use of result tensor
         res2val = torch.Tensor()
         res2ind = torch.LongTensor()
-        torch.sort(res2val, res2ind, x)
+        torch.sort(x, out=(res2val, res2ind))
         self.assertEqual(res1val, res2val, 0)
         self.assertEqual(res1ind, res2ind, 0)
 
@@ -835,7 +835,7 @@ class TestTorch(TestCase):
 
         # Test that we still have proper sorting with duplicate keys
         x = torch.floor(torch.rand(SIZE, SIZE)*10)
-        torch.sort(res2val, res2ind, x)
+        torch.sort(x, out=(res2val, res2ind))
         self.assertIsOrdered('ascending', x, res2val, res2ind, 'random with duplicate keys')
 
         # DESCENDING SORT
@@ -845,7 +845,7 @@ class TestTorch(TestCase):
         # Test use of result tensor
         res2val = torch.Tensor()
         res2ind = torch.LongTensor()
-        torch.sort(res2val, res2ind, x, x.dim()-1, True)
+        torch.sort(x, x.dim()-1, True, out=(res2val, res2ind))
         self.assertEqual(res1val, res2val, 0)
         self.assertEqual(res1ind, res2ind, 0)
 
@@ -926,7 +926,7 @@ class TestTorch(TestCase):
         k = random.randint(1, SIZE)
         res1val = torch.Tensor()
         res1ind = torch.LongTensor()
-        torch.kthvalue(res1val, res1ind, x, k)
+        torch.kthvalue(x, k, out=(res1val, res1ind))
         res2val, res2ind = torch.sort(x)
         self.assertEqual(res1val[:,:,0], res2val[:,:,k-1], 0)
         self.assertEqual(res1ind[:,:,0], res2ind[:,:,k-1], 0)
@@ -970,7 +970,7 @@ class TestTorch(TestCase):
             # Test use of result tensor
             res2val = torch.Tensor()
             res2ind = torch.LongTensor()
-            torch.median(res2val, res2ind, x)
+            torch.median(x, out=(res2val, res2ind))
             self.assertEqual(res2val, res1val, 0)
             self.assertEqual(res2ind, res1ind, 0)
 
@@ -1004,7 +1004,7 @@ class TestTorch(TestCase):
         # Test use of result tensor
         res2val = torch.Tensor()
         res2ind = torch.LongTensor()
-        torch.mode(res2val, res2ind, x)
+        torch.mode(x, out=(res2val, res2ind))
         self.assertEqual(res1val, res2val, 0)
         self.assertEqual(res1ind, res2ind, 0)
 
@@ -1020,14 +1020,14 @@ class TestTorch(TestCase):
         x = torch.rand(SIZE, SIZE)
         res1 = torch.tril(x)
         res2 = torch.Tensor()
-        torch.tril(res2, x)
+        torch.tril(x, out=res2)
         self.assertEqual(res1, res2, 0)
 
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)
         res1 = torch.triu(x)
         res2 = torch.Tensor()
-        torch.triu(res2, x)
+        torch.triu(x, out=res2)
         self.assertEqual(res1, res2, 0)
 
     def test_cat(self):
@@ -1057,7 +1057,7 @@ class TestTorch(TestCase):
         to = _from + random.random()
         res1 = torch.linspace(_from, to, 137)
         res2 = torch.Tensor()
-        torch.linspace(res2, _from, to, 137)
+        torch.linspace(_from, to, 137, out=res2)
         self.assertEqual(res1, res2, 0)
         self.assertRaises(RuntimeError, lambda: torch.linspace(0, 1, 1))
         self.assertEqual(torch.linspace(0, 0, 1), torch.zeros(1), 0)
@@ -1067,7 +1067,7 @@ class TestTorch(TestCase):
 
         # Check linspace for non-contiguous tensors.
         x = torch.zeros(2, 3)
-        y = torch.linspace(x.narrow(1, 1, 2), 0, 3, 4)
+        y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2))
         self.assertEqual(x, torch.Tensor(((0, 0, 1), (0, 2, 3))), 0)
 
     def test_logspace(self):
@@ -1075,7 +1075,7 @@ class TestTorch(TestCase):
         to = _from + random.random()
         res1 = torch.logspace(_from, to, 137)
         res2 = torch.Tensor()
-        torch.logspace(res2, _from, to, 137)
+        torch.logspace(_from, to, 137, out=res2)
         self.assertEqual(res1, res2, 0)
         self.assertRaises(RuntimeError, lambda: torch.logspace(0, 1, 1))
         self.assertEqual(torch.logspace(0, 0, 1), torch.ones(1), 0)
@@ -1085,7 +1085,7 @@ class TestTorch(TestCase):
 
         # Check logspace_ for non-contiguous tensors.
         x = torch.zeros(2, 3)
-        y = torch.logspace(x.narrow(1, 1, 2), 0, 3, 4)
+        y = torch.logspace(0, 3, 4, out=x.narrow(1, 1, 2))
         self.assertEqual(x, torch.Tensor(((0, 1, 10), (0, 100, 1000))), 0)
 
     def test_rand(self):
@@ -1093,7 +1093,7 @@ class TestTorch(TestCase):
         res1 = torch.rand(SIZE, SIZE)
         res2 = torch.Tensor()
         torch.manual_seed(123456)
-        torch.rand(res2, SIZE, SIZE)
+        torch.rand(SIZE, SIZE, out=res2)
         self.assertEqual(res1, res2)
 
     def test_randn(self):
@@ -1101,7 +1101,7 @@ class TestTorch(TestCase):
         res1 = torch.randn(SIZE, SIZE)
         res2 = torch.Tensor()
         torch.manual_seed(123456)
-        torch.randn(res2, SIZE, SIZE)
+        torch.randn(SIZE, SIZE, out=res2)
         self.assertEqual(res1, res2)
 
     @skipIfNoLapack
@@ -1119,8 +1119,8 @@ class TestTorch(TestCase):
         self.assertLessEqual(b.dist(torch.mm(a, res1)), 1e-12)
         ta = torch.Tensor()
         tb = torch.Tensor()
-        res2 = torch.gesv(tb, ta, b, a)[0]
-        res3 = torch.gesv(b, a, b, a)[0]
+        res2 = torch.gesv(b, a, out=(tb, ta))[0]
+        res3 = torch.gesv(b, a, out=(b, a))[0]
         self.assertEqual(res1, tb)
         self.assertEqual(res1, b)
         self.assertEqual(res1, res2)
@@ -1130,9 +1130,9 @@ class TestTorch(TestCase):
         res1 = torch.gesv(b, a)[0]
         ta = torch.Tensor()
         tb = torch.Tensor()
-        torch.gesv(tb, ta, b, a)[0]
+        torch.gesv(b, a, out=(tb, ta))[0]
         self.assertEqual(res1, tb)
-        torch.gesv(tb, ta, b, a)[0]
+        torch.gesv(b, a, out=(tb, ta))[0]
         self.assertEqual(res1, tb)
 
     @skipIfNoLapack
@@ -1157,7 +1157,7 @@ class TestTorch(TestCase):
 
             # in-place
             q, r = torch.Tensor(), torch.Tensor()
-            torch.qr(q, r, a)
+            torch.qr(a, out=(q, r))
             canon_and_check(q, r, expected_q, expected_r)
 
             # manually calculate qr using geqrf and orgqr
@@ -1302,10 +1302,10 @@ class TestTorch(TestCase):
         res1 = torch.trtrs(b,a)[0]
         ta = torch.Tensor()
         tb = torch.Tensor()
-        torch.trtrs(tb,ta,b,a)
+        torch.trtrs(b, a, out=(tb, ta))
         self.assertEqual(res1, tb, 0)
         tb.zero_()
-        torch.trtrs(tb,ta,b,a)
+        torch.trtrs(b, a, out=(tb, ta))
         self.assertEqual(res1, tb, 0)
 
     @skipIfNoLapack
@@ -1320,12 +1320,12 @@ class TestTorch(TestCase):
 
             ta = torch.Tensor()
             tb = torch.Tensor()
-            res2 = torch.gels(tb, ta, b, a)[0]
+            res2 = torch.gels(b, a, out=(tb, ta))[0]
             self.assertEqual(a, a_copy, 0)
             self.assertEqual(b, b_copy, 0)
             self.assertEqual((torch.mm(a, res1) - b).norm(), expectedNorm, 1e-8)
 
-            res3 = torch.gels(b, a, b, a)[0]
+            res3 = torch.gels(b, a, out=(b, a))[0]
             self.assertEqual((torch.mm(a_copy, b) - b_copy).norm(), expectedNorm, 1e-8)
             self.assertEqual(res1, tb, 0)
             self.assertEqual(res1, b, 0)
@@ -1372,11 +1372,11 @@ class TestTorch(TestCase):
                         (9.35, -4.43, -0.70, -0.26))).t()
         ta = torch.Tensor()
         tb = torch.Tensor()
-        torch.gels(tb, ta, b, a)
+        torch.gels(b, a, out=(tb, ta))
         self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
-        torch.gels(tb, ta, b, a)
+        torch.gels(b, a, out=(tb, ta))
         self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
-        torch.gels(tb, ta, b, a)
+        torch.gels(b, a, out=(tb, ta))
         self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
 
     @skipIfNoLapack
@@ -1390,7 +1390,7 @@ class TestTorch(TestCase):
         ee, vv = torch.eig(a, True)
         te = torch.Tensor()
         tv = torch.Tensor()
-        eee, vvv = torch.eig(te, tv, a, True)
+        eee, vvv = torch.eig(a, True, out=(te, tv))
         self.assertEqual(e, ee, 1e-12)
         self.assertEqual(ee, eee, 1e-12)
         self.assertEqual(ee, te, 1e-12)
@@ -1401,12 +1401,12 @@ class TestTorch(TestCase):
         X = torch.randn(4,4)
         X = torch.mm(X.t(), X)
         e, v = torch.zeros(4,2), torch.zeros(4,4)
-        torch.eig(e, v, X, True)
+        torch.eig(X, True, out=(e, v))
         Xhat = torch.mm(torch.mm(v, torch.diag(e.select(1, 0))), v.t())
         self.assertEqual(X, Xhat, 1e-8, 'VeV\' wrong')
         self.assertFalse(v.is_contiguous(), 'V is contiguous')
 
-        torch.eig(e, v, X, True)
+        torch.eig(X, True, out=(e, v))
         Xhat = torch.mm(v, torch.mm(e.select(1, 0).diag(), v.t()))
         self.assertEqual(X, Xhat, 1e-8, 'VeV\' wrong')
         self.assertFalse(v.is_contiguous(), 'V is contiguous')
@@ -1418,7 +1418,7 @@ class TestTorch(TestCase):
         v = torch.zeros(4, 2, 4)[:,1]
         self.assertFalse(v.is_contiguous(), 'V is contiguous')
         self.assertFalse(e.is_contiguous(), 'E is contiguous')
-        torch.eig(e, v, X, True)
+        torch.eig(X, True, out=(e, v))
         Xhat = torch.mm(torch.mm(v, torch.diag(e.select(1, 0))), v.t())
         self.assertEqual(X, Xhat, 1e-8, 'VeV\' wrong')
 
@@ -1431,13 +1431,13 @@ class TestTorch(TestCase):
 
         # First call to symeig
         self.assertTrue(resv.is_contiguous(), 'resv is not contiguous')
-        torch.symeig(rese, resv, cov.clone(), True)
+        torch.symeig(cov.clone(), True, out=(rese, resv))
         ahat = torch.mm(torch.mm(resv, torch.diag(rese)), resv.t())
         self.assertEqual(cov, ahat, 1e-8, 'VeV\' wrong')
 
         # Second call to symeig
         self.assertFalse(resv.is_contiguous(), 'resv is contiguous')
-        torch.symeig(rese, resv, cov.clone(), True)
+        torch.symeig(cov.clone(), True, out=(rese, resv))
         ahat = torch.mm(torch.mm(resv, torch.diag(rese)), resv.t())
         self.assertEqual(cov, ahat, 1e-8, 'VeV\' wrong')
 
@@ -1448,7 +1448,7 @@ class TestTorch(TestCase):
         v = torch.zeros(4, 2, 4)[:,1]
         self.assertFalse(v.is_contiguous(), 'V is contiguous')
         self.assertFalse(e.is_contiguous(), 'E is contiguous')
-        torch.symeig(e, v, X, True)
+        torch.symeig(X, True, out=(e, v))
         Xhat = torch.mm(torch.mm(v, torch.diag(e)), v.t())
         self.assertEqual(X, Xhat, 1e-8, 'VeV\' wrong')
 
@@ -1463,7 +1463,7 @@ class TestTorch(TestCase):
         uu = torch.Tensor()
         ss = torch.Tensor()
         vv = torch.Tensor()
-        uuu, sss, vvv = torch.svd(uu, ss, vv, a)
+        uuu, sss, vvv = torch.svd(a, out=(uu, ss, vv))
         self.assertEqual(u, uu, 0, 'torch.svd')
         self.assertEqual(u, uuu, 0, 'torch.svd')
         self.assertEqual(s, ss, 0, 'torch.svd')
@@ -1478,7 +1478,7 @@ class TestTorch(TestCase):
         self.assertEqual(X, Xhat, 1e-8, 'USV\' wrong')
 
         self.assertFalse(U.is_contiguous(), 'U is contiguous')
-        torch.svd(U, S, V, X)
+        torch.svd(X, out=(U, S, V))
         Xhat = torch.mm(U, torch.mm(S.diag(), V.t()))
         self.assertEqual(X, Xhat, 1e-8, 'USV\' wrong')
 
@@ -1491,7 +1491,7 @@ class TestTorch(TestCase):
         self.assertFalse(U.is_contiguous(), 'U is contiguous')
         self.assertFalse(S.is_contiguous(), 'S is contiguous')
         self.assertFalse(V.is_contiguous(), 'V is contiguous')
-        torch.svd(U, S, V, X)
+        torch.svd(X, out=(U, S, V))
         Xhat = torch.mm(U, torch.mm(S.diag(), V.t()))
         self.assertEqual(X, Xhat, 1e-8, 'USV\' wrong')
 
@@ -1505,11 +1505,11 @@ class TestTorch(TestCase):
         self.assertEqual(E, torch.mm(MI, M), 1e-8, 'inverse value')
 
         MII = torch.Tensor(5, 5)
-        torch.inverse(MII, M)
+        torch.inverse(M, out=MII)
         self.assertFalse(MII.is_contiguous(), 'MII is contiguous')
         self.assertEqual(MII, MI, 0, 'inverse value in-place')
         # second call, now that MII is transposed
-        torch.inverse(MII, M)
+        torch.inverse(M, out=MII)
         self.assertFalse(MII.is_contiguous(), 'MII is contiguous')
         self.assertEqual(MII, MI, 0, 'inverse value in-place')
 
@@ -1789,14 +1789,15 @@ class TestTorch(TestCase):
             if inplace:
                 u = torch.Tensor(a.size())
                 piv = torch.IntTensor(a.size(0))
-                args = [u, piv, a]
+                kwargs = {'out': (u, piv)}
             else:
-                args = [a]
+                kwargs = {}
+            args = [a]
 
             if uplo is not None:
                 args += [uplo]
 
-            u, piv = torch.pstrf(*args)
+            u, piv = torch.pstrf(*args, **kwargs)
 
             if uplo is False:
                 a_reconstructed = torch.mm(u, u.t())
@@ -2333,7 +2334,7 @@ class TestTorch(TestCase):
                 dst1 = torch.nonzero(tensor)
                 dst2 = tensor.nonzero()
                 dst3 = torch.LongTensor()
-                torch.nonzero(dst3, tensor)
+                torch.nonzero(tensor, out=dst3)
                 if len(shape) == 1:
                     dst = []
                     for i in range(num_src):

--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -185,7 +185,10 @@ class cwrap(object):
             lambda arg: not 'ignore_check' in arg or not arg['ignore_check'],
             option['arguments']))
         option['num_checked_args'] = len(checked_args)
-        for i, arg in enumerate(checked_args):
+        idx_args = list(filter(
+            lambda arg: not arg.get('ignore_check') and not arg.get('no_idx'),
+            option['arguments']))
+        for i, arg in enumerate(idx_args):
             arg['idx'] = i
 
         # Generate checks

--- a/tools/cwrap/plugins/ArgcountChecker.py
+++ b/tools/cwrap/plugins/ArgcountChecker.py
@@ -7,6 +7,6 @@ class ArgcountChecker(CWrapPlugin):
             checks = '__argcount == 0'
         else:
             indent = '\n          '
-            checks = '__argcount == {} &&'.format(option['num_checked_args']) + \
-                indent + checks
+            argcount = option['num_checked_args'] + option.get('argcount_offset', 0)
+            checks = '__argcount == {} &&'.format(str(argcount)) + indent + checks
         return checks

--- a/tools/cwrap/plugins/KwargsPlugin.py
+++ b/tools/cwrap/plugins/KwargsPlugin.py
@@ -40,7 +40,9 @@ class KwargsPlugin(CWrapPlugin):
         for option in declaration['options']:
             for arg in option['arguments']:
                 name = arg['name']
-                if not arg.get('ignore_check') and name not in seen_args:
+                if (not arg.get('ignore_check') and
+                        not arg.get('no_kwargs') and
+                        name not in seen_args):
                     seen_args.add(name)
                     args.append(name)
         declarations = '\n    '.join(['PyObject *__kw_{} = NULL;'.format(name) for name in args])

--- a/torch/autograd/functions/blas.py
+++ b/torch/autograd/functions/blas.py
@@ -24,8 +24,8 @@ class Addmm(_BlasBase):
     def forward(self, add_matrix, matrix1, matrix2):
         self.save_for_backward(matrix1, matrix2)
         output = self._get_output(add_matrix)
-        return torch.addmm(output, self.alpha, add_matrix, self.beta,
-                matrix1, matrix2)
+        return torch.addmm(self.alpha, add_matrix, self.beta,
+                matrix1, matrix2, out=output)
 
     def backward(self, grad_output):
         matrix1, matrix2 = self.saved_tensors
@@ -54,8 +54,8 @@ class Addbmm(_BlasBase):
     def forward(self, add_matrix, batch1, batch2):
         self.save_for_backward(batch1, batch2)
         output = self._get_output(add_matrix)
-        return torch.addbmm(output, self.alpha, add_matrix, self.beta,
-                batch1, batch2)
+        return torch.addbmm(self.alpha, add_matrix, self.beta,
+                batch1, batch2, out=output)
 
     def backward(self, grad_output):
         batch1, batch2 = self.saved_tensors
@@ -89,8 +89,8 @@ class Baddbmm(_BlasBase):
     def forward(self, add_batch, batch1, batch2):
         self.save_for_backward(batch1, batch2)
         output = self._get_output(add_batch)
-        return torch.baddbmm(output, self.alpha, add_batch, self.beta,
-                batch1, batch2)
+        return torch.baddbmm(self.alpha, add_batch, self.beta,
+                batch1, batch2, out=output)
 
     def backward(self, grad_output):
         batch1, batch2 = self.saved_tensors
@@ -119,8 +119,8 @@ class Addmv(_BlasBase):
     def forward(self, add_vector, matrix, vector):
         self.save_for_backward(matrix, vector)
         output = self._get_output(add_vector)
-        return torch.addmv(output, self.alpha, add_vector, self.beta,
-                matrix, vector)
+        return torch.addmv(self.alpha, add_vector, self.beta,
+                matrix, vector, out=output)
 
     def backward(self, grad_output):
         matrix, vector = self.saved_tensors
@@ -149,8 +149,8 @@ class Addr(_BlasBase):
     def forward(self, add_matrix, vector1, vector2):
         self.save_for_backward(vector1, vector2)
         output = self._get_output(add_matrix)
-        return torch.addr(output, self.alpha, add_matrix, self.beta,
-                vector1, vector2)
+        return torch.addr(self.alpha, add_matrix, self.beta,
+                vector1, vector2, out=output)
 
     def backward(self, grad_output):
         vector1, vector2 = self.saved_tensors

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -448,7 +448,7 @@ IMPLEMENT_STATELESS_REVERSED(ne)
 // In nonzero, the first argument might be a LongTensor that will be used
 // for indices output, so we should pick a function based on second
 // tensor's type.
-static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args)
+static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args, PyObject *kwargs)
 {
   PyObject *tensor = THPDefaultTensorClass;
   if (PyTuple_Size(args) == 1)
@@ -462,19 +462,22 @@ static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args)
   THPObjectPtr method = PyObject_GetAttrString(methods, "nonzero");
   THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
       tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  return PyObject_Call(method, args, NULL);
+  return PyObject_Call(method, args, kwargs);
 }
 
-static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args)
+static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args, PyObject *kwargs)
 {
   PyObject *tensor = THPLongTensorClass;
+  PyObject *out;
+  if (kwargs && (out = PyDict_GetItemString(kwargs, "out")))
+      tensor = out;
   THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
   THPUtils_assert(methods, "Type %s doesn't implement stateless methods",
       tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
   THPObjectPtr method = PyObject_GetAttrString(methods, "randperm");
   THPUtils_assert(method, "Type %s doesn't implement stateless method randperm",
       tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  return PyObject_Call(method, args, NULL);
+  return PyObject_Call(method, args, kwargs);
 }
 
 static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
@@ -679,7 +682,7 @@ static PyMethodDef TorchMethods[] = {
   {"t",               (PyCFunction)THPModule_t,                 METH_VARARGS | METH_KEYWORDS, NULL},
   {"transpose",       (PyCFunction)THPModule_transpose,         METH_VARARGS | METH_KEYWORDS, NULL},
   {"squeeze",         (PyCFunction)THPModule_squeeze,           METH_VARARGS | METH_KEYWORDS, NULL},
-  {"nonzero",         (PyCFunction)THPModule_nonzero,           METH_VARARGS, NULL},
+  {"nonzero",         (PyCFunction)THPModule_nonzero,           METH_VARARGS | METH_KEYWORDS, NULL},
   {"renorm",          (PyCFunction)THPModule_renorm,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"dist",            (PyCFunction)THPModule_dist,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"linspace",        (PyCFunction)THPModule_linspace,          METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -102,7 +102,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -123,7 +123,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -355,7 +355,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - THBoolTensor* mask
 ]]
@@ -417,12 +417,12 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   options:
     - arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
     - cname: squeeze1d
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -448,7 +448,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THIndexTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -485,7 +485,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dim
     - THIndexTensor* index
@@ -532,7 +532,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dimension
     - long start
@@ -544,7 +544,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dimension
     - long size
@@ -558,7 +558,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - accreal xmin
     - accreal xmax
     - arg: accreal step
@@ -592,7 +592,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
     THTensor_(resize)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, _size, NULL);
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dim
     - THIndexTensor* index

--- a/torch/csrc/generic/methods/TensorCompare.cwrap
+++ b/torch/csrc/generic/methods/TensorCompare.cwrap
@@ -5,13 +5,13 @@
     - cname: ltValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: ltTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -40,13 +40,13 @@
     - cname: ltValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: ltTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: ltValueT
@@ -69,13 +69,13 @@
     - cname: gtValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: gtTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -104,13 +104,13 @@
     - cname: gtValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: gtTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: gtValueT
@@ -133,13 +133,13 @@
     - cname: leValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: leTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -168,13 +168,13 @@
     - cname: leValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: leTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: leValueT
@@ -197,13 +197,13 @@
     - cname: geValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: geTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -232,13 +232,13 @@
     - cname: geValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: geTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: geValueT
@@ -261,13 +261,13 @@
     - cname: eqValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: eqTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -296,13 +296,13 @@
     - cname: eqValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: eqTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: eqValueT
@@ -325,13 +325,13 @@
     - cname: neValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: neTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -360,13 +360,13 @@
     - cname: neValue
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - real value
     - cname: neTensor
       arguments:
         - arg: THBoolTensor* result
-          allocate: True
+          output: True
         - THTensor* tensor
         - THTensor* other
     - cname: neValueT
@@ -393,9 +393,9 @@
       return: argument 0,1
       arguments:
         - arg: THTensor* min
-          allocate: True
+          output: True
         - arg: THIndexTensor* min_indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -412,9 +412,9 @@
       return: argument 0,1
       arguments:
         - arg: THTensor* max
-          allocate: True
+          output: True
         - arg: THIndexTensor* max_indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -428,17 +428,17 @@
     - before_call: long __last_dim = THTensor_(nDimension)(LIBRARY_STATE ((THPTensor*)$arg2)->cdata)-1;
       arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long k
         - CONSTANT __last_dim
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long k
         - long dim
@@ -453,16 +453,16 @@
     - before_call: long __last_dim = THTensor_(nDimension)(LIBRARY_STATE ((THPTensor*)$arg2)->cdata)-1;
       arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - CONSTANT __last_dim
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -476,16 +476,16 @@
     - before_call: long __last_dim = THTensor_(nDimension)(LIBRARY_STATE ((THPTensor*)$arg2)->cdata)-1;
       arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - CONSTANT __last_dim
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -498,25 +498,25 @@
     - before_call: long __last_dim = THTensor_(nDimension)(LIBRARY_STATE ((THPTensor*)$arg2)->cdata)-1;
       arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - CONSTANT __last_dim
         - CONSTANT false
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
         - CONSTANT false
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
         - bool descending
@@ -531,9 +531,9 @@
     - before_call: long __last_dim = THTensor_(nDimension)(LIBRARY_STATE ((THPTensor*)$arg2)->cdata)-1;
       arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long k
         - CONSTANT __last_dim
@@ -541,9 +541,9 @@
         - CONSTANT false
     - arguments:
         - arg: THTensor* values
-          allocate: True
+          output: True
         - arg: THIndexTensor* indices
-          allocate: True
+          output: True
         - THTensor* self
         - long k
         - long dim

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -5,7 +5,7 @@
   with_stateless: True
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -38,7 +38,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -60,7 +60,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -82,7 +82,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -104,7 +104,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -126,7 +126,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -148,7 +148,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -170,7 +170,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -192,7 +192,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -214,7 +214,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -236,7 +236,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -258,7 +258,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -280,7 +280,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -302,7 +302,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -324,7 +324,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -346,7 +346,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -368,7 +368,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -390,7 +390,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -412,7 +412,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -434,7 +434,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -456,7 +456,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -473,7 +473,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -491,7 +491,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
         - CONSTANT false
@@ -510,7 +510,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
         - CONSTANT false
@@ -531,7 +531,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - real p
         - long dim
@@ -546,7 +546,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - real p
         - long dim
@@ -590,7 +590,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
 ]]
 
@@ -614,7 +614,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
 ]]
 
@@ -637,7 +637,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* other
 ]]
@@ -666,19 +666,19 @@
     - cname: pow
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - real exponent
     - cname: cpow
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* exponent
     - cname: tpow
       arguments:
         - arg: THTensor* destination
-          allocate: True
+          output: True
         - real base
         - THTensor* self
 ]]
@@ -709,7 +709,7 @@
   cname: lerp
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* end
     - real weight
@@ -734,7 +734,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - real start
     - real end
     - arg: long steps
@@ -748,7 +748,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - real start
     - real end
     - arg: long steps
@@ -763,28 +763,28 @@
   options:
     - arguments:
       - arg: THTensor* destination
-        allocate: True
+        output: True
       - THTensor* self
       - CONSTANT 100
       - CONSTANT 0
       - CONSTANT 0
     - arguments:
       - arg: THTensor* destination
-        allocate: True
+        output: True
       - THTensor* self
       - long bins
       - CONSTANT 0
       - CONSTANT 0
     - arguments:
       - arg: THTensor* destination
-        allocate: True
+        output: True
       - THTensor* self
       - long bins
       - real min
       - CONSTANT 0
     - arguments:
       - arg: THTensor* destination
-        allocate: True
+        output: True
       - THTensor* self
       - long bins
       - real min
@@ -807,13 +807,13 @@
     - cname: cmax
       arguments:
       - arg: THTensor* result
-        allocate: True
+        output: True
       - THTensor* self
       - THTensor* other
     - cname: cmaxValue
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
 ]]
@@ -842,13 +842,13 @@
     - cname: cmin
       arguments:
       - arg: THTensor* result
-        allocate: True
+        output: True
       - THTensor* self
       - THTensor* other
     - cname: cminValue
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
 ]]
@@ -881,7 +881,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -898,7 +898,7 @@
       return: argument 0
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - long dim
 ]]
@@ -909,7 +909,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dim
 ]]
@@ -920,7 +920,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long dim
 ]]
@@ -931,7 +931,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -960,13 +960,13 @@
     - cname: add
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: cadd
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - arg: real value
           default: AS_REAL(1)
@@ -1000,13 +1000,13 @@
     - cname: sub
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: csub
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - arg: real value
           default: AS_REAL(1)
@@ -1040,13 +1040,13 @@
     - cname: mul
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: cmul
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -1076,13 +1076,13 @@
     - cname: div
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: cdiv
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -1112,13 +1112,13 @@
     - cname: fmod
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: cfmod
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -1148,13 +1148,13 @@
     - cname: remainder
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - real value
     - cname: cremainder
       arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - THTensor* other
 ]]
@@ -1181,7 +1181,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - real min
     - real max
@@ -1214,7 +1214,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - arg: long k
       default: 0
@@ -1237,7 +1237,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - arg: long k
       default: 0
@@ -1260,7 +1260,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* destination
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* other
     - arg: long dim
@@ -1275,12 +1275,12 @@
   options:
     - arguments:
       - arg: THTensor* result
-        allocate: True
+        output: True
       - long n
       - argument 1
     - arguments:
       - arg: THTensor* result
-        allocate: True
+        output: True
       - long n
       - long m
 ]]
@@ -1292,7 +1292,7 @@
   options:
     - arguments:
         - arg: THTensor* result
-          allocate: True
+          output: True
         - THTensor* self
         - arg: long diagonal
           default: 0
@@ -1304,7 +1304,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: real beta
       default: AS_REAL(1)
     - THTensor* self
@@ -1335,7 +1335,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: real beta
       default: AS_REAL(1)
     - THTensor* self
@@ -1366,7 +1366,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: real beta
       default: AS_REAL(1)
     - THTensor* self
@@ -1403,7 +1403,7 @@
     THTensor_(zero)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata);
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - CONSTANT AS_REAL(0)
     - argument 0
     - CONSTANT AS_REAL(1)
@@ -1422,7 +1422,7 @@
     THTensor_(zero)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata);
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - CONSTANT AS_REAL(0)
     - argument 0
     - CONSTANT AS_REAL(1)
@@ -1442,7 +1442,7 @@
     THTensor_(zero)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata);
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - CONSTANT AS_REAL(0)
     - argument 0
     - CONSTANT AS_REAL(1)
@@ -1463,7 +1463,7 @@
     THTensor_(zero)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata);
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - CONSTANT AS_REAL(0)
     - argument 0
     - CONSTANT AS_REAL(1)
@@ -1477,7 +1477,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: real beta
       default: AS_REAL(1)
     - THTensor* self
@@ -1508,7 +1508,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: real beta
       default: AS_REAL(1)
     - THTensor* self
@@ -1539,7 +1539,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - arg: real value
       default: AS_REAL(1)
@@ -1566,7 +1566,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - arg: real value
       default: AS_REAL(1)
@@ -1619,9 +1619,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* solution
-      allocate: True
+      output: True
     - arg: THTensor* lu
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* A
 ]]
@@ -1633,9 +1633,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* A
 ]]
@@ -1647,9 +1647,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* A
     - arg: bool upper
@@ -1674,9 +1674,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool eigenvectors
       if_true: V
@@ -1696,9 +1696,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool eigenvectors
       if_true: V
@@ -1714,11 +1714,11 @@ static const char *R = &__R;
   return: argument 0,1,2
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - arg: THTensor* res3
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool some
       if_true: S
@@ -1734,7 +1734,7 @@ static const char *R = &__R;
   return: argument 0
   arguments:
     - arg: THTensor* output
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -1745,7 +1745,7 @@ static const char *R = &__R;
   return: argument 0
   arguments:
     - arg: THTensor* output
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool upper
       if_true: U
@@ -1760,7 +1760,7 @@ static const char *R = &__R;
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* input2
     - arg: bool upper
@@ -1776,7 +1776,7 @@ static const char *R = &__R;
   return: argument 0
   arguments:
     - arg: THTensor* output
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool upper
       if_true: U
@@ -1793,9 +1793,9 @@ static const char *R = &__R;
     THIntTensor_sub(((THPIntTensor*)$arg1)->cdata, ((THPIntTensor*)$arg1)->cdata, 1);
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THIntTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
     - arg: bool upper
       if_true: U
@@ -1812,9 +1812,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -1825,9 +1825,9 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* res1
-      allocate: True
+      output: True
     - arg: THTensor* res2
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 
@@ -1838,7 +1838,7 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* input2
 ]]
@@ -1850,7 +1850,7 @@ static const char *R = &__R;
   return: argument 0,1
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - THTensor* input2
     - THTensor* input3

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -5,7 +5,7 @@
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
     - long n
@@ -57,7 +57,7 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
   return: argument 0
   arguments:
     - arg: THLongTensor* result
-      allocate: True
+      output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
     - THTensor* self
@@ -115,7 +115,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - cname: normal_means
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
         - THTensor* means
@@ -124,7 +124,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - cname: normal_stddevs
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
         - arg: real mean
@@ -133,7 +133,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - cname: normal_means_stddevs
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
         - THTensor* means
@@ -206,7 +206,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
     - arg: THSize* size
@@ -220,7 +220,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
     - arg: THSize* size
@@ -234,7 +234,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
   return: argument 0
   arguments:
     - arg: THIndexTensor* result
-      allocate: True
+      output: True
     - THTensor* self
     - long num_samples
     - arg: bool replacement
@@ -288,7 +288,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
     - cname: normal
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - arg: double mean
           default: 0
         - arg: double stddev
@@ -296,21 +296,21 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
     - cname: normal_means
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - THTensor* means
         - arg: double stddev
           default: 1
     - cname: normal_stddevs
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - arg: double mean
           default: 0
         - THTensor* stddevs
     - cname: normal_means_stddevs
       arguments:
         - arg: THTensor* output
-          allocate: True
+          output: True
         - THTensor* means
         - THTensor* stddevs
 ]]
@@ -373,7 +373,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -385,7 +385,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
   return: argument 0
   arguments:
     - arg: THTensor* result
-      allocate: True
+      output: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -415,7 +415,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
   cname: BERNOULLI_TENSOR
   arguments:
     - arg: THTensor* output
-      allocate: True
+      output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
     - THTensor* self
@@ -473,7 +473,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
     THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg1)->cdata);
   arguments:
     - arg: THTensor* output
-      allocate: True
+      output: True
     - THTensor* self
 ]]
 

--- a/torch/legacy/nn/BCECriterion.py
+++ b/torch/legacy/nn/BCECriterion.py
@@ -31,14 +31,14 @@ class BCECriterion(Criterion):
             weights = self.weights.view(1, target.size(1)).expand_as(target)
 
         # log(input) * target
-        torch.add(buffer, input, self.eps).log_()
+        torch.add(input, self.eps, out=buffer).log_()
         if weights is not None:
             buffer.mul_(weights)
 
         output = torch.dot(target, buffer)
 
         # log(1 - input) * (1 - target)
-        torch.mul(buffer, input, -1).add_(1+self.eps).log_()
+        torch.mul(input, -1, out=buffer).add_(1+self.eps).log_()
         if weights is not None:
             buffer.mul_(weights)
 
@@ -75,11 +75,11 @@ class BCECriterion(Criterion):
 
          buffer.resize_as_(input)
          # - x ( 1 + self.eps -x ) + self.eps
-         torch.add(buffer, input, -1).add_(-self.eps).mul_(input).add_(-self.eps)
+         torch.add(input, -1, out=buffer).add_(-self.eps).mul_(input).add_(-self.eps)
 
          gradInput.resize_as_(input)
          # y - x
-         torch.add(gradInput, target, -1, input)
+         torch.add(target, -1, input, out=gradInput)
          # - (y - x) / ( x ( 1 + self.eps -x ) + self.eps )
          gradInput.div_(buffer)
 

--- a/torch/legacy/nn/CMul.py
+++ b/torch/legacy/nn/CMul.py
@@ -97,8 +97,8 @@ class CMul(Module):
         contiguousView(self._gradOutput, gradOutput, batchSize, -1)
         self._gradWeight = self.gradWeight.view(1, -1)
 
-        torch.mul(self._repeat, self._input, self._gradOutput)
-        torch.sum(self._sum, self._repeat, 0)
+        torch.mul(self._input, self._gradOutput, out=self._repeat)
+        torch.sum(self._repeat, 0, out=self._sum)
         self._gradWeight.add_(scale, self._sum)
 
     def type(self, type=None, tensorCache=None):

--- a/torch/legacy/nn/Cosine.py
+++ b/torch/legacy/nn/Cosine.py
@@ -38,7 +38,7 @@ class Cosine(Module):
 
         # y_j = (w_j * x) / ( || w_j || * || x || )
 
-        torch.norm(self._weightNorm, self.weight, 2, 1).add_(1e-12)
+        torch.norm(self.weight, 2, 1, out=self._weightNorm).add_(1e-12)
 
         batchSize = input.size(0)
         nelement = self.output.nelement()
@@ -48,7 +48,7 @@ class Cosine(Module):
 
         self.output.addmm_(0., 1., input, self.weight.t())
 
-        torch.norm(self._inputNorm, input, 2, 1).add_(1e-12)
+        torch.norm(input, 2, 1, out=self._inputNorm).add_(1e-12)
         self.output.div_(self._weightNorm.view(1, outputSize).expand_as(self.output))
         self.output.div_(self._inputNorm.expand_as(self.output))
         return self.output
@@ -85,7 +85,7 @@ class Cosine(Module):
         self.gradInput.copy_(input).div_(inputNorm)
         self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
         self._gradOutput.mul_(self.output)
-        torch.sum(self._sum, self._gradOutput, 1)
+        torch.sum(self._gradOutput, 1, out=self._sum)
         self.gradInput.mul_(self._sum.expand_as(input))
 
         self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
@@ -116,7 +116,7 @@ class Cosine(Module):
               self._gradOutput = gradOutput.new()
         self._gradOutput.resize_as_(gradOutput).copy_(gradOutput)
         self._gradOutput.mul_(self.output)
-        torch.sum(self._sum, self._gradOutput, 0)
+        torch.sum(self._gradOutput, 0, out=self._sum)
         grad = self._sum[0]
         grad.div_(self._weightNorm.select(1, 0))
         self._weight.mul_(grad.view(outputSize, 1).expand_as(self._weight))

--- a/torch/legacy/nn/CosineDistance.py
+++ b/torch/legacy/nn/CosineDistance.py
@@ -45,22 +45,22 @@ class CosineDistance(Module):
            self.w32 = input1.new()
            self.ones = input1.new()
 
-        torch.mul(self.buffer, input1, input2)
-        torch.sum(self.w1, self.buffer, 1)
+        torch.mul(input1, input2, out=self.buffer)
+        torch.sum(self.buffer, 1, out=self.w1)
 
         epsilon = 1e-12
-        torch.mul(self.buffer, input1, input1)
-        torch.sum(self.w22, self.buffer, 1).add_(epsilon)
+        torch.mul(input1, input1, out=self.buffer)
+        torch.sum(self.buffer, 1, out=self.w22).add_(epsilon)
         self.w22.cinv_()
         self.w.resize_as_(self.w22).copy_(self.w22)
 
-        torch.mul(self.buffer, input2, input2)
-        torch.sum(self.w32, self.buffer, 1).add_(epsilon)
+        torch.mul(input2, input2, out=self.buffer)
+        torch.sum(self.buffer, 1, out=self.w32).add_(epsilon)
         self.w32.cinv_()
         self.w.mul_(self.w32)
         self.w.sqrt_()
 
-        torch.mul(self.output, self.w1, self.w)
+        torch.mul(self.w1, self.w, out=self.output)
         self.output.resize_(input1.size(0))
 
         return self.output
@@ -83,11 +83,11 @@ class CosineDistance(Module):
         gw1.resize_as_(v1).copy_(v2)
         gw2.resize_as_(v1).copy_(v1)
 
-        torch.mul(self.buffer, self.w1, self.w22)
+        torch.mul(self.w1, self.w22, out=self.buffer)
         gw1.addcmul_(-1, self.buffer.expand_as(v1), v1)
         gw1.mul_(self.w.expand_as(v1))
 
-        torch.mul(self.buffer, self.w1, self.w32)
+        torch.mul(self.w1, self.w32, out=self.buffer)
         gw2.addcmul_(-1, self.buffer.expand_as(v1), v2)
         gw2.mul_(self.w.expand_as(v1))
 

--- a/torch/legacy/nn/DotProduct.py
+++ b/torch/legacy/nn/DotProduct.py
@@ -15,8 +15,8 @@ class DotProduct(Module):
         if self.buffer is None:
            self.buffer = input1.new()
 
-        torch.mul(self.buffer, input1, input2)
-        torch.sum(self.output, self.buffer, 1)
+        torch.mul(input1, input2, out=self.buffer)
+        torch.sum(self.buffer, 1, out=self.output)
         self.output.resize_(input1.size(0))
         return self.output
 

--- a/torch/legacy/nn/Euclidean.py
+++ b/torch/legacy/nn/Euclidean.py
@@ -81,7 +81,7 @@ class Euclidean(Module):
         else:
             self._repeat.add_(-1, self._expand2)
 
-        torch.norm(self.output, self._repeat, 2, 1)
+        torch.norm(self._repeat, 2, 1, out=self.output)
         self.output.resize_(batchSize, outputSize)
 
         return self.output
@@ -113,7 +113,7 @@ class Euclidean(Module):
         # to prevent div by zero (NaN) bugs
         self._output.resize_as_(self.output).copy_(self.output).add_(0.0000001)
         self._view(self._gradOutput, gradOutput, gradOutput.size())
-        torch.div(self._div, gradOutput, self._output)
+        torch.div(gradOutput, self._output, out=self._div)
         assert input.dim() == 2
         batchSize = input.size(0)
 
@@ -124,10 +124,10 @@ class Euclidean(Module):
             self._repeat2.resize_as_(self._expand3).copy_(self._expand3)
             self._repeat2.mul_(self._repeat)
         else:
-            torch.mul(self._repeat2, self._repeat, self._expand3)
+            torch.mul(self._repeat, self._expand3, out=self._repeat2)
 
 
-        torch.sum(self.gradInput, self._repeat2, 2)
+        torch.sum(self._repeat2, 2, out=self.gradInput)
         self.gradInput.resize_as_(input)
 
         return self.gradInput
@@ -145,7 +145,7 @@ class Euclidean(Module):
         assert input.dim() == 2
         if self._sum is None:
               self._sum = input.new()
-        torch.sum(self._sum, self._repeat2, 0)
+        torch.sum(self._repeat2, 0, out=self._sum)
         self._sum.resize_(inputSize, outputSize)
         self.gradWeight.add_(-scale, self._sum)
 

--- a/torch/legacy/nn/Exp.py
+++ b/torch/legacy/nn/Exp.py
@@ -4,8 +4,8 @@ from .Module import Module
 class Exp(Module):
 
     def updateOutput(self, input):
-        return torch.exp(self.output, input)
+        return torch.exp(input, out=self.output)
 
     def updateGradInput(self, input, gradOutput):
-        return torch.mul(self.gradInput, self.output, gradOutput)
+        return torch.mul(self.output, gradOutput, out=self.gradInput)
 

--- a/torch/legacy/nn/Index.py
+++ b/torch/legacy/nn/Index.py
@@ -11,7 +11,7 @@ class Index(Module):
     def updateOutput(self, input):
          t = input[0]
          index = input[1]
-         torch.index_select(self.output, t, self.dimension, index)
+         torch.index_select(t, self.dimension, index, out=self.output)
          return self.output
 
     def updateGradInput(self, input, gradOutput):

--- a/torch/legacy/nn/LookupTable.py
+++ b/torch/legacy/nn/LookupTable.py
@@ -59,9 +59,9 @@ class LookupTable(Module):
         self.renorm(input)
         input = self._makeInputContiguous(input)
         if input.dim() == 1:
-           torch.index_select(self.output, self.weight, 0, input)
+           torch.index_select(self.weight, 0, input, out=self.output)
         elif input.dim() == 2:
-           torch.index_select(self.output, self.weight, 0, input.view(-1))
+           torch.index_select(self.weight, 0, input.view(-1), out=self.output)
            self.output = self.output.view(input.size(0), input.size(1), self.weight.size(1))
         else:
            raise RuntimeError("input must be a vector or matrix")

--- a/torch/legacy/nn/MM.py
+++ b/torch/legacy/nn/MM.py
@@ -21,7 +21,7 @@ class MM(Module):
             if self.transB:
                 b = b.t()
             self.output.resize_(a.size(0), b.size(1))
-            torch.mm(self.output, a, b)
+            torch.mm(a, b, out=self.output)
         else:
             if self.transA:
                 a = a.transpose(2, 3)
@@ -29,7 +29,7 @@ class MM(Module):
                 b = b.transpose(2, 3)
 
             self.output.resize_(a.size(0), a.size(1), b.size(2))
-            torch.bmm(self.output, a, b)
+            torch.bmm(a, b, out=self.output)
 
         return self.output
 
@@ -59,14 +59,14 @@ class MM(Module):
             b = b.transpose(h_dim, w_dim)
 
         if self.transA:
-            getattr(torch, f)(self.gradInput[0], b, gradOutput.transpose(h_dim, w_dim))
+            getattr(torch, f)(b, gradOutput.transpose(h_dim, w_dim), out=self.gradInput[0])
         else:
-            getattr(torch, f)(self.gradInput[0], gradOutput, b)
+            getattr(torch, f)(gradOutput, b, out=self.gradInput[0])
 
         if self.transB:
-            getattr(torch, f)(self.gradInput[1], gradOutput.transpose(h_dim, w_dim), a)
+            getattr(torch, f)(gradOutput.transpose(h_dim, w_dim), a, out=self.gradInput[1])
         else:
-            getattr(torch, f)(self.gradInput[1], a, gradOutput)
+            getattr(torch, f)(a, gradOutput, out=self.gradInput[1])
 
         return self.gradInput
 

--- a/torch/legacy/nn/MaskedSelect.py
+++ b/torch/legacy/nn/MaskedSelect.py
@@ -14,18 +14,18 @@ class MaskedSelect(Module):
 
     def updateOutput(self, input):
         input, mask = input
-        torch.masked_select(self.output, input, mask)
+        torch.masked_select(input, mask, out=self.output)
         return self.output
 
     def updateGradInput(self, input, gradOutput):
         input, mask = input
         if input.type() == 'torch.cuda.FloatTensor':
-            torch.range(self._maskIndexBufferCPU, 0, mask.nelement()-1).resize_(mask.size())
+            torch.range(0, mask.nelement()-1, out=self._maskIndexBufferCPU).resize_(mask.size())
             self._maskIndexBuffer.resize_(self._maskIndexBufferCPU.size()).copy_(self._maskIndexBufferCPU)
         else:
-            torch.range(self._maskIndexBuffer, 0, mask.nelement()-1).resize_(mask.size())
+            torch.range(0, mask.nelement()-1, out=self._maskIndexBuffer).resize_(mask.size())
 
-        torch.masked_select(self._maskIndices, self._maskIndexBuffer, mask)
+        torch.masked_select(self._maskIndexBuffer, mask, out=self._maskIndices)
         self._gradBuffer.resize_(input.nelement()).zero_()
         self._gradBuffer.scatter_(0, self._maskIndices, gradOutput)
         self._gradBuffer.resize_(input.size())

--- a/torch/legacy/nn/Max.py
+++ b/torch/legacy/nn/Max.py
@@ -27,7 +27,7 @@ class Max(Module):
     def updateOutput(self, input):
         self._lazyInit()
         dimension = self._getPositiveDimension(input)
-        torch.max(self._output, self._indices, input, dimension)
+        torch.max(input, dimension, out=(self._output, self._indices))
         if input.dim() > 1:
           self.output.set_(self._output.select(dimension, 0))
         else:

--- a/torch/legacy/nn/Min.py
+++ b/torch/legacy/nn/Min.py
@@ -27,7 +27,7 @@ class Min(Module):
     def updateOutput(self, input):
         self._lazyInit()
         dimension = self._getPositiveDimension(input)
-        torch.min(self._output, self._indices, input, dimension)
+        torch.min(input, dimension, out=(self._output, self._indices))
         if input.dim() > 1:
           self.output.set_(self._output.select(dimension, 0))
         else:

--- a/torch/legacy/nn/Normalize.py
+++ b/torch/legacy/nn/Normalize.py
@@ -39,21 +39,21 @@ class Normalize(Module):
                 self._indices = torch.cuda.FloatTensor() if torch.typename(self.output) == 'torch.cuda.FloatTensor' \
                     else torch.LongTensor()
 
-            torch.abs(self.buffer, input)
-            torch.max(self.norm, self._indices, self.buffer, 1)
+            torch.abs(input, out=self.buffer)
+            torch.max(self._indices, self.buffer, 1, out=self.norm)
             self.norm.add_(self.eps)
         else:
             if self.normp is None:
                   self.normp = input.new()
             if self.p % 2 != 0:
-                torch.abs(self.buffer, input).pow_(self.p)
+                torch.abs(input, out=self.buffer).pow_(self.p)
             else:
-                torch.pow(self.buffer, input, self.p)
+                torch.pow(input, self.p, out=self.buffer)
 
-            torch.sum(self.normp, self.buffer, 1).add_(self.eps)
-            torch.pow(self.norm, self.normp, 1./self.p)
+            torch.sum(self.buffer, 1, out=self.normp).add_(self.eps)
+            torch.pow(self.normp, 1./self.p, out=self.norm)
 
-        torch.div(self._output, input, self.norm.view(-1, 1).expand_as(input))
+        torch.div(input, self.norm.view(-1, 1).expand_as(input), out=self._output)
 
         self.output = self._output.view(input_size)
         return self.output
@@ -74,29 +74,29 @@ class Normalize(Module):
         self._gradInput.resize_(n, d)
         if self.p == float('inf'):
                 # specialization for the inf case
-                torch.mul(self._gradInput, self.norm.view(n, 1,1).expand(n, d,1), gradOutput)
+                torch.mul(self.norm.view(n, 1,1).expand(n, d,1), gradOutput, out=self._gradInput)
                 self.buffer.resize_as_(input).zero_()
                 self.cross.resize_(n, 1)
-                torch.gather(self.cross, input, 1, self._indices)
+                torch.gather(input, 1, self._indices, out=self.cross)
                 self.cross.div_(self.norm)
                 self.buffer.scatter_(1, self._indices, self.cross)
         else:
-                torch.mul(self._gradInput, self.normp.view(n, 1).expand(n, d), gradOutput)
+                torch.mul(self.normp.view(n, 1).expand(n, d), gradOutput, out=self._gradInput)
                 # small optimizations for different p
                 # buffer = input*|input|^(p-2)
                 # for non-even p, need to add absolute value
                 if self.p % 2 != 0:
                     if self.p < 2:
                         # add eps to avoid possible division by 0
-                        torch.abs(self.buffer, input).add_(self.eps).pow_(self.p-2).mul_(input)
+                        torch.abs(input, out=self.buffer).add_(self.eps).pow_(self.p-2).mul_(input)
                     else:
-                        torch.abs(self.buffer, input).pow_(self.p-2).mul_(input)
+                        torch.abs(input, out=self.buffer).pow_(self.p-2).mul_(input)
                 # special case for p == 2, pow(x, 0) = 1
                 elif self.p == 2:
                     self.buffer.copy_(input)
                 else:
                     # p is even and > 2, pow(x, p) is always positive
-                    torch.pow(self.buffer, input, self.p-2).mul_(input)
+                    torch.pow(input, self.p-2, out=self.buffer).mul_(input)
 
         # compute cross term in two steps
         self.cross.resize_(n, 1)
@@ -106,17 +106,17 @@ class Normalize(Module):
         # computation and also a huge buffer of size n*d^2
         if self.buffer2 is None:
               self.buffer2 = input.new() # nxd
-        torch.mul(self.buffer2, input, gradOutput)
-        torch.sum(self.cross, self.buffer2, 1)
+        torch.mul(input, gradOutput, out=self.buffer2)
+        torch.sum(self.buffer2, 1, out=self.cross)
 
         self.buffer.mul_(self.cross.expand_as(self.buffer))
         self._gradInput.add_(-1, self.buffer)
 
         # reuse cross buffer for normalization
         if self.p == float('inf'):
-            torch.mul(self.cross, self.norm, self.norm)
+            torch.mul(self.norm, self.norm, out=self.cross)
         else:
-            torch.mul(self.cross, self.normp, self.norm)
+            torch.mul(self.normp, self.norm, out=self.cross)
 
         self._gradInput.div_(self.cross.expand(n, d))
 

--- a/torch/legacy/nn/PairwiseDistance.py
+++ b/torch/legacy/nn/PairwiseDistance.py
@@ -22,7 +22,7 @@ class PairwiseDistance(Module):
         if self.diff is None:
               self.diff = input[0].new()
 
-        torch.add(self.diff, input[0], -1, input[1]).abs_()
+        torch.add(input[0], -1, input[1], out=self.diff).abs_()
 
         self.output.resize_(input[0].size(0))
         self.output.zero_()

--- a/torch/legacy/nn/PartialLinear.py
+++ b/torch/legacy/nn/PartialLinear.py
@@ -77,7 +77,7 @@ class PartialLinear(Module):
             if self.buffer is None:
                 self.buffer = input.new()
             self.buffer.resize_(gradOutput.size(1))
-            torch.mv(self.buffer, gradOutput.t(), self.addBuffer).mul_(scale)
+            torch.mv(gradOutput.t(), self.addBuffer, out=self.buffer).mul_(scale)
             self.gradBias.index_add_(
                 1, self.partition, self.buffer.view(1, self.buffer.nelement())
             )

--- a/torch/legacy/nn/Replicate.py
+++ b/torch/legacy/nn/Replicate.py
@@ -28,5 +28,5 @@ class Replicate(Module):
         size.insert(self.dim, 1)
 
         gradInput = self.gradInput.view(*size)
-        torch.sum(gradInput, gradOutput, self.dim)
+        torch.sum(gradOutput, self.dim, out=gradInput)
         return self.gradInput

--- a/torch/legacy/nn/Sum.py
+++ b/torch/legacy/nn/Sum.py
@@ -20,7 +20,7 @@ class Sum(Module):
     def updateOutput(self, input):
         dimension = self._getPositiveDimension(input)
 
-        torch.sum(self.output, input, dimension)
+        torch.sum(input, dimension, out=self.output)
         if self.sizeAverage:
             self.output.div_(input.size(dimension))
         if self.output.dim() > 1:

--- a/torch/legacy/optim/adamax.py
+++ b/torch/legacy/optim/adamax.py
@@ -56,7 +56,7 @@ def adamax(opfunc, x, config, state=None):
     # Update the exponentially weighted infinity norm.
     state['max'][0].copy_(state['u']).mul_(beta2)
     state['max'][1].copy_(dfdx).abs_().add_(epsilon)
-    torch.max(state['u'], state['max'], 0)
+    torch.max(state['max'], 0, out=(state['u'], state['u'].new().long()))
 
     biasCorrection1 = 1 - beta1 ** state['t']
     stepSize = lr / biasCorrection1

--- a/torch/legacy/optim/rmsprop.py
+++ b/torch/legacy/optim/rmsprop.py
@@ -50,7 +50,7 @@ def rmsprop(opfunc, x, config, state=None):
     state['m'].addcmul_(1.0-alpha, dfdx, dfdx)
 
     # (5) perform update
-    torch.sqrt(state['tmp'], state['m']).add_(epsilon)
+    torch.sqrt(state['m'], out=state['tmp']).add_(epsilon)
     x.addcdiv_(-lr, dfdx, state['tmp'])
 
     # return x*, f(x) before optimization

--- a/torch/nn/functions/thnn/sparse.py
+++ b/torch/nn/functions/thnn/sparse.py
@@ -43,11 +43,10 @@ class Embedding(Function):
         if self.max_norm is not None:
             self._renorm(indices, weight)
 
-        output = weight.new()
         if indices.dim() == 1:
-            torch.index_select(output, weight, 0, indices)
+            output = torch.index_select(weight, 0, indices)
         else:
-            torch.index_select(output, weight, 0, indices.view(-1))
+            output = torch.index_select(weight, 0, indices.view(-1))
             output = output.view(indices.size(0), indices.size(1), weight.size(1))
 
         return output


### PR DESCRIPTION
```python
torch.add(output, input1, input2)
torch.max(values, indices, tensor, 1)
```
becomes
```python
torch.add(input1, input2, out=output)
torch.max(tensor, 1, out=(values, indices))
a.add(b, out=c) # this was not possible before
```

`out` is a keyword only argument.