### PR TITLE
make THPPointer have explicit constructors

### DIFF
--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -127,7 +127,7 @@ PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
     """)
 
     ALLOCATE_TMPL = Template("""\
-THP${type}TensorPtr _${name}_guard = (THP${type}Tensor*) THP${type}Tensor_NewEmpty();
+THP${type}TensorPtr _${name}_guard((THP${type}Tensor*) THP${type}Tensor_NewEmpty());
 if (!_${name}_guard.get()) return NULL;
 THP${type}Tensor* $name = _${name}_guard.get();
 """)

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -33,7 +33,7 @@ static PyObject * THPGenerator_pynew(PyTypeObject *type, PyObject *args, PyObjec
     THPUtils_setError("torch.Generator constructor doesn't accept any arguments");
     return NULL;
   }
-  THPGeneratorPtr self = (THPGenerator *)type->tp_alloc(type, 0);
+  THPGeneratorPtr self((THPGenerator *)type->tp_alloc(type, 0));
   self->cdata = THGenerator_new();
 
   return (PyObject*)self.release();
@@ -44,7 +44,7 @@ static PyObject * THPGenerator_getState(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
   THGenerator *generator = self->cdata;
-  THPByteTensorPtr res = (THPByteTensor *)THPByteTensor_NewEmpty();
+  THPByteTensorPtr res((THPByteTensor *)THPByteTensor_NewEmpty());
   if (!res) return NULL;
   THByteTensor_getRNGState(generator, res->cdata);
   return (PyObject *)res.release();

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -63,7 +63,7 @@ static PyObject * THPModule_initNames(PyObject *self, PyObject *arg)
 {
   static std::vector<std::string> names;
 
-  THPObjectPtr types = PySequence_Fast(arg, "expected a sequence");
+  THPObjectPtr types(PySequence_Fast(arg, "expected a sequence"));
   if (!types) return NULL;
 
   int num_classes = PySequence_Fast_GET_SIZE(types.get());
@@ -73,7 +73,7 @@ static PyObject * THPModule_initNames(PyObject *self, PyObject *arg)
     THPUtils_assert(PyType_Check(obj), "expected a PyTypeObject");
     PyTypeObject* type = (PyTypeObject*)obj;
 
-    THPObjectPtr module_name = PyObject_GetAttrString(obj, "__module__");
+    THPObjectPtr module_name(PyObject_GetAttrString(obj, "__module__"));
     if (!module_name) return NULL;
     THPUtils_assert(THPUtils_checkString(module_name.get()),
         "expected __module__ to be a string");

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -25,7 +25,7 @@ PyObject * THPSize_New(int dim, long *sizes)
 
 static PyObject * THPSize_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
-  THPObjectPtr self = PyTuple_Type.tp_new(type, args, kwargs);
+  THPObjectPtr self(PyTuple_Type.tp_new(type, args, kwargs));
   if (self) {
     for (Py_ssize_t i = 0; i < PyTuple_Size(self); ++i) {
       PyObject *item = PyTuple_GET_ITEM(self.get(), i);

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -81,7 +81,7 @@ PyObject* getTupleAttr(PyObject* obj, void* _unused)
   THPCppFunction* self = (THPCppFunction*)obj;
   auto& arr = ((T*)(self->cdata.get()))->*ptr;
   auto num_elems = arr.size();
-  THPObjectPtr py_tuple = PyTuple_New(num_elems);
+  THPObjectPtr py_tuple(PyTuple_New(num_elems));
   if (!py_tuple) return NULL;
   for (size_t i = 0; i < num_elems; ++i) {
     PyTuple_SET_ITEM(py_tuple.get(), i, Convert(arr[i]));
@@ -203,7 +203,7 @@ static struct PyGetSetDef accumulate_grad_properties[] = {
 
 bool THPAutograd_initFunctions(PyObject* _unused)
 {
-  THPObjectPtr module = PyModule_New("torch._C._functions");
+  THPObjectPtr module(PyModule_New("torch._C._functions"));
   if (!module) return false;
 
   static PyTypeObject BatchNormClass, BatchNormBackwardClass;
@@ -233,7 +233,7 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   static PyTypeObject IdentityClass;
   addClass<Identity, NoCtor>(module, IdentityClass, "Identity");
 
-  THPObjectPtr parent = PyImport_ImportModule("torch._C");
+  THPObjectPtr parent(PyImport_ImportModule("torch._C"));
   if (!parent) return false;
   PyModule_AddObject(parent.get(), "_functions", module.release());
   return true;

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -53,7 +53,7 @@ PyObject* THPCppFunction_call(PyObject* self, PyObject* args, PyObject *kwargs)
     return THPVariable_Wrap(output[0]);
   }
 
-  THPObjectPtr tuple = PyTuple_New(num_outputs);
+  THPObjectPtr tuple(PyTuple_New(num_outputs));
   for (int i = 0; i != num_outputs; ++i) {
     PyTuple_SET_ITEM(tuple.get(), i, THPVariable_Wrap(output[i]));
   }
@@ -94,11 +94,11 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
 {
   auto& next_functions = self->cdata->next_functions;
   auto num_next = next_functions.size();
-  THPObjectPtr py_functions = PyTuple_New(num_next);
+  THPObjectPtr py_functions(PyTuple_New(num_next));
   if (!py_functions) return NULL;
   for (size_t i = 0; i < num_next; ++i) {
     auto& c_tuple = next_functions[i];
-    THPObjectPtr tuple = PyTuple_New(2);
+    THPObjectPtr tuple(PyTuple_New(2));
     if (!tuple) return NULL;
     PyObject *py_fn = functionToPyObject(c_tuple.first);
     if (!py_fn) return NULL;
@@ -181,7 +181,7 @@ PyObject* functionToPyObject(std::shared_ptr<Function> cdata)
   }
 
   PyTypeObject* type = (PyTypeObject*)it->second.get();
-  THPObjectPtr obj = type->tp_alloc(type, 0);
+  THPObjectPtr obj(type->tp_alloc(type, 0));
   if (!obj) return NULL;
   THPCppFunction* f = (THPCppFunction*)obj.get();
   new (&f->cdata) std::shared_ptr<Function>(cdata);
@@ -207,9 +207,9 @@ PyObject* registerFunctionHook(Function& fn, PyObject* hook)
     }
   }
 
-  THPObjectPtr register_fn = PyObject_GetAttrString(THPFunctionClass, "_register_hook");
+  THPObjectPtr register_fn(PyObject_GetAttrString(THPFunctionClass, "_register_hook"));
   if (!register_fn) return NULL;
-  THPObjectPtr res = PyObject_CallFunctionObjArgs(register_fn.get(), dict, hook, NULL);
+  THPObjectPtr res(PyObject_CallFunctionObjArgs(register_fn.get(), dict, hook, NULL));
   if (!res) return NULL;
 
   if (dict == Py_None) {

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -18,7 +18,7 @@ struct THPCppFunction {
 template<typename Ctor>
 PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-  THPObjectPtr obj = type->tp_alloc(type, 0);
+  THPObjectPtr obj(type->tp_alloc(type, 0));
   if (!obj) return NULL;
   THPCppFunction* f = (THPCppFunction*)obj.get();
   HANDLE_TH_ERRORS

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -59,11 +59,11 @@ static PyObject* _allocate_grad_output(output_info_type& info, AutoGPU& gpu_guar
   gpu_guard.setDevice(std::get<1>(info));
   std::vector<long> &sizes = std::get<2>(info);
 
-  THPObjectPtr grad_size = THPSize_New(sizes.size(), sizes.data());
+  THPObjectPtr grad_size(THPSize_New(sizes.size(), sizes.data()));
   if (!grad_size) throw python_error();
-  THPObjectPtr new_grad = PyObject_CallFunctionObjArgs(tensor_cls, grad_size.get(), NULL);
+  THPObjectPtr new_grad(PyObject_CallFunctionObjArgs(tensor_cls, grad_size.get(), NULL));
   if (!new_grad) throw python_error();
-  THPObjectPtr result = PyObject_CallMethod(new_grad.get(), "zero_", "");
+  THPObjectPtr result(PyObject_CallMethod(new_grad.get(), "zero_", ""));
   if (!result) throw python_error();
   return new_grad.release();
 }
@@ -73,7 +73,7 @@ namespace torch { namespace autograd {
 auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   AutoGIL gil;
 
-  THPObjectPtr pyInputs = PyTuple_New(inputs.size());
+  THPObjectPtr pyInputs(PyTuple_New(inputs.size()));
   if (!pyInputs) throw python_error();
 
   for (size_t i = 0; i != inputs.size(); ++i) {
@@ -88,8 +88,8 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
     PyTuple_SET_ITEM(pyInputs.get(), i, input);
   }
 
-  THPObjectPtr r = PyObject_CallMethod(
-      obj, "_do_backward", "OO", pyInputs.get(), Py_True);
+  THPObjectPtr r(PyObject_CallMethod(
+      obj, "_do_backward", "OO", pyInputs.get(), Py_True));
   if (!r) throw python_error();
 
   auto num_outputs = PyTuple_GET_SIZE(r.get());
@@ -126,14 +126,14 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   AutoGPU _gpu_guard(-1);
   THPFunction* py_fn = (THPFunction*)obj;
 
-  THPObjectPtr _legacy = PyObject_GetAttrString(obj, "_is_legacy");
+  THPObjectPtr _legacy(PyObject_GetAttrString(obj, "_is_legacy"));
   if (_legacy == Py_True) {
     return legacy_apply(inputs);
   }
 
   // Massage a C++ variable_list into a Python arguments tuple
   auto num_inputs = inputs.size();
-  THPObjectPtr pyInputs = PyTuple_New(num_inputs);
+  THPObjectPtr pyInputs(PyTuple_New(num_inputs));
   if (!pyInputs) throw python_error();
   auto& output_info = *py_fn->output_info;
   for (size_t i = 0; i < num_inputs; ++i) {
@@ -141,7 +141,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
     if (inputs[i]) {
       input = THPVariable_Wrap(inputs[i]);
     } else {
-      THPObjectPtr tensor = _allocate_grad_output(output_info[i], _gpu_guard);
+      THPObjectPtr tensor(_allocate_grad_output(output_info[i], _gpu_guard));
       input = THPVariable_NewLeaf(tensor);
     }
     if (!input) throw python_error();
@@ -149,9 +149,9 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   }
 
   // TODO: theoretically we could take a shortcut here and call apply directly
-  THPObjectPtr apply_fn = PyObject_GetAttrString(obj, "apply");
+  THPObjectPtr apply_fn(PyObject_GetAttrString(obj, "apply"));
   if (!apply_fn) throw python_error();
-  THPObjectPtr r = PyObject_CallObject(apply_fn, pyInputs.get());
+  THPObjectPtr r(PyObject_CallObject(apply_fn, pyInputs.get()));
   if (!r) throw python_error();
   _ensure_tuple(r);
 
@@ -625,12 +625,12 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 
-PyObject* process_outputs(THPFunction* grad_fn, const UnpackedInput& unpacked, THPObjectPtr raw_output, bool is_volatile) {
+PyObject* process_outputs(THPFunction* grad_fn, const UnpackedInput& unpacked, THPObjectPtr&& raw_output, bool is_volatile) {
   bool unpack_output = _ensure_tuple(raw_output);
 
   auto num_outputs = PyTuple_GET_SIZE(raw_output.get());
 
-  THPObjectPtr outputs = PyTuple_New(num_outputs);
+  THPObjectPtr outputs(PyTuple_New(num_outputs));
   if (!outputs) throw python_error();
 
   grad_fn->cdata.num_inputs = num_outputs;
@@ -678,9 +678,9 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   self->needs_input_grad = input_info.needs_input_grad.release();
 
   // Now we're ready to call a forward (implemented in Python)
-  THPObjectPtr forward_fn = PyObject_GetAttrString((PyObject*)self, "forward");
+  THPObjectPtr forward_fn(PyObject_GetAttrString((PyObject*)self, "forward"));
   if (!forward_fn) return NULL;
-  THPObjectPtr raw_output = PyObject_CallObject(forward_fn, unpacked_input.tensor_input);
+  THPObjectPtr raw_output(PyObject_CallObject(forward_fn, unpacked_input.tensor_input));
   if (!raw_output) return NULL;
 
   return process_outputs(self, unpacked_input, std::move(raw_output), is_volatile);
@@ -691,9 +691,9 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *_inputs)
 {
   HANDLE_TH_ERRORS
 
-  THPObjectPtr backward_cls = PyObject_GetAttrString(cls, "_backward_cls");
+  THPObjectPtr backward_cls(PyObject_GetAttrString(cls, "_backward_cls"));
   if (!backward_cls) return NULL;
-  THPObjectPtr ctx_obj = PyObject_CallFunctionObjArgs(backward_cls, NULL);
+  THPObjectPtr ctx_obj(PyObject_CallFunctionObjArgs(backward_cls, NULL));
   if (!ctx_obj) return NULL;
   THPFunction* ctx = (THPFunction*)ctx_obj.get();
 
@@ -708,7 +708,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *_inputs)
 
   // Prepend ctx to tensor_input, in preparation for static method call
   auto num_args = PyTuple_GET_SIZE(_inputs);
-  THPObjectPtr ctx_tensor_input = PyTuple_New(num_args + 1);
+  THPObjectPtr ctx_tensor_input(PyTuple_New(num_args + 1));
   PyTuple_SET_ITEM(ctx_tensor_input.get(), 0, ctx_obj.release());
   for (int i = 0; i < num_args; ++i) {
     PyObject *arg = PyTuple_GET_ITEM(unpacked_input.tensor_input.get(), i);
@@ -717,9 +717,9 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *_inputs)
   }
 
   // Call forward
-  THPObjectPtr forward_fn = PyObject_GetAttrString(cls, "forward");
+  THPObjectPtr forward_fn(PyObject_GetAttrString(cls, "forward"));
   if (!forward_fn) return NULL;
-  THPObjectPtr tensor_outputs = PyObject_CallObject(forward_fn, ctx_tensor_input);
+  THPObjectPtr tensor_outputs(PyObject_CallObject(forward_fn, ctx_tensor_input));
   if (!tensor_outputs) return NULL;
 
   return process_outputs(ctx, unpacked_input, std::move(tensor_outputs), is_volatile);
@@ -800,14 +800,14 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
     // Some of the output might have been unused, so we have to allocate
     // zero-filled buffers instead
     Py_INCREF(raw_grad_output);
-    THPObjectPtr grad_output = raw_grad_output;
+    THPObjectPtr grad_output(raw_grad_output);
     _prepare_grad_output(self, grad_output);
 
     // self.backward(*grad_output)
-    THPObjectPtr backward_fn = PyObject_GetAttrString((PyObject*)self, "backward");
+    THPObjectPtr backward_fn(PyObject_GetAttrString((PyObject*)self, "backward"));
     THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
         "'backward' method", THPUtils_typename((PyObject*)self));
-    THPObjectPtr grad_input = PyObject_CallObject(backward_fn, grad_output.get());
+    THPObjectPtr grad_input(PyObject_CallObject(backward_fn, grad_output.get()));
     if (!grad_input) return NULL;
     _ensure_tuple(grad_input);
 
@@ -856,7 +856,7 @@ PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
     return PyTuple_New(0);
 
   int num_saved = self->saved_variables->size();
-  THPObjectPtr saved_tensors = PyTuple_New(num_saved);
+  THPObjectPtr saved_tensors(PyTuple_New(num_saved));
   if (!saved_tensors)
     return NULL;
   auto& saved_variables = *self->saved_variables;
@@ -883,7 +883,7 @@ PyObject *THPFunction_saved_variables(THPFunction *self, void *_unused)
     return PyTuple_New(0);
 
   int num_saved = self->saved_variables->size();
-  THPObjectPtr py_saved_variables = PyTuple_New(num_saved);
+  THPObjectPtr py_saved_variables(PyTuple_New(num_saved));
   if (!py_saved_variables) return NULL;
   auto& saved_variables = *self->saved_variables;
   for (int i = 0; i < num_saved; i++) {
@@ -905,11 +905,11 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
 {
   auto& next_fns = self->cdata.next_functions;
   int size = next_fns.size();
-  THPObjectPtr result = PyTuple_New(size);
+  THPObjectPtr result(PyTuple_New(size));
   if (!result)
     return NULL;
   for (int i = 0; i < size; i++) {
-    THPObjectPtr fn_tuple = PyTuple_New(2);
+    THPObjectPtr fn_tuple(PyTuple_New(2));
     if (!fn_tuple) return NULL;
     PyObject* fn = functionToPyObject(next_fns[i].first);
     if (!fn) return NULL;

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -161,7 +161,7 @@ PyObject * THCPModule_getDriverVersion(PyObject *self)
 PyObject * THCPModule_getRNGState(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  THPByteTensorPtr res = (THPByteTensor *)THPByteTensor_NewEmpty();
+  THPByteTensorPtr res((THPByteTensor *)THPByteTensor_NewEmpty());
   if (!res) return NULL;
   THCRandom_getRNGState(state, res->cdata);
   return (PyObject *)res.release();

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -24,7 +24,7 @@ static PyObject * THCPStream_pynew(PyTypeObject *type, PyObject *args, PyObject 
     return NULL;
   }
 
-  THPObjectPtr ptr = type->tp_alloc(type, 0);
+  THPObjectPtr ptr(type->tp_alloc(type, 0));
   if (!ptr) {
     return NULL;
   }

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -37,7 +37,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   HANDLE_TH_ERRORS
     Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;
 
-  THSPTensorPtr self = (THSPTensor *)type->tp_alloc(type, 0);
+  THSPTensorPtr self((THSPTensor *)type->tp_alloc(type, 0));
   THPUtils_assert(self, "failed to allocate a " THSPTensorStr " object");
   THLongStoragePtr sizes;
 
@@ -72,7 +72,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   }
   // torch.SparseTensor(torch.Size sizes)
   else if (num_args == 1 && THPSize_Check(first_arg)) {
-    THLongStoragePtr sizes = THPUtils_unpackSize(first_arg);
+    THLongStoragePtr sizes(THPUtils_unpackSize(first_arg));
     self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get());
   }
   // torch.SparseTensor(torch.LongTensor indices, torch.LongTensor values)
@@ -95,7 +95,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
     THIndexTensor *indices = ((THPIndexTensor*)first_arg)->cdata;
     THTensor *values = ((THPTensor*)second_arg)->cdata;
-    THLongStoragePtr sizes = THPUtils_unpackSize(third_arg);
+    THLongStoragePtr sizes(THPUtils_unpackSize(third_arg));
     self->cdata = THSTensor_(newWithTensorAndSize)(
         LIBRARY_STATE indices, values, sizes);
   }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -37,7 +37,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   HANDLE_TH_ERRORS
   Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;
 
-  THPStoragePtr self = (THPStorage *)type->tp_alloc(type, 0);
+  THPStoragePtr self((THPStorage *)type->tp_alloc(type, 0));
   THPUtils_assert(self, "failed to allocate a " THPStorageStr " object");
   THAllocator* allocator = NULL;
 
@@ -113,7 +113,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         size, numel - offset, offset);
 
     real *data_ptr = storage_arg->cdata->data + offset;
-    THStoragePtr storage = THStorage_(newWithData)(LIBRARY_STATE data_ptr, size);
+    THStoragePtr storage(THStorage_(newWithData)(LIBRARY_STATE data_ptr, size));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
     THStorage_(retain)(LIBRARY_STATE storage_arg->cdata);
@@ -197,7 +197,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     }
 
     real *data = THStorage_(data)(LIBRARY_STATE self->cdata);
-    THStoragePtr new_storage = THStorage_(newWithData)(LIBRARY_STATE data + start, slicelength);
+    THStoragePtr new_storage(THStorage_(newWithData)(LIBRARY_STATE data + start, slicelength));
     new_storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     new_storage->view = self->cdata;
     THStorage_(retain)(LIBRARY_STATE self->cdata);

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -50,7 +50,7 @@ static PyObject * THPStorage_(elementSize)(THPStorage *self)
 static PyObject * THPStorage_(new)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  THStoragePtr new_storage = THStorage_(new)(LIBRARY_STATE_NOARGS);
+  THStoragePtr new_storage(THStorage_(new)(LIBRARY_STATE_NOARGS));
   PyObject *_ret = THPStorage_(New)(new_storage);
   new_storage.release();
   return _ret;
@@ -257,7 +257,7 @@ PyObject * THPStorage_(_rootStorage)(THPStorage *self)
     root = root->view;
   size_t offset = self->cdata->data - root->data;
   THStorage_(retain)(LIBRARY_STATE root);
-  THPObjectPtr storage = THPStorage_(New)(root);
+  THPObjectPtr storage(THPStorage_(New)(root));
   PyObject *result = Py_BuildValue("(NN)", storage.get(), PyLong_FromLong(offset));
   storage.release();
   return result;

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -26,7 +26,7 @@ static PyObject * THPTensor_(storage)(THPTensor *self, PyObject *args)
   if (result == NULL)
     Py_RETURN_NONE;
   THStorage_(retain)(LIBRARY_STATE result);
-  THStoragePtr _tmp = result;
+  THStoragePtr _tmp(result);
   PyObject *ret = THPStorage_(New)(result);
   _tmp.release();
   return ret;
@@ -152,7 +152,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
         - THTensor* self
         - CONSTANT NULL, 0, NULL, NULL
     - cname: setStorage
-      before_call: THLongStoragePtr __storage_size = THLongStorage_newWithSize1(THStorage_(size)(LIBRARY_STATE arg_storage));
+      before_call: THLongStoragePtr __storage_size(THLongStorage_newWithSize1(THStorage_(size)(LIBRARY_STATE arg_storage)));
       arguments:
         - THTensor* self
         - THStorage* storage
@@ -191,7 +191,7 @@ static PyObject * THPTensor_(select)(THPTensor *self, PyObject *args)
   if (dim<0) dim += ndim;
 
   if(ndim > 1) {
-    THTensorPtr selected = THTensor_(newWithTensor)(LIBRARY_STATE self->cdata);
+    THTensorPtr selected(THTensor_(newWithTensor)(LIBRARY_STATE self->cdata));
     THTensor_(select)(LIBRARY_STATE selected.get(), NULL, dim, idx);
     return THPTensor_(New)(selected.release());
   }
@@ -693,7 +693,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   with_stateless: True
   return: argument 0
   before_call: |
-    THLongStoragePtr _size = THIndexTensor_(newSizeOf)(LIBRARY_STATE arg_index);
+    THLongStoragePtr _size(THIndexTensor_(newSizeOf)(LIBRARY_STATE arg_index));
     THTensor_(resize)(LIBRARY_STATE arg_result, _size, NULL);
   arguments:
     - arg: THTensor* result

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -89,10 +89,10 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
     sizes_ptr = &zero;
   }
 
-  THPObjectPtr array = PyArray_New(
+  THPObjectPtr array(PyArray_New(
       &PyArray_Type, ndim, sizes_ptr, NUMPY_TYPE_ENUM,
       strides.get(), self->cdata->storage->data + self->cdata->storageOffset,
-      0, NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE | NPY_ARRAY_C_CONTIGUOUS, nullptr);
+      0, NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE | NPY_ARRAY_C_CONTIGUOUS, nullptr));
   if (!array) {
     THPUtils_setError("an error occured during conversion to numpy array");
     return NULL;

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -14,7 +14,7 @@ void THPTensor_(writeMetadataRaw)(THTensor *self, int fd)
 
 THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage)
 {
-  THTensorPtr tensor = THTensor_(new)(LIBRARY_STATE_NOARGS);
+  THTensorPtr tensor(THTensor_(new)(LIBRARY_STATE_NOARGS));
   SYSCHECK(read(fd, &tensor->nDimension, sizeof(long)));
   tensor->size = (long*)THAlloc(tensor->nDimension * sizeof(long));
   tensor->stride = (long*)THAlloc(tensor->nDimension * sizeof(long));

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -21,7 +21,7 @@ int THPUtils_getCallable(PyObject *arg, PyObject **result) {
   return 1;
 }
 
-THLongStorage* THPUtils_unpackSize(PyObject *arg) {
+THLongStoragePtr THPUtils_unpackSize(PyObject *arg) {
   THLongStoragePtr result;
   if (!THPUtils_tryUnpackLongs(arg, result)) {
     std::string msg = "THPUtils_unpackSize() expects a torch.Size (got '";
@@ -29,7 +29,7 @@ THLongStorage* THPUtils_unpackSize(PyObject *arg) {
     msg += "')";
     throw std::runtime_error(msg);
   }
-  return result.release();
+  return result;
 }
 
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -21,7 +21,7 @@ int THPUtils_getCallable(PyObject *arg, PyObject **result) {
   return 1;
 }
 
-THLongStoragePtr THPUtils_unpackSize(PyObject *arg) {
+THLongStorage* THPUtils_unpackSize(PyObject *arg) {
   THLongStoragePtr result;
   if (!THPUtils_tryUnpackLongs(arg, result)) {
     std::string msg = "THPUtils_unpackSize() expects a torch.Size (got '";
@@ -29,7 +29,7 @@ THLongStoragePtr THPUtils_unpackSize(PyObject *arg) {
     msg += "')";
     throw std::runtime_error(msg);
   }
-  return result;
+  return result.release();
 }
 
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {
@@ -37,7 +37,7 @@ bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {
   bool list = PyList_Check(arg);
   if (tuple || list) {
     int nDim = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
-    THLongStoragePtr storage = THLongStorage_newWithSize(nDim);
+    THLongStoragePtr storage(THLongStorage_newWithSize(nDim));
     for (int i = 0; i != nDim; ++i) {
       PyObject* item = tuple ? PyTuple_GET_ITEM(arg, i) : PyList_GET_ITEM(arg, i);
       if (!THPUtils_checkLong(item)) {
@@ -45,7 +45,7 @@ bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {
       }
       storage->data[i] = THPUtils_unpackLong(item);
     }
-    result = storage.release();
+    result  = std::move(storage);
     return true;
   }
   return false;
@@ -136,14 +136,14 @@ static const char* classOrTypename(PyObject* obj) {
 PyObject * THPUtils_dispatchStateless(
     PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs)
 {
-  THPObjectPtr methods = PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME);
+  THPObjectPtr methods(PyObject_GetAttrString(tensor, THP_STATELESS_ATTRIBUTE_NAME));
   if (!methods) {
     return PyErr_Format(
         PyExc_TypeError,
         "Type %s doesn't implement stateless methods",
         classOrTypename(tensor));
   }
-  THPObjectPtr method = PyObject_GetAttrString(methods, name);
+  THPObjectPtr method(PyObject_GetAttrString(methods, name));
   if (!method) {
     return PyErr_Format(
         PyExc_TypeError,

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -161,7 +161,7 @@ struct THPUtils_typeTraits {};
 #include "generic/utils.h"
 #include <TH/THGenerateHalfType.h>
 
-THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
+THLongStorage* THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
 PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -161,7 +161,7 @@ struct THPUtils_typeTraits {};
 #include "generic/utils.h"
 #include <TH/THGenerateHalfType.h>
 
-THLongStorage* THPUtils_unpackSize(PyObject *arg);
+THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
 PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -5,9 +5,9 @@
 template<class T>
 class THPPointer {
 public:
-  THPPointer(): ptr(nullptr) {};
-  THPPointer(T *ptr): ptr(ptr) {};
-  THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
+  explicit THPPointer(): ptr(nullptr) {};
+  explicit THPPointer(T *ptr): ptr(ptr) {};
+  explicit THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
 
   ~THPPointer() { free(); };
   T * get() { return ptr; }

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -5,9 +5,9 @@
 template<class T>
 class THPPointer {
 public:
-  explicit THPPointer(): ptr(nullptr) {};
+  THPPointer(): ptr(nullptr) {};
   explicit THPPointer(T *ptr): ptr(ptr) {};
-  explicit THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
+  THPPointer(THPPointer &&p) { free(); ptr = p.ptr; p.ptr = nullptr; };
 
   ~THPPointer() { free(); };
   T * get() { return ptr; }

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -24,7 +24,7 @@ inline std::string THPUtils_unpackString(PyObject* obj) {
   }
   if (PyUnicode_Check(obj)) {
 #if PY_MAJOR_VERSION == 2
-    THPObjectPtr bytes = PyUnicode_AsUTF8String(obj);
+    THPObjectPtr bytes(PyUnicode_AsUTF8String(obj));
     if (!bytes) {
       throw std::runtime_error("error unpacking string as utf-8");
     }


### PR DESCRIPTION
Previously, THPPointer did not have its constructors marked as explicit. As a result, something like:

```
THTensor *someIntermediateResult = THTensor_(new)(LIBRARY_STATE_NOARGS);
// do some things to someIntermediateResult
THPTensor wrapped = someIntermediateResult; // calls implicit constructor
```

The fact that `THPTensor` takes "ownership" of the `THTensor` in this case is obfuscated, which could lead to double frees. 

This diff marks all the `THPTensor` constructors explicit, preventing this type of implicit constructor from a pointer. I followed it with the following codemod:

```
codemod -m -d torch/ --extensions h,hpp,cpp,cwrap \
    '(TH[a-zA-Z_]+Ptr [a-zA-Z_]+) = ([^;]*);'  \
    '\1(\2);'
```

To replace all assignment calls with calls to the explicit constructor. There were a couple of other places where I need to fix this, e.g. in the `THPPlugin.py` allocation template. 

Test Plan: Run Tests locally