### PR TITLE
Replace thpp::Tensor with ATen Tensor in autograd csrc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,22 @@ cache:
 install:
     - unset CCACHE_DISABLE
     - export CCACHE_DIR=$HOME/.ccache
-    - export CC="ccache gcc-4.8"
-    - export CXX="ccache g++-4.8"
+    - export CC="ccache gcc-5"
+    - export CXX="ccache g++-5"
     - ccache --show-stats
     - travis_retry pip install --upgrade pip setuptools wheel
     - travis_retry pip install -r requirements.txt --only-binary=scipy
-    - python setup.py install
-
-script:
-    - OMP_NUM_THREADS=2 ./test/run_test.sh
+    - MAX_JOBS=8 python setup.py install
 
 addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
         packages:
-            - gcc-4.8
-            - g++-4.8
+            - g++-5
+
+script:
+    - OMP_NUM_THREADS=2 ./test/run_test.sh
 
 # This reportedly works around an issue downloading packages from pypi on
 # travis.  Consider removing this after the underlying issue is fixed.

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ def parallelCCompile(self, sources, output_dir=None, macros=None,
         src, ext = build[obj]
         self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
     num_jobs = multiprocessing.cpu_count()
+    max_jobs = os.getenv("MAX_JOBS")
+    if max_jobs is not None:
+        num_jobs = min(num_jobs, int(max_jobs))
     multiprocessing.pool.ThreadPool(num_jobs).map(_single_compile, objects)
 
     return objects

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -221,7 +221,7 @@ PyObject* createPyObject(at::Tensor& tensor)
   PyObject *obj = type->tp_alloc(type, 0);
   if (obj) {
     // Retain underlying TH Tensor
-    ((THPVoidTensor*)obj)->cdata = (THVoidTensor *)tensor.detach()->unsafeGetTH(true);
+    ((THPVoidTensor*)obj)->cdata = (THVoidTensor *)tensor.unsafeGetTH(true);
   }
   return obj;
 }

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -213,13 +213,14 @@ at::Tensor createTensorAT(PyObject *data)
 {
   auto tensor_type = pytype_to_attype.at(Py_TYPE(data));
   auto tensor = ((THPVoidTensor *)data)->cdata;
-  return tensor_type->unsafeTensorFromTH(tensor, true);
+  return tensor_type->unsafeTensorFromTH(tensor, true); // Calls retain on underlying TH Tensor
 }
