### PR TITLE
DataLoader: Fix batch data type for numpy array

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -64,7 +64,7 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    elif type(batch[0]).__module__ == 'numpy' and type(batch[0]).__name__ == 'ndarray':  
+    elif type(batch[0]).__module__ == 'numpy' and type(batch[0]).__name__ == 'ndarray':
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1,7 +1,6 @@
 import torch
 import torch.multiprocessing as multiprocessing
 from .sampler import SequentialSampler, RandomSampler
-import numpy as np
 import collections
 import math
 import sys
@@ -65,7 +64,7 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    elif isinstance(batch[0], np.ndarray):
+    elif type(batch[0]).__name__ == 'ndarray':  # this allows to not import numpy
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -64,8 +64,7 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    elif type(batch[0]).__module__ == 'numpy' and \
-         type(batch[0]).__name__ == 'ndarray':  # this allows to not import numpy
+    elif type(batch[0]).__module__ == 'numpy' and type(batch[0]).__name__ == 'ndarray':  
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -64,8 +64,8 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    # this allows to not import numpy
-    elif type(batch[0]).__module__ == 'numpy' and type(batch[0]).__name__ == 'ndarray':  
+    elif type(batch[0]).__module__ == 'numpy' and \
+         type(batch[0]).__name__ == 'ndarray':  # this allows to not import numpy
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1,6 +1,7 @@
 import torch
 import torch.multiprocessing as multiprocessing
 from .sampler import SequentialSampler, RandomSampler
+import numpy as np
 import collections
 import math
 import sys
@@ -64,7 +65,7 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    elif type(batch[0]).__module__ == 'numpy':  # this allows to not import numpy
+    elif isinstance(batch[0], np.ndarray):
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -64,7 +64,8 @@ def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
     if torch.is_tensor(batch[0]):
         return torch.stack(batch, 0)
-    elif type(batch[0]).__name__ == 'ndarray':  # this allows to not import numpy
+    # this allows to not import numpy
+    elif type(batch[0]).__module__ == 'numpy' and type(batch[0]).__name__ == 'ndarray':  
         return torch.stack([torch.from_numpy(b) for b in batch], 0)
     elif isinstance(batch[0], int):
         return torch.LongTensor(batch)


### PR DESCRIPTION
The original code is reasonable under purpose without importing numpy. However, in some cases, the user shall generate data set themselves by using Numpy and often the labels are of type `np.float32` which gives True for `type(label).__module__ == 'numpy'`, but it is not the purpose for this line and will raise runtime error, since label is not array, it can not be used for `torch.from_numpy()`.