### PR TITLE
[doc] variable shape error of LSTMCell, GRUCell

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -563,11 +563,11 @@ class LSTMCell(RNNCellBase):
 
     Attributes:
         weight_ih: the learnable input-hidden weights, of shape
-            `(input_size x hidden_size)`
+            `(4*hidden_size x input_size)`
         weight_hh: the learnable hidden-hidden weights, of shape
-            `(hidden_size x hidden_size)`
-        bias_ih: the learnable input-hidden bias, of shape `(hidden_size)`
-        bias_hh: the learnable hidden-hidden bias, of shape `(hidden_size)`
+            `(4*hidden_size x input_size)`
+        bias_ih: the learnable input-hidden bias, of shape `(4*hidden_size)`
+        bias_hh: the learnable hidden-hidden bias, of shape `(4*hidden_size)`
 
     Examples::
 
@@ -638,11 +638,11 @@ class GRUCell(RNNCellBase):
 
     Attributes:
         weight_ih: the learnable input-hidden weights, of shape
-            `(input_size x hidden_size)`
+            `(3*hidden_size x input_size)`
         weight_hh: the learnable hidden-hidden weights, of shape
-            `(hidden_size x hidden_size)`
-        bias_ih: the learnable input-hidden bias, of shape `(hidden_size)`
-        bias_hh: the learnable hidden-hidden bias, of shape `(hidden_size)`
+            `(3*hidden_size x input_size)`
+        bias_ih: the learnable input-hidden bias, of shape `(3*hidden_size)`
+        bias_hh: the learnable hidden-hidden bias, of shape `(3*hidden_size)`
 
     Examples::
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -565,7 +565,7 @@ class LSTMCell(RNNCellBase):
         weight_ih: the learnable input-hidden weights, of shape
             `(4*hidden_size x input_size)`
         weight_hh: the learnable hidden-hidden weights, of shape
-            `(4*hidden_size x input_size)`
+            `(4*hidden_size x hidden_size)`
         bias_ih: the learnable input-hidden bias, of shape `(4*hidden_size)`
         bias_hh: the learnable hidden-hidden bias, of shape `(4*hidden_size)`
 
@@ -640,7 +640,7 @@ class GRUCell(RNNCellBase):
         weight_ih: the learnable input-hidden weights, of shape
             `(3*hidden_size x input_size)`
         weight_hh: the learnable hidden-hidden weights, of shape
-            `(3*hidden_size x input_size)`
+            `(3*hidden_size x hidden_size)`
         bias_ih: the learnable input-hidden bias, of shape `(3*hidden_size)`
         bias_hh: the learnable hidden-hidden bias, of shape `(3*hidden_size)`
 


### PR DESCRIPTION
The current variable shapes of LSTMCell and GRUCell in the document are incorrect. Fixed in their docstrings.