-PyObject* createPyObject(at::Tensor tensor)
+PyObject* createPyObject(at::Tensor& tensor)
 {
   auto type = getPyTypeObject(tensor);
   PyObject *obj = type->tp_alloc(type, 0);
   if (obj) {
+    // Retain underlying TH Tensor
     ((THPVoidTensor*)obj)->cdata = (THVoidTensor *)tensor.detach()->unsafeGetTH(true);
   }
   return obj;

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -23,7 +23,7 @@ std::unique_ptr<thpp::Tensor> createTensor(PyObject *data);
 // Creates Python tensor object from a Tensor
 PyObject* createPyObject(const thpp::Tensor& tensor);
 
-PyObject* createPyObject(at::Tensor tensor);
+PyObject* createPyObject(at::Tensor& tensor);
 PyTypeObject* getPyTypeObject(const at::Tensor& tensor);
 //rename to createPyObject when THPP is removed
 at::Tensor createTensorAT(PyObject *data);

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -10,7 +10,7 @@ struct THPSize {
   PyTupleObject tuple;
 };
 
-PyObject * THPSize_New(int dim, long *sizes)
+PyObject * THPSize_New(int dim, int64_t *sizes)
 {
   PyTypeObject* type = (PyTypeObject*)THPSizeClass;
   PyObject* self = type->tp_alloc(type, dim);

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -10,7 +10,7 @@ struct THPSize {
   PyTupleObject tuple;
 };
 
-PyObject * THPSize_New(int dim, int64_t *sizes)
+PyObject * THPSize_New(int dim, long *sizes)
 {
   PyTypeObject* type = (PyTypeObject*)THPSizeClass;
   PyObject* self = type->tp_alloc(type, dim);

--- a/torch/csrc/Size.h
+++ b/torch/csrc/Size.h
@@ -7,7 +7,7 @@ extern PyObject *THPSizeClass;
 
 #define THPSize_Check(obj) ((PyObject*)Py_TYPE(obj) == THPSizeClass)
 
-PyObject * THPSize_New(int dim, long *sizes);
+PyObject * THPSize_New(int dim, int64_t *sizes);
 
 #ifdef _THP_CORE
 bool THPSize_init(PyObject *module);

--- a/torch/csrc/Size.h
+++ b/torch/csrc/Size.h
@@ -7,7 +7,7 @@ extern PyObject *THPSizeClass;
 
 #define THPSize_Check(obj) ((PyObject*)Py_TYPE(obj) == THPSizeClass)
 
-PyObject * THPSize_New(int dim, int64_t *sizes);
+PyObject * THPSize_New(int dim, long *sizes);
 
 #ifdef _THP_CORE
 bool THPSize_init(PyObject *module);

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -9,7 +9,7 @@
 #include <Python.h>
 #include "torch/csrc/autograd/function_hook.h"
 
-#include <THPP/THPP.h>
+#include <ATen/ATen.h>
 
 #include <memory>
 #include <vector>
@@ -19,7 +19,7 @@ namespace torch { namespace autograd {
 struct Function;
 struct Variable;
 
-using tensor_list = std::vector<std::unique_ptr<thpp::Tensor>>;
+using tensor_list = std::vector<at::Tensor>;
 using variable_list = std::vector<std::shared_ptr<Variable>>;
 using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -21,7 +21,11 @@ auto AccumulateGrad::acc_inplace(std::shared_ptr<Variable>& grad,
   auto& new_grad_data = new_grad->data;
   AutoGPU guard(grad_data.type().isCuda() ? grad_data.get_device() : -1);
 
-  grad_data += new_grad_data;
+  if (grad_data.type().isSparse() && !new_grad_data.type().isSparse()) {
+    grad->data = new_grad_data + grad_data;
+  } else {
+    grad_data += new_grad_data;
+  }
 }
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -19,16 +19,9 @@ auto AccumulateGrad::acc_inplace(std::shared_ptr<Variable>& grad,
     std::shared_ptr<Variable>& new_grad) -> void {
   auto& grad_data = grad->data;
   auto& new_grad_data = new_grad->data;
-  AutoGPU guard(grad_data->getDevice());
+  AutoGPU guard(grad_data.type().isCuda() ? grad_data.get_device() : -1);
 
-  // The grad may need a promotion from a sparse to dense type
-  if (grad_data->isSparse() && !new_grad_data->isSparse()) {
-    std::unique_ptr<thpp::Tensor> result = new_grad_data->newTensor();
-    result->cadd(*new_grad_data, *grad_data);
-    grad->data = std::move(result);
-  } else {
-    grad_data->cadd(*grad_data, *new_grad_data);
-  }
+  grad_data += new_grad_data;
 }
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
@@ -80,8 +73,7 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   } else {
     // Once the grad becomes not volatile, it should stay like that
     if (!var->grad->is_volatile && new_grad->is_volatile) {
-      new_grad = std::make_shared<Variable>(
-              std::unique_ptr<thpp::Tensor>(new_grad->data->clone_shallow()), false, false);
+      new_grad = std::make_shared<Variable>(new_grad->data, false, false);
     }
     var->grad = Add().apply({var->grad, new_grad})[0];
   }

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -14,7 +14,7 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   tensor_list outputs;
   outputs.reserve(inputs.size());
   for (auto& var : inputs) {
-    outputs.emplace_back(var ? var->data->clone_shallow() : nullptr);
+    outputs.emplace_back(var ? var->data : at::Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<Error>(msg, std::move(f));
@@ -25,16 +25,14 @@ auto Add::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Add", inputs, 2);
   auto& input1 = inputs[0]->data;
   auto& input2 = inputs[1]->data;
-  AutoGPU guard(input1->getDevice());
+  AutoGPU guard(input1.type().isCuda() ? input1.get_device() : -1);
 
-  bool first_sparse = input1->isSparse();
-  auto output = first_sparse ? input2->newTensor() : input1->newTensor();
-  if (first_sparse) {
-    output->cadd(*input2, *input1);
+  at::Tensor output;
+  if (input1.type().isSparse()) {
+    output = input2 + input1;
   } else {
-    output->cadd(*input1, *input2);
+    output = input1 + input2;
   }
-
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<AddBackward>(std::move(f));
   });

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -98,7 +98,7 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
         eps);
   }
 
-  auto outputs = as_tensor_list(output);
+  auto outputs = as_tensor_list(std::move(output));
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<BatchNormBackward>(
         f, *this, std::move(save_mean), std::move(save_std),

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -30,80 +30,75 @@ namespace {
 
 namespace torch { namespace autograd {
 
-using thpp::Tensor;
-
 #ifndef CUDNN_BN_MIN_EPSILON
 #define CUDNN_BN_MIN_EPSILON 0
 #endif
 
 auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("BatchNorm", inputs, 3, 1);
-  
+
   auto& input = inputs[0];
   auto& weight = inputs[1];
   auto& bias = inputs[2];
-  AutoGPU guard(input->data->getDevice());
-   
-  auto num_features = input->data->rawSizes()[1];
-  check_dims_match_num_input_features("running_mean", num_features, running_mean->numel());
-  check_dims_match_num_input_features("running_var", num_features, running_var->numel());
+  AutoGPU guard(input->data.type().isCuda() ? input->data.get_device() : -1);
+
+  auto num_features = input->data.sizes()[1];
+  check_dims_match_num_input_features("running_mean", num_features, running_mean.numel());
+  check_dims_match_num_input_features("running_var", num_features, running_var.numel());
   if (weight){
-    check_dims_match_num_input_features("weight", num_features, weight->data->numel());
+    check_dims_match_num_input_features("weight", num_features, weight->data.numel());
   }
   if (bias){
-    check_dims_match_num_input_features("bias", num_features, bias->data->numel());
+    check_dims_match_num_input_features("bias", num_features, bias->data.numel());
   }
 
   bool use_cudnn = false;
 #ifdef WITH_CUDNN
-  use_cudnn = (input->data->isCuda()
-               && input->data->type() != thpp::Type::HALF
+  use_cudnn = (input->data.type().isCuda()
+               && input->data.type().scalarType() != at::kHalf
                && weight && bias
                && cudnn_enabled && CUDNN_VERSION >= 5110L);
 #endif
 
-  auto output = input->data->newTensor();
-  output->resizeAs(*input->data);
-
-  std::unique_ptr<Tensor> save_mean(output->newTensor());
-  save_mean->resizeAs(*running_mean);
-  std::unique_ptr<Tensor> save_std(output->newTensor());
-  save_std->resizeAs(*running_var);
+  auto output = input->data.type().tensor(input->data.sizes());
+  auto save_mean = running_mean.type().tensor(running_mean.sizes());
+  auto save_std = running_var.type().tensor(running_var.sizes());
 
   if (use_cudnn && eps >= CUDNN_BN_MIN_EPSILON) {
 #ifdef WITH_CUDNN
     torch::cudnn::cudnn_batch_norm_forward(
         state,
         torch::cudnn::getCudnnHandle(),
-        torch::cudnn::getCudnnDataType(*input->data),
-        (THVoidTensor*)input->data->cdata(),
-        (THVoidTensor*)output->cdata(),
-        (THVoidTensor*)weight->data->cdata(),
-        (THVoidTensor*)bias->data->cdata(),
-        (THVoidTensor*)running_mean->cdata(),
-        (THVoidTensor*)running_var->cdata(),
-        (THVoidTensor*)save_mean->cdata(),
-        (THVoidTensor*)save_std->cdata(),
+        torch::cudnn::getCudnnDataType(input->data),
+        (THVoidTensor*)input->data.unsafeGetTH(false),
+        (THVoidTensor*)output.unsafeGetTH(false),
+        (THVoidTensor*)weight->data.unsafeGetTH(false),
+        (THVoidTensor*)bias->data.unsafeGetTH(false),
+        (THVoidTensor*)running_mean.unsafeGetTH(false),
+        (THVoidTensor*)running_var.unsafeGetTH(false),
+        (THVoidTensor*)save_mean.unsafeGetTH(false),
+        (THVoidTensor*)save_std.unsafeGetTH(false),
         training,
         momentum,
         eps);
 #endif
   } else {
-    torch::nn::BatchNormalization_updateOutput(
-        input->data.get(),
-        output.get(),
-        weight ? weight->data.get() : nullptr,
-        bias ? bias->data.get() : nullptr,
-        running_mean.get(),
-        running_var.get(),
-        save_mean.get(),
-        save_std.get(),
+      at::Tensor nt;
+      at::BatchNormalization_updateOutput(
+        input->data,
+        output,
+        weight ? weight->data : nt,
+        bias ? bias->data : nt,
+        running_mean,
+        running_var,
+        save_mean,
+        save_std,
         training,
         momentum,
         eps);
   }
 
-  auto outputs = as_tensor_list(std::move(output));
+  auto outputs = as_tensor_list(output);
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<BatchNormBackward>(
         f, *this, std::move(save_mean), std::move(save_std),
@@ -119,77 +114,74 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
   auto weight_var = this->weight.unpack();
   auto bias_var = this->bias.unpack();
 
-  std::unique_ptr<thpp::Tensor> input {input_var->data->clone_shallow()};
-  std::unique_ptr<thpp::Tensor> weight {weight_var ? weight_var->data->clone_shallow() : nullptr};
-  std::unique_ptr<thpp::Tensor> bias {bias_var ? bias_var->data->clone_shallow() : nullptr};
+  auto input = input_var->data;
+  auto weight = weight_var ? weight_var->data : at::Tensor();
+  auto bias = bias_var ? bias_var->data : at::Tensor();
 
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
   bool use_cudnn = false;
 #ifdef WITH_CUDNN
-  use_cudnn = (input->isCuda()
-               && input->type() != thpp::Type::HALF
-               && weight && bias && training
+  use_cudnn = (input.type().backend() == at::kCUDA
+               && input.type().scalarType() != at::kHalf
+               && weight.defined() && bias.defined() && training
                && cudnn_enabled && CUDNN_VERSION >= 5110L);
 #endif
 
-  std::unique_ptr<Tensor> grad_input;
+  at::Tensor grad_input;
   if (should_compute_output(0) || use_cudnn) {
-    grad_input = input->newTensor();
-    grad_input->resizeAs(*input);
+    grad_input = input.type().tensor(input.sizes());
   }
 
-  std::unique_ptr<Tensor> grad_weight;
+  at::Tensor grad_weight;
   if (should_compute_output(1) || use_cudnn) {
-    grad_weight = weight->newTensor();
-    grad_weight->resizeAs(*weight);
+    grad_weight = weight.type().tensor(weight.sizes());
     if (!use_cudnn) {
-      grad_weight->zero();
+      grad_weight.zero_();
     }
   }
 
-  std::unique_ptr<Tensor> grad_bias;
+  at::Tensor grad_bias;
   if (should_compute_output(2) || use_cudnn) {
-    grad_bias = bias->newTensor();
-    grad_bias->resizeAs(*bias);
+    grad_bias = bias.type().tensor(bias.sizes());
     if (!use_cudnn) {
-      grad_bias->zero();
+      grad_bias.zero_();
     }
   }
 
-  auto grad_output = grad_outputs[0]->data->contiguous();
+  auto grad_output = grad_outputs[0]->data.contiguous();
 
   if (use_cudnn && eps >= CUDNN_BN_MIN_EPSILON) {
 #ifdef WITH_CUDNN
     torch::cudnn::cudnn_batch_norm_backward(
         state,
         torch::cudnn::getCudnnHandle(),
-        torch::cudnn::getCudnnDataType(*input),
-        (THVoidTensor*)input->cdata(),
-        (THVoidTensor*)grad_output->cdata(),
-        (THVoidTensor*)grad_input->cdata(),
-        (THVoidTensor*)grad_weight->cdata(),
-        (THVoidTensor*)grad_bias->cdata(),
-        (THVoidTensor*)weight->cdata(),
-        (THVoidTensor*)running_mean->cdata(),
-        (THVoidTensor*)running_var->cdata(),
-        (THVoidTensor*)save_mean->cdata(),
-        (THVoidTensor*)save_std->cdata(),
+        torch::cudnn::getCudnnDataType(input),
+        (THVoidTensor*)input.unsafeGetTH(false),
+        (THVoidTensor*)grad_output.unsafeGetTH(false),
+        (THVoidTensor*)grad_input.unsafeGetTH(false),
+        (THVoidTensor*)grad_weight.unsafeGetTH(false),
+        (THVoidTensor*)grad_bias.unsafeGetTH(false),
+        (THVoidTensor*)weight.unsafeGetTH(false),
+        (THVoidTensor*)running_mean.unsafeGetTH(false),
+        (THVoidTensor*)running_var.unsafeGetTH(false),
+        (THVoidTensor*)save_mean.unsafeGetTH(false),
+        (THVoidTensor*)save_std.unsafeGetTH(false),
         training,
         eps);
 #endif
   } else {
-    torch::nn::BatchNormalization_backward(
-        input.get(),
-        grad_output.get(),
-        grad_input.get(),
-        grad_weight.get(),
-        grad_bias.get(),
-        weight.get(),
-        running_mean.get(),
-        running_var.get(),
-        save_mean.get(),
-        save_std.get(),
+    at::BatchNormalization_backward(
+        input,
+        grad_output,
+        grad_input,
+        grad_weight,
+        grad_bias,
+        weight,
+        running_mean,
+        running_var,
+        save_mean,
+        save_std,
         training,
         1.0,
         eps);

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -2,7 +2,7 @@
 
 #include <Python.h>
 #include <memory>
-#include <THPP/THPP.h>
+#include <ATen/ATen.h>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
@@ -10,8 +10,8 @@
 namespace torch { namespace autograd {
 
 struct BatchNormParams {
-  std::shared_ptr<thpp::Tensor> running_mean;
-  std::shared_ptr<thpp::Tensor> running_var;
+  at::Tensor running_mean;
+  at::Tensor running_var;
   bool training;
   double momentum;
   double eps;
@@ -29,8 +29,8 @@ struct BatchNormBackward : public Function, public BatchNormParams {
   BatchNormBackward(
       FunctionFlags flags,
       BatchNormParams params,
-      std::unique_ptr<thpp::Tensor> save_mean,
-      std::unique_ptr<thpp::Tensor> save_std,
+      at::Tensor save_mean,
+      at::Tensor save_std,
       SavedVariable input,
       SavedVariable weight,
       SavedVariable bias)
@@ -49,8 +49,8 @@ struct BatchNormBackward : public Function, public BatchNormParams {
 
   virtual void releaseVariables() override;
 
-  std::unique_ptr<thpp::Tensor> save_mean;
-  std::unique_ptr<thpp::Tensor> save_std;
+  at::Tensor save_mean;
+  at::Tensor save_std;
   SavedVariable input;
   SavedVariable weight;
   SavedVariable bias;

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -60,8 +60,8 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
   BatchNormBackwardBackward(
       FunctionFlags flags,
       BatchNormParams params,
-      std::unique_ptr<thpp::Tensor> save_mean,
-      std::unique_ptr<thpp::Tensor> save_std,
+      at::Tensor save_mean,
+      at::Tensor save_std,
       SavedVariable input,
       SavedVariable weight,
       SavedVariable grad_output)
@@ -80,8 +80,8 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
 
   virtual void releaseVariables() override;
 
-  std::unique_ptr<thpp::Tensor> save_mean;
-  std::unique_ptr<thpp::Tensor> save_std;
+  at::Tensor save_mean;
+  at::Tensor save_std;
   SavedVariable input;
   SavedVariable weight;
   SavedVariable grad_output;

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -10,6 +10,7 @@
 #include "torch/csrc/utils/auto_gpu.h"
 
 #include "THPP/Type.hpp"
+#include "ATen/Tensor.h"
 
 #ifdef WITH_CUDNN
 #include "torch/csrc/cudnn/Conv.h"
@@ -20,24 +21,24 @@ using namespace torch::cudnn;
 #endif
 
 using namespace torch::nn;
-using thpp::Tensor;
+// using thpp::Tensor;
 using torch::cudnn::Convolution;
-using tensor_pair = std::pair<std::unique_ptr<Tensor>, std::unique_ptr<Tensor>>;
+using tensor_pair = std::pair<at::Tensor, at::Tensor>;
 
 namespace torch { namespace autograd {
 
 // Forward function definition and utility functions
 
-static std::unique_ptr<Tensor> compute_output(
-  Tensor* input, Tensor* weight, Tensor* bias, Tensor* columns, Tensor* ones,
+static at::Tensor compute_output(
+  at::Tensor& input, at::Tensor& weight, at::Tensor& bias, at::Tensor& columns, at::Tensor& ones,
   const std::vector<long>& kernel_size, const ConvParams& params);
 
-static std::unique_ptr<Tensor> compute_grad_input(
-  Tensor* input, Tensor* grad_output, Tensor* weight, Tensor* columns, Tensor* ones,
+static at::Tensor compute_grad_input(
+  at::Tensor& input, at::Tensor& grad_output, at::Tensor& weight, at::Tensor& columns, at::Tensor& ones,
   const std::vector<long>& kernel_size, const ConvParams& params);
 
 static tensor_pair compute_grad_params(
-  Tensor* input, Tensor* grad_output, Tensor* weight, Tensor* bias, Tensor* columns, Tensor* ones,
+  at::Tensor& input, at::Tensor& grad_output, at::Tensor& weight, at::Tensor& bias, at::Tensor& columns, at::Tensor& ones,
   const std::vector<long>& kernel_size, const ConvBackward& params);
 
 auto ConvParams::is_dilated() const -> bool {
@@ -74,9 +75,9 @@ auto ConvParams::view1d_as_2d() -> void {
   }
 }
 
-auto ConvParams::use_cudnn(const Tensor& input) const -> bool {
+auto ConvParams::use_cudnn(const at::Tensor& input) const -> bool {
 #ifdef WITH_CUDNN
-  if (!input.isCuda() || !cudnn_enabled) {
+  if (!input.type().isCuda() || !cudnn_enabled) {
     return false;
   }
   if (is_dilated()) {
@@ -89,10 +90,10 @@ auto ConvParams::use_cudnn(const Tensor& input) const -> bool {
   return false;
 }
 
-auto ConvForward::output_size(Tensor& input, Tensor& weight) -> std::vector<long> {
+auto ConvForward::output_size(at::Tensor& input, at::Tensor& weight) -> std::vector<long> {
   auto in_size = input.sizes();
   auto weight_size = weight.sizes();
-  auto dim = input.nDim();
+  auto dim = input.ndimension();
 
   std::vector<long> output_size(dim);
   output_size[0] = in_size[0];
@@ -109,48 +110,44 @@ auto ConvForward::output_size(Tensor& input, Tensor& weight) -> std::vector<long
   return output_size;
 }
 
-static auto view4d(const Tensor& tensor) -> std::unique_ptr<Tensor> {
-  if (tensor.nDim() != 3) throw std::runtime_error("expected 3D tensor");
-  auto result = tensor.newTensor();
-  result->unsqueeze(tensor, 2);
-  return result;
+static auto view4d(const at::Tensor& tensor) -> at::Tensor {
+  if (tensor.ndimension() != 3) throw std::runtime_error("expected 3D tensor");
+  return tensor.unsqueeze(2);
 }
 
-static auto view3d(const Tensor& tensor) -> std::unique_ptr<Tensor> {
-  if (tensor.nDim() != 4) throw std::runtime_error("expected 4D tensor");
-  auto result = tensor.newTensor();
-  result->squeeze(tensor, 2);
-  return result;
+static auto view3d(const at::Tensor& tensor) -> at::Tensor {
+  if (tensor.ndimension() != 4) throw std::runtime_error("expected 4D tensor");
+  return tensor.squeeze(2);
 }
 
-static std::unique_ptr<Tensor> subtensor(Tensor* tensor, int dim, int groups, int g) {
-  if (!tensor) {
-    return nullptr;
+static at::Tensor subtensor(at::Tensor& tensor, int dim, int groups, int g) {
+  if (!tensor.defined()) {
+    at::Tensor empty;
+    return empty;
   }
-  long n = tensor->rawSizes()[dim] / groups;
-  auto result = tensor->newTensor();
-  result->narrow(*tensor, dim, n * g, n);
-  return result->contiguous();
+  long n = tensor.sizes()[dim] / groups;
+  return tensor.narrow(dim, n * g, n).contiguous();
 }
 
 static std::shared_ptr<Variable> subvariable(std::shared_ptr<Variable> var, int dim, int groups, int g) {
-  long n = var->data->rawSizes()[dim] / groups;
+  long n = var->data.sizes()[dim] / groups;
   auto result = std::make_shared<Narrow>(dim, n * g, n)->apply({var})[0];
   return result;
 }
 
-static std::unique_ptr<Tensor> cat(const tensor_list& tensors, int dim) {
+static at::Tensor cat(const tensor_list& tensors, int dim) {
   int num_inputs = tensors.size();
   if (num_inputs == 0) {
-    return nullptr;
+    at::Tensor empty;
+    return empty;
   }
 
-  std::vector<Tensor*> ptrs(num_inputs);
+  std::vector<at::Tensor> ptrs(num_inputs);
   for (int i = 0; i < num_inputs; ++i) {
-    ptrs[i] = tensors[i].get();
+    ptrs[i] = tensors[i];
   }
-  auto output = tensors[0]->newTensor();
-  output->cat(ptrs, dim);
+  auto output = tensors[0].type().tensor();
+  at::cat_out(tensors, dim, output);
   return output;
 }
 
@@ -161,79 +158,80 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("ConvNd", inputs, 3, 2);
   if (is_padding_neg()) throw std::runtime_error("negative padding is not supported");
   if (is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
-  AutoGPU guard(inputs[0]->data->getDevice());
-  auto input = inputs[0]->data->contiguous();
-  std::unique_ptr<Tensor> weight(inputs[1]->data->clone_shallow());
-  std::unique_ptr<Tensor> bias(inputs[2] ? inputs[2]->data->clone_shallow() : nullptr);
+  AutoGPU guard(inputs[0]->data.type().isCuda() ? inputs[0]->data.get_device() : -1);
+  auto input = inputs[0]->data.contiguous();
+  auto weight = inputs[1]->data;
+  auto bias = inputs[2] ? inputs[2]->data : at::Tensor();
 
-  int k = input->nDim();
+  int k = input.ndimension();
   if (k == 3) {
     view1d_as_2d();
-    input = view4d(*input);
-    weight = view4d(*weight);
+    input = view4d(input);
+    weight = view4d(weight);
   }
 
-  auto weight_size = weight->sizes();
+  auto weight_size = weight.sizes();
   std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
 
-  std::unique_ptr<Tensor> output;
+  auto output = input.type().tensor();
   tensor_list columns(groups);
   tensor_list ones(groups);
   std::unique_ptr<Convolution> convolution;
 
-  if (use_cudnn(*input)) {
+  if (use_cudnn(input)) {
 #ifdef WITH_CUDNN
-    if (input->type() != weight->type()){
+    if (input.type().ID() != weight.type().ID()){
       std::stringstream ss;
-      ss << "Input type (" << thpp::toString(input->type()) << ") and weight type (" << thpp::toString(weight->type()) << ") should be the same";
+      ss << "Input type (" << input.toString() << ") and weight type (" << weight.toString() << ") should be the same";
       throw std::runtime_error(ss.str());
     }
-    if (bias.get() != NULL && input->type() != bias->type()){
+    if (bias.defined() && input.type().ID() != bias.type().ID()){
       std::stringstream ss;
-      ss << "Input type (" << thpp::toString(input->type()) << ") and bias type (" << thpp::toString(bias->type()) << ") should be the same";
+      ss << "Input type (" << input.toString() << ") and bias type (" << bias.toString() << ") should be the same";
       throw std::runtime_error(ss.str());
     }
-    output = input->newTensor();
-    output->resize(output_size(*input, *weight));
+
+    output = input.type().tensor();
+    output.resize_(output_size(input, weight));
     if (transposed) {
       convolution.reset(cudnn_convolution_transpose_full_forward(
-          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-          (THVoidTensor*)input->cdata(), (THVoidTensor*)weight->cdata(),
-          bias ? (THVoidTensor*)bias->cdata() : nullptr, (THVoidTensor*)output->cdata(),
+          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+          (THVoidTensor*)input.unsafeGetTH(false), (THVoidTensor*)weight.unsafeGetTH(false),
+          bias.defined() ? (THVoidTensor*)bias.unsafeGetTH(false) : nullptr, (THVoidTensor*)output.unsafeGetTH(false),
           padding, stride, dilation, groups, benchmark));
     } else {
       convolution.reset(cudnn_convolution_full_forward(
-          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-          (THVoidTensor*)input->cdata(), (THVoidTensor*)weight->cdata(),
-          bias ? (THVoidTensor*)bias->cdata() : nullptr, (THVoidTensor*)output->cdata(),
+          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+          (THVoidTensor*)input.unsafeGetTH(false), (THVoidTensor*)weight.unsafeGetTH(false),
+          bias.defined() ? (THVoidTensor*)bias.unsafeGetTH(false) : nullptr, (THVoidTensor*)output.unsafeGetTH(false),
           padding, stride, dilation, groups, benchmark));
     }
 #endif
   } else {
     for (int g = 0; g < groups; ++g) {
-      columns[g] = input->newTensor();
-      ones[g] = input->newTensor();
+      columns[g] = input.type().tensor();
+      ones[g] = input.type().tensor();
     }
     if (groups == 1) {
       output = compute_output(
-          input.get(), weight.get(), bias.get(),
-          columns[0].get(), ones[0].get(), kernel_size, *this);
+          input, weight, bias,
+          columns[0], ones[0], kernel_size, *this);
     } else {
       tensor_list outputs(groups);
       for (int g = 0; g < groups; ++g) {
-        auto input_g = subtensor(input.get(), 1, groups, g);
-        auto weight_g = subtensor(weight.get(), 0, groups, g);
-        auto bias_g = subtensor(bias.get(), 0, groups, g);
+        auto input_g = subtensor(input, 1, groups, g);
+        auto weight_g = subtensor(weight, 0, groups, g);
+        auto bias_g = subtensor(bias, 0, groups, g);
         outputs[g] = compute_output(
-            input_g.get(), weight_g.get(), bias_g.get(),
-            columns[g].get(), ones[g].get(), kernel_size, *this);
+            input_g, weight_g, bias_g,
+            columns[g], ones[g], kernel_size, *this);
       }
       output = cat(outputs, 1);
     }
   }
 
   if (k == 3) {
-    output = view3d(*output);
+    output = view3d(output);
   }
 
   auto outputs = as_tensor_list(std::move(output));
@@ -257,63 +255,63 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   auto weight_var = weight_.unpack();
   auto bias_var = bias_.unpack();
 
-  std::unique_ptr<thpp::Tensor> input {input_var->data->clone_shallow()};
-  std::unique_ptr<thpp::Tensor> weight {weight_var->data->clone_shallow()};
-  std::unique_ptr<thpp::Tensor> bias {bias_var ? bias_var->data->clone_shallow() : nullptr};
+  auto input = input_var->data;
+  auto weight = weight_var->data;
+  auto bias = bias_var ? bias_var->data : at::Tensor();
 
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  input = input->contiguous();
-  auto grad_output = grad_outputs[0]->data->contiguous();
+  input = input.contiguous();
+  auto grad_output = grad_outputs[0]->data.contiguous();
 
-  int k = input->nDim();
+  int k = input.ndimension();
   if (k == 3) {
-    input = view4d(*input);
-    weight = view4d(*weight);
-    grad_output = view4d(*grad_output);
+    input = view4d(input);
+    weight = view4d(weight);
+    grad_output = view4d(grad_output);
   }
 
-  auto weight_size = weight->sizes();
+  auto weight_size = weight.sizes();
   std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
 
-  bool use_cudnn = this->use_cudnn(*input);
+  bool use_cudnn = this->use_cudnn(input);
 
-  std::unique_ptr<Tensor> grad_input;
-  std::unique_ptr<Tensor> grad_weight;
-  std::unique_ptr<Tensor> grad_bias;
+  at::Tensor grad_input;
+  at::Tensor grad_weight;
+  at::Tensor grad_bias;
 
   if (should_compute_output(0)) {
     if (use_cudnn) {
 #ifdef WITH_CUDNN
-      grad_input = input->newTensor();
-      grad_input->resizeAs(*input);
+      grad_input = input.type().tensor();
+      grad_input.resize_as_(input);
       if (transposed) {
         // ConvTranspose uses the same kernels as regular convolution
         // but swaps forward and backward calls
         cudnn_convolution_forward(
-            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-            (THVoidTensor*)grad_output->cdata(), (THVoidTensor*)weight->cdata(), (THVoidTensor*)grad_input->cdata(),
+            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+            (THVoidTensor*)grad_output.unsafeGetTH(false), (THVoidTensor*)weight.unsafeGetTH(false), (THVoidTensor*)grad_input.unsafeGetTH(false),
             convolution.get(), benchmark);
       } else {
         cudnn_convolution_backward_data(
-            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-            (THVoidTensor*)grad_output->cdata(), (THVoidTensor*)grad_input->cdata(), (THVoidTensor*)weight->cdata(),
+            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+            (THVoidTensor*)grad_output.unsafeGetTH(false), (THVoidTensor*)grad_input.unsafeGetTH(false), (THVoidTensor*)weight.unsafeGetTH(false),
             convolution.get(), benchmark);
       }
 #endif
     } else if (groups == 1) {
       grad_input = compute_grad_input(
-          input.get(), grad_output.get(), weight.get(),
-          columns[0].get(), ones[0].get(), kernel_size, *this);
+          input, grad_output, weight,
+          columns[0], ones[0], kernel_size, *this);
     } else {
       tensor_list grad_inputs(groups);
       for (int g = 0; g < groups; ++g) {
-        auto input_g = subtensor(input.get(), 1, groups, g);
-        auto grad_output_g = subtensor(grad_output.get(), 1, groups, g);
-        auto weight_g = subtensor(weight.get(), 0, groups, g);
+        auto input_g = subtensor(input, 1, groups, g);
+        auto grad_output_g = subtensor(grad_output, 1, groups, g);
+        auto weight_g = subtensor(weight, 0, groups, g);
         grad_inputs[g] = compute_grad_input(
-            input_g.get(), grad_output_g.get(), weight_g.get(),
-            columns[g].get(), ones[g].get(), kernel_size, *this);
+            input_g, grad_output_g, weight_g,
+            columns[g], ones[g], kernel_size, *this);
       }
       grad_input = cat(grad_inputs, 1);
     }
@@ -322,51 +320,51 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   if (should_compute_output(1) || should_compute_output(2)) {
     if (use_cudnn) {
 #ifdef WITH_CUDNN
-      grad_weight = weight->newTensor();
-      grad_weight->resizeAs(*weight);
+      grad_weight = weight.type().tensor();
+      grad_weight.resize_as_(weight);
       cudnn_convolution_backward_filter(
-          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-          (THVoidTensor*)grad_output->cdata(), (THVoidTensor*)input->cdata(), (THVoidTensor*)grad_weight->cdata(),
+          state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+          (THVoidTensor*)grad_output.unsafeGetTH(false), (THVoidTensor*)input.unsafeGetTH(false), (THVoidTensor*)grad_weight.unsafeGetTH(false),
           convolution.get(), benchmark);
 
-      if (bias && should_compute_output(2)) {
-        grad_bias = bias->newTensor();
-        grad_bias->resizeAs(*bias);
+      if (bias.defined() && should_compute_output(2)) {
+        grad_bias = bias.type().tensor();
+        grad_bias.resize_as_(bias);
         cudnn_convolution_backward_bias(
-            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(*input),
-            (THVoidTensor*)grad_output->cdata(), (THVoidTensor*)grad_bias->cdata(),
+            state, torch::cudnn::getCudnnHandle(), torch::cudnn::getCudnnDataType(input),
+            (THVoidTensor*)grad_output.unsafeGetTH(false), (THVoidTensor*)grad_bias.unsafeGetTH(false),
             convolution.get());
       }
 #endif
     } else if (groups == 1) {
       std::tie(grad_weight, grad_bias) = compute_grad_params(
-          input.get(), grad_output.get(), weight.get(), bias.get(),
-          columns[0].get(), ones[0].get(), kernel_size, *this);
+          input, grad_output, weight, bias,
+          columns[0], ones[0], kernel_size, *this);
     } else {
       tensor_list grad_weights(groups);
       tensor_list grad_biases(groups);
       for (int g = 0; g < groups; ++g) {
-        auto input_g = subtensor(input.get(), 1, groups, g);
-        auto grad_output_g = subtensor(grad_output.get(), 1, groups, g);
-        auto weight_g = subtensor(weight.get(), 0, groups, g);
-        auto bias_g = subtensor(bias.get(), 0, groups, g);
+        auto input_g = subtensor(input, 1, groups, g);
+        auto grad_output_g = subtensor(grad_output, 1, groups, g);
+        auto weight_g = subtensor(weight, 0, groups, g);
+        auto bias_g = subtensor(bias, 0, groups, g);
         std::tie(grad_weights[g], grad_biases[g]) = compute_grad_params(
-            input_g.get(), grad_output_g.get(), weight_g.get(), bias_g.get(),
-            columns[g].get(), ones[g].get(), kernel_size, *this);
+            input_g, grad_output_g, weight_g, bias_g,
+            columns[g], ones[g], kernel_size, *this);
       }
       grad_weight = cat(grad_weights, 0);
-      if (bias && should_compute_output(2)) {
+      if (bias.defined() && should_compute_output(2)) {
         grad_bias = cat(grad_biases, 0);
       }
     }
   }
 
   if (k == 3) {
-    if (grad_input) {
-      grad_input = view3d(*grad_input);
+    if (grad_input.defined()) {
+      grad_input = view3d(grad_input);
     }
-    if (grad_weight) {
-      grad_weight = view3d(*grad_weight);
+    if (grad_weight.defined()) {
+      grad_weight = view3d(grad_weight);
     }
   }
 
@@ -409,14 +407,14 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   // Compute ggO = conv(w, ggI) + conv(ggW, i) + ggb
   std::shared_ptr<Variable> ggO = nullptr;
   if (ggI) {
-    if (weight->data->isCuda()) {
+    if (weight->data.type().isCuda()) {
       weight = Contiguous().apply({weight})[0];
     }
     ggO = ConvForward(*this).apply({ggI, weight, nullptr})[0];
   }
 
   if (ggW) {
-    if (ggW->data->isCuda()) {
+    if (ggW->data.type().isCuda()) {
       ggW = Contiguous().apply({ggW})[0];
     }
     auto ggW_term = ConvForward(*this).apply({input_.unpack(), ggW, nullptr})[0];
@@ -429,13 +427,15 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
 
   if (ggb) {
     // View as (1, ggb.size(0), 1, 1...)
-    std::vector<long> new_size(gO->data->nDim(), 1);
-    new_size[1] = ggb->data->rawSizes()[0];
+
+    // Expand
+    std::vector<long> new_size(gO->data.ndimension(), 1);
+    new_size[1] = ggb->data.sizes()[0];
     auto ggb_contiguous = Contiguous().apply({ggb})[0];
     auto ggb_view = View(new_size).apply({ggb_contiguous})[0];
 
-    // Expand 
-    auto ggb_expanded = Expand(gO->data->sizes()).apply({ggb_view})[0];
+    // Expand
+    auto ggb_expanded = Expand(gO->data.sizes()).apply({ggb_view})[0];
 
     if (ggO) {
       ggO = Add().apply({ggO, ggb_expanded})[0];
@@ -452,9 +452,9 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     // Disable groups as they are handled separately
     auto groups = gw_conv_params.groups;
     gw_conv_params.groups = 1;
-    auto weight_size = weight->data->sizes();
+    auto weight_size = weight->data.sizes();
     std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
-    auto input_size = ggI->data->sizes();
+    auto input_size = ggI->data.sizes();
     std::vector<long> input_shape(input_size.begin() + 2, input_size.end());
     for(size_t i=0; i<gw_conv_params.padding.size(); ++i) {
       // Check if whole input has been used or not
@@ -475,7 +475,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     std::shared_ptr<Variable> gWt = nullptr;
     // Compute conv
     if (groups == 1) {
-      if (gOt->data->isCuda()) {
+      if (gOt->data.type().isCuda()) {
         gOt = Contiguous().apply({gOt})[0];
       }
 
@@ -486,7 +486,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
       for (int g = 0; g < groups; ++g) {
         auto ggIt_g = subvariable(ggIt, 0, groups, g);
         auto gOt_g = subvariable(gOt, 0, groups, g);
-        if (gOt_g->data->isCuda()) {
+        if (gOt_g->data.type().isCuda()) {
           gOt_g = Contiguous().apply({gOt_g})[0];
         }
 
@@ -523,7 +523,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
 
     std::shared_ptr<Variable> gIt = nullptr;
     if (groups == 1) {
-      if (gOt->data->isCuda()) {
+      if (gOt->data.type().isCuda()) {
         gOt = Contiguous().apply({gOt})[0];
       }
 
@@ -533,7 +533,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
       for (int g = 0; g < groups; ++g) {
         auto ggWt_g = subvariable(ggWt, 1, groups, g);
         auto gOt_g = subvariable(gOt, 0, groups, g);
-        if (gOt_g->data->isCuda()) {
+        if (gOt_g->data.type().isCuda()) {
           gOt_g = Contiguous().apply({gOt_g})[0];
         }
 
@@ -542,7 +542,7 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
 
       gIt = Cat(0).apply(gIt_list)[0];
     }
-    
+
     gI = Transpose(0, 1).apply({gIt})[0];
   }
 
@@ -558,14 +558,14 @@ auto ConvBackwardBackward::releaseVariables() -> void {
 
 // Forward and backward functions for Tensor
 
-static std::unique_ptr<Tensor> compute_output(
-    Tensor* input, Tensor* weight, Tensor* bias,
-    Tensor* columns, Tensor* ones,
+static at::Tensor compute_output(
+    at::Tensor& input, at::Tensor& weight, at::Tensor& bias,
+    at::Tensor& columns, at::Tensor& ones,
     const std::vector<long>& kernel_size,
     const ConvParams& params) {
 
-  auto output = input->newTensor();
-  auto dim = input->nDim();
+  auto output = input.type().tensor();
+  auto dim = input.ndimension();
   auto dilated = params.is_dilated();
 
   if (dilated) {
@@ -575,15 +575,15 @@ static std::unique_ptr<Tensor> compute_output(
     } else /* !transposed */ {
       /* dilated && !transposed */
       if (dim == 4) {
-        SpatialDilatedConvolution_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+        at::SpatialDilatedConvolution_updateOutput(
+            input, output, weight, bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.dilation[1], params.dilation[0]); goto done;
       } else if (dim == 5) {
-        VolumetricDilatedConvolution_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+        at::VolumetricDilatedConvolution_updateOutput(
+            input, output, weight, bias, columns, ones,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
@@ -594,15 +594,15 @@ static std::unique_ptr<Tensor> compute_output(
     if (params.transposed) {
       /* !dilated && transposed */
       if (dim == 4) {
-        SpatialFullConvolution_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+        at::SpatialFullConvolution_updateOutput(
+            input, output, weight, bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.output_padding[1], params.output_padding[0]); goto done;
       } else if (dim == 5) {
-        VolumetricFullConvolution_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+        at::VolumetricFullConvolution_updateOutput(
+            input, output, weight, bias, columns, ones,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
             params.output_padding[0], params.output_padding[2], params.output_padding[1]); goto done;
@@ -610,19 +610,19 @@ static std::unique_ptr<Tensor> compute_output(
     } else /* !transposed */ {
       /* !dilated && !transposed */
       if (dim == 4) {
-        SpatialConvolutionMM_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+        at::SpatialConvolutionMM_updateOutput(
+            input, output, weight, bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0]); goto done;
-      } else if (dim == 5 && input->isCuda()) {
-        VolumetricConvolution_updateOutput(
-            input, output.get(), weight, bias, columns, ones,
+      } else if (dim == 5 && input.type().isCuda()) {
+        at::VolumetricConvolution_updateOutput(
+            input, output, weight, bias, columns, ones,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1]); goto done;
       } else if (dim == 5) {
-        VolumetricConvolutionMM_updateOutput(
-            input, output.get(), weight, bias, columns,
+        at::VolumetricConvolutionMM_updateOutput(
+            input, output, weight, bias, columns,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1]); goto done;
@@ -635,13 +635,13 @@ done:
   return output;
 }
 
-static std::unique_ptr<Tensor> compute_grad_input(
-    Tensor* input, Tensor* grad_output, Tensor* weight, Tensor* columns, Tensor* ones,
+static at::Tensor compute_grad_input(
+    at::Tensor& input, at::Tensor& grad_output, at::Tensor& weight, at::Tensor& columns, at::Tensor& ones,
     const std::vector<long>& kernel_size, const ConvParams& params) {
 
-  auto grad_input = input->newTensor();
-  grad_input->resizeAs(*input);
-  auto dim = input->nDim();
+  auto grad_input = input.type().tensor();
+  grad_input.resize_as_(input);
+  auto dim = input.ndimension();
   auto dilated = params.is_dilated();
 
   if (dilated) {
@@ -651,15 +651,15 @@ static std::unique_ptr<Tensor> compute_grad_input(
     } else /* !transposed */ {
       /* dilated && !transposed */
       if (dim == 4) {
-        SpatialDilatedConvolution_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns,
+        at::SpatialDilatedConvolution_updateGradInput(
+            input, grad_output, grad_input, weight, columns,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.dilation[1], params.dilation[0]); goto done;
       } else if (dim == 5) {
-        VolumetricDilatedConvolution_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns,
+        at::VolumetricDilatedConvolution_updateGradInput(
+            input, grad_output, grad_input, weight, columns,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
@@ -670,15 +670,15 @@ static std::unique_ptr<Tensor> compute_grad_input(
     if (params.transposed) {
       /* !dilated && transposed */
       if (dim == 4) {
-        SpatialFullConvolution_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns,
+        at::SpatialFullConvolution_updateGradInput(
+            input, grad_output, grad_input, weight, columns,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.output_padding[1], params.output_padding[0]); goto done;
       } else if (dim == 5) {
-        VolumetricFullConvolution_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns, ones,
+        at::VolumetricFullConvolution_updateGradInput(
+            input, grad_output, grad_input, weight, columns, ones,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
             params.output_padding[0], params.output_padding[2], params.output_padding[1]); goto done;
@@ -686,19 +686,19 @@ static std::unique_ptr<Tensor> compute_grad_input(
     } else /* !transposed */ {
       /* !dilated && !transposed */
       if (dim == 4) {
-        SpatialConvolutionMM_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns, ones,
+        at::SpatialConvolutionMM_updateGradInput(
+            input, grad_output, grad_input, weight, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0]); goto done;
-      } else if (dim == 5 && input->isCuda()) {
-        VolumetricConvolution_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns,
+      } else if (dim == 5 && input.type().isCuda()) {
+        at::VolumetricConvolution_updateGradInput(
+            input, grad_output, grad_input, weight, columns,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1]); goto done;
       } else if (dim == 5) {
-        VolumetricConvolutionMM_updateGradInput(
-            input, grad_output, grad_input.get(), weight, columns, ones,
+        at::VolumetricConvolutionMM_updateGradInput(
+            input, grad_output, grad_input, weight, columns, ones,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1]); goto done;
@@ -712,20 +712,20 @@ done:
 }
 
 static tensor_pair compute_grad_params(
-    Tensor* input, Tensor* grad_output, Tensor* weight, Tensor* bias,
-    Tensor* columns, Tensor* ones,
+    at::Tensor& input, at::Tensor& grad_output, at::Tensor& weight, at::Tensor& bias,
+    at::Tensor& columns, at::Tensor& ones,
     const std::vector<long>& kernel_size, const ConvBackward& params) {
 
-  auto grad_weight = weight->newTensor();
-  grad_weight->resizeAs(*weight).zero();
+  auto grad_weight = weight.type().tensor();
+  grad_weight.resize_as_(weight).zero_();
 
-  std::unique_ptr<Tensor> grad_bias;
-  if (bias && params.should_compute_output(2)) {
-    grad_bias = bias->newTensor();
-    grad_bias->resizeAs(*bias).zero();
+  at::Tensor grad_bias;
+  if (bias.defined() && params.should_compute_output(2)) {
+    grad_bias = bias.type().tensor();
+    grad_bias.resize_as_(bias).zero_();
   }
 
-  auto dim = input->nDim();
+  auto dim = input.ndimension();
   auto dilated = params.is_dilated();
 
   if (dilated) {
@@ -735,15 +735,15 @@ static tensor_pair compute_grad_params(
     } else /* !transposed */ {
       /* dilated && !transposed */
       if (dim == 4) {
-        SpatialDilatedConvolution_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+        at::SpatialDilatedConvolution_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.dilation[1], params.dilation[0], 1.0); goto done;
       } else if (dim == 5) {
-        VolumetricDilatedConvolution_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+        at::VolumetricDilatedConvolution_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
@@ -754,15 +754,15 @@ static tensor_pair compute_grad_params(
     if (params.transposed) {
       /* !dilated && transposed */
       if (dim == 4) {
-        SpatialFullConvolution_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+        at::SpatialFullConvolution_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0],
             params.output_padding[1], params.output_padding[0], 1.0); goto done;
       } else if (dim == 5) {
-        VolumetricFullConvolution_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+        at::VolumetricFullConvolution_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1],
             params.output_padding[0], params.output_padding[2], params.output_padding[1], 1.0); goto done;
@@ -770,19 +770,19 @@ static tensor_pair compute_grad_params(
     } else /* !transposed */ {
       /* !dilated && !transposed */
       if (dim == 4) {
-        SpatialConvolutionMM_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+        at::SpatialConvolutionMM_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             kernel_size[1], kernel_size[0],
             params.stride[1], params.stride[0],
             params.padding[1], params.padding[0], 1.0); goto done;
-      } else if (dim == 5 && input->isCuda()) {
-        VolumetricConvolution_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns, ones,
+      } else if (dim == 5 && input.type().isCuda()) {
+        at::VolumetricConvolution_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns, ones,
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1], 1.0); goto done;
       } else if (dim == 5) {
-        VolumetricConvolutionMM_accGradParameters(
-            input, grad_output, grad_weight.get(), grad_bias.get(), columns,
+        at::VolumetricConvolutionMM_accGradParameters(
+            input, grad_output, grad_weight, grad_bias, columns,
             kernel_size[0], kernel_size[2], kernel_size[1],
             params.stride[0], params.stride[2], params.stride[1],
             params.padding[0], params.padding[2], params.padding[1], 1.0); goto done;

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Python.h>
-#include <THPP/THPP.h>
+#include <ATen/ATen.h>
 #include <memory>
 #include <vector>
 #include <iostream>
@@ -33,7 +33,7 @@ struct ConvParams {
   bool is_output_padding_neg() const;
   bool is_padding_neg() const;
   void view1d_as_2d();
-  bool use_cudnn(const thpp::Tensor& input) const;
+  bool use_cudnn(const at::Tensor& input) const;
 };
 
 struct ConvForward : public Function, public ConvParams {
@@ -41,7 +41,7 @@ struct ConvForward : public Function, public ConvParams {
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  std::vector<long> output_size(thpp::Tensor& input, thpp::Tensor& weight);
+  std::vector<long> output_size(at::Tensor& input, at::Tensor& weight);
 };
 
 struct ConvBackward : public Function, public ConvParams {

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -101,18 +101,18 @@ PyObject* getValueAttr(PyObject* obj, void* _unused)
   END_HANDLE_TH_ERRORS
 }
 
-template<typename T, typename ParamsT, std::shared_ptr<thpp::Tensor> ParamsT::*ptr>
+template<typename T, typename ParamsT, at::Tensor ParamsT::*ptr>
 PyObject* getTensorAttr(PyObject* obj, void* _unused)
 {
   HANDLE_TH_ERRORS
   THPCppFunction* self = (THPCppFunction*)obj;
   auto& val = ((T*)(self->cdata.get()))->*ptr;
   THPObjectPtr py_tensor;
-  if (!val) {
+  if (!val.defined()) {
     Py_INCREF(Py_None);
     py_tensor = Py_None;
   } else {
-    py_tensor = torch::createPyObject(*val);
+    py_tensor = torch::createPyObject(val);
   }
   return py_tensor.release();
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -14,11 +14,11 @@ auto Identity::apply(const variable_list& inputs) -> variable_list {
 auto Clone::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Clone", inputs, 1);
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output {input->clone()};
+  at::Tensor output = input.clone();
 
-  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+  return wrap_outputs(inputs, as_tensor_list(output), [&](FunctionFlags f) {
     return std::make_shared<Identity>(std::move(f));
   });
 };
@@ -26,9 +26,9 @@ auto Clone::apply(const variable_list& inputs) -> variable_list {
 auto Contiguous::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Contiguous", inputs, 1);
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output {input->contiguous()};
+  at::Tensor output = input.contiguous();
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<Identity>(std::move(f));
@@ -39,9 +39,9 @@ auto Transpose::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Transpose", inputs, 1);
 
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output(input->newTranspose(dim1, dim2));
+  at::Tensor output = input.transpose(dim1, dim2);
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<Transpose>(dim1, dim2);
@@ -52,12 +52,12 @@ auto View::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("View", inputs, 1);
 
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output(input->newView(size));
+  at::Tensor output = input.view(size);
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
-    return std::make_shared<View>(input->sizes());
+    return std::make_shared<View>(input.sizes());
   });
 }
 
@@ -65,9 +65,9 @@ auto Expand::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Expand", inputs, 1);
 
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output(input->newExpand(size));
+  at::Tensor output = input.expand(size);
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<Error>("Expand is not differentiable", std::move(f));
@@ -78,9 +78,9 @@ auto Narrow::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Narrow", inputs, 1);
 
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::unique_ptr<thpp::Tensor> output(input->newNarrow(dim, start, size));
+  at::Tensor output = input.narrow(dim, start, size);
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<Error>("Narrow is not differentiable", std::move(f));
@@ -94,16 +94,15 @@ auto Cat::apply(const variable_list& inputs) -> variable_list {
   }
 
   auto& input = inputs[0]->data;
-  AutoGPU guard(input->getDevice());
+  AutoGPU guard(input.type().isCuda() ? input.get_device() : -1);
 
-  std::vector<thpp::Tensor*> ptrs(num_inputs);
+  std::vector<at::Tensor> tensors(num_inputs);
   for (int i = 0; i < num_inputs; ++i) {
-    ptrs[i] = inputs[i]->data.get();
+    tensors[i] = inputs[i]->data;
   }
-  auto output = inputs[0]->data->newTensor();
-  output->cat(ptrs, dim);
+  auto output = input.type().cat(tensors, dim);
 
-  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
+  return wrap_outputs(inputs, as_tensor_list(output), [&](FunctionFlags f) {
     return std::make_shared<Error>("Cat is not differentiable", std::move(f));
   });
 }

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -18,7 +18,7 @@ auto Clone::apply(const variable_list& inputs) -> variable_list {
 
   at::Tensor output = input.clone();
 
-  return wrap_outputs(inputs, as_tensor_list(output), [&](FunctionFlags f) {
+  return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
     return std::make_shared<Identity>(std::move(f));
   });
 };

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -29,54 +29,54 @@ struct Contiguous : public Function {
 };
 
 struct Transpose : public Function {
-  Transpose(long dim1, long dim2)
+  Transpose(int64_t dim1, int64_t dim2)
     : dim1(dim1)
     , dim2(dim2) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  long dim1;
-  long dim2;
+  int64_t dim1;
+  int64_t dim2;
 };
 
 struct View : public Function {
-  View(std::vector<long> size)
+  View(std::vector<int64_t> size)
     : size(size) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  std::vector<long> size;
+  std::vector<int64_t> size;
 };
 
 struct Expand : public Function {
-  Expand(std::vector<long> size)
+  Expand(std::vector<int64_t> size)
     : size(size) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  std::vector<long> size;
+  std::vector<int64_t> size;
 };
 
 struct Narrow : public Function {
-  Narrow(long dim, long start, long size)
+  Narrow(int64_t dim, int64_t start, int64_t size)
     : dim(dim)
     , start(start)
     , size(size) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  long dim;
-  long start;
-  long size;
+  int64_t dim;
+  int64_t start;
+  int64_t size;
 };
 
 struct Cat : public Function {
-  Cat(long dim)
+  Cat(int64_t dim)
     : dim(dim) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
 
-  long dim;
+  int64_t dim;
 };
 
 }}

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -11,13 +11,13 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   result.reserve(outputs.size());
   if (flags.is_volatile) {
     for (auto& output : outputs) {
-     result.emplace_back(Variable::of(std::move(output), true));
+     result.emplace_back(Variable::of(output, true));
     }
   } else {
     auto grad_fn = ctr(std::move(flags));
     for (auto& output : outputs) {
-      if (output) {
-        result.emplace_back(std::make_shared<Variable>(std::move(output), grad_fn));
+      if (output.defined()) {
+        result.emplace_back(std::make_shared<Variable>(output, grad_fn));
       } else {
         ++grad_fn->num_inputs;
         result.emplace_back(nullptr);

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -26,8 +26,8 @@ void InputBuffer::add(size_t pos, std::shared_ptr<Variable>&& var) {
 
 auto InputBuffer::device() const -> int {
   for (auto& pair : buffer) {
-    if (pair.first) {
-      return pair.first->data->getDevice();
+    if (pair.first && pair.first->data.type().isCuda()) {
+      return pair.first->data.get_device();
     }
   }
   return -1;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -58,7 +58,7 @@ static PyObject* _allocate_grad_output(output_info_type& info, AutoGPU& gpu_guar
   // TODO: no need to do this for non-differentiable outputs
   PyObject *tensor_cls = std::get<0>(info);
   gpu_guard.setDevice(std::get<1>(info));
-  std::vector<long> &sizes = std::get<2>(info);
+  std::vector<int64_t> &sizes = std::get<2>(info);
 
   THPObjectPtr grad_size(THPSize_New(sizes.size(), sizes.data()));
   if (!grad_size) throw python_error();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -59,8 +59,9 @@ static PyObject* _allocate_grad_output(output_info_type& info, AutoGPU& gpu_guar
   PyObject *tensor_cls = std::get<0>(info);
   gpu_guard.setDevice(std::get<1>(info));
   std::vector<int64_t> &sizes = std::get<2>(info);
+  std::vector<long> long_sizes(sizes.begin(), sizes.end());
 
-  THPObjectPtr grad_size(THPSize_New(sizes.size(), sizes.data()));
+  THPObjectPtr grad_size(THPSize_New(long_sizes.size(), long_sizes.data()));
   if (!grad_size) throw python_error();
   THPObjectPtr new_grad(PyObject_CallFunctionObjArgs(tensor_cls, grad_size.get(), NULL));
   if (!new_grad) throw python_error();

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -10,7 +10,7 @@
 #include "torch/csrc/utils/object_ptr.h"
 
 // (class, gpu id, sizes)
-using output_info_type = std::tuple<PyObject *, int, std::vector<long>>;
+using output_info_type = std::tuple<PyObject *, int, std::vector<int64_t>>;
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -158,23 +158,23 @@ static void check_single_result(PyObject* _original, PyObject* _result, PyObject
     throw python_error();
   }
 
-  auto& original = *((THPVariable*)_original)->cdata->data;
-  auto& result = *((THPVariable*)_result)->cdata->data;
+  auto& original = ((THPVariable*)_original)->cdata->data;
+  auto& result = ((THPVariable*)_result)->cdata->data;
 
-  if (original.type() != result.type()) {
+  if (original.type().ID() != result.type().ID()) {
     std::stringstream ss;
     auto name = hook_name(hook);
     ss << "hook '" << name << "' has changed the type of value (";
-    ss << "was " << thpp::toString(original.type()) << " got ";
-    ss << thpp::toString(result.type()) << ")";
+    ss << "was " << original.toString() << " got ";
+    ss << result.toString() << ")";
     throw std::runtime_error(ss.str());
   }
 
-  if (original.isCuda() != result.isCuda()) {
+  if (original.type().isCuda() != result.type().isCuda()) {
     std::stringstream ss;
     auto name = hook_name(hook);
     ss << "hook '" << name << "' has changed the type of value";
-    if (original.isCuda()) {
+    if (original.type().isCuda()) {
       ss << " (was CUDA tensor got CPU tensor)";
     } else {
       ss << " (was CPU tensor got CUDA tensor)";
@@ -182,7 +182,7 @@ static void check_single_result(PyObject* _original, PyObject* _result, PyObject
     throw std::runtime_error(ss.str());
   }
 
-  if (original.sizes() != result.sizes()) {
+  if (original.sizes().vec() != result.sizes().vec()) {
     std::stringstream ss;
     auto name = hook_name(hook);
     ss << "hook '" << name << "' has changed the size of value";

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -544,6 +544,7 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
   name: clone
   cname: newClone
   return: THTensor*
+  aten_sparse: True
   arguments:
     - THTensor* self
 ]]

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1364,6 +1364,7 @@
         - THTensor* self
         - real value
     - cname: cadd
+      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -1374,6 +1375,7 @@
         - THTensor* other
     - sparse: True
       cname: spcadd
+      aten_dense_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -1393,6 +1395,7 @@
         - THTensor* self
         - real value
     - cname: cadd
+      aten_sparse: True
       arguments:
         - THTensor* self
         - arg: THTensor* self
@@ -1402,6 +1405,7 @@
         - THTensor* other
     - sparse: True
       cname: spcadd
+      aten_dense_sparse: True
       arguments:
         - THTensor* self
         - THTensor* self

--- a/torch/lib/ATen/SparseTensorRef.h
+++ b/torch/lib/ATen/SparseTensorRef.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace at {
+
+struct Tensor;
+struct SparseTensor {
+  explicit SparseTensor(const Tensor& t): tref(t) {}
+  const Tensor& tref;
+};
+
+}

--- a/torch/lib/ATen/gen.py
+++ b/torch/lib/ATen/gen.py
@@ -121,6 +121,7 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
     env['Storage'] = "{}{}Storage".format(backend, scalar_name)
     env['Type'] = "{}{}{}Type".format(density_tag, backend, scalar_name)
     env['Tensor'] = "{}{}{}Tensor".format(density_tag, backend, scalar_name)
+    env['SparseTensor'] = "Sparse{}{}Tensor".format(backend, scalar_name)
     env['Backend'] = density_tag + backend
 
     # used for generating switch logic for external functions
@@ -133,9 +134,9 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
                              '#include <THCUNN/THCUNN.h>',
                              '#undef THNN_',
                              '#undef THCIndexTensor_']
-        if density == 'Sparse':
-            env['th_headers'] += ['#include <THCS/THCS.h>',
-                                  '#undef THCIndexTensor_']
+        # if density == 'Sparse':
+        env['th_headers'] += ['#include <THCS/THCS.h>',
+                              '#undef THCIndexTensor_']
         sname = '' if scalar_name == "Float" else scalar_name
         env['THType'] = 'Cuda{}'.format(sname)
         env['THStorage'] = 'THCuda{}Storage'.format(sname)
@@ -152,8 +153,8 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
         env['th_headers'] = ['#include <TH/TH.h>',
                              '#include <THNN/THNN.h>',
                              '#undef THNN_']
-        if density == 'Sparse':
-            env['th_headers'].append('#include <THS/THS.h>')
+        # if density == 'Sparse':
+        env['th_headers'].append('#include <THS/THS.h>')
 
         env['THType'] = scalar_name
         env['THStorage'] = "TH{}Storage".format(scalar_name)
@@ -165,6 +166,7 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
         env['Generator'] = 'CPUGenerator'
     env['AS_REAL'] = env['ScalarType']
     if scalar_name == "Half":
+        env['SparseTensor'] = 'Tensor'
         if backend == "CUDA":
             env['to_th_type'] = 'HalfFix<__half,Half>'
             env['to_at_type'] = 'HalfFix<Half,__half>'

--- a/torch/lib/ATen/gen.py
+++ b/torch/lib/ATen/gen.py
@@ -102,7 +102,8 @@ def write(filename, s):
 
 def format_yaml(data):
     if options.output_dependencies:
-        return ""  # yaml formatting is slow so don't do it if we will ditch it.
+        # yaml formatting is slow so don't do it if we will ditch it.
+        return ""
     noalias_dumper = yaml.dumper.SafeDumper
     noalias_dumper.ignore_aliases = lambda self, data: True
     return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper)

--- a/torch/lib/ATen/preprocess_declarations.py
+++ b/torch/lib/ATen/preprocess_declarations.py
@@ -31,7 +31,11 @@ def process_types_and_backends(option):
     # if backend or type is not defined, it is assumed to be all of them
     if 'backend_type_pairs' not in option:
         backends = option.get('backends', default_backends)
+        if option.get('aten_sparse', False):
+            backends = all_backends
+
         types = option.get('types', all_types)
+
         pairs = [[p, t] for p in backends for t in types]
     else:
         pairs = option['backend_type_pairs']
@@ -46,7 +50,12 @@ def process_types_and_backends(option):
         return [(p, t)]
     pairs = set(p for pair in pairs for p in expand(pair))
 
-    # special case remove Half for cpu unless it is explicitly enabled
+    # disable CUDA Half if there is a Sparse argument
+    for arg in option.get('arguments', []):
+        if arg['type'] == 'THSTensor*':
+            pairs.discard(('CUDA', 'Half'))
+
+    # special case remove Half for cpu unless it is explicitly enabled,
     if not option.get('cpu_half', False):
         pairs.discard(('CPU', 'Half'))
 
@@ -150,6 +159,38 @@ def discover_zero_dim_tensor_operations(declaration):
                     # print("SHARED "+names[i])
 
 
+def discover_sparse_tensor_operations(declaration):
+    def exclude(arg):
+        return arg.get('ignore_check')
+
+    def signature(option, i=None, value=None):
+        elements = [TYPE_FORMAL_GENERIC.get(arg['type'], arg['type'])
+                    if i is None or j != i else value
+                    for j, arg in enumerate(option['arguments'])
+                    if not exclude(arg)]
+        return '#'.join(elements)
+
+    name = declaration['name']
+    if name == 'add' or name == 'add_':
+        signature_to_option = {signature(option): option
+                               for option in declaration['options']}
+
+        for option in declaration['options']:
+            for i, arg in enumerate(option['arguments']):
+                if (arg['type'] == 'THSTensor*' and
+                        option.get('aten_dense_sparse', False)):
+                    signature_of_tensor_version = signature(option, i, 'Tensor &')
+                    if signature_of_tensor_version in signature_to_option:
+                        tensor_version = \
+                            signature_to_option[signature_of_tensor_version]
+                        raw_args = len(tensor_version['arguments'])
+                        names = [arg['name'] for arg in tensor_version['arguments']
+                                 if not exclude(arg)]
+                        filtered_args = len(names)
+                        tensor_version['when_sparse_dispatch'] = names[i -
+                                (raw_args - filtered_args)]
+
+
 def run(declarations):
     declarations = [d for d in declarations if not exclude(d)]
     for declaration in declarations:
@@ -161,6 +202,7 @@ def run(declarations):
             remove_self=True)
         common_with_cwrap.sort_by_number_of_options(declaration)
         discover_zero_dim_tensor_operations(declaration)
+        discover_sparse_tensor_operations(declaration)
 
         for option in declaration['options']:
             set_mode(option)

--- a/torch/lib/ATen/preprocess_declarations.py
+++ b/torch/lib/ATen/preprocess_declarations.py
@@ -179,7 +179,8 @@ def discover_sparse_tensor_operations(declaration):
             for i, arg in enumerate(option['arguments']):
                 if (arg['type'] == 'THSTensor*' and
                         option.get('aten_dense_sparse', False)):
-                    signature_of_tensor_version = signature(option, i, 'Tensor &')
+                    signature_of_tensor_version = signature(
+                        option, i, 'Tensor &')
                     if signature_of_tensor_version in signature_to_option:
                         tensor_version = \
                             signature_to_option[signature_of_tensor_version]
@@ -188,7 +189,7 @@ def discover_sparse_tensor_operations(declaration):
                                  if not exclude(arg)]
                         filtered_args = len(names)
                         tensor_version['when_sparse_dispatch'] = names[i -
-                                (raw_args - filtered_args)]
+                                                                       (raw_args - filtered_args)]
 
 
 def run(declarations):

--- a/torch/lib/ATen/templates/TensorDerived.cpp
+++ b/torch/lib/ATen/templates/TensorDerived.cpp
@@ -27,9 +27,9 @@ int64_t ${Tensor}::dim() {
   if(isScalar())
     return 0;
   int64_t d = ${THTensor}_nDimension(${state,}tensor);
-  if(d != 0)
-    return d;
   // See Note [Undefined-dim versus 0-dim]
+  if (d != 0)
+    return d;
   return kUndefinedDimensions;
 }
 

--- a/torch/lib/ATen/templates/TensorMethods.h
+++ b/torch/lib/ATen/templates/TensorMethods.h
@@ -2,6 +2,7 @@
 
 #include "ATen/Tensor.h"
 #include "ATen/Scalar.h"
+#include "ATen/SparseTensorRef.h"
 
 namespace at {
 

--- a/torch/lib/ATen/templates/Type.cpp
+++ b/torch/lib/ATen/templates/Type.cpp
@@ -2,6 +2,7 @@
 #include "ATen/Tensor.h"
 #include "ATen/Storage.h"
 #include "ATen/Scalar.h"
+#include "ATen/SparseTensorRef.h"
 
 #include <iostream>
 ${type_headers}

--- a/torch/lib/ATen/templates/Type.h
+++ b/torch/lib/ATen/templates/Type.h
@@ -5,6 +5,7 @@
 
 #include "ATen/ArrayRef.h"
 #include "ATen/Half.h"
+#include "ATen/SparseTensorRef.h"
 
 namespace at {
 

--- a/torch/lib/ATen/templates/TypeDerived.cpp
+++ b/torch/lib/ATen/templates/TypeDerived.cpp
@@ -5,6 +5,7 @@
 #include "ATen/${Backend}ByteTensor.h"
 #include "ATen/${Backend}IntTensor.h"
 #include "ATen/${Backend}LongTensor.h"
+#include "ATen/${SparseTensor}.h"
 #include "ATen/Utils.h"
 #include "ATen/THLongStorageView.h"
 #include <iostream>
@@ -20,7 +21,7 @@ Backend ${Type}::backend() {
   return Backend::${Backend};
 }
 bool ${Type}::isCuda() { return backend() == kCUDA; }
-bool ${Type}::isSparse() { return false; }
+bool ${Type}::isSparse() { return backend() == kSparseCPU || backend() == kSparseCUDA; }
 bool ${Type}::isDistributed() { return false; }
 
 std::unique_ptr<Storage> ${Type}::storage() {
@@ -33,7 +34,7 @@ std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size) {
     return std::unique_ptr<Storage>(
       new ${Storage}(context,data,size));
 }
-Tensor ${Type}::unsafeTensorFromTH(void * th_pointer,bool retain) {
+Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) {
   if (retain)
     ${THTensor}_retain(${state,} (${THTensor}*) th_pointer);
   return Tensor(new ${Tensor}(context,(${THTensor}*)(th_pointer)),false);

--- a/torch/lib/ATen/templates/TypeDerived.cpp
+++ b/torch/lib/ATen/templates/TypeDerived.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size) {
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) {
   if (retain)
     ${THTensor}_retain(${state,} (${THTensor}*) th_pointer);
-  return Tensor(new ${Tensor}(context,(${THTensor}*)(th_pointer)),false);
+  return Tensor(new ${Tensor}(context,(${THTensor}*)(th_pointer)), false);
 }
 std::unique_ptr<Generator> ${Type}::generator() {
   return std::unique_ptr<Generator>(new ${Generator}(context));


### PR DESCRIPTION
As title - moves to using the ATen tensor to wrap TH Tensors for use in autograd. Includes some fixes to ATen discovered by this refactor.