### PR TITLE
Add btriunpack and update the btrifact test to use it.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -429,24 +429,9 @@ class TestTorch(TestCase):
                                 (1.3728, 0.1319))))
         a = cast(a)
         info = cast(torch.IntTensor())
-        LU_data, pivots = a.btrifact(info=info)
+        a_LU = a.btrifact(info=info)
         self.assertEqual(info.abs().sum(), 0)
-        I_U = torch.triu(torch.ones(2, 2)).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()
-        I_L = 1 - I_U
-        a_L = torch.zeros(a.size()).type_as(a)
-        a_U = a_L.clone()
-        a_L[torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a).byte()] = 1.0
-        a_L[I_L] = LU_data[I_L]
-        a_U[I_U] = LU_data[I_U]
-
-        P = torch.eye(2).unsqueeze(0).expand(3, 2, 2).type_as(a)
-        for i in range(3):
-            for j in range(2):
-                k = pivots[i, j] - 1
-                t = P[i, j, :].clone()
-                P[i, j, :] = P[i, k, :]
-                P[i, k, :] = t
-
+        P, a_L, a_U = torch.btriunpack(*a_LU)
         a_ = torch.bmm(P, torch.bmm(a_L, a_U))
         self.assertEqual(a_, a)
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -66,3 +66,46 @@ def unbind(tensor, dim=0):
         dim (int): dimension to remove.
     """
     return tuple(tensor.select(dim, i) for i in _range(tensor.size(dim)))
+
+
+def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
+    """Unpacks the data and pivots from a batched LU factorization (btrifact) of a tensor.
+
+    Returns a tuple indexed by:
+      0: The pivots.
+      1: The L tensor.
+      2: The U tensor.
+
+    Arguments:
+        LU_data (Tensor): The packed LU factorization data.
+        LU_pivots (Tensor): The packed LU factorization pivots.
+        unpack_data (bool): Flag indicating if the data should be unpacked.
+        unpack_pivots (bool): Flag indicating if the pivots should be unpacked.
+    """
+
+    nBatch, sz, _ = LU_data.size()
+
+    if unpack_data:
+        I_U = torch.triu(torch.ones(sz, sz)).type_as(LU_data).byte().unsqueeze(0).expand(nBatch, sz, sz)
+        I_L = 1 - I_U
+        L = LU_data.new(LU_data.size()).zero_()
+        U = LU_data.new(LU_data.size()).zero_()
+        I_diag = torch.eye(sz).type_as(LU_data).byte().unsqueeze(0).expand(nBatch, sz, sz)
+        L[I_diag] = 1.0
+        L[I_L] = LU_data[I_L]
+        U[I_U] = LU_data[I_U]
+    else:
+        L = U = None
+
+    if unpack_pivots:
+        P = torch.eye(sz).type_as(LU_data).unsqueeze(0).repeat(nBatch, 1, 1)
+        for i in range(nBatch):
+            for j in range(sz):
+                k = LU_pivots[i, j] - 1
+                t = P[i, :, j].clone()
+                P[i, :, j] = P[i, :, k]
+                P[i, :, k] = t
+    else:
+        P = None
+
+    return P, L, U


### PR DESCRIPTION
I'm open to changes in the interface. I included `mode` for efficiency so that both aren't extracted if somebody only needs one. I included `dtype` for convenience because when only the pivots are being extracted, there is no way to know the type of the main LU data because the pivots are ints.