### PR TITLE
Fix isContiguous

### DIFF
--- a/torch/lib/THC/generic/THCTensor.c
+++ b/torch/lib/THC/generic/THCTensor.c
@@ -635,7 +635,7 @@ int THCTensor_(isContiguous)(THCState *state, const THCTensor *self)
   int d;
   for(d = self->nDimension-1; d >= 0; d--)
   {
-    if(self->size[d] != 1)
+    if(self->size[d] != 1 || d == 0)
     {
       if(self->stride[d] == z)
         z *= self->size[d];


### PR DESCRIPTION
Fixes #2996 .

Currently the isContiguous doesn't perform size check at dim 0 if `size[0] == 1`, causing tensors non-contiguous at dim 1 to incorrectly pass the check.