### PR TITLE
Let Gloo check if it supports GPU Direct at run-time

### DIFF
--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -79,8 +79,6 @@ ENDIF()
 
 IF(GLOO_FOUND)
   ADD_DEFINITIONS(-DWITH_GLOO=1)
-  # This flag will be reserved until we officially enable Gloo IBVERBS support in pytorch
-  ADD_DEFINITIONS(-DGLOO_USE_GPUDIRECT=0)
 ENDIF()
 
 ADD_DEFINITIONS(-D_THD_CORE=1)


### PR DESCRIPTION
@pietern added the new functionality for Gloo device to check if it supports GPU direct. 
 I changed the Gloo submodule to 3b0f3f9ce9e48739370dd0a28a3e559ed54ffa46 so that we are able to use this feature in Pytorch

This allows us to detect if we should enable GPU direct at runtime.  This will only be available when GLOO_USE_IBVERBS is ON.

Tested with both DUSE_IBVERBS ON and OFF.

This will avoid unnecessary issues like pytorch/pytorch#2835