### PR TITLE
Fix invalidArguments to take kwargs and out into account

### DIFF
--- a/tools/cwrap/plugins/CuDNNPlugin.py
+++ b/tools/cwrap/plugins/CuDNNPlugin.py
@@ -52,7 +52,7 @@ static PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
     $options
     }
 
-    THPUtils_invalidArguments(args, "$readable_name", $num_options, $expected_args);
+    THPUtils_invalidArguments(args, kwargs, "$readable_name", $num_options, $expected_args);
     return NULL;
     END_HANDLE_TH_ERRORS
 }

--- a/tools/cwrap/plugins/StandaloneExtension.py
+++ b/tools/cwrap/plugins/StandaloneExtension.py
@@ -70,7 +70,7 @@ PyObject * $name(PyObject *_unused, PyObject *args)
   int __argcount = args ? PyTuple_Size(args) : 0;
     $options
   } else {
-    THPUtils_invalidArguments(args, "$name", 1, $expected_args);
+    THPUtils_invalidArguments(args, NULL, "$name", 1, $expected_args);
     return NULL;
   }
   END_HANDLE_TH_ERRORS

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -85,7 +85,7 @@ PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
     $options
     }
 
-    THPUtils_invalidArguments(args, "$readable_name", $num_options, $expected_args);
+    THPUtils_invalidArguments(args, kwargs, "$readable_name", $num_options, $expected_args);
     return NULL;
     END_HANDLE_TH_ERRORS
 }
@@ -174,6 +174,18 @@ ${cpu}
                            for arg in args
                            if not arg.get('ignore_check', False)
                            and not arg.get('output')]
+            output_args = list(filter(lambda a: a.get('output'), args))
+            if output_args:
+                if len(output_args) > 1:
+                    out_type = 'tuple['
+                    out_type += ', '.join(
+                            self.TYPE_NAMES[arg['type']] for arg in output_args)
+                    out_type += ']'
+                    option_desc += ['#' + out_type + ' out']
+                else:
+                    arg = output_args[0]
+                    option_desc += ['#' + self.TYPE_NAMES[arg['type']] + ' out']
+
             if option_desc:
                 return '({})'.format(', '.join(option_desc))
             else:

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -644,7 +644,7 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
     PyObject *raw_grad_output = PyTuple_GET_ITEM(args, 0);
     PyObject *retain_variables = PyTuple_GET_ITEM(args, 1);
     if (!PyTuple_Check(raw_grad_output) || !PyBool_Check(retain_variables)) {
-      THPUtils_invalidArguments(args, "_do_backward", 1, "(tuple, bool)");
+      THPUtils_invalidArguments(args, NULL, "_do_backward", 1, "(tuple, bool)");
       return NULL;
     }
 

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -151,7 +151,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   }
 
 invalid_arguments:
