### PR TITLE
improved serialization (no tar copy)

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import argparse
 import unittest
 import contextlib
@@ -212,3 +213,25 @@ def get_numerical_jacobian(fn, input, target):
             d_tensor[i] = outb
 
     return jacobian
+
+
+def download_file(url, path, binary=True):
+    if sys.version_info < (3,):
+        import urllib2
+        request = urllib2
+        error = urllib2
+    else:
+        import urllib.request
+        import urllib.error
+        request = urllib.request
+        error = urllib.error
+
+    if os.path.exists(path):
+        return True
+    try:
+        data = request.urlopen(url, timeout=15).read()
+        with open(path, 'wb' if binary else 'w') as f:
+            f.write(data)
+        return True
+    except error.URLError as e:
+        return False

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2534,6 +2534,9 @@ class TestTorch(TestCase):
             self.assertEqual(views[0], views[2])
             self.assertNotEqual(views[0]._cdata, views[2]._cdata)
 
+            rootview = c[8]
+            self.assertEqual(rootview.data_ptr(), c[0].data_ptr())
+
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_serialization_cuda(self):
         device_count = torch.cuda.device_count()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import math
 import random
 import torch
@@ -8,7 +9,7 @@ import unittest
 import warnings
 from itertools import product, chain
 from functools import wraps
-from common import TestCase, iter_indices, TEST_NUMPY, run_tests
+from common import TestCase, iter_indices, TEST_NUMPY, run_tests, download_file
 
 if TEST_NUMPY:
     import numpy as np
@@ -2428,7 +2429,9 @@ class TestTorch(TestCase):
         a_clone = a.clone()
         b = copy(a)
         b.fill_(1)
-        self.assertEqual(a, a_clone)
+        # copy is a shallow copy, only copies the tensor view,
+        # not the data
+        self.assertEqual(a, b)
 
     def test_pickle(self):
         if sys.version_info[0] == 2:
@@ -2500,6 +2503,7 @@ class TestTorch(TestCase):
         b = [a[i % 2] for i in range(4)]
         b += [a[0].storage()]
         b += [a[0].storage()[1:4]]
+        b + [torch.range(1, 10).int()]
         for use_name in (False, True):
             with tempfile.NamedTemporaryFile() as f:
                 handle = f if not use_name else f.name
