### PR TITLE
[Lint] Use flake8 instead of pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,5 @@ matrix:
         env: LINT_CHECK
         python: "2.7"
         addons: true
-        install: pip install pep8
-        script: pep8
+        install: pip install flake8
+        script: flake8

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -382,7 +382,7 @@ class TestCuda(TestCase):
             self.assertEqual(z.get_device(), 0)
             self.assertIs(z.cuda(0), z)
 
-    def test_serialization(self):
+    def test_serialization_array_with_storage(self):
         x = torch.randn(5, 5).cuda()
         y = torch.IntTensor(2, 5).fill_(0).cuda()
         q = [x, y, x, y.storage()]
@@ -537,7 +537,7 @@ class TestCuda(TestCase):
         self.assertIs(type(x_copy), type(x))
         self.assertEqual(x_copy.get_device(), x.get_device())
 
-    def test_serialization_empty(self):
+    def test_serialization_array_with_empty(self):
         x = [torch.randn(4, 4).cuda(), torch.cuda.FloatTensor()]
         with tempfile.NamedTemporaryFile() as f:
             torch.save(x, f)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -473,7 +473,8 @@ class TestNN(NNTestCase):
             module_list.extend(nn.ReLU())
 
     def test_ParameterList(self):
-        make_param = lambda: Parameter(torch.randn(10, 10))
+        def make_param():
+            return Parameter(torch.randn(10, 10))
         parameters = [make_param(), make_param()]
         param_list = nn.ParameterList(parameters)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1655,7 +1655,7 @@ class TestTorch(TestCase):
         self._test_conv_corr_eq(lambda x, k: torch.xcorr3(x, k), reference)
 
     @unittest.skip("Not implemented yet")
-    def test_xcorr3_xcorr2_eq(self):
+    def test_xcorr3_xcorr2_eq_full(self):
         def reference(x, k, o3, o32):
             for i in range(x.size(1)):
                 for j in range(k.size(1)):
@@ -1663,7 +1663,7 @@ class TestTorch(TestCase):
         self._test_conv_corr_eq(lambda x, k: torch.xcorr3(x, k, 'F'), reference)
 
     @unittest.skip("Not implemented yet")
-    def test_conv3_conv2_eq(self):
+    def test_conv3_conv2_eq_valid(self):
         def reference(x, k, o3, o32):
             for i in range(o3.size(1)):
                 for j in range(k.size(1)):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -798,9 +798,11 @@ class TestTorch(TestCase):
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
         if order == 'descending':
-            check_order = lambda a, b: a >= b
+            def check_order(a, b):
+                return a >= b
         elif order == 'ascending':
-            check_order = lambda a, b: a <= b
+            def check_order(a, b):
+                return a <= b
         else:
             error('unknown order "{}", must be "ascending" or "descending"'.format(order))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,7 +6,6 @@ import shutil
 import random
 import tempfile
 import unittest
-import sys
 import traceback
 import torch
 import torch.cuda

--- a/tools/cwrap/plugins/KwargsPlugin.py
+++ b/tools/cwrap/plugins/KwargsPlugin.py
@@ -53,9 +53,9 @@ class KwargsPlugin(CWrapPlugin):
                         name not in seen_args):
                     seen_args.add(name)
                     args.append(name)
-        declarations = '\n    '.join(['PyObject *__kw_{} = NULL;'.format(name) for name in args])
+        declarations = '\n    '.join(['PyObject *__kw_{} = NULL;'.format(a) for a in args])
         lookups = '\n      '.join(
-            ['__kw_{name} = PyDict_GetItemString(kwargs, "{name}");'.format(name=name) for name in args])
+            ['__kw_{name} = PyDict_GetItemString(kwargs, "{name}");'.format(name=a) for a in args])
         start_idx = code.find('{') + 1
         new_code = self.WRAPPER_TEMPLATE.substitute(declarations=declarations, lookups=lookups)
         return code[:start_idx] + new_code + code[start_idx:]

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -430,12 +430,6 @@ class Variable(_C._VariableBase):
     def trunc(self):
         return Trunc()(self)
 
-    def floor(self):
-        return Floor()(self)
-
-    def ceil(self):
-        return Ceil()(self)
-
     def fmod(self, value):
         return Fmod(value)(self)
 
@@ -490,9 +484,6 @@ class Variable(_C._VariableBase):
 
     def split(self, split_size, dim=0):
         return torch.split(self, split_size, dim)
-
-    def chunk(self, n_chunks, dim=0):
-        return torch.chunk(self, n_chunks, dim)
 
     def repeat(self, *repeats):
         if len(repeats) == 1 and isinstance(repeats[0], torch.Size):

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,E731,F401,F403,F405,F811,F812,F821,F841
+ignore = E305,E402,E721,F401,F403,F405,F811,F812,F821,F841
 exclude = venv,docs/src

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,4 @@
-[pep8]
-max-line-length = 120
-ignore = E402,E721,E731,W503
-exclude = docs/src
-
 [flake8]
 max-line-length = 120
 ignore = E305,E402,E721,E731,F401,F403,F405,F811,F812,F821,F841
+exclude = venv,docs/src

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,F401,F403,F405,F811,F812,F821,F841
+ignore = E305,E402,E721,F401,F403,F405,F811,F821,F841
 exclude = venv,docs/src

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,F401,F403,F405,F811,F821,F841
-exclude = venv,docs/src
+ignore = E305,E402,E721,F401,F403,F405,F821,F841
+exclude = docs/src,venv


### PR DESCRIPTION
`flake8` checks for logic errors as well as stylistic issues. It also uses `pycodestyle` internally instead of the outdated `pep8` (thanks to @colesbury for pointing this out in https://github.com/pytorch/pytorch/pull/646).

While switching over, I fixed a few easy rules. Here are the errors `flake8` reported before the fixes:
```
428   F401 'torchvision' imported but unused
311   F405 'InplaceFunction' may be undefined, or defined from star imports: torch.autograd._functions
50    E402 module level import not at top of file
48    F821 undefined name 'error'
34    F841 local variable 'e' is assigned to but never used
26    E305 expected 2 blank lines after class or function definition, found 1
23    F403 'from torch.autograd._functions import *' used; unable to detect undefined names
6     F811 redefinition of unused 'test_serialization' from line 385
3     E731 do not assign a lambda expression, use a def
2     E721 do not compare types, use 'isinstance()'
1     F812 list comprehension redefines 'name' from line 50
```
And here is the trimmed down list:
```
428   F401 'torchvision' imported but unused
308   F405 'InplaceFunction' may be undefined, or defined from star imports: torch.autograd._functions
50    E402 module level import not at top of file
48    F821 undefined name 'error'
34    F841 local variable 'e' is assigned to but never used
26    E305 expected 2 blank lines after class or function definition, found 1
23    F403 'from torch.autograd._functions import *' used; unable to detect undefined names
2     E721 do not compare types, use 'isinstance()'
```
^ Those rules are the ones I've placed in `tox.ini`.

If you like `flake8`, I'll take a look at adding it to `pytorch/vision` as well (https://github.com/pytorch/vision/pull/65#issuecomment-282256807).