### PR TITLE
Cwrap arg assign

### DIFF
--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -7,6 +7,8 @@ from .plugins import ArgcountChecker, OptionalArguments, ArgumentReferences, \
 
 
 class cwrap(object):
+    BASE_INDENT_SIZE = 6
+
     RETURN_WRAPPERS = {
         'void': Template('Py_RETURN_NONE;'),
         'long': Template('return PyLong_FromLong($result);'),
@@ -16,15 +18,19 @@ class cwrap(object):
 
     OPTION_TEMPLATE = Template("""
     ${els}if ($arg_check) {
+      $pre_arg_assign
+      $arg_assign
       $code
     """)
+
+    ARG_ASSIGN_TEMPLATE = Template("""${type} ${name} = ${unpack};""")
 
     OPTION_CODE_TEMPLATE = [
         '$call',
         '$return_result',
     ]
 
-    FUNCTION_CALL_TEMPLATE = Template("$capture_result$cname($arg_unpack);")
+    FUNCTION_CALL_TEMPLATE = Template("$capture_result$cname($call_arg);")
 
     DEFAULT_PLUGIN_CLASSES = [ArgcountChecker, ConstantArguments, OptionalArguments,
                               ArgumentReferences, BeforeAfterCall, ReturnArguments, GILRelease]
@@ -148,6 +154,9 @@ class cwrap(object):
     def get_wrapper_template(self, declaration):
         return self.search_plugins('get_wrapper_template', (declaration,), lambda _: None)
 
+    def get_formal_args(self, arguments):
+        return self.search_plugins('get_formal_args', (arguments,), lambda _: arguments)
+
     def get_arg_accessor(self, arg, option):
         def wrap_accessor(arg, _):
             if arg.get('idx') is None:
@@ -178,8 +187,43 @@ class cwrap(object):
             res = tmpl.substitute(arg=accessor, idx=arg.get('idx'))
             for plugin in self.plugins:
                 res = getattr(plugin, plugin_fn_name)(res, arg, accessor)
+
             result.append(res)
         return result
+
+    def build_arg_assign(self, arguments, arg_unpack):
+        assignement = []
+        call_arg = []
+        # If type names needs to be changed
+        arguments = self.get_formal_args(arguments)
+        for arg, unpack in zip(arguments, arg_unpack):
+            if arg['type'] == 'CONSTANT':
+                call_arg.append(str(arg['name']))
+            else:
+                var_name = "arg_"+str(arg.get('formal_name', arg['name']))
+                res = self.ARG_ASSIGN_TEMPLATE.substitute(
+                    type = arg['type'],
+                    name = var_name,
+                    unpack = unpack)
+
+                if not var_name in call_arg:
+                    assignement.append(res)
+                call_arg.append(var_name)
+        return assignement, call_arg
+
+    def indent_code(self, code):
+        if code == '':
+            return code
+        code_lines = map(lambda s: s.strip(), code.split('\n'))
+        code = '\n'
+        depth = self.BASE_INDENT_SIZE
+        for line in code_lines:
+            depth -= line.count('}') * 2
+            code += ' ' * depth + line + '\n'
+            depth += line.count('{') * 2
+            depth += line.count('(') * 4
+            depth -= line.count(')') * 4
+        return code[:-1]
 
     def generate_option(self, option, is_first):
         checked_args = list(filter(
@@ -199,22 +243,29 @@ class cwrap(object):
         for plugin in self.plugins:
             arg_checks = plugin.process_all_checks(arg_checks, option)
 
-        # Generate unpacks
+        # Generate pre_arg assign
+        pre_arg_assign = []
+        for plugin in self.plugins:
+            pre_arg_assign = plugin.process_pre_arg_assign(pre_arg_assign, option)
+
+        # Generate arg assignment and call arguments
         arg_unpack = self.map_selected_arguments('get_type_unpack',
                                                  'process_single_unpack', option, option['arguments'])
-        arg_unpack = ', '.join(arg_unpack)
+        arg_assign, call_arg = self.build_arg_assign(option['arguments'], arg_unpack)
+
+        call_arg = ', '.join(call_arg)
         for plugin in self.plugins:
-            arg_unpack = plugin.process_all_unpacks(arg_unpack, option)
+            call_arg = plugin.process_all_unpacks(call_arg, option)
 
         # Generate call
         try:
             return_result = self.get_return_wrapper(option).substitute()
             call = self.FUNCTION_CALL_TEMPLATE.substitute(capture_result='',
-                                                          cname=option['cname'], arg_unpack=arg_unpack)
+                                                          cname=option['cname'], call_arg=call_arg)
         except KeyError:
             return_result = self.get_return_wrapper(option).substitute(result='__result')
             call = self.FUNCTION_CALL_TEMPLATE.substitute(capture_result=(option['return'] + ' __result = '),
-                                                          cname=option['cname'], arg_unpack=arg_unpack)
+                                                          cname=option['cname'], call_arg=call_arg)
 
         code_template = deepcopy(self.OPTION_CODE_TEMPLATE)
         for plugin in self.plugins:
@@ -222,19 +273,15 @@ class cwrap(object):
                                                                 option)
         code_template = Template('\n'.join(code_template))
         code = code_template.substitute(call=call, return_result=return_result)
