### PR TITLE
hidding statically linked libstdc++ symbols

### DIFF
--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -22,6 +22,12 @@ ENDIF ()
 IF ($ENV{PYTORCH_BINARY_BUILD})
   MESSAGE(STATUS "PYTORCH_BINARY_BUILD detected. Statically linking libstdc++")
   SET(CMAKE_CXX_FLAGS "-static-libstdc++ ${CMAKE_CXX_FLAGS}")
+  
+  IF (UNIX AND NOT APPLE)
+    # hiding statically linked library symbols, this flag is not available for the linker under MACOSX
+    SET(CMAKE_CXX_FLAGS "-Wl,--exclude-libs,ALL ${CMAKE_CXX_FLAGS}")
+  ENDIF(UNIX AND NOT APPLE)
+  
 ENDIF()
 
 ADD_LIBRARY(shm SHARED core.cpp)


### PR DESCRIPTION
This is a solution for the problem described in this comment:
https://github.com/pytorch/pytorch/commit/1d9b10d312fe5e6325e399277e28aeb78fd2ddf7#commitcomment-23678756

And a solution for the issue #2462