### PR TITLE
[wip] Add index_add_ and scatter_add_ safety check

### DIFF
--- a/torch/lib/TH/generic/THTensorMath.c
+++ b/torch/lib/TH/generic/THTensorMath.c
@@ -359,6 +359,7 @@ void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTenso
   THArgCheck(index->nDimension == 1, 3, "Index is supposed to be a vector");
   THArgCheck(dim < src->nDimension, 4,"Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
   THArgCheck(numel == src->size[dim],4,"Number of indices should be equal to source:size(dim)");
+  THArgCheck(tensor->storage != src->storage, 4, "Output and input tensors should not share storage");
 
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
@@ -514,6 +515,7 @@ void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTen
              "Index tensor must have same dimensions as output tensor");
   THArgCheck(THTensor_(nDimension)(src) == THTensor_(nDimension)(tensor), 4,
              "Input tensor must have same dimensions as output tensor");
+  THArgCheck(tensor->storage != src->storage, 4, "Output and input tensors should not share storage");
 
   elems_per_row = THLongTensor_size(index, dim);
 

--- a/torch/lib/THC/generic/THCTensorIndex.cu
+++ b/torch/lib/THC/generic/THCTensorIndex.cu
@@ -164,6 +164,7 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
   THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
   THArgCheck(srcDims > 0, 2, "Source tensor is empty");
   THArgCheck(numIndices == src->size[dim], 4, "length of src.size[dim] is not equal to length of indices");
+  THArgCheck(dst->storage != src->storage, 5, "Output and input tensors should not share storage");
 
   int indContig = THCudaLongTensor_isContiguous(state, indices);
 

--- a/torch/lib/THC/generic/THCTensorScatterGather.cu
+++ b/torch/lib/THC/generic/THCTensorScatterGather.cu
@@ -203,6 +203,7 @@ void THCTensor_(scatterAdd)(THCState* state, THCTensor *tensor, int dim, THCudaL
   THArgCheck(THCTensor_(isSize)(state, src, indexDims), 3,
              "Index tensor must have the same size as input tensor.");
   THLongStorage_free(indexDims);
+  THArgCheck(tensor->storage != src->storage, 5, "Output and input tensors should not share storage");
 
   for (int d = 0; d < THCTensor_(nDimension)(state, tensor); d++) {
     if (d != dim) {


### PR DESCRIPTION
Fixes #3176.

index_add_ and scatter_add_ are not well defined when the input tensor uses the same storage as the output tensor (the result will depend on the order the additions are performed in). This adds a safety check to disallow that.

### Test Plan
Check that the safety checks work when they're supposed to and aren't triggered otherwise.
Run gist: https://gist.github.com/zou3519/4c57da40fc287fa8a8399308412a5d0d