### PR TITLE
Conv double backward

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1273,7 +1273,7 @@ class TestAutograd(TestCase):
 
     def test_conv_double_backward(self):
         batch_size = 2
-        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 9, [2]), (4, 10, [1])]:
+        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
             for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 2], [1], [2, 3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
@@ -1292,16 +1292,7 @@ class TestAutograd(TestCase):
                                 "\ndilation: " + str(dilation))
 
     def test_error_conv_double_backward(self):
-        # Invalid kernel and input size for stride of 2
         batch_size = 2
-        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 8, [1, 2]), (4, 9, [1]), (4, 10, [2])]:
-            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
-                no_weight = stride == 2
-                with self.assertRaises(RuntimeError):
-                    self.run_conv_double_back_test(kern, stride,
-                                                   padding, chan_in, chan_out,
-                                                   batch_size, inp_size, dilation,
-                                                   no_weight)
 
         # Cannot provide ggW when stride is > 1
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8,7 +8,8 @@ import warnings
 from copy import deepcopy
 from collections import OrderedDict
 from itertools import product
-from torch.autograd import gradcheck
+import torch.nn.functional as F
+from torch.autograd import gradcheck, gradgradcheck
 from torch.autograd.function import once_differentiable
 
 from common import TestCase, run_tests, skipIfNoLapack
@@ -1230,6 +1231,87 @@ class TestAutograd(TestCase):
         c = F2()(a, b)
         c.backward(torch.ones(c.size()))
         self.assertEqual(x.grad.data, torch.ones(x.size()))
+
+    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size, inp_size, dilation, no_weight):
+        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
+        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
+        bias = Variable(torch.randn(chan_out), requires_grad=True)
+
+        if no_weight:
+            # Special case because transpose dilated convolution is not implemented
+            def func(x, bias):
+                return F.conv2d(x, weight, bias, stride, padding, dilation)
+            inputs = (x, bias,)
+        else:
+            def func(x, weight, bias):
+                return F.conv2d(x, weight, bias, stride, padding, dilation)
+            inputs = (x, weight, bias,)
+
+        dummy_out = func(*inputs)
+        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
+
+        # print("Conv double backward testing with parameters:" +
+        #     "\nkern: " + str(kern) +
+        #     "\nstride: " + str(stride) +
+        #     "\npadding: " + str(padding) +
+        #     "\nchan_in: " + str(chan_in) +
+        #     "\nchan_out: " + str(chan_out) +
+        #     "\nbatch_size: " + str(batch_size) +
+        #     "\ninp_size: " + str(inp_size) +
+        #     "\ndilation: " + str(dilation))
+
+        return gradgradcheck(func, inputs, (grad_y,))
+
+    def test_conv_double_backward(self):
+        batch_size = 2
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 9, [2]), (4, 10, [1])]:
+            for stride in [1, 2]:
+                for padding in [0, 1, 2]:
+                    for chan_in in [1, 3]:
+                        for chan_out in [1, 3]:
+                            for dilation in dilations:
+                                no_weight = stride==2
+                                result = self.run_conv_double_back_test(kern, stride,
+                                    padding, chan_in, chan_out,
+                                    batch_size, inp_size, dilation, no_weight)
+                                self.assertTrue(result,
+                                    "Conv double backward test failed with parameters:" +
+                                    "\nkern: " + str(kern) +
+                                    "\nstride: " + str(stride) +
+                                    "\npadding: " + str(padding) +
+                                    "\nchan_in: " + str(chan_in) +
+                                    "\nchan_out: " + str(chan_out) +
+                                    "\nbatch_size: " + str(batch_size) +
+                                    "\ninp_size: " + str(inp_size) +
+                                    "\ndilation: " + str(dilation))
+
+    def test_error_conv_double_backward(self):
+        # Invalid kernel and input size for stride of 2
+        batch_size = 2
+        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 8, [1, 2]), (4, 9, [1]), (4, 10, [2])]:
+            for stride in [2]:
+                for padding in [0, 1, 2]:
+                    for chan_in in [1, 3]:
+                        for chan_out in [1, 3]:
+                            for dilation in dilations:
+                                no_weight = stride==2
+                                with self.assertRaises(RuntimeError):
+                                    self.run_conv_double_back_test(kern, stride,
+                                        padding, chan_in, chan_out,
+                                        batch_size, inp_size, dilation, no_weight)
+
+        # Cannot provide ggW when stride is > 1
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
+            for stride in [2]:
+                for padding in [0, 1, 2]:
+                    for chan_in in [1, 3]:
+                        for chan_out in [1, 3]:
+                            for dilation in dilations:
+                                no_weight = False
+                                with self.assertRaises(RuntimeError):
+                                    self.run_conv_double_back_test(kern, stride,
+                                        padding, chan_in, chan_out,
+                                        batch_size, inp_size, dilation, no_weight)
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1324,6 +1324,7 @@ class TestAutograd(TestCase):
                                                         batch_size, inp_size, dilation,
                                                         no_weight, use_cuda=True)
 
+
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):
         shape = (shape,)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1235,8 +1235,14 @@ class TestAutograd(TestCase):
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
                                   batch_size, inp_size, dilation, no_weight):
-        # Tests fail when using cudnn
-        torch.backends.cudnn.enabled = False
+        # When using cudnn
+        # Works for eps = 1e-3
+        # Give wrong values for eps = 1e-6
+        # Give only zeros for eps = 1e-8
+        # Without cudnn
+        # works for all eps
+        torch.backends.cudnn.enabled = True
+        epsilon = 1e-3
         x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size).cuda(), requires_grad=True)
         weight = Variable(torch.randn(chan_out, chan_in, kern, kern).cuda(), requires_grad=True)
         bias = Variable(torch.randn(chan_out).cuda(), requires_grad=True)
@@ -1254,7 +1260,7 @@ class TestAutograd(TestCase):
         dummy_out = func(*inputs)
         grad_y = Variable(torch.randn(dummy_out.size()).cuda(), requires_grad=True)
 
-        return gradgradcheck(func, inputs, (grad_y,))
+        return gradgradcheck(func, inputs, (grad_y,), eps=epsilon)
 
     def test_conv_double_backward(self):
         batch_size = 2

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1232,7 +1232,8 @@ class TestAutograd(TestCase):
         c.backward(torch.ones(c.size()))
         self.assertEqual(x.grad.data, torch.ones(x.size()))
 
-    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size, inp_size, dilation, no_weight):
+    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
+                                  batch_size, inp_size, dilation, no_weight):
         x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
         weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
         bias = Variable(torch.randn(chan_out), requires_grad=True)
@@ -1270,20 +1271,21 @@ class TestAutograd(TestCase):
                     for chan_in in [1, 3]:
                         for chan_out in [1, 3]:
                             for dilation in dilations:
-                                no_weight = stride==2
+                                no_weight = stride == 2
                                 result = self.run_conv_double_back_test(kern, stride,
-                                    padding, chan_in, chan_out,
-                                    batch_size, inp_size, dilation, no_weight)
+                                                                        padding, chan_in, chan_out,
+                                                                        batch_size, inp_size, dilation,
+                                                                        no_weight)
                                 self.assertTrue(result,
-                                    "Conv double backward test failed with parameters:" +
-                                    "\nkern: " + str(kern) +
-                                    "\nstride: " + str(stride) +
-                                    "\npadding: " + str(padding) +
-                                    "\nchan_in: " + str(chan_in) +
-                                    "\nchan_out: " + str(chan_out) +
-                                    "\nbatch_size: " + str(batch_size) +
-                                    "\ninp_size: " + str(inp_size) +
-                                    "\ndilation: " + str(dilation))
+                                                "Conv double backward test failed with parameters:" +
+                                                "\nkern: " + str(kern) +
+                                                "\nstride: " + str(stride) +
+                                                "\npadding: " + str(padding) +
+                                                "\nchan_in: " + str(chan_in) +
+                                                "\nchan_out: " + str(chan_out) +
+                                                "\nbatch_size: " + str(batch_size) +
+                                                "\ninp_size: " + str(inp_size) +
+                                                "\ndilation: " + str(dilation))
 
     def test_error_conv_double_backward(self):
         # Invalid kernel and input size for stride of 2
@@ -1294,11 +1296,12 @@ class TestAutograd(TestCase):
                     for chan_in in [1, 3]:
                         for chan_out in [1, 3]:
                             for dilation in dilations:
-                                no_weight = stride==2
+                                no_weight = stride == 2
                                 with self.assertRaises(RuntimeError):
                                     self.run_conv_double_back_test(kern, stride,
-                                        padding, chan_in, chan_out,
-                                        batch_size, inp_size, dilation, no_weight)
+                                                                   padding, chan_in, chan_out,
+                                                                   batch_size, inp_size, dilation,
+                                                                   no_weight)
 
         # Cannot provide ggW when stride is > 1
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
@@ -1310,8 +1313,9 @@ class TestAutograd(TestCase):
                                 no_weight = False
                                 with self.assertRaises(RuntimeError):
                                     self.run_conv_double_back_test(kern, stride,
-                                        padding, chan_in, chan_out,
-                                        batch_size, inp_size, dilation, no_weight)
+                                                                   padding, chan_in, chan_out,
+                                                                   batch_size, inp_size, dilation,
+                                                                   no_weight)
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -35,6 +35,16 @@ def backward_engine(engine):
         Variable._execution_engine = _prev_engine
 
 
+@contextlib.contextmanager
+def use_cudnn(should_use):
+    orig = torch.backends.cudnn.enabled
+    torch.backends.cudnn.enabled = should_use
+    try:
+        yield
+    finally:
+        torch.backends.cudnn.enabled = orig
+
+
 def graph_desc(fn):
     if fn is None:
         return 'None'
@@ -1248,19 +1258,15 @@ class TestAutograd(TestCase):
             # Special case because transpose dilated convolution is not implemented
             def func(x, bias):
                 # We disable cudnn during forward to avoid finite difference imprecision issues
