### PR TITLE
Add comments for readability

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -654,6 +654,9 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch.
+        ignore_index (int, optional): Specifies a target value that is ignored
+                and does not contribute to the input gradient. When size_average is
+                True, the loss is averaged over non-ignored targets.
     """
     return nll_loss(log_softmax(input), target, weight, size_average, ignore_index)
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -394,11 +394,20 @@ class CrossEntropyLoss(_WeightedLoss):
         loss(x, class) = weights[class] * (-x[class] + log(\sum_j exp(x[j])))
 
     The losses are averaged across observations for each minibatch.
-
+    
+    Args:
+        weight (Tensor, optional): a manual rescaling weight given to each class.
+           If given, has to be a Tensor of size "nclasses"
+        size_average (bool, optional): By default, the losses are averaged over observations for each minibatch.
+           However, if the field size_average is set to False, the losses are
+           instead summed for each minibatch.
+        ignore_index (int, optional): Specifies a target value that is ignored
+            and does not contribute to the input gradient. When size_average is
+            True, the loss is averaged over non-ignored targets.
+            
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
-        - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
-
+        - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1
     """
 
     def __init__(self, weight=None, size_average=True, ignore_index=-100):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -394,7 +394,7 @@ class CrossEntropyLoss(_WeightedLoss):
         loss(x, class) = weights[class] * (-x[class] + log(\sum_j exp(x[j])))
 
     The losses are averaged across observations for each minibatch.
-    
+
     Args:
         weight (Tensor, optional): a manual rescaling weight given to each class.
            If given, has to be a Tensor of size "nclasses"
@@ -404,7 +404,7 @@ class CrossEntropyLoss(_WeightedLoss):
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average is
             True, the loss is averaged over non-ignored targets.
-            
+
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
         - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1


### PR DESCRIPTION
Added comments for index_ignore arguments in cross_entropy loss function. Also copied comments for the arguments in nn.NLLLoss and pasted them into nn.CrossEntropy. This will help users to understand nn.CrossEntropy easily.