### PR TITLE
mark tools as excluded in find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -397,7 +397,7 @@ def make_relative_rpath(path):
 ################################################################################
 
 extensions = []
-packages = find_packages(exclude=('tools.*',))
+packages = find_packages(exclude=('tools', 'tools.*',))
 
 C = Extension("torch._C",
               libraries=main_libraries,


### PR DESCRIPTION
Otherwise 'tools' is included: https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages