### PR TITLE
Make sparse tensors work with reduce_add_coalesced and broadcast_coalesced

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1519,6 +1519,33 @@ class TestNN(NNTestCase):
         out = dp.data_parallel(l, i)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_data_parallel_sparse(self):
+        l = nn.Embedding(10, 5, sparse = True).cuda(1)
+        i = Variable(torch.LongTensor(20, 5).random_(0, 10).cuda(1))
+        expected_out = l(i)
+        loss = expected_out.sum()
+        loss.backward()
+        expected_grads = []
+        for param in l.parameters():
+            expected_grads.append(param.grad.clone())
+        dev_ids_list = [(0, 1), (1, 0)]
+        for dev_id in dev_ids_list:
+            with torch.cuda.device(dev_id[0]):
+                l.cuda()
+                l.zero_grad()
+                out = dp.data_parallel(l, i, dev_id)
+                loss = out.sum()
+                loss.backward()
+                self.assertEqual(out.get_device(), dev_id[0])
+                self.assertEqual(out.data, expected_out.data)
+                for expected, param in zip(expected_grads, l.parameters()):
+                    self.assertEqual(param.grad.data, expected.data)
+
+        # Check for None device_ids
+        l = l.cuda()
+        out = dp.data_parallel(l, i)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_nested_output(self):
         def fn(input):
             return [input, (input.sin(), input.cos(), [input.add(1)]), input]

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -110,9 +110,15 @@ class TestSparse(TestCase):
         self.assertEqual(i, x._indices())
         self.assertEqual(v, x._values())
         self.assertEqual(x.ndimension(), 3)
-        self.assertEqual(x.coalesce()._nnz(), 10)
+        self.assertEqual(self.safeCoalesce(x)._nnz(), 10)
         for i in range(3):
             self.assertEqual(x.size(i), 100)
+
+        # Make sure that coalesce handles duplicate indices correctly
+        i = self.IndexTensor([[9, 0, 0, 0, 8, 1, 1, 1, 2, 7, 2, 2, 3, 4, 6, 9]])
+        v = self.ValueTensor([[i**2, i] for i in range(i.size(1))])
+        x = self.SparseTensor(i, v, torch.Size([10, 2]))
+        self.assertEqual(self.safeCoalesce(x)._nnz(), 9)
 
         # Make sure we can access empty indices / values
         x = self.SparseTensor()

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -29,7 +29,9 @@ def _type(self, new_type=None, async=False):
         new_type_name = new_type.__module__ + '.' + new_type.__name__
         new_values_type_name = new_type_name.replace('.sparse', '')
         new_values = self._values().type(new_values_type_name, async)
-        return new_type(self._indices(), new_values, self.size())
+        new_indices_type_name = new_type.__module__ + '.LongTensor'
+        new_indices = self._indices().type(new_indices_type_name, async)
+        return new_type(new_indices, new_values, self.size())
     if new_type.is_sparse:
         raise RuntimeError("Cannot cast dense tensor to sparse tensor")
     return new_type(self.size()).copy_(self, async)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -104,44 +104,106 @@ def _accumulate(iterable, fn=lambda x, y: x + y):
 
 
 def _flatten_tensors(tensors):
-    """Flatten tensors into a single contiguous 1D buffer"""
-    if len(tensors) == 1:
-        return tensors[0].contiguous().view(-1)
-    numels = [tensor.numel() for tensor in tensors]
-    size = sum(numels)
-    offset = 0
-    flat = tensors[0].new(size)
-    for tensor, numel in zip(tensors, numels):
-        flat.narrow(0, offset, numel).copy_(tensor, broadcast=False)
-        offset += numel
-    return flat
+    """Flatten tensors into a sequence of contiguous 1D buffers. Assume tensors
+    are of same type.
+
+    In case of dense tensors, the resulting tensor will be a concatenated 1D
+    buffer. Element-wise operation on this buffer will be equivalent to
+    operating separately.
+
+    In case of sparse tensors, the result will be a tuple of two flat tensors,
+    one for indices and one for values.
+    """
+    if tensors[0].is_sparse:
+        flat_indices = _flatten_tensors([t._indices() for t in tensors])
+        flat_values = _flatten_tensors([t._values() for t in tensors])
+        return flat_indices, flat_values
+    else:
+        if len(tensors) == 1:
+            return tensors[0].contiguous().view(-1)
+        numels = [tensor.numel() for tensor in tensors]
+        size = sum(numels)
+        offset = 0
+        flat = tensors[0].new(size)
+        for tensor, numel in zip(tensors, numels):
+            flat.narrow(0, offset, numel).copy_(tensor, broadcast=False)
+            offset += numel
+        return flat
 
 
 def _unflatten_tensors(flat, tensors):
