### PR TITLE
fix bug in autograd type() for non-default GPU input

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1048,7 +1048,7 @@ class TestAutograd(TestCase):
             self.assertIs(type(x.float().cuda().data), torch.cuda.FloatTensor)
             self.assertIs(type(x.int().cuda().data), torch.cuda.IntTensor)
             self.assertIs(type(x.int().cuda().cpu().data), torch.IntTensor)
-            if torch.cuda.device_count() > 2:
+            if torch.cuda.device_count() >= 2:
                 x2 = x.float().cuda(1)
                 self.assertIs(type(x2.data), torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
@@ -1058,6 +1058,10 @@ class TestAutograd(TestCase):
                 x2 = x2.cuda(1)
                 self.assertIs(type(x2.data), torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
+                y = Variable(torch.randn(5).cuda(1), requires_grad=True)
+                y.cpu().sum().backward()
+                self.assertIs(y.grad.get_device(), 1)
+                self.assertIs(y.long().data.get_device(), 1)
 
         for t in [torch.DoubleTensor, torch.FloatTensor, torch.IntTensor, torch.ByteTensor]:
             for var in (True, False):

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -166,11 +166,16 @@ class Type(Function):
     @staticmethod
     def forward(ctx, i, dest_type):
         ctx.input_type = type(i)
+        ctx.input_device = -1 if not i.is_cuda else i.get_device()
         return i.type(dest_type)
 
     @staticmethod
     def backward(ctx, grad_output):
-        return grad_output.type(ctx.input_type), None
+        if ctx.input_device == -1:
+            return grad_output.type(ctx.input_type), None
+        else:
+            with torch.cuda.device(ctx.input_device):
+                return grad_output.type(ctx.input_type), None
 
 
 class CudaTransfer(Function):


### PR DESCRIPTION

Simple failure case where gradients of xv would be on device 0 in master, instead of device 1.

```python
import torch
from torch.autograd import Variable

x = torch.randn(10).cuda(1)
xv = Variable(x, requires_grad=True)
y = xv.cpu()
y.sum().backward()

print(xv.grad.get_device() == 1)
```