### PR TITLE
Fix build without numpy

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -147,7 +147,7 @@ static void THPTensor_(setInconsistentDepthError)(std::vector<size_t> &sizes,
   THPUtils_setError(error.c_str());
 }
 
-#if defined(NUMPY_TYPE_ENUM) || defined(THC_GENERIC_FILE)
+#ifdef WITH_NUMPY
 
 #ifndef THC_REAL_IS_HALF
 #define load_real real

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -1,4 +1,5 @@
 #ifndef TH_GENERIC_FILE
+
 #define TH_GENERIC_FILE "generic/Tensor.cpp"
 #else
 
@@ -147,7 +148,7 @@ static void THPTensor_(setInconsistentDepthError)(std::vector<size_t> &sizes,
   THPUtils_setError(error.c_str());
 }
 
-#ifdef WITH_NUMPY
+#if defined(NUMPY_TYPE_ENUM) || (defined(WITH_NUMPY) && defined(THC_GENERIC_FILE))
 
 #ifndef THC_REAL_IS_HALF
 #define load_real real


### PR DESCRIPTION
This PR fixes #3046

The condition at https://github.com/pytorch/pytorch/blame/master/torch/csrc/generic/Tensor.cpp#L150

```
#if defined(NUMPY_TYPE_ENUM) || defined(THC_GENERIC_FILE)
```
was evaluating to true in the case of a CUDA build without NumPy. As a bit of background, `NUMPY_TYPE_ENUM` is undefined for CUDA builds.

The condition can safely be replaced with
```
#if defined(NUMPY_TYPE_ENUM) || (defined(WITH_NUMPY) && defined(THC_GENERIC_FILE))
```