### PR TITLE
Conv double backward groups

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2442,9 +2442,9 @@ class TestNN(NNTestCase):
 
     def test_conv_double_backward(self):
         batch_size = 2
-        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1]), (4, 9, [1]), (4, 10, [1, 2])]:
+        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1]), (4, 9, [1])]:
             for stride, padding, chan_in, chan_out, dilation in \
-                    product([1, 2], [0, 2], [2], [2, 3], dilations):
+                    product([1, 2], [0, 2], [2], [3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
                                                         padding, chan_in, chan_out,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2399,7 +2399,7 @@ class TestNN(NNTestCase):
 
         x = Variable(tensor.new(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
         x.data.normal_()
-        weight = Variable(tensor.new(chan_out, int(chan_in/groups), kern, kern), requires_grad=True)
+        weight = Variable(tensor.new(chan_out, chan_in // groups, kern, kern), requires_grad=True)
         weight.data.normal_()
         if use_bias:
             bias = Variable(tensor.new(chan_out), requires_grad=True)
@@ -2443,10 +2443,11 @@ class TestNN(NNTestCase):
     def test_conv_double_backward(self):
         batch_size = 2
         for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
-            for stride, padding, chan_in, groups, chan_out, dilation in product([1, 2], [0, 2], [2], [1,2], [2, 3], dilations):
+            for stride, padding, chan_in, groups, chan_out, dilation in \
+                    product([1, 2], [0, 2], [2], [1, 2], [2, 3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
-                                                        padding, chan_in*groups, chan_out*groups,
+                                                        padding, chan_in * groups, chan_out * groups,
                                                         batch_size, inp_size, dilation,
                                                         no_weight, groups=groups)
                 self.assertTrue(result,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2442,14 +2442,14 @@ class TestNN(NNTestCase):
 
     def test_conv_double_backward(self):
         batch_size = 2
-        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
-            for stride, padding, chan_in, groups, chan_out, dilation in \
-                    product([1, 2], [0, 2], [2], [1, 2], [2, 3], dilations):
+        for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1]), (4, 9, [1]), (4, 10, [1, 2])]:
+            for stride, padding, chan_in, chan_out, dilation in \
+                    product([1, 2], [0, 2], [2], [2, 3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
-                                                        padding, chan_in * groups, chan_out * groups,
+                                                        padding, chan_in, chan_out,
                                                         batch_size, inp_size, dilation,
-                                                        no_weight, groups=groups)
+                                                        no_weight)
                 self.assertTrue(result,
                                 "Conv double backward test failed with parameters:" +
                                 "\nkern: " + str(kern) +
@@ -2459,8 +2459,7 @@ class TestNN(NNTestCase):
                                 "\nchan_out: " + str(chan_out) +
                                 "\nbatch_size: " + str(batch_size) +
                                 "\ninp_size: " + str(inp_size) +
-                                "\ndilation: " + str(dilation) +
-                                "\ngroups: " + str(groups))
+                                "\ndilation: " + str(dilation))
 
     def test_conv_double_backward_no_bias(self):
         kern = 3
@@ -2487,12 +2486,38 @@ class TestNN(NNTestCase):
                         "\ninp_size: " + str(inp_size) +
                         "\ndilation: " + str(dilation))
 
+    def test_conv_double_backward_groups(self):
+        kern = 3
+        stride = 1
+        padding = 2
+        chan_in, chan_out = 2, 4
+        batch_size = 2
+        inp_size = 6
+        dilation = 1
+        no_weight = False
+        groups = 2
+        result = self.run_conv_double_back_test(kern, stride,
+                                                padding, chan_in * groups, chan_out * groups,
+                                                batch_size, inp_size, dilation,
+                                                no_weight, groups=groups)
+        self.assertTrue(result,
+                        "Conv double backward test failed with parameters:" +
+                        "\nkern: " + str(kern) +
+                        "\nstride: " + str(stride) +
+                        "\npadding: " + str(padding) +
+                        "\nchan_in: " + str(chan_in) +
+                        "\nchan_out: " + str(chan_out) +
+                        "\nbatch_size: " + str(batch_size) +
+                        "\ninp_size: " + str(inp_size) +
+                        "\ndilation: " + str(dilation) +
+                        "\ngroups: " + str(groups))
+
     def test_error_conv_double_backward(self):
         batch_size = 2
 
         # Cannot provide ggW when stride is > 1
-        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1, 2]), (4, 6, [1]), (4, 7, [2])]:
-            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1, 2], [1, 3], [1, 3], dilations):
+        for kern, inp_size, dilations in [(3, 5, [1, 2]), (3, 7, [1])]:
+            for stride, padding, chan_in, chan_out, dilation in product([2], [0, 1], [1], [2], dilations):
                 no_weight = False
                 with self.assertRaises(RuntimeError):
                     self.run_conv_double_back_test(kern, stride,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2392,14 +2392,14 @@ class TestNN(NNTestCase):
                                           (input1_1, input2_1))
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size,
-                                  inp_size, dilation, no_weight, use_cuda=False, use_bias=True):
+                                  inp_size, dilation, no_weight, groups=1, use_cuda=False, use_bias=True):
         tensor = torch.Tensor(1)
         if use_cuda:
             tensor = tensor.cuda()
 
         x = Variable(tensor.new(batch_size, chan_in, inp_size, inp_size), requires_grad=True)
         x.data.normal_()
