### PR TITLE
Allow None to be returned from hooks (fixes #1269)

### DIFF
--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -146,8 +146,12 @@ static void check_result(PyObject* prev, PyObject* result, PyObject* hook) {
 }
 
 static void check_single_result(PyObject* _original, PyObject* _result, PyObject* hook) {
+  if (_result == Py_None) {
+    return;
+  }
+
   if (!PyObject_IsInstance(_result, THPVariableClass)) {
-    PyErr_Format(PyExc_TypeError, "expected Variable, but hook returned '%s'",
+    PyErr_Format(PyExc_TypeError, "expected Variable or None, but hook returned '%s'",
         THPUtils_typename(_result));
     throw python_error();
   }


### PR DESCRIPTION
This is a fix for #1269. 

Currently `python_hook.cpp` checks that individual values returned from a hook are tensors. However, as in the example with Conv without bias, they could be `None`. This fix simply allows `None` to be returned from a hook and updates the error message accordingly.