### PR TITLE
Add reduce keyword to NLLLoss and NLLLoss2d

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -27,6 +27,9 @@ PRECISION = 1e-5
 def get_size_average(m):
     return getattr(m, 'size_average', False) or getattr(m, 'sizeAverage', False)
 
+def get_weight(m):
+    return getattr(m, 'weight', None)
+
 module_tests = [
     dict(
         module_name='Linear',
@@ -239,6 +242,56 @@ module_tests = [
 ]
 
 
+def nllloss2d_reference(input, target, weight=None, ignore_index=-100,
+                        size_average=True, reduce=True):
+    N, C, H, W = input.size()
+    output = torch.zeros(N, H, W).type_as(input)
+    if isinstance(target, Variable):
+        target = target.data
+
+    if weight is None:
+        weight = torch.ones(C).type_as(input)
+
+    total_weight_data = 0
+    for n in range(0, N):
+        for h in range(0, H):
+            for w in range(0, W):
+                t_nhw = target[n][h][w]
+                norm = 0. if ignore_index == t_nhw else weight[t_nhw]
+                output[n][h][w] = -input[n][t_nhw][h][w] * norm
+                total_weight_data += norm
+
+    if reduce and size_average:
+        return output.sum() / total_weight_data
+    elif reduce:
+        return output.sum()
+    return output
+
+
+def nllloss_reference(input, target, weight=None, ignore_index=-100,
+                      size_average=True, reduce=True):
+    if isinstance(target, Variable):
+        target = target.data
+
+    def nll_loss_helper(input, target, weight, ignore_index):
+        if target is ignore_index:
+            return (0, 0)
+        norm = 1 if weight is None else weight[target]
+        result = -input[target] * norm
+        return (result, norm)
+
+    losses_and_weights = [nll_loss_helper(i, t, weight, ignore_index)
+                          for i, t in zip(input, target)]
+    losses, weights = zip(*losses_and_weights)
+    losses_tensor = torch.Tensor(losses).type_as(input)
+    if reduce and size_average:
+        return sum(losses_tensor) / sum(weights)
+    elif reduce:
+        return sum(losses_tensor)
+    else:
+        return losses_tensor
+
+
 criterion_tests = [
     dict(
         module_name='L1Loss',
@@ -251,13 +304,16 @@ criterion_tests = [
         module_name='NLLLoss',
         input_fn=lambda: torch.rand(15, 10).log(),
         target_fn=lambda: torch.Tensor(15).uniform_().mul(10).floor().long(),
-        check_no_size_average=True,
+        reference_fn=lambda i, t, m:
+            nllloss_reference(i, t, size_average=get_size_average(m)),
+        check_no_size_average=True
     ),
     dict(
         module_name='NLLLoss',
         constructor_args=(None, True, 2),
         input_fn=lambda: torch.rand(15, 10).log(),
         target_fn=lambda: torch.Tensor(15).uniform_().mul(10).floor().long(),
+        reference_fn=lambda i, t, _: nllloss_reference(i, t, ignore_index=2),
         desc='ignore_index'
     ),
     dict(
@@ -265,6 +321,8 @@ criterion_tests = [
         constructor_args_fn=lambda: (torch.rand(10),),
         input_fn=lambda: torch.rand(15, 10).add(1e-2).log(),
         target_fn=lambda: torch.Tensor(15).uniform_().mul(10).floor().long(),
+        reference_fn=lambda i, t, m:
+            nllloss_reference(i, t, weight=get_weight(m)),
         desc='weights',
     ),
     dict(
@@ -272,6 +330,8 @@ criterion_tests = [
         constructor_args_fn=lambda: (torch.rand(10), True, 2),
         input_fn=lambda: torch.rand(15, 10).add(1e-2).log(),
         target_fn=lambda: torch.Tensor(15).uniform_().mul(10).floor().long(),
+        reference_fn=lambda i, t, m:
+            nllloss_reference(i, t, weight=get_weight(m), ignore_index=2),
         desc='weights_ignore_index'
     ),
     dict(
@@ -279,6 +339,8 @@ criterion_tests = [
         constructor_args_fn=lambda: (torch.rand(10), True, -1),
         input_fn=lambda: torch.rand(15, 10).add(1e-2).log(),
         target_fn=lambda: torch.Tensor(15).uniform_().mul(10 + 1).floor().long() - 1,
+        reference_fn=lambda i, t, m:
+            nllloss_reference(i, t, weight=get_weight(m), ignore_index=-1),
         desc='weights_ignore_index_neg'
     ),
     dict(
@@ -324,6 +386,8 @@ criterion_tests = [
         module_name='NLLLoss2d',
         input_size=(2, 3, 5, 5),
         target_fn=lambda: torch.rand(2, 5, 5).mul(3).floor().long(),
+        reference_fn=lambda i, t, m:
+            nllloss2d_reference(i, t, size_average=get_size_average(m)),
         check_no_size_average=True,
     ),
     dict(
@@ -331,13 +395,17 @@ criterion_tests = [
         constructor_args_fn=lambda: (torch.rand(3),),
         input_size=(2, 3, 5, 5),
         target=torch.rand(2, 5, 5).mul(3).floor().long(),
+        reference_fn=lambda i, t, m:
+            nllloss2d_reference(i, t, weight=get_weight(m)),
         desc='weights',
     ),
     dict(
         module_name='NLLLoss2d',
-        constructor_args=(None, True, 3),
+        constructor_args=(None, True, 1),
         input_size=(2, 3, 5, 5),
-        target_fn=lambda: torch.rand(2, 5, 5).mul(4).floor().long(),
+        target_fn=lambda: torch.rand(2, 5, 5).mul(3).floor().long(),
+        reference_fn=lambda i, t, m:
+            nllloss2d_reference(i, t, ignore_index=1),
         desc='ignore_index',
     ),
     dict(

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -27,8 +27,12 @@ PRECISION = 1e-5
 def get_size_average(m):
     return getattr(m, 'size_average', False) or getattr(m, 'sizeAverage', False)
 
+
 def get_weight(m):
-    return getattr(m, 'weight', None)
+    result = getattr(m, 'weight', None)
+    if result is not None:
+        return result
+    return getattr(m, 'weights', None)
 
 module_tests = [
     dict(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3648,8 +3648,134 @@ def mseloss_no_reduce_module_test():
         reference_fn=lambda i, m: (i - target).pow(2))
 
 
+class TestNLLLoss(torch.nn.modules.module.Module):
+    def __init__(self, target, *args, **kwargs):
+        super(TestNLLLoss, self).__init__()
+        kwargs['reduce'] = False
+        self.nllloss = torch.nn.NLLLoss(*args, **kwargs)
+        self.target = target
+
+    def forward(self, input):
+        return self.nllloss.forward(input, self.target.type_as(input).long())
+
+
+def nllloss_no_reduce_module_test():
+    target = Variable(
+        torch.Tensor(15).uniform_().mul(10).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss_no_reduce',
+        module_name='TestNLLLoss',
+        constructor=TestNLLLoss,
+        constructor_args=(target, ),
+        input=torch.rand(15, 10).log())
+
+
+def nllloss_no_reduce_ignore_index_module_test():
+    target = Variable(
+        torch.Tensor(15).uniform_().mul(10).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss_no_reduce_ignore_index',
+        module_name='TestNLLLoss',
+        constructor=TestNLLLoss,
+        constructor_args=(target, None, True, 2),
+        input=torch.rand(15, 10).log())
+
+
+def nllloss_no_reduce_weights_module_test():
+    target = Variable(
+        torch.Tensor(15).uniform_().mul(10).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss_no_reduce_weights',
+        module_name='TestNLLLoss',
+        constructor=TestNLLLoss,
+        constructor_args=(target, torch.rand(10),),
+        input=torch.rand(15, 10).add(1e-2).log())
+
+
+def nllloss_no_reduce_weights_ignore_index_module_test():
+    target = Variable(
+        torch.Tensor(15).uniform_().mul(10).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss_no_reduce_weights_ignore_index',
+        module_name='TestNLLLoss',
+        constructor=TestNLLLoss,
+        constructor_args=(target, torch.rand(10), True, 2),
+        input=torch.rand(15, 10).add(1e-2).log())
+
+
+def nllloss_no_reduce_weights_ignore_index_neg_module_test():
+    target = Variable(
+        torch.Tensor(15).uniform_().mul(10 + 1).floor().long() - 1,
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss_no_reduce_weights_ignore_index_neg',
+        module_name='TestNLLLoss',
+        constructor=TestNLLLoss,
+        constructor_args=(target, torch.rand(10), True, -1),
+        input=torch.rand(15, 10).add(1e-2).log())
+
+
+class TestNLLLoss2d(torch.nn.modules.module.Module):
+    def __init__(self, target, *args, **kwargs):
+        super(TestNLLLoss2d, self).__init__()
+        kwargs['reduce'] = False
+        self.nllloss = torch.nn.NLLLoss2d(*args, **kwargs)
+        self.target = target
+
+    def forward(self, input):
+        return self.nllloss.forward(input, self.target.type_as(input).long())
+
+
+def nllloss2d_no_reduce_module_test():
+    target = Variable(
+        torch.rand(2, 5, 5).mul(3).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss2d_no_reduce',
+        module_name='TestNLLLoss2d',
+        constructor=TestNLLLoss2d,
+        constructor_args=(target,),
+        input_size=(2, 3, 5, 5))
+
+
+def nllloss2d_no_reduce_weights_module_test():
+    target = Variable(
+        torch.rand(2, 5, 5).mul(3).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss2d_no_reduce_weights',
+        module_name='TestNLLLoss2d',
+        constructor=TestNLLLoss2d,
+        constructor_args=(target, torch.rand(3)),
+        input_size=(2, 3, 5, 5))
+
+
+def nllloss2d_no_reduce_ignore_index_module_test():
+    target = Variable(
+        torch.rand(2, 5, 5).mul(4).floor().long(),
+        requires_grad=False)
+    return dict(
+        fullname='NLLLoss2d_no_reduce_ignore_index',
+        module_name='TestNLLLoss2d',
+        constructor=TestNLLLoss2d,
+        constructor_args=(target, None, True, 3),
+        input_size=(2, 3, 5, 5))
+
+
 new_module_tests = [
     mseloss_no_reduce_module_test(),
+    nllloss_no_reduce_module_test(),
+    nllloss_no_reduce_ignore_index_module_test(),
+    nllloss_no_reduce_weights_module_test(),
+    nllloss_no_reduce_weights_ignore_index_module_test(),
+    nllloss_no_reduce_weights_ignore_index_neg_module_test(),
+    nllloss2d_no_reduce_module_test(),
+    nllloss2d_no_reduce_weights_module_test(),
+    nllloss2d_no_reduce_ignore_index_module_test(),
     dict(
         module_name='BatchNorm1d',
         constructor_args=(10,),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -593,10 +593,12 @@
   grad_output: mse_loss_double_backward_grad_output(grad, grad_output, input, target, size_average, reduce)
   input: mse_loss_double_backward(grad * grad_output, input, size_average, reduce)
 
-- name: nll_loss_backward(Tensor input, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, Tensor total_weight)
+- name: nll_loss_backward(Tensor grad_output, Tensor input, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce, Tensor total_weight)
+  grad_output: nll_loss(grad, target, weight, size_average, ignore_index, reduce)
   input: zeros_like(grad)
 
-- name: nll_loss2d_backward(Tensor input, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, Tensor total_weight)
+- name: nll_loss2d_backward(Tensor grad_output, Tensor input, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce, Tensor total_weight)
+  grad_output: nll_loss2d(grad, target, weight, size_average, ignore_index, reduce)
   input: zeros_like(grad)
 
 - name: prelu_backward(Tensor grad_output, Tensor input, Tensor weight, std::array<bool, 2> output_mask)

--- a/torch/legacy/nn/ClassNLLCriterion.py
+++ b/torch/legacy/nn/ClassNLLCriterion.py
@@ -27,7 +27,8 @@ class ClassNLLCriterion(Criterion):
             self.sizeAverage,
             self.weights,
             self.total_weight_tensor,
-            self.ignore_index
+            self.ignore_index,
+            True,  # reduce
         )
         self.output = self.output_tensor[0]
         return self.output
@@ -35,16 +36,19 @@ class ClassNLLCriterion(Criterion):
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
         target = target.long()
+        implicit_gradOutput = torch.ones(1).type_as(input)
 
         self._backend.ClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
             self.sizeAverage,
             self.weights,
             self.total_weight_tensor,
-            self.ignore_index
+            self.ignore_index,
+            True,  # reduce
         )
 
         return self.gradInput

--- a/torch/legacy/nn/ClassNLLCriterion.py
+++ b/torch/legacy/nn/ClassNLLCriterion.py
@@ -36,7 +36,7 @@ class ClassNLLCriterion(Criterion):
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
         target = target.long()
-        implicit_gradOutput = torch.ones_like(input)
+        implicit_gradOutput = torch.ones(1).type_as(input)
 
         self._backend.ClassNLLCriterion_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/ClassNLLCriterion.py
+++ b/torch/legacy/nn/ClassNLLCriterion.py
@@ -36,7 +36,7 @@ class ClassNLLCriterion(Criterion):
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
         target = target.long()
-        implicit_gradOutput = torch.ones(1).type_as(input)
+        implicit_gradOutput = torch.ones_like(input)
 
         self._backend.ClassNLLCriterion_updateGradInput(
             self._backend.library_state,

--- a/torch/legacy/nn/SpatialClassNLLCriterion.py
+++ b/torch/legacy/nn/SpatialClassNLLCriterion.py
@@ -25,21 +25,25 @@ class SpatialClassNLLCriterion(Criterion):
             self.sizeAverage,
             self.weights,
             self.total_weight_tensor,
-            self.ignore_index
+            self.ignore_index,
+            True,  # reduce
         )
         self.output = self.output_tensor[0]
         return self.output
 
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.SpatialClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
             self.sizeAverage,
             self.weights,
             self.total_weight_tensor,
-            self.ignore_index
+            self.ignore_index,
+            True,  # reduce
         )
         return self.gradInput

--- a/torch/legacy/nn/SpatialClassNLLCriterion.py
+++ b/torch/legacy/nn/SpatialClassNLLCriterion.py
@@ -33,7 +33,7 @@ class SpatialClassNLLCriterion(Criterion):
 
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
-        implicit_gradOutput = torch.ones_like(input)
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.SpatialClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,

--- a/torch/legacy/nn/SpatialClassNLLCriterion.py
+++ b/torch/legacy/nn/SpatialClassNLLCriterion.py
@@ -33,7 +33,7 @@ class SpatialClassNLLCriterion(Criterion):
 
     def updateGradInput(self, input, target):
         self.gradInput.resize_as_(input).zero_()
-        implicit_gradOutput = torch.ones(1).type_as(input)
+        implicit_gradOutput = torch.ones_like(input)
         self._backend.SpatialClassNLLCriterion_updateGradInput(
             self._backend.library_state,
             input,

--- a/torch/lib/ATen/nn.yaml
+++ b/torch/lib/ATen/nn.yaml
@@ -19,11 +19,11 @@
   cname: MultiLabelMarginCriterion
   buffers: [is_target]
 
-- name: nll_loss(Tensor input, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100)
+- name: nll_loss(Tensor input, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100, bool reduce=True)
   cname: ClassNLLCriterion
   buffers: [total_weight]
 
-- name: nll_loss2d(Tensor input, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100)
+- name: nll_loss2d(Tensor input, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100, bool reduce=True)
   cname: SpatialClassNLLCriterion
   buffers: [total_weight]
 

--- a/torch/lib/THCUNN/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/ClassNLLCriterion.cu
@@ -42,7 +42,7 @@ __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
     int64_t batch_size,
     THCDeviceTensor<Dtype, 2> input,
     THCDeviceTensor<THCIndex_t, 1> target,
-    THCDeviceTensor<Dtype, 1> output, 
+    THCDeviceTensor<Dtype, 1> output,
     Dtype *weights,
     int64_t ignore_index) {
 

--- a/torch/lib/THCUNN/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/ClassNLLCriterion.cu
@@ -130,6 +130,7 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel(Dtype *output,
 template <typename Dtype>
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
   Dtype* gradInput,
+  Dtype gradOutput,
   Dtype* weights,
   THCIndex_t* target,
   Dtype* total_weight,
@@ -144,13 +145,14 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
   int t = (int)*target - TH_INDEX_BASE;
   if (t != (int) ignore_index) {
     assert(t >= 0 && t < n_classes);
-    gradInput[t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm;
+    gradInput[t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput;
   }
 }
 
 template <typename Dtype>
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
   Dtype *gradInput,
+  Dtype gradOutput,
   THCIndex_t *target,
   Dtype *weights,
   Dtype *total_weight,
@@ -170,7 +172,7 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
     t = (int)target[i] - TH_INDEX_BASE;
     if (t != (int) ignore_index) {
       assert(t >= 0 && t < n_classes);
-      gradInput[i * ndim + t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm;
+      gradInput[i * ndim + t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput;
     }
   }
 }

--- a/torch/lib/THCUNN/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/ClassNLLCriterion.cu
@@ -39,15 +39,15 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel1(Dtype *output,
 
 template <typename Dtype>
 __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
-    int64_t batch_size,
+    int batch_size,
     THCDeviceTensor<Dtype, 2> input,
     THCDeviceTensor<THCIndex_t, 1> target,
     THCDeviceTensor<Dtype, 1> output,
     Dtype *weights,
-    int64_t ignore_index) {
+    int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
-    int64_t cur_target = target[index];
+    int cur_target = target[index];
     if (cur_target == ignore_index) {
       output[index] = ScalarConvert<int, Dtype>::to(0);
       continue;
@@ -60,15 +60,15 @@ __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
 
 template <typename Dtype>
 __global__ void ClassNLLCriterion_updateGradInput_no_reduce_kernel(
-    int64_t batch_size,
+    int batch_size,
     THCDeviceTensor<THCIndex_t, 1> target,
     THCDeviceTensor<Dtype, 1> gradOutput,
     THCDeviceTensor<Dtype, 2> gradInput,
     Dtype *weights,
-    int64_t ignore_index) {
+    int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
-    int64_t cur_target = target[index];
+    int cur_target = target[index];
     if (cur_target == ignore_index) {
       continue;
     }
@@ -130,7 +130,7 @@ __global__ void cunn_ClassNLLCriterion_updateOutput_kernel(Dtype *output,
 template <typename Dtype>
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
   Dtype* gradInput,
-  Dtype gradOutput,
+  Dtype* gradOutput,
   Dtype* weights,
   THCIndex_t* target,
   Dtype* total_weight,
@@ -145,14 +145,14 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel1(
   int t = (int)*target - TH_INDEX_BASE;
   if (t != (int) ignore_index) {
     assert(t >= 0 && t < n_classes);
-    gradInput[t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput;
+    gradInput[t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput[0];
   }
 }
 
 template <typename Dtype>
 __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
   Dtype *gradInput,
-  Dtype gradOutput,
+  Dtype *gradOutput,
   THCIndex_t *target,
   Dtype *weights,
   Dtype *total_weight,
@@ -172,7 +172,7 @@ __global__ void cunn_ClassNLLCriterion_updateGradInput_kernel(
     t = (int)target[i] - TH_INDEX_BASE;
     if (t != (int) ignore_index) {
       assert(t >= 0 && t < n_classes);
-      gradInput[i * ndim + t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput;
+      gradInput[i * ndim + t] = -(weights ? weights[t] : ScalarConvert<int, Dtype>::to(1)) * norm * gradOutput[0];
     }
   }
 }

--- a/torch/lib/THCUNN/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/ClassNLLCriterion.cu
@@ -47,7 +47,7 @@ __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
     int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
-    int cur_target = target[index];
+    int cur_target = target[index] - TH_INDEX_BASE;
     if (cur_target == ignore_index) {
       output[index] = ScalarConvert<int, Dtype>::to(0);
       continue;
@@ -68,7 +68,7 @@ __global__ void ClassNLLCriterion_updateGradInput_no_reduce_kernel(
     int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
-    int cur_target = target[index];
+    int cur_target = target[index] - TH_INDEX_BASE;
     if (cur_target == ignore_index) {
       continue;
     }

--- a/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -3,9 +3,69 @@
 #include "THCHalfAutoNumerics.cuh"
 #include "THCAtomics.cuh"
 #include "common.h"
+#include "THCDeviceTensor.cuh"
+#include "THCDeviceTensorUtils.cuh"
+#include "THCDeviceUtils.cuh"
 #include <THC/THCApply.cuh>
 
 #include <thrust/functional.h>
+
+template <typename Dtype>
+__global__ void SpatialClassNLLCriterion_updateOutput_no_reduce_kernel(
+    int64_t nthreads,
+    THCDeviceTensor<Dtype, 4> input,
+    THCDeviceTensor<THCIndex_t, 3> target,
+    THCDeviceTensor<Dtype, 3> output,
+    Dtype *weights,
+    int64_t ignore_index) {
+  int64_t batch_size = input.getSize(0);
+  int64_t H = input.getSize(2);
+  int64_t W = input.getSize(3);
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int64_t b = index % batch_size;
+    const int64_t h = (index / batch_size) % H;
+    const int64_t w = (index / (batch_size * H)) % W;
+
+    int64_t cur_target = target[b][h][w];
+    if (cur_target == ignore_index) {
+      output[b][h][w] = ScalarConvert<int, Dtype>::to(0);
+      continue;
+    }
+    Dtype value = input[b][cur_target][h][w];
+    Dtype weight = 
+        weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1);
+    output[b][h][w] = -value * weight;
+  }
+}
+
+template <typename Dtype>
+__global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
+    int64_t nthreads,
+    THCDeviceTensor<THCIndex_t, 3> target,
+    THCDeviceTensor<Dtype, 3> gradOutput,
+    THCDeviceTensor<Dtype, 4> gradInput,
+    Dtype *weights,
+    int64_t ignore_index) {
+  int64_t batch_size = target.getSize(0);
+  int64_t H = target.getSize(1);
+  int64_t W = target.getSize(2);
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int64_t b = index % batch_size;
+    const int64_t h = (index / batch_size) % H;
+    const int64_t w = (index / (batch_size * H)) % W;
+
+    int64_t cur_target = target[b][h][w];
+    if (cur_target == ignore_index) {
+      continue;
+    }
+    Dtype value = 
+        -(weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1));
+    Dtype gradOutput_value = gradOutput[b][h][w];
+    gradInput[b][cur_target][h][w] = value * gradOutput_value;
+  }
+}
 
 template <typename T, typename AccumT>
 __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
@@ -67,6 +127,7 @@ __global__ void cunn_SpatialClassNLLCriterion_sizeAverage_kernel(
 template<typename T>
 __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
           T *gradInput,
+          T gradOutput,
           THCIndex_t *target,
           T *weights,
           T *total_weight,
@@ -93,7 +154,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
     t = (int)target[toffset + i] - TH_INDEX_BASE;
     if (t != ignore_index) {
       assert(t >= 0 && t < n_classes);
-      gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : ScalarConvert<int, T>::to(1)) * norm;
+      gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : ScalarConvert<int, T>::to(1)) * norm * gradOutput;
     }
   }
 }

--- a/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -33,7 +33,7 @@ __global__ void SpatialClassNLLCriterion_updateOutput_no_reduce_kernel(
       continue;
     }
     Dtype value = input[b][cur_target][h][w];
-    Dtype weight = 
+    Dtype weight =
         weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1);
     output[b][h][w] = -value * weight;
   }
@@ -60,7 +60,7 @@ __global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
     if (cur_target == ignore_index) {
       continue;
     }
-    Dtype value = 
+    Dtype value =
         -(weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1));
     Dtype gradOutput_value = gradOutput[b][h][w];
     gradInput[b][cur_target][h][w] = value * gradOutput_value;

--- a/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -62,8 +62,7 @@ __global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
     }
     Dtype value =
         -(weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1));
-    Dtype gradOutput_value = gradOutput[b][h][w];
-    gradInput[b][cur_target][h][w] = value * gradOutput_value;
+    gradInput[b][cur_target][h][w] = value * gradOutput[b][h][w];
   }
 }
 
@@ -127,7 +126,7 @@ __global__ void cunn_SpatialClassNLLCriterion_sizeAverage_kernel(
 template<typename T>
 __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
           T *gradInput,
-          T gradOutput,
+          T *gradOutput,
           THCIndex_t *target,
           T *weights,
           T *total_weight,
@@ -154,7 +153,7 @@ __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
     t = (int)target[toffset + i] - TH_INDEX_BASE;
     if (t != ignore_index) {
       assert(t >= 0 && t < n_classes);
-      gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : ScalarConvert<int, T>::to(1)) * norm * gradOutput;
+      gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : ScalarConvert<int, T>::to(1)) * norm * gradOutput[0];
     }
   }
 }

--- a/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -27,7 +27,7 @@ __global__ void SpatialClassNLLCriterion_updateOutput_no_reduce_kernel(
     const int64_t h = (index / batch_size) % H;
     const int64_t w = (index / (batch_size * H)) % W;
 
-    int64_t cur_target = target[b][h][w];
+    int64_t cur_target = target[b][h][w] - TH_INDEX_BASE;
     if (cur_target == ignore_index) {
       output[b][h][w] = ScalarConvert<int, Dtype>::to(0);
       continue;
@@ -56,7 +56,7 @@ __global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
     const int64_t h = (index / batch_size) % H;
     const int64_t w = (index / (batch_size * H)) % W;
 
-    int64_t cur_target = target[b][h][w];
+    int64_t cur_target = target[b][h][w] - TH_INDEX_BASE;
     if (cur_target == ignore_index) {
       continue;
     }

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -97,11 +97,13 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCIndexTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
            bool sizeAverage,
            THCTensor *weights,
            THCTensor *total_weight,
-           int64_t ignore_index) {
+           int64_t ignore_index,
+           bool reduce) {
   if (THCIndexTensor_(nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -18,6 +18,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
 
   int n_dims = THCTensor_(nDimension)(state, input);
   int n_classes = THCTensor_(size)(state, input, n_dims - 1);
+  ignore_index -= TH_INDEX_BASE;
 
   if (weights) {
     THCUNN_assertSameGPU(
@@ -70,8 +71,6 @@ void THNN_(ClassNLLCriterion_updateOutput)(
 
   THCTensor_(resize1d)(state, output, 1);
   THCTensor_(resize1d)(state, total_weight, 1);
-  ignore_index -= TH_INDEX_BASE;
-
 
   input = THCTensor_(newContiguous)(state, input);
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -179,9 +179,9 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         toDeviceTensor<real, 2>(state, gradInput),
         weights ? THCTensor_(data)(state, weights) : NULL,
         ignore_index);
-    
+ 
     if (weights) {
-      THCTensor_(free)(state, weights); 
+      THCTensor_(free)(state, weights);
     }
     return;
   }
@@ -194,7 +194,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
 
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;
   target = THCIndexTensor_(newContiguous)(state, target);
-  
+
   THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
   real gradOutput_data = THCTensor_(get1d)(state, gradOutput, 0);
   real *weights_data = weights ? THCTensor_(data)(state, weights) : NULL;

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -196,7 +196,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   target = THCIndexTensor_(newContiguous)(state, target);
 
   THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
-  real gradOutput_data = THCTensor_(get1d)(state, gradOutput, 0);
+  real *gradOutput_data = THCTensor_(data)(state, gradOutput);
   real *weights_data = weights ? THCTensor_(data)(state, weights) : NULL;
   real *gradInput_data = THCTensor_(data)(state, gradInput);
   THCIndex_t  *target_data = THCIndexTensor_(data)(state, target);

--- a/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -10,11 +10,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
            bool sizeAverage,
            THCTensor *weights,
            THCTensor *total_weight,
-           int64_t ignore_index) {
-  THCTensor_(resize1d)(state, output, 1);
-  THCTensor_(resize1d)(state, total_weight, 1);
-  ignore_index -= TH_INDEX_BASE;
-
+           int64_t ignore_index,
+           bool reduce) {
   if (THCIndexTensor_(nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
@@ -45,6 +42,37 @@ void THNN_(ClassNLLCriterion_updateOutput)(
     THError("weight tensor should be defined either for all %d classes or no classes"
             " but got weight tensor of shape: %s", n_classes, s1.str);
   }
+
+  if (!reduce && n_dims == 2) {
+    THCTensor_(resize1d)(state, output, batch_size);
+    bool not_contiguous_weights = weights && !THCTensor_(isContiguous)(state, weights);
+    if (not_contiguous_weights) {
+      weights = THCTensor_(newContiguous)(state, weights);
+    }
+
+    ClassNLLCriterion_updateOutput_no_reduce_kernel<real>
+      <<<GET_BLOCKS(batch_size), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+        batch_size,
+        toDeviceTensor<real, 2>(state, input),
+        toDeviceTensor<THCIndex_t, 1>(state, target),
+        toDeviceTensor<real, 1>(state, output),
+        weights ? THCTensor_(data)(state, weights) : NULL,
+        ignore_index);
+
+    if (not_contiguous_weights) {
+      THCTensor_(free)(state, weights);
+    }
+    return;
+  }
+
+  if (!reduce && n_dims <= 1) {
+    sizeAverage = false;
+  }
+
+  THCTensor_(resize1d)(state, output, 1);
+  THCTensor_(resize1d)(state, total_weight, 1);
+  ignore_index -= TH_INDEX_BASE;
+
 
   input = THCTensor_(newContiguous)(state, input);
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;
@@ -107,7 +135,6 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   if (THCIndexTensor_(nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
-  ignore_index -= TH_INDEX_BASE;
 
   int n_dims = THCTensor_(nDimension)(state, input);
   int n_classes = THCTensor_(size)(state, input, n_dims - 1);
@@ -138,6 +165,34 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
   if (weights && THCTensor_(nElement)(state, weights) != n_classes) {
     THError("weight tensor should be defined either for all or no classes");
   }
+
+  if (!reduce && n_dims == 2) {
+    THCUNN_check_dim_size(state, gradOutput, 1, 0, batch_size);
+    bool not_contiguous_weights = weights && !THCTensor_(isContiguous)(state, weights);
+    if (not_contiguous_weights) {
+      weights = THCTensor_(newContiguous)(state, weights);
+    }
+
+    ClassNLLCriterion_updateGradInput_no_reduce_kernel<real>
+      <<<GET_BLOCKS(batch_size), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+        batch_size,
+        toDeviceTensor<THCIndex_t, 1>(state, target),
+        toDeviceTensor<real, 1>(state, gradOutput),
+        toDeviceTensor<real, 2>(state, gradInput),
+        weights ? THCTensor_(data)(state, weights) : NULL,
+        ignore_index);
+    
+    if (not_contiguous_weights) {
+      THCTensor_(free)(state, weights); 
+    }
+    return;
+  }
+
+  if (!reduce && n_dims <= 1) {
+    sizeAverage = false;
+  }
+
+  ignore_index -= TH_INDEX_BASE;
 
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;
   target = THCIndexTensor_(newContiguous)(state, target);

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -29,7 +29,7 @@ void THNN_(SpatialClassNLLCriterion_shapeCheck)(
   }
 }
 
-void THNN_(SpatialClassNLLCriterion_gradOutput_no_reduce_shapeCheck)(
+static void THNN_(SpatialClassNLLCriterion_gradOutput_no_reduce_shapeCheck)(
            THCState *state,
            THCTensor *gradOutput,
            THCIndexTensor *target)
@@ -74,9 +74,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
     
     THCTensor_(resize3d)(state, output, batch_size, H, W);
 
-    bool not_contiguous_weights = 
-        weights && !THCTensor_(isContiguous)(state, weights);
-    if (not_contiguous_weights) {
+    if (weights) {
       weights = THCTensor_(newContiguous)(state, weights);
     }
 
@@ -90,7 +88,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
         weights ? THCTensor_(data)(state, weights) : NULL, 
         ignore_index);
 
-    if (not_contiguous_weights) {
+    if (weights) {
       THCTensor_(free)(state, weights);
     }
     return;
@@ -176,9 +174,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
     int64_t H = THCTensor_(size)(state, input, 2);
     int64_t W = THCTensor_(size)(state, input, 3);
 
-    bool not_contiguous_weights = 
-        weights && !THCTensor_(isContiguous)(state, weights);
-    if (not_contiguous_weights) {
+    if (weights) {
       weights = THCTensor_(newContiguous)(state, weights);
     }
 
@@ -192,7 +188,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
         weights ? THCTensor_(data)(state, weights) : NULL, 
         ignore_index);
 
-    if (not_contiguous_weights) {
+    if (weights) {
       THCTensor_(free)(state, weights);
     }
     return;
@@ -234,7 +230,5 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   THCIndexTensor_(free)(state, target);
   THCTensor_(free)(state, input);
 }
-
-#undef TO_DEVICE
 
 #endif

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -71,7 +71,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
     int64_t batch_size = THCTensor_(size)(state, input, 0);
     int64_t H = THCTensor_(size)(state, input, 2);
     int64_t W = THCTensor_(size)(state, input, 3);
-    
+
     THCTensor_(resize3d)(state, output, batch_size, H, W);
 
     if (weights) {
@@ -81,11 +81,11 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
     int64_t count = batch_size * H * W;
     SpatialClassNLLCriterion_updateOutput_no_reduce_kernel<real>
       <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-        count, 
-        toDeviceTensor<real, 4>(state, input), 
-        toDeviceTensor<THCIndex_t, 3>(state, target), 
-        toDeviceTensor<real, 3>(state, output), 
-        weights ? THCTensor_(data)(state, weights) : NULL, 
+        count,
+        toDeviceTensor<real, 4>(state, input),
+        toDeviceTensor<THCIndex_t, 3>(state, target),
+        toDeviceTensor<real, 3>(state, output),
+        weights ? THCTensor_(data)(state, weights) : NULL,
         ignore_index);
 
     if (weights) {
@@ -166,8 +166,8 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
 
   if (!reduce) {
     THNN_(SpatialClassNLLCriterion_gradOutput_no_reduce_shapeCheck)(
-        state, 
-        gradOutput, 
+        state,
+        gradOutput,
         target);
 
     int64_t batch_size = THCTensor_(size)(state, input, 0);
@@ -181,19 +181,19 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
     int64_t count = batch_size * H * W;
     SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel<real>
       <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-        count, 
-        toDeviceTensor<THCIndex_t, 3>(state, target), 
-        toDeviceTensor<real, 3>(state, gradOutput), 
-        toDeviceTensor<real, 4>(state, gradInput), 
-        weights ? THCTensor_(data)(state, weights) : NULL, 
+        count,
+        toDeviceTensor<THCIndex_t, 3>(state, target),
+        toDeviceTensor<real, 3>(state, gradOutput),
+        toDeviceTensor<real, 4>(state, gradInput),
+        weights ? THCTensor_(data)(state, weights) : NULL,
         ignore_index);
 
     if (weights) {
       THCTensor_(free)(state, weights);
     }
     return;
-  }  
-  
+  }
+
   input = THCTensor_(newContiguous)(state, input);
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;
   target = THCIndexTensor_(newContiguous)(state, target);

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -37,7 +37,8 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
            bool sizeAverage,
            THCTensor *weights,
            THCTensor *total_weight,
-           int64_t ignore_index)
+           int64_t ignore_index,
+           bool reduce)
 {
   THNN_(SpatialClassNLLCriterion_shapeCheck)(state, input, target, weights);
   THCTensor_(resize1d)(state, output, 1);
@@ -99,11 +100,13 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCIndexTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
            bool sizeAverage,
            THCTensor *weights,
            THCTensor *total_weight,
-           int64_t ignore_index)
+           int64_t ignore_index,
+           bool reduce)
 {
   THNN_(SpatialClassNLLCriterion_shapeCheck)(state, input, target, weights);
   THCTensor_(resizeAs)(state, gradInput, input);

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -61,6 +61,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   THNN_(SpatialClassNLLCriterion_shapeCheck)(state, input, target, weights);
   THCTensor_(resize1d)(state, output, 1);
   THCTensor_(resize1d)(state, total_weight, 1);
+  ignore_index -= TH_INDEX_BASE;
 
   if (weights)
     THCUNN_assertSameGPU(state, 5, input, target, weights, output, total_weight);
@@ -158,6 +159,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THArgCheck(THCTensor_(isContiguous)(state, gradInput), 4,
              "gradInput must be contiguous");
+  ignore_index -= TH_INDEX_BASE;
 
   if (weights)
     THCUNN_assertSameGPU(state, 5, weights, input, target, gradInput, total_weight);

--- a/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/torch/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -198,6 +198,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   weights = weights ? THCTensor_(newContiguous)(state, weights) : NULL;
   target = THCIndexTensor_(newContiguous)(state, target);
 
+  real *gradOutput_data = THCTensor_(data)(state, gradOutput);
   real *weights_data = weights ? THCTensor_(data)(state, weights) : NULL;
   real *gradInput_data = THCTensor_(data)(state, gradInput);
   THCIndex_t *target_data = THCIndexTensor_(data)(state, target);
@@ -212,7 +213,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   cunn_SpatialClassNLLCriterion_updateGradInput_kernel
     <<<total_blocks, CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
       gradInput_data,
-      THCTensor_(get1d)(state, gradOutput, 0),
+      gradOutput_data,
       target_data,
       weights_data,
       total_weight_data,

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -81,17 +81,20 @@ TH_API void THNN_(ClassNLLCriterion_updateOutput)(
                   bool sizeAverage,
                   THCTensor *weights,       // [OPTIONAL]
                   THCTensor *total_weight,
-                  int64_t ignore_index);
+                  int64_t ignore_index,
+                  bool reduce);
 
 TH_API void THNN_(ClassNLLCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
                   bool sizeAverage,
                   THCTensor *weights,       // [OPTIONAL]
                   THCTensor *total_weight,
-                  int64_t ignore_index);
+                  int64_t ignore_index,
+                  bool reduce);
 
 TH_API void THNN_(DistKLDivCriterion_updateOutput)(
                   THCState *state,
@@ -574,17 +577,20 @@ TH_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
                   bool sizeAverage,
                   THCTensor *weights,       // [OPTIONAL]
                   THCTensor *total_weight,
-                  int64_t ignore_index);
+                  int64_t ignore_index,
+                  bool reduce);
 
 TH_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
                   bool sizeAverage,
                   THCTensor *weights,       // [OPTIONAL]
                   THCTensor *total_weight,
-                  int64_t ignore_index);
+                  int64_t ignore_index,
+                  bool reduce);
 
 TH_API void THNN_(SpatialConvolutionLocal_updateOutput)(
                   THCState *state,

--- a/torch/lib/THNN/generic/ClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/ClassNLLCriterion.c
@@ -10,7 +10,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
           bool sizeAverage,
           THTensor *weights,
           THTensor *total_weight,
-          int64_t ignore_index)
+          int64_t ignore_index,
+          bool reduce)
 {
   THTensor_(resize1d)(output, 1);
   THTensor_(resize1d)(total_weight, 1);
@@ -83,11 +84,13 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THIndexTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
           bool sizeAverage,
           THTensor *weights,
           THTensor *total_weight,
-          int64_t ignore_index)
+          int64_t ignore_index,
+          bool reduce)
 {
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(zero)(gradInput);

--- a/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -27,6 +27,25 @@
               input0, input1, input2, input3, target0, target1, target2);        \
   }
 
