### PR TITLE
Add document on how Module.cuda() and optims should work together

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -16,6 +16,15 @@ To construct an :class:`Optimizer` you have to give it an iterable containing th
 parameters (all should be :class:`~torch.autograd.Variable` s) to optimize. Then,
 you can specify optimizer-specific options such as the learning rate, weight decay, etc.
 
+.. note::
+
+    If you need to move a model to GPU via `.cuda()`, please do so before 
+    constructing optimizers for it. Parameters of a model after `.cuda()` will
+    be differnt objects with those before the call. 
+
+    In general, you should make sure that optimized parameters live in  
+    consistent locations when optimizers are constructed and used.
+
 Example::
 
     optimizer = optim.SGD(model.parameters(), lr = 0.01, momentum=0.9)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -173,7 +173,11 @@ class Module(object):
         return self
 
     def cuda(self, device_id=None):
-        """Moves all model parameters and buffers to the GPU.
+        """Moves all model parameters and buffers to the GPU. 
+
+        This also makes associated parameters and buffers different objects. So 
+        it should be called before constructing optimizer if the module will  
+        live on GPU while being optimized.
 
         Arguments:
             device_id (int, optional): if specified, all parameters will be

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -173,10 +173,10 @@ class Module(object):
         return self
 
     def cuda(self, device_id=None):
-        """Moves all model parameters and buffers to the GPU. 
+        """Moves all model parameters and buffers to the GPU.
 
-        This also makes associated parameters and buffers different objects. So 
-        it should be called before constructing optimizer if the module will  
+        This also makes associated parameters and buffers different objects. So
+        it should be called before constructing optimizer if the module will
         live on GPU while being optimized.
 
         Arguments:


### PR DESCRIPTION
In #2021 , many users are facing an error when calling `Module.cuda()` after constructing an optimizer. The error is expected, because the optimizer is initialized with different parameters with what it sees in `.step()`. It is difficult to make a better error message for it as well, as it can potentially happen with in any place of an optim that saves parameter-specific tensors in its state dict. As pointed out by @matt-gardner in #2021 , better documentation should be helpful. 