### PR TITLE
Add compiled cudnn version to torch.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Once you have [Anaconda](https://www.continuum.io/downloads) installed, here are
 
 If you want to compile with CUDA support, install
 - [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 7.5 or above
-- [NVIDIA cuDNN](https://developer.nvidia.com/cudnn) v5.x or above
+- [NVIDIA cuDNN](https://developer.nvidia.com/cudnn) v6.x or above
 
 If you want to disable CUDA support, export environment variable `NO_CUDA=1`.
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ import os
 
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME, CUDA_VERSION
-from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
+from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR, \
+    CUDNN_VERSION
 from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, \
     NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
 from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
@@ -173,6 +174,7 @@ class build_py(setuptools.command.build_py.build_py):
             # this would claim to be a release build when it's not.)
             f.write("debug = {}\n".format(repr(DEBUG)))
             f.write("cuda = {}\n".format(repr(CUDA_VERSION)))
+            f.write("cudnn = {}\n".format(repr(CUDNN_VERSION)))
 
 
 class develop(setuptools.command.develop.develop):

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -17,25 +17,39 @@ def find_cudnn_version(cudnn_lib_dir):
     candidate_names = [os.path.basename(c) for c in candidate_names]
 
     # suppose version is MAJOR.MINOR.PATCH, all numbers
-    version_regex = re.compile('[0-9]+\.[0-9]+\.[0-9]+')
+    version_regex = re.compile('\d+\.\d+\.\d+')
     candidates = [c.group() for c in map(version_regex.search, candidate_names) if c]
     if len(candidates) > 0:
         # normally only one will be retrieved, take the first result
         return candidates[0]
 
     # if no candidates were found, try MAJOR.MINOR
-    version_regex = re.compile('[0-9]+\.[0-9]+')
+    version_regex = re.compile('\d+\.\d+')
     candidates = [c.group() for c in map(version_regex.search, candidate_names) if c]
     if len(candidates) > 0:
         return candidates[0]
 
     # if no candidates were found, try MAJOR
-    version_regex = re.compile('[0-9]+')
+    version_regex = re.compile('\d+')
     candidates = [c.group() for c in map(version_regex.search, candidate_names) if c]
     if len(candidates) > 0:
         return candidates[0]
 
     return 'unknown'
+
+
+def check_cudnn_version(cudnn_version_string):
+    if cudnn_version_string is 'unknown':
+        return  # Assume version is OK and let compilation continue
+
+    cudnn_min_version = 6
+    cudnn_version = int(cudnn_version_string.split('.')[0])
+    if cudnn_version < cudnn_min_version:
+        raise RuntimeError(
+            'CuDNN v%s found, but need at least CuDNN v%s. '
+            'You can get the latest version of CuDNN from '
+            'https://developer.nvidia.com/cudnn' %
+            (cudnn_version_string, cudnn_min_version))
 
 
 is_conda = 'conda' in sys.version or 'Continuum' in sys.version
@@ -86,4 +100,5 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         CUDNN_LIB_DIR = CUDNN_INCLUDE_DIR = None
     else:
         CUDNN_VERSION = find_cudnn_version(CUDNN_LIB_DIR)
+        check_cudnn_version(CUDNN_VERSION)
         WITH_CUDNN = True


### PR DESCRIPTION
This does two things:
1) Adds a `cudnn` flag to `torch.version` so one can check what version of cudnn pytorch was compiled with.

2) Fixes #3093. Gives an error message when someone tries to build pytorch using an outdated CuDNN version.

### Test Plan
Verified that torch.version.cudnn exists:
`python setup.py install`
![image](https://user-images.githubusercontent.com/5652049/31562049-0434c928-b028-11e7-8c57-5abebe5bde9f.png)

Verified that `python setup.py install` doesn't raise the error on a system that uses CuDNN 6.

Changed the code to bug out if CuDNN version is less than 7. Re-ran `python setup.py install` and verified that an error is raised.
![image](https://user-images.githubusercontent.com/5652049/31566584-4a833dd6-b039-11e7-8a85-e9095f934bf9.png)
