### PR TITLE
Basket of JIT fixes

### DIFF
--- a/test/expect/TestJit.test_python_ir.expect
+++ b/test/expect/TestJit.test_python_ir.expect
@@ -4,6 +4,6 @@ graph(%1 : UNKNOWN_TYPE
   %6 : Double(1) = Mul[note=from_pyop, some_value=0](%1, %4), uses = [[%7.i0]];
   %8 : Double(1) = Tanh[note=from_pyop, some_value=0](%6), uses = [[%9.i0]];
   %10 : Double(1) = Sigmoid[note=from_pyop, some_value=0](%8), uses = [[%0.i0]];
-  %11 : UNKNOWN_TYPE = TensorTest[a=<Tensor>](), uses = [];
+  %11 : UNKNOWN_TYPE = TensorTest[a= 1  1  1  1 [ CPUDoubleTensor{2,2} ]](), uses = [];
   return (%10);
 }

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -108,40 +108,7 @@ def set_default_tensor_type(t):
     _C._set_default_tensor_type(Tensor)
 
 
-def set_rng_state(new_state):
-    r"""Sets the random number generator state.
-
-    Args:
-        new_state (torch.ByteTensor): The desired state
-    """
-    default_generator.set_state(new_state)
-
-
-def get_rng_state():
-    r"""Returns the random number generator state as a ByteTensor."""
-    return default_generator.get_state()
-
-
-def manual_seed(seed):
-    r"""Sets the seed for generating random numbers. And returns a
-    `torch._C.Generator` object.
-
-    Args:
-        seed (int or long): The desired seed.
-    """
-    if not torch.cuda._in_bad_fork:
-        torch.cuda.manual_seed_all(seed)
-
-    return default_generator.manual_seed(seed)
-
-
-def initial_seed():
-    r"""Returns the initial seed for generating random numbers as a
-    python `long`.
-    """
-    return default_generator.initial_seed()
-
-
+from .random import set_rng_state, get_rng_state, manual_seed, initial_seed
 from .serialization import save, load
 from ._tensor_str import set_printoptions
 
@@ -341,6 +308,7 @@ import torch.multiprocessing
 import torch.sparse
 import torch.utils.backcompat
 import torch.onnx
