### PR TITLE
Bug fixes

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1561,6 +1561,7 @@ function_tests = [
     (Dot, (), ((L,), (L,)),),
     (Max, (), ((S, S, S),),),
     (Repeat, (), ((S, S, S, S), torch.Size([2, 3, 1, 2]))),
+    (Repeat, (), ((S, S, S, S), torch.Size([2, 2, 1, 3, 1, 2])), 'unsqueeze'),
     (Cumsum, (), ((S, S, S), 0), 'dim0', [1]),
     (Cumsum, (), ((S, S, S), 1), 'dim1', [1]),
     (Cumsum, (), ((S,), 0), '1d', [1]),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2296,7 +2296,7 @@ class TestTorch(TestCase):
         target_value = torch.rand(1000)
         # Dramatically alter the internal state of the main generator
         _ = torch.rand(100000)
-        forked_value = torch.rand(gen, 1000)
+        forked_value = torch.rand(1000, generator=gen)
         self.assertEqual(target_value, forked_value, 0, "RNG has not forked correctly.")
 
     def test_boxMullerState(self):

--- a/tools/cwrap/plugins/KwargsPlugin.py
+++ b/tools/cwrap/plugins/KwargsPlugin.py
@@ -30,10 +30,8 @@ class KwargsPlugin(CWrapPlugin):
             for option in declaration['options']:
                 offset = 0
                 for arg in option['arguments']:
-                    if arg.get('kwarg_only') and not arg.get('ignore_check', False):
-                        offset += 1
-                    else:
-                        arg['kwarg_offset'] = offset
+                    if arg.get('kwarg_only'):
+                        arg['no_idx'] = True
         return declarations
 
     def get_arg_accessor(self, arg, option):
@@ -41,14 +39,14 @@ class KwargsPlugin(CWrapPlugin):
             return
         if arg.get('kwarg_only'):
             return self.KWARG_ONLY_ACCESSOR_TEMPLATE.substitute(name=arg['name'])
-        return self.ACCESSOR_TEMPLATE.substitute(idx=arg['idx'] - arg['kwarg_offset'], name=arg['name'])
+        return self.ACCESSOR_TEMPLATE.substitute(idx=arg['idx'], name=arg['name'])
 
     def process_single_check(self, code, arg, arg_accessor):
         if arg.get('no_kwargs'):
             return code
         if arg.get('kwarg_only'):
             return self.KWARG_ONLY_CHECK_TEMPLATE.substitute(name=arg['name'], code=code)
-        return self.CHECK_TEMPLATE.substitute(idx=arg['idx'] - arg['kwarg_offset'], name=arg['name'], code=code)
+        return self.CHECK_TEMPLATE.substitute(idx=arg['idx'], name=arg['name'], code=code)
 
     def process_wrapper(self, code, declaration):
         if declaration.get('no_kwargs'):

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -439,7 +439,10 @@ ${cpu}
                 declaration['variables'] += ['PyObject *__out;']
                 self.generate_out_options(declaration)
             if has_long_args(declaration):
-                declaration['no_kwargs'] = True
+                for option in declaration['options']:
+                    for arg in option['arguments']:
+                        if arg.get('long_args', False):
+                            arg['no_kwargs'] = True
             for option in declaration['options']:
                 option['cname'] = 'TH{}Tensor_({})'.format(
                     'S' if option.get('sparse', False) else '', option['cname'])
@@ -554,7 +557,9 @@ ${cpu}
 
         if any(arg.get('long_args', False) for arg in option['arguments']):
             code = code.replace('__argcount ==', '__argcount >=')
-            expected = str(int(option.get('output_provided', False)))
+            expected = str(int(option.get('output_provided', False)) +
+                           sum(not arg.get('no_kwargs', False) and not arg.get('ignore_check', False)
+                               for arg in option['arguments']))
             code = '__dictcount == ' + expected + ' &&\n          ' + code
 
         return code

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -152,5 +152,5 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Non
         outputs, grad_outputs, retain_graph,
         inputs, only_inputs)
 
-status = torch._C._autograd_init()
-assert status, "Autograd failed to initialize."
+if not torch._C._autograd_init():
+    raise RuntimeError("autograd initialization failed")

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -105,12 +105,15 @@ class View(Function):
 class Expand(Function):
 
     @staticmethod
+    # NOTE: new_size can be a tuple of any arguments that expand accepts, including a single-element
+    # tuple containing torch.Size or a list
     def forward(ctx, i, new_size):
-        ctx.num_unsqueezed = len(new_size) - i.dim()
-        ctx.expanded_dims = [dim for dim, (expanded, original)
-                             in enumerate(zip(new_size[ctx.num_unsqueezed:], i.size()))
-                             if expanded != original]
         result = i.expand(*new_size)
+        ctx.num_unsqueezed = result.dim() - i.dim()
+        ctx.expanded_dims = [dim for dim, (expanded, original)
+                             in enumerate(zip(result.size()[ctx.num_unsqueezed:], i.size()))
+                             if expanded != original]
+
         ctx.mark_shared_storage((i, result))
         return result
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -695,15 +695,10 @@ class Variable(_C._VariableBase):
         return MaskedSelect.apply(self, mask)
 
     def expand(self, *sizes):
