### PR TITLE
Enable specifying of margin in HingeEmbeddingLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -217,7 +217,15 @@ class HingeEmbeddingLoss(_Loss):
 
     The `margin` has a default value of `1`, or can be set in the constructor.
     """
-    pass
+
+    def __init__(self, margin=1.0, size_average=True):
+        super(HingeEmbeddingLoss, self).__init__()
+        self.margin = margin
+        self.size_average = size_average
+
+    def forward(self, input, target):
+        return self._backend.HingeEmbeddingLoss(self.margin,
+                                                self.size_average)(input, target)
 
 
 class MultiLabelMarginLoss(_Loss):


### PR DESCRIPTION
Previously it was not possible to set a value for the margin in the HingeEmbeddingLoss in the constructor. This patch fixes the issue and makes the loss behave as it is described in the docs. 

A discussion of this issue can be viewed here:
https://discuss.pytorch.org/t/issue-with-setting-margin-for-hingeembeddingloss/2088