### PR TITLE
Parallelize CUDA LookupTable_renorm

### DIFF
--- a/torch/lib/THCUNN/generic/LookupTable.cu
+++ b/torch/lib/THCUNN/generic/LookupTable.cu
@@ -145,6 +145,7 @@ void THNN_(LookupTable_accGradParameters)(
   THCudaCheck(cudaGetLastError());
 }
 
+#include <cuda_profiler_api.h>
 void THNN_(LookupTable_renorm)(
            THCState *state,
            THCIndexTensor *idx,
@@ -190,10 +191,12 @@ void THNN_(LookupTable_renorm)(
   threads_per_block |= threads_per_block >> 32;
   threads_per_block++;
 
+  cudaProfilerStart();
   calculate_norms_and_renorm<real, accreal>
-    <<<num_blocks, threads_per_block, threads_per_block * sizeof(accreal)>>>
+    <<<num_blocks, threads_per_block/2, threads_per_block * sizeof(accreal)>>>
     (weight_ptr_raw, idx_ptr_raw, normType, maxNorm, normType_, stride);
-
+  cudaDeviceSynchronize();
+  cudaProfilerStop();
 }
 
 #endif


### PR DESCRIPTION
Investigating https://github.com/pytorch/pytorch/issues/1278 I found that while the CUDA algorithm for the renorming was using parallel algorithms to calculate norms and the renormalize, each slice was being processed sequentially. This PR attempts to fix that by nesting the original renorming logic in a thrust functor that can be applied over the embedding weights in parallel. 

My profiling using nvprof shows approximately a 33x speedup using embedding dimensions of 100k x 128 and a batch size of 1024 (~20ms vs 600us). I don't have a lot of experience with GPU programming so here's hoping I've interpreted the profiling results correctly!

Original benchmark - you can see we are launching kernels and calling cudaMalloc, memcpy, and other API calls (some even twice) for every idx in the batch:
```
 pow_v<real, accreal> unary_pow(normType);
  thrust::plus<accreal> binary_plus;
  // numel << stride, since idx usually contains sparse row indices
  cudaProfilerStart();
  for (THCIndex_t i = 0; i < numel; i++)
  {
    THCIndex_t k = idx_ptr[i] - TH_INDEX_BASE;
    thrust::device_ptr<real> row_ptr = weight_ptr + k * stride;
    accreal norm = thrust::transform_reduce(row_ptr, row_ptr + stride,
      unary_pow, (accreal)0, binary_plus);
    norm = std::pow(norm, (accreal) (1.0 / normType));
    if (norm > ScalarConvert<real, accreal>::to(maxNorm))
    {
      multiply_s<real> unary_mul(ScalarConvert<accreal, real>::to(maxNorm / (norm + 1e-7)));
      thrust::transform(row_ptr, row_ptr + stride, row_ptr, unary_mul);
    }
  }
  cudaDeviceSynchronize();
  cudaProfilerStop();

**** Test results ****

$ nvprof --profile-from-start off test/test0.py

  3 ==188596== Profiling result:
  4 Time(%)      Time     Calls       Avg       Min       Max  Name
  5  52.71%  11.001ms      1024  10.742us  10.496us  13.120us  _ZN6thrust6system4cuda6detail5bulk_6detail15launch_by_valueILj128ENS4_9cuda_taskINS3_14parallel_groupINS3_16concurrent_groupINS3_5agentILm7EEELm128EEELm0EEENS4_7closureINS2_13reduce_detail17reduce_partitionsENS_5tuple    INS4_6cursorILj1EEENS_18transform_iteratorI5pow_vIffENS_10device_ptrIfEEfNS_11use_defaultEEENS2_21aligned_decompositionIlEENS_6detail15normal_iteratorINS_7pointerIfNS2_3tagESO_SO_EEEEfNS_4plusIfEENS_9null_typeES10_S10_S10_EEEEEEEEvT0_
  6  31.65%  6.6055ms      2048  3.2250us  2.7200us  16.352us  [CUDA memcpy DtoH]
  7  15.64%  3.2644ms      1024  3.1870us  3.1360us  3.3600us  void thrust::system::cuda::detail::bulk_::detail::launch_by_value<unsigned int=0, thrust::system::cuda::detail::bulk_::detail::cuda_task<thrust::system::cuda::detail::bulk_::parallel_group<thrust::system::cuda::detail    ::bulk_::concurrent_group<thrust::system::cuda::detail::bulk_::agent<unsigned long=1>, unsigned long=0>, unsigned long=0>, thrust::system::cuda::detail::bulk_::detail::closure<thrust::system::cuda::detail::for_each_n_detail::for_each_kernel, thrust::tuple<thrust::system::cuda    ::detail::bulk_::detail::cursor<unsigned int=0>, thrust::zip_iterator<thrust::tuple<thrust::device_ptr<float>, thrust::device_ptr<float>, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrus    t::null_type>>, thrust::detail::wrapped_function<thrust::detail::unary_transform_functor<multiply_s<float>>, void>, unsigned int, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type>>>>(unsigned long=1)
  8
  9 ==188596== API calls:
 10 Time(%)      Time     Calls       Avg       Min       Max  Name
 11  54.54%  1.32840s      2048  648.63us  13.739us  1.29628s  cudaLaunch
 12  28.54%  695.05ms      1024  678.76us  505.18us  22.304ms  cudaMalloc
 13  12.88%  313.75ms      1024  306.39us  176.28us  23.175ms  cudaFree
 14   1.86%  45.341ms      2048  22.139us  18.996us  317.06us  cudaMemcpyAsync
 15   0.73%  17.893ms      1024  17.473us  4.0190us  48.252us  cudaEventSynchronize
 16   0.60%  14.723ms      6144  2.3960us  1.8940us  16.599us  cudaFuncGetAttributes
 17   0.28%  6.7438ms      2048  3.2920us  2.8040us  16.990us  cudaStreamSynchronize
 18   0.14%  3.4725ms      6144     565ns     287ns  14.442us  cudaGetDevice
 19   0.14%  3.3119ms      2048  1.6170us  1.2890us  25.005us  cudaEventCreateWithFlags
 20   0.10%  2.4582ms      2048  1.2000us  1.0140us  15.245us  cudaEventRecord
 21   0.09%  2.2588ms      2048  1.1020us     759ns  296.39us  cudaEventDestroy
 22   0.05%  1.2316ms      2048     601ns     353ns  385.44us  cudaConfigureCall
 23   0.03%  811.96us      2048     396ns     331ns  12.707us  cudaSetupArgument
 24   0.00%  12.811us         1  12.811us  12.811us  12.811us  cudaDeviceSynchronize
```

Newly parallelized version only calls cudaLaunch a single time :

```
180   cudaProfilerStart();
181   pow_v<real, accreal> unary_pow(normType);
182   thrust::plus<accreal> binary_plus;
183
184   thrust::for_each(idx_ptr, end_ptr,
185       renorm_functor<real, accreal>(weight_ptr, stride, maxNorm, normType, binary_plus, unary_pow));
186
187   cudaDeviceSynchronize();
188   cudaProfilerStop();

**** Test results ****

$ nvprof --profile-from-start off test/test0.py

   1 ==244630== NVPROF is profiling process 244630, command: python test/test0.py
  2 ==244630== Profiling application: python test/test0.py
  3 ==244630== Profiling result:
  4 Time(%)      Time     Calls       Avg       Min       Max  Name
  5 100.00%  602.12us         1  602.12us  602.12us  602.12us  void thrust::system::cuda::detail::bulk_::detail::launch_by_value<unsigned int=0, thrust::system::cuda::detail::bulk_::detail::cuda_task<thrust::system::cuda::detail::bulk_::parallel_group<thrust::system::cuda::detail    ::bulk_::concurrent_group<thrust::system::cuda::detail::bulk_::agent<unsigned long=1>, unsigned long=0>, unsigned long=0>, thrust::system::cuda::detail::bulk_::detail::closure<thrust::system::cuda::detail::for_each_n_detail::for_each_kernel, thrust::tuple<thrust::system::cuda    ::detail::bulk_::detail::cursor<unsigned int=0>, thrust::device_ptr<long>, thrust::detail::wrapped_function<renorm_functor<float, float>, void>, unsigned int, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type>>>>(    unsigned long=1)
  6
  7 ==244630== API calls:
  8 Time(%)      Time     Calls       Avg       Min       Max  Name
  9  99.95%  1.32124s         1  1.32124s  1.32124s  1.32124s  cudaLaunch
 10   0.04%  576.35us         1  576.35us  576.35us  576.35us  cudaDeviceSynchronize
 11   0.00%  17.015us         4  4.2530us  3.4190us  5.7650us  cudaFuncGetAttributes
 12   0.00%  9.6330us         1  9.6330us  9.6330us  9.6330us  cudaEventCreateWithFlags
 13   0.00%  4.2920us         3  1.4300us     526ns  3.2190us  cudaGetDevice
 14   0.00%  3.4740us         1  3.4740us  3.4740us  3.4740us  cudaEventRecord
 15   0.00%  2.0270us         1  2.0270us  2.0270us  2.0270us  cudaEventDestroy
 16   0.00%     541ns         1     541ns     541ns     541ns  cudaConfigureCall
 17   0.00%     420ns         1     420ns     420ns     420ns  cudaSetupArgument
```

Simple test harness:
```
  2 import torch
  3
  4 size = 128
  5 num_relations = 100000
  6
  7 embeds = torch.nn.Embedding(num_relations, size, max_norm=0.5).cuda()
  8 input = torch.autograd.Variable(torch.randperm(1024).cuda())
  9 embeds(input)
```