### PR TITLE
Add batch triangular factorization and solves

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7,6 +7,7 @@ import torch
 import torch.cuda
 import torch.cuda.comm as comm
 
+from test_torch import TestTorch
 from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests
 
 HAS_CUDA = True
@@ -739,48 +740,10 @@ class TestCuda(TestCase):
         self.assertEqual(gpu_tensor0[0], 2)
 
     def test_btrifact(self):
-        a = torch.Tensor((((1.3722, -0.9020),
-                           (1.8849, 1.9169)),
-                          ((0.7187, -1.1695),
-                           (-0.0139, 1.3572)),
-                          ((-1.6181, 0.7148),
-                           (1.3728, 0.1319)))).cuda()
-        LU_data, pivots, info = a.btrifact()
-        self.assertEqual(info.abs().sum(), 0)
-        I_U = torch.triu(torch.ones(2, 2)).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()
-        I_L = 1 - I_U
-        a_L = torch.zeros(a.size()).type_as(a)
-        a_U = a_L.clone()
-        a_L[torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()] = 1.0
-        a_L[I_L] = LU_data[I_L]
-        a_U[I_U] = LU_data[I_U]
-
-        P = torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a)
-        for i in range(3):
-            for j in range(2):
-                k = pivots[i, j] - 1
-                t = P[i, j, :].clone()
-                P[i, j, :] = P[i, k, :]
-                P[i, k, :] = t
-
-        a_ = torch.bmm(P, torch.bmm(a_L, a_U))
-        self.assertEqual(a_, a)
+        TestTorch._test_btrifact(self, lambda t: t.cuda())
 
     def test_btrisolve(self):
-        a = torch.Tensor((((1.3722, -0.9020),
-                           (1.8849, 1.9169)),
-                          ((0.7187, -1.1695),
-                           (-0.0139, 1.3572)),
-                          ((-1.6181, 0.7148),
-                           (1.3728, 0.1319)))).cuda()
-        b = torch.Tensor(((4.02, 6.19),
-                          (-1.56, 4.00),
-                          (9.81, -4.09))).cuda()
-        LU_data, pivots, info = a.btrifact()
-        self.assertEqual(info.abs().sum(), 0)
-        x = b.btrisolve(LU_data, pivots)
-        b_ = torch.bmm(a, x.unsqueeze(2)).squeeze()
-        self.assertEqual(b_, b)
+        TestTorch._test_btrisolve(self, lambda t: t.cuda())
 
 
 if HAS_CUDA:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -738,6 +738,50 @@ class TestCuda(TestCase):
         self.assertEqual(gpu_tensor1[0], 1)
         self.assertEqual(gpu_tensor0[0], 2)
 
+    def test_btrifact(self):
+        a = torch.Tensor((((1.3722, -0.9020),
+                           (1.8849, 1.9169)),
+                          ((0.7187, -1.1695),
+                           (-0.0139, 1.3572)),
+                          ((-1.6181, 0.7148),
+                           (1.3728, 0.1319)))).cuda()
+        LU_data, pivots, info = a.btrifact()
+        self.assertEqual(info.abs().sum(), 0)
+        I_U = torch.triu(torch.ones(2, 2)).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()
+        I_L = 1 - I_U
+        a_L = torch.zeros(a.size()).type_as(a)
+        a_U = a_L.clone()
+        a_L[torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()] = 1.0
+        a_L[I_L] = LU_data[I_L]
+        a_U[I_U] = LU_data[I_U]
+
+        P = torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a)
+        for i in range(3):
+            for j in range(2):
+                k = pivots[i, j] - 1
+                t = P[i, j, :].clone()
+                P[i, j, :] = P[i, k, :]
+                P[i, k, :] = t
+
+        a_ = torch.bmm(P, torch.bmm(a_L, a_U))
+        self.assertEqual(a_, a)
+
+    def test_btrisolve(self):
+        a = torch.Tensor((((1.3722, -0.9020),
+                           (1.8849, 1.9169)),
+                          ((0.7187, -1.1695),
+                           (-0.0139, 1.3572)),
+                          ((-1.6181, 0.7148),
+                           (1.3728, 0.1319)))).cuda()
+        b = torch.Tensor(((4.02, 6.19),
+                          (-1.56, 4.00),
+                          (9.81, -4.09))).cuda()
+        LU_data, pivots, info = a.btrifact()
+        self.assertEqual(info.abs().sum(), 0)
+        x = b.btrisolve(LU_data, pivots)
+        b_ = torch.bmm(a, x.unsqueeze(2)).squeeze()
+        self.assertEqual(b_, b)
+
 
 if HAS_CUDA:
     for decl in tests:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -419,6 +419,52 @@ class TestTorch(TestCase):
         res2 = matrixmultiply(mat1, mat2)
         self.assertEqual(res, res2)
 