-                prev_cudnn = torch.backends.cudnn.enabled
-                torch.backends.cudnn.enabled = False
-                out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                torch.backends.cudnn.enabled = prev_cudnn
+                with use_cudnn(False):
+                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, bias,)
         else:
             def func(x, weight, bias):
                 # We disable cudnn during forward to avoid finite difference imprecision issues
-                prev_cudnn = torch.backends.cudnn.enabled
-                torch.backends.cudnn.enabled = False
-                out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                torch.backends.cudnn.enabled = prev_cudnn
+                with use_cudnn(False):
+                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, weight, bias,)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9,7 +9,8 @@ from copy import deepcopy
 from collections import OrderedDict
 from itertools import product
 import torch.nn.functional as F
-from torch.autograd import gradcheck, gradgradcheck
+from torch.autograd import gradcheck
+from torch.autograd.gradcheck import gradgradcheck
 from torch.autograd.function import once_differentiable
 
 from common import TestCase, run_tests, skipIfNoLapack
@@ -1234,9 +1235,11 @@ class TestAutograd(TestCase):
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
                                   batch_size, inp_size, dilation, no_weight):
-        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
-        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
-        bias = Variable(torch.randn(chan_out), requires_grad=True)
+        # Tests fail when using cudnn
+        torch.backends.cudnn.enabled = False
+        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size).cuda(), requires_grad=True)
+        weight = Variable(torch.randn(chan_out, chan_in, kern, kern).cuda(), requires_grad=True)
+        bias = Variable(torch.randn(chan_out).cuda(), requires_grad=True)
 
         if no_weight:
             # Special case because transpose dilated convolution is not implemented
@@ -1249,73 +1252,51 @@ class TestAutograd(TestCase):
             inputs = (x, weight, bias,)
 
         dummy_out = func(*inputs)
-        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
-
-        # print("Conv double backward testing with parameters:" +
-        #     "\nkern: " + str(kern) +
-        #     "\nstride: " + str(stride) +
-        #     "\npadding: " + str(padding) +
-        #     "\nchan_in: " + str(chan_in) +
-        #     "\nchan_out: " + str(chan_out) +
-        #     "\nbatch_size: " + str(batch_size) +
-        #     "\ninp_size: " + str(inp_size) +
-        #     "\ndilation: " + str(dilation))
+        grad_y = Variable(torch.randn(dummy_out.size()).cuda(), requires_grad=True)
 
         return gradgradcheck(func, inputs, (grad_y,))
 
     def test_conv_double_backward(self):
         batch_size = 2
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 9, [2]), (4, 10, [1])]:
-            for stride in [1, 2]:
-                for padding in [0, 1, 2]:
-                    for chan_in in [1, 3]:
-                        for chan_out in [1, 3]:
-                            for dilation in dilations:
-                                no_weight = stride == 2
-                                result = self.run_conv_double_back_test(kern, stride,
-                                                                        padding, chan_in, chan_out,
-                                                                        batch_size, inp_size, dilation,
-                                                                        no_weight)
-                                self.assertTrue(result,
-                                                "Conv double backward test failed with parameters:" +
-                                                "\nkern: " + str(kern) +
-                                                "\nstride: " + str(stride) +
-                                                "\npadding: " + str(padding) +
-                                                "\nchan_in: " + str(chan_in) +
-                                                "\nchan_out: " + str(chan_out) +
-                                                "\nbatch_size: " + str(batch_size) +
-                                                "\ninp_size: " + str(inp_size) +
-                                                "\ndilation: " + str(dilation))
+            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 1, 2], [1, 3], [1, 3], dilations):
+                no_weight = stride == 2
+                result = self.run_conv_double_back_test(kern, stride,
+                                                        padding, chan_in, chan_out,
+                                                        batch_size, inp_size, dilation,
+                                                        no_weight)
+                self.assertTrue(result,
+                                "Conv double backward test failed with parameters:" +
+                                "\nkern: " + str(kern) +
+                                "\nstride: " + str(stride) +
+                                "\npadding: " + str(padding) +
+                                "\nchan_in: " + str(chan_in) +
+                                "\nchan_out: " + str(chan_out) +
+                                "\nbatch_size: " + str(batch_size) +
+                                "\ninp_size: " + str(inp_size) +
+                                "\ndilation: " + str(dilation))
 
     def test_error_conv_double_backward(self):
         # Invalid kernel and input size for stride of 2
         batch_size = 2
         for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 8, [1, 2]), (4, 9, [1]), (4, 10, [2])]:
-            for stride in [2]:
-                for padding in [0, 1, 2]:
-                    for chan_in in [1, 3]:
-                        for chan_out in [1, 3]:
-                            for dilation in dilations:
-                                no_weight = stride == 2
-                                with self.assertRaises(RuntimeError):
-                                    self.run_conv_double_back_test(kern, stride,
-                                                                   padding, chan_in, chan_out,
-                                                                   batch_size, inp_size, dilation,
-                                                                   no_weight)
+            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
+                no_weight = stride == 2
+                with self.assertRaises(RuntimeError):
+                    self.run_conv_double_back_test(kern, stride,
+                                                   padding, chan_in, chan_out,
+                                                   batch_size, inp_size, dilation,
+                                                   no_weight)
 
         # Cannot provide ggW when stride is > 1
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
-            for stride in [2]:
-                for padding in [0, 1, 2]:
-                    for chan_in in [1, 3]:
-                        for chan_out in [1, 3]:
-                            for dilation in dilations:
-                                no_weight = False
-                                with self.assertRaises(RuntimeError):
-                                    self.run_conv_double_back_test(kern, stride,
-                                                                   padding, chan_in, chan_out,
-                                                                   batch_size, inp_size, dilation,
-                                                                   no_weight)
+            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
+                no_weight = False
+                with self.assertRaises(RuntimeError):
+                    self.run_conv_double_back_test(kern, stride,
+                                                   padding, chan_in, chan_out,
+                                                   batch_size, inp_size, dilation,
+                                                   no_weight)
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -10,7 +10,6 @@ from collections import OrderedDict
 from itertools import product
 import torch.nn.functional as F
 from torch.autograd import gradcheck
-from torch.autograd.gradcheck import gradgradcheck
 from torch.autograd.function import once_differentiable
 
 from common import TestCase, run_tests, skipIfNoLapack
@@ -33,16 +32,6 @@ def backward_engine(engine):
         yield
     finally:
         Variable._execution_engine = _prev_engine
-
-
-@contextlib.contextmanager
-def use_cudnn(should_use):
-    orig = torch.backends.cudnn.enabled
-    torch.backends.cudnn.enabled = should_use
-    try:
-        yield
-    finally:
-        torch.backends.cudnn.enabled = orig
 
 
 def graph_desc(fn):
@@ -1242,84 +1231,6 @@ class TestAutograd(TestCase):
         c = F2()(a, b)
         c.backward(torch.ones(c.size()))
         self.assertEqual(x.grad.data, torch.ones(x.size()))
-
-    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
-                                  batch_size, inp_size, dilation, no_weight, use_cuda=False):
-        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
-        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
-        bias = Variable(torch.randn(chan_out), requires_grad=True)
-
-        if use_cuda:
-            x = x.cuda()
-            weight = weight.cuda()
-            bias = bias.cuda()
-
-        if no_weight:
-            # Special case because transpose dilated convolution is not implemented
-            def func(x, bias):
-                # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                return out
-            inputs = (x, bias,)
-        else:
-            def func(x, weight, bias):
-                # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                return out
-            inputs = (x, weight, bias,)
-
-        dummy_out = func(*inputs)
-        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
-        if use_cuda:
-            grad_y = grad_y.cuda()
-
-        return gradgradcheck(func, inputs, (grad_y,))
-
-    def test_conv_double_backward(self):
-        batch_size = 2
-        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
-            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 2], [1], [2, 3], dilations):
-                no_weight = stride == 2
-                result = self.run_conv_double_back_test(kern, stride,
-                                                        padding, chan_in, chan_out,
-                                                        batch_size, inp_size, dilation,
-                                                        no_weight)
-                self.assertTrue(result,
-                                "Conv double backward test failed with parameters:" +
-                                "\nkern: " + str(kern) +
-                                "\nstride: " + str(stride) +
-                                "\npadding: " + str(padding) +
-                                "\nchan_in: " + str(chan_in) +
-                                "\nchan_out: " + str(chan_out) +
-                                "\nbatch_size: " + str(batch_size) +
-                                "\ninp_size: " + str(inp_size) +
-                                "\ndilation: " + str(dilation))
-
-    def test_error_conv_double_backward(self):
-        batch_size = 2
-
-        # Cannot provide ggW when stride is > 1
-        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
-            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
-                no_weight = False
-                with self.assertRaises(RuntimeError):
-                    self.run_conv_double_back_test(kern, stride,
-                                                   padding, chan_in, chan_out,
-                                                   batch_size, inp_size, dilation,
-                                                   no_weight)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
-    def test_conv_double_backward_cuda(self):
-        batch_size = 1
-        for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 10, [1])]:
-            for stride, padding, chan_in, chan_out, dilation in product([1], [2], [2], [3], dilations):
-                no_weight = stride == 2
-                result = self.run_conv_double_back_test(kern, stride,
-                                                        padding, chan_in, chan_out,
-                                                        batch_size, inp_size, dilation,
-                                                        no_weight, use_cuda=True)
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1234,38 +1234,47 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, torch.ones(x.size()))
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
-                                  batch_size, inp_size, dilation, no_weight):
-        # When using cudnn
-        # Works for eps = 1e-3
-        # Give wrong values for eps = 1e-6
-        # Give only zeros for eps = 1e-8
-        # Without cudnn
-        # works for all eps
-        torch.backends.cudnn.enabled = True
-        epsilon = 1e-3
-        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size).cuda(), requires_grad=True)
-        weight = Variable(torch.randn(chan_out, chan_in, kern, kern).cuda(), requires_grad=True)
-        bias = Variable(torch.randn(chan_out).cuda(), requires_grad=True)
+                                  batch_size, inp_size, dilation, no_weight, use_cuda=False):
+        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
+        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
+        bias = Variable(torch.randn(chan_out), requires_grad=True)
+
+        if use_cuda:
+            x = x.cuda()
+            weight = weight.cuda()
+            bias = bias.cuda()
 
         if no_weight:
             # Special case because transpose dilated convolution is not implemented
             def func(x, bias):
