### PR TITLE
Add unit tests for ONNX helper functions

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -389,61 +389,71 @@ class TestONNXUtils(TestCase):
         self.assertEqual(paddings, [0, 0, 3, 4, 1, 2])
 
     def test_check_onnx_broadcast(self):
-        #Case 1
+
+        def try_check_onnx_broadcast(dims1, dims2):
+            broadcast = True
+            failed = False
+            try:
+                broadcast = check_onnx_broadcast(dims1, dims2)
+            except ValueError:
+                failed = True
+            return broadcast, failed
+
+        # Case 1
         dims1 = [3, 4]
         dims2 = [2, 3, 4]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, False)
+        self.assertEqual(failed, True)
 
-        #Case 2
+        # Case 2
         dims1 = [3, 4]
         dims2 = [1, 1, 1]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, True)
+        self.assertEqual(failed, False)
 
-        #Case 3
+        # Case 3
         dims1 = [1, 1]
         dims2 = [1]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, True)
+        self.assertEqual(failed, False)
 
-        #Case 4
+        # Case 4
         dims1 = [2, 3, 4]
         dims2 = [3, 4]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, True)
+        self.assertEqual(failed, False)
 
-        #Case 5
+        # Case 5
         dims1 = [2, 3, 4]
         dims2 = [1, 4]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, False)
+        self.assertEqual(failed, True)
 
-        #Case 6
+        # Case 6
         dims1 = [3, 4]
         dims2 = [3, 4]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, False)
-        self.assertEqual(supported, True)
+        self.assertEqual(failed, False)
 
-        #Case 7
+        # Case 7
         dims1 = [3, 4]
         dims2 = [1, 4]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, False)
+        self.assertEqual(failed, True)
 
-        #Case 8
+        # Case 8
         dims1 = [3, 4]
         dims2 = [1, 1]
-        broadcast, supported = check_onnx_broadcast(dims1, dims2)
+        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
         self.assertEqual(broadcast, True)
-        self.assertEqual(supported, True)
+        self.assertEqual(failed, False)
 
 
 TestLuaReader.init()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -390,70 +390,55 @@ class TestONNXUtils(TestCase):
 
     def test_check_onnx_broadcast(self):
 
-        def try_check_onnx_broadcast(dims1, dims2):
+        def try_check_onnx_broadcast(dims1, dims2, expect_broadcast, expect_fail):
             broadcast = True
-            failed = False
+            fail = False
             try:
                 broadcast = check_onnx_broadcast(dims1, dims2)
             except ValueError:
-                failed = True
-            return broadcast, failed
+                fail = True
+            self.assertEqual(broadcast, expect_broadcast)
+            self.assertEqual(fail, expect_fail)
 
-        # Case 1
+        # Case 1, check the case when len(dims1) < len(dims2) and numel(dims2) > 1
         dims1 = [3, 4]
         dims2 = [2, 3, 4]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, True)
+        try_check_onnx_broadcast(dims1, dims2, True, True)
 
-        # Case 2
+        # Case 2, check the case when len(dims1) < len(dims2) and numel(dims2) == 1
         dims1 = [3, 4]
         dims2 = [1, 1, 1]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, False)
+        try_check_onnx_broadcast(dims1, dims2, True, False)
 
-        # Case 3
+        # Case 3, check the case when len(dims1) > len(dims2) and numel(dims2) == 1
         dims1 = [1, 1]
         dims2 = [1]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, False)
+        try_check_onnx_broadcast(dims1, dims2, True, False)
 
-        # Case 4
+        # Case 4, check the case when len(dims1) > len(dims2) and dims1[x:] == dims2
         dims1 = [2, 3, 4]
         dims2 = [3, 4]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, False)
+        try_check_onnx_broadcast(dims1, dims2, True, False)
 
-        # Case 5
+        # Case 5, check the case when len(dims1) > len(dims2), but dims1[x:] != dims2
         dims1 = [2, 3, 4]
         dims2 = [1, 4]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, True)
+        try_check_onnx_broadcast(dims1, dims2, True, True)
 
