### PR TITLE
Improve const-correctness of JIT / fix bug where ONNX verbose=1 export says the wrong thing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -410,6 +410,7 @@ main_sources = [
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
     "torch/csrc/jit/passes/common_subexpression_elimination.cpp",
     "torch/csrc/jit/passes/peephole.cpp",
+    "torch/csrc/jit/passes/onnx/peephole.cpp",
     "torch/csrc/jit/generated/aten_dispatch.cpp",
     "torch/csrc/autograd/init.cpp",
     "torch/csrc/autograd/engine.cpp",

--- a/test/expect/TestJit.test_dropout.expect
+++ b/test/expect/TestJit.test_dropout.expect
@@ -1,0 +1,4 @@
+graph(%1 : Double(2, 2)) {
+  %3 : Double(2, 2), %4 : Handle = ^Dropout(0.6, True, False)(%1), uses = [[%0.i0], []];
+  return (%3);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -621,6 +621,11 @@ class TestJit(TestCase):
         trace, _ = torch.jit.trace(nn.BatchNorm2d(2), x)
         self.assertExpected(str(trace))
 
+    def test_dropout(self):
+        x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
+        trace, _ = torch.jit.trace(nn.Dropout(0.6), x)
+        self.assertExpected(str(trace))
+
     @unittest.skip("unrecognized NodeKind: SpatialBN")
     def test_batchnorm_run_twice(self):
         @torch.jit.compile(nderivs=0)

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -501,7 +501,7 @@ struct StageClosure {
 
         // All Eval nodes take context edges as an input, and we need to register
         // all such places
-        auto & inputs = value->inputs();
+        auto inputs = value->inputs();
         JIT_ASSERT(inputs.size() > 0);
         auto handle_input = inputs[inputs.size() - 1];
         JIT_ASSERT(handle_input->type()->kind() == TypeKind::HandleType);

--- a/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
@@ -20,8 +20,8 @@ jit::node_list BatchNormForward::symbolic(SymbolicContext* ctx, jit::node_list i
   auto orig_output = g->appendNode(g->createSelect(bn, 0));
 
   if(this->training) {
-    g->appendNode(g->createSelect(bn, 1)->setType(bn->inputs().at(3)->type()));
-    g->appendNode(g->createSelect(bn, 2)->setType(bn->inputs().at(4)->type()));
+    g->appendNode(g->createSelect(bn, 1)->setType(bn->input(3)->type()));
+    g->appendNode(g->createSelect(bn, 2)->setType(bn->input(4)->type()));
     // dummy output
     for(int i = 3; i < 5; i++) {
       g->appendNode(g->createSelect(bn, i)->setDebugName("batch_norm_dead_output"));

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -220,89 +220,7 @@ void encodeModel(onnx::ModelProto* p_m, const std::shared_ptr<Graph>& g,
   encodeGraph(p_g, g, initializers);
 }
 
-// Broadcasting operators have the following property:
-// They support a 'broadcast' flag, which enables broadcasting
-// on the last argument.  ATM this is not full-Numpy broadcasting,
-// only left-size extension (no size 1 to size n broadcast)
-std::unordered_set<NodeKind> broadcasting = {
-  kAdd,
-  kDiv,
-  kMul,
-  kPow,
-  kSub,
-  kGemm,
-};
-
-bool isBroadcasting(Node *node) {
-  return broadcasting.count(node->kind());
-}
-
-// When iterating over the dimension sizes, starting at the trailing dimension,
-// the dimension sizes must either be equal, or one of them does not exist.
-//
-//  equivalently:
-//
-// Test that 'from' is a suffix of 'to'.
-bool fusibleExpandTo(at::IntList from, at::IntList to) {
-  auto f = from.rbegin();
-  auto t = to.rbegin();
-  for (; f != from.rend() && t != to.rend(); f++, t++) {
-    // TODO: if 1->n expansion is supported, adjust this conditional.
-    if (*f != *t) return false;
-  }
-  return f == from.rend();
-}
-
-// This optimization fuses expand calls into ONNX operators, because it is
-// easier for non-strided backends to more efficiently do broadcasts if this is
-// local information.  This optimization is not useful for PyTorch as 'expand'
-// is free.
-void fuseBroadcast(const std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
-    auto* n = *it;
-
-    // Can't fuse into nodes that don't support broadcasting
-    if (!isBroadcasting(n)) continue;
-
-    // If the node already broadcasts, can't "rebroadcast"
-    // TODO: Actually, maybe you can, if there is a broadcast for some
-    // dims, and then another broadcast for the rest.  But this will
-    // never happen in practice so I didn't implement it.
-    if (n->hasAttribute(kbroadcast) && n->i(kbroadcast)) continue;
-    JIT_ASSERT(!n->hasAttribute(kaxis));
-
-    auto input_index = n->inputs().size() - 1;
-    auto* expanded_rhs = n->inputs().at(input_index);
-
-    // The expanded_rhs input isn't actually an expand, so no fusion available
-    if (expanded_rhs->kind() != kExpand) continue;
-
-    auto* unexpanded_rhs = expanded_rhs->input();
-
-    // We need to know what the type pre-expand is.  We should basically
-    // always have this information (because expands are only ever traced,
-    // not generated from symbolic), but if for some reason we don't
-    // have it, we need to skip.
-    if (!unexpanded_rhs->hasType()) continue;
-
-    // Not all broadcasts are supported by ONNX broadcast.
-    if (!fusibleExpandTo(unexpanded_rhs->type()->expect<TensorType>()->sizes(),    // from
-                         expanded_rhs->type()->expect<TensorType>()->sizes()) // to
-       ) continue;
-
-    n->replaceInput(input_index, unexpanded_rhs);
-    n->i_(kbroadcast, 1);
-    if (expanded_rhs->uses().size() == 0) {
-      expanded_rhs->destroy();
-    }
-  }
-}
-
-
-void standardizeGraph(const std::shared_ptr<Graph>& graph) {
-  // TODO: move this out of here...
-  fuseBroadcast(graph);
-
+void validateGraph(const std::shared_ptr<Graph>& graph) {
   for (auto it = graph->begin(); it != graph->end(); ++it) {
       // Macro'ed so we get a marginally better line number on failed export
 #define FAIL_EXPORT(name) \
@@ -340,7 +258,7 @@ void standardizeGraph(const std::shared_ptr<Graph>& graph) {
 std::string ExportGraph(const std::shared_ptr<Graph>& graph,
                         const std::vector<at::Tensor> & initializers) {
 
-  standardizeGraph(graph);
+  validateGraph(graph);
 
   onnx::ModelProto model_proto;
   // Set up nanopb callbacks and compute the amount of space needed to store

--- a/torch/csrc/jit/graph_node_list.h
+++ b/torch/csrc/jit/graph_node_list.h
@@ -35,6 +35,7 @@ struct generic_graph_node_list_iterator;
 
 struct Node;
 using graph_node_list = generic_graph_node_list<Node>;
+using const_graph_node_list = generic_graph_node_list<const Node>;
 using graph_node_list_iterator = generic_graph_node_list_iterator<Node>;
 using const_graph_node_list_iterator = generic_graph_node_list_iterator<const Node>;
 

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -8,6 +8,7 @@
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
 #include "torch/csrc/jit/passes/peephole.h"
+#include "torch/csrc/jit/passes/onnx/peephole.h"
 
 
 
@@ -39,6 +40,7 @@ void initJITBindings(PyObject *module) {
 
   m.def("_jit_init", loadPythonClasses)
    .def("_jit_pass_onnx", ToONNX)
+   .def("_jit_pass_onnx_peephole", graph_pass<PeepholeOptimizeONNX>)
    .def("_jit_pass_fuse", graph_pass<FuseGraph>)
    .def("_jit_pass_dce", graph_pass<EliminateDeadCode>)
    .def("_jit_pass_cse", graph_pass<EliminateCommonSubexpression>)

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -40,6 +40,11 @@ void printNodeRef(std::ostream & out, const Node * n) {
 
 template <typename T>
 std::ostream& operator<<(std::ostream & out, const std::vector<T> & nodes) {
+  out << at::ArrayRef<T>{nodes};
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
   size_t i = 0;
   for(auto n : nodes) {
     if(i++ > 0)

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -98,9 +98,12 @@ struct EqualNodeCSE {
     if (lhs->stage() != rhs->stage()) return false;
 
     // Check whether the inputs are the same.
-    if (lhs->inputs().size() != rhs->inputs().size()) return false;
+    auto lhs_inputs = lhs->inputs();
+    auto rhs_inputs = rhs->inputs();
 
-    if (!std::equal(lhs->inputs().begin(), lhs->inputs().end(), rhs->inputs().begin())) return false;
+    if (lhs_inputs.size() != rhs_inputs.size()) return false;
+
+    if (!std::equal(lhs_inputs.begin(), lhs_inputs.end(), rhs_inputs.begin())) return false;
 
     // Check the attributes.
     if (!attributesEqualCSE(lhs, rhs)) return false;
@@ -114,9 +117,8 @@ struct EqualNodeCSE {
 // The function implements common subexpression elimination.
 // Since the nodes are visited in topological order, one pass is enough.
 void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
-  auto nodes = graph->nodes();
   std::unordered_set<Node*, HashNodeCSE, EqualNodeCSE> subexprs;
-  for (auto it = nodes.begin(); it != nodes.end(); ++ it) {
+  for (auto it = graph->begin(); it != graph->end(); ++ it) {
     auto node = *it;
     if (node->kind() == kPythonOp
         || node->kind() == kCppOp

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -66,7 +66,7 @@ struct GraphFuser {
 
     // this concat fusion only works when all the inputs are the same size
     // otherwise they cannot partipate in the same map
-    auto sizes = node->inputs().at(0)->type()->expect<TensorType>()->sizes();
+    auto sizes = node->input(0)->type()->expect<TensorType>()->sizes();
     for(auto i : node->inputs()) {
       if(sizes != i->type()->expect<TensorType>()->sizes()){
         return false;

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -113,7 +113,6 @@ struct GraphFuser {
   }
   Node * mergeNodeIntoGroup(Node* group, Node * n) {
     auto & subgraph = getSubgraph(group);
-    auto & inputs = group->inputs();
     // map from nodes in the surrounding graph to parameters in the fusion
     // group's subgraph that correspond to them
     std::unordered_map<Node*,Node*> inputs_map;
@@ -139,6 +138,7 @@ struct GraphFuser {
     // we need to remove it because n is now inside the fusion group
     // remapping nodes that used the input to the newly-merged node
     // n is not an input when the fusion group is empty
+    auto inputs = group->inputs();
     auto it = std::find(inputs.begin(), inputs.end(), n);
     if(it != inputs.end()) {
       size_t p = it - inputs.begin();

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -162,7 +162,8 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     Py_ssize_t input_nr = 0;
     py::tuple py_symbolic_args(1 + op->cconv.size());
     py_symbolic_args[input_nr++] = py::cast(ctx.graph);
-    auto node_it = op->inputs().begin();
+    auto inputs = op->inputs();
+    auto node_it = inputs.begin();
     auto scalar_it = op->scalar_args.begin();
     for (auto arg_type : op->cconv) {
       py::object obj;
@@ -170,7 +171,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
         JIT_ASSERTM(scalar_it != op->scalar_args.end(), "expected too many scalar args");
         obj = py::reinterpret_borrow<py::object>(py::handle((scalar_it++)->get()));
       } else if (arg_type == 't') {
-        JIT_ASSERTM(node_it != op->inputs().end(), "expected too many inputs");
+        JIT_ASSERTM(node_it != inputs.end(), "expected too many inputs");
         obj = py::cast(envFn(*node_it++));
       } else {
         throw std::runtime_error("unexpected calling convention");

--- a/torch/csrc/jit/passes/onnx/README.md
+++ b/torch/csrc/jit/passes/onnx/README.md
@@ -1,0 +1,4 @@
+The optimization passes in this directory work exclusively on ONNX-style IRs,
+e.g., IRs that have had ToONNX applied to them.  ONNX defines operators
+differently from ATen, so there are different opportunities for peephole
+optimization.

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -50,7 +50,7 @@ void fuseBroadcast(std::shared_ptr<Graph>& graph) {
     JIT_ASSERT(!n->hasAttribute(kaxis));
 
     auto input_index = n->inputs().size() - 1;
-    auto* expanded_rhs = n->inputs().at(input_index);
+    auto* expanded_rhs = n->input(input_index);
 
     // The expanded_rhs input isn't actually an expand, so no fusion available
     if (expanded_rhs->kind() != kExpand) continue;

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -1,0 +1,99 @@
+#include "torch/csrc/jit/passes/onnx/peephole.h"
+
+namespace torch { namespace jit {
+
+// Broadcasting operators have the following property:
+// They support a 'broadcast' flag, which enables broadcasting
+// on the last argument.  ATM this is not full-Numpy broadcasting,
+// only left-size extension (no size 1 to size n broadcast)
+std::unordered_set<NodeKind> broadcasting = {
+  kAdd,
+  kDiv,
+  kMul,
+  kPow,
+  kSub,
+  kGemm,
+};
+
+bool isBroadcasting(Node *node) {
+  return broadcasting.count(node->kind());
+}
+
+// When iterating over the dimension sizes, starting at the trailing dimension,
+// the dimension sizes must either be equal, or one of them does not exist.
+//
+//  equivalently:
+//
+// Test that 'from' is a suffix of 'to'.
+bool fusibleExpandTo(at::IntList from, at::IntList to) {
+  auto f = from.rbegin();
+  auto t = to.rbegin();
+  for (; f != from.rend() && t != to.rend(); f++, t++) {
+    // TODO: if 1->n expansion is supported, adjust this conditional.
+    if (*f != *t) return false;
+  }
+  return f == from.rend();
+}
+
+void fuseBroadcast(std::shared_ptr<Graph>& graph) {
+  for (auto it = graph->begin(); it != graph->end(); ++it) {
+    auto* n = *it;
+
+    // Can't fuse into nodes that don't support broadcasting
+    if (!isBroadcasting(n)) continue;
+
+    // If the node already broadcasts, can't "rebroadcast"
+    // TODO: Actually, maybe you can, if there is a broadcast for some
+    // dims, and then another broadcast for the rest.  But this will
+    // never happen in practice so I didn't implement it.
+    if (n->hasAttribute(kbroadcast) && n->i(kbroadcast)) continue;
+    JIT_ASSERT(!n->hasAttribute(kaxis));
+
+    auto input_index = n->inputs().size() - 1;
+    auto* expanded_rhs = n->inputs().at(input_index);
+
+    // The expanded_rhs input isn't actually an expand, so no fusion available
+    if (expanded_rhs->kind() != kExpand) continue;
+
+    auto* unexpanded_rhs = expanded_rhs->input();
+
+    // We need to know what the type pre-expand is.  We should basically
+    // always have this information (because expands are only ever traced,
+    // not generated from symbolic), but if for some reason we don't
+    // have it, we need to skip.
+    if (!unexpanded_rhs->hasType()) continue;
+
+    // Not all broadcasts are supported by ONNX broadcast.
+    if (!fusibleExpandTo(unexpanded_rhs->type()->expect<TensorType>()->sizes(), // from
+                         expanded_rhs->type()->expect<TensorType>()->sizes())   // to
+       ) continue;
+
+    n->replaceInput(input_index, unexpanded_rhs);
+    n->i_(kbroadcast, 1);
+    if (expanded_rhs->uses().size() == 0) {
+      expanded_rhs->destroy();
+    }
+  }
+}
+
+// This optimization does ONNX-specific peephole optimizations.
+//
+// At the moment, here are the optimizations it does:
+//  - This optimization fuses expand calls into ONNX operators, because it is
+//    easier for non-strided backends to more efficiently do broadcasts if this is
+//    local information.  This optimization is not useful for PyTorch as 'expand'
+//    is free.
+//
+// Before you write an optimization here, ask yourself, "Could I do this
+// optimization on ATen operators"?  If so, you should seriously consider
+// writing your optimization in jit/passes/peephole.cpp rather than
+// here, as it will be generally applicable to the JIT as well.  The
+// optimizations here are ONLY applied on ONNX update
+void PeepholeOptimizeONNX(std::shared_ptr<Graph>& graph) {
+  // TODO: decide on fixpoint strategy
+  // TODO: make it easier not to do O(k) iterations over the graph, where
+  // k is the number of distinct peephole optimizations
+  fuseBroadcast(graph);
+}
+
+}}

--- a/torch/csrc/jit/passes/onnx/peephole.h
+++ b/torch/csrc/jit/passes/onnx/peephole.h
@@ -1,0 +1,7 @@
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+void PeepholeOptimizeONNX(std::shared_ptr<Graph>& graph);
+
+}}

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -10,7 +10,7 @@ namespace torch { namespace jit {
 //
 // TODO: Decide what kind of fixed point strategy we will have
 void PeepholeOptimize(std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->nodes().begin(); it != graph->nodes().end(); ++it) {
+  for (auto it = graph->begin(); it != graph->end(); ++it) {
     auto* n = *it;
 
     if (n->kind() == kexpand) {

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -83,5 +83,16 @@ public:
   }
 };
 
+// See https://github.com/pybind/pybind11/issues/637
+using ListCasterBase = pybind11::detail::list_caster<std::vector<torch::jit::Node *>, torch::jit::Node *>;
+template<> struct type_caster<std::vector<torch::jit::Node *>> : ListCasterBase {
+    static handle cast(const std::vector<torch::jit::Node *> &src, return_value_policy, handle parent) {
+        return ListCasterBase::cast(src, return_value_policy::reference, parent);
+    }
+    static handle cast(const std::vector<torch::jit::Node *> *src, return_value_policy pol, handle parent) {
+        return cast(*src, pol, parent);
+    }
+};
+
 }} // namespace pybind11::detail
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -21,8 +21,12 @@ void initPythonIRBindings(PyObject * module_) {
       ss << g;
       return ss.str();
     })
-    .def("inputs",[](Graph &g) { return g.inputs(); })
-    .def("outputs",[](Graph &g) { return g.outputs(); })
+    .def("inputs",[](Graph &g) {
+      return py::make_iterator(g.inputs().begin(), g.inputs().end());
+    })
+    .def("outputs",[](Graph &g) {
+      return py::make_iterator(g.outputs().begin(), g.outputs().end());
+    })
     // TODO: Iterator invalidation might make this hazardous
     .def("nodes",[](Graph &g) {
       return py::make_iterator(g.begin(), g.end());
@@ -76,9 +80,14 @@ void initPythonIRBindings(PyObject * module_) {
     .NS(uniqueName)
     .NS(setStage)
     .NS(stage)
-    .def("inputs",[](Node &n) { return n.inputs(); })
+    .def("inputs",[](Node &n) {
+      return py::make_iterator(n.inputs().begin(), n.inputs().end());
+    })
+    // NB: outputs on Node returns a COPY.  So we better not make_iterator
+    // on a temporary!
     .def("outputs",[](Node &n) { return n.outputs(); })
     .def("input",[](Node &n) { return n.input(); })
+    .def("input",[](Node &n, size_t i) { return n.input(i); })
     .NS(offset)
     .NS(uses)
     .NS(addInput)

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -21,10 +21,11 @@ void initPythonIRBindings(PyObject * module_) {
       ss << g;
       return ss.str();
     })
-    .GS(inputs)
-    .GS(outputs)
+    .def("inputs",[](Graph &g) { return g.inputs(); })
+    .def("outputs",[](Graph &g) { return g.outputs(); })
+    // TODO: Iterator invalidation might make this hazardous
     .def("nodes",[](Graph &g) {
-      return py::make_iterator(g.nodes().begin(),g.nodes().end());
+      return py::make_iterator(g.begin(), g.end());
     })
     .def("addInput",[](Graph &g) { return g.addInput(); })
     .GS(advanceStage)
@@ -75,9 +76,9 @@ void initPythonIRBindings(PyObject * module_) {
     .NS(uniqueName)
     .NS(setStage)
     .NS(stage)
-    .NS(inputs)
-    .NS(input)
-    .NS(outputs)
+    .def("inputs",[](Node &n) { return n.inputs(); })
+    .def("outputs",[](Node &n) { return n.outputs(); })
+    .def("input",[](Node &n) { return n.input(); })
     .NS(offset)
     .NS(uses)
     .NS(addInput)

--- a/torch/csrc/utils/functional.h
+++ b/torch/csrc/utils/functional.h
@@ -4,8 +4,12 @@
 
 namespace torch {
 
+// NB: Order matters.  If you put the forwarding definitions before
+// the actual implementations, C++ will resolve the overload to
+// itself, because there's an implicit conversion to vector in ArrayRef.
+
 template<typename F, typename T, typename R = typename std::result_of<F(T)>::type>
-inline std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
+inline std::vector<R> fmap(at::ArrayRef<T> inputs, const F& fn) {
   std::vector<R> r;
   r.reserve(inputs.size());
   for(auto & input : inputs)
@@ -13,9 +17,13 @@ inline std::vector<R> fmap(const std::vector<T> & inputs, const F& fn) {
   return r;
 }
 
-// C++ forbids taking an address of a constructor, so here's a workaround...
+template<typename F, typename T, typename R = typename std::result_of<F(T)>::type>
+inline std::vector<R> fmap(const std::vector<T>& inputs, const F& fn) {
+  return fmap<F, T, R>(static_cast<at::ArrayRef<T>>(inputs), fn);
+}
+
 template<typename R, typename T>
-inline std::vector<R> fmap(const std::vector<T> & inputs) {
+inline std::vector<R> fmap(at::ArrayRef<T> inputs) {
   std::vector<R> r;
   r.reserve(inputs.size());
   for(auto & input : inputs)
@@ -23,8 +31,14 @@ inline std::vector<R> fmap(const std::vector<T> & inputs) {
   return r;
 }
 
+// C++ forbids taking an address of a constructor, so here's a workaround...
+template<typename R, typename T>
+inline std::vector<R> fmap(const std::vector<T>& inputs) {
+  return fmap<R, T>(static_cast<at::ArrayRef<T>>(inputs));
+}
+
 template<typename F, typename T>
-inline std::vector<T> filter(const std::vector<T> & inputs, const F& fn) {
+inline std::vector<T> filter(at::ArrayRef<T> inputs, const F& fn) {
   std::vector<T> r;
   r.reserve(inputs.size());
   for(auto & input : inputs) {
@@ -33,6 +47,11 @@ inline std::vector<T> filter(const std::vector<T> & inputs, const F& fn) {
     }
   }
   return r;
+}
+
+template<typename F, typename T>
+inline std::vector<T> filter(const std::vector<T>& inputs, const F& fn) {
+  return filter<F, T>(static_cast<at::ArrayRef<T>>(inputs), fn);
 }
 
 }

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -96,9 +96,12 @@ def _export(model, args, f, export_params=True, verbose=False, training=False):
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
+    # TODO: write a helper function
     torch._C._jit_pass_peephole(trace)
     torch._C._jit_pass_lint(trace)
     torch._C._jit_pass_onnx(trace)
+    torch._C._jit_pass_lint(trace)
+    torch._C._jit_pass_onnx_peephole(trace)
     torch._C._jit_pass_lint(trace)
     torch._C._jit_pass_dce(trace)
     torch._C._jit_pass_lint(trace)


### PR DESCRIPTION
This started off as a minor fix based on Adam's question, "why is printing
a graph not const" and snowballed into a giant yak shaving exercise.

- The Graph and Node APIs now uniformly enforce deep constness; e.g., if you
  get a const Node* or const Graph*, it is not possible to get a non-const
  Node*/Graph* somewhere else in the graph (even though the member variables
  of these are non-const.  Hooray for private access specifier.)

- A big pile of functions got const versions, most notably the printing
  functions, and functions for accessing inputs().

- REALLY IMPORTANT, BC-BREAKING CHANGE: inputs() now returns a COPY of the
  inputs, rather than a reference to the underlying.  I was forced to do this
  because there is no way to portably turn a std::vector<Node*> into a
  std::vector<const Node*>, which is necessary to provide a const-correct
  version of inputs() that enforces deep const-correctness.  I then justified
  this choice to myself with the observation that outputs() returned a
  copy (by necessity), so this makes the API more uniform.

  But making this change uncovered two very subtle bugs:

    1. If you change functions from returning a reference to returning a copy,
       the idiom node->inputs().begin() is no longer valid, because the memory
       the iterator points to immediately becomes invalid.  THIS SUCKS.
       Honestly, we should add a lint rule rejecting calling begin()/end() on
       temporaries because this is very dangerous.  To excise this pattern from
       the codebase, I added begin() and end() methods to Graph, so that we got
       rid of the graph->nodes().begin() idiom, which happens to be sound,
       despite not returning a reference, because graph_node_list is a
       non-owning reference.

    2. pybind11 doesn't handle std::vector<Node*> cast out of the box.
       Fortunately, I found a simple fix in the GitHub issues tracker
       that involved adding an extra type converter.  And yes, this
       does mean that outputs() in Python never worked correctly.

- New const_graph_node_list, which is a graph_node_list that gives you const
  Node*

There are some more miscellaneous improvements:

- Applied CR comment fixes on export.cpp; using replaceInput, and renaming
  variables for clarity.

- assertValidInput helper method added, and applied to replaceInput

Signed-off-by: Edward Z. Yang <ezyang@fb.com>