### PR TITLE
Combine autograd function and method tests, preferring method tests

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1485,6 +1485,36 @@ class TestAutograd(TestCase):
         out.sum().backward()
         self.assertEqual(x.grad.data, y_data)
 
+    def test_cat(self):
+        f_args_variable = (Variable(torch.randn(1, S, S), requires_grad=True),
+                           Variable(torch.randn(2, S, S), requires_grad=True),
+                           Variable(torch.randn(3, S, S), requires_grad=True),
+                           0)
+        f_args_tensor = deepcopy(unpack_variables(f_args_variable))
+        run_functional_checks(self, "test_cat",
+                              lambda a, b, c, dim: torch.cat((a, b, c), dim),
+                              True, f_args_variable, f_args_tensor)
+
+    def test_cat_negdim_1(self):
+        f_args_variable = (Variable(torch.randn(S, S, 1), requires_grad=True),
+                           Variable(torch.randn(S, S, 2), requires_grad=True),
+                           Variable(torch.randn(S, S, 3), requires_grad=True),
+                           -1)
+        f_args_tensor = deepcopy(unpack_variables(f_args_variable))
+        run_functional_checks(self, "test_cat_negdim_1",
+                              lambda a, b, c, dim: torch.cat((a, b, c), dim),
+                              True, f_args_variable, f_args_tensor)
+
+    def test_cat_negdim_2(self):
+        f_args_variable = (Variable(torch.randn(S, 1, S), requires_grad=True),
+                           Variable(torch.randn(S, 2, S), requires_grad=True),
+                           Variable(torch.randn(S, 3, S), requires_grad=True),
+                           -2)
+        f_args_tensor = deepcopy(unpack_variables(f_args_variable))
+        run_functional_checks(self, "test_cat_negdim_2",
+                              lambda a, b, c, dim: torch.cat((a, b, c), dim),
+                              True, f_args_variable, f_args_tensor)
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):
@@ -2138,6 +2168,25 @@ def run_grad_and_gradgrad_checks(test_case, test_name, apply_method, output_vari
     else:
         test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y,))
 
+
+def run_functional_checks(test_case, test_name, apply_fn, run_grad_checks,
+                          f_args_variable, f_args_tensor):
+    output_variable = apply_fn(*f_args_variable)
+    output_tensor = apply_fn(*f_args_tensor)
+    if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
+        output_tensor = torch.DoubleTensor((output_tensor,))
+    test_case.assertEqual(unpack_variables(output_variable), output_tensor)
+
+    if run_grad_checks:
+        run_grad_and_gradgrad_checks(test_case, test_name, apply_fn,
+                                     output_variable, f_args_variable)
+
+    self_variable = f_args_variable[0]
+    if isinstance(output_variable, torch.autograd.Variable) and self_variable is not None:
+        output_variable.backward(torch.randn(*output_variable.size()).type_as(output_variable.data))
+        test_case.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
+        test_case.assertTrue(self_variable.size() == self_variable.grad.size())
+
 for test in method_tests:
     name, self_size, args = test[:3]
     basic_test_name = 'test_' + name + ('_' + test[3] if len(test) >= 4 else '')
@@ -2179,19 +2228,9 @@ for test in method_tests:
                         not exclude_tensor_method(name, test_name)):
                     f_args_variable = (self_variable,) + args_variable
                     f_args_tensor = (self_tensor,) + args_tensor
-                    output_variable = getattr(torch, name)(*f_args_variable)
-                    output_tensor = getattr(torch, name)(*f_args_tensor)
-                    if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
-                        output_tensor = torch.DoubleTensor((output_tensor,))
-                    self.assertEqual(unpack_variables(output_variable), output_tensor)
-
-                    if name not in EXCLUDE_GRADCHECK:
-                        run_grad_and_gradgrad_checks(self, test_name, lambda *inputs: getattr(torch, name)(*inputs),
-                                                     output_variable, f_args_variable)
-                    if isinstance(output_variable, torch.autograd.Variable):
-                        output_variable.backward(torch.randn(*output_variable.size()).type_as(output_variable.data))
-                        self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
-                        self.assertTrue(self_variable.size() == self_variable.grad.size())
+                    run_functional_checks(self, test_name,
+                                          lambda *inputs: getattr(torch, name)(*inputs),
+                                          name not in EXCLUDE_GRADCHECK, f_args_variable, f_args_tensor)
 
                 # check for correct type of input.data and input.grad.data
                 if not is_inplace:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1491,7 +1491,7 @@ class TestAutograd(TestCase):
                            Variable(torch.randn(3, S, S), requires_grad=True),
                            0)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
-        run_functional_checks(self, "test_cat",
+        run_functional_checks(self, "test_cat", "cat",
                               lambda a, b, c, dim: torch.cat((a, b, c), dim),
                               True, f_args_variable, f_args_tensor)
 
@@ -1501,7 +1501,7 @@ class TestAutograd(TestCase):
                            Variable(torch.randn(S, S, 3), requires_grad=True),
                            -1)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
-        run_functional_checks(self, "test_cat_negdim_1",
+        run_functional_checks(self, "test_cat_negdim_1", "cat",
                               lambda a, b, c, dim: torch.cat((a, b, c), dim),
                               True, f_args_variable, f_args_tensor)
 
@@ -1511,7 +1511,7 @@ class TestAutograd(TestCase):
                            Variable(torch.randn(S, 3, S), requires_grad=True),
                            -2)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
