### PR TITLE
Fix AttributeError: module 'torch.utils' has no attribute 'data'

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -1,0 +1,1 @@
+from . import data


### PR DESCRIPTION
As @soumith replied in [Discuss Forum](https://discuss.pytorch.org/t/attributeerror-module-torch-utils-has-no-attribute-data/1666), it can be solved by adding `import torch.utils.data`. However, many tutorials and examples already directly call `torch.utils.data.DataLoader` only with `import torch`. This PR is to fix this need. 