### PR TITLE
Add zero, zeros_like, _dimI and _dimV for sparse tensors

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -545,6 +545,44 @@ class TestSparse(TestCase):
         self._test_sparse_mask_shape([50, 30, 20])
         self._test_sparse_mask_shape([5, 5, 5, 5, 5, 5])
 
+    def _test_zeros(self, shape, out_shape_i, out_shape_v=None):
+        out_shape = out_shape_i + (out_shape_v or [])
+        for nnz in [9, 12]:
+            out, _, _ = self._gen_sparse(len(out_shape_i), nnz, out_shape)
+            torch.zeros(*shape, out=out)
+            self.assertEqual(tuple(out.size()), tuple(shape))
+            self.assertTrue(out._indices().numel() == out._values().numel() == 0)
+            self.assertEqual(out._nnz(), 0)
+            self.assertEqual(out._dimI(), len(shape))
+            self.assertEqual(out._dimV(), 0)
+
+    def test_zeros(self):
+        i_shapes = [2, 3, 4]
+        v_shapes = [3, 4, 5, 6]
+        for i_dim in range(1, len(i_shapes) + 1):
+            for v_dim in range(len(v_shapes) + 1):
+                self._test_zeros([2, 3, 4], i_shapes[:i_dim], v_shapes[:v_dim])
+
+    def _test_zeros_like(self, template_shape_i, template_shape_v=None):
+        # import pdb; pdb.set_trace()
+        template_shape_v = template_shape_v or []
+        template_shape = template_shape_i + template_shape_v
+        for nnz in [9, 12]:
+            t, _, _ = self._gen_sparse(len(template_shape_i), nnz, template_shape)
+            res = torch.zeros_like(t)
+            self.assertEqual(tuple(res.size()), tuple(template_shape))
+            self.assertTrue(res._indices().numel() == res._values().numel() == 0)
+            self.assertEqual(res._nnz(), 0)
+            self.assertEqual(res._dimI(), len(template_shape_i))
+            self.assertEqual(res._dimV(), len(template_shape_v))
+
+    def test_zeros_like(self):
+        i_shapes = [2, 3, 4]
+        v_shapes = [3, 4, 5, 6]
+        for i_dim in range(1, len(i_shapes) + 1):
+            for v_dim in range(len(v_shapes) + 1):
+                self._test_zeros_like(i_shapes[:i_dim], v_shapes[:v_dim])
+
     def _test_sparse_mask_hybrid_fixed(self):
         i = self.IndexTensor([
             [1, 3, 0, 4],

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -564,7 +564,6 @@ class TestSparse(TestCase):
                 self._test_zeros([2, 3, 4], i_shapes[:i_dim], v_shapes[:v_dim])
 
     def _test_zeros_like(self, template_shape_i, template_shape_v=None):
-        # import pdb; pdb.set_trace()
         template_shape_v = template_shape_v or []
         template_shape = template_shape_i + template_shape_v
         for nnz in [9, 12]:

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -63,6 +63,24 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: nDimensionI
+  python_name: _dimI
+  sparse: yes
+  return: long
+  arguments:
+  - THSTensor* self
+]]
+
+[[
+  name: nDimensionV
+  python_name: _dimV
+  sparse: yes
+  return: long
+  arguments:
+  - THSTensor* self
+]]
+
+[[
   name: isCoalesced
   sparse: yes
   python_name: is_coalesced

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -296,6 +296,33 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: zeros
+  sparse: yes
+  variants:
+    - function
+  auto_gpu: False
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - arg: THSize* size
+      long_args: True
+]]
+
+[[
+  name: zeros_like
+  sparse: yes
+  cname: zerosLike
+  variants:
+    - function
+  return: argument 0
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THSTensor* input
+]]
+
+[[
   name: add
   sparse: yes
   variants:

--- a/torch/lib/THCS/generic/THCSTensorMath.cu
+++ b/torch/lib/THCS/generic/THCSTensorMath.cu
@@ -32,6 +32,20 @@ void THCSTensor_(zero)(THCState *state, THCSTensor *self) {
   self->nnz = 0;
 }
 
+void THCSTensor_(zeros)(THCState *state, THCSTensor *r_, THLongStorage *size)
+{
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 1, 1, r_));
+  THCSTensor_(resize)(state, r_, size);
+  THCSTensor_(zero)(state, r_);
+}
+
+void THCSTensor_(zerosLike)(THCState *state, THCSTensor *r_, THCSTensor *input)
+{
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 2, 2, r_, input));
+  THCSTensor_(resizeAs)(state, r_, input);
+  THCSTensor_(zero)(state, r_);
+}
+
 void THCTensor_(spaddcmul)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2) {
   THError("WARNING: Sparse Cuda Tensor op spaddcmul is not implemented");
 }

--- a/torch/lib/THCS/generic/THCSTensorMath.h
+++ b/torch/lib/THCS/generic/THCSTensorMath.h
@@ -11,6 +11,8 @@
  */
 
 TH_API void THCSTensor_(zero)(THCState *state, THCSTensor *r_);
+TH_API void THCSTensor_(zeros)(THCState *state, THCSTensor *r_, THLongStorage *size);
+TH_API void THCSTensor_(zerosLike)(THCState *state, THCSTensor *r_, THCSTensor *input);
 
 TH_API void THCTensor_(spaddcmul)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2);
 TH_API void THCTensor_(spaddcdiv)(THCState *state, THCTensor *r_, THCTensor *t, real value, THCSTensor *src1, THCSTensor *src2);

--- a/torch/lib/THS/generic/THSTensorMath.c
+++ b/torch/lib/THS/generic/THSTensorMath.c
@@ -15,6 +15,18 @@ void THSTensor_(zero)(THSTensor *self) {
   self->nnz = 0;
 }
 
+void THSTensor_(zeros)(THSTensor *r_, THLongStorage *size)
+{
+  THSTensor_(resize)(r_, size);
+  THSTensor_(zero)(r_);
+}
+
+void THSTensor_(zerosLike)(THSTensor *r_, THSTensor *input)
+{
+  THSTensor_(resizeAs)(r_, input);
+  THSTensor_(zero)(r_);
+}
+
 void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value) {
   if (r_ == t) {
     THTensor *r_values_ = THSTensor_(newValues)(r_);
@@ -68,7 +80,7 @@ void THSTensor_(pow)(THSTensor *r_, THSTensor *t_, real value) {
   THTensor_(free)(r_values_);
   THLongTensor_free(t_indices_);
   THTensor_(free)(t_values_);
-    
+
   THSTensor_(free)(t);
 }
 #endif

--- a/torch/lib/THS/generic/THSTensorMath.h
+++ b/torch/lib/THS/generic/THSTensorMath.h
@@ -11,6 +11,8 @@
  */
 
 TH_API void THSTensor_(zero)(THSTensor *r_);
+TH_API void THSTensor_(zeros)(THSTensor *r_, THLongStorage *size);
+TH_API void THSTensor_(zerosLike)(THSTensor *r_, THSTensor *input);
 
 TH_API void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value);
 TH_API void THSTensor_(div)(THSTensor *r_, THSTensor *t, real value);


### PR DESCRIPTION
This will enable better code for #3137 , #3211 , and future sparse optimizers.