### PR TITLE
Fixes and improvements

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -472,6 +472,16 @@ Multi-GPU layers
 .. autoclass:: DataParallel
     :members:
 
+
+Utilities
+---------
+
+:hidden:`clip_grad_norm`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.utils.clip_grad_norm
+
+
 torch.nn.functional
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ class clean(distutils.command.clean.clean):
 ################################################################################
 
 include_dirs = []
+library_dirs = []
 extra_link_args = []
 extra_compile_args = ['-std=c++11', '-Wno-write-strings']
 if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
@@ -212,7 +213,7 @@ include_dirs += [
     tmp_install_path + "/include/THNN",
 ]
 
-extra_link_args.append('-L' + lib_path)
+library_dirs.append(lib_path)
 
 # we specify exact lib names to avoid conflict with lua-torch installs
 TH_LIB = os.path.join(lib_path, 'libTH.so.1')
@@ -295,7 +296,7 @@ if WITH_CUDA:
             break
     include_dirs.append(cuda_include_path)
     include_dirs.append(tmp_install_path + "/include/THCUNN")
-    extra_link_args.append('-L' + cuda_lib_path)
+    library_dirs.append(cuda_lib_path)
     extra_link_args.append('-Wl,-rpath,' + cuda_lib_path)
     extra_compile_args += ['-DWITH_CUDA']
     extra_compile_args += ['-DCUDA_LIB_PATH=' + cuda_lib_path]
@@ -314,7 +315,7 @@ if WITH_CUDA:
 if WITH_CUDNN:
     main_libraries += ['cudnn']
     include_dirs.append(CUDNN_INCLUDE_DIR)
