### PR TITLE
Allow LongTensor backed variables to be used in Advanced Indexing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -593,12 +593,7 @@ class TestAutograd(TestCase):
         x = torch.arange(1, 17).view(4, 4)
         y = Variable(x, requires_grad=True)
 
-        def check_index(x, y, idx):
-            if y.grad is not None:
-                y.grad.data.zero_()
-            indexed_tensor = x[idx]
-            indexed_var = y[idx]
-
+        def compare(x, y, idx, indexed_tensor, indexed_var):
             indexed_var_t = indexed_var.data
             if not torch.is_tensor(indexed_tensor):
                 indexed_var_t = indexed_var_t[0]
@@ -608,6 +603,13 @@ class TestAutograd(TestCase):
             expected_grad = torch.Tensor(x.size()).fill_(0)
             expected_grad[idx] = 1
             self.assertEqual(y.grad.data, expected_grad)
+
+        def check_index(x, y, idx):
+            if y.grad is not None:
+                y.grad.data.zero_()
+            indexed_tensor = x[idx]
+            indexed_var = y[idx]
+            compare(x, y, idx, indexed_tensor, indexed_var)
 
         check_index(x, y, 1)
         check_index(x, y, (1, 1))
@@ -653,6 +655,18 @@ class TestAutograd(TestCase):
         check_index(x, y, ([1, 2], [0, 1]))
         check_index(x, y, ([1, 2], [0, 1], Ellipsis))
         check_index(x, y, (Ellipsis, [1, 2], [0, 1]))
+
+        # advanced indexing, with a tensor wrapped in a variable
+        z = torch.LongTensor([0, 1])
+        zv = Variable(z, requires_grad=False)
+        seq = [z, Ellipsis]
+        seqv = [zv, Ellipsis]
+
+        if y.grad is not None:
+            y.grad.data.zero_()
+        indexed_tensor = x[seq]
+        indexed_var = y[seqv]
+        compare(x, y, seq, indexed_tensor, indexed_var)
 
     def test_indexing_duplicates(self):
         x = torch.arange(1, 17).view(4, 4)
@@ -919,8 +933,20 @@ class TestAutograd(TestCase):
         self.assertNotEqual(y._version, y_version)
         y.backward(torch.ones(*size))
         expected_grad_input = torch.ones(*size)
+
+        # remove all variables when indexing a Tensor for comparison,
+        # whether a top-level Variable or in a sequence
         if isinstance(index, Variable):
             index = index.data
+        elif isinstance(index, list):
+            novars = []
+            for i in index:
+                if isinstance(i, Variable):
+                    novars.append(i.data)
+                else:
+                    novars.append(i)
+            index = novars
+
         expected_grad_input[index] = 0
         self.assertEqual(x.grad.data, expected_grad_input)
         self.assertEqual(value.grad.data, torch.ones(value.size()))
@@ -952,6 +978,8 @@ class TestAutograd(TestCase):
         self._test_setitem_tensor((5, 5, 5), [[1, 3], slice(None), slice(None)])
         self._test_setitem_tensor((5, 5, 5), [slice(None), [2, 4], [1, 3]])
         self._test_setitem_tensor((5, 5, 5), [[1, 3], [2, 4], slice(None)])
+        self._test_setitem_tensor((5, 5, 5), [Variable(torch.LongTensor([1,
+                                              3]), requires_grad=False), [2, 4], slice(None)])
 
     def test_setitem_mask(self):
         mask = torch.ByteTensor(5, 5).bernoulli_()
@@ -1969,6 +1997,8 @@ method_tests = [
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], ]),), 'adv_index_sub'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], slice(None)]),), 'adv_index_sub_2'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], Ellipsis]),), 'adv_index_sub_3'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 2, 3], [1, 3, 3],
+     Variable(torch.LongTensor([0, 0, 2]), requires_grad=False)]),), 'adv_index_var'),
 ]
 # TODO: clamp with min/max
 

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -7,6 +7,17 @@ from ..variable import Variable
 from .utils import maybe_unexpand
 
 
+def _preprocess_adv_index_seq(index):
+    result = []
+    for indexer in index:
+        if isinstance(indexer, Variable):
+            assert not indexer.requires_grad
+            result.append(indexer.data)
+        else:
+            result.append(indexer)
+    return result
+
+
 class Index(Function):
 
     @staticmethod
@@ -32,9 +43,13 @@ class Index(Function):
     def forward(ctx, i, index):
         ctx.input_size = i.size()
         ctx.index = index
-        result = i.index(ctx.index)
         ctx.advanced_indexing = i._check_advanced_indexing(index)
-        if not ctx.advanced_indexing:
+        if ctx.advanced_indexing:
+            # handle any Variable arguments in the index sequence
+            ctx.index = _preprocess_adv_index_seq(index)
+            result = i.index(ctx.index)
+        else:
+            result = i.index(ctx.index)
             ctx.mark_shared_storage((i, result))
         return result
 
@@ -59,6 +74,9 @@ class SetItem(InplaceFunction):
         ctx.tensor_value = torch.is_tensor(value)
         if ctx.tensor_value:
             ctx.value_size = value.size()
+        ctx.advanced_indexing = i._check_advanced_indexing(index)
+        if ctx.advanced_indexing:
+            ctx.index = _preprocess_adv_index_seq(index)
         i._set_index(ctx.index, value)
         return i
 
@@ -258,7 +276,10 @@ class AdvancedIndexAdd(InplaceFunction):
             ctx.adv_index = adv_index
         ctx.mark_dirty(tensor1)
         ctx.tensor2_size = tensor2.size()
-        return tensor1._advanced_index_add(adv_index, tensor2)
+        index = _preprocess_adv_index_seq(adv_index)
+        if ctx.needs_input_grad[2]:
+            ctx.adv_index = index
+        return tensor1._advanced_index_add(index, tensor2)
 
     @staticmethod
     @once_differentiable


### PR DESCRIPTION
Followup to #2587 but against master. In this PR, I implement Variable handling entirely at the Python level.

cc @fmassa 