### PR TITLE
[WIP] Adding numpy support to HalfTensor

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3009,7 +3009,7 @@ class TestTorch(TestCase):
         types = [
             'torch.ByteTensor',
             'torch.IntTensor',
-            'torch.HalfTensor'
+            'torch.HalfTensor',
             'torch.FloatTensor',
             'torch.DoubleTensor',
             'torch.LongTensor',

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3009,6 +3009,7 @@ class TestTorch(TestCase):
         types = [
             'torch.ByteTensor',
             'torch.IntTensor',
+            'torch.HalfTensor'
             'torch.FloatTensor',
             'torch.DoubleTensor',
             'torch.LongTensor',

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3089,6 +3089,7 @@ class TestTorch(TestCase):
         dtypes = [
             np.double,
             np.float,
+            np.half,
             np.int64,
             np.int32,
             np.int16,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -164,6 +164,8 @@ PyObject * THPModule_fromNumpy(PyObject *_unused, PyObject *array)
     return PyObject_CallFunctionObjArgs(THPDoubleTensorClass, array, NULL);
   } else if (type == NPY_FLOAT) {
     return PyObject_CallFunctionObjArgs(THPFloatTensorClass, array, NULL);
+  } else if (type == NPY_HALF) {
+    return PyObject_CallFunctionObjArgs(THPHalfTensorClass, arraym NULL);
   } else if (type == NPY_INT64) {
     return PyObject_CallFunctionObjArgs(THPLongTensorClass, array, NULL);
   } else if (type == NPY_INT32) {
@@ -174,8 +176,8 @@ PyObject * THPModule_fromNumpy(PyObject *_unused, PyObject *array)
     return PyObject_CallFunctionObjArgs(THPByteTensorClass, array, NULL);
   }
   THPUtils_setError("can't convert a given np.ndarray to a tensor - it has an "
-      "invalid type. The only supported types are: double, float, int64, "
-      "int32, and uint8.");
+      "invalid type. The only supported types are: double, float, half, "
+      "int64, int32, and uint8.");
   return NULL;
 #endif
 }

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -165,7 +165,7 @@ PyObject * THPModule_fromNumpy(PyObject *_unused, PyObject *array)
   } else if (type == NPY_FLOAT) {
     return PyObject_CallFunctionObjArgs(THPFloatTensorClass, array, NULL);
   } else if (type == NPY_HALF) {
-    return PyObject_CallFunctionObjArgs(THPHalfTensorClass, arraym NULL);
+    return PyObject_CallFunctionObjArgs(THPHalfTensorClass, array, NULL);
   } else if (type == NPY_INT64) {
     return PyObject_CallFunctionObjArgs(THPLongTensorClass, array, NULL);
   } else if (type == NPY_INT32) {

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -10,6 +10,9 @@
 #ifdef TH_REAL_IS_FLOAT
 #define NUMPY_TYPE_ENUM NPY_FLOAT
 #endif
+#ifdef TH_REAL_IS_HALF
+#define NUMPY_TYPE_ENUM NPY_HALF
+#endif
 #ifdef TH_REAL_IS_LONG
 #define NUMPY_TYPE_ENUM NPY_INT64
 #endif

--- a/torch/csrc/generic/utils.h
+++ b/torch/csrc/generic/utils.h
@@ -28,7 +28,7 @@ template<>
 struct THPUtils_typeTraits<real> {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || \
     defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || \
-    defined(THC_REAL_IS_HALF)
+    defined(THC_REAL_IS_HALF) || defined(TH_REAL_IS_HALF)
   static constexpr char *python_type_str = "float";
 #else
   static constexpr char *python_type_str = "int";


### PR DESCRIPTION
Tries to address: https://github.com/pytorch/pytorch/issues/2014

Right now, the ```.numpy()``` method isn't being generated for half tensor by just adding the preprocessing variable 