### PR TITLE
Convert contiguous() call in adagrad to out-of-place coalesce.

### DIFF
--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -64,7 +64,7 @@ class Adagrad(Optimizer):
                 clr = group['lr'] / (1 + (state['step'] - 1) * group['lr_decay'])
 
                 if p.grad.data.is_sparse:
-                    grad.contiguous()  # the update is non-linear so indices must be unique
+                    grad = grad.coalesce()  # the update is non-linear so indices must be unique
                     grad_indices = grad.indices()
                     grad_values = grad.values()
                     size = torch.Size([x for x in grad.size()])


### PR DESCRIPTION
We missed this one in f2903332c7dce1fbb7d7d9f18dcfba8e853581df!

CC @adamlerer 

Signed-off-by: Edward Z. Yang <ezyang@fb.com>