### PR TITLE
Alpha dropout quickfix

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -230,6 +230,12 @@ Non-linear Activations
 .. autoclass:: ELU
     :members:
 
+:hidden:`SELU`
+~~~~~~~~~~~~~
+
+.. autoclass:: SELU
+    :members:
+
 :hidden:`PReLU`
 ~~~~~~~~~~~~~~~
 
@@ -422,6 +428,12 @@ Dropout layers
 ~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: Dropout3d
+    :members:
+
+:hidden:`AlphaDropout`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AlphaDropout
     :members:
 
 
@@ -770,6 +782,11 @@ Non-linear activation functions
 
 .. autofunction:: elu
 
+:hidden:`selu`
+~~~~~~~~~~~~~
+
+.. autofunction:: selu
+
 :hidden:`leaky_relu`
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -863,6 +880,11 @@ Dropout functions
 ~~~~~~~~~~~~~~~~~
 
 .. autofunction:: dropout
+
+:hidden:`alpha_dropout`
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: alpha_dropout
 
 Distance functions
 ----------------------------------

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -408,6 +408,14 @@ def dropout(input, p=0.5, training=False, inplace=False):
 
 
 def alpha_dropout(input, p=0.5, training=False):
+    r"""Applies alpha dropout to the input.
+
+    See :class:`~torch.nn.AlphaDropout` for details.
+
+    Args:
+        p (float, optional): the drop probability
+        training (bool, optional): switch between training and evaluation mode
+    """
     if p < 0 or p > 1:
         raise ValueError("dropout probability has to be between 0 and 1, "
                          "but got {}".format(p))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -417,9 +417,10 @@ def alpha_dropout(input, p=0.5, training=False):
 
     alpha = -1.7580993408473766
     keep_prob = 1 - p
-    noise = input.data.new().byte().resize_(input.size())
+    # TODO avoid casting to byte after resize
+    noise = input.data.new().resize_(input.size())
     noise.bernoulli_(p)
-    noise = Variable(noise)
+    noise = Variable(noise.byte())
 
     output = input.masked_fill(noise, alpha)
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -246,8 +246,9 @@ class ELU(Module):
 
 
 class SELU(Module):
-    """Applies element-wise, :math:`f(x) = scale * (max(0,x) + min(0, alpha * (exp(x) - 1)))`,
-    with alpha=1.6732632423543772848170429916717 and scale=1.0507009873554804934193349852946.
+    """Applies element-wise, :math:`f(x) = scale * (\max(0,x) + \min(0, alpha * (\exp(x) - 1)))`,
+    with ``alpha=1.6732632423543772848170429916717`` and ``scale=1.0507009873554804934193349852946``.
+
     More details can be found in the paper `Self-Normalizing Neural Networks`_ .
 
     Args:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/1785

I didn't go for the route of changing `bernoulli_`/`bernoulli` because it requires further discussion on how to approach it.

Also add docs to SELU and AlphaDropout.