### PR TITLE
Fix to #2236 - tensor.numpy() checks that no positional arguments are passed.

### DIFF
--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -64,7 +64,6 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
   THPUtils_setError("numpy conversion for %s is not supported\n", THPUtils_typename(self));
   return NULL;
 #else
-
   npy_intp zero = 0;
   int ndim;
   npy_intp* sizes_ptr;

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -70,10 +70,7 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
   std::unique_ptr<npy_intp[]> sizes;
   std::unique_ptr<npy_intp[]> strides;
 
-  if (!PyArg_ParseTuple(args, "")) {
-    THPUtils_setError("numpy() takes no positional arguments");
-    return NULL;
-  }
+  THPUtils_assert(PyTuple_Size(args) == 0, "numpy() takes no positional arguments");
 
   // Numpy and Torch disagree on empty tensors. In Torch, an empty tensor
   // is a tensor with zero dimensions. In Numpy, a tensor with zero dimensions

--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -64,11 +64,17 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
   THPUtils_setError("numpy conversion for %s is not supported\n", THPUtils_typename(self));
   return NULL;
 #else
+
   npy_intp zero = 0;
   int ndim;
   npy_intp* sizes_ptr;
   std::unique_ptr<npy_intp[]> sizes;
   std::unique_ptr<npy_intp[]> strides;
+
+  if (!PyArg_ParseTuple(args, "")) {
+    THPUtils_setError("numpy() takes no positional arguments");
+    return NULL;
+  }
 
   // Numpy and Torch disagree on empty tensors. In Torch, an empty tensor
   // is a tensor with zero dimensions. In Numpy, a tensor with zero dimensions


### PR DESCRIPTION
Created a check in tensor.numpy() that checks if no positional arguments are passed.

Fixes:
https://github.com/pytorch/pytorch/issues/2236