### PR TITLE
Bug fixes

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -622,8 +622,9 @@ class TestNN(NNTestCase):
             for p, g in zip(l.parameters(), grads):
                 p._grad = Variable(g.clone())
             norm_before = compute_norm(norm_type)
-            clip_grad_norm(l.parameters(), max_norm, norm_type=norm_type)
+            norm = clip_grad_norm(l.parameters(), max_norm, norm_type=norm_type)
             norm_after = compute_norm(norm_type)
+            self.assertEqual(norm, norm_before)
             self.assertEqual(norm_after, max_norm)
             self.assertLessEqual(norm_after, norm_before)
             compare_scaling(grads)
@@ -634,8 +635,9 @@ class TestNN(NNTestCase):
             for p, g in zip(l.parameters(), grads):
                 p.grad.data.copy_(g)
             norm_before = compute_norm(norm_type)
-            clip_grad_norm(l.parameters(), max_norm, norm_type=norm_type)
+            norm = clip_grad_norm(l.parameters(), max_norm, norm_type=norm_type)
             norm_after = compute_norm(norm_type)
+            self.assertEqual(norm, norm_before)
             self.assertEqual(norm_before, norm_after)
             self.assertLessEqual(norm_after, max_norm)
             scale = compare_scaling(grads)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1030,15 +1030,16 @@ class TestTorch(TestCase):
 
     def test_cat(self):
         SIZE = 10
-        for dim in range(3):
-            x = torch.rand(13, SIZE, SIZE).transpose(0, dim)
-            y = torch.rand(17, SIZE, SIZE).transpose(0, dim)
-            z = torch.rand(19, SIZE, SIZE).transpose(0, dim)
+        for dim in range(-3, 3):
+            pos_dim = dim if dim >= 0 else 3 + dim
+            x = torch.rand(13, SIZE, SIZE).transpose(0, pos_dim)
+            y = torch.rand(17, SIZE, SIZE).transpose(0, pos_dim)
+            z = torch.rand(19, SIZE, SIZE).transpose(0, pos_dim)
 
             res1 = torch.cat((x, y, z), dim)
-            self.assertEqual(res1.narrow(dim, 0, 13), x, 0)
-            self.assertEqual(res1.narrow(dim, 13, 17), y, 0)
-            self.assertEqual(res1.narrow(dim, 30, 19), z, 0)
+            self.assertEqual(res1.narrow(pos_dim, 0, 13), x, 0)
+            self.assertEqual(res1.narrow(pos_dim, 13, 17), y, 0)
+            self.assertEqual(res1.narrow(pos_dim, 30, 19), z, 0)
 
         x = torch.randn(20, SIZE, SIZE)
         self.assertEqual(torch.cat(torch.split(x, 7)), x)
@@ -1048,7 +1049,7 @@ class TestTorch(TestCase):
         z = torch.cat([x, y])
         self.assertEqual(z.size(), (21, SIZE, SIZE))
 