+#define GRADOUTPUT_SHAPE_CHECK                                                \
+  THArgCheck(THTensor_(nDimension)(gradOutput) == 3, 3,                       \
+    "gradOutput must have same dimension as target (3)"                       \
+	     " but got dimension: %d",			                                        \
+	     THTensor_(nDimension)(gradOutput));			                              \
+  {                                                                           \
+    int64_t gradOutput0 = THTensor_(size)(gradOutput, 0);                     \
+    int64_t gradOutput1 = THTensor_(size)(gradOutput, 1);                     \
+    int64_t gradOutput2 = THTensor_(size)(gradOutput, 2);                     \
+    int64_t target0 = THIndexTensor_(size)(target, 0);                        \
+    int64_t target1 = THIndexTensor_(size)(target, 1);                        \
+    int64_t target2 = THIndexTensor_(size)(target, 2);                        \
+    THAssertMsg(                                                              \
+        gradOutput0 == target0 && gradOutput1 == target1 && gradOutput2 == target2, \
+        "size mismatch (got gradOutput: %ldx%ldx%ld, target: %ldx%ldx%ld)",   \
+        gradOutput0, gradOutput1, gradOutput2, target0, target1, target2);    \
+  }
+
+
 void THNN_(SpatialClassNLLCriterion_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -41,6 +60,31 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   INITIAL_CHECK;
   THTensor_(resize1d)(output, 1);
   THTensor_(resize1d)(total_weight, 1);
+
+  if (!reduce) {
+    int64_t batch_size = THTensor_(size)(input, 0);
+    int64_t H = THTensor_(size)(input, 2);
+    int64_t W = THTensor_(size)(input, 3);
+    THTensor_(resize3d)(output, batch_size, H, W);
+
+    int64_t b, h, w;
+    #pragma omp parallel for private(b, h, w)
+    for (b = 0; b < batch_size; b++) {
+      for (h = 0; h < H; h++) {
+        for (w = 0; w < W; w++) {
+          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w);
+          if (cur_target == ignore_index) {
+            THTensor_(set3d)(output, b, h, w, 0.0f);
+            continue;
+          }
+          real value = THTensor_(get4d)(input, b, cur_target, h, w);
+          real weight = weights ? THTensor_(get1d)(weights, cur_target) : 1.0f;
+          THTensor_(set3d)(output, b, h, w, -value * weight);
+        }
+      }
+    }
+    return;
+  }
 
   input = THTensor_(newContiguous)(input);
   target = THIndexTensor_(newContiguous)(target);
