### PR TITLE
Add Alpha Dropout

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -763,6 +763,23 @@ class TestNN(NNTestCase):
         input = torch.Tensor(num_features, b, d, w, h)
         self._test_dropout(nn.Dropout3d, input)
 
+    def test_AlphaDropout(self):
+        # generate random tensor with zero mean and unit std
+        input = torch.randn(5000)
+
+        mean = input.mean()
+        std = input.std()
+
+        for p in [0.2, 0.5, 0.8]:
+            module = nn.AlphaDropout(p)
+            input_var = Variable(input, requires_grad=True)
+            output = module(input_var)
+            # output mean should be close to input mean
+            self.assertLess(abs(output.data.mean() - mean), 0.1)
+            # output std should be close to input std
+            self.assertLess(abs(output.data.std() - std), 0.1)
+            output.backward(input)
+
     def _test_InstanceNorm(self, cls, input):
         b, c = input.size(0), input.size(1)
         input_var = Variable(input)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -8,6 +8,7 @@ from . import _functions
 from .modules import utils
 from ._functions.padding import ConstantPad2d
 from ..autograd import _functions as _autograd_functions
+from torch.autograd import Variable
 from .modules.utils import _single, _pair, _triple
 
 # Convolutions
@@ -404,6 +405,28 @@ def adaptive_avg_pool2d(input, output_size):
 
 def dropout(input, p=0.5, training=False, inplace=False):
     return _functions.dropout.Dropout(p, training, inplace)(input)
+
+
+def alpha_dropout(input, p=0.5, training=False):
+    if not 0 < p <= 1:
+        raise ValueError("dropout probability has to be between 0 and 1, "
+                         "but got {}".format(p))
+
+    if p > 0 and training:
+        alpha = -1.7580993408473766
+        keep_prob = 1 - p
+        noise = input.data.new(input.size())
+        noise.bernoulli_(keep_prob)
+        noise = Variable(noise)
+
+        output = (input * noise).add_(noise.neg().add_(1).mul_(alpha))
+
+        a = (keep_prob + alpha ** 2 * keep_prob * (1 - keep_prob)) ** (-0.5)
+        b = -a * alpha * (1 - keep_prob)
+
+        return output.mul_(a).add_(b)
+
+    return input.clone()
 
 
 def threshold(input, threshold, value, inplace=False):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -417,11 +417,11 @@ def alpha_dropout(input, p=0.5, training=False):
 
     alpha = -1.7580993408473766
     keep_prob = 1 - p
-    noise = input.data.new(input.size())
-    noise.bernoulli_(keep_prob)
+    noise = input.data.new().byte().resize_(input.size())
+    noise.bernoulli_(p)
     noise = Variable(noise)
 
-    output = (input * noise).add_(noise.neg().add_(1).mul_(alpha))
+    output = input.masked_fill(noise, alpha)
 
     a = (keep_prob + alpha ** 2 * keep_prob * (1 - keep_prob)) ** (-0.5)
     b = -a * alpha * (1 - keep_prob)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -408,25 +408,25 @@ def dropout(input, p=0.5, training=False, inplace=False):
 
 
 def alpha_dropout(input, p=0.5, training=False):
-    if not 0 < p <= 1:
+    if p < 0 or p > 1:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))
 
-    if p > 0 and training:
-        alpha = -1.7580993408473766
-        keep_prob = 1 - p
-        noise = input.data.new(input.size())
-        noise.bernoulli_(keep_prob)
-        noise = Variable(noise)
+    if p == 0 or not training:
+        return input
 
-        output = (input * noise).add_(noise.neg().add_(1).mul_(alpha))
+    alpha = -1.7580993408473766
+    keep_prob = 1 - p
+    noise = input.data.new(input.size())
+    noise.bernoulli_(keep_prob)
+    noise = Variable(noise)
 
