### PR TITLE
 Make test_jit more robust about compilation (plus a random setup.py enhancement)

### DIFF
--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -48,7 +48,8 @@ def check_cudnn_version(cudnn_version_string):
         raise RuntimeError(
             'CuDNN v%s found, but need at least CuDNN v%s. '
             'You can get the latest version of CuDNN from '
-            'https://developer.nvidia.com/cudnn' %
+            'https://developer.nvidia.com/cudnn or disable '
+            'CuDNN with NO_CUDNN=1' %
             (cudnn_version_string, cudnn_min_version))
 
 


### PR DESCRIPTION
```
commit 4867b97f0c4e99bd70de2edc851addeb999cd106
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Fri Oct 13 20:04:07 2017 -0700

    Suggest NO_CUDNN=1 as alternative when CuDNN is too old.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 2d3a7323e6cf3d38aa77eb5a0ded941a7ec013f7
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Fri Oct 13 19:57:51 2017 -0700

    Make test_jit more robust about compilation.
    
    It's pretty easy to accidentally fail to actually compile
    a JITed region, which means that we have accidentally failed
    to have test coverage for a number of features.  This adds
    a secret _assert_compiled kwarg, which will raise an error
    if we don't actually hit the compiled codepath.
        
    This is not intended to be user visible; we have some other
    ideas for handle this case.
        
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```