### PR TITLE
Make grad_output contiguous in cudnn path for batchnorm

### DIFF
--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -127,6 +127,8 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
     }
   }
 
+  auto grad_output = grad_outputs[0]->data->contiguous();
+
   if (use_cudnn && eps >= CUDNN_BN_MIN_EPSILON) {
 #ifdef WITH_CUDNN
     torch::cudnn::cudnn_batch_norm_backward(
@@ -134,7 +136,7 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
         torch::cudnn::getCudnnHandle(),
         torch::cudnn::getCudnnDataType(*input),
         (THVoidTensor*)input->cdata(),
-        (THVoidTensor*)grad_outputs[0]->data->cdata(),
+        (THVoidTensor*)grad_output->cdata(),
         (THVoidTensor*)grad_input->cdata(),
         (THVoidTensor*)grad_weight->cdata(),
         (THVoidTensor*)grad_bias->cdata(),
@@ -147,7 +149,6 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
         eps);
 #endif
   } else {
-    auto grad_output = grad_outputs[0]->data->contiguous();
     torch::nn::BatchNormalization_backward(
         input.get(),
         grad_output.get(),

--- a/torch/csrc/cudnn/BatchNorm.cpp
+++ b/torch/csrc/cudnn/BatchNorm.cpp
@@ -81,6 +81,7 @@ void cudnn_batch_norm_forward(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
   if (training) {
+    THVoidTensor_assertContiguous(input);
     THVoidTensor_assertContiguous(bias);
     THVoidTensor_assertContiguous(running_mean);
     THVoidTensor_assertContiguous(running_var);
@@ -99,6 +100,7 @@ void cudnn_batch_norm_forward(
       tensorPointer(dataType, save_mean),
       tensorPointer(dataType, save_var)));
   } else {
+    THVoidTensor_assertContiguous(input);
     THVoidTensor_assertContiguous(bias);
     THVoidTensor_assertContiguous(running_mean);
     THVoidTensor_assertContiguous(running_var);
@@ -131,6 +133,13 @@ void cudnn_batch_norm_backward(
     mode = CUDNN_BATCHNORM_SPATIAL;
   }
 
+  THVoidTensor_assertContiguous(input);
+  THVoidTensor_assertContiguous(grad_output);
+  THVoidTensor_assertContiguous(grad_weight);
+  THVoidTensor_assertContiguous(grad_bias);
+  THVoidTensor_assertContiguous(save_mean);
+  THVoidTensor_assertContiguous(save_var);
+
   TensorDescriptor idesc;  // input descriptor
   TensorDescriptor odesc;  // output descriptor
   TensorDescriptor gdesc;  // grad_input descriptor
@@ -142,10 +151,7 @@ void cudnn_batch_norm_backward(
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
-  THVoidTensor_assertContiguous(grad_weight);
-  THVoidTensor_assertContiguous(grad_bias);
-  THVoidTensor_assertContiguous(save_mean);
-  THVoidTensor_assertContiguous(save_var);
+
   CHECK(cudnnBatchNormalizationBackward(
     handle, mode, &one, &zero, &one, &zero,
     idesc.desc, tensorPointer(dataType, input),


### PR DESCRIPTION
Also added asserts that the input is contiguous (similar to the THNN path).

This is a fix for issue #1866 and #603 

Note I also moved all of the asserts in `torch/csrc/cudnn/BatchNorm.cpp` before the `setInputDescriptor` calls, as the `setInputDescriptor` computes the stride (and was crashing on non-contiguous inputs)