### PR TITLE
Implement THCUNN code for GridSampler

### DIFF
--- a/torch/lib/THCUNN/SpatialGridSamplerBilinear.cu
+++ b/torch/lib/THCUNN/SpatialGridSamplerBilinear.cu
@@ -1,0 +1,190 @@
+#include "THCUNN.h"
+#include "common.h"
+#include "THCDeviceTensor.cuh"
+#include "THCDeviceTensorUtils.cuh"
+#include "THCDeviceUtils.cuh"
+#include "THCHalf.h"
+#include "THCHalfAutoNumerics.cuh"
+#include "THCAtomics.cuh"
+
+#define WITHIN_BOUNDS(x, y, H, W) (x >= 0 && x < W && y >= 0 && y < H)
+#define SAFE_ADD(input, x, y, n, c, H, W, value)    \
+  do {    \
+    if (WITHIN_BOUNDS(x, y, H, W)) {    \
+      atomicAdd(&input[n][c][y][x], value);   \
+    }   \
+  } while(0)
+
+template <typename Dtype>
+__global__ void SpatialGridSamplerBilinear_updateOutput_kernel(
+    const int nthreads,
+    THCDeviceTensor<Dtype, 4> input,
+    THCDeviceTensor<Dtype, 4> grid,
+    THCDeviceTensor<Dtype, 4> output) {
+
+  int N = input.getSize(0);
+  int C = input.getSize(1);
+  int IH = input.getSize(2);
+  int IW = input.getSize(3);
+  int H = grid.getSize(1);
+  int W = grid.getSize(2);
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+
+    const int n = index % N;
+    const int h = (index / N) % H;
+    const int w = (index / (N * H)) % W;
+    int c;
+
+    // get the corresponding input x, y co-ordinates from grid
+    Dtype ix = grid[n][h][w][0];
+    Dtype iy = grid[n][h][w][1];
+
+    // normalize ix, iy from [-1, 1] to [0, IH-1] & [0, IW-1]
+    ix = ScalarConvert<float,Dtype>::to(((ix + 1) / 2) * (IW-1));
+    iy = ScalarConvert<float,Dtype>::to(((iy + 1) / 2) * (IH-1));
+
+    // get NE, NW, SE, SW pixel values from (x, y)
+    int ix_nw = floor(ScalarConvert<Dtype,float>::to(ix));
+    int iy_nw = floor(ScalarConvert<Dtype,float>::to(iy));
+    int ix_ne = ix_nw + 1;
+    int iy_ne = iy_nw;
+    int ix_sw = ix_nw;
+    int iy_sw = iy_nw + 1;
+    int ix_se = ix_nw + 1;
+    int iy_se = iy_nw + 1;
+
+    // get surfaces to each neighbor:
+    Dtype nw = (ix_se - ix)    * (iy_se - iy);
+    Dtype ne = (ix    - ix_sw) * (iy_sw - iy);
+    Dtype sw = (ix_ne - ix)    * (iy    - iy_ne);
+    Dtype se = (ix    - ix_nw) * (iy    - iy_nw);
+
+    // calculate bilinear weighted pixel value and set output pixel
+    Dtype out_val;
+    for (c = 0; c < C; ++c) {
+      out_val = ScalarConvert<int,Dtype>::to(0);
+      if (WITHIN_BOUNDS(ix_nw, iy_nw, IH, IW)) {
+        out_val += input[n][c][iy_nw][ix_nw] * nw;
+      }
+      if (WITHIN_BOUNDS(ix_ne, iy_ne, IH, IW)) {
+        out_val += input[n][c][iy_ne][ix_ne] * ne;
+      }
+      if (WITHIN_BOUNDS(ix_sw, iy_sw, IH, IW)) {
+        out_val += input[n][c][iy_sw][ix_sw] * sw;
+      }
+      if (WITHIN_BOUNDS(ix_se, iy_se, IH, IW)) {
+        out_val += input[n][c][iy_se][ix_se] * se;
+      }
+      output[n][c][h][w] = out_val;
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void SpatialGridSamplerBilinear_updateGradInput_kernel(
+    const int nthreads,
+    THCDeviceTensor<Dtype, 4> input, THCDeviceTensor<Dtype, 4> gradInput,
+    THCDeviceTensor<Dtype, 4> grid, THCDeviceTensor<Dtype, 4> gradGrid,
+    THCDeviceTensor<Dtype, 4> gradOutput) {
+
+  int N = input.getSize(0);
+  int C = input.getSize(1);
+  int IH = input.getSize(2);
+  int IW = input.getSize(3);
+  int H = grid.getSize(1);
+  int W = grid.getSize(2);
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+
+    const int n = index % N;
+    const int h = (index / N) % H;
+    const int w = (index / (N * H)) % W;
+
+    // get the corresponding input x, y co-ordinates from grid
+    Dtype ix = grid[n][h][w][0];
+    Dtype iy = grid[n][h][w][1];
+
+    Dtype gix = ScalarConvert<int,Dtype>::to(0);
+    Dtype giy = ScalarConvert<int,Dtype>::to(0);
+
+    // normalize ix, iy from [-1, 1] to [0, H-1] & [0, W-1]
+    ix = ScalarConvert<float,Dtype>::to(((ix + 1) / 2) * (IW-1));
+    iy = ScalarConvert<float,Dtype>::to(((iy + 1) / 2) * (IH-1));;
+
+    // get NE, NW, SE, SW pixel values from (x, y)
+    int ix_nw = floor(ScalarConvert<Dtype,float>::to(ix));
+    int iy_nw = floor(ScalarConvert<Dtype,float>::to(iy));;
+    int ix_ne = ix_nw + 1;
+    int iy_ne = iy_nw;
+    int ix_sw = ix_nw;
+    int iy_sw = iy_nw + 1;
+    int ix_se = ix_nw + 1;
+    int iy_se = iy_nw + 1;
+
+    // get surfaces to each neighbor:
+    Dtype nw = (ix_se - ix)    * (iy_se - iy);
+    Dtype ne = (ix    - ix_sw) * (iy_sw - iy);
+    Dtype sw = (ix_ne - ix)    * (iy    - iy_ne);
+    Dtype se = (ix    - ix_nw) * (iy    - iy_nw);
+
+    Dtype gradout;
+    Dtype nw_val;
+    Dtype ne_val;
+    Dtype sw_val;
+    Dtype se_val;
+    for (int c = 0; c < C; ++c) {
+      gradout = gradOutput[n][c][h][w];
+
+      // calculate and set gradInput
+      SAFE_ADD(gradInput, ix_nw, iy_nw, n, c, IH, IW, nw * gradout);
+      SAFE_ADD(gradInput, ix_ne, iy_ne, n, c, IH, IW, ne * gradout);
+      SAFE_ADD(gradInput, ix_sw, iy_sw, n, c, IH, IW, sw * gradout);
+      SAFE_ADD(gradInput, ix_se, iy_se, n, c, IH, IW, se * gradout);
+
+      // calculate gradGrid
+      nw_val = ScalarConvert<int,Dtype>::to(0);
+      if (WITHIN_BOUNDS(ix_nw, iy_nw, IH, IW)) {
+        nw_val = input[n][c][iy_nw][ix_nw];
+      }
+      ne_val = ScalarConvert<int,Dtype>::to(0);
+      if (WITHIN_BOUNDS(ix_ne, iy_ne, IH, IW)) {
+        ne_val = input[n][c][iy_ne][ix_ne];
+      }
+      sw_val = ScalarConvert<int,Dtype>::to(0);
+      if (WITHIN_BOUNDS(ix_sw, iy_sw, IH, IW)) {
+        sw_val = input[n][c][iy_sw][ix_sw];
+      }
+      se_val = ScalarConvert<int,Dtype>::to(0);
+      if (WITHIN_BOUNDS(ix_se, iy_se, IH, IW)) {
+        se_val = input[n][c][iy_se][ix_se];
+      }
+
+      gix += ScalarConvert<int,Dtype>::to(-1)*(nw_val * (iy_se - iy) * gradout);
+      gix += ne_val * (iy_sw - iy) * gradout;
+      gix += ScalarConvert<int,Dtype>::to(-1)*(sw_val * (iy - iy_ne) * gradout);
+      gix += se_val * (iy - iy_nw) * gradout;
+
+      giy += ScalarConvert<int,Dtype>::to(-1)*(nw_val * (ix_se - ix) * gradout);
+      giy += ScalarConvert<int,Dtype>::to(-1)*(ne_val * (ix - ix_sw) * gradout);
+      giy += sw_val * (ix_ne - ix) * gradout;
+      giy += se_val * (ix - ix_nw) * gradout;
+    }
+
+    // un-normalize gradGrid values back to [-1, 1] constraints
+    gix = gix * (IW - 1) / 2;
+    giy = giy * (IH - 1) / 2;
+
+    Dtype gix_old = gradGrid[n][h][w][0];
+    Dtype giy_old = gradGrid[n][h][w][1];
+
+    gradGrid[n][h][w][0] = gix_old + gix;
+    gradGrid[n][h][w][1] = giy_old + giy;
+  }
+}
+
+#undef WITHIN_BOUNDS
+#undef SAFE_ADD
+
+#include "generic/SpatialGridSamplerBilinear.cu"
+#include "THCGenerateFloatTypes.h"

--- a/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -12,12 +12,12 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)(
   THCUNN_argCheck(state, THCTensor_(nDimension)(state, grid) == 4, 2, grid,
       "4D grid tensor expected but got: %s");
 
-  int nbatch   = THCTensor_(size)(state, input, 0);
-  int channels = THCTensor_(size)(state, input, 1);
-  int iheight   = THCTensor_(size)(state, input, 2);
-  int iwidth    = THCTensor_(size)(state, input, 3);
-  int oheight   = THCTensor_(size)(state, grid, 1);
-  int owidth    = THCTensor_(size)(state, grid, 2);
+  int64_t nbatch   = THCTensor_(size)(state, input, 0);
+  int64_t channels = THCTensor_(size)(state, input, 1);
+  int64_t iheight   = THCTensor_(size)(state, input, 2);
+  int64_t iwidth    = THCTensor_(size)(state, input, 3);
+  int64_t oheight   = THCTensor_(size)(state, grid, 1);
+  int64_t owidth    = THCTensor_(size)(state, grid, 2);
 
   THCUNN_check_dim_size(state, grid, 4, 0, nbatch);
   THCUNN_check_dim_size(state, grid, 4, 3, 2);
@@ -38,12 +38,12 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
 
   THCUNN_assertSameGPU(state, 3, input, grid, output);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, NULL);
