### PR TITLE
Not changing dimension size for expand when target size is -1

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3339,6 +3339,10 @@ class TestTorch(TestCase):
         self.assertEqual(expanded, unsqueezed)
         self.assertEqual(expanded.stride(), unsqueezed.stride())
 
+        # test -1 as target size
+        self.assertEqual(tensor.expand(4, -1, 5), tensor.expand(4, 8, 5))
+        self.assertRaises(RuntimeError, lambda: tensor2.expand(-1, -1))
+
     def test_repeat(self):
         result = torch.Tensor()
         tensor = torch.rand(8, 4)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1717,7 +1717,10 @@ add_docstr_all('expand',
 expand(*sizes) -> Tensor
 
 Returns a new view of the tensor with singleton dimensions expanded
-to a larger size. -1 means not changing the size on that dimension.
+to a larger size.
+
+Passing -1 as the size for a dimension means not changing the size of
+that dimension.
 
 Tensor can be also expanded to a larger number of dimensions, and the
 new ones will be appended at the front. (For the new dimensions, the
@@ -1737,6 +1740,11 @@ Example:
     >>> x.size()
     torch.Size([3, 1])
     >>> x.expand(3, 4)
+     1  1  1  1
+     2  2  2  2
+     3  3  3  3
+    [torch.FloatTensor of size 3x4]
+    >>> x.expand(-1, 4)   # -1 means not changing the size of that dimension
      1  1  1  1
      2  2  2  2
      3  3  3  3

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1717,10 +1717,11 @@ add_docstr_all('expand',
 expand(*sizes) -> Tensor
 
 Returns a new view of the tensor with singleton dimensions expanded
-to a larger size.
+to a larger size. -1 means not changing the size on that dimension.
 
 Tensor can be also expanded to a larger number of dimensions, and the
-new ones will be appended at the front.
+new ones will be appended at the front. (For the new dimensions, the
+size cannot be set to -1.)
 
 Expanding a tensor does not allocate new memory, but only creates a
 new view on the existing tensor where a dimension of size one is

--- a/torch/lib/TH/THStorage.c
+++ b/torch/lib/TH/THStorage.c
@@ -132,6 +132,16 @@ int THLongStorage_inferExpandGeometry(long *tensorSizes, long *tensorStrides, lo
     long stride = (dim >= 0) ?
         tensorStrides[dim] : expandedSizesCalc[i + 1] * expandedStridesCalc[i+1];
     long targetSize = THLongStorage_data(sizes)[i];
+    if (targetSize == -1) {
+      if (dim < 0) {
+        THFree(expandedSizesCalc);
+        THFree(expandedStridesCalc);
+        snprintf(error_buffer, buffer_len, "The expanded size of the tensor (%ld) isn't allowed in a leading, non-existing dimension %ld.", targetSize, i);
+        return -1;
+      } else {
+        targetSize = size;
+      }
+    }
     if (size != targetSize) {
       if (size == 1) {
         size = targetSize;


### PR DESCRIPTION
#2350 .
Previously set size to -1 will produce a no dimension tensor. I hope no one ever did this otherwise this will break their code.