### PR TITLE
Resize outputs in criterions

### DIFF
--- a/torch/lib/THCUNN/generic/AbsCriterion.cu
+++ b/torch/lib/THCUNN/generic/AbsCriterion.cu
@@ -10,6 +10,7 @@ void THNN_(AbsCriterion_updateOutput)(
            bool sizeAverage)
 {
   THCUNN_check_nElement(state, input, target);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 2, input, target);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);

--- a/torch/lib/THCUNN/generic/BCECriterion.cu
+++ b/torch/lib/THCUNN/generic/BCECriterion.cu
@@ -12,7 +12,7 @@ void THNN_(BCECriterion_updateOutput)(
 {
   THCUNN_check_nElement(state, input, target);
   THCUNN_check_nElement(state, input, weights);
-  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 3, input, target, weights);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -11,7 +11,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
            THCTensor *weights,
            THCTensor *total_weight,
            int64_t ignore_index) {
-  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_check_dim_size(state, total_weight, 1, 0, 1);
   ignore_index -= TH_INDEX_BASE;
 

--- a/torch/lib/THCUNN/generic/DistKLDivCriterion.cu
+++ b/torch/lib/THCUNN/generic/DistKLDivCriterion.cu
@@ -10,7 +10,7 @@ void THNN_(DistKLDivCriterion_updateOutput)(
            bool sizeAverage)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 2, input, target);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,

--- a/torch/lib/THCUNN/generic/MSECriterion.cu
+++ b/torch/lib/THCUNN/generic/MSECriterion.cu
@@ -16,7 +16,7 @@ void THNN_(MSECriterion_updateOutput)(
   THCUNN_assertSameGPU(state, 3, input, target, output);
 
   if (reduce) {
-    THCUNN_check_dim_size(state, output, 1, 0, 1);
+    THCTensor_(resize1d)(state, output, 1);
 
     ptrdiff_t size = THCTensor_(nElement)(state, input);
 
@@ -45,11 +45,11 @@ void THNN_(MSECriterion_updateOutput)(
 
   THCTensor_(resizeAs)(state, output, input);
   THC_pointwiseApply3(
-      state, 
-      input, 
-      target, 
-      output, 
-      mse_updateOutput_functor<real>()); 
+      state,
+      input,
+      target,
+      output,
+      mse_updateOutput_functor<real>());
 }
 
 void THNN_(MSECriterion_updateGradInput)(

--- a/torch/lib/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/torch/lib/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -15,13 +15,13 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   target = THCIndexTensor_(newContiguous)(state, target);
   istarget = THCTensor_(newContiguous)(state, istarget);
   THCTensor_(resizeAs)(state, istarget, input);
+  THCTensor_(resize1d)(state, output, 1);
 
   if(input->nDimension == 1)
   {
     int dim = input->size[0];
     THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
         "inconsistent target size");
-    THCTensor_(resize1d)(state, output, 1);
 
     dim3 blocks(1);
     dim3 threads(MULTILABELMARGIN_THREADS);
@@ -58,7 +58,6 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
         sizeaverage
         );
     THCudaCheck(cudaGetLastError());
-    THCTensor_(resize1d)(state, output, 1);
     THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, real>::to(THCTensor_(sumall)(state, output_tmp)));
     THCTensor_(free)(state, output_tmp);
   }

--- a/torch/lib/THCUNN/generic/MultiMarginCriterion.cu
+++ b/torch/lib/THCUNN/generic/MultiMarginCriterion.cu
@@ -15,6 +15,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
 {
   real margin = ScalarConvert<accreal, real>::to(margin_);
   THCUNN_assertSameGPU(state, 2, input, target);
+  THCTensor_(resize1d)(state, output, 1);
   input = THCTensor_(newContiguous)(state, input);
   if(weights)
     weights = THCTensor_(newContiguous)(state, weights);

--- a/torch/lib/THCUNN/generic/SmoothL1Criterion.cu
+++ b/torch/lib/THCUNN/generic/SmoothL1Criterion.cu
@@ -10,7 +10,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
            bool sizeAverage)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 2, input, target);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,

