### PR TITLE
make keepdim backcompat warnings emit in autograd as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,7 @@ if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
     CXXNAME = os.getenv('CXX', 'g++')
     path = subprocess.check_output([CXXNAME, '-print-file-name=libstdc++.a'])
     path = path[:-1]
-    if type(path) != str: # python 3
+    if type(path) != str:  # python 3
         path = path.decode(sys.stdout.encoding)
     extra_link_args += [path]
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1366,6 +1366,35 @@ class TestAutograd(TestCase):
         c.backward(torch.ones(c.size()))
         self.assertEqual(x.grad.data, torch.ones(x.size()))
 
+    def test_keepdim_warning(self):
+        torch.utils.backcompat.keepdim_warning.enabled = True
+        x = Variable(torch.randn(3, 4), requires_grad=True)
+
+        def keepdim_check(f):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                y = f(x, 1)
+                self.assertTrue(len(w) == 1)
+                self.assertTrue(issubclass(w[-1].category, UserWarning))
+                self.assertTrue("keepdim" in str(w[-1].message))
+                if type(y) is tuple:
+                    y = y[0]
+                # check that backward runs smooth
+                y.backward(y.data.new(y.size()).normal_())
+                self.assertEqual(x.size(), x.grad.size())
+
+        keepdim_check(torch.sum)
+        keepdim_check(torch.prod)
+        keepdim_check(torch.mean)
+        keepdim_check(torch.max)
+        keepdim_check(torch.min)
+        keepdim_check(torch.mode)
+        keepdim_check(torch.median)
+        keepdim_check(torch.kthvalue)
+        keepdim_check(torch.var)
+        keepdim_check(torch.std)
+        torch.utils.backcompat.keepdim_warning.enabled = False
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -449,32 +449,32 @@ class Variable(_C._VariableBase):
     def rsqrt(self):
         return Rsqrt.apply(self)
 
-    def sum(self, dim=None, keepdim=False):
+    def sum(self, dim=None, keepdim=None):
         return Sum.apply(self, dim, keepdim)
 
-    def prod(self, dim=None, keepdim=False):
+    def prod(self, dim=None, keepdim=None):
         return Prod.apply(self, dim, keepdim)
 
-    def mean(self, dim=None, keepdim=False):
+    def mean(self, dim=None, keepdim=None):
         return Mean.apply(self, dim, keepdim)
 
-    def max(self, dim=None, keepdim=False):
+    def max(self, dim=None, keepdim=None):
         if isinstance(dim, Variable):
             return Cmax.apply(self, dim)
         return Max.apply(self, dim, keepdim)
 
-    def min(self, dim=None, keepdim=False):
+    def min(self, dim=None, keepdim=None):
         if isinstance(dim, Variable):
             return Cmin.apply(self, dim)
         return Min.apply(self, dim, keepdim)
 
-    def mode(self, dim=None, keepdim=False):
+    def mode(self, dim=None, keepdim=None):
         return Mode.apply(self, dim, keepdim)
 
-    def median(self, dim=None, keepdim=False):
+    def median(self, dim=None, keepdim=None):
         return Median.apply(self, dim, keepdim)
 
-    def kthvalue(self, k, dim=None, keepdim=False):
+    def kthvalue(self, k, dim=None, keepdim=None):
         return Kthvalue.apply(self, k, dim, keepdim)
 
     def sort(self, dim=None, descending=False):
@@ -508,20 +508,21 @@ class Variable(_C._VariableBase):
     def unfold(self, dim, size, step):
         return Unfold.apply(self, dim, size, step)
 
-    def var(self, dim=None, keepdim=False, unbiased=True):
+    def var(self, dim=None, keepdim=None, unbiased=True):
+        keepdim_ = False if keepdim is None else keepdim
         mean = self.mean(dim, keepdim)
         if dim is None:
             mean = mean.view(*(1 for s in self.size()))
         # we could just set keepdim to True, but this preserves some fidelity
-        elif keepdim is False and self.dim() != 1:
+        elif keepdim_ is False and self.dim() != 1:
             mean = mean.unsqueeze(dim)
         mean_expanded = mean.expand_as(self)
         zero_centered = self.sub(mean_expanded)
-        var = zero_centered.mul(zero_centered).sum(dim, keepdim)
+        var = zero_centered.mul(zero_centered).sum(dim, keepdim=keepdim_)
         numel = self.numel() if dim is None else self.size(dim)
         return var.div(numel - int(unbiased))
 
-    def std(self, dim=None, keepdim=False, unbiased=True):
+    def std(self, dim=None, keepdim=None, unbiased=True):
         return self.var(dim, keepdim, unbiased).sqrt()
 
     def renorm(self, p, dim, maxnorm):
@@ -626,7 +627,7 @@ class Variable(_C._VariableBase):
     def addcdiv_(self, *args):
         return self._addcop(Addcdiv, args, True)
 
-    def norm(self, p=2, dim=None, keepdim=False):
+    def norm(self, p=2, dim=None, keepdim=None):
         return Norm.apply(self, p, dim, keepdim)
 
     def dist(self, tensor, p=2):


### PR DESCRIPTION
keepdim backward compatibility warnings were silent in the context of `Variable`. Fixed this.
cc: @gchanan for review.