### PR TITLE
Use raw string for documentation in nn

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -21,7 +21,7 @@ _ConvNd = torch._C._functions.ConvNd
 
 def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
            groups=1):
-    """Applies a 1D convolution over an input signal composed of several input
+    r"""Applies a 1D convolution over an input signal composed of several input
     planes.
 
     See :class:`~torch.nn.Conv1d` for details and output shape.
@@ -56,7 +56,7 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
            groups=1):
-    """Applies a 2D convolution over an input image composed of several input
+    r"""Applies a 2D convolution over an input image composed of several input
     planes.
 
     See :class:`~torch.nn.Conv2d` for details and output shape.
@@ -92,7 +92,7 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
            groups=1):
-    """Applies a 3D convolution over an input image composed of several input
+    r"""Applies a 3D convolution over an input image composed of several input
     planes.
 
     See :class:`~torch.nn.Conv3d` for details and output shape.
@@ -128,7 +128,7 @@ def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
                      output_padding=0, groups=1, dilation=1):
-    """Applies a 1D transposed convolution operator over an input signal
+    r"""Applies a 1D transposed convolution operator over an input signal
     composed of several input planes, sometimes also called "deconvolution".
 
     See :class:`~torch.nn.ConvTranspose1d` for details and output shape.
@@ -161,7 +161,7 @@ def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
 
 def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
                      output_padding=0, groups=1, dilation=1):
-    """Applies a 2D transposed convolution operator over an input image
+    r"""Applies a 2D transposed convolution operator over an input image
     composed of several input planes, sometimes also called "deconvolution".
 
     See :class:`~torch.nn.ConvTranspose2d` for details and output shape.
@@ -194,7 +194,7 @@ def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
 
 def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
                      output_padding=0, groups=1, dilation=1):
-    """Applies a 3D transposed convolution operator over an input image
+    r"""Applies a 3D transposed convolution operator over an input image
     composed of several input planes, sometimes also called "deconvolution"
 
     See :class:`~torch.nn.ConvTranspose3d` for details and output shape.
@@ -621,7 +621,7 @@ def _get_softmax_dim(name, ndim, stacklevel):
 
 
 def softmin(input, dim=None, _stacklevel=3):
-    """Applies a softmin function.
+    r"""Applies a softmin function.
 
     Note that softmin(x) = softmax(-x). See softmax definition for mathematical formula.
 
@@ -636,7 +636,7 @@ def softmin(input, dim=None, _stacklevel=3):
 
 
 def softmax(input, dim=None, _stacklevel=3):
-    """Applies a softmax function.
+    r"""Applies a softmax function.
 
     Softmax is defined as:
 
@@ -661,7 +661,7 @@ def softmax(input, dim=None, _stacklevel=3):
 
 
 def log_softmax(input, dim=None, _stacklevel=3):
-    """Applies a softmax followed by a logarithm.
+    r"""Applies a softmax followed by a logarithm.
 
     While mathematically equivalent to log(softmax(x)), doing these two
     operations separately is slower, and numerically unstable. This function
@@ -1160,7 +1160,7 @@ def pixel_shuffle(input, upscale_factor):
 
 
 def upsample(input, size=None, scale_factor=None, mode='nearest'):
-    """Upsamples the input to either the given :attr:`size` or the given
+    r"""Upsamples the input to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
     The algorithm used for upsampling is determined by :attr:`mode`.
@@ -1213,7 +1213,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
 
 
 def upsample_nearest(input, size=None, scale_factor=None):
-    """Upsamples the input, using nearest neighbours' pixel values.
+    r"""Upsamples the input, using nearest neighbours' pixel values.
 
     **Note:: This function is deprecated. Use nn.functional.upsample instead**
 
@@ -1232,7 +1232,7 @@ def upsample_nearest(input, size=None, scale_factor=None):
 
 
 def upsample_bilinear(input, size=None, scale_factor=None):
