### PR TITLE
add `init` to `__init__.py` of `torch.nn` module

### DIFF
--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -1,3 +1,4 @@
 from .modules import *
 from .parameter import Parameter
 from .parallel import DataParallel
+from . import init


### PR DESCRIPTION
Currently in master this does not work: (reported by @y0ast)
```python
import torch
torch.nn.init.orthogonal(...)
```