### PR TITLE
Make csrc -Werror clean.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,17 @@ WITH_DISTRIBUTED_MW = WITH_DISTRIBUTED and check_env_flag('WITH_DISTRIBUTED_MW')
 WITH_NCCL = WITH_CUDA and platform.system() != 'Darwin'
 SYSTEM_NCCL = False
 
+
+################################################################################
+# Workaround setuptools -Wstrict-prototypes warnings
+# I lifted this code from https://stackoverflow.com/a/29634231/23845
+################################################################################
+import distutils.sysconfig
+cfg_vars = distutils.sysconfig.get_config_vars()
+for key, value in cfg_vars.items():
+    if type(value) == str:
+            cfg_vars[key] = value.replace("-Wstrict-prototypes", "")
+
 ################################################################################
 # Monkey-patch setuptools to compile in parallel
 ################################################################################
@@ -211,7 +222,10 @@ class clean(distutils.command.clean.clean):
 include_dirs = []
 library_dirs = []
 extra_link_args = []
-extra_compile_args = ['-std=c++11', '-Wno-write-strings']
+extra_compile_args = ['-std=c++11', '-Wno-write-strings',
+                      # Python 2.6 requires -fno-strict-aliasing, see
+                      # http://legacy.python.org/dev/peps/pep-3123/
+                      '-fno-strict-aliasing']
 if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
     print('PYTORCH_BINARY_BUILD found. Static linking libstdc++ on Linux')
     extra_compile_args += ['-static-libstdc++']

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -2,8 +2,8 @@
 
 // Provides conversions between Python tensor objects and thpp::Tensors.
 
-#include <memory>
 #include <Python.h>
+#include <memory>
 #include <THPP/THPP.h>
 
 namespace torch {

--- a/torch/csrc/README.md
+++ b/torch/csrc/README.md
@@ -12,6 +12,11 @@ important gotchas:
 * DO NOT forget to take out the GIL with `AutoGil` before calling Python
   API or bringing a `THPObjectPtr` into scope.
 
+* Make sure you include `Python.h` first in your header files, before
+  any system headers; otherwise, you will get `error: "_XOPEN_SOURCE" redefined`
+  error.  If you pay attention to warnings, you will see where you need to
+  do this.
+
 ## Notes
 
 ### Note [Storage is not NULL]

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -1,12 +1,14 @@
 #ifndef THP_H
 #define THP_H
 
+#include <Python.h>
 #include <stdbool.h>
 #include <TH/TH.h>
 #include <THS/THS.h>
 
 // Back-compatibility macros, Thanks to http://cx-oracle.sourceforge.net/
-// define PyInt_* macros for Python 3.x
+// define PyInt_* macros for Python 3.x.  NB: We must include Python.h first,
+// otherwise we'll incorrectly conclude PyInt_Check isn't defined!
 #ifndef PyInt_Check
 #define PyInt_Check             PyLong_Check
 #define PyInt_FromLong          PyLong_FromLong

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -3,6 +3,7 @@
 // Engine implements backpropagation from output variables and their gradients
 // to "root" variables (variables created by the user with requires_grad=True).
 
+#include <Python.h>
 #include <deque>
 #include <memory>
 #include <unordered_map>

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -6,11 +6,13 @@
 // Subclasses may represent "forward" or "backward" operations (i.e functions
 // and their derivatives). Some functions may be used as both.
 
-#include <memory>
-#include <THPP/THPP.h>
-#include <vector>
-
+#include <Python.h>
 #include "torch/csrc/autograd/function_hook.h"
+
+#include <THPP/THPP.h>
+
+#include <memory>
+#include <vector>
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <memory>
+#include <Python.h>
 #include <THPP/THPP.h>
+#include <memory>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Python.h>
 #include <memory>
 #include <string>
 #include <THPP/THPP.h>

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Python.h>
 #include <memory>
 #include <THPP/THPP.h>
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -1,6 +1,6 @@
-#include <sstream>
-
 #include "convolution.h"
+
+#include <sstream>
 
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/functions/utils.h"

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <Python.h>
+#include <THPP/THPP.h>
 #include <memory>
 #include <vector>
-#include <THPP/THPP.h>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <memory>
+#include <Python.h>
 #include <THPP/THPP.h>
+#include <memory>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Python.h>
 #include <functional>
 #include <memory>
 #include <array>

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -5,6 +5,7 @@
 // values in-place (adding an input twice will accumulate the result).
 // This behaviour needed and used only in backward graphs.
 
+#include <Python.h>
 #include <vector>
 #include <utility>
 #include <memory>

--- a/torch/csrc/autograd/python_hook.h
+++ b/torch/csrc/autograd/python_hook.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <Python.h>
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/utils/object_ptr.h"
-#include <Python.h>
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Python.h>
 #include <mutex>
 #include <memory>
 #include <functional>

--- a/torch/csrc/cuda/THCP.h
+++ b/torch/csrc/cuda/THCP.h
@@ -1,6 +1,7 @@
 #ifndef THCP_H
 #define THCP_H
 
+#include <Python.h>
 #include <TH/TH.h>
 #include <THC/THC.h>
 #include <THC/THCHalf.h>


### PR DESCRIPTION
Primary things I had to fix:

- Suppress _XOPEN_SOURCE warnings by ensuring that Python.h is included
  first, because it always unconditionally defines this macro.

- Turn off strict aliasing, because Python 2 doesn't work with strict
  aliasing.

- Workaround setuptools bug, where it's incorrectly passing
  -Wstrict-prototypes to C++ compilers (where this doesn't make
  any sense)

To compile csrc with -Werror, run `CFLAGS="-Werror" python setup.py build_ext`

Signed-off-by: Edward Z. Yang <ezyang@fb.com>