### PR TITLE
Fix unfold variable types

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2211,10 +2211,38 @@ new_module_tests = [
     ),
     dict(
         module_name='Conv1d',
-        constructor_args=(4, 5, 3),
+        constructor_args=(4, 5, 3, 2),
         input_size=(2, 4, 10),
         cudnn=True,
         desc='stride'
+    ),
+    dict(
+        module_name='Conv1d',
+        constructor_args=(4, 5, 3, 1, 1),
+        input_size=(2, 4, 10),
+        cudnn=True,
+        desc='pad1'
+    ),
+    dict(
+        module_name='Conv1d',
+        constructor_args=(4, 5, 5, 1, 2),
+        input_size=(2, 4, 10),
+        cudnn=True,
+        desc='pad2'
+    ),
+    dict(
+        module_name='Conv1d',
+        constructor_args=(4, 4, 3, 1, 1),
+        input_size=(1, 4, 1),
+        cudnn=True,
+        desc='pad1size1'
+    ),
+    dict(
+        module_name='Conv1d',
+        constructor_args=(4, 4, 5, 1, 2),
+        input_size=(1, 4, 1),
+        cudnn=True,
+        desc='pad2size1'
     ),
     dict(
         fullname='Conv1d_dilated',

--- a/torch/lib/THNN/generic/unfold.c
+++ b/torch/lib/THNN/generic/unfold.c
@@ -2,10 +2,6 @@
 #define TH_GENERIC_FILE "generic/unfold.c"
 #else
 
-#ifdef _WIN32
-# include <windows.h>
-#endif
-
 /* note: due to write issues, this one cannot be parallelized as well as unfolded_copy */
 void THNN_(unfolded_acc)(
           THTensor *finput,
@@ -22,11 +18,11 @@ void THNN_(unfolded_acc)(
           int outputWidth,
           int outputHeight)
 {
-#ifdef _WIN32
-  LONG_PTR nip;
-#else
-  size_t nip;
-#endif
+  // This function assumes that
+  // outputHeight*dH does not overflow a long
+  // outputWidth*dW does not overflow a long
+
+  int nip;
 
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);
@@ -34,34 +30,34 @@ void THNN_(unfolded_acc)(
 #pragma omp parallel for private(nip)
   for(nip = 0; nip < nInputPlane; nip++)
   {
-    size_t kw, kh, y, x;
-    long long ix = 0, iy = 0;
+    int kw, kh, y, x;
+    long ix, iy;
     for(kh = 0; kh < kH; kh++)
     {
       for(kw = 0; kw < kW; kw++)
       {
-        real *src = finput_data + nip*(kH*kW*outputHeight*outputWidth) + kh*(kW*outputHeight*outputWidth) + kw*(outputHeight*outputWidth);
-        real *dst = input_data + nip*(inputHeight*inputWidth);
+        real *src = finput_data + nip*((size_t)kH*kW*outputHeight*outputWidth) + kh*((size_t)kW*outputHeight*outputWidth) + kw*((size_t)outputHeight*outputWidth);
+        real *dst = input_data + nip*((size_t)inputHeight*inputWidth);
         if (padW > 0 || padH > 0) {
-          size_t lpad,rpad;
+          int lpad,rpad;
           for(y = 0; y < outputHeight; y++) {
-            iy = (long long)(y*dH - padH + kh);
+            iy = (long)y*dH - padH + kh;
             if (iy < 0 || iy >= inputHeight) {
             } else {
               if (dW==1){
-                 ix = (long long)(0 - padW + kw);
-                 lpad = fmaxf(0,(int)(padW-kw));
-                 rpad = fmaxf(0,(int)(padW-(kW-kw-1)));
-                 real *dst_slice = dst+(size_t)(iy*inputWidth+ix+lpad);
-                 THVector_(cadd)(dst_slice, dst_slice, src+(size_t)(y*outputWidth+lpad), 1, outputWidth - lpad - rpad); /* note: THVector_add could handle 1 value better */
+                 ix = 0 - padW + kw;
+                 lpad = fmaxf(0,padW-kw);
+                 rpad = fmaxf(0,padW-(kW-kw-1));
+                 real *dst_slice = dst+(size_t)iy*inputWidth+ix+lpad;
+                 THVector_(cadd)(dst_slice, dst_slice, src+(size_t)y*outputWidth+lpad, 1, outputWidth - lpad - rpad); /* note: THVector_add could handle 1 value better */
               }
               else{
                 for (x=0; x<outputWidth; x++){
-                   ix = (long long)(x*dW - padW + kw);
+                   ix = (long)x*dW - padW + kw;
                    if (ix < 0 || ix >= inputWidth){
                    }else{
-                     real *dst_slice = dst+(size_t)(iy*inputWidth+ix);
-                     THVector_(cadd)(dst_slice, dst_slice, src+(size_t)(y*outputWidth+x), 1, 1);
+                     real *dst_slice = dst+(size_t)iy*inputWidth+ix;
+                     THVector_(cadd)(dst_slice, dst_slice, src+(size_t)y*outputWidth+x, 1, 1);
                    }
                 }
               }
@@ -69,15 +65,15 @@ void THNN_(unfolded_acc)(
           }
         } else {
           for(y = 0; y < outputHeight; y++) {
-            iy = (long long)(y*dH + kh);
-            ix = (long long)(0 + kw);
+            iy = (long)y*dH + kh;
+            ix = 0 + kw;
             if (dW == 1 ) {
-               real *dst_slice = dst+(size_t)(iy*inputWidth+ix);
-               THVector_(cadd)(dst_slice, dst_slice, src+(size_t)(y*outputWidth), 1, outputWidth); /* note: THVector_add could handle 1 value better */
+               real *dst_slice = dst+(size_t)iy*inputWidth+ix;
+               THVector_(cadd)(dst_slice, dst_slice, src+(size_t)y*outputWidth, 1, outputWidth); /* note: THVector_add could handle 1 value better */
             }else{
               for(x = 0; x < outputWidth; x++) {
-                real *dst_slice = dst+(size_t)(iy*inputWidth+ix+x*dW);
-                THVector_(cadd)(dst_slice, dst_slice, src+(size_t)(y*outputWidth+x), 1, 1);
+                real *dst_slice = dst+(size_t)iy*inputWidth+ix+x*dW;
+                THVector_(cadd)(dst_slice, dst_slice, src+(size_t)y*outputWidth+x, 1, 1);
               }
             }
           }
@@ -102,59 +98,65 @@ void THNN_(unfolded_copy)(
           int outputWidth,
           int outputHeight)
 {
+  // This function assumes that
+  // kH*kW does not overflow an int
+  // nInputPlane*kH*kW does not overflow a long
+  // outputHeight*dH does not overflow a long
+  // outputWidth*dW does not overflow a long
+
   long k;
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);
 
 #pragma omp parallel for private(k)
-  for(k = 0; k < nInputPlane*kH*kW; k++) {
-    size_t nip = k / (kH*kW);
-    size_t rest = k % (kH*kW);
-    size_t kh = rest / kW;
-    size_t kw = rest % kW;
-    size_t x,y;
-    long long ix,iy;
-    real *dst = finput_data + nip*(kH*kW*outputHeight*outputWidth) + kh*(kW*outputHeight*outputWidth) + kw*(outputHeight*outputWidth);
-    real *src = input_data + nip*(inputHeight*inputWidth);
+  for(k = 0; k < (long)nInputPlane*kH*kW; k++) {
+    long nip = k / (kH*kW);
+    long rest = k % (kH*kW);
+    long kh = rest / kW;
+    long kw = rest % kW;
+    int x, y;
+    long ix, iy;
+    real *dst = finput_data + nip*((size_t)kH*kW*outputHeight*outputWidth) + kh*((size_t)kW*outputHeight*outputWidth) + kw*((size_t)outputHeight*outputWidth);
+    real *src = input_data + nip*((size_t)inputHeight*inputWidth);
     if (padW > 0 || padH > 0) {
-      size_t lpad,rpad;
+      long lpad,rpad;
       for(y = 0; y < outputHeight; y++) {
-        iy = (long long)(y*dH - padH + kh);
+        iy = (long)y*dH - padH + kh;
         if (iy < 0 || iy >= inputHeight) {
-          memset(dst+y*outputWidth, 0, sizeof(real)*outputWidth);
+          memset(dst+(size_t)y*outputWidth, 0, sizeof(real)*outputWidth);
         } else {
           if (dW==1){
-             ix = (long long)(0 - padW + kw);
-             lpad = fmaxf(0,(int)(padW-kw));
-             rpad = fmaxf(0,(int)(padW-(kW-kw-1)));
+             ix = 0 - padW + kw;
+             lpad = fmaxf(0,padW-kw);
+             rpad = fmaxf(0,padW-(kW-kw-1));
              if (outputWidth-rpad-lpad <= 0) {
-                memset(dst+(size_t)(y*outputWidth), 0, sizeof(real)*outputWidth);
+                memset(dst+(size_t)y*outputWidth, 0, sizeof(real)*outputWidth);
              } else {
-                if (lpad > 0) memset(dst+y*outputWidth, 0, sizeof(real)*lpad);
-                memcpy(dst+(size_t)(y*outputWidth+lpad), src+(size_t)(iy*inputWidth+ix+lpad), sizeof(real)*(outputWidth-rpad-lpad));
-                if (rpad > 0) memset(dst+y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
+                if (lpad > 0) memset(dst+(size_t)y*outputWidth, 0, sizeof(real)*lpad);
+                memcpy(dst+(size_t)y*outputWidth+lpad, src+(size_t)iy*inputWidth+ix+lpad, sizeof(real)*(outputWidth-rpad-lpad));
+                if (rpad > 0) memset(dst+(size_t)y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
              }
           }
           else{
             for (x=0; x<outputWidth; x++){
-               ix = (long long)(x*dW - padW + kw);
+               ix = (long)x*dW - padW + kw;
                if (ix < 0 || ix >= inputWidth)
-                 memset(dst+(size_t)(y*outputWidth+x), 0, sizeof(real)*1);
+                 memset(dst+(size_t)y*outputWidth+x, 0, sizeof(real)*1);
                else
-                 memcpy(dst+(size_t)(y*outputWidth+x), src+(size_t)(iy*inputWidth+ix), sizeof(real)*(1));
+                 memcpy(dst+(size_t)y*outputWidth+x, src+(size_t)iy*inputWidth+ix, sizeof(real)*(1));
             }
           }
         }
       }
     } else {
       for(y = 0; y < outputHeight; y++) {
-        iy = (long long)(y*dH + kh);
-        ix = (long long)(0 + kw);
+        iy = (long)y*dH + kh;
+        ix = 0 + kw;
         if (dW == 1)
-           memcpy(dst+(size_t)(y*outputWidth), src+(size_t)(iy*inputWidth+ix), sizeof(real)*outputWidth);
+           memcpy(dst+(size_t)y*outputWidth, src+(size_t)iy*inputWidth+ix, sizeof(real)*outputWidth);
         else{
           for (x=0; x<outputWidth; x++)
-             memcpy(dst+(size_t)(y*outputWidth+x), src+(size_t)(iy*inputWidth+ix+x*dW), sizeof(real)*(1));
+             memcpy(dst+(size_t)y*outputWidth+x, src+(size_t)iy*inputWidth+ix+(long)x*dW, sizeof(real)*(1));
          }
       }
     }


### PR DESCRIPTION
Fix segfault corresponding to [this](https://discuss.pytorch.org/t/sigsegv-when-applying-conv1d-with-padding/1726/2) forum bug, thanks to @tudor-berariu .

This rework the changes of torch/nn#443 and the following commits that solved various bugs introduced by the original PR by casting only when necessary and keeping all types (other than pointers and sizes) signed.
Added a comment on the assumptions made which is mainly that any size of the image (given as an `int` to the function) multiplied by the stride should not overflow a `long`.