### PR TITLE
adding docs for some torch.* functions

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -26,12 +26,16 @@ The :class:`torch.Tensor` constructor is an alias for the default tensor type
 
 A tensor can be constructed from a Python :class:`list` or sequence:
 
+::
+
     >>> torch.FloatTensor([[1, 2, 3], [4, 5, 6]])
     1  2  3
     4  5  6
     [torch.FloatTensor of size 2x3]
 
 An empty tensor can be constructed by specifying its size:
+
+::
 
     >>> torch.IntTensor(2, 4).zero_()
     0  0  0  0
@@ -40,6 +44,8 @@ An empty tensor can be constructed by specifying its size:
 
 The contents of a tensor can be accessed and modified using Python's indexing
 and slicing notation:
+
+::
 
     >>> x = torch.FloatTensor([[1, 2, 3], [4, 5, 6]])
     >>> print(x[1][2])

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -21,7 +21,6 @@ Math operations
 .. autofunction:: bernoulli
 .. autofunction:: bmm
 .. autofunction:: cat
-.. autofunction:: cauchy
 .. autofunction:: ceil
 .. autofunction:: cinv
 .. autofunction:: clamp
@@ -61,7 +60,6 @@ Math operations
 .. autofunction:: linspace
 .. autofunction:: log
 .. autofunction:: log1p
-.. autofunction:: log_normal
 .. autofunction:: logspace
 .. autofunction:: lt
 .. autofunction:: masked_select
@@ -125,7 +123,6 @@ Math operations
 .. autofunction:: unfold
 .. autofunction:: uniform
 .. autofunction:: var
-.. autofunction:: zero
 .. autofunction:: zeros
 
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -14,8 +14,6 @@ Math operations
 .. autofunction:: addmm
 .. autofunction:: addmv
 .. autofunction:: addr
-.. autofunction:: all
-.. autofunction:: any
 .. autofunction:: asin
 .. autofunction:: atan
 .. autofunction:: atan2

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -121,7 +121,6 @@ Math operations
 .. autofunction:: trtrs
 .. autofunction:: trunc
 .. autofunction:: unfold
-.. autofunction:: uniform
 .. autofunction:: var
 .. autofunction:: zeros
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -90,7 +90,6 @@ Math operations
 .. autofunction:: qr
 .. autofunction:: rand
 .. autofunction:: randn
-.. autofunction:: random
 .. autofunction:: randperm
 .. autofunction:: range
 .. autofunction:: remainder

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -279,8 +279,6 @@ IMPLEMENT_STATELESS(gather)
 IMPLEMENT_STATELESS(scatter)
 IMPLEMENT_STATELESS(rand)
 IMPLEMENT_STATELESS(randn)
-IMPLEMENT_STATELESS(all)
-IMPLEMENT_STATELESS(any)
 IMPLEMENT_STATELESS(masked_select)
 IMPLEMENT_STATELESS(gesv)
 IMPLEMENT_STATELESS(gels)
@@ -607,8 +605,6 @@ static PyMethodDef TorchMethods[] = {
   {"range",           (PyCFunction)THPModule_range,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"gather",          (PyCFunction)THPModule_gather,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"scatter",         (PyCFunction)THPModule_scatter,           METH_VARARGS | METH_KEYWORDS, NULL},
-  {"all",             (PyCFunction)THPModule_all,               METH_VARARGS | METH_KEYWORDS, NULL},
-  {"any",             (PyCFunction)THPModule_any,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"cat",             (PyCFunction)THPModule_cat,               METH_VARARGS, NULL},
   {"masked_select",   (PyCFunction)THPModule_masked_select,     METH_VARARGS | METH_KEYWORDS, NULL},
   {"gesv",            (PyCFunction)THPModule_gesv,              METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -559,8 +559,8 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   arguments:
     - arg: THTensor* result
       output: True
-    - accreal xmin
-    - accreal xmax
+    - accreal start
+    - accreal end
     - arg: accreal step
       default: 1
 ]]

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -1615,6 +1615,48 @@ add_docstr(torch._C.lerp,
 
 add_docstr(torch._C.linspace,
 """
+linspace(start, end, steps=100, out=None) -> Tensor
+
+Returns a one-dimensional Tensor of :attr:`steps` 
+equally spaced points between :attr:`start` and :attr:`end`
+
+The output tensor is 1D of size :attr:`steps`
+
+Args:
+    start (float): The starting value for the set of points
+    start (float): The ending value for the set of points
+    steps (long): Number of points to sample between :attr:`start` and :attr:`end`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> torch.linspace(3, 10, steps=5)
+    
+      3.0000
+      4.7500
+      6.5000
+      8.2500
+     10.0000
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.linspace(-10, 10, steps=5)
+    
+    -10
+     -5
+      0
+      5
+     10
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.linspace(start=-10, end=10, steps=5)
+    
+    -10
+     -5
+      0
+      5
+     10
+    [torch.FloatTensor of size 5]
+                
 """)
 
 add_docstr(torch._C.log,
@@ -1658,7 +1700,7 @@ Returns a new `Tensor` with the natural logarithm of (1 + :attr:`input`).
 
 :math:`y_i = log(x_i + 1)`
 
-.. note:: This function is more accurate than :function:`torch.log` for small values of :attr:`input`
+.. note:: This function is more accurate than :func:`torch.log` for small values of :attr:`input`
 
 Args:
     input (Tensor): the input `Tensor`
@@ -1689,6 +1731,39 @@ Example::
 
 add_docstr(torch._C.logspace,
 """
+logspace(start, end, steps=100, out=None) -> Tensor
+
+Returns a one-dimensional Tensor of :attr:`steps` 
+logirathmically equally spaced points between :math:`10^start` and :math:`10^end`
+
+The output tensor is 1D of size :attr:`steps`
+
+Args:
+    start (float): The starting value for the set of points
+    start (float): The ending value for the set of points
+    steps (long): Number of points to sample between :attr:`start` and :attr:`end`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> torch.logspace(start=-10, end=10, steps=5)
+    
+     1.0000e-10
+     1.0000e-05
+     1.0000e+00
+     1.0000e+05
+     1.0000e+10
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.logspace(start=0.1, end=1.0, steps=5)
+    
+      1.2589
+      2.1135
+      3.5481
+      5.9566
+     10.0000
+    [torch.FloatTensor of size 5]
+            
 """)
 
 add_docstr(torch._C.lt,
@@ -1891,6 +1966,37 @@ Example::
 
 add_docstr(torch._C.neg,
 """
+neg(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the negative of the elements of :attr:`input`.
+
+:math:`out = -1 * input`
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(5)
+    >>> a
+    
+    -0.4430
+     1.1690
+    -0.8836
+    -0.4565
+     0.2968
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.neg(a)
+    
+     0.4430
+    -1.1690
+     0.8836
+     0.4565
+    -0.2968
+    [torch.FloatTensor of size 5]
+    
 """)
 
 add_docstr(torch._C.nonzero,
@@ -1967,6 +2073,39 @@ add_docstr(torch._C.randperm,
 
 add_docstr(torch._C.range,
 """
+range(start, end, step=1, out=None) -> Tensor
+
+returns a 1D Tensor of size :math:`floor((end - start) / step) + 1` with values 
+from :attr:`start` to :attr:`end` with step :attr:`step`. Step is the gap between two values in the tensor.
+:math:`x_{i+1} = x_i + step`
+
+Args:
+    start (float): The starting value for the set of points
+    start (float): The ending value for the set of points
+    step (float): The gap between each pair of adjacent points
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+    
+    >>> torch.range(1, 4)
+    
+     1
+     2
+     3
+     4
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.range(1, 4, 0.5)
+    
+     1.0000
+     1.5000
+     2.0000
+     2.5000
+     3.0000
+     3.5000
+     4.0000
+    [torch.FloatTensor of size 7]
+                    
 """)
 
 add_docstr(torch._C.remainder,
@@ -2312,10 +2451,6 @@ add_docstr(torch._C.trunc,
 """)
 
 add_docstr(torch._C.unfold,
-"""
-""")
-
-add_docstr(torch._C.uniform,
 """
 """)
 

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -1611,6 +1611,46 @@ Example::
 
 add_docstr(torch._C.lerp,
 """
+lerp(start, end, weight, out=None)
+
+Does a linear interpolation of two tensors :attr:`start` and :attr:`end` based on a scalar :attr:`weight`: and returns the resulting :attr:`out` Tensor.
+
+:math:`out_i = start_i + weight * (end_i - start_i)`
+
+Args:
+    start (Tensor): the `Tensor` with the starting points
+    end (Tensor): the `Tensor` with the ending points
+    weight (float): the weight for the interpolation formula
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> start = torch.range(1, 4)
+    >>> end = torch.Tensor(4).fill_(10)
+    >>> start
+    
+     1
+     2
+     3
+     4
+    [torch.FloatTensor of size 4]
+    
+    >>> end
+    
+     10
+     10
+     10
+     10
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.lerp(start, end, 0.5)
+    
+     5.5000
+     6.0000
+     6.5000
+     7.0000
+    [torch.FloatTensor of size 4]
+    
 """)
 
 add_docstr(torch._C.linspace,
@@ -1797,18 +1837,233 @@ add_docstr(torch._C.masked_select,
 
 add_docstr(torch._C.max,
 """
+.. function:: max(input) -> float
+
+Returns the maximum value of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+     0.4729 -0.2266 -0.2085
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.max(a)
+    0.4729
+    
+
+.. function:: max(input, dim, max=None, max_indices=None) -> (Tensor, LongTensor)
+
+Returns the maximum value of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+Also returns the index location of each maximum value found.
+
+THe output Tensors are of the same size as :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    max (Tensor, optional): the result Tensor with maximum values in dimension :attr:`dim`
+    max_indices (LongTensor, optional): the result Tensor with the index locations of the maximum values in dimension :attr:`dim`
+
+Example::
+
+    >> a = torch.randn(4, 4)
+    >> a
+    
+    0.0692  0.3142  1.2513 -0.5428
+    0.9288  0.8552 -0.2073  0.6409
+    1.0695 -0.0101 -2.4507 -1.2230
+    0.7426 -0.7666  0.4862 -0.6628
+    torch.FloatTensor of size 4x4]
+    
+    >>> torch.max(a, 1)
+    (
+     1.2513
+     0.9288
+     1.0695
+     0.7426
+    [torch.FloatTensor of size 4x1]
+    ,
+     2
+     0
+     0
+     0
+    [torch.LongTensor of size 4x1]
+    )
+        
 """)
 
 add_docstr(torch._C.mean,
 """
+.. function:: mean(input) -> float
+
+Returns the mean value of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+    -0.2946 -0.9143  2.1809
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.mean(a)
+    0.32398951053619385
+    
+
+.. function:: mean(input, dim, out=None) -> Tensor
+
+Returns the mean value of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 4)
+    >>> a
+    
+    -1.2738 -0.3058  0.1230 -1.9615
+     0.8771 -0.5430 -0.9233  0.9879
+     1.4107  0.0317 -0.6823  0.2255
+    -1.3854  0.4953 -0.2160  0.2435
+    [torch.FloatTensor of size 4x4]
+    
+    >>> torch.mean(a, 1)
+    
+    -0.8545
+     0.0997
+     0.2464
+    -0.2157
+    [torch.FloatTensor of size 4x1]
+            
 """)
 
 add_docstr(torch._C.median,
 """
+median(input, dim=-1, values=None, indices=None) -> (Tensor, LongTensor)
+
+Returns the median value of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+Also returns the index location of the median value as a `LongTensor`.
+
+By default, :attr:`dim` is the last dimension of the :attr:`input` Tensor.
+
+THe output Tensors are of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+.. note:: This function is not defined for ``torch.cuda.Tensor`` yet.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    values (Tensor, optional): the result Tensor
+    indices (Tensor, optional): the result index Tensor
+
+Example::
+
+    >>> a
+    
+     -0.6891 -0.6662
+     0.2697  0.7412
+     0.5254 -0.7402
+     0.5528 -0.2399
+    [torch.FloatTensor of size 4x2]
+    
+    >>> a = torch.randn(4, 5)
+    >>> a
+    
+     0.4056 -0.3372  1.0973 -2.4884  0.4334
+     2.1336  0.3841  0.1404 -0.1821 -0.7646
+    -0.2403  1.3975 -2.0068  0.1298  0.0212
+    -1.5371 -0.7257 -0.4871 -0.2359 -1.1724
+    [torch.FloatTensor of size 4x5]
+    
+    >>> torch.median(a, 1)
+    (
+     0.4056
+     0.1404
+     0.0212
+    -0.7257
+    [torch.FloatTensor of size 4x1]
+    ,
+     0
+     2
+     4
+     1
+    [torch.LongTensor of size 4x1]
+    )
+  
 """)
 
 add_docstr(torch._C.min,
 """
+.. function:: min(input) -> float
+
+Returns the minimum value of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+     0.4729 -0.2266 -0.2085
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.min(a)
+    -0.22663167119026184
+    
+
+.. function:: min(input, dim, min=None, min_indices=None) -> (Tensor, LongTensor)
+
+Returns the minimum value of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+Also returns the index location of each minimum value found.
+
+THe output Tensors are of the same size as :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    min (Tensor, optional): the result Tensor with minimum values in dimension :attr:`dim`
+    min_indices (LongTensor, optional): the result Tensor with the index locations of the minimum values in dimension :attr:`dim`
+
+Example::
+
+    >> a = torch.randn(4, 4)
+    >> a
+    
+    0.0692  0.3142  1.2513 -0.5428
+    0.9288  0.8552 -0.2073  0.6409
+    1.0695 -0.0101 -2.4507 -1.2230
+    0.7426 -0.7666  0.4862 -0.6628
+    torch.FloatTensor of size 4x4]
+    
+    >> torch.min(a, 1)
+    
+    0.5428
+    0.2073
+    2.4507
+    0.7666
+    torch.FloatTensor of size 4x1]
+    
+    3
+    2
+    2
+    1
+    torch.LongTensor of size 4x1]
+    
 """)
 
 add_docstr(torch._C.mm,
@@ -1836,6 +2091,57 @@ Example::
 
 add_docstr(torch._C.mode,
 """
+mode(input, dim=-1, values=None, indices=None) -> (Tensor, LongTensor)
+
+Returns the mode value of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+Also returns the index location of the mode value as a `LongTensor`.
+
+By default, :attr:`dim` is the last dimension of the :attr:`input` Tensor.
+
+THe output Tensors are of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+.. note:: This function is not defined for ``torch.cuda.Tensor`` yet.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    values (Tensor, optional): the result Tensor
+    indices (Tensor, optional): the result index Tensor
+
+Example::
+
+    >>> a
+    
+     -0.6891 -0.6662
+     0.2697  0.7412
+     0.5254 -0.7402
+     0.5528 -0.2399
+    [torch.FloatTensor of size 4x2]
+    
+    >>> a = torch.randn(4, 5)
+    >>> a
+    
+     0.4056 -0.3372  1.0973 -2.4884  0.4334
+     2.1336  0.3841  0.1404 -0.1821 -0.7646
+    -0.2403  1.3975 -2.0068  0.1298  0.0212
+    -1.5371 -0.7257 -0.4871 -0.2359 -1.1724
+    [torch.FloatTensor of size 4x5]
+        
+    >>> torch.mode(a, 1)
+    (
+    -2.4884
+    -0.7646
+    -2.0068
+    -1.5371
+    [torch.FloatTensor of size 4x1]
+    ,
+     3
+     4
+     2
+     0
+    [torch.LongTensor of size 4x1]
+    )
+
 """)
 
 add_docstr(torch._C.mul,
@@ -2001,10 +2307,115 @@ Example::
 
 add_docstr(torch._C.nonzero,
 """
+nonzero(input, out=None) -> LongTensor
+
+Returns a list of indices of all the non-zero elements of the :attr:`input` Tensor. Each row in the result Tensor is one set of indices giving the location of a non-zero element in :attr:`input`
+
+If :attr:`input` has `n` dimensions, then the resulting indices Tensor :attr:`out` is of size `z x n`, where `z` is the total number of non-zero elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (LongTensor, optional): The result `Tensor` containing indices
+
+Example::
+
+    >>> a = torch.Tensor(5).bernoulli_()
+    >>> a
+    
+     1
+     1
+     1
+     0
+     1
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.nonzero(a)
+    
+     0
+     1
+     2
+     4
+    [torch.LongTensor of size 4x1]
+    
+    >>> a = torch.diag(torch.randn(4)) # create a matrix where only the diagonal is non-zero
+    >>> a
+    
+     0.6116  0.0000  0.0000  0.0000
+     0.0000  0.4126  0.0000  0.0000
+     0.0000  0.0000 -1.2886  0.0000
+     0.0000  0.0000  0.0000 -0.4112
+    [torch.FloatTensor of size 4x4]
+    
+    >>> torch.nonzero(a)
+    
+     0  0
+     1  1
+     2  2
+     3  3
+    [torch.LongTensor of size 4x2]
+        
 """)
 
 add_docstr(torch._C.norm,
 """
+.. function:: norm(input, p=2) -> float
+
+Returns the p-norm of the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+    p (float, optional): the exponent value in the norm formulation
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+    -0.4376 -0.5328  0.9547
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.norm(a, 3)
+    1.0338925067372466
+        
+
+.. function:: norm(input, p, dim, out=None) -> Tensor
+
+Returns the p-norm of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    p (float):  the exponent value in the norm formulation
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 2)
+    >>> a
+    
+    -0.6891 -0.6662
+     0.2697  0.7412
+     0.5254 -0.7402
+     0.5528 -0.2399
+    [torch.FloatTensor of size 4x2]
+    
+    >>> torch.norm(a, 2, 1)
+    
+     0.9585
+     0.7888
+     0.9077
+     0.6026
+    [torch.FloatTensor of size 4x1]
+    
+    >>> torch.norm(a, 0, 1)
+    
+     2
+     2
+     2
+     2
+    [torch.FloatTensor of size 4x1]
+            
 """)
 
 add_docstr(torch._C.normal,
@@ -2013,6 +2424,22 @@ add_docstr(torch._C.normal,
 
 add_docstr(torch._C.numel,
 """
+numel(input) -> long
+
+Returns the total number of elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1,2,3,4,5)
+    >>> torch.numel(a)
+    120
+    >>> a = torch.zeros(4,4)
+    >>> torch.numel(a)
+    16
+    
 """)
 
 add_docstr(torch._C.ones,
@@ -2041,10 +2468,150 @@ add_docstr(torch._C.potrs,
 
 add_docstr(torch._C.pow,
 """
