### PR TITLE
Update docstring for ConvTranspose functions

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -372,6 +372,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
     composed of several input planes.
 
     This module can be seen as the gradient of Conv1d with respect to its input.
+    It is sometimes (but incorrectly) refered to as a deconvolutional operation. 
 
     .. note::
 
@@ -421,7 +422,8 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
     r"""Applies a 2D transposed convolution operator over an input image
     composed of several input planes.
 
-    This module can be seen as the gradient of Conv2d with respect to its input.
+    This module can be seen as the gradient of Conv2d with respect to its input. 
+    It is sometimes (but incorrectly) refered to as a deconvolutional operation. 
 
     | :attr:`stride` controls the stride for the cross-correlation.
     | If :attr:`padding` is non-zero, then the input is implicitly zero-padded on both sides
@@ -520,7 +522,8 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
     The transposed convolution operator multiplies each input value element-wise by a learnable kernel,
     and sums over the outputs from all input feature planes.
 
-    **This module can be seen as the exact reverse of Conv3d**
+    **This module can be seen as the exact reverse of Conv3d**. 
+    It is sometimes (but incorrectly) refered to as a deconvolutional operation. 
 
     | :attr:`stride` controls the stride for the cross-correlation.
     | If :attr:`padding` is non-zero, then the input is implicitly zero-padded on both sides


### PR DESCRIPTION
**Transposed convolutions** are often (*but incorrectly*) referred to as **Deconvolutional operations**. Made mention of this in the docstring to make it easier for people to search for this operation in the documentation.