+    @skipIfNoLapack
+    def test_btrifact(self):
+        a = torch.FloatTensor((((1.3722, -0.9020),
+                                (1.8849, 1.9169)),
+                               ((0.7187, -1.1695),
+                                (-0.0139, 1.3572)),
+                               ((-1.6181, 0.7148),
+                                (1.3728, 0.1319))))
+        LU_data, pivots, info = a.btrifact()
+        self.assertEqual(info.abs().sum(), 0)
+        I_U = torch.triu(torch.ones(2, 2)).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()
+        I_L = 1 - I_U
+        a_L = torch.zeros(a.size()).type_as(a)
+        a_U = a_L.clone()
+        a_L[torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()] = 1.0
+        a_L[I_L] = LU_data[I_L]
+        a_U[I_U] = LU_data[I_U]
+
+        P = torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a)
+        for i in range(3):
+            for j in range(2):
+                k = pivots[i, j] - 1
+                t = P[i, j, :].clone()
+                P[i, j, :] = P[i, k, :]
+                P[i, k, :] = t
+
+        a_ = torch.bmm(P, torch.bmm(a_L, a_U))
+        self.assertEqual(a_, a)
+
+    @skipIfNoLapack
+    def test_btrisolve(self):
+        a = torch.FloatTensor((((1.3722, -0.9020),
+                                (1.8849, 1.9169)),
+                               ((0.7187, -1.1695),
+                                (-0.0139, 1.3572)),
+                               ((-1.6181, 0.7148),
+                                (1.3728, 0.1319))))
+        b = torch.FloatTensor(((4.02, 6.19),
+                               (-1.56, 4.00),
+                               (9.81, -4.09)))
+        LU_data, pivots, info = a.btrifact()
+        self.assertEqual(info.abs().sum(), 0)
+        x = b.btrisolve(LU_data, pivots)
+        b_ = torch.bmm(a, x.unsqueeze(2)).squeeze()
+        self.assertEqual(b_, b)
+
     def test_bmm(self):
         num_batches = 10
         M, N, O = 23, 8, 12

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -15,6 +15,7 @@ class THPPlugin(CWrapPlugin):
         'THTensor*': Template('((THPTensor*)$arg)->cdata'),
         'THBoolTensor*': Template('((THPBoolTensor*)$arg)->cdata'),
         'THIndexTensor*': Template('((THPIndexTensor*)$arg)->cdata'),
+        'THIntegerTensor*': Template('((THPIntegerTensor*)$arg)->cdata'),
 
         'THCudaTensor*': Template('((THCPFloatTensor*)$arg)->cdata'),
         'THCudaDoubleTensor*': Template('((THCPDoubleTensor*)$arg)->cdata'),
@@ -51,6 +52,7 @@ class THPPlugin(CWrapPlugin):
         'THTensor*': Template('(PyObject*)Py_TYPE($arg) == THPTensorClass'),
         'THBoolTensor*': Template('(PyObject*)Py_TYPE($arg) == THPBoolTensorClass'),
         'THIndexTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIndexTensorClass'),
+        'THIntegerTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIntegerTensorClass'),
 
         'THCudaTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPFloatTensorClass'),
         'THCudaDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPDoubleTensorClass'),
@@ -152,6 +154,7 @@ ${cpu}
         'THIntTensor*': _allocate('Int', ALLOCATE_TMPL),
         'THBoolTensor*': _allocate('Byte', ALLOCATE_TMPL, ALLOCATE_CUDA),
         'THIndexTensor*': _allocate('Long', ALLOCATE_TMPL, ALLOCATE_CUDA),
+        'THIntegerTensor*': _allocate('Int', ALLOCATE_TMPL, ALLOCATE_CUDA),
 
         'THSTensor*': _allocate('', ALLOCATE_TMPL, sparse=True),
     }
@@ -166,6 +169,7 @@ ${cpu}
         'THIntTensor*': '" THPModuleStr "IntTensor',
         'THBoolTensor*': '" THPModuleStr "ByteTensor',
         'THIndexTensor*': '" THPModuleStr "LongTensor',
