### PR TITLE
Improve kthvalue documentation.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1757,12 +1757,14 @@ add_docstr(torch._C.kthvalue,
            """
 kthvalue(input, k, dim=None, out=None) -> (Tensor, LongTensor)
 
-Returns the :attr:`k`th smallest element of the given :attr:`input` Tensor along a given dimension.
+Returns the :attr:`k` th smallest element of the given :attr:`input` Tensor along a given dimension.
 
 If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 
 A tuple of `(values, indices)` is returned, where the `indices` is the indices of
-the kth-smallest element in the original `input` Tensor in dimention `dim`.
+the kth-smallest element in the original `input` Tensor in dimention `dim`.  Both the
+:attr:`values` and :attr:`indices` tensors are the same size as :attr:`input` except in
+the dimension :attr:`dim` where they are of size 1.
 
 Args:
     input (Tensor): the input `Tensor`
@@ -1792,6 +1794,21 @@ Example::
     [torch.LongTensor of size 1]
     )
 
+    >>> x=torch.arange(1,7).resize_(2,3)
+    >>> x
+
+    1  2  3
+    4  5  6
+    [torch.FloatTensor of size 2x3]
+
+    >>> torch.kthvalue(x,2,0)
+    (
+    4  5  6
+    [torch.FloatTensor of size 1x3]
+           ,
+    1  1  1
+    [torch.LongTensor of size 1x3]
+    )
 """)
 
 add_docstr(torch._C.le,


### PR DESCRIPTION
1) Fix "kth" attr specification -- I can't get sphinx to generate `k`th,
but `k` th works with a space, unlike now where the highlighting continues
until the next attr.
2) Specify the size of the return tensors.
3) Add an example of the return tensor sizes with more than 1 dimension.