### PR TITLE
Speed up torch.matmul for 3D+ x 2D/1D tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1307,6 +1307,24 @@ class TestTorch(TestCase):
     def test_broadcast_batched_matmul(self):
         self._test_broadcast_batched_matmul(self, lambda t: t)
 
+    def test_matmul_out(self):
+
+        def check_matmul(size1, size2):
+            a = torch.randn(size1)
+            b = torch.randn(size2)
+            expected = torch.matmul(a, b)
+
+            out = torch.Tensor(expected.size()).zero_()
+            # make output non-contiguous
+            out = out.transpose(-1, -2).contiguous().transpose(-1, -2)
+            self.assertFalse(out.is_contiguous())
+
+            torch.matmul(a, b, out=out)
+            self.assertEqual(expected, out)
+
+        check_matmul((2, 3, 4), (2, 4, 5))
+        check_matmul((2, 3, 4), (4, 5))
+
     def test_broadcast_copy_fn(self):
         torch.zeros(5, 6).copy_(torch.zeros(6))
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -224,9 +224,9 @@ def matmul(tensor1, tensor2, out=None):
 
         def maybeSqueeze(tensor):
             if dim_tensor1 == 1:
-                return tensor.squeeze_(-2)
+                return tensor.squeeze(-2)
             elif dim_tensor2 == 1:
-                return tensor.squeeze_(-1)
+                return tensor.squeeze(-1)
             else:
                 return tensor
 


### PR DESCRIPTION
If the left tensor is 3D+ and the right tensor is at most 2D, we can
fold the batch into the matrix dimension and use `torch.mm` instead of
`torch.bmm`. In practice, this is faster especially if the right tensor is
column major.

See micro-benchmark at:
https://gist.github.com/colesbury/b230e68f548b72bef791685aad72db83