### PR TITLE
NCCL C Bindings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,9 @@ if WITH_NCCL:
     else:
         main_link_args += [NCCL_LIB]
     extra_compile_args += ['-DWITH_NCCL']
-
+    main_sources += [
+        "torch/csrc/cuda/nccl.cpp",
+    ]
 if WITH_CUDNN:
     main_libraries += ['cudnn']
     # NOTE: this this at the front, in case there's another cuDNN in CUDA path

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import os
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
-from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR
+from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
 from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
 from tools.setup_helpers.split_types import split_types
 
@@ -215,7 +215,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
             print('-- Not using CUDA')
         if WITH_NCCL and WITH_SYSTEM_NCCL:
             print('-- Using system provided NCCL library at ' +
-                  NCCL_LIB_DIR + ', ' + NCCL_INCLUDE_DIR)
+                  NCCL_SYSTEM_LIB + ', ' + NCCL_INCLUDE_DIR)
         elif WITH_NCCL:
             print('-- Building NCCL library')
         else:
@@ -480,9 +480,8 @@ if WITH_CUDA:
 
 if WITH_NCCL:
     if WITH_SYSTEM_NCCL:
-        main_libraries += ['nccl']
+        main_link_args += [NCCL_SYSTEM_LIB]
         include_dirs.append(NCCL_INCLUDE_DIR)
-        library_dirs.append(NCCL_LIB_DIR)
     else:
         main_link_args += [NCCL_LIB]
     extra_compile_args += ['-DWITH_NCCL']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ import os
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
-from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
+from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, \
+    NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
 from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
 from tools.setup_helpers.split_types import split_types
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -345,6 +345,8 @@ PyObject * THCPModule_initExtension(PyObject *self)
 }
 
 #ifdef WITH_NCCL
+#include "nccl.h"
+
 void THCPModule_useNccl()
 {
   // Use NCCL to ensure that the symbols are loaded
@@ -384,6 +386,7 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_sleep", (PyCFunction)THCPModule_cudaSleep, METH_O, NULL},
   {"_cuda_lock_mutex",   (PyCFunction)THCPModule_cudaLockMutex,   METH_NOARGS,  NULL},
   {"_cuda_unlock_mutex", (PyCFunction)THCPModule_cudaUnlockMutex, METH_NOARGS,  NULL},
+  {"_nccl_reduce", (PyCFunction)THCPModule_nccl_reduce, METH_VARARGS, NULL},
   {NULL}
 };
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -387,6 +387,10 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_lock_mutex",   (PyCFunction)THCPModule_cudaLockMutex,   METH_NOARGS,  NULL},
   {"_cuda_unlock_mutex", (PyCFunction)THCPModule_cudaUnlockMutex, METH_NOARGS,  NULL},
   {"_nccl_reduce", (PyCFunction)THCPModule_nccl_reduce, METH_VARARGS, NULL},
