### PR TITLE
Add missing Modules to nn.functional

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -913,6 +913,16 @@ Dropout functions
 
 .. autofunction:: alpha_dropout
 
+:hidden:`dropout2d`
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: dropout2d
+
+:hidden:`dropout3d`
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: dropout3d
+
 Distance functions
 ----------------------------------
 
@@ -930,30 +940,70 @@ Distance functions
 Loss functions
 --------------
 
-:hidden:`nll_loss`
-~~~~~~~~~~~~~~~~~~
+:hidden:`binary_cross_entropy`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: nll_loss
+.. autofunction:: binary_cross_entropy
 
 :hidden:`poisson_nll_loss`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: poisson_nll_loss
 
-:hidden:`kl_div`
-~~~~~~~~~~~~~~~~
+:hidden:`cosine_embedding_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: kl_div
+.. autofunction:: cosine_embedding_loss
 
 :hidden:`cross_entropy`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: cross_entropy
 
-:hidden:`binary_cross_entropy`
+:hidden:`hinge_embedding_loss`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: binary_cross_entropy
+.. autofunction:: hinge_embedding_loss
+
+:hidden:`kl_div`
+~~~~~~~~~~~~~~~~
+
+.. autofunction:: kl_div
+
+:hidden:`l1_loss`
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: l1_loss
+
+:hidden:`mse_loss`
+~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: mse_loss
+
+:hidden:`margin_ranking_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: margin_ranking_loss
+
+:hidden:`multilabel_margin_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: multilabel_margin_loss
+
+:hidden:`multilabel_soft_margin_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: multilabel_soft_margin_loss
+
+:hidden:`multi_margin_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: multi_margin_loss
+
+:hidden:`nll_loss`
+~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: nll_loss
 
 :hidden:`binary_cross_entropy_with_logits`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -964,6 +1014,11 @@ Loss functions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: smooth_l1_loss
+
+:hidden:`soft_margin_loss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: soft_margin_loss
 
 :hidden:`triplet_margin_loss`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -216,7 +216,6 @@ module_tests = [
     ),
 ]
 
