### PR TITLE
Support unicode objects in default_collate (Issue #826)

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -60,6 +60,10 @@ def _pin_memory_loop(in_queue, out_queue, done_event):
 
 def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
+    if sys.version_info[0] < 3:
+        # handle the case of unicode in python 2.7
+        if isinstance(batch[0], unicode):
+            return batch
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
     elif type(batch[0]).__module__ == 'numpy':  # this allows to not import numpy


### PR DESCRIPTION
Add the code for handling unicode objects in Python 2.7. I tested the code works well in Python 2.7.

[issue #826 ](https://github.com/pytorch/pytorch/issues/826)