+.. function:: pow(input, exponent, out=None)
+
+Takes the power of each element in :attr:`input` with :attr:`exponent` and returns a Tensor with the result.
+
+:attr:`exponent` can be either a single ``float`` number or a ``Tensor`` 
+with the same number of elements as :attr:`input`.
+
+When :attr:`exponent` is a scalar value, the operation applied is:
+
+:math:`out_i = x_i ^ {exponent}`
+
+When :attr:`exponent` is a Tensor, the operation applied is:
+
+:math:`out_i = x_i ^ {exponent_i}`
+
+Args:
+    input (Tensor): the input `Tensor`
+    exponent (float or Tensor): the exponent value
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+    -0.5274
+    -0.8232
+    -2.1128
+     1.7558
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.pow(a, 2)
+    
+     0.2781
+     0.6776
+     4.4640
+     3.0829
+    [torch.FloatTensor of size 4]
+    
+    >>> exp = torch.range(1, 4)
+    >>> a = torch.range(1, 4)
+    >>> a
+    
+     1
+     2
+     3
+     4
+    [torch.FloatTensor of size 4]
+    
+    >>> exp
+    
+     1
+     2
+     3
+     4
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.pow(a, exp)
+    
+       1
+       4
+      27
+     256
+    [torch.FloatTensor of size 4]
+    
+
+.. function:: pow(base, input, out=None)
+
+:attr:`base` is a scalar ``float`` value, and :attr:`input` is a Tensor. The returned Tensor :attr:`out` is of the same shape as :attr:`input`
+
+The operation applied is: 
+
+:math:`out_i = base ^ {input_i}`
+
+Args:
+    base (float): the scalar base value for the power operation
+    input (Tensor): the exponent `Tensor`    
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> exp = torch.range(1, 4)
+    >>> base = 2
+    >>> torch.pow(base, exp)
+    
+      2
+      4
+      8
+     16
+    [torch.FloatTensor of size 4]
+            
 """)
 
 add_docstr(torch._C.prod,
 """
+.. function:: prod(input) -> float
+
+Returns the product of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+     0.6170  0.3546  0.0253
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.prod(a)
+    0.005537458061418483
+    
+
+.. function:: prod(input, dim, out=None) -> Tensor
+
+Returns the product of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 2)
+    >>> a
+    
+     0.1598 -0.6884
+    -0.1831 -0.4412
+    -0.9925 -0.6244
+    -0.2416 -0.8080
+    [torch.FloatTensor of size 4x2]
+    
+    >>> torch.prod(a, 1)
+    
+    -0.1100
+     0.0808
+     0.6197
+     0.1952
+    [torch.FloatTensor of size 4x1]
+        
 """)
 
 add_docstr(torch._C.pstrf,
@@ -2063,12 +2630,37 @@ add_docstr(torch._C.randn,
 """
 """)
 
-add_docstr(torch._C.random,
-"""
-""")
-
 add_docstr(torch._C.randperm,
 """
+randperm(n, out=None) -> long
+
+Returns a random permutation of integers from `1` to :attr:`n`.
+
+Args:
+    n (long): the last integer in the sequence
+
+Example::
+
+    >>> torch.randperm(4)
+    
+     2
+     1
+     3
+     0
+    [torch.LongTensor of size 4]
+    
+    >>> torch.randperm(8)
+    
+     2
+     6
+     5
+     4
+     3
+     1
+     7
+     0
+    [torch.LongTensor of size 8]
+    
 """)
 
 add_docstr(torch._C.range,
@@ -2219,6 +2811,33 @@ Sets the number of OpenMP threads used for parallelizing CPU operations
 
 add_docstr(torch._C.sigmoid,
 """
+sigmoid(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the sigmoid of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+    -0.4972
+     1.3512
+     0.1056
+    -0.2650
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.sigmoid(a)
+    
+     0.3782
+     0.7943
+     0.5264
+     0.4341
+    [torch.FloatTensor of size 4]
+        
 """)
 
 add_docstr(torch._C.sign,
@@ -2348,10 +2967,108 @@ add_docstr(torch._C.squeeze,
 
 add_docstr(torch._C.std,
 """
+.. function:: std(input) -> float
+
+Returns the standard-deviation of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+    -1.3063  1.4182 -0.3061
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.std(a)
+    1.3782334731508061
+            
+
+.. function:: std(input, dim, out=None) -> Tensor
+
+Returns the standard-deviation of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 4)
+    >>> a
+    
+     0.1889 -2.4856  0.0043  1.8169
+    -0.7701 -0.4682 -2.2410  0.4098
+     0.1919 -1.1856 -1.0361  0.9085
+     0.0173  1.0662  0.2143 -0.5576
+    [torch.FloatTensor of size 4x4]
+    
+    >>> torch.std(a, dim=1)
+    
+     1.7756
+     1.1025
+     1.0045
+     0.6725
+    [torch.FloatTensor of size 4x1]
+    
 """)
 
 add_docstr(torch._C.sum,
 """
+.. function:: sum(input) -> float
+
+Returns the sum of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+     0.6170  0.3546  0.0253
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.sum(a)
+    0.9969287421554327
+    
+
+.. function:: sum(input, dim, out=None) -> Tensor
+
+Returns the sum of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 4)
+    >>> a
+    
+    -0.4640  0.0609  0.1122  0.4784
+    -1.3063  1.6443  0.4714 -0.7396
+    -1.3561 -0.1959  1.0609 -1.9855
+     2.6833  0.5746 -0.5709 -0.4430
+    [torch.FloatTensor of size 4x4]
+    
+    >>> torch.sum(a, 1)
+    
+     0.1874
+     0.0698
+    -2.4767
+     2.2440
+    [torch.FloatTensor of size 4x1]
+    
 """)
 
 add_docstr(torch._C.svd,
@@ -2436,10 +3153,108 @@ add_docstr(torch._C.transpose,
 
 add_docstr(torch._C.tril,
 """
+tril(input, k=0, out=None) -> Tensor
+
+Returns the lower triangular part of the matrix (2D Tensor) :attr:`input`, 
+the other elements of the result Tensor :attr:`out` are set to 0.
+
+The lower triangular part of the matrix is defined as the elements on and below the diagonal.
+
+The argument :attr:`k` controls which diagonal to consider.
+
+- :attr:`k` = 0, is the main diagonal.
+- :attr:`k` > 0, is above the main diagonal.
+- :attr:`k` < 0, is below the main diagonal.
+
+Args:
+    input (Tensor): the input `Tensor`
+    k (long, optional): the diagonal to consider
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(3,3)
+    >>> a
+    
+     1.3225  1.7304  1.4573
+    -0.3052 -0.3111 -0.1809
+     1.2469  0.0064 -1.6250
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.tril(a)
+    
+     1.3225  0.0000  0.0000
+    -0.3052 -0.3111  0.0000
+     1.2469  0.0064 -1.6250
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.tril(a, k=1)
+    
+     1.3225  1.7304  0.0000
+    -0.3052 -0.3111 -0.1809
+     1.2469  0.0064 -1.6250
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.tril(a, k=-1)
+    
+     0.0000  0.0000  0.0000
+    -0.3052  0.0000  0.0000
+     1.2469  0.0064  0.0000
+    [torch.FloatTensor of size 3x3]
+    
 """)
 
 add_docstr(torch._C.triu,
 """
