### PR TITLE
Change the default algo for cuDNN conv forward to PRECOMP_GEMM

### DIFF
--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -108,7 +108,7 @@ struct algorithm_search {
 
 template<>
 struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
-  static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+  static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
   static BenchmarkCache<cudnnConvolutionFwdAlgo_t>& cache() {
     return fwd_algos;
   }


### PR DESCRIPTION
Workspace size should be still fairly small, but it is often faster than IMPLICIT_GEMM.