### PR TITLE
Fix deadlock in autograd

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -98,6 +98,7 @@ auto Engine::thread_main(ReadyQueue& queue) -> void {
       }
     }
     if (--task.base->outstanding_tasks == 0) {
+      std::lock_guard<std::mutex> lock(task.base->mutex);
       task.base->not_done.notify_all();
     }
   }


### PR DESCRIPTION
Apparently that `notify_all()` was sometimes executed when the main thread wasn't sleeping, but doing some other stuff while holding the mutex. Once it returned to sleep it was never woken up again.

Fixes #1136