### PR TITLE
Use streams in scatter to overlap copy with compute

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -839,13 +839,6 @@ class TestNN(NNTestCase):
         inputs = (i1, Variable(i2.data.new()))
         expected_outputs = (expected1, expected2.new())
 
-    def test_data_parallel_noop(self):
-        l = nn.Linear(10, 5).float()
-        i = Variable(torch.randn(20, 10).float())
-        out = dp.data_parallel(l, i, [])
-        self.assertEqual(out, l(i))
-        self.assertFalse(out.is_cuda)
-
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_multiple_input(self):
         class TestModule(nn.Module):
@@ -862,8 +855,6 @@ class TestNN(NNTestCase):
         var3 = Variable(torch.randn(5, 5).float(), requires_grad=False)
 
         float1 = torch.randn(1)[0]
-        target = Variable(torch.randn(5, 5).float()).cuda()
-        crit = nn.MSELoss()
 
         expected = m(var1, var2, float1)
         loss = expected.sum()

--- a/torch/csrc/cuda/Stream.h
+++ b/torch/csrc/cuda/Stream.h
@@ -11,7 +11,12 @@ struct THCPStream {
   int device;
   cudaStream_t cuda_stream;
 };
+extern PyObject *THCPStreamClass;
 
 bool THCPStream_init(PyObject *module);
+
+inline bool THCPStream_Check(PyObject* obj) {
+  return THCPStreamClass && PyObject_IsInstance(obj, THCPStreamClass);
+}
 
 #endif // THCP_STREAM_INC

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -189,29 +189,45 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
 };
 
 template<typename algo_t>
