### PR TITLE
fix example in docs for nn.init.calculate_gain

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -25,7 +25,7 @@ def calculate_gain(nonlinearity, param=None):
         param: optional parameter for the nonlinear function
 
     Examples:
-        >>> gain = nn.init.gain('leaky_relu')
+        >>> gain = nn.init.calculate_gain('leaky_relu')
     """
     linear_fns = ['linear', 'conv1d', 'conv2d', 'conv3d', 'conv_transpose1d', 'conv_transpose2d', 'conv_transpose3d']
     if nonlinearity in linear_fns or nonlinearity == 'sigmoid':


### PR DESCRIPTION
`init.gain` was renamed to `calculate_gain` some time ago, the docs were not updated to reflect this.