### PR TITLE
move normal variants to TH/THC

### DIFF
--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -102,56 +102,6 @@ static void THTensor_(random1__)(THTensor *self, THGenerator *gen, long b)
       default: 1
 ]]
 
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-static void THTensor_(normal_means)(THTensor *self, THGenerator *gen, THTensor *means, double stddev)
-{
-  THTensor_(resizeAs)(self, means);
-  THTensor_(normal)(self, gen, 0, stddev);
-  THTensor_(cadd)(self, self, 1, means);
-}
-
-static void THTensor_(normal_stddevs)(THTensor *self, THGenerator *gen, double mean, THTensor *stddevs)
-{
-  THTensor_(resizeAs)(self, stddevs);
-  THTensor_(normal)(self, gen, 0, 1);
-  THTensor_(cmul)(self, self, stddevs);
-  THTensor_(add)(self, self, mean);
-}
-
-static void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, THTensor *means, THTensor *stddevs)
-{
-  THTensor_(resizeAs)(self, means);
-  THTensor_(normal)(self, gen, 0, 1);
-  THTensor_(cmul)(self, self, stddevs);
-  THTensor_(cadd)(self, self, 1, means);
-}
-#endif
-
-#if CUDA_FLOAT || CUDA_DOUBLE || CUDA_HALF
-static void THTensor_(normal_means)(THCState *_, THTensor *self, THTensor *means, double stddev)
-{
-  THTensor_(resizeAs)(LIBRARY_STATE self, means);
-  THTensor_(normal)(LIBRARY_STATE self, 0, stddev);
-  THTensor_(cadd)(LIBRARY_STATE self, self, AS_REAL(1), means);
-}
-
-static void THTensor_(normal_stddevs)(THCState *_, THTensor *self, double mean, THTensor *stddevs)
-{
-  THTensor_(resizeAs)(LIBRARY_STATE self, stddevs);
-  THTensor_(normal)(LIBRARY_STATE self, 0, 1);
-  THTensor_(cmul)(LIBRARY_STATE self, self, stddevs);
-  THTensor_(add)(LIBRARY_STATE self, self, AS_REAL(mean));
-}
-
-static void THTensor_(normal_means_stddevs)(THCState *_, THTensor *self, THTensor *means, THTensor *stddevs)
-{
-  THTensor_(resizeAs)(LIBRARY_STATE self, means);
-  THTensor_(normal)(LIBRARY_STATE self, 0, 1);
-  THTensor_(cmul)(LIBRARY_STATE self, self, stddevs);
-  THTensor_(cadd)(LIBRARY_STATE self, self, AS_REAL(1), means);
-}
-#endif
-
 [[
   name: normal
   types:

--- a/torch/lib/TH/generic/THTensorRandom.c
+++ b/torch/lib/TH/generic/THTensorRandom.c
@@ -55,6 +55,29 @@ void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, dou
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_normal(_generator, mean, stdv););
 }
 
+void THTensor_(normal_means)(THTensor *self, THGenerator *gen, THTensor *means, double stddev)
+{
+  THTensor_(resizeAs)(self, means);
+  THTensor_(normal)(self, gen, 0, stddev);
+  THTensor_(cadd)(self, self, 1, means);
+}
+
+void THTensor_(normal_stddevs)(THTensor *self, THGenerator *gen, double mean, THTensor *stddevs)
+{
+  THTensor_(resizeAs)(self, stddevs);
+  THTensor_(normal)(self, gen, 0, 1);
+  THTensor_(cmul)(self, self, stddevs);
+  THTensor_(add)(self, self, mean);
+}
+
+void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, THTensor *means, THTensor *stddevs)
+{
+  THTensor_(resizeAs)(self, means);
+  THTensor_(normal)(self, gen, 0, 1);
+  THTensor_(cmul)(self, self, stddevs);
+  THTensor_(cadd)(self, self, 1, means);
+}
+
 void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_exponential(_generator, lambda););

