### PR TITLE
Add CUDNN_LIB_DIR in rpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -499,10 +499,10 @@ if WITH_NCCL:
     ]
 if WITH_CUDNN:
     main_libraries += ['cudnn']
-    # NOTE: this this at the front, in case there's another cuDNN in CUDA path
-    include_dirs.insert(0, CUDNN_INCLUDE_DIR)
     library_dirs.append(CUDNN_LIB_DIR)
-    extra_link_args.append('-Wl,-rpath,' + CUDNN_LIB_DIR)
+    # NOTE: these are at the front, in case there's another cuDNN in CUDA path
+    include_dirs.insert(0, CUDNN_INCLUDE_DIR)
+    extra_link_args.insert(0, '-Wl,-rpath,' + CUDNN_LIB_DIR)
     main_sources += [
         "torch/csrc/cudnn/BatchNorm.cpp",
         "torch/csrc/cudnn/Conv.cpp",

--- a/setup.py
+++ b/setup.py
@@ -502,6 +502,7 @@ if WITH_CUDNN:
     # NOTE: this this at the front, in case there's another cuDNN in CUDA path
     include_dirs.insert(0, CUDNN_INCLUDE_DIR)
     library_dirs.append(CUDNN_LIB_DIR)
+    extra_link_args.append('-Wl,-rpath,' + CUDNN_LIB_DIR)
     main_sources += [
         "torch/csrc/cudnn/BatchNorm.cpp",
         "torch/csrc/cudnn/Conv.cpp",


### PR DESCRIPTION
Fixes #3242 by adding CUDNN_LIB_DIR in the linker's rpath.