### PR TITLE
Add HalfTensor to documentation

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -13,7 +13,7 @@ Data type                CPU tensor                    GPU tensor
 ======================== ===========================   ================================
 32-bit floating point    :class:`torch.FloatTensor`    :class:`torch.cuda.FloatTensor`
 64-bit floating point    :class:`torch.DoubleTensor`   :class:`torch.cuda.DoubleTensor`
-16-bit floating point    N/A                           :class:`torch.cuda.HalfTensor`
+16-bit floating point    :class:`torch.HalfTensor`     :class:`torch.cuda.HalfTensor`
 8-bit integer (unsigned) :class:`torch.ByteTensor`     :class:`torch.cuda.ByteTensor`
 8-bit integer (signed)   :class:`torch.CharTensor`     :class:`torch.cuda.CharTensor`
 16-bit integer (signed)  :class:`torch.ShortTensor`    :class:`torch.cuda.ShortTensor`


### PR DESCRIPTION
The ```torch.Tensor``` page listed FP16 CPU Tensor as N/A, so this patch changes it to ```torch.HalfTensor```. 
Could not find any other relevant pages to add HalfTensor to, but can add those as well.

Issue mentioned in https://github.com/pytorch/pytorch/issues/2014