### PR TITLE
sparse tensor operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test/.coverage
 */*.so*
 */**/*.so*
 */**/*.dylib*
+.watchmanconfig

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ test/.coverage
 */*.so*
 */**/*.so*
 */**/*.dylib*
-.watchmanconfig

--- a/test/common.py
+++ b/test/common.py
@@ -118,11 +118,18 @@ class TestCase(unittest.TestCase):
             y = y.data
 
         if torch.is_tensor(x) and torch.is_tensor(y):
-            max_err = 0
-            super(TestCase, self).assertEqual(x.size(), y.size())
-            for index in iter_indices(x):
-                max_err = max(max_err, abs(x[index] - y[index]))
-            self.assertLessEqual(max_err, prec, message)
+            def assertTensorsEqual(a, b):
+                max_err = 0
+                super(TestCase, self).assertEqual(a.size(), b.size())
+                for index in iter_indices(a):
+                    max_err = max(max_err, abs(a[index] - b[index]))
+                self.assertLessEqual(max_err, prec, message)
+            self.assertEqual(x.is_sparse, y.is_sparse, message)
+            if x.is_sparse:
+                assertTensorsEqual(x.indices(), y.indices())
+                assertTensorsEqual(x.values(), y.values())
+            else:
+                assertTensorsEqual(x, y)
         elif type(x) == str and type(y) == str:
             super(TestCase, self).assertEqual(x, y)
         elif is_iterable(x) and is_iterable(y):

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -337,15 +337,18 @@ class NNTestCase(TestCase):
 
     def _flatten_tensors(self, x):
         if torch.is_tensor(x):
-            return x.view(-1)
+            if x.is_sparse:
+                return x.to_dense().view(-1)
+            else:
+                return x.view(-1)
         elif isinstance(x, Variable):
-            return x.data.view(-1)
+            return self._flatten_tensors(x.data)
         else:
             return tuple(self._flatten_tensors(a) for a in x)
 
     def _zero_grad_input(self, input):
         if isinstance(input, Variable):
-            if input.requires_grad:
+            if input.requires_grad and input.grad is not None:
                 input.grad.data.zero_()
         elif torch.is_tensor(input):
             return

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -129,7 +129,7 @@ class TestAutograd(TestCase):
         self._test_backward()
 
     def test_sparse_backward(self):
-        class SparseGradientFunction(Function):
+        class FixedGradientFunction(Function):
 
             def __init__(self, grad):
                 self.grad = grad
@@ -140,24 +140,36 @@ class TestAutograd(TestCase):
             def backward(self, grad_x):
                 return self.grad
 
+        size = torch.Size([6, 3, 2])
         i1 = torch.LongTensor([
             [0, 3, 4],
             [0, 2, 2],
         ])
         v1 = torch.DoubleTensor([[1, 2], [4, 5], [7, 8]])
-        grad1 = torch.sparse.DoubleTensor(i1, v1, torch.Size([6, 3, 2]))
+        sparse_grad1 = torch.sparse.DoubleTensor(i1, v1, size)
         i2 = torch.LongTensor([
             [0, 1, 3, 4],
             [0, 1, 2, 2],
         ])
         v2 = torch.DoubleTensor([[1, 2], [4, 3], [4, 5], [7, 8]])
-        grad2 = torch.sparse.DoubleTensor(i2, v2, torch.Size([6, 3, 2]))
-        fn1 = SparseGradientFunction(grad1)
-        fn2 = SparseGradientFunction(grad2)
+        sparse_grad2 = torch.sparse.DoubleTensor(i2, v2, size)
+        dense_grad = torch.rand(size).double()
+        sparse_fn1 = FixedGradientFunction(sparse_grad1)
+        sparse_fn2 = FixedGradientFunction(sparse_grad2)
+        dense_fn = FixedGradientFunction(dense_grad)
 
+        # sparse first
         x = Variable(torch.randn(5, 5), requires_grad=True)
-        (fn1(x) + fn2(x)).sum().backward()
-        self.assertEqual(x.grad.data, grad1 + grad2)
+        (sparse_fn1(x) + dense_fn(x) + sparse_fn2(x)).sum().backward()
+        self.assertEqual(x.grad.data, dense_grad + sparse_grad1 + sparse_grad2)
+        # dense first
+        x = Variable(torch.randn(5, 5), requires_grad=True)
+        (dense_fn(x) + sparse_fn1(x) + sparse_fn2(x)).sum().backward()
+        self.assertEqual(x.grad.data, dense_grad + sparse_grad1 + sparse_grad2)
+        # sparse only
+        x = Variable(torch.randn(5, 5), requires_grad=True)
+        (sparse_fn1(x) + sparse_fn2(x)).sum().backward()
+        self.assertEqual(x.grad.data, sparse_grad1 + sparse_grad2)
 
     @unittest.skip("BasicEngine is out of date")
     def test_backward_basic_engine(self):

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -80,8 +80,8 @@ def autograd_sharing(queue, ready, master_modified):
     is_ok = var.data.equal(expected_var)
     var.data[:] = torch.ones(5, 5)
 
-    is_ok &= var.grad.data.equal(torch.zeros(5, 5))
-    var.grad.data[:] = torch.ones(5, 5)
+    is_ok &= var.grad is None
+    var._grad = Variable(torch.ones(5, 5), requires_grad=False)
 
     queue.put(is_ok)
 
@@ -358,7 +358,7 @@ class TestMultiprocessing(TestCase):
         queue = mp.Queue()
         p = mp.Process(target=autograd_sharing, args=(queue, ready, master_modified))
         p.start()
-        var.grad.data.zero_()
+        var._grad = Variable(torch.zeros(5, 5), requires_grad=False)
         queue.put(var)
 
         ready.wait()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1235,9 +1235,9 @@ class TestNN(NNTestCase):
     def test_variable_sequence(self):
         self._test_variable_sequence(False)
 
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_variable_sequence_cuda(self):
-        self._test_variable_sequence(True)
+    # @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    # def test_variable_sequence_cuda(self):
+    #     self._test_variable_sequence(True)
 
     def test_LSTM_cell(self):
         # this is just a smoke test; these modules are implemented through

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1174,7 +1174,8 @@ class TestNN(NNTestCase):
             self.assertEqual(unpacked_len, lengths)
 
             # check grad
-            padded.grad.data.zero_()
+            if padded.grad is not None:
+                padded.grad.data.zero_()
             grad_output = unpacked.data.clone().normal_()
             unpacked.backward(grad_output)
             if batch_first:
@@ -1583,7 +1584,7 @@ class TestNN(NNTestCase):
         grad = torch.randn(2, 2, 5, 10, 10).cuda()[:, 1]
         assert not grad.is_contiguous()
         output.backward(grad, retain_variables=True)
-        assert input.grad is not None
+        self.assertIsNotNone(input.grad)
         result = input.grad.data.clone()
         input.grad.data.zero_()
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -14,13 +14,15 @@ class TestSparse(TestCase):
 
     @staticmethod
     def _gen_sparse(d, nnz, with_size):
-        v = torch.randn(nnz)
         if isinstance(with_size, Number):
+            v = torch.randn(nnz)
             i = (torch.rand(d, nnz) * with_size).type(torch.LongTensor)
             x = SparseTensor(i, v)
         else:
+            v_size = [nnz] + list(with_size[d:])
+            v = torch.randn(*v_size)
             i = torch.rand(d, nnz) * \
-                torch.Tensor(with_size).repeat(nnz, 1).transpose(0, 1)
+                torch.Tensor(with_size[:d]).repeat(nnz, 1).transpose(0, 1)
             i = i.type(torch.LongTensor)
             x = SparseTensor(i, v, torch.Size(with_size))
 
@@ -66,6 +68,33 @@ class TestSparse(TestCase):
              [0, 0, 0, 0, 0],
              [0, 0, 0, 0, 0],
              [0, 0, 0, 0, 4]],
+        ])
+
+        x.to_dense()  # Tests double to_dense for memory corruption
+        x.to_dense()
+        x.to_dense()
+        self.assertEqual(res, x.to_dense())
+
+    def test_to_dense_hybrid(self):
+        i = torch.LongTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+        ])
+        v = torch.Tensor([[2, 3], [1, 2], [3, 4], [4, 5]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 2]))
+        res = torch.Tensor([
+            [[2, 3],
+             [0, 0],
+             [0, 0],
+             [0, 0]],
+            [[1, 2],
+             [0, 0],
+             [0, 0],
+             [0, 0]],
+            [[3, 4],
+             [0, 0],
+             [0, 0],
+             [4, 5]],
         ])
 
         x.to_dense()  # Tests double to_dense for memory corruption
@@ -121,6 +150,65 @@ class TestSparse(TestCase):
             [0, 4],
         ])
         exp_v = torch.Tensor([6, 4])
+
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+    def test_contig_hybrid(self):
+        i = torch.LongTensor([
+            [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
+            [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
+        ])
+        v = torch.Tensor([
+            [1, 2], [2, 3], [3, 4], [4, 5], [5, 6],
+            [6, 7], [7, 8], [8, 9], [9, 10], [10, 11],
+        ])
+        x = SparseTensor(i, v, torch.Size([100, 100, 2]))
+        exp_i = torch.LongTensor([
+            [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
+            [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
+        ])
+        exp_v = torch.Tensor([
+            [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
+            [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
+        ])
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+        i = torch.LongTensor([
+            [2, 0, 2, 1],
+            [0, 0, 3, 0],
+            [1, 0, 4, 0],
+        ])
+        v = torch.Tensor([[3, 3, 3], [2, 2, 2], [4, 4, 4], [1, 1, 1]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = torch.LongTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+            [0, 0, 1, 4],
+        ])
+        exp_v = torch.Tensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
+
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+        # Duplicate indices
+        i = torch.LongTensor([
+            [0, 0, 2, 0],
+            [0, 0, 3, 0],
+            [0, 0, 4, 0],
+        ])
+        v = torch.Tensor([[3, 2, 3], [2, 1, 1], [4, 3, 4], [1, 1, 1]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = torch.LongTensor([
+            [0, 2],
+            [0, 3],
+            [0, 4],
+        ])
+        exp_v = torch.Tensor([[6, 4, 5], [4, 3, 4]])
 
         x.contiguous()
         self.assertEqual(exp_i, x.indices())
@@ -187,33 +275,97 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
+    def _test_spadd_shape(self, shape_i, shape_v=None):
+        shape = shape_i + (shape_v or [])
+        x, _, _ = self._gen_sparse(len(shape_i), 10, shape)
+        y = torch.randn(*shape)
+        r = random.random()
+
+        expected = y + r * x.to_dense()
+        res = torch.add(y, r, x)
+
+        self.assertEqual(res, expected)
+
+        # Non contiguous dense tensor
+        s = list(shape)
+        s[0] = shape[-1]
+        s[-1] = shape[0]
+        y = torch.randn(*s).transpose_(0, len(s) - 1)
+        r = random.random()
+
+        expected = y + r * x.to_dense()
+        res = torch.add(y, r, x)
+
+        self.assertEqual(res, expected)
+
     def test_spadd(self):
-        def test_shape(*shape):
-            x, _, _ = self._gen_sparse(len(shape), 10, shape)
-            y = torch.randn(*shape)
-            r = random.random()
+        self._test_spadd_shape([5, 6])
+        self._test_spadd_shape([10, 10, 10])
+        self._test_spadd_shape([50, 30, 20])
+        self._test_spadd_shape([5, 5, 5, 5, 5, 5])
 
-            expected = y + r * x.to_dense()
-            res = torch.add(y, r, x)
+    def test_spadd_hybrid(self):
+        self._test_spadd_shape([5, 6], [2, 3])
+        self._test_spadd_shape([10, 10, 10], [3])
+        self._test_spadd_shape([50, 30, 20], [2])
+        self._test_spadd_shape([5, 5, 5, 5, 5, 5], [2])
 
-            self.assertEqual(res, expected)
+    def _test_basic_ops_shape(self, shape_i, shape_v=None):
+        shape = shape_i + (shape_v or [])
+        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape)
+        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape)
 
-            # Non contiguous dense tensor
-            s = list(shape)
-            s[0] = shape[-1]
-            s[-1] = shape[0]
-            y = torch.randn(*s).transpose_(0, len(s) - 1)
-            r = random.random()
+        y1 = x1 + x2
+        y2 = x1.clone()
+        y2.add_(x2)
+        expected = x1.to_dense() + x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            expected = y + r * x.to_dense()
-            res = torch.add(y, r, x)
+        y1 = x1 - x2
+        y2 = x1.clone()
+        y2.sub_(x2)
+        expected = x1.to_dense() - x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            self.assertEqual(res, expected)
+        y1 = x1 * x2
+        y2 = x1.clone()
+        y2.mul_(x2)
+        expected = x1.to_dense() * x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-        test_shape(5, 6)
-        test_shape(10, 10, 10)
-        test_shape(50, 30, 20)
-        test_shape(5, 5, 5, 5, 5, 5)
+        y1 = x1 * 37.5
+        y2 = x1.clone()
+        y2.mul_(37.5)
+        expected = x1.to_dense() * 37.5
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
+
+        y1 = x1 / 37.5
+        y2 = x1.clone()
+        y2.div_(37.5)
+        expected = x1.to_dense() / 37.5
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
+
+        y = x1.clone()
+        y.zero_()
+        expected = torch.zeros(x1.size())
+        self.assertEqual(y.to_dense(), expected)
+
+    def test_basic_ops(self):
+        self._test_basic_ops_shape([5, 6])
+        self._test_basic_ops_shape([10, 10, 10])
+        self._test_basic_ops_shape([50, 30, 20])
+        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5])
+
+    def test_basic_ops_hybrid(self):
+        self._test_basic_ops_shape([5, 6], [2, 3])
+        self._test_basic_ops_shape([10, 10, 10], [3])
+        self._test_basic_ops_shape([50, 30, 20], [2])
+        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5], [2])
 
 
 if __name__ == '__main__':

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -18,6 +18,7 @@ class THPPlugin(CWrapPlugin):
 
         'THCudaTensor*': Template('((THCPFloatTensor*)$arg)->cdata'),
         'THCudaDoubleTensor*': Template('((THCPDoubleTensor*)$arg)->cdata'),
+        'THCudaLongTensor*': Template('((THCPLongTensor*)$arg)->cdata'),
 
         'THSFloatTensor*': Template('((THSPFloatTensor*)$arg)->cdata'),
         'THSDoubleTensor*': Template('((THSPDoubleTensor*)$arg)->cdata'),
@@ -53,6 +54,7 @@ class THPPlugin(CWrapPlugin):
 
         'THCudaTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPFloatTensorClass'),
         'THCudaDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPDoubleTensorClass'),
+        'THCudaLongTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPLongTensorClass'),
 
         'THSDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THSPDoubleTensorClass'),
         'THSFloatTensor*': Template('(PyObject*)Py_TYPE($arg) == THSPFloatTensorClass'),
@@ -84,6 +86,7 @@ class THPPlugin(CWrapPlugin):
         'THSTensor*': Template('return THSPTensor_(New)($result);'),
         'THLongTensor*': Template('return THPLongTensor_New($result);'),
         'THLongStorage*': Template('return THPLongStorage_New($result);'),
+        'THCudaLongTensor*': Template('return THCPLongTensor_New($result);'),
         # TODO: make it smarter - it should return python long if result doesn't fit into an int
         'long': Template('return PyInt_FromLong($result);'),
         'accreal': Template('return THPUtils_(newAccreal)($result);'),
@@ -167,6 +170,7 @@ ${cpu}
         'THDoubleTensor*': '" THPModuleStr "DoubleTensor',
         'THCudaTensor*': 'torch.cuda.FloatTensor',
         'THCudaDoubleTensor*': 'torch.cuda.DoubleTensor',
+        'THCudaLongTensor*': 'torch.cuda.LongTensor',
         'THSize*': 'torch.Size',
         'THStride*': 'tuple',
         'long': 'int',

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -322,7 +322,6 @@ del SparseByteTensorBase
 ################################################################################
 
 import torch.cuda
-import torch.cuda.sparse
 import torch.autograd
 import torch.nn
 import torch.optim

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -322,6 +322,7 @@ del SparseByteTensorBase
 ################################################################################
 
 import torch.cuda
+import torch.cuda.sparse
 import torch.autograd
 import torch.nn
 import torch.optim

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -22,10 +22,14 @@ def _type(self, new_type=None, async=False):
     if new_type == type(self):
         return self
     if self.is_sparse:
+        if not new_type.is_sparse:
+            raise RuntimeError("Cannot cast sparse tensor to dense tensor")
         new_type_name = new_type.__module__ + '.' + new_type.__name__
         new_values_type_name = new_type_name.replace('.sparse', '')
         new_values = self.values().type(new_values_type_name, async)
         return new_type(self.indices(), new_values, self.size())
