### PR TITLE
Trying to construct a Tensor from a Variable fails more appropriately

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -317,7 +317,7 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
 #endif
 
   // torch.Tensor(Sequence data)
-  if (num_args == 1 && PySequence_Check(first_arg)) {
+  if (num_args == 1 && PySequence_Check(first_arg) && !THPVariable_Check(first_arg)) {
     Py_ssize_t length = PySequence_Length(first_arg);
     THPUtils_assert(length >= 0, "couldn't obtain the length of %s",
         THPUtils_typename(first_arg));


### PR DESCRIPTION
Addresses #3001. New error message:

```
TypeError: torch.LongTensor constructor received an invalid combination of arguments - got (Variable), but expected one of:
 * no arguments
 * (int ...)
      didn't match because some of the arguments have invalid types: (Variable)
 * (torch.LongTensor viewed_tensor)
      didn't match because some of the arguments have invalid types: (Variable)
 * (torch.Size size)
      didn't match because some of the arguments have invalid types: (Variable)
 * (torch.LongStorage data)
      didn't match because some of the arguments have invalid types: (Variable)
 * (Sequence data)
      didn't match because some of the arguments have invalid types: (Variable)
```

See https://github.com/pytorch/pytorch/issues/3001#issuecomment-335621646 for the previous behavior.