### PR TITLE
Add reduce keyword to CrossEntropyLoss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -972,7 +972,7 @@ Args:
 """)
 
 
-def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-100):
+def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-100, reduce=True):
     r"""This criterion combines `log_softmax` and `nll_loss` in a single
     function.
 
@@ -987,10 +987,14 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
-                for each minibatch. Default: True
+                for each minibatch. Ignored if reduce is False. Default: True
         ignore_index (int, optional): Specifies a target value that is ignored
                 and does not contribute to the input gradient. When size_average is
                 True, the loss is averaged over non-ignored targets. Default: -100
+        reduce (bool, optional): By default, the losses are averaged or summed over
+                observations for each minibatch depending on size_average. When reduce
+                is False, returns a loss per batch element instead and ignores
+                size_average. Default: True
 
     Examples::
 
@@ -999,7 +1003,7 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
         >>> loss = F.cross_entropy(input, target)
         >>> loss.backward()
     """
-    return nll_loss(log_softmax(input, 1), target, weight, size_average, ignore_index)
+    return nll_loss(log_softmax(input, 1), target, weight, size_average, ignore_index, reduce)
 
 
 def binary_cross_entropy(input, target, weight=None, size_average=True):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -506,14 +506,19 @@ class CrossEntropyLoss(_WeightedLoss):
            If given, has to be a Tensor of size "nclasses"
         size_average (bool, optional): By default, the losses are averaged over observations for each minibatch.
            However, if the field size_average is set to False, the losses are
-           instead summed for each minibatch.
+           instead summed for each minibatch. Ignored if reduce is False.
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average is
             True, the loss is averaged over non-ignored targets.
+        reduce (bool, optional): By default, the losses are averaged or summed over
+            observations for each minibatch depending on size_average. When reduce
+            is False, returns a loss per batch element instead and ignores
+            size_average. Default: True
 
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
         - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
+        - Output: scalar. If reduce is False, then :math:`(N)` instead.
 
     Examples::
 
@@ -524,14 +529,15 @@ class CrossEntropyLoss(_WeightedLoss):
         >>> output.backward()
     """
 
-    def __init__(self, weight=None, size_average=True, ignore_index=-100):
+    def __init__(self, weight=None, size_average=True, ignore_index=-100, reduce=True):
         super(CrossEntropyLoss, self).__init__(weight, size_average)
         self.ignore_index = ignore_index
+        self.reduce = reduce
 
     def forward(self, input, target):
         _assert_no_grad(target)
         return F.cross_entropy(input, target, self.weight, self.size_average,
-                               self.ignore_index)
+                               self.ignore_index, self.reduce)
 
 
 class MultiLabelSoftMarginLoss(_WeightedLoss):


### PR DESCRIPTION
### Summary
As per #264. `reduce=True` is the normal behavior, while `reduce=False` returns a loss per batch element.

### Test Plan
```
import torch
import torch.nn as nn
from torch.autograd import Variable
x = Variable(torch.randn(5, 6), requires_grad=True)
t = Variable(torch.zeros(5).random_(0, 6).long())
loss_reduce = nn.CrossEntropyLoss(size_average=False, reduce=True)
loss_no_reduce = nn.CrossEntropyLoss(reduce=False)
out_reduce = loss_reduce(x,t)
out_no_reduce = loss_no_reduce(x,t)
# assert that out_reduce, out_no_reduce.sum() are equal
# and that out_no_reduce is not scalar
```