### PR TITLE
Fix invalidArguments for functions with tuple outputs, but no other arguments

### DIFF
--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -301,8 +301,11 @@ std::pair<Option, std::string> _parseOption(const std::string& _option_str,
       printable_option.erase(out_pos);
       printable_option += "*, ";
       printable_option += kwonly_part;
-    } else {
+    } else if (out_pos >= 2) {
       printable_option.erase(out_pos-2);
+      printable_option += ")";
+    } else {
+      printable_option.erase(out_pos);
       printable_option += ")";
     }
     has_out = true;


### PR DESCRIPTION
For example:

   >>> torch.randn(5, 5).geqrf('invalid arg')
   TypeError: geqrf received an invalid combination of arguments - got (str), but expected ()