@@ -99,6 +143,34 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   THTensor_(zero)(gradInput);
   THArgCheck(THTensor_(isContiguous)(gradInput), 4,
               "gradInput must be contiguous");
+  THNN_CHECK_SHAPE(input, gradInput);
+
+  if (!reduce) {
+    GRADOUTPUT_SHAPE_CHECK;
+
+    int64_t batch_size = THTensor_(size)(input, 0);
+    int64_t H = THTensor_(size)(input, 2);
+    int64_t W = THTensor_(size)(input, 3);
+
+    int64_t b, h, w;
+    #pragma omp parallel for private(b, h, w)
+    for (b = 0; b < batch_size; b++) {
+      for (h = 0; h < H; h++) {
+        for (w = 0; w < W; w++) {
+          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w);
+          if (cur_target == ignore_index) {
+            continue;
+          }
+          real value = -(weights ? THTensor_(get1d)(weights, cur_target) : 1.0f);
+          real gradOutput_value = THTensor_(get3d)(gradOutput, b, h, w);
+          THTensor_(set4d)(gradInput, b, cur_target, h, w, value * gradOutput_value);
+        }
+      }
+    }
+    return;
+  }
+
+  THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, 1);
 
   real *total_weight_data = THTensor_(data)(total_weight);
   if (*total_weight_data <= 0)
