### PR TITLE
bugfix: initialize new tensor in backwards of Variable.zero_()

### DIFF
--- a/torch/autograd/_functions/initializers.py
+++ b/torch/autograd/_functions/initializers.py
@@ -17,4 +17,4 @@ class Zero(InplaceFunction):
     @staticmethod
     def backward(ctx, grad_output):
         result, = ctx.saved_variables
-        return Variable(result.data.new(1).expand_as(result))
+        return Variable(result.data.new(1).zero_().expand_as(result))


### PR DESCRIPTION
In [this PR](https://github.com/pytorch/pytorch/pull/2212#discussion_r142120780)  the new tensor in the backward function is uninitialized. 

cc @apaszke 