### PR TITLE
Fix bug with 'coalesced' calculation in 'cadd'.

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -575,6 +575,15 @@ class TestSparse(TestCase):
         self._test_sparse_mask_shape([50, 30, 20], [2])
         self._test_sparse_mask_shape([5, 5, 5, 5, 5, 5], [2])
 
+    def test_sparse_add_coalesce(self):
+        i = self.IndexTensor([[1, 2, 1]])
+        v = self.ValueTensor([3, 4, 5])
+        x = self.SparseTensor(i, v, torch.Size([3]))
+        y = self.SparseTensor(i, v, torch.Size([3]))
+        z = x + y
+
+        self.assertFalse(z._indices().numel() != 2 and z.is_coalesced())
+
     @cuda_only
     def test_storage_not_null(self):
         x = torch.cuda.sparse.FloatTensor(2)


### PR DESCRIPTION
Apparently, the algorithm only guarantees the output is coalesced if
the inputs are coalesced.

I'm planning to do another PR that does much more stringent correctness
testing for the 'coalesced' bit shortly, but y'all should merge
this one first.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>