### PR TITLE
Update documentation to reflect Linear with 2+D inputs

### DIFF
--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -16,8 +16,10 @@ class Linear(Module):
             Default: True
 
     Shape:
-        - Input: :math:`(N, in\_features)`
-        - Output: :math:`(N, out\_features)`
+        - Input: :math:`(N, *, in\_features)` where `*` means any number of
+          additional dimensions
+        - Output: :math:`(N, *, out\_features)` where all but the last dimension
+          are the same shape as the input.
 
     Attributes:
         weight: the learnable weights of the module of shape


### PR DESCRIPTION
Update the documentation / shape signature of `nn.Linear` to reflect the changes introduced in https://github.com/pytorch/pytorch/pull/1935

The symbol added into the shape signature is the same as [the one from the activation function](http://pytorch.org/docs/master/nn.html#torch.nn.ReLU) for consistency 