### PR TITLE
Specifying the value used for padding

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -84,7 +84,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     return PackedSequence(torch.cat(steps), batch_sizes)
 
 
-def pad_packed_sequence(sequence, padding_value=0.0, batch_first=False):
+def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0):
     """Pads a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
@@ -97,9 +97,9 @@ def pad_packed_sequence(sequence, padding_value=0.0, batch_first=False):
 
     Arguments:
         sequence (PackedSequence): batch to pad
-        padding_value (float, optional): values for padded elements
         batch_first (bool, optional): if True, the output will be in BxTx*
             format.
+        padding_value (float, optional): values for padded elements
 
     Returns:
         Tuple of Variable containing the padded sequence, and a list of lengths

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -84,7 +84,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     return PackedSequence(torch.cat(steps), batch_sizes)
 
 
-def pad_packed_sequence(sequence, batch_first=False):
+def pad_packed_sequence(sequence, padding_value=0.0, batch_first=False):
     """Pads a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
@@ -97,6 +97,7 @@ def pad_packed_sequence(sequence, batch_first=False):
 
     Arguments:
         sequence (PackedSequence): batch to pad
+        padding_value (float, optional): values for padded elements
         batch_first (bool, optional): if True, the output will be in BxTx*
             format.
 
@@ -106,7 +107,7 @@ def pad_packed_sequence(sequence, batch_first=False):
     """
     var_data, batch_sizes = sequence
     max_batch_size = batch_sizes[0]
-    output = var_data.data.new(len(batch_sizes), max_batch_size, *var_data.size()[1:]).zero_()
+    output = var_data.data.new(len(batch_sizes), max_batch_size, *var_data.size()[1:]).fill_(padding_value)
     output = Variable(output)
 
     lengths = []


### PR DESCRIPTION
The "pad_packed_sequence" function fills padded elements with zeros, but sometimes it is not useful. For example, some previous papers on NLP, including my recent paper [1], use a max-pooling technique for RNN-based sentence representations. More specifically, the max-pooling technique selects the maximum value from all time steps (i.e., hidden states) for each dimension. In such a case, we do not want the padded zeros to be selected. To overcome this situation, we can simply use a very small value instead of zero.

An LSTM example is shown below:

input = embedding(Variable(batchInput))
packedInput = torch.nn.utils.rnn.pack_padded_sequence(input, lengths, batch_first = True)
h, (hn, cn) = lstm(packedInput, (h0, c0))
h, _ = torch.nn.utils.rnn.pad_packed_sequence(h, -1024.0, batch_first = True)
sentenceRep, _ = torch.max(h, 1, keepdim = True)

[1] A Joint Many-Task Model: Growing a Neural Network for Multiple NLP Tasks. Kazuma Hashimoto, Caiming Xiong, Yoshimasa Tsuruoka, and Richard Socher. The 2017 Conference on Empirical Methods in Natural Language Processing (EMNLP 2017).
https://arxiv.org/abs/1611.01587 (Equation (4))