### PR TITLE
fix some more mathjax

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -184,7 +184,7 @@ class ReLU6(Hardtanh):
 
 
 class Sigmoid(Module):
-    r"""Applies the element-wise function :math:`f(x) = 1 / ( 1 + exp(-x))`
+    r"""Applies the element-wise function :math:`f(x) = \frac{1}{1 + \exp(-x)}`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -208,7 +208,7 @@ class Sigmoid(Module):
 
 class Tanh(Module):
     r"""Applies element-wise,
-    :math:`f(x) = (exp(x) - exp(-x)) / (exp(x) + exp(-x))`
+    :math:`f(x) = \frac{\exp(x) - \exp(-x)} {\exp(x) + \exp(-x)}`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -232,7 +232,7 @@ class Tanh(Module):
 
 class ELU(Module):
     r"""Applies element-wise,
-    :math:`f(x) = max(0,x) + min(0, alpha * (exp(x) - 1))`
+    :math:`f(x) = max(0,x) + min(0, alpha * (\exp(x) - 1))`
 
     Args:
         alpha: the alpha value for the ELU formulation. Default: 1.0
@@ -373,7 +373,7 @@ class Hardshrink(Module):
 
 class LeakyReLU(Module):
     r"""Applies element-wise,
-    :math:`f(x) = max(0, x) + {negative\_slope} * min(0, x)`
+    :math:`f(x) = \max(0, x) + \text{negative\_slope} * \min(0, x)`
 
     Args:
         negative_slope: Controls the angle of the negative slope. Default: 1e-2
@@ -408,7 +408,7 @@ class LeakyReLU(Module):
 
 
 class LogSigmoid(Module):
-    r"""Applies element-wise :math:`LogSigmoid(x) = log( 1 / (1 + exp(-x_i)))`
+    r"""Applies element-wise :math:`LogSigmoid(x) = \log\left(\frac{ 1 }{ 1 + \exp(-x_i)}\right)`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -431,7 +431,7 @@ class LogSigmoid(Module):
 
 
 class Softplus(Module):
-    r"""Applies element-wise :math:`f(x) = 1/beta * log(1 + exp(beta * x_i))`
+    r"""Applies element-wise :math:`f(x) = \frac{1}{\text{beta}} * \log(1 + \exp(\text{beta} * x_i))`
 
     SoftPlus is a smooth approximation to the ReLU function and can be used
     to constrain the output of a machine to always be positive.
@@ -548,7 +548,7 @@ class PReLU(Module):
 
 
 class Softsign(Module):
-    r"""Applies element-wise, the function :math:`f(x) = x / (1 + |x|)`
+    r"""Applies element-wise, the function :math:`f(x) = \frac{x}{ 1 + |x|}`
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -715,7 +715,7 @@ class LogSoftmax(Module):
     r"""Applies the Log(Softmax(x)) function to an n-dimensional input Tensor.
     The LogSoftmax formulation can be simplified as
 
-    :math:`f_i(x) = log(exp(x_i) / sum_j exp(x_j) )`
+    :math:`f_i(x) = \log\left(\frac{\exp(x_i) }{ \sum_j \exp(x_j)} \right)`
 
     Shape:
         - Input: any shape

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -305,7 +305,7 @@ class LSTM(RNNBase):
     state at time `t`, :math:`x_t` is the hidden state of the previous layer at
     time `t` or :math:`input_t` for the first layer, and :math:`i_t`,
     :math:`f_t`, :math:`g_t`, :math:`o_t` are the input, forget, cell,
-    and out gates, respectively.
+    and out gates, respectively. :math:`\sigma` is the sigmoid function.
 
     Args:
         input_size: The number of expected features in the input x
@@ -382,7 +382,7 @@ class GRU(RNNBase):
     where :math:`h_t` is the hidden state at time `t`, :math:`x_t` is the hidden
     state of the previous layer at time `t` or :math:`input_t` for the first
     layer, and :math:`r_t`, :math:`z_t`, :math:`n_t` are the reset, input,
-    and new gates, respectively.
+    and new gates, respectively. :math:`\sigma` is the sigmoid function.
 
     Args:
         input_size: The number of expected features in the input x
@@ -539,6 +539,8 @@ class LSTMCell(RNNCellBase):
         c' = f * c + i * g \\
         h' = o * \tanh(c') \\
         \end{array}
+        
+    where :math:`\sigma` is the sigmoid function.
 
     Args:
         input_size: The number of expected features in the input x
