### PR TITLE
Deduplicate THPUtils_checkLong/THPUtils_unpackLong

### DIFF
--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -6,24 +6,13 @@
 #include <type_traits>
 
 #include "torch/csrc/utils/object_ptr.h"
+#include "torch/csrc/utils/python_numbers.h"
 
 #define THPUtils_(NAME) TH_CONCAT_4(THP,Real,Utils_,NAME)
 
 #define THPUtils_typename(obj) (Py_TYPE(obj)->tp_name)
 
 
-#if PY_MAJOR_VERSION == 2
-#define THPUtils_checkLong(obj) ((PyLong_Check(obj) || PyInt_Check(obj)) && !PyBool_Check(obj))
-#define THPUtils_unpackLong(obj)                                               \
-    (PyLong_Check(obj) ? PyLong_AsLong(obj) :                                  \
-    PyInt_Check(obj) ? PyInt_AsLong(obj) :                                     \
-    (throw std::runtime_error("Could not unpack long"), 0))
-#else
-#define THPUtils_checkLong(obj) (PyLong_Check(obj) && !PyBool_Check(obj))
-#define THPUtils_unpackLong(obj)                                               \
-    (PyLong_Check(obj) ? PyLong_AsLong(obj) :                                  \
-    (throw std::runtime_error("Could not unpack long"), 0))
-#endif
 
 #if PY_MAJOR_VERSION == 2
 #define THPUtils_checkReal_FLOAT(object)                                       \


### PR DESCRIPTION
There were two implementations of THPUtils_checkLong/THPUtils_unpackLong; one
that was a macro and one that was not, which is hella bad if you accidentally
include the macro before the real definition.  Now we always use the inline
function.

A reasonable follow-up task would be to un-macro-ify the rest of these functions.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>