### PR TITLE
add shape alias

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -97,6 +97,14 @@ class _TensorBase(object):
         """
         return self.storage().is_shared()
 
+    @property
+    def shape(self):
+        """Alias for .size()
+
+        Returns a torch.Size object, containing the dimensions of the tensor
+        """
+        return self.size()
+
     def __deepcopy__(self, _memo):
         memo = _memo.setdefault('torch', {})
         if self._cdata in memo:


### PR DESCRIPTION
Usage:

```
a = torch.rand(3, 2)
print(a.shape)
```
(consistent with how `numpy` works, and addresses https://github.com/pytorch/pytorch/issues/1980 )