### PR TITLE
Add option to disable ppc64le's VSX support

### DIFF
--- a/torch/lib/TH/README.md
+++ b/torch/lib/TH/README.md
@@ -1,7 +1,11 @@
 Environment variables control the disabling of certain explicit SIMD optimizations.
 
 ```
+x64 options:
 TH_NO_AVX2=1 # disable AVX2 codepaths
 TH_NO_AVX=1  # disable AVX codepaths
 TH_NO_SSE=1  # disable SSE codepaths
+
+ppc64le options:
+TH_NO_VSX=1  # disable VSX codepaths
 ```

--- a/torch/lib/TH/generic/simd/simd.h
+++ b/torch/lib/TH/generic/simd/simd.h
@@ -78,7 +78,13 @@ static inline uint32_t detectHostSIMDExtensions()
 
 static inline uint32_t detectHostSIMDExtensions()
 {
-  return SIMDExtension_VSX;
+  uint32_t hostSimdExts = SIMDExtension_DEFAULT;
+  char *evar;
+
+  evar = getenv("TH_NO_VSX");
+  if (evar == NULL || strncmp(evar, "1", 2) != 0)
+    hostSimdExts = SIMDExtension_VSX;
+  return hostSimdExts;
 }
 
  #else //PPC64 without VSX
@@ -89,7 +95,7 @@ static inline uint32_t detectHostSIMDExtensions()
 }
 
  #endif
-  
+
 #else   // x86
 static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
 {
@@ -146,7 +152,7 @@ static inline uint32_t detectHostSIMDExtensions()
 
   evar = getenv("TH_NO_SSE");
   if (evar == NULL || strncmp(evar, "1", 2) != 0)
-    TH_NO_SSE = 0;  
+    TH_NO_SSE = 0;
   if (edx & CPUID_SSE_BIT && TH_NO_SSE == 0) {
     hostSimdExts |= SIMDExtension_SSE;
   }


### PR DESCRIPTION
Set environment variable TH_NO_VSX=1 to disable VSX.
This helps debugging SIMD implementations in ppc64le builds.