### PR TITLE
Limit print scale by sys.float_info

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4053,7 +4053,6 @@ class TestTorch(TestCase):
         x.__repr__()
         str(x),
 
-
     def test_unsqueeze(self):
         x = torch.randn(2, 3, 4)
         y = x.unsqueeze(1)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4049,6 +4049,11 @@ class TestTorch(TestCase):
         x.__repr__()
         str(x)
 
+        x = torch.DoubleTensor([1e-324, 1e-323, 1e-322, 1e307, 1e308, 1e309])
+        x.__repr__()
+        str(x),
+
+
     def test_unsqueeze(self):
         x = torch.randn(2, 3, 4)
         y = x.unsqueeze(1)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -2,6 +2,10 @@ import math
 import torch
 from functools import reduce
 from ._utils import _range
+from sys import float_info
+
+
+__MIN_LOG_SCALE = math.ceil(math.log(float_info.min * float_info.epsilon, 10))
 
 
 class __PrinterOptions(object):
@@ -119,7 +123,7 @@ def _number_format(tensor, min_sz=-1):
         else:
             if exp_max > prec + 1 or exp_max < 0:
                 sz = max(min_sz, 7)
-                scale = math.pow(10, exp_max - 1)
+                scale = math.pow(10, max(exp_max - 1, __MIN_LOG_SCALE))
             else:
                 if exp_max == 0:
                     sz = 7


### PR DESCRIPTION
Fixes #3035 . `float_info.min * float_info.epsilon` gives smallest unnormalized float representable in the system. 

Test:
```
>>> torch.DoubleTensor([1e-323])

9.88131e-324 *
  1.0000
[torch.DoubleTensor of size 1]
```