### PR TITLE
ONNX improvements

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -278,6 +278,7 @@ class TestCase(unittest.TestCase):
             callable(*args, **kwargs)
         except exc_type as e:
             self.assertExpected(str(e), subname)
+            return
         # Don't put this in the try block; the AssertionError will catch it
         self.fail(msg="Did not raise when expected to")
 

--- a/test/common.py
+++ b/test/common.py
@@ -292,7 +292,7 @@ class TestCase(unittest.TestCase):
         If you call this multiple times in a single function, you must
         give a unique subname each time.
         """
-        if not isinstance(s, str):
+        if not (isinstance(s, str) or (sys.version_info[0] == 2 and isinstance(s, unicode))):
             raise TypeError("assertExpected is strings only")
 
         def remove_prefix(text, prefix):

--- a/test/expect/TestONNX.test_batchnorm_training.expect
+++ b/test/expect/TestONNX.test_batchnorm_training.expect
@@ -5,10 +5,14 @@ node {
   input: "3"
   input: "4"
   output: "7"
+  output: "8"
+  output: "9"
+  output: "batch_norm_dead_output_10"
+  output: "batch_norm_dead_output_11"
   op_type: "SpatialBN"
   attribute {
     name: "is_test"
-    i: 1
+    i: 0
   }
   attribute {
     name: "epsilon"
@@ -50,13 +54,13 @@ initializer {
   dims: 2
   data_type: FLOAT
   name: "3"
-  raw_data: "\000\000\000\000\000\000\000\000"
+  raw_data: "\315\314\314=\315\314\314="
 }
 initializer {
   dims: 2
   data_type: FLOAT
   name: "4"
-  raw_data: "\000\000\200?\000\000\200?"
+  raw_data: "fff?fff?"
 }
 ir_version: 1
 producer_version: 20000

--- a/test/expect/TestONNX.test_concat.expect
+++ b/test/expect/TestONNX.test_concat.expect
@@ -1,0 +1,18 @@
+node {
+  input: "1"
+  input: "2"
+  output: "4"
+  output: "5"
+  op_type: "Concat"
+  attribute {
+    name: "axis"
+    i: 1
+  }
+}
+name: "torch-jit-export"
+input: "1"
+input: "2"
+output: "4"
+ir_version: 1
+producer_version: 20000
+producer_tag: "pytorch"

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -81,6 +81,10 @@ class TestONNX(TestCase):
         x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
         self.assertONNXExpected(export_to_string(nn.BatchNorm2d(2), x))
 
+    def test_batchnorm_training(self):
+        x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
+        self.assertONNXExpected(export_to_string(nn.BatchNorm2d(2), x, training=True))
+
     def test_conv(self):
         x = Variable(torch.randn(20, 16, 50, 40).fill_(1.0), requires_grad=True)
         self.assertONNXExpected(export_to_string(nn.Conv2d(16, 13, 3, bias=False), x))

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -54,6 +54,16 @@ class TestONNX(TestCase):
         torch._C._jit_pass_onnx(trace)
         self.assertONNXExpected(trace.export())
 
+    def test_concat(self):
+        class ConcatNet(nn.Module):
+            def forward(self, inputs):
+                return torch.cat(inputs, 1)
+
+        # volatile is of particular interest; there was a bug involving this
+        x = Variable(torch.randn(2, 3), volatile=True)
+        y = Variable(torch.randn(2, 3), volatile=True)
+        self.assertONNXExpected(export_to_string(ConcatNet(), ((x, y),)))
+
     def test_permute(self):
         x = Variable(torch.Tensor([[[[[[0]]]]]]), requires_grad=True)
         trace, _ = torch.jit.record_trace(lambda x: x.permute(0, 1, 4, 2, 5, 3), x)

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -26,6 +26,12 @@ bool hasUsedHandle(Node *node) {
 
 // Transform PythonOps and Cpp Ops into Node's that match ONNX semantics.
 void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
+  // Check that the tracing state is live (it should be, because
+  // you were supposed to request zero derivatives.)
+  if (state->is_expired()) {
+    throw std::runtime_error("Tracing state is expired!  You should run the tracer with num_derivatives=0");
+  }
+
   auto new_graph = std::make_shared<Graph>();
   std::unordered_map<void*, Node*> new_buffer_map;
 

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -29,7 +29,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
   // Check that the tracing state is live (it should be, because
   // you were supposed to request zero derivatives.)
   if (state->is_expired()) {
-    throw std::runtime_error("Tracing state is expired!  You should run the tracer with num_derivatives=0");
+    throw std::logic_error("ToONNX: tracing state is expired");
   }
 
   auto new_graph = std::make_shared<Graph>();

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -415,9 +415,9 @@ class AvgPool2d(Function):
             raise RuntimeError("ceil_mode not supported in AvgPool2d")
         stride = stride or kernel_size
         n = g.appendNode(g.create("AveragePool", [input])
-                          .is_("kernel_shape", [kernel_size] * 2)
-                          .is_("strides", [stride] * 2)
-                          .is_("pads", [padding] * 4))
+                          .is_("kernel_shape", _pair(kernel_size))
+                          .is_("strides", _pair(stride))
+                          .is_("pads", _pair(padding)))
         return n
 
     @staticmethod

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -418,7 +418,7 @@ class AvgPool2d(Function):
                           .is_("kernel_shape", [kernel_size] * 2)
                           .is_("strides", [stride] * 2)
                           .is_("pads", [padding] * 4))
-        return (n, None)
+        return n
 
     @staticmethod
     def forward(ctx, input, kernel_size, stride=None, padding=0,

--- a/torch/onnx.py
+++ b/torch/onnx.py
@@ -13,10 +13,31 @@ import collections
 import string
 import json
 import math
+import contextlib
 from ._utils import _range
 
 
-def export(model, args, f, export_params=True, kwargs=None, verbose=False):
+@contextlib.contextmanager
+def set_training(model, mode):
+    """
+    A context manager to temporarily set the training mode of 'model'
+    to 'mode', resetting it when we exit the with-block.  A no-op if
+    mode is None.
+    """
+    if mode is None:
+        yield
+        return
+    old_mode = model.training
+    if old_mode != mode:
+        model.train(mode)
+    try:
+        yield
+    finally:
+        if old_mode != mode:
+            model.train(old_mode)
+
+
+def export(model, args, f, export_params=True, verbose=False, training=False):
     """
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported; at the
@@ -26,35 +47,60 @@ def export(model, args, f, export_params=True, kwargs=None, verbose=False):
 
     Arguments:
         model (torch.nn.Module): the model to be exported.
