### PR TITLE
Refactor test_sparse to reduce boilerplate.

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -10,9 +10,7 @@ from numbers import Number
 
 def cpu_only(inner):
     def outer(self, *args, **kwargs):
-        if self.is_cuda:
-            unittest.skip("Test is CPU-only")
-        inner(self, *args, **kwargs)
+        unittest.skipIf(self.is_cuda, "Test is CPU-only")(inner)(self, *args, **kwargs)
     return outer
 
 class TestSparse(TestCase):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -8,10 +8,12 @@ from common import TestCase, run_tests
 from common_nn import TEST_CUDA
 from numbers import Number
 
+
 def cpu_only(inner):
     def outer(self, *args, **kwargs):
         unittest.skipIf(self.is_cuda, "Test is CPU-only")(inner)(self, *args, **kwargs)
     return outer
+
 
 class TestSparse(TestCase):
 
@@ -508,6 +510,7 @@ class TestSparse(TestCase):
         self._test_sparse_mask_shape([10, 10, 10], [3])
         self._test_sparse_mask_shape([50, 30, 20], [2])
         self._test_sparse_mask_shape([5, 5, 5, 5, 5, 5], [2])
+
 
 @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
 class TestCudaSparse(TestSparse):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -8,28 +8,38 @@ from common import TestCase, run_tests
 from common_nn import TEST_CUDA
 from numbers import Number
 
-# triplet := (index type, value type, sparse type)
-cpu_triplet = (
-    torch.LongTensor,
-    torch.DoubleTensor,
-    torch.sparse.DoubleTensor)
-
-if TEST_CUDA:
-    cuda_triplet = (
-        torch.cuda.LongTensor,
-        torch.cuda.DoubleTensor,
-        torch.cuda.sparse.DoubleTensor)
-
+def cpu_only(inner):
+    def outer(self, *args, **kwargs):
+        if self.is_cuda:
+            unittest.skip("Test is CPU-only")
+        inner(self, *args, **kwargs)
+    return outer
 
 class TestSparse(TestCase):
 
-    @staticmethod
-    def _gen_sparse(d, nnz, with_size, is_cuda=False):
+    def setUp(self):
+        # These parameters control the various ways we can run the test.
+        # We will subclass and override this method to implement CUDA
+        # tests
+        self.is_cuda = False
+        self.IndexTensor = torch.LongTensor
+        self.ValueTensor = torch.DoubleTensor
+        self.SparseTensor = torch.sparse.DoubleTensor
+
+    def _gen_sparse(self, d, nnz, with_size):
+        # TODO: Consider implementing this in the CUDA case by directly
+        # performing the operations on the GPU.  You won't be able to
+        # use torch.rand/torch.randn in this case because they are
+        # CPU-only.  If you do this, you can remove the is_cuda branch
+        # at the end.
+
         if isinstance(with_size, Number):
             v = torch.randn(nnz)
             i = (torch.rand(d, nnz) * with_size).type(torch.LongTensor)
             x = torch.sparse.DoubleTensor(i, v)
         else:
+            # Generate a sparse tensor with d sparse dimensions; the
+            # rest the dimensions with_size[d:] are dense.
             v_size = [nnz] + list(with_size[d:])
             v = torch.randn(*v_size)
             i = torch.rand(d, nnz) * \
@@ -37,18 +47,25 @@ class TestSparse(TestCase):
             i = i.type(torch.LongTensor)
             x = torch.sparse.DoubleTensor(i, v, torch.Size(with_size))
 
-        if is_cuda:
+        if self.is_cuda:
             return x.cuda(), i.cuda(), v.cuda()
         else:
             return x, i.clone(), v.clone()
 
-    def _test_basic(self, is_cuda):
-        x, i, v = self._gen_sparse(3, 10, 100, is_cuda)
+    def randn(self, *args, **kwargs):
+        # TODO: Maybe do this directly on GPU
+        x = torch.randn(*args, **kwargs)
+        if self.is_cuda:
+            x = x.cuda()
+        return x
+
+    def test_basic(self):
+        x, i, v = self._gen_sparse(3, 10, 100)
 
         self.assertEqual(i, x.indices())
         self.assertEqual(v, x.values())
 
