### PR TITLE
Fix resizing of gradInput in BatchNormalization

### DIFF
--- a/torch/lib/THCUNN/generic/BatchNormalization.cu
+++ b/torch/lib/THCUNN/generic/BatchNormalization.cu
@@ -72,6 +72,10 @@ void THNN_(BatchNormalization_backward)(
   THCTensor *saveMean_, THCTensor *saveStd_, bool train, double scale, double eps) {
 
   THCUNN_check_shape(state, input_, gradOutput_);
+  if (gradInput_) {
+    THCTensor_(resizeAs)(state, gradInput_, input_);
+  }
+
   DeviceTensor3 input = devicetensor<3>(state, input_);
   DeviceTensor3 gradOutput = devicetensor<3>(state, gradOutput_);
   DeviceTensor3 gradInput = devicetensor<3>(state, gradInput_);

--- a/torch/lib/THNN/generic/BatchNormalization.c
+++ b/torch/lib/THNN/generic/BatchNormalization.c
@@ -77,6 +77,10 @@ void THNN_(BatchNormalization_backward)(
   int64_t f;
   ptrdiff_t n = THTensor_(nElement)(input) / nInput;
 
+  if (gradInput) {
+    THTensor_(resizeAs)(gradInput, input);
+  }
+
   #pragma omp parallel for
   for (f = 0; f < nInput; ++f) {
     THTensor *in = THTensor_(newSelect)(input, 1, f);
@@ -101,7 +105,6 @@ void THNN_(BatchNormalization_backward)(
       dotp += (*in_data - mean) * (*gradOut_data););
 
     if (gradInput) {
-      THTensor_(resizeAs)(gradInput, input);      
       THTensor *gradIn = THTensor_(newSelect)(gradInput, 1, f);
 
       if (train) {


### PR DESCRIPTION
 * In C there was a race condition when gradInput was resized within the
   parallel for
 * CUDA was missing the resize for gradInput