### PR TITLE
Bug fixes

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -173,6 +173,36 @@ class TestDataLoader(TestCase):
         check_len(DataLoader(self.dataset, batch_size=2), 50)
         check_len(DataLoader(self.dataset, batch_size=3), 34)
 
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_numpy_scalars(self):
+        import numpy as np
+
+        class ScalarDataset(torch.utils.data.Dataset):
+            def __init__(self, dtype):
+                self.dtype = dtype
+
+            def __getitem__(self, i):
+                return self.dtype()
+
+            def __len__(self):
+                return 4
+
+        dtypes = {
+            np.float64: torch.DoubleTensor,
+            np.float32: torch.FloatTensor,
+            np.float16: torch.HalfTensor,
+            np.int64: torch.LongTensor,
+            np.int32: torch.IntTensor,
+            np.int16: torch.ShortTensor,
+            np.int8: torch.CharTensor,
+            np.uint8: torch.ByteTensor,
+        }
+        for dt, tt in dtypes.items():
+            dset = ScalarDataset(dt)
+            loader = DataLoader(dset, batch_size=2)
+            batch = next(iter(loader))
+            self.assertIsInstance(batch, tt)
+
 
 class StringDataset(Dataset):
     def __init__(self):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -88,7 +88,7 @@ def is_tensor(obj):
     Args:
         obj (Object): Object to test
     """
-    return obj.__class__ in _tensor_classes
+    return type(obj) in _tensor_classes
 
 
 def is_storage(obj):
@@ -97,7 +97,7 @@ def is_storage(obj):
     Args:
         obj (Object): Object to test
     """
