### PR TITLE
Fixes for Tensor constructor with NumPy array argument

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -135,8 +135,20 @@ class TestTorch(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_has_storage_numpy(self):
-        arr = np.array([], dtype=np.float32)
-        self.assertIsNotNone(torch.Tensor(arr).storage())
+        for dtype in [np.float32, np.float64, np.int64,
+                      np.int32, np.int16, np.uint8]:
+            arr = np.array([1], dtype=dtype)
+            self.assertIsNotNone(torch.FloatTensor(arr).storage())
+            self.assertIsNotNone(torch.DoubleTensor(arr).storage())
+            self.assertIsNotNone(torch.IntTensor(arr).storage())
+            self.assertIsNotNone(torch.LongTensor(arr).storage())
+            self.assertIsNotNone(torch.ByteTensor(arr).storage())
+            if torch.cuda.is_available():
+                self.assertIsNotNone(torch.cuda.FloatTensor(arr).storage())
+                self.assertIsNotNone(torch.cuda.DoubleTensor(arr).storage())
+                self.assertIsNotNone(torch.cuda.IntTensor(arr).storage())
+                self.assertIsNotNone(torch.cuda.LongTensor(arr).storage())
+                self.assertIsNotNone(torch.cuda.ByteTensor(arr).storage())
 
     def _testSelection(self, torchfn, mathfn):
         # contiguous

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -26,7 +26,7 @@
 #define COPY_FROM_ARRAY(ELTYPE) \
 { \
   ELTYPE *data = (ELTYPE*)PyArray_DATA(array); \
-  for (ptrdiff_t i=0; i<storage_size; i++) {   \
+  for (size_t i=0; i<storage_size; i++) {   \
     storage->data[i] = data[i];                \
   }                                            \
 }


### PR DESCRIPTION
This PR addresses #1957 and #2246.
Given
`
torch.DoubleTensor(np.array([0,1,2], dtype=np.float32))
`
torch will now copy the contents of the array in a storage of appropriate type. If types match, it will share the underlying array (no-copy), with equivalent semantics to initializing a tensor with another tensor.

On CUDA,
`
torch.cuda.FloatTensor(np.random.rand(10,2).astype(np.float32))
`
will now work by making a copy.

I added a test for the various combinations.

__Question for the reviewers__: in the `COPY_FROM_ARRAY_CUDA` macro, I always copy into `data_guard` regardless of whether the array had the same type as the tensor. Should we share the underlying C array in this case or would there be any issues with it?