### PR TITLE
[Need Discussion] fix #1524, let long_args False for param "size" of set_

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -34,12 +34,6 @@ class TestTorch(TestCase):
                 res2 += i * j
             self.assertEqual(res1, res2)
 
-    def test_kwargs(self):
-        a = torch.range(0, 15).view(4, 4)
-        a.set_(a.storage(), 0, torch.Size([4, 4]), (4, 1))  # okay
-        a.set_(a.storage(), 0, torch.Size([4, 4]), strides=(4, 1))  # Torch: invalid memory size at THGeneral.c:257
-        a.set_(a.storage(), 0, size=torch.Size([4, 4]), strides=(4, 1))  # segfault
-
     def _testMath(self, torchfn, mathfn):
         size = (10, 5)
         # contiguous
@@ -2485,7 +2479,10 @@ class TestTorch(TestCase):
         stride = (10, 360, 90, 1)
         t1.set_(t2.storage(), 0, size, stride)
         self.assertEqual(t1.stride(), stride)
-
+        a.set_(a.storage(), 0, size=size, stride=stride)
+        self.assertEqual(t1.size(), size)
+        self.assertEqual(t1.stride(), stride)
+        
     def test_equal(self):
         # Contiguous, 1D
         t1 = torch.Tensor((3, 4, 9, 10))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -34,6 +34,12 @@ class TestTorch(TestCase):
                 res2 += i * j
             self.assertEqual(res1, res2)
 
+    def test_kwargs(self):
+        a = torch.range(0, 15).view(4, 4)
+        a.set_(a.storage(), 0, torch.Size([4, 4]), (4, 1))  # okay
+        a.set_(a.storage(), 0, torch.Size([4, 4]), strides=(4, 1))  # Torch: invalid memory size at THGeneral.c:257
+        a.set_(a.storage(), 0, size=torch.Size([4, 4]), strides=(4, 1))  # segfault
+
     def _testMath(self, torchfn, mathfn):
         size = (10, 5)
         # contiguous

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2479,10 +2479,10 @@ class TestTorch(TestCase):
         stride = (10, 360, 90, 1)
         t1.set_(t2.storage(), 0, size, stride)
         self.assertEqual(t1.stride(), stride)
-        a.set_(a.storage(), 0, size=size, stride=stride)
+        t1.set_(t2.storage(), 0, size=size, stride=stride)
         self.assertEqual(t1.size(), size)
         self.assertEqual(t1.stride(), stride)
-        
+
     def test_equal(self):
         # Contiguous, 1D
         t1 = torch.Tensor((3, 4, 9, 10))

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -165,7 +165,6 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THStorage* sourceStorage
         - long storage_offset
         - arg: THSize* size
-          long_args: True
         - CONSTANT NULL
     - cname: setStorage
       arguments:

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -164,15 +164,9 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THTensor* self
         - THStorage* sourceStorage
         - long storage_offset
-        - arg: THSize* size
-        - CONSTANT NULL
-    - cname: setStorage
-      arguments:
-        - THTensor* self
-        - THStorage* sourceStorage
-        - long storage_offset
         - THSize* size
-        - THStride* strides
+        - arg: THStride* strides
+          default: NULL
 ]]
 
 [[

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -165,7 +165,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THStorage* sourceStorage
         - long storage_offset
         - THSize* size
-        - arg: THStride* strides
+        - arg: THStride* stride
           default: NULL
 ]]
 


### PR DESCRIPTION
It passed on my python3.5 w/o CUDA environment.

Just curious, why does `size` need to be a long argument? I thought that the size of a tensor should be fixed.

p.s. The test will be removed if this PR is approved.