### PR TITLE
check_env_flag now ignores case

### DIFF
--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -2,4 +2,4 @@ import os
 
 
 def check_env_flag(name):
-    return os.getenv(name) in ['ON', '1', 'YES', 'TRUE', 'Y']
+    return os.getenv(name, '').upper() in ['ON', '1', 'YES', 'TRUE', 'Y']


### PR DESCRIPTION
Very minor change that ignores the case of environment variable flags. 

I had set `NO_CUDNN=True` and wondered why pytorch still tried to find cudnn. Turns out I needed to set `NO_CUDNN=TRUE`. These 12 characters do their part to prevent a few seconds of confusion for a handful of people.