### PR TITLE
Add upsample 3d, subsample 2d and 3d modules

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -519,6 +519,18 @@ Vision layers
 .. autoclass:: PixelShuffle
     :members:
 
+:hidden:`Subsampling2d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Subsampling2d
+    :members:
+
+:hidden:`Subsampling3d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Subsampling3d
+    :members:
+
 :hidden:`UpsamplingNearest2d`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -529,6 +541,18 @@ Vision layers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: UpsamplingBilinear2d
+    :members:
+
+:hidden:`UpsamplingNearest3d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: UpsamplingNearest3d
+    :members:
+
+:hidden:`UpsamplingTrilinear3d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: UpsamplingTrilinear3d
     :members:
 
 
@@ -866,6 +890,27 @@ Vision functions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: pad
+
+:hidden:`subsample`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: subsample
+
+:hidden:`upsample_nearest`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: upsample_nearest
+
+:hidden:`upsample_bilinear`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: upsample_bilinear
+
+:hidden:`upsample_trilinear`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: upsample_trilinear
+
 
 torch.nn.init
 =============

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2085,6 +2085,68 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=0), (input1, input2)))
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
 
+    def test_subsampling2d(self):
+        m = nn.Subsampling2d(1, 2, stride=2)
+        m.weight.data[:] = 1.0 / 4.0
+        m.bias.data[:] = 1.0
+        in_t = torch.ones(1, 1, 4, 4)
+        out_t = m(Variable(in_t))
+        self.assertEqual(2.0 * torch.ones(1, 1, 2, 2), out_t)
+
+        input = Variable(torch.randn(1, 1, 4, 4), requires_grad=True)
+        weight = Parameter(torch.randn(1))
+        bias = Parameter(torch.randn(1))
+        self.assertTrue(gradcheck(lambda x: F.subsample(x, weight, bias, 2), (input,)))
+
+    def test_subsampling3d(self):
+        m = nn.Subsampling3d(1, 2, stride=2)
+        m.weight.data[:] = 1.0 / 8.0
+        m.bias.data[:] = 1.0
+        in_t = torch.ones(1, 1, 4, 4, 4)
+        out_t = m(Variable(in_t))
+        self.assertEqual(2.0 * torch.ones(1, 1, 2, 2, 2), out_t)
+
+        input = Variable(torch.randn(1, 1, 4, 4, 4), requires_grad=True)
+        weight = Parameter(torch.randn(1))
+        bias = Parameter(torch.randn(1))
+        self.assertTrue(gradcheck(lambda x: F.subsample(x, weight, bias, 2), (input,)))
+
+    def test_upsamplingNearest2d(self):
+        m = nn.UpsamplingNearest2d(size=4)
+        in_t = torch.ones(1, 1, 2, 2)
+        out_t = m(Variable(in_t))
+        self.assertEqual(torch.ones(1, 1, 4, 4), out_t)
+
+        input = Variable(torch.randn(1, 1, 2, 2), requires_grad=True)
+        self.assertTrue(gradcheck(lambda x: F.upsample_nearest(x, 4), (input,)))
+
+    def test_upsamplingNearest3d(self):
+        m = nn.UpsamplingNearest3d(size=4)
+        in_t = torch.ones(1, 1, 2, 2, 2)
+        out_t = m(Variable(in_t))
+        self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t)
+
+        input = Variable(torch.randn(1, 1, 2, 2, 2), requires_grad=True)
+        self.assertTrue(gradcheck(lambda x: F.upsample_nearest(x, 4), (input,)))
+
+    def test_upsamplingBilinear2d(self):
+        m = nn.UpsamplingBilinear2d(size=4)
+        in_t = torch.ones(1, 1, 2, 2)
+        out_t = m(Variable(in_t))
+        self.assertEqual(torch.ones(1, 1, 4, 4), out_t)
+
+        input = Variable(torch.randn(1, 1, 2, 2), requires_grad=True)
+        self.assertTrue(gradcheck(lambda x: F.upsample_bilinear(x, 4), (input,)))
+
+    def test_upsamplingTrilinear3d(self):
+        m = nn.UpsamplingTrilinear3d(size=4)
+        in_t = torch.ones(1, 1, 2, 2, 2)
+        out_t = m(Variable(in_t))
+        self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t)
+
+        input = Variable(torch.randn(1, 1, 2, 2, 2), requires_grad=True)
+        self.assertTrue(gradcheck(lambda x: F.upsample_trilinear(x, 4), (input,)))
+
     def test_bilinear(self):
         module = nn.Bilinear(10, 10, 8)
         module2 = legacy.Bilinear(10, 10, 8)
@@ -2915,6 +2977,28 @@ new_module_tests = [
         input_size=(1, 9, 4, 4),
     ),
     dict(
+        module_name='Subsampling2d',
+        constructor_args=(2, 1),
+        input_size=(1, 2, 4, 4),
+    ),
+    dict(
+        module_name='Subsampling2d',
+        constructor_args=((2, 3), (1, 2)),
+        input_size=(1, 2, 8, 8),
+        desc='tuple'
+    ),
+    dict(
+        module_name='Subsampling3d',
+        constructor_args=(2, 1),
+        input_size=(1, 2, 4, 4, 4),
+    ),
+    dict(
+        module_name='Subsampling3d',
+        constructor_args=(2, (2, 3, 3), (1, 2, 2)),
+        input_size=(1, 2, 8, 8, 8),
+        desc='tuple'
+    ),
+    dict(
         module_name='UpsamplingNearest2d',
         constructor_args=(12,),
         input_size=(1, 2, 4, 4),
@@ -2929,6 +3013,23 @@ new_module_tests = [
         module_name='UpsamplingNearest2d',
         constructor_args=(None, 4),
         input_size=(1, 2, 4, 4),
+        desc='scale'
+    ),
+    dict(
+        module_name='UpsamplingNearest3d',
+        constructor_args=(12,),
+        input_size=(1, 2, 4, 4, 4),
+    ),
+    dict(
+        module_name='UpsamplingNearest3d',
+        constructor_args=((12, 16, 16),),
+        input_size=(1, 2, 3, 4, 4),
+        desc='tuple'
+    ),
+    dict(
+        module_name='UpsamplingNearest3d',
+        constructor_args=(None, 4),
+        input_size=(1, 2, 4, 4, 4),
         desc='scale'
     ),
     dict(
@@ -2959,6 +3060,23 @@ new_module_tests = [
         constructor_args=(None, (2, 1)),
         input_size=(1, 2, 4, 4),
         desc='scale_tuple_skewed'
+    ),
+    dict(
+        module_name='UpsamplingTrilinear3d',
+        constructor_args=(12,),
+        input_size=(1, 2, 4, 4, 4),
+    ),
+    dict(
+        module_name='UpsamplingTrilinear3d',
+        constructor_args=((4, 6, 6),),
+        input_size=(1, 2, 2, 3, 3),
+        desc='tuple'
+    ),
+    dict(
+        module_name='UpsamplingTrilinear3d',
+        constructor_args=(None, 4),
+        input_size=(1, 2, 4, 4, 4),
+        desc='scale'
     ),
     dict(
         module_name='AdaptiveMaxPool1d',

--- a/torch/lib/THCUNN/VolumetricSubSampling.cu
+++ b/torch/lib/THCUNN/VolumetricSubSampling.cu
@@ -1,0 +1,300 @@
+#include "THCUNN.h"
+#include "THCHalf.h"
+#include "THCHalfAutoNumerics.cuh"
+#include "THCAtomics.cuh"
+
+#define CUDA_MAX_THREADS 1024   // this is safe, in reality 256 is our limit
+
+/*
+ * Description:
+ *    this function subsamples an input 3D tensor along dimensions 1 and 2
+ *    3D input, 3D output, 1D weight, 1D bias
+ */
+ template <typename Dtype, typename Acctype>
+__global__ void vsubsample(Dtype *input, Dtype *output, Dtype *weight, Dtype *bias,
+                           int input_n, int input_t, int input_h, int input_w,
+                           int kT, int kH, int kW, int dT, int dH, int dW)
+{
+  // iterators
+  int xx, yy, zz;
+
+  // output size
+  int output_w = (input_w - kW) / dW + 1;
+  int output_h = (input_h - kH) / dH + 1;
+  int output_t = (input_t - kT) / dT + 1;
+
+  // compute offsets based on thread/block ID
+  int o = blockIdx.x;
+  int i = o;
+  int k = blockIdx.x % input_n;
+
+  int xx_start = threadIdx.x;
+  int xx_end = output_w;
+  int xx_step = blockDim.x;
+
+  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
+  int yy_end = output_h;
+  int yy_step = blockDim.y*gridDim.y;
+
+  int zz_start = blockDim.z*blockIdx.z + threadIdx.z;
+  int zz_end = output_t;
+  int zz_step = blockDim.z*gridDim.z;
+
+  // select input/output plane
+  output = output + o*output_w*output_h*output_t;
+  input = input + i*input_w*input_h*input_t;
+
+  // Get the good mask for (k,i) (k out, i in)
+  Dtype the_weight = weight[k];
+
+  // Initialize to the bias
+  Dtype the_bias = bias[k];
+
+  // For all output pixels...
+  for(zz = zz_start; zz < zz_end; zz+=zz_step) {
+    for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+      for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+        // Compute the mean of the input image...
+        Dtype *ptr_input = input + zz*dT*input_h*input_w + yy*dH*input_w + xx*dW;
+        Dtype *ptr_output = output + zz*output_h*output_w + yy*output_w + xx;
+        Acctype sum = 0;
+        int kx, ky, kz;
+        for(kz = 0; kz < kT; kz++) {
+          for(ky = 0; ky < kH; ky++) {
+            for(kx = 0; kx < kW; kx++)
+              sum += ptr_input[ky*input_w+kx];
+          }
+          ptr_input += input_h*input_w; // next input plane
+        }
+        // Update output
+        *ptr_output = ScalarConvert<Acctype, Dtype>::to(the_weight*sum + the_bias);
+      }
+    }
+  }
+}
+
+/*
+ * Description:
+ *    this function computes the gradWeight from input and gradOutput
+ */
+ template <typename Dtype, typename Acctype>
+__global__ void vsubgradweight(Dtype *input, Dtype *gradOutput, Dtype *gradWeight, Dtype *gradBias,
+                               int input_n, int input_t, int input_h, int input_w,
+                               int kT, int kH, int kW, int dT, int dH, int dW,
+                               float scale)
+{
+  // iterators
+  int xx, yy, zz;
+
+  // output size
+  int output_w = (input_w - kW) / dW + 1;
+  int output_h = (input_h - kH) / dH + 1;
+  int output_t = (input_t - kT) / dT + 1;
+
+  // compute offsets based on thread/block ID
+  int o = blockIdx.x;
+  int i = o;
+  int k = blockIdx.x % input_n;
+
+  int xx_start = threadIdx.x;
+  int xx_end = output_w;
+  int xx_step = blockDim.x;
+
+  int yy_start = threadIdx.y;
+  int yy_end = output_h;
+  int yy_step = blockDim.y;
+
+  int zz_start = threadIdx.z;
+  int zz_end = output_t;
+  int zz_step = blockDim.z;
+
+  // select input/output plane
+  gradOutput = gradOutput + o*output_w*output_h*output_t;
+  input = input + i*input_w*input_h*input_t;
+
+  // thread ID
+  int tid = blockDim.y*blockDim.x*threadIdx.z + blockDim.x*threadIdx.y + threadIdx.x;
+
+  // create array to hold partial sums
+  __shared__ Acctype sums[CUDA_MAX_THREADS];
+  sums[tid] = 0;
+
+  // compute partial sums
+  for(zz = zz_start; zz < zz_end; zz+=zz_step) {
+    for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+      for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+        Dtype *ptr_input = input + zz*dT*input_h*input_w + yy*dH*input_w + xx*dW;
+        Dtype *ptr_gradOutput = gradOutput + zz*output_h*output_w + yy*output_w + xx;
+        Dtype z = *ptr_gradOutput;
+        long kx, ky, kz;
+        for(kz = 0; kz < kT; kz++) {
+          for(ky = 0; ky < kH; ky++) {
+            for(kx = 0; kx < kW; kx++) {
+              sums[tid] += z * ptr_input[ky*input_w+kx];
+            }
+          }
+          ptr_input += input_h*input_w;
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  // reduce: accumulate all partial sums to produce final gradWeight
+  if ((threadIdx.x == 0) && (threadIdx.y == 0) && (threadIdx.z == 0)) {
+    Acctype scaledSums = Acctype(0);
+    for(int i = 0; i < blockDim.x*blockDim.y*blockDim.z; i++) {
+      scaledSums += scale*sums[i];
+    }
+    gradWeight[k] += ScalarConvert<Acctype, Dtype>::to(scaledSums);
+  }
+  __syncthreads();
+
+  // compute gradBias
+  sums[tid] = 0;
+  for (int i=tid; i<output_w*output_h*output_t; i+=(blockDim.x*blockDim.y*blockDim.z)) {
+    sums[tid] += gradOutput[i];
+  }
+  __syncthreads();
+
+  // reduce gradBias
+  if ((threadIdx.x == 0) && (threadIdx.y == 0) && (threadIdx.z == 0)) {
+    Acctype scaledSums = Acctype(0);
+    for (int i=0; i<(blockDim.x*blockDim.y*blockDim.z); i++) {
+      scaledSums += scale*sums[i];
+    }
+    gradBias[k] += ScalarConvert<Acctype, Dtype>::to(scaledSums);
+  }
+}
+
+/*
+ * Description:
+ *    this function computes the gradInput from weight and gradOutput
+ */
+ template <typename Dtype>
+__global__ void vsubgradinput(Dtype *gradInput, Dtype *gradOutput, Dtype *weight,
+                              int input_n, int input_t, int input_h, int input_w,
+                              int kT, int kH, int kW, int dT, int dH, int dW)
+{
+  // iterators
+  int xx, yy, zz;
+
+  // output size
+  int output_w = (input_w - kW) / dW + 1;
+  int output_h = (input_h - kH) / dH + 1;
+  int output_t = (input_t - kT) / dT + 1;
+
+  // compute offsets based on thread/block ID
+  int o = blockIdx.x;
+  int i = o;
+  int k = blockIdx.x % input_n;
+
+  int xx_start = threadIdx.x;
+  int xx_end = output_w;
+  int xx_step = blockDim.x;
+
+  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
+  int yy_end = output_h;
+  int yy_step = blockDim.y*gridDim.y;
+
+  int zz_start = blockDim.z*blockIdx.z + threadIdx.z;
+  int zz_end = output_t;
+  int zz_step = blockDim.z*gridDim.z;
+
+  // select input/output plane
+  gradOutput = gradOutput + o*output_w*output_h*output_t;
+  gradInput = gradInput + i*input_w*input_h*input_t;
+
+  // get weight
+  Dtype the_weight = weight[k];
+
+  // compute gradInput
+  for(zz = zz_start; zz < zz_end; zz+=zz_step) {
+    for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+      for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+        Dtype *ptr_gradInput = gradInput + zz*dT*input_h*input_w + yy*dH*input_w + xx*dW;
+        Dtype *ptr_gradOutput = gradOutput + zz*output_h*output_w + yy*output_w + xx;
+        Dtype z = *ptr_gradOutput * the_weight;
+        int kx, ky, kz;
+        for(kz = 0; kz < kT; kz++) {
+          for(ky = 0; ky < kH; ky++) {
+            for(kx = 0; kx < kW; kx++) {
+              // FIXME: should this be done at accreal precision?
+              ptr_gradInput[ky*input_w+kx] += z;
+            }
+          }
+          ptr_gradInput += input_h*input_w;
+        }
+      }
+    }
+  }
+}
+
+/*
+ * Description:
+ *    this function computes the gradInput from weight and gradOutput
+ */
+ template <typename Dtype>
+__global__ void vsubgradinputAtomic(Dtype *gradInput, Dtype *gradOutput, Dtype *weight,
+                                    int input_n, int input_t, int input_h, int input_w,
+                                    int kT, int kH, int kW, int dT, int dH, int dW)
+{
+  // iterators
+  int xx, yy, zz;
+
+  // output size
+  int output_w = (input_w - kW) / dW + 1;
+  int output_h = (input_h - kH) / dH + 1;
+  int output_t = (input_t - kT) / dT + 1;
+
+  // compute offsets based on thread/block ID
+  int o = blockIdx.x;
+  int i = o;
+  int k = blockIdx.x % input_n;
+
+  int xx_start = threadIdx.x;
+  int xx_end = output_w;
+  int xx_step = blockDim.x;
+
+  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
+  int yy_end = output_h;
+  int yy_step = blockDim.y*gridDim.y;
+
+  int zz_start = blockDim.z*blockIdx.z + threadIdx.z;
+  int zz_end = output_t;
+  int zz_step = blockDim.z*gridDim.z;
+
+  // select input/output plane
+  gradOutput = gradOutput + o*output_w*output_h*output_t;
+  gradInput = gradInput + i*input_w*input_h*input_t;
+
+  // get weight
+  Dtype the_weight = weight[k];
+
+  // compute gradInput
+  for(zz = zz_start; zz < zz_end; zz+=zz_step) {
+    for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+      for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+        Dtype *ptr_gradInput = gradInput + zz*dT*input_h*input_w + yy*dH*input_w + xx*dW;
+        Dtype *ptr_gradOutput = gradOutput + zz*output_h*output_w + yy*output_w + xx;
+        Dtype z = *ptr_gradOutput * the_weight;
+        int kx, ky, kz;
+        for(kz = 0; kz < kT; kz++) {
+          for(ky = 0; ky < kH; ky++) {
+            for(kx = 0; kx < kW; kx++) {
+              // FIXME: should this be done at accreal precision?
+              atomicAdd(&(ptr_gradInput[ky*input_w+kx]), z);
+            }
+          }
+          ptr_gradInput += input_h*input_w;
+        }
+      }
+    }
+  }
+}
+
+
+#include "generic/VolumetricSubSampling.cu"
+#include "THCGenerateFloatTypes.h"
+
+#undef CUDA_MAX_THREADS