-        run_functional_checks(self, "test_cat_negdim_2",
+        run_functional_checks(self, "test_cat_negdim_2", "cat",
                               lambda a, b, c, dim: torch.cat((a, b, c), dim),
                               True, f_args_variable, f_args_tensor)
 
@@ -1579,11 +1579,6 @@ class dont_convert(tuple):
 L = 20
 M = 10
 S = 5
-function_tests = [
-    (Concat, (), (0, (1, S, S), (2, S, S), (3, S, S))),
-    (Concat, (), (-1, (S, S, 1), (S, S, 2), (S, S, 3)), 'negdim-1'),
-    (Concat, (), (-2, (S, 1, S), (S, 2, S), (S, 3, S)), 'negdim-2'),
-]
 
 
 # (name, size, args...)
@@ -1987,119 +1982,6 @@ def generate_gradoutput(dummy_out, non_contiguous=False):
 
     return grad_y
 
-ignore_inplace = set((
-    'test_DivConstantFunction_by_tensor',
-
-))
-
-# these are just empirical observations, we should improve
-gradgradcheck_precision_override = {
-    'test_NormFunction_1_5': {'atol': 1.5e-2, 'rtol': 1e-2},
-    'test_NormFunction_2': {'atol': 2e-2, 'rtol': 1e-2},
-    'test_NormFunction_3': {'atol': 5e-2, 'rtol': 1e-2},
-}
-
-for test in function_tests:
-    cls, constructor_args, call_args = test[:3]
-    basic_test_name = 'test_{}Function'.format(cls.__name__)
-    if len(test) >= 4:
-        basic_test_name += '_' + test[3]
-
-    dim_args_idx = test[4] if len(test) == 5 else []
-
-    skipTestIf = test[5] if len(test) == 6 else []
-
-    for dim_perm in product([-1, 1], repeat=len(dim_args_idx)):
-        test_name = basic_test_name + ''.join('_neg' + str(i) for i, idx in enumerate(dim_perm) if idx < 0)
-
-        def make_neg_dims(args):
-            for i in dim_args_idx:
-                assert isinstance(args[i], int), test_name
-            return tuple(arg * dim_perm[dim_args_idx.index(i)] if i in dim_args_idx else arg
-                         for i, arg in enumerate(args))
-        if cls._is_legacy:
-            new_constructor_args = make_neg_dims(constructor_args)
-            new_call_args = call_args
-        else:
-            assert len(constructor_args) == 0, test_name
-            new_constructor_args = constructor_args
-            new_call_args = make_neg_dims(call_args)
-
-        def do_test(self, cls=cls, constructor_args=new_constructor_args,
-                    call_args=new_call_args, test_name=test_name):
-            input = create_input(call_args, non_contiguous="View" not in cls.__name__)
-            if cls._is_legacy:
-                def apply_fn(*input):
-                    return cls(*constructor_args)(*input)
-
-                def apply_inplace_fn(*input):
-                    return cls(*constructor_args, inplace=True)(*input)
-            else:
-                def apply_fn(*input):
-                    return cls.apply(*input)
-
-                def apply_inplace_fn(*input):
-                    args = input + (True,)  # for Python 2.7
-                    return cls.apply(*args)
-            self.assertTrue(gradcheck(apply_fn, input, eps=1e-6, atol=PRECISION))
-
-            # check for correct type of input.data and input.grad.data
-            output = apply_fn(*input)
-            if isinstance(output, torch.autograd.Variable):
-                output.backward(torch.randn(*output.size()).type_as(output.data))
-                for inp in input:
-                    if isinstance(inp, torch.autograd.Variable) and inp.grad is not None:
-                        self.assertTrue(type(inp.data) == type(inp.grad.data))
-                        self.assertTrue(inp.size() == inp.grad.size())
-
-            dummy_out = apply_fn(*input)
-            grad_y = generate_gradoutput(dummy_out, non_contiguous=True)
-
-            if test_name in gradgradcheck_precision_override:
-                atol = gradgradcheck_precision_override[test_name]['atol']
-                rtol = gradgradcheck_precision_override[test_name]['rtol']
-                self.assertTrue(gradgradcheck(apply_fn, input, grad_y, atol=atol, rtol=rtol))
-            else:
-                self.assertTrue(gradgradcheck(apply_fn, input, grad_y,))
-
-            # can't broadcast inplace to left hand side
-            broadcast_skip_inplace = 'broadcast_lhs' in test_name or 'broadcast_all' in test_name
-            if test_name not in ignore_inplace and not broadcast_skip_inplace and issubclass(cls, InplaceFunction):
-                output = apply_fn(*input)
-                if not isinstance(output, tuple):
-                    output = (output,)
-                inplace_input = deepcopy(input)
-                inplace_input_copy = tuple(i + 0 if i is not None else None for i in inplace_input)
-                inplace_output = apply_inplace_fn(*inplace_input_copy)
-                if not isinstance(inplace_output, tuple):
-                    inplace_output = (inplace_output,)
-                self.assertEqual(inplace_output, output)
-                # Check that gradient is the same
-                for inp_i, i in zip(inplace_input, input):
-                    if not isinstance(inp_i, Variable):
-                        assert not isinstance(i, Variable)
-                        continue
-                    if inp_i.grad is not None:
-                        inp_i.grad.data.zero_()
-                    if i.grad is not None:
-                        i.grad.data.zero_()
-                for io, o in zip(inplace_output, output):
-                    grad = torch.randn(*io.size()).double()
-                    io.backward(grad)
-                    o.backward(grad)
-                for inp_i, i in zip(inplace_input, input):
-                    if not isinstance(inp_i, Variable):
-                        continue
-                    self.assertEqual(inp_i.grad, i.grad)
-
-        assert not hasattr(TestAutograd, test_name), 'Two tests have the same name: ' + test_name
-
-        for skip in skipTestIf:
-            do_test = skip(do_test)
-
-        setattr(TestAutograd, test_name, do_test)
-
-
 EXCLUDE_FUNCTIONAL = {
     'addmm',
     'addbmm',
@@ -2150,8 +2032,10 @@ def gradgradcheck_method_precision_override(test_name):
     override = gradgradcheck_precision_override.get(non_broadcasted_test_name)
     if override:
         if 'broadcast_lhs' in test_name or 'broadcast_rhs' in test_name:
+            # errors accumulated across 1 dimension
             override = {'atol': override['atol'] * S, 'rtol': override['atol'] * S}
         elif 'broadcast_all' in test_name:
+            # errors accumulated across multiple dimensions
             override = {'atol': override['atol'] * S * S, 'rtol': override['atol'] * S * S}
     return override
 
@@ -2169,13 +2053,14 @@ def run_grad_and_gradgrad_checks(test_case, test_name, apply_method, output_vari
         test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y,))
 
 
-def run_functional_checks(test_case, test_name, apply_fn, run_grad_checks,
+def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
                           f_args_variable, f_args_tensor):
     output_variable = apply_fn(*f_args_variable)
-    output_tensor = apply_fn(*f_args_tensor)
-    if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
-        output_tensor = torch.DoubleTensor((output_tensor,))
-    test_case.assertEqual(unpack_variables(output_variable), output_tensor)
+    if not exclude_tensor_method(name, test_name):
+        output_tensor = apply_fn(*f_args_tensor)
+        if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
+            output_tensor = torch.DoubleTensor((output_tensor,))
+        test_case.assertEqual(unpack_variables(output_variable), output_tensor)
 
     if run_grad_checks:
         run_grad_and_gradgrad_checks(test_case, test_name, apply_fn,
@@ -2205,9 +2090,8 @@ for test in method_tests:
             def check(name):
                 is_rhs_operator = name[:3] == "__r" and name[-2:] == "__"
                 is_inplace = name[-1] == "_" and not is_rhs_operator
-                requires_grad = False if is_inplace else True
-                self_variable = create_input((self_size,), requires_grad=requires_grad)[0]
-                args_variable = create_input(args, requires_grad=requires_grad)
+                self_variable = create_input((self_size,), requires_grad=not is_inplace)[0]
+                args_variable = create_input(args, requires_grad=not is_inplace)
                 self_tensor = deepcopy(self_variable.data)
                 args_tensor = deepcopy(unpack_variables(args_variable))
                 output_variable = getattr(self_variable, name)(*args_variable)
@@ -2224,13 +2108,13 @@ for test in method_tests:
                                                  output_variable, (self_variable,) + args_variable)
 
                 # functional interface tests
-                if (hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL and
-                        not exclude_tensor_method(name, test_name)):
+                if hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL:
                     f_args_variable = (self_variable,) + args_variable
                     f_args_tensor = (self_tensor,) + args_tensor
-                    run_functional_checks(self, test_name,
+                    # could run the gradchecks again, but skip since we did it for the methods above.
+                    run_functional_checks(self, test_name, name,
                                           lambda *inputs: getattr(torch, name)(*inputs),
-                                          name not in EXCLUDE_GRADCHECK, f_args_variable, f_args_tensor)
+                                          False, f_args_variable, f_args_tensor)
 
                 # check for correct type of input.data and input.grad.data
                 if not is_inplace:
@@ -2259,7 +2143,7 @@ for test in method_tests:
 
                         try:
                             inplace_output_variable = (
-                                getattr(*inplace_self_variable_copy, inplace_name)(*inplace_args_variable_copy))
+                                getattr(inplace_self_variable_copy[0], inplace_name)(*inplace_args_variable_copy))
                         except RuntimeError as err:
                             if 'only supports scalar multiplication' in str(err):
                                 return

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1822,50 +1822,55 @@ method_tests = [
     ('add', (S, S), ((S, S, S),), 'broadcast_lhs'),
     ('add', (S, 1, S), ((M, S),), 'broadcast_all'),
     ('add', (S, S, S), (3.14,), 'constant'),
+    ('__radd__', (S, S, S), (3.14,), 'constant'),
     ('sub', (S, S, S), ((S, S, S),)),
     ('sub', (S, S, S), ((S, S),), 'broadcast_rhs'),
     ('sub', (S, S), ((S, S, S),), 'broadcast_lhs'),
     ('sub', (S, 1, S), ((M, S),), 'broadcast_all'),
     ('sub', (S, S, S), (3.14,), 'constant'),
+    ('__rsub__', (S, S, S), (3.14,), 'constant'),
     ('mul', (S, S, S), ((S, S, S),)),
     ('mul', (S, S, S), ((S, S),), 'broadcast_rhs'),
     ('mul', (S, S), ((S, S, S),), 'broadcast_lhs'),
     ('mul', (S, 1, S), ((M, S),), 'broadcast_all'),
     ('mul', (S, S, S), (3.14,), 'constant'),
-    ('div', (S, S, S), ((S, S, S),)),
-    ('div', (S, S, S), ((S, S),), 'broadcast_rhs'),
-    ('div', (S, S), ((S, S, S),), 'broadcast_lhs'),
-    ('div', (S, 1, S), ((M, S),), 'broadcast_all'),
-    ('div', (S, S, S), (3.14,), 'constant'),
-    ('pow', (S, S, S), ((S, S, S),)),
-    ('pow', (S, S, S), ((1,),), 'broadcast_rhs'),
-    ('pow', (1,), ((S, S, S),), 'broadcast_lhs'),
-    ('pow', (S, 1, S), ((1, S, 1),), 'broadcast_all'),
-    ('pow', (S, S, S), (3.14,), 'constant'),
+    ('__rmul__', (S, S, S), (3.14,), 'constant'),
+    ('div', (S, S, S), (torch.rand(S, S, S) + 0.1,)),
+    ('div', (S, S, S), (torch.rand(S, S) + 0.1,), 'broadcast_rhs'),
+    ('div', (S, S), (torch.rand(S, S, S) + 0.1,), 'broadcast_lhs'),
+    ('div', (S, 1, S), (torch.rand(M, S) + 0.1,), 'broadcast_all'),
+    ('div', torch.rand(S, S, S) + 1e-1, (3.14,), 'constant'),
+    ('__rdiv__', torch.rand(S, S, S) + 1e-1, (3.14,), 'constant'),
+    ('pow', torch.rand(S, S, S) + 1e-3, (torch.rand(S, S, S) + 0.1,)),
+    ('pow', torch.rand(S, S, S) + 1e-3, (torch.rand(1,) + 0.1,), 'broadcast_rhs'),
+    ('pow', torch.rand(1,) + 1e-3, (torch.rand(S, S, S) + 0.1,), 'broadcast_lhs'),
+    ('pow', torch.rand(S, 1, S) + 1e-3, (torch.rand(1, S, 1) + 0.1,), 'broadcast_all'),
+    ('pow', torch.rand(S, S, S) + 1e-3, (3.14,), 'constant'),
+    ('__rpow__', torch.rand(S, S, S) + 1e-3, (3.14,), 'constant'),
     ('transpose', (1, 2, 3), (1, 2), 'dim', [0, 1]),
     ('t', (1, 2), ()),
     ('view', (S, S, S), (S * S, S),),
-    ('view_as', (S, S, S), ((S * S, S),)),
+    ('view_as', (S, S, S), (Variable(torch.rand(S * S, S), requires_grad=False),)),
     ('expand', (S, 1, 1), (S, S, S)),
     ('expand', (torch.Size([S, 1, S]),), (S, S, S), 'size'),
     ('expand', (S, 1), (S, S, S), 'new_dim'),
     ('expand', (1,), (S, S, S), 'scalar'),
     ('expand', (1, S), (1, 1, S), 'new_dim_front_old_front_1'),
     ('exp', (S, S, S), ()),
-    ('log', (S, S, S), ()),
-    ('log1p', (S, S, S), ()),
+    ('log', torch.rand(S, S, S) + 1e-2, ()),
+    ('log1p', torch.rand(S, S, S), ()),
     ('tanh', (S, S, S), ()),
     ('sigmoid', (S, S, S), ()),
     ('sinh', (S, S, S), ()),
     ('cosh', (S, S, S), ()),
     ('abs', (S, S, S), ()),
     ('clamp', (S, S, S), (0, 1)),
-    ('sqrt', (S, S, S), ()),
+    ('sqrt', torch.rand(S, S, S) + 5e-4, ()),
     ('sin', (S, S, S), ()),
     ('cos', (S, S, S), ()),
     ('tan', (S, S, S), ()),
-    ('asin', (S, S, S), ()),
-    ('acos', (S, S, S), ()),
+    ('asin', torch.randn(S, S, S).clamp(-0.9, 0.9), ()),
+    ('acos', torch.randn(S, S, S).clamp(-0.9, 0.9), ()),
     ('atan', (S, S, S), ()),
     ('atan2', (S, S, S), ((S, S, S),)),
     ('reciprocal', (S, S, S), ()),
@@ -1874,7 +1879,7 @@ method_tests = [
     ('trunc', (S, S, S), ()),
     ('floor', (S, S, S), ()),
     ('ceil', (S, S, S), ()),
-    ('rsqrt', (S, S, S), ()),
+    ('rsqrt', torch.rand(S, S, S) + 1e-2, ()),
     ('fmod', (S, S, S), (1.5,)),
     ('fmod', (S, S, S), (Variable(torch.rand(S, S, S) + 1.5, requires_grad=False),), 'tensor'),
     ('fmod', (S,), (Variable(torch.rand(S, S, S) + 1.5, requires_grad=False),), 'tensor_broadcast_lhs'),
@@ -2271,6 +2276,27 @@ EXCLUDE_FUNCTIONAL = {
     'addmv',
     'addr',
 }
+EXCLUDE_GRADCHECK = {
+    'potrf'
+}
+
+
+def gradgradcheck_method_precision_override(test_name):
+    # these are just empirical observations, we should improve
+    gradgradcheck_precision_override = {
+        'test_norm': {'atol': 2e-2, 'rtol': 1e-2},
+        'test_dist': {'atol': 5e-2, 'rtol': 1e-2},
+        'test_dist_4': {'atol': 8e-2, 'rtol': 1e-2},
+    }
+    non_broadcasted_test_name = test_name.split("_broadcast")[0]
+    override = gradgradcheck_precision_override.get(non_broadcasted_test_name)
+    if override:
+        if 'broadcast_lhs' in test_name or 'broadcast_rhs' in test_name:
+            override = {'atol': override['atol'] * S, 'rtol': override['atol'] * S}
+        elif 'broadcast_all' in test_name:
+            override = {'atol': override['atol'] * S * S, 'rtol': override['atol'] * S * S}
+    return override
+
 for test in method_tests:
     name, self_size, args = test[:3]
     basic_test_name = 'test_' + name + ('_' + test[3] if len(test) >= 4 else '')
@@ -2287,8 +2313,11 @@ for test in method_tests:
 
         def do_test(self, name=name, self_size=self_size, args=new_args, test_name=test_name):
             def check(name):
-                self_variable = create_input((self_size,), requires_grad=False)[0]
-                args_variable = create_input(args, requires_grad=False)
+                is_rhs_operator = name[:3] == "__r" and name[-2:] == "__"
+                is_inplace = name[-1] == "_" and not is_rhs_operator
+                requires_grad = False if is_inplace else True
+                self_variable = create_input((self_size,), requires_grad=requires_grad)[0]
+                args_variable = create_input(args, requires_grad=requires_grad)
                 self_tensor = deepcopy(self_variable.data)
                 args_tensor = deepcopy(unpack_variables(args_variable))
                 output_variable = getattr(self_variable, name)(*args_variable)
@@ -2297,6 +2326,25 @@ for test in method_tests:
                     output_tensor = torch.DoubleTensor((output_tensor,))
                 self.assertEqual(unpack_variables(output_variable), output_tensor)
                 # TODO: check that both have changed after adding all inplace ops
+
+                def apply_method(*inputs):
+                    return getattr(inputs[0], name)(*inputs[1:])
+
+                if not is_inplace and name not in EXCLUDE_GRADCHECK:
+                    self.assertTrue(gradcheck(apply_method,
+                                              (self_variable,) + args_variable,
+                                              eps=1e-6, atol=PRECISION))
+
+                    grad_y = generate_gradoutput(output_variable, non_contiguous=True)
+                    gradgradcheck_precision_override = gradgradcheck_method_precision_override(test_name)
+                    if gradgradcheck_precision_override is not None:
+                        atol = gradgradcheck_precision_override['atol']
+                        rtol = gradgradcheck_precision_override['rtol']
+                        self.assertTrue(gradgradcheck(apply_method,
+                                        (self_variable,) + args_variable, grad_y, atol=atol, rtol=rtol))
+                    else:
+                        self.assertTrue(gradgradcheck(apply_method,
+                                                      (self_variable,) + args_variable, grad_y,))
 
                 # functional interface tests
                 if hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL:
@@ -2309,7 +2357,7 @@ for test in method_tests:
                     self.assertEqual(unpack_variables(output_variable), output_tensor)
 
                 # check for correct type of input.data and input.grad.data
-                if name[-1] != '_':
+                if not is_inplace:
                     self_variable = create_input((self_size,), requires_grad=True)[0]
                     args_variable = create_input(args, requires_grad=False)
                     output_variable = getattr(self_variable, name)(*args_variable)
@@ -2317,6 +2365,51 @@ for test in method_tests:
                         output_variable.backward(torch.randn(*output_variable.size()).type_as(output_variable.data))
                         self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
                         self.assertTrue(self_variable.size() == self_variable.grad.size())
+
+                    # compare grads to inplace grads
+                    inplace_name = name + '_'
+                    # can't broadcast inplace to left hand side
+                    broadcast_skip_inplace = 'broadcast_lhs' in test_name or 'broadcast_all' in test_name
+                    if hasattr(Variable(torch.ones(1)), inplace_name) and not broadcast_skip_inplace:
+                        output_variable = getattr(self_variable, name)(*args_variable)
+                        if not isinstance(output_variable, tuple):
+                            output_variable = (output_variable,)
+                        inplace_self_variable = deepcopy(self_variable)
+                        inplace_self_variable_copy = tuple(i + 0 if i is not None else None
+                                                           for i in (inplace_self_variable,))
+                        inplace_args_variable = deepcopy(args_variable)
+                        inplace_args_variable_copy = tuple(i + 0 if i is not None else None
+                                                           for i in inplace_args_variable)
+
+                        try:
+                            inplace_output_variable = (
+                                getattr(*inplace_self_variable_copy, inplace_name)(*inplace_args_variable_copy))
+                        except RuntimeError as err:
+                            if 'only supports scalar multiplication' in str(err):
+                                return
+                            raise
+                        if not isinstance(inplace_output_variable, tuple):
+                            inplace_output_variable = (inplace_output_variable,)
+                        self.assertEqual(inplace_output_variable, output_variable)
+                        # Check that gradient is the same
+                        for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,
+                                            (self_variable,) + args_variable):
+                            if not isinstance(inp_i, Variable):
+                                assert not isinstance(i, Variable)
+                                continue
+                            if inp_i.grad is not None:
+                                inp_i.grad.data.zero_()
+                            if i.grad is not None:
+                                i.grad.data.zero_()
+                        for io, o in zip(inplace_output_variable, output_variable):
+                            grad = torch.randn(*io.size()).double()
+                            io.backward(grad)
+                            o.backward(grad)
+                        for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,
+                                            (self_variable,) + args_variable):
+                            if not isinstance(inp_i, Variable):
+                                continue
+                            self.assertEqual(inp_i.grad, i.grad)
 
             check(name)
             inplace_name = name + '_'

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1550,268 +1550,9 @@ L = 20
 M = 10
 S = 5
 function_tests = [
-    (Add, (), ((M, M), (M, M))),
-    (Add, (), ((M, M), (M, )), 'broadcast_rhs'),
-    (Add, (), ((M, ), (M, M)), 'broadcast_lhs'),
-    (Add, (), ((M, 1, M), (S, M)), 'broadcast_all'),
-    (Sub, (), ((M, M), (M, M))),
-    (Sub, (), ((M, M), (M, )), 'broadcast_rhs'),
-    (Sub, (), ((M, ), (M, M)), 'broadcast_lhs'),
-    (Sub, (), ((M, 1, M), (S, M)), 'broadcast_all'),
-    (Mul, (), ((M, M), (M, M))),
-    (Mul, (), ((M, M), (M, )), 'broadcast_rhs'),
-    (Mul, (), ((M, ), (M, M)), 'broadcast_lhs'),
-    (Mul, (), ((M, 1, M), (S, M)), 'broadcast_all'),
-    (Div, (), ((M, M), torch.rand(M, M) + 5e-2)),
-    (Div, (), ((M, M), torch.rand(M, ) + 5e-2), 'broadcast_rhs'),
-    (Div, (), ((M, ), torch.rand(M, M) + 5e-2), 'broadcast_lhs'),
-    (Div, (), ((M, 1, M), torch.rand(S, M) + 5e-2), 'broadcast_all'),
-    (Pow, (), (torch.rand(M, M) + 1e-3, torch.rand(M, M) + 0.1)),
-    (Pow, (), (torch.rand(M, M) + 1e-3, torch.rand(M,) + 0.1), 'broadcast_rhs'),
-    (Pow, (), (torch.rand(M, ) + 1e-3, torch.rand(M, M) + 0.1), 'broadcast_lhs'),
-    (Pow, (), (torch.rand(M, 1) + 1e-3, torch.rand(1, M) + 0.1), 'broadcast_all'),
-    (AddConstant, (), ((2, 2), 3.14)),
-    (AddConstant, (), (3.14, (2, 2)), 'add_tensor'),
-    (SubConstant, (), ((L, L), 3.14)),
-    (SubConstant, (), (3.14, (L, L),), 'sub_tensor'),
-    (MulConstant, (), ((L, L), 3.14)),
-    (MulConstant, (), (3.14, (L, L)), 'mul_tensor'),
-    (DivConstant, (), (torch.rand(L, L) + 1e-1, 3.14)),
-    (DivConstant, (), (3.14, torch.rand(L, L) + 0.5,), 'div_tensor'),
-    (PowConstant, (), (torch.rand(L, L), 3)),
-    (PowConstant, (), (3.14, torch.rand(L, L)), 'tensor_power'),
-    # TODO: enable neg dim checks
-    (Transpose, (), (torch.rand(L, L), 0, 1)),
-    (Transpose, (), (torch.rand(S, S, S), 2, 0), '3d'),
-    (Permute, (), ((1, 2, 3, 4, 5, 6), torch.Size([0, 4, 3, 5, 1, 2]))),
-    (Index, (), (torch.rand(S, S, S), dont_convert([1, 2]))),
-    (Index, (), (torch.rand(S, S, S), slice(0, 3)), 'slice'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([slice(0, 3), 1])), 'slice_index'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 2, 3], [1, 3, 3], [0, 0, 2]])), 'adv_index'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 0, 3], [1, 1, 3], [0, 0, 2]])), 'adv_index_dup'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([slice(None), slice(None), [0, 3]])), 'adv_index_end'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([slice(None), [0, 3], slice(None)])), 'adv_index_mid'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], slice(None), slice(None)])), 'adv_index_beg'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], [1, 2], slice(None)])), 'adv_index_comb'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], ])), 'adv_index_sub'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], slice(None)])), 'adv_index_sub_2'),
-    (Index, (), (torch.rand(S, S, S), dont_convert([[0, 3], Ellipsis])), 'adv_index_sub_3'),
-    (View, (), (torch.rand(S, S, S), torch.Size([S * S, S]))),
-    (Expand, (), ((1, S, 1, S, 1), torch.Size([5, S, 5, S, 5]))),
-    (Expand, (), ((S, 1), torch.Size([S, S, S])), 'new_dim'),
-    (Expand, (), ((1, S), torch.Size([S, S, S])), 'new_dim_front'),
-    (Expand, (), ((1, S), torch.Size([1, 1, S])), 'new_dim_front_old_front_1'),
-    (Expand, (), ((1,), torch.Size([S, S, S])), 'scalar'),
-    (Exp, (), (torch.rand(S, S, S),)),
-    (Log, (), (torch.rand(S, S, S) + 1e-2,)),
-    (Log1p, (), (torch.rand(S, S, S),)),
-    (Tanh, (), ((S, S, S),)),
-    (Sigmoid, (), ((S, S, S),)),
-    (Sinh, (), ((S, S, S),)),
-    (Cosh, (), ((S, S, S),)),
-    (Abs, (), ((S, S, S),)),
-    (Clamp, (), ((S, S, S), 0, 1)),
-    (Sqrt, (), (torch.rand(S, S, S) + 5e-4,)),
-    (Sin, (), ((S, S, S),)),
-    (Cos, (), ((S, S, S),)),
-    (Tan, (), (torch.randn(S, S, S).clamp(-1, 1),)),
-    (Asin, (), (torch.randn(S, S, S).clamp(-0.9, 0.9),)),
-    (Acos, (), (torch.randn(S, S, S).clamp(-0.9, 0.9),)),
-    (Atan, (), ((S, S, S),)),
-    (Atan2, (), ((S, S), (S, S))),
-    (Reciprocal, (), (torch.rand(S, S, S) + 0.1,)),
-    (Cmax, (), ((S, S, S), (S, S, S))),
-    (Cmax, (), ((S, S, S), (S,)), 'broadcast_rhs'),
-    (Cmax, (), ((S,), (S, S, S)), 'broadcast_lhs'),
-    (Cmax, (), ((S, 1, S), (S, S)), 'broadcast_all'),
-    (Cmin, (), ((S, S, S), (S, S, S))),
-    (Cmin, (), ((S, S, S), (S,)), 'broadcast_rhs'),
-    (Cmin, (), ((S,), (S, S, S)), 'broadcast_lhs'),
-    (Cmin, (), ((S, 1, S), (S, S)), 'broadcast_all'),
-    (Round, (), ((S, S, S),)),
-    (Sign, (), ((S, S, S),)),
-    (Trunc, (), ((S, S, S),)),
-    (Floor, (), ((S, S, S),)),
-    (Ceil, (), ((S, S, S),)),
-    (Frac, (), ((S, S, S),)),
-    (Fmod, (), ((S, S, S), 1.5)),
-    (Fmod, (), ((S, S, S), Variable(torch.rand(S, S, S) + 1.5, requires_grad=False)), 'tensor'),
-    (Fmod, (), ((S, S, S), Variable(torch.rand(S) + 1.5, requires_grad=False)), 'tensor_broadcast_rhs'),
-    (Fmod, (), ((S,), Variable(torch.rand(S, S, S) + 1.5, requires_grad=False)), 'tensor_broadcast_lhs'),
-    (Fmod, (), ((S, 1, S), Variable(torch.rand(S, S) + 1.5, requires_grad=False)), 'tensor_broadcast_all'),
-    (Lerp, (), ((S, S, S), (S, S, S), 0.2)),
-    (Lerp, (), ((S, S, S), (S,), 0.2), 'broadcast_rhs'),
-    (Lerp, (), ((S,), (S, S, S), 0.2), 'broadcast_lhs'),
-    (Lerp, (), ((S, 1, S), (S, S), 0.2), 'broadcast_all'),
-    (Rsqrt, (), (torch.rand(S, S, S) + 1e-2,)),
-    (Remainder, (), ((S, S, S), 1.5)),
-    (Remainder, (), ((S, S, S), Variable(torch.rand(S, S, S) + 1.5, requires_grad=False)), 'tensor'),
-    (Remainder, (), ((S, S, S), Variable(torch.rand(S) + 1.5, requires_grad=False)), 'tensor_broadcast_rhs'),
-    (Remainder, (), ((S,), Variable(torch.rand(S, S, S) + 1.5, requires_grad=False)), 'tensor_broadcast_lhs'),
-    (Remainder, (), ((S, 1, S), Variable(torch.rand(S, S) + 1.5, requires_grad=False)), 'tensor_broadcast_all'),
-    (CmaxConstant, (), ((S, S, S), 0.5)),
-    (CminConstant, (), ((S, S, S), 0.5)),
-    (Mean, (), ((S, S, S),)),
-    (Mean, (), ((S, S, S), 1), 'dim', [1]),
-    (Mean, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Mean, (), ((S,), 0), 'dim_1d', [1]),
-    (Mean, (), ((S,), 0, True), 'keepdim_1d', [1]),
-    (Sum, (), ((S, S, S),)),
-    (Sum, (), ((S, S, S), 1), 'dim', [1]),
-    (Sum, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Sum, (), ((S,), 0), 'dim_1d', [1]),
-    (Sum, (), ((S,), 0, True), 'keepdim_1d', [1]),
-    (Prod, (), ((S, S, S),)),
-    (Prod, (), (prod_zeros(S, [0, 1]),), 'zerosdim2'),
-    (Prod, (), (prod_zeros(S, [0, 2]),), 'zerosdim1'),
-    (Prod, (), (prod_zeros(S, [1, 2]),), 'zerosdim0'),
-    (Prod, (), (prod_single_zero(S),), 'single_zero'),
-    (Prod, (), ((S, S, S), 1), 'dim', [1]),
-    (Prod, (), (prod_zeros(S, [0, 1]), 1), 'zeros_dim2', [1]),
-    (Prod, (), (prod_zeros(S, [0, 2]), 1), 'zeros_dim1', [1]),
-    (Prod, (), (prod_zeros(S, [1, 2]), 1), 'zeros_dim0', [1]),
-    (Prod, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Prod, (), (prod_zeros(S, [0, 1]), 1, True), 'keepdim_zeros_dim2', [1]),
-    (Prod, (), (prod_zeros(S, [0, 2]), 1, True), 'keepdim_zeros_dim1', [1]),
-    (Prod, (), (prod_zeros(S, [1, 2]), 1, True), 'keepdim_zeros_dim0', [1]),
-    (Prod, (), ((S,), 0), 'dim_1d', [1]),
-    (Prod, (), ((S,), 0, True), 'keepdim_1d', [1]),
-    (Addmm, (), ((S, M), (S, S), (S, M)),),
-    (Addmm, (), ((1,), (S, S), (S, M)), 'broadcast_lhs'),
-    (Addmm, (), ((S, M), (S, S), (S, M), 0.1, 1), 'coef'),
-    (Addmm, (), ((1,), (S, S), (S, M), 0.1, 1), 'broadcast_lhs_coef'),
-    (Addbmm, (), ((S, M), (S, S, S), (S, S, M)),),
-    (Addbmm, (), ((1,), (S, S, S), (S, S, M)), 'broadcast_lhs'),
-    (Addbmm, (), ((S, M), (S, S, S), (S, S, M), 0.1, 0.4), 'coef'),
-    (Addbmm, (), ((1,), (S, S, S), (S, S, M), 0.1, 0.4), 'broadcast_lhs_coef'),
-    (Baddbmm, (), ((S, S, M), (S, S, S), (S, S, M)),),
-    (Baddbmm, (), ((1,), (S, S, S), (S, S, M)), 'broadcast_lhs'),
-    (Baddbmm, (), ((S, S, M), (S, S, S), (S, S, M), 0.1, 0.4), 'coef'),
-    (Baddbmm, (), ((1,), (S, S, S), (S, S, M), 0.1, 0.4), 'broadcast_lhs_coef'),
-    (Addmv, (), ((S,), (S, M), (M,)),),
-    (Addmv, (), ((1,), (S, M), (M,)), 'broadcast_lhs'),
-    (Addmv, (), ((S,), (S, M), (M,), 0.1, 0.4), 'coef'),
-    (Addmv, (), ((1,), (S, M), (M,), 0.1, 0.4), 'broadcast_lhs_coef'),
-    (Addr, (), ((S, M), (S,), (M,)),),
-    (Addr, (), ((1,), (S,), (M,)), 'broadcast_lhs'),
-    (Addr, (), ((S, M), (S,), (M,), 0.1, 0.4), 'coef'),
-    (Addr, (), ((1,), (S,), (M,), 0.1, 0.4), 'broadcast_lhs_coef'),
-    (Dot, (), ((L,), (L,)),),
-    (Max, (), ((S, S, S),),),
-    (Repeat, (), ((S, S, S, S), torch.Size([2, 3, 1, 2]))),
-    (Repeat, (), ((S, S, S, S), torch.Size([2, 2, 1, 3, 1, 2])), 'unsqueeze'),
-    (Cumsum, (), ((S, S, S), 0), 'dim0', [1]),
-    (Cumsum, (), ((S, S, S), 1), 'dim1', [1]),
-    (Cumsum, (), ((S,), 0), '1d', [1]),
-    (Cumprod, (), ((S, S, S), 0),),
-    (Cumprod, (), ((S, S, S), 1), 'dim1'),
-    (Cumprod, (), ((S,), 0), '1d'),
-    (Cumprod, (), (prod_zeros(S, [0, 1]), 1), 'zeros_dim2', [1]),
-    (Cumprod, (), (prod_zeros(S, [0, 2]), 1), 'zeros_dim1', [1]),
-    (Cumprod, (), (prod_zeros(S, [1, 2]), 1), 'zeros_dim0', [1]),
-    (Unfold, (), ((S, S, S), 1, 3, 1)),
-    (Unfold, (), ((S, S, S), 2, 3, 2), 'lastdim'),
-    (Min, (), ((S, S, S),),),
-    (Max, (), ((S, S, S), 1), 'dim', [1]),
-    (Min, (), ((S, S, S), 1), 'dim', [1]),
-    (Min, (), ((S,), 0), 'dim_1d', [1]),
-    (Max, (), ((S,), 0), 'dim_1d', [1]),
-    (Max, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Min, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Max, (), ((S,), 0, True), 'keepdim_dim_1d', [1]),
-    (Min, (), ((S,), 0, True), 'keepdim_dim_1d', [1]),
-    (Mode, (), ((S, S, S),),),
-    (Mode, (), ((S, S, S), 1), 'dim', [1]),
-    (Mode, (), ((S, S, S), 1, True), 'keepdim_dim', [1]),
-    (Mode, (), ((S,), 0), 'dim_1d', [1]),
-    (Mode, (), ((S,), 0, True), 'keepdim_dim_1d', [1]),
-    (Kthvalue, (), ((S, S, S), 2),),
-    (Kthvalue, (), ((S, S, S), 2, 0), 'dim0'),
-    (Kthvalue, (), ((S, S, S), 2, 0, True), "keepdim"),
-    (Kthvalue, (), ((S,), 2, 0), 'dim0_1d'),
-    (Kthvalue, (), ((S,), 2, 0, True), "keepdim_1d"),
-    (Median, (), ((S, S, S),),),
-    (Median, (), ((S, S, S), 0), 'dim0'),
-    (Median, (), ((S, S, S), 0, True), "keepdim"),
-    (Median, (), ((S,), 0), 'dim0_1d'),
-    (Median, (), ((S,), 0, True), "keepdim_1d"),
-    (Norm, (), (torch.rand(S, S, S) + 5e-2, 1.5), '1_5'),
-    (Norm, (), ((S, S, S),), '2'),
-    (Norm, (), ((S, S, S), 3), '3'),
-    (Norm, (), (torch.rand(S, S, S) + 5e-2, 1.5, 1), '1_5_dim', [2]),
-    (Norm, (), ((S, S, S), 2, 1), '2_dim', [2]),
-    (Norm, (), ((S, S, S), 3, 1), '3_dim', [2]),
-    (Norm, (), (torch.rand(S, S, S) + 5e-2, 1.5, 1, True), 'keepdim_1_5_dim', [2]),
-    (Norm, (), ((S, S, S), 2, 1, True), 'keepdim_2_dim', [2]),
-    (Norm, (), ((S, S, S), 3, 1, True), 'keepdim_3_dim', [2]),
-    (Norm, (), ((S,), 2, 0), '2_dim_1d', [2]),
-    (Norm, (), ((S,), 3, 0), '3_dim_1d', [2]),
-    (Norm, (), ((S,), 2, 0, True), 'keepdim_2_dim_1d', [2]),
-    (Norm, (), ((S,), 3, 0, True), 'keepdim_3_dim_1d', [2]),
-    (Addcmul, (), ((S, S), (S, S), (S, S))),
-    (Addcmul, (), ((S, S), (S, 1), (1, S)), 'broadcast_rhs'),
-    (Addcmul, (), ((1,), (S, S, 1), (1, S)), 'broadcast_all'),
-    (Addcmul, (), ((S, S), (S, S), (S, S), 0.6), 'scale'),
-    (Addcmul, (), ((S, S), (S, 1), (1, S), 0.6), 'broadcast_rhs_scale'),
-    (Addcmul, (), ((1,), (S, S, 1), (1, S), 0.6), 'broadcast_all_scale'),
-    (Addcdiv, (), ((S, S), (S, S), torch.rand(S, S) + 5e-2)),
-    (Addcdiv, (), ((S, S), (S, 1), torch.rand(1, S) + 5e-2), 'broadcast_rhs'),
-    (Addcdiv, (), ((1,), (S, S, 1), torch.rand(1, S) + 5e-2), 'broadcast_all'),
-    (Addcdiv, (), ((S, S), (S, S), torch.rand(S, S) + 5e-2, 0.6), 'scale'),
-    (Addcdiv, (), ((S, S), (S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_rhs_scale'),
-    (Addcdiv, (), ((1,), (S, S, 1), torch.rand(1, S) + 5e-2, 0.6), 'broadcast_all_scale'),
-    (IndexAdd, (), ((S, S), 0, index_variable(2, S), (2, S))),
-    (IndexCopy, (), ((S, S), 0, index_perm_variable(2, S), (2, S))),
-    (IndexFill, (), ((S, S), 0, index_variable(2, S), 2)),
-    (IndexSelect, (), ((S, S), 0, index_variable(2, S))),
-    (Gather, (), ((M, S), 0, gather_variable((S, S), 1, M, True))),
-    # TODO: enable neg dim checks
-    (Gather, (), ((M, S), 1, gather_variable((M, S // 2), 0, S, True)), 'dim1'),
-    (Scatter, (), ((M, S), 0, gather_variable((S, S), 1, M), (S, S))),
-    (Scatter, (), ((M, S), 1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1'),
-    (ScatterAdd, (), ((M, S), 0, gather_variable((S, S), 1, M), (S, S))),
-    (ScatterAdd, (), ((M, S), 1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1'),
     (Concat, (), (0, (1, S, S), (2, S, S), (3, S, S))),
     (Concat, (), (-1, (S, S, 1), (S, S, 2), (S, S, 3)), 'negdim-1'),
     (Concat, (), (-2, (S, 1, S), (S, 2, S), (S, 3, S)), 'negdim-2'),
-    (Resize, (), ((S, S, S), torch.Size([S * S, S]))),
-    (Diag, (), ((S, S),), '2d'),
-    (Diag, (), ((S,),), '1d'),
-    (Diag, (), ((S, S), 1), '2d_1'),
-    (Diag, (), ((S, S), 2), '2d_2'),
-    (Tril, (), ((S, S),)),
-    (Tril, (), ((S, S), 2), 'idx'),
-    (Triu, (), ((S, S),)),
-    (Triu, (), ((S, S), 2), 'idx'),
-    (Trace, (), ((S, S),)),
-    (Cross, (), ((S, 3), (S, 3))),
-    (Cross, (), ((S, 3, S), (S, 3, S), 1), 'dim'),
-    (Inverse, (), ((S, S),), '', (), [skipIfNoLapack]),
-    (Gesv, (), ((S, S), (S, S)), '', (), [skipIfNoLapack]),
-    (Clone, (), ((S, M, S),)),
-    (Squeeze, (), ((S, 1, M, 1), None)),
-    # TODO: enable neg dim checks
-    (Squeeze, (), ((S, 1, M, 1), 1), 'dim'),
-    (Unsqueeze, (), ((S, M, S), 0), '0'),
-    (Unsqueeze, (), ((S, M, S), 1), '1'),
-    # no lhs or all broadcast on MaskedScatter because it's always inplace
-    (MaskedScatter, (), ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False), (S, S),)),
-    (MaskedScatter, (), ((S, S), Variable(torch.ones(S,).gt(0), requires_grad=False), (S, S),), 'broadcast_rhs'),
-    (MaskedFill, (), ((S, S), Variable(torch.randn(S, S).gt(0), requires_grad=False), 10)),
-    # no lhs or all broadcast on MaskedFill because it's always inplace
-    (MaskedFill, (), ((S, S), Variable(torch.randn(S,).gt(0), requires_grad=False), 10), 'broadcast_rhs'),
-    # ensure the mask isn't all zeros or else we get a tensor with 0 dimensions
-    (MaskedSelect, (), ((S, S), Variable(mask_not_all_zeros((S, S)), requires_grad=False))),
-    (MaskedSelect, (), ((S, S), Variable(mask_not_all_zeros((S,)), requires_grad=False)), 'broadcast_rhs'),
-    (MaskedSelect, (), ((S,), Variable(mask_not_all_zeros((S, S,)), requires_grad=False)), 'broadcast_lhs'),
-    (MaskedSelect, (), ((S, 1, S), Variable(mask_not_all_zeros((S, S)), requires_grad=False)), 'broadcast_all'),
-    (Sort, (), ((S, M, S),)),
-    (Sort, (), ((S, M, S), 1), 'dim'),
-    (Sort, (), ((S, M, S), 1, True), 'dim_desc'),
-    (Topk, (), ((S, M, S), 3)),
-    (Topk, (), ((S, M, S), 3, 1), 'dim'),
-    (Topk, (), ((S, M, S), 3, 1, True), 'dim_desc'),
-    (Topk, (), ((S, M, S), 3, 1, True, True), 'dim_desc_sort'),
 ]
 
 
@@ -1848,6 +1589,8 @@ method_tests = [
     ('pow', torch.rand(S, S, S) + 1e-3, (3.14,), 'constant'),
     ('__rpow__', torch.rand(S, S, S) + 1e-3, (3.14,), 'constant'),
     ('transpose', (1, 2, 3), (1, 2), 'dim', [0, 1]),
+    ('transpose', torch.rand(L, L), (0, 1), '2d'),
+    ('transpose', torch.rand(S, S, S), (2, 0), '3d'),
     ('t', (1, 2), ()),
     ('view', (S, S, S), (S * S, S),),
     ('view_as', (S, S, S), (Variable(torch.rand(S * S, S), requires_grad=False),)),
@@ -1865,24 +1608,28 @@ method_tests = [
     ('cosh', (S, S, S), ()),
     ('abs', (S, S, S), ()),
     ('clamp', (S, S, S), (0, 1)),
+    ('clamp', (S, S, S), (None, 0.5), 'min'),
+    ('clamp', (S, S, S), (0.5, None), 'max'),
     ('sqrt', torch.rand(S, S, S) + 5e-4, ()),
     ('sin', (S, S, S), ()),
     ('cos', (S, S, S), ()),
-    ('tan', (S, S, S), ()),
+    ('tan', torch.randn(S, S, S).clamp(-1, 1), ()),
     ('asin', torch.randn(S, S, S).clamp(-0.9, 0.9), ()),
     ('acos', torch.randn(S, S, S).clamp(-0.9, 0.9), ()),
     ('atan', (S, S, S), ()),
     ('atan2', (S, S, S), ((S, S, S),)),
-    ('reciprocal', (S, S, S), ()),
+    ('reciprocal', torch.rand(S, S, S) + 0.1, ()),
     ('round', (S, S, S), ()),
     ('sign', (S, S, S), ()),
     ('trunc', (S, S, S), ()),
     ('floor', (S, S, S), ()),
     ('ceil', (S, S, S), ()),
     ('rsqrt', torch.rand(S, S, S) + 1e-2, ()),
+    ('frac', (S, S, S), ()),
     ('fmod', (S, S, S), (1.5,)),
     ('fmod', (S, S, S), (Variable(torch.rand(S, S, S) + 1.5, requires_grad=False),), 'tensor'),
     ('fmod', (S,), (Variable(torch.rand(S, S, S) + 1.5, requires_grad=False),), 'tensor_broadcast_lhs'),
+    ('fmod', (S, S, S), (Variable(torch.rand(S) + 1.5, requires_grad=False),), 'tensor_broadcast_rhs'),
     ('fmod', (S, 1, S), (Variable(torch.rand(S, S) + 1.5, requires_grad=False),), 'tensor_broacast_all'),
     ('remainder', (S, S, S), (1.5,)),
     ('remainder', (S, S, S), (Variable(torch.rand(S, S, S) + 1.5, requires_grad=False),), 'tensor'),
@@ -1940,6 +1687,16 @@ method_tests = [
     ('prod', (S, S, S), (1, True,), 'keepdim_dim', [0]),
     ('prod', (S,), (0,), 'dim_1d', [0]),
     ('prod', (S,), (0, True), 'keepdim_1d', [0]),
+    ('prod', prod_zeros(S, [0, 1]), (), 'zerodims2'),
+    ('prod', prod_zeros(S, [0, 2]), (), 'zerodims1'),
+    ('prod', prod_zeros(S, [1, 2]), (), 'zerodims0'),
+    ('prod', prod_zeros(S, [0, 1]), (1,), 'zeros_dims2', [0]),
+    ('prod', prod_zeros(S, [0, 2]), (1,), 'zeros_dims1', [0]),
+    ('prod', prod_zeros(S, [1, 2]), (1,), 'zeros_dims0', [0]),
+    ('prod', prod_zeros(S, [0, 1]), (1, True), 'keepdim_zeros_dims2', [0]),
+    ('prod', prod_zeros(S, [0, 2]), (1, True), 'keepdim_zeros_dims1', [0]),
+    ('prod', prod_zeros(S, [1, 2]), (1, True), 'keepdim_zeros_dims0', [0]),
+    ('prod', prod_single_zero(S), (), 'single_zero'),
     ('var', (S, S, S), ()),
     ('var', (S, S, S), (1,), 'dim', [0]),
     ('var', (S, S, S), (1, True, True), 'keepdim_dim', [0]),
@@ -1953,10 +1710,16 @@ method_tests = [
     ('renorm', (S, S, S), (2, 1, 0.5), 'dim', [1]),
     ('renorm', (S, S, S), (1, 2, 3), 'norm_1'),
     ('repeat', (S, S, S, S), (2, 3, 1, 4)),
-    ('cumsum', (S, S, S), (1,)),
-    ('cumsum', (S,), (0,), '1d'),
+    ('repeat', (S, S, S, S), (2, 2, 1, 3, 1, 2), 'unsqueeze'),
+    ('cumsum', (S, S, S), (1,), 'dim0', [0]),
+    ('cumsum', (S, S, S), (1,), 'dim1', [0]),
+    ('cumsum', (S,), (0,), '1d', [0]),
+    ('cumprod', (S, S, S), (0,)),
     ('cumprod', (S, S, S), (1,), 'dim1', [0]),
-    ('cumprod', prod_zeros(S, [0, 1]), (1,), 'zeros_dim', [0]),
+    ('cumprod', (S,), (0,), '1d'),
+    ('cumprod', prod_zeros(S, [0, 1]), (1,), 'zeros_dim2', [0]),
+    ('cumprod', prod_zeros(S, [0, 2]), (1,), 'zeros_dim1', [0]),
+    ('cumprod', prod_zeros(S, [1, 2]), (1,), 'zeros_dim0', [0]),
     ('unfold', (S, S, S, S), (1, 3, 1)),
     ('unfold', (S, S, S), (2, 3, 2), 'lastdim'),
     ('addmm', (S, M), ((S, S), (S, M)),),
@@ -2004,10 +1767,19 @@ method_tests = [
     ('addcdiv', (S, S), (0.5, (S, 1), (1, S)), 'scale_broadcast_rhs'),
     ('addcdiv', (1,), (0.5, (S, S, 1), (1, S)), 'scale_broadcast_all'),
     ('norm', (S, S, S), (2,)),
-    ('norm', (S, S, S), (2, 1), 'dim', [1]),
-    ('norm', (S, S, S), (2, 1, True), 'keepdim_dim', [0]),
-    ('norm', (S,), (2, 0), 'dim_1d', [1]),
-    ('norm', (S,), (2, 0, True), 'keepdim_dim_1d', [0]),
+    ('norm', (S, S, S), (3,), '3'),
+    ('norm', torch.rand(S, S, S) + 5e-2, (1.5,), '1_5'),
+    ('norm', (S, S, S), (2, 1), '2_dim', [1]),
+    ('norm', (S, S, S), (3, 1), '3_dim', [1]),
+    ('norm', torch.rand(S, S, S) + 5e-2, (1.5, 1), '1_5_dim', [1]),
+    ('norm', (S, S, S), (2, 1, True), 'keepdim_2_dim', [1]),
+    ('norm', (S, S, S), (3, 1, True), 'keepdim_3_dim', [1]),
+    ('norm', torch.rand(S, S, S) + 5e-2, (1.5, 1, True), 'keepdim_1_5_dim', [1]),
+    ('norm', (S,), (2, 0), '2_dim_1d', [1]),
+    ('norm', (S,), (3, 0), '3_dim_1d', [1]),
+    ('norm', (S,), (2, 0, True), 'keepdim_2_dim_1d', [1]),
+    ('norm', (S,), (3, 0, True), 'keepdim_3_dim_1d', [1]),
+    ('clone', (S, M, S), ()),
     ('dist', (S, S, S), ((S, S, S),)),
     ('dist', (S, S, S), ((S,),), 'broadcast_rhs'),
     ('dist', (S,), ((S, S, S),), 'broadcast_lhs'),
@@ -2016,18 +1788,24 @@ method_tests = [
     ('dist', (S, S, S), ((S,), 4), '4_broadcast_rhs'),
     ('dist', (S,), ((S, S, S), 4), '4_broadcast_lhs'),
     ('dist', (S, 1, S), ((S, S), 4), '4_broadcast_all'),
-    ('index_select', (S, S, S), (0, index_variable(2, S)), 'dim', [0]),
     ('diag', (M, M), (), '2d'),
     ('diag', (M,), (), '1d'),
+    ('diag', (M, M), (1,), '2d_1'),
+    ('diag', (M, M), (2,), '2d_2'),
     ('tril', (M, M), ()),
+    ('tril', (M, M), (2,), 'idx'),
     ('triu', (M, M), ()),
+    ('triu', (M, M), (2,), 'idx'),
     ('trace', (M, M), ()),
     ('cross', (S, 3), ((S, 3),)),
     ('cross', (S, 3, S), ((S, 3, S), 1), 'dim'),
+    ('index_select', (S, S, S), (0, index_variable(2, S)), 'dim', [0]),
+    ('index_add', (S, S), (0, index_variable(2, S), (2, S)), 'dim', [0]),
+    ('index_copy', (S, S), (0, index_perm_variable(2, S), (2, S)), 'dim', [0]),
+    ('index_fill', (S, S), (0, index_variable(2, S), 2), 'dim', [0]),
     ('inverse', (S, S), (), '', (), [skipIfNoLapack]),
     ('gesv', (S, S), ((S, S),), '', (), [skipIfNoLapack]),
     ('potrf', _make_cov(S), (True,), '', (), [skipIfNoLapack]),
-    ('clone', (S, M, S), ()),
     ('eq', (S, S, S), ((S, S, S),)),
     ('eq', (S, S, S), ((1,),), 'broadcast_rhs'),
     ('eq', (1,), ((S, S, S),), 'broadcast_lhs'),
@@ -2067,6 +1845,12 @@ method_tests = [
     ('unsqueeze', (S, S, S), (0,), 'first', [0]),
     ('unsqueeze', (S, S, S), (1,), 'middle', [0]),
     ('unsqueeze', (S, S, S), (3,), 'last', [0]),
+    ('gather', (M, S), (0, gather_variable((S, S), 1, M, True)), 'dim0', [0]),
+    ('gather', (M, S), (1, gather_variable((M, S // 2), 0, S, True)), 'dim1', [0]),
+    ('scatter', (M, S), (0, gather_variable((S, S), 1, M), (S, S)), 'dim0', [0]),
+    ('scatter', (M, S), (1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1', [0]),
+    ('scatter_add', (M, S), (0, gather_variable((S, S), 1, M), (S, S)), 'dim0', [0]),
+    ('scatter_add', (M, S), (1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1', [0]),
     ('masked_select', (M, M), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),)),
     ('masked_select', (M, M), (Variable(mask_not_all_zeros((M,)), requires_grad=False),), 'broadcast_rhs'),
     ('masked_select', (M,), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),), 'broadcast_lhs'),
@@ -2078,11 +1862,28 @@ method_tests = [
     ('masked_scatter_', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), (M, M))),
     ('masked_scatter_', (M, M), (Variable(torch.ByteTensor(M,).bernoulli_(), requires_grad=False), (M, M)),
      'broadcast_rhs'),
+    ('resize', (S, S, S), (torch.Size([S * S, S])), 'fewer_dims'),
+    ('resize_as', (S, S, S), (Variable(torch.randn((S * S, S)), requires_grad=False),)),
+    ('sort', (S, M, S), ()),
+    ('sort', (S, M, S), (1,), 'dim'),
+    ('sort', (S, M, S), (1, True), 'dim_desc'),
+    ('topk', (S, M, S), (3,)),
+    ('topk', (S, M, S), (3, 1), 'dim'),
+    ('topk', (S, M, S), (3, 1, True), 'dim_desc'),
+    ('topk', (S, M, S), (3, 1, True, True), 'dim_desc_sort'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([1, 2]),)),
+    ('__getitem__', torch.randn(S, S, S), (slice(0, 3),), 'slice'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([slice(0, 3), 1]),), 'slice_index'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 2, 3], [1, 3, 3], [0, 0, 2]]),), 'adv_index'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 0, 3], [1, 1, 3], [0, 0, 2]]),), 'adv_index_dup'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([slice(None), slice(None), [0, 3]]),), 'adv_index_end'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([slice(None), [0, 3], slice(None)]),), 'adv_index_mid'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], slice(None), slice(None)]),), 'adv_index_beg'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], [1, 2], slice(None)]),), 'adv_index_comb'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], ]),), 'adv_index_sub'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], slice(None)]),), 'adv_index_sub_2'),
+    ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], Ellipsis]),), 'adv_index_sub_3'),
 ]
