### PR TITLE
Add flexible bilinear upsampling aspect ratio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,5 +70,49 @@ For example:
 
 You do not need to repeatedly install after modifying python files.
 
+When you are developing on the C++ side of things, the environment variables `DEBUG` and `NOCUDA` are helpful.
+
+- `DEBUG=1` will enable debug builds (-g -O0)
+- `NOCUDA=1` will disable compiling CUDA (in case you are developing on something not CUDA related), to save compile time.
+
+For example:
+```
+NO_CUDA=1 DEBUG=1 python setup.py build develop
+```
+
+Also, if you are developing a lot, using ccache is a real time-saver. By default, ccache does not properly support CUDA stuff, so here are the instructions for installing a custom `ccache` fork that has CUDA support:
+```
+# install and export ccache
+if ! ls ~/ccache/bin/ccache
+then
+    sudo apt-get update
+    sudo apt-get install -y automake autoconf
+    sudo apt-get install -y asciidoc
+    mkdir -p ~/ccache
+    pushd /tmp
+    rm -rf ccache
+    git clone https://github.com/colesbury/ccache -b ccbin
+    pushd ccache
+    ./autogen.sh
+    ./configure
+    make install prefix=~/ccache
+    popd
+    popd
+
+    mkdir -p ~/ccache/lib
+    mkdir -p ~/ccache/cuda
+    ln -s ~/ccache/bin/ccache ~/ccache/lib/cc
+    ln -s ~/ccache/bin/ccache ~/ccache/lib/c++
+    ln -s ~/ccache/bin/ccache ~/ccache/lib/gcc
+    ln -s ~/ccache/bin/ccache ~/ccache/lib/g++
+    ln -s ~/ccache/bin/ccache ~/ccache/cuda/nvcc
+
+    ~/ccache/bin/ccache -M 25Gi
+fi
+
+export PATH=~/ccache/lib:$PATH
+export CUDA_NVCC_EXECUTABLE=~/ccache/cuda/nvcc
+```
+
 
 Hope this helps, and thanks for considering to contribute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ For example:
 
 You do not need to repeatedly install after modifying python files.
 
+#### C++ Development tips
+
 When you are developing on the C++ side of things, the environment variables `DEBUG` and `NOCUDA` are helpful.
 
 - `DEBUG=1` will enable debug builds (-g -O0)