--- a/torch/lib/THCUNN/VolumetricUpSamplingNearest.cu
+++ b/torch/lib/THCUNN/VolumetricUpSamplingNearest.cu
@@ -1,0 +1,95 @@
+#include "THCUNN.h"
+#include "common.h"
+
+#include <thrust/transform.h>
+#include <thrust/reduce.h>
+#include <thrust/transform_reduce.h>
+#include <thrust/functional.h>
+
+#include "THCHalf.h"
+#include "THCHalfAutoNumerics.cuh"
+
+/*
+ * Description:
+ */
+
+__device__ int translate_idx(int ii, int d1, int d2, int d3, int d4, int scale_factor)
+{
+  int x, y, z, w, v;
+  v = ii % d4;
+  ii = ii/d4;
+  w = ii % d3;
+  ii = ii/d3;
+  z = ii % d2;
+  ii = ii/d2;
+  y = ii % d1;
+  ii = ii/d1;
+  x = ii;
+  v = v/scale_factor;
+  w = w/scale_factor;
+  z = z/scale_factor;
+  d2 /= scale_factor;
+  d3 /= scale_factor;
+  d4 /= scale_factor;
+  return ((((x*d1+y)*d2)+z)*d3+w)*d4+v;
+
+}
+__device__ int translate_idx_inv(int ii, int d1, int d2, int d3, int d4, int scale_factor, int off_x, int off_y, int off_z)
+{
+  int x, y, z, w, v;
+  v = ii % d4;
+  ii = ii/d4;
+  w = ii % d3;
+  ii = ii/d3;
+  z = ii % d2;
+  ii = ii/d2;
+  y = ii % d1;
+  ii = ii/d1;
+  x = ii;
+  v = v*scale_factor+off_x;
+  w = w*scale_factor+off_y;
+  z = z*scale_factor+off_z;
+  d2 *= scale_factor;
+  d3 *= scale_factor;
+  d4 *= scale_factor;
+  return ((((x*d1+y)*d2)+z)*d3+w)*d4+v;
+
+}
+
+template <typename Dtype>
+__global__ void vupscale(Dtype *input, Dtype *output, long no_elements,
+                         int scale_factor, int d1, int d2, int d3, int d4)
+{
+  // output offset:
+  long ii = threadIdx.x + blockDim.x * blockIdx.x;
+  ii += threadIdx.y + blockDim.y * (blockDim.x * gridDim.x) * blockIdx.y;
+  if (ii >= no_elements) return;
+  int ipidx = translate_idx(ii, d1, d2, d3, d4, scale_factor);
+  output[ii]=input[ipidx];
+}
+
+/*
+ * Description:
+ */
+template <typename Dtype, typename Acctype>
+__global__ void vdownscale(Dtype *gradInput_data, Dtype *gradOutput_data, long no_elements,
+                              int scale_factor, int d1, int d2, int d3, int d4)
+{
+  // output offset:
+  long ii = threadIdx.x + blockDim.x * blockIdx.x;
+  ii += threadIdx.y + blockDim.y * (blockDim.x * gridDim.x) * blockIdx.y;
+  if (ii >= no_elements) return;
+  Acctype sum = Acctype(0);
+  for (int i=0; i < scale_factor; i++){
+    for(int j=0; j < scale_factor; j++){
+      for(int k=0; k < scale_factor; k++){
+        int ipidx = translate_idx_inv(ii, d1, d2, d3, d4, scale_factor, i, j, k);
+        sum += gradOutput_data[ipidx];
+      }
+    }
+  }
+  gradInput_data[ii] += ScalarConvert<Acctype, Dtype>::to(sum);
+}
+
+#include "generic/VolumetricUpSamplingNearest.cu"
+#include "THCGenerateFloatTypes.h"

--- a/torch/lib/THCUNN/VolumetricUpSamplingTrilinear.cu
+++ b/torch/lib/THCUNN/VolumetricUpSamplingTrilinear.cu
@@ -1,0 +1,155 @@
+// Adapted from interp.cpp from Caffe util by Pauline Luc
+// Originally developed by George Papandreou
+#include "THCUNN.h"
+#include "common.h"
+#include "THCDeviceTensor.cuh"
+#include "THCDeviceTensorUtils.cuh"
+#include "THCDeviceUtils.cuh"
+#include "THCHalf.h"
+#include "THCHalfAutoNumerics.cuh"
+#include "THCAtomics.cuh"
+
+template<typename Dtype, typename Acctype>
+__global__ void caffe_gpu_interp2_kernel(const int n,
+    const Acctype rdepth, const Acctype rheight, const Acctype rwidth,
+    const THCDeviceTensor<Dtype, 5> data1, THCDeviceTensor<Dtype, 5> data2) {
+  int index = threadIdx.x + blockIdx.x * blockDim.x;
+  const int batchsize = data1.getSize(0);
+  const int channels = data1.getSize(1);
+  const int depth1 = data1.getSize(2);
+  const int height1 = data1.getSize(3);
+  const int width1 = data1.getSize(4);
+  const int depth2 = data2.getSize(2);
+  const int height2 = data2.getSize(3);
+  const int width2 = data2.getSize(4);
+
+  if (index < n) {
+    const int w2 = (index % (height2*width2)) % width2; // 0:width2-1
+    const int h2 = (index % (height2*width2)) / width2; // 0:height2-1
+    const int t2 = index / (height2*width2);            // 0:depth2-1
+    // special case: just copy
+    if (depth1 == depth2 && height1 == height2 && width1 == width2) {
+      const int t1 = t2;
+      const int h1 = h2;
+      const int w1 = w2;
+      for (int n = 0; n < batchsize ; n++){
+        for (int c = 0; c < channels; ++c) {
+          const Dtype val = data1[n][c][t1][h1][w1];
+          data2[n][c][t2][h2][w2] = val;
+        }
+      }
+      return;
+    }
+    //
+    const Acctype t1r = rdepth * t2;
+    const int t1 = t1r;
+    const int t1p = (t1 < depth1 - 1) ? 1 : 0;
+    const Acctype t1lambda = t1r - t1;
+    const Acctype t0lambda = Acctype(1) - t1lambda;
+    //
+    const Acctype h1r = rheight * h2;
+    const int h1 = h1r;
+    const int h1p = (h1 < height1 - 1) ? 1 : 0;
+    const Acctype h1lambda = h1r - h1;
+    const Acctype h0lambda = Acctype(1) - h1lambda;
+    //
+    const Acctype w1r = rwidth * w2;
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const Acctype w1lambda = w1r - w1;
+    const Acctype w0lambda = Acctype(1) - w1lambda;
+    //
+    for (int n = 0; n < batchsize ; n++){
+        for (int c = 0; c < channels; ++c) {
+        const Acctype val = t0lambda * (h0lambda * (w0lambda * data1[n][c][t1][h1][w1] 
+                                                  + w1lambda * data1[n][c][t1][h1][w1+w1p])
+                                      + h1lambda * (w0lambda * data1[n][c][t1][h1+h1p][w1]
+                                                  + w1lambda * data1[n][c][t1][h1+h1p][w1+w1p]))
+                          + t1lambda * (h0lambda * (w0lambda * data1[n][c][t1+t1p][h1][w1] 
+                                                  + w1lambda * data1[n][c][t1+t1p][h1][w1+w1p])
+                                      + h1lambda * (w0lambda * data1[n][c][t1+t1p][h1+h1p][w1]
+                                                  + w1lambda * data1[n][c][t1+t1p][h1+h1p][w1+w1p]));
+        data2[n][c][t2][h2][w2] = ScalarConvert<Acctype, Dtype>::to(val);
+      }
+    }
+  }
+}
+
+// Backward (adjoint) operation 1 <- 2 (accumulates)
+template <typename Dtype, typename Acctype>
+__global__ void caffe_gpu_interp2_kernel_backward(const int n,
+    const Acctype rdepth, const Acctype rheight, const Acctype rwidth,
+    THCDeviceTensor<Dtype, 5> data1, const THCDeviceTensor<Dtype, 5> data2){
+  int index = threadIdx.x + blockIdx.x * blockDim.x;
+  const int batchsize = data1.getSize(0);
+  const int channels = data1.getSize(1);
+  const int depth1 = data1.getSize(2);
+  const int height1 = data1.getSize(3);
+  const int width1 = data1.getSize(4);
+  const int depth2 = data2.getSize(2);
+  const int height2 = data2.getSize(3);
+  const int width2 = data2.getSize(4);
+  if (index < n) {
+    const int w2 = (index % (height2*width2)) % width2; // 0:width2-1
+    const int h2 = (index % (height2*width2)) / width2; // 0:height2-1
+    const int t2 = index / (height2*width2);            // 0:depth2-1
+    // special case: just copy
+    if (depth1 == depth2 && height1 == height2 && width1 == width2) {
+      const int t1 = t2;
+      const int h1 = h2;
+      const int w1 = w2;
+      for (int n = 0; n < batchsize ; n++){
+        for (int c = 0; c < channels; ++c) {
+          const Dtype val = data2[n][c][t1][h1][w1];
+          data1[n][c][t2][h2][w2] += val;
+        }
+      }
+      return;
+    }
+    //
+    const Acctype t1r = rdepth * t2;
+    const int t1 = t1r;
+    const int t1p = (t1 < depth1 - 1) ? 1 : 0;
+    const Acctype t1lambda = t1r - t1;
+    const Acctype t0lambda = Acctype(1) - t1lambda;
+    //
+    const Acctype h1r = rheight * h2;
+    const int h1 = h1r;
+    const int h1p = (h1 < height1 - 1) ? 1 : 0;
+    const Acctype h1lambda = h1r - h1;
+    const Acctype h0lambda = Acctype(1) - h1lambda;
+    //
+    const Acctype w1r = rwidth * w2;
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const Acctype w1lambda = w1r - w1;
+    const Acctype w0lambda = Acctype(1) - w1lambda;
+    //
+    for (int n = 0; n < batchsize ; n++){
+      for (int c = 0; c < channels; ++c) {
+        const Dtype d2val = data2[n][c][t2][h2][w2];
+        atomicAdd(data1[n][c][t1][h1][w1].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t0lambda * h0lambda * w0lambda * d2val));
+        atomicAdd(data1[n][c][t1][h1][w1+w1p].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t0lambda * h0lambda * w1lambda * d2val));
+        atomicAdd(data1[n][c][t1][h1+h1p][w1].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t0lambda * h1lambda * w0lambda * d2val));
+        atomicAdd(data1[n][c][t1][h1+h1p][w1+w1p].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t0lambda * h1lambda * w1lambda * d2val));
+        atomicAdd(data1[n][c][t1+t1p][h1][w1].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t1lambda * h0lambda * w0lambda * d2val));
+        atomicAdd(data1[n][c][t1+t1p][h1][w1+w1p].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t1lambda * h0lambda * w1lambda * d2val));
+        atomicAdd(data1[n][c][t1+t1p][h1+h1p][w1].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t1lambda * h1lambda * w0lambda * d2val));
+        atomicAdd(data1[n][c][t1+t1p][h1+h1p][w1+w1p].data(),
+                  ScalarConvert<Acctype, Dtype>::to(t1lambda * h1lambda * w1lambda * d2val));
+      }
+    }
+  }
+  /////////////////////////////////////////////////////////
+}
+
+
+#include "generic/VolumetricUpSamplingTrilinear.cu"
+#include "THCGenerateFloatTypes.h"

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -1328,4 +1328,66 @@ TH_API void THNN_(VolumetricReplicationPadding_updateGradInput)(
                   int ptop, int pbottom,
                   int pfront, int pback);
 