-    """Upscales the input, using bilinear upsampling.
+    r"""Upscales the input, using bilinear upsampling.
 
     **Note:: This function is deprecated. Use nn.functional.upsample instead**
 
@@ -1250,7 +1250,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
 
 
 def grid_sample(input, grid, mode='bilinear'):
-    """Given an :attr:`input` and a flow-field :attr:`grid`, computes the
+    r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
     `output` using input pixel locations from the grid.
 
     Uses bilinear interpolation to sample the input pixels.
@@ -1283,7 +1283,7 @@ def grid_sample(input, grid, mode='bilinear'):
 
 
 def affine_grid(theta, size):
-    """Generates a 2d flow field, given a batch of affine matrices :attr:`theta`
+    r"""Generates a 2d flow field, given a batch of affine matrices :attr:`theta`
     Generally used in conjunction with :func:`grid_sample` to
     implement Spatial Transformer Networks.
 
@@ -1299,7 +1299,7 @@ def affine_grid(theta, size):
 
 
 def pad(input, pad, mode='constant', value=0):
-    """Pads tensor.
+    r"""Pads tensor.
 
     Nd constant padding:  The number of dimensions to pad is
         len(padding) // 2 and the dimensions that gets padded begins with the

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -7,7 +7,7 @@ from .. import functional as F
 
 
 class Threshold(Module):
-    """Thresholds each element of the input Tensor
+    r"""Thresholds each element of the input Tensor
 
     Threshold is defined as::
 
@@ -51,7 +51,7 @@ class Threshold(Module):
 
 
 class ReLU(Threshold):
-    """Applies the rectified linear unit function element-wise
+    r"""Applies the rectified linear unit function element-wise
     :math:`{ReLU}(x)= max(0, x)`
 
     Args:
@@ -99,7 +99,7 @@ class RReLU(Module):
 
 
 class Hardtanh(Module):
-    """Applies the HardTanh function element-wise
+    r"""Applies the HardTanh function element-wise
 
     HardTanh is defined as::
 
@@ -156,7 +156,7 @@ class Hardtanh(Module):
 
 
 class ReLU6(Hardtanh):
-    """Applies the element-wise function :math:`{ReLU6}(x) = min(max(0,x), 6)`
+    r"""Applies the element-wise function :math:`{ReLU6}(x) = min(max(0,x), 6)`
 
     Args:
         inplace: can optionally do the operation in-place. Default: False
@@ -184,7 +184,7 @@ class ReLU6(Hardtanh):
 
 
 class Sigmoid(Module):
-    """Applies the element-wise function :math:`f(x) = 1 / ( 1 + exp(-x))`
+    r"""Applies the element-wise function :math:`f(x) = 1 / ( 1 + exp(-x))`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -207,7 +207,7 @@ class Sigmoid(Module):
 
 
 class Tanh(Module):
-    """Applies element-wise,
+    r"""Applies element-wise,
     :math:`f(x) = (exp(x) - exp(-x)) / (exp(x) + exp(-x))`
 
     Shape:
@@ -231,7 +231,7 @@ class Tanh(Module):
 
 
 class ELU(Module):
-    """Applies element-wise,
+    r"""Applies element-wise,
     :math:`f(x) = max(0,x) + min(0, alpha * (exp(x) - 1))`
 
     Args:
@@ -267,7 +267,7 @@ class ELU(Module):
 
 
 class SELU(Module):
-    """Applies element-wise,
+    r"""Applies element-wise,
     :math:`f(x) = scale * (\max(0,x) + \min(0, alpha * (\exp(x) - 1)))`,
     with ``alpha=1.6732632423543772848170429916717`` and
     ``scale=1.0507009873554804934193349852946``.
@@ -305,7 +305,7 @@ class SELU(Module):
 
 
 class GLU(Module):
-    """Applies the gated linear unit function
+    r"""Applies the gated linear unit function
     :math:`{GLU}(a, b)= a \otimes \sigma(b)` where `a` is the first half of
     the input vector and `b` is the second half.
 
@@ -337,7 +337,7 @@ class GLU(Module):
 
 
 class Hardshrink(Module):
-    """Applies the hard shrinkage function element-wise
+    r"""Applies the hard shrinkage function element-wise
     Hardshrink is defined as::
         f(x) = x, if x >  lambda
         f(x) = x, if x < -lambda
@@ -372,7 +372,7 @@ class Hardshrink(Module):
 
 
 class LeakyReLU(Module):
-    """Applies element-wise,
+    r"""Applies element-wise,
     :math:`f(x) = max(0, x) + {negative\_slope} * min(0, x)`
 
     Args:
@@ -408,7 +408,7 @@ class LeakyReLU(Module):
 
 
 class LogSigmoid(Module):
-    """Applies element-wise :math:`LogSigmoid(x) = log( 1 / (1 + exp(-x_i)))`
+    r"""Applies element-wise :math:`LogSigmoid(x) = log( 1 / (1 + exp(-x_i)))`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -431,7 +431,7 @@ class LogSigmoid(Module):
 
 
 class Softplus(Module):
-    """Applies element-wise :math:`f(x) = 1/beta * log(1 + exp(beta * x_i))`
+    r"""Applies element-wise :math:`f(x) = 1/beta * log(1 + exp(beta * x_i))`
 
     SoftPlus is a smooth approximation to the ReLU function and can be used
     to constrain the output of a machine to always be positive.
@@ -471,7 +471,7 @@ class Softplus(Module):
 
 
 class Softshrink(Module):
-    """Applies the soft shrinkage function elementwise
+    r"""Applies the soft shrinkage function elementwise
 
     SoftShrinkage operator is defined as::
 
@@ -507,7 +507,7 @@ class Softshrink(Module):
 
 
 class PReLU(Module):
-    """Applies element-wise the function
+    r"""Applies element-wise the function
     :math:`PReLU(x) = max(0,x) + a * min(0,x)` Here "a" is a learnable
     parameter. When called without arguments, nn.PReLU() uses a single
     parameter "a" across all input channels. If called with nn.PReLU(nChannels),
@@ -548,7 +548,7 @@ class PReLU(Module):
 
 
 class Softsign(Module):
-    """Applies element-wise, the function :math:`f(x) = x / (1 + |x|)`
+    r"""Applies element-wise, the function :math:`f(x) = x / (1 + |x|)`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -571,7 +571,7 @@ class Softsign(Module):
 
 
 class Tanhshrink(Module):
-    """Applies element-wise, :math:`Tanhshrink(x) = x - Tanh(x)`
+    r"""Applies element-wise, :math:`Tanhshrink(x) = x - Tanh(x)`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -594,7 +594,7 @@ class Tanhshrink(Module):
 
 
 class Softmin(Module):
-    """Applies the Softmin function to an n-dimensional input Tensor
+    r"""Applies the Softmin function to an n-dimensional input Tensor
     rescaling them so that the elements of the n-dimensional output Tensor
     lie in the range `(0, 1)` and sum to 1
 
@@ -631,7 +631,7 @@ class Softmin(Module):
 
 
 class Softmax(Module):
-    """Applies the Softmax function to an n-dimensional input Tensor
+    r"""Applies the Softmax function to an n-dimensional input Tensor
     rescaling them so that the elements of the n-dimensional output Tensor
     lie in the range (0,1) and sum to 1
 
@@ -680,7 +680,7 @@ class Softmax(Module):
 
 
 class Softmax2d(Module):
-    """Applies SoftMax over features to each spatial location
+    r"""Applies SoftMax over features to each spatial location
 
     When given an image of Channels x Height x Width, it will
 
@@ -712,7 +712,7 @@ class Softmax2d(Module):
 
 
 class LogSoftmax(Module):
-    """Applies the Log(Softmax(x)) function to an n-dimensional input Tensor.
+    r"""Applies the Log(Softmax(x)) function to an n-dimensional input Tensor.
     The LogSoftmax formulation can be simplified as
 
     :math:`f_i(x) = log(exp(x_i) / sum_j exp(x_j) )`

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -17,7 +17,7 @@ class Container(Module):
 
 
 class Sequential(Module):
-    """A sequential container.
+    r"""A sequential container.
     Modules will be added to it in the order they are passed in the constructor.
     Alternatively, an ordered dict of modules can also be passed in.
 
@@ -69,7 +69,7 @@ class Sequential(Module):
 
 
 class ModuleList(Module):
-    """Holds submodules in a list.
+    r"""Holds submodules in a list.
 
     ModuleList can be indexed like a regular Python list, but modules it
     contains are properly registered, and will be visible by all Module methods.
@@ -116,7 +116,7 @@ class ModuleList(Module):
         return self.extend(modules)
 
     def append(self, module):
-        """Appends a given module at the end of the list.
+        r"""Appends a given module at the end of the list.
 
         Arguments:
             module (nn.Module): module to append
@@ -125,7 +125,7 @@ class ModuleList(Module):
         return self
 
     def extend(self, modules):
-        """Appends modules from a Python list at the end.
+        r"""Appends modules from a Python list at the end.
 
         Arguments:
             modules (list): list of modules to append
@@ -140,7 +140,7 @@ class ModuleList(Module):
 
 
 class ParameterList(Module):
-    """Holds parameters in a list.
+    r"""Holds parameters in a list.
 
     ParameterList can be indexed like a regular Python list, but parameters it
     contains are properly registered, and will be visible by all Module methods.

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -395,7 +395,7 @@ class _ConvTransposeMixin(object):
 
 
 class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
-    """Applies a 1D transposed convolution operator over an input image
+    r"""Applies a 1D transposed convolution operator over an input image
     composed of several input planes.
 
     This module can be seen as the gradient of Conv1d with respect to its input.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -21,7 +21,7 @@ def _addindent(s_, numSpaces):
 
 
 class Module(object):
-    """Base class for all neural network modules.
+    r"""Base class for all neural network modules.
 
     Your models should also subclass this class.
 

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -669,7 +669,7 @@ class AvgPool3d(Module):
 
 
 class FractionalMaxPool2d(Module):
-    """Applies a 2D fractional max pooling over an input signal composed of several input planes.
+    r"""Applies a 2D fractional max pooling over an input signal composed of several input planes.
 
     Fractiona MaxPooling is described in detail in the paper `Fractional MaxPooling`_ by Ben Graham
 
@@ -832,7 +832,7 @@ class LPPool1d(Module):
 
 
 class AdaptiveMaxPool1d(Module):
-    """Applies a 1D adaptive max pooling over an input signal composed of several input planes.
+    r"""Applies a 1D adaptive max pooling over an input signal composed of several input planes.
 
     The output size is H, for any input size.
     The number of output features is equal to the number of input planes.
@@ -864,7 +864,7 @@ class AdaptiveMaxPool1d(Module):
 
 
 class AdaptiveMaxPool2d(Module):
-    """Applies a 2D adaptive max pooling over an input signal composed of several input planes.
+    r"""Applies a 2D adaptive max pooling over an input signal composed of several input planes.
 
     The output is of size H x W, for any input size.
     The number of output features is equal to the number of input planes.
@@ -901,7 +901,7 @@ class AdaptiveMaxPool2d(Module):
 
 
 class AdaptiveMaxPool3d(Module):
-    """Applies a 3D adaptive max pooling over an input signal composed of several input planes.
+    r"""Applies a 3D adaptive max pooling over an input signal composed of several input planes.
 
     The output is of size D x H x W, for any input size.
     The number of output features is equal to the number of input planes.
@@ -938,7 +938,7 @@ class AdaptiveMaxPool3d(Module):
 
 
 class AdaptiveAvgPool1d(Module):
-    """Applies a 1D adaptive average pooling over an input signal composed of several input planes.
+    r"""Applies a 1D adaptive average pooling over an input signal composed of several input planes.
 
     The output size is H, for any input size.
     The number of output features is equal to the number of input planes.
@@ -967,7 +967,7 @@ class AdaptiveAvgPool1d(Module):
 
 
 class AdaptiveAvgPool2d(Module):
-    """Applies a 2D adaptive average pooling over an input signal composed of several input planes.
+    r"""Applies a 2D adaptive average pooling over an input signal composed of several input planes.
 
     The output is of size H x W, for any input size.
     The number of output features is equal to the number of input planes.
@@ -1001,7 +1001,7 @@ class AdaptiveAvgPool2d(Module):
 
 
 class AdaptiveAvgPool3d(Module):
-    """Applies a 3D adaptive average pooling over an input signal composed of several input planes.
+    r"""Applies a 3D adaptive average pooling over an input signal composed of several input planes.
 
     The output is of size D x H x W, for any input size.
     The number of output features is equal to the number of input planes.

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -6,8 +6,7 @@ from .. import functional as F
 
 
 class Upsample(Module):
-    """
-    Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D (volumetric) data.
+    r"""Upsamples a given multi-channel 1D (temporal), 2D (spatial) or 3D (volumetric) data.
 
     The input data is assumed to be of the form `minibatch x channels x [depth] x [height] x width`.
     Hence, for spatial inputs, we expect a 4D Tensor and for volumetric inputs, we expect a 5D Tensor.
@@ -89,8 +88,7 @@ class Upsample(Module):
 
 
 class UpsamplingNearest2d(Upsample):
-    """
-    Applies a 2D nearest neighbor upsampling to an input signal composed of several input
+    r"""Applies a 2D nearest neighbor upsampling to an input signal composed of several input
     channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
@@ -137,8 +135,7 @@ class UpsamplingNearest2d(Upsample):
 
 
 class UpsamplingBilinear2d(Upsample):
-    """
-    Applies a 2D bilinear upsampling to an input signal composed of several input
+    r"""Applies a 2D bilinear upsampling to an input signal composed of several input
     channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -6,7 +6,7 @@ from .parallel_apply import parallel_apply
 
 
 class DataParallel(Module):
-    """Implements data parallelism at the module level.
+    r"""Implements data parallelism at the module level.
 
     This container parallelizes the application of the given module by
     splitting the input across the specified devices by chunking in the batch
@@ -74,7 +74,7 @@ class DataParallel(Module):
 
 
 def data_parallel(module, inputs, device_ids=None, output_device=None, dim=0, module_kwargs=None):
-    """Evaluates module(input) in parallel across the GPUs given in device_ids.
+    r"""Evaluates module(input) in parallel across the GPUs given in device_ids.
 
     This is the functional version of the DataParallel module.
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -22,7 +22,7 @@ else:
 
 
 class DistributedDataParallel(Module):
-    """Implements distributed data parallelism at the module level.
+    r"""Implements distributed data parallelism at the module level.
 
     This container parallelizes the application of the given module by
     splitting the input across the specified devices by chunking in the batch

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -4,7 +4,7 @@ from ._functions import Scatter, Gather
 
 
 def scatter(inputs, target_gpus, dim=0):
-    """
+    r"""
     Slices variables into approximately equal chunks and
     distributes them across given GPUs. Duplicates
     references to objects that are not variables. Does not
@@ -26,7 +26,7 @@ def scatter(inputs, target_gpus, dim=0):
 
 
 def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
-    """Scatter with support for kwargs dictionary"""
+    r"""Scatter with support for kwargs dictionary"""
     inputs = scatter(inputs, target_gpus, dim) if inputs else []
     kwargs = scatter(kwargs, target_gpus, dim) if kwargs else []
     if len(inputs) < len(kwargs):
@@ -39,7 +39,7 @@ def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
 
 
 def gather(outputs, target_device, dim=0):
-    """
+    r"""
     Gathers variables from different GPUs on a specified device
       (-1 means the CPU).
     """

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -2,7 +2,7 @@ from torch.autograd import Variable
 
 
 class Parameter(Variable):
