### PR TITLE
Fix Tensor.set_ with kwargs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2479,6 +2479,9 @@ class TestTorch(TestCase):
         stride = (10, 360, 90, 1)
         t1.set_(t2.storage(), 0, size, stride)
         self.assertEqual(t1.stride(), stride)
+        t1.set_(t2.storage(), storage_offset=0, size=size, stride=stride)
+        self.assertEqual(t1.size(), size)
+        self.assertEqual(t1.stride(), stride)
 
     def test_equal(self):
         # Contiguous, 1D

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -247,8 +247,9 @@ ${cpu}
         arg_desc = sorted(list(arg_desc.keys()), key=len)
         arg_desc = ['"' + desc + '"' for desc in arg_desc]
         arg_str = ', '.join(arg_desc)
-        variables_str = '\n'.join(declaration.get('variables', []))
-        init_str = '\n'.join(declaration.get('init', []))
+        sep = '\n' + (' ' * 4)
+        variables_str = sep.join(declaration.get('variables', []))
+        init_str = sep.join(declaration.get('init', []))
         if 'stateless' in declaration['name']:
             readable_name = 'torch.' + declaration['python_name']
         else:
@@ -325,9 +326,11 @@ ${cpu}
                        for arg in option['arguments'])
 
         def has_long_args(declaration):
-            return any(arg.get('long_args', False)
-                       for option in declaration['options']
-                       for arg in option['arguments'])
+            long_args = [any(arg.get('long_args', False) for arg in option['arguments'])
+                         for option in declaration['options']]
+            if any(long_args) != all(long_args):
+                raise RuntimeError("Only some options have long_args")
+            return long_args[0]
 
         def has_output_args(declaration):
             return any(arg.get('output')

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -165,7 +165,6 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THStorage* sourceStorage
         - long storage_offset
         - arg: THSize* size
-          long_args: True
         - CONSTANT NULL
     - cname: setStorage
       arguments:
@@ -173,7 +172,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THStorage* sourceStorage
         - long storage_offset
         - THSize* size
-        - THStride* strides
+        - THStride* stride
 ]]
 
 [[


### PR DESCRIPTION
Removes long_args from Tensor.set_ and adds support for kwargs. This is a potentially breaking change, since it removes support for:

```
t1.set_(storage, storage_offset, size0, size1, ...)
```

I think it's unlikely people are using this syntax, which we don't document or test. (I also searched through Facebook's code). You can instead use:

```
t1.set(storage, storage_offset, size)
```

Where size is a tuple.

The cwrap generated code is incorrect when there is more than one option and only some of the options have long_args.

Fixes #1524 