### PR TITLE
add keyword `out` for autograd function Concat to match torch.cat

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1074,6 +1074,7 @@ function_tests = [
     (Concat, (0,), ((1, S, S), (2, S, S), (3, S, S))),
     (Concat, (-1,), ((S, S, 1), (S, S, 2), (S, S, 3)), 'negdim-1'),
     (Concat, (-2,), ((S, 1, S), (S, 2, S), (S, 3, S)), 'negdim-2'),
+    (Concat, (0, None), ((1, S, S), (2, S, S), (3, S, S)), 'out'),
     (Resize, (S * S, S), ((S, S, S),)),
     (Diag, (), ((S, S),), '2d'),
     (Diag, (), ((S,),), '1d'),

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -301,13 +301,14 @@ class IndexSelect(Function):
 
 class Concat(Function):
 
-    def __init__(self, dim):
+    def __init__(self, dim, out=None):
         super(Concat, self).__init__()
         self.dim = dim
+        self.out = out
 
     def forward(self, *inputs):
         self.input_sizes = [i.size(self.dim) for i in inputs]
-        return torch.cat(inputs, self.dim)
+        return torch.cat(inputs, self.dim, out=self.out)
 
     def backward(self, grad_output):
         return tuple(grad_output.narrow(self.dim, end - size, size) for size, end

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -837,8 +837,8 @@ class Variable(_C._VariableBase):
     class _torch(object):
 
         @staticmethod
-        def cat(iterable, dim=0):
-            return Concat(dim)(*iterable)
+        def cat(iterable, dim=0, out=None):
+            return Concat(dim, out)(*iterable)
 
         @staticmethod
         def normal(means, std=1):


### PR DESCRIPTION
torch.cat has been improved by [pull request 1323](https://github.com/pytorch/pytorch/pull/1323), while autograd function hasn't, so sometimes it raises error(torch.stack for Variable).

see discuss in [forum](https://discuss.pytorch.org/t/cat-got-an-unexpected-keyword-argument-out/2151)