-    extra_link_args.append('-L' + CUDNN_LIB_DIR)
+    library_dirs.append(CUDNN_LIB_DIR)
     main_sources += [
         "torch/csrc/cudnn/BatchNorm.cpp",
         "torch/csrc/cudnn/Conv.cpp",
@@ -348,6 +349,7 @@ C = Extension("torch._C",
               language='c++',
               extra_compile_args=main_compile_args + extra_compile_args,
               include_dirs=include_dirs,
+              library_dirs=library_dirs,
               extra_link_args=extra_link_args + main_link_args + [make_relative_rpath('lib')],
               )
 extensions.append(C)

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -248,6 +248,13 @@ criterion_tests = [
         target=torch.rand(2, 5, 5).mul(3).floor().long()
     ),
     dict(
+        module_name='NLLLoss2d',
+        constructor_args=(torch.rand(3),),
+        input_size=(2, 3, 5, 5),
+        target=torch.rand(2, 5, 5).mul(3).floor().long(),
+        desc='weights'
+    ),
+    dict(
         module_name='HingeEmbeddingLoss',
         input=torch.rand(10),
         target=torch.randn(10).gt(0).double().mul_(2).sub(1)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -654,6 +654,31 @@ class TestAutograd(TestCase):
         y.sum().backward()
         self.assertEqual(x.grad.data, x.data.clone().fill_(1))
 
+    def test_reinforce_check(self):
+        x = Variable(torch.randn(5, 5), requires_grad=True)
+
+        # these should be ok
+        y = torch.normal(x)
+        y.reinforce(torch.randn(5, 5))
+        y = torch.normal(x)
+        y.reinforce(2)
+
+        # can't call reinforce on non-stochastic variables
+        self.assertRaises(RuntimeError, lambda: x.reinforce(2))
+
+        # can't call reinforce twice
+        y = torch.normal(x)
+        y.reinforce(2)
+        self.assertRaises(RuntimeError, lambda: y.reinforce(2))
+
+        # check type of reward
+        y = torch.normal(x)
+        self.assertRaises(TypeError, lambda: y.reinforce(torch.randn(5, 5).long()))
+
+        # check size of reward
+        y = torch.normal(x)
+        self.assertRaises(ValueError, lambda: y.reinforce(torch.randn(4, 5)))
+
     def test_stochastic(self):
         x = Variable(torch.rand(2, 10), requires_grad=True)
         stddevs = Variable(torch.rand(2, 10) * 5, requires_grad=True)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -59,6 +59,12 @@ def small_2d_scaled(t, scale=10):
     return make_tensor(t, S, S).mul(scale)
 
 
+def small_2d_oneish(t):
+    if is_floating(t):
+        return make_tensor(t, S, S).clamp(min=0.99, max=1.01)
+    else:
+        return t(S, S).fill_(1)
+
 def small_3d(t):
     return make_tensor(t, S, S, S)
 
@@ -82,7 +88,6 @@ def small_3d_ones(t):
 def small_3d_positive(t):
     min_val = 1e-3 if is_floating(t) else 2
     return make_tensor(t, S, S, S).clamp_(min_val, 120)
-
 
 def small_3d_unique(t):
     return t(S, S, S).copy_(torch.range(1, S * S * S))
@@ -206,7 +211,7 @@ tests = [
     ('norm', small_3d, lambda t: [3, 0], '3_norm_dim'),
     ('ones', small_3d, lambda t: [1, 2, 3, 4, 5],),
     ('permute', new_t(1, 2, 3, 4), lambda t: [2, 1, 3, 0],),
-    ('prod', small_3d, lambda t: [],),
+    ('prod', small_2d_oneish, lambda t: [],),
     ('prod', small_3d, lambda t: [1], 'dim'),
     ('sum', small_2d, lambda t: [],),
     ('sum', small_3d, lambda t: [1], 'dim'),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1867,7 +1867,7 @@ class TestTorch(TestCase):
         self.assertEqual(reference[2, 2, 2], 27, 0)
         self.assertEqual(reference[:], self._consecutive((3, 3, 3)), 0)
 
-        # Check Ellipsis
+        # indexing with Ellipsis
         self.assertEqual(reference[..., 2], torch.Tensor([[3, 6, 9],
                                                           [12, 15, 18],
                                                           [21, 24, 27]]), 0)
@@ -1880,6 +1880,11 @@ class TestTorch(TestCase):
         self.assertEqual(reference[2, 2, ..., 2], 27, 0)
         self.assertEqual(reference[2, 2, 2, ...], 27, 0)
 
+        reference_5d = self._consecutive((3, 3, 3, 3, 3))
+        self.assertEqual(reference_5d[..., 1, 0], reference_5d[:, :, :, 1, 0], 0)
+        self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
+        self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
+
         # LongTensor indexing
         reference = self._consecutive((5, 5, 5))
         idx = torch.LongTensor([2, 4])
@@ -1887,10 +1892,26 @@ class TestTorch(TestCase):
         self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
         self.assertEqual(reference[3, idx, 1], torch.stack([reference[3, 2], reference[3, 4]])[:, 1])
 
-        reference_5d = self._consecutive((3, 3, 3, 3, 3))
-        self.assertEqual(reference_5d[..., 1, 0], reference_5d[:, :, :, 1, 0], 0)
-        self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
-        self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
+        # None indexing
+        self.assertEqual(reference[2, None], reference[2].unsqueeze(0))
+        self.assertEqual(reference[2, None, None], reference[2].unsqueeze(0).unsqueeze(0))
+        self.assertEqual(reference[2:4, None], reference[2:4].unsqueeze(1))
+        self.assertEqual(reference[None, 2, None, None], reference.unsqueeze(0)[:, 2].unsqueeze(0).unsqueeze(0))
+        self.assertEqual(reference[None, 2:5, None, None], reference.unsqueeze(0)[:, 2:5].unsqueeze(2).unsqueeze(2))
+
+        # indexing with step
+        reference = self._consecutive((10, 10, 10))
+        self.assertEqual(reference[1:5:2], torch.stack([reference[1], reference[3]], 0))
+        self.assertEqual(reference[1:6:2], torch.stack([reference[1], reference[3], reference[5]], 0))
+        self.assertEqual(reference[1:9:4], torch.stack([reference[1], reference[5]], 0))
+        self.assertEqual(reference[2:4, 1:5:2], torch.stack([reference[2:4, 1], reference[2:4, 3]], 1))
+        self.assertEqual(reference[3, 1:6:2], torch.stack([reference[3, 1], reference[3, 3], reference[3, 5]], 0))
+        self.assertEqual(reference[None, 2, 1:9:4], torch.stack([reference[2, 1], reference[2, 5]], 0).unsqueeze(0))
+        self.assertEqual(reference[:, 2, 1:6:2],
+                         torch.stack([reference[:, 2, 1], reference[:, 2, 3], reference[:, 2, 5]], 1))
+
+        self.assertRaises(ValueError, lambda: reference[1:9:0])
+        self.assertRaises(ValueError, lambda: reference[1:9:-1])
 
         self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1])
         self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1:1])

