### PR TITLE
device_ids can be None again in data_parallel

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -983,6 +983,9 @@ class TestNN(NNTestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out.data, expected_out)
 
+        # Check for None device_ids
+        out = dp.data_parallel(l, i)
+
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_nested_output(self):
         def fn(input):

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -74,7 +74,7 @@ class DataParallel(Module):
         return gather(outputs, output_device, dim=self.dim)
 
 
-def data_parallel(module, inputs, device_ids, output_device=None, dim=0, module_kwargs=None):
+def data_parallel(module, inputs, device_ids=None, output_device=None, dim=0, module_kwargs=None):
     """Evaluates module(input) in parallel across the GPUs given in device_ids.
 
     This is the functional version of the DataParallel module.
@@ -91,6 +91,9 @@ def data_parallel(module, inputs, device_ids, output_device=None, dim=0, module_
     """
     if not isinstance(inputs, tuple):
         inputs = (inputs,)
+
+    if device_ids is None:
+        device_ids = list(range(torch.cuda.device_count()))
 
     if output_device is None:
         output_device = device_ids[0]


### PR DESCRIPTION
For some reason, this was removed in https://github.com/pytorch/pytorch/commit/e50a1f19b3dc735f0710929b97b0af384aafe09b by @colesbury . I presume accidental.

Here's the original bug report: https://discuss.pytorch.org/t/torch-nn-dataparallel-does-not-accept-none-for-device-ids-in-0-1-11/1474