### PR TITLE
add support for using nnpack when installed via conda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME, CUDA_VERSION
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
 from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, \
     NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
-from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, NNPACK_INCLUDE_DIRS
+from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, \
+    NNPACK_INCLUDE_DIRS, NNPACK_IS_USER_DEFINED, NNPACK_IS_CONDA_DEFINED, \
+    NNPACK_LIB_PATHS, NNPACK_HEADER_PATHS
 from tools.setup_helpers.split_types import split_types
 
 DEBUG = check_env_flag('DEBUG')
@@ -230,7 +232,11 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
         # Do we actually need this here?
         if WITH_NNPACK:
-            print('-- Detected NNPACK at ' + NNPACK_LIB_DIR)
+            if NNPACK_IS_USER_DEFINED:
+                nnpack_dir = NNPACK_LIB_DIR
+            else:
+                nnpack_dir = NNPACK_LIB_PATHS[0]
+            print('-- Detected NNPACK at ' + nnpack_dir)
         else:
             print('-- Not using NNPACK')
 
@@ -507,9 +513,20 @@ if WITH_CUDNN:
     extra_compile_args += ['-DWITH_CUDNN']
 
 if WITH_NNPACK:
-    main_libraries += ['nnpack', 'pthreadpool']
-    include_dirs.extend(NNPACK_INCLUDE_DIRS)
-    library_dirs.append(NNPACK_LIB_DIR)
+    if NNPACK_IS_USER_DEFINED:
+        main_libraries += ['nnpack', 'pthreadpool']
+        include_dirs.extend(NNPACK_INCLUDE_DIRS)
+        library_dirs.append(NNPACK_LIB_DIR)
+    else:
+        # Conda Defined
+        main_link_args.extend(NNPACK_LIB_PATHS)
+
+        # We don't want to add the Conda include dir as an include dir,
+        # just the NNPACK headers, so let's move them somewhere we already
+        # know about, like tmp_install
+        for header in NNPACK_HEADER_PATHS:
+            shutil.copy(header, tmp_install_path + "/include")
+
     main_sources += [
         "torch/csrc/nnpack/NNPACK.cpp",
     ]

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ from tools.setup_helpers.cuda import WITH_CUDA, CUDA_HOME, CUDA_VERSION
 from tools.setup_helpers.cudnn import WITH_CUDNN, CUDNN_LIB_DIR, CUDNN_INCLUDE_DIR
 from tools.setup_helpers.nccl import WITH_NCCL, WITH_SYSTEM_NCCL, NCCL_LIB_DIR, \
     NCCL_INCLUDE_DIR, NCCL_ROOT_DIR, NCCL_SYSTEM_LIB
-from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_DIR, \
-    NNPACK_INCLUDE_DIRS, NNPACK_IS_USER_DEFINED, NNPACK_IS_CONDA_DEFINED, \
-    NNPACK_LIB_PATHS, NNPACK_HEADER_PATHS
+from tools.setup_helpers.nnpack import WITH_NNPACK, NNPACK_LIB_PATHS, \
+    NNPACK_INCLUDE_DIRS
 from tools.setup_helpers.split_types import split_types
 
 DEBUG = check_env_flag('DEBUG')
@@ -232,10 +231,7 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
         # Do we actually need this here?
         if WITH_NNPACK:
-            if NNPACK_IS_USER_DEFINED:
-                nnpack_dir = NNPACK_LIB_DIR
-            else:
-                nnpack_dir = NNPACK_LIB_PATHS[0]
+            nnpack_dir = NNPACK_LIB_PATHS[0]
             print('-- Detected NNPACK at ' + nnpack_dir)
         else:
             print('-- Not using NNPACK')
@@ -513,20 +509,8 @@ if WITH_CUDNN:
     extra_compile_args += ['-DWITH_CUDNN']
 
 if WITH_NNPACK:
-    if NNPACK_IS_USER_DEFINED:
-        main_libraries += ['nnpack', 'pthreadpool']
-        include_dirs.extend(NNPACK_INCLUDE_DIRS)
-        library_dirs.append(NNPACK_LIB_DIR)
-    else:
-        # Conda Defined
-        main_link_args.extend(NNPACK_LIB_PATHS)
-
-        # We don't want to add the Conda include dir as an include dir,
-        # just the NNPACK headers, so let's move them somewhere we already
-        # know about, like tmp_install
-        for header in NNPACK_HEADER_PATHS:
-            shutil.copy(header, tmp_install_path + "/include")
-
+    include_dirs.extend(NNPACK_INCLUDE_DIRS)
+    main_link_args.extend(NNPACK_LIB_PATHS)
     main_sources += [
         "torch/csrc/nnpack/NNPACK.cpp",
     ]

