### PR TITLE
Fix race conditions on SpatialConvolutionMM

### DIFF
--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -1342,6 +1342,7 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
     m2_ = THTensor_(newContiguous)(m2);
   }
 
+#pragma omp critical(blasgemm)
   /* do the operation */
   THBlas_(gemm)(transpose_m1,
                 transpose_m2,

--- a/torch/lib/THNN/generic/SpatialConvolutionMM.c
+++ b/torch/lib/THNN/generic/SpatialConvolutionMM.c
@@ -174,6 +174,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
       THTensor *output_t = THTensor_(newSelect)(output, 0, t);
       THTensor *finput_t = THTensor_(newSelect)(finput, 0, t);
 
+#pragma omp critical(updateOutputFrame)
       THNN_(SpatialConvolutionMM_updateOutput_frame)
 	(input_t, output_t, weight, bias, finput_t,
 	 kW, kH, dW, dH, padW, padH,
@@ -268,6 +269,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
       THTensor *gradOutput_t = THTensor_(newSelect)(gradOutput, 0, t);
       THTensor *fgradInput_t = THTensor_(newSelect)(fgradInput, 0, t);
 
+#pragma omp critical(updateGradInputFrame)
       THNN_(SpatialConvolutionMM_updateGradInput_frame)(gradInput_t, gradOutput_t,
 							tweight, fgradInput_t,
 							kW, kH, dW, dH, padW, padH);

--- a/torch/lib/THNN/generic/SpatialConvolutionMM.c
+++ b/torch/lib/THNN/generic/SpatialConvolutionMM.c
@@ -174,7 +174,6 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
       THTensor *output_t = THTensor_(newSelect)(output, 0, t);
       THTensor *finput_t = THTensor_(newSelect)(finput, 0, t);
 
-#pragma omp critical(updateOutputFrame)
       THNN_(SpatialConvolutionMM_updateOutput_frame)
 	(input_t, output_t, weight, bias, finput_t,
 	 kW, kH, dW, dH, padW, padH,
@@ -269,7 +268,6 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
       THTensor *gradOutput_t = THTensor_(newSelect)(gradOutput, 0, t);
       THTensor *fgradInput_t = THTensor_(newSelect)(fgradInput, 0, t);
 
-#pragma omp critical(updateGradInputFrame)
       THNN_(SpatialConvolutionMM_updateGradInput_frame)(gradInput_t, gradOutput_t,
 							tweight, fgradInput_t,
 							kW, kH, dW, dH, padW, padH);


### PR DESCRIPTION
In ppc64le, when running testNN's convolution tests sometimes a precision assertion failed.
Fixes #1380