-Workspace chooseAlgorithm(
+void findAlgorithm(
     THCState* state, cudnnHandle_t handle, const Convolution& conv,
     bool benchmark, algo_t* algo)
 {
   using search = algorithm_search<algo_t>;
   auto& cache = search::cache();
 
-  if (!cache.find(conv.params, algo)) {
-    if (benchmark) {
-      // findAlgorithm may call cudaFree()
-      std::lock_guard<std::mutex> lock(*THCCachingAllocator_getCudaFreeMutex());
-      auto perfResults = search::findAlgorithm(handle, conv);
-      if (perfResults.status == CUDNN_STATUS_SUCCESS) {
-        *algo = perfResults.algo;
-      } else {
-        *algo = search::DEFAULT_ALGO;
-      }
-      cache.insert(conv.params, *algo);
-    } else {
-      search::getAlgorithm(handle, conv, algo);
-    }
+  if (cache.find(conv.params, algo)) {
+    return;
   }
 
+  if (!benchmark) {
+    search::getAlgorithm(handle, conv, algo);
+    return;
+  }
+
+  // findAlgorithm may call cudaFree()
+  std::lock_guard<std::mutex> lock(*THCCachingAllocator_getCudaFreeMutex());
+  if (cache.find(conv.params, algo)) {
+    // re-check cache since another thread may have benchmarked the algorithm
+    return;
+  }
+  auto perfResults = search::findAlgorithm(handle, conv);
+  if (perfResults.status == CUDNN_STATUS_SUCCESS) {
+    *algo = perfResults.algo;
+  } else {
+    *algo = search::DEFAULT_ALGO;
+  }
+  cache.insert(conv.params, *algo);
+}
+
+template<typename algo_t>
+Workspace chooseAlgorithm(
+    THCState* state, cudnnHandle_t handle, const Convolution& conv,
+    bool benchmark, algo_t* algo)
+{
+  findAlgorithm(state, handle, conv, benchmark, algo);
+
+  using search = algorithm_search<algo_t>;
   size_t workspace_size;
   search::getWorkspaceSize(handle, conv, *algo, &workspace_size);
   try {
@@ -222,7 +238,7 @@ Workspace chooseAlgorithm(
     // switch to default algorithm and record it in the cache to prevent
     // further OOM errors
     *algo = search::DEFAULT_ALGO;
-    cache.insert(conv.params, *algo);
+    search::cache().insert(conv.params, *algo);
 
     search::getWorkspaceSize(handle, conv, *algo, &workspace_size);
     return Workspace(state, workspace_size);

--- a/torch/csrc/generic/methods/TensorCuda.cwrap
+++ b/torch/csrc/generic/methods/TensorCuda.cwrap
@@ -23,3 +23,23 @@ PyObject * THPTensor_(new)(THPTensor *self, PyObject *args, PyObject *kwargs)
 }
 #endif
 
+[[
+  name: THPTensor_(recordStream)
+  python_name: record_stream
+  override_method_flags: METH_O
+  defined_if: IS_CUDA
+  only_register: True
+]]
+#if IS_CUDA
+PyObject * THPTensor_(recordStream)(THPTensor *self, PyObject *arg)
+{
+  HANDLE_TH_ERRORS
+  if (!THCPStream_Check(arg)) {
+    return PyErr_Format(PyExc_TypeError, "expected Stream object");
+  }
+  void* data = THTensor_(data)(LIBRARY_STATE self->cdata);
+  THCCachingAllocator_recordStream(data, ((THCPStream*)arg)->cdata);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+#endif

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -1,7 +1,6 @@
 import torch
-from torch.autograd import Variable
 from ..modules import Module
-from .scatter_gather import scatter, gather
+from .scatter_gather import scatter_kwargs, gather
 from .replicate import replicate
 from .parallel_apply import parallel_apply
 
@@ -35,10 +34,7 @@ class DataParallel(Module):
 
     Example::
 
-        >>> device_ids=[0, 1, 2]
-        >>> net = torch.nn.DataParallel(model, device_ids=device_ids)
-        >>> input_var.size(0) % len(device_ids)
-        0
+        >>> net = torch.nn.DataParallel(model, device_ids=[0, 1, 2])
         >>> output = net(input_var)
     """
 
@@ -58,45 +54,18 @@ class DataParallel(Module):
             self.module.cuda(device_ids[0])
 
     def forward(self, *inputs, **kwargs):
-        def _to_cuda(obj):
-            if isinstance(obj, Variable):
-                return obj.cuda()
-            if isinstance(obj, tuple) or isinstance(obj, list):
-                return type(obj)((map(_to_cuda, obj)))
-            return obj
-
+        inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
         if len(self.device_ids) == 1:
-            with torch.cuda.device(self.device_ids[0]):
-                inputs_cuda = _to_cuda(inputs)
-                if kwargs:
-                    gpu_dict = {}
-                    for key in kwargs.keys():
-                        gpu_dict[key] = _to_cuda(kwargs[key])
-                    return self.module(*inputs_cuda, **gpu_dict)
-                else:
-                    return self.module(*inputs_cuda)
-
-        replicas = self.replicate(self.module, self.device_ids)
-        scattered = self.scatter(inputs, self.device_ids)
-        used_gpus = len(scattered)  # The last GPU might not be used. For example, input of size 4, on 5 GPUs
-        gpu_dicts = None
-        if kwargs is not None:
-            gpu_dicts = [{} for i in range(used_gpus)]
-            for key in kwargs.keys():
-                scattered_kwargs = self.scatter(_to_cuda(kwargs[key]), self.device_ids)
-                assert len(scattered_kwargs) == used_gpus
-                for i in range(used_gpus):
-                    gpu_dicts[i][key] = scattered_kwargs[i]
-
-        replicas = replicas[:len(scattered)]
-        outputs = self.parallel_apply(replicas, scattered, gpu_dicts)
+            return self.module(*inputs[0], **kwargs[0])
+        replicas = self.replicate(self.module, self.device_ids[:len(inputs)])
+        outputs = self.parallel_apply(replicas, inputs, kwargs)
         return self.gather(outputs, self.output_device)
 
     def replicate(self, module, device_ids):
         return replicate(module, device_ids)
 
-    def scatter(self, input, device_ids):
-        return scatter(input, device_ids, dim=self.dim)
+    def scatter(self, inputs, kwargs, device_ids):
+        return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
 
     def parallel_apply(self, replicas, inputs, kwargs):
         return parallel_apply(replicas, inputs, kwargs)
@@ -123,28 +92,12 @@ def data_parallel(module, inputs, device_ids, output_device=None, dim=0, module_
     if not isinstance(inputs, tuple):
         inputs = (inputs,)
 
-    if not device_ids:
-        if module_kwargs is None:
-            return module(*inputs)
-        else:
-            return module(*inputs, **module_kwargs)
-
     if output_device is None:
         output_device = device_ids[0]
 
-    replicas = replicate(module, device_ids)
-    scattered = scatter(inputs, device_ids, dim)
-
-    gpu_dicts = None
-    if module_kwargs:
-        scatter_kwargs = {}
-        for key in module_kwargs.keys():
-            scatter_kwargs[key] = scatter(module_kwargs[key], device_ids, dim)
-        gpu_dicts = tuple(
-            {key: values[i] for key, values in scatter_kwargs.items()}
-            for i in device_ids
-        )
-
-    replicas = replicas[:len(scattered)]
-    outputs = parallel_apply(replicas, scattered, gpu_dicts)
+    inputs, module_kwargs = scatter_kwargs(inputs, module_kwargs, device_ids, dim)
+    if len(device_ids) == 1:
+        return module(*inputs[0], **module_kwargs[0])
+    replicas = replicate(module, device_ids[:len(inputs)])
+    outputs = parallel_apply(replicas, inputs, module_kwargs)
     return gather(outputs, output_device, dim)

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -1,11 +1,6 @@
-import sys
 import threading
 import torch
 from torch.autograd import Variable
-if sys.version_info[0] == 3:
-    import queue
-else:
-    import Queue as queue
 
 
 def parallel_apply(modules, inputs, kwargs_tup=None):


### PR DESCRIPTION
I've also changed DataParallel to use scatter in the one GPU case. This reduces code duplication and allows the one GPU case to still overlap copy with compute.