### PR TITLE
fix corner case in kwargs for DataParallel

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -869,6 +869,9 @@ class TestNN(NNTestCase):
         out = dp.data_parallel(m, (var1, var2, float1), (0, 1))
         local_test(out)
 
+        out = dp.data_parallel(m, (var1, var2, float1), (1, 0))
+        local_test(out)
+
         out = dp.data_parallel(m, (var1, var2, float1), (0,))
         local_test(out)
 

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -80,7 +80,7 @@ class DataParallel(Module):
         scattered = self.scatter(inputs, self.device_ids)
         used_gpus = len(scattered)  # The last GPU might not be used. For example, input of size 4, on 5 GPUs
         gpu_dicts = None
-        if kwargs:
+        if kwargs is not None:
             gpu_dicts = [{} for i in range(used_gpus)]
             for key in kwargs.keys():
                 scattered_kwargs = self.scatter(_to_cuda(kwargs[key]), self.device_ids)

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -78,21 +78,16 @@ class DataParallel(Module):
 
         replicas = self.replicate(self.module, self.device_ids)
         scattered = self.scatter(inputs, self.device_ids)
-        used_gpus = len(scattered)  # The last GPU might not be used. For example, input of size 5, on 4 GPUs
+        used_gpus = len(scattered)  # The last GPU might not be used. For example, input of size 4, on 5 GPUs
         gpu_dicts = None
         if kwargs:
-            scatter_kwargs = {}
+            gpu_dicts = [{} for i in range(used_gpus)]
             for key in kwargs.keys():
-                scatter_kwargs[key] = self.scatter(
-                    _to_cuda(kwargs[key]), self.device_ids)
+                scattered_kwargs = self.scatter(_to_cuda(kwargs[key]), self.device_ids)
+                assert len(scattered_kwargs) == used_gpus
+                for i in range(used_gpus):
+                    gpu_dicts[i][key] = scattered_kwargs[i]
 
-            gpu_dicts = tuple()
-            for i in range(used_gpus):
-                gpu_dict = {}
-                for key, values in scatter_kwargs.items():
-                    assert len(values) == used_gpus
-                    gpu_dict[key] = values[i]
-                gpu_dicts += (gpu_dict,)
         replicas = replicas[:len(scattered)]
         outputs = self.parallel_apply(replicas, scattered, gpu_dicts)
         return self.gather(outputs, self.output_device)


### PR DESCRIPTION
When you have an input of dim[0] = 5, and it is sent to DataParallel on 4 GPUs, it is scattered as (2, 2, 1) and GPU-4 is unused.

In this case, the scattering logic of the kwargs scatter is broken, as it does not check for the number of GPUs used, and instead tries to use self.device_ids. This is wrong. 
Also, another bug is that it tries to use the values of self.device_ids, assuming that self.device_ids are given in ascending order starting from 0. If they are given as `(1,2,3,0)`, the incorrect kwargs are sent to the wrong GPU.

Fix these corner cases.
cc: @csarofeen 