### PR TITLE
Fix nvprof mode in autograd profiler

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -59,3 +59,7 @@ Profiler
 .. autoclass:: torch.autograd.profiler.profile
     :members:
 
+.. autoclass:: torch.autograd.profiler.emit_nvtx
+    :members:
+
+.. autofunction:: torch.autograd.profiler.load_nvprof

--- a/torch/cuda/profiler.py
+++ b/torch/cuda/profiler.py
@@ -1,5 +1,6 @@
 import ctypes
 import tempfile
+import contextlib
 from . import cudart, check_error
 
 
@@ -43,3 +44,12 @@ def start():
 
 def stop():
     check_error(cudart().cudaProfilerStop())
+
+
+@contextlib.contextmanager
+def profile():
+    try:
+        start()
+        yield
+    finally:
+        stop()


### PR DESCRIPTION
I realized that the `use_nvprof` mode of autograd profiler can't be implemented to return summary in the profiled process, because there's no way to force nvprof to flush data to disk. Instead, the trace has to be loaded offline using `torch.autograd.profiler.load_nvprof(path)`.

---

Tested by running this script:
```python
import torch
from torch.autograd import Variable
from torchvision import models

x = Variable(torch.randn(1, 3, 224, 224).cuda())
model = models.resnet18()
model.cuda()

with torch.cuda.profiler.profile():
    model(x) # Run once, to pre-allocate memory, and initialize CUDA profiler
    with torch.autograd.profiler.emit_nvtx() as p:
        model(x)
```
with this command:
```
nvprof --profile-from-start off -f -o out.prof python3 tmp.py
```

and checked that
```
ipython3 -c "torch.autograd.profiler.open_nvprof('out.prof')" | head
```
prints
```
[<FunctionEvent id=2 cpu_time=108.569us cuda_time=269.342us name=ConvForward>,                       
 <FunctionEvent id=3 cpu_time=43.092us cuda_time=331.935us name=N5torch8autograd16BatchNormForwardE>,
 <FunctionEvent id=4 cpu_time=77.851us cuda_time=47.744us name=Threshold>,                           
 <FunctionEvent id=5 cpu_time=125.062us cuda_time=124.159us name=MaxPool2d>,                         
 <FunctionEvent id=6 cpu_time=52.249us cuda_time=147.103us name=ConvForward>,                        
 <FunctionEvent id=7 cpu_time=35.582us cuda_time=98.656us name=N5torch8autograd16BatchNormForwardE>, 
 <FunctionEvent id=8 cpu_time=46.830us cuda_time=14.752us name=Threshold>,                           
 <FunctionEvent id=9 cpu_time=44.941us cuda_time=138.559us name=ConvForward>,                        
 <FunctionEvent id=10 cpu_time=33.857us cuda_time=98.112us name=N5torch8autograd16BatchNormForwardE>,
```