### PR TITLE
Instance norm

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -302,6 +302,23 @@ Normalization layers
 .. autoclass:: BatchNorm3d
     :members:
 
+:hidden:`InstanceNorm1d`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InstanceNorm1d
+    :members:
+
+:hidden:`InstanceNorm2d`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InstanceNorm2d
+    :members:
+
+:hidden:`InstanceNorm3d`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: InstanceNorm3d
+    :members:
 
 Recurrent layers
 ----------------------------------

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -771,9 +771,8 @@ class TestNN(NNTestCase):
         self.assertAlmostEqual(torch.abs(mean.data).mean(), 0, delta=1e-5)
         self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
 
-
-        # If momentum==1 running_mean/var should be 
-        # equal to mean/var of the input 
+        # If momentum==1 running_mean/var should be
+        # equal to mean/var of the input
         IN = cls(c, momentum=1, eps=0)
 
         output = IN(input_var)
@@ -785,7 +784,7 @@ class TestNN(NNTestCase):
         var = input_reshaped.var(2, unbiased=True)[:, :]
 
         self.assertAlmostEqual(torch.abs(mean.data - IN.running_mean).mean(), 0, delta=1e-5)
-        self.assertAlmostEqual(torch.abs(var.data.mean(1) -  IN.running_var).mean(), 0, delta=1e-5)
+        self.assertAlmostEqual(torch.abs(var.data.mean(1) - IN.running_var).mean(), 0, delta=1e-5)
 
     def test_InstanceNorm2d(self):
         b = random.randint(3, 5)

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -14,6 +14,7 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, LPPool2d, AdaptiveMaxPool1d, \
     AdaptiveMaxPool2d, AdaptiveAvgPool1d, AdaptiveAvgPool2d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
+from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d
 from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d
 from .normalization import CrossMapLRN2d
