### PR TITLE
Reverse the order of checks in torch.gather

### DIFF
--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -424,7 +424,6 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
 {
   int64_t elems_per_row, i, idx;
 
-  // Reverse the order of checks to provide more helpful error messages
   THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(src), 4,
              "Index tensor must have same dimensions as input tensor");
   THArgCheck(dim < THTensor_(nDimension)(tensor), 3, "Index dimension is out of bounds");

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -426,7 +426,8 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
 
   THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(src), 4,
              "Index tensor must have same dimensions as input tensor");
-  THArgCheck(dim < THTensor_(nDimension)(tensor), 3, "Index dimension is out of bounds");
+  THArgCheck(dim >= 0 && dim < THTensor_(nDimension)(tensor), 3,
+             "Index dimension is out of bounds");
   THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 2,
              "Input tensor must have same dimensions as output tensor");
 

--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -424,11 +424,12 @@ void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *i
 {
   int64_t elems_per_row, i, idx;
 
-  THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 2,
-             "Input tensor must have same dimensions as output tensor");
-  THArgCheck(dim < THTensor_(nDimension)(tensor), 3, "Index dimension is out of bounds");
+  // Reverse the order of checks to provide more helpful error messages
   THArgCheck(THLongTensor_nDimension(index) == THTensor_(nDimension)(src), 4,
              "Index tensor must have same dimensions as input tensor");
+  THArgCheck(dim < THTensor_(nDimension)(tensor), 3, "Index dimension is out of bounds");
+  THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 2,
+             "Input tensor must have same dimensions as output tensor");
 
   elems_per_row = THLongTensor_size(index, dim);
 

--- a/torch/lib/THC/generic/THCTensorScatterGather.cu
+++ b/torch/lib/THC/generic/THCTensorScatterGather.cu
@@ -12,7 +12,6 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  // Reverse the order of checks to provide more helpful error messages
   THArgCheck(THCudaLongTensor_nDimension(state, index) == THCTensor_(nDimension)(state, src), 4,
              "Index tensor must have same dimensions as input tensor");
   THLongStorage *indexSize = THCudaLongTensor_newSizeOf(state, index);

--- a/torch/lib/THC/generic/THCTensorScatterGather.cu
+++ b/torch/lib/THC/generic/THCTensorScatterGather.cu
@@ -12,16 +12,17 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, tensor, src));
   THCAssertSameGPU(THCudaLongTensor_checkGPU(state, 1, index));
 
-  THArgCheck(THCTensor_(nDimension)(state, src) == THCTensor_(nDimension)(state, tensor), 2,
-             "Input tensor must have same dimensions as output tensor");
-  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 3,
-             "Index dimension is out of bounds");
+  // Reverse the order of checks to provide more helpful error messages
   THArgCheck(THCudaLongTensor_nDimension(state, index) == THCTensor_(nDimension)(state, src), 4,
              "Index tensor must have same dimensions as input tensor");
   THLongStorage *indexSize = THCudaLongTensor_newSizeOf(state, index);
   THArgCheck(THCTensor_(isSize)(state, tensor, indexSize), 4,
              "Index tensor must have the same size as output tensor.");
   THLongStorage_free(indexSize);
+  THArgCheck(dim >= 0 && dim < THCTensor_(nDimension)(state, tensor), 3,
+             "Index dimension is out of bounds");
+  THArgCheck(THCTensor_(nDimension)(state, src) == THCTensor_(nDimension)(state, tensor), 2,
+             "Input tensor must have same dimensions as output tensor");
 
   for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
     if (d != dim) {


### PR DESCRIPTION
Right now
```python
idx = th.LongTensor([0, 1, 2])
arr = th.eye(3)
th.gather(arr, 1, idx)
```
gives 
```python
RuntimeError: invalid argument 2: Input tensor must have same dimensions as output tensor
```
By checking the index dimensions first we get
```python
RuntimeError: invalid argument 4: Index tensor must have same dimensions as input tensor
```