### PR TITLE
Lazily create Variable.data PyObject*

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -37,7 +37,7 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
   return obj;
 }
 
-PyObject * THPVariable_Wrap(const Variable& var)
+PyObject * THPVariable_Wrap(Variable var)
 {
   if (!var.defined()) {
     Py_RETURN_NONE;
@@ -48,13 +48,7 @@ PyObject * THPVariable_Wrap(const Variable& var)
     return obj;
   }
 
-  THPObjectPtr obj(THPVariable_NewWithVar((PyTypeObject *)THPVariableClass, var));
-  if (obj) {
-    PyObject* data = torch::createPyObject(var.data());
-    if (!data) return NULL;
-    ((THPVariable*)obj.get())->data = data;
-  }
-  return obj.release();
+  return THPVariable_NewWithVar((PyTypeObject *)THPVariableClass, std::move(var));
 }
 
 // This function DOES NOT steal a reference to data

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -27,7 +27,7 @@ bool THPVariable_initModule(PyObject *module);
 PyObject * THPVariable_NewVolatile(PyObject *data);
 PyObject * THPVariable_NewLeaf(PyObject *data);
 PyObject * THPVariable_NewWithFunction(PyObject *data, const std::shared_ptr<torch::autograd::Function>& var);
-PyObject * THPVariable_Wrap(const torch::autograd::Variable& var);
+PyObject * THPVariable_Wrap(torch::autograd::Variable var);
 PyObject * THPVariable_get_data(THPVariable *self);
 
 inline bool THPVariable_Check(PyObject *obj)


### PR DESCRIPTION
Previously, we the Variable.data PyObject* in THPVariable_Wrap. For many
Variables, we don't access their data directly. Instead, they passed
from one Variable compuatation to another.

This reduces the overhead of ATen-implemented Variable methods by
~200ns.