-    """View a flat buffer using the sizes of tensors"""
+    """View a flat buffer using the sizes of tensors. Assume that tensors are of
+    same type, and that flat is given by _flatten_tensors.
+    """
+    if tensors[0].is_sparse:
+        flat_indices, flat_values = flat
+        indices = _unflatten_tensors(flat_indices, [t._indices() for t in tensors])
+        values = _unflatten_tensors(flat_values, [t._values() for t in tensors])
+        outputs = []
+        for t, i, v in zip(tensors, indices, values):
+            outputs.append(t.new(i, v, t.size()))
+        return tuple(outputs)
+    else:
+        outputs = []
+        offset = 0
+        for tensor in tensors:
+            numel = tensor.numel()
+            outputs.append(flat.narrow(0, offset, numel).view_as(tensor))
+            offset += numel
+        return tuple(outputs)
+
+
+def _reorder_tensors_as(tensors, ordered_tensors):
+    """Assume that tensors are of same order as ordered_tensors within sparse
+    and dense classes. Reordered them to be of same order as ordered_tensors.
+    """
+    sparse_tensors = iter(t for t in tensors if t.is_sparse)
+    dense_tensors = iter(t for t in tensors if not t.is_sparse)
     outputs = []
-    offset = 0
-    for tensor in tensors:
-        numel = tensor.numel()
-        outputs.append(flat.narrow(0, offset, numel).view_as(tensor))
-        offset += numel
+    for t in ordered_tensors:
+        if t.is_sparse:
+            outputs.append(next(sparse_tensors))
+        else:
+            outputs.append(next(dense_tensors))
     return tuple(outputs)
 
+def _take_tensors(tensors, size_limit, sparse_single_chunk):
+    """Groups tensors into chunks. This generator yeilds a chunk at each call,
+    each containing tensors of up to certain byte limit in total size.
 
-def _take_tensors(tensors, size_limit):
-    """Groups tensors into lists of up to size_limit bytes"""
+    If sparse_single_chunk=True, yielded tensors are guaranteed to be only of
+    same order within sparse and dense classes, i.e., sparse tensors are of same
+    order with those in input tensors, and same for dense ones.
+
+    Args:
+        tensors (Sequence): A sequence of tensors to be separated into chunks.
+        size_limit (int): The limit of each chunk in bytes.
+        sparse_single_chunk (bool): Whether to put each sparse tensor in single
+            chunks.
+    """
     buf = []
-    size = 0
-    last_type = type(tensors[0]) if len(tensors) > 0 else None
+    buf_size = 0
+    last_type = None
+    last_is_sparse = False
     for tensor in tensors:
         t = type(tensor)
-        param_size = tensor.numel() * tensor.element_size()
-        if t is not last_type or (size + param_size > size_limit and size > 0):
+        is_sparse = tensor.is_sparse
+        if not is_sparse:
+            param_size = tensor.numel() * tensor.element_size()
+        elif sparse_single_chunk:
+            yield [tensor]
+            continue
+        else:
+            indices = tensor._indices()
+            values = tensor._values()
+            param_size = indices.numel() * indices.element_size() + values.numel() * values.element_size()
+        if (len(buf) > 0 and t is not last_type) or (buf_size + param_size > size_limit and buf_size > 0):
             yield buf
             last_type = t
-            size = 0
+            buf_size = 0
             buf = []
         buf.append(tensor)
-        size += param_size
+        last_is_sparse = is_sparse
+        buf_size += param_size
     if len(buf) > 0:
         yield buf

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -55,7 +55,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   HANDLE_TH_ERRORS
 
 #ifdef THC_GENERIC_FILE
-  THCPAutoGPU gpu_guard;
+  THCPAutoGPU gpu_guard(args, NULL);
 #endif
 
   Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -238,7 +238,7 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
   }
   self->cdata = NULL;
 #ifdef THC_GENERIC_FILE
-  THCPAutoGPU gpu_guard;
+  THCPAutoGPU gpu_guard(args, NULL);
 #endif
 
   // Internally we allow constructing with a keyword only argument cdata

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -12,6 +12,8 @@ SUM = 0  # ncclRedOp_t
 def is_available(tensors):
     devices = set()
     for tensor in tensors:
+        if tensor.is_sparse:
+            return False
         if not tensor.is_contiguous():
             return False
         if not tensor.is_cuda:
@@ -22,7 +24,7 @@ def is_available(tensors):
         devices.add(device)
 
     if not hasattr(torch._C, '_nccl_all_reduce'):
-        warnings.warn('PyTorch Not compiled with NCCL support')
+        warnings.warn('PyTorch is not compiled with NCCL support')
         return False
 
     return True

--- a/torch/lib/ATen/Declarations.cwrap
+++ b/torch/lib/ATen/Declarations.cwrap
@@ -1296,6 +1296,7 @@
   python_name: get_device
   backends:
     - CUDA
+    - SparseCUDA
   return: long
   arguments:
     - THTensor* self