-# TODO: mm, bmm, mv, ger
-# TODO: sort, topk (problem with indices)
-# TODO: indexAdd, indexCopy, indexFill
-# TODO: resize, resize_as (tensors only have resize_ and resize_as_)
 # TODO: clamp with min/max
 
 
@@ -2281,10 +2082,37 @@ EXCLUDE_GRADCHECK = {
 }
 
 
+def exclude_tensor_method(name, test_name):
+    # there are no tensor equivalents for these (inplace or out)
+    exclude_all_tensor_method_by_test_name = {
+        'test_clamp_min',
+        'test_clamp_max',
+    }
+    # there are no out-of-place tensor equivalents for these
+    exclude_outplace_tensor_method = {
+        'index_add',
+        'index_copy',
+        'index_fill',
+        'resize',
+        'resize_as',
+        'scatter',
+        'scatter_add',
+    }
+    if test_name in exclude_all_tensor_method_by_test_name:
+        return True
+    is_rhs_operator = name[:3] == "__r" and name[-2:] == "__"
+    is_inplace = name[-1] == "_" and not is_rhs_operator
+    if not is_inplace and name in exclude_outplace_tensor_method:
+        return True
+    return False
+
+
 def gradgradcheck_method_precision_override(test_name):
     # these are just empirical observations, we should improve
     gradgradcheck_precision_override = {
         'test_norm': {'atol': 2e-2, 'rtol': 1e-2},
+        'test_norm_1_5': {'atol': 1.5e-2, 'rtol': 1e-2},
+        'test_norm_3': {'atol': 5e-2, 'rtol': 1e-2},
         'test_dist': {'atol': 5e-2, 'rtol': 1e-2},
         'test_dist_4': {'atol': 8e-2, 'rtol': 1e-2},
     }
