### PR TITLE
Add calls to contiguous for cudnn affine_grid

### DIFF
--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -74,6 +74,7 @@ class AffineGridGenerator(Function):
             ctx.is_cuda = True
             AffineGridGenerator._enforce_cudnn(theta)
             grid = theta.new(N, H, W, 2)
+            theta = theta.contiguous()
             torch._C._cudnn_affine_grid_generator_forward(theta, grid, N, C, H, W)
         else:
             ctx.is_cuda = False
@@ -97,6 +98,7 @@ class AffineGridGenerator(Function):
         if grad_grid.is_cuda:
             AffineGridGenerator._enforce_cudnn(grad_grid)
             grad_theta = grad_grid.new(N, 2, 3)
+            grad_grid = grad_grid.contiguous()
             torch._C._cudnn_affine_grid_generator_backward(grad_theta, grad_grid,
                                                            N, C, H, W)
         else:


### PR DESCRIPTION
The cudnn version of `affine_grid` requires `theta` to be contiguous. I ran into an issue where I was generating `theta` using skimage (which produces 3x3 matrices) and then sliced it to get 3x2 matrices which were no longer contiguous. i.e:

```Python
import torch
import torch.nn.functional as F
from torch.autograd import Variable

theta = Variable(torch.Tensor(16, 3, 3).uniform_())
theta = theta[:, 0:2, :].cuda()
grid = F.affine_grid(theta, torch.Size((16, 3, 24, 24))
```
fails as `theta` is not contiguous. This PR adds the calls to `contiguous` in the cudnn code path as its a no-op if the tensors are already contiguous.

