### PR TITLE
THMapAllocatorContext_ only define once in #if

### DIFF
--- a/torch/lib/TH/THAllocator.c
+++ b/torch/lib/TH/THAllocator.c
@@ -33,14 +33,14 @@ THAllocator THDefaultAllocator = {
   &THDefaultAllocator_free
 };
 
-#if defined(_WIN32) || defined(HAVE_MMAP)
-
 struct THMapAllocatorContext_ {
   char *filename; /* file name */
   int flags;
   ptrdiff_t size; /* mapped size */
   int fd;
 };
+
+#if defined(_WIN32) || defined(HAVE_MMAP)
 
 #define TH_ALLOC_ALIGNMENT 64
 


### PR DESCRIPTION
THMapAllocatorContext_ only define once in #if defined(_WIN32) || defined(HAVE_MMAP)