### PR TITLE
Make sparse test also check that coalesce status of tensors makes sense.

### DIFF
--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -13,7 +13,9 @@ typedef struct THSTensor
     // as buffer, so we keep track of both
     THLongTensor *indices;
     THTensor *values;
-    // Math operations can only be performed on ordered sparse tensors
+    // A sparse tensor is 'coalesced' if every index occurs at most once in
+    // the indices tensor, and the indices are in sorted order.
+    // Most math operations can only be performed on ordered sparse tensors
     int coalesced;
     int refcount;
 


### PR DESCRIPTION
This adds more heavy sanity checking when we run to_dense(); in particular,
we make sure that if it claims to be coalesced, it truly is coalesced, and if
it is not, that the coalesced version also to_dense() to the same thing.

Unfortunately, this uncovered a bug which I wasn't able to solve in the
30min I allocated to it: https://github.com/pytorch/pytorch/issues/3170
It is marked as expect failure.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>