-  THPUtils_invalidArguments(args, THPStorageStr " constructor", 6,
+  THPUtils_invalidArguments(args, kwargs, THPStorageStr " constructor", 6,
           "no arguments",
           "(int size)",
           "(Sequence data)",

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -109,7 +109,8 @@ static PyObject * THPStorage_(newSharedFilename)(PyObject *_unused, PyObject *ar
   PyObject *_object_handle = PyTuple_GET_ITEM(args, 1);
   PyObject *_size = PyTuple_GET_ITEM(args, 2);
   if (!THPUtils_checkBytes(_manager_handle) || !THPUtils_checkBytes(_object_handle) || !THPUtils_checkLong(_size)) {
-    THPUtils_invalidArguments(args, "_new_shared in file system mode", 1, "a handle (string/bytes) and storage size (int)");
+    THPUtils_invalidArguments(args, NULL, "_new_shared in file system mode", 1,
+        "a handle (string/bytes) and storage size (int)");
     return NULL;
   }
   const char *manager_handle = THPUtils_bytesAsString(_manager_handle);
@@ -163,7 +164,8 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
   PyObject *_tmp_fd = PyTuple_GET_ITEM(args, 0);
   PyObject *_size = PyTuple_GET_ITEM(args, 1);
   if (!THPUtils_checkLong(_tmp_fd) || !THPUtils_checkLong(_size)) {
-    THPUtils_invalidArguments(args, "_new_shared in file descriptor mode", 1, "a file descriptor (int) and storage size (int)");
+    THPUtils_invalidArguments(args, NULL, "_new_shared in file descriptor mode",
+        1, "a file descriptor (int) and storage size (int)");
     return NULL;
   }
   int fd;
@@ -233,7 +235,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size)
       && (_handle == Py_None || PyBytes_Check(_handle))
       && THPUtils_checkLong(_offset) && THPUtils_checkLong(_view_size))) {
-    THPUtils_invalidArguments(args, "_new_shared in CUDA mode", 1,
+    THPUtils_invalidArguments(args, NULL, "_new_shared in CUDA mode", 1,
         "(int device, bytes handle, int storage_size, int offset, int view_size");
     return NULL;
   }
@@ -357,7 +359,7 @@ static PyObject * THPStorage_(newView)(THPStorage *self, PyObject *args)
   HANDLE_TH_ERRORS
   if (PyTuple_Size(args) != 2 || !THPUtils_checkLong(PyTuple_GET_ITEM(args, 0))
       || ! THPUtils_checkLong(PyTuple_GET_ITEM(args, 1))) {
-    THPUtils_invalidArguments(args, "_new_view", 1, "(int offset, int size)");
+    THPUtils_invalidArguments(args, NULL, "_new_view", 1, "(int offset, int size)");
     return NULL;
   }
   long offset = THPUtils_unpackLong(PyTuple_GET_ITEM(args, 0));

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -382,7 +382,7 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
     return (PyObject *)self.release();
   }
 
-  THPUtils_invalidArguments(args, THPTensorStr " constructor", 6,
+  THPUtils_invalidArguments(args, kwargs, THPTensorStr " constructor", 6,
           "no arguments",
           "(int ...)",
           "(" THPTensorStr " viewed_tensor)",

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -240,7 +240,7 @@ PyObject * THPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
     return PyInt_FromLong(THTensor_(size)(LIBRARY_STATE tensor, dim));
   }
 
-  THPUtils_invalidArguments(args, "size", 2, "(int dim)", "no arguments");
+  THPUtils_invalidArguments(args, kwargs, "size", 2, "(int dim)", "no arguments");
   return NULL;
   END_HANDLE_TH_ERRORS
 }
@@ -280,7 +280,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
     return PyInt_FromLong(THTensor_(stride)(LIBRARY_STATE tensor, dim));
   }
 
-  THPUtils_invalidArguments(args, "stride", 2, "(int dim)", "no arguments");
+  THPUtils_invalidArguments(args, kwargs, "stride", 2, "(int dim)", "no arguments");
   return NULL;
   END_HANDLE_TH_ERRORS
 }
@@ -650,9 +650,9 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
   return (PyObject*)result.release();
 
 invalid_arguments:
