### PR TITLE
Autograd bugfixes and improvements

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -902,6 +902,13 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, torch.ones(5))
         self.assertEqual(z.grad.data, torch.ones(5) * 2)
 
+    def test_volatile_assignment(self):
+        x = Variable(torch.randn(5, 5))
+        y = Variable(torch.randn(5), volatile=True)
+
+        x[0] = y
+        self.assertTrue(x.volatile)
+
     def test_backward_copy(self):
         # This tests checks backward engine for a very subtle bug that appreared
         # in one of the initial versions of autograd. Gradients tensors were

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -183,7 +183,7 @@ class TestNN(NNTestCase):
             return module(input)
 
     def _backward(self, module, input, output, grad_output):
-        output.backward(grad_output, retain_variables=True)
+        output.backward(grad_output, retain_graph=True)
         if input.grad is None:
             return None
         return input.grad.data
@@ -266,11 +266,11 @@ class TestNN(NNTestCase):
         self.assertEqual(counter['forwards'], 3)
         self.assertEqual(counter['backwards'], 0)
 
-        output.backward(torch.ones(5, 5) * 2, retain_variables=True)
+        output.backward(torch.ones(5, 5) * 2, retain_graph=True)
         self.assertEqual(counter['forwards'], 3)
         self.assertEqual(counter['backwards'], 1)
 
-        output.backward(torch.ones(5, 5) * 2, retain_variables=True)
+        output.backward(torch.ones(5, 5) * 2, retain_graph=True)
         self.assertEqual(counter['forwards'], 3)
         self.assertEqual(counter['backwards'], 2)
 
@@ -704,7 +704,7 @@ class TestNN(NNTestCase):
         grads = torch.arange(1, 101), torch.ones(10).div(1000)
         for norm_type in [0.5, 1.5, 2, 4, 'inf']:
             for p, g in zip(l.parameters(), grads):
-                p._grad = Variable(g.clone())
+                p._grad = Variable(g.clone().view_as(p.data))
             norm_before = compute_norm(norm_type)
             norm = clip_grad_norm(l.parameters(), max_norm, norm_type=norm_type)
             norm_after = compute_norm(norm_type)
@@ -868,7 +868,7 @@ class TestNN(NNTestCase):
 
         # Make sure backward works
         grad_output = torch.ones(output.size()).type(type)
-        output.backward(grad_output, retain_variables=True)
+        output.backward(grad_output, retain_graph=True)
         expected_grad = expected_grad(num_dim)
         self.assertEqual(input_var.grad.data, expected_grad.view_as(input))
 
@@ -1670,11 +1670,11 @@ class TestNN(NNTestCase):
         rnn = nn.LSTM(10, 20, num_layers=2).type(dtype)
         input = Variable(torch.randn(5, 6, 10).type(dtype), requires_grad=True)
         output = rnn(input)
-        output[0].sum().backward(retain_variables=True)
+        output[0].sum().backward(retain_graph=True)
         grads = [input.grad.data.clone()] + [p.grad.data.clone() for p in rnn.parameters()]
         rnn.zero_grad()
         input.grad.data.zero_()
-        output[0].sum().backward(retain_variables=True)
+        output[0].sum().backward(retain_graph=True)
         grads2 = [input.grad.data] + [p.grad.data for p in rnn.parameters()]
         self.assertEqual(grads, grads2)
 
@@ -1986,7 +1986,7 @@ class TestNN(NNTestCase):
 
         grad = torch.randn(2, 2, 5, 10, 10).cuda()[:, 1]
         assert not grad.is_contiguous()
-        output.backward(grad, retain_variables=True)
+        output.backward(grad, retain_graph=True)
         self.assertIsNotNone(input.grad)
         result = input.grad.data.clone()
         input.grad.data.zero_()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -401,6 +401,12 @@ class TestNN(NNTestCase):
         self.assertEqual(module.weight.grad.data, module.weight.data.clone().zero_())
         self.assertEqual(module.bias.grad.data, module.bias.data.clone().zero_())
 
