### PR TITLE
Norm subgradient at 0

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1565,6 +1565,17 @@ class TestAutograd(TestCase):
         # This will segfault if things have been erroneously released
         out.backward(torch.randn(out.size()))
 
+    def test_norm_subgradient(self):
+        def run_test(input_size, norm_deg):
+            input = Variable(torch.randn(*input_size).clamp(min=0), requires_grad=True)
+            out = input.norm(norm_deg)
+            out.backward()
+            self.assertEqual(input.grad.data[input.data == 0].abs().sum(), 0)
+
+        run_test((10,), 2)
+        run_test((10, 10), 2)
+        run_test((10,), 3)
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1567,10 +1567,10 @@ class TestAutograd(TestCase):
 
     def test_norm_subgradient(self):
         def run_test(input_size, norm_deg):
-            input = Variable(torch.randn(*input_size).clamp(min=0), requires_grad=True)
+            input = Variable(torch.zeros(*input_size), requires_grad=True)
             out = input.norm(norm_deg)
             out.backward()
-            self.assertEqual(input.grad.data[input.data == 0].abs().sum(), 0)
+            self.assertEqual(input.grad.data.abs().sum(), 0)
 
         run_test((10,), 2)
         run_test((10, 10), 2)

--- a/torch/autograd/_functions/reduce.py
+++ b/torch/autograd/_functions/reduce.py
@@ -251,8 +251,7 @@ class Norm(Function):
             grad_input = input.mul(input_pow).mul(grad_output).div(output_pow)
 
         # Special case at 0 where we return a subgradient containing 0
-        zero_mask = (output == 0).type_as(grad_input)
-        grad_input.mul(1 - zero_mask)
+        grad_input.masked_fill_(output == 0, 0)
 
         return grad_input, None, None, None
 

--- a/torch/autograd/_functions/reduce.py
+++ b/torch/autograd/_functions/reduce.py
@@ -226,43 +226,35 @@ class Norm(Function):
         ctx.keepdim = False if keepdim is None else keepdim
 
         if dim is None:
-            ctx.norm = input.norm(p)
-            ctx.save_for_backward(input)
-            return input.new((ctx.norm,))
+            norm = input.norm(p)
+            output = input.new((norm,))
         else:
             if keepdim is not None:
                 output = input.norm(p, dim, keepdim=keepdim)
             else:
                 output = input.norm(p, dim)
-            ctx.save_for_backward(input, output)
-            return output
+        ctx.save_for_backward(input, output)
+        return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        if ctx.dim is None:
-            input, = ctx.saved_variables
-            if ctx.p == 2:
-                scale_v = (grad_output / ctx.norm).expand_as(input)
-                return input.mul(scale_v), None, None, None
-            else:
-                pow = input.abs().pow(ctx.p - 2)
-                scale_v = (grad_output / ctx.norm ** (ctx.p - 1)).expand_as(input)
-                return input.mul(pow).mul(scale_v), None, None, None
+        input, output = ctx.saved_variables
+        if ctx.dim is not None and ctx.keepdim is False and input.dim() != 1:
+            grad_output = grad_output.unsqueeze(ctx.dim)
+            output = output.unsqueeze(ctx.dim)
+
+        if ctx.p == 2:
+            grad_input = input.mul(grad_output).div(output)
         else:
-            input, output = ctx.saved_variables
+            input_pow = input.abs().pow(ctx.p - 2)
+            output_pow = output.pow(ctx.p - 1)
+            grad_input = input.mul(input_pow).mul(grad_output).div(output_pow)
 
-            if ctx.keepdim is False and input.dim() != 1:
-                grad_output = grad_output.unsqueeze(ctx.dim)
-                output = output.unsqueeze(ctx.dim)
+        # Special case at 0 where we return a subgradient containing 0
+        zero_mask = (output == 0).type_as(grad_input)
+        grad_input.mul(1 - zero_mask)
 
-            big_grad_output = grad_output.expand_as(input)
-            if ctx.p == 2:
-                big_output = output.expand_as(input)
-                return input.mul(big_grad_output).div(big_output), None, None, None
-            else:
-                pow = input.abs().pow(ctx.p - 2)
-                big_output = output.pow(ctx.p - 1).expand_as(input)
-                return input.mul(pow).mul(big_grad_output).div(big_output), None, None, None
+        return grad_input, None, None, None
 
 
 # TODO: renorm


### PR DESCRIPTION
Fix #2421 

Note that with this, at `0`, it is now different to use `.norm()` or `.pow(2).sum().sqrt()` as the first one will return `0` and the second one `NaN`