### PR TITLE
fix a bug when calling modules

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -210,15 +210,16 @@ class Module(object):
                 raise RuntimeError(
                     "forward hooks should never return any values, but '{}'"
                     "didn't return None".format(hook))
-        var = result
-        while not isinstance(var, Variable):
-            var = var[0]
-        grad_fn = var.grad_fn
-        if grad_fn is not None and len(self._backward_hooks) > 0:
-            for hook in self._backward_hooks.values():
-                wrapper = functools.partial(hook, self)
-                functools.update_wrapper(wrapper, hook)
-                grad_fn.register_hook(wrapper)
+        if len(self._backward_hooks) > 0:
+            var = result
+            while not isinstance(var, Variable):
+                var = var[0]
+            grad_fn = var.grad_fn
+            if grad_fn is not None:
+                for hook in self._backward_hooks.values():
+                    wrapper = functools.partial(hook, self)
+                    functools.update_wrapper(wrapper, hook)
+                    grad_fn.register_hook(wrapper)
         return result
 
     def __getattr__(self, name):


### PR DESCRIPTION
a module that returns a non-standard data structure currently breaks
due to checks for backwards hooks. This refactors the code slightly so
this will only break in the event of backwards hooks.