### PR TITLE
Add zero padding module

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2548,6 +2548,11 @@ new_module_tests = [
         input_size=(2, 3, 4, 4)
     ),
     dict(
+        module_name='ConstantPad2d',
+        constructor_args=((1, 2, 3, 4), 2),
+        input_size=(2, 3, 4, 4)
+    ),
+    dict(
         module_name='Conv3d',
         constructor_args=(3, 4, (2, 3, 4)),
         input_size=(2, 3, 3, 4, 5),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2543,6 +2543,11 @@ new_module_tests = [
         input_size=(2, 3, 4, 4)
     ),
     dict(
+        module_name='ZeroPad2d',
+        constructor_args=((1, 2, 3, 4),),
+        input_size=(2, 3, 4, 4)
+    ),
+    dict(
         module_name='Conv3d',
         constructor_args=(3, 4, (2, 3, 4)),
         input_size=(2, 3, 3, 4, 5),

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -15,7 +15,7 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     AdaptiveMaxPool2d, AdaptiveAvgPool1d, AdaptiveAvgPool2d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d
-from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d, ZeroPad2d
+from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d, ZeroPad2d, ConstantPad2d
 from .normalization import CrossMapLRN2d
 from .sparse import Embedding
 from .rnn import RNNBase, RNN, LSTM, GRU, \

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -41,5 +41,5 @@ __all__ = [
     'Embedding', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
-    'TripletMarginLoss'
+    'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad2d'
 ]

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -15,7 +15,7 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     AdaptiveMaxPool2d, AdaptiveAvgPool1d, AdaptiveAvgPool2d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d
-from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d
+from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d, ZeroPad2d
 from .normalization import CrossMapLRN2d
 from .sparse import Embedding
 from .rnn import RNNBase, RNN, LSTM, GRU, \

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -62,7 +62,7 @@ class ConstantPad2d(Module):
     def __init__(self, padding, value):
         super(ConstantPad2d, self).__init__()
         self.padding = _quadruple(padding)
-        self.valud = value
+        self.value = value
 
     def forward(self, input):
         return F_ConstantPad2d(pad=self.padding, value=self.value)(input)

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -1,5 +1,6 @@
 from .module import Module
 from .utils import _quadruple, _ntuple
+from .._functions.padding import ConstantPad2d
 
 # TODO: grad_output size asserts in THNN
 
@@ -42,4 +43,15 @@ class ReplicationPad3d(Module):
     def __repr__(self):
         return self.__class__.__name__ + ' ' + str(self.padding)
 
-# TODO: ZeroPad2d
+
+class ZeroPad2d(Module):
+
+    def __init__(self, padding):
+        super(ZeroPad2d, self).__init__()
+        self.padding = _quadruple(padding)
+
+    def forward(self, input):
+        return ConstantPad2d(pad=self.padding, value=0)(input)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self.padding)

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -56,7 +56,7 @@ class ZeroPad2d(Module):
     def __repr__(self):
         return self.__class__.__name__ + ' ' + str(self.padding)
 
-   
+  
 class ConstantPad2d(Module):
 
     def __init__(self, padding, value):

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -56,7 +56,7 @@ class ZeroPad2d(Module):
     def __repr__(self):
         return self.__class__.__name__ + ' ' + str(self.padding)
 
-  
+
 class ConstantPad2d(Module):
 
     def __init__(self, padding, value):

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -1,6 +1,6 @@
 from .module import Module
 from .utils import _quadruple, _ntuple
-from .._functions.padding import ConstantPad2d
+from .._functions.padding import ConstantPad2d as F_ConstantPad2d
 
 # TODO: grad_output size asserts in THNN
 
@@ -51,7 +51,21 @@ class ZeroPad2d(Module):
         self.padding = _quadruple(padding)
 
     def forward(self, input):
-        return ConstantPad2d(pad=self.padding, value=0)(input)
+        return F_ConstantPad2d(pad=self.padding, value=0)(input)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ' + str(self.padding)
+
+   
+class ConstantPad2d(Module):
+
+    def __init__(self, padding, value):
+        super(ConstantPad2d, self).__init__()
+        self.padding = _quadruple(padding)
+        self.valud = value
+
+    def forward(self, input):
+        return F_ConstantPad2d(pad=self.padding, value=self.value)(input)
 
     def __repr__(self):
         return self.__class__.__name__ + ' ' + str(self.padding)


### PR DESCRIPTION
Addresses #1324 

Since `F.pad` simply wraps [`ConstantPad2d`](https://github.com/pytorch/pytorch/blob/master/torch/nn/_functions/padding.py), I used `ConstantPad2d` instead.