### PR TITLE
Rename sparse contiguous() to coalesce(); make out of place; speed up THC Embedding 10x

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -150,8 +150,8 @@ class TestCase(unittest.TestCase):
                     self.assertLessEqual(max_err, prec, message)
             self.assertEqual(x.is_sparse, y.is_sparse, message)
             if x.is_sparse:
-                x = x.clone().coalesce_()
-                y = y.clone().coalesce_()
+                x = x.coalesce()
+                y = y.coalesce()
                 assertTensorsEqual(x.indices(), y.indices())
                 assertTensorsEqual(x.values(), y.values())
             else:

--- a/test/common.py
+++ b/test/common.py
@@ -150,8 +150,8 @@ class TestCase(unittest.TestCase):
                     self.assertLessEqual(max_err, prec, message)
             self.assertEqual(x.is_sparse, y.is_sparse, message)
             if x.is_sparse:
-                x = x.clone().contiguous()
-                y = y.clone().contiguous()
+                x = x.clone().coalesce_()
+                y = y.clone().coalesce_()
                 assertTensorsEqual(x.indices(), y.indices())
                 assertTensorsEqual(x.values(), y.values())
             else:

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -156,7 +156,7 @@ class TestSparse(TestCase):
             [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
         ])
         exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -174,7 +174,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([2, 1, 3, 4])
 
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -193,7 +193,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([6, 4])
 
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -224,7 +224,7 @@ class TestSparse(TestCase):
             [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
             [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
         ])
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -242,7 +242,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
 
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -261,7 +261,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
 
-        x.coalesce_()
+        x = x.coalesce()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -482,6 +482,16 @@ class TestSparse(TestCase):
         y.zero_()
         expected = torch.zeros(x1.size())
         self.assertEqual(y.to_dense(), expected)
+
+        self.assertFalse(x1.is_coalesced())
+        y = x1.coalesce()
+        z = x1.coalesce()
+        self.assertFalse(x1.is_coalesced())
+        self.assertTrue(y.is_coalesced())
+        self.assertEqual(x1, y)
+        # check that coalesce is out of place
+        y.values().add_(1)
+        self.assertEqual(z.values() + 1, y.values())
 
     def _test_basic_ops(self, is_cuda):
         self._test_basic_ops_shape(is_cuda, [5, 6])

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -156,7 +156,7 @@ class TestSparse(TestCase):
             [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
         ])
         exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -174,7 +174,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([2, 1, 3, 4])
 
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -193,7 +193,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([6, 4])
 
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -224,7 +224,7 @@ class TestSparse(TestCase):
             [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
             [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
         ])
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -242,7 +242,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
 
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -261,7 +261,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
 
-        x = x.coalesce()
+        x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -156,7 +156,7 @@ class TestSparse(TestCase):
             [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
         ])
         exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -174,7 +174,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([2, 1, 3, 4])
 
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -193,7 +193,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([6, 4])
 
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -224,7 +224,7 @@ class TestSparse(TestCase):
             [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
             [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
         ])
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -242,7 +242,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
 
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
@@ -261,7 +261,7 @@ class TestSparse(TestCase):
         ])
         exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
 
-        x.contiguous()
+        x.coalesce_()
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -62,9 +62,9 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
-  name: isContiguous
+  name: isCoalesced
   sparse: yes
-  python_name: is_contiguous
+  python_name: is_coalesced
   return: bool
   arguments:
   - THSTensor* self
