### PR TITLE
update README to install pyyaml from conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,12 @@ conda install -c soumith magma-cuda75 # or magma-cuda80 if CUDA 8.0
 On OSX
 ```bash
 export CMAKE_PREFIX_PATH=[anaconda root directory]
-conda install numpy setuptools cmake cffi
+conda install numpy pyyaml setuptools cmake cffi
 ```
 
 #### Install PyTorch
 ```bash
 export MACOSX_DEPLOYMENT_TARGET=10.9 # if OSX
-pip install -r requirements.txt
 python setup.py install
 ```
 


### PR DESCRIPTION
Pretty straightforward: PyYAML is in conda, so instead of mixing conda and pip, I think it makes more sense to just install everything with conda.

I was tempted to remove the `requirements.txt` file entirely, since the only other references to it are in `.travis.yml` and `Dockfile`, but I don't know enough about testing Docker to validate that change. That said, I don't see any reason that PyYAML couldn't be installed from conda in Travis/Docker as well.