@@ -116,7 +188,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   int64_t map_size = THTensor_(size)(input, 2) * THTensor_(size)(input, 3);
   int64_t sample_size = map_size * n_classes;
 
-  real normalize = sizeAverage ? *total_weight_data : 1.0f;
+  real normalize = (sizeAverage) ? *total_weight_data : 1.0f;
 
   int b;
   #pragma omp parallel for
@@ -127,8 +199,10 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
       if (cur_target == ignore_index) continue;
       THAssert(cur_target >= 0 && cur_target < n_classes);
 
-      gradInput_data[b * sample_size + cur_target * map_size + elem] =
+      int index = b * sample_size + cur_target * map_size + elem;
+      gradInput_data[index] =
         -(weights ? weights_data[cur_target] : 1.0f) / normalize;
+      gradInput_data[index] *= THTensor_(get1d)(gradOutput, 0);
     }
   }
 

--- a/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -74,12 +74,12 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
         for (w = 0; w < W; w++) {
           int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w);
           if (cur_target == ignore_index) {
-            THTensor_(set3d)(output, b, h, w, 0.0f);
+            THTensor_fastSet3d(output, b, h, w, 0.0f);
             continue;
           }
-          real value = THTensor_(get4d)(input, b, cur_target, h, w);
-          real weight = weights ? THTensor_(get1d)(weights, cur_target) : 1.0f;
-          THTensor_(set3d)(output, b, h, w, -value * weight);
+          real value = THTensor_fastGet4d(input, b, cur_target, h, w);
+          real weight = weights ? THTensor_fastGet1d(weights, cur_target) : 1.0f;
+          THTensor_fastSet3d(output, b, h, w, -value * weight);
         }
       }
     }
