### PR TITLE
search for ldconfig in /sbin for nccl detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,7 +282,8 @@ if platform.system() == 'Darwin':
     THD_LIB = os.path.join(lib_path, 'libTHD.1.dylib')
     NCCL_LIB = os.path.join(lib_path, 'libnccl.1.dylib')
 
-if WITH_NCCL and subprocess.call('ldconfig -p | grep libnccl >/dev/null', shell=True) == 0:
+if WITH_NCCL and (subprocess.call('ldconfig -p | grep libnccl >/dev/null', shell=True) == 0
+                  or subprocess.call('/sbin/ldconfig -p | grep libnccl >/dev/null', shell=True) == 0):
         SYSTEM_NCCL = True
 
 main_compile_args = ['-D_THP_CORE']

--- a/setup.py
+++ b/setup.py
@@ -282,8 +282,8 @@ if platform.system() == 'Darwin':
     THD_LIB = os.path.join(lib_path, 'libTHD.1.dylib')
     NCCL_LIB = os.path.join(lib_path, 'libnccl.1.dylib')
 
-if WITH_NCCL and (subprocess.call('ldconfig -p | grep libnccl >/dev/null', shell=True) == 0
-                  or subprocess.call('/sbin/ldconfig -p | grep libnccl >/dev/null', shell=True) == 0):
+if WITH_NCCL and (subprocess.call('ldconfig -p | grep libnccl >/dev/null', shell=True) == 0 or
+                  subprocess.call('/sbin/ldconfig -p | grep libnccl >/dev/null', shell=True) == 0):
         SYSTEM_NCCL = True
 
 main_compile_args = ['-D_THP_CORE']


### PR DESCRIPTION
On Debian and possibly other systes, ldconfig is not in the path
by default. This patch looks for ldconfig in /sbin after trying in the
search path, this is the location specified by the Filesystem
Hierarchy Standard and used e.g. by Debian.

Fixes issue #2252