-  THPUtils_invalidArguments(args, "cat", 2,
-      "(sequence tensors)",
-      "(sequence tensors, int dim)");
+  THPUtils_invalidArguments(args, NULL, "cat", 2,
+      "(sequence[" THPTensorStr "] tensors)",
+      "(sequence[" THPTensorStr "] tensors, int dim)");
   return NULL;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -6,7 +6,7 @@
 PyObject * THPTensor_(writeMetadata)(THPTensor *self, PyObject *args)
 {
   if (!args || PyTuple_Size(args) != 1) {
-    THPUtils_invalidArguments(args, "_write_metadata", 1, "a single file object");
+    THPUtils_invalidArguments(args, NULL, "_write_metadata", 1, "a single file object");
     return NULL;
   }
   int fd = PyObject_AsFileDescriptor(PyTuple_GET_ITEM(args, 0));
@@ -28,7 +28,8 @@ PyObject * THPTensor_(newWithMetadataFile)(PyObject *_null, PyObject *args)
 {
   if (!args || PyTuple_Size(args) != 2 ||
         !THPStorage_(Check)(PyTuple_GET_ITEM(args, 1))) {
-    THPUtils_invalidArguments(args, "_new_with_metadata_file", 1, "single file object and a storage object");
+    THPUtils_invalidArguments(args, NULL, "_new_with_metadata_file", 1,
+        "single file object and a storage object");
     return NULL;
   }
   int fd = PyObject_AsFileDescriptor(PyTuple_GET_ITEM(args, 0));

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -2,6 +2,9 @@
 #include <stdarg.h>
 #include <string>
 #include <vector>
+#include <sstream>
+#include <algorithm>
+#include <unordered_map>
 #include "THP.h"
 
 #include "generic/utils.cpp"
@@ -148,160 +151,389 @@ std::string _THPUtils_typename(PyObject *object)
   return result;
 }
 
-struct Argument {
-  Argument(): type(), is_nullable(false), is_variadic(false) {};
-  std::string type;
-  bool is_nullable;
-  bool is_variadic;
+
+struct Type {
+  virtual bool is_matching(PyObject *object) = 0;
+  virtual ~Type() {};
 };
 
-std::vector<Argument> THPUtils_parseOption(const std::string &option)
-{
+struct SimpleType: public Type {
+  SimpleType(std::string& name): name(name) {};
+
+  bool is_matching(PyObject *object) {
+    return _THPUtils_typename(object) == name;
+  }
+
+  std::string name;
+};
+
+struct MultiType: public Type {
+  MultiType(std::initializer_list<std::string> accepted_types):
+    types(accepted_types) {};
+
+  bool is_matching(PyObject *object) {
+    auto it = std::find(types.begin(), types.end(), _THPUtils_typename(object));
+    return it != types.end();
+  }
+
+  std::vector<std::string> types;
+};
+
+struct NullableType: public Type {
+  NullableType(std::unique_ptr<Type> type): type(std::move(type)) {};
+
+  bool is_matching(PyObject *object) {
+    return object == Py_None || type->is_matching(object);
+  }
+
+  std::unique_ptr<Type> type;
+};
+
+struct TupleType: public Type {
+  TupleType(std::vector<std::unique_ptr<Type>> types):
+    types(std::move(types)) {};
+
+  bool is_matching(PyObject *object) {
+    if (!PyTuple_Check(object)) return false;
+    auto num_elements = PyTuple_GET_SIZE(object);
+    if (num_elements != (long)types.size()) return false;
+    for (int i = 0; i < num_elements; i++) {
+      if (!types[i]->is_matching(PyTuple_GET_ITEM(object, i)))
+        return false;
+    }
+    return true;
+  }
+
+  std::vector<std::unique_ptr<Type>> types;
+};
+
+struct SequenceType: public Type {
+  SequenceType(std::unique_ptr<Type> type):
+    type(std::move(type)) {};
+
+  bool is_matching(PyObject *object) {
+    if (!PySequence_Check(object)) return false;
+    auto num_elements = PySequence_Length(object);
+    for (int i = 0; i < num_elements; i++) {
+      if (!type->is_matching(PySequence_GetItem(object, i)))
+        return false;
+    }
+    return true;
+  }
+
+  std::unique_ptr<Type> type;
+};
+
+struct Argument {
+  Argument(std::string name, std::unique_ptr<Type> type):
+      name(name), type(std::move(type)) {};
+
+  std::string name;
+  std::unique_ptr<Type> type;
+};
+
+struct Option {
+  Option(std::vector<Argument> arguments, bool is_variadic, bool has_out):
+      arguments(std::move(arguments)), is_variadic(is_variadic), has_out(has_out) {};
+  Option(bool is_variadic, bool has_out):
+      arguments(), is_variadic(is_variadic), has_out(has_out) {};
+  Option(const Option&) = delete;
+  Option(Option&& other):
+    arguments(std::move(other.arguments)), is_variadic(other.is_variadic) {};
+
   std::vector<Argument> arguments;
-  if (option == "no arguments")
-    return arguments;
-  long current_index = -1;
-  do {
-    Argument arg;
-    auto type_end_idx = option.find_first_of(' ', current_index+2);
-    // Last argument - there are no more spaces
-    if (type_end_idx == std::string::npos)
-      type_end_idx = option.length()-2;
-    arg.type = option.substr(current_index+2, type_end_idx-current_index-2);
-    // A dumb check for [type or None]
-    if (arg.type[0] == '[')
-      arg.is_nullable = true;
-    current_index++;
-    current_index = option.find_first_of(',', current_index+1);
-    arguments.push_back(std::move(arg));
-  } while ((size_t)current_index != std::string::npos);
-  // Look for "type name...)" at the end
-  if (option.substr(option.length()-4, 3) == "...")
-    arguments.back().is_variadic = true;
-  return arguments;
+  bool is_variadic;
+  bool has_out;
+};
+
+std::vector<std::string> _splitString(const std::string &s, const std::string& delim) {
+  std::vector<std::string> tokens;
+  std::size_t start = 0;
+  std::size_t end;
+  while((end = s.find(delim, start)) != std::string::npos) {
+    tokens.push_back(s.substr(start, end-start));
+    start = end + delim.length();
+  }
+  tokens.push_back(s.substr(start));
+  return tokens;
 }
 
-bool THPUtils_argumentCountMatches(
-    const std::vector<Argument> expected_arguments,
-    const std::vector<std::string> argument_types)
+std::unique_ptr<Type> _buildType(std::string type_name, bool is_nullable) {
+  std::unique_ptr<Type> result;
+  if (type_name == "float") {
+    result.reset(new MultiType({"float", "int", "long"}));
+  } else if (type_name == "int") {
+    result.reset(new MultiType({"int", "long"}));
+  } else if (type_name.find("tuple[") == 0) {
+    auto type_list = type_name.substr(6);
+    type_list.pop_back();
+    std::vector<std::unique_ptr<Type>> types;
+    for (auto& type: _splitString(type_list, ","))
+      types.emplace_back(_buildType(type, false));
+    result.reset(new TupleType(std::move(types)));
+  } else if (type_name.find("sequence[") == 0) {
+    auto subtype = type_name.substr(9);
+    subtype.pop_back();
+    result.reset(new SequenceType(_buildType(subtype, false)));
+  } else {
+    result.reset(new SimpleType(type_name));
+  }
+  if (is_nullable)
+    result.reset(new NullableType(std::move(result)));
+  return result;
+}
+
+std::pair<Option, std::string> _parseOption(const std::string& _option_str,
+    const std::unordered_map<std::string, PyObject*> kwargs)
 {
-  return argument_types.size() == expected_arguments.size() ||
-    (expected_arguments.size() && expected_arguments.back().is_variadic &&
-     expected_arguments.size() < argument_types.size());
+  if (_option_str == "no arguments")
+    return std::pair<Option, std::string>(Option(false, false), _option_str);
+  bool has_out = false;
+  std::vector<Argument> arguments;
+  std::string printable_option = _option_str;
+  std::string option_str = _option_str.substr(1, _option_str.length()-2);
+
+  /// XXX: this is a hack only for the out arg in TensorMethods
+  auto out_pos = printable_option.find('#');
+  if (out_pos != std::string::npos) {
+    if (kwargs.count("out") > 0) {
+      std::string kwonly_part = printable_option.substr(out_pos+1);
+      printable_option.erase(out_pos);
+      printable_option += "*, ";
+      printable_option += kwonly_part;
+    } else {
+      printable_option.erase(out_pos-2);
+      printable_option += ")";
+    }
+    has_out = true;
+  }
+
+  for (auto& arg: _splitString(option_str, ", ")) {
+    bool is_nullable = false;
+    auto type_start_idx = 0;
+    if (arg[type_start_idx] == '#') {
+      type_start_idx++;
+    }
+    if (arg[type_start_idx] == '[') {
+      is_nullable = true;
+      type_start_idx++;
+      arg.erase(arg.length() - std::string(" or None]").length());
+    }
+
+    auto type_end_idx = arg.find_last_of(' ');
+    auto name_start_idx = type_end_idx + 1;
+
+    // "type ... name" => "type ... name"
+    //          ^              ^
+    auto dots_idx = arg.find("...");
+    if (dots_idx != std::string::npos)
+        type_end_idx -= 4;
+
+    std::string type_name =
+      arg.substr(type_start_idx, type_end_idx-type_start_idx);
+    std::string name =
+        arg.substr(name_start_idx);
+
+    arguments.emplace_back(name, _buildType(type_name, is_nullable));
+  }
+
+  bool is_variadic = option_str.find("...") != std::string::npos;
+  return std::pair<Option, std::string>(
+    Option(std::move(arguments), is_variadic, has_out),
+    std::move(printable_option)
+  );
 }
 
-std::string THPUtils_formattedTupleDesc(
-    const std::vector<Argument> expected_arguments,
-    const std::vector<std::string> argument_types)
+bool _argcountMatch(
+    const Option& option,
+    const std::vector<PyObject*>& arguments,
+    const std::unordered_map<std::string, PyObject*>& kwargs)
+{
+  auto num_expected = option.arguments.size();
+  auto num_got = arguments.size() + kwargs.size();
+  // Note: variadic functions don't accept kwargs, so it's ok
+  if (option.has_out && kwargs.count("out") == 0)
+    num_expected--;
+  return num_got == num_expected ||
+    (option.is_variadic && num_got > num_expected);
+}
+
+std::string _formattedArgDesc(
+    const Option& option,
+    const std::vector<PyObject*>& arguments,
+    const std::unordered_map<std::string, PyObject*>& kwargs)
 {
   std::string red;
   std::string reset_red;
   std::string green;
   std::string reset_green;
   if (isatty(1) && isatty(2)) {
-      red = "\33[31;1m";
-      reset_red = "\33[0m";
-      green = "\33[32;1m";
-      reset_green = "\33[0m";
+    red = "\33[31;1m";
+    reset_red = "\33[0m";
+    green = "\33[32;1m";
+    reset_green = "\33[0m";
   } else {
-      red = "!";
-      reset_red = "!";
-      green = "";
-      reset_green = "";
+    red = "!";
+    reset_red = "!";
+    green = "";
+    reset_green = "";
   }
 
+  auto num_args = arguments.size() + kwargs.size();
   std::string result = "(";
-  bool is_variadic = expected_arguments.size() &&
-    expected_arguments.back().is_variadic;
-  for (size_t i = 0; i < argument_types.size(); i++) {
+  for (size_t i = 0; i < num_args; i++) {
+    bool is_kwarg = i >= arguments.size();
+    PyObject *arg = is_kwarg ? kwargs.at(option.arguments[i].name) : arguments[i];
+
     bool is_matching = false;
-    if (i < expected_arguments.size()) {
-      if (expected_arguments[i].type == "float") {
-          is_matching = argument_types[i] == "float" ||
-                        argument_types[i] == "int" ||
-                        argument_types[i] == "long";
-      } else if (expected_arguments[i].type == "int") {
-          is_matching = argument_types[i] == "int" ||
-                        argument_types[i] == "long";
-      } else {
-          is_matching = expected_arguments[i].type == argument_types[i];
-      }
-      if (expected_arguments[i].is_nullable && argument_types[i] == "NoneType")
-          is_matching = true;
-    } else if (is_variadic) {
-      is_matching = argument_types[i] == expected_arguments.back().type;
+    if (i < option.arguments.size()) {
+      is_matching = option.arguments[i].type->is_matching(arg);
+    } else if (option.is_variadic) {
+      is_matching = option.arguments.back().type->is_matching(arg);
     }
+
     if (is_matching)
       result += green;
     else
       result += red;
-    result += argument_types[i];
+    if (is_kwarg) result += option.arguments[i].name + "=";
+    result += _THPUtils_typename(arg);
     if (is_matching)
         result += reset_green;
     else
         result += reset_red;
     result += ", ";
   }
-  if (argument_types.size() > 0)
+  if (arguments.size() > 0)
     result.erase(result.length()-2);
   result += ")";
   return result;
 }
 
-std::string THPUtils_tupleDesc(const std::vector<std::string> argument_types)
+std::string _argDesc(const std::vector<PyObject *>& arguments,
+    const std::unordered_map<std::string, PyObject *>& kwargs)
 {
   std::string result = "(";
-  for (auto &type: argument_types)
-    result += type + ", ";
-  if (argument_types.size() > 0)
+  for (auto& arg: arguments)
+    result += std::string(_THPUtils_typename(arg)) + ", ";
+  for (auto& kwarg: kwargs)
+    result += kwarg.first + "=" + _THPUtils_typename(kwarg.second) + ", ";
+  if (arguments.size() > 0)
     result.erase(result.length()-2);
   result += ")";
   return result;
 }
 
-void THPUtils_invalidArguments(PyObject *given_args,
+std::vector<std::string> _tryMatchKwargs(const Option& option,
+    const std::unordered_map<std::string, PyObject*>& kwargs) {
+  std::vector<std::string> unmatched;
+  int start_idx = option.arguments.size() - kwargs.size();
+  if (option.has_out && kwargs.count("out") == 0)
+    start_idx--;
+  if (start_idx < 0)
+    start_idx = 0;
+  for (auto& entry: kwargs) {
+    bool found = false;
+    for (unsigned int i = start_idx; i < option.arguments.size(); i++) {
+      if (option.arguments[i].name == entry.first) {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      unmatched.push_back(entry.first);
+  }
+  return unmatched;
+}
+
+std::string _parseDictKey(PyObject *key_str) {
+#if PY_MAJOR_VERSION == 3
+  THPObjectPtr ascii = PyUnicode_AsASCIIString(key_str);
+  return std::string(PyBytes_AS_STRING(ascii.get()));
+#else
+  return std::string(PyString_AS_STRING(key_str));
+#endif
+}
+
+void THPUtils_invalidArguments(PyObject *given_args, PyObject *given_kwargs,
         const char *function_name, size_t num_options, ...) {
   std::vector<std::string> option_strings;
-  std::vector<std::string> argument_types;
+  std::vector<PyObject *> args;
+  std::unordered_map<std::string, PyObject *> kwargs;
   std::string error_msg;
   error_msg.reserve(2000);
   error_msg += function_name;
-  error_msg += " received an invalid combination of argument types - got ";
+  error_msg += " received an invalid combination of arguments - ";
   va_list option_list;
   va_start(option_list, num_options);
   for (size_t i = 0; i < num_options; i++)
     option_strings.push_back(va_arg(option_list, const char*));
   va_end(option_list);
 
-  // TODO: assert that args is a tuple?
   Py_ssize_t num_args = PyTuple_Size(given_args);
   for (int i = 0; i < num_args; i++) {
     PyObject *arg = PyTuple_GET_ITEM(given_args, i);
-    argument_types.push_back(_THPUtils_typename(arg));
+    args.push_back(arg);
+  }
+
+  bool has_kwargs = given_kwargs && PyDict_Size(given_kwargs) > 0;
+  if (has_kwargs) {
+    PyObject *key, *value;
+    Py_ssize_t pos = 0;
+
+    while (PyDict_Next(given_kwargs, &pos, &key, &value)) {
+      kwargs.emplace(_parseDictKey(key), value);
+    }
   }
 
   if (num_options == 1) {
-    auto expected_arguments = THPUtils_parseOption(option_strings[0]);
-    if (THPUtils_argumentCountMatches(expected_arguments, argument_types)) {
-      error_msg += THPUtils_formattedTupleDesc(expected_arguments,
-          argument_types);
+    auto pair = _parseOption(option_strings[0], kwargs);
+    auto& option = pair.first;
+    auto& option_str = pair.second;
+    std::vector<std::string> unmatched_kwargs;
+    if (has_kwargs)
+      unmatched_kwargs = _tryMatchKwargs(option, kwargs);
+    if (unmatched_kwargs.size()) {
+      error_msg += "got unrecognized keyword arguments: ";
+      for (auto& kwarg: unmatched_kwargs)
+        error_msg += kwarg + ", ";
+      error_msg.erase(error_msg.length()-2);
     } else {
-      error_msg += THPUtils_tupleDesc(argument_types);
+      error_msg += "got ";
+      if (_argcountMatch(option, args, kwargs)) {
+        error_msg += _formattedArgDesc(option, args, kwargs);
+      } else {
+        error_msg += _argDesc(args, kwargs);
+      }
+      error_msg += ", but expected ";
+      error_msg += option_str;
     }
-    error_msg += ", but expected ";
-    error_msg += option_strings[0];
   } else {
-    error_msg += THPUtils_tupleDesc(argument_types);
+    error_msg += "got ";
+    error_msg += _argDesc(args, kwargs);
     error_msg += ", but expected one of:\n";
-    for (auto &option: option_strings) {
+    for (auto &option_str: option_strings) {
+      auto pair = _parseOption(option_str, kwargs);
+      auto& option = pair.first;
+      auto& printable_option_str = pair.second;
       error_msg += " * ";
-      error_msg += option;
+      error_msg += printable_option_str;
       error_msg += "\n";
-      auto expected_args = THPUtils_parseOption(option);
-      if (THPUtils_argumentCountMatches(expected_args, argument_types)) {
-        error_msg += "      didn't match because some of the arguments have invalid types: ";
-        error_msg += THPUtils_formattedTupleDesc(expected_args, argument_types);
-        error_msg += "\n";
+      if (_argcountMatch(option, args, kwargs)) {
+        std::vector<std::string> unmatched_kwargs;
+        if (has_kwargs)
+          unmatched_kwargs = _tryMatchKwargs(option, kwargs);
+        if (unmatched_kwargs.size() > 0) {
+          error_msg += "      didn't match because some of the keywords were incorrect: ";
+          for (auto& kwarg: unmatched_kwargs)
+            error_msg += kwarg + ", ";
+          error_msg.erase(error_msg.length()-2);
+          error_msg += "\n";
+        } else {
+          error_msg += "      didn't match because some of the arguments have invalid types: ";
+          error_msg += _formattedArgDesc(option, args, kwargs);
+          error_msg += "\n";
+        }
       }
     }
   }

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -130,8 +130,9 @@
 #define THPUtils_assertRet(value, cond, ...)                                   \
 if (__builtin_expect(!(cond), 0)) { THPUtils_setError(__VA_ARGS__); return value; }
 THP_API void THPUtils_setError(const char *format, ...);
-THP_API void THPUtils_invalidArguments(PyObject *given_args,
-            const char *function_name, size_t num_options, ...);
+THP_API void THPUtils_invalidArguments(
+        PyObject *given_args, PyObject *given_kwargs,
+        const char *function_name, size_t num_options, ...);
 
 #ifdef _THP_CORE
 


### PR DESCRIPTION
`invalidArguments` now understands [type-annotation](https://docs.python.org/3/library/typing.html) like syntax, and checks the type of tuple elements (can be different) and sequence elements (have to be uniform).

I'm only wondering if we should show the `out` with its type in all options. Any other suggestions welcome.

Fixes #365.

Demos:

* invalid keyword arg
<img width="911" alt="screen shot 2017-01-03 at 18 08 47" src="https://cloud.githubusercontent.com/assets/4583066/21616130/a48b4086-d1e0-11e6-9d2d-c225ce7685a9.png">

* valid keyword arg, invalid type
<img width="1085" alt="screen shot 2017-01-03 at 18 09 25" src="https://cloud.githubusercontent.com/assets/4583066/21616154/b72a9002-d1e0-11e6-9477-3c3f9a079910.png">

* invalid `out` type
<img width="1118" alt="screen shot 2017-01-03 at 18 16 55" src="https://cloud.githubusercontent.com/assets/4583066/21616191/db15d6fc-d1e0-11e6-98b9-33143f9d3ce1.png">

* valid `out` type, invalid arguments
<img width="1118" alt="screen shot 2017-01-03 at 18 09 55" src="https://cloud.githubusercontent.com/assets/4583066/21616203/e881eb50-d1e0-11e6-89ac-63d0a07df733.png">

* invalid out tuple (wrong order)
<img width="938" alt="screen shot 2017-01-03 at 18 10 20" src="https://cloud.githubusercontent.com/assets/4583066/21616226/fa14f038-d1e0-11e6-863f-190d67b06282.png">

* valid out tuple, invalid arguments
<img width="921" alt="screen shot 2017-01-03 at 18 10 34" src="https://cloud.githubusercontent.com/assets/4583066/21616244/06591c98-d1e1-11e6-9d13-dbae8938d10f.png">

* invalid `cat` sequence
<img width="681" alt="screen shot 2017-01-03 at 18 10 51" src="https://cloud.githubusercontent.com/assets/4583066/21616259/10e5bd60-d1e1-11e6-9faf-24d918b26a40.png">

* valid `cat` sequence, invalid `dim`
<img width="713" alt="screen shot 2017-01-03 at 18 14 35" src="https://cloud.githubusercontent.com/assets/4583066/21616274/216969c0-d1e1-11e6-8214-b42c3b1a6d50.png">