### PR TITLE
Fix bug where pinned memory event could be recorded on incorrect device

### DIFF
--- a/torch/lib/THC/THCStream.c
+++ b/torch/lib/THC/THCStream.c
@@ -3,6 +3,9 @@
 #include <cuda_runtime_api.h>
 #include "THAtomic.h"
 
+#define MAX_DEVICES 256
+static THCStream default_streams[MAX_DEVICES];
+
 
 THCStream* THCStream_new(int flags)
 {
@@ -13,18 +16,38 @@ THCStream* THCStream_new(int flags)
   return self;
 }
 
+THC_API THCStream* THCStream_defaultStream(int device)
+{
+  // default streams aren't refcounted
+  THAssert(device >= 0 && device < MAX_DEVICES);
+  THCStream* stream = &default_streams[device];
+  stream->device = device;
+  return stream;
+}
+
+THCStream* THCStream_newWithPriority(int flags, int priority)
+{
+  THCStream* self = (THCStream*) malloc(sizeof(THCStream));
+  self->refcount = 1;
+  THCudaCheck(cudaGetDevice(&self->device));
+  THCudaCheck(cudaStreamCreateWithPriority(&self->stream, flags, priority));
+  return self;
+}
+
 void THCStream_free(THCStream* self)
 {
-  if (!self) {
+  if (!self || !self->stream) {
     return;
   }
   if (THAtomicDecrementRef(&self->refcount)) {
-    THCudaCheck(cudaStreamDestroy(self->stream));
+    THCudaCheckWarn(cudaStreamDestroy(self->stream));
     free(self);
   }
 }
 
 void THCStream_retain(THCStream* self)
 {
-  THAtomicIncrementRef(&self->refcount);
+  if (self->stream) {
+    THAtomicIncrementRef(&self->refcount);
+  }
 }

--- a/torch/lib/THC/THCStream.h
+++ b/torch/lib/THC/THCStream.h
@@ -13,6 +13,8 @@ struct THCStream
 
 
 THC_API THCStream* THCStream_new(int flags);
+THC_API THCStream* THCStream_defaultStream(int device);
+THC_API THCStream* THCStream_newWithPriority(int flags, int priority);
 THC_API void THCStream_free(THCStream* self);
 THC_API void THCStream_retain(THCStream* self);
 

--- a/torch/lib/THC/generic/THCTensorCopy.c
+++ b/torch/lib/THC/generic/THCTensorCopy.c
@@ -123,7 +123,7 @@ void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, struct THTensor 
                               THTensor_(data)(src),
                               THTensor_(nElement)(src) * sizeof(real),
                               cudaMemcpyHostToDevice,
-                              stream == NULL ? NULL : stream->stream));
+                              stream->stream));
 
   THCudaCheck(THCCachingHostAllocator_recordEvent(src->storage->data, stream));
 


### PR DESCRIPTION
**Do not merge**

I want the contbuilds to run before I submit this upstream to THC