### PR TITLE
add env var for python executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,11 @@ def build_libs(libs):
     for lib in libs:
         assert lib in dep_libs, 'invalid lib: {}'.format(lib)
     build_libs_cmd = ['bash', 'torch/lib/build_libs.sh']
+    my_env = os.environ.copy()
+    my_env["PYTORCH_PYTHON"] = sys.executable
     if WITH_CUDA:
         build_libs_cmd += ['--with-cuda']
-    if subprocess.call(build_libs_cmd + libs) != 0:
+    if subprocess.call(build_libs_cmd + libs, env=my_env) != 0:
         sys.exit(1)
 
 


### PR DESCRIPTION
addresses #2304 

ran into the same problem when trying to build from source using the Python executable from Homebrew. Seems there's still no fix.