### PR TITLE
Added docstring to Module.add_module

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -102,6 +102,10 @@ class Module(object):
             self._parameters[name] = param
 
     def add_module(self, name, module):
+        """Adds a child module to the current module.
+
+        The module can be accessed as an attribute using the given name.
+        """
         if hasattr(self, name):
             raise KeyError("attribute already exists '{}'".format(name))
         if not isinstance(module, Module) and module is not None:


### PR DESCRIPTION
Added a basic docstring to `add_module` as it was not appearing on pytorch.org/docs. 

As a side note, this is called `add_module` whereas for parameters and buffers the functions are named `register_*`, which I found a bit confusing.