### PR TITLE
Remove THCTensor_(expand2) and THCTensor_(expand3).

### DIFF
--- a/torch/lib/THC/generic/THCTensor.c
+++ b/torch/lib/THC/generic/THCTensor.c
@@ -329,65 +329,6 @@ void THCTensor_(expand)(THCState *state, THCTensor *r, THCTensor *tensor, THLong
   THFree(expandedStrides);
 }
 
-void THCTensor_(expand2)(THCState *state, THCTensor *ra, THCTensor *rb, THCTensor *opa, THCTensor *opb)
-{
-  THArgCheck(THCTensor_(nDimension)(state, opa) > 0, 0, "can't expand empty tensor opa");
-  THArgCheck(THCTensor_(nDimension)(state, opb) > 0, 0, "can't expand empty tensor opb");
-
-  THLongStorage *sizes = THLongStorage_new();
-  char error_buffer[1024];
-  int ret = THLongStorage_inferSize2(sizes,
-                                     opa->size, THCTensor_(nDimension)(state, opa),
-                                     opb->size, THCTensor_(nDimension)(state, opb),
-                                     error_buffer, 1024);
-  if(ret != 0) {
-    THLongStorage_free(sizes);
-    THError(error_buffer);
-    return;
-  }
-  THCTensor_(expand)(state, ra, opa, sizes);
-  THCTensor_(expand)(state, rb, opb, sizes);
-
-  THLongStorage_free(sizes);
-}
-
-void THCTensor_(expand3)(THCState *state, THCTensor *ra, THCTensor *rb, THCTensor *rc, THCTensor *opa, THCTensor *opb, THCTensor *opc) {
-  THArgCheck(THCTensor_(nDimension)(state, opa) > 0, 0, "can't expand empty tensor opa");
-  THArgCheck(THCTensor_(nDimension)(state, opb) > 0, 0, "can't expand empty tensor opb");
-  THArgCheck(THCTensor_(nDimension)(state, opc) > 0, 0, "can't expand empty tensor opc");
-
-  long *op_sizes[3];
-  long op_dims[3];
-
-  op_sizes[ 0 ] = opa->size;
-  op_sizes[ 1 ] = opb->size;
-  op_sizes[ 2 ] = opc->size;
-  op_dims[ 0 ] = opa->nDimension;
-  op_dims[ 1 ] = opb->nDimension;
-  op_dims[ 2 ] = opc->nDimension;
-
-  THLongStorage *sizes = THLongStorage_new();
-  char error_buffer[1024];
-  int ret = THLongStorage_inferSizeN(sizes,
-                                     3,
-                                     op_sizes,
-                                     op_dims,
-                                     error_buffer,
-                                     1024);
-
-  if(ret != 0) {
-    THLongStorage_free(sizes);
-    THError(error_buffer);
-    return;
-  }
-
-  THCTensor_(expand)(state, ra, opa, sizes);
-  THCTensor_(expand)(state, rb, opb, sizes);
-  THCTensor_(expand)(state, rc, opc, sizes);
-
-  THLongStorage_free(sizes);
-}
-
 void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src)
 {
   if(self != src)

--- a/torch/lib/THC/generic/THCTensor.h
+++ b/torch/lib/THC/generic/THCTensor.h
@@ -70,8 +70,6 @@ THC_API THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLon
 THC_API THCTensor *THCTensor_(newExpand)(THCState *state, THCTensor *tensor, THLongStorage *size);
 
 THC_API void THCTensor_(expand)(THCState *state, THCTensor *r, THCTensor *tensor, THLongStorage *sizes);
-THC_API void THCTensor_(expand2)(THCState *state, THCTensor *ra, THCTensor *rb, THCTensor *opa, THCTensor *opb);
-THC_API void THCTensor_(expand3)(THCState *state, THCTensor *ra, THCTensor *rb, THCTensor *rc, THCTensor *opa, THCTensor *opb, THCTensor *opc);
 
 THC_API void THCTensor_(resize)(THCState *state, THCTensor *tensor, THLongStorage *size, THLongStorage *stride);
 THC_API void THCTensor_(resizeAs)(THCState *state, THCTensor *tensor, THCTensor *src);


### PR DESCRIPTION
They are no longer needed and the corresponding TH versions have been removed.