+triu(input, k=0, out=None) -> Tensor
+
+Returns the upper triangular part of the matrix (2D Tensor) :attr:`input`, 
+the other elements of the result Tensor :attr:`out` are set to 0.
+
+The upper triangular part of the matrix is defined as the elements on and above the diagonal.
+
+The argument :attr:`k` controls which diagonal to consider.
+
+- :attr:`k` = 0, is the main diagonal.
+- :attr:`k` > 0, is above the main diagonal.
+- :attr:`k` < 0, is below the main diagonal.
+
+Args:
+    input (Tensor): the input `Tensor`
+    k (long, optional): the diagonal to consider
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(3,3)
+    >>> a
+    
+     1.3225  1.7304  1.4573
+    -0.3052 -0.3111 -0.1809
+     1.2469  0.0064 -1.6250
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.triu(a)
+    
+     1.3225  1.7304  1.4573
+     0.0000 -0.3111 -0.1809
+     0.0000  0.0000 -1.6250
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.triu(a, k=1)
+    
+     0.0000  1.7304  1.4573
+     0.0000  0.0000 -0.1809
+     0.0000  0.0000  0.0000
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.triu(a, k=-1)
+    
+     1.3225  1.7304  1.4573
+    -0.3052 -0.3111 -0.1809
+     0.0000  0.0064 -1.6250
+    [torch.FloatTensor of size 3x3]
+                        
 """)
 
 add_docstr(torch._C.trtrs,
@@ -2448,6 +3263,33 @@ add_docstr(torch._C.trtrs,
 
 add_docstr(torch._C.trunc,
 """
