### PR TITLE
Fix documentation - replace 'matrix' with 'vector'

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2544,7 +2544,7 @@ located in the corresponding row of Tensor :attr:`input`.
 Indices are ordered from left to right according to when each was sampled
 (first samples are placed in first column).
 
-If :attr:`input` is a vector, :attr:`out` is a matrix of size `num_samples`.
+If :attr:`input` is a vector, :attr:`out` is a vector of size `num_samples`.
 
 If :attr:`input` is a matrix with `m` rows, :attr:`out` is an matrix of shape `m \u00D7 n`.
 


### PR DESCRIPTION
Returned object is actually a vector, not a matrix.
For reference: https://github.com/torch/torch7/blob/master/doc/maths.md#res-torchmultinomialres-p-n-replacement