### PR TITLE
Prevent divide by zero in dropout with p=1

### DIFF
--- a/torch/nn/_functions/dropout.py
+++ b/torch/nn/_functions/dropout.py
@@ -26,9 +26,10 @@ class Dropout(InplaceFunction):
 
         if self.p > 0 and self.train:
             self.noise = self._make_noise(input)
-            self.noise.bernoulli_(1 - self.p).div_(1 - self.p)
             if self.p == 1:
                 self.noise.fill_(0)
+            else:
+                self.noise.bernoulli_(1 - self.p).div_(1 - self.p)
             self.noise = self.noise.expand_as(input)
             output.mul_(self.noise)
 


### PR DESCRIPTION
Ran into this logic problem - because the condition for `self.p == 1` is only checked after `.div_(1 - self.p)`, there's a divide by zero error. Fixed by putting the noise initialisation into an if-else statement.