### PR TITLE
Add AutoGPU RAII that doesn't depend on Python API

### DIFF
--- a/torch/csrc/cuda/AutoGPU.cpp
+++ b/torch/csrc/cuda/AutoGPU.cpp
@@ -3,59 +3,52 @@
 #include "THCP.h"
 #include <THC/THC.h>
 
-THCPAutoGPU::THCPAutoGPU(int device_id) {
-  setDevice(device_id);
-}
-
-THCPAutoGPU::THCPAutoGPU(PyObject *args, PyObject *self) {
-  if (self && setObjDevice(self))
-    return;
-
-  if (!args)
-    return;
-  for (int i = 0; i < PyTuple_Size(args); i++) {
-    PyObject *arg = PyTuple_GET_ITEM(args, i);
-    if (setObjDevice(arg)) return;
-  }
-}
-
-bool THCPAutoGPU::setObjDevice(PyObject *obj) {
-  int new_device = -1;
+static int getObjDevice(PyObject *obj) {
   PyObject *obj_type = (PyObject*)Py_TYPE(obj);
   if (obj_type == THCPDoubleTensorClass) {
-    new_device = THCudaDoubleTensor_getDevice(LIBRARY_STATE ((THCPDoubleTensor*)obj)->cdata);
+    return THCudaDoubleTensor_getDevice(LIBRARY_STATE ((THCPDoubleTensor*)obj)->cdata);
   } else if (obj_type == THCPFloatTensorClass) {
-    new_device = THCudaTensor_getDevice(LIBRARY_STATE ((THCPFloatTensor*)obj)->cdata);
+    return THCudaTensor_getDevice(LIBRARY_STATE ((THCPFloatTensor*)obj)->cdata);
   } else if (obj_type == THCPHalfTensorClass) {
-    new_device = THCudaHalfTensor_getDevice(LIBRARY_STATE ((THCPHalfTensor*)obj)->cdata);
+    return THCudaHalfTensor_getDevice(LIBRARY_STATE ((THCPHalfTensor*)obj)->cdata);
   } else if (obj_type == THCPLongTensorClass) {
-    new_device = THCudaLongTensor_getDevice(LIBRARY_STATE ((THCPLongTensor*)obj)->cdata);
+    return THCudaLongTensor_getDevice(LIBRARY_STATE ((THCPLongTensor*)obj)->cdata);
   } else if (obj_type == THCPIntTensorClass) {
-    new_device = THCudaIntTensor_getDevice(LIBRARY_STATE ((THCPIntTensor*)obj)->cdata);
+    return THCudaIntTensor_getDevice(LIBRARY_STATE ((THCPIntTensor*)obj)->cdata);
   } else if (obj_type == THCPShortTensorClass) {
-    new_device = THCudaShortTensor_getDevice(LIBRARY_STATE ((THCPShortTensor*)obj)->cdata);
+    return THCudaShortTensor_getDevice(LIBRARY_STATE ((THCPShortTensor*)obj)->cdata);
   } else if (obj_type == THCPCharTensorClass) {
-    new_device = THCudaCharTensor_getDevice(LIBRARY_STATE ((THCPCharTensor*)obj)->cdata);
+    return THCudaCharTensor_getDevice(LIBRARY_STATE ((THCPCharTensor*)obj)->cdata);
   } else if (obj_type == THCPByteTensorClass) {
-    new_device = THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
+    return THCudaByteTensor_getDevice(LIBRARY_STATE ((THCPByteTensor*)obj)->cdata);
   }
-  return setDevice(new_device);
+  return -1;
 }
 
-bool THCPAutoGPU::setDevice(int new_device) {
-  if (new_device == -1)
-    return false;
-
-  if (device == -1)
-    THCudaCheck(cudaGetDevice(&device));
-  if (new_device != device)
-    THCPModule_setDevice(new_device);
-  return true;
+static int getObjDevice(PyObject *args, PyObject *self) {
+  if (self) {
+    int device = getObjDevice(self);
+    if (device != -1) {
+      return device;
+    }
+  }
+  if (args) {
+    for (int i = 0; i < PyTuple_Size(args); i++) {
+      int device = getObjDevice(PyTuple_GET_ITEM(args, i));
+      if (device != -1) {
+        return device;
+      }
+    }
+  }
+  return -1;
 }
 
-// This can throw... But if it does I have no idea how to recover.
-THCPAutoGPU::~THCPAutoGPU() {
-  if (device != -1)
-    THCPModule_setDevice(device);
+THCPAutoGPU::THCPAutoGPU(int device_id) : AutoGPU(device_id) {}
+
+THCPAutoGPU::THCPAutoGPU(PyObject *args, PyObject *self)
+  : AutoGPU(getObjDevice(args, self)) {
 }
 
+void THCPAutoGPU::setObjDevice(PyObject *obj) {
+  setDevice(getObjDevice(obj));
+}

--- a/torch/csrc/cuda/AutoGPU.h
+++ b/torch/csrc/cuda/AutoGPU.h
@@ -2,15 +2,13 @@
 #define THCP_AUTOGPU_INC
 
 #include <Python.h>
+#include "torch/csrc/utils/auto_gpu.h"
 
-class THCPAutoGPU {
+class THCPAutoGPU : public AutoGPU {
 public:
-  THCPAutoGPU(int device_id=-1);
+  explicit THCPAutoGPU(int device_id=-1);
   THCPAutoGPU(PyObject *args, PyObject *self=NULL);
-  ~THCPAutoGPU();
-  bool setObjDevice(PyObject *obj);
-  bool setDevice(int new_device);
-  int device = -1;
+  void setObjDevice(PyObject *obj);
 };
 
 #endif

--- a/torch/csrc/utils/auto_gpu.h
+++ b/torch/csrc/utils/auto_gpu.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// RAII structs to set CUDA device
+
+#include <string>
+#include <stdexcept>
+
+#ifdef WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+struct AutoGPU {
+  explicit AutoGPU(int device=-1) {
+    setDevice(device);
+  }
+
+  ~AutoGPU() {
+#ifdef WITH_CUDA
+    if (original_device != -1) {
+      cudaSetDevice(original_device);
+    }
+#endif
+  }
+
+  inline void setDevice(int device) {
+#ifdef WITH_CUDA
+    if (device == -1) {
+      return;
+    }
+    if (original_device == -1) {
+      cudaCheck(cudaGetDevice(&original_device));
+      if (device != original_device) {
+        cudaCheck(cudaSetDevice(device));
+      }
+    } else {
+      cudaCheck(cudaSetDevice(device));
+    }
+#endif
+  }
+
+  int original_device = -1;
+
+private:
+#ifdef WITH_CUDA
+  static void cudaCheck(cudaError_t err) {
+    if (err != cudaSuccess) {
+      std::string msg = "CUDA error (";
+      msg += std::to_string(err);
+      msg += "): ";
+      msg += cudaGetErrorString(err);
+      throw std::runtime_error(msg);
+    }
+  }
+#endif
+};

--- a/torch/csrc/utils/auto_stream.h
+++ b/torch/csrc/utils/auto_stream.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// RAII structs to set CUDA stream
+
+#ifdef WITH_CUDA
+#include <THC/THC.h>
+extern THCState* state;
+#endif
+
+struct AutoStream {
+#ifdef WITH_CUDA
+  explicit AutoStream(THCStream* stream)
+    : original_stream(THCState_getStream(state))
+  {
+    THCStream_retain(original_stream);
+    THCState_setStream(state, stream);
+  }
+
+  ~AutoStream() {
+    THCState_setStream(state, original_stream);
+    THCStream_free(original_stream);
+  }
+
+  THCStream* original_stream;
+#endif
+};


### PR DESCRIPTION
Separates out non-Python part of AutoGPU. This also compiles without
CUDA which is useful for generic tensor code.

Also fixes a bug where THCPAutoGPU may not always switch the device:

```
  THCPAutoGPU guard(-1);
  guard.setDevice(0);
  guard.setDevice(1);
  guard.setDevice(0);  // would not switch batch to 0
```