-        weight = Variable(tensor.new(chan_out, chan_in, kern, kern), requires_grad=True)
+        weight = Variable(tensor.new(chan_out, int(chan_in/groups), kern, kern), requires_grad=True)
         weight.data.normal_()
         if use_bias:
             bias = Variable(tensor.new(chan_out), requires_grad=True)
@@ -2423,7 +2423,7 @@ class TestNN(NNTestCase):
                     lbias = None
             # We disable cudnn during forward to avoid finite difference imprecision issues
             with use_cudnn(False):
-                out = F.conv2d(lx, lweight, lbias, stride, padding, dilation)
+                out = F.conv2d(lx, lweight, lbias, stride, padding, dilation, groups)
             return out
 
         if no_weight:
@@ -2443,12 +2443,12 @@ class TestNN(NNTestCase):
     def test_conv_double_backward(self):
         batch_size = 2
         for kern, inp_size, dilations in [(3, 6, [1, 2]), (3, 7, [1, 2]), (4, 9, [1, 2]), (4, 10, [1, 2])]:
-            for stride, padding, chan_in, chan_out, dilation in product([1, 2], [0, 2], [1], [2, 3], dilations):
+            for stride, padding, chan_in, groups, chan_out, dilation in product([1, 2], [0, 2], [2], [1,2], [2, 3], dilations):
                 no_weight = stride == 2
                 result = self.run_conv_double_back_test(kern, stride,
-                                                        padding, chan_in, chan_out,
+                                                        padding, chan_in*groups, chan_out*groups,
                                                         batch_size, inp_size, dilation,
-                                                        no_weight)
+                                                        no_weight, groups=groups)
                 self.assertTrue(result,
                                 "Conv double backward test failed with parameters:" +
                                 "\nkern: " + str(kern) +
@@ -2458,7 +2458,8 @@ class TestNN(NNTestCase):
                                 "\nchan_out: " + str(chan_out) +
                                 "\nbatch_size: " + str(batch_size) +
                                 "\ninp_size: " + str(inp_size) +
-                                "\ndilation: " + str(dilation))
+                                "\ndilation: " + str(dilation) +
+                                "\ngroups: " + str(groups))
 
     def test_conv_double_backward_no_bias(self):
         kern = 3

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -259,6 +259,8 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   addClass<Expand, NoCtor>(module, ExpandClass, "Expand");
   static PyTypeObject NarrowClass;
   addClass<Narrow, NoCtor>(module, NarrowClass, "Narrow");
+  static PyTypeObject CatClass;
+  addClass<Cat, NoCtor>(module, CatClass, "Cat");
 
   THPObjectPtr parent(PyImport_ImportModule("torch._C"));
   if (!parent) return false;

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -87,4 +87,25 @@ auto Narrow::apply(const variable_list& inputs) -> variable_list {
   });
 }
 
+auto Cat::apply(const variable_list& inputs) -> variable_list {
+  int num_inputs = inputs.size();
+  if (num_inputs == 0) {
+    throw std::runtime_error("Cat operation expect at least one argument.");
+  }
+
+  auto& input = inputs[0]->data;
+  AutoGPU guard(input->getDevice());
+
+  std::vector<thpp::Tensor*> ptrs(num_inputs);
+  for (int i = 0; i < num_inputs; ++i) {
+    ptrs[i] = inputs[i]->data.get();
+  }
+  auto output = inputs[0]->data->newTensor();
+  output->cat(ptrs, dim);
+
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+    return std::make_shared<Error>("Cat is not differentiable", std::move(f));
+  });
+}
+
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -70,6 +70,15 @@ struct Narrow : public Function {
   long size;
 };
 
+struct Cat : public Function {
+  Cat(long dim)
+    : dim(dim) {}
+
+  virtual variable_list apply(const variable_list& inputs) override;
+
+  long dim;
+};
+
 }}
 
 


### PR DESCRIPTION
Fixes #1972 

@apaszke I am starting to worry that the conv double backward test are taking too much time because they test all possible combination of parameters.
If you think this is a problem, maybe I could leave a subset of these tests (most common cases only) in `test_nn.py` and move the complete tests to a separate file? I am not sure if it's a good solution though.