### PR TITLE
Raise error when each channel only has 1 value in batch norm

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -704,7 +704,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
                training=False, momentum=0.1, eps=1e-5):
     size = list(input.size())
     if reduce(mul, size[2:], size[0]) == 1:
-      raise ValueError('Expected more than 1 value per channel, got input size {}'.format(size))
+        raise ValueError('Expected more than 1 value per channel, got input size {}'.format(size))
     f = torch._C._functions.BatchNorm(running_mean, running_var, training, momentum, eps, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3,6 +3,8 @@
 from numbers import Integral
 import warnings
 import math
+from operator import mul
+from functools import reduce
 
 import torch
 from torch._C import _infer_size
@@ -700,6 +702,9 @@ def embedding(input, embedding_matrix,
 
 def batch_norm(input, running_mean, running_var, weight=None, bias=None,
                training=False, momentum=0.1, eps=1e-5):
+    size = list(input.size())
+    if reduce(mul, size[2:], size[0]) == 1:
+      raise ValueError('Expected more than 1 value per channel, got input size {}'.format(size))
     f = torch._C._functions.BatchNorm(running_mean, running_var, training, momentum, eps, torch.backends.cudnn.enabled)
     return f(input, weight, bias)
 


### PR DESCRIPTION
Fixes #1381 by raising error when a channel observes only 1 value for a batch in batch norm.