### PR TITLE
Add inplace checks in JIT

### DIFF
--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -57,7 +57,8 @@ _(axis) \
 _(perm) \
 _(shape) \
 _(axes) \
-_(group)
+_(group) \
+_(__inplace)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -4,6 +4,7 @@ from torch.autograd import Variable
 from torch.nn import Module, ParameterList, Parameter
 from torch._six import raise_from
 from collections import defaultdict
+from . import passes as _passes
 import itertools
 import types
 import contextlib
@@ -461,8 +462,9 @@ class TraceForKey(object):
 
             # It's important to always run DCE, because backward can create a lot of unnecessary nodes
             _run_pass(torch._C._jit_pass_dce, complete_trace)
+            _run_pass(torch._C._jit_pass_onnx, complete_trace)
+            _run_pass(_passes._check_inplace, complete_trace)
             if self.optimize:
-                _run_pass(torch._C._jit_pass_onnx, complete_trace)
                 _run_pass(torch._C._jit_pass_fuse, complete_trace)
 
             _dump_trace(self.name, "final", self.key, complete_trace)

--- a/torch/jit/passes/__init__.py
+++ b/torch/jit/passes/__init__.py
@@ -1,0 +1,1 @@
+from .inplace import _check_inplace

--- a/torch/jit/passes/inplace.py
+++ b/torch/jit/passes/inplace.py
@@ -1,0 +1,11 @@
+
+def _check_inplace(trace):
+    """Checks that all PythonOps that were not translated into JIT format are out of place.
+
+    Should be run after the ONNX pass.
+    """
+    graph = trace.graph()
+    for node in graph.nodes():
+        if node.kind() == 'PythonOp':
+            if node.i('__inplace'):
+                raise RuntimeError("inplace {} not supported in the JIT".format(node.pyname()))


### PR DESCRIPTION
We use the ONNX pass to de-inplace operators, and in case there are any left we raise an error.

Note that all CppOps we have right now are out-of-place so it's not necessary, but will be once we expose autogenerated autograd functions. Currently they won't even get traced, which is a problem on its own.