--- a/torch/lib/TH/generic/THTensorRandom.h
+++ b/torch/lib/TH/generic/THTensorRandom.h
@@ -11,6 +11,9 @@ TH_API void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_gene
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 TH_API void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b);
 TH_API void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
+TH_API void THTensor_(normal_means)(THTensor *self, THGenerator *gen, THTensor *means, double stddev);
+TH_API void THTensor_(normal_stddevs)(THTensor *self, THGenerator *gen, double mean, THTensor *stddevs);
+TH_API void THTensor_(normal_means_stddevs)(THTensor *self, THGenerator *gen, THTensor *means, THTensor *stddevs);
 TH_API void THTensor_(exponential)(THTensor *self, THGenerator *_generator, double lambda);
 TH_API void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma);
 TH_API void THTensor_(logNormal)(THTensor *self, THGenerator *_generator, double mean, double stdv);

--- a/torch/lib/THC/generic/THCTensorRandom.cu
+++ b/torch/lib/THC/generic/THCTensorRandom.cu
@@ -34,6 +34,28 @@ THC_API void THCTensor_(normal)(THCState* state, THCTensor *self_, double mean, 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
 
+THC_API void THCTensor_(normal_means)(THCState *state, THCTensor *self, THCTensor *means, double stddev) {
+  THCTensor_(resizeAs)(state, self, means);
+  THCTensor_(normal)(state, self, 0, stddev);
+  THCTensor_(cadd)(state, self, self, ScalarConvert<int, real>::to(1), means);
+}
+
+THC_API void THCTensor_(normal_stddevs)(THCState *state, THCTensor *self, double mean, THCTensor *stddevs)
+{
+  THCTensor_(resizeAs)(state, self, stddevs);
+  THCTensor_(normal)(state, self, 0, 1);
+  THCTensor_(cmul)(state, self, self, stddevs);
+  THCTensor_(add)(state, self, self, ScalarConvert<double, real>::to(mean));
+}
+
+THC_API void THCTensor_(normal_means_stddevs)(THCState *state, THCTensor *self, THCTensor *means, THCTensor *stddevs)
+{
+  THCTensor_(resizeAs)(state, self, means);
+  THCTensor_(normal)(state, self, 0, 1);
+  THCTensor_(cmul)(state, self, self, stddevs);
+  THCTensor_(cadd)(state, self, self, ScalarConvert<int, real>::to(1), means);
+}
+
 THC_API void THCTensor_(logNormal)(THCState* state, THCTensor *self_, double mean, double stdv)
 {
 

--- a/torch/lib/THC/generic/THCTensorRandom.h
+++ b/torch/lib/THC/generic/THCTensorRandom.h
@@ -8,6 +8,9 @@ THC_API void THCTensor_(uniform)(struct THCState *state, THCTensor *self, double
 THC_API void THCTensor_(rand)(THCState *state, THCTensor *r_, THLongStorage *size);
 THC_API void THCTensor_(randn)(THCState *state, THCTensor *r_, THLongStorage *size);
 THC_API void THCTensor_(normal)(struct THCState *state, THCTensor *self, double mean, double stdv);
+THC_API void THCTensor_(normal_means)(struct THCState *state, THCTensor *self, THCTensor *means, double stddev);
+THC_API void THCTensor_(normal_stddevs)(struct THCState *state, THCTensor *self, double mean, THCTensor *stddevs);
+THC_API void THCTensor_(normal_means_stddevs)(struct THCState *state, THCTensor *self, THCTensor *means, THCTensor *stddevs);
 THC_API void THCTensor_(logNormal)(struct THCState *state, THCTensor *self, double mean, double stdv);
 THC_API void THCTensor_(exponential)(struct THCState *state, THCTensor *self, double lambda);
 THC_API void THCTensor_(cauchy)(struct THCState *state, THCTensor *self, double median, double sigma);


### PR DESCRIPTION
As title. This way, other libraries (aka ATen), can call these functions. They don't have any PyTorch specific code.