### PR TITLE
add checks in autograd c++ ops for double backward without retain_variables

### DIFF
--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -3,6 +3,7 @@
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/nn/THNN_generic.h"
 #include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/autograd/functions/errors.h"
 
 #ifdef WITH_CUDNN
 #include "torch/csrc/cudnn/BatchNorm.h"
@@ -85,9 +86,7 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
 auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_list {
   auto& input = this->input.unpack();
 
-  if (!input) throw std::runtime_error("Trying to backward through the "
-      "graph second time, but the buffers have already been freed. Please "
-      "specify retain_variables=True when calling backward for the first time.");
+  if (!input) throw std::runtime_error(PT_ERR_BACKWARD_TWICE);
 
   auto& weight = this->weight.unpack();
   auto& bias = this->bias.unpack();

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -84,6 +84,11 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
 
 auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_list {
   auto& input = this->input.unpack();
+
+  if (!input) throw std::runtime_error("Trying to backward through the "
+      "graph second time, but the buffers have already been freed. Please "
+      "specify retain_variables=True when calling backward for the first time.");
+
   auto& weight = this->weight.unpack();
   auto& bias = this->bias.unpack();
   AutoGPU guard(input->getDevice());

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -3,6 +3,7 @@
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/nn/THNN_generic.h"
 #include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/autograd/functions/errors.h"
 
 #ifdef WITH_CUDNN
 #include "torch/csrc/cudnn/Conv.h"
@@ -192,9 +193,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   if (grad_outputs.size() != 1) throw std::runtime_error("expected one grad_output");
   if (is_padding_neg()) throw std::runtime_error("negative padding is not supported");
   if (is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
-  if (!input_.data) throw std::runtime_error("Trying to backward through the "
-      "graph second time, but the buffers have already been freed. Please "
-      "specify retain_variables=True when calling backward for the first time.");
+  if (!input_.data) throw std::runtime_error(PT_ERR_BACKWARD_TWICE);
 
   AutoGPU guard(input_.data->getDevice());
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -192,6 +192,9 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   if (grad_outputs.size() != 1) throw std::runtime_error("expected one grad_output");
   if (is_padding_neg()) throw std::runtime_error("negative padding is not supported");
   if (is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
+  if (!input_.data) throw std::runtime_error("Trying to backward through the "
+      "graph second time, but the buffers have already been freed. Please "
+      "specify retain_variables=True when calling backward for the first time.");
 
   AutoGPU guard(input_.data->getDevice());
 

--- a/torch/csrc/autograd/functions/errors.h
+++ b/torch/csrc/autograd/functions/errors.h
@@ -1,0 +1,9 @@
+#ifndef PYTORCH_AUTOGRAD_ERRORS_H
+#define PYTORCH_AUTOGRAD_ERRORS_H
+
+#define PT_ERR_BACKWARD_TWICE "Trying to backward through the " \
+      "graph second time, but the buffers have already been freed. Please " \
+      "specify retain_variables=True when calling backward for the first time."
+
+
+#endif

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -10,6 +10,7 @@
 #include "THP.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
+#include "torch/csrc/autograd/functions/errors.h"
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/Exceptions.h"
@@ -661,9 +662,7 @@ PyObject* THPFunction_register_hook(THPFunction *self, PyObject *hook)
 
 PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 {
-  THPUtils_assert(!self->has_freed_buffers, "Trying to backward through the "
-      "graph second time, but the buffers have already been freed. Please "
-      "specify retain_variables=True when calling backward for the first time.");
+  THPUtils_assert(!self->has_freed_buffers, PT_ERR_BACKWARD_TWICE);
   if (!self->saved_variables)
     return PyTuple_New(0);
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/1288