### PR TITLE
serialization fix to preserve backward compatibility and contbuild

### DIFF
--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -6,7 +6,7 @@
 
 void THPTensor_(writeMetadataRaw)(THTensor *self, int fd)
 {
-  SYSCHECK(write(fd, &self->nDimension, sizeof(self->nDimension)));
+  SYSCHECK(write(fd, &self->nDimension, sizeof(int64_t)));
   SYSCHECK(write(fd, self->size, sizeof(*self->size) * self->nDimension));
   SYSCHECK(write(fd, self->stride, sizeof(*self->stride) * self->nDimension));
   SYSCHECK(write(fd, &self->storageOffset, sizeof(self->storageOffset)));
@@ -15,7 +15,7 @@ void THPTensor_(writeMetadataRaw)(THTensor *self, int fd)
 THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage)
 {
   THTensorPtr tensor(THTensor_(new)(LIBRARY_STATE_NOARGS));
-  SYSCHECK(read(fd, &tensor->nDimension, sizeof(tensor->nDimension)));
+  SYSCHECK(read(fd, &tensor->nDimension, sizeof(int64_t)));
   tensor->size = (int64_t*)THAlloc(tensor->nDimension * sizeof(*tensor->size));
   tensor->stride = (int64_t*)THAlloc(tensor->nDimension * sizeof(*tensor->stride));
   SYSCHECK(read(fd, tensor->size, sizeof(*tensor->size) * tensor->nDimension));


### PR DESCRIPTION
As @fmassa discovered, we've been reading and writing `self.nDimension` in serialization as a `long`, even though it was an `int`. I think we need to do a more proper fix for this that's back-compatible, but right now this gets things into a working state.