@@ -2518,6 +2522,50 @@ class TestTorch(TestCase):
             c[1].fill_(20)
             self.assertEqual(c[1], c[3], 0)
             self.assertEqual(c[4], c[5][1:4], 0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
+    def test_serialization_cuda(self):
+        device_count = torch.cuda.device_count()
+        t0 = torch.cuda.FloatTensor(5).fill_(1)
+        torch.cuda.set_device(device_count - 1)
+        tn = torch.cuda.FloatTensor(3).fill_(2)
+        torch.cuda.set_device(0)
+        b = (t0, tn)
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(b, f)
+            f.seek(0)
+            c = torch.load(f)
+            self.assertEqual(b, c, 0)
+            u0, un = c
+            self.assertEqual(u0.get_device(), 0)
+            self.assertEqual(un.get_device(), device_count - 1)
+
+    def test_serialization_backwards_compat(self):
+        a = [torch.range(1 + i, 25 + i).view(5, 5).float() for i in range(2)]
+        b = [a[i % 2] for i in range(4)]
+        b += [a[0].storage()]
+        b += [a[0].storage()[1:4]]
+        DATA_URL = 'https://s3.amazonaws.com/pytorch/legacy_serialized.pt'
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        test_file_path = os.path.join(data_dir, 'legacy_serialized.pt')
+        succ = download_file(DATA_URL, test_file_path)
+        if not succ:
+            warnings.warn(("Couldn't download the test file for backwards compatibility! "
+                           "Tests will be incomplete!"), RuntimeWarning)
+            return
+        c = torch.load(test_file_path)
+        self.assertEqual(b, c, 0)
+        self.assertTrue(isinstance(c[0], torch.FloatTensor))
+        self.assertTrue(isinstance(c[1], torch.FloatTensor))
+        self.assertTrue(isinstance(c[2], torch.FloatTensor))
+        self.assertTrue(isinstance(c[3], torch.FloatTensor))
+        self.assertTrue(isinstance(c[4], torch.FloatStorage))
+        c[0].fill_(10)
+        self.assertEqual(c[0], c[2], 0)
+        self.assertEqual(c[4], torch.FloatStorage(25).fill_(10), 0)
+        c[1].fill_(20)
+        self.assertEqual(c[1], c[3], 0)
+        self.assertEqual(c[4], c[5][1:4], 0)
 
     def test_serialization_container(self):
         def import_module(name, filename):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -19,7 +19,7 @@ from torch.utils.serialization import load_lua
 
 HAS_CUDA = torch.cuda.is_available()
 
-from common import TestCase, run_tests
+from common import TestCase, run_tests, download_file
 
 try:
     import cffi
@@ -297,34 +297,12 @@ class TestLuaReader(TestCase):
         return do_test
 
     @classmethod
-    def _download_data(cls, test_file_path):
-        if os.path.exists(test_file_path):
-            return
-        print('Downloading test file for TestLuaReader.')
-        DATA_URL = 'https://s3.amazonaws.com/pytorch/legacy_modules.t7'
-        urllib = cls._get_urllib('request')
-        data = urllib.urlopen(DATA_URL, timeout=15).read()
-        with open(test_file_path, 'wb') as f:
-            f.write(data)
-
-    @staticmethod
-    def _get_urllib(submodule):
-        if sys.version_info < (3,):
-            import urllib2
-            return urllib2
-        else:
-            import urllib.error
-            import urllib.request
-            return getattr(urllib, submodule)
-
-    @classmethod
     def init(cls):
+        DATA_URL = 'https://s3.amazonaws.com/pytorch/legacy_modules.t7'
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
         test_file_path = os.path.join(data_dir, 'legacy_modules.t7')
-        urllib = cls._get_urllib('error')
-        try:
-            cls._download_data(test_file_path)
-        except urllib.URLError as e:
+        succ = download_file(DATA_URL, test_file_path)
+        if not succ:
             warnings.warn(("Couldn't download the test file for TestLuaReader! "
                            "Tests will be incomplete!"), RuntimeWarning)
             return

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -191,6 +191,8 @@ PyObject * THPStorage_(newWithFile)(PyObject *_unused, PyObject *file)
   THPUtils_assert(fd != -1, "_new_with_file couldn't retrieve a file "
       "descriptor from given object");
   THStorage *storage = THPStorage_(readFileRaw)(fd, nullptr);
+  if (storage == nullptr)
+    return nullptr;
   PyObject *result = THPStorage_(New)(storage);
   return result;
   END_HANDLE_TH_ERRORS
@@ -209,7 +211,9 @@ static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
 
   THPUtils_assert(fd != -1, "_set_from_file couldn't retrieve a file "
       "descriptor from given object");
-  THPStorage_(readFileRaw)(fd, self->cdata);
+  THStorage *storage = THPStorage_(readFileRaw)(fd, self->cdata);
+  if (storage == nullptr)
+    return nullptr;
   Py_INCREF(self);
 
   return (PyObject *) self;

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -190,9 +190,8 @@ PyObject * THPStorage_(newWithFile)(PyObject *_unused, PyObject *file)
   int fd = PyObject_AsFileDescriptor(file);
   THPUtils_assert(fd != -1, "_new_with_file couldn't retrieve a file "
       "descriptor from given object");
-  THStoragePtr storage = THPStorage_(readFileRaw)(fd, nullptr);
+  THStorage *storage = THPStorage_(readFileRaw)(fd, nullptr);
   PyObject *result = THPStorage_(New)(storage);
-  storage.release();
   return result;
   END_HANDLE_TH_ERRORS
 }