--- a/LogSigmoid.cu
+++ b/LogSigmoid.cu
@@ -6,22 +6,49 @@
 template <typename T>
 struct logSigmoid_updateOutput_functor
 {
-  __device__ void operator()(T *output, const T *input) const
-  {
-    T z = exp(-*input);
-    *output = ScalarConvert<double, T>::to(-log(1. + z));
+  __device__ void operator()(T *output, const T *input) const {
+    *output = -THCNumerics<T>::log(1.f + THCNumerics<T>::exp(- *input));
   }
 };
 
 template <typename T>
 struct logSigmoid_updateGradInput_functor
 {
-  __device__ void operator()(T *gradInput, const T *input, const T *gradOutput) const
-  {
-    T z = exp(-*input);
-    *gradInput = ScalarConvert<double, T>::to(*gradOutput * z / (1. + z));
+  __device__ void operator()(T *gradInput, const T *input, const T *gradOutput) const {
+    const T z = THCNumerics<T>::exp(- *input);
+    *gradInput = *gradOutput * z / (1.f + z);
   }
 };
+
+#ifdef CUDA_HALF_TENSOR
+template <>
+struct logSigmoid_updateOutput_functor<half> {
+  __device__ __forceinline__ void operator()(half* output, const half *input) const {
+#ifdef CUDA_HALF_INSTRUCTIONS
+    const half one = __float2half(1.f);
+    *output = __hneg(THCNumerics<half>::log(one + THCNumerics<half>::exp(__hneg(*input))));
+#else
+    float in = __half2float(*input);
+    *output = __float2half(-THCNumerics<float>::log(1.f + THCNumerics<float>::exp(-in)));
+#endif
+  }
+};
+
+template <>
+struct logSigmoid_updateGradInput_functor<half> {
+  __device__ __forceinline__ void operator()(half* gradInput, const half *input, const half *gradOutput) const {
+#ifdef CUDA_HALF_INSTRUCTIONS
+    const half one = __float2half(1.f);
+    const half in_exp = THCNumerics<half>::exp(__hneg(*input));
+    *gradInput = hdiv(__hmul(*gradOutput, in_exp), __hadd(one, in_exp));
+#else
+    const float in_exp = THCNumerics<float>::exp(-(__half2float(*input)));
+    const float go = __half2float(*gradOutput);
+    *gradInput = __float2half(go * in_exp / (1.f + in_exp));
+#endif
+  }
+};
+#endif
 
 #include "generic/LogSigmoid.cu"
 #include "THCGenerateFloatTypes.h"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ NVCC ?= $(CUDA_HOME)/bin/nvcc
 NVCC_GENCODE ?= -gencode=arch=compute_35,code=sm_35 \
                 -gencode=arch=compute_50,code=sm_50 \
                 -gencode=arch=compute_52,code=sm_52 \
-                -gencode=arch=compute_52,code=compute_52
+                -gencode=arch=compute_60,code=sm_60\
+                -gencode=arch=compute_61,code=sm_61 \
+                -gencode=arch=compute_60,code=compute_60
 
 CXXFLAGS   := -I$(CUDA_INC) -fPIC -fvisibility=hidden
 NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -lineinfo -std=c++11 -maxrregcount 96
@@ -52,7 +54,7 @@ endif
 
 NCCL_MAJOR   := 1
 NCCL_MINOR   := 3
-NCCL_PATCH   := 3
+NCCL_PATCH   := 4
 CXXFLAGS  += -DNCCL_MAJOR=$(NCCL_MAJOR) -DNCCL_MINOR=$(NCCL_MINOR) -DNCCL_PATCH=$(NCCL_PATCH)
 
 CUDA_VERSION ?= $(shell ls $(CUDA_LIB)/libcudart.so.* | head -1 | rev | cut -d "." -f -2 | rev)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2015-2017, NVIDIA CORPORATION. All rights reserved.
 #
 # See LICENCE.txt for license information
 #
@@ -52,7 +52,7 @@ endif
 
 NCCL_MAJOR   := 1
 NCCL_MINOR   := 3
-NCCL_PATCH   := 2
+NCCL_PATCH   := 3
 CXXFLAGS  += -DNCCL_MAJOR=$(NCCL_MAJOR) -DNCCL_MINOR=$(NCCL_MINOR) -DNCCL_PATCH=$(NCCL_PATCH)
 
 CUDA_VERSION ?= $(shell ls $(CUDA_LIB)/libcudart.so.* | head -1 | rev | cut -d "." -f -2 | rev)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 NCCL_MAJOR   := 1
 NCCL_MINOR   := 3
-NCCL_PATCH   := 0
+NCCL_PATCH   := 1
 CXXFLAGS  += -DNCCL_MAJOR=$(NCCL_MAJOR) -DNCCL_MINOR=$(NCCL_MINOR) -DNCCL_PATCH=$(NCCL_PATCH)
 
 CUDA_VERSION ?= $(shell ls $(CUDA_LIB)/libcudart.so.* | head -1 | rev | cut -d "." -f -2 | rev)
@@ -146,7 +146,7 @@ MPITESTBINS:= $(patsubst %, $(MPITSTDIR)/%, $(MPITESTS))
 
 test : $(TESTBINS)
 
-$(TSTDIR)/% : test/single/%.cu test/include/*.h $(TSTDEP) 
+$(TSTDIR)/% : test/single/%.cu test/include/*.h $(TSTDEP)
 	@printf "Building  %-25s > %-24s\n" $< $@
 	mkdir -p $(TSTDIR)
 	$(NVCC) $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" -o $@ $< $(TSTLIB) -lcuda -lcurand -lnvToolsExt
@@ -158,7 +158,7 @@ $(TSTDIR)/% : test/single/%.cu test/include/*.h $(TSTDEP)
 
 mpitest : $(MPITESTBINS)
 
-$(MPITSTDIR)/% : test/mpi/%.cu $(TSTDEP) 
+$(MPITSTDIR)/% : test/mpi/%.cu $(TSTDEP)
 	@printf "Building  %-25s > %-24s\n" $< $@
 	mkdir -p $(MPITSTDIR)
 	$(NVCC) $(MPIFLAGS) $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" -o $@ $< $(TSTLIB) -lcurand

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 
 NCCL_MAJOR   := 1
 NCCL_MINOR   := 3
-NCCL_PATCH   := 1
+NCCL_PATCH   := 2
 CXXFLAGS  += -DNCCL_MAJOR=$(NCCL_MAJOR) -DNCCL_MINOR=$(NCCL_MINOR) -DNCCL_PATCH=$(NCCL_PATCH)
 
 CUDA_VERSION ?= $(shell ls $(CUDA_LIB)/libcudart.so.* | head -1 | rev | cut -d "." -f -2 | rev)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Once you have [anaconda](https://www.continuum.io/downloads) installed, here are
 
 If you want to compile with CUDA support, install
 - [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 7.5 or above
-- [NVIDIA CuDNN](https://developer.nvidia.com/cudnn) v5.x
+- [NVIDIA CuDNN](https://developer.nvidia.com/cudnn) v5.x or above
 
 If you want to disable CUDA support, export environment variable `NO_CUDA=1`.
 
@@ -172,7 +172,7 @@ export CMAKE_PREFIX_PATH=[anaconda root directory]
 conda install numpy pyyaml mkl setuptools cmake gcc cffi
 
 # Add LAPACK support for the GPU
-conda install -c soumith magma-cuda75 # or magma-cuda80 if CUDA 8.0
+conda install -c soumith magma-cuda80 # or magma-cuda75 if CUDA 7.5
 ```
 
 On OSX

--- a/Sigmoid.cu
+++ b/Sigmoid.cu
@@ -4,7 +4,7 @@
 #include <THC/THCApply.cuh>
 
 template <typename T>
-struct SigmoidGradInputOp {
+struct sigmoid_updateGradInput_functor {
   __device__ __forceinline__ void operator()(T* gradInput, const T *output, const T *gradOutput) const {
     *gradInput = *gradOutput * (1.f - *output) * (*output);
   }
@@ -12,14 +12,14 @@ struct SigmoidGradInputOp {
 
 #ifdef CUDA_HALF_TENSOR
 template <>
-struct SigmoidGradInputOp<half> {
+struct sigmoid_updateGradInput_functor<half> {
   __device__ __forceinline__ void operator()(half* gradInput, const half *output, const half *gradOutput) const {
 #ifdef CUDA_HALF_INSTRUCTIONS
-    half one = __float2half(1.f);
+    const half one = __float2half(1.f);
     *gradInput = __hmul(*gradOutput, __hmul(__hadd(one, __hneg(*output)), *output));
 #else
-    float out = __half2float(*output);
-    float go = __half2float(*gradOutput);
+    const float out = __half2float(*output);
+    const float go = __half2float(*gradOutput);
     *gradInput = __float2half(go * (1.f - out) * out);
 #endif
   }

--- a/Tanh.cu
+++ b/Tanh.cu
@@ -4,7 +4,7 @@
 #include <THC/THCApply.cuh>
 
 template <typename T>
-struct TanhGradInputOp
+struct tanh_updateGradInput_functor
 {
   __device__ __forceinline__ void operator()(T *gradInput,
           const T *output, const T *gradOutput) const {
@@ -14,7 +14,7 @@ struct TanhGradInputOp
 
 #ifdef CUDA_HALF_TENSOR
 template <>
-struct TanhGradInputOp<half>
+struct tanh_updateGradInput_functor<half>
 {
   __device__ __forceinline__ void operator()(half *gradInput,
           const half *output, const half *gradOutput) const {
@@ -23,8 +23,8 @@ struct TanhGradInputOp<half>
     const half out_square = __hmul(*output, *output);
     *gradInput = __hmul(*gradOutput, __hadd(one, __hneg(out_square)));
 #else
-    float out = __half2float(*output);
-    float go = __half2float(*gradOutput);
+    const float out = __half2float(*output);
+    const float go = __half2float(*gradOutput);
     *gradInput = __float2half(go * (1.f - out * out));
 #endif
   }

--- a/Tanh.cu
+++ b/Tanh.cu
@@ -4,22 +4,32 @@
 #include <THC/THCApply.cuh>
 
 template <typename T>
-struct tanhupdateOutput_functor
+struct TanhGradInputOp
 {
-  __device__ void operator()(T *output, const T *input) const
-  {
-    *output = tanh(*input);
+  __device__ __forceinline__ void operator()(T *gradInput,
+          const T *output, const T *gradOutput) const {
+    *gradInput = *gradOutput * (1.f - *output * *output);
   }
 };
 
-template <typename T>
-struct tanhupdateGradInput_functor
+#ifdef CUDA_HALF_TENSOR
+template <>
+struct TanhGradInputOp<half>
 {
-  __device__ void operator()(T *gradInput, const T *output, const T *gradOutput) const
-  {
-    *gradInput = *gradOutput * (1 - *output * *output);
+  __device__ __forceinline__ void operator()(half *gradInput,
+          const half *output, const half *gradOutput) const {
+#ifdef CUDA_HALF_INSTRUCTIONS
+    const half one = __float2half(1.f);
+    const half out_square = __hmul(*output, *output);
+    *gradInput = __hmul(*gradOutput, __hadd(one, __hneg(out_square)));
+#else
+    float out = __half2float(*output);
+    float go = __half2float(*gradOutput);
+    *gradInput = __float2half(go * (1.f - out * out));
+#endif
   }
 };
+#endif
 
 #include "generic/Tanh.cu"
 #include "THCGenerateFloatTypes.h"

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -1,0 +1,81 @@
+FC := gfortran
+FCNAME := $(notdir $(FC))
+
+BUILDDIR ?= ../build
+INCDIR := $(BUILDDIR)/include
+LIBDIR := $(BUILDDIR)/lib
+OBJDIR := $(BUILDDIR)/obj
+
+LIBNAME    := libncclfor.so
+LIBSONAME  := $(patsubst %,%.$(NCCL_MAJOR),$(LIBNAME))
+LIBTARGET  := $(patsubst %,%.$(NCCL_MAJOR).$(NCCL_MINOR).$(NCCL_PATCH),$(LIBNAME))
+LIBLINK    += $(patsubst lib%.so,-l%,$(LIBNAME))
+
+LIBCUDAFOR := libcudafor.so
+
+ifneq ($(filter pgf%, $(FCNAME)), )
+# PGI compiler (pgfortran, pgf90, pgf95)
+FCMODFLAGS  := -module $(INCDIR)
+FCPREFLAGS  := -Mpreprocess
+FCCUDAFLAGS := -Mcuda,cuda$(CUDA_MAJOR).$(CUDA_MINOR)
+FCFLAGS     := -fast -O3
+else
+# non-PGI compilers do not have CUDA support, compile our own CUDA lib
+CUDAFORDEP  := $(LIBDIR)/$(LIBCUDAFOR)
+CUDALINK    := -L$(CUDA_LIB) -lcudart
+CUDAFORLINK := -lcudafor
+ifeq ($(FCNAME), gfortran)
+FCMODFLAGS  := -J$(INCDIR)
+FCPREFLAGS  += -cpp
+FCFLAGS     += -ffree-line-length-none
+else ifeq ($(FCNAME), ifort)
+FCMODFLAGS  := -module $(INCDIR)
+FCPREFLAGS  += -fpp
+endif
+endif
+
+ifeq ($(VERBOSE), 0)
+.SILENT:
+endif
+
+lib: $(CUDAFORDEP)
+	$(MAKE) $(LIBDIR)/$(LIBTARGET)
+
+$(LIBDIR)/$(LIBTARGET): $(OBJDIR)/ncclfor.o
+	@printf "Linking   %-35s > %s\n" $(LIBTARGET) $@
+	mkdir -p $(LIBDIR)
+	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBSONAME) $< -o $(LIBDIR)/$(LIBTARGET)
+	ln -sf $(LIBSONAME) $(LIBDIR)/$(LIBNAME)
+	ln -sf $(LIBTARGET) $(LIBDIR)/$(LIBSONAME)
+
+$(LIBDIR)/$(LIBCUDAFOR): $(OBJDIR)/cudafor.o
+	@printf "Linking   %-35s > %s\n" $(LIBCUDAFOR) $@
+	mkdir -p $(LIBDIR)
+	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBCUDAFOR) $< -o $(LIBDIR)/$(LIBCUDAFOR)
+
+$(OBJDIR)/%.o: src/%.f90
+	@printf "Building  %-35s > %s\n" $< $@
+	mkdir -p $(OBJDIR)
+	mkdir -p $(INCDIR)
+	$(FC) -c $(FCMODFLAGS) $(FCPREFLAGS) -fPIC $(FCCUDAFLAGS) $(FCFLAGS) $< -o $@
+
+TESTS := reduce_ptr_out allreduce_ptr_out reducescatter_ptr_out broadcast_ptr allgather_ptr_out
+ifneq ($(filter pgf%, $(FCNAME)), )
+TESTS += reduce_arr_out allreduce_arr_out reducescatter_arr_out broadcast_arr allgather_arr_out
+endif
+
+TESTDIR  := $(BUILDDIR)/test/fortran
+TESTBINS := $(patsubst %,$(TESTDIR)/%,$(TESTS))
+
+test: lib $(TESTBINS)
+
+$(TESTDIR)/%: test/%.f90 lib
+	@printf "Building  %-35s > %s\n" $< $@
+	@mkdir -p $(TESTDIR)
+	$(FC) $(FCCUDAFLAGS) $(FCFLAGS) $< $(CUDALINK) -I$(INCDIR) -L$(LIBDIR) $(CUDAFORLINK) $(LIBLINK) -o $@
+
+clean:
+	rm -f $(LIBDIR)/$(LIBTARGET) $(LIBDIR)/$(LIBSONAME) $(LIBDIR)/$(LIBNAME)
+	rm -f $(LIBDIR)/$(LIBCUDAFOR) $(OBJDIR)/*for.o $(INCDIR)/*.mod
+	rm -rf $(TESTDIR)/
+

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -1,0 +1,164 @@
+#ifndef _CUDA
+
+!Start cudaFor module
+module cudaFor
+use iso_c_binding
+implicit none
+private
+public :: c_devptr
+public :: cudaMemcpyKind,           &
+          cudaMemcpyHostToHost,     &
+          cudaMemcpyHostToDevice,   &
+          cudaMemcpyDeviceToHost,   &
+          cudaMemcpyDeviceToDevice, &
+          cudaMemcpyDefault
+public :: cuda_stream_kind
+public :: cudaGetDeviceCount
+public :: cudaSetDevice
+public :: cudaMalloc
+public :: cudaMemcpy
+public :: cudaFree
+public :: cudaStreamCreate
+public :: cudaStreamSynchronize
+public :: cudaStreamDestroy
+
+!Start types
+
+!Start c_devptr
+type, bind(c) :: c_devptr
+type(c_ptr) :: member
+end type c_devptr
+!End c_devptr
+
+!Start cudaMemcpyKind
+type, bind(c) :: cudaMemcpyKind
+integer(c_int) :: member
+end type cudaMemcpyKind
+
+type(cudaMemcpyKind), parameter :: cudaMemcpyHostToHost     = cudaMemcpyKind(0), &
+                                   cudaMemcpyHostToDevice   = cudaMemcpyKind(1), &
+                                   cudaMemcpyDeviceToHost   = cudaMemcpyKind(2), &
+                                   cudaMemcpyDeviceToDevice = cudaMemcpyKind(3), &
+                                   cudaMemcpyDefault        = cudaMemcpyKind(4)
+!End cudaMemcpyKind
+
+!Start cuda_stream_kind
+integer(c_intptr_t), parameter :: cuda_stream_kind = c_intptr_t
+!End cuda_stream_kind
+
+!End types
+
+!Start interfaces
+
+!Start cudaGetDeviceCount
+interface cudaGetDeviceCount
+integer(c_int) function cudaGetDeviceCount(count) bind(c, name = "cudaGetDeviceCount")
+import :: c_int
+implicit none
+integer(c_int) :: count
+end function cudaGetDeviceCount
+end interface cudaGetDeviceCount
+!End cudaGetDeviceCount
+
+!Start cudaSetDevice
+interface cudaSetDevice
+integer(c_int) function cudaSetDevice(device) bind(c, name = "cudaSetDevice")
+import :: c_int
+implicit none
+integer(c_int), value :: device
+end function cudaSetDevice
+end interface cudaSetDevice
+!End cudaSetDevice
+
+!Start cudaMalloc
+interface cudaMalloc
+integer(c_int) function cudaMalloc(devPtr, size) bind(c, name = "cudaMalloc")
+import :: c_int, c_size_t
+import :: c_devptr
+implicit none
+type(c_devptr) :: devPtr
+integer(c_size_t), value :: size
+end function cudaMalloc
+end interface cudaMalloc
+!End cudaMalloc
+
+!Start cudaMemcpy
+interface cudaMemcpy
+
+!Start cudaMemcpyH2D
+integer(c_int) function cudaMemcpyH2D(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+import :: c_ptr, c_int, c_size_t
+import :: c_devptr, cudaMemcpyKind
+implicit none
+type(c_devptr), value :: dst
+type(c_ptr), value :: src
+integer(c_size_t), value :: count
+type(cudaMemcpyKind), value :: kind
+end function cudaMemcpyH2D
+!End cudaMemcpyH2D
+
+!Start cudaMemcpyD2H
+integer(c_int) function cudaMemcpyD2H(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+import :: c_ptr, c_int, c_size_t
+import :: c_devptr, cudaMemcpyKind
+implicit none
+type(c_ptr), value :: dst
+type(c_devptr), value :: src
+integer(c_size_t), value :: count
+type(cudaMemcpyKind), value :: kind
+end function cudaMemcpyD2H
+!End cudaMemcpyD2H
+
+end interface cudaMemcpy
+!End cudaMemcpy
+
+!Start cudaFree
+interface cudaFree
+integer(c_int) function cudaFree(devPtr) bind(c, name = "cudaFree")
+import :: c_int
+import :: c_devptr
+implicit none
+type(c_devptr), value :: devPtr
+end function cudaFree
+end interface cudaFree
+!End cudaFree
+
+!Start cudaStreamCreate
+interface cudaStreamCreate
+integer(c_int) function cudaStreamCreate(pStream) bind(c, name = "cudaStreamCreate")
+import :: c_int
+import :: cuda_stream_kind
+implicit none
+integer(cuda_stream_kind) :: pStream
+end function cudaStreamCreate
+end interface cudaStreamCreate
+!End cudaStreamCreate
+
+!Start cudaStreamSynchronize
+interface cudaStreamSynchronize
+integer(c_int) function cudaStreamSynchronize(stream) bind(c, name = "cudaStreamSynchronize")
+import :: c_int
+import :: cuda_stream_kind
+implicit none
+integer(cuda_stream_kind), value :: stream
+end function cudaStreamSynchronize
+end interface cudaStreamSynchronize
+!End cudaStreamSynchronize
+
+!Start cudaStreamDestroy
+interface cudaStreamDestroy
+integer(c_int) function cudaStreamDestroy(stream) bind(c, name = "cudaStreamDestroy")
+import :: c_int
+import :: cuda_stream_kind
+implicit none
+integer(cuda_stream_kind), value :: stream
+end function cudaStreamDestroy
+end interface cudaStreamDestroy
+!End cudaStreamDestroy
+
+!End interfaces
+
+end module cudaFor
+!End cudaFor module
+
+#endif

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 #ifndef _CUDA
 
 !Start cudaFor module

--- a/fortran/src/ncclfor.f90
+++ b/fortran/src/ncclfor.f90
@@ -1,0 +1,305 @@
+!Start defines
+#define NCCL_UNIQUE_ID_BYTES 128
+!End defines
+
+!Start ncclFor module
+module ncclFor
+use iso_c_binding
+use cudaFor
+implicit none
+private
+public :: ncclUniqueId
+public :: ncclComm
+public :: ncclResult,                 &
+          ncclSuccess,                &
+          ncclUnhandledCudaError,     &
+          ncclSystemError,            &
+          ncclInternalError,          &
+          ncclInvalidDevicePointer,   &
+          ncclInvalidRank,            &
+          ncclUnsupportedDeviceCount, &
+          ncclDeviceNotFound,         &
+          ncclInvalidDeviceIndex,     &
+          ncclLibWrapperNotSet,       &
+          ncclCudaMallocFailed,       &
+          ncclRankMismatch,           &
+          ncclInvalidArgument,        &
+          ncclInvalidType,            &
+          ncclInvalidOperation,       &
+          nccl_NUM_RESULTS
+public :: ncclDataType, &
+          ncclChar,     &
+          ncclInt,      &
+#ifdef CUDA_HAS_HALF
+          ncclHalf,     &
+#endif
+          ncclFloat,    &
+          ncclDouble,   &
+          ncclInt64,    &
+          ncclUInt64,   &
+          nccl_NUM_TYPES
+public :: ncclRedOp, &
+          ncclSum,   &
+          ncclProd,  &
+          ncclMax,   &
+          ncclMin,   &
+          nccl_NUM_OPS
+public :: ncclGetUniqueId
+public :: ncclCommInitRank
+public :: ncclCommInitAll
+public :: ncclCommCuDevice
+public :: ncclCommUserRank
+public :: ncclCommCount
+public :: ncclCommDestroy
+public :: ncclReduce
+public :: ncclAllReduce
+public :: ncclReduceScatter
+public :: ncclBcast
+public :: ncclAllGather
+
+!Start types
+
+!Start ncclUniqueId
+type, bind(c) :: ncclUniqueId
+character(c_char) :: internal(NCCL_UNIQUE_ID_BYTES)
+end type ncclUniqueId
+!End ncclUniqueId
+
+!Start ncclComm
+type, bind(c) :: ncclComm
+type(c_ptr) :: member
+end type ncclComm
+!End ncclComm
+
+!Start ncclResult
+type, bind(c) :: ncclResult
+integer(c_int) :: member
+end type ncclResult
+
+type(ncclResult), parameter :: ncclSuccess                = ncclResult( 0), &
+                               ncclUnhandledCudaError     = ncclResult( 1), &
+                               ncclSystemError            = ncclResult( 2), &
+                               ncclInternalError          = ncclResult( 3), &
+                               ncclInvalidDevicePointer   = ncclResult( 4), &
+                               ncclInvalidRank            = ncclResult( 5), &
+                               ncclUnsupportedDeviceCount = ncclResult( 6), &
+                               ncclDeviceNotFound         = ncclResult( 7), &
+                               ncclInvalidDeviceIndex     = ncclResult( 8), &
+                               ncclLibWrapperNotSet       = ncclResult( 9), &
+                               ncclCudaMallocFailed       = ncclResult(10), &
+                               ncclRankMismatch           = ncclResult(11), &
+                               ncclInvalidArgument        = ncclResult(12), &
+                               ncclInvalidType            = ncclResult(13), &
+                               ncclInvalidOperation       = ncclResult(14), &
+                               nccl_NUM_RESULTS           = ncclResult(15)
+!End ncclResult
+
+!Start ncclDataType
+type, bind(c) :: ncclDataType
+integer(c_int) :: member
+end type ncclDataType
+
+type(ncclDataType), parameter :: ncclChar       = ncclDataType(0), &
+                                 ncclInt        = ncclDataType(1), &
+#ifdef CUDA_HAS_HALF
+                                 ncclHalf       = ncclDataType(2), &
+#endif
+                                 ncclFloat      = ncclDataType(3), &
+                                 ncclDouble     = ncclDataType(4), &
+                                 ncclInt64      = ncclDataType(5), &
+                                 ncclUInt64     = ncclDataType(6), &
+                                 nccl_NUM_TYPES = ncclDataType(7)
+!End ncclDataType
+
+!Start ncclRedOp
+type, bind(c) :: ncclRedOp
+integer(c_int) :: member
+end type ncclRedOp
+
+type(ncclRedOp), parameter :: ncclSum      = ncclRedOp(0), &
+                              ncclProd     = ncclRedOp(1), &
+                              ncclMax      = ncclRedOp(2), &
+                              ncclMin      = ncclRedOp(3), &
+                              nccl_NUM_OPS = ncclRedOp(4)
+!End ncclRedOp
+
+!End types
+
+!Start interfaces
+
+!Start ncclGetUniqueId
+interface ncclGetUniqueId
+type(ncclResult) function ncclGetUniqueId(uniqueId) bind(c, name = 'ncclGetUniqueId')
+import :: ncclResult, ncclUniqueId
+implicit none
+type(ncclUniqueId) :: uniqueId
+end function ncclGetUniqueId
+end interface ncclGetUniqueId
+!End ncclGetUniqueId
+
+!Start ncclCommInitRank
+interface ncclCommInitRank
+type(ncclResult) function ncclCommInitRank(comm, ndev, commId, rank) bind(c, name = 'ncclCommInitRank')
+import :: c_int
+import :: ncclResult, ncclUniqueId, ncclComm
+implicit none
+type(ncclComm) :: comm(*)
+integer(c_int), value :: ndev
+type(ncclUniqueId), value :: commId
+integer(c_int), value :: rank
+end function ncclCommInitRank
+end interface ncclCommInitRank
+!End ncclCommInitRank
+
+!Start ncclCommInitAll
+interface ncclCommInitAll
+type(ncclResult) function ncclCommInitAll(comm, ndev, devlist) bind(c, name = 'ncclCommInitAll')
+import :: c_int
+import :: ncclResult, ncclComm
+implicit none
+type(ncclComm) :: comm(*)
+integer(c_int), value :: ndev
+integer(c_int) :: devlist(*)
+end function ncclCommInitAll
+end interface ncclCommInitAll
+!End ncclCommInitAll
+
+!Start ncclCommCuDevice
+interface ncclCommCuDevice
+type(ncclResult) function ncclCommCuDevice(comm, devid) bind(c, name = 'ncclCommCuDevice')
+import :: c_int
+import :: ncclResult, ncclComm
+implicit none
+type(ncclComm), value :: comm
+integer(c_int) :: devid
+end function ncclCommCuDevice
+end interface ncclCommCuDevice
+!End ncclCommCuDevice
+
+!Start ncclCommUserRank
+interface ncclCommUserRank
+type(ncclResult) function ncclCommUserRank(comm, rank) bind(c, name = 'ncclCommUserRank')
+import :: c_int
+import :: ncclResult, ncclComm
+implicit none
+type(ncclComm), value :: comm
+integer(c_int) :: rank
+end function ncclCommUserRank
+end interface ncclCommUserRank
+!End ncclCommUserRank
+
+!Start ncclCommCount
+interface ncclCommCount
+type(ncclResult) function ncclCommCount(comm, count) bind(c, name = 'ncclCommCount')
+import :: c_int
+import :: ncclResult, ncclComm
+implicit none
+type(ncclComm), value :: comm
+integer(c_int) :: count
+end function ncclCommCount
+end interface ncclCommCount
+!End ncclCommCount
+
+!Start ncclCommDestroy
+interface ncclCommDestroy
+subroutine ncclCommDestroy(comm) bind(c, name = 'ncclCommDestroy')
+import :: ncclComm
+implicit none
+type(ncclComm), value :: comm
+end subroutine ncclCommDestroy
+end interface ncclCommDestroy
+!End ncclCommDestroy
+
+!Start ncclReduce
+interface ncclReduce
+type(ncclResult) function ncclReduce(sendbuff, recvbuff, count, datatype, op, root, comm, stream) bind(c, name = 'ncclReduce')
+import :: c_int
+import :: c_devptr, cuda_stream_kind
+import :: ncclResult, ncclComm, ncclDataType, ncclRedOp
+implicit none
+type(c_devptr), value :: sendbuff
+type(c_devptr), value :: recvbuff
+integer(c_int), value :: count
+type(ncclDataType), value :: datatype
+type(ncclRedOp), value :: op
+integer(c_int), value :: root
+type(ncclComm), value :: comm
+integer(cuda_stream_kind), value :: stream
+end function ncclReduce
+end interface ncclReduce
+!End ncclReduce
+
+!Start ncclAllReduce
+interface ncclAllReduce
+type(ncclResult) function ncclAllReduce(sendbuff, recvbuff, count, datatype, op, comm, stream) bind(c, name = 'ncclAllReduce')
+import :: c_int
+import :: c_devptr, cuda_stream_kind
+import :: ncclResult, ncclComm, ncclDataType, ncclRedOp
+implicit none
+type(c_devptr), value :: sendbuff
+type(c_devptr), value :: recvbuff
+integer(c_int), value :: count
+type(ncclDataType), value :: datatype
+type(ncclRedOp), value :: op
+type(ncclComm), value :: comm
+integer(cuda_stream_kind), value :: stream
+end function ncclAllReduce
+end interface ncclAllReduce
+!End ncclAllReduce
+
+!Start ncclReduceScatter
+interface ncclReduceScatter
+type(ncclResult) function ncclReduceScatter(sendbuff, recvbuff, recvcount, datatype, op, comm, stream) bind(c, name = 'ncclReduceScatter')
+import :: c_int
+import :: c_devptr, cuda_stream_kind
+import :: ncclResult, ncclComm, ncclDataType, ncclRedOp
+implicit none
+type(c_devptr), value :: sendbuff
+type(c_devptr), value :: recvbuff
+integer(c_int), value :: recvcount
+type(ncclDataType), value :: datatype
+type(ncclRedOp), value :: op
+type(ncclComm), value :: comm
+integer(cuda_stream_kind), value :: stream
+end function ncclReduceScatter
+end interface ncclReduceScatter
+!End ncclReduceScatter
+
+!Start ncclBcast
+interface ncclBcast
+type(ncclResult) function ncclBcast(buff, count, datatype, root, comm, stream) bind(c, name = 'ncclBcast')
+import :: c_int
+import :: c_devptr, cuda_stream_kind
+import :: ncclResult, ncclComm, ncclDataType
+implicit none
+type(c_devptr), value :: buff
+integer(c_int), value :: count
+type(ncclDataType), value :: datatype
+integer(c_int), value :: root
+type(ncclComm), value :: comm
+integer(cuda_stream_kind), value :: stream
+end function ncclBcast
+end interface ncclBcast
+!End ncclBcast
+
+!Start ncclAllGather
+interface ncclAllGather
+type(ncclResult) function ncclAllGather(sendbuff, count, datatype, recvbuff, comm, stream) bind(c, name = 'ncclAllGather')
+import :: c_int
+import :: c_devptr, cuda_stream_kind
+import :: ncclResult, ncclComm, ncclDataType
+implicit none
+type(c_devptr), value :: sendbuff
+integer(c_int), value :: count
+type(ncclDataType), value :: datatype
+type(c_devptr), value :: recvbuff
+type(ncclComm), value :: comm
+integer(cuda_stream_kind), value :: stream
+end function ncclAllGather
+end interface ncclAllGather
+!End ncclAllGather
+
+!End interfaces
+
+end module ncclFor
+!End nccl module

--- a/fortran/src/ncclfor.f90
+++ b/fortran/src/ncclfor.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 !Start defines
 #define NCCL_UNIQUE_ID_BYTES 128
 !End defines

--- a/fortran/test/allgather_arr_out.f90
+++ b/fortran/test/allgather_arr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/allgather_arr_out.f90
+++ b/fortran/test/allgather_arr_out.f90
@@ -1,0 +1,155 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable :: hostBuff(:, :)
+real(real32), allocatable, device :: sendBuff(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+real(real32), allocatable, device :: recvBuff(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl * nDev, nDev + 1))
+
+  call random_number(hostBuff)
+
+  print "(a)", "before allgather:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs sendbuff = ", err
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(sendBuff(nEl))
+    sendBuffPtr(i) = c_devloc(sendBuff)
+    sendBuff = hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(recvBuff(nEl * nDev))
+    recvBuffPtr(i) = c_devloc(recvBuff)
+    recvBuff = hostBuff(:, i)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclAllGather(sendBuffPtr(i), nEl, dataType, recvBuffPtr(i), comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl * nDev])
+    hostBuff(:, i) = recvBuff
+  end do
+
+  print "(a)", ""
+  print "(a)", "after allgather:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs sendbuff = ", err
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    hostBuff((i - 1) * nEl + 1:i * nEl, 1) = sendBuff
+  end do
+
+  err = maxval(abs(hostBuff(:, 1) / hostBuff(:, nDev + 1) - 1.0_real32))
+  print "(a)", ""
+  print "(a, e11.4e2)", "maximum error in sendbuff = ", err
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl * nDev])
+    deallocate(recvBuff)
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    deallocate(sendBuff)
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/allgather_ptr_out.f90
+++ b/fortran/test/allgather_ptr_out.f90
@@ -1,0 +1,164 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable, target :: hostBuff(:, :)
+type(c_ptr), allocatable :: hostBuffPtr(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl * nDev, nDev + 1))
+
+  call random_number(hostBuff)
+
+  print "(a)", "before allgather:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs sendbuff = ", err
+  end do
+
+  allocate(hostBuffPtr(nDev))
+
+  do i = 1, nDev
+    hostBuffPtr(i) = c_loc(hostBuff((i - 1) * nEl + 1, nDev + 1))
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    hostBuffPtr(i) = c_loc(hostBuff(1, i))
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclAllGather(sendBuffPtr(i), nEl, dataType, recvBuffPtr(i), comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyDeviceToHost)
+  end do
+
+  print "(a)", ""
+  print "(a)", "after allgather:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs sendbuff = ", err
+  end do
+
+  do i = 1, nDev
+    hostBuffPtr(i) = c_loc(hostBuff((i - 1) * nEl + 1, 1))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+  end do
+
+  err = maxval(abs(hostBuff(:, 1) / hostBuff(:, nDev + 1) - 1.0_real32))
+  print "(a)", ""
+  print "(a, e11.4e2)", "maximum error in sendbuff = ", err
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(recvBuffPtr(i))
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(sendBuffPtr(i))
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/allgather_ptr_out.f90
+++ b/fortran/test/allgather_ptr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/allreduce_arr_out.f90
+++ b/fortran/test/allreduce_arr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/allreduce_arr_out.f90
+++ b/fortran/test/allreduce_arr_out.f90
@@ -1,0 +1,158 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable :: hostBuff(:, :)
+real(real32), allocatable, device :: sendBuff(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+real(real32), allocatable, device :: recvBuff(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before allreduce:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(sendBuff(nEl))
+    sendBuffPtr(i) = c_devloc(sendBuff)
+    sendBuff = hostBuff(:, i)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(recvBuff(nEl))
+    recvBuffPtr(i) = c_devloc(recvBuff)
+    recvBuff = hostBuff(:, i)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclAllReduce(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  print "(a)", ""
+  print "(a)", "after allreduce:"
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+    hostBuff(:, nDev + 1) = recvBuff
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    hostBuff(:, nDev + 1) = sendBuff
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+    deallocate(recvBuff)
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    deallocate(sendBuff)
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/allreduce_ptr_out.f90
+++ b/fortran/test/allreduce_ptr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/allreduce_ptr_out.f90
+++ b/fortran/test/allreduce_ptr_out.f90
@@ -1,0 +1,159 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable, target :: hostBuff(:, :)
+type(c_ptr), allocatable :: hostBuffPtr(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before allreduce:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  allocate(hostBuffPtr(nDev + 1))
+
+  do i = 1, nDev + 1
+    hostBuffPtr(i) = c_loc(hostBuff(1, i))
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclAllReduce(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  print "(a)", ""
+  print "(a)", "after allreduce:"
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(recvBuffPtr(i))
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(sendBuffPtr(i))
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/broadcast_arr.f90
+++ b/fortran/test/broadcast_arr.f90
@@ -1,0 +1,130 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev, root
+type(ncclDataType) :: dataType
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable :: hostBuff(:, :)
+real(real32), allocatable, device :: devBuff(:)
+type(c_devptr), allocatable :: devBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+!  root = 0
+  stat = cudaGetDeviceCount(nDev)
+  root = nDev - 1
+
+  dataType = ncclFloat
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 1))
+
+  call random_number(hostBuff(:, 1:nDev))
+
+  hostBuff(:, nDev + 1) = hostBuff(:, root + 1)
+
+  print "(a)", "before broadcast:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs root (rank ", root,") = ", err
+  end do
+
+  allocate(devBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(devBuff(nEl))
+    devBuffPtr(i) = c_devloc(devBuff)
+    devBuff = hostBuff(:, i)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclBcast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(devBuffPtr(i), devBuff, [nEl])
+    hostBuff(:, i) = devBuff
+  end do
+
+  print "(a)", ""
+  print "(a)", "after broadcast:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs root (rank ", root,") = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(devBuffPtr(i), devBuff, [nEl])
+    deallocate(devBuff)
+  end do
+
+  deallocate(devBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/broadcast_arr.f90
+++ b/fortran/test/broadcast_arr.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/broadcast_ptr.f90
+++ b/fortran/test/broadcast_ptr.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/broadcast_ptr.f90
+++ b/fortran/test/broadcast_ptr.f90
@@ -1,0 +1,135 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev, root
+type(ncclDataType) :: dataType
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable, target :: hostBuff(:, :)
+type(c_ptr), allocatable :: hostBuffPtr(:)
+type(c_devptr), allocatable :: devBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+!  root = 0
+  stat = cudaGetDeviceCount(nDev)
+  root = nDev - 1
+
+  dataType = ncclFloat
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 1))
+
+  call random_number(hostBuff(:, 1:nDev))
+
+  hostBuff(:, nDev + 1) = hostBuff(:, root + 1)
+
+  print "(a)", "before broadcast:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs root (rank ", root,") = ", err
+  end do
+
+  allocate(hostBuffPtr(nDev))
+
+  do i = 1, nDev
+    hostBuffPtr(i) = c_loc(hostBuff(1, i))
+  end do
+
+  allocate(devBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(devBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclBcast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(i), devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+  end do
+
+  print "(a)", ""
+  print "(a)", "after broadcast:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff(:, i) / hostBuff(:, nDev + 1) - 1.0_real32))
+    print "(a, i2.2, a, i2.2, a, e11.4e2)", "maximum error of rank ", i - 1, " vs root (rank ", root,") = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(devBuffPtr(i))
+  end do
+
+  deallocate(devBuffPtr)
+
+  deallocate(hostBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/reduce_arr_out.f90
+++ b/fortran/test/reduce_arr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/reduce_arr_out.f90
+++ b/fortran/test/reduce_arr_out.f90
@@ -125,17 +125,6 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
   end do
-
-  print "(a)", ""
-  do i = 1, nDev
-    if (i - 1 /= root) then
-      stat = cudaSetDevice(devList(i))
-      call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
-      hostBuff(:, nDev + 1) = recvBuff
-      err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
-      print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff of rank ", i - 1," = ", err
-    end if
-  end do
   print "(a)", ""
 
   do i = 1, nDev

--- a/fortran/test/reduce_arr_out.f90
+++ b/fortran/test/reduce_arr_out.f90
@@ -1,0 +1,168 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev, root
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable :: hostBuff(:, :)
+real(real32), allocatable, device :: sendBuff(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+real(real32), allocatable, device :: recvBuff(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+!  root = 0
+  stat = cudaGetDeviceCount(nDev)
+  root = nDev - 1
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before reduce:"
+  err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+  print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from root (rank ", root,") = ", err
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(sendBuff(nEl))
+    sendBuffPtr(i) = c_devloc(sendBuff)
+    sendBuff = hostBuff(:, i)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(recvBuff(nEl))
+    recvBuffPtr(i) = c_devloc(recvBuff)
+    recvBuff = hostBuff(:, i)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclReduce(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, root, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  stat = cudaSetDevice(devList(root + 1))
+  call c_f_pointer(recvBuffPtr(root + 1), recvBuff, [nEl])
+  hostBuff(:, nDev + 1) = recvBuff
+
+  print "(a)", ""
+  print "(a)", "after reduce:"
+  err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+  print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from root (rank ", root,") = ", err
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    hostBuff(:, nDev + 1) = sendBuff
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    if (i - 1 /= root) then
+      stat = cudaSetDevice(devList(i))
+      call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+      hostBuff(:, nDev + 1) = recvBuff
+      err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+      print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff of rank ", i - 1," = ", err
+    end if
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+    deallocate(recvBuff)
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl])
+    deallocate(sendBuff)
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/reduce_ptr_out.f90
+++ b/fortran/test/reduce_ptr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/reduce_ptr_out.f90
+++ b/fortran/test/reduce_ptr_out.f90
@@ -126,16 +126,6 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
   end do
-
-  print "(a)", ""
-  do i = 1, nDev
-    if (i - 1 /= root) then
-      stat = cudaSetDevice(devList(i))
-      stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
-      err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
-      print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff of rank ", i - 1," = ", err
-    end if
-  end do
   print "(a)", ""
 
   do i = 1, nDev

--- a/fortran/test/reduce_ptr_out.f90
+++ b/fortran/test/reduce_ptr_out.f90
@@ -1,0 +1,168 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev, root
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable, target :: hostBuff(:, :)
+type(c_ptr), allocatable :: hostBuffPtr(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+!  root = 0
+  stat = cudaGetDeviceCount(nDev)
+  root = nDev - 1
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before reduce:"
+  err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+  print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from root (rank ", root,") = ", err
+
+  allocate(hostBuffPtr(nDev + 1))
+
+  do i = 1, nDev + 1
+    hostBuffPtr(i) = c_loc(hostBuff(1, i))
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclReduce(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, root, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  stat = cudaSetDevice(devList(root + 1))
+  stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(root + 1), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+
+  print "(a)", ""
+  print "(a)", "after reduce:"
+  err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
+  print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from root (rank ", root,") = ", err
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    if (i - 1 /= root) then
+      stat = cudaSetDevice(devList(i))
+      stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+      err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+      print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff of rank ", i - 1," = ", err
+    end if
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(recvBuffPtr(i))
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(sendBuffPtr(i))
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/reducescatter_arr_out.f90
+++ b/fortran/test/reducescatter_arr_out.f90
@@ -1,0 +1,158 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable :: hostBuff(:, :)
+real(real32), allocatable, device :: sendBuff(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+real(real32), allocatable, device :: recvBuff(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl * nDev, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before reducescatter:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) / hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(sendBuff(nEl * nDev))
+    sendBuffPtr(i) = c_devloc(sendBuff)
+    sendBuff = hostBuff(:, i)
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    allocate(recvBuff(nEl))
+    recvBuffPtr(i) = c_devloc(recvBuff)
+    recvBuff = hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclReduceScatter(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  print "(a)", ""
+  print "(a)", "after reducescatter:"
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+    hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) = recvBuff
+    err = maxval(abs(hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) / hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl * nDev])
+    hostBuff(:, nDev + 1) = sendBuff
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(recvBuffPtr(i), recvBuff, [nEl])
+    deallocate(recvBuff)
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    call c_f_pointer(sendBuffPtr(i), sendBuff, [nEl * nDev])
+    deallocate(sendBuff)
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/fortran/test/reducescatter_arr_out.f90
+++ b/fortran/test/reducescatter_arr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/reducescatter_ptr_out.f90
+++ b/fortran/test/reducescatter_ptr_out.f90
@@ -1,3 +1,10 @@
+!*************************************************************************
+!* Copyright (c) 2016 Research Computing Services (RCS), University of
+!* Cambridge. All rights reserved.
+!*
+!* See LICENSE.txt for license information
+!*************************************************************************
+
 program test
 use iso_c_binding
 use iso_fortran_env

--- a/fortran/test/reducescatter_ptr_out.f90
+++ b/fortran/test/reducescatter_ptr_out.f90
@@ -1,0 +1,167 @@
+program test
+use iso_c_binding
+use iso_fortran_env
+use cudaFor
+use ncclFor
+implicit none
+integer(int32) :: stat, i
+real(real32) :: err
+integer(int32) :: nEl, nDev
+type(ncclDataType) :: dataType
+type(ncclRedOp) :: redOp
+type(ncclComm), allocatable :: comm(:)
+integer(int32), allocatable :: devList(:)
+type(ncclResult) :: res
+integer(int32) :: cudaDev, rank
+integer(cuda_stream_kind), allocatable :: stream(:)
+integer(int32) :: time(8)
+integer(int32), allocatable :: seed(:)
+real(real32), allocatable, target :: hostBuff(:, :)
+type(c_ptr), allocatable :: hostBuffPtr(:)
+type(c_devptr), allocatable :: sendBuffPtr(:)
+type(c_devptr), allocatable :: recvBuffPtr(:)
+
+  nEl = 2621440
+
+!  nDev = 2
+  stat = cudaGetDeviceCount(nDev)
+
+  dataType = ncclFloat
+  redOp = ncclProd
+
+  allocate(comm(nDev))
+  allocate(devList(nDev))
+
+  do i = 1, nDev
+    devList(i) = i - 1
+  end do
+
+  res = ncclCommInitAll(comm, nDev, devList)
+
+  do i = 1, nDev
+    res = ncclCommCuDevice(comm(i), cudaDev)
+    res = ncclCommUserRank(comm(i), rank)
+  end do
+
+  allocate(stream(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamCreate(stream(i))
+  end do
+
+  call date_and_time(values = time)
+  call random_seed(size = i)
+  allocate(seed(i))
+  call random_seed(get = seed)
+  seed = 60 * 60 * 1000 * time(5) + 60 * 1000 * time(6) + 1000 * time(7) + time(8) - seed
+  call random_seed(put = seed)
+
+  allocate(hostBuff(nEl * nDev, nDev + 2))
+
+  call random_number(hostBuff(:, 1:nDev + 1))
+
+  hostBuff(:, nDev + 2) = hostBuff(:, 1)
+  do i = 2, nDev
+    hostBuff(:, nDev + 2) = hostBuff(:, nDev + 2) * hostBuff(:, i)
+  end do
+
+  print "(a)", "before reducescatter:"
+  do i = 1, nDev
+    err = maxval(abs(hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) / hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  allocate(hostBuffPtr(nDev + 1))
+
+  do i = 1, nDev + 1
+    hostBuffPtr(i) = c_loc(hostBuff(1, i))
+  end do
+
+  allocate(sendBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    hostBuffPtr(i) = c_loc(hostBuff((i - 1) * nEl + 1, nDev + 1))
+  end do
+
+  allocate(recvBuffPtr(nDev))
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    res = ncclReduceScatter(sendBuffPtr(i), recvBuffPtr(i), nEl, dataType, redOp, comm(i), stream(i))
+  end do
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamSynchronize(stream(i))
+  end do
+
+  print "(a)", ""
+  print "(a)", "after reduceScatter:"
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
+    err = maxval(abs(hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) / hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 2) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
+  end do
+
+  do i = 1, nDev + 1
+    hostBuffPtr(i) = c_loc(hostBuff(1, nDev + 1))
+  end do
+
+  print "(a)", ""
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaMemcpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyDeviceToHost)
+    err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
+    print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
+  end do
+  print "(a)", ""
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(recvBuffPtr(i))
+  end do
+
+  deallocate(recvBuffPtr)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaFree(sendBuffPtr(i))
+  end do
+
+  deallocate(sendBuffPtr)
+
+  deallocate(hostBuffPtr)
+
+  deallocate(hostBuff)
+
+  deallocate(seed)
+
+  do i = 1, nDev
+    stat = cudaSetDevice(devList(i))
+    stat = cudaStreamDestroy(stream(i))
+  end do
+
+  deallocate(stream)
+
+  do i = 1, nDev
+    call ncclCommDestroy(comm(i))
+  end do
+
+  deallocate(devList)
+  deallocate(comm)
+
+end program test

--- a/generic/FusedRNNKernel.cu
+++ b/generic/FusedRNNKernel.cu
@@ -439,66 +439,8 @@ __global__ void
   }
 }
 
-// *********** START Generate specializations *************** //
-#define EXPAND_FUNCTION(ITYPE, DIM)                                     \
-  template __global__ void THNN_(GRUForward)<DATATYPE, ITYPE, DIM>      \
-    (TensorInfo<DATATYPE, ITYPE> inputI,                                \
-     TensorInfo<DATATYPE, ITYPE> hiddenI,                               \
-     TensorInfo<DATATYPE, ITYPE> bias1I,                                \
-     TensorInfo<DATATYPE, ITYPE> bias2I,                                \
-     TensorInfo<DATATYPE, ITYPE> hxI,                                   \
-     TensorInfo<DATATYPE, ITYPE> hyI,                                   \
-     ITYPE hsz,                                                         \
-     ITYPE totalElements);                                              \
-                                                                        \
-  template void __global__ THNN_(GRUBackward)<DATATYPE, ITYPE, DIM>     \
-    (TensorInfo<DATATYPE, ITYPE> inputI,                                \
-     TensorInfo<DATATYPE, ITYPE> hiddenI,                               \
-     TensorInfo<DATATYPE, ITYPE> gradoutputI,                           \
-     TensorInfo<DATATYPE, ITYPE> gradinputI,                            \
-     ITYPE hsz,                                                         \
-     ITYPE totalElements);                                              \
-                                                                        \
-  template void __global__ THNN_(LSTMForward)<DATATYPE, ITYPE, DIM>     \
-    (TensorInfo<DATATYPE, ITYPE> inputI,                                \
-     TensorInfo<DATATYPE, ITYPE> hiddenI,                               \
-     TensorInfo<DATATYPE, ITYPE> bias1I,                                \
-     TensorInfo<DATATYPE, ITYPE> bias2I,                                \
-     TensorInfo<DATATYPE, ITYPE> cxI,                                   \
-     TensorInfo<DATATYPE, ITYPE> hyI,                                   \
-     TensorInfo<DATATYPE, ITYPE> cyI,                                   \
-     ITYPE hsz,                                                         \
-     ITYPE totalElements);                                              \
-                                                                        \
-  template void __global__ THNN_(LSTMBackward)<DATATYPE, ITYPE, DIM>    \
-    (TensorInfo<DATATYPE, ITYPE> inputI,                                \
-     TensorInfo<DATATYPE, ITYPE> hiddenI,                               \
-     TensorInfo<DATATYPE, ITYPE> cxI,                                   \
-     TensorInfo<DATATYPE, ITYPE> cyI,                                   \
-     TensorInfo<DATATYPE, ITYPE> gradoutputI,                           \
-     TensorInfo<DATATYPE, ITYPE> gradoutputcellI,                       \
-     TensorInfo<DATATYPE, ITYPE> gradinputI,                            \
-     ITYPE hsz,                                                         \
-     ITYPE totalElements);                                              \
 
-
-#define EXPAND_DIM(ITYPE)                            \
-  EXPAND_FUNCTION(ITYPE, -2)                         \
-  EXPAND_FUNCTION(ITYPE, -1)                         \
-  EXPAND_FUNCTION(ITYPE, 1)                          \
-  EXPAND_FUNCTION(ITYPE, 2)                          \
-
-
-#define EXPAND_TYPE                        \
-  EXPAND_DIM(unsigned int)                 \
-  EXPAND_DIM(unsigned long)                \
-
-
-EXPAND_TYPE
-
-// ************ END generating specializations ************** //
-
-// ************ START Create actual function calls ********** //
+// ************ START Create function calls ********** //
 #define FILL_FUNCTION(ITYPE, DIM, FUNCTION) FUNCTION(ITYPE, DIM)
 
 #define FILL_DIM(ITYPE, DIM, FUNCTION)          \

--- a/generic/Sigmoid.c
+++ b/generic/Sigmoid.c
@@ -7,11 +7,7 @@ void THNN_(Sigmoid_updateOutput)(
           THTensor *input,
           THTensor *output)
 {
-  THTensor_(resizeAs)(output, input);
-
-  TH_TENSOR_APPLY2(real, output, real, input,
-    *output_data = 1./(1.+ exp(- *input_data));
-  );
+  THTensor_(sigmoid)(output, input);
 }
 
 void THNN_(Sigmoid_updateGradInput)(
@@ -21,7 +17,7 @@ void THNN_(Sigmoid_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
-  THNN_CHECK_NELEMENT(input, gradOutput);
+  THNN_CHECK_NELEMENT(output, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, output,
     real z = *output_data;

--- a/generic/Sigmoid.cu
+++ b/generic/Sigmoid.cu
@@ -10,8 +10,7 @@ void THNN_(Sigmoid_updateOutput)(
            THCTensor *output)
 {
   THCUNN_assertSameGPU(state, 2, input, output);
-  THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, sigmoidupdateOutput_functor<real>());
+  THCTensor_(sigmoid)(state, output, input);
 }
 
 void THNN_(Sigmoid_updateGradInput)(
@@ -24,7 +23,7 @@ void THNN_(Sigmoid_updateGradInput)(
   THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, sigmoidupdateGradInput_functor<real>());
+  THC_pointwiseApply3(state, gradInput, output, gradOutput, SigmoidGradInputOp<real>());
 }
 
 #endif

--- a/generic/Sigmoid.cu
+++ b/generic/Sigmoid.cu
@@ -20,10 +20,10 @@ void THNN_(Sigmoid_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
-  THCUNN_check_nElement(state, input, gradOutput);
+  THCUNN_check_nElement(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, SigmoidGradInputOp<real>());
+  THC_pointwiseApply3(state, gradInput, output, gradOutput, sigmoid_updateGradInput_functor<real>());
 }
 
 #endif

--- a/generic/THCUNN.h
+++ b/generic/THCUNN.h
@@ -911,7 +911,7 @@ TH_API void THNN_(Sigmoid_updateOutput)(
 
 TH_API void THNN_(Sigmoid_updateGradInput)(
                   THCState *state,
-                  THCTensor *input,
+                  THCTensor *input,          // [OPTIONAL]
                   THCTensor *gradOutput,
                   THCTensor *gradInput,
                   THCTensor *output);
@@ -1002,7 +1002,7 @@ TH_API void THNN_(Tanh_updateOutput)(
 
 TH_API void THNN_(Tanh_updateGradInput)(
                   THCState *state,
-                  THCTensor *input,
+                  THCTensor *input,          // [OPTIONAL]
                   THCTensor *gradOutput,
                   THCTensor *gradInput,
                   THCTensor *output);

--- a/generic/THNN.h
+++ b/generic/THNN.h
@@ -398,7 +398,7 @@ TH_API void THNN_(Sigmoid_updateOutput)(
           THTensor *output);
 TH_API void THNN_(Sigmoid_updateGradInput)(
           THNNState *state,
-          THTensor *input,
+          THTensor *input,             // [OPTIONAL]
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output);
@@ -593,7 +593,7 @@ TH_API void THNN_(Tanh_updateOutput)(
           THTensor *output);
 TH_API void THNN_(Tanh_updateGradInput)(
           THNNState *state,
-          THTensor *input,
+          THTensor *input,             // [OPTIONAL]
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output);

--- a/generic/Tanh.c
+++ b/generic/Tanh.c
@@ -7,7 +7,6 @@ void THNN_(Tanh_updateOutput)(
           THTensor *input,
           THTensor *output)
 {
-  THTensor_(resizeAs)(output, input);
   THTensor_(tanh)(output, input);
 }
 
@@ -21,8 +20,8 @@ void THNN_(Tanh_updateGradInput)(
   THNN_CHECK_SHAPE(output, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
 
-  if (output->nDimension == 1 || 
-      !THTensor_(isContiguous)(output) || 
+  if (output->nDimension == 1 ||
+      !THTensor_(isContiguous)(output) ||
       !THTensor_(isContiguous)(gradOutput) ||
       !THTensor_(isContiguous)(gradInput))
   {

--- a/generic/Tanh.cu
+++ b/generic/Tanh.cu
@@ -11,7 +11,7 @@ void THNN_(Tanh_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, tanhupdateOutput_functor<real>());
+  THCTensor_(tanh)(state, output, input);
 }
 
 void THNN_(Tanh_updateGradInput)(
@@ -24,7 +24,7 @@ void THNN_(Tanh_updateGradInput)(
   THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, tanhupdateGradInput_functor<real>());
+  THC_pointwiseApply3(state, gradInput, output, gradOutput, TanhGradInputOp<real>());
 }
 
 #endif

--- a/generic/Tanh.cu
+++ b/generic/Tanh.cu
@@ -24,7 +24,7 @@ void THNN_(Tanh_updateGradInput)(
   THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, TanhGradInputOp<real>());
+  THC_pointwiseApply3(state, gradInput, output, gradOutput, tanh_updateGradInput_functor<real>());
 }
 
 #endif

--- a/src/common_coll.h
+++ b/src/common_coll.h
@@ -1,0 +1,118 @@
+/*************************************************************************
+ * Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef COMMON_COLL_H_
+#define COMMON_COLL_H_
+
+#include "core.h"
+
+static ncclResult_t PointerCheck(const void* pointer, struct ncclComm* comm, const char* ptrname, const char* opname) {
+  cudaPointerAttributes attr;
+  cudaError_t err = cudaPointerGetAttributes(&attr, pointer);
+  if (err != cudaSuccess || attr.devicePointer == NULL) {
+    WARN("%s : %s is not a valid pointer\n", opname, ptrname);
+    return ncclInvalidDevicePointer;
+  }
+  if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
+    WARN("%s : %s allocated on device %d mismatchs with NCCL device %d \n", opname, ptrname, attr.device, comm->cudaDev);
+    return ncclInvalidDevicePointer;
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t PtrCheck(void* ptr, const char* opname, const char* ptrname) {
+  if (ptr == NULL) {
+    WARN("%s : %s argument is NULL", opname, ptrname);
+    return ncclInvalidArgument;
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t ArgsCheck(const void* sendbuff, const void* recvbuff, int count, ncclDataType_t type, ncclRedOp_t op, int root, struct ncclComm* comm, const char* opname) {
+  NCCLCHECK(PtrCheck(comm, opname, "comm"));
+  // First, the easy ones
+  if (root < 0 || root >= comm->nRanks) {
+    WARN("%s : invalid root %d (root should be in the 0..%d range)\n", opname, root, comm->nRanks);
+    return ncclInvalidRank;
+  }
+  if (type < 0 || type >= nccl_NUM_TYPES) {
+    WARN("%s : invalid type %d\n", opname, type);
+    return ncclInvalidType;
+  }
+  if (op < 0 || op >= nccl_NUM_OPS) {
+    WARN("%s : invalid reduction operation %d\n", opname, op);
+    return ncclInvalidOperation;
+  }
+  if (count < 0) {
+    WARN("%s : invalid count %d\n", opname, count);
+    return ncclInvalidArgument;
+  }
+
+  // Check pointers
+  NCCLCHECK(PointerCheck(sendbuff, comm, "sendbuff", opname))
+  if (strcmp(opname, "Reduce") == 0 && comm->rank != root) {
+    // No need to check recvbuff pointer for non-root reduce
+    return ncclSuccess;
+  }
+  NCCLCHECK(PointerCheck(recvbuff, comm, "recvbuff", opname))
+  return ncclSuccess;
+}
+
+// Kernel launch
+template<typename T>
+struct KernelArgs {
+  // general parameters
+  int nRanks;
+  int root;
+  int buffSize;
+  int N;
+  int opIndex;
+  volatile int * __restrict__ opCounter;
+  int * __restrict__ doneCount;
+  bool pushrecv;
+
+  // some pre-computed sizes
+  int SliceSize;
+  int SliceOffset;
+  int ChunkSize;
+  int NumChunks;
+
+  // local and remote input, output, and buffer
+  const T * __restrict__ ThisInput;
+  T * __restrict__ ThisOutput;
+
+  DevRing<char>* ring;
+  int nRings;
+};
+
+template<typename T>
+void ArgsSetup(KernelArgs<T> *args, const void* sendbuff, void* recvbuff,
+		const int root, const int count, ncclComm *comm) {
+  args->nRanks = comm->nRanks;
+  args->root = root;
+  args->buffSize = comm->buffSizePerRing;
+  args->N = count;
+  args->opIndex = comm->opSched;
+  args->opCounter = comm->opCounter;
+  args->doneCount = &comm->devMem->doneCount;
+  args->ThisInput = (const T*)sendbuff;
+  args->ThisOutput = (T*)recvbuff;
+  args->ring = comm->devRing;
+  args->pushrecv = comm->globalMemSpace;
+  args->nRings = comm->nRings;
+}
+
+#define LAUNCH_KERNEL(K, THREADS, UNROLL, FUNC, T, \
+		args, stream) do { \
+  dim3 grid(args.nRings, 1, 1); \
+  dim3 block(THREADS+1, 1, 1); \
+  void* argptrs[] = {&args}; \
+  CUDACHECK(cudaLaunchKernel( \
+            (void*)K<THREADS, UNROLL, FUNC, T>, \
+            grid, block, argptrs, 0, stream), ncclUnhandledCudaError); \
+} while (0)
+
+#endif

--- a/src/common_coll.h
+++ b/src/common_coll.h
@@ -85,7 +85,6 @@ struct KernelArgs {
   T * __restrict__ ThisOutput;
 
   DevRing<char>* ring;
-  int nRings;
 };
 
 template<typename T>
@@ -93,21 +92,19 @@ void ArgsSetup(KernelArgs<T> *args, const void* sendbuff, void* recvbuff,
 		const int root, const int count, ncclComm *comm) {
   args->nRanks = comm->nRanks;
   args->root = root;
-  args->buffSize = comm->buffSizePerRing;
+  args->buffSize = comm->buffSize;
   args->N = count;
   args->opIndex = comm->opSched;
   args->opCounter = comm->opCounter;
-  args->doneCount = &comm->devMem->doneCount;
   args->ThisInput = (const T*)sendbuff;
   args->ThisOutput = (T*)recvbuff;
   args->ring = comm->devRing;
   args->pushrecv = comm->globalMemSpace;
-  args->nRings = comm->nRings;
 }
 
 #define LAUNCH_KERNEL(K, THREADS, UNROLL, FUNC, T, \
 		args, stream) do { \
-  dim3 grid(args.nRings, 1, 1); \
+  dim3 grid(1, 1, 1); \
   dim3 block(THREADS+1, 1, 1); \
   void* argptrs[] = {&args}; \
   CUDACHECK(cudaLaunchKernel( \

--- a/src/common_kernel.h
+++ b/src/common_kernel.h
@@ -30,6 +30,32 @@
 #define BAR(type, barid, nthreads) \
     BAR_EXPAND(type, barid, ROUNDUP(nthreads, WARP_SIZE))
 
+template<typename T> inline __device__
+T vFetch(const volatile T* ptr) {
+  return *ptr;
+}
+
+#ifdef CUDA_HAS_HALF
+template<> inline __device__
+half vFetch<half>(const volatile half* ptr) {
+  half r;
+  r.x = ptr->x;
+  return r;
+}
+#endif
+
+template<typename T> inline __device__
+void vStore(volatile T* ptr, const T val) {
+  *ptr = val;
+}
+
+#ifdef CUDA_HAS_HALF
+template<> inline __device__
+void vStore<half>(volatile half* ptr, const half val) {
+  ptr->x = val.x;
+}
+#endif
+
 __device__ unsigned int spinct;
 
 // Spin wait until func evaluates to true
@@ -224,32 +250,6 @@ __device__ inline volatile T* AlignUp(volatile T * ptr, size_t align) {
   size_t ptrval = reinterpret_cast<size_t>(ptr);
   return reinterpret_cast<volatile T*>(ALIGNUP(ptrval, align));
 }
-
-template<typename T> inline __device__
-T vFetch(const volatile T* ptr) {
-  return *ptr;
-}
-
-#ifdef CUDA_HAS_HALF
-template<> inline __device__
-half vFetch<half>(const volatile half* ptr) {
-  half r;
-  r.x = ptr->x;
-  return r;
-}
-#endif
-
-template<typename T> inline __device__
-void vStore(volatile T* ptr, const T val) {
-  *ptr = val;
-}
-
-#ifdef CUDA_HAS_HALF
-template<> inline __device__
-void vStore<half>(volatile half* ptr, const half val) {
-  ptr->x = val.x;
-}
-#endif
 
 // Assumptions:
 // - there is exactly 1 block

--- a/src/common_kernel.h
+++ b/src/common_kernel.h
@@ -174,32 +174,46 @@ struct MULTI<FUNC, long long> {
   }
 };
 
-template<typename T, bool FETCHTWO>
-__device__ inline void FetchOneOrTwo64b(PackType& s0,
-    const volatile T * __restrict__ const src0, PackType& s1,
-    const volatile T * __restrict__ const src1, const int idx) {
-  s0 = (reinterpret_cast<const volatile PackType *>(src0))[idx];
-  if (FETCHTWO) {
-    s1 = (reinterpret_cast<const volatile PackType *>(src1))[idx];
+template<class FUNC, typename T, bool TWO_INPUTS, bool TWO_OUTPUTS>
+__device__ inline void ReduceCopy(
+    const volatile T * __restrict__ const src0,
+    const volatile T * __restrict__ const src1,
+    volatile T * __restrict__ const dest0,
+    volatile T * __restrict__ const dest1, const int idx) {
+  T val = vFetch(src0+idx);
+  if (TWO_INPUTS) {
+    val = FUNC()(val, vFetch(src1+idx));
+  }
+  vStore(dest0+idx, val);
+  if (TWO_OUTPUTS) {
+    vStore(dest1+idx, val);
   }
 }
 
-template<typename T, bool STORETWO>
-__device__ inline void StoreOneOrTwo64b(volatile T * __restrict__ const dest0,
-    volatile T * __restrict__ const dest1, PackType val, const int idx) {
-  (reinterpret_cast<volatile PackType *>(dest0))[idx] = val;
-  if (STORETWO) {
-    (reinterpret_cast<volatile PackType *>(dest1))[idx] = val;
+template<class FUNC, typename T, bool TWO_INPUTS, bool TWO_OUTPUTS, int UNROLL, int THREADS>
+__device__ inline void ReduceCopy64b(
+    const volatile T * __restrict__ const src0,
+    const volatile T * __restrict__ const src1,
+    volatile T * __restrict__ const dest0,
+    volatile T * __restrict__ const dest1, const int offset) {
+  PackType t0[UNROLL];
+  PackType t1[UNROLL];
+  #pragma unroll
+  for (int u = 0; u < UNROLL; ++u) {
+    int idx = offset + u*THREADS;
+    t0[u] = (reinterpret_cast<const volatile PackType *>(src0))[idx];
+    if (TWO_INPUTS) {
+      t1[u] = (reinterpret_cast<const volatile PackType *>(src1))[idx];
+    }
   }
-}
-
-template<class FUNC, typename T, bool ISREDUCE>
-__device__ inline PackType ReduceOrCopy64b(const PackType s0,
-    const PackType s1) {
-  if (ISREDUCE) {
-    return MULTI<FUNC, T>()(s0, s1);
-  } else {
-    return s0;
+  #pragma unroll
+  for (int u = 0; u < UNROLL; ++u) {
+    int idx = offset + u*THREADS;
+    PackType val = TWO_INPUTS ? MULTI<FUNC, T>()(t0[u], t1[u]) : t0[u];
+    (reinterpret_cast<volatile PackType *>(dest0))[idx] = val;
+    if (TWO_OUTPUTS) {
+      (reinterpret_cast<volatile PackType *>(dest1))[idx] = val;
+    }
   }
 }
 
@@ -251,9 +265,6 @@ __device__ inline void ReduceOrCopy(const int tid,
     return;
   }
 
-  const int UNROLL2 = (UNROLL >= 2) ? (UNROLL / 2) : 1;
-  const bool NOUNROLL2 = ((UNROLL / 2) == 0);
-
   int Npreamble = (N<alignof(PackType)) ? N : AlignUp(dest0, alignof(PackType)) - dest0;
 
   // stage 0: check if we'll be able to use the fast, 64-bit aligned path.
@@ -266,246 +277,59 @@ __device__ inline void ReduceOrCopy(const int tid,
     Npreamble = N;
   }
 
-/*
-  if (threadIdx.x == 0) {
-    printf("** alignable: %s", (alignable ? "YES" : " NO"));
-    printf(", dest0 = 0x%08X", dest0);
-    printf(", src0 = 0x%08X", src0);
-    if (HAS_DEST1) printf(", dest1 = 0x%08X", dest1);
-    if (HAS_SRC1) printf(", src1 = 0x%08X", src1);
-    printf("\n");
-  }
-*/
-
   // stage 1: preamble: handle any elements up to the point of everything coming
   // into alignment
   for (int idx = tid; idx < Npreamble; idx += THREADS) {
     // ought to be no way this is ever more than one iteration, except when
     // alignable is false
-    T val = vFetch(src0+idx);
-    if (HAS_SRC1) {
-      val = FUNC()(val, vFetch(src1+idx));
-    }
-
-    vStore(dest0+idx, val);
-    if (HAS_DEST1) {
-      vStore(dest1+idx, val);
-    }
+    ReduceCopy<FUNC, T, HAS_SRC1, HAS_DEST1>(src0, src1, dest0, dest1, idx);
   }
-
-  // reduce N by however many elements we've handled already
-  int Ndone = Npreamble;
-  int Nrem = N - Ndone;
 
   // stage 2: fast path: use 64b loads/stores to do the bulk of the work,
   // assuming the pointers we have are all 64-bit alignable.
   if (alignable) {
-    if (Ndone > 0) {
-      // align up pointers
-      dest0 += Ndone; if (HAS_DEST1) { dest1 += Ndone; }
-      src0  += Ndone; if (HAS_SRC1)  { src1  += Ndone; }
-    }
+    const int PackFactor = sizeof(PackType) / sizeof(T);
+    int Nrem = N - Npreamble;
+    dest0 += Npreamble; if (HAS_DEST1) { dest1 += Npreamble; }
+    src0  += Npreamble; if (HAS_SRC1)  { src1  += Npreamble; }
 
     // stage 2a: main loop
-    int Nalign = (Nrem / (sizeof(PackType) / sizeof(T)) / (UNROLL * THREADS))
+    int Nalign2a = (Nrem / (PackFactor * UNROLL * THREADS))
         * (UNROLL * THREADS); // round down
 
     #pragma unroll 1 // don't unroll this loop
-    for (int idx = tid; idx < Nalign; idx += UNROLL * THREADS) {
-      PackType t0[UNROLL2];
-      PackType t1[UNROLL2];
-      PackType t2[UNROLL2];
-
-      #pragma unroll
-      for (int j = 0; j < UNROLL2; ++j)
-        FetchOneOrTwo64b<T, HAS_SRC1>(t0[j], src0, t1[j], src1,
-            idx + j * THREADS);
-
-      #pragma unroll
-      for (int j = 0; j < UNROLL2; ++j)
-        t2[j] = ReduceOrCopy64b<FUNC, T, HAS_SRC1>(t0[j], t1[j]);
-
-      if (!NOUNROLL2) {
-        #pragma unroll
-        for (int j = 0; j < UNROLL2; ++j)
-          FetchOneOrTwo64b<T, HAS_SRC1>(t0[j], src0, t1[j], src1,
-              idx + (UNROLL2 + j) * THREADS);
-      }
-
-      #pragma unroll
-      for (int j = 0; j < UNROLL2; ++j)
-        StoreOneOrTwo64b<T, HAS_DEST1>(dest0, dest1, t2[j], idx + j * THREADS);
-
-      if (!NOUNROLL2) {
-        #pragma unroll
-        for (int j = 0; j < UNROLL2; ++j)
-          t2[j] = ReduceOrCopy64b<FUNC, T, HAS_SRC1>(t0[j], t1[j]);
-
-        #pragma unroll
-        for (int j = 0; j < UNROLL2; ++j)
-          StoreOneOrTwo64b<T, HAS_DEST1>(dest0, dest1, t2[j],
-              idx + (UNROLL2 + j) * THREADS);
-      }
+    for (int idx = tid; idx < Nalign2a; idx += UNROLL * THREADS) {
+      ReduceCopy64b<FUNC, T, HAS_SRC1, HAS_DEST1, UNROLL, THREADS>(src0, src1, dest0, dest1, idx);
     }
+
+    int Ndone2a = Nalign2a * PackFactor;
+    Nrem -= Ndone2a;
 
     // stage 2b: slightly less optimized for section when we don't have full
     // UNROLLs
-    int Ndone2a = Nalign * (sizeof(PackType)/sizeof(T));
-    Ndone += Ndone2a;
-    Nrem = N - Ndone;
 
-    // TODO: This kind of pointer update arithmetic is expensive.  Should
-    // probably find a better way.
-    if (Nrem > 0) {
-      dest0 += Ndone2a; if (HAS_DEST1) { dest1 += Ndone2a; }
-      src0  += Ndone2a; if (HAS_SRC1)  { src1  += Ndone2a; }
-    }
-
-    Nalign = Nrem / (sizeof(PackType)/sizeof(T));
+    int Nalign2b = Nrem / PackFactor;
 
     #pragma unroll 4
-    for (int idx = tid; idx < Nalign; idx += THREADS) {
-      PackType t0, t1, t2;
-
-      FetchOneOrTwo64b<T, HAS_SRC1>(t0, src0, t1, src1, idx);
-      t2 = ReduceOrCopy64b<FUNC, T, HAS_SRC1>(t0, t1);
-      StoreOneOrTwo64b<T, HAS_DEST1>(dest0, dest1, t2, idx);
+    for (int idx = Nalign2a + tid; idx < Nalign2a + Nalign2b; idx += THREADS) {
+      ReduceCopy64b<FUNC, T, HAS_SRC1, HAS_DEST1, 1, 0>(src0, src1, dest0, dest1, idx);
     }
+
+    int Ndone2b = Nalign2b * PackFactor;
+    Nrem -= Ndone2b;
+    int Ndone2 = Ndone2a + Ndone2b;
+    dest0 += Ndone2; if (HAS_DEST1) { dest1 += Ndone2; }
+    src0  += Ndone2; if (HAS_SRC1)  { src1  += Ndone2; }
 
     // stage 2c: tail
-    int Ndone2b = Nalign * (sizeof(PackType)/sizeof(T));
-    Ndone += Nalign * (sizeof(PackType)/sizeof(T));
-    Nrem = N - Ndone;
-
-    if (Nrem > 0) {
-      dest0 += Ndone2b; if (HAS_DEST1) { dest1 += Ndone2b; }
-      src0  += Ndone2b; if (HAS_SRC1)  { src1  += Ndone2b; }
-    }
 
     for (int idx = tid; idx < Nrem; idx += THREADS) {
       // never ought to make it more than one time through this loop.  only a
       // few threads should even participate
-      T val = vFetch(src0+idx);
-      if (HAS_SRC1) {
-        val = FUNC()(val, vFetch(src1+idx));
-      }
-
-      vStore(dest0+idx, val);
-      if (HAS_DEST1) {
-        vStore(dest1+idx, val);
-      }
+      ReduceCopy<FUNC, T, HAS_SRC1, HAS_DEST1>(src0, src1, dest0, dest1, idx);
     }
   } // done fast path
 }
-
-template<int THREADS, int UNROLL, typename T>
-__device__ inline void CalcLastChunk(int * const bigSliceN,
-    int * const smallSliceN, int * const lastSliceN, int * const numSlices,
-    int * const numBigSlices, int * const numSmallSlices, const int N,
-    const int numChunks, const int chunkSize) {
-  int Nleft = N - ((numChunks - 1) * chunkSize);
-  // semi-equally split up the remaining work into numslices slices.
-  // it's "semi"-equal because we want the divisions to land as neatly as we
-  // can on alignable boundaries
-  int NperTile = UNROLL * THREADS * (sizeof(PackType)/sizeof(T));
-  int numTiles = (Nleft + NperTile - 1) / NperTile;
-  int numTilesPerBigSlice = (numTiles + *numSlices - 1)
-      / *numSlices;
-  int numTilesPerSmallSlice = numTiles / *numSlices;
-
-  *bigSliceN   = NperTile * numTilesPerBigSlice;
-  *smallSliceN = NperTile * numTilesPerSmallSlice;
-  *numBigSlices = numTiles % *numSlices;
-  *numSmallSlices = (*smallSliceN > 0) ?
-      *numSlices - *numBigSlices : 0;
-
-  // the lastSlice will take the place of one of the small slices unless
-  // there are no small slices (because this is a very small reduction), in
-  // which case we replace one of the big slices and leave the small slices
-  // as 0.
-  if (*numSmallSlices > 0) {
-    --*numSmallSlices;
-    if (*numSmallSlices == 0)
-      *smallSliceN = 0;
-  }
-  else {
-    --*numBigSlices;
-    if (*numBigSlices == 0)
-      *bigSliceN = 0;
-  }
-
-  *lastSliceN = Nleft -
-      (*numBigSlices * *bigSliceN
-          + *numSmallSlices * *smallSliceN);
-
-  // in cases where args.N % numSlices is pretty small, we'd rather have one
-  // slightly big last slice than one big slice, a bunch of small slices,
-  // and one smaller last slice
-  if ((*numBigSlices == 1) &&
-      (*numSmallSlices == *numSlices - 2) &&
-      (*lastSliceN < *smallSliceN)) {
-    *numBigSlices += *numSmallSlices;
-    *numSmallSlices = 0;
-    *bigSliceN = *smallSliceN;
-    *smallSliceN = 0;
-    *lastSliceN = Nleft -
-        *numBigSlices * *bigSliceN;
-  }
-
-  // done recalculating
-  *numSlices = *numBigSlices +
-      *numSmallSlices + 1;
-}
-
-// Kernel launch
-template<typename T>
-struct KernelArgs {
-  // general parameters
-  int nRanks;
-  int root;
-  int buffSize;
-  int N;
-  int opIndex;
-  volatile int * __restrict__ opCounter;
-  bool pushrecv;
-
-  // some pre-computed sizes
-  int SliceSize;
-  int SliceOffset;
-  int ChunkSize;
-  int NumChunks;
-
-  // local and remote input, output, and buffer
-  const T * __restrict__ ThisInput;
-  T * __restrict__ ThisOutput;
-
-  DevRing<char>* ring;
-};
-
-template<typename T>
-void ArgsSetup(KernelArgs<T> *args, const void* sendbuff, void* recvbuff,
-		const int root, const int count, ncclComm *comm) {
-  args->nRanks = comm->nRanks;
-  args->root = root;
-  args->buffSize = comm->buffSize;
-  args->N = count;
-  args->opIndex = comm->opSched;
-  args->opCounter = comm->opCounter;
-  args->ThisInput = (const T*)sendbuff;
-  args->ThisOutput = (T*)recvbuff;
-  args->ring = comm->devRing;
-  args->pushrecv = comm->globalMemSpace;
-}
-
-#define LAUNCH_KERNEL(K, THREADS, UNROLL, FUNC, T, \
-		args, stream) do { \
-  dim3 grid(1, 1, 1); \
-  dim3 block(THREADS+1, 1, 1); \
-  void* argptrs[] = {&args}; \
-  CUDACHECK(cudaLaunchKernel( \
-            (void*)K<THREADS, UNROLL, FUNC, T>, \
-            grid, block, argptrs, 0, stream)); \
-} while (0)
 
 template <typename T>
 __device__ inline void incrementOpCounter(const KernelArgs<T> *args) {

--- a/src/common_kernel.h
+++ b/src/common_kernel.h
@@ -17,6 +17,8 @@
 #define WARP_SIZE 32
 #define ROUNDUP(x, y)                                                           \
     (((((x) + (y) - 1) / (y))) * (y))
+#define DIVUP(x, y) \
+    (((x)+(y)-1)/(y))
 #define BAR_EXEC(type, barid, nthreads) \
     asm("bar." #type " " #barid ", " #nthreads ";\n\t")
 #define BAR_EXPAND(type, barid, nthreads) \

--- a/src/core.cu
+++ b/src/core.cu
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2017, NVIDIA CORPORATION. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -823,7 +823,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
 
   showVersion();
 
-  NCCLCHECK(PtrCheck(comms, "CommInitRank", "comms"));
+  NCCLCHECK(PtrCheck(comms, "CommInitAll", "comms"));
 
   if (ndev < 1) {
     WARN("Invalid device count requested : %d", ndev);

--- a/src/core.h
+++ b/src/core.h
@@ -12,18 +12,6 @@
 #include <cstdio>
 #include <cuda_runtime.h>
 
-
-// DIE on error
-#define CUDACHECK(cmd) do {                              \
-    cudaError_t e = cmd;                                 \
-    if( e != cudaSuccess ) {                             \
-        printf("Cuda failure %s:%d '%s'\n",              \
-               __FILE__,__LINE__,cudaGetErrorString(e)); \
-        exit(EXIT_FAILURE);                              \
-    }                                                    \
-} while(false)
-
-
 #define MAXRANKS 32
 #define DEFAULT_BUFFER_SIZE_BYTES (1UL << 21)
 #define NCCL_MEM_PAD_ALIGN 65536
@@ -135,6 +123,23 @@ extern DebugLevel ncclDebugLevel;
     fflush(stdout);                                              \
   }                                                              \
 } while(0)
+
+// Check CUDA calls
+#define CUDACHECK(cmd, retcode) do {                        \
+    cudaError_t e = cmd;                                    \
+    if( e != cudaSuccess ) {                                \
+        WARN("Cuda failure '%s'\n", cudaGetErrorString(e)); \
+        return retcode;                                     \
+    }                                                       \
+} while(false)
+
+// Propagate errors up
+#define NCCLCHECK(call) do { \
+  ncclResult_t res = call; \
+  if (res != ncclSuccess) { \
+    return res; \
+  } \
+} while (0);
 
 #ifdef PROFAPI
 #define NCCL_API(ret, func, args...)        \

