### PR TITLE
Fix ATen build for debug python

### DIFF
--- a/torch/lib/ATen/CMakeLists.txt
+++ b/torch/lib/ATen/CMakeLists.txt
@@ -121,6 +121,8 @@ EXECUTE_PROCESS(
     ERROR_VARIABLE generated_cpp
     RESULT_VARIABLE RETURN_VALUE
 )
+# Filter out anything that is not a source file
+filter_list(generated_cpp generated_cpp "(\\.cpp|\\.h)$")
 if (NOT RETURN_VALUE EQUAL 0)
     message(STATUS ${generated_cpp})
     message(FATAL_ERROR "Failed to get generated_cpp list")


### PR DESCRIPTION
Because debug python print extra information every time it is ran which where interpreted as source files.