### PR TITLE
Fix errors when no CUDA devices are available

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -351,13 +351,10 @@ auto Engine::ready_queue(int device) -> ReadyQueue& {
 auto Engine::start_threads() -> void {
   int num_devices = 0;
 #ifdef WITH_CUDA
-  cudaError_t err = cudaGetDeviceCount(&num_devices);
-
-  // check for case of compiled with CUDA but no NVIDIA driver available
-  if (err == cudaErrorInsufficientDriver) {
+  // check for case of compiled with CUDA but no available devices
+  if (cudaGetDeviceCount(&num_devices) != cudaSuccess) {
+    cudaGetLastError();
     num_devices = 0;
-  } else {
-    THCudaCheck(err);
   }
 #endif
   ready_queues = std::vector<std::shared_ptr<ReadyQueue>>(num_devices + 1);

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -53,6 +53,20 @@ auto ConvParams::view1d_as_2d() -> void {
   }
 }
 
+auto ConvParams::use_cudnn(const Tensor& input) const -> bool {
+#ifdef WITH_CUDNN
+  if (!input.isCuda() || !cudnn_enabled) {
+    return false;
+  }
+  if (is_dilated()) {
+    cudaDeviceProp* prop = THCState_getCurrentDeviceProperties(state);
+    return CUDNN_VERSION >= 6000 && prop->major >= 5;
+  }
+  return true;
+#endif
+  return false;
+}
+
 auto ConvForward::output_size(Tensor& input, Tensor& weight) -> std::vector<long> {
   auto in_size = input.sizes();
   auto weight_size = weight.sizes();
@@ -123,19 +137,12 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   auto weight_size = weight->sizes();
   std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
 
-  bool use_cudnn = false;
-#ifdef WITH_CUDNN
-  cudaDeviceProp* prop =
-    THCState_getCurrentDeviceProperties(state);
-  use_cudnn = (input->isCuda() && (!is_dilated() || CUDNN_VERSION >= 6000) && (!is_dilated() || prop->major >= 5) ) && cudnn_enabled;
-#endif
-
   std::unique_ptr<Tensor> output;
   tensor_list columns(groups);
   tensor_list ones(groups);
   std::unique_ptr<Convolution> convolution;
 
-  if (use_cudnn) {
+  if (use_cudnn(*input)) {
 #ifdef WITH_CUDNN
     output = input->newTensor();
     output->resize(output_size(*input, *weight));
@@ -212,12 +219,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   auto weight_size = weight->sizes();
   std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
 
-  bool use_cudnn = false;
-#ifdef WITH_CUDNN
-  cudaDeviceProp* prop =
-    THCState_getCurrentDeviceProperties(state);
-  use_cudnn = (input->isCuda() && (!is_dilated() || CUDNN_VERSION >= 6000) && (!is_dilated() || prop->major >= 5) ) && cudnn_enabled;
-#endif
+  bool use_cudnn = this->use_cudnn(*input);
 
   std::unique_ptr<Tensor> grad_input;
   std::unique_ptr<Tensor> grad_weight;

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -31,11 +31,11 @@ struct ConvParams {
   bool is_output_padding_neg() const;
   bool is_padding_neg() const;
   void view1d_as_2d();
-
+  bool use_cudnn(const thpp::Tensor& input) const;
 };
 
 struct ConvForward : public Function, public ConvParams {
-  ConvForward(ConvParams params) : ConvParams(std::move(params)) {}
+  explicit ConvForward(ConvParams params) : ConvParams(std::move(params)) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -109,7 +109,10 @@ PyObject * THCPModule_getDeviceCount_wrap(PyObject *self)
 {
   HANDLE_TH_ERRORS
   int ndevice;
-  THCudaCheck(cudaGetDeviceCount(&ndevice));
+  if (cudaGetDeviceCount(&ndevice) != cudaSuccess) {
+    cudaGetLastError();
+    ndevice = 0;
+  }
   return PyLong_FromLong(ndevice);
   END_HANDLE_TH_ERRORS
 }
@@ -313,7 +316,10 @@ PyObject * THCPModule_initExtension(PyObject *self)
     THPUtils_setError("class loader couldn't access torch module");
     return NULL;
   }
-  return PyBool_FromLong(THCPModule_initCuda(torch_module));
+  if (!THCPModule_initCuda(torch_module)) {
+    return NULL;
+  }
+  Py_RETURN_NONE;
 }
 
 #ifdef WITH_NCCL

--- a/torch/csrc/cuda/ModuleSparse.cpp
+++ b/torch/csrc/cuda/ModuleSparse.cpp
@@ -62,5 +62,8 @@ PyObject * THCSPModule_initExtension(PyObject *self)
     THPUtils_setError("class loader couldn't access torch.cuda.sparse module");
     return NULL;
   }
-  return PyBool_FromLong(THCSPModule_initCudaSparse(module));
+  if (!THCSPModule_initCudaSparse(module)) {
+    return NULL;
+  }
+  Py_RETURN_NONE;
 }

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -26,12 +26,7 @@ def is_available():
     if (not hasattr(torch._C, '_cuda_isDriverSufficient') or
             not torch._C._cuda_isDriverSufficient()):
         return False
-    try:
-        return torch._C._cuda_getDeviceCount() > 0
-    except RuntimeError as e:
-        if 'no CUDA-capable device is detected' in e.args[0]:
-            return False
-        raise
+    return torch._C._cuda_getDeviceCount() > 0
 
 
 def _sleep(cycles):
@@ -87,8 +82,8 @@ def _lazy_init():
         raise RuntimeError(
             "Cannot re-initialize CUDA in forked subprocess. " + msg)
     _check_driver()
-    assert torch._C._cuda_init()
-    assert torch._C._cuda_sparse_init()
+    torch._C._cuda_init()
+    torch._C._cuda_sparse_init()
     _cudart = _load_cudart()
     _cudart.cudaGetErrorName.restype = ctypes.c_char_p
     _cudart.cudaGetErrorString.restype = ctypes.c_char_p


### PR DESCRIPTION
Fixes #1267

This fixes a number of issues when PyTorch was compiled with CUDA
support but run on a machine without any GPUs. Now, we treat all errors
from cudaGetDeviceCount() as if the machine has no devices.

Now all tests pass with:

`CUDA_VISIBLE_DEVICES= ./run_test.sh`

I also changed _cuda_init and _cuda_sparse_init to return None on success and raise an exception on failure. Previously, they set the exception but returned a Python bool False which isn't allowed.

We should probably add a smoke test for the PyTorch compiled with CUDA but run without any GPUs (or with no visible device).