### PR TITLE
Fix THC triu/tril

### DIFF
--- a/torch/lib/THC/generic/THCTensorMathPairwise.cu
+++ b/torch/lib/THC/generic/THCTensorMathPairwise.cu
@@ -199,7 +199,7 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
 
   int64_t stride0 = src->stride[0];
   int64_t stride1 = src->stride[1];
-  real *start = THCTensor_(data)(state, src) + src->storageOffset;
+  real *start = THCTensor_(data)(state, src);
 
   TensorTriOp<real, 0> op(start, stride0, stride1, k);
 
@@ -232,7 +232,7 @@ void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
 
   int64_t stride0 = src->stride[0];
   int64_t stride1 = src->stride[1];
-  real *start = THCTensor_(data)(state, src) + src->storageOffset;
+  real *start = THCTensor_(data)(state, src);
 
   TensorTriOp<real, 1> op(start, stride0, stride1, k);
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/pytorch/pytorch/issues/2749

The bug is that `THCTensor_(data)` already takes into account `storageOffset` so there is no need to add them together.

### Test Plan
Run the offending code and assert that the output is expected (triangular)
```
import torch
x = torch.ones(3,4,4).cuda()
[t.triu() for t in x]
[t.tril() for t in x]
```