### PR TITLE
Correct padding docs of 3D modules

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -303,7 +303,7 @@ class Conv3d(_ConvNd):
         out_channels (int): Number of channels produced by the convolution
         kernel_size (int or tuple): Size of the convolving kernel
         stride (int or tuple, optional): Stride of the convolution. Default: 1
-        padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
+        padding (int or tuple, optional): Zero-padding added to all three sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
         bias (bool, optional): If True, adds a learnable bias to the output. Default: True
@@ -612,7 +612,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         out_channels (int): Number of channels produced by the convolution
         kernel_size (int or tuple): Size of the convolving kernel
         stride (int or tuple, optional): Stride of the convolution. Default: 1
-        padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
+        padding (int or tuple, optional): Zero-padding added to all three sides of the input. Default: 0
         output_padding (int or tuple, optional): Zero-padding added to one side of the output. Default: 0
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
         bias (bool, optional): If True, adds a learnable bias to the output. Default: True

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -542,7 +542,7 @@ class MaxPool3d(Module):
     Args:
         kernel_size: the size of the window to take a max over
         stride: the stride of the window. Default value is :attr:`kernel_size`
-        padding: implicit zero padding to be added on both sides
+        padding: implicit zero padding to be added on all three sides
         dilation: a parameter that controls the stride of elements in the window
         return_indices: if True, will return the max indices along with the outputs.
                         Useful when Unpooling later


### PR DESCRIPTION
3D modules apply padding on all three sides. "Both" doesn't make sense here.
I used the wording of the AvgPool3d docstring, where it was already correct.