### PR TITLE
add device asserts in scatter/gather kernels

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -829,6 +829,15 @@ class TestCuda(TestCase):
     def test_btrisolve(self):
         TestTorch._test_btrisolve(self, lambda t: t.cuda())
 
+    def test_tensor_gather(self):
+        TestTorch._test_gather(self, lambda t: t.cuda(), False)
+
+    def test_tensor_scatter(self):
+        TestTorch._test_scatter(self, lambda t: t.cuda(), False)
+
+    def test_tensor_scatterFill(self):
+        TestTorch._test_scatterFill(self, lambda t: t.cuda(), False)
+
 
 if HAS_CUDA:
     for decl in tests:

--- a/torch/lib/THC/THCTensorScatterGather.cu
+++ b/torch/lib/THC/THCTensorScatterGather.cu
@@ -93,7 +93,7 @@ __global__ void THCudaTensor_gatherKernel(
                                                           src, &srcOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
-    assert(indexValue < src.sizes[dim]);
+    assert(indexValue >= 0 && indexValue < src.sizes[dim]);
     srcOffset += indexValue * src.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -120,7 +120,7 @@ __global__ void THCudaTensor_scatterKernel(
                                                           tensor, &tensorOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
-    assert(indexValue < tensor.sizes[dim]);
+    assert(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -145,7 +145,7 @@ __global__ void THCudaTensor_scatterFillKernel(
                                                           tensor, &tensorOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
-    assert(indexValue < tensor.sizes[dim]);
+    assert(indexValue >= 0 && indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = value;

--- a/torch/lib/THC/THCTensorScatterGather.cu
+++ b/torch/lib/THC/THCTensorScatterGather.cu
@@ -93,6 +93,7 @@ __global__ void THCudaTensor_gatherKernel(
                                                           src, &srcOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
+    assert(indexValue < src.sizes[dim]);
     srcOffset += indexValue * src.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -119,6 +120,7 @@ __global__ void THCudaTensor_scatterKernel(
                                                           tensor, &tensorOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
+    assert(indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = src.data[srcOffset];
@@ -143,6 +145,7 @@ __global__ void THCudaTensor_scatterFillKernel(
                                                           tensor, &tensorOffset);
 
     IndexType indexValue = (IndexType)index.data[indexOffset] - TH_INDEX_BASE;
+    assert(indexValue < tensor.sizes[dim]);
     tensorOffset += indexValue * tensor.strides[dim];
 
     tensor.data[tensorOffset] = value;


### PR DESCRIPTION
Addresses #1368.

Test Plan:
- Test in existing CuTorch repository, verify that tests still pass
- Test with invalid index, and `CUDA_LAUNCH_BLOCKING=1`, verify device-side assert is triggered