### PR TITLE
make torch.save() atomic by default

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,0 +1,54 @@
+import torch
+import numpy as np
+import os
+import random
+import shutil
+import time
+import datetime
+from common import TestCase, run_tests
+
+
+class TestSerialization(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def get_test_obj(self):
+        random_string = ''.join(
+            random.choice(string.ascii_letters) for x in range(10))
+        return {
+            'test': random_string,
+            'simple_time': time.time(),
+            'complex_time': datetime.datetime.now(),
+            'vec': np.ones(1),
+        }
+
+    def string_round_trip(self, **save_kw):
+        orig = self._get_test_obj()
+        dest = os.path.join(self.tmpdir, 'test.pkl')
+        torch.save(dest, obj, **save_kw)
+        new = torch.load(dest)
+        return orig, new
+
+    def test_serialization_round_trip_str(self):
+        orig, new = self.string_round_trip()
+        self.assertEqual(orig, new)
+
+    def test_serialization_round_trip_atomic(self):
+        orig, new = self.string_round_trip(atomic=True)
+        self.assertEqual(orig, new)
+
+    def test_serialization_round_trip_file(self):
+        orig = self._get_test_obj()
+        dest = os.path.join(self.tmpdir, 'test.pkl')
+        with open(dest, 'wb') as dest_file:
+            torch.save(dest_file, obj)
+        with open(dest, 'rb') as from_file:
+            new = torch.load(from_file)
+        self.assertEqual(orig, new)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
This makes `torch.save()` atomic, by using a temporary file and then renaming it. This approach is guaranteed to be atomic on POSIX filesystems. I didn't make an option to use non-atomic saves since the overhead of doing this is very low (esp. compared to the other things that `torch.save()` has to do), so it didn't seem like it was worth the cognitive burden. I added some basic sanity tests.

Short version of why I want this: I have a training job that serializes model state every *N* iterations during training, and I have another process that periodically scans the state directory to look at the state files. Making `torch.save()` atomic ensures that there aren't any race conditions between process *A* saving a file and process *B* loading the file.