### PR TITLE
Fix CUDA_HOME detection

### DIFF
--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -3,6 +3,7 @@ from subprocess import Popen, PIPE
 
 from .env import check_env_flag
 
+
 def find_nvcc():
     proc = Popen(['which', 'nvcc'], stdout=PIPE, stderr=PIPE)
     out, err = proc.communicate()
@@ -11,6 +12,7 @@ def find_nvcc():
         return os.path.dirname(out)
     else:
         return None
+
 
 if check_env_flag('NO_CUDA'):
     WITH_CUDA = False

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -27,7 +27,11 @@ else:
         if osname == 'Linux':
             cuda_path = find_nvcc()
         else:
-            cuda_path = os.path.dirname(ctypes.util.find_library('cudart'))
+            cudart_path = ctypes.util.find_library('cudart')
+            if cudart_path is not None:
+                cuda_path = os.path.dirname(cudart_path)
+            else:
+                cuda_path = None
         if cuda_path is not None:
             CUDA_HOME = os.path.dirname(cuda_path)
         else:

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import ctypes.util
 from subprocess import Popen, PIPE
 
 from .env import check_env_flag
@@ -20,9 +22,14 @@ if check_env_flag('NO_CUDA'):
 else:
     CUDA_HOME = os.getenv('CUDA_HOME', '/usr/local/cuda')
     if not os.path.exists(CUDA_HOME):
-        nvcc_path = find_nvcc()
-        if nvcc_path is not None:
-            CUDA_HOME = os.path.dirname(nvcc_path)
+        # We use nvcc path on Linux and cudart path on macOS
+        osname = platform.system()
+        if osname == 'Linux':
+            cuda_path = find_nvcc()
+        else:
+            cuda_path = os.path.dirname(ctypes.util.find_library('cudart'))
+        if cuda_path is not None:
+            CUDA_HOME = os.path.dirname(cuda_path)
         else:
             CUDA_HOME = None
     WITH_CUDA = CUDA_HOME is not None

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -1,7 +1,16 @@
-import ctypes.util
 import os
+from subprocess import Popen, PIPE
 
 from .env import check_env_flag
+
+def find_nvcc():
+    proc = Popen(['which', 'nvcc'], stdout=PIPE, stderr=PIPE)
+    out, err = proc.communicate()
+    out = out.decode().strip()
+    if len(out) > 0:
+        return os.path.dirname(out)
+    else:
+        return None
 
 if check_env_flag('NO_CUDA'):
     WITH_CUDA = False
@@ -9,9 +18,9 @@ if check_env_flag('NO_CUDA'):
 else:
     CUDA_HOME = os.getenv('CUDA_HOME', '/usr/local/cuda')
     if not os.path.exists(CUDA_HOME):
-        cudart_path = ctypes.util.find_library('cudart')
-        if cudart_path is not None:
-            CUDA_HOME = os.path.dirname(cudart_path)
+        nvcc_path = find_nvcc()
+        if nvcc_path is not None:
+            CUDA_HOME = os.path.dirname(nvcc_path)
         else:
             CUDA_HOME = None
     WITH_CUDA = CUDA_HOME is not None


### PR DESCRIPTION
The way `CUDA_HOME` detection was implemented in `tools/setup_helpers/cuda.py` does not work, as `ctypes.util.find_library(cudart)` returns only the library name, not its path. `os.path.dirname(...)` in this case would return `/usr/local/cuda/lib`, not `/usr/local/cuda`. I am proposing a fix based on using the path to `nvcc` instead of `ctypes.util.find_library`. 