### PR TITLE
AdaptiveMaxPool: change indice format to MaxPool style, support double backwards

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3990,21 +3990,18 @@ new_module_tests = [
         module_name='AdaptiveMaxPool1d',
         constructor_args=(3,),
         input=torch.rand(1, 3, 5),
-        check_gradgrad=False,
     ),
     dict(
         module_name='AdaptiveMaxPool2d',
         constructor_args=(3,),
         input=torch.rand(1, 3, 5, 6),
         desc='single',
-        check_gradgrad=False,
     ),
     dict(
         module_name='AdaptiveMaxPool2d',
         constructor_args=((3, 4),),
         input=torch.rand(1, 3, 5, 6),
         desc='tuple',
-        check_gradgrad=False,
     ),
     dict(
         module_name='AdaptiveAvgPool1d',

--- a/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -33,7 +33,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     input_data = THCTensor_(data)(state, input);
 
     THCTensor_(resize3d)(state, output, nInputPlane, nOutputRows, nOutputCols);
-    THCIndexTensor_(resize4d)(state, indices, 2, nInputPlane, nOutputRows, nOutputCols);
+    THCIndexTensor_(resize3d)(state, indices, nInputPlane, nOutputRows, nOutputCols);
 
     indices_data = THCIndexTensor_(data)(state, indices);
     output_data = THCTensor_(data)(state, output);
@@ -46,7 +46,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
-                                   indices_data+nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                   indices_data,
                                    nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols,
                                    istride_h, istride_w, istride_d);
     THCudaCheck(cudaGetLastError());
@@ -65,7 +65,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     input_data = THCTensor_(data)(state, input);
 
     THCTensor_(resize4d)(state, output, nbatch, nInputPlane, nOutputRows, nOutputCols);
-    THCIndexTensor_(resize5d)(state, indices, 2, nbatch, nInputPlane, nOutputRows, nOutputCols);
+    THCIndexTensor_(resize4d)(state, indices, nbatch, nInputPlane, nOutputRows, nOutputCols);
 
     indices_data = THCIndexTensor_(data)(state, indices);
     output_data = THCTensor_(data)(state, output);
@@ -78,7 +78,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
-                                   indices_data+nbatch*nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                   indices_data,
                                    nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols,
                                    istride_h, istride_w, istride_d);
     THCudaCheck(cudaGetLastError());
@@ -130,14 +130,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     {
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
-                                          indices_data+nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                          indices_data,
                                           nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
     }
     else
     {
       // run updateGradInput kernel
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
-                                          indices_data+nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                          indices_data,
                                           nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
     }
     THCudaCheck(cudaGetLastError());
@@ -168,14 +168,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     {
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
-                                          indices_data+nbatch*nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                          indices_data,
                                           nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
     }
     else
     {
       // run updateGradInput kernel, accumulate gradients atomically
       adaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
-                                          indices_data+nbatch*nInputPlane*nOutputCols*nOutputRows, indices_data,
+                                          indices_data,
                                           nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
     }
     THCudaCheck(cudaGetLastError());

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -529,13 +529,12 @@ class AvgPool3dBackward(Function):
 class AdaptiveMaxPool1d(Function):
 
     @staticmethod
-    def forward(ctx, input, output_size, return_indices=False):
+    def forward(ctx, input, output_size):
         if input.dim() != 3:
             raise ValueError('expected 3D input (got {}D input)'
                              .format(input.dim()))
 
         ctx.output_size = _single(output_size)
-        ctx.return_indices = return_indices
         input2d = input.unsqueeze(2)    # size = N*C*1*L
         backend = type2backend[type(input)]
         indices, output = input2d.new().long(), input2d.new()
@@ -544,23 +543,24 @@ class AdaptiveMaxPool1d(Function):
                                                        ctx.output_size[0], 1)
         indices = indices.squeeze(2)
         output = output.squeeze(2)
-        if ctx.return_indices:
-            ctx.save_for_backward(input, indices)
-            ctx.mark_non_differentiable(indices)
-            return output, indices
-        else:
-            ctx.save_for_backward(input)
-            ctx.indices = indices
-            return output
+        ctx.save_for_backward(input, indices)
+        ctx.mark_non_differentiable(indices)
+        return output, indices
 
     @staticmethod
-    @once_differentiable
     def backward(ctx, grad_output, _indices_grad=None):
-        if ctx.return_indices:
-            input, indices = ctx.saved_tensors
-        else:
-            input, = ctx.saved_tensors
-            indices = ctx.indices
+        input, indices = ctx.saved_variables
+
+        grad_input = AdaptiveMaxPool1dBackward.apply(input, indices, grad_output)
+        return grad_input, None, None
+
+
+class AdaptiveMaxPool1dBackward(Function):
+
+    @staticmethod
+    def forward(ctx, input, indices, grad_output):
+        backend = type2backend[type(input)]
+        ctx.save_for_backward(indices)
 
         input2d = input.unsqueeze(2)
         indices2d = indices.unsqueeze(2)
@@ -570,42 +570,58 @@ class AdaptiveMaxPool1d(Function):
         backend.SpatialAdaptiveMaxPooling_updateGradInput(backend.library_state,
                                                           input2d, grad_output2d, grad_input, indices2d)
         grad_input = grad_input.squeeze(2)
