### PR TITLE
Modify the sample code of extending autograd

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -95,7 +95,7 @@ numerical approximations using small finite differences::
     # gradchek takes a tuple of tensor as input, check if your gradient
     # evaluated with these tensors are close enough to numerical
     # approximations and returns True if they all verify this condition.
-    input = (Variable(torch.randn(20,20).double(), requires_grad=True),)
+    input = (Variable(torch.randn(20,20).double(), requires_grad=True), Variable(torch.randn(30,20).double(), requires_grad=True),)
     test = gradcheck(Linear(), input, eps=1e-6, atol=1e-4)
     print(test)
 


### PR DESCRIPTION
The original input can not be used as input of Linear(), because forward() takes at least 3 arguments (2 given)