### PR TITLE
isCountiguous problems

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1075,17 +1075,6 @@ class TestNN(NNTestCase):
 
         y.backward(grad)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_conv_transpose2d_contig_wrong_stride_dim1_cuda(self):
-        # x has to have batch_size 1 to test contiguous checks
-        x = torch.randn(1, 16, 5, 5).cuda()
-        stride = list(x.stride())
-        stride[0] = 20
-        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
-        x.set_(x.storage(), 0, x.size(), stride)
-        assert x.is_contiguous()
-        F.conv_transpose2d(Variable(x), Variable(torch.randn(16, 1, 1, 1)).cuda())
-
     def test_EmbeddingBag(self):
         self._test_EmbeddingBag(False, 'sum')
         self._test_EmbeddingBag(False, 'mean')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1075,6 +1075,17 @@ class TestNN(NNTestCase):
 
         y.backward(grad)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_conv_transpose2d_contig_wrong_stride_dim1_cuda(self):
+        # x has to have batch_size 1 to test contiguous checks
+        x = torch.randn(1, 16, 5, 5).cuda()
+        stride = list(x.stride())
+        stride[0] = 20
+        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
+        x.set_(x.storage(), 0, x.size(), stride)
+        assert x.is_contiguous()
+        F.conv_transpose2d(Variable(x), Variable(torch.randn(16, 1, 1, 1)).cuda())
+
     def test_EmbeddingBag(self):
         self._test_EmbeddingBag(False, 'sum')
         self._test_EmbeddingBag(False, 'mean')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4417,6 +4417,29 @@ class TestTorch(TestCase):
         id_after = id(t)
         self.assertEqual(id_before, id_after)
 
+    def test_contiguous(self):
+        # x has to have batch_size 1 to test contiguous checks
+        x = torch.randn(1, 16, 5, 5)
+        assert x.is_contiguous()
+        stride = list(x.stride())
+        stride[0] = 20
+        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
+        x.set_(x.storage(), 0, x.size(), stride)
+        assert x.is_contiguous()
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_contiguous_cuda(self):
+        # x has to have batch_size 1 to test contiguous checks
+        x = torch.randn(1, 16, 5, 5).cuda()
+        assert x.is_contiguous()
+        stride = list(x.stride())
+        stride[0] = 20
+        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
+        x.set_(x.storage(), 0, x.size(), stride)
+        assert x.is_contiguous()
+        new_x = x.contiguous()
+        self.assertEqual(new_x.stride(), [400, 25, 5, 1])
+
 # Functions to test negative dimension wrapping
 METHOD = 1
 INPLACE_METHOD = 2

--- a/torch/lib/TH/generic/THTensorRandom.c
+++ b/torch/lib/TH/generic/THTensorRandom.c
@@ -127,13 +127,13 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
   THTensor_(resize1d)(q, inputsize);
   real *q_data = THTensor_(data)(q);
   int64_t *J_data = THLongTensor_data(J);
