### PR TITLE
[Need Discussion] Implement twice backward of ConvNd

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from .variable import Variable
 from .function import Function, NestedIOFunction
 from .stochastic_function import StochasticFunction
-from .gradcheck import gradcheck
+from .gradcheck import gradcheck, gradgradcheck
 
 __all__ = ['Variable', 'Function', 'StochasticFunction', 'backward']
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -172,3 +172,13 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3):
             return False
 
     return True
+
+
+def gradgradcheck(func, inputs, grad_outputs, eps=1e-6, atol=1e-5, rtol=1e-3):
+    def new_func(*inputs):
+        outputs = func(*inputs)
+        outputs = _as_tuple(outputs)
+        grad_inputs = torch.autograd.grad(outputs, inputs, grad_outputs, only_inputs=True)
+        return grad_inputs
+
+    return gradcheck(new_func, inputs, eps, atol, rtol)

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -126,8 +126,8 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
 
   AutoGPU guard(inputs[0]->data->getDevice());
   auto input = inputs[0]->data->contiguous();
-  std::unique_ptr<Tensor> weight(high_grad ? weight_->data->clone_shallow(): inputs[1]->data->clone_shallow());
-  std::unique_ptr<Tensor> bias(high_grad ? bias_ : (inputs[2] ? inputs[2]->data->clone_shallow() : nullptr));
+  std::unique_ptr<Tensor> weight(high_grad ? weight_.unpack_data()->clone_shallow(): inputs[1]->data->clone_shallow());
+  std::unique_ptr<Tensor> bias(high_grad ? bias_.unpack_data()->clone_shallow() : (inputs[2] ? inputs[2]->data->clone_shallow() : nullptr));
 
   int k = input->nDim();
   if (k == 3) {
@@ -193,8 +193,8 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<ConvBackward>(
         f, *this,
-        inputs[0]->save(this), high_grad ? weight_->save(this) : inputs[1]->save(this),
-        Variable::save_opt(high_grad ? bias_.get() : inputs[2].get(), this),
+        inputs[0]->save(this), high_grad ? weight_.save(this) : inputs[1]->save(this),
+        high_grad ? bias_.save(this) : Variable::save_opt(inputs[2].get(), this),
         std::move(columns), std::move(ones), std::move(convolution));
   });
 };

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -167,7 +167,7 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
       std::unique_ptr<Tensor> output;
       tensor_list columns(groups);
       tensor_list ones(groups);
-      std::unique_ptr<Convolution> convolution;
+      std::shared_ptr<Convolution> convolution;
 
       if (use_cudnn(*input)) {
     #ifdef WITH_CUDNN
@@ -220,7 +220,7 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
         return std::make_shared<ConvBackward>(
             f, *this,
             inputs[0]->save(this), inputs[1]->save(this), Variable::save_opt(inputs[2].get(), this),
-            std::move(columns), std::move(ones), std::move(convolution));
+            std::move(columns), std::move(ones), convolution);
       });
   } else {
       std::cout << "ConvForward in grad mode" << std::endl;
@@ -349,7 +349,7 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
         return std::make_shared<ConvBackward>(
             f, *this,
             grad_outputs[0]->save(this), weight_.unpack()->save(this), bias_.unpack()->save(this),
-            std::move(columns), std::move(ones), std::move(convolution));
+            std::move(columns), std::move(ones), convolution);
       });
   }
 
@@ -381,7 +381,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
       std::unique_ptr<Tensor> output;
       tensor_list columns(groups);
       tensor_list ones(groups);
-      std::unique_ptr<Convolution> convolution;
+      std::shared_ptr<Convolution> convolution;
 
       if (use_cudnn(*input)) {
     #ifdef WITH_CUDNN
@@ -434,7 +434,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
         return std::make_shared<ConvForward>(
             f, *this,
             inputs[0]->save(this), inputs[1]->save(this), Variable::save_opt(inputs[2].get(), this),
-            std::move(columns), std::move(ones), std::move(convolution));
+            std::move(columns), std::move(ones), convolution);
       });
   } else {
       std::cout << "ConvBackward in grad mode" << std::endl;
@@ -565,7 +565,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
         return std::make_shared<ConvForward>(
             f, *this,
             grad_outputs[0]->save(this), weight_.unpack()->save(this), bias_.unpack()->save(this),
-            std::move(columns), std::move(ones), std::move(convolution));
+            std::move(columns), std::move(ones), convolution);
       });
   }
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -193,8 +193,8 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<ConvBackward>(
         f, *this,
-        inputs[0]->save(this), high_grad ? weight_.save(this) : inputs[1]->save(this),
-        high_grad ? bias_.save(this) : Variable::save_opt(inputs[2].get(), this),
+        inputs[0]->save(this), high_grad ? weight_.unpack()->save(this) : inputs[1]->save(this),
+        high_grad ? bias_.unpack()->save(this) : Variable::save_opt(inputs[2].get(), this),
         std::move(columns), std::move(ones), std::move(convolution));
   });
 };
