### PR TITLE
[bugfix] in bce_with_logits logsumexp calculation

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2333,7 +2333,7 @@ class TestNN(NNTestCase):
         with self.assertRaises(ValueError):
             nn.BCEWithLogitsLoss()(input, target)
 
-    def test_bce_with_logits_gives_same_result_as_sigmooid_and_bce_loss(self):
+    def test_bce_with_logits_gives_same_result_as_sigmoid_and_bce_loss(self):
         sigmoid = nn.Sigmoid()
 
         target = Variable(torch.rand(64, 4))
@@ -2343,6 +2343,15 @@ class TestNN(NNTestCase):
 
         weight = torch.rand(4)
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
+
+        target = Variable(torch.FloatTensor(4, 1).fill_(0))
+        output = Variable(torch.FloatTensor(4, 1).fill_(-100))
+
+        self.assertEqual(nn.BCEWithLogitsLoss()(output, target), nn.BCELoss()(sigmoid(output), target))
+
+        weight = torch.FloatTensor(1).uniform_()
+        self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
+
 
     def test_bce_with_logits_has_correct_grad_at_zero(self):
         output = Variable(torch.zeros(3, 1), requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2352,7 +2352,6 @@ class TestNN(NNTestCase):
         weight = torch.FloatTensor(1).uniform_()
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
 
-
     def test_bce_with_logits_has_correct_grad_at_zero(self):
         output = Variable(torch.zeros(3, 1), requires_grad=True)
         target = Variable(torch.zeros(3, 1))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -795,7 +795,7 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
     if not target.is_same_size(input):
         raise ValueError("Target size ({}) must be the same as input size ({})".format(target.size(), input.size()))
 
-    max_val = input.clamp(min=0)
+    max_val = (-input).clamp(min=0)
     loss = input - input * target + max_val + ((-max_val).exp() + (-input - max_val).exp()).log()
 
     if weight is not None:


### PR DESCRIPTION
Hi, 

In #2195 I re-formulated the bce with logits to not use abs (so that it could provide a gradient at an input of 0). In this re-formulation, I missed a `-` sign on the `clamp` which leads to numerical instability with large negative input values - leading to the wrong output. 

This PR adds a fix for this, Sorry for introducing the bug in the first place.

Details about the bug:

For example,
```python
inp = Variable(torch.FloatTensor([-100]))
tar = Variable(torch.FloatTensor([0]))
nn.BCELoss()(nn.Sigmoid()(inp), tar)   # returns ~0 
nn.BCEWithLogitsLoss()(inp, tar)  #return inf
```

This is because the (wrong) calculation was:
```
max_val = max(inp, 0)
loss = inp - inp*tar + max_val + log(e^-max_val + e^(-inp -max_val))
```
whereas `max_val` should be `max_val = max(-inp, 0)` (missing `-` sign). 

This didn't present an issue until unless with large `inp` where `e(-inp -max_val)` overflows giving `inf`. For example:
```
nn.BCELoss()(nn.Sigmoid()(inp), tar)
```python
inp = Variable(torch.FloatTensor([-50]))
tar = Variable(torch.FloatTensor([0]))
nn.BCELoss()(nn.Sigmoid()(inp), tar)   # returns ~0 
nn.BCEWithLogitsLoss()(inp, tar)  #returns 0
```
are equal (with reasonable precision).

I have now added a test using FloatTensors explicitly that shows this overflow. And fixed it by adding the `-` sign. 