+  {"_nccl_all_reduce", (PyCFunction)THCPModule_nccl_all_reduce, METH_VARARGS, NULL},
+  {"_nccl_broadcast", (PyCFunction)THCPModule_nccl_broadcast, METH_VARARGS, NULL},
+  {"_nccl_all_gather", (PyCFunction)THCPModule_nccl_all_gather, METH_VARARGS, NULL},
+  {"_nccl_reduce_scatter", (PyCFunction)THCPModule_nccl_reduce_scatter, METH_VARARGS, NULL},
   {NULL}
 };
 

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -1,0 +1,176 @@
+#include "nccl.h"
+#include "torch/csrc/THP.h"
+#include "torch/csrc/Types.h"
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/cuda/THCP.h"
+
+#include <nccl.h>
+#include <sstream>
+#include <unordered_map>
+
+static inline void CHECK(ncclResult_t status)
+{
+  if (status != ncclSuccess) {
+    std::stringstream err;
+    err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
+    throw std::runtime_error(err.str());
+  }
+}
+
+struct NcclCommList {
+  std::unique_ptr<ncclComm_t[]> comms;
+  int ndevices;
+  NcclCommList(const std::vector<int>& devices)
+    : comms(new ncclComm_t[devices.size()]), ndevices(devices.size()) {
+    CHECK(ncclCommInitAll(comms.get(), devices.size(), devices.data()));
+  }
+  NcclCommList(NcclCommList&& foo) = default;
+  ~NcclCommList() {
+    if (comms) {
+      for (int i = 0; i < ndevices; i++) {
+	ncclCommDestroy(comms[i]);
+      }
+    }
+  }
+};
+
+// accesses to this object have to be guarded by THC's CudaFreeMutex
+std::unordered_map<std::string, NcclCommList > _communicators;
+
+static ncclComm_t* _get_communicator(std::vector<at::Tensor>& inputs) {
+  int ndevices = inputs.size();
+  std::stringstream hash_stream;
+  std::vector<int> devs;
+  for (int i = 0; i < ndevices; i++) {
+    int dev = inputs[i].get_device();
+    hash_stream <<  dev << ",";
+    devs.push_back(dev);
+  }
+  std::string hash = hash_stream.str();
+  auto it = _communicators.find(hash);
+  if (it == _communicators.end()) {
+    return _communicators.emplace_hint(it, hash, devs)->second.comms.get();
+  } else {
+    return it->second.comms.get();
+  }
+}
+
+static void _check_inputs(std::vector<at::Tensor> &inputs, std::vector<at::Tensor> &outputs, int size_multiplier) {
+  // len(inputs) == len(outputs)
+  size_t len = inputs.size();
+
+  if (len <= 0) {
+    throw std::runtime_error("input sequence can't be empty");
+  }
+
+  if (len != outputs.size()) {
+    std::stringstream err;
+    err << "inputs and outputs sequences have to be of the same length, but got input of length " << len << " and output of length " << outputs.size();
+    throw std::runtime_error(err.str());
+  }
+
+  std::unordered_set<int> devices;
+  devices.reserve(len);
+  int64_t numel = inputs[0].numel();
+  auto type = inputs[0].type().ID();
+
+  for (size_t i = 0; i < len; i++) {
+    auto input = inputs[i];
+    auto output = outputs[i];
+
+    if (!(input.type().isCuda() && !input.type().isSparse()
+	  && output.type().isCuda()  && !output.type().isSparse())) {
+      throw std::runtime_error("input and output elements have to be cuda dense Tensors");
+    }
+
+    if (type != input.type().ID() || type != output.type().ID()) {
+      throw std::runtime_error("all inputs and outputs must be of the same Tensor type");
+    }
+
+    if (!input.is_contiguous() || !output.is_contiguous()) {
+      throw std::runtime_error("all inputs and outputs have to be contiguous");
+    }
+
+    auto input_device = input.get_device();
+    // inputs must be on unique devices
+    if (devices.find(input_device) != devices.end()) {
+      throw std::runtime_error("inputs must be on unique devices");
+    }
+    devices.insert(input_device);
+
+    // inputs and outputs must be on same device respectively
+    if (input_device != output.get_device()) {
+      throw std::runtime_error("input and output must be on the same device");
+    }
+
+    // all inputs must be same size
+    if (input.numel() != numel) {
+      throw std::runtime_error("all inputs must have the same number of elements");
+    }
+  
+    // outputs have to be of size * size_multiplier
+    if (output.numel() != (numel * size_multiplier)) {
+      throw std::runtime_error("output must be of size input_size * size_multiplier");
+    }
+  }
+}
+
+static ncclDataType_t _get_data_type(at::TypeID type) {
+  switch(type) {
+  case at::TypeID::CUDAFloat   : return ncclFloat;
+  case at::TypeID::CUDAHalf    : return ncclHalf;
+  case at::TypeID::CUDADouble  : return ncclDouble;
+  case at::TypeID::CUDALong    : return ncclInt64;
+  case at::TypeID::CUDAInt     : return ncclInt;
+  case at::TypeID::CUDAChar    : return ncclChar;
+  case at::TypeID::CUDAByte    : return ncclChar;
+  default: throw std::runtime_error("Unconvertible NCCL type");
+  }
+}
+
+PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_outputs, *_streams;
+  int root, op;
+
+  if (!PyArg_ParseTuple(args, "OOOii", &_inputs, &_outputs, &_streams, &root, &op)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_reduce", 1,
+			      "(sequence[Tensor] inputs, sequence[Tensor]"
+			      " outputs, sequence[torch.cuda.Stream or None], int root, int op");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  std::vector<THCStream*> streams = THPUtils_PySequence_to_THCStreamList(_streams);
+
+  THPUtils_assert(inputs.size() == streams.size(), "number of streams is not equal to number of inputs");
+  
+  // we can safely release GIL after this line, no python API used
+  AutoNoGIL no_gil;
+  _check_inputs(inputs, outputs, 1);
+  size_t len = inputs.size();
+
+  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+
+  int64_t count = inputs[0].numel();
+  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+  ncclComm_t *comm = _get_communicator(inputs);
+  AutoGPU gpu_guard;
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+  CHECK(ncclGroupStart());
+#endif
+  for (size_t i = 0; i < len; i++) {
+    int device = inputs[i].get_device();
+    gpu_guard.setDevice(device);
+    auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+    CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
+		     count, data_type, (ncclRedOp_t) op, root, comm[i], stream));
+  }
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+  CHECK(ncclGroupEnd());
+#endif
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -3,6 +3,9 @@
 #include <Python.h>
 
 PyObject* THCPModule_nccl_reduce(PyObject *self, PyObject *args);
