### PR TITLE
Use at::Tensor based autograd Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ torch/lib/build
 torch/lib/tmp_install
 torch/lib/include
 torch/lib/torch_shm_manager
+torch/csrc/autograd/generated/python_variable_methods.cpp
+torch/csrc/autograd/generated/Functions.h
+torch/csrc/autograd/generated/Functions.cpp
+torch/csrc/autograd/generated/VariableType.h
+torch/csrc/autograd/generated/VariableType.cpp
 torch/csrc/cudnn/cuDNN.cpp
 torch/csrc/nn/THNN.cwrap
 torch/csrc/nn/THNN.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,7 @@ torch/lib/build
 torch/lib/tmp_install
 torch/lib/include
 torch/lib/torch_shm_manager
-torch/csrc/autograd/generated/python_variable_methods.cpp
-torch/csrc/autograd/generated/Functions.h
-torch/csrc/autograd/generated/Functions.cpp
-torch/csrc/autograd/generated/VariableType.h
-torch/csrc/autograd/generated/VariableType.cpp
+torch/csrc/autograd/generated/*
 torch/csrc/cudnn/cuDNN.cpp
 torch/csrc/nn/THNN.cwrap
 torch/csrc/nn/THNN.cpp

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ import distutils.sysconfig
 cfg_vars = distutils.sysconfig.get_config_vars()
 for key, value in cfg_vars.items():
     if type(value) == str:
-            cfg_vars[key] = value.replace("-Wstrict-prototypes", "")
+        cfg_vars[key] = value.replace("-Wstrict-prototypes", "")
 
 ################################################################################
 # Monkey-patch setuptools to compile in parallel
@@ -209,6 +209,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
         from tools.cwrap.plugins.AssertNDim import AssertNDim
         from tools.cwrap.plugins.Broadcast import Broadcast
         from tools.cwrap.plugins.ProcessorSpecificPlugin import ProcessorSpecificPlugin
+        from tools.autograd.gen_variable_type import gen_variable_type
         thp_plugin = THPPlugin()
         cwrap('torch/csrc/generic/TensorMethods.cwrap', plugins=[
             ProcessorSpecificPlugin(), BoolOption(), thp_plugin,
@@ -218,6 +219,14 @@ class build_ext(setuptools.command.build_ext.build_ext):
         cwrap('torch/csrc/cudnn/cuDNN.cwrap', plugins=[
             CuDNNPlugin(), NullableArguments()
         ])
+        # Build ATen based Variable classes
+        autograd_gen_dir = 'torch/csrc/autograd/generated'
+        if not os.path.exists(autograd_gen_dir):
+            os.mkdir(autograd_gen_dir)
+        gen_variable_type(
+            'torch/lib/build/ATen/ATen/Declarations.yaml',
+            autograd_gen_dir)
+
         # It's an old-style class in Python 2.7...
         setuptools.command.build_ext.build_ext.run(self)
 
@@ -359,6 +368,7 @@ main_sources = [
     "torch/csrc/autograd/engine.cpp",
     "torch/csrc/autograd/function.cpp",
     "torch/csrc/autograd/variable.cpp",
+    "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/input_buffer.cpp",
     "torch/csrc/autograd/python_function.cpp",
     "torch/csrc/autograd/python_cpp_function.cpp",
@@ -366,6 +376,9 @@ main_sources = [
     "torch/csrc/autograd/python_engine.cpp",
     "torch/csrc/autograd/python_hook.cpp",
     "torch/csrc/autograd/functions/jit_closure.cpp",
+    "torch/csrc/autograd/generated/VariableType.cpp",
+    "torch/csrc/autograd/generated/Functions.cpp",
+    "torch/csrc/autograd/generated/python_variable_methods.cpp",
     "torch/csrc/autograd/functions/batch_normalization.cpp",
     "torch/csrc/autograd/functions/convolution.cpp",
     "torch/csrc/autograd/functions/basic_ops.cpp",

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -144,6 +144,7 @@ class TestAutograd(TestCase):
             y.backward(go2)
 
             # That's the only case when we can accumulate in-place
+            # TODO: reconsider this logic (see accumulate_grad.cpp)
             if start_volatile:
                 expected_grad = x_grad_clone * 2
             else:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -141,12 +141,10 @@ class TestAutograd(TestCase):
             y.backward(go1, retain_graph=True)
             x_grad = x.grad
             x_grad_clone = x.grad.data.clone()
-
-            del x
             y.backward(go2)
 
             # That's the only case when we can accumulate in-place
-            if start_volatile and end_volatile:
+            if start_volatile:
                 expected_grad = x_grad_clone * 2
             else:
                 expected_grad = x_grad_clone

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1,0 +1,5 @@
+# TODO: define derivatives e.g.
+# - name: addbmm(Scalar beta=1, Tensor self, Scalar alpha=1, Tensor mat1, Tensor mat2)
+#   self: grad * alpha
+#   mat1: grad.bmm(mat2.transpose(1, 2)) * beta
+#   mat2: mat1.transpose(1, 2).bmm(grad) * beta

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1,0 +1,205 @@
+import argparse
+import os
+import yaml
+from tools.shared.module_loader import import_module
+
+CodeTemplate = import_module('code_template', 'torch/lib/ATen/code_template.py').CodeTemplate
+
+try:
+    # use faster C loader if available
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+
+METHOD_DECLARATION = CodeTemplate("""\
+virtual ${return_type} ${method_prefix}${api_name}(${formals}) override;
+""")
+
+METHOD_DEFINITION = CodeTemplate("""\
+${return_type} VariableType::${method_prefix}${api_name}(${formals}) {
+    ${type_definition_body}
+}
+""")
+
+METHOD_DEFINITION_NYI = CodeTemplate("""\
+throw std::runtime_error("${api_name}: NYI");""")
+
+METHOD_DEFINITION_FALLTHROUGH = CodeTemplate("""\
+return baseType->${method_prefix}${api_name}(${unpacked_args});""")
+
+UNWRAP_TENSOR = CodeTemplate("""\
+auto& ${arg_name}_ = checked_unpack(${arg_name}, "${arg_name}", ${arg_pos});""")
+
+GENERATED_COMMENT = CodeTemplate("""\
+generated from tools/autograd/templates/${filename}""")
+
+PY_VARIABLE_METHOD_DEF = CodeTemplate("""\
+{"${name}", (PyCFunction)THPVariable_${name}, ${flags}, NULL},""")
+
+
+template_path = os.path.join(os.path.dirname(__file__), 'templates')
+
+VARIABLE_TYPE_H = CodeTemplate.from_file(template_path + '/VariableType.h')
+VARIABLE_TYPE_CPP = CodeTemplate.from_file(template_path + '/VariableType.cpp')
+VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')
+
+FUNCTIONS_H = CodeTemplate.from_file(template_path + '/Functions.h')
+FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/Functions.cpp')
+
+derivatives_path = os.path.join(os.path.dirname(__file__), 'derivatives.yaml')
+
+# Functions with these return types delegate completely to the underlying
+# base at::Type
+FALLTHROUGH_RETURN_TYPES = {'int64_t', 'void*', 'bool', 'IntList'}
+
+
+def format_return_type(returns):
+    if len(returns) == 0:
+        return 'void'
+    elif len(returns) == 1:
+        return returns[0]['type']
+    else:
+        return_types = [r['type'] for r in returns]
+        return 'std::tuple<{}>'.format(','.join(return_types))
+
+
+def write(dirname, name, template, env):
+    env['generated_comment'] = GENERATED_COMMENT.substitute(filename=name)
+    path = os.path.join(dirname, name)
+    with open(path, 'w') as f:
+        f.write(template.substitute(env))
+
+
+def load_derivatives(path):
+    with open(path, 'r') as f:
+        # TODO: load and parse derivatives.yaml
+        d = yaml.load(f, Loader=Loader)
+        return [] if d is None else d
+
+
+def create_autograd_functions(top_env, declarations):
+    """Functions.h and Functions.cpp body
+
+    These contain the auto-generated subclasses of torch::autograd::Function
+    for each every differentiable torch function.
+    """
+    # function_definitions = top_env['autograd_function_definitions']
+    # function_declarations = top_env['autograd_function_declarations']
+
+    def process_function(option):
+        # TODO: generate autograd::Function classes for each function specified
+        # in derivatives.yaml
+        pass
+
+    for option in declarations:
+        process_function(option)
+
+
+def create_variable_type(top_env, aten_declarations):
+    """VariableType.h and VariableType.cpp body
+
+    This is the at::Type subclass for differentiable tensors. The
+    implementation of each function dispatches to the base tensor type to
+    compute the output. The grad_fn is attached to differentiable functions.
+    """
+
+    type_declarations = top_env['type_derived_method_declarations']
+    type_definitions = top_env['type_derived_method_definitions']
+
+    def unpack_args(option):
+        body = []
+        unpacked_args = []
+        for i, arg in enumerate(option['arguments']):
+            if arg['dynamic_type'] == 'Tensor':
+                env = {'arg_name': arg['name'], 'arg_pos': i}
+                body.append(UNWRAP_TENSOR.substitute(env))
+                unpacked_args.append(arg['name'] + '_')
+            else:
+                unpacked_args.append(arg['name'])
+        option['unpacked_args'] = unpacked_args
+        return body
+
+    def process_function(option):
+        option['formals'] = [arg['type'] + ' ' + arg['name']
+                             for arg in option['arguments']]
+        option['args'] = [arg['name'] for arg in option['arguments']]
+        option['api_name'] = option['name']
+        return_type = format_return_type(option['returns'])
+        option['return_type'] = return_type
+        option['type_definition_body'] = emit_body(option)
+
+        type_declarations.append(METHOD_DECLARATION.substitute(option))
+        type_definitions.append(METHOD_DEFINITION.substitute(option))
+
+    def emit_body(option):
+        body = []
+        body += unpack_args(option)
+
+        if option['return_type'] in FALLTHROUGH_RETURN_TYPES:
+            body.extend(METHOD_DEFINITION_FALLTHROUGH.substitute(option).split('\n'))
+            return body
+
+        return METHOD_DEFINITION_NYI.substitute(option)
+
+    for function in aten_declarations:
+        process_function(function)
+
+
+def create_python_bindings(top_env, aten_decls, derivatives):
+    """python_variable_methods.cpp
+
+    Generates Python bindings to Variable methods
+    """
+
+    # py_methods = top_env['py_methods']
+    # py_method_defs = top_env['py_method_defs']
+
+    def process_option(option):
+        # TODO: generate Python bindings
+        pass
+
+    for option in aten_decls:
+        process_option(option)
+
+
+def gen_variable_type(declarations, out):
+    with open(declarations, 'r') as f:
+        aten_decls = [option for option in yaml.load(f, Loader=Loader)
+                      if option['has_full_argument_list']]
+
+    derivatives = load_derivatives(derivatives_path)
+
+    env = {
+        'autograd_function_declarations': [],
+        'autograd_function_definitions': [],
+        'type_derived_method_declarations': [],
+        'type_derived_method_definitions': [],
+        'py_methods': [],
+        'py_method_defs': [],
+    }
+
+    create_autograd_functions(env, derivatives)
+    create_variable_type(env, aten_decls)
+    create_python_bindings(env, aten_decls, derivatives)
+
+    write(out, 'VariableType.h', VARIABLE_TYPE_H, env)
+    write(out, 'VariableType.cpp', VARIABLE_TYPE_CPP, env)
+    write(out, 'python_variable_methods.cpp', VARIABLE_METHODS_CPP, env)
+    write(out, 'Functions.h', FUNCTIONS_H, env)
+    write(out, 'Functions.cpp', FUNCTIONS_CPP, env)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate autograd C++ files script')
+    parser.add_argument('declarations', metavar='DECL',
+                        help='path to Declarations.yaml')
+    parser.add_argument('out', metavar='OUT',
+                        help='path to output directory')
+    args = parser.parse_args()
+    gen_variable_type(args.declarations, args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1,0 +1,11 @@
+#include "Functions.h"
+
+// ${generated_comment}
+
+using namespace at;
+
+namespace torch { namespace autograd {
+
+${autograd_function_definitions}
+
+}} // namespace torch::autograd

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// ${generated_comment}
+
+#include <ATen/ATen.h>
+
+#include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/saved_variable.h"
+
+namespace torch { namespace autograd {
+
+using at::Scalar;
+using at::Tensor;
+using at::IntList;
+
+${autograd_function_declarations}
+
+}} // namespace torch::autograd

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -1,0 +1,80 @@
+#include "VariableType.h"
+
+// ${generated_comment}
+
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/saved_variable.h"
+#include "torch/csrc/autograd/generated/Functions.h"
+
+#include <iostream>
+
+using namespace at;
+
+namespace torch { namespace autograd {
+
+VariableType::VariableType(Context* context, Type* baseType)
+  : Type(context)
+  , baseType(baseType) {
+}
+
+ScalarType VariableType::scalarType() {
+  return baseType->scalarType();
+}
+Backend VariableType::backend() {
+  return baseType->backend();
+}
+bool VariableType::isCuda() { return baseType->isCuda(); }
+bool VariableType::isSparse() { return baseType->isSparse(); }
+bool VariableType::isDistributed() { return baseType->isDistributed(); }
+
+std::unique_ptr<Storage> VariableType::storage() {
+  return baseType->storage();
+}
+std::unique_ptr<Storage> VariableType::storage(size_t size) {
+  return baseType->storage(size);
+}
+std::unique_ptr<Storage> VariableType::storageFromBlob(void * data, int64_t size) {
+  return baseType->storageFromBlob(data, size);
+}
+Tensor VariableType::unsafeTensorFromTH(void * th_pointer, bool retain) {
+  return baseType->unsafeTensorFromTH(th_pointer, retain);
+}
+std::unique_ptr<Generator> VariableType::generator() {
+  return baseType->generator();
+}
+
+const char * VariableType::toString() const {
+  return VariableType::typeString();
+}
+size_t VariableType::elementSizeInBytes() const {
+  return baseType->elementSizeInBytes();
+}
+TypeID VariableType::ID() const {
+  throw std::runtime_error("VariableType::ID() not implemented");
+}
+
+const char * VariableType::typeString() {
+  return "VariableType";
+}
+
+void VariableType::copy(const Tensor & src, Tensor & dst) {
+  throw std::runtime_error("VariableType::copy() not implemented");
+}
+
+Tensor & VariableType::checked_unpack(const Tensor & t, const char * name, int pos) const
+{
+ if(!t.defined()) {
+   runtime_error("Expected a Tensor of type %s but found an undefined Tensor for argument #%d '%s'",
+     toString(),pos,name);
+ }
+ if (&t.type() == this) {
+   return static_cast<VariableTensor*>(t.pImpl)->data;
+ }
+ runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
+   toString(),t.type().toString(),pos,name);
+}
+
+${type_derived_method_definitions}
+
+}} // namespace torch::autograd

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -69,7 +69,7 @@ Tensor & VariableType::checked_unpack(const Tensor & t, const char * name, int p
      toString(),pos,name);
  }
  if (&t.type() == this) {
-   return static_cast<VariableTensor*>(t.pImpl)->data;
+   return static_cast<VariableImpl*>(t.pImpl)->data;
  }
  runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
    toString(),t.type().toString(),pos,name);

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// ${generated_comment}
+
+#include <ATen/ATen.h>
+
+namespace torch { namespace autograd {
+
+using at::Context;
+using at::Generator;
+using at::IntList;
+using at::Scalar;
+using at::SparseTensor;
+using at::Storage;
+using at::Tensor;
+using at::TensorList;
+using at::Type;
+
+struct VariableType : public at::Type {
+  VariableType(Context* context, at::Type* baseType);
+  virtual at::ScalarType scalarType() override;
+  virtual at::Backend backend() override;
+  virtual bool isCuda() override;
+  virtual bool isSparse() override;
+  virtual bool isDistributed() override;
+  virtual std::unique_ptr<at::Storage> storage() override;
+  virtual std::unique_ptr<at::Storage> storage(size_t size) override;
+  virtual std::unique_ptr<at::Storage> storageFromBlob(void * data, int64_t size) override;
+  virtual std::unique_ptr<at::Generator> generator() override;
+  virtual const char * toString() const override;
+  virtual at::TypeID ID() const override;
+  virtual size_t elementSizeInBytes() const override;
+  static const char * typeString();
+  at::Tensor unsafeTensorFromTH(void * th_pointer, bool retain) override;
+
+  virtual void copy(const at::Tensor & src, at::Tensor & dst) override;
+  ${type_derived_method_declarations}
+
+private:
+  at::Tensor & checked_unpack(const Tensor & t, const char * name, int pos) const;
+
+private:
+  at::Type* baseType;
+};
+
+}} // namespace torch::autograd

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -1,0 +1,20 @@
+// ${generated_comment}
+
+#include <Python.h>
+
+#include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/Exceptions.h"
+
+using at::Tensor;
+using at::Scalar;
+
+namespace torch { namespace autograd {
+
+${py_methods}
+
+PyMethodDef variable_methods[] = {
+  ${py_method_defs}
+  {NULL}
+};
+
+}} // namespace torch::autograd

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -64,7 +64,7 @@ at::Tensor createTensor(PyObject *data)
   auto tensor = ((THPVoidTensor *)data)->cdata;
   return tensor_type->unsafeTensorFromTH(tensor, true); // Calls retain on underlying TH Tensor
 }
-PyObject* createPyObject(at::Tensor& tensor)
+PyObject* createPyObject(const at::Tensor& tensor)
 {
   auto type = getPyTypeObject(tensor);
   PyObject *obj = type->tp_alloc(type, 0);

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -14,7 +14,7 @@ void registerPyTypeObject(
     PyTypeObject *pytype, const std::string& name,
     bool is_cuda, bool is_sparse);
 
-PyObject* createPyObject(at::Tensor& tensor);
+PyObject* createPyObject(const at::Tensor& tensor);
 PyTypeObject* getPyTypeObject(const at::Tensor& tensor);
 //rename to createPyObject when THPP is removed
 // Creates a at::Tensor from a PyObject.  Does NOT steal the PyObject reference.

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -15,14 +15,14 @@ auto Function::flags(const variable_list& inputs) -> FunctionFlags {
   f.is_volatile = false;
   f.next_functions.resize(num_inputs);
   for (int i = 0; i != num_inputs; ++i) {
-    auto& var = inputs[i];
-    if (var) {
-      f.is_executable |= var->requires_grad;
-      f.is_volatile |= var->is_volatile;
-      if (var->grad_fn) {
-        f.next_functions[i] = std::make_pair<>(var->grad_fn, var->output_nr);
+    if (inputs[i].defined()) {
+      auto& var = inputs[i];
+      f.is_executable |= var.requires_grad();
+      f.is_volatile |= var.is_volatile();
+      if (var.grad_fn()) {
+        f.next_functions[i] = std::make_pair<>(var.grad_fn(), var.output_nr());
       } else {
-        f.next_functions[i] = std::make_pair<>(var->get_grad_accumulator(), 0);
+        f.next_functions[i] = std::make_pair<>(var.grad_accumulator(), 0);
       }
     }
   }
@@ -64,7 +64,7 @@ variable_list Function::tracedApply(variable_list inputs) {
   for (int i = 0; i < num_outputs; ++i) {
     auto& output = outputs[i];
     Node* sel = graph->appendNode(graph->createSelect(this_node, i));
-    sel->inferTypeFrom(output->data);
+    sel->inferTypeFrom(output.data());
     tracer::setValueTrace(state, output, sel);
   }
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -7,6 +7,7 @@
 // and their derivatives). Some functions may be used as both.
 
 #include <Python.h>
+#include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/jit/tracer.h"
@@ -22,7 +23,7 @@ struct Function;
 struct Variable;
 
 using tensor_list = std::vector<at::Tensor>;
-using variable_list = std::vector<std::shared_ptr<Variable>>;
+using variable_list = std::vector<Variable>;
 using edge_type = std::pair<std::shared_ptr<Function>, int>;
 using function_list = std::vector<edge_type>;
 using saved_variable_list = std::vector<SavedVariable>;
@@ -178,12 +179,12 @@ struct apply_fn {
   apply_fn(Args&& ...args)
     : fn_(std::make_shared<T>(std::forward<Args>(args)...)) {}
 
-  std::shared_ptr<Variable> operator()(const variable_list& inputs) {
+  Variable operator()(const variable_list& inputs) {
     return (*fn_)(inputs)[0];
   }
 
   template<typename... Args>
-  std::shared_ptr<Variable> operator()(Args&& ...inputs) {
+  Variable operator()(Args&& ...inputs) {
     return (*fn_)(variable_list{inputs...})[0];
   }
 

--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -8,7 +8,7 @@
 namespace torch { namespace autograd {
 
 struct Variable;
-using variable_list = std::vector<std::shared_ptr<Variable>>;
+using variable_list = std::vector<Variable>;
 
 struct FunctionPreHook {
   virtual ~FunctionPreHook() {}

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -26,6 +26,8 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
     throw std::logic_error("leaf variable has been moved into the graph interior");
   if (variable.current_version() != 0)
     throw std::runtime_error("leaf variable was used in an inplace operation");
+  if (!variable.requires_grad())
+    return {};
 
   auto new_grad = grads[0];
   for (auto& hook : variable.hooks()) {

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -54,7 +54,7 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   } else {
     // If grad is non-volatile, it should stay like that
     if (new_grad.is_volatile()) {
-      new_grad = Variable(new VariableTensor(new_grad.data()), false);
+      new_grad = Variable(new VariableImpl(new_grad.data()), false);
     }
     variable.grad() = apply_fn<Add>()(grad, new_grad);
   }

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -6,80 +6,55 @@
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
+using at::Tensor;
+
 namespace torch { namespace autograd {
 
-AccumulateGrad::AccumulateGrad(std::shared_ptr<Variable> _variable)
-    : variable(_variable)
-    , variable_grad(_variable->grad) {
-  is_executable = _variable->requires_grad;
+AccumulateGrad::AccumulateGrad(Variable variable_)
+   : variable(std::move(variable_)) {
   num_inputs = 1;
-}
-
-auto AccumulateGrad::acc_inplace(std::shared_ptr<Variable>& grad,
-    std::shared_ptr<Variable>& new_grad) -> void {
-  auto& grad_data = grad->data;
-  auto& new_grad_data = new_grad->data;
-  AutoGPU guard(grad_data);
-
-  if (grad_data.type().isSparse() && !new_grad_data.type().isSparse()) {
-    grad->data = new_grad_data + grad_data;
-  } else {
-    grad_data += new_grad_data;
-  }
+  is_executable = 1;
 }
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   // XXX: this method is not thread-safe!
   check_input_variables("AccumulateGrad", grads, 1, 0);
-  auto new_grad = grads[0];
 
-  if (!new_grad) return {};
-
-  auto var = variable.lock();
-  // It's possible that the Variable went out of scope and was freed.
-  // We still need to handle the unlikely case of someone holding to its grad.
-  if (!var) {
-    auto var_grad = variable_grad.lock();
-    // Everything was freed. Nothing to do.
-    if (!var_grad) return variable_list();
-    // Now here's the hard part. If both the new_grad and var_grad are volatile
-    // then we just acumulate the data in place (as we'd do if the Variable was
-    // alive). Otherwise, we'd need to perform the out-of-place reduction, but
-    // since the user only holds a reference to .grad and there's no way to
-    // give him the new Value, we just assume that they know these attributes
-    // are changing when using higher order graphs.
-    if (!var_grad->is_volatile || !new_grad->is_volatile) return variable_list();
-    acc_inplace(var_grad, new_grad);
-    return variable_list();
-  }
-
-  if (var->grad_fn)
+  if (!grads[0].defined())
+    return {};
+  if (!variable.defined())
+    throw std::logic_error("leaf variable was freed");
+  if (variable.grad_fn())
     throw std::logic_error("leaf variable has been moved into the graph interior");
-  if (**var->version_counter != 0)
+  if (variable.current_version() != 0)
     throw std::runtime_error("leaf variable was used in an inplace operation");
-  if (var->get_grad_accumulator().get() != this)
-    throw std::logic_error("AccumulateGrad's variable is not bound to it");
 
-  for (auto& hook : var->hooks) {
+  auto new_grad = grads[0];
+  for (auto& hook : variable.hooks()) {
     new_grad = (*hook)({new_grad})[0];
   }
 
-  if (!var->grad) {
-    var->grad = apply_fn<Clone>()(new_grad);
-    variable_grad = var->grad; // We need to update our reference
-  // This case is not strictly necessary, but it makes the first-order only case
-  // slightly more efficient and, what's more important, more predictable for
-  // the users. Thanks to this case we can avoid changing the grad tensor,
-  // a thing never promised and documented, but used in some hacks seen
-  // on the internet.
-  } else if (var->grad->is_volatile) {
-    acc_inplace(var->grad, new_grad);
+  auto& grad = variable.grad();
+  if (!grad.defined()) {
+    grad = apply_fn<Clone>()(new_grad);
+  } else if (grad.is_volatile()) {
+    // This case is not strictly necessary, but it makes the first-order only case
+    // slightly more efficient and, what's more important, more predictable for
+    // the users. Thanks to this case we can avoid changing the grad tensor,
+    // a thing never promised and documented, but used in some hacks seen
+    // on the internet.
+    AutoGPU guard(grad);
+    if (grad.type().isSparse() && !new_grad.type().isSparse()) {
+      grad.data() = new_grad.data() + grad.data();
+    } else {
+      grad.data() += new_grad.data();
+    }
   } else {
     // Once the grad becomes not volatile, it should stay like that
-    if (!var->grad->is_volatile && new_grad->is_volatile) {
-      new_grad = std::make_shared<Variable>(new_grad->data, false, false);
+    if (new_grad.is_volatile()) {
+      new_grad = Variable(new VariableTensor(new_grad.data()), false);
     }
-    var->grad = apply_fn<Add>()(var->grad, new_grad);
+    variable.grad() = apply_fn<Add>()(grad, new_grad);
   }
 
   return variable_list();

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -1,22 +1,16 @@
 #pragma once
 
-#include <Python.h>
-#include <memory>
-
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
 namespace torch { namespace autograd {
 
 struct AccumulateGrad : public Function {
-  AccumulateGrad(std::shared_ptr<Variable> variable);
+  AccumulateGrad(Variable variable);
 
   virtual variable_list apply(const variable_list& inputs) override;
-  void acc_inplace(std::shared_ptr<Variable>& grad,
-    std::shared_ptr<Variable>& new_grad);
 
-  std::weak_ptr<Variable> variable;
-  std::weak_ptr<Variable> variable_grad;
+  Variable variable;
 };
 
 }}

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -14,7 +14,7 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   tensor_list outputs;
   outputs.reserve(inputs.size());
   for (auto& var : inputs) {
-    outputs.emplace_back(var ? var->data : at::Tensor());
+    outputs.emplace_back(var.defined() ? var.data() : Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
     return std::make_shared<Error>(msg, std::move(f));
@@ -23,8 +23,8 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
 
 auto Add::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Add", inputs, 2);
-  auto& input1 = inputs[0]->data;
-  auto& input2 = inputs[1]->data;
+  auto& input1 = inputs[0].data();
+  auto& input2 = inputs[1].data();
   AutoGPU guard(input1);
 
   at::Tensor output;
@@ -45,14 +45,14 @@ auto AddBackward::apply(const variable_list& grad_outputs) -> variable_list {
 
 auto Mul::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Mul", inputs, 2);
-  auto& input1 = inputs[0]->data;
-  auto& input2 = inputs[1]->data;
-  AutoGPU guard(input1.type().isCuda() ? input1.get_device() : -1);
+  AutoGPU guard(inputs[0]);
+  auto& input1 = inputs[0].data();
+  auto& input2 = inputs[1].data();
 
   auto output = input1 * input2;
 
   return wrap_outputs(inputs, as_tensor_list(std::move(output)), [&](FunctionFlags f) {
-    return std::make_shared<MulBackward>(std::move(f), inputs[0]->save(this), inputs[1]->save(this));
+    return std::make_shared<MulBackward>(std::move(f));
   });
 };
 

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -14,6 +14,7 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   tensor_list outputs;
   outputs.reserve(inputs.size());
   for (auto& var : inputs) {
+    // FIXME: share version counters
     outputs.emplace_back(var.defined() ? var.data() : Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -67,7 +67,7 @@ struct Mul : public ForwardFunction<> {
 };
 
 struct MulBackward : public Function {
-  MulBackward(FunctionFlags&& flags, SavedVariable a, SavedVariable b)
+  MulBackward(FunctionFlags&& flags)
     : Function(std::move(flags)) {}
 
   virtual variable_list apply(const variable_list& gradOutputs) override;

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -37,30 +37,31 @@ namespace torch { namespace autograd {
 auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("BatchNorm", inputs, 3, 1);
 
+  AutoGPU guard(inputs[0]);
   auto& input = inputs[0];
   auto& weight = inputs[1];
   auto& bias = inputs[2];
-  AutoGPU guard(input->data);
 
-  auto num_features = input->data.sizes()[1];
+  auto num_features = input.sizes()[1];
   check_dims_match_num_input_features("running_mean", num_features, running_mean.numel());
   check_dims_match_num_input_features("running_var", num_features, running_var.numel());
-  if (weight){
-    check_dims_match_num_input_features("weight", num_features, weight->data.numel());
+  if (weight.defined()) {
+    check_dims_match_num_input_features("weight", num_features, weight.numel());
   }
-  if (bias){
-    check_dims_match_num_input_features("bias", num_features, bias->data.numel());
+  if (bias.defined()) {
+    check_dims_match_num_input_features("bias", num_features, bias.numel());
   }
 
   bool use_cudnn = false;
 #ifdef WITH_CUDNN
-  use_cudnn = (input->data.type().isCuda()
-               && input->data.type().scalarType() != at::kHalf
-               && weight && bias
+  use_cudnn = (input.type().isCuda()
+               && input.type().scalarType() != at::kHalf
+               && weight.defined() && bias.defined()
                && cudnn_enabled && CUDNN_VERSION >= 5110L);
 #endif
 
-  auto output = input->data.type().tensor(input->data.sizes());
+  auto input_data = input.data();
+  auto output = input_data.type().tensor(input.sizes());
   auto save_mean = running_mean.type().tensor(running_mean.sizes());
   auto save_std = running_var.type().tensor(running_var.sizes());
 
@@ -69,11 +70,11 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
     torch::cudnn::cudnn_batch_norm_forward(
         state,
         torch::cudnn::getCudnnHandle(),
-        torch::cudnn::getCudnnDataType(input->data),
-        (THVoidTensor*)input->data.unsafeGetTH(false),
+        torch::cudnn::getCudnnDataType(input),
+        (THVoidTensor*)input.unsafeGetTH(false),
         (THVoidTensor*)output.unsafeGetTH(false),
-        (THVoidTensor*)weight->data.unsafeGetTH(false),
-        (THVoidTensor*)bias->data.unsafeGetTH(false),
+        (THVoidTensor*)weight.unsafeGetTH(false),
+        (THVoidTensor*)bias.unsafeGetTH(false),
         (THVoidTensor*)running_mean.unsafeGetTH(false),
         (THVoidTensor*)running_var.unsafeGetTH(false),
         (THVoidTensor*)save_mean.unsafeGetTH(false),
@@ -83,19 +84,18 @@ auto BatchNormForward::apply(const variable_list& inputs) -> variable_list {
         eps);
 #endif
   } else {
-      at::Tensor nt;
-      at::BatchNormalization_updateOutput(
-        input->data,
-        output,
-        weight ? weight->data : nt,
-        bias ? bias->data : nt,
-        running_mean,
-        running_var,
-        save_mean,
-        save_std,
-        training,
-        momentum,
-        eps);
+    at::BatchNormalization_updateOutput(
+      input_data,
+      output,
+      weight.opt_data(),
+      bias.opt_data(),
+      running_mean,
+      running_var,
+      save_mean,
+      save_std,
+      training,
+      momentum,
+      eps);
   }
 
   auto outputs = as_tensor_list(std::move(output));
@@ -112,9 +112,9 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
   auto weight_var = this->weight.unpack();
   auto bias_var = this->bias.unpack();
 
-  auto input = input_var->data;
-  auto weight = weight_var ? weight_var->data : at::Tensor();
-  auto bias = bias_var ? bias_var->data : at::Tensor();
+  auto input = input_var.data();
+  auto weight = weight_var.opt_data();
+  auto bias = bias_var.opt_data();
 
   AutoGPU guard(input);
 
@@ -147,7 +147,7 @@ auto BatchNormBackward::apply(const variable_list& grad_outputs) -> variable_lis
     }
   }
 
-  auto grad_output = grad_outputs[0]->data.contiguous();
+  auto grad_output = grad_outputs[0].data().contiguous();
 
   if (use_cudnn && eps >= CUDNN_BN_MIN_EPSILON) {
 #ifdef WITH_CUDNN
@@ -208,9 +208,12 @@ auto BatchNormBackward::releaseVariables() -> void {
   bias.data.reset();
 }
 
-std::shared_ptr<torch::autograd::Variable> getReturnTupleVar(PyObject *p, Py_ssize_t pos) {
+Variable getReturnTupleVar(PyObject *p, Py_ssize_t pos) {
   PyObject *item = PyTuple_GET_ITEM(p, pos);
-  return item == Py_None ? nullptr : ((THPVariable*)item)->cdata;
+  if (item != Py_None) {
+    return Variable(((THPVariable*)item)->cdata, true);
+  }
+  return Variable();
 }
 
 auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> variable_list {
@@ -220,11 +223,12 @@ auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> 
   auto ggb = grad_grad_inputs[2];
 
   auto input_var = input.unpack();
+  AutoGPU guard(input_var);
+
   auto weight_var = weight.unpack();
   auto gO_var = grad_output.unpack();
 
-  auto input = input_var->data;
-  AutoGPU guard(input);
+  auto input = input_var.data();
   AutoGIL gil;
 
   THPObjectPtr input_pvar(THPVariable_Wrap(input_var));
@@ -257,7 +261,7 @@ auto BatchNormBackwardBackward::apply(const variable_list& grad_grad_inputs) -> 
   auto gG_var = getReturnTupleVar(r, 1);
   auto ggO_var = getReturnTupleVar(r, 2);
 
-  if (weight_var) {
+  if (weight_var.defined()) {
     return {ggO_var, gI_var, gG_var};
   } else {
     return {ggO_var, gI_var};

--- a/torch/csrc/autograd/functions/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/batch_normalization.cpp
@@ -211,7 +211,7 @@ auto BatchNormBackward::releaseVariables() -> void {
 Variable getReturnTupleVar(PyObject *p, Py_ssize_t pos) {
   PyObject *item = PyTuple_GET_ITEM(p, pos);
   if (item != Py_None) {
-    return Variable(((THPVariable*)item)->cdata, true);
+    return ((THPVariable*)item)->cdata;
   }
   return Variable();
 }

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -7,6 +7,7 @@
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/symbolic.h"
+#include "torch/csrc/autograd/saved_variable.h"
 
 namespace torch { namespace autograd {
 
@@ -33,17 +34,17 @@ struct BatchNormBackward : public Function, public BatchNormParams {
       BatchNormParams params,
       at::Tensor save_mean,
       at::Tensor save_std,
-      const std::shared_ptr<Variable> &input,
-      const std::shared_ptr<Variable> &weight,
-      const std::shared_ptr<Variable> &bias)
+      Variable input,
+      Variable weight,
+      Variable bias)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = input->save(this);
-        this->weight = Variable::save_opt(weight.get(), this);
-        this->bias = Variable::save_opt(bias.get(), this);
+        this->input = SavedVariable(input, this);
+        this->weight = SavedVariable(weight, this);
+        this->bias = SavedVariable(bias, this);
       }
     }
 
@@ -64,17 +65,17 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
       BatchNormParams params,
       at::Tensor save_mean,
       at::Tensor save_std,
-      const std::shared_ptr<Variable> &input,
-      const std::shared_ptr<Variable> &weight,
-      const std::shared_ptr<Variable> &grad_output)
+      Variable input,
+      Variable weight,
+      Variable grad_output)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = input->save(this);
-        this->weight = Variable::save_opt(weight.get(), this);
-        this->grad_output = grad_output->save(this);
+        this->input = SavedVariable(input, this);
+        this->weight = SavedVariable(weight, this);
+        this->grad_output = SavedVariable(grad_output, this);
       }
     }
 

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -19,6 +19,7 @@ using namespace torch::cudnn;
 #endif
 
 using torch::cudnn::Convolution;
+using at::Tensor;
 using tensor_pair = std::pair<at::Tensor, at::Tensor>;
 
 namespace torch { namespace autograd {
@@ -134,8 +135,8 @@ static at::Tensor subtensor(at::Tensor& tensor, int dim, int groups, int g) {
   return tensor.narrow(dim, n * g, n).contiguous();
 }
 
-static std::shared_ptr<Variable> subvariable(std::shared_ptr<Variable> var, int dim, int groups, int g) {
-  int64_t n = var->data.sizes()[dim] / groups;
+static Variable subvariable(Variable var, int dim, int groups, int g) {
+  int64_t n = var.sizes()[dim] / groups;
   auto result = apply_fn<Narrow>(dim, n * g, n)(var);
   return result;
 }
@@ -158,10 +159,16 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("ConvNd", inputs, 3, 2);
   if (is_padding_neg()) throw std::runtime_error("negative padding is not supported");
   if (is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
-  AutoGPU guard(inputs[0]->data);
-  auto input = inputs[0]->data.contiguous();
-  auto weight = inputs[1]->data;
-  auto bias = inputs[2] ? inputs[2]->data : at::Tensor();
+
+  AutoGPU guard(inputs[0]);
+
+  auto input = inputs[0].data().contiguous();
+  auto weight = inputs[1].data();
+
+  Tensor bias;
+  if (inputs[2].defined()) {
+    bias = inputs[2].data();
+  }
 
   int k = input.ndimension();
   if (k == 3) {
@@ -255,14 +262,14 @@ auto ConvBackward::apply(const variable_list& grad_outputs) -> variable_list {
   auto weight_var = weight_.unpack();
   auto bias_var = bias_.unpack();
 
-  auto input = input_var->data;
-  auto weight = weight_var->data;
-  auto bias = bias_var ? bias_var->data : at::Tensor();
+  auto input = input_var.data();
+  auto weight = weight_var.data();
+  auto bias = bias_var.defined() ? bias_var.data() : Tensor();
 
   AutoGPU guard(input);
 
   input = input.contiguous();
-  auto grad_output = grad_outputs[0]->data.contiguous();
+  auto grad_output = grad_outputs[0].data().contiguous();
 
   int k = input.ndimension();
   if (k == 3) {
@@ -406,39 +413,39 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   auto input = input_.unpack();
 
   // Compute ggO = conv(w, ggI) + conv(ggW, i) + ggb
-  std::shared_ptr<Variable> ggO = nullptr;
-  if (ggI) {
-    if (weight->data.type().isCuda()) {
+  Variable ggO;
+  if (ggI.defined()) {
+    if (weight.type().isCuda()) {
       weight = apply_fn<Contiguous>()(weight);
     }
-    ggO = apply_fn<ConvForward>(*this)(ggI, weight, nullptr);
+    ggO = apply_fn<ConvForward>(*this)(ggI, weight, Variable());
   }
 
-  if (ggW) {
-    if (ggW->data.type().isCuda()) {
+  if (ggW.defined()) {
+    if (ggW.type().isCuda()) {
       ggW = apply_fn<Contiguous>()(ggW);
     }
-    auto ggW_term = apply_fn<ConvForward>(*this)(input_.unpack(), ggW, nullptr);
-    if (ggO) {
+    auto ggW_term = apply_fn<ConvForward>(*this)(input_.unpack(), ggW, Variable());
+    if (ggO.defined()) {
       ggO = apply_fn<Add>()(ggO, ggW_term);
     } else {
       ggO = ggW_term;
     }
   }
 
-  if (ggb) {
+  if (ggb.defined()) {
     // View as (1, ggb.size(0), 1, 1...)
 
     // Expand
-    std::vector<int64_t> new_size(gO->data.ndimension(), 1);
-    new_size[1] = ggb->data.sizes()[0];
+    std::vector<int64_t> new_size(gO.ndimension(), 1);
+    new_size[1] = ggb.sizes()[0];
     auto ggb_contiguous = apply_fn<Contiguous>()(ggb);
     auto ggb_view = apply_fn<View>(new_size)(ggb_contiguous);
 
     // Expand
-    auto ggb_expanded = apply_fn<Expand>(gO->data.sizes())(ggb_view);
+    auto ggb_expanded = apply_fn<Expand>(gO.sizes())(ggb_view);
 
-    if (ggO) {
+    if (ggO.defined()) {
       ggO = apply_fn<Add>()(ggO, ggb_expanded);
     } else {
       ggO = ggb_expanded;
@@ -446,8 +453,8 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   }
 
   // Compute gW = conv(ggI, g0)
-  std::shared_ptr<Variable> gW = nullptr;
-  if (ggI) {
+  Variable gW;
+  if (ggI.defined()) {
     // Modified params with correct padding
     ConvParams gw_conv_params(*this);
 
@@ -460,25 +467,25 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto gOt = apply_fn<Transpose>(0, 1)(gO);
     auto ggIt = apply_fn<Transpose>(0, 1)(ggI);
 
-    std::shared_ptr<Variable> gWt = nullptr;
+    Variable gWt;
     // Compute conv
     if (groups == 1) {
-      if (gOt->data.type().isCuda()) {
+      if (gOt.type().isCuda()) {
         gOt = apply_fn<Contiguous>()(gOt);
       }
 
       // Compute conv
-      gWt = apply_fn<ConvForward>(gw_conv_params)(ggIt, gOt, nullptr);
+      gWt = apply_fn<ConvForward>(gw_conv_params)(ggIt, gOt, Variable());
     } else {
       variable_list gWt_list(groups);
       for (int g = 0; g < groups; ++g) {
         auto ggIt_g = subvariable(ggIt, 0, groups, g);
         auto gOt_g = subvariable(gOt, 0, groups, g);
-        if (gOt_g->data.type().isCuda()) {
+        if (gOt_g.type().isCuda()) {
           gOt_g = apply_fn<Contiguous>()(gOt_g);
         }
 
-        gWt_list[g] = apply_fn<ConvForward>(gw_conv_params)(ggIt_g, gOt_g, nullptr);
+        gWt_list[g] = apply_fn<ConvForward>(gw_conv_params)(ggIt_g, gOt_g, Variable());
       }
 
       gWt = apply_fn<Cat>(1)(gWt_list);
@@ -490,8 +497,8 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     // narrow gW to only relevant portion
     // we do it this way instead of narrowing the input itself because
     // the ConvForward kernels don't support asymmetric padding.
-    auto gW_size = gW->data.sizes();
-    auto w_size = weight->data.sizes();
+    auto gW_size = gW.sizes();
+    auto w_size = weight.sizes();
     for (size_t i = 2; i < gW_size.size(); ++i) {
       if (gW_size[i] > w_size[i]) {
           gW = apply_fn<Narrow>(i, 0, w_size[i])(gW);
@@ -500,8 +507,8 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
   }
 
   // Compute gI = convT(gO, ggW)
-  std::shared_ptr<Variable> gI = nullptr;
-  if (ggW) {
+  Variable gI;
+  if (ggW.defined()) {
     // select conv transpose
     ConvParams gi_conv_params(*this);
     gi_conv_params.transposed = true;
@@ -510,11 +517,11 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     std::swap(gi_conv_params.dilation, gi_conv_params.stride);
 
     // calculate output_padding
-    auto weight_size = weight->data.sizes();
+    auto weight_size = weight.sizes();
     std::vector<long> kernel_size(weight_size.begin() + 2, weight_size.end());
-    auto input_size = input->data.sizes();
+    auto input_size = input.sizes();
     std::vector<long> input_shape(input_size.begin() + 2, input_size.end());
-    auto grad_output_size = gO->data.sizes();
+    auto grad_output_size = gO.sizes();
     std::vector<long> grad_output_shape(grad_output_size.begin() + 2, grad_output_size.end());
 
     if (kernel_size.size() == 1) {
@@ -543,23 +550,23 @@ auto ConvBackwardBackward::apply(const variable_list& grad_grad_inputs) -> varia
     auto ggWt = apply_fn<Transpose>(0, 1)(ggW);
     auto gOt = apply_fn<Transpose>(0, 1)(gO);
 
-    std::shared_ptr<Variable> gIt = nullptr;
+    Variable gIt;
     if (groups == 1) {
-      if (gOt->data.type().isCuda()) {
+      if (gOt.type().isCuda()) {
         gOt = apply_fn<Contiguous>()(gOt);
       }
 
-      gIt = apply_fn<ConvForward>(gi_conv_params)(ggWt, gOt, nullptr);
+      gIt = apply_fn<ConvForward>(gi_conv_params)(ggWt, gOt, Variable());
     } else {
       variable_list gIt_list(groups);
       for (int g = 0; g < groups; ++g) {
         auto ggWt_g = subvariable(ggWt, 1, groups, g);
         auto gOt_g = subvariable(gOt, 0, groups, g);
-        if (gOt_g->data.type().isCuda()) {
+        if (gOt_g.type().isCuda()) {
           gOt_g = apply_fn<Contiguous>()(gOt_g);
         }
 
-        gIt_list[g] = apply_fn<ConvForward>(gi_conv_params)(ggWt_g, gOt_g, nullptr);
+        gIt_list[g] = apply_fn<ConvForward>(gi_conv_params)(ggWt_g, gOt_g, Variable());
       }
 
       gIt = apply_fn<Cat>(0)(gIt_list);

--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -135,7 +135,7 @@ static at::Tensor subtensor(at::Tensor& tensor, int dim, int groups, int g) {
   return tensor.narrow(dim, n * g, n).contiguous();
 }
 
-static Variable subvariable(Variable var, int dim, int groups, int g) {
+static Variable subvariable(const Variable& var, int dim, int groups, int g) {
   int64_t n = var.sizes()[dim] / groups;
   auto result = apply_fn<Narrow>(dim, n * g, n)(var);
   return result;
@@ -164,11 +164,7 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
 
   auto input = inputs[0].data().contiguous();
   auto weight = inputs[1].data();
-
-  Tensor bias;
-  if (inputs[2].defined()) {
-    bias = inputs[2].data();
-  }
+  auto bias = inputs[2].opt_data();
 
   int k = input.ndimension();
   if (k == 3) {

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -9,6 +9,7 @@
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/symbolic.h"
+#include "torch/csrc/autograd/saved_variable.h"
 
 #ifdef WITH_CUDNN
 #include "torch/csrc/cudnn/Conv.h"
@@ -52,9 +53,9 @@ struct ConvBackward : public Function, public ConvParams {
   ConvBackward(
       FunctionFlags flags,
       ConvParams params,
-      const std::shared_ptr<Variable>& input,
-      const std::shared_ptr<Variable>& weight,
-      const std::shared_ptr<Variable>& bias,
+      Variable input,
+      Variable weight,
+      Variable bias,
       tensor_list columns,
       tensor_list ones,
       std::unique_ptr<torch::cudnn::Convolution> convolution)
@@ -62,9 +63,11 @@ struct ConvBackward : public Function, public ConvParams {
     , ConvParams(std::move(params))
     , convolution(std::move(convolution)) {
       if (is_executable) {
-        this->input_ = input->save(this);
-        this->weight_ = weight->save(this);
-        this->bias_ = Variable::save_opt(bias.get(), this);
+        this->input_ = SavedVariable(input, this);
+        this->weight_ = SavedVariable(weight, this);
+        if (bias.defined()) {
+          this->bias_ = SavedVariable(bias, this);
+        }
         this->columns = std::move(columns);
         this->ones = std::move(ones);
       }
@@ -86,17 +89,19 @@ struct ConvBackwardBackward : public Function, public ConvParams {
   ConvBackwardBackward(
       FunctionFlags flags,
       ConvParams params,
-      const std::shared_ptr<Variable>& input,
-      const std::shared_ptr<Variable>& weight,
-      const std::shared_ptr<Variable>& bias,
-      const std::shared_ptr<Variable>& grad_output)
+      Variable input,
+      Variable weight,
+      Variable bias,
+      Variable grad_output)
     : Function(std::move(flags))
     , ConvParams(std::move(params)) {
       if (is_executable) {
-        this->input_ = input->save(this);
-        this->weight_ = weight->save(this);
-        this->bias_ = Variable::save_opt(bias.get(), this);
-        this->grad_output_ = grad_output->save(this);
+        this->input_ = SavedVariable(input, this);
+        this->weight_ = SavedVariable(weight, this);
+        if (bias.defined()) {
+          this->bias_ = SavedVariable(bias, this);
+        }
+        this->grad_output_ = SavedVariable(grad_output, this);
       }
     }
 

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -247,9 +247,7 @@ static PyObject* accumulateGradVar(PyObject *_self, void* _unused)
 {
   THPCppFunction* self = (THPCppFunction*)_self;
   auto grad_acc = (AccumulateGrad*)self->cdata.get();
-  auto var = grad_acc->variable.lock();
-  if (!var) Py_RETURN_NONE;
-  return THPVariable_Wrap(var);
+  return THPVariable_Wrap(grad_acc->variable);
 }
 
 static struct PyGetSetDef accumulate_grad_properties[] = {

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -709,7 +709,7 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
     return Variable(new VariableImpl(v.data(), v.requires_grad(), v.is_volatile()), false);
   });
   for (auto unique : desc->stages[stage].prev_stage_variables)
-    input_leaves.emplace_back(new VariableImpl(saved_vars.at(unique), true, false), false);
+    input_leaves.emplace_back(Variable(new VariableImpl(saved_vars.at(unique), true, false), false));
   input_leaves.emplace_back(Variable()); // for ConstantFactory
 
   auto& engine = python::PythonEngine::getDefaultEngine();

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -171,7 +171,7 @@ struct PythonCall : public Function {
       if (!THPVariable_Check(output))
         throw std::runtime_error("Function.apply returned a non-Variable output");
       THPVariable *var = (THPVariable*)output;
-      var_result.emplace_back(var->cdata);
+      var_result.emplace_back(Variable(var->cdata, true));
     }
 
     return var_result;
@@ -209,10 +209,10 @@ struct WrapConstant : public Function {
   }
 
   virtual variable_list apply(const variable_list& inputs) {
-    if (inputs.size() != 1 || inputs[0])
+    if (inputs.size() != 1 || inputs[0].defined())
       throw std::logic_error("WrapConstant nodes should only receive a single NULL input");
-    AutoGPU guard(value.type().isCuda() ? value.get_device() : -1);
-    return {std::make_shared<Variable>(value.clone(), false, false)};
+    AutoGPU guard(value);
+    return {Variable(new VariableTensor(value.clone()), false)};
   }
 
   at::Tensor value;
@@ -226,7 +226,7 @@ struct ConstantFactory : public Function {
   }
 
   virtual variable_list apply(const variable_list& inputs) {
-    if (inputs.size() != 1 || inputs[0])
+    if (inputs.size() != 1 || inputs[0].defined())
       throw std::logic_error("ConstantFactory nodes should only receive a single NULL input");
     return variable_list(next_functions.size());
   }
@@ -241,7 +241,7 @@ struct FusionGroupFunction : public Function {
     // compiled for
     std::vector<at::Tensor> data;
     for(auto & input : inputs)
-      data.push_back(input->data);
+      data.push_back(input.data());
     AutoGPU guard(data.back());
     std::vector<at::Tensor> outputs;
     outputs.reserve(function->outputDescriptors().size());
@@ -641,7 +641,7 @@ AutogradClosure::AutogradClosure(const std::shared_ptr<MultiStageClosure>& desc,
     auto saved_idx = std::get<2>(entry);
     post_callbacks.emplace(fn, [this, saved_idx, output_offset](Function* fn, variable_list& inputs, variable_list& outputs) {
       std::lock_guard<std::mutex> lock(this->capture_mutex);
-      this->captured_vars[saved_idx] = outputs[output_offset]->data;
+      this->captured_vars[saved_idx] = outputs[output_offset].data();
       return true;
     });
   }
@@ -675,7 +675,7 @@ AutogradClosure::AutogradClosure(const std::shared_ptr<MultiStageClosure>& desc,
     std::lock_guard<std::mutex> lock(this->capture_mutex);
     this->outputs.reserve(inputs.size());
     for (auto & input : inputs)
-      this->outputs.emplace_back(input->data);
+      this->outputs.emplace_back(input.data());
     return false; // Stop execution
   });
 
@@ -699,18 +699,18 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
   for (std::size_t i = 0; i < num_inputs; ++i) {
     auto & input = inputs[i];
     auto & flags = stage_closure.var_flags[i];
-    if (input->requires_grad != flags.requires_grad || input->is_volatile != flags.is_volatile)
+    if (input.requires_grad() != flags.requires_grad || input.is_volatile() != flags.is_volatile)
       throw std::runtime_error("AutogradClosure received inputs with different flags");
   }
 
   // TODO: we could run all this with volatile variables, but we need to somehow capture handles
   // we should enable requires_grad only for the parts that need it
-  auto input_leaves = fmap(inputs, [](const std::shared_ptr<Variable>& v) {
-    return std::make_shared<Variable>(v->data, v->requires_grad, v->is_volatile);
+  auto input_leaves = fmap(inputs, [](const Variable& v) {
+    return Variable(new VariableTensor(v.data(), v.requires_grad(), v.is_volatile()), false);
   });
   for (auto unique : desc->stages[stage].prev_stage_variables)
-    input_leaves.emplace_back(std::make_shared<Variable>(saved_vars.at(unique), true, false));
-  input_leaves.emplace_back(nullptr); // for ConstantFactory
+    input_leaves.emplace_back(new VariableTensor(saved_vars.at(unique), true, false), false);
+  input_leaves.emplace_back(Variable()); // for ConstantFactory
 
   auto& engine = python::PythonEngine::getDefaultEngine();
   engine.execute(stage_closure.roots, input_leaves, true, pre_callbacks, post_callbacks);

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -171,7 +171,7 @@ struct PythonCall : public Function {
       if (!THPVariable_Check(output))
         throw std::runtime_error("Function.apply returned a non-Variable output");
       THPVariable *var = (THPVariable*)output;
-      var_result.emplace_back(Variable(var->cdata, true));
+      var_result.emplace_back(var->cdata);
     }
 
     return var_result;

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -212,7 +212,7 @@ struct WrapConstant : public Function {
     if (inputs.size() != 1 || inputs[0].defined())
       throw std::logic_error("WrapConstant nodes should only receive a single NULL input");
     AutoGPU guard(value);
-    return {Variable(new VariableTensor(value.clone()), false)};
+    return {Variable(new VariableImpl(value.clone()), false)};
   }
 
   at::Tensor value;
@@ -706,10 +706,10 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
   // TODO: we could run all this with volatile variables, but we need to somehow capture handles
   // we should enable requires_grad only for the parts that need it
   auto input_leaves = fmap(inputs, [](const Variable& v) {
-    return Variable(new VariableTensor(v.data(), v.requires_grad(), v.is_volatile()), false);
+    return Variable(new VariableImpl(v.data(), v.requires_grad(), v.is_volatile()), false);
   });
   for (auto unique : desc->stages[stage].prev_stage_variables)
-    input_leaves.emplace_back(new VariableTensor(saved_vars.at(unique), true, false), false);
+    input_leaves.emplace_back(new VariableImpl(saved_vars.at(unique), true, false), false);
   input_leaves.emplace_back(Variable()); // for ConstantFactory
 
   auto& engine = python::PythonEngine::getDefaultEngine();

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -71,7 +71,7 @@ struct Eval : Function {
     auto relevant_outputs = filterRelevantOutputs(inputs, outputs);
     if (relevant_outputs.size() == 0)
       return nullptr;
-    return std::dynamic_pointer_cast<Eval>(relevant_outputs[0]->grad_fn);
+    return std::dynamic_pointer_cast<Eval>(relevant_outputs[0].grad_fn());
   }
 
   virtual std::shared_ptr<Eval> newEval() {

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -38,7 +38,7 @@ auto Identity::apply(const variable_list& inputs) -> variable_list {
 
 auto Clone::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Clone", inputs, 1);
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.clone();
@@ -50,7 +50,7 @@ auto Clone::apply(const variable_list& inputs) -> variable_list {
 
 auto Contiguous::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Contiguous", inputs, 1);
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.contiguous();
@@ -63,7 +63,7 @@ auto Contiguous::apply(const variable_list& inputs) -> variable_list {
 auto Transpose::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Transpose", inputs, 1);
 
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.transpose(dim1, dim2);
@@ -76,7 +76,7 @@ auto Transpose::apply(const variable_list& inputs) -> variable_list {
 auto View::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("View", inputs, 1);
 
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.view(size);
@@ -89,7 +89,7 @@ auto View::apply(const variable_list& inputs) -> variable_list {
 auto Expand::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Expand", inputs, 1);
 
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.expand(size);
@@ -102,7 +102,7 @@ auto Expand::apply(const variable_list& inputs) -> variable_list {
 auto Narrow::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("Narrow", inputs, 1);
 
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   at::Tensor output = input.narrow(dim, start, size);
@@ -118,12 +118,12 @@ auto Cat::apply(const variable_list& inputs) -> variable_list {
     throw std::runtime_error("Cat operation expect at least one argument.");
   }
 
-  auto& input = inputs[0]->data;
+  auto& input = inputs[0].data();
   AutoGPU guard(input);
 
   std::vector<at::Tensor> tensors(num_inputs);
   for (int i = 0; i < num_inputs; ++i) {
-    tensors[i] = inputs[i]->data;
+    tensors[i] = inputs[i].data();
   }
   auto output = input.type().cat(tensors, dim);
 
@@ -133,7 +133,7 @@ auto Cat::apply(const variable_list& inputs) -> variable_list {
 }
 
 auto Chunk::apply(const variable_list& inputs) -> variable_list {
-  auto outputs = chunk(inputs[0]->data, chunks,dim);
+  auto outputs = chunk(inputs[0].data(), chunks,dim);
   return wrap_outputs(inputs, std::move(outputs), [](FunctionFlags f) {
     return std::make_shared<Error>("Chunk is not differentiable", std::move(f));
   });

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -14,7 +14,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   if (flags.is_volatile) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(new VariableTensor(output, false, true), false);
+        result.emplace_back(new VariableImpl(output, false, true), false);
       } else {
         result.emplace_back();
       }
@@ -23,7 +23,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
     auto grad_fn = ctr(std::move(flags));
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(new VariableTensor(output, grad_fn), false);
+        result.emplace_back(new VariableImpl(output, grad_fn), false);
       } else {
         ++grad_fn->num_inputs;
         result.emplace_back();

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,5 +1,7 @@
 #include "torch/csrc/autograd/functions/utils.h"
 
+#include "torch/csrc/autograd/variable.h"
+
 #include <sstream>
 
 namespace torch { namespace autograd {
@@ -11,16 +13,22 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   result.reserve(outputs.size());
   if (flags.is_volatile) {
     for (auto& output : outputs) {
-     result.emplace_back(Variable::of(output, true));
+      if (output.defined()) {
+        auto pImpl = new VariableTensor(output);
+        pImpl->is_volatile = true;
+        result.emplace_back(pImpl, false);
+      } else {
+        result.emplace_back();
+      }
     }
   } else {
     auto grad_fn = ctr(std::move(flags));
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(std::make_shared<Variable>(output, grad_fn));
+        result.emplace_back(new VariableTensor(output, grad_fn), false);
       } else {
         ++grad_fn->num_inputs;
-        result.emplace_back(nullptr);
+        result.emplace_back();
       }
     }
   }
@@ -38,7 +46,7 @@ void check_input_variables(const char* name, const variable_list& inputs, int ar
     throw std::runtime_error(ss.str());
   }
   for (int i = 0; i < required_args; ++i) {
-    if (!inputs[i]) {
+    if (!inputs[i].defined()) {
       std::stringstream ss;
       ss << name << ": expected Variable at argument " << i << " (got None)";
       throw std::runtime_error(ss.str());

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -14,7 +14,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   if (flags.is_volatile) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(new VariableImpl(output, false, true), false);
+        result.emplace_back(Variable(new VariableImpl(output, false, true), false));
       } else {
         result.emplace_back();
       }
@@ -23,7 +23,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
     auto grad_fn = ctr(std::move(flags));
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(new VariableImpl(output, grad_fn), false);
+        result.emplace_back(Variable(new VariableImpl(output, grad_fn), false));
       } else {
         ++grad_fn->num_inputs;
         result.emplace_back();

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -14,9 +14,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   if (flags.is_volatile) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        auto pImpl = new VariableTensor(output);
-        pImpl->is_volatile = true;
-        result.emplace_back(pImpl, false);
+        result.emplace_back(new VariableTensor(output, false, true), false);
       } else {
         result.emplace_back();
       }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -15,7 +15,8 @@ void InputBuffer::add(size_t pos, Variable var) {
   }
   auto& item = buffer[pos];
   if (!item.first.defined()) {
-    buffer[pos] = std::make_pair<>(std::move(var), var.current_version());
+    auto current_version = var.current_version();
+    buffer[pos] = std::make_pair<>(std::move(var), current_version);
   } else {
     auto result = apply_fn<Add>()(item.first, std::move(var));
     buffer[pos] = std::make_pair<>(std::move(result), 0);

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -9,15 +9,13 @@ InputBuffer::InputBuffer(size_t size)
   : buffer(size)
   {}
 
-void InputBuffer::add(size_t pos, std::shared_ptr<Variable>&& var) {
-  if (!var) {
+void InputBuffer::add(size_t pos, const Variable& var) {
+  if (!var.defined()) {
     return;
   }
   auto& item = buffer[pos];
-  auto& saved_var_ptr = item.first;
-  if (!saved_var_ptr) {
-    auto version = **var->version_counter;
-    buffer[pos] = std::make_pair<>(std::move(var), version);
+  if (!item.first.defined()) {
+    buffer[pos] = std::make_pair<>(std::move(var), var.current_version());
   } else {
     auto result = apply_fn<Add>()(item.first, std::move(var));
     buffer[pos] = std::make_pair<>(std::move(result), 0);
@@ -26,22 +24,21 @@ void InputBuffer::add(size_t pos, std::shared_ptr<Variable>&& var) {
 
 auto InputBuffer::device() const -> int {
   for (auto& pair : buffer) {
-    if (pair.first && pair.first->data.type().isCuda()) {
-      return pair.first->data.get_device();
+    if (pair.first.defined() && pair.first.type().isCuda()) {
+      return pair.first.get_device();
     }
   }
   return -1;
 }
 
-auto InputBuffer::variables(InputBuffer&& g) -> std::vector<std::shared_ptr<Variable>> {
+auto InputBuffer::variables(InputBuffer&& g) -> std::vector<Variable> {
   InputBuffer _buffer = std::move(g);
   auto& buffer = _buffer.buffer;
   int size = buffer.size();
-  std::vector<std::shared_ptr<Variable>> result;
+  std::vector<Variable> result;
   result.reserve(size);
   for (int i = 0; i != size; ++i) {
-    auto var_ptr = buffer[i].first;
-    result.emplace_back(var_ptr ? std::move(buffer[i].first) : nullptr);
+    result.emplace_back(buffer[i].first);
   }
   return result;
 }

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -9,7 +9,7 @@ InputBuffer::InputBuffer(size_t size)
   : buffer(size)
   {}
 
-void InputBuffer::add(size_t pos, const Variable& var) {
+void InputBuffer::add(size_t pos, Variable var) {
   if (!var.defined()) {
     return;
   }

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <utility>
 #include <memory>
+#include <ATen/ATen.h>
 
 #include "torch/csrc/autograd/variable.h"
 
@@ -20,16 +21,16 @@ struct InputBuffer {
   InputBuffer(InputBuffer&& other) = default;
 
   // Accumulates the variable at a specified index.
-  void add(size_t idx, std::shared_ptr<Variable>&& var);
+  void add(size_t idx, const Variable& var);
 
   int device() const;
 
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
-  static std::vector<std::shared_ptr<Variable>> variables(InputBuffer&& buffer);
+  static std::vector<Variable> variables(InputBuffer&& buffer);
 
 private:
   // (Variable, version at save)
-  std::vector<std::pair<std::shared_ptr<Variable>, int>> buffer;
+  std::vector<std::pair<Variable, int>> buffer;
 };
 
 }}  // namespace torch::autograd

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -21,7 +21,7 @@ struct InputBuffer {
   InputBuffer(InputBuffer&& other) = default;
 
   // Accumulates the variable at a specified index.
-  void add(size_t idx, const Variable& var);
+  void add(size_t idx, Variable var);
 
   int device() const;
 

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -35,7 +35,7 @@ PyObject* THPCppFunction_call(PyObject* self, PyObject* args, PyObject *kwargs)
     if (!THPVariable_Check(arg)) {
       return PyErr_Format(PyExc_TypeError, "argument %d is not a Variable", i);
     }
-    vars[i] = Variable(((THPVariable*)arg)->cdata, true);
+    vars[i] = ((THPVariable*)arg)->cdata;
   }
 
   variable_list output;
@@ -128,7 +128,7 @@ PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var)
   auto var = (THPVariable*)_var;
   auto& fn = *((THPCppFunction*)self)->cdata;
   fn.pre_hooks.push_back(std::make_shared<PyFunctionPreHook>(
-      var->backward_hooks, var->cdata->output_nr));
+      var->backward_hooks, var->cdata.output_nr()));
   Py_RETURN_NONE;
 }
 

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -35,7 +35,7 @@ PyObject* THPCppFunction_call(PyObject* self, PyObject* args, PyObject *kwargs)
     if (!THPVariable_Check(arg)) {
       return PyErr_Format(PyExc_TypeError, "argument %d is not a Variable", i);
     }
-    vars[i] = ((THPVariable*)arg)->cdata;
+    vars[i] = Variable(((THPVariable*)arg)->cdata, true);
   }
 
   variable_list output;

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -201,12 +201,12 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
       if (is_leaf) {
           grad_fn = input_var->cdata.get()->grad_accumulator.lock();
       }
-      if (input_var->cdata.requires_grad()) {
-        THPUtils_assert(grad_fn, "One of the differentiated Variables appears to not have "
-            "been used in the graph");
-      }
-      THPUtils_assert(grad_fn && grad_fn->is_executable, "One of the differentiated Variables does "
-          "not require grad");
+      THPUtils_assert(input_var->cdata.requires_grad(),
+          "One of the differentiated Variables does not require grad");
+      THPUtils_assert(grad_fn,
+          "One of the differentiated Variables appears to not have been used in the graph");
+      THPUtils_assert(grad_fn->is_executable,
+          "One of the differentiated Variables has a non-executable grad_fn. Submit a bug report.");
       auto& fn_info = ctx.output_map[grad_fn];
       fn_info.first.emplace_back(output_nr, i);
       fn_info.second = is_leaf;

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -10,7 +10,6 @@
 #include <unordered_set>
 
 using namespace torch::autograd;
-using at::Tensor;
 
 struct THPEngine {
     PyObject_HEAD

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -555,7 +555,7 @@ static void _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
       THPFunction_assert(false, "mark_non_differentiable only accepts function "
           "outputs");
     }
-    var->cdata.set_requires_grad(false);
+    var->cdata.requires_grad() = false;
   }
   Py_DECREF(self->non_differentiable);
   self->non_differentiable = NULL;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -334,7 +334,7 @@ static void _mark_dirty(THPFunction *self, t2var_type &t2var,
   self->dirty_tensors = NULL;
 }
 
-static void _transplant_var(VariableTensor& var, const std::shared_ptr<Function>& fn, int output_nr, bool is_volatile)
+static void _transplant_var(VariableImpl& var, const std::shared_ptr<Function>& fn, int output_nr, bool is_volatile)
 {
   if (is_volatile) {
     var.grad_fn = nullptr;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -190,7 +190,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
         msg += ")";
         throw std::runtime_error(msg);
       }
-      results.emplace_back(((THPVariable*)output)->cdata, true);
+      results.emplace_back(((THPVariable*)output)->cdata);
     } else {
       results.emplace_back();
     }
@@ -322,7 +322,7 @@ static void _mark_dirty(THPFunction *self, t2var_type &t2var,
       THPFunction_assert(false, "mark_dirty only accepts input tensors, but "
           "argument %d isn't one", i);
     }
-    auto &v_counter = *variable->cdata->version_counter;
+    auto &v_counter = *variable->cdata.get()->version_counter;
     THPFunction_assert(v_counter.var_refcnt() == 1, "in-place operations can be "
         "only used on variables that don't share storage with any other "
         "variables, but detected that there are %d objects sharing it",
@@ -389,8 +389,8 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
     } else {
       // If one of the outputs was also an input tensor it's a bit more complicated.
       THPVariable *input_var = it->second;
-      auto& input_var_ = *input_var->cdata;
-      if (input_var_.grad_fn) {
+      auto& input_var_ = input_var->cdata;
+      if (input_var_.grad_fn()) {
         Py_INCREF(input_var);
         output_var = input_var;
         // If it's not a leaf we want to move it in the graph so backprop
@@ -398,7 +398,7 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
         // it's better to minimize the number of operations that mutate the graph.
         // grad_fn <- variable <- self  ==>  grad_fn <- self <- variable
         if (dirty_inputs.count(output) > 0) {
-          _transplant_var(input_var_, cdata, i, is_volatile);
+          _transplant_var(*input_var_.get(), cdata, i, is_volatile);
         }
       } else {
         // If the leaf Variable has been returned, we have to move it after the
@@ -410,10 +410,10 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
         // returned unchanged, and we can simply return a new Variable
         // referencing the same storage.
         if (dirty_inputs.count(output) > 0) {
-          if (!input_var_.requires_grad) {
+          if (!input_var_.requires_grad()) {
             Py_INCREF(input_var);
             output_var = input_var;
-            _transplant_var(input_var_, cdata, i, is_volatile);
+            _transplant_var(*input_var_.get(), cdata, i, is_volatile);
           } else { // input_var_.requires_grad
             throw std::runtime_error("a leaf Variable that requires grad has been used in an in-place operation.");
           }
@@ -434,14 +434,14 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
             output_var = (THPVariable*)THPVariable_NewWithFunction(output, cdata);
           }
           if (!output_var) throw python_error();
-          output_var->cdata->version_counter->join_with(*input_var->cdata->version_counter);
+          output_var->cdata.get()->version_counter->join_with(*input_var->cdata.get()->version_counter);
         }
       }
     }
     if (!output_var) throw python_error();
 
     if (self->output_info) {
-      auto& output_tensor = output_var->cdata->data;
+      auto& output_tensor = output_var->cdata.data();
       self->output_info->emplace_back(
         (PyObject *)getPyTypeObject(output_tensor),
         output_tensor.type().isCuda() ? output_tensor.get_device() : -1,
@@ -449,7 +449,7 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
       );
     }
     t2var[output] = output_var;
-    output_var->cdata->output_nr = i;
+    output_var->cdata.get()->output_nr = i;
     PyTuple_SET_ITEM(outputs, i, (PyObject*)output_var);
   }
 }
@@ -484,9 +484,7 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
           "tensors, but argument %d doesn't satisfy this condition", i);
     }
 
-    self->saved_variables->emplace_back(
-      Variable(variable->cdata, true),
-      cdata_ptr);
+    self->saved_variables->emplace_back(variable->cdata, cdata_ptr);
   }
   // Free .to_save
   Py_DECREF(self->to_save);
@@ -527,7 +525,7 @@ static void _join_version_counters(THPFunction *self, t2var_type &t2var)
           "and output tensors, but argument %d doesn't satify this "
           "condition", i);
     }
-    v2->cdata->version_counter->join_with(*v1->cdata->version_counter);
+    v2->cdata.get()->version_counter->join_with(*v1->cdata.get()->version_counter);
   }
   // Free .shared_pairs
   Py_DECREF(self->shared_pairs);
@@ -548,7 +546,7 @@ static void _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
     THPVariable *var;
     try {
       var = t2var.at(t);
-      THPFunction_assert(var->cdata->grad_fn.get() == &self->cdata,
+      THPFunction_assert(var->cdata.grad_fn().get() == &self->cdata,
           "mark_non_differentiable only accepts output tensors, but "
           "argument %d isn't an output", i);
     } catch (std::out_of_range &e) {
@@ -557,7 +555,7 @@ static void _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
       THPFunction_assert(false, "mark_non_differentiable only accepts function "
           "outputs");
     }
-    var->cdata->requires_grad = 0;
+    var->cdata.set_requires_grad(false);
   }
   Py_DECREF(self->non_differentiable);
   self->non_differentiable = NULL;
@@ -601,8 +599,8 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
     } else {
       THPVariable* variable = (THPVariable*)arg;
       new_arg = THPVariable_get_data(variable);
-      unpacked.input_vars.push_back(Variable(variable->cdata, true));
-      PyObject* needs_grad = variable->cdata->requires_grad ? Py_True : Py_False;
+      unpacked.input_vars.push_back(variable->cdata);
+      PyObject* needs_grad = variable->cdata.requires_grad() ? Py_True : Py_False;
       Py_INCREF(needs_grad);
       PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, needs_grad);
     }
@@ -670,7 +668,7 @@ static void trace_create(PyObject* op_obj,
   variable_list output_vars;
   for (int i = 0; i < PyTuple_GET_SIZE(output_tuple.get()); ++i) {
     THPVariable *var = (THPVariable*)PyTuple_GET_ITEM(output_tuple.get(), i);
-    output_vars.emplace_back(Variable(var->cdata, true));
+    output_vars.emplace_back(var->cdata);
   }
 
   // Save scalar args and the calling convention
@@ -929,7 +927,7 @@ PyObject* THPFunction__register_hook_dict(THPFunction *self, PyObject *_var)
 {
   THPUtils_assert(THPVariable_Check(_var), "_register_hook_dict expected a variable");
   THPVariable *var = (THPVariable*)_var;
-  self->cdata.pre_hooks.emplace_back(new PyFunctionPreHook(var->backward_hooks, var->cdata->output_nr));
+  self->cdata.pre_hooks.emplace_back(new PyFunctionPreHook(var->backward_hooks, var->cdata.output_nr()));
   Py_RETURN_NONE;
 }
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <exception>
+#include <ATen/ATen.h>
 
 #include "THP.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
@@ -13,6 +14,7 @@
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
 #include "torch/csrc/jit/tracer.h"
+#include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
@@ -25,6 +27,7 @@
 using namespace torch;
 using namespace torch::autograd;
 using namespace torch::jit;
+using at::Tensor;
 
 PyObject *THPFunctionClass = NULL;
 PyObject *THPStochasticFunctionClass = NULL;
@@ -63,8 +66,8 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
 
   for (size_t i = 0; i != inputs.size(); ++i) {
     PyObject* input;
-    if (inputs[i]) {
-      input = createPyObject(inputs[i]->data);
+    if (inputs[i].defined()) {
+      input = createPyObject(inputs[i].data());
       if (!input) throw python_error();
     } else {
       input = Py_None;
@@ -123,7 +126,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   auto& output_info = *py_fn->output_info;
   for (size_t i = 0; i < num_inputs; ++i) {
     PyObject* input;
-    if (inputs[i]) {
+    if (inputs[i].defined()) {
       input = THPVariable_Wrap(inputs[i]);
     } else {
       THPObjectPtr tensor(_allocate_grad_output(output_info[i], _gpu_guard));
@@ -187,7 +190,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
         msg += ")";
         throw std::runtime_error(msg);
       }
-      results.emplace_back(((THPVariable*)output)->cdata);
+      results.emplace_back(((THPVariable*)output)->cdata, true);
     } else {
       results.emplace_back();
     }
@@ -331,7 +334,7 @@ static void _mark_dirty(THPFunction *self, t2var_type &t2var,
   self->dirty_tensors = NULL;
 }
 
-static void _transplant_var(Variable& var, const std::shared_ptr<Function>& fn, int output_nr, bool is_volatile)
+static void _transplant_var(VariableTensor& var, const std::shared_ptr<Function>& fn, int output_nr, bool is_volatile)
 {
   if (is_volatile) {
     var.grad_fn = nullptr;
@@ -344,12 +347,11 @@ static void _transplant_var(Variable& var, const std::shared_ptr<Function>& fn, 
     var.is_volatile = is_volatile;
     var.output_nr = output_nr;
   }
-  var.grad = nullptr;
+  var.grad.reset();
   var.hooks.clear();
   if (auto grad_acc_fn = var.grad_accumulator.lock()) {
     auto grad_acc = dynamic_cast<AccumulateGrad*>(grad_acc_fn.get());
     grad_acc->variable.reset();
-    grad_acc->variable_grad.reset();
   }
 }
 
@@ -482,7 +484,9 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
           "tensors, but argument %d doesn't satisfy this condition", i);
     }
 
-    self->saved_variables->emplace_back(variable->cdata->save(cdata_ptr));
+    self->saved_variables->emplace_back(
+      Variable(variable->cdata, true),
+      cdata_ptr);
   }
   // Free .to_save
   Py_DECREF(self->to_save);
@@ -597,7 +601,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
     } else {
       THPVariable* variable = (THPVariable*)arg;
       new_arg = THPVariable_get_data(variable);
-      unpacked.input_vars.push_back(variable->cdata);
+      unpacked.input_vars.push_back(Variable(variable->cdata, true));
       PyObject* needs_grad = variable->cdata->requires_grad ? Py_True : Py_False;
       Py_INCREF(needs_grad);
       PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, needs_grad);
@@ -622,7 +626,7 @@ PyObject* process_outputs(THPFunction* grad_fn, const UnpackedInput& unpacked, T
   // Initialize t2var map
   t2var_type t2var;
   for (auto& c_var : unpacked.input_vars) {
-    THPVariable* py_var = (THPVariable*)c_var->pyobj;
+    THPVariable* py_var = (THPVariable*)c_var.get()->pyobj;
     t2var.emplace(py_var->data, py_var);
   }
 
@@ -666,7 +670,7 @@ static void trace_create(PyObject* op_obj,
   variable_list output_vars;
   for (int i = 0; i < PyTuple_GET_SIZE(output_tuple.get()); ++i) {
     THPVariable *var = (THPVariable*)PyTuple_GET_ITEM(output_tuple.get(), i);
-    output_vars.emplace_back(var->cdata);
+    output_vars.emplace_back(Variable(var->cdata, true));
   }
 
   // Save scalar args and the calling convention
@@ -725,7 +729,7 @@ static void trace_create(PyObject* op_obj,
     // output, but Python nodes can't be optimized away, so we simplify the
     // code here.
     Node* sel = graph->appendNode(graph->createSelect(this_expr, i));
-    sel->inferTypeFrom(output->data);
+    sel->inferTypeFrom(output.data());
     tracer::setValueTrace(tracing_state, output, sel);
   }
 
@@ -936,7 +940,7 @@ PyObject* THPFunction_register_hook(THPFunction *self, PyObject *hook)
 
 static PyObject *unpack_saved_variables(
     THPFunction *self,
-    std::function<PyObject*(std::shared_ptr<Variable>)> unpack_fn)
+    std::function<PyObject*(const Variable&)> unpack_fn)
 {
   THPUtils_assert(!self->has_freed_buffers, ERR_BACKWARD_TWICE);
   if (!self->saved_variables)
@@ -951,7 +955,7 @@ static PyObject *unpack_saved_variables(
   for (int i = 0; i < num_saved; i++) {
     auto unpacked_var = saved_variables[i].unpack(saved_for);
     THPObjectPtr value;
-    if (!unpacked_var) {
+    if (!unpacked_var.defined()) {
       Py_INCREF(Py_None);
       value = Py_None;
     } else {
@@ -964,14 +968,14 @@ static PyObject *unpack_saved_variables(
 
 PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 {
-  return unpack_saved_variables(self, [](std::shared_ptr<Variable> var) {
-    return createPyObject(var->data);
+  return unpack_saved_variables(self, [](const Variable& var) {
+    return createPyObject(var.data());
   });
 }
 
 PyObject *THPFunction_saved_variables(THPFunction *self, void *_unused)
 {
-  return unpack_saved_variables(self, [](std::shared_ptr<Variable> var) {
+  return unpack_saved_variables(self, [](const Variable& var) {
     return THPVariable_Wrap(var);
   });
 }

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -8,6 +8,7 @@
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/utils/object_ptr.h"
 
 // (class, gpu id, sizes)

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -51,7 +51,7 @@ auto PyFunctionPreHook::operator()(const variable_list& values) -> variable_list
   }
 
   variable_list results(values);
-  results[value_idx] = Variable(((THPVariable*)value.get())->cdata, true);
+  results[value_idx] = ((THPVariable*)value.get())->cdata;
   return results;
 }
 
@@ -110,7 +110,7 @@ static variable_list unwrap_variables(PyObject* py_variables)  {
     if (item == Py_None) {
       continue;
     } else if (THPVariable_Check(item)) {
-      results[i] = Variable(((THPVariable*)item)->cdata, true);
+      results[i] = ((THPVariable*)item)->cdata;
     } else {
       // this should never happen, but just in case...
       std::stringstream ss;
@@ -157,8 +157,8 @@ static void check_single_result(PyObject* _original, PyObject* _result, PyObject
     throw python_error();
   }
 
-  auto& original = ((THPVariable*)_original)->cdata->data;
-  auto& result = ((THPVariable*)_result)->cdata->data;
+  auto& original = ((THPVariable*)_original)->cdata.data();
+  auto& result = ((THPVariable*)_result)->cdata.data();
 
   if (original.type().ID() != result.type().ID()) {
     std::stringstream ss;

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -10,6 +10,7 @@
 #include "torch/csrc/Exceptions.h"
 
 using torch::autograd::variable_list;
+using torch::autograd::Variable;
 
 static PyObject* wrap_variables(const variable_list& c_variables);
 static variable_list unwrap_variables(PyObject* py_variables);
@@ -50,7 +51,7 @@ auto PyFunctionPreHook::operator()(const variable_list& values) -> variable_list
   }
 
   variable_list results(values);
-  results[value_idx] = ((THPVariable*)value.get())->cdata;
+  results[value_idx] = Variable(((THPVariable*)value.get())->cdata, true);
   return results;
 }
 
@@ -109,7 +110,7 @@ static variable_list unwrap_variables(PyObject* py_variables)  {
     if (item == Py_None) {
       continue;
     } else if (THPVariable_Check(item)) {
-      results[i] = ((THPVariable*)item)->cdata;
+      results[i] = Variable(((THPVariable*)item)->cdata, true);
     } else {
       // this should never happen, but just in case...
       std::stringstream ss;

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -11,19 +11,23 @@
 #include "torch/csrc/cuda/AutoGPU.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/Exceptions.h"
+#include "torch/csrc/autograd/variable.h"
 
 
+using namespace at;
 using namespace torch::autograd;
 
 PyObject *THPVariableClass = NULL;
 
-static PyObject* THPVariable_NewWithVar(PyTypeObject* type, std::shared_ptr<Variable> var)
+static PyObject* THPVariable_NewWithVar(PyTypeObject* type, const Variable& var)
 {
   PyObject* obj = type->tp_alloc(type, 0);
   if (obj) {
     auto v = (THPVariable*) obj;
-    new (&v->cdata) std::shared_ptr<Variable>(std::move(var));
-    if (auto fn = dynamic_cast<PyFunction*>(v->cdata->grad_fn.get())) {
+    v->cdata = var.get();
+    v->cdata->retain();
+    v->cdata->pyobj = obj;
+    if (auto fn = dynamic_cast<PyFunction*>(var.grad_fn().get())) {
       // Create a new reference to the THPFunction. This ensures that ref count
       // of the THPFunction is at least the number of referring THPVariables.
       v->cdata->grad_fn = THPFunction_asFunction((THPFunction*)fn->obj);
@@ -32,31 +36,36 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, std::shared_ptr<Vari
   return obj;
 }
 
-PyObject * THPVariable_Wrap(const std::shared_ptr<Variable>& var)
+PyObject * THPVariable_Wrap(const Variable& var)
 {
-  if (!var) {
+  if (!var.defined()) {
     Py_RETURN_NONE;
-  } else if (var->pyobj) {
-    Py_INCREF(var->pyobj);
-  } else {
-    var->pyobj = THPVariable_NewWithVar((PyTypeObject *)THPVariableClass, var);
-    THPVariable* py_var = (THPVariable*)var->pyobj;
-    py_var->data = torch::createPyObject(var->data);
   }
-  return var->pyobj;
+
+  if (auto obj = var.get()->pyobj) {
+    Py_INCREF(obj);
+    return obj;
+  }
+
+  PyObject* obj = THPVariable_NewWithVar((PyTypeObject *)THPVariableClass, var);
+  if (obj) {
+    ((THPVariable*)obj)->data = torch::createPyObject(var.data());
+  }
+  return obj;
 }
 
 // This function DOES NOT steal a reference to data
 PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<torch::autograd::Function>& grad_fn)
 {
   THPUtils_assert(THPModule_isTensor(data), "data must be a Tensor");
-  auto v = std::make_shared<Variable>(torch::createTensor(data), grad_fn->is_executable, false);
-  v->grad_fn = grad_fn;
+
+  Variable v(new VariableTensor(torch::createTensor(data), grad_fn->is_executable), false);
+  v.grad_fn() = grad_fn;
+
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
-    v->pyobj = obj;
-    Py_INCREF(data);
     ((THPVariable*)obj)->data = data;
+    Py_INCREF(data);
   }
   return obj;
 }
@@ -64,10 +73,9 @@ PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<tor
 // This function DOES NOT steal a reference to data
 PyObject * THPVariable_NewVolatile(PyObject *data)
 {
-  auto v = std::make_shared<Variable>(torch::createTensor(data), false, true);
+  Variable v(new VariableTensor(torch::createTensor(data), false, true), false);
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
-    v->pyobj = obj;
     ((THPVariable*)obj)->data = data;
     Py_INCREF(data);
   }
@@ -77,10 +85,9 @@ PyObject * THPVariable_NewVolatile(PyObject *data)
 // This function DOES NOT steal a reference to data
 PyObject * THPVariable_NewLeaf(PyObject *data)
 {
-  auto v = std::make_shared<Variable>(torch::createTensor(data), false, false);
+  Variable v(new VariableTensor(torch::createTensor(data)), false);
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
-    v->pyobj = obj;
     ((THPVariable*)obj)->data = data;
     Py_INCREF(data);
   }
@@ -113,8 +120,9 @@ static int THPVariable_clear(THPVariable *self)
       grad_acc->pre_hooks.clear();
     }
     self->cdata->pyobj = nullptr;
+    self->cdata->release();
+    self->cdata = nullptr;
   }
-  self->cdata.reset();
   return 0;
 }
 
@@ -122,7 +130,6 @@ static void THPVariable_dealloc(THPVariable* self)
 {
   PyObject_GC_UnTrack(self);
   THPVariable_clear(self);
-  self->cdata.~shared_ptr<Variable>();
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -157,20 +164,19 @@ PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   THPUtils_assert(THPModule_isTensor(data), "Variable data has to "
           "be a tensor, but got %s", THPUtils_typename(data));
 
-  std::shared_ptr<Variable> var;
+  Variable var;
   if (grad_fn) {
-    var = std::make_shared<Variable>(torch::createTensor(data), THPFunction_asFunction((THPFunction*)grad_fn));
+    auto grad_fn_ = THPFunction_asFunction((THPFunction*)grad_fn);
+    var.reset(new VariableTensor(torch::createTensor(data), grad_fn_), false);
   } else {
-    var = std::make_shared<Variable>(torch::createTensor(data), requires_grad, is_volatile);
+    var.reset(new VariableTensor(torch::createTensor(data), requires_grad, is_volatile), false);
   }
+
   PyObject* self = THPVariable_NewWithVar(type, var);
   if (self) {
-    var->pyobj = self;
-    ((THPVariable*)self)->cdata = var;
     ((THPVariable*)self)->data = data;
     Py_INCREF(data);
   }
-
   return self;
 }
 
@@ -197,17 +203,17 @@ typedef int (*setter)(PyObject *, PyObject *, void *);
 
 PyObject *THPVariable_get_version(THPVariable *self)
 {
-  auto& var = *self->cdata;
-  return PyInt_FromLong(**var.version_counter);
+  auto var = self->cdata;
+  return PyInt_FromLong(**var->version_counter);
 }
 
 PyObject *THPVariable_get_grad_fn(THPVariable *self)
 {
-  auto& var = *self->cdata;
-  if (!var.grad_fn) {
+  auto var = self->cdata;
+  if (!var->grad_fn) {
     Py_RETURN_NONE;
   }
-  return functionToPyObject(var.grad_fn);
+  return functionToPyObject(var->grad_fn);
 }
 
 int THPVariable_set_grad_fn(THPVariable *self, PyObject *obj)
@@ -231,6 +237,30 @@ PyObject * THPVariable_get_data(THPVariable *self)
   return self->data;
 }
 
+namespace {
+
+// XXX: This is a hack to access private TensorImpl::type_
+// http://bloglitb.blogspot.com/2011/12/access-to-private-members-safer.html
+// This is currently needed because module.float() changes the type of the
+// data field of each variable. We should fix this and not allow changing the
+// type of var.data.
+
+template<typename Tag, typename Tag::type M>
+struct Rob {
+  friend typename Tag::type get(Tag) {
+    return M;
+  }
+};
+
+struct TensorImpl_Type {
+  typedef Type* TensorImpl::*type;
+  friend type get(TensorImpl_Type);
+};
+
+template struct Rob<TensorImpl_Type, &TensorImpl::type_>;
+
+}
+
 int THPVariable_set_data(THPVariable *self, PyObject *data)
 {
   THPUtils_assertRet(-1, THPModule_isTensor(data), "Variable data has to "
@@ -238,16 +268,20 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   Py_INCREF(data);
   Py_XDECREF(self->data);
   self->data = data;
-  auto& var = *self->cdata;
-  auto tensor = torch::createTensor(data);
-  var.data.swap(tensor);
+  Tensor tensor = torch::createTensor(data);
+  if (&self->cdata->data.type() != &tensor.type()) {
+    // we change the type of var.data so we must change the type of var
+    auto newType = VariableTensor::getType(tensor);
+    self->cdata->*get(TensorImpl_Type()) = newType;
+  }
+  self->cdata->data = tensor;
   return 0;
 }
 
 PyObject *THPVariable_get_grad(THPVariable *self)
 {
   auto& var = *self->cdata;
-  if (!var.grad) {
+  if (!var.grad.defined()) {
     Py_RETURN_NONE;
   }
   return THPVariable_Wrap(var.grad);
@@ -266,7 +300,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *other)
   THPUtils_assertRet(-1, self != (THPVariable*)other,
       "can't assign Variable as its own grad");
 
-  auto& other_var = ((THPVariable*)other)->cdata;
+  auto other_var = ((THPVariable*)other)->cdata;
 
   // Make sure the data is ok
   THPUtils_assertRet(-1, other_var->data.type().ID() == var.data.type().ID(),
@@ -280,10 +314,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *other)
   THPUtils_assertRet(-1, other_var->data.sizes().vec() == var.data.sizes().vec(),
       "assigned grad has data of a different size");
 
-  var.grad = other_var;
-  if (auto grad_acc = var.grad_accumulator.lock()) {
-    ((AccumulateGrad*)grad_acc.get())->variable_grad = other_var;
-  }
+  var.grad = Variable(other_var, true);
   return 0;
 }
 
@@ -416,8 +447,17 @@ PyTypeObject THPVariableType = {
   THPVariable_pynew                      /* tp_new */
 };
 
