### PR TITLE
added simple initializer to some modules

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -56,7 +56,7 @@ class _ConvNd(Module):
             self.weight.data.uniform_(-stdv, stdv)
         else:
             weight_initializer(self.weight)
-        if self.bias is None:
+        if self.bias is not None:
             if bias_initializer is None:
                 self.bias.data.uniform_(-stdv, stdv)
             else:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -11,7 +11,7 @@ class _ConvNd(Module):
 
     def __init__(self, in_channels, out_channels, kernel_size, stride,
                  padding, dilation, transposed, output_padding, groups, bias,
-                 initializer=dict()):
+                 initializer=None):
         super(_ConvNd, self).__init__()
         if in_channels % groups != 0:
             raise ValueError('in_channels must be divisible by groups')
@@ -36,7 +36,7 @@ class _ConvNd(Module):
             self.bias = Parameter(torch.Tensor(out_channels))
         else:
             self.register_parameter('bias', None)
-        self.initializer = initializer
+        self.initializer = {} if initializer is None else initializer
         self.reset_parameters()
 
     def reset_parameters(self):
@@ -45,7 +45,7 @@ class _ConvNd(Module):
             n *= k
         stdv = 1. / math.sqrt(n)
 
-        if isinstance(self.initializer, function):
+        if callable(self.initializer):
             weight_initializer = self.initializer
             bias_initializer = None
         else:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -34,17 +34,19 @@ class _ConvNd(Module):
             self.weight = Parameter(torch.Tensor(
                 out_channels, in_channels // groups, *kernel_size))
 
-        n = self.in_channels
-        for k in self.kernel_size:
-            n *= k
-        stdv = 1. / math.sqrt(n)
-        self.initializer = {"weight": lambda x: init.uniform(x, -stdv, stdv)} \
-            if initializer is None else initializer
+        def _initializer(x):
+            n = self.in_channels
+            for k in self.kernel_size:
+                n *= k
+            stdv = 1. / math.sqrt(n)
+            return init.uniform(x, -stdv, stdv)
+
+        self.initializer = {"weight": _initializer} if initializer is None else initializer
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
             if self.initializer.get("bias") is None:
-                self.initializer["bias"] = lambda x: init.uniform(x, -stdv, stdv)
+                self.initializer["bias"] = _initializer
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -34,19 +34,12 @@ class _ConvNd(Module):
             self.weight = Parameter(torch.Tensor(
                 out_channels, in_channels // groups, *kernel_size))
 
-        def _initializer(x):
-            n = self.in_channels
-            for k in self.kernel_size:
-                n *= k
-            stdv = 1. / math.sqrt(n)
-            return init.uniform(x, -stdv, stdv)
-
-        self.initializer = {"weight": _initializer} if initializer is None else initializer
+        self.initializer = {"weight": self._initializer} if initializer is None else initializer
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
             if self.initializer.get("bias") is None:
-                self.initializer["bias"] = _initializer
+                self.initializer["bias"] = self._initializer
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()
@@ -75,6 +68,13 @@ class _ConvNd(Module):
             s += ', bias=False'
         s += ')'
         return s.format(name=self.__class__.__name__, **self.__dict__)
+
+    def _initializer(self, x):
+        n = self.in_channels
+        for k in self.kernel_size:
+            n *= k
+        stdv = 1. / math.sqrt(n)
+        return init.uniform(x, -stdv, stdv)
 
 
 class Conv1d(_ConvNd):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -12,7 +12,7 @@ class _ConvNd(Module):
 
     def __init__(self, in_channels, out_channels, kernel_size, stride,
                  padding, dilation, transposed, output_padding, groups, bias,
-                 initializer=None):
+                 initializer):
         super(_ConvNd, self).__init__()
         if in_channels % groups != 0:
             raise ValueError('in_channels must be divisible by groups')
@@ -123,6 +123,8 @@ class Conv1d(_ConvNd):
         dilation (int or tuple, optional): Spacing between kernel elements
         groups (int, optional): Number of blocked connections from input channels to output channels
         bias (bool, optional): If True, adds a learnable bias to the output
+        initializer(dict, optional): dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Shape:
         - Input: :math:`(N, C_{in}, L_{in})`
@@ -147,14 +149,14 @@ class Conv1d(_ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, dilation=1, groups=1, bias=True):
+                 padding=0, dilation=1, groups=1, bias=True, initializer=None):
         kernel_size = _single(kernel_size)
         stride = _single(stride)
         padding = _single(padding)
         dilation = _single(dilation)
         super(Conv1d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            False, _single(0), groups, bias)
+            False, _single(0), groups, bias, initializer)
 
     def forward(self, input):
         return F.conv1d(input, self.weight, self.bias, self.stride,
@@ -213,6 +215,8 @@ class Conv2d(_ConvNd):
         dilation (int or tuple, optional): Spacing between kernel elements
         groups (int, optional): Number of blocked connections from input channels to output channels
         bias (bool, optional): If True, adds a learnable bias to the output
+        initializer(dict, optional): dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Shape:
         - Input: :math:`(N, C_{in}, H_{in}, W_{in})`
@@ -244,14 +248,14 @@ class Conv2d(_ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, dilation=1, groups=1, bias=True):
+                 padding=0, dilation=1, groups=1, bias=True, initializer=None):
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)
         padding = _pair(padding)
         dilation = _pair(dilation)
         super(Conv2d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            False, _pair(0), groups, bias)
