### PR TITLE
Fix cuDNN dropout desc for multi-gpu

### DIFF
--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -47,7 +47,7 @@ def init_rnn_descriptor(fn, handle):
         handle,
         fn.hidden_size,
         fn.num_layers,
-        fn.dropout_state['desc'].get(),
+        fn.dropout_state['desc_'+ str( torch.cuda.current_device() ) ].get(),
         fn.input_mode,
         fn.bidirectional,
         fn.mode,
@@ -217,8 +217,9 @@ def forward(fn, input, hx, weight, output, hy):
         y = output
 
         # init descriptors
-        if ('desc' not in fn.dropout_state) or (fn.dropout_state['desc'].get() is None):
-            fn.dropout_state['desc'] = Unserializable(
+        desc_name = 'desc_'+ str( torch.cuda.current_device() )
+        if (desc_name not in fn.dropout_state) or (fn.dropout_state[desc_name].get() is None):
+            fn.dropout_state[desc_name] = Unserializable(
                 init_dropout_descriptor(fn, handle)
             )
         fn.rnn_desc = init_rnn_descriptor(fn, handle)

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -47,7 +47,7 @@ def init_rnn_descriptor(fn, handle):
         handle,
         fn.hidden_size,
         fn.num_layers,
-        fn.dropout_state['desc_'+ str( torch.cuda.current_device() ) ].get(),
+        fn.dropout_state['desc_' + str(torch.cuda.current_device())].get(),
         fn.input_mode,
         fn.bidirectional,
         fn.mode,
@@ -217,7 +217,7 @@ def forward(fn, input, hx, weight, output, hy):
         y = output
 
         # init descriptors
-        desc_name = 'desc_'+ str( torch.cuda.current_device() )
+        desc_name = 'desc_' + str(torch.cuda.current_device())
         if (desc_name not in fn.dropout_state) or (fn.dropout_state[desc_name].get() is None):
             fn.dropout_state[desc_name] = Unserializable(
                 init_dropout_descriptor(fn, handle)


### PR DESCRIPTION
Create separate dropout descriptors for each GPU in multi-GPU runs to prevent sharing and transferring of dropout state.