### PR TITLE
compile with cudart

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ if WITH_CUDA:
     ]
 
 if WITH_CUDNN:
-    main_libraries += ['cudnn']
+    main_libraries += ['cudart', 'cudnn']
     include_dirs.append(CUDNN_INCLUDE_DIR)
     extra_link_args.append('-L' + CUDNN_LIB_DIR)
     main_sources += [

--- a/setup.py
+++ b/setup.py
@@ -266,6 +266,7 @@ if WITH_CUDA:
     extra_link_args.append('-Wl,-rpath,' + cuda_lib_path)
     extra_compile_args += ['-DWITH_CUDA']
     extra_compile_args += ['-DCUDA_LIB_PATH=' + cuda_lib_path]
+    main_libraries += ['cudart']
     main_link_args += [THC_LIB, THCS_LIB, THCUNN_LIB]
     main_sources += [
         "torch/csrc/cuda/Module.cpp",
@@ -278,7 +279,7 @@ if WITH_CUDA:
     ]
 
 if WITH_CUDNN:
-    main_libraries += ['cudart', 'cudnn']
+    main_libraries += ['cudnn']
     include_dirs.append(CUDNN_INCLUDE_DIR)
     extra_link_args.append('-L' + CUDNN_LIB_DIR)
     main_sources += [


### PR DESCRIPTION
This makes it work on osx with cuda and cudnn. Else it give:

```
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/torch/__init__.py", line 45, in <module>
    from torch._C import *
ImportError: dlopen(/usr/local/lib/python2.7/site-packages/torch/_C.so, 10): Symbol not found: _cudaDeviceSynchronize
  Referenced from: /usr/local/lib/python2.7/site-packages/torch/_C.so
  Expected in: flat namespace
 in /usr/local/lib/python2.7/site-packages/torch/_C.so
```