### PR TITLE
fix the bug of named_parameters

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -34,7 +34,7 @@ class Optimizer(object):
         param_set = set()
         for group in self.param_groups:
             if isinstance(group['params'], torch.nn.paramter.Parameter):
-                group['params'] = [group['params']
+                group['params'] = [group['params']]
             else:
                 group['params'] = list(group['params'])
             group_set = set(group['params'])

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -33,7 +33,10 @@ class Optimizer(object):
 
         param_set = set()
         for group in self.param_groups:
-            group['params'] = list(group['params'])
+            if isinstance(group['params'], torch.nn.paramter.Parameter):
+                group['params'] = [group['params']
+            else:
+                group['params'] = list(group['params'])
             group_set = set(group['params'])
             if not param_set.isdisjoint(group_set):
                 raise ValueError("some parameters appear in more than one "

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -33,7 +33,7 @@ class Optimizer(object):
 
         param_set = set()
         for group in self.param_groups:
-            if isinstance(group['params'], torch.nn.paramter.Parameter):
+            if isinstance(group['params'], torch.autograd.Variable):
                 group['params'] = [group['params']]
             else:
                 group['params'] = list(group['params'])


### PR DESCRIPTION
When I use the named_parametes to modify the lr and weight decay, I will face a bug. Because the value of the named_parameters return is  torch.nn.paramter.Parameter, not a generator of the Parameter.
the error information:
https://discuss.pytorch.org/t/problem-on-different-learning-rate-and-weight-decay-in-different-layers/3619