### PR TITLE
Big batch of JIT and ONNX fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -409,6 +409,7 @@ main_sources = [
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
     "torch/csrc/jit/passes/common_subexpression_elimination.cpp",
+    "torch/csrc/jit/passes/peephole.cpp",
     "torch/csrc/jit/generated/aten_dispatch.cpp",
     "torch/csrc/autograd/init.cpp",
     "torch/csrc/autograd/engine.cpp",

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -370,24 +370,6 @@ class IndexSelect(Function):
         return grad_tensor, None, None
 
 
-class Concat(Function):
-
-    @staticmethod
-    def symbolic(g, dim, *inputs):
-        return g.op("Concat", *inputs, axis_i=dim)
-
-    @staticmethod
-    def forward(ctx, dim, *inputs):
-        ctx.dim = dim
-        ctx.input_sizes = [i.size(dim) for i in inputs]
-        return torch.cat(inputs, dim)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        return (None,) + tuple(grad_output.narrow(ctx.dim, end - size, size) for size, end
-                               in zip(ctx.input_sizes, _accumulate(ctx.input_sizes)))
-
-
 # TODO: deprecate this
 class Resize(Function):
 

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/jit/passes/onnx.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
+#include "torch/csrc/jit/passes/peephole.h"
 
 
 
@@ -41,6 +42,7 @@ void initJITBindings(PyObject *module) {
    .def("_jit_pass_fuse", graph_pass<FuseGraph>)
    .def("_jit_pass_dce", graph_pass<EliminateDeadCode>)
    .def("_jit_pass_cse", graph_pass<EliminateCommonSubexpression>)
+   .def("_jit_pass_peephole", graph_pass<PeepholeOptimize>)
    .def("_jit_pass_lint", graph_pass<LintGraph>)
    .def("_jit_run_cpp_tests", runJITCPPTests);
 

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -16,8 +16,11 @@ _(Select) \
 _(Return) \
 _(Eval) \
 _(Add) \
+_(Div) \
 _(Mul) \
 _(Neg) \
+_(Sub) \
+_(Pow) \
 _(Sigmoid) \
 _(Tanh) \
 _(Constant) \
@@ -43,6 +46,7 @@ _(Caffe2ConvTranspose) \
 _(ConvTranspose) \
 _(is_test) \
 _(epsilon) \
+_(expand) \
 _(order) \
 _(momentum) \
 _(consumed_inputs) \
@@ -60,6 +64,7 @@ _(dilations) \
 _(dilation) \
 _(broadcast) \
 _(axis) \
+_(size) \
 _(perm) \
 _(shape) \
 _(axes) \

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -47,6 +47,7 @@ _(ConvTranspose) \
 _(is_test) \
 _(epsilon) \
 _(expand) \
+_(Expand) \
 _(order) \
 _(momentum) \
 _(consumed_inputs) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -633,6 +633,12 @@ public:
       delete n;
   }
 
+  std::string toString() {
+    std::ostringstream oss;
+    oss << *this;
+    return oss.str();
+  }
+
   friend std::ostream& operator<<(std::ostream & out, Graph & g);
 
 private:

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -220,6 +220,14 @@ public:
   // Result:  %3 = f(%1, %2, %4)
   Node* addInput(Node * node) {
     JIT_ASSERT(graph_ == node->graph_);
+    // Select invariant
+    if (kind_ == kSelect) {
+      // You have no excuse for not having accurate type information on
+      // multi-return
+      JIT_ASSERT(node->hasType() && node->type()->kind() == TypeKind::MultiType);
+    } else {
+      JIT_ASSERT(!node->hasType() || node->type()->kind() != TypeKind::MultiType);
+    }
     node->uses_.emplace_back(this, inputs_.size());
     inputs_.push_back(node);
     return node;

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -1,0 +1,30 @@
+#include "torch/csrc/jit/passes/dead_code_elimination.h"
+
+namespace torch { namespace jit {
+
+// The intent for this optimization pass is to catch all of the small, easy to
+// catch peephole optimizations you might be interested in doing.
+//
+// Right now, it does:
+//    - Redundant 'expand' elimination
+//
+// TODO: Decide what kind of fixed point strategy we will have
+void PeepholeOptimize(std::shared_ptr<Graph>& graph) {
+  for (auto it = graph->nodes().begin(); it != graph->nodes().end(); ++it) {
+    auto* n = *it;
+
+    if (n->kind() == kexpand) {
+      if (n->is(ksize) == n->input()->type()->expect<TensorType>()->sizes()) {
+        // Attractive but wrong way to do this:
+        // n->replaceAllUsesWith(n->input());
+        auto* out = n->outputs().at(0);
+        out->replaceAllUsesWith(n->input());
+        out->destroy();
+        it.destroyCurrent();
+        continue;
+      }
+    }
+  }
+}
+
+}}

--- a/torch/csrc/jit/passes/peephole.h
+++ b/torch/csrc/jit/passes/peephole.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+void PeepholeOptimize(std::shared_ptr<Graph>& graph);
+
+}}

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -471,6 +471,7 @@ class TraceForKey(object):
             _run_pass(torch._C._jit_pass_dce, complete_trace)
             _run_pass(_passes._check_inplace, complete_trace)
             if self.optimize:
