### PR TITLE
Add torchvision reference to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,11 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import torch
+try:
+    import torchvision
+except ImportError:
+    import warnings
+    warnings.warn('unable to load "torchvision" package')
 import sphinx_rtd_theme
 
 
@@ -61,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyTorch'
-copyright = '2016, Torch Contributors'
+copyright = '2017, Torch Contributors'
 author = 'Torch Contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,17 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    data
    model_zoo
 
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: torchvision Reference
+
+   torchvision/torchvision
+   torchvision/datasets
+   torchvision/models
+   torchvision/transforms
+   torchvision/utils
+
 
 Indices and tables
 ==================

--- a/docs/source/torchvision/datasets.rst
+++ b/docs/source/torchvision/datasets.rst
@@ -1,0 +1,109 @@
+torchvision.datasets
+====================
+
+The following dataset loaders are available:
+
+-  `COCO (Captioning and Detection)`_
+-  `LSUN Classification`_
+-  `ImageFolder`_
+-  `Imagenet-12`_
+-  `CIFAR10 and CIFAR100`_
+
+Datasets have the API:
+
+-  ``__getitem__``
+-  ``__len__``
+   They all subclass from ``torch.utils.data.Dataset``
+   Hence, they can all be multi-threaded (python multiprocessing) using
+   standard torch.utils.data.DataLoader.
+
+For example:
+
+``torch.utils.data.DataLoader(coco_cap, batch_size=args.batchSize, shuffle=True, num_workers=args.nThreads)``
+
+In the constructor, each dataset has a slightly different API as needed,
+but they all take the keyword args:
+
+-  ``transform`` - a function that takes in an image and returns a
+   transformed version
+-  common stuff like ``ToTensor``, ``RandomCrop``, etc. These can be
+   composed together with ``transforms.Compose`` (see transforms section
+   below)
+-  ``target_transform`` - a function that takes in the target and
+   transforms it. For example, take in the caption string and return a
+   tensor of word indices.
+
+COCO
+~~~~
+
+This requires the `COCO API to be installed`_
+
+Captions:
+^^^^^^^^^
+
+``dset.CocoCaptions(root="dir where images are", annFile="json annotation file", [transform, target_transform])``
+
+Example:
+
+.. code:: python
+
+    import torchvision.datasets as dset
+    import torchvision.transforms as transforms
+    cap = dset.CocoCaptions(root = 'dir where images are',
+                            annFile = 'json annotation file',
+                            transform=transforms.ToTensor())
+
+    print('Number of samples: ', len(cap))
+    img, target = cap[3] # load 4th sample
+
+    print("Image Size: ", img.size())
+    print(target)
+
+Output:
+
+::
+
+    Number of samples: 82783
+    Image Size: (3L, 427L, 640L)
+    [u'A plane emitting smoke stream flying over a mountain.',
+    u'A plane darts across a bright blue sky behind a mountain covered in snow',
+    u'A plane leaves a contrail above the snowy mountain top.',
+    u'A mountain that has a plane flying overheard in the distance.',
+    u'A mountain view with a plume of smoke in the background']
+
+Detection:
+^^^^^^^^^^
+
+``dset.CocoDetection(root="dir where images are", annFile="json annotation file", [transform, target_transform])``
+
+LSUN
+~~~~
+
+``dset.LSUN(db_path, classes='train', [transform, target_transform])``
+
+-  db\_path = root directory for the database files
+-  classes =
+-  ‘train’ - all categories, training set
+-  ‘val’ - all categories, validation set
+-  ‘test’ - all categories, test set
+-  [‘bedroom\_train’, ‘church\_train’, …] : a list of categories to load
+
+CIFAR
+~~~~~
+
+``dset.CIFAR10(root, train=True, transform=None, target_transform=None, download=False)``
+
+``dset.CIFAR100(root, train=True, transform=None, target_transform=None, download=False)``
+
+-  ``root`` : root directory of dataset where there is folder
+   ``cifar-10-batches-py``
+-  ``train`` : ``True`` = Training set, ``False`` = Test set
+-  ``download`` : ``True`` = downloads the dataset from the internet and
+   puts it in root directory. If dataset already downloaded, do
+
+.. _COCO (Captioning and Detection): #coco
+.. _LSUN Classification: #lsun
+.. _ImageFolder: #imagefolder
+.. _Imagenet-12: #imagenet-12
+.. _CIFAR10 and CIFAR100: #cifar
+.. _COCO API to be installed: https://github.com/pdollar/coco/tree/master/PythonAPI

