### PR TITLE
Fix #1447: sparse_mask doesn't make sense with uncoalesced tensors

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -492,11 +492,11 @@ class TestSparse(TestCase):
 
     def _test_sparse_mask_fixed(self):
         i = self.IndexTensor([
-            [1, 3, 3, 0, 4],
-            [2, 1, 1, 2, 3],
+            [1, 3, 0, 4],
+            [2, 1, 2, 3],
         ])
-        v = self.ValueTensor([1, 2, 3, 4, 5])
-        x = self.SparseTensor(i, v, torch.Size([5, 4]))
+        v = self.ValueTensor([1, 2, 3, 4])
+        x = self.SparseTensor(i, v, torch.Size([5, 4])).coalesce()
         dense = self.ValueTensor([
             [1, 2, 3, 4],
             [5, 6, 7, 8],
@@ -504,7 +504,7 @@ class TestSparse(TestCase):
             [13, 14, 15, 16],
             [17, 18, 19, 20],
         ])
-        exp_v = self.ValueTensor([7, 14, 14, 3, 20])
+        exp_v = self.ValueTensor([7, 14, 3, 20])
         res = dense._sparse_mask(x)
         expected = self.SparseTensor(i, exp_v, torch.Size([5, 4]))
         self.assertEqual(res, expected)
@@ -519,11 +519,14 @@ class TestSparse(TestCase):
 
     def _test_sparse_mask_hybrid_fixed(self):
         i = self.IndexTensor([
-            [1, 3, 3, 0, 4],
-            [2, 1, 1, 2, 3],
+            [1, 3, 0, 4],
+            [2, 1, 2, 3],
         ])
-        v = self.ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]])
-        x = self.SparseTensor(i, v, torch.Size([5, 4, 2]))
+        v = self.ValueTensor([[1, 2], [2, 3], [3, 4], [4, 5]])
+        # TODO: This is also testing that, if coalesce is a no-op,
+        # the indices don't get permuted. I don't know if we actually
+        # want to give this invariant.
+        x = self.SparseTensor(i, v, torch.Size([5, 4, 2])).coalesce()
         dense = self.ValueTensor([
             [[1, 3], [2, 2], [3, 3], [4, 2]],
             [[5, 7], [6, 7], [7, 9], [8, 9]],
@@ -532,7 +535,7 @@ class TestSparse(TestCase):
             [[17, 7], [18, 2], [19, 7], [20, 1]],
         ])
         res = dense._sparse_mask(x)
-        exp_v = self.ValueTensor([[7, 9], [14, 1], [14, 1], [3, 3], [20, 1]])
+        exp_v = self.ValueTensor([[7, 9], [14, 1], [3, 3], [20, 1]])
         expected = self.SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
         self.assertEqual(res, expected)
 

--- a/torch/lib/THCS/generic/THCSTensor.c
+++ b/torch/lib/THCS/generic/THCSTensor.c
@@ -420,6 +420,7 @@ int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned
 }
 
 void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCSTensor *mask) {
+  THArgCheck(mask->coalesced, 2, "mask is uncoalesced");
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 2, 3, r_, mask, t));
   if(!THCSTensor_(isSameSizeAsDense)(state, mask, t)) {
     THError("sparseMask operands have incompatible sizes");

--- a/torch/lib/THS/generic/THSTensor.c
+++ b/torch/lib/THS/generic/THSTensor.c
@@ -465,6 +465,7 @@ THSTensor *THSTensor_(newCoalesce)(THSTensor *self) {
 }
 
 void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask) {
+  THArgCheck(mask->coalesced, 2, "mask is uncoalesced");
   THSTensor_(resizeAs)(r_, mask);
   if (mask->nnz == 0) {
     THSTensor_(zero)(r_);


### PR DESCRIPTION
```
commit e3265c38fa8f87fae36a2b774236f0d77c3c22cf
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed May 3 12:23:32 2017 -0400

    Add test for sparse adagrad.
    
    Previously, the sparse codepath was not exercised at all; this commit
    adds a very simple test case "sparse Rosenbrock"; the idea is to do
    Rosenbrock but then knock out one of the dimensions so that the
    tensor is sparse.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 1bd6e8e6288212777ebf767dffe81453fd852078
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed May 3 11:28:18 2017 -0400

    Make sparseMask error if mask is uncoalesced.
    
    Fixes #1447.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```