### PR TITLE
Add sparseTensor.new wrapper bindings

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -644,6 +644,16 @@ class TestSparse(TestCase):
         v = self.ValueTensor([5]).cuda(0)
         self.assertRaises(RuntimeError, lambda: self.SparseTensor(i, v, torch.Size([3])))
 
+    @cuda_only
+    @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
+    def test_new_device(self):
+        with torch.cuda.device(1):
+            x = torch.cuda.sparse.DoubleTensor(30, 2)
+        self.assertEqual(x.get_device(), 1)
+
+        y = x.new(2, 3)
+        self.assertEqual(y.get_device(), 1)
+
 
 class TestUncoalescedSparse(TestSparse):
     def setUp(self):

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -38,6 +38,24 @@ PyObject * THSPTensor_(size)(PyObject *self, PyObject *args, PyObject *kwargs)
 #endif
 
 [[
+  name: THSPTensor_(new)
+  python_name: new
+  method_flags: METH_KEYWORDS
+  backends:
+    - CUDA
+  only_register: True
+  sparse: yes
+]]
+#if IS_CUDA
+static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject *kwargs);
+PyObject * THSPTensor_(new)(THPTensor *self, PyObject *args, PyObject *kwargs)
+{
+  THCPAutoGPU gpu_guard(args, (PyObject*)self);
+  return THSPTensor_(pynew)(Py_TYPE(self), args, kwargs);
+}
+#endif
+
+[[
   name: nDimension
   sparse: yes
   python_name: ndimension


### PR DESCRIPTION
Fixes #3312 . Relevant to #3137 .

However, I'd appreciate if someone can explain to me how all these `.cwrap` bindings work. From poking around, my understanding is:

1. Both ATen cwrap and `csrc/generic` crwap are needed for the method to exist.
2. Somehow, if a python `new` is not supplied in a cwrap binding, calling `.new` will automatically invoke the `tp_new` on the c `PyObject`. I'm also curious where this happens.

