### PR TITLE
Fix segfault in autograd:

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -248,6 +248,10 @@ class TestCase(unittest.TestCase):
                 return
         raise AssertionError("object not found in iterable")
 
+    if sys.version_info < (3, 2):
+        # assertRaisesRegexp renamed assertRaisesRegex in 3.2
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 
 def download_file(url, path, binary=True):
     if sys.version_info < (3,):


### PR DESCRIPTION
1) Every "output" variable must have a grad_fn or grad_accumulator
2) compute_partial_exec_callbacks uses Python errors

Fixes #1622 