### PR TITLE
Define sparse tensors with Sparse*Tensor naming for better errors.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,10 @@ You do not need to repeatedly install after modifying python files.
 
 #### C++ Development tips
 
-When you are developing on the C++ side of things, the environment variables `DEBUG` and `NOCUDA` are helpful.
+When you are developing on the C++ side of things, the environment variables `DEBUG` and `NO_CUDA` are helpful.
 
 - `DEBUG=1` will enable debug builds (-g -O0)
-- `NOCUDA=1` will disable compiling CUDA (in case you are developing on something not CUDA related), to save compile time.
+- `NO_CUDA=1` will disable compiling CUDA (in case you are developing on something not CUDA related), to save compile time.
 
 For example:
 ```

--- a/torch/cuda/sparse.py
+++ b/torch/cuda/sparse.py
@@ -28,54 +28,62 @@ class _CudaSparseBase(object):
         return super(_CudaSparseBase, cls).__new__(cls, *args, **kwargs)
 
 
-class DoubleTensor(_CudaSparseBase, torch._C.CudaSparseDoubleTensorBase, _SparseBase, _TensorBase):
+class SparseDoubleTensor(_CudaSparseBase, torch._C.CudaSparseDoubleTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
+DoubleTensor = SparseDoubleTensor
 
-class FloatTensor(_CudaSparseBase, torch._C.CudaSparseFloatTensorBase, _SparseBase, _TensorBase):
-
-    def is_signed(self):
-        return True
-
-
-class LongTensor(_CudaSparseBase, torch._C.CudaSparseLongTensorBase, _SparseBase, _TensorBase):
+class SparseFloatTensor(_CudaSparseBase, torch._C.CudaSparseFloatTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
+FloatTensor = SparseFloatTensor
 
-class IntTensor(_CudaSparseBase, torch._C.CudaSparseIntTensorBase, _SparseBase, _TensorBase):
-
-    def is_signed(self):
-        return True
-
-
-class ShortTensor(_CudaSparseBase, torch._C.CudaSparseShortTensorBase, _SparseBase, _TensorBase):
+class SparseLongTensor(_CudaSparseBase, torch._C.CudaSparseLongTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
+LongTensor = SparseLongTensor
 
-class CharTensor(_CudaSparseBase, torch._C.CudaSparseCharTensorBase, _SparseBase, _TensorBase):
+class SparseIntTensor(_CudaSparseBase, torch._C.CudaSparseIntTensorBase, _SparseBase, _TensorBase):
+
+    def is_signed(self):
+        return True
+
+IntTensor = SparseIntTensor
+
+class SparseShortTensor(_CudaSparseBase, torch._C.CudaSparseShortTensorBase, _SparseBase, _TensorBase):
+
+    def is_signed(self):
+        return True
+
+ShortTensor = SparseShortTensor
+
+class SparseCharTensor(_CudaSparseBase, torch._C.CudaSparseCharTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         # TODO
         return False
 
+CharTensor = SparseCharTensor
 
-class ByteTensor(_CudaSparseBase, torch._C.CudaSparseByteTensorBase, _SparseBase, _TensorBase):
+class SparseByteTensor(_CudaSparseBase, torch._C.CudaSparseByteTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return False
 
+ByteTensor = SparseByteTensor
 
-class HalfTensor(_CudaSparseBase, torch._C.CudaSparseHalfTensorBase, _SparseBase, _TensorBase):
+class SparseHalfTensor(_CudaSparseBase, torch._C.CudaSparseHalfTensorBase, _SparseBase, _TensorBase):
 
     def is_signed(self):
         return True
 
+HalfTensor = SparseHalfTensor
 
 _sparse_tensor_classes.add(DoubleTensor)
 _sparse_tensor_classes.add(FloatTensor)
@@ -85,4 +93,12 @@ _sparse_tensor_classes.add(ShortTensor)
 _sparse_tensor_classes.add(CharTensor)
 _sparse_tensor_classes.add(ByteTensor)
 _sparse_tensor_classes.add(HalfTensor)
+_sparse_tensor_classes.add(SparseDoubleTensor)
+_sparse_tensor_classes.add(SparseFloatTensor)
+_sparse_tensor_classes.add(SparseLongTensor)
+_sparse_tensor_classes.add(SparseIntTensor)
+_sparse_tensor_classes.add(SparseShortTensor)
+_sparse_tensor_classes.add(SparseCharTensor)
+_sparse_tensor_classes.add(SparseByteTensor)
+_sparse_tensor_classes.add(SparseHalfTensor)
 torch._tensor_classes.update(_sparse_tensor_classes)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -138,41 +138,50 @@ class _SparseBase(object):
             self.__class__.__name__, self.indices(), self.values())
 
 
-class DoubleTensor(_SparseBase, _C.SparseDoubleTensorBase, _TensorBase):
+class SparseDoubleTensor(_SparseBase, _C.SparseDoubleTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
+# NB: Define the class with Sparse in the name, so we have better error
+# messages.
+DoubleTensor = SparseDoubleTensor
 
-class FloatTensor(_SparseBase, _C.SparseFloatTensorBase, _TensorBase):
+class SparseFloatTensor(_SparseBase, _C.SparseFloatTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
+FloatTensor = SparseFloatTensor
 
-class LongTensor(_SparseBase, _C.SparseLongTensorBase, _TensorBase):
+class SparseLongTensor(_SparseBase, _C.SparseLongTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
+LongTensor = SparseLongTensor
 
-class IntTensor(_SparseBase, _C.SparseIntTensorBase, _TensorBase):
+class SparseIntTensor(_SparseBase, _C.SparseIntTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
+IntTensor = SparseIntTensor
 
-class ShortTensor(_SparseBase, _C.SparseShortTensorBase, _TensorBase):
+class SparseShortTensor(_SparseBase, _C.SparseShortTensorBase, _TensorBase):
     def is_signed(self):
         return True
 
+ShortTensor = SparseShortTensor
 
-class CharTensor(_SparseBase, _C.SparseCharTensorBase, _TensorBase):
+class SparseCharTensor(_SparseBase, _C.SparseCharTensorBase, _TensorBase):
     def is_signed(self):
         # TODO
         return False
 
+CharTensor = SparseCharTensor
 
-class ByteTensor(_SparseBase, _C.SparseByteTensorBase, _TensorBase):
+class SparseByteTensor(_SparseBase, _C.SparseByteTensorBase, _TensorBase):
     def is_signed(self):
         return False
 
+ByteTensor = SparseByteTensor
 
 _sparse_tensor_classes.add(DoubleTensor)
 _sparse_tensor_classes.add(FloatTensor)
@@ -181,6 +190,13 @@ _sparse_tensor_classes.add(IntTensor)
 _sparse_tensor_classes.add(ShortTensor)
 _sparse_tensor_classes.add(CharTensor)
 _sparse_tensor_classes.add(ByteTensor)
+_sparse_tensor_classes.add(SparseDoubleTensor)
+_sparse_tensor_classes.add(SparseFloatTensor)
+_sparse_tensor_classes.add(SparseLongTensor)
+_sparse_tensor_classes.add(SparseIntTensor)
+_sparse_tensor_classes.add(SparseShortTensor)
+_sparse_tensor_classes.add(SparseCharTensor)
+_sparse_tensor_classes.add(SparseByteTensor)
 torch._tensor_classes.update(_sparse_tensor_classes)
 
 _C._sparse_init()


### PR DESCRIPTION
Previously, when you got a type error involving a tensor,
you got the following message:

    AttributeError: type object 'FloatTensor' has no attribute 'foo'

This error would be the same whether or not you had a sparse or
regular tensor.

With this commit, by defining the sparse tensor classes with sparse
in their name, and then creating aliases, means that now we will
see 'SparseFloatTensor' if there is an error.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>