### PR TITLE
Doc fixes for init and InstanceNorm

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -303,19 +303,19 @@ Normalization layers
     :members:
 
 :hidden:`InstanceNorm1d`
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: InstanceNorm1d
     :members:
 
 :hidden:`InstanceNorm2d`
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: InstanceNorm2d
     :members:
 
 :hidden:`InstanceNorm3d`
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: InstanceNorm3d
     :members:

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -7,6 +7,7 @@ from torch.autograd import Variable
 
 def calculate_gain(nonlinearity, param=None):
     """Return the recommended gain value for the given nonlinearity function. The values are as follows:
+
     ============ ==========================================
     nonlinearity gain
     ============ ==========================================
@@ -179,7 +180,7 @@ def xavier_uniform(tensor, gain=1):
     """Fills the input Tensor or Variable with values according to the method described in "Understanding the
     difficulty of training deep feedforward neural networks" - Glorot, X. & Bengio, Y. (2010), using a uniform
     distribution. The resulting tensor will have values sampled from :math:`U(-a, a)` where
-    :math:`a = gain \times \sqrt{2 / (fan\_in + fan\_out)} \times \sqrt{3}`. Also known as Glorot initialisation.
+    :math:`a = gain \\times \sqrt{2 / (fan\_in + fan\_out)} \\times \sqrt{3}`. Also known as Glorot initialisation.
 
     Args:
         tensor: an n-dimensional torch.Tensor or autograd.Variable
@@ -203,7 +204,7 @@ def xavier_normal(tensor, gain=1):
     """Fills the input Tensor or Variable with values according to the method described in "Understanding the
     difficulty of training deep feedforward neural networks" - Glorot, X. & Bengio, Y. (2010), using a normal
     distribution. The resulting tensor will have values sampled from :math:`N(0, std)` where
-    :math:`std = gain \times \sqrt{2 / (fan\_in + fan\_out)}`. Also known as Glorot initialisation.
+    :math:`std = gain \\times \sqrt{2 / (fan\_in + fan\_out)}`. Also known as Glorot initialisation.
 
     Args:
         tensor: an n-dimensional torch.Tensor or autograd.Variable
@@ -236,7 +237,7 @@ def kaiming_uniform(tensor, a=0, mode='fan_in'):
     """Fills the input Tensor or Variable with values according to the method described in "Delving deep into
     rectifiers: Surpassing human-level performance on ImageNet classification" - He, K. et al. (2015), using a uniform
     distribution. The resulting tensor will have values sampled from :math:`U(-bound, bound)` where
-    :math:`bound = \sqrt{2 / ((1 + a^2) \times fan\_in)} \times \sqrt{3}`. Also known as He initialisation.
+    :math:`bound = \sqrt{2 / ((1 + a^2) \\times fan\_in)} \\times \sqrt{3}`. Also known as He initialisation.
 
     Args:
         tensor: an n-dimensional torch.Tensor or autograd.Variable
@@ -263,7 +264,7 @@ def kaiming_normal(tensor, a=0, mode='fan_in'):
     """Fills the input Tensor or Variable with values according to the method described in "Delving deep into
     rectifiers: Surpassing human-level performance on ImageNet classification" - He, K. et al. (2015), using a normal
     distribution. The resulting tensor will have values sampled from :math:`N(0, std)` where
-    :math:`std = \sqrt{2 / ((1 + a^2) \times fan\_in)}`. Also known as He initialisation.
+    :math:`std = \sqrt{2 / ((1 + a^2) \\times fan\_in)}`. Also known as He initialisation.
 
     Args:
         tensor: an n-dimensional torch.Tensor or autograd.Variable

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -84,8 +84,11 @@ class InstanceNorm1d(_InstanceNorm):
 
 class InstanceNorm2d(_InstanceNorm):
     r"""Applies Instance Normalization over a 4d input that is seen as a mini-batch of 3d inputs
+
     .. math::
+
         y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
+
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. Gamma and beta are learnable parameter vectors
     of size C (where C is the input size).


### PR DESCRIPTION
Fixes the table and `\times` in the init docs.
Fixes the title underlining and maths indentation in the InstanceNorm docs.

On a side note, my local Sphinx docs seem to build from my install (within the miniconda folder), not the cloned repo itself - any ideas?