### PR TITLE
Replace StochasticFunctions v2

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -1,0 +1,32 @@
+.. role:: hidden
+    :class: hidden-section
+
+Probability distributions - torch.distributions
+==================================================
+
+.. automodule:: torch.distributions
+.. currentmodule:: torch.distributions
+
+:hidden:`Distribution`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Distribution
+    :members:
+
+:hidden:`Bernoulli`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Bernoulli
+    :members:
+
+:hidden:`Multinomial`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Multinomial
+    :members:
+
+:hidden:`Normal`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Normal
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    nn
    optim
    torch.autograd <autograd>
+   torch.distributions <distributions>
    torch.multiprocessing <multiprocessing>
    torch.distributed <distributed>
    torch.legacy <legacy>

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -30,6 +30,9 @@ echo "Running autograd tests"
 $PYCMD test_autograd.py $@
 $PYCMD test_potrf.py $@
 
+echo "Running torch.distributions tests"
+$PYCMD test_distributions.py $@
+
 echo "Running sparse tests"
 $PYCMD test_sparse.py $@
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -62,6 +62,8 @@ class TestDistributions(TestCase):
         std = Variable(torch.randn(5, 5).abs(), requires_grad=True)
         self.assertEqual(Normal(mean, std).sample().size(), (5, 5))
         self._gradcheck_log_prob(Normal, (mean, std))
+        self._gradcheck_log_prob(Normal, (mean, 1.0))
+        self._gradcheck_log_prob(Normal, (0.0, std))
 
         def ref_log_prob(idx, x, log_prob):
             m = mean.data.view(-1)[idx]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,0 +1,77 @@
+from common import TestCase, run_tests
+import math
+import torch
+from torch.autograd import Variable, gradcheck
+from torch.distributions import Bernoulli, Multinomial, Normal
+
+
+class TestDistributions(TestCase):
+    def _gradcheck_log_prob(self, dist_ctor, ctor_params):
+        # performs gradient checks on log_prob
+        distribution = dist_ctor(*ctor_params)
+        s = distribution.sample()
+
+        self.assertEqual(s.size(), distribution.log_prob(s).size())
+
+        def apply_fn(*params):
+            return dist_ctor(*params).log_prob(s)
+
+        gradcheck(apply_fn, ctor_params, raise_exception=True)
+
+    def _check_log_prob(self, dist, asset_fn):
+        # checks that the log_prob matches a reference function
+        s = dist.sample()
+        log_probs = dist.log_prob(s)
+        for i, (val, log_prob) in enumerate(zip(s.data.view(-1), log_probs.data.view(-1))):
+            asset_fn(i, val, log_prob)
+
+    def test_bernoulli(self):
+        p = Variable(torch.Tensor([0.7, 0.2, 0.4]), requires_grad=True)
+        self._gradcheck_log_prob(Bernoulli, (p,))
+
+        def ref_log_prob(idx, val, log_prob):
+            prob = p.data[idx]
+            self.assertEqual(log_prob, math.log(prob if val else 1 - prob))
+
+        self._check_log_prob(Bernoulli(p), ref_log_prob)
+
+    def test_bernoulli_3d(self):
+        p = Variable(torch.Tensor(2, 3, 5).fill_(0.5), requires_grad=True)
+        self.assertEqual(Bernoulli(p).sample().size(), (2, 3, 5))
+
+    def test_multinomial_1d(self):
+        p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
+        # TODO: this should return a 0-dim tensor once we have Scalar support
+        self.assertEqual(Multinomial(p).sample().size(), (1,))
+        self._gradcheck_log_prob(Multinomial, (p,))
+
+    def test_multinomial_2d(self):
+        probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
+        p = Variable(torch.Tensor(probabilities), requires_grad=True)
+        self.assertEqual(Multinomial(p).sample().size(), (2,))
+        self._gradcheck_log_prob(Multinomial, (p,))
+
+        def ref_log_prob(idx, val, log_prob):
+            sample_prob = p.data[idx][val] / p.data[idx].sum()
+            self.assertEqual(log_prob, math.log(sample_prob))
+
+        self._check_log_prob(Multinomial(p), ref_log_prob)
+
+    def test_normal(self):
+        mean = Variable(torch.randn(5, 5), requires_grad=True)
+        std = Variable(torch.randn(5, 5).abs(), requires_grad=True)
+        self.assertEqual(Normal(mean, std).sample().size(), (5, 5))
+        self._gradcheck_log_prob(Normal, (mean, std))
+
+        def ref_log_prob(idx, x, log_prob):
+            m = mean.data.view(-1)[idx]
+            s = std.data.view(-1)[idx]
+            expected = (math.exp(-(x - m) ** 2 / (2 * s ** 2)) /
+                        math.sqrt(2 * math.pi * s ** 2))
+            self.assertAlmostEqual(log_prob, math.log(expected), places=3)
+
+        self._check_log_prob(Normal(mean, std), ref_log_prob)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -309,6 +309,7 @@ import torch.sparse
 import torch.utils.backcompat
 import torch.onnx
 import torch.random
