### PR TITLE
Add ones_like and zeros_like

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -18,13 +18,14 @@ Creation Ops
 .. autofunction:: linspace
 .. autofunction:: logspace
 .. autofunction:: ones
+.. autofunction:: ones_like
 .. autofunction:: rand
 .. autofunction:: randn
 .. autofunction:: randperm
 .. autofunction:: arange
 .. autofunction:: range
 .. autofunction:: zeros
-
+.. autofunction:: zeros_like
 
 Indexing, Slicing, Joining, Mutating Ops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -793,25 +793,25 @@ class TestTorch(TestCase):
 
     def test_zeros_like(self):
         expected = torch.zeros(100, 100)
-        
+
         res1 = torch.zeros_like(expected)
         self.assertEqual(res1, expected)
-        
+
         res2 = torch.Tensor()
         torch.zeros_like(expected, out=res2)
         self.assertEqual(res2, expected)
-    
+
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_zeros_like_cuda(self):
         expected = torch.zeros(100, 100).cuda()
-        
+
         res1 = torch.zeros_like(expected)
         self.assertEqual(res1, expected)
-        
+
         res2 = torch.Tensor().cuda()
         torch.zeros_like(expected, out=res2)
         self.assertEqual(res2, expected)
-    
+
     def test_histc(self):
         x = torch.Tensor((2, 4, 2, 2, 5, 4))
         y = torch.histc(x, 5, 1, 5)  # nbins,  min,  max
@@ -823,13 +823,13 @@ class TestTorch(TestCase):
         res2 = torch.Tensor()
         torch.ones(100, 100, out=res2)
         self.assertEqual(res1, res2)
-    
+
     def test_ones_like(self):
         expected = torch.ones(100, 100)
-        
+
         res1 = torch.ones_like(expected)
         self.assertEqual(res1, expected)
-        
+
         res2 = torch.Tensor()
         torch.ones_like(expected, out=res2)
         self.assertEqual(res2, expected)