@@ -205,7 +204,7 @@ static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
 
   PyObject *offset = PyTuple_GET_ITEM(args, 1);
   if (offset != Py_None) {
-    lseek(fd, PyLong_AsLong(offset), SEEK_SET);
+    lseek(fd, THPUtils_unpackLong(offset), SEEK_SET);
   }
 
   THPUtils_assert(fd != -1, "_set_from_file couldn't retrieve a file "

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -190,10 +190,30 @@ PyObject * THPStorage_(newWithFile)(PyObject *_unused, PyObject *file)
   int fd = PyObject_AsFileDescriptor(file);
   THPUtils_assert(fd != -1, "_new_with_file couldn't retrieve a file "
       "descriptor from given object");
-  THStoragePtr storage = THPStorage_(readFileRaw)(fd);
+  THStoragePtr storage = THPStorage_(readFileRaw)(fd, nullptr);
   PyObject *result = THPStorage_(New)(storage);
   storage.release();
   return result;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
+{
+  HANDLE_TH_ERRORS
+  PyObject *file = PyTuple_GET_ITEM(args, 0);
+  int fd = PyObject_AsFileDescriptor(file);
+
+  PyObject *offset = PyTuple_GET_ITEM(args, 1);
+  if (offset != Py_None) {
+    lseek(fd, PyLong_AsLong(offset), SEEK_SET);
+  }
+
+  THPUtils_assert(fd != -1, "_set_from_file couldn't retrieve a file "
+      "descriptor from given object");
+  THPStorage_(readFileRaw)(fd, self->cdata);
+  Py_INCREF(self);
+
+  return (PyObject *) self;
   END_HANDLE_TH_ERRORS
 }
 
@@ -250,6 +270,7 @@ static PyMethodDef THPStorage_(methods)[] = {
   {"is_pinned", (PyCFunction)THPStorage_(isPinned), METH_NOARGS, NULL},
   {"_write_file", (PyCFunction)THPStorage_(writeFile), METH_O, NULL},
   {"_new_with_file", (PyCFunction)THPStorage_(newWithFile), METH_O | METH_STATIC, NULL},
+  {"_set_from_file", (PyCFunction)THPStorage_(setFromFile), METH_VARARGS, NULL},
 #ifndef THC_GENERIC_FILE
   {"from_buffer", (PyCFunction)THPStorage_(fromBuffer), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
 #endif

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -54,7 +54,7 @@ void THPStorage_(writeFileRaw)(THStorage *self, int fd)
     if (remaining != 0)
       throw std::system_error(result, std::system_category());
   } else {
-    int64_t buffer_size = std::min(size, (long)5000);
+    int64_t buffer_size = std::min(size, (int64_t)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(real)]);
     for (int64_t i = 0; i < size; i += buffer_size) {
       size_t to_convert = std::min(size - i, buffer_size);
@@ -117,7 +117,7 @@ THStorage * THPStorage_(readFileRaw)(int fd, THStorage *_storage)
     if (remaining != 0)
       throw std::system_error(result, std::system_category());
   } else {
-    int64_t buffer_size = std::min(size, (long)5000);
+    int64_t buffer_size = std::min(size, (int64_t)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(real)]);
     for (int64_t i = 0; i < size; i += buffer_size) {
       size_t to_convert = std::min(size - i, buffer_size);

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -74,12 +74,19 @@ void THPStorage_(writeFileRaw)(THStorage *self, int fd)
   }
 }
 
-THStorage * THPStorage_(readFileRaw)(int fd)
+THStorage * THPStorage_(readFileRaw)(int fd, THStorage *_storage)
 {
   real *data;
   long size;
   SYSCHECK(read(fd, &size, sizeof(long)));
-  THStoragePtr storage = THStorage_(newWithSize)(LIBRARY_STATE size);
+
+  THStoragePtr storage;
+  if (_storage == nullptr) {
+    storage = THStorage_(newWithSize)(LIBRARY_STATE size);
+  } else {
+    THPUtils_assert(_storage->size == size, "storage has wrong size");
+    storage = _storage;
+  }
 
 #ifndef THC_GENERIC_FILE
   data = storage->data;

--- a/torch/csrc/generic/serialization.h
+++ b/torch/csrc/generic/serialization.h
@@ -5,6 +5,6 @@
 void THPTensor_(writeMetadataRaw)(THTensor *self, int fd);
 THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage);
 void THPStorage_(writeFileRaw)(THStorage *self, int fd);
-THStorage * THPStorage_(readFileRaw)(int fd);
+THStorage * THPStorage_(readFileRaw)(int fd, THStorage *storage);
 
 #endif

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -88,7 +88,7 @@ def rebuild_storage_filename(cls, manager, handle, size):
     return storage._shared_decref()
 
 
-def reubild_storage_cuda(cls, device, handle, size, offset, view_size):
+def rebuild_storage_cuda(cls, device, handle, size, offset, view_size):
     storage = storage_from_cache(cls, handle)
     if storage is not None:
         return storage._new_view(offset, view_size)
@@ -103,7 +103,7 @@ def reduce_storage(storage):
     if storage.is_cuda:
         metadata = storage._share_cuda_()
         cache_key = metadata[1]
-        rebuild = reubild_storage_cuda
+        rebuild = rebuild_storage_cuda
     elif get_sharing_strategy() == 'file_system':
         metadata = storage._share_filename_()
         cache_key = metadata[1]

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -111,7 +111,7 @@ def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
         pickle_protocol: can be specified to override the default protocol
     """
     new_fd = False
-    if isinstance(f, str):
+    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)):
         new_fd = True
         f = open(f, "wb")
     try:
@@ -213,7 +213,7 @@ def load(f, map_location=None, pickle_module=pickle):
             the pickle_module used to serialize file)
     """
     new_fd = False
-    if isinstance(f, str):
+    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)):
         new_fd = True
         f = open(f, 'rb')
     try:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -21,19 +21,13 @@ LONG_SIZE = struct.Struct('=l').size
 INT_SIZE = struct.Struct('=i').size
 SHORT_SIZE = struct.Struct('=h').size
 
