### PR TITLE
add support for persistent rnns

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ python setup.py install
 
 Dockerfile is supplied to build images with cuda support and cudnn v6. Build as usual
 ```
-docker build -t pytorch-cudnnv6 .
+docker build -t pytorch .
 ```
 and run  with nvidia-docker:
 ```
-nvidia-docker run --rm -ti --ipc=host pytorch-cudnnv5
+nvidia-docker run --rm -ti --ipc=host pytorch
 ```
 Please note that pytorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
 for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1552,7 +1552,7 @@ class TestNN(NNTestCase):
                     self.assertEqual(cpu_weight.grad.data, gpu_weight.grad.data, prec=5e-5)
 
         for module in (nn.RNN, nn.LSTM, nn.GRU):
-            for bias, bidirectional, batch_first, contig, variable_len in product((True, False), repeat=5):
+            for bias, bidirectional, batch_first, contig, variable_len, persistent in product((True, False), repeat=6):                
                 num_directions = 2 if bidirectional else 1
                 if batch_first:
                     input_val = torch.randn(batch, seq_length, input_size)
@@ -1592,11 +1592,11 @@ class TestNN(NNTestCase):
                                  bias=bias,
                                  dropout=dropout,
                                  bidirectional=bidirectional,
-                                 batch_first=batch_first)
+                                 batch_first=batch_first,
+                                 persistent=persistent)
 
                 outputs_gpu = forward_backward(
                     True, rnn_gpu, input_val, hx_val, grad_output, grad_hy, rnn.all_weights)
-
                 compare_cpu_gpu(outputs_cpu, outputs_gpu)
 
         for nonlinearity in ('tanh', 'relu'):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1552,7 +1552,7 @@ class TestNN(NNTestCase):
                     self.assertEqual(cpu_weight.grad.data, gpu_weight.grad.data, prec=5e-5)
 
         for module in (nn.RNN, nn.LSTM, nn.GRU):
-            for bias, bidirectional, batch_first, contig, variable_len, persistent in product((True, False), repeat=6):                
+            for bias, bidirectional, batch_first, contig, variable_len, persistent in product((True, False), repeat=6):
                 num_directions = 2 if bidirectional else 1
                 if batch_first:
                     input_val = torch.randn(batch, seq_length, input_size)

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -211,12 +211,22 @@ class DropoutDescriptor(object):
 
 class RNNDescriptor(object):
     def __init__(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
-                 bidirectional, mode, datatype):
+                 bidirectional, mode, datatype, persistent):
         ptr = ctypes.c_void_p()
         check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
         self._as_parameter_ = ptr
+        self.persistent = persistent
+        self._set(handle, hidden_size, num_layers, dropout_desc, input_mode, 
+             bidirectional, mode, datatype)
+
+    def _set(self, handle, hidden_size, num_layers, dropout_desc, input_mode, 
+             bidirectional, mode, datatype):
         if version() >= 6000:
