### PR TITLE
Introduce scopes during tracing

### DIFF
--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(20, 16, 50, 40)
       %1 : Double(13, 16, 3, 3)) {
-  %2 : UNKNOWN_TYPE = Undefined(), scope: Conv2d;
-  %3 : Double(20, 13, 48, 38), %4 : Handle = CppOp[ConvForward](%0, %1, %2), scope: Conv2d;
+  %2 : UNKNOWN_TYPE = Undefined(), scope: Conv2d
+  %3 : Double(20, 13, 48, 38), %4 : Handle = CppOp[ConvForward](%0, %1, %2), scope: Conv2d
   return (%3);
 }

--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(20, 16, 50, 40)
       %1 : Double(13, 16, 3, 3)) {
-  %2 : UNKNOWN_TYPE = Undefined()
-  %3 : Double(20, 13, 48, 38), %4 : Handle = CppOp[ConvForward](%0, %1, %2)
+  %2 : UNKNOWN_TYPE = Undefined(), scope: Conv2d;
+  %3 : Double(20, 13, 48, 38), %4 : Handle = CppOp[ConvForward](%0, %1, %2), scope: Conv2d;
   return (%3);
 }

--- a/test/expect/TestJit.test_dropout.expect
+++ b/test/expect/TestJit.test_dropout.expect
@@ -1,4 +1,4 @@
 graph(%0 : Double(2, 2)) {
-  %1 : Double(2, 2), %2 : Handle = ^Dropout(0.6, True, False)(%0)
+  %1 : Double(2, 2), %2 : Handle = ^Dropout(0.6, True, False)(%0), scope: Dropout;
   return (%1);
 }

--- a/test/expect/TestJit.test_dropout.expect
+++ b/test/expect/TestJit.test_dropout.expect
@@ -1,4 +1,4 @@
 graph(%0 : Double(2, 2)) {
-  %1 : Double(2, 2), %2 : Handle = ^Dropout(0.6, True, False)(%0), scope: Dropout;
+  %1 : Double(2, 2), %2 : Handle = ^Dropout(0.6, True, False)(%0), scope: Dropout
   return (%1);
 }

--- a/test/expect/TestJit.test_scopes.expect
+++ b/test/expect/TestJit.test_scopes.expect
@@ -1,12 +1,8 @@
 graph(%0 : Double(1)
       %1 : Double(1)) {
   %2 : Double(1) = add[alpha={1}](%0, %1)
-  %3 : Double(1), %4 : Handle = ^Index(0)(%2)
-  %5 : Double(1), %6 : Handle = ^Index(0)(%2)
-  %7 : Double(1) = mul(%0, %2), scope: Foo
-  %8 : Double(1), %9 : Handle = ^Index(0)(%7), scope: Foo
-  %10 : Double(1), %11 : Handle = ^Index(0)(%7), scope: Foo
-  %12 : Double(1) = tanh(%7), scope: Foo/Bar
-  %13 : Double(1) = sigmoid(%12), scope: Foo
-  return (%13);
+  %3 : Double(1) = mul(%0, %2), scope: Foo
+  %4 : Double(1) = tanh(%3), scope: Foo/Bar
+  %5 : Double(1) = sigmoid(%4), scope: Foo
+  return (%5);
 }

--- a/test/expect/TestJit.test_scopes.expect
+++ b/test/expect/TestJit.test_scopes.expect
@@ -1,0 +1,12 @@
+graph(%1 : Double(1)
+      %2 : Double(1)) {
+  %3 : Double(1) = add[alpha={1}](%1, %2), uses = [%4.i0, %7.i0, %10.i1];
+  %5 : Double(1), %6 : Handle = ^Index(0)(%3), uses = [[], []];
+  %8 : Double(1), %9 : Handle = ^Index(0)(%3), uses = [[], []];
+  %10 : Double(1) = mul(%1, %3), uses = [%11.i0, %14.i0, %17.i0], scope: Foo;
+  %12 : Double(1), %13 : Handle = ^Index(0)(%10), uses = [[], []], scope: Foo;
+  %15 : Double(1), %16 : Handle = ^Index(0)(%10), uses = [[], []], scope: Foo;
+  %17 : Double(1) = tanh(%10), uses = [%18.i0], scope: Foo/Bar;
+  %18 : Double(1) = sigmoid(%17), uses = [%0.i0], scope: Foo;
+  return (%18);
+}

