### PR TITLE
fix capitalization of Python, make it consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PyTorch is a Python package that provides two high-level features:
 - Tensor computation (like NumPy) with strong GPU acceleration
 - Deep neural networks built on a tape-based autograd system
 
-You can reuse your favorite python packages such as NumPy, SciPy and Cython to extend PyTorch when needed.
+You can reuse your favorite Python packages such as NumPy, SciPy and Cython to extend PyTorch when needed.
 
 We are in an early-release beta. Expect some adventures and rough edges.
 


### PR DESCRIPTION
Everywhere else in the README it is indeed capitalized.