### PR TITLE
Add .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
`.gitignore` should have uninteresting files listed, so acts as a good
`.dockerignore`. Reduces the build context sent to the docker daemon from to
2.927GB (after building locally) to 66.66MB (:O).