-        # Case 6
+        # Case 6, check the equal case, no broadcast
         dims1 = [3, 4]
         dims2 = [3, 4]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, False)
-        self.assertEqual(failed, False)
+        try_check_onnx_broadcast(dims1, dims2, False, False)
 
-        # Case 7
+        # Case 7, check the case when len(dims1) == len(dims2), but dims1 != dims2
         dims1 = [3, 4]
         dims2 = [1, 4]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, True)
+        try_check_onnx_broadcast(dims1, dims2, True, True)
 
-        # Case 8
+        # Case 8, check the case when len(dims1) == len(dims2) and numel(s2) == 1
         dims1 = [3, 4]
         dims2 = [1, 1]
-        broadcast, failed = try_check_onnx_broadcast(dims1, dims2)
-        self.assertEqual(broadcast, True)
-        self.assertEqual(failed, False)
+        try_check_onnx_broadcast(dims1, dims2, True, False)
 
 
 TestLuaReader.init()

--- a/torch/autograd/_functions/blas.py
+++ b/torch/autograd/_functions/blas.py
@@ -22,10 +22,7 @@ class Addmm(InplaceFunction):
         sizes2 = matrix2.type().sizes()
         sizes_add = add_matrix.type().sizes()
         assert len(sizes1) == 2 and len(sizes2) == 2 and len(sizes_add) <= 2 and len(sizes_add) > 0
-        broadcast, supported = check_onnx_broadcast([sizes1[0], sizes2[1]], sizes_add)
-        if not supported:
-            raise ValueError("Numpy style broadcasting is not supported in ONNX. Input dims are: {}, {}, {}"
-                             .format(add_matrix.type().sizes(), matrix1.type().sizes(), matrix2.type().sizes()))
+        broadcast = check_onnx_broadcast([sizes1[0], sizes2[1]], sizes_add)
         return g.op("Gemm", matrix1, matrix2, add_matrix, beta_f=beta, alpha_f=alpha, broadcast_i=broadcast)
 
     @staticmethod

--- a/torch/autograd/_functions/utils.py
+++ b/torch/autograd/_functions/utils.py
@@ -97,4 +97,8 @@ def check_onnx_broadcast(dims1, dims2):
             broadcast = True
             if numel2 != 1:
                 supported = False
-    return broadcast, supported
+
+    if not supported:
+        raise ValueError("Numpy style broadcasting is not supported in ONNX. "
+                         "Input dims are: {}, {}".format(dims1, dims2))
+    return broadcast

--- a/torch/nn/_functions/padding.py
+++ b/torch/nn/_functions/padding.py
@@ -6,7 +6,7 @@ class ConstantPadNd(Function):
 
     @staticmethod
     def symbolic(g, input, pad, value=0):
-        paddings = prepare_onnx_paddings(input, pad)
+        paddings = prepare_onnx_paddings(len(input.type().sizes()), pad)
         return g.appendNode(g.create("Pad", [input]).is_("paddings", paddings)
                              .s_("mode", "constant").f_("value", value))
 

--- a/torch/nn/_functions/thnn/auto_symbolic.py
+++ b/torch/nn/_functions/thnn/auto_symbolic.py
@@ -28,13 +28,13 @@ def softmax_symbolic(g, input):
 
 def reflectionpad_symbolic(g, input, *params):
     mode = "reflect"
-    paddings = prepare_onnx_paddings(input, params)
+    paddings = prepare_onnx_paddings(len(input.type().sizes()), params)
     return g.op("Pad", input, paddings_i=paddings, mode_s=mode)
 
 
 def replicationpad_symbolic(g, input, *params):
     mode = "edge"
-    paddings = prepare_onnx_paddings(input, params)
+    paddings = prepare_onnx_paddings(len(input.type().sizes()), params)
     return g.op("Pad", input, paddings_i=paddings, mode_s=mode)
 
 


### PR DESCRIPTION
Although we have test_model and test_caffe2 (end to end tests) in onnx-pytorch repository.
It's better to have some unit tests for the helper functions.