### PR TITLE
fix Python 2 gloo install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ class build_deps(Command):
             libs += ['nccl']
         libs += ['THPP', 'libshm', 'ATen']
         if WITH_DISTRIBUTED:
-            if sys.platform == 'linux':
+            if sys.platform.startswith('linux')
                 libs += ['gloo']
             libs += ['THD']
         build_libs(libs)

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ class build_deps(Command):
             libs += ['nccl']
         libs += ['THPP', 'libshm', 'ATen']
         if WITH_DISTRIBUTED:
-            if sys.platform.startswith('linux')
+            if sys.platform.startswith('linux'):
                 libs += ['gloo']
             libs += ['THD']
         build_libs(libs)


### PR DESCRIPTION
Currently sys.platform returns 'linux2' on Python 2, making it compile without gloo.