### PR TITLE
Copy-edit sparse constructor docs for clarity.

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -12,15 +12,29 @@ efficiently store and process tensors for which the majority of elements
 are zeros.
 
 A sparse tensor is represented as a pair of dense tensors: a tensor
-of values and a tensor of indices.  A sparse tensor can be constructed
+of values and a 2D tensor of indices.  A sparse tensor can be constructed
 by providing these two tensors, as well as the size of the sparse tensor
-(which cannot be inferred from these tensors!)
+(which cannot be inferred from these tensors!)  Suppose we want to define
+a sparse tensor with the entry 3 at location (0, 2), entry 4 at
+location (1, 0), and entry 5 at location (1, 2).  We would then write:
 
-    >>> i = torch.LongTensor([[0, 1], [2, 0]])
-    >>> v = torch.FloatTensor([3, 4])
+    >>> i = torch.LongTensor([[0, 1, 1],
+                              [2, 0, 2]])
+    >>> v = torch.FloatTensor([3, 4, 5])
     >>> torch.sparse.FloatTensor(i, v, torch.Size([2,3])).to_dense()
      0  0  3
-     4  0  0
+     4  0  5
+    [torch.FloatTensor of size 2x3]
+
+Note that the input to LongTensor is NOT a list of index tuples.  If you want
+to write your indices this way, you should transpose before passing them to
+the sparse constructor:
+
+    >>> i = torch.LongTensor([[0, 2], [1, 0], [1, 2]])
+    >>> v = torch.FloatTensor([3,      4,      5    ])
+    >>> torch.sparse.FloatTensor(i.t(), v, torch.Size([2,3])).to_dense()
+     0  0  3
+     4  0  5
     [torch.FloatTensor of size 2x3]
 
 You can also construct hybrid sparse tensors, where only the first n


### PR DESCRIPTION
Basically, it's easy to confuse the dimensions of the index tensor.
This adds some more text which should hopefully clarify the situation.

Fixes #2416.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>