### PR TITLE
Allow LongTensor backed variables to be used in Advanced Indexing (v0.2.0)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -626,6 +626,10 @@ class TestAutograd(TestCase):
         check_index(x, y, ([1, 2], [0, 1], Ellipsis))
         check_index(x, y, (Ellipsis, [1, 2], [0, 1]))
 
+        # advanced indexing, with a tensor wrapped in a variable
+        z = Variable(torch.LongTensor([0, 1]))
+        check_index(x, y, (z, Ellipsis))
+
     def test_indexing_duplicates(self):
         x = torch.arange(1, 17).view(4, 4)
         y = Variable(x, requires_grad=True)

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -695,8 +695,16 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
     if (!PySlice_Check(item)) {
       // Returns NULL upon conversion failure
+      PyObject *obj = PySequence_Fast_GET_ITEM(fast.get(), i);
+
+      // Need to check if this is a Variable, if so, extract the underyling Tensor
+      // to pass to the indexer constructor
+      if (THPVariable_Check(obj)) {
+        obj = ((THPVariable *)obj)->data;
+      }
+
       THPIndexTensor *indexer = (THPIndexTensor *)PyObject_CallFunctionObjArgs(
-          THPIndexTensorClass, PySequence_Fast_GET_ITEM(fast.get(), i), NULL);
+          THPIndexTensorClass, obj, NULL);
       if (!indexer) {
         PyErr_Format(PyExc_IndexError,
             "When performing advanced indexing the indexing objects must be LongTensors or "


### PR DESCRIPTION
Addresses #2469, #2484.

Essentially just extracts the underlying Tensor at conversion time if the indexing object is a PyTorch variable.

I'm not sure exactly what constraints we want to put on what variable objects are appropriate, @soumith mentioned adding n assert that `requires_grad=False` - but I wanted to make sure this was the right approach first.