### PR TITLE
Expose custom attributes from C++ functions

### DIFF
--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -78,7 +78,7 @@ PyObject* getTupleAttr(PyObject* obj, void* _unused)
 {
   HANDLE_TH_ERRORS
   THPCppFunction* self = (THPCppFunction*)obj;
-  auto& arr = (T*)(self->cdata.get())->*ptr;
+  auto& arr = ((T*)(self->cdata.get()))->*ptr;
   auto num_elems = arr.size();
   THPObjectPtr py_tuple = PyTuple_New(num_elems);
   if (!py_tuple) return NULL;
@@ -95,7 +95,7 @@ PyObject* getValueAttr(PyObject* obj, void* _unused)
 {
   HANDLE_TH_ERRORS
   THPCppFunction* self = (THPCppFunction*)obj;
-  auto& val = (T*)(self->cdata.get())->*ptr;
+  auto& val = ((T*)(self->cdata.get()))->*ptr;
   return Convert(val);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -4,6 +4,7 @@
 #include "accumulate_grad.h"
 #include "basic_ops.h"
 #include "tensor.h"
+#include "torch/csrc/THP.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/utils/tuple_parser.h"
 
@@ -62,27 +63,83 @@ struct NoCtor {
 };
 
 template<typename C, typename T>
-static void addClass(PyObject* module, PyTypeObject& type, const char* name)
+static void addClass(PyObject* module, PyTypeObject& type, const char* name,
+  PyGetSetDef* function_properties=NULL, PyMethodDef* function_methods=NULL)
 {
-  createForwardFunctionPyTypeObject<T>(type, name);
+  createForwardFunctionPyTypeObject<T>(type, name, function_properties, function_methods);
   Py_INCREF(&type);
   PyModule_AddObject(module, name, (PyObject*)&type);
   registerCppFunction(typeid(C), &type);
 }
+
+template<typename T, typename M, typename P, M P::*ptr, typename V, PyObject* (*Convert)(V)>
+PyObject* getTupleAttr(PyObject* obj, void* _unused)
+{
+  THPCppFunction* self = (THPCppFunction*)obj;
+  auto& arr = std::static_pointer_cast<T>(self->cdata).get()->*ptr;
+  auto num_elems = arr.size();
+  THPObjectPtr py_tuple = PyTuple_New(num_elems);
+  if (!py_tuple) return NULL;
+  for (size_t i = 0; i < num_elems; ++i) {
+    PyTuple_SET_ITEM(py_tuple.get(), i, Convert(arr[i]));
+  }
+  return py_tuple.release();
+}
+
+template<typename T, typename M, typename P, M P::*ptr, typename V, PyObject* (*Convert)(V)>
+PyObject* getValueAttr(PyObject* obj, void* _unused)
+{
+  THPCppFunction* self = (THPCppFunction*)obj;
+  auto& val = std::static_pointer_cast<T>(self->cdata).get()->*ptr;
+  return Convert(val);
+}
+
+static struct PyGetSetDef conv_forward_properties[] = {
+  THP_FUNCTION_DEFAULT_PROPERTIES,
+  {(char*)"stride", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+                                         &ConvParams::stride, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+                                         &ConvParams::padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"dilation", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+                                         &ConvParams::dilation, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"transposed", (getter)getValueAttr<ConvForward, bool, ConvParams, 
+                                         &ConvParams::transposed, long, PyBool_FromLong>, NULL, NULL, NULL},
+  {(char*)"output_padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+                                         &ConvParams::output_padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"groups", (getter)getValueAttr<ConvForward, int, ConvParams, 
+                                         &ConvParams::groups, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {NULL}
+};
+
+static struct PyGetSetDef conv_backward_properties[] = {
+  THP_FUNCTION_DEFAULT_PROPERTIES,
+  {(char*)"stride", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+                                         &ConvParams::stride, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+                                         &ConvParams::padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"dilation", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+                                         &ConvParams::dilation, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"transposed", (getter)getValueAttr<ConvBackward, bool, ConvParams, 
+                                         &ConvParams::transposed, long, PyBool_FromLong>, NULL, NULL, NULL},
+  {(char*)"output_padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+                                         &ConvParams::output_padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"groups", (getter)getValueAttr<ConvBackward, int, ConvParams, 
+                                         &ConvParams::groups, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {NULL}
+};
 
 bool THPAutograd_initFunctions(PyObject* _unused)
 {
   THPObjectPtr module = PyModule_New("torch._C._functions");
   if (!module) return false;
 
-
   static PyTypeObject BatchNormClass, BatchNormBackwardClass;
   addClass<BatchNormForward, BatchNormCtor>(module, BatchNormClass, "BatchNorm");
   addClass<BatchNormBackward, NoCtor>(module, BatchNormBackwardClass, "BatchNormBackward");
 
   static PyTypeObject ConvClass, ConvBackwardClass;
-  addClass<ConvForward, ConvCtor>(module, ConvClass, "ConvNd");
-  addClass<ConvBackward, NoCtor>(module, ConvBackwardClass, "ConvNdBackward");
+  addClass<ConvForward, ConvCtor>(module, ConvClass, "ConvNd", conv_forward_properties);
+  addClass<ConvBackward, NoCtor>(module, ConvBackwardClass, "ConvNdBackward", conv_backward_properties);
 
   static PyTypeObject AccumulateGradClass;
   addClass<AccumulateGrad, NoCtor>(module, AccumulateGradClass, "AccumulateGrad");

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -72,11 +72,13 @@ static void addClass(PyObject* module, PyTypeObject& type, const char* name,
   registerCppFunction(typeid(C), &type);
 }
 
-template<typename T, typename M, typename P, M P::*ptr, typename V, PyObject* (*Convert)(V)>
+template<typename T, typename ValueT, typename ParamsT, ValueT ParamsT::*ptr,
+         typename ConvertArgT, PyObject* (*Convert)(ConvertArgT)>
 PyObject* getTupleAttr(PyObject* obj, void* _unused)
 {
+  HANDLE_TH_ERRORS
   THPCppFunction* self = (THPCppFunction*)obj;
-  auto& arr = std::static_pointer_cast<T>(self->cdata).get()->*ptr;
+  auto& arr = (T*)(self->cdata.get())->*ptr;
   auto num_elems = arr.size();
   THPObjectPtr py_tuple = PyTuple_New(num_elems);
   if (!py_tuple) return NULL;
@@ -84,14 +86,18 @@ PyObject* getTupleAttr(PyObject* obj, void* _unused)
     PyTuple_SET_ITEM(py_tuple.get(), i, Convert(arr[i]));
   }
   return py_tuple.release();
+  END_HANDLE_TH_ERRORS
 }
 
-template<typename T, typename M, typename P, M P::*ptr, typename V, PyObject* (*Convert)(V)>
+template<typename T, typename ValueT, typename ParamsT, ValueT ParamsT::*ptr,
+         typename ConvertArgT, PyObject* (*Convert)(ConvertArgT)>
 PyObject* getValueAttr(PyObject* obj, void* _unused)
 {
+  HANDLE_TH_ERRORS
   THPCppFunction* self = (THPCppFunction*)obj;
-  auto& val = std::static_pointer_cast<T>(self->cdata).get()->*ptr;
+  auto& val = (T*)(self->cdata.get())->*ptr;
   return Convert(val);
+  END_HANDLE_TH_ERRORS
 }
 
 static struct PyGetSetDef conv_forward_properties[] = {

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -90,7 +90,7 @@ void THPCppFunction_dealloc(PyObject* self)
 
 } // namespace
 
-PyObject* next_functions(THPCppFunction* self, PyObject* hook)
+PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
 {
   auto& next_functions = self->cdata->next_functions;
   auto num_next = next_functions.size();
@@ -111,7 +111,7 @@ PyObject* next_functions(THPCppFunction* self, PyObject* hook)
   return py_functions.release();
 }
 
-PyObject* register_hook_dict(PyObject* self, PyObject* _var)
+PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var)
 {
   if (!THPVariable_Check(_var)) {
     return PyErr_Format(PyExc_TypeError, "_register_hook_dict expected a variable");
@@ -123,7 +123,7 @@ PyObject* register_hook_dict(PyObject* self, PyObject* _var)
   Py_RETURN_NONE;
 }
 
-PyObject* register_hook(PyObject* self, PyObject* hook)
+PyObject* THPCppFunction_register_hook(PyObject* self, PyObject* hook)
 {
   auto& fn = *((THPCppFunction*)self)->cdata;
   return registerFunctionHook(fn, hook);

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -31,15 +31,15 @@ PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 #define THP_FUNCTION_DEFAULT_METHODS \
-  {(char*)"_register_hook_dict", (PyCFunction)register_hook_dict, METH_O, NULL}, \
-  {(char*)"register_hook", (PyCFunction)register_hook, METH_O, NULL}
+  {(char*)"_register_hook_dict", (PyCFunction)THPCppFunction_register_hook_dict, METH_O, NULL}, \
+  {(char*)"register_hook", (PyCFunction)THPCppFunction_register_hook, METH_O, NULL}
 
 #define THP_FUNCTION_DEFAULT_PROPERTIES \
-  {(char*)"next_functions", (getter)next_functions, NULL, NULL, NULL}
+  {(char*)"next_functions", (getter)THPCppFunction_next_functions, NULL, NULL, NULL}
 
-PyObject* next_functions(THPCppFunction* self, PyObject* hook);
-PyObject* register_hook_dict(PyObject* self, PyObject* _var);
-PyObject* register_hook(PyObject* self, PyObject* hook);
+PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook);
+PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var);
+PyObject* THPCppFunction_register_hook(PyObject* self, PyObject* hook);
 
 PyTypeObject* _initFunctionPyTypeObject(PyTypeObject& type, const char* name,
   PyGetSetDef* function_properties, PyMethodDef* function_methods);

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -30,15 +30,28 @@ PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   return obj.release();
 }
 
-PyTypeObject* _initFunctionPyTypeObject(PyTypeObject& type, const char* name);
+#define THP_FUNCTION_DEFAULT_METHODS \
+  {(char*)"_register_hook_dict", (PyCFunction)register_hook_dict, METH_O, NULL}, \
+  {(char*)"register_hook", (PyCFunction)register_hook, METH_O, NULL}
+
+#define THP_FUNCTION_DEFAULT_PROPERTIES \
+  {(char*)"next_functions", (getter)next_functions, NULL, NULL, NULL}
+
+PyObject* next_functions(THPCppFunction* self, PyObject* hook);
+PyObject* register_hook_dict(PyObject* self, PyObject* _var);
+PyObject* register_hook(PyObject* self, PyObject* hook);
+
+PyTypeObject* _initFunctionPyTypeObject(PyTypeObject& type, const char* name,
+  PyGetSetDef* function_properties, PyMethodDef* function_methods);
 
 PyObject* registerFunctionHook(Function& fn, PyObject* hook);
 
 template<typename Ctor>
-PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* name)
+PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* name,
+  PyGetSetDef* function_properties=NULL, PyMethodDef* function_methods=NULL)
 {
   type.tp_new = &CppFunction_pynew<Ctor>;
-  return _initFunctionPyTypeObject(type, name);
+  return _initFunctionPyTypeObject(type, name, function_properties, function_methods);
 }
 
 void registerCppFunction(const std::type_info& type, PyTypeObject* pytype);


### PR DESCRIPTION
**This PR is a resubmission of #1405 rebased onto `master` after the `autograd` refactor merge.**

This PR demonstrates a possible way to expose custom attributes from C++ functions.
Motivation: right now functions implemented in C++ do not expose function-specific attributes or methods (e.g. stride for ConvForward). This makes it impossible to get such attributes while traversing a computation graph.

Currently only convolution attributes have been exposed, with the aim of illustrating the approach. If the proposal gets a thumbs up, I'll proceed and expose attributes for the rest of the C++ functions.