### PR TITLE
unsqueeze instead of view in DataLoader

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -61,7 +61,7 @@ def _pin_memory_loop(in_queue, out_queue, done_event):
 def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
-        return torch.cat([t.view(1, *t.size()) for t in batch], 0)
+        return torch.cat([t.unsqueeze(0) for t in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)
     elif isinstance(batch[0], float):


### PR DESCRIPTION
`t` is often non-contiguous, so view doesn't handle it.