### PR TITLE
better error message in load_state_dict when there are inconsistent tensor sizes

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -357,7 +357,13 @@ class Module(object):
             if isinstance(param, Parameter):
                 # backwards compatibility for serialized parameters
                 param = param.data
-            own_state[name].copy_(param)
+            try:
+                own_state[name].copy_(param)
+            except:
+                print('While copying the parameter named {}, whose dimensions in the model are'
+                      ' {} and whose dimensions in the checkpoint are {}, ...'.format(
+                          name, own_state[name].size(), param.size()))
+                raise
 
         missing = set(own_state.keys()) - set(state_dict.keys())
         if len(missing) > 0:


### PR DESCRIPTION
I have often got the message "inconsistent tensor sizes" from `load_state_dict`, usually just because I am trying to load a checkpoint with a different version of the code or a different configuration.  This patch makes it easier to locate the problem.