### PR TITLE
fix triplet margin loss documentation

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1443,7 +1443,7 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2^2`.
+    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2`.
 
     Args:
         anchor: anchor input tensor

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1443,7 +1443,7 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2`.
+    where :math:`d(x_i, y_i) = \lVert {\bf x}_i - {\bf y}_i \rVert_p`.
 
     Args:
         anchor: anchor input tensor

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1443,7 +1443,7 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \lVert {\bf x}_i - {\bf y}_i \rVert_p`.
+    where :math:`d(x_i, y_i) = \left\lVert {\bf x}_i - {\bf y}_i \right\rVert_p`.
 
     Args:
         anchor: anchor input tensor

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -668,7 +668,7 @@ class TripletMarginLoss(Module):
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \lVert {\bf x}_i - {\bf y}_i \rVert_p`.
+    where :math:`d(x_i, y_i) = \left\lVert {\bf x}_i - {\bf y}_i \right\rVert_p`.
 
     Args:
         anchor: anchor input tensor

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -668,7 +668,7 @@ class TripletMarginLoss(Module):
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2`.
+    where :math:`d(x_i, y_i) = \lVert {\bf x}_i - {\bf y}_i \rVert_p`.
 
     Args:
         anchor: anchor input tensor

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -668,7 +668,7 @@ class TripletMarginLoss(Module):
     .. math::
         L(a, p, n) = \frac{1}{N} \left( \sum_{i=1}^N \max \{d(a_i, p_i) - d(a_i, n_i) + {\rm margin}, 0\} \right)
 
-    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2^2`.
+    where :math:`d(x_i, y_i) = \| {\bf x}_i - {\bf y}_i \|_2`.
 
     Args:
         anchor: anchor input tensor


### PR DESCRIPTION
Hi all! The documentation of the triplet margin loss suggests that the squared euclidean distances are used, but in practice the true euclidean distances are used. This can cause confusion as in some algorithms that use triplets (e.g. Large Margin Nearest Neighbor), the squared distances are actually used.