### PR TITLE
Add momentum and centered options to RMSProp

### DIFF
--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -19,7 +19,7 @@ class RMSprop(Optimizer):
     """
 
     def __init__(self, params, lr=1e-2, momentum=0, alpha=0.99, eps=1e-8, centered=False, weight_decay=0):
-        defaults = dict(lr=lr, momentum=0, alpha=alpha, eps=eps, centered=False, weight_decay=weight_decay)
+        defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=False, weight_decay=weight_decay)
         super(RMSprop, self).__init__(params, defaults)
 
     def step(self, closure=None):

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -4,7 +4,7 @@ from .optimizer import Optimizer
 class RMSprop(Optimizer):
     """Implements RMSprop algorithm.
 
-    Proposed by G. Hinton in its `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
+    Proposed by G. Hinton in his `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
 
     The centered version first appears in `Generating Sequences
     With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -23,7 +23,7 @@ class RMSprop(Optimizer):
 
     """
 
-    def __init__(self, params, lr=1e-2, momentum=0, alpha=0.99, eps=1e-8, centered=False, weight_decay=0):
+    def __init__(self, params, lr=1e-2, alpha=0.99, eps=1e-8, weight_decay=0, momentum=0, centered=False):
         defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=centered, weight_decay=weight_decay)
         super(RMSprop, self).__init__(params, defaults)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -27,6 +27,12 @@ class RMSprop(Optimizer):
         defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=centered, weight_decay=weight_decay)
         super(RMSprop, self).__init__(params, defaults)
 
+    def __setstate__(self, state):
+        super(RMSprop, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault('momentum', 0)
+            group.setdefault('centered', False)
+
     def step(self, closure=None):
         """Performs a single optimization step.
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -4,6 +4,9 @@ from .optimizer import Optimizer
 class RMSprop(Optimizer):
     """Implements RMSprop algorithm.
 
+    Proposed by G. Hinton in its `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
+    The centered version first appears in `Generating Sequences With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.
+
     Arguments:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -54,7 +54,7 @@ class RMSprop(Optimizer):
                     state['step'] = 0
                     state['square_avg'] = grad.new().resize_as_(grad).zero_()
                     if group['momentum'] > 0:
-                        state['momentum'] = grad.new().resize_as_(grad).zero_()
+                        state['momentum_buffer'] = grad.new().resize_as_(grad).zero_()
                     if group['centered']:
                         state['grad_avg'] = grad.new().resize_as_(grad).zero_()
 
@@ -68,7 +68,6 @@ class RMSprop(Optimizer):
 
                 square_avg.mul_(alpha).addcmul_(1 - alpha, grad, grad)
 
-                avg = None
                 if group['centered']:
                     grad_avg = state['grad_avg']
                     grad_avg.mul_(alpha).add_(1 - alpha, grad)
@@ -77,9 +76,9 @@ class RMSprop(Optimizer):
                     avg = square_avg.sqrt().add_(group['eps'])
 
                 if group['momentum'] > 0:
-                    mom = state['momentum']
-                    mom.mul_(group['momentum']).addcdiv_(grad, avg)
-                    p.data.add_(-group['lr'], mom)
+                    buf = state['momentum_buffer']
+                    buf.mul_(group['momentum']).addcdiv_(grad, avg)
+                    p.data.add_(-group['lr'], buf)
                 else:
                     p.data.addcdiv_(-group['lr'], grad, avg)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -5,7 +5,9 @@ class RMSprop(Optimizer):
     """Implements RMSprop algorithm.
 
     Proposed by G. Hinton in its `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
-    The centered version first appears in `Generating Sequences With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.
+
+    The centered version first appears in `Generating Sequences
+    With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.
 
     Arguments:
         params (iterable): iterable of parameters to optimize or dicts defining

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -12,7 +12,7 @@ class RMSprop(Optimizer):
         alpha (float, optional): smoothing constant (default: 0.99)
         eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
-        centered (bool, optional) : if True, compute the centered RMSProp, 
+        centered (bool, optional) : if True, compute the centered RMSProp,
             the gradient is normalized by an estimation of its variance
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
 
@@ -63,7 +63,7 @@ class RMSprop(Optimizer):
                     avg = square_avg.addcmul(-1, grad_avg, grad_avg).sqrt().add_(group['eps'])
                 else:
                     avg = square_avg.sqrt().add_(group['eps'])
-                
+
                 momentum.mul_(group['momentum']).addcdiv_(-group['lr'], grad, avg)
                 p.data.add_(-momentum)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -19,7 +19,7 @@ class RMSprop(Optimizer):
     """
 
     def __init__(self, params, lr=1e-2, momentum=0, alpha=0.99, eps=1e-8, centered=False, weight_decay=0):
-        defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=False, weight_decay=weight_decay)
+        defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=centered, weight_decay=weight_decay)
         super(RMSprop, self).__init__(params, defaults)
 
     def step(self, closure=None):

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -78,8 +78,8 @@ class RMSprop(Optimizer):
 
                 if group['momentum'] > 0:
                     mom = state['momentum']
-                    mom.mul_(group['momentum']).addcdiv_(group['lr'], grad, avg)
-                    p.data.add_(-mom)
+                    mom.mul_(group['momentum']).addcdiv_(grad, avg)
+                    p.data.add_(-group['lr'], mom)
                 else:
                     p.data.addcdiv_(-group['lr'], grad, avg)
 

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -64,7 +64,7 @@ class RMSprop(Optimizer):
                 else:
                     avg = square_avg.sqrt().add_(group['eps'])
 
-                momentum.mul_(group['momentum']).addcdiv_(-group['lr'], grad, avg)
+                momentum.mul_(group['momentum']).addcdiv_(group['lr'], grad, avg)
                 p.data.add_(-momentum)
 
         return loss


### PR DESCRIPTION
Add two options :
 - Momentum (like SGD's momentum)
- Centered RMSprop, as in Graves 2013 ( https://arxiv.org/abs/1308.0850 ) : grad is normalized by running estimation of its variance