### PR TITLE
Replace StochasticFunctions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    nn
    optim
    torch.autograd <autograd>
+   torch.reinforce <reinforce>
    torch.multiprocessing <multiprocessing>
    torch.distributed <distributed>
    torch.legacy <legacy>

--- a/docs/source/reinforce.rst
+++ b/docs/source/reinforce.rst
@@ -1,0 +1,8 @@
+.. role:: hidden
+    :class: hidden-section
+
+Reinforcement learning - torch.reinforce
+==================================================
+
+.. automodule:: torch.reinforce
+  :members:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -536,16 +536,6 @@ class TestAutograd(TestCase):
         self.assertEqual(b.grad.data, grad_c * a.data)
         self.assertEqual(q.grad.data, (grad_c + grad_z) * 2)
 
-    def test_multi_backward_stochastic(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
-
-        z = x + y
-        q = torch.normal(x)
-        q.reinforce(torch.randn(5, 5))
-
-        torch.autograd.backward([z, q], [torch.ones(5, 5), None])
-
     def test_multi_backward_no_grad(self):
         x = Variable(torch.randn(5, 5), requires_grad=True)
         y = Variable(torch.randn(5, 5), requires_grad=False)
@@ -1361,100 +1351,60 @@ class TestAutograd(TestCase):
         y.sum().backward()
         self.assertEqual(x.grad.data, x.data.clone().fill_(1))
 
-    def test_reinforce_check(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+    def test_reinforce_bernoulli(self):
+        p = Variable(torch.Tensor([0.7, 0.2, 0.4]), requires_grad=True)
+        s, logpmf = torch.reinforce.bernoulli(p)
+        self.assertEqual(s.size(), logpmf.size())
 
-        # these should be ok
-        y = torch.normal(x)
-        y.reinforce(torch.randn(5, 5))
-        y = torch.normal(x)
-        y.reinforce(2)
+        self.assertEqual(logpmf.data[0], math.log(0.7 if s.data[0] == 1 else 0.3))
 
-        # can't call reinforce on non-stochastic variables
-        self.assertRaises(RuntimeError, lambda: x.reinforce(2))
+        def apply_fn(p):
+            return torch.reinforce._bernoulli_logpmf(s, p)
 
-        # can't call reinforce twice
-        y = torch.normal(x)
-        y.reinforce(2)
-        self.assertRaises(RuntimeError, lambda: y.reinforce(2))
+        gradcheck(apply_fn, (p,), raise_exception=True)
 
-        # check type of reward
-        y = torch.normal(x)
-        self.assertRaises(TypeError, lambda: y.reinforce(torch.randn(5, 5).long()))
+    def test_reinforce_multinomial_1d(self):
+        p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
+        s, logprobs = torch.reinforce.multinomial(p)
+        self.assertEqual(s.size(), logprobs.size())
 
-        # check size of reward
-        y = torch.normal(x)
-        self.assertRaises(ValueError, lambda: y.reinforce(torch.randn(4, 5)))
+        def apply_fn(p):
+            return torch.reinforce._multinomial_logpmf(s, p)
 
-    def test_stochastic(self):
-        x = Variable(torch.rand(2, 10), requires_grad=True)
-        stddevs = Variable(torch.rand(2, 10) * 5, requires_grad=True)
-        y = (x * 2).clamp(0, 1)
-        y = y / y.sum(1, True).expand_as(y)
-        samples_multi = y.multinomial(5)
-        samples_multi_flat = y[0].multinomial(5)
-        samples_bernoulli = y.bernoulli()
-        samples_norm = torch.normal(y)
-        samples_norm_std = torch.normal(y, stddevs)
-        z = samples_multi * 2 + 4
-        z = z + samples_multi_flat.unsqueeze(0).expand_as(samples_multi)
-        z = torch.cat([z, z], 1)
-        z = z.double()
-        z = z + samples_bernoulli + samples_norm + samples_norm_std
-        last_sample = torch.normal(z, 4)
-        z = last_sample + 2
-        self.assertFalse(z.requires_grad)
+        gradcheck(apply_fn, (p,), raise_exception=True)
 
-        self.assertRaises(RuntimeError, lambda: z.backward(retain_graph=True))
-        samples_multi.reinforce(torch.randn(2, 5))
-        self.assertRaises(RuntimeError, lambda: z.backward(retain_graph=True))
-        samples_multi_flat.reinforce(torch.randn(5))
-        self.assertRaises(RuntimeError, lambda: z.backward(retain_graph=True))
-        samples_bernoulli.reinforce(torch.randn(2, 10))
-        self.assertRaises(RuntimeError, lambda: z.backward(retain_graph=True))
-        samples_norm.reinforce(torch.randn(2, 10))
-        self.assertRaises(RuntimeError, lambda: z.backward(retain_graph=True))
-        samples_norm_std.reinforce(torch.randn(2, 10))
-        # We don't have to specify rewards w.r.t. last_sample - it doesn't
-        # require gradient
+    def test_reinforce_multinomial_2d(self):
+        probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
+        p = Variable(torch.Tensor(probabilities), requires_grad=True)
+        s, logprobs = torch.reinforce.multinomial(p)
+        self.assertEqual(s.size(), logprobs.size())
 
-        last_sample.backward(retain_graph=True)
-        z.backward()
+        logp = logprobs.data[1][0]
+        expected_prob = probabilities[1][s.data[1][0]]
+        self.assertEqual(logp, math.log(expected_prob))
 
-        self.assertGreater(x.grad.data.abs().sum(), 0)
+        def apply_fn(p):
+            return torch.reinforce._multinomial_logpmf(s, p)
 
-    def test_stochastic_require_grad(self):
-        # This tests a DSD function sequence (D=deterministic, S=stochastic),
-        # where all functions require grad.
-        x = Variable(torch.randn(2, 10), requires_grad=True)
-        y = Variable(torch.randn(2, 10), requires_grad=True)
-        z = torch.normal(x + 2, 2)
-        o = z + y
-        z.reinforce(torch.randn(2, 10))
-        o.sum().backward()
-        self.assertEqual(y.grad.data, torch.ones(2, 10))
-        self.assertGreater(x.grad.data.abs().sum(), 0)
+        gradcheck(apply_fn, (p,), raise_exception=True)
 
-    def test_stochastic_sequence(self):
-        x = Variable(torch.rand(10).clamp_(0, 1), requires_grad=True)
-        b = x.bernoulli()
-        n1 = torch.normal(b, x)
-        n2 = torch.normal(n1, 2)
+    def test_reinforce_normal(self):
+        mean = Variable(torch.randn(5, 5), requires_grad=True)
+        std = Variable(torch.randn(5, 5).abs(), requires_grad=True)
+        s, logpdf = torch.reinforce.normal(mean, std)
+        self.assertEqual(s.size(), logpdf.size())
 
-        b.reinforce(torch.randn(10))
-        n1.reinforce(torch.randn(10))
-        n2.reinforce(torch.randn(10))
+        def check_logpdf(x, m, std, actual):
+            expected = (math.exp(-(x - m) ** 2 / (2 * std ** 2)) /
+                        math.sqrt(2 * math.pi * std ** 2))
+            self.assertAlmostEqual(math.log(expected), actual)
 
-        n2.backward()
+        check_logpdf(s.data[0][0], mean.data[0][0], std.data[0][0], logpdf.data[0][0])
 
-        self.assertGreater(x.grad.data.abs().sum(), 0)
+        def apply_fn(mean, std):
+            return torch.reinforce._normal_logpdf(s, mean, std)
 
-    def test_stochastic_output(self):
-        x = Variable(torch.rand(10), requires_grad=True)
-        b = x.clone().clamp(0, 1).bernoulli()
-        b.reinforce(torch.randn(10))
-        b.backward()
-        self.assertGreater(x.grad.data.abs().sum(), 0)
+        gradcheck(apply_fn, (mean, std), raise_exception=True)
 
     def test_pickle(self):
         x = Variable(torch.randn(10, 10), requires_grad=True)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -309,6 +309,7 @@ import torch.sparse
 import torch.utils.backcompat
 import torch.onnx
 import torch.random
+import torch.reinforce
 
 _C._init_names(list(torch._tensor_classes) + list(torch._storage_classes))
 

--- a/torch/autograd/_functions/stochastic.py
+++ b/torch/autograd/_functions/stochastic.py
@@ -1,92 +1,38 @@
-from ..stochastic_function import StochasticFunction
-
-# Gradient formulas are based on Simple Statistical Gradient-Following
-# Algorithms for Connectionist Reinforcement Learning, available at
-# http://incompleteideas.net/sutton/williams-92.pdf
+import torch
+from ..function import Function
 
 
-class Multinomial(StochasticFunction):
-
-    def __init__(self, num_samples, with_replacement):
-        super(Multinomial, self).__init__()
-        self.num_samples = num_samples
-        self.with_replacement = with_replacement
-
-    def forward(self, probs):
-        samples = probs.multinomial(self.num_samples, self.with_replacement)
-        self.save_for_backward(probs, samples)
-        self.mark_non_differentiable(samples)
+class Multinomial(Function):
+    @staticmethod
+    def forward(ctx, probs, num_samples, with_replacement):
+        samples = probs.multinomial(num_samples, with_replacement)
+        ctx.mark_non_differentiable(samples)
         return samples
 
-    def backward(self, reward):
-        probs, samples = self.saved_tensors
-        if probs.dim() == 1:
-            probs = probs.unsqueeze(0)
-            samples = samples.unsqueeze(0)
-            reward = reward.unsqueeze(0)
-        # normalize probs (multinomial accepts weights)
-        probs /= probs.sum(1, True).expand_as(probs)
-        grad_probs = probs.new().resize_as_(probs).zero_()
-        output_probs = probs.gather(1, samples)
-        output_probs.add_(1e-6).reciprocal_()
-        output_probs.neg_().mul_(reward)
-        # TODO: add batched index_add
-        for i in range(probs.size(0)):
-            grad_probs[i].index_add_(0, samples[i], output_probs[i])
-        return grad_probs
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None, None, None
 
 
-class Bernoulli(StochasticFunction):
-
-    def forward(self, probs):
+class Bernoulli(Function):
+    @staticmethod
+    def forward(ctx, probs):
         samples = probs.new().resize_as_(probs).bernoulli_(probs)
-        self.save_for_backward(probs, samples)
-        self.mark_non_differentiable(samples)
+        ctx.mark_non_differentiable(samples)
         return samples
 
-    def backward(self, reward):
-        probs, samples = self.saved_tensors
-        rev_probs = probs.neg().add_(1)
-        return (probs - samples) / (probs * rev_probs + 1e-6) * reward
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None
 
 
-class Normal(StochasticFunction):
+class Normal(Function):
+    @staticmethod
+    def forward(ctx, means, stddevs=None):
+        samples = torch.normal(means, stddevs)
+        ctx.mark_non_differentiable(samples)
+        return samples
 
-    def __init__(self, stddev=None):
-        super(Normal, self).__init__()
-        self.stddev = stddev
-        assert stddev is None or stddev > 0
-
-    def forward(self, means, stddevs=None):
-        output = means.new().resize_as_(means)
-        output.normal_()
-        if self.stddev is not None:
-            output.mul_(self.stddev)
-        elif stddevs is not None:
-            output.mul_(stddevs)
-        else:
-            raise RuntimeError("Normal function requires specifying a common "
-                               "stddev, or per-sample stddev")
-        output.add_(means)
-        self.save_for_backward(output, means, stddevs)
-        self.mark_non_differentiable(output)
-        return output
-
-    def backward(self, reward):
-        output, means, stddevs = self.saved_tensors
-        grad_stddevs = None
-        grad_means = means - output  # == -(output - means)
-        assert self.stddev is not None or stddevs is not None
-        if self.stddev is not None:
-            grad_means /= 1e-6 + self.stddev ** 2
-        else:
-            stddevs_sq = stddevs * stddevs
-            stddevs_cb = stddevs_sq * stddevs
-            stddevs_sq += 1e-6
-            stddevs_cb += 1e-6
-            grad_stddevs = (stddevs_sq - (grad_means * grad_means))
-            grad_stddevs /= stddevs_cb
-            grad_stddevs *= reward
-            grad_means /= stddevs_sq
-        grad_means *= reward
-        return grad_means, grad_stddevs
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None, None

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -791,10 +791,10 @@ class Variable(_C._VariableBase):
         return Potrf.apply(self, upper)
 
     def multinomial(self, num_samples=1, replacement=False):
-        return Multinomial(num_samples, replacement)(self)
+        return Multinomial.apply(self, num_samples, replacement)
 
     def bernoulli(self):
-        return Bernoulli()(self)
+        return Bernoulli.apply(self)
 
     def zero_(self):
         return Zero.apply(self, True)
@@ -918,10 +918,7 @@ class Variable(_C._VariableBase):
 
         @staticmethod
         def normal(means, std=1):
-            if isinstance(std, Variable):
-                return Normal()(means, std)
-            else:
-                return Normal(std)(means)
+            return Normal.apply(means, std)
 
         @staticmethod
         def _blas(cls, args, inplace):

--- a/torch/reinforce/__init__.py
+++ b/torch/reinforce/__init__.py
@@ -1,0 +1,104 @@
+"""
+The ``reinforce`` package contains sampling functions that return both the
+random samples and the log of the probability density function (pdf) or
+probability mass function (pmf) evaluated at each sample. These
+log-probabilities can be backpropagated through for policy gradient methods.
+
+Example::
+
+    probs = network(input)
+    action, log_prob = torch.reinforce.multinomial(probs)
+    loss = -log_prob * get_reward(env, action)
+    loss.backward()
+"""
+import math
+import torch
+
+
+__all__ = ['multinomial', 'bernoulli', 'normal']
+
+
+def multinomial(input, num_samples=1):
+    r"""
+    Samples from the multinomial distribution characterized by `input`. Returns
+    the samples and the log-probabilities of each returned sample.
+
+    See also: :func:`torch.multinomial`
+
+    .. note::
+
+        When `num_samples` is greater than one, this function always samples
+        with replacement.
+
+    Args:
+        input (Variable): event probabilities
+        num_samples (int): number of samples to draw
+
+    Returns:
+        a tuple of the samples and the log-probabilities
+    """
+    if input.dim() < 1 or input.dim() > 2:
+        raise ValueError("multinomial expects a 1D or 2D tensor 'input' (got {})"
+                         .format(input.dim()))
+
+    s = torch.multinomial(input, num_samples, True)
+    return s, _multinomial_logpmf(s, input)
+
+
+def _multinomial_logpmf(s, p):
+    # normalize probabilities: multinomial accepts probabilities that sum to
+    # less than one
+    p = p / p.sum(-1, keepdim=True)
+    return p.gather(-1, s).log()
+
+
+def bernoulli(input):
+    r"""
+    Draws binary random numbers from the bernoulli distribution characterized
+    by `input`. Returns the samples and the log-probabilities of each returned
+    sample.
+
+    See also: :func:`torch.bernoulli`
+
+    Args:
+        input (Variable): event probabilities
+
+    Returns:
+        a tuple of the samples and the log-probabilities
+    """
+    s = torch.bernoulli(input)
+    return s, _bernoulli_logpmf(s, input)
+
+
+def _bernoulli_logpmf(s, p):
+    # compute the log probabilities for 0 and 1
+    log_pfms = torch.stack([1 - p, p]).log()
+
+    # evaluate using the samples s.
+    return log_pfms.gather(0, s.unsqueeze(0).long()).squeeze(0)
+
+
+def normal(mean, std):
+    r"""
+    Draws random numbers from the normal distribution and returns the samples
+    and the logarithm of the probability density function at each sample.
+
+    See also: :func:`torch.normal`
+
+    Args:
+        mean (float or Variable): mean of the distribution
+        std (float or Variable): standard deviation of the distribution
+
+    Returns:
+        a tuple of the samples and the log-probabilities
+    """
+    s = torch.normal(mean, std)
+    return s, _normal_logpdf(s, mean, std)
+
+
+def _normal_logpdf(s, mean, std):
+    # compute the variance and clamp it to at least 1e-10 to avoid divide-by-zero
+    var = (std ** 2).clamp(min=1e-10)
+
+    # compute the log-pdf
+    return (s - mean) ** 2 / (-2 * var) - std.log() - math.log(math.sqrt(2 * math.pi))


### PR DESCRIPTION
This removes the StochasticFunctions for bernoulli, multinomial, and
normal and replaces them with functions in torch.reinforce that return
both the samples and the log-probabilities of the samples.

The current StochasticFunction implementation has a few problems: it can
be painful to use when there are multiple stochastic outputs which need
to be back-propagated through. It also requires that we store grad_fns
on Variables that have requires_grad=False in order to find stochastic
nodes.