-    """A kind of Variable that is to be considered a module parameter.
+    r"""A kind of Variable that is to be considered a module parameter.
 
     Parameters are :class:`~torch.autograd.Variable` subclasses, that have a
     very special property when used with :class:`Module` s - when they're

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -1,6 +1,6 @@
 
 def clip_grad_norm(parameters, max_norm, norm_type=2):
-    """Clips gradient norm of an iterable of parameters.
+    r"""Clips gradient norm of an iterable of parameters.
 
     The norm is computed over all gradients together, as if they were
     concatenated into a single vector. Gradients are modified in-place.

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -3,7 +3,7 @@ from torch.autograd import Variable
 
 
 def parameters_to_vector(parameters):
-    """Convert parameters to one vector
+    r"""Convert parameters to one vector
 
     Arguments:
         parameters (Iterable[Variable]): an iterator of Variables that are the
@@ -25,7 +25,7 @@ def parameters_to_vector(parameters):
 
 
 def vector_to_parameters(vec, parameters):
-    """Convert one vector to the parameters
+    r"""Convert one vector to the parameters
 
     Arguments:
         vec (Variable): a single vector represents the parameters of a model.
@@ -55,7 +55,7 @@ def vector_to_parameters(vec, parameters):
 
 
 def _check_param_device(param, old_param_device):