-        args (torch.autograd.Variable or tuple of variables): the inputs to
-            the model, e.g., such that ``model(*args, **kwargs)`` is a valid
-            invocation of the model (see kwargs below).
+        args (tuple of arguments): the inputs to
+            the model, e.g., such that ``model(*args)`` is a valid
+            invocation of the model.  Any non-Variable arguments will
+            be hard-coded into the exported model; any Variable arguments
+            will become inputs of the exported model, in the order they
+            occur in args.  If args is a Variable, this is equivalent
+            to having called it with a 1-ary tuple of that Variable.
+            (Note: passing keyword arguments to the model is not currently
+            supported.  Give us a shout if you need it.)
         f: a file-like object (has to implement fileno that returns a file descriptor)
             or a string containing a file name.  A binary Protobuf will be written
             to this file.
         export_params (bool, default True): if specified, all parameters will
-            be exported.  Set this to False if you are exporting an
-            untrained model.
-        kwargs (dict, optional): keyword inputs to the model.
+            be exported.  Set this to False if you want to export an untrained model.
+            In this case, the exported model will first take all of its parameters
+            as arguments, the ordering as specified by ``model.state_dict().values()``
+        verbose (bool, default False): if specified, we will print out a debug
+            description of the trace being exported.
+        training (bool, default False): export the model in training mode.  At
+            the moment, ONNX is oriented towards exporting models for inference
+            only, so you will generally not need to set this to True.
     """
-    _export(model, args, f, export_params, kwargs, verbose)
+    _export(model, args, f, export_params, verbose, training)
 
 
-def _export(model, args, f, export_params=True, kwargs=None, verbose=False):
+def _export(model, args, f, export_params=True, verbose=False, training=False):
     # Special case for common case of passing a single Variable
     if isinstance(args, torch.autograd.Variable):
         args = (args, )
-    if not kwargs:
-        kwargs = {}
-    trace, torch_out = torch.jit.record_trace(model, *args, **kwargs)
+    # Look at the state_dict *prior* to running the model, as this
+    # accurately captures what inputs we actually passed to the model.
+    # If we run it afterwards, a buggy forward pass could have
+    # added/deleted parameters, changing the structure of the state_dict.
+    #
+    # Note that it's possible the actual /data/ may change by the time we
+    # actually export the model, because we're not cloning the parameters
+    # here.  This shouldn't happen, because we've turned off training
+    # mode and networks in inference mode should be purely functional.
+    # But it's user code; anything can happen!
+    params = None
+    if export_params:
+        # NB: OrderedDict values is not actually a list, but trace.export is
+        # not duck-typed and expects an actual list.
+        params = list(model.state_dict().values())
+    # It's important to run the model in inference mode when exporting;
+    # otherwise internal buffers may get updated, dropout gets applied, etc.
+    with set_training(model, training):
+        trace, torch_out = torch.jit.record_trace(model, *args)
     torch._C._jit_pass_onnx(trace)
     if verbose:
         print(trace)
     # TODO: Don't allocate a in-memory string for the protobuf
     if export_params:
-        # NB: OrderedDict values is not actually a list, but trace.export is
-        # not duck-typed and expects an actual list.
-        proto = trace.export(list(model.state_dict().values()))
+        proto = trace.export(params)
     else:
         proto = trace.export()
     torch.serialization._with_file_like(f, "wb", lambda f: f.write(proto))

--- a/torch/onnx.py
+++ b/torch/onnx.py
@@ -110,6 +110,20 @@ def _export(model, args, f, export_params=True, verbose=False, training=False):
 attr_pattern = re.compile("^(.+)_([ifstg])$")
 
 
+def run_symbolic(op_name, symbolic_fn, args):
+    """
+    This trampoline function gets invoked for every symbolic call.
+    """
+    try:
+        return symbolic_fn(*args)
+    except TypeError as e:
+        # Handle the specific case where we didn't successfully dispatch
+        # to symbolic_fn.  Otherwise, the backtrace will have the clues
+        # you need.
+        e.args = ("{} (occurred when translating {})".format(e.args[0], op_name), )
+        raise
+
+
 def _add_attribute(node, key, value):
     """ initializes the right attribute based on type of value """
     m = attr_pattern.match(key)

--- a/torch/onnx.py
+++ b/torch/onnx.py
@@ -94,7 +94,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=False):
     # It's important to run the model in inference mode when exporting;
     # otherwise internal buffers may get updated, dropout gets applied, etc.
     with set_training(model, training):
-        trace, torch_out = torch.jit.record_trace(model, *args)
+        trace, torch_out = torch.jit.record_trace(model, *args, num_derivatives=0)
     torch._C._jit_pass_onnx(trace)
     if verbose:
         print(trace)


### PR DESCRIPTION
```
commit 88a1e6acbc1d2aaf7731dadad69e0b4f8456cc29
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Sep 19 09:03:08 2017 -0700

    Ask for the correct number of derivatives when tracing.
    
    - If you operate with TracingState, you MUST check if it is live.
      Otherwise you will segfault if it is expired; it is VALID for
      tracing states to become expired.
    
    - Tracing states can expire if they request backward tracing
      (which the tracer does by default).  We don't want this to
      happen for exports, which only look at forwards.  So make
      sure we set the correct num_derivatives.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 37941667d8e82ed1888c5b0aeb6b46a65875b89e
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Sep 19 08:48:11 2017 -0700

    Make assertExpected work with Unicode strings in Python 2.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit d0dc72d8cd9a0df7b094633a40486715680e3c60
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Mon Sep 18 18:55:33 2017 -0700

    More expect test improvements.
    
    - Print some diagnostic information when accepting new test output.
    
    - If it's the first time you ran an expect test, print out
      the output you got so it's easier to decide if you want
      to accept it.
    
    - Add infrastructure for expect-testing against exceptions
      (I'm going to use this in a later patch).
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit dd12823fade09e679629974ec3915c8585741d84
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Mon Sep 18 13:57:37 2017 -0700

    Tighten up the ONNX export interface
    
    - If a user accidentally attempts to export a model that is in training mode, the
      tracer may perturb the parameters (since modules like batchnorm will update
      their parameters.)  To prevent this from happening, we temporarily turn
      off training mode to make sure this doesn't happen.  Temporary is
      important, since model export should not actually affect the model
    
    - If you have a buggy model which is changing the parameters,
      it is much better for us to export the state_dict() *prior*
      to executing the model, because that is what we actually
      used as the inputs to the trace.  The state_dict() afterwards
      could be anything.
    
    - kwargs support never worked, so it's been excised.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 9e20d5b58b1d876f66effba438b096345bb0e687
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Sep 19 14:29:17 2017 -0700

    Give better error message when symbolic() arguments to line up.
    
    Now we actually tell the user what operator was being translated
    when there was a failure.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 6d9b3455c6278f297ab479542bf9aa2a611d172b
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Sep 19 11:08:14 2017 -0700

    Fix minor bug when --accept'ing commits.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 73d3972feeb577a40dbcf138e882769bbbd760f5
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Tue Sep 19 10:53:57 2017 -0700

    Also fix AvgPool2d to follow new convention.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```

CC @apaszke, @zdevito, @prigoyal, @houseroad 