### PR TITLE
Bug fixes

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -28,6 +28,18 @@ Containers
 .. autoclass:: Sequential
     :members:
 
+:hidden:`ModuleList`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ModuleList
+    :members:
+
+:hidden:`ParameterList`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ParameterList
+    :members:
+
 Convolution Layers
 ----------------------------------
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -487,7 +487,6 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, torch.ones(10, 10) * 2)
 
     def test_type_conversions(self):
-        import torch.cuda
         x = Variable(torch.randn(5, 5))
         self.assertIs(type(x.float().data), torch.FloatTensor)
         self.assertIs(type(x.int().data), torch.IntTensor)
@@ -871,7 +870,10 @@ function_tests = [
     (Index, (slice(0, 3),), (torch.rand(S, S, S),), 'slice'),
     (Index, ((slice(0, 3), 1),), (torch.rand(S, S, S),), 'slice_index'),
     (View, (S * S, S), (torch.rand(S, S, S),)),
-    (Expand, ((S, 5, S, 5),), ((S, 1, S, 1),)),
+    (Expand, ((5, S, 5, S, 5),), ((1, S, 1, S, 1),)),
+    (Expand, ((S, S, S),), ((S, 1),), 'new_dim'),
+    (Expand, ((S, S, S),), ((1, S),), 'new_dim_front'),
+    (Expand, ((S, S, S),), ((1,),), 'scalar'),
     (Exp, (), (torch.rand(S, S, S),)),
     (Log, (), (torch.rand(S, S, S) + 1e-2,)),
     (Log1p, (), (torch.rand(S, S, S),)),
@@ -921,7 +923,7 @@ function_tests = [
     (Addr, (0.1, 0.4), ((S, M), (S,), (M,)), 'coef'),
     (Dot, (), ((L,), (L,)),),
     (Max, (), ((S, S, S),),),
-    (Repeat, (torch.Size([2, 3, 1, 4]),), ((S, S, S, S),)),
+    (Repeat, (torch.Size([2, 3, 1, 2]),), ((S, S, S, S),)),
     (Min, (), ((S, S, S),),),
     (Max, (0,), ((S, S, S),), 'dim'),
     (Min, (0,), ((S, S, S),), 'dim'),
@@ -987,8 +989,10 @@ method_tests = [
     ('t', (1, 2), ()),
     ('view', (S, S, S), (S * S, S),),
     ('view_as', (S, S, S), ((S * S, S),)),
-    ('expand', (S, 1, S), (S, S, S)),
+    ('expand', (S, 1, 1), (S, S, S)),
     ('expand', (torch.Size([S, 1, S]),), (S, S, S), 'size'),
+    ('expand', (S, 1), (S, S, S), 'new_dim'),
+    ('expand', (1,), (S, S, S), 'scalar'),
     ('exp', (S, S, S), ()),
     ('log', (S, S, S), ()),
     ('log1p', (S, S, S), ()),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -254,6 +254,21 @@ class TestAutograd(TestCase):
         check_index(torch.rand(4, 4).bernoulli().byte())
         check_index((Ellipsis, slice(2, None)))
 
+    def test_basic_op_grad(self):
+        """Grad output might need to be reshaped to match the second argument."""
+        x = Variable(torch.randn(4, 6), requires_grad=True)
+        b = Variable(torch.rand(12, 1) + 1e-2, requires_grad=True)
+
+        def y():
+            # .mm() depends on the grad_output being of correct size
+            return b.mm(Variable(torch.rand(1, 2) + 1e-2))
+
+        (x + y()).sum().backward()
+        (x - y()).sum().backward()
+        (x * y()).sum().backward()
+        (x / y()).sum().backward()
+        (x.abs() ** y()).sum().backward()
+
     def test_requires_grad(self):
         x = Variable(torch.randn(5, 5))
         y = Variable(torch.randn(5, 5))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1055,18 +1055,18 @@ method_tests = [
 # TODO: clamp with min/max
 
 
-def create_input(call_args):
+def create_input(call_args, requires_grad=True):
     if not isinstance(call_args, tuple):
         call_args = (call_args,)
 
     def map_arg(arg):
         if isinstance(arg, tuple) and not isinstance(arg[0], Variable):
-            return Variable(torch.randn(*arg).double(), requires_grad=True)
+            return Variable(torch.randn(*arg).double(), requires_grad=requires_grad)
         elif torch.is_tensor(arg):
             if isinstance(arg, torch.FloatTensor):
-                return Variable(arg.double(), requires_grad=True)
+                return Variable(arg.double(), requires_grad=requires_grad)
             else:
-                return Variable(arg, requires_grad=True)
+                return Variable(arg, requires_grad=requires_grad)
         else:
             return arg
     return tuple(map_arg(arg) for arg in call_args)
@@ -1150,8 +1150,8 @@ for test in method_tests:
 
     def do_test(self, name=name, self_size=self_size, args=args, test_name=test_name):
         def check(name):
-            self_variable = create_input((self_size,))[0]
-            args_variable = create_input(args)
+            self_variable = create_input((self_size,), requires_grad=False)[0]
+            args_variable = create_input(args, requires_grad=False)
             self_tensor = deepcopy(self_variable.data)
             args_tensor = deepcopy(unpack_variables(args_variable))
             output_variable = getattr(self_variable, name)(*args_variable)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1088,7 +1088,7 @@ class TestNN(NNTestCase):
         model_cp = deepcopy(model)
         self.assertEqual(model(input).data, model_cp(input).data)
 
-        model_cp.linear.weight[:] = 2
+        model_cp.linear.weight.data[:] = 2
         self.assertNotEqual(model(input).data, model_cp(input).data)
 
     def test_RNN_cell(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1892,8 +1892,9 @@ class TestTorch(TestCase):
         reference = self._consecutive((5, 5, 5))
         idx = torch.LongTensor([2, 4])
         self.assertEqual(reference[idx], torch.stack([reference[2], reference[4]]))
-        self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
-        self.assertEqual(reference[3, idx, 1], torch.stack([reference[3, 2], reference[3, 4]])[:, 1])
+        # TODO: enable one indexing is implemented like in numpy
+        # self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
+        # self.assertEqual(reference[3, idx, 1], torch.stack([reference[3, 2], reference[3, 4]])[:, 1])
 
         # None indexing
         self.assertEqual(reference[2, None], reference[2].unsqueeze(0))
@@ -1944,6 +1945,7 @@ class TestTorch(TestCase):
         checkPartialAssign((0, 1))
         checkPartialAssign((1, 2))
         checkPartialAssign((0, 2))
+        checkPartialAssign(torch.LongTensor((0, 2)))
 
         with self.assertRaises(IndexError):
             reference[1, 1, 1, 1] = 1
@@ -1964,10 +1966,8 @@ class TestTorch(TestCase):
         with self.assertRaises(TypeError):
             reference[0.0, :, 0.0] = 1
 
-        # LongTensor assignments are not supported yet
-        with self.assertRaises(RuntimeError):
-            reference[torch.LongTensor([2, 4])] = 1
-        with self.assertRaises(RuntimeError):
+        # LongTensor assignments are not fully supported yet
+        with self.assertRaises(TypeError):
             reference[0, torch.LongTensor([2, 4])] = 1
 
     def test_index_copy(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2181,13 +2181,30 @@ class TestTorch(TestCase):
         self.assertRaises(RuntimeError, lambda: tensor.view(15, -1, -1))
 
     def test_expand(self):
-        result = torch.Tensor()
-        tensor = torch.rand(8, 1)
-        template = torch.rand(8, 5)
+        tensor = torch.rand(1, 8, 1)
+        tensor2 = torch.rand(5)
+        template = torch.rand(4, 8, 5)
         target = template.size()
         self.assertEqual(tensor.expand_as(template).size(), target)
-        self.assertEqual(tensor.expand(8, 5).size(), target)
-        self.assertEqual(tensor.expand(torch.Size([8, 5])).size(), target)
+        self.assertEqual(tensor.expand(4, 8, 5).size(), target)
+        self.assertEqual(tensor.expand(target).size(), target)
+        self.assertEqual(tensor2.expand_as(template).size(), target)
+        self.assertEqual(tensor2.expand(4, 8, 5).size(), target)
+        self.assertEqual(tensor2.expand(target).size(), target)
+
+        # test double expand
+        self.assertEqual(tensor2.expand(1, 5).expand(2, 2, 5), tensor2.repeat(2, 2, 1))
+
+        # test non-contiguous
+        noncontig = torch.randn(5, 2, 1, 3)[:, 0]
+        assert not noncontig.is_contiguous()
+        self.assertEqual(noncontig.expand(2, 5, 4, 3), noncontig.contiguous().repeat(2, 1, 4, 1))
+
+        # make sure it's compatible with unsqueeze
+        expanded = tensor2.expand(1, 1, 5)
+        unsqueezed = tensor2.unsqueeze(0).unsqueeze(1)
+        self.assertEqual(expanded, unsqueezed)
+        self.assertEqual(expanded.stride(), unsqueezed.stride())
 
     def test_repeat(self):
         result = torch.Tensor()

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -109,10 +109,11 @@ class Expand(Function):
         self.expanded_dims = []
 
     def forward(self, i):
-        self.expanded_dims = [dim for dim, (expanded, original)
-                              in enumerate(zip(self.sizes, i.size()))
-                              if expanded != original]
         result = i.expand(*self.sizes)
+        unsqueezed = (1,) * (len(self.sizes) - len(i.size()))
+        self.expanded_dims = [dim for dim, (expanded, original)
+                              in enumerate(zip(self.sizes, unsqueezed + i.size()))
+                              if expanded != original]
         self.mark_shared_storage((i, result))
         return result
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -18,9 +18,8 @@ class Index(Function):
         return result
 
     def backward(self, grad_output):
-        # TODO: this won't have to be zeroed
         grad_input = grad_output.new(self.input_size).zero_()
-        grad_input.index(self.index).copy_(grad_output)
+        grad_input._set_index(self.index, grad_output)
         return grad_input
 
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -220,32 +220,36 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
         output_var = input_var;
         input_var_.creator = THPFunction_asFunction(self);
       } else {
-        // If the Variable has been changed, we have to move it after the
+        // If the leaf Variable has been returned, we have to move it after the
         // current function to ensure the gradient is computed correctly.
         // There are two cases now:
-        // 1. If it requires grad, it is an error, and this will be caught
-        // when its _do_backward is called, because it won't be a leaf anymore.
-        // Also we'll change its version.
-        // 2. If it doesn't require grad, we can safely move it in the graph,
-        // because its _do_backward will never be called.
+        // 1. It has been modified in-place. If it didn't require_grad it's ok,
+        // but if it does, then it's a clear error.
+        // 2. It hasn't been modified. This means that it must have been
+        // returned unchanged, and we can simply return a new Variable
+        // referencing the same storage.
         if (dirty_inputs.count(output) > 0) {
           Py_INCREF(input_var);
           output_var = input_var;
           auto& output_var_ = *output_var->cdata;
           output_var_.creator = THPFunction_asFunction(self);
-          if (!output_var_.requires_grad && self->cdata.requires_grad) {
+          if (!output_var_.requires_grad) {
             // Now, there's another subtlety. We move the input in the graph
-            // and we change its requires_grad to True. However, remember
+            // and possibly change its requires_grad to True. However, remember
             // that we're still holding a reference to is as a previous
             // function. Backward engine will think that it was really a
             // leaf that initialy did require grad and call its _do_backward
             // and that will throw. Because of this, we need to allocate
             // a dummy leaf that doesn't require grad and put it as our
             // previous function.
-            output_var_.requires_grad = true;
+            // Even if the function doesn't require grad, creating a dummy leaf
+            // prevents the creation of reference cycles.
+            output_var_.requires_grad = self->cdata.requires_grad;
             auto dummy_prev_fn = std::make_shared<Variable>(
                 std::unique_ptr<Tensor>(output_var_.data->clone_shallow()), false, false);
             self->cdata.previous_functions[i] = std::make_pair<>(dummy_prev_fn, 0);
+          } else { // output_var_.requires_grad
+            throw std::runtime_error("a leaf Variable that requires grad has been used in an in-place operation.");
           }
         } else {
           // An input has been returned, but it wasn't modified. It's better

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -60,6 +60,7 @@ static bool THCPModule_assignStateless()
   PyObject *stateless;
   INIT_STATELESS(Double);
   INIT_STATELESS_DETAIL(Float, Cuda);
+  INIT_STATELESS(Half);
   INIT_STATELESS(Long);
   INIT_STATELESS(Int);
   INIT_STATELESS(Short);

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -23,6 +23,7 @@
 #endif
 
 PyObject *THPTensorClass = NULL;
+THPCopyList THTensor_(copy_functions);
 
 PyObject * THPTensor_(NewEmpty)()
 {
@@ -425,7 +426,6 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
 #endif
 
 
-template<bool allow_index>
 static bool THPTensor_(_indexOnce)(PyObject *index, int &indexed_dim,
         THTensorPtr &tresult, THStorage* &sresult, long &storage_offset)
 {
@@ -478,14 +478,6 @@ static bool THPTensor_(_indexOnce)(PyObject *index, int &indexed_dim,
     tresult->stride[indexed_dim] *= step;
     tresult->size[indexed_dim] /= step;
     indexed_dim++;
-  // Indexing with a LongTensor
-  } else if (THPIndexTensor_Check(index)) {
-    if (!allow_index)
-      throw std::runtime_error("assignments using LongTensors as index aren't supported yet");
-    THIndexTensor *index_t = ((THPIndexTensor*)index)->cdata;
-    THTensorPtr index_result = THTensor_(new)(LIBRARY_STATE_NOARGS);
-    THTensor_(indexSelect)(LIBRARY_STATE index_result.get(), tresult.get(), indexed_dim++, index_t);
-    tresult = index_result.release();
   } else {
     return false;
   }
@@ -493,7 +485,6 @@ static bool THPTensor_(_indexOnce)(PyObject *index, int &indexed_dim,
 }
 
 
-template<bool allow_index>
 static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
     THTensorPtr &tresult, THStorage * &sresult, long &storage_offset)
 {
@@ -531,7 +522,7 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
         continue;
       }
       PyObject *dimidx = PyTuple_GET_ITEM(index, dim);
-      valid = THPTensor_(_indexOnce)<allow_index>(dimidx, indexed_dim, tresult, sresult, storage_offset);
+      valid = THPTensor_(_indexOnce)(dimidx, indexed_dim, tresult, sresult, storage_offset);
       if (!valid) {
         tresult = NULL;
         // overwrite this, so the message mentions the incorrect object
@@ -540,78 +531,28 @@ static bool THPTensor_(_index)(THPTensor *self, PyObject *index,
       }
     }
     if (valid) return true;
-  } else if (index == Py_Ellipsis) return true;
-  else {
-    if (THPTensor_(_indexOnce)<allow_index>(index, indexed_dim, tresult, sresult, storage_offset))
+  } else if (index == Py_Ellipsis) {
+    return true;
+  } else {
+    if (THPTensor_(_indexOnce)(index, indexed_dim, tresult, sresult, storage_offset))
       return true;
   }
 
   PyErr_Format(PyExc_TypeError, "indexing a tensor with an object of type %s. "
       "The only supported types are integers, slices"
 #ifdef WITH_NUMPY
-      ", numpy scalars"
+      ", numpy scalars and "
 #endif
 #ifndef THC_GENERIC_FILE
-      ", torch.LongTensor and torch.ByteTensor.",
+      "torch.LongTensor or torch.ByteTensor as the only argument.",
 #else
-      ", torch.cuda.LongTensor and torch.cuda.ByteTensor.",
+      "torch.cuda.LongTensor or torch.cuda.ByteTensor as the only argument.",
 #endif
     THPUtils_typename(index));
   return false;
 }
 #undef IS_SCALAR
-#undef THIndexTensor
-#undef THIndexTensor_
-#undef THPIndexTensor
-#undef THPIndexTensor_Check
-
-extern THPCopyList THTensor_(copy_functions);
-THPCopyList THTensor_(copy_functions);
-
-void THPTensor_(initCopyMethods)()
-{
-  auto& h = THTensor_(copy_functions);
-  // copy from CPU types
-  THPInsertCopyFunction(h, &THTensor_(copyByte));
-  THPInsertCopyFunction(h, &THTensor_(copyChar));
-  THPInsertCopyFunction(h, &THTensor_(copyShort));
-  THPInsertCopyFunction(h, &THTensor_(copyInt));
-  THPInsertCopyFunction(h, &THTensor_(copyLong));
-  THPInsertCopyFunction(h, &THTensor_(copyFloat));
-  THPInsertCopyFunction(h, &THTensor_(copyDouble));
-#ifdef THC_GENERIC_FILE
-  // copy from GPU types
-  THPInsertCopyFunction(h, &THTensor_(copyCudaByte));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaChar));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaShort));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaInt));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaLong));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaFloat));
-  THPInsertCopyFunction(h, &THTensor_(copyCudaDouble));
-#ifdef CUDA_HALF_TENSOR
-  THPInsertCopyFunction(h, &THTensor_(copyCudaHalf));
-#endif
-#ifndef THC_REAL_IS_HALF
-  THPInsertCopyFunction(h, &THCTensor_(copyAsyncCPU), true);
-  // add CPU <- GPU copies to base type
-  #define THCpuTensor_(name) TH_CONCAT_4(TH, Real, Tensor_, name)
-  extern THPCopyList THCpuTensor_(copy_functions);
-  auto& b = THCpuTensor_(copy_functions);
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaByte));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaChar));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaShort));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaInt));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaLong));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaFloat));
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaDouble));
-#ifdef CUDA_HALF_TENSOR
-  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaHalf));
-#endif
-  THPInsertCopyFunction(b, &THCpuTensor_(copyAsyncCuda), true);
-  #undef THCpuTensor_
-#endif
-#endif
-}
+#undef UNPACK_SCALAR
 
 template<bool force_tensor>
 static PyObject * THPTensor_(getValue)(THPTensor *self, PyObject *index)
