### PR TITLE
Make ATen able to wrap Bernoulli

### DIFF
--- a/torch/csrc/Declarations.cwrap
+++ b/torch/csrc/Declarations.cwrap
@@ -4332,7 +4332,7 @@
     - function
   before_call:
     THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg2)->cdata);
-  cname: BERNOULLI_TENSOR
+  cname: bernoulli_Tensor
   arguments:
     - arg: THTensor* output
       output: True

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -265,11 +265,6 @@
     - double p
 ]]
 
-#define THDoubleTensor_BERNOULLI_TENSOR THDoubleTensor_bernoulli_DoubleTensor
-#define THFloatTensor_BERNOULLI_TENSOR THFloatTensor_bernoulli_FloatTensor
-#define THCudaDoubleTensor_BERNOULLI_TENSOR THCudaDoubleTensor_bernoulli_DoubleTensor
-#define THCudaTensor_BERNOULLI_TENSOR THCudaTensor_bernoulli_FloatTensor
-
 [[
   name: bernoulli
   types:
@@ -285,7 +280,7 @@
   before_call:
     CPU: THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg2)->cdata);
     CUDA: THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg1)->cdata);
-  cname: BERNOULLI_TENSOR
+  cname: bernoulli_Tensor
   arguments:
     - arg: THTensor* output
       output: True
@@ -295,11 +290,6 @@
       kwarg_only: True
     - THTensor* self
 ]]