-        if isinstance(sizes[0], torch.Size):
-            if len(sizes) > 1:
-                raise ValueError("expand expects a several ints or a single "
-                                 "torch.Size argument")
-            sizes = sizes[0]
         return Expand.apply(self, sizes)
 
     def expand_as(self, tensor):
-        return Expand.apply(self, tensor.size())
+        return Expand.apply(self, (tensor.size(),))
 
     def t(self):
         if self.dim() != 2:

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -734,14 +734,14 @@ class Variable(_C._VariableBase):
     def permute(self, *permutation):
         return Permute.apply(self, permutation)
 
-    def diag(self, diagonal_idx=0):
-        return Diag.apply(self, diagonal_idx)
+    def diag(self, diagonal=0):
+        return Diag.apply(self, diagonal)
 
-    def tril(self, diagonal_idx=0):
-        return Tril.apply(self, diagonal_idx)
+    def tril(self, diagonal=0):
+        return Tril.apply(self, diagonal)
 
-    def triu(self, diagonal_idx=0):
-        return Triu.apply(self, diagonal_idx)
+    def triu(self, diagonal=0):
+        return Triu.apply(self, diagonal)
 
     def trace(self):
         return Trace.apply(self)
@@ -755,8 +755,8 @@ class Variable(_C._VariableBase):
     def gesv(self, a):
         return Gesv.apply(self, a)
 
-    def multinomial(self, num_samples=1, with_replacement=False):
-        return Multinomial(num_samples, with_replacement)(self)
+    def multinomial(self, num_samples=1, replacement=False):
+        return Multinomial(num_samples, replacement)(self)
 
     def bernoulli(self):
         return Bernoulli()(self)

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1694,7 +1694,7 @@
     - arg: THTensor* destination
       output: True
     - THTensor* self
-    - arg: long k
+    - arg: long diagonal
       default: 0
 ]]
 
@@ -1705,7 +1705,7 @@
   arguments:
     - THTensor* self
     - THTensor* self
-    - arg: long k
+    - arg: long diagonal
       default: 0
 ]]
 
@@ -1719,7 +1719,7 @@
     - arg: THTensor* destination
       output: True
     - THTensor* self
-    - arg: long k
+    - arg: long diagonal
       default: 0
 ]]
 
@@ -1730,7 +1730,7 @@
   arguments:
     - THTensor* self
     - THTensor* self
-    - arg: long k
+    - arg: long diagonal
       default: 0
 ]]
 

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -45,7 +45,8 @@ def init_process_group(backend, init_method='env://', **kwargs):
     torch._C._dist_init_process_group(backend, init_method, world_size,
                                       group_name, rank)
     _initialized = _INITIALIZED_PG
-    assert torch._C._dist_init_extension(False, reduce_op, group)
+    if not torch._C._dist_init_extension(False, reduce_op, group):
+        raise RuntimeError("distributed module initialization failed")
 
 
 def init_master_worker(backend, init_method='env://', **kwargs):
@@ -75,7 +76,8 @@ def init_master_worker(backend, init_method='env://', **kwargs):
     import torch.distributed.remote_types as remote_types
     _extend_scope(collectives)
     _extend_scope(remote_types)
-    assert torch._C._dist_init_extension(True, reduce_op, group)
+    if not torch._C._dist_init_extension(True, reduce_op, group):
+        raise RuntimeError("distributed module initialization failed")
 
 
 class reduce_op(object):

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -67,7 +67,7 @@ class DataParallel(Module):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
 
     def parallel_apply(self, replicas, inputs, kwargs):
-        return parallel_apply(replicas, inputs, kwargs)
+        return parallel_apply(replicas, inputs, kwargs, self.device_ids)
 
     def gather(self, outputs, output_device):
         return gather(outputs, output_device, dim=self.dim)
@@ -101,5 +101,5 @@ def data_parallel(module, inputs, device_ids=None, output_device=None, dim=0, mo
     if len(device_ids) == 1:
         return module(*inputs[0], **module_kwargs[0])
     replicas = replicate(module, device_ids[:len(inputs)])
-    outputs = parallel_apply(replicas, inputs, module_kwargs)
+    outputs = parallel_apply(replicas, inputs, module_kwargs, device_ids)
     return gather(outputs, output_device, dim)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -164,7 +164,7 @@ class DistributedDataParallel(Module):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
 
     def parallel_apply(self, replicas, inputs, kwargs):
-        return parallel_apply(replicas, inputs, kwargs)
+        return parallel_apply(replicas, inputs, kwargs, self.device_ids)
 
     def gather(self, outputs, output_device):
         return gather(outputs, output_device, dim=self.dim)


### PR DESCRIPTION
* Handle unsqueezed dimensions in Repeat backward (#2095)
* `parallel_apply` can now accept arbitrary inputs (#1992)
* Keyword args are now allows in options that also use `long_args` (#1616)
* `Variable.expand` now accepts all inputs that `Tensor.expand` accepts (#1910)
* Unified argument names for Variable and Tensor methods (#1924, #1839)
* Changed assertions with side effects to `if` statements (#1848)