### PR TITLE
Fix legacy load_lua for SpatialConvolution

### DIFF
--- a/torch/utils/serialization/read_lua_file.py
+++ b/torch/utils/serialization/read_lua_file.py
@@ -329,6 +329,11 @@ def ensure_attr(obj, *attrs):
 
 
 @registry_addon
+def make_none_attr(obj, *attrs):
+    for attr in attrs:
+        setattr(obj, attr, None)
+
+@registry_addon
 def decrement(obj, *attrs):
     for attr in attrs:
         value = getattr(obj, attr)
@@ -376,8 +381,8 @@ ensure_attr('SpatialClassNLLCriterion', 'weights')
 ensure_attr('ClassNLLCriterion', 'weights')
 ensure_attr('ParallelCriterion', 'repeatTarget')
 ensure_attr('MultiMarginCriterion', 'weights')
-ensure_attr('SpatialConvolution', 'bias', 'finput', 'fgradInput',
-            'gradWeight', 'gradBias', '_gradOutput')
+ensure_attr('SpatialConvolution', 'bias', 'gradWeight', 'gradBias', '_gradOutput')
+make_none_attr('SpatialConvolution', 'finput', 'fgradInput')
 attr_map('ReLU', {'val': 'value'})
 attr_map('Threshold', {'val': 'value'})
 attr_map('Unsqueeze', {'pos': 'dim'})

--- a/torch/utils/serialization/read_lua_file.py
+++ b/torch/utils/serialization/read_lua_file.py
@@ -333,6 +333,7 @@ def make_none_attr(obj, *attrs):
     for attr in attrs:
         setattr(obj, attr, None)
 
+
 @registry_addon
 def decrement(obj, *attrs):
     for attr in attrs:


### PR DESCRIPTION
Fixes this:
```python
model = load_lua('model.t7')
model.cuda() # only if casted to cuda, float works
model.forward(input)
```
if model has any SpatialConvolution modules