### PR TITLE
Fix scope error

### DIFF
--- a/torch/lib/THD/test/data_channel_gloo_cache.cpp
+++ b/torch/lib/THD/test/data_channel_gloo_cache.cpp
@@ -46,7 +46,7 @@ void init_gloo_master(int workers) {
   setenv(WORLD_SIZE_ENV, std::to_string((workers + 1)).data(), 1);
   setenv(RANK_ENV, "0", 1);
   setenv(MASTER_PORT_ENV, std::to_string(MASTER_PORT).data(), 1);
-  auto masterChannel = std::make_shared<thd::DataChannelGloo>(getInitConfig("env://")); // reads all env variable
+  auto masterChannel = std::make_shared<thd::DataChannelGloo>(thd::getInitConfig("env://")); // reads all env variable
   g_mutex.unlock();
 
   assert(masterChannel->init());
@@ -57,7 +57,7 @@ void init_gloo_worker(unsigned int id, int workers) {
   g_mutex.lock();
   setenv(RANK_ENV, std::to_string(id).data(), 1);
   setenv(MASTER_ADDR_ENV, std::string("127.0.0.1:" + std::to_string(MASTER_PORT)).data(), 1);
-  auto worker_channel = std::make_shared<thd::DataChannelGloo>(getInitConfig("env://")); // reads all env variable
+  auto worker_channel = std::make_shared<thd::DataChannelGloo>(thd::getInitConfig("env://")); // reads all env variable
   g_mutex.unlock();
 
   assert(worker_channel->init());


### PR DESCRIPTION
error: ‘getInitConfig’ was not declared in this scope