### PR TITLE
Bug fixes

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -21,6 +21,7 @@ Creation Ops
 .. autofunction:: rand
 .. autofunction:: randn
 .. autofunction:: randperm
+.. autofunction:: arange
 .. autofunction:: range
 .. autofunction:: zeros
 
@@ -161,7 +162,7 @@ BLAS and LAPACK Operations
 .. autofunction:: baddbmm
 .. autofunction:: bmm
 .. autofunction:: btrifact
-.. autofunction:: btrisolve                  
+.. autofunction:: btrisolve
 .. autofunction:: dot
 .. autofunction:: eig
 .. autofunction:: gels

--- a/test/common.py
+++ b/test/common.py
@@ -2,6 +2,7 @@ import sys
 import os
 import argparse
 import unittest
+import warnings
 import contextlib
 from functools import wraps
 from itertools import product
@@ -48,6 +49,14 @@ def skipIfNoLapack(fn):
             if 'Lapack library not found' in e.args[0]:
                 raise unittest.SkipTest('Compiled without Lapack')
             raise
+    return wrapper
+
+
+def suppress_warnings(fn):
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fn(*args, **kwargs)
     return wrapper
 
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -280,7 +280,7 @@ class TestAutograd(TestCase):
         self.assertIsNone(w.creator)
 
     def test_indexing(self):
-        x = torch.range(1, 16).resize_(4, 4)
+        x = torch.arange(1, 17).resize_(4, 4)
         y = Variable(x, requires_grad=True)
 
         def check_index(idx):
@@ -597,6 +597,10 @@ class TestAutograd(TestCase):
                 x2 = x2.cuda(1)
                 self.assertIs(type(x2.data), torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
+
+        for t in [torch.DoubleTensor, torch.FloatTensor, torch.IntTensor, torch.ByteTensor]:
+            y = Variable(torch.randn(5, 5).type(t))
+            self.assertIs(type(x.type_as(y).data), t)
 
     def test_isolated_node(self):
         x = Variable(torch.randn(5, 5), requires_grad=True)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -94,23 +94,23 @@ def small_3d_positive(t):
 
 
 def small_3d_unique(t):
-    return t(S, S, S).copy_(torch.range(1, S * S * S))
+    return t(S, S, S).copy_(torch.arange(1, S * S * S + 1))
 
 
 def small_1d_lapack(t):
-    return t(1, 3).copy_(torch.range(1, 3).view(3))
+    return t(1, 3).copy_(torch.arange(1, 4).view(3))
 
 
 def small_2d_lapack(t):
-    return t(3, 3).copy_(torch.range(1, 9).view(3, 3))
+    return t(3, 3).copy_(torch.arange(1, 10).view(3, 3))
 
 
 def small_2d_lapack_skinny(t):
-    return t(3, 4).copy_(torch.range(1, 12).view(3, 4))
+    return t(3, 4).copy_(torch.arange(1, 13).view(3, 4))
 
 
 def small_2d_lapack_fat(t):
-    return t(4, 3).copy_(torch.range(1, 12).view(4, 3))
+    return t(4, 3).copy_(torch.arange(1, 13).view(4, 3))
 
 
 def new_t(*sizes):
@@ -506,7 +506,7 @@ class TestCuda(TestCase):
 
     def test_from_sequence(self):
         seq = [list(range(i * 4, i * 4 + 4)) for i in range(5)]
-        reference = torch.range(0, 19).resize_(5, 4)
+        reference = torch.arange(0, 20).resize_(5, 4)
         for t in types:
             cuda_type = get_gpu_type(t)
             self.assertEqual(cuda_type(seq), reference)

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -75,7 +75,7 @@ def autograd_sharing(queue, ready, master_modified):
     ready.set()
     master_modified.wait()
 
-    expected_var = torch.range(1, 25).view(5, 5)
+    expected_var = torch.arange(1, 26).view(5, 5)
     expected_var[0, 0] = 1000
     is_ok = var.data.equal(expected_var)
     var.data[:] = torch.ones(5, 5)
@@ -296,7 +296,7 @@ class TestMultiprocessing(TestCase):
         ctx = mp.get_context('spawn')
         tensors = []
         for i in range(5):
-            tensors += [torch.range(i * 5, (i * 5) + 4).cuda()]
+            tensors += [torch.arange(i * 5, (i + 1) * 5).cuda()]
 
         inq = ctx.Queue()
         outq = ctx.Queue()
@@ -311,7 +311,7 @@ class TestMultiprocessing(TestCase):
 
         for i, tensor in enumerate(tensors):
             v, device, tensor_size, storage_size = results[i]
-            self.assertEqual(v, torch.range(i * 5, (i * 5) + 4).sum())
+            self.assertEqual(v, torch.arange(i * 5, (i + 1) * 5).sum())
             self.assertEqual(device, 0)
             self.assertEqual(tensor_size, 5)
             self.assertEqual(storage_size, 5)
@@ -382,13 +382,13 @@ class TestMultiprocessing(TestCase):
             (False, True),
         ]
         for requires_grad, volatile in configs:
