### PR TITLE
Add argument to children to yield the name of the modules

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -456,6 +456,26 @@ class TestNN(NNTestCase):
         s = nn.Sequential(n, n, n, n)
         self.assertEqual(list(s.modules()), [s, n, l])
 
+    def test_named_modules(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.l1 = l
+                self.l2 = l
+                self.param = Variable(torch.Tensor(3, 5))
+                self.block = block
+        l = nn.Linear(10, 20)
+        l1 = nn.Linear(10, 20)
+        l2 = nn.Linear(10, 20)
+        block = nn.Sequential()
+        block.add_module('linear1', l1)
+        block.add_module('linear2', l2)
+        n = Net()
+        s = nn.Sequential(n, n, n, n)
+        self.assertEqual(list(s.named_modules()), [('', s), ('0', n), ('0.l1', l),
+                                                   ('0.block', block), ('0.block.linear1', l1),
+                                                   ('0.block.linear2', l2)])
+
     def test_Sequential_getitem(self):
         l1 = nn.Linear(10, 20)
         l2 = nn.Linear(20, 30)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -444,20 +444,27 @@ class TestNN(NNTestCase):
         self.assertEqual(num_params(s), 3)
 
     def test_children(self):
-      l1 = nn.Linear(2, 2)
-      l2 = nn.Linear(2, 2)
-      s = nn.Sequential(l1, l2, l1, l2)
-      self.assertEqual(list(s.children()), [l1, l2])
+        l1 = nn.Linear(2, 2)
+        l2 = nn.Linear(2, 2)
+        l3 = nn.Linear(2, 2)
+        l4 = nn.Linear(2, 2)
+        subnet = nn.Sequential(l3, l4)
+        s = nn.Sequential(l1, l2, l1, l2, subnet)
+        self.assertEqual(list(s.children()), [l1, l2])
 
     def test_named_children(self):
-      l1 = nn.Linear(2, 2)
-      l2 = nn.Linear(2, 2)
-      s = nn.Sequential()
-      s.add_module('layer1', l1)
-      s.add_module('layer2', l2)
-      s.add_module('layer3', l1)
-      s.add_module('layer4', l2)
-      self.assertEqual(list(s.named_children()), [('layer1', l1), ('layer2', l2)])
+        l1 = nn.Linear(2, 2)
+        l2 = nn.Linear(2, 2)
+        l3 = nn.Linear(2, 2)
+        l4 = nn.Linear(2, 2)
+        subnet = nn.Sequential(l3, l4)
+        s = nn.Sequential()
+        s.add_module('layer1', l1)
+        s.add_module('layer2', l2)
+        s.add_module('layer3', l1)
+        s.add_module('layer4', l2)
+        s.add_module('subnet', subnet)
+        self.assertEqual(list(s.named_children()), [('layer1', l1), ('layer2', l2)])
 
     def test_modules(self):
         class Net(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -450,7 +450,7 @@ class TestNN(NNTestCase):
         l4 = nn.Linear(2, 2)
         subnet = nn.Sequential(l3, l4)
         s = nn.Sequential(l1, l2, l1, l2, subnet)
-        self.assertEqual(list(s.children()), [l1, l2])
+        self.assertEqual(list(s.children()), [l1, l2, subnet])
 
     def test_named_children(self):
         l1 = nn.Linear(2, 2)
@@ -464,7 +464,7 @@ class TestNN(NNTestCase):
         s.add_module('layer3', l1)
         s.add_module('layer4', l2)
         s.add_module('subnet', subnet)
-        self.assertEqual(list(s.named_children()), [('layer1', l1), ('layer2', l2)])
+        self.assertEqual(list(s.named_children()), [('layer1', l1), ('layer2', l2), ('subnet', subnet)])
 
     def test_modules(self):
         class Net(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -443,6 +443,22 @@ class TestNN(NNTestCase):
         self.assertEqual(num_params(n), 3)
         self.assertEqual(num_params(s), 3)
 
+    def test_children(self):
+      l1 = nn.Linear(2, 2)
+      l2 = nn.Linear(2, 2)
+      s = nn.Sequential(l1, l2, l1, l2)
+      self.assertEqual(list(s.children()), [l1, l2])
+
+    def test_named_children(self):
+      l1 = nn.Linear(2, 2)
+      l2 = nn.Linear(2, 2)
+      s = nn.Sequential()
+      s.add_module('layer1', l1)
+      s.add_module('layer2', l2)
+      s.add_module('layer3', l1)
+      s.add_module('layer4', l2)
+      self.assertEqual(list(s.named_children()), [('layer1', l1), ('layer2', l2)])
+
     def test_modules(self):
         class Net(nn.Module):
             def __init__(self):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -403,7 +403,7 @@ class Module(object):
         if self not in memo:
             memo.add(self)
             yield prefix, self
-            for name, module in self.named_children():
+            for name, module in self._modules.items():
                 submodule_prefix = prefix + ('.' if prefix else '') + name
                 for m in module.named_modules(memo, submodule_prefix):
                     yield m

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -404,10 +404,7 @@ class Module(object):
             memo.add(self)
             yield prefix, self
             for name, module in self.named_children():
-                if prefix:
-                    submodule_prefix = prefix + '.' + name
-                else:
-                    submodule_prefix = name
+                submodule_prefix = prefix + ('.' if prefix else '') + name
                 for m in module.named_modules(memo, submodule_prefix):
                     yield m
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -339,7 +339,6 @@ class Module(object):
             for p in module.parameters(memo):
                 yield p
 
-
     def children(self):
         """Returns an iterator over immediate children modules."""
         memo = set()
@@ -350,7 +349,7 @@ class Module(object):
 
     def named_children(self):
         """Returns an iterator over immediate children modules, yielding both
-	the name of the module as well as the module itself.
+        the name of the module as well as the module itself.
 
         Example:
             >>> for name, module in model.named_children():

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -360,15 +360,26 @@ class Module(object):
                 else:
                     yield module
 
-    def modules(self, memo=None):
+    def modules(self, named=False, memo=None, prefix=None):
         if memo is None:
             memo = set()
+            prefix = []
         if self not in memo:
             memo.add(self)
-            yield self
-            for module in self.children():
-                for m in module.modules(memo):
+            if named is True:
+                yield '.'.join(prefix), self
+            else:
+                yield self
+            for child in self.children(named):
+                if named is True:
+                    name, module = child
+                    prefix.append(name)
+                else:
+                    module = child
+                for m in module.modules(named, memo, prefix):
                     yield m
+                if prefix:
+                    prefix.pop()
 
     def train(self, mode=True):
         """Sets the module in training mode.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -367,7 +367,7 @@ class Module(object):
 
         Note:
             Duplicate modules are returned only once. In the following
-            example, `l` will be returned only once.
+            example, ``l`` will be returned only once.
 
             >>> l = nn.Linear(2, 2)
             >>> net = nn.Sequential(l, l)
@@ -394,7 +394,7 @@ class Module(object):
 
         Note:
             Duplicate modules are returned only once. In the following
-            example, `l` will be returned only once.
+            example, ``l`` will be returned only once.
 
             >>> l = nn.Linear(2, 2)
             >>> net = nn.Sequential(l, l)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -339,13 +339,26 @@ class Module(object):
             for p in module.parameters(memo):
                 yield p
 
-    def children(self):
-        """Returns an iterator over children modules."""
+    def children(self, named=False):
+        """Returns an iterator over children modules.
+
+        Arguments:
+            named (boolean): A boolean indicating if the names of the
+                children modules should also be returned.
+
+        Example:
+            >>> for name, module in model.children(named=True):
+            >>>     if name in PRINT_LIST:
+            >>>         print(module)
+        """
         memo = set()
-        for module in self._modules.values():
+        for name, module in self._modules.items():
             if module is not None and module not in memo:
                 memo.add(module)
-                yield module
+                if named is True:
+                    yield name, module
+                else:
+                    yield module
 
     def modules(self, memo=None):
         if memo is None:


### PR DESCRIPTION
Fixes #864.

Note that I'm not sure we should add the same option to `.modules()`, as the top-most model don't have a `name`.