--- a/tools/setup_helpers/nnpack.py
+++ b/tools/setup_helpers/nnpack.py
@@ -5,24 +5,25 @@ from .env import check_env_flag
 
 WITH_NNPACK = False
 
-NNPACK_IS_USER_DEFINED = False
-NNPACK_LIB_DIR = []
 NNPACK_INCLUDE_DIRS = []
-
-NNPACK_IS_CONDA_DEFINED = False
 NNPACK_LIB_PATHS = []
-NNPACK_HEADER_PATHS = []
 
 if not check_env_flag('NO_NNPACK') and 'Windows' not in platform.system():
     # assume we have a flag set that determines the path
     nnpack_dir = os.getenv('NNPACK_DIR')
     if nnpack_dir is not None:
-        NNPACK_LIB_DIR = os.path.join(nnpack_dir, 'lib')
+        lib = os.path.join(nnpack_dir, 'lib')
+        libs = [
+            os.path.join(lib, 'libnnpack.a'),
+            os.path.join(lib, 'libpthreadpool.a')
+        ]
+
         NNPACK_INCLUDE_DIRS = [os.path.join(nnpack_dir, 'include'),
                                os.path.join(nnpack_dir, 'deps', 'pthreadpool', 'include')]
 
-        if os.path.exists(NNPACK_LIB_DIR) and all(os.path.exists(d) for d in NNPACK_INCLUDE_DIRS):
-            WITH_NNPACK = NNPACK_IS_USER_DEFINED = True
+        if all(os.path.exists(d) for d in NNPACK_INCLUDE_DIRS + libs):
+            WITH_NNPACK = True
+            NNPACK_LIB_PATHS = libs
         else:
             NNPACK_LIB_DIR = NNPACK_INCLUDE_DIRS = None
     else:
@@ -42,6 +43,6 @@ if not check_env_flag('NO_NNPACK') and 'Windows' not in platform.system():
             ]
 
             if all([os.path.exists(f) for f in libs + headers]):
-                WITH_NNPACK = NNPACK_IS_CONDA_DEFINED = True
+                WITH_NNPACK = True
                 NNPACK_LIB_PATHS = libs
-                NNPACK_HEADER_PATHS = headers
+                NNPACK_INCLUDE_DIRS = [include]

--- a/tools/setup_helpers/nnpack.py
+++ b/tools/setup_helpers/nnpack.py
@@ -4,8 +4,14 @@ import platform
 from .env import check_env_flag
 
 WITH_NNPACK = False
-NNPACK_LIB_DIR = None
-NNPACK_INCLUDE_DIRS = None
+
+NNPACK_IS_USER_DEFINED = False
+NNPACK_LIB_DIR = []
+NNPACK_INCLUDE_DIRS = []
+
+NNPACK_IS_CONDA_DEFINED = False
+NNPACK_LIB_PATHS = []
+NNPACK_HEADER_PATHS = []
 
 if not check_env_flag('NO_NNPACK') and 'Windows' not in platform.system():
     # assume we have a flag set that determines the path
@@ -16,6 +22,26 @@ if not check_env_flag('NO_NNPACK') and 'Windows' not in platform.system():
                                os.path.join(nnpack_dir, 'deps', 'pthreadpool', 'include')]
 
         if os.path.exists(NNPACK_LIB_DIR) and all(os.path.exists(d) for d in NNPACK_INCLUDE_DIRS):
-            WITH_NNPACK = True
+            WITH_NNPACK = NNPACK_IS_USER_DEFINED = True
         else:
             NNPACK_LIB_DIR = NNPACK_INCLUDE_DIRS = None
+    else:
+        # Look in the Conda directory to see if we've Conda installed it.
+        prefix = os.getenv('CONDA_PREFIX')
+        if prefix is not None:
+            lib = os.path.join(prefix, 'lib')
+            include = os.path.join(prefix, 'include')
+
+            libs = [
+                os.path.join(lib, 'libnnpack.a'),
+                os.path.join(lib, 'libpthreadpool.a')
+            ]
+            headers = [
+                os.path.join(include, 'nnpack.h'),
+                os.path.join(include, 'pthreadpool.h')
+            ]
+
+            if all([os.path.exists(f) for f in libs + headers]):
+                WITH_NNPACK = NNPACK_IS_CONDA_DEFINED = True
+                NNPACK_LIB_PATHS = libs
+                NNPACK_HEADER_PATHS = headers


### PR DESCRIPTION
Pairs with https://github.com/pytorch/builder/pull/14. This basically searches for the appropriate `NNPACK` libraries and headers in the Conda installation environment, and builds with them. We move the headers to `tmp_install/include` so that we don't pass the conda include dir to the build, which seems like a bad idea.

cc @ezyang 