### PR TITLE
reformulate bce_with_logits to not use abs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2288,6 +2288,13 @@ class TestNN(NNTestCase):
         weight = torch.rand(4)
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
 
+    def test_bce_with_logits_has_correct_grad_at_zero(self):
+        output = Variable(torch.zeros(3, 1), requires_grad=True)
+        target = Variable(torch.zeros(3, 1))
+        nn.BCEWithLogitsLoss(size_average=False)(output, target).backward()
+        expected_grad = Variable(torch.Tensor(3, 1).fill_(0.5))
+        self.assertEqual(output.grad, expected_grad)
+
     def test_bce_with_logits_broadcasts_weights(self):
         target = Variable(torch.rand(16, 4))
         output = Variable(torch.rand(16, 4) - 0.5)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -797,8 +797,9 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
     if not target.is_same_size(input):
         raise ValueError("Target size ({}) must be the same as input size ({})".format(target.size(), input.size()))
 
-    neg_abs = - input.abs()
-    loss = input.clamp(min=0) - input * target + (1 + neg_abs.exp()).log()
+    max_val = input.clamp(min=0)
+    loss = input - input*target + max_val + ((-max_val).exp() + (-input -max_val).exp()).log()
+
     if weight is not None:
         loss = loss * weight
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -798,7 +798,7 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
         raise ValueError("Target size ({}) must be the same as input size ({})".format(target.size(), input.size()))
 
     max_val = input.clamp(min=0)
-    loss = input - input*target + max_val + ((-max_val).exp() + (-input -max_val).exp()).log()
+    loss = input - input * target + max_val + ((-max_val).exp() + (-input - max_val).exp()).log()
 
     if weight is not None:
         loss = loss * weight


### PR DESCRIPTION
This is a fix for the bug reported [here](https://github.com/pytorch/pytorch/pull/1792#issuecomment-317289657) in which `binary_cross_entropy_with_logits` gives the wrong gradient with `input` and `target` are `0`. 

After some investigation, this is because the gradient of `abs` at `0` is `0` (see [here](https://github.com/pytorch/pytorch/blob/master/torch/autograd/_functions/pointwise.py#L139))

In this PR I have reformulated the numerically stable `binary_cross_entropy_with_logits` to not use `abs` (originally I used what [tensorflow does](https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits), which is use abs).

I guess in general we should think about whether we want the grad of `abs(0)` to be `0`?