### PR TITLE
Memory issue for SGD and sparse grad

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -86,7 +86,8 @@ class SGD(Optimizer):
                 if momentum != 0:
                     param_state = self.state[p]
                     if 'momentum_buffer' not in param_state:
-                        buf = param_state['momentum_buffer'] = d_p.clone()
+                        buf = param_state['momentum_buffer'] = p.data.new().resize_as_(p.data).zero_()
+                        buf.mul_(momentum).add_(d_p)
                     else:
                         buf = param_state['momentum_buffer']
                         buf.mul_(momentum).add_(1 - dampening, d_p)


### PR DESCRIPTION
Fixes #3129 .

Previously we use buffer with same type as grad. For sparse grad, the buffer grows continuously as we never call coalesce. Since the buffer will likely become dense anyways, this PR changes it so that buffer are init'd as same type of param.

Performance on script in #3219 
Before change: GPU memory usage fluctuates greatly, with max at 10800MB. Decaying speed from 110it/s to 44it/s in 9 epochs.
Adding coalesce in each call: Constant GPU memory usage 1231MB. Constant speed at 150it/s.
After change: Constant GPU memory usage 1197MB. Constant speed at 210it/s.