--- a/torch/autograd/stochastic_function.py
+++ b/torch/autograd/stochastic_function.py
@@ -1,3 +1,5 @@
+import torch
+from numbers import Number
 from .function import Function
 
 _NOT_PROVIDED = object()
@@ -17,5 +19,26 @@ class StochasticFunction(Function):
             self.reward = None
         return result
 
+    def _do_forward(self, *inputs):
+        result = super(StochasticFunction, self)._do_forward(*inputs)
+        # save output type and size, to check the type of reward
+        assert isinstance(result, torch.autograd.Variable), \
+            "stochastic functions support only a single output at the moment"
+        self.reward_info = (type(inputs[0].data), result.size())
+        return result
+
+    __call__ = _do_forward
+
     def _reinforce(self, reward):
+        is_number = isinstance(reward, Number)
+        if not is_number and type(reward) != self.reward_info[0]:
+            raise TypeError("mismatch between reward and output type: got {}, "
+                            "but expected {}".format(torch.typename(reward),
+                                                     torch.typename(self.reward_info[0])))
+        if not is_number and reward.size() != self.reward_info[1]:
+            raise ValueError("got reward of size {}, but expected a tensor of size {}".format(
+                             'x'.join(map(str, reward.size())),
+                             'x'.join(map(str, self.reward_info[1]))))
+        if self.reward is not _NOT_PROVIDED:
+            raise RuntimeError("you can only reinforce a stochastic Function once")
         self.reward = reward

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -5,10 +5,16 @@
 #include <stdexcept>
 #include <string>
 