-        self.assertRaises(TypeError, lambda: torch.cat([]))
+        self.assertRaises(RuntimeError, lambda: torch.cat([]))
 
     def test_stack(self):
         x = torch.rand(2, 3, 4)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -221,7 +221,7 @@ See :func:`torch.bmm`
 
 add_docstr(torch._C.FloatTensorBase.cauchy_,
            """
-cauchy_(generator=None, median=0, sigma=1) -> Tensor
+cauchy_(median=0, sigma=1, *, generator=None) -> Tensor
 
 Fills the tensor with numbers drawn from the Cauchy distribution:
 
@@ -445,7 +445,7 @@ In-place version of :meth:`~Tensor.exp`
 
 add_docstr(torch._C.FloatTensorBase.exponential_,
            """
-exponential_(generator=None, lambd=1) -> Tensor
+exponential_(lambd=1, *, generator=None) -> Tensor
 
 Fills this tensor with elements drawn from the exponential distribution:
 
@@ -533,7 +533,7 @@ See :func:`torch.gels`
 
 add_docstr(torch._C.FloatTensorBase.geometric_,
            """
-geometric_(generator=None, p) -> Tensor
+geometric_(p, *, generator=None) -> Tensor
 
 Fills this tensor with elements drawn from the geometric distribution:
 
@@ -761,7 +761,7 @@ In-place version of :meth:`~Tensor.log`
 """)
 
 add_docstr(torch._C.FloatTensorBase.log_normal_, u"""
-log_normal_(generator=None, mean=1, std=2)
+log_normal_(mean=1, std=2, *, generator=None)
 
 Fills this tensor with numbers samples from the log-normal distribution
 parameterized by the given mean (\u00B5) and standard deviation (\u03C3). Note that
@@ -895,7 +895,7 @@ In-place version of :meth:`~Tensor.mul`
 
 add_docstr(torch._C.FloatTensorBase.multinomial,
            """
-multinomial(generator=None, num_samples, replacement=False)
+multinomial(num_samples, replacement=False, *, generator=None)
 
 See :func:`torch.multinomial`
 """)
@@ -991,7 +991,7 @@ See :func:`torch.norm`
 
 add_docstr(torch._C.FloatTensorBase.normal_,
            """
-normal_(generator=None, mean=0, std=1)
+normal_(mean=0, std=1, *, generator=None)
 
 Fills this tensor with elements samples from the normal distribution
 parameterized by :attr:`mean` and :attr:`std`.
@@ -1085,11 +1085,11 @@ See :func:`torch.qr`
 
 add_docstr(torch._C.FloatTensorBase.random_,
            """
-random_(generator=None, from=0, to=None)
+random_(from=0, to=None, *, generator=None)
 
 Fills this tensor with numbers sampled from the uniform distribution or
-discrete uniform distribution over [from, to]. If not specified, :attr:`to`
-defaults to the largest value representable by this tensor's data type.
+discrete uniform distribution over [from, to - 1]. If not specified, the
+values are only bounded by this tensor's data type.
 """)
 
 add_docstr(torch._C.FloatTensorBase.reciprocal,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -363,8 +363,8 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
     PyObject *first_arg = PyTuple_GET_ITEM(args, 0);
     if (THPModule_isTensor(first_arg)) {
       tensor = first_arg;
-    } else if ((iterator = PyObject_GetIter(first_arg))) {
-      item = PyIter_Next(iterator);
+    } else if (PySequence_Check(first_arg)) {
+      item = PySequence_GetItem(first_arg, 0);
       if (item && (THPModule_isTensor(item) || THPVariable_Check(item))) {
         tensor = item;
       }

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -690,8 +690,8 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
     goto invalid_arguments;
   sequence = PyTuple_GET_ITEM(args, 0);
   seq_length = PySequence_Length(sequence);
-  if (seq_length <= 0)
-    goto invalid_arguments;
+  THPUtils_assert(seq_length > 0, "sequence length has to be positive, but is %lld",
+                  (long long)seq_length);
 
   items.reserve(seq_length);
   item_tensors.reserve(seq_length);
@@ -708,6 +708,17 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
     dimension = THPUtils_unpackLong(PyTuple_GET_ITEM(args, 1));
   } else {
     dimension = 0;
+  }
+
+  for (THTensor *t : item_tensors) {
+    auto ndim = THTensor_(nDimension)(LIBRARY_STATE t);
+    if (ndim > 0) {
+      THPUtils_assert(dimension > 0 ? dimension < ndim : ndim + dimension >= 0,
+                      "dimension out of range - got %d but the tensor is only %dD",
+                      dimension, ndim);
+      if (dimension < 0) dimension += ndim;
+      break;
+    }
   }
 
 #if IS_CUDA

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -8,19 +8,20 @@
       output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - long n
 ]]
 
 #if !defined(TH_REAL_IS_HALF) && !IS_CUDA
 static void THTensor_(random2__)(THTensor *self, THGenerator *gen, long a, long b)
 {
-  THArgCheck(b >= a, 2, "upper bound must be greater or equal than lower bound");
+  THArgCheck(b > a, 2, "upper bound must be greater than lower bound");
   TH_TENSOR_APPLY(real, self, *self_data = ((THRandom_random(gen) % (b+1-a)) + a);)
 }
 
 static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
 {
-  THArgCheck(b >= 0, 1, "upper bound must be positive");
+  THArgCheck(b > 0, 1, "upper bound must be positive");
   TH_TENSOR_APPLY(real, self, *self_data = (THRandom_random(gen) % b);)
 }
 #endif
@@ -35,17 +36,20 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
     - cname: random1__
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - long to
     - cname: random2__
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - long from
         - long to
 ]]
@@ -60,6 +64,7 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
       output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - THTensor* self
     - long num_samples
     - arg: bool replacement
@@ -75,6 +80,7 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: real from
       default: 0
     - arg: real to
@@ -118,6 +124,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
           output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - THTensor* means
         - arg: real std
           default: 1
@@ -127,6 +134,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
           output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - arg: real mean
           default: 0
         - THTensor* std
@@ -136,6 +144,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
           output: True
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - THTensor* means
         - THTensor* std
 ]]
@@ -149,6 +158,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: real mean
       default: 0
     - arg: real std
@@ -164,6 +174,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: real median
       default: 0
     - arg: real sigma
@@ -180,6 +191,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: real mean
       default: 1
     - arg: real std
