### PR TITLE
Dynamically find min log scale

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -5,9 +5,6 @@ from ._utils import _range
 from sys import float_info
 
 
-__MIN_LOG_SCALE = math.ceil(math.log(float_info.min * float_info.epsilon, 10))
-
-
 class __PrinterOptions(object):
     precision = 4
     threshold = 1000
@@ -69,6 +66,13 @@ def set_printoptions(
         PRINT_OPTS.linewidth = linewidth
 
 
+def _min_log_scale():
+    min_positive = float_info.min * float_info.epsilon  # get smallest denormal
+    if min_positive == 0:  # use smallest normal if DAZ/FTZ is set
+        min_positive = float_info.min
+    return math.ceil(math.log(min_positive, 10))
+
+
 def _number_format(tensor, min_sz=-1):
     min_sz = max(min_sz, 2)
     tensor = torch.DoubleTensor(tensor.size()).copy_(tensor).abs_().view(tensor.nelement())
@@ -123,7 +127,7 @@ def _number_format(tensor, min_sz=-1):
         else:
             if exp_max > prec + 1 or exp_max < 0:
                 sz = max(min_sz, 7)
-                scale = math.pow(10, max(exp_max - 1, __MIN_LOG_SCALE))
+                scale = math.pow(10, max(exp_max - 1, _min_log_scale()))
             else:
                 if exp_max == 0:
                     sz = 7

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -66,7 +66,7 @@ def set_printoptions(
         PRINT_OPTS.linewidth = linewidth
 
 
-def _min_log_scale():
+def _get_min_log_scale():
     min_positive = float_info.min * float_info.epsilon  # get smallest denormal
     if min_positive == 0:  # use smallest normal if DAZ/FTZ is set
         min_positive = float_info.min
@@ -74,6 +74,7 @@ def _min_log_scale():
 
 
 def _number_format(tensor, min_sz=-1):
+    _min_log_scale = _get_min_log_scale()
     min_sz = max(min_sz, 2)
     tensor = torch.DoubleTensor(tensor.size()).copy_(tensor).abs_().view(tensor.nelement())
 
@@ -127,7 +128,7 @@ def _number_format(tensor, min_sz=-1):
         else:
             if exp_max > prec + 1 or exp_max < 0:
                 sz = max(min_sz, 7)
-                scale = math.pow(10, max(exp_max - 1, _min_log_scale()))
+                scale = math.pow(10, max(exp_max - 1, _min_log_scale))
             else:
                 if exp_max == 0:
                     sz = 7


### PR DESCRIPTION
Fixes #3195 . Blame #3113 .

Hardcoding -323 won't work since FTZ/DAZ will make `pow(10, -323)` zero, causing division by zero error again.

cc @colesbury 