### PR TITLE
Improve handling of graph roots in autograd engine

### DIFF
--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -44,7 +44,7 @@ protected:
       const function_list& roots,
       variable_list& inputs,
       GraphTask& task);
-  void find_stochastic_functions(function_queue& queue, GraphTask& task);
+  void find_stochastic_functions(function_queue& queue, Function* graph_root, GraphTask& task);
   void compute_dependencies(function_queue queue, GraphTask& task);
   void evaluate_function(FunctionTask& task);
   ReadyQueue& ready_queue(int device);

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -32,6 +32,20 @@ struct DelayedError : public Function {
   std::string msg;
 };
 
+struct GraphRoot : public Function {
+  GraphRoot(function_list functions, variable_list inputs)
+    : outputs(std::move(inputs)) {
+      next_functions = std::move(functions);
+      is_executable = true;
+    };
+
+  virtual variable_list apply(const variable_list& inputs) {
+    return outputs;
+  }
+
+  variable_list outputs;
+};
+
 struct Add : public Function {
   Add() {}
 


### PR DESCRIPTION
After this change the engine will create a no-op node that points to all roots. This allows us to take advantage of the code that evaluates functions to resolve the dependencies correctly, instead of having separate methods for roots. Fixes #1605.