--- a/src/enqueue.h
+++ b/src/enqueue.h
@@ -34,7 +34,7 @@ ncclResult_t enqueue(const void* sendbuff,
 {
   if (stream != comm->prevStream) { // sync required for calls in different streams
     comm->prevStream = stream;
-    CUDACHECK( cudaStreamWaitEvent(stream, comm->doneEvent, 0) );
+    CUDACHECK(cudaStreamWaitEvent(stream, comm->doneEvent, 0), ncclUnhandledCudaError);
   }
 
   ncclResult_t ret;
@@ -42,7 +42,7 @@ ncclResult_t enqueue(const void* sendbuff,
 
   // Always have to record done event because we don't know what stream next
   // collective will be in.
-  CUDACHECK( cudaEventRecord(comm->doneEvent, stream) );
+  CUDACHECK(cudaEventRecord(comm->doneEvent, stream), ncclUnhandledCudaError);
   comm->opSched += 1;
   return ret;
 }

--- a/src/libwrap.cu
+++ b/src/libwrap.cu
@@ -8,16 +8,15 @@
 #include <dlfcn.h>
 #include "core.h"
 
-typedef enum { SUCCESS = 0 } RetCode;
 int symbolsLoaded = 0;
 
-static RetCode (*nvmlInternalInit)(void);
-static RetCode (*nvmlInternalShutdown)(void);
-static RetCode (*nvmlInternalDeviceGetHandleByPciBusId)(const char* pciBusId, nvmlDevice_t* device);
-static RetCode (*nvmlInternalDeviceGetIndex)(nvmlDevice_t device, unsigned* index);
-static RetCode (*nvmlInternalDeviceSetCpuAffinity)(nvmlDevice_t device);
-static RetCode (*nvmlInternalDeviceClearCpuAffinity)(nvmlDevice_t device);
-static const char* (*nvmlInternalErrorString)(RetCode r);
+static nvmlReturn_t (*nvmlInternalInit)(void);
+static nvmlReturn_t (*nvmlInternalShutdown)(void);
+static nvmlReturn_t (*nvmlInternalDeviceGetHandleByPciBusId)(const char* pciBusId, nvmlDevice_t* device);
+static nvmlReturn_t (*nvmlInternalDeviceGetIndex)(nvmlDevice_t device, unsigned* index);
+static nvmlReturn_t (*nvmlInternalDeviceSetCpuAffinity)(nvmlDevice_t device);
+static nvmlReturn_t (*nvmlInternalDeviceClearCpuAffinity)(nvmlDevice_t device);
+static const char* (*nvmlInternalErrorString)(nvmlReturn_t r);
 
 ncclResult_t wrapSymbols(void) {
 
@@ -76,8 +75,8 @@ ncclResult_t wrapNvmlInit(void) {
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalInit();
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalInit();
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlInit() failed: %s",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
@@ -90,8 +89,8 @@ ncclResult_t wrapNvmlShutdown(void) {
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalShutdown();
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalShutdown();
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlShutdown() failed: %s ",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
@@ -104,8 +103,8 @@ ncclResult_t wrapNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalDeviceGetHandleByPciBusId(pciBusId, device);
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalDeviceGetHandleByPciBusId(pciBusId, device);
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlDeviceGetHandleByPciBusId() failed: %s ",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
@@ -118,8 +117,8 @@ ncclResult_t wrapNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index) {
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalDeviceGetIndex(device, index);
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalDeviceGetIndex(device, index);
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlDeviceGetIndex() failed: %s ",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
@@ -132,8 +131,8 @@ ncclResult_t wrapNvmlDeviceSetCpuAffinity(nvmlDevice_t device) {
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalDeviceSetCpuAffinity(device);
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalDeviceSetCpuAffinity(device);
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlDeviceSetCpuAffinity() failed: %s ",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
@@ -146,12 +145,11 @@ ncclResult_t wrapNvmlDeviceClearCpuAffinity(nvmlDevice_t device) {
     WARN("lib wrapper not initialized.");
     return ncclLibWrapperNotSet;
   }
-  RetCode ret = nvmlInternalDeviceClearCpuAffinity(device);
-  if (ret != SUCCESS) {
+  nvmlReturn_t ret = nvmlInternalDeviceClearCpuAffinity(device);
+  if (ret != NVML_SUCCESS) {
     WARN("nvmlDeviceClearCpuAffinity() failed: %s ",
       nvmlInternalErrorString(ret));
     return ncclSystemError;
   }
   return ncclSuccess;
 }
-

--- a/src/libwrap.h
+++ b/src/libwrap.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -12,16 +12,34 @@
 
 #include "core.h"
 
+/* Extracted from nvml.h */
 typedef struct nvmlDevice_st* nvmlDevice_t;
 
-/**
- * Generic enable/disable enum.
- */
-typedef enum nvmlEnableState_enum
+typedef enum nvmlReturn_enum
 {
-    NVML_FEATURE_DISABLED    = 0,     //!< Feature disabled
-    NVML_FEATURE_ENABLED     = 1      //!< Feature enabled
-} nvmlEnableState_t;
+    NVML_SUCCESS = 0,                   //!< The operation was successful
+    NVML_ERROR_UNINITIALIZED = 1,       //!< NVML was not first initialized with nvmlInit()
+    NVML_ERROR_INVALID_ARGUMENT = 2,    //!< A supplied argument is invalid
+    NVML_ERROR_NOT_SUPPORTED = 3,       //!< The requested operation is not available on target device
+    NVML_ERROR_NO_PERMISSION = 4,       //!< The current user does not have permission for operation
+    NVML_ERROR_ALREADY_INITIALIZED = 5, //!< Deprecated: Multiple initializations are now allowed through ref counting
+    NVML_ERROR_NOT_FOUND = 6,           //!< A query to find an object was unsuccessful
+    NVML_ERROR_INSUFFICIENT_SIZE = 7,   //!< An input argument is not large enough
+    NVML_ERROR_INSUFFICIENT_POWER = 8,  //!< A device's external power cables are not properly attached
+    NVML_ERROR_DRIVER_NOT_LOADED = 9,   //!< NVIDIA driver is not loaded
+    NVML_ERROR_TIMEOUT = 10,            //!< User provided timeout passed
+    NVML_ERROR_IRQ_ISSUE = 11,          //!< NVIDIA Kernel detected an interrupt issue with a GPU
+    NVML_ERROR_LIBRARY_NOT_FOUND = 12,  //!< NVML Shared Library couldn't be found or loaded
+    NVML_ERROR_FUNCTION_NOT_FOUND = 13, //!< Local version of NVML doesn't implement this function
+    NVML_ERROR_CORRUPTED_INFOROM = 14,  //!< infoROM is corrupted
+    NVML_ERROR_GPU_IS_LOST = 15,        //!< The GPU has fallen off the bus or has otherwise become inaccessible
+    NVML_ERROR_RESET_REQUIRED = 16,     //!< The GPU requires a reset before it can be used again
+    NVML_ERROR_OPERATING_SYSTEM = 17,   //!< The GPU control device has been blocked by the operating system/cgroups
+    NVML_ERROR_LIB_RM_VERSION_MISMATCH = 18,   //!< RM detects a driver/library version mismatch
+    NVML_ERROR_IN_USE = 19,             //!< An operation cannot be performed because the GPU is currently in use
+    NVML_ERROR_UNKNOWN = 999            //!< An internal driver error occurred
+} nvmlReturn_t;
+/* End of nvml.h */
 
 ncclResult_t wrapSymbols(void);
 
@@ -31,7 +49,6 @@ ncclResult_t wrapNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_
 ncclResult_t wrapNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index);
 ncclResult_t wrapNvmlDeviceSetCpuAffinity(nvmlDevice_t device);
 ncclResult_t wrapNvmlDeviceClearCpuAffinity(nvmlDevice_t device);
-ncclResult_t wrapNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t *device);
 
 #endif // End include guard
 

--- a/src/primitives.h
+++ b/src/primitives.h
@@ -177,29 +177,29 @@ class Primitives {
   template <typename... SYNC_Ts>
   static __device__ __forceinline__ void
   Copy(const T* src, T* dst,
-      int len, int step, SYNC_Ts... flags) {
-    GenericOp(src, nullptr, dst, nullptr, len, step, flags...);
+      int len, int maxOffset, int step, SYNC_Ts... flags) {
+    GenericOp(src, nullptr, dst, nullptr, len, maxOffset, step, flags...);
   }
 
   template <typename... SYNC_Ts>
   static __device__ __forceinline__ void
   DoubleCopy(const T* src, T* dst1, T* dst2,
-      int len, int step, SYNC_Ts... flags) {
-    GenericOp(src, nullptr, dst1, dst2, len, step, flags...);
+      int len, int maxOffset, int step, SYNC_Ts... flags) {
+    GenericOp(src, nullptr, dst1, dst2, len, maxOffset, step, flags...);
   }
 
   template <typename... SYNC_Ts>
   static __device__ __forceinline__ void
   Reduce(const T* src1, const T* src2, T* dst,
-      int len, int step, SYNC_Ts... flags) {
-    GenericOp(src1, src2, dst, nullptr, len, step, flags...);
+      int len, int maxOffset, int step, SYNC_Ts... flags) {
+    GenericOp(src1, src2, dst, nullptr, len, maxOffset, step, flags...);
   }
 
   template <typename... SYNC_Ts>
   static __device__ __forceinline__ void
   ReduceCopy(const T* src1, const T* src2, T* dst1, T* dst2,
-      int len, int step, SYNC_Ts... flags) {
-    GenericOp(src1, src2, dst1, dst2, len, step, flags...);
+      int len, int maxOffset, int step, SYNC_Ts... flags) {
+    GenericOp(src1, src2, dst1, dst2, len, maxOffset, step, flags...);
   }
 };
 

--- a/src/primitives.h
+++ b/src/primitives.h
@@ -101,7 +101,7 @@ Tptr ptradd(Tptr ptr, int i) {
 }
 
 __device__ __forceinline__
-nullptr_t ptradd(nullptr_t ptr, int i) {
+std::nullptr_t ptradd(std::nullptr_t ptr, int i) {
   return nullptr;
 }
 
@@ -120,8 +120,8 @@ class Primitives {
                   DST2_T dst2,
             int len, int maxoffset, int step, SYNC_Ts... flags) {
 
-    enum { noSrc2 = std::is_same<SRC2_T, nullptr_t>::value };
-    enum { noDst2 = std::is_same<DST2_T, nullptr_t>::value };
+    enum { noSrc2 = std::is_same<SRC2_T, std::nullptr_t>::value };
+    enum { noDst2 = std::is_same<DST2_T, std::nullptr_t>::value };
     static_assert(noSrc2 || std::is_same<SRC2_T, const T*>::value,
         "src2 must be of type T* or nullptr_t");
     static_assert(noDst2 || std::is_same<DST2_T, T*>::value,
@@ -146,8 +146,8 @@ class Primitives {
              THREADS,
              OpType,
              T,
-             !std::is_same<DST2_T, nullptr_t>::value, // HAS_DEST1
-             !std::is_same<SRC2_T, nullptr_t>::value  // HAS_SRC1
+             !std::is_same<DST2_T, std::nullptr_t>::value, // HAS_DEST1
+             !std::is_same<SRC2_T, std::nullptr_t>::value  // HAS_SRC1
             >
             (
              threadIdx.x,

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2017, NVIDIA CORPORATION. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -74,18 +74,17 @@ __global__ void ReduceKernel(const KernelArgs<T> args) {
           postReadyToNext);
     } else if (rank == root) {
       Prims::Reduce(
-          prevInput  + boffset,
           thisInput + offset,
+          prevInput + boffset,
           thisOutput + offset,
           sliceSize, maxOffset,
           step,
           waitReadyFromPrev,
           postDoneToPrev);
     } else {
-      Prims::ReduceCopy(
+      Prims::Reduce(
           thisInput + offset,
           prevInput + boffset,
-          thisOutput + offset,
           nextOutput + boffset,
           sliceSize, maxOffset,
           step,

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "core.h"
+#include "common_coll.h"
 #include "enqueue.h"
 #include "primitives.h"
 
@@ -117,12 +118,9 @@ __global__ void ReduceKernel(const KernelArgs<T> args) {
 template<class FUNC, typename T>
 ncclResult_t RingReduce(const void* sendbuff, void* recvbuff, const int count, const int root,
     ncclComm* comm, cudaStream_t stream) {
-  if (count == 0)
-    return ncclSuccess;
-
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
-      CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, count*sizeof(T), cudaMemcpyDeviceToDevice, stream));
+      CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, count*sizeof(T), cudaMemcpyDeviceToDevice, stream), ncclUnhandledCudaError);
   } else {
     KernelArgs<T> args;
     ArgsSetup(&args, sendbuff, recvbuff, root, count, comm);
@@ -145,6 +143,7 @@ NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, int cou
     ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, int count,
     ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+  NCCLCHECK(ArgsCheck(sendbuff, recvbuff, count, datatype, op, root, comm, "Reduce"));
   return enqueue<ReduceFunctor>(sendbuff, recvbuff, count, datatype, op, root, comm, stream);
 }
 

--- a/src/reduce_scatter.cu
+++ b/src/reduce_scatter.cu
@@ -96,7 +96,7 @@ __global__ void ReduceScatterKernel(const KernelArgs<T> args) {
       NEXT_STEP;
     }
 
-    // step k - 1: reduce this buffer and data, which will produce the final
+    // step k-1: reduce this buffer and data, which will produce the final
     // result that we store in this data and push to the next GPU
     rankDest = ring.userRank[0];
     offset = chunkOffset + rankDest * size;

--- a/src/reduce_scatter.cu
+++ b/src/reduce_scatter.cu
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "core.h"
+#include "common_coll.h"
 #include "enqueue.h"
 #include "primitives.h"
 
@@ -133,12 +134,9 @@ __global__ void ReduceScatterKernel(const KernelArgs<T> args) {
 template<class FUNC, typename T>
 ncclResult_t RingReduceScatter(const void* sendbuff, void* recvbuff,
     const int count, ncclComm* comm, cudaStream_t stream) {
-  if (count == 0)
-    return ncclSuccess;
-
   if (comm->nRanks == 1) {
     if (sendbuff != recvbuff)
-      CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, count*sizeof(T), cudaMemcpyDeviceToDevice, stream));
+      CUDACHECK(cudaMemcpyAsync(recvbuff, sendbuff, count*sizeof(T), cudaMemcpyDeviceToDevice, stream), ncclUnhandledCudaError);
   } else {
     KernelArgs<T> args;
     ArgsSetup(&args, sendbuff, recvbuff, 0, count, comm);
@@ -161,6 +159,7 @@ NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, 
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, int recvcount,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+  NCCLCHECK(ArgsCheck(sendbuff, recvbuff, recvcount, datatype, op, 0, comm, "ReduceScatter"));
   return enqueue<ReduceScatter>(sendbuff, recvbuff, recvcount, datatype, op, 0, comm, stream);
 }
 

--- a/test/common.py
+++ b/test/common.py
@@ -118,6 +118,13 @@ def is_iterable(obj):
 class TestCase(unittest.TestCase):
     precision = 1e-5
 
+    def assertTensorsSlowEqual(self, x, y, prec=None, message=''):
+        max_err = 0
+        self.assertEqual(x.size(), y.size())
+        for index in iter_indices(x):
+            max_err = max(max_err, abs(x[index] - y[index]))
+        self.assertLessEqual(max_err, prec, message)
+
     def assertEqual(self, x, y, prec=None, message=''):
         if prec is None:
             prec = self.precision
@@ -132,10 +139,19 @@ class TestCase(unittest.TestCase):
                 if a.numel() > 0:
                     b = b.type_as(a)
                     b = b.cuda(device=a.get_device()) if a.is_cuda else b.cpu()
-                    max_err = (a - b).abs().max()
+                    # check that NaNs are in the same locations
+                    nan_mask = a != a
+                    self.assertTrue(torch.equal(nan_mask, b != b))
+                    diff = a - b
+                    diff[nan_mask] = 0
+                    if diff.is_signed():
+                        diff = diff.abs()
+                    max_err = diff.max()
                     self.assertLessEqual(max_err, prec, message)
             self.assertEqual(x.is_sparse, y.is_sparse, message)
             if x.is_sparse:
+                x = x.clone().contiguous()
+                y = y.clone().contiguous()
                 assertTensorsEqual(x.indices(), y.indices())
                 assertTensorsEqual(x.values(), y.values())
             else:
@@ -167,8 +183,14 @@ class TestCase(unittest.TestCase):
             self.assertGreater(x.numel(), 0)
             y = y.type_as(x)
             y = y.cuda(device=x.get_device()) if x.is_cuda else y.cpu()
-            max_err = (x - y).abs().max()
-            self.assertGreaterEqual(max_err, prec, message)
+            nan_mask = x != x
+            if torch.equal(nan_mask, y != y):
+                diff = x - y
+                if diff.is_signed():
+                    diff = diff.abs()
+                diff[nan_mask] = 0
+                max_err = diff.max()
+                self.assertGreaterEqual(max_err, prec, message)
         elif type(x) == str and type(y) == str:
             super(TestCase, self).assertNotEqual(x, y)
         elif is_iterable(x) and is_iterable(y):

--- a/test/single/broadcast_test.cu
+++ b/test/single/broadcast_test.cu
@@ -14,7 +14,8 @@
 #include "test_utilities.h"
 
 int errors = 0;
-double min_bw = 10000.0;
+double avg_bw = 0.0;
+int avg_count = 0;
 bool is_reduction = false;
 
 template<typename T>
@@ -91,7 +92,9 @@ void RunTest(T** buff, const int N, const ncclDataType_t type, const int root,
             maxDelta);
 
     if (maxDelta > deltaMaxValue(type, is_reduction)) errors++;
-    if (busbw < min_bw) min_bw = busbw;
+    avg_bw += busbw;
+    avg_count++;
+
   }
 
   for(int i=0; i < nDev; ++i) {
@@ -218,12 +221,13 @@ int main(int argc, char* argv[]) {
   free(comms);
 
   char* str = getenv("NCCL_TESTS_MIN_BW");
-  double check_min_bw = str ? atof(str) : -1;
+  double check_avg_bw = str ? atof(str) : -1;
+  avg_bw /= avg_count;
 
   printf(" Out of bounds values : %d %s\n", errors, errors ? "FAILED" : "OK");
-  printf(" Min bus bandwidth    : %g %s\n", min_bw, check_min_bw == -1 ? "" : (min_bw < check_min_bw ? "FAILED" : "OK"));
+  printf(" Avg bus bandwidth    : %g %s\n", avg_bw, check_avg_bw == -1 ? "" : (avg_bw < check_avg_bw ? "FAILED" : "OK"));
   printf("\n");
-  if (errors || min_bw < check_min_bw)
+  if (errors || avg_bw < check_avg_bw)
     exit(EXIT_FAILURE);
   else 
     exit(EXIT_SUCCESS);

--- a/test/single/reduce_scatter_test.cu
+++ b/test/single/reduce_scatter_test.cu
@@ -14,7 +14,8 @@
 #include "test_utilities.h"
 
 int errors = 0;
-double min_bw = 10000.0;
+double avg_bw = 0.0;
+int avg_count = 0;
 bool is_reduction = true;
 
 template<typename T>
@@ -95,7 +96,8 @@ void RunTest(T** sendbuff, T** recvbuff, const int N, const ncclDataType_t type,
         maxDelta);
 
     if (maxDelta > deltaMaxValue(type, is_reduction)) errors++;
-    if (busbw < min_bw) min_bw = busbw;
+    avg_bw += busbw;
+    avg_count++;
   }
 
   {
@@ -134,7 +136,8 @@ void RunTest(T** sendbuff, T** recvbuff, const int N, const ncclDataType_t type,
         maxDelta);
 
     if (maxDelta > deltaMaxValue(type, is_reduction)) errors++;
-    if (busbw < min_bw) min_bw = busbw;
+    avg_bw += busbw;
+    avg_count++;
   }
 
   for (int i = 0; i < nDev; ++i) {
@@ -268,12 +271,13 @@ int main(int argc, char* argv[]) {
   free(comms);
 
   char* str = getenv("NCCL_TESTS_MIN_BW");
-  double check_min_bw = str ? atof(str) : -1;
+  double check_avg_bw = str ? atof(str) : -1;
+  avg_bw /= avg_count;
 
   printf(" Out of bounds values : %d %s\n", errors, errors ? "FAILED" : "OK");
-  printf(" Min bus bandwidth    : %g %s\n", min_bw, check_min_bw == -1 ? "" : (min_bw < check_min_bw ? "FAILED" : "OK"));
+  printf(" Avg bus bandwidth    : %g %s\n", avg_bw, check_avg_bw == -1 ? "" : (avg_bw < check_avg_bw ? "FAILED" : "OK"));
   printf("\n");
-  if (errors || min_bw < check_min_bw)
+  if (errors || avg_bw < check_avg_bw)
     exit(EXIT_FAILURE);
   else 
     exit(EXIT_SUCCESS);

--- a/test/single/reduce_test.cu
+++ b/test/single/reduce_test.cu
@@ -16,7 +16,8 @@
 
 int csv = false;
 int errors = 0;
-double min_bw = 10000.0;
+double avg_bw = 0.0;
+int avg_count = 0;
 bool is_reduction = true;
 
 template<typename T>
@@ -98,7 +99,8 @@ void RunTest(T** sendbuff, T** recvbuff, const int N, const ncclDataType_t type,
         elapsedSec * 1.0E3, algbw, busbw, maxDelta);
 
     if (maxDelta > deltaMaxValue(type, is_reduction)) errors++;
-    if (busbw < min_bw) min_bw = busbw;
+    avg_bw += busbw;
+    avg_count++;
 
     nvtxRangePop();
   }
@@ -140,7 +142,8 @@ void RunTest(T** sendbuff, T** recvbuff, const int N, const ncclDataType_t type,
         elapsedSec * 1.0E3, algbw, busbw, maxDelta);
 
     if (maxDelta > deltaMaxValue(type, is_reduction)) errors++;
-    if (busbw < min_bw) min_bw = busbw;
+    avg_bw += busbw;
+    avg_count++;
 
     nvtxRangePop();
   }
@@ -282,12 +285,13 @@ int main(int argc, char* argv[]) {
   free(comms);
 
   char* str = getenv("NCCL_TESTS_MIN_BW");
-  double check_min_bw = str ? atof(str) : -1;
+  double check_avg_bw = str ? atof(str) : -1;
+  avg_bw /= avg_count;
 
   printf(" Out of bounds values : %d %s\n", errors, errors ? "FAILED" : "OK");
-  printf(" Min bus bandwidth    : %g %s\n", min_bw, check_min_bw == -1 ? "" : (min_bw < check_min_bw ? "FAILED" : "OK"));
+  printf(" Avg bus bandwidth    : %g %s\n", avg_bw, check_avg_bw == -1 ? "" : (avg_bw < check_avg_bw ? "FAILED" : "OK"));
   printf("\n");
-  if (errors || min_bw < check_min_bw)
+  if (errors || avg_bw < check_avg_bw)
     exit(EXIT_FAILURE);
   else 
     exit(EXIT_SUCCESS);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2692,6 +2692,18 @@ new_module_tests = [
         desc='scale'
     ),
     dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 2)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_shared'
+    ),
+    dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 1)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_skewed'
+    ),
+    dict(
         module_name='AdaptiveMaxPool1d',
         constructor_args=(3,),
         input=torch.rand(1, 3, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2615,8 +2615,7 @@ new_module_tests = [
         constructor=lambda: nn.Embedding(4, 3, sparse=True),
         input=Variable(torch.randperm(2).repeat(1, 2)),
         jacobian_input=False,
-        fullname='Embedding_sparse',
-        test_cuda=False,
+        fullname='Embedding_sparse'
     ),
     dict(
         constructor=lambda: nn.FractionalMaxPool2d(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2645,6 +2645,18 @@ new_module_tests = [
         desc='scale'
     ),
     dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 2)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_shared'
+    ),
+    dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 1)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_skewed'
+    ),
+    dict(
         module_name='AdaptiveMaxPool1d',
         constructor_args=(3,),
         input=torch.rand(1, 3, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2394,6 +2394,13 @@ new_module_tests = [
         desc='no_bias'
     ),
     dict(
+        module_name='ConvTranspose1d',
+        constructor_args=(3, 4, 3, 2, 1, 1, 1, True, 2),
+        input_size=(1, 3, 6),
+        cudnn=True,
+        desc='dilated'
+    ),
+    dict(
         module_name='MaxPool1d',
         constructor_args=(4,),
         input_size=(2, 10, 4)
@@ -2454,6 +2461,13 @@ new_module_tests = [
         constructor_args=(3, 4, 3, (3, 2), 1, (1, 1)),
         cudnn=True,
         input_size=(1, 3, 7, 6)
+    ),
+    dict(
+        module_name='ConvTranspose2d',
+        constructor_args=(3, 4, 3, (2, 3), 1, (1, 1), 1, False, (2, 2)),
+        input_size=(1, 3, 6, 7),
+        cudnn=True,
+        desc='dilated'
     ),
     dict(
         module_name='ConvTranspose2d',
@@ -2571,6 +2585,13 @@ new_module_tests = [
         constructor_args=(2, 3, (2, 3, 2)),
         cudnn=True,
         input_size=(1, 2, 4, 5, 4)
+    ),
+    dict(
+        module_name='ConvTranspose3d',
+        constructor_args=(2, 3, (2, 3, 2), 1, 0, 0, 1, True, (2, 2, 2)),
+        cudnn=True,
+        input_size=(1, 2, 4, 5, 4),
+        desc='dilated'
     ),
     dict(
         module_name='MaxPool3d',

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -15,7 +15,7 @@ cpu_triplet = (
 type_triplets = [cpu_triplet]
 if torch.cuda.is_available():
     cuda_triplet = (
-        torch.cuda.IntTensor,
+        torch.cuda.LongTensor,
         torch.cuda.DoubleTensor,
         torch.cuda.sparse.DoubleTensor)
     type_triplets.append(cuda_triplet)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -295,6 +295,22 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
+    def test_dsmm(self):
+        def test_shape(di, dj, dk):
+            for is_cuda in [False, True]:
+                x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
+                y = torch.randn(dj, dk)
+                if is_cuda:
+                    y = y.cuda()
+
+                expected = torch.mm(x.to_dense(), y)
+                res = torch.dsmm(x, y)
+                self.assertEqual(res, expected)
+
+        test_shape(7, 5, 3)
+        test_shape(1000, 100, 100)
+        test_shape(3000, 64, 300)
+
     def _test_spadd_shape(self, shape_i, shape_v=None):
         shape = shape_i + (shape_v or [])
         x, _, _ = self._gen_sparse(len(shape_i), 10, shape)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -314,7 +314,7 @@ class TestSparse(TestCase):
 
     def test_hsmm(self):
         def test_shape(di, dj, dk):
-            for is_cuda in [True]:
+            for is_cuda in [False, True]:
                 x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
                 y = torch.randn(dj, dk)
                 if is_cuda:

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5,6 +5,7 @@ import itertools
 import random
 import unittest
 from common import TestCase, run_tests
+from common_nn import TEST_CUDA
 from numbers import Number
 
 # triplet := (index type, value type, sparse type)
@@ -12,19 +13,18 @@ cpu_triplet = (
     torch.LongTensor,
     torch.DoubleTensor,
     torch.sparse.DoubleTensor)
-type_triplets = [cpu_triplet]
-if torch.cuda.is_available():
+
+if TEST_CUDA:
     cuda_triplet = (
         torch.cuda.LongTensor,
         torch.cuda.DoubleTensor,
         torch.cuda.sparse.DoubleTensor)
-    type_triplets.append(cuda_triplet)
 
 
 class TestSparse(TestCase):
 
     @staticmethod
-    def _gen_sparse(d, nnz, with_size, is_cuda=False):  # FIXME remove default is_cuda value to ensure coverage
+    def _gen_sparse(d, nnz, with_size, is_cuda=False):
         if isinstance(with_size, Number):
             v = torch.randn(nnz)
             i = (torch.rand(d, nnz) * with_size).type(torch.LongTensor)
@@ -40,213 +40,257 @@ class TestSparse(TestCase):
         if is_cuda:
             return x.cuda(), i.cuda(), v.cuda()
         else:
-            return x, i, v
+            return x, i.clone(), v.clone()
+
+    def _test_basic(self, is_cuda):
+        x, i, v = self._gen_sparse(3, 10, 100, is_cuda)
+
+        self.assertEqual(i, x.indices())
+        self.assertEqual(v, x.values())
+
+        x, i, v = self._gen_sparse(3, 10, [100, 100, 100], is_cuda)
+        self.assertEqual(i, x.indices())
+        self.assertEqual(v, x.values())
+        self.assertEqual(x.ndimension(), 3)
+        self.assertEqual(x.nnz(), 10)
+        for i in range(3):
+            self.assertEqual(x.size(i), 100)
+
+        SparseTensor = (cuda_triplet if is_cuda else cpu_triplet)[2]
+        # Make sure we can access empty indices / values
+        x = SparseTensor()
+        self.assertEqual(x.indices().numel(), 0)
+        self.assertEqual(x.values().numel(), 0)
 
     def test_basic(self):
-        for is_cuda in [False, True] if torch.cuda.is_available() else [False]:
-            x, i, v = self._gen_sparse(3, 10, 100, is_cuda)
+        self._test_basic(False)
 
-            self.assertEqual(i, x.indices())
-            self.assertEqual(v, x.values())
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_basic_cuda(self):
+        self._test_basic(True)
 
-            x, i, v = self._gen_sparse(3, 10, [100, 100, 100], is_cuda)
-            self.assertEqual(i, x.indices())
-            self.assertEqual(v, x.values())
-            self.assertEqual(x.ndimension(), 3)
-            self.assertEqual(x.nnz(), 10)
-            for i in range(3):
-                self.assertEqual(x.size(i), 100)
+    def _test_to_dense(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+            [0, 0, 1, 4],
+        ])
+        v = ValueTensor([2, 1, 3, 4])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
+        res = ValueTensor([
+            [[2, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0]],
+            [[1, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0]],
+            [[0, 3, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 4]],
+        ])
 
-        for _, _, SparseTensor in type_triplets:
-            # Make sure we can access empty indices / values
-            x = SparseTensor()
-            self.assertEqual(x.indices().numel(), 0)
-            self.assertEqual(x.values().numel(), 0)
+        x.to_dense()  # Tests double to_dense for memory corruption
+        x.to_dense()
+        x.to_dense()
+        self.assertEqual(res, x.to_dense())
 
     def test_to_dense(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [0, 1, 2, 2],
-                [0, 0, 0, 3],
-                [0, 0, 1, 4],
-            ])
-            v = ValueTensor([2, 1, 3, 4])
-            x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-            res = ValueTensor([
-                [[2, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0]],
-                [[1, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0]],
-                [[0, 3, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 0],
-                 [0, 0, 0, 0, 4]],
-            ])
+        self._test_to_dense(False)
 
-            x.to_dense()  # Tests double to_dense for memory corruption
-            x.to_dense()
-            x.to_dense()
-            self.assertEqual(res, x.to_dense())
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_to_dense_cuda(self):
+        self._test_to_dense(True)
+
+    def _test_to_dense_hybrid(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+        ])
+        v = ValueTensor([[2, 3], [1, 2], [3, 4], [4, 5]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 2]))
+        res = ValueTensor([
+            [[2, 3],
+             [0, 0],
+             [0, 0],
+             [0, 0]],
+            [[1, 2],
+             [0, 0],
+             [0, 0],
+             [0, 0]],
+            [[3, 4],
+             [0, 0],
+             [0, 0],
+             [4, 5]],
+        ])
+
+        x.to_dense()  # Tests double to_dense for memory corruption
+        x.to_dense()
+        x.to_dense()
+        self.assertEqual(res, x.to_dense())
 
     def test_to_dense_hybrid(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [0, 1, 2, 2],
-                [0, 0, 0, 3],
-            ])
-            v = ValueTensor([[2, 3], [1, 2], [3, 4], [4, 5]])
-            x = SparseTensor(i, v, torch.Size([3, 4, 2]))
-            res = ValueTensor([
-                [[2, 3],
-                 [0, 0],
-                 [0, 0],
-                 [0, 0]],
-                [[1, 2],
-                 [0, 0],
-                 [0, 0],
-                 [0, 0]],
-                [[3, 4],
-                 [0, 0],
-                 [0, 0],
-                 [4, 5]],
-            ])
+        self._test_to_dense_hybrid(False)
 
-            x.to_dense()  # Tests double to_dense for memory corruption
-            x.to_dense()
-            x.to_dense()
-            self.assertEqual(res, x.to_dense())
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_to_dense_hybrid_cuda(self):
+        self._test_to_dense_hybrid(True)
+
+    def _test_contig(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
+            [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
+        ])
+        v = ValueTensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = SparseTensor(i, v, torch.Size([100, 100]))
+        exp_i = IndexTensor([
+            [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
+            [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
+        ])
+        exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+        i = IndexTensor([
+            [2, 0, 2, 1],
+            [0, 0, 3, 0],
+            [1, 0, 4, 0],
+        ])
+        v = ValueTensor([3, 2, 4, 1])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
+        exp_i = IndexTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+            [0, 0, 1, 4],
+        ])
+        exp_v = ValueTensor([2, 1, 3, 4])
+
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+        # Duplicate indices
+        i = IndexTensor([
+            [0, 0, 2, 0],
+            [0, 0, 3, 0],
+            [0, 0, 4, 0],
+        ])
+        v = ValueTensor([3, 2, 4, 1])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
+        exp_i = IndexTensor([
+            [0, 2],
+            [0, 3],
+            [0, 4],
+        ])
+        exp_v = ValueTensor([6, 4])
+
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
 
     def test_contig(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
-                [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
-            ])
-            v = ValueTensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-            x = SparseTensor(i, v, torch.Size([100, 100]))
-            exp_i = IndexTensor([
-                [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
-                [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
-            ])
-            exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+        self._test_contig(False)
 
-            i = IndexTensor([
-                [2, 0, 2, 1],
-                [0, 0, 3, 0],
-                [1, 0, 4, 0],
-            ])
-            v = ValueTensor([3, 2, 4, 1])
-            x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-            exp_i = IndexTensor([
-                [0, 1, 2, 2],
-                [0, 0, 0, 3],
-                [0, 0, 1, 4],
-            ])
-            exp_v = ValueTensor([2, 1, 3, 4])
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_contig_cuda(self):
+        self._test_contig(True)
 
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+    def _test_contig_hybrid(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
+            [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
+        ])
+        v = ValueTensor([
+            [1, 2], [2, 3], [3, 4], [4, 5], [5, 6],
+            [6, 7], [7, 8], [8, 9], [9, 10], [10, 11],
+        ])
+        x = SparseTensor(i, v, torch.Size([100, 100, 2]))
+        exp_i = IndexTensor([
+            [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
+            [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
+        ])
+        exp_v = ValueTensor([
+            [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
+            [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
+        ])
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
 
-            # Duplicate indices
-            i = IndexTensor([
-                [0, 0, 2, 0],
-                [0, 0, 3, 0],
-                [0, 0, 4, 0],
-            ])
-            v = ValueTensor([3, 2, 4, 1])
-            x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-            exp_i = IndexTensor([
-                [0, 2],
-                [0, 3],
-                [0, 4],
-            ])
-            exp_v = ValueTensor([6, 4])
+        i = IndexTensor([
+            [2, 0, 2, 1],
+            [0, 0, 3, 0],
+            [1, 0, 4, 0],
+        ])
+        v = ValueTensor([[3, 3, 3], [2, 2, 2], [4, 4, 4], [1, 1, 1]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = IndexTensor([
+            [0, 1, 2, 2],
+            [0, 0, 0, 3],
+            [0, 0, 1, 4],
+        ])
+        exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
 
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
+
+        # Duplicate indices
+        i = IndexTensor([
+            [0, 0, 2, 0],
+            [0, 0, 3, 0],
+            [0, 0, 4, 0],
+        ])
+        v = ValueTensor([[3, 2, 3], [2, 1, 1], [4, 3, 4], [1, 1, 1]])
+        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = IndexTensor([
+            [0, 2],
+            [0, 3],
+            [0, 4],
+        ])
+        exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
+
+        x.contiguous()
+        self.assertEqual(exp_i, x.indices())
+        self.assertEqual(exp_v, x.values())
 
     def test_contig_hybrid(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
-                [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
-            ])
-            v = ValueTensor([
-                [1, 2], [2, 3], [3, 4], [4, 5], [5, 6],
-                [6, 7], [7, 8], [8, 9], [9, 10], [10, 11],
-            ])
-            x = SparseTensor(i, v, torch.Size([100, 100, 2]))
-            exp_i = IndexTensor([
-                [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
-                [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
-            ])
-            exp_v = ValueTensor([
-                [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
-                [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
-            ])
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+        self._test_contig_hybrid(False)
 
-            i = IndexTensor([
-                [2, 0, 2, 1],
-                [0, 0, 3, 0],
-                [1, 0, 4, 0],
-            ])
-            v = ValueTensor([[3, 3, 3], [2, 2, 2], [4, 4, 4], [1, 1, 1]])
-            x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
-            exp_i = IndexTensor([
-                [0, 1, 2, 2],
-                [0, 0, 0, 3],
-                [0, 0, 1, 4],
-            ])
-            exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_contig_hybrid_cuda(self):
+        self._test_contig_hybrid(True)
 
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+    def _test_transpose(self, is_cuda):
+        x = self._gen_sparse(4, 20, 5, is_cuda=is_cuda)[0]
+        y = x.to_dense()
 
-            # Duplicate indices
-            i = IndexTensor([
-                [0, 0, 2, 0],
-                [0, 0, 3, 0],
-                [0, 0, 4, 0],
-            ])
-            v = ValueTensor([[3, 2, 3], [2, 1, 1], [4, 3, 4], [1, 1, 1]])
-            x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
-            exp_i = IndexTensor([
-                [0, 2],
-                [0, 3],
-                [0, 4],
-            ])
-            exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
+        for i, j in itertools.combinations(range(4), 2):
+            x = x.transpose_(i, j)
+            y = y.transpose(i, j)
+            self.assertEqual(x.to_dense(), y)
 
-            x.contiguous()
-            self.assertEqual(exp_i, x.indices())
-            self.assertEqual(exp_v, x.values())
+            x = x.transpose(i, j)
+            y = y.transpose(i, j)
+            self.assertEqual(x.to_dense(), y)
 
     def test_transpose(self):
-        for is_cuda in [False, True]:
-            x = self._gen_sparse(4, 20, 5, is_cuda=is_cuda)[0]
-            y = x.to_dense()
+        self._test_transpose(False)
 
-            for i, j in itertools.combinations(range(4), 2):
-                x = x.transpose_(i, j)
-                y = y.transpose(i, j)
-                self.assertEqual(x.to_dense(), y)
-
-                x = x.transpose(i, j)
-                y = y.transpose(i, j)
-                self.assertEqual(x.to_dense(), y)
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_transpose_cuda(self):
+        self._test_transpose(True)
 
     def test_mm(self):
         def test_shape(di, dj, dk):
@@ -256,16 +300,16 @@ class TestSparse(TestCase):
             alpha = random.random()
             beta = random.random()
 
-            expected = torch.addmm(alpha, t, beta, x.to_dense(), y)
             res = torch.addmm(alpha, t, beta, x, y)
+            expected = torch.addmm(alpha, t, beta, x.to_dense(), y)
             self.assertEqual(res, expected)
 
-            expected = torch.addmm(t, x.to_dense(), y)
             res = torch.addmm(t, x, y)
+            expected = torch.addmm(t, x.to_dense(), y)
             self.assertEqual(res, expected)
 
-            expected = torch.mm(x.to_dense(), y)
             res = torch.mm(x, y)
+            expected = torch.mm(x.to_dense(), y)
             self.assertEqual(res, expected)
 
         test_shape(10, 100, 100)
@@ -280,205 +324,274 @@ class TestSparse(TestCase):
             alpha = random.random()
             beta = random.random()
 
-            expected = torch.addmm(alpha, t.to_dense(), beta, x.to_dense(), y)
             res = torch.saddmm(alpha, t, beta, x, y)
+            expected = torch.addmm(alpha, t.to_dense(), beta, x.to_dense(), y)
             self.assertEqual(res.to_dense(), expected)
 
-            expected = torch.addmm(t.to_dense(), x.to_dense(), y)
             res = torch.saddmm(t, x, y)
+            expected = torch.addmm(t.to_dense(), x.to_dense(), y)
             self.assertEqual(res.to_dense(), expected)
 
-            expected = torch.mm(x.to_dense(), y)
             res = torch.smm(x, y)
+            expected = torch.mm(x.to_dense(), y)
             self.assertEqual(res.to_dense(), expected)
+
+        test_shape(7, 5, 3)
+        test_shape(1000, 100, 100)
+        test_shape(3000, 64, 300)
+
+    def _test_dsmm(self, is_cuda):
+        def test_shape(di, dj, dk):
+            x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
+            y = torch.randn(dj, dk)
+            if is_cuda:
+                y = y.cuda()
+
+            res = torch.dsmm(x, y)
+            expected = torch.mm(x.to_dense(), y)
+            self.assertEqual(res, expected)
 
         test_shape(7, 5, 3)
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
     def test_dsmm(self):
-        def test_shape(di, dj, dk):
-            for is_cuda in [False, True]:
-                x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
-                y = torch.randn(dj, dk)
-                if is_cuda:
-                    y = y.cuda()
+        self._test_dsmm(False)
 
-                expected = torch.mm(x.to_dense(), y)
-                res = torch.dsmm(x, y)
-                self.assertEqual(res, expected)
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_dsmm_cuda(self):
+        self._test_dsmm(True)
+
+    def _test_hsmm(self, is_cuda):
+        def test_shape(di, dj, dk):
+            x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
+            y = torch.randn(dj, dk)
+            if is_cuda:
+                y = y.cuda()
+
+            res = torch.hsmm(x, y)
+            expected = torch.mm(x.to_dense(), y)
+            self.assertEqual(res.to_dense(), expected)
 
         test_shape(7, 5, 3)
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
     def test_hsmm(self):
-        def test_shape(di, dj, dk):
-            for is_cuda in [False, True]:
-                x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
-                y = torch.randn(dj, dk)
-                if is_cuda:
-                    y = y.cuda()
+        self._test_hsmm(False)
 
-                expected = torch.mm(x.to_dense(), y)
-                res = torch.hsmm(x, y)
-                self.assertEqual(res.to_dense(), expected)
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_hsmm_cuda(self):
+        self._test_hsmm(True)
 
-        test_shape(7, 5, 3)
-        test_shape(1000, 100, 100)
-        test_shape(3000, 64, 300)
+    def _test_spadd_shape(self, is_cuda, shape_i, shape_v=None):
+        shape = shape_i + (shape_v or [])
+        x, _, _ = self._gen_sparse(len(shape_i), 10, shape, is_cuda)
+        y = torch.randn(*shape)
+        if is_cuda:
+            y = y.cuda()
+        r = random.random()
 
-    def _test_spadd_shape(self, shape_i, shape_v=None):
-        for is_cuda in [False, True]:
-            shape = shape_i + (shape_v or [])
-            x, _, _ = self._gen_sparse(len(shape_i), 10, shape, is_cuda)
-            y = torch.randn(*shape)
-            if is_cuda:
-                y = y.cuda()
-            r = random.random()
+        res = torch.add(y, r, x)
+        expected = y + r * x.to_dense()
 
-            expected = y + r * x.to_dense()
-            res = torch.add(y, r, x)
+        self.assertEqual(res, expected)
 
-            self.assertEqual(res, expected)
+        # Non contiguous dense tensor
+        s = list(shape)
+        s[0] = shape[-1]
+        s[-1] = shape[0]
+        y = torch.randn(*s)
+        if is_cuda:
+            y = y.cuda()
+        y.transpose_(0, len(s) - 1)
+        r = random.random()
 
-            # Non contiguous dense tensor
-            s = list(shape)
-            s[0] = shape[-1]
-            s[-1] = shape[0]
-            y = torch.randn(*s)
-            if is_cuda:
-                y = y.cuda()
-            y.transpose_(0, len(s) - 1)
-            r = random.random()
+        res = torch.add(y, r, x)
+        expected = y + r * x.to_dense()
 
-            expected = y + r * x.to_dense()
-            res = torch.add(y, r, x)
+        self.assertEqual(res, expected)
 
-            self.assertEqual(res, expected)
+    def _test_spadd(self, is_cuda):
+        self._test_spadd_shape(is_cuda, [5, 6])
+        self._test_spadd_shape(is_cuda, [10, 10, 10])
+        self._test_spadd_shape(is_cuda, [50, 30, 20])
+        self._test_spadd_shape(is_cuda, [5, 5, 5, 5, 5, 5])
 
     def test_spadd(self):
-        self._test_spadd_shape([5, 6])
-        self._test_spadd_shape([10, 10, 10])
-        self._test_spadd_shape([50, 30, 20])
-        self._test_spadd_shape([5, 5, 5, 5, 5, 5])
+        self._test_spadd(False)
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_spadd_cuda(self):
+        self._test_spadd(True)
+
+    def _test_spadd_hybrid(self, is_cuda):
+        self._test_spadd_shape(is_cuda, [5, 6], [2, 3])
+        self._test_spadd_shape(is_cuda, [10, 10, 10], [3])
+        self._test_spadd_shape(is_cuda, [50, 30, 20], [2])
+        self._test_spadd_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
 
     def test_spadd_hybrid(self):
-        self._test_spadd_shape([5, 6], [2, 3])
-        self._test_spadd_shape([10, 10, 10], [3])
-        self._test_spadd_shape([50, 30, 20], [2])
-        self._test_spadd_shape([5, 5, 5, 5, 5, 5], [2])
+        self._test_spadd_hybrid(False)
 
-    def _test_basic_ops_shape(self, shape_i, shape_v=None):
-        for is_cuda in [False, True]:
-            shape = shape_i + (shape_v or [])
-            x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
-            x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_spadd_hybrid_cuda(self):
+        self._test_spadd_hybrid(True)
 
-            y1 = x1 + x2
-            y2 = x1.clone()
-            y2.add_(x2)
-            expected = x1.to_dense() + x2.to_dense()
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+    def _test_basic_ops_shape(self, is_cuda, shape_i, shape_v=None):
+        shape = shape_i + (shape_v or [])
+        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
+        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
 
-            y1 = x1 - x2
-            y2 = x1.clone()
-            y2.sub_(x2)
-            expected = x1.to_dense() - x2.to_dense()
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+        y1 = x1 + x2
+        y2 = x1.clone()
+        y2.add_(x2)
+        expected = x1.to_dense() + x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            y1 = x1 * x2
-            y2 = x1.clone()
-            y2.mul_(x2)
-            expected = x1.to_dense() * x2.to_dense()
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+        y1 = x1 - x2
+        y2 = x1.clone()
+        y2.sub_(x2)
+        expected = x1.to_dense() - x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            y1 = x1 * 37.5
-            y2 = x1.clone()
-            y2.mul_(37.5)
-            expected = x1.to_dense() * 37.5
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+        y1 = x1 * x2
+        y2 = x1.clone()
+        y2.mul_(x2)
+        expected = x1.to_dense() * x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            y1 = x1 / 37.5
-            y2 = x1.clone()
-            y2.div_(37.5)
-            expected = x1.to_dense() / 37.5
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+        y1 = x1 * 37.5
+        y2 = x1.clone()
+        y2.mul_(37.5)
+        expected = x1.to_dense() * 37.5
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
 
-            y = x1.clone()
-            y.zero_()
-            expected = torch.zeros(x1.size())
-            self.assertEqual(y.to_dense(), expected)
+        y1 = x1 / 37.5
+        y2 = x1.clone()
+        y2.div_(37.5)
+        expected = x1.to_dense() / 37.5
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
+
+        y = x1.clone()
+        y.zero_()
+        expected = torch.zeros(x1.size())
+        self.assertEqual(y.to_dense(), expected)
+
+    def _test_basic_ops(self, is_cuda):
+        self._test_basic_ops_shape(is_cuda, [5, 6])
+        self._test_basic_ops_shape(is_cuda, [10, 10, 10])
+        self._test_basic_ops_shape(is_cuda, [50, 30, 20])
+        self._test_basic_ops_shape(is_cuda, [5, 5, 5, 5, 5, 5])
 
     def test_basic_ops(self):
-        self._test_basic_ops_shape([5, 6])
-        self._test_basic_ops_shape([10, 10, 10])
-        self._test_basic_ops_shape([50, 30, 20])
-        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5])
+        self._test_basic_ops(False)
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_basic_ops_cuda(self):
+        self._test_basic_ops(True)
+
+    def _test_basic_ops_hybrid(self, is_cuda):
+        self._test_basic_ops_shape(is_cuda, [5, 6], [2, 3])
+        self._test_basic_ops_shape(is_cuda, [10, 10, 10], [3])
+        self._test_basic_ops_shape(is_cuda, [50, 30, 20], [2])
+        self._test_basic_ops_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
 
     def test_basic_ops_hybrid(self):
-        self._test_basic_ops_shape([5, 6], [2, 3])
-        self._test_basic_ops_shape([10, 10, 10], [3])
-        self._test_basic_ops_shape([50, 30, 20], [2])
-        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5], [2])
+        self._test_basic_ops_hybrid(False)
 
-    def _test_sparse_mask_shape(self, shape_i, shape_v=None):
-        for is_cuda in [False, True]:
-            shape = shape_i + (shape_v or [])
-            x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
-            x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_basic_ops_hybrid_cuda(self):
+        self._test_basic_ops_hybrid(True)
 
-            y1 = x1 + x2
-            y2 = x1.clone()
-            y2.add_(x2)
-            expected = x1.to_dense() + x2.to_dense()
-            self.assertEqual(y1.to_dense(), expected)
-            self.assertEqual(y2.to_dense(), expected)
+    def _test_sparse_mask_shape(self, is_cuda, shape_i, shape_v=None):
+        shape = shape_i + (shape_v or [])
+        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
+        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
+
+        y1 = x1 + x2
+        y2 = x1.clone()
+        y2.add_(x2)
+        expected = x1.to_dense() + x2.to_dense()
+        self.assertEqual(y1.to_dense(), expected)
+        self.assertEqual(y2.to_dense(), expected)
+
+    def _test_sparse_mask_fixed(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [1, 3, 3, 0, 4],
+            [2, 1, 1, 2, 3],
+        ])
+        v = ValueTensor([1, 2, 3, 4, 5])
+        x = SparseTensor(i, v, torch.Size([5, 4]))
+        dense = ValueTensor([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+            [17, 18, 19, 20],
+        ])
+        exp_v = ValueTensor([7, 14, 14, 3, 20])
+        res = dense.sparse_mask(x)
+        expected = SparseTensor(i, exp_v, torch.Size([5, 4]))
+        self.assertEqual(res, expected)
+
+    def _test_sparse_mask(self, is_cuda):
+        self._test_sparse_mask_fixed(is_cuda)
+
+        self._test_sparse_mask_shape(is_cuda, [5, 6])
+        self._test_sparse_mask_shape(is_cuda, [10, 10, 10])
+        self._test_sparse_mask_shape(is_cuda, [50, 30, 20])
+        self._test_sparse_mask_shape(is_cuda, [5, 5, 5, 5, 5, 5])
 
     def test_sparse_mask(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [1, 3, 3, 0, 4],
-                [2, 1, 1, 2, 3],
-            ])
-            v = ValueTensor([1, 2, 3, 4, 5])
-            x = SparseTensor(i, v, torch.Size([5, 4]))
-            dense = ValueTensor([
-                [1, 2, 3, 4],
-                [5, 6, 7, 8],
-                [9, 10, 11, 12],
-                [13, 14, 15, 16],
-                [17, 18, 19, 20],
-            ])
-            exp_v = ValueTensor([7, 14, 14, 3, 20])
-            expected = SparseTensor(i, exp_v, torch.Size([5, 4]))
-            res = dense.sparse_mask(x)
-            self.assertEqual(res, expected)
+        self._test_sparse_mask(False)
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_sparse_mask_cuda(self):
+        self._test_sparse_mask(True)
+
+    def _test_sparse_mask_hybrid_fixed(self, is_cuda):
+        IndexTensor, ValueTensor, SparseTensor = \
+            cuda_triplet if is_cuda else cpu_triplet
+        i = IndexTensor([
+            [1, 3, 3, 0, 4],
+            [2, 1, 1, 2, 3],
+        ])
+        v = ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]])
+        x = SparseTensor(i, v, torch.Size([5, 4, 2]))
+        dense = ValueTensor([
+            [[1, 3], [2, 2], [3, 3], [4, 2]],
+            [[5, 7], [6, 7], [7, 9], [8, 9]],
+            [[9, 2], [10, 4], [11, 1], [12, 3]],
+            [[13, 5], [14, 1], [15, 1], [16, 6]],
+            [[17, 7], [18, 2], [19, 7], [20, 1]],
+        ])
+        res = dense.sparse_mask(x)
+        exp_v = ValueTensor([[7, 9], [14, 1], [14, 1], [3, 3], [20, 1]])
+        expected = SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
+        self.assertEqual(res, expected)
+
+    def _test_sparse_mask_hybrid(self, is_cuda):
+        self._test_sparse_mask_hybrid_fixed(is_cuda)
+
+        self._test_sparse_mask_shape(is_cuda, [5, 6], [2, 3])
+        self._test_sparse_mask_shape(is_cuda, [10, 10, 10], [3])
+        self._test_sparse_mask_shape(is_cuda, [50, 30, 20], [2])
+        self._test_sparse_mask_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
 
     def test_sparse_mask_hybrid(self):
-        for IndexTensor, ValueTensor, SparseTensor in type_triplets:
-            i = IndexTensor([
-                [1, 3, 3, 0, 4],
-                [2, 1, 1, 2, 3],
-            ])
-            v = ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]])
-            x = SparseTensor(i, v, torch.Size([5, 4, 2]))
-            dense = ValueTensor([
-                [[1, 3], [2, 2], [3, 3], [4, 2]],
-                [[5, 7], [6, 7], [7, 9], [8, 9]],
-                [[9, 2], [10, 4], [11, 1], [12, 3]],
-                [[13, 5], [14, 1], [15, 1], [16, 6]],
-                [[17, 7], [18, 2], [19, 7], [20, 1]],
-            ])
-            exp_v = ValueTensor([[7, 9], [14, 1], [14, 1], [3, 3], [20, 1]])
-            expected = SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
-            res = dense.sparse_mask(x)
-            self.assertEqual(res, expected)
+        self._test_sparse_mask_hybrid(False)
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_sparse_mask_hybrid_cuda(self):
+        self._test_sparse_mask_hybrid(True)
 
 
 if __name__ == '__main__':

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2312,7 +2312,8 @@ class TestTorch(TestCase):
             data = original.type(t)
             switch = switch.type(t)
             res = torch.mul(data, switch)
-            self.assertEqual(res.abs(), data, 1e-16)
+            # abs is used in assertEqual so we use the slow version instead
+            self.assertTensorsSlowEqual(res.abs(), data, 1e-16)
 
         # Checking that the right abs function is called for LongTensor
         bignumber = 2 ^ 31 + 1

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -19,6 +19,7 @@ class THPPlugin(CWrapPlugin):
 
         'THCudaTensor*': Template('((THCPFloatTensor*)$arg)->cdata'),
         'THCudaDoubleTensor*': Template('((THCPDoubleTensor*)$arg)->cdata'),
+        'THCudaIntTensor*': Template('((THCPIntTensor*)$arg)->cdata'),
         'THCudaLongTensor*': Template('((THCPLongTensor*)$arg)->cdata'),
 
         'THSFloatTensor*': Template('((THSPFloatTensor*)$arg)->cdata'),
@@ -56,6 +57,7 @@ class THPPlugin(CWrapPlugin):
 
         'THCudaTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPFloatTensorClass'),
         'THCudaDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPDoubleTensorClass'),
+        'THCudaIntTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPIntTensorClass'),
         'THCudaLongTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPLongTensorClass'),
 
         'THSDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THSPDoubleTensorClass'),
