### PR TITLE
Make cuDNN use the current stream

### DIFF
--- a/torch/csrc/cudnn/AffineGridGenerator.cpp
+++ b/torch/csrc/cudnn/AffineGridGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include "Descriptors.h"
 #include "Types.h"
+#include "Handles.h"
 
 
 namespace torch { namespace cudnn {
@@ -49,6 +50,7 @@ void cudnn_affine_grid_generator_forward(
     THVoidTensor* theta, THVoidTensor* grid,
     int N, int C, int H, int W)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, theta, grid);
   checkIOSize(theta, grid, N, H, W);  
   SpatialTransformerDescriptor desc;
@@ -63,6 +65,7 @@ void cudnn_affine_grid_generator_backward(
     THVoidTensor* grad_theta, THVoidTensor* grad_grid,
     int N, int C, int H, int W)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, grad_theta, grad_grid);
   checkIOSize(grad_theta, grad_grid, N, H, W);
   SpatialTransformerDescriptor desc;

--- a/torch/csrc/cudnn/BatchNorm.cpp
+++ b/torch/csrc/cudnn/BatchNorm.cpp
@@ -2,6 +2,7 @@
 
 #include "Descriptors.h"
 #include "Types.h"
+#include "Handles.h"
 
 
 namespace torch { namespace cudnn {
@@ -62,6 +63,7 @@ void cudnn_batch_norm_forward(
     THVoidTensor* save_mean, THVoidTensor* save_var, bool training,
     double exponential_average_factor, double epsilon)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, input, output, weight, bias, running_mean, running_var,
       save_mean, save_var);
   cudnnBatchNormMode_t mode;
@@ -128,6 +130,7 @@ void cudnn_batch_norm_backward(
     THVoidTensor* save_mean, THVoidTensor* save_var, bool training,
     double epsilon)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, input, grad_output, grad_input, grad_weight, grad_bias, weight,
       running_mean, running_var, save_mean, save_var);
   cudnnBatchNormMode_t mode;

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -3,6 +3,7 @@
 #include "THC/THC.h"
 #include "Exceptions.h"
 #include "Types.h"
+#include "Handles.h"
 
 #include <cudnn.h>
 #include <functional>
@@ -493,6 +494,7 @@ void cudnn_convolution_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* output,
     Convolution* info, bool benchmark)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, input, weight, output);
   int groups = info->groups;
 
@@ -528,6 +530,7 @@ void cudnn_convolution_add_bias(
     THVoidTensor* bias, THVoidTensor* output,
     Convolution* info)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, bias, output);
   CHECK_ARG(output->nDimension <= 5);
   TensorDescriptor& bdesc = info->bdesc;
@@ -549,6 +552,7 @@ void cudnn_convolution_backward_data(
     THVoidTensor* gradOutput, THVoidTensor* gradInput, THVoidTensor* weight,
     Convolution* info, bool benchmark)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, gradOutput, gradInput, weight);
   int groups = info->params.groups;
 
@@ -583,6 +587,7 @@ void cudnn_convolution_backward_filter(
     THVoidTensor* gradOutput, THVoidTensor* input, THVoidTensor* gradWeight,
     Convolution* info, bool benchmark)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, gradOutput, input, gradWeight);
   int groups = info->params.groups;
 
