### PR TITLE
Always copy indices in Embedding._renorm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -822,6 +822,21 @@ class TestNN(NNTestCase):
         self.assertEqual(output[0][0].sum().data[0], 0)
         self.assertEqual(output[1][2].sum().data[0], 0)
 
+    def test_embedding_max_norm(self):
+        embedding = nn.Embedding(22, 5, max_norm=1.0)
+        input = Variable(torch.LongTensor([2, 8, 8, 6]))
+        output = embedding(input)
+        self.assertEqual(output[1], output[2])
+        self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_embedding_max_norm_cuda(self):
+        embedding = nn.Embedding(22, 5, max_norm=1.0).cuda()
+        input = Variable(torch.LongTensor([2, 8, 8, 6])).cuda()
+        output = embedding(input)
+        self.assertEqual(output[1], output[2])
+        self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
+
     def test_embedding_functional(self):
         a = Variable(torch.LongTensor([
             [1, 3, 2],

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -10,12 +10,10 @@ class Embedding(Function):
 
     @staticmethod
     def _renorm(ctx, indices, weight, max_norm, norm_type):
-        if indices.dim() == 2:
-            indices = indices.clone().view(-1)
-
+        # clone indices since LookupTable_renorm modifies it in-place
         ctx._backend.LookupTable_renorm(
             ctx._backend.library_state,
-            indices,
+            indices.clone().view(-1),
             weight,
             max_norm,
             norm_type


### PR DESCRIPTION
LookupTable_renorm sorts and de-dupes the passed in indices tensor
in-place.

Fixes #2413