### PR TITLE
Add a common sub-expression elimination pass in JIT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -381,6 +381,7 @@ main_sources = [
     "torch/csrc/jit/passes/graph_fuser.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
+    "torch/csrc/jit/passes/common_subexpression_elimination.cpp",
     "torch/csrc/autograd/init.cpp",
     "torch/csrc/autograd/engine.cpp",
     "torch/csrc/autograd/function.cpp",

--- a/test/expect/TestJit.test_cse.expect
+++ b/test/expect/TestJit.test_cse.expect
@@ -1,6 +1,7 @@
 graph(%1 : Double(2)
       %2 : Double(2)) {
-  %3 : Double(2) = Add(%1, %2), uses = [%5.i0, %5.i1];
-  %5 : Double(2) = Mul(%3, %3), uses = [%0.i0];
-  return (%5);
+  %3 : Double(2) = Add(%1, %2), uses = [%5.i0, %5.i1, %7.i1];
+  %5 : Double(2) = Mul(%3, %3), uses = [%7.i0];
+  %7 : Double(2) = Mul(%5, %3), uses = [%0.i0];
+  return (%7);
 }

--- a/test/expect/TestJit.test_cse.expect
+++ b/test/expect/TestJit.test_cse.expect
@@ -2,6 +2,9 @@ graph(%1 : Double(2)
       %2 : Double(2)) {
   %3 : Double(2) = Add(%1, %2), uses = [%5.i0, %5.i1, %7.i1];
   %5 : Double(2) = Mul(%3, %3), uses = [%7.i0];
-  %7 : Double(2) = Mul(%5, %3), uses = [%0.i0];
-  return (%7);
+  %7 : Double(2) = Mul(%5, %3), uses = [%8.i0, %16.i0];
+  %8 : Double(2) = Tanh(%7), uses = [%10.i0, %10.i1];
+  %10 : Double(2) = Add(%8, %8), uses = [%16.i1];
+  %16 : Double(2) = Add(%7, %10), uses = [%0.i0];
+  return (%16);
 }

--- a/test/expect/TestJit.test_cse.expect
+++ b/test/expect/TestJit.test_cse.expect
@@ -1,0 +1,6 @@
+graph(%1 : Double(2)
+      %2 : Double(2)) {
+  %3 : Double(2) = Add(%1, %2), uses = [%5.i0, %5.i1];
+  %5 : Double(2) = Mul(%3, %3), uses = [%0.i0];
+  return (%5);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -98,6 +98,20 @@ class TestJit(TestCase):
         torch._C._jit_pass_lint(trace)
         self.assertExpected(str(trace))
 
+    def test_cse(self):
+        x = Variable(torch.Tensor([0.4, 0.3]), requires_grad=True)
+        y = Variable(torch.Tensor([0.7, 0.5]), requires_grad=True)
+
+        trace = torch._C._tracer_enter((x, y), 0)
+        z = (x + y) * (x + y)
+        torch._C._tracer_exit((z,))
+        torch._C._jit_pass_lint(trace)
+        torch._C._jit_pass_onnx(trace)
+        torch._C._jit_pass_lint(trace)
+        torch._C._jit_pass_cse(trace)
+
+        self.assertExpected(str(trace))
+
     def test_verify(self):
         x = Variable(torch.Tensor([0.4]), requires_grad=True)
         y = Variable(torch.Tensor([0.7]), requires_grad=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -103,7 +103,7 @@ class TestJit(TestCase):
         y = Variable(torch.Tensor([0.7, 0.5]), requires_grad=True)
 
         trace = torch._C._tracer_enter((x, y), 0)
-        z = (x + y) * (x + y)
+        z = (x + y) * (x + y) * (x + y)
         torch._C._tracer_exit((z,))
         torch._C._jit_pass_lint(trace)
         torch._C._jit_pass_onnx(trace)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -103,7 +103,9 @@ class TestJit(TestCase):
         y = Variable(torch.Tensor([0.7, 0.5]), requires_grad=True)
 
         trace = torch._C._tracer_enter((x, y), 0)
-        z = (x + y) * (x + y) * (x + y)
+        w = (x + y) * (x + y) * (x + y)
+        t = torch.tanh(w) + torch.tanh(w)
+        z = (x + y) * (x + y) * (x + y) + t
         torch._C._tracer_exit((z,))
         torch._C._jit_pass_lint(trace)
         torch._C._jit_pass_onnx(trace)

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/passes/graph_fuser.h"
 #include "torch/csrc/jit/passes/onnx.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/jit/passes/common_subexpression_elimination.h"
 
 
 
@@ -39,6 +40,7 @@ void initJITBindings(PyObject *module) {
    .def("_jit_pass_onnx", ToONNX)
    .def("_jit_pass_fuse", graph_pass<FuseGraph>)
    .def("_jit_pass_dce", graph_pass<EliminateDeadCode>)
+   .def("_jit_pass_cse", graph_pass<EliminateCommonSubexpression>)
    .def("_jit_pass_lint", graph_pass<LintGraph>)
    .def("_jit_run_cpp_tests", runJITCPPTests);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -488,15 +488,11 @@ private:
   // having corner cases where the list is empty.
   Node * const output_;
 
-  // Indicate whether the results of nodes() are in topological order.
-  bool topological_;
-
 public:
   Graph()
   : next_unique_(0)
   , new_node_stage_(0)
-  , output_(initOutput(create(kReturn)))
-  , topological_(true) {}
+  , output_(initOutput(create(kReturn))) {}
 
   const param_list & inputs() {
     return inputs_;
@@ -532,12 +528,6 @@ public:
   }
   size_t stage() const {
     return new_node_stage_;
-  }
-  void setTopological(bool topological) {
-    topological_ = topological;
-  }
-  bool topological() const {
-    return topological_;
   }
   ResourceGuard setStageTemporary(size_t s) {
     auto prev_stage = new_node_stage_;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -488,11 +488,15 @@ private:
   // having corner cases where the list is empty.
   Node * const output_;
 
+  // Indicate whether the results of nodes() are in topological order.
+  bool topological_;
+
 public:
   Graph()
   : next_unique_(0)
   , new_node_stage_(0)
-  , output_(initOutput(create(kReturn))) {}
+  , output_(initOutput(create(kReturn)))
+  , topological_(true) {}
 
   const param_list & inputs() {
     return inputs_;
@@ -528,6 +532,12 @@ public:
   }
   size_t stage() const {
     return new_node_stage_;
+  }
+  void setTopological(bool topological) {
+    topological_ = topological;
+  }
+  bool topological() const {
+    return topological_;
   }
   ResourceGuard setStageTemporary(size_t s) {
     auto prev_stage = new_node_stage_;

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -73,7 +73,7 @@ void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
         // If not put it into the map
         subexprs.insert(node);
       } else {
-        // Subexpression exists, replace the uses of node, and destory it.
+        // Subexpression exists, replace the uses of node, and destroy it.
         auto existing = *subexprs.find(node);
         const use_list & uses = node->uses();
         const use_list & reuses= existing->uses();

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -1,0 +1,105 @@
+#include "torch/csrc/jit/ir.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "torch/csrc/jit/interned_strings.h"
+#include "torch/csrc/jit/passes/common_subexpression_elimination.h"
+
+namespace torch { namespace jit {
+
+struct HashNodeCSE {
+  std::size_t operator()(const Node* k) const {
+    JIT_ASSERT(k != nullptr);
+    std::size_t p = 31; // A prime.
+    std::size_t h = k->kind() * p + k->stage();
+    for (auto i : k->inputs()) {
+      h = h * p + i->unique();
+    }
+    return h;
+  }
+};
+
+struct EqualNodeCSE {
+  bool operator()(const Node* lhs, const Node* rhs) const {
+    if (lhs == nullptr && rhs == nullptr) return true;
+    if (lhs == nullptr || rhs == nullptr) return false;
+
+    // Check whether two nodes are the same kind.
+    if (lhs->kind() != rhs->kind()) return false;
+
+    // Check the stage.
+    if (lhs->stage() != rhs->stage()) return false;
+
+    // TODO check the device.
+
+    // Check whether the inputs are the same.
+    if (lhs->inputs().size() != rhs->inputs().size()) return false;
+
+    if (!std::equal(lhs->inputs().begin(), lhs->inputs().end(), rhs->inputs().begin())) return false;
+
+    // Check the attributes.
+    // TODO support attributes comparison.
+    if (lhs->hasAttributes() || rhs->hasAttributes()) return false;
+
+    return true;
+  }
+};
+
+void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
+  // Keep iterating until reach the fixed point.
+  bool reach_fixed = false;
+  while (!reach_fixed) {
+    reach_fixed = true;
+    auto nodes = graph->nodes();
+    std::unordered_set<Node*, HashNodeCSE, EqualNodeCSE> subexprs;
+    for (auto it = nodes.begin(); it != nodes.end(); ++ it) {
+      auto node = *it;
+      if (node->kind() != kAdd
+          && node->kind() != kMul
+          && node->kind() != kNeg
+          && node->kind() != kSigmoid
+          && node->kind() != kTanh
+          && node->kind() != kSplit
+          && node->kind() != kAddConstant
+         ) {
+        // TODO support more kinds of nodes.
+        // Only support CSE on these nodes.
+        continue;
+      }
+
+      // Check whether the same subexpression already exists.
+      if (subexprs.find(node) == subexprs.end()) {
+        // If not put it into the map
+        subexprs.insert(node);
+      } else {
+        // Subexpression exists, replace the uses of node, and destory it.
+        auto existing = *subexprs.find(node);
+        const use_list & uses = node->uses();
+        const use_list & reuses= existing->uses();
+        if (node->hasMultipleOutputs()) {
+          // For Multi-Output nodes, all its uses should be Select nodes.
+          JIT_ASSERT(uses.size() == reuses.size());
+          // Replace the uses of Select nodes.
+          for (size_t i = 0; i < uses.size(); ++ i) {
+            JIT_ASSERT(uses[i].user->kind() == kSelect);
+            JIT_ASSERT(reuses[i].user->kind() == kSelect);
+            uses[i].user->replaceAllUsesWith(reuses[i].user);
+          }
+          // Destroy Select nodes.
+          while (uses.size() > 0) {
+            uses[0].user->destroy();
+          }
+        } else {
+          node->replaceAllUsesWith(existing);
+        }
+        // Destroy the node.
+        node->destroy();
+        reach_fixed = false;
+        break;
+      }
+    }
+  }
+}
+
+}}

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -8,15 +8,88 @@
 
 namespace torch { namespace jit {
 
-struct HashNodeCSE {
-  std::size_t operator()(const Node* k) const {
-    JIT_ASSERT(k != nullptr);
-    std::size_t p = 31; // A prime.
-    std::size_t h = k->kind() * p + k->stage();
-    for (auto i : k->inputs()) {
-      h = h * p + i->unique();
+
+
+// Check whether two nodes have the same attributes in CSE.
+// This function may be too conservative for general use.
+bool attributesEqualCSE(const Node* lhs, const Node* rhs) {
+  JIT_ASSERT(lhs != nullptr);
+  JIT_ASSERT(rhs != nullptr);
+  if (lhs->hasAttributes() && rhs->hasAttributes()) return true;
+  if (lhs->hasAttributes() || rhs->hasAttributes()) return false;
+
+  auto lnames = lhs->attributeNames();
+  auto rnames = rhs->attributeNames();
+  if (lnames != rnames) return false;
+
+  Node* l = const_cast<Node*>(lhs);
+  Node* r = const_cast<Node*>(rhs);
+  for (auto name : lnames) {
+    switch(l->kindOf(name)) {
+      case AttributeKind::f: 
+        {
+          auto lv = l->f(name);
+          auto rv = r->f(name);
+          if (lv != rv) return false;
+        }
+        break;
+      case AttributeKind::fs:
+        {
+          auto lv = l->fs(name);
+          auto rv = r->fs(name);
+          if (lv != rv) return false;
+        }
+        break;
+      case AttributeKind::i:
+        {
+          auto lv = l->i(name);
+          auto rv = r->i(name);
+          if (lv != rv) return false;
+        }
+        break;
+      case AttributeKind::is:
+        {
+          auto lv = l->is(name);
+          auto rv = r->is(name);
+          if (lv != rv) return false;
+        }
+        break;
+      case AttributeKind::s:
+        {
+          auto lv = l->s(name);
+          auto rv = r->s(name);
+          if (lv != rv) return false;
+        }
+        break;
+      case AttributeKind::ss:
+        {
+          auto lv = l->ss(name);
+          auto rv = r->ss(name);
+          if (lv != rv) return false;
+        }
+        break;
+      default:
+        return false;
     }
-    return h;
+  }
+  return true;
+}
+
+// Later, if someone wants to reuse this, it can be moved to some header files.
+inline void hash_combine(size_t& seed, size_t value) {
+  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+struct HashNodeCSE {
+  size_t operator()(const Node* k) const {
+    JIT_ASSERT(k != nullptr);
+    size_t seed = 0;
+    hash_combine(seed, k->kind());
+    hash_combine(seed, k->stage());
+    for (auto i : k->inputs()) {
+      hash_combine(seed, i->unique());
+    }
+    return seed;
   }
 };
 
@@ -39,15 +112,16 @@ struct EqualNodeCSE {
     if (!std::equal(lhs->inputs().begin(), lhs->inputs().end(), rhs->inputs().begin())) return false;
 
     // Check the attributes.
-    // TODO support attributes comparison.
-    if (lhs->hasAttributes() || rhs->hasAttributes()) return false;
+    if (!attributesEqualCSE(lhs, rhs)) return false;
 
     return true;
   }
 };
 
+// If the nodes are visited in topological order, one pass is enough.
 void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
   // Keep iterating until reach the fixed point.
+  bool topological = graph->topological();
   bool reach_fixed = false;
   while (!reach_fixed) {
     reach_fixed = true;
@@ -69,12 +143,14 @@ void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
       }
 
       // Check whether the same subexpression already exists.
-      if (subexprs.find(node) == subexprs.end()) {
-        // If not put it into the map
+      auto subit = subexprs.find(node);
+      if (subit == subexprs.end()) {
+        // If not put current node into the map
         subexprs.insert(node);
       } else {
         // Subexpression exists, replace the uses of node, and destroy it.
-        auto existing = *subexprs.find(node);
+        auto existing = *subit;
+        JIT_ASSERT(existing != node);
         const use_list & uses = node->uses();
         const use_list & reuses= existing->uses();
         if (node->hasMultipleOutputs()) {
@@ -94,11 +170,11 @@ void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
           node->replaceAllUsesWith(existing);
         }
         // Destroy the node.
-        node->destroy();
+        it.destroyCurrent();
         reach_fixed = false;
-        break;
       }
     }
+    if (topological) break;
   }
 }
 

--- a/torch/csrc/jit/passes/common_subexpression_elimination.h
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph);
+
+}}


### PR DESCRIPTION
Move the PR from ezyang/pytorch#237. 

Now, support all ops except CppOp/PythonOp/Eval/Undefined ops. The graph is guaranteed to be in topological order, so one pass is enough.