### PR TITLE
Add reduce keyword for KLDivLoss

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -3,7 +3,7 @@
 - name: binary_cross_entropy(Tensor input, Tensor target, Tensor weight={}, bool size_average=true)
   cname: BCECriterion
 
-- name: kl_div(Tensor input, Tensor target, bool size_average=true)
+- name: kl_div(Tensor input, Tensor target, bool size_average=true, bool reduce=true)
   cname: DistKLDivCriterion
 
 - name: l1_loss(Tensor input, Tensor target, bool size_average=true, bool reduce=True)

--- a/aten/src/THCUNN/generic/DistKLDivCriterion.cu
+++ b/aten/src/THCUNN/generic/DistKLDivCriterion.cu
@@ -2,19 +2,30 @@
 #define THC_GENERIC_FILE "generic/DistKLDivCriterion.cu"
 #else
 
+#include "THCApply.cuh"
+
 void THNN_(DistKLDivCriterion_updateOutput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
            THCTensor *output,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCTensor_(resize1d)(state, output, 1);
   THCUNN_assertSameGPU(state, 2, input, target);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
              "input and target need to have the same number of elements");
+
+  if (!reduce) {
+    THCTensor_(resizeAs)(state, output, input);
+    THC_pointwiseApply3(state, input, target, output,
+                        kl_updateOutput_no_reduce_functor<real>());
+    return;
+  }
+
+  THCTensor_(resize1d)(state, output, 1);
 
   accreal sum;
 
@@ -40,14 +51,27 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
              "input and target need to have the same number of elements");
+
+  THCTensor_(resizeAs)(state, gradInput, input);
+
+  if (!reduce) {
+    THCUNN_check_nElement(state, gradOutput, input);
+    THC_pointwiseApply3(state, target, gradOutput, gradInput,
+                        kl_updateGradInput_no_reduce_functor<real>());
+    return;
+  }
+
+  THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
   real norm = (sizeAverage ? ScalarConvert<accreal, real>::to(accreal(1)/size) : ScalarConvert<int, real>::to(1));
@@ -55,13 +79,12 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);
 
-  THCTensor_(resizeAs)(state, gradInput, input);
-
   thrust::device_ptr<real> input_data(THCTensor_(data)(state, input));
   thrust::device_ptr<real> target_data(THCTensor_(data)(state, target));
   thrust::device_ptr<real> gradInput_data(THCTensor_(data)(state, gradInput));
 