-        code_lines = map(lambda s: s.strip(), code.split('\n'))
-        code = '\n'
-        depth = 6
-        for line in code_lines:
-            depth -= line.count('}') * 2
-            code += ' ' * depth + line + '\n'
-            depth += line.count('{') * 2
-            depth += line.count('(') * 4
-            depth -= line.count(')') * 4
+        code = self.indent_code(code)
+        pre_arg_assign = self.indent_code('\n'.join(pre_arg_assign))
+        arg_assign = self.indent_code('\n'.join(arg_assign))
 
         # Put everything together
         return self.OPTION_TEMPLATE.substitute(
             els=('} else ' if not is_first else ''),
             arg_check=arg_checks,
+            pre_arg_assign=pre_arg_assign,
+            arg_assign=arg_assign,
             code=code,
         )

--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -154,8 +154,8 @@ class cwrap(object):
     def get_wrapper_template(self, declaration):
         return self.search_plugins('get_wrapper_template', (declaration,), lambda _: None)
 
-    def get_formal_args(self, arguments):
-        return self.search_plugins('get_formal_args', (arguments,), lambda _: arguments)
+    def get_assign_args(self, arguments):
+        return self.search_plugins('get_assign_args', (arguments,), lambda _: arguments)
 
     def get_arg_accessor(self, arg, option):
         def wrap_accessor(arg, _):
@@ -191,16 +191,16 @@ class cwrap(object):
             result.append(res)
         return result
 
-    def build_arg_assign(self, arguments, arg_unpack):
+    def build_option_args(self, arguments, arg_unpack):
         assignement = []
         call_arg = []
-        # If type names needs to be changed
-        arguments = self.get_formal_args(arguments)
+        # If types or names needs to be changed
+        arguments = self.get_assign_args(arguments)
         for arg, unpack in zip(arguments, arg_unpack):
             if arg['type'] == 'CONSTANT':
                 call_arg.append(str(arg['name']))
             else:
-                var_name = "arg_" + str(arg.get('formal_name', arg['name']))
+                var_name = "arg_" + str(arg.get('assign_name', arg['name']))
                 res = self.ARG_ASSIGN_TEMPLATE.substitute(
                     type=arg['type'],
                     name=var_name,
@@ -251,11 +251,11 @@ class cwrap(object):
         # Generate arg assignment and call arguments
         arg_unpack = self.map_selected_arguments('get_type_unpack',
                                                  'process_single_unpack', option, option['arguments'])
-        arg_assign, call_arg = self.build_arg_assign(option['arguments'], arg_unpack)
+        arg_assign, call_arg = self.build_option_args(option['arguments'], arg_unpack)
 
         call_arg = ', '.join(call_arg)
         for plugin in self.plugins:
-            call_arg = plugin.process_all_unpacks(call_arg, option)
+            call_arg = plugin.process_all_call_arg(call_arg, option)
 
         # Generate call
         try:

--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -200,13 +200,13 @@ class cwrap(object):
             if arg['type'] == 'CONSTANT':
                 call_arg.append(str(arg['name']))
             else:
-                var_name = "arg_"+str(arg.get('formal_name', arg['name']))
+                var_name = "arg_" + str(arg.get('formal_name', arg['name']))
                 res = self.ARG_ASSIGN_TEMPLATE.substitute(
-                    type = arg['type'],
-                    name = var_name,
-                    unpack = unpack)
+                    type=arg['type'],
+                    name=var_name,
+                    unpack=unpack)
 
-                if not var_name in call_arg:
+                if var_name not in call_arg:
                     assignement.append(res)
                 call_arg.append(var_name)
         return assignement, call_arg

