### PR TITLE
Docs(RNN|GRU|LSTM): Note dropout applies to all layers *except* the last layer

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -154,7 +154,7 @@ class RNN(RNNBase):
         nonlinearity: The non-linearity to use ['tanh'|'relu']. Default: 'tanh'
         bias: If False, then the layer does not use bias weights b_ih and b_hh. Default: True
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
-        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer
+        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
 
     Inputs: input, h_0
@@ -231,7 +231,7 @@ class LSTM(RNNBase):
         num_layers: Number of recurrent layers.
         bias: If False, then the layer does not use bias weights b_ih and b_hh. Default: True
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
-        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer
+        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
 
     Inputs: input, (h_0, c_0)
@@ -301,7 +301,7 @@ class GRU(RNNBase):
         num_layers: Number of recurrent layers.
         bias: If False, then the layer does not use bias weights b_ih and b_hh. Default: True
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
-        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer
+        dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
 
     Inputs: input, h_0


### PR DESCRIPTION
This is an important clarification to make as otherwise users are misled as to where they may need to add dropout and to clarify the situation would need to delve into the backend implementation.

This may not even be obvious to the user if they don't have a model with an expected behaviour that they're trying to match.

The specific implementation detail this refers to is below:
https://github.com/pytorch/pytorch/blob/4647f753bc22d3fc4b57f326608663173109aeb0/torch/nn/_functions/rnn.py#L73