-
 criterion_tests = [
     dict(module_name='L1Loss',
          input_size=(2, 3, 4),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -18,7 +18,6 @@ import torch.nn.parallel as dp
 import torch.nn.init as init
 import torch.nn.utils.rnn as rnn_utils
 import torch.legacy.nn as legacy
-from torch.nn.modules.loss import _Loss
 from torch.nn.utils import clip_grad_norm
 from torch.autograd import Variable, gradcheck
 from torch.autograd.gradcheck import gradgradcheck
@@ -3086,61 +3085,6 @@ class TestNNInit(TestCase):
                                          torch.eye(rows) * gain ** 2, prec=1e-6)
 
 
-# functional loss wrappers
-
-
-class _SmoothL1LossFunctional(_Loss):
-
-    def __init__(self, *args, **kwargs):
-        super(_SmoothL1LossFunctional, self).__init__(*args, **kwargs)
-
-    def forward(self, *args, **kwargs):
-        return F.smooth_l1_loss(*args, **kwargs)
-
-
-class _L1LossFunctional(_Loss):
-
-    def __init__(self, *args, **kwargs):
-        super(_L1LossFunctional, self).__init__(*args, **kwargs)
-
-    def forward(self, *args, **kwargs):
-        return F.l1_loss(*args, **kwargs)
-
-
-class _MSELossFunctional(_Loss):
-
-    def __init__(self, *args, **kwargs):
-        super(_MSELossFunctional, self).__init__(*args, **kwargs)
-
-    def forward(self, *args, **kwargs):
-        return F.mse_loss(*args, **kwargs)
-
-
-class _MultiLabelMarginLossFunctional(_Loss):
-
-    def __init__(self, *args, **kwargs):
-        super(_MultiLabelMarginLossFunctional, self).__init__(*args, **kwargs)
-
-    def forward(self, *args, **kwargs):
-        return F.multilabel_margin_loss(*args, **kwargs)
-
-
-class _SoftMarginLossFunctional(_Loss):
-
-    def __init__(self, *args, **kwargs):
-        super(_SoftMarginLossFunctional, self).__init__(*args, **kwargs)
-
-    def forward(self, *args, **kwargs):
-        return F.soft_margin_loss(*args, **kwargs)
-
-
-nn.SmoothL1LossFunctional = _SmoothL1LossFunctional
-nn.L1LossFunctional = _L1LossFunctional
-nn.MSELossFunctional = _MSELossFunctional
-nn.MultiLabelMarginLossFunctional = _MultiLabelMarginLossFunctional
-nn.SoftMarginLossFunctional = _SoftMarginLossFunctional
-
-
 def add_test(test):
     test_name = test.get_name()
     cuda_test_name = test_name + '_cuda'
@@ -3718,37 +3662,6 @@ new_criterion_tests = [
 ]
 
 
-functional_criterion_tests = [
-    dict(module_name='L1LossFunctional',
-         input_size=(2, 3, 4),
-         target=torch.randn(2, 3, 4),
-         reference_fn=lambda i, t, _: 1. / i.numel() *
-         sum((a - b).abs().sum() for a, b in zip(i, t))
-         ),
-    dict(
-        module_name='MSELossFunctional',
-        input=torch.randn(2, 3, 4, 5),
-        target=torch.randn(2, 3, 4, 5),
-        reference_fn=lambda i, t, _: (i - t).abs().pow(2).sum() / i.numel()
-    ),
-    dict(
-        module_name='MultiLabelMarginLossFunctional',
-        input_size=(5, 10),
-        target=torch.rand(5, 10).mul(10).floor().long()
-    ),
-    dict(
-        module_name='SmoothL1LossFunctional',
-        input_size=(5, 10),
-        target=torch.randn(5, 10)
-    ),
-    dict(
-        module_name='SoftMarginLossFunctional',
-        input_size=(5, 5),
-        target=torch.randn(5, 5).sign()
-    ),
-]
-
-
 for test_params in module_tests + new_module_tests:
     # TODO: CUDA is not implemented yet
     if 'constructor' not in test_params:
@@ -3757,7 +3670,7 @@ for test_params in module_tests + new_module_tests:
     test = NewModuleTest(**test_params)
     add_test(test)
 
-for test_params in criterion_tests + new_criterion_tests + functional_criterion_tests:
+for test_params in criterion_tests + new_criterion_tests:
     name = test_params.pop('module_name')
     test_params['constructor'] = getattr(nn, name)
     test = NewCriterionTest(**test_params)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -640,7 +640,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
         return torch.sum(loss)
 
 
-def kl_div(input, target, size_average=True):
+def kl_div(input, target, size_average=True, weight=None):
     r"""The `Kullback-Leibler divergence`_ Loss.
 
     See :class:`~torch.nn.KLDivLoss` for details.
@@ -650,8 +650,10 @@ def kl_div(input, target, size_average=True):
         target: Variable of the same shape as input
         size_average: if True the output is divided by the number of elements
           in input tensor
+        weight (Tensor, optional): a manual rescaling weight given to each
+                class. If given, has to be a Tensor of size "nclasses"
     """
-    return _functions.thnn.KLDivLoss(size_average)(input, target)
+    return _functions.thnn.KLDivLoss(size_average, weight=weight)(input, target)
 
 
 def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-100):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -447,6 +447,14 @@ def alpha_dropout(input, p=0.5, training=False):
     return output.mul_(a).add_(b)
 
 
+def dropout2d(input, p=0.5, training=False, inplace=False):
+    return _functions.dropout.FeatureDropout.apply(input, p, training, inplace)
+
+
+def dropout3d(input, p=0.5, training=False, inplace=False):
+    return _functions.dropout.FeatureDropout.apply(input, p, training, inplace)
+
+
 def threshold(input, threshold, value, inplace=False):
     return _functions.thnn.Threshold.apply(input, threshold, value, inplace)
 
