### PR TITLE
Fix CUDA sharing across processes

### DIFF
--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -209,7 +209,7 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 
     _handle = PyBytes_FromStringAndSize((char *)&handle, CUDA_IPC_HANDLE_SIZE);
     _offset = PyLong_FromSsize_t((Py_ssize_t)offset);
-    size = PyLong_FromSize_t(base_size);
+    size = PyLong_FromSize_t(base_size / sizeof(real));
   }
   if (!tuple || !device || !_handle || !size || !_offset || !view_size) {
     return NULL;
@@ -244,7 +244,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   ptrdiff_t offset = (ptrdiff_t)THPUtils_unpackLong(_offset);
   size_t view_size =  (size_t)THPUtils_unpackLong(_view_size);
 
-  THCPAutoGPU((int)THPUtils_unpackLong(_device));
+  THCPAutoGPU __autogpu((int)THPUtils_unpackLong(_device));
 
   char *buffer;
   Py_ssize_t handle_size;

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -92,7 +92,7 @@ def rebuild_storage_filename(cls, manager, handle, size):
 def reubild_storage_cuda(cls, device, handle, size, offset, view_size):
     storage = storage_from_cache(cls, handle)
     if storage is not None:
-        return storage._new_view(offset, size)
+        return storage._new_view(offset, view_size)
     torch.cuda._lazy_init()
     storage = cls._new_shared_cuda(device, handle, size, offset, view_size)
     shared_cache[handle] = storage._weak_ref(StorageRef)


### PR DESCRIPTION
Fixes CUDA multiprocessing bugs:

 - The tensor in a subprocess could end up on the wrong device
 - The storage size was computed incorrectly for small allocations
