### PR TITLE
Cleanup: remove useCurrentStream function

### DIFF
--- a/torch/csrc/cudnn/AffineGridGenerator.cpp
+++ b/torch/csrc/cudnn/AffineGridGenerator.cpp
@@ -50,7 +50,7 @@ void cudnn_affine_grid_generator_forward(
     THVoidTensor* theta, THVoidTensor* grid,
     int N, int C, int H, int W)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, theta, grid);
   checkIOSize(theta, grid, N, H, W);  
   SpatialTransformerDescriptor desc;
@@ -65,7 +65,7 @@ void cudnn_affine_grid_generator_backward(
     THVoidTensor* grad_theta, THVoidTensor* grad_grid,
     int N, int C, int H, int W)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, grad_theta, grad_grid);
   checkIOSize(grad_theta, grad_grid, N, H, W);
   SpatialTransformerDescriptor desc;

--- a/torch/csrc/cudnn/BatchNorm.cpp
+++ b/torch/csrc/cudnn/BatchNorm.cpp
@@ -2,7 +2,6 @@
 
 #include "Descriptors.h"
 #include "Types.h"
-#include "Handles.h"
 
 
 namespace torch { namespace cudnn {
@@ -63,7 +62,7 @@ void cudnn_batch_norm_forward(
     THVoidTensor* save_mean, THVoidTensor* save_var, bool training,
     double exponential_average_factor, double epsilon)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, input, output, weight, bias, running_mean, running_var,
       save_mean, save_var);
   cudnnBatchNormMode_t mode;
@@ -130,7 +129,7 @@ void cudnn_batch_norm_backward(
     THVoidTensor* save_mean, THVoidTensor* save_var, bool training,
     double epsilon)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, input, grad_output, grad_input, grad_weight, grad_bias, weight,
       running_mean, running_var, save_mean, save_var);
   cudnnBatchNormMode_t mode;

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -3,7 +3,6 @@
 #include "THC/THC.h"
 #include "Exceptions.h"
 #include "Types.h"
-#include "Handles.h"
 
 #include <cudnn.h>
 #include <functional>
@@ -494,7 +493,7 @@ void cudnn_convolution_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* output,
     Convolution* info, bool benchmark)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, input, weight, output);
   int groups = info->groups;
 
@@ -530,7 +529,7 @@ void cudnn_convolution_add_bias(
     THVoidTensor* bias, THVoidTensor* output,
     Convolution* info)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, bias, output);
   CHECK_ARG(output->nDimension <= 5);
   TensorDescriptor& bdesc = info->bdesc;
@@ -552,7 +551,7 @@ void cudnn_convolution_backward_data(
     THVoidTensor* gradOutput, THVoidTensor* gradInput, THVoidTensor* weight,
     Convolution* info, bool benchmark)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, gradOutput, gradInput, weight);
   int groups = info->params.groups;
 
@@ -587,7 +586,7 @@ void cudnn_convolution_backward_filter(
     THVoidTensor* gradOutput, THVoidTensor* input, THVoidTensor* gradWeight,
     Convolution* info, bool benchmark)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, gradOutput, input, gradWeight);
   int groups = info->params.groups;
 
@@ -628,7 +627,7 @@ void cudnn_convolution_backward_bias(
     THCState* state, cudnnHandle_t handle, cudnnDataType_t dataType,
     THVoidTensor* gradOutput, THVoidTensor* gradBias, Convolution* info)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, gradOutput, gradBias);
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
@@ -645,7 +644,7 @@ Convolution* cudnn_convolution_full_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* bias, THVoidTensor* output,
     std::vector<int> pad, std::vector<int> stride, std::vector<int> dilation, int groups, bool benchmark)
 {
-    useCurrentStream(handle, state);
+    CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
     std::unique_ptr<Convolution> info(new Convolution(
         dataType, input, weight, bias, output, pad, stride, dilation, groups, false));
     cudnn_convolution_forward(
@@ -662,7 +661,7 @@ Convolution* cudnn_convolution_transpose_full_forward(
     THVoidTensor* input, THVoidTensor* weight, THVoidTensor* bias, THVoidTensor* output,
     std::vector<int> pad, std::vector<int> stride, std::vector<int> dilation, int groups, bool benchmark)
 {
-    useCurrentStream(handle, state);
+    CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
     std::unique_ptr<Convolution> info(new Convolution(
         dataType, output, weight, bias, input, pad, stride, dilation, groups, true));
     cudnn_convolution_backward_data(

--- a/torch/csrc/cudnn/GridSampler.cpp
+++ b/torch/csrc/cudnn/GridSampler.cpp
@@ -2,7 +2,6 @@
 
 #include "Descriptors.h"
 #include "Types.h"
-#include "Handles.h"
 
 
 namespace torch { namespace cudnn {
@@ -68,7 +67,7 @@ void cudnn_grid_sampler_forward(
     THCState* state, cudnnHandle_t handle, cudnnDataType_t dataType,
     THVoidTensor* input, THVoidTensor* grid, THVoidTensor* output)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, input, output, grid);
   checkGridSize(grid, input);
   checkIOSize(input, output, grid);
@@ -96,7 +95,7 @@ void cudnn_grid_sampler_backward(
     THVoidTensor* grid, THVoidTensor* grad_grid,
     THVoidTensor* grad_output)
 {
-  useCurrentStream(handle, state);
+  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
   assertSameGPU(dataType, input, grad_output, grad_input, grid, grad_grid);
   checkGridSize(grid, input);
   checkGridSize(grad_grid, input);

--- a/torch/csrc/cudnn/Handles.cpp
+++ b/torch/csrc/cudnn/Handles.cpp
@@ -36,10 +36,4 @@ cudnnHandle_t getCudnnHandle()
   return handles[device].handle;
 }
 
-
-void useCurrentStream(cudnnHandle_t handle, THCState *state)
-{
-  CHECK(cudnnSetStream(handle, THCState_getCurrentStream(state)));
-}
-
 }} // namespace torch::cudnn

--- a/torch/csrc/cudnn/Handles.h
+++ b/torch/csrc/cudnn/Handles.h
@@ -2,13 +2,10 @@
 #define THP_CUDNN_HANDLE_INC
 
 #include <cudnn.h>
-#include "THC/THC.h"
-#include "Types.h"
 
 namespace torch { namespace cudnn {
 
 cudnnHandle_t getCudnnHandle();
-void useCurrentStream(cudnnHandle_t handle, THCState *state);
 
 }} // namespace
 


### PR DESCRIPTION
Because this function is a one-liner, delete it and replace all instances of useCurrentStream with its previous definition in the code.

### Test Plan
`python setup.py build develop`