### PR TITLE
Fix typos

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2768,16 +2768,16 @@ class TestTorch(TestCase):
         self.assertEqual(reference[rows, columns],
                          torch.Tensor([[4, 6], [2, 3]]))
 
-        # Verify still works with Tranposed (i.e. non-contiguous) Tensors
+        # Verify still works with Transposed (i.e. non-contiguous) Tensors
 
         reference = conv_fn(torch.Tensor([[0, 1, 2, 3],
                                           [4, 5, 6, 7],
                                           [8, 9, 10, 11]])).t_()
 
-        # Tranposed: [[0, 4, 8],
-        #             [1, 5, 9],
-        #             [2, 6, 10],
-        #             [3, 7, 11]]
+        # Transposed: [[0, 4, 8],
+        #              [1, 5, 9],
+        #              [2, 6, 10],
+        #              [3, 7, 11]]
 
         self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([0, 1,
                          2]))

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -32,7 +32,7 @@ class _ContextMethodMixin(object):
 
         Every tensor that's been modified in-place in a call to :func:`forward`
         should be given to this function, to ensure correctness of our checks.
-        It doesn't matter wheter the function is called before or after
+        It doesn't matter whether the function is called before or after
         modification.
         """
         self.dirty_tensors = args

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -959,7 +959,7 @@ class Variable(_C._VariableBase):
 
 for method in dir(Variable):
     # This will also wrap some methods that normally aren't part of the
-    # funcitonal interface, but we don't care, as they won't ever be used
+    # functional interface, but we don't care, as they won't ever be used
     if method.startswith('_') or method.endswith('_'):
         continue
     if hasattr(Variable._torch, method):

--- a/torch/lib/THC/THCScanUtils.cuh
+++ b/torch/lib/THC/THCScanUtils.cuh
@@ -50,7 +50,7 @@ __device__ void inclusivePrefixScan(T *smem, BinaryOp binop) {
   }
 }
 
-// Generic Op that can be be used to support segmented scans by re-using
+// Generic Op that can be used to support segmented scans by re-using
 // the basic inclusiveScanOp. Merely requires that the input data has both
 // a flag and val component
 template <typename T, class BinaryOp>

--- a/torch/lib/THCS/generic/THCSTensorMath.h
+++ b/torch/lib/THCS/generic/THCSTensorMath.h
@@ -7,7 +7,7 @@
  * sspOP returns a sparse result
  * spOPs has all arguments sparse
  *
- * Everything is is up to discretion
+ * Everything is up to discretion
  */
 
 TH_API void THCSTensor_(zero)(THCState *state, THCSTensor *r_);

--- a/torch/lib/THS/generic/THSTensorMath.h
+++ b/torch/lib/THS/generic/THSTensorMath.h
@@ -7,7 +7,7 @@
  * sspOP returns a sparse result
  * spOPs has all arguments sparse
  *
- * Everything is is up to discretion
+ * Everything is up to discretion
  */
 
 TH_API void THSTensor_(zero)(THSTensor *r_);

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -54,7 +54,7 @@ class Optimizer(object):
 
         * state - a dict holding current optimization state. Its content
             differs between optimizer classes.
-        * param_groups - a dict containig all parameter groups
+        * param_groups - a dict containing all parameter groups
         """
         # Save ids instead of Variables
         def pack_group(group):


### PR DESCRIPTION
This PR fixes some typos: `Tranposed`, `wheter`, `funcitonal`, `be be`, `is is`, and `containig`.