### PR TITLE
Pretty names: support names set via export or Variable constructor

### DIFF
--- a/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
@@ -30,7 +30,8 @@ jit::value_list BatchNormForward::symbolic(
     bn->addOutput()->setType(bn->input(4)->type());
     // dummy output
     for(int i = 3; i < 5; i++) {
-      bn->addOutput()->setDebugName("batch_norm_dead_output");
+      auto o = bn->addOutput();
+      o->setUniqueName("batch_norm_dead_output-" + o->uniqueName());
     }
   }
   bn->is_(jit::kconsumed_inputs,{0,0,0,1,1});

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -86,6 +86,9 @@ struct Variable : public at::Tensor {
   inline bool is_view() const;
   inline Variable& base() const;
 
+  inline const std::string& name() const;
+  inline       std::string& name();
+
   inline Variable & operator=(Variable && rhs) &;
   inline Variable & operator=(const Variable & rhs) &;
   inline Variable & operator=(Tensor && rhs) &;
@@ -132,6 +135,8 @@ public:
   // correctly when this variable is passed to another function.
   int output_nr;
   PyObject *pyobj;  // weak reference
+
+  std::string name;
 
   // For use in torch::jit::tracer
   auto_unique_ptr<jit::tracer::ValueTracingState> tracing_state;
@@ -270,6 +275,13 @@ inline const bool& Variable::requires_grad() const {
 }
 inline bool& Variable::requires_grad() {
   return get()->requires_grad;
+}
+
+inline const std::string& Variable::name() const {
+  return get()->name;
+}
+inline std::string& Variable::name() {
+  return get()->name;
 }
 
 inline const bool& Variable::is_volatile() const {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -76,10 +76,9 @@ void initPythonIRBindings(PyObject * module_) {
     .VS(inferTypeFrom)
     // skip owningGraph because it returns a raw pointer to a otherwise
     // std::shared_ptr stored graph object, and would cause a double free
-    .VS(debugName)
-    .VS(setDebugName)
     .VS(unique)
     .VS(uniqueName)
+    .VS(setUniqueName)
     .VS(setStage)
     .VS(stage)
     .VS(offset)

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -186,7 +186,7 @@ inline std::shared_ptr<TracingState> enter(std::vector<TraceInput>&& trace_input
     if (trace_input.variable.defined()) {
       JIT_ASSERT(!trace_input.buffer.defined());
       auto& input = trace_input.variable;
-      auto input_node = state->graph->addInput();
+      auto input_node = state->graph->addInput(input.name());
       setValueTrace(state, input, input_node);
       input_node->inferTypeFrom(input.data());
       inputs.push_back(input);


### PR DESCRIPTION
Add an argument to the Variable constructor in python. When supplied,
this string will be used as the unique name of the operator, rather
than an integer taken from a global counter. When provided, these names
must be unique among all Variables in the graph.