### PR TITLE
Avoid segfault when calling join_with with self as arg

### DIFF
--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -37,10 +37,11 @@ struct VariableVersion {
   }
 
   void cleanup() {
-    if (!saved_ref) --version_block[2];
-    if (--version_block[1]) return;
-    delete[] version_block;
+    auto vb = version_block;
     version_block = nullptr;
+    if (!saved_ref) --vb[2];
+    if (--vb[1]) return;
+    delete[] vb;
   }
 
   ~VariableVersion() { cleanup(); }

--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -18,6 +18,9 @@ struct VariableVersion {
   int var_refcnt() { return version_block[2]; }
 
   void join_with(VariableVersion &other) {
+    if (this == &other) {
+      return;
+    }
     cleanup();
     version_block = other.version_block;
     version_block[1]++;


### PR DESCRIPTION
This PR solves #1480 and potentially similar corner cases.

With reference to #1480, when permute is called, the input and the result are marked as sharing storage (https://github.com/pytorch/pytorch/blob/master/torch/autograd/_functions/tensor.py#L161).
When identity indices (e.g. `(0,1,2)`) are provided, `input` and `result` are the same object, i.e. marking causes the segfault.

Marking leads to this call:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/python_function.cpp#L479
```
v2->cdata->version_counter->join_with(*v1->cdata->version_counter);
```
with `v1` and `v2` now being the same object.

Which in turn leads to https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/variable_version.h#L20-L25
```
  void join_with(VariableVersion &other) {
    cleanup(); // <------- version_block deallocated and set to null here 
    version_block = other.version_block; <------- other is the same object, so other.version_block is null now
    version_block[1]++; // <------- segfault!
    version_block[2]++;
  }
```

With this PR, `join_with` simply returns (no need to increase versions, @apaszke @soumith please check that my assumption is correct) when `this == &other`.