### PR TITLE
Support "expanding" an empty tensor to an empty tensor.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3500,6 +3500,9 @@ class TestTorch(TestCase):
         self.assertEqual(tensor.expand(4, -1, 5), tensor.expand(4, 8, 5))
         self.assertRaises(RuntimeError, lambda: tensor2.expand(-1, -1))
 
+        # test expanding empty to empty
+        self.assertEqual(torch.randn(()).expand(()), torch.randn(()))
+
     def test_repeat(self):
         result = torch.Tensor()
         tensor = torch.rand(8, 4)

--- a/torch/lib/TH/generic/THTensor.c
+++ b/torch/lib/TH/generic/THTensor.c
@@ -292,7 +292,8 @@ THTensor* THTensor_(newExpand)(THTensor *tensor, THLongStorage *sizes) {
 }
 
 void THTensor_(expand)(THTensor *r, THTensor *tensor, THLongStorage *sizes) {
-  THArgCheck(THTensor_(nDimension)(tensor) > 0, 0, "can't expand an empty tensor");
+  THArgCheck(THTensor_(nDimension)(tensor) > 0 || THLongStorage_size(sizes) == 0, 0,
+             "can't expand an empty tensor");
   THArgCheck(THLongStorage_size(sizes) >= THTensor_(nDimension)(tensor), 1,
              "the number of sizes provided must be greater or equal to the "
              "number of dimensions in the tensor");

--- a/torch/lib/THC/generic/THCTensor.c
+++ b/torch/lib/THC/generic/THCTensor.c
@@ -303,7 +303,8 @@ THCTensor* THCTensor_(newExpand)(THCState *state, THCTensor *tensor, THLongStora
 
 void THCTensor_(expand)(THCState *state, THCTensor *r, THCTensor *tensor, THLongStorage *sizes)
 {
-  THArgCheck(THCTensor_(nDimension)(state, tensor) > 0, 0, "can't expand an empty tensor");
+  THArgCheck(THCTensor_(nDimension)(state, tensor) > 0 || THLongStorage_size(sizes) == 0, 0,
+	     "can't expand an empty tensor");
   THArgCheck(THLongStorage_size(sizes) >= THCTensor_(nDimension)(state, tensor), 1,
              "the number of sizes provided must be greater or equal to the "
              "number of dimensions in the tensor");


### PR DESCRIPTION
This doesn't currently support expanding the sizes to (0,), but
we can handle that eventually at the ATen level.