### PR TITLE
Cleanup External NCCL detection process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,12 @@ import os
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
+from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR
 from tools.setup_helpers.split_types import split_types
 
 DEBUG = check_env_flag('DEBUG')
 WITH_DISTRIBUTED = not check_env_flag('NO_DISTRIBUTED')
 WITH_DISTRIBUTED_MW = WITH_DISTRIBUTED and check_env_flag('WITH_DISTRIBUTED_MW')
-WITH_NCCL = WITH_CUDA and platform.system() != 'Darwin'
-SYSTEM_NCCL = False
 
 
 ################################################################################
@@ -90,6 +89,9 @@ def build_libs(libs):
     build_libs_cmd = ['bash', 'torch/lib/build_libs.sh']
     my_env = os.environ.copy()
     my_env["PYTORCH_PYTHON"] = sys.executable
+    if WITH_SYSTEM_NCCL:
+        my_env["NCCL_ROOT_DIR"] = NCCL_ROOT_DIR
+
     if WITH_CUDA:
         build_libs_cmd += ['--with-cuda']
     if subprocess.call(build_libs_cmd + libs, env=my_env) != 0:
@@ -109,7 +111,7 @@ class build_deps(Command):
         libs = ['TH', 'THS', 'THNN']
         if WITH_CUDA:
             libs += ['THC', 'THCS', 'THCUNN']
-        if WITH_NCCL and not SYSTEM_NCCL:
+        if WITH_NCCL and not WITH_SYSTEM_NCCL:
             libs += ['nccl']
         libs += ['THPP', 'libshm', 'ATen', 'nanopb']
         if WITH_DISTRIBUTED:
@@ -204,8 +206,9 @@ class build_ext(setuptools.command.build_ext.build_ext):
             print('-- Detected CUDA at ' + CUDA_HOME)
         else:
             print('-- Not using CUDA')
-        if WITH_NCCL and SYSTEM_NCCL:
-            print('-- Using system provided NCCL library')
+        if WITH_NCCL and WITH_SYSTEM_NCCL:
+            print('-- Using system provided NCCL library at ' +
+                  NCCL_LIB_DIR + ', ' + NCCL_INCLUDE_DIR)
         elif WITH_NCCL:
             print('-- Building NCCL library')
         else:
@@ -345,10 +348,6 @@ if platform.system() == 'Darwin':
 # static library only
 NANOPB_STATIC_LIB = os.path.join(lib_path, 'libprotobuf-nanopb.a')
 
-if WITH_NCCL and (subprocess.call('ldconfig -p | grep libnccl >/dev/null', shell=True) == 0 or
-                  subprocess.call('/sbin/ldconfig -p | grep libnccl >/dev/null', shell=True) == 0):
-    SYSTEM_NCCL = True
-
 main_compile_args = ['-D_THP_CORE']
 main_libraries = ['shm']
 main_link_args = [TH_LIB, THS_LIB, THNN_LIB, ATEN_LIB, NANOPB_STATIC_LIB]
@@ -461,8 +460,10 @@ if WITH_CUDA:
     main_sources += split_types("torch/csrc/cuda/Tensor.cpp")
 
 if WITH_NCCL:
-    if SYSTEM_NCCL:
+    if WITH_SYSTEM_NCCL:
         main_libraries += ['nccl']
