### PR TITLE
Backward in autograd __init.py__ was doing an illegal multiply

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -77,7 +77,7 @@ def backward(variables, grad_variables=None, retain_graph=None, create_graph=Non
     variables = tuple(variables)
 
     if grad_variables is None:
-        grad_variables = (None,) * variables
+        grad_variables = (None,) * len(variables)
     grad_variables, create_graph = _make_grads(variables, list(grad_variables), create_graph)
 
     if retain_variables is not None:


### PR DESCRIPTION
In the case of grad_variables being None, the torch.autograd.backward function wanted to create a tuple of Nones the same length as the number of variables. But instead of multiplying (None) by len(variables), it was multiplying (None) by the variables themselves.

Just changed the line to have it multiply by len(variables).
