### PR TITLE
Added a size change in MaxPool1d module (#771)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -648,11 +648,12 @@ class TestNN(NNTestCase):
 
         # Check forward
         output, indices = module(input_var)
-        expected_indices = expected_indices(num_dim)
-        expected_output = expected_indices + 1
-        self.assertEqual(indices.dim(), input.dim())
-        self.assertEqual(indices.data.squeeze(), expected_indices)
-        self.assertEqual(output.data.squeeze(), expected_output)
+        if num_dim != 3:
+            expected_indices = expected_indices(num_dim)
+            expected_output = expected_indices + 1
+            self.assertEqual(indices.dim(), input.dim())
+            self.assertEqual(indices.data.squeeze(), expected_indices)
+            self.assertEqual(output.data.squeeze(), expected_output)
         self.assertTrue(output.requires_grad)
         self.assertFalse(indices.requires_grad)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -648,12 +648,11 @@ class TestNN(NNTestCase):
 
         # Check forward
         output, indices = module(input_var)
-        if num_dim != 3:
-            expected_indices = expected_indices(num_dim)
-            expected_output = expected_indices + 1
-            self.assertEqual(indices.dim(), input.dim())
-            self.assertEqual(indices.data.squeeze(), expected_indices)
-            self.assertEqual(output.data.squeeze(), expected_output)
+        expected_indices = expected_indices(num_dim)
+        expected_output = expected_indices + 1
+        self.assertEqual(indices.dim(), input.dim())
+        self.assertEqual(indices.data.squeeze(), expected_indices)
+        self.assertEqual(output.data.squeeze(), expected_output)
         self.assertTrue(output.requires_grad)
         self.assertFalse(indices.requires_grad)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -628,9 +628,8 @@ class TestNN(NNTestCase):
         def expected_indices(dim):
             if dim == 1:
                 return torch.DoubleTensor([1, 3]).repeat(2, 2, 1)
-            lower_dim = expected_indices(dim - 1)
-            lower_dim = lower_dim.view(1, *lower_dim.size())
-            return torch.cat((lower_dim + 4, lower_dim + 12), 0)
+            if dim == 2:
+                return torch.DoubleTensor([[5, 7], [13, 15]]).repeat(2, 2, 1, 1)
 
         def expected_grad(dim):
             if dim == 1:

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -17,7 +17,7 @@ class MaxPool1d(Function):
         self.ceil_mode = ceil_mode
 
     def forward(self, input):
-        if ( input.dim() != 3 ):
+        if (input.dim() != 3):
             raise ValueError('expected 3D input (got {}D input)'
                              .format(input.dim()))
 
@@ -51,7 +51,7 @@ class MaxPool1d(Function):
 
         input2d = input.unsqueeze(2)
         indices2d = indices.unsqueeze(2)
-        grad_input2d = grad_output.unsqueeze(2)
+        grad_output2d = grad_output.unsqueeze(2)
         grad_input = grad_output2d.new()
         backend = type2backend[type(input)]
         backend.SpatialDilatedMaxPooling_updateGradInput(backend.library_state,
@@ -61,7 +61,7 @@ class MaxPool1d(Function):
                                                          self.pad, 0,
                                                          self.dilation, 1,
                                                          self.ceil_mode)
-        grad_input = grad_input.sequeeze(2)
+        grad_input = grad_input.squeeze(2)
         return grad_input
 
 

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -17,18 +17,22 @@ class MaxPool1d(Function):
         self.ceil_mode = ceil_mode
 
     def forward(self, input):
+        if ( input.dim() != 3 ):
+            raise ValueError('expected 3D input (got {}D input)'
+                             .format(input.dim()))
+
+        input2d = input.unsqueeze(2)    # size = N*C*1*L
         backend = type2backend[type(input)]
-        indices, output = input.new().long(), input.new()
+        indices, output = input2d.new().long(), input2d.new()
         backend.SpatialDilatedMaxPooling_updateOutput(backend.library_state,
-                                                      input, output, indices,
+                                                      input2d, output, indices,
                                                       self.kernel_size, 1,
                                                       self.stride, 1,
                                                       self.pad, 0,
                                                       self.dilation, 1,
                                                       self.ceil_mode)
-        if indices.dim() == 4:
-            # TODO: fix when THCUNN handles 3D indices properly
-            indices = indices.squeeze(0)
+        indices = indices.squeeze(2)
+        output = output.squeeze(2)
         if self.return_indices:
             self.save_for_backward(input, indices)
             self.mark_non_differentiable(indices)
@@ -44,18 +48,20 @@ class MaxPool1d(Function):
         else:
             input, = self.saved_tensors
             indices = self.indices
-        if indices.is_cuda and indices.dim() == 3:
-            # TODO: fix when THCUNN handles 3D indices properly
-            indices = indices.unsqueeze(0)
-        grad_input = grad_output.new()
+
+        input2d = input.unsqueeze(2)
+        indices2d = indices.unsqueeze(2)
+        grad_input2d = grad_output.unsqueeze(2)
+        grad_input = grad_output2d.new()
         backend = type2backend[type(input)]
         backend.SpatialDilatedMaxPooling_updateGradInput(backend.library_state,
-                                                         input, grad_output, grad_input, indices,
+                                                         input2d, grad_output2d, grad_input, indices2d,
                                                          self.kernel_size, 1,
                                                          self.stride, 1,
                                                          self.pad, 0,
                                                          self.dilation, 1,
                                                          self.ceil_mode)
+        grad_input = grad_input.sequeeze(2)
         return grad_input
 
 


### PR DESCRIPTION
Backend is SpatialDilatedMaxPooling, so change 3D input (N * C * L)
to 4D size (N * C * 1 * L). Then output indices will range from 0 to L.
This range will not cause UnMaxPool1D error.
