### PR TITLE
Add W503 to PEP8 ignore list (wrapping around binary operators)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
 max-line-length = 120
-ignore = E402,E721,E731
+ignore = E402,E721,E731,W503
 exclude = docs/src
 
 [flake8]


### PR DESCRIPTION
It's now in the "default ignore" list, but I guess we're not running the latest version.