### PR TITLE
BUGFIX in serialization.py: deal with unicode filename in torch.load() and torch.save()

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -116,7 +116,7 @@ def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
         pickle_protocol: can be specified to override the default protocol
     """
     new_fd = False
-    if isinstance(f, str):
+    if isinstance(f, str) or isinstance(f, unicode):
         new_fd = True
         f = open(f, "wb")
     try:
@@ -241,7 +241,7 @@ def load(f, map_location=None, pickle_module=pickle):
             the pickle_module used to serialize file)
     """
     new_fd = False
-    if isinstance(f, str):
+    if isinstance(f, str) or isinstance(f, unicode):
         new_fd = True
         f = open(f, 'rb')
     try:


### PR DESCRIPTION
BUG FIX: the torch.load() and torch.save() function did not deal with unicode filename properly.