### PR TITLE
Fix group-convolution w/o biases on CPU.

### DIFF
--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -292,7 +292,9 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
             columns[g].get(), ones[g].get(), kernel_size, *this);
       }
       grad_weight = cat(grad_weights, 0);
-      grad_bias = cat(grad_biases, 0);
+      if (bias && needs_input_grad(2)) {
+        grad_bias = cat(grad_biases, 0);
+      }
     }
   }
 


### PR DESCRIPTION
Not having this guard will cause a crash further down in the `cat`
function when it uses the first element in the passed list to create a
new tensor. (And even after that, `cat` doesn't handle `NULL`s well.)

I have a minimal reproducing example that I only attach here as I didn't find a canonical place for unittests in the C/C++ code:

```python
import torch
import torch.nn as nn
import torch.nn.functional as F
from torch.autograd import Variable

Xv = Variable(torch.randn(1,8,3,3))
yv = Variable(torch.LongTensor([0]))

conv = nn.Conv2d(8, 16, kernel_size=3, bias=False, groups=4)
cost = F.cross_entropy(conv(Xv).view(1,-1), yv)
print("Going to bprop", flush=True)
cost.backward()
print("Done", flush=True)
```

Is there some upstream autograd repo that I should also contribute this to, or is this it?