### PR TITLE
Add sequential to documentation

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -22,6 +22,12 @@ Containers
 .. autoclass:: Module
     :members:
 
+:hidden:`Sequential`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Sequential
+    :members:
+
 Convolution Layers
 ----------------------------------
 


### PR DESCRIPTION
nn.Sequential() was a torch staple. 
It is missing in the documentation confusing the old torch users. 
I am adding it to the documentation. 

Sasank.