### PR TITLE
include <string> to support std::to_string()

### DIFF
--- a/torch/lib/ATen/Half.h
+++ b/torch/lib/ATen/Half.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <stdint.h>
+#include <string>
 #ifdef AT_CUDA_ENABLED
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
Fix issue #3192 by adding `#include <string>` in `Half.h` to support `std::to_string()`.