### PR TITLE
tensor: Ensure that the tensor is contiguous before pinning (#3266)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -808,6 +808,11 @@ class TestCuda(TestCase):
             tmp3 = torch.cuda.FloatTensor(t.size())
             self.assertEqual(tmp3.data_ptr(), ptr[0], 'allocation not re-used')
 
+    def test_noncontiguous_pinned_memory(self):
+        # See issue #3266
+        x = torch.arange(0, 10).view((2, 5))
+        self.assertEqual(x.t(), x.t().pin_memory())
+
     def test_caching_pinned_memory(self):
         cycles_per_ms = get_cycles_per_ms()
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -76,7 +76,7 @@ class _TensorBase(object):
         if self.is_cuda:
             raise TypeError("cannot pin '{0}' only CPU memory can be pinned"
                             .format(self.type()))
-        storage = self.storage()
+        storage = self.contiguous().storage()
         if storage is None:
             storage = (self.storage_type())()
         return type(self)().set_(storage.pin_memory()).view_as(self)


### PR DESCRIPTION
pin_memory() was producing out-of-order tensor when the given
tensor was transposed, i.e. in column-major order.
This commit fixes this by calling contiguous() before pinning.