### PR TITLE
Add support for NVTX functions.

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -25,3 +25,10 @@ Streams and events
 
 .. autoclass:: Event
    :members:
+
+NVIDIA Tools Extension (NVTX)
+-----------------------------
+
+.. autofunction:: torch.cuda.nvtx.mark
+.. autofunction:: torch.cuda.nvtx.range_push
+.. autofunction:: torch.cuda.nvtx.range_pop

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ if WITH_CUDA:
     extra_link_args.append('-Wl,-rpath,' + cuda_lib_path)
     extra_compile_args += ['-DWITH_CUDA']
     extra_compile_args += ['-DCUDA_LIB_PATH=' + cuda_lib_path]
-    main_libraries += ['cudart']
+    main_libraries += ['cudart', 'nvToolsExt']
     main_link_args += [THC_LIB, THCS_LIB, THCUNN_LIB]
     main_sources += [
         "torch/csrc/cuda/Module.cpp",

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -847,6 +847,12 @@ class TestCuda(TestCase):
     def test_tensor_scatterFill(self):
         TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', True, test_bounds=False)
 
+    def test_nvtx(self):
+        # Just making sure we can see the symbols
+        torch.cuda.nvtx.range_push("foo")
+        torch.cuda.nvtx.mark("bar")
+        torch.cuda.nvtx.range_pop()
+
 
 if HAS_CUDA:
     for decl in tests:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -412,4 +412,5 @@ torch._tensor_classes.add(ByteTensor)
 torch._tensor_classes.add(HalfTensor)
 
 from . import sparse
+from . import nvtx
 from .streams import Stream, Event

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -1,0 +1,46 @@
+import os
+import ctypes
+import warnings
+import torch.cuda
+
+lib = None
+
+__all__ = ['range_push', 'range_pop', 'mark']
+
+def _libnvToolsExt():
+    global lib
+    if lib is None:
+        lib = ctypes.cdll.LoadLibrary(None)
+    return lib
+
+def range_push(msg):
+    """
+    Pushes a range onto a stack of nested range span.  Returns zero-based
+    depth of the range that is started.
+
+    Arguments:
+        msg (string): ASCII message to associate with range
+    """
+    if _libnvToolsExt() is None:
+        raise RuntimeError('Unable to load nvToolsExt library')
+    return lib.nvtxRangePushA(ctypes.c_char_p(msg))
+
+def range_pop():
+    """
+    Pops a range off of a stack of nested range spans.  Returns the
+    zero-based depth of the range that is ended.
+    """
+    if _libnvToolsExt() is None:
+        raise RuntimeError('Unable to load nvToolsExt library')
+    return lib.nvtxRangePop()
+
+def mark(msg):
+    """
+    Describe an instantaneous event that occurred at some point.
+
+    Arguments:
+        msg (string): ASCII message to associate with the event.
+    """
+    if _libnvToolsExt() is None:
+        raise RuntimeError('Unable to load nvToolsExt library')
+    return lib.nvtxMarkA(ctypes.c_char_p(msg))

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -4,12 +4,14 @@ lib = None
 
 __all__ = ['range_push', 'range_pop', 'mark']
 
+
 def _libnvToolsExt():
     global lib
     if lib is None:
         lib = ctypes.cdll.LoadLibrary(None)
         lib.nvtxMarkA.restype = None
     return lib
+
 
 def range_push(msg):
     """
@@ -23,6 +25,7 @@ def range_push(msg):
         raise RuntimeError('Unable to load nvToolsExt library')
     return lib.nvtxRangePushA(ctypes.c_char_p(msg))
 
+
 def range_pop():
     """
     Pops a range off of a stack of nested range spans.  Returns the
@@ -31,6 +34,7 @@ def range_pop():
     if _libnvToolsExt() is None:
         raise RuntimeError('Unable to load nvToolsExt library')
     return lib.nvtxRangePop()
+
 
 def mark(msg):
     """

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -23,7 +23,7 @@ def range_push(msg):
     """
     if _libnvToolsExt() is None:
         raise RuntimeError('Unable to load nvToolsExt library')
-    return lib.nvtxRangePushA(ctypes.c_char_p(msg))
+    return lib.nvtxRangePushA(ctypes.c_char_p(msg.encode("ascii")))
 
 
 def range_pop():
@@ -45,4 +45,4 @@ def mark(msg):
     """
     if _libnvToolsExt() is None:
         raise RuntimeError('Unable to load nvToolsExt library')
-    return lib.nvtxMarkA(ctypes.c_char_p(msg))
+    return lib.nvtxMarkA(ctypes.c_char_p(msg.encode("ascii")))

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -1,7 +1,4 @@
-import os
 import ctypes
-import warnings
-import torch.cuda
 
 lib = None
 
@@ -11,6 +8,7 @@ def _libnvToolsExt():
     global lib
     if lib is None:
         lib = ctypes.cdll.LoadLibrary(None)
+        lib.nvtxMarkA.restype = None
     return lib
 
 def range_push(msg):


### PR DESCRIPTION
This commit adds support for the simple, ASCII message only
NVTX functions.  There are a few more but these are the ones
I'm mostly interested in.

I tested by running this script under nvprof:

    import torch.cuda.nvtx
    torch.cuda.nvtx.range_push("foo")
    torch.cuda.nvtx.mark("bar")
    torch.cuda.nvtx.range_pop()

And verifying that the events showed up.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>