### PR TITLE
Make CPU and CUDA share bernoulli yaml declaration

### DIFF
--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -200,12 +200,27 @@ ${cpu}
         self.stateless_declarations = []
         self.docstrings = []
 
+    BACKEND_SUBSTITUTIONS = {
+        'CPU': 'TH',
+        'CUDA': 'THCuda',
+    }
+
+    def substitute_tensor_backend(self, arg, option):
+        if 'Backend' in arg['type']:
+            arg['type'] = arg['type'].replace('Backend',
+                                              self.BACKEND_SUBSTITUTIONS.get(option['backends'][0]))
+            # handle the fact that THCudaTensor isn't THCudaFloatTensor
+            if option['backends'][0] == 'CUDA' and 'Float' in arg['type']:
+                arg['type'] = arg['type'].replace('Float', '')
+
     def get_type_unpack(self, arg, option):
+        self.substitute_tensor_backend(arg, option)
         return self.TYPE_UNPACK.get(arg['type'], None)
 
     def get_type_check(self, arg, option):
         if arg['type'] == 'THSize*' and arg.get('long_args', False):
             return self.SIZE_VARARG_CHECK
+        self.substitute_tensor_backend(arg, option)
         return self.TYPE_CHECK.get(arg['type'], None)
 
     # TODO: argument descriptions shouldn't be part of THP, but rather a general cwrap thing

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -267,6 +267,8 @@
 
 #define THDoubleTensor_BERNOULLI_TENSOR THDoubleTensor_bernoulli_DoubleTensor
 #define THFloatTensor_BERNOULLI_TENSOR THFloatTensor_bernoulli_FloatTensor
+#define THCudaDoubleTensor_BERNOULLI_TENSOR THCudaDoubleTensor_bernoulli_DoubleTensor
+#define THCudaTensor_BERNOULLI_TENSOR THCudaTensor_bernoulli_FloatTensor
 
 [[
   name: bernoulli
@@ -294,12 +296,15 @@
 
 #undef THDoubleTensor_BERNOULLI_TENSOR
 #undef THFloatTensor_BERNOULLI_TENSOR
+#undef THCudaDoubleTensor_BERNOULLI_TENSOR
+#undef THCudaTensor_BERNOULLI_TENSOR
 
 [[
   name: bernoulli_
   defined_if: "!IS_DISTRIBUTED"
   backends:
     - CPU
+    - CUDA
   return: self
   options:
     - cname: bernoulli
@@ -316,62 +321,12 @@
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
           kwarg_only: True
-        - THFloatTensor* float_p
+        - BackendFloatTensor* float_p
     - cname: bernoulli_DoubleTensor
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
           default: THPDefaultGenerator->cdata
           kwarg_only: True
-        - THDoubleTensor* float_p
-]]
-
-#define THCudaDoubleTensor_BERNOULLI_TENSOR THCudaDoubleTensor_bernoulli_DoubleTensor
-#define THCudaTensor_BERNOULLI_TENSOR THCudaTensor_bernoulli_FloatTensor
-
-[[
-  name: bernoulli
-  types:
-    - Float
-    - Double
-  backends:
-    - CUDA
-  return: argument 0
-  variants:
-    - method
-    - function
-  cname: BERNOULLI_TENSOR
-  before_call:
-    THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg1)->cdata);
-  arguments:
-    - arg: THTensor* output
-      output: True
-      resize: self
-    - THTensor* self
-]]
-
-#undef THCudaDoubleTensor_BERNOULLI_TENSOR
-#undef THCudaTensor_BERNOULLI_TENSOR
-
-[[
-  name: bernoulli_
-  types:
-    - floating_point
-  backends:
-    - CUDA
-  return: self
-  options:
-    - cname: bernoulli
-      arguments:
-        - THTensor* self
-        - arg: double p
-          default: 0.5
-    - cname: bernoulli_FloatTensor
-      arguments:
-        - THTensor* self
-        - THCudaTensor* float_p
-    - cname: bernoulli_DoubleTensor
-      arguments:
-        - THTensor* self
-        - THCudaDoubleTensor* float_p
+        - BackendDoubleTensor* float_p
 ]]


### PR DESCRIPTION
As title. This achieved by:

- Simply combining the out-of-place declarations, and making sure the macros are defined for both CPU and CUDA
- Adding a new argument type, Backend<Type>Tensor, to handle the fact that we want THFloatTensor or THCudaTensor as arguments, depending on which backend we are generating for