### PR TITLE
Don't free interned Python strings held in global variables

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -226,7 +226,7 @@ static void missing_args(const FunctionSignature& signature, int idx) {
 static ssize_t find_param(FunctionSignature& signature, PyObject* name) {
   ssize_t i = 0;
   for (auto& param : signature.params) {
-    int cmp = PyObject_RichCompareBool(name, param.python_name.get(), Py_EQ);
+    int cmp = PyObject_RichCompareBool(name, param.python_name, Py_EQ);
     if (cmp < 0) {
       throw python_error();
     } else if (cmp) {
@@ -309,7 +309,7 @@ bool FunctionSignature::parse(PyObject* args, PyObject* kwargs, PyObject* dst[],
       }
     }
 
-    obj = kwargs ? PyDict_GetItem(kwargs, param.python_name.get()) : nullptr;
+    obj = kwargs ? PyDict_GetItem(kwargs, param.python_name) : nullptr;
     if (obj) {
       remaining_kwargs--;
       if (!param.check(obj)) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -109,7 +109,9 @@ struct FunctionParameter {
   bool optional;
   bool keyword_only;
   std::string name;
-  THPObjectPtr python_name;
+  // having this as a raw PyObject * will presumably leak it, but these are only held by static objects
+  // anyway, and Py_Finalize can already be called when this is destructed.
+  PyObject *python_name;
   at::Scalar default_scalar;
   union {
     bool default_bool;


### PR DESCRIPTION
This pulls in @gchanan's fix for some crashes on exit in PyArgParser
from #2997