+trunc(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the truncated integer values of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+    -0.4972
+     1.3512
+     0.1056
+    -0.2650
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.trunc(a)
+    
+    -0
+     1
+     0
+    -0
+    [torch.FloatTensor of size 4]
+            
 """)
 
 add_docstr(torch._C.unfold,
@@ -2456,6 +3298,55 @@ add_docstr(torch._C.unfold,
 
 add_docstr(torch._C.var,
 """
+.. function:: var(input) -> float
+
+Returns the variance of all elements in the :attr:`input` Tensor.
+
+Args:
+    input (Tensor): the input `Tensor`
+
+Example::
+
+    >>> a = torch.randn(1, 3)
+    >>> a
+    
+    -1.3063  1.4182 -0.3061
+    [torch.FloatTensor of size 1x3]
+    
+    >>> torch.var(a)
+    1.899527506513334
+        
+
+.. function:: var(input, dim, out=None) -> Tensor
+
+Returns the variance of each row of the :attr:`input` Tensor in the given dimension :attr:`dim`.
+
+THe output Tensor is of the same size as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim (long): the dimension to reduce
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> a = torch.randn(4, 4)
+    >>> a
+    
+    -1.2738 -0.3058  0.1230 -1.9615
+     0.8771 -0.5430 -0.9233  0.9879
+     1.4107  0.0317 -0.6823  0.2255
+    -1.3854  0.4953 -0.2160  0.2435
+    [torch.FloatTensor of size 4x4]
+    
+    >>> torch.var(a, 1)
+    
+     0.8859
+     0.9509
+     0.7548
+     0.6949
+    [torch.FloatTensor of size 4x1]
+                
 """)
 
 add_docstr(torch._C.zeros,

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -15,13 +15,29 @@ Example:
 
 add_docstr(torch._C.acos,
 """
-acos(tensor, out=None) -> tensor
+acos(input, out=None) -> Tensor
 
-Computes the element-wise inverse cosine of a tensor.
+Returns a new `Tensor` with the arccosine  of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
 
 Example:
-    >>> torch.acos(torch.FloatTensor([1, -1]))
-    FloatTensor([0.0000, 3.1416])
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.acos(a)
+     2.2608
+     1.2956
+     1.1075
+        nan
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.add,
@@ -50,26 +66,117 @@ add_docstr(torch._C.addmv,
 
 add_docstr(torch._C.addr,
 """
-""")
+addr(beta=1, mat, alpha=1, vec1, vec2, out=None) -> Tensor
 
-add_docstr(torch._C.all,
-"""
-""")
+Performs the outer-product between vectors :attr:`vec1` and :attr:`vec2` and adds it to the matrix :attr:`mat`.
 
-add_docstr(torch._C.any,
-"""
+Optional values :attr:`beta` and :attr:`alpha` are scalars that multiply :attr:`mat` and `(vec1 [out] vec2)` respectively
+
+In other words,
+
+:math:`res_{ij} = (beta * mat_i_j) + (alpha * vec1_i * vec2_j)`
+
+If :attr:`vec1` is a vector of size `n` and :attr:`vec2` is a vector of size `m`, then :attr:`mat` must be a matrix of size `n x m`
+
+Args:
+    beta (float, optional): multiplier for :attr:`mat`
+    mat (Tensor): matrix to be added
+    alpha (float, optional): multiplier for `vec1 (out) vec2`
+    vec1 (Tensor): First vector of the outer product
+    vec2 (Tensor): Second vector of the outer product
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> vec1 = torch.range(1, 3)
+    >>> vec2 = torch.range(1, 2)
+    >>> M = torch.zeros(3, 2)
+    >>> torch.addr(M, x, y)
+     1  2
+     2  4
+     3  6
+    [torch.FloatTensor of size 3x2]
 """)
 
 add_docstr(torch._C.asin,
 """
+asin(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the arcsine  of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.asin(a)
+    -0.6900
+     0.2752
+     0.4633
+        nan
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.atan,
 """
+atan(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the arctangent  of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.atan(a)
+    -0.5669
+     0.2653
+     0.4203
+     0.9196
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.atan2,
 """
+atan2(input1, input2, out=None) -> Tensor
+
+Returns a new `Tensor` with the arctangent of the elements of :attr:`input1` and :attr:`input2`.
+
+Args:
+    tensor (Tensor): the first input `Tensor`
+    tensor (Tensor): the second input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.atan2(a, torch.randn(4))
+    -2.4167
+     2.9755
+     0.9363
+     1.6613
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.baddbmm,
@@ -114,10 +221,56 @@ add_docstr(torch._C.cmin,
 
 add_docstr(torch._C.cos,
 """
+cos(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the cosine  of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cos(a)
+     0.8041
+     0.9633
+     0.9018
+     0.2557
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.cosh,
 """
+cosh(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the hyperbolic cosine  of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cosh(a)
+     1.2095
+     1.0372
+     1.1015
+     1.9917
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.cross,
@@ -788,10 +941,56 @@ add_docstr(torch._C.sign,
 
 add_docstr(torch._C.sin,
 """
+sin(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the sine of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.sin(a)
+    -0.5944
+     0.2684
+     0.4322
+     0.9667
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.sinh,
 """
+sinh(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the hyperbolic sine of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.sinh(a)
+    -0.6804
+     0.2751
+     0.4619
+     1.7225
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.sort,
@@ -828,10 +1027,56 @@ add_docstr(torch._C.t,
 
 add_docstr(torch._C.tan,
 """
+tan(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the tangent of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.tan(a)
+    -0.7392
+     0.2786
+     0.4792
+     3.7801
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.tanh,
 """
+tanh(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the hyperbolic tangent of the elements of :attr:`input`.
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+    >>> a = torch.randn(4)
+    >>> print(a)
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.tanh(a)
+    -0.5625
+     0.2653
+     0.4193
+     0.8648
+    [torch.FloatTensor of size 4]
 """)
 
 add_docstr(torch._C.topk,

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -53,7 +53,7 @@ Adds the scalar :attr:`value` to each element of the input :attr:`input` and ret
 
 Args:
     input (Tensor): the input `Tensor`
-    value (Float): the number to be added to each element of :attr:`input`
+    value (float): the number to be added to each element of :attr:`input`
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -87,7 +87,7 @@ The shapes of :attr:`input` and :attr:`other` dont need to match. The total numb
 
 Args:
     input (Tensor): the first input `Tensor`
-    value (Float): the scalar multiplier for :attr:`other`
+    value (float): the scalar multiplier for :attr:`other`
     other (Tensor): the second input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
@@ -136,9 +136,9 @@ In other words,
 :math:`res = (beta * M) + (alpha * sum(batch1_i @ batch2_i, i = 0, b))`
 
 Args:
-    beta (Float, optional): multiplier for :attr:`mat`
+    beta (float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (Float, optional): multiplier for `batch1 @ batch2`
+    alpha (float, optional): multiplier for `batch1 @ batch2`
     batch1 (Tensor): First batch of matrices to be multiplied
     batch2 (Tensor): Second batch of matrices to be multiplied
     out (Tensor, optional): Output tensor
@@ -167,7 +167,7 @@ The number of elements must match, but sizes do not matter.
 
 Args:
     tensor (Tensor): the tensor to be added
-    value (Float, optional): multiplier for `tensor1 ./ tensor2`
+    value (float, optional): multiplier for `tensor1 ./ tensor2`
     tensor1 (Tensor): Numerator tensor
     tensor2 (Tensor): Denominator tensor
     out (Tensor, optional): Output tensor
@@ -195,7 +195,7 @@ The number of elements must match, but sizes do not matter.
 
 Args:
     tensor (Tensor): the tensor to be added
-    value (Float, optional): multiplier for `tensor1 .* tensor2`
+    value (float, optional): multiplier for `tensor1 .* tensor2`
     tensor1 (Tensor): tensor to be multiplied
     tensor2 (Tensor): tensor to be multiplied
     out (Tensor, optional): Output tensor
@@ -227,9 +227,9 @@ In other words,
 :math:`out = (beta * M) + (alpha * mat1 @ mat2)`
 
 Args:
-    beta (Float, optional): multiplier for :attr:`mat`
+    beta (float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (Float, optional): multiplier for `mat1 @ mat2`
+    alpha (float, optional): multiplier for `mat1 @ mat2`
     mat1 (Tensor): First matrix to be multiplied
     mat2 (Tensor): Second matrix to be multiplied
     out (Tensor, optional): Output tensor
@@ -262,9 +262,9 @@ In other words:
 :math:`out = (beta * tensor) + (alpha * (mat @ vec2))`
 
 Args:
-    beta (Float, optional): multiplier for :attr:`tensor`
+    beta (float, optional): multiplier for :attr:`tensor`
     tensor (Tensor): vector to be added
-    alpha (Float, optional): multiplier for `mat @ vec`
+    alpha (float, optional): multiplier for `mat @ vec`
     mat (Tensor): matrix to be multiplied
     vec (Tensor): vector to be multiplied
     out (Tensor, optional): Output tensor
@@ -296,9 +296,9 @@ In other words,
 If :attr:`vec1` is a vector of size `n` and :attr:`vec2` is a vector of size `m`, then :attr:`mat` must be a matrix of size `n x m`
 
 Args:
-    beta (Float, optional): multiplier for :attr:`mat`
+    beta (float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (Float, optional): multiplier for `vec1 (out) vec2`
+    alpha (float, optional): multiplier for `vec1 (out) vec2`
     vec1 (Tensor): First vector of the outer product
     vec2 (Tensor): Second vector of the outer product
     out (Tensor, optional): Output tensor
@@ -415,9 +415,9 @@ In other words,
 :math:`res_i = (beta * M_i) + (alpha * batch1_i @ batch2_i)`
 
 Args:
-    beta (Float, optional): multiplier for :attr:`mat`
+    beta (float, optional): multiplier for :attr:`mat`
     mat (Tensor): tensor to be added
-    alpha (Float, optional): multiplier for `batch1 @ batch2`
+    alpha (float, optional): multiplier for `batch1 @ batch2`
     batch1 (Tensor): First batch of matrices to be multiplied
     batch2 (Tensor): Second batch of matrices to be multiplied
     out (Tensor, optional): Output tensor
@@ -544,8 +544,8 @@ Clamp all elements in :attr:`input` into the range `[min, max]` and return a res
 
 Args:
     input (Tensor): the input `Tensor`
-    min (Float): lower-bound of the range to be clamped to
-    max (Float): upper-bound of the range to be clamped to
+    min (float): lower-bound of the range to be clamped to
+    max (float): upper-bound of the range to be clamped to
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -577,7 +577,7 @@ Takes the element-wise `max` of the scalar :attr:`value` and each element of the
 
 Args:
     input (Tensor): the input `Tensor`
-    value (Float): the scalar to be compared with
+    value (float): the scalar to be compared with
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -654,7 +654,7 @@ Takes the element-wise `min` of the scalar :attr:`value` and each element of the
 
 Args:
     input (Tensor): the input `Tensor`
-    value (Float): the scalar to be compared with
+    value (float): the scalar to be compared with
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -793,7 +793,7 @@ If :attr:`dim` is not given, it defaults to the first dimension found with the s
 Args:
     input (Tensor): the input `Tensor`
     other  (Tensor): the second input `Tensor`
-    dim  (Long, optional): the dimension to take the cross-product in.
+    dim  (long, optional): the dimension to take the cross-product in.
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -844,7 +844,7 @@ For example, if :attr:`input` is a vector of size N, the result will also be a v
 
 Args:
     input (Tensor): the input `Tensor`
-    dim  (Long): the dimension to do the operation over
+    dim  (long): the dimension to do the operation over
     out (Tensor, optional): The result `Tensor`
 
 Example::
@@ -906,7 +906,7 @@ For example, if :attr:`input` is a vector of size N, the result will also be a v
 
 Args:
     input (Tensor): the input `Tensor`
-    dim  (Long): the dimension to do the operation over
+    dim  (long): the dimension to do the operation over
     out (Tensor, optional): The result `Tensor`
 
 Example::

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -4,11 +4,12 @@ import torch._C
 from torch._C import _add_docstr as add_docstr
 
 add_docstr(torch._C.abs,
-"""abs(tensor, out=None) -> tensor
+"""abs(input, out=None) -> Tensor
 
-Computes the element-wise absolute value of a tensor.
+Computes the element-wise absolute value of the given :attr:`input` a tensor.
 
-Example:
+Example::
+
     >>> torch.abs(torch.FloatTensor([-1, -2, 3]))
     FloatTensor([1, 2, 3])
 """)
@@ -20,14 +21,13 @@ acos(input, out=None) -> Tensor
 Returns a new `Tensor` with the arccosine  of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     
     -0.6366
      0.2718
@@ -45,22 +45,21 @@ Example:
 
 add_docstr(torch._C.add,
 """
-.. function:: add(tensor, value, out=None)
+.. function:: add(input, value, out=None)
 
-Adds the scalar :attr:`value` to each element of the input :attr:`tensor` and returns a new resulting tensor.
+Adds the scalar :attr:`value` to each element of the input :attr:`input` and returns a new resulting tensor.
 
 :math:`out = tensor + value`
 
 Args:
-    tensor (Tensor): the input `Tensor`
-    value (number): the number to be added to each element of :attr:`tensor`
+    input (Tensor): the input `Tensor`
+    value (Float): the number to be added to each element of :attr:`input`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
 
      0.4050
     -1.2227
@@ -77,27 +76,26 @@ Example:
     [torch.FloatTensor of size 4]
 
 
-.. function:: add(tensor, value=1, other, out=None)
+.. function:: add(input, value=1, other, out=None)
 
-Each element of the Tensor :attr:`other` is multiplied by the scalar :attr:`value` and added to each element of the Tensor :attr:`tensor`. The resulting Tensor is returned.
-The shapes of :attr:`tensor` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+Each element of the Tensor :attr:`other` is multiplied by the scalar :attr:`value` and added to each element of the Tensor :attr:`input`. The resulting Tensor is returned.
+The shapes of :attr:`input` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
 
-.. note:: When the shapes do not match, the shape of :attr:`tensor` is used as the shape for the returned output Tensor
+.. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
 
 :math:`out = tensor + (other * value)`
 
 Args:
-    tensor (Tensor): the first input `Tensor`
-    value (number): the scalar multiplier for :attr:`other`
+    input (Tensor): the first input `Tensor`
+    value (Float): the scalar multiplier for :attr:`other`
     other (Tensor): the second input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> import torch
     >>> a = torch.randn(4)
-    >>> print(a)    
+    >>> a    
 
     -0.9310
      2.0330
@@ -106,7 +104,7 @@ Example:
     [torch.FloatTensor of size 4]
 
     >>> b = torch.randn(2, 2)
-    >>> print(b)
+    >>> b
 
      1.0663  0.2544
     -0.1513  0.0749
@@ -127,7 +125,7 @@ add_docstr(torch._C.addbmm,
 addbmm(beta=1, mat, alpha=1, batch1, batch2, out=None) -> Tensor
 
 Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and :attr:`batch2`, 
-with a reduced add step (all matrix multiplications get accumulated in a single place). 
+with a reduced add step (all matrix multiplications get accumulated along the first dimension). 
 :attr:`mat` is added to the final result.
 
 :attr:`batch1` and :attr:`batch2` must be 3D Tensors each containing the same number of matrices.
@@ -135,18 +133,17 @@ with a reduced add step (all matrix multiplications get accumulated in a single 
 If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor, :attr:`out` and :attr:`mat` will be `n x p` Tensors.
 
 In other words,
-:math:`res = (beta * M) + (alpha * sum(batch1_i * batch2_i, i = 1, b))`
+:math:`res = (beta * M) + (alpha * sum(batch1_i @ batch2_i, i = 0, b))`
 
 Args:
-    beta (float, optional): multiplier for :attr:`mat`
+    beta (Float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (float, optional): multiplier for `batch1 @ batch2`
+    alpha (Float, optional): multiplier for `batch1 @ batch2`
     batch1 (Tensor): First batch of matrices to be multiplied
     batch2 (Tensor): Second batch of matrices to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> M = torch.randn(3, 5)
     >>> batch1 = torch.randn(10, 3, 4)
@@ -170,13 +167,12 @@ The number of elements must match, but sizes do not matter.
 
 Args:
     tensor (Tensor): the tensor to be added
-    value (float, optional): multiplier for `tensor1 ./ tensor2`
+    value (Float, optional): multiplier for `tensor1 ./ tensor2`
     tensor1 (Tensor): Numerator tensor
     tensor2 (Tensor): Denominator tensor
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> t = torch.randn(2, 3)
     >>> t1 = torch.randn(1, 6)
@@ -199,13 +195,12 @@ The number of elements must match, but sizes do not matter.
 
 Args:
     tensor (Tensor): the tensor to be added
-    value (float, optional): multiplier for `tensor1 .* tensor2`
+    value (Float, optional): multiplier for `tensor1 .* tensor2`
     tensor1 (Tensor): tensor to be multiplied
     tensor2 (Tensor): tensor to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> t = torch.randn(2, 3)
     >>> t1 = torch.randn(1, 6)
@@ -226,21 +221,20 @@ The matrix :attr:`mat` is added to the final result.
 
 If :attr:`mat1` is a `n x m` Tensor, :attr:`mat2` is a `m x p` Tensor, :attr:`out` and :attr:`mat` will be `n x p` Tensors.
 
-`alpha` and `beta` are scaling factors on `mat1@mat2` and `mat` respectively.
+`alpha` and `beta` are scaling factors on `mat1 @ mat2` and `mat` respectively.
 
 In other words,
-:math:`out = (beta * M) + (alpha * mat1 * mat2)`
+:math:`out = (beta * M) + (alpha * mat1 @ mat2)`
 
 Args:
-    beta (float, optional): multiplier for :attr:`mat`
+    beta (Float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (float, optional): multiplier for `mat1 @ mat2`
+    alpha (Float, optional): multiplier for `mat1 @ mat2`
     mat1 (Tensor): First matrix to be multiplied
     mat2 (Tensor): Second matrix to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> M = torch.randn(2, 3)
     >>> mat1 = torch.randn(2, 3)
@@ -261,22 +255,21 @@ The vector :attr:`tensor` is added to the final result.
 
 If :attr:`mat` is a `n x m` Tensor, :attr:`vec` is a 1D Tensor of size `m`, :attr:`out` and :attr:`tensor` will be 1D of size `n`.
 
-`alpha` and `beta` are scaling factors on `mat*vec` and `tensor` respectively.
+`alpha` and `beta` are scaling factors on `mat * vec` and `tensor` respectively.
 
 In other words:
 
-:math:`out = (beta * tensor) + (alpha * (mat * vec2))`
+:math:`out = (beta * tensor) + (alpha * (mat @ vec2))`
 
 Args:
-    beta (float, optional): multiplier for :attr:`tensor`
+    beta (Float, optional): multiplier for :attr:`tensor`
     tensor (Tensor): vector to be added
-    alpha (float, optional): multiplier for `mat @ vec`
+    alpha (Float, optional): multiplier for `mat @ vec`
     mat (Tensor): matrix to be multiplied
     vec (Tensor): vector to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> M = torch.randn(2)
     >>> mat = torch.randn(2, 3)
@@ -298,20 +291,19 @@ Optional values :attr:`beta` and :attr:`alpha` are scalars that multiply :attr:`
 
 In other words,
 
-:math:`res_{ij} = (beta * mat_i_j) + (alpha * vec1_i * vec2_j)`
+:math:`res_{ij} = (beta * mat_i_j) + (alpha * vec1_i @ vec2_j)`
 
 If :attr:`vec1` is a vector of size `n` and :attr:`vec2` is a vector of size `m`, then :attr:`mat` must be a matrix of size `n x m`
 
 Args:
-    beta (float, optional): multiplier for :attr:`mat`
+    beta (Float, optional): multiplier for :attr:`mat`
     mat (Tensor): matrix to be added
-    alpha (float, optional): multiplier for `vec1 (out) vec2`
+    alpha (Float, optional): multiplier for `vec1 (out) vec2`
     vec1 (Tensor): First vector of the outer product
     vec2 (Tensor): Second vector of the outer product
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> vec1 = torch.range(1, 3)
     >>> vec2 = torch.range(1, 2)
@@ -330,14 +322,13 @@ asin(input, out=None) -> Tensor
 Returns a new `Tensor` with the arcsine  of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -359,14 +350,13 @@ atan(input, out=None) -> Tensor
 Returns a new `Tensor` with the arctangent  of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -388,15 +378,14 @@ atan2(input1, input2, out=None) -> Tensor
 Returns a new `Tensor` with the arctangent of the elements of :attr:`input1` and :attr:`input2`.
 
 Args:
-    tensor (Tensor): the first input `Tensor`
-    tensor (Tensor): the second input `Tensor`
+    input1 (Tensor): the first input `Tensor`
+    input2 (Tensor): the second input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -415,7 +404,7 @@ add_docstr(torch._C.baddbmm,
 """
 baddbmm(beta=1, mat, alpha=1, batch1, batch2, out=None) -> Tensor
 
-Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and :attr:`batch2`. 
+Performs a batch matrix-matrix product of matrices in :attr:`batch1` and :attr:`batch2`. 
 :attr:`mat` is added to the final result.
 
 :attr:`batch1` and :attr:`batch2` must be 3D Tensors each containing the same number of matrices.
@@ -423,18 +412,17 @@ Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and 
 If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor, :attr:`out` and :attr:`mat` will be `b x n x p` Tensors.
 
 In other words,
-:math:`res_i = (beta * M_i) + (alpha * batch1_i * batch2_i)`
+:math:`res_i = (beta * M_i) + (alpha * batch1_i @ batch2_i)`
 
 Args:
-    beta (float, optional): multiplier for :attr:`mat`
+    beta (Float, optional): multiplier for :attr:`mat`
     mat (Tensor): tensor to be added
-    alpha (float, optional): multiplier for `batch1 @ batch2`
+    alpha (Float, optional): multiplier for `batch1 @ batch2`
     batch1 (Tensor): First batch of matrices to be multiplied
     batch2 (Tensor): Second batch of matrices to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> M = torch.randn(10, 3, 5)
     >>> batch1 = torch.randn(10, 3, 4)
@@ -463,13 +451,12 @@ Args:
     batch2 (Tensor): Second batch of matrices to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> batch1 = torch.randn(10, 3, 4)
     >>> batch2 = torch.randn(10, 4, 5)
     >>> res = torch.bmm(M, batch1, batch2)
-    >>> print(res.size())
+    >>> res.size()
     torch.Size([10, 3, 5])
 """)
 
@@ -483,22 +470,257 @@ add_docstr(torch._C.cauchy,
 
 add_docstr(torch._C.ceil,
 """
+ceil(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the ceil of the elements of :attr:`input`, the smallest integer greater than or equal to each element.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.ceil(a)
+    
+     2
+     1
+    -0
+    -0
+    [torch.FloatTensor of size 4]
+    
 """)
 
 add_docstr(torch._C.cinv,
 """
+cinv(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the scalar inverse of the elements of :attr:`input`, i.e. :math:`1.0 / x`
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cinv(a)
+    
+     0.7210
+     2.5565
+    -1.1583
+    -1.8289
+    [torch.FloatTensor of size 4]    
+
 """)
 
 add_docstr(torch._C.clamp,
 """
+clamp(input, min, max, out=None) -> Tensor
+
+Clamp all elements in :attr:`input` into the range `[min, max]` and return a resulting Tensor.
+
+::
+
+          | min, if x_i < min
+    y_i = | x_i, if min <= x_i <= max
+          | max, if x_i > max
+
+Args:
+    input (Tensor): the input `Tensor`
+    min (Float): lower-bound of the range to be clamped to
+    max (Float): upper-bound of the range to be clamped to
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.clamp(a, min=-0.5, max=0.5)
+    
+     0.5000
+     0.3912
+    -0.5000
+    -0.5000
+    [torch.FloatTensor of size 4]
+    
 """)
 
 add_docstr(torch._C.cmax,
 """
+.. function:: cmax(input, value, out=None) -> Tensor
+
+Takes the element-wise `max` of the scalar :attr:`value` and each element of the input :attr:`input` and returns a new tensor with the result.
+
+Args:
+    input (Tensor): the input `Tensor`
+    value (Float): the scalar to be compared with
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cmax(a, 0.5)
+
+     1.3869
+     0.5000
+     0.5000
+     0.5000
+    [torch.FloatTensor of size 4]
+    
+    
+.. function:: cmax(input, other, out=None) -> Tensor
+
+Each element of the Tensor :attr:`other` is compared with the corresponding element of the Tensor :attr:`input` 
+and an element-wise `max` is taken. The resulting Tensor is returned.
+
+The shapes of :attr:`input` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+
+.. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
+
+:math:`out_i = max(tensor_i, other_i)`
+
+Args:
+    input (Tensor): the input `Tensor`
+    other (Tensor): the second input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> b = torch.randn(4)
+    >>> b
+    
+     1.0067
+    -0.8010
+     0.6258
+     0.3627
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cmax(a, b)
+    
+     1.3869
+     0.3912
+     0.6258
+     0.3627
+    [torch.FloatTensor of size 4]
+
 """)
 
 add_docstr(torch._C.cmin,
 """
+.. function:: cmin(input, value, out=None) -> Tensor
+
+Takes the element-wise `min` of the scalar :attr:`value` and each element of the input :attr:`input` and returns a new tensor with the result.
+
+Args:
+    input (Tensor): the input `Tensor`
+    value (Float): the scalar to be compared with
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cmin(a, 0.5)
+    
+     0.5000
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+        
+    
+.. function:: cmin(input, other, out=None) -> Tensor
+
+Each element of the Tensor :attr:`other` is compared with the corresponding element of the Tensor :attr:`input` 
+and an element-wise `min` is taken. The resulting Tensor is returned.
+
+The shapes of :attr:`input` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+
+.. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
+
+:math:`out_i = min(tensor_i, other_i)`
+
+Args:
+    input (Tensor): the input `Tensor`
+    other (Tensor): the second input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> b = torch.randn(4)
+    >>> b
+    
+     1.0067
+    -0.8010
+     0.6258
+     0.3627
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.cmin(a, b)    
+    
+     1.0067
+    -0.8010
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
 """)
 
 add_docstr(torch._C.cos,
@@ -508,14 +730,13 @@ cos(input, out=None) -> Tensor
 Returns a new `Tensor` with the cosine  of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -537,14 +758,13 @@ cosh(input, out=None) -> Tensor
 Returns a new `Tensor` with the hyperbolic cosine  of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -561,14 +781,166 @@ Example:
 
 add_docstr(torch._C.cross,
 """
+cross(input, other, dim=-1, out=None) -> Tensor
+
+
+Returns the cross product of vectors in dimension :attr:`dim` of :attr:`input` and :attr:`other`.
+
+:attr:`input` and :attr:`other` must have the same size, and the size of their :attr:`dim` dimension should be 3.
+
+If :attr:`dim` is not given, it defaults to the first dimension found with the size 3.
+
+Args:
+    input (Tensor): the input `Tensor`
+    other  (Tensor): the second input `Tensor`
+    dim  (Long, optional): the dimension to take the cross-product in.
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4, 3)
+    >>> a
+    
+    -0.6652 -1.0116 -0.6857
+     0.2286  0.4446 -0.5272
+     0.0476  0.2321  1.9991
+     0.6199  1.1924 -0.9397
+    [torch.FloatTensor of size 4x3]
+    
+    >>> b = torch.randn(4, 3)
+    >>> b
+    
+    -0.1042 -1.1156  0.1947
+     0.9947  0.1149  0.4701
+    -1.0108  0.8319 -0.0750
+     0.9045 -1.3754  1.0976
+    [torch.FloatTensor of size 4x3]
+    
+    >>> torch.cross(a, b, dim=1)
+    
+    -0.9619  0.2009  0.6367
+     0.2696 -0.6318 -0.4160
+    -1.6805 -2.0171  0.2741
+     0.0163 -1.5304 -1.9311
+    [torch.FloatTensor of size 4x3]
+    
+    >>> torch.cross(a, b)
+    
+    -0.9619  0.2009  0.6367
+     0.2696 -0.6318 -0.4160
+    -1.6805 -2.0171  0.2741
+     0.0163 -1.5304 -1.9311
+    [torch.FloatTensor of size 4x3]
 """)
 
 add_docstr(torch._C.cumprod,
 """
+cumprod(input, dim, out=None) -> Tensor
+
+Returns the cumulative product of elements of :attr:`input` in the dimension :attr:`dim`.
+
+For example, if :attr:`input` is a vector of size N, the result will also be a vector of size N, with elements:
+:math:`y_i = x_1 * x_2 * x_3 * ... * x_i`
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim  (Long): the dimension to do the operation over
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(10)
+    >>> a
+    
+     1.1148
+     1.8423
+     1.4143
+    -0.4403
+     1.2859
+    -1.2514
+    -0.4748
+     1.1735
+    -1.6332
+    -0.4272
+    [torch.FloatTensor of size 10]
+    
+    >>> torch.cumprod(a, dim=0)
+    
+     1.1148
+     2.0537
+     2.9045
+    -1.2788
+    -1.6444
+     2.0578
+    -0.9770
+    -1.1466
+     1.8726
+    -0.8000
+    [torch.FloatTensor of size 10]
+    
+    >>> a[5] = 0.0
+    >>> torch.cumprod(a, dim=0)
+    
+     1.1148
+     2.0537
+     2.9045
+    -1.2788
+    -1.6444
+    -0.0000
+     0.0000
+     0.0000
+    -0.0000
+     0.0000
+    [torch.FloatTensor of size 10]
+        
 """)
 
 add_docstr(torch._C.cumsum,
 """
+cumsum(input, dim, out=None) -> Tensor
+
+Returns the cumulative sum of elements of :attr:`input` in the dimension :attr:`dim`.
+
+For example, if :attr:`input` is a vector of size N, the result will also be a vector of size N, with elements:
+:math:`y_i = x_1 + x_2 + x_3 + ... + x_i`
+
+Args:
+    input (Tensor): the input `Tensor`
+    dim  (Long): the dimension to do the operation over
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(10)
+    >>> a
+    
+    -0.6039
+    -0.2214
+    -0.3705
+    -0.0169
+     1.3415
+    -0.1230
+     0.9719
+     0.6081
+    -0.1286
+     1.0947
+    [torch.FloatTensor of size 10]
+    
+    >>> torch.cumsum(a, dim=0)
+    
+    -0.6039
+    -0.8253
+    -1.1958
+    -1.2127
+     0.1288
+     0.0058
+     0.9777
+     1.5858
+     1.4572
+     2.5519
+    [torch.FloatTensor of size 10]
+            
+    
 """)
 
 add_docstr(torch._C.diag,
@@ -590,8 +962,7 @@ dot(tensor1, tensor2) -> float
 Computes the dot product (inner product) of two tensors. Both tensors are
 treated as 1-D vectors.
 
-Example:
-::
+Example::
 
     >>> torch.dot(torch.Tensor([2, 3]), torch.Tensor([2, 1]))
     7.0
@@ -619,7 +990,7 @@ Returns:
 
 add_docstr(torch._C.eq,
 """
-eq(tensor, other, out=None) -> Tensor
+eq(input, other, out=None) -> Tensor
 
 Computes element-wise equality
 
@@ -627,15 +998,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where the tensors are equal and a 0 at every other location
 
-Example:
-::
+Example::
 
     >>> torch.eq(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
     1  0
@@ -649,8 +1019,7 @@ equal(tensor1, tensor2) -> bool
 
 True if two tensors have the same size and elements, False otherwise.
 
-Example:
-::
+Example::
 
     >>> torch.equal(torch.Tensor([1, 2]), torch.Tensor([1, 2]))
     True
@@ -658,12 +1027,11 @@ Example:
 
 add_docstr(torch._C.exp,
 """
-exp(tensor, out=None) -> tensor
+exp(tensor, out=None) -> Tensor
 
 Computes the exponential of each element.
 
-Example:
-::
+Example::
 
     >>> torch.exp(torch.Tensor([0, math.log(2)]))
     torch.FloatTensor([1, 2])
@@ -683,8 +1051,7 @@ Args:
 Returns:
     Tensor: a 2-D tensor with ones on the diagonal and zeros elsewhere
 
-Example:
-::
+Example::
 
     >>> torch.eye(3)
      1  0  0
@@ -695,21 +1062,39 @@ Example:
 
 add_docstr(torch._C.floor,
 """
-floor(tensor, out=None) -> Tensor
+floor(input, out=None) -> Tensor
 
-Computes the floor of each element in `tensor`. That is, each element is
-rounded down to the nearest integer.
+Returns a new `Tensor` with the floor of the elements of :attr:`input`, the largest integer less than or equal to each element.
 
-Example:
-::
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
 
-    >>> torch.floor(torch.Tensor([1.5, -2.7, 3.0]))
-    torch.FloatTensor([1, -3, 3])
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.3869
+     0.3912
+    -0.8634
+    -0.5468
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.floor(a)
+    
+     1
+     0
+    -1
+    -1
+    [torch.FloatTensor of size 4]
+    
+
 """)
 
 add_docstr(torch._C.fmod,
 """
-fmod(tensor, divisor, out=None) -> Tensor
+fmod(input, divisor, out=None) -> Tensor
 
 Computes the element-wise remainder of division.
 
@@ -717,13 +1102,12 @@ The dividend and divisor may contain both for integer and floating point
 numbers. The remainder has the same sign as the dividend `tensor`.
 
 Args:
-    tensor (Tensor): The dividend
+    input (Tensor): The dividend
     divisor (Tensor or float): The divisor. This may be either a number or a
                                tensor of the same shape as the dividend.
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> torch.fmod(torch.Tensor([-3, -2, -1, 1, 2, 3]), 2)
     torch.FloatTensor([-1, -0, -1, 1, 0, 1])
@@ -742,8 +1126,7 @@ frac(tensor, out=None) -> Tensor
 
 Computes the fractional portion of each element in `tensor`.
 
-Example:
-::
+Example::
 
     >>> torch.frac(torch.Tensor([1, 2.5, -3.2])
     torch.FloatTensor([0, 0.5, -0.2])
@@ -759,8 +1142,7 @@ The returned tensor and `ndarray` share the same memory. Modifications to the
 tensor will be reflected in the `ndarray` and vice versa. The returned tensor
 is not resizable.
 
-Example:
-::
+Example::
 
     >>> a = numpy.array([1, 2, 3])
     >>> t = torch.from_numpy(a)
@@ -773,7 +1155,7 @@ Example:
 
 add_docstr(torch._C.gather,
 """
-gather(tensor, dim, index, out=None) -> Tensor
+gather(input, dim, index, out=None) -> Tensor
 
 Gathers values along an axis specified by `dim`.
 
@@ -784,13 +1166,12 @@ For a 3-D tensor the output is specified by::
     out[i][j][k] = tensor[i][j][index[i][j][k]]  # dim=3
 
 Args:
-    tensor (Tensor): The source tensor
+    input (Tensor): The source tensor
     dim (int): The axis along which to index
     index (LongTensor): The indices of elements to gather
     out (Tensor, optional): Destination tensor
 
-Example:
-::
+Example::
 
     >>> t = torch.Tensor([[1,2],[3,4]])
     >>> torch.gather(t, 1, torch.LongTensor([[0,0],[1,0]]))
@@ -800,7 +1181,7 @@ Example:
 
 add_docstr(torch._C.ge,
 """
-ge(tensor, other, out=None) -> Tensor
+ge(input, other, out=None) -> Tensor
 
 Computes `tensor >= other` element-wise.
 
@@ -808,15 +1189,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
-Example:
-::
+Example::
 
     >>> torch.ge(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      1  1
@@ -869,8 +1249,7 @@ Returns:
     of the input matrices. That is, they will have stride `(1, m)` instead of
     `(m, 1)`.
 
-Example:
-::
+Example::
 
 
     >>> A = torch.Tensor([[1, 1, 1],
@@ -912,7 +1291,7 @@ Gets the number of OpenMP threads used for parallelizing CPU operations
 
 add_docstr(torch._C.gt,
 """
-gt(tensor, other, out=None) -> Tensor
+gt(input, other, out=None) -> Tensor
 
 Computes `tensor > other` element-wise.
 
@@ -920,15 +1299,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
-Example:
-::
+Example::
 
     >>> torch.gt(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  1
@@ -938,7 +1316,7 @@ Example:
 
 add_docstr(torch._C.histc,
 """
-histc(tensor, bins=100, min=0, max=0, out=None) -> Tensor
+histc(input, bins=100, min=0, max=0, out=None) -> Tensor
 
 Computes the histogram of a tensor.
 
@@ -946,7 +1324,7 @@ The elements are sorted into equal width bins between `min` and `max`. If `min`
 and `max` are both zero, the minimum and maximum values of the data are used.
 
 Args:
-    tensor (Tensor): Input data
+    input (Tensor): Input data
     bins (int): Number of histogram bins
     min (int): Lower end of the range (inclusive)
     max (int): Upper end of the range (inclusive)
@@ -955,8 +1333,7 @@ Args:
 Returns:
     Tensor: the histogram
 
-Example:
-::
+Example::
 
     >>> torch.histc(torch.FloatTensor([1, 2, 1]), bins=4, min=0, max=3)
     FloatTensor([0, 2, 1, 0])
@@ -977,7 +1354,7 @@ add_docstr(torch._C.kthvalue,
 
 add_docstr(torch._C.le,
 """
-le(tensor, other, out=None) -> Tensor
+le(input, other, out=None) -> Tensor
 
 Computes `tensor <= other` element-wise.
 
@@ -985,15 +1362,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
-Example:
-::
+Example::
 
     >>> torch.le(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      1  0
@@ -1027,7 +1403,7 @@ add_docstr(torch._C.logspace,
 
 add_docstr(torch._C.lt,
 """
-lt(tensor, other, out=None) -> Tensor
+lt(input, other, out=None) -> Tensor
 
 Computes `tensor < other` element-wise.
 
@@ -1035,15 +1411,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
-Example:
-::
+Example::
 
     >>> torch.lt(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  0
@@ -1084,8 +1459,7 @@ Args:
     mat2 (Tensor): Second matrix to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> mat1 = torch.randn(2, 3)
     >>> mat2 = torch.randn(3, 3)
@@ -1120,8 +1494,7 @@ Args:
     vec (Tensor): vector to be multiplied
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> M = torch.randn(2)
     >>> mat = torch.randn(2, 3)
@@ -1134,7 +1507,7 @@ Example:
 
 add_docstr(torch._C.ne,
 """
-ne(tensor, other, out=None) -> Tensor
+ne(input, other, out=None) -> Tensor
 
 Computes `tensor != other` element-wise.
 
@@ -1142,15 +1515,14 @@ The second argument can be a number or a tensor of the same shape and
 type as the first argument.
 
 Args:
-    tensor (Tensor): Tensor to compare
+    input (Tensor): Tensor to compare
     other (Tensor or float): Tensor or value to compare
     out (Tensor, optional): Output tensor. Must be a `ByteTensor` or the same type as `tensor`.
 
 Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
-Example:
-::
+Example::
 
     >>> torch.ne(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  1
@@ -1240,7 +1612,7 @@ add_docstr(torch._C.range,
 
 add_docstr(torch._C.remainder,
 """
-remainder(tensor, divisor, out=None) -> Tensor
+remainder(input, divisor, out=None) -> Tensor
 
 Computes the element-wise remainder of division.
 
@@ -1248,13 +1620,12 @@ The divisor and dividend may contain both for integer and floating point
 numbers. The remainder has the same sign as the divisor.
 
 Args:
-    tensor (Tensor): The dividend
+    input (Tensor): The dividend
     divisor (Tensor or float): The divisor. This may be either a number or a
                                tensor of the same shape as the dividend.
     out (Tensor, optional): Output tensor
 
-Example:
-::
+Example::
 
     >>> torch.remainder(torch.Tensor([-3, -2, -1, 1, 2, 3]), 2)
     torch.FloatTensor([1, 0, 1, 1, 0, 1])
@@ -1309,14 +1680,13 @@ sin(input, out=None) -> Tensor
 Returns a new `Tensor` with the sine of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -1338,14 +1708,13 @@ sinh(input, out=None) -> Tensor
 Returns a new `Tensor` with the hyperbolic sine of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -1399,14 +1768,13 @@ tan(input, out=None) -> Tensor
 Returns a new `Tensor` with the tangent of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469
@@ -1428,14 +1796,13 @@ tanh(input, out=None) -> Tensor
 Returns a new `Tensor` with the hyperbolic tangent of the elements of :attr:`input`.
 
 Args:
-    tensor (Tensor): the input `Tensor`
+    input (Tensor): the input `Tensor`
     out (Tensor, optional): The result `Tensor`
 
-Example:
-::
+Example::
 
     >>> a = torch.randn(4)
-    >>> print(a)
+    >>> a
     -0.6366
      0.2718
      0.4469

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -46,22 +46,152 @@ add_docstr(torch._C.add,
 
 add_docstr(torch._C.addbmm,
 """
+addbmm(beta=1, mat, alpha=1, batch1, batch2, out=None) -> Tensor
+
+Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and :attr:`batch2`, 
+with a reduced add step (all matrix multiplications get accumulated in a single place). 
+:attr:`mat` is added to the final result.
+
+:attr:`batch1` and :attr:`batch2` must be 3D Tensors each containing the same number of matrices.
+
+If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor, :attr:`out` and :attr:`mat` will be `n x p` Tensors.
+
+In other words,
+:math:`res = (beta * M) + (alpha * sum(batch1_i * batch2_i, i = 1, b))`
+
+Args:
+    beta (float, optional): multiplier for :attr:`mat`
+    mat (Tensor): matrix to be added
+    alpha (float, optional): multiplier for `batch1 @ batch2`
+    batch1 (Tensor): First batch of matrices to be multiplied
+    batch2 (Tensor): Second batch of matrices to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> M = torch.randn(3, 5)
+    >>> batch1 = torch.randn(10, 3, 4)
+    >>> batch2 = torch.randn(10, 4, 5)
+    >>> torch.addbmm(M, batch1, batch2)
+     -3.1162  11.0071   7.3102   0.1824  -7.6892
+      1.8265   6.0739   0.4589  -0.5641  -5.4283
+     -9.3387  -0.1794  -1.2318  -6.8841  -4.7239
+    [torch.FloatTensor of size 3x5]
 """)
 
 add_docstr(torch._C.addcdiv,
 """
+addcdiv(tensor, value=1, tensor1, tensor2, out=None) -> Tensor
+
+Performs the element-wise division of :attr:`tensor1` by :attr:`tensor2`, multiply
+the result by the scalar :attr:`value` and add it to :attr:`tensor`.
+
+The number of elements must match, but sizes do not matter.
+
+Args:
+    tensor (Tensor): the tensor to be added
+    value (float, optional): multiplier for `tensor1 ./ tensor2`
+    tensor1 (Tensor): Numerator tensor
+    tensor2 (Tensor): Denominator tensor
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> t = torch.randn(2, 3)
+    >>> t1 = torch.randn(1, 6)
+    >>> t2 = torch.randn(6, 1)
+    >>> torch.addcdiv(t, 0.1, t1, t2)
+     0.0122 -0.0188 -0.2354
+     0.7396 -1.5721  1.2878
+    [torch.FloatTensor of size 2x3]
 """)
 
 add_docstr(torch._C.addcmul,
 """
-""")
+addcmul(tensor, value=1, tensor1, tensor2, out=None) -> Tensor
+
+Performs the element-wise multiplication of :attr:`tensor1` by :attr:`tensor2`, multiply
+the result by the scalar :attr:`value` and add it to :attr:`tensor`.
+
+The number of elements must match, but sizes do not matter.
+
+Args:
+    tensor (Tensor): the tensor to be added
+    value (float, optional): multiplier for `tensor1 .* tensor2`
+    tensor1 (Tensor): tensor to be multiplied
+    tensor2 (Tensor): tensor to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> t = torch.randn(2, 3)
+    >>> t1 = torch.randn(1, 6)
+    >>> t2 = torch.randn(6, 1)
+    >>> torch.addcmul(t, 0.1, t1, t2)
+     0.0122 -0.0188 -0.2354
+     0.7396 -1.5721  1.2878
+    [torch.FloatTensor of size 2x3]""")
 
 add_docstr(torch._C.addmm,
 """
+addmm(beta=1, mat, alpha=1, mat1, mat2, out=None) -> Tensor
+
+Performs a matrix multiplication of the matrices :attr:`mat1` and :attr:`mat2`. 
+The matrix :attr:`mat` is added to the final result.
+
+If :attr:`mat1` is a `n x m` Tensor, :attr:`mat2` is a `m x p` Tensor, :attr:`out` and :attr:`mat` will be `n x p` Tensors.
+
+`alpha` and `beta` are scaling factors on `mat1@mat2` and `mat` respectively.
+
+In other words,
+:math:`out = (beta * M) + (alpha * mat1 * mat2)`
+
+Args:
+    beta (float, optional): multiplier for :attr:`mat`
+    mat (Tensor): matrix to be added
+    alpha (float, optional): multiplier for `mat1 @ mat2`
+    mat1 (Tensor): First matrix to be multiplied
+    mat2 (Tensor): Second matrix to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> M = torch.randn(2, 3)
+    >>> mat1 = torch.randn(2, 3)
+    >>> mat2 = torch.randn(3, 3)
+    >>> torch.addmm(M, mat1, mat2)
+    -0.4095 -1.9703  1.3561
+     5.7674 -4.9760  2.7378
+    [torch.FloatTensor of size 2x3]
 """)
 
 add_docstr(torch._C.addmv,
 """
+addmv(beta=1, tensor, alpha=1, mat, vec, out=None) -> Tensor
+
+Performs a matrix-vector product of the matrix :attr:`mat` and the vector :attr:`vec`.
+The vector :attr:`tensor` is added to the final result.
+
+If :attr:`mat` is a `n x m` Tensor, :attr:`vec` is a 1D Tensor of size `m`, :attr:`out` and :attr:`tensor` will be 1D of size `n`.
+
+`alpha` and `beta` are scaling factors on `mat*vec` and `tensor` respectively.
+
+In other words:
+
+:math:`out = (beta * tensor) + (alpha * (mat * vec2))`
+
+Args:
+    beta (float, optional): multiplier for :attr:`tensor`
+    tensor (Tensor): vector to be added
+    alpha (float, optional): multiplier for `mat @ vec`
+    mat (Tensor): matrix to be multiplied
+    vec (Tensor): vector to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> M = torch.randn(2)
+    >>> mat = torch.randn(2, 3)
+    >>> vec = torch.randn(3)
+    >>> torch.addmv(M, mat, vec)
+    -2.0939
+    -2.2950
+    [torch.FloatTensor of size 2]
 """)
 
 add_docstr(torch._C.addr,
@@ -90,7 +220,7 @@ Example:
     >>> vec1 = torch.range(1, 3)
     >>> vec2 = torch.range(1, 2)
     >>> M = torch.zeros(3, 2)
-    >>> torch.addr(M, x, y)
+    >>> torch.addr(M, vec1, vec2)
      1  2
      2  4
      3  6
@@ -181,6 +311,32 @@ Example:
 
 add_docstr(torch._C.baddbmm,
 """
+baddbmm(beta=1, mat, alpha=1, batch1, batch2, out=None) -> Tensor
+
+Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and :attr:`batch2`. 
+:attr:`mat` is added to the final result.
+
+:attr:`batch1` and :attr:`batch2` must be 3D Tensors each containing the same number of matrices.
+
+If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor, :attr:`out` and :attr:`mat` will be `b x n x p` Tensors.
+
+In other words,
+:math:`res_i = (beta * M_i) + (alpha * batch1_i * batch2_i)`
+
+Args:
+    beta (float, optional): multiplier for :attr:`mat`
+    mat (Tensor): tensor to be added
+    alpha (float, optional): multiplier for `batch1 @ batch2`
+    batch1 (Tensor): First batch of matrices to be multiplied
+    batch2 (Tensor): Second batch of matrices to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> M = torch.randn(10, 3, 5)
+    >>> batch1 = torch.randn(10, 3, 4)
+    >>> batch2 = torch.randn(10, 4, 5)
+    >>> torch.baddbmm(M, batch1, batch2).size()
+    torch.Size([10, 3, 5])
 """)
 
 add_docstr(torch._C.bernoulli,
@@ -189,6 +345,26 @@ add_docstr(torch._C.bernoulli,
 
 add_docstr(torch._C.bmm,
 """
+bmm(batch1, batch2, out=None) -> Tensor
+
+Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and :attr:`batch2`.
+
+:attr:`batch1` and :attr:`batch2` must be 3D Tensors each containing the same number of matrices.
+
+If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor, 
+:attr:`out` will be a `b x n x p` Tensor.
+
+Args:
+    batch1 (Tensor): First batch of matrices to be multiplied
+    batch2 (Tensor): Second batch of matrices to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> batch1 = torch.randn(10, 3, 4)
+    >>> batch2 = torch.randn(10, 4, 5)
+    >>> res = torch.bmm(M, batch1, batch2)
+    >>> print(res.size())
+    torch.Size([10, 3, 5])
 """)
 
 add_docstr(torch._C.cat,
@@ -755,6 +931,24 @@ add_docstr(torch._C.min,
 
 add_docstr(torch._C.mm,
 """
+mm(mat1, mat2, out=None) -> Tensor
+
+Performs a matrix multiplication of the matrices :attr:`mat1` and :attr:`mat2`. 
+
+If :attr:`mat1` is a `n x m` Tensor, :attr:`mat2` is a `m x p` Tensor, :attr:`out` will be a `n x p` Tensor.
+
+Args:
+    mat1 (Tensor): First matrix to be multiplied
+    mat2 (Tensor): Second matrix to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> mat1 = torch.randn(2, 3)
+    >>> mat2 = torch.randn(3, 3)
+    >>> torch.mm(mat1, mat2)
+     0.0519 -0.3304  1.2232
+     4.3910 -5.1498  2.7571
+    [torch.FloatTensor of size 2x3]
 """)
 
 add_docstr(torch._C.mode,
@@ -771,6 +965,25 @@ add_docstr(torch._C.multinomial,
 
 add_docstr(torch._C.mv,
 """
+addmv(mat, vec, out=None) -> Tensor
+
+Performs a matrix-vector product of the matrix :attr:`mat` and the vector :attr:`vec`.
+
+If :attr:`mat` is a `n x m` Tensor, :attr:`vec` is a 1D Tensor of size `m`, :attr:`out` will be 1D of size `n`.
+
+Args:
+    mat (Tensor): matrix to be multiplied
+    vec (Tensor): vector to be multiplied
+    out (Tensor, optional): Output tensor
+
+Example:
+    >>> M = torch.randn(2)
+    >>> mat = torch.randn(2, 3)
+    >>> vec = torch.randn(3)
+    >>> torch.mv(mat, vec)
+    -2.0939
+    -2.2950
+    [torch.FloatTensor of size 2]
 """)
 
 add_docstr(torch._C.ne,

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -83,7 +83,7 @@ The shapes of :attr:`input` and :attr:`other` dont need to match. The total numb
 
 .. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
 
-:math:`out = tensor + (other * value)`
+:math:`out = input + (other * value)`
 
 Args:
     input (Tensor): the first input `Tensor`
@@ -433,6 +433,54 @@ Example::
 
 add_docstr(torch._C.bernoulli,
 """
+bernoulli(input, out=None) -> Tensor
+
+Draws binary random numbers (0 or 1) from a bernoulli distribution.
+
+The :attr:`input` Tensor should be a tensor containing probabilities to be used for drawing the binary random number. 
+Hence, all values in :attr:`input` have to be in the range: :math:`0 <= input_i <= 1`
+
+The `i-th` element of the output tensor will draw a value `1` according to the `i-th` probability value given in :attr:`input`.
+
+The returned :attr:`out` Tensor only has values 0 or 1 and is of the same shape as :attr:`input`
+
+Args:
+    input (Tensor): Probability values for the bernoulli distribution
+    out (Tensor, optional): Output tensor
+
+Example::
+
+    >>> a = torch.Tensor(3, 3).uniform_(0, 1) # generate a uniform random matrix with range [0, 1]
+    >>> a
+    
+     0.7544  0.8140  0.9842
+     0.5282  0.0595  0.6445
+     0.1925  0.9553  0.9732
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.bernoulli(a)
+    
+     1  1  1
+     0  0  1
+     0  1  1
+    [torch.FloatTensor of size 3x3]
+    
+    >>> a = torch.ones(3, 3) # probability of drawing "1" is 1
+    >>> torch.bernoulli(a)
+    
+     1  1  1
+     1  1  1
+     1  1  1
+    [torch.FloatTensor of size 3x3]
+    
+    >>> a = torch.zeros(3, 3) # probability of drawing "1" is 0
+    >>> torch.bernoulli(a)
+    
+     0  0  0
+     0  0  0
+     0  0  0
+    [torch.FloatTensor of size 3x3]
+        
 """)
 
 add_docstr(torch._C.bmm,
@@ -461,10 +509,6 @@ Example::
 """)
 
 add_docstr(torch._C.cat,
-"""
-""")
-
-add_docstr(torch._C.cauchy,
 """
 """)
 
@@ -792,7 +836,7 @@ If :attr:`dim` is not given, it defaults to the first dimension found with the s
 
 Args:
     input (Tensor): the input `Tensor`
-    other  (Tensor): the second input `Tensor`
+    other (Tensor): the second input `Tensor`
     dim  (long, optional): the dimension to take the cross-product in.
     out (Tensor, optional): The result `Tensor`
 
@@ -945,14 +989,201 @@ Example::
 
 add_docstr(torch._C.diag,
 """
+diag(input, diagonal=0, out=None) -> Tensor
+
+- If :attr:`input` is a vector (1D Tensor), then returns a 2D square Tensor with the elements of :attr:`input` as the diagonal.
+- If :attr:`input` is a matrix (2D Tensor), then returns a 1D Tensor with the diagonal elements of :attr:`input`.
+
+The argument :attr:`diagional` controls which diagonal to consider.
+
+- :attr:`diagional` = 0, is the main diagonal.
+- :attr:`diagional` > 0, is above the main diagonal.
+- :attr:`diagional` < 0, is below the main diagonal.
+
+Args:
+    input (Tensor): the input `Tensor`
+    diagonal (long, optional): the diagonal to consider
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+
+Get the square matrix where the input vector is the diagonal::
+
+    >>> a = torch.randn(3)
+    >>> a
+    
+     1.0480
+    -2.3405
+    -1.1138
+    [torch.FloatTensor of size 3]
+    
+    >>> torch.diag(a)
+    
+     1.0480  0.0000  0.0000
+     0.0000 -2.3405  0.0000
+     0.0000  0.0000 -1.1138
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.diag(a, 1)
+    
+     0.0000  1.0480  0.0000  0.0000
+     0.0000  0.0000 -2.3405  0.0000
+     0.0000  0.0000  0.0000 -1.1138
+     0.0000  0.0000  0.0000  0.0000
+    [torch.FloatTensor of size 4x4]
+    
+
+Get the k-th diagonal of a given matrix::
+
+    >>> a = torch.randn(3, 3)
+    >>> a
+    
+    -1.5328 -1.3210 -1.5204
+     0.8596  0.0471 -0.2239
+    -0.6617  0.0146 -1.0817
+    [torch.FloatTensor of size 3x3]
+    
+    >>> torch.diag(a, 0)
+    
+    -1.5328
+     0.0471
+    -1.0817
+    [torch.FloatTensor of size 3]
+    
+    >>> torch.diag(a, 1)
+    
+    -1.3210
+    -0.2239
+    [torch.FloatTensor of size 2]
+                
 """)
 
 add_docstr(torch._C.dist,
 """
+dist(input, other, p=2, out=None) -> Tensor
+
+Returns the p-norm of (:attr:`input` - :attr:`other`)
+
+Args:
+    input (Tensor): the input `Tensor`
+    other (Tensor): the Right-hand-side input `Tensor`
+    p (float, optional): The norm to be computed.
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> x = torch.randn(4)
+    >>> x
+    
+     0.2505
+    -0.4571
+    -0.3733
+     0.7807
+    [torch.FloatTensor of size 4]
+    
+    >>> y = torch.randn(4)
+    >>> y
+    
+     0.7782
+    -0.5185
+     1.4106
+    -2.4063
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.dist(x, y, 3.5)
+    3.302832063224223
+    >>> torch.dist(x, y, 3)
+    3.3677282206393286
+    >>> torch.dist(x, y, 0)
+    inf
+    >>> torch.dist(x, y, 1)
+    5.560028076171875
+    
+    
 """)
 
 add_docstr(torch._C.div,
 """
+.. function:: div(input, value, out=None)
+
+Divides each element of the input :attr:`input` with the scalar :attr:`value` and returns a new resulting tensor.
+
+:math:`out = tensor / value`
+
+Args:
+    input (Tensor): the input `Tensor`
+    value (float): the number to be divided to each element of :attr:`input`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(5)
+    >>> a
+    
+    -0.6147
+    -1.1237
+    -0.1604
+    -0.6853
+     0.1063
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.div(a, 0.5)
+    
+    -1.2294
+    -2.2474
+    -0.3208
+    -1.3706
+     0.2126
+    [torch.FloatTensor of size 5]
+    
+
+.. function:: div(input, other, out=None)
+
+Each element of the Tensor :attr:`input` is divided by each element of the Tensor :attr:`other`. The resulting Tensor is returned.
+The shapes of :attr:`input` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+
+.. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
+
+:math:`out_i = input_i / other_i`
+
+Args:
+    input (Tensor): the numerator `Tensor`
+    other (Tensor): the denominator `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4,4)
+    >>> a
+    
+    -0.1810  0.4017  0.2863 -0.1013
+     0.6183  2.0696  0.9012 -1.5933
+     0.5679  0.4743 -0.0117 -0.1266
+    -0.1213  0.9629  0.2682  1.5968
+    [torch.FloatTensor of size 4x4]
+    
+    >>> b = torch.randn(8, 2)
+    >>> b
+    
+     0.8774  0.7650
+     0.8866  1.4805
+    -0.6490  1.1172
+     1.4259 -0.8146
+     1.4633 -0.1228
+     0.4643 -0.6029
+     0.3492  1.5270
+     1.6103 -0.6291
+    [torch.FloatTensor of size 8x2]
+    
+    >>> torch.div(a, b)
+    
+    -0.2062  0.5251  0.3229 -0.0684
+    -0.9528  1.8525  0.6320  1.9559
+     0.3881 -3.8625 -0.0253  0.2099
+    -0.3473  0.6306  0.1666 -2.5381
+    [torch.FloatTensor of size 4x4]
+        
+    
 """)
 
 add_docstr(torch._C.dot,
@@ -1177,7 +1408,8 @@ Example::
     >>> torch.gather(t, 1, torch.LongTensor([[0,0],[1,0]]))
      1  1
      4  3
-    [torch.FloatTensor of size 2x2]""")
+    [torch.FloatTensor of size 2x2]
+""")
 
 add_docstr(torch._C.ge,
 """
@@ -1387,14 +1619,72 @@ add_docstr(torch._C.linspace,
 
 add_docstr(torch._C.log,
 """
+log(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the natural logarithm of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(5)
+    >>> a
+    
+    -0.4183
+     0.3722
+    -0.3091
+     0.4149
+     0.5857
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.log(a)
+    
+        nan
+    -0.9883
+        nan
+    -0.8797
+    -0.5349
+    [torch.FloatTensor of size 5]
+        
 """)
 
 add_docstr(torch._C.log1p,
 """
-""")
+log1p(input, out=None) -> Tensor
 
-add_docstr(torch._C.log_normal,
-"""
+Returns a new `Tensor` with the natural logarithm of (1 + :attr:`input`).
+
+:math:`y_i = log(x_i + 1)`
+
+.. note:: This function is more accurate than :function:`torch.log` for small values of :attr:`input`
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(5)
+    >>> a
+    
+    -0.4183
+     0.3722
+    -0.3091
+     0.4149
+     0.5857
+    [torch.FloatTensor of size 5]
+    
+    >>> torch.log1p(a)
+    
+    -0.5418
+     0.3164
+    -0.3697
+     0.3471
+     0.4611
+    [torch.FloatTensor of size 5]
+            
 """)
 
 add_docstr(torch._C.logspace,
@@ -1475,6 +1765,75 @@ add_docstr(torch._C.mode,
 
 add_docstr(torch._C.mul,
 """
+.. function:: mul(input, value, out=None)
+
+Multiplies each element of the input :attr:`input` with the scalar :attr:`value` and returns a new resulting tensor.
+
+:math:`out = tensor / value`
+
+Args:
+    input (Tensor): the input `Tensor`
+    value (float): the number to be multiplied to each element of :attr:`input`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(3)
+    >>> a
+    
+    -0.9374
+    -0.5254
+    -0.6069
+    [torch.FloatTensor of size 3]
+    
+    >>> torch.mul(a, 100)
+    
+    -93.7411
+    -52.5374
+    -60.6908
+    [torch.FloatTensor of size 3]
+        
+    
+.. function:: mul(input, other, out=None)
+
+Each element of the Tensor :attr:`input` is multiplied by each element of the Tensor :attr:`other`. The resulting Tensor is returned.
+The shapes of :attr:`input` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+
+.. note:: When the shapes do not match, the shape of :attr:`input` is used as the shape for the returned output Tensor
+
+:math:`out_i = input_i / other_i`
+
+Args:
+    input (Tensor): the first multiplicand `Tensor`
+    other (Tensor): the second multiplicand `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4,4)
+    >>> a
+    
+    -0.7280  0.0598 -1.4327 -0.5825
+    -0.1427 -0.0690  0.0821 -0.3270
+    -0.9241  0.5110  0.4070 -1.1188
+    -0.8308  0.7426 -0.6240 -1.1582
+    [torch.FloatTensor of size 4x4]
+    
+    >>> b = torch.randn(2, 8)
+    >>> b
+    
+     0.0430 -1.0775  0.6015  1.1647 -0.6549  0.0308 -0.1670  1.0742
+    -1.2593  0.0292 -0.0849  0.4530  1.2404 -0.4659 -0.1840  0.5974
+    [torch.FloatTensor of size 2x8]
+    
+    >>> torch.mul(a, b)
+    
+    -0.0313 -0.0645 -0.8618 -0.6784
+     0.0934 -0.0021 -0.0137 -0.3513
+     1.1638  0.0149 -0.0346 -0.5068
+    -1.0304 -0.3460  0.1148 -0.6919
+    [torch.FloatTensor of size 4x4]        
+    
 """)
 
 add_docstr(torch._C.multinomial,
@@ -1648,10 +2007,64 @@ add_docstr(torch._C.reshape,
 
 add_docstr(torch._C.round,
 """
+round(input, out=None) -> Tensor
+
+Returns a new `Tensor` with each of the elements of :attr:`input` rounded to the closest integer.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.2290
+     1.3409
+    -0.5662
+    -0.0899
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.round(a)
+    
+     1
+     1
+    -1
+    -0
+    [torch.FloatTensor of size 4]
+        
 """)
 
 add_docstr(torch._C.rsqrt,
 """
+rsqrt(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the reciprocal of the square-root of each of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.2290
+     1.3409
+    -0.5662
+    -0.0899
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.rsqrt(a)
+    
+     0.9020
+     0.8636
+        nan
+        nan
+    [torch.FloatTensor of size 4]
+        
 """)
 
 add_docstr(torch._C.scatter,
@@ -1671,6 +2084,32 @@ add_docstr(torch._C.sigmoid,
 
 add_docstr(torch._C.sign,
 """
+sign(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the sign of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    -0.6366
+     0.2718
+     0.4469
+     1.3122
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.sign(a)
+    
+    -1
+     1
+     1
+     1
+    [torch.FloatTensor of size 4]
+    
 """)
 
 add_docstr(torch._C.sin,
@@ -1735,6 +2174,33 @@ add_docstr(torch._C.sort,
 
 add_docstr(torch._C.sqrt,
 """
+sqrt(input, out=None) -> Tensor
+
+Returns a new `Tensor` with the square-root of the elements of :attr:`input`.
+
+Args:
+    input (Tensor): the input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> a = torch.randn(4)
+    >>> a
+    
+     1.2290
+     1.3409
+    -0.5662
+    -0.0899
+    [torch.FloatTensor of size 4]
+    
+    >>> torch.sqrt(a)
+    
+     1.1086
+     1.1580
+        nan
+        nan
+    [torch.FloatTensor of size 4]
+            
 """)
 
 add_docstr(torch._C.squeeze,
@@ -1854,10 +2320,6 @@ add_docstr(torch._C.uniform,
 """)
 
 add_docstr(torch._C.var,
-"""
-""")
-
-add_docstr(torch._C.zero,
 """
 """)
 

--- a/torch/docs.py
+++ b/torch/docs.py
@@ -24,14 +24,17 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
+    
     -0.6366
      0.2718
      0.4469
      1.3122
     [torch.FloatTensor of size 4]
-    
+
     >>> torch.acos(a)
      2.2608
      1.2956
@@ -42,6 +45,81 @@ Example:
 
 add_docstr(torch._C.add,
 """
+.. function:: add(tensor, value, out=None)
+
+Adds the scalar :attr:`value` to each element of the input :attr:`tensor` and returns a new resulting tensor.
+
+:math:`out = tensor + value`
+
+Args:
+    tensor (Tensor): the input `Tensor`
+    value (number): the number to be added to each element of :attr:`tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+::
+
+    >>> a = torch.randn(4)
+    >>> print(a)
+
+     0.4050
+    -1.2227
+     1.8688
+    -0.4185
+    [torch.FloatTensor of size 4]
+
+    >>> torch.add(a, 20)
+
+     20.4050
+     18.7773
+     21.8688
+     19.5815
+    [torch.FloatTensor of size 4]
+
+
+.. function:: add(tensor, value=1, other, out=None)
+
+Each element of the Tensor :attr:`other` is multiplied by the scalar :attr:`value` and added to each element of the Tensor :attr:`tensor`. The resulting Tensor is returned.
+The shapes of :attr:`tensor` and :attr:`other` dont need to match. The total number of elements in each Tensor need to be the same. 
+
+.. note:: When the shapes do not match, the shape of :attr:`tensor` is used as the shape for the returned output Tensor
+
+:math:`out = tensor + (other * value)`
+
+Args:
+    tensor (Tensor): the first input `Tensor`
+    value (number): the scalar multiplier for :attr:`other`
+    other (Tensor): the second input `Tensor`
+    out (Tensor, optional): The result `Tensor`
+
+Example:
+::
+
+    >>> import torch
+    >>> a = torch.randn(4)
+    >>> print(a)    
+
+    -0.9310
+     2.0330
+     0.0852
+    -0.2941
+    [torch.FloatTensor of size 4]
+
+    >>> b = torch.randn(2, 2)
+    >>> print(b)
+
+     1.0663  0.2544
+    -0.1513  0.0749
+    [torch.FloatTensor of size 2x2]
+
+    >>> torch.add(a, 10, b)
+     9.7322
+     4.5770
+    -1.4279
+     0.4552
+    [torch.FloatTensor of size 4]
+    
+
 """)
 
 add_docstr(torch._C.addbmm,
@@ -68,10 +146,13 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> M = torch.randn(3, 5)
     >>> batch1 = torch.randn(10, 3, 4)
     >>> batch2 = torch.randn(10, 4, 5)
     >>> torch.addbmm(M, batch1, batch2)
+
      -3.1162  11.0071   7.3102   0.1824  -7.6892
       1.8265   6.0739   0.4589  -0.5641  -5.4283
      -9.3387  -0.1794  -1.2318  -6.8841  -4.7239
@@ -95,10 +176,13 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> t = torch.randn(2, 3)
     >>> t1 = torch.randn(1, 6)
     >>> t2 = torch.randn(6, 1)
     >>> torch.addcdiv(t, 0.1, t1, t2)
+
      0.0122 -0.0188 -0.2354
      0.7396 -1.5721  1.2878
     [torch.FloatTensor of size 2x3]
@@ -121,13 +205,17 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> t = torch.randn(2, 3)
     >>> t1 = torch.randn(1, 6)
     >>> t2 = torch.randn(6, 1)
     >>> torch.addcmul(t, 0.1, t1, t2)
+
      0.0122 -0.0188 -0.2354
      0.7396 -1.5721  1.2878
-    [torch.FloatTensor of size 2x3]""")
+    [torch.FloatTensor of size 2x3]
+""")
 
 add_docstr(torch._C.addmm,
 """
@@ -152,10 +240,13 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> M = torch.randn(2, 3)
     >>> mat1 = torch.randn(2, 3)
     >>> mat2 = torch.randn(3, 3)
     >>> torch.addmm(M, mat1, mat2)
+
     -0.4095 -1.9703  1.3561
      5.7674 -4.9760  2.7378
     [torch.FloatTensor of size 2x3]
@@ -185,10 +276,13 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> M = torch.randn(2)
     >>> mat = torch.randn(2, 3)
     >>> vec = torch.randn(3)
     >>> torch.addmv(M, mat, vec)
+
     -2.0939
     -2.2950
     [torch.FloatTensor of size 2]
@@ -217,6 +311,8 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> vec1 = torch.range(1, 3)
     >>> vec2 = torch.range(1, 2)
     >>> M = torch.zeros(3, 2)
@@ -238,6 +334,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -265,6 +363,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -293,6 +393,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -332,6 +434,8 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> M = torch.randn(10, 3, 5)
     >>> batch1 = torch.randn(10, 3, 4)
     >>> batch2 = torch.randn(10, 4, 5)
@@ -360,6 +464,8 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> batch1 = torch.randn(10, 3, 4)
     >>> batch2 = torch.randn(10, 4, 5)
     >>> res = torch.bmm(M, batch1, batch2)
@@ -406,6 +512,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -433,6 +541,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -481,6 +591,8 @@ Computes the dot product (inner product) of two tensors. Both tensors are
 treated as 1-D vectors.
 
 Example:
+::
+
     >>> torch.dot(torch.Tensor([2, 3]), torch.Tensor([2, 1]))
     7.0
 """)
@@ -523,6 +635,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where the tensors are equal and a 0 at every other location
 
 Example:
+::
+
     >>> torch.eq(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
     1  0
     0  1
@@ -536,6 +650,8 @@ equal(tensor1, tensor2) -> bool
 True if two tensors have the same size and elements, False otherwise.
 
 Example:
+::
+
     >>> torch.equal(torch.Tensor([1, 2]), torch.Tensor([1, 2]))
     True
 """)
@@ -547,6 +663,8 @@ exp(tensor, out=None) -> tensor
 Computes the exponential of each element.
 
 Example:
+::
+
     >>> torch.exp(torch.Tensor([0, math.log(2)]))
     torch.FloatTensor([1, 2])
 """)
@@ -566,6 +684,8 @@ Returns:
     Tensor: a 2-D tensor with ones on the diagonal and zeros elsewhere
 
 Example:
+::
+
     >>> torch.eye(3)
      1  0  0
      0  1  0
@@ -581,6 +701,8 @@ Computes the floor of each element in `tensor`. That is, each element is
 rounded down to the nearest integer.
 
 Example:
+::
+
     >>> torch.floor(torch.Tensor([1.5, -2.7, 3.0]))
     torch.FloatTensor([1, -3, 3])
 """)
@@ -601,12 +723,14 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> torch.fmod(torch.Tensor([-3, -2, -1, 1, 2, 3]), 2)
     torch.FloatTensor([-1, -0, -1, 1, 0, 1])
     >>> torch.fmod(torch.Tensor([1, 2, 3, 4, 5]), 1.5)
     torch.FloatTensor([1.0, 0.5, 0.0, 1.0, 0.5])
 
-    .. seealso::
+.. seealso::
 
         :func:`torch.remainder`, which computes the element-wise remainder of
         division equivalently to Python's `%` operator
@@ -619,6 +743,8 @@ frac(tensor, out=None) -> Tensor
 Computes the fractional portion of each element in `tensor`.
 
 Example:
+::
+
     >>> torch.frac(torch.Tensor([1, 2.5, -3.2])
     torch.FloatTensor([0, 0.5, -0.2])
 """)
@@ -634,6 +760,8 @@ tensor will be reflected in the `ndarray` and vice versa. The returned tensor
 is not resizable.
 
 Example:
+::
+
     >>> a = numpy.array([1, 2, 3])
     >>> t = torch.from_numpy(a)
     >>> t
@@ -662,6 +790,8 @@ Args:
     out (Tensor, optional): Destination tensor
 
 Example:
+::
+
     >>> t = torch.Tensor([[1,2],[3,4]])
     >>> torch.gather(t, 1, torch.LongTensor([[0,0],[1,0]]))
      1  1
@@ -686,6 +816,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
 Example:
+::
+
     >>> torch.ge(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      1  1
      0  1
@@ -738,6 +870,8 @@ Returns:
     `(m, 1)`.
 
 Example:
+::
+
 
     >>> A = torch.Tensor([[1, 1, 1],
     ...                   [2, 3, 4],
@@ -794,6 +928,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
 Example:
+::
+
     >>> torch.gt(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  1
      0  0
@@ -820,6 +956,8 @@ Returns:
     Tensor: the histogram
 
 Example:
+::
+
     >>> torch.histc(torch.FloatTensor([1, 2, 1]), bins=4, min=0, max=3)
     FloatTensor([0, 2, 1, 0])
 
@@ -855,6 +993,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
 Example:
+::
+
     >>> torch.le(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      1  0
      1  1
@@ -903,6 +1043,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
 Example:
+::
+
     >>> torch.lt(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  0
      1  0
@@ -943,6 +1085,8 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> mat1 = torch.randn(2, 3)
     >>> mat2 = torch.randn(3, 3)
     >>> torch.mm(mat1, mat2)
@@ -977,6 +1121,8 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> M = torch.randn(2)
     >>> mat = torch.randn(2, 3)
     >>> vec = torch.randn(3)
@@ -1004,6 +1150,8 @@ Returns:
     Tensor: a ``torch.ByteTensor`` containing a 1 at each location where comparison is true.
 
 Example:
+::
+
     >>> torch.ne(torch.Tensor([[1, 2], [3, 4]]), torch.Tensor([[1, 1], [4, 4]]))
      0  1
      1  0
@@ -1106,12 +1254,14 @@ Args:
     out (Tensor, optional): Output tensor
 
 Example:
+::
+
     >>> torch.remainder(torch.Tensor([-3, -2, -1, 1, 2, 3]), 2)
     torch.FloatTensor([1, 0, 1, 1, 0, 1])
     >>> torch.remainder(torch.Tensor([1, 2, 3, 4, 5]), 1.5)
     torch.FloatTensor([1.0, 0.5, 0.0, 1.0, 0.5])
 
-    .. seealso::
+.. seealso::
 
         :func:`torch.fmod`, which computes the element-wise remainder of
         division equivalently to the C library function ``fmod()``
@@ -1163,6 +1313,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -1190,6 +1342,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -1249,6 +1403,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366
@@ -1276,6 +1432,8 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example:
+::
+
     >>> a = torch.randn(4)
     >>> print(a)
     -0.6366


### PR DESCRIPTION
also, removing all, any stateless methods

Still left:

- [ ] ones
- [ ] zeros
- [ ] rand
- [ ] randn
- [ ] index_select
- [ ] masked_select
- [ ] t
- [ ] transpose
- [ ] reshape
- [ ] cat
- [ ] squeeze
- [ ] scatter
- [ ] multinomial
- [ ] normal
- [ ] sort
- [ ] topk
- [ ] kthvalue
- [ ] renorm
- [ ] trace
- [ ] unfold
- [ ] symeig
- [ ] geqrf
- [ ] ger
- [ ] gesv
- [ ] inverse
- [ ] orgqr
- [ ] ormqr
- [ ] potrf
- [ ] potri
- [ ] potrs
- [ ] pstrf
- [ ] qr
- [ ] svd
- [ ] trtrs