### PR TITLE
Update Dockerfile to use Ubuntu 17.04, GCC 6.3, and CUDA 9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04 
+FROM nvidia/cuda:9.0-devel-ubuntu17.04
 
 RUN echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
 


### PR DESCRIPTION
I have been testing this Dockerfile mod for past two weeks, and speed + stability are great.  Users can benefit from newer CUDA 9.0 and GCC 6.3 (included with Ubuntu 17.04).  

Base image provided by Felix @ NVidia: 
https://gitlab.com/nvidia/cuda/issues/9