@@ -728,6 +736,49 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
 
 def smooth_l1_loss(input, target, size_average=True):
     return _functions.thnn.SmoothL1Loss(size_average)(input, target)
+
+
+def l1_loss(input, target, size_average=True):
+    return _functions.thnn.L1Loss(size_average)(input, target)
+
+
+def mse_loss(input, target, size_average=True):
+    return _functions.thnn.MSELoss(size_average)(input, target)
+
+
+def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):
+    return _functions.loss.MarginRankingLoss(margin, size_average)(input1, input2, target)
+
+
+def hinge_embedding_loss(input, target, margin=1.0, size_average=True):
+    return _functions.loss.HingeEmbeddingLoss(margin, size_average)(input, target)
+
+
+def multilabel_margin_loss(input, target, size_average=True):
+    return _functions.thnn.MultiLabelMarginLoss(size_average)(input, target)
+
+
+def soft_margin_loss(input, target, size_average=True):
+    return _functions.thnn.SoftMarginLoss(size_average)(input, target)
+
+
+def multilabel_soft_margin_loss(input, target, weight=None, size_average=True):
+    input = torch.sigmoid(input)
+    return binary_cross_entropy(input, target, weight, size_average)
+
+
+def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True):
+    return _functions.loss.CosineEmbeddingLoss(margin, size_average)(input1, input2, target)
+
+
+def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True):
+    if p != 1 and p != 2:
+        raise ValueError('only p == 1 and p == 2 supported')
+    if weight is not None and weight.dim() != 1:
+        raise ValueError('weight must be one-dimensional')
+
+    return _functions.thnn.MultiMarginLoss(size_average, p, margin,
+                                           weight=weight)(input, target)
 
 
 def pixel_shuffle(input, upscale_factor):

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -96,7 +96,7 @@ class Dropout2d(Module):
         self.inplace = inplace
 
     def forward(self, input):
-        return self._backend.Dropout2d.apply(input, self.p, self.training, self.inplace)
+        return F.dropout2d(input, self.p, self.training, self.inplace)
 
     def __repr__(self):
         inplace_str = ', inplace' if self.inplace else ''
@@ -149,7 +149,7 @@ class Dropout3d(Module):
         self.inplace = inplace
 
     def forward(self, input):
-        return self._backend.Dropout3d.apply(input, self.p, self.training, self.inplace)
+        return F.dropout3d(input, self.p, self.training, self.inplace)
 
     def __repr__(self):
         inplace_str = ', inplace' if self.inplace else ''

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -17,21 +17,11 @@ class _Loss(Module):
         super(_Loss, self).__init__()
         self.size_average = size_average
 
-    def forward(self, input, target):
-        _assert_no_grad(target)
-        backend_fn = getattr(self._backend, type(self).__name__)
-        return backend_fn(self.size_average)(input, target)
-
 
 class _WeightedLoss(_Loss):
     def __init__(self, weight=None, size_average=True):
         super(_WeightedLoss, self).__init__(size_average)
         self.register_buffer('weight', weight)
-
-    def forward(self, input, target):
-        _assert_no_grad(target)
-        backend_fn = getattr(self._backend, type(self).__name__)
-        return backend_fn(self.size_average, weight=self.weight)(input, target)
 
 
 class L1Loss(_Loss):
@@ -47,7 +37,9 @@ class L1Loss(_Loss):
     The division by `n` can be avoided if one sets the constructor argument
     `size_average=False`
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.l1_loss(input, target, size_average=self.size_average)
 
 
 class NLLLoss(_WeightedLoss):
@@ -220,7 +212,9 @@ class KLDivLoss(_WeightedLoss):
     .. _Kullback-Leibler divergence:
         https://en.wikipedia.org/wiki/Kullback-Leibler_divergence
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.kl_div(input, target, size_average=self.size_average, weight=self.weight)
 
 
 class MSELoss(_Loss):