+MAGIC_NUMBER = 0x1950a86a20f9469cfc6c
+PROTOCOL_VERSION = 1001
+STORAGE_KEY_SEPARATOR = ','
+
 
 class SourceChangeWarning(Warning):
     pass
-
-
-def _add_to_tar(fn, tar_file, name):
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    fn(tmp_file)
-    tmp_file.close()
-
-    tar_file.add(tmp_file.name, arcname=name)
-    if os.path.isfile(tmp_file.name):
-        os.remove(tmp_file.name)
 
 
 @contextmanager
@@ -92,7 +86,8 @@ def default_restore_location(storage, location):
         if result is not None:
             return result
     raise RuntimeError("don't know how to restore data location of " +
-                       torch.typename(storage) + " (tagged with " + location + ")")
+                       torch.typename(storage) + " (tagged with " +
+                       location + ")")
 
 
 def normalize_storage_type(storage_type):
@@ -128,11 +123,15 @@ def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
 
 def _save(obj, f, pickle_module, pickle_protocol):
     import torch.nn as nn
-    serialized_tensors = {}
-    serialized_storages = {}
     serialized_container_types = {}
+    serialized_storages = {}
 
     def persistent_id(obj):
+        # FIXME: the docs say that persistent_id should only return a string
+        # but torch store returns tuples. This works only in the binary protocol
+        # see
+        # https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-external-objects
+        # https://github.com/python/cpython/blob/master/Lib/pickle.py#L527-L537
         if isinstance(obj, type) and issubclass(obj, nn.Module):
             if obj in serialized_container_types:
                 return None
@@ -145,77 +144,41 @@ def _save(obj, f, pickle_module, pickle_protocol):
                 warnings.warn("Couldn't retrieve source code for container of "
                               "type " + obj.__name__ + ". It won't be checked "
                               "for correctness upon loading.")
-            return (obj, source_file, source)
-        if torch.is_tensor(obj):
-            serialized_tensors[obj._cdata] = obj
-            return str(obj._cdata)
+            return ('module', obj, source_file, source)
         elif torch.is_storage(obj):
-            serialized_storages[obj._cdata] = obj
-            return str(obj._cdata)
+            storage_type = normalize_storage_type(type(obj))
+            root, offset = obj._root_storage()
+            root_key = str(root._cdata)
+            location = location_tag(obj)
+            serialized_storages[root_key] = root
+            is_view = obj._cdata != root._cdata
+
+            return ('storage', storage_type, root_key, location, root.size(), is_view, offset, obj.size())
+
         return None
 
