### PR TITLE
Add CUDA version of eye

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -277,6 +277,7 @@ tests = [
     ('view_as', small_3d, lambda t: [t(100, 10)],),
     ('zero', small_3d, lambda t: [],),
     ('zeros', small_3d, lambda t: [1, 2, 3, 4],),
+    ('eye', small_2d, lambda t: [3, 4],),
     ('rsqrt', lambda t: small_3d(t) + 1, lambda t: [], None, float_types),
     ('sinh', lambda t: small_3d(t).clamp(-1, 1), lambda t: [], None, float_types),
     ('tan', lambda t: small_3d(t).clamp(-1, 1), lambda t: [], None, float_types),

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -1757,6 +1757,7 @@
   name: eye
   backends:
     - CPU
+    - CUDA
   variants:
     - function
   return: argument 0

--- a/torch/lib/THC/generic/THCTensorMath.cu
+++ b/torch/lib/THC/generic/THCTensorMath.cu
@@ -376,6 +376,28 @@ void THCTensor_(diag)(THCState *state, THCTensor *self_, THCTensor *src_, long k
   THCudaCheck(cudaGetLastError());
 }
 
+void THCTensor_(eye)(THCState *state, THCTensor *self_, long n, long m)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
+  THArgCheck(n > 0, 1, "invalid argument");
+
+  if(m <= 0)
+    m = n;
+
+  THCTensor_(resize2d)(state, self_, n, m);
+  THCTensor_(zero)(state, self_);
+
+  long sz = THMin(n, m);
+  long stride = THCTensor_(stride)(state, self_, 0) +
+                THCTensor_(stride)(state, self_, 1);
+
+  THCTensor *diag = THCTensor_(newWithStorage1d)(state, self_->storage,
+      self_->storageOffset,  sz, stride);
+
+  THCTensor_(fill)(state, diag, ScalarConvert<int, real>::to(1));
+  THCTensor_(free)(state, diag);
+}
+
 accreal THCTensor_(trace)(THCState *state, THCTensor *src_) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, src_));
   THArgCheck((src_->nDimension == 2), 1, "expected a matrix");

--- a/torch/lib/THC/generic/THCTensorMath.h
+++ b/torch/lib/THC/generic/THCTensorMath.h
@@ -16,6 +16,7 @@ THC_API void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor, THCT
 THC_API void THCTensor_(tril)(THCState *state, THCTensor *self, THCTensor *src, long k);
 THC_API void THCTensor_(triu)(THCState *state, THCTensor *self, THCTensor *src, long k);
 THC_API void THCTensor_(diag)(THCState *state, THCTensor *self, THCTensor *src, long k);
+THC_API void THCTensor_(eye)(THCState *state, THCTensor *self, long n, long m);
 THC_API accreal THCTensor_(trace)(THCState *state, THCTensor *self);
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)


### PR DESCRIPTION
Instead of writing a dedicated kernel, just selects the diagonal elements of the tensor using stride tricks, and fill them with ones.