### PR TITLE
Added delete and insert in nn.ModuleList  (please check changed test assumptions)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -627,14 +627,18 @@ class TestNN(NNTestCase):
 
     def test_ListModule(self):
         modules = [nn.ReLU(), nn.Linear(5, 5)]
-        module_list = nn.ModuleList(modules)
+        module_list = ModuleList(modules)
 
         def check():
             self.assertEqual(len(module_list), len(modules))
             for m1, m2 in zip(modules, module_list):
                 self.assertIs(m1, m2)
-            for m1, m2 in zip(modules, module_list.children()):
-                self.assertIs(m1, m2)
+            children = list(module_list.children())
+            # children don't have to be ordered in the order of module_list
+            for m1 in modules:  # every module is a child of module_list
+                self.assertIn(m1, children)
+            for m2 in children:  # every child is in modules
+                self.assertIn(m2, modules)
             for i in range(len(modules)):
                 self.assertIs(module_list[i], modules[i])
 
@@ -651,6 +655,12 @@ class TestNN(NNTestCase):
         check()
         modules[2] = nn.Conv2d(5, 3, 2)
         module_list[2] = modules[2]
+        check()
+        modules.insert(2, nn.SELU())
+        module_list.insert(2, modules[2])
+        check()
+        del modules[1]
+        del module_list[1]
         check()
 
         with self.assertRaises(TypeError):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -627,7 +627,7 @@ class TestNN(NNTestCase):
 
     def test_ListModule(self):
         modules = [nn.ReLU(), nn.Linear(5, 5)]
-        module_list = ModuleList(modules)
+        module_list = nn.ModuleList(modules)
 
         def check():
             self.assertEqual(len(module_list), len(modules))

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import string
 import torch
-import warnings
+import warnings, random
 from .module import Module
 
 
@@ -70,20 +70,15 @@ class Sequential(Module):
 
 class ModuleList(Module):
     """Holds submodules in a list.
-
     ModuleList can be indexed like a regular Python list, but modules it
     contains are properly registered, and will be visible by all Module methods.
-
     Arguments:
         modules (list, optional): a list of modules to add
-
     Example::
-
         class MyModule(nn.Module):
             def __init__(self):
                 super(MyModule, self).__init__()
                 self.linears = nn.ModuleList([nn.Linear(10, 10) for i in range(10)])
-
             def forward(self, x):
                 # ModuleList can act as an iterable, or be indexed using ints
                 for i, l in enumerate(self.linears):
@@ -93,6 +88,7 @@ class ModuleList(Module):
 
     def __init__(self, modules=None):
         super(ModuleList, self).__init__()
+        self._ordering = []
         if modules is not None:
             self += modules
 
@@ -101,42 +97,66 @@ class ModuleList(Module):
             raise IndexError('index {} is out of range'.format(idx))
         if idx < 0:
             idx += len(self)
-        return self._modules[str(idx)]
+        return self._modules[self._ordering[idx]]
 
     def __setitem__(self, idx, module):
-        return setattr(self, str(idx), module)
+        return setattr(self, self._ordering[idx], module)
+
+    def __delitem__(self, idx):
+        delattr(self, self._ordering[idx])
+        del self._ordering[idx]
 
     def __len__(self):
         return len(self._modules)
 
     def __iter__(self):
-        return iter(self._modules.values())
+        for x in self._ordering:
+            yield self._modules[x]
 
     def __iadd__(self, modules):
         return self.extend(modules)
 
     def append(self, module):
         """Appends a given module at the end of the list.
-
         Arguments:
             module (nn.Module): module to append
         """
-        self.add_module(str(len(self)), module)
+        newhash = self._make_new_hash()
+        self._ordering.append(newhash)
+        self.add_module(newhash, module)
+        return self
+
+    def insert(self, i, module):
+        """ Inserts a given module at a given position.
+        Arguments:
+            i (int): position where to insert
+            module (nn.Module): module to insert
+        """
+        newhash = self._make_new_hash()
+        self._ordering.insert(i, newhash)
+        self.add_module(newhash, module)
         return self
 
     def extend(self, modules):
         """Appends modules from a Python list at the end.
-
         Arguments:
             modules (list): list of modules to append
         """
         if not isinstance(modules, list):
             raise TypeError("ModuleList.extend should be called with a "
                             "list, but got " + type(modules).__name__)
-        offset = len(self)
         for i, module in enumerate(modules):
-            self.add_module(str(offset + i), module)
+            newhash = self._make_new_hash()
+            self._ordering.append(newhash)
+            self.add_module(newhash, module)
         return self
+
+    def _make_new_hash(self):
+        newhash = str(random.getrandbits(32))
+        while newhash in self._modules:
+            newhash = str(random.getrandbits(32))
+        return newhash
+
 
 
 class ParameterList(Module):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 import string
 import torch
-import warnings, random
+import warnings
+import random
 from .module import Module
 
 
@@ -156,7 +157,6 @@ class ModuleList(Module):
         while newhash in self._modules:
             newhash = str(random.getrandbits(32))
         return newhash
-
 
 
 class ParameterList(Module):


### PR DESCRIPTION
* nn.ModuleList now computes a hash for the submodules (which is used as the key in ._modules dictionary) and keeps the ordering in a separate Python list (._ordering)
* tests were also checking that the order in which children of nn.ModuleList are returned corresponds to the python list order. However, since the underlying ._modules OrderedDict() doesn't reflect the order of nn.ModuleList's ordering, this test doesn't pass anymore. Instead changed to test for inclusion of children (please verify changed assumption)