@@ -2296,6 +2124,19 @@ def gradgradcheck_method_precision_override(test_name):
         elif 'broadcast_all' in test_name:
             override = {'atol': override['atol'] * S * S, 'rtol': override['atol'] * S * S}
     return override
+
+
+def run_grad_and_gradgrad_checks(test_case, test_name, apply_method, output_variable, input_variables):
+    test_case.assertTrue(gradcheck(apply_method, input_variables, eps=1e-6, atol=PRECISION))
+
+    grad_y = generate_gradoutput(output_variable, non_contiguous=True)
+    gradgradcheck_precision_override = gradgradcheck_method_precision_override(test_name)
+    if gradgradcheck_precision_override is not None:
+        atol = gradgradcheck_precision_override['atol']
+        rtol = gradgradcheck_precision_override['rtol']
+        test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y, atol=atol, rtol=rtol))
+    else:
+        test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y,))
 
 for test in method_tests:
     name, self_size, args = test[:3]
@@ -2321,33 +2162,21 @@ for test in method_tests:
                 self_tensor = deepcopy(self_variable.data)
                 args_tensor = deepcopy(unpack_variables(args_variable))
                 output_variable = getattr(self_variable, name)(*args_variable)
-                output_tensor = getattr(self_tensor, name)(*args_tensor)
-                if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
-                    output_tensor = torch.DoubleTensor((output_tensor,))
-                self.assertEqual(unpack_variables(output_variable), output_tensor)
-                # TODO: check that both have changed after adding all inplace ops
-
-                def apply_method(*inputs):
-                    return getattr(inputs[0], name)(*inputs[1:])
+                if not exclude_tensor_method(name, test_name):
+                    output_tensor = getattr(self_tensor, name)(*args_tensor)
+                    if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
+                        output_tensor = torch.DoubleTensor((output_tensor,))
+                    self.assertEqual(unpack_variables(output_variable), output_tensor)
+                    # TODO: check that both have changed after adding all inplace ops
 
                 if not is_inplace and name not in EXCLUDE_GRADCHECK:
-                    self.assertTrue(gradcheck(apply_method,
-                                              (self_variable,) + args_variable,
-                                              eps=1e-6, atol=PRECISION))
-
-                    grad_y = generate_gradoutput(output_variable, non_contiguous=True)
-                    gradgradcheck_precision_override = gradgradcheck_method_precision_override(test_name)
-                    if gradgradcheck_precision_override is not None:
-                        atol = gradgradcheck_precision_override['atol']
-                        rtol = gradgradcheck_precision_override['rtol']
-                        self.assertTrue(gradgradcheck(apply_method,
-                                        (self_variable,) + args_variable, grad_y, atol=atol, rtol=rtol))
-                    else:
-                        self.assertTrue(gradgradcheck(apply_method,
-                                                      (self_variable,) + args_variable, grad_y,))
+                    run_grad_and_gradgrad_checks(self, test_name,
+                                                 lambda *inputs: getattr(inputs[0], name)(*inputs[1:]),
+                                                 output_variable, (self_variable,) + args_variable)
 
                 # functional interface tests
-                if hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL:
+                if (hasattr(torch, name) and name not in EXCLUDE_FUNCTIONAL and
+                        not exclude_tensor_method(name, test_name)):
                     f_args_variable = (self_variable,) + args_variable
                     f_args_tensor = (self_tensor,) + args_tensor
                     output_variable = getattr(torch, name)(*f_args_variable)