-  int N = THCTensor_(size)(state, input, 0);
-  int C = THCTensor_(size)(state, input, 1);
-  int IH = THCTensor_(size)(state, input, 2);
-  int IW = THCTensor_(size)(state, input, 3);
-  int H = THCTensor_(size)(state,grid, 1);
-  int W = THCTensor_(size)(state, grid, 2);
+  int64_t N = THCTensor_(size)(state, input, 0);
+  int64_t C = THCTensor_(size)(state, input, 1);
+  int64_t IH = THCTensor_(size)(state, input, 2);
+  int64_t IW = THCTensor_(size)(state, input, 3);
+  int64_t H = THCTensor_(size)(state,grid, 1);
+  int64_t W = THCTensor_(size)(state, grid, 2);
 
   // resize output to the same shape as input
   THCTensor_(resize4d)(state, output, N, C, H, W);
@@ -52,7 +52,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
   THCDeviceTensor<real, 4> devGrid = toDeviceTensor<real, 4>(state, grid);
   THCDeviceTensor<real, 4> devOutput = toDeviceTensor<real, 4>(state, output);
 
-  int count = N*H*W*2;
+  int64_t count = N*H*W*2;
   SpatialGridSamplerBilinear_updateOutput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
       count, devInput, devGrid, devOutput);
