### PR TITLE
Add function to compute cross_entropy for 2D image

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -391,7 +391,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
 
 # loss
 
-def nll_loss(input, target, weight=None, size_average=True, total_weight=None):
+def nll_loss(input, target, weight=None, size_average=True):
     r"""The negative log likelihood loss.
 
     See :class:`~torch.nn.NLLLoss` for details.
@@ -405,7 +405,6 @@ def nll_loss(input, target, weight=None, size_average=True, total_weight=None):
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch.
-        total_weight (Variable, optional): a element-wise rescaling weight.
 
     Attributes:
         weight: the class-weights given as input to the constructor
@@ -420,9 +419,9 @@ def nll_loss(input, target, weight=None, size_average=True, total_weight=None):
     """
     dim = input.dim()
     if dim == 2:
-        f = _functions.thnn.NLLLoss(size_average, weight=weight, total_weight=total_weight)
+        f = _functions.thnn.NLLLoss(size_average, weight=weight)
     elif dim == 4:
-        f = _functions.thnn.NLLLoss2d(size_average, weight=weight, total_weight=total_weight)
+        f = _functions.thnn.NLLLoss2d(size_average, weight=weight)
     else:
         raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
     return f(input, target)
@@ -442,7 +441,7 @@ def kl_div(input, target, size_average=True):
     return _functions.thnn.KLDivLoss(size_average)(input, target)
 
 
-def cross_entropy(input, target, weight=None, size_average=True, total_weight=None):
+def cross_entropy(input, target, weight=None, size_average=True):
     r"""This criterion combines `log_softmax` and `nll_loss` in one single class.
 
     See :class:`torch.nn.CrossEntropyLoss` for details.
@@ -456,9 +455,8 @@ def cross_entropy(input, target, weight=None, size_average=True, total_weight=No
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch.
-        total_weight (Variable, optional): a element-wise rescaling weight.
     """
-    return nll_loss(log_softmax(input), target, weight, size_average, total_weight)
+    return nll_loss(log_softmax(input), target, weight, size_average)
 
 
 def binary_cross_entropy(input, target, weight=None, size_average=True):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -449,10 +449,10 @@ def cross_entropy(input, target, weight=None, size_average=True):
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch.
     """
-    ndim = input.ndim()
-    if ndim == 2:
+    dim = input.dim()
+    if dim == 2:
         return nll_loss(log_softmax(input), target, weight, size_average)
-    elif ndim() == 4:
+    elif dim == 4:
         N, C, H, W = input.size()
         log_p = F.log_softmax(input)  # (N, C, H, W)
         log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, C)
@@ -467,7 +467,7 @@ def cross_entropy(input, target, weight=None, size_average=True):
             loss /= N
         return loss
     else:
-        raise ValueError('Expected 2 or 4 dimensions (got {})'.format(ndim))
+        raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
 
 
 def binary_cross_entropy(input, target, weight=None, size_average=True):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -449,37 +449,25 @@ def cross_entropy(input, target, weight=None, size_average=True):
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch.
     """
-    return nll_loss(log_softmax(input), target, weight, size_average)
-
-
-def cross_entropy2d(input, target, weight=None, size_average=True):
-    r"""Cross entropy function for 2D image.
-
-    Args:
-        input: Variable :math:`(N, C, H, W)` where `C = number of classes`,
-            `H = image height` and `W = image width`.
-        target: Variable :math:`(N, H, W)` where each value is
-            `targets[i] <= C-1` and negative values which will be ignored.
-        weight (Variable, optional): a manual rescaling weight given to each
-                class. If given, has to be a Variable of size "nclasses"
-        size_average (bool, optional): By default, the losses are averaged
-                over observations for each minibatch. However, if the field
-                sizeAverage is set to False, the losses are instead summed
-                for each minibatch.
-    """
-    N, C, H, W = input.size()
-    log_p = F.log_softmax(input)  # (N, C, H, W)
-    log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, C)
-    log_p = log_p[target.view(N, H, W, 1).repeat(1, 1, 1, C) >= 0]
-    log_p = log_p.view(-1, C)  # (M, C) where M = (target >= 0).sum()
-    mask = target >= 0  # (M,)
-    target = target[mask]
-    loss = F.nll_loss(log_p, target, weight=weight, size_average=False)
-    if size_average:
-        loss /= mask.sum().data[0]
+    ndim = input.ndim()
+    if ndim == 2:
+        return nll_loss(log_softmax(input), target, weight, size_average)
+    elif ndim() == 4:
+        N, C, H, W = input.size()
+        log_p = F.log_softmax(input)  # (N, C, H, W)
+        log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, C)
+        log_p = log_p[target.view(N, H, W, 1).repeat(1, 1, 1, C) >= 0]
+        log_p = log_p.view(-1, C)  # (M, C) where M = (target >= 0).sum()
+        mask = target >= 0  # (M,)
+        target = target[mask]
+        loss = F.nll_loss(log_p, target, weight=weight, size_average=False)
+        if size_average:
+            loss /= mask.sum().data[0]
+        else:
+            loss /= N
+        return loss
     else:
-        loss /= N
-    return loss
+        raise ValueError('Expected 2 or 4 dimensions (got {})'.format(ndim))
 
 
 def binary_cross_entropy(input, target, weight=None, size_average=True):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -26,14 +26,16 @@ class _Loss(Module):
 
 class _WeightedLoss(_Loss):
 
-    def __init__(self, weight=None, size_average=True):
+    def __init__(self, weight=None, size_average=True, total_weight=None):
         super(_WeightedLoss, self).__init__(size_average)
         self.register_buffer('weight', weight)
+        self.register_buffer('total_weight', total_weight)
 
     def forward(self, input, target):
         _assert_no_grad(target)
         backend_fn = getattr(self._backend, type(self).__name__)
-        return backend_fn(self.size_average, weight=self.weight)(input, target)
+        return backend_fn(self.size_average, weight=self.weight,
+                          total_weight=self.total_weight)(input, target)
 
 
 class L1Loss(_Loss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -26,16 +26,14 @@ class _Loss(Module):
 
 class _WeightedLoss(_Loss):
 
-    def __init__(self, weight=None, size_average=True, total_weight=None):
+    def __init__(self, weight=None, size_average=True):
         super(_WeightedLoss, self).__init__(size_average)
         self.register_buffer('weight', weight)
-        self.register_buffer('total_weight', total_weight)
 
     def forward(self, input, target):
         _assert_no_grad(target)
         backend_fn = getattr(self._backend, type(self).__name__)
-        return backend_fn(self.size_average, weight=self.weight,
-                          total_weight=self.total_weight)(input, target)
+        return backend_fn(self.size_average, weight=self.weight)(input, target)
 
 
 class L1Loss(_Loss):


### PR DESCRIPTION
This is used to compute loss for class segmentation task, for example.
Ignoring negative labels is required to use dataset with unlabeled region.