### PR TITLE
Match NumPy ellipsis semantics for Advanced Indexing (v0.2.0)

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2887,6 +2887,15 @@ class TestTorch(TestCase):
                 [Ellipsis, [2, 3, 4]],
                 [Ellipsis, slice(None), [2, 3, 4]],
                 [slice(None), Ellipsis, [2, 3, 4]],
+
+                # ellipsis counts for nothing
+                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
+                [slice(None), Ellipsis, slice(None), [0, 3, 4]],
+                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), slice(None), [0, 3, 4], Ellipsis],
+                [Ellipsis, [[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None)],
+                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], Ellipsis, slice(None)],
+                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None), Ellipsis],
             ]
 
             for indexer in indices_to_test:
@@ -2959,6 +2968,8 @@ class TestTorch(TestCase):
                 [[0, 2, 1], [3], [4], slice(None)],
                 [[0, 2, 1], [3], [4], Ellipsis],
                 [Ellipsis, [0, 2, 1], [3], [4]],
+
+
             ]
 
             for indexer in indices_to_test:

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -548,7 +548,8 @@ static bool THPTensor_(_checkAdvancedIndexing)(THPTensor *indexed, PyObject *arg
   // adjacent
 
   long ndim = THTensor_(nDimension)(LIBRARY_STATE indexed->cdata);
-  if (PySequence_Check(arg) && PySequence_Size(arg) <= ndim) {
+
+  if (PySequence_Check(arg) && PySequence_Size(arg) <= ndim + 1) {
     THPObjectPtr fast = THPObjectPtr(PySequence_Fast(arg, NULL));
 
     bool sequenceFound = false;
@@ -556,7 +557,17 @@ static bool THPTensor_(_checkAdvancedIndexing)(THPTensor *indexed, PyObject *arg
     bool ellipsisFound = false;
     Py_ssize_t lastSeqDim = -1;
 
+    // Note that we can have ndim + 1 Tensors in the case where we have an ellipsis,
+    // because Python semantics allow it to be "thrown away" so to speak. If this is
+    // the case, we have to shift the dimension we are considering (in the indexed
+    // tensor) by -1 afer encountering the Ellipsis when accessing properties of
+    // the indexed Tensor
+    bool extraIndexer = PySequence_Fast_GET_SIZE(fast.get()) == ndim + 1;
+
     for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(fast.get()); ++i) {
+      // see explanation above
+      int correspondingTensorDim = i + (extraIndexer && ellipsisFound ? -1 : 0);
+
       PyObject *item = PySequence_Fast_GET_ITEM(fast.get(), i);
       if (THPIndexTensor_Check(item) || PySequence_Check(item)) {
         sequenceFound = true;
@@ -570,7 +581,7 @@ static bool THPTensor_(_checkAdvancedIndexing)(THPTensor *indexed, PyObject *arg
         continue;
       }
       if (PySlice_Check(item)) {
-        long dimSize = THTensor_(size)(LIBRARY_STATE indexed->cdata, i);
+        long dimSize = THTensor_(size)(LIBRARY_STATE indexed->cdata, correspondingTensorDim);
         // Basically verify that the Slice is ':' and did not specify
         // a specific start, end or step
         Py_ssize_t start, end, length, step;
@@ -592,6 +603,11 @@ static bool THPTensor_(_checkAdvancedIndexing)(THPTensor *indexed, PyObject *arg
       }
       nonColonEllipsisFound = true;
       break;
+    }
+
+    // Check if we have ndim+1 indexing objects, that we found an ellipsis
+    if (PySequence_Size(arg) == ndim + 1 && !ellipsisFound) {
+      return false;
     }
 
     return sequenceFound && (!nonColonEllipsisFound);
@@ -687,9 +703,16 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
     // If this is an ellipsis, the all subsequent advanced indexing
     // objects "positions" should be shifted, e.g. if we have a 5D Tensor
-    // x, and then x[..., [2, 3]], then the "position" of [2, 3] is 4
+    // x, and then x[..., [2, 3]], then the "position" of [2, 3] is 4,
+    //
+    // BUT ONLY IF, we don't have ndim other indexing objects, in which case
+    // the ellipsis creates a shift of -1 to counterbalance its "emptyness"
     if (Py_TYPE(item) == &PyEllipsis_Type) {
-      ellipsisOffset = THTensor_(nDimension)(LIBRARY_STATE indexed) - sequenceLength;
+      if (sequenceLength != (THTensor_(nDimension)(LIBRARY_STATE indexed) + 1)) {
+        ellipsisOffset = THTensor_(nDimension)(LIBRARY_STATE indexed) - sequenceLength;
+      } else {
+        ellipsisOffset = -1;
+      }
       continue;
     }
 


### PR DESCRIPTION
Addresses #2404.

NumPy allows you to specify `ndim + 1` indexers if one of them is an Ellipsis, which is basically tossed away. This PR extends such logic to PyTorch advanced indexing.