### PR TITLE
fix corner-case in MaxPooling

### DIFF
--- a/torch/lib/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/torch/lib/THNN/generic/SpatialDilatedMaxPooling.c
@@ -300,8 +300,10 @@ static void THNN_(SpatialDilatedMaxPooling_updateGradInput_frame)(
       {
         /* retrieve position of max */
         long maxp = ind_p_k[i*outputWidth + j] - TH_INDEX_BASE;
-        /* update gradient */
-        gradInput_p_k[maxp] += gradOutput_p_k[i*outputWidth + j];
+	if (maxp != -1) {
+	  /* update gradient */
+	  gradInput_p_k[maxp] += gradOutput_p_k[i*outputWidth + j];
+	}
       }
     }
   }

--- a/torch/lib/THNN/generic/TemporalMaxPooling.c
+++ b/torch/lib/THNN/generic/TemporalMaxPooling.c
@@ -242,7 +242,8 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
       {
         /* compute local max: */
         long maxindex = (long)xp[y];
-        gip[maxindex*framesize+y] += gop[y];
+	if (maxindex != -1)
+	  gip[maxindex*framesize+y] += gop[y];
       }
     }
   }
@@ -268,7 +269,8 @@ void THNN_(TemporalMaxPooling_updateGradInput)(
         {
           /* compute local max: */
           long maxindex = (long)xp[y];
-          gip[maxindex*framesize+y] += gop[y];
+	  if (maxindex != -1)
+	    gip[maxindex*framesize+y] += gop[y];
         }
       }
     }

--- a/torch/lib/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/torch/lib/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -157,10 +157,11 @@ static void THNN_(VolumetricDilatedMaxPooling_updateOutput_frame)(
           THIndex_t *indzp = indz_p + k * otime * owidth * oheight
             + ti * owidth * oheight + i * owidth + j;
 
-          /* compute local max: */
-          real maxval = -THInf;
-          int x,y,z;
-          int mx, my, mz;
+	  /* compute local max: */
+	  real maxval = -THInf;
+	  int x,y,z;
+	  int mx, my, mz;
+	  mx = my = mz = -1;
 
           for (z = 0; z < kernel_t; z++)
           {
@@ -385,9 +386,11 @@ static void THNN_(VolumetricDilatedMaxPooling_updateGradInput_frame)(
           long maxi  = ((unsigned char*)(indzp))[1] * dilationH + i * dH - pH;
           long maxj  = ((unsigned char*)(indzp))[2] * dilationW + j * dW - pW;
 
-          /* update gradient */
-          gradInput_p_k[maxti * iheight * iwidth + maxi * iwidth + maxj] +=
-            gradOutput_p_k[ti * oheight * owidth + i * owidth + j];
+	  if (maxti != -1) {
+	    /* update gradient */
+	    gradInput_p_k[maxti * iheight * iwidth + maxi * iwidth + maxj] +=
+	      gradOutput_p_k[ti * oheight * owidth + i * owidth + j];
+	  }
         }
       }
     }


### PR DESCRIPTION
If the entire window in a MaxPooling operation is filled with NaN or -inf, then the indices stored in forward were remaining at -1 and MaxPooling operations were corrupting the stack by writing to illegal memory data[-1] = value.

This PR fixes that behavior.