### PR TITLE
Add flexible bilinear upsampling aspect ratio redux

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2692,6 +2692,18 @@ new_module_tests = [
         desc='scale'
     ),
     dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 2)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_shared'
+    ),
+    dict(
+        module_name='UpsamplingBilinear2d',
+        constructor_args=(None, (2, 1)),
+        input_size=(1, 2, 4, 4),
+        desc='scale_tuple_skewed'
+    ),
+    dict(
         module_name='AdaptiveMaxPool1d',
         constructor_args=(3,),
         input=torch.rand(1, 3, 5)

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -16,7 +16,7 @@ class _UpsamplingBase(Function):
             raise ValueError('either size or scale_factor should be defined')
         if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
             raise ValueError('scale_factor must be of integer type or tuple of integer types')
-        self.size = _pair(size)
+        self.size = _pair(size) if size is not None else None
         self.scale_factor = scale_factor
 
 

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -5,6 +5,7 @@ from torch._thnn import type2backend
 
 from . import _all_functions
 from ...modules.utils import _pair
+from ...functional import _check_bilinear_scale_factor
 
 
 class _UpsamplingBase(Function):
@@ -73,17 +74,7 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
 
         if self.scale_factor is not None:
-            self.scale_factor = _pair(self.scale_factor)
-            # we have to be a tuple at this point
-            try:
-                assert len(self.scale_factor) == 2
-                for i in self.scale_factor:
-                    assert isinstance(i, Integral)
-                    assert i >= 1
-            except AssertionError as e:
-                raise ValueError('scale_factor must be a non-negative integer, '
-                                 'or a tuple of non-negative integers for bilinear upsamplings, but got: '
-                                 '{}'.format(self.scale_factor))
+            self.scale_factor = _check_bilinear_scale_factor(self.scale_factor)
 
     def forward(self, input):
         assert input.dim() == 4

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -117,7 +117,10 @@ class UpsamplingBilinear2d(_UpsamplingBase):
             self.output_size[1],
         )
         return grad_input
-
+    
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.scale_factor = _tuple(self.scale_factor)
 
 _all_functions.append(UpsamplingNearest2d)
 _all_functions.append(UpsamplingBilinear2d)

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -5,7 +5,7 @@ from torch._thnn import type2backend
 
 from . import _all_functions
 from ...modules.utils import _pair
-from ...functional import _check_bilinear_scale_factor
+from ...functional import _check_bilinear_2d_scale_factor
 
 
 class _UpsamplingBase(Function):
@@ -16,7 +16,7 @@ class _UpsamplingBase(Function):
             raise ValueError('either size or scale_factor should be defined')
         if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
             raise ValueError('scale_factor must be of integer type or tuple of integer types')
-        self.size = _pair(size) if size is not None else None
+        self.size = size
         self.scale_factor = scale_factor
 
 
@@ -27,6 +27,8 @@ class UpsamplingNearest2d(_UpsamplingBase):
 
         if self.scale_factor is not None and not isinstance(scale_factor, Integral):
             raise ValueError('scale_factor must be of integer type for nearest neighbor sampling')
+
+        self.size = _pair(self.size) if self.size is not None else None
 
     def forward(self, input):
         assert input.dim() == 4
@@ -74,7 +76,9 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
 
         if self.scale_factor is not None:
-            self.scale_factor = _check_bilinear_scale_factor(self.scale_factor)
+            self.scale_factor = _check_bilinear_2d_scale_factor(self.scale_factor)
+
+        self.size = _pair(self.size) if self.size is not None else None
 
     def forward(self, input):
         assert input.dim() == 4

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -4,6 +4,7 @@ from torch.autograd import Function
 from torch._thnn import type2backend
 
 from . import _all_functions
+from ...modules.utils import _pair
 
 
 class _UpsamplingBase(Function):
@@ -12,15 +13,19 @@ class _UpsamplingBase(Function):
         super(_UpsamplingBase, self).__init__()
         if size is None and scale_factor is None:
             raise ValueError('either size or scale_factor should be defined')
