### PR TITLE
Fix BatchNorm double backwards memory leak (v.0.2.0)

### DIFF
--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -108,9 +108,7 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<BatchNormBackward>(
         f, *this, std::move(save_mean), std::move(save_std),
-        input->save(this),
-        Variable::save_opt(weight.get(), this),
-        Variable::save_opt(bias.get(), this));
+        input, weight, bias);
   });
 };
 
@@ -208,8 +206,8 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
   return wrap_outputs(all_inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<BatchNormBackwardBackward>(
       f, *this, save_mean, save_std,
-      input_var->save(this), Variable::save_opt(weight_var.get(), this),
-      grad_outputs[0]->save(this));
+      input_var, weight_var,
+      grad_outputs[0]);
     });
 };
 

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -249,15 +249,13 @@ auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> 
   THPObjectPtr running_mean_py(createPyObject(*running_mean));
   THPObjectPtr running_var_py(createPyObject(*running_var));
   PyObject *training_pyo = training ? Py_True : Py_False;
-  Py_INCREF(training_pyo);
-  THPObjectPtr training_py(training_pyo);
 
   THPObjectPtr args(PyTuple_Pack(12, input_pvar.get(), weight_pvar.get(),
                                  ggi_pvar.get(), ggW_pvar.get(), ggb_pvar.get(),
                                  gO_pvar.get(), eps_py.get(),
                                  save_mean_py.get(), save_std_py.get(),
                                  running_mean_py.get(), running_var_py.get(),
-                                 training_py.get()));
+                                 training_pyo));
   THPObjectPtr r(PyObject_CallObject(THPBatchNormBackwardBackwardFunction, args.get()));
   if (!r) throw python_error();
   if (!PyTuple_Check(r.get())) {

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -230,31 +230,37 @@ auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> 
   auto ggW = grad_grad_inputs[1];
   auto ggb = grad_grad_inputs[2];
 
-  auto gO = grad_output.unpack();
   auto input_var = input.unpack();
   auto weight_var = weight.unpack();
+  auto gO_var = grad_output.unpack();
 
+  std::unique_ptr<thpp::Tensor> input {input_var->data->clone_shallow()};
+  AutoGPU guard(input->getDevice());
   AutoGIL gil;
+
   THPObjectPtr input_pvar(THPVariable_Wrap(input_var));
-  THPObjectPtr weight_pvar(weight_var ? THPVariable_Wrap(weight_var) : Py_None);
-  THPObjectPtr ggi_pvar(ggI ? THPVariable_Wrap(ggI) : Py_None);
-  THPObjectPtr ggW_pvar(ggW ? THPVariable_Wrap(ggW) : Py_None);
-  THPObjectPtr ggb_pvar(ggb ? THPVariable_Wrap(ggb) : Py_None);
-  THPObjectPtr gO_pvar(THPVariable_Wrap(gO));
+  THPObjectPtr weight_pvar(THPVariable_Wrap(weight_var));
+
+  THPObjectPtr ggi_pvar(THPVariable_Wrap(ggI));
+  THPObjectPtr ggW_pvar(THPVariable_Wrap(ggW));
+  THPObjectPtr ggb_pvar(THPVariable_Wrap(ggb));
+  THPObjectPtr gO_pvar(THPVariable_Wrap(gO_var));
   THPObjectPtr eps_py(PyFloat_FromDouble(eps));
   THPObjectPtr save_mean_py(createPyObject(*save_mean));
   THPObjectPtr save_std_py(createPyObject(*save_std));
   THPObjectPtr running_mean_py(createPyObject(*running_mean));
   THPObjectPtr running_var_py(createPyObject(*running_var));
-  THPObjectPtr training_py(training ? Py_True : Py_False);
+  PyObject *training_pyo = training ? Py_True : Py_False;
+  Py_INCREF(training_pyo);
+  THPObjectPtr training_py(training_pyo);
 
-  PyObject* args = PyTuple_Pack(12, input_pvar.get(), weight_pvar.get(),
-                                ggi_pvar.get(), ggW_pvar.get(), ggb_pvar.get(),
-                                gO_pvar.get(), eps_py.get(),
-                                save_mean_py.get(), save_std_py.get(),
-                                running_mean_py.get(), running_var_py.get(),
-                                training_py.get());
-  THPObjectPtr r(PyObject_CallObject(THPBatchNormBackwardBackwardFunction, args));
+  THPObjectPtr args(PyTuple_Pack(12, input_pvar.get(), weight_pvar.get(),
+                                 ggi_pvar.get(), ggW_pvar.get(), ggb_pvar.get(),
+                                 gO_pvar.get(), eps_py.get(),
+                                 save_mean_py.get(), save_std_py.get(),
+                                 running_mean_py.get(), running_var_py.get(),
+                                 training_py.get()));
+  THPObjectPtr r(PyObject_CallObject(THPBatchNormBackwardBackwardFunction, args.get()));
   if (!r) throw python_error();
   if (!PyTuple_Check(r.get())) {
     throw std::runtime_error("expected PyTuple return from BatchNormBackwardBackward");

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -39,9 +39,9 @@ struct BatchNormBackward : public Function, public BatchNormParams {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = std::move(input->save(this));
-        this->weight = std::move(Variable::save_opt(weight.get(), this));
-        this->bias = std::move(Variable::save_opt(bias.get(), this));
+        this->input = input->save(this);
+        this->weight = Variable::save_opt(weight.get(), this);
+        this->bias = Variable::save_opt(bias.get(), this);
       }
     }
 
@@ -70,9 +70,9 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = std::move(input->save(this));
-        this->weight = std::move(Variable::save_opt(weight.get(), this));
-        this->grad_output = std::move(grad_output->save(this));
+        this->input = input->save(this);
+        this->weight = Variable::save_opt(weight.get(), this);
+        this->grad_output = grad_output->save(this);
       }
     }
 

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -31,17 +31,17 @@ struct BatchNormBackward : public Function, public BatchNormParams {
       BatchNormParams params,
       std::shared_ptr<thpp::Tensor> save_mean,
       std::shared_ptr<thpp::Tensor> save_std,
-      SavedVariable input,
-      SavedVariable weight,
-      SavedVariable bias)
+      const std::shared_ptr<Variable> &input,
+      const std::shared_ptr<Variable> &weight,
+      const std::shared_ptr<Variable> &bias)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = std::move(input);
-        this->weight = std::move(weight);
-        this->bias = std::move(bias);
+        this->input = std::move(input->save(this));
+        this->weight = std::move(Variable::save_opt(weight.get(), this));
+        this->bias = std::move(Variable::save_opt(bias.get(), this));
       }
     }
 