-    def save_tensors(f):
-        pickle_module.dump(len(serialized_tensors), f, protocol=pickle_protocol)
-        for key, tensor in serialized_tensors.items():
-            storage = tensor.storage()
-            if storage is not None:
-                storage_id = storage._cdata
-                serialized_storages[storage_id] = storage
-            else:
-                storage_id = None
+    sys_info = dict(
+        protocol_version=PROTOCOL_VERSION,
+        little_endian=sys.byteorder == 'little',
+        type_sizes=dict(
+            short=SHORT_SIZE,
+            int=INT_SIZE,
+            long=LONG_SIZE,
+        ),
+    )
 
-            pickle_module.dump((key, storage_id, type(tensor)), f,
-                               protocol=pickle_protocol)
-            f.flush()
-            tensor._write_metadata(f)
+    pickle_module.dump(MAGIC_NUMBER, f, protocol=pickle_protocol)
+    pickle_module.dump(PROTOCOL_VERSION, f, protocol=pickle_protocol)
+    pickle_module.dump(sys_info, f, protocol=pickle_protocol)
+    pickler = pickle_module.Pickler(f, protocol=pickle_protocol)
+    pickler.persistent_id = persistent_id
+    pickler.dump(obj)
 
-    def save_storages(f):
-        storage_views = []
-        storage_views_roots = {}
-
-        for key, storage in serialized_storages.items():
-            root, offset = storage._root_storage()
-            if root is not storage:
-                storage_views_roots[root._cdata] = root
-                storage_views.append((storage._cdata, root._cdata, offset,
-                                      storage.size()))
-        for view_info in storage_views:
-            del serialized_storages[view_info[0]]
-        serialized_storages.update(storage_views_roots)
-
-        pickle_module.dump(len(serialized_storages), f, protocol=pickle_protocol)
-        for key, storage in serialized_storages.items():
-            location = location_tag(storage)
-            storage_type = normalize_storage_type(type(storage))
-            pickle_module.dump((key, location, storage_type), f,
-                               protocol=pickle_protocol)
-            f.flush()
-            storage._write_file(f)
-
-        pickle_module.dump(storage_views, f, protocol=pickle_protocol)
-
-    def pickle_objects(f):
-        pickler = pickle_module.Pickler(f, protocol=pickle_protocol)
-        pickler.persistent_id = persistent_id
-        pickler.dump(obj)
-
-    def save_sys_info(f):
-        sys_info = dict(
-            protocol_version=1000,
-            little_endian=sys.byteorder == 'little',
-            type_sizes=dict(
-                short=SHORT_SIZE,
-                int=INT_SIZE,
-                long=LONG_SIZE,
-            ),
-        )
-        pickle_module.dump(sys_info, f, protocol=pickle_protocol)
-
-    with closing(tarfile.open(fileobj=f, mode='w:', format=tarfile.PAX_FORMAT)) as tar:
-        _add_to_tar(save_sys_info, tar, 'sys_info')
-        _add_to_tar(pickle_objects, tar, 'pickle')
-        _add_to_tar(save_tensors, tar, 'tensors')
-        _add_to_tar(save_storages, tar, 'storages')
+    serialized_storage_keys = sorted(serialized_storages.keys())
+    pickle_module.dump(serialized_storage_keys, f, protocol=pickle_protocol)
+    f.flush()
+    for key in serialized_storage_keys:
+        serialized_storages[key]._write_file(f)
 
 
 def load(f, map_location=None, pickle_module=pickle):
@@ -234,8 +197,8 @@ def load(f, map_location=None, pickle_module=pickle):
     tagging and deserialization methods using register_package.
 
     Args:
-        f: a file-like object (has to implement fileno that returns a file descriptor)
-            or a string containing a file name
+        f: a file-like object (has to implement fileno that returns a file descriptor,
+            and must implement seek), or a string containing a file name
         map_location: a function or a dict specifying how to remap storage locations
         pickle_module: module used for unpickling metadata and objects (has to match
             the pickle_module used to serialize file)
@@ -272,11 +235,10 @@ def _load(f, map_location, pickle_module):
         if original_source != current_source:
             if container_type.dump_patches:
                 file_name = container_type.__name__ + '.patch'
