### PR TITLE
Broadcast masked_select and implement double backwards for masked_scatter, index_copy, scatter_add, gather

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1857,7 +1857,6 @@ ignore_inplace = set((
 gradgradcheck_exclude_classes = set((
     'Cumprod',
     'Gather',
-    'MaskedScatter',
     'Norm',
     'Prod',
 ))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1857,7 +1857,6 @@ ignore_inplace = set((
 gradgradcheck_exclude_classes = set((
     'Cumprod',
     'Gather',
-    'IndexCopy',
     'Norm',
     'Prod',
 ))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1858,7 +1858,6 @@ ignore_inplace = set((
 
 gradgradcheck_exclude_classes = set((
     'Cumprod',
-    'Gather',
     'Norm',
     'Prod',
 ))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1514,6 +1514,8 @@ function_tests = [
     (Gather, (), ((M, S), 1, gather_variable((M, S // 2), 0, S, True)), 'dim1'),
     (Scatter, (), ((M, S), 0, gather_variable((S, S), 1, M), (S, S))),
     (Scatter, (), ((M, S), 1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1'),
+    (ScatterAdd, (), ((M, S), 0, gather_variable((S, S), 1, M), (S, S))),
+    (ScatterAdd, (), ((M, S), 1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1'),
     (Concat, (), (0, (1, S, S), (2, S, S), (3, S, S))),
     (Concat, (), (-1, (S, S, 1), (S, S, 2), (S, S, 3)), 'negdim-1'),
     (Concat, (), (-2, (S, 1, S), (S, 2, S), (S, 3, S)), 'negdim-2'),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1506,7 +1506,7 @@ function_tests = [
     (Addcdiv, (), ((S, S), (S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_rhs_scale'),
     (Addcdiv, (), ((1,), (S, S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_all_scale'),
     (IndexAdd, (), ((S, S), 0, index_variable(2, S), (2, S))),
-    # (IndexCopy,     (0,),               ((S, S), index_variable(2, S), (2, S))      ),
+    (IndexCopy, (), ((S, S), 0, index_variable(2, S), (2, S))),
     (IndexFill, (), ((S, S), 0, index_variable(2, S), 2)),
     (IndexSelect, (), ((S, S), 0, index_variable(2, S))),
     (Gather, (), ((M, S), 0, gather_variable((S, S), 1, M, True))),
@@ -1857,6 +1857,7 @@ ignore_inplace = set((
 gradgradcheck_exclude_classes = set((
     'Cumprod',
     'Gather',
+    'IndexCopy',
     'Norm',
     'Prod',
 ))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1274,12 +1274,14 @@ def index_variable(shape, max_indices):
     index = torch.rand(*shape).mul_(max_indices).floor_().long()
     return Variable(index, requires_grad=False)
 
+
 def index_perm_variable(shape, max_indices):
     if not isinstance(shape, tuple):
         shape = (shape,)
 
     index = torch.randperm(max_indices).narrow(0, 0, reduce(mul, shape)).view(shape)
     return Variable(index, requires_grad=False)
+
 
 def gather_variable(shape, index_dim, max_indices, duplicate=False):
     assert len(shape) == 2

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1286,6 +1286,14 @@ def gather_variable(shape, index_dim, max_indices, duplicate=False):
     return Variable(index, requires_grad=False)
 
 
+def mask_not_all_zeros(shape):
+    assert len(shape) > 0
+    while True:
+        result = torch.randn(shape).gt(0)
+        if result.sum() > 0:
+            return result
+
+
 def prod_zeros(dim_size, dim_select):
     assert len(dim_select) == 2
     result = torch.randn(dim_size, dim_size, dim_size)
@@ -1545,10 +1553,11 @@ function_tests = [
     (MaskedFill, (), ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False), 10)),
     # no lhs or all broadcast on MaskedFill because it's always inplace
     (MaskedFill, (), ((S, S), Variable(torch.randn(S,).gt(0), requires_grad=False), 10), 'broadcast_rhs'),
-    (MaskedSelect, (), ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False))),
-    (MaskedSelect, (), ((S, S), Variable(torch.randn(S,).gt(0), requires_grad=False)), 'broadcast_rhs'),
-    (MaskedSelect, (), ((S,), Variable(torch.randn(S, S).gt(0), requires_grad=False)), 'broadcast_lhs'),
-    (MaskedSelect, (), ((S, 1, S), Variable(torch.randn(S, S).gt(0), requires_grad=False)), 'broadcast_all'),
+    # ensure the mask isn't all zeros or else we get a tensor with 0 dimensions
+    (MaskedSelect, (), ((S, S), Variable(mask_not_all_zeros((S, S)), requires_grad=False))),
+    (MaskedSelect, (), ((S, S), Variable(mask_not_all_zeros((S,)), requires_grad=False)), 'broadcast_rhs'),
+    (MaskedSelect, (), ((S,), Variable(mask_not_all_zeros((S, S,)), requires_grad=False)), 'broadcast_lhs'),
+    (MaskedSelect, (), ((S, 1, S), Variable(mask_not_all_zeros((S, S)), requires_grad=False)), 'broadcast_all'),
     (Sort, (), ((S, M, S),)),
     (Sort, (), ((S, M, S), 1), 'dim'),
     (Sort, (), ((S, M, S), 1, True), 'dim_desc'),
@@ -1804,10 +1813,10 @@ method_tests = [
     ('unsqueeze', (S, S, S), (0,), 'first', [0]),
     ('unsqueeze', (S, S, S), (1,), 'middle', [0]),
     ('unsqueeze', (S, S, S), (3,), 'last', [0]),
-    ('masked_select', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),)),
-    ('masked_select', (M, M), (Variable(torch.ByteTensor(M,).bernoulli_(), requires_grad=False),), 'broadcast_rhs'),
-    ('masked_select', (M,), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),), 'broadcast_lhs'),
-    ('masked_select', (M, 1, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),),
+    ('masked_select', (M, M), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),)),
+    ('masked_select', (M, M), (Variable(mask_not_all_zeros((M,)), requires_grad=False),), 'broadcast_rhs'),
+    ('masked_select', (M,), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),), 'broadcast_lhs'),
+    ('masked_select', (M, 1, M), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),),
      'broadcast_all'),
     ('masked_fill_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), 10)),
     # no lhs or all broadcast on masked_fill or masked_scatter because it's always inplace

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8,6 +8,8 @@ import warnings
 from copy import deepcopy
 from collections import OrderedDict
 from itertools import product
+from operator import mul
+from functools import reduce
 import torch.nn.functional as F
 from torch.autograd import gradcheck
 from torch.autograd.gradcheck import gradgradcheck
@@ -1272,6 +1274,12 @@ def index_variable(shape, max_indices):
     index = torch.rand(*shape).mul_(max_indices).floor_().long()
     return Variable(index, requires_grad=False)
 
+def index_perm_variable(shape, max_indices):
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+
+    index = torch.randperm(max_indices).narrow(0, 0, reduce(mul, shape)).view(shape)
+    return Variable(index, requires_grad=False)
 
 def gather_variable(shape, index_dim, max_indices, duplicate=False):
     assert len(shape) == 2
@@ -1514,7 +1522,7 @@ function_tests = [
     (Addcdiv, (), ((S, S), (S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_rhs_scale'),
     (Addcdiv, (), ((1,), (S, S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_all_scale'),
     (IndexAdd, (), ((S, S), 0, index_variable(2, S), (2, S))),
-    (IndexCopy, (), ((S, S), 0, index_variable(2, S), (2, S))),
+    (IndexCopy, (), ((S, S), 0, index_perm_variable(2, S), (2, S))),
     (IndexFill, (), ((S, S), 0, index_variable(2, S), 2)),
     (IndexSelect, (), ((S, S), 0, index_variable(2, S))),
     (Gather, (), ((M, S), 0, gather_variable((S, S), 1, M, True))),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -580,6 +580,7 @@ class TestAutograd(TestCase):
             (x.min(y())).sum().backward()
             (x.masked_fill(y() < 0, 0.5)).sum().backward()
             (x.masked_scatter(Variable(y().data < 0.25), z())).sum().backward()
+            (x.masked_select(Variable(y().data < 0.25))).sum().backward()
             (x.addcmul(1, y(), z())).sum().backward()
             (x.addcdiv(1, y(), z())).sum().backward()
             (x.abs() ** y()).sum().backward()
@@ -1543,6 +1544,9 @@ function_tests = [
     # no lhs or all broadcast on MaskedFill because it's always inplace
     (MaskedFill, (), ((S, S), Variable(torch.randn(S,).gt(0), requires_grad=False), 10), 'broadcast_rhs'),
     (MaskedSelect, (), ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False))),
+    (MaskedSelect, (), ((S, S), Variable(torch.randn(S,).gt(0), requires_grad=False)), 'broadcast_rhs'),
+    (MaskedSelect, (), ((S,), Variable(torch.randn(S, S).gt(0), requires_grad=False)), 'broadcast_lhs'),
+    (MaskedSelect, (), ((S, 1, S), Variable(torch.randn(S, S).gt(0), requires_grad=False)), 'broadcast_all'),
     (Sort, (), ((S, M, S),)),
     (Sort, (), ((S, M, S), 1), 'dim'),
     (Sort, (), ((S, M, S), 1, True), 'dim_desc'),
@@ -1799,6 +1803,10 @@ method_tests = [
     ('unsqueeze', (S, S, S), (1,), 'middle', [0]),
     ('unsqueeze', (S, S, S), (3,), 'last', [0]),
     ('masked_select', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),)),
+    ('masked_select', (M, M), (Variable(torch.ByteTensor(M,).bernoulli_(), requires_grad=False),), 'broadcast_rhs'),
+    ('masked_select', (M,), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),), 'broadcast_lhs'),
+    ('masked_select', (M, 1, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False),),
+     'broadcast_all'),
     ('masked_fill_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), 10)),
     # no lhs or all broadcast on masked_fill or masked_scatter because it's always inplace
     ('masked_fill_', (M, M), (Variable(torch.ByteTensor(M,).bernoulli_(), requires_grad=False), 10), 'broadcast_rhs'),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2094,8 +2094,8 @@ masked_select(input, mask, out=None) -> Tensor
 Returns a new 1D `Tensor` which indexes the :attr:`input` `Tensor` according to
 the binary mask :attr:`mask` which is a `ByteTensor`.
 
-The :attr:`mask` tensor needs to have the same number of elements as
-:attr:`input`, but it's shape or dimensionality are irrelevant.
+The shapes of the :attr:`mask` tensor and the :attr:`input` tensor don't need to match,
+but they must be :ref:`broadcastable <broadcasting-semantics>`.
 
 .. note:: The returned `Tensor` does **not** use the same storage as the original `Tensor`
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -109,7 +109,7 @@ def _flatten_tensors(tensors):
     offset = 0
     flat = tensors[0].new(size)
     for tensor, numel in zip(tensors, numels):
-        flat.narrow(0, offset, numel).copy_(tensor)
+        flat.narrow(0, offset, numel).copy_(tensor, broadcast=False)
         offset += numel
     return flat
 

--- a/torch/autograd/_functions/basic_ops.py
+++ b/torch/autograd/_functions/basic_ops.py
@@ -1,5 +1,5 @@
 import torch
-from ..function import Function, InplaceFunction, once_differentiable
+from ..function import Function, InplaceFunction
 from .utils import maybe_unexpand, maybe_unexpand_or_view
 import math
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -527,10 +527,9 @@ class Gather(Function):
         return input.gather(dim, index)
 
     @staticmethod
-    @once_differentiable
     def backward(ctx, grad_output):
-        index, = ctx.saved_tensors
-        grad_input = grad_output.new(ctx.input_size).zero_()
+        index, = ctx.saved_variables
+        grad_input = Variable(grad_output.data.new(ctx.input_size).zero_())
         return grad_input.scatter_add_(ctx.dim, index, grad_output), None, None
 
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -207,7 +207,7 @@ class IndexCopy(InplaceFunction):
             tensor1 = tensor1.clone()
         else:
             ctx.mark_dirty(tensor1)
-        return tensor1.index_copy_(dim, index, tensor2)
+        return tensor1.index_copy_(ctx.dim, index, tensor2)
 
     @staticmethod
     @once_differentiable
@@ -220,7 +220,7 @@ class IndexCopy(InplaceFunction):
         if ctx.needs_input_grad[0]:
             grad_tensor1 = grad_output.clone().index_fill_(ctx.dim, index, 0)
 
-        if ctx.needs_input_grad[2]:
+        if ctx.needs_input_grad[3]:
             grad_tensor2 = grad_output.index_select(ctx.dim, index)
 
         return grad_tensor1, None, None, grad_tensor2, None

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -4,7 +4,7 @@ from torch._utils import _accumulate
 
 from ..function import Function, InplaceFunction, once_differentiable
 from ..variable import Variable
-from .utils import maybe_unexpand, variable_expandable
+from .utils import maybe_unexpand
 
 
 class Index(Function):
@@ -392,9 +392,7 @@ class MaskedScatter(InplaceFunction):
             grad_tensor1 = maybe_unexpand(grad_output.clone().masked_fill_(mask, 0), ctx.tensor1_size)
         if ctx.needs_input_grad[2]:
             grad_tensor2 = grad_output.new(ctx.tensor2_size).zero_()
-            # mask is potentially expanded against tensor1
-            mask_expanded = mask.expand(ctx.tensor1_size) if variable_expandable(mask, ctx.tensor1_size) else mask
-            grad_output.masked_select(mask_expanded, out=grad_tensor2.view(-1))
+            grad_output.masked_select(mask, out=grad_tensor2.view(-1))
             grad_tensor2 = maybe_unexpand(grad_tensor2, ctx.tensor2_size)
         return grad_tensor1, None, grad_tensor2, None
 
@@ -435,8 +433,17 @@ class MaskedSelect(Function):
         mask, = ctx.saved_variables
         grad_tensor = None
         if ctx.needs_input_grad[0]:
-            grad_tensor = Variable(grad_output.data.new(ctx.input_size).zero_())
+            # determine the actual broadcasted sizes used
+            try:
+                new_size = torch._C._infer_size(ctx.input_size, mask.size())
+            except RuntimeError:
+                new_size = None
+
+            # we need to potentitally expand grad_tensor, since it is passed to Variable.masked_scatter, which
+            # eventually is in-place (so can't rely on automatically broadcasting)
+            grad_tensor = Variable(grad_output.data.new(new_size if new_size is not None else ctx.input_size).zero_())
             grad_tensor = grad_tensor.masked_scatter(mask, grad_output)
+            grad_tensor = maybe_unexpand(grad_tensor, ctx.input_size)
         return grad_tensor, None
 
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -384,16 +384,23 @@ class MaskedScatter(InplaceFunction):
         return tensor1.masked_scatter_(mask, tensor2)
 
     @staticmethod
-    @once_differentiable
     def backward(ctx, grad_output):
-        mask, = ctx.saved_tensors
+        mask, = ctx.saved_variables
         grad_tensor1 = grad_tensor2 = None
         if ctx.needs_input_grad[0]:
             grad_tensor1 = maybe_unexpand(grad_output.clone().masked_fill_(mask, 0), ctx.tensor1_size)
         if ctx.needs_input_grad[2]:
-            grad_tensor2 = grad_output.new(ctx.tensor2_size).zero_()
-            grad_output.masked_select(mask, out=grad_tensor2.view(-1))
-            grad_tensor2 = maybe_unexpand(grad_tensor2, ctx.tensor2_size)
+            grad_tensor2 = Variable(grad_output.data.new(ctx.tensor2_size).zero_())
+            mask_selected = grad_output.masked_select(mask)
+            diff_nelem = grad_tensor2.nelement() - mask_selected.nelement()
+            if diff_nelem > 0:
+                # because mask_selected returns a 1-d tensor with size of masked elements that are 1,
+                # we need to fill out the rest with zeros then reshape back to tensor2's size.
+                zeros_fillin = Variable(grad_output.data.new(diff_nelem).zero_())
+                mask_selected = torch.cat((mask_selected, zeros_fillin), 0)
+
+            mask_selected = mask_selected.view(ctx.tensor2_size)
+            grad_tensor2 = maybe_unexpand(mask_selected, ctx.tensor2_size)
         return grad_tensor1, None, grad_tensor2, None
 
 
@@ -439,7 +446,7 @@ class MaskedSelect(Function):
             except RuntimeError:
                 new_size = None
 
-            # we need to potentitally expand grad_tensor, since it is passed to Variable.masked_scatter, which
+            # we need to potentially expand grad_tensor, since it is passed to Variable.masked_scatter, which
             # eventually is in-place (so can't rely on automatically broadcasting)
             grad_tensor = Variable(grad_output.data.new(new_size if new_size is not None else ctx.input_size).zero_())
             grad_tensor = grad_tensor.masked_scatter(mask, grad_output)

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -210,12 +210,11 @@ class IndexCopy(InplaceFunction):
         return tensor1.index_copy_(ctx.dim, index, tensor2)
 
     @staticmethod
-    @once_differentiable
     def backward(ctx, grad_output):
         grad_tensor1 = grad_tensor2 = None
 
         if any(ctx.needs_input_grad):
-            index, = ctx.saved_tensors
+            index, = ctx.saved_variables
 
         if ctx.needs_input_grad[0]:
             grad_tensor1 = grad_output.clone().index_fill_(ctx.dim, index, 0)

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -559,6 +559,30 @@ class Scatter(InplaceFunction):
         return grad_input, None, None, grad_source, None
 
 
+class ScatterAdd(InplaceFunction):
+
+    @staticmethod
+    def forward(ctx, input, dim, index, source, inplace=False):
+        assert not ctx.needs_input_grad[2], "ScatterAdd can't differentiate the index"
+        ctx.dim = dim
+        if inplace:
+            ctx.mark_dirty(input)
+        else:
+            input = input.clone()
+        ctx.save_for_backward(index)
+        return input.scatter_add_(ctx.dim, index, source)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        index, = ctx.saved_variables
+        grad_input = grad_source = None
+        if ctx.needs_input_grad[0]:
+            grad_input = grad_output
+        if ctx.needs_input_grad[3]:
+            grad_source = grad_output.gather(ctx.dim, index)
+        return grad_input, None, None, grad_source, None
+
+
 class Repeat(Function):
 
     @staticmethod

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -654,6 +654,12 @@ class Variable(_C._VariableBase):
     def scatter_(self, dim, index, source):
         return Scatter.apply(self, dim, index, source, True)
 
+    def scatter_add(self, dim, index, source):
+        return ScatterAdd.apply(self, dim, index, source)
+
+    def scatter_add_(self, dim, index, source):
+        return ScatterAdd.apply(self, dim, index, source, True)
+
     def masked_copy(self, mask, variable):
         warnings.warn("masked_copy is deprecated and renamed to masked_scatter, and will be removed in v0.3")
         return MaskedScatter.apply(self, mask, variable)

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -361,7 +361,8 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   arguments:
     - arg: THTensor* result
       output: True
-    - THTensor* self
+    - arg: THTensor* self
+      broadcast: mask fallback types:Byte
     - THBoolTensor* mask
 ]]
 


### PR DESCRIPTION
1) Add broadcasting to masked_select; it was arbitrary that we weren't broadcasting it previously (there is no exact numpy equivalent outside of advanced indexing).  For consistency with similar functions, it's probably better to broadcast it.
2) Implement double backwards of masked_scatter; this is easier with masked_select broadcasting because those two functions are the forward/backwards inverses.