### PR TITLE
fix import of StochasticFunction (#3340)

### DIFF
--- a/torch/autograd/_functions/__init__.py
+++ b/torch/autograd/_functions/__init__.py
@@ -7,3 +7,4 @@ from .blas import *
 from .stochastic import *
 from .compare import *
 from .initializers import *
+from ..stochastic_function import StochasticFunction


### PR DESCRIPTION
This reimports `StochasticFunction` which was not imported anymore as a side-effect of commit d9b89a352c4ceeff24878f4f5321e16f059e98c3