### PR TITLE
Speed up norm_backward

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -105,8 +105,8 @@
   self: grad.diag(diagonal)
 
 - name: dist(Tensor self, Tensor other, Scalar p=2)
-  self: norm_backward(grad, self - other, p)
-  other: -norm_backward(grad, self - other, p)
+  self: norm_backward(grad, self - other, p, result)
+  other: -norm_backward(grad, self - other, p, result)
 
 - name: div(Tensor self, Scalar value)
   self: grad / value
@@ -345,10 +345,10 @@
   self: zeros_like(grad)
 
 - name: norm(Tensor self, Scalar p=2)
-  self: norm_backward(grad, self, p)
+  self: norm_backward(grad, self, p, result)
 
 - name: norm(Tensor self, Scalar p, int64_t dim, bool keepdim=False)
-  self: norm_backward(grad, self, p, dim, keepdim)
+  self: norm_backward(grad, self, p, destination, dim, keepdim)
 
 - name: numel  # fallthrough
 - name: ones  # fallthrough

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -690,7 +690,7 @@ def load_aten_declarations(path):
 
         declaration['base_name'] = declaration['name']
 
-        # if the return value is missing a name, call it 'output'
+        # if the return value is missing a name, call it 'result'
         for ret in declaration['returns']:
             if 'name' not in ret:
                 assert len(declaration['returns']) == 1

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -30,41 +30,28 @@ Tensor maybe_multiply(const Tensor & t, const Scalar & s) {
   }
 }
 
-Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_) {
-  auto p = p_.toDouble();
-  auto norm = self.norm(p_);
-
-  if (norm.toDouble() == 0.0) {
-    // handle case at 0 where we return a subgradient containing 0
-    return zeros_like(self);
-  }
-
+Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_, const Tensor & norm) {
+  double p = p_.toDouble();
+  Tensor self_scaled;
+  Tensor scale_v;
   if (p == 2.0) {
-    return self * (grad / norm);
+    self_scaled = self;
+    scale_v = grad / norm;
   } else {
-    auto pow_ = self.abs().pow(p - 2);
-    auto scale_v = grad / norm.toTensor().pow(p - 1);
-    return self * pow_ * scale_v;
-  }
-}
-
-Tensor norm_backward(Tensor grad, const Tensor & self, const Scalar & p_, int64_t dim, bool keepdim) {
-  if (!keepdim && self.dim() > 1) {
-    grad = grad.unsqueeze(dim);
-  }
-  auto p = p_.toDouble();
-  auto norm = self.norm(p, dim, true);
-  Tensor grad_input;
-  if (p == 2.0) {
-    grad_input = self * (grad / norm);
-  } else {
-    auto pow_ = self.abs().pow(p - 2);
-    auto scale_v = grad / norm.pow(p - 1);
-    grad_input = self * pow_ * scale_v;
+    self_scaled = self.abs().pow(p - 2);
+    scale_v = grad / norm.pow(p - 1);
   }
   // handle case at 0 where we return a subgradient containing 0
-  grad_input.masked_fill_(norm == 0, 0);
-  return grad_input;
+  scale_v.masked_fill_(grad == 0, 0);
+  return self_scaled * scale_v;
+}
+
+Tensor norm_backward(Tensor grad, const Tensor & self, const Scalar & p_, Tensor norm, int64_t dim, bool keepdim) {
+  if (!keepdim && self.dim() > 1) {
+    grad = grad.unsqueeze(dim);
+    norm = norm.unsqueeze(dim);
+  }
+  return norm_backward(grad, self, p_, norm);
 }
 
 Tensor reduce_to(const Tensor & grad, IntList sizes) {


### PR DESCRIPTION
Also avoids a CUDA synchronization in norm_backward.

Here's a benchmarking script. **You must comment out norm in variable.py to see any difference.**

```python
import torch; from torch.autograd import Variable; v = Variable(torch.randn(1024,1024), requires_grad=True); vc = Variable(v.data.cuda(), requires_grad=True); g = torch.randn(1024); gc = torch.randn(1024).cuda()

%timeit v.norm().backward()
%timeit v.norm().backward()
%timeit v.norm(0).backward(g)
%timeit v.norm(0).backward(g)

%timeit vc.norm().backward()
%timeit vc.norm().backward()
%timeit vc.norm(0).backward(gc)
%timeit vc.norm(0).backward(gc)
```

Before:
```
100 loops, best of 3: 3.96 ms per loop
100 loops, best of 3: 4.04 ms per loop
100 loops, best of 3: 8 ms per loop
100 loops, best of 3: 7.94 ms per loop
1000 loops, best of 3: 544 µs per loop
1000 loops, best of 3: 532 µs per loop
1000 loops, best of 3: 619 µs per loop
1000 loops, best of 3: 620 µs per loop
```

After:
```
100 loops, best of 3: 2.99 ms per loop
100 loops, best of 3: 2.97 ms per loop
100 loops, best of 3: 6.02 ms per loop
100 loops, best of 3: 5.66 ms per loop
1000 loops, best of 3: 369 µs per loop
1000 loops, best of 3: 342 µs per loop
1000 loops, best of 3: 417 µs per loop
1000 loops, best of 3: 421 µs per loop
```