### PR TITLE
`random` doc fix

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -843,13 +843,13 @@ class TestTorch(TestCase):
     def test_random(self):
         # This test is flaky with p<=(2/(ub-lb))^200=6e-36
         t = torch.FloatTensor(200)
-        lb = 0
-        ub = 3
+        lb = 1
+        ub = 4
 
         t.fill_(-1)
         t.random_(lb, ub)
-        self.assertEqual(t.max(), ub-1)
         self.assertEqual(t.min(), lb)
+        self.assertEqual(t.max(), ub-1)
 
         t.fill_(-1)
         t.random_(ub)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -849,12 +849,12 @@ class TestTorch(TestCase):
         t.fill_(-1)
         t.random_(lb, ub)
         self.assertEqual(t.min(), lb)
-        self.assertEqual(t.max(), ub-1)
+        self.assertEqual(t.max(), ub - 1)
 
         t.fill_(-1)
         t.random_(ub)
         self.assertEqual(t.min(), 0)
-        self.assertEqual(t.max(), ub-1)
+        self.assertEqual(t.max(), ub - 1)
 
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -840,6 +840,16 @@ class TestTorch(TestCase):
         torch.randperm(100, out=res2)
         self.assertEqual(res1, res2, 0)
 
+    def test_random(self):
+        t = torch.FloatTensor(100).zero_()
+        lb = 1
+        ub = 3
+        # This test is flaky with p=(1/(ub-lb+1))^100=2e-48
+
+        t.random_(lb, ub)
+        self.assertEqual(t.max(), ub)
+        self.assertEqual(t.min(), lb)
+
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
         if order == 'descending':

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -840,6 +840,22 @@ class TestTorch(TestCase):
         torch.randperm(100, out=res2)
         self.assertEqual(res1, res2, 0)
 
+    def test_random(self):
+        # This test is flaky with p<=(2/(ub-lb))^200=6e-36
+        t = torch.FloatTensor(200)
+        lb = 0
+        ub = 3
+
+        t.fill_(-1)
+        t.random_(lb, ub)
+        self.assertEqual(t.max(), ub-1)
+        self.assertEqual(t.min(), lb)
+
+        t.fill_(-1)
+        t.random_(ub)
+        self.assertEqual(t.min(), 0)
+        self.assertEqual(t.max(), ub-1)
+
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
         if order == 'descending':

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -840,16 +840,6 @@ class TestTorch(TestCase):
         torch.randperm(100, out=res2)
         self.assertEqual(res1, res2, 0)
 
-    def test_random(self):
-        t = torch.FloatTensor(100).zero_()
-        lb = 1
-        ub = 3
-        # This test is flaky with p=(1/(ub-lb+1))^100=2e-48
-
-        t.random_(lb, ub)
-        self.assertEqual(t.max(), ub)
-        self.assertEqual(t.min(), lb)
-
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
         if order == 'descending':

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1088,7 +1088,7 @@ add_docstr(torch._C.FloatTensorBase.random_,
 random_(from=0, to=None, *, generator=None)
 
 Fills this tensor with numbers sampled from the uniform distribution or
-discrete uniform distribution over [from, to]. If not specified, the
+discrete uniform distribution over [from, to - 1]. If not specified, the
 values are only bounded by this tensor's data type.
 """)
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1088,7 +1088,7 @@ add_docstr(torch._C.FloatTensorBase.random_,
 random_(from=0, to=None, *, generator=None)
 
 Fills this tensor with numbers sampled from the uniform distribution or
-discrete uniform distribution over [from, to - 1]. If not specified, the
+discrete uniform distribution over [from, to]. If not specified, the
 values are only bounded by this tensor's data type.
 """)
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -266,11 +266,7 @@ IMPLEMENT_STATELESS(mm)
 IMPLEMENT_STATELESS(bmm)
 // TODO: this doesn't implement options that return numbers!
 IMPLEMENT_STATELESS(multinomial)
-IMPLEMENT_STATELESS(uniform)
 IMPLEMENT_STATELESS(normal)
-IMPLEMENT_STATELESS(cauchy)
-IMPLEMENT_STATELESS(log_normal)
-IMPLEMENT_STATELESS(random)
 IMPLEMENT_STATELESS(bernoulli)
 IMPLEMENT_STATELESS(range)
 IMPLEMENT_STATELESS(gather)
@@ -600,11 +596,7 @@ static PyMethodDef TorchMethods[] = {
   {"mm",              (PyCFunction)THPModule_mm,                METH_VARARGS | METH_KEYWORDS, NULL},
   {"bmm",             (PyCFunction)THPModule_bmm,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"multinomial",     (PyCFunction)THPModule_multinomial,       METH_VARARGS | METH_KEYWORDS, NULL},
-  {"uniform",         (PyCFunction)THPModule_uniform,           METH_VARARGS | METH_KEYWORDS, NULL},
   {"normal",          (PyCFunction)THPModule_normal,            METH_VARARGS | METH_KEYWORDS, NULL},
-  {"cauchy",          (PyCFunction)THPModule_cauchy,            METH_VARARGS | METH_KEYWORDS, NULL},
-  {"log_normal",      (PyCFunction)THPModule_log_normal,        METH_VARARGS | METH_KEYWORDS, NULL},
-  {"random",          (PyCFunction)THPModule_random,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"bernoulli",       (PyCFunction)THPModule_bernoulli,         METH_VARARGS | METH_KEYWORDS, NULL},
   {"rand",            (PyCFunction)THPModule_rand,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"randn",           (PyCFunction)THPModule_randn,             METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -16,7 +16,7 @@
 static void THTensor_(random2__)(THTensor *self, THGenerator *gen, long a, long b)
 {
   THArgCheck(b > a, 2, "upper bound must be greater than lower bound");
-  TH_TENSOR_APPLY(real, self, *self_data = ((THRandom_random(gen) % (b+1-a)) + a);)
+  TH_TENSOR_APPLY(real, self, *self_data = ((THRandom_random(gen) % (b-a)) + a);)
 }
 
 static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)


### PR DESCRIPTION
Fix the doc for random because it is actually inclusive.
Also removes some `torch.` functions that are not implemented and would always raise an error (they are not mentioned in the doc for `torch.`) 