+import torch.random
 
 _C._init_names(list(torch._tensor_classes) + list(torch._storage_classes))
 

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -549,6 +549,20 @@ struct StageClosure {
       return std::make_shared<LambdaFunction>(1, [](const variable_list& vars) -> variable_list {
         return {make_variable(vars[0].data().sigmoid(), vars[0].requires_grad())};
       });
+    IR_ELSEIF(AddConstant)
+      auto c = value->f(kvalue);
+      return std::make_shared<LambdaFunction>(1, [c](const variable_list& vars) -> variable_list {
+        return {vars[0].add(c)};
+      });
+    IR_ELSEIF(SubConstant)
+      auto c = value->f(kvalue);
+      return std::make_shared<LambdaFunction>(1, [c](const variable_list& vars) -> variable_list {
+        return {vars[0].sub(c)};
+      });
+    IR_ELSEIF(Neg)
+      return std::make_shared<LambdaFunction>(1, [](const variable_list& vars) -> variable_list {
+        return {vars[0].neg()};
+      });
     IR_ELSEIF(Gemm)
       auto beta = value->f(kbeta);
       auto alpha = value->f(kalpha);

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -541,6 +541,14 @@ struct StageClosure {
       return std::make_shared<LambdaFunction>(1, [shape](const variable_list& vars) -> variable_list {
         return {make_variable(vars[0].data().view(shape), vars[0].requires_grad())};
       });
+    IR_ELSEIF(Tanh)
+      return std::make_shared<LambdaFunction>(1, [](const variable_list& vars) -> variable_list {
+        return {make_variable(vars[0].data().tanh(), vars[0].requires_grad())};
+      });
+    IR_ELSEIF(Sigmoid)
+      return std::make_shared<LambdaFunction>(1, [](const variable_list& vars) -> variable_list {
+        return {make_variable(vars[0].data().sigmoid(), vars[0].requires_grad())};
+      });
     IR_ELSEIF(Gemm)
       auto beta = value->f(kbeta);
       auto alpha = value->f(kalpha);

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -29,6 +29,7 @@ _(FusionGroup) \
 _(Split) \
 _(Gemm) \
 _(AddConstant) \
+_(SubConstant) \
 _(Transpose) \
 _(Reshape) \
 _(split) \

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -1,9 +1,10 @@
-#include <iostream>
-#include <sstream>
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/utils/pybind.h"
+
+#include <iostream>
+#include <sstream>
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -33,7 +33,7 @@ struct TraceEval : autograd::Eval {
     }
   }
 
-  virtual variable_list apply(const variable_list& inputs) {
+  virtual variable_list apply(const variable_list& inputs) override {
     auto should_trace = !flag.test_and_set();
     if (should_trace) enterTrace(inputs);
     auto outputs = Eval::apply(inputs);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -124,7 +124,6 @@ def compile(arg=None, verify=False, **kwargs):
         >>> def f(x);
         >>>     return x * 2
     """
-    # TODO: handle decorating a class (not an instance)
     def _compile(arg):
         if inspect.isclass(arg):
             if issubclass(arg, _CompiledMixin):

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,4 +1,6 @@
 import torch
+import contextlib
+import warnings
 
 from torch._C import default_generator
 
@@ -37,3 +39,72 @@ def initial_seed():
     python `long`.
     """
     return default_generator.initial_seed()
+
+
+_fork_rng_warned_already = False
+
+
+@contextlib.contextmanager
+def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices"):
+    """
+    Forks the RNG, so that when you return, the RNG is reset
+    to the state that it was previously in.
+
+    Arguments:
+        devices (iterable of CUDA IDs): CUDA devices for which to fork
+            the RNG.  CPU RNG state is always forked.  By default, fork_rng operates
+            on all devices, but will emit a warning if your machine has a lot
+            of devices, since this function will run very slowly in that case.
+            If you explicitly specify devices, this warning will be supressed
+        enabled (bool): if False, the RNG is not forked.  This is a convenience
+            argument for easily disabling the context manager without having
+            to reindent your Python code.
+    """
+
+    import torch.cuda
+    global _fork_rng_warned_already
+
+    # Internal arguments:
+    #   _caller: the function which called fork_rng, which the user used
+    #   _devices_kw: the devices keyword of _caller
+
+    if not enabled:
+        yield
+        return
+
+    if devices is None:
+        num_devices = torch.cuda.device_count()
+        if num_devices > 1 and not _fork_rng_warned_already:
+            warnings.warn(
+                ("CUDA reports that you have {num_devices} available devices, and you "
+                 "have used {caller} without explicitly specifying which devices are being used. "
+                 "For safety, we initialize *every* CUDA device by default, which "
+                 "can be quite slow if you have a lot of GPUs.  If you know that you are only "
+                 "making use of a few CUDA devices, set the environment variable CUDA_VISIBLE_DEVICES "
+                 "or the '{devices_kw}' keyword argument of {caller} with the set of devices "
+                 "you are actually using.  For example, if you are using CPU only, "
+                 "set CUDA_VISIBLE_DEVICES= or devices=[]; if you are using "
+                 "GPU 0 only, set CUDA_VISIBLE_DEVICES=0 or devices=[0].  To initialize "
+                 "all devices and suppress this warning, set the '{devices_kw}' keyword argument "
+                 "to `range(torch.cuda.device_count())`."
+                 ).format(num_devices=num_devices, caller=_caller, devices_kw=_devices_kw))
+            _fork_rng_warned_already = True
+        devices = list(range(num_devices))
+    else:
+        # Protect against user passing us a generator; we need to traverse this
+        # multiple times but a generator will be exhausted upon first traversal
+        devices = list(devices)
+
+    cpu_rng_state = torch.get_rng_state()
+    gpu_rng_states = []
+    for device in devices:
+        with torch.cuda.device(device):
+            gpu_rng_states.append(torch.cuda.get_rng_state())
+
+    try:
+        yield
+    finally:
+        torch.set_rng_state(cpu_rng_state)
+        for device, gpu_rng_state in zip(devices, gpu_rng_states):
+            with torch.cuda.device(device):
+                torch.cuda.set_rng_state(gpu_rng_state)

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,0 +1,39 @@
+import torch
+
+from torch._C import default_generator
+
+
+def set_rng_state(new_state):
+    r"""Sets the random number generator state.
+
+    Args:
+        new_state (torch.ByteTensor): The desired state
+    """
+    default_generator.set_state(new_state)
+
+
+def get_rng_state():
+    r"""Returns the random number generator state as a ByteTensor."""
+    return default_generator.get_state()
+
+
+def manual_seed(seed):
+    r"""Sets the seed for generating random numbers. And returns a
+    `torch._C.Generator` object.
+
+    Args:
+        seed (int or long): The desired seed.
+    """
+    import torch.cuda
+
+    if not torch.cuda._in_bad_fork:
+        torch.cuda.manual_seed_all(seed)
+
+    return default_generator.manual_seed(seed)
+
+
+def initial_seed():
+    r"""Returns the initial seed for generating random numbers as a
+    python `long`.
+    """
+    return default_generator.initial_seed()


### PR DESCRIPTION
Executive summary:

- IR pretty-printing now prints small tensors
- We now can execute Tanh, Sigmoid, AddConstant, SubConstant and Neg in JIT execution
- `verify=True` now actually does something for forwards verification (but this might get obsoleted soon)
- New `torch.random` module for the random seeding functions originally in `torch`
- New `torch.random.fork_rng` for forking the RNG state

CC @zdevito, @apaszke 