### PR TITLE
Improve autograd memory usage

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -486,6 +486,12 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *inputs)
       if (self->cdata.requires_grad || self->cdata.is_stochastic) {
         _save_variables(self, t2var);
         _mark_non_differentiable(self, t2var);
+      } else {
+        // Remove unnecessary attributes
+        Py_XDECREF(self->to_save);
+        self->to_save = NULL;
+        Py_XDECREF(self->non_differentiable);
+        self->non_differentiable = NULL;
       }
     }
 

--- a/torch/nn/_functions/conv.py
+++ b/torch/nn/_functions/conv.py
@@ -91,10 +91,15 @@ class ConvNd(Function):
                 self._cudnn_info = torch._C._cudnn_convolution_full_forward(
                     input, weight, bias, output, self.padding, self.stride, self.dilation,
                     self.groups, cudnn.benchmark)
+            if not self.requires_grad:
+                del self._cudnn_info
             return output
 
         self._bufs = [[] for g in range(self.groups)]
-        return self._thnn('update_output', input, weight, bias)
+        output = self._thnn('update_output', input, weight, bias)
+        if not self.requires_grad:
+            del self._bufs
+        return output
 
     def _grad_input(self, input, weight, grad_output):
         if self.use_cudnn:

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -143,6 +143,9 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
         else:
             self.save_for_backward(input, *params)
 
+        if not self.requires_grad:
+            del self.buffers
+
         getattr(self._backend, update_output.name)(self._backend.library_state, input, output, *args)
         return output
 


### PR DESCRIPTION
References to tensors given to `save_for_backward()` and `mark_non_differentiable()` weren't freed if the function didn't require gradient. This lead to an increased memory usage when large parts of graph didn't require grad (e.g. ResNet-152 finetuning with batch_size 16 used to consume the same amount of memory as batch 256 after this commit).