### PR TITLE
Lock the cudaFree mutex.

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -495,6 +495,8 @@ extern PyObject * THCPModule_cudaHostAllocator(PyObject *_unused);
 extern PyObject * THCPModule_cudaSynchronize(PyObject *_unused);
 extern PyObject * THCPModule_getLibPath(PyObject *_unused);
 extern PyObject * THCPModule_cudaSleep(PyObject *_unused, PyObject *cycles);
+extern PyObject * THCPModule_cudaLockMutex(PyObject *module);
+extern PyObject * THCPModule_cudaUnlockMutex(PyObject *module);
 
 extern PyObject * THCSPModule_initExtension(PyObject *self);
 #endif
@@ -525,6 +527,8 @@ static PyMethodDef TorchMethods[] = {
   {"_cuda_getLibPath", (PyCFunction)THCPModule_getLibPath, METH_NOARGS, NULL},
   {"_cuda_sleep", (PyCFunction)THCPModule_cudaSleep, METH_O, NULL},
   {"_cuda_sparse_init",  (PyCFunction)THCSPModule_initExtension,    METH_NOARGS,  NULL},
+  {"_cuda_lock_mutex",   (PyCFunction)THCPModule_cudaLockMutex,   METH_NOARGS,  NULL},
+  {"_cuda_unlock_mutex", (PyCFunction)THCPModule_cudaUnlockMutex, METH_NOARGS,  NULL},
 #endif
   {"_safe_call",      (PyCFunction)THPModule_safeCall,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"_set_default_tensor_type", (PyCFunction)THPModule_setDefaultTensorType, METH_O, NULL},

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -239,6 +239,20 @@ PyObject * THCPModule_cudaSleep(PyObject *_unused, PyObject *cycles)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject * THCPModule_cudaLockMutex(PyObject *module)
+{
+  auto mutex = THCCachingAllocator_getCudaFreeMutex();
+  mutex->lock();
+  Py_RETURN_NONE;
+}
+
+PyObject * THCPModule_cudaUnlockMutex(PyObject *module)
+{
+  auto mutex = THCCachingAllocator_getCudaFreeMutex();
+  mutex->unlock();
+  Py_RETURN_NONE;
+}
+
 PyObject * THCPModule_getLibPath(PyObject *_unused)
 {
 #define _STR(x) #x

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -198,6 +198,8 @@ Workspace chooseAlgorithm(
 
   if (!cache.find(conv.params, algo)) {
     if (benchmark) {
+      // findAlgorithm may call cudaFree()
+      std::lock_guard<std::mutex> lock(*THCCachingAllocator_getCudaFreeMutex());
       auto perfResults = search::findAlgorithm(handle, conv);
       if (perfResults.status == CUDNN_STATUS_SUCCESS) {
         *algo = perfResults.algo;

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -223,6 +223,15 @@ def _host_allocator():
     return torch._C._cuda_cudaHostAllocator()
 
 
+@contextlib.contextmanager
+def _free_mutex():
+    torch._C._cuda_lock_mutex()
+    try:
+        yield
+    finally:
+        torch._C._cuda_unlock_mutex()
+
+
 from .random import *
 
 ################################################################################

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -29,7 +29,7 @@ def is_available(tensors):
     for tensor in tensors:
         if not tensor.is_contiguous():
             return False
-        if not hasattr(tensor, 'get_device'):
+        if not tensor.is_cuda:
             return False
         device = tensor.get_device()
         if device in devices:
@@ -154,12 +154,13 @@ def all_reduce(inputs, outputs=None, op=SUM):
     comm = communicator(inputs, outputs)
     count = inputs[0].numel()
     data_type = nccl_types[inputs[0].type()]
-    for i in range(len(inputs)):
-        with torch.cuda.device(comm.devices[i]):
-            check_error(lib.ncclAllReduce(
-                ctypes.c_void_p(inputs[i].data_ptr()),
-                ctypes.c_void_p(outputs[i].data_ptr()),
-                count, data_type, op, comm[i], cudaStream()))
+    with torch.cuda._free_mutex():
+        for i in range(len(inputs)):
+            with torch.cuda.device(comm.devices[i]):
+                check_error(lib.ncclAllReduce(
+                    ctypes.c_void_p(inputs[i].data_ptr()),
+                    ctypes.c_void_p(outputs[i].data_ptr()),
+                    count, data_type, op, comm[i], cudaStream()))
 
 
 def reduce(inputs, outputs=None, root=0, op=SUM):
@@ -170,12 +171,13 @@ def reduce(inputs, outputs=None, root=0, op=SUM):
     comm = communicator(inputs)
     count = inputs[0].numel()
     data_type = nccl_types[inputs[0].type()]
-    for i in range(len(inputs)):
-        with torch.cuda.device(comm.devices[i]):
-            check_error(lib.ncclReduce(
-                ctypes.c_void_p(inputs[i].data_ptr()),
-                ctypes.c_void_p(outputs[i].data_ptr()), count,
-                data_type, op, root, comm[i], cudaStream()))
+    with torch.cuda._free_mutex():
+        for i in range(len(inputs)):
+            with torch.cuda.device(comm.devices[i]):
+                check_error(lib.ncclReduce(
+                    ctypes.c_void_p(inputs[i].data_ptr()),
+                    ctypes.c_void_p(outputs[i].data_ptr()), count,
+                    data_type, op, root, comm[i], cudaStream()))
 
 
 def broadcast(inputs, root=0):
@@ -184,11 +186,12 @@ def broadcast(inputs, root=0):
     comm = communicator(inputs)
     count = inputs[0].numel()
     data_type = nccl_types[inputs[0].type()]
-    for i in range(len(inputs)):
-        with torch.cuda.device(comm.devices[i]):
-            check_error(lib.ncclBcast(
-                ctypes.c_void_p(inputs[i].data_ptr()), count,
-                data_type, root, comm[i], cudaStream()))
+    with torch.cuda._free_mutex():
+        for i in range(len(inputs)):
+            with torch.cuda.device(comm.devices[i]):
+                check_error(lib.ncclBcast(
+                    ctypes.c_void_p(inputs[i].data_ptr()), count,
+                    data_type, root, comm[i], cudaStream()))
 
 
 def all_gather(inputs, outputs):
@@ -196,11 +199,13 @@ def all_gather(inputs, outputs):
     comm = communicator(inputs, outputs)
     count = inputs[0].numel()
     data_type = nccl_types[inputs[0].type()]
-    for i in range(len(inputs)):
-        with torch.cuda.device(comm.devices[i]):
-            check_error(lib.ncclAllGather(
-                ctypes.c_void_p(inputs[i].data_ptr()), count, data_type,
-                ctypes.c_void_p(outputs[i].data_ptr()), comm[i], cudaStream()))
+    with torch.cuda._free_mutex():
+        for i in range(len(inputs)):
+            with torch.cuda.device(comm.devices[i]):
+                check_error(lib.ncclAllGather(
+                    ctypes.c_void_p(inputs[i].data_ptr()), count, data_type,
+                    ctypes.c_void_p(outputs[i].data_ptr()), comm[i],
+                    cudaStream()))
 
 
 def reduce_scatter(inputs, outputs, op=SUM):
@@ -208,12 +213,13 @@ def reduce_scatter(inputs, outputs, op=SUM):
     comm = communicator(inputs, outputs)
     count = inputs[0].numel() // len(inputs)
     data_type = nccl_types[inputs[0].type()]
-    for i in range(len(inputs)):
-        with torch.cuda.device(comm.devices[i]):
-            check_error(lib.ncclReduceScatter(
-                ctypes.c_void_p(inputs[i].data_ptr()),
-                ctypes.c_void_p(outputs[i].data_ptr()), count, data_type,
-                op, comm[i], cudaStream()))
+    with torch.cuda._free_mutex():
+        for i in range(len(inputs)):
+            with torch.cuda.device(comm.devices[i]):
+                check_error(lib.ncclReduceScatter(
+                    ctypes.c_void_p(inputs[i].data_ptr()),
+                    ctypes.c_void_p(outputs[i].data_ptr()), count, data_type,
+                    op, comm[i], cudaStream()))
 
 
 def _check_inputs(inputs, outputs=None, size_multiplier=1):


### PR DESCRIPTION
Prevents NCCL calls from overlapping with cudaFree() which can lead to
deadlocks.