### PR TITLE
2.5-3X perf improvement of Gloo AllReduce by enabling GPU direct

### DIFF
--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -79,6 +79,8 @@ ENDIF()
 
 IF(GLOO_FOUND)
   ADD_DEFINITIONS(-DWITH_GLOO=1)
+  # This flag will be reserved until we officially enable Gloo IBVERBS support in pytorch
+  ADD_DEFINITIONS(-DGLOO_USE_GPUDIRECT=0)
 ENDIF()
 
 ADD_DEFINITIONS(-D_THD_CORE=1)

--- a/torch/lib/THD/base/data_channels/GlooCache.hpp
+++ b/torch/lib/THD/base/data_channels/GlooCache.hpp
@@ -308,7 +308,12 @@ struct algorithm_spec<CollectiveType::ALL_REDUCE, T> {
         throw std::runtime_error("Gloo backend only supports sum op for CUDA all reduce");
       }
       auto stream = THCState_getCurrentStream(THDGetCudaState());
-      algo = std::make_shared<::gloo::CudaAllreduceHalvingDoublingPipelined<T>>(
+      algo = std::make_shared<::gloo::CudaAllreduceHalvingDoublingPipelined<T,
+#if defined(GLOO_USE_GPUDIRECT) && GLOO_USE_GPUDIRECT
+                              ::gloo::CudaDeviceWorkspace<T>>>(
+#else
+                              ::gloo::CudaHostWorkspace<T>>>(
+#endif
         context,
         std::initializer_list<T*>{reinterpret_cast<T*>(input_buffer.get())},
         count,


### PR DESCRIPTION
From my profiling results, we are only getting 1.2GB/s Allreduce throughput from Pytorch on ResNet50 on two nodes with IB. But compared with Microbenchmark roofline with the same data size, we can get around 5.7 GB/s.

Looks like CudaAllreduceHalvingDoublingPipelined by default uses the CudaHostWorkspace, which will not turn on the GPUDirect. This pull request enables this support.

With this change, we are now getting around avg. 3GB/s All reduce throughput for ResNet 50 instead of 1.2GB/s with IB, from my benchmarking/profiling