@@ -317,7 +317,7 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
                                  std::move(grad_weight),
                                  std::move(grad_bias));
   return wrap_outputs(grad_outputs, std::move(outputs), [&](FunctionFlags f) {
-    return std::make_shared<ConvForward>(*this, weight_->save(this), bias_->save(this));
+    return std::make_shared<ConvForward>(*this, weight_.unpack()->save(this), bias_.unpack()->save(this));
   });
 };
 

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -35,11 +35,22 @@ struct ConvParams {
 };
 
 struct ConvForward : public Function, public ConvParams {
-  explicit ConvForward(ConvParams params) : ConvParams(std::move(params)) {}
+  explicit ConvForward(ConvParams params) : ConvParams(std::move(params)), high_grad(False) {}
+  ConvForward(
+    ConvParams params,
+    SavedVariable weight,
+    SavedVariable bias)
+    : ConvParams(std::move(params))
+    , weight_(std::move(weight))
+    , bias_(std::move(bias))
+    , high_grad(True) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
   std::vector<long> output_size(thpp::Tensor& input, thpp::Tensor& weight);
+  SavedVariable weight_;
+  SavedVariable bias_;
+  bool high_grad;
 };
 
 struct ConvBackward : public Function, public ConvParams {

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -35,7 +35,7 @@ struct ConvParams {
 };
 
 struct ConvForward : public Function, public ConvParams {
-  explicit ConvForward(ConvParams params) : ConvParams(std::move(params)), high_grad(False) {}
+  explicit ConvForward(ConvParams params) : ConvParams(std::move(params)), high_grad(false) {}
   ConvForward(
     ConvParams params,
     SavedVariable weight,
@@ -43,7 +43,7 @@ struct ConvForward : public Function, public ConvParams {
     : ConvParams(std::move(params))
     , weight_(std::move(weight))
     , bias_(std::move(bias))
-    , high_grad(True) {}
+    , high_grad(true) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -44,7 +44,7 @@ struct ConvForward : public Function, public ConvParams {
       SavedVariable bias,
       tensor_list columns,
       tensor_list ones,
-      std::unique_ptr<torch::cudnn::Convolution> convolution)
+      std::shared_ptr<torch::cudnn::Convolution> convolution)
     : Function(std::move(flags))
     , ConvParams(std::move(params))
     , convolution(std::move(convolution))
@@ -69,8 +69,10 @@ struct ConvForward : public Function, public ConvParams {
   SavedVariable bias_;
   tensor_list columns;
   tensor_list ones;
-  std::unique_ptr<torch::cudnn::Convolution> convolution;
+  std::shared_ptr<torch::cudnn::Convolution> convolution;
   bool forward_mode;
+  tensor_list columns_back;
+  tensor_list ones_back;
 };
 
 struct ConvBackward : public Function, public ConvParams {
@@ -83,7 +85,7 @@ struct ConvBackward : public Function, public ConvParams {
       SavedVariable bias,
       tensor_list columns,
       tensor_list ones,
-      std::unique_ptr<torch::cudnn::Convolution> convolution)
+      std::shared_ptr<torch::cudnn::Convolution> convolution)
     : Function(std::move(flags))
     , ConvParams(std::move(params))
     , convolution(std::move(convolution))
@@ -108,8 +110,10 @@ struct ConvBackward : public Function, public ConvParams {
   SavedVariable bias_;
   tensor_list columns;
   tensor_list ones;
-  std::unique_ptr<torch::cudnn::Convolution> convolution;
+  std::shared_ptr<torch::cudnn::Convolution> convolution;
   bool forward_mode;
+  tensor_list columns_back;
+  tensor_list ones_back;
 };
 
 }}

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -46,6 +46,24 @@ struct ConvCtor {
   }
 };
 
