### PR TITLE
perf improvements for depthwise convolutions

### DIFF
--- a/torch/csrc/autograd/functions/convolution.cpp
+++ b/torch/csrc/autograd/functions/convolution.cpp
@@ -365,10 +365,8 @@ auto ConvForward::apply(const variable_list& inputs) -> variable_list {
 // For Convolution strategies that don't implicitly handle grad_bias, we add a helper
 // function here to perform it using simple Tensor operators
 static at::Tensor compute_grad_bias(const at::Tensor& grad_output) {
-  // grad_output is in N, C, H, W, we re-shape and make contiguous
-  at::Tensor transposed = grad_output.transpose(0, 1).contiguous();
-  // sum across all of the channels and add to grad_bias
-  return transposed.view({transposed.size(0), -1}).sum(1);
+  // grad_output is in N, C, H, W, we re-shape and reduce over spatial dims and batches 
+  return grad_output.contiguous().view({grad_output.size(0), grad_output.size(1), -1}).sum(0).sum(1);
 }
 
 // ConvBackward implementation

--- a/torch/lib/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/torch/lib/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -231,9 +231,6 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   // We parallelize so that each block computes a single value in gradWeight
   int blocks = outputChannels * kH * kW;
 
-  // Because each weight position is a function of convolving the gradOutput over
-  // the input, we need batchSize * outputHeight * outputWidth individual calculations
-  int n = batchSize * outputHeight * outputWidth;
 
   // Make sure we have enough threads to perform the reduction, and use this number
   // to create the shared memory size for the reduction
@@ -242,7 +239,7 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   int smem = block.x * sizeof(accreal);
 
   spatialDepthwiseConvolutionAccGradParameters<real, accreal, unsigned int><<<grid, block, smem, THCState_getCurrentStream(state)>>>(
-      dGradOutput, dInput, dGradWeight, batchSize, inputChannels, outputChannels, depthwiseMultiplier, n,
+      dGradOutput, dInput, dGradWeight, batchSize, inputChannels, outputChannels, depthwiseMultiplier, 
       width, height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
 
   THCudaCheck(cudaGetLastError());

--- a/torch/lib/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/torch/lib/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -67,11 +67,22 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   int blocks = GET_BLOCKS(n);
   dim3 grid(blocks);
   dim3 block(CUDA_NUM_THREADS);
-
-  spatialDepthwiseConvolutionUpdateOutput<real, accreal, unsigned int><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+  if (kW == 3 && kH == 3) {
+  spatialDepthwiseConvolutionUpdateOutput<real, accreal, unsigned int, 3><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
     dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
     width, height, outputWidth, outputHeight,
     kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  } else if (kW == 1 && kH == 1) {
+  spatialDepthwiseConvolutionUpdateOutput<real, accreal, unsigned int, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+    width, height, outputWidth, outputHeight,
+    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  } else {
+  spatialDepthwiseConvolutionUpdateOutput<real, accreal, unsigned int, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+    width, height, outputWidth, outputHeight,
+    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  }
 
   THCudaCheck(cudaGetLastError());
 }
@@ -127,10 +138,49 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
   int blocks = GET_BLOCKS(n);
   dim3 grid(blocks);
   dim3 block(CUDA_NUM_THREADS);
-
-  spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-    dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-    height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+  if (kW == 3 && kH == 3) 
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 3, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 3, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 3, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+  else if (kW == 1 && kH == 1) 
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 1, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 1, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 1, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+  else  
+    if (dW == 1 && dH == 1){
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 0, 1><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else if (dW == 2 && dH == 2) {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 0, 2><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    } else {
+      spatialDepthwiseConvolutionUpdateGradInput<real, accreal, unsigned int, 0, 0><<<grid, block, 0, THCState_getCurrentStream(state)>>>(
+      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    }
+  
 
   THCudaCheck(cudaGetLastError());
 }
@@ -188,7 +238,7 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   // Make sure we have enough threads to perform the reduction, and use this number
   // to create the shared memory size for the reduction
   dim3 grid(blocks);
-  dim3 block(std::min(nextHighestPowerOf2(n), (unsigned int64_t) CUDA_NUM_THREADS));
+  dim3 block(getGradParamsNumThreads(batchSize));
   int smem = block.x * sizeof(accreal);
 
   spatialDepthwiseConvolutionAccGradParameters<real, accreal, unsigned int><<<grid, block, smem, THCState_getCurrentStream(state)>>>(


### PR DESCRIPTION
batch size | Input channels | Height, Width | kH, kW | stride | current time | #3057 time | Speed-up
-- | -- | -- | -- | -- | -- | -- | --
1 | 32 | 112 | 3 | 1 | 0.0003635788 | 0.000360384 | 0.9912128843
1 | 64 | 112 | 3 | 2 | 0.000231576 | 0.0003566647 | 1.5401626686
1 | 128 | 56 | 3 | 1 | 0.0002005291 | 0.000383029 | 1.9100917868
1 | 128 | 56 | 3 | 2 | 0.000126195 | 0.0002591753 | 2.053769129
1 | 256 | 28 | 3 | 1 | 0.0001298428 | 0.0003213358 | 2.4748071979
1 | 256 | 28 | 3 | 2 | 0.0001278973 | 0.000162158 | 1.2678771158
1 | 512 | 14 | 3 | 1 | 0.0001259661 | 0.0001772976 | 1.4075027444
1 | 512 | 14 | 3 | 2 | 0.0001271725 | 0.0001322794 | 1.0401574803
1 | 1024 | 7 | 3 | 1 | 0.0001308775 | 0.0001342106 | 1.0254672642
64 | 32 | 112 | 3 | 1 | 0.0076541996 | 0.0177096987 | 2.3137231327
64 | 64 | 112 | 3 | 2 | 0.0076271296 | 0.0168428278 | 2.2082787077
64 | 128 | 56 | 3 | 1 | 0.0070373774 | 0.0168711519 | 2.3973635443
64 | 128 | 56 | 3 | 2 | 0.003865943 | 0.0091258287 | 2.3605699435
64 | 256 | 28 | 3 | 1 | 0.0035696888 | 0.0085421801 | 2.392976124
64 | 256 | 28 | 3 | 2 | 0.0021048355 | 0.005251503 | 2.4949707306
64 | 512 | 14 | 3 | 1 | 0.0019623423 | 0.0044877005 | 2.2869101627
64 | 512 | 14 | 3 | 2 | 0.0011884212 | 0.0028495121 | 2.3977290053
64 | 1024 | 7 | 3 | 1 | 0.0012278891 | 0.002658639 | 2.1652110428
128 | 32 | 112 | 3 | 1 | 0.0144340229 | 0.0354276562 | 2.4544547567
128 | 64 | 112 | 3 | 2 | 0.0154968691 | 0.0339261246 | 2.1892244415
128 | 128 | 56 | 3 | 1 | 0.014062891 | 0.0335231686 | 2.3838034831
128 | 128 | 56 | 3 | 2 | 0.0080575609 | 0.018141408 | 2.2514763643
128 | 256 | 28 | 3 | 1 | 0.0070493364 | 0.0169120741 | 2.3991015678
128 | 256 | 28 | 3 | 2 | 0.0041349077 | 0.0103336859 | 2.4991333709
128 | 512 | 14 | 3 | 1 | 0.003833847 | 0.0086662102 | 2.2604475533
128 | 512 | 14 | 3 | 2 | 0.0022731161 | 0.0053928566 | 2.3724510024
128 | 1024 | 7 | 3 | 1 | 0.0023054218 | 0.0047499275 | 2.0603290298

The biggest performance improvements are due to templating kernels. The benchmarks comparing to #3057 performance are above, I've taken sizes from https://github.com/marvis/pytorch-mobilenet/blob/master/benchmark.py#L19-L46 and some are slightly different from what was listed in #3057. Benchmarks are for 50 iterations, time is given per iteration. 