@@ -89,7 +89,8 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
-  name: contiguous
+  name: coalesce
+  python_name: coalesce_
   sparse: yes
   return: argument 0
   arguments:

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -90,9 +90,9 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 
 [[
   name: coalesce
-  python_name: coalesce_
+  cname: newCoalesce
   sparse: yes
-  return: argument 0
+  return: THSTensor*
   arguments:
   - THSTensor* self
 ]]

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -23,47 +23,22 @@ THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self) {
   THLongStorage *size;
   THCTensor *dst;
 
-  THCSTensor_(coalesce)(state, self);
-
   // set up the new tensor
   size = THCSTensor_(newSizeOf)(state, self);
   dst = THCTensor_(newWithSize)(state, size, NULL);
   THLongStorage_free(size);
   THCTensor_(zero)(state, dst);
 
-  const ptrdiff_t nnz = THCSTensor_(nnz)(state, self);
-  if (nnz == 0) {
-    return dst;
-  }
-
-  // TODO more benchmarking
-  const dim3 block = getApplyBlock();
-  dim3 grid;
-  if (self->nDimensionV == 0) {
-    THArgCheck(getApplyGrid(state, nnz, grid), 1, CUTORCH_DIM_WARNING);
-
-    THCSTensor_sparseElementwiseKernelScalar<TensorAddOp<real>, unsigned long, real>
-      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-          TensorAddOp<real>(),
-          V_INFO(dst), I_INFO(self->indices), V_INFO(self->values),
-          (unsigned long)(nnz));
-  } else {
-    THArgCheck(getApplyGrid(state, nnz * block.x, grid), 1, CUTORCH_DIM_WARNING);
-
-    THCSTensor_sparseElementwiseKernel<TensorAddOp<real>, unsigned long, real>
-      <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-          TensorAddOp<real>(),
-          V_INFO(dst), I_INFO(self->indices), V_INFO(self->values),
-          (unsigned long)(nnz));
-  }
-
+  real one = ScalarConvert<int, real>::to(1);
+  THCSTensor_(spcadd)(state, dst, dst, one, self);
   THCudaCheck(cudaGetLastError());
   return dst;
 }
 
 void THCSTensor_(coalesce)(THCState *state, THCSTensor *self) {
   if (self->coalesced) return;
-  if (self->nnz < 2) return;
+  int nnz = self->nnz;
+  if (nnz < 2) return;
 #if CUDA_VERSION >= 7000
   THCThrustAllocator thrustAlloc(state);
 #define THRUST_EXEC(fn, ...) fn(thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)), ##__VA_ARGS__)
@@ -72,139 +47,147 @@ void THCSTensor_(coalesce)(THCState *state, THCSTensor *self) {
 #endif
 
   // For indices, a simple sort + unique suffices
-  // For values, we reduce the problem to a sparse x dense matrix multiplication D2 = S x D1, such that:
-  // * D1 represents the input values, D2 represents the output values
-  // * D1 and D2 are views over the values where:
-  //    * the first dimension represents the nnz index (same as in the values tensor)
-  //    * the second dimension represents the "flattened" values (so they can be treated as blocks of scalars even if they are N-dimensional)
-  // * S maps values in D1 to their position in D2
-  //   Multiple values in D1 can map to the same position in D2 if there are duplicate indices
-  //   Values mapping to the same position are added together (which is what matrix multiplication does)
-  //
-  // When constructing S, we must make sure that it is coalesced (otherwise this function will call itself when doing the multiplication)
-  // To achieve this, we define the indices tensor of S as follows:
-  // * the second row contains the permutation corresponding to a stable sort of the original indices
-  // * the first row "maps" those indices to their final location after deduplication
-  //
-  // The construction of the second row ensures that the first row is sorted
-  // Because the sorting used for the second row is stable, groups of values mapped to the same position correspond to increasing subsequences of the permutation
-  // So the indices tensor of S is guaranteed to be sorted
+  // For values, we use a custom kernel for segmented reduction (can't use Thrust due to indirection).
 
-  // Initialize tensors
-  THCIndexTensor *indices = THCSTensor_(newIndices)(state, self);
-  THCTensor *values = THCSTensor_(newValues)(state, self);
-  THCudaLongTensor *sIndices = THCudaLongTensor_newWithSize2d(state, 2, self->nnz);
-  THCTensor *sValues = THCTensor_(newWithSize1d)(state, self->nnz);
-  THCTensor_(fill)(state, sValues, ScalarConvert<int, real>::to(1));
-  THCudaLongTensor *mapping = THCudaLongTensor_new(state);
-  THCudaLongTensor *permutation = THCudaLongTensor_new(state);
-  THCudaLongTensor_select(state, mapping, sIndices, 0, 0);
-  THCudaLongTensor_select(state, permutation, sIndices, 0, 1);
-  THCudaLongTensor *uniquePositions = THCudaLongTensor_newWithSize1d(state, self->nnz);
+  THCIndexTensor *indices_ = THCSTensor_(newIndices)(state, self);
+  THCIndexTensor *indices = THCIndexTensor_(newContiguous)(state, indices_);
+  THCIndexTensor_(free)(state, indices_);
+  THCTensor *values_ = THCSTensor_(newValues)(state, self);
+  THCTensor *values = THCTensor_(newContiguous)(state, values_);
+  THCTensor_(free)(state, values_);
 
-  // convert N-dimensional indices to scalar indices
-  THCIndexTensor *indicesScalar = THCIndexTensor_(newWithSize1d)(state, self->nnz);
-  THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
-  THCIndexTensor_(zero)(state, indicesScalar);
-  long factor = 1;
-  for (int i = self->nDimensionI - 1; i >= 0; i--) {
-    THCIndexTensor_(select)(state, indicesSlice, indices, 0, i);
-    THCIndexTensor_(cadd)(state, indicesScalar, indicesScalar, factor, indicesSlice);
-    factor *= self->size[i];
+  int nDimI = self->nDimensionI;
+  long stride = values->stride[0];
+
+  cudaStream_t stream = THCState_getCurrentStream(state);
+
+  THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, self);
+
+  THCIndexTensor *origIndices = THCIndexTensor_(newWithSize1d)(state, nnz);
+  THCIndexTensor *uniqueOffsets = THCIndexTensor_(newWithSize1d)(state, nnz);
+
+  typedef thrust::device_ptr<long> thrust_ptr;
+  thrust_ptr indicesIter(THCIndexTensor_(data)(state, indices1D));
+  thrust_ptr origIndicesIter(THCIndexTensor_(data)(state, origIndices));
+  thrust_ptr uniqueOffsetsIter(THCIndexTensor_(data)(state, uniqueOffsets));
+
+
+  // Fill sortedOrigIndices with sequential indices
+  thrust::counting_iterator<long> countIterI(TH_INDEX_BASE);
+  thrust::counting_iterator<long> countIterO(TH_INDEX_BASE);
+
+  THRUST_EXEC(thrust::copy, countIterI, countIterI + nnz, origIndicesIter);
+  THRUST_EXEC(thrust::copy, countIterO, countIterO + nnz, uniqueOffsetsIter);
+
+  THRUST_EXEC(thrust::sort_by_key,
+    indicesIter, indicesIter + nnz,
+    origIndicesIter, ThrustLTOp<long>()
+  );
+
+  // this forces device-host synchronization!
+  thrust::pair<thrust_ptr, thrust_ptr> newEnd = THRUST_EXEC(
+    thrust::unique_by_key,
+    indicesIter, indicesIter + nnz,
+    uniqueOffsetsIter
+  );
+  long newNnz = newEnd.first - indicesIter;
+
+  THCIndexTensor_(resize2d)(state, indices1D, 1, newNnz);
+  THLongStorage *newValuesSize = THCTensor_(newSizeOf)(state, values);
+  newValuesSize->data[0] = newNnz;
+  THCTensor *newValues = THCTensor_(newWithSize)(state, newValuesSize, NULL);
+  THLongStorage_free(newValuesSize);
+
+  dim3 grid(THCCeilDiv(newNnz, (long) 4), THCCeilDiv(stride, (long) 128));
+  dim3 block(32, 4);
+  THCSTensor_coalesceValuesKernel<real, accreal><<<grid, block, 0, stream>>>(
+    THCIndexTensor_(data)(state, uniqueOffsets),
+    THCIndexTensor_(data)(state, origIndices),
+    THCTensor_(data)(state, values),
+    THCTensor_(data)(state, newValues),
+    nnz,
+    newNnz,
+    stride
+  );
+
+// this grid-strided version is slower but probably more flexible
+  // to different sizes
+  // int blockX = min(stride, (long) 512);
+  // dim3 block(blockX, 512 / blockX);
+  // int grid = min((long) 1024, THCCeilDiv((long) newNnz * stride, (long) block.x * block.y));
+  // THCSTensor_coalesceValuesKernel_gridStrided<real, accreal><<<grid, block, 0, stream>>>(
+  //   THCIndexTensor_(data)(state, uniqueOffsets),
+  //   THCIndexTensor_(data)(state, origIndices),
+  //   THCTensor_(data)(state, values),
+  //   THCTensor_(data)(state, newValues),
+  //   nnz,
+  //   newNnz,
+  //   stride
+  // );
+
+  THCIndexTensor_(free)(state, origIndices);
+  THCIndexTensor_(free)(state, uniqueOffsets);
+
+  ////////////////////////////////////////////////////////////
+  // unflatten indices if necessary
+  THCIndexTensor *newIndices;
+  if (nDimI == 1) {
+    newIndices = indices1D;
+  } else {
+    newIndices = THCIndexTensor_(newWithSize2d)(state, nDimI, newNnz);
+    THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
+    if (TH_INDEX_BASE != 0) {
+      THCIndexTensor_(add)(state, indices1D, indices1D, -1);
+    }
+    for (long d = nDimI - 1; d >= 0; d--) {
+      THCIndexTensor_(select)(state, indicesSlice, newIndices, 0, d);
+      THCIndexTensor_(copy)(state, indicesSlice, indices1D);
+      THCIndexTensor_(div)(state, indices1D, indices1D, self->size[d]);
+      THCIndexTensor_(cadd)(state, indicesSlice, indicesSlice, -self->size[d], indices1D);
+    }
+    if (TH_INDEX_BASE != 0) {
+      THCIndexTensor_(add)(state, newIndices, newIndices, 1);
+    }
+    THCIndexTensor_(free)(state, indices1D);
+    THCIndexTensor_(free)(state, indicesSlice);
   }
-  THCIndexTensor_(free)(state, indicesSlice);
-
-  // stable sort indices and remember the permutation
-  thrust::device_ptr<long> permutationIter(THCudaLongTensor_data(state, permutation));
-  THRUST_EXEC(thrust::sequence, permutationIter, permutationIter + self->nnz);
-  thrust::device_ptr<indexT> indicesIter(THCIndexTensor_(data)(state, indicesScalar));
-  THRUST_EXEC(thrust::stable_sort_by_key, indicesIter, indicesIter + self->nnz, permutationIter);
-  // Note: the code below is much faster and seems to work, but the sort is not stable.
-  // It could be that csrmm2 works even when column indices are not sorted within rows
-  // THCIndexTensor *indicesScalarClone = THCIndexTensor_(newClone)(state, indicesScalar);
-  // THCIndexTensor_(sort)(state, indicesScalar, permutation, indicesScalarClone, 0, 0);
-  // THCIndexTensor_(free)(state, indicesScalarClone);
-
-  // compute a list of unique indices, along with their position in the original index tensor (using the saved permutation)
-  thrust::device_ptr<indexT> uniquePositionsIter(THCudaLongTensor_data(state, uniquePositions));
-  thrust::device_vector<indexT> uniqueIndicesBuffer(self->nnz); // not used, can we optimize?
-  thrust::pair<thrust::device_vector<long>::iterator, thrust::device_ptr<long> > newEnd =
-    THRUST_EXEC(thrust::unique_by_key_copy, indicesIter, indicesIter + self->nnz, permutationIter, uniqueIndicesBuffer.begin(), uniquePositionsIter);
-  long newNnz = newEnd.second - uniquePositionsIter;
-  THCudaLongTensor_resize1d(state, uniquePositions, newNnz);
-
-  // compute the mapping of sorted indices to their final location after deduplication
-  THCudaLongTensor_set1d(state, mapping, 0, 0);
-  thrust::device_ptr<long> mappingIter(THCudaLongTensor_data(state, mapping));
-  thrust::not_equal_to<indexT> op;
-  THRUST_EXEC(thrust::transform, indicesIter, indicesIter + self->nnz - 1, indicesIter + 1, mappingIter + 1, op);
-  THRUST_EXEC(thrust::inclusive_scan, mappingIter, mappingIter + self->nnz, mappingIter);
-
-  // build S
-  THCSTensor *S = THCSTensor_(newWithSize2d)(state, newNnz, self->nnz);
-  THCSTensor_(_move)(state, S, sIndices, sValues);
-  S->coalesced = 1;
-
-  // build output indices tensor by doing an indexSelect over the sorted list of unique indices
-  THCIndexTensor *newIndices = THCIndexTensor_(new)(state);
-  THCIndexTensor_(indexSelect)(state, newIndices, indices, 1, uniquePositions);
-  THCIndexTensor_(free)(state, indices);
+  ////////////////////////////////////////////////////////////
+  self->nnz = newNnz;
   THCIndexTensor_(free)(state, self->indices);
   self->indices = newIndices;
 
-  // create output values tensor
-  THLongStorage *newValuesSizes = THCTensor_(newSizeOf)(state, values);
-  THLongStorage_set(newValuesSizes, 0, newNnz);
-  THCTensor *newValues = THCTensor_(newWithSize)(state, newValuesSizes, NULL);
-  THLongStorage_free(newValuesSizes);
-
-  // create D1: view over input values tensor
-  THCTensor *valuesView;
-  if (THCTensor_(nDimension)(state, values) != 2) {
-    THLongStorage *valuesViewSizes = THLongStorage_newWithSize(2);
-    THLongStorage_set(valuesViewSizes, 0, self->nnz);
-    THLongStorage_set(valuesViewSizes, 1, -1);
-    valuesView = THCTensor_(newView)(state, values, valuesViewSizes);
-    THLongStorage_free(valuesViewSizes);
-  } else {
-    valuesView = values;
-  }
-
-  // create D2: view over output values tensor
-  THCTensor *newValuesView;
-  if (THCTensor_(nDimension)(state, newValues) != 2) {
-    THLongStorage *newValuesViewSizes = THLongStorage_newWithSize(2);
-    THLongStorage_set(newValuesViewSizes, 0, newNnz);
-    THLongStorage_set(newValuesViewSizes, 1, -1);
-    newValuesView = THCTensor_(newView)(state, newValues, newValuesViewSizes);
-    THLongStorage_free(newValuesViewSizes);
-  } else {
-    newValuesView = newValues;
-  }
-
-  // build output values tensor by computing D2 = S x D1
-  THCSTensor_(spaddmm)(state, newValuesView, ScalarConvert<int, real>::to(0), newValuesView, ScalarConvert<int, real>::to(1), S, valuesView);
   THCTensor_(free)(state, values);
   THCTensor_(free)(state, self->values);
   self->values = newValues;
 
-  self->nnz = newNnz;
-
-  THCudaLongTensor_free(state, permutation);
-  THCudaLongTensor_free(state, mapping);
-  THCudaLongTensor_free(state, uniquePositions);
-  THCIndexTensor_(free)(state, indicesScalar);
-  THCSTensor_(free)(state, S);
-  if (valuesView != values) {
-    THCTensor_(free)(state, valuesView);
-  }
-  if (newValuesView != newValues) {
-    THCTensor_(free)(state, newValuesView);
-  }
-
-self->coalesced = 1;
-
+  self->coalesced = 1;
+  THCudaCheck(cudaGetLastError());
 #undef THRUST_EXEC
+}
+
+THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self) {
+  THCIndexTensor *indices = THCSTensor_(newIndices)(state, self);
+  int nDimI = self->nDimensionI;
+  if (nDimI == 1) {
+    return indices;
+  } else {
+    // FIXME TH_INDEX_BASE
+    long factor = 1;
+    THCIndexTensor *indices1D = THCIndexTensor_(newWithSize2d)(state, 1, self->nnz);
+    THCIndexTensor_(fill)(state, indices1D, TH_INDEX_BASE);
+    THCIndexTensor *indicesSlice = THCIndexTensor_(new)(state);
+    for (long d = nDimI - 1; d >= 0; d--) {
+      THCIndexTensor_(select)(state, indicesSlice, indices, 0, d);
+      THCIndexTensor_(cadd)(state, indices1D, indices1D, factor, indicesSlice);
+      if (TH_INDEX_BASE != 0) {
+        THCIndexTensor_(add)(state, indices1D, indices1D, -TH_INDEX_BASE);
+      }
+      factor *= self->size[d];
+    }
+    THCIndexTensor_(free)(state, indices);
+    THCIndexTensor_(free)(state, indicesSlice);
+    return indices1D;
+  }
 }
 
 // In place transpose

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -13,7 +13,7 @@ typedef struct THCSTensor
     // as buffer, so we keep track of both
     THCIndexTensor *indices;
     THCTensor *values;