+// Throwing this exception means that the python error flags have been already
+// set and control should be immediately returned to the interpreter.
+class python_error : public std::exception {};
+
 #define HANDLE_TH_ERRORS                                                       \
   try {
 
 #define END_HANDLE_TH_ERRORS_RET(retval)                                       \
+  } catch (python_error &e) {                                                  \
+    return retval;                                                             \
   } catch (std::exception &e) {                                                \
     PyErr_SetString(PyExc_RuntimeError, e.what());                             \
     return retval;                                                             \
@@ -19,10 +25,6 @@
 extern PyObject *THPException_FatalError;
 
 #ifdef _THP_CORE
-
-// Throwing this exception means that the python error flags have been already
-// set and control should be immediately returned to the interpreter.
-class python_error : public std::exception {};
 
 struct THException: public std::exception {
   THException(const char* msg): msg(msg) {};

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -412,32 +412,6 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
 #define UNPACK_SCALAR(IDX_VARIABLE) idx = THPUtils_unpackLong(IDX_VARIABLE);
 #endif
 
-#define INDEX_SCALAR(DIM, IDX_VARIABLE, TENSOR_VARIABLE, CASE_1D, CASE_MD)     \
-  int64_t idx;                                                                 \
-  UNPACK_SCALAR(IDX_VARIABLE);                                                 \
-  long dimsize = THTensor_(size)(LIBRARY_STATE TENSOR_VARIABLE, DIM);          \
-  idx = (idx < 0) ? dimsize + idx : idx;                                       \
-                                                                               \
-  if (dimsize <= 0) {                                                          \
-    PyErr_SetString(PyExc_IndexError, "indexing an empty tensor");             \
-    return false;                                                              \
-  }                                                                            \
-  if (idx < 0 || idx >= dimsize) {                                             \
-    PyErr_Format(PyExc_IndexError, "index %lld is out of range for dimension "  \
-        "%lld (of size %lld)", (long long)idx, (long long)DIM, (long long)dimsize); \
-    return false;                                                              \
-  }                                                                            \
-                                                                               \
-  if(THTensor_(nDimension)(LIBRARY_STATE TENSOR_VARIABLE) == 1) {              \
-    CASE_1D;                                                                   \
-  } else {                                                                     \
-    CASE_MD;                                                                   \
-  }
-
-#define GET_OFFSET(t, idx)                                                     \
-  t->storageOffset + t->stride[0] * idx;
-
-
 #ifdef THC_GENERIC_FILE
 #define THIndexTensor THCudaLongTensor
 #define THIndexTensor_(NAME) TH_CONCAT_2(THCudaLongTensor_,NAME)
@@ -452,57 +426,94 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
 
 
 template<bool allow_index>
-static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
-    THTensorPtr &tresult, THStorage * &sresult, long &storage_offset)
+static bool THPTensor_(_indexOnce)(PyObject *index, int &indexed_dim,
+        THTensorPtr &tresult, THStorage* &sresult, long &storage_offset)
 {
 #ifdef WITH_NUMPY
   static PyArray_Descr *NumpyLongArrDescr = PyArray_DescrFromType(NPY_INT64);
   bool is_long, is_scalar_array;
 #endif
-  tresult = NULL;
-  sresult = NULL;
-  // Indexing with an integer
+  // Indexing with a scalar
   if(IS_SCALAR(index)) {
-    THTensor *self_t = self->cdata;
-    INDEX_SCALAR(0, index, self_t,
-      // 1D tensor
-      sresult = self_t->storage;
-      storage_offset = GET_OFFSET(self_t, idx),
-      // >1D tensor
-      tresult = THTensor_(newWithTensor)(LIBRARY_STATE self_t);
-      THTensor_(select)(LIBRARY_STATE tresult.get(), NULL, 0, idx)
-    )
-    return true;
+    int64_t idx;
+    UNPACK_SCALAR(index);
+    long dimsize = THTensor_(size)(LIBRARY_STATE tresult.get(), indexed_dim);
+    idx = (idx < 0) ? dimsize + idx : idx;
+
+    if (dimsize <= 0) {
+      PyErr_SetString(PyExc_IndexError, "indexing an empty tensor");
+      throw python_error();
+    }
+    if (idx < 0 || idx >= dimsize) {
+      PyErr_Format(PyExc_IndexError, "index %lld is out of range for dimension "
+          "%lld (of size %lld)", (long long)idx, (long long)indexed_dim, (long long)dimsize);
+      throw python_error();
+    }
+
+    if(THTensor_(nDimension)(LIBRARY_STATE tresult.get()) == 1) {
+      sresult = tresult.get()->storage;
+      storage_offset = tresult->storageOffset + tresult->stride[0] * idx;
+      tresult = NULL;
+    } else {
+      THTensor_(select)(LIBRARY_STATE tresult.get(), NULL, indexed_dim, idx);
+    }
+  } else if (index == Py_None) {
+    // _indexOnce will never be called with tresult == NULL, except for a None index
+    if (!tresult) {
+      tresult = THTensor_(newWithStorage1d)(LIBRARY_STATE sresult, storage_offset, 1, 1);
+      sresult = NULL;
+    } else {
+      THTensor_(unsqueeze1d)(LIBRARY_STATE tresult.get(), NULL, indexed_dim++);
+    }
   // Indexing with a slice
   } else if (PySlice_Check(index)) {
-    tresult = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
-    Py_ssize_t start, end, length;
-    if (!THPUtils_parseSlice(index, THTensor_(size)(LIBRARY_STATE tresult.get(), 0), &start, &end, &length))
-      return false;
-    THTensor_(narrow)(LIBRARY_STATE tresult.get(), NULL, 0, start, length);
-    return true;
-  } else if (THPIndexTensor_Check(index)) {
-    if (allow_index) {
-      THIndexTensor *index_t = ((THPIndexTensor*)index)->cdata;
-      tresult = THTensor_(new)(LIBRARY_STATE_NOARGS);
-      THTensor_(indexSelect)(LIBRARY_STATE tresult.get(), self->cdata, 0, index_t);
-      return true;
-    } else {
-      THPUtils_setError("assignments using LongTensors as index aren't supported yet");
-      tresult = NULL;
-      return false;
+    Py_ssize_t start, end, length, step;
+    if (!THPUtils_parseSlice(index, THTensor_(size)(LIBRARY_STATE tresult.get(), indexed_dim), &start, &end, &step, &length))
+      throw python_error();
+    if (step <= 0) {
+      PyErr_SetString(PyExc_ValueError, "slice step has to be greater than 0");
+      throw python_error();
     }
-  // Indexing multiple dimensions
-  } else if(PyTuple_Check(index)) {
+    THTensor_(narrow)(LIBRARY_STATE tresult.get(), NULL, indexed_dim, start, length * step);
+    tresult->stride[indexed_dim] *= step;
+    tresult->size[indexed_dim] /= step;
+    indexed_dim++;
+  // Indexing with a LongTensor
+  } else if (THPIndexTensor_Check(index)) {
+    if (!allow_index)
+      throw std::runtime_error("assignments using LongTensors as index aren't supported yet");
+    THIndexTensor *index_t = ((THPIndexTensor*)index)->cdata;
+    THTensorPtr index_result = THTensor_(new)(LIBRARY_STATE_NOARGS);
+    THTensor_(indexSelect)(LIBRARY_STATE index_result.get(), tresult.get(), indexed_dim++, index_t);
+    tresult = index_result.release();
+  } else {
+    return false;
+  }
+  return true;
+}
+
+
+template<bool allow_index>
+static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
+    THTensorPtr &tresult, THStorage * &sresult, long &storage_offset)
+{
+  tresult = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
+  sresult = NULL;
+  int indexed_dim = 0;
+  if(PyTuple_Check(index)) {
     long num_index_dim = (long)PyTuple_Size(index);
     long num_effective_index = num_index_dim;
     long num_tensor_dim = THTensor_(nDimension)(LIBRARY_STATE self->cdata);
-    long ellipsis_idx = num_tensor_dim + 1;
+    long ellipsis_idx = -1;
     for (int i = 0; i < num_index_dim; i++) {
-      if (PyTuple_GET_ITEM(index, i) == Py_Ellipsis) {
+      PyObject *dimidx = PyTuple_GET_ITEM(index, i);
+      if (dimidx == Py_Ellipsis) {
+        if (ellipsis_idx != -1) throw std::runtime_error("ellipsis can be used at most once");
         ellipsis_idx = i;
         num_effective_index--;
-        break;
+      }
+      if (dimidx == Py_None) {
+        num_effective_index--;
       }
     }
     if (num_effective_index > num_tensor_dim) {
@@ -512,53 +523,26 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
       return false;
     }
 
-    tresult = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
-    int t_dim = 0;
     bool valid = true;
-    for(int dim = 0; dim < num_index_dim; dim++) {
+    for (int dim = 0; dim < num_index_dim; dim++) {
       if (dim == ellipsis_idx) {
-        t_dim = tresult->nDimension - (num_index_dim - dim - 1);
+        // tresult can be NULL if ellipsis is the last item
+        if (tresult) indexed_dim = tresult->nDimension - (num_index_dim - dim - 1);
         continue;
       }
       PyObject *dimidx = PyTuple_GET_ITEM(index, dim);
-      if(IS_SCALAR(dimidx)) {
-        INDEX_SCALAR(t_dim, dimidx, tresult,
-            // 1D tensor
-            sresult = tresult->storage;
-            storage_offset = GET_OFFSET(tresult, idx);
-            tresult = NULL;
-            return true,
-            // >1D tensor
-            THTensor_(select)(LIBRARY_STATE tresult.get(), NULL, t_dim, idx)
-          )
-      } else if (PySlice_Check(dimidx)) {
-        Py_ssize_t start, end, length;
-        long size_dim = THTensor_(size)(LIBRARY_STATE tresult.get(), t_dim);
-        if (!THPUtils_parseSlice(dimidx, size_dim, &start, &end, &length))
-          return false;
-        THTensor_(narrow)(LIBRARY_STATE tresult.get(), NULL, t_dim++, start, length);
-      } else if (THPIndexTensor_Check(dimidx)) {
-        if (allow_index) {
-          THIndexTensor *index_t = ((THPIndexTensor*)dimidx)->cdata;
-          THTensorPtr index_result = THTensor_(new)(LIBRARY_STATE_NOARGS);
-          THTensor_(indexSelect)(LIBRARY_STATE index_result.get(), tresult.get(), t_dim++, index_t);
-          tresult = index_result.release();
-        } else {
-          THPUtils_setError("assignments using LongTensors as index aren't supported yet");
-          tresult = NULL;
-          return false;
-        }
-      } else {
+      valid = THPTensor_(_indexOnce)<allow_index>(dimidx, indexed_dim, tresult, sresult, storage_offset);
+      if (!valid) {
         tresult = NULL;
-        valid = false;
         // overwrite this, so the message mentions the incorrect object
         index = dimidx;
         break;
       }
     }
-    if (valid) {
+    if (valid) return true;
+  } else {
+    if (THPTensor_(_indexOnce)<allow_index>(index, indexed_dim, tresult, sresult, storage_offset))
       return true;
-    }
   }
 
   PyErr_Format(PyExc_TypeError, "indexing a tensor with an object of type %s. "
@@ -566,18 +550,15 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
 #ifdef WITH_NUMPY
       ", numpy scalars"
 #endif
-      " and "
 #ifndef THC_GENERIC_FILE
-      "torch.ByteTensor.",
+      "torch.LongTensor and torch.ByteTensor.",
 #else
-      "torch.cuda.ByteTensor.",
+      "torch.cuda.LongTensor and torch.cuda.ByteTensor.",
 #endif
     THPUtils_typename(index));
   return false;
 }
 #undef IS_SCALAR
-#undef INDEX_SCALAR
-#undef GET_OFFSET
 #undef THIndexTensor
 #undef THIndexTensor_
 #undef THPIndexTensor

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -52,6 +52,10 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
 #if !defined(WITH_NUMPY)
   THPUtils_setError("PyTorch was compiled without numpy support\n");
   return NULL;
+#elif defined(THC_GENERIC_FILE)
+  THPUtils_setError("can't convert CUDA tensor to numpy (it doesn't support GPU arrays). "
+    "Use .cpu() to move the tensor to host memory first.");
+  return NULL;
 #elif !defined(NUMPY_TYPE_ENUM)
   THPUtils_setError("numpy conversion for %s is not supported\n", THPUtils_typename(self));
   return NULL;

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -544,33 +544,6 @@ void THPUtils_invalidArguments(PyObject *given_args, PyObject *given_kwargs,
   PyErr_SetString(PyExc_TypeError, error_msg.c_str());
 }
 
-
-
-bool THPUtils_parseSlice(PyObject *slice, Py_ssize_t len, Py_ssize_t *ostart, Py_ssize_t *ostop, Py_ssize_t *oslicelength)
-{
-  Py_ssize_t start, stop, step, slicelength;
-  if (PySlice_GetIndicesEx(
-// https://bugsfiles.kde.org/attachment.cgi?id=61186
-#if PY_VERSION_HEX >= 0x03020000
-         slice,
-#else
-         (PySliceObject *)slice,
-#endif
-         len, &start, &stop, &step, &slicelength) < 0) {
-    return false;
-  }
-  if (step != 1) {
-    THPUtils_setError("Trying to slice with a step of %ld, but only a step of "
-        "1 is supported", (long)step);
-    return false;
-  }
-  *ostart = start;
-  *ostop = stop;
-  if(oslicelength)
-    *oslicelength = slicelength;
-  return true;
-}
-
 template<>
 void THPPointer<THPGenerator>::free() {
   if (ptr)

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -141,8 +141,14 @@ void THPUtils_addPyMethodDefs(std::vector<PyMethodDef>& vector, PyMethodDef* met
 
 #define THPUtils_classname(obj) (((PyTypeObject*)obj)->tp_name)
 int THPUtils_getCallable(PyObject *arg, PyObject **result);
-bool THPUtils_parseSlice(PyObject *slice, Py_ssize_t len, Py_ssize_t *ostart,
-        Py_ssize_t *ostop, Py_ssize_t *oslicelength);
+// https://bugsfiles.kde.org/attachment.cgi?id=61186
+#if PY_VERSION_HEX >= 0x03020000
+#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
+  (PySlice_GetIndicesEx(SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#else
+#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
+  (PySlice_GetIndicesEx((PySliceObject*)SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#endif
 
 #define THStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
 #define THTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)

--- a/torch/lib/THPP/Storage.hpp
+++ b/torch/lib/THPP/Storage.hpp
@@ -12,7 +12,7 @@
 
 namespace thpp {
 
-class Tensor;
+struct Tensor;
 
 struct Storage {
   Storage() {};

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -218,6 +218,8 @@ class CudnnRNN(NestedIOFunction):
                 output,
                 weight,
                 grad_weight)
+        else:
+            grad_weight = [(None,) * len(layer_weight) for layer_weight in weight]
 
         if self.retain_variables:
             self.reserve = self._reserve_clone

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -184,6 +184,7 @@ class CudnnRNN(NestedIOFunction):
 
     def backward_extended(self, grad_output, grad_hy):
         input, hx, weight, output = self.saved_tensors
+        input = input.contiguous()
 
         grad_input, grad_weight, grad_hx = None, None, None
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -24,10 +24,10 @@ class _Loss(Module):
         return backend_fn(self.size_average)(input, target)
 
 
-class _WeighedLoss(_Loss):
+class _WeightedLoss(_Loss):
 
     def __init__(self, weight=None, size_average=True):
-        super(_WeighedLoss, self).__init__(size_average)
+        super(_WeightedLoss, self).__init__(size_average)
         self.register_buffer('weight', weight)
 
     def forward(self, input, target):
@@ -51,7 +51,7 @@ class L1Loss(_Loss):
     pass
 
 
-class NLLLoss(_WeighedLoss):
+class NLLLoss(_WeightedLoss):
     r"""The negative log likelihood loss. It is useful to train a classification problem with n classes
 
     If provided, the optional argument `weights` should be a 1D Tensor assigning
@@ -106,15 +106,17 @@ class NLLLoss(_WeighedLoss):
     pass
 
 
-class NLLLoss2d(_Loss):
+class NLLLoss2d(_WeightedLoss):
     r"""This is negative log likehood loss, but for image inputs. It computes NLL loss per-pixel.
 
     This loss does not support per-class weights
 
     Args:
+        weight (Tensor, optional): a manual rescaling weight given to each class.
+            If given, has to be a 1D Tensor having as many elements, as there are classes.
         size_average: By default, the losses are averaged over observations for each minibatch.
-                      However, if the field sizeAverage is set to False, the losses
-                      are instead summed for each minibatch. Default: True
+            However, if the field sizeAverage is set to False, the losses
+            are instead summed for each minibatch. Default: True
 
     Shape:
         - Input: :math:`(N, C, H, W)` where `C = number of classes`
@@ -133,7 +135,7 @@ class NLLLoss2d(_Loss):
     pass
 
 
-class KLDivLoss(_WeighedLoss):
+class KLDivLoss(_WeightedLoss):
     r"""The `Kullback-Leibler divergence`_ Loss
 
     KL divergence is a useful distance measure for continuous distributions
@@ -178,7 +180,7 @@ class MSELoss(_Loss):
     pass
 
 
-class BCELoss(_WeighedLoss):
+class BCELoss(_WeightedLoss):
     r"""Creates a criterion that measures the Binary Cross Entropy
     between the target and the output:
 
@@ -276,7 +278,7 @@ class SoftMarginLoss(_Loss):
     pass
 
 
-class CrossEntropyLoss(_WeighedLoss):
+class CrossEntropyLoss(_WeightedLoss):
     r"""This criterion combines `LogSoftMax` and `NLLLoss` in one single class.
 
     It is useful when training a classification problem with `n` classes.
@@ -314,7 +316,7 @@ class CrossEntropyLoss(_WeighedLoss):
                                self.weight, self.size_average)
 
 
-class MultiLabelSoftMarginLoss(_WeighedLoss):
+class MultiLabelSoftMarginLoss(_WeightedLoss):
     r"""Creates a criterion that optimizes a multi-label one-versus-all
     loss based on max-entropy, between input `x`  (a 2D mini-batch `Tensor`) and
     target `y` (a binary 2D `Tensor`). For each sample in the minibatch::

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -12,7 +12,7 @@ def parallel_apply(modules, inputs):
     assert len(modules) == len(inputs)
     # Fast track
     if len(modules) == 1:
-        return (modules[0](inputs[0]),)
+        return (modules[0](*inputs[0]),)
 
     lock = threading.Lock()
     results = {}
@@ -23,7 +23,7 @@ def parallel_apply(modules, inputs):
             var_input = var_input[0]
         try:
             with torch.cuda.device_of(var_input):
-                output = module(input)
+                output = module(*input)
             with lock:
                 results[input] = output
         except Exception as e:

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -1,0 +1,1 @@
+from .clip_grad import clip_grad_norm

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -1,0 +1,29 @@
+
+def clip_grad_norm(parameters, max_norm, norm_type=2):
+    """Clips gradient norm of an iterable of parameters.
+
+    The norm is computed over all gradients together, as if they were
+    concatenated into a single vector. Gradients are modified in-place.
+
+    Arguments:
+        parameters (Iterable[Variable]): an iterable of Variables that will have
+            gradients normalized
+        max_norm (float or int): max norm of the gradients
+        norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for infinity norm.
+    """
+    parameters = list(parameters)
+    max_norm = float(max_norm)
+    norm_type = float(norm_type)
+    if norm_type == float('inf'):
+        total_norm = max(p.grad.data.abs().max() for p in parameters)
+    else:
+        total_norm = 0
+        for p in parameters:
+            param_norm = p.grad.data.norm(norm_type)
+            total_norm += param_norm ** norm_type
+        total_norm = total_norm ** (1. / norm_type)
+    clip_coef = max_norm / (total_norm + 1e-6)
+    if clip_coef >= 1:
+        return
+    for p in parameters:
+        p.grad.data.mul_(clip_coef)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -61,7 +61,9 @@ def _pin_memory_loop(in_queue, out_queue, done_event):
 def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
-        return torch.cat([t.unsqueeze(0) for t in batch], 0)
+        return torch.stack(batch, 0)
+    elif type(batch[0]).__module__ == 'numpy':  # this allows to not import numpy
+        return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)
     elif isinstance(batch[0], float):


### PR DESCRIPTION
* Added better error message for CUDA -> numpy conversions (#779)
* Added checks for type and size of rewards in StochasticFunction (#781)
* cuDNN RNN Function now returns a correct number of gradients (#776)
* input will be made contiguous only once in backward of cuDNN RNN (#621)
* DataParallel now supports multiple inputs (#649)
* Added `torch.nn.utils.clip_grad_norm` (#309)
* Added support for indexing with `None` and slices with positive steps (partially #229)
* Added support for numpy arrays in `default_collate` (#782)
* Fixed misspelling and made NLLLoss2d accept weights (#784)

NLLLoss2d test will be extremely flaky until torch/cunn#445 is merged.