### PR TITLE
Fix cudnn grid_sample backward for implicit gradOutput

### DIFF
--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -35,8 +35,9 @@ class GridSampler(Function):
             if 0 in input.stride():
                 input = input.contiguous()
             # Sometimes grad_output is a scalar (like 1) expanded as a tensor.
-            # cudnn requires a full tensor in memory so we give it one.
-            grad_output = grad_output.contiguous()
+            # cudnn requires a tensor that has non-zero strides.
+            if 0 in grad_output.stride():
+                grad_output = grad_output.contiguous()
             torch._C._cudnn_grid_sampler_backward(input, grad_input,
                                                   grid, grad_grid,
                                                   grad_output)

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -34,6 +34,9 @@ class GridSampler(Function):
             grid = grid.contiguous()
             if 0 in input.stride():
                 input = input.contiguous()
+            # Sometimes grad_output is a scalar (like 1) expanded as a tensor.
+            # cudnn requires a full tensor in memory so we give it one.
+            grad_output = grad_output.contiguous()
             torch._C._cudnn_grid_sampler_backward(input, grad_input,
                                                   grid, grad_grid,
                                                   grad_output)


### PR DESCRIPTION
### Summary
Fixes https://github.com/pytorch/pytorch/issues/2307.

The bug is that the cudnn function only accepts tensors that have positive stride. Unfortunately, when a scalar is expanded into a tensor (which is probably how the implicit grad output is implemented), the stride is all 0's. This makes it so that if the strides are indeed all 0's, grad_output is converted to a normal tensor that has positive strides.

### Test Plan
`test/run_tests.sh`
Run the previously offending code and assert that nothing errors:
```
import torch
x = torch.cuda.FloatTensor(1, 1, 16384, 16384)
x = torch.autograd.Variable(x, requires_grad=True)
y = x.expand(2, x.size(1), x.size(2), x.size(3))
grid = torch.rand(2, 1, 1, 2)
import torch.nn.functional as F
z = F.grid_sample(y, torch.autograd.Variable(grid.cuda()))
z.sum().backward()
```