### PR TITLE
Use template instead of sphinx-contrib for google analytics

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx
-sphinxcontrib-googleanalytics
 -e git://github.com/snide/sphinx_rtd_theme.git#egg=sphinx_rtd_theme

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,15 @@
+{% extends "!layout.html" %}
+
+{% block footer %}
+{{ super() }}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-90545585-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,13 +48,9 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.googleanalytics',
 ]
 
 napoleon_use_ivar = True
-
-googleanalytics_id = 'UA-90545585-1'
-googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Docs are failing to build because of some bug in sphinx-contrib.google-analytics

Fixing it by building from source is too much pain because the repo requires mercurial. This is much easier fix. I'm using the current fix for pytorch/tutorials: https://github.com/pytorch/tutorials/pull/115/commits/b703484ae8cfb276c4dd46b224566848b2e9326c

This PR undos this commit: https://github.com/pytorch/pytorch/commit/4cca286d9ed8c5c7b5cf17449be172d0f0d4e476