### PR TITLE
documentation nit fix for torch.Tensor.random_

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1115,9 +1115,9 @@ add_docstr_all('random_',
                """
 random_(from=0, to=None, *, generator=None)
 
-Fills this tensor with numbers sampled from the uniform distribution or
-discrete uniform distribution over [from, to - 1]. If not specified, the
-values are only bounded by this tensor's data type.
+Fills this tensor with numbers sampled from the discrete uniform distribution
+over [from, to - 1]. If not specified, the values are only bounded by this
+tensor's data type.
 """)
 
 add_docstr_all('reciprocal',


### PR DESCRIPTION
Based on my understanding on the implementation, we only sample integer values: https://github.com/pytorch/pytorch/blob/master/torch/lib/TH/generic/THTensorRandom.c#L5-L24. As such, it is always the discrete uniform distribution.