@@ -66,12 +66,12 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
 
   THCUNN_assertSameGPU(state, 5, input, gradInput, grid, gradGrid, gradOutput);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, gradOutput);
-  int N = THCTensor_(size)(state, input, 0);
-  int C = THCTensor_(size)(state, input, 1);
-  int IH = THCTensor_(size)(state, input, 2);
-  int IW = THCTensor_(size)(state, input, 3);
-  int H = THCTensor_(size)(state, grid, 1);
-  int W = THCTensor_(size)(state, grid, 2);
+  int64_t N = THCTensor_(size)(state, input, 0);
+  int64_t C = THCTensor_(size)(state, input, 1);
+  int64_t IH = THCTensor_(size)(state, input, 2);
+  int64_t IW = THCTensor_(size)(state, input, 3);
+  int64_t H = THCTensor_(size)(state, grid, 1);
+  int64_t W = THCTensor_(size)(state, grid, 2);
 
   THCTensor_(resize4d)(state, gradInput, N, C, IH, IW);
   THCTensor_(resize4d)(state, gradGrid, N, H, W, 2);
@@ -84,7 +84,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
   THCDeviceTensor<real, 4> devGradGrid = toDeviceTensor<real, 4>(state, gradGrid);
   THCDeviceTensor<real, 4> devGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
 
