### PR TITLE
Use ATen generator as default CPU generator

### DIFF
--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -14,7 +14,12 @@ struct THPGenerator {
   ((THPGenerator*)obj)->cdata
 
 THP_API PyObject * THPGenerator_New();
+
+// Creates a new Python object wrapping the THGenerator. The reference is
+// borrowed. The caller should ensure that the THGenerator* object lifetime
+// last at least as long as the Python wrapper.
 THP_API PyObject * THPGenerator_NewWithGenerator(THGenerator *cdata);
+
 extern PyObject *THPGeneratorClass;
 
 #ifdef _THP_CORE

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -4,6 +4,7 @@
 struct THPGenerator {
   PyObject_HEAD
   THGenerator *cdata;
+  bool owner;  // if true, frees cdata in destructor
 };
 
 #define THPGenerator_Check(obj) \
@@ -13,6 +14,7 @@ struct THPGenerator {
   ((THPGenerator*)obj)->cdata
 
 THP_API PyObject * THPGenerator_New();
+THP_API PyObject * THPGenerator_NewWithGenerator(THGenerator *cdata);
 extern PyObject *THPGeneratorClass;
 
 #ifdef _THP_CORE

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -907,13 +907,14 @@ PyMODINIT_FUNC PyInit__C()
   ASSERT_TRUE(THDPByteTensor_init(module));
 #endif
 
-  THPDefaultGenerator = (THPGenerator*)THPGenerator_New();
-  ASSERT_TRUE(THPDefaultGenerator != nullptr);
-  ASSERT_TRUE(PyModule_AddObject(module, "default_generator", (PyObject*)THPDefaultGenerator) == 0);
-
   // force ATen to initialize because it handles
   // setting up TH Errors so that they throw C++ exceptions
   at::init();
+
+  auto& defaultGenerator = at::globalContext().defaultGenerator(at::kCPU);
+  THPDefaultGenerator = (THPGenerator*)THPGenerator_NewWithGenerator(
+    (THGenerator*)defaultGenerator.unsafeGetTH());
+  ASSERT_TRUE(PyModule_AddObject(module, "default_generator", (PyObject*)THPDefaultGenerator) == 0);
 
 #ifdef WITH_NUMPY
   import_array();


### PR DESCRIPTION
ATen has it's own default CPU RNG. Use this as the default in PyTorch so
that random functions called through ATen have the same behavior as
random functions called through TensorMethods