+import torch.distributions
 
 _C._init_names(list(torch._tensor_classes) + list(torch._storage_classes))
 

--- a/torch/autograd/_functions/stochastic.py
+++ b/torch/autograd/_functions/stochastic.py
@@ -1,92 +1,38 @@
-from ..stochastic_function import StochasticFunction
-
-# Gradient formulas are based on Simple Statistical Gradient-Following
-# Algorithms for Connectionist Reinforcement Learning, available at
-# http://incompleteideas.net/sutton/williams-92.pdf
+import torch
+from ..function import Function
 
 
-class Multinomial(StochasticFunction):
-
-    def __init__(self, num_samples, with_replacement):
-        super(Multinomial, self).__init__()
-        self.num_samples = num_samples
-        self.with_replacement = with_replacement
-
-    def forward(self, probs):
-        samples = probs.multinomial(self.num_samples, self.with_replacement)
-        self.save_for_backward(probs, samples)
-        self.mark_non_differentiable(samples)
+class Multinomial(Function):
+    @staticmethod
+    def forward(ctx, probs, num_samples, with_replacement):
+        samples = probs.multinomial(num_samples, with_replacement)
+        ctx.mark_non_differentiable(samples)
         return samples
 
-    def backward(self, reward):
-        probs, samples = self.saved_tensors
-        if probs.dim() == 1:
-            probs = probs.unsqueeze(0)
-            samples = samples.unsqueeze(0)
-            reward = reward.unsqueeze(0)
-        # normalize probs (multinomial accepts weights)
-        probs /= probs.sum(1, True).expand_as(probs)
-        grad_probs = probs.new().resize_as_(probs).zero_()
-        output_probs = probs.gather(1, samples)
-        output_probs.add_(1e-6).reciprocal_()
-        output_probs.neg_().mul_(reward)
-        # TODO: add batched index_add
-        for i in range(probs.size(0)):
-            grad_probs[i].index_add_(0, samples[i], output_probs[i])
-        return grad_probs
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None, None, None
 
 
-class Bernoulli(StochasticFunction):
-
-    def forward(self, probs):
+class Bernoulli(Function):
+    @staticmethod
+    def forward(ctx, probs):
         samples = probs.new().resize_as_(probs).bernoulli_(probs)
-        self.save_for_backward(probs, samples)
-        self.mark_non_differentiable(samples)
+        ctx.mark_non_differentiable(samples)
         return samples
 
-    def backward(self, reward):
-        probs, samples = self.saved_tensors
-        rev_probs = probs.neg().add_(1)
-        return (probs - samples) / (probs * rev_probs + 1e-6) * reward
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None
 
 
-class Normal(StochasticFunction):
+class Normal(Function):
+    @staticmethod
+    def forward(ctx, means, stddevs=None):
+        samples = torch.normal(means, stddevs)
+        ctx.mark_non_differentiable(samples)
+        return samples
 
-    def __init__(self, stddev=None):
-        super(Normal, self).__init__()
-        self.stddev = stddev
-        assert stddev is None or stddev > 0
-
-    def forward(self, means, stddevs=None):
-        output = means.new().resize_as_(means)
-        output.normal_()
-        if self.stddev is not None:
-            output.mul_(self.stddev)
-        elif stddevs is not None:
-            output.mul_(stddevs)
-        else:
-            raise RuntimeError("Normal function requires specifying a common "
-                               "stddev, or per-sample stddev")
-        output.add_(means)
-        self.save_for_backward(output, means, stddevs)
-        self.mark_non_differentiable(output)
-        return output
-
-    def backward(self, reward):
-        output, means, stddevs = self.saved_tensors
-        grad_stddevs = None
-        grad_means = means - output  # == -(output - means)
-        assert self.stddev is not None or stddevs is not None
-        if self.stddev is not None:
-            grad_means /= 1e-6 + self.stddev ** 2
-        else:
-            stddevs_sq = stddevs * stddevs
-            stddevs_cb = stddevs_sq * stddevs
-            stddevs_sq += 1e-6
-            stddevs_cb += 1e-6
-            grad_stddevs = (stddevs_sq - (grad_means * grad_means))
-            grad_stddevs /= stddevs_cb
-            grad_stddevs *= reward
-            grad_means /= stddevs_sq
-        grad_means *= reward
-        return grad_means, grad_stddevs
+    @staticmethod
+    def backward(ctx, grad_output):
+        return None, None

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -791,10 +791,10 @@ class Variable(_C._VariableBase):
         return Potrf.apply(self, upper)
 
     def multinomial(self, num_samples=1, replacement=False):
