### PR TITLE
[bug fix] Dataloader can now handle growing datasets

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -91,6 +91,14 @@ class TestDataLoader(TestCase):
     def test_sequential_batch(self):
         self._test_sequential(DataLoader(self.dataset, batch_size=2))
 
+    def test_growing_dataset(self):
+        dataset = [torch.ones(4) for _ in range(4)]
+        dataloader_seq = DataLoader(dataset, shuffle=False)
+        dataloader_shuffle = DataLoader(dataset, shuffle=True)
+        dataset.append(torch.ones(4))
+        self.assertEqual(len(dataloader_seq), 5)
+        self.assertEqual(len(dataloader_shuffle), 5)
+
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_sequential_pin_memory(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -27,13 +27,13 @@ class SequentialSampler(Sampler):
     """
 
     def __init__(self, data_source):
-        self.num_samples = len(data_source)
+        self.data_source = data_source
 
     def __iter__(self):
-        return iter(range(self.num_samples))
+        return iter(range(len(self.data_source)))
 
     def __len__(self):
-        return self.num_samples
+        return len(self.data_source)
 
 
 class RandomSampler(Sampler):
@@ -44,13 +44,13 @@ class RandomSampler(Sampler):
     """
 
     def __init__(self, data_source):
-        self.num_samples = len(data_source)
+        self.data_source = data_source
 
     def __iter__(self):
-        return iter(torch.randperm(self.num_samples).long())
+        return iter(torch.randperm(len(self.data_source)).long())
 
     def __len__(self):
-        return self.num_samples
+        return len(self.data_source)
 
 
 class SubsetRandomSampler(Sampler):


### PR DESCRIPTION
Adding more data to a dataset did not propagate to the ```DataLoader``` instance:
```
>>> dataset = [1, 2, 3]
>>> dataloader = DataLoader(dataset)
>>> dataset.append(4)
>>> [batch[0] for batch in dataloader]
[1, 2, 3]
```
This is now fixed by keeping a reference to the dataset instead of counting the number of elements only at instantiation.

### Why add more data to the dataset?
E.g. exploration in reinforcement learning.

### Why not create a new ```DataLoader``` instance after adding new data?
The data loader and the sampler has a reference to the dataset, it feels unintuitive that updates does not reflect in the sampler. Creating new instances over and over again does not feel motivated.