-        return grad_input, None, None
+        return grad_input
+
+    @staticmethod
+    def backward(ctx, ggI):
+        indices, = ctx.saved_variables
+        gI = Variable(ggI.data.new(ggI.size()).zero_())
+        ggO = ggI.gather(dim=2, index=indices)
+        return gI, None, ggO, None, None, None, None, None, None
 
 
 class AdaptiveMaxPool2d(Function):
 
     @staticmethod
-    def forward(ctx, input, output_size, return_indices=False):
+    def forward(ctx, input, output_size):
         ctx.output_size = _pair(output_size)
-        ctx.return_indices = return_indices
         backend = type2backend[type(input)]
         indices, output = input.new().long(), input.new()
         backend.SpatialAdaptiveMaxPooling_updateOutput(backend.library_state,
                                                        input, output, indices,
                                                        ctx.output_size[1], ctx.output_size[0])
-        if ctx.return_indices:
-            ctx.save_for_backward(input, indices)
-            ctx.mark_non_differentiable(indices)
-            return output, indices
-        else:
-            ctx.save_for_backward(input)
-            ctx.indices = indices
-            return output
+        ctx.save_for_backward(input, indices)
+        ctx.mark_non_differentiable(indices)
+        return output, indices
 
     @staticmethod
-    @once_differentiable
     def backward(ctx, grad_output, _indices_grad=None):
-        if ctx.return_indices:
-            input, indices = ctx.saved_tensors
-        else:
-            input, = ctx.saved_tensors
-            indices = ctx.indices
+        input, indices = ctx.saved_variables
+
+        grad_input = AdaptiveMaxPool2dBackward.apply(input, indices, grad_output)
+        return grad_input, None, None
+
+
+class AdaptiveMaxPool2dBackward(Function):
+
+    @staticmethod
+    def forward(ctx, input, indices, grad_output):
+        ctx.save_for_backward(indices)
         grad_input = grad_output.new()
         backend = type2backend[type(input)]
         backend.SpatialAdaptiveMaxPooling_updateGradInput(backend.library_state,
                                                           input, grad_output, grad_input, indices)
-        return grad_input, None, None
+        return grad_input
+
+    @staticmethod
+    def backward(ctx, ggI):
+        indices, = ctx.saved_variables
+
+        gI = Variable(ggI.data.new(ggI.size()).zero_())
+        # ggO is equivalent to the 1d case, but the indices are given wrt the last two dimensions combined
+        indices_view = indices.view(indices.size()[:-2] + (-1,))
+        ggO = ggI.contiguous().view(ggI.size()[:-2] + (-1,)).gather(dim=2, index=indices_view).view_as(indices)
+        return gI, None, ggO, None, None, None, None, None, None
 
 
 class AdaptiveAvgPool1d(Function):
@@ -709,7 +725,9 @@ _all_functions.append(MaxUnpool3d)
 _all_functions.append(FractionalMaxPool2d)
 _all_functions.append(FractionalMaxPool2dBackward)
 _all_functions.append(AdaptiveMaxPool1d)
+_all_functions.append(AdaptiveMaxPool1dBackward)
 _all_functions.append(AdaptiveMaxPool2d)
+_all_functions.append(AdaptiveMaxPool2dBackward)
 _all_functions.append(AdaptiveAvgPool1d)
 _all_functions.append(AdaptiveAvgPool1dBackward)
 _all_functions.append(AdaptiveAvgPool2d)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -388,7 +388,8 @@ def adaptive_max_pool1d(input, output_size, return_indices=False):
         output_size: the target output size (single integer)
         return_indices: whether to return pooling indices. Default: False
     """
-    return _functions.thnn.AdaptiveMaxPool1d.apply(input, output_size, return_indices)
+    ret = _functions.thnn.AdaptiveMaxPool1d.apply(input, output_size)
+    return ret if return_indices else ret[0]
 
 
 def adaptive_max_pool2d(input, output_size, return_indices=False):
@@ -402,7 +403,8 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
             double-integer tuple)
         return_indices: whether to return pooling indices. Default: False
     """
-    return _functions.thnn.AdaptiveMaxPool2d.apply(input, output_size, return_indices)
+    ret = _functions.thnn.AdaptiveMaxPool2d.apply(input, output_size)
+    return ret if return_indices else ret[0]
 
 
 def adaptive_avg_pool1d(input, output_size):


### PR DESCRIPTION
1) AdaptiveMaxPool1d/2d today has it's own index format that is relative to the kernel, i.e. in the 2d case it has a new dimension of size 2 with x and y offsets.  This is inconsistent with MaxPooling (which has indices relative to the flattened dimensions over which its operating (i.e. 2 in the 2d case).  It's difficult to do anything useful with this format (outside of computing the backwards), because the kernels are not equally spaced like with MaxPooling).  This PR changes the format to be the same as MaxPooling.
2) Support double backwards for AdaptiveMaxPooling.  Related to 1), we implement double backwards in the same way as it's implemented for MaxPooling (i.e. with gather and always returning the indices from the autograd Function).