@@ -237,7 +231,9 @@ class MSELoss(_Loss):
     `size_average` to `False`.
 
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.mse_loss(input, target, size_average=self.size_average)
 
 
 class BCELoss(_WeightedLoss):
@@ -259,7 +255,10 @@ class BCELoss(_WeightedLoss):
     to `False`, the losses are instead summed.
 
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.binary_cross_entropy(input, target, weight=self.weight,
+                                      size_average=self.size_average)
 
 
 class BCEWithLogitsLoss(Module):
@@ -344,7 +343,9 @@ class MultiLabelMarginLoss(_Loss):
 
     This allows for different samples to have variable amounts of target classes
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.multilabel_margin_loss(input, target, size_average=self.size_average)
 
 
 class SmoothL1Loss(_Loss):
@@ -364,7 +365,9 @@ class SmoothL1Loss(_Loss):
     The division by `n` can be avoided if one sets the internal variable
     `size_average` to `False`
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.smooth_l1_loss(input, target, size_average=self.size_average)
 
 
 class SoftMarginLoss(_Loss):
@@ -379,7 +382,9 @@ class SoftMarginLoss(_Loss):
     The normalization by the number of elements in the input can be disabled by
     setting `self.size_average` to `False`.
     """
-    pass
+    def forward(self, input, target):
+        _assert_no_grad(target)
+        return F.soft_margin_loss(input, target, size_average=self.size_average)
 
 
 class CrossEntropyLoss(_WeightedLoss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -324,8 +324,7 @@ class HingeEmbeddingLoss(_Loss):
         self.size_average = size_average
 
     def forward(self, input, target):
-        return self._backend.HingeEmbeddingLoss(self.margin,
-                                                self.size_average)(input, target)
+        return F.hinge_embedding_loss(input, target, self.margin, self.size_average)
 
 
 class MultiLabelMarginLoss(_Loss):
@@ -447,8 +446,7 @@ class MultiLabelSoftMarginLoss(_WeightedLoss):
     """
 
     def forward(self, input, target):
-        return F.binary_cross_entropy(torch.sigmoid(input), target,
-                                      self.weight, self.size_average)
+        return F.multilabel_soft_margin_loss(input, target, self.weight, self.size_average)
 
 
 class CosineEmbeddingLoss(Module):
@@ -479,8 +477,7 @@ class CosineEmbeddingLoss(Module):
         self.size_average = size_average
 
     def forward(self, input1, input2, target):
-        return self._backend.CosineEmbeddingLoss(self.margin,
-                                                 self.size_average)(input1, input2, target)
+        return F.cosine_embedding_loss(input1, input2, target, self.margin, self.size_average)
 
 
 class MarginRankingLoss(Module):
@@ -508,8 +505,7 @@ class MarginRankingLoss(Module):
         self.size_average = size_average
 
     def forward(self, input1, input2, target):
-        return self._backend.MarginRankingLoss(self.margin,
-                                               self.size_average)(input1, input2, target)
+        return F.margin_ranking_loss(input1, input2, target, self.margin, self.size_average)
 
 
 class MultiMarginLoss(Module):
@@ -546,8 +542,8 @@ class MultiMarginLoss(Module):
         self.weight = weight
 
     def forward(self, input, target):
-        return self._backend.MultiMarginLoss(self.size_average, self.p,
-                                             self.margin, weight=self.weight)(input, target)
+        return F.multi_margin_loss(input, target, self.p, self.margin,
+                                   self.weight, self.size_average)
 
 
 class TripletMarginLoss(Module):


### PR DESCRIPTION
This PR adds some modules that are not available in nn.functional:

* Dropout2d
* Dropout3d
* BCE
* CosineEmbeddingLoss
* HingeEmbeddingLoss
* L1Loss
* MSELoss
* MarginRankinLoss
* MultilabelMarginLoss
* SoftMarginLoss
* MultilabelSoftMarginLoss
* MultiMarginLoss