### PR TITLE
disabling fd leakchecker test

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -112,9 +112,10 @@ class leak_checker(object):
             # test is no more than 4 higher than the 10th available at the
             # start. This attempts to catch file descriptor leaks, but allows
             # one-off initialization that may use up a file descriptor
-            available_fds = self._get_next_fds(10)
-            self.test_case.assertLessEqual(
-                available_fds[-1] - self.next_fds[-1], 5)
+            # Disabled because this check is too flaky
+            # available_fds = self._get_next_fds(10)
+            # self.test_case.assertLessEqual(
+            #     available_fds[-1] - self.next_fds[-1], 5)
             self.test_case.assertFalse(self.has_shm_files())
         return False
 

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -112,7 +112,7 @@ class leak_checker(object):
             # test is no more than 4 higher than the 10th available at the
             # start. This attempts to catch file descriptor leaks, but allows
             # one-off initialization that may use up a file descriptor
-            # Disabled because this check is too flaky
+            # TODO: Disabled because this check is too flaky
             # available_fds = self._get_next_fds(10)
             # self.test_case.assertLessEqual(
             #     available_fds[-1] - self.next_fds[-1], 5)


### PR DESCRIPTION
as discussed with @colesbury , disabling this test. It's too unreliable / flaky, and is giving way too many false-positives. 