### PR TITLE
Update THDTensor.cpp to fix gcc issues

### DIFF
--- a/torch/lib/THD/master_worker/master/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/THDTensor.cpp
@@ -1,3 +1,5 @@
+#include __STDC_FORMAT_MACROS
+
 #include "THDTensor.h"
 #include "State.hpp"
 #include "Utils.hpp"

--- a/torch/lib/THD/master_worker/master/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/THDTensor.cpp
@@ -1,4 +1,4 @@
-#include __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
 
 #include "THDTensor.h"
 #include "State.hpp"


### PR DESCRIPTION
Add `__STDC_FORMAT_MACROS` to fix gcc issues.

The ANSI/ISO C99 standard describes the fprintf macros in section 7.8.1 and states that

> C++ implementations should define these macros only when __STDC_FORMAT_MACROS is defined before <inttypes.h> is included

Apparently this is the case in some versions of gcc but not others, as #3183 points out. This commit fixes that problem.