### PR TITLE
Fix lint build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,F401,F403,F405,F821,F841,F999
+ignore = E305,E402,E721,E722,E741,F401,F403,F405,F821,F841,F999
 exclude = docs/src,venv,torch/lib/gloo,torch/lib/pybind11,torch/lib/nanopb


### PR DESCRIPTION
The flake8 package was upgraded to include new errors which cause the
build to break.