@@ -36,8 +37,9 @@ __all__ = [
     'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList',
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
-    'LPPool2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'Dropout', 'Dropout2d',
-    'Dropout3d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad3d', 'CrossMapLRN2d',
+    'LPPool2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d', 'InstanceNorm2d',
+    'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'ReflectionPad2d',
+    'ReplicationPad2d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -50,7 +50,7 @@ class InstanceNorm1d(_InstanceNorm):
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. Gamma and beta are learnable parameter vectors
-    of size С (where С is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
@@ -91,7 +91,7 @@ class InstanceNorm2d(_InstanceNorm):
         y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. Gamma and beta are learnable parameter vectors
-    of size С (where С is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
@@ -133,7 +133,7 @@ class InstanceNorm3d(_InstanceNorm):
 
     The mean and standard-deviation are calculated per-dimension separately for each object in a mini-batch.
     Gamma and beta are learnable parameter vectors
-    of size С (where С is the input size).
+    of size C (where C is the input size).
 
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -1,0 +1,169 @@
+from .batchnorm import _BatchNorm
+from .. import functional as F
+
+
+class _InstanceNorm(_BatchNorm):
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=False):
+        super(_InstanceNorm, self).__init__(
+            num_features, eps, momentum, affine)
+
+    def forward(self, input):
+        self._check_input_dim(input)
+
+        b, c = input.size(0), input.size(1)
+
+        # Repeat stored stats and affine transform params
+        running_mean = self.running_mean.repeat(b)
+        running_var = self.running_var.repeat(b)
+
+        weight, bias = None, None
+        if self.affine:
+            weight = self.weight.repeat(b)
+            bias = self.bias.repeat(b)
+
+        # Apply instance norm
+        input_reshaped = input.view(1, b * c, *input.size()[2:])
+
+        out = F.batch_norm(
+            input_reshaped, running_mean, running_var, weight, bias,
+            self.training, self.momentum, self.eps)
+
+        # Reshape back
+        self.running_mean.copy_(running_mean.view(b, c).mean(0))
+        self.running_var.copy_(running_var.view(b, c).mean(0))
+
+        return out.view(b, c, *input.size()[2:])
+
+    def force_eval(self):
+        self.training = False
+
+    def eval(self):
+        pass
+
+
+class InstanceNorm1d(_InstanceNorm):
+    r"""Applies Instance Normalization over a 2d or 3d input that is seen as a mini-batch.
+
+    .. math::
+
+        y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
+
+    The mean and standard-deviation are calculated per-dimension separately
+    for each object in a mini-batch. Gamma and beta are learnable parameter vectors
+    of size С (where С is the input size).
+
+    During training, this layer keeps a running estimate of its computed mean
+    and variance. The running sum is kept with a default momentum of 0.1.
+
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
+    i.e. running mean/variance is NOT used for normalization. One can force using stored 
+    mean and variance with `.force_eval()` method. 
+
+    Args:
+        num_features: num_features from an expected input of size `batch_size x num_features x width`
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        momentum: the value used for the running_mean and running_var computation. Default: 0.1
+        affine: a boolean value that when set to true, gives the layer learnable affine parameters.
+
+    Shape:
+        - Input: :math:`(N, C, L)`
+        - Output: :math:`(N, C, L)` (same shape as input)
+
+    Examples:
+        >>> # With Learnable Parameters
+        >>> m = nn.InstanceNorm1d(100)
+        >>> # Without Learnable Parameters
+        >>> m = nn.InstanceNorm1d(100, affine=False)
+        >>> input = autograd.Variable(torch.randn(20, 100))
+        >>> output = m(input)
+    """
+
+    def _check_input_dim(self, input):
+        if input.dim() != 3:
+            raise ValueError('expected 2D or 3D input (got {}D input)'
+                             .format(input.dim()))
+        super(InstanceNorm1d, self)._check_input_dim(input)
+
+
+class InstanceNorm2d(_InstanceNorm):
+    r"""Applies Instance Normalization over a 4d input that is seen as a mini-batch of 3d inputs
+    .. math::
+        y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
+    The mean and standard-deviation are calculated per-dimension separately
+    for each object in a mini-batch. Gamma and beta are learnable parameter vectors
+    of size С (where С is the input size).
+
+    During training, this layer keeps a running estimate of its computed mean
+    and variance. The running sum is kept with a default momentum of 0.1.
+
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
+    i.e. running mean/variance is NOT used for normalization. One can force using stored 
+    mean and variance with `.force_eval()` method. 
+
+    Args:
+        num_features: num_features from an expected input of size batch_size x num_features x height x width
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        momentum: the value used for the running_mean and running_var computation. Default: 0.1
+        affine: a boolean value that when set to true, gives the layer learnable affine parameters.
+    Shape:
+        - Input: :math:`(N, C, H, W)`
+        - Output: :math:`(N, C, H, W)` (same shape as input)
+    Examples:
+        >>> # With Learnable Parameters
+        >>> m = nn.InstanceNorm2d(100)
+        >>> # Without Learnable Parameters
+        >>> m = nn.InstanceNorm2d(100, affine=False)
+        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45))
+        >>> output = m(input)
+    """
+
+    def _check_input_dim(self, input):
+        if input.dim() != 4:
+            raise ValueError('expected 4D input (got {}D input)'
+                             .format(input.dim()))
+        super(InstanceNorm2d, self)._check_input_dim(input)
+
+
+class InstanceNorm3d(_InstanceNorm):
+    r"""Applies Instance Normalization over a 5d input that is seen as a mini-batch of 4d inputs
+
+    .. math::
+
+        y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
+
+    The mean and standard-deviation are calculated per-dimension separately for each object in a mini-batch.
+    Gamma and beta are learnable parameter vectors
+    of size С (where С is the input size).
+
+    During training, this layer keeps a running estimate of its computed mean
+    and variance. The running sum is kept with a default momentum of 0.1.
+
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
+    i.e. running mean/variance is NOT used for normalization. One can force using stored 
+    mean and variance with `.force_eval()` method. 
+
+
+    Args:
+        num_features: num_features from an expected input of size batch_size x num_features x depth x height x width
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        momentum: the value used for the running_mean and running_var computation. Default: 0.1
+        affine: a boolean value that when set to true, gives the layer learnable affine parameters.
+
+    Shape:
+        - Input: :math:`(N, C, D, H, W)`
+        - Output: :math:`(N, C, D, H, W)` (same shape as input)
+
+    Examples:
+        >>> # With Learnable Parameters
+        >>> m = nn.InstanceNorm3d(100)
+        >>> # Without Learnable Parameters
+        >>> m = nn.InstanceNorm3d(100, affine=False)
+        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45, 10))
+        >>> output = m(input)
+    """
+
+    def _check_input_dim(self, input):
+        if input.dim() != 5:
+            raise ValueError('expected 5D input (got {}D input)'
+                             .format(input.dim()))
+        super(InstanceNorm3d, self)._check_input_dim(input)

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -22,7 +22,7 @@ class _InstanceNorm(_BatchNorm):
             bias = self.bias.repeat(b)
 
         # Apply instance norm
-        input_reshaped = input.view(1, b * c, *input.size()[2:])
+        input_reshaped = input.contiguous().view(1, b * c, *input.size()[2:])
 
         out = F.batch_norm(
             input_reshaped, running_mean, running_var, weight, bias,
@@ -34,11 +34,8 @@ class _InstanceNorm(_BatchNorm):
 
         return out.view(b, c, *input.size()[2:])
 
-    def force_eval(self):
-        self.training = False
-
     def eval(self):
-        pass
+        return self
 
 
 class InstanceNorm1d(_InstanceNorm):
@@ -55,9 +52,9 @@ class InstanceNorm1d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
     i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.force_eval()` method.
+    mean and variance with `.train(False)` method.
 
     Args:
         num_features: num_features from an expected input of size `batch_size x num_features x width`
@@ -96,9 +93,9 @@ class InstanceNorm2d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
     i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.force_eval()` method.
+    mean and variance with `.train(False)` method.
 
     Args:
         num_features: num_features from an expected input of size batch_size x num_features x height x width
@@ -138,9 +135,9 @@ class InstanceNorm3d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
     i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.force_eval()` method.
+    mean and variance with `.train(False)` method.
 
 
     Args:

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -55,9 +55,9 @@ class InstanceNorm1d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
-    i.e. running mean/variance is NOT used for normalization. One can force using stored 
-    mean and variance with `.force_eval()` method. 
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    i.e. running mean/variance is NOT used for normalization. One can force using stored
+    mean and variance with `.force_eval()` method.
 
     Args:
         num_features: num_features from an expected input of size `batch_size x num_features x width`
@@ -96,9 +96,9 @@ class InstanceNorm2d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
-    i.e. running mean/variance is NOT used for normalization. One can force using stored 
-    mean and variance with `.force_eval()` method. 
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    i.e. running mean/variance is NOT used for normalization. One can force using stored
+    mean and variance with `.force_eval()` method.
 
     Args:
         num_features: num_features from an expected input of size batch_size x num_features x height x width
@@ -138,9 +138,9 @@ class InstanceNorm3d(_InstanceNorm):
     During training, this layer keeps a running estimate of its computed mean
     and variance. The running sum is kept with a default momentum of 0.1.
 
-    At evaluation time, the default behaviour of the InstanceNorm module stays the same 
-    i.e. running mean/variance is NOT used for normalization. One can force using stored 
-    mean and variance with `.force_eval()` method. 
+    At evaluation time, the default behaviour of the InstanceNorm module stays the same
+    i.e. running mean/variance is NOT used for normalization. One can force using stored
+    mean and variance with `.force_eval()` method.
 
 
     Args:


### PR DESCRIPTION
Implements instance normalization modules (1d, 2d, 3d). Based on batch norm, allows affine transform, but  it is switched off by default.