### PR TITLE
Fix exceptions not being caught

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -366,9 +366,9 @@ def make_relative_rpath(path):
 # Declare extensions and package
 ################################################################################
 
-#nvcc does not support '-fexceptions'
-nvcc_extra_compile_args=extra_compile_args
-extra_compile_args+=['-fexceptions']
+# nvcc does not support '-fexceptions'
+nvcc_extra_compile_args = extra_compile_args
+extra_compile_args += ['-fexceptions']
 
 extensions = []
 packages = find_packages(exclude=('tools.*',))

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ class clean(distutils.command.clean.clean):
 include_dirs = []
 library_dirs = []
 extra_link_args = []
-extra_compile_args = ['-std=c++11', '-Wno-write-strings', '-fexceptions']
+extra_compile_args = ['-std=c++11', '-Wno-write-strings']
 if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
     print('PYTORCH_BINARY_BUILD found. Static linking libstdc++ on Linux')
     extra_compile_args += ['-static-libstdc++']
@@ -366,6 +366,10 @@ def make_relative_rpath(path):
 # Declare extensions and package
 ################################################################################
 
+#nvcc does not support '-fexceptions'
+nvcc_extra_compile_args=extra_compile_args
+extra_compile_args+=['-fexceptions']
+
 extensions = []
 packages = find_packages(exclude=('tools.*',))
 
@@ -403,7 +407,7 @@ if WITH_CUDA:
     THCUNN = Extension("torch._thnn._THCUNN",
                        sources=['torch/csrc/nn/THCUNN.cpp'],
                        language='c++',
-                       extra_compile_args=extra_compile_args,
+                       extra_compile_args=nvcc_extra_compile_args,
                        include_dirs=include_dirs,
                        extra_link_args=extra_link_args + [
                            TH_LIB,

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ class clean(distutils.command.clean.clean):
 include_dirs = []
 library_dirs = []
 extra_link_args = []
-extra_compile_args = ['-std=c++11', '-Wno-write-strings']
+extra_compile_args = ['-std=c++11', '-Wno-write-strings', '-fexceptions']
 if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
     print('PYTORCH_BINARY_BUILD found. Static linking libstdc++ on Linux')
     extra_compile_args += ['-static-libstdc++']

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -24,7 +24,8 @@ INSTALL_DIR="$(pwd)/tmp_install"
 BASIC_C_FLAGS=" -DTH_INDEX_BASE=0 -I$INSTALL_DIR/include \
   -I$INSTALL_DIR/include/TH -I$INSTALL_DIR/include/THC \
   -I$INSTALL_DIR/include/THS -I$INSTALL_DIR/include/THCS \
-  -I$INSTALL_DIR/include/THPP "
+  -I$INSTALL_DIR/include/THPP \
+  -fexceptions "
 LDFLAGS="-L$INSTALL_DIR/lib "
 LD_POSTFIX=".so.1"
 LD_POSTFIX_UNVERSIONED=".so"


### PR DESCRIPTION
Adding -fexceptions to both torch and pytorch C/C++ builds fixes tests
not passing in ppc64le and aarch64.

See https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_exceptions.html

Closes #1297