### PR TITLE
Fixes and improvements

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1,3 +1,5 @@
+import sys
+import argparse
 import unittest
 import contextlib
 from itertools import product
@@ -9,9 +11,16 @@ from torch.autograd import Variable, Function
 
 
 torch.set_default_tensor_type('torch.DoubleTensor')
-torch.manual_seed(123)
-if torch.cuda.is_available():
-    torch.cuda.manual_seed_all(123)
+
+def run_tests():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--seed', type=int, default=123)
+    args, remaining = parser.parse_known_args()
+    torch.manual_seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
+    remaining = [sys.argv[0]] + remaining
+    unittest.main(argv=remaining)
 
 
 TEST_NUMPY = True

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -2,8 +2,17 @@
 set -e
 
 PYCMD=${PYCMD:="python"}
-if [ "$1" == "coverage" ];
-then
+COVERAGE=0
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -p|--python) PYCMD=$2; shift 2 ;;
+        -c|--coverage) COVERAGE=1; shift 2 ;;
+        --) shift; break ;;
+        *) echo "Invalid argument: $1!" ; exit 1 ;;
+    esac
+done
+
+if [[ $COVERAGE -eq 1 ]]; then
     coverage erase
     PYCMD="coverage run --parallel-mode --source torch "
     echo "coverage flag found. Setting python command to: \"$PYCMD\""
@@ -12,42 +21,41 @@ fi
 pushd "$(dirname "$0")"
 
 echo "Running torch tests"
-$PYCMD test_torch.py
+$PYCMD test_torch.py $@
 
 echo "Running autograd tests"
-$PYCMD test_autograd.py
+$PYCMD test_autograd.py $@
 
 echo "Running sparse tests"
-$PYCMD test_sparse.py
+$PYCMD test_sparse.py $@
 
 echo "Running nn tests"
-$PYCMD test_nn.py
+$PYCMD test_nn.py $@
 
 echo "Running legacy nn tests"
-$PYCMD test_legacy_nn.py
+$PYCMD test_legacy_nn.py $@
 
 echo "Running optim tests"
-$PYCMD test_optim.py
+$PYCMD test_optim.py $@
 
 echo "Running multiprocessing tests"
-$PYCMD test_multiprocessing.py
-MULTIPROCESSING_METHOD=spawn $PYCMD test_multiprocessing.py
-MULTIPROCESSING_METHOD=forkserver $PYCMD test_multiprocessing.py
+$PYCMD test_multiprocessing.py $@
+MULTIPROCESSING_METHOD=spawn $PYCMD test_multiprocessing.py $@
+MULTIPROCESSING_METHOD=forkserver $PYCMD test_multiprocessing.py $@
 
 echo "Running util tests"
-$PYCMD test_utils.py
+$PYCMD test_utils.py $@
 
 echo "Running dataloader tests"
-$PYCMD test_dataloader.py
+$PYCMD test_dataloader.py $@
 
 echo "Running cuda tests"
-$PYCMD test_cuda.py
+$PYCMD test_cuda.py $@
 
 echo "Running NCCL tests"
-$PYCMD test_nccl.py
+$PYCMD test_nccl.py $@
 
-if [ "$1" == "coverage" ];
-then
+if [[ $COVERAGE -eq 1 ]]; then
     coverage combine
     coverage html
 fi

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7,7 +7,8 @@ import unittest
 from copy import deepcopy
 from collections import OrderedDict
 
-from common import make_jacobian, TestCase, iter_tensors, get_numerical_jacobian
+from common import make_jacobian, TestCase, iter_tensors, \
+                   get_numerical_jacobian, run_tests
 from torch.autograd._functions import *
 from torch.autograd import Variable, Function
 
@@ -1069,4 +1070,4 @@ for test in method_tests:
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7,7 +7,7 @@ import torch
 import torch.cuda
 import torch.cuda.comm as comm
 
-from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state
+from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests
 
 if not torch.cuda.is_available():
     print('CUDA not available, skipping tests')
@@ -677,4 +677,4 @@ for decl in tests:
             setattr(TestCuda, test_name, compare_cpu_gpu(constr, arg_constr, name_inner, t, precision))
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -4,7 +4,7 @@ import torch
 import traceback
 import unittest
 from torch.utils.data import Dataset, TensorDataset, DataLoader
-from common import TestCase
+from common import TestCase, run_tests
 from common_nn import TEST_CUDA
 
 
