### PR TITLE
remove circular references in NestedIOFunction

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -18,6 +18,7 @@ else:
 TEST_CUDA = torch.cuda.is_available()
 TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
 TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.cuda.FloatTensor(1))
+TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
 PRECISION = 1e-5
 
 module_tests = [

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -174,14 +174,24 @@ def _iter_filter(condition):
     return _iter
 
 
+def _unflatten(input, proto):
+    # unflatten a list or tuple input into a nested list/tuple structure
+    # specified by proto
+    def unflatten_helper(input, proto):
+        res = []
+        if not isinstance(proto, (list, tuple)):
+            return input[0], input[1:]
+        for e in proto:
+            res_e, input = unflatten_helper(input, e)
+            res.append(res_e)
+        return type(proto)(res), input
+
+    return unflatten_helper(input, proto)[0]
+
 _iter_variables = _iter_filter(lambda o: isinstance(o, torch.autograd.Variable))
 _iter_tensors = _iter_filter(torch.is_tensor)
 _iter_None_tensors = _iter_filter(lambda o: o is None or torch.is_tensor(o))
 _map_variable_tensor = _nested_map(lambda o: isinstance(o, torch.autograd.Variable), lambda o: o.data)
-
-
-def _map_tensor_fromiter(itr):
-    return _nested_map(lambda o: torch.is_tensor(o), lambda o: next(itr))
 
 
 class NestedIOFunction(Function):
@@ -191,11 +201,11 @@ class NestedIOFunction(Function):
         flat_input = tuple(_iter_variables(input))
         flat_output = super(NestedIOFunction, self)._do_forward(*flat_input)
         nested_output = self._nested_output
-        nested_variables = _map_tensor_fromiter(iter(flat_output))(self._nested_output)
+        nested_variables = _unflatten(flat_output, self._nested_output)
         return nested_variables
 
     def backward(self, *gradients):
-        nested_gradients = _map_tensor_fromiter(iter(gradients))(self._nested_output)
+        nested_gradients = _unflatten(gradients, self._nested_output)
         del self._nested_output
         result = self.backward_extended(*nested_gradients)
         del self._to_save_nested
@@ -217,7 +227,7 @@ class NestedIOFunction(Function):
     @property
     def saved_tensors(self):
         flat_tensors = super(NestedIOFunction, self).saved_tensors
-        return _map_tensor_fromiter(iter(flat_tensors))(self._to_save_nested)
+        return _unflatten(flat_tensors, self._to_save_nested)
 
     def mark_dirty(self, *args, **kwargs):
         self.dirty_tensors = tuple(_iter_tensors((args, kwargs)))


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/599.

It looks like `_map_tensor_fromiter` was inducing a circular reference, probably because it doesn't run the iterator to completion, so ends up holding a reference to the output variables. I would expect this should still be destroyed when the function scope exists, but appears not to.

Writing a simple unflatten function fixed the memory leak. The example code in https://github.com/pytorch/pytorch/issues/599 no longer runs out of memory.

Thanks to @colesbury for identifying the problem.

P.S. I also fixed the tests to avoid running RNN dropout tests when the cudnn version is too low.
