### PR TITLE
Remove THHeapUpdate

### DIFF
--- a/torch/lib/THC/THCGeneral.c
+++ b/torch/lib/THC/THCGeneral.c
@@ -907,7 +907,7 @@ cudaError_t THCudaMemGetInfoCached(THCState *state,  size_t* freeBytes, size_t* 
 
   if (allocator->cacheInfo != NULL)
     allocator->cacheInfo(allocator->state, device, &cachedBytes, largestBlock);
-  
+
   /* Adjust resulting free bytes number. largesBlock unused for now */
   *freeBytes += cachedBytes;
   return cudaSuccess;
@@ -933,19 +933,6 @@ static void maybeTriggerGC(THCState *state, ptrdiff_t curHeapSize) {
     if (newHeapSize > state->heapSoftmax * heapSoftmaxGrowthThresh) {
       state->heapSoftmax = (ptrdiff_t)state->heapSoftmax * heapSoftmaxGrowthFactor;
     }
-  }
-}
-
-void THCHeapUpdate(THCState *state, ptrdiff_t size) {
-  state->heapDelta += size;
-  // batch updates to global heapSize to minimize thread contention
-  if (state->heapDelta < heapMaxDelta && state->heapDelta > heapMinDelta) {
-    return;
-  }
-
-  ptrdiff_t newHeapSize = applyHeapDelta(state);
-  if (size > 0) {
-    maybeTriggerGC(state, newHeapSize);
   }
 }
 

--- a/torch/lib/THC/THCGeneral.h.in
+++ b/torch/lib/THC/THCGeneral.h.in
@@ -213,6 +213,5 @@ THC_API cudaError_t THCudaMemGetInfoCached(THCState *state, size_t* freeBytes, s
 THC_API void THCSetGCHandler(THCState *state,
                              void (*torchGCHandlerFunction)(void *data),
                              void *data );
-THC_API void THCHeapUpdate(THCState *state, ptrdiff_t size);
 
 #endif

--- a/torch/lib/THC/generic/THCStorage.c
+++ b/torch/lib/THC/generic/THCStorage.c
@@ -71,14 +71,12 @@ THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
   if(size > 0)
   {
     // update heap *before* attempting malloc, to free space for the malloc
-    THCHeapUpdate(state, size * sizeof(real));
     cudaError_t err =
       (*allocator->malloc)(allocatorContext,
                            (void**)&(storage->data),
                            size * sizeof(real),
                            THCState_getCurrentStream(state));
     if(err != cudaSuccess){
-      THCHeapUpdate(state, -size * sizeof(real));
       free(storage);
     }
     THCudaCheck(err);
@@ -182,7 +180,6 @@ void THCStorage_(free)(THCState *state, THCStorage *self)
   if (THAtomicDecrementRef(&self->refcount))
   {
     if(self->flag & TH_STORAGE_FREEMEM) {
-      THCHeapUpdate(state, -self->size * sizeof(real));
       THCudaCheck(
         (*self->allocator->free)(self->allocatorContext, self->data));
     }


### PR DESCRIPTION
This removes THHeapUpdate from TH and THC. The functionality is not used in PyTorch and the record keeping adds some overhead (~200ns per tensor allocation).