### PR TITLE
remove zero padding in orthogonal initialization

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -334,19 +334,19 @@ def orthogonal(tensor, gain=1):
     rows = tensor.size(0)
     cols = tensor[0].numel()
     flattened = torch.Tensor(rows, cols).normal_(0, 1)
+
+    if rows < cols:
+        flattened.t_()
+
     # Compute the qr factorization
     q, r = torch.qr(flattened)
     # Make Q uniform according to https://arxiv.org/pdf/math-ph/0609050.pdf
     d = torch.diag(r, 0)
     ph = d.sign()
     q *= ph.expand_as(q)
-    # Pad zeros to Q (if rows smaller than cols)
+
     if rows < cols:
-        padding = torch.zeros(rows, cols - rows)
-        if q.is_cuda:
-            q = torch.cat([q, padding.cuda()], 1)
-        else:
-            q = torch.cat([q, padding], 1)
+        q.t_()
 
     tensor.view_as(q).copy_(q)
     tensor.mul_(gain)


### PR DESCRIPTION
PR [#1453](https://github.com/pytorch/pytorch/pull/1453) switched from using svd to qr factorization to get a semi-orthogonal matrix for orthogonal initialization. However, this padded a orthogonal matrix with 0 elements to become the same size as the input tensor. While this is not wrong (rows are still orthonormal), having a lot of weights set to 0 may not be desirable. 

PR #2708 wanted to remove this zero padding by transposing the input if `rows` < `cols` and then transposing back at the end. In theory this will work, there were just a few errors in the PR causing the tests to fail:
1) the transposes were not happening in place so not changing the tensor
2) the transpose should be done on the flat representation, in the form presented in the PR it will only work for 2D weigh tensors (for linear layers).

This PR addresses these two issues and should achieve the affect that #2708 wants.