### PR TITLE
Fix LogSoftMax

### DIFF
--- a/torch/lib/THNN/generic/LogSoftMax.c
+++ b/torch/lib/THNN/generic/LogSoftMax.c
@@ -47,7 +47,7 @@ void THNN_(LogSoftMax_updateOutput)(
     real *output_data = output_data_base + outer_idx * outer_stride + inner_idx;
 
     real max_input = -THInf;
-    for (d = 1; d < LOG_SOFTMAX_CAST_TYPE dim_size; d++)
+    for (d = 0; d < LOG_SOFTMAX_CAST_TYPE dim_size; d++)
       max_input = THMax(max_input, input_data[d * dim_stride]);
 
     accreal logsum = 0;


### PR DESCRIPTION
Fixes #3240. 

The bug is that `max_input` doesn't take into account the first element of the input. In this case, when the input only has one element (ie, `torch.Tensor([0.7])`), it thinks the max element is -inf instead of 0.7.

### Test Plan
```
import torch
from torch.nn.functional import log_softmax
from torch.autograd import Variable
log_softmax(Variable(torch.Tensor([0.7])), dim=0)
```
Verify that this prints out 0 now instead of -inf as before.