@@ -161,9 +161,9 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
           if (cur_target == ignore_index) {
             continue;
           }
-          real value = -(weights ? THTensor_(get1d)(weights, cur_target) : 1.0f);
-          real gradOutput_value = THTensor_(get3d)(gradOutput, b, h, w);
-          THTensor_(set4d)(gradInput, b, cur_target, h, w, value * gradOutput_value);
+          real value = -(weights ? THTensor_fastGet1d(weights, cur_target) : 1.0f);
+          real gradOutput_value = THTensor_fastGet3d(gradOutput, b, h, w);
+          THTensor_fastSet4d(gradInput, b, cur_target, h, w, value * gradOutput_value);
         }
       }
     }
@@ -201,8 +201,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
 
       int index = b * sample_size + cur_target * map_size + elem;
       gradInput_data[index] =
-        -(weights ? weights_data[cur_target] : 1.0f) / normalize;
-      gradInput_data[index] *= THTensor_(get1d)(gradOutput, 0);
+        -(weights ? weights_data[cur_target] : 1.0f) / normalize * THTensor_fastGet1d(gradOutput, 0);
     }
   }
 

--- a/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -60,6 +60,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
   INITIAL_CHECK;
   THTensor_(resize1d)(output, 1);
   THTensor_(resize1d)(total_weight, 1);
