### PR TITLE
the length of any item in padded_sequence should be greater than 0

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -50,7 +50,8 @@ def pack_padded_sequence(input, lengths, batch_first=False):
         a :class:`PackedSequence` object
     """
     if lengths[-1] <= 0:
-        raise ValueError("length has to be greater than 0")
+        raise ValueError("length of all samples has to be greater than 0, "
+                         "but found an element in 'lengths' that is <=0")
     if batch_first:
         input = input.transpose(0, 1)
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -49,6 +49,8 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     Returns:
         a :class:`PackedSequence` object
     """
+    if lengths[-1] <= 0:
+        raise ValueError("length has to be greater than 0")
     if batch_first:
         input = input.transpose(0, 1)
 


### PR DESCRIPTION
If we feed a lengths list whose minimal value is not greater than 0, we will get wrong packed result, because the body of the while loop in line 69 (while step == current_length:) may never run. For example, if the minimal length is 0, then the initial value of 'current_length' will be 0, while the initial value of 'step' is 1, so the while test will never be True and the body of the while loop will never run.