### PR TITLE
[Done]parallelize elementwise operation with openmp

### DIFF
--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -256,7 +256,6 @@
 
 #define TH_OMP_OVERHEAD_THRESHOLD_OMP 5000
 #include <omp.h>
-#include <x86intrin.h>
 
 /*
  * Calcuate the memory offset of an element in a tensor. The strategy is below:

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -370,16 +370,16 @@
   if( CONTIG1 && CONTIG2 ){                                                                    \
     ptrdiff_t iter = 0;                                                                        \
     if(tp != rp) {                                                                             \
-      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp)) \
       PRAGMA(ivdep) \
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp)) \
       for (iter = 0; iter < SIZE; iter++) {                             \
         TYPE2 *TENSOR2##_data = tp+iter;                                \
         TYPE1 *TENSOR1##_data = rp+iter;                                \
         CODE                                                            \
       }\
     } else {\
-      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp) )  \
       PRAGMA(simd) \
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE2* TENSOR2##_data = tp+iter;\
         TYPE1* TENSOR1##_data = rp+iter;\
@@ -448,8 +448,8 @@
   if(CONTIG1 && CONTIG2 && CONTIG3){                                                                    \
     ptrdiff_t iter = 0;\
     if (rp != tp) { \
-      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) )  \
       PRAGMA(ivdep) \
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE1 *TENSOR1##_data = rp+iter;\
         TYPE2 *TENSOR2##_data = tp+iter; \
@@ -457,6 +457,7 @@
         CODE                                \
       } \
     } else {\
+      PRAGMA(simd) \
       PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) )  \
       for (iter = 0; iter < SIZE; iter++) {\
         TYPE1 *TENSOR1##_data = rp+iter;\

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -94,6 +94,16 @@
       /* Stride of the inner most section */ \
       TENSOR##_stride = TENSOR##_strides[TENSOR##_dim-1]; \
     } \
+    else{\
+      TENSOR##_dim = 1;\
+      TENSOR##_counter = (int64_t*)THAlloc(sizeof(int64_t)*3);\
+      TENSOR##_sizes = TENSOR##_counter + 1;\
+      TENSOR##_strides = TENSOR##_counter + 2;\
+      TENSOR##_sizes[0] = TENSOR##_n;\
+      TENSOR##_strides[0] = 1;\
+      TENSOR##_size = TENSOR##_sizes[0];\
+      TENSOR##_stride = TENSOR##_strides[0];\
+    }\
   } \
   TENSOR##_i = 0;
 
@@ -235,4 +245,238 @@
 #define TH_TENSOR_APPLY(TYPE, TENSOR, CODE) \
   TH_TENSOR_APPLY_D(TYPE, TENSOR, -1, CODE)
 
