### PR TITLE
Give a better error message when we hit a legacy function.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -244,7 +244,7 @@ class TestJit(TestCase):
 
     def test_legacy_fail(self):
 
-        class Legacy(Function):
+        class MyLegacyFn(Function):
             def forward(self, x):
                 return x
 
@@ -253,7 +253,7 @@ class TestJit(TestCase):
 
         x = Variable(torch.Tensor([0]), requires_grad=True)
         trace = torch._C._tracer_enter((x,), 0)
-        self.assertRaises(RuntimeError, lambda: Legacy()(x))
+        self.assertRaisesRegex(RuntimeError, "MyLegacyFn", lambda: MyLegacyFn()(x))
         torch._C._tracer_exit((x,))
 
     def test_inplace_transplant(self):

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -630,8 +630,12 @@ static void _trace_create(PyObject* op_obj, THPFunction* bw_obj,
   if (!tracer::isTracing(input_vars))
     return;
 
-  if (!op_obj)
-    throw std::runtime_error("Tracing of legacy functions is not supported");
+  if (!op_obj) {
+    std::ostringstream oss;
+    oss << "Attempted to trace " << Py_TYPE(bw_obj)->tp_name;
+    oss << ", but tracing of legacy functions is not supported";
+    throw std::runtime_error(oss.str());
+  }
 
   auto tracing_state = tracer::getTracingState(input_vars);
   bw_obj->is_traced = true;


### PR DESCRIPTION
We now include the type name of the legacy function implementing
class.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>