--- a/tools/cwrap/plugins/AutoGPU.py
+++ b/tools/cwrap/plugins/AutoGPU.py
@@ -15,7 +15,7 @@ class AutoGPU(CWrapPlugin):
 #endif
 """
 
-    def process_option_code_template(self, template, option):
+    def process_pre_arg_assign(self, template, option):
         if not option.get('auto_gpu', True):
             return template
         call = 'THCPAutoGPU __autogpu_guard = THCPAutoGPU(args{});'.format(

--- a/tools/cwrap/plugins/BoolOption.py
+++ b/tools/cwrap/plugins/BoolOption.py
@@ -9,11 +9,20 @@ class BoolOption(CWrapPlugin):
     def is_bool_option(self, arg):
         return arg['type'] == 'bool' and 'if_true' in arg and 'if_false' in arg
 
+    def process_declarations(self, declarations):
+        for declaration in declarations:
+            for option in declaration['options']:
+                for arg in option['arguments']:
+                    if self.is_bool_option(arg):
+                        arg['is_bool_option'] = True
+                        arg['type'] = 'const char*'
+        return declarations
+
     def get_type_check(self, arg, option):
-        if self.is_bool_option(arg):
+        if arg.get('is_bool_option', False):
             return Template('PyBool_Check($arg)')
 
     def get_type_unpack(self, arg, option):
-        if self.is_bool_option(arg):
+        if arg.get('is_bool_option', False):
             return Template(self.UNPACK_TEMPLATE.safe_substitute(
                 if_true=arg['if_true'], if_false=arg['if_false']))

--- a/tools/cwrap/plugins/CuDNNPlugin.py
+++ b/tools/cwrap/plugins/CuDNNPlugin.py
@@ -84,15 +84,15 @@ static PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
     def get_type_check(self, arg, option):
         return self.TYPE_CHECK.get(arg['type'], None)
 
-    def get_formal_args(self, arguments):
-        formal_args = []
+    def get_assign_args(self, arguments):
+        assign_args = []
         for arg in arguments:
             arg = copy.copy(arg)
             new_type = self.INPUT_ARGUMENT_MAP.get(arg['type'])
             if new_type is not None:
                 arg['type'] = new_type
-            formal_args.append(arg)
-        return formal_args
+            assign_args.append(arg)
+        return assign_args
 
     def get_wrapper_template(self, declaration):
         arg_desc = []
@@ -158,7 +158,7 @@ static PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
             return self.preprocessor_guard(code, declaration['defined_if'])
         return code
 
-    def process_all_unpacks(self, code, option):
+    def process_all_call_arg(self, code, option):
         return 'state, ' + code
 
     def declare_methods(self):

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -386,7 +386,7 @@ ${cpu}
         for option in declaration['options']:
             for arg in option['arguments']:
                 if arg['name'] == 'self':
-                    arg['formal_name'] = 'self'
+                    arg['assign_name'] = 'self'
                     arg['name'] = 'source'
         return declaration
 
@@ -436,7 +436,7 @@ ${cpu}
             return self.preprocessor_guard(code, declaration['defined_if'])
         return code
 
-    def process_all_unpacks(self, code, option):
+    def process_all_call_arg(self, code, option):
         return 'LIBRARY_STATE ' + code
 
     def process_all_checks(self, code, option):

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -182,7 +182,7 @@ ${cpu}
         'double': 'float',
         'accreal': '" RealStr "',
         'bool': 'bool',
-        'const char*': 'bool', # Can come only from bool option.
+        'const char*': 'bool',  # Can come only from bool option.
     }
 
     OUT_INIT = """

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -182,6 +182,7 @@ ${cpu}
         'double': 'float',
         'accreal': '" RealStr "',
         'bool': 'bool',