+
+#ifdef _OPENMP
+
+#ifndef _WIN32
+#define PRAGMA(P) _Pragma(#P)
+#else
+#define PRAGMA(P) __pragma(P)
+#endif
+
+#define TH_OMP_OVERHEAD_THRESHOLD_OMP 5000
+#include <omp.h>
+#include <x86intrin.h>
+
+#define __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR) \
+  int64_t *TENSOR##_counter_tmp = (int64_t*)THAlloc(sizeof(int64_t) * TENSOR##_dim);\
+  ptrdiff_t TENSOR##_offset = 0;                                                                \
+  ptrdiff_t TENSOR##_quot = line_index_offset;                                                           \
+  for (TENSOR##_i = TENSOR##_dim-1; TENSOR##_i>=0; --TENSOR##_i) {                              \
+    TENSOR##_counter_tmp[TENSOR##_i] = TENSOR##_quot%TENSOR##_sizes[TENSOR##_i];                         \
+    TENSOR##_quot /= TENSOR##_sizes[TENSOR##_i];                                                         \
+    TENSOR##_offset += TENSOR##_counter_tmp[TENSOR##_i] * TENSOR##_strides[TENSOR##_i];         \
+  }
+
+#define __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR) \
+  if(TENSOR##_i == TENSOR##_size && TENSOR##_dim > 1){ \
+    int TENSOR##_carry_coord = 1; \
+    TENSOR##_data -= TENSOR##_size * TENSOR##_stride; \
+    TENSOR##_start = 0;                               \
+    for(TENSOR##_i = TENSOR##_dim - 2; (TENSOR##_i >= 0) && (TENSOR##_carry_coord); TENSOR##_i--){ \
+      TENSOR##_counter_tmp[TENSOR##_i]++; \
+      TENSOR##_data += TENSOR##_strides[TENSOR##_i]; \
+      if(TENSOR##_counter_tmp[TENSOR##_i] == TENSOR##_sizes[TENSOR##_i]){ \
+        TENSOR##_data -= TENSOR##_sizes[TENSOR##_i] * TENSOR##_strides[TENSOR##_i]; \
+        TENSOR##_counter_tmp[TENSOR##_i] = 0; \
+      } else { \
+        TENSOR##_carry_coord = 0; \
+      } \
+    } \
+  } else { \
+    TENSOR##_start = TENSOR##_i;                               \
+  }
+
+
+#define TH_TENSOR_APPLY_REDUCTION_OMP(TYPE, TENSOR, OPERATION, CODE) \
+{\
+  TYPE *rp = TENSOR->storage->data+TENSOR->storageOffset;                   \
+  int TENSOR##Contg = THTensor_(isContiguous)(TENSOR);                      \
+  ptrdiff_t TENSOR##Size = THTensor_(nElement)(TENSOR);                     \
+  ptrdiff_t iter = 0;                                                         \
+  if(TENSOR##Contg){                                                         \
+    TYPE *TENSOR##_data = NULL;         \
+    PRAGMA( omp parallel for if (TENSOR##Size > TH_OMP_OVERHEAD_THRESHOLD_OMP) private(TENSOR##_data,  iter) reduction(OPERATION) ) \
+    for (iter = 0; iter < TENSOR##Size; iter++) { \
+      TENSOR##_data = rp+iter;                    \
+      CODE                                         \
+    }                                              \
+  } else {                                         \
+    int TH_TENSOR_APPLY_hasFinished = 0;           \
+    int64_t TH_TENSOR_dim_index = 0;               \
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, -1, 1);\
+    PRAGMA(omp parallel if (TENSOR##Size > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(TENSOR##_sizes, TENSOR##_strides, TENSOR##_dim, TENSOR##_stride, TENSOR##_size, TENSOR##_i) reduction(OPERATION))\
+    {\
+      size_t num_threads = omp_get_num_threads();\
+      size_t tid = omp_get_thread_num();\
+      ptrdiff_t line_index_offset = tid * (TENSOR##Size/num_threads);\
+      ptrdiff_t line_index_end = (tid == num_threads - 1) ? TENSOR##Size:(line_index_offset + TENSOR##Size/num_threads);\
+      ptrdiff_t line_seg_len = line_index_end - line_index_offset;\
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR);\
+      TYPE *TENSOR##_data = rp + TENSOR##_offset;\
+      ptrdiff_t count = 0;\
+      ptrdiff_t TENSOR##_start = TENSOR##_counter_tmp[TENSOR##_dim - 1];\
+      while(count < line_seg_len){\
+        for(TENSOR##_i=TENSOR##_start; (count < line_seg_len)&&(TENSOR##_i < TENSOR##_size); ++TENSOR##_i, ++count){\
+          CODE\
+          TENSOR##_data += TENSOR##_stride;\
+        }\
+        if(count < line_seg_len){\
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR);\
+        }\
+      }\
+      if(TENSOR##_counter_tmp != NULL) \
+        THFree(TENSOR##_counter_tmp); \
+    }\
+    if(TENSOR##_counter != NULL)\
+      THFree(TENSOR##_counter);\
+  }\
+}
+#define TH_TENSOR_APPLY2_OMP(SIZE, CONTIG1, CONTIG2, TYPE1, TENSOR1, TYPE2, TENSOR2, CODE) \
+{                                                                                              \
+  /* for advanced searching index*/                                                            \
+  TYPE1 *rp = TENSOR1->storage->data+TENSOR1->storageOffset;                                    \
+  TYPE2 *tp = TENSOR2->storage->data+TENSOR2->storageOffset;                                    \
+  if( CONTIG1 && CONTIG2 ){                                                                    \
+    ptrdiff_t iter = 0;                                                                        \
+    if(tp != rp) {                                                                             \
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp)) \
+      PRAGMA(ivdep) \
+      for (iter = 0; iter < SIZE; iter++) {                             \
+        TYPE2 *TENSOR2##_data = tp+iter;                                \
+        TYPE1 *TENSOR1##_data = rp+iter;                                \
+        CODE                                                            \
+      }\
+    } else {\
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(rp, tp) )  \
+      PRAGMA(simd) \
+      for (iter = 0; iter < SIZE; iter++) {\
+        TYPE2* TENSOR2##_data = tp+iter;\
+        TYPE1* TENSOR1##_data = rp+iter;\
+        CODE                                \
+      }\
+    }\
+  } else {              \
+    int TH_TENSOR_APPLY_hasFinished = 0; \
+    int64_t TH_TENSOR_dim_index = 0; \
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, -1, 1) \
+    PRAGMA(omp parallel if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(TENSOR2##_sizes, TENSOR2##_strides, TENSOR2##_dim, TENSOR2##_stride, TENSOR2##_size, TENSOR2##_i, TENSOR1##_sizes, TENSOR1##_strides, TENSOR1##_dim, TENSOR1##_stride, TENSOR1##_size, TENSOR1##_i)) \
+    {                                                                                                    \
+      size_t num_threads = omp_get_num_threads();                                                        \
+      size_t tid = omp_get_thread_num();                                                                 \
+      ptrdiff_t line_index_offset = tid * (SIZE/num_threads);                                            \
+      ptrdiff_t line_index_end = (tid == num_threads - 1) ? SIZE:(line_index_offset + SIZE/num_threads); \
+      ptrdiff_t line_seg_len = line_index_end - line_index_offset;                                       \
+      /*divided segment maybe does not cover the size of the last contiguous dimension*/                 \
+      /*calculate each coord of the preamble tensor*/                                                    \
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR2);                                                            \
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR1);                                                            \
+      TYPE2 *TENSOR2##_data = tp + TENSOR2##_offset;                                                     \
+      TYPE1 *TENSOR1##_data = rp + TENSOR1##_offset;                                                     \
+      ptrdiff_t count = 0;                                                                               \
+      ptrdiff_t TENSOR2##_start =  TENSOR2##_counter_tmp[TENSOR2##_dim-1];                               \
+      ptrdiff_t TENSOR1##_start =  TENSOR1##_counter_tmp[TENSOR1##_dim-1];                               \
+      while (count < line_seg_len) {                                                                     \
+        for(TENSOR2##_i=TENSOR2##_start, TENSOR1##_i = TENSOR1##_start; ((count < line_seg_len) && (TENSOR2##_i < TENSOR2##_size) && (TENSOR1##_i < TENSOR1##_size)); ++TENSOR2##_i, ++TENSOR1##_i, ++count){ \
+          CODE                                                                                               \
+          TENSOR2##_data += TENSOR2##_stride;                                                                \
+          TENSOR1##_data += TENSOR1##_stride;                                                                \
+        }                                                                                                    \
+        if (count < line_seg_len){                                                                           \
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR2);                                                   \
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR1);                                                   \
+        }                                                                                                    \
+      }                                                                                                      \
+      if(TENSOR1##_counter_tmp != NULL) \
+        THFree(TENSOR1##_counter_tmp); \
+      if(TENSOR2##_counter_tmp != NULL) \
+        THFree(TENSOR2##_counter_tmp); \
+    }                                                                                                        \
+    if(TENSOR2##_counter != NULL) \
+      THFree(TENSOR2##_counter); \
+    if(TENSOR1##_counter != NULL) \
+      THFree(TENSOR1##_counter);\
+  }\
+}
+
+#define TH_TENSOR_APPLY3_OMP(SIZE, CONTIG1, CONTIG2, CONTIG3, TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, CODE) \
+{                                                                             \
+  /* for adveanced searching index*/                                                                    \
+  TYPE1 *rp = TENSOR1->storage->data+TENSOR1->storageOffset;                                             \
+  TYPE2 *tp = TENSOR2->storage->data+TENSOR2->storageOffset;                                             \
+  TYPE3 *srcp = TENSOR3->storage->data+TENSOR3->storageOffset;                                           \
+  if(CONTIG1 && CONTIG2 && CONTIG3){                                                                    \
+    ptrdiff_t iter = 0;\
+    if (rp != tp) { \
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) )  \
+      PRAGMA(ivdep) \
+      for (iter = 0; iter < SIZE; iter++) {\
+        TYPE1 *TENSOR1##_data = rp+iter;\
+        TYPE2 *TENSOR2##_data = tp+iter; \
+        TYPE3 *TENSOR3##_data = srcp+iter;\
+        CODE                                \
+      } \
+    } else {\
+      PRAGMA( omp parallel for if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) )  \
+      for (iter = 0; iter < SIZE; iter++) {\
+        TYPE1 *TENSOR1##_data = rp+iter;\
+        TYPE2 *TENSOR2##_data = tp+iter; \
+        TYPE3 *TENSOR3##_data = srcp+iter;\
+        CODE                                \
+      } \
+    }\
+  } else{              \
+    int TH_TENSOR_APPLY_hasFinished = 0;\
+    int64_t TH_TENSOR_dim_index = 0;\
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, -1, 1) \
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \
+    __TH_TENSOR_APPLYX_PREAMBLE(TYPE3, TENSOR3, -1, 1) \
+    PRAGMA(omp parallel if (SIZE > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(TENSOR1##_sizes, TENSOR1##_strides, TENSOR1##_dim, TENSOR1##_stride, TENSOR1##_size, TENSOR1##_i, TENSOR2##_sizes, TENSOR2##_strides, TENSOR2##_dim, TENSOR2##_stride, TENSOR2##_size, TENSOR2##_i, TENSOR3##_sizes, TENSOR3##_strides, TENSOR3##_dim, TENSOR3##_stride, TENSOR3##_size, TENSOR3##_i))\
+    {\
+      size_t num_threads = omp_get_num_threads();\
+      size_t tid = omp_get_thread_num();\
+      ptrdiff_t line_index_offset = tid * (SIZE/num_threads);\
+      ptrdiff_t line_index_end = (tid == num_threads - 1)? SIZE:(line_index_offset + SIZE/num_threads);\
+      ptrdiff_t line_seg_len = line_index_end - line_index_offset;\
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR1);\
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR2);\
+      __TH_TENSOR_APPLYX_CAL_OFFSET(TENSOR3);\
+      TYPE1 *TENSOR1##_data = rp + TENSOR1##_offset;\
+      TYPE2 *TENSOR2##_data = tp + TENSOR2##_offset;\
+      TYPE3 *TENSOR3##_data = srcp + TENSOR3##_offset;\
+      ptrdiff_t count = 0;\
+      ptrdiff_t TENSOR1##_start = TENSOR1##_counter_tmp[TENSOR1##_dim - 1];\
+      ptrdiff_t TENSOR2##_start = TENSOR2##_counter_tmp[TENSOR2##_dim - 1];\
+      ptrdiff_t TENSOR3##_start = TENSOR3##_counter_tmp[TENSOR3##_dim - 1];\
+      while(count < line_seg_len){\
+        for(TENSOR1##_i=TENSOR1##_start, TENSOR2##_i=TENSOR2##_start,TENSOR3##_i=TENSOR3##_start; (count<line_seg_len)&&(TENSOR1##_i<TENSOR1##_size)&&(TENSOR2##_i<TENSOR2##_size)&&(TENSOR3##_i<TENSOR3##_size); ++TENSOR1##_i,++TENSOR2##_i,++TENSOR3##_i,++count){\
+          CODE\
+          TENSOR1##_data += TENSOR1##_stride;\
+          TENSOR2##_data += TENSOR2##_stride;\
+          TENSOR3##_data += TENSOR3##_stride;\
+        }\
+        if(count < line_seg_len){\
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR1);\
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR2);\
+          __TH_TENSOR_APPLYX_UPDATE_COUNTERS_OMP(TENSOR3);\
+        }\
+      }\
+      if(TENSOR1##_counter_tmp != NULL) \
+        THFree(TENSOR1##_counter_tmp); \
+      if(TENSOR2##_counter_tmp != NULL) \
+        THFree(TENSOR2##_counter_tmp); \
+      if(TENSOR3##_counter_tmp != NULL) \
+        THFree(TENSOR3##_counter_tmp);\
+    }\
+    if(TENSOR1##_counter != NULL)\
+      THFree(TENSOR1##_counter);\
+    if(TENSOR2##_counter != NULL)\
+      THFree(TENSOR2##_counter);\
+    if(TENSOR3##_counter != NULL)\
+      THFree(TENSOR3##_counter);\
+  }\
+}
+
+#endif
 #endif

--- a/aten/src/TH/generic/THTensorCopy.c
+++ b/aten/src/TH/generic/THTensorCopy.c
@@ -2,6 +2,17 @@
 #define TH_GENERIC_FILE "generic/THTensorCopy.c"
 #else
 
+#ifndef _WIN32
+#define PRAGMA(P) _Pragma(#P)
+#else
+#define PRAGMA(P) __pragma(P)
+#endif
+
+#ifdef _OPENMP
+#define TH_OMP_OVERHEAD_THRESHOLD_COPY 20000
+#include <omp.h>
+#endif
+
 int THTensor_(copyTransposeValid)(THTensor *tensor, THTensor *src) {
   const int MIN_SZ = 60 * 60;
   return THTensor_(isContiguous)(tensor) &&
@@ -27,6 +38,7 @@ void THTensor_(copyTranspose)(THTensor *tensor, THTensor *src) {
   real *sp = THTensor_(data)(src);
   real *rp = THTensor_(data)(tensor);
   real *bp = THTensor_(data)(buf);
+
 
   int64_t NR = THTensor_(size)(src, 0);
   int64_t NC = THTensor_(size)(src, 1);
@@ -69,20 +81,74 @@ void THTensor_(copyTranspose)(THTensor *tensor, THTensor *src) {
 void THTensor_(copy)(THTensor *tensor, THTensor *src)
 {
   if (tensor == src) return;
-  if (THTensor_(isContiguous)(tensor) && THTensor_(isContiguous)(src) && THTensor_(nElement)(tensor) == THTensor_(nElement)(src)) {
-    real *sp = THTensor_(data)(src);
-    real *rp = THTensor_(data)(tensor);
-    ptrdiff_t sz = THTensor_(nElement)(tensor);
+  ptrdiff_t tensorSize = THTensor_(nElement)(tensor);
+  ptrdiff_t srcSize = THTensor_(nElement)(src);
+  int tensorContig = THTensor_(isContiguous)(tensor);
+  int srcContig = THTensor_(isContiguous)(src);
+
+  int serial_path = 0;
+#ifdef _OPENMP
+  int inOMP = omp_in_parallel();
+#endif
+  if (tensorSize == srcSize) {
+    if ( tensorContig && srcContig) {
+      real *sp = THTensor_(data)(src);
+      real *rp = THTensor_(data)(tensor);
 #ifndef TH_REAL_IS_HALF
-    THVector_(copy)(rp, sp, sz);
+#ifdef _OPENMP
+      #pragma omp parallel if ( (tensorSize > TH_OMP_OVERHEAD_THRESHOLD_COPY) && (!inOMP) )
+      {
+        size_t num_threads = omp_get_num_threads();
+        size_t tid = omp_get_thread_num();
+        ptrdiff_t offset = tid * (tensorSize / num_threads);
+        ptrdiff_t end = (tid == num_threads - 1) ? tensorSize : offset + tensorSize / num_threads;
+        ptrdiff_t len = end - offset;
+        real *tensorData = rp + offset;
+        real *srcData = sp + offset;
+        THVector_(copy)(tensorData, srcData, len);  
+      }
 #else
-    memcpy(rp, sp, sz * sizeof(real));
+        THVector_(copy)(rp, sp, srcSize);  
 #endif
+
+#else
+
+#ifdef _OPENMP
+      if ((srcSize > TH_OMP_OVERHEAD_THRESHOLD_COPY) && (!inOMP)) {
+        ptrdiff_t i;
+        #pragma omp parallel for private (i)
+        for(i=0; i<srcSize; i++){
+          rp[i] = sp[i];
+        }
+      } else {
+        memcpy(rp, sp, srcSize * sizeof(real));
+      }
+#else
+      memcpy(rp, sp, srcSize * sizeof(real));
+#endif
+
+#endif
+
 #ifndef TH_REAL_IS_HALF
-  } else if (THTensor_(copyTransposeValid)(tensor, src)) {
-    THTensor_(copyTranspose)(tensor, src);
+    } else if (THTensor_(copyTransposeValid)(tensor, src)) {
+      THTensor_(copyTranspose)(tensor, src);
 #endif
+    } else {
+#ifdef _OPENMP
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY2_OMP(srcSize, tensorContig, srcContig, real, tensor, real, src, *tensor_data = *src_data;)
+      }
+#else
+      serial_path = 1;
+#endif
+    }
   } else {
+    serial_path = 1;
+  }
+
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, tensor, real, src, *tensor_data = *src_data;)
   }
 }

--- a/aten/src/TH/generic/THTensorCopy.c
+++ b/aten/src/TH/generic/THTensorCopy.c
@@ -105,10 +105,10 @@ void THTensor_(copy)(THTensor *tensor, THTensor *src)
         ptrdiff_t len = end - offset;
         real *tensorData = rp + offset;
         real *srcData = sp + offset;
-        THVector_(copy)(tensorData, srcData, len);  
+        THVector_(copy)(tensorData, srcData, len);
       }
 #else
-        THVector_(copy)(rp, sp, srcSize);  
+        THVector_(copy)(rp, sp, srcSize);
 #endif
 
 #else

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -22,8 +22,9 @@
 
 #define TH_TENSOR_APPLY_CONTIG(TYPE, TENSOR, CODE) \
 { \
+  int inOmp = omp_in_parallel(); \
   ptrdiff_t TH_TENSOR_size = THTensor_(nElement)(TENSOR); \
-  PRAGMA(omp parallel if (TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD)) \
+  PRAGMA(omp parallel if ((TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD) && (!inOmp))) \
   { \
     size_t num_threads = omp_get_num_threads(); \
     size_t tid = omp_get_thread_num(); \
@@ -47,8 +48,9 @@
 #ifdef _OPENMP
 #define TH_TENSOR_APPLY2_CONTIG(TYPE1, TENSOR1, TYPE2, TENSOR2, CODE) \
 { \
+  int inOmp = omp_in_parallel(); \
   ptrdiff_t TH_TENSOR_size = THTensor_(nElement)(TENSOR1); \
-  PRAGMA(omp parallel if (TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD)) \
+  PRAGMA(omp parallel if ((TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD) && (!inOmp))) \
   { \
     size_t num_threads = omp_get_num_threads(); \
     size_t tid = omp_get_thread_num(); \
@@ -74,8 +76,9 @@
 #ifdef _OPENMP
 #define TH_TENSOR_APPLY3_CONTIG(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, CODE) \
 { \
+  int inOmp = omp_in_parallel(); \
   ptrdiff_t TH_TENSOR_size = THTensor_(nElement)(TENSOR1); \
-  PRAGMA(omp parallel if (TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD)) \
+  PRAGMA(omp parallel if ((TH_TENSOR_size > TH_OMP_OVERHEAD_THRESHOLD) && (!inOmp))) \
   { \
     size_t num_threads = omp_get_num_threads(); \
     size_t tid = omp_get_thread_num(); \
@@ -737,23 +740,65 @@ real THTensor_(medianall)(THTensor *tensor)
 accreal THTensor_(sumall)(THTensor *tensor)
 {
   accreal sum = 0;
-  TH_TENSOR_APPLY(real, tensor, sum += *tensor_data;);
+  int serial_path = 0;
+#ifdef _OPENMP
+  int inOMP = omp_in_parallel();
+  if(inOMP) {
+    serial_path = 1;
+  } else {
+    TH_TENSOR_APPLY_REDUCTION_OMP(real, tensor, +:sum, sum += *tensor_data;);
+  }
+#else
+    serial_path = 1;
+#endif
+  if (serial_path) {
+    TH_TENSOR_APPLY(real, tensor, sum += *tensor_data;);
+  }
   return sum;
 }
 
 accreal THTensor_(prodall)(THTensor *tensor)
 {
   accreal prod = 1;
-  TH_TENSOR_APPLY(real, tensor, prod *= *tensor_data;);
+  int serial_path = 0;
+#ifdef _OPENMP
+  int inOMP = omp_in_parallel();
+  if(inOMP) {
+    serial_path = 1;
+  } else {
+    TH_TENSOR_APPLY_REDUCTION_OMP(real, tensor, *:prod, prod *= *tensor_data;);
+  }
+#else
+    serial_path = 1;
+#endif
+  if (serial_path) {
+    TH_TENSOR_APPLY(real, tensor, prod *= *tensor_data;);
+  }
   return prod;
 }
 
 void THTensor_(add)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
     TH_TENSOR_APPLY2_CONTIG(real, r_, real, t, THVector_(adds)(r__data, t_data, value, r__len););
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data + value;)
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data + value;);
   }
 }
@@ -776,9 +821,25 @@ void THTensor_(sub_scaled)(THTensor *r_, THTensor *t, real value, real alpha)
 void THTensor_(mul)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
     TH_TENSOR_APPLY2_CONTIG(real, r_, real, t, THVector_(muls)(r__data, t_data, value, r__len););
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data * value;)
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data * value;);
   }
 }
@@ -786,9 +847,25 @@ void THTensor_(mul)(THTensor *r_, THTensor *t, real value)
 void THTensor_(div)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
     TH_TENSOR_APPLY2_CONTIG(real, r_, real, t, THVector_(divs)(r__data, t_data, value, r__len););
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data / value;)
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data / value;);
   }
 }
@@ -803,26 +880,43 @@ void THTensor_(lshift)(THTensor *r_, THTensor *t, real value)
   return THError("lshift is not supported for torch.HalfTensor");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      int64_t sz = THTensor_(nElement)(t);
-      int64_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
-      for (i=0; i<sz; i++) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
+    for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_BYTE)
-          rp[i] = ((real) tp[i]) << value;
+      rp[i] = ((real) tp[i]) << value;
 #else
-          rp[i] = ((ureal) tp[i]) << value;
+      rp[i] = ((ureal) tp[i]) << value;
 #endif
-      }
+    }
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
 #if defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((real) *t_data) << value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (((real) *t_data) << value););
 #else
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((ureal) *t_data) << value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (((ureal) *t_data) << value););
+#endif
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_BYTE)
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((real) *t_data) << value););
+#else
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((ureal) *t_data) << value););
 #endif
   }
 #endif