-            check_error(lib.cudnnSetRNNDescriptor_v6(
+            if self.persistent is True: 
+                algo = CUDNN_RNN_ALGO_PERSIST_STATIC
+            else:
+                algo = CUDNN_RNN_ALGO_STANDARD 
+            status = lib.cudnnSetRNNDescriptor_v6(
                 handle,
                 self,
                 hidden_size,
@@ -225,9 +235,17 @@ class RNNDescriptor(object):
                 input_mode,
                 bidirectional,
                 mode,
-                CUDNN_RNN_ALGO_STANDARD,
+                algo,
                 datatype
-            ))
+            )
+            if status is not 0:
+                if self.persistent is True:
+#try standard algo
+                    self.persistent = False
+                    self._set(handle, hidden_size, num_layers, dropout_desc, input_mode, 
+                         bidirectional, mode, datatype)
+                else:
+                    raise CuDNNError(status)
         else:
             check_error(lib.cudnnSetRNNDescriptor(
                 self,

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -216,16 +216,16 @@ class RNNDescriptor(object):
         check_error(lib.cudnnCreateRNNDescriptor(ctypes.byref(ptr)))
         self._as_parameter_ = ptr
         self.persistent = persistent
-        self._set(handle, hidden_size, num_layers, dropout_desc, input_mode, 
-             bidirectional, mode, datatype)
+        self._set(handle, hidden_size, num_layers, dropout_desc, input_mode,
+                  bidirectional, mode, datatype)
 
-    def _set(self, handle, hidden_size, num_layers, dropout_desc, input_mode, 
+    def _set(self, handle, hidden_size, num_layers, dropout_desc, input_mode,
              bidirectional, mode, datatype):
         if version() >= 6000:
-            if self.persistent is True: 
+            if self.persistent is True:
                 algo = CUDNN_RNN_ALGO_PERSIST_STATIC
             else:
-                algo = CUDNN_RNN_ALGO_STANDARD 
+                algo = CUDNN_RNN_ALGO_STANDARD
             status = lib.cudnnSetRNNDescriptor_v6(
                 handle,
                 self,
@@ -240,10 +240,10 @@ class RNNDescriptor(object):
             )
             if status is not 0:
                 if self.persistent is True:
-#try standard algo
+                    # try standard algo
                     self.persistent = False
-                    self._set(handle, hidden_size, num_layers, dropout_desc, input_mode, 
-                         bidirectional, mode, datatype)
+                    self._set(handle, hidden_size, num_layers, dropout_desc, input_mode,
+                              bidirectional, mode, datatype)
                 else:
                     raise CuDNNError(status)
         else:

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -197,8 +197,10 @@ def forward(fn, input, hx, weight, output, hy):
         fn.datatype = cudnn._typemap[input.type()]
         is_input_packed = fn.batch_sizes is not None
         if is_input_packed:
-            warnings.warn("Warning: persistent algorithm not supported for variable length input. Switching to standard")
-            fn.persistent = False #persistent algo is not supported for variable length input
+            warnings.warn(
+                "Warning: persistent algorithm not supported for variable length input."
+                "Switching to standard")
+            fn.persistent = False  # persistent algo is not supported for variable length input
         if fn.mode == cudnn.CUDNN_LSTM:
             hx, cx = hx
             hy, cy = hy

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -2,6 +2,7 @@ import torch.cuda
 import torch.backends.cudnn as cudnn
 from torch.backends.cudnn import check_error
 import ctypes
+import warnings
 
 
 def get_cudnn_mode(mode):
@@ -43,7 +44,7 @@ def init_rnn_descriptor(fn, handle):
         )
     dropout_desc = fn.dropout_state[dropout_desc_name].get()
     dropout_desc.set_dropout(dropout_p, fn.dropout_seed)
-    return cudnn.RNNDescriptor(
+    rnn_desc = cudnn.RNNDescriptor(
         handle,
         fn.hidden_size,
         fn.num_layers,
@@ -51,8 +52,13 @@ def init_rnn_descriptor(fn, handle):
         fn.input_mode,
         fn.bidirectional,
         fn.mode,
-        fn.datatype
+        fn.datatype,
+        fn.persistent
     )
+    if rnn_desc.persistent is False and fn.persistent is True:
+        warnings.warn("Warning: persistent RNN is not available for this configuration, switched to standard RNN")
+        fn.persistent = rnn_desc.persistent
+    return rnn_desc
 
 
 def init_weight_descriptor(fn, weight):
@@ -190,7 +196,9 @@ def forward(fn, input, hx, weight, output, hy):
         handle = cudnn.get_handle()
         fn.datatype = cudnn._typemap[input.type()]
         is_input_packed = fn.batch_sizes is not None
-
+        if is_input_packed:
+            warnings.warn("Warning: persistent algorithm not supported for variable length input. Switching to standard")
+            fn.persistent = False #persistent algo is not supported for variable length input
         if fn.mode == cudnn.CUDNN_LSTM:
             hx, cx = hx
             hy, cy = hy

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -191,7 +191,7 @@ def VariableRecurrentReverse(batch_sizes, inner):
 
 def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
                 dropout=0, train=True, bidirectional=False, batch_sizes=None,
-                dropout_state=None):
+                dropout_state=None, persistent=False):
 
     if mode == 'RNN_RELU':
         cell = RNNReLUCell
@@ -238,7 +238,7 @@ class CudnnRNN(NestedIOFunction):
 
     def __init__(self, mode, input_size, hidden_size, num_layers=1,
                  batch_first=False, dropout=0, train=True, bidirectional=False,
-                 batch_sizes=None, dropout_state=None):
+                 batch_sizes=None, dropout_state=None, persistent=False):
         super(CudnnRNN, self).__init__()
         if dropout_state is None:
             dropout_state = {}
