### PR TITLE
Fix indices bug in MM.py (#1613)

### DIFF
--- a/torch/legacy/nn/MM.py
+++ b/torch/legacy/nn/MM.py
@@ -25,9 +25,9 @@ class MM(Module):
             torch.mm(a, b, out=self.output)
         else:
             if self.transA:
-                a = a.transpose(2, 3)
+                a = a.transpose(1, 2)
             if self.transB:
-                b = b.transpose(2, 3)
+                b = b.transpose(1, 2)
 
             self.output.resize_(a.size(0), a.size(1), b.size(2))
             torch.bmm(a, b, out=self.output)


### PR DESCRIPTION
Hi all, 
In reference to https://github.com/pytorch/pytorch/issues/1613#issuecomment-303186361
I just changed the indices to fit python indexing.
Furthermore to make the code fully work in my application I needed to use
`torch.bmm(a, b, out=self.output.double())`

line 33 (specifying.double())  otherwise I had a typing error (float vs double tensor at execution with torch.bmm).

But as I wasn't sure it was a bug or my misuse of the framework I didn't change it in this pulling request.

Thank you,