@@ -838,26 +932,43 @@ void THTensor_(rshift)(THTensor *r_, THTensor *t, real value)
   return THError("rshift is not supported for torch.HalfTensor");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      int64_t sz = THTensor_(nElement)(t);
-      int64_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
-      for (i=0; i<sz; i++) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
+    for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_BYTE)
-          rp[i] = ((real) tp[i]) >> value;
+      rp[i] = ((real) tp[i]) >> value;
 #else
-          rp[i] = ((ureal) tp[i]) >> value;
+      rp[i] = ((ureal) tp[i]) >> value;
 #endif
-      }
+    }
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
 #if defined(TH_REAL_IS_BYTE)
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((real) *t_data) >> value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (((real) *t_data) >> value););
 #else
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((ureal) *t_data) >> value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (((ureal) *t_data) >> value););
+#endif
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_BYTE)
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((real) *t_data) >> value););
+#else
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (((ureal) *t_data) >> value););
 #endif
   }
 #endif
@@ -866,25 +977,43 @@ void THTensor_(rshift)(THTensor *r_, THTensor *t, real value)
 void THTensor_(fmod)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-      for (i=0; i<sz; i++) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+    for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-          rp[i] = fmod(tp[i], value);
+      rp[i] = fmod(tp[i], value);
 #else
