### PR TITLE
Add random_ for cuda, fix random_ for cpu 

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1130,10 +1130,10 @@ add_docstr_all('random_',
 random_(from=0, to=None, *, generator=None)
 
 Fills this tensor with numbers sampled from the discrete uniform distribution
-over [from, to - 1]. If not specified, the values are only bounded by this
-tensor's data type.
-
-This method is not available for CUDA tensors.  Use :meth:`~Tensor.uniform_` instead.
+over [from, to - 1]. If not specified, the values are usually only bounded by
+this tensor's data type. However, for floating point types, if unspecified,
+range will be [0, 2^mantissa] to ensure that every value is representable.
+For example, `torch.DoubleTensor(1).random_()` will be uniform in [0, 2^53].
 """)
 
 add_docstr_all('reciprocal',

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -20,6 +20,7 @@
   defined_if: "!IS_DISTRIBUTED"
   backends:
     - CPU
+    - CUDA
   return: self
   options:
     - cname: random

--- a/torch/lib/TH/generic/THTensorRandom.c
+++ b/torch/lib/TH/generic/THTensorRandom.c
@@ -8,13 +8,13 @@ void THTensor_(random)(THTensor *self, THGenerator *_generator)
 {
 
 #if defined(TH_REAL_IS_BYTE)
-  TH_TENSOR_APPLY(real, self, *self_data = (uint8_t)(THRandom_random(_generator) % (UINT8_MAX+1)););
+  TH_TENSOR_APPLY(real, self, *self_data = (uint8_t)(THRandom_random(_generator) % (UINT8_MAX + 1)););
 #elif defined(TH_REAL_IS_CHAR)
-  TH_TENSOR_APPLY(real, self, *self_data = (int8_t)(THRandom_random(_generator) % (INT8_MAX+1)););
+  TH_TENSOR_APPLY(real, self, *self_data = (int8_t)(THRandom_random(_generator) % (INT8_MAX + 1)););
 #elif defined(TH_REAL_IS_SHORT)
-  TH_TENSOR_APPLY(real, self, *self_data = (int16_t)(THRandom_random(_generator) % (INT16_MAX+1)););
+  TH_TENSOR_APPLY(real, self, *self_data = (int16_t)(THRandom_random(_generator) % (INT16_MAX + 1)););
 #elif defined(TH_REAL_IS_INT)
-  TH_TENSOR_APPLY(real, self, *self_data = (int32_t)(THRandom_random(_generator) % (INT32_MAX+1UL)););
+  TH_TENSOR_APPLY(real, self, *self_data = (int32_t)(THRandom_random(_generator) % (INT32_MAX + 1UL)););
 #elif defined(TH_REAL_IS_LONG)
   TH_TENSOR_APPLY(real, self, *self_data = (uint64_t)(RANDOM64(_generator) % (LONG_MAX + 1ULL)););
 #elif defined(TH_REAL_IS_FLOAT)
@@ -28,7 +28,7 @@ void THTensor_(random)(THTensor *self, THGenerator *_generator)
 }
 
 void THTensor_(clampedRandom)(THTensor *self, THGenerator *_generator, int64_t min, int64_t max) {
-  THArgCheck(max > min, 2, "max must be greater than min");
+  THArgCheck(max > min, 2, "max must be greater than min, but got: min = %lld, max = %lld", min, max);
   uint64_t range = max - min;
 #if defined(TH_REAL_IS_LONG) || defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
     if (range >= 1ULL << 32) {
@@ -40,7 +40,7 @@ void THTensor_(clampedRandom)(THTensor *self, THGenerator *_generator, int64_t m
 }
 
 void THTensor_(cappedRandom)(THTensor *self, THGenerator *_generator, int64_t max) {
-  THArgCheck(max > 0, 1, "max must be positive");
+  THArgCheck(max > 0, 1, "max must be positive, but got: max = %lld", max);
   THTensor_(clampedRandom)(self, _generator, 0, max);
 }
 
@@ -410,3 +410,5 @@ void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
 #endif
 
 #endif
+
+#undef RANDOM64

--- a/torch/lib/THC/generic/THCTensorRandom.cu
+++ b/torch/lib/THC/generic/THCTensorRandom.cu
@@ -311,15 +311,15 @@ THC_API void THCTensor_(multinomialAliasSetup)(THCState *state, THCTensor *_prob
   int inputBlockDim = THCCeilDiv((int)inputsize + BLOCK_SIZE - 1, BLOCK_SIZE);
   aliasMultinomialFilter
     <<<inputBlockDim, BLOCK_SIZE, 0, THCState_getCurrentStream(state) >>>(
-								     THCTensor_(data)(state, _q),
-								     THCTensor_(data)(state, _probs),
-								     THCudaLongTensor_data(state, smaller),
-								     THCudaLongTensor_data(state, larger),
-								     THCudaLongTensor_data(state, _J),
-								     THCudaLongTensor_data(state, smaller_short),
-								     THCudaLongTensor_data(state, larger_short),
-								     one, inputsize
-								     );
+                     THCTensor_(data)(state, _q),
+                     THCTensor_(data)(state, _probs),
+                     THCudaLongTensor_data(state, smaller),
+                     THCudaLongTensor_data(state, larger),
+                     THCudaLongTensor_data(state, _J),
+                     THCudaLongTensor_data(state, smaller_short),
+                     THCudaLongTensor_data(state, larger_short),
+                     one, inputsize
+                     );
   
   THCudaLongTensor_nonzero(state, smaller_short, smaller);
   THCudaLongTensor_nonzero(state, larger_short, larger);
@@ -328,20 +328,20 @@ THC_API void THCTensor_(multinomialAliasSetup)(THCState *state, THCTensor *_prob
   THCudaLongTensor_resize1d(state, larger_short, inputsize);
   aliasMultinomialSetup
     <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
-						    THCudaLongTensor_data(state, _J),
-						    THCTensor_(data)(state, _q),
-						    inputsize,
-						    THCudaLongTensor_data(state, smaller_short),
-						    THCudaLongTensor_data(state, larger_short),
-						    inputsize - h_large_c, h_large_c
-						    );
+                THCudaLongTensor_data(state, _J),
+                THCTensor_(data)(state, _q),
+                inputsize,
+                THCudaLongTensor_data(state, smaller_short),
+                THCudaLongTensor_data(state, larger_short),
+                inputsize - h_large_c, h_large_c
+                );
   real q_max = THCTensor_(maxall)(state, _q);
   condDiv<<<
     inputBlockDim, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-								      THCTensor_(data)(state, _q),
-								      THCudaLongTensor_data(state, _J),
-								      inputsize, q_max
-								      );
+                      THCTensor_(data)(state, _q),
+                      THCudaLongTensor_data(state, _J),
+                      inputsize, q_max
+                      );
   
   THCudaLongTensor_free(state, smaller);
   THCudaLongTensor_free(state, larger);
@@ -365,14 +365,14 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
 
   multinomialAliasDrawKernel
     <<<THCCeilDiv((int)output_nelem+BLOCK_SIZE-1, BLOCK_SIZE), BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-				  size,
-				  THCudaLongTensor_data(state, self),
-				  THCudaLongTensor_data(state, _J),
-				  THCTensor_(data)(state, _q),
-				  K,
-				  THCTensor_(data)(state, uniform),
-				  THCTensor_(data)(state, bernoulli)
-				  );
+          size,
+          THCudaLongTensor_data(state, self),
+          THCudaLongTensor_data(state, _J),
+          THCTensor_(data)(state, _q),
+          K,
+          THCTensor_(data)(state, uniform),
+          THCTensor_(data)(state, bernoulli)
+          );
 }
 
 THC_API void THCTensor_(rand)(THCState *state, THCTensor *r_, THLongStorage *size)
@@ -437,10 +437,19 @@ DEFINE_BERNOULLI_TENSOR(bernoulli_FloatTensor, THCudaTensor, float)
 DEFINE_BERNOULLI_TENSOR(bernoulli_DoubleTensor, THCudaDoubleTensor, double)
 
 #if defined(THC_REAL_IS_DOUBLE)
-
 GENERATE_KERNEL1(generate_geometric, double, double p, double, curand_uniform_double, ceil(log(x) / log(1-p)))
 #else
 GENERATE_KERNEL1(generate_geometric, real, double p, float, curand_uniform, (ScalarConvert<float, real>::to(ceilf(logf(x) / log(1-p)))))
+#endif
+
+#if defined(THC_REAL_IS_LONG) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_FLOAT)
+#define CURAND64(STATE) (((uint64_t)curand(&state[blockIdx.x])) << 32) | (uint64_t)curand(&state[blockIdx.x])
+GENERATE_KERNEL2(generate_random, real, int32_t base, uint32_t range, uint32_t, curand, (real)(x % range + base))
+GENERATE_KERNEL2(generate_random_64, real, int64_t base, uint64_t range, uint64_t, CURAND64, (real)(x % range + base))
+#elif defined(THC_REAL_IS_HALF)
+GENERATE_KERNEL2(generate_random, real, int32_t base, uint32_t range, uint32_t, curand, (ScalarConvert<uint32_t, real>::to(x % range + base)))
+#else
+GENERATE_KERNEL2(generate_random, real, int32_t base, uint32_t range, uint32_t, curand, (real)(x % range + base))
 #endif
 
 THC_API void THCTensor_(geometric)(THCState* state, THCTensor *self_, double p)
@@ -457,6 +466,69 @@ THC_API void THCTensor_(geometric)(THCState* state, THCTensor *self_, double p)
 
   THCTensor_(freeCopyTo)(state, self, self_);
 };
+
+THC_API void THCTensor_(clampedRandom)(THCState* state, THCTensor *self_, int64_t min_val, int64_t max_val)
+{
+  THArgCheck(min_val < max_val, 2,
+             "max must be greater than min, but got: min = %d, max = %d", min_val, max_val);
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
+  Generator* gen = THCRandom_getGenerator(state);
+  THCTensor *self = THCTensor_(newContiguous)(state, self_);
+  ptrdiff_t size = THCTensor_(nElement)(state, self);
+  real *data = THCTensor_(data)(state, self);
+
+  uint64_t range = max_val - min_val;
+
+#if defined(THC_REAL_IS_LONG) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_FLOAT)
+  if (range > 1ULL << 32) {
+    generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+        gen->gen_states, size, data, min_val, range);
+  } else {
+#endif
+    generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+        gen->gen_states, size, data, min_val, range);
+#if defined(THC_REAL_IS_LONG) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_FLOAT)
+  }
+#endif
+
+  THCTensor_(freeCopyTo)(state, self, self_);
+};
+
+THC_API void THCTensor_(cappedRandom)(THCState* state, THCTensor *self_, int64_t max_val)
+{
+  THCTensor_(clampedRandom)(state, self_, 0LL, max_val);
+};
+
+#define HLF_MANT_DIG 11
+
+THC_API void THCTensor_(random)(THCState* state, THCTensor *self_)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
+  Generator* gen = THCRandom_getGenerator(state);
+  THCTensor *self = THCTensor_(newContiguous)(state, self_);
+  ptrdiff_t size = THCTensor_(nElement)(state, self);
+  real *data = THCTensor_(data)(state, self);
+
+#if defined(THC_REAL_IS_HALF)
+  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+      gen->gen_states, size, data, 0UL, (1UL << HLF_MANT_DIG) + 1);
+#elif defined(THC_REAL_IS_FLOAT)
+  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+      gen->gen_states, size, data, 0UL, (1UL << FLT_MANT_DIG) + 1);
+#elif defined(THC_REAL_IS_DOUBLE)
+  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+      gen->gen_states, size, data, 0ULL, (1ULL << DBL_MANT_DIG) + 1);
+#elif defined(THC_REAL_IS_LONG)
+  generate_random_64<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+      gen->gen_states, size, data, 0ULL, static_cast<uint64_t>(std::numeric_limits<real>::max()) + 1);
+#else
+  generate_random<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
+      gen->gen_states, size, data, 0UL, static_cast<uint32_t>(std::numeric_limits<real>::max()) + 1);
+#endif
+
+  THCTensor_(freeCopyTo)(state, self, self_);
+};
+
 #undef NUM_BLOCKS
 
 #endif

--- a/torch/lib/THC/generic/THCTensorRandom.cu
+++ b/torch/lib/THC/generic/THCTensorRandom.cu
@@ -470,7 +470,7 @@ THC_API void THCTensor_(geometric)(THCState* state, THCTensor *self_, double p)
 THC_API void THCTensor_(clampedRandom)(THCState* state, THCTensor *self_, int64_t min_val, int64_t max_val)
 {
   THArgCheck(min_val < max_val, 2,
-             "max must be greater than min, but got: min = %d, max = %d", min_val, max_val);
+             "max must be greater than min, but got: min = %lld, max = %lld", min_val, max_val);
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
   Generator* gen = THCRandom_getGenerator(state);
   THCTensor *self = THCTensor_(newContiguous)(state, self_);
@@ -529,6 +529,8 @@ THC_API void THCTensor_(random)(THCState* state, THCTensor *self_)
   THCTensor_(freeCopyTo)(state, self, self_);
 };
 
+#undef HLF_MANT_DIG
+#undef CURAND64
 #undef NUM_BLOCKS
 
 #endif

--- a/torch/lib/THC/generic/THCTensorRandom.h
+++ b/torch/lib/THC/generic/THCTensorRandom.h
@@ -20,6 +20,9 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
 
 #endif
 
+THC_API void THCTensor_(random)(struct THCState *state, THCTensor *self);
+THC_API void THCTensor_(clampedRandom)(struct THCState *state, THCTensor *self, int64_t min, int64_t max);
+THC_API void THCTensor_(cappedRandom)(struct THCState *state, THCTensor *self, int64_t max);
 THC_API void THCTensor_(bernoulli)(struct THCState *state, THCTensor *self, double p);
 THC_API void THCTensor_(bernoulli_FloatTensor)(struct THCState *state, THCTensor *self, THCudaTensor *p);
 THC_API void THCTensor_(bernoulli_DoubleTensor)(struct THCState *state, THCTensor *self, THCudaDoubleTensor *p);


### PR DESCRIPTION
Implements #712 .

CPU random_() has the bug of having max value 2^32. This is a problem for DoubleTensor and LongTensor. Fixed in this PR as well.