### PR TITLE
add pyyaml to conda note here as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ On Linux
 export CMAKE_PREFIX_PATH=[anaconda root directory]
 
 # Install basic dependencies
-conda install numpy mkl setuptools cmake gcc cffi
+conda install numpy pyyaml mkl setuptools cmake gcc cffi
 
 # Add LAPACK support for the GPU
 conda install -c soumith magma-cuda75 # or magma-cuda80 if CUDA 8.0


### PR DESCRIPTION
Earlier you merged ade105fb7c198546a0a099ddf7ed2c87a9add5cd for me. I inadvertently only updated the OS X instructions; this adds the pyyaml note to the Linux instructions as well.