-    // Math operations can only be performed on ordered sparse tensors
+    // Some math operations can only be performed on ordered sparse tensors
     int coalesced;
     int refcount;
 
@@ -74,5 +74,6 @@ TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI,
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
+TH_API THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -58,7 +58,7 @@ TH_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src
 
 TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 TH_API int THCSTensor_(isCoalesced)(THCState *state, const THCSTensor *self);
-TH_API void THCSTensor_(coalesce)(THCState *state, THCSTensor *self);
+TH_API THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self);
 
 TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
 

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -14,7 +14,7 @@ typedef struct THCSTensor
     THCIndexTensor *indices;
     THCTensor *values;
     // Math operations can only be performed on ordered sparse tensors
-    int contiguous;
+    int coalesced;
     int refcount;
 
 } THCSTensor;
@@ -41,7 +41,6 @@ TH_API THCSTensor *THCSTensor_(newWithSize3d)(THCState *state, long size0_, long
 TH_API THCSTensor *THCSTensor_(newWithSize4d)(THCState *state, long size0_, long size1_, long size2_, long size3_);
 
 TH_API THCSTensor *THCSTensor_(newClone)(THCState *state, THCSTensor *self);
-TH_API THCSTensor *THCSTensor_(newContiguous)(THCState *state, THCSTensor *self);
 TH_API THCSTensor *THCSTensor_(newTranspose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
 
 /**** reshaping methods ***/
@@ -58,8 +57,8 @@ TH_API THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self);
 TH_API void THCSTensor_(copy)(THCState *state, THCSTensor *self, THCSTensor *src);
 
 TH_API void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int dimension1_, int dimension2_);
