### PR TITLE
fix conv1d backward segfault

### DIFF
--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -276,7 +276,9 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   }
 
   if (k == 3) {
-    grad_input = view3d(*grad_input);
+    if (needs_input_grad(0)) {
+        grad_input = view3d(*grad_input);
+    }
     grad_weight = view3d(*grad_weight);
   }
 


### PR DESCRIPTION
Fix for #967 - fix segfault in conv1d when input does not require_grad. @apaszke, @colesbury, apparently in tests input always requires grad - so how should test be modified to catch things like this?