-
+PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args);
 
 #endif

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -1,0 +1,8 @@
+#ifndef THCP_CUDA_NCCL_INC
+#define THCP_CUDA_NCCL_INC
+#include <Python.h>
+
+PyObject* THCPModule_nccl_reduce(PyObject *self, PyObject *args);
+
+
+#endif

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -8,12 +8,17 @@
 #include "THP.h"
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/utils/invalid_arguments.h"
+#include "torch/csrc/DynamicTypes.h"
 
 #include "generic/utils.cpp"
 #include <TH/THGenerateAllTypes.h>
 
 #include "generic/utils.cpp"
 #include <TH/THGenerateHalfType.h>
+
+#ifdef WITH_CUDA
+#include "torch/csrc/cuda/THCP.h"
+#endif
 
 int THPUtils_getCallable(PyObject *arg, PyObject **result) {
   if (!PyCallable_Check(arg))
@@ -205,3 +210,48 @@ bool maybeThrowBackCompatKeepdimWarn(char *func) {
   }
   return true;
 }
+
+std::vector<at::Tensor> THPUtils_PySequence_to_TensorList(PyObject *obj) {
+  if (!PySequence_Check(obj)) {
+    throw std::runtime_error("Expected a sequence in THPUtils_PySequence_to_TensorList");
+  }
+  THPObjectPtr seq = THPObjectPtr(PySequence_Fast(obj, NULL));
+  if (seq.get() == NULL) {
+    throw std::runtime_error("expected PySequence, but got " + std::string(THPUtils_typename(obj)));
+  }
+
+  std::vector<at::Tensor> list;
+  Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
+  for (Py_ssize_t i = 0; i < length; i++) {
+    at::Tensor tensor = torch::createTensor(PySequence_Fast_GET_ITEM(seq.get(), i));
+    list.push_back(tensor);
+  }
+  return list;
+}
+
+#ifdef WITH_CUDA
+std::vector <THCStream*> THPUtils_PySequence_to_THCStreamList(PyObject *obj) {
+  if (!PySequence_Check(obj)) {
+    throw std::runtime_error("Expected a sequence in THPUtils_PySequence_to_THCStreamList");
+  }
+  THPObjectPtr seq = THPObjectPtr(PySequence_Fast(obj, NULL));
+  if (seq.get() == NULL) {
+    throw std::runtime_error("expected PySequence, but got " + std::string(THPUtils_typename(obj)));
+  }
+
+  std::vector<THCStream*> streams;
+  Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
+  for (Py_ssize_t i = 0; i < length; i++) {
+    PyObject *stream = PySequence_Fast_GET_ITEM(seq.get(), i);
+
+    if (PyObject_IsInstance(stream, THCPStreamClass)) {
+      streams.push_back( ((THCPStream *)stream)->cdata);
+    } else if (stream == Py_None) {
+      streams.push_back(NULL);
+    } else {
+      std::runtime_error("Unknown data type found in stream list. Need THCStream or None");
+    }
+  }
+  return streams;
+}
+#endif

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -4,9 +4,13 @@
 #include <vector>
 #include <string>
 #include <type_traits>
-
+#include <ATen/ATen.h>
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_numbers.h"
+
+#ifdef WITH_CUDA
+#include <THC/THC.h>
+#endif
 
 #define THPUtils_(NAME) TH_CONCAT_4(THP,Real,Utils_,NAME)
 
@@ -184,6 +188,12 @@ bool getBackCompatBroadcastWarn();
 void setBackCompatKeepdimWarn(bool warn);
 bool getBackCompatKeepdimWarn();
 bool maybeThrowBackCompatKeepdimWarn(char *func);
+
+std::vector<at::Tensor> THPUtils_PySequence_to_TensorList(PyObject *obj);
+
+#ifdef WITH_CUDA
+std::vector <THCStream*> THPUtils_PySequence_to_THCStreamList(PyObject *obj);
+#endif
 
 #endif /* _THP_CORE */
 

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -4,82 +4,9 @@ import warnings
 import torch.cuda
 from torch.backends.cudnn import int_array
 
