### PR TITLE
add missing import for lr_scheduler

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -15,6 +15,7 @@ from .rprop import Rprop
 from .rmsprop import RMSprop
 from .optimizer import Optimizer
 from .lbfgs import LBFGS
+from .lr_scheduler import *
 
 del adadelta
 del adagrad
@@ -26,3 +27,4 @@ del rprop
 del rmsprop
 del optimizer
 del lbfgs
+del lr_scheduler


### PR DESCRIPTION
Currently, using the lr_scheduler by calling `torch.optim.ReduceLROnPlateau` as shown in the [documentation](http://pytorch.org/docs/master/optim.html#how-to-adjust-learning-rate) returns `module 'torch.optim' has no attribute 'ReduceLROnPlateau'`. My guess is that this is because it's not imported in `optim` `__init__.py`. I have imported it in a similar fashion to how the optimizers are imported into `__init__.py` 