### PR TITLE
Fix Python 3 portability problem.

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -180,8 +180,10 @@ def _graph_op(g, opname, *raw_args, **kwargs):
             in positional.
     """
     outputs = kwargs.pop('outputs', 1)
-    # Filter out None attributes, this can be convenient client side
-    kwargs = dict((k, v) for k, v in kwargs.iteritems() if v is not None)
+
+    # Filter out None attributes, this can be convenient client side because
+    # now they can pass through None attributes, and have them not show up
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
 
     def const_if_tensor(arg):
         if isinstance(arg, torch._C.Node):


### PR DESCRIPTION
This wasn't caught by PyTorch CI because all ONNX tests run in external repo, and I was only running locally with Python 2.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>