-                diff = difflib.unified_diff(
-                    current_source.split('\n'),
-                    original_source.split('\n'),
-                    source_file,
-                    source_file, lineterm="")
+                diff = difflib.unified_diff(current_source.split('\n'),
+                                            original_source.split('\n'),
+                                            source_file,
+                                            source_file, lineterm="")
                 lines = '\n'.join(diff)
                 try:
                     with open(file_name, 'a+') as f:
@@ -303,45 +265,101 @@ def _load(f, map_location, pickle_module):
                    .format(torch.typename(container_type), msg))
             warnings.warn(msg, SourceChangeWarning)
 
+    def legacy_load(f):
+        deserialized_objects = {}
+
+        def persistent_load(saved_id):
+            if isinstance(saved_id, tuple):
+                # Ignore containers that don't have any sources saved
+                if all(saved_id[1:]):
+                    _check_container_source(*saved_id)
+                return saved_id[0]
+            return deserialized_objects[int(saved_id)]
+
+        with closing(tarfile.open(fileobj=f, mode='r:', format=tarfile.PAX_FORMAT)) as tar, \
+                mkdtemp() as tmpdir:
+
+            tar.extract('storages', path=tmpdir)
+            with open(os.path.join(tmpdir, 'storages'), 'rb', 0) as f:
+                num_storages = pickle_module.load(f)
+                for i in range(num_storages):
+                    args = pickle_module.load(f)
+                    key, location, storage_type = args
+                    obj = storage_type._new_with_file(f)
+                    obj = restore_location(obj, location)
+                    deserialized_objects[key] = obj
+
+                storage_views = pickle_module.load(f)
+                for target_cdata, root_cdata, offset, size in storage_views:
+                    root = deserialized_objects[root_cdata]
+                    deserialized_objects[target_cdata] = root[offset:offset + size]
+
+            tar.extract('tensors', path=tmpdir)
+            with open(os.path.join(tmpdir, 'tensors'), 'rb', 0) as f:
+                num_tensors = pickle_module.load(f)
+                for i in range(num_tensors):
+                    args = pickle_module.load(f)
+                    key, storage_id, original_tensor_type = args
+                    storage = deserialized_objects[storage_id]
+                    tensor_type = storage_to_tensor_type(storage)
+                    tensor = tensor_type._new_with_metadata_file(f, storage)
+                    deserialized_objects[key] = tensor
+
+            pickle_file = tar.extractfile('pickle')
+            unpickler = pickle_module.Unpickler(pickle_file)
+            unpickler.persistent_load = persistent_load
+            result = unpickler.load()
+            return result
+
+    deserialized_storages = {}
+
     def persistent_load(saved_id):
-        if isinstance(saved_id, tuple):
+        assert isinstance(saved_id, tuple)
+        typename = saved_id[0]
+        data = saved_id[1:]
+
+        if typename == 'module':
             # Ignore containers that don't have any sources saved
-            if all(saved_id[1:]):
-                _check_container_source(*saved_id)
-            return saved_id[0]
-        return deserialized_objects[int(saved_id)]
+            if all(data[1:]):
+                _check_container_source(*data)
+            return data[0]
+        elif typename == 'storage':
+            data_type, key, location, size, is_view, offset, view_size = data
+            if key not in deserialized_storages:
+                deserialized_storages[key] = restore_location(
+                    data_type(size), location)
+            data = deserialized_storages[key]
+            if is_view:
+                data = data[offset:offset + view_size]
+            return data
+        else:
+            raise RuntimeError("Unknown saved id type: %s" % saved_id[0])
 
-    with closing(tarfile.open(fileobj=f, mode='r:', format=tarfile.PAX_FORMAT)) as tar, \
-            mkdtemp() as tmpdir:
+    # try the legacy loader first, which only works if f is a tarfile
+    try:
+        return legacy_load(f)
+    except tarfile.TarError:
+        pass
 