@@ -86,8 +88,10 @@ class THPPlugin(CWrapPlugin):
     RETURN_WRAPPER = {
         'THTensor*': Template('return THPTensor_(New)($result);'),
         'THSTensor*': Template('return THSPTensor_(New)($result);'),
+        'THIndexTensor*': Template('return THPIndexTensor_(New)($result);'),
         'THLongTensor*': Template('return THPLongTensor_New($result);'),
         'THLongStorage*': Template('return THPLongStorage_New($result);'),
+        'THCudaIntTensor*': Template('return THCPIntTensor_New($result);'),
         'THCudaLongTensor*': Template('return THCPLongTensor_New($result);'),
         # TODO: make it smarter - it should return python long if result doesn't fit into an int
         'long': Template('return PyInt_FromLong($result);'),
@@ -174,6 +178,7 @@ ${cpu}
         'THDoubleTensor*': '" THPModuleStr "DoubleTensor',
         'THCudaTensor*': 'torch.cuda.FloatTensor',
         'THCudaDoubleTensor*': 'torch.cuda.DoubleTensor',
+        'THCudaIntTensor*': 'torch.cuda.IntTensor',
         'THCudaLongTensor*': 'torch.cuda.LongTensor',
         'THSize*': 'torch.Size',
         'THStride*': 'tuple',

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -57,7 +57,7 @@ def _cuda(self, device=None, async=False):
     with torch.cuda.device(device):
         if self.is_sparse:
             new_type = getattr(torch.cuda.sparse, self.__class__.__name__)
-            indices = self.indices().cuda(device, async).int()
+            indices = self.indices().cuda(device, async)
             values = self.values().cuda(device, async)
             return new_type(indices, values, self.size())
         else:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -57,7 +57,7 @@ def _cuda(self, device=None, async=False):
     with torch.cuda.device(device):
         if self.is_sparse:
             new_type = getattr(torch.cuda.sparse, self.__class__.__name__)
-            indices = self.indices().cuda(device, async)
+            indices = self.indices().cuda(device, async).int()
             values = self.values().cuda(device, async)
             return new_type(indices, values, self.size())
         else:

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -635,6 +635,7 @@ static PyMethodDef TorchMethods[] = {
   {"smm",             (PyCFunction)THSPModule_sspmm,          METH_VARARGS | METH_KEYWORDS,  NULL},
   {"saddmm",          (PyCFunction)THSPModule_sspaddmm,       METH_VARARGS | METH_KEYWORDS,  NULL},
   {"dsmm",            (PyCFunction)THSPModule_spmm,           METH_VARARGS | METH_KEYWORDS,  NULL},
+  {"hsmm",            (PyCFunction)THSPModule_hspmm,          METH_VARARGS | METH_KEYWORDS,  NULL},
   {NULL, NULL, 0, NULL}
 };
 

--- a/torch/csrc/ModuleSparse.cpp
+++ b/torch/csrc/ModuleSparse.cpp
@@ -95,5 +95,6 @@ dispatch:                                                                      \
 IMPLEMENT_SPARSE_STATELESS(spmm);
 IMPLEMENT_SPARSE_STATELESS(sspmm);
 IMPLEMENT_SPARSE_STATELESS(sspaddmm);
+IMPLEMENT_SPARSE_STATELESS(hspmm);
 
 #undef IMPLEMENT_SPARSE_STATELESS

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -108,7 +108,7 @@ struct algorithm_search {
 
 template<>
 struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
-  static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+  static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
   static BenchmarkCache<cudnnConvolutionFwdAlgo_t>& cache() {
     return fwd_algos;
   }

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -26,9 +26,9 @@ static void THSPTensor_(dealloc)(THSPTensor* self)
 static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 #ifdef THC_GENERIC_FILE
-#define THPIndexTensor_Check THCPLongTensor_Check
-#define THPIndexTensor THCPLongTensor
-#define THIndexTensor THCudaLongTensor
+#define THPIndexTensor_Check THCPIntTensor_Check
+#define THPIndexTensor THCPIntTensor
+#define THIndexTensor THCudaIntTensor
 #else
 #define THPIndexTensor_Check THPLongTensor_Check
 #define THPIndexTensor THPLongTensor

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -26,9 +26,9 @@ static void THSPTensor_(dealloc)(THSPTensor* self)
 static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 #ifdef THC_GENERIC_FILE
-#define THPIndexTensor_Check THCPIntTensor_Check
-#define THPIndexTensor THCPIntTensor
-#define THIndexTensor THCudaIntTensor
+#define THPIndexTensor_Check THCPLongTensor_Check
+#define THPIndexTensor THCPLongTensor
+#define THIndexTensor THCudaLongTensor
 #else
 #define THPIndexTensor_Check THPLongTensor_Check
 #define THPIndexTensor THPLongTensor

--- a/torch/csrc/generic/TensorMethods.cwrap
+++ b/torch/csrc/generic/TensorMethods.cwrap
@@ -31,11 +31,13 @@
 #define THIndexTensor THCudaLongTensor
 #define THIndexTensor_(NAME) TH_CONCAT_2(THCudaLongTensor_,NAME)
 #define THPIndexTensor THCPLongTensor
+#define THPIndexTensor_(NAME) TH_CONCAT_2(THCPLongTensor_,NAME)
 #define THPIndexTensorClass THCPLongTensorClass
 #else
 #define THIndexTensor THLongTensor
 #define THIndexTensor_(NAME) TH_CONCAT_2(THLongTensor_,NAME)
 #define THPIndexTensor THPLongTensor
+#define THPIndexTensor_(NAME) TH_CONCAT_2(THPLongTensor_,NAME)
 #define THPIndexTensorClass THPLongTensorClass
 #endif
 

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -73,6 +73,7 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 [[
   name: indices
   sparse: yes
+  cname: newIndices
   return: THIndexTensor*
   arguments:
   - THSTensor* self
@@ -81,6 +82,7 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 [[
   name: values
   sparse: yes
+  cname: newValues
   return: THTensor*
   arguments:
   - THSTensor* self
@@ -88,15 +90,6 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: contiguous
-  sparse: yes
-  return: argument 0
-  arguments:
-  - THSTensor* self
-]]
-
-[[
-  name: markContiguous
-  python_name: mark_contiguous
   sparse: yes
   return: argument 0
   arguments:

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -155,6 +155,37 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: t
+  sparse: yes
+  with_stateless: True
+  cname: newTranspose
+  return: THSTensor*
+  before_call: |
+    long nDimI = ((THSPTensor*)${arg0})->cdata->nDimensionI;
+    long nDimV = ((THSPTensor*)${arg0})->cdata->nDimensionV;
+    THPUtils_assert(nDimI == 2 && nDimV == 0, "t() expects a 2D sparse tensor, but self is %ldD indices and %ldD values", nDimI, nDimV);
+  arguments:
+    - THSTensor* self
+    - CONSTANT 0
+    - CONSTANT 1
+]]
+
+[[
+  name: t_
+  sparse: yes
+  cname: transpose
+  return: self
+  before_call: |
+    long nDimI = ((THSPTensor*)${arg0})->cdata->nDimensionI;
+    long nDimV = ((THSPTensor*)${arg0})->cdata->nDimensionV;
+    THPUtils_assert(nDimI == 2 && nDimV == 0, "t_() expects a 2D sparse tensor, but self is %ldD indices and %ldD values", nDimI, nDimV);
+  arguments:
+    - THSTensor* self
+    - CONSTANT 0
+    - CONSTANT 1
+]]
+
+[[
   name: mm
   sparse: yes
   only_stateless: True
@@ -181,6 +212,20 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
       output: True
     - CONSTANT AS_REAL(0)
     - argument 0
+    - CONSTANT AS_REAL(1)
+    - THSTensor* mat1
+    - THTensor* mat2
+]]
+
+[[
+  name: hspmm
+  only_stateless: True
+  sparse: yes
+  cname: hspmm
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
     - CONSTANT AS_REAL(1)
     - THSTensor* mat1
     - THTensor* mat2

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -83,11 +83,10 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
   name: indices
   defined_if: "IS_CUDA"
   sparse: yes
-  return: THCudaLongTensor*
+  return: THCudaIntTensor*
   arguments:
   - THSTensor* self
 ]]
-
 
 [[
   name: values
@@ -371,4 +370,14 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
       output: True
     - THTensor* self
     - THSTensor* mask
+]]
+
+[[
+  name: getDevice
+  sparse: yes
+  python_name: get_device
+  defined_if: IS_CUDA
+  return: long
+  arguments:
+    - THSTensor* self
 ]]

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -72,18 +72,8 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: indices
-  defined_if: "!IS_CUDA"
   sparse: yes
-  return: THLongTensor*
-  arguments:
-  - THSTensor* self
-]]
-
-[[
-  name: indices
-  defined_if: "IS_CUDA"
-  sparse: yes
-  return: THCudaIntTensor*
+  return: THIndexTensor*
   arguments:
   - THSTensor* self
 ]]

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -95,6 +95,15 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: markContiguous
+  python_name: mark_contiguous
+  sparse: yes
+  return: argument 0
+  arguments:
+  - THSTensor* self
+]]
+
+[[
   name: clone
   sparse: yes
   cname: newClone

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1,7 +1,7 @@
 [[
   name: abs
   return: argument 0
-  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_LONG) || defined(TH_REAL_IS_INT) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE || CUDA_INT || CUDA_LONG
+  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_LONG) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_SHORT) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE || CUDA_SHORT || CUDA_INT || CUDA_LONG
   with_stateless: True
   arguments:
     - arg: THTensor* destination
@@ -13,7 +13,7 @@
   name: abs_
   cname: abs
   return: self
-  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_LONG) || defined(TH_REAL_IS_INT) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE || CUDA_INT || CUDA_LONG
+  defined_if: defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_LONG) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_SHORT) || CUDA_FLOAT || CUDA_HALF || CUDA_DOUBLE || CUDA_SHORT || CUDA_INT || CUDA_LONG
   arguments:
     - THTensor* self
     - THTensor* self

--- a/torch/legacy/nn/SpatialContrastiveNormalization.py
+++ b/torch/legacy/nn/SpatialContrastiveNormalization.py
@@ -14,6 +14,8 @@ class SpatialContrastiveNormalization(Module):
         self.nInputPlane = nInputPlane
         if kernel is None:
             self.kernel = torch.Tensor(9, 9).fill_(1)
+        else:
+            self.kernel = kernel
         self.threshold = threshold
         self.thresval = thresval or threshold
         kdim = self.kernel.ndimension()

--- a/torch/legacy/nn/SpatialDivisiveNormalization.py
+++ b/torch/legacy/nn/SpatialDivisiveNormalization.py
@@ -60,7 +60,7 @@ class SpatialDivisiveNormalization(Module):
             self.stdestimator.add(SpatialConvolution(self.nInputPlane, 1, self.kernel.size(1), self.kernel.size(0)))
         else:
             self.stdestimator.add(SpatialConvolutionMap(
-                SpatialContolutionMap.maps.oneToOne(self.nInputPlane), self.kernel.size(0), 1))
+                SpatialConvolutionMap.maps.oneToOne(self.nInputPlane), self.kernel.size(0), 1))
             self.stdestimator.add(SpatialConvolution(self.nInputPlane, 1, 1, self.kernel.size(0)))
 
         self.stdestimator.add(Replicate(self.nInputPlane, 1))

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -2697,7 +2697,7 @@ TENSOR_IMPLEMENT_LOGICAL(ne,!=)
 LAB_IMPLEMENT_BASIC_FUNCTION(abs,labs)
 #endif /* long only part */
 
-#if defined(TH_REAL_IS_INT)
+#if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT)
 LAB_IMPLEMENT_BASIC_FUNCTION(abs,abs)
 #endif /* int only part */
 

--- a/torch/lib/TH/generic/THTensorMath.h
+++ b/torch/lib/TH/generic/THTensorMath.h
@@ -132,7 +132,7 @@ TH_API void THTensor_(geTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);
 TH_API void THTensor_(neTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);
 TH_API void THTensor_(eqTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);
 
-#if defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
+#if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
 TH_API void THTensor_(abs)(THTensor *r_, THTensor *t);
 #endif
 

--- a/torch/lib/THC/CMakeLists.txt
+++ b/torch/lib/THC/CMakeLists.txt
@@ -289,6 +289,7 @@ INSTALL(FILES
           THCNumerics.cuh
           THCTensorSort.cuh
           THCTensorInfo.cuh
+          THCTensorMathPointwise.cuh
           THCTensorTypeUtils.cuh
           THCTensorRandom.cuh
           THCTensorMathMagma.cuh

--- a/torch/lib/THC/THCGeneral.c
+++ b/torch/lib/THC/THCGeneral.c
@@ -75,6 +75,7 @@ void THCudaInit(THCState* state)
     state->currentStreams[i] = THCThreadLocal_alloc();
   }
   state->currentPerDeviceBlasHandle = THCThreadLocal_alloc();
