### PR TITLE
Fix gradgrad issues with BatchNorm and Advanced Indexing (master)

### DIFF
--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -212,6 +212,7 @@ class AdvancedIndexAdd(InplaceFunction):
         if ctx.needs_input_grad[2]:
             ctx.adv_index = adv_index
         ctx.mark_dirty(tensor1)
+        ctx.tensor2_size = tensor2.size()
         return tensor1._advanced_index_add(adv_index, tensor2)
 
     @staticmethod
@@ -223,7 +224,7 @@ class AdvancedIndexAdd(InplaceFunction):
             grad_tensor1 = grad_output
 
         if ctx.needs_input_grad[2]:
-            grad_tensor2 = grad_output._advanced_index_select(ctx.adv_index)
+            grad_tensor2 = grad_output._advanced_index_select(ctx.adv_index).contiguous().view(ctx.tensor2_size)
         return grad_tensor1, None, grad_tensor2
 
 

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -197,7 +197,7 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
                                  std::move(grad_bias));
   return wrap_outputs(all_inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<BatchNormBackwardBackward>(
-      f, *this, std::move(save_mean), std::move(save_std),
+      f, *this,
       input_var->save(this), Variable::save_opt(weight_var.get(), this),
       grad_outputs[0]->save(this));
     });

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -60,16 +60,12 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
   BatchNormBackwardBackward(
       FunctionFlags flags,
       BatchNormParams params,
-      at::Tensor save_mean,
-      at::Tensor save_std,
       SavedVariable input,
       SavedVariable weight,
       SavedVariable grad_output)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
-        this->save_mean = std::move(save_mean);
-        this->save_std = std::move(save_std);
         this->input = std::move(input);
         this->weight = std::move(weight);
         this->grad_output = std::move(grad_output);
@@ -80,8 +76,6 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
 
   virtual void releaseVariables() override;
 
-  at::Tensor save_mean;
-  at::Tensor save_std;
   SavedVariable input;
   SavedVariable weight;
   SavedVariable grad_output;


### PR DESCRIPTION
This adds two tests for gradchecks:

1) That backward is reentrant
2) That input grad sizes match input sizez.

1) Uncovers an issue with BatchNorm which is now fixed
2) Uncovers an issue with advanced indexing which is also now fixed.