+                _run_pass(torch._C._jit_pass_peephole, complete_trace)
                 _run_pass(torch._C._jit_pass_fuse, complete_trace)
 
             _dump_trace(self.name, "final", self.key, complete_trace)

--- a/torch/nn/_functions/dropout.py
+++ b/torch/nn/_functions/dropout.py
@@ -12,14 +12,9 @@ class Dropout(InplaceFunction):
 
     @staticmethod
     def symbolic(g, input, p=0.5, train=False, inplace=False):
-        if inplace:
-            return None
-        n = g.appendNode(g.create("Dropout", [input])
-                          .f_("ratio", p)
-                          .i_("is_test", not train))
-        real = g.appendNode(g.createSelect(n, 0))
-        g.appendNode(g.createSelect(n, 1))
-        return real
+        # See Note [Export inplace]
+        r, _ = g.op("Dropout", input, ratio_f=p, is_test_i=not train, outputs=2)
+        return r
 
     @classmethod
     def forward(cls, ctx, input, p=0.5, train=False, inplace=False):
@@ -59,11 +54,11 @@ class FeatureDropout(Dropout):
 
     @staticmethod
     def symbolic(g, input, p=0.5, train=False, inplace=False):
+        # See Note [Export inplace]
         # NB: In inference mode, FeatureDropout is exported as an identity op.
+        from torch.onnx.symbolic import _unimplemented
         if train:
-            raise ValueError("Exporting ONNX FeatureDropout in train mode is not supported, "
-                             "and the exported model should not be used for training. "
-                             "The FeatureDropout support in ONNX is still under construction.")
+            return _unimplemented("FeatureDropout", "training mode")
         return input
 
     @staticmethod

--- a/torch/nn/_functions/padding.py
+++ b/torch/nn/_functions/padding.py
@@ -7,8 +7,7 @@ class ConstantPadNd(Function):
     @staticmethod
     def symbolic(g, input, pad, value=0):
         paddings = prepare_onnx_paddings(len(input.type().sizes()), pad)
-        return g.appendNode(g.create("Pad", [input]).is_("paddings", paddings)
-                             .s_("mode", "constant").f_("value", value))
+        return g.op("Pad", input, paddings_i=paddings, mode_s="constant", value_f=value)
 
     @staticmethod
     def forward(ctx, input, pad, value=0):

--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -15,16 +15,17 @@ class MaxPool1d(Function):
     @staticmethod
     def symbolic(g, input, kernel_size, stride=None, padding=0, dilation=1,
                  ceil_mode=False):
+        from torch.onnx.symbolic import _unimplemented
         if ceil_mode:
-            raise RuntimeError("ceil_mode not supported in MaxPool1d")
+            return _unimplemented("MaxPool1d", "ceil_mode")
         if stride is None:
             stride = kernel_size
