### PR TITLE
Advanced Indexing: Calculate linear offsets directly on the GPU when working with CUDA Tensors

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -931,9 +931,9 @@ static THIndexTensor* THPTensor_(_calculateLinearIndices)(
   THTensor_(calculateAdvancedIndexingOffsets)(LIBRARY_STATE cudaIndices, indexed, baseOffset, indexers);
 
   // Free the indexers
-  for (int i = 0; i < THTensor_(nDimension)(LIBRARY_STATE indexed.get(); ++i) {
+  for (int i = 0; i < THTensor_(nDimension)(LIBRARY_STATE indexed.get()); ++i) {
     if (indexers[i] != NULL) {
-      THCudaLongTensor_free(indexers[i]);
+      THCudaLongTensor_free(LIBRARY_STATE indexers[i]);
     }
   }
   return cudaIndices;

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -913,8 +913,8 @@ static THIndexTensor* THPTensor_(_calculateLinearIndices)(
 
   // Need to pass broadcast Tensors to API, pass NULL ptr for all empty
   // (i.e. not-advanced indexed) dims
-  std::vector<THCudaLongTensor *> indexers;
-  indexers.reserve(THTensor_(nDimension)(LIBRARY_STATE indexed.get()));
+  std::vector<THCudaLongTensor *> indexers(
+      THTensor_(nDimension)(LIBRARY_STATE indexed.get()), NULL);
 
   // Count the number of advanced indexers, and set the pointers to NULL for
   // those that are not advanced indexing dims
@@ -922,8 +922,6 @@ static THIndexTensor* THPTensor_(_calculateLinearIndices)(
   for (int i = 0; i < THTensor_(nDimension)(LIBRARY_STATE indexed.get()); ++i) {
     if (flattenedBroadcasters.count(i) > 0) {
       ++advancedIndexers;
-    } else {
-      indexers[i] = NULL;
     }
   }
 

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -926,14 +926,16 @@ static THIndexTensor* THPTensor_(_calculateLinearIndices)(
     } else {
       indexers[i] = NULL;
     }
-    /* indexers[i] = flattenedBroadcasters.find(i) != flattenedBroadcasters.end() ? */
-    /*               flattenedBroadcasters[i].get() : */
-    /*               NULL; */
   }
 
   THTensor_(calculateAdvancedIndexingOffsets)(LIBRARY_STATE cudaIndices, indexed, baseOffset, indexers);
 
-  // TODO: free the cuda tensors
+  // Free the indexers
+  for (int i = 0; i < THTensor_(nDimension)(LIBRARY_STATE indexed.get(); ++i) {
+    if (indexers[i] != NULL) {
+      THCudaLongTensor_free(indexers[i]);
+    }
+  }
   return cudaIndices;
 #else
   THLongTensor *linearIndices = THLongTensor_newWithSize1d(indexingElements);

--- a/torch/lib/TH/generic/THTensor.c
+++ b/torch/lib/TH/generic/THTensor.c
@@ -321,8 +321,8 @@ void THTensor_(expandNd)(THTensor **rets, THTensor **ops, int count) {
     THArgCheck(THTensor_(nDimension)(ops[i]) > 0, i, "can't expand empty tensor %d", i);
   }
 
-  long *op_sizes[count];
-  long op_dims[count];
+  long **op_sizes = THAlloc(sizeof(long*) * count);
+  long *op_dims = THAlloc(sizeof(long) * count);
 
   for (int i = 0; i < count; ++i) {
     op_sizes[i] = ops[i]->size;
@@ -339,6 +339,8 @@ void THTensor_(expandNd)(THTensor **rets, THTensor **ops, int count) {
                                      1024);
 
   if(ret != 0) {
+    THFree(op_sizes);
+    THFree(op_dims);
     THLongStorage_free(sizes);
     THError(error_buffer);
     return;
@@ -348,6 +350,8 @@ void THTensor_(expandNd)(THTensor **rets, THTensor **ops, int count) {
     THTensor_(expand)(rets[i], ops[i], sizes);
   }
 
+  THFree(op_sizes);
+  THFree(op_dims);
   THLongStorage_free(sizes);
 }
 

--- a/torch/lib/THC/THCTensorIndex.cu
+++ b/torch/lib/THC/THCTensorIndex.cu
@@ -332,33 +332,32 @@ __global__ void indexSelectLargeIndex(TensorInfo<T, IndexType> dst,
   }
 }
 
-struct CLIData {
-  long sizes[5];              // sizes for Tensor dims (either from the Tensor, or the size of the adv indexer at that dim)
-  long strides[5];            // strides for Tensor
-  bool adv[5];                // which Tensors are advanced indexers
-  long *advIndexTensors[5];    // Adv Indexing Tensors
+template <unsigned int Dims>
+struct LinearIndexCalcData {
+  // sizes for Tensor dims (either from the Tensor, or the size of the adv indexer at that dim)
+  long sizes[Dims];
+  long strides[Dims];            // strides for Tensor
+  bool adv[Dims];                // which Tensors are advanced indexers
+  long *advIndexTensors[Dims];   // Adv Indexing Tensors
 };
 
-/* __device__ __forceinline__ long calculateOffset( */
-__device__ long calculateOffset(
+template <unsigned int Dims>
+__device__ __forceinline__ long calculateOffset(
   long index,                  // index to calculate offset for
-  int ndim,                   // number of dimensions in Tensor
-  CLIData data
+  LinearIndexCalcData<Dims> data
 )
 {
   long offset = 0;
 
-  for (int dim = ndim - 1; dim >= 0; --dim) {
+#pragma unroll
+  for (int dim = Dims - 1; dim >= 0; --dim) {
     long sizeAtDim, strideAtDim, indexAtDim, nextIndex;
 
     strideAtDim = data.strides[dim];
     sizeAtDim = data.sizes[dim];
 
-    /* printf("size: %ld, stride: %d\n", sizeAtDim, strideAtDim); */
     if (data.adv[dim]) {
-      /* printf("indexing dim %d, with offset %ld\n", dim, index % sizeAtDim); */
       indexAtDim = data.advIndexTensors[dim][index % sizeAtDim];
-      /* indexAtDim = 0; */
       if (dim > 0 && data.adv[dim - 1]) {
         nextIndex = index;
       } else {
@@ -376,28 +375,18 @@ __device__ long calculateOffset(
   return offset;
 }
 
-
+template <unsigned int Dims>
 __global__ void calculateLinearIndices(
   long *output,               // output Tensor for indices
   int elements,               // number of elements in output <-> indices to calculate
-  int ndim,                   // number of dimensions in Tensor
-  ptrdiff_t baseOffset,
-  CLIData data
+  ptrdiff_t baseOffset,       // base offset into the Tensor
+  LinearIndexCalcData<Dims> data
 )
 {
-  /* printf("hello\n"); */
-  /* for (int i = 0; i < elements; ++i) { */
-  /*   printf("%ld\n", output[i]); */
-  /* } */
-
-  /* for (int i = 0; i < ndim; ++i) { */
-  /*   printf("size at dim %d: %ld\n", i, data.sizes[i]); */
-  /* } */
-
   for (long i = blockIdx.x * blockDim.x + threadIdx.x;
          i < elements;
          i += blockDim.x * gridDim.x) {
-      output[i] = baseOffset + calculateOffset(i, ndim, data);
+      output[i] = baseOffset + calculateOffset<Dims>(i, data);
    }
 }
 

--- a/torch/lib/THC/THCTensorIndex.cu
+++ b/torch/lib/THC/THCTensorIndex.cu
@@ -332,26 +332,26 @@ __global__ void indexSelectLargeIndex(TensorInfo<T, IndexType> dst,
   }
 }
 
-template <unsigned int Dims>
+template <typename IndexType, unsigned int Dims>
 struct LinearIndexCalcData {
   // sizes for Tensor dims (either from the Tensor, or the size of the adv indexer at that dim)
-  long sizes[Dims];
-  long strides[Dims];            // strides for Tensor
+  IndexType sizes[Dims];
+  IndexType strides[Dims];       // strides for Tensor
   bool adv[Dims];                // which Tensors are advanced indexers
   long *advIndexTensors[Dims];   // Adv Indexing Tensors
 };
 
-template <unsigned int Dims>
+template <typename IndexType, unsigned int Dims>
 __device__ __forceinline__ long calculateOffset(
-  long index,                  // index to calculate offset for
-  LinearIndexCalcData<Dims> data
+  IndexType index,                  // index to calculate offset for
+  LinearIndexCalcData<IndexType, Dims> data
 )
 {
-  long offset = 0;
+  IndexType offset = 0;
 
 #pragma unroll
   for (int dim = Dims - 1; dim >= 0; --dim) {
-    long sizeAtDim, strideAtDim, indexAtDim, nextIndex;
+    IndexType sizeAtDim, strideAtDim, indexAtDim, nextIndex;
 
     strideAtDim = data.strides[dim];
     sizeAtDim = data.sizes[dim];
@@ -375,18 +375,18 @@ __device__ __forceinline__ long calculateOffset(
   return offset;
 }
 
-template <unsigned int Dims>
+template <typename IndexType, unsigned int Dims>
 __global__ void calculateLinearIndices(
   long *output,               // output Tensor for indices
   int elements,               // number of elements in output <-> indices to calculate
   ptrdiff_t baseOffset,       // base offset into the Tensor
-  LinearIndexCalcData<Dims> data
+  LinearIndexCalcData<IndexType, Dims> data
 )
 {
   for (long i = blockIdx.x * blockDim.x + threadIdx.x;
          i < elements;
          i += blockDim.x * gridDim.x) {
-      output[i] = baseOffset + calculateOffset<Dims>(i, data);
+      output[i] = baseOffset + calculateOffset<IndexType, Dims>(i, data);
    }
 }
 

--- a/torch/lib/THC/generic/THCTensorIndex.cu
+++ b/torch/lib/THC/generic/THCTensorIndex.cu
@@ -535,12 +535,12 @@ void THCTensor_(calculateAdvancedIndexingOffsets)(
 {                                                                                               \
   LinearIndexCalcData<INDEX_TYPE, DIMS> data;                                                   \
   for (int i = 0; i < DIMS; ++i) {                                                              \
-    data.adv[i] = indexers[i] != NULL;                                                          \
-    data.sizes[i] = data.adv[i] ?                                                               \
+    data.sizes[i] = indexers[i] != NULL ?                                                       \
       THCudaLongTensor_nElement(state, indexers[i]) :                                           \
         THCTensor_(size)(state, indexed, i);                                                    \
     data.strides[i] = THCTensor_(stride)(state, indexed, i);                                    \
-    data.advIndexTensors[i] = data.adv[i] ? THCudaLongTensor_data(state, indexers[i]) : NULL;   \
+    data.advIndexTensors[i] = indexers[i] != NULL ?                                             \
+      THCudaLongTensor_data(state, indexers[i]) : NULL;                                         \
   }                                                                                             \
                                                                                                 \
   calculateLinearIndices<INDEX_TYPE, DIMS>                                                      \

--- a/torch/lib/THC/generic/THCTensorIndex.h
+++ b/torch/lib/THC/generic/THCTensorIndex.h
@@ -12,4 +12,6 @@ THC_API void THCTensor_(indexAdd_long)(THCState *state, THCTensor *res_, int dim
 THC_API void THCTensor_(indexFill_long)(THCState *state, THCTensor *tensor, int dim, THLongTensor *index, real val);
 THC_API void THCTensor_(indexSelect_long)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THLongTensor *index);
 
+THC_API void THCTensor_(calculateAdvancedIndexingOffsets)(THCState *state, THCudaLongTensor *output, THCTensor *indexed, ptrdiff_t baseOffset, THCudaLongTensor **indexers);
+
 #endif


### PR DESCRIPTION
Followup to #1890, continuing to address #1080.

This diff adds a CUDA kernel for calculating the linear offsets passed to the `Index*` functions used in advanced indexing directly on the GPU for CUDA Tensors.

Next Steps:
- We still have to do a CPU --> GPU copy because we instantiate CPU Tensors from Advanced Indexing parameters. There could be a way to get rid of this - though it would likely require another CUDA kernel or mechanism for verifying the bounds as in: https://github.com/pytorch/pytorch/blob/master/torch/csrc/generic/Tensor.cpp#L726.
- Fused kernel where we calculate the offsets and do the sets at the same time