### PR TITLE
Fix for clang 9 build issues

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -366,7 +366,6 @@ PythonArgs PythonArgParser::parse(PyObject* args, PyObject* kwargs, PyObject* pa
   print_error(args, kwargs, parsed_args);
 }
 
-[[noreturn]]
 void PythonArgParser::print_error(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]) {
   auto num_args = PyTuple_GET_SIZE(args) + (kwargs ? PyDict_Size(kwargs) : 0);
   std::vector<int> plausible_idxs;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -50,6 +50,7 @@ struct PythonArgParser {
   PythonArgs parse(PyObject* args, PyObject* kwargs, PyObject* dst[]);
 
 private:
+  [[noreturn]]
   void print_error(PyObject* args, PyObject* kwargs, PyObject* dst[]);
 
   std::vector<FunctionSignature> signatures_;
@@ -119,7 +120,7 @@ inline at::Scalar PythonArgs::scalar(int i) {
   if (PyFloat_Check(args[i])) {
     return at::Scalar(THPUtils_unpackDouble(args[i]));
   }
-  return at::Scalar(THPUtils_unpackLong(args[i]));
+  return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));
 }
 
 inline std::vector<int64_t> PythonArgs::intlist(int i) {


### PR DESCRIPTION
I just updated my XCode, it now ships with clang 9.

I'm getting two errors, one related to `as::Scalar` constructor:
```
/pytorch/torch/csrc/utils/python_arg_parser.h:122:10: error: 
      ambiguous conversion for functional-style cast from 'long' to 'at::Scalar'
  return at::Scalar(THPUtils_unpackLong(args[i]));
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
  AT_FORALL_SCALAR_TYPES(DEFINE_IMPLICIT_CTOR)
                         ^
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:28:26: note: 
      candidate constructor
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:14:7: note: 
      candidate is the implicit move constructor
class Scalar {
      ^
/pytorch/torch/lib/tmp_install/include/ATen/Scalar.h:14:7: note: 
      candidate is the implicit copy constructor
```

The other to a `[[noreturn]]` attribute:
```
torch/csrc/utils/python_arg_parser.cpp:369:3: error: function declared '[[noreturn]]' after its
      first declaration
[[noreturn]]
  ^
/pytorch/torch/csrc/utils/python_arg_parser.h:53:8: note: 
      declaration missing '[[noreturn]]' attribute is here
  void print_error(PyObject* args, PyObject* kwargs, PyObject* dst[]);
       ^
```

This PR fixes those. I'm going to see what happens with the CI builds as I don't have access to other OS/compilers at the moment.