### PR TITLE
README CMAKE_PREFIX_PATH trick, from Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If you want to disable CUDA support, export environment variable `NO_CUDA=1`.
 
 On Linux
 ```bash
-export CMAKE_PREFIX_PATH=[anaconda root directory]
+export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root directory]
 
 # Install basic dependencies
 conda install numpy pyyaml mkl setuptools cmake gcc cffi


### PR DESCRIPTION
If you're installing from source in a conda env that's not root, this saves time. Just copied from the Dockerfile already in the repo. Not really necessary if you have any idea how the compilation or conda actually works, but if you're lazy and you just want to copy-paste things from install instructions, this helps.