-        n = g.appendNode(g.create("MaxPool", [input])
-                          .is_("kernel_shape", _single(kernel_size))
-                          .is_("pads", _single(padding))
-                          .is_("dilations", _single(dilation))
-                          .is_("strides", _single(stride)))
-        return (n, None)
+        r = g.op("MaxPool", input,
+                 kernel_shape_i=_single(kernel_size),
+                 pads_i=_single(padding),
+                 dilations_i=_single(dilation),
+                 strides_i=_single(stride))
+        return r, None
 
     @staticmethod
     def forward(ctx, input, kernel_size, stride=None, padding=0, dilation=1,
@@ -101,16 +102,17 @@ class MaxPool3d(Function):
     @staticmethod
     def symbolic(g, input, kernel_size, stride=None, padding=0, dilation=1,
                  ceil_mode=False):
+        from torch.onnx.symbolic import _unimplemented
         if ceil_mode:
-            raise RuntimeError("ceil_mode not supported in MaxPool3d")
+            return _unimplemented("MaxPool3d", "ceil_mode")
         if stride is None:
             stride = kernel_size
-        n = g.appendNode(g.create("MaxPool", [input])
-                          .is_("kernel_shape", _triple(kernel_size))
-                          .is_("pads", _triple(padding))
-                          .is_("dilations", _triple(dilation))
-                          .is_("strides", _triple(stride)))
-        return (n, None)
+        r = g.op("MaxPool", input,
+                 kernel_shape_i=_triple(kernel_size),
+                 pads_i=_triple(padding),
+                 dilations_i=_triple(dilation),
+                 strides_i=_triple(stride))
+        return r, None
 
     @staticmethod
     def forward(ctx, input, kernel_size, stride=None, padding=0, dilation=1,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -100,6 +100,8 @@ def _export(model, args, f, export_params=True, verbose=False, training=False):
     torch._C._jit_pass_lint(trace)
     torch._C._jit_pass_onnx(trace)
     torch._C._jit_pass_lint(trace)
+    torch._C._jit_pass_dce(trace)
+    torch._C._jit_pass_lint(trace)
 
     if verbose:
         print(trace)
@@ -220,15 +222,12 @@ def _run_symbolic_function(g, n, inputs):
         else:
             op_name = n.kind()
         if not hasattr(torch.onnx.symbolic, op_name):
-            warnings.warn("ONNX conversion of {} not supported".format(op_name))
+            warnings.warn("ONNX export failed on {} because torch.onnx.symbolic.{} does not exist"
+                          .format(op_name, op_name))
             return None
         fn = getattr(torch.onnx.symbolic, op_name)
         attrs = {k: n[k] for k in n.attributeNames()}
-        r = fn(g, *inputs, **attrs)
-        if r is None:
-            raise NotImplementedError("torch.onnx.symbolic.{} returned None, "
-                                      "indicating ONNX translation not supported".format(op_name))
-        return r
+        return fn(g, *inputs, **attrs)
 
     except TypeError as e:
         # Handle the specific case where we didn't successfully dispatch.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -96,7 +96,10 @@ def _export(model, args, f, export_params=True, verbose=False, training=False):
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
+    torch._C._jit_pass_peephole(trace)
+    torch._C._jit_pass_lint(trace)
     torch._C._jit_pass_onnx(trace)
+    torch._C._jit_pass_lint(trace)
 
     if verbose:
         print(trace)


### PR DESCRIPTION
The pieces:

- I improved the lint / asserts to catch some bugs which I
  committed while working on my export.  There are two new
  properties which the linter checks now:

    (1) "Anticipated uses".  If a node says that is used by
    M, M better appear later in the topsort.  Previously,
    we only checked if it was in all_nodes.

    (2) If you are a select node, you better be a multi-type node;
    if you're not a select node, you better not be!  And you
    should never have an input that is multi-type.

- There is a new peephole optimization pass, for simple, local
  transformations to graphs.  Right now, it implements a simple
  optimization: remove 'expand' invocations that are no-ops
  (the size before matches the size after), but we can add other
  things to it later.  I needed this for ONNX because no-op expands
  show up in the left-hand argument, which we don't support.

- There is now a broadcast fuser, which fuses ATen expand ops
  into broadcastable ONNX ops (Add, Div, Mul, Pow, Sub, Gemm.)
  It only fuses when the original size is a suffix of the new
  size, as per the ONNX spec.

Then, in the next commit:

- Deleted Addmm/Concat Function class, as this is now native ATen operator

- Resurrected ONNX operator for Concat (now called 'cat')

- Add a "fake" Expand ONNX operator, which we now do the optimization on;
  this helps prevent us from emitting a warning that 'expand' is not supported.
  We still fail if any of these Expand operators make it to the final model,
  until we actually formalize Expand in ONNX.  This also simplifies the
  fuseBroadcast code, because single-return ONNX nodes don't get select nodes.

- New error reporting strategy.  If we fail to export an operator because of
  something, we emit a warning, but otherwise keep going.  At the very end,
  in export.cpp, we now check if there are any ATen operators left over.  If
  there are, we bug out.  This assumes that ATen is lower case and ONNX is upper
  case.  You're now supposed to 'return _unimplemented(msg)' in these cases.

- New toString() method on Graph, for getting the string graph (useful for
  slapping it into error messages.)

- Some of the legacy symbolics (still in Python symbolic method of Function
  subclass) have been cleaned up for clarity.)

CC @dzhulgakov @jamesr66a 