### PR TITLE
Batch norm layer for pseudo-fp16 support.

### DIFF
--- a/tools/cwrap/plugins/CuDNNPlugin.py
+++ b/tools/cwrap/plugins/CuDNNPlugin.py
@@ -9,7 +9,8 @@ class CuDNNPlugin(CWrapPlugin):
 
     TYPE_UNPACK = {
         'THTensor*': Template('((THPVoidTensor*)$arg)->cdata'),
-        'int': Template('((int) THPUtils_unpackLong($arg))'),
+        'THAccumTensor*': Template('((THPVoidTensor*)$arg)->cdata'),
+        'int': Template('THPUtils_unpackLong($arg)'),
         'std::vector<int>': Template('THPUtils_unpackIntTuple($arg)'),
         'cudnnDataType_t': Template('$arg'),
         'cudnnHandle_t': Template('$arg'),
@@ -20,11 +21,13 @@ class CuDNNPlugin(CWrapPlugin):
 
     INPUT_ARGUMENT_MAP = {
         'THTensor*': 'THVoidTensor*',
+        'THAccumTensor*': 'THVoidTensor*',
     }
 
     TYPE_CHECK = {
         'Convolution*': Template('THPWrapper_check($arg)'),
         'THTensor*': Template('(PyObject*)Py_TYPE($arg) == tensorClass'),
+        'THAccumTensor*': Template('(PyObject*)Py_TYPE($arg) == accumTensorClass'),
         'int': Template('THPUtils_checkLong($arg)'),
         'std::vector<int>': Template('THPUtils_checkIntTuple($arg)'),
         'bool': Template('PyBool_Check($arg)'),
@@ -55,6 +58,7 @@ static PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
     int __dictcount = kwargs ? (int) PyDict_Size(kwargs) : 0;
     int __argcount = __tuplecount + __dictcount;
     PyObject* tensorClass = getTensorClass(args);
+    PyObject* accumTensorClass = getAccumTensorClass(args);
     THCPAutoGPU __autogpu_guard = THCPAutoGPU(args);
 
     $options
@@ -70,6 +74,7 @@ static PyObject * $name(PyObject *self, PyObject *args, PyObject *kwargs)
 
     TYPE_NAMES = {
         'THTensor*': '" THPTensorStr "',
+        'THTAccumTensor*': '" THPTensorStr "',
         'long': 'int',
         'bool': 'bool',
         'int': 'int',

--- a/torch/csrc/cudnn/Types.cpp
+++ b/torch/csrc/cudnn/Types.cpp
@@ -45,6 +45,22 @@ PyObject * getTensorClass(PyObject *args)
   return NULL;
 }
 
+PyObject * getAccumTensorClass(PyObject *args)
+{
+  for (int i = 0; i < PyTuple_Size(args); i++) {
+    PyObject *item = PyTuple_GET_ITEM(args, i);
+    if (THPModule_isTensor(item)) {      
+      PyObject * tensorClass = (PyObject*)Py_TYPE(item);
+      if (tensorClass == THCPHalfTensorClass) 
+        return THCPFloatTensorClass;
+      else
+        return tensorClass;
+    }
+  }
+  return NULL;
+}
+
+
 void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& name)
 {
   static const std::string error_str = "cuDNN requires contiguous ";

--- a/torch/csrc/cudnn/Types.h
+++ b/torch/csrc/cudnn/Types.h
@@ -11,6 +11,7 @@
 namespace torch { namespace cudnn {
 
 PyObject * getTensorClass(PyObject *args);
+PyObject * getAccumTensorClass(PyObject * args);
 cudnnDataType_t getCudnnDataType(PyObject *tensorClass);
 cudnnDataType_t getCudnnDataType(const at::Tensor& tensor);
 void _THVoidTensor_assertContiguous(THVoidTensor *tensor, const std::string& name);

--- a/torch/csrc/cudnn/cuDNN.cwrap
+++ b/torch/csrc/cudnn/cuDNN.cwrap
@@ -132,12 +132,12 @@ extern THCState* state;
     - cudnnDataType_t dataType
     - THTensor* input
     - THTensor* output
-    - THTensor* weight
-    - THTensor* bias
-    - THTensor* running_mean
-    - THTensor* running_var
-    - THTensor* save_mean
-    - THTensor* save_var
+    - THAccumTensor* weight
+    - THAccumTensor* bias
+    - THAccumTensor* running_mean
+    - THAccumTensor* running_var
+    - THAccumTensor* save_mean
+    - THAccumTensor* save_var
     - bool training
     - double exponential_average_factor
     - double epsilon
@@ -152,13 +152,13 @@ extern THCState* state;
     - THTensor* input
     - THTensor* grad_output
     - THTensor* grad_input
-    - THTensor* grad_weight
-    - THTensor* grad_bias
-    - THTensor* weight
-    - THTensor* running_mean
-    - THTensor* running_var
-    - THTensor* save_mean
-    - THTensor* save_var
+    - THAccumTensor* grad_weight
+    - THAccumTensor* grad_bias
+    - THAccumTensor* weight
+    - THAccumTensor* running_mean
+    - THAccumTensor* running_var
+    - THAccumTensor* save_mean
+    - THAccumTensor* save_var
     - bool training
     - double epsilon
 ]]


### PR DESCRIPTION
Batch norm layer that keeps parameters in 32-bit when using 16-bit input/output. This layer is necessary for successful pseudo fp16 training.