### PR TITLE
Add examples in functional.py and loss.py

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -746,13 +746,20 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
         ignore_index (int, optional): Specifies a target value that is ignored
                 and does not contribute to the input gradient. When size_average is
                 True, the loss is averaged over non-ignored targets. Default: -100
+
+    Examples::
+
+        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
+        >>> target = autograd.Variable(torch.LongTensor(3).random_(5))
+        >>> loss = F.cross_entropy(input, target)
+        >>> loss.backward()
     """
     return nll_loss(log_softmax(input), target, weight, size_average, ignore_index)
 
 
 def binary_cross_entropy(input, target, weight=None, size_average=True):
     r"""Function that measures the Binary Cross Entropy
-    between the target and the output:
+    between the target and the output.
 
     See :class:`~torch.nn.BCELoss` for details.
 
@@ -765,6 +772,13 @@ def binary_cross_entropy(input, target, weight=None, size_average=True):
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch. Default: True
+
+    Examples::
+
+        >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
+        >>> target = autograd.Variable(torch.LongTensor(3).random_(2))
+        >>> loss = F.binary_cross_entropy(F.sigmoid(input), target)
+        >>> loss.backward()
     """
     if not (target.size() == input.size()):
         warnings.warn("Using a target size ({}) that is different to the input size ({}) is deprecated. "
@@ -782,7 +796,7 @@ def binary_cross_entropy(input, target, weight=None, size_average=True):
 
 def binary_cross_entropy_with_logits(input, target, weight=None, size_average=True):
     r"""Function that measures Binary Cross Entropy between target and output
-    logits:
+    logits.
 
     See :class:`~torch.nn.BCEWithLogitsLoss` for details.
 
@@ -795,6 +809,13 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch. Default: True
+
+    Examples::
+
+         >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
+         >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
+         >>> loss = F.binary_cross_entropy_with_logits(input, target)
+         >>> loss.backward()
     """
     if not (target.size() == input.size()):
         raise ValueError("Target size ({}) must be the same as input size ({})".format(target.size(), input.size()))

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -17,7 +17,7 @@ class PairwiseDistance(Module):
 
     Shape:
         - Input1: :math:`(N, D)` where `D = vector dimension`
-        - Input2: :math:`(N, D), same shape as the Input1
+        - Input2: :math:`(N, D)`, same shape as the Input1
         - Output: :math:`(N, 1)`
 
     Examples::

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -286,10 +286,25 @@ class BCELoss(_WeightedLoss):
     an auto-encoder. Note that the targets `t[i]` should be numbers
     between 0 and 1.
 
-    By default, the losses are averaged for each minibatch over observations
-    *as well as* over dimensions. However, if the field `size_average` is set
-    to `False`, the losses are instead summed.
+    Args:
+        size_average (bool, optional): By default, the losses are averaged
+            over observations for each minibatch. However, if the field
+            size_average is set to False, the losses are instead summed for
+            each minibatch. Default: True
 
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Target: :math:`(N, *)`, same shape as the input
+
+    Examples::
+
+        >>> m = nn.Sigmoid()
+        >>> loss = nn.BCELoss()
+        >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
+        >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
+        >>> output = loss(m(input), target)
+        >>> output.backward()
     """
     def forward(self, input, target):
         _assert_no_grad(target)
@@ -316,10 +331,24 @@ class BCEWithLogitsLoss(Module):
     an auto-encoder. Note that the targets `t[i]` should be numbers
     between 0 and 1.
 
-    By default, the losses are averaged for each minibatch over observations
-    *as well as* over dimensions. However, if the field `size_average` is set
-    to `False`, the losses are instead summed.
+    Args:
+        size_average (bool, optional): By default, the losses are averaged
+            over observations for each minibatch. However, if the field
+            size_average is set to False, the losses are instead summed for
+            each minibatch. Default: True
 
+     Shape:
+         - Input: :math:`(N, *)` where `*` means, any number of additional
+           dimensions
+         - Target: :math:`(N, *)`, same shape as the input
+
+     Examples::
+
+         >>> loss = nn.BCEWithLogitsLoss()
+         >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
+         >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
+         >>> output = loss(input, target)
+         >>> output.backward()
     """
     def __init__(self, weight=None, size_average=True):
         super(BCEWithLogitsLoss, self).__init__()


### PR DESCRIPTION
(1) functional.py

Added examples for `F.cross_entropy`, `F.binary_cross_entropy` and `F.binary_cross_entropy_with_logits`.

(2) loss.py

Added examples for `nn.BCELoss` and `nn.BCEWithLogitLoss`.