### PR TITLE
Use fully qualified name as tp_name for tensors and storages

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -335,6 +335,8 @@ import torch.autograd
 import torch.nn
 import torch.optim
 import torch.multiprocessing
+import torch.sparse
+_C._init_names(list(torch._tensor_classes) + list(torch._storage_classes))
 
 # attach docstrings to torch and tensor functions
 from . import _torch_docs, _tensor_docs

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -153,33 +153,9 @@ PyObject * THPUtils_dispatchStateless(
   return PyObject_Call(method.get(), args, kwargs);
 }
 
-std::string _THPUtils_typename(PyObject *object)
+static inline std::string _THPUtils_typename(PyObject *object)
 {
-  std::string type_name = Py_TYPE(object)->tp_name;
-  std::string result;
-  if (type_name.find("Storage") != std::string::npos ||
-          type_name.find("Tensor") != std::string::npos) {
-    PyObject *module_name = PyObject_GetAttrString(object, "__module__");
-#if PY_MAJOR_VERSION == 2
-    if (module_name && PyString_Check(module_name)) {
-      result = PyString_AS_STRING(module_name);
-    }
-#else
-    if (module_name && PyUnicode_Check(module_name)) {
-      PyObject *module_name_bytes = PyUnicode_AsASCIIString(module_name);
-      if (module_name_bytes) {
-        result = PyBytes_AS_STRING(module_name_bytes);
-        Py_DECREF(module_name_bytes);
-      }
-    }
-#endif
-    Py_XDECREF(module_name);
-    result += ".";
-    result += type_name;
-  } else {
-    result = std::move(type_name);
-  }
-  return result;
+  return Py_TYPE(object)->tp_name;
 }
 
 


### PR DESCRIPTION
Currently, AttributeErrors on tensors and storages are ambiguous. It's unclear if they refer to the CUDA, sparse, or regular CPU classes:

```
>>> torch.FloatTensor().foobar
AttributeError: 'FloatTensor' object has no attribute 'foobar'
```

Types defined in C don't have this problem because their `tp_name` field contains the fully qualified name:

```
>>> torch._C.FloatTensorBase().foobar
AttributeError: 'torch._C.FloatTensorBase' object has no attribute 'foobar'
```

This changes the `tp_name` field on the Tensor and Storage classes to be their fully qualified name. The `__name__` attribute is still the "simple" class name, which is necessary for pickling in Python 2. This matches the behavior for types defined in C:

```
>>> torch.FloatTensor().foobar
AttributeError: 'torch.FloatTensor' object has no attribute 'foobar'
>>> torch.cuda.FloatTensor().foobar
AttributeError: 'torch.cuda.FloatTensor' object has no attribute 'foobar'
>>> ~torch.cuda.FloatTensor()
TypeError: bad operand type for unary ~: 'torch.cuda.FloatTensor'
```