-  thrust::transform(input_data, input_data+size, target_data, gradInput_data, kl_updateGradInput_functor<real>(norm));
+  thrust::transform(input_data, input_data+size, target_data, gradInput_data,
+                    kl_updateGradInput_functor<real>(norm, THCTensor_(get1d)(state, gradOutput, 0)));
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -104,14 +104,17 @@ TH_API void THNN_(DistKLDivCriterion_updateOutput)(
                   THCTensor *input,
                   THCTensor *target,
                   THCTensor *output,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(DistKLDivCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(ELU_updateOutput)(
                   THCState *state,

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -108,13 +108,16 @@ TH_API void THNN_(DistKLDivCriterion_updateOutput)(
           THTensor *input,             // input tensor
           THTensor *target,            // target tensor
           THTensor *output,            // [OUT] a one-element tensor containing the loss
-          bool sizeAverage);           // if true, the loss will be normalized **by total number of elements**
+          bool sizeAverage,            // if true, the loss will be normalized **by total number of elements**
+          bool reduce);                // if true, returns summed or averaged loss. if false, returns a loss per element.
 TH_API void THNN_(DistKLDivCriterion_updateGradInput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor
           THTensor *target,            // target tensor
+          THTensor *gradOutput,        // grad output tensor
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
-          bool sizeAverage);           // if true, the loss will be normalized **by total number of elements**
+          bool sizeAverage,            // if true, the loss will be normalized **by total number of elements**
+          bool reduce);                // if true, returns summed or averaged loss. if false, returns a loss per element.
 
 TH_API void THNN_(GatedLinear_updateOutput)(
           THNNState *state,            // library's state

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -246,6 +246,17 @@ module_tests = [
 ]
 
 
+def kldivloss_reference(input, target, size_average=True, reduce=True):
+    safe_target = target * (target > 0).type_as(target)
+    safe_target_log = (safe_target + (target <= 0).type_as(target)).log()
+    result = safe_target * (safe_target_log - input)
+    if reduce and size_average:
+        return result.mean()
+    elif reduce:
+        return result.sum()
+    return result
+
+
 def nllloss2d_reference(input, target, weight=None, ignore_index=-100,
                         size_average=True, reduce=True):
     N, C, H, W = input.size()
@@ -309,6 +320,7 @@ def smoothl1loss_reference(input, target, size_average=True, reduce=True):
 
 
 loss_reference_fns = {
+    'KLDivLoss': kldivloss_reference,
     'NLLLoss': nllloss_reference,
     'NLLLoss2d': nllloss2d_reference,
     'SmoothL1Loss': smoothl1loss_reference,
@@ -370,6 +382,8 @@ criterion_tests = [
         module_name='KLDivLoss',
         input_fn=lambda: torch.rand(10, 10).log(),
         target_fn=lambda: torch.rand(10, 10),
+        reference_fn=lambda i, t, m:
+            kldivloss_reference(i, t, get_size_average(m), reduce=True),
         check_no_size_average=True,
     ),
     dict(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3667,6 +3667,18 @@ new_criterion_tests = [
 ]
 
 
+def kldivloss_no_reduce_test():
+    t = Variable(torch.randn(10, 10))
+    return dict(
+        fullname='KLDivLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.kl_div(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.rand(10, 10).log(),
+        reference_fn=lambda i, _:
+            loss_reference_fns['KLDivLoss'](i, t.data.type_as(i), reduce=False),
+        pickle=False)
+
+
 def l1loss_no_reduce_test():
     t = Variable(torch.randn(2, 3, 4))
     return dict(
@@ -3825,6 +3837,7 @@ def smoothl1loss_no_reduce_test():
 
 
 new_module_tests = [
+    kldivloss_no_reduce_test(),
     l1loss_no_reduce_test(),
     mseloss_no_reduce_test(),
     nllloss_no_reduce_test(),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -572,7 +572,8 @@
   grad_output: hardtanh_backward(grad, input, min_val, max_val, false)
   input: zeros_like(grad)
 
-- name: kl_div_backward(Tensor input, Tensor target, bool size_average)
+- name: kl_div_backward(Tensor grad_output, Tensor input, Tensor target, bool size_average, bool reduce)
+  grad_output: kl_div_double_backward_grad_output(grad, input, target, size_average, reduce)
   input: zeros_like(grad)
 
 - name: l1_loss_backward(Tensor grad_output, Tensor input, Tensor target, bool size_average, bool reduce)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -294,6 +294,16 @@ Tensor glu_double_backward_grad_output(const Tensor & grad, const Tensor & input
   return tmp.narrow(dim, 0, sizes[dim]) + tmp.narrow(dim, sizes[dim], sizes[dim]);
 }
 
+Tensor kl_div_double_backward_grad_output(const Tensor & grad, const Tensor & input, const Tensor & target, bool size_average, bool reduce) {
+  auto result = kl_div_backward(grad, input, target, size_average, false);
+  if (reduce && size_average) {
+    return result.mean().toTensor();
+  } else if (reduce) {
+    return result.sum().toTensor();
+  }
+  return result;
+}
+
 Tensor log_sigmoid_double_backward(const Tensor & grad, const Tensor & input) {
   auto z = input.sigmoid();
   return grad * (z - 1) * z;

--- a/torch/legacy/nn/DistKLDivCriterion.py
+++ b/torch/legacy/nn/DistKLDivCriterion.py
@@ -18,18 +18,22 @@ class DistKLDivCriterion(Criterion):
             input,
             target,
             self.output_tensor,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         self.output = self.output_tensor[0]
         return self.output
 
     def updateGradInput(self, input, target):
         assert input.is_same_size(target)
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.DistKLDivCriterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         return self.gradInput

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1087,7 +1087,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
 
 
 kl_div = _add_docstr(torch._C._nn.kl_div, r"""
-kl_div(input, target, size_average=True, weight=None) -> Variable
+kl_div(input, target, size_average=True) -> Variable
 
 The `Kullback-Leibler divergence`_ Loss.
 
@@ -1097,9 +1097,12 @@ Args:
     input: Variable of arbitrary shape
     target: Variable of the same shape as input
     size_average: if True the output is divided by the number of elements
-      in input tensor. Default: True
-    weight (Tensor, optional): a manual rescaling weight given to each
-            class. If given, has to be a Tensor of size `C`
+        in input tensor. Default: True
+    reduce (bool, optional): By default, the losses are averaged
+        over observations for each minibatch, or summed, depending on
+        size_average. When reduce is False, returns a loss per batch
+        element instead and ignores size_average. Default: True
+
 """)
 
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -253,10 +253,31 @@ class KLDivLoss(_Loss):
 
     .. _Kullback-Leibler divergence:
         https://en.wikipedia.org/wiki/Kullback-Leibler_divergence
+
+    Args:
+        size_average (bool, optional: By default, the losses are averaged
+            for each minibatch over observations **as well as** over
+            dimensions. However, if False the losses are instead summed.
+        reduce (bool, optional): By default, the losses are averaged
+            over observations for each minibatch, or summed, depending on
+            size_average. When reduce is False, returns a loss per batch
+            element instead and ignores size_average. Default: True
+
+    Shape:
+        - input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - target: :math:`(N, *)`, same shape as the input
+        - output: scalar. If `reduce` is True, then :math:`(N, *)`,
+            same shape as the input
+
     """
+    def __init__(self, size_average=True, reduce=True):
+        super(KLDivLoss, self).__init__(size_average)
+        self.reduce = reduce
+
     def forward(self, input, target):
         _assert_no_grad(target)
-        return F.kl_div(input, target, size_average=self.size_average)
+        return F.kl_div(input, target, size_average=self.size_average, reduce=self.reduce)
 
 
 class MSELoss(_Loss):


### PR DESCRIPTION
### Summary
As per #264, adds the reduce keyword to KLDivLoss. When reduce is False, the loss fn returns a loss per element.

### Test Plan
Run unit tests.
Added new unit test for the no reduce case as well as reference functions for both the no-reduce and reduce cases.