### PR TITLE
add dummy tensor.data property, to provide interpretable error messag…

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -367,6 +367,11 @@ class _TensorBase(object):
     def __hash__(self):
         return id(self)
 
+    # provide user guidance when they inavertently call autograd properties on a Tensor
+    @property
+    def data(self):
+        raise RuntimeError('cannot call .data on a torch.Tensor: did you intend to use autograd.Variable?')
+
 
 _TensorBase.type = _type
 _TensorBase.cuda = _cuda


### PR DESCRIPTION
…e to users

Pre-empt issues such as https://discuss.pytorch.org/t/attributeerror-torch-doubletensor-object-has-no-attribute-data/4768