### PR TITLE
Fix to make the sample code executable as-is in "Extending PyTorch"

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -40,7 +40,7 @@ Below you can find code for a ``Linear`` function from :mod:`torch.nn`, with
 additional comments::
 
     # Inherit from Function
-    class Linear(Function):
+    class LinearFunction(Function):
 
         # Note that both forward and backward are @staticmethods
         @staticmethod
@@ -79,7 +79,7 @@ additional comments::
 Now, to make it easier to use these custom ops, we recommend aliasing their
 ``apply`` method::
 
-    linear = Linear.apply
+    linear = LinearFunction.apply
 
 Here, we give an additional example of a function that is parametrized by
 non-Variable arguments::
@@ -145,6 +145,7 @@ This is how a ``Linear`` module can be implemented::
 
     class Linear(nn.Module):
         def __init__(self, input_features, output_features, bias=True):
+            super(Linear, self).__init__()
             self.input_features = input_features
             self.output_features = output_features
 
@@ -156,7 +157,7 @@ This is how a ``Linear`` module can be implemented::
             # .register_buffer() to register buffers.
             # nn.Parameters can never be volatile and, different than Variables,
             # they require gradients by default.
-            self.weight = nn.Parameter(torch.Tensor(input_features, output_features))
+            self.weight = nn.Parameter(torch.Tensor(output_features, input_features))
             if bias:
                 self.bias = nn.Parameter(torch.Tensor(output_features))
             else:
@@ -171,7 +172,7 @@ This is how a ``Linear`` module can be implemented::
 
         def forward(self, input):
             # See the autograd section for explanation of what happens here.
-            return Linear()(input, self.weight, self.bias)
+            return LinearFunction.apply(input, self.weight, self.bias)
 
 
 Writing custom C extensions


### PR DESCRIPTION
I find that current Linear(Function) class and Linear(nn.Module) class is inconsistent in that
1. weight Linear(nn.Module) is not compatible with Linear(Function) which transposes the weight
2. if one copy-pastes two classes in one file and instantiate Linear(nn.Module), it will result in error since the names of two classes are same

This change would enable instantiation and running Linear model as-is. 

First time in PR, so could anyone review the correctness of this?