### PR TITLE
forgotten import in variables.py

### DIFF
--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -4,6 +4,7 @@ import torch._C as _C
 from collections import OrderedDict
 import torch.sparse as sparse
 import torch.utils.hooks as hooks
+import warnings
 
 
 class Variable(_C._VariableBase):


### PR DESCRIPTION
Fixing error on line 661: 
warnings.warn("masked_copy_ is deprecated and renamed to masked_scatter_, and will be removed in v0.3")
NameError: name 'warnings' is not defined