### PR TITLE
Don't visit grad_fn in THPVariable_traverse

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -88,9 +88,6 @@ static int THPVariable_traverse(THPVariable *self, visitproc visit, void *arg)
   Py_VISIT(self->data);
   Py_VISIT(self->backward_hooks);
   if (self->cdata) {
-    if (auto fn = dynamic_cast<PyFunction*>(self->cdata->grad_fn.get())) {
-      Py_VISIT(fn->obj);
-    }
     for (auto& hook : self->cdata->hooks) {
       if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
         Py_VISIT(pyhook->dict);


### PR DESCRIPTION
The tp_traverse function should call Py_VISIT only once for every owned
PyObject. The issue is that multiple variables can have the same
grad_fn, so the calls to Py_VISIT may try to decref the grad_fn after
it's already zero.

This could potentitally lead to uncollectable cycles, but I don't see a
better alternative.

Fixes #1626