### PR TITLE
Fix Embedding and CosineEmbeddingLoss on non-float CUDA

### DIFF
--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -10,7 +10,7 @@ class CosineEmbeddingLoss(Function):
         self.size_average = size_average
 
     def _new_idx(self, input):
-        if torch.typename(input) == 'torch.cuda.FloatTensor':
+        if input.is_cuda:
             return torch.cuda.ByteTensor()
         else:
             return torch.ByteTensor()

--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -55,7 +55,7 @@ class CosineEmbeddingLoss(Function):
         v1, v2, y = self.saved_tensors
 
         buffer = v1.new()
-        _idx = self._new_idx(v1)
+        _idx = v1.new().byte()
 
         gw1 = grad_output.new()
         gw2 = grad_output.new()

--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -9,12 +9,6 @@ class CosineEmbeddingLoss(Function):
         self.margin = margin
         self.size_average = size_average
 
-    def _new_idx(self, input):
-        if input.is_cuda:
-            return torch.cuda.ByteTensor()
-        else:
-            return torch.ByteTensor()
-
     def forward(self, input1, input2, y):
         self.w1 = input1.new()
         self.w22 = input1.new()
@@ -22,7 +16,7 @@ class CosineEmbeddingLoss(Function):
         self.w32 = input1.new()
         self._outputs = input1.new()
 
-        _idx = self._new_idx(input1)
+        _idx = input1.new().byte()
 
         buffer = torch.mul(input1, input2)
         torch.sum(buffer, 1, out=self.w1)

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -77,7 +77,7 @@ class Embedding(Function):
                 indices = indices.view(-1)
 
             with torch.cuda.device_of(grad_output):
-                if torch.typename(grad_output) == 'torch.cuda.FloatTensor':
+                if grad_output.is_cuda:
                     _sorted = torch.cuda.LongTensor()
                     _indices = torch.cuda.LongTensor()
                     _count = torch.cuda.LongTensor()


### PR DESCRIPTION
Fixes #963 

There are currently no tests for other types than `float` in `nn` (even in CPU).
I'll add tests for other types in a separate PR.