@@ -837,14 +837,14 @@ class TestTorch(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_ones_like_cuda(self):
         expected = torch.ones(100, 100).cuda()
-        
+
         res1 = torch.ones_like(expected)
         self.assertEqual(res1, expected)
-        
+
         res2 = torch.Tensor().cuda()
         torch.ones_like(expected, out=res2)
         self.assertEqual(res2, expected)
-    
+
     def test_diag(self):
         x = torch.rand(100, 100)
         res1 = torch.diag(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -801,6 +801,17 @@ class TestTorch(TestCase):
         torch.zeros_like(expected, out=res2)
         self.assertEqual(res2, expected)
     
+    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
+    def test_zeros_like_cuda(self):
+        expected = torch.zeros(100, 100).cuda()
+        
+        res1 = torch.zeros_like(expected)
+        self.assertEqual(res1, expected)
+        
+        res2 = torch.Tensor().cuda()
+        torch.zeros_like(expected, out=res2)
+        self.assertEqual(res2, expected)
+    
     def test_histc(self):
         x = torch.Tensor((2, 4, 2, 2, 5, 4))
         y = torch.histc(x, 5, 1, 5)  # nbins,  min,  max
@@ -823,6 +834,17 @@ class TestTorch(TestCase):
         torch.ones_like(expected, out=res2)
         self.assertEqual(res2, expected)
 
+    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
+    def test_ones_like_cuda(self):
+        expected = torch.ones(100, 100).cuda()
+        
+        res1 = torch.ones_like(expected)
+        self.assertEqual(res1, expected)
+        
+        res2 = torch.Tensor().cuda()
+        torch.ones_like(expected, out=res2)
+        self.assertEqual(res2, expected)
+    
     def test_diag(self):
         x = torch.rand(100, 100)
         res1 = torch.diag(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -791,6 +791,16 @@ class TestTorch(TestCase):
         torch.zeros(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
+    def test_zeros_like(self):
+        expected = torch.zeros(100, 100)
+        
+        res1 = torch.zeros_like(expected)
+        self.assertEqual(res1, expected)
+        
+        res2 = torch.Tensor()
+        torch.zeros_like(expected, out=res2)
+        self.assertEqual(res2, expected)
+    
     def test_histc(self):
         x = torch.Tensor((2, 4, 2, 2, 5, 4))
         y = torch.histc(x, 5, 1, 5)  # nbins,  min,  max
@@ -802,6 +812,16 @@ class TestTorch(TestCase):
         res2 = torch.Tensor()
         torch.ones(100, 100, out=res2)
         self.assertEqual(res1, res2)
+    
+    def test_ones_like(self):
+        expected = torch.ones(100, 100)
+        
+        res1 = torch.ones_like(expected)
+        self.assertEqual(res1, expected)
+        
+        res2 = torch.Tensor()
+        torch.ones_like(expected, out=res2)
+        self.assertEqual(res2, expected)
 
     def test_diag(self):
         x = torch.rand(100, 100)

--- a/tools/docker/Dockerfile_runtime
+++ b/tools/docker/Dockerfile_runtime
@@ -25,5 +25,3 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 WORKDIR /workspace
 RUN chmod -R a+w /workspace
-
-RUN echo "source activate pytorch-py35" >> ~/.bashrc

--- a/tools/docker/Dockerfile_runtime
+++ b/tools/docker/Dockerfile_runtime
@@ -25,3 +25,5 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 WORKDIR /workspace
 RUN chmod -R a+w /workspace
+
+RUN echo "source activate pytorch-py35" >> ~/.bashrc

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3096,6 +3096,26 @@ Example::
 
 """)
 
+add_docstr(torch._C.ones_like,
+           """
+ones_like(input, out=None) -> Tensor
+
+Returns a Tensor filled with the scalar value `1`, with the same size as :attr:`input`.
+
+Args:
+    input (Tensor): The size of the input will determine the size of the output.
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> input = torch.FloatTensor(2, 3)
+    >>> torch.ones_like(input)
+
+     1  1  1
+     1  1  1
+    [torch.FloatTensor of size 2x3]
+""")
+
 # TODO
 # add_docstr(torch._C.orgqr,
 # """
@@ -4793,6 +4813,26 @@ Example::
      0
     [torch.FloatTensor of size 5]
 
+""")
+
+add_docstr(torch._C.zeros_like,
+           """
+zeros_like(input, out=None) -> Tensor
+
+Returns a Tensor filled with the scalar value `0`, with the same size as :attr:`input`.
+
+Args:
+    input (Tensor): The size of the input will determine the size of the output.
+    out (Tensor, optional): the result Tensor
+
+Example::
+
+    >>> input = torch.FloatTensor(2, 3)
+    >>> torch.zeros_like(input)
+
+     0  0  0
+     0  0  0
+    [torch.FloatTensor of size 2x3]
 """)
 
 add_docstr(torch._C.btrifact,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -280,7 +280,9 @@ IMPLEMENT_STATELESS(atan2)
 IMPLEMENT_STATELESS(pow)
 IMPLEMENT_STATELESS(lerp)
 IMPLEMENT_STATELESS(zeros)
+IMPLEMENT_STATELESS(zeros_like)
 IMPLEMENT_STATELESS(ones)
+IMPLEMENT_STATELESS(ones_like)
 IMPLEMENT_STATELESS(index_select)
 IMPLEMENT_STATELESS(addmm)
 IMPLEMENT_STATELESS(addmv)
@@ -671,7 +673,9 @@ static PyMethodDef TorchMethods[] = {
   {"pow",             (PyCFunction)THPModule_pow,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"lerp",            (PyCFunction)THPModule_lerp,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"zeros",           (PyCFunction)THPModule_zeros,             METH_VARARGS | METH_KEYWORDS, NULL},
+  {"zeros_like",      (PyCFunction)THPModule_zeros_like,        METH_VARARGS | METH_KEYWORDS, NULL},
   {"ones",            (PyCFunction)THPModule_ones,              METH_VARARGS | METH_KEYWORDS, NULL},
+  {"ones_like",       (PyCFunction)THPModule_ones_like,         METH_VARARGS | METH_KEYWORDS, NULL},
   {"index_select",    (PyCFunction)THPModule_index_select,      METH_VARARGS | METH_KEYWORDS, NULL},
   {"addmm",           (PyCFunction)THPModule_addmm,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"addmv",           (PyCFunction)THPModule_addmv,             METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -130,6 +130,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
 
 [[
   name: zeros_like
+  cname: zerosLike
   variants:
     - function
   auto_gpu: False
@@ -155,6 +156,7 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
 
 [[
   name: ones_like
+  cname: onesLike
   variants:
     - function
   auto_gpu: False

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -129,6 +129,18 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
 ]]
 
 [[
+  name: zeros_like
+  variants:
+    - function
+  auto_gpu: False
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* input
+]]
+
+[[
   name: ones
   variants:
     - function
@@ -139,6 +151,18 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
       output: True
     - arg: THSize* size
       long_args: True
+]]
+
+[[
+  name: ones_like
+  variants:
+    - function
+  auto_gpu: False
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* input
 ]]
 
 [[

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -1927,6 +1927,18 @@ void THTensor_(zeros)(THTensor *r_, THLongStorage *size)
   THTensor_(zero)(r_);
 }
 
+void THTensor_(zeros_like)(THTensor *r_, THTensor *input)
+{
+  THTensor_(resize)(r_, THTensor_(newSizeOf)(input), NULL);
+  THTensor_(zero)(r_);
+}
+
+void THTensor_(ones_like)(THTensor *r_, THTensor *input)
+{
+  THTensor_(resize)(r_, THTensor_(newSizeOf)(input), NULL);
+  THTensor_(fill)(r_, 1);
+}
+
 void THTensor_(ones)(THTensor *r_, THLongStorage *size)
 {
   THTensor_(resize)(r_, size, NULL);

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -1927,15 +1927,15 @@ void THTensor_(zeros)(THTensor *r_, THLongStorage *size)
   THTensor_(zero)(r_);
 }
 
-void THTensor_(zeros_like)(THTensor *r_, THTensor *input)
+void THTensor_(zerosLike)(THTensor *r_, THTensor *input)
 {
-  THTensor_(resize)(r_, THTensor_(newSizeOf)(input), NULL);
+  THTensor_(resizeAs)(r_, input);
   THTensor_(zero)(r_);
 }
 
-void THTensor_(ones_like)(THTensor *r_, THTensor *input)
+void THTensor_(onesLike)(THTensor *r_, THTensor *input)
 {
-  THTensor_(resize)(r_, THTensor_(newSizeOf)(input), NULL);
+  THTensor_(resizeAs)(r_, input);
   THTensor_(fill)(r_, 1);
 }
 

--- a/torch/lib/TH/generic/THTensorMath.h
+++ b/torch/lib/TH/generic/THTensorMath.h
@@ -90,7 +90,9 @@ TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, real value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, real value);
 
 TH_API void THTensor_(zeros)(THTensor *r_, THLongStorage *size);
+TH_API void THTensor_(zeros_like)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(ones)(THTensor *r_, THLongStorage *size);
+TH_API void THTensor_(ones_like)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
 TH_API void THTensor_(eye)(THTensor *r_, long n, long m);
 TH_API void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step);

--- a/torch/lib/TH/generic/THTensorMath.h
+++ b/torch/lib/TH/generic/THTensorMath.h
@@ -90,9 +90,9 @@ TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, real value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, real value);
 
 TH_API void THTensor_(zeros)(THTensor *r_, THLongStorage *size);
-TH_API void THTensor_(zeros_like)(THTensor *r_, THTensor *input);
+TH_API void THTensor_(zerosLike)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(ones)(THTensor *r_, THLongStorage *size);
-TH_API void THTensor_(ones_like)(THTensor *r_, THTensor *input);
+TH_API void THTensor_(onesLike)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
 TH_API void THTensor_(eye)(THTensor *r_, long n, long m);
 TH_API void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step);

--- a/torch/lib/THC/generic/THCTensorMath.cu
+++ b/torch/lib/THC/generic/THCTensorMath.cu
@@ -44,10 +44,10 @@ THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size)
 }
 
 THC_API void
-THCTensor_(zeros_like)(THCState *state, THCTensor *r_, THCTensor *input)
+THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor *input)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
-  THCTensor_(resize)(state, r_, THCTensor_(newSizeOf)(state, input), NULL);
+  THCTensor_(resizeAs)(state, r_, input);
   THCTensor_(zero)(state, r_);
 }
 
@@ -60,10 +60,10 @@ THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size)
 }
 
 THC_API void
-THCTensor_(ones_like)(THCState *state, THCTensor *r_, THCTensor *input)
+THCTensor_(onesLike)(THCState *state, THCTensor *r_, THCTensor *input)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
-  THCTensor_(resize)(state, r_, THCTensor_(newSizeOf)(state, input), NULL);
+  THCTensor_(resizeAs)(state, r_, input);
   THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
 }
 

--- a/torch/lib/THC/generic/THCTensorMath.cu
+++ b/torch/lib/THC/generic/THCTensorMath.cu
@@ -44,10 +44,26 @@ THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size)
 }
 
 THC_API void
+THCTensor_(zeros_like)(THCState *state, THCTensor *r_, THCTensor *input)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
+  THCTensor_(resize)(state, r_, THCTensor_(newSizeOf)(state, input), NULL);
+  THCTensor_(zero)(state, r_);
+}
+
+THC_API void
 THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
   THCTensor_(resize)(state, r_, size, NULL);
+  THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
+}
+
+THC_API void
+THCTensor_(ones_like)(THCState *state, THCTensor *r_, THCTensor *input)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, r_, input));
+  THCTensor_(resize)(state, r_, THCTensor_(newSizeOf)(state, input), NULL);
   THCTensor_(fill)(state, r_, ScalarConvert<int, real>::to(1));
 }
 

--- a/torch/lib/THC/generic/THCTensorMath.h
+++ b/torch/lib/THC/generic/THCTensorMath.h
@@ -6,9 +6,9 @@ THC_API void THCTensor_(fill)(THCState *state, THCTensor *self, real value);
 THC_API void THCTensor_(zero)(THCState *state, THCTensor *self);
 
 THC_API void THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size);
-THC_API void THCTensor_(zeros_like)(THCState *state, THCTensor *r_, THCTensor* input);
+THC_API void THCTensor_(zerosLike)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API void THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size);
-THC_API void THCTensor_(ones_like)(THCState *state, THCTensor *r_, THCTensor* input);
+THC_API void THCTensor_(onesLike)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API void THCTensor_(reshape)(THCState *state, THCTensor *r_, THCTensor *t, THLongStorage *size);
 THC_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
 THC_API void THCTensor_(cat)(THCState *state, THCTensor *result, THCTensor *ta, THCTensor *tb, int dimension);

--- a/torch/lib/THC/generic/THCTensorMath.h
+++ b/torch/lib/THC/generic/THCTensorMath.h
@@ -6,7 +6,9 @@ THC_API void THCTensor_(fill)(THCState *state, THCTensor *self, real value);
 THC_API void THCTensor_(zero)(THCState *state, THCTensor *self);
 
 THC_API void THCTensor_(zeros)(THCState *state, THCTensor *r_, THLongStorage *size);
+THC_API void THCTensor_(zeros_like)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API void THCTensor_(ones)(THCState *state, THCTensor *r_, THLongStorage *size);
+THC_API void THCTensor_(ones_like)(THCState *state, THCTensor *r_, THCTensor* input);
 THC_API void THCTensor_(reshape)(THCState *state, THCTensor *r_, THCTensor *t, THLongStorage *size);
 THC_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
 THC_API void THCTensor_(cat)(THCState *state, THCTensor *result, THCTensor *ta, THCTensor *tb, int dimension);


### PR DESCRIPTION
As part of #1875, this PR adds numpy-style `ones_like` and `zeros_like` to `torch`. Example usage:

```Python
import torch
input = torch.Tensor(2,3)
torch.ones_like(input)

 1  1  1
 1  1  1
[torch.FloatTensor of size 2x3]
```