### PR TITLE
Update nn.init docstrings to correctly reference the module

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -14,8 +14,9 @@ def uniform(tensor, a=0, b=1):
         b: the upper bound of the uniform distribution
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.uniform(w)
+        >>> nn.init.uniform(w)
     """
     if isinstance(tensor, Variable):
         uniform(tensor.data, a=a, b=b)
@@ -32,8 +33,9 @@ def normal(tensor, mean=0, std=1):
         std: the standard deviation of the normal distribution
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.normal(w)
+        >>> nn.init.normal(w)
     """
     if isinstance(tensor, Variable):
         normal(tensor.data, mean=mean, std=std)
@@ -49,8 +51,9 @@ def constant(tensor, val):
         val: the value to fill the tensor with
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.constant(w)
+        >>> nn.init.constant(w)
     """
     if isinstance(tensor, Variable):
         constant(tensor.data, val)
@@ -88,8 +91,9 @@ def xavier_uniform(tensor, gain=1):
         gain: an optional scaling factor to be applied
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.xavier_uniform(w, gain=math.sqrt(2.0))
+        >>> nn.init.xavier_uniform(w, gain=math.sqrt(2.0))
     """
     if isinstance(tensor, Variable):
         xavier_uniform(tensor.data, gain=gain)
@@ -112,8 +116,9 @@ def xavier_normal(tensor, gain=1):
         gain: an optional scaling factor to be applied
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.xavier_normal(w)
+        >>> nn.init.xavier_normal(w)
     """
     if isinstance(tensor, Variable):
         xavier_normal(tensor.data, gain=gain)
@@ -150,8 +155,9 @@ def kaiming_uniform(tensor, a=0, mode='fan_in'):
               weights in the forward pass. Choosing `fan_out` preserves the magnitudes in the backwards pass.
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.kaiming_uniform(w, mode='fan_in')
+        >>> nn.init.kaiming_uniform(w, mode='fan_in')
     """
     if isinstance(tensor, Variable):
         kaiming_uniform(tensor.data, a=a, mode=mode)
@@ -176,8 +182,9 @@ def kaiming_normal(tensor, a=0, mode='fan_in'):
               weights in the forward pass. Choosing `fan_out` preserves the magnitudes in the backwards pass.
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.kaiming_normal(w, mode='fan_out')
+        >>> nn.init.kaiming_normal(w, mode='fan_out')
     """
     if isinstance(tensor, Variable):
         kaiming_normal(tensor.data, a=a, mode=mode)
@@ -200,8 +207,9 @@ def orthogonal(tensor, gain=1):
         gain: optional gain to be applied
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.orthogonal(w)
+        >>> nn.init.orthogonal(w)
     """
     if isinstance(tensor, Variable):
         orthogonal(tensor.data, gain=gain)
@@ -233,8 +241,9 @@ def sparse(tensor, sparsity, std=0.01):
         std: the standard deviation of the normal distribution used to generate the non-zero values
 
     Examples:
+        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
-        >>> nninit.sparse(w, sparsity=0.1)
+        >>> nn.init.sparse(w, sparsity=0.1)
     """
     if isinstance(tensor, Variable):
         sparse(tensor.data, sparsity, std=std)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -14,7 +14,6 @@ def uniform(tensor, a=0, b=1):
         b: the upper bound of the uniform distribution
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.uniform(w)
     """
@@ -33,7 +32,6 @@ def normal(tensor, mean=0, std=1):
         std: the standard deviation of the normal distribution
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.normal(w)
     """
@@ -51,7 +49,6 @@ def constant(tensor, val):
         val: the value to fill the tensor with
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.constant(w)
     """
@@ -91,7 +88,6 @@ def xavier_uniform(tensor, gain=1):
         gain: an optional scaling factor to be applied
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.xavier_uniform(w, gain=math.sqrt(2.0))
     """
@@ -116,7 +112,6 @@ def xavier_normal(tensor, gain=1):
         gain: an optional scaling factor to be applied
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.xavier_normal(w)
     """
@@ -155,7 +150,6 @@ def kaiming_uniform(tensor, a=0, mode='fan_in'):
               weights in the forward pass. Choosing `fan_out` preserves the magnitudes in the backwards pass.
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.kaiming_uniform(w, mode='fan_in')
     """
@@ -182,7 +176,6 @@ def kaiming_normal(tensor, a=0, mode='fan_in'):
               weights in the forward pass. Choosing `fan_out` preserves the magnitudes in the backwards pass.
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.kaiming_normal(w, mode='fan_out')
     """
@@ -207,7 +200,6 @@ def orthogonal(tensor, gain=1):
         gain: optional gain to be applied
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.orthogonal(w)
     """
@@ -241,7 +233,6 @@ def sparse(tensor, sparsity, std=0.01):
         std: the standard deviation of the normal distribution used to generate the non-zero values
 
     Examples:
-        >>> from torch import nn
         >>> w = torch.Tensor(3, 5)
         >>> nn.init.sparse(w, sparsity=0.1)
     """


### PR DESCRIPTION
Currently the examples in the docstrings read:

```python
>>> w = torch.Tensor(3, 5)
>>> nninit.normal(w)
```
but should read 
```python
from torch import nn
>>> w = torch.Tensor(3, 5)
>>> nn.init.normal(w)
```

This was my mistake, just cleaning up after myself :)