-          rp[i] = tp[i] % value;
+      rp[i] = tp[i] % value;
 #endif
-      }
+    }
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = fmod(*t_data, value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = fmod(*t_data, value););
 #else
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (*t_data % value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (*t_data % value););
+#endif
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = fmod(*t_data, value););
+#else
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (*t_data % value););
 #endif
   }
 }
@@ -892,28 +1021,49 @@ void THTensor_(fmod)(THTensor *r_, THTensor *t, real value)
 void THTensor_(remainder)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-      for (i=0; i<sz; i++) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+    for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-          rp[i] = (value == 0)? NAN : tp[i] - value * floor(tp[i] / value);
+      rp[i] = (value == 0)? NAN : tp[i] - value * floor(tp[i] / value);
 #else
-          // There is no NAN for integers
-          rp[i] = tp[i] % value;
-          if (rp[i] * value < 0)
-            rp[i] += value;
+      // There is no NAN for integers
+      rp[i] = tp[i] % value;
+      if (rp[i] * value < 0)
+        rp[i] += value;
 #endif
-      }
+    }
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (value == 0)? NAN : *t_data - value * floor(*t_data / value););
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (value == 0)? NAN : *t_data - value * floor(*t_data / value););
 #else
-       // There is no NAN for integers
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data % value;
+      // There is no NAN for integers
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data % value;
+                                        if (*r__data * value < 0) *r__data += value;);
+#endif
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (value == 0)? NAN : *t_data - value * floor(*t_data / value););
+#else
+    // There is no NAN for integers
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data % value;
                                           if (*r__data * value < 0) *r__data += value;);
 #endif
   }
