### PR TITLE
Fix gc_refs assertion failure

### DIFF
--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -61,7 +61,6 @@ struct THPFunction {
 
     // The C++ wrapper for this Python function.
     // See a comment in THPFunction_asFunction for details about this field.
-    // You can use cdata directly if you don't actually need a shared_ptr.
     torch::autograd::PyFunction cdata;
 };
 

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -62,7 +62,6 @@ struct THPFunction {
     // The C++ wrapper for this Python function.
     // See a comment in THPFunction_asFunction for details about this field.
     // You can use cdata directly if you don't actually need a shared_ptr.
-    std::weak_ptr<torch::autograd::PyFunction> cdata_ptr;
     torch::autograd::PyFunction cdata;
 };
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -23,37 +23,34 @@ struct Variable : std::enable_shared_from_this<Variable> {
 
     SavedVariable(const Variable& variable, Function* saved_for)
       : data(variable.data->clone_shallow())
+      , has_grad_fn(variable.grad_fn != nullptr)
       , grad_accumulator(variable.grad_accumulator)
       , version(variable.version_counter->new_saved_ref())
       , requires_grad(variable.requires_grad)
       , is_volatile(false)
       , expected_version(**variable.version_counter) {
-        if (variable.grad_fn.get() == saved_for) {
-          weak_grad_fn = variable.grad_fn;
-        } else {
+        if (variable.grad_fn.get() != saved_for) {
           grad_fn = variable.grad_fn;
         }
       }
 
     std::unique_ptr<thpp::Tensor> data;
-    // The gradient function associated with this node.  If this is
-    // NULL, then this node is a leaf node.
+    // The gradient function associated with this node. If has_grad_fn
+    // is false, then this is a leaf node. Note that the grad_fn is not saved if
+    // it would create a circular reference. In that case, the grad_fn must be
+    // passed in to the unpack function when reconstructing the Variable.
+    bool has_grad_fn;
     std::shared_ptr<Function> grad_fn;
-    // this field is only necessary in case when a grad_fn saves a reference to
-    // one of the outputs of the forward fn. Saving the pointer in grad_fn
-    // would create a reference cycle. If this field is used, grad_fn is
-    // guaranteed to hold a nullptr;
-    std::weak_ptr<Function> weak_grad_fn;
     std::weak_ptr<Function> grad_accumulator;
     std::unique_ptr<VariableVersion> version;
     bool requires_grad;
     bool is_volatile;
     int expected_version;
 
-    std::shared_ptr<Variable> unpack();
+    std::shared_ptr<Variable> unpack(std::shared_ptr<Function> saved_for=nullptr);
 
-    std::unique_ptr<thpp::Tensor> unpack_data() {
-      auto var = unpack();
+    std::unique_ptr<thpp::Tensor> unpack_data(std::shared_ptr<Function> saved_for=nullptr) {
+      auto var = unpack(saved_for);
       return var ? std::move(var->data) : nullptr;
     }
   };


### PR DESCRIPTION
Ensure that each THPVariable -> THPFunction reference contributes one
ref count to the THPFunction by creating a new shared_ptr for each ref.

Because multiple shared_ptrs can again manage a single THPFunction, it's
not safe to use std::weak_ptr where it may point to a PyFunction. It's
still safe to use weak_ptr for grad_accumulator since these are never
PyFunctions.

Fixes #1626