--- a/torch/lib/ATen/templates/TypeDerived.cpp
+++ b/torch/lib/ATen/templates/TypeDerived.cpp
@@ -22,7 +22,7 @@ ScalarType ${Type}::scalarType() const {
 Backend ${Type}::backend() const {
   return Backend::${Backend};
 }
-bool ${Type}::isCuda() const { return backend() == kCUDA; }
+bool ${Type}::isCuda() const { return backend() == kCUDA || backend() == kSparseCUDA;; }
 bool ${Type}::isSparse() const { return backend() == kSparseCPU || backend() == kSparseCUDA; }
 bool ${Type}::isDistributed() const { return false; }
 

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -274,7 +274,7 @@ __global__ void THCSTensor_coalesceValuesKernel(
 
   int seg = blockIdx.x * 4 + threadIdx.y;
 
-  // Number of values proceessed by each thread (grain size)
+  // Number of values processed by each thread (grain size)
   const int SZ = 4;
 
   if (seg < newNnz) {

--- a/torch/lib/THCS/generic/THCSTensor.cu
+++ b/torch/lib/THCS/generic/THCSTensor.cu
@@ -55,9 +55,6 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
   // For indices, a simple sort + unique suffices
   // For values, we use a custom kernel for segmented reduction (can't use Thrust due to indirection).
 
-  THCIndexTensor *indices_ = THCSTensor_(newIndices)(state, self);
-  THCIndexTensor *indices = THCIndexTensor_(newContiguous)(state, indices_);
-  THCIndexTensor_(free)(state, indices_);
   THCTensor *values_ = THCSTensor_(newValues)(state, self);
   THCTensor *values = THCTensor_(newContiguous)(state, values_);
   THCTensor_(free)(state, values_);
@@ -67,7 +64,8 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
 
   cudaStream_t stream = THCState_getCurrentStream(state);
 
-  THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, self);
+  // indices will be modified, so we have to clone or use new storage here
+  THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, self, 1);
 
   THCIndexTensor *origIndices = THCIndexTensor_(newWithSize1d)(state, nnz);
   THCIndexTensor *uniqueOffsets = THCIndexTensor_(newWithSize1d)(state, nnz);
@@ -162,7 +160,6 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
   THCSTensor *dst = THCSTensor_(newWithTensorAndSize)(state, newIndices, newValues, size);
   THLongStorage_free(size);
 
-  THCIndexTensor_(free)(state, indices);
   THCTensor_(free)(state, values);
   THCIndexTensor_(free)(state, newIndices);
   THCTensor_(free)(state, newValues);
@@ -173,11 +170,17 @@ THCSTensor *THCSTensor_(newCoalesce)(THCState *state, THCSTensor *self) {
 #undef THRUST_EXEC
 }
 
-THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self) {
+THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self, int forceClone) {
   THCIndexTensor *indices = THCSTensor_(newIndices)(state, self);
   int nDimI = self->nDimensionI;
   if (nDimI == 1) {
-    return indices;
+    if (forceClone) {
+      THCIndexTensor *indices_clone = THCIndexTensor_(newClone)(state, indices);
+      THCIndexTensor_(free)(state, indices);
+      return indices_clone;
+    } else {
+      return indices;
+    }
   } else {
     // FIXME TH_INDEX_BASE
     int64_t factor = 1;

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -76,6 +76,6 @@ TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI,
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, int64_t nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
-TH_API THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self);
+TH_API THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self, int forceClone);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -263,7 +263,7 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
           (uint64_t) nnz);
     }
   } else {
-    THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, sparse);
+    THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, sparse, 0);
     THCIndexTensor_(resize1d)(state, indices1D, nnz);
 
     if (value != ScalarConvert<int, real>::to(1)) {

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -56,6 +56,9 @@ class DistributedDataParallel(Module):
         Same applies to buffers.
 
     .. warning::
+        This module assumes all buffers and gradients are dense.
+
+    .. warning::
         This module doesn't work with :func:`torch.autograd.grad` (i.e. it will
         only work if gradients are to be accumulated in ``.grad`` attributes of
         parameters).
@@ -96,7 +99,7 @@ class DistributedDataParallel(Module):
 
         if len(device_ids) > 1:
             # TODO: we don't need to replicate params in here. they're always going to
-            # be broadcasted using larger blocks in broadcast_coalesce, so it might be
+            # be broadcasted using larger blocks in broadcast_coalesced, so it might be
             # better to not pollute the caches with these small blocks
             self._module_copies = replicate(self.module, self.device_ids)
             self._module_copies[0] = self.module


### PR DESCRIPTION
As a result, sparse tensors now work with data_parallel. Fixes #1456 .

Commit structure:
1. Add support for sparse tensors in various places for `add_coalesced` and `broadcast_coalesced`.
2. Fix `_type` not working properly on sparse. Previously it didn't convert indices tensor when converted between cuda and cpu.
3. Add test in `test_cuda.py`.
4. Fix `pynew` `AutoGPU` arguments.