+        'const char*': 'bool', # Can come only from bool option.
     }
 
     OUT_INIT = """
@@ -385,6 +386,7 @@ ${cpu}
         for option in declaration['options']:
             for arg in option['arguments']:
                 if arg['name'] == 'self':
+                    arg['formal_name'] = 'self'
                     arg['name'] = 'source'
         return declaration
 
@@ -458,7 +460,7 @@ ${cpu}
 
         return code
 
-    def process_option_code_template(self, template, option):
+    def process_pre_arg_assign(self, template, option):
         new_args = []
         for arg in option['arguments']:
             if not option.get('output_provided', True) and arg.get('output'):

--- a/tools/cwrap/plugins/__init__.py
+++ b/tools/cwrap/plugins/__init__.py
@@ -16,6 +16,9 @@ class CWrapPlugin(object):
     def get_wrapper_template(self, declaration):
         pass
 
+    def get_formal_args(self, arguments):
+        pass
+
     def get_arg_accessor(self, arg, option):
         pass
 
@@ -44,6 +47,9 @@ class CWrapPlugin(object):
         return declarations
 
     def process_option_code_template(self, template, option):
+        return template
+
+    def process_pre_arg_assign(self, template, option):
         return template
 
 

--- a/tools/cwrap/plugins/__init__.py
+++ b/tools/cwrap/plugins/__init__.py
@@ -16,7 +16,7 @@ class CWrapPlugin(object):
     def get_wrapper_template(self, declaration):
         pass
 
-    def get_formal_args(self, arguments):
+    def get_assign_args(self, arguments):
         pass
 
     def get_arg_accessor(self, arg, option):
@@ -34,7 +34,7 @@ class CWrapPlugin(object):
     def process_single_unpack(self, code, arg, arg_accessor):
         return code
 
-    def process_all_unpacks(self, code, option):
+    def process_all_call_arg(self, code, option):
         return code
 
     def process_option_code(self, code, option):

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -52,9 +52,11 @@
 #endif
 
 #if IS_CUDA
+#define THBoolTensor THCudaByteTensor
 #define THPBoolTensor THCPByteTensor
 #define THPBoolTensorClass THCPByteTensorClass
 #else
+#define THBoolTensor THByteTensor
 #define THPBoolTensor THPByteTensor
 #define THPBoolTensorClass THPByteTensorClass
 #endif
@@ -96,6 +98,7 @@ typedef THLongStorage THStride;
 #undef THIndexTensor_
 #undef THPIndexTensor
 #undef THPIndexTensorClass
+#undef THBoolTensor
 #undef THPBoolTensor
 #undef THPBoolTensorClass
 #undef RealStr

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -152,7 +152,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THTensor* self
         - CONSTANT NULL, 0, NULL, NULL
     - cname: setStorage
-      before_call: THLongStoragePtr __storage_size = THLongStorage_newWithSize1(THStorage_(size)(LIBRARY_STATE ((THPStorage*)$arg1)->cdata));
+      before_call: THLongStoragePtr __storage_size = THLongStorage_newWithSize1(THStorage_(size)(LIBRARY_STATE arg_storage));
       arguments:
         - THTensor* self
         - THStorage* storage
@@ -411,7 +411,7 @@ THTensor* THTensor_(transpose_neg)(THTensor *self, THTensor *src, int dim0, int 
   cname: newTranspose
   return: THTensor*
   before_call: |
-    long ndim = ((THPTensor*)${arg0})->cdata->nDimension;
+    long ndim = arg_self->nDimension;
     THPUtils_assert(ndim == 2, "t() expects a 2D tensor, but self is %ldD", ndim);
   arguments:
     - THTensor* self
@@ -425,7 +425,7 @@ THTensor* THTensor_(transpose_neg)(THTensor *self, THTensor *src, int dim0, int 
   auto_gpu: False
   return: self
   before_call: |
-    long ndim = ((THPTensor*)${arg0})->cdata->nDimension;
+    long ndim = arg_self->nDimension;
     THPUtils_assert(ndim == 2, "t_() expects a 2D tensor, but self is %ldD", ndim);
   arguments:
     - THTensor* self
@@ -655,8 +655,8 @@ THTensor* THTensor_(transpose_neg)(THTensor *self, THTensor *src, int dim0, int 
   with_stateless: True
   return: argument 0
   before_call: |
-    THLongStoragePtr _size = THIndexTensor_(newSizeOf)(LIBRARY_STATE ((THPIndexTensor*)$arg3)->cdata);
-    THTensor_(resize)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, _size, NULL);
+    THLongStoragePtr _size = THIndexTensor_(newSizeOf)(LIBRARY_STATE arg_index);
+    THTensor_(resize)(LIBRARY_STATE arg_result, _size, NULL);
   arguments:
     - arg: THTensor* result
       output: True


### PR DESCRIPTION
My first `cwrap` PR, thorough review needed !

Extend cwrap stucture to assign the arguments to variables named `arg_*` before the function call.
This simplifies the `before_call` that can now access directly the arguments (the previous behaviour with `${arg0}` is still allowed right now for backward compatibility).
Also allows the `before_call` to modify the arguments!!

Also fixes #146 as the unpacking is done before.

Sample before:
```cpp
      PyThreadState *_save = NULL;
      try {
        long ndim = ((THPTensor*)self)->cdata->nDimension;
        THPUtils_assert(ndim == 2, "t_() expects a 2D tensor, but self is %ldD", ndim);
        
        Py_UNBLOCK_THREADS;
        THTensor_(transpose)(LIBRARY_STATE ((THPTensor*)self)->cdata, ((THPTensor*)self)->cdata, 0, 1);
        Py_BLOCK_THREADS;
        Py_INCREF(self);
        return (PyObject*)self;
      } catch (...) {
        if (_save) {
          Py_BLOCK_THREADS;
        }
        throw;
      }
```

Sample after:
```cpp
      THTensor* arg_self = ((THPTensor*)self)->cdata;
      
      PyThreadState *_save = NULL;
      try {
        long ndim = arg_self->nDimension;
        THPUtils_assert(ndim == 2, "t_() expects a 2D tensor, but self is %ldD", ndim);
        
        Py_UNBLOCK_THREADS;
        THTensor_(transpose)(LIBRARY_STATE arg_self, arg_self, 0, 1);
        Py_BLOCK_THREADS;
        Py_INCREF(self);
        return (PyObject*)self;
      } catch (...) {
        if (_save) {
          Py_BLOCK_THREADS;
        }
        throw;
      }
```