+struct ConvBCtor {
+  ConvBackward* operator()(PyObject* args) {
+    ConvParams params;
+
+    TupleParser parser(args, 8);
+    parser.parse(params.stride);
+    parser.parse(params.padding);
+    parser.parse(params.dilation);
+    parser.parse(params.transposed);
+    parser.parse(params.output_padding);
+    parser.parse(params.groups);
+    parser.parse(params.benchmark);
+    parser.parse(params.cudnn_enabled);
+
+    return new ConvBackward(std::move(params));
+  }
+};
+
 struct DelayedErrorCtor {
   DelayedError* operator()(PyObject* args) {
     std::string msg;
@@ -212,7 +230,7 @@ bool THPAutograd_initFunctions(PyObject* _unused)
 
   static PyTypeObject ConvClass, ConvBackwardClass;
   addClass<ConvForward, ConvCtor>(module, ConvClass, "ConvNd", conv_forward_properties);
-  addClass<ConvBackward, NoCtor>(module, ConvBackwardClass, "ConvNdBackward", conv_backward_properties);
+  addClass<ConvBackward, ConvBCtor>(module, ConvBackwardClass, "ConvNdBackward", conv_backward_properties);
 
   static PyTypeObject AccumulateGradClass;
   addClass<AccumulateGrad, NoCtor>(module, AccumulateGradClass, "AccumulateGrad", accumulate_grad_properties);

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -11,6 +11,7 @@ from .modules.utils import _single, _pair, _triple
 
 # Convolutions
 ConvNd = torch._C._functions.ConvNd
+ConvNdBackward = torch._C._functions.ConvNdBackward
 
 
 def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
@@ -102,7 +103,7 @@ def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
                      output_padding=0, groups=1, dilation=1):
-    f = ConvNd(_single(stride), _single(padding), _single(dilation), True,
+    f = ConvNdBackward(_single(stride), _single(padding), _single(dilation), True,
                _single(output_padding),
                groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
@@ -129,7 +130,7 @@ def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
           added to the output. Can be a single number or a tuple. Default: 0
         dilation: the spacing between kernel elements. Default: 1
     """
-    f = ConvNd(_pair(stride), _pair(padding), _pair(dilation), True,
+    f = ConvNdBackward(_pair(stride), _pair(padding), _pair(dilation), True,
                _pair(output_padding), groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 
@@ -155,7 +156,7 @@ def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
           the number of groups
         dilation: the spacing between kernel elements. Default: 1
     """
-    f = ConvNd(_triple(stride), _triple(padding), _triple(dilation), True,
+    f = ConvNdBackward(_triple(stride), _triple(padding), _triple(dilation), True,
                _triple(output_padding), groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 


### PR DESCRIPTION
Hi, all.

This PR is following the PR #1555 with cleaner rebase.

@apaszke I have followed your suggestion to modify the `ConvForward` directly. And change the implementation methods of `ConvTransposeNd` to use `ConvBackward` directly instead of `ConvForward(transposed)`. Here is the commit. And I have used `gradcheck` to check the two gradient. It passed the following test.

```python
from torch.autograd import gradcheck
input = (autograd.Variable(torch.randn(1, 20, 22), requires_grad=True),)
test = gradcheck(nn.Conv1d(20, 12, 4), input, eps=1e-3, atol=1e-4)
print(test)
input = (autograd.Variable(torch.randn(1, 20, 22), requires_grad=True),)
test = gradcheck(nn.ConvTranspose1d(20, 12, 4), input, eps=1e-3, atol=1e-4)
print(test)
```

However when I use it to perform grad of grad of `ConvForward`, it raise error. So for now, do not merge this PR.

Assume the forward formula to calculate, is ConvForward(forward_mode) -> ConvForward(forward_mode) -> ConvBackward(grad_mode) ->ConvBackward(grad_mode). And the backward process is ConvForward(grad_mode) -> ConvForward(grad_mode) -> ConvBackward(grad_mode) -> ConvBackward (grad_mode). It raised a `Segment Fault` Error at the **third backward process unit,ConvBackward(grad_mode)**

I have found the problem is because of the `std::move(convolution)` in `ConvBackward::apply`. During the forward process of `ConvBackward(grad_mode)`, it will use `std::move(convolution)` to pass arguments, and `convolution` of itself will be zero. When the second time processing this unit in backward process, some parameters like `convolution` will cause this `Segment error`.

- [x] So how can I pass this `convolution` parameters with itself retained not be cleared when using `std::move` in the following place? 
```python
file : torch/csrc/autograd/functions/convolution.cpp
568+            std::move(columns), std::move(ones), std::move(convolution));
```
- [ ] And the problem remained in PR #1555 

> I have a problem. Assume the forward formula to calculate, is ConvForward -> ConvForward -> ConvBackward ->ConvBackward. And the backward process is ConvForward -> ConvForward -> ConvBackward -> ConvBackward. Should I accumulate grad of weight and bias in every backward process unit? Or just do that in the ConvBackward unit.