### PR TITLE
Ensure displayed progress in ProgressMonitor is between 0 and 100%.

### DIFF
--- a/torch/utils/trainer/plugins/progress.py
+++ b/torch/utils/trainer/plugins/progress.py
@@ -19,7 +19,7 @@ class ProgressMonitor(Plugin):
 
     def iteration(self, iteration, input, *args):
         stats = self.trainer.stats.setdefault(self.stat_name, {})
-        stats['samples_used'] += input.size(0)
+        stats['samples_used'] += 1
         stats['percent'] = 100. * stats['samples_used'] / stats['epoch_size']
 
     def epoch(self, *args):


### PR DESCRIPTION
Increases samples_used by 1 instead of using the input batch size.

Fixes #1086 