+            False, _pair(0), groups, bias, initializer)
 
     def forward(self, input):
         return F.conv2d(input, self.weight, self.bias, self.stride,
@@ -310,6 +314,8 @@ class Conv3d(_ConvNd):
         dilation (int or tuple, optional): Spacing between kernel elements
         groups (int, optional): Number of blocked connections from input channels to output channels
         bias (bool, optional): If True, adds a learnable bias to the output
+        initializer(dict, optional): dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Shape:
         - Input: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
@@ -340,14 +346,14 @@ class Conv3d(_ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, dilation=1, groups=1, bias=True):
+                 padding=0, dilation=1, groups=1, bias=True, initializer=None):
         kernel_size = _triple(kernel_size)
         stride = _triple(stride)
         padding = _triple(padding)
         dilation = _triple(dilation)
         super(Conv3d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            False, _triple(0), groups, bias)
+            False, _triple(0), groups, bias, initializer)
 
     def forward(self, input):
         return F.conv3d(input, self.weight, self.bias, self.stride,

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -455,7 +455,8 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 initializer=None):
         kernel_size = _single(kernel_size)
         stride = _single(stride)
         padding = _single(padding)
@@ -463,7 +464,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
         output_padding = _single(output_padding)
         super(ConvTranspose1d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            True, output_padding, groups, bias)
+            True, output_padding, groups, bias, initializer)
 
     def forward(self, input, output_size=None):
         output_padding = self._output_padding(input, output_size)
@@ -559,7 +560,8 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 initializer=None):
         kernel_size = _pair(kernel_size)
         stride = _pair(stride)
         padding = _pair(padding)
@@ -567,7 +569,7 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
         output_padding = _pair(output_padding)
         super(ConvTranspose2d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            True, output_padding, groups, bias)
+            True, output_padding, groups, bias, initializer)
 
     def forward(self, input, output_size=None):
         output_padding = self._output_padding(input, output_size)
@@ -656,7 +658,8 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
     """
 
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
-                 padding=0, output_padding=0, groups=1, bias=True, dilation=1):
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 initializer=None):
         kernel_size = _triple(kernel_size)
         stride = _triple(stride)
         padding = _triple(padding)
@@ -664,7 +667,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         output_padding = _triple(output_padding)
         super(ConvTranspose3d, self).__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
-            True, output_padding, groups, bias)
+            True, output_padding, groups, bias, initializer)
 
     def forward(self, input, output_size=None):
         output_padding = self._output_padding(input, output_size)

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -56,7 +56,7 @@ class Linear(Module):
         bias_initializer = self.initializer.get("bias")
 
         weight_initializer(self.weight)
-        if self.bias is None:
+        if self.bias is not None:
             bias_initializer(self.bias)
 
     def forward(self, input):

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -33,7 +33,7 @@ class Linear(Module):
         >>> print(output.size())
     """
 