@@ -255,6 +255,7 @@ class CudnnRNN(NestedIOFunction):
         self.batch_sizes = batch_sizes
         self.dropout_seed = torch.IntTensor(1).random_()[0]
         self.dropout_state = dropout_state
+        self.persistent = persistent
 
     def forward_extended(self, input, weight, hx):
         assert cudnn.is_acceptable(input)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -10,7 +10,7 @@ class RNNBase(Module):
 
     def __init__(self, mode, input_size, hidden_size,
                  num_layers=1, bias=True, batch_first=False,
-                 dropout=0, bidirectional=False, persistent = False):
+                 dropout=0, bidirectional=False, persistent=False):
         super(RNNBase, self).__init__()
         self.mode = mode
         self.input_size = input_size
@@ -158,7 +158,10 @@ class RNN(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
-        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm
+        if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported
+        on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is
+        expected to provide performance benefits for long sequences and small batch sizes(less than 32).
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -236,7 +239,10 @@ class LSTM(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
-        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm
+        if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported
+        on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is
+        expected to provide performance benefits for long sequences and small batch sizes(less than 32).
 
     Inputs: input, (h_0, c_0)
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -307,7 +313,10 @@ class GRU(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
-        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm
+        if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported
+        on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is
+        expected to provide performance benefits for long sequences and small batch sizes(less than 32).
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -10,7 +10,7 @@ class RNNBase(Module):
 
     def __init__(self, mode, input_size, hidden_size,
                  num_layers=1, bias=True, batch_first=False,
-                 dropout=0, bidirectional=False):
+                 dropout=0, bidirectional=False, persistent = False):
         super(RNNBase, self).__init__()
         self.mode = mode
         self.input_size = input_size
@@ -21,6 +21,7 @@ class RNNBase(Module):
         self.dropout = dropout
         self.dropout_state = {}
         self.bidirectional = bidirectional
+        self.persistent = persistent
         num_directions = 2 if bidirectional else 1
 
         self._all_weights = []
@@ -86,7 +87,8 @@ class RNNBase(Module):
             train=self.training,
             bidirectional=self.bidirectional,
             batch_sizes=batch_sizes,
-            dropout_state=self.dropout_state
+            dropout_state=self.dropout_state,
+            persistent=self.persistent
         )
         output, hidden = func(input, self.all_weights, hx)
         if is_packed:
@@ -156,6 +158,7 @@ class RNN(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -233,6 +236,7 @@ class LSTM(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
 
     Inputs: input, (h_0, c_0)
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -303,6 +307,7 @@ class GRU(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        persistent: If True and cudnn is used, tries to run persistent algorithm, switching to standard algorithm if persistent cannot be used. Ignored in all other cases. Default: False. Persistent algorithm is supported on the devices with compute capability >=6.0 and for relatively small hidden sizes. Persistent algorithm is expected to provide performance benefits for long sequences and small batch sizes(less than 32). 
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.


### PR DESCRIPTION
Couple minor issues
1) it warns in tests, when testing variable length input with persistent (that's not a supported configuration). I can just omit test for this configuration. 
2) I was hoping to pass info that persistent is not supported from cudnn backend back to module, so that cudnn backend does not try to create persistent descriptor again and again, but that did not work. 