### PR TITLE
Add more contiguity checks

### DIFF
--- a/torch/csrc/cudnn/BatchNorm.cpp
+++ b/torch/csrc/cudnn/BatchNorm.cpp
@@ -1,6 +1,7 @@
 #include "BatchNorm.h"
 
 #include "Descriptors.h"
+#include "Types.h"
 
 
 namespace torch { namespace cudnn {
@@ -78,6 +79,11 @@ void cudnn_batch_norm_forward(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
   if (training) {
+    THVoidTensor_assertContiguous(bias);
+    THVoidTensor_assertContiguous(running_mean);
+    THVoidTensor_assertContiguous(running_var);
+    THVoidTensor_assertContiguous(save_mean);
+    THVoidTensor_assertContiguous(save_var);
     CHECK(cudnnBatchNormalizationForwardTraining(
       handle, mode, &one, &zero,
       idesc.desc, tensorPointer(dataType, input),
@@ -91,6 +97,9 @@ void cudnn_batch_norm_forward(
       tensorPointer(dataType, save_mean),
       tensorPointer(dataType, save_var)));
   } else {
+    THVoidTensor_assertContiguous(bias);
+    THVoidTensor_assertContiguous(running_mean);
+    THVoidTensor_assertContiguous(running_var);
     CHECK(cudnnBatchNormalizationForwardInference(
       handle, mode, &one, &zero,
       idesc.desc, tensorPointer(dataType, input),
@@ -129,6 +138,10 @@ void cudnn_batch_norm_backward(
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
+  THVoidTensor_assertContiguous(grad_weight);
+  THVoidTensor_assertContiguous(grad_bias);
+  THVoidTensor_assertContiguous(save_mean);
+  THVoidTensor_assertContiguous(save_var);
   CHECK(cudnnBatchNormalizationBackward(
     handle, mode, &one, &zero, &one, &one,
     idesc.desc, tensorPointer(dataType, input),

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -2,6 +2,7 @@
 
 #include "THC/THC.h"
 #include "Exceptions.h"
+#include "Types.h"
 
 #include <cudnn.h>
 #include <functional>
@@ -31,6 +32,7 @@ void setWeightDescriptor(FilterDescriptor& desc, cudnnDataType_t dataType, THVoi
 {
   CHECK_ARG(weight->nDimension <= 5);
   int weightSize[5];
+  THVoidTensor_assertContiguous(weight);
   for (int i = 0; i < weight->nDimension; ++i) {
     weightSize[i] = (int) weight->size[i];
   }

--- a/torch/csrc/cudnn/Types.cpp
+++ b/torch/csrc/cudnn/Types.cpp
@@ -31,4 +31,16 @@ PyObject * getTensorClass(PyObject *args)
   return NULL;
 }
 
+void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& name)
+{
+  static const std::string error_str = "cuDNN requires contiguous ";
+  // Contiguity check
+  long long expectedStride = 1;
+  for (int i = tensor->nDimension-1; i >= 0; --i) {
+    if (tensor->stride[i] != expectedStride)
+      throw std::invalid_argument(error_str + name);
+    expectedStride *= tensor->size[i];
+  }
+}
+
 }}  // namespace torch::cudnn

--- a/torch/csrc/cudnn/Types.h
+++ b/torch/csrc/cudnn/Types.h
@@ -3,12 +3,18 @@
 
 #include <Python.h>
 #include <cstddef>
+#include <string>
 #include <cudnn.h>
+#include "../Types.h"
 
 namespace torch { namespace cudnn {
 
 PyObject * getTensorClass(PyObject *args);
 cudnnDataType_t getCudnnDataType(PyObject *tensorClass);
+void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& name);
+
+#define THVoidTensor_assertContiguous(tensor) \
+_THVoidTensor_assertContiguous(tensor, #tensor " tensor")
 
 }}  // namespace torch::cudnn
 


### PR DESCRIPTION
Add checks where cuDNN assumes that the tensors are contiguous. All other unsupported configurations should give `CUDNN_STATUS_BAD_PARAM`.