### PR TITLE
Use NamedTemporaryFile to avoid filename collisions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3682,7 +3682,6 @@ class TestTorch(TestCase):
             sys.modules[module.__name__] = module
             return module
 
-        import os
         with tempfile.NamedTemporaryFile() as checkpoint:
             fname = os.path.join(os.path.dirname(__file__), 'data/network1.py')
             module = import_module('tmpmodule', fname)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3735,13 +3735,12 @@ class TestTorch(TestCase):
 
     def test_from_file(self):
         size = 10000
-        filename = 'testPytorchStorageFromFile'
-        try:
-            s1 = torch.FloatStorage.from_file(filename, True, size)
+        with tempfile.NamedTemporaryFile() as f:
+            s1 = torch.FloatStorage.from_file(f.name, True, size)
             t1 = torch.FloatTensor(s1).copy_(torch.randn(size))
 
             # check mapping
-            s2 = torch.FloatStorage.from_file(filename, True, size)
+            s2 = torch.FloatStorage.from_file(f.name, True, size)
             t2 = torch.FloatTensor(s2)
             self.assertEqual(t1, t2, 0)
 
@@ -3754,9 +3753,6 @@ class TestTorch(TestCase):
             rnum = random.uniform(-1, 1)
             t2.fill_(rnum)
             self.assertEqual(t1, t2, 0)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
 
     def test_print(self):
         for t in torch._tensor_classes:


### PR DESCRIPTION
We sometimes run tests in parallel. This test can fail due to filename collisions.