### PR TITLE
Allow kwarg-only inputs to DataParallel

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1357,6 +1357,24 @@ class TestNN(NNTestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out.data, expected_out)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_data_parallel_module_kwargs_only(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.l = l
+
+            def forward(self, input):
+                return self.l(input)
+
+        l = nn.Linear(10, 5).float().cuda()
+        i = Variable(torch.randn(20, 10).float().cuda())
+        expected_out = l(i).data
+        n = nn.DataParallel(Net())
+        out = n(input=i)
+        self.assertEqual(out.get_device(), 0)
+        self.assertEqual(out.data, expected_out)
+
     def test_state_dict(self):
         l = nn.Linear(5, 5)
         block = nn.Module()

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -15,23 +15,26 @@ def scatter(inputs, target_gpus, dim=0):
             return Scatter(target_gpus, dim=dim)(obj)
         assert not torch.is_tensor(obj), "Tensors not supported in scatter."
         if isinstance(obj, tuple):
-            return tuple(zip(*map(scatter_map, obj)))
+            return list(zip(*map(scatter_map, obj)))
         if isinstance(obj, list):
-            return tuple(map(list, zip(*map(scatter_map, obj))))
+            return list(map(list, zip(*map(scatter_map, obj))))
         if isinstance(obj, dict):
-            return tuple(map(type(obj), zip(*map(scatter_map, obj.items()))))
-        return tuple(obj for targets in target_gpus)
+            return list(map(type(obj), zip(*map(scatter_map, obj.items()))))
+        return [obj for targets in target_gpus]
 
     return scatter_map(inputs)
 
 
 def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
     """Scatter with support for kwargs dictionary"""
-    inputs = scatter(inputs, target_gpus, dim)
-    if kwargs is None or len(kwargs) == 0:
-        kwargs = tuple({} for _ in inputs)
-    else:
-        kwargs = scatter(kwargs, target_gpus, dim)[:len(inputs)]
+    inputs = scatter(inputs, target_gpus, dim) if inputs else []
+    kwargs = scatter(kwargs, target_gpus, dim) if kwargs else []
+    if len(inputs) < len(kwargs):
+        inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
+    elif len(kwargs) < len(inputs):
+        kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
+    inputs = tuple(inputs)
+    kwargs = tuple(kwargs)
     return inputs, kwargs
 
 


### PR DESCRIPTION
kwarg-only inputs are helpful when making generic training frameworks. This PR makes it so that what already works for a single-GPU work on many.