+    if new_type.is_sparse:
+        raise RuntimeError("Cannot cast dense tensor to sparse tensor")
     return new_type(self.size()).copy_(self, async)
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -21,6 +21,11 @@ def _type(self, new_type=None, async=False):
         new_type = _import_dotted_name(new_type)
     if new_type == type(self):
         return self
+    if self.is_sparse:
+        new_type_name = new_type.__module__ + '.' + new_type.__name__
+        new_values_type_name = new_type_name.replace('.sparse', '')
+        new_values = self.values().type(new_values_type_name, async)
+        return new_type(self.indices(), new_values, self.size())
     return new_type(self.size()).copy_(self, async)
 
 
@@ -39,16 +44,20 @@ def _cuda(self, device=None, async=False):
     if self.is_cuda:
         if device is None:
             device = torch.cuda.current_device()
-        if self.get_device() != device:
-            with torch.cuda.device(device):
-                return type(self)(self.size()).copy_(self, async)
-        else:
+        if self.get_device() == device:
             return self
     else:
         if device is None:
             device = -1
-        with torch.cuda.device(device):
-            return self.type(getattr(torch.cuda, self.__class__.__name__), async)
+    with torch.cuda.device(device):
+        if self.is_sparse:
+            new_type = getattr(torch.cuda.sparse, self.__class__.__name__)
+            indices = self.indices().cuda(device, async)
+            values = self.values().cuda(device, async)
+            return new_type(indices, values, self.size())
+        else:
+            new_type = getattr(torch.cuda, self.__class__.__name__)
+            return new_type(self.size()).copy_(self, async)
 
 
 def _range(*args, **kwargs):

--- a/torch/autograd/_functions/blas.py
+++ b/torch/autograd/_functions/blas.py
@@ -168,7 +168,7 @@ class Addr(_BlasBase):
 
         if self.needs_input_grad[2]:
             # TODO: maybe it's better to do transpose + mv + transpose
-            grad_vector2 = torch.mm(vector1.unsqueeze(0), grad_output)
+            grad_vector2 = torch.mm(vector1.unsqueeze(0), grad_output).squeeze(0)
             if self.beta != 1:
                 grad_vector2 *= self.beta
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -1,6 +1,7 @@
 import sys
 import torch._C as _C
 from collections import OrderedDict
+import torch.sparse as sparse
 import torch.utils.hooks as hooks
 
 from ._functions import *

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -8,7 +8,9 @@
 
 #ifdef WITH_CUDA
 #include <THC/THC.h>
+#include <THCS/THCS.h>
 #include <THPP/tensors/THCTensor.hpp>
+#include <THPP/tensors/THCSTensor.hpp>
 extern THCState* state;
 #endif
 
