### PR TITLE
test_distributed cuda tests don't skip if cuda not available.

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -228,6 +228,7 @@ class _DistTestBase(object):
         self._test_broadcast_helper(group, group_id, rank)
 
     @unittest.skipIf(BACKEND != 'gloo', "Only Gloo backend supports CUDA allReduce")
+    @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
     def test_broadcast_cuda(self):
         group, group_id, rank = self._init_global_test()
         self._test_broadcast_helper(group, group_id, rank, True)
@@ -333,6 +334,7 @@ class _DistTestBase(object):
         )
 
     @unittest.skipIf(BACKEND != 'gloo', "Only Gloo backend supports CUDA allReduce")
+    @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
     def test_all_reduce_sum_cuda(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_reduce_helper(

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -8,6 +8,7 @@ from functools import wraps, reduce
 from contextlib import contextmanager
 
 import torch
+import torch.cuda
 import torch.distributed as dist
 from common import TestCase
 
@@ -21,6 +22,20 @@ MASTER_ADDR = '127.0.0.1'
 if not dist.is_available():
     print('Distributed not available, skipping tests')
     sys.exit(0)
+
+SKIP_IF_NO_CUDA_EXIT_CODE = 75
+
+
+def skip_if_no_cuda_distributed(func):
+    func.skip_if_no_cuda_distributed = True
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not torch.cuda.is_available():
+            sys.exit(SKIP_IF_NO_CUDA_EXIT_CODE)
+
+        return func(*args, **kwargs)
+    return wrapper
 
 
 @contextmanager
@@ -228,7 +243,7 @@ class _DistTestBase(object):
         self._test_broadcast_helper(group, group_id, rank)
 
     @unittest.skipIf(BACKEND != 'gloo', "Only Gloo backend supports CUDA allReduce")
-    @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
+    @skip_if_no_cuda_distributed
     def test_broadcast_cuda(self):
         group, group_id, rank = self._init_global_test()
         self._test_broadcast_helper(group, group_id, rank, True)
@@ -334,7 +349,7 @@ class _DistTestBase(object):
         )
 
     @unittest.skipIf(BACKEND != 'gloo', "Only Gloo backend supports CUDA allReduce")
-    @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
+    @skip_if_no_cuda_distributed
     def test_all_reduce_sum_cuda(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_reduce_helper(
@@ -489,7 +504,7 @@ if BACKEND == 'tcp' or BACKEND == 'gloo':
             @wraps(fn)
             def wrapper(self):
                 if self.rank == self.MANAGER_PROCESS_RANK:
-                    self._join_and_reduce()
+                    self._join_and_reduce(fn)
                 else:
                     fn(self)
             return wrapper
@@ -535,10 +550,18 @@ if BACKEND == 'tcp' or BACKEND == 'gloo':
             getattr(self, self.id().split(".")[2])()
             sys.exit(0)
 
-        def _join_and_reduce(self):
+        def _join_and_reduce(self, fn):
+            skip_ok = getattr(fn, "skip_if_no_cuda_distributed", False)
             for p in self.processes:
                 p.join(self.JOIN_TIMEOUT)
-                self.assertEqual(p.exitcode, 0)
+                if not skip_ok:
+                    self.assertEqual(p.exitcode, 0)
+
+            if skip_ok:
+                exit_code_reduce = reduce((lambda x, y: x if x == y else None), (p.exitcode for p in self.processes))
+                if exit_code_reduce == SKIP_IF_NO_CUDA_EXIT_CODE:
+                    raise unittest.SkipTest("cuda is not available")
+                self.assertEqual(exit_code_reduce, 0)
 
 elif BACKEND == 'mpi':
     dist.init_process_group(init_method=INIT_METHOD, backend='mpi')

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -558,10 +558,14 @@ if BACKEND == 'tcp' or BACKEND == 'gloo':
                     self.assertEqual(p.exitcode, 0)
 
             if skip_ok:
-                exit_code_reduce = reduce((lambda x, y: x if x == y else None), (p.exitcode for p in self.processes))
-                if exit_code_reduce == SKIP_IF_NO_CUDA_EXIT_CODE:
+                first_process = self.processes[0]
+                # do this first so we don't give an error message about mismatched exit codes if the first isn't valid
+                assert first_process.exitcode == 0 or first_process.exitcode == SKIP_IF_NO_CUDA_EXIT_CODE
+
+                for p in self.processes:
+                    self.assertEqual(p.exitcode, first_process.exitcode)
+                if first_process.exitcode == SKIP_IF_NO_CUDA_EXIT_CODE:
                     raise unittest.SkipTest("cuda is not available")
-                self.assertEqual(exit_code_reduce, 0)
 
 elif BACKEND == 'mpi':
     dist.init_process_group(init_method=INIT_METHOD, backend='mpi')


### PR DESCRIPTION
Note that THD only builds with gloo if you are building with cuda; so to trigger this you need to compile with cuda support but e.g. have no visible devices.