### PR TITLE
Fix math block of GRUCell in docs

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -428,6 +428,7 @@ class LSTMCell(RNNCellBase):
 
 class GRUCell(RNNCellBase):
     r"""A gated recurrent unit (GRU) cell
+    
     .. math::
 
         \begin{array}{ll}


### PR DESCRIPTION
Added a blank space between the beginning of the `.. math::` block, otherwise it is displayed as a code block.