### PR TITLE
Fix `patched_make_field` for newer Sphinx versions.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,7 +204,10 @@ from sphinx.util.docfields import TypedField
 from sphinx import addnodes
 
 
-def patched_make_field(self, types, domain, items):
+def patched_make_field(self, types, domain, items, **kw):
+    # `kw` catches `env=None` needed for newer sphinx while maingaining
+    #  backwards compatibility when passed along further down!
+
     # type: (List, unicode, Tuple) -> nodes.field
     def handle_item(fieldarg, content):
         par = nodes.paragraph()
@@ -224,7 +227,7 @@ def patched_make_field(self, types, domain, items):
                 typename = typename.replace('float', 'python:float')
                 typename = typename.replace('type', 'python:type')
                 par.extend(self.make_xrefs(self.typerolename, domain, typename,
-                                           addnodes.literal_emphasis))
+                                           addnodes.literal_emphasis, **kw))
             else:
                 par += fieldtype
             par += nodes.Text(')')


### PR DESCRIPTION
Not sure since which version that change is needed, but using v1.5.5 here.

For reference, here's the full Sphinx error log without this patch:

```
# Sphinx version: 1.5.5
# Python version: 3.6.0 (CPython)
# Docutils version: 0.13.1 release
# Jinja2 version: 2.9.6
# Last messages:
#   not yet created
#   loading intersphinx inventory from https://docs.python.org/objects.inv...
#   intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/2/objects.inv
#   loading intersphinx inventory from http://docs.scipy.org/doc/numpy/objects.inv...
#   intersphinx inventory has moved: http://docs.scipy.org/doc/numpy/objects.inv -> https://docs.scipy.org/doc/numpy/objects.inv
#   building [mo]: targets for 0 po files that are out of date
#   building [html]: targets for 23 source files that are out of date
#   updating environment:
#   23 added, 0 changed, 0 removed
#   reading sources... [  4%] autograd
# Loaded extensions:
#   sphinx.ext.autodoc (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/autodoc.py
#   sphinx.ext.autosummary (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/autosummary/__init__.py
#   sphinx.ext.doctest (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/doctest.py
#   sphinx.ext.intersphinx (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/intersphinx.py
#   sphinx.ext.todo (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/todo.py
#   sphinx.ext.coverage (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/coverage.py
#   sphinx.ext.mathjax (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/mathjax.py
#   sphinx.ext.napoleon (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/napoleon/__init__.py
#   sphinx.ext.viewcode (1.5.5) from /home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/viewcode.py
#   alabaster (0.7.10) from /home/beyer/sci-env3/lib/python3.6/site-packages/alabaster/__init__.py
Traceback (most recent call last):
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/cmdline.py", line 296, in main
    app.build(opts.force_all, filenames)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/application.py", line 333, in build
    self.builder.build_update()
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 251, in build_update
    'out of date' % len(to_build))
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/builders/__init__.py", line 265, in build
    self.doctreedir, self.app))
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/environment/__init__.py", line 556, in update
    self._read_serial(docnames, app)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/environment/__init__.py", line 576, in _read_serial
    self.read_doc(docname, app)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/environment/__init__.py", line 684, in read_doc
    pub.publish()
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/core.py", line 217, in publish
    self.settings)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/io.py", line 55, in read
    self.parse()
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/readers/__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/__init__.py", line 185, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 170, in run
    input_source=document['source'])
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2745, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 326, in section
    self.new_subsection(title, lineno, messages)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 394, in new_subsection
    node=section_node, match_titles=True)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2320, in explicit_markup
    self.explicit_list(blank_finish)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2350, in explicit_list
    match_titles=self.state_machine.match_titles)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 318, in nested_list_parse
    node=node, match_titles=match_titles)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2623, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2330, in explicit_construct
    return method(self, expmatch)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2073, in directive
    directive_class, match, type_name, option_presets)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2122, in run_directive
    result = directive_instance.run()
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/ext/autodoc.py", line 1684, in run
    self.state.nested_parse(self.result, 0, node)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2318, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2330, in explicit_construct
    return method(self, expmatch)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2073, in directive
    directive_class, match, type_name, option_presets)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/docutils/parsers/rst/states.py", line 2122, in run_directive
    result = directive_instance.run()
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/domains/__init__.py", line 199, in run
    return BaseDirective.run(self)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/directives/__init__.py", line 165, in run
    DocFieldTransformer(self).transform_all(contentnode)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/util/docfields.py", line 222, in transform_all
    self.transform(child)
  File "/home/beyer/sci-env3/lib/python3.6/site-packages/sphinx/util/docfields.py", line 314, in transform
    content, env=self.directive.env)
TypeError: patched_make_field() got an unexpected keyword argument 'env'
```