### PR TITLE
fixing missing star in Repeat

### DIFF
--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -575,7 +575,7 @@ class Repeat(Function):
         self.repeats = repeats
 
     def forward(self, input):
-        return input.repeat(self.repeats)
+        return input.repeat(*self.repeats)
 
     def backward(self, grad_output):
         grad_input = grad_output


### PR DESCRIPTION
the call of method Tensor.repeat() will not work without the star to unwrap arguments