@@ -618,6 +620,8 @@ class GRUCell(RNNCellBase):
         n = \tanh(W_{in} x + b_{in} + r * (W_{hn} h + b_{hn})) \\
         h' = (1 - z) * n + z * h
         \end{array}
+        
+    where :math:`\sigma` is the sigmoid function.
 
     Args:
         input_size: The number of expected features in the input x

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -293,10 +293,10 @@ class LSTM(RNNBase):
     .. math::
 
             \begin{array}{ll}
-            i_t = \mathrm{sigmoid}(W_{ii} x_t + b_{ii} + W_{hi} h_{(t-1)} + b_{hi}) \\
-            f_t = \mathrm{sigmoid}(W_{if} x_t + b_{if} + W_{hf} h_{(t-1)} + b_{hf}) \\
+            i_t = \sigma(W_{ii} x_t + b_{ii} + W_{hi} h_{(t-1)} + b_{hi}) \\
+            f_t = \sigma(W_{if} x_t + b_{if} + W_{hf} h_{(t-1)} + b_{hf}) \\
             g_t = \tanh(W_{ig} x_t + b_{ig} + W_{hc} h_{(t-1)} + b_{hg}) \\
-            o_t = \mathrm{sigmoid}(W_{io} x_t + b_{io} + W_{ho} h_{(t-1)} + b_{ho}) \\
+            o_t = \sigma(W_{io} x_t + b_{io} + W_{ho} h_{(t-1)} + b_{ho}) \\
             c_t = f_t * c_{(t-1)} + i_t * g_t \\
             h_t = o_t * \tanh(c_t)
             \end{array}
@@ -373,8 +373,8 @@ class GRU(RNNBase):
     .. math::
 
             \begin{array}{ll}
-            r_t = \mathrm{sigmoid}(W_{ir} x_t + b_{ir} + W_{hr} h_{(t-1)} + b_{hr}) \\
-            z_t = \mathrm{sigmoid}(W_{iz} x_t + b_{iz} + W_{hz} h_{(t-1)} + b_{hz}) \\
+            r_t = \sigma(W_{ir} x_t + b_{ir} + W_{hr} h_{(t-1)} + b_{hr}) \\
+            z_t = \sigma(W_{iz} x_t + b_{iz} + W_{hz} h_{(t-1)} + b_{hz}) \\
             n_t = \tanh(W_{in} x_t + b_{in} + r_t * (W_{hn} h_{(t-1)}+ b_{hn})) \\
             h_t = (1 - z_t) * n_t + z_t * h_{(t-1)} \\
             \end{array}
@@ -532,10 +532,10 @@ class LSTMCell(RNNCellBase):
     .. math::
 
         \begin{array}{ll}
-        i = \mathrm{sigmoid}(W_{ii} x + b_{ii} + W_{hi} h + b_{hi}) \\
-        f = \mathrm{sigmoid}(W_{if} x + b_{if} + W_{hf} h + b_{hf}) \\
+        i = \sigma(W_{ii} x + b_{ii} + W_{hi} h + b_{hi}) \\
+        f = \sigma(W_{if} x + b_{if} + W_{hf} h + b_{hf}) \\
         g = \tanh(W_{ig} x + b_{ig} + W_{hc} h + b_{hg}) \\
-        o = \mathrm{sigmoid}(W_{io} x + b_{io} + W_{ho} h + b_{ho}) \\
+        o = \sigma(W_{io} x + b_{io} + W_{ho} h + b_{ho}) \\
         c' = f * c + i * g \\
         h' = o * \tanh(c') \\
         \end{array}
@@ -613,8 +613,8 @@ class GRUCell(RNNCellBase):
     .. math::
 
         \begin{array}{ll}
-        r = \mathrm{sigmoid}(W_{ir} x + b_{ir} + W_{hr} h + b_{hr}) \\
-        z = \mathrm{sigmoid}(W_{iz} x + b_{iz} + W_{hz} h + b_{hz}) \\
+        r = \sigma(W_{ir} x + b_{ir} + W_{hr} h + b_{hr}) \\
+        z = \sigma(W_{iz} x + b_{iz} + W_{hz} h + b_{hz}) \\
         n = \tanh(W_{in} x + b_{in} + r * (W_{hn} h + b_{hn})) \\
         h' = (1 - z) * n + z * h
         \end{array}


### PR DESCRIPTION
Note:
- changing `mathrm{sigmoid}` to `\sigma` might be controversial, though matches many papers, and matches existing syntax for the functional `glu` function http://pytorch.org/docs/master/nn.html#glu