-                return F.conv2d(x, weight, bias, stride, padding, dilation)
+                # We disable cudnn during forward to avoid finite difference imprecision issues
+                prev_cudnn = torch.backends.cudnn.enabled
+                torch.backends.cudnn.enabled = False
+                out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                torch.backends.cudnn.enabled = prev_cudnn
+                return out
             inputs = (x, bias,)
         else:
             def func(x, weight, bias):
-                return F.conv2d(x, weight, bias, stride, padding, dilation)
+                # We disable cudnn during forward to avoid finite difference imprecision issues
+                prev_cudnn = torch.backends.cudnn.enabled
+                torch.backends.cudnn.enabled = False
+                out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                torch.backends.cudnn.enabled = prev_cudnn
+                return out
             inputs = (x, weight, bias,)
 
         dummy_out = func(*inputs)
-        grad_y = Variable(torch.randn(dummy_out.size()).cuda(), requires_grad=True)
+        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
+        if use_cuda:
+            grad_y = grad_y.cuda()
 
-        return gradgradcheck(func, inputs, (grad_y,), eps=epsilon)
+        return gradgradcheck(func, inputs, (grad_y,))
 
     def test_conv_double_backward(self):
         batch_size = 2
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 9, [2]), (4, 10, [1])]:
-            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 1, 2], [1, 3], [1, 3], dilations):
+            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 2], [1], [2, 3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
                                                         padding, chan_in, chan_out,
@@ -1304,6 +1313,16 @@ class TestAutograd(TestCase):
                                                    batch_size, inp_size, dilation,
                                                    no_weight)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_conv_double_backward_cuda(self):
+        batch_size = 1
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 10, [1])]:
+            for stride, padding, chan_in, chan_out, dilation in product([1], [2], [2], [3], dilations):
+                no_weight = stride == 2
+                result = self.run_conv_double_back_test(kern, stride,
+                                                        padding, chan_in, chan_out,
+                                                        batch_size, inp_size, dilation,
+                                                        no_weight, use_cuda=True)
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2233,14 +2233,16 @@ class TestNN(NNTestCase):
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
                                   batch_size, inp_size, dilation, no_weight, use_cuda=False):
-        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
-        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
-        bias = Variable(torch.randn(chan_out), requires_grad=True)
-
+        x = torch.randn(batch_size, chan_in, inp_size, inp_size)
+        weight = torch.randn(chan_out, chan_in, kern, kern)
+        bias = torch.randn(chan_out)
         if use_cuda:
             x = x.cuda()
             weight = weight.cuda()
             bias = bias.cuda()
+        x = Variable(x, requires_grad=True)
+        weight = Variable(weight, requires_grad=True)
+        bias = Variable(bias, requires_grad=True)
 
         if no_weight:
             # Special case because transpose dilated convolution is not implemented
@@ -2259,9 +2261,10 @@ class TestNN(NNTestCase):
             inputs = (x, weight, bias,)
 
         dummy_out = func(*inputs)
-        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
+        grad_y = torch.randn(dummy_out.size())
         if use_cuda:
             grad_y = grad_y.cuda()
+        grad_y = Variable(grad_y, requires_grad=True)
 
         return gradgradcheck(func, inputs, (grad_y,))
 
@@ -2308,6 +2311,16 @@ class TestNN(NNTestCase):
                                                         padding, chan_in, chan_out,
                                                         batch_size, inp_size, dilation,
                                                         no_weight, use_cuda=True)
+                self.assertTrue(result,
+                                "Conv double backward test failed with parameters:" +
+                                "\nkern: " + str(kern) +
+                                "\nstride: " + str(stride) +
+                                "\npadding: " + str(padding) +
+                                "\nchan_in: " + str(chan_in) +
+                                "\nchan_out: " + str(chan_out) +
+                                "\nbatch_size: " + str(batch_size) +
+                                "\ninp_size: " + str(inp_size) +
+                                "\ndilation: " + str(dilation))
 
 
 class TestNNInit(TestCase):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2231,34 +2231,52 @@ class TestNN(NNTestCase):
 
         self.assertTrue(gradcheck(lambda x1, x2: F.bilinear(x1, x2, module.weight, module.bias), (input1_1, input2_1)))
 
-    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
-                                  batch_size, inp_size, dilation, no_weight, use_cuda=False):
+    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size,
+                                  inp_size, dilation, no_weight, use_cuda=False, use_bias=True):
         x = torch.randn(batch_size, chan_in, inp_size, inp_size)
         weight = torch.randn(chan_out, chan_in, kern, kern)
-        bias = torch.randn(chan_out)
+        if use_bias:
+            bias = torch.randn(chan_out)
+        else:
+            bias = None
         if use_cuda:
             x = x.cuda()
             weight = weight.cuda()
-            bias = bias.cuda()
+            if use_bias:
+                bias = bias.cuda()
         x = Variable(x, requires_grad=True)
         weight = Variable(weight, requires_grad=True)
-        bias = Variable(bias, requires_grad=True)
+        if use_bias:
+            bias = Variable(bias, requires_grad=True)
 
         if no_weight:
             # Special case because transpose dilated convolution is not implemented
-            def func(x, bias):
+            def func(*inputs):
+                if use_bias:
+                    x, bias = inputs
+                else:
+                    x, = inputs
+                    bias = None
                 # We disable cudnn during forward to avoid finite difference imprecision issues
                 with use_cudnn(False):
                     out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, bias,)
         else:
-            def func(x, weight, bias):
+            def func(*inputs):
+                if use_bias:
+                    x, weight, bias = inputs
+                else:
+                    x, weight = inputs
+                    bias = None
                 # We disable cudnn during forward to avoid finite difference imprecision issues
                 with use_cudnn(False):
                     out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, weight, bias,)
+
+        if not use_bias:
+            inputs = inputs[:-1]
 
         dummy_out = func(*inputs)
         grad_y = torch.randn(dummy_out.size())
@@ -2287,6 +2305,31 @@ class TestNN(NNTestCase):
                                 "\nbatch_size: " + str(batch_size) +
                                 "\ninp_size: " + str(inp_size) +
                                 "\ndilation: " + str(dilation))
+
+    def test_conv_double_backward_no_bias(self):
+        kern = 3
+        stride = 1
+        padding = 2
+        chan_in, chan_out = 2, 4
+        batch_size = 2
+        inp_size = 6
+        dilation = 1
+        no_weight = False
+        use_bias = True
+        result = self.run_conv_double_back_test(kern, stride,
+                                                padding, chan_in, chan_out,
+                                                batch_size, inp_size, dilation,
+                                                no_weight, use_bias=use_bias)
+        self.assertTrue(result,
+                        "Conv double backward test failed with parameters:" +
+                        "\nkern: " + str(kern) +
+                        "\nstride: " + str(stride) +
+                        "\npadding: " + str(padding) +
+                        "\nchan_in: " + str(chan_in) +
+                        "\nchan_out: " + str(chan_out) +
+                        "\nbatch_size: " + str(batch_size) +
+                        "\ninp_size: " + str(inp_size) +
+                        "\ndilation: " + str(dilation))
 
     def test_error_conv_double_backward(self):
         batch_size = 2

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -18,6 +18,7 @@ import torch.nn.utils.rnn as rnn_utils
 import torch.legacy.nn as legacy
 from torch.nn.utils import clip_grad_norm
 from torch.autograd import Variable, gradcheck
+from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
@@ -26,6 +27,16 @@ from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, TEST_S
 
 if TEST_SCIPY:
     from scipy import stats
+
+
+@contextlib.contextmanager
+def use_cudnn(should_use):
+    orig = torch.backends.cudnn.enabled
+    torch.backends.cudnn.enabled = should_use
+    try:
+        yield
+    finally:
+        torch.backends.cudnn.enabled = orig
 
 
 def default_tensor_type(type):
@@ -2219,6 +2230,84 @@ class TestNN(NNTestCase):
         self.assertEqual(module.bias.grad.data, module_legacy.gradBias)
 
         self.assertTrue(gradcheck(lambda x1, x2: F.bilinear(x1, x2, module.weight, module.bias), (input1_1, input2_1)))
+
+    def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out,
+                                  batch_size, inp_size, dilation, no_weight, use_cuda=False):
+        x = Variable(torch.randn(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
+        weight = Variable(torch.randn(chan_out, chan_in, kern, kern), requires_grad=True)
+        bias = Variable(torch.randn(chan_out), requires_grad=True)
+
+        if use_cuda:
+            x = x.cuda()
+            weight = weight.cuda()
+            bias = bias.cuda()
+
+        if no_weight:
+            # Special case because transpose dilated convolution is not implemented
+            def func(x, bias):
+                # We disable cudnn during forward to avoid finite difference imprecision issues
+                with use_cudnn(False):
+                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                return out
+            inputs = (x, bias,)
+        else:
+            def func(x, weight, bias):
+                # We disable cudnn during forward to avoid finite difference imprecision issues
+                with use_cudnn(False):
+                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                return out
+            inputs = (x, weight, bias,)
+
+        dummy_out = func(*inputs)
+        grad_y = Variable(torch.randn(dummy_out.size()), requires_grad=True)
+        if use_cuda:
+            grad_y = grad_y.cuda()
+
+        return gradgradcheck(func, inputs, (grad_y,))
+
+    def test_conv_double_backward(self):
+        batch_size = 2
+        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
+            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 2], [1], [2, 3], dilations):
+                no_weight = stride == 2
+                result = self.run_conv_double_back_test(kern, stride,
+                                                        padding, chan_in, chan_out,
+                                                        batch_size, inp_size, dilation,
+                                                        no_weight)
+                self.assertTrue(result,
+                                "Conv double backward test failed with parameters:" +
+                                "\nkern: " + str(kern) +
+                                "\nstride: " + str(stride) +
+                                "\npadding: " + str(padding) +
+                                "\nchan_in: " + str(chan_in) +
+                                "\nchan_out: " + str(chan_out) +
+                                "\nbatch_size: " + str(batch_size) +
+                                "\ninp_size: " + str(inp_size) +
+                                "\ndilation: " + str(dilation))
+
+    def test_error_conv_double_backward(self):
+        batch_size = 2
+
+        # Cannot provide ggW when stride is > 1
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
+            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
+                no_weight = False
+                with self.assertRaises(RuntimeError):
+                    self.run_conv_double_back_test(kern, stride,
+                                                   padding, chan_in, chan_out,
+                                                   batch_size, inp_size, dilation,
+                                                   no_weight)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_conv_double_backward_cuda(self):
+        batch_size = 1
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 10, [1])]:
+            for stride, padding, chan_in, chan_out, dilation in product([1], [2], [2], [3], dilations):
+                no_weight = stride == 2
+                result = self.run_conv_double_back_test(kern, stride,
+                                                        padding, chan_in, chan_out,
+                                                        batch_size, inp_size, dilation,
+                                                        no_weight, use_cuda=True)
 
 
 class TestNNInit(TestCase):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -29,16 +29,6 @@ if TEST_SCIPY:
     from scipy import stats
 
 
