### PR TITLE
Delete extra bracket in RNNCellBase.__repr__.

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -291,7 +291,7 @@ class RNNCellBase(Module):
     def __repr__(self):
         s = '{name}({input_size}, {hidden_size}'
         if 'bias' in self.__dict__ and self.bias is not True:
-            s += ', bias={bias}}'
+            s += ', bias={bias}'
         if 'nonlinearity' in self.__dict__ and self.nonlinearity != "tanh":
             s += ', nonlinearity={nonlinearity}'
         s += ')'


### PR DESCRIPTION
This extra bracket causes a ValueError to be thrown when attempting to print a Module that uses RNNCellBase or any of its subclasses.