### PR TITLE
DOC: i{send, recv} message order with MPI backend

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -141,6 +141,10 @@ as they should never be created manually, but they are guaranteed to support two
 * ``is_completed()`` - returns True if the operation has finished
 * ``wait()`` - will block the process until the operation is finished.
   ``is_completed()`` is guaranteed to return True once it returns.
+  
+When using the MPI backend, :func:`~torch.distributed.isend` and :func:`~torch.distributed.irecv`
+support non-overtaking, which has some guarantees on supporting message order. For more detail, see
+http://mpi-forum.org/docs/mpi-2.2/mpi22-report/node54.htm#Node54
 
 .. autofunction:: isend
 


### PR DESCRIPTION
Adds a link in the docs to http://mpi-forum.org/docs/mpi-2.2/mpi22-report/node54.htm#Node54

This comes from a forum post I asked: https://discuss.pytorch.org/t/sending-many-tensors-with-isend-possible-identify-which-tensor-sent/7406