### PR TITLE
Fix bug in magma qr decomposition

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -113,6 +113,10 @@ def small_2d_lapack_fat(t):
     return t(4, 3).copy_(torch.arange(1, 13).view(4, 3))
 
 
+def large_2d_lapack(t):
+    return t(1000, 1000).normal_()
+
+
 def new_t(*sizes):
     def tmp(t):
         return t(*sizes).copy_(torch.randn(*sizes))
@@ -280,6 +284,7 @@ tests = [
     ('qr', small_2d_lapack, lambda t: [], 'square', float_types),
     ('qr', small_2d_lapack_skinny, lambda t: [], 'skinny', float_types),
     ('qr', small_2d_lapack_fat, lambda t: [], 'fat', float_types),
+    ('qr', large_2d_lapack, lambda t: [], 'big', float_types),
 
 ]
 
@@ -294,6 +299,7 @@ custom_precision = {
     'baddbmm': 1e-4,
     'rsqrt': 1e-4,
     'cumprod': 1e-4,
+    'qr': 1e-4,
 }
 
 simple_pointwise = [

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1397,6 +1397,12 @@ class TestTorch(TestCase):
         ))
         check_qr(a, expected_q, expected_r)
 
+        # check big matrix
+        a = torch.randn(1000, 1000)
+        q, r = torch.qr(a)
+        a_qr = torch.mm(q, r)
+        self.assertEqual(a, a_qr, prec=1e-3)
+
     @skipIfNoLapack
     def test_ormqr(self):
         mat1 = torch.randn(10, 10)

--- a/torch/lib/THC/generic/THCTensorMathMagma.cu
+++ b/torch/lib/THC/generic/THCTensorMathMagma.cu
@@ -621,6 +621,22 @@ THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THC
 
   int info;
 #if defined(THC_REAL_IS_FLOAT)
+  magma_sgeqrf2_gpu(m, n, a_data, m, tau_data, &info);
+#else
+  magma_dgeqrf2_gpu(m, n, a_data, m, tau_data, &info);
+#endif
+
+  if (info != 0)
+    THError("MAGMA geqrf2 : Argument %d : illegal value.", -info);
+
+  THCTensor_(narrow)(state, a, a, 0, 0, k);
+  THCTensor_(triu)(state, rr_, a, 0);
+  THCTensor_(free)(state, a);
+
+  a = THCTensor_(newColumnMajor)(state, rq_, a_);
+  a_data = THCTensor_(data)(state, a);
+
+#if defined(THC_REAL_IS_FLOAT)
   magma_sgeqrf_gpu(m, n, a_data, m, tau_data, work_data, &info);
 #else
   magma_dgeqrf_gpu(m, n, a_data, m, tau_data, work_data, &info);
@@ -631,10 +647,6 @@ THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THC
 
   THCTensor *q = THCTensor_(newColumnMajor)(state, rq_, a);
   real *q_data = THCTensor_(data)(state, q);
-
-  THCTensor_(narrow)(state, a, a, 0, 0, k);
-  THCTensor_(triu)(state, rr_, a, 0);
-  THCTensor_(free)(state, a);
 
 #if defined(THC_REAL_IS_FLOAT)
   magma_sorgqr_gpu(m, k, k, q_data, m, tau_data, work_data, nb, &info);

--- a/torch/lib/THC/generic/THCTensorMathMagma.cu
+++ b/torch/lib/THC/generic/THCTensorMathMagma.cu
@@ -608,15 +608,22 @@ THC_API void THCTensor_(qr)(THCState *state, THCTensor *rq_, THCTensor *rr_, THC
   int k = (m < n ? m : n);
 
 #ifdef MAGMA_V2
+#if defined(THC_REAL_IS_FLOAT)
   int nb = magma_get_sgeqrf_nb(m, n);
 #else
+  int nb = magma_get_dgeqrf_nb(m, n);
+#endif
+#else
+#if defined(THC_REAL_IS_FLOAT)
   int nb = magma_get_sgeqrf_nb(m);
+#else
+  int nb = magma_get_dgeqrf_nb(m);
+#endif
 #endif
 
   real *a_data = THCTensor_(data)(state, a);
-  real *tau_data = th_magma_malloc_pinned<real>(n*n);
-
-  THCTensor *work = THCTensor_(newWithSize1d)(state, (2*k + ((n+31)/32)*32)*nb);
+  real *tau_data = th_magma_malloc_pinned<real>(k);
+  THCTensor *work = THCTensor_(newWithSize1d)(state, (2*k + magma_roundup(n, 32))*nb);
   real *work_data = THCTensor_(data)(state, work);
 
   int info;


### PR DESCRIPTION
[Documentation](http://icl.cs.utk.edu/magma/forum/viewtopic.php?f=2&t=1015&p=2800&hilit=geqrf_gpu#p2800) for `geqrf_gpu` is incorrect. Tests pass because for smaller matrices `magma` falls back on `lapack` for qr factorization. For large matrices, returned `r` is incorrect. Bug can be reproduced using the following script (`r` will contains matrix with ones on diagonal):
```python
import torch
a = torch.rand(1000, 1000).cuda()
q, r = torch.qr(a)
```