### PR TITLE
typo error for torch.addr

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -343,8 +343,8 @@ Args:
 
 Example::
 
-    >>> vec1 = torch.arange(1, 4)
-    >>> vec2 = torch.arange(1, 3)
+    >>> vec1 = torch.arange(1, 3)
+    >>> vec2 = torch.arange(1, 2)
     >>> M = torch.zeros(3, 2)
     >>> torch.addr(M, vec1, vec2)
      1  2


### PR DESCRIPTION
fix the typo error in the example for torch.addr