### PR TITLE
Remove flattening for torch.dot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,11 +156,12 @@ class build_ext(setuptools.command.build_ext.build_ext):
         from tools.cwrap.plugins.NullableArguments import NullableArguments
         from tools.cwrap.plugins.CuDNNPlugin import CuDNNPlugin
         from tools.cwrap.plugins.WrapDim import WrapDim
+        from tools.cwrap.plugins.CheckDim import CheckDim
         from tools.cwrap.plugins.Broadcast import Broadcast
         thp_plugin = THPPlugin()
         cwrap('torch/csrc/generic/TensorMethods.cwrap', plugins=[
             BoolOption(), thp_plugin, AutoGPU(condition='IS_CUDA'),
-            ArgcountSortPlugin(), KwargsPlugin(), WrapDim(), Broadcast()
+            ArgcountSortPlugin(), KwargsPlugin(), CheckDim(), WrapDim(), Broadcast()
         ])
         cwrap('torch/csrc/cudnn/cuDNN.cwrap', plugins=[
             CuDNNPlugin(), NullableArguments()

--- a/setup.py
+++ b/setup.py
@@ -156,12 +156,12 @@ class build_ext(setuptools.command.build_ext.build_ext):
         from tools.cwrap.plugins.NullableArguments import NullableArguments
         from tools.cwrap.plugins.CuDNNPlugin import CuDNNPlugin
         from tools.cwrap.plugins.WrapDim import WrapDim
-        from tools.cwrap.plugins.CheckDim import CheckDim
+        from tools.cwrap.plugins.AssertNDim import AssertNDim
         from tools.cwrap.plugins.Broadcast import Broadcast
         thp_plugin = THPPlugin()
         cwrap('torch/csrc/generic/TensorMethods.cwrap', plugins=[
             BoolOption(), thp_plugin, AutoGPU(condition='IS_CUDA'),
-            ArgcountSortPlugin(), KwargsPlugin(), CheckDim(), WrapDim(), Broadcast()
+            ArgcountSortPlugin(), KwargsPlugin(), AssertNDim(), WrapDim(), Broadcast()
         ])
         cwrap('torch/csrc/cudnn/cuDNN.cwrap', plugins=[
             CuDNNPlugin(), NullableArguments()

--- a/tools/cwrap/plugins/AssertNDim.py
+++ b/tools/cwrap/plugins/AssertNDim.py
@@ -2,11 +2,11 @@ from . import CWrapPlugin
 from string import Template
 
 
-class CheckDim(CWrapPlugin):
+class AssertNDim(CWrapPlugin):
 
     PRE_CODE_TEMPLATE = Template(
         """if(THTensor_(nDimension)(LIBRARY_STATE ${arg_op}) != ${dim_value}) {
-             THError("Expected argument %s to have %d dimensions, but has %d",
+             THError("Expected argument %s to have %d dimension(s), but has %d",
                      "${op}", ${dim_value}, THTensor_(nDimension)(LIBRARY_STATE ${arg_op}));
            }
         """)
@@ -15,10 +15,10 @@ class CheckDim(CWrapPlugin):
         new_code_pre = []
 
         for _, arg in enumerate(option['arguments']):
-            if 'checkdim' not in arg:
+            if 'assert_ndim' not in arg:
                 continue
 
-            dim_value = arg.get('checkdim')
+            dim_value = arg.get('assert_ndim')
             op = arg.get('assign_name', arg['name'])
             arg_op = "arg_" + op
             new_code_pre.append(self.PRE_CODE_TEMPLATE.substitute(op=op,

--- a/tools/cwrap/plugins/CheckDim.py
+++ b/tools/cwrap/plugins/CheckDim.py
@@ -1,0 +1,29 @@
+from . import CWrapPlugin
+from string import Template
+
+
+class CheckDim(CWrapPlugin):
+
+    PRE_CODE_TEMPLATE = Template(
+        """if(THTensor_(nDimension)(LIBRARY_STATE ${arg_op}) != ${dim_value}) {
+             THError("Expected argument %s to have %d dimensions, but has %d",
+                     "${op}", ${dim_value}, THTensor_(nDimension)(LIBRARY_STATE ${arg_op}));
+           }
+        """)
+
+    def process_option_code_template(self, template, option):
+        new_code_pre = []
+
+        for _, arg in enumerate(option['arguments']):
+            if 'checkdim' not in arg:
+                continue
+
+            dim_value = arg.get('checkdim')
+            op = arg.get('assign_name', arg['name'])
+            arg_op = "arg_" + op
+            new_code_pre.append(self.PRE_CODE_TEMPLATE.substitute(op=op,
+                                                                  arg_op=arg_op,
+                                                                  dim_value=dim_value))
+            template = new_code_pre + template
+
+        return template

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -548,6 +548,9 @@ Performs a batch matrix-matrix product of matrices stored in :attr:`batch1` and 
 If :attr:`batch1` is a `b x n x m` Tensor, :attr:`batch2` is a `b x m x p` Tensor,
 :attr:`out` will be a `b x n x p` Tensor.
 
+.. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.  For broadcasting matrix products,
+          see :func:`torch.matmul`.
+
 Args:
     batch1 (Tensor): First batch of matrices to be multiplied
     batch2 (Tensor): Second batch of matrices to be multiplied
@@ -1198,8 +1201,9 @@ add_docstr(torch._C.dot,
            """
 dot(tensor1, tensor2) -> float
 
-Computes the dot product (inner product) of two tensors. Both tensors are
-treated as 1-D vectors.
+Computes the dot product (inner product) of two tensors.
+
+.. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.
 
 Example::
 
@@ -1552,6 +1556,8 @@ ger(vec1, vec2, out=None) -> Tensor
 Outer product of :attr:`vec1` and :attr:`vec2`.
 If :attr:`vec1` is a vector of size `n` and :attr:`vec2` is a vector of size `m`,
 then :attr:`out` must be a matrix of size `n x m`.
+
+.. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.
 
 Args:
     vec1 (Tensor): 1D input vector
@@ -2486,6 +2492,9 @@ Performs a matrix multiplication of the matrices :attr:`mat1` and :attr:`mat2`.
 
 If :attr:`mat1` is a `n x m` Tensor, :attr:`mat2` is a `m x p` Tensor, :attr:`out` will be a `n x p` Tensor.
 
+.. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.  For broadcasting matrix products,
+          see :func:`torch.matmul`.
+
 Args:
     mat1 (Tensor): First matrix to be multiplied
     mat2 (Tensor): Second matrix to be multiplied
@@ -2697,6 +2706,8 @@ mv(mat, vec, out=None) -> Tensor
 Performs a matrix-vector product of the matrix :attr:`mat` and the vector :attr:`vec`.
 
 If :attr:`mat` is a `n x m` Tensor, :attr:`vec` is a 1D Tensor of size `m`, :attr:`out` will be 1D of size `n`.
+
+.. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.
 
 Args:
     mat (Tensor): matrix to be multiplied

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1300,9 +1300,9 @@
   return: accreal
   arguments:
     - arg: THTensor* self
-      checkdim: 1
+      assert_ndim: 1
     - arg: THTensor* tensor
-      checkdim: 1
+      assert_ndim: 1
 ]]
 
 [[

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1299,8 +1299,10 @@
   with_stateless: True
   return: accreal
   arguments:
-    - THTensor* self
-    - THTensor* tensor
+    - arg: THTensor* self
+      checkdim: 1
+    - arg: THTensor* tensor
+      checkdim: 1
 ]]
 
 [[

--- a/torch/legacy/nn/Mul.py
+++ b/torch/legacy/nn/Mul.py
@@ -29,4 +29,5 @@ class Mul(Module):
         return self.gradInput
 
     def accGradParameters(self, input, gradOutput, scale=1):
-        self.gradWeight[0] = self.gradWeight[0] + scale * input.dot(gradOutput)
+        self.gradWeight[0] = (self.gradWeight[0] +
+                              scale * input.contiguous().view(-1).dot(gradOutput.contiguous().view(-1)))


### PR DESCRIPTION
Also update broadcasting documentation for functions that torch.matmul delegates to (torch.mv/mm/bmm/dot/ger).