### PR TITLE
[READY] torch.nn.Threshold: `less or equal` vs `less` problem

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -10,8 +10,8 @@ class Threshold(Module):
 
     Threshold is defined as::
 
-         y =  x        if x >= threshold
-              value    if x <  threshold
+         y =  x        if x >  threshold
+              value    if x <= threshold
 
     Args:
         threshold: The value to threshold at


### PR DESCRIPTION
Resolves #2025 
Checked [cpu](https://github.com/pytorch/pytorch/blob/master/torch/lib/THNN/generic/Threshold.c) and [gpu](https://github.com/pytorch/pytorch/blob/master/torch/lib/THCUNN/Threshold.cu)  versions of the function. There was really a mistake in docs.