### PR TITLE
Use persistent tensor to store exp_inf (part of optimizer's state)

### DIFF
--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -65,7 +65,8 @@ class Adamax(Optimizer):
                     exp_inf.mul_(beta2).unsqueeze(0),
                     grad.abs().add_(eps).unsqueeze_(0)
                 ], 0)
-                state['exp_inf'] = exp_inf = (torch.max(norm_buf, 0)[0]).squeeze_(0)
+                torch.max(norm_buf, 0, out=(exp_inf, exp_inf.new().long()))
+                exp_inf.squeeze_(0)
 
                 bias_correction = 1 - beta1 ** state['step']
                 clr = group['lr'] / bias_correction


### PR DESCRIPTION
`exp_inf` in `optim.Adamax` was stored in a new tensor at each optimization step. It was the only tensor part of on optimizer state that was not persistent. This commit changes a call to `torch.max` in order to reuse the same tensor.

Persistent tensors for optimizer's state are useful when they are shared among multiple processes.