### PR TITLE
adding backward capability for potrf (Cholesky)

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -25,6 +25,7 @@ $PYCMD test_torch.py $@
 
 echo "Running autograd tests"
 $PYCMD test_autograd.py $@
+$PYCMD test_potrf.py $@
 
 echo "Running sparse tests"
 $PYCMD test_sparse.py $@

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1514,9 +1514,11 @@ def prod_single_zero(dim_size):
     result[0, 1] = 0
     return Variable(result, requires_grad=True)
 
+
 def _make_cov(S):
     L = torch.tril(torch.rand(S, S))
     return torch.mm(L, L.t())
+
 
 class dont_convert(tuple):
     pass

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1514,6 +1514,9 @@ def prod_single_zero(dim_size):
     result[0, 1] = 0
     return Variable(result, requires_grad=True)
 
+def _make_cov(S):
+    L = torch.tril(torch.rand(S, S))
+    return torch.mm(L, L.t())
 
 class dont_convert(tuple):
     pass
@@ -1994,6 +1997,7 @@ method_tests = [
     ('cross', (S, 3, S), ((S, 3, S), 1), 'dim'),
     ('inverse', (S, S), (), '', (), [skipIfNoLapack]),
     ('gesv', (S, S), ((S, S),), '', (), [skipIfNoLapack]),
+    ('potrf', _make_cov(S), (True,), '', (), [skipIfNoLapack]),
     ('clone', (S, M, S), ()),
     ('eq', (S, S, S), ((S, S, S),)),
     ('eq', (S, S, S), ((1,),), 'broadcast_rhs'),

--- a/test/test_potrf.py
+++ b/test/test_potrf.py
@@ -2,9 +2,10 @@ import torch
 import numpy as np
 from test_autograd import _make_cov
 from torch.autograd import Variable
-from common import TestCase, run_tests
+from common import TestCase, run_tests, skipIfNoLapack
 
 from torch.autograd._functions.linalg import Potrf
+
 
 class TestPotrf(TestCase):
 
@@ -12,9 +13,9 @@ class TestPotrf(TestCase):
         # numerical forward derivative
         dA = Variable(_make_cov(5))
         eps = 1e-6
-        outb = Potrf.apply(A + (eps/2) * dA, upper)
-        outa = Potrf.apply(A - (eps/2) * dA, upper)
-        dL = (outb - outa)/eps
+        outb = Potrf.apply(A + (eps / 2) * dA, upper)
+        outa = Potrf.apply(A - (eps / 2) * dA, upper)
+        dL = (outb - outa) / eps
 
         return dA, dL
 
@@ -36,10 +37,11 @@ class TestPotrf(TestCase):
         df1 = (dL * Lbar).sum()
         df2 = (dA * Abar).sum()
 
-        atol=1e-5
-        rtol=1e-3
+        atol = 1e-5
+        rtol = 1e-3
         assert (df1 - df2).abs().data[0] <= atol + rtol * df1.abs().data[0]
 
+    @skipIfNoLapack
     def test_potrf(self):
         for upper in [True, False]:
             A = Variable(_make_cov(5), requires_grad=True)

--- a/test/test_potrf.py
+++ b/test/test_potrf.py
@@ -1,0 +1,50 @@
+import torch
+import numpy as np
+from test_autograd import _make_cov
+from torch.autograd import Variable
+from common import TestCase, run_tests
+
+from torch.autograd._functions.linalg import Potrf
+
+class TestPotrf(TestCase):
+
+    def _calc_deriv_numeric(self, A, L, upper):
+        # numerical forward derivative
+        dA = Variable(_make_cov(5))
+        eps = 1e-6
+        outb = Potrf.apply(A + (eps/2) * dA, upper)
+        outa = Potrf.apply(A - (eps/2) * dA, upper)
+        dL = (outb - outa)/eps
+
+        return dA, dL
+
+    def _calc_deriv_sym(self, A, L, upper):
+        # reverse mode
+        Lbar = Variable(torch.rand(5, 5).tril())
+        if upper:
+            Lbar = Lbar.t()
+        L.backward(Lbar)
+        Abar = A.grad
+
+        return Abar, Lbar
+
+    def _check_total_variation(self, A, L, upper):
+        dA, dL = self._calc_deriv_numeric(A, L, upper)
+        Abar, Lbar = self._calc_deriv_sym(A, L, upper)
+
+        # compare df = Tr(dA^T Abar) = Tr(dL^T Lbar)
+        df1 = (dL * Lbar).sum()
+        df2 = (dA * Abar).sum()
+
+        atol=1e-5
+        rtol=1e-3
+        assert (df1 - df2).abs().data[0] <= atol + rtol * df1.abs().data[0]
+
+    def test_potrf(self):
+        for upper in [True, False]:
+            A = Variable(_make_cov(5), requires_grad=True)
+            L = Potrf.apply(A, upper)
+            self._check_total_variation(A, L, upper)
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/autograd/_functions/linalg.py
+++ b/torch/autograd/_functions/linalg.py
@@ -103,6 +103,7 @@ class Gesv(Function):
         grad_a = -torch.mm(grad_b, X.t())
         return grad_b, grad_a
 
+
 class Potrf(Function):
     """
     cf. Iain Murray (2016); arXiv 1602.07527
@@ -116,13 +117,14 @@ class Potrf(Function):
         return fact
 
     @staticmethod
-    def Phi(A):
+    def phi(A):
         """
         Return lower triangle of A and halve the diagonal.
         """
         B = A.tril()
-        for i in range(B.size(0)):
-            B[i, i] = B[i, i] * 0.5
+
+        B = B - 0.5 * torch.diag(torch.diag(B))
+
         return B
 
     @staticmethod
@@ -137,9 +139,9 @@ class Potrf(Function):
         # only half of output matrix is unique
         Lbar = grad_output.tril()
 
-        P = Potrf.Phi(torch.mm(L.t(), Lbar))
+        P = Potrf.phi(torch.mm(L.t(), Lbar))
         S = torch.gesv(P + P.t(), L.t())[0]
         S = torch.gesv(S.t(), L.t())[0]
-        S = Potrf.Phi(S)
+        S = Potrf.phi(S)
 
         return S, None

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -780,6 +780,9 @@ class Variable(_C._VariableBase):
     def gesv(self, a):
         return Gesv.apply(self, a)
 
+    def potrf(self, upper=True):
+        return Potrf.apply(self, upper)
+
     def multinomial(self, num_samples=1, replacement=False):
         return Multinomial(num_samples, replacement)(self)
 


### PR DESCRIPTION
- cf #440 
- Implementation based on Iain Murray's note (arXiv 1602.07527)
- Uses the symbolic method, which is easier to code and competitive for
  small arrays (according to experiments in the supplement to that paper)
- Unfortunately, the framework in `test_autograd` fails for the `Function` subclass because the outputs of `Potrf` are not independent, so the Jacobian calculation isn't correct. I implemented a different set of tests based on Murray's [here](https://github.com/imurray/chol-rev/blob/master/python/chol_rev_demo.py)