### PR TITLE
Fix sharing of CUDA tensors on non-current devices

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -297,7 +297,8 @@ class TestMultiprocessing(TestCase):
         ctx = mp.get_context('spawn')
         tensors = []
         for i in range(5):
-            tensors += [torch.arange(i * 5, (i + 1) * 5).cuda()]
+            device = i % 2
+            tensors += [torch.arange(i * 5, (i + 1) * 5).cuda(device)]
 
         inq = ctx.Queue()
         outq = ctx.Queue()
@@ -313,7 +314,7 @@ class TestMultiprocessing(TestCase):
         for i, tensor in enumerate(tensors):
             v, device, tensor_size, storage_size = results[i]
             self.assertEqual(v, torch.arange(i * 5, (i + 1) * 5).sum())
-            self.assertEqual(device, 0)
+            self.assertEqual(device, i % 2)
             self.assertEqual(tensor_size, 5)
             self.assertEqual(storage_size, 5)
 

--- a/torch/lib/THC/THCAllocator.c
+++ b/torch/lib/THC/THCAllocator.c
@@ -32,7 +32,21 @@ static cudaError_t THCIpcAllocator_malloc(void* ctx, void** devPtr, size_t size,
 
 static cudaError_t THCIpcAllocator_free(void* ctx, void* devPtr)
 {
-  return cudaIpcCloseMemHandle(devPtr);
+  cudaError_t err;
+  int prev_device;
+  int device = (int)(long)ctx;
+
+  err = cudaGetDevice(&prev_device);
+  if (err != cudaSuccess) { return err; }
+
+  err = cudaSetDevice(device);
+  if (err != cudaSuccess) { return err; }
+
+  err = cudaIpcCloseMemHandle(devPtr);
+  if (err != cudaSuccess) { return err; }
+
+  err = cudaSetDevice(prev_device);
+  return err;
 }
 
 THCDeviceAllocator THCIpcAllocator = {

--- a/torch/lib/THC/THCAllocator.c
+++ b/torch/lib/THC/THCAllocator.c
@@ -43,9 +43,8 @@ static cudaError_t THCIpcAllocator_free(void* ctx, void* devPtr)
   if (err != cudaSuccess) { return err; }
 
   err = cudaIpcCloseMemHandle(devPtr);
-  if (err != cudaSuccess) { return err; }
 
-  err = cudaSetDevice(prev_device);
+  cudaSetDevice(prev_device);
   return err;
 }
 


### PR DESCRIPTION
The correct device must be set when getting the base allocation and when
calling cudaIpcCloseMemHandle. Store the device in the allocators
context, which was previously always NULL.

Fixes #1707