### PR TITLE
Fix reference counting bug in python_nn_functions.cpp

### DIFF
--- a/tools/autograd/templates/python_nn_functions.cpp
+++ b/tools/autograd/templates/python_nn_functions.cpp
@@ -25,6 +25,7 @@ static PyMethodDef nn_functions[] = {
 void initNNFunctions(PyObject* module) {
 #if PY_MAJOR_VERSION == 2
   PyObject* nn = Py_InitModule("torch._C._nn", nn_functions);
+  Py_XINCREF(nn);  // Py_InitModule returns "borrowed" reference
 #else
   static struct PyModuleDef def = {
      PyModuleDef_HEAD_INIT,
@@ -38,6 +39,7 @@ void initNNFunctions(PyObject* module) {
   if (!nn) {
     throw python_error();
   }
+  // steals a reference to nn
   if (PyModule_AddObject(module, "_nn", nn) != 0) {
     throw python_error();
   }


### PR DESCRIPTION
Py_InitModule returns a borrowed reference. PyModule_AddObject steals
the reference, so we need to incref the `_nn` object.

(The Python 3 function PyModule_Create returns a new reference.)