+  state->currentPerDeviceSparseHandle = THCThreadLocal_alloc();
 
   state->resourcesPerDevice = (THCCudaResourcesPerDevice*)
     malloc(numDevices * sizeof(THCCudaResourcesPerDevice));
@@ -131,6 +132,7 @@ void THCudaInit(THCState* state)
   // cuBLAS handle is the first user BLAS handle. Note that the actual BLAS
   // handles are created lazily.
   state->numUserBlasHandles = 1;
+  state->numUserSparseHandles = 1;
 
   state->heapSoftmax = 3e8; // 300MB, adjusted upward dynamically
   state->heapDelta = 0;
@@ -166,6 +168,10 @@ void THCudaShutdown(THCState* state)
     for (int i = 0; i < res->numBlasHandles; ++i) {
       THCublasCheck(cublasDestroy(res->blasHandles[i]));
     }
+    /* Free user defined sparse handles */
+    for (int i = 0; i < res->numSparseHandles; ++i) {
+      THCusparseCheck(cusparseDestroy(res->sparseHandles[i]));
+    }
     /* Free per-stream scratch space; starts at 0 because there is space for
        the default stream as well*/
     if (res->devScratchSpacePerStream) {
@@ -176,6 +182,7 @@ void THCudaShutdown(THCState* state)
 
     free(res->streams);
     free(res->blasHandles);
+    free(res->sparseHandles);
     free(res->devScratchSpacePerStream);
     THCStream_free((THCStream*)THCThreadLocal_get(state->currentStreams[dev]));
     THCThreadLocal_free(state->currentStreams[dev]);
@@ -392,6 +399,29 @@ void THCState_reserveDeviceBlasHandles(THCState* state, int device, int numBlasH
   THCudaCheck(cudaSetDevice(prevDev));
 }
 
+void THCState_reserveDeviceSparseHandles(THCState* state, int device, int numSparseHandles)
+{
+  int prevDev = -1;
+  THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, device);
+  if (numSparseHandles <= res->numSparseHandles) {
+    return;
+  }
+
+  THCudaCheck(cudaGetDevice(&prevDev));
+  THCudaCheck(cudaSetDevice(device));
+
+  size_t size = numSparseHandles * sizeof(cusparseHandle_t);
+  cusparseHandle_t* handles = (cusparseHandle_t*) realloc(res->sparseHandles, size);
+  for (int i = res->numSparseHandles; i < numSparseHandles; ++i) {
+    handles[i] = NULL;
+    THCusparseCheck(cusparseCreate(&handles[i]));
+  }
+  res->sparseHandles = handles;
+  res->numSparseHandles = numSparseHandles;
+
+  THCudaCheck(cudaSetDevice(prevDev));
+}
+
 void THCState_reserveBlasHandles(THCState* state, int numBlasHandles)
 {
   // cuBLAS handles are created lazily from THCState_getDeviceBlasHandle
@@ -399,6 +429,16 @@ void THCState_reserveBlasHandles(THCState* state, int numBlasHandles)
   if (numBlasHandles > state->numUserBlasHandles)
   {
     state->numUserBlasHandles = numBlasHandles;
+  }
+}
+
+void THCState_reserveSparseHandles(THCState* state, int numSparseHandles)
+{
+  // cuBLAS handles are created lazily from THCState_getDeviceSparseHandle
+  // to avoid initializing unused devices
+  if (numSparseHandles > state->numUserSparseHandles)
+  {
+    state->numUserSparseHandles = numSparseHandles;
   }
 }
 
@@ -410,6 +450,11 @@ int THCState_getNumStreams(THCState* state)
 int THCState_getNumBlasHandles(THCState* state)
 {
   return state->numUserBlasHandles;
+}
+
+int THCState_getNumSparseHandles(THCState* state)
+{
+  return state->numUserSparseHandles;
 }
 
 THCCudaResourcesPerDevice* THCState_getDeviceResourcePtr(
@@ -444,6 +489,17 @@ cublasHandle_t THCState_getDeviceBlasHandle(THCState *state, int device, int han
   THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, device);
   THCState_reserveDeviceBlasHandles(state, device, handle);
   return res->blasHandles[handle - 1];
+}
+
+cusparseHandle_t THCState_getDeviceSparseHandle(THCState *state, int device, int handle)
+{
+  if (handle <= 0 || handle > state->numUserSparseHandles) {
+    THError("%d is not a valid handle, valid range is: (1, %d)",
+            handle, state->numUserSparseHandles);
+  }
+  THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, device);
+  THCState_reserveDeviceSparseHandles(state, device, handle);
+  return res->sparseHandles[handle - 1];
 }
 
 static THCStream* THCState_getStreamOnDevice(THCState* state, int device)
@@ -509,6 +565,22 @@ cublasHandle_t THCState_getCurrentBlasHandle(THCState *state)
   return NULL;
 }
 
+cusparseHandle_t THCState_getCurrentSparseHandle(THCState *state)
+{
+  /* This is called at the point of kernel execution.
+     For some debugging code or improperly instrumented kernels,
+     `state` is null */
+  if (state) {
+    int device;
+    THCudaCheck(cudaGetDevice(&device));
+
+    int handle = THCState_getCurrentSparseHandleIndex(state);
+    return THCState_getDeviceSparseHandle(state, device, handle);
+  }
+  THError("THCState and sparseHandles must be set as there is no default sparseHandle");
+  return NULL;
+}
+
 int THCState_getCurrentStreamIndex(THCState *state)
 {
   THCStream* stream = THCState_getStream(state);
@@ -528,6 +600,15 @@ int THCState_getCurrentStreamIndex(THCState *state)
 int THCState_getCurrentBlasHandleIndex(THCState *state)
 {
   void* value = THCThreadLocal_get(state->currentPerDeviceBlasHandle);
+  if (value == NULL) {
+    return 1;
+  }
+  return (int) (intptr_t) value;
+}
+
+int THCState_getCurrentSparseHandleIndex(THCState *state)
+{
+  void* value = THCThreadLocal_get(state->currentPerDeviceSparseHandle);
   if (value == NULL) {
     return 1;
   }
@@ -570,6 +651,16 @@ void THCState_setCurrentBlasHandleIndex(THCState *state, int handle)
             handle, state->numUserBlasHandles);
   }
   THCThreadLocal_set(state->currentPerDeviceBlasHandle, (void*)(intptr_t)handle);
+}
+
+void THCState_setCurrentSparseHandleIndex(THCState *state, int handle)
+{
+  if (handle > state->numUserSparseHandles || handle <= 0)
+  {
+    THError("%d is not a valid handle, valid range is: (1, %d)",
+            handle, state->numUserSparseHandles);
+  }
+  THCThreadLocal_set(state->currentPerDeviceSparseHandle, (void*)(intptr_t)handle);
 }
 
 void* THCState_getCurrentDeviceScratchSpace(THCState* state)
@@ -673,6 +764,55 @@ void __THCublasCheck(cublasStatus_t status, const char *file, const int line)
     }
 
     _THError(file, line, "cublas runtime error : %s", errmsg);
+  }
+}
+
+void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line)
+{
+  if(status != CUSPARSE_STATUS_SUCCESS)
+  {
+    const char* errmsg = NULL;
+
+    switch(status)
+    {
+      case CUSPARSE_STATUS_NOT_INITIALIZED:
+        errmsg = "library not initialized";
+        break;
+
+      case CUSPARSE_STATUS_ALLOC_FAILED:
+        errmsg = "resource allocation failed";
+        break;
+
+      case CUSPARSE_STATUS_INVALID_VALUE:
+        errmsg = "an invalid numeric value was used as an argument";
+        break;
+
+      case CUSPARSE_STATUS_ARCH_MISMATCH:
+        errmsg = "an absent device architectural feature is required";
+        break;
+
+      case CUSPARSE_STATUS_MAPPING_ERROR:
+        errmsg = "an access to GPU memory space failed";
+        break;
+
+      case CUSPARSE_STATUS_EXECUTION_FAILED:
+        errmsg = "the GPU program failed to execute";
+        break;
+
+      case CUSPARSE_STATUS_INTERNAL_ERROR:
+        errmsg = "an internal operation failed";
+        break;
+
+      case CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        errmsg = "the matrix type is not supported by this function";
+        break;
+
+      default:
+        errmsg = "unknown error";
+        break;
+    }
+
+    _THError(file, line, "cusparse runtime error : %s", errmsg);
   }
 }
 

--- a/torch/lib/THC/THCGeneral.h.in
+++ b/torch/lib/THC/THCGeneral.h.in
@@ -9,6 +9,7 @@
 #include "cuda.h"
 #include "cuda_runtime.h"
 #include "cublas_v2.h"
+#include "cusparse.h"
 
 #cmakedefine USE_MAGMA
 
@@ -57,8 +58,12 @@ typedef struct _THCCudaResourcesPerDevice {
   THCStream** streams;
   /* Number of materialized cuBLAS handles */
   int numBlasHandles;
+  /* Number of materialized cuSparse handles */
+  int numSparseHandles;
   /* cuBLAS handes are lazily initialized */
   cublasHandle_t* blasHandles;
+  /* cuSparse handes are lazily initialized */
+  cusparseHandle_t* sparseHandles;
   /* Size of scratch space per each stream on this device available */
   size_t scratchSpacePerStream;
   /* Device-resident scratch space per stream, used for global memory
@@ -72,9 +77,9 @@ struct THCState {
   struct THCRNGState* rngState;
   struct cudaDeviceProp* deviceProperties;
   /* Set of all allocated resources. resourcePerDevice[dev]->streams[0] is NULL,
-     which specifies the per-device default stream. blasHandles do not have a
-     default and must be explicitly initialized. We always initialize 1
-     blasHandle but we can use more.
+     which specifies the per-device default stream. blasHandles and
+     sparseHandles do not have a default and must be explicitly initialized.
+     We always initialize 1 blasHandle and 1 sparseHandle but we can use more.
   */
   THCCudaResourcesPerDevice* resourcesPerDevice;
   /* Captured number of devices upon startup; convenience for bounds checking */
@@ -82,6 +87,7 @@ struct THCState {
   /* Number of Torch defined resources available, indices 1 ... numStreams */
   int numUserStreams;
   int numUserBlasHandles;
+  int numUserSparseHandles;
 
   /* Allocator using cudaMallocHost. */
   THAllocator* cudaHostAllocator;
@@ -91,6 +97,9 @@ struct THCState {
   /* Index of the current selected BLAS handle. The actual BLAS handle used
      depends on the current device. */
   THCThreadLocal/*<int>*/ currentPerDeviceBlasHandle;
+  /* Index of the current selected sparse handle. The actual sparse handle used
+     depends on the current device. */
+  THCThreadLocal/*<int>*/ currentPerDeviceSparseHandle;
   /* Array of thread locals containing the current stream for each device */
   THCThreadLocal* currentStreams;
 
@@ -163,10 +172,18 @@ THC_API void THCState_setCurrentStreamIndex(THCState *state, int stream);
 THC_API void THCState_reserveBlasHandles(THCState* state, int numHandles);
 THC_API int THCState_getNumBlasHandles(THCState* state);
 
+THC_API void THCState_reserveSparseHandles(THCState* state, int numHandles);
+THC_API int THCState_getNumSparseHandles(THCState* state);
+
 THC_API cublasHandle_t THCState_getDeviceBlasHandle(THCState *state, int device, int handle);
 THC_API cublasHandle_t THCState_getCurrentBlasHandle(THCState *state);
 THC_API int THCState_getCurrentBlasHandleIndex(THCState *state);
 THC_API void THCState_setCurrentBlasHandleIndex(THCState *state, int handle);
+
+THC_API cusparseHandle_t THCState_getDeviceSparseHandle(THCState *state, int device, int handle);
+THC_API cusparseHandle_t THCState_getCurrentSparseHandle(THCState *state);
+THC_API int THCState_getCurrentSparseHandleIndex(THCState *state);
+THC_API void THCState_setCurrentSparseHandleIndex(THCState *state, int handle);
 
 /* For the current device and stream, returns the allocated scratch space */
 THC_API void* THCState_getCurrentDeviceScratchSpace(THCState* state);
@@ -178,10 +195,12 @@ THC_API size_t THCState_getDeviceScratchSpaceSize(THCState* state, int device);
 #define THCudaCheck(err)  __THCudaCheck(err, __FILE__, __LINE__)
 #define THCudaCheckWarn(err)  __THCudaCheckWarn(err, __FILE__, __LINE__)
 #define THCublasCheck(err)  __THCublasCheck(err,  __FILE__, __LINE__)
+#define THCusparseCheck(err)  __THCusparseCheck(err,  __FILE__, __LINE__)
 
 THC_API void __THCudaCheck(cudaError_t err, const char *file, const int line);
 THC_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line);
 THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
+THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
 
 THC_API cudaError_t THCudaMalloc(THCState *state, void **ptr, size_t size);
 THC_API cudaError_t THCudaFree(THCState *state, void *ptr);

--- a/torch/lib/THC/THCTensorMathPointwise.cuh
+++ b/torch/lib/THC/THCTensorMathPointwise.cuh
@@ -101,6 +101,13 @@ struct TensorSignOp<half> {
 #endif
 
 template <typename T>
+struct TensorAssignOp {
+  __device__ __forceinline__ void operator()(T* out, T* in) {
+    *out = *in;
+  }
+};
+
+template <typename T>
 struct TensorAddOp {
   __device__ __forceinline__ void operator()(T* out, T* in) {
     *out += *in;

--- a/torch/lib/THC/THCTensorMathPointwise.cuh
+++ b/torch/lib/THC/THCTensorMathPointwise.cuh
@@ -101,13 +101,6 @@ struct TensorSignOp<half> {
 #endif
 
 template <typename T>
-struct TensorAssignOp {
-  __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out = *in;
-  }
-};
-
-template <typename T>
 struct TensorAddOp {
   __device__ __forceinline__ void operator()(T* out, T* in) {
     *out += *in;

--- a/torch/lib/THC/generic/THCStorage.cu
+++ b/torch/lib/THC/generic/THCStorage.cu
@@ -62,6 +62,8 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
                                  THCState_getCurrentStream(state));
     if(err != cudaSuccess) {
       THCHeapUpdate(state, -size * sizeof(real));
+      // FIXME REMOVE ME
+      abort();
     }
     THCudaCheck(err);
 

--- a/torch/lib/THC/generic/THCStorage.cu
+++ b/torch/lib/THC/generic/THCStorage.cu
@@ -62,8 +62,6 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
                                  THCState_getCurrentStream(state));
     if(err != cudaSuccess) {
       THCHeapUpdate(state, -size * sizeof(real));
-      // FIXME REMOVE ME
-      abort();
     }
     THCudaCheck(err);
 

--- a/torch/lib/THCS/CMakeLists.txt
+++ b/torch/lib/THCS/CMakeLists.txt
@@ -106,6 +106,7 @@ SET(src
 
 SET(src-cuda
   THCSTensor.cu
+  THCSparse.cu
   )
 
 MESSAGE(STATUS "got cuda version " ${CUDA_VERSION})
@@ -149,6 +150,7 @@ INSTALL(FILES
           THCSGenerateFloatType.h
           THCSGenerateFloatTypes.h
           THCSGenerateDoubleType.h
+          THCSparse.h
           DESTINATION "${THCS_INSTALL_INCLUDE_SUBDIR}/THCS")
 
 INSTALL(FILES

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -1,5 +1,6 @@
 #include "THCSTensor.h"
 #include "THCApply.cuh"
+#include "THCTensorMathPointwise.cuh"
 #include "stdio.h"
 
 template <typename IndexType, typename Real>
@@ -13,10 +14,76 @@ __global__ void THCSTensor_toDenseKernel(
       linearId += gridDim.x * blockDim.x) {
     IndexType index = 0;
     IndexType indskip = indices.strides[0];
-    for (IndexType d = 0; d < indices.sizes[0]; d++)
+    IndexType valueStride = values.strides[0];
+    TensorAddOp<Real> addOp = TensorAddOp<Real>();
+    for (IndexType d = 0; d < indices.sizes[0]; d++) {
       index = other.sizes[d] * index + indices.data[d * indskip + linearId];
-    other.data[index] = other.data[index] + values.data[linearId];
+    }
+    for (IndexType k = 0; k < values.strides[0]; k++) {
+      addOp(other.data + index * valueStride + k, values.data + linearId * valueStride + k);
+    }
   }
+}
+
+template <typename IndexType, typename Real>
+__global__ void THCSTensor_uniqueValuesReorderKernel(
+    TensorInfo<long, IndexType> indices,
+    TensorInfo<Real, IndexType> values,
+    const IndexType nnz) {
+  IndexType i = 0;
+  IndexType indskip = indices.strides[0];
+  IndexType valueStride = values.strides[0];
+  TensorAddOp<Real> addOp = TensorAddOp<Real>();
+  for (IndexType j = 1; j < nnz; j++) {
+    int cmp = 1;
+    for (IndexType d = 0; d < indices.sizes[0]; d++) {
+      if (indices.data[d * indskip + i] != indices.data[d * indskip + j]) {
+        cmp = 0;
+        break;
+      }
+    }
+    if (cmp) {
+      for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
+           k < valueStride;
+           k += gridDim.x * blockDim.x) {
+        addOp(values.data + i * valueStride + k, values.data + j * valueStride + k);
+      }
+    } else {
+      ++i;
+      for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
+           k < valueStride;
+           k += gridDim.x * blockDim.x) {
+        values.data[i * valueStride + k] = values.data[j * valueStride + k];
+      }
+    }
+  }
+}
+
+template <typename IndexType, typename Real>
+__global__ void THCSTensor_uniqueIndicesReorderKernel(
+    TensorInfo<long, IndexType> indices,
+    const IndexType nnz,
+    IndexType* resultNnz) {
+  IndexType i = 0;
+  IndexType indskip = indices.strides[0];
+  for (IndexType j = 1; j < nnz; j++) {
+    int cmp = 1;
+    for (IndexType d = 0; d < indices.sizes[0]; d++) {
+      if (indices.data[d * indskip + i] != indices.data[d * indskip + j]) {
+        cmp = 0;
+        break;
+      }
+    }
+    if (!cmp) {
+      ++i;
+      if (blockIdx.x == 0 && threadIdx.x == 0) {
+        for (IndexType d = 0; d < indices.sizes[0]; d++) {
+          indices.data[d * indskip + i] = indices.data[d * indskip + j];
+        }
+      }
+    }
+  }
+  *resultNnz = i + 1;
 }
 
 #include "generic/THCSTensor.cu"

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -65,7 +65,7 @@ __global__ void THCSTensor_uniqueValuesReorderKernel(
   for (IndexType j = 1; j < nnz; j++) {
     int cmp = 1;
     for (IndexType d = 0; d < indices.sizes[0]; d++) {
-      if (indices.data[d * indskip + i] != indices.data[d * indskip + j]) {
+      if (indices.data[d * indskip + j - 1] != indices.data[d * indskip + j]) {
         cmp = 0;
         break;
       }
@@ -89,6 +89,8 @@ __global__ void THCSTensor_uniqueIndicesReorderKernel(
   for (IndexType j = 1; j < nnz; j++) {
     int cmp = 1;
     for (IndexType d = 0; d < indices.sizes[0]; d++) {
+      // note the difference with uniqueValuesReorderKernel:
+      // i instead of j - 1, because we're moving the indices
       if (indices.data[d * indskip + i] != indices.data[d * indskip + j]) {
         cmp = 0;
         break;

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -31,10 +31,10 @@ __device__ void applyOp3(
 }
 
 template <typename Op, typename IndexType, typename Real>
-__global__ void THCSTensor_spcKernel(
+__global__ void THCSTensor_sparseElementwiseKernel(
     Op op,
     TensorInfo<Real, IndexType> dense,
-    TensorInfo<integer, IndexType> indices,
+    TensorInfo<indexT, IndexType> indices,
     TensorInfo<Real, IndexType> values,
     const IndexType nnz) {
   IndexType indskip = indices.strides[0];
@@ -55,10 +55,10 @@ __global__ void THCSTensor_spcKernel(
 }
 
 template <typename Op, typename IndexType, typename Real>
-__global__ void THCSTensor_spcKernelScalar(
+__global__ void THCSTensor_sparseElementwiseKernelScalar(
     Op op,
     TensorInfo<Real, IndexType> dense,
-    TensorInfo<integer, IndexType> indices,
+    TensorInfo<indexT, IndexType> indices,
     TensorInfo<Real, IndexType> values,
     const IndexType nnz) {
   IndexType indskip = indices.strides[0];
@@ -78,9 +78,9 @@ __global__ void THCSTensor_valueSparseUnionKernel(
     OpBoth opBoth,
     OpLeft opLeft,
     OpRight opRight,
-    TensorInfo<integer, IndexType> r_indices,
-    TensorInfo<integer, IndexType> t_indices,
-    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<indexT, IndexType> r_indices,
+    TensorInfo<indexT, IndexType> t_indices,
+    TensorInfo<indexT, IndexType> s_indices,
     TensorInfo<Real, IndexType> r_values,
     TensorInfo<Real, IndexType> t_values,
     TensorInfo<Real, IndexType> s_values,
@@ -116,11 +116,12 @@ __global__ void THCSTensor_valueSparseUnionKernel(
   }
 }
 
+// TODO find a way to parallelize this...
 template <typename IndexType, typename Real>
 __global__ void THCSTensor_indexSparseUnionKernel(
-    TensorInfo<integer, IndexType> r_indices,
-    TensorInfo<integer, IndexType> t_indices,
-    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<indexT, IndexType> r_indices,
+    TensorInfo<indexT, IndexType> t_indices,
+    TensorInfo<indexT, IndexType> s_indices,
     const IndexType t_nnz, const IndexType s_nnz, IndexType *resultNnz) {
   IndexType r_indskip = r_indices.strides[0];
   IndexType t_indskip = t_indices.strides[0];
@@ -166,9 +167,9 @@ __global__ void THCSTensor_indexSparseUnionKernel(
 template <typename Op, typename IndexType, typename Real>
 __global__ void THCSTensor_valueSparseIntersectionKernel(
     Op op,
-    TensorInfo<integer, IndexType> r_indices,
-    TensorInfo<integer, IndexType> t_indices,
-    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<indexT, IndexType> r_indices,
+    TensorInfo<indexT, IndexType> t_indices,
+    TensorInfo<indexT, IndexType> s_indices,
     TensorInfo<Real, IndexType> r_values,
     TensorInfo<Real, IndexType> t_values,
     TensorInfo<Real, IndexType> s_values,
@@ -198,11 +199,12 @@ __global__ void THCSTensor_valueSparseIntersectionKernel(
   }
 }
 
+// TODO find a way to parallelize this...
 template <typename IndexType, typename Real>
 __global__ void THCSTensor_indexSparseIntersectionKernel(
-    TensorInfo<integer, IndexType> r_indices,
-    TensorInfo<integer, IndexType> t_indices,
-    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<indexT, IndexType> r_indices,
+    TensorInfo<indexT, IndexType> t_indices,
+    TensorInfo<indexT, IndexType> s_indices,
     const IndexType t_nnz, const IndexType s_nnz, IndexType *resultNnz) {
   IndexType r_indskip = r_indices.strides[0];
   IndexType t_indskip = t_indices.strides[0];

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -3,37 +3,65 @@
 #include "THCTensorMathPointwise.cuh"
 #include "stdio.h"
 
-template <typename IndexType, typename Real>
-__global__ void THCSTensor_toDenseKernel(
-    TensorInfo<Real, IndexType> other,
-    TensorInfo<long, IndexType> indices,
+template <typename Op, typename IndexType, typename Real>
+__global__ void THCSTensor_spcKernel(
+    Op op,
+    TensorInfo<Real, IndexType> dense,
+    TensorInfo<integer, IndexType> indices,
     TensorInfo<Real, IndexType> values,
     const IndexType nnz) {
+  IndexType indskip = indices.strides[0];
+  IndexType valueSize = values.strides[0];
   for (IndexType linearId = blockIdx.x * blockDim.x + threadIdx.x;
-      linearId < nnz;
-      linearId += gridDim.x * blockDim.x) {
+       linearId < nnz;
+       linearId += gridDim.x * blockDim.x) {
     IndexType index = 0;
-    IndexType indskip = indices.strides[0];
-    IndexType valueStride = values.strides[0];
-    TensorAddOp<Real> addOp = TensorAddOp<Real>();
     for (IndexType d = 0; d < indices.sizes[0]; d++) {
-      index = other.sizes[d] * index + indices.data[d * indskip + linearId];
+      index = dense.sizes[d] * index + indices.data[d * indskip + linearId];
     }
-    for (IndexType k = 0; k < values.strides[0]; k++) {
-      addOp(other.data + index * valueStride + k, values.data + linearId * valueStride + k);
+    for (IndexType k = 0; k < valueSize; k++) {
+      op(dense.data + index * valueSize + k, values.data + linearId * valueSize + k);
     }
+  }
+}
+
+template <typename IndexType, typename Real, typename Op>
+__device__ void applyOp2(
+    Op op, IndexType blockSize,
+    TensorInfo<Real, IndexType> values1, IndexType idx1,
+    TensorInfo<Real, IndexType> values2, IndexType idx2) {
+  for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
+       k < blockSize;
+       k += gridDim.x * blockDim.x) {
+    op(values1.data + idx1 * blockSize + k, values2.data + idx2 * blockSize + k);
+  }
+}
+
+template <typename IndexType, typename Real, typename Op>
+__device__ void applyOp3(
+    Op op, IndexType blockSize,
+    TensorInfo<Real, IndexType> values1, IndexType idx1,
+    TensorInfo<Real, IndexType> values2, IndexType idx2,
+    TensorInfo<Real, IndexType> values3, IndexType idx3) {
+  for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
+       k < blockSize;
+       k += gridDim.x * blockDim.x) {
+    op(values1.data + idx1 * blockSize + k,
+       values2.data + idx2 * blockSize + k,
+       values3.data + idx3 * blockSize + k);
   }
 }
 
 template <typename IndexType, typename Real>
 __global__ void THCSTensor_uniqueValuesReorderKernel(
-    TensorInfo<long, IndexType> indices,
+    TensorInfo<integer, IndexType> indices,
     TensorInfo<Real, IndexType> values,
     const IndexType nnz) {
   IndexType i = 0;
   IndexType indskip = indices.strides[0];
-  IndexType valueStride = values.strides[0];
+  IndexType valueSize = values.strides[0];
   TensorAddOp<Real> addOp = TensorAddOp<Real>();
+  TensorAssignOp<Real> assignOp = TensorAssignOp<Real>();
   for (IndexType j = 1; j < nnz; j++) {
     int cmp = 1;
     for (IndexType d = 0; d < indices.sizes[0]; d++) {
@@ -43,25 +71,17 @@ __global__ void THCSTensor_uniqueValuesReorderKernel(
       }
     }
     if (cmp) {
-      for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
-           k < valueStride;
-           k += gridDim.x * blockDim.x) {
-        addOp(values.data + i * valueStride + k, values.data + j * valueStride + k);
-      }
+      applyOp2(addOp, valueSize, values, i, values, j);
     } else {
       ++i;
-      for (IndexType k = blockIdx.x * blockDim.x + threadIdx.x;
-           k < valueStride;
-           k += gridDim.x * blockDim.x) {
-        values.data[i * valueStride + k] = values.data[j * valueStride + k];
-      }
+      applyOp2(assignOp, valueSize, values, i, values, j);
     }
   }
 }
 
 template <typename IndexType, typename Real>
 __global__ void THCSTensor_uniqueIndicesReorderKernel(
-    TensorInfo<long, IndexType> indices,
+    TensorInfo<integer, IndexType> indices,
     const IndexType nnz,
     IndexType* resultNnz) {
   IndexType i = 0;
@@ -84,6 +104,166 @@ __global__ void THCSTensor_uniqueIndicesReorderKernel(
     }
   }
   *resultNnz = i + 1;
+}
+
+template <typename OpBoth, typename OpLeft, typename OpRight, typename IndexType, typename Real>
+__global__ void THCSTensor_valueSparseUnionKernel(
+    OpBoth opBoth,
+    OpLeft opLeft,
+    OpRight opRight,
+    TensorInfo<integer, IndexType> r_indices,
+    TensorInfo<integer, IndexType> t_indices,
+    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<Real, IndexType> r_values,
+    TensorInfo<Real, IndexType> t_values,
+    TensorInfo<Real, IndexType> s_values,
+    const IndexType t_nnz, const IndexType s_nnz) {
+  IndexType t_indskip = t_indices.strides[0];
+  IndexType s_indskip = s_indices.strides[0];
+  long cmp, d;
+  long nDimI = r_indices.sizes[0];
+  IndexType valueSize = r_values.strides[0];
+  IndexType r_i = 0, t_i = 0, s_i = 0;
+  while (t_i < t_nnz || s_i < s_nnz) {
+    if (t_i >= t_nnz) {
+      cmp = -1;
+    } else if (s_i >= s_nnz) {
+      cmp = 1;
+    } else {
+      cmp = 0;
+      for (d = 0; d < nDimI; d++) {
+        if (t_indices.data[d * t_indskip + t_i] < s_indices.data[d * s_indskip + s_i]) {
+          cmp = 1;
+          break;
+        }
+        if (t_indices.data[d * t_indskip + t_i] > s_indices.data[d * s_indskip + s_i]) {
+          cmp = -1;
+          break;
+        }
+      }
+    }
+    if (cmp == 0) applyOp3(opBoth, valueSize, r_values, r_i, t_values, t_i++, s_values, s_i++);
+    else if (cmp > 0) applyOp2(opLeft, valueSize, r_values, r_i, t_values, t_i++);
+    else if (cmp < 0) applyOp2(opRight, valueSize, r_values, r_i, s_values, s_i++);
+    r_i++;
+  }
+}
+
+template <typename IndexType, typename Real>
+__global__ void THCSTensor_indexSparseUnionKernel(
+    TensorInfo<integer, IndexType> r_indices,
+    TensorInfo<integer, IndexType> t_indices,
+    TensorInfo<integer, IndexType> s_indices,
+    const IndexType t_nnz, const IndexType s_nnz, IndexType *resultNnz) {
+  IndexType r_indskip = r_indices.strides[0];
+  IndexType t_indskip = t_indices.strides[0];
+  IndexType s_indskip = s_indices.strides[0];
+  long cmp, d;
+  long nDimI = r_indices.sizes[0];
+  IndexType r_i = 0, t_i = 0, s_i = 0;
+  while (t_i < t_nnz || s_i < s_nnz) {
+    if (t_i >= t_nnz) {
+      cmp = -1;
+    } else if (s_i >= s_nnz) {
+      cmp = 1;
+    } else {
+      cmp = 0;
+      for (d = 0; d < nDimI; d++) {
+        if (t_indices.data[d * t_indskip + t_i] < s_indices.data[d * s_indskip + s_i]) {
+          cmp = 1;
+          break;
+        }
+        if (t_indices.data[d * t_indskip + t_i] > s_indices.data[d * s_indskip + s_i]) {
+          cmp = -1;
+          break;
+        }
+      }
+    }
+    if (cmp >= 0) {
+      for (d = 0; d < nDimI; d++) {
+        r_indices.data[d * r_indskip + r_i] = t_indices.data[d * t_indskip + t_i];
+      }
+      t_i++;
+    }
+    if (cmp <= 0) {
+      for (d = 0; d < nDimI; d++) {
+        r_indices.data[d * r_indskip + r_i] = s_indices.data[d * s_indskip + s_i];
+      }
+      s_i++;
+    }
+    r_i++;
+  }
+  *resultNnz = r_i;
+}
+
+template <typename Op, typename IndexType, typename Real>
+__global__ void THCSTensor_valueSparseIntersectionKernel(
+    Op op,
+    TensorInfo<integer, IndexType> r_indices,
+    TensorInfo<integer, IndexType> t_indices,
+    TensorInfo<integer, IndexType> s_indices,
+    TensorInfo<Real, IndexType> r_values,
+    TensorInfo<Real, IndexType> t_values,
+    TensorInfo<Real, IndexType> s_values,
+    const IndexType t_nnz, const IndexType s_nnz) {
+  IndexType t_indskip = t_indices.strides[0];
+  IndexType s_indskip = s_indices.strides[0];
+  long match, d;
+  long nDimI = r_indices.sizes[0];
+  IndexType valueSize = r_values.strides[0];
+  IndexType r_i = 0, t_i = 0, s_i = 0;
+  while (t_i < t_nnz && s_i < s_nnz) {
+    match = 1;
+    for (d = 0; d < nDimI; d++) {
+      if (t_indices.data[d * t_indskip + t_i] < s_indices.data[d * s_indskip + s_i]) {
+        t_i++;
+        match = 0;
+        break;
+      }
+      if (t_indices.data[d * t_indskip + t_i] > s_indices.data[d * s_indskip + s_i]) {
+        s_i++;
+        match = 0;
+        break;
+      }
+    }
+    if (!match) continue;
+    applyOp3(op, valueSize, r_values, r_i++, t_values, t_i++, s_values, s_i++);
+  }
+}
+
+template <typename IndexType, typename Real>
+__global__ void THCSTensor_indexSparseIntersectionKernel(
+    TensorInfo<integer, IndexType> r_indices,
+    TensorInfo<integer, IndexType> t_indices,
+    TensorInfo<integer, IndexType> s_indices,
+    const IndexType t_nnz, const IndexType s_nnz, IndexType *resultNnz) {
+  IndexType r_indskip = r_indices.strides[0];
+  IndexType t_indskip = t_indices.strides[0];
+  IndexType s_indskip = s_indices.strides[0];
+  long match, d;
+  long nDimI = r_indices.sizes[0];
+  IndexType r_i = 0, t_i = 0, s_i = 0;
+  while (t_i < t_nnz && s_i < s_nnz) {
+    match = 1;
+    for (d = 0; d < nDimI; d++) {
+      if (t_indices.data[d * t_indskip + t_i] < s_indices.data[d * s_indskip + s_i]) {
+        t_i++;
+        match = 0;
+        break;
+      }
+      if (t_indices.data[d * t_indskip + t_i] > s_indices.data[d * s_indskip + s_i]) {
+        s_i++;
+        match = 0;
+        break;
+      }
+    }
+    if (!match) continue;
+    for (d = 0; d < nDimI; d++) {
+      r_indices.data[d * r_indskip + r_i] = t_indices.data[d * t_indskip + t_i];
+    }
+    r_i++; t_i++; s_i++;
+  }
+  *resultNnz = r_i;
 }
 
 #include "generic/THCSTensor.cu"

--- a/torch/lib/THCS/THCSTensor.h
+++ b/torch/lib/THCS/THCSTensor.h
@@ -4,12 +4,15 @@
 #include <THC/THC.h>
 #include <THS/THSTensor.h>
 
+#include "THCSparse.h"
+
 #define THCSTensor          TH_CONCAT_3(THCS,Real,Tensor)
 #define THCSTensor_(NAME)   TH_CONCAT_4(THCS,Real,Tensor_,NAME)
 
-#define THCIndexTensor          THCudaLongTensor
-#define THCIndexTensor_(NAME)   THCudaLongTensor_ ## NAME
-#define integer                 long
+// Using int for indices because that's what cuSparse uses...
+#define THCIndexTensor          THCudaIntTensor
+#define THCIndexTensor_(NAME)   THCudaIntTensor_ ## NAME
+#define integer                 int
 
 #include "generic/THCSTensor.h"
 #include "THCSGenerateAllTypes.h"

--- a/torch/lib/THCS/THCSTensor.h
+++ b/torch/lib/THCS/THCSTensor.h
@@ -9,10 +9,9 @@
 #define THCSTensor          TH_CONCAT_3(THCS,Real,Tensor)
 #define THCSTensor_(NAME)   TH_CONCAT_4(THCS,Real,Tensor_,NAME)
 
-// Using int for indices because that's what cuSparse uses...
-#define THCIndexTensor          THCudaIntTensor
-#define THCIndexTensor_(NAME)   THCudaIntTensor_ ## NAME
-#define integer                 int
+#define THCIndexTensor          THCudaLongTensor
+#define THCIndexTensor_(NAME)   THCudaLongTensor_ ## NAME
+#define integer                 long
 
 #include "generic/THCSTensor.h"
 #include "THCSGenerateAllTypes.h"

--- a/torch/lib/THCS/THCSTensor.h
+++ b/torch/lib/THCS/THCSTensor.h
@@ -10,7 +10,7 @@
 #define THCSTensor_(NAME)   TH_CONCAT_4(THCS,Real,Tensor_,NAME)
 
 #define THCIndexTensor          THCudaLongTensor
-#define THCIndexTensor_(NAME)   THCudaLongTensor_ ## NAME
+#define THCIndexTensor_(NAME)   TH_CONCAT_2(THCudaLongTensor_,NAME)
 #define integer                 long
 
 #include "generic/THCSTensor.h"

--- a/torch/lib/THCS/THCSTensor.h
+++ b/torch/lib/THCS/THCSTensor.h
@@ -11,7 +11,7 @@
 
 #define THCIndexTensor          THCudaLongTensor
 #define THCIndexTensor_(NAME)   TH_CONCAT_2(THCudaLongTensor_,NAME)
-#define integer                 long
+#define indexT                  long
 
 #include "generic/THCSTensor.h"
 #include "THCSGenerateAllTypes.h"

--- a/torch/lib/THCS/THCSTensor.h
+++ b/torch/lib/THCS/THCSTensor.h
@@ -9,6 +9,7 @@
 
 #define THCIndexTensor          THCudaLongTensor
 #define THCIndexTensor_(NAME)   THCudaLongTensor_ ## NAME
+#define integer                 long
 
 #include "generic/THCSTensor.h"
 #include "THCSGenerateAllTypes.h"
@@ -17,4 +18,3 @@
 #include "THCSGenerateAllTypes.h"
 
 #endif
-

--- a/torch/lib/THCS/THCSparse.cu
+++ b/torch/lib/THCS/THCSparse.cu
@@ -1,0 +1,123 @@
+#include "THCSparse.h"
+
+void THCudaSparse_Xcoo2csr(THCState *state, const int *coorowind, long nnz, long m, int *csrrowptr) {
+  if ((m <= INT_MAX) && (nnz <= INT_MAX))
+  {
+    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+    cusparseSetStream(handle, THCState_getCurrentStream(state));
+    THCusparseCheck(cusparseXcoo2csr(handle, coorowind, nnz, m, csrrowptr,
+      TH_INDEX_BASE ? CUSPARSE_INDEX_BASE_ONE : CUSPARSE_INDEX_BASE_ZERO
+    ));
+    return;
+  }
+  THError("cusparseXcoo2csr only supports m, nnz "
+          "with the bound [val] <= %d", INT_MAX);
+}
+
+cusparseOperation_t convertTransToCusparseOperation(char trans) {
+  if (trans == 't') return CUSPARSE_OPERATION_TRANSPOSE;
+  else if (trans == 'n') return CUSPARSE_OPERATION_NON_TRANSPOSE;
+  else if (trans == 'c') return CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+  else {
+    THError("trans must be one of: t, n, c");
+    return CUSPARSE_OPERATION_TRANSPOSE;
+  }
+}
+
+void adjustLd(char transb, long m, long n, long k, long *ldb, long *ldc)
+{
+  int transb_ = ((transb == 't') || (transb == 'T'));
+
+  if(n == 1)
+    *ldc = m;
+
+  if(transb_)
+  {
+    if(k == 1)
+      *ldb = n;
+  }
+  else
+  {
+    if(n == 1)
+      *ldb = k;
+  }
+}
+
+/* Level 3 */
+void THCudaSparse_Scsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, long ldb, float beta, float *c, long ldc)
+{
+  adjustLd(transb, m, n, k, &ldb, &ldc);
+  cusparseOperation_t opa = convertTransToCusparseOperation(transa);
+  cusparseOperation_t opb = convertTransToCusparseOperation(transb);
+
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
+  {
+    int i_m = (int)m;
+    int i_n = (int)n;
+    int i_k = (int)k;
+    int i_nnz = (int)nnz;
+    int i_ldb = (int)ldb;
+    int i_ldc = (int)ldc;
+
+    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+    cusparseSetStream(handle, THCState_getCurrentStream(state));
+    cusparseMatDescr_t desc;
+    cusparseCreateMatDescr(&desc);
+#if TH_INDEX_BASE == 1
+    cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
+#endif
+    // cusparseMatDescr_t desc = { \
+    //   CUSPARSE_MATRIX_TYPE_GENERAL, \
+    //   CUSPARSE_FILL_MODE_LOWER, \
+    //   CUSPARSE_DIAG_TYPE_NON_UNIT, \
+    // #if TH_INDEX_BASE==1
+    //   CUSPARSE_INDEX_BASE_ONE \
+    // #else
+    //   CUSPARSE_INDEX_BASE_ZERO \
+    // #endif
+    // };  // completely general sparse matrix
+    THCusparseCheck(cusparseScsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
+    return;
+  }
+  THError("cusparseScsrmm2 only supports m, n, k, nnz, ldb, ldc "
+          "with the bound [val] <= %d", INT_MAX);
+}
+
+void THCudaSparse_Dcsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, long ldb, double beta, double *c, long ldc)
+{
+  adjustLd(transb, m, n, k, &ldb, &ldc);
+  cusparseOperation_t opa = convertTransToCusparseOperation(transa);
+  cusparseOperation_t opb = convertTransToCusparseOperation(transb);
+
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
+  {
+    int i_m = (int)m;
+    int i_n = (int)n;
+    int i_k = (int)k;
+    int i_nnz = (int)nnz;
+    int i_ldb = (int)ldb;
+    int i_ldc = (int)ldc;
+
+    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+    cusparseSetStream(handle, THCState_getCurrentStream(state));
+    cusparseMatDescr_t desc;
+    cusparseCreateMatDescr(&desc);
+#if TH_INDEX_BASE == 1
+    cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
+#endif
+    // cusparseMatDescr_t desc = { \
+    //   CUSPARSE_MATRIX_TYPE_GENERAL, \
+    //   CUSPARSE_FILL_MODE_LOWER, \
+    //   CUSPARSE_DIAG_TYPE_NON_UNIT, \
+    // #if TH_INDEX_BASE==1
+    //   CUSPARSE_INDEX_BASE_ONE \
+    // #else
+    //   CUSPARSE_INDEX_BASE_ZERO \
+    // #endif
+    // };  // completely general sparse matrix
+    THCusparseCheck(cusparseDcsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
+    return;
+  }
+  THError("cusparseDcsrmm2 only supports m, n, k, nnz, ldb, ldc "
+          "with the bound [val] <= %d", INT_MAX);
+}

--- a/torch/lib/THCS/THCSparse.cu
+++ b/torch/lib/THCS/THCSparse.cu
@@ -1,17 +1,14 @@
 #include "THCSparse.h"
 
 void THCudaSparse_Xcoo2csr(THCState *state, const int *coorowind, long nnz, long m, int *csrrowptr) {
-  if ((m <= INT_MAX) && (nnz <= INT_MAX))
-  {
-    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
-    cusparseSetStream(handle, THCState_getCurrentStream(state));
-    THCusparseCheck(cusparseXcoo2csr(handle, coorowind, nnz, m, csrrowptr,
-      TH_INDEX_BASE ? CUSPARSE_INDEX_BASE_ONE : CUSPARSE_INDEX_BASE_ZERO
-    ));
-    return;
-  }
-  THError("cusparseXcoo2csr only supports m, nnz "
-          "with the bound [val] <= %d", INT_MAX);
+  THAssertMsg((m <= INT_MAX) && (nnz <= INT_MAX),
+    "cusparseXcoo2csr only supports m, nnz with the bound [val] <= %d",
+    INT_MAX);
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  THCusparseCheck(cusparseXcoo2csr(handle, coorowind, nnz, m, csrrowptr,
+    TH_INDEX_BASE ? CUSPARSE_INDEX_BASE_ONE : CUSPARSE_INDEX_BASE_ZERO
+  ));
 }
 
 cusparseOperation_t convertTransToCusparseOperation(char trans) {
@@ -50,37 +47,24 @@ void THCudaSparse_Scsrmm2(THCState *state, char transa, char transb, long m, lon
   cusparseOperation_t opa = convertTransToCusparseOperation(transa);
   cusparseOperation_t opb = convertTransToCusparseOperation(transb);
 
-  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
-  {
-    int i_m = (int)m;
-    int i_n = (int)n;
-    int i_k = (int)k;
-    int i_nnz = (int)nnz;
-    int i_ldb = (int)ldb;
-    int i_ldc = (int)ldc;
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX),
+    "cusparseScsrmm2 only supports m, n, k, nnz, ldb, ldc with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_k = (int)k;
+  int i_nnz = (int)nnz;
+  int i_ldb = (int)ldb;
+  int i_ldc = (int)ldc;
 
-    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
-    cusparseSetStream(handle, THCState_getCurrentStream(state));
-    cusparseMatDescr_t desc;
-    cusparseCreateMatDescr(&desc);
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  cusparseMatDescr_t desc;
+  cusparseCreateMatDescr(&desc);
 #if TH_INDEX_BASE == 1
-    cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
+  cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
 #endif
-    // cusparseMatDescr_t desc = { \
-    //   CUSPARSE_MATRIX_TYPE_GENERAL, \
-    //   CUSPARSE_FILL_MODE_LOWER, \
-    //   CUSPARSE_DIAG_TYPE_NON_UNIT, \
-    // #if TH_INDEX_BASE==1
-    //   CUSPARSE_INDEX_BASE_ONE \
-    // #else
-    //   CUSPARSE_INDEX_BASE_ZERO \
-    // #endif
-    // };  // completely general sparse matrix
-    THCusparseCheck(cusparseScsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
-    return;
-  }
-  THError("cusparseScsrmm2 only supports m, n, k, nnz, ldb, ldc "
-          "with the bound [val] <= %d", INT_MAX);
+  THCusparseCheck(cusparseScsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
 }
 
 void THCudaSparse_Dcsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, long ldb, double beta, double *c, long ldc)
@@ -89,35 +73,95 @@ void THCudaSparse_Dcsrmm2(THCState *state, char transa, char transb, long m, lon
   cusparseOperation_t opa = convertTransToCusparseOperation(transa);
   cusparseOperation_t opb = convertTransToCusparseOperation(transb);
 
-  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
-  {
-    int i_m = (int)m;
-    int i_n = (int)n;
-    int i_k = (int)k;
-    int i_nnz = (int)nnz;
-    int i_ldb = (int)ldb;
-    int i_ldc = (int)ldc;
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX),
+    "cusparseDcsrmm2 only supports m, n, k, nnz, ldb, ldc with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_k = (int)k;
+  int i_nnz = (int)nnz;
+  int i_ldb = (int)ldb;
+  int i_ldc = (int)ldc;
 
-    cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
-    cusparseSetStream(handle, THCState_getCurrentStream(state));
-    cusparseMatDescr_t desc;
-    cusparseCreateMatDescr(&desc);
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  cusparseMatDescr_t desc;
+  cusparseCreateMatDescr(&desc);
 #if TH_INDEX_BASE == 1
-    cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
+  cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
 #endif
-    // cusparseMatDescr_t desc = { \
-    //   CUSPARSE_MATRIX_TYPE_GENERAL, \
-    //   CUSPARSE_FILL_MODE_LOWER, \
-    //   CUSPARSE_DIAG_TYPE_NON_UNIT, \
-    // #if TH_INDEX_BASE==1
-    //   CUSPARSE_INDEX_BASE_ONE \
-    // #else
-    //   CUSPARSE_INDEX_BASE_ZERO \
-    // #endif
-    // };  // completely general sparse matrix
-    THCusparseCheck(cusparseDcsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
-    return;
-  }
-  THError("cusparseDcsrmm2 only supports m, n, k, nnz, ldb, ldc "
-          "with the bound [val] <= %d", INT_MAX);
+  THCusparseCheck(cusparseDcsrmm2(handle, opa, opb, i_m, i_n, i_k, i_nnz, &alpha, desc, csrvala, csrrowptra, csrcolinda, b, i_ldb, &beta, c, i_ldc));
+}
+
+/* format conversion */
+void THCudaSparse_CreateIdentityPermutation(THCState *state, long nnz, int *P) {
+  THAssertMsg((nnz <= INT_MAX),
+    "Xcsrsort_bufferSizeExt only supports m, n, nnz with the bound [val] <= %d",
+    INT_MAX);
+  int i_nnz = (int)nnz;
+
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  cusparseCreateIdentityPermutation(handle, i_nnz, P);
+}
+
+void THCudaSparse_Xcsrsort_bufferSizeExt(THCState *state, long m, long n, long nnz, const int *csrRowPtr, const int *csrColInd, size_t *pBufferSizeInBytes)
+{
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (nnz <= INT_MAX),
+    "Xcsrsort_bufferSizeExt only supports m, n, nnz with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_nnz = (int)nnz;
+
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  THCusparseCheck(cusparseXcsrsort_bufferSizeExt(handle, i_m, i_n, i_nnz, csrRowPtr, csrColInd, pBufferSizeInBytes));
+}
+
+void THCudaSparse_Xcsrsort(THCState *state, long m, long n, long nnz, const int *csrRowPtr, int *csrColInd, int *P, void *pBuffer)
+{
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (nnz <= INT_MAX),
+    "Xcsrsort only supports m, n, nnz with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_nnz = (int)nnz;
+
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  cusparseMatDescr_t desc;
+  cusparseCreateMatDescr(&desc);
+#if TH_INDEX_BASE == 1
+  cusparseSetMatIndexBase(&desc, CUSPARSE_INDEX_BASE_ONE);
+#endif
+  THCusparseCheck(cusparseXcsrsort(handle, i_m, i_n, i_nnz, desc, csrRowPtr, csrColInd, P, pBuffer));
+}
+
+void THCudaSparse_Xcoosort_bufferSizeExt(THCState *state, long m, long n, long nnz, const int *cooRows, const int *cooCols, size_t *pBufferSizeInBytes)
+{
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (nnz <= INT_MAX),
+    "Xcoosort_bufferSizeExt only supports m, n, nnz with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_nnz = (int)nnz;
+
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  THCusparseCheck(cusparseXcoosort_bufferSizeExt(handle, i_m, i_n, i_nnz, cooRows, cooCols, pBufferSizeInBytes));
+}
+
+THC_API void THCudaSparse_XcoosortByRow(THCState *state, long m, long n, long nnz, int *cooRows, int *cooCols, int *P, void *pBuffer)
+{
+  THAssertMsg((m <= INT_MAX) && (n <= INT_MAX) && (nnz <= INT_MAX),
+    "XcoosortByRow only supports m, n, nnz with the bound [val] <= %d",
+    INT_MAX);
+  int i_m = (int)m;
+  int i_n = (int)n;
+  int i_nnz = (int)nnz;
+
+  cusparseHandle_t handle = THCState_getCurrentSparseHandle(state);
+  cusparseSetStream(handle, THCState_getCurrentStream(state));
+  THCusparseCheck(cusparseXcoosortByRow(handle, i_m, i_n, i_nnz, cooRows, cooCols, P, pBuffer));
 }

--- a/torch/lib/THCS/THCSparse.h
+++ b/torch/lib/THCS/THCSparse.h
@@ -1,0 +1,12 @@
+#ifndef THC_SPARSE_INC
+#define THC_SPARSE_INC
+
+#include <THC/THCGeneral.h>
+
+THC_API void THCudaSparse_Xcoo2csr(THCState *state, const int *coorowind, long nnz, long m, int *csrrowptr);
+
+/* Level 3 */
+THC_API void THCudaSparse_Scsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, long ldb, float beta, float *c, long ldc);
+THC_API void THCudaSparse_Dcsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, long ldb, double beta, double *c, long ldc);
+
+#endif

--- a/torch/lib/THCS/THCSparse.h
+++ b/torch/lib/THCS/THCSparse.h
@@ -9,4 +9,11 @@ THC_API void THCudaSparse_Xcoo2csr(THCState *state, const int *coorowind, long n
 THC_API void THCudaSparse_Scsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, long ldb, float beta, float *c, long ldc);
 THC_API void THCudaSparse_Dcsrmm2(THCState *state, char transa, char transb, long m, long n, long k, long nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, long ldb, double beta, double *c, long ldc);
 
+/* format conversion */
+THC_API void THCudaSparse_CreateIdentityPermutation(THCState *state, long nnz, int *P);
+THC_API void THCudaSparse_Xcsrsort_bufferSizeExt(THCState *state, long m, long n, long nnz, const int *csrRowPtr, const int *csrColInd, size_t *pBufferSizeInBytes);
+THC_API void THCudaSparse_Xcsrsort(THCState *state, long m, long n, long nnz, const int *csrRowPtr, int *csrColInd, int *P, void *pBuffer);
+THC_API void THCudaSparse_Xcoosort_bufferSizeExt(THCState *state, long m, long n, long nnz, const int *cooRows, const int *cooCols, size_t *pBufferSizeInBytes);
+THC_API void THCudaSparse_XcoosortByRow(THCState *state, long m, long n, long nnz, int *cooRows, int *cooCols, int *P, void *pBuffer);
+
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -221,6 +221,7 @@ THCSTensor *THCSTensor_(newClone)(THCState *state, THCSTensor *self) {
       );
 
   other->nnz = self->nnz;
+  other->contiguous = self->contiguous;
   return other;
 }
 
@@ -341,6 +342,24 @@ void THCSTensor_(free)(THCState *state, THCSTensor *self)
 void THCSTensor_(retain)(THCState *state, THCSTensor *self)
 {
   THAtomicIncrementRef(&self->refcount);
+}
+
+void THCSTensor_(contiguous)(THCState *state, THCSTensor *self) {
+  if (self->contiguous) return;
+  THCSTensor_(reorder)(state, self);
+  self->contiguous = 1;
+}
+
+void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self) {
+  self->contiguous = 1;
+}
+
+void THCSTensor_(contiguousValues)(THCState *state, THCSTensor *self) {
+  if (!THCTensor_(isContiguous)(state, self->values)) {
+    THCTensor *newValues = THCTensor_(newContiguous)(state, self->values);
+    THCTensor_(free)(state, self->values);
+    self->values = newValues;
+  }
 }
 
 int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...)

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -77,7 +77,7 @@ static void THCSTensor_(rawInit)(THCState *state, THCSTensor *self)
   self->refcount = 1;
 }
 
-static void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size) {
+void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size) {
   // Only resize valid sizes into tensor.
   self->size = THRealloc(self->size, sizeof(long)*(nDimI + nDimV));
 
@@ -105,6 +105,10 @@ THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor 
         "indices must be nDim x nnz");
     THArgCheck(THCIndexTensor_(size)(state, indices, 1) == THCTensor_(size)(state, values, 0), 2,
         "indices and values must have same nnz");
+    THArgCheck(THCIndexTensor_(size)(state, indices, 0) == self->nDimensionI, 2,
+        "indices has incorrect first dimension, expected %d, got %d", self->nDimensionI, THCIndexTensor_(size)(state, indices, 0));
+    THArgCheck(THCTensor_(nDimension)(state, values) == self->nDimensionV + 1, 3,
+        "values has incorrect number of dimensions, expected %d, got %d", self->nDimensionV + 1, THCTensor_(nDimension)(state, values));
   }
   THCIndexTensor_(free)(state, self->indices);
   THCTensor_(free)(state, self->values);
@@ -143,7 +147,6 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
 
   THCSTensor *self = THAlloc(sizeof(THCSTensor));
   THCSTensor_(rawInit)(state, self);
-  THCSTensor_(_set)(state, self, indices, values);
 
   nDimI = THCIndexTensor_(size)(state, indices, 0);
   nDimV = THCTensor_(nDimension)(state, values) - 1;
@@ -158,7 +161,9 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
 
     // TODO make sure this doesn't sync the hell out of everything
     //      Should be fine according to sam's memory manager.
-    computed_sizes = THLongTensor_newWithSize(THCIndexTensor_(newSizeOf)(state, s), NULL);
+    THLongStorage *newSize = THCIndexTensor_(newSizeOf)(state, s);
+    computed_sizes = THLongTensor_newWithSize(newSize, NULL);
+    THLongStorage_free(newSize);
     THLongTensor_copyCudaLong(state, computed_sizes, s);
     THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongTensor_data(computed_sizes));
 
@@ -171,6 +176,7 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
         "number of dimensions must be nDimI + nDimV");
     THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongStorage_data(sizes));
   }
+  THCSTensor_(_set)(state, self, indices, values);
 
   return self;
 }
@@ -214,12 +220,7 @@ THCSTensor *THCSTensor_(newClone)(THCState *state, THCSTensor *self) {
   THCSTensor *other = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, other, self->nDimensionI, self->nDimensionV, self->size);
 
-  THCSTensor_(_set)(
-      state,
-      other,
-      THCIndexTensor_(newClone)(state, self->indices),
-      THCTensor_(newClone)(state, self->values)
-      );
+  THCSTensor_(_set)(state, other, self->indices, self->values);
 
   other->nnz = self->nnz;
   other->contiguous = self->contiguous;

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -41,7 +41,7 @@ THLongStorage *THCSTensor_(newSizeOf)(THCState *state, THCSTensor *self)
 }
 
 /*** TODO: watch out for memory leaks ***/
-THCIndexTensor *THCSTensor_(indices)(THCState *state, const THCSTensor *self) {
+THCIndexTensor *THCSTensor_(newIndices)(THCState *state, const THCSTensor *self) {
   if (self->nnz == 0) {
     // Narrows don't work on 0-length tensors
     THCIndexTensor_(retain)(state, self->indices);
@@ -50,7 +50,7 @@ THCIndexTensor *THCSTensor_(indices)(THCState *state, const THCSTensor *self) {
   return THCIndexTensor_(newNarrow)(state, self->indices, 1, 0, self->nnz);
 }
 
-THCTensor *THCSTensor_(values)(THCState *state, const THCSTensor *self) {
+THCTensor *THCSTensor_(newValues)(THCState *state, const THCSTensor *self) {
   if (self->nnz == 0) {
     THCTensor_(retain)(state, self->values);
     return self->values;
@@ -81,24 +81,16 @@ void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nD
   // Only resize valid sizes into tensor.
   self->size = THRealloc(self->size, sizeof(long)*(nDimI + nDimV));
 
-  long d, nDimI_ = 0, nDimV_ = 0;
-  for (d = 0; d < nDimI; d++) {
-    if (size[d] > 0) {
-      self->size[nDimI_++] = size[d];
-    }
+  for (long d = 0; d < nDimI + nDimV; d++) {
+    self->size[d] = size[d];
   }
-  for (d = nDimI; d < nDimI + nDimV; d++) {
-    if (size[d] > 0) {
-      self->size[nDimI_ + nDimV_++] = size[d];
-    }
-  }
-  self->nDimensionI = nDimI_;
-  self->nDimensionV = nDimV_;
+  self->nDimensionI = nDimI;
+  self->nDimensionV = nDimV;
   self->contiguous = 0;
 }
 
 // directly assign without cloning or retaining (internal method)
-THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values) {
+THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values) {
   int empty = THCTensor_(nDimension)(state, values) == 0;
   if (!empty) {
     THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 2, 2,
@@ -109,6 +101,9 @@ THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor 
         "indices has incorrect first dimension, expected %d, got %d", self->nDimensionI, THCIndexTensor_(size)(state, indices, 0));
     THArgCheck(THCTensor_(nDimension)(state, values) == self->nDimensionV + 1, 3,
         "values has incorrect number of dimensions, expected %d, got %d", self->nDimensionV + 1, THCTensor_(nDimension)(state, values));
+  } else {
+    THArgCheck(THCIndexTensor_(nDimension)(state, indices) == 0, 2,
+        "if values is empty, indices must be empty too");
   }
   THCIndexTensor_(free)(state, self->indices);
   THCTensor_(free)(state, self->values);
@@ -122,7 +117,7 @@ THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor 
 
 THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values) {
   // Note: Not like torch.set, this is an internal method
-  return THCSTensor_(move)(state, self, THCIndexTensor_(newClone)(state, indices), THCTensor_(newClone)(state, values));
+  return THCSTensor_(_move)(state, self, THCIndexTensor_(newClone)(state, indices), THCTensor_(newClone)(state, values));
 }
 
 /*** end helper methods ***/
@@ -192,17 +187,35 @@ THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size)
 
 THCSTensor *THCSTensor_(newWithSize1d)(THCState *state, long size0)
 {
-  return THCSTensor_(newWithSize4d)(state, size0, -1, -1, -1);
+  long size[1] = {size0};
+
+  THCSTensor *self = THAlloc(sizeof(THCSTensor));
+  THCSTensor_(rawInit)(state, self);
+  THCSTensor_(rawResize)(state, self, 1, 0, size);
+
+  return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize2d)(THCState *state, long size0, long size1)
 {
-  return THCSTensor_(newWithSize4d)(state, size0, size1, -1, -1);
+  long size[2] = {size0, size1};
+
+  THCSTensor *self = THAlloc(sizeof(THCSTensor));
+  THCSTensor_(rawInit)(state, self);
+  THCSTensor_(rawResize)(state, self, 2, 0, size);
+
+  return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize3d)(THCState *state, long size0, long size1, long size2)
 {
-  return THCSTensor_(newWithSize4d)(state, size0, size1, size2, -1);
+  long size[3] = {size0, size1, size2};
+
+  THCSTensor *self = THAlloc(sizeof(THCSTensor));
+  THCSTensor_(rawInit)(state, self);
+  THCSTensor_(rawResize)(state, self, 3, 0, size);
+
+  return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize4d)(THCState *state, long size0, long size1, long size2, long size3)
@@ -296,17 +309,23 @@ THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor 
 
 THCSTensor *THCSTensor_(resize1d)(THCState *state, THCSTensor *self, long size0)
 {
-  return THCSTensor_(resize4d)(state, self, size0, -1, -1, -1);
+  long size[1] = {size0};
+  THCSTensor_(rawResize)(state, self, 1, 0, size);
+  return self;
 }
 
 THCSTensor *THCSTensor_(resize2d)(THCState *state, THCSTensor *self, long size0, long size1)
 {
-  return THCSTensor_(resize4d)(state, self, size0, size1, -1, -1);
+  long size[2] = {size0, size1};
+  THCSTensor_(rawResize)(state, self, 2, 0, size);
+  return self;
 }
 
 THCSTensor *THCSTensor_(resize3d)(THCState *state, THCSTensor *self, long size0, long size1, long size2)
 {
-  return THCSTensor_(resize4d)(state, self, size0, size1, size2, -1);
+  long size[3] = {size0, size1, size2};
+  THCSTensor_(rawResize)(state, self, 3, 0, size);
+  return self;
 }
 
 THCSTensor *THCSTensor_(resize4d)(THCState *state, THCSTensor *self, long size0, long size1, long size2, long size3)
@@ -350,18 +369,6 @@ void THCSTensor_(contiguous)(THCState *state, THCSTensor *self) {
   if (self->contiguous) return;
   THCSTensor_(reorder)(state, self);
   self->contiguous = 1;
-}
-
-void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self) {
-  self->contiguous = 1;
-}
-
-void THCSTensor_(contiguousValues)(THCState *state, THCSTensor *self) {
-  if (!THCTensor_(isContiguous)(state, self->values)) {
-    THCTensor *newValues = THCTensor_(newContiguous)(state, self->values);
-    THCTensor_(free)(state, self->values);
-    self->values = newValues;
-  }
 }
 
 int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...)
@@ -434,11 +441,11 @@ void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCST
     THCSTensor_(zero)(state, r_);
     return;
   }
-  THCIndexTensor *maskIndices = THCSTensor_(indices)(state, mask);
-  THCTensor *maskValues = THCSTensor_(values)(state, mask);
+  THCIndexTensor *maskIndices = THCSTensor_(newIndices)(state, mask);
+  THCTensor *maskValues = THCSTensor_(newValues)(state, mask);
   THCTensor *rValues = THCTensor_(new)(state);
   THCTensor_(resizeAs)(state, rValues, maskValues);
-  THCSTensor_(move)(state, r_, THCIndexTensor_(newClone)(state, maskIndices), rValues);
+  THCSTensor_(_move)(state, r_, THCIndexTensor_(newClone)(state, maskIndices), rValues);
   r_->contiguous = mask->contiguous;
   r_->nnz = mask->nnz;
 

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -111,6 +111,7 @@ THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor 
   self->indices = indices;
   self->values = values;
   self->nnz = empty ? 0 : THCTensor_(size)(state, values, 0);
+  self->contiguous = 0;
 
   return self;
 }

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -5,10 +5,13 @@
 #include "THCThrustAllocator.cuh"
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
+#include <thrust/gather.h>
 #include <thrust/generate.h>
+#include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
-#include <thrust/gather.h>
+#include <thrust/transform.h>
+#include <thrust/unique.h>
 #if CUDA_VERSION >= 7000
 #include <thrust/system/cuda/execution_policy.h>
 #endif
@@ -33,15 +36,26 @@ THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self) {
     return other;
   }
 
+  // TODO more benchmarking
   const dim3 block = getApplyBlock();
   dim3 grid;
-  THArgCheck(getApplyGrid(state, nnz, grid), 1, CUTORCH_DIM_WARNING);
+  if (self->nDimensionV == 0) {
+    THArgCheck(getApplyGrid(state, nnz, grid), 1, CUTORCH_DIM_WARNING);
 
-  THCSTensor_spcKernel<TensorAddOp<real>, unsigned long, real>
-    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-        TensorAddOp<real>(),
-        V_INFO(other), I_INFO(self->indices), V_INFO(self->values),
-        (unsigned long)(nnz));
+    THCSTensor_spcKernelScalar<TensorAddOp<real>, unsigned long, real>
+      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+          TensorAddOp<real>(),
+          V_INFO(other), I_INFO(self->indices), V_INFO(self->values),
+          (unsigned long)(nnz));
+  } else {
+    THArgCheck(getApplyGrid(state, nnz * block.x, grid), 1, CUTORCH_DIM_WARNING);
+
+    THCSTensor_spcKernel<TensorAddOp<real>, unsigned long, real>
+      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+          TensorAddOp<real>(),
+          V_INFO(other), I_INFO(self->indices), V_INFO(self->values),
+          (unsigned long)(nnz));
+  }
 
   THCudaCheck(cudaGetLastError());
   THLongStorage_free(storage);
