### PR TITLE
fixed issue #2613 in torch/legacy/nn

### DIFF
--- a/torch/legacy/nn/Module.py
+++ b/torch/legacy/nn/Module.py
@@ -76,10 +76,11 @@ class Module(object):
                 grad.zero_()
 
     def updateParameters(self, learningRate):
-        params, gradParams = self.parameters()
-        if params:
-            for p, gp in zip(params, gradParams):
-                p.add_(-learningRate, gp)
+        if self.parameters() is not None:
+            params, gradParams = self.parameters()
+            if params:
+                for p, gp in zip(params, gradParams):
+                    p.add_(-learningRate, gp)
 
     def training(self):
         self.train = True


### PR DESCRIPTION
Fixed the behavior of `Module.updateParameters` in #2613 . Now it works also with modules without parameters.

Check first that there are parameters, then eventually do the update.