### PR TITLE
WIP: add numpy() and from_numpy() to HalfTensor

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4333,6 +4333,7 @@ class TestTorch(TestCase):
         types = [
             'torch.ByteTensor',
             'torch.IntTensor',
+            'torch.HalfTensor',
             'torch.FloatTensor',
             'torch.DoubleTensor',
             'torch.LongTensor',
@@ -4384,28 +4385,37 @@ class TestTorch(TestCase):
 
             # with storage offset
             xm = torch.randn(sz2 * 2, sz1).mul(255).type(tp)
-            x = xm.narrow(0, sz2 - 1, sz2).t()
-            y = x.numpy()
-            self.assertTrue(x.storage_offset() > 0)
-            check2d(x, y)
+            if tp == 'torch.HalfTensor':
+                # TODO: remove when `t()` is implemented. This assertion is
+                # intended to mark this as to be changed when the feature
+                # becomes available. Later tests are just skipped for half
+                # floats.
+                with self.assertRaises(AttributeError):
+                    x = xm.narrow(0, sz2 - 1, sz2).t()
+            else:
+                x = xm.narrow(0, sz2 - 1, sz2).t()
+                y = x.numpy()
+                self.assertTrue(x.storage_offset() > 0)
+                check2d(x, y)
 
-            # non-contiguous 2D with holes
-            xm = torch.randn(sz2 * 2, sz1 * 2).mul(255).type(tp)
-            x = xm.narrow(0, sz2 - 1, sz2).narrow(1, sz1 - 1, sz1).t()
-            y = x.numpy()
-            self.assertTrue(x.storage_offset() > 0)
-            check2d(x, y)
+            if tp != 'torch.HalfTensor':
+                # non-contiguous 2D with holes
+                xm = torch.randn(sz2 * 2, sz1 * 2).mul(255).type(tp)
+                x = xm.narrow(0, sz2 - 1, sz2).narrow(1, sz1 - 1, sz1).t()
+                y = x.numpy()
+                self.assertTrue(x.storage_offset() > 0)
+                check2d(x, y)
 
-            # check writeable
-            x = torch.randn(3, 4).mul(255).type(tp)
-            y = x.numpy()
-            self.assertTrue(y.flags.writeable)
-            y[0][1] = 3
-            self.assertTrue(x[0][1] == 3)
-            y = x.t().numpy()
-            self.assertTrue(y.flags.writeable)
-            y[0][1] = 3
-            self.assertTrue(x[0][1] == 3)
+                # check writeable
+                x = torch.randn(3, 4).mul(255).type(tp)
+                y = x.numpy()
+                self.assertTrue(y.flags.writeable)
+                y[0][1] = 3
+                self.assertTrue(x[0][1] == 3)
+                y = x.t().numpy()
+                self.assertTrue(y.flags.writeable)
+                y[0][1] = 3
+                self.assertTrue(x[0][1] == 3)
 
     def test_dlpack_conversion(self):
         x = torch.randn(1, 2, 3, 4).type('torch.FloatTensor')
@@ -4417,6 +4427,7 @@ class TestTorch(TestCase):
         dtypes = [
             np.double,
             np.float,
+            np.float16,
             np.int64,
             np.int32,
             np.int16,
@@ -4424,7 +4435,11 @@ class TestTorch(TestCase):
         ]
         for dtype in dtypes:
             array = np.array([1, 2, 3, 4], dtype=dtype)
-            self.assertEqual(torch.from_numpy(array), torch.Tensor([1, 2, 3, 4]))
+            tensor_from_array = torch.from_numpy(array)
+            # TODO: change to tensor equality check once HalfTensor
+            # implements `==`
+            for i in range(len(array)):
+                self.assertEqual(tensor_from_array[i], array[i])
 
         # check storage offset
         x = np.linspace(1, 125, 125)
@@ -4463,6 +4478,7 @@ class TestTorch(TestCase):
         types = [
             torch.DoubleTensor,
             torch.FloatTensor,
+            torch.HalfTensor,
             torch.LongTensor,
             torch.IntTensor,
             torch.ShortTensor,
@@ -4471,6 +4487,7 @@ class TestTorch(TestCase):
         dtypes = [
             np.float64,
             np.float32,
+            np.float16,
             np.int64,
             np.int32,
             np.int16,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4466,6 +4466,49 @@ class TestTorch(TestCase):
         self.assertRaises(RuntimeError, lambda: torch.from_numpy(x))
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_ctor_with_numpy_array(self):
+        dtypes = [
+            np.double,
+            np.float,
+            np.float16,
+            np.int64,
+            np.int32,
+            np.int16,
+            np.uint8
+        ]
+        for dtype in dtypes:
+            array = np.array([1, 2, 3, 4], dtype=dtype)
+
+            # Upcast
+            tensor = torch.DoubleTensor(array)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+            if torch.cuda.is_available():
+                tensor = torch.cuda.DoubleTensor(array)
+                for i in range(len(array)):
+                    self.assertEqual(tensor[i], array[i])
+
+            # Downcast (sometimes)
+            if np.issubsctype(dtype, np.floating):
+                tensor = torch.FloatTensor(array)
+                for i in range(len(array)):
+                    self.assertEqual(tensor[i], array[i])
+
+                tensor = torch.HalfTensor(array)
+                for i in range(len(array)):
+                    self.assertEqual(tensor[i], array[i])
+
+                if torch.cuda.is_available():
+                    tensor = torch.cuda.FloatTensor(array)
+                    for i in range(len(array)):
+                        self.assertEqual(tensor[i], array[i])
+
+                    tensor = torch.cuda.HalfTensor(array)
+                    for i in range(len(array)):
+                        self.assertEqual(tensor[i], array[i])
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_numpy_index(self):
         i = np.int32([0, 1, 2])
         x = torch.randn(5, 5)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4490,23 +4490,22 @@ class TestTorch(TestCase):
                     self.assertEqual(tensor[i], array[i])
 
             # Downcast (sometimes)
-            if np.issubsctype(dtype, np.floating):
-                tensor = torch.FloatTensor(array)
+            tensor = torch.FloatTensor(array)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+            tensor = torch.HalfTensor(array)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+            if torch.cuda.is_available():
+                tensor = torch.cuda.FloatTensor(array)
                 for i in range(len(array)):
                     self.assertEqual(tensor[i], array[i])
 
-                tensor = torch.HalfTensor(array)
+                tensor = torch.cuda.HalfTensor(array)
                 for i in range(len(array)):
                     self.assertEqual(tensor[i], array[i])
-
-                if torch.cuda.is_available():
-                    tensor = torch.cuda.FloatTensor(array)
-                    for i in range(len(array)):
-                        self.assertEqual(tensor[i], array[i])
-
-                    tensor = torch.cuda.HalfTensor(array)
-                    for i in range(len(array)):
-                        self.assertEqual(tensor[i], array[i])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_numpy_index(self):

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -172,6 +172,8 @@ PyObject * THPModule_fromNumpy(PyObject *_unused, PyObject *array)
     return PyObject_CallFunctionObjArgs(THPDoubleTensorClass, array, NULL);
   } else if (type == NPY_FLOAT) {
     return PyObject_CallFunctionObjArgs(THPFloatTensorClass, array, NULL);
+  } else if (type == NPY_HALF) {
+    return PyObject_CallFunctionObjArgs(THPHalfTensorClass, array, NULL);
   } else if (type == NPY_INT64) {
     return PyObject_CallFunctionObjArgs(THPLongTensorClass, array, NULL);
   } else if (type == NPY_INT32) {
@@ -182,7 +184,7 @@ PyObject * THPModule_fromNumpy(PyObject *_unused, PyObject *array)
     return PyObject_CallFunctionObjArgs(THPByteTensorClass, array, NULL);
   }
   THPUtils_setError("can't convert a given np.ndarray to a tensor - it has an "
-      "invalid type. The only supported types are: double, float, int64, "
+      "invalid type. The only supported types are: double, float, float16, int64, "
       "int32, and uint8.");
   return NULL;
 #endif

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -88,8 +88,11 @@
 
 #define COPY_FROM_HALF_ARRAY_CUDA_HALF(ARRAY, STORAGE, SIZE)            \
 { \
-  char *arrdata = (char*)PyArray_DATA(ARRAY);                           \
-  cudaMemcpy(STORAGE->data, arrdata, SIZE * 2, cudaMemcpyHostToDevice); \
+  THHalf *arrdata = (THHalf*)PyArray_DATA(ARRAY);                       \
+  THHostStorage *cpu_storage =                                          \
+      THHostStorage_(newWithData)(arrdata, SIZE);                       \
+  cpu_storage->flag &= ~TH_STORAGE_FREEMEM;                             \
+  THCStorage_(copyCPU)(LIBRARY_STATE STORAGE, cpu_storage);             \
 }
 
 #define IDENTITY(X) (X)

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -60,10 +60,10 @@
   std::unique_ptr<load_real> data_guard(new load_real[SIZE]);           \
   load_real *data = data_guard.get();                                   \
   for (size_t i=0; i<SIZE; i++) {                                       \
-    data[i] = arrdata[i];                                   \
+    data[i] = arrdata[i];                                               \
   }                                                                     \
   THFloatStorage *cpu_storage =                                         \
-      THFloatStorage_newWithData(data_guard.get(), storage_size);       \
+      THFloatStorage_newWithData(data_guard.get(), SIZE);               \
   cpu_storage->flag &= ~TH_STORAGE_FREEMEM;                             \
   THCudaHalfStorage_copyFloat(LIBRARY_STATE STORAGE, cpu_storage);      \
   THFloatStorage_free(cpu_storage);                                     \

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -93,6 +93,7 @@
       THHostStorage_(newWithData)(arrdata, SIZE);                       \
   cpu_storage->flag &= ~TH_STORAGE_FREEMEM;                             \
   THCStorage_(copyCPU)(LIBRARY_STATE STORAGE, cpu_storage);             \
+  THHostStorage_(free)(cpu_storage);                                    \
 }
 
 #define IDENTITY(X) (X)

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -50,6 +50,7 @@ PyObject * THPTensor_(newWithMetadataFile)(PyObject *_null, PyObject *args)
   name: THPTensor_(toNumpy)
   python_name: numpy
   only_register: True
+  cpu_half: True
 ]]
 // Adapted from fblualib
 PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {


### PR DESCRIPTION
This is work in progress. I replaced the loop in the `COPY_FROM_ARRAY_CPU` macro with a `memcpy` as pointed out by @apaszke, and I added the entry in `torch/csrc/Module.cpp`. That makes `from_numpy` with `'float16` work as expected in first tries.
What I can't find is the place where the `tensor.numpy()` method is defined. I searched the repo for the string "numpy" but it didn't produce anything that strikes me as the obvious thing to look at. Can somebody please point me to it? Thx.