+        include_dirs.append(NCCL_INCLUDE_DIR)
+        library_dirs.append(NCCL_LIB_DIR)
     else:
         main_link_args += [NCCL_LIB]
     extra_compile_args += ['-DWITH_NCCL']

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -26,6 +26,8 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         '/usr/lib/aarch64-linux-gnu/',
     ] + gather_paths([
         'LIBRARY_PATH',
+    ]) + gather_paths([
+        'LD_LIBRARY_PATH',
     ])))
     include_paths = list(filter(bool, [
         os.getenv('CUDNN_INCLUDE_DIR'),

--- a/tools/setup_helpers/nccl.py
+++ b/tools/setup_helpers/nccl.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import glob
+import platform
+import warnings
+from itertools import chain
+
+from .env import check_env_flag
+from .cuda import WITH_CUDA, CUDA_HOME
+
+
+def gather_paths(env_vars):
+    return list(chain(*(os.getenv(v, '').split(':') for v in env_vars)))
+
+is_conda = 'conda' in sys.version or 'Continuum' in sys.version
+conda_dir = os.path.join(os.path.dirname(sys.executable), '..')
+
+WITH_NCCL = WITH_CUDA and platform.system() != 'Darwin'
+WITH_SYSTEM_NCCL = False
+NCCL_LIB_DIR = None
+NCCL_INCLUDE_DIR = None
+NCCL_ROOT_DIR = None
+if WITH_CUDA and not check_env_flag('NO_SYSTEM_NCCL'):
+    ENV_ROOT = os.getenv('NCCL_ROOT_DIR', None)
+    # NCCL_ROOT_DIR takes precedence over NCCL_LIB_DIR
+    lib_paths = list(filter(bool, [
+        os.path.join(ENV_ROOT, 'lib') if ENV_ROOT is not None else None,
+        os.path.join(ENV_ROOT, 'lib64') if ENV_ROOT is not None else None,
+        os.getenv('NCCL_LIB_DIR'),
+        os.path.join(CUDA_HOME, 'lib'),
+        os.path.join(CUDA_HOME, 'lib64'),
+        '/usr/lib/x86_64-linux-gnu/',
+        '/usr/lib/powerpc64le-linux-gnu/',
+        '/usr/lib/aarch64-linux-gnu/',
+    ] + gather_paths([
+        'LIBRARY_PATH',
+    ]) + gather_paths([
+        'LD_LIBRARY_PATH',
+    ])))
+
+    if os.getenv('NCCL_INCLUDE_DIR') is not None:
+        warnings.warn("Ignoring environment variable NCCL_INCLUDE_DIR because "
+                      "NCCL_INCLUDE_DIR is implicitly assumed as "
+                      "$NCCL_ROOT_DIR/include or $NCCL_LIB_DIR/../include")
+    if is_conda:
+        lib_paths.append(os.path.join(conda_dir, 'lib'))
+    for path in lib_paths:
+        if path is None or not os.path.exists(path):
+            continue
+        if glob.glob(os.path.join(path, 'libnccl*')):
+            if os.path.exists((os.path.join(path, '../include/nccl.h'))):
+                NCCL_LIB_DIR = path
+                NCCL_INCLUDE_DIR = path
+                break
+    if NCCL_LIB_DIR is not None:
+        WITH_SYSTEM_NCCL = True
+        NCCL_ROOT_DIR = os.path.abspath(os.path.join(NCCL_LIB_DIR, "../"))

--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -36,8 +36,9 @@ else
 fi
 CPP_FLAGS=" -std=c++11 "
 GLOO_FLAGS=""
+NCCL_ROOT_DIR=${NCCL_ROOT_DIR:-$INSTALL_DIR}
 if [[ $WITH_CUDA -eq 1 ]]; then
-    GLOO_FLAGS="-DUSE_CUDA=1 -DNCCL_ROOT_DIR=$INSTALL_DIR"
+    GLOO_FLAGS="-DUSE_CUDA=1 -DNCCL_ROOT_DIR=$NCCL_ROOT_DIR"
 fi
 
 # Used to build an individual library, e.g. build TH
@@ -82,7 +83,7 @@ function build() {
               -Dnanopb_BUILD_GENERATOR=0 \
               -DCMAKE_DEBUG_POSTFIX="" \
               -DCMAKE_BUILD_TYPE=$([ $DEBUG ] && echo Debug || echo Release) \
-              $2
+              ${@:2}
   make install -j$(getconf _NPROCESSORS_ONLN)
   cd ../..
 


### PR DESCRIPTION
Introduces a consistent and cleaner way of detecting external NCCL, similar to CuDNN detection.

`NCCL_ROOT_DIR="/foo/my_dir" python setup.py install` finds `nccl.h` in `/foo/my_dir/include` and `libnccl*` in `/foo/my_dir/lib` or `/foo/my_dir/lib64`.

Alternatively, `NCCL_LIB_DIR="/foo/my_dir/lib" python setup.py install` finds `nccl.h` in `/foo/my_dir/include` and `libnccl*` in `/foo/my_dir/lib`

Also fixes a small `build_libs.sh` arg parsing bug.

Fixes https://github.com/pytorch/pytorch/issues/2553 and https://github.com/pytorch/pytorch/issues/2375