-        return Multinomial(num_samples, replacement)(self)
+        return Multinomial.apply(self, num_samples, replacement)
 
     def bernoulli(self):
-        return Bernoulli()(self)
+        return Bernoulli.apply(self)
 
     def zero_(self):
         return Zero.apply(self, True)
@@ -918,10 +918,7 @@ class Variable(_C._VariableBase):
 
         @staticmethod
         def normal(means, std=1):
-            if isinstance(std, Variable):
-                return Normal()(means, std)
-            else:
-                return Normal(std)(means)
+            return Normal.apply(means, std)
 
         @staticmethod
         def _blas(cls, args, inplace):

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -1,0 +1,146 @@
+"""
+The ``distributions`` package contains parameterizable probability distributions
+and sampling functions.
+
+The :meth:`log_prob` method is useful for policy gradient based methods. If the
+parameters of the distribution are differentiable, then the result of ``log_prob``
+is also differentiable.
+
+Example::
+
+    probs = network(input)
+    m = Multinomial(probs)
+    action = m.sample()
+    loss = -m.log_prob(action) * get_reward(env, action)
+    loss.backward()
+"""
+import math
+import torch
+
+
+__all__ = ['Distribution', 'Bernoulli', 'Multinomial', 'Normal']
+
+
+class Distribution(object):
+    r"""
+    Distribution is the abstract base class for probability distributions.
+    """
+
+    def sample(self):
+        """
+        Generates a single sample or single batch of samples if the distribution
+        parameters are batched.
+        """
+        raise NotImplemented
+
+    def log_prob(self, value):
+        """
+        Returns the log of the probability density/mass function evaluated at
+        `value`.
+
+        Args:
+            value (Tensor or Variable):
+        """
+        raise NotImplemented
+
+
+class Bernoulli(Distribution):
+    r"""
+    Creates a Bernoulli distribution parameterized by `probs`.
+
+    Samples are binary (0 or 1). They take the value `1` with probability `p`
+    and `0` with probability `1 - p`.
+
+    Example::
+
+        >>> m = Bernoulli(torch.Tensor([0.3]))
+        >>> m.sample()  # 30% chance 1; 70% chance 0
+         0.0
+        [torch.FloatTensor of size 1]
+
+    Args:
+        probs (Tensor or Variable): the probabilty of sampling `1`
+    """
+    def __init__(self, probs):
+        self.probs = probs
+
+    def sample(self):
+        return torch.bernoulli(self.probs)
+
+    def log_prob(self, value):
+        # compute the log probabilities for 0 and 1
+        log_pmf = (torch.stack([1 - self.probs, self.probs])).log()
+
+        # evaluate using the values
+        return log_pmf.gather(0, value.unsqueeze(0).long()).squeeze(0)
+
+
+class Multinomial(Distribution):
+    r"""
+    Creates a multinomial distribution parameterized by `probs`.
+
+    Samples are integers from `0 ... K-1` where `K` is probs.size(-1).
+
+    If `probs` is 1D with length-`K`, each element is the relative probability
+    of sampling the class at that index.
+
+    If `probs` is 2D, it is treated as a batch of probability vectors.
+
+    See also: :func:`torch.multinomial`
+
+    Example::
+
+        >>> m = Multinomial(torch.Tensor([ 0.25, 0.25, 0.25, 0.25 ]))
+        >>> m.sample()  # equal probability of 0, 1, 2, 3
+         3
+        [torch.LongTensor of size 1]
+
+    Args:
+        probs (Tensor or Variable): event probabilities
+    """
+    def __init__(self, probs):
+        if probs.dim() != 1 and probs.dim() != 2:
+            # TODO: treat higher dimensions as part of the batch
+            raise ValueError("probs must be 1D or 2D")
+        self.probs = probs
+
+    def sample(self):
+        return torch.multinomial(self.probs, 1, True).squeeze(-1)
+
+    def log_prob(self, value):
+        p = self.probs / self.probs.sum(-1, keepdim=True)
+        if value.dim() == 1 and self.probs.dim() == 1:
+            # special handling until we have 0-dim tensor support
+            return p.gather(-1, value).log()
+
+        return p.gather(-1, value.unsqueeze(-1)).squeeze(-1).log()
+
+
+class Normal(Distribution):
+    r"""
+    Creates a normal (also called Gaussian) distribution parameterized by
+    `mean` and `std`.
+
+    Example::
+
+        >>> m = Normal(torch.Tensor([0.0]), torch.Tensor([1.0]))
+        >>> m.sample()  # normally distributed with mean=0 and stddev=1
+         0.1046
+        [torch.FloatTensor of size 1]
+
+    Args:
+        mean (float or Tensor or Variable): mean of the distribution
+        std (float or Tensor or Variable): standard deviation of the distribution
+    """
+    def __init__(self, mean, std):
+        # TODO: handle the case
+        self.mean = mean
+        self.std = std
+
+    def sample(self):
+        return torch.normal(self.mean, self.std)
+
+    def log_prob(self, value):
+        # compute the variance
+        var = (self.std ** 2)
+        return -((value - self.mean) ** 2) / (2 * var) - (self.std).log() - math.log(math.sqrt(2 * math.pi))

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -15,8 +15,8 @@ Example::
     loss.backward()
 """
 import math
+from numbers import Number
 import torch
-from torch.autograd import Variable
 
 
 __all__ = ['Distribution', 'Bernoulli', 'Multinomial', 'Normal']
@@ -130,14 +130,10 @@ class Normal(Distribution):
         [torch.FloatTensor of size 1]
 
     Args:
-        mean (Tensor or Variable): mean of the distribution
-        std (Tensor or Variable): standard deviation of the distribution
+        mean (float or Tensor or Variable): mean of the distribution
+        std (float or Tensor or Variable): standard deviation of the distribution
     """
     def __init__(self, mean, std):
