### PR TITLE
Lazier CUDA initialization

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -129,7 +129,7 @@ def manual_seed(seed):
     Args:
         seed (int or long): The desired seed.
     """
-    if torch.cuda.is_available() and not torch.cuda._in_bad_fork:
+    if not torch.cuda._in_bad_fork:
         torch.cuda.manual_seed_all(seed)
 
     return default_generator.manual_seed(seed)

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -19,6 +19,11 @@
 # SOFTWARE.
 
 import itertools
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
 
 def with_metaclass(meta, *bases):
@@ -40,3 +45,41 @@ if hasattr(itertools, 'imap'):
     imap = itertools.imap
 else:
     imap = map
+
+
+if PY3:
+    import builtins
+    exec_ = getattr(builtins, "exec")
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -25,6 +25,8 @@ def set_rng_state(new_state):
 
 def manual_seed(seed):
     r"""Sets the seed for generating random numbers for the current GPU.
+    It's safe to call this function if CUDA is not available; in that
+    case, it is silently ignored.
 
     Args:
         seed (int or long): The desired seed.
@@ -38,6 +40,8 @@ def manual_seed(seed):
 
 def manual_seed_all(seed):
     r"""Sets the seed for generating random numbers on all GPUs.
+    It's safe to call this function if CUDA is not available; in that
+    case, it is silently ignored.
 
     Args:
         seed (int or long): The desired seed.
@@ -47,6 +51,8 @@ def manual_seed_all(seed):
 
 def seed():
     r"""Sets the seed for generating random numbers to a random number for the current GPU.
+    It's safe to call this function if CUDA is not available; in that
+    case, it is silently ignored.
 
     .. warning::
         If you are working with a multi-GPU model, this function will only initialize
@@ -56,7 +62,10 @@ def seed():
 
 
 def seed_all():
-    r"""Sets the seed for generating random numbers to a random number on all GPUs."""
+    r"""Sets the seed for generating random numbers to a random number on all GPUs.
+    It's safe to call this function if CUDA is not available; in that
+    case, it is silently ignored.
+    """
     _lazy_call(lambda: _C._cuda_seedAll())
 
 

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -3,13 +3,15 @@ from . import _lazy_init
 
 
 def get_rng_state():
-    r"""Returns the random number generator state as a ByteTensor."""
+    r"""Returns the random number generator state of the current
+    GPU as a ByteTensor.
+    """
     _lazy_init()
     return _C._cuda_getRNGState()
 
 
 def set_rng_state(new_state):
-    r"""Sets the random number generator state.
+    r"""Sets the random number generator state of the current GPU.
 
     Args:
         new_state (torch.ByteTensor): The desired state
@@ -19,10 +21,14 @@ def set_rng_state(new_state):
 
 
 def manual_seed(seed):
-    r"""Sets the seed for generating random numbers.
+    r"""Sets the seed for generating random numbers for the current GPU.
 
     Args:
         seed (int or long): The desired seed.
+
+    .. warning::
+        If you are working with a multi-GPU model, this function is insufficient
+        to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
     """
     _lazy_init()
     return _C._cuda_manualSeed(seed)
@@ -39,7 +45,12 @@ def manual_seed_all(seed):
 
 
 def seed():
-    r"""Sets the seed for generating random numbers to a random number."""
+    r"""Sets the seed for generating random numbers to a random number for the current GPU.
+
+    .. warning::
+        If you are working with a multi-GPU model, this function will only initialize
+        the seed on one GPU.  To initialize all GPUs, use :func:`seed_all`.
+    """
     _lazy_init()
     return _C._cuda_seed()
 
@@ -51,6 +62,6 @@ def seed_all():
 
 
 def initial_seed():
-    r"""Returns the current random seed"""
+    r"""Returns the current random seed of the current GPU."""
     _lazy_init()
     return _C._cuda_initialSeed()

--- a/torch/cuda/random.py
+++ b/torch/cuda/random.py
@@ -1,10 +1,13 @@
 from torch import _C
-from . import _lazy_init
+from . import _lazy_init, _lazy_call
 
 
 def get_rng_state():
     r"""Returns the random number generator state of the current
     GPU as a ByteTensor.
+
+    .. warning::
+        This function eagerly initializes CUDA.
     """
     _lazy_init()
     return _C._cuda_getRNGState()
@@ -16,8 +19,8 @@ def set_rng_state(new_state):
     Args:
         new_state (torch.ByteTensor): The desired state
     """
-    _lazy_init()
-    return _C._cuda_setRNGState(new_state)
+    new_state_copy = new_state.clone()
+    _lazy_call(lambda: _C._cuda_setRNGState(new_state_copy))
 
 
 def manual_seed(seed):
@@ -30,8 +33,7 @@ def manual_seed(seed):
         If you are working with a multi-GPU model, this function is insufficient
         to get determinism.  To seed all GPUs, use :func:`manual_seed_all`.
     """
-    _lazy_init()
-    return _C._cuda_manualSeed(seed)
+    _lazy_call(lambda: _C._cuda_manualSeed(seed))
 
 
 def manual_seed_all(seed):
@@ -40,8 +42,7 @@ def manual_seed_all(seed):
     Args:
         seed (int or long): The desired seed.
     """
-    _lazy_init()
-    return _C._cuda_manualSeedAll(seed)
+    _lazy_call(lambda: _C._cuda_manualSeedAll(seed))
 
 
 def seed():
@@ -51,17 +52,19 @@ def seed():
         If you are working with a multi-GPU model, this function will only initialize
         the seed on one GPU.  To initialize all GPUs, use :func:`seed_all`.
     """
-    _lazy_init()
-    return _C._cuda_seed()
+    _lazy_call(lambda: _C._cuda_seed())
 
 
 def seed_all():
     r"""Sets the seed for generating random numbers to a random number on all GPUs."""
-    _lazy_init()
-    return _C._cuda_seedAll()
+    _lazy_call(lambda: _C._cuda_seedAll())
 
 
 def initial_seed():
-    r"""Returns the current random seed of the current GPU."""
+    r"""Returns the current random seed of the current GPU.
+
+    .. warning::
+        This function eagerly initializes CUDA.
+    """
     _lazy_init()
     return _C._cuda_initialSeed()


### PR DESCRIPTION
Make CUDA seeding/RNG state functions even lazier

Instead of initializing CUDA immediately and executing them,
we wait until we actually initialize CUDA before executing.
    
Fixes #2517
