### PR TITLE
Supporting old-style classes in torch.is_tensor and torch.is_storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ torch/csrc/nn/THNN_generic.cpp
 torch/csrc/nn/THNN_generic.h
 docs/src/**/*
 test/data/legacy_modules.t7
+test/data/gpu_tensors.pt
 test/htmlcov
 test/.coverage
 */*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+## Contributing to PyTorch
+
+If you are interested in contributing to PyTorch, your contributions will fall
+into two categories:
+1. You want to propose a new Feature and implement it
+    - post about your intended feature, and we shall discuss the design and
+    implementation. Once we agree that the plan looks good, go ahead and implement it.
+2. You want to implement a feature or bug-fix for an outstanding issue
+    - Look at the outstanding issues here: https://github.com/pytorch/pytorch/issues
+    - Especially look at the Low Priority and Medium Priority issues
+    - Pick an issue and comment on the task that you want to work on this feature
+    - If you need more context on a particular issue, please ask and we shall provide.
+
+Once you finish implementing a feature or bugfix, please send a Pull Request to
+https://github.com/pytorch/pytorch
+
+If you are not familiar with creating a Pull Request, here are some guides:
+- http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
+- https://help.github.com/articles/creating-a-pull-request/
+
+
+## Developing locally with PyTorch
+
+To locally develop with PyTorch, here are some tips:
+
+1. Uninstall all existing pytorch installs
+```
+conda uninstall pytorch
+pip uninstall pytorch
+pip uninstall pytorch # run this command twice
+```
+
+2. Locally clone a copy of PyTorch from source:
+
+```
+git clone https://github.com/pytorch/pytorch
+cd pytorch
+```
+
+3. Install PyTorch in `build develop` mode:
+
+A full set of instructions on installing PyTorch from Source are here:
+https://github.com/pytorch/pytorch#from-source
+
+The change you have to make is to replace
+
+`python setup.py install`
+
+with
+
+```
+python setup.py build develop
+```
+
+This is especially useful if you are only changing Python files.
+
+This mode will symlink the python files from the current local source tree into the
+python install.
+
+Hence, if you modify a python file, you do not need to reinstall pytorch again and again.
+
+For example:
+- Install local pytorch in `build develop` mode
+- modify your python file torch/__init__.py (for example)
+- test functionality
+- modify your python file torch/__init__.py
+- test functionality
+- modify your python file torch/__init__.py
+- test functionality
+
+You do not need to repeatedly install after modifying python files.
+
+
+Hope this helps, and thanks for considering to contribute.

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -62,7 +62,7 @@ Just pass an additional ``async=True`` argument to a :meth:`~torch.Tensor.cuda`
 call. This can be used to overlap data transfers with computation.
 
 You can make the :class:`~torch.utils.data.DataLoader` return batches placed in
-pinned memory by passing ``pinned=True`` to its constructor.
+pinned memory by passing ``pin_memory=True`` to its constructor.
 
 .. _cuda-nn-dataparallel-instead:
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1214,13 +1214,15 @@ def unpack_variables(args):
 
 
 ignore_inplace = set((
-    'test_DivConstant_by_tensor',
+    'test_DivConstantFunction_by_tensor',
 ))
 
 
 for test in function_tests:
     cls, constructor_args, call_args = test[:3]
-    test_name = 'test_' + cls.__name__ + ('_' + test[3] if len(test) == 4 else '')
+    test_name = 'test_{}Function'.format(cls.__name__)
+    if len(test) == 4:
+        test_name += '_' + test[3]
 
     def do_test(self, cls=cls, constructor_args=constructor_args,
                 call_args=call_args, test_name=test_name):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -940,6 +940,20 @@ def gather_variable(shape, index_dim, max_indices):
     return Variable(index, requires_grad=False)
 
 
+def prod_zeros(dim_size):
+    result = torch.randn(dim_size, dim_size, dim_size)
+    result[0, 1] = 0
+    result[2, 3] = 0
+    result[4, 3] = 0
+    return Variable(result, requires_grad=True)
+
+
+def prod_single_zero(dim_size):
+    result = torch.randn(dim_size, dim_size)
+    result[0, 1] = 0
+    return Variable(result, requires_grad=True)
+
+
 L = 20
 M = 10
 S = 5
@@ -1003,7 +1017,10 @@ function_tests = [
     (Sum, (), ((S, S, S),)),
     (Sum, (1,), ((S, S, S),), 'dim'),
     (Prod, (), ((S, S, S),)),
+    (Prod, (), (prod_zeros(S),), 'zeros'),
+    (Prod, (), (prod_single_zero(S),), 'single_zero'),
     (Prod, (1,), ((S, S, S),), 'dim'),
+    (Prod, (1,), (prod_zeros(S),), 'zeros_dim'),
     (Addmm, (), ((S, M), (S, S), (S, M)),),
     (Addmm, (0.1, 1), ((S, M), (S, S), (S, M)), 'coef'),
     (Addbmm, (), ((S, M), (S, S, S), (S, S, M)),),

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -1251,6 +1251,8 @@ class TestNN(NNTestCase):
                 self.assertIsInstance(module, type(reference))
 
 
+prepare_tests()
+
+
 if __name__ == '__main__':
-    prepare_tests()
     run_tests()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -149,9 +149,6 @@ class leak_checker(object):
 
 class TestMultiprocessing(TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(TestMultiprocessing, self).__init__(*args, **kwargs)
-
     def _test_sharing(self, ctx=mp, type=torch.FloatTensor, repeat=1):
         def test_fill():
             x = torch.zeros(5, 5).type(type)
@@ -160,9 +157,11 @@ class TestMultiprocessing(TestCase):
             data = [x, x[:, 1]]
             q.put(data)
             p = ctx.Process(target=simple_fill, args=(q, e))
+            p.daemon = True
             lc.check_pid(p.pid)
             p.start()
-            e.wait()
+            e.wait(10)
+            self.assertTrue(e.is_set())
             self.assertTrue(data[0].eq(4).all())
             self.assertTrue(data[1].eq(4).all())
             p.join(1)
@@ -172,6 +171,7 @@ class TestMultiprocessing(TestCase):
             q = ctx.Queue()
             e = ctx.Event()
             p = ctx.Process(target=send_tensor, args=(q, e, type))
+            p.daemon = True
             lc.check_pid(p.pid)
             p.start()
             t1 = q.get()
@@ -183,7 +183,7 @@ class TestMultiprocessing(TestCase):
             self.assertFalse(p.is_alive())
 
         with leak_checker(self) as lc:
-            for i in range(repeat):
+            for _ in range(repeat):
                 test_fill()
                 test_receive()
 
@@ -193,7 +193,7 @@ class TestMultiprocessing(TestCase):
             data = [x.storage(), x.storage()[1:4], x, x[2], x[:, 1]]
             q = ctx.Queue()
             q.put(data)
-            new_data = q.get()
+            new_data = q.get(timeout=1)
             self.assertEqual(new_data, data, 0)
             storage_cdata = data[0]._cdata
             self.assertEqual(new_data[0]._cdata, storage_cdata)
@@ -264,15 +264,15 @@ class TestMultiprocessing(TestCase):
             q.get()
 
         with fs_sharing(), leak_checker(self) as lc:
-            for i in range(TEST_REPEATS):
+            for _ in range(TEST_REPEATS):
                 queue_put()
 
     def test_inherit_tensor(self):
         class SubProcess(mp.Process):
-
             def __init__(self, tensor):
                 super(SubProcess, self).__init__()
                 self.tensor = tensor
+                self.daemon = True
 
             def run(self):
                 self.tensor.add_(3)
@@ -280,7 +280,7 @@ class TestMultiprocessing(TestCase):
         t = torch.zeros(5, 5)
         p = SubProcess(t.share_memory_())
         p.start()
-        p.join()
+        p.join(1)
         self.assertEqual(t, torch.ones(5, 5) * 3, 0)
 
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
@@ -357,6 +357,7 @@ class TestMultiprocessing(TestCase):
         master_modified = mp.Event()
         queue = mp.Queue()
         p = mp.Process(target=autograd_sharing, args=(queue, ready, master_modified))
+        p.daemon = True
         p.start()
         var._grad = Variable(torch.zeros(5, 5), requires_grad=False)
         queue.put(var)
@@ -371,7 +372,8 @@ class TestMultiprocessing(TestCase):
 
         self.assertEqual(var.data, torch.ones(5, 5))
         self.assertEqual(var.grad.data, torch.ones(5, 5) * 4)
-        p.join()
+        p.join(1)
+        self.assertFalse(p.is_alive())
 
     def test_variable_sharing(self):
         configs = [

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -297,7 +297,7 @@ class TestLuaReader(TestCase):
 
     @classmethod
     def init(cls):
-        DATA_URL = 'https://s3.amazonaws.com/pytorch/legacy_modules.t7'
+        DATA_URL = 'https://download.pytorch.org/test_data/legacy_modules.t7'
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
         test_file_path = os.path.join(data_dir, 'legacy_modules.t7')
         succ = download_file(DATA_URL, test_file_path)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -282,19 +282,21 @@ set_default_tensor_type('torch.FloatTensor')
 
 from .functional import *
 
+
 ################################################################################
 # Initialize extension
 ################################################################################
 
+def manager_path():
+    import os
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'lib', 'torch_shm_manager')
+    if not os.path.exists(path):
+        raise RuntimeError("Unable to find torch_shm_manager at " + path)
+    return path.encode('utf-8')
+
+
 # Shared memory manager needs to know the exact location of manager executable
-import os
-manager_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'lib', 'torch_shm_manager')
-if sys.version_info[0] >= 3:
-    manager_path = bytes(manager_path, 'ascii')
-
-_C._initExtension(manager_path)
-
-del os
+_C._initExtension(manager_path())
 del manager_path
 
 ################################################################################

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,7 +88,7 @@ def is_tensor(obj):
     Args:
         obj (Object): Object to test
     """
-    return getattr(obj, '__class__', None) in _tensor_classes
+    return type(obj) in _tensor_classes
 
 
 def is_storage(obj):
@@ -97,7 +97,7 @@ def is_storage(obj):
     Args:
         obj (Object): Object to test
     """
-    return getattr(obj, '__class__', None) in _storage_classes
+    return type(obj) in _storage_classes
 
 
 def set_default_tensor_type(t):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,7 +88,7 @@ def is_tensor(obj):
     Args:
         obj (Object): Object to test
     """
-    return obj.__class__ in _tensor_classes
+    return getattr(obj, '__class__', None) in _tensor_classes
 
 
 def is_storage(obj):
@@ -97,7 +97,7 @@ def is_storage(obj):
     Args:
         obj (Object): Object to test
     """
-    return obj.__class__ in _storage_classes
+    return getattr(obj, '__class__', None) in _storage_classes
 
 
 def set_default_tensor_type(t):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -1,4 +1,5 @@
 import torch
+import importlib
 
 
 def _type(self, new_type=None, async=False):
@@ -62,6 +63,13 @@ def _cuda(self, device=None, async=False):
         else:
             new_type = getattr(torch.cuda, self.__class__.__name__)
             return new_type(self.size()).copy_(self, async)
+
+
+def _rebuild_tensor(storage, storage_offset, size, stride):
+    class_name = storage.__class__.__name__.replace('Storage', 'Tensor')
+    module = importlib.import_module(storage.__module__)
+    tensor_class = getattr(module, class_name)
+    return tensor_class().set_(storage, storage_offset, size, stride)
 
 
 def _range(*args, **kwargs):

--- a/torch/autograd/_functions/reduce.py
+++ b/torch/autograd/_functions/reduce.py
@@ -46,13 +46,45 @@ class Prod(_DimReduceFunction):
     def backward(self, grad_output):
         if self.dim is None:
             input, = self.saved_tensors
-            grad_input = grad_output.new(self.input_size).fill_(self.result)
-            return grad_input.div(input)
+            zero_idx = (input == 0).nonzero()
+            if zero_idx.dim() == 0:
+                return grad_output.mul(self.result).expand_as(input).div(input)
+            elif zero_idx.size(0) > 1:
+                return grad_output.new(self.input_size).zero_()
+            else:
+                grad_input = grad_output.new(self.input_size).zero_()
+                zero_idx = tuple(zero_idx[0].cpu())
+                input_copy = input.clone()
+                input_copy[zero_idx] = 1.
+                grad_input[zero_idx] = grad_output[0] * input_copy.prod()
+                return grad_input
         else:
             input, output = self.saved_tensors
-            repeats = [1 for _ in self.input_size]
-            repeats[self.dim] = self.input_size[self.dim]
-            return output.mul(grad_output).repeat(*repeats).div_(input)
+            zero_mask = input == 0
+            slice_zero_count = zero_mask.sum(self.dim)
+            total_zeros = slice_zero_count.sum()
+            grad_input = grad_output.mul(output).expand_as(input).div(input)
+            if total_zeros == 0:
+                return grad_input
+
+            some_zeros = slice_zero_count.gt(0).expand_as(grad_input)
+            grad_input[some_zeros] = 0
+
+            single_zero_idx = slice_zero_count.eq(1).nonzero()
+            for idx in single_zero_idx:
+                idx_tuple = tuple(idx.cpu())
+                input_idx_tuple = idx_tuple[:self.dim] + (slice(0, None),) + idx_tuple[self.dim + 1:]
+
+                # slice_mask and input_copy are 1D
+                slice_mask = zero_mask[input_idx_tuple]
+                input_copy = input[input_idx_tuple].clone()
+                zero_idx = slice_mask.nonzero()[0, 0]
+                input_copy[zero_idx] = 1.
+
+                grad_idx_tuple = idx_tuple[:self.dim] + (zero_idx,) + idx_tuple[self.dim + 1:]
+                grad_input[grad_idx_tuple] = grad_output[idx_tuple] * input_copy.prod()
+
+            return grad_input
 
 
 class Mean(_DimReduceFunction):

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -1,45 +1,31 @@
-import torch._C as _C
 import ctypes
-import warnings
-import torch.cuda
 import sys
-import os.path as path
+import torch
+import warnings
 
 enabled = True  # set to False to globally disable cuDNN
 
 lib = None
-# TODO: fix libname for Windows
+__cudnn_version = None
 # TODO: dynamic version checks via cudnnGetVersion
-# TODO: load 5.1.3 if using CUDA 7.5 and 5.1.5 if using CUDA 8.0
-thisdir = path.dirname(__file__)
-libpaths = ['', path.join(thisdir, '../../lib')]
-if sys.platform.startswith('linux'):
-    libnames = ['libcudnn.so.6.0.5', 'libcudnn.so.6.0.10', 'libcudnn.so.5.1.5', 'libcudnn.so.5.1.3',
-                'libcudnn.so.5.0.5', 'libcudnn.so.5.1.10']
-elif sys.platform == 'darwin':
-    libnames = ['libcudnn.6.dylib', 'libcudnn.5.dylib']
-else:
-    libnames = []
 
 
-def _loadlib():
-    global lib
-    loaded = False
-    for libpath in libpaths:
-        for libname in libnames:
-            try:
-                lib = ctypes.cdll.LoadLibrary(path.join(libpath, libname))
-                loaded = True
-                break
-            except OSError:
-                continue
-        if loaded:
-            break
-    if loaded:
-        lib.cudnnGetErrorString.restype = ctypes.c_char_p
-    else:
-        lib = None
-        raise OSError("Could not load cuDNN")
+def _libcudnn():
+    global lib, __cudnn_version
+    if lib is None:
+        lib = ctypes.cdll.LoadLibrary(None)
+        if hasattr(lib, 'cudnnGetErrorString'):
+            lib.cudnnGetErrorString.restype = ctypes.c_char_p
+            __cudnn_version = lib.cudnnGetVersion()
+        else:
+            lib = None
+    return lib
+
+
+def version():
+    if _libcudnn() is None:
+        return None
+    return __cudnn_version
 
 
 def is_acceptable(tensor):
@@ -49,58 +35,29 @@ def is_acceptable(tensor):
             isinstance(tensor, torch.cuda.FloatTensor) or
             isinstance(tensor, torch.cuda.DoubleTensor)):
         return False
-    if lib is None:
-        try:
-            _loadlib()
-        except Exception:
-            warnings.warn('cuDNN library not found. Check your {libpath}'.format(
-                libpath={
-                    'darwin': 'DYLD_LIBRARY_PATH',
-                    'win32': 'PATH'
-                }.get(sys.platform, 'LD_LIBRARY_PATH')))
-            return False
-    if not _C.has_cudnn:
-        warnings.warn("cuDNN library has been detected, but your pytorch "
-                      "installation was compiled without support for it. You "
-                      "might want to rebuild pytorch, making sure the library "
-                      "is visible to the build system.")
+    if not torch._C.has_cudnn:
+        warnings.warn(
+            "PyTorch was compiled without cuDNN support. To use cuDNN, rebuild "
+            "PyTorch making sure the library is visible to the build system.")
+        return False
+    if _libcudnn() is None:
+        warnings.warn('cuDNN library not found. Check your {libpath}'.format(
+            libpath={
+                'darwin': 'DYLD_LIBRARY_PATH',
+                'win32': 'PATH'
+            }.get(sys.platform, 'LD_LIBRARY_PATH')))
         return False
     return True
 
-__cudnn_version = []
-
-
-def version():
-    if not lib:
-        raise RuntimeError("cuDNN not initialized")
-    if len(__cudnn_version) == 0:
-        __cudnn_version.append(lib.cudnnGetVersion())
-    return __cudnn_version[0]
 
 _handles = {}
 
 benchmark = False
 verbose = False
-workspace_limit = None
 
 CUDNN_DATA_FLOAT = 0
 CUDNN_DATA_DOUBLE = 1
 CUDNN_DATA_HALF = 2
-
-CUDNN_CONVOLUTION = 0
-CUDNN_CROSS_CORRELATION = 1
-
-CUDNN_CONVOLUTION_FWD_NO_WORKSPACE = 0
-CUDNN_CONVOLUTION_FWD_PREFER_FASTEST = 1
-CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT = 2
-
-CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE = 0
-CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST = 1
-CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT = 2
-
-CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE = 0
-CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST = 1
-CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT = 2
 
 CUDNN_TENSOR_NCHW = 0
 CUDNN_TENSOR_NHWC = 1
@@ -113,16 +70,12 @@ CUDNN_GRU = 3
 CUDNN_LINEAR_INPUT = 0
 CUDNN_SKIP_INPUT = 1
 
-CUDNN_NON_DETERMINISTIC = 0
-CUDNN_DETERMINISTIC = 1
-
 CUDNN_RNN_ALGO_STANDARD = 0
 CUDNN_RNN_ALGO_PERSIST_STATIC = 1
 CUDNN_RNN_ALGO_PERSIST_DYNAMIC = 2
 
 
 class CuDNNHandle:
-
     def __init__(self):
         ptr = ctypes.c_void_p()
         check_error(lib.cudnnCreate(ctypes.byref(ptr)))
@@ -133,7 +86,6 @@ class CuDNNHandle:
 
 
 class CuDNNError(RuntimeError):
-
     def __init__(self, status):
         self.status = status
         msg = '{}: {}'.format(status, get_error_string(status))
@@ -141,7 +93,6 @@ class CuDNNError(RuntimeError):
 
 
 class TensorDescriptor(object):
-
     def __init__(self):
         ptr = ctypes.c_void_p()
         check_error(lib.cudnnCreateTensorDescriptor(ctypes.byref(ptr)))
@@ -164,7 +115,6 @@ class TensorDescriptor(object):
 
 
 class TensorDescriptorArray(object):
-
     def __init__(self, N):
         self.ptrs = (ctypes.c_void_p * N)()
         for i in range(N):
@@ -194,31 +144,7 @@ class TensorDescriptorArray(object):
             ctypes.c_void_p(ptr), _type, _ndim, _size, _stride))
 
 
-class ConvolutionDescriptor(object):
-
-    def __init__(self):
-        ptr = ctypes.c_void_p()
-        check_error(lib.cudnnCreateConvolutionDescriptor(ctypes.byref(ptr)))
-        self._as_parameter_ = ptr
-
-    def __del__(self):
-        check_error(lib.cudnnDestroyConvolutionDescriptor(self._as_parameter_))
-        del self._as_parameter_
-
-    def set(self, typename, pad, stride):
-        self._pad = pad
-        self._stride = stride
-        upscale = int_array([1, 1])
-        check_error(lib.cudnnSetConvolutionNdDescriptor(
-            self, 2, int_array(pad), int_array(stride), upscale,
-            CUDNN_CROSS_CORRELATION, _typemap[typename]))
-
-    def as_tuple(self):
-        return (self._pad, self._stride)
-
-
 class FilterDescriptor(object):
-
     def __init__(self):
         ptr = ctypes.c_void_p()
         check_error(lib.cudnnCreateFilterDescriptor(ctypes.byref(ptr)))
@@ -232,14 +158,14 @@ class FilterDescriptor(object):
         self._size = weight.size()
         datatype = _typemap[weight.type()]
         check_error(lib.cudnnSetFilterNdDescriptor(
-            self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(), int_array(weight.size())))
+            self, datatype, CUDNN_TENSOR_NCHW, weight.ndimension(),
+            int_array(weight.size())))
 
     def as_tuple(self):
         return tuple(self._size)
 
 
 class DropoutDescriptor(object):
-
     def __init__(self, handle, dropout, seed):
         ptr = ctypes.c_void_p()
         check_error(lib.cudnnCreateDropoutDescriptor(ctypes.byref(ptr)))
@@ -284,7 +210,6 @@ class DropoutDescriptor(object):
 
 
 class RNNDescriptor(object):
-
     def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
                  bidirectional, mode, datatype):
         ptr = ctypes.c_void_p()
@@ -319,26 +244,6 @@ class RNNDescriptor(object):
         check_error(lib.cudnnDestroyRNNDescriptor(self))
 
 
-class ConvolutionAlgoPerf_v5(ctypes.Structure):
-    _fields_ = [
-        ("algo", ctypes.c_int),
-        ("status", ctypes.c_int),
-        ("time", ctypes.c_float),
-        ("memory", ctypes.c_size_t),
-    ]
-
-
-class ConvolutionAlgoPerf_v6(ctypes.Structure):
-    _fields_ = [
-        ("algo", ctypes.c_int),
-        ("status", ctypes.c_int),
-        ("time", ctypes.c_float),
-        ("memory", ctypes.c_size_t),
-        ("determinism", ctypes.c_int),
-        ("reserved", ctypes.c_int * 4)
-    ]
-
-
 def check_error(status):
     if status is not 0:
         raise CuDNNError(status)
@@ -349,14 +254,15 @@ def get_error_string(status):
 
 
 def get_handle():
-    if lib is None:
-        _loadlib()
+    if _libcudnn() is None:
+        raise RuntimeError('cuDNN not available')
     current_device = torch.cuda.current_device()
     handle = _handles.get(current_device, None)
     if handle is None:
         handle = CuDNNHandle()
         _handles[current_device] = handle
     return handle
+
 
 _typemap = {
     'torch.cuda.HalfTensor': CUDNN_DATA_HALF,
@@ -410,127 +316,6 @@ def descriptor_sequence(tensor, batch_sizes):
         _size[0] = batch_size
         descriptors.set_raw(i, _type, _ndim, _size, _stride)
     return descriptors
-
-
-_autotuner_forward = {}
-_autotuner_backward_data = {}
-_autotuner_backward_filter = {}
-
-
-def convolution_autotuner_key(idesc, weight_desc, conv_desc):
-    return (idesc.as_tuple(), weight_desc.as_tuple(), conv_desc.as_tuple())
-
-
-def convolution_forward_algorithm(idesc, weight_desc, conv_desc, odesc):
-    k = convolution_autotuner_key(idesc, weight_desc, conv_desc)
-    if k in _autotuner_forward:
-        return _autotuner_forward[k]
-
-    if benchmark:
-        if version() < 6000:
-            perf_results = ConvolutionAlgoPerf_v5()
-        else:
-            perf_results = ConvolutionAlgoPerf_v6()
-        algo_count = ctypes.c_int()
-        check_error(lib.cudnnFindConvolutionForwardAlgorithm(
-            get_handle(), idesc, weight_desc, conv_desc, odesc, 1,
-            ctypes.byref(algo_count), ctypes.byref(perf_results)))
-        _autotuner_forward[k] = perf_results.algo
-        return perf_results.algo
-
-    search_mode = CUDNN_CONVOLUTION_FWD_PREFER_FASTEST
-    wlimit = 0
-    if workspace_limit is not None:
-        wlimit = workspace_limit
-        search_mode = CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT
-
-    fwd_alg = ctypes.c_int()
-    check_error(lib.cudnnGetConvolutionForwardAlgorithm(
-        get_handle(), idesc, weight_desc, conv_desc, odesc, search_mode,
-        wlimit, ctypes.byref(fwd_alg)))
-    return fwd_alg
-
-
-def convolution_forward_workspace_size(*args):
-    check_error(lib.cudnnGetConvolutionForwardWorkspaceSize(*args))
-
-
-def convolution_forward(*args):
-    check_error(lib.cudnnConvolutionForward(*args))
-
-
-def convolution_backward_data(*args):
-    return check_error(lib.cudnnConvolutionBackwardData(*args))
-
-
-def convolution_backward_data_algorithm(weight_desc, odesc, conv_desc, idesc):
-    k = convolution_autotuner_key(idesc, weight_desc, conv_desc)
-    if k in _autotuner_backward_data:
-        return _autotuner_backward_data[k]
-
-    if benchmark:
-        perf_results = ConvolutionAlgoPerf()
-        algo_count = ctypes.c_int()
-        check_error(lib.cudnnFindConvolutionBackwardDataAlgorithm(
-            get_handle(), weight_desc, odesc, conv_desc, idesc, 1,
-            ctypes.byref(algo_count), ctypes.byref(perf_results)))
-        _autotuner_backward_data[k] = perf_results.algo
-        return perf_results.algo
-
-    search_mode = CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST
-    wlimit = 0
-    if workspace_limit is not None:
-        wlimit = workspace_limit
-        search_mode = CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
-
-    bwd_data_alg = ctypes.c_int()
-    check_error(lib.cudnnGetConvolutionBackwardDataAlgorithm(
-        get_handle(), weight_desc, odesc, conv_desc, idesc, search_mode,
-        wlimit, ctypes.byref(bwd_data_alg)))
-    return bwd_data_alg
-
-
-def convolution_backward_data_workspace_size(*args):
-    return check_error(lib.cudnnGetConvolutionBackwardDataWorkspaceSize(*args))
-
-
-def convolution_backward_filter(*args):
-    return check_error(lib.cudnnConvolutionBackwardFilter(*args))
-
-
-def convolution_backward_filter_algorithm(idesc, odesc, conv_desc, weight_desc):
-    k = convolution_autotuner_key(idesc, weight_desc, conv_desc)
-    if k in _autotuner_backward_filter:
-        return _autotuner_backward_filter[k]
-
-    if benchmark:
-        perf_results = ConvolutionAlgoPerf()
-        algo_count = ctypes.c_int()
-        check_error(lib.cudnnFindConvolutionBackwardFilterAlgorithm(
-            get_handle(), idesc, odesc, conv_desc, weight_desc, 1,
-            ctypes.byref(algo_count), ctypes.byref(perf_results)))
-        _autotuner_backward_filter[k] = perf_results.algo
-        return perf_results.algo
-
-    search_mode = CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST
-    wlimit = 0
-    if workspace_limit is not None:
-        wlimit = workspace_limit
-        search_mode = CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT
-
-    bwd_filter_alg = ctypes.c_int()
-    check_error(lib.cudnnGetConvolutionBackwardFilterAlgorithm(
-        get_handle(), idesc, odesc, conv_desc, weight_desc, search_mode,
-        wlimit, ctypes.byref(bwd_filter_alg)))
-    return bwd_filter_alg
-
-
-def convolution_backward_filter_workspace_size(*args):
-    return check_error(lib.cudnnGetConvolutionBackwardFilterWorkspaceSize(*args))
-
-
-def convolution_backward_bias(*args):
-    check_error(lib.cudnnConvolutionBackwardBias(*args))
 
 
 def add_tensor(*args):

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -180,13 +180,7 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
   }                                                                            \
                                                                                \
 dispatch:                                                                      \
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
-  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",      \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
-  THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  return PyObject_Call(method, args, kwargs);                                  \
+  return THPUtils_dispatchStateless(tensor, #name, args, kwargs);              \
 }
 
 IMPLEMENT_STATELESS(sigmoid)
@@ -326,13 +320,7 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
   }                                                                            \
                                                                                \
 dispatch:                                                                      \
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
-  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",      \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
-  THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  return PyObject_Call(method, args, kwargs);                                  \
+  return THPUtils_dispatchStateless(tensor, #name, args, kwargs);              \
 }
 
 IMPLEMENT_STATELESS_REVERSED(gt)
@@ -354,14 +342,7 @@ static PyObject * THPModule_nonzero(PyObject *_unused, PyObject *args, PyObject 
     tensor = PyTuple_GET_ITEM(args, 0);
   else if (PyTuple_Size(args) == 2)
     tensor = PyTuple_GET_ITEM(args, 1);
-
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
-  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  THPObjectPtr method = PyObject_GetAttrString(methods, "nonzero");
-  THPUtils_assert(method, "Type %s doesn't implement stateless method nonzero",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  return PyObject_Call(method, args, kwargs);
+  return THPUtils_dispatchStateless(tensor, "nonzero", args, kwargs);
 }
 
 static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args, PyObject *kwargs)
@@ -370,13 +351,7 @@ static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args, PyObject
   PyObject *out;
   if (kwargs && (out = PyDict_GetItemString(kwargs, "out")))
       tensor = out;
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
-  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  THPObjectPtr method = PyObject_GetAttrString(methods, "randperm");
-  THPUtils_assert(method, "Type %s doesn't implement stateless method randperm",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  return PyObject_Call(method, args, kwargs);
+  return THPUtils_dispatchStateless(tensor, "randperm", args, kwargs);
 }
 
 static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
@@ -397,13 +372,7 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
     PyErr_Clear();
   }
 
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
-  THPUtils_assert(methods, "Type %s doesn't implement statless methods",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  THPObjectPtr method = PyObject_GetAttrString(methods, "cat");
-  THPUtils_assert(method, "Type %s doesn't implement stateless method cat",
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor));
-  return PyObject_Call(method, args, NULL);
+  return THPUtils_dispatchStateless(tensor, "cat", args, NULL);
 }
 
 PyObject *THPModule_safeCall(PyObject *_unused, PyObject *args, PyObject *kwargs)

--- a/torch/csrc/ModuleSparse.cpp
+++ b/torch/csrc/ModuleSparse.cpp
@@ -89,13 +89,7 @@ static PyObject * TH_CONCAT_2(THSPModule_, name)(PyObject *_unused, PyObject *ar
   }                                                                            \
                                                                                \
 dispatch:                                                                      \
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME); \
-  THPUtils_assert(methods, "Type %s doesn't implement stateless methods",      \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  THPObjectPtr method = PyObject_GetAttrString(methods, #name);                \
-  THPUtils_assert(method, "Type %s doesn't implement stateless method " #name, \
-      tensor == THPDefaultTensorClass ? THPUtils_classname(tensor) : THPUtils_typename(tensor)); \
-  return PyObject_Call(method, args, kwargs);                                  \
+  return THPUtils_dispatchStateless(tensor, #name, args, kwargs);              \
 }
 
 IMPLEMENT_SPARSE_STATELESS(spmm);

--- a/torch/csrc/PtrWrapper.h
+++ b/torch/csrc/PtrWrapper.h
@@ -1,6 +1,7 @@
 #ifndef THP_PTR_WRAPPER_H
 #define THP_PTR_WRAPPER_H
 
+#include <Python.h>
 #include <functional>
 
 /**

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -4,6 +4,9 @@
 #include <unordered_map>
 #include <TH/TH.h>
 #include <THC/THCCachingAllocator.h>
+#ifdef WITH_NCCL
+#include <nccl.h>
+#endif
 
 #include "THCP.h"
 
@@ -312,3 +315,12 @@ PyObject * THCPModule_initExtension(PyObject *self)
   }
   return PyBool_FromLong(THCPModule_initCuda(torch_module));
 }
+
+#ifdef WITH_NCCL
+void THCPModule_useNccl()
+{
+  // Use NCCL to ensure that the symbols are loaded
+  ncclUniqueId uniqueId;
+  ncclGetUniqueId(&uniqueId);
+}
+#endif

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -143,7 +143,6 @@ std::vector<int> THPUtils_unpackIntTuple(PyObject *arg);
 
 void THPUtils_addPyMethodDefs(std::vector<PyMethodDef>& vector, PyMethodDef* methods);
 
-#define THPUtils_classname(obj) (((PyTypeObject*)obj)->tp_name)
 int THPUtils_getCallable(PyObject *arg, PyObject **result);
 // https://bugsfiles.kde.org/attachment.cgi?id=61186
 #if PY_VERSION_HEX >= 0x03020000
@@ -175,6 +174,7 @@ struct THPUtils_typeTraits {};
 THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
+PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);
 
 #endif /* _THP_CORE */
 

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -3,10 +3,13 @@
 set -e
 
 WITH_CUDA=0
