### PR TITLE
fix docs for torch.nn.functional.conv1d

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -53,7 +53,7 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
     Examples:
         >>> filters = autograd.Variable(torch.randn(33, 16, 3))
         >>> inputs = autograd.Variable(torch.randn(20, 16, 50))
-        >>> F.conv1d(inputs)
+        >>> F.conv1d(inputs, filters)
     """
     f = ConvNd(_single(stride), _single(padding), _single(dilation), False,
                _single(0), groups)


### PR DESCRIPTION
The docs were missing the parameter `filters` from the call `F.conv1d(inputs)` as shown here: pytorch.org/docs/nn.html#torch-nn-functional