-@contextlib.contextmanager
-def use_cudnn(should_use):
-    orig = torch.backends.cudnn.enabled
-    torch.backends.cudnn.enabled = should_use
-    try:
-        yield
-    finally:
-        torch.backends.cudnn.enabled = orig
-
-
 def default_tensor_type(type):
     type_str = torch.typename(type)
 
@@ -2246,15 +2236,13 @@ class TestNN(NNTestCase):
             # Special case because transpose dilated convolution is not implemented
             def func(x, bias):
                 # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, bias,)
         else:
             def func(x, weight, bias):
                 # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
+                out = F.conv2d(x, weight, bias, stride, padding, dilation)
                 return out
             inputs = (x, weight, bias,)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2304,7 +2304,7 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_conv_double_backward_cuda(self):
         batch_size = 1
-        for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 10, [1])]:
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 9, [1])]:
             for stride, padding, chan_in, chan_out, dilation in product([1], [2], [2], [3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2233,56 +2233,50 @@ class TestNN(NNTestCase):
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size,
                                   inp_size, dilation, no_weight, use_cuda=False, use_bias=True):
-        x = torch.randn(batch_size, chan_in, inp_size, inp_size)
-        weight = torch.randn(chan_out, chan_in, kern, kern)
+        tensor = torch.Tensor(1)
+        if use_cuda:
+            tensor = tensor.cuda()
+
+        x = Variable(tensor.new(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
+        x.data.normal_()
+        weight = Variable(tensor.new(chan_out, chan_in, kern, kern), requires_grad=True)
+        weight.data.normal_()
         if use_bias:
-            bias = torch.randn(chan_out)
+            bias = Variable(tensor.new(chan_out), requires_grad=True)
+            bias.data.normal_()
         else:
             bias = None
-        if use_cuda:
-            x = x.cuda()
-            weight = weight.cuda()
-            if use_bias:
-                bias = bias.cuda()
-        x = Variable(x, requires_grad=True)
-        weight = Variable(weight, requires_grad=True)
-        if use_bias:
-            bias = Variable(bias, requires_grad=True)
+
+        def func(*inputs):
+            if no_weight:
+                lweight = weight
+                if use_bias:
+                    lx, lbias = inputs
+                else:
+                    lx, = inputs
+                    lbias = None
+            else:
+                if use_bias:
+                    lx, lweight, lbias = inputs
+                else:
+                    lx, lweight = inputs
+                    lbias = None
+            # We disable cudnn during forward to avoid finite difference imprecision issues
+            with use_cudnn(False):
+                out = F.conv2d(lx, lweight, lbias, stride, padding, dilation)
+            return out
 
         if no_weight:
-            # Special case because transpose dilated convolution is not implemented
-            def func(*inputs):
-                if use_bias:
-                    x, bias = inputs
-                else:
-                    x, = inputs
-                    bias = None
-                # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                return out
-            inputs = (x, bias,)
+            inputs = (x, bias)
         else:
-            def func(*inputs):
-                if use_bias:
-                    x, weight, bias = inputs
-                else:
-                    x, weight = inputs
-                    bias = None
-                # We disable cudnn during forward to avoid finite difference imprecision issues
-                with use_cudnn(False):
-                    out = F.conv2d(x, weight, bias, stride, padding, dilation)
-                return out
-            inputs = (x, weight, bias,)
+            inputs = (x, weight, bias)
 
         if not use_bias:
             inputs = inputs[:-1]
 
         dummy_out = func(*inputs)
-        grad_y = torch.randn(dummy_out.size())
-        if use_cuda:
-            grad_y = grad_y.cuda()
-        grad_y = Variable(grad_y, requires_grad=True)
+        grad_y = Variable(tensor.new(dummy_out.size()), requires_grad=True)
+        grad_y.data.normal_()
 
         return gradgradcheck(func, inputs, (grad_y,))
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from .variable import Variable
 from .function import Function, NestedIOFunction
 from .stochastic_function import StochasticFunction
-from .gradcheck import gradcheck
+from .gradcheck import gradcheck, gradgradcheck
 
 __all__ = ['Variable', 'Function', 'StochasticFunction', 'backward']
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from .variable import Variable
 from .function import Function, NestedIOFunction
 from .stochastic_function import StochasticFunction
-from .gradcheck import gradcheck, gradgradcheck
+from .gradcheck import gradcheck
 
 __all__ = ['Variable', 'Function', 'StochasticFunction', 'backward']
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -173,6 +173,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3):
 
     return True
 
+
 def gradgradcheck(func, inputs, grad_outputs, eps=1e-6, atol=1e-5, rtol=1e-3):
     def new_func(*inputs):
         outputs = func(*inputs)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -175,6 +175,29 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3):
 
 
 def gradgradcheck(func, inputs, grad_outputs, eps=1e-6, atol=1e-5, rtol=1e-3):
+    """Check gradients of gradients computed via small finite differences
+       against analytical gradients
+    This function checks that backpropagating through the gradients computed
+    to the given grad_outputs are correct.
+
+    The check between numerical and analytical has the same behaviour as
+    numpy.allclose https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html
+    meaning it check that
+        absolute(a - n) <= (atol + rtol * absolute(n))
+    is true for all elements of analytical gradient a and numerical gradient n.
+
+    Args:
+        func: Python function that takes Variable inputs and returns
+            a tuple of Variables
+        inputs: tuple of Variables
+        grad_outputs: tuple of Variables
+        eps: perturbation for finite differences
+        atol: absolute tolerance
+        rtol: relative tolerance
+
+    Returns:
+        True if all differences satisfy allclose condition
+    """
     def new_func(*inputs):
         outputs = func(*inputs)
         outputs = _as_tuple(outputs)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -172,3 +172,12 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3):
             return False
 
     return True
+
+def gradgradcheck(func, inputs, grad_outputs, eps=1e-6, atol=1e-5, rtol=1e-3):
+    def new_func(*inputs):
+        outputs = func(*inputs)
+        outputs = _as_tuple(outputs)
+        grad_inputs = torch.autograd.grad(outputs, inputs, grad_outputs, only_inputs=True)
+        return grad_inputs
+
+    return gradcheck(new_func, inputs, eps, atol, rtol)

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -36,56 +36,56 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   check_input_variables("AccumulateGrad", grads, 1, 0);
   auto new_grad = grads[0];
 
