### PR TITLE
Allow Tensor to be compared to non-tensor types (like None) via __eq__ and __ne__ 

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -457,10 +457,10 @@ class _TensorBase(object):
         return self.neg()
 
     def __eq__(self, other):
-        return self.eq(other)
+        return torch.is_tensor(other) and self.eq(other)
 
     def __ne__(self, other):
-        return self.ne(other)
+        return not self.__eq__(other)
 
     def __lt__(self, other):
         return self.lt(other)


### PR DESCRIPTION
Hi, 

I currently ran into the following problem when trying to build my own `collate_fn` for a `torch.utils.data.DataLoader`.  For example, when loading data over the network it sometimes fails and my `Dataset` returns a tuple where one of the elements is `None` (depending if the input or target failed). I wanted to write a collate function to remove the data that failed to load by filtering as follows:

```python
import torch
from torch.utils.data.dataloader import default_collate
dummy_tensor = torch.Tensor(5)

dummy_batch = [(dummy_tensor, dummy_tensor), (None, dummy_tensor)]

def filter_out_failed_data(batch):
    return default_collate(list(filter(lambda x: None not in x, batch)))
```

However, this does not work as you cannot compare a tensor with `None` via the equality check (`==`) and returns the following error:

```python
TypeError: eq received an invalid combination of arguments - got (NoneType), but expected one of:
 * (float value)
      didn't match because some of the arguments have invalid types: (NoneType)
 * (torch.FloatTensor other)
      didn't match because some of the arguments have invalid types: (NoneType)
```

This PR is a patch to allow:
```python
dummy_tensor == None >> False
dummy_tensor != None >> True
```


