### PR TITLE
DOC fixed Tensor.expand docstring

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1714,7 +1714,7 @@ Example:
 
 add_docstr_all('expand',
                """
-expand(tensor, sizes) -> Tensor
+expand(*sizes) -> Tensor
 
 Returns a new view of the tensor with singleton dimensions expanded
 to a larger size.


### PR DESCRIPTION
As seen in example, t.expand doesn't take `tensor` as an argument, and sizes is *args.