@@ -195,6 +207,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: real lambd
       default: 1
 ]]
@@ -209,6 +222,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
       output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -223,6 +237,7 @@ static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, TH
       output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - arg: THSize* size
       long_args: True
 ]]
@@ -399,6 +414,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
     - THTensor* self
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - double p
 ]]
 
@@ -418,6 +434,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
       output: True
     - arg: THGenerator* generator
       default: THPDefaultGenerator->cdata
+      kwarg_only: True
     - THTensor* self
 ]]
 
@@ -434,6 +451,7 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - arg: double p
           default: 0.5
     - cname: bernoulli_FloatTensor
@@ -441,12 +459,14 @@ static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTenso
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - THFloatTensor* float_p
     - cname: bernoulli_DoubleTensor
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
+          kwarg_only: True
         - THDoubleTensor* float_p
 ]]
 

--- a/torch/legacy/optim/lbfgs.py
+++ b/torch/legacy/optim/lbfgs.py
@@ -179,10 +179,6 @@ def lbfgs(opfunc, x, config, state=None):
         # directional derivative
         gtd = g.dot(d)  # g * d
 
-        # check that progress can be made along that direction
-        if gtd > -tolX:
-            break
-
         # reset initial guess for step size
         if state['nIter'] == 1:
             tmp1.copy_(g).abs_()
@@ -228,6 +224,10 @@ def lbfgs(opfunc, x, config, state=None):
         if tmp1.sum() <= tolFun:
             # check optimality
             verbose('optimality condition below tolFun')
+            break
+
+        # check that progress can be made along that direction
+        if gtd > -tolX:
             break
 
         tmp1.copy_(d).mul_(t).abs_()

--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -84,9 +84,10 @@ class CosineEmbeddingLoss(Function):
             gw1.div_(y.size(0))
             gw2.div_(y.size(0))
 
-        if grad_output[0] != 1:
-            gw1.mul_(grad_output)
-            gw2.mul_(grad_output)
+        grad_output_val = grad_output[0]
+        if grad_output_val != 1:
+            gw1.mul_(grad_output_val)
+            gw2.mul_(grad_output_val)
 
         return gw1, gw2, None
 

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -10,6 +10,9 @@ def clip_grad_norm(parameters, max_norm, norm_type=2):
             gradients normalized
         max_norm (float or int): max norm of the gradients
         norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for infinity norm.
+
+    Returns:
+        Total norm of the parameters (viewed as a single vector).
     """
     parameters = list(filter(lambda p: p.grad is not None, parameters))
     max_norm = float(max_norm)
@@ -23,7 +26,7 @@ def clip_grad_norm(parameters, max_norm, norm_type=2):
             total_norm += param_norm ** norm_type
         total_norm = total_norm ** (1. / norm_type)
     clip_coef = max_norm / (total_norm + 1e-6)
-    if clip_coef >= 1:
-        return
-    for p in parameters:
-        p.grad.data.mul_(clip_coef)
+    if clip_coef < 1:
+        for p in parameters:
+            p.grad.data.mul_(clip_coef)
+    return total_norm

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -186,18 +186,14 @@ class LBFGS(Optimizer):
             ############################################################
             # compute step length
             ############################################################
-            # directional derivative
-            gtd = flat_grad.dot(d)  # g * d
-
-            # check that progress can be made along that direction
-            if gtd > -tolerance_change:
-                break
-
             # reset initial guess for step size
             if state['n_iter'] == 1:
                 t = min(1., 1. / abs_grad_sum) * lr
             else:
                 t = lr
+
+            # directional derivative
+            gtd = flat_grad.dot(d)  # g * d
 
             # optional line search: user function
             ls_func_evals = 0
@@ -230,6 +226,9 @@ class LBFGS(Optimizer):
                 break
 
             if abs_grad_sum <= tolerance_grad:
+                break
+
+            if gtd > -tolerance_change:
                 break
 
             if d.mul(t).abs_().sum() <= tolerance_change:


### PR DESCRIPTION
* Fix size mismatch in `CosineEmbeddingLoss` (#1058)
* **Make `random_` range exclusive** (it used to be exclusive when only the upper bound was specified, and inclusive when both were given). Also, all **`generator` args are now keyword only in random functions**. This should help with the confusing doc format. (#1046)
* Fixed two bugs in `torch.cat`:
  * It shouldn't accept `reverse` (it's not a `PySequence`) (#1015)
  * It now **disallows catting along inexistent dimensions** (to make it consistent with numpy and Variable cat) (#1014)
* Return the total norm of parameters from `clip_grad_norm` (#1032)
* Fix a bug in L-BFGS that caused it to use uninitialized locals (#1039)

Breaking changes are in bold.