-lib = None
-nccl_2_0 = None
 __all__ = ['all_reduce', 'reduce', 'broadcast', 'all_gather', 'reduce_scatter']
 
-_communicators = {}
-
-# ncclDataType_t
-nccl_types = {
-    'torch.cuda.ByteTensor': 0,
-    'torch.cuda.CharTensor': 0,
-    'torch.cuda.IntTensor': 1,
-    'torch.cuda.HalfTensor': 2,
-    'torch.cuda.FloatTensor': 3,
-    'torch.cuda.DoubleTensor': 4,
-    'torch.cuda.LongTensor': 5,
-}
-nccl_types_2_0 = {
-    'torch.cuda.ByteTensor': 0,
-    'torch.cuda.CharTensor': 0,
-    'torch.cuda.IntTensor': 2,
-    'torch.cuda.HalfTensor': 6,
-    'torch.cuda.FloatTensor': 7,
-    'torch.cuda.DoubleTensor': 8,
-    'torch.cuda.LongTensor': 4,
-}
-
-# ncclRedOp_t
-SUM = 0
-PROD = 1
-MAX = 2
-MIN = 3
-
-status_codes_2_0 = {
-    0: "Success",
-    1: "Unhandled Cuda Error",
-    2: "System Error",
-    3: "Internal Error",
-    4: "Invalid Argument Error",
-    5: "Invalid Usage Error",
-}
-
-status_codes = {
-    0: "Success",
-    1: "Unhandled Cuda Error",
-    2: "System Error",
-    3: "Internal Error",
-    4: "Invalid Device Pointer",
-    5: "Invalid Rank",
-    6: "Unsupported Device Count",
-    7: "Device Not Found",
-    8: "Invalid Device Index",
-    9: "Lib Wrapper Not Set",
-    10: "Cuda Malloc Failed",
-    11: "Rank Mismatch",
-    12: "Invalid Argument",
-    13: "Invalid Type",
-    14: "Invalid Operation",
-}
-
-
-def _libnccl():
-    global nccl_2_0
-    global lib
-    global status_codes
-    global nccl_types
-    if lib is None:
-        lib = ctypes.pydll.LoadLibrary(None)
-        if hasattr(lib, 'ncclCommDestroy'):
-            lib.ncclCommDestroy.restype = None
-        else:
-            lib = None
-        if hasattr(lib, 'ncclGroupStart'):
-            nccl_2_0 = True
-            status_codes = status_codes_2_0
-            nccl_types = nccl_types_2_0
-    return lib
+SUM = 0  # ncclRedOp_t
 
 
 def is_available(tensors):
@@ -94,66 +21,11 @@ def is_available(tensors):
             return False
         devices.add(device)
 
-    if _libnccl() is None:
-        warnings.warn('NCCL library not found. Check your LD_LIBRARY_PATH')
+    if not hasattr(torch._C, '_nccl_all_reduce'):
+        warnings.warn('PyTorch Not compiled with NCCL support')
         return False
 
     return True
-
-
-class NcclError(RuntimeError):
-
-    def __init__(self, status):
-        self.status = status
-        msg = '{0} ({1})'.format(status_codes.get(status), status)
-        super(NcclError, self).__init__(msg)
-
-
-class NcclComm(ctypes.c_void_p):
-    pass
-
-
-class NcclCommList(object):
-
-    def __init__(self, devices):
-        self.devices = devices
-        ptrs = (NcclComm * len(devices))()
-        self._as_parameter_ = ptrs
-        check_error(lib.ncclCommInitAll(self, len(devices), int_array(devices)))
-
-    def __getitem__(self, i):
-        return self._as_parameter_[i]
-
-    def __del__(self):
-        for i in range(len(self.devices)):
-            lib.ncclCommDestroy(self[i])
-
-
-def check_error(status):
-    if status != 0:
-        raise NcclError(status)
-
-
-def communicator(inputs, outputs=None):
-    if _libnccl() is None:
-        raise RuntimeError('Unable to load NCCL library')
-
-    devices = [input.get_device() for input in inputs]
-    if outputs is not None:
-        for device, output in zip(devices, outputs):
-            if output.get_device() != device:
-                raise ValueError("inputs and outputs must be on the same devices")
-
-    key = ','.join(str(d) for d in devices)
-    if key not in _communicators:
-        _communicators[key] = NcclCommList(devices)
-    return _communicators[key]
-
-
-def cudaStream():
-    # TODO: return the current stream
-    # ffi.C.THCState_getCurrentStream(cutorch.getState())
-    return None
 
 
 def all_reduce(inputs, outputs=None, op=SUM):
