### PR TITLE
Better cudnn version checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ import os
 
 from tools.setup_helpers.env import check_env_flag
 from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME, CUDA_VERSION
-from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR, \
-    CUDNN_VERSION
+from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
 from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, \
     NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
 from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
@@ -174,7 +173,6 @@ class build_py(setuptools.command.build_py.build_py):
             # this would claim to be a release build when it's not.)
             f.write("debug = {}\n".format(repr(DEBUG)))
             f.write("cuda = {}\n".format(repr(CUDA_VERSION)))
-            f.write("cudnn = {}\n".format(repr(CUDNN_VERSION)))
 
 
 class develop(setuptools.command.develop.develop):

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -2,72 +2,13 @@ import os
 import sys
 import glob
 from itertools import chain
-import re
 
 from .env import check_env_flag
 from .cuda import WITH_CUDA, CUDA_HOME
 
-try:  # python 3+
-    from itertools import zip_longest as zip_longest
-except:  # python 2.7+
-    from itertools import izip_longest as zip_longest
-
 
 def gather_paths(env_vars):
     return list(chain(*(os.getenv(v, '').split(':') for v in env_vars)))
-
-
-def find_cudnn_version(cudnn_lib_dir):
-    candidate_names = list(glob.glob(os.path.join(cudnn_lib_dir, 'libcudnn*')))
-    candidate_names = [os.path.basename(c) for c in candidate_names]
-
-    # suppose lib file is is libcudnn.so.MAJOR.MINOR.PATCH, all numbers
-    version_regex = re.compile('.so.(\d+\.\d+\.\d+)$')
-    candidates = [c.group(1) for c in map(version_regex.search, candidate_names) if c]
-
-    # libcudnn.so.MAJOR.MINOR
-    version_regex = re.compile('.so.(\d+\.\d+)$')
-    candidates += [c.group(1) for c in map(version_regex.search, candidate_names) if c]
-
-    # libcudnn.so.MAJOR
-    version_regex = re.compile('.so.(\d+)$')
-    candidates += [c.group(1) for c in map(version_regex.search, candidate_names) if c]
-
-    if len(candidates) == 0:
-        return 'unknown'
-
-    # Each candidate represented as list, eg 6.0.21 -> [6, 0, 21]
-    candidates = [[int(x) for x in c.split('.')] for c in candidates]
-
-    # From candidates, take the most recent, then most detailed version string
-    def version_cmp(a, b):
-        for (x, y) in zip_longest(a, b, fillvalue=-1):
-            diff = x - y
-            if diff != 0:
-                return diff
-        return 0
-
-    version = candidates[0]
-    for candidate in candidates:
-        result = version_cmp(version, candidate)
-        if result < 0:  # version < candidate
-            version = candidate
-    return '.'.join([str(v) for v in version])
-
-
-def check_cudnn_version(cudnn_version_string):
-    if cudnn_version_string is 'unknown':
-        return  # Assume version is OK and let compilation continue
-
-    cudnn_min_version = 6
-    cudnn_version = int(cudnn_version_string.split('.')[0])
-    if cudnn_version < cudnn_min_version:
-        raise RuntimeError(
-            'CuDNN v%s found, but need at least CuDNN v%s. '
-            'You can get the latest version of CuDNN from '
-            'https://developer.nvidia.com/cudnn or disable '
-            'CuDNN with NO_CUDNN=1' %
-            (cudnn_version_string, cudnn_min_version))
 
 
 is_conda = 'conda' in sys.version or 'Continuum' in sys.version
@@ -76,7 +17,6 @@ conda_dir = os.path.join(os.path.dirname(sys.executable), '..')
 WITH_CUDNN = False
 CUDNN_LIB_DIR = None
 CUDNN_INCLUDE_DIR = None