@@ -62,17 +62,17 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
       BatchNormParams params,
       std::shared_ptr<thpp::Tensor> save_mean,
       std::shared_ptr<thpp::Tensor> save_std,
-      SavedVariable input,
-      SavedVariable weight,
-      SavedVariable grad_output)
+      const std::shared_ptr<Variable> &input,
+      const std::shared_ptr<Variable> &weight,
+      const std::shared_ptr<Variable> &grad_output)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = std::move(input);
-        this->weight = std::move(weight);
-        this->grad_output = std::move(grad_output);
+        this->input = std::move(input->save(this));
+        this->weight = std::move(Variable::save_opt(weight.get(), this));
+        this->grad_output = std::move(grad_output->save(this));
       }
     }
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -249,7 +249,7 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<ConvBackward>(
         f, *this,
-        inputs[0]->save(this), inputs[1]->save(this), Variable::save_opt(inputs[2].get(), this),
+        inputs[0], inputs[1], inputs[2],
         std::move(columns), std::move(ones), std::move(convolution));
   });
 };
@@ -390,8 +390,8 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   return wrap_outputs(all_inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<ConvBackwardBackward>(
       f, *this,
-      input_var->save(this), weight_var->save(this),
-      Variable::save_opt(bias_var.get(), this), grad_outputs[0]->save(this));
+      input_var, weight_var,
+      bias_var, grad_outputs[0]);
   });
 };
 

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -49,9 +49,9 @@ struct ConvBackward : public Function, public ConvParams {
   ConvBackward(
       FunctionFlags flags,
       ConvParams params,
-      SavedVariable input,
-      SavedVariable weight,
-      SavedVariable bias,
+      const std::shared_ptr<Variable>& input,
+      const std::shared_ptr<Variable>& weight,
+      const std::shared_ptr<Variable>& bias,
       tensor_list columns,
       tensor_list ones,
       std::unique_ptr<torch::cudnn::Convolution> convolution)
@@ -59,9 +59,9 @@ struct ConvBackward : public Function, public ConvParams {
     , ConvParams(std::move(params))
     , convolution(std::move(convolution)) {
       if (is_executable) {
-        this->input_ = std::move(input);
-        this->weight_ = std::move(weight);
-        this->bias_ = std::move(bias);
+        this->input_ = std::move(input->save(this));
+        this->weight_ = std::move(weight->save(this));
+        this->bias_ = std::move(Variable::save_opt(bias.get(), this));
         this->columns = std::move(columns);
         this->ones = std::move(ones);
       }
@@ -83,17 +83,17 @@ struct ConvBackwardBackward : public Function, public ConvParams {
   ConvBackwardBackward(
       FunctionFlags flags,
       ConvParams params,
-      SavedVariable input,
-      SavedVariable weight,
-      SavedVariable bias,
-      SavedVariable grad_output)
+      const std::shared_ptr<Variable>& input,
+      const std::shared_ptr<Variable>& weight,
+      const std::shared_ptr<Variable>& bias,
+      const std::shared_ptr<Variable>& grad_output)
     : Function(std::move(flags))
     , ConvParams(std::move(params)) {
       if (is_executable) {
-        this->input_ = std::move(input);
-        this->weight_ = std::move(weight);
-        this->bias_ = std::move(bias);
-        this->grad_output_ = std::move(grad_output);
+        this->input_ = std::move(input->save(this));
+        this->weight_ = std::move(weight->save(this));
+        this->bias_ = std::move(Variable::save_opt(bias.get(), this));
+        this->grad_output_ = std::move(grad_output->save(this));
       }
     }
 


### PR DESCRIPTION
This fixes a couple of issues:
1) Fixes python reference counts in BatchNormBackwardBackward; previously there were a couple of issues such as using initializing THPObjectPtr with Py_None, when THPVariableWrap already does the correct thing and returns Py_RETURN_NONE.
2) Fixes the "saved_for" parameter in BatchNorm and Conv.  Previously, these were passed as the object itself, rather than the Backwards object, i.e. ConvForward would pass ConvForward as the save for backward, which is wrong (you never save something for the forward).  I'm not sure in these specific cases if it were possible to construct a graph where this was a problem (I wasn't able to with non-affine BatchNorm), but it's good to fix this anyway.