### PR TITLE
Copy libnccl.so.1 instead of libnccl.so

### DIFF
--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -45,7 +45,7 @@ function build_nccl() {
                -DCMAKE_C_FLAGS="$C_FLAGS" \
                -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS"
    make install
-   cp "lib/libnccl.so" "${INSTALL_DIR}/lib/libnccl.so"
+   cp "lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so"
    cd ../..
 }
 


### PR DESCRIPTION
Occasionally, my PyTorch checkout gets into a bad state where libnccl.so
does not exist, but the NCCL makefile doesn't build it because
libnccl.so.1 exists. Switch to copying libnccl.so.1 to work around this.