### PR TITLE
Use the actual C struct name for the PyCapsule

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -544,12 +544,12 @@ PyObject *THPModule_toDLPack(PyObject *_unused, PyObject *data)
   THPUtils_assert(THPModule_isTensor(data), "data must be a Tensor");
   auto atTensor = torch::createTensor(data);
   DLManagedTensor* dlMTensor = at::toDLPack(atTensor);
-  return PyCapsule_New(dlMTensor, "dltensor", NULL);
+  return PyCapsule_New(dlMTensor, "DLManagedTensor", NULL);
 }
 
 PyObject *THPModule_fromDLPack(PyObject *_unused, PyObject *data)
 {
-  DLManagedTensor * dlMTensor = (DLManagedTensor *)PyCapsule_GetPointer(data, "dltensor");
+  DLManagedTensor * dlMTensor = (DLManagedTensor *)PyCapsule_GetPointer(data, "DLManagedTensor");
   THPUtils_assert(dlMTensor, "from_dlpack received an invalid capsule. "
     "Note that DLTensor capsules can be consumed only once, "
     "so you might have already constructed a tensor from it once.")

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -129,7 +129,7 @@ void initPythonIRBindings(PyObject * module_) {
         return n.t(stringToSymbol(name));
     })
     .def("zs_",[](Node & n, const char * name, TensorsAttr::ValueType v) {
-        for (size_t i = 0; i < v.size(); ++ i) {
+        for (size_t i = 0; i < v.size(); ++i) {
             v[i] = v[i].view({});
         }
         return n.ts_(stringToSymbol(name), std::move(v));

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -211,6 +211,7 @@ void attributesTest() {
   auto two = kReturn;
   auto three = kConstant;
   auto four = kSlice;
+  (void) four; // silence assert warning, TODO: switch to JIT_ASSERT when these tests are enabled again
   Attr attr;
   attr.f_(one,3.4)->i_(two,5)->s_(three,"what");
   assert(attr.f(one) == 3.4);


### PR DESCRIPTION
Plus various things to silence the accumulated warnings.