-            var = Variable(torch.range(1, 25).view(5, 5),
+            var = Variable(torch.arange(1, 26).view(5, 5),
                            requires_grad=requires_grad,
                            volatile=volatile)
             self._test_autograd_sharing(var)
 
     def test_parameter_sharing(self):
-        param = Parameter(torch.range(1, 25).view(5, 5))
+        param = Parameter(torch.arange(1, 26).view(5, 5))
         self._test_autograd_sharing(param)
 
     def _test_is_shared(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -661,7 +661,7 @@ class TestNN(NNTestCase):
             self.assertEqual(scale.std(), 0)
             return scale[0]
 
-        grads = torch.range(1, 100), torch.ones(10).div(1000)
+        grads = torch.arange(1, 101), torch.ones(10).div(1000)
         for norm_type in [0.5, 1.5, 2, 4, 'inf']:
             for p, g in zip(l.parameters(), grads):
                 p._grad = Variable(g.clone())
@@ -742,15 +742,15 @@ class TestNN(NNTestCase):
 
         def expected_output(dim):
             if dim == 1:
-                return torch.range(2, 16, 2).view(2, 2, 2)
+                return torch.arange(2, 17, 2).view(2, 2, 2)
             if dim == 2:
-                col = torch.range(6, 62, 8)
+                col = torch.arange(6, 63, 8)
                 return torch.stack([col, col + 2], 1).view(2, 2, 2, 2)
 
         module_cls = getattr(nn, 'MaxPool{}d'.format(num_dim))
         module = module_cls(2, return_indices=True).type(type)
         numel = 4 ** (num_dim + 1)
-        input = torch.range(1, numel).view(2, 2, *repeat(4, num_dim)).type(type)
+        input = torch.arange(1, numel + 1).view(2, 2, *repeat(4, num_dim)).type(type)
         input_var = Variable(input, requires_grad=True)
 
         # Check forward
@@ -1083,7 +1083,7 @@ class TestNN(NNTestCase):
         state_dict = net.state_dict()
         state_dict.update({
             'linear1.weight': torch.ones(5, 5),
-            'block.conv1.bias': torch.range(1, 3),
+            'block.conv1.bias': torch.arange(1, 4),
             'bn.running_mean': torch.randn(2),
         })
         net.load_state_dict(state_dict)
@@ -1339,10 +1339,10 @@ class TestNN(NNTestCase):
         max_length = lengths[0]
         batch_sizes = [sum(map(bool, filter(lambda x: x >= i, lengths))) for i in range(1, max_length + 1)]
         offset = 0
-        padded = torch.cat([pad(i * 100 + torch.range(1, 5 * l).view(l, 1, 5), max_length)
+        padded = torch.cat([pad(i * 100 + torch.arange(1, 5 * l + 1).view(l, 1, 5), max_length)
                             for i, l in enumerate(lengths, 1)], 1)
         padded = Variable(padded, requires_grad=True)
-        expected_data = [[torch.range(1, 5) + i * 100 for i in range(batch_size)] for batch_size in batch_sizes]
+        expected_data = [[torch.arange(1, 6) + i * 100 for i in range(batch_size)] for batch_size in batch_sizes]
         expected_data = list(itertools.chain.from_iterable(expected_data))
         expected_data = torch.cat(expected_data)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8,7 +8,8 @@ import tempfile
 import unittest
 import warnings
 from itertools import product, combinations
-from common import TestCase, iter_indices, TEST_NUMPY, run_tests, download_file, skipIfNoLapack
+from common import TestCase, iter_indices, TEST_NUMPY, run_tests, download_file, skipIfNoLapack, \
+    suppress_warnings
 
 if TEST_NUMPY:
     import numpy as np
@@ -779,6 +780,7 @@ class TestTorch(TestCase):
         self.assertEqual(prob_dist.dim(), 1, "wrong number of prob_dist dimensions")
         self.assertEqual(sample_indices.size(0), n_sample, "wrong number of samples")
 
+    @suppress_warnings
     def test_range(self):
         res1 = torch.range(0, 1)
         res2 = torch.Tensor()
@@ -816,6 +818,67 @@ class TestTorch(TestCase):
         self.assertEqual(res1.size(0), 4)
         res1 = torch.range(1, 10, 0.3, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 31)
+
+    def test_arange(self):
+        res1 = torch.arange(0, 1)
+        res2 = torch.Tensor()
+        torch.arange(0, 1, out=res2)
+        self.assertEqual(res1, res2, 0)
+
+        # Check arange for non-contiguous tensors.
+        x = torch.zeros(2, 3)
+        torch.arange(0, 4, out=x.narrow(1, 1, 2))
+        res2 = torch.Tensor(((0, 0, 1), (0, 2, 3)))
+        self.assertEqual(x, res2, 1e-16)
+
+        # Check negative
+        res1 = torch.Tensor((1, 0))
+        res2 = torch.Tensor()
+        torch.arange(1, -1, -1, out=res2)
+        self.assertEqual(res1, res2, 0)
+
+        # Equal bounds
+        res1 = torch.ones(1)
+        res2 = torch.Tensor()
+        torch.arange(1, 0, -1, out=res2)
+        self.assertEqual(res1, res2, 0)
+        torch.arange(1, 2, 1, out=res2)
+        self.assertEqual(res1, res2, 0)
+
+        # FloatTensor
+        res1 = torch.arange(0.6, 0.89, 0.1, out=torch.FloatTensor())
+        self.assertEqual(res1.size(0), 3)
+        res1 = torch.arange(1, 10, 0.3, out=torch.FloatTensor())
+        self.assertEqual(res1.size(0), 31)
+
+        # DoubleTensor
+        res1 = torch.arange(0.6, 0.89, 0.1, out=torch.DoubleTensor())
+        self.assertEqual(res1.size(0), 3)
+        res1 = torch.arange(1, 10, 0.3, out=torch.DoubleTensor())
+        self.assertEqual(res1.size(0), 31)
+
+        # Check that it's exclusive
+        r = torch.arange(0, 5)
+        self.assertEqual(r.min(), 0)
+        self.assertEqual(r.max(), 4)
+        self.assertEqual(r.numel(), 5)
+
+        r = torch.arange(0, 5, 2)
+        self.assertEqual(r.min(), 0)
+        self.assertEqual(r.max(), 4)
+        self.assertEqual(r.numel(), 3)
+
+        r1 = torch.arange(0, 5 + 1e-6)
+        r2 = torch.arange(0, 5)
+        r3 = torch.arange(0, 5 - 1e-6)
+        self.assertEqual(r1[:-1], r2, 0)
+        self.assertEqual(r2, r3, 0)
+
+        r1 = torch.arange(10, -1 + 1e-6, -1)
+        r2 = torch.arange(10, -1, -1)
+        r3 = torch.arange(10, -1 - 1e-6, -1)
+        self.assertEqual(r1, r2, 0)
+        self.assertEqual(r2, r3[:-1], 0)
 
     def test_randperm(self):
         _RNGState = torch.get_rng_state()
@@ -1041,7 +1104,7 @@ class TestTorch(TestCase):
             self.assertEqual(x, x0, 0)
 
     def test_mode(self):
-        x = torch.range(1, SIZE * SIZE).clone().resize_(SIZE, SIZE)
+        x = torch.arange(1, SIZE * SIZE + 1).clone().resize_(SIZE, SIZE)
         x[:2] = 1
         x[:, :2] = 1
         x0 = x.clone()
@@ -2611,7 +2674,7 @@ class TestTorch(TestCase):
         b = [a[i % 2] for i in range(4)]
         b += [a[0].storage()]
         b += [a[0].storage()[1:4]]
-        b += [torch.range(1, 10).int()]
+        b += [torch.arange(1, 11).int()]
         t1 = torch.FloatTensor().set_(a[0].storage()[1:4], 0, (3,), (1,))
         t2 = torch.FloatTensor().set_(a[0].storage()[1:4], 0, (3,), (1,))
         b += [(t1.storage(), t1.storage(), t2.storage())]
@@ -2692,7 +2755,7 @@ class TestTorch(TestCase):
             self.assertEqual(un.get_device(), device_count - 1)
 
     def test_serialization_backwards_compat(self):
-        a = [torch.range(1 + i, 25 + i).view(5, 5).float() for i in range(2)]
+        a = [torch.arange(1 + i, 26 + i).view(5, 5).float() for i in range(2)]
         b = [a[i % 2] for i in range(4)]
         b += [a[0].storage()]
         b += [a[0].storage()[1:4]]
@@ -2961,20 +3024,20 @@ class TestTorch(TestCase):
         x = np.linspace(1, 125, 125)
         x.shape = (5, 5, 5)
         x = x[1]
-        expected = torch.range(1, 125).view(5, 5, 5)[1]
+        expected = torch.arange(1, 126).view(5, 5, 5)[1]
         self.assertEqual(torch.from_numpy(x), expected)
 
         # check noncontiguous
         x = np.linspace(1, 25, 25)
         x.shape = (5, 5)
-        expected = torch.range(1, 25).view(5, 5).t()
+        expected = torch.arange(1, 26).view(5, 5).t()
         self.assertEqual(torch.from_numpy(x.T), expected)
 
         # check noncontiguous with holes
         x = np.linspace(1, 125, 125)
         x.shape = (5, 5, 5)
         x = x[:, 1]
-        expected = torch.range(1, 125).view(5, 5, 5)[:, 1]
+        expected = torch.arange(1, 126).view(5, 5, 5)[:, 1]
         self.assertEqual(torch.from_numpy(x), expected)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
@@ -3051,7 +3114,7 @@ class TestTorch(TestCase):
         self.assertEqual(x_clone, xor_result)
 
     def test_apply(self):
-        x = torch.range(1, 5)
+        x = torch.arange(1, 6)
         res = x.clone().apply_(lambda k: k + k)
         self.assertEqual(res, x * 2)
         self.assertRaises(RuntimeError, lambda: x.apply_(lambda k: "str"))

--- a/tools/cwrap/plugins/BeforeAfterCall.py
+++ b/tools/cwrap/plugins/BeforeAfterCall.py
@@ -18,6 +18,11 @@ class BeforeAfterCall(CWrapPlugin):
             prepend_str = before_call_template.substitute(args)
         template.insert(offset, prepend_str)
 
+    def process_pre_arg_assign(self, template, option):
+        if option.get('before_arg_assign'):
+            self.insert_snippet(template, option, 0, 'before_arg_assign')
+        return template
+
     def process_option_code_template(self, template, option):
         if option.get('before_call') or option.get('after_call'):
             call_idx = template.index('$call')

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1590,7 +1590,7 @@ Args:
 
 Example::
 
-    >>> x = torch.range(1, 7)
+    >>> x = torch.arange(1, 8)
     >>> x
 
      1

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -343,8 +343,8 @@ Args:
 
 Example::
 
-    >>> vec1 = torch.range(1, 3)
-    >>> vec2 = torch.range(1, 2)
+    >>> vec1 = torch.arange(1, 4)
+    >>> vec2 = torch.arange(1, 3)
     >>> M = torch.zeros(3, 2)
     >>> torch.addr(M, vec1, vec2)
      1  2
@@ -1546,8 +1546,8 @@ Args:
 
 Example::
 
-    >>> v1 = torch.range(1, 4)
-    >>> v2 = torch.range(1, 3)
+    >>> v1 = torch.arange(1, 5)
+    >>> v2 = torch.arange(1, 4)
     >>> torch.ger(v1, v2)
 
       1   2   3
@@ -1774,7 +1774,7 @@ Args:
 
 Example::
 
-    >>> x = torch.range(1, 5)
+    >>> x = torch.arange(1, 6)
     >>> x
 
      1
@@ -1837,7 +1837,7 @@ Args:
 
 Example::
 
-    >>> start = torch.range(1, 4)
+    >>> start = torch.arange(1, 5)
     >>> end = torch.Tensor(4).fill_(10)
     >>> start
 
@@ -2832,7 +2832,7 @@ Args:
 
 Example::
 
-    torch.normal(means=torch.range(1, 10), std=torch.range(1, 0.1, -0.1))
+    torch.normal(means=torch.arange(1, 11), std=torch.arange(1, 0, -0.1))
 
      1.5104
      1.6955
@@ -2857,7 +2857,7 @@ Args:
 
 Example::
 
-    >>> torch.normal(mean=0.5, std=torch.range(1, 5))
+    >>> torch.normal(mean=0.5, std=torch.arange(1, 6))
 
       0.5723
       0.0871
@@ -2877,7 +2877,7 @@ Args:
 
 Example::
 
-    >>> torch.normal(means=torch.range(1, 5))
+    >>> torch.normal(means=torch.arange(1, 6))
 
      1.1681
      2.8884
@@ -3000,8 +3000,8 @@ Example::
      3.0829
     [torch.FloatTensor of size 4]
 
-    >>> exp = torch.range(1, 4)
-    >>> a = torch.range(1, 4)
+    >>> exp = torch.arange(1, 5)
+    >>> a = torch.arange(1, 5)
     >>> a
 
      1
@@ -3043,7 +3043,7 @@ Args:
 
 Example::
 
-    >>> exp = torch.range(1, 4)
+    >>> exp = torch.arange(1, 5)
     >>> base = 2
     >>> torch.pow(base, exp)
 
@@ -3260,6 +3260,9 @@ returns a 1D Tensor of size :math:`floor((end - start) / step) + 1` with values
 from :attr:`start` to :attr:`end` with step :attr:`step`. Step is the gap between two values in the tensor.
 :math:`x_{i+1} = x_i + step`
 
+Warning:
+    This function is deprecated in favor of :func:`torch.arange`.
+
 Args:
     start (float): The starting value for the set of points
     end (float): The ending value for the set of points
@@ -3288,6 +3291,38 @@ Example::
     [torch.FloatTensor of size 7]
 
 """)
+
+add_docstr(torch._C.arange,
+           """
+arange(start, end, step=1, out=None) -> Tensor
+
+Teturns a 1D Tensor of size :math:`floor((end - start) / step)` with values
+from the interval ``[start, end)`` taken with step :attr:`step` starting from `start`.
+
+Args:
+    start (float): The starting value for the set of points
+    end (float): The ending value for the set of points
+    step (float): The gap between each pair of adjacent points
+    out (Tensor, optional): The result `Tensor`
+
+Example::
+
+    >>> torch.arange(1, 4)
+
+     1
+     2
+     3
+    [torch.FloatTensor of size 3]
+
+    >>> torch.arange(1, 2.5, 0.5)
+
+     1.0000
+     1.5000
+     2.0000
+    [torch.FloatTensor of size 3]
+
+""")
+
 
 add_docstr(torch._C.remainder,
            """
@@ -4019,7 +4054,7 @@ Args:
 
 Example::
 
-    >>> x = torch.range(1, 5)
+    >>> x = torch.arange(1, 6)
     >>> x
 
      1
@@ -4064,7 +4099,7 @@ Returns the sum of the elements of the diagonal of the input 2D matrix.
 
 Example::
 
-    >>> x = torch.range(1, 9).view(3, 3)
+    >>> x = torch.arange(1, 10).view(3, 3)
     >>> x
 
      1  2  3

--- a/torch/autograd/_functions/blas.py
+++ b/torch/autograd/_functions/blas.py
@@ -179,6 +179,7 @@ class Dot(Function):
 
     def forward(self, vector1, vector2):
         self.save_for_backward(vector1, vector2)
+        self.sizes = (vector1.size(), vector2.size())
         return vector1.new((vector1.dot(vector2),))
 
     def backward(self, grad_output):
@@ -186,9 +187,9 @@ class Dot(Function):
         grad_vector1 = grad_vector2 = None
 
         if self.needs_input_grad[0]:
-            grad_vector1 = vector2.mul(grad_output[0])
+            grad_vector1 = vector2.mul(grad_output[0]).view(self.sizes[0])
 
         if self.needs_input_grad[1]:
-            grad_vector2 = vector1.mul(grad_output[0])
+            grad_vector2 = vector1.mul(grad_output[0]).view(self.sizes[1])
 
         return grad_vector1, grad_vector2

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -232,6 +232,9 @@ class Variable(_C._VariableBase):
             return Type(t)(self)
         return self
 
+    def type_as(self, t):
+        return self.type(type(t.data))
+
     def _get_type(self, name):
         module = torch._import_dotted_name(self.data.__module__)
         return getattr(module, name)

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -499,10 +499,10 @@ class Variable(_C._VariableBase):
     def std(self, dim=None, unbiased=True):
         return self.var(dim, unbiased).sqrt()
 
-    def renorm(self, norm_type, dim, maxnorm):
+    def renorm(self, p, dim, maxnorm):
         t = self.transpose(dim, 0)
         flat = t.contiguous().view(self.size(0), -1)
-        norms = flat.norm(norm_type, 1)
+        norms = flat.norm(p, 1)
         norms = norms.clamp(max=maxnorm).div(norms.add(1e-7))
         flat_out = flat.mul(norms.expand_as(flat))
         return flat_out.view(t.size()).transpose(dim, 0)
@@ -592,11 +592,11 @@ class Variable(_C._VariableBase):
     def addcdiv(self, *args):
         return self._addcop(Addcdiv, args)
 
-    def norm(self, norm_type=2, dim=None):
-        return Norm(norm_type, dim)(self)
+    def norm(self, p=2, dim=None):
+        return Norm(p, dim)(self)
 
-    def dist(self, tensor, norm_type=2):
-        return Norm(norm_type)(self - tensor)
+    def dist(self, tensor, p=2):
+        return Norm(p)(self - tensor)
 
     def index_add(self, dim, index, tensor):
         return IndexAdd(dim)(self, index, tensor)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -269,6 +269,7 @@ IMPLEMENT_STATELESS(multinomial)
 IMPLEMENT_STATELESS(normal)
 IMPLEMENT_STATELESS(bernoulli)
 IMPLEMENT_STATELESS(range)
+IMPLEMENT_STATELESS(arange)
 IMPLEMENT_STATELESS(gather)
 IMPLEMENT_STATELESS(rand)
 IMPLEMENT_STATELESS(randn)
@@ -602,6 +603,7 @@ static PyMethodDef TorchMethods[] = {
   {"randn",           (PyCFunction)THPModule_randn,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"randperm",        (PyCFunction)THPModule_randperm,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"range",           (PyCFunction)THPModule_range,             METH_VARARGS | METH_KEYWORDS, NULL},
+  {"arange",          (PyCFunction)THPModule_arange,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"gather",          (PyCFunction)THPModule_gather,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"cat",             (PyCFunction)THPModule_cat,               METH_VARARGS, NULL},
   {"masked_select",   (PyCFunction)THPModule_masked_select,     METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -623,6 +623,10 @@ THTensor* THTensor_(transpose_neg)(THTensor *self, THTensor *src, int dim0, int 
   only_stateless: True
   defined_if: "!IS_CUDA"
   return: argument 0
+  before_arg_assign: |
+    PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "
+        "and will be removed in 0.3. Note that arange generates values in [start; end), "
+        "not [start; end].", 1);
   arguments:
     - arg: THTensor* result
       output: True
@@ -630,6 +634,35 @@ THTensor* THTensor_(transpose_neg)(THTensor *self, THTensor *src, int dim0, int 
     - accreal end
     - arg: accreal step
       default: 1
+]]
+
+[[
+  name: arange
+  cname: range
+  only_stateless: True
+  defined_if: "!IS_CUDA"
+  return: argument 0
+  options:
+    - before_call: |
+        if (mod_traits<accreal>::mod(arg_end - arg_start, arg_step) == 0) {
+          arg_end -= arg_step;
+        }
+      arguments:
+        - arg: THTensor* result
+          output: True
+        - accreal start
+        - accreal end
+        - accreal step
+    - before_call: |
+        if (mod_traits<accreal>::mod(arg_end - arg_start, 1) == 0) {
+          arg_end -= 1;
+        }
+      arguments:
+        - arg: THTensor* result
+          output: True
+        - accreal start
+        - accreal end
+        - CONSTANT 1
 ]]
 
 [[

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <type_traits>
 
 #include "torch/csrc/utils/object_ptr.h"
 
@@ -175,6 +176,20 @@ THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
 PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);
+
+template<typename _real, typename = void>
+struct mod_traits {};
+
+template<typename _real>
+struct mod_traits<_real, typename std::enable_if<std::is_floating_point<_real>::value>::type> {
+  static _real mod(_real a, _real b) { return fmod(a, b); }
+};
+
+template<typename _real>
+struct mod_traits<_real, typename std::enable_if<std::is_integral<_real>::value>::type> {
+  static _real mod(_real a, _real b) { return a % b; }
+};
+
 
 #endif /* _THP_CORE */
 

--- a/torch/legacy/nn/MaskedSelect.py
+++ b/torch/legacy/nn/MaskedSelect.py
@@ -21,10 +21,10 @@ class MaskedSelect(Module):
     def updateGradInput(self, input, gradOutput):
         input, mask = input
         if input.type() == 'torch.cuda.FloatTensor':
-            torch.range(0, mask.nelement() - 1, out=self._maskIndexBufferCPU).resize_(mask.size())
+            torch.arange(0, mask.nelement(), out=self._maskIndexBufferCPU).resize_(mask.size())
             self._maskIndexBuffer.resize_(self._maskIndexBufferCPU.size()).copy_(self._maskIndexBufferCPU)
         else:
-            torch.range(0, mask.nelement() - 1, out=self._maskIndexBuffer).resize_(mask.size())
+            torch.arange(0, mask.nelement(), out=self._maskIndexBuffer).resize_(mask.size())
 
         torch.masked_select(self._maskIndexBuffer, mask, out=self._maskIndices)
         self._gradBuffer.resize_(input.nelement()).zero_()

--- a/torch/legacy/nn/PartialLinear.py
+++ b/torch/legacy/nn/PartialLinear.py
@@ -36,7 +36,7 @@ class PartialLinear(Module):
         # set partition:
         self.inputsize = inputsize
         self.outputsize = outputsize
-        self.allcolumns = torch.range(0, self.outputsize - 1).long()
+        self.allcolumns = torch.arange(0, self.outputsize).long()
         self.resetPartition()
         self.addBuffer = None
         self.buffer = None

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -33,7 +33,7 @@ class Embedding(Function):
     def _make_sparse(self, indices, tensor_type):
         i = torch.LongTensor(2, indices.numel())
         v = torch.ones(indices.numel())
-        i[1].copy_(torch.range(0, indices.numel() - 1))
+        i[1].copy_(torch.arange(0, indices.numel()))
         i[0].copy_(indices)
         SparseTensor = getattr(sparse, tensor_type.__name__)
         return SparseTensor(i, v, torch.Size(

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -234,7 +234,8 @@ class Module(object):
             modules = self.__dict__['_modules']
             if name in modules:
                 return modules[name]
-        return object.__getattr__(self, name)
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+            type(self).__name__, name))
 
     def __setattr__(self, name, value):
         def remove_from(*dicts):


### PR DESCRIPTION
* Reshape grad in the `Dot` function (inputs don't have to be 1D vectors...) (#1155)
* Raise `AttributeError` in `Module.__getattr__` instead of delegating the call to an inexistent method (#1126)
* Added `Variable.type_as` (#1163)
* Unify argument names of `norm` and `renorm` (#1145)
* Add `torch.arange` and deprecate `torch.range§ (#733)