### PR TITLE
Dynamically scheduled dataloader

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -77,6 +77,7 @@ def _worker_loop(dataset, index_queues, collate_queues, data_queue, collate_fn):
             else:
                 collate_queue.put((batch_idx, sample_idx, element))
 
+
 def _pin_memory_loop(in_queue, out_queue, done_event):
     while True:
         try:


### PR DESCRIPTION
Hello,

After using pytorch for a while I realized that the dataloader could be improved. (I saw few things on the discuss [forum](https://discuss.pytorch.org/t/how-to-prefetch-data-when-processing-with-gpu/548/3)).

# The current architecture

Here is what I understand from the current architecture of the multiprocess dataloader.

![existing architecture](https://user-images.githubusercontent.com/2017051/30046195-d61eda48-91d6-11e7-98a1-ae4afeee22bc.png)

1. The sample generate batches
2. Batches are put in a queue
3. A Worker take a batch, process it, collate and put the batch in another queue
4. Main thread take processed batch from the output queue and reorder them

## Disadvantages

- Since an entire batch is assigned to a single worker, the first batch will not be outputed before the first worker process `batch_size` elements. Adding more workers will not reduce this starting time.
- The amount of memory is proportinal to the number of workers (`2 x num_workers` batches are primed).
- If some baches takes longer than the others, workers might be left without work while the main thread is wating for another.
- The computation power is not focused on the next batch, even if the main thread is starving.

# Suggested Architecture

The key idea is to have an dataset element as a working unit instead of a batch. The second key idea is to use a circular buffer of k lists (like double/triple buffering in computer graphics application)

## Summary

### Step 1

The main thread append to a first queue all the elements in the batch, `num_workers - 1` makers `Next` and one maker `Collate`. 
![step 1](https://user-images.githubusercontent.com/2017051/30046421-a8295cf6-91d8-11e7-989e-491a9e8b791a.png)

### Step 2

Workers start consuming the queue and retrieve the data from the dataset and put it in another queue the `collate_queue`. Elements might be reorderd during this phase. In the meantime the main thread start filling the queue the queue for the next batch (if the `preload_batches` parameter allows it).

![step 2](https://user-images.githubusercontent.com/2017051/30046424-aabed9aa-91d8-11e7-8a49-0723f7a956fa.png)

### Step 3 

When workers reach the end of the queue they will start consuming `Next` markers. When it happens. It jumps from the current queue to the next one. The last remaining one will consume a `Collate`. The one who pick this one is will jump to the `collate_queue`. It consume the entire queue. Reorder elements in the batch and put the collated batch in the `data_queue`. In the meantime, if there are elements in the next queue, other workers start working on the next batch.

![step 3](https://user-images.githubusercontent.com/2017051/30046426-ad01970c-91d8-11e7-8af0-8d238a0bef6b.png)

### Step 4

We continue the process for all batches. When the main_thread reach the last queue (the number of queue is `preload_batches + 2`), it waits until the first one is completely empty and reuse it. This way we don't allocate a queue per batch.

![step 4](https://user-images.githubusercontent.com/2017051/30046433-b0e69fd4-91d8-11e7-8188-101f6eef528f.png)

## Key points

- [x] We limit the memory usage
- [x] All workers work in priority for the next batch
- [x] Users can control the amount of prefetching
- [x] No matter what, we always use 100% of the CPU unless we have prefetched what the user asked
- [x] All existing test pass
- [ ] Elements are loaded in order. This is not the case because we prallelize every element in a batch
- [ ] All Exception raised are reported. This is not the case because to mimic the behavior of the old architecture, only the first exception of the batch is raised.

# Conclusion

- What do you think ?
- Should it be a separate module or should it replace the existing `DataLoader` ?
- Would it be considered a breaking change since user code could assume that `__getitem__` is called in order ?
- Anything should be improved ?

Thank you for your feedback