+TH_API void THNN_(VolumetricSubSampling_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  THCTensor *weight,
+                  THCTensor *bias,
+                  int kT, int kW, int kH,
+                  int dT, int dW, int dH);
+
+TH_API void THNN_(VolumetricSubSampling_updateGradInput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  THCTensor *weight,
+                  int kT, int kW, int kH,
+                  int dT, int dW, int dH);
+
+TH_API void THNN_(VolumetricSubSampling_accGradParameters)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradWeight,
+                  THCTensor *gradBias,
+                  int kT, int kW, int kH,
+                  int dT, int dW, int dH,
+                  accreal scale);
+
+TH_API void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  int scale_factor);
+
+TH_API void THNN_(VolumetricUpSamplingNearest_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  int scale_factor);
+
+TH_API void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  int outputDepth,
+                  int outputHeight,
+                  int outputWidth);
+
+TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
+                  THCState *state,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  int nbatch,
+                  int nchannels,
+                  int inputDepth,
+                  int inputHeight,
+                  int inputWidth,
+                  int outputDepth,
+                  int outputHeight,
+                  int outputWidth);
+
 #endif

--- a/torch/lib/THCUNN/generic/VolumetricSubSampling.cu
+++ b/torch/lib/THCUNN/generic/VolumetricSubSampling.cu
@@ -1,0 +1,270 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/VolumetricSubSampling.cu"
+#else
+
+#include "../common.h"
+
+static inline void THNN_(VolumetricSubSampling_shapeCheck)(
+                         THCState *state,
+                         THCTensor *input,
+                         THCTensor *gradOutput,
+                         THCTensor *weight,
+                         int kW, int kH, int kT) {
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D input tensor expected but got: %s");
+
+  int nInputPlane = THCTensor_(size)(state, weight, 0);
+
+  int dimc = 3;
+  int dimr = 2;
+  int dimt = 1;
+  int dimp = 0;
+
+  if (input->nDimension == 5) {
+    dimc++;
+    dimr++;
+    dimt++;
+    dimp++;
+  }
+
+  long nInputCols = input->size[dimc];
+  long nInputRows = input->size[dimr];
+  long nInputFrames = input->size[dimt];
+  THArgCheck(input->size[dimp] == nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(nInputCols >= kW && nInputRows >= kH && nInputFrames >= kT, 2, "input image smaller than kernel size");
+}
+
+void THNN_(VolumetricSubSampling_updateOutput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *output,
+           THCTensor *weight,
+           THCTensor *bias,
+           int kW, int kH, int kT,
+           int dW, int dH, int dT)
+{
+  real *weight_data = THCTensor_(data)(state, weight);
+  real *bias_data = THCTensor_(data)(state, bias);
+  real *output_data;
+  real *input_data;
+
+  int nInputPlane = THCTensor_(size)(state, weight, 0);
+
+  THCUNN_assertSameGPU(state, 4, input, output, weight, bias);
+  THNN_(VolumetricSubSampling_shapeCheck)(state, input, NULL, weight, kW, kH, kT);
+
+  if (input->nDimension == 4) {
+    long nInputCols = input->size[3];
+    long nInputRows = input->size[2];
+    long nInputFrames = input->size[1];
+    long nOutputCols = (nInputCols - kW) / dW + 1;
+    long nOutputRows = (nInputRows - kH) / dH + 1;
+    long nOutputFrames = (nInputFrames - kT) / dT + 1;
+
+    input = THCTensor_(newContiguous)(state, input);
+    input_data = THCTensor_(data)(state, input);
+
+    THCTensor_(resize4d)(state, output, nInputPlane, nOutputFrames, nOutputRows, nOutputCols);
+    output_data = THCTensor_(data)(state, output);
+
+    // cuda blocks & threads:
+    int zblocks = (int)(16L / nInputPlane);
+    zblocks = zblocks < 1 ? 1 : zblocks;
+    dim3 blocks(nInputPlane,zblocks);
+    dim3 threads(32,8);
+
+    // run subsample kernel
+    vsubsample<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+      input_data, output_data, weight_data, bias_data,
+      nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    THCudaCheck(cudaGetLastError());
+  } else {
+    long nInputCols = input->size[4];
+    long nInputRows = input->size[3];
+    long nInputFrames = input->size[2];
+    long nbatch = input->size[0];
+    long nOutputCols = (nInputCols - kW) / dW + 1;
+    long nOutputRows = (nInputRows - kH) / dH + 1;
+    long nOutputFrames = (nInputFrames - kT) / dT + 1;
+
+    input = THCTensor_(newContiguous)(state, input);
+    input_data = THCTensor_(data)(state, input);
+
+    THCTensor_(resize5d)(state, output, nbatch, nInputPlane, nOutputFrames, nOutputRows, nOutputCols);
+    output_data = THCTensor_(data)(state, output);
+
+    // cuda blocks & threads:
+    int zblocks = (int)(16L / nInputPlane);
+    zblocks = zblocks < 1 ? 1 : zblocks;
+    dim3 blocks(nInputPlane*nbatch,zblocks);
+    dim3 threads(32,8);
+
+    // run subsample kernel
+    vsubsample<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+      input_data, output_data, weight_data, bias_data,
+      nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    THCudaCheck(cudaGetLastError());
+  }
+
+  // clean
+  THCTensor_(free)(state, input);
+
+}
+
+void THNN_(VolumetricSubSampling_updateGradInput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *gradOutput,
+           THCTensor *gradInput,
+           THCTensor *weight,
+           int kW, int kH, int kT,
+           int dW, int dH, int dT)
+{
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
+  THNN_(VolumetricSubSampling_shapeCheck)(state, input, gradOutput, weight, kW, kH, kT);
+
+  int nInputPlane = THCTensor_(size)(state, weight, 0);
+
+  if (input->nDimension == 4) {
+    long nInputCols = input->size[3];
+    long nInputRows = input->size[2];
+    long nInputFrames = input->size[1];
+
+    real *weight_data = THCTensor_(data)(state, weight);
+    gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+    real *gradOutput_data = THCTensor_(data)(state, gradOutput);
+    real *gradInput_data;
+
+    THCTensor_(resizeAs)(state, gradInput, input);
+    THCTensor_(zero)(state, gradInput);
+    gradInput_data = THCTensor_(data)(state, gradInput);
+
+    // cuda blocks & threads:
+    int zblocks = (int)(16L / nInputPlane);
+    zblocks = zblocks < 1 ? 1 : zblocks;
+    dim3 blocks(nInputPlane,zblocks);
+    dim3 threads(32,8);
+
+    // run updateGradInput kernel
+    if (kT <= dT && kH <= dH && kW <= dW) {
+      vsubgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+        gradInput_data, gradOutput_data, weight_data,
+        nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    } else {
+      vsubgradinputAtomic <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+        gradInput_data, gradOutput_data, weight_data,
+        nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    }
+    THCudaCheck(cudaGetLastError());
+  } else {
+    long nInputCols = input->size[4];
+    long nInputRows = input->size[3];
+    long nInputFrames = input->size[2];
+    long nbatch = input->size[0];
+
+    real *weight_data = THCTensor_(data)(state, weight);
+    gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+    real *gradOutput_data = THCTensor_(data)(state, gradOutput);
+    real *gradInput_data;
+
+    THCTensor_(resizeAs)(state, gradInput, input);
+    THCTensor_(zero)(state, gradInput);
+    gradInput_data = THCTensor_(data)(state, gradInput);
+
+    // cuda blocks & threads:
+    int zblocks = (int)(16L / nInputPlane);
+    zblocks = zblocks < 1 ? 1 : zblocks;
+    dim3 blocks(nInputPlane*nbatch,zblocks);
+    dim3 threads(32,8);
+
+    // run updateGradInput kernel
+    if (kT <= dT && kH <= dH && kW <= dW) {
+      vsubgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+        gradInput_data, gradOutput_data, weight_data,
+        nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    } else {
+      vsubgradinputAtomic <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+        gradInput_data, gradOutput_data, weight_data,
+        nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW);
+    }
+    THCudaCheck(cudaGetLastError());
+  }
+  THCTensor_(free)(state, gradOutput);
+}
+
+void THNN_(VolumetricSubSampling_accGradParameters)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *gradOutput,
+           THCTensor *gradWeight,
+           THCTensor *gradBias,
+           int kW, int kH, int kT,
+           int dW, int dH, int dT,
+           accreal scale)
+{
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, gradWeight, gradBias);
+  THNN_(VolumetricSubSampling_shapeCheck)(state, input, gradOutput, gradWeight, kW, kH, kT);
+
+  int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
+
+  if (input->nDimension == 4) {
+    long nInputCols = input->size[3];
+    long nInputRows = input->size[2];
+    long nInputFrames = input->size[1];
+
+    real *gradWeight_data = THCTensor_(data)(state, gradWeight);
+    real *gradBias_data = THCTensor_(data)(state, gradBias);
+    gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+    real *gradOutput_data = THCTensor_(data)(state, gradOutput);
+    real *input_data;
+
+    input = THCTensor_(newContiguous)(state, input);
+    input_data = THCTensor_(data)(state, input);
+
+    // cuda blocks & threads:
+    dim3 blocks(nInputPlane);
+    dim3 threads(32,8);
+
+    // run gradweight kernel
+    vsubgradweight<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+      input_data, gradOutput_data, gradWeight_data, gradBias_data,
+      nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW, scale);
+    THCudaCheck(cudaGetLastError());
+  } else {
+    long nInputCols = input->size[4];
+    long nInputRows = input->size[3];
+    long nInputFrames = input->size[2];
+    long nbatch = input->size[0];
+
+    real *gradWeight_data = THCTensor_(data)(state, gradWeight);
+    real *gradBias_data = THCTensor_(data)(state, gradBias);
+    gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+    real *gradOutput_data = THCTensor_(data)(state, gradOutput);
+    real *input_data;
+
+    input = THCTensor_(newContiguous)(state, input);
+    input_data = THCTensor_(data)(state, input);
+
+    // cuda blocks & threads:
+    dim3 blocks(nInputPlane);
+    dim3 threads(32,8);
+
+    // run gradweight kernel
+    long sl;
+    for (sl=0; sl<nbatch; sl++) {
+      vsubgradweight<real, accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (
+        input_data + sl*input->stride[0],
+        gradOutput_data + sl*gradOutput->stride[0],
+        gradWeight_data, gradBias_data,
+        nInputPlane, nInputFrames, nInputRows, nInputCols, kT, kH, kW, dT, dH, dW, scale);
+    }
+    THCudaCheck(cudaGetLastError());
+  }
+
+  // clean
+  THCTensor_(free)(state, input);
+  THCTensor_(free)(state, gradOutput);
+
+}
+
+#endif