-
-#undef THDoubleTensor_BERNOULLI_TENSOR
-#undef THFloatTensor_BERNOULLI_TENSOR
-#undef THCudaDoubleTensor_BERNOULLI_TENSOR
-#undef THCudaTensor_BERNOULLI_TENSOR
 
 [[
   name: bernoulli_

--- a/torch/lib/ATen/function_wrapper.py
+++ b/torch/lib/ATen/function_wrapper.py
@@ -8,7 +8,7 @@ else:
     string_type = basestring
 
 # temporary things we cannot handle
-EXCLUDE_PATTERN = "bernoulli.*|normal.*|exponential.*|random.*|arange.*"
+EXCLUDE_PATTERN = "normal.*|exponential.*|random.*|arange.*"
 # what has to be done to add a Operation ...
 # 1. if broadcasting or without the full list of arguments, add a non-virtual
 #    declaration under Type.h
@@ -103,6 +103,8 @@ TYPE_FORMAL_GENERIC = {
     'accreal': 'Scalar',
     'real': 'Scalar',
     'long': 'int64_t',
+    'BackendFloatTensor*': 'Tensor &',
+    'BackendDoubleTensor*': 'Tensor &',
 }
 
 DYNAMIC_TYPE = {
@@ -117,6 +119,8 @@ DYNAMIC_TYPE = {
     'accreal': 'accreal',
     'real': 'real',
     'long': 'int64_t',
+    'BackendFloatTensor*': 'FloatTensor',
+    'BackendDoubleTensor*': 'DoubleTensor',
 }
 
 TYPE_RETURN = {
@@ -142,6 +146,12 @@ CHECKED_CAST = {
     'THIntegerTensor*':
         CodeTemplate(
             'checked_cast<${Backend}IntTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
+    'BackendFloatTensor*':
+        CodeTemplate(
+            'checked_cast<${Backend}FloatTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
+    'BackendDoubleTensor*':
+        CodeTemplate(
+            'checked_cast<${Backend}DoubleTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
     'THStorage*': CodeTemplate('checked_cast<${Storage}>(&${arg_name},"${arg_name}",${arg_pos}, false)'),
     'THGenerator*': CodeTemplate('check_generator<${Backend}Generator>(&${arg_name})'),
     'THSize*': CodeTemplate('THLongStorageView::make(${arg_name}, true)'),
@@ -158,6 +168,8 @@ CHECKED_USE = {
     'THIndexTensor*': '{}_->tensor',
     'THBoolTensor*': '{}_->tensor',
     'THIntegerTensor*': '{}_->tensor',
+    'BackendFloatTensor*': '{}_->tensor',
+    'BackendDoubleTensor*': '{}_->tensor',
     'THStorage*': '{}_->storage',
     'THGenerator*': '{}_->generator',
     'TensorList': "{0}_.data(), {0}_.size()",

--- a/torch/lib/ATen/templates/TypeDerived.cpp
+++ b/torch/lib/ATen/templates/TypeDerived.cpp
@@ -5,6 +5,8 @@
 #include "ATen/${Backend}ByteTensor.h"
 #include "ATen/${Backend}IntTensor.h"
 #include "ATen/${Backend}LongTensor.h"
+#include "ATen/${Backend}FloatTensor.h"
+#include "ATen/${Backend}DoubleTensor.h"
 #include "ATen/${SparseTensor}.h"
 #include "ATen/Utils.h"
 #include "ATen/WrapDimUtils.h"

--- a/torch/lib/TH/generic/THTensorRandom.c
+++ b/torch/lib/TH/generic/THTensorRandom.c
@@ -55,6 +55,11 @@ void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, 
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
+void THTensor_(bernoulli_Tensor)(THTensor *self, THGenerator *_generator, THTensor *p)
+{
+  TH_TENSOR_APPLY2(real, self, real , p, *self_data = (real)THRandom_bernoulli(_generator, (double)*p_data););
+}
+
 void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_uniform(_generator, a, b););
@@ -116,13 +121,13 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
   THTensor_(resize1d)(q, inputsize);
   real *q_data = THTensor_(data)(q);
   int64_t *J_data = THLongTensor_data(J);
-      
+
   for (i = 0; i < inputsize; i++)
     {
       THTensor_fastSet1d(J, i, 0L);
       real val = THTensor_fastGet1d(probs, i);
       THTensor_fastSet1d(q, i, inputsize*val);
-      
+
       if (inputsize * val < 1.0)
         {
           THTensor_fastSet1d(smaller, small_c, i);
@@ -143,7 +148,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     {
       large = THTensor_fastGet1d(larger, large_c-1);
       small = THTensor_fastGet1d(smaller, small_c-1);
-      
+
       THTensor_fastSet1d(J, small, large);
       q_data[large * q->stride[0]] -= 1.0 - THTensor_fastGet1d(q, small);
 
@@ -173,7 +178,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
   THArgCheckWithCleanup((q_min > 0),
                         THCleanup(THLongTensor_free(smaller); THLongTensor_free(larger);), 2,
                         "q_min is less than 0");
-  
+
   if (q_max > 1)
     {
       for (i=0; i < inputsize; i++)
@@ -183,7 +188,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     }
   for (i=0; i < inputsize; i++)
     {
-      // sometimes an large index isn't added to J. 
+      // sometimes an large index isn't added to J.
       // fix it by making the probability 1 so that J isn't indexed.
       if(J_data[i] <= 0)
         q_data[i] = 1.0;
@@ -206,7 +211,7 @@ void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator
       _q = THTensor_fastGet1d(q, rand_ind);
 
       _mask = THRandom_bernoulli(_generator, _q);
-      
+
       J_sample = THTensor_fastGet1d(J, rand_ind);
 
       sample_idx = J_sample*(1 -_mask) + (rand_ind+1L) * _mask;

--- a/torch/lib/TH/generic/THTensorRandom.h
+++ b/torch/lib/TH/generic/THTensorRandom.h
@@ -11,6 +11,7 @@ TH_API void THTensor_(bernoulli_FloatTensor)(THTensor *self, THGenerator *_gener
 TH_API void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, THDoubleTensor *p);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+TH_API void THTensor_(bernoulli_Tensor)(THTensor *self, THGenerator *_generator, THTensor *p);
 TH_API void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b);
 TH_API void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
 TH_API void THTensor_(normal_means)(THTensor *self, THGenerator *gen, THTensor *means, double stddev);

--- a/torch/lib/THC/generic/THCTensorRandom.h
+++ b/torch/lib/THC/generic/THCTensorRandom.h
@@ -20,6 +20,10 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
 
 #endif
 
+#if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
+THC_API void THCTensor_(bernoulli_Tensor)(struct THCState *state, THCTensor *self, THCTensor *p);
+#endif
+
 THC_API void THCTensor_(bernoulli)(struct THCState *state, THCTensor *self, double p);
 THC_API void THCTensor_(bernoulli_FloatTensor)(struct THCState *state, THCTensor *self, THCudaTensor *p);
 THC_API void THCTensor_(bernoulli_DoubleTensor)(struct THCState *state, THCTensor *self, THCudaDoubleTensor *p);


### PR DESCRIPTION
I'm not super elated about how I went about this. I essentially needed to do two things:

1. Add a new function `bernoulli_Tensor` that is defined for Float/Double Tensors, to replace the need for macros in the cwrap
2. Add support for `BackendFloatTensor` and `BackendDoubleTensor` to ATen. These are hacks needed to get an appropriately typed Tensor for the PyTorch bernoulli wrapping, that I had to also handle in ATen

Needed to fully finish off all of the unsupported methods, combined with https://github.com/zdevito/ATen/pull/76.

**Caveat:** This doesn't bind (in ATen) taking a `DoubleTensor` as a probability vector.