@@ -629,11 +570,17 @@ static PyObject * THPTensor_(getValue)(THPTensor *self, PyObject *index)
     THTensor_(maskedSelect)(LIBRARY_STATE t.get(), self->cdata, mask->cdata);
     return THPTensor_(New)(t.release());
   }
+  if (THPIndexTensor_Check(index)) {
+    THIndexTensor *index_t = ((THPIndexTensor*)index)->cdata;
+    THTensorPtr index_result = THTensor_(new)(LIBRARY_STATE_NOARGS);
+    THTensor_(indexSelect)(LIBRARY_STATE index_result.get(), self->cdata, 0, index_t);
+    return THPTensor_(New)(index_result.release());
+  }
 
   THTensorPtr tresult;
   THStorage *sresult;
   long storage_offset;
-  if (!THPTensor_(_index)<true>(self, index, tresult, sresult, storage_offset))
+  if (!THPTensor_(_index)(self, index, tresult, sresult, storage_offset))
     return NULL;
   if (tresult)
     return THPTensor_(New)(tresult.release());
@@ -675,11 +622,25 @@ static int THPTensor_(setValue)(THPTensor *self, PyObject *index, PyObject *valu
     }
     return 0;
   }
+  if (THPIndexTensor_Check(index)) {
+    THIndexTensor *index_t = ((THPIndexTensor*)index)->cdata;
+    if (THPUtils_(checkReal)(value)) {
+      real v = THPUtils_(unpackReal)(value);
+      THTensor_(indexFill)(LIBRARY_STATE self->cdata, 0, index_t, v);
+    } else if (THPTensor_(Check)(value)) {
+      THTensor_(indexCopy)(LIBRARY_STATE self->cdata, 0, index_t, ((THPTensor*)value)->cdata);
+    } else {
+      THPUtils_setError("can't assign %s to a " THPTensorStr " using a LongTensor "
+          "(only " THPTensorStr " or %s are supported)",
+          THPUtils_typename(value), THPUtils_typeTraits<real>::python_type_str);
+    }
+    return 0;
+  }
 
   THTensorPtr tresult;
   THStorage *sresult;
   long storage_offset;