-  int count = N*H*W;
+  int64_t count = N*H*W;
   SpatialGridSamplerBilinear_updateGradInput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
       count, devInput, devGradInput, devGrid, devGradGrid, devGradOutput);

--- a/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -52,7 +52,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
   THCDeviceTensor<real, 4> devGrid = toDeviceTensor<real, 4>(state, grid);
   THCDeviceTensor<real, 4> devOutput = toDeviceTensor<real, 4>(state, output);
 
-  int64_t count = N*H*W*2;
+  int count = static_cast<int>(N*H*W);
   SpatialGridSamplerBilinear_updateOutput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
       count, devInput, devGrid, devOutput);

--- a/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -84,7 +84,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
   THCDeviceTensor<real, 4> devGradGrid = toDeviceTensor<real, 4>(state, gradGrid);
   THCDeviceTensor<real, 4> devGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
 
-  int64_t count = N*H*W;
+  int count = static_cast<int>(N*H*W);
   SpatialGridSamplerBilinear_updateGradInput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
       count, devInput, devGradInput, devGrid, devGradGrid, devGradOutput);

--- a/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/torch/lib/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -1,0 +1,93 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/SpatialGridSamplerBilinear.cu"
+#else
+
+static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)(
+    THCState *state,
+    THCTensor *input,
+    THCTensor *grid,
+    THCTensor *gradOutput) {
+  THCUNN_argCheck(state, THCTensor_(nDimension)(state, input) == 4, 2, input,
+      "4D input tensor expected but got: %s");
+  THCUNN_argCheck(state, THCTensor_(nDimension)(state, grid) == 4, 2, grid,
+      "4D grid tensor expected but got: %s");
+
+  int nbatch   = THCTensor_(size)(state, input, 0);
+  int channels = THCTensor_(size)(state, input, 1);
+  int iheight   = THCTensor_(size)(state, input, 2);
+  int iwidth    = THCTensor_(size)(state, input, 3);
+  int oheight   = THCTensor_(size)(state, grid, 1);
+  int owidth    = THCTensor_(size)(state, grid, 2);
+
+  THCUNN_check_dim_size(state, grid, 4, 0, nbatch);
+  THCUNN_check_dim_size(state, grid, 4, 3, 2);
+
+  if (gradOutput != NULL) {
+    THCUNN_check_dim_size(state, gradOutput, 4, 0, nbatch);
+    THCUNN_check_dim_size(state, gradOutput, 4, 1, channels);
+    THCUNN_check_dim_size(state, gradOutput, 4, 2, oheight);
+    THCUNN_check_dim_size(state, gradOutput, 4, 3, owidth);
+  }
+}
+
+TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
+    THCState *state,
+    THCTensor *input,
+    THCTensor *grid,
+    THCTensor *output) {
+
+  THCUNN_assertSameGPU(state, 3, input, grid, output);
+  THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, NULL);
+  int N = THCTensor_(size)(state, input, 0);
+  int C = THCTensor_(size)(state, input, 1);
+  int IH = THCTensor_(size)(state, input, 2);
+  int IW = THCTensor_(size)(state, input, 3);
+  int H = THCTensor_(size)(state,grid, 1);
+  int W = THCTensor_(size)(state, grid, 2);
+
+  // resize output to the same shape as input
+  THCTensor_(resize4d)(state, output, N, C, H, W);
+
+  THCDeviceTensor<real, 4> devInput = toDeviceTensor<real, 4>(state, input);
+  THCDeviceTensor<real, 4> devGrid = toDeviceTensor<real, 4>(state, grid);
+  THCDeviceTensor<real, 4> devOutput = toDeviceTensor<real, 4>(state, output);
+
+  int count = N*H*W*2;
+  SpatialGridSamplerBilinear_updateOutput_kernel
+    <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count, devInput, devGrid, devOutput);
+}
+
+TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
+    THCState *state,
+    THCTensor *input, THCTensor *gradInput,
+    THCTensor *grid, THCTensor *gradGrid,
+    THCTensor *gradOutput) {
+
+  THCUNN_assertSameGPU(state, 5, input, gradInput, grid, gradGrid, gradOutput);
+  THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, gradOutput);
+  int N = THCTensor_(size)(state, input, 0);
+  int C = THCTensor_(size)(state, input, 1);
+  int IH = THCTensor_(size)(state, input, 2);
+  int IW = THCTensor_(size)(state, input, 3);
+  int H = THCTensor_(size)(state, grid, 1);
+  int W = THCTensor_(size)(state, grid, 2);
+
+  THCTensor_(resize4d)(state, gradInput, N, C, IH, IW);
+  THCTensor_(resize4d)(state, gradGrid, N, H, W, 2);
+  THCTensor_(zero)(state, gradInput);
+  THCTensor_(zero)(state, gradGrid);
+
+  THCDeviceTensor<real, 4> devInput = toDeviceTensor<real, 4>(state, input);
+  THCDeviceTensor<real, 4> devGradInput = toDeviceTensor<real, 4>(state, gradInput);
+  THCDeviceTensor<real, 4> devGrid = toDeviceTensor<real, 4>(state, grid);
+  THCDeviceTensor<real, 4> devGradGrid = toDeviceTensor<real, 4>(state, gradGrid);
+  THCDeviceTensor<real, 4> devGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
+
+  int count = N*H*W;
+  SpatialGridSamplerBilinear_updateGradInput_kernel
+    <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      count, devInput, devGradInput, devGrid, devGradGrid, devGradOutput);
+}
+
+#endif

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -1012,6 +1012,18 @@ TH_API void THNN_(SpatialUpSamplingNearest_updateOutput)(
                   THCTensor *output,
                   int scale_factor);
 
+TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
+	               THCState *state,
+	               THCTensor *input,
+	               THCTensor *grid,
+	               THCTensor *output);
+
+TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
+	               THCState *state,
+	               THCTensor *input, THCTensor *gradInput,
+	               THCTensor *grid, THCTensor *gradGrid,
+	               THCTensor *gradOutput);
+
 TH_API void THNN_(RReLU_updateOutput)(
                   THCState *state,
                   THCTensor *input,

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -1013,16 +1013,16 @@ TH_API void THNN_(SpatialUpSamplingNearest_updateOutput)(
                   int scale_factor);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
-	               THCState *state,
-	               THCTensor *input,
-	               THCTensor *grid,
-	               THCTensor *output);
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *grid,
+                  THCTensor *output);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
-	               THCState *state,
-	               THCTensor *input, THCTensor *gradInput,
-	               THCTensor *grid, THCTensor *gradGrid,
-	               THCTensor *gradOutput);
+                  THCState *state,
+                  THCTensor *input, THCTensor *gradInput,
+                  THCTensor *grid, THCTensor *gradGrid,
+                  THCTensor *gradOutput);
 
 TH_API void THNN_(RReLU_updateOutput)(
                   THCState *state,

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -9,15 +9,10 @@ import torch.backends.cudnn as cudnn
 class GridSampler(Function):
 
     @staticmethod
-    def _enforce_cudnn(input):
-        assert cudnn.is_acceptable(input)
-
-    @staticmethod
     def forward(ctx, input, grid):
         ctx.save_for_backward(input, grid)
         grid_sz = grid.size()
-        if input.is_cuda and cudnn.enabled:
-            GridSampler._enforce_cudnn(input)
+        if cudnn.is_acceptable(input):
             output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
             grid = grid.contiguous()
             if 0 in input.stride():
@@ -33,8 +28,7 @@ class GridSampler(Function):
     @once_differentiable
     def backward(ctx, grad_output):
         input, grid = ctx.saved_tensors
-        if input.is_cuda and cudnn.enabled:
-            GridSampler._enforce_cudnn(input)
+        if cudnn.is_acceptable(input):
             grad_input = input.new(input.size())
             grad_grid = grid.new(grid.size())
             grid = grid.contiguous()

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -9,24 +9,47 @@ import torch.backends.cudnn as cudnn
 class GridSampler(Function):
 
     @staticmethod
+    def _enforce_cudnn(input):
+        assert cudnn.is_acceptable(input)
+
+    @staticmethod
     def forward(ctx, input, grid):
         ctx.save_for_backward(input, grid)
         grid_sz = grid.size()
-        backend = type2backend[type(input)]
-        output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
-        backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output)
+        if input.is_cuda and cudnn.enabled:
+            GridSampler._enforce_cudnn(input)
+            output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
+            grid = grid.contiguous()
+            if 0 in input.stride():
+                input = input.contiguous()
+            torch._C._cudnn_grid_sampler_forward(input, grid, output)
+        else:
+            backend = type2backend[type(input)]
+            output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
+            backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output)
         return output
 
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_output):
         input, grid = ctx.saved_tensors
