### PR TITLE
Added aarch64 support

### DIFF
--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -23,6 +23,7 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         os.path.join(CUDA_HOME, 'lib64'),
         '/usr/lib/x86_64-linux-gnu/',
         '/usr/lib/powerpc64le-linux-gnu/',
+        '/usr/lib/aarch64-linux-gnu/',
     ] + gather_paths([
         'LIBRARY_PATH',
     ])))


### PR DESCRIPTION
cuDNN isn't found on arm64 machine like a NVidia Jetson TX2.
This fixes it.