### PR TITLE
only test gets for advanced indexing with duplicates

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2823,16 +2823,18 @@ class TestTorch(TestCase):
                 # first, third rows,
                 [[0, 2], slice(None)],
 
-                # dupes
-                [slice(None), [0, 1, 1, 2, 2]],
-
                 # weird shape
                 [slice(None), [[0, 1],
                                [2, 3]]]
             ]
 
-            for indexer in indices_to_test:
+            # only test dupes on gets
+            get_indices_to_test = indices_to_test + [[slice(None), [0, 1, 1, 2, 2]]]
+
+            for indexer in get_indices_to_test:
                 assert_get_eq(reference, indexer)
+
+            for indexer in indices_to_test:
                 assert_set_eq(reference, indexer, 44)
                 assert_set_eq(reference,
                               indexer,


### PR DESCRIPTION
Addresses #1953. I think the best solution is to only test duplicate elements for `gets` as the NumPy documentation does not make any guarantees about the ordering:

(from https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html)
> For advanced assignments, there is in general no guarantee for the iteration order. This means that if an element is set more than once, it is not possible to predict the final result. 