@@ -925,19 +1075,32 @@ void THTensor_(bitand)(THTensor *r_, THTensor *t, real value)
   return THError("bitand is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      int64_t sz = THTensor_(nElement)(t);
-      int64_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
-      for (i=0; i<sz; i++) {
-          rp[i] = tp[i] & value;
-      }
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int serial_path = 0;
+  int tContig = THTensor_(isContiguous)(t);
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
+    for (i=0; i<r_Size; i++) {
+      rp[i] = tp[i] & value;
+    }
   } else {
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data & value;);
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data & value;);
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data & value;);
   }
 #endif
 }
@@ -945,22 +1108,35 @@ void THTensor_(bitand)(THTensor *r_, THTensor *t, real value)
 void THTensor_(bitor)(THTensor *r_, THTensor *t, real value)
 {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_HALF)
-  return THError("bitor is only supported for integer type tensors");
+  return THError("bitxor is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      int64_t sz = THTensor_(nElement)(t);
-      int64_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
-      for (i=0; i<sz; i++) {
-          rp[i] = tp[i] | value;
-      }
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
+    for (i=0; i<r_Size; i++) {
+      rp[i] = tp[i] | value;
+    }
   } else {
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data | value;);
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data | value;);
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data | value;);
   }
 #endif
 }
@@ -971,19 +1147,32 @@ void THTensor_(bitxor)(THTensor *r_, THTensor *t, real value)
   return THError("bitxor is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
-      real *tp = THTensor_(data)(t);
-      real *rp = THTensor_(data)(r_);
-      int64_t sz = THTensor_(nElement)(t);
-      int64_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
-      for (i=0; i<sz; i++) {
-          rp[i] = tp[i] ^ value;
-      }
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD * 100) private(i)
+    for (i=0; i<r_Size; i++) {
+      rp[i] = tp[i] ^ value;
+    }
   } else {
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data ^ value;);
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data ^ value;);
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
+    TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data ^ value;);
   }
 #endif
 }
@@ -991,16 +1180,31 @@ void THTensor_(bitxor)(THTensor *r_, THTensor *t, real value)
 void THTensor_(clamp)(THTensor *r_, THTensor *t, real min_value, real max_value)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
     real *tp = THTensor_(data)(t);
     real *rp = THTensor_(data)(r_);
     /* real t_val; */
-    ptrdiff_t sz = THTensor_(nElement)(t);
-    ptrdiff_t i;
-    #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++)
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+    for (i=0; i<r_Size; i++)
       rp[i] = (tp[i] < min_value) ? min_value : (tp[i] > max_value ? max_value : tp[i]);
   } else {
+#ifdef _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = (*t_data < min_value) ? min_value : (*t_data > max_value ? max_value : *t_data););
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = (*t_data < min_value) ? min_value : (*t_data > max_value ? max_value : *t_data););
   }
 }
@@ -1008,13 +1212,35 @@ void THTensor_(clamp)(THTensor *r_, THTensor *t, real min_value, real max_value)
 void THTensor_(cadd)(THTensor *r_, THTensor *t, real value, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
-    if(r_ == t) {
-      THBlas_(axpy)(THTensor_(nElement)(t), value, THTensor_(data)(src), 1, THTensor_(data)(r_), 1);
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
+      if(r_ == t) {
+        THBlas_(axpy)(THTensor_(nElement)(t), value, THTensor_(data)(src), 1, THTensor_(data)(r_), 1);
+      } else {
+        TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cadd)(r__data, t_data, src_data, value, r__len););
+      }
     } else {
-      TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cadd)(r__data, t_data, src_data, value, r__len););
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data + value * *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data + value * *src_data;);
   }
 }
@@ -1027,9 +1253,31 @@ void THTensor_(csub)(THTensor *r_, THTensor *t, real value, THTensor *src)
 void THTensor_(cmul)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
-    TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cmul)(r__data, t_data, src_data, r__len););
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
+      TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cmul)(r__data, t_data, src_data, r__len););
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data * *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
+    }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data * *src_data;);
   }
 }
@@ -1037,16 +1285,37 @@ void THTensor_(cmul)(THTensor *r_, THTensor *t, THTensor *src)
 void THTensor_(cpow)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
