### PR TITLE
add 'at' helper method

### DIFF
--- a/test/expect/TestONNX.test_at_op.expect
+++ b/test/expect/TestONNX.test_at_op.expect
@@ -1,0 +1,49 @@
+ir_version: 1
+producer_name: "pytorch"
+producer_version: "0.2"
+domain: "com.facebook"
+graph {
+  node {
+    input: "1"
+    input: "1"
+    output: "2"
+    op_type: "ATen"
+    attribute {
+      name: "operator"
+      s: "add"
+    }
+  }
+  name: "torch-jit-export"
+  input {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: DOUBLE
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: DOUBLE
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -125,5 +125,26 @@ class TestONNX(TestCase):
         x = Variable(torch.randn(20, 16, 50))
         self.assertONNXExpected(export_to_string(nn.MaxPool1d(3, stride=2), x))
 
+    def test_at_op(self):
+        x = Variable(torch.randn(3, 4))
+
+        class MyFun(Function):
+
+            @staticmethod
+            def symbolic(g, x):
+                return g.at("add", x, x)
+
+            @staticmethod
+            def forward(ctx, x):
+                return x + x
+
+        class MyModule(Module):
+
+            def forward(self, x):
+                return MyFun.apply(x)
+
+        self.assertONNXExpected(export_to_string(MyModule(), x))
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/onnx.py
+++ b/torch/onnx.py
@@ -15,6 +15,7 @@ import json
 import math
 import contextlib
 from ._utils import _range
+from torch._six import string_classes
 
 
 @contextlib.contextmanager
@@ -135,7 +136,7 @@ def _add_attribute(node, key, value):
             "Invalid attribute specifier '{}' names " +
             " must be suffixed with type, e.g. 'dim_i' or 'dims_i'").format(key))
     name, kind = m.group(1), m.group(2)
-    if isinstance(value, collections.Iterable):
+    if not isinstance(value, string_classes) and isinstance(value, collections.Iterable):
         kind += "s"
     return getattr(node, kind + '_')(name, value)
 
@@ -155,4 +156,9 @@ def _op(self, opname, *args, **kwargs):
     return tuple(self.appendNode(self.createSelect(n, i)) for i in _range(outputs))
 
 
+def _at(self, opname, *args, **kwargs):
+    return self.op("ATen", *args, operator_s=opname, **kwargs)
+
+
 torch._C.Graph.op = _op
+torch._C.Graph.at = _at


### PR DESCRIPTION
This is 1/2 commits (the other being put into caffe2) for the ATen tutorial going out with the ONNX release. This adds a simple helper method for create ATen ops and fixes a bug in the handling of string attributes.