+  ignore_index -= TH_INDEX_BASE;
 
   if (!reduce) {
     int64_t batch_size = THTensor_(size)(input, 0);
@@ -72,7 +73,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
     for (b = 0; b < batch_size; b++) {
       for (h = 0; h < H; h++) {
         for (w = 0; w < W; w++) {
-          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w);
+          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w) - TH_INDEX_BASE;
           if (cur_target == ignore_index) {
             THTensor_fastSet3d(output, b, h, w, 0.0f);
             continue;
@@ -144,6 +145,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
   THArgCheck(THTensor_(isContiguous)(gradInput), 4,
               "gradInput must be contiguous");
   THNN_CHECK_SHAPE(input, gradInput);
+  ignore_index -= TH_INDEX_BASE;
 
   if (!reduce) {
     GRADOUTPUT_SHAPE_CHECK;
@@ -157,7 +159,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
     for (b = 0; b < batch_size; b++) {
       for (h = 0; h < H; h++) {
         for (w = 0; w < W; w++) {
-          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w);
+          int64_t cur_target = (int64_t)THIndexTensor_(get3d)(target, b, h, w) - TH_INDEX_BASE;
           if (cur_target == ignore_index) {
             continue;
           }

--- a/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/torch/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -35,7 +35,8 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
           bool sizeAverage,
           THTensor *weights,
           THTensor *total_weight,
-          int64_t ignore_index)
+          int64_t ignore_index,
+          bool reduce)
 {
   INITIAL_CHECK;
   THTensor_(resize1d)(output, 1);
@@ -85,11 +86,13 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THIndexTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
           bool sizeAverage,
           THTensor *weights,
           THTensor *total_weight,
-          int64_t ignore_index)
+          int64_t ignore_index,
+          bool reduce)
 {
   INITIAL_CHECK;
   THTensor_(resizeAs)(gradInput, input);

--- a/torch/lib/THNN/generic/THNN.h
+++ b/torch/lib/THNN/generic/THNN.h
@@ -48,16 +48,19 @@ TH_API void THNN_(ClassNLLCriterion_updateOutput)(
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
           THTensor *total_weight,      // [BUFFER]
-          int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
+          int64_t ignore_index,        // target index to ignore (loss = 0, gradInput = 0)
+          bool reduce);
 TH_API void THNN_(ClassNLLCriterion_updateGradInput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor (1D/2D)
           THIndexTensor *target,       // tensor containing indexes of target classes
+          THTensor *gradOutput,
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
           THTensor *total_weight,      // [BUFFER]
-          int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
+          int64_t ignore_index,        // target index to ignore (loss = 0, gradInput = 0)
+          bool reduce);
 
 TH_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
           THNNState *state,            // library's state
@@ -67,17 +70,20 @@ TH_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
           THTensor *total_weight,      // [BUFFER]
-          int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
+          int64_t ignore_index,        // target index to ignore (loss = 0, gradInput = 0)
+          bool reduce);
 
 TH_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor (4D)
           THIndexTensor *target,       // tensor containing indexes of target classes (3D)
+          THTensor *gradOutput,
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
           THTensor *total_weight,      // [BUFFER]
-          int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
+          int64_t ignore_index,        // target index to ignore (loss = 0, gradInput = 0)
+          bool reduce);
 
 TH_API void THNN_(ELU_updateOutput)(
           THNNState *state,            // library's state

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -886,7 +886,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
 
 # loss
 
-def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100):
+def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, reduce=True):
     r"""The negative log likelihood loss.
 
     See :class:`~torch.nn.NLLLoss` for details.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -917,9 +917,9 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
     if torch.is_tensor(weight):
         weight = Variable(weight)
     if dim == 2:
-        return torch._C._nn.nll_loss(input, target, weight, size_average, ignore_index)
+        return torch._C._nn.nll_loss(input, target, weight, size_average, ignore_index, reduce)
     elif dim == 4:
-        return torch._C._nn.nll_loss2d(input, target, weight, size_average, ignore_index)
+        return torch._C._nn.nll_loss2d(input, target, weight, size_average, ignore_index, reduce)
     else:
         raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -122,14 +122,15 @@ class NLLLoss(_WeightedLoss):
         >>> output.backward()
     """
 
-    def __init__(self, weight=None, size_average=True, ignore_index=-100):
+    def __init__(self, weight=None, size_average=True, ignore_index=-100, reduce=True):
         super(NLLLoss, self).__init__(weight, size_average)
         self.ignore_index = ignore_index
+        self.reduce = reduce
 
     def forward(self, input, target):
         _assert_no_grad(target)
         return F.nll_loss(input, target, self.weight, self.size_average,
-                          self.ignore_index)
+                          self.ignore_index, self.reduce)
 
 
 class NLLLoss2d(NLLLoss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -101,14 +101,19 @@ class NLLLoss(_WeightedLoss):
         size_average (bool, optional): By default, the losses are averaged
            over observations for each minibatch. However, if the field
            size_average is set to False, the losses are instead summed for
-           each minibatch. Default: True
+           each minibatch. Ignored when reduce is False. Default: True
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average
             is True, the loss is averaged over non-ignored targets.
+        reduce (bool, optional): By default, the losses are averaged or summed
+            for each minibatch. When reduce is False, the loss function returns
+            a loss per batch element instead and ignores size_average.
+            Default: True
 
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
         - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
+        - Output: scalar. If reduce is False, then :math:`(N)` instead.
 
     Examples::
 
@@ -144,11 +149,17 @@ class NLLLoss2d(NLLLoss):
         size_average: By default, the losses are averaged over observations
             for each minibatch. However, if the field size_average is set to
             False, the losses are instead summed for each minibatch.
-            Default: True
+            Ignored when reduce is False. Default: True
+        reduce (bool, optional): By default, the losses are averaged or summed
+            for each minibatch depending on size_average. When reduce is False,
+            the loss function returns a loss per batch element instead and
+            ignores size_average. Default: True
+
 
     Shape:
         - Input: :math:`(N, C, H, W)` where `C = number of classes`
         - Target: :math:`(N, H, W)` where each value is `0 <= targets[i] <= C-1`
+        - Output: scalar. If reduce is False, then :math:`(N, H, W)` instead.
 
     Examples::
 


### PR DESCRIPTION
### Summary
Adding a reduce keyword to NLLLoss as per https://github.com/pytorch/pytorch/issues/264. 
By default reduce is True and gives the usual behavior; when reduce is False the loss returns
a loss per element.

### Test Plan
Added a few new module unit tests. Each unit test is analogous to a criterion test (in the case that reduce is True):
- NLLLoss, no reduce
- NLLLoss, no reduce, ignore index
- NLLLoss, no reduce, weights
- NLLLoss, no reduce, weights and ignore index
- NLLLoss, no reduce, negative ignore index
- NLLLoss2d, no reduce
- NLLLoss2d, weights
- NLLLoss2d, ignore index

Also ran gradcheck by hand for several of the above cases. Example code:
```
import torch
import torch.autograd as autograd
import torch.nn as nn

loss = nn.NLLLoss(size_average=False)
loss2 = nn.NLLLoss(reduce=False)
input = autograd.Variable(torch.randn(3, 5).double().cuda(), requires_grad=True)
target = autograd.Variable(torch.LongTensor([1, 0, 4]).cuda(), requires_grad=False)
autograd.gradcheck(loss2, (input, target), raise_exception=True)
sum(loss2(input, target)) - loss(input, target)  # check that this is 0
```