### PR TITLE
Improve error message when accessing attributes that don't exist

### DIFF
--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -61,7 +61,7 @@ class Variable(_C._VariableBase):
     def __getattr__(self, name):
         if name in self._fallthrough_methods:
             return getattr(self.data, name)
-        raise AttributeError(name)
+        return object.__getattribute__(self, name)
 
     def __getitem__(self, key):
         if torch.is_tensor(key):


### PR DESCRIPTION
New:
```
   >>> torch.autograd.Variable(torch.randn(3, 3)).foobar
   AttributeError: 'Variable' object has no attribute 'foobar'
```

Old:
```
   >>> torch.autograd.Variable(torch.randn(3, 3)).foobar
   AttributeError: foobar
```