### PR TITLE
dont clobber gen.py error, fix for old versions of python

### DIFF
--- a/torch/lib/ATen/CMakeLists.txt
+++ b/torch/lib/ATen/CMakeLists.txt
@@ -121,12 +121,14 @@ EXECUTE_PROCESS(
     ERROR_VARIABLE generated_cpp
     RESULT_VARIABLE RETURN_VALUE
 )
-# Filter out anything that is not a source file
-filter_list(generated_cpp generated_cpp "(\\.cpp|\\.h)$")
+
 if (NOT RETURN_VALUE EQUAL 0)
     message(STATUS ${generated_cpp})
     message(FATAL_ERROR "Failed to get generated_cpp list")
 endif()
+
+# Filter out anything that is not a source file
+filter_list(generated_cpp generated_cpp "(\\.cpp|\\.h)$")
 
 FILE(GLOB_RECURSE all_templates "templates/*")
 

--- a/torch/lib/ATen/code_template.py
+++ b/torch/lib/ATen/code_template.py
@@ -11,8 +11,15 @@ import re
 
 
 class CodeTemplate(object):
-    subtitution = re.compile(
-        '(^[^\n\S]*)?\$([^\d\W]\w*|\{,?[^\d\W]\w*\,?})', re.MULTILINE)
+    substitution_str = '(^[^\n\S]*)?\$([^\d\W]\w*|\{,?[^\d\W]\w*\,?})'
+
+    # older versions of Python have a bug where \w* does not work,
+    # so we need to replace with the non-shortened version [a-zA-Z0-9_]*
+    # https://bugs.python.org/issue18647
+
+    substitution_str = substitution_str.replace('\w', '[a-zA-Z0-9_]')
+
+    subtitution = re.compile(substitution_str, re.MULTILINE)
 
     @staticmethod
     def from_file(filename):


### PR DESCRIPTION
Attempts to address some build problems for ATen:

- Replace `\w` with `[a-zA-Z0-9_]` so that older versions of Python with issue https://bugs.python.org/issue18647 still work
- The change in #2065 clobbers the stack trace output for when the `gen.py` script fails, so its hard to debug errors, so we move the code to after the error check that does the filter