### PR TITLE
Use at most one shared_ptr block at a time to manage THPFunctions

### DIFF
--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -43,6 +43,8 @@ struct THPFunction {
     std::vector<bool> *is_variable_input;
     char has_freed_buffers;
 
+    // See a comment in THPFucntion_asFunction for details about this field.
+    std::weak_ptr<torch::autograd::PyFunction> cdata_ptr;
     torch::autograd::PyFunction cdata;
 };
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -93,7 +93,7 @@ auto SavedVariable::unpack() -> std::shared_ptr<Variable> {
   // should have saved the grad accumulator. Even if the Variable no longer
   // alive, the accumulator should be kept alive by the references in the graph).
   if (requires_grad && !grad_fn && weak_grad_fn.expired() && grad_accumulator.expired())
-      throw std::logic_error("No grad accumulator for a saved leaf!");
+    throw std::logic_error("No grad accumulator for a saved leaf!");
   new_var->grad_accumulator = grad_accumulator;
 
   return new_var;

--- a/torch/lib/build_all.sh
+++ b/torch/lib/build_all.sh
@@ -28,7 +28,7 @@ BASIC_C_FLAGS=" -DTH_INDEX_BASE=0 -I$INSTALL_DIR/include \
 LDFLAGS="-L$INSTALL_DIR/lib "
 LD_POSTFIX=".so.1"
 LD_POSTFIX_UNVERSIONED=".so"
-if [[ $(uname) == 'Darwin' ]]; then    
+if [[ $(uname) == 'Darwin' ]]; then
     LDFLAGS="$LDFLAGS -Qunused-arguments -Wl,-rpath,@loader_path"
     LD_POSTFIX=".1.dylib"
     LD_POSTFIX_UNVERSIONED=".dylib"
@@ -93,7 +93,9 @@ function build_nccl() {
                -DCMAKE_CXX_FLAGS="$C_FLAGS $CPP_FLAGS"
    make install
    cp "lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so.1"
-   ln -s "${INSTALL_DIR}/lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so"
+   if [ ! -f "${INSTALL_DIR}/lib/libnccl.so" ]; then
+     ln -s "${INSTALL_DIR}/lib/libnccl.so.1" "${INSTALL_DIR}/lib/libnccl.so"
+   fi
    cd ../..
 }
 


### PR DESCRIPTION
Fixes #1450. Also, a minor fix for `build_all.sh`.