--- a/test/expect/TestJit.test_scopes.expect
+++ b/test/expect/TestJit.test_scopes.expect
@@ -1,12 +1,12 @@
-graph(%1 : Double(1)
-      %2 : Double(1)) {
-  %3 : Double(1) = add[alpha={1}](%1, %2), uses = [%4.i0, %7.i0, %10.i1];
-  %5 : Double(1), %6 : Handle = ^Index(0)(%3), uses = [[], []];
-  %8 : Double(1), %9 : Handle = ^Index(0)(%3), uses = [[], []];
-  %10 : Double(1) = mul(%1, %3), uses = [%11.i0, %14.i0, %17.i0], scope: Foo;
-  %12 : Double(1), %13 : Handle = ^Index(0)(%10), uses = [[], []], scope: Foo;
-  %15 : Double(1), %16 : Handle = ^Index(0)(%10), uses = [[], []], scope: Foo;
-  %17 : Double(1) = tanh(%10), uses = [%18.i0], scope: Foo/Bar;
-  %18 : Double(1) = sigmoid(%17), uses = [%0.i0], scope: Foo;
-  return (%18);
+graph(%0 : Double(1)
+      %1 : Double(1)) {
+  %2 : Double(1) = add[alpha={1}](%0, %1)
+  %3 : Double(1), %4 : Handle = ^Index(0)(%2)
+  %5 : Double(1), %6 : Handle = ^Index(0)(%2)
+  %7 : Double(1) = mul(%0, %2), scope: Foo
+  %8 : Double(1), %9 : Handle = ^Index(0)(%7), scope: Foo
+  %10 : Double(1), %11 : Handle = ^Index(0)(%7), scope: Foo
+  %12 : Double(1) = tanh(%7), scope: Foo/Bar
+  %13 : Double(1) = sigmoid(%12), scope: Foo
+  return (%13);
 }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -239,7 +239,15 @@ std::ostream& printNode(std::ostream & out, const Node * n, std::vector<const No
       printAttributes(out,n);
     }
   IR_END()
-  out << "(" << n->inputs() << ")\n";
+  out << "(" << n->inputs() << "), uses = [";
+  std::string scopeName = n->scopeName();
+  if (scopeName.empty()) {
+    out << "];\n";
+  }
+  else {
+    out << "], ";
+    out << "scope: " << scopeName << ";\n";
+  }
   return out;
 }
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -239,14 +239,14 @@ std::ostream& printNode(std::ostream & out, const Node * n, std::vector<const No
       printAttributes(out,n);
     }
   IR_END()
-  out << "(" << n->inputs() << "), uses = [";
+  out << "(" << n->inputs() << ")";
   std::string scopeName = n->scopeName();
   if (scopeName.empty()) {
-    out << "];\n";
+    out << "\n";
   }
   else {
-    out << "], ";
-    out << "scope: " << scopeName << ";\n";
+    out << ", ";
+    out << "scope: " << scopeName << "\n";
   }
   return out;
 }

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -71,12 +71,12 @@ struct SourceLocation {
 };
 
 // Scope is a node of a trie that represents the tree of nested scopes.
-// Individual scopes are pushed and popped from TracingState, which holds a
+// Individual scopes are pushed and popped from Graph, which holds a
 // pointer to the current scope. Each Node in Graph holds a pointer
 // to the scope that was current when the node was created.
 // The trie never needs to shrink, it only grows until it is disposed
