### PR TITLE
Adds __getattr__ to DataParallel to forward to self.module

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1029,6 +1029,23 @@ class TestNN(NNTestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out.data, expected_out)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_data_parallel_getattr(self):
+        class FooModule(nn.Module):
+            foo = 'foo'
+
+        fm_net = FooModule().cuda()
+        dp_net = nn.DataParallel(fm_net)
+
+        self.assertEqual(fm_net.foo, 'foo')
+        self.assertEqual(dp_net.foo, 'foo')
+
+        with self.assertRaises(AttributeError):
+            _ = fm_net.bar_does_not_exist
+
+        with self.assertRaises(AttributeError):
+            _ = dp_net.bar_does_not_exist
+
     def test_state_dict(self):
         l = nn.Linear(5, 5)
         block = nn.Module()

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -73,6 +73,16 @@ class DataParallel(Module):
     def gather(self, outputs, output_device):
         return gather(outputs, output_device, dim=self.dim)
 
+    def __getattr__(self, item):
+        try:
+            return super(DataParallel, self).__getattr__(item)
+        except AttributeError:
+            # Using the simpler `self.modules` goes infinitely recursive
+            if '_modules' in self.__dict__:
+                return getattr(self.__dict__['_modules']['module'], item)
+            else:
+                raise
+
 
 def data_parallel(module, inputs, device_ids, output_device=None, dim=0, module_kwargs=None):
     """Evaluates module(input) in parallel across the GPUs given in device_ids.


### PR DESCRIPTION
Helps keep the use of `DataParallel` transparent to other code.