--- a/torch/lib/THCUNN/generic/VolumetricUpSamplingNearest.cu
+++ b/torch/lib/THCUNN/generic/VolumetricUpSamplingNearest.cu
@@ -1,0 +1,185 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/VolumetricUpSamplingNearest.cu"
+#else
+
+#include "../common.h"
+
+static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
+                        (THCState *state,THCTensor *input, THCTensor *gradOutput,
+                         int scale_factor) {
+  THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
+  THArgCheck(scale_factor > 1, 4,
+             "scale_factor must be greater than 1, but got: %d", scale_factor);
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D input tensor expected but got: %s");
+  if (input->nDimension == 4) {
+    int nChannels    = THCTensor_(size)(state, input, 0);
+    int inputDepth   = THCTensor_(size)(state, input, 1);
+    int inputHeight  = THCTensor_(size)(state, input, 2);
+    int inputWidth   = THCTensor_(size)(state, input, 3);
+    int outputDepth  = inputDepth * scale_factor;
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THCUNN_check_dim_size(state, gradOutput, 4, 0, nChannels);
+      THCUNN_check_dim_size(state, gradOutput, 4, 1, outputDepth);
+      THCUNN_check_dim_size(state, gradOutput, 4, 2, outputHeight);
+      THCUNN_check_dim_size(state, gradOutput, 4, 3, outputWidth);
+    }
+  } else {
+    int nBatch       = THCTensor_(size)(state, input, 0);
+    int nChannels    = THCTensor_(size)(state, input, 1);
+    int inputDepth   = THCTensor_(size)(state, input, 2);
+    int inputHeight  = THCTensor_(size)(state, input, 3);
+    int inputWidth   = THCTensor_(size)(state, input, 4);
+    int outputDepth  = inputDepth  * scale_factor;
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THCUNN_check_dim_size(state, gradOutput, 5, 0, nBatch);
+      THCUNN_check_dim_size(state, gradOutput, 5, 1, nChannels);
+      THCUNN_check_dim_size(state, gradOutput, 5, 2, outputDepth);
+      THCUNN_check_dim_size(state, gradOutput, 5, 3, outputHeight);
+      THCUNN_check_dim_size(state, gradOutput, 5, 4, outputWidth);
+    }
+  }
+}
+
+void THNN_(VolumetricUpSamplingNearest_updateOutput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *output,
+           int scale_factor)
+{
+  THCTensor_(zero)(state, output);
+
+  THCUNN_assertSameGPU(state, 2, input, output);
+  THNN_(VolumetricUpSamplingNearest_shapeCheck)(state, input, NULL, scale_factor);
+  int inputDepth = THCTensor_(size)(state, input, input->nDimension-3);
+  int inputHeight = THCTensor_(size)(state, input, input->nDimension-2);
+  int inputWidth  = THCTensor_(size)(state, input,  input->nDimension-1);
+  int outputDepth = inputDepth * scale_factor;
+  int outputHeight = inputHeight * scale_factor;
+  int outputWidth = inputWidth * scale_factor;
+
+   if (input->nDimension == 4) {
+     THCTensor_(resize4d)(state, output,
+                          THCTensor_(size)(state, input, 0),
+                          outputDepth, outputHeight, outputWidth);
+   } else {
+     THCTensor_(resize5d)(state, output,
+                          THCTensor_(size)(state, input, 0),
+                          THCTensor_(size)(state, input, 1),
+                          outputDepth, outputHeight, outputWidth);
+  }
+
+  input = THCTensor_(newContiguous)(state, input);
+  // This is for allocating output Tensor
+  long no_elements = 1;
+  for(int i = 0; i < input->nDimension; i++){
+    no_elements *= input->size[i];
+  }
+  no_elements *= scale_factor * scale_factor * scale_factor;
+
+  int d1;
+  int d2;
+  int d3;
+  int d4;
+
+  if (input->nDimension == 4) {
+    d1 = output->size[0];
+    d2 = output->size[1];
+    d3 = output->size[2];
+    d4 = output->size[3];
+  } else {
+    d1 = output->size[1];
+    d2 = output->size[2];
+    d3 = output->size[3];
+    d4 = output->size[4];
+  }
+
+  real *input_data = THCTensor_(data)(state, input);
+  real *output_data = THCTensor_(data)(state, output);
+
+  // cuda blocks & threads:
+  long nthreads = 256;
+  // Max number of blocks: http://en.wikipedia.org/wiki/CUDA
+  // 65535 for SM 2.x, 2^32 -1 for >= 3.0
+  // TODO: When we move to SM 3.5 we should update this
+  long n_xblocks = min(max((int)ceil((float)no_elements / nthreads), 1), 65535);
+  long n_yblocks = (long)ceil((float)no_elements / (float)(n_xblocks * nthreads));
+  if (n_yblocks > 65535) {
+    THError("Input size is too large!  aborting");
+  }
+  dim3 blocks(n_xblocks, n_yblocks);
+  dim3 threads(nthreads);
+
+  // kernel:
+  vupscale<<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data, no_elements, scale_factor, d1, d2, d3, d4);
+  THCudaCheck(cudaGetLastError());
+
+  // final cut:
+  THCTensor_(free)(state, input);
+}
+
+void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *gradOutput,
+           THCTensor *gradInput,
+           int scale_factor)
+{
+
+  THCUNN_assertSameGPU(state, 2, gradOutput, gradInput);
+  THNN_(VolumetricUpSamplingNearest_shapeCheck)(state, input, gradOutput, scale_factor);
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+  THCTensor_(resizeAs)(state, gradInput, input);
+
+  THCTensor_(zero)(state, gradInput);
+
+  real *gradInput_data = THCTensor_(data)(state, gradInput);
+  real *gradOutput_data = THCTensor_(data)(state, gradOutput);
+
+  long no_elements = 1;
+  for(int i = 0; i < gradInput->nDimension; i++){
+    no_elements *= gradInput->size[i];
+  }
+
+  int d1;
+  int d2;
+  int d3;
+  int d4;
+
+  if (gradInput->nDimension == 4) {
+    d1 = gradInput->size[0];
+    d2 = gradInput->size[1];
+    d3 = gradInput->size[2];
+    d4 = gradInput->size[3];
+  } else {
+    d1 = gradInput->size[1];
+    d2 = gradInput->size[2];
+    d3 = gradInput->size[3];
+    d4 = gradInput->size[4];
+  }
+
+  // cuda blocks & threads:
+  long nthreads = 256;
+  // Max number of blocks: http://en.wikipedia.org/wiki/CUDA
+  // 65535 for SM 2.x, 2^32 -1 for >= 3.0
+  // TODO: When we move to SM 3.5 we should update this
+  long n_xblocks = min(max((int)ceil((float)no_elements / nthreads), 1), 65535);
+  long n_yblocks = (long)ceil((float)no_elements / (float)(n_xblocks * nthreads));
+  if (n_yblocks > 65535) {
+    THError("Input size is too large!  aborting");
+  }
+  dim3 blocks(n_xblocks, n_yblocks);
+  dim3 threads(nthreads);
+
+  // kernel:
+  vdownscale<real ,accreal> <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data, no_elements,
+    scale_factor, d1, d2, d3, d4);
+  THCudaCheck(cudaGetLastError());
+  THCTensor_(free)(state, gradOutput);
+}
+
+#endif

--- a/torch/lib/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/torch/lib/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -1,0 +1,118 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/VolumetricUpSamplingTrilinear.cu"
+#else
+
+static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+                        (THCState *state,
+                         THCTensor *input, THCTensor *gradOutput,
+                         int nBatch, int nChannels,
+                         int inputDepth, int inputHeight, int inputWidth,
+                         int outputDepth, int outputHeight, int outputWidth) {
+  THArgCheck(inputDepth > 0 && inputHeight > 0 && inputWidth > 0
+             && outputDepth && outputHeight > 0 && outputWidth > 0, 2,
+             "input and output sizes should be greater than 0,"
+             " but got input (D: %d, H: %d, W: %d) output (D: %d, H: %d, W: %d)",
+             inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
+  if (input != NULL) {
+     THCUNN_argCheck(state, input->nDimension == 5, 2, input,
+                     "5D input tensor expected but got: %s");
+  }
+
+  if (gradOutput != NULL) {
+    THCUNN_check_dim_size(state, gradOutput, 5, 0, nBatch);
+    THCUNN_check_dim_size(state, gradOutput, 5, 1, nChannels);
+    THCUNN_check_dim_size(state, gradOutput, 5, 2, outputDepth);
+    THCUNN_check_dim_size(state, gradOutput, 5, 3, outputHeight);
+    THCUNN_check_dim_size(state, gradOutput, 5, 4, outputWidth);
+  }
+}
+
+void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *output,
+           int outputDepth,
+           int outputHeight,
+           int outputWidth)
+{
+  int nbatch = THCTensor_(size)(state, input, 0);
+  int channels = THCTensor_(size)(state, input, 1);
+  int inputDepth = THCTensor_(size)(state, input, 2);
+  int inputHeight = THCTensor_(size)(state, input, 3);
+  int inputWidth = THCTensor_(size)(state, input, 4);
+  THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+       (state, input, NULL,
+        nbatch, channels,
+        inputDepth, inputHeight, inputWidth,
+        outputDepth, outputHeight, outputWidth);
+  input = THCTensor_(newContiguous)(state, input);
+  THCUNN_assertSameGPU(state, 2, input, output);
+  THCTensor_(resize5d)(state, output,
+                       THCTensor_(size)(state, input, 0),
+                       THCTensor_(size)(state, input, 1),
+                       outputDepth, outputHeight, outputWidth);
+  THCTensor_(zero)(state, output);
+  THCDeviceTensor<real, 5> idata = toDeviceTensor<real, 5>(state, input);
+  THCDeviceTensor<real, 5> odata = toDeviceTensor<real, 5>(state, output);
+  THAssert(inputDepth > 0 && inputHeight > 0 && inputWidth > 0 && outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
+  const accreal rdepth= (outputDepth > 1) ? (accreal)(inputDepth - 1)/(outputDepth - 1) : accreal(0);
+  const accreal rheight= (outputHeight > 1) ? (accreal)(inputHeight - 1)/(outputHeight - 1) : accreal(0);
+  const accreal rwidth = (outputWidth > 1) ? (accreal)(inputWidth - 1)/(outputWidth - 1) : accreal(0);
+  const int num_kernels = outputDepth * outputHeight * outputWidth;
+  const int num_threads =
+    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  caffe_gpu_interp2_kernel<real, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
+   0 , stream>>>(num_kernels, rdepth, rheight, rwidth, idata, odata);
+  THCudaCheck(cudaGetLastError());
+  THCTensor_(free)(state, input);
+}
+
+
+void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
+           THCState *state,
+           THCTensor *gradOutput,
+           THCTensor *gradInput,
+           int nbatch,
+           int nchannels,
+           int inputDepth,
+           int inputHeight,
+           int inputWidth,
+           int outputDepth,
+           int outputHeight,
+           int outputWidth)
+{
+  THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+       (state, NULL, gradOutput,
+        nbatch, nchannels,
+        inputDepth, inputHeight, inputWidth,
+        outputDepth, outputHeight, outputWidth);
+  gradInput = THCTensor_(newContiguous)(state, gradInput);
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+  THCUNN_assertSameGPU(state, 2, gradOutput, gradInput);
+  THCTensor_(resize5d)(state, gradInput, nbatch, nchannels, inputDepth, inputHeight, inputWidth);
+  THCTensor_(zero)(state, gradInput);
+  THCDeviceTensor<real, 5> data1 = toDeviceTensor<real, 5>(state, gradInput);
+  THCDeviceTensor<real, 5> data2 = toDeviceTensor<real, 5>(state, gradOutput);
+  int depth1 = data1.getSize(2);
+  int height1 = data1.getSize(3);
+  int width1 = data1.getSize(4);
+  int depth2 = data2.getSize(2);
+  int height2 = data2.getSize(3);
+  int width2 = data2.getSize(4);
+  assert(depth1 > 0 && height1 > 0 && width1 > 0 && depth2 > 0 && height2 > 0 && width2 > 0);
+  const accreal rdepth= (depth2 > 1) ? (accreal)(depth1 - 1)/(depth2 - 1) : accreal(0);
+  const accreal rheight= (height2 > 1) ? (accreal)(height1 - 1)/(height2 - 1) : accreal(0);
+  const accreal rwidth = (width2 > 1) ? (accreal)(width1 - 1) / (width2 - 1) : accreal(0);
+  const int num_kernels = depth2 * height2 * width2;
+  const int num_threads =
+    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  caffe_gpu_interp2_kernel_backward<real ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
+  num_threads, 0, stream>>>(num_kernels, rdepth, rheight, rwidth, data1, data2);
+  THCudaCheck(cudaGetLastError());
+  THCTensor_(free)(state, gradInput);
+  THCTensor_(free)(state, gradOutput);
+}
+
+#endif

