### PR TITLE
Add missing models to torch vision documentation

### DIFF
--- a/docs/source/torchvision/models.rst
+++ b/docs/source/torchvision/models.rst
@@ -7,5 +7,6 @@ torchvision.models
 .. automodule:: torchvision.models
    :members: alexnet, resnet18, resnet34, resnet50, resnet101, resnet152,
              vgg11, vgg11_bn, vgg13, vgg13_bn, vgg16, vgg16_bn, vgg19,
-             vgg19_bn
+             vgg19_bn, inception_v3, squeezenet1_0, squeezenet1_1, densenet121, 
+             densenet169, densenet201, densenet161
    :undoc-members:


### PR DESCRIPTION
These models were present in torch vision repo, but not in docs.