### PR TITLE
A number of post-merge fixes for test_sparse

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -84,11 +84,11 @@ class TestSparse(TestCase):
         assert (z.values() > 1).sum() > 0
 
     def randn(self, *args, **kwargs):
-        # TODO: Maybe do this directly on GPU
-        x = torch.randn(*args, **kwargs)
-        if self.is_cuda:
-            x = x.cuda()
-        return x
+        """
+        Variant of torch.randn that also works in the TEST_CUDA case.
+        """
+        # TODO: Put this in torch.cuda.randn
+        return self.ValueTensor(*args, **kwargs).normal_()
 
     def test_basic(self):
         x, i, v = self._gen_sparse(3, 10, 100)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -35,6 +35,8 @@ class TestSparse(TestCase):
         # use torch.rand/torch.randn in this case because they are
         # CPU-only.  If you do this, you can remove the is_cuda branch
         # at the end.
+        #
+        # If you do this, be sure to update assert_uncoalesced too
 
         if isinstance(with_size, Number):
             with_size = [with_size] * d
@@ -69,7 +71,7 @@ class TestSparse(TestCase):
 
     def assert_uncoalesced(self, x):
         """
-        Test if a tensor is uncoalesced.  This is used to ensure
+        Test if a CPU tensor is uncoalesced.  This is used to ensure
         correctness of the uncoalesced tensor generation algorithm.
         """
         assert not x.is_coalesced()
@@ -79,7 +81,7 @@ class TestSparse(TestCase):
         # original was uncoalesced.)
         i = x.indices().clone()
         v = x.values().clone().fill_(1)
-        y = self.SparseTensor(i, v, x.size())
+        y = torch.sparse.DoubleTensor(i, v, x.size())
         z = self.safeCoalesce(y)
         assert (z.values() > 1).sum() > 0
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -11,7 +11,9 @@ from numbers import Number
 
 def cpu_only(inner):
     def outer(self, *args, **kwargs):
-        unittest.skipIf(self.is_cuda, "Test is CPU-only")(inner)(self, *args, **kwargs)
+        if self.is_cuda:
+            raise unittest.SkipTest("Test is CPU-only")
+        inner(self, *args, **kwargs)
     return outer
 
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -43,12 +43,12 @@ class TestSparse(TestCase):
             # We want to generate a tensor with a lot of uncoalesced
             # entries to stress test whether or not we handle this
             # (subtle) case correctly
-            v_size = [nnz*2] + list(with_size[d:])
+            v_size = [nnz * 2] + list(with_size[d:])
             v = torch.randn(*v_size)
             r = torch.rand(d, nnz)
             # Repeat the indexes, so every position shows up twice
             i = torch.cat([r, r], dim=1) * \
-                torch.Tensor(with_size[:d]).repeat(nnz*2, 1).transpose(0, 1)
+                torch.Tensor(with_size[:d]).repeat(nnz * 2, 1).transpose(0, 1)
             i = i.type(torch.LongTensor)
             x = torch.sparse.DoubleTensor(i, v, torch.Size(with_size))
             self.assert_uncoalesced(x)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -34,18 +34,16 @@ class TestSparse(TestCase):
         # at the end.
 
         if isinstance(with_size, Number):
-            v = torch.randn(nnz)
-            i = (torch.rand(d, nnz) * with_size).type(torch.LongTensor)
-            x = torch.sparse.DoubleTensor(i, v)
-        else:
-            # Generate a sparse tensor with d sparse dimensions; the
-            # rest the dimensions with_size[d:] are dense.
-            v_size = [nnz] + list(with_size[d:])
-            v = torch.randn(*v_size)
-            i = torch.rand(d, nnz) * \
-                torch.Tensor(with_size[:d]).repeat(nnz, 1).transpose(0, 1)
-            i = i.type(torch.LongTensor)
-            x = torch.sparse.DoubleTensor(i, v, torch.Size(with_size))
+            with_size = [with_size] * d
+
+        # Generate a sparse tensor with d sparse dimensions; the
+        # rest the dimensions with_size[d:] are dense.
+        v_size = [nnz] + list(with_size[d:])
+        v = torch.randn(*v_size)
+        i = torch.rand(d, nnz) * \
+            torch.Tensor(with_size[:d]).repeat(nnz, 1).transpose(0, 1)
+        i = i.type(torch.LongTensor)
+        x = torch.sparse.DoubleTensor(i, v, torch.Size(with_size))
 
         if self.is_cuda:
             return x.cuda(), i.cuda(), v.cuda()


### PR DESCRIPTION
Handle two of the reviewer comments, add testing with uncoalesced tensors as inputs, and a simpler `_gen_sparse` implementation. Read commit-by-commit.