-CUDNN_VERSION = None
 if WITH_CUDA and not check_env_flag('NO_CUDNN'):
     lib_paths = list(filter(bool, [
         os.getenv('CUDNN_LIB_DIR'),
@@ -117,6 +57,4 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
     if not CUDNN_LIB_DIR or not CUDNN_INCLUDE_DIR:
         CUDNN_LIB_DIR = CUDNN_INCLUDE_DIR = None
     else:
-        CUDNN_VERSION = find_cudnn_version(CUDNN_LIB_DIR)
-        check_cudnn_version(CUDNN_VERSION)
         WITH_CUDNN = True

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -12,6 +12,7 @@ try:  # python 3+
 except:  # python 2.7+
     from itertools import izip_longest as zip_longest
 
+
 def gather_paths(env_vars):
     return list(chain(*(os.getenv(v, '').split(':') for v in env_vars)))
 

--- a/torch/csrc/cudnn/AffineGridGenerator.h
+++ b/torch/csrc/cudnn/AffineGridGenerator.h
@@ -4,7 +4,7 @@
 #include "../Types.h"
 #include "THC/THC.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/BatchNorm.h
+++ b/torch/csrc/cudnn/BatchNorm.h
@@ -2,7 +2,7 @@
 #define THP_CUDNN_BATCH_NORM_INC
 
 #include "../Types.h"
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "THC/THC.h"
 
 

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -4,7 +4,7 @@
 #include "Exceptions.h"
 #include "Types.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <functional>
 #include <iterator>
 #include <sstream>

--- a/torch/csrc/cudnn/Conv.h
+++ b/torch/csrc/cudnn/Conv.h
@@ -6,7 +6,7 @@
 
 #include "Descriptors.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <vector>
 
 namespace torch { namespace cudnn {

--- a/torch/csrc/cudnn/Descriptors.h
+++ b/torch/csrc/cudnn/Descriptors.h
@@ -3,7 +3,7 @@
 
 #include "Exceptions.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Exceptions.h
+++ b/torch/csrc/cudnn/Exceptions.h
@@ -2,7 +2,7 @@
 #define THP_CUDNN_EXCEPTIONS_INC
 
 #include <THC/THC.h>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include <string>
 #include <stdexcept>
 #include <sstream>

--- a/torch/csrc/cudnn/GridSampler.h
+++ b/torch/csrc/cudnn/GridSampler.h
@@ -4,7 +4,7 @@
 #include "../Types.h"
 #include "THC/THC.h"
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Handles.h
+++ b/torch/csrc/cudnn/Handles.h
@@ -1,7 +1,7 @@
 #ifndef THP_CUDNN_HANDLE_INC
 #define THP_CUDNN_HANDLE_INC
 
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 
 namespace torch { namespace cudnn {
 

--- a/torch/csrc/cudnn/Types.h
+++ b/torch/csrc/cudnn/Types.h
@@ -4,7 +4,7 @@
 #include <Python.h>
 #include <cstddef>
 #include <string>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "../Types.h"
 #include <ATen/Tensor.h>
 

--- a/torch/csrc/cudnn/cuDNN.cwrap
+++ b/torch/csrc/cudnn/cuDNN.cwrap
@@ -4,7 +4,7 @@
  */
 
 #include <Python.h>
-#include <cudnn.h>
+#include "cudnn-wrapper.h"
 #include "Types.h"
 #include "Handles.h"
 #include "BatchNorm.h"

--- a/torch/csrc/cudnn/cudnn-wrapper.h
+++ b/torch/csrc/cudnn/cudnn-wrapper.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cudnn.h>
+
+#define STRINGIFY(x) #x
+#define STRING(x) STRINGIFY(x)
+
+#if CUDNN_MAJOR < 6
+#pragma message ("CuDNN v" STRING(CUDNN_MAJOR) " found, but need at least CuDNN v6. You can get the latest version of CuDNN from https://developer.nvidia.com/cudnn or disable CuDNN with NO_CUDNN=1")
+#error "CuDNN version not supported"
+#endif
+
+#undef STRINGIFY
+#undef STRING
+


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/3126.

This removes the version checking from setup.py and instead does checking when the c compiler processes the cudnn.h import.

### Test Plan
Created some fake libcudnn.so files:
![image](https://user-images.githubusercontent.com/5652049/31618739-c8e6b51c-b260-11e7-9e35-b233684faee7.png)

Verified that `python setup.py build develop` doesn't work on master due to https://github.com/pytorch/pytorch/commit/1322f9a272db91b8bc0254c6cdf4ea787120631b detecting that a cudnn library with version <= 5 exists on the system.

Verified with these changes that `python setup.py build develop` doesn't get blocked by detecting a cudnn version <= 5.

Changed the version cutoff to 7, and verified that an error message happens when building:
![image](https://user-images.githubusercontent.com/5652049/31622936-d72e23ca-b26b-11e7-8f2d-0ddea133381a.png)