-        backend = type2backend[type(input)]
-        grad_input = input.new(input.size())
-        grad_grid = grid.new(grid.size())
-        backend.SpatialGridSamplerBilinear_updateGradInput(
-            backend.library_state, input, grad_input,
-            grid, grad_grid, grad_output)
+        if input.is_cuda and cudnn.enabled:
+            GridSampler._enforce_cudnn(input)
+            grad_input = input.new(input.size())
+            grad_grid = grid.new(grid.size())
+            grid = grid.contiguous()
+            if 0 in input.stride():
+                input = input.contiguous()
+            torch._C._cudnn_grid_sampler_backward(input, grad_input,
+                                                  grid, grad_grid,
+                                                  grad_output)
+        else:
+            backend = type2backend[type(input)]
+            grad_input = input.new(input.size())
+            grad_grid = grid.new(grid.size())
+            backend.SpatialGridSamplerBilinear_updateGradInput(
+                backend.library_state, input, grad_input,
+                grid, grad_grid, grad_output)
         return grad_input, grad_grid
 
 

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -9,50 +9,24 @@ import torch.backends.cudnn as cudnn
 class GridSampler(Function):
 
     @staticmethod
-    def _enforce_cudnn(input):
-        if not cudnn.enabled:
-            raise RuntimeError("GridSampler needs CuDNN for processing CUDA inputs,"
-                               " but CuDNN is not enabled")
-        assert cudnn.is_acceptable(input)
-
-    @staticmethod
     def forward(ctx, input, grid):
         ctx.save_for_backward(input, grid)
         grid_sz = grid.size()
-        if input.is_cuda:
-            GridSampler._enforce_cudnn(input)
-            output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
-            grid = grid.contiguous()
-            if 0 in input.stride():
-                input = input.contiguous()
-            torch._C._cudnn_grid_sampler_forward(input, grid, output)
-        else:
-            backend = type2backend[type(input)]
-            output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
-            backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output)
+        backend = type2backend[type(input)]
+        output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
+        backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output)
         return output
 
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_output):
         input, grid = ctx.saved_tensors
-        if input.is_cuda:
-            GridSampler._enforce_cudnn(input)
-            grad_input = input.new(input.size())
-            grad_grid = grid.new(grid.size())
-            grid = grid.contiguous()
-            if 0 in input.stride():
-                input = input.contiguous()
-            torch._C._cudnn_grid_sampler_backward(input, grad_input,
-                                                  grid, grad_grid,
-                                                  grad_output)
-        else:
-            backend = type2backend[type(input)]
-            grad_input = input.new(input.size())
-            grad_grid = grid.new(grid.size())
-            backend.SpatialGridSamplerBilinear_updateGradInput(
-                backend.library_state, input, grad_input,
-                grid, grad_grid, grad_output)
+        backend = type2backend[type(input)]
+        grad_input = input.new(input.size())
+        grad_grid = grid.new(grid.size())
+        backend.SpatialGridSamplerBilinear_updateGradInput(
+            backend.library_state, input, grad_input,
+            grid, grad_grid, grad_output)
         return grad_input, grad_grid
 
 


### PR DESCRIPTION
## Summary
Implemented a THCUNN version of https://github.com/pytorch/pytorch/blob/master/torch/lib/THNN/generic/SpatialGridSamplerBilinear.c and changed GridSampler to use the new THCUNN SpatialGridSamplerBilinear when CUDNN isn't available.

This change should make it nicer for #2625 to happen.

## Test plan
  `test/run_tests.sh`