+        'THIntegerTensor*': '" THPModuleStr "IntTensor',
         'THFloatTensor*': '" THPModuleStr "FloatTensor',
         'THDoubleTensor*': '" THPModuleStr "DoubleTensor',
         'THCudaTensor*': 'torch.cuda.FloatTensor',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4362,3 +4362,48 @@ Example::
     [torch.FloatTensor of size 5]
 
 """)
+
+add_docstr(torch._C.btrifact,
+           """
+btrifact(A) -> Tensor, Tensor, IntTensor
+
+Batch LU factorization.
+
+Returns a tuple containing the LU factorization, pivots, and pivot format,
+and info if the factorizations succeeded across the minibatch.
+The error codes are from dgetrf and a non-zero value indicates an error occurred.
+The specific values are from cublas if cuda is being used, otherwise LAPACK.
+
+Arguments:
+    A (Tensor): tensor to factor.
+
+Example::
+
+    >>> A = torch.randn(2, 3, 3)
+    >>> A_LU_data, A_LU_pivots, info = A.btrifact()
+
+""")
+
+
+add_docstr(torch._C.btrisolve,
+           """
+btrisolve(b, A_LU_data, A_LU_pivots) -> Tensor
+
+Batch LU solve.
+
+Returns the LU solve of the linear system Ax = b.
+
+Arguments:
+    b (Tensor): RHS tensor.
+    A_LU (Tensor, IntTensor, fmt): LU-factorization of A from btrifact.
+
+Example::
+
+    >>> A = torch.randn(2, 3, 3)
+    >>> b = torch.randn(2, 3)
+    >>> A_LU_data, A_LU_pivots, info = torch.btrifact(A)
+    >>> x = b.trisolve(A_LU_data, A_LU_pivots)
+    >>> torch.norm(A.bmm(x.unsqueeze(2)) - b)
+    6.664001874625056e-08
+
+""")

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -292,6 +292,8 @@ IMPLEMENT_STATELESS(qr)
 IMPLEMENT_STATELESS(geqrf)
 IMPLEMENT_STATELESS(orgqr)
 IMPLEMENT_STATELESS(ormqr)
+IMPLEMENT_STATELESS(btrifact)
+IMPLEMENT_STATELESS(btrisolve)
 
 #undef IMPLEMENT_STATELESS
 
@@ -624,6 +626,8 @@ static PyMethodDef TorchMethods[] = {
   {"geqrf",           (PyCFunction)THPModule_geqrf,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"orgqr",           (PyCFunction)THPModule_orgqr,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"ormqr",           (PyCFunction)THPModule_ormqr,             METH_VARARGS | METH_KEYWORDS, NULL},
+  {"btrifact",        (PyCFunction)THPModule_btrifact,          METH_VARARGS | METH_KEYWORDS, NULL},
+  {"btrisolve",       (PyCFunction)THPModule_btrisolve,         METH_VARARGS | METH_KEYWORDS, NULL},
 
   // Sparse functions
   {"smm",             (PyCFunction)THSPModule_sspmm,          METH_VARARGS | METH_KEYWORDS,  NULL},

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -40,6 +40,18 @@
 #endif
 
 #if IS_CUDA
+#define THIntegerTensor THCudaIntTensor
+#define THIntegerTensor_(NAME) TH_CONCAT_2(THCudaIntTensor_,NAME)
+#define THPIntegerTensor THCPIntTensor
+#define THPIntegerTensorClass THCPIntTensorClass
+#else
+#define THIntegerTensor THIntTensor
+#define THIntegerTensor_(NAME) TH_CONCAT_2(THIntTensor_,NAME)
+#define THPIntegerTensor THPIntTensor
+#define THPIntegerTensorClass THPIntTensorClass
+#endif
+
+#if IS_CUDA
 #define THPBoolTensor THCPByteTensor
 #define THPBoolTensorClass THCPByteTensorClass
 #else

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1891,3 +1891,33 @@ static const char *R = &__R;
       if_false: N
       default: N
 ]]
+
+[[
+  name: btrifact
+  cname: btrifact
+  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE
+  with_stateless: true
+  return: argument 0,1,2
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - arg: THIntegerTensor* pivots
+      output: True
+    - arg: THIntegerTensor* info
+      output: True
+    - THTensor* self
+]]
+
+[[
+  name: btrisolve
+  cname: btrisolve
+  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE
+  with_stateless: true
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* A_LU_data
+    - THTensor* self
+    - THIntegerTensor* A_LU_pivots
+]]

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1897,14 +1897,15 @@ static const char *R = &__R;
   cname: btrifact
   defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE
   with_stateless: true
-  return: argument 0,1,2
+  return: argument 0,1
   arguments:
     - arg: THTensor* result
       output: True
     - arg: THIntegerTensor* pivots
       output: True
     - arg: THIntegerTensor* info
-      output: True
+      kwarg_only: True
+      default: THIntegerTensor_(new)(LIBRARY_STATE_NOARGS)
     - THTensor* self
 ]]
 
@@ -1912,12 +1913,12 @@ static const char *R = &__R;
   name: btrisolve
   cname: btrisolve
   defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE
-  with_stateless: true
+  only_stateless: true
   return: argument 0
   arguments:
     - arg: THTensor* result
       output: True
-    - THTensor* A_LU_data
-    - THTensor* self
-    - THIntegerTensor* A_LU_pivots
+    - THTensor* LU
+    - THTensor* x
+    - THIntegerTensor* pivots
 ]]


### PR DESCRIPTION
Hi, this PR is not ready, but I would like to open it to get the conversation started and to keep a list of things we need to do to get this merged in. This contains batch triangular (LU) factorization and solves that our new QP PyTorch library [qpth](https://github.com/locuslab/qpth) needs. It provides this by calling into cuBLAS' `getR{f,s}Batched` funcitons. Here are things I plan to do (and I'll keep this list updated). Is there anything else I should do to help get this merged in?

+ [x] Add a CPU version (is there a way I can do this in Python?)
+ [x] Add tests
+ [x] Add docs
+ [x] Do you prefer `btrf` and `btrs` as names or something more memorable?

\cc @zkolter