@@ -161,13 +33,13 @@ def all_reduce(inputs, outputs=None, op=SUM):
         outputs = inputs
     torch._C._nccl_all_reduce(inputs, outputs, op)
 
+
 def reduce(inputs, outputs=None, root=0, op=SUM, streams=None):
     assert(root >= 0 and root < len(inputs))
     if outputs is None:
         outputs = inputs
     if streams is None:
         streams = [None] * len(inputs)
-
     torch._C._nccl_reduce(inputs, outputs, streams, root, op)
 
 
@@ -175,33 +47,10 @@ def broadcast(inputs, root=0):
     assert(root >= 0 and root < len(inputs))
     torch._C._nccl_broadcast(inputs, root)
 
+
 def all_gather(inputs, outputs):
     torch._C._nccl_all_gather(inputs, outputs)
 
+
 def reduce_scatter(inputs, outputs, op=SUM):
     torch._C._nccl_reduce_scatter(inputs, outputs, op)
-
-def _check_inputs(inputs, outputs=None, size_multiplier=1):
-    devices = set()
-    size = inputs[0].numel()
-    if len(inputs) != len(outputs):
-        raise ValueError('inputs and outputs must be the same length')
-    for input, output in zip(inputs, outputs):
-        if not input.is_cuda:
-            raise TypeError('inputs must be CUDA inputs')
-        if not input.is_contiguous():
-            raise ValueError('inputs must be contiguous')
-        device = input.get_device()
-        if device in devices:
-            raise ValueError('inputs must be on unique devices')
-        devices.add(device)
-        if input.numel() != size:
-            raise ValueError('inputs must be the same size')
-
-        if not output.is_contiguous():
-            raise ValueError('outputs must be contiguous')
-        if output.get_device() != device:
-            raise ValueError('inputs and outputs must be on the same devices')
-        if output.numel() != size * size_multiplier:
-            raise ValueError(('incorrect output size; expected {0} but got {1}'
-                              .format(size * size_multiplier, output.numel())))

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -182,21 +182,8 @@ def reduce(inputs, outputs=None, root=0, op=SUM, streams=None):
         outputs = inputs
     if streams is None:
         streams = [None] * len(inputs)
-    _check_inputs(inputs, outputs)
-    comm = communicator(inputs)
-    count = inputs[0].numel()
-    data_type = nccl_types[inputs[0].type()]
-    with torch.cuda._free_mutex():
-        if nccl_2_0 is not None:
-            lib.ncclGroupStart()
-        for i in range(len(inputs)):
-            with torch.cuda.device(comm.devices[i]):
-                check_error(lib.ncclReduce(
-                    ctypes.c_void_p(inputs[i].data_ptr()),
-                    ctypes.c_void_p(outputs[i].data_ptr()), count,
-                    data_type, op, root, comm[i], streams[i]))
-        if nccl_2_0 is not None:
-            lib.ncclGroupEnd()
+
+    torch._C._nccl_reduce(inputs, outputs, streams, root, op)
 
 
 def broadcast(inputs, root=0):


### PR DESCRIPTION
Initial PR to move the NCCL bindings to C++.

This avoids some deadlocks in the distributed setting that @ailzhang noticed (the deadlocks were in a Python multi-threading setting, where THC's `CudaFreeMutex` and `GIL` were starving for each other.

Current status: the call to `ncclReduce` never returns / deadlocks deep inside nccl. More precisely hangs at:

```
#0  0x00007ffff6aa6dc7 in sched_yield () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007fffc4027a95 in ncclEnqueueCheck(ncclResult_t (*)(void const*, void*, unsigned long, ncclDataType_t, ncclRedOp_t, int, ncclComm*, CUstream_st*), char const*, void const*, void*, unsigned long, ncclDataType_t, ncclRedOp_t, int, ncclComm*, CUstream_st*) () from /public/apps/NCCL/2.0.5/lib/libnccl.so.2
#2  0x00007fffc407d7a0 in ncclReduce () from /public/apps/NCCL/2.0.5/lib/libnccl.so.2
#3  0x00007fffedcba270 in THCPModule_nccl_reduce (self=<optimized out>, args=<optimized out>) at torch/csrc/cuda/nccl.cpp:198
```

Opening the PR for @apaszke to review.