### PR TITLE
Change device_id to device in python land

### DIFF
--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -183,11 +183,11 @@ class Type(Function):
 class CudaTransfer(Function):
 
     @staticmethod
-    def forward(ctx, i, device_id=None, async=False):
+    def forward(ctx, i, device=None, async=False):
         ctx.source_device = -1 if not i.is_cuda else i.get_device()
         ctx.source_was_cuda = i.is_cuda
-        if device_id is not None:
-            return i.cuda(device_id, async=async)
+        if device is not None:
+            return i.cuda(device, async=async)
         else:
             return i.cuda(async=async)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -172,7 +172,7 @@ class Module(object):
         fn(self)
         return self
 
-    def cuda(self, device_id=None):
+    def cuda(self, device=None):
         """Moves all model parameters and buffers to the GPU.
 
         This also makes associated parameters and buffers different objects. So
@@ -180,10 +180,10 @@ class Module(object):
         live on GPU while being optimized.
 
         Arguments:
-            device_id (int, optional): if specified, all parameters will be
+            device (int, optional): if specified, all parameters will be
                 copied to that device
         """
-        return self._apply(lambda t: t.cuda(device_id))
+        return self._apply(lambda t: t.cuda(device))
 
     def cpu(self):
         """Moves all model parameters and buffers to the CPU."""

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -63,8 +63,8 @@ def _cpu_deserialize(obj, location):
 
 def _cuda_deserialize(obj, location):
     if location.startswith('cuda'):
-        device_id = max(int(location[5:]), 0)
-        return obj.cuda(device_id)
+        device = max(int(location[5:]), 0)
+        return obj.cuda(device)
 
 
 register_package(10, _cpu_tag, _cpu_deserialize)


### PR DESCRIPTION
Fixes #3131 . 

However, `device_id`s are unchanged in `torch/cuda/random.py` (https://github.com/pytorch/pytorch/blob/master/torch/cuda/random.py) because there is an existing imported function called `device`. To change those to being consistent, should we do an `import as` for it?