### PR TITLE
Remove error message assertion

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -78,8 +78,6 @@ class TestDataLoader(TestCase):
             try:
                 it.next()
             except NotImplementedError:
-                msg = "".join(traceback.format_exception(*sys.exc_info()))
-                self.assertTrue("collate_fn" in msg)
                 errors += 1
             except StopIteration:
                 self.assertEqual(errors,


### PR DESCRIPTION
Depending on how PyTorch is compiled, the source code for DataLoader
might not be fully available, which can cause a spurious error in
test_dataloader.py