### PR TITLE
Add CUDA support for arange

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -880,6 +880,14 @@ class TestCuda(TestCase):
     def test_tensor_scatterFill(self):
         TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', True, test_bounds=False)
 
+    def test_arange(self):
+        for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:
+            a = torch.cuda.__dict__[t]()
+            torch.arange(0, 10, out=a)
+            b = torch.__dict__[t]()
+            torch.arange(0, 10, out=b)
+            self.assertEqual(a, b.cuda())
+
     def test_nvtx(self):
         # Just making sure we can see the symbols
         torch.cuda.nvtx.range_push("foo")

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -670,6 +670,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
     - function
   backends:
     - CPU
+    - CUDA
   return: argument 0
   before_arg_assign: |
     PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "
@@ -690,6 +691,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
     - function
   backends:
     - CPU
+    - CUDA
   return: argument 0
   options:
       - arguments:

--- a/torch/lib/THC/generic/THCTensorMath.cu
+++ b/torch/lib/THC/generic/THCTensorMath.cu
@@ -449,4 +449,15 @@ void THCTensor_(range)(THCState *state, THCTensor *r_, accreal xmin, accreal xma
   THCudaCheck(cudaGetLastError());
 }
 
+void THCTensor_(arange)(THCState* state, THCTensor *r_, accreal xmin, accreal xmax, accreal step) {
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
+  int m = fmod(xmax - xmin, step) == 0;
+#else
+  int m = (xmax - xmin) % step == 0;
+#endif
+  if (m)
+    xmax -= step;
+  THCTensor_(range)(state, r_, xmin, xmax, step);
+}
+
 #endif

--- a/torch/lib/THC/generic/THCTensorMath.h
+++ b/torch/lib/THC/generic/THCTensorMath.h
@@ -26,5 +26,6 @@ THC_API void THCTensor_(logspace)(THCState *state, THCTensor *r_, real a, real b
 #endif
 
 THC_API void THCTensor_(range)(THCState *state, THCTensor *r_, accreal xmin, accreal xmax, accreal step);
+THC_API void THCTensor_(arange)(THCState *state, THCTensor *r_, accreal xmin, accreal xmax, accreal step);
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/2139 and https://github.com/pytorch/pytorch/issues/1925

Also enables CUDA for range.
I didn't look into adding support for `arange` in THD, but it might be good do it later.

One more thing, I think there is currently no good way of testing initializer functions on the GPU (like random, arange, etc), so I just added a quick test for `arange`.