### PR TITLE
Cuda reduce in a consistent direction

### DIFF
--- a/torch/lib/THC/THCTensorMathReduce.cuh
+++ b/torch/lib/THC/THCTensorMathReduce.cuh
@@ -568,7 +568,7 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
           thrust::make_pair<K, Index>(sline[threadIdx.x], iline[threadIdx.x]);
         thrust::pair<K, Index> arg2 =
           thrust::make_pair<K, Index>(sline[threadIdx.x + s], iline[threadIdx.x + s]);
-        thrust::pair<K, Index> res = binary_op(arg1, arg2);
+        thrust::pair<K, Index> res = binary_op(arg2, arg1);
 
         sline[threadIdx.x] = res.first;
         iline[threadIdx.x] = res.second;
@@ -665,7 +665,7 @@ struct MaxValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::ge(a.first, b.first) ? a : b;
+    return THCNumerics<T>::gt(a.first, b.first) ? a : b;
   }
 };
 
@@ -674,7 +674,7 @@ struct MinValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::le(a.first, b.first) ? a : b;
+    return THCNumerics<T>::lt(a.first, b.first) ? a : b;
   }
 };
 

--- a/torch/lib/THC/THCTensorMathReduce.cuh
+++ b/torch/lib/THC/THCTensorMathReduce.cuh
@@ -469,8 +469,8 @@ kernelTransformReduceOuterDimIndex(K *tgt1,
 
       for (unsigned col = 0; col < row_size; ++col) {
         // +1 for Lua index
-        acc = binary_op(thrust::make_pair<K, Index>(*src, col + TH_INDEX_BASE),
-                        acc);
+        acc = binary_op(acc,
+                        thrust::make_pair<K, Index>(*src, col + TH_INDEX_BASE));
         src += num_irows;
       }
 
@@ -550,7 +550,7 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
       K *src = src_ + row * row_size;
       // Sequential reduction within a thread.
       for (unsigned col = threadIdx.x; col < row_size; col += blockDim.x) {
-        acc = binary_op(thrust::make_pair<K, Index>(src[col], col + TH_INDEX_BASE), acc);
+        acc = binary_op(acc, thrust::make_pair<K, Index>(src[col], col + TH_INDEX_BASE));
       }
     }
 
@@ -568,7 +568,7 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
           thrust::make_pair<K, Index>(sline[threadIdx.x], iline[threadIdx.x]);
         thrust::pair<K, Index> arg2 =
           thrust::make_pair<K, Index>(sline[threadIdx.x + s], iline[threadIdx.x + s]);
-        thrust::pair<K, Index> res = binary_op(arg2, arg1);
+        thrust::pair<K, Index> res = binary_op(arg1, arg2);
 
         sline[threadIdx.x] = res.first;
         iline[threadIdx.x] = res.second;
@@ -665,7 +665,7 @@ struct MaxValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::gt(a.first, b.first) ? a : b;
+    return THCNumerics<T>::ge(a.first, b.first) ? a : b;
   }
 };
 
@@ -674,7 +674,7 @@ struct MinValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::lt(a.first, b.first) ? a : b;
+    return THCNumerics<T>::le(a.first, b.first) ? a : b;
   }
 };
 


### PR DESCRIPTION
The bug was discovered by @danielamassiceti.

Repro script:

```python
import torch
x = torch.zeros(10,1).cuda()
print(torch.max(x, 0))

y = torch.zeros(10,1)
print(torch.max(y,0))


x = torch.zeros(10).cuda()
print(torch.max(x, 0))

y = torch.zeros(10)
print(torch.max(y,0))
```

With the current master, the resulting index that are going to be obtained as max are for each print:
-> 9, 0, 0, 0

So the cuda implementation has a problem.
If you look [here](https://github.com/pytorch/pytorch/blob/6fab62173e842bbf550de1c68cfae507ca35b800/torch/lib/THC/THCTensorMathReduce.cuh#L553) or [here](https://github.com/pytorch/pytorch/blob/6fab62173e842bbf550de1c68cfae507ca35b800/torch/lib/THC/THCTensorMathReduce.cuh#L553), you can see that the binaryOp function is called with the new value (later in the tensor) as first argument and the running max as second argument.

The checks made in the comparison function default to the first argument in case of equality, so that would be here defaulting to the new value. This is different to what is implemented on the CPU (see for example [here](https://github.com/pytorch/pytorch/blob/master/torch/lib/TH/generic/THTensorMath.c#L1515) )

This leads to the fix inside the struct. However, if we just apply these fixes, the resulting index from running the repro case becomes:
-> 0, 0, 7, 0

which is still wrong.

The reason for this is that when reducing over the results of the threads in the kernel, the arguments are passed as early in the array as first argument, late in the array as second argument.

This leads to the fix in kernelTransformReduceInnermostDimIndex.






An alternative fix would be to  keep everything that I've changed as it was and swap the order of the arguments [here](https://github.com/pytorch/pytorch/blob/6fab62173e842bbf550de1c68cfae507ca35b800/torch/lib/THC/THCTensorMathReduce.cuh#L472) and [here](https://github.com/pytorch/pytorch/blob/6fab62173e842bbf550de1c68cfae507ca35b800/torch/lib/THC/THCTensorMathReduce.cuh#L553). This would probably be cleaner.


Let me know what you think.Should I add a test for this?

*EDIT*: I actually went ahead and  did the alternate fix. I find it cleaner.