-    real *tp = THTensor_(data)(t);
-    real *sp = THTensor_(data)(src);
-    real *rp = THTensor_(data)(r_);
-    ptrdiff_t sz = THTensor_(nElement)(t);
-    ptrdiff_t i;
-    #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++)
-      rp[i] = pow(tp[i], sp[i]);
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
+      real *tp = THTensor_(data)(t);
+      real *sp = THTensor_(data)(src);
+      real *rp = THTensor_(data)(r_);
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++)
+        rp[i] = pow(tp[i], sp[i]);
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = pow(*t_data, *src_data););
+      }
+#else
+      serial_path = 1;
+#endif
+    }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = pow(*t_data, *src_data););
   }
 }
@@ -1054,9 +1323,31 @@ void THTensor_(cpow)(THTensor *r_, THTensor *t, THTensor *src)
 void THTensor_(cdiv)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
-    TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cdiv)(r__data, t_data, src_data, r__len););
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
+      TH_TENSOR_APPLY3_CONTIG(real, r_, real, t, real, src, THVector_(cdiv)(r__data, t_data, src_data, r__len););
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data / *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
+    }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data / *src_data;);
   }
 }
@@ -1067,28 +1358,54 @@ void THTensor_(clshift)(THTensor *r_, THTensor *t, THTensor *src)
   return THError("clshift is not supported for torch.HalfTensor");
 #endif
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(isContiguous)(src) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++) {
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT)
-      rp[i] = tp[i] * powf(2, sp[i]);
+        rp[i] = tp[i] * powf(2, sp[i]);
 #elif defined(TH_REAL_IS_DOUBLE)
-      rp[i] = tp[i] * pow(2, sp[i]);
+        rp[i] = tp[i] * pow(2, sp[i]);
 #elif defined(TH_REAL_IS_BYTE)
-      rp[i] = ((real) tp[i]) << sp[i];
+        rp[i] = ((real) tp[i]) << sp[i];
 #else
-      rp[i] = ((ureal) tp[i]) << sp[i];
+        rp[i] = ((ureal) tp[i]) << sp[i];
+#endif
+      }
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+#if defined(TH_REAL_IS_FLOAT)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data * powf(2, *src_data););
+#elif defined(TH_REAL_IS_DOUBLE)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data * pow(2, *src_data););
+#elif defined(TH_REAL_IS_BYTE)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = ((real)*t_data) << *src_data;);
+#else
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = ((ureal)*t_data) << *src_data;);
+#endif
+      }
+#else
+      serial_path = 1;
 #endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
 #if defined(TH_REAL_IS_FLOAT)
       TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data * powf(2, *src_data););
 #elif defined(TH_REAL_IS_DOUBLE)
@@ -1107,28 +1424,54 @@ void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
   return THError("crshift is not supported for torch.HalfTensor");
 #endif
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(isContiguous)(src) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++) {
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT)
-      rp[i] = tp[i] / powf(2, sp[i]);
+        rp[i] = tp[i] / powf(2, sp[i]);
 #elif defined(TH_REAL_IS_DOUBLE)
-      rp[i] = tp[i] / pow(2, sp[i]);
+        rp[i] = tp[i] / pow(2, sp[i]);
 #elif defined(TH_REAL_IS_BYTE)
-      rp[i] = ((real) tp[i]) >> sp[i];
+        rp[i] = ((real) tp[i]) >> sp[i];
 #else
-      rp[i] = ((ureal) tp[i]) >> sp[i];
+        rp[i] = ((ureal) tp[i]) >> sp[i];
+#endif
+      }
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+#if defined(TH_REAL_IS_FLOAT)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data / powf(2, *src_data););
+#elif defined(TH_REAL_IS_DOUBLE)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data / pow(2, *src_data););
+#elif defined(TH_REAL_IS_BYTE)
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = ((real)*t_data) >> *src_data;);
+#else
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = ((ureal)*t_data) >> *src_data;);
+#endif
+      }
+#else
+      serial_path = 1;
 #endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
 #if defined(TH_REAL_IS_FLOAT)
       TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data / powf(2, *src_data););
 #elif defined(TH_REAL_IS_DOUBLE)
@@ -1144,56 +1487,106 @@ void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
 void THTensor_(cfmod)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-      for (i=0; i<sz; i++) {
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-          rp[i] = fmod(tp[i], sp[i]);
+        rp[i] = fmod(tp[i], sp[i]);
 #else
-          rp[i] = tp[i] % sp[i];
+        rp[i] = tp[i] % sp[i];
 #endif
       }
-  } else {
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = fmod(*t_data, *src_data););
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig,real, r_, real, t, real, src, *r__data = fmod(*t_data, *src_data););
 #else
-      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = (*t_data % *src_data););
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = (*t_data % *src_data););
 #endif
-
+      }
+#else
+      serial_path = 1;
+#endif
+    }
+  } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+    TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = fmod(*t_data, *src_data););
+#else
+    TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = (*t_data % *src_data););
+#endif
   }
 }
 
 void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(isContiguous)(src) && THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-      for (i=0; i<sz; i++) {
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-          rp[i] = (sp[i] == 0)? NAN : tp[i] - sp[i] * floor(tp[i] / sp[i]);
+        rp[i] = (sp[i] == 0)? NAN : tp[i] - sp[i] * floor(tp[i] / sp[i]);
 #else
-          // There is no NAN for integers
-          rp[i] = tp[i] % sp[i];
-          if (rp[i] * sp[i] < 0)
-            rp[i] += sp[i];
+        // There is no NAN for integers
+        rp[i] = tp[i] % sp[i];
+        if (rp[i] * sp[i] < 0)
+          rp[i] += sp[i];
 #endif
       }
-  } else {
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = (*src_data == 0)? NAN : *t_data - *src_data * floor(*t_data / *src_data););
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = (*src_data == 0)? NAN : *t_data - *src_data * floor(*t_data / *src_data););
 #else
-      // There is no NAN for integers
-      TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data % *src_data;
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data % *src_data;
+                                                     if (*r__data * *src_data < 0) *r__data += *src_data;);
+#endif
+      }
+#else
+      serial_path = 1;
+#endif
+    }
+  } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+    TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = (*src_data == 0)? NAN : *t_data - *src_data * floor(*t_data / *src_data););
+#else
+    // There is no NAN for integers
+    TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data % *src_data;
                                                      if (*r__data * *src_data < 0) *r__data += *src_data;);
 #endif
 
@@ -1206,20 +1599,38 @@ void THTensor_(cbitand)(THTensor *r_, THTensor *t, THTensor *src)
   return THError("cbitand is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(isContiguous)(src) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++) {
-      rp[i] = tp[i] & sp[i];
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
+        rp[i] = tp[i] & sp[i];
+      }
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data & *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
       TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data & *src_data;);
   }
 #endif
@@ -1231,20 +1642,38 @@ void THTensor_(cbitor)(THTensor *r_, THTensor *t, THTensor *src)
   return THError("cbitor is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(isContiguous)(src) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++) {
-      rp[i] = tp[i] | sp[i];
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
+        rp[i] = tp[i] | sp[i];
+      }
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data | *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
       TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data | *src_data;);
   }
 #endif
