### PR TITLE
Added support for multidimensional tensors in PReLU

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -164,13 +164,41 @@ module_tests = [
     ),
     dict(
         module_name='PReLU',
-        input_size=(2, 3, 4, 5)
+        input_size=(2, 3, 4),
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
+        desc='1d',
+    ),
+    dict(
+        module_name='PReLU',
+        constructor_args=(3,),
+        input_size=(2, 3, 4),
+        desc='1d_multiparam',
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
+    ),    dict(
+        module_name='PReLU',
+        input_size=(2, 3, 4, 5),
+        desc='2d',
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
     ),
     dict(
         module_name='PReLU',
         constructor_args=(3,),
         input_size=(2, 3, 4, 5),
-        desc='multiparam'
+        desc='2d_multiparam',
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
+    ),
+    dict(
+        module_name='PReLU',
+        input_size=(2, 3, 4, 5, 6),
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
+        desc='3d',
+    ),
+    dict(
+        module_name='PReLU',
+        constructor_args=(3,),
+        input_size=(2, 3, 4, 5, 6),
+        desc='3d_multiparam',
+        reference_fn=lambda i, p: torch.clamp(i, min=0) + torch.clamp(i, max=0) * p[0][0],
     ),
     dict(
         module_name='Softsign',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2034,6 +2034,26 @@ class TestNNInit(TestCase):
                         self.assertEqual(torch.mm(flattened_tensor, flattened_tensor.t()),
                                          torch.eye(rows) * gain ** 2, prec=1e-6)
 
+    def test_PReLU(self):
+        p = nn.PReLU(3, 0.3)
+
+        def forward_backward(input, grad_output):
+            output = p(input)
+            self.assertEqual(output[input > 0], input[input > 0])
+            self.assertEqual(output[input < 0], input[input < 0] * 0.3)
+
+            output.backward(grad_output)
+            grad_output = Variable(grad_output)
+            self.assertEqual(input.grad[input > 0], grad_output[input > 0])
+            self.assertEqual(input.grad[input < 0], grad_output[input < 0] * 0.3)
+
+        input = Variable(torch.randn(2, 3, 4), requires_grad=True)
+        grad_output = torch.randn(2, 3, 4)
+        forward_backward(input, grad_output)
+        input = Variable(torch.randn(2, 3, 4, 5, 6), requires_grad=True)
+        grad_output = torch.randn(2, 3, 4, 5, 6)
+        forward_backward(input, grad_output)
+
 
 def add_test(test):
     test_name = test.get_name()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2034,26 +2034,6 @@ class TestNNInit(TestCase):
                         self.assertEqual(torch.mm(flattened_tensor, flattened_tensor.t()),
                                          torch.eye(rows) * gain ** 2, prec=1e-6)
 
-    def test_PReLU(self):
-        p = nn.PReLU(3, 0.3)
-
-        def forward_backward(input, grad_output):
-            output = p(input)
-            self.assertEqual(output[input > 0], input[input > 0])
-            self.assertEqual(output[input < 0], input[input < 0] * 0.3)
-
-            output.backward(grad_output)
-            grad_output = Variable(grad_output)
-            self.assertEqual(input.grad[input > 0], grad_output[input > 0])
-            self.assertEqual(input.grad[input < 0], grad_output[input < 0] * 0.3)
-
-        input = Variable(torch.randn(2, 3, 4), requires_grad=True)
-        grad_output = torch.randn(2, 3, 4)
-        forward_backward(input, grad_output)
-        input = Variable(torch.randn(2, 3, 4, 5, 6), requires_grad=True)
-        grad_output = torch.randn(2, 3, 4, 5, 6)
-        forward_backward(input, grad_output)
-
 
 def add_test(test):
     test_name = test.get_name()


### PR DESCRIPTION
Fixes #724 
Also, for tensors with more than 1 dimension, the number of PReLU channels is now to be input in the second tensor dimension. 