--- a/torch/lib/THNN/generic/THNN.h
+++ b/torch/lib/THNN/generic/THNN.h
@@ -1426,4 +1426,63 @@ TH_API void THNN_(VolumetricReplicationPadding_updateGradInput)(
           int pleft, int pright,
           int ptop, int pbottom,
           int pfront, int pback);
+
+TH_API void THNN_(VolumetricSubSampling_updateOutput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *output,
+          THTensor *weight,
+          THTensor *bias,
+          int kT, int kW, int kH,
+          int dT, int dW, int dH);
+TH_API void THNN_(VolumetricSubSampling_updateGradInput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *gradOutput,
+          THTensor *gradInput,
+          THTensor *weight,
+          int kT, int kW, int kH,
+          int dT, int dW, int dH);
+TH_API void THNN_(VolumetricSubSampling_accGradParameters)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *gradOutput,
+          THTensor *gradWeight,
+          THTensor *gradBias,
+          int kT, int kW, int kH,
+          int dT, int dW, int dH,
+          accreal scale);
+
+TH_API void THNN_(VolumetricUpSamplingNearest_updateOutput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *output,
+          int scale_factor);
+TH_API void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *gradOutput,
+          THTensor *gradInput,
+          int scale_factor);
+
+TH_API void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *output,
+	  int outputDepth,
+          int outputHeight,
+          int outputWidth);
+TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
+          THNNState *state,
+          THTensor *gradOutput,
+          THTensor *gradInput,
+          int nbatch,
+          int nchannels,
+          int inputDepth,
+          int inputHeight,
+          int inputWidth,
+          int outputDepth,
+          int outputHeight,
+          int outputWidth);
+
 #endif

--- a/torch/lib/THNN/generic/VolumetricSubSampling.c
+++ b/torch/lib/THNN/generic/VolumetricSubSampling.c
@@ -1,0 +1,342 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/VolumetricSubSampling.c"
+#else
+
+static inline void THNN_(VolumetricSubSampling_shapeCheck)(
+                         THTensor *input,
+                         THTensor *gradOutput,
+                         THTensor *weight,
+                         int kW, int kH, int kT) {
+  int ndims = input->nDimension;
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D input tensor expected but got: %s");
+
+  int nInputPlane = THTensor_(size)(weight, 0);
+
+  int dimw = 3;
+  int dimh = 2;
+  int dimt = 1;
+
+  long inputWidth;
+  long inputHeight;
+  long inputDepth;
+
+  if (input->nDimension == 5) {
+    dimw++;
+    dimh++;
+    dimt++;
+  }
+
+  inputWidth = input->size[dimw];
+  inputHeight = input->size[dimh];
+  inputDepth = input->size[dimt];
+
+  THArgCheck(input->size[dimt-1] == nInputPlane, 2, "invalid number of input planes");
+  THArgCheck(inputWidth >= kW && inputHeight >= kH
+             && inputDepth >= kT, 2, "input image smaller than kernel size");
+}
+
+void THNN_(VolumetricSubSampling_updateOutput)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *output,
+    THTensor *weight,
+    THTensor *bias,
+    int kW, int kH, int kT,
+    int dW, int dH, int dT)
+{
+
+  real *weight_data = THTensor_(data)(weight);
+  real *bias_data = THTensor_(data)(bias);
+  real *output_data;
+  real *input_data;
+
+  int dimw = 3;
+  int dimh = 2;
+  int dimt = 1;
+  long nbatch = 1;
+
+  long inputWidth;
+  long inputHeight;
+  long inputDepth;
+  long outputWidth;
+  long outputHeight;
+  long outputDepth;
+
+  int nInputPlane = THTensor_(size)(weight,0);
+
+  long k;
+
+  THNN_(VolumetricSubSampling_shapeCheck)(input, NULL, weight, kW, kH, kT);
+
+  if (input->nDimension == 5) {
+    nbatch = input->size[0];
+    dimw++;
+    dimh++;
+    dimt++;
+  }
+
+  inputWidth = input->size[dimw];
+  inputHeight = input->size[dimh];
+  inputDepth = input->size[dimt];
+  outputWidth = (inputWidth - kW) / dW + 1;
+  outputHeight = (inputHeight - kH) / dH + 1;
+  outputDepth = (inputDepth - kT) / dT + 1;
+
+  if (input->nDimension == 4)
+    THTensor_(resize4d)(output, nInputPlane, outputDepth, outputHeight, outputWidth);
+  else
+    THTensor_(resize5d)(output, input->size[0], nInputPlane, outputDepth, outputHeight, outputWidth);
+
+  input = THTensor_(newContiguous)(input);
+  input_data = THTensor_(data)(input);
+  output_data = THTensor_(data)(output);
+
+#pragma omp parallel for private(k)
+  for(k = 0; k < nInputPlane; k++)
+  {
+    long p;
+    for(p = 0; p < nbatch; p++)
+    {
+      long xx, yy, zz;
+      /* For all output pixels... */
+      real *ptr_output = output_data + p*nInputPlane*outputWidth*outputHeight*outputDepth
+                         + k*outputWidth*outputHeight*outputDepth;
+      /* Get the good mask for (k,i) (k out, i in) */
+      real the_weight = weight_data[k];
+      /* Initialize to the bias */
+      real z = bias_data[k];
+      long i;
+      for(i = 0; i < outputWidth*outputHeight*outputDepth; i++)
+        ptr_output[i] = z;
+
+      for(zz = 0; zz < outputDepth; zz++)
+      {
+        for(yy = 0; yy < outputHeight; yy++)
+        {
+          for(xx = 0; xx < outputWidth; xx++)
+          {
+            /* Compute the mean of the input image... */
+            real *ptr_input = input_data + p*nInputPlane*inputWidth*inputHeight*inputDepth + k*inputWidth*inputHeight*inputDepth + zz*dT*inputHeight*inputWidth + yy*dH*inputWidth + xx*dW;
+            real sum = 0;
+            long kx, ky, kz;
+
+            for(kz = 0; kz < kT; kz++)
+            {
+              for(ky = 0; ky < kH; ky++)
+              {
+                for(kx = 0; kx < kW; kx++)
+                  sum += ptr_input[ky*inputWidth+kx];
+              }
+              ptr_input += inputHeight * inputWidth; /* next input frame */
+            }
+            /* Update output */
+            *ptr_output++ += the_weight*sum;
+          }
+        }
+      }
+    }
+  }
+  THTensor_(free)(input);
+}
+
+void THNN_(VolumetricSubSampling_updateGradInput)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *gradOutput,
+    THTensor *gradInput,
+    THTensor *weight,
+    int kW, int kH, int kT,
+    int dW, int dH, int dT)
+{
+  THNN_(VolumetricSubSampling_shapeCheck)(input, gradOutput, weight, kW, kH, kT);
+
+  int dimw = 3;
+  int dimh = 2;
+  int dimt = 1;
+  long nbatch = 1;
+
+  long inputWidth;
+  long inputHeight;
+  long inputDepth;
+  long outputWidth;
+  long outputHeight;
+  long outputDepth;
+
+  int nInputPlane = THTensor_(size)(weight,0);
+
+  real *weight_data;
+  real *gradOutput_data;
+  real *input_data, *gradInput_data;
+
+  long k;
+
+  if (input->nDimension == 5) {
+    nbatch = input->size[0];
+    dimw++;
+    dimh++;
+    dimt++;
+  }
+
+  inputWidth = input->size[dimw];
+  inputHeight = input->size[dimh];
+  inputDepth = input->size[dimt];
+  outputWidth = (inputWidth - kW) / dW + 1;
+  outputHeight = (inputHeight - kH) / dH + 1;
+  outputDepth = (inputDepth - kT) / dT + 1;
+
+  weight_data = THTensor_(data)(weight);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+  gradOutput_data = THTensor_(data)(gradOutput);
+
+  input_data = THTensor_(data)(input);
+
+  THTensor_(resizeAs)(gradInput, input);
+  gradInput_data = THTensor_(data)(gradInput);
+
+#pragma omp parallel for private(k)
+  for(k = 0; k < nInputPlane; k++)
+  {
+    long p;
+    for(p = 0; p < nbatch; p++)
+    {
+      real the_weight = weight_data[k];
+      real *ptr_gradOutput = gradOutput_data + p*nInputPlane*outputHeight*outputWidth*outputDepth + k*outputWidth*outputHeight*outputDepth;
+      long xx, yy, zz;
+
+      real* ptr_gi = gradInput_data + p*nInputPlane*inputWidth*inputHeight*inputDepth + k*inputWidth*inputHeight*inputDepth;
+      long i;
+      for(i=0; i<inputWidth*inputHeight*inputDepth; i++)
+        ptr_gi[i] = 0.0;
+
+      for(zz = 0; zz < outputDepth; zz++)
+      {
+        for(yy = 0; yy < outputHeight; yy++)
+        {
+          for(xx = 0; xx < outputWidth; xx++)
+          {
+            real *ptr_gradInput = gradInput_data + p*nInputPlane*inputWidth*inputHeight*inputDepth + k*inputWidth*inputHeight*inputDepth + zz*dT*inputHeight*inputWidth + yy*dH*inputWidth + xx*dW;
+            real z = *ptr_gradOutput++ * the_weight;
+            long kx, ky, kz;
+
+            for(kz = 0; kz < kT; kz++)
+            {
+              for(ky = 0; ky < kH; ky++)
+              {
+                for(kx = 0; kx < kW; kx++)
+                  ptr_gradInput[ky*inputWidth+kx] += z;
+              }
+              ptr_gradInput += inputHeight * inputWidth;
+            }
+          }
+        }
+      }
+    }
+  }
+  THTensor_(free)(gradOutput);
+}
+
+void THNN_(VolumetricSubSampling_accGradParameters)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *gradOutput,
+    THTensor *gradWeight,
+    THTensor *gradBias,
+    int kW, int kH, int kT,
+    int dW, int dH, int dT,
+    accreal scale_)
+{
+  real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
+  THNN_(VolumetricSubSampling_shapeCheck)(input, gradOutput, gradWeight, kW, kH, kT);
+
+  long nbatch = 1;
+  long dimw = 3;
+  long dimh = 2;
+  long dimt = 1;
+
+  long inputWidth;
+  long inputHeight;
+  long inputDepth;
+  long outputWidth;
+  long outputHeight;
+  long outputDepth;
+
+  int nInputPlane = THTensor_(size)(gradWeight,0);
+
+  real *gradWeight_data;
+  real *gradBias_data;
+  real *gradOutput_data;
+  real *input_data;
+
+  long k;
+
+  if (input->nDimension == 5) {
+    dimw++;
+    dimh++;
+    dimt++;
+    nbatch = input->size[0];
+  }
+
+  inputWidth = input->size[dimw];
+  inputHeight = input->size[dimh];
+  inputDepth = input->size[dimt];
+  outputWidth = (inputWidth - kW) / dW + 1;
+  outputHeight = (inputHeight - kH) / dH + 1;
+  outputDepth = (inputDepth - kT) / dT + 1;
+
+  gradWeight_data = THTensor_(data)(gradWeight);
+  gradBias_data = THTensor_(data)(gradBias);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+  gradOutput_data = THTensor_(data)(gradOutput);
+
+  input = THTensor_(newContiguous)(input);
+  input_data = THTensor_(data)(input);
+
+#pragma omp parallel for private(k)
+  for(k = 0; k < nInputPlane; k++)
+  {
+    long p;
+    for(p = 0; p < nbatch; p++)
+    {
+      real *ptr_gradOutput = gradOutput_data + p*nInputPlane*outputHeight*outputWidth*outputDepth + k*outputWidth*outputHeight*outputDepth;
+      real sum;
+      long xx, yy, zz;
+      long i;
+
+      sum = 0;
+      for(i = 0; i < outputWidth*outputHeight*outputDepth; i++)
+        sum += ptr_gradOutput[i];
+      gradBias_data[k] += scale*sum;
+
+      sum = 0;
+      for(zz = 0; zz < outputDepth; zz++)
+      {
+        for(yy = 0; yy < outputHeight; yy++)
+        {
+          for(xx = 0; xx < outputWidth; xx++)
+          {
+            real *ptr_input = input_data + p*nInputPlane*inputWidth*inputHeight*inputDepth + k*inputWidth*inputHeight*inputDepth + zz*dT*inputHeight*inputWidth + yy*dH*inputWidth + xx*dW;
+            real z = *ptr_gradOutput++;
+            long kx, ky, kz;
+
+            for(kz = 0; kz < kT; kz++)
+            {
+              for(ky = 0; ky < kH; ky++)
+              {
+                for(kx = 0; kx < kW; kx++)
+                  sum += z * ptr_input[ky*inputWidth+kx];
+              }
+              ptr_input += inputHeight * inputWidth;
+            }
+          }
+        }
+      }
+      gradWeight_data[k] += scale*sum;
+    }
+  }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
+}
+
+#endif