-        a = (keep_prob + alpha ** 2 * keep_prob * (1 - keep_prob)) ** (-0.5)
-        b = -a * alpha * (1 - keep_prob)
+    output = (input * noise).add_(noise.neg().add_(1).mul_(alpha))
 
-        return output.mul_(a).add_(b)
+    a = (keep_prob + alpha ** 2 * keep_prob * (1 - keep_prob)) ** (-0.5)
+    b = -a * alpha * (1 - keep_prob)
 
-    return input.clone()
+    return output.mul_(a).add_(b)
 
 
 def threshold(input, threshold, value, inplace=False):

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -103,8 +103,8 @@ def constant(tensor, val):
 
 
 def eye(tensor):
-    """Fills the 2-dimensional input Tensor or Variable with the identity matrix. Preserves the identity of the inputs in
-    Linear layers, where as many inputs are preserved as possible.
+    """Fills the 2-dimensional input Tensor or Variable with the identity matrix. Preserves the identity of the inputs
+    in Linear layers, where as many inputs are preserved as possible.
 
     Args:
         tensor: a 2-dimensional torch.Tensor or autograd.Variable

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -15,7 +15,7 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     AdaptiveMaxPool2d, AdaptiveAvgPool1d, AdaptiveAvgPool2d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
-from .dropout import Dropout, Dropout2d, Dropout3d
+from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
 from .padding import ReflectionPad2d, ReplicationPad2d, ReplicationPad3d, ZeroPad2d, ConstantPad2d
 from .normalization import CrossMapLRN2d
 from .sparse import Embedding
@@ -38,7 +38,7 @@ __all__ = [
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
     'LPPool2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d', 'InstanceNorm2d',
-    'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'ReflectionPad2d',
+    'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'ReflectionPad2d',
     'ReplicationPad2d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -153,3 +153,54 @@ class Dropout3d(Module):
         return self.__class__.__name__ + ' (' \
             + 'p=' + str(self.p) \
             + inplace_str + ')'
+
+
+class AlphaDropout(Module):
+    r"""Applies Alpha Dropout over the input.
+
+    Alpha Dropout is a type of Dropout that maintains the self-normalizing
+    property.
+    For an input with zero mean and unit standard deviation, the output of
+    Alpha Dropout maintains the original mean and standard deviation of the
+    input.
+    Alpha Dropout goes hand-in-hand with SELU activation function, which ensures
+    that the outputs have zero mean and unit standard deviation.
+
+    During training, it randomly masks some of the elements of the input
+    tensor with probability *p* using samples from a bernoulli distribution.
+    The elements to masked are randomized on every forward call, and scaled
+    and shifted to maintain zero mean and unit standard deviation.
+
+    During evaluation the module simply computes an identity function.
+
+    More details can be found in the paper `Self-Normalizing Neural Networks`_ .
+
+    Args:
+        p (float): probability of an element to be dropped. Default: 0.5
+
+    Shape:
+        - Input: `Any`. Input can be of any shape
+        - Output: `Same`. Output is of the same shape as input
+
+    Examples::
+
+        >>> m = nn.AlphaDropout(p=0.2)
+        >>> input = autograd.Variable(torch.randn(20, 16))
+        >>> output = m(input)
+
+    .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515
+    """
+
+    def __init__(self, p=0.5):
+        super(AlphaDropout, self).__init__()
+        if p < 0 or p > 1:
+            raise ValueError("dropout probability has to be between 0 and 1, "
+                             "but got {}".format(p))
+        self.p = p
+
+    def forward(self, input):
+        return F.alpha_dropout(input, self.p, self.training)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'p = ' + str(self.p) + ')'


### PR DESCRIPTION
Complements https://github.com/pytorch/pytorch/issues/1768.

Note that I have not added the `fixed_mean` and `fixed_var` parameters from the original paper, as SELU outputs have zero mean and unit std, so I only considered this case. Let me know if you think it's worth adding support for these extra parameters.