-  if (new_grad) {
-    auto var = variable.lock();
-    // It's possible that the Variable went out of scope and was freed.
-    // We still need to handle the unlikely case of someohe holding to its grad.
-    if (!var) {
-      auto var_grad = variable_grad.lock();
-      // Everything was freed. Nothing to do.
-      if (!var_grad) return variable_list();
-      // Now here's the hard part. If both the new_grad and var_grad are volatile
-      // then we just acumulate the data in place (as we'd do if the Variable was
-      // alive). Otherwise, we'd need to perform the out-of-place reduction, but
-      // since the user only holds a reference to .grad and there's no way to
-      // give him the new Value, we just assume that they know these attributes
-      // are changing when using higher order graphs.
-      if (!var_grad->is_volatile || !new_grad->is_volatile) return variable_list();
-      acc_inplace(var_grad, new_grad);
-      return variable_list();
-    }
+  if (!new_grad) return {};
 
-    if (var->grad_fn)
-      throw std::logic_error("leaf variable has been moved into the graph interior");
-    if (**var->version_counter != 0)
-      throw std::runtime_error("leaf variable was used in an inplace operation");
-    if (var->get_grad_accumulator().get() != this)
-      throw std::logic_error("AccumulateGrad's variable is not bound to it");
+  auto var = variable.lock();
+  // It's possible that the Variable went out of scope and was freed.
+  // We still need to handle the unlikely case of someohe holding to its grad.
+  if (!var) {
+    auto var_grad = variable_grad.lock();
+    // Everything was freed. Nothing to do.
+    if (!var_grad) return variable_list();
+    // Now here's the hard part. If both the new_grad and var_grad are volatile
+    // then we just acumulate the data in place (as we'd do if the Variable was
+    // alive). Otherwise, we'd need to perform the out-of-place reduction, but
+    // since the user only holds a reference to .grad and there's no way to
+    // give him the new Value, we just assume that they know these attributes
+    // are changing when using higher order graphs.
+    if (!var_grad->is_volatile || !new_grad->is_volatile) return variable_list();
+    acc_inplace(var_grad, new_grad);
+    return variable_list();
+  }
 
-    for (auto& hook : var->hooks) {
-      new_grad = (*hook)({new_grad})[0];
-    }
+  if (var->grad_fn)
+    throw std::logic_error("leaf variable has been moved into the graph interior");
+  if (**var->version_counter != 0)
+    throw std::runtime_error("leaf variable was used in an inplace operation");
+  if (var->get_grad_accumulator().get() != this)
+    throw std::logic_error("AccumulateGrad's variable is not bound to it");
 
-    if (!var->grad) {
-      auto clone_fn = std::make_shared<Clone>();
-      var->grad = clone_fn->apply({new_grad})[0];
-      variable_grad = var->grad; // We need to update our reference
-    // This case is not strictly necessary, but it makes the first-order only case
-    // slightly more efficient and, what's more important, more predictable for
-    // the users. Thanks to this case we can avoid changing the grad tensor,
-    // a thing never promised and documented, but used in some hacks seen
-    // on the internet.
-    } else if (var->grad->is_volatile) {
-      acc_inplace(var->grad, new_grad);
-    } else {
-      auto add_fn = std::make_shared<Add>();
-      // Once the grad becomes not volatile, it should stay like that
-      if (!var->grad->is_volatile && new_grad->is_volatile) {
-        new_grad = std::make_shared<Variable>(
-                std::unique_ptr<thpp::Tensor>(new_grad->data->clone_shallow()), false, false);
-      }
-      var->grad = add_fn->apply({var->grad, new_grad})[0];
+  for (auto& hook : var->hooks) {
+    new_grad = (*hook)({new_grad})[0];
+  }
+
+  if (!var->grad) {
+    auto clone_fn = std::make_shared<Clone>();
+    var->grad = clone_fn->apply({new_grad})[0];
+    variable_grad = var->grad; // We need to update our reference
+  // This case is not strictly necessary, but it makes the first-order only case
+  // slightly more efficient and, what's more important, more predictable for
+  // the users. Thanks to this case we can avoid changing the grad tensor,
+  // a thing never promised and documented, but used in some hacks seen
+  // on the internet.
+  } else if (var->grad->is_volatile) {
+    acc_inplace(var->grad, new_grad);
+  } else {
+    auto add_fn = std::make_shared<Add>();
+    // Once the grad becomes not volatile, it should stay like that
+    if (!var->grad->is_volatile && new_grad->is_volatile) {
+      new_grad = std::make_shared<Variable>(
+              std::unique_ptr<thpp::Tensor>(new_grad->data->clone_shallow()), false, false);
     }
+    var->grad = add_fn->apply({var->grad, new_grad})[0];
   }
 
   return variable_list();

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -33,57 +33,59 @@ auto AccumulateGrad::acc_inplace(std::shared_ptr<Variable>& grad,
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   // XXX: this method is not thread-safe!
-  check_input_variables("AccumulateGrad", grads, 1);
-  auto var = variable.lock();
+  check_input_variables("AccumulateGrad", grads, 1, 0);
   auto new_grad = grads[0];
 
-  // It's possible that the Variable went out of scope and was freed.
-  // We still need to handle the unlikely case of someohe holding to its grad.
-  if (!var) {
-    auto var_grad = variable_grad.lock();
-    // Everything was freed. Nothing to do.
-    if (!var_grad) return variable_list();
-    // Now here's the hard part. If both the new_grad and var_grad are volatile
-    // then we just acumulate the data in place (as we'd do if the Variable was
-    // alive). Otherwise, we'd need to perform the out-of-place reduction, but
-    // since the user only holds a reference to .grad and there's no way to
-    // give him the new Value, we just assume that they know these attributes
-    // are changing when using higher order graphs.
-    if (!var_grad->is_volatile || !new_grad->is_volatile) return variable_list();
-    acc_inplace(var_grad, new_grad);
-    return variable_list();
-  }
-
-  if (var->grad_fn)
-    throw std::logic_error("leaf variable has been moved into the graph interior");
-  if (**var->version_counter != 0)
-    throw std::runtime_error("leaf variable was used in an inplace operation");
-  if (var->get_grad_accumulator().get() != this)
-    throw std::logic_error("AccumulateGrad's variable is not bound to it");
-
-  for (auto& hook : var->hooks) {
-    new_grad = (*hook)({new_grad})[0];
-  }
-
-  if (!var->grad) {
-    auto clone_fn = std::make_shared<Clone>();
-    var->grad = clone_fn->apply({new_grad})[0];
-    variable_grad = var->grad; // We need to update our reference
-  // This case is not strictly necessary, but it makes the first-order only case
-  // slightly more efficient and, what's more important, more predictable for
-  // the users. Thanks to this case we can avoid changing the grad tensor,
-  // a thing never promised and documented, but used in some hacks seen
-  // on the internet.
-  } else if (var->grad->is_volatile) {
-    acc_inplace(var->grad, new_grad);
-  } else {
-    auto add_fn = std::make_shared<Add>();
-    // Once the grad becomes not volatile, it should stay like that
-    if (!var->grad->is_volatile && new_grad->is_volatile) {
-      new_grad = std::make_shared<Variable>(
-              std::unique_ptr<thpp::Tensor>(new_grad->data->clone_shallow()), false, false);
+  if (new_grad) {
+    auto var = variable.lock();
+    // It's possible that the Variable went out of scope and was freed.
+    // We still need to handle the unlikely case of someohe holding to its grad.
+    if (!var) {
+      auto var_grad = variable_grad.lock();
+      // Everything was freed. Nothing to do.
+      if (!var_grad) return variable_list();
+      // Now here's the hard part. If both the new_grad and var_grad are volatile
+      // then we just acumulate the data in place (as we'd do if the Variable was
+      // alive). Otherwise, we'd need to perform the out-of-place reduction, but
+      // since the user only holds a reference to .grad and there's no way to
+      // give him the new Value, we just assume that they know these attributes
+      // are changing when using higher order graphs.
+      if (!var_grad->is_volatile || !new_grad->is_volatile) return variable_list();
+      acc_inplace(var_grad, new_grad);
+      return variable_list();
     }
-    var->grad = add_fn->apply({var->grad, new_grad})[0];
+
+    if (var->grad_fn)
+      throw std::logic_error("leaf variable has been moved into the graph interior");
+    if (**var->version_counter != 0)
+      throw std::runtime_error("leaf variable was used in an inplace operation");
+    if (var->get_grad_accumulator().get() != this)
+      throw std::logic_error("AccumulateGrad's variable is not bound to it");
+
+    for (auto& hook : var->hooks) {
+      new_grad = (*hook)({new_grad})[0];
+    }
+
+    if (!var->grad) {
+      auto clone_fn = std::make_shared<Clone>();
+      var->grad = clone_fn->apply({new_grad})[0];
+      variable_grad = var->grad; // We need to update our reference
+    // This case is not strictly necessary, but it makes the first-order only case
+    // slightly more efficient and, what's more important, more predictable for
+    // the users. Thanks to this case we can avoid changing the grad tensor,
+    // a thing never promised and documented, but used in some hacks seen
+    // on the internet.
+    } else if (var->grad->is_volatile) {
+      acc_inplace(var->grad, new_grad);
+    } else {
+      auto add_fn = std::make_shared<Add>();
+      // Once the grad becomes not volatile, it should stay like that
+      if (!var->grad->is_volatile && new_grad->is_volatile) {
+        new_grad = std::make_shared<Variable>(
+                std::unique_ptr<thpp::Tensor>(new_grad->data->clone_shallow()), false, false);
+      }
+      var->grad = add_fn->apply({var->grad, new_grad})[0];
+    }
   }
 
   return variable_list();

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -421,14 +421,14 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   std::shared_ptr<Variable> ggO = nullptr;
   if (ggI) {
     if (weight->data->isCuda()) {
-      weight = std::make_shared<Contiguous>()->apply({weight})[0];
+      weight = std::make_shared<CudnnContiguous>()->apply({weight})[0];
     }
     ggO = std::make_shared<ConvForward>(*this)->apply({ggI, weight, nullptr})[0];
   }
 
   if (ggW) {
     if (ggW->data->isCuda()) {
-      ggW = std::make_shared<Contiguous>()->apply({ggW})[0];
+      ggW = std::make_shared<CudnnContiguous>()->apply({ggW})[0];
     }
     auto ggW_term = std::make_shared<ConvForward>(*this)->apply({input_.unpack(), ggW, nullptr})[0];
     if (ggO) {
@@ -483,7 +483,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto ggIt = std::make_shared<Transpose>(0, 1)->apply({ggI})[0];
 
     if (gOt->data->isCuda()) {
-      gOt = std::make_shared<Contiguous>()->apply({gOt})[0];
+      gOt = std::make_shared<CudnnContiguous>()->apply({gOt})[0];
     }
 
     // Compute conv
@@ -512,7 +512,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto gOt = std::make_shared<Transpose>(0, 1)->apply({gO})[0];
 
     if (gOt->data->isCuda()) {
-      gOt = std::make_shared<Contiguous>()->apply({gOt})[0];
+      gOt = std::make_shared<CudnnContiguous>()->apply({gOt})[0];
     }
 
     auto gIt = std::make_shared<ConvForward>(gi_conv_params)->apply({ggWt, gOt, nullptr})[0];

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -152,30 +152,6 @@ static std::unique_ptr<Tensor> cat(const tensor_list& tensors, int dim) {
 // ConvForward implementation
 
 auto ConvForward::apply(const variable_list& inputs) -> variable_list {
-  // std::cout<<"Applying conv with:"<<std::endl;
-  // std::cout<<"stride ";
-  // for(auto val: this->stride) {
-  //   std::cout<<val<<" ";
-  // }
-  // std::cout<<std::endl;
-  // std::cout<<"padding ";
-  // for(auto val: this->padding) {
-  //   std::cout<<val<<" ";
-  // }
-  // std::cout<<std::endl;
-  // std::cout<<"dilation ";
-  // for(auto val: this->dilation) {
-  //   std::cout<<val<<" ";
-  // }
-  // std::cout<<std::endl;
-  // std::cout<<"output_padding ";
-  // for(auto val: this->output_padding) {
-  //   std::cout<<val<<" ";
-  // }
-  // std::cout<<std::endl;
-  // std::cout<<"transposed "<<this->transposed<<std::endl;
-  // std::cout<<"groups "<<this->groups<<std::endl;
-
   check_input_variables("ConvNd", inputs, 3, 2);
   if (is_padding_neg()) throw std::runtime_error("negative padding is not supported");
   if (is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
@@ -382,14 +358,14 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   }
 
   // Add saved variables used out of the pure autograd to inputs
-  variable_list all_grad_outputs(grad_outputs);
-  all_grad_outputs.push_back(input_.unpack());
-  all_grad_outputs.push_back(weight_.unpack());
+  variable_list all_inputs(grad_outputs);
+  all_inputs.push_back(input_.unpack());
+  all_inputs.push_back(weight_.unpack());
 
   auto outputs =  as_tensor_list(std::move(grad_input),
                                  std::move(grad_weight),
                                  std::move(grad_bias));
-  return wrap_outputs(all_grad_outputs, std::move(outputs), [&](FunctionFlags f) {
+  return wrap_outputs(all_inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<ConvBackwardBackward>(
       f, *this,
       input_.unpack()->save(this), weight_.unpack()->save(this),
@@ -770,6 +746,4 @@ done:
   return std::make_pair<>(std::move(grad_weight), std::move(grad_bias));
 }
 
-
-// Utils functions
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -127,7 +127,7 @@ static std::unique_ptr<Tensor> subtensor(Tensor* tensor, int dim, int groups, in
   if (!tensor) {
     return nullptr;
   }
-  long n = tensor->sizes()[dim] / groups;
+  long n = tensor->rawSizes()[dim] / groups;
   auto result = tensor->newTensor();
   result->narrow(*tensor, dim, n * g, n);
   return result->contiguous();
@@ -417,7 +417,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   if (ggb) {
     // View as (1, ggb.size(0), 1, 1...)
     std::vector<long> new_size(gO->data->nDim(), 1);
-    new_size[1] = ggb->data->sizes()[0];
+    new_size[1] = ggb->data->rawSizes()[0];
     auto ggb_contiguous = std::make_shared<Contiguous>()->apply({ggb})[0];
     auto ggb_view = std::make_shared<View>(new_size)->apply({ggb_contiguous})[0];
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -397,14 +397,14 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   std::shared_ptr<Variable> ggO = nullptr;
   if (ggI) {
     if (weight->data->isCuda()) {
-      weight = std::make_shared<CudnnContiguous>()->apply({weight})[0];
+      weight = std::make_shared<Contiguous>()->apply({weight})[0];
     }
     ggO = std::make_shared<ConvForward>(*this)->apply({ggI, weight, nullptr})[0];
   }
 
   if (ggW) {
     if (ggW->data->isCuda()) {
-      ggW = std::make_shared<CudnnContiguous>()->apply({ggW})[0];
+      ggW = std::make_shared<Contiguous>()->apply({ggW})[0];
     }
     auto ggW_term = std::make_shared<ConvForward>(*this)->apply({input_.unpack(), ggW, nullptr})[0];
     if (ggO) {
@@ -460,7 +460,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto ggIt = std::make_shared<Transpose>(0, 1)->apply({ggI})[0];
 
     if (gOt->data->isCuda()) {
-      gOt = std::make_shared<CudnnContiguous>()->apply({gOt})[0];
+      gOt = std::make_shared<Contiguous>()->apply({gOt})[0];
     }
 
     // Compute conv
@@ -489,7 +489,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto gOt = std::make_shared<Transpose>(0, 1)->apply({gO})[0];
 
     if (gOt->data->isCuda()) {
-      gOt = std::make_shared<CudnnContiguous>()->apply({gOt})[0];
+      gOt = std::make_shared<Contiguous>()->apply({gOt})[0];
     }
 
     auto gIt = std::make_shared<ConvForward>(gi_conv_params)->apply({ggWt, gOt, nullptr})[0];

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -4,6 +4,7 @@
 #include <THPP/THPP.h>
 #include <memory>
 #include <vector>
+#include <iostream>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
@@ -77,4 +78,32 @@ struct ConvBackward : public Function, public ConvParams {
   std::unique_ptr<torch::cudnn::Convolution> convolution;
 };
 
-}}
+struct ConvBackwardBackward : public Function, public ConvParams {
+  ConvBackwardBackward(
+      FunctionFlags flags,
+      ConvParams params,
+      SavedVariable input,
+      SavedVariable weight,
+      SavedVariable bias,
+      SavedVariable grad_output)
+    : Function(std::move(flags))
+    , ConvParams(std::move(params)) {
+      if (is_executable) {
+        this->input_ = std::move(input);
+        this->weight_ = std::move(weight);
+        this->bias_ = std::move(bias);
+        this->grad_output_ = std::move(grad_output);
+      }
+    }
+
+  virtual variable_list apply(const variable_list& grad_grad_inputs) override;
+
+  virtual void releaseVariables() override;
+
+  SavedVariable input_;
+  SavedVariable weight_;
+  SavedVariable bias_;
+  SavedVariable grad_output_;
+};
+
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -247,14 +247,16 @@ bool THPAutograd_initFunctions(PyObject* _unused)
 
   static PyTypeObject CloneClass;
   addClass<Clone, NoCtor>(module, CloneClass, "Clone");
+  static PyTypeObject ContiguousClass;
+  addClass<Contiguous, NoCtor>(module, ContiguousClass, "Contiguous");
   static PyTypeObject IdentityClass;
   addClass<Identity, NoCtor>(module, IdentityClass, "Identity");
   static PyTypeObject TransposeClass;
-  addClass<Transpose, NoCtor>(module, TransposeClass, "CTranspose");
+  addClass<Transpose, NoCtor>(module, TransposeClass, "Transpose");
   static PyTypeObject ViewClass;
-  addClass<View, NoCtor>(module, ViewClass, "CView");
+  addClass<View, NoCtor>(module, ViewClass, "View");
   static PyTypeObject ExpandClass;
-  addClass<Expand, NoCtor>(module, ExpandClass, "CExpand");
+  addClass<Expand, NoCtor>(module, ExpandClass, "Expand");
 
   THPObjectPtr parent(PyImport_ImportModule("torch._C"));
   if (!parent) return false;

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -186,6 +186,23 @@ static struct PyGetSetDef conv_backward_properties[] = {
   {NULL}
 };
 
+static struct PyGetSetDef conv_backward_backward_properties[] = {
+  THP_FUNCTION_DEFAULT_PROPERTIES,
+  {(char*)"stride", (getter)getTupleAttr<ConvBackwardBackward, std::vector<int>, ConvParams,
+                                         &ConvParams::stride, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"padding", (getter)getTupleAttr<ConvBackwardBackward, std::vector<int>, ConvParams,
+                                         &ConvParams::padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"dilation", (getter)getTupleAttr<ConvBackwardBackward, std::vector<int>, ConvParams,
+                                         &ConvParams::dilation, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"transposed", (getter)getValueAttr<ConvBackwardBackward, bool, ConvParams,
+                                         &ConvParams::transposed, long, PyBool_FromLong>, NULL, NULL, NULL},
+  {(char*)"output_padding", (getter)getTupleAttr<ConvBackwardBackward, std::vector<int>, ConvParams,
+                                         &ConvParams::output_padding, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {(char*)"groups", (getter)getValueAttr<ConvBackwardBackward, int, ConvParams,
+                                         &ConvParams::groups, long, PyInt_FromLong>, NULL, NULL, NULL},
+  {NULL}
+};
+
 static PyObject* accumulateGradVar(PyObject *_self, void* _unused)
 {
   THPCppFunction* self = (THPCppFunction*)_self;
@@ -210,9 +227,10 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   addClass<BatchNormForward, BatchNormCtor>(module, BatchNormClass, "BatchNorm", batch_norm_forward_properties);
   addClass<BatchNormBackward, NoCtor>(module, BatchNormBackwardClass, "BatchNormBackward", batch_norm_backward_properties);
 
-  static PyTypeObject ConvClass, ConvBackwardClass;
+  static PyTypeObject ConvClass, ConvBackwardClass, ConvBackwardBackwardClass;
   addClass<ConvForward, ConvCtor>(module, ConvClass, "ConvNd", conv_forward_properties);
   addClass<ConvBackward, NoCtor>(module, ConvBackwardClass, "ConvNdBackward", conv_backward_properties);
+  addClass<ConvBackwardBackward, NoCtor>(module, ConvBackwardBackwardClass, "ConvNdBackwardBackward", conv_backward_backward_properties);
 
   static PyTypeObject AccumulateGradClass;
   addClass<AccumulateGrad, NoCtor>(module, AccumulateGradClass, "AccumulateGrad", accumulate_grad_properties);

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -247,9 +247,14 @@ bool THPAutograd_initFunctions(PyObject* _unused)
 
   static PyTypeObject CloneClass;
   addClass<Clone, NoCtor>(module, CloneClass, "Clone");
-
   static PyTypeObject IdentityClass;
   addClass<Identity, NoCtor>(module, IdentityClass, "Identity");
+  static PyTypeObject TransposeClass;
+  addClass<Transpose, NoCtor>(module, TransposeClass, "CTranspose");
+  static PyTypeObject ViewClass;
+  addClass<View, NoCtor>(module, ViewClass, "CView");
+  static PyTypeObject ExpandClass;
+  addClass<Expand, NoCtor>(module, ExpandClass, "CExpand");
 
   THPObjectPtr parent(PyImport_ImportModule("torch._C"));
   if (!parent) return false;

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -247,8 +247,6 @@ bool THPAutograd_initFunctions(PyObject* _unused)
 
   static PyTypeObject CloneClass;
   addClass<Clone, NoCtor>(module, CloneClass, "Clone");
-  static PyTypeObject CudnnContiguousClass;
-  addClass<CudnnContiguous, NoCtor>(module, CudnnContiguousClass, "CudnnContiguous");
   static PyTypeObject ContiguousClass;
   addClass<Contiguous, NoCtor>(module, ContiguousClass, "Contiguous");
   static PyTypeObject IdentityClass;

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -247,6 +247,8 @@ bool THPAutograd_initFunctions(PyObject* _unused)
 
   static PyTypeObject CloneClass;
   addClass<Clone, NoCtor>(module, CloneClass, "Clone");
+  static PyTypeObject CudnnContiguousClass;
+  addClass<CudnnContiguous, NoCtor>(module, CudnnContiguousClass, "CudnnContiguous");
   static PyTypeObject ContiguousClass;
   addClass<Contiguous, NoCtor>(module, ContiguousClass, "Contiguous");
   static PyTypeObject IdentityClass;

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -259,6 +259,8 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   addClass<View, NoCtor>(module, ViewClass, "View");
   static PyTypeObject ExpandClass;
   addClass<Expand, NoCtor>(module, ExpandClass, "Expand");
+  static PyTypeObject NarrowClass;
+  addClass<Narrow, NoCtor>(module, NarrowClass, "Narrow");
 
   THPObjectPtr parent(PyImport_ImportModule("torch._C"));
   if (!parent) return false;

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -23,6 +23,18 @@ auto Clone::apply(const variable_list& inputs) -> variable_list {
   });
 };
 
+auto Contiguous::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("Contiguous", inputs, 1);
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::unique_ptr<thpp::Tensor> output {input->contiguous()};
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<Identity>(std::move(f));
+  });
+};
+
 auto Transpose::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Transpose", inputs, 1);
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -1,6 +1,7 @@
 #include "tensor.h"
 
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/functions/basic_ops.h"
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
@@ -21,5 +22,44 @@ auto Clone::apply(const variable_list& inputs) -> variable_list {
     return std::make_shared<Identity>(std::move(f));
   });
 };
+
+auto Transpose::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("Transpose", inputs, 1);
+
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::unique_ptr<thpp::Tensor> output(input->newTranspose(dim1, dim2));
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<Transpose>(dim1, dim2);
+  });
+}
+
+auto View::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("View", inputs, 1);
+
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::unique_ptr<thpp::Tensor> output(input->newView(size));
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<View>(input->sizes());
+  });
+}
+
+auto Expand::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("Expand", inputs, 1);
+
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::unique_ptr<thpp::Tensor> output(input->newExpand(size));
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<Error>("Expand is not differentiable", std::move(f));
+  });
+}
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -35,37 +35,6 @@ auto Contiguous::apply(const variable_list& inputs) -> variable_list {
   });
 };
 
