### PR TITLE
Fix __iter__ for empty tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3814,6 +3814,9 @@ class TestTorch(TestCase):
         for i, sub in enumerate(x):
             self.assertEqual(sub, x[i])
 
+        x = torch.Tensor()
+        self.assertEqual(list(x), [])
+
     def test_accreal_type(self):
         x = torch.randn(2, 3, 4) * 10
         self.assertIsInstance(x.double().sum(), float)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -146,7 +146,10 @@ class _TensorBase(object):
     __nonzero__ = __bool__
 
     def __iter__(self):
-        return iter(map(lambda i: self.select(0, i), _range(self.size(0))))
+        if self.nelement() > 0:
+            return iter(map(lambda i: self.select(0, i), _range(self.size(0))))
+        else:
+            return iter([])
 
     def split(self, split_size, dim=0):
         """Splits this tensor into a tuple of tensors.


### PR DESCRIPTION
In response to issue #1952 calling `list` on an empty tensor throws a runtime error instead of returning `[]` whereas `torch.Tensor().tolist()` works fine.