-TH_API int THCSTensor_(isContiguous)(THCState *state, const THCSTensor *self);
-TH_API void THCSTensor_(contiguous)(THCState *state, THCSTensor *self);
+TH_API int THCSTensor_(isCoalesced)(THCState *state, const THCSTensor *self);
+TH_API void THCSTensor_(coalesce)(THCState *state, THCSTensor *self);
 
 TH_API void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask);
 
@@ -72,7 +71,6 @@ TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, u
 
 /* internal methods */
 TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, long *size);
-TH_API void THCSTensor_(reorder)(THCState *state, THCSTensor *self);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, long nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);

--- a/torch/lib/THPP/tensors/generic/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.cpp
@@ -41,7 +41,7 @@ auto THCSTensor<real>::clone_shallow() -> THCSTensor* {
 
 template<>
 auto THCSTensor<real>::contiguous() const -> std::unique_ptr<Tensor> {
-  return std::unique_ptr<Tensor>(new THCSTensor(state, THCSTensor_(newContiguous)(state, tensor)));
+  throw std::runtime_error("THCSTensor::contiguous() not supported");
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THSTensor.cpp
@@ -40,7 +40,7 @@ auto THSTensor<real>::clone_shallow() -> THSTensor* {
 
 template<>
 auto THSTensor<real>::contiguous() const -> std::unique_ptr<Tensor> {
-  return std::unique_ptr<Tensor>(new THSTensor(THSTensor_(newContiguous)(tensor)));
+  throw std::runtime_error("THCSTensor::rawStrides() not supported");
 }
 
 template<>

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -303,58 +303,18 @@ THSTensor *THSTensor_(resize4d)(THSTensor *self, long size0, long size1, long si
 }
 
 THTensor *THSTensor_(toDense)(THSTensor *self) {
-  int d, k, l, index;
-  ptrdiff_t nnz;
-  long nDimI, nDimV, indskip, blocksize = 1;
-  long *sizes;
-  THLongStorage *storage;
-
-  THTensor *other_, *values_;
-  real *other, *values;
-  THLongTensor *indices_;
-  long *indices;
-
-  THSTensor_(coalesce)(self);
+  THLongStorage *size;
+  THTensor *dst;
 
   // set up the new tensor
-  storage = THSTensor_(newSizeOf)(self);
-  other_ = THTensor_(newWithSize)(storage, NULL);
-  THTensor_(zero)(other_);
-  other = THTensor_(data)(other_);
+  size = THSTensor_(newSizeOf)(self);
+  dst = THTensor_(newWithSize)(size, NULL);
+  THLongStorage_free(size);
+  THTensor_(zero)(dst);
 
-  nnz = THSTensor_(nnz)(self);
-  if (nnz == 0) {
-    THLongStorage_free(storage);
-    return other_;
-  }
-
-  // Some necessary dimensions and sizes
-  nDimI = THSTensor_(nDimensionI)(self);
-  nDimV = THSTensor_(nDimensionV)(self);
-  sizes = storage->data;
-  for (int i = 0; i < nDimV; i++) {
-    blocksize *= sizes[nDimI + i];
-  }
-
-  // These should be contiguous...
-  values_ = THSTensor_(newValues)(self);
-  indices_ = self->indices;
-  values = THTensor_(data)(values_);
-  indices = THLongTensor_data(indices_);
-  indskip = THLongTensor_size(indices_, 1); // To index indices
-
-  #pragma omp parallel for private(k, d, l, index)
-  for (k = 0; k < nnz; k++) {
-    for (d = 0, index = 0; d < nDimI; d++)
-      index = sizes[d] * index + indices[d * indskip + k];
-    for (l = 0; l < blocksize; l++) {
-      other[index * blocksize + l] = values[k * blocksize + l];
-    }
-  }
-
-  THTensor_(free)(values_);
-  THLongStorage_free(storage);
-  return other_;
+  // real one = ScalarConvert<int, real>::to(1);
+  THSTensor_(spcadd)(dst, dst, 1, self);
+  return dst;
 }
 
 void THSTensor_(copy)(THSTensor *self, THSTensor *src) {
@@ -433,14 +393,17 @@ THTensor *THSTensor_(newValuesWithSizeOf)(THTensor *values, long nnz) {
   return new_values;
 }
 
-void THSTensor_(coalesce)(THSTensor *self) {
-  if (self->coalesced) return;
-  if (self->nnz < 2) return;
-  THLongTensor *indices_ = THSTensor_(newIndices)(self);
+THSTensor *THSTensor_(newCoalesce)(THSTensor *self) {
+  if (self->nnz < 2) {
+    self->coalesced = 1;
+  }
+  if (self->coalesced) {
+    THSTensor_(retain)(self);
+    return self;
+  }
+  THLongTensor *indices = THSTensor_(newIndices)(self);
   THTensor *values_ = THSTensor_(newValues)(self);
-  THTensor *contiguousValues = THTensor_(newContiguous)(values_);
-  long *indices = THLongTensor_data(indices_);
-  real *values = THTensor_(data)(values_);
+  THTensor *values = THTensor_(newContiguous)(values_);
   long nDimI = THSTensor_(nDimensionI)(self);
   long nDimV = THSTensor_(nDimensionV)(self);
 
@@ -451,49 +414,54 @@ void THSTensor_(coalesce)(THSTensor *self) {
   THLongTensor_zero(indicesScalar);
   long factor = 1;
   for (long d = nDimI - 1; d >= 0; d--) {
-    THLongTensor_select(indicesSlice, indices_, 0, d);
+    THLongTensor_select(indicesSlice, indices, 0, d);
     THLongTensor_cadd(indicesScalar, indicesScalar, factor, indicesSlice);
     factor *= self->size[d];
   }
 
   THLongTensor *newIndices = THLongTensor_new();
   THTensor *newValues = THTensor_(new)();
-  THLongTensor_resizeAs(newIndices, indices_);
+  THLongTensor_resizeAs(newIndices, indices);
   THTensor_(resizeAs)(newValues, values_);
-  THSTensor_(_move)(self, newIndices, newValues);
+  // THSTensor_(_move)(self, newIndices, newValues);
+  THSTensor *dst = THSTensor_(new)();
+  THSTensor_(rawResize)(dst, nDimI, nDimV, self->size);
+  THSTensor_(_move)(dst, newIndices, newValues);
 
   THLongTensor_sort(indicesBuffer, indicesPermutation, indicesScalar, 0, 0);
 
   long i = -1;
   long prev = -1;
-  long blockSize = contiguousValues->stride[0];
+  long blockSize = values->stride[0];
   for (long j = 0; j < self->nnz; j++) {
     long pos = THTensor_fastGet1d(indicesPermutation, j);
     long curr = THTensor_fastGet1d(indicesBuffer, j);
     if (curr == prev) {
       THBlas_(axpy)(blockSize, 1,
-        THTensor_(data)(contiguousValues) + pos * blockSize, 1,
+        THTensor_(data)(values) + pos * blockSize, 1,
         THTensor_(data)(newValues) + i * blockSize, 1);
     } else {
       ++i;
       for (long d = 0; d < nDimI; d++) {
-        THTensor_fastSet2d(newIndices, d, i, THTensor_fastGet2d(indices_, d, pos));
+        THTensor_fastSet2d(newIndices, d, i, THTensor_fastGet2d(indices, d, pos));
       }
       THBlas_(copy)(blockSize,
-        THTensor_(data)(contiguousValues) + pos * blockSize, 1,
+        THTensor_(data)(values) + pos * blockSize, 1,
         THTensor_(data)(newValues) + i * blockSize, 1);
     }
     prev = curr;
   }
-  self->nnz = i + 1;
-  self->coalesced = 1;
+  dst->nnz = i + 1;
+  dst->coalesced = 1;
   THLongTensor_free(indicesScalar);
   THLongTensor_free(indicesBuffer);
   THLongTensor_free(indicesPermutation);
   THLongTensor_free(indicesSlice);
-  THLongTensor_free(indices_);
+  THLongTensor_free(indices);
   THTensor_(free)(values_);
-  THTensor_(free)(contiguousValues);
+  THTensor_(free)(values);
+
+  return dst;
 }
 
 void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask) {

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -57,7 +57,7 @@ TH_API void THSTensor_(copy)(THSTensor *self, THSTensor *src);
 TH_API void THSTensor_(transpose)(THSTensor *self, int dimension1_, int dimension2_);
 TH_API int THSTensor_(isCoalesced)(const THSTensor *self);
 TH_API int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor *src);
-TH_API void THSTensor_(coalesce)(THSTensor *self);
+TH_API THSTensor *THSTensor_(newCoalesce)(THSTensor *self);
 
 TH_API void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask);
 

--- a/torch/lib/THS/generic/THSTensor.h
+++ b/torch/lib/THS/generic/THSTensor.h
@@ -14,7 +14,7 @@ typedef struct THSTensor
     THLongTensor *indices;
     THTensor *values;
     // Math operations can only be performed on ordered sparse tensors
-    int contiguous;
+    int coalesced;
     int refcount;
 
 } THSTensor;
@@ -41,7 +41,6 @@ TH_API THSTensor *THSTensor_(newWithSize3d)(long size0_, long size1_, long size2
 TH_API THSTensor *THSTensor_(newWithSize4d)(long size0_, long size1_, long size2_, long size3_);
 
 TH_API THSTensor *THSTensor_(newClone)(THSTensor *self);
-TH_API THSTensor *THSTensor_(newContiguous)(THSTensor *self);
 TH_API THSTensor *THSTensor_(newTranspose)(THSTensor *self, int dimension1_, int dimension2_);
 
 /**** reshaping methods ***/
@@ -56,9 +55,9 @@ TH_API THTensor *THSTensor_(toDense)(THSTensor *self);
 TH_API void THSTensor_(copy)(THSTensor *self, THSTensor *src);
 
 TH_API void THSTensor_(transpose)(THSTensor *self, int dimension1_, int dimension2_);
-TH_API int THSTensor_(isContiguous)(const THSTensor *self);
+TH_API int THSTensor_(isCoalesced)(const THSTensor *self);
 TH_API int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor *src);
-TH_API void THSTensor_(contiguous)(THSTensor *self);
+TH_API void THSTensor_(coalesce)(THSTensor *self);
 
 TH_API void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask);
 

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -71,8 +71,6 @@ void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   if(!THSTensor_(isSameSizeAs)(t, src)) {
     THError("cadd operands have incompatible sizes or dimension types");
   }
-  THSTensor_(coalesce)(t);
-  THSTensor_(coalesce)(src);
 
   if (src->nnz == 0) {
     THSTensor_(copy)(r_, t);
@@ -152,17 +150,18 @@ void THSTensor_(csub)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   THSTensor_(cadd)(r_, t, -value, src);
 }
 
-void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src) {
-  if(!THSTensor_(isSameSizeAs)(t, src)) {
+void THSTensor_(cmul)(THSTensor *r_, THSTensor *t_, THSTensor *src_) {
+  if(!THSTensor_(isSameSizeAs)(t_, src_)) {
     THError("cadd operands have incompatible sizes or dimension types");
   }
-  THSTensor_(coalesce)(t);
-  THSTensor_(coalesce)(src);
 
-  if (src->nnz == 0 || t->nnz == 0) {
+  if (src_->nnz == 0 || t_->nnz == 0) {
     THSTensor_(zero)(r_);
     return;
   }
+
+  THSTensor *t = THSTensor_(newCoalesce)(t_);
+  THSTensor *src = THSTensor_(newCoalesce)(src_);
 
   // saving those because they can be overwritten when doing in-place operations
   ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz;
@@ -218,6 +217,8 @@ void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src) {
   THTensor_(free)(src1Buffer);
   THTensor_(free)(src2Buffer);
   THTensor_(free)(dstBuffer);
+  THSTensor_(free)(t);
+  THSTensor_(free)(src);
 }
 
 void THTensor_(spaddcmul)(THTensor *r_, THTensor *t, real value, THSTensor *src1, THSTensor *src2) {
@@ -246,21 +247,21 @@ THLongTensor *THSTensor_(toCSR)(long const *indices, long dim, long nnz) {
 
 void THSTensor_(spaddmm)(THTensor *r_,
     real beta, THTensor *t,
-    real alpha, THSTensor *sparse, THTensor *dense) {
+    real alpha, THSTensor *sparse_, THTensor *dense) {
   long h, i;
   long dim_i, dim_j, dim_k; // ixj * jxk = ixk
   long nnz;
   THLongTensor *csr, *indices;
   THTensor *values;
 
-  THArgCheck(sparse->nDimensionI == 2, 2,
-      "matrices expected, got %dD tensor", sparse->nDimensionI);
-  THArgCheck(sparse->nDimensionV == 0, 2,
-      "scalar values expected, got %dD values", sparse->nDimensionV);
+  THArgCheck(sparse_->nDimensionI == 2, 2,
+      "matrices expected, got %dD tensor", sparse_->nDimensionI);
+  THArgCheck(sparse_->nDimensionV == 0, 2,
+      "scalar values expected, got %dD values", sparse_->nDimensionV);
   THArgCheck(dense->nDimension == 2, 2,
       "matrices expected, got %dD tensor", dense->nDimension);
 
-  THSTensor_(coalesce)(sparse);
+  THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
   dim_i = THSTensor_(size)(sparse, 0);
   dim_j = THSTensor_(size)(sparse, 1);
@@ -313,11 +314,12 @@ void THSTensor_(spaddmm)(THTensor *r_,
   THLongTensor_free(csr);
   THLongTensor_free(indices);
   THTensor_(free)(values);
+  THSTensor_(free)(sparse);
 }
 
 void THSTensor_(sspaddmm)(THSTensor *r_,
     real beta, THSTensor *t,
-    real alpha, THSTensor *sparse, THTensor *dense) {
+    real alpha, THSTensor *sparse_, THTensor *dense) {
 
   long h, i, p;
   long dim_i, dim_j, dim_k; // ixj * jxk = ixk
@@ -325,13 +327,14 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
   THLongTensor *csr, *indices, *newi, *narrowi;
   THTensor *values, *newv, *narrowv;
 
-  THArgCheck(sparse->nDimensionI == 2, 2,
-      "matrices expected, got %dD tensor", sparse->nDimensionI);
-  THArgCheck(sparse->nDimensionV == 0, 2,
-      "scalar values expected, got %dD values", sparse->nDimensionV);
+  THArgCheck(sparse_->nDimensionI == 2, 2,
+      "matrices expected, got %dD tensor", sparse_->nDimensionI);
+  THArgCheck(sparse_->nDimensionV == 0, 2,
+      "scalar values expected, got %dD values", sparse_->nDimensionV);
   THArgCheck(dense->nDimension == 2, 2,
       "matrices expected, got %dD tensor", dense->nDimension);
-  THSTensor_(coalesce)(sparse);
+
+  THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
   dim_i = THSTensor_(size)(sparse, 0);
   dim_j = THSTensor_(size)(sparse, 1);
@@ -404,23 +407,23 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
   r_->indices = newi;
   r_-> values = newv;
   r_->    nnz = p;
-  THSTensor_(coalesce)(r_);
 
   THLongTensor_free(csr);
   THLongTensor_free(indices);
   THTensor_(free)(values);
+  THSTensor_(free)(sparse);
 }
 
-void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *dense) {
-  THArgCheck(sparse->nDimensionI == 2, 2,
-      "matrices expected, got %dD tensor", sparse->nDimensionI);
-  THArgCheck(sparse->nDimensionV == 0, 2,
-      "scalar values expected, got %dD values", sparse->nDimensionV);
+void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse_, THTensor *dense) {
+  THArgCheck(sparse_->nDimensionI == 2, 2,
+      "matrices expected, got %dD tensor", sparse_->nDimensionI);
+  THArgCheck(sparse_->nDimensionV == 0, 2,
+      "scalar values expected, got %dD values", sparse_->nDimensionV);
   THArgCheck(dense->nDimension == 2, 2,
       "matrices expected, got %dD tensor", dense->nDimension);
 
-  long m = THSTensor_(size)(sparse, 0);
-  long k = THSTensor_(size)(sparse, 1);
+  long m = THSTensor_(size)(sparse_, 0);
+  long k = THSTensor_(size)(sparse_, 1);
   long n = THTensor_(size)(dense, 1);
 
   THArgCheck(THTensor_(size)(dense, 0) == k, 3,
@@ -428,7 +431,7 @@ void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *d
   long size[2] = {m, n};
   THSTensor_(rawResize)(r_, 1, 1, size);
 
-  THSTensor_(coalesce)(sparse);
+  THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
   long nnz = THSTensor_(nnz)(sparse);
   THLongTensor *indices = THLongTensor_newWithSize2d(1, nnz);
@@ -462,11 +465,12 @@ void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *d
   THSTensor_(free)(newSparse);
   THLongTensor_free(spIndices);
   THLongTensor_free(valueIndices);
+  THSTensor_(free)(sparse);
 }
 
-void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse) {
+void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse_) {
   THTensor_(resizeAs)(r_, dense);
-  THSTensor_(coalesce)(sparse);
+  THSTensor *sparse = THSTensor_(newCoalesce)(sparse_);
 
   long k;
   THLongTensor  *indices = THSTensor_(newIndices)(sparse);
@@ -505,6 +509,7 @@ void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sp
   THLongTensor_free(indices);
   THTensor_(free)(values);
   THLongStorage_free(storage);
+  THSTensor_(free)(sparse);
 }
 
 #undef ROW_PTR2

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -32,7 +32,7 @@ void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value) {
     THLongTensor_copy(r_indices_, t_indices_);
     THTensor_(mul)(r_values_, t_values_, value);
     r_->nnz = t->nnz;
-    r_->contiguous = t->contiguous;
+    r_->coalesced = t->coalesced;
 
     THLongTensor_free(r_indices_);
     THTensor_(free)(r_values_);
@@ -58,7 +58,7 @@ void THSTensor_(div)(THSTensor *r_, THSTensor *t, real value) {
     THLongTensor_copy(r_indices_, t_indices_);
     THTensor_(div)(r_values_, t_values_, value);
     r_->nnz = t->nnz;
-    r_->contiguous = t->contiguous;
+    r_->coalesced = t->coalesced;
 
     THLongTensor_free(r_indices_);
     THTensor_(free)(r_values_);
@@ -71,8 +71,8 @@ void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   if(!THSTensor_(isSameSizeAs)(t, src)) {
     THError("cadd operands have incompatible sizes or dimension types");
   }
-  THSTensor_(contiguous)(t);
-  THSTensor_(contiguous)(src);
+  THSTensor_(coalesce)(t);
+  THSTensor_(coalesce)(src);
 
   if (src->nnz == 0) {
     THSTensor_(copy)(r_, t);
@@ -140,7 +140,7 @@ void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   }
 
   r_->nnz = r_i;
-  r_->contiguous = 1;
+  r_->coalesced = 1;
 
   THLongTensor_free(t_indices_);
   THTensor_(free)(t_values_);
@@ -156,8 +156,8 @@ void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src) {
   if(!THSTensor_(isSameSizeAs)(t, src)) {
     THError("cadd operands have incompatible sizes or dimension types");
   }
-  THSTensor_(contiguous)(t);
-  THSTensor_(contiguous)(src);
+  THSTensor_(coalesce)(t);
+  THSTensor_(coalesce)(src);
 
   if (src->nnz == 0 || t->nnz == 0) {
     THSTensor_(zero)(r_);
@@ -209,7 +209,7 @@ void THSTensor_(cmul)(THSTensor *r_, THSTensor *t, THSTensor *src) {
   }
 
   r_->nnz = r_i;
-  r_->contiguous = 1;
+  r_->coalesced = 1;
 
   THLongTensor_free(t_indices_);
   THTensor_(free)(t_values_);
@@ -260,7 +260,7 @@ void THSTensor_(spaddmm)(THTensor *r_,
   THArgCheck(dense->nDimension == 2, 2,
       "matrices expected, got %dD tensor", dense->nDimension);
 
-  THSTensor_(contiguous)(sparse);
+  THSTensor_(coalesce)(sparse);
 
   dim_i = THSTensor_(size)(sparse, 0);
   dim_j = THSTensor_(size)(sparse, 1);
@@ -331,7 +331,7 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
       "scalar values expected, got %dD values", sparse->nDimensionV);
   THArgCheck(dense->nDimension == 2, 2,
       "matrices expected, got %dD tensor", dense->nDimension);
-  THSTensor_(contiguous)(sparse);
+  THSTensor_(coalesce)(sparse);
 
   dim_i = THSTensor_(size)(sparse, 0);
   dim_j = THSTensor_(size)(sparse, 1);
@@ -404,7 +404,7 @@ void THSTensor_(sspaddmm)(THSTensor *r_,
   r_->indices = newi;
   r_-> values = newv;
   r_->    nnz = p;
-  THSTensor_(contiguous)(r_);
+  THSTensor_(coalesce)(r_);
 
   THLongTensor_free(csr);
   THLongTensor_free(indices);
@@ -428,7 +428,7 @@ void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *d
   long size[2] = {m, n};
   THSTensor_(rawResize)(r_, 1, 1, size);
 
-  THSTensor_(contiguous)(sparse);
+  THSTensor_(coalesce)(sparse);
 
   long nnz = THSTensor_(nnz)(sparse);
   THLongTensor *indices = THLongTensor_newWithSize2d(1, nnz);
@@ -466,7 +466,7 @@ void THSTensor_(hspmm)(THSTensor *r_, real alpha, THSTensor *sparse, THTensor *d
 
 void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sparse) {
   THTensor_(resizeAs)(r_, dense);
-  THSTensor_(contiguous)(sparse);
+  THSTensor_(coalesce)(sparse);
 
   long k;
   THLongTensor  *indices = THSTensor_(newIndices)(sparse);

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -75,7 +75,6 @@ class Embedding(Function):
                     _count = torch.IntTensor()
                     _sorted = _indices = None
 
-            # TODO: sparse updates...
             grad_weight = grad_output.new(self._weight_size).zero_()
             self._backend.LookupTable_accGradParameters(
                 self._backend.library_state,

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -133,7 +133,7 @@ class _SparseBase(object):
         raise NotImplementedError
 
     def __str__(self):
-        self.contiguous()  # to make sure the output is consistent
+        self.coalesce_()  # to make sure the output is consistent
         return '{} with indices:\n{}and values:\n{}'.format(
             self.__class__.__name__, self.indices(), self.values())
 

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -133,7 +133,6 @@ class _SparseBase(object):
         raise NotImplementedError
 
     def __str__(self):
-        self.coalesce_()  # to make sure the output is consistent
         return '{} with indices:\n{}and values:\n{}'.format(
             self.__class__.__name__, self.indices(), self.values())
 


### PR DESCRIPTION
Rename sparse tensor `contiguous` to `coalesce`, and be more sane about in-place vs out-of-place (i.e. always do it in place).

One thing I'm wondering: should the python methods `tensor.indices()`, `tensor.values()`, and `tensor.__repr__()` automatically coalesce first? This would have the advantage of hiding the implementation detail of coalescing from the Python user, guaranteeing expected invariants such as `t.indices() == t.coalesce_().indices()`. On the other hand, it limits what you can do in python (i.e. if you want to do something that uses the indices without coalescing for efficiency).

Opinions welcome!