-        if scale_factor is not None and not isinstance(scale_factor, Integral):
-            raise ValueError('scale_factor must be of integer type')
-        if size is not None and not isinstance(size, tuple):
-            size = (size, size)
-        self.size = size
+        if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
+            raise ValueError('scale_factor must be of integer type or tuple of integer types')
+        self.size = _pair(size)
         self.scale_factor = scale_factor
 
 
 class UpsamplingNearest2d(_UpsamplingBase):
+
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest2d, self).__init__(size, scale_factor)
+
+        if self.scale_factor is not None and not isinstance(scale_factor, Integral):
+            raise ValueError('scale_factor must be of integer type for nearest neighbor sampling')
 
     def forward(self, input):
         assert input.dim() == 4
@@ -64,13 +69,29 @@ class UpsamplingNearest2d(_UpsamplingBase):
 
 class UpsamplingBilinear2d(_UpsamplingBase):
 
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
+
+        if self.scale_factor is not None:
+            self.scale_factor = _pair(self.scale_factor)
+            # we have to be a tuple at this point
+            try:
+                assert len(self.scale_factor) == 2
+                for i in self.scale_factor:
+                    assert isinstance(i, Integral)
+                    assert i >= 1
+            except AssertionError as e:
+                raise ValueError('scale_factor must be a non-negative integer, '
+                                 'or a tuple of non-negative integers for bilinear upsamplings, but got: '
+                                 '{}'.format(self.scale_factor))
+
     def forward(self, input):
         assert input.dim() == 4
 
-        if self.scale_factor:
+        if self.scale_factor is not None:
             self.output_size = (
-                input.size(2) * self.scale_factor,
-                input.size(3) * self.scale_factor,
+                input.size(2) * self.scale_factor[0],
+                input.size(3) * self.scale_factor[1],
             )
         else:
             self.output_size = self.size

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -117,7 +117,7 @@ class UpsamplingBilinear2d(_UpsamplingBase):
             self.output_size[1],
         )
         return grad_input
-    
+
     def __setstate__(self, state):
         self.__dict__.update(state)
         self.scale_factor = _tuple(self.scale_factor)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -618,6 +618,7 @@ def _check_bilinear_scale_factor(scale_factor):
         raise ValueError('scale_factor must be a non-negative integer, '
                          'or a tuple of non-negative integers for bilinear upsamplings, but got: '
                          '{}'.format(scale_factor))
+    return scale_factor
 
 
 def pad(input, pad, mode='constant', value=0):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -609,7 +609,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return _functions.thnn.UpsamplingBilinear2d(size, scale_factor)(input)
 
 
-def _check_bilinear_scale_factor(scale_factor):
+def _check_bilinear_2d_scale_factor(scale_factor):
     scale_factor = _pair(scale_factor)
     try:
         assert len(scale_factor) == 2

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,5 +1,7 @@
 """Functional interface"""
 
+from numbers import Integral
+
 import torch
 from . import _functions
 from .modules import utils

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -602,7 +602,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     Args:
         input (Variable): input
         size (int or Tuple[int, int]): output spatial size.
-        scale_factor (int): multiplier for spatial size. Has to be an integer.
+        scale_factor (int or Tuple[int, int]): multiplier for spatial size
     """
     return _functions.thnn.UpsamplingBilinear2d(size, scale_factor)(input)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -607,6 +607,17 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return _functions.thnn.UpsamplingBilinear2d(size, scale_factor)(input)
 
 
+def _check_bilinear_scale_factor(scale_factor):
+    scale_factor = _pair(scale_factor)
+    try:
+        assert len(scale_factor) == 2
+        assert all(isinstance(s, Integral) and s >= 1 for s in scale_factor)
+    except AssertionError as e:
+        raise ValueError('scale_factor must be a non-negative integer, '
+                         'or a tuple of non-negative integers for bilinear upsamplings, but got: '
+                         '{}'.format(scale_factor))
+
+
 def pad(input, pad, mode='constant', value=0):
     """Pads tensor.
 

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -119,17 +119,7 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
 
         if self.scale_factor is not None:
-            self.scale_factor = _pair(self.scale_factor)
-            # we have to be a tuple at this point
-            try:
-                assert len(self.scale_factor) == 2
-                for i in self.scale_factor:
-                    assert isinstance(i, Integral)
-                    assert i >= 1
-            except AssertionError as e:
-                raise ValueError('scale_factor must be a non-negative integer, '
-                                 'or a tuple of non-negative integers for bilinear upsamplings, but got: '
-                                 '{}'.format(self.scale_factor))
+            self.scale_factor = F._check_bilinear_scale_factor(self.scale_factor)
 
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -13,7 +13,7 @@ class _UpsamplingBase(Module):
             raise ValueError('either size or scale_factor should be defined')
         if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
             raise ValueError('scale_factor must be of integer type or tuple of integer types')
-        self.size = _pair(size)
+        self.size = _pair(size) if size is not None else None
         self.scale_factor = scale_factor
 
     def __repr__(self):

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -11,8 +11,8 @@ class _UpsamplingBase(Module):
         super(_UpsamplingBase, self).__init__()
         if size is None and scale_factor is None:
             raise ValueError('either size or scale_factor should be defined')
-        if scale_factor is not None and not isinstance(scale_factor, Integral):
-            raise ValueError('scale_factor must be of integer type')
+        if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
+            raise ValueError('scale_factor must be of integer type or tuple of integer types')
         self.size = _pair(size)
         self.scale_factor = scale_factor
 
@@ -65,6 +65,11 @@ class UpsamplingNearest2d(_UpsamplingBase):
 
     """
 
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest2d, self).__init__(size, scale_factor)
+        if self.scale_factor is not None and not isinstance(scale_factor, Integral):
+            raise ValueError('scale_factor must be of integer type for neighest neighbor sampling')
+
     def forward(self, input):
         return F.upsample_nearest(input, self.size, self.scale_factor)
 
@@ -109,6 +114,22 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         [torch.FloatTensor of size 1x1x4x4]
 
     """
+
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
+
+        if self.scale_factor is not None:
+            self.scale_factor = _pair(self.scale_factor)
+            # we have to be a tuple at this point
+            try:
+                assert len(self.scale_factor) == 2
+                for i in self.scale_factor:
+                    assert isinstance(i, Integral)
+                    assert i >= 1
+            except AssertionError as e:
+                raise ValueError('scale_factor must be a non-negative integer, '
+                                 'or a tuple of non-negative integers for bilinear upsamplings, but got: '
+                                 '{}'.format(self.scale_factor))
 
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -13,7 +13,7 @@ class _UpsamplingBase(Module):
             raise ValueError('either size or scale_factor should be defined')
         if scale_factor is not None and not isinstance(scale_factor, (Integral, tuple)):
             raise ValueError('scale_factor must be of integer type or tuple of integer types')
-        self.size = _pair(size) if size is not None else None
+        self.size = size
         self.scale_factor = scale_factor
 
     def __repr__(self):
@@ -69,6 +69,7 @@ class UpsamplingNearest2d(_UpsamplingBase):
         super(UpsamplingNearest2d, self).__init__(size, scale_factor)
         if self.scale_factor is not None and not isinstance(scale_factor, Integral):
             raise ValueError('scale_factor must be of integer type for neighest neighbor sampling')
+        self.size = _pair(self.size) if self.size is not None else None
 
     def forward(self, input):
         return F.upsample_nearest(input, self.size, self.scale_factor)
@@ -119,7 +120,8 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
 
         if self.scale_factor is not None:
-            self.scale_factor = F._check_bilinear_scale_factor(self.scale_factor)
+            self.scale_factor = F._check_bilinear_2d_scale_factor(self.scale_factor)
+        self.size = _pair(self.size) if self.size is not None else None
 
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)


### PR DESCRIPTION
This PR addresses issue #1257, which aims to add non-coupled scaling factors for bilinear 2d upsampling. I've added two new tests, and currently everything passes. This is a relatively simple change which only touches python code.

Furthermore, this is is a re-do of PR https://github.com/pytorch/pytorch/pull/1279, wherein I messed up a rebase.  There are some in-line comments there that might be worth skimming through, as well, but I tried to address most of the concerns raised there.  In particular, I maintained the base class of all the upsampling methods.

Tests pass, on GPU and CPU.

tagging @apaszke @fmassa @soumith.  Thanks in advance everyone.

ps:  I'll probably need a pointer on how to best rebase to master, eventually ;)