### PR TITLE
Add compiled CUDA version in torch.version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import sys
 import os
 
 from tools.setup_helpers.env import check_env_flag
-from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME
+from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME, CUDA_VERSION
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
 from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR
 from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
@@ -171,6 +171,7 @@ class build_py(setuptools.command.build_py.build_py):
             # library code with DEBUG, but csrc without DEBUG (in which case
             # this would claim to be a release build when it's not.)
             f.write("debug = {}\n".format(repr(DEBUG)))
+            f.write("cuda = {}\n".format(repr(CUDA_VERSION)))
 
 
 class develop(setuptools.command.develop.develop):

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import platform
 import ctypes.util
 from subprocess import Popen, PIPE
@@ -16,9 +17,38 @@ def find_nvcc():
         return None
 
 
+def find_cuda_version(cuda_home=None):
+    if cuda_home is  None:
+        return None
+    # first try loading the version from the version.txt file
+    version_file = os.path.join(cuda_home, 'version.txt')
+    if os.path.exists(version_file):
+        with open(version_file, 'r') as f:
+            version = f.read().strip().split(' ')
+        # take only the version number
+        version = version[-1]
+    else:
+        cuda_lib_dirs = ['lib64', 'lib']
+        for lib_dir in cuda_lib_dirs:
+            cuda_lib_path = os.path.join(CUDA_HOME, lib_dir)
+            if os.path.exists(cuda_lib_path):
+                break
+        # get a list of candidates for the version number
+        # which are files containing libcudart
+        candidates = list(glob.glob(os.path.join(cuda_lib_path, 'libcudart*')))
+        candidates = [os.path.basename(c) for c in candidates]
+        # suppose version is MAJOR.MINOR.PATCH, all numbers
+        d = re.compile('[0-9]+\.[0-9]+\.[0-9]+')
+        candidates = [c.group() for c in map(d.search, candidates) if c]
+        assert len(candidates) == 1
+        version = candidates[0]
+    return version
+
+
 if check_env_flag('NO_CUDA'):
     WITH_CUDA = False
     CUDA_HOME = None
+    CUDA_VERSION = None
 else:
     CUDA_HOME = os.getenv('CUDA_HOME', '/usr/local/cuda')
     if not os.path.exists(CUDA_HOME):
@@ -36,4 +66,5 @@ else:
             CUDA_HOME = os.path.dirname(cuda_path)
         else:
             CUDA_HOME = None
+    CUDA_VERSION = find_cuda_version(CUDA_HOME)
     WITH_CUDA = CUDA_HOME is not None

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -20,28 +20,21 @@ def find_nvcc():
 def find_cuda_version(cuda_home=None):
     if cuda_home is  None:
         return None
-    # first try loading the version from the version.txt file
-    version_file = os.path.join(cuda_home, 'version.txt')
-    if os.path.exists(version_file):
-        with open(version_file, 'r') as f:
-            version = f.read().strip().split(' ')
-        # take only the version number
-        version = version[-1]
-    else:
-        cuda_lib_dirs = ['lib64', 'lib']
-        for lib_dir in cuda_lib_dirs:
-            cuda_lib_path = os.path.join(CUDA_HOME, lib_dir)
-            if os.path.exists(cuda_lib_path):
-                break
-        # get a list of candidates for the version number
-        # which are files containing libcudart
-        candidates = list(glob.glob(os.path.join(cuda_lib_path, 'libcudart*')))
-        candidates = [os.path.basename(c) for c in candidates]
-        # suppose version is MAJOR.MINOR.PATCH, all numbers
-        d = re.compile('[0-9]+\.[0-9]+\.[0-9]+')
-        candidates = [c.group() for c in map(d.search, candidates) if c]
-        assert len(candidates) == 1
-        version = candidates[0]
+    # get CUDA lib folder
+    cuda_lib_dirs = ['lib64', 'lib']
+    for lib_dir in cuda_lib_dirs:
+        cuda_lib_path = os.path.join(cuda_home, lib_dir)
+        if os.path.exists(cuda_lib_path):
+            break
+    # get a list of candidates for the version number
+    # which are files containing cudart
+    candidates = list(glob.glob(os.path.join(cuda_lib_path, '*cudart*')))
+    candidates = [os.path.basename(c) for c in candidates]
+    # suppose version is MAJOR.MINOR.PATCH, all numbers
+    version_regex = re.compile('[0-9]+\.[0-9]+\.[0-9]+')
+    candidates = [c.group() for c in map(version_regex.search, candidates) if c]
+    assert len(candidates) == 1
+    version = candidates[0]
     return version
 
 


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/2969

I copied [some code from here](https://github.com/pytorch/pytorch/blob/master/setup.py#L455-L460) to retrieve the lib folders.

I'm unsure about how robust this is on different systems though. Another option is to read from the `version.txt` file, but I'm not sure how robust that is either (a first version can be found in the first commit).