### PR TITLE
Double backwards loss function improvements

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -379,7 +379,7 @@ criterion_tests = [
         module_name='SoftMarginLoss',
         input_size=(5, 5),
         target=torch.randn(5, 5).sign(),
-        check_gradgrad=False,
+        check_no_size_average=True,
     ),
     dict(
         module_name='CosineEmbeddingLoss',

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -301,7 +301,6 @@ criterion_tests = [
         module_name='CrossEntropyLoss',
         input=torch.randn(15, 10),
         target=torch.Tensor(15).uniform_().mul(10).floor().long(),
-        check_gradgrad=False,
     ),
     dict(
         module_name='CrossEntropyLoss',
@@ -309,7 +308,6 @@ criterion_tests = [
         input=torch.randn(15, 10),
         target=torch.Tensor(15).uniform_().mul(10).floor().long(),
         desc='weights',
-        check_gradgrad=False,
     ),
     dict(
         module_name='NLLLoss2d',

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -399,7 +399,7 @@ criterion_tests = [
         module_name='MarginRankingLoss',
         input=(torch.randn(50).mul(10), torch.randn(50).mul(10)),
         target=torch.randn(50).sign(),
-        check_gradgrad=False,
+        check_no_size_average=True,
     ),
     dict(
         module_name='MarginRankingLoss',
@@ -407,7 +407,7 @@ criterion_tests = [
         input=(torch.randn(50).mul(10), torch.randn(50).mul(10)),
         target=torch.randn(50).sign(),
         desc='margin',
-        check_gradgrad=False,
+        check_no_size_average=True,
     ),
 ]
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -240,13 +240,7 @@ criterion_tests = [
         module_name='NLLLoss',
         input=torch.rand(15, 10).log(),
         target=torch.Tensor(15).uniform_().mul(10).floor().long(),
-    ),
-    dict(
-        module_name='NLLLoss',
-        constructor_args=(None, False),
-        input=torch.rand(15, 10).log(),
-        target=torch.Tensor(15).uniform_().mul(10).floor().long(),
-        desc='no_size_average'
+        check_no_size_average=True,
     ),
     dict(
         module_name='NLLLoss',
@@ -280,27 +274,14 @@ criterion_tests = [
         module_name='KLDivLoss',
         input=torch.rand(10, 10).log(),
         target=torch.rand(10, 10),
-    ),
-    dict(
-        module_name='KLDivLoss',
-        constructor_args=(False,),
-        input=torch.rand(10, 10).log(),
-        target=torch.rand(10, 10),
-        desc='no_size_average',
+        check_no_size_average=True,
     ),
     dict(
         module_name='MSELoss',
         input=torch.randn(2, 3, 4, 5),
         target=torch.randn(2, 3, 4, 5),
         reference_fn=lambda i, t, _: (i - t).abs().pow(2).sum() / i.numel(),
-    ),
-    dict(
-        module_name='MSELoss',
-        constructor_args=(False,),
-        input=torch.randn(2, 3, 4, 5),
-        target=torch.randn(2, 3, 4, 5),
-        reference_fn=lambda i, t, _: (i - t).abs().pow(2).sum(),
-        desc='no_size_average',
+        check_no_size_average=True,
     ),
     dict(
         module_name='BCELoss',
@@ -360,13 +341,7 @@ criterion_tests = [
         input=torch.rand(10),
         target=torch.randn(10).gt(0).double().mul_(2).sub(1),
         desc='margin',
-    ),
-    dict(
-        module_name='HingeEmbeddingLoss',
-        constructor_args=(0.5, False),
-        input=torch.rand(10),
-        target=torch.randn(10).gt(0).double().mul_(2).sub(1),
-        desc='margin_no_size_average',
+        check_no_size_average=True,
     ),
     dict(
         module_name='MultiLabelMarginLoss',
@@ -398,13 +373,7 @@ criterion_tests = [
         module_name='SmoothL1Loss',
         input_size=(5, 10),
         target=torch.randn(5, 10),
-    ),
-    dict(
-        module_name='SmoothL1Loss',
-        constructor_args=(False,),
-        input_size=(5, 10),
-        target=torch.randn(5, 10),
-        desc='no_size_average',
+        check_no_size_average=True,
     ),
     dict(
         module_name='SoftMarginLoss',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3917,6 +3917,19 @@ for test_params in criterion_tests + new_criterion_tests:
     test_params['constructor'] = getattr(nn, name)
     test = NewCriterionTest(**test_params)
     add_test(test)
+    if 'check_no_size_average' in test_params:
+        test_params['desc'] = test_params.get('desc', '') + 'no_size_average'
+
+        def gen_no_size_average_constructor(constructor):
+            def no_size_average_constructor(*args, **kwargs):
+                cons = constructor(*args, size_average=False, **kwargs)
+                return cons
+                no_size_average_constructor.__name__ = constructor.__name__
+                return no_size_average_constructor
+
+        test_params['constructor'] = gen_eval_constructor(test_params['constructor'])
+        test = NewCriterionTest(**test_params)
+        add_test(test)
 
 
 class UnpoolingNet(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -216,8 +216,12 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
     def _do_extra_tests(self, test_case, module, input, target):
         if self.check_gradgrad:
             params = tuple(x for x in module.parameters())
-            _assertGradAndGradgradChecks(test_case, lambda x, y, *args, **kw: module(x, y),
-                                         (input, target) + params)
+            if not isinstance(input, tuple):
+                _assertGradAndGradgradChecks(test_case, lambda x, y, *args, **kw: module(x, y),
+                                             (input, target) + params)
+            else:
+                _assertGradAndGradgradChecks(test_case, lambda x, y, z, *args, **kw: module(x, y, z),
+                                             input + (target,) + params)
 
     def _get_target(self, target):
         return Variable(target, requires_grad=False)
@@ -3898,7 +3902,8 @@ for test_params in module_tests + new_module_tests:
     add_test(test)
     if 'check_eval' in test_params:
         # create a new test that is identical but that sets module.training to False
-        test_params['desc'] = test_params.get('desc', '') + 'eval'
+        desc = test_params.get('desc', None)
+        test_params['desc'] = 'eval' if desc is None else desc + '_eval'
 
         def gen_eval_constructor(constructor):
             def eval_constructor(*args, **kwargs):
@@ -3918,7 +3923,8 @@ for test_params in criterion_tests + new_criterion_tests:
     test = NewCriterionTest(**test_params)
     add_test(test)
     if 'check_no_size_average' in test_params:
-        test_params['desc'] = test_params.get('desc', '') + 'no_size_average'
+        desc = test_params.get('desc', None)
+        test_params['desc'] = 'eval' if desc is None else desc + '_no_size_average'
 
         def gen_no_size_average_constructor(constructor):
             def no_size_average_constructor(*args, **kwargs):

--- a/torch/nn/_functions/thnn/auto_double_backwards.py
+++ b/torch/nn/_functions/thnn/auto_double_backwards.py
@@ -251,6 +251,22 @@ def smoothl1loss_double_backwards(ctx, ggI):
 
     return gI, None, ggO, None, None, None
 
+
+def softmarginloss_double_backwards(ctx, ggI):
+    size_average = ctx.additional_args[0]
+    input, target, gO = ctx.saved_variables
+    div_factor = input.nelement() if size_average else 1
+
+    t0 = (1 + (-target * input).exp()).pow(-1)
+    t1 = (-target * (-target * input).exp())
+    first_deriv = t0 * t1
+
+    gI = -1 * gO * ggI / div_factor * (first_deriv.pow(2) + first_deriv * target)
+    ggO = (ggI * first_deriv).sum() / div_factor
+
+    return gI, None, ggO, None, None, None
+
+
 double_backwards_fns = {
     'ELU': elu_double_backwards,
     'GatedLinear': gatedlinear_double_backwards,
@@ -269,4 +285,5 @@ double_backwards_fns = {
     'NLLLoss': nllloss_double_backwards,
     'NLLLoss2d': nllloss_double_backwards,
     'SmoothL1Loss': smoothl1loss_double_backwards,
+    'SoftMarginLoss': softmarginloss_double_backwards,
 }


### PR DESCRIPTION
- Generate no_size_average criterion tests rather than specifying them explicitly
- Double backwards support for SoftMarginLoss, MarginRankingLoss
- Test for CrossEntropyLoss double backwards (it was already supported, just not tested).