### PR TITLE
Concatenate directly into shared memory when constructing batches

### DIFF
--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -192,6 +192,7 @@ ${cpu}
 
     OUT_INIT = """
     __out = kwargs ? PyDict_GetItemString(kwargs, "out") : NULL;
+    if (__out == Py_None) { __out = NULL; __dictcount--; __argcount--; }
     """
 
     def __init__(self):

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -715,66 +715,63 @@ static PyObject * THPTensor_stateless_(cat)(THPTensor *_unused, PyObject *args, 
 #if IS_CUDA
   THCPAutoGPU __autogpu_guard(-1);
 #endif
-  Py_ssize_t _tuplecount = args ? PyTuple_GET_SIZE(args) : 0;
-  Py_ssize_t _dictcount = kwargs ? PyDict_Size(kwargs) : 0;
-  Py_ssize_t _argcount = _tuplecount + _dictcount;
-  std::vector<THPObjectPtr> items;
-  std::vector<THTensor *> item_tensors;
-  Py_ssize_t seq_length;
+  static char* argnames[] = { "seq", "dim", "out", NULL };
+  PyObject *_seq = NULL;
+  long dim = 0;
+  PyObject *__out = NULL;
+
+  THPObjectPtr sequence;
+  std::vector<THTensor *> tensors;
   THPTensorPtr result;
-  long dimension = -1;
-  PyObject *sequence = _tuplecount > 0 ? PyTuple_GET_ITEM(args, 0)
-                     : (kwargs ? PyDict_GetItemString(kwargs, "seq") : NULL);
-  PyObject *pydim = _tuplecount > 1 ? PyTuple_GET_ITEM(args, 1)
-                  : (kwargs ? PyDict_GetItemString(kwargs, "dim") : NULL);
+  Py_ssize_t len;
 
-  if (_argcount == 0 || _argcount > 2)
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|lO", argnames, &_seq, &dim, &__out)) {
     goto invalid_arguments;
-  if (sequence == NULL || (_argcount > 1 && pydim == NULL))
-    goto invalid_arguments;
-  if (!PySequence_Check(sequence))
-    goto invalid_arguments;
-  seq_length = PySequence_Length(sequence);
-  THPUtils_assert(seq_length > 0, "sequence length has to be positive, but is %lld",
-                  (long long)seq_length);
-
-  items.reserve(seq_length);
-  item_tensors.reserve(seq_length);
-  for (int i = 0; i < seq_length; i++) {
-    items.push_back(PySequence_ITEM(sequence, i));
-    if (!THPTensor_(Check)(items[i].get()))
-      goto invalid_arguments;
-    item_tensors.push_back(((THPTensor*)items[i].get())->cdata);
   }
 
-  if (pydim) {
-    if (!THPUtils_checkLong(pydim))
+  sequence = PySequence_Fast(_seq, "seq must be a sequence");
+  if (!sequence) {
+    // NOTE: we use the error message from invalidArguments when _seq is not a sequence
+    goto invalid_arguments;
+  }
+
+  len = PySequence_Fast_GET_SIZE(sequence.get());
+  THPUtils_assert(len > 0, "seq can't be empty");
+
+  if (__out && __out != Py_None) {
+    if (!THPTensor_(Check)(__out)) {
       goto invalid_arguments;
-    dimension = THPUtils_unpackLong(pydim);
+    }
+    Py_INCREF(__out);
+    result = (THPTensor *)__out;
   } else {
-    dimension = 0;
+    result = (THPTensor *)THPTensor_(NewEmpty)();
+    if (!result) return NULL;
   }
 
-  for (THTensor *t : item_tensors) {
+  for (int i = 0; i < len; i++) {
+    PyObject *item = PySequence_Fast_GET_ITEM(sequence.get(), i);
+    if (!THPTensor_(Check)(item))
+      goto invalid_arguments;
+    tensors.push_back(((THPTensor*)item)->cdata);
+  }
+
+  for (THTensor *t : tensors) {
     auto ndim = THTensor_(nDimension)(LIBRARY_STATE t);
     if (ndim > 0) {
-      THPUtils_assert(dimension > 0 ? dimension < ndim : ndim + dimension >= 0,
-                      "dimension out of range - got %d but the tensor is only %dD",
-                      dimension, ndim);
-      if (dimension < 0) dimension += ndim;
+      THPUtils_assert(dim > 0 ? dim < ndim : ndim + dim >= 0,
+                      "dim out of range - got %d but the tensor is only %dD",
+                      dim, ndim);
+      if (dim < 0) dim += ndim;
       break;
     }
   }
 
 #if IS_CUDA
-  __autogpu_guard.setDevice(THTensor_(getDevice)(LIBRARY_STATE item_tensors[0]));
+  __autogpu_guard.setDevice(THTensor_(getDevice)(LIBRARY_STATE tensors[0]));
 #endif
 
-  result = (THPTensor *)THPTensor_(NewEmpty)();
-  if (!result) return NULL;
-
-  THTensor_(catArray)(LIBRARY_STATE result->cdata, item_tensors.data(),
-      items.size(), dimension);
+  THTensor_(catArray)(LIBRARY_STATE result->cdata, tensors.data(), tensors.size(), dim);
   return (PyObject*)result.release();
 
 invalid_arguments:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -39,7 +39,7 @@ def chunk(tensor, chunks, dim=0):
     return split(tensor, split_size, dim)
 
 
-def stack(sequence, dim=0):
+def stack(sequence, dim=0, out=None):
     """Concatenates sequence of tensors along a new dimension.
 
     All tensors need to be of the same size.
@@ -53,7 +53,7 @@ def stack(sequence, dim=0):
         raise TypeError("stack expects a non-empty sequence of tensors")
     if dim < 0:
         dim += sequence[0].dim()
-    return torch.cat(list(t.unsqueeze(dim) for t in sequence), dim)
+    return torch.cat(list(t.unsqueeze(dim) for t in sequence), dim, out=out)
 
 
 def unbind(tensor, dim=0):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -101,6 +101,17 @@ class _StorageBase(object):
             self._share_fd_()
         return self
 
+    @classmethod
+    def _new_shared(cls, size):
+        """Creates a new storage in shared memory with the same data type"""
+        from torch.multiprocessing import get_sharing_strategy
+        if cls.is_cuda:
+            return cls(size)
+        elif get_sharing_strategy() == 'file_system':
+            return cls._new_using_filename(size)
+        else:
+            return cls._new_using_fd(size)
+
 
 _StorageBase.type = _type
 _StorageBase.cuda = _cuda


### PR DESCRIPTION
This saves an extra memory copy, which speeds up data loading a bit
(5-10% with accimage).

As part of this change:

 * torch.cat accepts keyword argument out
 * sepcifiying out=None is treated like not specifying out