### PR TITLE
Bug fixes

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -196,7 +196,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: lt
    .. automethod:: lt_
    .. automethod:: map_
-   .. automethod:: masked_copy_
+   .. automethod:: masked_scatter_
    .. automethod:: masked_fill_
    .. automethod:: masked_select
    .. automethod:: max

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1578,7 +1578,7 @@ method_tests = [
     ('unsqueeze', (S, S, S), (3,), 'last', [0]),
     ('masked_select', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),)),
     ('masked_fill_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), 10)),
-    ('masked_copy_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), (M, M))),
+    ('masked_scatter_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), (M, M))),
 ]
 # TODO: mm, bmm, mv, ger
 # TODO: max, min with dim (problem with indices)
@@ -1633,6 +1633,7 @@ for test in function_tests:
 
     for dim_perm in product([-1, 1], repeat=len(dim_args_idx)):
         test_name = basic_test_name + ''.join('_neg' + str(i) for i, idx in enumerate(dim_perm) if idx < 0)
+
         def make_neg_dims(args):
             for i in dim_args_idx:
                 assert isinstance(args[i], int), test_name

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1331,34 +1331,34 @@ function_tests = [
     (CmaxConstant, (), ((S, S, S), 0.5)),
     (CminConstant, (), ((S, S, S), 0.5)),
     (Mean, (), ((S, S, S),)),
-    (Mean, (1,), ((S, S, S),), 'dim', [0]),
-    (Mean, (1, False,), ((S, S, S),), 'keepdim_false_dim', [0]),
+    (Mean, (), ((S, S, S), 1), 'dim', [1]),
+    (Mean, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
     (Sum, (), ((S, S, S),)),
-    (Sum, (1,), ((S, S, S),), 'dim', [0]),
-    (Sum, (1, False,), ((S, S, S),), 'keepdim_false_dim', [0]),
+    (Sum, (), ((S, S, S), 1), 'dim', [1]),
+    (Sum, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
     (Prod, (), ((S, S, S),)),
     (Prod, (), (prod_zeros(S, [0, 1]),), 'zerosdim2'),
     (Prod, (), (prod_zeros(S, [0, 2]),), 'zerosdim1'),
     (Prod, (), (prod_zeros(S, [1, 2]),), 'zerosdim0'),
     (Prod, (), (prod_single_zero(S),), 'single_zero'),
-    (Prod, (1,), ((S, S, S),), 'dim', [0]),
-    (Prod, (1,), (prod_zeros(S, [0, 1]),), 'zeros_dim2', [0]),
-    (Prod, (1,), (prod_zeros(S, [0, 2]),), 'zeros_dim1', [0]),
-    (Prod, (1,), (prod_zeros(S, [1, 2]),), 'zeros_dim0', [0]),
-    (Prod, (1, False,), ((S, S, S),), 'keepdim_false_dim', [0]),
-    (Prod, (1, False,), (prod_zeros(S, [0, 1]),), 'keepdim_false_zeros_dim2', [0]),
-    (Prod, (1, False,), (prod_zeros(S, [0, 2]),), 'keepdim_false_zeros_dim1', [0]),
-    (Prod, (1, False), (prod_zeros(S, [1, 2]),), 'keepdim_false_zeros_dim0', [0]),
+    (Prod, (), ((S, S, S), 1), 'dim', [1]),
+    (Prod, (), (prod_zeros(S, [0, 1]), 1), 'zeros_dim2', [1]),
+    (Prod, (), (prod_zeros(S, [0, 2]), 1), 'zeros_dim1', [1]),
+    (Prod, (), (prod_zeros(S, [1, 2]), 1), 'zeros_dim0', [1]),
+    (Prod, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
+    (Prod, (), (prod_zeros(S, [0, 1]), 1, False), 'keepdim_false_zeros_dim2', [1]),
+    (Prod, (), (prod_zeros(S, [0, 2]), 1, False), 'keepdim_false_zeros_dim1', [1]),
+    (Prod, (), (prod_zeros(S, [1, 2]), 1, False), 'keepdim_false_zeros_dim0', [1]),
     (Addmm, (), ((S, M), (S, S), (S, M)),),
-    (Addmm, (0.1, 1), ((S, M), (S, S), (S, M)), 'coef'),
+    (Addmm, (), ((S, M), (S, S), (S, M), 0.1, 1), 'coef'),
     (Addbmm, (), ((S, M), (S, S, S), (S, S, M)),),
-    (Addbmm, (0.1, 0.4), ((S, M), (S, S, S), (S, S, M)), 'coef'),
+    (Addbmm, (), ((S, M), (S, S, S), (S, S, M), 0.1, 0.4), 'coef'),
     (Baddbmm, (), ((S, S, M), (S, S, S), (S, S, M)),),
-    (Baddbmm, (0.1, 0.4), ((S, S, M), (S, S, S), (S, S, M)), 'coef'),
+    (Baddbmm, (), ((S, S, M), (S, S, S), (S, S, M), 0.1, 0.4), 'coef'),
     (Addmv, (), ((S,), (S, M), (M,)),),
-    (Addmv, (0.1, 0.4), ((S,), (S, M), (M,)), 'coef'),
+    (Addmv, (), ((S,), (S, M), (M,), 0.1, 0.4), 'coef'),
     (Addr, (), ((S, M), (S,), (M,)),),
-    (Addr, (0.1, 0.4), ((S, M), (S,), (M,)), 'coef'),
+    (Addr, (), ((S, M), (S,), (M,), 0.1, 0.4), 'coef'),
     (Dot, (), ((L,), (L,)),),
     (Max, (), ((S, S, S),),),
     (Repeat, (), ((S, S, S, S), torch.Size([2, 3, 1, 2]))),
@@ -1368,28 +1368,28 @@ function_tests = [
     (Unfold, (), ((S, S, S), 1, 3, 1)),
     (Unfold, (), ((S, S, S), 2, 3, 2), 'lastdim'),
     (Min, (), ((S, S, S),),),
-    (Max, (), ((S, S, S), 1), 'dim', [0]),
-    (Min, (), ((S, S, S), 1), 'dim', [0]),
-    (Max, (), ((S, S, S), 1, False), 'keepdim_false_dim', [0]),
-    (Min, (), ((S, S, S), 1, False), 'keepdim_false_dim', [0]),
+    (Max, (), ((S, S, S), 1), 'dim', [1]),
+    (Min, (), ((S, S, S), 1), 'dim', [1]),
+    (Max, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
+    (Min, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
     (Mode, (), ((S, S, S),),),
-    (Mode, (), ((S, S, S), 1), 'dim', [0]),
-    (Mode, (), ((S, S, S), 1, False), 'keepdim_false_dim', [0]),
+    (Mode, (), ((S, S, S), 1), 'dim', [1]),
+    (Mode, (), ((S, S, S), 1, False), 'keepdim_false_dim', [1]),
     (Kthvalue, (), ((S, S, S), 2),),
     (Kthvalue, (), ((S, S, S), 2, 0), 'dim0'),
     (Kthvalue, (), ((S, S, S), 2, 0, False), "keepdim_false"),
     (Median, (), ((S, S, S),),),
     (Median, (), ((S, S, S), 0), 'dim0'),
     (Median, (), ((S, S, S), 0, False), "keepdim_false"),
-    (Norm, (1.5,), (torch.rand(S, S, S),), '1_5'),
+    (Norm, (), (torch.rand(S, S, S), 1.5), '1_5'),
     (Norm, (), ((S, S, S),), '2'),
-    (Norm, (3,), ((S, S, S),), '3'),
-    (Norm, (1.5, 1), (torch.rand(S, S, S),), '1_5_dim', [1]),
-    (Norm, (2, 1), ((S, S, S),), '2_dim', [1]),
-    (Norm, (3, 1), ((S, S, S),), '3_dim', [1]),
-    (Norm, (1.5, 1, False,), (torch.rand(S, S, S),), 'keepdim_false_1_5_dim', [1]),
-    (Norm, (2, 1, False,), ((S, S, S),), 'keepdim_false_2_dim', [1]),
-    (Norm, (3, 1, False), ((S, S, S),), 'keepdim_false_3_dim', [1]),
+    (Norm, (), ((S, S, S), 3), '3'),
+    (Norm, (), (torch.rand(S, S, S), 1.5, 1), '1_5_dim', [2]),
+    (Norm, (), ((S, S, S), 2, 1), '2_dim', [2]),
+    (Norm, (), ((S, S, S), 3, 1), '3_dim', [2]),
+    (Norm, (), (torch.rand(S, S, S), 1.5, 1, False), 'keepdim_false_1_5_dim', [2]),
+    (Norm, (), ((S, S, S), 2, 1, False), 'keepdim_false_2_dim', [2]),
+    (Norm, (), ((S, S, S), 3, 1, False), 'keepdim_false_3_dim', [2]),
     (Addcmul, (), ((S, S), (S, S), (S, S))),
     (Addcmul, (), ((S, S), (S, S), (S, S), 0.6), 'scale'),
     (Addcdiv, (), ((S, S), (S, S), torch.rand(S, S) + 5e-2)),
@@ -1423,7 +1423,7 @@ function_tests = [
     (Clone, (), ((S, M, S),)),
     (Squeeze, (), ((S, 1, M, 1),)),
     # TODO: enable neg dim checks
-    (Squeeze, (1,), ((S, 1, M, 1),), 'dim'),
+    (Squeeze, (), ((S, 1, M, 1), 1), 'dim'),
     (Unsqueeze, (), ((S, M, S), 0), '0'),
     (Unsqueeze, (), ((S, M, S), 1), '1'),
     # (MaskedCopy,    (),                 ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False), (S, S),)),
@@ -1632,14 +1632,22 @@ for test in function_tests:
     skipTestIf = test[5] if len(test) == 6 else []
 
     for dim_perm in product([-1, 1], repeat=len(dim_args_idx)):
-        test_name = basic_test_name
-        new_constructor_args = [arg * dim_perm[dim_args_idx.index(i)] if i in dim_args_idx else arg
-                                for i, arg in enumerate(constructor_args)]
         test_name = basic_test_name + ''.join('_neg' + str(i) for i, idx in enumerate(dim_perm) if idx < 0)
-        new_constructor_args = tuple(new_constructor_args)
+        def make_neg_dims(args):
+            for i in dim_args_idx:
+                assert isinstance(args[i], int), test_name
+            return tuple(arg * dim_perm[dim_args_idx.index(i)] if i in dim_args_idx else arg
+                         for i, arg in enumerate(args))
+        if cls._is_legacy:
+            new_constructor_args = make_neg_dims(constructor_args)
+            new_call_args = call_args
+        else:
+            assert len(constructor_args) == 0, test_name
+            new_constructor_args = constructor_args
+            new_call_args = make_neg_dims(call_args)
 
         def do_test(self, cls=cls, constructor_args=new_constructor_args,
-                    call_args=call_args, test_name=test_name):
+                    call_args=new_call_args, test_name=test_name):
             input = create_input(call_args)
             if cls._is_legacy:
                 def apply_fn(*input):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2300,13 +2300,13 @@ class TestTorch(TestCase):
     def test_scatterFill(self):
         self._test_scatter_base(self, lambda t: t, 'scatter_', True)
 
-    def test_masked_copy(self):
+    def test_masked_scatter(self):
         num_copy, num_dest = 3, 10
         dest = torch.randn(num_dest)
         src = torch.randn(num_copy)
         mask = torch.ByteTensor((0, 0, 0, 0, 1, 0, 1, 0, 1, 0))
         dest2 = dest.clone()
-        dest.masked_copy_(mask, src)
+        dest.masked_scatter_(mask, src)
         j = 0
         for i in range(num_dest):
             if mask[i]:
@@ -2316,12 +2316,12 @@ class TestTorch(TestCase):
 
         # make source bigger than number of 1s in mask
         src = torch.randn(num_dest)
-        dest.masked_copy_(mask, src)
+        dest.masked_scatter_(mask, src)
 
         # make src smaller. this should fail
         src = torch.randn(num_copy - 1)
         with self.assertRaises(RuntimeError):
-            dest.masked_copy_(mask, src)
+            dest.masked_scatter_(mask, src)
 
     def test_masked_select(self):
         num_src = 10

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -798,9 +798,9 @@ signature::
     def callable(a, b) -> number
 """)
 
-add_docstr(torch._C.FloatTensorBase.masked_copy_,
+add_docstr(torch._C.FloatTensorBase.masked_scatter_,
            """
-masked_copy_(mask, source)
+masked_scatter_(mask, source)
 
 Copies elements from :attr:`source` into this tensor at positions where the
 :attr:`mask` is one. The :attr:`mask` should have the same number of elements

--- a/torch/autograd/_functions/compare.py
+++ b/torch/autograd/_functions/compare.py
@@ -10,13 +10,14 @@ class _CompareOp(Function):
     @classmethod
     def forward(cls, ctx, a, b):
         ctx.b_tensor = torch.is_tensor(b)
+        ctx.input_type = type(a)
         mask = getattr(a, cls.fn_name)(b)
         ctx.mark_non_differentiable(mask)
         return mask
 
     @staticmethod
     def backward(ctx, grad_output):
-        grad_input = grad_output * 0
+        grad_input = (grad_output * 0).type(ctx.input_type)
         return grad_input, (grad_input if ctx.b_tensor else None)
 
 

--- a/torch/autograd/_functions/reduce.py
+++ b/torch/autograd/_functions/reduce.py
@@ -69,7 +69,7 @@ class Prod(Function):
 
             zero_mask = input == 0
             slice_zero_count = zero_mask.sum(dim, True)
-            total_zeros = slice_zero_count.sum()
+            total_zeros = slice_zero_count.data.sum()
             grad_input = grad_output.mul(output).expand_as(input).div(input)
             if total_zeros == 0:
                 return grad_input, None, None
@@ -77,7 +77,7 @@ class Prod(Function):
             some_zeros = slice_zero_count.gt(0).expand_as(grad_input)
             grad_input[some_zeros] = 0
 
-            single_zero_idx = slice_zero_count.eq(1).nonzero()
+            single_zero_idx = slice_zero_count.data.eq(1).nonzero()
 
             if len(single_zero_idx) == 0:
                 return grad_input, None, None
@@ -89,7 +89,7 @@ class Prod(Function):
                 # slice_mask and input_copy are 1D
                 slice_mask = zero_mask[input_idx_tuple]
                 input_copy = input[input_idx_tuple].clone()
-                zero_idx = slice_mask.nonzero()[0, 0]
+                zero_idx = slice_mask.data.nonzero()[0, 0]
                 input_copy[zero_idx] = 1.
 
                 grad_idx_tuple = idx_tuple[:dim] + (zero_idx,) + idx_tuple[dim + 1:]

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -363,17 +363,17 @@ class Unsqueeze(Function):
         return grad_output.squeeze(ctx.dim), None
 
 
-class MaskedCopy(InplaceFunction):
+class MaskedScatter(InplaceFunction):
 
     @staticmethod
     def forward(ctx, tensor1, mask, tensor2, inplace=False):
-        assert not ctx.needs_input_grad[1], "MaskedCopy can't differentiate the mask"
+        assert not ctx.needs_input_grad[1], "MaskedScatter can't differentiate the mask"
         if not inplace:
             tensor1 = tensor1.clone()
         else:
             ctx.mark_dirty(tensor1)
         ctx.save_for_backward(mask)
-        return tensor1.masked_copy_(mask, tensor2)
+        return tensor1.masked_scatter_(mask, tensor2)
 
     @staticmethod
     @once_differentiable
@@ -425,7 +425,7 @@ class MaskedSelect(Function):
         grad_tensor = None
         if ctx.needs_input_grad[0]:
             grad_tensor = grad_output.new(ctx.input_size).zero_()
-            grad_tensor.masked_copy_(mask, grad_output)
+            grad_tensor.masked_scatter_(mask, grad_output)
         return grad_tensor, None
 
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -76,7 +76,7 @@ class Variable(_C._VariableBase):
     def __setitem__(self, key, value):
         if isinstance(key, Variable) and type(key.data).__name__ == 'ByteTensor':
             if isinstance(value, Variable):
-                return MaskedCopy.apply(self, key, value, True)
+                return MaskedScatter.apply(self, key, value, True)
             else:
                 return MaskedFill.apply(self, key, value, True)
         else:
@@ -647,10 +647,18 @@ class Variable(_C._VariableBase):
         return Scatter.apply(self, dim, index, source, True)
 
     def masked_copy(self, mask, variable):
-        return MaskedCopy.apply(self, mask, variable)
+        warnings.warn("masked_copy is deprecated and renamed to masked_scatter, and will be removed in v0.3")
+        return MaskedScatter.apply(self, mask, variable)
 
     def masked_copy_(self, mask, variable):
-        return MaskedCopy.apply(self, mask, variable, True)
+        warnings.warn("masked_copy_ is deprecated and renamed to masked_scatter_, and will be removed in v0.3")
+        return MaskedScatter.apply(self, mask, variable, True)
+
+    def masked_scatter(self, mask, variable):
+        return MaskedScatter.apply(self, mask, variable)
+
+    def masked_scatter_(self, mask, variable):
+        return MaskedScatter.apply(self, mask, variable, True)
 
     def masked_fill(self, mask, value):
         return MaskedFill.apply(self, mask, value)

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -146,6 +146,12 @@ static void check_result(PyObject* prev, PyObject* result, PyObject* hook) {
 }
 
 static void check_single_result(PyObject* _original, PyObject* _result, PyObject* hook) {
+  if (_result == Py_None) return;
+
+  if (_original == Py_None) {
+    throw std::runtime_error("can't replace a None gradient with a non-None value");
+  }
+
   if (!PyObject_IsInstance(_result, THPVariableClass)) {
     PyErr_Format(PyExc_TypeError, "expected Variable, but hook returned '%s'",
         THPUtils_typename(_result));

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -337,7 +337,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
 [[
   name: maskedCopy_
   cname: maskedCopy
-  python_name: masked_copy_
+  python_name: masked_scatter_
   return: self
   arguments:
     - THTensor* self

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1,4 +1,5 @@
 import torch
+import warnings
 from . import _tensor_str
 from ._utils import _type, _cuda, _range, _rebuild_tensor
 import sys
@@ -261,6 +262,10 @@ class _TensorBase(object):
         xxtensor = xtensor.expand_as(urtensor)
         urtensor.copy_(xxtensor)
         return result
+
+    def masked_copy_(self, *args, **kwargs):
+        warnings.warn("masked_copy_ is deprecated and renamed to masked_scatter_, and will be removed in v0.3")
+        return self.masked_scatter_(self, *args, **kwargs)
 
     # TODO: add tests for operators
     def __add__(self, other):


### PR DESCRIPTION
* Fix Prod backward formula (and a few errors in autograd tests too) (#1709)
* Fix grad type of compare functions (#1677)
* Fix a bug when type checks didn't accept `None` values returned from grad hooks (#1269)
* Renamed `masked_copy_` to `masked_scatter_`. The old name is still available but is deprecated (#1662)