### PR TITLE
Minor fixes to docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -82,6 +82,9 @@ Pointwise Ops
 .. autofunction:: cosh
 .. autofunction:: div
 .. autofunction:: exp
+.. autofunction:: floor
+.. autofunction:: fmod
+.. autofunction:: frac
 .. autofunction:: lerp
 .. autofunction:: log
 .. autofunction:: log1p
@@ -121,9 +124,6 @@ Comparison Ops
 ~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: eq
 .. autofunction:: equal
-.. autofunction:: floor
-.. autofunction:: fmod
-.. autofunction:: frac
 .. autofunction:: ge
 .. autofunction:: gt
 .. autofunction:: kthvalue

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -29,6 +29,9 @@ class Module(object):
     Modules can also contain other Modules, allowing to nest them in
     a tree structure. You can assign the submodules as regular attributes::
 
+        import torch.nn as nn
+        import torch.nn.functional as F
+
         class Model(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()


### PR DESCRIPTION
Two small fixes/additions to the docs:
- `floor`, `fmod` and `frac` were in `Comparison Ops`, but they are better suited in `Pointwise Ops`
- The first example of the `nn` docs requires to import `nn` and mentions a `F` (the functional interface) without a prior reference to it.

**Note:** I didn't compile the docs to verify that everything is working fine. BTW, how should it be done?