### PR TITLE
add gumbel_softmax, based on Eric Jang's implementation

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1014,6 +1014,48 @@ class TestNN(NNTestCase):
         res_F = F.embedding(a, embeddings)
         self.assertEqual(res_old, res_F)
 
+    def test_gumbel_softmax_st(self):
+        old_rng_state = torch.get_rng_state()
+        torch.manual_seed(123)
+        """
+        Things we might want to check:
+        - if we make various draws, do we get different one-hot values?
+        - is the proportion approximately in line with the softmax values?
+        - with hard, is it one-hot?
+        - with hard, is there still a gradient?
+        """
+        num_draws = 100
+        K = 3
+        logits = torch.FloatTensor([[0.2, 0.8, 0.1]])
+        logits_softmax = torch.nn.functional.softmax(Variable(logits), 1)
+        y_draws = torch.zeros(num_draws, K)
+        preds = torch.zeros(num_draws)
+        for draw in range(num_draws):
+            logits_var = Variable(logits, requires_grad=True)
+            y_draw = torch.nn.functional.gumbel_softmax(
+                logits_var,
+                hard=True)
+            assert y_draw.size() == logits.size()
+            # check we have a gradient
+            assert y_draw.requires_grad
+            err = y_draw - Variable(torch.FloatTensor([[0, 0.5, 0.3]]))
+            loss = (err * err).sum()
+            loss.backward()
+            assert logits_var.grad.abs().min().data[0] > 0.001
+            y_draws[draw] = y_draw.data
+            _, pred = y_draw.max(1)
+            preds[draw] = pred.data[0]
+        # check it's approximately one-hot
+        num_ones = (y_draws == 1).int().sum()
+        num_zeros = (y_draws == 0).int().sum()
+        assert num_ones + num_zeros == num_draws * K
+        assert num_ones == num_draws
+        # check output classes approx in line with logits
+        num_class_one = (preds == 1).int().sum()
+        assert num_class_one < num_draws
+        assert num_class_one > num_draws / 3
+        torch.set_rng_state(old_rng_state)
+
     def _test_EmbeddingBag(self, cuda, mode):
         # check a known test example
         es = nn.EmbeddingBag(5, 2, mode=mode)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -835,6 +835,70 @@ def softmax(input, dim=None, _stacklevel=3):
     return torch._C._nn.softmax(input, dim)
 
 
+def sample_gumbel(shape, eps=1e-10):
+    """
+    Sample from Gumbel(0, 1)
+
+    based on
+    https://github.com/ericjang/gumbel-softmax/blob/3c8584924603869e90ca74ac20a6a03d99a91ef9/Categorical%20VAE.ipynb ,
+    (MIT license)
+    """
+    U = torch.rand(shape).float()
+    return - torch.log(eps - torch.log(U + eps))
+
+
+def gumbel_softmax_sample(logits, tau=1, eps=1e-10):
+    """
+    Draw a sample from the Gumbel-Softmax distribution
+
+    based on
+    https://github.com/ericjang/gumbel-softmax/blob/3c8584924603869e90ca74ac20a6a03d99a91ef9/Categorical%20VAE.ipynb
+    (MIT license)
+    """
+    dims = len(logits.size())
+    gumbel_noise = sample_gumbel(logits.size(), eps=eps)
+    y = logits + Variable(gumbel_noise)
+    return softmax(y / tau, dims - 1)
+
+
+def gumbel_softmax(logits, tau=1, hard=False, eps=1e-10):
+    """
+    Sample from the Gumbel-Softmax distribution and optionally discretize.
+    Args:
+      logits: [batch_size, n_class] unnormalized log-probs
+      tau: non-negative scalar temperature
+      hard: if True, take argmax, but differentiate w.r.t. soft sample y
+    Returns:
+      [batch_size, n_class] sample from the Gumbel-Softmax distribution.
+      If hard=True, then the returned sample will be one-hot, otherwise it will
+      be a probability distribution that sums to 1 across classes
+
+    Constraints:
+    - this implementation only works on batch_size x num_features tensor for now
+
+    based on
+    https://github.com/ericjang/gumbel-softmax/blob/3c8584924603869e90ca74ac20a6a03d99a91ef9/Categorical%20VAE.ipynb ,
+    (MIT license)
+    """
+    shape = logits.size()
+    assert len(shape) == 2
+    y_soft = gumbel_softmax_sample(logits, tau=tau, eps=eps)
+    if hard:
+        _, k = y_soft.data.max(-1)
+        # this bit is based on
+        # https://discuss.pytorch.org/t/stop-gradients-for-st-gumbel-softmax/530/5
+        y_hard = torch.FloatTensor(*shape).zero_().scatter_(-1, k.view(-1, 1), 1.0)
+        # this cool bit of code achieves two things:
+        # - makes the output value exactly one-hot (since we add then
+        #   subtract y_soft value)
+        # - makes the gradient equal to y_soft gradient (since we strip
+        #   all other gradients)
+        y = Variable(y_hard - y_soft.data) + y_soft
+    else:
+        y = y_soft
+    return y
+
+
 def log_softmax(input, dim=None, _stacklevel=3):
     r"""Applies a softmax followed by a logarithm.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -835,7 +835,7 @@ def softmax(input, dim=None, _stacklevel=3):
     return torch._C._nn.softmax(input, dim)
 
 
-def sample_gumbel(shape, eps=1e-10, out=None):
+def _sample_gumbel(shape, eps=1e-10, out=None):
     """
     Sample from Gumbel(0, 1)
 
@@ -847,7 +847,7 @@ def sample_gumbel(shape, eps=1e-10, out=None):
     return - torch.log(eps - torch.log(U + eps))
 
 
-def gumbel_softmax_sample(logits, tau=1, eps=1e-10):
+def _gumbel_softmax_sample(logits, tau=1, eps=1e-10):
     """
     Draw a sample from the Gumbel-Softmax distribution
 
@@ -855,8 +855,8 @@ def gumbel_softmax_sample(logits, tau=1, eps=1e-10):
     https://github.com/ericjang/gumbel-softmax/blob/3c8584924603869e90ca74ac20a6a03d99a91ef9/Categorical%20VAE.ipynb
     (MIT license)
     """
-    dims = len(logits.size())
-    gumbel_noise = sample_gumbel(logits.size(), eps=eps, out=logits.data.new())
+    dims = logits.dim()
+    gumbel_noise = _sample_gumbel(logits.size(), eps=eps, out=logits.data.new())
     y = logits + Variable(gumbel_noise)
     return softmax(y / tau, dims - 1)
 
@@ -882,7 +882,7 @@ def gumbel_softmax(logits, tau=1, hard=False, eps=1e-10):
     """
     shape = logits.size()
     assert len(shape) == 2
-    y_soft = gumbel_softmax_sample(logits, tau=tau, eps=eps)
+    y_soft = _gumbel_softmax_sample(logits, tau=tau, eps=eps)
     if hard:
         _, k = y_soft.data.max(-1)
         # this bit is based on


### PR DESCRIPTION
based on:
- https://discuss.pytorch.org/t/stop-gradients-for-st-gumbel-softmax/530/5
- https://github.com/ericjang/gumbel-softmax/blob/3c8584924603869e90ca74ac20a6a03d99a91ef9/Categorical%20VAE.ipynb (section 1)

Gumbel softmax lets you use the reparameterization trick for discrete variables