### PR TITLE
Allow DataParallel returning dict and any other instances of iterable custom classes

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1367,6 +1367,44 @@ class TestNN(NNTestCase):
         self.assertIsInstance(output[1][2], list)
         self.assertIsInstance(output[1][2][0], Variable)
         self.assertIsInstance(output[2], Variable)
+    
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_data_parallel_dict_and_custom_instance_output(self):
+        
+        class State(object):
+            def __init__(self, state_list):
+                self.state_list = state_list
+                self.i = -1
+            def __iter__(self):
+                return self
+            def next(self):
+                self.i += 1
+                if self.i >= len(self.state_list):
+                    self.i = -1
+                    raise StopIteration()
+                return self.state_list[i]
+            def __next__(self):
+                self.next()
+
+        def fn(input):
+            return {'input':input}, State([input.sin(), input.cos()])
+        
+        class Net(nn.Module):
+            def forward(self, input):
+                return fn(input)
+
+
+        i = Variable(torch.randn(2, 2).float().cuda())
+        gpus = range(torch.cuda.device_count())
+        output = dp.data_parallel(Net(), i, gpus)
+        expected_out = fn(i)
+        self.assertIsInstance(output, tuple)
+        self.assertEqual(len(output), 2)
+        self.assertIsInstance(output[0], dict)
+        self.assertIsInstance(output[1], State)
+        self.assertEqual(output[0].keys(), expected_out[0].keys())
+        self.assertEqual(output[0].values(), expected_out[0].values())
+        self.assertEqual(tuple(output[1]), tuple(expected_out[1]))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_nested_input(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1367,32 +1367,33 @@ class TestNN(NNTestCase):
         self.assertIsInstance(output[1][2], list)
         self.assertIsInstance(output[1][2][0], Variable)
         self.assertIsInstance(output[2], Variable)
-    
+
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_dict_and_custom_instance_output(self):
-        
         class State(object):
             def __init__(self, state_list):
                 self.state_list = state_list
                 self.i = -1
+
             def __iter__(self):
                 return self
+
             def next(self):
                 self.i += 1
                 if self.i >= len(self.state_list):
                     self.i = -1
                     raise StopIteration()
                 return self.state_list[i]
+
             def __next__(self):
                 self.next()
 
         def fn(input):
-            return {'input':input}, State([input.sin(), input.cos()])
-        
+            return {'input': input}, State([input.sin(), input.cos()])
+
         class Net(nn.Module):
             def forward(self, input):
                 return fn(input)
-
 
         i = Variable(torch.randn(2, 2).float().cuda())
         gpus = range(torch.cuda.device_count())

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -46,5 +46,8 @@ def gather(outputs, target_device, dim=0):
             return Gather.apply(target_device, dim, *outputs)
         if out is None:
             return None
-        return type(out)(map(gather_map, zip(*outputs)))
+        if isinstance(out, dict):
+            return dict(zip(out.keys(), 
+                            map(gather_map, zip(*[d.values() for d in outputs]))))
+        return type(out)(map(gather_map, zip(*[tuple(o) for o in outputs])))
     return gather_map(outputs)

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -47,7 +47,7 @@ def gather(outputs, target_device, dim=0):
         if out is None:
             return None
         if isinstance(out, dict):
-            return dict(zip(out.keys(), 
+            return dict(zip(out.keys(),
                             map(gather_map, zip(*[d.values() for d in outputs]))))
         return type(out)(map(gather_map, zip(*[tuple(o) for o in outputs])))
     return gather_map(outputs)


### PR DESCRIPTION
Returning a dict or instances of custom classes can be very helpful, especially for complex networks. For exmaple, the RNN state of a complex RNN model is usually wrapped inside a custom class.