--- a/docs/source/torchvision/models.rst
+++ b/docs/source/torchvision/models.rst
@@ -1,0 +1,11 @@
+torchvision.models
+===================
+
+.. currentmodule:: torchvision.models
+
+
+.. automodule:: torchvision.models
+   :members: alexnet, resnet18, resnet34, resnet50, resnet101, resnet152,
+             vgg11, vgg11_bn, vgg13, vgg13_bn, vgg16, vgg16_bn, vgg19,
+             vgg19_bn
+   :undoc-members:

--- a/docs/source/torchvision/torchvision.rst
+++ b/docs/source/torchvision/torchvision.rst
@@ -1,0 +1,5 @@
+torchvision
+===================
+
+The :mod:`torchvision` package consists of popular datasets, model
+architectures, and common image transformations for computer vision.

--- a/docs/source/torchvision/transforms.rst
+++ b/docs/source/torchvision/transforms.rst
@@ -1,0 +1,114 @@
+torchvision.transforms
+======================
+
+| Transforms are common image transforms.
+| They can be chained together using ``transforms.Compose``
+
+``transforms.Compose``
+~~~~~~~~~~~~~~~~~~~~~~
+
+| One can compose several transforms together.
+| For example.
+
+.. code:: python
+
+    transform = transforms.Compose([
+        transforms.RandomSizedCrop(224),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.Normalize(mean = [ 0.485, 0.456, 0.406 ],
+                              std = [ 0.229, 0.224, 0.225 ]),
+    ])
+
+Transforms on PIL.Image
+-----------------------
+
+``Scale(size, interpolation=Image.BILINEAR)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Rescales the input PIL.Image to the given ‘size’.
+| ‘size’ will be the size of the smaller edge.
+
+| For example, if height > width, then image will be
+| rescaled to (size \* height / width, size)
+
+-  size: size of the smaller edge
+-  interpolation: Default: PIL.Image.BILINEAR
+
+``CenterCrop(size)`` - center-crops the image to the given size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Crops the given PIL.Image at the center to have a region of
+| the given size. size can be a tuple (target\_height, target\_width)
+| or an integer, in which case the target will be of a square shape
+  (size, size)
+
+``RandomCrop(size, padding=0)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Crops the given PIL.Image at a random location to have a region of
+| the given size. size can be a tuple (target\_height, target\_width)
+| or an integer, in which case the target will be of a square shape
+  (size, size)
+| If ``padding`` is non-zero, then the image is first zero-padded on
+  each side with ``padding`` pixels.
+
+``RandomHorizontalFlip()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Randomly horizontally flips the given PIL.Image with a probability of
+0.5
+
+``RandomSizedCrop(size, interpolation=Image.BILINEAR)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Random crop the given PIL.Image to a random size of (0.08 to 1.0) of
+  the original size
+| and and a random aspect ratio of 3/4 to 4/3 of the original aspect
+  ratio
+
+This is popularly used to train the Inception networks
+
+-  size: size of the smaller edge
+-  interpolation: Default: PIL.Image.BILINEAR
+
+``Pad(padding, fill=0)``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Pads the given image on each side with ``padding`` number of pixels,
+  and the padding pixels are filled with
+| pixel value ``fill``.
+| If a ``5x5`` image is padded with ``padding=1`` then it becomes
+  ``7x7``
+
+Transforms on torch.\*Tensor
+----------------------------
+
+``Normalize(mean, std)``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given mean: (R, G, B) and std: (R, G, B), will normalize each channel of
+the torch.\*Tensor, i.e. channel = (channel - mean) / std
+
+Conversion Transforms
+---------------------
+
+-  ``ToTensor()`` - Converts a PIL.Image (RGB) or numpy.ndarray (H x W x
+   C) in the range [0, 255] to a torch.FloatTensor of shape (C x H x W)
+   in the range [0.0, 1.0]
+-  ``ToPILImage()`` - Converts a torch.\*Tensor of range [0, 1] and
+   shape C x H x W or numpy ndarray of dtype=uint8, range[0, 255] and
+   shape H x W x C to a PIL.Image of range [0, 255]
+
+Generic Transofrms
+------------------
+
+``Lambda(lambda)``
+~~~~~~~~~~~~~~~~~~
+
+| Given a Python lambda, applies it to the input ``img`` and returns it.
+| For example:
+
+.. code:: python
+
+    transforms.Lambda(lambda x: x.add(10))

--- a/docs/source/torchvision/utils.rst
+++ b/docs/source/torchvision/utils.rst
@@ -1,0 +1,15 @@
+torchvision.utils
+===================
+
+make\_grid(tensor, nrow=8, padding=2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given a 4D mini-batch Tensor of shape (B x C x H x W), makes a grid of
+images
+
+save\_image(tensor, filename, nrow=8, padding=2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Saves a given Tensor into an image file.
+
+If given a mini-batch tensor, will save the tensor as a grid of images.


### PR DESCRIPTION
Some documentation is just copied from the GitHub readme for now.

I will update the pytorch/builder script to support this