### PR TITLE
Fix BatchNorm double backwards when training=False.

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3241,6 +3241,7 @@ new_module_tests = [
         constructor_args=(10,),
         input_size=(4, 10),
         cudnn=True,
+        check_eval=True,
         desc='affine',
     ),
     dict(
@@ -3248,6 +3249,7 @@ new_module_tests = [
         constructor_args=(5,),
         input_size=(4, 5, 3),
         cudnn=True,
+        check_eval=True,
         desc='3d_input',
     ),
     dict(
@@ -3255,6 +3257,7 @@ new_module_tests = [
         constructor_args=(10, 1e-3, 0.3, False),
         input_size=(4, 10),
         cudnn=True,
+        check_eval=True,
         desc='not_affine',
     ),
     dict(
@@ -3262,6 +3265,7 @@ new_module_tests = [
         constructor_args=(5, 1e-3, 0.3, False),
         input_size=(4, 5, 3),
         cudnn=True,
+        check_eval=True,
         desc='3d_input_not_affine',
     ),
     dict(
@@ -3269,12 +3273,14 @@ new_module_tests = [
         constructor_args=(3,),
         input_size=(2, 3, 6, 6),
         cudnn=True,
+        check_eval=True,
     ),
     dict(
         module_name='BatchNorm2d',
         constructor_args=(3, 1e-3, 0.8),
         input_size=(2, 3, 6, 6),
         cudnn=True,
+        check_eval=True,
         desc='momentum',
     ),
     dict(
@@ -3282,6 +3288,7 @@ new_module_tests = [
         constructor_args=(3, 1e-3, 0.8, False),
         input_size=(2, 3, 6, 6),
         cudnn=True,
+        check_eval=True,
         desc='not_affine',
     ),
     dict(
@@ -3289,12 +3296,14 @@ new_module_tests = [
         constructor_args=(3,),
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
+        check_eval=True,
     ),
     dict(
         module_name='BatchNorm3d',
         constructor_args=(3, 1e-3, 0.7),
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
+        check_eval=True,
         desc='momentum',
     ),
     dict(
@@ -3302,6 +3311,7 @@ new_module_tests = [
         constructor_args=(3, 1e-3, 0.7, False),
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
+        check_eval=True,
         desc='not_affine',
     ),
     dict(
@@ -3837,6 +3847,21 @@ for test_params in module_tests + new_module_tests:
         test_params['constructor'] = getattr(nn, name)
     test = NewModuleTest(**test_params)
     add_test(test)
+    if 'check_eval' in test_params:
+        # create a new test that is identical but that sets module.training to False
+        test_params['desc'] = test_params.get('desc', '') + 'eval'
+
+        def gen_eval_constructor(constructor):
+            def eval_constructor(*args, **kwargs):
+                cons = constructor(*args, **kwargs)
+                cons.training = False
+                return cons
+            eval_constructor.__name__ = constructor.__name__
+            return eval_constructor
+
+        test_params['constructor'] = gen_eval_constructor(test_params['constructor'])
+        test = NewModuleTest(**test_params)
+        add_test(test)
 
 for test_params in criterion_tests + new_criterion_tests:
     name = test_params.pop('module_name')

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -29,8 +29,8 @@ struct BatchNormBackward : public Function, public BatchNormParams {
   BatchNormBackward(
       FunctionFlags flags,
       BatchNormParams params,
-      std::unique_ptr<thpp::Tensor> save_mean,
-      std::unique_ptr<thpp::Tensor> save_std,
+      std::shared_ptr<thpp::Tensor> save_mean,
+      std::shared_ptr<thpp::Tensor> save_std,
       SavedVariable input,
       SavedVariable weight,
       SavedVariable bias)
@@ -49,8 +49,8 @@ struct BatchNormBackward : public Function, public BatchNormParams {
 
   virtual void releaseVariables() override;
 
-  std::unique_ptr<thpp::Tensor> save_mean;
-  std::unique_ptr<thpp::Tensor> save_std;
+  std::shared_ptr<thpp::Tensor> save_mean;
+  std::shared_ptr<thpp::Tensor> save_std;
   SavedVariable input;
   SavedVariable weight;
   SavedVariable bias;
@@ -60,12 +60,16 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
   BatchNormBackwardBackward(
       FunctionFlags flags,
       BatchNormParams params,
+      std::shared_ptr<thpp::Tensor> save_mean,
+      std::shared_ptr<thpp::Tensor> save_std,
       SavedVariable input,
       SavedVariable weight,
       SavedVariable grad_output)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
+        this->save_mean = std::move(save_mean);
+        this->save_std = std::move(save_std);
         this->input = std::move(input);
         this->weight = std::move(weight);
         this->grad_output = std::move(grad_output);
@@ -76,6 +80,8 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
 
   virtual void releaseVariables() override;
 
+  std::shared_ptr<thpp::Tensor> save_mean;
+  std::shared_ptr<thpp::Tensor> save_std;
   SavedVariable input;
   SavedVariable weight;
   SavedVariable grad_output;

--- a/torch/nn/_functions/thnn/batchnorm_double_backwards.py
+++ b/torch/nn/_functions/thnn/batchnorm_double_backwards.py
@@ -11,6 +11,17 @@ def sum_exclude_dim1(to_sum, keepdim=True):
     return to_sum
 
 
+# similar to expand_as below, but doesn't do the expand_as; operates as if
+# reductions were done with keepdim=True
+def unsqueeze_dim1(src, target):
+    src_expanded = src
+    while len(src_expanded.size()) < len(target.size()) - 1:
+        src_expanded = src_expanded.unsqueeze(1)
+    if len(src_expanded.size()) == len(target.size()) - 1:
+        src_expanded = src_expanded.unsqueeze(0)
+    return src_expanded
+
+
 # because gamma/ggG/ggB are 1-dimensional and represent dim==1, we can't
 # do a straight expansion because it won't follow the broadcasting rules.
 def expand_as_dim1(src, target):
@@ -20,7 +31,8 @@ def expand_as_dim1(src, target):
     return src_expanded.expand_as(target)
 
 
-def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
+def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps,
+                                  save_mean, save_std, running_mean, running_var, training):
     affine = gamma is not None
     if affine:
         gamma_expanded = expand_as_dim1(gamma, input)
@@ -35,11 +47,11 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
 
     # define some terms we will reuse
     M = reduce(mul, input.size()[0:1] + input.size()[2:])
-    mu = sum_exclude_dim1(input).div_(M)
+    mu = unsqueeze_dim1(Variable(save_mean if training else running_mean), input)
     input_sub_mu = input - mu
-    sigma2_eps = sum_exclude_dim1(input_sub_mu.pow(2)).div_(M).add_(eps)
-    sigma2_eps_neg_1_2 = (sigma2_eps).pow(-1. / 2)
-    sigma2_eps_neg_3_2 = (sigma2_eps).pow(-3. / 2)
+    sigma2_eps_neg_1_2 = unsqueeze_dim1(Variable(save_std if training else (running_var + eps).pow(-1. / 2)), input)
+    sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2)
+    sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3)
 
     # calculate gI
     input_mu_sigma2_neg_3_2 = (input_sub_mu * sigma2_eps_neg_3_2)
@@ -48,11 +60,11 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
 
     # start with contribution of input term
     gI = None
-    if ggI is not None:
+    if ggI is not None and training:
         ggI_sum = sum_exclude_dim1(ggI)
         ggIinmu_sum = sum_exclude_dim1(ggI * input_sub_mu)
         all_sub = ((ggI_sum * gO_sum).div_(M)).sub_(sum_exclude_dim1(gO * ggI)).add_(
-                  ((sigma2_eps).pow(-1) * gOinmu_sum * ggIinmu_sum).mul_(3. / M))
+                  (sigma2_eps_neg_1 * gOinmu_sum * ggIinmu_sum).mul_(3. / M))
         gI_0t = (input_mu_sigma2_neg_3_2 * all_sub).div_(M)
         gI_1t = (ggIinmu_sum * sigma2_eps_neg_3_2).div_(M) * (gO_sum.div(M) - gO)
         gI_2t = (gOinmu_sum * sigma2_eps_neg_3_2).div_(M) * (ggI_sum.div(M) - ggI)
@@ -60,31 +72,41 @@ def batchnorm_double_backwards_fn(input, gamma, ggI, ggG, ggB, gO, eps):
 
     # add contribution of gamma term to gI
     if affine and ggG is not None:
-        t0 = gO * sigma2_eps_neg_1_2
-        t1 = (sigma2_eps_neg_1_2 * gO_sum).div_(-M)
-        t2 = (input_mu_sigma2_neg_3_2 * sum_exclude_dim1(gO * input_sub_mu)).div_(-M)
-        gI_G_term = ggG_expanded * (t0.add_(t1).add_(t2))
-        gI = gI.add_(gI_G_term) if gI is not None else gI_G_term
+        if training:
+            t0 = gO * sigma2_eps_neg_1_2
+            t1 = (sigma2_eps_neg_1_2 * gO_sum).div_(-M)
+            t2 = (input_mu_sigma2_neg_3_2 * sum_exclude_dim1(gO * input_sub_mu)).div_(-M)
+            gI_G_term = ggG_expanded * (t0.add_(t1).add_(t2))
+            gI = gI.add_(gI_G_term) if gI is not None else gI_G_term
+        else:
+            gI_G_term = ggG_expanded * sigma2_eps_neg_1_2 * gO
+            gI = gI.add_(gI_G_term) if gI is not None else gI_G_term
 
     # this is the first backward's grad_input
     def first_back_grad_input(gO, gamma):
-        h0 = (gamma / (sigma2_eps).sqrt()).div_(M)
+        h0 = (gamma * sigma2_eps_neg_1_2).div_(M)
         h1 = (M * gO).sub_(sum_exclude_dim1(gO)).sub_(
-            input_sub_mu.div(sigma2_eps) * sum_exclude_dim1(gO * input_sub_mu))
+            input_sub_mu.mul(sigma2_eps_neg_1) * sum_exclude_dim1(gO * input_sub_mu))
         return h0 * h1
 
     # calculate gG
     gG = None
     if affine and ggI is not None:
-        # gG is just the first backwards with the gamma term removed (then shaped properly)
-        gG = ggI * first_back_grad_input(gO, 1)
-        gG = sum_exclude_dim1(gG, keepdim=False)
+        if training:
+            # gG is just the first backwards with the gamma term removed (then shaped properly)
+            gG = ggI * first_back_grad_input(gO, 1)
+            gG = sum_exclude_dim1(gG, keepdim=False)
+        else:
+            gG = sum_exclude_dim1(ggI * gO * sigma2_eps_neg_1_2, keepdim=False)
 
     # calculate ggO
     ggO = None
     # contribution of input term
     if ggI is not None:
-        ggO = first_back_grad_input(ggI, gamma_expanded)
+        if training:
+            ggO = first_back_grad_input(ggI, gamma_expanded)
+        else:
+            ggO = ggI * sigma2_eps_neg_1_2 * gamma_expanded
     if ggG is not None:
         ggO_G_term = ggG_expanded * input_sub_mu * sigma2_eps_neg_1_2
         ggO = ggO.add_(ggO_G_term) if ggO is not None else ggO_G_term


### PR DESCRIPTION
Changes for v.0.2.0 around using shared_ptrs rather than at::Tensors.