### PR TITLE
Refactor parts of utils.h

### DIFF
--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <string>
 
+#include "torch/csrc/utils/object_ptr.h"
+
 #define THPUtils_(NAME) TH_CONCAT_4(THP,Real,Utils_,NAME)
 
 #define THPUtils_typename(obj) (Py_TYPE(obj)->tp_name)
@@ -149,28 +151,6 @@ bool THPUtils_parseSlice(PyObject *slice, Py_ssize_t len, Py_ssize_t *ostart,
 #define THSTensorPtr  TH_CONCAT_3(THS,Real,TensorPtr)
 #define THSPTensorPtr  TH_CONCAT_3(THSP,Real,TensorPtr)
 
-template<class T>
-class THPPointer {
-public:
-  THPPointer(): ptr(nullptr) {};
-  THPPointer(T *ptr): ptr(ptr) {};
-  THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
-
-  ~THPPointer() { free(); };
-  T * get() { return ptr; }
-  T * release() { T *tmp = ptr; ptr = NULL; return tmp; }
-  operator T*() { return ptr; }
-  THPPointer& operator =(T *new_ptr) { free(); ptr = new_ptr; return *this; }
-  THPPointer& operator =(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; return *this; }
-  T * operator ->() { return ptr; }
-  operator bool() { return ptr != nullptr; }
-
-private:
-  void free();
-  T *ptr = nullptr;
-};
-
-typedef THPPointer<PyObject> THPObjectPtr;
 typedef THPPointer<THPGenerator> THPGeneratorPtr;
 
 template <typename T>

--- a/torch/csrc/utils/auto_gil.h
+++ b/torch/csrc/utils/auto_gil.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// RAII structs to acquire and release Python's global interpreter lock (GIL)
+
+#include <Python.h>
+
+// Acquires the GIL on construction
+struct AutoGIL {
+  AutoGIL() : gstate(PyGILState_Ensure()) {
+  }
+  ~AutoGIL() {
+    PyGILState_Release(gstate);
+  }
+
+  PyGILState_STATE gstate;
+};
+
+// Releases the GIL on construction
+struct AutoNoGIL {
+  AutoNoGIL() : save(PyEval_SaveThread()) {
+  }
+  ~AutoNoGIL() {
+    PyEval_RestoreThread(save);
+  }
+
+  PyThreadState* save;
+};

--- a/torch/csrc/utils/object_ptr.cpp
+++ b/torch/csrc/utils/object_ptr.cpp
@@ -1,0 +1,11 @@
+#include "torch/csrc/utils/object_ptr.h"
+
+#include <Python.h>
+
+template<>
+void THPPointer<PyObject>::free() {
+  if (ptr)
+    Py_DECREF(ptr);
+}
+
+template class THPPointer<PyObject>;

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Python.h>
+
+template<class T>
+class THPPointer {
+public:
+  THPPointer(): ptr(nullptr) {};
+  THPPointer(T *ptr): ptr(ptr) {};
+  THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
+
+  ~THPPointer() { free(); };
+  T * get() { return ptr; }
+  const T * get() const { return ptr; }
+  T * release() { T *tmp = ptr; ptr = NULL; return tmp; }
+  operator T*() { return ptr; }
+  THPPointer& operator =(T *new_ptr) { free(); ptr = new_ptr; return *this; }
+  THPPointer& operator =(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; return *this; }
+  T * operator ->() { return ptr; }
+  operator bool() { return ptr != nullptr; }
+
+private:
+  void free();
+  T *ptr = nullptr;
+};
+
+typedef THPPointer<PyObject> THPObjectPtr;


### PR DESCRIPTION
Moves THPObjectPtr into a separate header, so that it can be included
independently. Currently, utils.h requries all of THP.h. Also adds RAII
structs for acquiring and releasing the GIL.