@@ -623,6 +628,7 @@ void cudnn_convolution_backward_bias(
     THCState* state, cudnnHandle_t handle, cudnnDataType_t dataType,
     THVoidTensor* gradOutput, THVoidTensor* gradBias, Convolution* info)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, gradOutput, gradBias);
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
@@ -639,6 +645,7 @@ Convolution* cudnn_convolution_full_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* bias, THVoidTensor* output,
     std::vector<int> pad, std::vector<int> stride, std::vector<int> dilation, int groups, bool benchmark)
 {
+    useCurrentStream(handle, state);
     std::unique_ptr<Convolution> info(new Convolution(
         dataType, input, weight, bias, output, pad, stride, dilation, groups, false));
     cudnn_convolution_forward(
@@ -655,6 +662,7 @@ Convolution* cudnn_convolution_transpose_full_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* bias, THVoidTensor* output,
     std::vector<int> pad, std::vector<int> stride, std::vector<int> dilation, int groups, bool benchmark)
 {
+    useCurrentStream(handle, state);
     std::unique_ptr<Convolution> info(new Convolution(
         dataType, output, weight, bias, input, pad, stride, dilation, groups, true));
     cudnn_convolution_backward_data(

--- a/torch/csrc/cudnn/GridSampler.cpp
+++ b/torch/csrc/cudnn/GridSampler.cpp
@@ -2,6 +2,7 @@
 
 #include "Descriptors.h"
 #include "Types.h"
+#include "Handles.h"
 
 
 namespace torch { namespace cudnn {
@@ -67,6 +68,7 @@ void cudnn_grid_sampler_forward(
     THCState* state, cudnnHandle_t handle, cudnnDataType_t dataType,
     THVoidTensor* input, THVoidTensor* grid, THVoidTensor* output)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, input, output, grid);
   checkGridSize(grid, input);
   checkIOSize(input, output, grid);
@@ -94,6 +96,7 @@ void cudnn_grid_sampler_backward(
     THVoidTensor* grid, THVoidTensor* grad_grid,
     THVoidTensor* grad_output)
 {
+  useCurrentStream(handle, state);
   assertSameGPU(dataType, input, grad_output, grad_input, grid, grad_grid);
   checkGridSize(grid, input);
   checkGridSize(grad_grid, input);

--- a/torch/csrc/cudnn/Handles.cpp
+++ b/torch/csrc/cudnn/Handles.cpp
@@ -36,4 +36,20 @@ cudnnHandle_t getCudnnHandle()
   return handles[device].handle;
 }
 
+
+void useCurrentStream(cudnnHandle_t handle, THCState *state)
+{
+  cudnnStatus_t status = cudnnSetStream(
+      handle,
+      THCState_getCurrentStream(state));
+  if (status == CUDNN_STATUS_BAD_PARAM) {
+    std::cerr << "WARNING: invalid handle\n";
+  } else if (status == CUDNN_STATUS_MAPPING_ERROR) {
+    std::cerr <<
+        "WARNING: Mismatch between user stream and the cuDNN handle context\n";
+  } else if (status != CUDNN_STATUS_SUCCESS) {
+    std::cerr << "WARNING: Could not set cuDNN to use current stream\n";
+  }
+}
+
 }} // namespace torch::cudnn

--- a/torch/csrc/cudnn/Handles.h
+++ b/torch/csrc/cudnn/Handles.h
@@ -2,10 +2,13 @@
 #define THP_CUDNN_HANDLE_INC
 
 #include <cudnn.h>
+#include "THC/THC.h"
+#include "Types.h"
 
 namespace torch { namespace cudnn {
 
 cudnnHandle_t getCudnnHandle();
+void useCurrentStream(cudnnHandle_t handle, THCState *state);
 
 }} // namespace
 


### PR DESCRIPTION
### Summary
cudnnSetStream calls were missing in the cudnn bindings, resulting in cudnn not using the current stream. This makes it so that the cudnn functions use the current stream. #2523

### Test plan
Create a [test file](https://gist.github.com/zou3519/47f961bb0745ff8fea04a603ac653431) (adopted from [here](https://discuss.pytorch.org/t/torch-nn-in-context-of-a-cuda-stream/6304))

Ran it through `nvprof`. Asserted that the cudnn functions did not use the current stream before changes. Asserted that the cudnn functions did use the current stream after changes.

Before:
![image](https://user-images.githubusercontent.com/5652049/31227505-1388a89e-a9a8-11e7-873d-153433dc6fc1.png)

After:
![image](https://user-images.githubusercontent.com/5652049/31227514-1b2994aa-a9a8-11e7-87f1-a12d80e17eb5.png)

