### PR TITLE
Add add_scaled and sub_scaled to TH and THC

### DIFF
--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -642,6 +642,16 @@ void THTensor_(sub)(THTensor *r_, THTensor *t, real value)
   THTensor_(add)(r_, t, -value);
 }
 
+void THTensor_(add_scaled)(THTensor *r_, THTensor *t, real value, real alpha)
+{
+  THTensor_(add)(r_, t, value * alpha);
+}
+
+void THTensor_(sub_scaled)(THTensor *r_, THTensor *t, real value, real alpha)
+{
+  THTensor_(add)(r_, t, -value * alpha);
+}
+
 void THTensor_(mul)(THTensor *r_, THTensor *t, real value)
 {
   THTensor_(resizeAs)(r_, t);
@@ -888,7 +898,7 @@ void THTensor_(cadd)(THTensor *r_, THTensor *t, real value, THTensor *src)
   }
 }
 
-void THTensor_(csub)(THTensor *r_, THTensor *t, real value,THTensor *src)
+void THTensor_(csub)(THTensor *r_, THTensor *t, real value, THTensor *src)
 {
   THTensor_(cadd)(r_, t, -value, src);
 }

--- a/torch/lib/TH/generic/THTensorMath.h
+++ b/torch/lib/TH/generic/THTensorMath.h
@@ -33,7 +33,9 @@ TH_API void THTensor_(neg)(THTensor *self, THTensor *src);
 TH_API void THTensor_(cinv)(THTensor *self, THTensor *src);
 
 TH_API void THTensor_(add)(THTensor *r_, THTensor *t, real value);
-TH_API void THTensor_(sub)(THTensor *self, THTensor *src, real value);
+TH_API void THTensor_(sub)(THTensor *r_, THTensor *t, real value);
+TH_API void THTensor_(add_scaled)(THTensor *r_, THTensor *t, real value, real alpha);
+TH_API void THTensor_(sub_scaled)(THTensor *r_, THTensor *t, real value, real alpha);
 TH_API void THTensor_(mul)(THTensor *r_, THTensor *t, real value);
 TH_API void THTensor_(div)(THTensor *r_, THTensor *t, real value);
 TH_API void THTensor_(lshift)(THTensor *r_, THTensor *t, real value);

--- a/torch/lib/THC/generic/THCTensorMathPairwise.cu
+++ b/torch/lib/THC/generic/THCTensorMathPairwise.cu
@@ -41,6 +41,28 @@ THCTensor_(sub)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 }
 
 THC_API void
+THCTensor_(add_scaled)(THCState *state, THCTensor *self_, THCTensor *src_, real value, real alpha)
+{
+#ifdef THC_REAL_IS_HALF
+  auto v = THC_half2float(value) * THC_half2float(alpha);
+  THCTensor_(add)(state, self_, src_, THC_float2half(v));
+#else
+  THCTensor_(add)(state, self_, src_, value * alpha);
+#endif
+}
+
+THC_API void
+THCTensor_(sub_scaled)(THCState *state, THCTensor *self_, THCTensor *src_, real value, real alpha)
+{
+#ifdef THC_REAL_IS_HALF
+  auto v = THC_half2float(value) * THC_half2float(alpha);
+  THCTensor_(sub)(state, self_, src_, THC_float2half(v));
+#else
+  THCTensor_(sub)(state, self_, src_, value * alpha);
+#endif
+}
+
+THC_API void
 THCTensor_(mul)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));

--- a/torch/lib/THC/generic/THCTensorMathPairwise.h
+++ b/torch/lib/THC/generic/THCTensorMathPairwise.h
@@ -4,6 +4,8 @@
 
 THC_API void THCTensor_(add)(THCState *state, THCTensor *self, THCTensor *src, real value);
 THC_API void THCTensor_(sub)(THCState *state, THCTensor *self, THCTensor *src, real value);
+THC_API void THCTensor_(add_scaled)(THCState *state, THCTensor *self, THCTensor *src, real value, real alpha);
+THC_API void THCTensor_(sub_scaled)(THCState *state, THCTensor *self, THCTensor *src, real value, real alpha);
 THC_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, real value);
 THC_API void THCTensor_(div)(THCState *state, THCTensor *self, THCTensor *src, real value);
 THC_API void THCTensor_(lshift)(THCState *state, THCTensor *self, THCTensor *src, real value);


### PR DESCRIPTION
These functions accept a scaling parameter like THTensor_(cadd)/(csub),
which will make it easier to have the same signature for tensor and
scalar addition in PyTorch and ATen. For example:

  tensor.add(other, alpha=2)

Will work if other is a scalar or a tensor value.

See #2739 