### PR TITLE
doc: Fix emmbedding doc formatting

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -161,17 +161,17 @@ class EmbeddingBag(Module):
 
     Examples:
 
-    >>> # an Embedding module containing 10 tensors of size 3
-    >>> embedding_sum = nn.EmbeddingBag(10, 3, mode='sum')
-    >>> # a batch of 2 samples of 4 indices each
-    >>> input = Variable(torch.LongTensor([1,2,4,5,4,3,2,9]))
-    >>> offsets = Variable(torch.LongTensor([0,4]))
-    >>> embedding_sum(input, offsets)
+        >>> # an Embedding module containing 10 tensors of size 3
+        >>> embedding_sum = nn.EmbeddingBag(10, 3, mode='sum')
+        >>> # a batch of 2 samples of 4 indices each
+        >>> input = Variable(torch.LongTensor([1,2,4,5,4,3,2,9]))
+        >>> offsets = Variable(torch.LongTensor([0,4]))
+        >>> embedding_sum(input, offsets)
 
-    Variable containing:
-    -0.7296 -4.6926  0.3295
-    -0.5186 -0.5631 -0.2792
-    [torch.FloatTensor of size 2x3]
+        Variable containing:
+        -0.7296 -4.6926  0.3295
+        -0.5186 -0.5631 -0.2792
+        [torch.FloatTensor of size 2x3]
     """
 
     def __init__(self, num_embeddings, embedding_dim,


### PR DESCRIPTION
Noticed that the example section of `nn.EmbeddingBag` wasn't rendered correctly. http://pytorch.org/docs/master/nn.html#torch.nn.EmbeddingBag