### PR TITLE
Added powerpc64le support for cuDNN

### DIFF
--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -19,6 +19,7 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         os.path.join(CUDA_HOME, 'lib'),
         os.path.join(CUDA_HOME, 'lib64'),
         '/usr/lib/x86_64-linux-gnu/',
+        '/usr/lib/powerpc64le-linux-gnu/',
     ] + gather_paths([
         'LIBRARY_PATH',
     ])))


### PR DESCRIPTION
When installing cuDNN via apt-get (such as in the Dockerfile) cuDNN isn't found by the build tools on POWER8, this fixes it!