-auto CudnnContiguous::apply(const variable_list& inputs) -> variable_list {
-  check_input_variables("CudnnContiguous", inputs, 1);
-  auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
-
-  auto size = input->sizes();
-  auto stride = input->strides();
-
-  // cudnn contiguity check
-  bool contiguous = true;
-  long long expectedStride = 1;
-  for (int i = input->nDim()-1; i >= 0; --i) {
-    if (stride[i] != expectedStride) {
-      contiguous = false;
-      break;
-    }
-    expectedStride *= size[i];
-  }
-
-  if (!contiguous) {
-    std::unique_ptr<thpp::Tensor> output {input->clone()};
-
-    return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
-      return std::make_shared<Identity>(std::move(f));
-    });
-  } else {
-    return {inputs[0]};
-  }
-
-};
-
 auto Transpose::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Transpose", inputs, 1);
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -35,6 +35,37 @@ auto Contiguous::apply(const variable_list& inputs) -> variable_list {
   });
 };
 
+auto CudnnContiguous::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("CudnnContiguous", inputs, 1);
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  auto size = input->sizes();
+  auto stride = input->strides();
+
+  // cudnn contiguity check
+  bool contiguous = true;
+  long long expectedStride = 1;
+  for (int i = input->nDim()-1; i >= 0; --i) {
+    if (stride[i] != expectedStride) {
+      contiguous = false;
+      break;
+    }
+    expectedStride *= size[i];
+  }
+
+  if (!contiguous) {
+    std::unique_ptr<thpp::Tensor> output {input->clone()};
+
+    return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+      return std::make_shared<Identity>(std::move(f));
+    });
+  } else {
+    return {inputs[0]};
+  }
+
+};
+
 auto Transpose::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Transpose", inputs, 1);
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -105,4 +105,17 @@ auto Expand::apply(const variable_list& inputs) -> variable_list {
   });
 }
 