@@ -58,79 +72,131 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
 #endif
 
   THCIndexTensor *indices = THCSTensor_(indices)(state, self);
+  THCTensor *values = THCSTensor_(values)(state, self);
   THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
-  THCudaLongTensor *permutation = THCudaLongTensor_newWithSize1d(state, self->nnz);
+  THCIndexTensor *indicesScalar = THCIndexTensor_(newWithSize1d)(state, self->nnz);
+  THCIndexTensor *projectIndices = THCIndexTensor_(newWithSize2d)(state, 2, self->nnz);
+  THCTensor *projectValues = THCTensor_(newWithSize1d)(state, self->nnz);
+  THCTensor_(fill)(state, projectValues, ScalarConvert<int, real>::to(1));
+  THCudaLongTensor *mapping = THCudaLongTensor_new(state);
+  THCudaLongTensor *permutation = THCudaLongTensor_new(state);
+  THCudaLongTensor_select(state, mapping, projectIndices, 0, 0);
+  THCudaLongTensor_select(state, permutation, projectIndices, 0, 1);
+  THCudaLongTensor *unique = THCudaLongTensor_newWithSize1d(state, self->nnz);
 
-  // Sort indices in lexicographic order (following thrust's example recipe)
   thrust::device_ptr<long> permutationIter(THCudaLongTensor_data(state, permutation));
-  thrust::device_vector<integer> indicesBuffer(self->nnz);
   THRUST_EXEC(thrust::sequence, permutationIter, permutationIter + self->nnz);
-
+  THCIndexTensor_(zero)(state, indicesScalar);
+  integer factor = 1;
   for (int i = self->nDimensionI - 1; i >= 0; i--) {
     THCIndexTensor_(select)(state, indicesSlice, indices, 0, i);
-    thrust::device_ptr<integer> indicesIter(THCIndexTensor_(data)(state, indicesSlice));
-    THRUST_EXEC(thrust::gather, permutationIter, permutationIter + self->nnz, indicesIter, indicesBuffer.begin());
-    THRUST_EXEC(thrust::stable_sort_by_key, indicesBuffer.begin(), indicesBuffer.end(), permutationIter);
+    THCIndexTensor_(cadd)(state, indicesScalar, indicesScalar, factor, indicesSlice);
+    factor *= self->size[i];
+  }
+  thrust::device_ptr<integer> indicesIter(THCIndexTensor_(data)(state, indicesScalar));
+
+  // HACK *theoretically* we need stable sort, so that indices mapped to the same
+  // location are sorted in the permutation. This is necessary to ensure that
+  // the projection matrix is contiguous
+  // However, it seems to work even with non-stable sort, which is nice because it's faster...
+  // Revert this if bugs arise, or add a step to sort the projection matrix indices explicitly
+  // THRUST_EXEC(thrust::stable_sort_by_key, indicesIter, indicesIter + self->nnz, permutationIter);
+  THCIndexTensor *indicesScalarClone = THCIndexTensor_(newClone)(state, indicesScalar);
+  THCIndexTensor_(sort)(state, indicesScalar, permutation, indicesScalarClone, 0, 0);
+  THCIndexTensor_(free)(state, indicesScalarClone);
+
+  thrust::device_ptr<long> uniqueIter(THCudaLongTensor_data(state, unique));
+  thrust::device_vector<integer> indicesBuffer(self->nnz); // not used, can we optimize?
+  thrust::pair<thrust::device_vector<integer>::iterator, thrust::device_ptr<long> > newEnd =
+    THRUST_EXEC(thrust::unique_by_key_copy, indicesIter, indicesIter + self->nnz, permutationIter, indicesBuffer.begin(), uniqueIter);
+  long newNnz = newEnd.second - uniqueIter;
+  THCudaLongTensor_resize1d(state, unique, newNnz);
+  THCudaLongTensor_set1d(state, mapping, 0, 0);
+  thrust::device_ptr<long> mappingIter(THCudaLongTensor_data(state, mapping));
+
+  thrust::not_equal_to<integer> op;
+  THRUST_EXEC(thrust::transform, indicesIter, indicesIter + self->nnz - 1, indicesIter + 1, mappingIter + 1, op);
+  THRUST_EXEC(thrust::inclusive_scan, mappingIter, mappingIter + self->nnz, mappingIter);
+
+  THCIndexTensor *newIndices = THCIndexTensor_(new)(state);
+  THCIndexTensor_(indexSelect)(state, newIndices, indices, 1, unique);
+  THCIndexTensor_(free)(state, indices);
+  THCIndexTensor_(free)(state, self->indices);
+  self->indices = newIndices;
+
+  THCSTensor *project = THCSTensor_(newWithSize2d)(state, newNnz, self->nnz);
+  THCSTensor_(move)(state, project, projectIndices, projectValues);
+  project->contiguous = 1;
+  THLongStorage *newValuesSizes = THCTensor_(newSizeOf)(state, values);
+  THLongStorage_set(newValuesSizes, 0, newNnz);
+  THCTensor *newValues = THCTensor_(newWithSize)(state, newValuesSizes, NULL);
+  THLongStorage_free(newValuesSizes);
+
+  THCTensor *valuesView;
+  if (THCTensor_(nDimension)(state, values) != 2) {
+    THLongStorage *valuesViewSizes = THLongStorage_newWithSize(2);
+    THLongStorage_set(valuesViewSizes, 0, self->nnz);
+    THLongStorage_set(valuesViewSizes, 1, -1);
+    valuesView = THCTensor_(newView)(state, values, valuesViewSizes);
+    THLongStorage_free(valuesViewSizes);
+  } else {
+    valuesView = values;
   }
 
-  for (int i = 0; i < self->nDimensionI; i++) {
-    THCIndexTensor_(select)(state, indicesSlice, indices, 0, i);
-    thrust::device_ptr<integer> indicesIter(THCIndexTensor_(data)(state, indicesSlice));
-    THRUST_EXEC(thrust::copy, indicesIter, indicesIter + self->nnz, indicesBuffer.begin());
-    THRUST_EXEC(thrust::gather, permutationIter, permutationIter + self->nnz, indicesBuffer.begin(), indicesIter);
+  THCTensor *newValuesView;
+  if (THCTensor_(nDimension)(state, newValues) != 2) {
+    THLongStorage *newValuesViewSizes = THLongStorage_newWithSize(2);
+    THLongStorage_set(newValuesViewSizes, 0, newNnz);
+    THLongStorage_set(newValuesViewSizes, 1, -1);
+    newValuesView = THCTensor_(newView)(state, newValues, newValuesViewSizes);
+    THLongStorage_free(newValuesViewSizes);
+  } else {
+    newValuesView = newValues;
   }
 
-  THCTensor *values = THCSTensor_(values)(state, self);
-  THCTensor *newValues = THCTensor_(new)(state);
-  THCTensor_(indexSelect)(state, newValues, values, 0, permutation);
+  THCSTensor_(spaddmm)(state, newValuesView, ScalarConvert<int, real>::to(0), newValuesView, ScalarConvert<int, real>::to(1), project, valuesView);
   THCTensor_(free)(state, values);
   THCTensor_(free)(state, self->values);
   self->values = newValues;
 
-  // Make indices unique
-  // TODO for the moment the only parallelism is when copying/adding non-scalar values
-  const dim3 block = getApplyBlock();
-  dim3 grid;
-  THArgCheck(getApplyGrid(state, newValues->stride[0], grid), 1, CUTORCH_DIM_WARNING);
-
-  THCSTensor_uniqueValuesReorderKernel<unsigned long, real>
-    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-        I_INFO(indices), V_INFO(newValues), (unsigned long)(self->nnz));
-  THCudaCheck(cudaGetLastError());
-
-  THCudaLongStorage *resultNnz = THCudaLongStorage_newWithSize(state, 1);
-  THCSTensor_uniqueIndicesReorderKernel<unsigned long, real>
-    <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
-        I_INFO(indices), (unsigned long)(self->nnz), (unsigned long*)resultNnz->data);
-  THCudaCheck(cudaGetLastError());
-  self->nnz = THCudaLongStorage_get(state, resultNnz, 0);
-  THCudaLongStorage_free(state, resultNnz);
+  self->nnz = newNnz;
 
   THCudaLongTensor_free(state, permutation);
+  THCudaLongTensor_free(state, mapping);
+  THCudaLongTensor_free(state, unique);
   THCIndexTensor_(free)(state, indicesSlice);
-  THCIndexTensor_(free)(state, indices);
+  THCIndexTensor_(free)(state, indicesScalar);
+  THCSTensor_(free)(state, project);
+  if (valuesView != values) {
+    THCTensor_(free)(state, valuesView);
+  }
+  if (newValuesView != newValues) {
+    THCTensor_(free)(state, newValuesView);
+  }
 
 #undef THRUST_EXEC
 }
 
 // In place transpose
 void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
-  /* TODO
-  THCudaLongTensor *indices = THCSTensor_(indices)(state, self);
-  long i;
-  for (i = 0; i < THCSTensor_(nnz)(state, self); i++) {
-    long tmp = THCTensor_fastGet2d(indices, d1, i);
-    THCTensor_fastSet2d(indices, d1, i,
-        THCTensor_fastGet2d(indices, d2, i));
-    THCTensor_fastSet2d(indices, d2, i, tmp);
-  }
-  i = self->size[d1];
+  THCIndexTensor *indices = THCSTensor_(indices)(state, self);
+  long nnz = THCSTensor_(nnz)(state, self);
+  THCIndexTensor *buffer = THCIndexTensor_(newWithSize1d)(state, nnz);
+  THCIndexTensor *slice1 = THCIndexTensor_(new)(state);
+  THCIndexTensor *slice2 = THCIndexTensor_(new)(state);
+  THCIndexTensor_(select)(state, slice1, indices, 0, d1);
+  THCIndexTensor_(select)(state, slice2, indices, 0, d2);
+  THCIndexTensor_(copy)(state, buffer, slice1);
+  THCIndexTensor_(copy)(state, slice1, slice2);
+  THCIndexTensor_(copy)(state, slice2, buffer);
+  long i = self->size[d1];
   self->size[d1] = self->size[d2];
   self->size[d2] = i;
   self->contiguous = 0;
-  THFree(indices);
-  */
-  THError("WARNING: Sparse Cuda Tensor op transpose is not implemented");
+  THCIndexTensor_(free)(state, indices);
+  THCIndexTensor_(free)(state, buffer);
+  THCIndexTensor_(free)(state, slice1);
+  THCIndexTensor_(free)(state, slice2);
 }
 
 int THCSTensor_(getDevice)(THCState* state, const THCSTensor* tensor) {

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -113,16 +113,6 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
 #undef THRUST_EXEC
 }
 