+        # non-volatile grad should be zeroed out of place
+        initial = module.weight.grad = Variable(torch.ones(5, 5))
+        module.zero_grad()
+        self.assertIsNot(module.weight.grad, initial)
+        self.assertEqual(module.weight.grad.data, torch.zeros(5, 5))
+
     def test_volatile(self):
         module = nn.Conv2d(2, 5, kernel_size=3, padding=1)
         input = torch.randn(1, 2, 10, 10)

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -74,11 +74,16 @@ def backward(variables, grad_variables=None, retain_graph=None, create_graph=Non
             Defaults to False, unless ``grad_variables`` contains at least one
             non-volatile Variable.
     """
-    variables = tuple(variables)
+    variables = (variables,) if isinstance(variables, Variable) else tuple(variables)
 
     if grad_variables is None:
-        grad_variables = (None,) * len(variables)
-    grad_variables, create_graph = _make_grads(variables, list(grad_variables), create_graph)
+        grad_variables = [None] * len(variables)
+    elif isinstance(grad_variables, Variable) or torch.is_tensor(grad_variables):
+        grad_variables = [grad_variables]
+    else:
+        grad_variables = list(grad_variables)
+
+    grad_variables, create_graph = _make_grads(variables, grad_variables, create_graph)
 
     if retain_variables is not None:
         if retain_graph is not None:
@@ -133,9 +138,11 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Non
     outputs = (outputs,) if isinstance(outputs, Variable) else tuple(outputs)
     inputs = (inputs,) if isinstance(inputs, Variable) else tuple(inputs)
     if grad_outputs is None:
-        grad_outputs = (None,) * len(outputs)
+        grad_outputs = [None] * len(outputs)
     elif isinstance(grad_outputs, Variable) or torch.is_tensor(grad_outputs):
-        grad_outputs = (grad_outputs,)
+        grad_outputs = [grad_outputs]
+    else:
+        grad_outputs = list(grad_outputs)
 
     grad_outputs, create_graph = _make_grads(outputs, grad_outputs, create_graph)
     if retain_graph is None:

--- a/torch/autograd/_functions/pointwise.py
+++ b/torch/autograd/_functions/pointwise.py
@@ -367,6 +367,7 @@ class Addcmul(InplaceFunction):
     def forward(self, add_tensor, mul_tensor1, mul_tensor2):
         self.save_for_backward(mul_tensor1, mul_tensor2)
         if self.inplace:
+            self.mark_dirty(add_tensor)
             return add_tensor.addcmul_(self.scale, mul_tensor1, mul_tensor2)
         else:
             return add_tensor.addcmul(self.scale, mul_tensor1, mul_tensor2)
@@ -396,6 +397,7 @@ class Addcdiv(InplaceFunction):
     def forward(self, add_tensor, div_tensor1, div_tensor2):
         self.save_for_backward(div_tensor1, div_tensor2)
         if self.inplace:
+            self.mark_dirty(add_tensor)
             return add_tensor.addcdiv_(self.scale, div_tensor1, div_tensor2)
         else:
             return add_tensor.addcdiv(self.scale, div_tensor1, div_tensor2)

--- a/torch/autograd/_functions/reduce.py
+++ b/torch/autograd/_functions/reduce.py
@@ -53,7 +53,7 @@ class Prod(Function):
             if zero_idx.dim() == 0:
                 return grad_output.mul(ctx.result).expand_as(input).div(input), None
             elif zero_idx.size(0) > 1:
-                return Variable(grad_output.data.new(ctx.input_size).zero_()), None
+                return (grad_output * 0).expand_as(input), None
             else:
                 grad_input = Variable(grad_output.data.new(ctx.input_size).zero_())
                 zero_idx = tuple(zero_idx[0].cpu())

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -94,8 +94,9 @@ class FunctionMeta(type):
 
     def __init__(cls, name, bases, attrs):
         for super_cls in cls.mro():
-            if 'forward' in super_cls.__dict__:
-                has_static_forward = isinstance(super_cls.__dict__['forward'], staticmethod)
+            forward = super_cls.__dict__.get('forward')
+            if forward is not None:
+                has_static_forward = isinstance(forward, staticmethod) or isinstance(forward, classmethod)
                 break
 
         setattr(cls, '_is_legacy', not has_static_forward)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -101,7 +101,7 @@ def get_analytical_jacobian(input, output):
         flat_grad_output.zero_()
         flat_grad_output[i] = 1
         zero_gradients(input)
-        output.backward(grad_output, retain_variables=True)
+        output.backward(grad_output, retain_graph=True)
         for jacobian_x, d_x in zip(jacobian, iter_gradients(input)):
             if d_x is None:
                 jacobian_x[:, i].zero_()

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -706,40 +706,28 @@ class Variable(_C._VariableBase):
         return Bernoulli()(self)
 
     def eq(self, other):
-        if isinstance(other, Variable):
-            return Eq()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Eq(other)(self)
+        return Eq.apply(self, other)
 
     def ne(self, other):
-        if isinstance(other, Variable):
-            return Ne()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Ne(other)(self)
+        return Ne.apply(self, other)
 
     def gt(self, other):
-        if isinstance(other, Variable):
-            return Gt()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Gt(other)(self)
+        return Gt.apply(self, other)
 
     def ge(self, other):
-        if isinstance(other, Variable):
-            return Ge()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Ge(other)(self)
+        return Ge.apply(self, other)
 
     def lt(self, other):
-        if isinstance(other, Variable):
-            return Lt()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Lt(other)(self)
+        return Lt.apply(self, other)
 
     def le(self, other):
-        if isinstance(other, Variable):
-            return Le()(self, other)
         assert not torch.is_tensor(other), "can't compare Variable and tensor"
-        return Le(other)(self)
+        return Le.apply(self, other)
 
     def __add__(self, other):
         return self.add(other)

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -154,35 +154,50 @@ static struct PyGetSetDef batch_norm_backward_properties[] = {
 
 static struct PyGetSetDef conv_forward_properties[] = {
   THP_FUNCTION_DEFAULT_PROPERTIES,
-  {(char*)"stride", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+  {(char*)"stride", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams,
                                          &ConvParams::stride, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+  {(char*)"padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams,
                                          &ConvParams::padding, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"dilation", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+  {(char*)"dilation", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams,
                                          &ConvParams::dilation, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"transposed", (getter)getValueAttr<ConvForward, bool, ConvParams, 
+  {(char*)"transposed", (getter)getValueAttr<ConvForward, bool, ConvParams,
                                          &ConvParams::transposed, long, PyBool_FromLong>, NULL, NULL, NULL},
-  {(char*)"output_padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams, 
+  {(char*)"output_padding", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams,
                                          &ConvParams::output_padding, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"groups", (getter)getValueAttr<ConvForward, int, ConvParams, 
+  {(char*)"groups", (getter)getValueAttr<ConvForward, int, ConvParams,
                                          &ConvParams::groups, long, PyInt_FromLong>, NULL, NULL, NULL},
   {NULL}
 };
 
 static struct PyGetSetDef conv_backward_properties[] = {
   THP_FUNCTION_DEFAULT_PROPERTIES,
-  {(char*)"stride", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+  {(char*)"stride", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams,
                                          &ConvParams::stride, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+  {(char*)"padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams,
                                          &ConvParams::padding, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"dilation", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+  {(char*)"dilation", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams,
                                          &ConvParams::dilation, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"transposed", (getter)getValueAttr<ConvBackward, bool, ConvParams, 
+  {(char*)"transposed", (getter)getValueAttr<ConvBackward, bool, ConvParams,
                                          &ConvParams::transposed, long, PyBool_FromLong>, NULL, NULL, NULL},
-  {(char*)"output_padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams, 
+  {(char*)"output_padding", (getter)getTupleAttr<ConvBackward, std::vector<int>, ConvParams,
                                          &ConvParams::output_padding, long, PyInt_FromLong>, NULL, NULL, NULL},
-  {(char*)"groups", (getter)getValueAttr<ConvBackward, int, ConvParams, 
+  {(char*)"groups", (getter)getValueAttr<ConvBackward, int, ConvParams,
                                          &ConvParams::groups, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {NULL}
+};
+
+static PyObject* accumulateGradVar(PyObject *_self, void* _unused)
+{
+  THPCppFunction* self = (THPCppFunction*)_self;
+  auto grad_acc = (AccumulateGrad*)self->cdata.get();
+  auto var = grad_acc->variable.lock();
+  if (!var) Py_RETURN_NONE;
+  return THPVariable_Wrap(var);
+}
+
+static struct PyGetSetDef accumulate_grad_properties[] = {
+  THP_FUNCTION_DEFAULT_PROPERTIES,
+  {(char*)"variable", accumulateGradVar, NULL, NULL, NULL},
   {NULL}
 };
 
@@ -200,7 +215,7 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   addClass<ConvBackward, NoCtor>(module, ConvBackwardClass, "ConvNdBackward", conv_backward_properties);
 
   static PyTypeObject AccumulateGradClass;
-  addClass<AccumulateGrad, NoCtor>(module, AccumulateGradClass, "AccumulateGrad");
+  addClass<AccumulateGrad, NoCtor>(module, AccumulateGradClass, "AccumulateGrad", accumulate_grad_properties);
 
   static PyTypeObject AddClass, AddBackwardClass;
   addClass<Add, NoCtor>(module, AddClass, "Add");

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -135,6 +135,8 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     THPUtils_assert(THPVariable_Check(_variable), "element %d of variables "
         "tuple is not a Variable", i);
     auto& variable = ((THPVariable*)_variable)->cdata;
+    THPUtils_assert(!variable->is_volatile,
+        "element %d of variables tuple is volatile", i);
     auto grad_fn = variable->grad_fn ? variable->grad_fn : variable->get_grad_accumulator();
     int output_nr = variable->grad_fn ? variable->output_nr : 0;
     roots[i] = std::make_pair<>(std::move(grad_fn), output_nr);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -41,17 +41,15 @@ PyObject * THPVariable_Wrap(const std::shared_ptr<Variable>& var)
   return var->pyobj;
 }
 
-// This function DOES NOT steal a reference to data and grad_fn
-PyObject * THPVariable_New(PyObject *data, PyObject *_grad_fn)
+// This function DOES NOT steal a reference to data
+PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<torch::autograd::Function>& grad_fn)
 {
   THPUtils_assert(THPModule_isTensor(data), "data must be a Tensor");
-  THPUtils_assert(THPFunction_Check(_grad_fn), "grad_fn must be a Function");
-  THPFunction *grad_fn = (THPFunction*)_grad_fn;
-  auto v = std::make_shared<Variable>(torch::createTensor(data), grad_fn->cdata.is_executable, false);
+  auto v = std::make_shared<Variable>(torch::createTensor(data), grad_fn->is_executable, false);
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
     v->pyobj = obj;
-    v->grad_fn = THPFunction_asFunction((THPFunction*)grad_fn);
+    v->grad_fn = grad_fn;
     ((THPVariable*)obj)->data = data;
     Py_INCREF(data);
   }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/Types.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
+#include "torch/csrc/autograd/functions/accumulate_grad.h"
 #include "torch/csrc/cuda/AutoGPU.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/Exceptions.h"
@@ -239,28 +240,6 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   return 0;
 }
 
-PyObject *THPVariable_get_raw_grad(THPVariable *self)
-{
-  auto& var = *self->cdata;
-  if (!var.grad) {
-    Py_RETURN_NONE;
-  }
-  return THPVariable_Wrap(var.grad);
-}
-
-int THPVariable_set_raw_grad(THPVariable *self, PyObject *data)
-{
-  auto& var = *self->cdata;
-  if (data == Py_None) {
-    var.grad.reset();
-    return 0;
-  }
-  THPUtils_assertRet(-1, THPVariable_Check(data),
-      "expected Variable or None (got %s)", THPUtils_typename(data));
-  var.grad = ((THPVariable*)data)->cdata;
-  return 0;
-}
-
 PyObject *THPVariable_get_grad(THPVariable *self)
 {
   auto& var = *self->cdata;
@@ -268,6 +247,38 @@ PyObject *THPVariable_get_grad(THPVariable *self)
     Py_RETURN_NONE;
   }
   return THPVariable_Wrap(var.grad);
+}
+
+int THPVariable_set_grad(THPVariable *self, PyObject *other)
+{
+  auto& var = *self->cdata;
+  if (other == Py_None) {
+    var.grad.reset();
+    return 0;
+  }
+
+  THPUtils_assertRet(-1, THPVariable_Check(other),
+      "expected Variable or None (got %s)", THPUtils_typename(other));
+  THPUtils_assertRet(-1, self != (THPVariable*)other,
+      "can't assign Variable as its own grad");
+
+  auto& other_var = ((THPVariable*)other)->cdata;
+
+  // Make sure the data is ok
+  THPUtils_assertRet(-1, other_var->data->type() == var.data->type(),
+      "assigned grad has data of a different type");
+  THPUtils_assertRet(-1, other_var->data->isCuda() == var.data->isCuda(),
+      "assigned grad has data located on a different device");
+  THPUtils_assertRet(-1, other_var->data->getDevice() == var.data->getDevice(),
+      "assigned grad has data located on a different device");
+  THPUtils_assertRet(-1, other_var->data->sizes() == var.data->sizes(),
+      "assigned grad has data of a different size");
+
+  var.grad = other_var;
+  if (auto grad_acc = var.grad_accumulator.lock()) {
+    ((AccumulateGrad*)grad_acc.get())->variable_grad = other_var;
+  }
+  return 0;
 }
 
 PyObject *THPVariable_get_volatile(THPVariable *self)
@@ -313,8 +324,7 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
     return -1;
   }
   var.requires_grad = obj == Py_True;
-  auto grad_accumulator = var.grad_accumulator.lock();
-  if (grad_accumulator) {
+  if (auto grad_accumulator = var.grad_accumulator.lock()) {
     grad_accumulator->is_executable = var.requires_grad;
   }
   return 0;
@@ -350,8 +360,8 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {"_grad_fn", (getter)THPVariable_get_grad_fn, (setter)THPVariable_set_grad_fn, NULL, NULL},
   {"is_leaf", (getter)THPVariable_is_leaf, NULL, NULL, NULL},
   {"data", (getter)THPVariable_get_data, (setter)THPVariable_set_data, NULL, NULL},
-  {"_grad", (getter)THPVariable_get_raw_grad, (setter)THPVariable_set_raw_grad, NULL, NULL},
-  {"grad", (getter)THPVariable_get_grad, NULL, NULL, NULL},
+  {"_grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, NULL, NULL}, // only for legacy reasons
+  {"grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, NULL, NULL},
   {"volatile", (getter)THPVariable_get_volatile, (setter)THPVariable_set_volatile, NULL, NULL},
   {"output_nr", (getter)THPVariable_get_output_nr, NULL, NULL, NULL},
   {"requires_grad", (getter)THPVariable_get_requires_grad, (setter)THPVariable_set_requires_grad, NULL, NULL},

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -17,7 +17,7 @@ extern PyObject *THPVariableClass;
 bool THPVariable_initModule(PyObject *module);
 PyObject * THPVariable_NewVolatile(PyObject *data);
 PyObject * THPVariable_NewLeaf(PyObject *data);
-PyObject * THPVariable_New(PyObject *data, PyObject *grad_fn);
+PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<torch::autograd::Function>& var);
 PyObject * THPVariable_Wrap(const std::shared_ptr<torch::autograd::Variable>& var);
 PyObject * THPVariable_get_data(THPVariable *self);
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -44,22 +44,14 @@ Variable::Variable(
 }
 
 auto Variable::get_grad_accumulator() -> std::shared_ptr<Function> {
-  using weak_type = std::weak_ptr<Function>;
-
-  static std::shared_ptr<Function> null_shared_ptr;
-  static weak_type null_weak_ptr;
-
-  if (grad_fn) return nullptr;
+  if (grad_fn) {
+    throw std::logic_error("get_grad_accumulator() should be only called on leaf Variables");
+  }
   if (!requires_grad) return nullptr;
 
-  auto result = grad_accumulator.lock();
-  if (result) return result;
-
-  // That didn't work, we need to allocate it, but taking into account that other
-  // threads might be doing the same thing.
   std::lock_guard<std::mutex> lock(grad_accumulator_lock);
 
-  result = grad_accumulator.lock();
+  auto result = grad_accumulator.lock();
   if (result) return result;
 
   result = std::make_shared<AccumulateGrad>(shared_from_this());

--- a/torch/nn/_functions/linear.py
+++ b/torch/nn/_functions/linear.py
@@ -11,9 +11,7 @@ class Linear(Function):
         output = input.new(input.size(0), weight.size(0))
         output.addmm_(0, 1, input, weight.t())
         if bias is not None:
-            # cuBLAS doesn't support 0 strides in sger, so we can't use expand
-            ctx.add_buffer = input.new(input.size(0)).fill_(1)
-            output.addr_(ctx.add_buffer, bias)
+            output.add_(bias.expand_as(output))
         return output
 
     @staticmethod
@@ -26,7 +24,7 @@ class Linear(Function):
         if ctx.needs_input_grad[1]:
             grad_weight = torch.mm(grad_output.t(), input)
         if bias is not None and ctx.needs_input_grad[2]:
-            grad_bias = torch.mv(grad_output.t(), Variable(ctx.add_buffer))
+            grad_bias = grad_output.sum(0, False)
 
         if bias is not None:
             return grad_input, grad_weight, grad_bias

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -462,8 +462,11 @@ class Module(object):
         """Sets gradients of all model parameters to zero."""
         for p in self.parameters():
             if p.grad is not None:
-                p.grad.data.zero_()
-                p.grad.detach_()
+                if p.grad.volatile:
+                    p.grad.data.zero_()
+                else:
+                    data = p.grad.data
+                    p.grad = Variable(data.new().resize_as_(data).zero_())
 
     def share_memory(self):
         return self._apply(lambda t: t.share_memory_())

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -131,10 +131,13 @@ class Optimizer(object):
     def zero_grad(self):
         """Clears the gradients of all optimized :class:`Variable` s."""
         for group in self.param_groups:
-            for param in group['params']:
-                if param.grad is not None:
-                    param.grad.data.zero_()
-                    param.grad.detach_()
+            for p in group['params']:
+                if p.grad is not None:
+                    if p.grad.volatile:
+                        p.grad.data.zero_()
+                    else:
+                        data = p.grad.data
+                        p.grad = Variable(data.new().resize_as_(data).zero_())
 
     def step(self, closure):
         """Performs a single optimization step (parameter update).


### PR DESCRIPTION
* Turns out we can't really take a short path for volatile inputs. The flags aren't propagated correctly in case a non-volatile input is modified in an in-place op with a volatile Variable -- e.g. `x[2] = y`, where `x` is not volatile, and `y` is. Also, volatile ops didn't mark inputs as dirty.
* Replace deprecated `retain_variables` with `retain_graph` 
* Add new flags to `Variable.backward` (and delegate to `torch.autograd.backward` to simplify the code)
* Minor fix for `Prod` backward (`grad_input` wasn't volatile, even if `grad_output` was)
* If a Variable has non-volatile gradient (i.e. when higher order grads are used), `model.zero_grad()` now replaces the grad with a new zero-filled Variable. This is useful if one wants to zero grad but used the old Variable to compute sth. Additionally assignments to `.grad` are now allowed (new grad is checked for its device, type and size).
* Exposed `.variable` attribute from `AccumulateGrad` nodes (cc @szagoruyko)