### PR TITLE
Prevent numerical issues with poisson_nll_loss when log_input=False

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -947,7 +947,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
     if log_input:
         loss = torch.exp(input) - target * input
     else:
-        loss = input - target * torch.log(input+eps)
+        loss = input - target * torch.log(input + eps)
     if full:
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -924,7 +924,7 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
         raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
 
 
-def poisson_nll_loss(input, target, log_input=True, full=False, size_average=True):
+def poisson_nll_loss(input, target, log_input=True, full=False, size_average=True, eps=1e-8):
     r"""Poisson negative log likelihood loss.
 
     See :class:`~torch.nn.PoissonNLLLoss` for details.
@@ -934,18 +934,20 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
         target: random sample :math:`target \sim Pois(input)`.
         log_input: if True the loss is computed as
             `exp(input) - target * input`, if False then loss is
-            `input - target * log(input)`. Default: True
+            `input - target * log(input+eps)`. Default: True
         full: whether to compute full loss, i. e. to add the Stirling
             approximation term. Default: False
             `target * log(target) - target + 0.5 * log(2 * pi * target)`.
         size_average: By default, the losses are averaged over observations for
             each minibatch. However, if the field sizeAverage is set to False,
             the losses are instead summed for each minibatch. Default: True
+        eps (float, optional): Small value to avoid evaluation of log(0) when
+            log_input=False. Default: 1e-8
     """
     if log_input:
         loss = torch.exp(input) - target * input
     else:
-        loss = input - target * torch.log(input)
+        loss = input - target * torch.log(input+eps)
     if full:
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -190,13 +190,15 @@ class PoissonNLLLoss(_Loss):
     Args:
         log_input (bool, optional): if True the loss is computed as
             `exp(input) - target * input`, if False the loss is
-            `input - target * log(input)`.
+            `input - target * log(input+eps)`.
         full (bool, optional): whether to compute full loss, i. e. to add the
             Stirling approximation term
             `target * log(target) - target + 0.5 * log(2 * pi * target)`.
         size_average (bool, optional): By default, the losses are averaged over
             observations for each minibatch. However, if the field size_average
             is set to False, the losses are instead summed for each minibatch.
+        eps (float, optional): Small value to avoid evaluation of log(0) when
+            log_input=False. Default: 1e-8
 
     Examples::
 
@@ -206,15 +208,16 @@ class PoissonNLLLoss(_Loss):
         >>> output = loss(log_input, target)
         >>> output.backward()
     """
-    def __init__(self, log_input=True, full=False, size_average=True):
+    def __init__(self, log_input=True, full=False, size_average=True, eps=1e-8):
         super(PoissonNLLLoss, self).__init__()
         self.log_input = log_input
         self.full = full
         self.size_average = size_average
+        self.eps = eps
 
     def forward(self, log_input, target):
         _assert_no_grad(target)
-        return F.poisson_nll_loss(log_input, target, self.log_input, self.full, self.size_average)
+        return F.poisson_nll_loss(log_input, target, self.log_input, self.full, self.size_average, self.eps)
 
 
 class KLDivLoss(_Loss):


### PR DESCRIPTION
Evaluation of the logarithm of the input variable in poisson negative log likelihood leads to NaN loss if variable being evaluated is zero. Small epsilon is added to prevent this. See equivalent Keras epsilon here: https://github.com/fchollet/keras/blob/master/keras/losses.py#L68

Here is the code to reproduce the issue:

```python
import numpy as np
import torch
from torch.autograd import Variable

torch.manual_seed(42)
np.random.seed(42)

poisson_mean = 4
poisson_numsample = 200

samples = np.random.poisson(poisson_mean, poisson_numsample)

param = Variable(torch.zeros(1), requires_grad=True)
torch_samples = Variable(torch.from_numpy(samples).float(), requires_grad=False)

optimizer = torch.optim.RMSprop([param], lr=0.1)
loss = torch.nn.PoissonNLLLoss(log_input=False, full=True)

for i in range(5000):
    optimizer.zero_grad()
    output = loss(param, torch_samples)
    output.backward()

    if i % 1000 == 0:
        print('Loss:', output.data[0])

    optimizer.step()

print('Sample mean: ', torch_samples.mean().data.numpy())
print('Mean is : ', param.data.numpy())

```