-    """This helper function is to check if the parameters are located
+    r"""This helper function is to check if the parameters are located
     in the same device. Currently, the conversion between model parameters
     and single vector form is not supported for multiple allocations,
     e.g. parameters in different GPUs, or mixture of CPU/GPU.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -7,7 +7,7 @@ PackedSequence_ = namedtuple('PackedSequence', ['data', 'batch_sizes'])
 
 
 class PackedSequence(PackedSequence_):
-    """Holds the data and list of batch_sizes of a packed sequence.
+    r"""Holds the data and list of batch_sizes of a packed sequence.
 
     All RNN modules accept packed sequences as inputs.
 
@@ -24,7 +24,7 @@ class PackedSequence(PackedSequence_):
 
 
 def pack_padded_sequence(input, lengths, batch_first=False):
-    """Packs a Variable containing padded sequences of variable length.
+    r"""Packs a Variable containing padded sequences of variable length.
 
     Input can be of size ``TxBx*`` where T is the length of the longest sequence
     (equal to ``lengths[0]``), B is the batch size, and * is any number of
@@ -77,7 +77,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
 
 
 def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0):
-    """Pads a packed batch of variable length sequences.
+    r"""Pads a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
 

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -59,7 +59,7 @@ class WeightNorm(object):
 
 
 def weight_norm(module, name='weight', dim=0):
-    """Applies weight normalization to a parameter in the given module.
+    r"""Applies weight normalization to a parameter in the given module.
 
     .. math::
          \mathbf{w} = g \dfrac{\mathbf{v}}{\|\mathbf{v}\|}
@@ -101,7 +101,7 @@ def weight_norm(module, name='weight', dim=0):
 
 
 def remove_weight_norm(module, name='weight'):
-    """Removes the weight normalization reparameterization from a module.
+    r"""Removes the weight normalization reparameterization from a module.
 
     Args:
         module (nn.Module): containing module


### PR DESCRIPTION
Sphinx documentation should be in raw string to avoid issues like: https://stackoverflow.com/questions/16468397/mathjax-expression-in-sphinx-python-not-rendering-correclty
and https://github.com/pytorch/pytorch/issues/3186.

This PR converts top level doc strings under `torch.nn` to raw string.

Fixing #3186 