--- a/torch/lib/THCUNN/generic/SoftMarginCriterion.cu
+++ b/torch/lib/THCUNN/generic/SoftMarginCriterion.cu
@@ -10,7 +10,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
            bool sizeAverage)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 2, input, target);
   accreal sum;
 

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -40,6 +40,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
            int64_t ignore_index)
 {
   THNN_(SpatialClassNLLCriterion_shapeCheck)(state, input, target, weights);
+  THCTensor_(resize1d)(state, output, 1);
 
   if (weights)
     THCUNN_assertSameGPU(state, 5, input, target, weights, output, total_weight);

--- a/torch/lib/THNN/generic/AbsCriterion.c
+++ b/torch/lib/THNN/generic/AbsCriterion.c
@@ -11,6 +11,7 @@ void THNN_(AbsCriterion_updateOutput)(
 {
   real sum = 0;
   THNN_CHECK_NELEMENT(input, target);
+  THTensor_(resize1d)(output, 1);
   TH_TENSOR_APPLY2(real, input, real, target,
     sum += fabs(*input_data - *target_data);
   );

--- a/torch/lib/THNN/generic/BCECriterion.c
+++ b/torch/lib/THNN/generic/BCECriterion.c
@@ -10,7 +10,7 @@ void THNN_(BCECriterion_updateOutput)(THNNState *state, THTensor *input,
 {
   THNN_CHECK_NELEMENT(input, target);
   THNN_CHECK_NELEMENT(input, weights);
-  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+	THTensor_(resize1d)(output, 1);
   real sum = 0;
 
   if(weights)

--- a/torch/lib/THNN/generic/ClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/ClassNLLCriterion.c
@@ -12,7 +12,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
           THTensor *total_weight,
           int64_t ignore_index)
 {
-  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+  THTensor_(resize1d)(output, 1);
   THNN_CHECK_DIM_SIZE(total_weight, 1, 0, 1);
   int n_dims = THTensor_(nDimension)(input);
   int n_classes = THTensor_(size)(input, n_dims - 1);

--- a/torch/lib/THNN/generic/DistKLDivCriterion.c
+++ b/torch/lib/THNN/generic/DistKLDivCriterion.c
@@ -10,8 +10,8 @@ void THNN_(DistKLDivCriterion_updateOutput)(
           bool sizeAverage)
 {
   THNN_CHECK_NELEMENT(input, target);
-  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
-  
+  THTensor_(resize1d)(output, 1);
+
   real sum = 0;
 
   TH_TENSOR_APPLY2(real, input, real, target,
@@ -32,7 +32,7 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
           bool sizeAverage)
 {
   THNN_CHECK_NELEMENT(input, target);
-  
+
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/torch/lib/THNN/generic/MSECriterion.c
+++ b/torch/lib/THNN/generic/MSECriterion.c
@@ -13,7 +13,7 @@ void THNN_(MSECriterion_updateOutput)(
   THNN_CHECK_NELEMENT(input, target);
 
   if (reduce) {
-    THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+    THTensor_(resize1d)(output, 1);
 
     real sum = 0;
 

--- a/torch/lib/THNN/generic/MultiLabelMarginCriterion.c
+++ b/torch/lib/THNN/generic/MultiLabelMarginCriterion.c
@@ -19,6 +19,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
 
   THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
 	     "vector or matrix expected");
+  THTensor_(resize1d)(output, 1);
 
   if (input->nDimension == 1)
   {

--- a/torch/lib/THNN/generic/MultiMarginCriterion.c
+++ b/torch/lib/THNN/generic/MultiMarginCriterion.c
@@ -22,6 +22,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
 
   THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
 	     "vector or matrix expected");
+  THTensor_(resize1d)(output, 1);
 
   if (input->nDimension == 1)
   {

--- a/torch/lib/THNN/generic/SmoothL1Criterion.c
+++ b/torch/lib/THNN/generic/SmoothL1Criterion.c
@@ -10,8 +10,8 @@ void THNN_(SmoothL1Criterion_updateOutput)(
           bool sizeAverage)
 {
   THNN_CHECK_NELEMENT(input, target);
-  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
-  
+  THTensor_(resize1d)(output, 1);
+
   real sum = 0;
   TH_TENSOR_APPLY2(real, input, real, target,
     real z = fabs(*input_data - *target_data);

--- a/torch/lib/THNN/generic/SoftMarginCriterion.c
+++ b/torch/lib/THNN/generic/SoftMarginCriterion.c
@@ -10,7 +10,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   bool sizeAverage)
 {
   THNN_CHECK_NELEMENT(input, target);
-  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+  THTensor_(resize1d)(output, 1);
 
   real sum;
 

--- a/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -38,6 +38,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
           int64_t ignore_index)
 {
   INITIAL_CHECK;
+  THTensor_(resize1d)(output, 1);
 
   input = THTensor_(newContiguous)(input);
   target = THIndexTensor_(newContiguous)(target);


### PR DESCRIPTION
Most NN functions size their outputs appropriately. This makes the
criterions used in PyTorch consistent with the other NN functions, which simplifies the generated bindings.