### PR TITLE
Address integer division to make it compatible with py2

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -31,7 +31,7 @@ class DistributedSampler(Sampler):
         self.num_replicas = num_replicas
         self.rank = rank
         self.epoch = 0
-        self.num_samples = int(math.ceil(len(self.dataset) / self.num_replicas))
+        self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.num_replicas))
         self.total_size = self.num_samples * self.num_replicas
 
     def __iter__(self):


### PR DESCRIPTION
In py2 self.num_samples is actually truncated before the ceil() method takes effect . And it hurts when we add extra samples to make it evenly divisible since our total_size is less than indices, finally caused Assertion failed in __iter__().