### PR TITLE
Implement BatchNorm double backwards

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3236,7 +3236,6 @@ new_module_tests = [
         input_size=(4, 10),
         cudnn=True,
         desc='affine',
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm1d',
@@ -3244,7 +3243,6 @@ new_module_tests = [
         input_size=(4, 5, 3),
         cudnn=True,
         desc='3d_input',
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm1d',
@@ -3252,14 +3250,19 @@ new_module_tests = [
         input_size=(4, 10),
         cudnn=True,
         desc='not_affine',
-        check_gradgrad=False,
+    ),
+    dict(
+        module_name='BatchNorm1d',
+        constructor_args=(5, 1e-3, 0.3, False),
+        input_size=(4, 5, 3),
+        cudnn=True,
+        desc='3d_input_not_affine',
     ),
     dict(
         module_name='BatchNorm2d',
         constructor_args=(3,),
         input_size=(2, 3, 6, 6),
         cudnn=True,
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm2d',
@@ -3267,22 +3270,19 @@ new_module_tests = [
         input_size=(2, 3, 6, 6),
         cudnn=True,
         desc='momentum',
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm2d',
         constructor_args=(3, 1e-3, 0.8, False),
         input_size=(2, 3, 6, 6),
         cudnn=True,
-        desc='no_affine',
-        check_gradgrad=False,
+        desc='not_affine',
     ),
     dict(
         module_name='BatchNorm3d',
         constructor_args=(3,),
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm3d',
@@ -3290,15 +3290,13 @@ new_module_tests = [
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
         desc='momentum',
-        check_gradgrad=False,
     ),
     dict(
         module_name='BatchNorm3d',
         constructor_args=(3, 1e-3, 0.7, False),
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
-        desc='no_affine',
-        check_gradgrad=False,
+        desc='not_affine',
     ),
     dict(
         module_name='Conv1d',

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -200,7 +200,6 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
   all_inputs.push_back(input_var);
   if (weight.get()) {
     all_inputs.push_back(weight_var);
-    all_inputs.push_back(bias_var);
   }
   auto outputs =  as_tensor_list(std::move(grad_input),
                                  std::move(grad_weight),
@@ -253,11 +252,10 @@ auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> 
 
   auto gI_var = getReturnTupleVar(r, 0);
   auto gG_var = getReturnTupleVar(r, 1);
-  auto gB_var = getReturnTupleVar(r, 2);
-  auto ggO_var = getReturnTupleVar(r, 3);
+  auto ggO_var = getReturnTupleVar(r, 2);
 
   if (weight_var) {
-    return {ggO_var, gI_var, gG_var, gB_var};
+    return {ggO_var, gI_var, gG_var};
   } else {
     return {ggO_var, gI_var};
   }

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -1,10 +1,14 @@
 #include "batch_normalization.h"
 
+#include "torch/csrc/autograd/python_function.h"
+#include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/autograd/functions/basic_ops.h"
 #include "torch/csrc/nn/THNN_generic.h"
+#include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/Exceptions.h"
 #include <sstream>
 
 #ifdef WITH_CUDNN
@@ -111,9 +115,14 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
 
 auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_list {
   check_input_variables("BatchNormBackward", grad_outputs, 1);
-  auto input = this->input.unpack_data();
-  auto weight = this->weight.unpack_data();
-  auto bias = this->bias.unpack_data();
+  auto input_var = this->input.unpack();
+  auto weight_var = this->weight.unpack();
+  auto bias_var = this->bias.unpack();
+
+  std::unique_ptr<thpp::Tensor> input {input_var->data->clone_shallow()};
+  std::unique_ptr<thpp::Tensor> weight {weight_var ? weight_var->data->clone_shallow() : nullptr};
+  std::unique_ptr<thpp::Tensor> bias {bias_var ? bias_var->data->clone_shallow() : nullptr};
+
   AutoGPU guard(input->getDevice());
 
   bool use_cudnn = false;
@@ -186,12 +195,22 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
         eps);
   }
 
+  // Add saved variables used out of the pure autograd to inputs
+  variable_list all_inputs(grad_outputs);
+  all_inputs.push_back(input_var);
+  if (weight.get()) {
+    all_inputs.push_back(weight_var);
+    all_inputs.push_back(bias_var);
+  }
   auto outputs =  as_tensor_list(std::move(grad_input),
                                  std::move(grad_weight),
                                  std::move(grad_bias));
-  return wrap_outputs(grad_outputs, std::move(outputs), [&](FunctionFlags f) {
-    return std::make_shared<Error>("BatchNormBackward is not differentiable", std::move(f));
-  });
+  return wrap_outputs(all_inputs, std::move(outputs), [&](FunctionFlags f) {
+    return std::make_shared<BatchNormBackwardBackward>(
+      f, *this, std::move(save_mean), std::move(save_std),
+      input_var->save(this), Variable::save_opt(weight_var.get(), this),
+      grad_outputs[0]->save(this));
+    });
 };
 
 auto BatchNormBackward::releaseVariables() -> void {
@@ -199,5 +218,56 @@ auto BatchNormBackward::releaseVariables() -> void {
   weight.data.reset();
   bias.data.reset();
 }
+
+std::shared_ptr<torch::autograd::Variable> getReturnTupleVar(PyObject *p, Py_ssize_t pos) {
+  PyObject *item = PyTuple_GET_ITEM(p, pos);
+  return item == Py_None ? nullptr : ((THPVariable*)item)->cdata;
+}
+
+auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> variable_list {
+  check_input_variables("BatchNormBackwardBackward", grad_grad_inputs, 3, 0);
+  auto ggI = grad_grad_inputs[0];
+  auto ggW = grad_grad_inputs[1];
+  auto ggb = grad_grad_inputs[2];
+
+  auto gO = grad_output.unpack();
+  auto input_var = input.unpack();
+  auto weight_var = weight.unpack();
+
+  AutoGIL gil;
+  THPObjectPtr input_pvar(THPVariable_Wrap(input_var));
+  THPObjectPtr weight_pvar(weight_var ? THPVariable_Wrap(weight_var) : Py_None);
+  THPObjectPtr ggi_pvar(ggI ? THPVariable_Wrap(ggI) : Py_None);
+  THPObjectPtr ggW_pvar(ggW ? THPVariable_Wrap(ggW) : Py_None);
+  THPObjectPtr ggb_pvar(ggb ? THPVariable_Wrap(ggb) : Py_None);
+  THPObjectPtr gO_pvar(THPVariable_Wrap(gO));
+  THPObjectPtr eps_py(PyFloat_FromDouble(eps));
+  PyObject* args = PyTuple_Pack(7, input_pvar.get(), weight_pvar.get(),
+                                ggi_pvar.get(), ggW_pvar.get(), ggb_pvar.get(),
+                                gO_pvar.get(), eps_py.get());
+  THPObjectPtr r(PyObject_CallObject(THPBatchNormBackwardBackwardFunction, args));
+  if (!r) throw python_error();
+  if (!PyTuple_Check(r.get())) {
+    throw std::runtime_error("expected PyTuple return from BatchNormBackwardBackward");
+  }
+
+  auto gI_var = getReturnTupleVar(r, 0);
+  auto gG_var = getReturnTupleVar(r, 1);
+  auto gB_var = getReturnTupleVar(r, 2);
+  auto ggO_var = getReturnTupleVar(r, 3);
+
+  if (weight_var) {
+    return {ggO_var, gI_var, gG_var, gB_var};
+  } else {
+    return {ggO_var, gI_var};
+  }
+};
+
+auto BatchNormBackwardBackward::releaseVariables() -> void {
+  input.data.reset();
+  weight.data.reset();
+  grad_output.data.reset();
+}
+
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -56,4 +56,35 @@ struct BatchNormBackward : public Function, public BatchNormParams {
   SavedVariable bias;
 };
 
+struct BatchNormBackwardBackward : public Function, public BatchNormParams {
+  BatchNormBackwardBackward(
+      FunctionFlags flags,
+      BatchNormParams params,
+      std::unique_ptr<thpp::Tensor> save_mean,
+      std::unique_ptr<thpp::Tensor> save_std,
+      SavedVariable input,
+      SavedVariable weight,
+      SavedVariable grad_output)
+    : Function(std::move(flags))
+    , BatchNormParams(std::move(params)) {
+      if (is_executable) {
+        this->save_mean = std::move(save_mean);
+        this->save_std = std::move(save_std);
+        this->input = std::move(input);
+        this->weight = std::move(weight);
+        this->grad_output = std::move(grad_output);
+      }
+    }
+
+  virtual variable_list apply(const variable_list& grad_grad_inputs) override;
+
+  virtual void releaseVariables() override;
+
+  std::unique_ptr<thpp::Tensor> save_mean;
+  std::unique_ptr<thpp::Tensor> save_std;
+  SavedVariable input;
+  SavedVariable weight;
+  SavedVariable grad_output;
+};
+
 }}

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -152,6 +152,23 @@ static struct PyGetSetDef batch_norm_backward_properties[] = {
   {NULL}
 };
 
+static struct PyGetSetDef batch_norm_backward_backward_properties[] = {
+  THP_FUNCTION_DEFAULT_PROPERTIES,
+  {(char*)"running_mean", (getter)getTensorAttr<BatchNormBackwardBackward, BatchNormParams,
+                                         &BatchNormParams::running_mean>, NULL, NULL, NULL},
+  {(char*)"running_var", (getter)getTensorAttr<BatchNormBackwardBackward, BatchNormParams,
+                                         &BatchNormParams::running_var>, NULL, NULL, NULL},
+  {(char*)"training", (getter)getValueAttr<BatchNormBackwardBackward, bool, BatchNormParams,
+                                         &BatchNormParams::training, long, PyBool_FromLong>, NULL, NULL, NULL},
+  {(char*)"momentum", (getter)getValueAttr<BatchNormBackwardBackward, double, BatchNormParams,
+                                         &BatchNormParams::momentum, double, PyFloat_FromDouble>, NULL, NULL, NULL},
+  {(char*)"eps", (getter)getValueAttr<BatchNormBackwardBackward, double, BatchNormParams,
+                                         &BatchNormParams::eps, double, PyFloat_FromDouble>, NULL, NULL, NULL},
+  {(char*)"cudnn_enabled", (getter)getValueAttr<BatchNormBackwardBackward, bool, BatchNormParams,
+                                         &BatchNormParams::cudnn_enabled, long, PyBool_FromLong>, NULL, NULL, NULL},
+  {NULL}
+};
+
 static struct PyGetSetDef conv_forward_properties[] = {
   THP_FUNCTION_DEFAULT_PROPERTIES,
   {(char*)"stride", (getter)getTupleAttr<ConvForward, std::vector<int>, ConvParams,
@@ -223,9 +240,10 @@ bool THPAutograd_initFunctions(PyObject* _unused)
   THPObjectPtr module(PyModule_New("torch._C._functions"));
   if (!module) return false;
 
-  static PyTypeObject BatchNormClass, BatchNormBackwardClass;
+  static PyTypeObject BatchNormClass, BatchNormBackwardClass, BatchNormBackwardBackwardClass;
   addClass<BatchNormForward, BatchNormCtor>(module, BatchNormClass, "BatchNorm", batch_norm_forward_properties);
   addClass<BatchNormBackward, NoCtor>(module, BatchNormBackwardClass, "BatchNormBackward", batch_norm_backward_properties);
+  addClass<BatchNormBackwardBackward, NoCtor>(module, BatchNormBackwardBackwardClass, "BatchNormBackwardBackward", batch_norm_backward_backward_properties);
 
   static PyTypeObject ConvClass, ConvBackwardClass, ConvBackwardBackwardClass;
   addClass<ConvForward, ConvCtor>(module, ConvClass, "ConvNd", conv_forward_properties);

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -12,6 +12,12 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
 
   THPVariableClass      = PyMapping_GetItemString(autograd_dict,(char*)"Variable");
   THPFunctionClass      = PyMapping_GetItemString(autograd_dict,(char*)"Function");
+
+  PyObject *thnn_functions = PyImport_ImportModule("torch.nn._functions.thnn");
+  THPUtils_assert(thnn_functions, "class loader couldn't access "
+      "torch.nn._functions.thnn module");
+  THPBatchNormBackwardBackwardFunction = PyObject_GetAttrString(thnn_functions,(char*)"batchnorm_double_backwards_fn");
+
   THPStochasticFunctionClass = PyMapping_GetItemString(autograd_dict,(char*)"StochasticFunction");
   THPUtils_assert(THPVariableClass, "couldn't find Variable class in "
           "torch.autograd module");

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -28,6 +28,7 @@ using thpp::Tensor;
 
 PyObject *THPFunctionClass = NULL;
 PyObject *THPStochasticFunctionClass = NULL;
+PyObject *THPBatchNormBackwardBackwardFunction = NULL;
 
 
 #define THPFunction_assert(condition, ...)                                     \

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -68,6 +68,7 @@ bool THPFunction_initModule(PyObject *module);
 extern PyTypeObject THPFunctionType;
 extern PyObject *THPFunctionClass;
 extern PyObject *THPStochasticFunctionClass;
+extern PyObject *THPBatchNormBackwardBackwardFunction;  // Temporarily here until we move it to C++
 
 // XXX: this function requires the GIL (it can have side effects).
 std::shared_ptr<torch::autograd::PyFunction> THPFunction_asFunction(THPFunction* self);

--- a/torch/nn/_functions/thnn/__init__.py
+++ b/torch/nn/_functions/thnn/__init__.py
@@ -7,3 +7,4 @@ from .pooling import *
 from .sparse import *
 from .upsampling import *
 from .rnnFusedPointwise import *
+from .batchnorm_double_backwards import batchnorm_double_backwards_fn

--- a/torch/nn/_functions/thnn/batchnorm_double_backwards.py
+++ b/torch/nn/_functions/thnn/batchnorm_double_backwards.py
@@ -4,10 +4,10 @@ from operator import mul
 
 
 def sum_exclude_dim1(to_sum, keepdim=True):
-    to_sum = to_sum.sum(dim=0, keepdim=True)
-    dim = 2
-    for dim in range(2, to_sum.dim()):
-        to_sum = to_sum.sum(dim=dim, keepdim=True)
+    to_sum = to_sum.sum(dim=0, keepdim=keepdim)
+    start_point_exclusive = 1 if keepdim else 0
+    for dim in range(to_sum.dim() - 1, start_point_exclusive, -1):
+        to_sum = to_sum.sum(dim=dim, keepdim=keepdim)
     return to_sum
 
 
@@ -80,9 +80,6 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
         gG = ggI * first_back_grad_input(gO, 1)
         gG = sum_exclude_dim1(gG, keepdim=False)
 
-    # calculate gB
-    gB = None
-
     # calculate ggO
     ggO = None
     # contribution of input term
@@ -95,4 +92,4 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
         ggO_B_term = ggB_expanded
         ggO = ggO.add_(ggO_B_term) if ggO is not None else ggO_B_term
 
-    return gI, gG, gB, ggO
+    return gI, gG, ggO

--- a/torch/nn/_functions/thnn/batchnorm_double_backwards.py
+++ b/torch/nn/_functions/thnn/batchnorm_double_backwards.py
@@ -52,7 +52,7 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
         ggI_sum = sum_exclude_dim1(ggI)
         ggIinmu_sum = sum_exclude_dim1(ggI * input_sub_mu)
         all_sub = ((ggI_sum * gO_sum).div_(M)).sub_(sum_exclude_dim1(gO * ggI)).add_(
-                   ((sigma2_eps).pow(-1) * gOinmu_sum * ggIinmu_sum).mul_(3. / M))
+                  ((sigma2_eps).pow(-1) * gOinmu_sum * ggIinmu_sum).mul_(3. / M))
         gI_0t = (input_mu_sigma2_neg_3_2 * all_sub).div_(M)
         gI_1t = (ggIinmu_sum * sigma2_eps_neg_3_2).div_(M) * (gO_sum.div(M) - gO)
         gI_2t = (gOinmu_sum * sigma2_eps_neg_3_2).div_(M) * (ggI_sum.div(M) - ggI)
@@ -69,7 +69,8 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
     # this is the first backward's grad_input
     def first_back_grad_input(gO, gamma):
         h0 = (gamma / (sigma2_eps).sqrt()).div_(M)
-        h1 = (M * gO).sub_(sum_exclude_dim1(gO)).sub_(input_sub_mu.div(sigma2_eps) * sum_exclude_dim1(gO * input_sub_mu))
+        h1 = (M * gO).sub_(sum_exclude_dim1(gO)).sub_(
+            input_sub_mu.div(sigma2_eps) * sum_exclude_dim1(gO * input_sub_mu))
         return h0 * h1
 
     # calculate gG

--- a/torch/nn/_functions/thnn/batchnorm_double_backwards.py
+++ b/torch/nn/_functions/thnn/batchnorm_double_backwards.py
@@ -1,0 +1,95 @@
+from torch.autograd.variable import Variable
+from functools import reduce
+from operator import mul
+
+
+def sum_exclude_dim1(to_sum, keepdim=True):
+    to_sum = to_sum.sum(dim=0, keepdim=True)
+    dim = 2
+    for dim in range(2, to_sum.dim()):
+        to_sum = to_sum.sum(dim=dim, keepdim=True)
+    return to_sum
+
+
+# because gamma/ggG/ggB are 1-dimensional and represent dim==1, we can't
+# do a straight expansion because it won't follow the broadcasting rules.
+def expand_as_dim1(src, target):
+    src_expanded = src
+    while len(src_expanded.size()) < len(target.size()) - 1:
+        src_expanded = src_expanded.unsqueeze(1)
+    return src_expanded.expand_as(target)
+
+
+def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
+    affine = gamma is not None
+    if affine:
+        gamma_expanded = expand_as_dim1(gamma, input)
+
+        if ggG is not None:
+            ggG_expanded = expand_as_dim1(ggG, input)
+
+        if ggB is not None:
+            ggB_expanded = expand_as_dim1(ggB, input)
+    else:
+        gamma_expanded = 1
+
+    # define some terms we will reuse
+    M = reduce(mul, input.size()[0:1] + input.size()[2:])
+    mu = sum_exclude_dim1(input).div(M)
+    input_sub_mu = input - mu
+    sigma2_eps = sum_exclude_dim1(input_sub_mu.pow(2)).div(M) + eps
+    sigma2_eps_neg_1_2 = (sigma2_eps).pow(-1. / 2)
+    sigma2_eps_neg_3_2 = (sigma2_eps).pow(-3. / 2)
+
+    # calculate gI
+    input_mu_sigma2_neg_3_2 = (input_sub_mu * sigma2_eps_neg_3_2)
+    gOinmu_sum = sum_exclude_dim1(gO * input_sub_mu)
+
+    # start with contribution of input term
+    gI = None
+    if ggI is not None:
+        ggIinmu_sum = sum_exclude_dim1(ggI * input_sub_mu)
+        all_sub = (1. / M * sum_exclude_dim1(ggI) * sum_exclude_dim1(gO) - sum_exclude_dim1(gO * ggI) +
+                   3. / M * (sigma2_eps).pow(-1) * gOinmu_sum * ggIinmu_sum)
+        gI_0t = 1. / M * input_mu_sigma2_neg_3_2 * all_sub
+        gI_1t = 1. / M * (ggIinmu_sum * sigma2_eps_neg_3_2) * (1. / M * sum_exclude_dim1(gO) - gO)
+        gI_2t = 1. / M * (gOinmu_sum * sigma2_eps_neg_3_2) * (1. / M * sum_exclude_dim1(ggI) - ggI)
+        gI = gamma_expanded * (gI_0t + gI_1t + gI_2t)
+
+    # add contribution of gamma term to gI
+    if affine and ggG is not None:
+        t0 = gO * sigma2_eps_neg_1_2
+        t1 = -1. / M * sigma2_eps_neg_1_2 * sum_exclude_dim1(gO)
+        t2 = -1. / M * input_mu_sigma2_neg_3_2 * sum_exclude_dim1(gO * input_sub_mu)
+        gI_G_term = ggG_expanded * (t0 + t1 + t2)
+        gI = gI + gI_G_term if gI is not None else gI_G_term
+
+    # this is the first backward's grad_input
+    def first_back_grad_input(gO, gamma):
+        h0 = (gamma / (sigma2_eps).sqrt()).div(M)
+        h1 = M * gO - sum_exclude_dim1(gO) - input_sub_mu.div(sigma2_eps) * sum_exclude_dim1(gO * input_sub_mu)
+        return h0 * h1
+
+    # calculate gG
+    gG = None
+    if affine and ggI is not None:
+        # gG is just the first backwards with the gamma term removed (then shaped properly)
+        gG = ggI * first_back_grad_input(gO, 1)
+        gG = sum_exclude_dim1(gG, keepdim=False)
+
+    # calculate gB
+    gB = None
+
+    # calculate ggO
+    ggO = None
+    # contribution of input term
+    if ggI is not None:
+        ggO = first_back_grad_input(ggI, gamma_expanded)
+    if ggG is not None:
+        ggO_G_term = ggG_expanded * input_sub_mu * sigma2_eps_neg_1_2
+        ggO = ggO + ggO_G_term if ggO is not None else ggO_G_term
+    if ggB is not None:
+        ggO_B_term = ggB_expanded
+        ggO = ggO + ggO_B_term if ggO is not None else ggO_B_term
+
+    return gI, gG, gB, ggO


### PR DESCRIPTION
The double backwards function is currently implemented as a python function called direction from C++, but the plan is to convert it to C++ code once ATen is integrated with autograd.