-    def __init__(self, in_features, out_features, bias=True, initializer=dict()):
+    def __init__(self, in_features, out_features, bias=True, initializer=None):
         super(Linear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
@@ -42,13 +42,13 @@ class Linear(Module):
             self.bias = Parameter(torch.Tensor(out_features))
         else:
             self.register_parameter('bias', None)
-        self.initializer = initializer
+        self.initializer = {} if initializer is None else initializer
         self.reset_parameters()
 
     def reset_parameters(self):
         stdv = 1. / math.sqrt(self.weight.size(1))
 
-        if isinstance(self.initializer, function):
+        if callable(self.initializer):
             weight_initializer = self.initializer
             bias_initializer = None
         else:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -59,7 +59,7 @@ class Linear(Module):
             self.weight.data.uniform_(-stdv, stdv)
         else:
             weight_initializer(self.weight)
-        if self.bias is None:
+        if self.bias is not None:
             if bias_initializer is None:
                 self.bias.data.uniform_(-stdv, stdv)
             else:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -38,32 +38,26 @@ class Linear(Module):
         self.in_features = in_features
         self.out_features = out_features
         self.weight = Parameter(torch.Tensor(out_features, in_features))
+
+        stdv = 1. / math.sqrt(self.weight.size(1))
+        self.initializer = {"weight": lambda x: init.uniform(x, -stdv, stdv)} \
+            if initializer is None else initializer
         if bias:
             self.bias = Parameter(torch.Tensor(out_features))
+            if self.initializer.get("bias") is None:
+                self.initializer["bias"] = lambda x: init.uniform(x, -stdv, stdv)
         else:
             self.register_parameter('bias', None)
-        self.initializer = {} if initializer is None else initializer
         self.reset_parameters()
 
     def reset_parameters(self):
-        stdv = 1. / math.sqrt(self.weight.size(1))
 
-        if callable(self.initializer):
-            weight_initializer = self.initializer
-            bias_initializer = None
-        else:
-            weight_initializer = self.initializer.get("weight")
-            bias_initializer = self.initializer.get("bias")
+        weight_initializer = self.initializer.get("weight")
+        bias_initializer = self.initializer.get("bias")
 
-        if weight_initializer is None:
-            self.weight.data.uniform_(-stdv, stdv)
-        else:
-            weight_initializer(self.weight)
-        if self.bias is not None:
-            if bias_initializer is None:
-                self.bias.data.uniform_(-stdv, stdv)
-            else:
-                bias_initializer(self.bias)
+        weight_initializer(self.weight)
+        if self.bias is None:
+            bias_initializer(self.bias)
 
     def forward(self, input):
         if self.bias is None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -59,10 +59,11 @@ class Linear(Module):
             self.weight.data.uniform_(-stdv, stdv)
         else:
             weight_initializer(self.weight)
-        if bias_initializer is None:
-            self.bias.data.uniform_(-stdv, stdv)
-        else:
-            bias_initializer(self.bias)
+        if self.bias is None:
+            if bias_initializer is None:
+                self.bias.data.uniform_(-stdv, stdv)
+            else:
+                bias_initializer(self.bias)
 
     def forward(self, input):
         if self.bias is None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -39,15 +39,11 @@ class Linear(Module):
         self.out_features = out_features
         self.weight = Parameter(torch.Tensor(out_features, in_features))
 
-        def _initializer(x):
-            stdv = 1. / math.sqrt(self.weight.size(1))
-            return init.uniform(x, -stdv, stdv)
-
-        self.initializer = {"weight": _initializer} if initializer is None else initializer
+        self.initializer = {"weight": self._initializer} if initializer is None else initializer
         if bias:
             self.bias = Parameter(torch.Tensor(out_features))
             if self.initializer.get("bias") is None:
-                self.initializer["bias"] = _initializer
+                self.initializer["bias"] = self._initializer
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()
@@ -126,5 +122,9 @@ class Bilinear(Module):
             + 'in1_features=' + str(self.in1_features) \
             + ', in2_features=' + str(self.in2_features) \
             + ', out_features=' + str(self.out_features) + ')'
+
+    def _initializer(self, x):
+        stdv = 1. / math.sqrt(self.weight.size(1))
+        return init.uniform(x, -stdv, stdv)
 
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -14,7 +14,7 @@ class Linear(Module):
         in_features: size of each input sample
         out_features: size of each output sample
         bias: If set to False, the layer will not learn an additive bias. Default: True
-        initializer: dictionary of initializer of weights and bias. Default: dict()
+        initializer: dictionary of initializer of weights and bias, if None (default), they are uniformly initialized.
 
     Shape:
         - Input: :math:`(N, in\_features)`

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -26,8 +26,7 @@ class Linear(Module):
 
     Examples::
 
-        >>> m = nn.Linear(20, 30, initializer=lambda x: init.xavier_normal(x, 1))
-        >>> m = nn.Linear(20, 30, initializer={"weight": lambda x: init.xavier_normal(x, 1)})
+        >>> m = nn.Linear(20, 30)
         >>> input = autograd.Variable(torch.randn(128, 20))
         >>> output = m(input)
         >>> print(output.size())

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -68,6 +68,10 @@ class Linear(Module):
             + str(self.in_features) + ' -> ' \
             + str(self.out_features) + ')'
 
+    def _initializer(self, x):
+        stdv = 1. / math.sqrt(self.weight.size(1))
+        return init.uniform(x, -stdv, stdv)
+
 
 class Bilinear(Module):
     r"""Applies a bilinear transformation to the incoming data: :math:`y = x_1 * A * x_2 + b`
@@ -122,9 +126,5 @@ class Bilinear(Module):
             + 'in1_features=' + str(self.in1_features) \
             + ', in2_features=' + str(self.in2_features) \
             + ', out_features=' + str(self.out_features) + ')'
-
-    def _initializer(self, x):
-        stdv = 1. / math.sqrt(self.weight.size(1))
-        return init.uniform(x, -stdv, stdv)
 
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -39,13 +39,15 @@ class Linear(Module):
         self.out_features = out_features
         self.weight = Parameter(torch.Tensor(out_features, in_features))
 
-        stdv = 1. / math.sqrt(self.weight.size(1))
-        self.initializer = {"weight": lambda x: init.uniform(x, -stdv, stdv)} \
-            if initializer is None else initializer
+        def _initializer(x):
+            stdv = 1. / math.sqrt(self.weight.size(1))
+            return init.uniform(x, -stdv, stdv)
+
+        self.initializer = {"weight": _initializer} if initializer is None else initializer
         if bias:
             self.bias = Parameter(torch.Tensor(out_features))
             if self.initializer.get("bias") is None:
-                self.initializer["bias"] = lambda x: init.uniform(x, -stdv, stdv)
+                self.initializer["bias"] = _initializer
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -10,7 +10,7 @@ class RNNBase(Module):
 
     def __init__(self, mode, input_size, hidden_size,
                  num_layers=1, bias=True, batch_first=False,
-                 dropout=0, bidirectional=False, initializer=dict()):
+                 dropout=0, bidirectional=False, initializer=None):
         super(RNNBase, self).__init__()
         self.mode = mode
         self.input_size = input_size
@@ -51,13 +51,13 @@ class RNNBase(Module):
                 else:
                     self._all_weights += [weights[:2]]
 
-        self.initializer = initializer
+        self.initializer = {} if initializer is None else initializer
         self.reset_parameters()
 
     def reset_parameters(self):
         stdv = 1.0 / math.sqrt(self.hidden_size)
 
-        if isinstance(self.initializer, function):
+        if callable(self.initializer):
             weight_initializer = self.initializer
             bias_initializer = None
         else:

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -52,13 +52,10 @@ class RNNBase(Module):
                 else:
                     self._all_weights += [weights[:2]]
 
-        def _initializer(x):
-            stdv = 1.0 / math.sqrt(self.hidden_size)
-            return init.uniform(x, -stdv, stdv)
-        self.initializer = {"weight": _initializer} if initializer is None else initializer
+        self.initializer = {"weight": self._initializer} if initializer is None else initializer
 
         if bias and self.initializer.get("bias") is None:
-            self.initializer["bias"] = _initializer
+            self.initializer["bias"] = self._initializer
 
         self.reset_parameters()
 
@@ -141,6 +138,10 @@ class RNNBase(Module):
                     self._all_weights += [weights]
                 else:
                     self._all_weights += [weights[:2]]
+
+    def _initializer(self, x):
+        stdv = 1.0 / math.sqrt(self.hidden_size)
+        return init.uniform(x, -stdv, stdv)
 
     @property
     def all_weights(self):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -172,6 +172,8 @@ class RNN(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        initializer: dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -249,6 +251,8 @@ class LSTM(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        initializer: dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Inputs: input, (h_0, c_0)
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.
@@ -319,6 +323,8 @@ class GRU(RNNBase):
         batch_first: If True, then the input and output tensors are provided as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each RNN layer except the last layer
         bidirectional: If True, becomes a bidirectional RNN. Default: False
+        initializer: dictionary of initializer of weights and bias, if None (default),
+        they are uniformly initialized
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features of the input sequence.

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -52,11 +52,13 @@ class RNNBase(Module):
                 else:
                     self._all_weights += [weights[:2]]
 
-        stdv = 1.0 / math.sqrt(self.hidden_size)
-        self.initializer = {"weight": lambda x: init.uniform(x, -stdv, stdv)} \
-            if initializer is None else initializer
+        def _initializer(x):
+            stdv = 1.0 / math.sqrt(self.hidden_size)
+            return init.uniform(x, -stdv, stdv)
+        self.initializer = {"weight": _initializer} if initializer is None else initializer
+
         if bias and self.initializer.get("bias") is None:
-            self.initializer["bias"] = lambda x: init.uniform(x, -stdv, stdv)
+            self.initializer["bias"] = _initializer
 
         self.reset_parameters()
 


### PR DESCRIPTION
Hi, I thought `nn.init` is great but initializing variables in layers using `nn.init` is a bit complicated. So I try to implement easier way of initialization like below. 

```python
m = nn.Linear(20, 30, initializer=lambda x: init.xavier_normal(x, 1))
```

I do not think this is the best way and thus implemented only for `Linear`. If you think this is useful, give me advice and help me. Thank you.