+auto Narrow::apply(const variable_list& inputs) -> variable_list {
+  check_input_variables("Narrow", inputs, 1);
+
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::unique_ptr<thpp::Tensor> output(input->newNarrow(dim, start, size));
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<Error>("Narrow is not differentiable", std::move(f));
+  });
+}
+
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -22,6 +22,12 @@ struct Clone : public Function {
   virtual variable_list apply(const variable_list& inputs) override;
 };
 
+struct Contiguous : public Function {
+  Contiguous() {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+};
+
 struct Transpose : public Function {
   Transpose(long dim1, long dim2)
     : dim1(dim1)

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -22,6 +22,35 @@ struct Clone : public Function {
   virtual variable_list apply(const variable_list& inputs) override;
 };
 
+struct Transpose : public Function {
+  Transpose(long dim1, long dim2)
+    : dim1(dim1)
+    , dim2(dim2) {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+
+  long dim1;
+  long dim2;
+};
+
+struct View : public Function {
+  View(std::vector<long> size)
+    : size(size) {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+
+  std::vector<long> size;
+};
+
+struct Expand : public Function {
+  Expand(std::vector<long> size)
+    : size(size) {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+
+  std::vector<long> size;
+};
+
 }}
 
 

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -28,12 +28,6 @@ struct Contiguous : public Function {
   virtual variable_list apply(const variable_list& inputs) override;
 };
 
-struct CudnnContiguous : public Function {
-  CudnnContiguous() {}
-
-  virtual variable_list apply(const variable_list& inputs) override;
-};
-
 struct Transpose : public Function {
   Transpose(long dim1, long dim2)
     : dim1(dim1)

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -63,6 +63,19 @@ struct Expand : public Function {
   std::vector<long> size;
 };
 
+struct Narrow : public Function {
+  Narrow(long dim, long start, long size)
+    : dim(dim)
+    , start(start)
+    , size(size) {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+
+  long dim;
+  long start;
+  long size;
+};
+
 }}
 
 

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -28,6 +28,12 @@ struct Contiguous : public Function {
   virtual variable_list apply(const variable_list& inputs) override;
 };
 
+struct CudnnContiguous : public Function {
+  CudnnContiguous() {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+};
+
 struct Transpose : public Function {
   Transpose(long dim1, long dim2)
     : dim1(dim1)

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -19,6 +19,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
       if (output) {
         result.emplace_back(std::make_shared<Variable>(std::move(output), grad_fn));
       } else {
+        ++grad_fn->num_inputs;
         result.emplace_back(nullptr);
       }
     }

--- a/torch/csrc/cudnn/Types.cpp
+++ b/torch/csrc/cudnn/Types.cpp
@@ -51,9 +51,15 @@ void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& nam
   // Contiguity check
   long long expectedStride = 1;
   for (int i = tensor->nDimension-1; i >= 0; --i) {
-    if (tensor->stride[i] != expectedStride)
-      throw std::invalid_argument(error_str + name);
-    expectedStride *= tensor->size[i];
+    if (tensor->size[i] != 1) {
+      if (tensor->stride[i] != expectedStride)
+        throw std::invalid_argument(error_str + name);
+      expectedStride *= tensor->size[i];
+    } else {
+      // Stride can be arbitrary for 1-sized dimension
+      // but cudnn expect a stride of 1
+      tensor->stride[i] = 1;
+    }
   }
 }
 

--- a/torch/csrc/cudnn/Types.cpp
+++ b/torch/csrc/cudnn/Types.cpp
@@ -55,10 +55,6 @@ void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& nam
       if (tensor->stride[i] != expectedStride)
         throw std::invalid_argument(error_str + name);
       expectedStride *= tensor->size[i];
-    } else {
-      // Stride can be arbitrary for 1-sized dimension
-      // but cudnn expect a stride of 1
-      tensor->stride[i] = 1;
     }
   }
 }