-    return obj.__class__ in _storage_classes
+    return type(obj) in _storage_classes
 
 
 def set_default_tensor_type(t):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -559,17 +559,17 @@ Example::
 
 add_docstr(torch._C.cat,
            """
-cat(inputs, dimension=0) -> Tensor
+cat(seq, dim=0) -> Tensor
 
-Concatenates the given sequence of :attr:`inputs` Tensors in the given dimension.
+Concatenates the given sequence of :attr:`seq` Tensors in the given dimension.
 
 :func:`torch.cat` can be seen as an inverse operation for :func:`torch.split` and :func:`torch.chunk`
 
 :func:`cat` can be best understood via examples.
 
 Args:
-    inputs (sequence of Tensors): Can be any python sequence of `Tensor` of the same type.
-    dimension (int, optional): The dimension over which the tensors are concatenated
+    seq (sequence of Tensors): Can be any python sequence of `Tensor` of the same type.
+    dim (int, optional): The dimension over which the tensors are concatenated
 
 Example::
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -353,13 +353,19 @@ static PyObject * THPModule_randperm(PyObject *_unused, PyObject *args, PyObject
   return THPUtils_dispatchStateless(tensor, "randperm", args, kwargs);
 }
 
-static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
+static PyObject * THPModule_cat(PyObject *_unused, PyObject *args, PyObject *kwargs)
 {
   PyObject *tensor = THPDefaultTensorClass;
   THPObjectPtr iterator;
   THPObjectPtr item;
-  if (args && PyTuple_Size(args) > 0) {
-    PyObject *first_arg = PyTuple_GET_ITEM(args, 0);
+  PyObject *first_arg;
+  if (args && PyTuple_GET_SIZE(args) > 0) {
+    first_arg = PyTuple_GET_ITEM(args, 0);
+  } else if (kwargs && PyTuple_GET_ITEM(args, 0)) {
+    first_arg = PyDict_GetItemString(kwargs, "seq");
+  }
+
+  if (first_arg) {
     if (THPModule_isTensor(first_arg)) {
       tensor = first_arg;
     } else if (PySequence_Check(first_arg)) {
@@ -371,7 +377,7 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args)
     PyErr_Clear();
   }
 
-  return THPUtils_dispatchStateless(tensor, "cat", args, NULL);
+  return THPUtils_dispatchStateless(tensor, "cat", args, kwargs);
 }
 
 PyObject *THPModule_safeCall(PyObject *_unused, PyObject *args, PyObject *kwargs)
@@ -605,7 +611,7 @@ static PyMethodDef TorchMethods[] = {
   {"range",           (PyCFunction)THPModule_range,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"arange",          (PyCFunction)THPModule_arange,            METH_VARARGS | METH_KEYWORDS, NULL},
   {"gather",          (PyCFunction)THPModule_gather,            METH_VARARGS | METH_KEYWORDS, NULL},
-  {"cat",             (PyCFunction)THPModule_cat,               METH_VARARGS, NULL},
+  {"cat",             (PyCFunction)THPModule_cat,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"masked_select",   (PyCFunction)THPModule_masked_select,     METH_VARARGS | METH_KEYWORDS, NULL},
   {"gesv",            (PyCFunction)THPModule_gesv,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"gels",            (PyCFunction)THPModule_gels,              METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -704,27 +704,36 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
 [[
   name: THPTensor_stateless_(cat)
   python_name: cat
+  method_flags: METH_KEYWORDS
   only_register: True
   only_stateless: True
 ]]
 #ifndef TH_REAL_IS_HALF
-static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
+static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args, PyObject *kwargs)
 {
   HANDLE_TH_ERRORS
 #if IS_CUDA
   THCPAutoGPU __autogpu_guard(-1);
 #endif
-  Py_ssize_t _argcount = args ? PyTuple_Size(args) : 0;
+  Py_ssize_t _tuplecount = args ? PyTuple_GET_SIZE(args) : 0;
+  Py_ssize_t _dictcount = kwargs ? PyDict_Size(kwargs) : 0;
+  Py_ssize_t _argcount = _tuplecount + _dictcount;
   std::vector<THPObjectPtr> items;
   std::vector<THTensor *> item_tensors;
-  PyObject *sequence;
   Py_ssize_t seq_length;
   THPTensorPtr result;
   long dimension = -1;
+  PyObject *sequence = _tuplecount > 0 ? PyTuple_GET_ITEM(args, 0)
+                     : (kwargs ? PyDict_GetItemString(kwargs, "seq") : NULL);
+  PyObject *pydim = _tuplecount > 1 ? PyTuple_GET_ITEM(args, 1)
+                  : (kwargs ? PyDict_GetItemString(kwargs, "dim") : NULL);
 
-  if (_argcount == 0 || _argcount > 2 || !PySequence_Check(PyTuple_GET_ITEM(args, 0)))
+  if (_argcount == 0 || _argcount > 2)
     goto invalid_arguments;
-  sequence = PyTuple_GET_ITEM(args, 0);
+  if (sequence == NULL || (_argcount > 1 && pydim == NULL))
+    goto invalid_arguments;
+  if (!PySequence_Check(sequence))
+    goto invalid_arguments;
   seq_length = PySequence_Length(sequence);
   THPUtils_assert(seq_length > 0, "sequence length has to be positive, but is %lld",
                   (long long)seq_length);
@@ -738,10 +747,10 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
     item_tensors.push_back(((THPTensor*)items[i].get())->cdata);
   }
 
-  if (_argcount == 2) {
-    if (!THPUtils_checkLong(PyTuple_GET_ITEM(args, 1)))
+  if (pydim) {
+    if (!THPUtils_checkLong(pydim))
       goto invalid_arguments;
-    dimension = THPUtils_unpackLong(PyTuple_GET_ITEM(args, 1));
+    dimension = THPUtils_unpackLong(pydim);
   } else {
     dimension = 0;
   }
@@ -769,9 +778,9 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args)
   return (PyObject*)result.release();
 
 invalid_arguments:
-  THPUtils_invalidArguments(args, NULL, "cat", 2,
-      "(sequence[" THPTensorStr "] tensors)",
-      "(sequence[" THPTensorStr "] tensors, int dim)");
+  THPUtils_invalidArguments(args, kwargs, "cat", 2,
+      "(sequence[" THPTensorStr "] seq)",
+      "(sequence[" THPTensorStr "] seq, int dim)");
   return NULL;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -8,7 +8,7 @@ from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
 from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, NLLLoss2d, \
     CosineEmbeddingLoss, HingeEmbeddingLoss, MarginRankingLoss, \
     MultiLabelMarginLoss, MultiLabelSoftMarginLoss, MultiMarginLoss, \
-    SmoothL1Loss, SoftMarginLoss, CrossEntropyLoss
+    SmoothL1Loss, SoftMarginLoss, CrossEntropyLoss, TripletMarginLoss
 from .container import Container, Sequential, ModuleList, ParameterList
 from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxPool3d, \
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, LPPool2d, AdaptiveMaxPool1d, \
@@ -41,4 +41,5 @@ __all__ = [
     'Embedding', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
+    'TripletMarginLoss'
 ]

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -142,7 +142,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
             try:
                 source_file = inspect.getsourcefile(obj)
                 source = inspect.getsource(obj)
-            except (TypeError, IOError):
+            except:  # saving the source is optional, so we can ignore any errors
                 warnings.warn("Couldn't retrieve source code for container of "
                               "type " + obj.__name__ + ". It won't be checked "
                               "for correctness upon loading.")


### PR DESCRIPTION
* Handle all errors if Module's sources can't be loaded (#1212)
* Improve serialization error messages (in case `read` returns 0)
* Retain the type of numpy scalars in `collate_fn` (#1113)
* Import TripletMarginLoss (#1224) 
* Fix `is_tensor` and `is_storage` to support old-style classes (#1003)
* Add support for keyword arguments in `torch.cat` (#1028)
* Fix coalesced CUDA collectives for nonhomogeneous lists (#1179)