### PR TITLE
Fix LSTMCell Doc Typo

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -436,7 +436,7 @@ class LSTMCell(RNNCellBase):
     Examples::
 
         >>> rnn = nn.LSTMCell(10, 20)
-        >>> input = Variable(torch.randn(3, 10))
+        >>> input = Variable(torch.randn(6, 3, 10))
         >>> hx = Variable(torch.randn(3, 20))
         >>> cx = Variable(torch.randn(3, 20))
         >>> output = []

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -442,7 +442,7 @@ class LSTMCell(RNNCellBase):
         >>> output = []
         >>> for i in range(6):
         ...     hx, cx = rnn(input, (hx, cx))
-        ...     output[i] = hx
+        ...     output.append(hx)
     """
 
     def __init__(self, input_size, hidden_size, bias=True):


### PR DESCRIPTION
There seems to be a small typo in the LSTMCell documentation
```
rnn = nn.LSTMCell(10, 20)
input = Variable(torch.randn(3, 10))
hx = Variable(torch.randn(3, 20))
cx = Variable(torch.randn(3, 20))
output = []
for i in range(6):
    hx, cx = rnn(input, (hx, cx))
    output[i] = hx
```

should be 

```
rnn = nn.LSTMCell(10, 20)
input = Variable(torch.randn(6, 3, 10))
hx = Variable(torch.randn(3, 20))
cx = Variable(torch.randn(3, 20))
output = []
for i in range(6):
    hx = rnn(input[i], (hx, cx))
    output.append(hx)
```