### PR TITLE
Symbolic representation for mm

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -107,12 +107,14 @@ def div(g, self, other):
     # See Note [Pointwise by scalar]
     return g.op("Div", self, _if_scalar_type_as(other, self), **_broadcast_if_scalar(other))
 
+
 def mm(g, self, other):
     # Create a dummy C tensor. Only needed for API purposes, the value is
     # since beta = 0
     ty = self.type().scalarType().lower()
     C = g.constant(0, [1], ty)
     return g.op("Gemm", self, other, C, beta_f=0.0, alpha_f=1.0, broadcast_i=True)
+
 
 def addmm(g, self, mat1, mat2, beta, alpha):
     return g.op("Gemm", mat1, mat2, self, beta_f=_scalar(beta), alpha_f=_scalar(alpha))

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -107,6 +107,12 @@ def div(g, self, other):
     # See Note [Pointwise by scalar]
     return g.op("Div", self, _if_scalar_type_as(other, self), **_broadcast_if_scalar(other))
 
+def mm(g, self, other):
+    # Create a dummy C tensor. Only needed for API purposes, the value is
+    # since beta = 0
+    ty = self.type().scalarType().lower()
+    C = g.constant(0, [1], ty)
+    return g.op("Gemm", self, other, C, beta_f=0.0, alpha_f=1.0, broadcast_i=True)
 
 def addmm(g, self, mat1, mat2, beta, alpha):
     return g.op("Gemm", mat1, mat2, self, beta_f=_scalar(beta), alpha_f=_scalar(alpha))


### PR DESCRIPTION
Symbolic representation for torch.mm. This uses the underlying Gemm operator, with alpha=1, beta=0, and C=a dummy tensor.

Correctness tests can be found at https://github.com/ezyang/onnx-pytorch/pull/23