### PR TITLE
support dictionary return types in nn.Module's __call__

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -520,6 +520,10 @@ class TestNN(NNTestCase):
             def __init__(self):
                 super(Net, self).__init__()
                 self.l1 = l
+                self.register_backward_hook(self.hook)
+
+            def hook(self, module, grad_out, grad_in):
+                pass
 
             def forward(self, inputs):
                 return {"output": self.l1(inputs)}

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -526,7 +526,7 @@ class TestNN(NNTestCase):
 
         l = nn.Linear(10, 20)
         net = Net()
-        data = torch.randn(5, 10)
+        data = Variable(torch.randn([5, 10]))
         net(data)
 
     def test_children(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -532,8 +532,8 @@ class TestNN(NNTestCase):
         l = nn.Linear(10, 20)
         net = Net()
         data = Variable(torch.randn([5, 10]))
-        output = net(data)
-        output.backward()
+        model_output = net(data)
+        model_output["output"].backward()
         assert net.check_backward_hook_flag
 
     def test_children(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -519,7 +519,7 @@ class TestNN(NNTestCase):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
-                self.l1 = l
+                self.l1 = nn.Linear(10, 20)
                 self.register_backward_hook(self.hook)
                 self.check_backward_hook_flag = False
 
@@ -529,12 +529,10 @@ class TestNN(NNTestCase):
             def forward(self, inputs):
                 return {"output": self.l1(inputs).sum()}
 
-        l = nn.Linear(10, 20)
         net = Net()
-        data = Variable(torch.randn([5, 10]))
-        model_output = net(data)
+        model_output = net(Variable(torch.randn([5, 10]))
         model_output["output"].backward()
-        assert net.check_backward_hook_flag
+        self.assertTrue(net.check_backward_hook_flag)
 
     def test_children(self):
         l1 = nn.Linear(2, 2)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -521,8 +521,8 @@ class TestNN(NNTestCase):
                 super(Net, self).__init__()
                 self.l1 = l
 
-            def forward(self, *input):
-                return {"output": self.l1(input)}
+            def forward(self, inputs):
+                return {"output": self.l1(inputs)}
 
         l = nn.Linear(10, 20)
         net = Net()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -521,9 +521,10 @@ class TestNN(NNTestCase):
                 super(Net, self).__init__()
                 self.l1 = l
                 self.register_backward_hook(self.hook)
+                self.check_backward_hook_flag = False
 
             def hook(self, module, grad_out, grad_in):
-                pass
+                self.check_backward_hook_flag = True
 
             def forward(self, inputs):
                 return {"output": self.l1(inputs)}
@@ -531,7 +532,9 @@ class TestNN(NNTestCase):
         l = nn.Linear(10, 20)
         net = Net()
         data = Variable(torch.randn([5, 10]))
-        net(data)
+        output = net(data)
+        output.backward()
+        assert net.check_backward_hook_flag
 
     def test_children(self):
         l1 = nn.Linear(2, 2)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -527,7 +527,7 @@ class TestNN(NNTestCase):
                 self.check_backward_hook_flag = True
 
             def forward(self, inputs):
-                return {"output": self.l1(inputs)}
+                return {"output": self.l1(inputs).sum()}
 
         l = nn.Linear(10, 20)
         net = Net()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -515,6 +515,20 @@ class TestNN(NNTestCase):
         self.assertEqual(num_params(n), 3)
         self.assertEqual(num_params(s), 3)
 
+    def test_call_supports_python_dict_output(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.l1 = l
+
+            def forward(self, *input):
+                return {"output": self.l1(input)}
+
+        l = nn.Linear(10, 20)
+        net = Net()
+        data = torch.randn(5, 10)
+        net(data)
+
     def test_children(self):
         l1 = nn.Linear(2, 2)
         l2 = nn.Linear(2, 2)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -530,7 +530,7 @@ class TestNN(NNTestCase):
                 return {"output": self.l1(inputs).sum()}
 
         net = Net()
-        model_output = net(Variable(torch.randn([5, 10]))
+        model_output = net(Variable(torch.randn([5, 10])))
         model_output["output"].backward()
         self.assertTrue(net.check_backward_hook_flag)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -232,7 +232,10 @@ class Module(object):
         if len(self._backward_hooks) > 0:
             var = result
             while not isinstance(var, Variable):
-                var = var[0]
+                if isinstance(var, dict):
+                    var = list(var.values())[0]
+                else:
+                    var = var[0]
             grad_fn = var.grad_fn
             if grad_fn is not None:
                 for hook in self._backward_hooks.values():

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -233,7 +233,7 @@ class Module(object):
             var = result
             while not isinstance(var, Variable):
                 if isinstance(var, dict):
-                    var = list(var.values())[0]
+                    var = next((v for v in var.values() if isinstance(v, Variable)))
                 else:
                     var = var[0]
             grad_fn = var.grad_fn


### PR DESCRIPTION
using `__call__` currently throws an error if the return type of `forward` is a `dict`. It would be useful to be able to return complex outputs with names - this PR just hooks the backward hooks onto an arbitrary element of the return dict (I assumed this was ok because previously the hook is just registered to the first element returned from `forward`). Let me know if i've put the test in the wrong place/ you would like it to be different. 

Thanks!