### PR TITLE
[dlpack] Conversion for python tensor <--> dlpack via ATen

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4185,6 +4185,12 @@ class TestTorch(TestCase):
             y[0][1] = 3
             self.assertTrue(x[0][1] == 3)
 
+    def test_dlpack_conversion(self):
+        x = torch.randn(1, 2, 3, 4).type('torch.FloatTensor')
+        y = torch._C._to_dlpack(x)
+        z = torch._C._from_dlpack(y)
+        self.assertEqual(z, x)
+
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_from_numpy(self):
         dtypes = [


### PR DESCRIPTION
To make it easy to pass tensors across frameworks for example pytorch <-> dlpack <-> caffe2, I added conversion for ATen tensor to DLpack tensor last week in the main ATen repo. The second step is to add support for converting the python tensors in pytorch to dlpack. This PR does that. I wrote a unit test for it and it runs fine

This PR depends on Updating Aten subtree and PR for that is here https://github.com/pytorch/pytorch/pull/2930 