### PR TITLE
Fix E722 ('do not use bare except')

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -210,7 +210,7 @@ class TestCase(unittest.TestCase):
             try:
                 self.assertLessEqual(abs(x - y), prec, message)
                 return
-            except TypeError:
+            except (TypeError, AssertionError):
                 pass
             super(TestCase, self).assertEqual(x, y, message)
 
@@ -242,7 +242,7 @@ class TestCase(unittest.TestCase):
             try:
                 self.assertGreaterEqual(abs(x - y), prec, message)
                 return
-            except TypeError:
+            except (TypeError, AssertionError):
                 pass
             super(TestCase, self).assertNotEqual(x, y, message)
 

--- a/test/common.py
+++ b/test/common.py
@@ -116,7 +116,7 @@ def is_iterable(obj):
     try:
         iter(obj)
         return True
-    except:
+    except TypeError:
         return False
 
 
@@ -210,7 +210,7 @@ class TestCase(unittest.TestCase):
             try:
                 self.assertLessEqual(abs(x - y), prec, message)
                 return
-            except:
+            except TypeError:
                 pass
             super(TestCase, self).assertEqual(x, y, message)
 
@@ -242,7 +242,7 @@ class TestCase(unittest.TestCase):
             try:
                 self.assertGreaterEqual(abs(x - y), prec, message)
                 return
-            except:
+            except TypeError:
                 pass
             super(TestCase, self).assertNotEqual(x, y, message)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -35,7 +35,7 @@ import os as _dl_flags
 # or there is risk that later c modules will segfault when importing numpy
 try:
     import numpy as np
-except:
+except ImportError:
     pass
 
 # first check if the os package has the required flags

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -404,7 +404,7 @@ class Module(object):
                     param = param.data
                 try:
                     own_state[name].copy_(param)
-                except:
+                except Exception:
                     raise RuntimeError('While copying the parameter named {}, ' +
                                        'whose dimensions in the model are {} and ' +
                                        'whose dimensions in the checkpoint are {}.'

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -150,7 +150,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
             try:
                 source_file = inspect.getsourcefile(obj)
                 source = inspect.getsource(obj)
-            except:  # saving the source is optional, so we can ignore any errors
+            except Exception:  # saving the source is optional, so we can ignore any errors
                 warnings.warn("Couldn't retrieve source code for container of "
                               "type " + obj.__name__ + ". It won't be checked "
                               "for correctness upon loading.")

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -49,7 +49,7 @@ def _pin_memory_loop(in_queue, out_queue, done_event):
     while True:
         try:
             r = in_queue.get()
-        except:
+        except Exception:
             if done_event.is_set():
                 return
             raise

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,E722,E741,F401,F403,F405,F821,F841,F999
+ignore = E305,E402,E721,E741,F401,F403,F405,F821,F841,F999
 exclude = docs/src,venv,torch/lib/gloo,torch/lib/pybind11,torch/lib/nanopb


### PR DESCRIPTION
The new version of flake8 includes a check for not using bare except. We
should avoid this since it catches things like KeyboardInterrupt.

(See also #3237)