### PR TITLE
Translate addmm into Gemm operator / fix alpha-beta mixup / execute in JIT

### DIFF
--- a/test/expect/TestJit.test_lstm_fusion.expect
+++ b/test/expect/TestJit.test_lstm_fusion.expect
@@ -5,16 +5,14 @@ graph(%1 : Double(3, 10)
       %5 : Double(80, 20)
       %6 : Double(80)
       %7 : Double(80)) {
-  %8 : Double(10!, 80!) = Transpose[perm=[1, 0]](%4), uses = [%9.i0];
-  %9 : UNKNOWN_TYPE = Transpose(%8), uses = [%10.i1];
-  %10 : Double(3, 80) = FC(%1, %9, %6), uses = [%32.i0];
-  %11 : Double(20!, 80!) = Transpose[perm=[1, 0]](%5), uses = [%12.i0];
-  %12 : UNKNOWN_TYPE = Transpose(%11), uses = [%13.i1];
-  %13 : Double(3, 80) = FC(%2, %12, %7), uses = [%37.i0];
-  %33 : Double(3!, 20), %34 : Double(3!, 20), %35 : Double(3!, 20), %36 : Double(3!, 20) = Split[split=[20, 20, 20, 20], axis=1](%10), uses = [[%29.i7], [%29.i5], [%29.i3], [%29.i1]];
-  %38 : Double(3!, 20), %39 : Double(3!, 20), %40 : Double(3!, 20), %41 : Double(3!, 20) = Split[split=[20, 20, 20, 20], axis=1](%13), uses = [[%29.i8], [%29.i6], [%29.i4], [%29.i2]];
-  %30 : Double(3, 20), %31 : Double(3, 20) = fusion_group_0(%3, %36, %41, %35, %40, %34, %39, %33, %38), uses = [[%0.i0], [%0.i1]];
-  return (%30, %31);
+  %8 : Double(10!, 80!) = Transpose[perm=[1, 0]](%4), uses = [%9.i1];
+  %9 : Double(3, 80) = Gemm[alpha=1, beta=1, broadcast=1](%1, %8, %6), uses = [%30.i0];
+  %10 : Double(20!, 80!) = Transpose[perm=[1, 0]](%5), uses = [%11.i1];
+  %11 : Double(3, 80) = Gemm[alpha=1, beta=1, broadcast=1](%2, %10, %7), uses = [%35.i0];
+  %31 : Double(3!, 20), %32 : Double(3!, 20), %33 : Double(3!, 20), %34 : Double(3!, 20) = Split[split=[20, 20, 20, 20], axis=1](%9), uses = [[%27.i7], [%27.i5], [%27.i3], [%27.i1]];
+  %36 : Double(3!, 20), %37 : Double(3!, 20), %38 : Double(3!, 20), %39 : Double(3!, 20) = Split[split=[20, 20, 20, 20], axis=1](%11), uses = [[%27.i8], [%27.i6], [%27.i4], [%27.i2]];
+  %28 : Double(3, 20), %29 : Double(3, 20) = fusion_group_0(%3, %34, %39, %33, %38, %32, %37, %31, %36), uses = [[%0.i0], [%0.i1]];
+  return (%28, %29);
 }
 with fusion_group_0 = graph(%13 : Double(3, 20)
       %23 : Double(3!, 20)

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -541,6 +541,12 @@ struct StageClosure {
       return std::make_shared<LambdaFunction>(1, [shape](const variable_list& vars) -> variable_list {
         return {make_variable(vars[0].data().view(shape), vars[0].requires_grad())};
       });
+    IR_ELSEIF(Gemm)
+      auto beta = value->f(kbeta);
+      auto alpha = value->f(kalpha);
+      return std::make_shared<LambdaFunction>(3, [beta, alpha](const variable_list& vars) -> variable_list {
+        return {vars[2].addmm(beta, alpha, vars[0], vars[1])};
+      });
     IR_ELSEIF(Split)
       auto dim = value->i(kaxis);
       auto splits = value->is(ksplit);

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -27,6 +27,7 @@ _(Squeeze) \
 _(Undefined) \
 _(FusionGroup) \
 _(Split) \
+_(Gemm) \
 _(AddConstant) \
 _(Transpose) \
 _(Reshape) \
@@ -50,6 +51,8 @@ _(strides) \
 _(stride) \
 _(pads) \
 _(pad) \
+_(beta) \
+_(alpha) \
 _(dilations) \
 _(dilation) \
 _(broadcast) \


### PR DESCRIPTION
The alpha/beta naming in addmm was flipped; this commit fixes that
problem.  It also fixes the ONNX export of alpha/beta parameters.
Finally, it supports executing matmul in the JIT.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>