-// of when TracingState is deallocated. Hence, pointers to scopes held by nodes
-// will always be valid as long as TracingState is alive.
+// of when Graph is deallocated. Hence, pointers to scopes held by nodes
+// will always be valid as long as Graph is alive.
 struct Scope {
 private:
   Scope* parent_;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -198,6 +198,9 @@ public:
   const Node * node() const {
     return node_;
   }
+  Scope* scope();
+  void setScope(Scope* scope);
+  std::string scopeName() const;
   Graph * owningGraph();
   const Graph * owningGraph() const;
   // TODO: make this more const correct
@@ -838,6 +841,18 @@ inline Value::Value(Node * node_, size_t offset_)
   unique_(node_->graph_->next_unique_++),
   stage_(node_->graph_->new_node_stage_) {
   node_->graph_->all_values.emplace(this);
+}
+
+inline Scope* Value::scope() {
+  return node()->scope();
+}
+
+inline void Value::setScope(Scope* scope) {
+  node()->setScope(scope);
+}
+
+inline std::string Value::scopeName() const {
+  return node()->scopeName();
 }
 
 inline Graph * Value::owningGraph() {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -92,9 +92,8 @@ public:
     parent_ = parent;
   }
   Scope* push(Symbol name) {
-    Scope* newScope = new Scope(this, name);
-    children_.push_back(std::unique_ptr<Scope>(newScope));
-    return newScope;
+    children_.push_back(std::unique_ptr<Scope>(new Scope(this, name)));
+    return children_.back().get();
   }
   Scope* parent() {
     if (parent_ == NULL) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -81,7 +81,7 @@ struct Scope {
 private:
   Scope* parent_;
   Symbol name_;
-  std::unordered_set<std::unique_ptr<Scope> > children_;
+  std::vector<std::unique_ptr<Scope> > children_;
 public:
   Scope() {
     name_ = stringToSymbol("");
@@ -93,7 +93,7 @@ public:
   }
   Scope* push(Symbol name) {
     Scope* newScope = new Scope(this, name);
-    children_.insert(std::unique_ptr<Scope>(newScope));
+    children_.push_back(std::unique_ptr<Scope>(newScope));
     return newScope;
   }
   Scope* parent() {
@@ -643,12 +643,6 @@ private:
   Node * const input_;
 
 public:
-  Graph()
-  : next_unique_(0)
-  , new_node_stage_(0)
-  , scope_root_(std::make_shared<Scope>())
-  , current_scope_(scope_root_.get())
-  , output_(initOutput(create(kReturn, 0))), input_(create(kParam, 0)) {}
 
   Graph(std::shared_ptr<Scope> scope_root)
   : next_unique_(0)
@@ -656,6 +650,9 @@ public:
   , scope_root_(scope_root)
   , current_scope_(scope_root_.get())
   , output_(initOutput(create(kReturn, 0))), input_(create(kParam, 0)) {}
+
+  Graph()
+  : Graph( std::make_shared<Scope>()) {}
 
   at::ArrayRef<Value*> inputs() {
     return input_->outputs();

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -31,8 +31,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     throw std::logic_error("ToONNX: tracing state is expired");
   }
 
-  auto new_graph = std::make_shared<Graph>();
-  new_graph->setCurrentScope(state->get_current_scope());
+  auto new_graph = std::make_shared<Graph>(state->graph->scope_root());
   std::unordered_map<void*, Value*> new_buffer_map;
 
   torch::autograd::SymbolicContext ctx;

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -40,8 +40,6 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   TracingState(std::size_t num_stages)
     : graph(new Graph())
     , active(false)
-    , scope_root(std::unique_ptr<Scope>(new Scope()))
-    , current_scope(scope_root.get())
     , num_stages(num_stages)
     , eval_count(0)
     , var_flags(num_stages)
@@ -51,9 +49,6 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   // the stages we care about)
   std::shared_ptr<Graph> graph;
   bool active;
-
-  std::unique_ptr<Scope> scope_root;
-  Scope * current_scope;
 
   // Used to free the Graph as soon as we know this trace will fail
   std::size_t num_stages;
@@ -81,17 +76,11 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   }
 
   void push_scope(const std::string& scope_name) {
-    current_scope = current_scope->push(stringToSymbol(scope_name));
-    graph->setCurrentScope(current_scope);
+    graph->push_scope(scope_name);
   }
 
   void pop_scope() {
-    current_scope = current_scope->pop();
-    graph->setCurrentScope(current_scope);
-  }
-
-  Scope * get_current_scope() {
-    return current_scope;
+    graph->pop_scope();
   }
 };
 

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -40,6 +40,8 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   TracingState(std::size_t num_stages)
     : graph(new Graph())
     , active(false)
+    , scope_root(std::unique_ptr<Scope>(new Scope()))
+    , current_scope(scope_root.get())
     , num_stages(num_stages)
     , eval_count(0)
     , var_flags(num_stages)
@@ -49,6 +51,9 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   // the stages we care about)
   std::shared_ptr<Graph> graph;
   bool active;
+
+  std::unique_ptr<Scope> scope_root;
+  Scope * current_scope;
 
   // Used to free the Graph as soon as we know this trace will fail
   std::size_t num_stages;
@@ -73,6 +78,20 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
 
   bool is_complete() const {
     return !is_expired() && graph->stage() == num_stages - 1;
+  }
+
+  void push_scope(const std::string& scope_name) {
+    current_scope = current_scope->push(stringToSymbol(scope_name));
+    graph->setCurrentScope(current_scope);
+  }
+
+  void pop_scope() {
+    current_scope = current_scope->pop();
+    graph->setCurrentScope(current_scope);
+  }
+
+  Scope * get_current_scope() {
+    return current_scope;
   }
 };
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -19,6 +19,30 @@ import copy
 _flatten = torch._C._jit_flatten
 
 
+# This global variable is set when we are tracing a *forwards* computation.
+# It is intended to be a cheap way to test if tracing has occurred, before
+# doing the slower path using `get_tracing_state` (below.)
+_tracing = False
+
+
+def get_tracing_state(args):
+    if not torch._C._is_tracing(args):
+        return None
+    return torch._C._get_tracing_state(args)
+
+
+@contextlib.contextmanager
+def scope(scope_name, vars):
+    tracing_state = get_tracing_state(vars)
+    if tracing_state:
+        tracing_state.push_scope(scope_name)
+    try:
+        yield
+    finally:
+        if tracing_state:
+            tracing_state.pop_scope()
+
+
 def compile(arg=None, nderivs=1, optimize=True, enabled=True):
     """
     Decorator which marks a function or module class as eligible for
@@ -237,13 +261,16 @@ class TracedModule(Module):
         self.nderivs = nderivs
 
     def forward(self, *args):
+        global _tracing
         in_vars = _flatten(args)
         # NOTE: use full state, because we need it for BatchNorm export
         # This differs from the compiler path, which doesn't support it at the moment.
         module_state = list(self.state_dict(keep_vars=True).values())
         trace = torch._C._tracer_enter(in_vars + module_state, self.nderivs)
+        _tracing = True
         out = self.inner(*args)
         out_vars = _flatten(out)
+        _tracing = False
         torch._C._tracer_exit(out_vars)
         return trace, out
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -32,7 +32,7 @@ def get_tracing_state(args):
 
 
 @contextlib.contextmanager
-def scope(scope_name, vars):
+def scope(scope_name, *vars):
     tracing_state = get_tracing_state(vars)
     if tracing_state:
         tracing_state.push_scope(scope_name)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 import functools
 
 import torch
@@ -319,10 +319,42 @@ class Module(object):
         self._forward_hooks[handle.id] = hook
         return handle
 
+    def tracing_name(self, tracing_state):
+        if not tracing_state._traced_module_stack:
+            return None
+        module = tracing_state._traced_module_stack[-1]
+        for name, child in module.named_children():
+            if child == self:
+                return name
+        return None
+
+    def slow_forward(self, *input, **kwargs):
+        input_vars = tuple(torch.autograd.function._iter_variables(input))
+        tracing_state = torch.jit.get_tracing_state(input_vars)
+        if not tracing_state:
+            return self.forward(*input, **kwargs)
+        if not hasattr(tracing_state, '_traced_module_stack'):
+            tracing_state._traced_module_stack = []
+        name = self.tracing_name(tracing_state)
+        if name:
+            tracing_state.push_scope('%s[%s]' % (self.__class__.__name__, name))
+        else:
+            tracing_state.push_scope(self.__class__.__name__)
+        tracing_state._traced_module_stack.append(self)
+        try:
+            result = self.forward(*input, **kwargs)
+        finally:
+            tracing_state.pop_scope()
+            tracing_state._traced_module_stack.pop()
+        return result
+
     def __call__(self, *input, **kwargs):
         for hook in self._forward_pre_hooks.values():
             hook(self, input)
-        result = self.forward(*input, **kwargs)
+        if torch.jit._tracing:
+            result = self.slow_forward(*input, **kwargs)
+        else:
+            result = self.forward(*input, **kwargs)
         for hook in self._forward_hooks.values():
             hook_result = hook(self, input, result)
             if hook_result is not None:


### PR DESCRIPTION
This PR introduces scopes (or namespaces) in order to group operations in the tracing IR, e.g.

```python
x = Variable(torch.Tensor([0.4]), requires_grad=True)
y = Variable(torch.Tensor([0.7]), requires_grad=True)

def doit(x, y):
    tracing_state = torch.jit.get_tracing_state(x,y)
    if tracing_state:
        tracing_state.push_scope('Foo')
    z = Variable(torch.Tensor([0.7]), requires_grad=True)
    out = torch.sigmoid(torch.tanh(x * (y + z)))
    if tracing_state:
        tracing_state.pop_scope()
    return out

traced, _ = torch.jit.trace(doit, (x, y))
g = torch._C._jit_get_graph(traced)
print(g)
```

outputs

```
graph(%1 : Float(1)
      %2 : Float(1)) {
  %3 : Float(1) = Constant[value=<Tensor>](), uses = [%4.i1], scope: Foo;
  %5 : Float(1) = ^Add(False)(%2, %3), uses = [[%6.i1]], scope: Foo;
  %7 : Float(1) = ^Mul()(%1, %5), uses = [[%8.i0]], scope: Foo;
  %9 : Float(1) = ^Tanh()(%7), uses = [[%10.i0]], scope: Foo;
  %11 : Float(1) = ^Sigmoid()(%9), uses = [[%0.i0]], scope: Foo;
  return (%11);
}
```

Scopes work like a stack: they can be pushed and popped manually (as in the example above). Modules automatically push a scope during `__call__` and pops it before returning. The scope is named as `className$id`, where id is the value of the Python `id` function:

```python
class Net(nn.Module):

        def __init__(self):
            super(Net, self).__init__()
            self.layer1 = nn.Sequential(nn.Linear(2,2), nn.ReLU())

        def forward(self, x):
            return self.layer1(x)

    net = Net()

    t = Variable(torch.ones(2), requires_grad=True)

    traced, _ = torch.jit.trace(net, (t, ))
    g = torch._C._jit_get_graph(traced)
    print(g)
```

outputs

```
graph(%1 : Float(2)
      %2 : Float(2, 2)
      %3 : Float(2)) {
  %5 : Float(2!, 2!) = ^Transpose(0, 1)(%2), uses = [[%10.i2]], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %7 : Float(1, 2), %8 : Handle = ^Unsqueeze(0)(%1), uses = [[%10.i1], []], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %9 : Float(1, 2) = Constant[value=<Tensor>](), uses = [%10.i0], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %11 : Float(1, 2), %12 : Handle = ^Addmm(0, 1, True)(%9, %7, %5), uses = [[%13.i0], []], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %14 : Float(2), %15 : Handle = ^Squeeze(0, True)(%11), uses = [[%16.i0], []], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %17 : Float(2) = ^Add(True)(%14, %3), uses = [[%18.i0]], scope: Net$4569918736.Sequential$4569919312.Linear$4569919120;
  %19 : Float(2), %20 : Handle = ^Threshold(0, 0, False)(%17), uses = [[%0.i0], []], scope: Net$4569918736.Sequential$4569919312.ReLU$4569919184;
  return (%19);
}
``` 

*Tests fail at the moment* because the expected output of traces differs, as I added a `scope` description. I'm not sure it belongs there, at the moment it's handy for debugging purposes. If we decide to keep them this way I'll update the expected output.

Under the hood, scope names are implemented using interned strings.

/cc @ezyang @fmassa