@@ -84,7 +86,25 @@ static std::unique_ptr<Tensor> createTensor(void *tensor, Type type, bool is_cud
 {
   if (is_cuda) {
 #ifdef WITH_CUDA
-    if (type == Type::UCHAR) {
+    if (is_sparse) {
+      if (type == Type::UCHAR) {
+        return std::unique_ptr<Tensor>(new THCSTensor<unsigned char>(state, (THCSByteTensor*)tensor));
+      } else if (type == Type::CHAR) {
+        return std::unique_ptr<Tensor>(new THCSTensor<char>(state, (THCSCharTensor*)tensor));
+      } else if (type == Type::SHORT) {
+        return std::unique_ptr<Tensor>(new THCSTensor<short>(state, (THCSShortTensor*)tensor));
+      } else if (type == Type::INT) {
+        return std::unique_ptr<Tensor>(new THCSTensor<int>(state, (THCSIntTensor*)tensor));
+      } else if (type == Type::LONG) {
+        return std::unique_ptr<Tensor>(new THCSTensor<long>(state, (THCSLongTensor*)tensor));
+      } else if (type == Type::FLOAT) {
+        return std::unique_ptr<Tensor>(new THCSTensor<float>(state, (THCSFloatTensor*)tensor));
+      } else if (type == Type::DOUBLE) {
+        return std::unique_ptr<Tensor>(new THCSTensor<double>(state, (THCSDoubleTensor*)tensor));
+      } else if (type == Type::HALF) {
+        return std::unique_ptr<Tensor>(new THCSTensor<half>(state, (THCSHalfTensor*)tensor));
+      }
+    } else if (type == Type::UCHAR) {
       return std::unique_ptr<Tensor>(new THCTensor<unsigned char>(state, (THCudaByteTensor*)tensor));
     } else if (type == Type::CHAR) {
       return std::unique_ptr<Tensor>(new THCTensor<char>(state, (THCudaCharTensor*)tensor));

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -659,6 +659,7 @@ static PyMethodDef TorchMethods[] = {
   // Sparse functions
   {"smm",             (PyCFunction)THSPModule_sspmm,          METH_VARARGS | METH_KEYWORDS,  NULL},
   {"saddmm",          (PyCFunction)THSPModule_sspaddmm,       METH_VARARGS | METH_KEYWORDS,  NULL},
+  {"dsmm",            (PyCFunction)THSPModule_spmm,           METH_VARARGS | METH_KEYWORDS,  NULL},
   {NULL, NULL, 0, NULL}
 };
 

--- a/torch/csrc/ModuleSparse.cpp
+++ b/torch/csrc/ModuleSparse.cpp
@@ -98,6 +98,7 @@ dispatch:                                                                      \
   return PyObject_Call(method, args, kwargs);                                  \
 }
 
+IMPLEMENT_SPARSE_STATELESS(spmm);
 IMPLEMENT_SPARSE_STATELESS(sspmm);
 IMPLEMENT_SPARSE_STATELESS(sspaddmm);
 

--- a/torch/csrc/autograd/grad_buffer.cpp
+++ b/torch/csrc/autograd/grad_buffer.cpp
@@ -19,6 +19,9 @@ auto GradBuffer::addGrad(size_t pos, std::shared_ptr<Variable>&& var) -> void {
   if (!item.first) {
     buffer[pos] = std::make_pair<>(std::move(tensor), true);
   } else {
+    if (item.first->isSparse() && !tensor->isSparse()) {
+      throw std::runtime_error("mixing sparse and dense gradients is not yet supported");
+    }
 #ifdef WITH_CUDA
     THCPAutoGPU auto_gpu(tensor->getDevice());
 #endif

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -859,7 +859,7 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
 
     // self.backward(*grad_output)
     THPObjectPtr backward_fn = PyObject_GetAttrString((PyObject*)self, "backward");
-    THPUtils_assert(backward_fn.get(), "function %s doesn't cdataement a required "
+    THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
         "'backward' method", THPUtils_typename((PyObject*)self));
     THPObjectPtr grad_input = PyObject_CallObject(backward_fn, grad_output.get());
     if (!grad_input) return NULL;

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -224,7 +224,7 @@ PyObject *THPVariable_get_grad(THPVariable *self)
 {
   auto& var = *self->cdata;
   if (!var.grad) {
-    return Py_None;
+    Py_RETURN_NONE;
   }
   return THPVariable_Wrap(var.grad);
 }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -224,12 +224,7 @@ PyObject *THPVariable_get_grad(THPVariable *self)
 {
   auto& var = *self->cdata;
   if (!var.grad) {
-#ifdef WITH_CUDA
-    THCPAutoGPU __guard(var.data->getDevice());
-#endif
-    auto grad = var.data->newTensor();
-    grad->resizeAs(*var.data).zero();
-    var.grad = std::make_shared<Variable>(std::move(grad), 0, 1);
+    return Py_None;
   }
   return THPVariable_Wrap(var.grad);
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -63,10 +63,11 @@ auto Variable::backward(std::shared_ptr<Variable> gradOutput) -> void {
   if (!grad) {
     std::unique_ptr<Tensor> data(gradOutput->data->clone());
     grad = std::make_shared<Variable>(std::move(data), false, true);
+  } else if (grad->data->isSparse() && !gradOutput->data->isSparse()) {
+    auto* sum = gradOutput->data->clone();
+    sum->cadd(*sum, *grad->data);
+    grad->data.reset(sum);
   } else {
-    if (grad->data->isSparse() && !gradOutput->data->isSparse()) {
-      throw std::runtime_error("mixing sparse and dense gradients is not yet supported");
-    }
     grad->data->cadd(*grad->data, *gradOutput->data);
   }
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -64,6 +64,9 @@ auto Variable::backward(std::shared_ptr<Variable> gradOutput) -> void {
     std::unique_ptr<Tensor> data(gradOutput->data->clone());
     grad = std::make_shared<Variable>(std::move(data), false, true);
   } else {
+    if (grad->data->isSparse() && !gradOutput->data->isSparse()) {
+      throw std::runtime_error("mixing sparse and dense gradients is not yet supported");
+    }
     grad->data->cadd(*grad->data, *gradOutput->data);
   }
 }

--- a/torch/csrc/cuda/AutoGPU.cpp
+++ b/torch/csrc/cuda/AutoGPU.cpp
@@ -21,6 +21,22 @@ static int getObjDevice(PyObject *obj) {
     return THCudaCharTensor_getDevice(LIBRARY_STATE ((THCPCharTensor*)obj)->cdata);
   } else if (obj_type == THCPByteTensorClass) {
     return THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
+  } else if (obj_type == THCSPDoubleTensorClass) {
+    return THCSDoubleTensor_getDevice(LIBRARY_STATE ((THCSPDoubleTensor*)obj)->cdata);
+  } else if (obj_type == THCSPFloatTensorClass) {
+    return THCSFloatTensor_getDevice(LIBRARY_STATE ((THCSPFloatTensor*)obj)->cdata);
+  } else if (obj_type == THCSPHalfTensorClass) {
+    return THCSHalfTensor_getDevice(LIBRARY_STATE ((THCSPHalfTensor*)obj)->cdata);
+  } else if (obj_type == THCSPLongTensorClass) {
+    return THCSLongTensor_getDevice(LIBRARY_STATE ((THCSPLongTensor*)obj)->cdata);
+  } else if (obj_type == THCSPIntTensorClass) {
+    return THCSIntTensor_getDevice(LIBRARY_STATE ((THCSPIntTensor*)obj)->cdata);
+  } else if (obj_type == THCSPShortTensorClass) {
+    return THCSShortTensor_getDevice(LIBRARY_STATE ((THCSPShortTensor*)obj)->cdata);
+  } else if (obj_type == THCSPCharTensorClass) {
+    return THCSCharTensor_getDevice(LIBRARY_STATE ((THCSPCharTensor*)obj)->cdata);
+  } else if (obj_type == THCSPByteTensorClass) {
+    return THCSByteTensor_getDevice(LIBRARY_STATE ((THCSPByteTensor*)obj)->cdata);
   }
   return -1;
 }

--- a/torch/csrc/cuda/ModuleSparse.cpp
+++ b/torch/csrc/cuda/ModuleSparse.cpp
@@ -1,19 +1,18 @@
 #include "THCP.h"
 
-static bool THCSPModule_loadClasses(PyObject *module_dict)
+static bool THCSPModule_loadClasses(PyObject *sparse_module)
 {
-#define ASSERT_NOT_NULL(ptr) if (!(ptr)) { THPUtils_setError("couldn't load classes"); return false; }
-  ASSERT_NOT_NULL(THCSPDoubleTensorClass  = PyMapping_GetItemString(module_dict, (char*)"DoubleTensor"));
-  ASSERT_NOT_NULL(THCSPHalfTensorClass    = PyMapping_GetItemString(module_dict, (char*)"HalfTensor"));
-  ASSERT_NOT_NULL(THCSPFloatTensorClass   = PyMapping_GetItemString(module_dict, (char*)"FloatTensor"));
-  ASSERT_NOT_NULL(THCSPLongTensorClass    = PyMapping_GetItemString(module_dict, (char*)"LongTensor"));
-  ASSERT_NOT_NULL(THCSPIntTensorClass     = PyMapping_GetItemString(module_dict, (char*)"IntTensor"));
-  ASSERT_NOT_NULL(THCSPShortTensorClass   = PyMapping_GetItemString(module_dict, (char*)"ShortTensor"));
-  ASSERT_NOT_NULL(THCSPCharTensorClass    = PyMapping_GetItemString(module_dict, (char*)"CharTensor"));
-  ASSERT_NOT_NULL(THCSPByteTensorClass    = PyMapping_GetItemString(module_dict, (char*)"ByteTensor"));
-
+  if (!THCSPDoubleTensor_postInit(sparse_module)) return false;
+  if (!THCSPFloatTensor_postInit(sparse_module)) return false;
+#ifdef CUDA_HALF_TENSOR
+  if (!THCSPHalfTensor_postInit(sparse_module)) return false;
+#endif
+  if (!THCSPLongTensor_postInit(sparse_module)) return false;
+  if (!THCSPIntTensor_postInit(sparse_module)) return false;
+  if (!THCSPShortTensor_postInit(sparse_module)) return false;
+  if (!THCSPCharTensor_postInit(sparse_module)) return false;
+  if (!THCSPByteTensor_postInit(sparse_module)) return false;
   return true;
-#undef ASSERT_NOT_NULL
 }
 
 static bool THCSPModule_assignStateless()
@@ -31,7 +30,9 @@ static bool THCSPModule_assignStateless()
   PyObject *stateless;
   INIT_STATELESS(Double);
   INIT_STATELESS(Float);
+#ifdef CUDA_HALF_TENSOR
   INIT_STATELESS(Half);
+#endif
   INIT_STATELESS(Long);
   INIT_STATELESS(Int);
   INIT_STATELESS(Short);
@@ -46,9 +47,9 @@ static bool THCSPModule_assignStateless()
 // Sparse Cuda module initialization
 ////////////////////////////////////////////////////////////////////////////////
 
-bool THCSPModule_initCudaSparse(PyObject *module_dict) {
+bool THCSPModule_initCudaSparse(PyObject *module) {
 #define ASSERT_TRUE(cond) if (!(cond)) { return false; }
-  ASSERT_TRUE(THCSPModule_loadClasses(module_dict));
+  ASSERT_TRUE(THCSPModule_loadClasses(module));
   ASSERT_TRUE(THCSPModule_assignStateless());
   return true;
 #undef ASSERT_TRUE
@@ -56,11 +57,10 @@ bool THCSPModule_initCudaSparse(PyObject *module_dict) {
 
 PyObject * THCSPModule_initExtension(PyObject *self)
 {
-  PyObject *torch_module = PyImport_ImportModule("torch.cuda.sparse");
-  if (!torch_module) {
+  PyObject *module = PyImport_ImportModule("torch.cuda.sparse");
+  if (!module) {
     THPUtils_setError("class loader couldn't access torch.cuda.sparse module");
     return NULL;
   }
-  PyObject* module_dict = PyModule_GetDict(torch_module);
-  return PyBool_FromLong(THCSPModule_initCudaSparse(module_dict));
+  return PyBool_FromLong(THCSPModule_initCudaSparse(module));
 }

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -26,13 +26,13 @@ static void THSPTensor_(dealloc)(THSPTensor* self)
 static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 #ifdef THC_GENERIC_FILE
-#define THPIndicesTensor_Check THCPLongTensor_Check
-#define THPIndicesTensor THCPLongTensor
-#define THIndicesTensor THCudaLongTensor
+#define THPIndexTensor_Check THCPLongTensor_Check
+#define THPIndexTensor THCPLongTensor
+#define THIndexTensor THCudaLongTensor
 #else
-#define THPIndicesTensor_Check THPLongTensor_Check
-#define THPIndicesTensor THPLongTensor
-#define THIndicesTensor THLongTensor
+#define THPIndexTensor_Check THPLongTensor_Check
+#define THPIndexTensor THPLongTensor
+#define THIndexTensor THLongTensor
 #endif
   HANDLE_TH_ERRORS
     Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;
@@ -76,24 +76,24 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
     self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get());
   }
   // torch.SparseTensor(torch.LongTensor indices, torch.LongTensor values)
-  else if (num_args == 2 && THPIndicesTensor_Check(first_arg)) {
+  else if (num_args == 2 && THPIndexTensor_Check(first_arg)) {
     PyObject *second_arg = PyTuple_GET_ITEM(args, 1);
     if (!THPTensor_(Check)(second_arg)) goto invalid_arguments;
 
-    THIndicesTensor *indices = ((THPIndicesTensor*)first_arg)->cdata;
+    THIndexTensor *indices = ((THPIndexTensor*)first_arg)->cdata;
     THTensor *values = ((THPTensor*)second_arg)->cdata;
     self->cdata = THSTensor_(newWithTensor)(LIBRARY_STATE indices, values);
   }
   // torch.SparseTensor(torch.LongTensor indices,
   //                    torch.Tensor values,
   //                    torch.Size sizes)
-  else if (num_args > 2 && THPIndicesTensor_Check(first_arg)) {
+  else if (num_args > 2 && THPIndexTensor_Check(first_arg)) {
     PyObject *second_arg = PyTuple_GET_ITEM(args, 1);
     PyObject *third_arg = PyTuple_GET_ITEM(args, 2);
     if (!THPTensor_(Check)(second_arg)) goto invalid_arguments;
     if (!THPSize_Check(third_arg)) goto invalid_arguments;
 
-    THIndicesTensor *indices = ((THPIndicesTensor*)first_arg)->cdata;
+    THIndexTensor *indices = ((THPIndexTensor*)first_arg)->cdata;
     THTensor *values = ((THPTensor*)second_arg)->cdata;
     THLongStoragePtr sizes = THPUtils_unpackSize(third_arg);
     self->cdata = THSTensor_(newWithTensorAndSize)(
@@ -122,9 +122,9 @@ invalid_arguments:
       "(int ...)");
   return NULL;
   END_HANDLE_TH_ERRORS
-#undef THPIndicesTensor_Check
-#undef THPIndicesTensor
-#undef THIndicesTensor
+#undef THPIndexTensor_Check
+#undef THPIndexTensor
+#undef THIndexTensor
 }
 
 // TODO: implement equality

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -26,9 +26,14 @@ static void THSPTensor_(dealloc)(THSPTensor* self)
 static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 #ifdef THC_GENERIC_FILE
-  printf("Sparse CUDA Tensors not supported!\n");
-  return NULL;
+#define THPIndicesTensor_Check THCPLongTensor_Check
+#define THPIndicesTensor THCPLongTensor
+#define THIndicesTensor THCudaLongTensor
 #else
+#define THPIndicesTensor_Check THPLongTensor_Check
+#define THPIndicesTensor THPLongTensor
+#define THIndicesTensor THLongTensor
+#endif
   HANDLE_TH_ERRORS
     Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;
 
@@ -71,24 +76,24 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
     self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get());
   }
   // torch.SparseTensor(torch.LongTensor indices, torch.LongTensor values)
-  else if (num_args == 2 && THPLongTensor_Check(first_arg)) {
+  else if (num_args == 2 && THPIndicesTensor_Check(first_arg)) {
     PyObject *second_arg = PyTuple_GET_ITEM(args, 1);
     if (!THPTensor_(Check)(second_arg)) goto invalid_arguments;
 
-    THLongTensor *indices = ((THPLongTensor*)first_arg)->cdata;
+    THIndicesTensor *indices = ((THPIndicesTensor*)first_arg)->cdata;
     THTensor *values = ((THPTensor*)second_arg)->cdata;
     self->cdata = THSTensor_(newWithTensor)(LIBRARY_STATE indices, values);
   }
   // torch.SparseTensor(torch.LongTensor indices,
   //                    torch.Tensor values,
   //                    torch.Size sizes)
-  else if (num_args > 2 && THPLongTensor_Check(first_arg)) {
+  else if (num_args > 2 && THPIndicesTensor_Check(first_arg)) {
     PyObject *second_arg = PyTuple_GET_ITEM(args, 1);
     PyObject *third_arg = PyTuple_GET_ITEM(args, 2);
     if (!THPTensor_(Check)(second_arg)) goto invalid_arguments;
     if (!THPSize_Check(third_arg)) goto invalid_arguments;
 
-    THLongTensor *indices = ((THPLongTensor*)first_arg)->cdata;
+    THIndicesTensor *indices = ((THPIndicesTensor*)first_arg)->cdata;
     THTensor *values = ((THPTensor*)second_arg)->cdata;
     THLongStoragePtr sizes = THPUtils_unpackSize(third_arg);
     self->cdata = THSTensor_(newWithTensorAndSize)(
@@ -107,12 +112,19 @@ invalid_arguments:
       "no arguments",
       "(int size)",
       "(torch.Size sizes)",
+#ifdef THC_GENERIC_FILE
+      "(torch.cuda.LongTensor indices, " THPTensorStr " values)",
+      "(torch.cuda.LongTensor indices, " THPTensorStr " values, torch.Size sizes)",
+#else
       "(torch.LongTensor indices, " THPTensorStr " values)",
       "(torch.LongTensor indices, " THPTensorStr " values, torch.Size sizes)",
+#endif
       "(int ...)");
   return NULL;
   END_HANDLE_TH_ERRORS
-#endif
+#undef THPIndicesTensor_Check
+#undef THPIndicesTensor
+#undef THIndicesTensor
 }
 
 // TODO: implement equality

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -1,5 +1,4 @@
-// Sparse Tensors not supported for CUDA
-
+#if IS_CUDA || !defined(TH_REAL_IS_HALF)
 PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   HANDLE_TH_ERRORS
@@ -36,10 +35,10 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
   only_register: True
   sparse: yes
 ]]
+#endif
 
 [[
   name: nDimension
-  defined_if: "!IS_CUDA"
   sparse: yes
   python_name: ndimension
   return: long
@@ -56,7 +55,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: nnz
-  defined_if: "!IS_CUDA"
   sparse: yes
   return: long
   arguments:
@@ -65,7 +63,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: isContiguous
-  defined_if: "!IS_CUDA"
   sparse: yes
   python_name: is_contiguous
   return: bool
@@ -83,8 +80,17 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: indices
+  defined_if: "IS_CUDA"
+  sparse: yes
+  return: THCudaLongTensor*
+  arguments:
+  - THSTensor* self
+]]
+
+
+[[
   name: values
-  defined_if: "!IS_CUDA"
   sparse: yes
   return: THTensor*
   arguments:
@@ -93,7 +99,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: contiguous
-  defined_if: "!IS_CUDA"
   sparse: yes
   return: argument 0
   arguments:
@@ -102,7 +107,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: clone
-  defined_if: "!IS_CUDA"
   sparse: yes
   cname: newClone
   return: THSTensor*
@@ -112,7 +116,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: toDense
-  defined_if: "!IS_CUDA"
   sparse: yes
   python_name: to_dense
   return: THTensor*
@@ -121,8 +124,18 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: resizeAs_
+  python_name: resize_as_
+  sparse: yes
+  cname: resizeAs
+  return: self
+  arguments:
+    - THSTensor* self
+    - THSTensor* template
+]]
+
+[[
   name: transpose
-  defined_if: "!IS_CUDA"
   sparse: yes
   cname: newTranspose
   return: THSTensor*
@@ -134,7 +147,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: transpose_
-  defined_if: "!IS_CUDA"
   sparse: yes
   cname: transpose
   return: argument 0
@@ -146,7 +158,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: mm
-  defined_if: "!IS_CUDA"
   sparse: yes
   only_stateless: True
   cname: spaddmm
@@ -167,7 +178,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: spmm
-  defined_if: "!IS_CUDA"
   only_stateless: True
   sparse: yes
   cname: spaddmm
@@ -189,7 +199,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: sspmm
-  defined_if: "!IS_CUDA"
   only_stateless: True
   sparse: yes
   cname: sspaddmm
@@ -210,7 +219,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: sspaddmm
-  defined_if: "!IS_CUDA"
   sparse: yes
   with_stateless: True
   return: argument 0
@@ -228,7 +236,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: spadd
-  defined_if: "!IS_CUDA"
   sparse: yes
   cname: spcadd
   with_stateless: True
@@ -244,7 +251,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: zero_
-  defined_if: "!IS_CUDA"
   sparse: yes
   cname: zero
   return: self
@@ -254,11 +260,10 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: add
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cadd
   with_stateless: True
   return: argument 0
+  cname: cadd
   arguments:
     - arg: THSTensor* result
       output: True
@@ -270,10 +275,37 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: add_
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cadd
   return: argument 0
+  cname: cadd
+  arguments:
+    - THSTensor* self
+    - THSTensor* self
+    - arg: real value
+      default: AS_REAL(1)
+    - THSTensor* other
+]]
+
+[[
+  name: sub
+  sparse: yes
+  with_stateless: True
+  return: argument 0
+  cname: csub
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THSTensor* self
+    - arg: real value
+      default: AS_REAL(1)
+    - THSTensor* other
+]]
+
+[[
+  name: sub_
+  sparse: yes
+  return: argument 0
+  cname: csub
   arguments:
     - THSTensor* self
     - THSTensor* self
@@ -284,59 +316,67 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: mul
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cmul
   return: argument 0
   with_stateless: True
-  arguments:
-    - arg: THSTensor* result
-      output: True
-    - THSTensor* self
-    - THSTensor* other
+  options:
+    - cname: mul
+      arguments:
+        - arg: THSTensor* result
+          output: True
+        - THSTensor* self
+        - real value
+    - cname: cmul
+      arguments:
+        - arg: THSTensor* result
+          output: True
+        - THSTensor* self
+        - THSTensor* other
 ]]
 
 [[
   name: mul_
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cmul
   return: argument 0
-  arguments:
-    - THSTensor* self
-    - THSTensor* self
-    - THSTensor* other
+  options:
+    - cname: mul
+      arguments:
+        - THSTensor* self
+        - THSTensor* self
+        - real value
+    - cname: cmul
+      arguments:
+        - THSTensor* self
+        - THSTensor* self
+        - THSTensor* other
 ]]
 
 [[
   name: div
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cdiv
+  cname: div
   with_stateless: True
   return: argument 0
   arguments:
     - arg: THSTensor* result
       output: True
     - THSTensor* self
-    - THSTensor* other
+    - real value
 ]]
 
 [[
   name: div_
-  defined_if: "!IS_CUDA"
   sparse: yes
-  cname: cdiv
+  cname: div
   return: argument 0
   arguments:
     - THSTensor* self
     - THSTensor* self
-    - THSTensor* other
+    - real value
 ]]
 
 [[
   name: sparse_mask
-  defined_if: "!IS_CUDA"
   cname: sparseMask
   return: argument 0
   arguments:

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -1,19 +1,40 @@
 // Sparse Tensors not supported for CUDA
 
+PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  HANDLE_TH_ERRORS
+  THSTensor* tensor = ((THSPTensor*)self)->cdata;
+  if (PyTuple_Size(args) == 0 && (!kwargs || PyDict_Size(kwargs) == 0)) {
+    return THPSize_New(tensor->nDimensionI + tensor->nDimensionV, tensor->size);
+  }
+
+  int tuplecount = args ? PyTuple_Size(args) : 0;
+  int dictcount = kwargs ? PyDict_Size(kwargs) : 0;
+
+  PyObject* pydim = NULL;
+  if (tuplecount == 1 && dictcount == 0) {
+    pydim = PyTuple_GET_ITEM(args, 0);
+  } else if (dictcount == 1 && tuplecount == 0) {
+    pydim = PyDict_GetItemString(kwargs, "dim");
+  }
+
+  if (pydim && THPUtils_checkLong(pydim)) {
+    int dim = (int)THPUtils_unpackLong(pydim);
+    if (dim < 0)
+      dim += tensor->nDimensionI + tensor->nDimensionV;
+    return PyInt_FromLong(THSTensor_(size)(LIBRARY_STATE tensor, dim));
+  }
+
+  THPUtils_invalidArguments(args, kwargs, "size", 2, "(int dim)", "no arguments");
+  return NULL;
+  END_HANDLE_TH_ERRORS
+}
 [[
-  name: size
-  defined_if: "!IS_CUDA"
+  name: THSPTensor_(size)
+  python_name: size
+  method_flags: METH_KEYWORDS
+  only_register: True
   sparse: yes
-  options:
-  - return: long
-    cname: size
-    arguments:
-    - THSTensor* self
-    - long dim
-  - return: THLongStorage*
-    cname: newSizeOf
-    arguments:
-    - THSTensor* self
 ]]
 
 [[
@@ -24,6 +45,13 @@
   return: long
   arguments:
   - THSTensor* self
+]]
+[[
+  name: THPTensor_(nDimension)
+  python_name: dim
+  only_register: True
+  method_flags: METH_KEYWORDS
+  sparse: yes
 ]]
 
 [[
@@ -73,6 +101,16 @@
 ]]
 
 [[
+  name: clone
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: newClone
+  return: THSTensor*
+  arguments:
+    - THSTensor* self
+]]
+
+[[
   name: toDense
   defined_if: "!IS_CUDA"
   sparse: yes
@@ -117,6 +155,28 @@
     long s1 = THSTensor_(size)(LIBRARY_STATE ((THSPTensor*)$arg4)->cdata, 0);
     long s2 = THTensor_(size)(LIBRARY_STATE ((THPTensor*)$arg5)->cdata, 1);
     THTensor_(resize2d)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, s1, s2);
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - CONSTANT AS_REAL(0)
+    - argument 0
+    - CONSTANT AS_REAL(1)
+    - THSTensor* mat1
+    - THTensor* mat2
+]]
+
+[[
+  name: spmm
+  defined_if: "!IS_CUDA"
+  only_stateless: True
+  sparse: yes
+  cname: spaddmm
+  return: argument 0
+  before_call: |
+    long s1 = THSTensor_(size)(LIBRARY_STATE ((THSPTensor*)$arg4)->cdata, 0);
+    long s2 = THTensor_(size)(LIBRARY_STATE ((THPTensor*)$arg5)->cdata, 1);
+    THTensor_(resize2d)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, s1, s2);
+    THTensor_(zero)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata);
   arguments:
     - arg: THTensor* result
       output: True
@@ -182,3 +242,106 @@
     - THSTensor* mat2
 ]]
 
+[[
+  name: zero_
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: zero
+  return: self
+  arguments:
+    - THSTensor* self
+]]
+
+[[
+  name: add
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cadd
+  with_stateless: True
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THSTensor* self
+    - arg: real value
+      default: AS_REAL(1)
+    - THSTensor* other
+]]
+
+[[
+  name: add_
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cadd
+  return: argument 0
+  arguments:
+    - THSTensor* self
+    - THSTensor* self
+    - arg: real value
+      default: AS_REAL(1)
+    - THSTensor* other
+]]
+
+[[
+  name: mul
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cmul
+  return: argument 0
+  with_stateless: True
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THSTensor* self
+    - THSTensor* other
+]]
+
+[[
+  name: mul_
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cmul
+  return: argument 0
+  arguments:
+    - THSTensor* self
+    - THSTensor* self
+    - THSTensor* other
+]]
+
+[[
+  name: div
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cdiv
+  with_stateless: True
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THSTensor* self
+    - THSTensor* other
+]]
+
+[[
+  name: div_
+  defined_if: "!IS_CUDA"
+  sparse: yes
+  cname: cdiv
+  return: argument 0
+  arguments:
+    - THSTensor* self
+    - THSTensor* self
+    - THSTensor* other
+]]
+
+[[
+  name: sparse_mask
+  defined_if: "!IS_CUDA"
+  cname: sparseMask
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THTensor* self
+    - THSTensor* mask
+]]

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -906,10 +906,10 @@
       arguments:
         - arg: THTensor* result
           output: True
-        - THTensor* mat1
+        - THTensor* self
         - arg: real value
           default: AS_REAL(1)
-        - THSTensor* mat2
+        - THSTensor* other
 ]]
 
 [[
@@ -1567,15 +1567,25 @@
 
 [[
   name: addcmul_
-  cname: addcmul
-  return: argument 0
-  arguments:
-    - THTensor* self
-    - THTensor* self
-    - arg: real value
-      default: AS_REAL(1)
-    - THTensor* tensor1
-    - THTensor* tensor2
+  options:
+    - cname: addcmul
+      return: argument 0
+      arguments:
+        - THTensor* self
+        - THTensor* self
+        - arg: real value
+          default: AS_REAL(1)
+        - THTensor* tensor1
+        - THTensor* tensor2
+    - cname: spaddcmul
+      return: argument 0
+      arguments:
+        - THTensor* self
+        - THTensor* self
+        - arg: real value
+          default: AS_REAL(1)
+        - THSTensor* tensor1
+        - THSTensor* tensor2
 ]]
 
 [[
@@ -1594,15 +1604,25 @@
 
 [[
   name: addcdiv_
-  cname: addcdiv
-  return: argument 0
-  arguments:
-    - THTensor* self
-    - THTensor* self
-    - arg: real value
-      default: AS_REAL(1)
-    - THTensor* tensor1
-    - THTensor* tensor2
+  options:
+    - cname: addcdiv
+      return: argument 0
+      arguments:
+        - THTensor* self
+        - THTensor* self
+        - arg: real value
+          default: AS_REAL(1)
+        - THTensor* tensor1
+        - THTensor* tensor2
+    - cname: spaddcdiv
+      return: argument 0
+      arguments:
+        - THTensor* self
+        - THTensor* self
+        - arg: real value
+          default: AS_REAL(1)
+        - THSTensor* tensor1
+        - THSTensor* tensor2
 ]]
 
 #ifndef THP_LAPACK_CONSTANTS

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1604,25 +1604,15 @@
 
 [[
   name: addcdiv_
-  options:
-    - cname: addcdiv
-      return: argument 0
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - arg: real value
-          default: AS_REAL(1)
-        - THTensor* tensor1
-        - THTensor* tensor2
-    - cname: spaddcdiv
-      return: argument 0
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - arg: real value
-          default: AS_REAL(1)
-        - THSTensor* tensor1
-        - THSTensor* tensor2
+  cname: addcdiv
+  return: argument 0
+  arguments:
+    - THTensor* self
+    - THTensor* self
+    - arg: real value
+      default: AS_REAL(1)
+    - THTensor* tensor1
+    - THTensor* tensor2
 ]]
 
 #ifndef THP_LAPACK_CONSTANTS

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -95,6 +95,7 @@ def _lazy_init():
             "Cannot re-initialize CUDA in forked subprocess. " + msg)
     _check_driver()
     assert torch._C._cuda_init()
+    assert torch._C._cuda_sparse_init()
     _cudart = _load_cudart()
     _cudart.cudaGetErrorName.restype = ctypes.c_char_p
     _cudart.cudaGetErrorString.restype = ctypes.c_char_p
@@ -259,6 +260,7 @@ if not hasattr(torch._C, 'CudaDoubleStorageBase'):
 
 class _CudaBase(object):
     is_cuda = True
+    is_sparse = False
 
     def type(self, *args, **kwargs):
         with device(self.get_device()):

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -246,16 +246,25 @@ from .random import *
 from ..tensor import _TensorBase
 from ..storage import _StorageBase
 
+
+def _dummy_type(name):
+    def init_err(self):
+        class_name = self.__class__.__name__
+        raise RuntimeError(
+            "Tried to instantiate dummy base class {}".format(class_name))
+    return type(storage_name, (object,), {"__init__": init_err})
+
+
 if not hasattr(torch._C, 'CudaDoubleStorageBase'):
     # Define dummy base classes
     for t in ['Double', 'Float', 'Long', 'Int', 'Short', 'Char', 'Byte', 'Half']:
         storage_name = 'Cuda{0}StorageBase'.format(t)
         tensor_name = 'Cuda{0}TensorBase'.format(t)
 
-        torch._C.__dict__[storage_name] = type(storage_name, (object,), {})
-        torch._C.__dict__[tensor_name] = type(tensor_name, (object,), {})
+        torch._C.__dict__[storage_name] = _dummy_type(storage_name)
+        torch._C.__dict__[tensor_name] = _dummy_type(tensor_name)
 
-    torch._C.__dict__['_CudaStreamBase'] = type('CudaStreamBase', (object,), {})
+    torch._C.__dict__['_CudaStreamBase'] = _dummy_type('CudaStreamBase')
 
 
 class _CudaBase(object):

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -413,4 +413,5 @@ torch._tensor_classes.add(CharTensor)
 torch._tensor_classes.add(ByteTensor)
 torch._tensor_classes.add(HalfTensor)
 
+from . import sparse
 from .streams import Stream, Event

--- a/torch/cuda/sparse.py
+++ b/torch/cuda/sparse.py
@@ -2,14 +2,15 @@ import torch
 from torch import _C
 from ..tensor import _TensorBase
 from torch.sparse import _SparseBase, _sparse_tensor_classes
-from . import _lazy_init, device
+from . import _lazy_init, device, _dummy_type
 
 
 if not hasattr(torch._C, 'CudaSparseDoubleTensorBase'):
     # Define dummy base classes
     for t in ['Double', 'Float', 'Long', 'Int', 'Short', 'Char', 'Byte', 'Half']:
         tensor_name = 'CudaSparse{0}TensorBase'.format(t)
-        torch._C.__dict__[tensor_name] = type(tensor_name, (object,), {})
+
+        torch._C.__dict__[tensor_name] = _dummy_type(tensor_name)
 
 
 class _CudaSparseBase(object):

--- a/torch/cuda/sparse.py
+++ b/torch/cuda/sparse.py
@@ -1,0 +1,86 @@
+import torch
+from torch import _C
+from torch.sparse import _SparseTensorBase, _sparse_tensor_classes
+from . import _lazy_init, device
+
+
+if not hasattr(torch._C, 'CudaSparseDoubleTensorBase'):
+    # Define dummy base classes
+    for t in ['Double', 'Float', 'Long', 'Int', 'Short', 'Char', 'Byte', 'Half']:
+        tensor_name = 'CudaSparse{0}TensorBase'.format(t)
+        torch._C.__dict__[tensor_name] = type(tensor_name, (object,), {})
+
+
+class _CudaSparseBase(object):
+    is_cuda = True
+    is_sparse = True
+
+    def type(self, *args, **kwargs):
+        with device(self.get_device()):
+            return super(_CudaSparseBase, self).type(*args, **kwargs)
+
+    def __new__(cls, *args, **kwargs):
+        _lazy_init()
+        # We need this method only for lazy init, so we can remove it
+        del _CudaSparseBase.__new__
+        return super(_CudaSparseBase, cls).__new__(cls, *args, **kwargs)
+
+
+class DoubleTensor(_CudaSparseBase, torch._C.CudaSparseDoubleTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+class FloatTensor(_CudaSparseBase, torch._C.CudaSparseFloatTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+class LongTensor(_CudaSparseBase, torch._C.CudaSparseLongTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+class IntTensor(_CudaSparseBase, torch._C.CudaSparseIntTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+class ShortTensor(_CudaSparseBase, torch._C.CudaSparseShortTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+class CharTensor(_CudaSparseBase, torch._C.CudaSparseCharTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        # TODO
+        return False
+
+
+class ByteTensor(_CudaSparseBase, torch._C.CudaSparseByteTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return False
+
+
+class HalfTensor(_CudaSparseBase, torch._C.CudaSparseHalfTensorBase, _SparseTensorBase):
+
+    def is_signed(self):
+        return True
+
+
+_sparse_tensor_classes.add(DoubleTensor)
+_sparse_tensor_classes.add(FloatTensor)
+_sparse_tensor_classes.add(LongTensor)
+_sparse_tensor_classes.add(IntTensor)
+_sparse_tensor_classes.add(ShortTensor)
+_sparse_tensor_classes.add(CharTensor)
+_sparse_tensor_classes.add(ByteTensor)
+_sparse_tensor_classes.add(HalfTensor)
+torch._tensor_classes.update(_sparse_tensor_classes)

--- a/torch/cuda/sparse.py
+++ b/torch/cuda/sparse.py
@@ -1,6 +1,7 @@
 import torch
 from torch import _C
-from torch.sparse import _SparseTensorBase, _sparse_tensor_classes
+from ..tensor import _TensorBase
+from torch.sparse import _SparseBase, _sparse_tensor_classes
 from . import _lazy_init, device
 
 
@@ -26,50 +27,50 @@ class _CudaSparseBase(object):
         return super(_CudaSparseBase, cls).__new__(cls, *args, **kwargs)
 
 
-class DoubleTensor(_CudaSparseBase, torch._C.CudaSparseDoubleTensorBase, _SparseTensorBase):
+class DoubleTensor(_CudaSparseBase, torch._C.CudaSparseDoubleTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
 
-class FloatTensor(_CudaSparseBase, torch._C.CudaSparseFloatTensorBase, _SparseTensorBase):
+class FloatTensor(_CudaSparseBase, torch._C.CudaSparseFloatTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
 
-class LongTensor(_CudaSparseBase, torch._C.CudaSparseLongTensorBase, _SparseTensorBase):
+class LongTensor(_CudaSparseBase, torch._C.CudaSparseLongTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
 
-class IntTensor(_CudaSparseBase, torch._C.CudaSparseIntTensorBase, _SparseTensorBase):
+class IntTensor(_CudaSparseBase, torch._C.CudaSparseIntTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
 
-class ShortTensor(_CudaSparseBase, torch._C.CudaSparseShortTensorBase, _SparseTensorBase):
+class ShortTensor(_CudaSparseBase, torch._C.CudaSparseShortTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
 
-class CharTensor(_CudaSparseBase, torch._C.CudaSparseCharTensorBase, _SparseTensorBase):
+class CharTensor(_CudaSparseBase, torch._C.CudaSparseCharTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         # TODO
         return False
 
 
-class ByteTensor(_CudaSparseBase, torch._C.CudaSparseByteTensorBase, _SparseTensorBase):
+class ByteTensor(_CudaSparseBase, torch._C.CudaSparseByteTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return False
 
 
-class HalfTensor(_CudaSparseBase, torch._C.CudaSparseHalfTensorBase, _SparseTensorBase):
+class HalfTensor(_CudaSparseBase, torch._C.CudaSparseHalfTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -8,12 +8,23 @@
 
 int THCSTensor_(nDimension)(THCState *state, const THCSTensor *self)
 {
-  return self->nDimension;
+  return self->nDimensionI + self->nDimensionV;
+}
+
+int THCSTensor_(nDimensionI)(THCState *state, const THCSTensor *self)
+{
+  return self->nDimensionI;
+}
+
+int THCSTensor_(nDimensionV)(THCState *state, const THCSTensor *self)
+{
+  return self->nDimensionV;
 }
 
 long THCSTensor_(size)(THCState *state, const THCSTensor *self, int dim)
 {
-  THArgCheck((dim >= 0) && (dim < self->nDimension), 1, "dimension %d out of range of %dD tensor",
+  THArgCheck((dim >= 0) && (dim < self->nDimensionI + self->nDimensionV),
+      1, "dimension %d out of range of %dD tensor",
       dim+1, THCSTensor_(nDimension)(state, self));
   return self->size[dim];
 }
@@ -24,7 +35,7 @@ ptrdiff_t THCSTensor_(nnz)(THCState *state, const THCSTensor *self) {
 
 THLongStorage *THCSTensor_(newSizeOf)(THCState *state, THCSTensor *self)
 {
-  THLongStorage *size = THLongStorage_newWithSize(self->nDimension);
+  THLongStorage *size = THLongStorage_newWithSize(self->nDimensionI + self->nDimensionV);
   THLongStorage_rawCopy(size, self->size);
   return size;
 }
@@ -51,29 +62,38 @@ static void THCSTensor_(rawInit)(THCState *state, THCSTensor *self)
   self->size = NULL;
   self->indices = NULL;
   self->values = NULL;
-  self->nDimension = 0;
+  self->nDimensionI = 0;
+  self->nDimensionV = 0;
   self->contiguous = 0;
   self->nnz = 0;
   // self->flag = TH_TENSOR_REFCOUNTED;
+  self->refcount = 1;
 }
 
-static void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDim, long *size) {
+static void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size) {
   // Only resize valid sizes into tensor.
-  self->size = THRealloc(self->size, sizeof(long)*nDim);
+  self->size = THRealloc(self->size, sizeof(long)*(nDimI + nDimV));
 
-  long d, nDim_ = 0;
-  for (d = 0; d < nDim; d++)
-    if (size[d] > 0)
-      self->size[nDim_++] = size[d];
-  self->nDimension = nDim_;
+  long d, nDimI_ = 0, nDimV_ = 0;
+  for (d = 0; d < nDimI; d++) {
+    if (size[d] > 0) {
+      self->size[nDimI_++] = size[d];
+    }
+  }
+  for (d = nDimI; d < nDimI + nDimV; d++) {
+    if (size[d] > 0) {
+      self->size[nDimI_ + nDimV_++] = size[d];
+    }
+  }
+  self->nDimensionI = nDimI_;
+  self->nDimensionV = nDimV_;
   self->contiguous = 0;
 }
 
 THCSTensor *THCSTensor_(set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values) {
-  THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 2, 1,
+  THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 2, 2,
       "indices must be nDim x nnz");
-  THArgCheck(THCTensor_(nDimension)(state, values) == 1, 2, "values must nnz vector");
-  THArgCheck(THCIndexTensor_(size)(state, indices, 1) == THCTensor_(size)(state, values, 0), 1,
+  THArgCheck(THCIndexTensor_(size)(state, indices, 1) == THCTensor_(size)(state, values, 0), 2,
       "indices and values must have same nnz");
   THCIndexTensor_(free)(state, self->indices);
   THCTensor_(free)(state, self->values);
@@ -102,14 +122,17 @@ THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices,
 
 THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes)
 {  // If sizes are not given, it is inferred as max index of each dim.
-  long nDim;
+  long nDimI, nDimV;
 
   THCSTensor *self = THAlloc(sizeof(THCSTensor));
   THCSTensor_(rawInit)(state, self);
   THCSTensor_(set)(state, self, indices, values);
 
-  nDim = THCIndexTensor_(size)(state, indices, 0);
+  nDimI = THCIndexTensor_(size)(state, indices, 0);
+  nDimV = THCTensor_(nDimension)(state, values) - 1;
   if (!sizes) {
+    // TODO Make it work with N-dimensional values
+    THArgCheck(nDimV > 0, 3, "size must be provided when nDimV > 0");
     THCudaLongTensor *ignore, *s;
     THLongTensor *computed_sizes;
     ignore = THCudaLongTensor_new(state);
@@ -121,14 +144,16 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
     //      Should be fine according to sam's memory manager.
     computed_sizes = THLongTensor_newWithSize(THCudaLongTensor_newSizeOf(state, s), NULL);
     THLongTensor_copyCudaLong(state, computed_sizes, s);
-    THCSTensor_(rawResize)(state, self, nDim, THLongTensor_data(computed_sizes));
+    THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongTensor_data(computed_sizes));
 
     THCudaFree(state, s);
     THCudaFree(state, ignore);
     THLongTensor_free(computed_sizes);
   }
   else {
-    THCSTensor_(rawResize)(state, self, nDim, THLongStorage_data(sizes));
+    THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 3,
+        "number of dimensions must be nDimI + nDimV");
+    THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongStorage_data(sizes));
   }
 
   return self;
@@ -138,7 +163,7 @@ THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size)
 {
   THCSTensor *self = THAlloc(sizeof(THCSTensor));
   THCSTensor_(rawInit)(state, self);
-  THCSTensor_(rawResize)(state, self, size->size, size->data);
+  THCSTensor_(rawResize)(state, self, size->size, 0, size->data);
 
   return self;
 }
@@ -164,14 +189,14 @@ THCSTensor *THCSTensor_(newWithSize4d)(THCState *state, long size0, long size1, 
 
   THCSTensor *self = THAlloc(sizeof(THCSTensor));
   THCSTensor_(rawInit)(state, self);
-  THCSTensor_(rawResize)(state, self, 4, size);
+  THCSTensor_(rawResize)(state, self, 4, 0, size);
 
   return self;
 }
 
 THCSTensor *THCSTensor_(newClone)(THCState *state, THCSTensor *self) {
   THCSTensor *other = THCSTensor_(new)(state);
-  THCSTensor_(rawResize)(state, other, self->nDimension, self->size);
+  THCSTensor_(rawResize)(state, other, self->nDimensionI, self->nDimensionV, self->size);
 
   THCSTensor_(set)(
       state,
@@ -201,9 +226,32 @@ THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self, int d1,
  * reshaping methods
  ******************************************************************************/
 
+int THCSTensor_(isSameSizeAs)(THCState *state, const THCSTensor *self, const THCSTensor* src)
+{
+  int d;
+  if (self->nDimensionI != src->nDimensionI || self->nDimensionV != src->nDimensionV)
+    return 0;
+  for(d = 0; d < self->nDimensionI + self->nDimensionV; ++d)
+  {
+    if(self->size[d] != src->size[d])
+      return 0;
+  }
+  return 1;
+}
+
 THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size)
 {
-  THCSTensor_(rawResize)(state, self, size->size, size->data);
+  THCSTensor_(rawResize)(state, self, size->size, 0, size->data);
+  return self;
+}
+
+THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor *src)
+{
+  if(!THCSTensor_(isSameSizeAs)(state, self, src)) {
+    // TODO the reshaped tensor may contain out of bounds values
+    // We may want to filter them out
+    THCSTensor_(rawResize)(state, self, src->nDimensionI, src->nDimensionV, src->size);
+  }
   return self;
 }
 
@@ -225,7 +273,7 @@ THCSTensor *THCSTensor_(resize3d)(THCState *state, THCSTensor *self, long size0,
 THCSTensor *THCSTensor_(resize4d)(THCState *state, THCSTensor *self, long size0, long size1, long size2, long size3)
 {
   long size[4] = {size0, size1, size2, size3};
-  THCSTensor_(rawResize)(state, self, 4, size);
+  THCSTensor_(rawResize)(state, self, 4, 0, size);
   return self;
 }
 
@@ -237,10 +285,17 @@ void THCSTensor_(free)(THCState *state, THCSTensor *self)
 {
   if(!self)
     return;
+  if(THAtomicDecrementRef(&self->refcount))
+  {
+    THCIndexTensor_(free)(state, self->indices);
+    THCTensor_(free)(state, self->values);
+    THFree(self);
+  }
+}
 
-  THCIndexTensor_(free)(state, self->indices);
-  THCTensor_(free)(state, self->values);
-  THFree(self);
+void THCSTensor_(retain)(THCState *state, THCSTensor *self)
+{
+  THAtomicIncrementRef(&self->refcount);
 }
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -248,8 +248,6 @@ THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage
 THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor *src)
 {
   if(!THCSTensor_(isSameSizeAs)(state, self, src)) {
-    // TODO the reshaped tensor may contain out of bounds values
-    // We may want to filter them out
     THCSTensor_(rawResize)(state, self, src->nDimensionI, src->nDimensionV, src->size);
   }
   return self;
@@ -287,6 +285,7 @@ void THCSTensor_(free)(THCState *state, THCSTensor *self)
     return;
   if(THAtomicDecrementRef(&self->refcount))
   {
+    THFree(self->size);
     THCIndexTensor_(free)(state, self->indices);
     THCTensor_(free)(state, self->values);
     THFree(self);

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -69,4 +69,13 @@ void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
   THError("WARNING: Sparse Cuda Tensor op transpose is not implemented");
 }
 
+int THCSTensor_(getDevice)(THCState* state, const THCSTensor* tensor) {
+  if (!tensor->values || !tensor->values->storage) return -1;
+  return THCStorage_(getDevice)(state, tensor->values->storage);
+}
+
+void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask) {
+  THError("WARNING: Sparse Cuda Tensor op sparseMask is not implemented");
+}
+
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -6,7 +6,8 @@ typedef struct THCSTensor
 {  // Stored in COO format, indices + values
     long *size;
     ptrdiff_t nnz;
-    int nDimension;
+    int nDimensionI; // dimension of indices
+    int nDimensionV; // dimension of values
 
     // 2-D tensor of nDim x nnz of indices. May have nnz dim bigger than nnz
     // as buffer, so we keep track of both
@@ -14,11 +15,14 @@ typedef struct THCSTensor
     THCTensor *values;
     // Math operations can only be performed on ordered sparse tensors
     int contiguous;
+    int refcount;
 
 } THCSTensor;
 
 /**** access methods ****/
 TH_API int THCSTensor_(nDimension)(THCState *state, const THCSTensor *self);
+TH_API int THCSTensor_(nDimensionI)(THCState *state, const THCSTensor *self);
+TH_API int THCSTensor_(nDimensionV)(THCState *state, const THCSTensor *self);
 TH_API long THCSTensor_(size)(THCState *state, const THCSTensor *self, int dim);
 TH_API ptrdiff_t THCSTensor_(nnz)(THCState *state, const THCSTensor *self);
 TH_API THLongStorage *THCSTensor_(newSizeOf)(THCState *state, THCSTensor *self);
@@ -42,6 +46,7 @@ TH_API THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self, 
 
 /**** reshaping methods ***/
 TH_API THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size);
+TH_API THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor *src);
 TH_API THCSTensor *THCSTensor_(resize1d)(THCState *state, THCSTensor *self, long size0);
 TH_API THCSTensor *THCSTensor_(resize2d)(THCState *state, THCSTensor *self, long size0, long size1);
 TH_API THCSTensor *THCSTensor_(resize3d)(THCState *state, THCSTensor *self, long size0, long size1, long size2);
@@ -53,6 +58,12 @@ TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimens
 TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
 TH_API void THCSTensor_(contiguous)(THCState *state, THCSTensor *self);
 
+TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
+
 TH_API void THCSTensor_(free)(THCState *state, THCSTensor *self);
+TH_API void THCSTensor_(retain)(THCState *state, THCSTensor *self);
+
+/* CUDA-specific functions */
+TH_API int THCSTensor_(getDevice)(THCState *state, const THCSTensor *self);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -11,6 +11,18 @@ THCudaLongTensor *THCSTensor_(toCSR)(THCState *state, long const *indices, long 
   return NULL;
 }
 
+void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
+  self->nnz = 0;
+}
+
+void THCTensor_(spaddcmul)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2) {
+  THError("WARNING: Sparse Cuda Tensor op spaddcmul is not implemented");
+}
+
+void THCTensor_(spaddcdiv)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2) {
+  THError("WARNING: Sparse Cuda Tensor op spaddcdiv is not implemented");
+}
+
 void THCSTensor_(spaddmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense) {
   THError("WARNING: Sparse Cuda Tensor op spaddmm is not implemented");
   // TODO This is just a cusparse call (gemm?)
@@ -24,6 +36,26 @@ void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTenso
 void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse) {
   THError("WARNING: Sparse Cuda Tensor op spcadd is not implemented");
   // TODO pretty sure this is also just a cusparse call (axpyi)
+}
+
+void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
+  THError("WARNING: Sparse Cuda Tensor op mul is not implemented");
+}
+
+void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
+  THError("WARNING: Sparse Cuda Tensor op div is not implemented");
+}
+
+void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {
+  THError("WARNING: Sparse Cuda Tensor op cadd is not implemented");
+}
+
+void THCSTensor_(csub)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {
+  THError("WARNING: Sparse Cuda Tensor op csub is not implemented");
+}
+
+void THCSTensor_(cmul)(THCState *state, THCSTensor *r_, THCSTensor *t, THCSTensor *src) {
+  THError("WARNING: Sparse Cuda Tensor op cmul is not implemented");
 }
 
 #undef ROW_PTR2

--- a/torch/lib/THCS/generic/THCSTensorMath.h
+++ b/torch/lib/THCS/generic/THCSTensorMath.h
@@ -10,11 +10,20 @@
  * Everything is is up to discretion
  */
 
+TH_API void THCSTensor_(zero)(THCState *state, THCSTensor *r_);
+
+TH_API void THCTensor_(spaddcmul)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2);
+TH_API void THCTensor_(spaddcdiv)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2);
+
 // dense = beta * dense + alpha * sparse * dense
 TH_API void THCSTensor_(spaddmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense);
 // sparse = beta * sparse + alpha * sparse * dense
 TH_API void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense);
 TH_API void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse);
+TH_API void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value);
+TH_API void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value);
+TH_API void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src);
+TH_API void THCSTensor_(csub)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src);
+TH_API void THCSTensor_(cmul)(THCState *state, THCSTensor *r_, THCSTensor *t, THCSTensor *src);
 
 #endif
-

--- a/torch/lib/THPP/tensors/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/THCSTensor.cpp
@@ -1,0 +1,9 @@
+#include "THCSTensor.hpp"
+#include "../TraitsCuda.hpp"
+
+namespace thpp {
+
+#include "generic/THCSTensor.cpp"
+#include <THCS/THCSGenerateAllTypes.h>
+
+} // namespace thpp

--- a/torch/lib/THPP/tensors/THCSTensor.hpp
+++ b/torch/lib/THPP/tensors/THCSTensor.hpp
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <THCS/THCS.h>
+
+// We're defining THCSTensor as a custom class
+#undef THCSTensor
+#define THCSRealTensor TH_CONCAT_3(THCS,Real,Tensor)
+
+#include "../Tensor.hpp"
+#include "../Traits.hpp"
+
+namespace thpp {
+
+template<typename real>
+struct thcs_tensor_traits {};
+
+#include "tensors/generic/THCSTensor.hpp"
+#include <THCS/THCSGenerateAllTypes.h>
+
+} // namespace thpp
+
+namespace thpp {
+
+template<typename real>
+struct THCSTensor : public interface_traits<real>::tensor_interface_type {
+  friend class THCSTensor<unsigned char>;
+  friend class THCSTensor<char>;
+  friend class THCSTensor<short>;
+  friend class THCSTensor<int>;
+  friend class THCSTensor<long>;
+  friend class THCSTensor<float>;
+  friend class THCSTensor<double>;
+
+private:
+  using interface_type = typename interface_traits<real>::tensor_interface_type;
+public:
+  using tensor_type = typename thcs_tensor_traits<real>::tensor_type;
+  using scalar_type = typename interface_type::scalar_type;
+  using long_range = Tensor::long_range;
+
+  THCSTensor(THCState* state);
+  THCSTensor(THCState* state, tensor_type *wrapped);
+  virtual ~THCSTensor();
+
+  virtual THCSTensor* clone() const override;
+  virtual THCSTensor* clone_shallow() override;
+  virtual std::unique_ptr<Tensor> contiguous() const override;
+
+  virtual int nDim() const override;
+  virtual long_range sizes() const override;
+  virtual long_range strides() const override;
+  virtual const long* rawSizes() const override;
+  virtual const long* rawStrides() const override;
+  virtual std::size_t storageOffset() const override;
+  virtual std::size_t elementSize() const override;
+  virtual long long numel() const override;
+  virtual bool isContiguous() const override;
+  virtual void* data() override;
+  virtual const void* data() const override;
+  virtual void* cdata() override;
+  virtual const void* cdata() const override;
+  virtual THCSTensor& retain() override;
+  virtual THCSTensor& free() override;
+
+  virtual THCSTensor& resize(const std::initializer_list<long>& new_size) override;
+  virtual THCSTensor& resize(const std::vector<long>& new_size) override;
+  virtual THCSTensor& resize(THLongStorage *size,
+                            THLongStorage *stride) override;
+  virtual THCSTensor& resizeAs(const Tensor& src) override;
+  virtual THCSTensor& set(const Tensor& src) override;
+  virtual THCSTensor& setStorage(const Storage& storage,
+                                ptrdiff_t storageOffset,
+                                const long_range& size,
+                                const long_range& stride) override;
+  virtual THCSTensor& setStorage(const Storage& storage,
+                                ptrdiff_t storageOffset,
+                                THLongStorage *size,
+                                THLongStorage *stride) override;
+
+  virtual THCSTensor& narrow(const Tensor& src, int dimension,
+                           long firstIndex, long size) override;
+  virtual THCSTensor& select(const Tensor& src, int dimension,
+                            long sliceIndex) override;
+  virtual THCSTensor& transpose(const Tensor& src, int dimension1,
+                               int dimension2) override;
+  virtual THCSTensor& unfold(const Tensor& src, int dimension,
+                            long size, long step) override;
+  virtual THCSTensor& squeeze(const Tensor& src, int dimension) override;
+  virtual THCSTensor& unsqueeze(const Tensor& src, int dimension) override;
+
+  virtual THCSTensor& diag(const Tensor& src, int k) override;
+  virtual THCSTensor& eye(long n, long m) override;
+  virtual THCSTensor& range(scalar_type xmin, scalar_type xmax,
+                          scalar_type step) override;
+  virtual THCSTensor& sort(const Tensor& ri, const Tensor& src,
+                       int dimension, int desc) override;
+  virtual THCSTensor& topk(const Tensor& ri, const Tensor& src,
+                       long k, int dim, int dir, int sorted) override;
+  virtual THCSTensor& tril(const Tensor& src, long k) override;
+  virtual THCSTensor& triu(const Tensor& src, long k) override;
+  // TODO: remove in favor of cat
+  virtual THCSTensor& catArray(const std::vector<Tensor*>& inputs,
+                             int dimension) override;
+  virtual int equal(const Tensor& other) const override;
+
+  // Note: the order in *Value and *Tensor is reversed compared to
+  // the declarations in TH/generic/THCSTensorMath.h, so for instance
+  // the call THRealTensor_ltTensor(r, ta, tb) is equivalent to
+  // ta->ltTensor(r, tb). It is done this way so that the first
+  // argument can be casted onto a byte tensor type
+  virtual THCSTensor& ltTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& leTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& gtTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& geTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& neTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& eqTensor(const Tensor& r, const Tensor& tb) override;
+  virtual THCSTensor& ltTensorT(const Tensor& ta, const Tensor& tb) override;
+  virtual THCSTensor& leTensorT(const Tensor& ta, const Tensor& tb) override;
+  virtual THCSTensor& gtTensorT(const Tensor& ta, const Tensor& tb) override;
+  virtual THCSTensor& geTensorT(const Tensor& ta, const Tensor& tb) override;
+  virtual THCSTensor& neTensorT(const Tensor& ta, const Tensor& tb) override;
+  virtual THCSTensor& eqTensorT(const Tensor& ta, const Tensor& tb) override;
+
+  virtual THCSTensor& abs(const Tensor& src) override;
+  virtual THCSTensor& sigmoid(const Tensor& src) override;
+  virtual THCSTensor& log(const Tensor& src) override;
+  virtual THCSTensor& log1p(const Tensor& src) override;
+  virtual THCSTensor& exp(const Tensor& src) override;
+  virtual THCSTensor& cos(const Tensor& src) override;
+  virtual THCSTensor& acos(const Tensor& src) override;
+  virtual THCSTensor& cosh(const Tensor& src) override;
+  virtual THCSTensor& sin(const Tensor& src) override;
+  virtual THCSTensor& asin(const Tensor& src) override;
+  virtual THCSTensor& sinh(const Tensor& src) override;
+
+  virtual THCSTensor& ltValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& leValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& gtValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& geValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& neValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& eqValue(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& ltValueT(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& leValueT(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& gtValueT(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& geValueT(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& neValueT(const Tensor& t, scalar_type value) override;
+  virtual THCSTensor& eqValueT(const Tensor& t, scalar_type value) override;
+
+  virtual THCSTensor& fill(scalar_type value) override;
+
+  virtual THCSTensor& copy(const Tensor& src) override;
+  virtual THCSTensor& cat(const std::vector<Tensor*>& src, int dimension) override;
+  virtual THCSTensor& gather(const Tensor& src, int dimension, const Tensor& index) override;
+  virtual THCSTensor& scatter(int dimension, const Tensor& index, const Tensor& src) override;
+  virtual THCSTensor& scatterFill(int dimension, const Tensor& index, scalar_type value) override;
+  virtual scalar_type dot(const Tensor& source) override;
+  virtual scalar_type minall() override;
+  virtual scalar_type maxall() override;
+  virtual scalar_type sumall() override;
+  virtual scalar_type prodall() override;
+  virtual THCSTensor& neg(const Tensor& src) override;
+  virtual THCSTensor& cinv(const Tensor& src) override;
+  virtual THCSTensor& add(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& sub(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& mul(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& div(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& fmod(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& remainder(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& clamp(const Tensor& src, scalar_type min_value, scalar_type max_value) override;
+  virtual THCSTensor& cadd(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cadd(const Tensor& src1, scalar_type value, const Tensor& src2) override;
+  virtual THCSTensor& csub(const Tensor& src1, scalar_type value, const Tensor& src2) override;
+  virtual THCSTensor& cmul(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cpow(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cdiv(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cfmod(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cremainder(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& addcmul(const Tensor& src1, scalar_type value, const Tensor& src2, const Tensor& src3) override;
+  virtual THCSTensor& addcdiv(const Tensor& src1, scalar_type value, const Tensor& src2, const Tensor& src3) override;
+  virtual THCSTensor& addmv(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& mat, const Tensor& vec) override;
+  virtual THCSTensor& addmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& mat1, const Tensor& mat2) override;
+  virtual THCSTensor& addr(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& vec1, const Tensor& vec2) override;
+  virtual THCSTensor& addbmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& batch1, const Tensor& batch2) override;
+  virtual THCSTensor& baddbmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& batch1, const Tensor& batch2) override;
+  virtual THCSTensor& match(const Tensor& m1, const Tensor& m2, scalar_type gain) override;
+  virtual THCSTensor& max(const Tensor& indices_, const Tensor& src, int dimension) override;
+  virtual THCSTensor& min(const Tensor& indices_, const Tensor& src, int dimension) override;
+  virtual THCSTensor& kthvalue(const Tensor& indices_, const Tensor& src, long k, int dimension) override;
+  virtual THCSTensor& mode(const Tensor& indices_, const Tensor& src, int dimension) override;
+  virtual THCSTensor& median(const Tensor& indices_, const Tensor& src, int dimension) override;
+  virtual THCSTensor& sum(const Tensor& src, int dimension) override;
+  virtual THCSTensor& prod(const Tensor& src, int dimension) override;
+  virtual THCSTensor& cumsum(const Tensor& src, int dimension) override;
+  virtual THCSTensor& cumprod(const Tensor& src, int dimension) override;
+  virtual THCSTensor& sign(const Tensor& source) override;
+  virtual scalar_type trace() override;
+  virtual THCSTensor& cross(const Tensor& src1, const Tensor& src2, int dimension) override;
+  virtual THCSTensor& cmax(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cmin(const Tensor& src1, const Tensor& src2) override;
+  virtual THCSTensor& cmaxValue(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& cminValue(const Tensor& src, scalar_type value) override;
+  virtual THCSTensor& zero() override;
+
+  virtual thpp::Type type() const override;
+  virtual bool isCuda() const override;
+  virtual bool isSparse() const override;
+  virtual int getDevice() const override;
+  virtual std::unique_ptr<Tensor> newTensor() const override;
+
+private:
+  template<typename iterator>
+  THCSTensor& resize(const iterator& begin, const iterator& end);
+  template<typename iterator>
+  THCSTensor& resize(const iterator& size_begin, const iterator& size_end,
+                    const iterator& stride_begin, const iterator& stride_end);
+
+public:
+  tensor_type *tensor;
+  THCState *state;
+};
+
+}

--- a/torch/lib/THPP/tensors/THCSTensor.hpp
+++ b/torch/lib/THPP/tensors/THCSTensor.hpp
@@ -23,13 +23,8 @@ namespace thpp {
 
 template<typename real>
 struct THCSTensor : public interface_traits<real>::tensor_interface_type {
-  friend class THCSTensor<unsigned char>;
-  friend class THCSTensor<char>;
-  friend class THCSTensor<short>;
-  friend class THCSTensor<int>;
-  friend class THCSTensor<long>;
-  friend class THCSTensor<float>;
-  friend class THCSTensor<double>;
+  template<typename U>
+  friend struct THCSTensor;
 
 private:
   using interface_type = typename interface_traits<real>::tensor_interface_type;

--- a/torch/lib/THPP/tensors/generic/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.cpp
@@ -1,0 +1,653 @@
+#ifndef THCS_GENERIC_FILE
+#define THCS_GENERIC_FILE "tensors/generic/THCSTensor.cpp"
+#else
+
+template<>
+THCSTensor<real>::THCSTensor(THCState* state):
+  tensor(THCSTensor_(new)(state)), state(state)
+  {};
+
+template<>
+THCSTensor<real>::THCSTensor(THCState* state, THCSRealTensor *wrapped):
+  tensor(wrapped), state(state)
+  {};
+
+template<>
+THCSTensor<real>::~THCSTensor() {
+  if (tensor)
+    THCSTensor_(free)(state, tensor);
+}
+
+template<>
+auto THCSTensor<real>::clone() const -> THCSTensor* {
+  return new THCSTensor(state, THCSTensor_(newClone)(state, tensor));
+}
+
+template<>
+auto THCSTensor<real>::clone_shallow() -> THCSTensor* {
+  THCSTensor_(retain)(state, tensor);
+  return new THCSTensor(state, tensor);
+}
+
+template<>
+auto THCSTensor<real>::contiguous() const -> std::unique_ptr<Tensor> {
+  return std::unique_ptr<Tensor>(new THCSTensor(state, THCSTensor_(newContiguous)(state, tensor)));
+}
+
+template<>
+int THCSTensor<real>::nDim() const {
+  return tensor->nDimensionI;
+}
+
+template<>
+auto THCSTensor<real>::sizes() const -> long_range {
+  return std::vector<long>(tensor->size, tensor->size + tensor->nDimensionI);
+}
+
+template<>
+const long* THCSTensor<real>::rawSizes() const {
+  return tensor->size;
+}
+
+template<>
+auto THCSTensor<real>::strides() const -> long_range {
+  throw std::runtime_error("THCSTensor::strides() not supported");
+}
+
+template<>
+const long* THCSTensor<real>::rawStrides() const {
+  throw std::runtime_error("THCSTensor::rawStrides() not supported");
+}
+
+template<>
+std::size_t THCSTensor<real>::storageOffset() const {
+  throw std::runtime_error("THCSTensor::storageOffset() not supported");
+}
+
+template<>
+std::size_t THCSTensor<real>::elementSize() const {
+  return sizeof(real);
+}
+
+template<>
+long long THCSTensor<real>::numel() const {
+  throw std::runtime_error("THCSTensor::numel not supported");
+}
+
+template<>
+bool THCSTensor<real>::isContiguous() const {
+  throw std::runtime_error("THCSTensor::isContiguous() not supported");
+}
+
+template<>
+void* THCSTensor<real>::data() {
+  throw std::runtime_error("THCSTensor::data() not supported");
+}
+
+template<>
+const void* THCSTensor<real>::data() const {
+  throw std::runtime_error("THCSTensor::data() not supported");
+}
+
+template<>
+void* THCSTensor<real>::cdata() {
+  return tensor;
+}
+
+template<>
+const void* THCSTensor<real>::cdata() const {
+  return tensor;
+}
+
+template<>
+auto THCSTensor<real>::resize(const std::initializer_list<long> &new_size) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::resize() not supported");
+}
+
+template<>
+auto THCSTensor<real>::resize(const std::vector<long> &new_size) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::resize() not supported");
+}
+
+template<>
+auto THCSTensor<real>::resize(THLongStorage *size, THLongStorage *stride) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::resize() not supported");
+}
+
+template<>
+auto THCSTensor<real>::resizeAs(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::resizeAs() not supported");
+}
+
+template<>
+template<typename iterator>
+auto THCSTensor<real>::resize(const iterator& begin, const iterator& end) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::resize() not supported");
+}
+
+template<>
+auto THCSTensor<real>::set(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::set() not supported");
+}
+
+template<>
+auto THCSTensor<real>::setStorage(const Storage& storage,
+                                 ptrdiff_t storageOffset,
+                                 const long_range& size,
+                                 const long_range& stride) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::setStorage not supported");
+}
+
+template<>
+auto THCSTensor<real>::setStorage(const Storage& storage,
+                                 ptrdiff_t storageOffset,
+                                 THLongStorage *size,
+                                 THLongStorage *stride) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::setStorage not supported");
+}
+
+template<>
+auto THCSTensor<real>::narrow(const Tensor& src,
+                             int dimension,
+                             long firstIndex,
+                             long size) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::narrow not supported");
+}
+
+template<>
+auto THCSTensor<real>::select(const Tensor& src, int dimension,
+                             long sliceIndex) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::select not supported");
+}
+
+template<>
+auto THCSTensor<real>::transpose(const Tensor& src, int dimension1,
+                                int dimension2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::transpose not supported");
+}
+
+
+template<>
+auto THCSTensor<real>::unfold(const Tensor& src, int dimension,
+                             long size, long step) ->THCSTensor& {
+  throw std::runtime_error("THCSTensor::unfold not supported");
+}
+
+template<>
+auto THCSTensor<real>::squeeze(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::squeeze not supported");
+}
+
+template<>
+auto THCSTensor<real>::unsqueeze(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::unsqueeze not supported");
+}
+
+#ifdef THCS_REAL_IS_HALF
+#define cast_scalar(v) THC_float2half(v)
+#define uncast_scalar(v) THC_half2float(v)
+#else
+#define cast_scalar(v) v
+#define uncast_scalar(v) v
+#endif
+
+template<>
+auto THCSTensor<real>::fill(scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::fill() not supported");
+}
+
+template<>
+auto THCSTensor<real>::retain() -> THCSTensor& {
+  THCSTensor_(retain)(state, tensor);
+  return *this;
+}
+
+template<>
+auto THCSTensor<real>::free() -> THCSTensor& {
+  THCSTensor_(free)(state, tensor);
+  return *this;
+}
+
+#define non_const_cast(tensor) const_cast<THCSTensor&>(dynamic_cast<const THCSTensor&>(tensor))
+
+template<>
+auto THCSTensor<real>::diag(const Tensor& src, int k) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::diag() not supported");
+}
+
+template<>
+auto THCSTensor<real>::eye(long n, long m) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::eye() not supported");
+}
+
+template<>
+auto THCSTensor<real>::range(scalar_type xmin, scalar_type xmax,
+                           scalar_type step) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::range() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sort(const Tensor& ri, const Tensor& src,
+                          int dimension, int desc) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sort() not supported");
+}
+
+template<>
+auto THCSTensor<real>::topk(const Tensor& ri, const Tensor& src,
+                          long k, int dim, int dir, int sorted) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::topk() not supported");
+}
+
+template<>
+auto THCSTensor<real>::tril(const Tensor& src, long k) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::tril() not supported");
+}
+
+template<>
+auto THCSTensor<real>::triu(const Tensor& src, long k) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::triu() not supported");
+}
+
+template<>
+auto THCSTensor<real>::catArray(const std::vector<Tensor*>& inputs_vec,
+                              int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::catArray() not supported");
+}
+
+template<>
+int THCSTensor<real>::equal(const Tensor& other) const {
+  throw std::runtime_error("THCSTensor::equal() not supported");
+}
+
+  // Note: the order in *Value and *Tensor is reversed compared to
+  // the declarations in TH/generic/THCSTensorMath.h, so for instance
+  // the call THRealTensor_ltTensor(r, ta, tb) is equivalent to
+  // ta->ltTensor(r, tb). It is done this way so that the first
+  // argument can be casted onto a byte tensor type
+
+#define TENSOR_IMPLEMENT_LOGICAL(NAME)                               \
+  template<>                                                         \
+  auto THCSTensor<real>::NAME##Value(const Tensor& r,                \
+                                     scalar_type value) -> THCSTensor& { \
+    throw std::invalid_argument("THCSTensor::" #NAME "Value() not supported"); \
+  }                                                                  \
+                                                                     \
+  template<>                                                         \
+  auto THCSTensor<real>::NAME##ValueT(const Tensor& t,               \
+                                      scalar_type value) -> THCSTensor& { \
+    throw std::invalid_argument("THCSTensor::" #NAME "ValueT() not supported"); \
+  }                                                                  \
+                                                                     \
+  template<>                                                         \
+  auto THCSTensor<real>::NAME##Tensor(const Tensor& r,               \
+                                      const Tensor& tb) -> THCSTensor& { \
+    throw std::invalid_argument("THCSTensor::" #NAME "Tensor() not supported"); \
+  }                                                                  \
+                                                                     \
+  template<>                                                         \
+  auto THCSTensor<real>::NAME##TensorT(const Tensor& ta,             \
+                                       const Tensor& tb) -> THCSTensor& { \
+    throw std::invalid_argument("THCSTensor::" #NAME "TensorT() not supported"); \
+  }                                                                  \
+
+TENSOR_IMPLEMENT_LOGICAL(lt)
+TENSOR_IMPLEMENT_LOGICAL(gt)
+TENSOR_IMPLEMENT_LOGICAL(le)
+TENSOR_IMPLEMENT_LOGICAL(ge)
+TENSOR_IMPLEMENT_LOGICAL(eq)
+TENSOR_IMPLEMENT_LOGICAL(ne)
+
+#undef TENSOR_IMPLEMENT_LOGICAL
+
+
+template<>
+auto THCSTensor<real>::abs(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::abs() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sigmoid(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sigmoid() not supported");
+}
+
+template<>
+auto THCSTensor<real>::log(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::log() not supported");
+}
+
+template<>
+auto THCSTensor<real>::log1p(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::log1p() not supported");
+}
+
+template<>
+auto THCSTensor<real>::exp(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::exp() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cos(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cos() not supported");
+}
+
+template<>
+auto THCSTensor<real>::acos(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::acos() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cosh(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cosh() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sin(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sin() not supported");
+}
+
+template<>
+auto THCSTensor<real>::asin(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::asin() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sinh(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sinh() not supported");
+}
+
+template<>
+auto THCSTensor<real>::copy(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::copy() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cat(const std::vector<Tensor*>& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cat() not supported");
+}
+
+template<>
+auto THCSTensor<real>::gather(const Tensor& src, int dimension, const Tensor& index) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::gather() not supported");
+}
+
+template<>
+auto THCSTensor<real>::scatter(int dimension, const Tensor& index, const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::scatter() not supported");
+}
+
+template<>
+auto THCSTensor<real>::scatterFill(int dimension, const Tensor& index, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::scatterFill() not supported");
+}
+
+template<>
+auto THCSTensor<real>::dot(const Tensor &src) -> scalar_type {
+  throw std::runtime_error("THCSTensor::dot() not supported");
+}
+
+template<>
+auto THCSTensor<real>::minall() -> scalar_type {
+  throw std::runtime_error("THCSTensor::minall() not supported");
+}
+
+template<>
+auto THCSTensor<real>::maxall() -> scalar_type {
+  throw std::runtime_error("THCSTensor::maxall() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sumall() -> scalar_type {
+  throw std::runtime_error("THCSTensor::sumall() not supported");
+}
+
+template<>
+auto THCSTensor<real>::prodall() -> scalar_type {
+  throw std::runtime_error("THCSTensor::prodall() not supported");
+}
+
+template<>
+auto THCSTensor<real>::neg(const Tensor &src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::neg() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cinv(const Tensor &src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cinv() not supported");
+}
+
+template<>
+auto THCSTensor<real>::add(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::add() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sub(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sub() not supported");
+}
+
+template<>
+auto THCSTensor<real>::mul(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::mul() not supported");
+}
+
+template<>
+auto THCSTensor<real>::div(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::div() not supported");
+}
+
+template<>
+auto THCSTensor<real>::fmod(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::fmod() not supported");
+}
+
+template<>
+auto THCSTensor<real>::remainder(const Tensor &src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::remainder() not supported");
+}
+
+template<>
+auto THCSTensor<real>::clamp(const Tensor &src, scalar_type min_value, scalar_type max_value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::clamp() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& src2) -> THCSTensor& {
+  THCSTensor &src1_t = non_const_cast(src1);
+  THCSTensor &src2_t = non_const_cast(src2);
+  THCSTensor_(cadd)(state, tensor, src1_t.tensor, cast_scalar(value), src2_t.tensor);
+  return *this;
+}
+
+template<>
+auto THCSTensor<real>::cadd(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  return cadd(src1, static_cast<scalar_type>(1), src2);
+  throw std::runtime_error("THCSTensor::cadd() not supported");
+}
+
+template<>
+auto THCSTensor<real>::csub(const Tensor& src1, scalar_type value, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::csub() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cmul(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  THCSTensor &src1_t = non_const_cast(src1);
+  THCSTensor &src2_t = non_const_cast(src2);
+  THCSTensor_(cmul)(state, tensor, src1_t.tensor, src2_t.tensor);
+  return *this;
+}
+
+template<>
+auto THCSTensor<real>::cpow(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cpow() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cdiv(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cdiv() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cfmod(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cfmod() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cremainder(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cremainder() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addcmul(const Tensor& src1, scalar_type value, const Tensor& src2, const Tensor& src3) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addcmul() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addcdiv(const Tensor& src1, scalar_type value, const Tensor& src2, const Tensor& src3) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addcdiv() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addmv(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& mat, const Tensor& vec) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addmv() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& mat1, const Tensor& mat2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addmm() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addr(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& vec1, const Tensor& vec2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addr() not supported");
+}
+
+template<>
+auto THCSTensor<real>::addbmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& batch1, const Tensor& batch2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::addbmm() not supported");
+}
+
+template<>
+auto THCSTensor<real>::baddbmm(scalar_type beta, const Tensor& src, scalar_type alpha, const Tensor& batch1, const Tensor& batch2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::baddbmm() not supported");
+}
+
+template<>
+auto THCSTensor<real>::match(const Tensor& m1, const Tensor& m2, scalar_type gain) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::match() not supported");
+}
+
+template<>
+auto THCSTensor<real>::max(const Tensor& indices_, const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::max() not supported");
+}
+
+template<>
+auto THCSTensor<real>::min(const Tensor& indices_, const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::min() not supported");
+}
+
+template<>
+auto THCSTensor<real>::kthvalue(const Tensor& indices_, const Tensor& src, long k, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::kthvalue() not supported");
+}
+
+template<>
+auto THCSTensor<real>::mode(const Tensor& indices_, const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::mode() not supported");
+}
+
+template<>
+auto THCSTensor<real>::median(const Tensor& indices_, const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::median() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sum(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sum() not supported");
+}
+
+template<>
+auto THCSTensor<real>::prod(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::prod() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cumsum(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cumsum() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cumprod(const Tensor& src, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cumprod() not supported");
+}
+
+template<>
+auto THCSTensor<real>::sign(const Tensor& src) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::sign() not supported");
+}
+
+template<>
+auto THCSTensor<real>::trace() -> scalar_type {
+  throw std::runtime_error("THCSTensor::trace() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cross(const Tensor& src1, const Tensor& src2, int dimension) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cross() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cmax(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cmax() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cmin(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cmin() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cmaxValue(const Tensor& src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cmaxValue() not supported");
+}
+
+template<>
+auto THCSTensor<real>::cminValue(const Tensor& src, scalar_type value) -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::cminValue() not supported");
+}
+
+template<>
+auto THCSTensor<real>::zero() -> THCSTensor& {
+  throw std::runtime_error("THCSTensor::zero() not supported");
+}
+
+template<>
+thpp::Type THCSTensor<real>::type() const {
+  return thpp::type_traits<real>::type;
+}
+
+template<>
+bool THCSTensor<real>::isCuda() const {
+  return false;
+}
+
+template<>
+bool THCSTensor<real>::isSparse() const {
+  return true;
+}
+
+template<>
+int THCSTensor<real>::getDevice() const {
+  return -1;
+}
+
+template<>
+std::unique_ptr<Tensor> THCSTensor<real>::newTensor() const {
+  return std::unique_ptr<Tensor>(new THCSTensor<real>(state));
+}
+
+#undef cast_scalar
+#undef uncast_scalar
+
+#endif

--- a/torch/lib/THPP/tensors/generic/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.cpp
@@ -2,6 +2,16 @@
 #define THCS_GENERIC_FILE "tensors/generic/THCSTensor.cpp"
 #else
 
+#define const_tensor_cast(tensor) \
+  dynamic_cast<const THCSTensor&>(tensor)
+#define const_storage_cast(storage) \
+  dynamic_cast<const THCStorage<real>&>(storage)
+#define const_long_cast(tensor) \
+  dynamic_cast<const THCSTensor<long>&>(tensor)
+#define const_byte_cast(tensor) \
+  dynamic_cast<const THCSTensor<unsigned char>&>(tensor)
+
+
 template<>
 THCSTensor<real>::THCSTensor(THCState* state):
   tensor(THCSTensor_(new)(state)), state(state)
@@ -207,8 +217,6 @@ auto THCSTensor<real>::free() -> THCSTensor& {
   THCSTensor_(free)(state, tensor);
   return *this;
 }
-
-#define non_const_cast(tensor) const_cast<THCSTensor&>(dynamic_cast<const THCSTensor&>(tensor))
 
 template<>
 auto THCSTensor<real>::diag(const Tensor& src, int k) -> THCSTensor& {
@@ -452,8 +460,8 @@ auto THCSTensor<real>::clamp(const Tensor &src, scalar_type min_value, scalar_ty
 
 template<>
 auto THCSTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& src2) -> THCSTensor& {
-  THCSTensor &src1_t = non_const_cast(src1);
-  THCSTensor &src2_t = non_const_cast(src2);
+  const THCSTensor &src1_t = const_tensor_cast(src1);
+  const THCSTensor &src2_t = const_tensor_cast(src2);
   THCSTensor_(cadd)(state, tensor, src1_t.tensor, cast_scalar(value), src2_t.tensor);
   return *this;
 }
@@ -471,8 +479,8 @@ auto THCSTensor<real>::csub(const Tensor& src1, scalar_type value, const Tensor&
 
 template<>
 auto THCSTensor<real>::cmul(const Tensor& src1, const Tensor& src2) -> THCSTensor& {
-  THCSTensor &src1_t = non_const_cast(src1);
-  THCSTensor &src2_t = non_const_cast(src2);
+  const THCSTensor &src1_t = const_tensor_cast(src1);
+  const THCSTensor &src2_t = const_tensor_cast(src2);
   THCSTensor_(cmul)(state, tensor, src1_t.tensor, src2_t.tensor);
   return *this;
 }

--- a/torch/lib/THPP/tensors/generic/THCSTensor.hpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.hpp
@@ -1,0 +1,10 @@
+#ifndef THCS_GENERIC_FILE
+#define THCS_GENERIC_FILE "tensors/generic/THCSTensor.hpp"
+#else
+
+template<>
+struct thcs_tensor_traits<real> {
+  using tensor_type = THCSRealTensor;
+};
+
+#endif

--- a/torch/lib/THPP/tensors/generic/THSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THSTensor.cpp
@@ -36,12 +36,12 @@ auto THSTensor<real>::contiguous() const -> std::unique_ptr<Tensor> {
 
 template<>
 int THSTensor<real>::nDim() const {
-  return tensor->nDimension;
+  return tensor->nDimensionI;
 }
 
 template<>
 auto THSTensor<real>::sizes() const -> long_range {
-  return std::vector<long>(tensor->size, tensor->size + tensor->nDimension);
+  return std::vector<long>(tensor->size, tensor->size + tensor->nDimensionI);
 }
 
 template<>
@@ -91,12 +91,12 @@ const void* THSTensor<real>::data() const {
 
 template<>
 void* THSTensor<real>::cdata() {
-  throw std::runtime_error("THSTensor::cdata() not supported");
+  return tensor;
 }
 
 template<>
 const void* THSTensor<real>::cdata() const {
-  throw std::runtime_error("THSTensor::cdata() not supported");
+  return tensor;
 }
 
 template<>
@@ -199,6 +199,8 @@ auto THSTensor<real>::free() -> THSTensor& {
   THSTensor_(free)(tensor);
   return *this;
 }
+
+#define non_const_cast(tensor) const_cast<THSTensor&>(dynamic_cast<const THSTensor&>(tensor))
 
 template<>
 auto THSTensor<real>::diag(const Tensor& src, int k) -> THSTensor& {
@@ -442,11 +444,15 @@ auto THSTensor<real>::clamp(const Tensor &src, scalar_type min_value, scalar_typ
 
 template<>
 auto THSTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& src2) -> THSTensor& {
-  throw std::runtime_error("THSTensor::cadd() not supported");
+  THSTensor &src1_t = non_const_cast(src1);
+  THSTensor &src2_t = non_const_cast(src2);
+  THSTensor_(cadd)(tensor, src1_t.tensor, value, src2_t.tensor);
+  return *this;
 }
 
 template<>
 auto THSTensor<real>::cadd(const Tensor& src1, const Tensor& src2) -> THSTensor& {
+  return cadd(src1, static_cast<scalar_type>(1), src2);
   throw std::runtime_error("THSTensor::cadd() not supported");
 }
 
@@ -457,7 +463,10 @@ auto THSTensor<real>::csub(const Tensor& src1, scalar_type value, const Tensor& 
 
 template<>
 auto THSTensor<real>::cmul(const Tensor& src1, const Tensor& src2) -> THSTensor& {
-  throw std::runtime_error("THSTensor::cmul() not supported");
+  THSTensor &src1_t = non_const_cast(src1);
+  THSTensor &src2_t = non_const_cast(src2);
+  THSTensor_(cmul)(tensor, src1_t.tensor, src2_t.tensor);
+  return *this;
 }
 
 template<>
@@ -467,7 +476,10 @@ auto THSTensor<real>::cpow(const Tensor& src1, const Tensor& src2) -> THSTensor&
 
 template<>
 auto THSTensor<real>::cdiv(const Tensor& src1, const Tensor& src2) -> THSTensor& {
-  throw std::runtime_error("THSTensor::cdiv() not supported");
+  THSTensor &src1_t = non_const_cast(src1);
+  THSTensor &src2_t = non_const_cast(src2);
+  THSTensor_(cdiv)(tensor, src1_t.tensor, src2_t.tensor);
+  return *this;
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THSTensor.cpp
@@ -2,6 +2,15 @@
 #define THS_GENERIC_FILE "tensors/generic/THSTensor.cpp"
 #else
 
+#define const_tensor_cast(tensor) \
+  dynamic_cast<const THSTensor&>(tensor)
+#define const_storage_cast(storage) \
+  dynamic_cast<const THStorage<real>&>(storage)
+#define const_long_cast(tensor) \
+  dynamic_cast<const THSTensor<long>&>(tensor)
+#define const_byte_cast(tensor) \
+  dynamic_cast<const THSTensor<unsigned char>&>(tensor)
+
 template<>
 THSTensor<real>::THSTensor():
   tensor(THSTensor_(new)())
@@ -199,8 +208,6 @@ auto THSTensor<real>::free() -> THSTensor& {
   THSTensor_(free)(tensor);
   return *this;
 }
-
-#define non_const_cast(tensor) const_cast<THSTensor&>(dynamic_cast<const THSTensor&>(tensor))
 
 template<>
 auto THSTensor<real>::diag(const Tensor& src, int k) -> THSTensor& {
@@ -419,12 +426,16 @@ auto THSTensor<real>::sub(const Tensor &src, scalar_type value) -> THSTensor& {
 
 template<>
 auto THSTensor<real>::mul(const Tensor &src, scalar_type value) -> THSTensor& {
-  throw std::runtime_error("THSTensor::mul() not supported");
+  const THSTensor &src_t = const_tensor_cast(src);
+  THSTensor_(mul)(tensor, src_t.tensor, value);
+  return *this;
 }
 
 template<>
 auto THSTensor<real>::div(const Tensor &src, scalar_type value) -> THSTensor& {
-  throw std::runtime_error("THSTensor::div() not supported");
+  const THSTensor &src_t = const_tensor_cast(src);
+  THSTensor_(div)(tensor, src_t.tensor, value);
+  return *this;
 }
 
 template<>
@@ -444,8 +455,8 @@ auto THSTensor<real>::clamp(const Tensor &src, scalar_type min_value, scalar_typ
 
 template<>
 auto THSTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& src2) -> THSTensor& {
-  THSTensor &src1_t = non_const_cast(src1);
-  THSTensor &src2_t = non_const_cast(src2);
+  const THSTensor &src1_t = const_tensor_cast(src1);
+  const THSTensor &src2_t = const_tensor_cast(src2);
   THSTensor_(cadd)(tensor, src1_t.tensor, value, src2_t.tensor);
   return *this;
 }
@@ -463,8 +474,8 @@ auto THSTensor<real>::csub(const Tensor& src1, scalar_type value, const Tensor& 
 
 template<>
 auto THSTensor<real>::cmul(const Tensor& src1, const Tensor& src2) -> THSTensor& {
-  THSTensor &src1_t = non_const_cast(src1);
-  THSTensor &src2_t = non_const_cast(src2);
+  const THSTensor &src1_t = const_tensor_cast(src1);
+  const THSTensor &src2_t = const_tensor_cast(src2);
   THSTensor_(cmul)(tensor, src1_t.tensor, src2_t.tensor);
   return *this;
 }
@@ -476,10 +487,7 @@ auto THSTensor<real>::cpow(const Tensor& src1, const Tensor& src2) -> THSTensor&
 
 template<>
 auto THSTensor<real>::cdiv(const Tensor& src1, const Tensor& src2) -> THSTensor& {
-  THSTensor &src1_t = non_const_cast(src1);
-  THSTensor &src2_t = non_const_cast(src2);
-  THSTensor_(cdiv)(tensor, src1_t.tensor, src2_t.tensor);
-  return *this;
+  throw std::runtime_error("THSTensor::cdiv() not supported");
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THSTensor.cpp
@@ -464,7 +464,6 @@ auto THSTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& 
 template<>
 auto THSTensor<real>::cadd(const Tensor& src1, const Tensor& src2) -> THSTensor& {
   return cadd(src1, static_cast<scalar_type>(1), src2);
-  throw std::runtime_error("THSTensor::cadd() not supported");
 }
 
 template<>

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -375,6 +375,7 @@ void THSTensor_(addSlice)(
   THTensor *dst, THTensor *src1, real value, THTensor *src2,
   long dim, long dstIdx, long src1Idx, long src2Idx) {
   if (src1->nDimension > 1) {
+    THTensor_(select)(src1Buffer, src1, dim, src1Idx);
     THTensor_(select)(src2Buffer, src2, dim, src2Idx);
     THTensor_(select)(dstBuffer, dst, dim, dstIdx);
     THTensor_(cadd)(dstBuffer, src1Buffer, value, src2Buffer);

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -6,7 +6,8 @@ typedef struct THSTensor
 {  // Stored in COO format, indices + values
     long *size;
     ptrdiff_t nnz;
-    int nDimension;
+    int nDimensionI; // dimension of indices
+    int nDimensionV; // dimension of values
 
     // 2-D tensor of nDim x nnz of indices. May have nnz dim bigger than nnz
     // as buffer, so we keep track of both
@@ -20,6 +21,8 @@ typedef struct THSTensor
 
 /**** access methods ****/
 TH_API int THSTensor_(nDimension)(const THSTensor *self);
+TH_API int THSTensor_(nDimensionI)(const THSTensor *self);
+TH_API int THSTensor_(nDimensionV)(const THSTensor *self);
 TH_API long THSTensor_(size)(const THSTensor *self, int dim);
 TH_API ptrdiff_t THSTensor_(nnz)(const THSTensor *self);
 TH_API THLongStorage *THSTensor_(newSizeOf)(THSTensor *self);
@@ -43,16 +46,21 @@ TH_API THSTensor *THSTensor_(newTranspose)(THSTensor *self, int dimension1_, int
 
 /**** reshaping methods ***/
 TH_API THSTensor *THSTensor_(resize)(THSTensor *self, THLongStorage *size);
+TH_API THSTensor *THSTensor_(resizeAs)(THSTensor *self, THSTensor *src);
 TH_API THSTensor *THSTensor_(resize1d)(THSTensor *self, long size0);
 TH_API THSTensor *THSTensor_(resize2d)(THSTensor *self, long size0, long size1);
 TH_API THSTensor *THSTensor_(resize3d)(THSTensor *self, long size0, long size1, long size2);
 TH_API THSTensor *THSTensor_(resize4d)(THSTensor *self, long size0, long size1, long size2, long size3);
 
 TH_API THTensor *THSTensor_(toDense)(THSTensor *self);
+TH_API void THSTensor_(copy)(THSTensor *self, THSTensor *src);
 
 TH_API void THSTensor_(transpose)(THSTensor *self, int dimension1_, int dimension2_);
 TH_API int THSTensor_(isContiguous)(const THSTensor *self);
+TH_API int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor *src);
 TH_API void THSTensor_(contiguous)(THSTensor *self);
+
+TH_API void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask);
 
 TH_API void THSTensor_(free)(THSTensor *self);
 TH_API void THSTensor_(retain)(THSTensor *self);
@@ -64,5 +72,9 @@ TH_API void THSTensor_(freeCopyTo)(THSTensor *self, THSTensor *dst);
 TH_API void THSTensor_(narrow)(THSTensor *self, THSTensor *src, int dimension_, long firstIndex_, long size_);
 TH_API void THSTensor_(select)(THSTensor *self, THSTensor *src, int dimension_, long sliceIndex_);
 */
+
+// internal methods
+THSTensor* THSTensor_(move)(THSTensor *self, THLongTensor *indices, THTensor *values);
+THSTensor* THSTensor_(set)(THSTensor *self, THLongTensor *indices, THTensor *values);
 
 #endif

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -75,6 +75,6 @@ TH_API void THSTensor_(select)(THSTensor *self, THSTensor *src, int dimension_, 
 
 // internal methods
 THSTensor* THSTensor_(move)(THSTensor *self, THLongTensor *indices, THTensor *values);
-THSTensor* THSTensor_(set)(THSTensor *self, THLongTensor *indices, THTensor *values);
+THSTensor* THSTensor_(_set)(THSTensor *self, THLongTensor *indices, THTensor *values);
 
 #endif

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -6,6 +6,12 @@
 #define COL_PTR2(t, c) (THTensor_(data)(t) + (c) * (t)->stride[1])
 
 void THSTensor_(zero)(THSTensor *self) {
+    if (self->indices->nDimension) {
+      THLongTensor_resizeNd(self->indices, 0, NULL, NULL);
+    }
+    if (self->values->nDimension) {
+      THTensor_(resizeNd)(self->values, 0, NULL, NULL);
+    }
   self->nnz = 0;
 }
 

--- a/torch/lib/THS/generic/THSTensorMath.h
+++ b/torch/lib/THS/generic/THSTensorMath.h
@@ -10,6 +10,20 @@
  * Everything is is up to discretion
  */
 
+TH_API void THSTensor_(zero)(THSTensor *r_);
+TH_API void THSTensor_(sqrt)(THSTensor *r_, THSTensor *t);
+TH_API void THSTensor_(rsqrt)(THSTensor *r_, THSTensor *t);
+
+TH_API void THSTensor_(add)(THSTensor *r_, THSTensor *t, real value);
+TH_API void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value);
+TH_API void THSTensor_(div)(THSTensor *r_, THSTensor *t, real value);
+TH_API void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src);
+TH_API void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src);
+TH_API void THSTensor_(cdiv)(THSTensor *r_, THSTensor *t, THSTensor *src);
+
+TH_API void THTensor_(spaddcmul)(THTensor *r_, THTensor *t, real value, THSTensor *src1, THSTensor *src2);
+TH_API void THTensor_(spaddcdiv)(THTensor *r_, THTensor *t, real value, THSTensor *src1, THSTensor *src2);
+
 // dense = beta * dense + alpha * sparse * dense
 TH_API void THSTensor_(spaddmm)(THTensor *r_, real beta, THTensor *t, real alpha, THSTensor *sparse, THTensor *dense);
 // sparse = beta * sparse + alpha * sparse * dense
@@ -17,4 +31,3 @@ TH_API void THSTensor_(sspaddmm)(THSTensor *r_, real beta, THSTensor *t, real al
 TH_API void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse);
 
 #endif
-

--- a/torch/lib/THS/generic/THSTensorMath.h
+++ b/torch/lib/THS/generic/THSTensorMath.h
@@ -11,18 +11,14 @@
  */
 
 TH_API void THSTensor_(zero)(THSTensor *r_);
-TH_API void THSTensor_(sqrt)(THSTensor *r_, THSTensor *t);
-TH_API void THSTensor_(rsqrt)(THSTensor *r_, THSTensor *t);
 
-TH_API void THSTensor_(add)(THSTensor *r_, THSTensor *t, real value);
 TH_API void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value);
 TH_API void THSTensor_(div)(THSTensor *r_, THSTensor *t, real value);
 TH_API void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src);
+TH_API void THSTensor_(csub)(THSTensor *r_, THSTensor *t, real value, THSTensor *src);
 TH_API void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src);
-TH_API void THSTensor_(cdiv)(THSTensor *r_, THSTensor *t, THSTensor *src);
 
 TH_API void THTensor_(spaddcmul)(THTensor *r_, THTensor *t, real value, THSTensor *src1, THSTensor *src2);
-TH_API void THTensor_(spaddcdiv)(THTensor *r_, THTensor *t, real value, THSTensor *src1, THSTensor *src2);
 
 // dense = beta * dense + alpha * sparse * dense
 TH_API void THSTensor_(spaddmm)(THTensor *r_, real beta, THTensor *t, real alpha, THSTensor *sparse, THTensor *dense);

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -37,6 +37,8 @@ class Adadelta(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -48,6 +48,8 @@ class Adagrad(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -40,6 +40,8 @@ class Adam(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -38,6 +38,8 @@ class Adamax(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -38,6 +38,8 @@ class ASGD(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -132,7 +132,8 @@ class Optimizer(object):
         """Clears the gradients of all optimized :class:`Variable` s."""
         for group in self.param_groups:
             for param in group['params']:
-                param.grad.data.zero_()
+                if param.grad is not None:
+                    param.grad.data.zero_()
 
     def step(self, closure):
         """Performs a single optimization step (parameter update).

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -32,6 +32,8 @@ class RMSprop(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -32,6 +32,8 @@ class Rprop(Optimizer):
 
         for group in self.param_groups:
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -56,6 +56,8 @@ class SGD(Optimizer):
             nesterov = group['nesterov']
 
             for p in group['params']:
+                if p.grad is None:
+                    continue
                 d_p = p.grad.data
                 if weight_decay != 0:
                     d_p.add_(weight_decay, p.data)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -1,52 +1,90 @@
 import torch
 from torch import _C
-
-import sys
+from .._utils import _type, _cuda
 
 _sparse_tensor_classes = set()
 
 
-class DoubleTensor(_C.SparseDoubleTensorBase):
+class _SparseTensorBase(object):
+    is_cuda = False
+    is_sparse = True
 
+    def double(self):
+        """Casts this tensor to double type"""
+        return self.type(type(self).__module__ + '.DoubleTensor')
+
+    def float(self):
+        """Casts this tensor to float type"""
+        return self.type(type(self).__module__ + '.FloatTensor')
+
+    def half(self):
+        """Casts this tensor to half-precision float type"""
+        return self.type(type(self).__module__ + '.HalfTensor')
+
+    def long(self):
+        """Casts this tensor to long type"""
+        return self.type(type(self).__module__ + '.LongTensor')
+
+    def int(self):
+        """Casts this tensor to int type"""
+        return self.type(type(self).__module__ + '.IntTensor')
+
+    def short(self):
+        """Casts this tensor to short type"""
+        return self.type(type(self).__module__ + '.ShortTensor')
+
+    def char(self):
+        """Casts this tensor to char type"""
+        return self.type(type(self).__module__ + '.CharTensor')
+
+    def byte(self):
+        """Casts this tensor to byte type"""
+        return self.type(type(self).__module__ + '.ByteTensor')
+
+    def __deepcopy__(self, _memo):
+        memo = _memo.setdefault('torch', {})
+        if self._cdata in memo:
+            return memo[self._cdata]
+        new_tensor = self.clone()
+        memo[self._cdata] = new_tensor
+        return new_tensor
+
+
+class DoubleTensor(_SparseTensorBase, _C.SparseDoubleTensorBase):
     def is_signed(self):
         return True
 
 
-class FloatTensor(_C.SparseFloatTensorBase):
-
+class FloatTensor(_SparseTensorBase, _C.SparseFloatTensorBase):
     def is_signed(self):
         return True
 
 
-class LongTensor(_C.SparseLongTensorBase):
-
+class LongTensor(_SparseTensorBase, _C.SparseLongTensorBase):
     def is_signed(self):
         return True
 
 
-class IntTensor(_C.SparseIntTensorBase):
-
+class IntTensor(_SparseTensorBase, _C.SparseIntTensorBase):
     def is_signed(self):
         return True
 
 
-class ShortTensor(_C.SparseShortTensorBase):
-
+class ShortTensor(_SparseTensorBase, _C.SparseShortTensorBase):
     def is_signed(self):
         return True
 
 
-class CharTensor(_C.SparseCharTensorBase):
-
+class CharTensor(_SparseTensorBase, _C.SparseCharTensorBase):
     def is_signed(self):
         # TODO
         return False
 
 
-class ByteTensor(_C.SparseByteTensorBase):
-
+class ByteTensor(_SparseTensorBase, _C.SparseByteTensorBase):
     def is_signed(self):
         return False
+
 
 _sparse_tensor_classes.add(DoubleTensor)
 _sparse_tensor_classes.add(FloatTensor)
@@ -56,5 +94,8 @@ _sparse_tensor_classes.add(ShortTensor)
 _sparse_tensor_classes.add(CharTensor)
 _sparse_tensor_classes.add(ByteTensor)
 torch._tensor_classes.update(_sparse_tensor_classes)
+
+_SparseTensorBase.type = _type
+_SparseTensorBase.cuda = _cuda
 
 _C._sparse_init()

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -132,6 +132,10 @@ class _SparseBase(object):
     def __ixor__(self, other):
         raise NotImplementedError
 
+    def __str__(self):
+        return '{} with indices:\n{}and values:\n{}'.format(
+            self.__class__.__name__, self.indices(), self.values())
+
 
 class DoubleTensor(_SparseBase, _C.SparseDoubleTensorBase, _TensorBase):
     def is_signed(self):

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -49,6 +49,33 @@ class _SparseTensorBase(object):
         memo[self._cdata] = new_tensor
         return new_tensor
 
+    def __add__(self, other):
+        return self.add(other)
+    __radd__ = __add__
+
+    def __iadd__(self, other):
+        return self.add_(other)
+
+    def __sub__(self, other):
+        return self.sub(other)
+
+    def __isub__(self, other):
+        return self.sub_(other)
+
+    def __mul__(self, other):
+        return self.mul(other)
+    __rmul__ = __mul__
+
+    def __imul__(self, other):
+        return self.mul_(other)
+
+    def __div__(self, other):
+        return self.div(other)
+    __truediv__ = __div__
+
+    def __idiv__(self, other):
+        return self.div_(other)
+
 
 class DoubleTensor(_SparseTensorBase, _C.SparseDoubleTensorBase):
     def is_signed(self):

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -1,45 +1,28 @@
 import torch
 from torch import _C
-from .._utils import _type, _cuda
+from ..tensor import _TensorBase
 
 _sparse_tensor_classes = set()
 
 
-class _SparseTensorBase(object):
+class _SparseBase(object):
     is_cuda = False
     is_sparse = True
 
-    def double(self):
-        """Casts this tensor to double type"""
-        return self.type(type(self).__module__ + '.DoubleTensor')
+    def cpu(self):
+        return self.type(getattr(torch.sparse, self.__class__.__name__))
 
-    def float(self):
-        """Casts this tensor to float type"""
-        return self.type(type(self).__module__ + '.FloatTensor')
+    def is_pinned(self):
+        raise NotImplementedError
 
-    def half(self):
-        """Casts this tensor to half-precision float type"""
-        return self.type(type(self).__module__ + '.HalfTensor')
+    def pin_memory(self):
+        raise NotImplementedError
 
-    def long(self):
-        """Casts this tensor to long type"""
-        return self.type(type(self).__module__ + '.LongTensor')
+    def share_memory_(self):
+        raise NotImplementedError
 
-    def int(self):
-        """Casts this tensor to int type"""
-        return self.type(type(self).__module__ + '.IntTensor')
-
-    def short(self):
-        """Casts this tensor to short type"""
-        return self.type(type(self).__module__ + '.ShortTensor')
-
-    def char(self):
-        """Casts this tensor to char type"""
-        return self.type(type(self).__module__ + '.CharTensor')
-
-    def byte(self):
-        """Casts this tensor to byte type"""
-        return self.type(type(self).__module__ + '.ByteTensor')
+    def is_shared(self):
+        raise NotImplementedError
 
     def __deepcopy__(self, _memo):
         memo = _memo.setdefault('torch', {})
@@ -49,66 +32,139 @@ class _SparseTensorBase(object):
         memo[self._cdata] = new_tensor
         return new_tensor
 
-    def __add__(self, other):
-        return self.add(other)
-    __radd__ = __add__
+    def __reduce__(self):
+        raise NotImplementedError
 
-    def __iadd__(self, other):
-        return self.add_(other)
+    def __getstate__(self):
+        raise NotImplementedError
 
-    def __sub__(self, other):
-        return self.sub(other)
+    def __setstate__(self, state):
+        raise NotImplementedError
 
-    def __isub__(self, other):
-        return self.sub_(other)
+    def __bool__(self):
+        # TODO (easy) implement numel and remove this override
+        raise NotImplementedError
 
-    def __mul__(self, other):
-        return self.mul(other)
-    __rmul__ = __mul__
+    def __iter__(self):
+        raise NotImplementedError
 
-    def __imul__(self, other):
-        return self.mul_(other)
+    def split(self, split_size, dim=0):
+        raise NotImplementedError
 
-    def __div__(self, other):
-        return self.div(other)
-    __truediv__ = __div__
+    def chunk(self, n_chunks, dim=0):
+        raise NotImplementedError
+
+    def tolist(self):
+        raise NotImplementedError
+
+    def view_as(self, tensor):
+        raise NotImplementedError
+
+    def permute(self, *dims):
+        raise NotImplementedError
+
+    def expand(self, *sizes):
+        raise NotImplementedError
+
+    def expand_as(self, tensor):
+        raise NotImplementedError
+
+    def repeat(self, *sizes):
+        raise NotImplementedError
+
+    def __rsub__(self, other):
+        raise NotImplementedError
+
+    def __matmul__(self, other):
+        raise NotImplementedError
+
+    def __pow__(self, other):
+        raise NotImplementedError
+
+    def __ipow__(self, other):
+        raise NotImplementedError
+
+    def __rdiv__(self, other):
+        raise NotImplementedError
 
     def __idiv__(self, other):
-        return self.div_(other)
+        raise NotImplementedError
+
+    def __mod__(self, other):
+        raise NotImplementedError
+
+    def __neg__(self):
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        raise NotImplementedError
+
+    def __ne__(self, other):
+        raise NotImplementedError
+
+    def __lt__(self, other):
+        raise NotImplementedError
+
+    def __le__(self, other):
+        raise NotImplementedError
+
+    def __gt__(self, other):
+        raise NotImplementedError
+
+    def __ge__(self, other):
+        raise NotImplementedError
+
+    def __and__(self, other):
+        raise NotImplementedError
+
+    def __or__(self, other):
+        raise NotImplementedError
+
+    def __xor__(self, other):
+        raise NotImplementedError
+
+    def __iand__(self, other):
+        raise NotImplementedError
+
+    def __ior__(self, other):
+        raise NotImplementedError
+
+    def __ixor__(self, other):
+        raise NotImplementedError
 
 
-class DoubleTensor(_SparseTensorBase, _C.SparseDoubleTensorBase):
+class DoubleTensor(_SparseBase, _C.SparseDoubleTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
 
-class FloatTensor(_SparseTensorBase, _C.SparseFloatTensorBase):
+class FloatTensor(_SparseBase, _C.SparseFloatTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
 
-class LongTensor(_SparseTensorBase, _C.SparseLongTensorBase):
+class LongTensor(_SparseBase, _C.SparseLongTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
 
-class IntTensor(_SparseTensorBase, _C.SparseIntTensorBase):
+class IntTensor(_SparseBase, _C.SparseIntTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
 
-class ShortTensor(_SparseTensorBase, _C.SparseShortTensorBase):
+class ShortTensor(_SparseBase, _C.SparseShortTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
 
-class CharTensor(_SparseTensorBase, _C.SparseCharTensorBase):
+class CharTensor(_SparseBase, _C.SparseCharTensorBase, _TensorBase):
     def is_signed(self):
         # TODO
         return False
 
 
-class ByteTensor(_SparseTensorBase, _C.SparseByteTensorBase):
+class ByteTensor(_SparseBase, _C.SparseByteTensorBase, _TensorBase):
     def is_signed(self):
         return False
 
@@ -121,8 +177,5 @@ _sparse_tensor_classes.add(ShortTensor)
 _sparse_tensor_classes.add(CharTensor)
 _sparse_tensor_classes.add(ByteTensor)
 torch._tensor_classes.update(_sparse_tensor_classes)
-
-_SparseTensorBase.type = _type
-_SparseTensorBase.cuda = _cuda
 
 _C._sparse_init()

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -4,6 +4,7 @@ from ._utils import _type, _cuda, _range
 
 class _StorageBase(object):
     is_cuda = False
+    is_sparse = False
 
     def __str__(self):
         content = ' ' + '\n '.join(str(self[i]) for i in _range(len(self)))

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -99,7 +99,7 @@ class _TensorBase(object):
             return memo[self._cdata]
         new_storage = self.storage().__deepcopy__(_memo)
         new_tensor = self.new()
-        new_tensor.set_(new_storage, self.storage_offset(), torch.Size(self.size()), self.stride())
+        new_tensor.set_(new_storage, self.storage_offset(), self.size(), self.stride())
         memo[self._cdata] = new_tensor
         return new_tensor
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -7,6 +7,7 @@ import sys
 class _TensorBase(object):
     #: bool: True if this is a CUDA tensor
     is_cuda = False
+    is_sparse = False
 
     def new(self, *args, **kwargs):
         """Constructs a new tensor of the same data type."""
@@ -98,7 +99,7 @@ class _TensorBase(object):
             return memo[self._cdata]
         new_storage = self.storage().__deepcopy__(_memo)
         new_tensor = self.new()
-        new_tensor.set_(new_storage, self.storage_offset(), self.size(), self.stride())
+        new_tensor.set_(new_storage, self.storage_offset(), torch.Size(self.size()), self.stride())
         memo[self._cdata] = new_tensor
         return new_tensor
 


### PR DESCRIPTION
This pull request adds more support for sparse operations in Pytorch.

The original goals:

- ability to propagate sparse updates in a network (e.g. for updating an embedding matrix)
- ability to efficiently compute "bag-of-words" sentence embeddings (e.g. weighted average of word embeddings)

This request implements the following individual features to achieve those goals:

- enable backpropagation of sparse gradients without conversion to dense tensors. In most cases a runtime exception is thrown when mixing different gradient types for the same variable
- add some methods for `THSTensor`: `zero`, elementwise `add` and `mul`, scalar `mul` and `div`
- make `addcmul` method of `THTensor` compatible with sparse operands
- make `spmm` method accessible from Python (I had to use the name `dsmm` since `smm` was already taken. Maybe we should rename the current `smm` to `ssmm` to follow the convention)
- `sparse_mask` method on `THTensor`. This produces a sparse tensor from a dense tensor, by using a sparse tensor as a mask. A value is only present in the output sparse tensor if it also exists in the mask. See the changes to `adagrad.py` for an example of why this is needed.
- update Adagrad code to use sparse updates when possible. I was hoping the optimizers wouldn't require any modification, but it looks like they do (let me know if you see a better option). In addition, not every optimizer supports sparse updates easily. For example it looks like Adam is accumulating moments over time, which effectively makes the updates dense. For the same reason, Adagrad doesn't support having both sparse updates + weight decay.
- leave `Variable`'s gradient to `None` by default (required updating a few tests). This is because there is no canonical zero gradient anymore (it could be dense or sparse, and if it is sparse we don't know how many dimensions are sparse)
- I also added the basic glue code to hook up the existing THCS (cuda sparse) tensor implementation to Python (I did pretty much the same as for TH, THC, THS). I did that mainly so that existing tests keep working even when cuda sparse gradients are involved. Most of the THCS operations are still stubs and will throw an exception with an error message, but it means the only thing remaining for GPU sparse ops support is to fill in the appropriate functions. 

...and last but not least: N-dimensional values for sparse tensors. This one is a slightly bigger item. Basically for things like applying sparse updates to embedding matrices, only the first dimension (the one that corresponds to the word index) is sparse. The other dimension is always dense (only whole embedding vectors are updated). An elegant solution is to make the `values` tensor N-dimensional instead of 1-dimensional. For an embedding matrix, the sparse gradient will have a `values` tensor of size `nnz * embedding_size` instead of just `nnz`. I had to update a few existing functions to make that work, but otherwise the changes are actually not that big. Existing usecases with scalar values should all work as usual.