### PR TITLE
Correct typo in batchnorm documentation

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -71,8 +71,8 @@ class BatchNorm1d(_BatchNorm):
         affine: a boolean value that when set to true, gives the layer learnable affine parameters.
 
     Shape:
-        - Input: :math:`(N, L)` or :math:`(N, C, L)`
-        - Output: :math:`(N, L)` or :math:`(N, C, L)` (same shape as input)
+        - Input: :math:`(N, C)` or :math:`(N, C, L)`
+        - Output: :math:`(N, C)` or :math:`(N, C, L)` (same shape as input)
 
     Examples:
         >>> # With Learnable Parameters


### PR DESCRIPTION
When applying batchnorm, the second dimension always indicates the number of hidden units.
The dimension is expressed as `C` in the documentation, however there was a typo in that of `BatchNorm1d`.