-void THCSTensor_(contiguous)(THCState *state, THCSTensor *self) {
-  if (self->contiguous) return;
-  THCSTensor_(reorder)(state, self);
-  self->contiguous = 1;
-}
-
-void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self) {
-  self->contiguous = 1;
-}
-
 // In place transpose
 void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
   /* TODO

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -119,6 +119,10 @@ void THCSTensor_(contiguous)(THCState *state, THCSTensor *self) {
   self->contiguous = 1;
 }
 
+void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self) {
+  self->contiguous = 1;
+}
+
 // In place transpose
 void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
   /* TODO

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -20,20 +20,20 @@
 #define V_INFO(tensor) getTensorInfo<THCTensor, unsigned long>(state, tensor)
 
 THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self) {
-  THLongStorage *storage;
-  THCTensor *other;
+  THLongStorage *size;
+  THCTensor *dst;
 
   THCSTensor_(contiguous)(state, self);
 
   // set up the new tensor
-  storage = THCSTensor_(newSizeOf)(state, self);
-  other = THCTensor_(newWithSize)(state, storage, NULL);
-  THCTensor_(zero)(state, other);
+  size = THCSTensor_(newSizeOf)(state, self);
+  dst = THCTensor_(newWithSize)(state, size, NULL);
+  THLongStorage_free(size);
+  THCTensor_(zero)(state, dst);
 
   const ptrdiff_t nnz = THCSTensor_(nnz)(state, self);
   if (nnz == 0) {
-    THLongStorage_free(storage);
-    return other;
+    return dst;
   }
 
   // TODO more benchmarking
@@ -42,24 +42,23 @@ THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self) {
   if (self->nDimensionV == 0) {
     THArgCheck(getApplyGrid(state, nnz, grid), 1, CUTORCH_DIM_WARNING);
 
-    THCSTensor_spcKernelScalar<TensorAddOp<real>, unsigned long, real>
+    THCSTensor_sparseElementwiseKernelScalar<TensorAddOp<real>, unsigned long, real>
       <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           TensorAddOp<real>(),
-          V_INFO(other), I_INFO(self->indices), V_INFO(self->values),
+          V_INFO(dst), I_INFO(self->indices), V_INFO(self->values),
           (unsigned long)(nnz));
   } else {
     THArgCheck(getApplyGrid(state, nnz * block.x, grid), 1, CUTORCH_DIM_WARNING);
 
-    THCSTensor_spcKernel<TensorAddOp<real>, unsigned long, real>
+    THCSTensor_sparseElementwiseKernel<TensorAddOp<real>, unsigned long, real>
       <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           TensorAddOp<real>(),
-          V_INFO(other), I_INFO(self->indices), V_INFO(self->values),
+          V_INFO(dst), I_INFO(self->indices), V_INFO(self->values),
           (unsigned long)(nnz));
   }
 
   THCudaCheck(cudaGetLastError());
-  THLongStorage_free(storage);
-  return other;
+  return dst;
 }
 
 void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
@@ -71,67 +70,94 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
 #define THRUST_EXEC(fn, ...) fn(##__VA_ARGS__)
 #endif
 
-  THCIndexTensor *indices = THCSTensor_(indices)(state, self);
-  THCTensor *values = THCSTensor_(values)(state, self);
-  THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
-  THCIndexTensor *indicesScalar = THCIndexTensor_(newWithSize1d)(state, self->nnz);
-  THCIndexTensor *projectIndices = THCIndexTensor_(newWithSize2d)(state, 2, self->nnz);
-  THCTensor *projectValues = THCTensor_(newWithSize1d)(state, self->nnz);
-  THCTensor_(fill)(state, projectValues, ScalarConvert<int, real>::to(1));
+  // For indices, a simple sort + unique suffices
+  // For values, we reduce the problem to a sparse x dense matrix multiplication D2 = S x D1, such that:
+  // * D1 represents the input values, D2 represents the output values
+  // * D1 and D2 are views over the values where:
+  //    * the first dimension represents the nnz index (same as in the values tensor)
+  //    * the second dimension represents the "flattened" values (so they can be treated as blocks of scalars even if they are N-dimensional)
+  // * S maps values in D1 to their position in D2
+  //   Multiple values in D1 can map to the same position in D2 if there are duplicate indices
+  //   Values mapping to the same position are added together (which is what matrix multiplication does)
+  //
+  // When constructing S, we must make sure that it is contiguous (otherwise this function will call itself when doing the multiplication)
+  // To achieve this, we define the indices tensor of S as follows:
+  // * the second row contains the permutation corresponding to a stable sort of the original indices
+  // * the first row "maps" those indices to their final location after deduplication
+  //
+  // The construction of the second row ensures that the first row is sorted
+  // Because the sorting used for the second row is stable, groups of values mapped to the same position correspond to increasing subsequences of the permutation
+  // So the indices tensor of S is guaranteed to be sorted
+
+  // Initialize tensors
+  THCIndexTensor *indices = THCSTensor_(newIndices)(state, self);
+  THCTensor *values = THCSTensor_(newValues)(state, self);
+  THCudaLongTensor *sIndices = THCudaLongTensor_newWithSize2d(state, 2, self->nnz);
+  THCTensor *sValues = THCTensor_(newWithSize1d)(state, self->nnz);
+  THCTensor_(fill)(state, sValues, ScalarConvert<int, real>::to(1));
   THCudaLongTensor *mapping = THCudaLongTensor_new(state);
   THCudaLongTensor *permutation = THCudaLongTensor_new(state);
-  THCudaLongTensor_select(state, mapping, projectIndices, 0, 0);
-  THCudaLongTensor_select(state, permutation, projectIndices, 0, 1);
-  THCudaLongTensor *unique = THCudaLongTensor_newWithSize1d(state, self->nnz);
+  THCudaLongTensor_select(state, mapping, sIndices, 0, 0);
+  THCudaLongTensor_select(state, permutation, sIndices, 0, 1);
+  THCudaLongTensor *uniquePositions = THCudaLongTensor_newWithSize1d(state, self->nnz);
 
-  thrust::device_ptr<long> permutationIter(THCudaLongTensor_data(state, permutation));
-  THRUST_EXEC(thrust::sequence, permutationIter, permutationIter + self->nnz);
+  // convert N-dimensional indices to scalar indices
+  THCIndexTensor *indicesScalar = THCIndexTensor_(newWithSize1d)(state, self->nnz);
+  THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
   THCIndexTensor_(zero)(state, indicesScalar);
-  integer factor = 1;
+  long factor = 1;
   for (int i = self->nDimensionI - 1; i >= 0; i--) {
     THCIndexTensor_(select)(state, indicesSlice, indices, 0, i);
     THCIndexTensor_(cadd)(state, indicesScalar, indicesScalar, factor, indicesSlice);
     factor *= self->size[i];
   }
-  thrust::device_ptr<integer> indicesIter(THCIndexTensor_(data)(state, indicesScalar));
+  THCIndexTensor_(free)(state, indicesSlice);
 
-  // HACK *theoretically* we need stable sort, so that indices mapped to the same
-  // location are sorted in the permutation. This is necessary to ensure that
-  // the projection matrix is contiguous
-  // However, it seems to work even with non-stable sort, which is nice because it's faster...
-  // Revert this if bugs arise, or add a step to sort the projection matrix indices explicitly
-  // THRUST_EXEC(thrust::stable_sort_by_key, indicesIter, indicesIter + self->nnz, permutationIter);
-  THCIndexTensor *indicesScalarClone = THCIndexTensor_(newClone)(state, indicesScalar);
-  THCIndexTensor_(sort)(state, indicesScalar, permutation, indicesScalarClone, 0, 0);
-  THCIndexTensor_(free)(state, indicesScalarClone);
+  // stable sort indices and remember the permutation
+  thrust::device_ptr<long> permutationIter(THCudaLongTensor_data(state, permutation));
+  THRUST_EXEC(thrust::sequence, permutationIter, permutationIter + self->nnz);
+  thrust::device_ptr<indexT> indicesIter(THCIndexTensor_(data)(state, indicesScalar));
+  THRUST_EXEC(thrust::stable_sort_by_key, indicesIter, indicesIter + self->nnz, permutationIter);
+  // Note: the code below is much faster and seems to work, but the sort is not stable.
+  // It could be that csrmm2 works even when column indices are not sorted within rows
+  // THCIndexTensor *indicesScalarClone = THCIndexTensor_(newClone)(state, indicesScalar);
+  // THCIndexTensor_(sort)(state, indicesScalar, permutation, indicesScalarClone, 0, 0);
+  // THCIndexTensor_(free)(state, indicesScalarClone);
 
-  thrust::device_ptr<long> uniqueIter(THCudaLongTensor_data(state, unique));
-  thrust::device_vector<integer> indicesBuffer(self->nnz); // not used, can we optimize?
-  thrust::pair<thrust::device_vector<integer>::iterator, thrust::device_ptr<long> > newEnd =
-    THRUST_EXEC(thrust::unique_by_key_copy, indicesIter, indicesIter + self->nnz, permutationIter, indicesBuffer.begin(), uniqueIter);
-  long newNnz = newEnd.second - uniqueIter;
-  THCudaLongTensor_resize1d(state, unique, newNnz);
+  // compute a list of unique indices, along with their position in the original index tensor (using the saved permutation)
+  thrust::device_ptr<indexT> uniquePositionsIter(THCudaLongTensor_data(state, uniquePositions));
+  thrust::device_vector<indexT> uniqueIndicesBuffer(self->nnz); // not used, can we optimize?
+  thrust::pair<thrust::device_vector<long>::iterator, thrust::device_ptr<long> > newEnd =
+    THRUST_EXEC(thrust::unique_by_key_copy, indicesIter, indicesIter + self->nnz, permutationIter, uniqueIndicesBuffer.begin(), uniquePositionsIter);
+  long newNnz = newEnd.second - uniquePositionsIter;
+  THCudaLongTensor_resize1d(state, uniquePositions, newNnz);
+
+  // compute the mapping of sorted indices to their final location after deduplication
   THCudaLongTensor_set1d(state, mapping, 0, 0);
   thrust::device_ptr<long> mappingIter(THCudaLongTensor_data(state, mapping));
-
-  thrust::not_equal_to<integer> op;
+  thrust::not_equal_to<indexT> op;
   THRUST_EXEC(thrust::transform, indicesIter, indicesIter + self->nnz - 1, indicesIter + 1, mappingIter + 1, op);
   THRUST_EXEC(thrust::inclusive_scan, mappingIter, mappingIter + self->nnz, mappingIter);
 
+  // build S
+  THCSTensor *S = THCSTensor_(newWithSize2d)(state, newNnz, self->nnz);
+  THCSTensor_(_move)(state, S, sIndices, sValues);
+  S->contiguous = 1;
+
+  // build output indices tensor by doing an indexSelect over the sorted list of unique indices
   THCIndexTensor *newIndices = THCIndexTensor_(new)(state);
-  THCIndexTensor_(indexSelect)(state, newIndices, indices, 1, unique);
+  THCIndexTensor_(indexSelect)(state, newIndices, indices, 1, uniquePositions);
   THCIndexTensor_(free)(state, indices);
   THCIndexTensor_(free)(state, self->indices);
   self->indices = newIndices;
 
-  THCSTensor *project = THCSTensor_(newWithSize2d)(state, newNnz, self->nnz);
-  THCSTensor_(move)(state, project, projectIndices, projectValues);
-  project->contiguous = 1;
+  // create output values tensor
   THLongStorage *newValuesSizes = THCTensor_(newSizeOf)(state, values);
   THLongStorage_set(newValuesSizes, 0, newNnz);
   THCTensor *newValues = THCTensor_(newWithSize)(state, newValuesSizes, NULL);
   THLongStorage_free(newValuesSizes);
 
+  // create D1: view over input values tensor
   THCTensor *valuesView;
   if (THCTensor_(nDimension)(state, values) != 2) {
     THLongStorage *valuesViewSizes = THLongStorage_newWithSize(2);
@@ -143,6 +169,7 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
     valuesView = values;
   }
 
+  // create D2: view over output values tensor
   THCTensor *newValuesView;
   if (THCTensor_(nDimension)(state, newValues) != 2) {
     THLongStorage *newValuesViewSizes = THLongStorage_newWithSize(2);
@@ -154,7 +181,8 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
     newValuesView = newValues;
   }
 
-  THCSTensor_(spaddmm)(state, newValuesView, ScalarConvert<int, real>::to(0), newValuesView, ScalarConvert<int, real>::to(1), project, valuesView);
+  // build output values tensor by computing D2 = S x D1
+  THCSTensor_(spaddmm)(state, newValuesView, ScalarConvert<int, real>::to(0), newValuesView, ScalarConvert<int, real>::to(1), S, valuesView);
   THCTensor_(free)(state, values);
   THCTensor_(free)(state, self->values);
   self->values = newValues;
@@ -163,10 +191,9 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
 
   THCudaLongTensor_free(state, permutation);
   THCudaLongTensor_free(state, mapping);
-  THCudaLongTensor_free(state, unique);
-  THCIndexTensor_(free)(state, indicesSlice);
+  THCudaLongTensor_free(state, uniquePositions);
   THCIndexTensor_(free)(state, indicesScalar);
-  THCSTensor_(free)(state, project);
+  THCSTensor_(free)(state, S);
   if (valuesView != values) {
     THCTensor_(free)(state, valuesView);
   }
@@ -179,13 +206,14 @@ void THCSTensor_(reorder)(THCState *state, THCSTensor *self) {
 
 // In place transpose
 void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
-  THCIndexTensor *indices = THCSTensor_(indices)(state, self);
+  long nDimI = THCSTensor_(nDimensionI)(state, self);
+  long nDimV = THCSTensor_(nDimensionV)(state, self);
+  THArgCheck(d1 < nDimI && d2 < nDimI, 1, "Transposed dimensions should be sparse. Got nDimI: %ld, d1: %ld, d2: %ld", nDimI, d1, d2);
+  THCIndexTensor *indices = THCSTensor_(newIndices)(state, self);
   long nnz = THCSTensor_(nnz)(state, self);
   THCIndexTensor *buffer = THCIndexTensor_(newWithSize1d)(state, nnz);
-  THCIndexTensor *slice1 = THCIndexTensor_(new)(state);
-  THCIndexTensor *slice2 = THCIndexTensor_(new)(state);
-  THCIndexTensor_(select)(state, slice1, indices, 0, d1);
-  THCIndexTensor_(select)(state, slice2, indices, 0, d2);
+  THCIndexTensor *slice1 = THCIndexTensor_(newSelect)(state, indices, 0, d1);
+  THCIndexTensor *slice2 = THCIndexTensor_(newSelect)(state, indices, 0, d2);
   THCIndexTensor_(copy)(state, buffer, slice1);
   THCIndexTensor_(copy)(state, slice1, slice2);
   THCIndexTensor_(copy)(state, slice2, buffer);

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -45,6 +45,8 @@ TH_API THCSTensor *THCSTensor_(newContiguous)(THCState *state, THCSTensor *self)
 TH_API THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 
 /**** reshaping methods ***/
+TH_API int THCSTensor_(isSameSizeAs)(THCState *state, const THCSTensor *self, const THCSTensor* src);
+TH_API int THCSTensor_(isSameSizeAsDense)(THCState *state, const THCSTensor *self, const THCTensor* src);
 TH_API THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size);
 TH_API THCSTensor *THCSTensor_(resizeAs)(THCState *state, THCSTensor *self, THCSTensor *src);
 TH_API THCSTensor *THCSTensor_(resize1d)(THCState *state, THCSTensor *self, long size0);
@@ -53,6 +55,7 @@ TH_API THCSTensor *THCSTensor_(resize3d)(THCState *state, THCSTensor *self, long
 TH_API THCSTensor *THCSTensor_(resize4d)(THCState *state, THCSTensor *self, long size0, long size1, long size2, long size3);
 
 TH_API THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self);
+TH_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src);
 
 TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
@@ -65,5 +68,11 @@ TH_API void THCSTensor_(retain)(THCState *state, THCSTensor *self);
 
 /* CUDA-specific functions */
 TH_API int THCSTensor_(getDevice)(THCState *state, const THCSTensor *self);
+TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...);
+
+/* internal methods */
+TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
+TH_API THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
+TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -73,6 +73,7 @@ TH_API int THCSTensor_(getDevice)(THCState *state, const THCSTensor *self);
 TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...);
 
 /* internal methods */
+TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size);
 TH_API void THCSTensor_(reorder)(THCState *state, THCSTensor *self);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
 TH_API THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -26,8 +26,8 @@ TH_API int THCSTensor_(nDimensionV)(THCState *state, const THCSTensor *self);
 TH_API long THCSTensor_(size)(THCState *state, const THCSTensor *self, int dim);
 TH_API ptrdiff_t THCSTensor_(nnz)(THCState *state, const THCSTensor *self);
 TH_API THLongStorage *THCSTensor_(newSizeOf)(THCState *state, THCSTensor *self);
-TH_API THCIndexTensor *THCSTensor_(indices)(THCState *state, const THCSTensor *self);
-TH_API THCTensor *THCSTensor_(values)(THCState *state, const THCSTensor *self);
+TH_API THCIndexTensor *THCSTensor_(newIndices)(THCState *state, const THCSTensor *self);
+TH_API THCTensor *THCSTensor_(newValues)(THCState *state, const THCSTensor *self);
 
 /**** creation methods ****/
 TH_API THCSTensor *THCSTensor_(new)(THCState *state);
@@ -60,8 +60,6 @@ TH_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src
 TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
 TH_API void THCSTensor_(contiguous)(THCState *state, THCSTensor *self);
-TH_API void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self);
-TH_API void THCSTensor_(contiguousValues)(THCState *state, THCSTensor *self);
 
 TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
 
@@ -76,7 +74,7 @@ TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, u
 TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size);
 TH_API void THCSTensor_(reorder)(THCState *state, THCSTensor *self);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
-TH_API THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
+TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -60,6 +60,7 @@ TH_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src
 TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
 TH_API void THCSTensor_(contiguous)(THCState *state, THCSTensor *self);
+TH_API void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self);
 
 TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
 

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -61,6 +61,7 @@ TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimens
 TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
 TH_API void THCSTensor_(contiguous)(THCState *state, THCSTensor *self);
 TH_API void THCSTensor_(markContiguous)(THCState *state, THCSTensor *self);
+TH_API void THCSTensor_(contiguousValues)(THCState *state, THCSTensor *self);
 
 TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
 
@@ -72,6 +73,7 @@ TH_API int THCSTensor_(getDevice)(THCState *state, const THCSTensor *self);
 TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...);
 
 /* internal methods */
+TH_API void THCSTensor_(reorder)(THCState *state, THCSTensor *self);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
 TH_API THCSTensor* THCSTensor_(move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -39,11 +39,55 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
 }
 
 void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
-  THError("WARNING: Sparse Cuda Tensor op mul is not implemented");
+  if (r_ == t) {
+    THCTensor *r_values_ = THCSTensor_(values)(state, r_);
+    THCTensor_(mul)(state, r_values_, r_values_, value);
+    THCTensor_(free)(state, r_values_);
+  } else {
+    THCSTensor_(resizeAs)(state, r_, t);
+
+    THCIndexTensor *r_indices_ = THCSTensor_(indices)(state, r_);
+    THCTensor *r_values_ = THCSTensor_(values)(state, r_);
+    THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
+    THCTensor *t_values_ = THCSTensor_(values)(state, t);
+
+    THCIndexTensor_(resizeAs)(state, r_indices_, t_indices_);
+    THCIndexTensor_(copy)(state, r_indices_, t_indices_);
+    THCTensor_(mul)(state, r_values_, t_values_, value);
+    r_->nnz = t->nnz;
+    r_->contiguous = t->contiguous;
+
+    THCIndexTensor_(free)(state, r_indices_);
+    THCTensor_(free)(state, r_values_);
+    THCIndexTensor_(free)(state, t_indices_);
+    THCTensor_(free)(state, t_values_);
+  }
 }
 
 void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
-  THError("WARNING: Sparse Cuda Tensor op div is not implemented");
+  if (r_ == t) {
+    THCTensor *r_values_ = THCSTensor_(values)(state, r_);
+    THCTensor_(mul)(state, r_values_, r_values_, value);
+    THCTensor_(free)(state, r_values_);
+  } else {
+    THCSTensor_(resizeAs)(state, r_, t);
+
+    THCIndexTensor *r_indices_ = THCSTensor_(indices)(state, r_);
+    THCTensor *r_values_ = THCSTensor_(values)(state, r_);
+    THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
+    THCTensor *t_values_ = THCSTensor_(values)(state, t);
+
+    THCIndexTensor_(resizeAs)(state, r_indices_, t_indices_);
+    THCIndexTensor_(copy)(state, r_indices_, t_indices_);
+    THCTensor_(div)(state, r_values_, t_values_, value);
+    r_->nnz = t->nnz;
+    r_->contiguous = t->contiguous;
+
+    THCIndexTensor_(free)(state, r_indices_);
+    THCTensor_(free)(state, r_values_);
+    THCIndexTensor_(free)(state, t_indices_);
+    THCTensor_(free)(state, t_values_);
+  }
 }
 
 void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -241,7 +241,6 @@ void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value
   }
 }
 
-// TODO for the moment the only parallelism is when copying/adding non-scalar values
 void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 3, 3, r_, t, src));
   if(!THCSTensor_(isSameSizeAs)(state, t, src)) {

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -5,13 +5,22 @@
 #define ROW_PTR2(t, r) (THCTensor_(data)(THCState *state, t) + (r) * (t)->stride[0])
 #define COL_PTR2(t, c) (THCTensor_(data)(THCState *state, t) + (c) * (t)->stride[1])
 
-THCudaLongTensor *THCSTensor_(toCSR)(THCState *state, long const *indices, long dim, long nnz) {
-  THError("WARNING: Sparse Cuda Tensor op toCSR is not implemented");
-  // TODO hook up with cusparse
-  return NULL;
+#define I_INFO(tensor) getTensorInfo<THCIndexTensor, unsigned long>(state, tensor)
+#define V_INFO(tensor) getTensorInfo<THCTensor, unsigned long>(state, tensor)
+
+THCIndexTensor *THCSTensor_(toCSR)(THCState *state, integer const *indices, long dim, long nnz) {
+  THCIndexTensor *csr = THCIndexTensor_(newWithSize1d)(state, dim + 1);
+  THCudaSparse_Xcoo2csr(state, indices, nnz, dim, THCIndexTensor_(data)(state, csr));
+  return csr;
 }
 
 void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
+  if (self->indices->nDimension) {
+    THCIndexTensor_(resizeNd)(state, self->indices, 0, NULL, NULL);
+  }
+  if (self->values->nDimension) {
+    THCTensor_(resizeNd)(state, self->values, 0, NULL, NULL);
+  }
   self->nnz = 0;
 }
 
@@ -24,8 +33,106 @@ void THCTensor_(spaddcdiv)(THCState *state, THCTensor *r_, THCTensor *t, real va
 }
 
 void THCSTensor_(spaddmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense) {
-  THError("WARNING: Sparse Cuda Tensor op spaddmm is not implemented");
-  // TODO This is just a cusparse call (gemm?)
+#if defined(THCS_REAL_IS_FLOAT) || defined(THCS_REAL_IS_DOUBLE)
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 4, sparse, r_, t, dense));
+  THCIndexTensor *csr, *indices;
+  THCTensor *values, *r__, *dense_;
+
+  THArgCheck(sparse->nDimensionI == 2, 2,
+      "matrices expected, got %dD tensor", sparse->nDimensionI);
+  THArgCheck(sparse->nDimensionV == 0, 2,
+      "scalar values expected, got %dD values", sparse->nDimensionV);
+  THArgCheck(dense->nDimension == 2, 2,
+      "matrices expected, got %dD tensor", dense->nDimension);
+
+  long m = THCSTensor_(size)(state, sparse, 0);
+  long k = THCSTensor_(size)(state, sparse, 1);
+  long n = THCTensor_(size)(state, dense, 1);
+
+  THArgCheck(THCTensor_(size)(state, t, 0) == m, 1,
+      "Expected dim 0 size %d, got %d", m, THCTensor_(size)(state, t, 0));
+  THArgCheck(THCTensor_(size)(state, t, 1) == n, 1,
+      "Expected dim 1 size %d, got %d", n, THCTensor_(size)(state, t, 1));
+  THArgCheck(THCTensor_(size)(state, dense, 0) == k, 3,
+      "Expected dim 0 size %d, got %d", k, THCTensor_(size)(state, dense, 0));
+
+  THCSTensor_(contiguous)(state, sparse);
+
+  long nnz     = THCSTensor_(nnz)(state, sparse);
+  indices = THCSTensor_(indices)(state, sparse);
+  values  = THCSTensor_(values)(state, sparse);
+
+  csr = THCSTensor_(toCSR)(state, THCIndexTensor_(data)(state, indices), m, nnz);
+  THCIndexTensor *colindices = THCIndexTensor_(new)(state);
+  THCIndexTensor_(select)(state, colindices, indices, 0, 1);
+
+  char transpose_dense;
+
+  if(t != r_)
+  {
+    THCTensor_(resizeAs)(state, r_, t);
+    THCTensor_(copy)(state, r_, t);
+  }
+
+  /* r_ */
+  if(r_->stride[0] == 1 && r_->stride[1] != 0) {
+    r__ = r_;
+  } else {
+    THCTensor *transp_r_ = THCTensor_(newTranspose)(state, r_, 0, 1);
+    r__ = THCTensor_(newClone)(state, transp_r_);
+    THCTensor_(free)(state, transp_r_);
+    THCTensor_(transpose)(state, r__, NULL, 0, 1);
+  }
+
+  /* dense */
+  if(dense->stride[0] == 1 && dense->stride[1] != 0) {
+    transpose_dense = 'n';
+    dense_ = dense;
+  } else if(dense->stride[1] == 1 && dense->stride[0] != 0) {
+    transpose_dense = 't';
+    dense_ = dense;
+  } else {
+    transpose_dense = 't';
+    dense_ = THCTensor_(newContiguous)(state, dense);
+  }
+#if defined(THCS_REAL_IS_FLOAT)
+  THCudaSparse_Scsrmm2(
+#elif defined(THCS_REAL_IS_DOUBLE)
+  THCudaSparse_Dcsrmm2(
+#endif
+    state,
+    'n',
+    transpose_dense,
+    m,
+    n,
+    k,
+    nnz,
+    alpha,
+    THCTensor_(data)(state, values),
+    THCIndexTensor_(data)(state, csr),
+    THCIndexTensor_(data)(state, colindices),
+    THCTensor_(data)(state, dense_),
+    (transpose_dense == 'n' ? dense_->stride[1] : dense_->stride[0]),
+    beta,
+    THCTensor_(data)(state, r__),
+    r__->stride[1]);
+
+  /* free intermediate variables */
+  if(dense_ != dense) {
+    THCTensor_(free)(state, dense_);
+  }
+
+  if(r__ != r_) {
+    THCTensor_(freeCopyTo)(state, r__, r_);
+  }
+
+  THCIndexTensor_(free)(state, csr);
+  THCIndexTensor_(free)(state, indices);
+  THCIndexTensor_(free)(state, colindices);
+  THCTensor_(free)(state, values);
+#else
+  THError("unimplemented data type");
+#endif
 }
 
 void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense) {
@@ -34,8 +141,40 @@ void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTenso
 }
 
 void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse) {
-  THError("WARNING: Sparse Cuda Tensor op spcadd is not implemented");
-  // TODO pretty sure this is also just a cusparse call (axpyi)
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 3, sparse, r_, dense));
+  THCTensor_(resizeAs)(state, r_, dense);
+  THCSTensor_(contiguous)(state, sparse);
+
+  THCIndexTensor *indices = THCSTensor_(indices)(state, sparse);
+  THCTensor *values = THCSTensor_(values)(state, sparse);
+  THLongStorage *storage = THCSTensor_(newSizeOf)(state, sparse);
+  long nDim = THCTensor_(nDimension)(state, dense);
+  long nDimI = THCSTensor_(nDimensionI)(state, sparse);
+
+  if (r_ != dense) {
+    THCTensor_(copy)(state, r_, dense);
+  } else {
+    if(!THCTensor_(isContiguous)(state, r_)) {
+      THCTensor* r_contiguous = THCTensor_(newContiguous)(state, r_);
+      THCTensor_(copy)(state, r_, r_contiguous);
+      THCTensor_(free)(state, r_contiguous);
+    }
+  }
+
+  const dim3 block = getApplyBlock();
+  dim3 grid;
+  THArgCheck(getApplyGrid(state, sparse->nnz, grid), 1, CUTORCH_DIM_WARNING);
+
+  THCSTensor_spcKernel<TensorCAddOp<real>, unsigned long, real>
+    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      TensorCAddOp<real>(value),
+      V_INFO(r_), I_INFO(indices), V_INFO(values),
+      (unsigned long)sparse->nnz);
+  THCudaCheck(cudaGetLastError());
+
+  THCIndexTensor_(free)(state, indices);
+  THCTensor_(free)(state, values);
+  THLongStorage_free(storage);
 }
 
 void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
@@ -67,7 +206,7 @@ void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value
 void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
   if (r_ == t) {
     THCTensor *r_values_ = THCSTensor_(values)(state, r_);
-    THCTensor_(mul)(state, r_values_, r_values_, value);
+    THCTensor_(div)(state, r_values_, r_values_, value);
     THCTensor_(free)(state, r_values_);
   } else {
     THCSTensor_(resizeAs)(state, r_, t);
@@ -90,16 +229,124 @@ void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value
   }
 }
 
+// TODO for the moment the only parallelism is when copying/adding non-scalar values
 void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {
-  THError("WARNING: Sparse Cuda Tensor op cadd is not implemented");
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 3, 3, r_, t, src));
+  if(!THCSTensor_(isSameSizeAs)(state, t, src)) {
+    THError("cadd operands have incompatible sizes or dimension types");
+  }
+  THCSTensor_(contiguous)(state, t);
+  THCSTensor_(contiguous)(state, src);
+
+  if (src->nnz == 0) {
+    THCSTensor_(copy)(state, r_, t);
+    return;
+  }
+  if (t->nnz == 0) {
+    THCSTensor_(mul)(state, r_, src, value);
+    return;
+  }
+
+  // saving those because they can be overwritten when doing in-place operations
+  ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz, max_nnz = t_nnz + s_nnz;
+  long nDimI = src->nDimensionI;
+  THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
+  THCTensor *t_values_ = THCSTensor_(values)(state, t);
+  THCIndexTensor *s_indices_ = THCSTensor_(indices)(state, src);
+  THCTensor *s_values_ = THCSTensor_(values)(state, src);
+  THCIndexTensor *r_indices_ = THCIndexTensor_(newWithSize2d)(state, nDimI, max_nnz);
+  THCTensor *r_values_ = THCSTensor_(newValuesWithSizeOf)(state, s_values_, max_nnz);
+  THCTensor_(zero)(state, r_values_);
+  THCSTensor_(resizeAs)(state, r_, src);
+  THCSTensor_(move)(state, r_, r_indices_, r_values_);
+
+  const dim3 block = getApplyBlock();
+  dim3 grid;
+  THArgCheck(getApplyGrid(state, t_values_->stride[0], grid), 1, CUTORCH_DIM_WARNING);
+
+  THCSTensor_valueSparseUnionKernel<TensorCAddOp<real>, TensorAddOp<real>, TensorCAddOp<real>, unsigned long, real>
+    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      TensorCAddOp<real>(value),
+      TensorAddOp<real>(),
+      TensorCAddOp<real>(value),
+      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+      V_INFO(r_values_), V_INFO(t_values_), V_INFO(s_values_),
+      (unsigned long)t_nnz, (unsigned long)s_nnz);
+  THCudaCheck(cudaGetLastError());
+
+  THCudaLongStorage *resultNnz = THCudaLongStorage_newWithSize(state, 1);
+  THCSTensor_indexSparseUnionKernel<unsigned long, real>
+    <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+      (unsigned long)t_nnz, (unsigned long)s_nnz, (unsigned long*)resultNnz->data);
+  THCudaCheck(cudaGetLastError());
+  r_->nnz = THCudaLongStorage_get(state, resultNnz, 0);
+  THCudaLongStorage_free(state, resultNnz);
+  r_->contiguous = 1;
+
+  THCIndexTensor_(free)(state, t_indices_);
+  THCTensor_(free)(state, t_values_);
+  THCIndexTensor_(free)(state, s_indices_);
+  THCTensor_(free)(state, s_values_);
 }
 
 void THCSTensor_(csub)(THCState *state, THCSTensor *r_, THCSTensor *t, real value, THCSTensor *src) {
-  THError("WARNING: Sparse Cuda Tensor op csub is not implemented");
+  THCSTensor_(cadd)(state, r_, t, ScalarNegate<real>::to(value), src);
 }
 
 void THCSTensor_(cmul)(THCState *state, THCSTensor *r_, THCSTensor *t, THCSTensor *src) {
-  THError("WARNING: Sparse Cuda Tensor op cmul is not implemented");
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 3, 3, r_, t, src));
+  if(!THCSTensor_(isSameSizeAs)(state, t, src)) {
+    THError("cmul operands have incompatible sizes or dimension types");
+  }
+  THCSTensor_(contiguous)(state, t);
+  THCSTensor_(contiguous)(state, src);
+
+  if (t->nnz == 0 || src->nnz == 0) {
+    THCSTensor_(zero)(state, r_);
+    return;
+  }
+
+  // saving those because they can be overwritten when doing in-place operations
+  ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz;
+  ptrdiff_t max_nnz = t_nnz < s_nnz ? t_nnz : s_nnz;
+  long nDimI = src->nDimensionI;
+  THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
+  THCTensor *t_values_ = THCSTensor_(values)(state, t);
+  THCIndexTensor *s_indices_ = THCSTensor_(indices)(state, src);
+  THCTensor *s_values_ = THCSTensor_(values)(state, src);
+  THCIndexTensor *r_indices_ = THCIndexTensor_(newWithSize2d)(state, nDimI, max_nnz);
+  THCTensor *r_values_ = THCSTensor_(newValuesWithSizeOf)(state, s_values_, max_nnz);
+  THCTensor_(zero)(state, r_values_);
+  THCSTensor_(resizeAs)(state, r_, src);
+  THCSTensor_(move)(state, r_, r_indices_, r_values_);
+
+  const dim3 block = getApplyBlock();
+  dim3 grid;
+  THArgCheck(getApplyGrid(state, t_values_->stride[0], grid), 1, CUTORCH_DIM_WARNING);
+
+  THCSTensor_valueSparseIntersectionKernel<TensorMulOp<real>, unsigned long, real>
+    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      TensorMulOp<real>(),
+      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+      V_INFO(r_values_), V_INFO(t_values_), V_INFO(s_values_),
+      (unsigned long)t_nnz, (unsigned long)s_nnz);
+  THCudaCheck(cudaGetLastError());
+
+  THCudaLongStorage *resultNnz = THCudaLongStorage_newWithSize(state, 1);
+  THCSTensor_indexSparseIntersectionKernel<unsigned long, real>
+    <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+      (unsigned long)t_nnz, (unsigned long)s_nnz, (unsigned long*)resultNnz->data);
+  THCudaCheck(cudaGetLastError());
+  r_->nnz = THCudaLongStorage_get(state, resultNnz, 0);
+  THCudaLongStorage_free(state, resultNnz);
+  r_->contiguous = 1;
+
+  THCIndexTensor_(free)(state, t_indices_);
+  THCTensor_(free)(state, t_values_);
+  THCIndexTensor_(free)(state, s_indices_);
+  THCTensor_(free)(state, s_values_);
 }
 
 #undef ROW_PTR2

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -155,7 +155,7 @@ void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTenso
 void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse) {
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 3, sparse, r_, dense));
   THCTensor_(resizeAs)(state, r_, dense);
-  THCSTensor_(contiguous)(state, sparse);
+  THCSTensor_(contiguousValues)(state, sparse);
 
   THCIndexTensor *indices = THCSTensor_(indices)(state, sparse);
   THCTensor *values = THCSTensor_(values)(state, sparse);

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -2,6 +2,10 @@
 #define THCS_GENERIC_FILE "generic/THCSTensorMath.cu"
 #else
 
+#include "THCThrustAllocator.cuh"
+#include <thrust/device_ptr.h>
+#include <thrust/sequence.h>
+
 #define ROW_PTR2(t, r) (THCTensor_(data)(THCState *state, t) + (r) * (t)->stride[0])
 #define COL_PTR2(t, c) (THCTensor_(data)(THCState *state, t) + (c) * (t)->stride[1])
 
@@ -152,6 +156,61 @@ void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTenso
   // TODO Write some kernels
 }
 
+void THCSTensor_(hspmm)(THCState *state, THCSTensor *r_, real alpha, THCSTensor *sparse, THCTensor *dense) {
+#if CUDA_VERSION >= 7000
+  THCThrustAllocator thrustAlloc(state);
+#define THRUST_EXEC(fn, ...) fn(thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)), ##__VA_ARGS__)
+#else
+#define THRUST_EXEC(fn, ...) fn(##__VA_ARGS__)
+#endif
+
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 2, 3, r_, sparse, dense));
+
+  THArgCheck(sparse->nDimensionI == 2, 2,
+      "matrices expected, got %dD tensor", sparse->nDimensionI);
+  THArgCheck(sparse->nDimensionV == 0, 2,
+      "scalar values expected, got %dD values", sparse->nDimensionV);
+  THArgCheck(dense->nDimension == 2, 2,
+      "matrices expected, got %dD tensor", dense->nDimension);
+
+  long m = THCSTensor_(size)(state, sparse, 0);
+  long k = THCSTensor_(size)(state, sparse, 1);
+  long n = THCTensor_(size)(state, dense, 1);
+
+  THArgCheck(THCTensor_(size)(state, dense, 0) == k, 3,
+      "Expected dim 0 size %d, got %d", k, THCTensor_(size)(state, dense, 0));
+  long size[2] = {m, n};
+  THCSTensor_(rawResize)(state, r_, 1, 1, size);
+
+  THCSTensor_(contiguous)(state, sparse);
+
+  long nnz = THCSTensor_(nnz)(state, sparse);
+  THCIndexTensor *indices = THCIndexTensor_(newWithSize2d)(state, 1, nnz);
+  // create values in column-major format to avoid copying in spaddmm
+  THCTensor *values = THCTensor_(newWithSize2d)(state, n, nnz);
+  THCTensor_(transpose)(state, values, NULL, 0, 1);
+
+  THCSTensor *newSparse = THCSTensor_(newClone)(state, sparse);
+  THCIndexTensor *spIndices = THCSTensor_(indices)(state, newSparse);
+  THCIndexTensor *dstIndices = THCIndexTensor_(new)(state);
+  THCIndexTensor_(select)(state, dstIndices, spIndices, 0, 0);
+  // Save destination indices to output hybrid tensor
+  THCIndexTensor_(copy)(state, indices, dstIndices);
+  // Replace destination indices with 0, 1, 2, 3, ... and compute output values
+  // tensor with sparse * dense multiplication
+  thrust::device_ptr<integer> indicesIter(THCIndexTensor_(data)(state, dstIndices));
+  THRUST_EXEC(thrust::sequence, indicesIter, indicesIter + nnz);
+  newSparse->size[0] = nnz;
+  THCSTensor_(spaddmm)(state, values, ScalarConvert<int, real>::to(0), values, alpha, newSparse, dense);
+  THCSTensor_(move)(state, r_, indices, values);
+
+  THCSTensor_(free)(state, newSparse);
+  THCIndexTensor_(free)(state, spIndices);
+  THCIndexTensor_(free)(state, dstIndices);
+
+#undef THRUST_EXEC
+}
+
 void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse) {
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 3, sparse, r_, dense));
   THCTensor_(resizeAs)(state, r_, dense);
