### PR TITLE
Add docs for ByteTensor any()/all()

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -311,3 +311,10 @@ view of a storage and defines numeric operations on it.
    .. automethod:: view
    .. automethod:: view_as
    .. automethod:: zero_
+
+.. class:: ByteTensor()
+
+   The following methods are unique to :class:`torch.ByteTensor`.
+
+   .. automethod:: all
+   .. automethod:: any

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -150,6 +150,20 @@ addr_(beta=1, alpha=1, vec1, vec2) -> Tensor
 In-place version of :meth:`~Tensor.addr`
 """)
 
+add_docstr_all('all',
+               """
+all() -> bool
+
+Returns True if all elements in the tensor are non-zero, False otherwise.
+""")
+
+add_docstr_all('any',
+               """
+any() -> bool
+
+Returns True if any elements in the tensor are non-zero, False otherwise.
+""")
+
 add_docstr_all('apply_',
                """
 apply_(callable) -> Tensor


### PR DESCRIPTION
Addresses #2586. Adds a docstring to the any and all methods for ByteTensor and reveals it in html docs.

### Test Plan
Check the docstring exists in the interpreter:
```
import torch
x = torch.randn(4).byte()
help(x.all)  # assert this returns the docstring
help(x.any)  # assert this returns the docstring
```

Build the sphinx docs and check that the any/all functions appear.
![image](https://user-images.githubusercontent.com/5652049/32180339-1023be0e-bd68-11e7-851f-4ba8b68c2525.png)
