### PR TITLE
Avoid two unnecessary copies in addmm backward

### DIFF
--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -1493,7 +1493,7 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
 
   if (t != result) {
     THTensor_(resizeAs)(result, t);
-    if (beta != 0) {
+    if (beta != 0.0) {
       THTensor_(copy)(result, t);
     }
   }

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -1279,7 +1279,9 @@ void THTensor_(addmm)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor
   if(t != r_)
   {
     THTensor_(resizeAs)(r_, t);
-    THTensor_(copy)(r_, t);
+    if (beta != 0.0) {
+      THTensor_(copy)(r_, t);
+    }
   }
 
   /* r_ */
@@ -1448,7 +1450,9 @@ void THTensor_(addbmm)(THTensor *result, real beta, THTensor *t, real alpha, THT
 
   if (t != result) {
     THTensor_(resizeAs)(result, t);
-    THTensor_(copy)(result, t);
+    if (beta != 0.0) {
+      THTensor_(copy)(result, t);
+    }
   }
 
   THTensor *matrix1 = THTensor_(new)();
@@ -1489,7 +1493,9 @@ void THTensor_(baddbmm)(THTensor *result, real beta, THTensor *t, real alpha, TH
 
   if (t != result) {
     THTensor_(resizeAs)(result, t);
-    THTensor_(copy)(result, t);
+    if (beta != 0) {
+      THTensor_(copy)(result, t);
+    }
   }
 
   THTensor *matrix1 = THTensor_(new)();

--- a/torch/lib/THC/generic/THCTensorMathBlas.cu
+++ b/torch/lib/THC/generic/THCTensorMathBlas.cu
@@ -121,7 +121,7 @@ THCTensor_(addmv)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
 
     THCTensor_(addmm)(state, r_, beta, tAsMatrix, alpha, mat, vecAsMatrix);
 
-    // r_ will have answer as matrix, need to return a vecotr
+    // r_ will have answer as matrix, need to return a vector
     THCTensor_(resize1d)(state, r_, r_->size[0]);
     THCTensor_(free)(state, vecAsMatrix);
     THCTensor_(free)(state, tAsMatrix);
@@ -245,7 +245,9 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   if(t != r_)
   {
     THCTensor_(resizeAs)(state, r_, t);
-    THCTensor_(copy)(state, r_, t);
+    if (ScalarConvert<real, double>::to(beta) != 0.0) {
+      THCTensor_(copy)(state, r_, t);
+    }
   }
 
   /* r_ */
@@ -402,7 +404,9 @@ THCTensor_(addbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
 
   if (t != result) {
     THCTensor_(resizeAs)(state, result, t);
-    THCTensor_(copy)(state, result, t);
+    if (ScalarConvert<real, double>::to(beta) != 0.0) {
+      THCTensor_(copy)(state, result, t);
+    }
   }
 
   THCTensor *slice1 = THCTensor_(new)(state);
@@ -450,7 +454,9 @@ THCTensor_(baddbmm)(THCState *state, THCTensor *result, real beta, THCTensor *t,
 
   if (t != result) {
     THCTensor_(resizeAs)(state, result, t);
-    THCTensor_(copy)(state, result, t);
+    if (ScalarConvert<real, double>::to(beta) != 0.0) {
+      THCTensor_(copy)(state, result, t);
+    }
   }
 
   bool transpose_result;


### PR DESCRIPTION
The `r_` and `t` tensors become different objects, even though they point to the same data. Avoid the copy whenever beta=0.

cc @ngimel 