### PR TITLE
Allow kwarg-only inputs to DataParallel

### DIFF
--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -55,9 +55,10 @@ class DataParallel(Module):
 
     def forward(self, *inputs, **kwargs):
         inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
-        if len(self.device_ids) == 1:
+        n_gpus = len(self.device_ids)
+        if n_gpus == 1:
             return self.module(*inputs[0], **kwargs[0])
-        replicas = self.replicate(self.module, self.device_ids[:len(inputs)])
+        replicas = self.replicate(self.module, self.device_ids[:n_gpus])
         outputs = self.parallel_apply(replicas, inputs, kwargs)
         return self.gather(outputs, self.output_device)
 

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -31,7 +31,7 @@ def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
     if kwargs is None or len(kwargs) == 0:
         kwargs = tuple({} for _ in inputs)
     else:
-        kwargs = scatter(kwargs, target_gpus, dim)[:len(inputs)]
+        kwargs = scatter(kwargs, target_gpus, dim)[:len(target_gpus)]
     return inputs, kwargs
 
 


### PR DESCRIPTION
Module doesn't disallow kwarg-only inputs, but DataParallel has several places where it non-crucially depends on there being positional arguments (e.g., for determining the count/index of devices). This PR removes these odd dependencies and enables, for instance, connecting generic data loaders to models that use only a subset of the loaded data