### PR TITLE
Fix memory leak in coalesce.

### DIFF
--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -164,6 +164,8 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
 
   THCIndexTensor_(free)(state, indices);
   THCTensor_(free)(state, values);
+  THCIndexTensor_(free)(state, newIndices);
+  THCTensor_(free)(state, newValues);
 
   dst->coalesced = 1;
   THCudaCheck(cudaGetLastError());


### PR DESCRIPTION
Fixes #1449.

For future reference, we should have a doc explaining our ref-counting
conventions; it looks like this bug slipped by because we assumed that
newTensor was taking ownership of the pointers it was passed in.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>