--- a/torch/lib/THNN/generic/VolumetricUpSamplingNearest.c
+++ b/torch/lib/THNN/generic/VolumetricUpSamplingNearest.c
@@ -1,0 +1,226 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/VolumetricUpSamplingNearest.c"
+#else
+
+
+static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
+     (THTensor *input, THTensor *gradOutput,
+      int scale_factor) {
+  THArgCheck(input != NULL, 2, "5D input tensor expected but got NULL");
+  THArgCheck(scale_factor > 1, 4,
+	     "scale_factor must be greater than 1, but got: %d", scale_factor);
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D input tensor expected but got: %s");
+  if (input->nDimension == 4) {
+    int nChannels    = THTensor_(size)(input, 0);
+    int inputDepth   = THTensor_(size)(input, 1);
+    int inputHeight  = THTensor_(size)(input, 2);
+    int inputWidth   = THTensor_(size)(input, 3);
+    int outputDepth  = inputDepth  * scale_factor;
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 0, nChannels);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 1, outputDepth);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 2, outputHeight);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 3, outputWidth);
+    }
+  } else {
+    int nBatch       = THTensor_(size)(input, 0);
+    int nChannels    = THTensor_(size)(input, 1);
+    int inputDepth   = THTensor_(size)(input, 2);
+    int inputHeight  = THTensor_(size)(input, 3);
+    int inputWidth   = THTensor_(size)(input, 4);  
+    int outputDepth  = inputDepth  * scale_factor;
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THNN_CHECK_DIM_SIZE(gradOutput, 5, 0, nBatch);
+      THNN_CHECK_DIM_SIZE(gradOutput, 5, 1, nChannels);
+      THNN_CHECK_DIM_SIZE(gradOutput, 5, 2, outputDepth);
+      THNN_CHECK_DIM_SIZE(gradOutput, 5, 3, outputHeight);
+      THNN_CHECK_DIM_SIZE(gradOutput, 5, 4, outputWidth);
+    }
+  }
+}
+
+void THNN_(VolumetricUpSamplingNearest_updateOutput)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *output,
+    int scale_factor)
+{
+  THNN_(VolumetricUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
+  int inputDepth   = THTensor_(size)(input, input->nDimension-3);
+  int inputHeight  = THTensor_(size)(input, input->nDimension-2);
+  int inputWidth   = THTensor_(size)(input,  input->nDimension-1);
+  int outputDepth  = inputDepth * scale_factor;
+  int outputHeight = inputHeight * scale_factor;
+  int outputWidth  = inputWidth * scale_factor;
+
+  if (input->nDimension == 4) {
+    THTensor_(resize4d)(output,
+			THTensor_(size)(input, 0),
+			outputDepth, outputHeight, outputWidth);    
+  } else {
+    THTensor_(resize5d)(output,
+			THTensor_(size)(input, 0),
+			THTensor_(size)(input, 1),
+			outputDepth, outputHeight, outputWidth);
+  }
+
+  int dT = scale_factor;
+  int dW = scale_factor;
+  int dH = scale_factor;
+  int xDim = input->nDimension-3;
+  int yDim = input->nDimension-2;
+  int zDim = input->nDimension-1;
+
+  // dims
+  int idim = input->nDimension;
+  int osz0 = output->size[0];
+  int osz1 = output->size[1];
+  int osz2 = output->size[2];
+  int osz3 = output->size[3];
+  int osz4 = 1;
+  if (idim > 4) {
+    osz4 = output->size[4];
+  }
+
+  // get strides
+  long *is = input->stride;
+  long *os = output->stride;
+
+  // get raw pointers
+  real *pin = THTensor_(data)(input);
+  real *pout = THTensor_(data)(output);
+
+  // perform the upsampling
+  int i0, i1, i2, i3, i4, isrc, idst;
+  int iout[5];  // Output indices
+  int iin[5];  // Input indices
+
+  for (i0 = 0; i0 < osz0; i0++) {
+    iout[0] = i0;
+    iin[0] = i0;
+    for (i1 = 0; i1 < osz1; i1++) {
+      iout[1] = i1;
+      iin[1] = i1;
+      for (i2 = 0; i2 < osz2; i2++) {
+        iout[2] = i2;
+        iin[2] = i2;
+        for (i3 = 0; i3 < osz3; i3++) {
+          iout[3] = i3;
+          iin[3] = i3;
+          for (i4 = 0; i4 < osz4; i4++) {
+            iout[4] = i4;
+            iin[4] = i4;
+
+            // set the indices for the upsampled dimensions
+            iin[xDim] = iout[xDim] / dW;
+            iin[yDim] = iout[yDim] / dH;
+            iin[zDim] = iout[zDim] / dT;
+
+            idst = i0*os[0] + i1*os[1] + i2*os[2] + i3*os[3];
+            isrc = iin[0]*is[0] + iin[1]*is[1] + iin[2]*is[2] + iin[3]*is[3];
+            if (idim > 4) {
+              idst += i4*os[4];
+              isrc += iin[4]*is[4];
+            }
+
+            pout[idst] = pin[isrc];
+          }
+        }
+      }
+    }
+  }
+}
+
+void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *gradOutput,
+    THTensor *gradInput,
+    int scale_factor)
+{
+  THNN_(VolumetricUpSamplingNearest_shapeCheck)(input, gradOutput, scale_factor);
+  THTensor_(resizeAs)(gradInput, input);
+
+  int dW = scale_factor;
+  int dH = scale_factor;
+  int dT = scale_factor;
+  int xDim = gradInput->nDimension-3;
+  int yDim = gradInput->nDimension-2;
+  int zDim = gradInput->nDimension-1;
+
+  // dims
+  int idim = gradInput->nDimension;  // Guaranteed to be between 3 and 5
+  int isz0 = gradInput->size[0];
+  int isz1 = gradInput->size[1];
+  int isz2 = gradInput->size[2];
+  int isz3 = gradInput->size[3];
+  int isz4 = 1;
+  if (idim > 4) {
+    isz4 = gradInput->size[4];
+  }
+
+  // get strides
+  long *is = gradInput->stride;
+  long *os = gradOutput->stride;
+
+  // get raw pointers
+  real *pin = THTensor_(data)(gradInput);
+  real *pout = THTensor_(data)(gradOutput);
+
+  // perform the upsampling
+  int i0, i1, i2, i3, i4, isrc, idst, x, y, z;
+  int iin[5];  // Input indices
+  int iout[5];  // Output indices
+
+  THTensor_(zero)(gradInput);
+
+  for (i0 = 0; i0 < isz0; i0++) {
+    iin[0] = i0;
+    iout[0] = i0;
+    for (i1 = 0; i1 < isz1; i1++) {
+      iin[1] = i1;
+      iout[1] = i1;
+      for (i2 = 0; i2 < isz2; i2++) {
+        iin[2] = i2;
+        iout[2] = i2;
+        for (i3 = 0; i3 < isz3; i3++) {
+          iin[3] = i3;
+          iout[3] = i3;
+
+          for (i4 = 0; i4 < isz4; i4++) {
+            iin[4] = i4;
+            iout[4] = i4;
+
+            idst = i0*is[0] + i1*is[1] + i2*is[2] + i3*is[3];
+            if (idim > 4) {
+              idst += i4*is[4];
+            }
+
+            // Now accumulate the gradients from gradOutput
+            for (z = 0; z < dT; z++) {
+              for (y = 0; y < dH; y++) {
+                for (x = 0; x < dW; x++) {
+                  iout[xDim] = dW * iin[xDim] + x;
+                  iout[yDim] = dH * iin[yDim] + y;
+                  iout[zDim] = dT * iin[zDim] + z;
+                  isrc = iout[0]*os[0] + iout[1]*os[1] + iout[2]*os[2] + iout[3]*os[3];
+                  if (idim > 4) {
+                    isrc += iout[4]*os[4];
+                  }
+                  pin[idst] += pout[isrc];
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/torch/lib/THNN/generic/VolumetricUpSamplingTrilinear.c
+++ b/torch/lib/THNN/generic/VolumetricUpSamplingTrilinear.c
@@ -1,0 +1,213 @@
+// Adapted from interp.cpp from Caffe util by Pauline Luc
+// Originally developed by George Papandreou
+
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/VolumetricUpSamplingTrilinear.c"
+#else
+
+static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+     (THTensor *input, THTensor *gradOutput,
+      int nBatch, int nChannels,
+      int inputDepth, int inputHeight, int inputWidth,
+      int outputDepth, int outputHeight, int outputWidth) {
+  THArgCheck(inputDepth > 0 && inputHeight > 0 && inputWidth > 0
+	     && outputDepth > 0 && outputHeight > 0 && outputWidth > 0, 2,
+	     "input and output sizes should be greater than 0,"
+	     " but got input (D: %d, H: %d, W: %d) output (D: %d, H: %d, W: %d)",
+	     inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
+  if (input != NULL) {
+    THNN_ARGCHECK(input->nDimension == 5, 2, input,
+		  "5D input tensor expected but got: %s");
+  }
+
+  if (gradOutput != NULL) {
+    THNN_CHECK_DIM_SIZE(gradOutput, 5, 0, nBatch);
+    THNN_CHECK_DIM_SIZE(gradOutput, 5, 1, nChannels);
+    THNN_CHECK_DIM_SIZE(gradOutput, 5, 2, outputDepth);
+    THNN_CHECK_DIM_SIZE(gradOutput, 5, 3, outputHeight);
+    THNN_CHECK_DIM_SIZE(gradOutput, 5, 4, outputWidth);
+  }
+}
+
+void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
+    THNNState *state,
+    THTensor *input,
+    THTensor *output,
+    int outputDepth,
+    int outputHeight,
+    int outputWidth){
+
+  int nbatch = THTensor_(size)(input, 0);
+  int channels = THTensor_(size)(input, 1);
+  int inputDepth = THTensor_(size)(input, 2);
+  int inputHeight = THTensor_(size)(input, 3);
+  int inputWidth = THTensor_(size)(input, 4);
+
+  THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+    (input, NULL,
+     nbatch, channels,
+     inputDepth, inputHeight, inputWidth,
+     outputDepth, outputHeight, outputWidth);
+
+  input = THTensor_(newContiguous)(input);
+  THTensor_(resize5d)(output, 
+		      THTensor_(size)(input, 0), 
+		      THTensor_(size)(input, 1), 
+		      outputDepth, outputHeight, outputWidth);
+  THTensor_(zero)(output);
+  real *idata = THTensor_(data)(input);
+  real *odata = THTensor_(data)(output);
+  channels = nbatch * channels;
+  THAssert(inputDepth > 0 && inputHeight > 0 && inputWidth > 0 && 
+           outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
+  // special case: just copy
+  if (inputDepth == outputDepth && inputHeight == outputHeight && inputWidth == outputWidth) {
+    for (int t2 = 0; t2 < outputDepth; ++t2) {
+      const int t1 = t2;
+      for (int h2 = 0; h2 < outputHeight; ++h2) {
+        const int h1 = h2;
+        for (int w2 = 0; w2 < outputWidth; ++w2) {
+          const int w1 = w2;
+          const real* pos1 = &idata[t1 * inputHeight * inputWidth + h1 * inputWidth + w1];
+          real* pos2 = &odata[t2 * outputHeight * outputWidth + h2 * outputWidth + w2];
+          for (int c = 0; c < channels; ++c) {
+            pos2[0] = pos1[0];
+            pos1 += inputWidth * inputHeight * inputDepth;
+            pos2 += outputWidth * outputHeight * outputDepth;
+          }
+        }
+      }
+    }
+    return;
+  }
+  const float rdepth  = (outputDepth > 1) ? (float)(inputDepth - 1)/(outputDepth - 1) : 0.f;
+  const float rheight = (outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
+  const float rwidth  = (outputWidth > 1) ? (float)(inputWidth - 1) / (outputWidth - 1) : 0.f;
+  for (int t2 = 0; t2 < outputDepth; ++t2) {
+    const float t1r = rdepth * t2;
+    const int t1 = t1r;
+    const int t1p = (t1 < inputDepth - 1) ? 1 : 0;
+    const real t1lambda = t1r - t1;
+    const real t0lambda = (real)1. - t1lambda;
+    for (int h2 = 0; h2 < outputHeight; ++h2) {
+      const float h1r = rheight * h2;
+      const int h1 = h1r;
+      const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
+      const real h1lambda = h1r - h1;
+      const real h0lambda = (real)1. - h1lambda;
+      for (int w2 = 0; w2 < outputWidth; ++w2) {
+        const float w1r = rwidth * w2;
+        const int w1 = w1r;
+        const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
+        const real w1lambda = w1r - w1;
+        const real w0lambda = (real)1. - w1lambda;
+        const real* pos1 = &idata[t1 * inputHeight * inputWidth + h1 * inputWidth + w1];
+        real* pos2 = &odata[t2 * outputHeight * outputWidth + h2 * outputWidth + w2];
+        for (int c = 0; c < channels; ++c) {
+          pos2[0] = t0lambda * (h0lambda * (w0lambda * pos1[0] + w1lambda * pos1[w1p])
+                              + h1lambda * (w0lambda * pos1[h1p * inputWidth]
+                                          + w1lambda * pos1[h1p * inputWidth + w1p]))
+                  + t1lambda * (h0lambda * (w0lambda * pos1[t1p * inputHeight * inputWidth] 
+                                          + w1lambda * pos1[t1p * inputHeight * inputWidth
+                                                            + w1p])
+                              + h1lambda * (w0lambda * pos1[t1p * inputHeight * inputWidth 
+                                                            + h1p * inputWidth]
+                                          + w1lambda * pos1[t1p * inputHeight * inputWidth 
+                                                            + h1p * inputWidth + w1p]));
+          pos1 += inputWidth * inputHeight * inputDepth;
+          pos2 += outputWidth * outputHeight * outputDepth;
+        }
+      }
+    }
+  }
+  THTensor_(free)(input);
+}
+
+void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
+    THNNState *state,
+    THTensor *gradOutput,
+    THTensor *gradInput,
+    int nbatch,
+    int channels,
+    int inputDepth,
+    int inputHeight,
+    int inputWidth,
+    int outputDepth,
+    int outputHeight,
+    int outputWidth){
+
+  THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
+    (NULL, gradOutput,
+     nbatch, channels,
+     inputDepth, inputHeight, inputWidth,
+     outputDepth, outputHeight, outputWidth);
+
+  THTensor_(resize5d)(gradInput, nbatch, channels, inputDepth, inputHeight, inputWidth);
+  THTensor_(zero)(gradInput);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+  real *data1 = THTensor_(data)(gradInput);
+  real *data2 = THTensor_(data)(gradOutput);
+  channels = nbatch * channels;
+
+  // special case: same-size matching grids
+  if (inputDepth == outputDepth && inputHeight == outputHeight && inputWidth == outputWidth) {
+    for (int t2 = 0; t2 < outputDepth; ++t2) {
+      const int t1 = t2;
+      for (int h2 = 0; h2 < outputHeight; ++h2) {
+        const int h1 = h2;
+        for (int w2 = 0; w2 < outputWidth; ++w2) {
+          const int w1 = w2;
+          real* pos1 = &data1[t1 * inputHeight * inputWidth + h1 * inputWidth + w1];
+          const real* pos2 = &data2[t2 * outputHeight * outputWidth + h2 * outputWidth + w2];
+          for (int c = 0; c < channels; ++c) {
+            pos1[0] += pos2[0];
+            pos1 += inputWidth * inputHeight * inputDepth;
+            pos2 += outputWidth * outputHeight * outputDepth;
+          }
+        }
+      }
+    }
+    return;
+  }
+  const float rdepth  = (outputDepth > 1) ? (float)(inputDepth - 1)/(outputDepth - 1) : 0.f;
+  const float rheight = (outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
+  const float rwidth  = (outputWidth > 1) ? (float)(inputWidth - 1)/(outputWidth - 1) : 0.f;
+  for (int t2 = 0; t2 < outputDepth; ++t2) {
+    const float t1r = rdepth * t2;
+    const int t1 = t1r;
+    const int t1p = (t1 < inputDepth - 1) ? 1 : 0;
+    const real t1lambda = t1r - t1;
+    const real t0lambda = (real)1. - t1lambda;
+    for (int h2 = 0; h2 < outputHeight; ++h2) {
+      const float h1r = rheight * h2;
+      const int h1 = h1r;
+      const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
+      const real h1lambda = h1r - h1;
+      const real h0lambda = (real)1. - h1lambda;
+      for (int w2 = 0; w2 < outputWidth; ++w2) {
+        const float w1r = rwidth * w2;
+        const int w1 = w1r;
+        const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
+        const real w1lambda = w1r - w1;
+        const real w0lambda = (real)1. - w1lambda;
+        real* pos1 = &data1[t1 * inputHeight * inputWidth + h1 * inputWidth + w1];
+        const real* pos2 = &data2[t2 * outputHeight * outputWidth + h2 * outputWidth + w2];
+        for (int c = 0; c < channels; ++c) {
+          pos1[0] += t0lambda * h0lambda * w0lambda * pos2[0];
+          pos1[w1p] += t0lambda * h0lambda * w1lambda * pos2[0];
+          pos1[h1p * inputWidth] += t0lambda * h1lambda * w0lambda * pos2[0];
+          pos1[h1p * inputWidth + w1p] += t0lambda * h1lambda * w1lambda * pos2[0];
+          pos1[t1p * inputHeight * inputWidth] += t1lambda * h0lambda * w0lambda * pos2[0];
+          pos1[t1p * inputHeight * inputWidth + w1p] += t1lambda * h0lambda * w1lambda * pos2[0]; 
+          pos1[t1p * inputHeight * inputWidth + h1p * inputWidth] += t1lambda * h1lambda * w0lambda * pos2[0];
+          pos1[t1p * inputHeight * inputWidth + h1p * inputWidth + w1p] += t1lambda * h1lambda * w1lambda * pos2[0]; 
+          pos1 += inputWidth * inputHeight * inputDepth;
+          pos2 += outputWidth * outputHeight * outputDepth;
+        }
+      }
+    }
+  }
+  THTensor_(free)(gradOutput);
+}
+
+#endif

--- a/torch/lib/THNN/init.c
+++ b/torch/lib/THNN/init.c
@@ -268,3 +268,13 @@
 
 #include "generic/VolumetricReplicationPadding.c"
 #include "THGenerateFloatTypes.h"
+
+#include "generic/VolumetricSubSampling.c"
+#include "THGenerateFloatTypes.h"
+
+#include "generic/VolumetricUpSamplingNearest.c"
+#include "THGenerateFloatTypes.h"
+
+#include "generic/VolumetricUpSamplingTrilinear.c"
+#include "THGenerateFloatTypes.h"
+

--- a/torch/nn/_functions/thnn/__init__.py
+++ b/torch/nn/_functions/thnn/__init__.py
@@ -7,4 +7,5 @@ from .pooling import *
 from .sparse import *
 from .loss import *
 from .upsampling import *
+from .subsampling import *
 from .rnnFusedPointwise import *

--- a/torch/nn/_functions/thnn/subsampling.py
+++ b/torch/nn/_functions/thnn/subsampling.py
@@ -1,0 +1,131 @@
+import torch
+from torch.autograd import Function
+from torch._thnn import type2backend
+
+from . import _all_functions
+
+
+class Subsampling2d(Function):
+
+    def __init__(self, size, stride):
+        self.size = size
+        self.stride = stride
+
+    def forward(self, input, weight, bias):
+        assert input.dim() == 4
+        assert weight.dim() == 1
+        assert bias.dim() == 1
+
+        output = input.new()
+        backend = type2backend[type(input)]
+        self.save_for_backward(input, weight, bias)
+        backend.SpatialSubSampling_updateOutput(
+            backend.library_state,
+            input,
+            output,
+            weight,
+            bias,
+            self.size[0], self.size[1],
+            self.stride[0], self.stride[1]
+        )
+        return output
+
+    def backward(self, grad_output, scale=1):
+        input, weight, bias = self.saved_tensors
+
+        backend = type2backend[type(input)]
+
+        grad_input = None
+        if self.needs_input_grad[0]:
+            grad_input = input.new().resize_as_(input)
+            backend.SpatialSubSampling_updateGradInput(
+                backend.library_state,
+                input,
+                grad_output,
+                grad_input,
+                weight,
+                self.size[0], self.size[1],
+                self.stride[0], self.stride[1]
+            )
+
+        grad_weight, grad_bias = (None, None)
+        if any(self.needs_input_grad[1:]):
+            grad_weight = weight.new().resize_as_(weight).zero_()
+            grad_bias = bias.new().resize_as_(bias).zero_()
+            backend.SpatialSubSampling_accGradParameters(
+                backend.library_state,
+                input,
+                grad_output,
+                grad_weight,
+                grad_bias,
+                self.size[0], self.size[1],
+                self.stride[0], self.stride[1],
+                scale
+            )
+
+        return grad_input, grad_weight, grad_bias
+
+
+class Subsampling3d(Function):
+
+    def __init__(self, size, stride):
+        self.size = size
+        self.stride = stride
+
+    def forward(self, input, weight, bias):
+        assert input.dim() == 5
+        assert weight.dim() == 1
+        assert bias.dim() == 1
+
+        output = input.new()
+        backend = type2backend[type(input)]
+        self.save_for_backward(input, weight, bias)
+        backend.VolumetricSubSampling_updateOutput(
+            backend.library_state,
+            input,
+            output,
+            weight,
+            bias,
+            self.size[0], self.size[1], self.size[2],
+            self.stride[0], self.stride[1], self.stride[2]
+        )
+        return output
+
+    def backward(self, grad_output, scale=1):
+        input, weight, bias = self.saved_tensors
+
+        backend = type2backend[type(input)]
+
+        grad_input = None
+        if self.needs_input_grad[0]:
+            grad_input = input.new().resize_as_(input)
+            backend.VolumetricSubSampling_updateGradInput(
+                backend.library_state,
+                input,
+                grad_output,
+                grad_input,
+                weight,
+                self.size[0], self.size[1], self.size[2],
+                self.stride[0], self.stride[1], self.stride[2]
+            )
+
+        grad_weight, grad_bias = (None, None)
+        if any(self.needs_input_grad[1:]):
+            grad_weight = weight.new().resize_as_(weight).zero_()
+            grad_bias = bias.new().resize_as_(bias).zero_()
+            backend.VolumetricSubSampling_accGradParameters(
+                backend.library_state,
+                input,
+                grad_output,
+                grad_weight,
+                grad_bias,
+                self.size[0], self.size[1], self.size[2],
+                self.stride[0], self.stride[1], self.stride[2],
+                scale
+            )
+
+        return grad_input, grad_weight, grad_bias
+
+
+_all_functions.append(Subsampling2d)
+_all_functions.append(Subsampling3d)

--- a/torch/nn/_functions/thnn/upsampling.py
+++ b/torch/nn/_functions/thnn/upsampling.py
@@ -126,5 +126,95 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         self.__dict__.update(state)
         self.scale_factor = _tuple(self.scale_factor)
 
+class UpsamplingNearest3d(_UpsamplingBase):
+
+    def forward(self, input):
+        assert input.dim() == 5
+
+        if self.scale_factor is None:
+            if (self.size[0] % input.size(2) != 0 or self.size[1] % input.size(3) != 0 or
+               self.size[2] % input.size(4) != 0):
+                raise RuntimeError("output size specified in UpSamplingNearest "
+                                   "({}) has to be divisible by the input size, but got: "
+                                   "{}".format('x'.join(map(str, self.size)),
+                                               'x'.join(map(str, input.size()))))
+            self.scale_factor = self.size[0] // input.size(2)
+            if (self.scale_factor != self.size[1] // input.size(3) or
+               self.scale_factor != self.size[2] // input.size(4)):
+                raise RuntimeError("input aspect ratio doesn't match the "
+                                   "output ratio")
+
+        output = input.new()
+        backend = type2backend[type(input)]
+        self.save_for_backward(input)
+        backend.VolumetricUpSamplingNearest_updateOutput(backend.library_state,
+                                                         input,
+                                                         output,
+                                                         self.scale_factor)
+        return output
+
+    def backward(self, grad_output):
+        input, = self.saved_tensors
+        grad_input = grad_output.new()
+        backend = type2backend[type(input)]
+        backend.VolumetricUpSamplingNearest_updateGradInput(backend.library_state,
+                                                            input,
+                                                            grad_output,
+                                                            grad_input,
+                                                            self.scale_factor)
+        return grad_input
+
+
+class UpsamplingTrilinear3d(_UpsamplingBase):
+
+    def forward(self, input):
+        assert input.dim() == 5
+
+        if self.scale_factor:
+            self.output_size = (
+                input.size(2) * self.scale_factor,
+                input.size(3) * self.scale_factor,
+                input.size(4) * self.scale_factor,
+            )
+        else:
+            self.output_size = self.size
+
+        self.input_size = input.size()
+        output = input.new()
+        backend = type2backend[type(input)]
+        backend.VolumetricUpSamplingTrilinear_updateOutput(
+            backend.library_state,
+            input,
+            output,
+            self.output_size[0],
+            self.output_size[1],
+            self.output_size[2]
+        )
+        return output
+
+    def backward(self, grad_output):
+        assert grad_output.dim() == 5
+
+        grad_output = grad_output.contiguous()
+        grad_input = grad_output.new()
+        backend = type2backend[type(grad_output)]
+        backend.VolumetricUpSamplingTrilinear_updateGradInput(
+            backend.library_state,
+            grad_output,
+            grad_input,
+            self.input_size[0],
+            self.input_size[1],
+            self.input_size[2],
+            self.input_size[3],
+            self.input_size[4],
+            self.output_size[0],
+            self.output_size[1],
+            self.output_size[2]
+        )
+        return grad_input
+
+
 _all_functions.append(UpsamplingNearest2d)
 _all_functions.append(UpsamplingBilinear2d)
+_all_functions.append(UpsamplingNearest3d)
+_all_functions.append(UpsamplingTrilinear3d)

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -22,7 +22,8 @@ from .sparse import Embedding
 from .rnn import RNNBase, RNN, LSTM, GRU, \
     RNNCell, LSTMCell, GRUCell
 from .pixelshuffle import PixelShuffle
-from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d
+from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d, UpsamplingNearest3d, UpsamplingTrilinear3d
+from .subsampling import Subsampling2d, Subsampling3d
 from .distance import PairwiseDistance
 
 
@@ -41,7 +42,8 @@ __all__ = [
     'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'ReflectionPad2d',
     'ReplicationPad2d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
-    'PixelShuffle', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
+    'PixelShuffle', 'Subsampling2d', 'Subsampling3d', 'UpsamplingNearest2d',
+    'UpsamplingBilinear2d', 'UpsamplingNearest3d', 'UpsamplingTrilinear3d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad2d', 'Bilinear',
 ]

--- a/torch/nn/modules/subsampling.py
+++ b/torch/nn/modules/subsampling.py
@@ -1,0 +1,162 @@
+import math
+import torch
+from torch.nn.parameter import Parameter
+from .. import functional as F
+from .module import Module
+from .utils import _pair, _triple
+
+
+class _SubsamplingNd(Module):
+
+    def __init__(self, in_channels, size, stride):
+        super(_SubsamplingNd, self).__init__()
+        self.in_channels = in_channels
+        self.size = size
+        self.stride = stride
+        self.weight = Parameter(torch.Tensor(in_channels))
+        self.bias = Parameter(torch.Tensor(in_channels))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        n = 1.0
+        for k in self.size:
+            n *= k
+        stdv = 1. / math.sqrt(n)
+        self.weight.data.uniform_(-stdv, stdv)
+        self.bias.data.uniform_(-stdv, stdv)
+
+    def __repr__(self):
+        s = ('{name}({in_channels}, size={size}, stride={stride})')
+        return s.format(name=self.__class__.__name__, **self.__dict__)
+
+
+class Subsampling2d(_SubsamplingNd):
+    r"""Subsamples the input by averaging over input neighborhoods of given size and stride,
+    multiplying by weight and adding bias.
+    The module preserves the number of channels (``in_channels == out_channels``).
+    Weight and bias are learned 1D tensors of size (in_channels).
+
+    The output value of the layer with input size :math:`(N, C_{in}, H, W)` can be described
+    as
+
+    .. math::
+
+        \begin{array}{ll}
+        out(N_i, C_{in_j}) = bias(C_{in_j}
+                      + weight(C_{in_j}) * 1_{size_0,size_1} \star input(N_i, C_{in_j})
+        \end{array}
+
+    where :math:`\star` is the valid 2D `cross-correlation`_ operator and
+    :math:`1_{size_0,size_1}` is a one tensor of rank 2, and size :math:`(size_0,size_1)`
+
+    | :attr:`size` controls the size of the identity tensor
+    | :attr:`stride` controls the stride for the cross-correlation
+
+    The parameters :attr:`size` and :attr:`stride` can either be:
+
+        - a single ``int`` -- in which case the same value is used for the height and width dimension
+        - a ``tuple`` of two ints -- in which case the first `int` is used for the height dimension
+          and the second `int` for the width dimension
+
+    Args:
+        in_channels (int): Number of channels in the input image
+        size (int or tuple): Size of the averaging operation
+        stride (int or tuple, optional): Stride of the averaging operation
+
+    Shape:
+        - Input: :math:`(N, C_{in}, H_{in}, W_{in})`
+        - Output: :math:`(N, C_{in}, H_{out}, W_{out})` where
+          :math:`H_{out} = floor((H_{in} - size[1]) / stride[1] + 1)
+          :math:`W_{out} = floor((W_{in} - size[0]) / stride[0] + 1)
+
+    Attributes:
+        weight (Tensor): the learnable weights of the module of shape (in_channels)
+        bias (Tensor):   the learnable bias of the module of shape (in_channels)
+
+    Examples:
+
+        >>> # With square averaging and equal stride
+        >>> m = nn.Subsample2d(10, 3, stride=2)
+        >>> # non-square averaging and unequal stride
+        >>> m = nn.Subsample2d(10, (2,3), stride=(1,2))
+        >>> input = autograd.Variable(torch.randn(10,2,8,8)
+        >>> output = m(input)
+
+    .. _cross-correlation:
+        https://en.wikipedia.org/wiki/Cross-correlation
+    """
+
+    def __init__(self, in_channels, size, stride=1):
+        size = _pair(size)
+        stride = _pair(stride)
+        super(Subsampling2d, self).__init__(in_channels, size, stride)
+
+    def forward(self, input):
+        return F.subsample(input, self.weight, self.bias, self.size, self.stride)
+
+
+class Subsampling3d(_SubsamplingNd):
+    r"""Subsamples the input by averaging over input neighborhoods of given size and stride,
+    multiplying by weight and adding bias.
+    The module preserves the number of channels (``in_channels == out_channels``).
+    Weight and bias are learned 1D tensors of size (in_channels).
+
+    The output value of the layer with input size :math:`(N, C_{in}, D, H, W)` can be described
+    as
+
+    .. math::
+
+        \begin{array}{ll}
+        out(N_i, C_{in_j}) = bias(C_{in_j}
+                      + weight(C_{in_j}) * 1_{size_0,size_1,size_2} \star input(N_i, C_{in_j})
+        \end{array}
+
+    where :math:`\star` is the valid 2D `cross-correlation`_ operator and
+    :math:`1_{size_0,size_1,size_2}` is a one tensor of rank 3 and size :math:`(size_0,size_1,size_2)`
+
+    | :attr:`size` controls the size of the identity tensor
+    | :attr:`stride` controls the stride for the cross-correlation
+
+    The parameters :attr:`size` and :attr:`stride` can either be:
+
+        - a single ``int`` -- in which case the same value is used for the depth, height
+          and width dimension
+        - a ``tuple`` of three ints -- in which case the first `int` is used for the depth dimension,
+          the second `int` for the height dimension and the third `int` for the width dimension
+
+    Args:
+        in_channels (int): Number of channels in the input image
+        size (int or tuple): Size of the averaging operation
+        stride (int or tuple, optional): Stride of the averaging operation
+
+    Shape:
+        - Input: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
+        - Output: :math:`(N, C_{in}, D_{out}, H_{out}, W_{out})` where
+          :math:`D_{out} = floor((D_{in} - size[2]) / stride[2] + 1)
+          :math:`H_{out} = floor((H_{in} - size[1]) / stride[1] + 1)
+          :math:`W_{out} = floor((W_{in} - size[0]) / stride[0] + 1)
+
+    Attributes:
+        weight (Tensor): the learnable weights of the module of shape (in_channels)
+        bias (Tensor):   the learnable bias of the module of shape (in_channels)
+
+    Examples:
+
+        >>> # With square averaging and equal stride
+        >>> m = nn.Subsample2d(10, 3, stride=2)
+        >>> # non-square averaging and unequal stride
+        >>> m = nn.Subsample2d(10, (2,2,3), stride=(1,1,2))
+        >>> input = autograd.Variable(torch.randn(10,2,8,8,8)
+        >>> output = m(input)
+
+    .. _cross-correlation:
+        https://en.wikipedia.org/wiki/Cross-correlation
+    """
+
+    def __init__(self, in_channels, size, stride=1):
+        size = _triple(size)
+        stride = _triple(stride)
+        super(Subsampling3d, self).__init__(in_channels, size, stride)
+
+    def forward(self, input):
+        return F.subsample(input, self.weight, self.bias, self.size, self.stride)

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -2,7 +2,7 @@ from numbers import Integral
 
 from .module import Module
 from .. import functional as F
-from .utils import _pair
+from .utils import _pair, _triple
 
 
 class _UpsamplingBase(Module):
@@ -64,6 +64,8 @@ class UpsamplingNearest2d(_UpsamplingBase):
         [torch.FloatTensor of size 1x1x4x4]
 
     """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest2d, self).__init__(_pair(size), scale_factor)
 
     def __init__(self, size=None, scale_factor=None):
         super(UpsamplingNearest2d, self).__init__(size, scale_factor)
@@ -115,6 +117,8 @@ class UpsamplingBilinear2d(_UpsamplingBase):
         [torch.FloatTensor of size 1x1x4x4]
 
     """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingBilinear2d, self).__init__(_pair(size), scale_factor)
 
     def __init__(self, size=None, scale_factor=None):
         super(UpsamplingBilinear2d, self).__init__(size, scale_factor)
@@ -125,3 +129,99 @@ class UpsamplingBilinear2d(_UpsamplingBase):
 
     def forward(self, input):
         return F.upsample_bilinear(input, self.size, self.scale_factor)
+
+
+class UpsamplingNearest3d(_UpsamplingBase):
+    """
+    Applies a 3D nearest neighbor upsampling to an input signal composed of several input
+    channels.
+
+    To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
+    as it's constructor argument.
+
+    When `size` is given, it is the output size of the volume (d, h, w).
+
+    Args:
+        size (tuple, optional): a tuple of ints (D_out, H_out, W_out) output sizes
+        scale_factor (int, optional): the multiplier for the image depth / height / width
+
+    Shape:
+        - Input: :math:`(N, C, D_{in}, H_{in}, W_{in})`
+        - Output: :math:`(N, C, D_{out}, H_{out}, W_{out})` where
+          :math:`D_{out} = floor(D_{in} * scale\_factor)`
+          :math:`H_{out} = floor(H_{in} * scale\_factor)`
+          :math:`W_{out} = floor(W_{in}  * scale\_factor)`
+
+    Examples::
+
+        >>> inp
+        Variable containing:
+        (0 ,0 ,.,.) =
+          1  2
+          3  4
+        [torch.FloatTensor of size 1x1x2x2x2]
+
+        >>> m = nn.UpsamplingNearest3d(scale_factor=2)
+        >>> m(inp)
+        Variable containing:
+        (0 ,0 ,.,.) =
+          1  1  2  2
+          1  1  2  2
+          3  3  4  4
+          3  3  4  4
+        [torch.FloatTensor of size 1x1x4x4x4]
+
+    """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingNearest3d, self).__init__(_triple(size), scale_factor)
+
+    def forward(self, input):
+        return F.upsample_nearest(input, self.size, self.scale_factor)
+
+
+class UpsamplingTrilinear3d(_UpsamplingBase):
+    """
+    Applies a 3D trilinear upsampling to an input signal composed of several input
+    channels.
+
+    To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
+    as it's constructor argument.
+
+    When `size` is given, it is the output size of the volume (d, h, w).
+
+    Args:
+        size (tuple, optional): a tuple of ints (D_out, H_out, W_out) output sizes
+        scale_factor (int, optional): the multiplier for the image depth / height / width
+
+    Shape:
+        - Input: :math:`(N, C, D_{in}, H_{in}, W_{in})`
+        - Output: :math:`(N, C, D_{out}, H_{out}, W_{out})` where
+          :math:`D_{out} = floor(D_{in} * scale\_factor)`
+          :math:`H_{out} = floor(H_{in} * scale\_factor)`
+          :math:`W_{out} = floor(W_{in}  * scale\_factor)`
+
+    Examples::
+
+        >>> inp
+        Variable containing:
+        (0 ,0 ,.,.) =
+          1  2
+          3  4
+        [torch.FloatTensor of size 1x1x2x2x2]
+
+        >>> m = nn.UpsamplingTrilinear3d(scale_factor=2)
+        >>> m(inp)
+        Variable containing:
+        (0 ,0 ,.,.) =
+          1.0000  1.3333  1.6667  2.0000
+          1.6667  2.0000  2.3333  2.6667
+          2.3333  2.6667  3.0000  3.3333
+          3.0000  3.3333  3.6667  4.0000
+        [torch.FloatTensor of size 1x1x4x4x4]
+
+    """
+    def __init__(self, size=None, scale_factor=None):
+        super(UpsamplingTrilinear3d, self).__init__(_triple(size), scale_factor)
+
+    def forward(self, input):
+        return F.upsample_trilinear(input, self.size, self.scale_factor)


### PR DESCRIPTION
As anticipated on Slack #general on Apr 20, this PR includes
- THNN and THCUNN implementations of:
  - `VolumetricUpsamplingNearest`
  - `VolumetricUpsamplingTrilinear`
  - `VolumetricSubsampling`
- `nn` (and `functional`) modules:
  - `UpsamplingNearest2d`, `UpsamplingNearest3d` (functional: `upsample_nearest`)
  - `UpsamplingTrilinear3d` (functional: `upsample_trilinear`)
  - `Subsampling2d`, `Subsampling3d` (functional: `subsample`)
- docs and tests for all modules (including `gradcheck`)

Commits may need to be squashed, in which case I'd need some direction.