+namespace torch { namespace autograd {
+
+extern PyMethodDef variable_methods[];
+
+}}
+
 bool THPVariable_initModule(PyObject *module)
 {
+  static std::vector<PyMethodDef> methods;
+  THPUtils_addPyMethodDefs(methods, torch::autograd::variable_methods);
+  THPVariableType.tp_methods = methods.data();
   if (PyType_Ready(&THPVariableType) < 0)
     return false;
   Py_INCREF(&THPVariableType);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -63,7 +63,7 @@ PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<tor
 {
   THPUtils_assert(THPModule_isTensor(data), "data must be a Tensor");
 
-  Variable v(new VariableTensor(torch::createTensor(data), grad_fn->is_executable), false);
+  Variable v(new VariableImpl(torch::createTensor(data), grad_fn->is_executable), false);
   v.grad_fn() = grad_fn;
 
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
@@ -77,7 +77,7 @@ PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<tor
 // This function DOES NOT steal a reference to data
 PyObject * THPVariable_NewVolatile(PyObject *data)
 {
-  Variable v(new VariableTensor(torch::createTensor(data), false, true), false);
+  Variable v(new VariableImpl(torch::createTensor(data), false, true), false);
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
     ((THPVariable*)obj)->data = data;
@@ -89,7 +89,7 @@ PyObject * THPVariable_NewVolatile(PyObject *data)
 // This function DOES NOT steal a reference to data
 PyObject * THPVariable_NewLeaf(PyObject *data)
 {
-  Variable v(new VariableTensor(torch::createTensor(data)), false);
+  Variable v(new VariableImpl(torch::createTensor(data)), false);
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, v);
   if (obj) {
     ((THPVariable*)obj)->data = data;
@@ -171,9 +171,9 @@ PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   Variable var;
   if (grad_fn) {
     auto grad_fn_ = THPFunction_asFunction((THPFunction*)grad_fn);
-    var.reset(new VariableTensor(torch::createTensor(data), grad_fn_), false);
+    var.reset(new VariableImpl(torch::createTensor(data), grad_fn_), false);
   } else {
-    var.reset(new VariableTensor(torch::createTensor(data), requires_grad, is_volatile), false);
+    var.reset(new VariableImpl(torch::createTensor(data), requires_grad, is_volatile), false);
   }
 
   PyObject* self = THPVariable_NewWithVar(type, var);
@@ -275,7 +275,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   Tensor tensor = torch::createTensor(data);
   if (&self->cdata->data.type() != &tensor.type()) {
     // we change the type of var.data so we must change the type of var
-    auto newType = VariableTensor::getType(tensor);
+    auto newType = VariableImpl::getType(tensor);
     self->cdata->*get(TensorImpl_Type()) = newType;
   }
   self->cdata->data = tensor;

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -63,7 +63,7 @@ PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<tor
   THPUtils_assert(THPModule_isTensor(data), "data must be a Tensor");
 
   Variable v(new VariableImpl(torch::createTensor(data)), false);
-  v.set_requires_grad(grad_fn->is_executable);
+  v.requires_grad() = grad_fn->is_executable;
   v.grad_fn() = grad_fn;
 
   PyObject* obj = THPVariable_NewWithVar((PyTypeObject*)THPVariableClass, std::move(v));
@@ -331,7 +331,7 @@ int THPVariable_set_volatile(THPVariable *self, PyObject *obj)
   THPUtils_assertRet(-1, PyBool_Check(obj), "volatile must be a bool");
   THPUtils_assertRet(-1, !self->cdata.grad_fn(),
       "volatile can only be set on leaf variables");
-  self->cdata.set_volatile(obj == Py_True);
+  self->cdata.is_volatile() = (obj == Py_True);
   return 0;
 }
 
@@ -359,7 +359,7 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
     THPUtils_setError("you can only change requires_grad flags of leaf variables.%s", hint);
     return -1;
   }
-  var.set_requires_grad(obj == Py_True);
+  var.requires_grad() = (obj == Py_True);
   if (auto grad_accumulator = var.get()->grad_accumulator.lock()) {
     grad_accumulator->is_executable = var.requires_grad();
   }

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -2,6 +2,7 @@
 
 #include <Python.h>
 #include <memory>
+#include <ATen/ATen.h>
 
 #include "torch/csrc/autograd/variable.h"
 
@@ -9,7 +10,7 @@
 struct THPVariable {
     PyObject_HEAD
     // Payload
-    std::shared_ptr<torch::autograd::Variable> cdata;
+    torch::autograd::VariableTensor* cdata;
     // Tensor this wraps (corresponds to Python attr 'data').
     // It assumed that a THPVariable is *uniquely* identified by the
     // tensor it wraps.
@@ -26,7 +27,7 @@ bool THPVariable_initModule(PyObject *module);
 PyObject * THPVariable_NewVolatile(PyObject *data);
 PyObject * THPVariable_NewLeaf(PyObject *data);
 PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<torch::autograd::Function>& var);
-PyObject * THPVariable_Wrap(const std::shared_ptr<torch::autograd::Variable>& var);
+PyObject * THPVariable_Wrap(const torch::autograd::Variable& var);
 PyObject * THPVariable_get_data(THPVariable *self);
 
 inline bool THPVariable_Check(PyObject *obj)

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -10,7 +10,7 @@
 struct THPVariable {
     PyObject_HEAD
     // Payload
-    torch::autograd::VariableImpl* cdata;
+    torch::autograd::Variable cdata;
     // Tensor this wraps (corresponds to Python attr 'data').
     // It assumed that a THPVariable is *uniquely* identified by the
     // tensor it wraps.

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -10,7 +10,7 @@
 struct THPVariable {
     PyObject_HEAD
     // Payload
-    torch::autograd::VariableTensor* cdata;
+    torch::autograd::VariableImpl* cdata;
     // Tensor this wraps (corresponds to Python attr 'data').
     // It assumed that a THPVariable is *uniquely* identified by the
     // tensor it wraps.

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -43,7 +43,7 @@ auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) const -> Variabl
         "inplace operation");
   }
 
-  Variable var(new VariableTensor(data, requires_grad, is_volatile), false);
+  Variable var(new VariableImpl(data, requires_grad, is_volatile), false);
   if (has_grad_fn && !grad_fn) {
     if (!saved_for) {
       // If saving the grad_fn would create a circular reference, then it must

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -1,0 +1,86 @@
+#include "torch/csrc/autograd/saved_variable.h"
+
+#include "torch/csrc/autograd/function.h"
+
+using namespace at;
+
+namespace torch { namespace autograd {
+
+SavedVariable::SavedVariable(const Variable& variable, Function* saved_for)
+  : SavedVariable() {
+  if (variable.defined()) {
+    data = variable.data();
+    requires_grad = variable.requires_grad();
+    is_volatile = variable.is_volatile();
+    expected_version = variable.current_version();
+    version = variable.get()->version_counter->new_saved_ref();
+    has_grad_fn = variable.grad_fn() != nullptr;
+    if (!has_grad_fn) {
+      grad_accumulator = variable.grad_accumulator();
+    }
+    if (variable.grad_fn().get() != saved_for) {
+      grad_fn = variable.grad_fn();
+    }
+    if (variable.tracing_state()) {
+      tracing_state.reset(new jit::tracer::ValueTracingState(*variable.tracing_state()));
+	  }
+  }
+}
+
+auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) const -> Variable {
+  if (!data.defined()) {
+    if (version) {
+      throw std::runtime_error(ERR_BACKWARD_TWICE);
+    }
+    return Variable();
+  }
+
+  int current_version = **version;
+  if (expected_version != current_version) {
+    throw std::runtime_error("one of the variables "
+        "needed for gradient computation has been modified by an "
+        "inplace operation");
+  }
+
+  Variable var(new VariableTensor(data), false);
+  var.set_requires_grad(requires_grad);
+  var.set_volatile(is_volatile);
+  if (has_grad_fn && !grad_fn) {
+    if (!saved_for) {
+      // If saving the grad_fn would create a circular reference, then it must
+      // be passed in to the unpack function.
+      throw std::runtime_error("No grad_fn for non-leaf saved variable");
+    }
+    var.grad_fn() = saved_for;
+  } else {
+    var.grad_fn() = grad_fn;
+  }
+  var.get()->version_counter->join_with(*version);
+
+  // If a Variable is a leaf (no grad_fn saved), and it requires_grad, then we
+  // should have saved the grad accumulator. Even if the Variable no longer
+  // alive, the accumulator should be kept alive by the references in the graph).
+  if (requires_grad && !var.grad_fn() && grad_accumulator.expired())
+    throw std::logic_error("No grad accumulator for a saved leaf!");
+  var.get()->grad_accumulator = grad_accumulator;
+  if (tracing_state)
+    var.tracing_state().reset(new jit::tracer::ValueTracingState(*tracing_state));
+
+  return var;
+}
+
+auto SavedVariable::unpack_data(std::shared_ptr<Function> saved_for) const -> Tensor {
+  auto var = unpack(saved_for);
+  if (var.defined()) {
+    return var.data();
+  }
+  return Tensor();
+}
+
+
+const char* ERR_BACKWARD_TWICE =
+    "Trying to backward through the graph a second time, but the buffers have "
+    "already been freed. Specify retain_graph=True when calling backward "
+    "the first time.";
+
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Python.h>
+#include <mutex>
+#include <memory>
+#include <functional>
+#include <ATen/ATen.h>
+
+#include "torch/csrc/jit/tracer_state.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/variable_version.h"
+#include "torch/csrc/Types.h"
+
+namespace torch { namespace autograd {
+
+struct Function;
+
+extern const char* ERR_BACKWARD_TWICE;
+
+struct SavedVariable {
+  SavedVariable()
+    : data()
+    , has_grad_fn(false)
+    , version()
+    , requires_grad(false)
+    , is_volatile(false)
+    , expected_version(-1) {}
+
+  SavedVariable(const Variable& variable, Function* saved_for);
+
+
+  at::Tensor data;
+  // The gradient function associated with this node. If has_grad_fn
+  // is false, then this is a leaf node. Note that the grad_fn is not saved if
+  // it would create a circular reference. In that case, the grad_fn must be
+  // passed in to the unpack function when reconstructing the Variable.
+  bool has_grad_fn;
+  std::shared_ptr<Function> grad_fn;
+  std::weak_ptr<Function> grad_accumulator;
+  std::unique_ptr<VariableVersion> version;
+  bool requires_grad;
+  bool is_volatile;
+  int expected_version;
+  std::unique_ptr<jit::tracer::ValueTracingState> tracing_state;
+
+  Variable unpack(std::shared_ptr<Function> saved_for=nullptr) const;
+  at::Tensor unpack_data(std::shared_ptr<Function> saved_for=nullptr) const;
+};
+
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -1,105 +1,125 @@
 #include "torch/csrc/autograd/variable.h"
 
+#include "torch/csrc/autograd/generated/VariableType.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
-#include "torch/csrc/utils/auto_gpu.h"
 
-using namespace torch;
+using namespace at;
 
 namespace torch { namespace autograd {
 
-Variable::Variable(
-  at::Tensor data,
-  bool requires_grad,
-  bool is_volatile)
-    : data(data)
-    , grad_fn(nullptr)
-    , grad(nullptr)
-    , version_counter(new VariableVersion())
-    , requires_grad(requires_grad)
-    , is_volatile(is_volatile)
-    , output_nr(0)
-    , pyobj(nullptr)
-{
-  if (!this->data.defined()) {
-    throw std::runtime_error("Variable data is NULL");
+VariableTensor::VariableTensor(Tensor data_, bool requires_grad, bool is_volatile)
+  : TensorImpl(getType(data_))
+  , data(std::move(data_))
+  , grad()
+  , version_counter(new VariableVersion())
+  , requires_grad(requires_grad)
+  , is_volatile(is_volatile)
+  , output_nr(0)
+  , pyobj(nullptr) {
+  if (!data.defined()) {
+    throw std::runtime_error("data is undefined");
   }
 }
 
-Variable::Variable(
-  at::Tensor data,
-  std::shared_ptr<Function> grad_fn)
-    : data(data)
-    , grad_fn(grad_fn)
-    , grad(nullptr)
-    , version_counter(new VariableVersion())
-    , requires_grad(grad_fn->is_executable)
-    , is_volatile(false)
-    , output_nr(grad_fn->num_inputs++)
-    , pyobj(nullptr)
+VariableTensor::VariableTensor(Tensor data, std::shared_ptr<Function> grad_fn)
+  : VariableTensor(std::move(data))
 {
-  if (!this->data.defined()) {
-    throw std::runtime_error("Variable data is NULL");
-  }
+  this->grad_fn = grad_fn;
+  requires_grad = grad_fn->is_executable;
+  output_nr = grad_fn->num_inputs++;
 }
 
-auto Variable::get_grad_accumulator() -> std::shared_ptr<Function> {
+VariableTensor::VariableTensor(Tensor data)
+  : VariableTensor(std::move(data), false, false)
+{
+}
+
+VariableTensor::~VariableTensor() {
+}
+
+const char * VariableTensor::toString() const {
+  return "Variable";
+}
+
+IntList VariableTensor::sizes() {
+  return data.sizes();
+}
+
+int64_t VariableTensor::dim() {
+  return data.dim();
+}
+
+const char * VariableTensor::typeString() {
+  return "VariableType";
+}
+
+void * VariableTensor::unsafeGetTH(bool retain) {
+  return data.unsafeGetTH(retain);
+}
+
+IntList VariableTensor::strides() {
+  return data.strides();
+}
+
+Scalar VariableTensor::localScalar() {
+  return data.pImpl->localScalar();
+}
+
+void VariableTensor::assign_(Scalar s) {
+  data.assign_(s);
+}
+
+std::shared_ptr<Function> VariableTensor::get_grad_accumulator() {
   if (grad_fn) {
     throw std::logic_error("get_grad_accumulator() should be only called on leaf Variables");
   }
-  if (is_volatile) return nullptr;
+  if (!requires_grad) {
+    return nullptr;
+  }
 
   std::lock_guard<std::mutex> lock(grad_accumulator_lock);
 
   auto result = grad_accumulator.lock();
   if (result) return result;
 
-  result = std::make_shared<AccumulateGrad>(shared_from_this());
+  result = std::make_shared<AccumulateGrad>(Variable(this, true));
   grad_accumulator = result;
   return result;
 }
 
-auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) -> std::shared_ptr<Variable> {
-  if (!data.defined()) {
-    if (version) {
-      throw std::runtime_error(ERR_BACKWARD_TWICE);
+namespace {
+
+struct VariableTypes {
+  VariableTypes() {
+    auto& context = at::globalContext();
+    for (int p = 0; p < static_cast<int>(Backend::NumOptions); ++p) {
+      for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); s++) {
+        auto baseType = context.type_registry[p][s].get();
+        if (baseType) {
+          auto id = static_cast<int>(baseType->ID());
+          types[id].reset(new VariableType(&context, baseType));
+        }
+      }
     }
-    return nullptr;
   }
 
-  int current_version = **version;
-  if (expected_version != current_version) {
-    throw std::runtime_error("one of the variables "
-        "needed for gradient computation has been modified by an "
-        "inplace operation");
-  }
+  std::unique_ptr<Type> types[static_cast<int>(TypeID::NumOptions)];
+};
 
-  auto new_var = std::make_shared<Variable>(data, requires_grad, is_volatile);
-  if (has_grad_fn && !grad_fn) {
-    if (!saved_for) {
-      // If saving the grad_fn would create a circular reference, then it must
-      // be passed in to the unpack function.
-      throw std::runtime_error("No grad_fn for non-leaf saved variable");
-    }
-    new_var->grad_fn = saved_for;
-  } else {
-    new_var->grad_fn = grad_fn;
-  }
-  new_var->version_counter->join_with(*version);
-  // If a Variable is a leaf (no grad_fn saved), and it requires_grad, then we
-  // should have saved the grad accumulator. Even if the Variable no longer
-  // alive, the accumulator should be kept alive by the references in the graph).
-  if (requires_grad && !new_var->grad_fn && grad_accumulator.expired())
-    throw std::logic_error("No grad accumulator for a saved leaf!");
-  new_var->grad_accumulator = grad_accumulator;
-  if (tracing_state)
-    new_var->tracing_state.reset(new jit::tracer::ValueTracingState(*tracing_state));
+} // anonymous namespace
 
-  return new_var;
+Type* VariableTensor::getType(const Tensor& tensor)
+{
+  if (!tensor.defined()) {
+    throw std::runtime_error("tensor is undefined");
+  }
+  return getType(tensor.type());
 }
 
-const char* ERR_BACKWARD_TWICE =
-    "Trying to backward through the graph a second time, but the buffers have "
-    "already been freed. Specify retain_graph=True when calling backward "
-    "the first time.";
+Type* VariableTensor::getType(const Type& baseType)
+{
+  static VariableTypes vt;
+  return vt.types[static_cast<int>(baseType.ID())].get();
+}
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -7,7 +7,7 @@ using namespace at;
 
 namespace torch { namespace autograd {
 
-VariableTensor::VariableTensor(Tensor data_, bool requires_grad, bool is_volatile)
+VariableImpl::VariableImpl(Tensor data_, bool requires_grad, bool is_volatile)
   : TensorImpl(getType(data_))
   , data(std::move(data_))
   , grad()
@@ -21,55 +21,55 @@ VariableTensor::VariableTensor(Tensor data_, bool requires_grad, bool is_volatil
   }
 }
 
-VariableTensor::VariableTensor(Tensor data, std::shared_ptr<Function> grad_fn)
-  : VariableTensor(std::move(data))
+VariableImpl::VariableImpl(Tensor data, std::shared_ptr<Function> grad_fn)
+  : VariableImpl(std::move(data))
 {
   this->grad_fn = grad_fn;
   requires_grad = grad_fn->is_executable;
   output_nr = grad_fn->num_inputs++;
 }
 
-VariableTensor::VariableTensor(Tensor data)
-  : VariableTensor(std::move(data), false, false)
+VariableImpl::VariableImpl(Tensor data)
+  : VariableImpl(std::move(data), false, false)
 {
 }
 
-VariableTensor::~VariableTensor() {
+VariableImpl::~VariableImpl() {
 }
 
-const char * VariableTensor::toString() const {
+const char * VariableImpl::toString() const {
   return "Variable";
 }
 
-IntList VariableTensor::sizes() {
+IntList VariableImpl::sizes() {
   return data.sizes();
 }
 
-int64_t VariableTensor::dim() {
+int64_t VariableImpl::dim() {
   return data.dim();
 }
 
-const char * VariableTensor::typeString() {
+const char * VariableImpl::typeString() {
   return "VariableType";
 }
 
-void * VariableTensor::unsafeGetTH(bool retain) {
+void * VariableImpl::unsafeGetTH(bool retain) {
   return data.unsafeGetTH(retain);
 }
 
-IntList VariableTensor::strides() {
+IntList VariableImpl::strides() {
   return data.strides();
 }
 
-Scalar VariableTensor::localScalar() {
+Scalar VariableImpl::localScalar() {
   return data.pImpl->localScalar();
 }
 
-void VariableTensor::assign_(Scalar s) {
+void VariableImpl::assign_(Scalar s) {
   data.assign_(s);
 }
 
-std::shared_ptr<Function> VariableTensor::get_grad_accumulator() {
+std::shared_ptr<Function> VariableImpl::get_grad_accumulator() {
   if (grad_fn) {
     throw std::logic_error("get_grad_accumulator() should be only called on leaf Variables");
   }
@@ -108,7 +108,7 @@ struct VariableTypes {
 
 } // anonymous namespace
 
-Type* VariableTensor::getType(const Tensor& tensor)
+Type* VariableImpl::getType(const Tensor& tensor)
 {
   if (!tensor.defined()) {
     throw std::runtime_error("tensor is undefined");
@@ -116,7 +116,7 @@ Type* VariableTensor::getType(const Tensor& tensor)
   return getType(tensor.type());
 }
 
-Type* VariableTensor::getType(const Type& baseType)
+Type* VariableImpl::getType(const Type& baseType)
 {
   static VariableTypes vt;
   return vt.types[static_cast<int>(baseType.ID())].get();

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -20,10 +20,10 @@
 namespace torch { namespace autograd {
 
 using at::Tensor;
-struct VariableTensor;
+struct VariableImpl;
 
 struct Variable : public at::Tensor {
-  inline Variable(VariableTensor * self, bool retain);
+  inline Variable(VariableImpl * self, bool retain);
   Variable() : Tensor() {}
   Variable(const Variable & rhs) : Tensor(rhs) {}
   Variable(Variable && rhs) noexcept : Tensor(std::move(rhs)) {}
@@ -31,7 +31,7 @@ struct Variable : public at::Tensor {
   explicit Variable(Tensor const & rhs) : Tensor(rhs) {}
   explicit Variable(Tensor && rhs) noexcept : Tensor(std::move(rhs)) {}
 
-  inline VariableTensor* get() const;
+  inline VariableImpl* get() const;
 
   inline const Tensor & data() const;
   inline       Tensor & data();
@@ -67,12 +67,12 @@ struct Variable : public at::Tensor {
   operator Tensor() const { return Tensor(pImpl, true); }
 };
 
-struct VariableTensor : public at::TensorImpl {
+struct VariableImpl : public at::TensorImpl {
 public:
-  explicit VariableTensor(at::Tensor data);
-  VariableTensor(at::Tensor data, std::shared_ptr<Function> grad_fn);
-  VariableTensor(at::Tensor data, bool requires_grad, bool is_volatile=false);
-  virtual ~VariableTensor();
+  explicit VariableImpl(at::Tensor data);
+  VariableImpl(at::Tensor data, std::shared_ptr<Function> grad_fn);
+  VariableImpl(at::Tensor data, bool requires_grad, bool is_volatile=false);
+  virtual ~VariableImpl();
   virtual const char * toString() const override;
   virtual at::IntList sizes() override;
   virtual at::IntList strides() override;
@@ -110,11 +110,11 @@ public:
   friend struct VariableType;
 };
 
-inline Variable::Variable(VariableTensor * self, bool retain) : Tensor(self, retain) {
+inline Variable::Variable(VariableImpl * self, bool retain) : Tensor(self, retain) {
 }
 
-inline VariableTensor* Variable::get() const {
-  return static_cast<VariableTensor*>(pImpl);
+inline VariableImpl* Variable::get() const {
+  return static_cast<VariableImpl*>(pImpl);
 }
 
 inline const Tensor & Variable::data() const {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -1,8 +1,12 @@
 #pragma once
 
+// A wrapper around at::Tensor to represent autograd Variables. Variables
+// can be implicitly converted to an at::Tensor.
+
 #include <Python.h>
 #include <mutex>
 #include <memory>
+#include <vector>
 #include <functional>
 #include <ATen/ATen.h>
 
@@ -15,88 +19,79 @@
 
 namespace torch { namespace autograd {
 
-struct Function;
+using at::Tensor;
+struct VariableTensor;
 
-extern const char* ERR_BACKWARD_TWICE;
+struct Variable : public at::Tensor {
+  inline Variable(VariableTensor * self, bool retain);
+  Variable() : Tensor() {}
+  Variable(const Variable & rhs) : Tensor(rhs) {}
+  Variable(Variable && rhs) noexcept : Tensor(std::move(rhs)) {}
 
-struct Variable : std::enable_shared_from_this<Variable> {
-  struct SavedVariable {
-    SavedVariable()
-      : data()
-      , version()
-      , expected_version(-1) {}
+  explicit Variable(Tensor const & rhs) : Tensor(rhs) {}
+  explicit Variable(Tensor && rhs) noexcept : Tensor(std::move(rhs)) {}
 
-    SavedVariable(Variable& variable, bool with_grad_fn)
-      : data(variable.data)
-      , has_grad_fn(variable.grad_fn != nullptr)
-      , grad_fn(with_grad_fn ? variable.grad_fn : nullptr)
-      , grad_accumulator(variable.grad_accumulator)
-      , version(variable.version_counter->new_saved_ref())
-      , requires_grad(variable.requires_grad)
-      , is_volatile(false)
-      , expected_version(**variable.version_counter) {
-      if (variable.tracing_state) {
-        tracing_state.reset(new jit::tracer::ValueTracingState(*variable.tracing_state));
-      }
-    }
+  inline VariableTensor* get() const;
 
-    at::Tensor data;
-    // The gradient function associated with this node. If has_grad_fn
-    // is false, then this is a leaf node. Note that the grad_fn is not saved if
-    // it would create a circular reference. In that case, the grad_fn must be
-    // passed in to the unpack function when reconstructing the Variable.
-    bool has_grad_fn;
-    std::shared_ptr<Function> grad_fn;
-    std::weak_ptr<Function> grad_accumulator;
-    std::unique_ptr<VariableVersion> version;
-    bool requires_grad;
-    bool is_volatile;
-    int expected_version;
-    std::unique_ptr<jit::tracer::ValueTracingState> tracing_state;
+  inline const Tensor & data() const;
+  inline       Tensor & data();
 
-    std::shared_ptr<Variable> unpack(std::shared_ptr<Function> saved_for=nullptr);
+  inline Tensor opt_data() const;
 
-    at::Tensor unpack_data(std::shared_ptr<Function> saved_for=nullptr) {
-      auto var = unpack(saved_for);
-      return var ? var->data : at::Tensor();
-    }
-  };
+  inline const Variable & grad() const;
+  inline       Variable & grad();
 
-  // WARNING: this registers the Variable as a new output
-  Variable(
-      at::Tensor data,
-      std::shared_ptr<Function> grad_fn);
+  inline const std::shared_ptr<Function>& grad_fn() const;
+  inline       std::shared_ptr<Function>& grad_fn();
 
-  Variable(
-      at::Tensor data,
-      bool requires_grad,
-      bool is_volatile);
+  std::shared_ptr<Function> grad_accumulator() const;
 
+  inline const std::vector<std::shared_ptr<FunctionPreHook>>& hooks() const;
+  inline       std::vector<std::shared_ptr<FunctionPreHook>>& hooks();
+
+  inline auto_unique_ptr<jit::tracer::ValueTracingState>& tracing_state() const;
+
+  inline int current_version() const;
+  inline int output_nr() const;
+
+  inline bool requires_grad() const;
+  inline void set_requires_grad(bool requires_grad);
+
+  inline bool is_volatile() const;
+  inline void set_volatile(bool is_volatile);
+
+  inline Variable & operator=(Variable && rhs) &;
+  inline Variable & operator=(const Variable & rhs) &;
+
+  // implicit conversion to Tensor
+  operator Tensor() const { return Tensor(pImpl, true); }
+};
+
+struct VariableTensor : public at::TensorImpl {
+public:
+  explicit VariableTensor(at::Tensor data);
+  VariableTensor(at::Tensor data, std::shared_ptr<Function> grad_fn);
+  VariableTensor(at::Tensor data, bool requires_grad, bool is_volatile=false);
+  virtual ~VariableTensor();
+  virtual const char * toString() const override;
+  virtual at::IntList sizes() override;
+  virtual at::IntList strides() override;
+  virtual int64_t dim() override;
+  virtual at::Scalar localScalar() override;
+  virtual void assign_(at::Scalar s) override;
+  virtual void * unsafeGetTH(bool retain) override;
+  static const char * typeString();
+
+  // Get the VariableType for a base Tensor type
+  static at::Type* getType(const at::Type& baseType);
+  static at::Type* getType(const at::Tensor& tensor);
+
+public:
   std::shared_ptr<Function> get_grad_accumulator();
 
-  inline SavedVariable save(Function* saved_for) {
-    return SavedVariable(*this, grad_fn.get() != saved_for);
-  }
-
-  inline SavedVariable save(bool with_grad_fn) {
-    return SavedVariable(*this, with_grad_fn);
-  }
-
-  static inline SavedVariable save_opt(Variable* var, Function* saved_for) {
-    return var ? var->save(saved_for) : SavedVariable();
-  }
-
-  // TODO: should be at::Tensor&& if we are taking ownership?
-  static inline std::shared_ptr<Variable> of(at::Tensor data, bool is_volatile=false) {
-    if (!data.defined()) {
-      return std::shared_ptr<Variable>();
-    }
-    return std::make_shared<Variable>(data, false, is_volatile);
-  }
-
   at::Tensor data;
+  Variable grad;
   std::shared_ptr<Function> grad_fn;
-  std::shared_ptr<Variable> grad;
   std::unique_ptr<VariableVersion> version_counter;
   std::vector<std::shared_ptr<FunctionPreHook>> hooks;
   std::weak_ptr<Function> grad_accumulator;
@@ -112,8 +107,87 @@ struct Variable : std::enable_shared_from_this<Variable> {
 
   // For use in torch::jit::tracer
   auto_unique_ptr<jit::tracer::ValueTracingState> tracing_state;
+  friend struct VariableType;
 };
 
-using SavedVariable = Variable::SavedVariable;
+inline Variable::Variable(VariableTensor * self, bool retain) : Tensor(self, retain) {
+}
+
+inline VariableTensor* Variable::get() const {
+  return static_cast<VariableTensor*>(pImpl);
+}
+
+inline const Tensor & Variable::data() const {
+  return get()->data;
+}
+inline Tensor & Variable::data() {
+  return get()->data;
+}
+
+inline Tensor Variable::opt_data() const {
+  if (!defined()) {
+    return Tensor();
+  }
+  return data();
+}
+
+inline const Variable & Variable::grad() const {
+  return get()->grad;
+}
+inline Variable & Variable::grad() {
+  return get()->grad;
+}
+
+inline const std::shared_ptr<Function>& Variable::grad_fn() const {
+  return get()->grad_fn;
+};
+inline std::shared_ptr<Function>& Variable::grad_fn() {
+  return get()->grad_fn;
+};
+inline std::shared_ptr<Function> Variable::grad_accumulator() const {
+  return get()->get_grad_accumulator();
+};
+
+inline const std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks() const {
+  return get()->hooks;
+};
+inline std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks() {
+  return get()->hooks;
+};
+
+inline auto_unique_ptr<jit::tracer::ValueTracingState>& Variable::tracing_state() const {
+  return get()->tracing_state;
+};
+
+inline int Variable::current_version() const {
+  return **get()->version_counter;
+}
+
+inline int Variable::output_nr() const {
+  return get()->output_nr;
+}
+
+inline bool Variable::requires_grad() const {
+  return get()->requires_grad;
+}
+inline void Variable::set_requires_grad(bool requires_grad) {
+  get()->requires_grad = requires_grad;
+}
+
+inline bool Variable::is_volatile() const {
+  return get()->is_volatile;
+}
+inline void Variable::set_volatile(bool is_volatile) {
+  get()->is_volatile = is_volatile;
+}
+
+inline Variable & Variable::operator=(Variable && rhs) & {
+  rhs.swap(*this);
+  return *this;
+}
+inline Variable & Variable::operator=(const Variable & rhs) & {
+  Variable(rhs).swap(*this);
+  return *this;
+}
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -54,11 +54,11 @@ struct Variable : public at::Tensor {
   inline int current_version() const;
   inline int output_nr() const;
 
-  inline bool requires_grad() const;
-  inline void set_requires_grad(bool requires_grad);
+  inline const bool& requires_grad() const;
+  inline       bool& requires_grad();
 
-  inline bool is_volatile() const;
-  inline void set_volatile(bool is_volatile);
+  inline const bool& is_volatile() const;
+  inline       bool& is_volatile();
 
   inline Variable & operator=(Variable && rhs) &;
   inline Variable & operator=(const Variable & rhs) &;
@@ -167,18 +167,18 @@ inline int Variable::output_nr() const {
   return get()->output_nr;
 }
 
-inline bool Variable::requires_grad() const {
+inline const bool& Variable::requires_grad() const {
   return get()->requires_grad;
 }
-inline void Variable::set_requires_grad(bool requires_grad) {
-  get()->requires_grad = requires_grad;
+inline bool& Variable::requires_grad() {
+  return get()->requires_grad;
 }
 
-inline bool Variable::is_volatile() const {
+inline const bool& Variable::is_volatile() const {
   return get()->is_volatile;
 }
-inline void Variable::set_volatile(bool is_volatile) {
-  get()->is_volatile = is_volatile;
+inline bool& Variable::is_volatile() {
+  return get()->is_volatile;
 }
 
 inline Variable & Variable::operator=(Variable && rhs) & {

--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace torch { namespace autograd {
 
 struct VariableVersion {
@@ -51,4 +53,3 @@ struct VariableVersion {
 };
 
 }} // namespace torch::autograd
-

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -27,7 +27,7 @@ namespace pybind11 { namespace detail {
     bool load(handle src, bool) {
       PyObject *source = src.ptr();
       if (THPVariable_Check(source)) {
-        value = TraceInput(Variable(((THPVariable*)source)->cdata, true));
+        value = TraceInput(((THPVariable*)source)->cdata);
         return true;
       } else if (THPModule_isTensor(source)) {
         value = TraceInput(torch::createTensor(source));
@@ -51,7 +51,7 @@ namespace pybind11 { namespace detail {
     bool load(handle src, bool) {
       PyObject *source = src.ptr();
       if (THPVariable_Check(source)) {
-        value = Variable(((THPVariable*)source)->cdata, true);
+        value = ((THPVariable*)source)->cdata;
         return true;
       } else {
         return false;

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -27,7 +27,7 @@ namespace pybind11 { namespace detail {
     bool load(handle src, bool) {
       PyObject *source = src.ptr();
       if (THPVariable_Check(source)) {
-        value = TraceInput(((THPVariable*)source)->cdata);
+        value = TraceInput(Variable(((THPVariable*)source)->cdata, true));
         return true;
       } else if (THPModule_isTensor(source)) {
         value = TraceInput(torch::createTensor(source));
@@ -37,7 +37,7 @@ namespace pybind11 { namespace detail {
       }
     }
     static handle cast(TraceInput src, return_value_policy /* policy */, handle /* parent */) {
-      if (src.variable) {
+      if (src.variable.defined()) {
         return handle(THPVariable_Wrap(src.variable));
       } else {
         return handle(torch::createPyObject(src.buffer));
@@ -45,19 +45,19 @@ namespace pybind11 { namespace detail {
     }
   };
 
-  template<> struct type_caster<std::shared_ptr<Variable>> {
+  template<> struct type_caster<Variable> {
   public:
-    PYBIND11_TYPE_CASTER(std::shared_ptr<Variable>, _("torch::autograd::Variable"));
+    PYBIND11_TYPE_CASTER(Variable, _("torch::autograd::Variable"));
     bool load(handle src, bool) {
       PyObject *source = src.ptr();
       if (THPVariable_Check(source)) {
-        value = ((THPVariable*)source)->cdata;
+        value = Variable(((THPVariable*)source)->cdata, true);
         return true;
       } else {
         return false;
       }
     }
-    static handle cast(std::shared_ptr<Variable> src, return_value_policy /* policy */, handle /* parent */) {
+    static handle cast(Variable src, return_value_policy /* policy */, handle /* parent */) {
       return handle(THPVariable_Wrap(src));
     }
   };

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -53,7 +53,7 @@ struct TraceEval : autograd::Eval {
       JIT_ASSERT(!detail::getValueState(tracing_state, input, false));
       Node *input_node = graph->addInput();
       setValueTrace(tracing_state, input, input_node);
-      input_node->inferTypeFrom(input->data);
+      input_node->inferTypeFrom(input.data());
     }
     tracing_state->var_flags.at(graph->stage()) = detail::getVarFlags(inputs);
   }
@@ -84,10 +84,10 @@ void traceBackward(const std::shared_ptr<TracingState>& tracing_state, const var
 
 } // namespace detail
 
-VariableFlags VariableFlags::create(const std::shared_ptr<Variable>& var) {
+VariableFlags VariableFlags::create(const Variable& var) {
   VariableFlags f;
-  f.requires_grad = var->requires_grad;
-  f.is_volatile = var->is_volatile;
+  f.requires_grad = var.requires_grad();
+  f.is_volatile = var.is_volatile();
   return f;
 }
 

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -20,7 +20,7 @@ namespace torch { namespace jit { namespace tracer {
 
 using torch::autograd::Variable;
 using torch::autograd::Function;
-using variable_list = std::vector<std::shared_ptr<Variable>>;
+using variable_list = std::vector<Variable>;
 using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 
 // TracingState tracks the necessary state when we are tracing the execution of
@@ -34,7 +34,7 @@ using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 // actual trace itself.
 
 struct VariableFlags {
-  static VariableFlags create(const std::shared_ptr<Variable>& var);
+  static VariableFlags create(const Variable& var);
 
   bool requires_grad;
   bool is_volatile;


### PR DESCRIPTION
Variable is now a subclass of `at::Tensor` backed by a `VariableTensor* pImpl`. The implementation of the ATen functions is defined in the auto-generated VariableType.h/cpp file.

Currently, only functions which delegate to the base type (such as `sizes()` and `isCuda()`) are implemented on VariableType. Differentiable ops like `add()` and `mul()` will be added in a subsequent PR.