-        x, i, v = self._gen_sparse(3, 10, [100, 100, 100], is_cuda)
+        x, i, v = self._gen_sparse(3, 10, [100, 100, 100])
         self.assertEqual(i, x.indices())
         self.assertEqual(v, x.values())
         self.assertEqual(x.ndimension(), 3)
@@ -56,30 +73,20 @@ class TestSparse(TestCase):
         for i in range(3):
             self.assertEqual(x.size(i), 100)
 
-        SparseTensor = (cuda_triplet if is_cuda else cpu_triplet)[2]
         # Make sure we can access empty indices / values
-        x = SparseTensor()
+        x = self.SparseTensor()
         self.assertEqual(x.indices().numel(), 0)
         self.assertEqual(x.values().numel(), 0)
 
-    def test_basic(self):
-        self._test_basic(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_basic_cuda(self):
-        self._test_basic(True)
-
-    def _test_to_dense(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def test_to_dense(self):
+        i = self.IndexTensor([
             [0, 1, 2, 2],
             [0, 0, 0, 3],
             [0, 0, 1, 4],
         ])
-        v = ValueTensor([2, 1, 3, 4])
-        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-        res = ValueTensor([
+        v = self.ValueTensor([2, 1, 3, 4])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 5]))
+        res = self.ValueTensor([
             [[2, 0, 0, 0, 0],
              [0, 0, 0, 0, 0],
              [0, 0, 0, 0, 0],
@@ -99,23 +106,14 @@ class TestSparse(TestCase):
         x.to_dense()
         self.assertEqual(res, x.to_dense())
 
-    def test_to_dense(self):
-        self._test_to_dense(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_to_dense_cuda(self):
-        self._test_to_dense(True)
-
-    def _test_to_dense_hybrid(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def test_to_dense_hybrid(self):
+        i = self.IndexTensor([
             [0, 1, 2, 2],
             [0, 0, 0, 3],
         ])
-        v = ValueTensor([[2, 3], [1, 2], [3, 4], [4, 5]])
-        x = SparseTensor(i, v, torch.Size([3, 4, 2]))
-        res = ValueTensor([
+        v = self.ValueTensor([[2, 3], [1, 2], [3, 4], [4, 5]])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 2]))
+        res = self.ValueTensor([
             [[2, 3],
              [0, 0],
              [0, 0],
@@ -135,92 +133,74 @@ class TestSparse(TestCase):
         x.to_dense()
         self.assertEqual(res, x.to_dense())
 
-    def test_to_dense_hybrid(self):
-        self._test_to_dense_hybrid(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_to_dense_hybrid_cuda(self):
-        self._test_to_dense_hybrid(True)
-
-    def _test_contig(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def test_contig(self):
+        i = self.IndexTensor([
             [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
             [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
         ])
-        v = ValueTensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        x = SparseTensor(i, v, torch.Size([100, 100]))
-        exp_i = IndexTensor([
+        v = self.ValueTensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        x = self.SparseTensor(i, v, torch.Size([100, 100]))
+        exp_i = self.IndexTensor([
             [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
             [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
         ])
-        exp_v = ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
+        exp_v = self.ValueTensor([2, 1, 6, 4, 10, 3, 5, 9, 8, 7])
         x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
-        i = IndexTensor([
+        i = self.IndexTensor([
             [2, 0, 2, 1],
             [0, 0, 3, 0],
             [1, 0, 4, 0],
         ])
-        v = ValueTensor([3, 2, 4, 1])
-        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-        exp_i = IndexTensor([
+        v = self.ValueTensor([3, 2, 4, 1])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 5]))
+        exp_i = self.IndexTensor([
             [0, 1, 2, 2],
             [0, 0, 0, 3],
             [0, 0, 1, 4],
         ])
-        exp_v = ValueTensor([2, 1, 3, 4])
+        exp_v = self.ValueTensor([2, 1, 3, 4])
 
         x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
         # Duplicate indices
-        i = IndexTensor([
+        i = self.IndexTensor([
             [0, 0, 2, 0],
             [0, 0, 3, 0],
             [0, 0, 4, 0],
         ])
-        v = ValueTensor([3, 2, 4, 1])
-        x = SparseTensor(i, v, torch.Size([3, 4, 5]))
-        exp_i = IndexTensor([
+        v = self.ValueTensor([3, 2, 4, 1])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 5]))
+        exp_i = self.IndexTensor([
             [0, 2],
             [0, 3],
             [0, 4],
         ])
-        exp_v = ValueTensor([6, 4])
+        exp_v = self.ValueTensor([6, 4])
 
         x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
-    def test_contig(self):
-        self._test_contig(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_contig_cuda(self):
-        self._test_contig(True)
-
-    def _test_contig_hybrid(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def test_contig_hybrid(self):
+        i = self.IndexTensor([
             [1, 0, 35, 14, 39, 6, 71, 66, 40, 27],
             [92, 31, 62, 50, 22, 65, 89, 74, 56, 34],
         ])
-        v = ValueTensor([
+        v = self.ValueTensor([
             [1, 2], [2, 3], [3, 4], [4, 5], [5, 6],
             [6, 7], [7, 8], [8, 9], [9, 10], [10, 11],
         ])
-        x = SparseTensor(i, v, torch.Size([100, 100, 2]))
-        exp_i = IndexTensor([
+        x = self.SparseTensor(i, v, torch.Size([100, 100, 2]))
+        exp_i = self.IndexTensor([
             [0, 1, 6, 14, 27, 35, 39, 40, 66, 71],
             [31, 92, 65, 50, 34, 62, 22, 56, 74, 89],
         ])
-        exp_v = ValueTensor([
+        exp_v = self.ValueTensor([
             [2, 3], [1, 2], [6, 7], [4, 5], [10, 11],
             [3, 4], [5, 6], [9, 10], [8, 9], [7, 8],
         ])
@@ -228,52 +208,45 @@ class TestSparse(TestCase):
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
-        i = IndexTensor([
+        i = self.IndexTensor([
             [2, 0, 2, 1],
             [0, 0, 3, 0],
             [1, 0, 4, 0],
         ])
-        v = ValueTensor([[3, 3, 3], [2, 2, 2], [4, 4, 4], [1, 1, 1]])
-        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
-        exp_i = IndexTensor([
+        v = self.ValueTensor([[3, 3, 3], [2, 2, 2], [4, 4, 4], [1, 1, 1]])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = self.IndexTensor([
             [0, 1, 2, 2],
             [0, 0, 0, 3],
             [0, 0, 1, 4],
         ])
-        exp_v = ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
+        exp_v = self.ValueTensor([[2, 2, 2], [1, 1, 1], [3, 3, 3], [4, 4, 4]])
 
         x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
         # Duplicate indices
-        i = IndexTensor([
+        i = self.IndexTensor([
             [0, 0, 2, 0],
             [0, 0, 3, 0],
             [0, 0, 4, 0],
         ])
-        v = ValueTensor([[3, 2, 3], [2, 1, 1], [4, 3, 4], [1, 1, 1]])
-        x = SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
-        exp_i = IndexTensor([
+        v = self.ValueTensor([[3, 2, 3], [2, 1, 1], [4, 3, 4], [1, 1, 1]])
+        x = self.SparseTensor(i, v, torch.Size([3, 4, 5, 3]))
+        exp_i = self.IndexTensor([
             [0, 2],
             [0, 3],
             [0, 4],
         ])
-        exp_v = ValueTensor([[6, 4, 5], [4, 3, 4]])
+        exp_v = self.ValueTensor([[6, 4, 5], [4, 3, 4]])
 
         x = self.safeCoalesce(x)
         self.assertEqual(exp_i, x.indices())
         self.assertEqual(exp_v, x.values())
 
-    def test_contig_hybrid(self):
-        self._test_contig_hybrid(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_contig_hybrid_cuda(self):
-        self._test_contig_hybrid(True)
-
-    def _test_transpose(self, is_cuda):
-        x = self._gen_sparse(4, 20, 5, is_cuda=is_cuda)[0]
+    def test_transpose(self):
+        x = self._gen_sparse(4, 20, 5)[0]
         y = x.to_dense()
 
         for i, j in itertools.combinations(range(4), 2):
@@ -285,13 +258,7 @@ class TestSparse(TestCase):
             y = y.transpose(i, j)
             self.assertEqual(x.to_dense(), y)
 
-    def test_transpose(self):
-        self._test_transpose(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_transpose_cuda(self):
-        self._test_transpose(True)
-
+    @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk):
             x, _, _ = self._gen_sparse(2, 20, [di, dj])
@@ -316,6 +283,7 @@ class TestSparse(TestCase):
         test_shape(100, 1000, 200)
         test_shape(64, 10000, 300)
 
+    @cpu_only
     def test_saddmm(self):
         def test_shape(di, dj, dk):
             x = self._gen_sparse(2, 20, [di, dj])[0]
@@ -340,12 +308,10 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
-    def _test_dsmm(self, is_cuda):
+    def test_dsmm(self):
         def test_shape(di, dj, dk):
-            x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
-            y = torch.randn(dj, dk)
-            if is_cuda:
-                y = y.cuda()
+            x = self._gen_sparse(2, 20, [di, dj])[0]
+            y = self.randn(dj, dk)
 
             res = torch.dsmm(x, y)
             expected = torch.mm(x.to_dense(), y)
@@ -355,19 +321,10 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
-    def test_dsmm(self):
-        self._test_dsmm(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_dsmm_cuda(self):
-        self._test_dsmm(True)
-
-    def _test_hsmm(self, is_cuda):
+    def test_hsmm(self):
         def test_shape(di, dj, dk):
-            x = self._gen_sparse(2, 20, [di, dj], is_cuda)[0]
-            y = torch.randn(dj, dk)
-            if is_cuda:
-                y = y.cuda()
+            x = self._gen_sparse(2, 20, [di, dj])[0]
+            y = self.randn(dj, dk)
 
             res = torch.hsmm(x, y)
             expected = torch.mm(x.to_dense(), y)
@@ -377,19 +334,10 @@ class TestSparse(TestCase):
         test_shape(1000, 100, 100)
         test_shape(3000, 64, 300)
 
-    def test_hsmm(self):
-        self._test_hsmm(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_hsmm_cuda(self):
-        self._test_hsmm(True)
-
-    def _test_spadd_shape(self, is_cuda, shape_i, shape_v=None):
+    def _test_spadd_shape(self, shape_i, shape_v=None):
         shape = shape_i + (shape_v or [])
-        x, _, _ = self._gen_sparse(len(shape_i), 10, shape, is_cuda)
-        y = torch.randn(*shape)
-        if is_cuda:
-            y = y.cuda()
+        x, _, _ = self._gen_sparse(len(shape_i), 10, shape)
+        y = self.randn(*shape)
         r = random.random()
 
         res = torch.add(y, r, x)
@@ -401,9 +349,7 @@ class TestSparse(TestCase):
         s = list(shape)
         s[0] = shape[-1]
         s[-1] = shape[0]
-        y = torch.randn(*s)
-        if is_cuda:
-            y = y.cuda()
+        y = self.randn(*s)
         y.transpose_(0, len(s) - 1)
         r = random.random()
 
@@ -412,36 +358,22 @@ class TestSparse(TestCase):
 
         self.assertEqual(res, expected)
 
-    def _test_spadd(self, is_cuda):
-        self._test_spadd_shape(is_cuda, [5, 6])
-        self._test_spadd_shape(is_cuda, [10, 10, 10])
-        self._test_spadd_shape(is_cuda, [50, 30, 20])
-        self._test_spadd_shape(is_cuda, [5, 5, 5, 5, 5, 5])
-
     def test_spadd(self):
-        self._test_spadd(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_spadd_cuda(self):
-        self._test_spadd(True)
-
-    def _test_spadd_hybrid(self, is_cuda):
-        self._test_spadd_shape(is_cuda, [5, 6], [2, 3])
-        self._test_spadd_shape(is_cuda, [10, 10, 10], [3])
-        self._test_spadd_shape(is_cuda, [50, 30, 20], [2])
-        self._test_spadd_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
+        self._test_spadd_shape([5, 6])
+        self._test_spadd_shape([10, 10, 10])
+        self._test_spadd_shape([50, 30, 20])
+        self._test_spadd_shape([5, 5, 5, 5, 5, 5])
 
     def test_spadd_hybrid(self):
-        self._test_spadd_hybrid(False)
+        self._test_spadd_shape([5, 6], [2, 3])
+        self._test_spadd_shape([10, 10, 10], [3])
+        self._test_spadd_shape([50, 30, 20], [2])
+        self._test_spadd_shape([5, 5, 5, 5, 5, 5], [2])
 
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_spadd_hybrid_cuda(self):
-        self._test_spadd_hybrid(True)
-
-    def _test_basic_ops_shape(self, is_cuda, shape_i, shape_v=None):
+    def _test_basic_ops_shape(self, shape_i, shape_v=None):
         shape = shape_i + (shape_v or [])
-        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
-        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
+        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape)
+        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape)
 
         y1 = x1 + x2
         y2 = x1.clone()
@@ -501,36 +433,22 @@ class TestSparse(TestCase):
         y.values().add_(1)
         self.assertEqual(z.values() + 1, y.values())
 
-    def _test_basic_ops(self, is_cuda):
-        self._test_basic_ops_shape(is_cuda, [5, 6])
-        self._test_basic_ops_shape(is_cuda, [10, 10, 10])
-        self._test_basic_ops_shape(is_cuda, [50, 30, 20])
-        self._test_basic_ops_shape(is_cuda, [5, 5, 5, 5, 5, 5])
-
     def test_basic_ops(self):
-        self._test_basic_ops(False)
-
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_basic_ops_cuda(self):
-        self._test_basic_ops(True)
-
-    def _test_basic_ops_hybrid(self, is_cuda):
-        self._test_basic_ops_shape(is_cuda, [5, 6], [2, 3])
-        self._test_basic_ops_shape(is_cuda, [10, 10, 10], [3])
-        self._test_basic_ops_shape(is_cuda, [50, 30, 20], [2])
-        self._test_basic_ops_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
+        self._test_basic_ops_shape([5, 6])
+        self._test_basic_ops_shape([10, 10, 10])
+        self._test_basic_ops_shape([50, 30, 20])
+        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5])
 
     def test_basic_ops_hybrid(self):
-        self._test_basic_ops_hybrid(False)
+        self._test_basic_ops_shape([5, 6], [2, 3])
+        self._test_basic_ops_shape([10, 10, 10], [3])
+        self._test_basic_ops_shape([50, 30, 20], [2])
+        self._test_basic_ops_shape([5, 5, 5, 5, 5, 5], [2])
 
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_basic_ops_hybrid_cuda(self):
-        self._test_basic_ops_hybrid(True)
-
-    def _test_sparse_mask_shape(self, is_cuda, shape_i, shape_v=None):
+    def _test_sparse_mask_shape(self, shape_i, shape_v=None):
         shape = shape_i + (shape_v or [])
-        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape, is_cuda)
-        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape, is_cuda)
+        x1, _, _ = self._gen_sparse(len(shape_i), 9, shape)
+        x2, _, _ = self._gen_sparse(len(shape_i), 12, shape)
 
         y1 = x1 + x2
         y2 = x1.clone()
@@ -539,52 +457,41 @@ class TestSparse(TestCase):
         self.assertEqual(y1.to_dense(), expected)
         self.assertEqual(y2.to_dense(), expected)
 
-    def _test_sparse_mask_fixed(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def _test_sparse_mask_fixed(self):
+        i = self.IndexTensor([
             [1, 3, 3, 0, 4],
             [2, 1, 1, 2, 3],
         ])
-        v = ValueTensor([1, 2, 3, 4, 5])
-        x = SparseTensor(i, v, torch.Size([5, 4]))
-        dense = ValueTensor([
+        v = self.ValueTensor([1, 2, 3, 4, 5])
+        x = self.SparseTensor(i, v, torch.Size([5, 4]))
+        dense = self.ValueTensor([
             [1, 2, 3, 4],
             [5, 6, 7, 8],
             [9, 10, 11, 12],
             [13, 14, 15, 16],
             [17, 18, 19, 20],
         ])
-        exp_v = ValueTensor([7, 14, 14, 3, 20])
+        exp_v = self.ValueTensor([7, 14, 14, 3, 20])
         res = dense.sparse_mask(x)
-        expected = SparseTensor(i, exp_v, torch.Size([5, 4]))
+        expected = self.SparseTensor(i, exp_v, torch.Size([5, 4]))
         self.assertEqual(res, expected)
 
-    def _test_sparse_mask(self, is_cuda):
-        self._test_sparse_mask_fixed(is_cuda)
-
-        self._test_sparse_mask_shape(is_cuda, [5, 6])
-        self._test_sparse_mask_shape(is_cuda, [10, 10, 10])
-        self._test_sparse_mask_shape(is_cuda, [50, 30, 20])
-        self._test_sparse_mask_shape(is_cuda, [5, 5, 5, 5, 5, 5])
-
     def test_sparse_mask(self):
-        self._test_sparse_mask(False)
+        self._test_sparse_mask_fixed()
 
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_sparse_mask_cuda(self):
-        self._test_sparse_mask(True)
+        self._test_sparse_mask_shape([5, 6])
+        self._test_sparse_mask_shape([10, 10, 10])
+        self._test_sparse_mask_shape([50, 30, 20])
+        self._test_sparse_mask_shape([5, 5, 5, 5, 5, 5])
 
-    def _test_sparse_mask_hybrid_fixed(self, is_cuda):
-        IndexTensor, ValueTensor, SparseTensor = \
-            cuda_triplet if is_cuda else cpu_triplet
-        i = IndexTensor([
+    def _test_sparse_mask_hybrid_fixed(self):
+        i = self.IndexTensor([
             [1, 3, 3, 0, 4],
             [2, 1, 1, 2, 3],
         ])
-        v = ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]])
-        x = SparseTensor(i, v, torch.Size([5, 4, 2]))
-        dense = ValueTensor([
+        v = self.ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]])
+        x = self.SparseTensor(i, v, torch.Size([5, 4, 2]))
+        dense = self.ValueTensor([
             [[1, 3], [2, 2], [3, 3], [4, 2]],
             [[5, 7], [6, 7], [7, 9], [8, 9]],
             [[9, 2], [10, 4], [11, 1], [12, 3]],
@@ -592,25 +499,25 @@ class TestSparse(TestCase):
             [[17, 7], [18, 2], [19, 7], [20, 1]],
         ])
         res = dense.sparse_mask(x)
-        exp_v = ValueTensor([[7, 9], [14, 1], [14, 1], [3, 3], [20, 1]])
-        expected = SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
+        exp_v = self.ValueTensor([[7, 9], [14, 1], [14, 1], [3, 3], [20, 1]])
+        expected = self.SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
         self.assertEqual(res, expected)
 
-    def _test_sparse_mask_hybrid(self, is_cuda):
-        self._test_sparse_mask_hybrid_fixed(is_cuda)
-
-        self._test_sparse_mask_shape(is_cuda, [5, 6], [2, 3])
-        self._test_sparse_mask_shape(is_cuda, [10, 10, 10], [3])
-        self._test_sparse_mask_shape(is_cuda, [50, 30, 20], [2])
-        self._test_sparse_mask_shape(is_cuda, [5, 5, 5, 5, 5, 5], [2])
-
     def test_sparse_mask_hybrid(self):
-        self._test_sparse_mask_hybrid(False)
+        self._test_sparse_mask_hybrid_fixed()
 
-    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_sparse_mask_hybrid_cuda(self):
-        self._test_sparse_mask_hybrid(True)
+        self._test_sparse_mask_shape([5, 6], [2, 3])
+        self._test_sparse_mask_shape([10, 10, 10], [3])
+        self._test_sparse_mask_shape([50, 30, 20], [2])
+        self._test_sparse_mask_shape([5, 5, 5, 5, 5, 5], [2])
 
+@unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+class TestCudaSparse(TestSparse):
+    def setUp(self):
+        self.is_cuda = True
+        self.IndexTensor = torch.cuda.LongTensor
+        self.ValueTensor = torch.cuda.DoubleTensor
+        self.SparseTensor = torch.cuda.sparse.DoubleTensor
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Instead of manually creating a helper function, threading an is_cuda
parameter around, and creating a test method for CUDA and non-CUDA
variants, we take a different approach:

- There is now some new member variables initialized in setUp which
  control the aspects of how we carry out the test; at the moment,
  it's just whether or not we are using CUDA or not.  This means
  you don't have to pass is_cuda around, or do a conditional to
  get the triplet of constructors you need.

  I'll note that I am not a big fan of member variables in test
  objects, but these are (intended to be) immutable so I think
  it should be OK.

- Instead of manually defining test_foo and test_foo_cuda, we now
  have a new TestCudaSparse class which overrides setUp (from above)
  to swap in the CUDA implementation.  Way less boilerplate, and NO
  metaprogramming needed.

  If you need to opt out of CUDA testing, there is a new cpu_only
  decorator you can use.

BUYER BEWARE: I haven't actually tested this on GPU yet.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>