### PR TITLE
Autograd deadlock for recent glibc fix

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -358,7 +358,7 @@ static PyObject * THPModule_cat(PyObject *_unused, PyObject *args, PyObject *kwa
   PyObject *tensor = THPDefaultTensorClass;
   THPObjectPtr iterator;
   THPObjectPtr item;
-  PyObject *first_arg;
+  PyObject *first_arg=nullptr;
   if (args && PyTuple_GET_SIZE(args) > 0) {
     first_arg = PyTuple_GET_ITEM(args, 0);
   } else if (kwargs && PyTuple_GET_ITEM(args, 0)) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -85,6 +85,7 @@ auto ReadyQueue::pop_back() -> FunctionTask {
 Engine::Engine() : ready_queues() {
 }
 
+// This Engine's ReadyQueues and their corresponding threads are leaked here
 Engine::~Engine() = default;
 
 auto Engine::thread_main(std::shared_ptr<ReadyQueue> queue) -> void {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -90,7 +90,7 @@ Engine::~Engine() = default;
 
 auto Engine::thread_main(std::shared_ptr<ReadyQueue> queue) -> void {
   while (1) {
-    FunctionTask task = queue.get()->pop_back();
+    FunctionTask task = queue->pop_back();
     if (!task.base->has_error.load()) {
       try {
         evaluate_function(task);

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -18,6 +18,8 @@ struct ReadyQueue;
 struct FunctionTask;
 struct BackwardTask;
 
+// A single instance of this struct should be created through the whole process lifetime.
+// The worker thread creation logic and Engine's destructor rely on this.
 struct Engine {
   Engine();
   virtual ~Engine();

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -43,10 +43,10 @@ protected:
   void evaluate_function(FunctionTask& task);
   ReadyQueue& ready_queue(int device);
   void start_threads();
-  virtual void thread_main(ReadyQueue& queue);
+  virtual void thread_main(std::shared_ptr<ReadyQueue> queue);
   virtual void thread_on_exception(FunctionTask& task, std::exception& e);
 
-  std::vector<std::unique_ptr<ReadyQueue>> ready_queues;
+  std::vector<std::shared_ptr<ReadyQueue>> ready_queues;
 };
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -12,7 +12,7 @@ struct THPEngine {
 };
 
 struct PythonEngine : public Engine {
-  virtual void thread_main(ReadyQueue& queue) override {
+  virtual void thread_main(std::shared_ptr<ReadyQueue> queue) override {
     // Create a PyThreadState, but release the GIL. This lets AutoGIL calls
     // inside thread_main acquire the GIL without having to create a new
     // PyThreadState each time.

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -55,8 +55,9 @@ void unregister_fd(int fd) {
 
 
 void print_init_message(const char *message) {
-  write(1, message, strlen(message));
-  write(1, "\n", 1);
+  size_t unused;
+  unused = write(1, message, strlen(message));
+  unused = write(1, "\n", 1);
 }
 
 bool object_exists(const char *name) {
@@ -109,7 +110,7 @@ int main(int argc, char *argv[]) {
     if (nevents == 0 && client_sessions.size() == 0)
       break;
 
-    for (struct pollfd &pfd: pollfds) {
+    for (auto &pfd: pollfds) {
       if (pfd.revents & (POLLERR | POLLHUP)) {
         // some process died
         DEBUG("detaching process");


### PR DESCRIPTION
* Remove compilation warning in `csrc/Module.cpp`
* Remove compilation warnings in `lib/libshm/manager.cpp`
* Make the `ReadyQueue` passed to worker threads in the autograd engine `shared_ptr` so that they get destroyed properly (without causing any deadlocks like #1233)