### PR TITLE
Make DtoH and HtoD transfers respect the current stream

### DIFF
--- a/torch/lib/THC/THCReduceAll.cuh
+++ b/torch/lib/THC/THCReduceAll.cuh
@@ -331,7 +331,13 @@ bool THC_reduceAll(THCState* state,
   // If our destination is not on the device, copy the value back to
   // the host (synchronous!)
   if (!outOnDevice) {
-    THCudaCheck(cudaMemcpy(out, devOut, sizeof(AccT), cudaMemcpyDeviceToHost));
+    cudaStream_t stream = THCState_getCurrentStream(state);
+    THCudaCheck(cudaMemcpyAsync(out, 
+                                devOut, 
+                                sizeof(AccT), 
+                                cudaMemcpyDeviceToHost, 
+                                stream));
+    THCudaCheck(cudaStreamSynchronize(stream));
   }
 
   if (freeDevOut) {

--- a/torch/lib/THC/generic/THCStorage.c
+++ b/torch/lib/THC/generic/THCStorage.c
@@ -20,16 +20,21 @@ int THCStorage_(elementSize)(THCState *state)
 void THCStorage_(set)(THCState *state, THCStorage *self, ptrdiff_t index, real value)
 {
   THArgCheck((index >= 0) && (index < self->size), 2, "index out of bounds");
-  THCudaCheck(cudaMemcpy(self->data + index, &value, sizeof(real),
-                         cudaMemcpyHostToDevice));
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  THCudaCheck(cudaMemcpyAsync(self->data + index, &value, sizeof(real),
+                              cudaMemcpyHostToDevice,
+                              stream));
+  THCudaCheck(cudaStreamSynchronize(stream));
 }
 
 real THCStorage_(get)(THCState *state, const THCStorage *self, ptrdiff_t index)
 {
   THArgCheck((index >= 0) && (index < self->size), 2, "index out of bounds");
   real value;
-  THCudaCheck(cudaMemcpy(&value, self->data + index, sizeof(real),
-                         cudaMemcpyDeviceToHost));
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  THCudaCheck(cudaMemcpyAsync(&value, self->data + index, sizeof(real),
+                              cudaMemcpyDeviceToHost, stream));
+  THCudaCheck(cudaStreamSynchronize(stream));
   return value;
 }
 

--- a/torch/lib/THC/generic/THCStorageCopy.c
+++ b/torch/lib/THC/generic/THCStorageCopy.c
@@ -5,7 +5,13 @@
 void THCStorage_(copyCPU)(THCState *state, THCStorage *self, struct THStorage *src)
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
-  THCudaCheck(cudaMemcpy(self->data, src->data, self->size * sizeof(real), cudaMemcpyHostToDevice));
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  THCudaCheck(cudaMemcpyAsync(self->data,
+                              src->data,
+                              self->size * sizeof(real),
+                              cudaMemcpyHostToDevice,
+                              stream));
+  THCudaCheck(cudaStreamSynchronize(stream));
 }
 
 #define TH_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC)                          \
@@ -31,7 +37,13 @@ TH_CUDA_STORAGE_IMPLEMENT_COPY(Double)
 void THStorage_(copyCuda)(THCState *state, THStorage *self, struct THCStorage *src)
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
-  THCudaCheck(cudaMemcpy(self->data, src->data, self->size * sizeof(real), cudaMemcpyDeviceToHost));
+  cudaStream_t stream = THCState_getCurrentStream(state);
+  THCudaCheck(cudaMemcpyAsync(self->data,
+                              src->data,
+                              self->size * sizeof(real),
+                              cudaMemcpyDeviceToHost,
+                              stream));
+  THCudaCheck(cudaStreamSynchronize(stream));
 }
 
 #define TH_CUDA_STORAGE_IMPLEMENT_COPYTO(TYPEC)                             \


### PR DESCRIPTION
### Summary
Fixes #2702. The bug is that cudaMemcpy calls occur on the default stream. This makes it so that those calls happen on the current stream.

### Test Plan

Run the code provided in #2702. Assert that junk data is not printed out.