### PR TITLE
add support for advanced indexing with less than ndim indexers, ellipsis

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -555,6 +555,9 @@ class TestAutograd(TestCase):
         check_index(x, y, ([slice(None), [2, 3]]))
         check_index(x, y, ([[2, 3], slice(None)]))
 
+        # advanced indexing, with less dim, or ellipsis
+        check_index(x, y, ([0], ))
+
         x = torch.arange(1, 49).view(4, 3, 4)
         y = Variable(x, requires_grad=True)
 
@@ -569,6 +572,14 @@ class TestAutograd(TestCase):
         check_index(x, y, (slice(None), slice(None), [2, 1]))
         check_index(x, y, (slice(None), [2, 1], slice(None)))
         check_index(x, y, ([2, 1], slice(None), slice(None)))
+
+        # advanced indexing, with less dim, or ellipsis
+        check_index(x, y, ([0], ))
+        check_index(x, y, ([0], slice(None)))
+        check_index(x, y, ([0], Ellipsis))
+        check_index(x, y, ([1, 2], [0, 1]))
+        check_index(x, y, ([1, 2], [0, 1], Ellipsis))
+        check_index(x, y, (Ellipsis, [1, 2], [0, 1]))
 
     def test_indexing_duplicates(self):
         x = torch.arange(1, 17).view(4, 4)
@@ -1458,6 +1469,9 @@ function_tests = [
     (Index, (), (torch.rand(S, S, S), dont_convert([slice(None), [0, 3], slice(None)])), 'adv_index_mid'),
     (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], slice(None), slice(None)])), 'adv_index_beg'),
     (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], [1, 2], slice(None)])), 'adv_index_comb'),
+    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], ])), 'adv_index_sub'),
+    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], slice(None)])), 'adv_index_sub_2'),
+    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], Ellipsis])), 'adv_index_sub_3'),
     (View, (), (torch.rand(S, S, S), torch.Size([S * S, S]))),
     (Expand, (), ((1, S, 1, S, 1), torch.Size([5, S, 5, S, 5]))),
     (Expand, (), ((S, 1), torch.Size([S, S, S])), 'new_dim'),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2762,6 +2762,16 @@ class TestTorch(TestCase):
         self.assertEqual(strided[rows, columns],
                          torch.Tensor([[4, 6], [2, 3]]))
 
+        # Tests using less than the number of dims, and ellipsis
+
+        # reference is 1 2
+        #              3 4
+        #              5 6
+        reference = conv_fn(consec((3, 2)))
+        self.assertEqual(reference[ri([0, 2]), ], torch.Tensor([[1, 2], [5, 6]]))
+        self.assertEqual(reference[ri([1]), ...], torch.Tensor([[3, 4]]))
+        self.assertEqual(reference[..., ri([1])], torch.Tensor([[2], [4], [6]]))
+
         if TEST_NUMPY:
             # we use numpy to compare against, to verify that our advanced
             # indexing semantics are the same, and also for ease of test
@@ -2864,6 +2874,19 @@ class TestTorch(TestCase):
                 [[[0, 1], [2, 3]], [[0]], slice(None)],
                 [[[2, 1]], [[0, 3], [4, 4]], slice(None)],
                 [[[2]], [[0, 3], [4, 1]], slice(None)],
+
+                # less dim, ellipsis
+                [[0, 2], ],
+                [[0, 2], slice(None)],
+                [[0, 2], Ellipsis],
+                [[0, 2], slice(None), Ellipsis],
+                [[0, 2], Ellipsis, slice(None)],
+                [[0, 2], [1, 3]],
+                [[0, 2], [1, 3], Ellipsis],
+                [Ellipsis, [1, 3], [2, 3]],
+                [Ellipsis, [2, 3, 4]],
+                [Ellipsis, slice(None), [2, 3, 4]],
+                [slice(None), Ellipsis, [2, 3, 4]],
             ]
 
             for indexer in indices_to_test:
@@ -2917,6 +2940,25 @@ class TestTorch(TestCase):
                 [[0], [4], [1, 3, 4], slice(None)],
                 [[1], [0, 2, 3], [1], slice(None)],
                 [[[1, 2], [1, 2]], [[0, 1], [2, 3]], [[2, 3], [3, 5]], slice(None)],
+
+                # less dim, ellipsis
+                [Ellipsis, [0, 3, 4]],
+                [Ellipsis, slice(None), [0, 3, 4]],
+                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
+                [slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), [0, 2, 3], [1, 3, 4]],
+                [slice(None), [0, 2, 3], [1, 3, 4], Ellipsis],
+                [Ellipsis, [0, 2, 3], [1, 3, 4], slice(None)],
+                [[0], [1, 2, 4]],
+                [[0], [1, 2, 4], slice(None)],
+                [[0], [1, 2, 4], Ellipsis],
+                [[0], [1, 2, 4], Ellipsis, slice(None)],
+                [[1], ],
+                [[0, 2, 1], [3], [4]],
+                [[0, 2, 1], [3], [4], slice(None)],
+                [[0, 2, 1], [3], [4], Ellipsis],
+                [Ellipsis, [0, 2, 1], [3], [4]],
             ]
 
             for indexer in indices_to_test:


### PR DESCRIPTION
Followup to #1890, part of #1080.

This allows the use of advanced indexing on Tensors when specifying less than `ndim` indexers, and also adds Ellipsis support:

```
In [7]: x = torch.Tensor(5, 5, 5, 5)

In [8]: x[[1, 2],].size()
Out[8]: torch.Size([2, 5, 5, 5])

In [9]: x[[1, 2], ...].size()
Out[9]: torch.Size([2, 5, 5, 5])

In [10]: x[..., [1, 2], [3, 4]].size()
Out[10]: torch.Size([5, 5, 2])

In [11]: x[..., [1, 2], [3, 4], :].size()
Out[11]: torch.Size([5, 2, 5])
```