@@ -1256,20 +1685,38 @@ void THTensor_(cbitxor)(THTensor *r_, THTensor *t, THTensor *src)
   return THError("cbitxor is only supported for integer type tensors");
 #else
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) &&
-      THTensor_(isContiguous)(t) &&
-      THTensor_(isContiguous)(src) &&
-      THTensor_(nElement)(r_) == THTensor_(nElement)(src)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  int serial_path = 0;
+  if (srcSize == r_Size){
+    if (r_Contig && tContig && srcContig) {
       real *tp = THTensor_(data)(t);
       real *sp = THTensor_(data)(src);
       real *rp = THTensor_(data)(r_);
-      ptrdiff_t sz = THTensor_(nElement)(t);
-      ptrdiff_t i;
-      #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++) {
-      rp[i] = tp[i] ^ sp[i];
+      int64_t i;
+      #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+      for (i=0; i<r_Size; i++) {
+        rp[i] = tp[i] ^ sp[i];
+      }
+    } else {
+#if _OPENMP
+      int inOMP = omp_in_parallel();
+      if (inOMP) {
+        serial_path = 1;
+      } else {
+        TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data ^ *src_data;);
+      }
+#else
+      serial_path = 1;
+#endif
     }
   } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
       TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data ^ *src_data;);
   }
 #endif
@@ -1278,15 +1725,30 @@ void THTensor_(cbitxor)(THTensor *r_, THTensor *t, THTensor *src)
 void THTensor_(tpow)(THTensor *r_, real value, THTensor *t)
 {
   THTensor_(resizeAs)(r_, t);
-  if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t) && THTensor_(nElement)(r_) == THTensor_(nElement)(t)) {
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int serial_path = 0;
+  if (r_Contig && tContig) {
     real *tp = THTensor_(data)(t);
     real *rp = THTensor_(data)(r_);
-    ptrdiff_t sz = THTensor_(nElement)(t);
-    ptrdiff_t i;
-    #pragma omp parallel for if(sz > TH_OMP_OVERHEAD_THRESHOLD) private(i)
-    for (i=0; i<sz; i++)
+    int64_t i;
+    #pragma omp parallel for if(r_Size > TH_OMP_OVERHEAD_THRESHOLD) private(i)
+    for (i=0; i<r_Size; i++)
       rp[i] = pow(value, tp[i]);
   } else {
+#if _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = pow(value, *t_data););
+    }
+#else
+    serial_path = 1;
+#endif
+  }
+  if (serial_path) {
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = pow(value, *t_data););
   }
 }
@@ -1298,10 +1760,31 @@ void THTensor_(addcmul)(THTensor *r_, THTensor *t, real value, THTensor *src1, T
     THTensor_(resizeAs)(r_, t);
     THTensor_(copy)(r_, t);
   }
-
-  TH_TENSOR_APPLY3(real, r_, real, src1, real, src2, *r__data += value * *src1_data * *src2_data;);
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t src1Size = THTensor_(nElement)(src1);
+  int64_t src2Size = THTensor_(nElement)(src2);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int src1Contig = THTensor_(isContiguous)(src1);
+  int src2Contig = THTensor_(isContiguous)(src2);
+  int serial_path = 0;
+  if( (src1Size == src2Size) && (src1Size == r_Size) ){
+#if _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, src1Contig, src2Contig, real, r_, real, src1, real, src2, *r__data += value * *src1_data * *src2_data;);
+    }
+#else
+    serial_path = 1;
+#endif
+  } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
+    TH_TENSOR_APPLY3(real, r_, real, src1, real, src2, *r__data += value * *src1_data * *src2_data;);
+  }
 }
-
 
 void THTensor_(addcdiv)(THTensor *r_, THTensor *t, real value, THTensor *src1, THTensor *src2)
 {
@@ -1310,8 +1793,30 @@ void THTensor_(addcdiv)(THTensor *r_, THTensor *t, real value, THTensor *src1, T
     THTensor_(resizeAs)(r_, t);
     THTensor_(copy)(r_, t);
   }
-
-  TH_TENSOR_APPLY3(real, r_, real, src1, real, src2, *r__data += value * *src1_data / *src2_data;);
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t src1Size = THTensor_(nElement)(src1);
+  int64_t src2Size = THTensor_(nElement)(src2);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int src1Contig = THTensor_(isContiguous)(src1);
+  int src2Contig = THTensor_(isContiguous)(src2);
+  int serial_path = 0;
+  if( (src1Size == src2Size) && (src1Size == r_Size) ){
+#if _OPENMP
+    int inOMP = omp_in_parallel();
+    if (inOMP) {
+      serial_path = 1;
+    } else {
+      TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, src1Contig, src2Contig, real, r_, real, src1, real, src2, *r__data += value * *src1_data / *src2_data;);
+    }
+#else
+    serial_path = 1;
+#endif
+  } else {
+    serial_path = 1;
+  }
+  if (serial_path) {
+    TH_TENSOR_APPLY3(real, r_, real, src1, real, src2, *r__data += value * *src1_data / *src2_data;);
+  }
 }
 
 void THTensor_(addmv)(THTensor *r_, real beta, THTensor *t, real alpha, THTensor *mat, THTensor *vec)
@@ -1870,7 +2375,6 @@ void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int 
   }
 }
 
