### PR TITLE
Allow unhashable inputs to parallel_apply

### DIFF
--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -16,7 +16,7 @@ def parallel_apply(modules, inputs, kwargs_tup=None):
     lock = threading.Lock()
     results = {}
 
-    def _worker(module, input, kwargs, results, lock):
+    def _worker(i, module, input, kwargs, results, lock):
         var_input = input
         while not isinstance(var_input, Variable):
             var_input = var_input[0]
@@ -24,22 +24,23 @@ def parallel_apply(modules, inputs, kwargs_tup=None):
             with torch.cuda.device_of(var_input):
                 output = module(*input, **kwargs)
             with lock:
-                results[input] = output
+                results[i] = output
         except Exception as e:
             with lock:
-                results[input] = e
+                results[i] = e
 
     threads = [threading.Thread(target=_worker,
-                                args=(module, input, kwargs, results, lock),
+                                args=(i, module, input, kwargs, results, lock),
                                 )
-               for module, input, kwargs in zip(modules, inputs, kwargs_tup)]
+               for i, (module, input, kwargs) in
+               enumerate(zip(modules, inputs, kwargs_tup))]
 
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
     outputs = []
-    for i in inputs:
+    for i in range(len(inputs)):
         output = results[i]
         if isinstance(output, Exception):
             raise output


### PR DESCRIPTION
Since the spec for `nn.Module` doesn't require the inputs to be hashable (e.g., lists, sets), `parallel_apply` cannot use the input to identify itself; this implementation proposes using the natural indexing as a unique id.