### PR TITLE
Add batch sampler to DataLoader

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -77,7 +77,7 @@ class TestDataLoader(TestCase):
         errors = 0
         while True:
             try:
-                it.next()
+                next(it)
             except NotImplementedError:
                 errors += 1
             except StopIteration:
@@ -123,6 +123,29 @@ class TestDataLoader(TestCase):
 
     def test_shuffle_batch_workers(self):
         self._test_shuffle(DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4))
+
+    def _test_batch_sampler(self, **kwargs):
+        # [(0, 1), (2, 3, 4), (5, 6), (7, 8, 9), ...]
+        batches = []
+        for i in range(0, 100, 5):
+            batches.append(tuple(range(i, i + 2)))
+            batches.append(tuple(range(i + 2, i + 5)))
+
+        dl = DataLoader(self.dataset, batch_sampler=batches, **kwargs)
+        self.assertEqual(len(dl), 40)
+        for i, (input, _target) in enumerate(dl):
+            if i % 2 == 0:
+                offset = i * 5 // 2
+                self.assertEqual(len(input), 2)
+                self.assertEqual(input, self.data[offset:offset+2])
+            else:
+                offset = i * 5 // 2
+                self.assertEqual(len(input), 3)
+                self.assertEqual(input, self.data[offset:offset+3])
+
+    def test_batch_sampler(self):
+        self._test_batch_sampler()
+        self._test_batch_sampler(num_workers=4)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_shuffle_pin_memory(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -137,11 +137,11 @@ class TestDataLoader(TestCase):
             if i % 2 == 0:
                 offset = i * 5 // 2
                 self.assertEqual(len(input), 2)
-                self.assertEqual(input, self.data[offset:offset+2])
+                self.assertEqual(input, self.data[offset:offset + 2])
             else:
                 offset = i * 5 // 2
                 self.assertEqual(len(input), 3)
-                self.assertEqual(input, self.data[offset:offset+3])
+                self.assertEqual(input, self.data[offset:offset + 3])
 
     def test_batch_sampler(self):
         self._test_batch_sampler()

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1,8 +1,7 @@
 import torch
 import torch.multiprocessing as multiprocessing
-from .sampler import SequentialSampler, RandomSampler
+from .sampler import SequentialSampler, RandomSampler, BatchSampler
 import collections
-import math
 import sys
 import traceback
 import threading
@@ -131,16 +130,13 @@ class DataLoaderIter(object):
 
     def __init__(self, loader):
         self.dataset = loader.dataset
-        self.batch_size = loader.batch_size
         self.collate_fn = loader.collate_fn
-        self.sampler = loader.sampler
+        self.batch_sampler = loader.batch_sampler
         self.num_workers = loader.num_workers
         self.pin_memory = loader.pin_memory
-        self.drop_last = loader.drop_last
         self.done_event = threading.Event()
 
-        self.samples_remaining = len(self.sampler)
-        self.sample_iter = iter(self.sampler)
+        self.sample_iter = iter(self.batch_sampler)
 
         if self.num_workers > 0:
             self.index_queue = multiprocessing.SimpleQueue()
@@ -175,18 +171,11 @@ class DataLoaderIter(object):
                 self._put_indices()
 
     def __len__(self):
-        if self.drop_last:
-            return len(self.sampler) // self.batch_size
-        else:
-            return (len(self.sampler) + self.batch_size - 1) // self.batch_size
+        return len(self.batch_sampler)
 
     def __next__(self):
         if self.num_workers == 0:  # same-process loading
-            if self.drop_last and self.samples_remaining < self.batch_size:
-                raise StopIteration
-            if self.samples_remaining == 0:
-                raise StopIteration
-            indices = self._next_indices()
+            indices = next(self.sample_iter)  # may raise StopIteration
             batch = self.collate_fn([self.dataset[i] for i in indices])
             if self.pin_memory:
                 batch = pin_memory_batch(batch)
@@ -216,21 +205,14 @@ class DataLoaderIter(object):
     def __iter__(self):
         return self
 
-    def _next_indices(self):
-        batch_size = min(self.samples_remaining, self.batch_size)
-        batch = [next(self.sample_iter) for _ in range(batch_size)]
-        self.samples_remaining -= len(batch)
-        return batch
-
     def _put_indices(self):
         assert self.batches_outstanding < 2 * self.num_workers
-        if self.samples_remaining > 0:
-            if self.samples_remaining < self.batch_size and self.drop_last:
-                self._next_indices()
-            else:
-                self.index_queue.put((self.send_idx, self._next_indices()))
-                self.batches_outstanding += 1
-                self.send_idx += 1
+        indices = next(self.sample_iter, None)
+        if indices is None:
+            return
+        self.index_queue.put((self.send_idx, indices))
+        self.batches_outstanding += 1
+        self.send_idx += 1
 
     def _process_next_batch(self, batch):
         self.rcvd_idx += 1
@@ -272,19 +254,23 @@ class DataLoader(object):
             at every epoch (default: False).
         sampler (Sampler, optional): defines the strategy to draw samples from
             the dataset. If specified, the ``shuffle`` argument is ignored.
+        batch_sampler (Sampler, optional): like sampler, but returns a batch of
+            indices at a time. If specified, batch_size, shuffle, sampler, and
+            drop_last are ignored.
         num_workers (int, optional): how many subprocesses to use for data
             loading. 0 means that the data will be loaded in the main process
             (default: 0)
-        collate_fn (callable, optional)
-        pin_memory (bool, optional)
+        collate_fn (callable, optional): merges a list of samples to form a mini-batch.
+        pin_memory (bool, optional): If ``True``, the data loader will copy tensors
+            into CUDA pinned memory before returning them.
         drop_last (bool, optional): set to ``True`` to drop the last incomplete batch,
             if the dataset size is not divisible by the batch size. If False and
             the size of dataset is not divisible by the batch size, then the last batch
             will be smaller. (default: False)
     """
 
-    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, num_workers=0,
-                 collate_fn=default_collate, pin_memory=False, drop_last=False):
+    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None,
+                 num_workers=0, collate_fn=default_collate, pin_memory=False, drop_last=False):
         self.dataset = dataset
         self.batch_size = batch_size
         self.num_workers = num_workers
@@ -292,18 +278,20 @@ class DataLoader(object):
         self.pin_memory = pin_memory
         self.drop_last = drop_last
 
-        if sampler is not None:
-            self.sampler = sampler
-        elif shuffle:
-            self.sampler = RandomSampler(dataset)
-        elif not shuffle:
-            self.sampler = SequentialSampler(dataset)
+        if batch_sampler is not None:
+            self.batch_sampler = batch_sampler
+            self.sampler = None
+        else:
+            if sampler is not None:
+                self.sampler = sampler
+            elif shuffle:
+                self.sampler = RandomSampler(dataset)
+            elif not shuffle:
+                self.sampler = SequentialSampler(dataset)
+            self.batch_sampler = BatchSampler(self.sampler, batch_size, drop_last)
 
     def __iter__(self):
         return DataLoaderIter(self)
 
     def __len__(self):
-        if self.drop_last:
-            return len(self.sampler) // self.batch_size
-        else:
-            return (len(self.sampler) + self.batch_size - 1) // self.batch_size
+        return len(self.batch_sampler)

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -87,3 +87,41 @@ class WeightedRandomSampler(Sampler):
 
     def __len__(self):
         return self.num_samples
+
+
+class BatchSampler(object):
+    """Wraps another sampler to yield a mini-batch of indices.
+
+    Args:
+        sampler (Sampler): Base sampler.
+        batch_size (int): Size of mini-batch.
+        drop_last (bool): If ``True``, the sampler will drop the last batch if
+            its size would be less than ``batch_size``
+
+    Example:
+        >>> list(BatchSampler(range(10), batch_size=3, drop_last=False))
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+        >>> list(BatchSampler(range(10), batch_size=3, drop_last=True))
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+    """
+
+    def __init__(self, sampler, batch_size, drop_last):
+        self.sampler = sampler
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+
+    def __iter__(self):
+        batch = []
+        for idx in self.sampler:
+            batch.append(idx)
+            if len(batch) == self.batch_size:
+                yield batch
+                batch = []
+        if len(batch) > 0 and not self.drop_last:
+            yield batch
+
+    def __len__(self):
+        if self.drop_last:
+            return len(self.sampler) // self.batch_size
+        else:
+            return (len(self.sampler) + self.batch_size - 1) // self.batch_size


### PR DESCRIPTION
The optional batch_sampler argument combines the sampler with the
grouping of indices into mini-batches. This allows for non-standard
batch sizes.

This is important for some sequence to sequence tasks. For example, when [fairseq](https://github.com/facebookresearch/fairseq/) evaluates on the validation or test set, it groups samples into batches only if it would not require padding. This means that some batches may be smaller than the requested batch size. 