### PR TITLE
Fix typos

### DIFF
--- a/tools/cwrap/plugins/Broadcast.py
+++ b/tools/cwrap/plugins/Broadcast.py
@@ -3,7 +3,7 @@ from string import Template
 
 # Arguments to the Broadcast Plugin:
 # broadcast: args_to_broadcast_against [inplace] [fallback]
-# [args_to_broadcast_against]: either a single argument (e.g. "arg1") or a comma-seperated
+# [args_to_broadcast_against]: either a single argument (e.g. "arg1") or a comma-separated
 #                              list of two arguments (e.g. "tensor1,tensor2") indicating
 #                              arguments to broadcast specified argument (usually "self") against
 # [inplace] will generate code for in-place function, which doesn't allow the in-place

--- a/torch/legacy/nn/SpatialZeroPadding.py
+++ b/torch/legacy/nn/SpatialZeroPadding.py
@@ -31,7 +31,7 @@ class SpatialZeroPadding(Module):
             c_input = c_input.narrow(3, 0 - self.pad_l, c_input.size(3) + self.pad_l)
         if self.pad_r < 0:
             c_input = c_input.narrow(3, 0, c_input.size(3) + self.pad_r)
-        # crop outout if necessary
+        # crop output if necessary
         c_output = self.output
         if self.pad_t > 0:
             c_output = c_output.narrow(2, 0 + self.pad_t, c_output.size(2) - self.pad_t)
@@ -60,7 +60,7 @@ class SpatialZeroPadding(Module):
             cg_input = cg_input.narrow(3, 0 - self.pad_l, cg_input.size(3) + self.pad_l)
         if self.pad_r < 0:
             cg_input = cg_input.narrow(3, 0, cg_input.size(3) + self.pad_r)
-        # crop gradOutout if necessary
+        # crop gradOutput if necessary
         cg_output = gradOutput
         if self.pad_t > 0:
             cg_output = cg_output.narrow(2, 0 + self.pad_t, cg_output.size(2) - self.pad_t)
@@ -70,7 +70,7 @@ class SpatialZeroPadding(Module):
             cg_output = cg_output.narrow(3, 0 + self.pad_l, cg_output.size(3) - self.pad_l)
         if self.pad_r > 0:
             cg_output = cg_output.narrow(3, 0, cg_output.size(3) - self.pad_r)
-        # copy gradOuput to gradInput
+        # copy gradOutput to gradInput
         cg_input.copy_(cg_output)
 
         return self.gradInput

--- a/torch/lib/ATen/test/broadcast_test.cpp
+++ b/torch/lib/ATen/test/broadcast_test.cpp
@@ -70,7 +70,7 @@ int main() {
       assert(false);
     } catch(std::runtime_error &e) {}
 
-    // with mistmatched sizes
+    // with mismatched sizes
     try {
       auto c = T.randn({5, 5, 5});
       a.addcmul(b, c);
@@ -137,7 +137,7 @@ int main() {
     aScalar.get()->maybeScalar(true);
     assert(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
 
-    // with mistmatched sizes
+    // with mismatched sizes
     try {
       auto a = T.randn({3, 3});
       a.addmm(b, c);


### PR DESCRIPTION
This PR fixes some typos: `seperated`, `outout`, `Outout`, `Ouput`, and `mistmatched`.