### PR TITLE
fix serialization bug for large files

### DIFF
--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -39,11 +39,19 @@ void THPStorage_(writeFileRaw)(THStorage *self, int fd)
   SYSCHECK(write(fd, &self->size, sizeof(long)));
   // fast track for bytes and little endian
   if (sizeof(real) == 1 || THP_nativeByteOrder() == THPByteOrder::THP_LITTLE_ENDIAN) {
-    SYSCHECK(write(fd, data, sizeof(real) * self->size));
+    char *bytes = (char *) data;
+    uint64_t remaining = sizeof(real) * self->size;
+    while (remaining > 0) {
+      ssize_t result = write(fd, bytes, remaining);
+      if (result < 0)
+        throw std::system_error(result, std::system_category());
+      bytes += result;
+      remaining -= result;
+    }
   } else {
     long buffer_size = std::min(self->size, (long)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(real)]);
-    for (long i = 0; i < self->size; i += buffer_size) {
+    for (int64_t i = 0; i < self->size; i += buffer_size) {
       size_t to_convert = std::min(self->size - i, buffer_size);
       if (sizeof(real) == 2) {
         THP_encodeInt16Buffer((uint8_t*)le_buffer.get(),
@@ -61,7 +69,7 @@ void THPStorage_(writeFileRaw)(THStorage *self, int fd)
             THPByteOrder::THP_LITTLE_ENDIAN,
             to_convert);
       }
-      SYSCHECK(write(fd, data, to_convert * sizeof(real)));
+      SYSCHECK(write(fd, le_buffer.get(), to_convert * sizeof(real)));
     }
   }
 }
@@ -82,11 +90,19 @@ THStorage * THPStorage_(readFileRaw)(int fd)
 
   // fast track for bytes and little endian
   if (sizeof(real) == 1 || THP_nativeByteOrder() == THPByteOrder::THP_LITTLE_ENDIAN) {
-    SYSCHECK(read(fd, data, sizeof(real) * storage->size));
+    char *bytes = (char *) data;
+    uint64_t remaining = sizeof(real) * storage->size;
+    while (remaining > 0) {
+      ssize_t result = read(fd, bytes, remaining);
+      if (result < 0)
+        throw std::system_error(result, std::system_category());
+      bytes += result;
+      remaining -= result;
+    }
   } else {
     long buffer_size = std::min(size, (long)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(real)]);
-    for (long i = 0; i < size; i += buffer_size) {
+    for (int64_t i = 0; i < size; i += buffer_size) {
       size_t to_convert = std::min(size - i, buffer_size);
       SYSCHECK(read(fd, le_buffer.get(), sizeof(real) * to_convert));
       if (sizeof(real) == 2) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/717

read(2) and write(2) are not guaranteed to write arbitrarily large sizes, and at least on my system (CentOS7) they read/write a maximum of 2GB. This writes in a loop until the whole tensor is written.

Test:
```
import torch
t = torch.IntTensor(600000000).fill_(42)
t[0]=100
t[-1]=101
In [9]: torch.save(t, "foo.pt")
u = torch.load('foo.pt')
print(u[:5])
print(u[-5:])

 100
  42
  42
  42
  42
[torch.IntTensor of size 5]

  42
  42
  42
  42
 101
[torch.IntTensor of size 5]
```

This may also fix https://github.com/pytorch/pytorch/issues/718 but I haven't written any tests for big-endian.