### PR TITLE
Don't create grad_fn if requires_grad=False

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -545,8 +545,9 @@ class TestAutograd(TestCase):
         # NB: we currently raise an exception if any arguments to backwards
         # have requires_grad=False and don't have a grad_fn. We may want to
         # relax that check to a warning.
-        self.assertRaises(RuntimeError, lambda:
-            torch.autograd.backward([z, q], [torch.ones(5, 5), torch.ones(5, 5)]))
+        def call_backwards():
+            torch.autograd.backward([z, q], [torch.ones(5, 5), torch.ones(5, 5)])
+        self.assertRaises(RuntimeError, call_backwards)
 
     def test_dependent_backward(self):
         x = Variable(torch.randn(10), requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -542,8 +542,11 @@ class TestAutograd(TestCase):
         z = x + y
         q = y * 2
 
-        torch.autograd.backward([z, q], [torch.ones(5, 5), torch.ones(5, 5)])
-        self.assertEqual(x.grad.data, torch.ones(5, 5))
+        # NB: we currently raise an exception if any arguments to backwards
+        # have requires_grad=False and don't have a grad_fn. We may want to
+        # relax that check to a warning.
+        self.assertRaises(RuntimeError, lambda:
+            torch.autograd.backward([z, q], [torch.ones(5, 5), torch.ones(5, 5)]))
 
     def test_dependent_backward(self):
         x = Variable(torch.randn(10), requires_grad=True)


### PR DESCRIPTION
```
Don't create grad_fn if requires_grad=False

Other changes:

 - Check that arguments without derivative definitions have
   requires_grad=False
 - Pass all tensor arguments to the tracer, including ones without
   derivative definitions
````

Note that this may trigger errors in the calls to `backwards()` if any of the outputs have requires_grad=False, since now they will not have a grad_fn. I suspect that this mostly occurs in tests, but we may want to relax the check to issue a warning instead of raising an error.