@@ -2355,6 +2184,14 @@ for test in method_tests:
                     if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
                         output_tensor = torch.DoubleTensor((output_tensor,))
                     self.assertEqual(unpack_variables(output_variable), output_tensor)
+
+                    if name not in EXCLUDE_GRADCHECK:
+                        run_grad_and_gradgrad_checks(self, test_name, lambda *inputs: getattr(torch, name)(*inputs),
+                                                     output_variable, f_args_variable)
+                    if isinstance(output_variable, torch.autograd.Variable):
+                        output_variable.backward(torch.randn(*output_variable.size()).type_as(output_variable.data))
+                        self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
+                        self.assertTrue(self_variable.size() == self_variable.grad.size())
 
                 # check for correct type of input.data and input.grad.data
                 if not is_inplace:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -702,6 +702,10 @@ class TestTorch(TestCase):
             res2[i] = math.pow(3, m1[i][4])
         self.assertEqual(res1, res2)
 
+    def test_rpow(self):
+        m = torch.randn(10, 10)
+        self.assertEqual(torch.pow(2, m), 2**m)
+
     def _test_cop(self, torchfn, mathfn):
         def reference_implementation(res2):
             for i, j in iter_indices(sm1):

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -320,6 +320,9 @@ class _TensorBase(object):
     def __pow__(self, other):
         return self.pow(other)
 
+    def __rpow__(self, other):
+        return torch.pow(other, self)
+
     def __ipow__(self, other):
         return self.pow_(other)
 


### PR DESCRIPTION
The goal of this PR is to leave a single procedure for specifying common autograd tests; prior to this there are both Function and method tests, which is error prone because:
1) tests need to be specified in two places
2) each way tests something different, e.g. method tests didn't test autograd, so in some cases weren't specified properly (e.g. division by 0)

Here, we prefer method tests because Functions are really an implementation detail, and relatedly we are working to remove the python overhead by moving most of the Function code to C++.

The mechanical part of this PR is basically:
1) Moving the test logic that is not duplicated from the Function tests to the method tests
2) Moving or de-duplicating the Function tests to method test equivalents
3) Small cleanups:
a) Making tensor and variable equivalent (i.e. adding __rpow__ to tensor, as it exists on Variable)
b) Moving Concat function tests to individual test cases because it doesn't have a Variable method and doesn't fit clearly in anywhere else.
c) cleaning up some method tests that failed the new checks, as mentioned above. 