--- a/torch/lib/THPP/Tensor.hpp
+++ b/torch/lib/THPP/Tensor.hpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
+#include <cstring>
 
 namespace thpp {
 

--- a/torch/lib/THPP/Tensor.hpp
+++ b/torch/lib/THPP/Tensor.hpp
@@ -30,6 +30,8 @@ struct Tensor {
   virtual Tensor* newNarrow(int dimension, long firstIndex, long size) const = 0;
   virtual Tensor* newTranspose(int dimension1, int dimension2) const = 0;
   virtual Tensor* newUnfold(int dimension, long size, long step) const = 0;
+  virtual Tensor* newExpand(const long_range& size) const = 0;
+  virtual Tensor* newView(const long_range& size) const = 0;
 
   virtual int nDim() const = 0;
   virtual long_range sizes() const = 0;

--- a/torch/lib/THPP/tensors/THCSTensor.hpp
+++ b/torch/lib/THPP/tensors/THCSTensor.hpp
@@ -44,6 +44,8 @@ public:
   virtual THCSTensor* newNarrow(int dimension, long firstIndex, long size) const override;
   virtual THCSTensor* newTranspose(int dimension1, int dimension2) const override;
   virtual THCSTensor* newUnfold(int dimension, long size, long step) const override;
+  virtual THCSTensor* newExpand(const long_range& size) const override;
+  virtual THCSTensor* newView(const long_range& size) const override;
 
   virtual int nDim() const override;
   virtual long_range sizes() const override;

--- a/torch/lib/THPP/tensors/THCTensor.hpp
+++ b/torch/lib/THPP/tensors/THCTensor.hpp
@@ -46,6 +46,8 @@ public:
   virtual THCTensor* newNarrow(int dimension, long firstIndex, long size) const override;
   virtual THCTensor* newTranspose(int dimension1, int dimension2) const override;
   virtual THCTensor* newUnfold(int dimension, long size, long step) const override;
+  virtual THCTensor* newExpand(const long_range& size) const override;
+  virtual THCTensor* newView(const long_range& size) const override;
 
   virtual int nDim() const override;
   virtual long_range sizes() const override;

--- a/torch/lib/THPP/tensors/THSTensor.hpp
+++ b/torch/lib/THPP/tensors/THSTensor.hpp
@@ -47,6 +47,8 @@ public:
   virtual THSTensor* newNarrow(int dimension, long firstIndex, long size) const override;
   virtual THSTensor* newTranspose(int dimension1, int dimension2) const override;
   virtual THSTensor* newUnfold(int dimension, long size, long step) const override;
+  virtual THSTensor* newExpand(const long_range& size) const override;
+  virtual THSTensor* newView(const long_range& size) const override;
 
   virtual int nDim() const override;
   virtual long_range sizes() const override;

--- a/torch/lib/THPP/tensors/THTensor.hpp
+++ b/torch/lib/THPP/tensors/THTensor.hpp
@@ -54,6 +54,8 @@ public:
   virtual THTensor* newNarrow(int dimension, long firstIndex, long size) const override;
   virtual THTensor* newTranspose(int dimension1, int dimension2) const override;
   virtual THTensor* newUnfold(int dimension, long size, long step) const override;
+  virtual THTensor* newExpand(const long_range& size) const override;
+  virtual THTensor* newView(const long_range& size) const override;
 
   virtual int nDim() const override;
   virtual long_range sizes() const override;

--- a/torch/lib/THPP/tensors/generic/THCSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCSTensor.cpp
@@ -65,6 +65,16 @@ auto THCSTensor<real>::newUnfold(int dimension, long size, long step) const -> T
 }
 
 template<>
+auto THCSTensor<real>::newExpand(const long_range& size) const -> THCSTensor* {
+  throw std::runtime_error("newExpand is not yet available for sparse tensors");
+}
+
+template<>
+auto THCSTensor<real>::newView(const long_range& size) const -> THCSTensor* {
+  throw std::runtime_error("newView is not yet available for sparse tensors");
+}
+
+template<>
 int THCSTensor<real>::nDim() const {
   return tensor->nDimensionI;
 }

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -68,7 +68,7 @@ auto THCTensor<real>::newNarrow(int dimension, long firstIndex, long size) const
 
 template<>
 auto THCTensor<real>::newTranspose(int dimension1, int dimension2) const -> THCTensor* {
-  throw std::runtime_error("newTranspose is not yet available for CUDA tensors");
+  return new THCTensor(state, THCTensor_(newTranspose)(state, tensor, dimension1, dimension2));
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -63,7 +63,7 @@ auto THCTensor<real>::newSelect(int dimension, long sliceIndex) const -> THCTens
 
 template<>
 auto THCTensor<real>::newNarrow(int dimension, long firstIndex, long size) const -> THCTensor* {
-  return new THCTensor(state, THCTensor_(neNarrow)(state, tensor, dimension, firstIndex, size));
+  return new THCTensor(state, THCTensor_(newNarrow)(state, tensor, dimension, firstIndex, size));
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -63,7 +63,7 @@ auto THCTensor<real>::newSelect(int dimension, long sliceIndex) const -> THCTens
 
 template<>
 auto THCTensor<real>::newNarrow(int dimension, long firstIndex, long size) const -> THCTensor* {
-  throw std::runtime_error("newNarrow is not yet available for CUDA tensors");
+  return new THCTensor(state, THCTensor_(neNarrow)(state, tensor, dimension, firstIndex, size));
 }
 
 template<>

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -77,6 +77,30 @@ auto THCTensor<real>::newUnfold(int dimension, long size, long step) const -> TH
 }
 
 template<>
+auto THCTensor<real>::newExpand(const long_range& size) const -> THCTensor* {
+  THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
+  long *size_storage_d = size_storage->data;
+  for (auto it = size.begin(); it != size.end(); ++it)
+    *size_storage_d++ = *it;
+  // TODO this might leak on error
+  auto expanded = new THCTensor(state, THCTensor_(newExpand)(state, tensor, size_storage));
+  THLongStorage_free(size_storage);
+  return expanded;
+}
+
+template<>
+auto THCTensor<real>::newView(const long_range& size) const -> THCTensor* {
+  THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
+  long *size_storage_d = size_storage->data;
+  for (auto it = size.begin(); it != size.end(); ++it)
+    *size_storage_d++ = *it;
+  // TODO this might leak on error
+  auto viewed = new THCTensor(state, THCTensor_(newView)(state, tensor, size_storage));
+  THLongStorage_free(size_storage);
+  return viewed;
+}
+
+template<>
 int THCTensor<real>::nDim() const {
   return tensor->nDimension;
 }

--- a/torch/lib/THPP/tensors/generic/THCTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THCTensor.cpp
@@ -79,9 +79,7 @@ auto THCTensor<real>::newUnfold(int dimension, long size, long step) const -> TH
 template<>
 auto THCTensor<real>::newExpand(const long_range& size) const -> THCTensor* {
   THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
-  long *size_storage_d = size_storage->data;
-  for (auto it = size.begin(); it != size.end(); ++it)
-    *size_storage_d++ = *it;
+  std::memcpy(size_storage->data, size.data(), sizeof(long) * size.size());
   // TODO this might leak on error
   auto expanded = new THCTensor(state, THCTensor_(newExpand)(state, tensor, size_storage));
   THLongStorage_free(size_storage);
@@ -91,9 +89,7 @@ auto THCTensor<real>::newExpand(const long_range& size) const -> THCTensor* {
 template<>
 auto THCTensor<real>::newView(const long_range& size) const -> THCTensor* {
   THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
-  long *size_storage_d = size_storage->data;
-  for (auto it = size.begin(); it != size.end(); ++it)
-    *size_storage_d++ = *it;
+  std::memcpy(size_storage->data, size.data(), sizeof(long) * size.size());
   // TODO this might leak on error
   auto viewed = new THCTensor(state, THCTensor_(newView)(state, tensor, size_storage));
   THLongStorage_free(size_storage);

--- a/torch/lib/THPP/tensors/generic/THSTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THSTensor.cpp
@@ -64,6 +64,16 @@ auto THSTensor<real>::newUnfold(int dimension, long size, long step) const -> TH
 }
 
 template<>
+auto THSTensor<real>::newExpand(const long_range& size) const -> THSTensor* {
+  throw std::runtime_error("newExpand is not yet available for sparse tensors");
+}
+
+template<>
+auto THSTensor<real>::newView(const long_range& size) const -> THSTensor* {
+  throw std::runtime_error("newView is not yet available for sparse tensors");
+}
+
+template<>
 int THSTensor<real>::nDim() const {
   return tensor->nDimensionI;
 }

--- a/torch/lib/THPP/tensors/generic/THTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THTensor.cpp
@@ -89,6 +89,30 @@ auto THTensor<real>::newUnfold(int dimension, long size, long step) const -> THT
 }
 
 template<>
+auto THTensor<real>::newExpand(const long_range& size) const -> THTensor* {
+  THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
+  long *size_storage_d = size_storage->data;
+  for (auto it = size.begin(); it != size.end(); ++it)
+    *size_storage_d++ = *it;
+  // TODO this might leak on error
+  auto expanded = new THTensor(THTensor_(newExpand)(tensor, size_storage));
+  THLongStorage_free(size_storage);
+  return expanded;
+}
+
+template<>
+auto THTensor<real>::newView(const long_range& size) const -> THTensor* {
+  THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
+  long *size_storage_d = size_storage->data;
+  for (auto it = size.begin(); it != size.end(); ++it)
+    *size_storage_d++ = *it;
+  // TODO this might leak on error
+  auto viewed = new THTensor(THTensor_(newView)(tensor, size_storage));
+  THLongStorage_free(size_storage);
+  return viewed;
+}
+
+template<>
 int THTensor<real>::nDim() const {
   return tensor->nDimension;
 }

--- a/torch/lib/THPP/tensors/generic/THTensor.cpp
+++ b/torch/lib/THPP/tensors/generic/THTensor.cpp
@@ -91,9 +91,7 @@ auto THTensor<real>::newUnfold(int dimension, long size, long step) const -> THT
 template<>
 auto THTensor<real>::newExpand(const long_range& size) const -> THTensor* {
   THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
-  long *size_storage_d = size_storage->data;
-  for (auto it = size.begin(); it != size.end(); ++it)
-    *size_storage_d++ = *it;
+  std::memcpy(size_storage->data, size.data(), sizeof(long) * size.size());
   // TODO this might leak on error
   auto expanded = new THTensor(THTensor_(newExpand)(tensor, size_storage));
   THLongStorage_free(size_storage);
@@ -103,9 +101,7 @@ auto THTensor<real>::newExpand(const long_range& size) const -> THTensor* {
 template<>
 auto THTensor<real>::newView(const long_range& size) const -> THTensor* {
   THLongStorage *size_storage = THLongStorage_newWithSize(size.size());
-  long *size_storage_d = size_storage->data;
-  for (auto it = size.begin(); it != size.end(); ++it)
-    *size_storage_d++ = *it;
+  std::memcpy(size_storage->data, size.data(), sizeof(long) * size.size());
   // TODO this might leak on error
   auto viewed = new THTensor(THTensor_(newView)(tensor, size_storage));
   THLongStorage_free(size_storage);

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,F401,F403,F405,F821,F841
+ignore = E305,E402,E721,F401,F403,F405,F821,F841,F999
 exclude = docs/src,venv


### PR DESCRIPTION
Remaining to discuss:
* Better testing strategy: right now the tests test everything that should work and should fail. Maybe we do not want to keep all these tests as they are quite slow?
    * Option 1: keep all of these but in a separate place so that we do not have to run all these tests every time but only if/when we modify this code.
    * Option 2: keep only a subset of these tests for specific stride/padding/dilation values.
    * Option 3: Something else?
* Anything that would use dilated transpose convolution raises an explicit error. Do we want to keep this? Is the cudnn implementation of dilated transpose convolution correct and we want to possibly use it?
* The case specified in the doc where part of the input is ignored due to striding is not always supported and raises an explicit error when it's not.
* The Expand C Function is not différentiable.
* For GPU support, few contiguous calls are missing.
* transposed convolution are not supported at all and raises an explicit error.

@apaszke is any of these points blocking for merging this or can these be added afterward?