@@ -159,11 +218,11 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
 
   THCIndexTensor *indices = THCSTensor_(indices)(state, sparse);
   THCTensor *values = THCSTensor_(values)(state, sparse);
-  THLongStorage *storage = THCSTensor_(newSizeOf)(state, sparse);
   long nDim = THCTensor_(nDimension)(state, dense);
   long nDimI = THCSTensor_(nDimensionI)(state, sparse);
 
   if (r_ != dense) {
+    THCTensor_(resizeAs)(state, r_, dense);
     THCTensor_(copy)(state, r_, dense);
   } else {
     if(!THCTensor_(isContiguous)(state, r_)) {
@@ -173,20 +232,30 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
     }
   }
 
+  // TODO more benchmarking
   const dim3 block = getApplyBlock();
   dim3 grid;
-  THArgCheck(getApplyGrid(state, sparse->nnz, grid), 1, CUTORCH_DIM_WARNING);
+  if (sparse->nDimensionV == 0) {
+    THArgCheck(getApplyGrid(state, sparse->nnz, grid), 1, CUTORCH_DIM_WARNING);
 
-  THCSTensor_spcKernel<TensorCAddOp<real>, unsigned long, real>
-    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-      TensorCAddOp<real>(value),
-      V_INFO(r_), I_INFO(indices), V_INFO(values),
-      (unsigned long)sparse->nnz);
+    THCSTensor_spcKernelScalar<TensorCAddOp<real>, unsigned long, real>
+      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+        TensorCAddOp<real>(value),
+        V_INFO(r_), I_INFO(indices), V_INFO(values),
+        (unsigned long)sparse->nnz);
+  } else {
+    THArgCheck(getApplyGrid(state, sparse->nnz * block.x, grid), 1, CUTORCH_DIM_WARNING);
+
+    THCSTensor_spcKernel<TensorCAddOp<real>, unsigned long, real>
+      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+        TensorCAddOp<real>(value),
+        V_INFO(r_), I_INFO(indices), V_INFO(values),
+        (unsigned long)sparse->nnz);
+  }
   THCudaCheck(cudaGetLastError());
 
   THCIndexTensor_(free)(state, indices);
   THCTensor_(free)(state, values);
-  THLongStorage_free(storage);
 }
 
 void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value) {
@@ -258,42 +327,75 @@ void THCSTensor_(cadd)(THCState *state, THCSTensor *r_, THCSTensor *t, real valu
     return;
   }
 
-  // saving those because they can be overwritten when doing in-place operations
-  ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz, max_nnz = t_nnz + s_nnz;
-  long nDimI = src->nDimensionI;
+  // We deliberately choose to simply concat the indices and values tensors
+  // rather than merging them. This removes the need to synchronously fetch nnz
+  // at the end of the operation, at the cost of having a non-contiguous result.
+  // This trade-off is preferable for the common use-case of gradient accumulation.
+  // TODO have two distinct functions? The other option is commented out below
   THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
   THCTensor *t_values_ = THCSTensor_(values)(state, t);
   THCIndexTensor *s_indices_ = THCSTensor_(indices)(state, src);
   THCTensor *s_values_ = THCSTensor_(values)(state, src);
-  THCIndexTensor *r_indices_ = THCIndexTensor_(newWithSize2d)(state, nDimI, max_nnz);
-  THCTensor *r_values_ = THCSTensor_(newValuesWithSizeOf)(state, s_values_, max_nnz);
-  THCTensor_(zero)(state, r_values_);
+  if (value != ScalarConvert<int, real>::to(1)) {
+    THCTensor *s_values_orig = s_values_;
+    s_values_ = THCTensor_(new)(state);
+    THCTensor_(mul)(state, s_values_, s_values_orig, value);
+    THCTensor_(free)(state, s_values_orig);
+  }
+  THCIndexTensor *r_indices_ = THCIndexTensor_(new)(state);
+  THCTensor *r_values_ = THCTensor_(new)(state);
+  THCIndexTensor_(cat)(state, r_indices_, t_indices_, s_indices_, 1);
+  THCTensor_(cat)(state, r_values_, t_values_, s_values_, 0);
   THCSTensor_(resizeAs)(state, r_, src);
   THCSTensor_(move)(state, r_, r_indices_, r_values_);
 
-  const dim3 block = getApplyBlock();
-  dim3 grid;
-  THArgCheck(getApplyGrid(state, t_values_->stride[0], grid), 1, CUTORCH_DIM_WARNING);
-
-  THCSTensor_valueSparseUnionKernel<TensorCAddOp<real>, TensorAddOp<real>, TensorCAddOp<real>, unsigned long, real>
-    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-      TensorCAddOp<real>(value),
-      TensorAddOp<real>(),
-      TensorCAddOp<real>(value),
-      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
-      V_INFO(r_values_), V_INFO(t_values_), V_INFO(s_values_),
-      (unsigned long)t_nnz, (unsigned long)s_nnz);
-  THCudaCheck(cudaGetLastError());
-
-  THCudaLongStorage *resultNnz = THCudaLongStorage_newWithSize(state, 1);
-  THCSTensor_indexSparseUnionKernel<unsigned long, real>
-    <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
-      I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
-      (unsigned long)t_nnz, (unsigned long)s_nnz, (unsigned long*)resultNnz->data);
-  THCudaCheck(cudaGetLastError());
-  r_->nnz = THCudaLongStorage_get(state, resultNnz, 0);
-  THCudaLongStorage_free(state, resultNnz);
-  r_->contiguous = 1;
+  // // saving those because they can be overwritten when doing in-place operations
+  // ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz, max_nnz = t_nnz + s_nnz;
+  // long nDimI = src->nDimensionI;
+  // THCIndexTensor *t_indices_ = THCSTensor_(indices)(state, t);
+  // THCTensor *t_values_ = THCSTensor_(values)(state, t);
+  // THCIndexTensor *s_indices_ = THCSTensor_(indices)(state, src);
+  // THCTensor *s_values_ = THCSTensor_(values)(state, src);
+  // THCIndexTensor *r_indices_ = THCIndexTensor_(newWithSize2d)(state, nDimI, max_nnz);
+  // THCTensor *r_values_ = THCSTensor_(newValuesWithSizeOf)(state, s_values_, max_nnz);
+  // THCTensor_(zero)(state, r_values_);
+  // THCSTensor_(resizeAs)(state, r_, src);
+  // THCSTensor_(move)(state, r_, r_indices_, r_values_);
+  //
+  // const dim3 block = getApplyBlock();
+  // dim3 grid;
+  // THArgCheck(getApplyGrid(state, t_values_->stride[0], grid), 1, CUTORCH_DIM_WARNING);
+  //
+  // THCSTensor_valueSparseUnionKernel<TensorCAddOp<real>, TensorAddOp<real>, TensorCAddOp<real>, unsigned long, real>
+  //   <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+  //     TensorCAddOp<real>(value),
+  //     TensorAddOp<real>(),
+  //     TensorCAddOp<real>(value),
+  //     I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+  //     V_INFO(r_values_), V_INFO(t_values_), V_INFO(s_values_),
+  //     (unsigned long)t_nnz, (unsigned long)s_nnz);
+  // THCudaCheck(cudaGetLastError());
+  //
+  // bool freeScratchSpace = false;
+  // void* scratchSpace = THCState_getCurrentDeviceScratchSpace(state);
+  // if (!scratchSpace) {
+  //   THCudaCheck(THCudaMalloc(state, &scratchSpace,
+  //       THCState_getCurrentDeviceScratchSpaceSize(state)));
+  //   freeScratchSpace = true;
+  // }
+  // THCSTensor_indexSparseUnionKernel<unsigned long, real>
+  //   <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+  //     I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
+  //     (unsigned long)t_nnz, (unsigned long)s_nnz, (unsigned long*)scratchSpace);
+  // THCudaCheck(cudaGetLastError());
+  // // Synchronous!
+  // unsigned long nnzOut;
+  // THCudaCheck(cudaMemcpy(&nnzOut, scratchSpace, sizeof(unsigned long), cudaMemcpyDeviceToHost));
+  // r_->nnz = nnzOut;
+  // r_->contiguous = 1;
+  // if (freeScratchSpace) {
+  //   THCudaCheck(THCudaFree(state, scratchSpace));
+  // }
 
   THCIndexTensor_(free)(state, t_indices_);
   THCTensor_(free)(state, t_values_);

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -166,18 +166,18 @@ void THCSTensor_(hspmm)(THCState *state, THCSTensor *r_, real alpha, THCSTensor 
 
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 2, 3, r_, sparse, dense));
 
-  THArgCheck(sparse->nDimensionI == 2, 2,
+  THArgCheck(sparse->nDimensionI == 2, 3,
       "matrices expected, got %dD tensor", sparse->nDimensionI);
-  THArgCheck(sparse->nDimensionV == 0, 2,
+  THArgCheck(sparse->nDimensionV == 0, 3,
       "scalar values expected, got %dD values", sparse->nDimensionV);
-  THArgCheck(dense->nDimension == 2, 2,
+  THArgCheck(dense->nDimension == 2, 4,
       "matrices expected, got %dD tensor", dense->nDimension);
 
   long m = THCSTensor_(size)(state, sparse, 0);
   long k = THCSTensor_(size)(state, sparse, 1);
   long n = THCTensor_(size)(state, dense, 1);
 
-  THArgCheck(THCTensor_(size)(state, dense, 0) == k, 3,
+  THArgCheck(THCTensor_(size)(state, dense, 0) == k, 4,
       "Expected dim 0 size %d, got %d", k, THCTensor_(size)(state, dense, 0));
   long size[2] = {m, n};
   THCSTensor_(rawResize)(state, r_, 1, 1, size);

--- a/torch/lib/THCS/generic/THCSTensorMath.h
+++ b/torch/lib/THCS/generic/THCSTensorMath.h
@@ -19,6 +19,8 @@ TH_API void THCTensor_(spaddcdiv)(THCState *state, THCTensor *r_, THCTensor *t, 
 TH_API void THCSTensor_(spaddmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense);
 // sparse = beta * sparse + alpha * sparse * dense
 TH_API void THCSTensor_(sspaddmm)(THCState *state, THCSTensor *r_, real beta, THCSTensor *t, real alpha, THCSTensor *sparse, THCTensor *dense);
+// hybrid = alpha * sparse * dense
+TH_API void THCSTensor_(hspmm)(THCState *state, THCSTensor *r_, real alpha, THCSTensor *sparse, THCTensor *dense);
 TH_API void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real value, THCSTensor *sparse);
 TH_API void THCSTensor_(mul)(THCState *state, THCSTensor *r_, THCSTensor *t, real value);
 TH_API void THCSTensor_(div)(THCState *state, THCSTensor *r_, THCSTensor *t, real value);

--- a/torch/lib/THPP/tensors/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/THCTensor.cpp
@@ -1,4 +1,7 @@
+#include <THCS/THCS.h>
+
 #include "THCTensor.hpp"
+#include "THCSTensor.hpp"
 #include "THCHalf.h"
 #include "../TraitsCuda.hpp"
 

--- a/torch/lib/THPP/tensors/generic/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.cpp
@@ -637,7 +637,7 @@ thpp::Type THCSTensor<real>::type() const {
 
 template<>
 bool THCSTensor<real>::isCuda() const {
-  return false;
+  return true;
 }
 
 template<>
@@ -647,7 +647,7 @@ bool THCSTensor<real>::isSparse() const {
 
 template<>
 int THCSTensor<real>::getDevice() const {
-  return -1;
+  return tensor->values->storage->device;
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -691,8 +691,14 @@ template<>
 auto THCTensor<real>::cadd(const Tensor& src1, scalar_type value,
                            const Tensor& src2) -> THCTensor& {
   const THCTensor &src1_t = const_tensor_cast(src1);
-  const THCTensor &src2_t = const_tensor_cast(src2);
-  THCTensor_(cadd)(state, tensor, src1_t.tensor, cast_scalar(value), src2_t.tensor);
+
+  const THCSTensor<real>* src2_sparse;
+  if ((src2_sparse = dynamic_cast<const THCSTensor<real>*>(&src2))) {
+    THCSTensor_(spcadd)(state, tensor, src1_t.tensor, cast_scalar(value), src2_sparse->tensor);
+  } else {
+    const THCTensor &src2_t = const_tensor_cast(src2);
+    THCTensor_(cadd)(state, tensor, src1_t.tensor, cast_scalar(value), src2_t.tensor);
+  }
   return *this;
 }
 

--- a/torch/lib/THPP/tensors/generic/THTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THTensor.cpp
@@ -671,7 +671,6 @@ auto THTensor<real>::cadd(const Tensor& src1, scalar_type value, const Tensor& s
   const THSTensor<real>* src2_sparse;
   if ((src2_sparse = dynamic_cast<const THSTensor<real>*>(&src2))) {
     THSTensor_(spcadd)(tensor, src1_t.tensor, value, src2_sparse->tensor);
-    return *this;
   } else {
     const THTensor &src2_t = const_tensor_cast(src2);
     THTensor_(cadd)(tensor, src1_t.tensor, value, src2_t.tensor);

--- a/torch/lib/THS/THSTensor.h
+++ b/torch/lib/THS/THSTensor.h
@@ -14,4 +14,3 @@
 #include "THSGenerateAllTypes.h"
 
 #endif
-

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -110,6 +110,7 @@ THSTensor* THSTensor_(move)(THSTensor *self, THLongTensor *indices, THTensor *va
   self->indices = indices;
   self->values = values;
   self->nnz = empty ? 0 : THTensor_(size)(values, 0);
+  self->contiguous = 0;
 
   return self;
 }

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -508,6 +508,10 @@ void THSTensor_(contiguous)(THSTensor *self) {
   self->contiguous = 1;
 }
 
+void THSTensor_(markContiguous)(THSTensor *self) {
+  self->contiguous = 1;
+}
+
 void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask) {
   THSTensor_(resizeAs)(r_, mask);
   if (mask->nnz == 0) {

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -344,6 +344,7 @@ void THSTensor_(copy)(THSTensor *self, THSTensor *src) {
   THSTensor_(rawResize)(self, src->nDimensionI, src->nDimensionV, src->size);
   THSTensor_(_set)(self, src->indices, src->values);
   self->nnz = src->nnz;
+  self->contiguous = src->contiguous;
 }
 
 // In place transpose

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -59,6 +59,7 @@ TH_API void THSTensor_(transpose)(THSTensor *self, int dimension1_, int dimensio
 TH_API int THSTensor_(isContiguous)(const THSTensor *self);
 TH_API int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor *src);
 TH_API void THSTensor_(contiguous)(THSTensor *self);
+TH_API void THSTensor_(markContiguous)(THSTensor *self);
 
 TH_API void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask);
 

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -26,8 +26,8 @@ TH_API int THSTensor_(nDimensionV)(const THSTensor *self);
 TH_API long THSTensor_(size)(const THSTensor *self, int dim);
 TH_API ptrdiff_t THSTensor_(nnz)(const THSTensor *self);
 TH_API THLongStorage *THSTensor_(newSizeOf)(THSTensor *self);
-TH_API THLongTensor *THSTensor_(indices)(const THSTensor *self);
-TH_API THTensor *THSTensor_(values)(const THSTensor *self);
+TH_API THLongTensor *THSTensor_(newIndices)(const THSTensor *self);
+TH_API THTensor *THSTensor_(newValues)(const THSTensor *self);
 
 /**** creation methods ****/
 TH_API THSTensor *THSTensor_(new)(void);
@@ -59,7 +59,6 @@ TH_API void THSTensor_(transpose)(THSTensor *self, int dimension1_, int dimensio
 TH_API int THSTensor_(isContiguous)(const THSTensor *self);
 TH_API int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor *src);
 TH_API void THSTensor_(contiguous)(THSTensor *self);
-TH_API void THSTensor_(markContiguous)(THSTensor *self);
 
 TH_API void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask);
 
@@ -75,7 +74,7 @@ TH_API void THSTensor_(select)(THSTensor *self, THSTensor *src, int dimension_, 
 */
 
 // internal methods
-THSTensor* THSTensor_(move)(THSTensor *self, THLongTensor *indices, THTensor *values);
+THSTensor* THSTensor_(_move)(THSTensor *self, THLongTensor *indices, THTensor *values);
 THSTensor* THSTensor_(_set)(THSTensor *self, THLongTensor *indices, THTensor *values);
 
 #endif

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -406,6 +406,10 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
   THTensor_(free)(values);
 }
 
+void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *dense) {
+  THError("WARNING: Sparse Tensor op hspmm is not implemented");
+}
+
 void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse) {
   THTensor_(resizeAs)(r_, dense);
   THSTensor_(contiguous)(sparse);

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -6,12 +6,12 @@
 #define COL_PTR2(t, c) (THTensor_(data)(t) + (c) * (t)->stride[1])
 
 void THSTensor_(zero)(THSTensor *self) {
-    if (self->indices->nDimension) {
-      THLongTensor_resizeNd(self->indices, 0, NULL, NULL);
-    }
-    if (self->values->nDimension) {
-      THTensor_(resizeNd)(self->values, 0, NULL, NULL);
-    }
+  if (self->indices->nDimension) {
+    THLongTensor_resizeNd(self->indices, 0, NULL, NULL);
+  }
+  if (self->values->nDimension) {
+    THTensor_(resizeNd)(self->values, 0, NULL, NULL);
+  }
   self->nnz = 0;
 }
 
@@ -94,7 +94,6 @@ void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   THLongTensor *r_indices_ = THLongTensor_newWithSize2d(nDimI, max_nnz);
   THTensor *r_values_ = THSTensor_(newValuesWithSizeOf)(s_values_, max_nnz);
   THTensor_(zero)(r_values_);
-  // TODO handle case where src values is empty
   THSTensor_(resizeAs)(r_, src);
   THSTensor_(move)(r_, r_indices_, r_values_);
 
@@ -408,6 +407,9 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
 }
 
 void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse) {
+  THTensor_(resizeAs)(r_, dense);
+  THSTensor_(contiguous)(sparse);
+
   long k;
   THLongTensor  *indices = THSTensor_(indices)(sparse);
   THTensor      *values = THSTensor_(values)(sparse);
@@ -416,11 +418,7 @@ void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sp
   long          nDim = THTensor_(nDimension)(dense);
   long          nDimI = THSTensor_(nDimensionI)(sparse);
 
-  THTensor_(resizeAs)(r_, dense);
-  THSTensor_(contiguous)(sparse);
-
   if (r_ != dense) THTensor_(copy)(r_, dense);
-
 
   if (nDim > nDimI) {
     THTensor *srcBuffer = THTensor_(new)();

--- a/torch/lib/THS/generic/THSTensorMath.h
+++ b/torch/lib/THS/generic/THSTensorMath.h
@@ -24,6 +24,8 @@ TH_API void THTensor_(spaddcmul)(THTensor *r_, THTensor *t, real value, THSTenso
 TH_API void THSTensor_(spaddmm)(THTensor *r_, real beta, THTensor *t, real alpha, THSTensor *sparse, THTensor *dense);
 // sparse = beta * sparse + alpha * sparse * dense
 TH_API void THSTensor_(sspaddmm)(THSTensor *r_, real beta, THSTensor *t, real alpha, THSTensor *sparse, THTensor *dense);
+// hybrid = alpha * sparse * dense
+TH_API void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *dense);
 TH_API void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse);
 
 #endif

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -7,7 +7,7 @@ from . import _all_functions
 
 
 class UpsamplingNearest2d(Function):
-    
+
     def __init__(self, size=None, scale_factor=None):
         super(UpsamplingNearest2d, self).__init__()
         if size is None and scale_factor is None:
@@ -76,7 +76,7 @@ class UpsamplingBilinear2d(Function):
                         assert i >= 1
                 except AssertionError as e:
                     raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')
-                
+
         if size is not None and not isinstance(size, tuple):
             size = (size, size)
         if scale_factor is not None and not isinstance(scale_factor, tuple):

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -72,7 +72,7 @@ class UpsamplingBilinear2d(Function):
                 try:
                     assert len(scale_factor) == 2
                     for i in scale_factor:
-                        assert isinstance(i, (Integral, int))
+                        assert isinstance(i, Integral)
                         assert i >= 1
                 except AssertionError as e:
                     raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -586,7 +586,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     Args:
         input (Variable): input
         size (int or Tuple[int, int]): output spatial size.
-        scale_factor (int): multiplier for spatial size. Has to be an integer.
+        scale_factor (int or Tuple[int, int]): multiplier for spatial size
     """
     return _functions.thnn.UpsamplingBilinear2d(size, scale_factor)(input)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -25,6 +25,7 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
           a tuple (sh x sw). Default: 1
         padding: implicit zero padding on the input. Can be a single number or
           a tuple. Default: 0
+        dilation: the spacing between kernel elements. Default: 1
         groups: split input into groups, in_channels should be divisible by
           the number of groups
 
@@ -51,6 +52,11 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
         weight: filters of shape (out_channels, in_channels, kW)
         bias: optional bias of shape (out_channels)
         stride: the stride of the convolving kernel, default 1
+        padding: implicit zero padding on the input. Can be a single number or
+          a tuple. Default: 0
+        dilation: the spacing between kernel elements. Default: 1
+        groups: split input into groups, in_channels should be divisible by
+          the number of groups
 
     Examples:
         >>> filters = autograd.Variable(torch.randn(33, 16, 3))
@@ -77,6 +83,9 @@ def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
           a tuple (st x sh x sw). Default: 1
         padding: implicit zero padding on the input. Can be a single number or
           a tuple. Default: 0
+        dilation: the spacing between kernel elements. Default: 1
+        groups: split input into groups, in_channels should be divisible by
+          the number of groups
 
     Examples:
         >>> filters = autograd.Variable(torch.randn(33, 16, 3, 3, 3))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -463,7 +463,7 @@ def nll_loss(input, target, weight=None, size_average=True):
     See :class:`~torch.nn.NLLLoss` for details.
 
     Args:
-        input: :math:`(N, C)` where `C = number of classes`
+        input: :math:`(N, C)` where `C = number of classes` or `(N, C, H, W)` in case of 2D - Loss
         target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
         weight (Variable, optional): a manual rescaling weight given to each
                 class. If given, has to be a Variable of size "nclasses"

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -602,7 +602,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     Args:
         input (Variable): input
         size (int or Tuple[int, int]): output spatial size.
-        scale_factor (int): multiplier for spatial size. Has to be an integer.
+        scale_factor (int or Tuple[int, int]): multiplier for spatial size
     """
     return _functions.thnn.UpsamplingBilinear2d(size, scale_factor)(input)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -98,14 +98,15 @@ def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 
 def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1):
-    f = ConvNd(_single(stride), _single(padding), _single(1), True,
-               _single(output_padding), groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
+                     output_padding=0, groups=1, dilation=1):
+    f = ConvNd(_single(stride), _single(padding), _single(dilation), True,
+               _single(output_padding),
+               groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 
 
 def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1):
+                     output_padding=0, groups=1, dilation=1):
     """Applies a 2D transposed convolution operator over an input image
     composed of several input planes, sometimes also called "deconvolution".
 
@@ -123,14 +124,15 @@ def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
           the number of groups
         output_padding: A zero-padding of 0 <= padding < stride that should be
           added to the output. Can be a single number or a tuple. Default: 0
+        dilation: the spacing between kernel elements. Default: 1
     """
-    f = ConvNd(_pair(stride), _pair(padding), _pair(1), True,
+    f = ConvNd(_pair(stride), _pair(padding), _pair(dilation), True,
                _pair(output_padding), groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 
 
 def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1):
+                     output_padding=0, groups=1, dilation=1):
     """Applies a 3D transposed convolution operator over an input image
     composed of several input planes, sometimes also called "deconvolution"
 
@@ -144,8 +146,13 @@ def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
           tuple (sh x sw). Default: 1
         padding: implicit zero padding on the input, a single number or a
           tuple (padh x padw). Default: 0
+        output_padding: A zero-padding of 0 <= padding < stride that should be
+          added to the output. Can be a single number or a tuple. Default: 0
+        groups: split input into groups, in_channels should be divisible by
+          the number of groups
+        dilation: the spacing between kernel elements. Default: 1
     """
-    f = ConvNd(_triple(stride), _triple(padding), _triple(1), True,
+    f = ConvNd(_triple(stride), _triple(padding), _triple(dilation), True,
                _triple(output_padding), groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -57,7 +57,7 @@ class BatchNorm1d(_BatchNorm):
 
     The mean and standard-deviation are calculated per-dimension over
     the mini-batches and gamma and beta are learnable parameter vectors
-    of size N (where N is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
@@ -99,7 +99,7 @@ class BatchNorm2d(_BatchNorm):
 
     The mean and standard-deviation are calculated per-dimension over
     the mini-batches and gamma and beta are learnable parameter vectors
-    of size N (where N is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
@@ -141,7 +141,7 @@ class BatchNorm3d(_BatchNorm):
 
     The mean and standard-deviation are calculated per-dimension over
     the mini-batches and gamma and beta are learnable parameter vectors
-    of size N (where N is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
@@ -149,7 +149,7 @@ class BatchNorm3d(_BatchNorm):
     During evaluation, this running mean/variance is used for normalization.
 
     Args:
-        num_features: num_features from an expected input of size batch_size x num_features x height x width
+        num_features: num_features from an expected input of size batch_size x num_features x depth x height x width
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to true, gives the layer learnable affine parameters.

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -407,11 +407,11 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
         kernel_size = _single(kernel_size)
         stride = _single(stride)
         padding = _single(padding)
-        dilation = _single(1)
+        dilation = _single(dilation)
         output_padding = _single(output_padding)
         super(ConvTranspose1d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
@@ -467,6 +467,7 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
         output_padding (int or tuple, optional): Zero-padding added to one side of the output
         groups (int, optional): Number of blocked connections from input channels to output channels
         bias (bool, optional): If True, adds a learnable bias to the output
+        dilation (int or tuple, optional): Spacing between kernel elements
 
     Shape:
         - Input: :math:`(N, C_{in}, H_{in}, W_{in})`
@@ -506,11 +507,11 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)
         padding = _pair(padding)
-        dilation = _pair(1)
+        dilation = _pair(dilation)
         output_padding = _pair(output_padding)
         super(ConvTranspose2d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
@@ -566,6 +567,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         output_padding (int or tuple, optional): Zero-padding added to one side of the output
         groups (int, optional): Number of blocked connections from input channels to output channels
         bias (bool, optional): If True, adds a learnable bias to the output
+        dilation (int or tuple, optional): Spacing between kernel elements
 
     Shape:
         - Input: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
@@ -596,11 +598,11 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
         kernel_size = _triple(kernel_size)
         stride = _triple(stride)
         padding = _triple(padding)
-        dilation = _triple(1)
+        dilation = _triple(dilation)
         output_padding = _triple(output_padding)
         super(ConvTranspose3d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -364,7 +364,7 @@ class CosineEmbeddingLoss(Module):
 
 class MarginRankingLoss(Module):
     r"""Creates a criterion that measures the loss given
-    inputs `x1`, `x2`, two 1D min-batch `Tensor`s,
+    inputs `x1`, `x2`, two 1D mini-batch `Tensor`s,
     and a label 1D mini-batch tensor `y` with values (`1` or `-1`).
 
     If `y == 1` then it assumed the first input should be ranked higher

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -5,7 +5,26 @@ from .. import functional as F
 from .utils import _pair
 
 
-class UpsamplingNearest2d(Module):
+class _UpsamplingBase(Module):
+
+    def __init__(self, size=None, scale_factor=None):
+        super(_UpsamplingBase, self).__init__()
+        if size is None and scale_factor is None:
+            raise ValueError('either size or scale_factor should be defined')
+        if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
+            raise ValueError('scale_factor must be of integer type or tuple of integer types')
+        self.size = _pair(size)
+        self.scale_factor = scale_factor
+
+    def __repr__(self):
+        if self.scale_factor is not None:
+            info = 'scale_factor=' + str(self.scale_factor)
+        else:
+            info = 'size=' + str(self.size)
+        return self.__class__.__name__ + '(' + info + ')'
+
+
+class UpsamplingNearest2d(_UpsamplingBase):
     """
     Applies a 2D nearest neighbor upsampling to an input signal composed of several input
     channels.
@@ -45,27 +64,17 @@ class UpsamplingNearest2d(Module):
         [torch.FloatTensor of size 1x1x4x4]
 
     """
-    def __init__(self, size=None, scale_factor=None):
-        super(UpsamplingNearest2d, self).__init__()
-        if size is None and scale_factor is None:
-            raise ValueError('either size or scale_factor should be defined')
-        if scale_factor is not None and not isinstance(scale_factor, Integral):
-            raise ValueError('scale_factor must be of integer type')
-        self.size = _pair(size)
-        self.scale_factor = scale_factor
 
-    def __repr__(self):
-        if self.scale_factor is not None:
-            info = 'scale_factor=' + str(self.scale_factor)
-        else:
-            info = 'size=' + str(self.size)
-        return self.__class__.__name__ + '(' + info + ')'
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest2d, self).__init__(size, scale_factor)
+        if self.scale_factor is not None and not isinstance(scale_factor, Integral):
+            raise ValueError('scale_factor must be of integer type for neighest neighbor sampling')
 
     def forward(self, input):
         return F.upsample_nearest(input, self.size, self.scale_factor)
 
 
-class UpsamplingBilinear2d(Module):
+class UpsamplingBilinear2d(_UpsamplingBase):
     """Applies a 2D bilinear upsampling to an input signal composed of several input
     channels.
 
@@ -118,32 +127,20 @@ class UpsamplingBilinear2d(Module):
         [torch.FloatTensor of size 1x1x4x2]
     """
     def __init__(self, size=None, scale_factor=None):
-        super(UpsamplingBilinear2d, self).__init__()
-        if size is None and scale_factor is None:
-            raise ValueError('either size or scale_factor should be defined')
-        if scale_factor is not None:
-            if not isinstance(scale_factor, (Integral, tuple)):
-                raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')
-            if isinstance(scale_factor, tuple):
-                try:
-                    assert len(scale_factor) == 2
-                    for i in scale_factor:
-                        assert isinstance(i, Integral)
-                        assert i >= 1
-                except AssertionError as e:
-                    raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')
-        self.size = _pair(size)
-        if scale_factor is not None:
-            self.scale_factor = _pair(scale_factor)
-        else:
-            self.scale_factor = scale_factor
+        super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
 
-    def __repr__(self):
         if self.scale_factor is not None:
-            info = 'scale_factor=' + str(self.scale_factor)
-        else:
-            info = 'size=' + str(self.size)
-        return self.__class__.__name__ + '(' + info + ')'
-
+            self.scale_factor = _pair(self.scale_factor)
+            # we have to be a tuple at this point
+            try:
+                assert len(self.scale_factor) == 2
+                for i in self.scale_factor:
+                    assert isinstance(i, Integral)
+                    assert i >= 1
+            except AssertionError as e:
+                raise ValueError('scale_factor must be a non-negative integer, '
+                                 'or a tuple of non-negative integers for bilinear upsamplings, but got: '
+                                 '{}'.format(self.scale_factor))
+    
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -5,26 +5,7 @@ from .. import functional as F
 from .utils import _pair
 
 
-class _UpsamplingBase(Module):
-
-    def __init__(self, size=None, scale_factor=None):
-        super(_UpsamplingBase, self).__init__()
-        if size is None and scale_factor is None:
-            raise ValueError('either size or scale_factor should be defined')
-        if scale_factor is not None and not isinstance(scale_factor, Integral):
-            raise ValueError('scale_factor must be of integer type')
-        self.size = _pair(size)
-        self.scale_factor = scale_factor
-
-    def __repr__(self):
-        if self.scale_factor is not None:
-            info = 'scale_factor=' + str(self.scale_factor)
-        else:
-            info = 'size=' + str(self.size)
-        return self.__class__.__name__ + '(' + info + ')'
-
-
-class UpsamplingNearest2d(_UpsamplingBase):
+class UpsamplingNearest2d(Module):
     """
     Applies a 2D nearest neighbor upsampling to an input signal composed of several input
     channels.
@@ -64,14 +45,28 @@ class UpsamplingNearest2d(_UpsamplingBase):
         [torch.FloatTensor of size 1x1x4x4]
 
     """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest2d, self).__init__()
+        if size is None and scale_factor is None:
+            raise ValueError('either size or scale_factor should be defined')
+        if scale_factor is not None and not isinstance(scale_factor, Integral):
+            raise ValueError('scale_factor must be of integer type')
+        self.size = _pair(size)
+        self.scale_factor = scale_factor
+
+    def __repr__(self):
+        if self.scale_factor is not None:
+            info = 'scale_factor=' + str(self.scale_factor)
+        else:
+            info = 'size=' + str(self.size)
+        return self.__class__.__name__ + '(' + info + ')'
 
     def forward(self, input):
         return F.upsample_nearest(input, self.size, self.scale_factor)
 
 
-class UpsamplingBilinear2d(_UpsamplingBase):
-    """
-    Applies a 2D bilinear upsampling to an input signal composed of several input
+class UpsamplingBilinear2d(Module):
+    """Applies a 2D bilinear upsampling to an input signal composed of several input
     channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
@@ -79,15 +74,19 @@ class UpsamplingBilinear2d(_UpsamplingBase):
 
     When `size` is given, it is the output size of the image (h, w).
 
+    When `scale_factor` is given, it must be either an integer (in
+    which case the image will be scaled with a constant aspect
+    ratio), or a tuple of integers (height scalar, width scalar).
+
     Args:
         size (tuple, optional): a tuple of ints (H_out, W_out) output sizes
-        scale_factor (int, optional): the multiplier for the image height / width
+        scale_factor (int or Tuple[int, int], optional): the multiplier for the image height / width
 
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
         - Output: :math:`(N, C, H_{out}, W_{out})` where
-          :math:`H_{out} = floor(H_{in} * scale\_factor)`
-          :math:`W_{out} = floor(W_{in}  * scale\_factor)`
+          :math:`H_{out} = floor(H_{in} * scale\_factor\_h)`
+          :math:`W_{out} = floor(W_{in}  * scale\_factor\_w)`
 
     Examples::
 
@@ -108,7 +107,43 @@ class UpsamplingBilinear2d(_UpsamplingBase):
           3.0000  3.3333  3.6667  4.0000
         [torch.FloatTensor of size 1x1x4x4]
 
+        >>> m = nn.UpsamplingBilinear2d(scale_factor=(2,1))
+        >>> m(inp)
+        Variable containing:
+        (0 ,0 ,.,.) =
+          1.0000  2.0000
+          1.6667  2.6667
+          2.3333  3.3333
+          3.0000  4.0000
+        [torch.FloatTensor of size 1x1x4x2]
     """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingBilinear2d, self).__init__()
+        if size is None and scale_factor is None:
+            raise ValueError('either size or scale_factor should be defined')
+        if scale_factor is not None:
+            if not isinstance(scale_factor, (Integral, tuple)):
+                raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')
+            if isinstance(scale_factor, tuple):
+                try:
+                    assert len(scale_factor) == 2
+                    for i in scale_factor:
+                        assert isinstance(i, Integral)
+                        assert i >= 1
+                except AssertionError as e:
+                    raise ValueError('scale_factor must be a non-negative integer, or a tuple of non-negative integers')
+        self.size = _pair(size)
+        if scale_factor is not None:
+            self.scale_factor = _pair(scale_factor)
+        else:
+            self.scale_factor = scale_factor
+
+    def __repr__(self):
+        if self.scale_factor is not None:
+            info = 'scale_factor=' + str(self.scale_factor)
+        else:
+            info = 'size=' + str(self.size)
+        return self.__class__.__name__ + '(' + info + ')'
 
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -89,7 +89,7 @@ def pad_packed_sequence(sequence, batch_first=False):
     It is an inverse operation to :func:`pack_padded_sequence`.
 
     The returned Variable's data will be of size TxBx*, where T is the length
-    of the longest sequence and B is the batch size. If ``batch_size`` is True,
+    of the longest sequence and B is the batch size. If ``batch_first`` is True,
     the data will be transposed into BxTx* format.
 
     Batch elements will be ordered decreasingly by their length.

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -63,6 +63,7 @@ class Adagrad(Optimizer):
                 clr = group['lr'] / (1 + (state['step'] - 1) * group['lr_decay'])
 
                 if p.grad.data.is_sparse:
+                    grad.contiguous()  # the update is non-linear so indices must be unique
                     grad_indices = grad.indices()
                     grad_values = grad.values()
                     size = torch.Size([x for x in grad.size()])

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -50,6 +50,7 @@ class Adagrad(Optimizer):
             for p in group['params']:
                 if p.grad is None:
                     continue
+
                 grad = p.grad.data
                 state = self.state[p]
 

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -133,6 +133,7 @@ class _SparseBase(object):
         raise NotImplementedError
 
     def __str__(self):
+        self.contiguous()  # to make sure the output is consistent
         return '{} with indices:\n{}and values:\n{}'.format(
             self.__class__.__name__, self.indices(), self.values())
 


### PR DESCRIPTION
This PR addresses #1257, which aims to add non-coupled scaling factors for bilinear 2d upsampling.  I've added two new tests, and currently everything passes.  This is a relatively simple change which only touches python code.

Some high level notes:

* The largest changes refactor the Upsampling module (f2efeba) and functions (0760a41), moving everything from the base constructor down into the individual classes.  I normally don't like removing that sort of abstraction, but I didn't see a good way to cleanly check the inputs for all cases at that higher level.  

* I changed `scale_factor` to be a pair (tuple) of non-negative ints instead of a single int, and edited two lines in the `foward()` of `UpsamplingBilinear2d` to reflect this.  If a single number is passed in for scaling, it is duplicated in the tuple.

* docstrings have been adjusted throughout

* I added 2 tests.  Not sure if this is sufficient, but given that nothing breaks, seems ok for now.  As an aside, is there a way to run just one test?

Thanks, and input welcome.  Tagging @soumith and @fmassa, who commented on the initial issue.