### PR TITLE
Fix compilation without numpy.

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -304,7 +304,7 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
     return (PyObject *)self.release();
   }
 
-#if defined(NUMPY_TYPE_ENUM) || defined(THC_GENERIC_FILE)
+#if defined(NUMPY_TYPE_ENUM) || (defined(WITH_NUMPY) && defined(THC_GENERIC_FILE))
   // torch.Tensor(np.ndarray array)
   if (num_args == 1 && PyArray_Check(first_arg)) {
     THPObjectPtr numpy_array(


### PR DESCRIPTION
I accidentally tried compiling without numpy and stumbled into this. The docs say to install numpy but building without it looks like it's intended to be supported, hence the fix.

For reference, the error:

    Tensor.cpp:309:47: error: ‘PyArray_Check’ was not declared in this scope