### PR TITLE
Make cuda default stream wait for operations in other streams by default

### DIFF
--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -15,7 +15,7 @@ static PyObject * THCPStream_pynew(PyTypeObject *type, PyObject *args, PyObject 
   int current_device;
   THCudaCheck(cudaGetDevice(&current_device));
 
-  int flags = cudaStreamNonBlocking;
+  int flags = 0;
   int priority = 0;
   unsigned long long cdata = 0;
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/pytorch/pytorch/issues/2702.

The bug is that cuda streams are created with the `CudaStreamNonBlocking` flag which means that operations on default streams do not block to wait for operations on the created stream. Matrix operations are run on some non-default stream while device to host transfers run on the default stream, leading to some race conditions.

Another way to fix the issue is to change device-to-host transfers to run on the cuda current stream but I think removing the `CudaStreamNonBlocking` flag makes it easier to reason about the default stream vs other streams.

### Test Plan
Run the code provided in https://github.com/pytorch/pytorch/issues/2702. Assert that junk data is not printed out.