### PR TITLE
torch.diag bug fix

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1077,6 +1077,8 @@ function_tests = [
     (Resize, (S * S, S), ((S, S, S),)),
     (Diag, (), ((S, S),), '2d'),
     (Diag, (), ((S,),), '1d'),
+    (Diag, (1,), ((S, S),), '2d_1'),
+    (Diag, (2,), ((S, S),), '2d_2'),
     (Tril, (), ((S, S),)),
     (Tril, (2,), ((S, S),), 'idx'),
     (Triu, (), ((S, S),)),

--- a/torch/autograd/_functions/linalg.py
+++ b/torch/autograd/_functions/linalg.py
@@ -10,10 +10,10 @@ class Diag(Function):
         self.diagonal_idx = diagonal_idx
 
     def forward(self, input):
-        return input.diag()
+        return input.diag(self.diagonal_idx)
 
     def backward(self, grad_output):
-        return grad_output.diag()
+        return grad_output.diag(self.diagonal_idx)
 
 
 class Tril(Function):


### PR DESCRIPTION
`torch.diag` wasn't working when the diagonal idx was something other than zero.

example error:
```python
x = Variable(torch.ones((5,5)))
print(torch.diag(x,2)) # still prints middle diag
print(torch.diag(x.data,2)) # print correct diag idx
```