### PR TITLE
the length of any item in padded_sequence should be greater than 0

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -59,6 +59,8 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     batch_size = input.size(1)
     if len(lengths) != batch_size:
         raise ValueError("lengths array has incorrect size")
+    if lengths_iter[0] <= 0:
+        raise ValueError("length has to be greater than 0")
 
     for step, step_value in enumerate(input, 1):
         steps.append(step_value[:batch_size])


### PR DESCRIPTION
If we feed a lengths list whose minimal value is not greater than 0, we will get wrong packed result, because the body of the while loop in line 70 (while step == current_length:) may never run.