### PR TITLE
Add compiler error when compiling with an outdated cuDNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Once you have [Anaconda](https://www.continuum.io/downloads) installed, here are
 
 If you want to compile with CUDA support, install
 - [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 7.5 or above
-- [NVIDIA cuDNN](https://developer.nvidia.com/cudnn) v5.x or above
+- [NVIDIA cuDNN](https://developer.nvidia.com/cudnn) v6.x or above
 
 If you want to disable CUDA support, export environment variable `NO_CUDA=1`.
 

--- a/torch/csrc/cudnn/AffineGridGenerator.h
+++ b/torch/csrc/cudnn/AffineGridGenerator.h
@@ -4,7 +4,7 @@
 #include "../Types.h"
 #include "THC/THC.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/BatchNorm.h
+++ b/torch/csrc/cudnn/BatchNorm.h
@@ -2,7 +2,7 @@
 #define THP_CUDNN_BATCH_NORM_INC
 
 #include "../Types.h"
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "THC/THC.h"
 
 

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -4,7 +4,7 @@
 #include "Exceptions.h"
 #include "Types.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <functional>
 #include <iterator>
 #include <sstream>

--- a/torch/csrc/cudnn/Conv.h
+++ b/torch/csrc/cudnn/Conv.h
@@ -6,7 +6,7 @@
 
 #include "Descriptors.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <vector>
 
 namespace torch { namespace cudnn {

--- a/torch/csrc/cudnn/Descriptors.h
+++ b/torch/csrc/cudnn/Descriptors.h
@@ -3,7 +3,7 @@
 
 #include "Exceptions.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Exceptions.h
+++ b/torch/csrc/cudnn/Exceptions.h
@@ -2,7 +2,7 @@
 #define THP_CUDNN_EXCEPTIONS_INC
 
 #include <THC/THC.h>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <string>
 #include <stdexcept>
 #include <sstream>

--- a/torch/csrc/cudnn/GridSampler.h
+++ b/torch/csrc/cudnn/GridSampler.h
@@ -4,7 +4,7 @@
 #include "../Types.h"
 #include "THC/THC.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Handles.h
+++ b/torch/csrc/cudnn/Handles.h
@@ -1,7 +1,7 @@
 #ifndef THP_CUDNN_HANDLE_INC
 #define THP_CUDNN_HANDLE_INC
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Types.h
+++ b/torch/csrc/cudnn/Types.h
@@ -4,7 +4,7 @@
 #include <Python.h>
 #include <cstddef>
 #include <string>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "../Types.h"
 #include <ATen/Tensor.h>
 

--- a/torch/csrc/cudnn/cuDNN.cwrap
+++ b/torch/csrc/cudnn/cuDNN.cwrap
@@ -4,7 +4,7 @@
  */
 
 #include <Python.h>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "Types.h"
 #include "Handles.h"
 #include "BatchNorm.h"

--- a/torch/csrc/cudnn/cudnn-wrapper.h
+++ b/torch/csrc/cudnn/cudnn-wrapper.h
@@ -1,0 +1,9 @@
+#ifndef THP_CUDNN_CUDNN_WRAPPER_INC
+#define THP_CUDNN_CUDNN_WRAPPER_INC
+
+#include <cudnn.h>
+#if CUDNN_MAJOR < 6
+#error CuDNN v5 and lower not supported. Please update or build without it.
+#endif
+
+#endif

--- a/torch/csrc/cudnn/cudnn-wrapper.h
+++ b/torch/csrc/cudnn/cudnn-wrapper.h
@@ -6,8 +6,8 @@
 #define STRING(x) STRINGIFY(x)
 
 #if CUDNN_MAJOR < 6
-#pragma message ("CuDNN v" STRING(CUDNN_MAJOR) " found, but need at least CUDNN v6. You can get the latest version of CUDNN from https://developer.nvidia.com/cudnn")
-#error "Old version of CuDNN found but need at least CuDNN v6. You can get the latest version of CuDNN from https://developer.nvidia.com/cudnn"
+#pragma message ("CuDNN v" STRING(CUDNN_MAJOR) " found, but need at least CuDNN v6. You can get the latest version of CuDNN from https://developer.nvidia.com/cudnn")
+#error "CuDNN version not supported"
 #endif
 
 #undef STRINGIFY

--- a/torch/csrc/cudnn/cudnn-wrapper.h
+++ b/torch/csrc/cudnn/cudnn-wrapper.h
@@ -1,9 +1,15 @@
-#ifndef THP_CUDNN_CUDNN_WRAPPER_INC
-#define THP_CUDNN_CUDNN_WRAPPER_INC
+#pragma once
 
 #include <cudnn.h>
+
+#define STRINGIFY(x) #x
+#define STRING(x) STRINGIFY(x)
+
 #if CUDNN_MAJOR < 6
-#error CuDNN v5 and lower not supported. Please update or build without it.
+#pragma message ("CuDNN v" STRING(CUDNN_MAJOR) " found, but need at least CUDNN v6. You can get the latest version of CUDNN from https://developer.nvidia.com/cudnn")
+#error "Old version of CuDNN found but need at least CuDNN v6. You can get the latest version of CuDNN from https://developer.nvidia.com/cudnn"
 #endif
 
-#endif
+#undef STRINGIFY
+#undef STRING
+


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/3093

### Test Plan
`python setup.py build install` (I have cudnn 6 installed). Asserted that no error was thrown.

Changed the macro to `if CUDNN_MAJOR < 7` and recompiled with `python setup.py build install`. Asserted that a compiler error occurred: 

![image](https://user-images.githubusercontent.com/5652049/31557384-7b5caa0a-b016-11e7-8288-5a21cb4fef6e.png)

(It's okay that it says "CuDNN v6 found" because the macro was changed to < 7 for testing purposes)
