### PR TITLE
Adjust error message for View

### DIFF
--- a/torch/lib/TH/THStorage.c
+++ b/torch/lib/TH/THStorage.c
@@ -34,11 +34,11 @@ THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElemen
   if (dim_infer != -1) {
     THDescBuff buf = THLongStorage_sizeDesc(size);
     THArgCheck(total_size > 0 && nElement % total_size == 0, 2,
-        "size '%s' is invalid for input of with %td elements", buf.str, nElement);
+        "size '%s' is invalid for input with %td elements", buf.str, nElement);
   } else {
     THDescBuff buf = THLongStorage_sizeDesc(size);
     THArgCheck(nElement == total_size, 2,
-        "size '%s' is invalid for input of with %td elements", buf.str, nElement);
+        "size '%s' is invalid for input with %td elements", buf.str, nElement);
   }
   THLongStorage* copy = THLongStorage_newWithSize(size->size);
   THLongStorage_copy(copy, size);


### PR DESCRIPTION
When the size given is incorrect for the number of elements, the current error message is:
`size '[1 x 1 x 5]' is invalid for input of with 1 elements at /pytorch/torch/lib/TH/THStorage.c:41`

This replaces it by 
`size '[1 x 1 x 5]' is invalid for input with 1 elements at /pytorch/torch/lib/TH/THStorage.c:41`
which is grammatically better