### PR TITLE
Don't resize output in cpu torch.gels

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2047,7 +2047,11 @@ class TestTorch(TestCase):
 
     @skipIfNoLapack
     def test_gels(self):
-        def _test(a, b, expectedNorm):
+        def _test_underdetermined(a, b, expectedNorm):
+            m = a.size()[0]
+            n = a.size()[1]
+            assert(m <= n)
+
             a_copy = a.clone()
             b_copy = b.clone()
             res1 = torch.gels(b, a)[0]
@@ -2069,6 +2073,47 @@ class TestTorch(TestCase):
             self.assertEqual(res1, res2, 0)
             self.assertEqual(res1, res3, 0)
 
+        def _test_overdetermined(a, b, expectedNorm):
+            m = a.size()[0]
+            n = a.size()[1]
+            assert(m > n)
+
+            def check_norm(a, b, expected_norm, gels_result):
+                # Checks |ax - b| and the residual info from the result
+                n = a.size()[1]
+
+                # The first n rows is the least square solution.
+                # Rows n to m-1 contain residual information.
+                x = gels_result[:n]
+                resid_info = gels_result[n:]
+
+                resid_norm = (torch.mm(a, x) - b).norm()
+                self.assertEqual(resid_norm, expectedNorm, 1e-8)
+                self.assertEqual(resid_info.norm(), resid_norm, 1e-8)
+
+            a_copy = a.clone()
+            b_copy = b.clone()
+            res1 = torch.gels(b, a)[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            check_norm(a, b, expectedNorm, res1)
+
+            ta = torch.Tensor()
+            tb = torch.Tensor()
+            res2 = torch.gels(b, a, out=(tb, ta))[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            check_norm(a, b, expectedNorm, res2)
+
+            res3 = torch.gels(b, a, out=(b, a))[0]
+            check_norm(a_copy, b_copy, expectedNorm, res3)
+
+            self.assertEqual(res1, tb, 0)
+            self.assertEqual(res1, b, 0)
+            self.assertEqual(res1, res2, 0)
+            self.assertEqual(res1, res3, 0)
+
+
         # basic test
         expectedNorm = 0
         a = torch.Tensor(((1.44, -9.96, -7.55, 8.34),
@@ -2077,7 +2122,7 @@ class TestTorch(TestCase):
                           (4.53, 3.83, -6.64, 2.06))).t()
         b = torch.Tensor(((8.58, 8.26, 8.48, -5.28),
                           (9.35, -4.43, -0.70, -0.26))).t()
-        _test(a, b, expectedNorm)
+        _test_underdetermined(a, b, expectedNorm)
 
         # test overderemined
         expectedNorm = 17.390200628863
@@ -2087,7 +2132,7 @@ class TestTorch(TestCase):
                           (4.53, 3.83, -6.64, 2.06, -2.47, 4.70))).t()
         b = torch.Tensor(((8.58, 8.26, 8.48, -5.28, 5.72, 8.93),
                           (9.35, -4.43, -0.70, -0.26, -7.36, -2.52))).t()
-        _test(a, b, expectedNorm)
+        _test_overdetermined(a, b, expectedNorm)
 
         # test underdetermined
         expectedNorm = 0
@@ -2097,7 +2142,7 @@ class TestTorch(TestCase):
                           (4.53, 3.83, -6.64))).t()
         b = torch.Tensor(((8.58, 8.26, 8.48),
                           (9.35, -4.43, -0.70))).t()
-        _test(a, b, expectedNorm)
+        _test_underdetermined(a, b, expectedNorm)
 
         # test reuse
         expectedNorm = 0

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2113,7 +2113,6 @@ class TestTorch(TestCase):
             self.assertEqual(res1, res2, 0)
             self.assertEqual(res1, res3, 0)
 
-
         # basic test
         expectedNorm = 0
         a = torch.Tensor(((1.44, -9.96, -7.55, 8.34),

--- a/torch/lib/TH/generic/THTensorLapack.c
+++ b/torch/lib/TH/generic/THTensorLapack.c
@@ -259,10 +259,14 @@ void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
                                      if (free_b) THTensor_(free)(b);),
                            "gels", info,"");
 
-  /* rb__ is currently ldb by nrhs; resize it to n by nrhs */
-  rb__->size[0] = n;
-  if (rb__ != rb_)
+  /*
+   * In the m < n case, if the input b is used as the result (so b == _rb),
+   * then rb_ was originally m by nrhs but now should be n by nrhs.
+   * This is larger than before, so we need to expose the new rows by resizing.
+   */
+  if (m < n && b == rb_) {
     THTensor_(resize2d)(rb_, n, nrhs);
+  }
 
   THTensor_(freeCopyTo)(ra__, ra_);
   THTensor_(freeCopyTo)(rb__, rb_);


### PR DESCRIPTION
### Summary
Fixes https://github.com/pytorch/pytorch/issues/3103.

The output of Lapack gels when `m > n` (where the input matrix `A` has size `m` by `n`) was being resized to `n` rows. This is a bug because [gels returns information in rows n+1 to m of the output](https://software.intel.com/en-us/node/521112)

### Test Plan
Make sure CPU and GPU `gels` now return the same output:
```
import torch
b = torch.randn(600,1)
A = torch.randn(600,2)
X, _ = torch.gels(b,A)
Y, _ = torch.gels(b.cuda(),A.cuda())
sum((X - Y.cpu()) ** 2)  # verify this is close to 0
X.size()  # verify this is (600, 2)
Y.size()  # verify this is (600, 2)
```

Also added some new unit tests to test the new `m > n` behavior. 