### PR TITLE
clarification in docstring of Module.register_forward_hook()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -244,7 +244,7 @@ class Module(object):
     def register_forward_hook(self, hook):
         """Registers a forward hook on the module.
 
-        The hook will be called every time :func:`forward` computes an output.
+        The hook will be called every time after :func:`forward` has computed an output.
         It should have the following signature::
 
             hook(module, input, output) -> None

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -228,7 +228,7 @@ class Module(object):
     def register_forward_pre_hook(self, hook):
         """Registers a forward pre-hook on the module.
 
-        The hook will be called before :func:`forward` is invoked.
+        The hook will be called every time before :func:`forward` is invoked.
         It should have the following signature::
 
             hook(module, input) -> None


### PR DESCRIPTION
Made it explicit that the hooks given to `Module.register_forward_hook()` are called *after* the calls to forward (the current formulation is not 100% clear even though one can guess this from the fact one of the parameters given to the hooks is the output).

No code changes.

By the way, the docstrings for `register_forward_hook()` and `register_backward_hook()` contain 'every time' while the one of `register_forward_pre_hook()` does not. Should this also be streamlined ?