### PR TITLE
Fixed typo in GRUCell example

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -505,7 +505,7 @@ class GRUCell(RNNCellBase):
 
     Examples::
 
-        >>> rnn = nn.RNNCell(10, 20)
+        >>> rnn = nn.GRUCell(10, 20)
         >>> input = Variable(torch.randn(6, 3, 10))
         >>> hx = Variable(torch.randn(3, 20))
         >>> output = []


### PR DESCRIPTION
Minor typo in the GRUCell example; fixed it to avoid confusion. 