-  if (!THPTensor_(_index)<false>(self, index, tresult, sresult, storage_offset))
+  if (!THPTensor_(_index)(self, index, tresult, sresult, storage_offset))
     return -1;
   if (sresult) {
     if (!force_tensor) {
@@ -714,6 +675,10 @@ static int THPTensor_(setValue)(THPTensor *self, PyObject *index, PyObject *valu
   return -1;
   END_HANDLE_TH_ERRORS_RET(-1)
 }
+#undef THIndexTensor
+#undef THIndexTensor_
+#undef THPIndexTensor
+#undef THPIndexTensor_Check
 
 Py_ssize_t THPTensor_(length)(THPTensor *self)
 {
@@ -830,6 +795,51 @@ PyTypeObject THPTensorStatelessType = {
 };
 
 #include "SparseTensor.cpp"
+
+void THPTensor_(initCopyMethods)()
+{
+  auto& h = THTensor_(copy_functions);
+  // copy from CPU types
+  THPInsertCopyFunction(h, &THTensor_(copyByte));
+  THPInsertCopyFunction(h, &THTensor_(copyChar));
+  THPInsertCopyFunction(h, &THTensor_(copyShort));
+  THPInsertCopyFunction(h, &THTensor_(copyInt));
+  THPInsertCopyFunction(h, &THTensor_(copyLong));
+  THPInsertCopyFunction(h, &THTensor_(copyFloat));
+  THPInsertCopyFunction(h, &THTensor_(copyDouble));
+#ifdef THC_GENERIC_FILE
+  // copy from GPU types
+  THPInsertCopyFunction(h, &THTensor_(copyCudaByte));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaChar));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaShort));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaInt));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaLong));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaFloat));
+  THPInsertCopyFunction(h, &THTensor_(copyCudaDouble));
+#ifdef CUDA_HALF_TENSOR
+  THPInsertCopyFunction(h, &THTensor_(copyCudaHalf));
+#endif
+#ifndef THC_REAL_IS_HALF
+  THPInsertCopyFunction(h, &THCTensor_(copyAsyncCPU), true);
+  // add CPU <- GPU copies to base type
+  #define THCpuTensor_(name) TH_CONCAT_4(TH, Real, Tensor_, name)
+  extern THPCopyList THCpuTensor_(copy_functions);
+  auto& b = THCpuTensor_(copy_functions);
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaByte));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaChar));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaShort));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaInt));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaLong));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaFloat));
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaDouble));
+#ifdef CUDA_HALF_TENSOR
+  THPInsertCopyFunction(b, &THCpuTensor_(copyCudaHalf));
+#endif
+  THPInsertCopyFunction(b, &THCpuTensor_(copyAsyncCuda), true);
+  #undef THCpuTensor_
+#endif
+#endif
+}
 
 bool THPTensor_(init)(PyObject *module)
 {

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -66,6 +66,27 @@ class Sequential(Module):
 
 
 class ModuleList(Module):
+    """Holds submodules in a list.
+
+    ModuleList can be indexed like a regular Python list, but modules it contains
+    are properly registered, and will be visible by all Module methods.
+
+    Arguments:
+        modules (list, optional): a list of modules to add
+
+    Example:
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.linears = nn.ModuleList([nn.Linear(10, 10) for i in range(10)])
+
+            def forward(self, x):
+                # ModuleList can act as an iterable, or be indexed using ints
+                for i, l in enumerate(self.linears):
+                    x = self.linears[i // 2](x) + l(x)
+                return x
+    """
 
     def __init__(self, modules=None):
         super(ModuleList, self).__init__()
@@ -90,10 +111,20 @@ class ModuleList(Module):
         return self.extend(modules)
 
     def append(self, module):
+        """Appends a given module at the end of the list.
+
+        Arguments:
+            module (nn.Module): module to append
+        """
         self.add_module(str(len(self)), module)
         return self
 
     def extend(self, modules):
+        """Appends modules from a Python list at the end.
+
+        Arguments:
+            modules (list): list of modules to append
+        """
         if not isinstance(modules, list):
             raise TypeError("ModuleList.extend should be called with a "
                             "list, but got " + type(modules).__name__)
@@ -104,6 +135,28 @@ class ModuleList(Module):
 
 
 class ParameterList(Module):
+    """Holds submodules in a list.
+
+    ParameterList can be indexed like a regular Python list, but parameters it contains
+    are properly registered, and will be visible by all Module methods.
+
+    Arguments:
+        modules (list, optional): a list of :class:`nn.Parameter`` to add
+
+    Example:
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.params = nn.ParameterList([nn.Parameter(torch.randn(10, 10)) for i in range(10)])
+
+            def forward(self, x):
+                # ModuleList can act as an iterable, or be indexed using ints
+                for i, p in enumerate(self.params):
+                    x = self.params[i // 2].mm(x) + p.mm(x)
+                return x
+    """
+
     def __init__(self, parameters=None):
         super(ParameterList, self).__init__()
         if parameters is not None:
@@ -127,10 +180,20 @@ class ParameterList(Module):
         return self.extend(parameters)
 
     def append(self, parameter):
+        """Appends a given parameter at the end of the list.
+
+        Arguments:
+            parameter (nn.Parameter): parameter to append
+        """
         self.register_parameter(str(len(self)), parameter)
         return self
 
     def extend(self, parameters):
+        """Appends parameters from a Python list at the end.
+
+        Arguments:
+            parameters (list): list of parameters to append
+        """
         if not isinstance(parameters, list):
             raise TypeError("ParameterList.extend should be called with a "
                             "list, but got " + type(parameters).__name__)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -66,6 +66,9 @@ class Optimizer(object):
             'param_groups': self.param_groups,
         }
 
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def state_dict(self):
         """Returns the state of the optimizer as a :class:`dict`.
 
@@ -115,14 +118,15 @@ class Optimizer(object):
         id_map = {old_id: p for old_id, p in
                   zip(chain(*(g['params'] for g in saved_groups)),
                       chain(*(g['params'] for g in groups)))}
-        self.state = {id_map.get(k, k): v for k, v in state_dict['state'].items()}
+        state = {id_map.get(k, k): v for k, v in state_dict['state'].items()}
 
         # Update parameter groups, setting their 'params' value
         def update_group(group, new_group):
             new_group['params'] = group['params']
             return new_group
-        self.param_groups = [
+        param_groups = [
             update_group(g, ng) for g, ng in zip(groups, saved_groups)]
+        self.__setstate__({'state': state, 'param_groups': param_groups})
 
     def zero_grad(self):
         """Clears the gradients of all optimized :class:`Variable` s."""


### PR DESCRIPTION
* Expose stateless methods for `torch.cuda.HalfTensor` (#827)
* Prevent creation of reference cycles in autograd (#839)
* Fix for Byte and Long tensor indexing of Variables (#828)
* Reshape grad_output in backward of basic ops (#818)
* Add docs for `ModuleList` and `ParameterList` (#814)
* Allow using expand to broadcast/unsqueeze tensors
* Make indexing 100% compatible with numpy again. Unfortunately this rolls back part of the support we had (LongTensors can now be be used only as the sole argument to indexing functions).
* Make `Optimizer.load_state_dict` use its `__setstate__` so we can implement backward-compatible extensions for optimizers (#766, #810).