-
 void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
 {
   THLongStorage *dim;
@@ -1883,23 +2387,66 @@ void THTensor_(sum)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
-  // two implementations optimized for data locality
-  if (t->stride[dimension] == 1) {
-    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
-                         accreal sum = 0;
-                         int64_t i;
-                         for(i = 0; i < t_size; i++)
-                           sum += t_data[i*t_stride];
-                         *r__data = (real)sum;);
+  int serial_path = 0;
+#ifdef _OPENMP
+  int inOMP = omp_in_parallel();
+  if (inOMP) {
+    serial_path = 1;
   } else {
-    THTensor_(zero)(r_);
-    THTensor *temp_ = THTensor_(newWithTensor)(r_);
-    // r_.expand_as(t)
-    temp_->size[dimension] = t->size[dimension];
-    temp_->stride[dimension] = 0;
+    int r_Contig = THTensor_(isContiguous)(r_);
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    if(r_Contig && (tp != rp)){
+      ptrdiff_t iter = 0;
+      ptrdiff_t r_Size = THTensor_(nElement)(r_);
+      int r_Dim = r_->nDimension;
+      #pragma omp parallel for if ( r_Size > TH_OMP_OVERHEAD_THRESHOLD)
+      for (iter = 0; iter < r_Size; iter++) {
+        int j;
+        int64_t quot;
+        int64_t rem = iter;
+        ptrdiff_t tBasicIndex = 0;
 
-    TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
-    THTensor_(free)(temp_);
+        for(j = 0; j < r_Dim; ++j) {
+          if(j != dimension){
+            quot = rem/r_->stride[j];
+            rem = rem%r_->stride[j];
+            tBasicIndex += quot*t->stride[j];
+          }
+        }
+        real *t_data = tp+tBasicIndex;
+        real *r__data = rp+iter;
+        *r__data = 0;
+        for(j=0; j < t->size[dimension]; ++j) {
+          *r__data += *(t_data + j*t->stride[dimension]);
+        }
+      }
+    } else {
+      serial_path = 1;
+    }
+  }
+#else
+  serial_path = 1;
+#endif
+  if (serial_path) {
+    // two implementations optimized for data locality
+    if (t->stride[dimension] == 1) {
+      TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
+                           accreal sum = 0;
+                           int64_t i;
+                           for(i = 0; i < t_size; i++)
+                             sum += t_data[i*t_stride];
+                           *r__data = (real)sum;);
+    } else {
+      THTensor_(zero)(r_);
+      THTensor *temp_ = THTensor_(newWithTensor)(r_);
+      // r_.expand_as(t)
+      temp_->size[dimension] = t->size[dimension];
+      temp_->stride[dimension] = 0;
+
+      TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data + *t_data;);
+      THTensor_(free)(temp_);
+    }
   }
 
   if (!keepdim) {
@@ -1919,25 +2466,68 @@ void THTensor_(prod)(THTensor *r_, THTensor *t, int dimension, int keepdim)
   THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
-  // two implementations optimized for data locality
-  if (t->stride[dimension] == 1) {
-    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
-                         accreal prod = 1;
-                         int64_t i;
-                         for(i = 0; i < t_size; i++)
-                           prod *= t_data[i*t_stride];
-                         *r__data = (real)prod;);
+  int serial_path = 0;
+#ifdef _OPENMP
+  int inOMP = omp_in_parallel();
+  if (inOMP) {
+    serial_path = 1;
   } else {
-    THTensor_(fill)(r_, 1);
-    THTensor *temp_ = THTensor_(newWithTensor)(r_);
-    // r_.expand_as(t)
-    temp_->size[dimension] = t->size[dimension];
-    temp_->stride[dimension] = 0;
+    int r_Contig = THTensor_(isContiguous)(r_);
+    real *tp = THTensor_(data)(t);
+    real *rp = THTensor_(data)(r_);
+    if(r_Contig && (tp != rp)){
+      ptrdiff_t iter = 0;
+      ptrdiff_t r_Size = THTensor_(nElement)(r_);
+      int r_Dim = r_->nDimension;
+      #pragma omp parallel for if ( r_Size > TH_OMP_OVERHEAD_THRESHOLD)
+      for (iter = 0; iter < r_Size; iter++) {
+        int j;
+        int64_t quot;
+        int64_t rem = iter;
+        ptrdiff_t tBasicIndex = 0;
 
-    TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
-    THTensor_(free)(temp_);
+        for(j = 0; j < r_Dim; ++j) {
+          if(j != dimension){
+            quot = rem/r_->stride[j];
+            rem = rem%r_->stride[j];
+            tBasicIndex += quot*t->stride[j];
+          }
+        }
+        real *t_data = tp+tBasicIndex;
+        real *r__data = rp+iter;
+        *r__data = 1;
+        for(j=0; j < t->size[dimension]; ++j) {
+          *r__data *= *(t_data + j*t->stride[dimension]);
+        }
+      }
+    } else {
+      serial_path = 1;
+    }
   }
+#else
+  serial_path = 1;
+#endif
 
+  if(serial_path) {
+    // two implementations optimized for data locality
+    if (t->stride[dimension] == 1) {
+      TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
+                           accreal prod = 1;
+                           int64_t i;
+                           for(i = 0; i < t_size; i++)
+                             prod *= t_data[i*t_stride];
+                           *r__data = (real)prod;);
+    } else {
+      THTensor_(fill)(r_, 1);
+      THTensor *temp_ = THTensor_(newWithTensor)(r_);
+      // r_.expand_as(t)
+      temp_->size[dimension] = t->size[dimension];
+      temp_->stride[dimension] = 0;
+
+      TH_TENSOR_APPLY2(real, temp_, real, t, *temp__data = *temp__data * *t_data;);
+      THTensor_(free)(temp_);
+    }
+  }
   if (!keepdim) {
     THTensor_(squeeze1d)(r_, r_, dimension);
   }
@@ -3017,16 +3607,33 @@ TENSOR_IMPLEMENT_LOGICAL(ge,>=)
 TENSOR_IMPLEMENT_LOGICAL(eq,==)
 TENSOR_IMPLEMENT_LOGICAL(ne,!=)
 
+#ifdef _OPENMP
+
+#define LAB_IMPLEMENT_BASIC_FUNCTION(NAME, CFUNC)             \
+  void THTensor_(NAME)(THTensor *r_, THTensor *t)             \
+  {                                                           \
+    THTensor_(resizeAs)(r_, t);                               \
+    ptrdiff_t r_Size = THTensor_(nElement)(r_);               \
+    int r_Contig = THTensor_(isContiguous)(r_);               \
+    int tContig = THTensor_(isContiguous)(t);                 \
+    int inOMP = omp_in_parallel();                            \
+    if( (r_Size > TH_OMP_OVERHEAD_THRESHOLD) && (!inOMP) ){   \
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = CFUNC(*t_data););        \
+    }                                                                                                        \
+    else {                                                                                                   \
+      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = CFUNC(*t_data););                                       \
+    }                                                                                                        \
+  }
+#else
+
 #define LAB_IMPLEMENT_BASIC_FUNCTION(NAME, CFUNC)             \
   void THTensor_(NAME)(THTensor *r_, THTensor *t)                \
   {                                                           \
     THTensor_(resizeAs)(r_, t);                               \
-    if (THTensor_(isContiguous)(r_) && THTensor_(isContiguous)(t)) { \
-      TH_TENSOR_APPLY2_CONTIG(real, r_, real, t, THVector_(NAME)(r__data, t_data, r__len););  \
-    } else {  \
-      TH_TENSOR_APPLY2(real, r_, real, t, *r__data = CFUNC(*t_data);); \
-    } \
-  }
+    TH_TENSOR_APPLY2(real, t, real, r_, *r__data = CFUNC(*t_data);); \
+  }                                                           \
+
+#endif
 
 LAB_IMPLEMENT_BASIC_FUNCTION(neg,-)
 
@@ -3647,6 +4254,7 @@ void THTensor_(dirichlet_grad)(THTensor *self, THTensor *x, THTensor *alpha, THT
 
   THTensor_(freeCopyTo)(grad, self);
 }
+
 
 #undef TH_MATH_NAME
 #endif /* floating point only part */


### PR DESCRIPTION
Most of elementwise operations of discontiguous THTensor such as copy, addition, multiplication and so on are serial with CPU backend,  and the openmp overhead theshold is too high. This commit will parallelize elementwise operation of discontiguous THTensor with openmp.