### PR TITLE
address issue #1488 by using defaultdict in load_state_dict

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -96,7 +96,8 @@ class Optimizer(object):
         id_map = {old_id: p for old_id, p in
                   zip(chain(*(g['params'] for g in saved_groups)),
                       chain(*(g['params'] for g in groups)))}
-        state = {id_map.get(k, k): v for k, v in state_dict['state'].items()}
+        state = defaultdict(
+            dict, {id_map.get(k, k): v for k, v in state_dict['state'].items()})
 
         # Update parameter groups, setting their 'params' value
         def update_group(group, new_group):


### PR DESCRIPTION
Try PR another time. Based on Adam's feedback, when restoring state in the function "load_state_dict" of class "optimizer.py", use defaultdict to maintain consistency with self.state. 

**Test Procedure**
(1) Use the following test case to verify the restored state is indeed a defaultdict.
(2) Run test_optim.py to make sure no other impact.

----------------------------- Test Case -------------------------------------------------
```python
import torch
from torch.optim import SGD
from torch.autograd import Variable

# initialize model
N, D_in, H, D_out = 64, 1000, 100, 10
x = Variable(torch.randn(N, D_in))
y = Variable(torch.randn(N, D_out), requires_grad=False)
model = torch.nn.Sequential(
          torch.nn.Linear(D_in, H),
          torch.nn.ReLU(),
          torch.nn.Linear(H, D_out),
        )

# initialize optimizer
optimizer = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)

# state should be defaultdict
original_type = type(optimizer.state)
print(original_type)

# after saving and loading, the restored state should also be a defaultdict
torch.save(optimizer.state_dict(), 'optim.pth') 
optimizer.load_state_dict(torch.load('optim.pth')) 
restored_type = type(optimizer.state)
print(restored_type)

assert(original_type==restored_type)
```