-        tar.extract('storages', path=tmpdir)
-        with open(os.path.join(tmpdir, 'storages'), 'rb', 0) as f:
-            num_storages = pickle_module.load(f)
-            for i in range(num_storages):
-                args = pickle_module.load(f)
-                key, location, storage_type = args
-                obj = storage_type._new_with_file(f)
-                obj = restore_location(obj, location)
-                deserialized_objects[key] = obj
+    f.seek(0)
+    magic_number = pickle_module.load(f)
+    if magic_number != MAGIC_NUMBER:
+        raise RuntimeError("Invalid magic number; corrupt file?")
+    protocol_version = pickle_module.load(f)
+    if protocol_version != PROTOCOL_VERSION:
+        raise RuntimeError("Invalid protocol version: %s" % protocol_version)
 
-            storage_views = pickle_module.load(f)
-            for target_cdata, root_cdata, offset, size in storage_views:
-                root = deserialized_objects[root_cdata]
-                deserialized_objects[target_cdata] = root[offset:offset + size]
+    _sys_info = pickle_module.load(f)
+    unpickler = pickle_module.Unpickler(f)
+    unpickler.persistent_load = persistent_load
+    result = unpickler.load()
 
-        tar.extract('tensors', path=tmpdir)
-        with open(os.path.join(tmpdir, 'tensors'), 'rb', 0) as f:
-            num_tensors = pickle_module.load(f)
-            for i in range(num_tensors):
-                args = pickle_module.load(f)
-                key, storage_id, original_tensor_type = args
-                storage = deserialized_objects[storage_id]
-                tensor_type = storage_to_tensor_type(storage)
-                tensor = tensor_type._new_with_metadata_file(f, storage)
-                deserialized_objects[key] = tensor
+    deserialized_storage_keys = pickle_module.load(f)
 
-        pickle_file = tar.extractfile('pickle')
-        unpickler = pickle_module.Unpickler(pickle_file)
-        unpickler.persistent_load = persistent_load
-        result = unpickler.load()
-        return result
+    offset = f.tell()
+    for key in deserialized_storage_keys:
+        assert key in deserialized_storages
+        deserialized_storages[key]._set_from_file(f, offset)
+        offset = None
+
+    return result

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -103,11 +103,13 @@ class _TensorBase(object):
         return new_tensor
 
     def __reduce__(self):
-        return (type(self), (),
-                (self.storage(),
+        return (type(self), (), self.__getstate__())
+
+    def __getstate__(self):
+        return (self.storage(),
                 self.storage_offset(),
                 tuple(self.size()),
-                self.stride()))
+                self.stride())
 
     def __setstate__(self, state):
         self.set_(*state)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -103,7 +103,14 @@ class _TensorBase(object):
         return new_tensor
 
     def __reduce__(self):
-        return type(self), (self.tolist(),)
+        return (type(self), (),
+                (self.storage(),
+                self.storage_offset(),
+                tuple(self.size()),
+                self.stride()))
+
+    def __setstate__(self, state):
+        self.set_(*state)
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
Some notes:

- This runs 5-10x faster than the old code on my machine; it reads big tensors at ~2.5GB/s, which is faster than the file reading unless the file is cached.

- I tried to make this avoid seeks, but `load` takes arbitrary file objects and they may be buffered in python, so when you start reading the storages in C, you need to do a C seek to before the extra Python buffering. If we want to avoid seeks, the only choice is to do the file reading purely in C. I will leave this to a future PR if it's necessary.

- I change `tensor.__reduce__` to return `(t.storage(), t.storageOffset, t.size(), t.stride)` instead of a nested list representation of the tensor. I think this is more consistent with the fact that a tensor is a view on storage (otherwise `__reduce__` would break sharing, etc.). One upshot of this is it changes the behavior of copy.copy (which is now just a shallow copy of the tensor view).

- `persistent_id` technically is only allowed to return a string, but we return tuples. This happens to work for the binary protocol, but not the string protocol. It's not guaranteed to work in the future. I'm not sure how to fix it for the module case

- `load` remains backwards compatible with old checkpoints (although they'll still be slow). There's a test for it.

- the old serialization code had a little bug I noticed, where it only treated a storage as a view if `offset != 0`. But technically, you could have a view with `offset ==0`, e.g. `s2 = s[0:5]`.