### PR TITLE
Daemon-ize Reduction Threads in DistributedDataParallel

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -279,6 +279,7 @@ class DistributedDataParallel(Module):
             self._reduction_threads.append(threading.Thread(
                 target=self._reduction_thread_fn,
                 args=(reduction_queue, group_id, self.device_ids, reduction_streams, self._nccl_streams)))
+            self._reduction_threads[-1].daemon = True
             self._reduction_threads[-1].start()
 
     @staticmethod


### PR DESCRIPTION
Set the daemon flag in the reduction threads in DistributedDataParallel so they exit when main process finishes.

Tested this and it addresses https://github.com/pytorch/pytorch/issues/2520