-        if not torch.is_tensor(mean) and not isinstance(mean, Variable):
-            raise TypeError('mean must be a Tensor or Variable')
-        if not torch.is_tensor(std) and not isinstance(std, Variable):
-            raise TypeError('std must be a Tensor or Variable')
         self.mean = mean
         self.std = std
 
@@ -147,4 +143,5 @@ class Normal(Distribution):
     def log_prob(self, value):
         # compute the variance
         var = (self.std ** 2)
-        return -((value - self.mean) ** 2) / (2 * var) - self.std.log() - math.log(math.sqrt(2 * math.pi))
+        log_std = math.log(self.std) if isinstance(self.std, Number) else self.std.log()
+        return -((value - self.mean) ** 2) / (2 * var) - log_std - math.log(math.sqrt(2 * math.pi))

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -16,6 +16,7 @@ Example::
 """
 import math
 import torch
+from torch.autograd import Variable
 
 
 __all__ = ['Distribution', 'Bernoulli', 'Multinomial', 'Normal']
@@ -31,7 +32,7 @@ class Distribution(object):
         Generates a single sample or single batch of samples if the distribution
         parameters are batched.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def log_prob(self, value):
         """
@@ -41,7 +42,7 @@ class Distribution(object):
         Args:
             value (Tensor or Variable):
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class Bernoulli(Distribution):
@@ -129,11 +130,14 @@ class Normal(Distribution):
         [torch.FloatTensor of size 1]
 
     Args:
-        mean (float or Tensor or Variable): mean of the distribution
-        std (float or Tensor or Variable): standard deviation of the distribution
+        mean (Tensor or Variable): mean of the distribution
+        std (Tensor or Variable): standard deviation of the distribution
     """
     def __init__(self, mean, std):
-        # TODO: handle the case
+        if not torch.is_tensor(mean) and not isinstance(mean, Variable):
+            raise TypeError('mean must be a Tensor or Variable')
+        if not torch.is_tensor(std) and not isinstance(std, Variable):
+            raise TypeError('std must be a Tensor or Variable')
         self.mean = mean
         self.std = std
 
@@ -143,4 +147,4 @@ class Normal(Distribution):
     def log_prob(self, value):
         # compute the variance
         var = (self.std ** 2)
-        return -((value - self.mean) ** 2) / (2 * var) - (self.std).log() - math.log(math.sqrt(2 * math.pi))
+        return -((value - self.mean) ** 2) / (2 * var) - self.std.log() - math.log(math.sqrt(2 * math.pi))


### PR DESCRIPTION
This removes the StochasticFunctions for bernoulli, multinomial, and
normal and replaces them with classes in the torch.distributions
package. Each distribution supports the differentiable log_prob function
that returns the log of the pdf/pmf of the samples.

The current StochasticFunction implementation has a few problems: it can
be painful to use when there are multiple stochastic outputs which need
to be back-propagated through. It also requires that we store grad_fns
on Variables that have requires_grad=False in order to find stochastic
nodes.