-      
+
   for (i = 0; i < inputsize; i++)
     {
       THTensor_fastSet1d(J, i, 0L);
       real val = THTensor_fastGet1d(probs, i);
       THTensor_fastSet1d(q, i, inputsize*val);
-      
+
       if (inputsize * val < 1.0)
         {
           THTensor_fastSet1d(smaller, small_c, i);
@@ -154,7 +154,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     {
       large = THTensor_fastGet1d(larger, large_c-1);
       small = THTensor_fastGet1d(smaller, small_c-1);
-      
+
       THTensor_fastSet1d(J, small, large);
       q_data[large * q->stride[0]] -= 1.0 - THTensor_fastGet1d(q, small);
 
@@ -184,7 +184,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
   THArgCheckWithCleanup((q_min > 0),
                         THCleanup(THLongTensor_free(smaller); THLongTensor_free(larger);), 2,
                         "q_min is less than 0");
-  
+
   if (q_max > 1)
     {
       for (i=0; i < inputsize; i++)
@@ -194,7 +194,7 @@ void THTensor_(multinomialAliasSetup)(THTensor *probs, THLongTensor *J, THTensor
     }
   for (i=0; i < inputsize; i++)
     {
-      // sometimes an large index isn't added to J. 
+      // sometimes an large index isn't added to J.
       // fix it by making the probability 1 so that J isn't indexed.
       if(J_data[i] <= 0)
         q_data[i] = 1.0;
@@ -217,7 +217,7 @@ void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator
       _q = THTensor_fastGet1d(q, rand_ind);
 
       _mask = THRandom_bernoulli(_generator, _q);
-      
+
       J_sample = THTensor_fastGet1d(J, rand_ind);
 
       sample_idx = J_sample*(1 -_mask) + (rand_ind+1L) * _mask;
@@ -409,6 +409,6 @@ void THTensor_(setRNGState)(THGenerator *_generator, THTensor *self)
 }
 #endif
 
-#endif
-
 #undef RANDOM64
+
+#endif

--- a/torch/lib/THC/THCDeviceTensor.cuh
+++ b/torch/lib/THC/THCDeviceTensor.cuh
@@ -181,8 +181,8 @@ class THCDeviceTensor {
   // touch the same memory locations multiple times.
   __host__ __device__ bool isConsistentlySized() const;
 
-  /// Returns true if the given dimension index has no padding
-  __host__ __device__ bool isContiguousDim(int i) const;
+  /// Returns true if the given dimension range [first, last) has no padding.
+  __host__ __device__ bool isContiguousRange(int first, int last) const;
 
   /// Returns a tensor of the same dimension after transposing the two
   /// dimensions given. Does not actually move elements; transposition

--- a/torch/lib/THC/generic/THCTensor.c
+++ b/torch/lib/THC/generic/THCTensor.c
@@ -184,12 +184,48 @@ THCTensor *THCTensor_(newClone)(THCState *state, THCTensor *self)
   return tensor;
 }
 
+// isContiguous doesn't care about strides for dimensions of size 1. This
+// variant checks those strides while checking contiguity.
+// This function is currently only used by newContiguous and not exposed in API.
+static int THCTensor_(isContiguousDetectOneSizedDimStride)(
+  THCState *state, THCTensor *self, int *should_update_stride)
+{
+  *should_update_stride = 0;
+  int64_t z = 1;
+  int d;
+  for(d = self->nDimension-1; d >= 0; d--)
+  {
+    if(self->size[d] != 1)
+    {
+      if(self->stride[d] == z)
+        z *= self->size[d];
+      else
+        return 0;
+    } else if (!(*should_update_stride)) {
+      *should_update_stride = (self->stride[d] != z);
+    }
+  }
+  return 1;
+}
+
 THCTensor *THCTensor_(newContiguous)(THCState *state, THCTensor *self)
 {
-  if(!THCTensor_(isContiguous)(state, self))
+  int should_update_stride = 0;
+  if(!THCTensor_(isContiguousDetectOneSizedDimStride)(state, self, &should_update_stride)) {
     return THCTensor_(newClone)(state, self);
-  else
-  {
+  }
+  if (should_update_stride) {
+    THLongStorage *new_stride = THLongStorage_newWithSize(self->nDimension);
+    int64_t z = 1;
+    for(int d = self->nDimension-1; d >= 0; d--)
+    {
+      new_stride->data[d] = z;
+      z *= self->size[d];
+    }
+    return THCTensor_(newWithStorage)(state, self->storage, self->storageOffset,
+                                      THCTensor_(newSizeOf)(state, self),
+                                      new_stride);
+  } else {
     THCTensor_(retain)(state, self);
     return self;
   }

--- a/torch/lib/THC/generic/THCTensor.c
+++ b/torch/lib/THC/generic/THCTensor.c
@@ -222,9 +222,13 @@ THCTensor *THCTensor_(newContiguous)(THCState *state, THCTensor *self)
       new_stride->data[d] = z;
       z *= self->size[d];
     }
-    return THCTensor_(newWithStorage)(state, self->storage, self->storageOffset,
-                                      THCTensor_(newSizeOf)(state, self),
-                                      new_stride);
+    THLongStorage *new_size = THCTensor_(newSizeOf)(state, self);
+    THCTensor*tensor = THCTensor_(newWithStorage)(state, self->storage,
+                                                  self->storageOffset,
+                                                  new_size, new_stride);
+    THLongStorage_free(new_stride);
+    THLongStorage_free(new_size);
+    return tensor;
   } else {
     THCTensor_(retain)(state, self);
     return self;


### PR DESCRIPTION
1. Fixes #3064 . Cause: cuDNN doesn't like tensor to have bizarre stride at size-1 dimensions. Fixed by letting THCTensor's `newContiguous` fix these strides. 

2. Previous fix to `isContiguousDim` in #3011 is only partially correct. That allows some dimension before size-1 dimension to incorrectly fail check, e.g. size `[4,1,3]`, stride `[3,50,1]`. It is impossible to do point checks without considering all dimensions of interest. This PR changes `isContiguousDim` to `isContiguousRange`.

3. Fix a mis-scoped `undef` in #3042 .

