### PR TITLE
Fix assertEquals for lists and tuples

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -200,6 +200,7 @@ class TestCase(unittest.TestCase):
         elif type(x) == set and type(y) == set:
             super(TestCase, self).assertEqual(x, y)
         elif is_iterable(x) and is_iterable(y):
+            super(TestCase, self).assertEqual(len(x), len(y))
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, prec, message)
         else:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3393,7 +3393,7 @@ class TestTorch(TestCase):
             self.assertEqual(c[4], torch.FloatStorage(25).fill_(10), 0)
             c[1].fill_(20)
             self.assertEqual(c[1], c[3], 0)
-            self.assertEqual(c[4], c[5][1:4], 0)
+            self.assertEqual(c[4][1:4], c[5], 0)
 
             # check that serializing the same storage view object unpickles
             # it as one object not two (and vice versa)
@@ -3476,7 +3476,7 @@ class TestTorch(TestCase):
         self.assertEqual(c[4], torch.FloatStorage(25).fill_(10), 0)
         c[1].fill_(20)
         self.assertEqual(c[1], c[3], 0)
-        self.assertEqual(c[4], c[5][1:4], 0)
+        self.assertEqual(c[4][1:4], c[5], 0)
 
     def test_serialization_container(self):
         def import_module(name, filename):


### PR DESCRIPTION
zip finishes once the first iterator is exhausted, so we were erroneously allowing things like `assertEquals([1, 2], [1])` to pass.