+WITH_NCCL=0
 WITH_DISTRIBUTED=0
 for arg in "$@"; do
     if [[ "$arg" == "--with-cuda" ]]; then
         WITH_CUDA=1
+    elif [[ "$arg" == "--with-nccl" ]]; then
+        WITH_NCCL=1
     elif [[ "$arg" == "--with-distributed" ]]; then
         WITH_DISTRIBUTED=1
     else
@@ -79,7 +82,7 @@ function build_nccl() {
                -DCMAKE_C_FLAGS="$C_FLAGS" \
                -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS"
    make install
-   cp "lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so"
+   cp "lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so.1"
    cd ../..
 }
 
@@ -91,11 +94,9 @@ if [[ $WITH_CUDA -eq 1 ]]; then
     build THC
     build THCS
     build THCUNN
-    if [[ $(uname) != 'Darwin' ]]; then
-        if [[ `ldconfig -p | grep libnccl` == '' ]]; then
-          build_nccl
-        fi
-    fi
+fi
+if [[ $WITH_NCCL -eq 1 ]]; then
+    build_nccl
 fi
 
 build THPP

--- a/torch/lib/libshm/alloc_info.h
+++ b/torch/lib/libshm/alloc_info.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <unistd.h>
 
 struct AllocInfo {
   pid_t pid;

--- a/torch/lib/libshm/err.h
+++ b/torch/lib/libshm/err.h
@@ -1,3 +1,5 @@
+#pragma once
 
 #include <system_error>
+
 #define SYSCHECK(call) { auto __ret = (call); if (__ret < 0) { throw std::system_error(errno, std::system_category()); } }

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
           // someone wants to register a segment
           DEBUG("got alloc info");
           auto &session = client_sessions.at(pfd.fd);
-          AllocInfo info = session.socket.recieve();
+          AllocInfo info = session.socket.receive();
           session.pid = info.pid;
           DEBUG("got alloc info: %d %d %s", (int)info.free, info.pid, info.filename);
           if (info.free) {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -417,7 +417,14 @@ def nll_loss(input, target, weight=None, size_average=True):
         >>> output = F.nll_loss(F.log_softmax(input), target)
         >>> output.backward()
     """
-    return _functions.thnn.NLLLoss(size_average, weight=weight)(input, target)
+    dim = input.dim()
+    if dim == 2:
+        f = _functions.thnn.NLLLoss(size_average, weight=weight)
+    elif dim == 4:
+        f = _functions.thnn.NLLLoss2d(size_average, weight=weight)
+    else:
+        raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
+    return f(input, target)
 
 
 def kl_div(input, target, size_average=True):

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -49,6 +49,9 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     Returns:
         a :class:`PackedSequence` object
     """
+    if lengths[-1] <= 0:
+        raise ValueError("length of all samples has to be greater than 0, "
+                         "but found an element in 'lengths' that is <=0")
     if batch_first:
         input = input.transpose(0, 1)
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -193,7 +193,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
 
 
 def load(f, map_location=None, pickle_module=pickle):
-    """Loads an object saved with torch.save from a disk file.
+    """Loads an object saved with :func:`torch.save` from a file.
 
     torch.load can dynamically remap storages to be loaded on a different device
     using the map_location argument. If it's a callable, it will be called with
@@ -213,6 +213,13 @@ def load(f, map_location=None, pickle_module=pickle):
         map_location: a function or a dict specifying how to remap storage locations
         pickle_module: module used for unpickling metadata and objects (has to match
             the pickle_module used to serialize file)
+
+    Example:
+        >>> torch.load('tensors.pt')
+        # Load all tensors onto the CPU
+        >>> torch.load('tensors.pt', map_location=lambda storage, loc: storage)
+        # Map tensors from GPU 1 to GPU 0
+        >>> torch.load('tensors.pt', map_location={'cuda:1':'cuda:0'})
     """
     new_fd = False
     if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)):
@@ -237,7 +244,7 @@ def _load(f, map_location, pickle_module):
     else:
         def restore_location(storage, location):
             result = map_location(storage, location)
-            if not result:
+            if result is None:
                 result = default_restore_location(storage, location)
             return result
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1,6 +1,6 @@
 import torch
 from . import _tensor_str
-from ._utils import _type, _cuda, _range
+from ._utils import _type, _cuda, _range, _rebuild_tensor
 import sys
 
 
@@ -104,7 +104,9 @@ class _TensorBase(object):
         return new_tensor
 
     def __reduce__(self):
-        return (type(self), (), self.__getstate__())
+        # NOTE: _rebuild_tensor does not call __setstate__
+        args = self.__getstate__()
+        return (_rebuild_tensor, args)
 
     def __getstate__(self):
         return (self.storage(),


### PR DESCRIPTION
This change makes `torch.is_tensor` and `torch.is_storage` resilient to inputs of old-style class instances (still may be common in Python 2 codebases) that do not have `__class__` attribute.

Very welcoming the feedback :) It's somehow my first PR ever.

Details how the old behavior broke serialization is here: https://github.com/pytorch/pytorch/issues/1003