### PR TITLE
Fix sparse bugs; add reduce_add, broadcase, data_parallel for sparse

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1519,6 +1519,33 @@ class TestNN(NNTestCase):
         out = dp.data_parallel(l, i)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_data_parallel_sparse(self):
+        l = nn.Embedding(10, 5, sparse=True).cuda(1)
+        i = Variable(torch.LongTensor(20, 5).random_(0, 10).cuda(1))
+        expected_out = l(i)
+        loss = expected_out.sum()
+        loss.backward()
+        expected_grads = []
+        for param in l.parameters():
+            expected_grads.append(param.grad.clone())
+        dev_ids_list = [(0, 1), (1, 0)]
+        for dev_id in dev_ids_list:
+            with torch.cuda.device(dev_id[0]):
+                l.cuda()
+                l.zero_grad()
+                out = dp.data_parallel(l, i, dev_id)
+                loss = out.sum()
+                loss.backward()
+                self.assertEqual(out.get_device(), dev_id[0])
+                self.assertEqual(out.data, expected_out.data)
+                for expected, param in zip(expected_grads, l.parameters()):
+                    self.assertEqual(param.grad.data, expected.data)
+
+        # Check for None device_ids
+        l = l.cuda()
+        out = dp.data_parallel(l, i)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_nested_output(self):
         def fn(input):
             return [input, (input.sin(), input.cos(), [input.add(1)]), input]

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -110,9 +110,15 @@ class TestSparse(TestCase):
         self.assertEqual(i, x._indices())
         self.assertEqual(v, x._values())
         self.assertEqual(x.ndimension(), 3)
-        self.assertEqual(x.coalesce()._nnz(), 10)
+        self.assertEqual(self.safeCoalesce(x)._nnz(), 10)
         for i in range(3):
             self.assertEqual(x.size(i), 100)
+
+        # Make sure that coalesce handles duplicate indices correctly
+        i = self.IndexTensor([[9, 0, 0, 0, 8, 1, 1, 1, 2, 7, 2, 2, 3, 4, 6, 9]])
+        v = self.ValueTensor([[idx**2, idx] for idx in range(i.size(1))])
+        x = self.SparseTensor(i, v, torch.Size([10, 2]))
+        self.assertEqual(self.safeCoalesce(x)._nnz(), 9)
 
         # Make sure we can access empty indices / values
         x = self.SparseTensor()

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -26,10 +26,12 @@ def _type(self, new_type=None, async=False):
     if self.is_sparse:
         if not new_type.is_sparse:
             raise RuntimeError("Cannot cast sparse tensor to dense tensor")
-        new_type_name = new_type.__module__ + '.' + new_type.__name__
-        new_values_type_name = new_type_name.replace('.sparse', '')
+        new_module_name = new_type.__module__.replace('.sparse', '')
+        new_values_type_name = new_module_name + '.' + new_type.__name__
         new_values = self._values().type(new_values_type_name, async)
-        return new_type(self._indices(), new_values, self.size())
+        new_indices_type_name = new_module_name + '.LongTensor'
+        new_indices = self._indices().type(new_indices_type_name, async)
+        return new_type(new_indices, new_values, self.size())
     if new_type.is_sparse:
         raise RuntimeError("Cannot cast dense tensor to sparse tensor")
     return new_type(self.size()).copy_(self, async)

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -55,7 +55,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   HANDLE_TH_ERRORS
 
 #ifdef THC_GENERIC_FILE
-  THCPAutoGPU gpu_guard;
+  THCPAutoGPU gpu_guard(args, NULL);
 #endif
 
   Py_ssize_t num_args = args ? PyTuple_Size(args) : 0;

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -238,7 +238,7 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
   }
   self->cdata = NULL;
 #ifdef THC_GENERIC_FILE
-  THCPAutoGPU gpu_guard;
+  THCPAutoGPU gpu_guard(args, NULL);
 #endif
 
   // Internally we allow constructing with a keyword only argument cdata

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -12,6 +12,8 @@ SUM = 0  # ncclRedOp_t
 def is_available(tensors):
     devices = set()
     for tensor in tensors:
+        if tensor.is_sparse:
+            return False
         if not tensor.is_contiguous():
             return False
         if not tensor.is_cuda:
@@ -22,7 +24,7 @@ def is_available(tensors):
         devices.add(device)
 
     if not hasattr(torch._C, '_nccl_all_reduce'):
-        warnings.warn('PyTorch Not compiled with NCCL support')
+        warnings.warn('PyTorch is not compiled with NCCL support')
         return False
 
     return True

--- a/torch/lib/THCS/THCSTensor.cu
+++ b/torch/lib/THCS/THCSTensor.cu
@@ -274,7 +274,7 @@ __global__ void THCSTensor_coalesceValuesKernel(
 
   int seg = blockIdx.x * 4 + threadIdx.y;
 
-  // Number of values proceessed by each thread (grain size)
+  // Number of values processed by each thread (grain size)
   const int SZ = 4;
 
   if (seg < newNnz) {

--- a/torch/lib/THCS/generic/THCSTensor.h
+++ b/torch/lib/THCS/generic/THCSTensor.h
@@ -76,6 +76,7 @@ TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI,
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, int64_t nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
-TH_API THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self);
+// forceClone is intended to use as a boolean
+TH_API THCIndexTensor* THCSTensor_(newFlattenedIndices)(THCState *state, THCSTensor *self, int forceClone);
 
 #endif

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -277,7 +277,7 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
           (uint64_t) nnz);
     }
   } else {
-    THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, sparse);
+    THCIndexTensor *indices1D = THCSTensor_(newFlattenedIndices)(state, sparse, 0);
     THCIndexTensor_(resize1d)(state, indices1D, nnz);
 
     if (value != ScalarConvert<int, real>::to(1)) {


### PR DESCRIPTION
This PR adds various fixes for sparse tensors. In particular, it contains the following:

Fixes:
1. Fixes `.type()` not converting indices tensor.
2. Fixes ATen not considering sparse cuda tensors as cuda and missing `get_device` bindings, causing `AutoGPU` checks to fail in backward engine.
3. Fixes `AutoGPU` missing args in `pynew`.
4. Fixes sparse tensor coalesce. The bug is caused by using `thrust::unique_by_key`, which modifies the key tensor. In case where key is 1D, original implementation is operating on the same tensor indices data storage, and thus modifies it. This is fixed by adding a flag to `THCSTensor_(newFlattenedIndices)`, controlling whether the returned value is forced to be a clone.

New functionalities:
Added support for sparse tensors in `broadcast_coalesced` and `reduce_add_coalesced`, and thus enabling `data_parallel` (fixing #1456 ). In particular, the `_take_tensors` function is modified:

1.  ~~~In case of `reduce_add_coalesced`, it returns each sparse tensor in a separate chunk because reduce_add on combined tensors only makes sense in dense case. In addition, the yielded tensors are now only maintaining order within sparse/dense class, as specified in code comments. Hence, an additional method `_reorder_tensors_as` is provided to get back the original order.~~~
2. ~~~In case `broadcast_coalesced`, sparse tensors of same type are returned together in chunk. Furthermore, `_flatten_tensors` and `_unflatten_tensors` are updated to support combining sparse tensors, allowing faster broadcasting.~~~

See comment below for details.

Various tests are added for the fixes and new functionalities above.

cc: @ezyang @colesbury
