### PR TITLE
Ensure GIL is held in ObjectPtrAllocators

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -198,6 +198,7 @@ THTensor* THPTensor_(fromNumpy)(PyObject *numpy_array) {
           // See Note [Numpy memory management]
           &THNumpyArrayAllocator,
           new NumpyArrayAllocator(numpy_array)));
+      THStorage_(clearFlag)(storage.get(), TH_STORAGE_RESIZABLE);
       result = THTensor_(newWithStorage)(LIBRARY_STATE storage, 0, sizes, strides);
     }
     else

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -108,6 +108,10 @@ PyObject * THPTensor_(setIndex)(THPTensor *self, PyObject *args)
   return: self
   cname: resize
   cpu_half: True
+  before_call:
+    THPUtils_assert(arg_self->storage->flag & TH_STORAGE_RESIZABLE,
+      "calling resize_ on a tensor that has non-resizable storage. Clone it first "
+      "or create a new tensor instead.");
   arguments:
     - THTensor* self
     - arg: THSize* size


### PR DESCRIPTION
Also, make Storages that share data with numpy arrays non-resizable.

Fixes #2348.

