### PR TITLE
add checks for input, weight and bias types when using cudnn conv2d

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1346,7 +1346,6 @@ class TestNN(NNTestCase):
         # but it should work with the same type
         nn.functional.conv2d(inputs.float(), weights.float(), bias.float())
 
-
     def test_Conv2d_missing_argument(self):
         c = nn.Conv2d(3, 3, 3)
         self.assertRaises(RuntimeError, lambda: c(None))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1347,7 +1347,7 @@ class TestNN(NNTestCase):
         nn.functional.conv2d(inputs.float(), weights.float(), bias.float())
 
 
-def test_Conv2d_missing_argument(self):
+    def test_Conv2d_missing_argument(self):
         c = nn.Conv2d(3, 3, 3)
         self.assertRaises(RuntimeError, lambda: c(None))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1317,7 +1317,37 @@ class TestNN(NNTestCase):
         # but it should work with the same type
         nn.functional.conv2d(inputs.float(), weights.float())
 
-    def test_Conv2d_missing_argument(self):
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    def test_Conv2d_inconsistent_types_on_GPU_without_cudnn(self):
+        inputs = Variable(torch.randn(4, 1, 7, 7).float().cuda())
+        weights = Variable(torch.randn(1, 1, 3, 3).double().cuda())
+        bias = Variable(torch.randn(1).double().cuda())
+
+        torch.backends.cudnn.enabled = False
+        # inconsistent types should raise an exception
+        self.assertRaises(RuntimeError, lambda: nn.functional.conv2d(inputs, weights))
+        self.assertRaises(RuntimeError, lambda: nn.functional.conv2d(inputs, weights.float(), bias))
+
+        # but it should work with the same type
+        nn.functional.conv2d(inputs.float(), weights.float(), bias.float())
+
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
+    @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
+    def test_Conv2d_inconsistent_types_on_GPU_with_cudnn(self):
+        inputs = Variable(torch.randn(4, 1, 7, 7).float().cuda())
+        weights = Variable(torch.randn(1, 1, 3, 3).double().cuda())
+        bias = Variable(torch.randn(1).double().cuda())
+
+        torch.backends.cudnn.enabled = True
+        # inconsistent types should raise an exception
+        self.assertRaises(RuntimeError, lambda: nn.functional.conv2d(inputs, weights))
+        self.assertRaises(RuntimeError, lambda: nn.functional.conv2d(inputs, weights.float(), bias))
+
+        # but it should work with the same type
+        nn.functional.conv2d(inputs.float(), weights.float(), bias.float())
+
+
+def test_Conv2d_missing_argument(self):
         c = nn.Conv2d(3, 3, 3)
         self.assertRaises(RuntimeError, lambda: c(None))
 


### PR DESCRIPTION
Fix for issue #1685. Currently, 

This gives an error as expected:
```
import torch
import torch.nn.functional as F
from torch.autograd import Variable

a = torch.ones(1, 1, 10, 10)
b = torch.ones(1, 1, 3, 3) / 9

o = F.conv2d(Variable(a.double()), Variable(b))
```


So does this:
```
import torch
import torch.nn.functional as F
from torch.autograd import Variable

a = torch.ones(1, 1, 10, 10)
b = torch.ones(1, 1, 3, 3) / 9
torch.backends.cudnn.enabled = False
a = a.cuda()
b = b.cuda()
o = F.conv2d(Variable(a.double()), Variable(b))
```
But with cudnn enabled, no error is thrown and the output is wrong
```
import torch
import torch.nn.functional as F
from torch.autograd import Variable

a = torch.ones(1, 1, 10, 10)
b = torch.ones(1, 1, 3, 3) / 9
torch.backends.cudnn.enabled = True
a = a.cuda()
b = b.cuda()
o = F.conv2d(Variable(a.double()), Variable(b))
```