@@ -159,4 +159,4 @@ class TestDataLoader(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -7,7 +7,7 @@ import torch
 import torch.legacy.nn as nn
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, TEST_CUDA, PRECISION
-from common import to_gpu, freeze_rng_state
+from common import to_gpu, freeze_rng_state, run_tests
 
 class OldModuleTest(ModuleTest):
     def __init__(self, *args, **kwargs):
@@ -1229,4 +1229,4 @@ class TestNN(NNTestCase):
 
 if __name__ == '__main__':
     prepare_tests()
-    unittest.main()
+    run_tests()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -11,7 +11,7 @@ import torch.cuda
 import torch.multiprocessing as mp
 from torch.autograd import Variable
 from torch.nn import Parameter
-from common import TestCase
+from common import TestCase, run_tests
 
 
 HAS_SHM_FILES = os.path.isdir('/dev/shm')
@@ -409,4 +409,4 @@ class TestMultiprocessing(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -4,7 +4,7 @@ import torch
 import torch.cuda.nccl as nccl
 import torch.cuda
 
-from common import TestCase
+from common import TestCase, run_tests
 
 if not torch.cuda.is_available():
     print('CUDA not available, skipping tests')
@@ -87,4 +87,4 @@ class TestNCCL(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14,7 +14,7 @@ from torch.autograd import Variable
 from torch.nn import Parameter
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, PRECISION
-from common import freeze_rng_state
+from common import freeze_rng_state, run_tests
 
 def default_tensor_type(type):
     type_str = torch.typename(type)
@@ -1600,4 +1600,4 @@ add_test(NewModuleTest(
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -63,10 +63,14 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
             test_case.assertEqual(input._version, input_version)
 
             input_ip = deepcopy(input)
-            output_ip = module_ip(input_ip)
-            test_case.assertNotEqual(input_ip._version, input_version)
-
+            input_ip_clone = input_ip.clone()
+            output_ip = module_ip(input_ip_clone)
+            test_case.assertNotEqual(input_ip_clone._version, input_version)
             test_case.assertEqual(output, output_ip)
+            grad = output.data.clone().normal_()
+            output.backward(grad)
+            output_ip.backward(grad)
+            test_case.assertEqual(output.grad, output_ip.grad)
 
         if type(input.data) == torch.LongTensor and TEST_CUDA:
             input = input.cuda()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -6,7 +6,7 @@ import torch.optim as optim
 import torch.legacy.optim as old_optim
 from torch.autograd import Variable
 
-from common import TestCase
+from common import TestCase, run_tests
 
 
 def rosenbrock(tensor):
@@ -344,4 +344,4 @@ class TestOptim(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4,7 +4,7 @@ from torch import sparse
 import itertools
 import random
 import unittest
-from common import TestCase
+from common import TestCase, run_tests
 from numbers import Number
 
 SparseTensor = sparse.DoubleTensor
@@ -216,5 +216,4 @@ class TestSparse(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
-
+    run_tests()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8,7 +8,7 @@ import unittest
 import warnings
 from itertools import product, chain
 from functools import wraps
-from common import TestCase, iter_indices, TEST_NUMPY
+from common import TestCase, iter_indices, TEST_NUMPY, run_tests
 
 if TEST_NUMPY:
     import numpy as np
@@ -2815,4 +2815,4 @@ class TestTorch(TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -19,7 +19,7 @@ from torch.utils.serialization import load_lua
 
 HAS_CUDA = torch.cuda.is_available()
 
-from common import TestCase
+from common import TestCase, run_tests
 
 try:
     import cffi
@@ -364,4 +364,4 @@ class TestLuaReader(TestCase):
 
 TestLuaReader.init()
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -1,8 +1,14 @@
 import os
 import glob
+from itertools import chain
 
 from .env import check_env_flag
 from .cuda import WITH_CUDA, CUDA_HOME
+
+
+def gather_paths(env_vars):
+    return list(chain(*(os.getenv(v, '').split(':') for v in env_vars)))
+
 
 WITH_CUDNN = False
 CUDNN_LIB_DIR = None
@@ -12,13 +18,19 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         os.getenv('CUDNN_LIB_DIR'),
         os.path.join(CUDA_HOME, 'lib'),
         os.path.join(CUDA_HOME, 'lib64'),
-        '/usr/lib/x86_64-linux-gnu/',        
-    ]))
+        '/usr/lib/x86_64-linux-gnu/',
+    ] + gather_paths([
+        'LIBRARY_PATH',
+    ])))
     include_paths = list(filter(bool, [
         os.getenv('CUDNN_INCLUDE_DIR'),
         os.path.join(CUDA_HOME, 'include'),
-        '/usr/include/'
-    ]))
+        '/usr/include/',
+    ] + gather_paths([
+        'CPATH',
+        'C_INCLUDE_PATH',
+        'CPLUS_INCLUDE_PATH',
+    ])))
     for path in lib_paths:
         if path is None or not os.path.exists(path):
             continue

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -28,7 +28,7 @@ def backward(variables, grad_variables, retain_variables=False):
     Arguments:
         variables (sequence of Variable): Variables of which the derivative will be
             computed.
-        grad_variables (sequence of Variable): Gradients w.r.t. each element of
+        grad_variables (sequence of Tensor): Gradients w.r.t. each element of
             corresponding variables. Required only for non-scalar variables that
             require gradient.
         retain_variables (bool): If ``True``, buffers necessary for computing

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -288,7 +288,7 @@ class IndexSelect(Function):
         if self.needs_input_grad[0]:
             index, = self.saved_tensors
             grad_tensor = grad_output.new(*self.input_size).zero_()
-            grad_tensor.index_copy_(self.dim, index, grad_output)
+            grad_tensor.index_add_(self.dim, index, grad_output)
 
         return grad_tensor, None
 

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -135,13 +135,13 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
         if is_inplace and self.inplace:
             self.mark_dirty(input)
             output = input
-            self.save_for_backward(input, *params)
         else:
             output = input.new()
-            if save_output:
-                self.save_for_backward(input, output, *params)
-            else:
-                self.save_for_backward(input, *params)
+
+        if save_output:
+            self.save_for_backward(input, output, *params)
+        else:
+            self.save_for_backward(input, *params)
 
         getattr(self._backend, update_output.name)(self._backend.library_state, input, output, *args)
         return output


### PR DESCRIPTION
* Fixed bug in ELU backward when `inplace=True` (#582)
* Tests can now be run with `--seed` flag that overrides the default seed.
* Added test for `BatchNorm` in evaluation mode (#590)
* Minor fix in autograd docs
* Support cc-like flags in cuDNN build tools (#573)
* Fixed `index_select` backward (failed when indices contained duplicate entries).