### PR TITLE
Use thnn version of Tanh/Sigmoid instead of autograd.

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -391,7 +391,7 @@ def hardshrink(input, lambd=0.5):
 
 
 def tanhshrink(input):
-    return input - torch.tanh(input)
+    return input - _functions.thnn.Tanh()(input)
 
 
 def softsign(input):
@@ -419,11 +419,11 @@ def log_softmax(input):
 
 
 def tanh(input):
-    return torch.tanh(input)
+    return _functions.thnn.Tanh()(input)
 
 
 def sigmoid(input):
-    return torch.sigmoid(input)
+    return _functions.thnn.Sigmoid()(input)
 
 
 # etc.


### PR DESCRIPTION
Will help with using nn.functional.sigmoid and nn.functional.tanh by reducing number of backwards kernels.