### PR TITLE
Adaptive max pool 3d

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -162,6 +162,12 @@ Pooling Layers
 .. autoclass:: AdaptiveMaxPool2d
     :members:
 
+:hidden:`AdaptiveMaxPool3d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AdaptiveMaxPool3d
+    :members:
+
 :hidden:`AdaptiveAvgPool1d`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -780,6 +786,11 @@ Pooling functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: adaptive_max_pool2d
+
+:hidden:`adaptive_max_pool3d`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: adaptive_max_pool3d
 
 :hidden:`adaptive_avg_pool1d`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1170,7 +1170,7 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=1, dim=-1), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=2, dim=-2), (inputs,)))
 
-    def _test_maxpool_indices(self, num_dim, type=torch.FloatTensor):
+    def _test_maxpool_indices(self, num_dim, adaptive=False, type=torch.FloatTensor):
         def expected_indices(dim):
             if dim == 1:
                 return torch.DoubleTensor([1, 3]).repeat(2, 2, 1)
@@ -1191,7 +1191,11 @@ class TestNN(NNTestCase):
                 col = torch.arange(6, 63, 8)
                 return torch.stack([col, col + 2], 1).view(2, 2, 2, 2)
 
-        module_cls = getattr(nn, 'MaxPool{}d'.format(num_dim))
+        if adaptive:
+            cls_name = 'AdaptiveMaxPool{}d'.format(num_dim)
+        else:
+            cls_name = 'MaxPool{}d'.format(num_dim)
+        module_cls = getattr(nn, cls_name)
         module = module_cls(2, return_indices=True).type(type)
         numel = 4 ** (num_dim + 1)
         input = torch.arange(1, numel + 1).view(2, 2, *repeat(4, num_dim)).type(type)
@@ -1237,35 +1241,35 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_MaxPool1d_indices_cuda(self):
-        self._test_maxpool_indices(1, torch.cuda.FloatTensor)
+        self._test_maxpool_indices(1, type=torch.cuda.FloatTensor)
 
     def test_MaxPool2d_indices(self):
         self._test_maxpool_indices(2)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_MaxPool2d_indices_cuda(self):
-        self._test_maxpool_indices(2, torch.cuda.FloatTensor)
+        self._test_maxpool_indices(2, type=torch.cuda.FloatTensor)
 
     def test_MaxPool3d_indices(self):
         self._test_maxpool_indices(3)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_MaxPool3d_indices_cuda(self):
-        self._test_maxpool_indices(3, torch.cuda.FloatTensor)
+        self._test_maxpool_indices(3, type=torch.cuda.FloatTensor)
 
     def test_AdaptiveMaxPool1d_indices(self):
-        self._test_maxpool_indices(1)
+        self._test_maxpool_indices(1, adaptive=True)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_AdaptiveMaxPool1d_indices_cuda(self):
-        self._test_maxpool_indices(1, torch.cuda.FloatTensor)
+        self._test_maxpool_indices(1, adaptive=True, type=torch.cuda.FloatTensor)
 
     def test_AdaptiveMaxPool2d_indices(self):
-        self._test_maxpool_indices(2)
+        self._test_maxpool_indices(2, adaptive=True)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_AdaptiveMaxPool2d_indices_cuda(self):
-        self._test_maxpool_indices(2, torch.cuda.FloatTensor)
+        self._test_maxpool_indices(2, adaptive=True, type=torch.cuda.FloatTensor)
 
     def _test_scatter(self, tensor):
         x = Variable(tensor, requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1271,6 +1271,13 @@ class TestNN(NNTestCase):
     def test_AdaptiveMaxPool2d_indices_cuda(self):
         self._test_maxpool_indices(2, adaptive=True, type=torch.cuda.FloatTensor)
 
+    def test_AdaptiveMaxPool3d_indices(self):
+        self._test_maxpool_indices(3, adaptive=True)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_AdaptiveMaxPool3d_indices_cuda(self):
+        self._test_maxpool_indices(3, adaptive=True, type=torch.cuda.FloatTensor)
+
     def _test_scatter(self, tensor):
         x = Variable(tensor, requires_grad=True)
         result = dp.scatter(x, (0, 1))
@@ -4125,6 +4132,30 @@ new_module_tests = [
         constructor_args=((3, 4),),
         input=torch.rand(1, 3, 5, 6),
         desc='tuple',
+    ),
+    dict(
+        module_name='AdaptiveMaxPool3d',
+        constructor_args=(3,),
+        input=torch.rand(2, 3, 5, 6, 7),
+        desc='single',
+    ),
+    dict(
+        module_name='AdaptiveMaxPool3d',
+        constructor_args=((3, 4, 5),),
+        input=torch.rand(2, 3, 5, 6, 7),
+        desc='tuple',
+    ),
+    dict(
+        module_name='AdaptiveMaxPool3d',
+        constructor_args=(3,),
+        input=torch.rand(2, 3, 12, 9, 3),
+        desc='single_nonatomic',
+    ),
+    dict(
+        module_name='AdaptiveMaxPool3d',
+        constructor_args=((3, 4, 5),),
+        input=torch.rand(2, 3, 6, 4, 10),
+        desc='tuple_nonatomic',
     ),
     dict(
         module_name='AdaptiveAvgPool1d',

--- a/torch/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
@@ -12,60 +12,60 @@
  */
  template <typename T>
 __global__ void adaptivemaxpool(T *input, T *output, THCIndex_t *indices,
-                        int input_n, int input_h, int input_w,
-                        int output_h, int output_w,
-                        int strideh, int stridew,
-                        int strided)
+                        int sizeD, int isizeH, int isizeW,
+                        int osizeH, int osizeW,
+                        int istrideH, int istrideW,
+                        int istrideD)
 {
   // iterators
-  int xx, yy;
+  int ow, oh;
 
   // compute offsets based on thread/block ID
-  int o = blockIdx.x;
-  int i = o;
-  //int k = blockIdx.x % input_n;
+  int o_plane = blockIdx.x;
+  int i_plane = o_plane;
+  //int k = blockIdx.x % sizeD;
 
-  int xx_start = threadIdx.x;
-  int xx_end = output_w;
-  const int xx_step = blockDim.x;
+  int ostartW = threadIdx.x;
+  int oendW = osizeW;
+  const int ostepW = blockDim.x;
 
-  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
-  int yy_end = output_h;
-  const int yy_step = blockDim.y*gridDim.y;
+  int ostartH = blockDim.y*blockIdx.y + threadIdx.y;
+  int oendH = osizeH;
+  const int ostepH = blockDim.y*gridDim.y;
   // select input/output plane
-  output = output + o*output_w*output_h;
-  input = input + i*strided;
-  indices = indices + o*output_w*output_h;
+  output = output + o_plane*osizeW*osizeH;
+  input = input + i_plane*istrideD;
+  indices = indices + o_plane*osizeW*osizeH;
 
   // For all output pixels...
-  for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+  for(oh = ostartH; oh < oendH; oh+=ostepH) {
 
-    int y_start = (int)floor(float(yy) / output_h * input_h);
-    int y_end   = (int)ceil(float(yy+1) / output_h * input_h);
-    int kH = y_end-y_start;
+    int istartH = (int)floor(float(oh) / osizeH * isizeH);
+    int iendH   = (int)ceil(float(oh+1) / osizeH * isizeH);
+    int kH = iendH-istartH;
 
-    for(xx = xx_start; xx < xx_end; xx+=xx_step) {
-      int x_start = (int)floor(float(xx) / output_w * input_w);
-      int x_end   = (int)ceil(float(xx + 1) / output_w * input_w);
+    for(ow = ostartW; ow < oendW; ow+=ostepW) {
+      int istartW = (int)floor(float(ow) / osizeW * isizeW);
+      int iendW   = (int)ceil(float(ow + 1) / osizeW * isizeW);
 
-      int kW = x_end-x_start;
+      int kW = iendW-istartW;
 
       // Compute the mean of the input image...
-      T *ptr_input = input + y_start*strideh + x_start*stridew;
-      T *ptr_output = output + yy*output_w + xx;
-      THCIndex_t *ptr_ind = indices + yy*output_w + xx;
+      T *ptr_input = input + istartH*istrideH + istartW*istrideW;
+      T *ptr_output = output + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices + oh*osizeW + ow;
       int argmax = -1;
       T max = THCNumerics<T>::min();
-      int kx, ky;
-      for(ky = 0; ky < kH; ky++) {
-        for(kx = 0; kx < kW; kx++) {
-          T val = ptr_input[kx*stridew];
+      int iw, ih;
+      for(ih = 0; ih < kH; ih++) {
+        for(iw = 0; iw < kW; iw++) {
+          T val = ptr_input[iw*istrideW];
           if (val > max) {
             max = val;
-            argmax = (ky+y_start)*input_w + kx+x_start;
+            argmax = (ih+istartH)*isizeW + iw+istartW;
           }
         }
-        ptr_input += strideh; // next input line
+        ptr_input += istrideH; // next input line
       }
       // Update output and argmax
       *ptr_output = max;
@@ -80,45 +80,45 @@ __global__ void adaptivemaxpool(T *input, T *output, THCIndex_t *indices,
  */
  template <typename T>
 __global__ void adaptivemaxgradinput(T *gradInput, T *gradOutput, THCIndex_t *indices,
-                             int input_n, int input_h, int input_w,
-                             int output_h, int output_w)
+                             int sizeD, int isizeH, int isizeW,
+                             int osizeH, int osizeW)
 {
   // iterators
-  int xx, yy;
+  int ow, oh;
 
   // compute offsets based on thread/block ID
-  int o = blockIdx.x;
-  int i = o;
-  //int k = blockIdx.x % input_n;
+  int o_plane = blockIdx.x;
+  int i_plane = o_plane;
+  //int k = blockIdx.x % sizeD;
 
-  int xx_start = threadIdx.x;
-  int xx_end = output_w;
-  int xx_step = blockDim.x;
+  int ostartW = threadIdx.x;
+  int oendW = osizeW;
+  int ostepW = blockDim.x;
 
-  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
-  int yy_end = output_h;
-  int yy_step = blockDim.y*gridDim.y;
+  int ostartH = blockDim.y*blockIdx.y + threadIdx.y;
+  int oendH = osizeH;
+  int ostepH = blockDim.y*gridDim.y;
 
   // select input/output plane
-  gradOutput = gradOutput + o*output_w*output_h;
-  gradInput = gradInput + i*input_w*input_h;
-  indices = indices + o*output_w*output_h;
+  gradOutput = gradOutput + o_plane*osizeW*osizeH;
+  gradInput = gradInput + i_plane*isizeW*isizeH;
+  indices = indices + o_plane*osizeW*osizeH;
 
   // compute gradInput
-  for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+  for(oh = ostartH; oh < oendH; oh+=ostepH) {
 
-    int y_start = (int)floor(float(yy) / output_h * input_h);
+    int istartH = (int)floor(float(oh) / osizeH * isizeH);
 
-    for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+    for(ow = ostartW; ow < oendW; ow+=ostepW) {
 
-      int x_start = (int)floor(float(xx) / output_w * input_w);
+      int istartW = (int)floor(float(ow) / osizeW * isizeW);
 
-      T *ptr_gradInput = gradInput + y_start*input_w + x_start;
-      T *ptr_gradOutput = gradOutput + yy*output_w + xx;
-      THCIndex_t *ptr_ind = indices + yy*output_w + xx;
+      T *ptr_gradInput = gradInput + istartH*isizeW + istartW;
+      T *ptr_gradOutput = gradOutput + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices + oh*osizeW + ow;
       T z = *ptr_gradOutput;
 
-      int argmax = (*ptr_ind) - TH_INDEX_BASE - x_start - y_start*input_w;
+      int argmax = (*ptr_ind) - TH_INDEX_BASE - istartW - istartH*isizeW;
 
       ptr_gradInput[argmax] += z;
     }
@@ -133,44 +133,44 @@ __global__ void adaptivemaxgradinput(T *gradInput, T *gradOutput, THCIndex_t *in
  template <typename T>
 __global__ void atomicadaptivemaxgradinput(
   T *gradInput, T *gradOutput, THCIndex_t *indices,
-  int input_n, int input_h, int input_w, int output_h, int output_w
+  int sizeD, int isizeH, int isizeW, int osizeH, int osizeW
 )
 {
   // iterators
-  int xx, yy;
+  int ow, oh;
 
   // compute offsets based on thread/block ID
-  int o = blockIdx.x;
-  int i = o;
+  int o_plane = blockIdx.x;
+  int i_plane = o_plane;
 
-  int xx_start = threadIdx.x;
-  int xx_end = output_w;
-  int xx_step = blockDim.x;
+  int ostartW = threadIdx.x;
+  int oendW = osizeW;
+  int ostepW = blockDim.x;
 
-  int yy_start = blockDim.y*blockIdx.y + threadIdx.y;
-  int yy_end = output_h;
-  int yy_step = blockDim.y*gridDim.y;
+  int ostartH = blockDim.y*blockIdx.y + threadIdx.y;
+  int oendH = osizeH;
+  int ostepH = blockDim.y*gridDim.y;
 
   // select input/output plane
-  gradOutput = gradOutput + o*output_w*output_h;
-  gradInput = gradInput + i*input_w*input_h;
-  indices = indices + o*output_w*output_h;
+  gradOutput = gradOutput + o_plane*osizeW*osizeH;
+  gradInput = gradInput + i_plane*isizeW*isizeH;
+  indices = indices + o_plane*osizeW*osizeH;
 
   // compute gradInput
-  for(yy = yy_start; yy < yy_end; yy+=yy_step) {
+  for(oh = ostartH; oh < oendH; oh+=ostepH) {
 
-    int y_start = (int)floor(float(yy) / output_h * input_h);
+    int istartH = (int)floor(float(oh) / osizeH * isizeH);
 
-    for(xx = xx_start; xx < xx_end; xx+=xx_step) {
+    for(ow = ostartW; ow < oendW; ow+=ostepW) {
 
-      int x_start = (int)floor(float(xx) / output_w * input_w);
+      int istartW = (int)floor(float(ow) / osizeW * isizeW);
 
-      T *ptr_gradInput = gradInput + y_start*input_w + x_start;
-      T *ptr_gradOutput = gradOutput + yy*output_w + xx;
-      THCIndex_t *ptr_ind = indices + yy*output_w + xx;
+      T *ptr_gradInput = gradInput + istartH*isizeW + istartW;
+      T *ptr_gradOutput = gradOutput + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices + oh*osizeW + ow;
       T z = *ptr_gradOutput;
 
-      int argmax = (*ptr_ind) - TH_INDEX_BASE - x_start - y_start*input_w;
+      int argmax = (*ptr_ind) - TH_INDEX_BASE - istartW - istartH*isizeW;
 
       // atomic add since different threads could update same variable
       atomicAdd(&(ptr_gradInput[argmax]), z);

--- a/torch/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
@@ -19,9 +19,9 @@
  */
  template <typename T>
 __global__ void adaptivemaxpool(T *input, T *output, THCIndex_t *indices,
-                        int sizeD, int isizeH, int isizeW,
+                        int isizeH, int isizeW,
                         int osizeH, int osizeW,
-                        int istrideD, int istrideH, int istrideW)
+                        int64_t istrideD, int64_t istrideH, int64_t istrideW)
 {
   // iterators
   int oh, ow;
@@ -85,7 +85,7 @@ __global__ void adaptivemaxpool(T *input, T *output, THCIndex_t *indices,
  */
  template <typename T>
 __global__ void adaptivemaxgradinput(T *gradInput, T *gradOutput, THCIndex_t *indices,
-                             int sizeD, int isizeH, int isizeW,
+                             int isizeH, int isizeW,
                              int osizeH, int osizeW)
 {
   // iterators
@@ -133,7 +133,7 @@ __global__ void adaptivemaxgradinput(T *gradInput, T *gradOutput, THCIndex_t *in
  template <typename T>
 __global__ void atomicadaptivemaxgradinput(
   T *gradInput, T *gradOutput, THCIndex_t *indices,
-  int sizeD, int isizeH, int isizeW, int osizeH, int osizeW
+  int isizeH, int isizeW, int osizeH, int osizeW
 )
 {
   // iterators

--- a/torch/lib/THCUNN/VolumetricAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/VolumetricAdaptiveMaxPooling.cu
@@ -1,0 +1,206 @@
+#include "THCUNN.h"
+#include "THCHalf.h"
+#include "THCHalfAutoNumerics.cuh"
+#include "THCAtomics.cuh"
+
+#define CUDA_MAX_THREADS 1024   // this is safe, in reality 256 is our limit
+
+#define START_IND(a,b,c) (int)floor((float)(a * c) / b)
+#define END_IND(a,b,c) (int)ceil((float)((a + 1) * c) / b)
+// #define START_IND(a,b,c) a * c / b
+// #define END_IND(a,b,c)  (a + 1) * c / b + ((a + 1) * c % b > 0)?1:0
+
+// 5d tensor B x D x T x H x W
+
+/*
+ * Description:
+ *    this function adaptively maxpools an input 4D tensor along dimensions 2 and 3
+ *    4D input, 4D output, 4D argmax x and y
+ */
+ template <typename T>
+__global__ void cunn_VolumetricAdaptiveMaxPooling_updateOutput_kernel(
+                        T *input, T *output, THCIndex_t *indices,
+                        int isizeT, int isizeH, int isizeW,
+                        int osizeT, int osizeH, int osizeW,
+                        int64_t istrideD,
+                        int64_t istrideT, int64_t istrideH, int64_t istrideW,
+                        int64_t offsetZ)
+{
+  // iterators on output pixels
+  int ot, oh, ow;
+
+  // compute offsets based on thread/block ID
+  int ostartH = blockIdx.y * blockDim.y + threadIdx.y;
+  int oendH   = osizeH;
+  int ostepH  = gridDim.y * blockDim.y;
+  int ostartW = threadIdx.x;
+  int oendW   = osizeW;
+  int ostepW  = blockDim.x;
+
+  // select output plane
+  int64_t o_plane = blockIdx.x + offsetZ;
+  ot = o_plane % osizeT;     // output frame/time
+  int d = o_plane / osizeT;  // slice/feature
+
+  // input frame/time ramge is fixed.
+  int istartT = START_IND(ot, osizeT, isizeT);
+  int iendT = END_IND(ot, osizeT, isizeT);
+  int kT = iendT - istartT;
+
+  // input offset by slice/feature and earliest relevant frame/time
+  T *input_dt = input + d*istrideD + istartT*istrideT;
+  // output offset by slice/feature and frame/time
+  T *output_dt = output + o_plane*osizeH*osizeW;
+  // indices offset by slice/feature and frame/time
+  THCIndex_t *indices_dt = indices + o_plane*osizeH*osizeW;
+
+  // For all output pixels...
+  for(oh = ostartH; oh < oendH; oh += ostepH) {
+
+    int istartH = START_IND(oh, osizeH, isizeH);
+    int iendH   = END_IND(oh, osizeH, isizeH);
+    int kH = iendH - istartH;
+
+    for(ow = ostartW; ow < oendW; ow += ostepW) {
+
+      int istartW = START_IND(ow, osizeW, isizeW);
+      int iendW   = END_IND(ow, osizeW, isizeW);
+      int kW = iendW - istartW;
+
+      // Compute the average pooling from corresponding input pixels
+      T *ptr_input = input_dt + istartH*istrideH + istartW*istrideW;
+      T *ptr_output = output_dt + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices_dt + oh*osizeW + ow;
+      int64_t argmax = -1;
+      T max = THCNumerics<T>::min();
+
+      int it, ih, iw;
+      for(it = 0; it < kT; ++it) {
+        for(ih = 0; ih < kH; ++ih) {
+          for(iw = 0; iw < kW; ++iw) {
+            T val = ptr_input[ih*istrideH + iw*istrideW];
+            if (val > max) {
+              max = val;
+              argmax = (it+istartT)*isizeH*isizeW + (ih+istartH)*isizeW + iw+istartW;
+            }
+          }
+        }
+        ptr_input += istrideT;   // next input frame
+      }
+      // Update output and argmax
+      *ptr_output = max;
+      *ptr_ind = argmax + TH_INDEX_BASE;
+    }
+  }
+}
+
+/*
+ * Description:
+ *    This function computes the gradInput from gradOutput.
+ *
+ *    gridDim.y blocks work together on a single 2D output plane specified by
+ *    (blockIdx.x + offsetZ).
+ *
+ *    Assumes that input size can be perfectly divided by output size, i.e.
+ *    each input pixel can only be argmax of one output pixel.
+ */
+ template <typename T>
+__global__ void cunn_VolumetricAdaptiveMaxPooling_updateGradInput_kernel(
+  T *gradInput, T *gradOutput, THCIndex_t *indices,
+  int isizeT, int isizeH, int isizeW,
+  int osizeT, int osizeH, int osizeW,
+  int64_t offsetZ
+)
+{
+  // iterators on output pixels
+  int oh, ow;
+
+  // compute offsets based on thread/block ID
+  int ostartH = blockIdx.y * blockDim.y + threadIdx.y;
+  int oendH   = osizeH;
+  int ostepH  = gridDim.y * blockDim.y;
+  int ostartW = threadIdx.x;
+  int oendW   = osizeW;
+  int ostepW  = blockDim.x;
+
+  // select output plane
+  int64_t o_plane = blockIdx.x + offsetZ;
+  int d = o_plane / osizeT;     // output slice/feature
+
+  // gradInput offset by slice/feature
+  T *gradInput_d = gradInput + d*isizeT*isizeH*isizeW;
+  // gradOutput offset by slice/feature and frame/otme
+  T *gradOutput_dt = gradOutput + o_plane*osizeH*osizeW;
+  // indices offset by slice/feature and frame/otme
+  THCIndex_t *indices_dt = indices + o_plane*osizeH*osizeW;
+
+  // For all output pixels...
+  for(oh = ostartH; oh < oendH; oh += ostepH) {
+    for(ow = ostartW; ow < oendW; ow += ostepW) {
+      // Compute the gradients for the argmax input pixel
+      T *ptr_gradOutput = gradOutput_dt + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices_dt + oh*osizeW + ow;
+      T grad_delta = *ptr_gradOutput;
+      int argmax = (*ptr_ind) - TH_INDEX_BASE;
+      gradInput_d[argmax] += grad_delta;
+    }
+  }
+}
+
+
+/*
+ * Description:
+ *    This function computes the gradInput from gradOutput.
+ *
+ *    gridDim.y blocks work together on a single 2D output plane specified by
+ *    (blockIdx.x + offsetZ).
+ *
+ *    Uses atomic add.
+ */
+ template <typename T>
+__global__ void cunn_atomic_VolumetricAdaptiveMaxPooling_updateGradInput_kernel(
+  T *gradInput, T *gradOutput, THCIndex_t *indices,
+  int isizeT, int isizeH, int isizeW,
+  int osizeT, int osizeH, int osizeW,
+  int64_t offsetZ
+)
+{
+  // iterators on output pixels
+  int oh, ow;
+
+  // compute offsets based on thread/block ID
+  int ostartH = blockIdx.y * blockDim.y + threadIdx.y;
+  int oendH   = osizeH;
+  int ostepH  = gridDim.y * blockDim.y;
+  int ostartW = threadIdx.x;
+  int oendW   = osizeW;
+  int ostepW  = blockDim.x;
+
+  // select output plane
+  int64_t o_plane = blockIdx.x + offsetZ;
+  int d = o_plane / osizeT;     // output slice/feature
+
+  // gradInput offset by slice/feature
+  T *gradInput_d = gradInput + d*isizeT*isizeH*isizeW;
+  // gradOutput offset by slice/feature and frame/otme
+  T *gradOutput_dt = gradOutput + o_plane*osizeH*osizeW;
+  // indices offset by slice/feature and frame/otme
+  THCIndex_t *indices_dt = indices + o_plane*osizeH*osizeW;
+
+  // For all output pixels...
+  for(oh = ostartH; oh < oendH; oh += ostepH) {
+    for(ow = ostartW; ow < oendW; ow += ostepW) {
+      // Compute the gradients for the argmax input pixel
+      T *ptr_gradOutput = gradOutput_dt + oh*osizeW + ow;
+      THCIndex_t *ptr_ind = indices_dt + oh*osizeW + ow;
+      T grad_delta = *ptr_gradOutput;
+      int64_t argmax = (*ptr_ind) - TH_INDEX_BASE;
+      atomicAdd(&(gradInput_d[argmax]), grad_delta);
+    }
+  }
+}
+
+#include "generic/VolumetricAdaptiveMaxPooling.cu"
+#include "THCGenerateFloatTypes.h"
+
+#undef CUDA_MAX_THREADS

--- a/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -49,7 +49,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
                                    indices_data,
-                                   sizeD, isizeH, isizeW, osizeH, osizeW,
+                                   isizeH, isizeW, osizeH, osizeW,
                                    istrideD, istrideH, istrideW);
     THCudaCheck(cudaGetLastError());
 
@@ -81,7 +81,7 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
                                    indices_data,
-                                   sizeD, isizeH, isizeW, osizeH, osizeW,
+                                   isizeH, isizeW, osizeH, osizeW,
                                    istrideD, istrideH, istrideW);
     THCudaCheck(cudaGetLastError());
     // clean
@@ -134,14 +134,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          sizeD, isizeH, isizeW, osizeH, osizeW);
+                                          isizeH, isizeW, osizeH, osizeW);
     }
     else
     {
       // run updateGradInput kernel
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          sizeD, isizeH, isizeW, osizeH, osizeW);
+                                          isizeH, isizeW, osizeH, osizeW);
     }
     THCudaCheck(cudaGetLastError());
   } else {
@@ -173,14 +173,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          sizeD, isizeH, isizeW, osizeH, osizeW);
+                                          isizeH, isizeW, osizeH, osizeW);
     }
     else
     {
       // run updateGradInput kernel, accumulate gradients atomically
       adaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          sizeD, isizeH, isizeW, osizeH, osizeW);
+                                          isizeH, isizeW, osizeH, osizeW);
     }
     THCudaCheck(cudaGetLastError());
   }

--- a/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -9,8 +9,8 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
            THCTensor *input,
            THCTensor *output,
            THCIndexTensor *indices,
-           int nOutputCols,
-           int nOutputRows)
+           int osizeW,
+           int osizeH)
 {
   THCUNN_assertSameGPU(state, 3, input, output, indices);
 
@@ -22,65 +22,65 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
                   "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 3) {
-    int64_t nInputCols = input->size[2];
-    int64_t nInputRows = input->size[1];
-    int64_t nInputPlane = input->size[0];
+    int64_t isizeW = input->size[2];
+    int64_t isizeH = input->size[1];
+    int64_t sizeD = input->size[0];
 
-    int64_t istride_d = input->stride[0];
-    int64_t istride_h = input->stride[1];
-    int64_t istride_w = input->stride[2];
+    int64_t istrideD = input->stride[0];
+    int64_t istrideH = input->stride[1];
+    int64_t istrideW = input->stride[2];
 
     input_data = THCTensor_(data)(state, input);
 
-    THCTensor_(resize3d)(state, output, nInputPlane, nOutputRows, nOutputCols);
-    THCIndexTensor_(resize3d)(state, indices, nInputPlane, nOutputRows, nOutputCols);
+    THCTensor_(resize3d)(state, output, sizeD, osizeH, osizeW);
+    THCIndexTensor_(resize3d)(state, indices, sizeD, osizeH, osizeW);
 
     indices_data = THCIndexTensor_(data)(state, indices);
     output_data = THCTensor_(data)(state, output);
 
     // cuda blocks & threads:
-    int yblocks = (int)(16L / nInputPlane);
-    yblocks = yblocks < 1 ? 1 : yblocks;
-    dim3 blocks(nInputPlane,yblocks);
+    int blocksH = (int)(16L / sizeD);
+    blocksH = blocksH < 1 ? 1 : blocksH;
+    dim3 blocks(sizeD,blocksH);
     dim3 threads(32,8);
 
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
                                    indices_data,
-                                   nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols,
-                                   istride_h, istride_w, istride_d);
+                                   sizeD, isizeH, isizeW, osizeH, osizeW,
+                                   istrideH, istrideW, istrideD);
     THCudaCheck(cudaGetLastError());
 
   } else {
     input = THCTensor_(newContiguous)(state, input);
-    int64_t nInputCols = input->size[3];
-    int64_t nInputRows = input->size[2];
-    int64_t nInputPlane = input->size[1];
-    int64_t nbatch = input->size[0];
+    int64_t isizeW = input->size[3];
+    int64_t isizeH = input->size[2];
+    int64_t sizeD = input->size[1];
+    int64_t sizeB = input->size[0];
 
-    int64_t istride_d = input->stride[1];
-    int64_t istride_h = input->stride[2];
-    int64_t istride_w = input->stride[3];
+    int64_t istrideD = input->stride[1];
+    int64_t istrideH = input->stride[2];
+    int64_t istrideW = input->stride[3];
 
     input_data = THCTensor_(data)(state, input);
 
-    THCTensor_(resize4d)(state, output, nbatch, nInputPlane, nOutputRows, nOutputCols);
-    THCIndexTensor_(resize4d)(state, indices, nbatch, nInputPlane, nOutputRows, nOutputCols);
+    THCTensor_(resize4d)(state, output, sizeB, sizeD, osizeH, osizeW);
+    THCIndexTensor_(resize4d)(state, indices, sizeB, sizeD, osizeH, osizeW);
 
     indices_data = THCIndexTensor_(data)(state, indices);
     output_data = THCTensor_(data)(state, output);
 
     // cuda blocks & threads:
-    int yblocks = (int)(16L / nInputPlane);
-    yblocks = yblocks < 1 ? 1 : yblocks;
-    dim3 blocks(nInputPlane*nbatch,yblocks);
+    int blocksH = (int)(16L / sizeD);
+    blocksH = blocksH < 1 ? 1 : blocksH;
+    dim3 blocks(sizeD*sizeB,blocksH);
     dim3 threads(32,8);
 
     // run maxpool kernel
     adaptivemaxpool <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (input_data, output_data,
                                    indices_data,
-                                   nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols,
-                                   istride_h, istride_w, istride_d);
+                                   sizeD, isizeH, isizeW, osizeH, osizeW,
+                                   istrideH, istrideW, istrideD);
     THCudaCheck(cudaGetLastError());
     // clean
     THCTensor_(free)(state, input);
@@ -105,13 +105,13 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
   if (input->nDimension == 3) {
-    int64_t nInputCols = input->size[2];
-    int64_t nInputRows = input->size[1];
-    int64_t nInputPlane = input->size[0];
-    int64_t nOutputCols = gradOutput->size[2];
-    int64_t nOutputRows = gradOutput->size[1];
+    int64_t isizeW = input->size[2];
+    int64_t isizeH = input->size[1];
+    int64_t sizeD = input->size[0];
+    int64_t osizeW = gradOutput->size[2];
+    int64_t osizeH = gradOutput->size[1];
 
-    //bool atomic = (nInputCols%nOutputCols != 0) || (nInputRows%nOutputRows != 0);
+    //bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 
     THCTensor_(resizeAs)(state, gradInput, input);
     THCTensor_(zero)(state, gradInput);
@@ -121,9 +121,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     gradInput_data = THCTensor_(data)(state, gradInput);
 
     // cuda blocks & threads:
-    int yblocks = (int)(16L / nInputPlane);
-    yblocks = yblocks < 1 ? 1 : yblocks;
-    dim3 blocks(nInputPlane,yblocks);
+    int blocksH = (int)(16L / sizeD);
+    blocksH = blocksH < 1 ? 1 : blocksH;
+    dim3 blocks(sizeD,blocksH);
     dim3 threads(32,8);
 
     if(atomic)
@@ -131,25 +131,25 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
+                                          sizeD, isizeH, isizeW, osizeH, osizeW);
     }
     else
     {
       // run updateGradInput kernel
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
+                                          sizeD, isizeH, isizeW, osizeH, osizeW);
     }
     THCudaCheck(cudaGetLastError());
   } else {
-    int64_t nInputCols = input->size[3];
-    int64_t nInputRows = input->size[2];
-    int64_t nInputPlane = input->size[1];
-    int64_t nbatch = input->size[0];
-    int64_t nOutputCols = gradOutput->size[3];
-    int64_t nOutputRows = gradOutput->size[2];
+    int64_t isizeW = input->size[3];
+    int64_t isizeH = input->size[2];
+    int64_t sizeD = input->size[1];
+    int64_t sizeB = input->size[0];
+    int64_t osizeW = gradOutput->size[3];
+    int64_t osizeH = gradOutput->size[2];
 
-    //bool atomic = //(nInputCols%nOutputCols != 0) || (nInputRows%nOutputRows != 0);
+    //bool atomic = //(isizeW%osizeW != 0) || (isizeH%osizeH != 0);
 
     THCTensor_(resizeAs)(state, gradInput, input);
     THCTensor_(zero)(state, gradInput);
@@ -159,9 +159,9 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
     gradInput_data = THCTensor_(data)(state, gradInput);
 
     // cuda blocks & threads:
-    int yblocks = (int)(16L / nInputPlane);
-    yblocks = yblocks < 1 ? 1 : yblocks;
-    dim3 blocks(nInputPlane*nbatch,yblocks);
+    int blocksH = (int)(16L / sizeD);
+    blocksH = blocksH < 1 ? 1 : blocksH;
+    dim3 blocks(sizeD*sizeB,blocksH);
     dim3 threads(32,8);
 
     if(atomic)
@@ -169,14 +169,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
       // run updateGradInput kernel, accumulate gradients atomically
       atomicadaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
+                                          sizeD, isizeH, isizeW, osizeH, osizeW);
     }
     else
     {
       // run updateGradInput kernel, accumulate gradients atomically
       adaptivemaxgradinput <<<blocks, threads, 0, THCState_getCurrentStream(state)>>> (gradInput_data, gradOutput_data,
                                           indices_data,
-                                          nInputPlane, nInputRows, nInputCols, nOutputRows, nOutputCols);
+                                          sizeD, isizeH, isizeW, osizeH, osizeW);
     }
     THCudaCheck(cudaGetLastError());
   }

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -522,8 +522,8 @@ TH_API void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
                   THCTensor *input,
                   THCTensor *output,
                   THCIndexTensor *indices,
-                  int nOutputCols,
-                  int nOutputRows);
+                  int osizeW,
+                  int osizeH);
 
 TH_API void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
                   THCState *state,

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -1553,6 +1553,22 @@ TH_API void THNN_(VolumetricMaxUnpooling_updateGradInput)(
                   int dT, int dW, int dH,
                   int padT, int padW, int padH);
 
+TH_API void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *output,
+                  THCIndexTensor *indices,
+                  int osizeT,
+                  int osizeW,
+                  int osizeH);
+
+TH_API void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
+                  THCState *state,
+                  THCTensor *input,
+                  THCTensor *gradOutput,
+                  THCTensor *gradInput,
+                  THCIndexTensor *indices);
+
 TH_API void THNN_(VolumetricAdaptiveAveragePooling_updateOutput)(
                   THCState *state,
                   THCTensor *input,

--- a/torch/lib/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
+++ b/torch/lib/THCUNN/generic/VolumetricAdaptiveMaxPooling.cu
@@ -1,0 +1,178 @@
+#ifndef THC_GENERIC_FILE
+#define THC_GENERIC_FILE "generic/VolumetricAdaptiveMaxPooling.cu"
+#else
+
+#include "../common.h"
+
+// 5d tensor B x D x T x H x W
+
+void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *output,
+           THCIndexTensor *indices,
+           int osizeT,
+           int osizeW,
+           int osizeH)
+{
+  THCUNN_assertSameGPU(state, 3, input, output, indices);
+
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
+
+  THCIndex_t *indices_data;
+  real *output_data;
+  real *input_data;
+
+  int64_t sizeD, isizeT, isizeH, isizeW;
+  int64_t istrideD, istrideT, istrideH, istrideW;
+  int64_t totalZ;
+
+  if (input->nDimension == 4) {
+    sizeD = input->size[0];
+    isizeT = input->size[1];
+    isizeH = input->size[2];
+    isizeW = input->size[3];
+
+    istrideD = input->stride[0];
+    istrideT = input->stride[1];
+    istrideH = input->stride[2];
+    istrideW = input->stride[3];
+
+    THCTensor_(resize4d)(state, output, sizeD, osizeT, osizeH, osizeW);
+    THCIndexTensor_(resize4d)(state, indices, sizeD, osizeT, osizeH, osizeW);
+
+    totalZ = sizeD * osizeT;
+  } else {
+    input = THCTensor_(newContiguous)(state, input);
+
+    int64_t sizeB = input->size[0];
+    sizeD = input->size[1];
+    isizeT = input->size[2];
+    isizeH = input->size[3];
+    isizeW = input->size[4];
+
+    istrideD = input->stride[1];
+    istrideT = input->stride[2];
+    istrideH = input->stride[3];
+    istrideW = input->stride[4];
+
+    THCTensor_(resize5d)(state, output, sizeB, sizeD, osizeT, osizeH, osizeW);
+    THCIndexTensor_(resize5d)(state, indices, sizeB, sizeD, osizeT, osizeH, osizeW);
+
+    totalZ = sizeB * sizeD * osizeT;
+  }
+
+  input_data = THCTensor_(data)(state, input);
+  output_data = THCTensor_(data)(state, output);
+  indices_data = THCIndexTensor_(data)(state, indices);
+
+  int64_t offsetZ = 0;
+  dim3 threads(32, 8);
+  // each H*W plane is processed by blocksH thread blocks
+  int blocksH = max((int)(16L / totalZ), 1);
+  while (totalZ > 0) {
+    dim3 blocks(totalZ > 65535 ? 65535 : totalZ, blocksH);
+    cunn_VolumetricAdaptiveMaxPooling_updateOutput_kernel
+      <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
+        input_data, output_data, indices_data, isizeT, isizeH, isizeW,
+        osizeT, osizeH, osizeW, istrideD, istrideT, istrideH, istrideW, offsetZ
+      );
+
+    totalZ -= 65535;
+    offsetZ += 65535;
+    THCudaCheck(cudaGetLastError());
+  }
+
+  if (input->nDimension == 5) {
+    // clean
+    THCTensor_(free)(state, input);
+  }
+}
+
+void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
+           THCState *state,
+           THCTensor *input,
+           THCTensor *gradOutput,
+           THCTensor *gradInput,
+           THCIndexTensor *indices)
+{
+  THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
+
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+
+  THCTensor_(resizeAs)(state, gradInput, input);
+  THCTensor_(zero)(state, gradInput);
+
+  THCIndex_t *indices_data;
+  real *gradInput_data;
+  real *gradOutput_data;
+
+  int64_t sizeD, isizeT, isizeH, isizeW;
+  int64_t osizeT, osizeH, osizeW;
+  int64_t totalZ;
+
+  if (input->nDimension == 4) {
+    sizeD = input->size[0];
+    isizeT = input->size[1];
+    isizeH = input->size[2];
+    isizeW = input->size[3];
+
+    osizeT = gradOutput->size[1];
+    osizeH = gradOutput->size[2];
+    osizeW = gradOutput->size[3];
+  } else {
+    sizeD = input->size[1];
+    isizeT = input->size[2];
+    isizeH = input->size[3];
+    isizeW = input->size[4];
+
+    osizeT = gradOutput->size[2];
+    osizeH = gradOutput->size[3];
+    osizeW = gradOutput->size[4];
+  }
+
+  bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0) || (isizeT%osizeT != 0);
+
+  if (input->nDimension == 4) {
+    totalZ = sizeD * osizeT;
+  } else {
+    int sizeB = input->size[0];
+    totalZ = sizeB * sizeD * osizeT;
+  }
+
+  indices_data = THCIndexTensor_(data)(state, indices);
+  gradInput_data = THCTensor_(data)(state, gradInput);
+  gradOutput_data = THCTensor_(data)(state, gradOutput);
+
+  int64_t offsetZ = 0;
+  dim3 threads(32, 8);
+  // each H*W plane is processed by blocksH thread blocks
+  int blocksH = max((int)(16L / totalZ), 1);
+  while (totalZ > 0) {
+    dim3 blocks(totalZ > 65535 ? 65535 : totalZ, blocksH);
+
+    if (atomic)
+    {
+      cunn_atomic_VolumetricAdaptiveMaxPooling_updateGradInput_kernel
+        <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
+          gradInput_data, gradOutput_data, indices_data,
+          isizeT, isizeH, isizeW, osizeT, osizeH, osizeW, offsetZ
+        );
+    } else {
+      cunn_VolumetricAdaptiveMaxPooling_updateGradInput_kernel
+        <<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
+          gradInput_data, gradOutput_data, indices_data,
+          isizeT, isizeH, isizeW, osizeT, osizeH, osizeW, offsetZ
+        );
+    }
+
+    totalZ -= 65535;
+    offsetZ += 65535;
+    THCudaCheck(cudaGetLastError());
+  }
+  // clean
+  THCTensor_(free)(state, gradOutput);
+}
+
+#endif

--- a/torch/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/torch/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -2,6 +2,11 @@
 #define TH_GENERIC_FILE "generic/SpatialAdaptiveMaxPooling.c"
 #else
 
+#define START_IND(a,b,c) (int)floor((float)(a * c) / b)
+#define END_IND(a,b,c) (int)ceil((float)((a + 1) * c) / b)
+// #define START_IND(a,b,c) a * c / b
+// #define END_IND(a,b,c)  (a + 1) * c / b + ((a + 1) * c % b > 0)?1:0
+
 // 4d tensor B x D x H x W
 
 static void THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(
@@ -25,15 +30,14 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(
     int64_t oh, ow;
     for(oh = 0; oh < osizeH; oh++)
     {
-      int istartH = (int)floor((float)oh / osizeH * isizeH);
-      int iendH   = (int)ceil((float)(oh + 1) / osizeH * isizeH);
+      int istartH = START_IND(oh, osizeH, isizeH);
+      int iendH   = END_IND(oh, osizeH, isizeH);
       int kH = iendH - istartH;
 
       for(ow = 0; ow < osizeW; ow++)
       {
-
-        int istartW = (int)floor((float)ow / osizeW * isizeW);
-        int iendW   = (int)ceil((float)(ow + 1) / osizeW * isizeW);
+        int istartW = START_IND(ow, osizeW, isizeW);
+        int iendW   = END_IND(ow, osizeW, isizeW);
         int kW = iendW - istartW;
 
         /* local pointers */
@@ -181,10 +185,8 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(
     int64_t oh, ow;
     for(oh = 0; oh < osizeH; oh++)
     {
-      int istartH = (int)floor((float) oh / osizeH * isizeH);
       for(ow = 0; ow < osizeW; ow++)
       {
-        int istartW = (int)floor((float) ow / osizeW * isizeW);
         /* retrieve position of max */
         int64_t maxp = ind_p_d[oh*osizeW + ow] - TH_INDEX_BASE;
 

--- a/torch/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/torch/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -6,53 +6,53 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(
           real *input_p,
           real *output_p,
           THIndex_t *ind_p,
-          int64_t nslices,
-          int64_t iwidth,
-          int64_t iheight,
-          int64_t owidth,
-          int64_t oheight,
-          int64_t stridew,
-          int64_t strideh,
-          int64_t strided)
+          int64_t sizeD,
+          int64_t isizeW,
+          int64_t isizeH,
+          int64_t osizeW,
+          int64_t osizeH,
+          int64_t istrideW,
+          int64_t istrideH,
+          int64_t istrideD)
 {
-  int64_t k;
-#pragma omp parallel for private(k)
-  for (k = 0; k < nslices; k++)
+  int64_t d;
+#pragma omp parallel for private(d)
+  for (d = 0; d < sizeD; d++)
   {
     /* loop over output */
-    int64_t i, j;
-    for(i = 0; i < oheight; i++)
+    int64_t oh, ow;
+    for(oh = 0; oh < osizeH; oh++)
     {
-      int y_start = (int)floor((float)i / oheight * iheight);
-      int y_end   = (int)ceil((float)(i + 1) / oheight * iheight);
-      int kH = y_end-y_start;
+      int istartH = (int)floor((float)oh / osizeH * isizeH);
+      int iendH   = (int)ceil((float)(oh + 1) / osizeH * isizeH);
+      int kH = iendH-istartH;
 
-      for(j = 0; j < owidth; j++)
+      for(ow = 0; ow < osizeW; ow++)
       {
 
-        int x_start = (int)floor((float)j / owidth * iwidth);
-        int x_end   = (int)ceil((float)(j + 1) / owidth * iwidth);
-        int kW = x_end-x_start;
+        int istartW = (int)floor((float)ow / osizeW * isizeW);
+        int iendW   = (int)ceil((float)(ow + 1) / osizeW * isizeW);
+        int kW = iendW-istartW;
 
         /* local pointers */
-        real *ip = input_p   + k*strided + y_start*strideh + x_start*stridew;
-        real *op = output_p  + k*owidth*oheight + i*owidth + j;
-        THIndex_t *indp = ind_p   + k*owidth*oheight + i*owidth + j;
+        real *ip = input_p   + d*istrideD + istartH*istrideH + istartW*istrideW;
+        real *op = output_p  + d*osizeW*osizeH + oh*osizeW + ow;
+        THIndex_t *indp = ind_p   + d*osizeW*osizeH + oh*osizeW + ow;
 
         /* compute local max: */
         int64_t maxindex = -1;
         real maxval = -FLT_MAX;
         int64_t tcntr = 0;
-        int x,y;
-        for(y = 0; y < kH; y++)
+        int iw,ih;
+        for(ih = 0; ih < kH; ih++)
         {
-          for(x = 0; x < kW; x++)
+          for(iw = 0; iw < kW; iw++)
           {
-            real val = *(ip + y*strideh + x*stridew);
+            real val = *(ip + ih*istrideH + iw*istrideW);
             if (val > maxval)
             {
               maxval = val;
-              maxindex = (y+y_start)*iwidth + (x+x_start);
+              maxindex = (ih+istartH)*isizeW + (iw+istartW);
             }
           }
         }
@@ -72,20 +72,20 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
           THTensor *input,
           THTensor *output,
           THIndexTensor *indices,
-          int owidth,
-          int oheight)
+          int osizeW,
+          int osizeH)
 {
-  int dimw = 2;
-  int dimh = 1;
-  int64_t nbatch = 1;
-  int64_t nslices;
-  int64_t iheight;
-  int64_t iwidth;
+  int dimW = 2;
+  int dimH = 1;
+  int64_t sizeB = 1;
+  int64_t sizeD;
+  int64_t isizeH;
+  int64_t isizeW;
 
-  int64_t istride_d;
-  int64_t istride_h;
-  int64_t istride_w;
-  int64_t istride_b;
+  int64_t istrideD;
+  int64_t istrideH;
+  int64_t istrideW;
+  int64_t istrideB;
 
   real *input_data;
   real *output_data;
@@ -97,27 +97,27 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
   if (input->nDimension == 4)
   {
-    istride_b = input->stride[0];
-    nbatch = input->size[0];
-    dimw++;
-    dimh++;
+    istrideB = input->stride[0];
+    sizeB = input->size[0];
+    dimW++;
+    dimH++;
   }
 
   /* sizes */
-  nslices = input->size[dimh-1];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
+  sizeD = input->size[dimH-1];
+  isizeH = input->size[dimH];
+  isizeW = input->size[dimW];
   /* strides */
-  istride_d = input->stride[dimh-1];
-  istride_h = input->stride[dimh];
-  istride_w = input->stride[dimw];
+  istrideD = input->stride[dimH-1];
+  istrideH = input->stride[dimH];
+  istrideW = input->stride[dimW];
 
   /* resize output */
   if (input->nDimension == 3)
   {
-    THTensor_(resize3d)(output, nslices, oheight, owidth);
+    THTensor_(resize3d)(output, sizeD, osizeH, osizeW);
     /* indices will contain i,j locations for each output point */
-    THIndexTensor_(resize3d)(indices, nslices, oheight, owidth);
+    THIndexTensor_(resize3d)(indices, sizeD, osizeH, osizeW);
 
     input_data = THTensor_(data)(input);
     output_data = THTensor_(data)(output);
@@ -125,34 +125,34 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
 
     THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(input_data, output_data,
                                                       indices_data,
-                                                      nslices,
-                                                      iwidth, iheight,
-                                                      owidth, oheight,
-                                                      istride_w,istride_h,
-                                                      istride_d);
+                                                      sizeD,
+                                                      isizeW, isizeH,
+                                                      osizeW, osizeH,
+                                                      istrideW,istrideH,
+                                                      istrideD);
   }
   else
   {
-    int64_t p;
+    int64_t b;
 
-    THTensor_(resize4d)(output, nbatch, nslices, oheight, owidth);
+    THTensor_(resize4d)(output, sizeB, sizeD, osizeH, osizeW);
     /* indices will contain i,j locations for each output point */
-    THIndexTensor_(resize4d)(indices, nbatch, nslices, oheight, owidth);
+    THIndexTensor_(resize4d)(indices, sizeB, sizeD, osizeH, osizeW);
 
     input_data = THTensor_(data)(input);
     output_data = THTensor_(data)(output);
     indices_data = THIndexTensor_(data)(indices);
 
-#pragma omp parallel for private(p)
-    for (p = 0; p < nbatch; p++)
+#pragma omp parallel for private(b)
+    for (b = 0; b < sizeB; b++)
     {
-      THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(input_data+p*istride_b, output_data+p*nslices*owidth*oheight,
-                                                        indices_data+p*nslices*owidth*oheight,
-                                                        nslices,
-                                                        iwidth, iheight,
-                                                        owidth, oheight,
-                                                        istride_w,istride_h,
-                                                        istride_d);
+      THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(input_data+b*istrideB, output_data+b*sizeD*osizeW*osizeH,
+                                                        indices_data+b*sizeD*osizeW*osizeH,
+                                                        sizeD,
+                                                        isizeW, isizeH,
+                                                        osizeW, osizeH,
+                                                        istrideW,istrideH,
+                                                        istrideD);
     }
   }
 }
@@ -161,33 +161,33 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(
           real *gradInput_p,
           real *gradOutput_p,
           THIndex_t *ind_p,
-          int64_t nslices,
-          int64_t iwidth,
-          int64_t iheight,
-          int64_t owidth,
-          int64_t oheight)
+          int64_t sizeD,
+          int64_t isizeW,
+          int64_t isizeH,
+          int64_t osizeW,
+          int64_t osizeH)
 {
-  int64_t k;
-#pragma omp parallel for private(k)
-  for (k = 0; k < nslices; k++)
+  int64_t d;
+#pragma omp parallel for private(d)
+  for (d = 0; d < sizeD; d++)
   {
-    real *gradInput_p_k = gradInput_p + k*iwidth*iheight;
-    real *gradOutput_p_k = gradOutput_p + k*owidth*oheight;
-    THIndex_t *ind_p_k = ind_p + k*owidth*oheight;
+    real *gradInput_p_d = gradInput_p + d*isizeW*isizeH;
+    real *gradOutput_p_d = gradOutput_p + d*osizeW*osizeH;
+    THIndex_t *ind_p_d = ind_p + d*osizeW*osizeH;
 
     /* calculate max points */
-    int64_t i, j;
-    for(i = 0; i < oheight; i++)
+    int64_t oh, ow;
+    for(oh = 0; oh < osizeH; oh++)
     {
-      int y_start = (int)floor((float) i / oheight * iheight);
-      for(j = 0; j < owidth; j++)
+      int istartH = (int)floor((float) oh / osizeH * isizeH);
+      for(ow = 0; ow < osizeW; ow++)
       {
-        int x_start = (int)floor((float) j / owidth * iwidth);
+        int istartW = (int)floor((float) ow / osizeW * isizeW);
         /* retrieve position of max */
-        int64_t maxp = ind_p_k[i*owidth + j] - TH_INDEX_BASE;
+        int64_t maxp = ind_p_d[oh*osizeW + ow] - TH_INDEX_BASE;
 
         /* update gradient */
-        gradInput_p_k[maxp] += gradOutput_p_k[i*owidth + j];
+        gradInput_p_d[maxp] += gradOutput_p_d[oh*osizeW + ow];
       }
     }
   }
@@ -200,14 +200,14 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
           THTensor *gradInput,
           THIndexTensor *indices)
 {
-  int dimw = 2;
-  int dimh = 1;
-  int64_t nbatch = 1;
-  int nslices;
-  int iheight;
-  int iwidth;
-  int oheight;
-  int owidth;
+  int dimW = 2;
+  int dimH = 1;
+  int64_t sizeB = 1;
+  int sizeD;
+  int isizeH;
+  int isizeW;
+  int osizeH;
+  int osizeW;
   real *gradInput_data;
   real *gradOutput_data;
   THIndex_t *indices_data;
@@ -220,17 +220,17 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   THTensor_(zero)(gradInput);
 
   if (input->nDimension == 4) {
-    nbatch = input->size[0];
-    dimw++;
-    dimh++;
+    sizeB = input->size[0];
+    dimW++;
+    dimH++;
   }
 
   /* sizes */
-  nslices = input->size[dimh-1];
-  iheight = input->size[dimh];
-  iwidth = input->size[dimw];
-  oheight = gradOutput->size[dimh];
-  owidth = gradOutput->size[dimw];
+  sizeD = input->size[dimH-1];
+  isizeH = input->size[dimH];
+  isizeW = input->size[dimW];
+  osizeH = gradOutput->size[dimH];
+  osizeW = gradOutput->size[dimW];
 
   /* get raw pointers */
   gradInput_data = THTensor_(data)(gradInput);
@@ -242,21 +242,21 @@ void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
   {
     THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
                                                            indices_data,
-                                                           nslices,
-                                                           iwidth, iheight,
-                                                           owidth, oheight);
+                                                           sizeD,
+                                                           isizeW, isizeH,
+                                                           osizeW, osizeH);
   }
   else
   {
-    int64_t p;
-#pragma omp parallel for private(p)
-    for (p = 0; p < nbatch; p++)
+    int64_t b;
+#pragma omp parallel for private(b)
+    for (b = 0; b < sizeB; b++)
     {
-      THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data+p*nslices*iwidth*iheight, gradOutput_data+p*nslices*owidth*oheight,
-                                                             indices_data+p*nslices*owidth*oheight,
-                                                             nslices,
-                                                             iwidth, iheight,
-                                                             owidth, oheight);
+      THNN_(SpatialAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data+b*sizeD*isizeW*isizeH, gradOutput_data+b*sizeD*osizeW*osizeH,
+                                                             indices_data+b*sizeD*osizeW*osizeH,
+                                                             sizeD,
+                                                             isizeW, isizeH,
+                                                             osizeW, osizeH);
     }
   }
 

--- a/torch/lib/THNN/generic/THNN.h
+++ b/torch/lib/THNN/generic/THNN.h
@@ -924,7 +924,7 @@ TH_API void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
           THTensor *input,
           THTensor *output,
           THIndexTensor *indices,
-          int owidth, int oheight);
+          int osizeW, int osizeH);
 TH_API void THNN_(SpatialAdaptiveMaxPooling_updateGradInput)(
           THNNState *state,
           THTensor *input,

--- a/torch/lib/THNN/generic/THNN.h
+++ b/torch/lib/THNN/generic/THNN.h
@@ -1558,6 +1558,19 @@ TH_API void THNN_(VolumetricAdaptiveAveragePooling_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput);
 
+TH_API void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *output,
+          THIndexTensor *indices,
+          int osizeT, int osizeW, int osizeH);
+TH_API void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *gradOutput,
+          THTensor *gradInput,
+          THIndexTensor *indices);
+
 TH_API void THNN_(SpatialReflectionPadding_updateOutput)(
           THNNState *state,
           THTensor *input,

--- a/torch/lib/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/torch/lib/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -1,0 +1,305 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/VolumetricAdaptiveMaxPooling.c"
+#else
+
+#define START_IND(a,b,c) (int)floor((float)(a * c) / b)
+#define END_IND(a,b,c) (int)ceil((float)((a + 1) * c) / b)
+// #define START_IND(a,b,c) a * c / b
+// #define END_IND(a,b,c)  (a + 1) * c / b + ((a + 1) * c % b > 0)?1:0
+
+// 5d tensor B x D x T x H x W
+
+static void THNN_(VolumetricAdaptiveMaxPooling_updateOutput_frame)(
+          real *input_p,
+          real *output_p,
+          THIndex_t *ind_p,
+          int64_t sizeD,
+          int64_t isizeT,
+          int64_t isizeH,
+          int64_t isizeW,
+          int64_t osizeT,
+          int64_t osizeH,
+          int64_t osizeW,
+          int64_t istrideD,
+          int64_t istrideT,
+          int64_t istrideH,
+          int64_t istrideW)
+{
+  int64_t d;
+#pragma omp parallel for private(d)
+  for (d = 0; d < sizeD; d++)
+  {
+    /* loop over output */
+    int64_t ot, oh, ow;
+    for(ot = 0; ot < osizeT; ot++)
+    {
+      int64_t istartT = START_IND(ot, osizeT, isizeT);
+      int64_t iendT   = END_IND(ot, osizeT, isizeT);
+      int64_t kT = iendT - istartT;
+
+      for(oh = 0; oh < osizeH; oh++)
+      {
+        int64_t istartH = START_IND(oh, osizeH, isizeH);
+        int64_t iendH   = END_IND(oh, osizeH, isizeH);
+        int64_t kH = iendH - istartH;
+
+        for(ow = 0; ow < osizeW; ow++)
+        {
+
+          int64_t istartW = START_IND(ow, osizeW, isizeW);
+          int64_t iendW   = END_IND(ow, osizeW, isizeW);
+          int64_t kW = iendW - istartW;
+
+          /* local pointers */
+          real *ip = input_p   + d*istrideD + istartT *istrideT + istartH*istrideH + istartW*istrideW;
+          real *op = output_p  + d*osizeT*osizeH*osizeW + ot*osizeH*osizeW + oh*osizeW + ow;
+          THIndex_t *indp = ind_p   + d*osizeT*osizeH*osizeW + ot*osizeH*osizeW + oh*osizeW + ow;
+
+          /* compute local max: */
+          int64_t maxindex = -1;
+          real maxval = -FLT_MAX;
+          int64_t it, ih, iw;
+          for(it = 0; it < kT; it++)
+          {
+            for(ih = 0; ih < kH; ih++)
+            {
+              for(iw = 0; iw < kW; iw++)
+              {
+                real val = *(ip + it*istrideT + ih*istrideH + iw*istrideW);
+                if (val > maxval)
+                {
+                  maxval = val;
+                  maxindex = (it+istartT)*isizeH*isizeW + (ih+istartH)*isizeW + (iw+istartW);
+                }
+              }
+            }
+          }
+
+          /* set output to local max */
+          *op = maxval;
+
+          /* store location of max */
+          *indp = maxindex + TH_INDEX_BASE;
+        }
+      }
+    }
+  }
+}
+
+void THNN_(VolumetricAdaptiveMaxPooling_updateOutput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *output,
+          THIndexTensor *indices,
+          int osizeT,
+          int osizeW,
+          int osizeH)
+{
+  int dimD = 0;
+  int dimT = 1;
+  int dimH = 2;
+  int dimW = 3;
+  int64_t sizeB = 1;
+  int64_t sizeD;
+  int64_t isizeT;
+  int64_t isizeH;
+  int64_t isizeW;
+
+  int64_t istrideB;
+  int64_t istrideD;
+  int64_t istrideT;
+  int64_t istrideH;
+  int64_t istrideW;
+
+  real *input_data;
+  real *output_data;
+  THIndex_t *indices_data;
+
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+    "4D or 5D (batch mode) tensor expected for input, but got: %s");
+
+  if (input->nDimension == 5)
+  {
+    istrideB = input->stride[0];
+    sizeB = input->size[0];
+    dimD++;
+    dimT++;
+    dimH++;
+    dimW++;
+  }
+
+  /* sizes */
+  sizeD  = input->size[dimD];
+  isizeT = input->size[dimT];
+  isizeH = input->size[dimH];
+  isizeW = input->size[dimW];
+  /* strides */
+  istrideD = input->stride[dimD];
+  istrideT = input->stride[dimT];
+  istrideH = input->stride[dimH];
+  istrideW = input->stride[dimW];
+
+  /* resize output */
+  if (input->nDimension == 4)
+  {
+    THTensor_(resize4d)(output, sizeD, osizeT, osizeH, osizeW);
+    /* indices will contain max input locations for each output point */
+    THIndexTensor_(resize4d)(indices, sizeD, osizeT, osizeH, osizeW);
+
+    input_data = THTensor_(data)(input);
+    output_data = THTensor_(data)(output);
+    indices_data = THIndexTensor_(data)(indices);
+
+    THNN_(VolumetricAdaptiveMaxPooling_updateOutput_frame)(input_data, output_data,
+                                                      indices_data,
+                                                      sizeD,
+                                                      isizeT, isizeH, isizeW,
+                                                      osizeT, osizeH, osizeW,
+                                                      istrideD, istrideT,
+                                                      istrideH, istrideW);
+  }
+  else
+  {
+    int64_t b;
+
+    THTensor_(resize5d)(output, sizeB, sizeD, osizeT, osizeH, osizeW);
+    /* indices will contain max input locations for each output point */
+    THIndexTensor_(resize5d)(indices, sizeB, sizeD, osizeT, osizeH, osizeW);
+
+    input_data = THTensor_(data)(input);
+    output_data = THTensor_(data)(output);
+    indices_data = THIndexTensor_(data)(indices);
+
+#pragma omp parallel for private(b)
+    for (b = 0; b < sizeB; b++)
+    {
+      THNN_(VolumetricAdaptiveMaxPooling_updateOutput_frame)(input_data+b*istrideB, output_data+b*sizeD*osizeT*osizeH*osizeW,
+                                                        indices_data+b*sizeD*osizeT*osizeH*osizeW,
+                                                        sizeD,
+                                                        isizeT, isizeH, isizeW,
+                                                        osizeT, osizeH, osizeW,
+                                                        istrideD, istrideT,
+                                                        istrideH, istrideW);
+    }
+  }
+}
+
+static void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput_frame)(
+          real *gradInput_p,
+          real *gradOutput_p,
+          THIndex_t *ind_p,
+          int64_t sizeD,
+          int64_t isizeT,
+          int64_t isizeH,
+          int64_t isizeW,
+          int64_t osizeT,
+          int64_t osizeH,
+          int64_t osizeW)
+{
+  int64_t d;
+#pragma omp parallel for private(d)
+  for (d = 0; d < sizeD; d++)
+  {
+    real *gradInput_p_d = gradInput_p + d*isizeT*isizeH*isizeW;
+    real *gradOutput_p_d = gradOutput_p + d*osizeT*osizeH*osizeW;
+    THIndex_t *ind_p_d = ind_p + d*osizeT*osizeH*osizeW;
+
+    /* calculate max points */
+    int64_t ot, oh, ow;
+    for(ot = 0; ot < osizeT; ot++)
+    {
+      for(oh = 0; oh < osizeH; oh++)
+      {
+        for(ow = 0; ow < osizeW; ow++)
+        {
+          /* retrieve position of max */
+          int64_t maxp = ind_p_d[ot*osizeH*osizeW + oh*osizeW + ow] - TH_INDEX_BASE;
+
+          /* update gradient */
+          gradInput_p_d[maxp] += gradOutput_p_d[ot*osizeH*osizeW + oh*osizeW + ow];
+        }
+      }
+    }
+  }
+}
+
+void THNN_(VolumetricAdaptiveMaxPooling_updateGradInput)(
+          THNNState *state,
+          THTensor *input,
+          THTensor *gradOutput,
+          THTensor *gradInput,
+          THIndexTensor *indices)
+{
+  int dimD = 0;
+  int dimT = 1;
+  int dimH = 2;
+  int dimW = 3;
+  int64_t sizeB = 1;
+  int64_t sizeD;
+  int64_t isizeT;
+  int64_t isizeH;
+  int64_t isizeW;
+  int64_t osizeT;
+  int64_t osizeH;
+  int64_t osizeW;
+  real *gradInput_data;
+  real *gradOutput_data;
+  THIndex_t *indices_data;
+
+  /* get contiguous gradOutput */
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+
+  /* resize */
+  THTensor_(resizeAs)(gradInput, input);
+  THTensor_(zero)(gradInput);
+
+  if (input->nDimension == 5) {
+    sizeB = input->size[0];
+    dimD++;
+    dimT++;
+    dimH++;
+    dimW++;
+  }
+
+  /* sizes */
+  sizeD  = input->size[dimD];
+  isizeT = input->size[dimT];
+  isizeH = input->size[dimH];
+  isizeW = input->size[dimW];
+  osizeT = gradOutput->size[dimT];
+  osizeH = gradOutput->size[dimH];
+  osizeW = gradOutput->size[dimW];
+
+  /* get raw pointers */
+  gradInput_data = THTensor_(data)(gradInput);
+  gradOutput_data = THTensor_(data)(gradOutput);
+  indices_data = THIndexTensor_(data)(indices);
+
+  /* backprop */
+  if (input->nDimension == 4)
+  {
+    THNN_(VolumetricAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
+                                                         indices_data,
+                                                         sizeD,
+                                                         isizeT, isizeH, isizeW,
+                                                         osizeT, osizeH, osizeW);
+  }
+  else
+  {
+    int64_t b;
+#pragma omp parallel for private(b)
+    for (b = 0; b < sizeB; b++)
+    {
+      THNN_(VolumetricAdaptiveMaxPooling_updateGradInput_frame)(gradInput_data+b*sizeD*isizeT*isizeH*isizeW, gradOutput_data+b*sizeD*osizeT*osizeH*osizeW,
+                                                           indices_data+b*sizeD*osizeT*osizeH*osizeW,
+                                                           sizeD,
+                                                           isizeT, isizeH, isizeW,
+                                                           osizeT, osizeH, osizeW);
+    }
+  }
+
+  /* cleanup */
+  THTensor_(free)(gradOutput);
+}
+
+#endif

--- a/torch/lib/THNN/init.c
+++ b/torch/lib/THNN/init.c
@@ -269,6 +269,9 @@
 #include "generic/VolumetricDilatedConvolution.c"
 #include "THGenerateFloatTypes.h"
 
+#include "generic/VolumetricAdaptiveMaxPooling.c"
+#include "THGenerateFloatTypes.h"
+
 #include "generic/VolumetricAdaptiveAveragePooling.c"
 #include "THGenerateFloatTypes.h"
 

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -276,6 +276,7 @@ def _generate_function_classes(scope_dict):
         'VolumetricMaxPooling',
         'VolumetricMaxUnpooling',
         'VolumetricAdaptiveAveragePooling',
+        'VolumetricAdaptiveMaxPooling',
         'VolumetricConvolution',
         'VolumetricFullConvolution',
         'VolumetricConvolutionMM',

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -412,6 +412,21 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
     return ret if return_indices else ret[0]
 
 
+def adaptive_max_pool3d(input, output_size, return_indices=False):
+    r"""Applies a 3D adaptive max pooling over an input signal composed of
+    several input planes.
+
+    See :class:`~torch.nn.AdaptiveMaxPool3d` for details and output shape.
+
+    Args:
+        output_size: the target output size (single integer or
+            triple-integer tuple)
+        return_indices: whether to return pooling indices. Default: False
+    """
+    ret = _functions.thnn.AdaptiveMaxPool3d.apply(input, output_size)
+    return ret if return_indices else ret[0]
+
+
 def adaptive_avg_pool1d(input, output_size):
     r"""Applies a 1D adaptive average pooling over an input signal composed of
     several input planes.

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -12,7 +12,7 @@ from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLos
 from .container import Container, Sequential, ModuleList, ParameterList
 from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxPool3d, \
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, LPPool1d, LPPool2d, AdaptiveMaxPool1d, \
-    AdaptiveMaxPool2d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
+    AdaptiveMaxPool2d, AdaptiveMaxPool3d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
@@ -43,7 +43,7 @@ __all__ = [
     'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
-    'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d', 'AdaptiveAvgPool3d',
-    'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d', 'ConstantPad3d',
-    'Bilinear', 'CosineSimilarity',
+    'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
+    'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
+    'ConstantPad3d', 'Bilinear', 'CosineSimilarity',
 ]

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -879,6 +879,7 @@ class AdaptiveMaxPool2d(Module):
         >>> # target output size of 5x7
         >>> m = nn.AdaptiveMaxPool2d((5,7))
         >>> input = autograd.Variable(torch.randn(1, 64, 8, 9))
+        >>> output = m(input)
         >>> # target output size of 7x7 (square)
         >>> m = nn.AdaptiveMaxPool2d(7)
         >>> input = autograd.Variable(torch.randn(1, 64, 10, 9))
@@ -893,6 +894,43 @@ class AdaptiveMaxPool2d(Module):
 
     def forward(self, input):
         return F.adaptive_max_pool2d(input, self.output_size, self.return_indices)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' (' \
+            + 'output_size=' + str(self.output_size) + ')'
+
+
+class AdaptiveMaxPool3d(Module):
+    """Applies a 3D adaptive max pooling over an input signal composed of several input planes.
+
+    The output is of size D x H x W, for any input size.
+    The number of output features is equal to the number of input planes.
+
+    Args:
+        output_size: the target output size of the image of the form D x H x W.
+                     Can be a tuple (D, H, W) or a single number D for a cube D x D x D
+        return_indices: if True, will return the indices along with the outputs.
+                        Useful to pass to nn.MaxUnpool3d. Default: False
+
+    Examples:
+        >>> # target output size of 5x7x9
+        >>> m = nn.AdaptiveMaxPool3d((5,7,9))
+        >>> input = autograd.Variable(torch.randn(1, 64, 8, 9, 10))
+        >>> output = m(input)
+        >>> # target output size of 7x7x7 (cube)
+        >>> m = nn.AdaptiveMaxPool3d(7)
+        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9, 8))
+        >>> output = m(input)
+
+    """
+
+    def __init__(self, output_size, return_indices=False):
+        super(AdaptiveMaxPool3d, self).__init__()
+        self.output_size = output_size
+        self.return_indices = return_indices
+
+    def forward(self, input):
+        return F.adaptive_max_pool3d(input, self.output_size, self.return_indices)
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \


### PR DESCRIPTION
Adding AdaptiveMaxPool3d as per request in #1988 .

Commit structure:
1. renamed spatial version variable names for same reason as in #2728 
2. reordered spatial version variables to be of order B(batch) D(feature) H(height) W(width)
3. refactored spatial version code by using START_IND and END_IND macros, removed some unnecessary computation.
4. changed spatial version CUDA kernel to have input strides of type `int64_t`, removed an unused input in spatial CUDA kernels, and fixed a typo in `AdaptiveMaxPool1d` doc.
5. fixed `TestNN._test_maxpool_indices` for adaptive max pooling layers.
6. volumetric adaptive max pooling, including CPU, CUDA, Python, tests.

Test plan:
./run_test.sh