### PR TITLE
Blas zero stride checks

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -35,6 +35,104 @@ class TestTorch(TestCase):
                 res2 += i * j
             self.assertEqual(res1, res2)
 
+        # Test 0-strided
+        for tname, _prec in types.items():
+            v1 = torch.randn(1).type(tname).expand(100)
+            v2 = torch.randn(100).type(tname)
+            res1 = torch.dot(v1, v2)
+            res2 = 0
+            for i, j in zip(v1, v2):
+                res2 += i * j
+            self.assertEqual(res1, res2)
+
+    def test_ger(self):
+        types = {
+            'torch.DoubleTensor': 1e-8,
+            'torch.FloatTensor': 1e-4,
+        }
+        for tname, _prec in types.items():
+            v1 = torch.randn(100).type(tname)
+            v2 = torch.randn(100).type(tname)
+            res1 = torch.ger(v1, v2)
+            res2 = torch.zeros(100, 100).type(tname)
+            for i in range(100):
+                for j in range(100):
+                    res2[i, j] = v1[i] * v2[j]
+            self.assertEqual(res1, res2)
+
+        # Test 0-strided
+        for tname, _prec in types.items():
+            v1 = torch.randn(1).type(tname).expand(100)
+            v2 = torch.randn(100).type(tname)
+            res1 = torch.ger(v1, v2)
+            res2 = torch.zeros(100, 100).type(tname)
+            for i in range(100):
+                for j in range(100):
+                    res2[i, j] = v1[i] * v2[j]
+            self.assertEqual(res1, res2)
+
+    def test_addmv(self):
+        types = {
+            'torch.DoubleTensor': 1e-8,
+            'torch.FloatTensor': 1e-4,
+        }
+        for tname, _prec in types.items():
+            t = torch.randn(10).type(tname)
+            m = torch.randn(10, 100).type(tname)
+            v = torch.randn(100).type(tname)
+            res1 = torch.addmv(t, m, v)
+            res2 = torch.zeros(10).type(tname)
+            res2 += t
+            for i in range(10):
+                for j in range(100):
+                    res2[i] += m[i, j] * v[j]
+            self.assertEqual(res1, res2)
+
+        # Test 0-strided
+        for tname, _prec in types.items():
+            t = torch.randn(1).type(tname).expand(10)
+            m = torch.randn(10, 1).type(tname).expand(10, 100)
+            v = torch.randn(100).type(tname)
+            res1 = torch.addmv(t, m, v)
+            res2 = torch.zeros(10).type(tname)
+            res2 += t
+            for i in range(10):
+                for j in range(100):
+                    res2[i] += m[i, j] * v[j]
+            self.assertEqual(res1, res2)
+
+    def test_addmm(self):
+        types = {
+            'torch.DoubleTensor': 1e-8,
+            'torch.FloatTensor': 1e-4,
+        }
+        for tname, _prec in types.items():
+            M = torch.randn(10, 25).type(tname)
+            m1 = torch.randn(10, 50).type(tname)
+            m2 = torch.randn(50, 25).type(tname)
+            res1 = torch.addmm(M, m1, m2)
+            res2 = torch.zeros(10, 25).type(tname)
+            res2 += M
+            for i in range(10):
+                for j in range(25):
+                    for k in range(50):
+                        res2[i, j] += m1[i, k] * m2[k, j]
+            self.assertEqual(res1, res2)
+
+        # Test 0-strided
+        for tname, _prec in types.items():
+            M = torch.randn(10, 1).type(tname).expand(10, 25)
+            m1 = torch.randn(10, 1).type(tname).expand(10, 50)
+            m2 = torch.randn(50, 25).type(tname)
+            res1 = torch.addmm(M, m1, m2)
+            res2 = torch.zeros(10, 25).type(tname)
+            res2 += M
+            for i in range(10):
+                for j in range(25):
+                    for k in range(50):
+                        res2[i, j] += m1[i, k] * m2[k, j]
+            self.assertEqual(res1, res2)
+
     def _testMath(self, torchfn, mathfn):
         size = (10, 5)
         # contiguous

--- a/torch/lib/TH/generic/THBlas.c
+++ b/torch/lib/TH/generic/THBlas.c
@@ -202,7 +202,7 @@ void THBlas_(gemv)(char trans, int64_t m, int64_t n, real alpha, real *a, int64_
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
   if( (m <= INT_MAX) && (n <= INT_MAX) &&
-      (lda > 0) && (lda <= INT_MAX) &&
+      (lda >= THMax(1, n)) && (lda <= INT_MAX) &&
       (incx > 0) && (incx <= INT_MAX) &&
       (incy > 0) && (incy <= INT_MAX) )
   {
@@ -259,7 +259,10 @@ void THBlas_(ger)(int64_t m, int64_t n, real alpha, real *x, int64_t incx, real 
     lda = m;
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
-  if( (m <= INT_MAX) && (n <= INT_MAX) && (lda <= INT_MAX)  && (incx <= INT_MAX) && (incy <= INT_MAX) )
+  if( (m <= INT_MAX) && (n <= INT_MAX) &&
+      (lda >= THMax(1, n)) && (lda <= INT_MAX) &&
+      (incx > 0) && (incx <= INT_MAX) &&
+      (incy > 0) && (incy <= INT_MAX) )
   {
     int i_m = (int)m;
     int i_n = (int)n;
@@ -318,7 +321,10 @@ void THBlas_(gemm)(char transa, char transb, int64_t m, int64_t n, int64_t k, re
   }
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
-  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (lda <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) &&
+      (lda >= THMax(1, (transa_ ? m : k))) && (lda <= INT_MAX) &&
+      (ldb >= THMax(1, (transb_ ? k : n))) && (ldb <= INT_MAX) &&
+      (ldc >= THMax(1, n)) && (ldc <= INT_MAX) )
   {
     int i_m = (int)m;
     int i_n = (int)n;


### PR DESCRIPTION
Add some checks to the BLAS bindings not to use it for strides that are not supported (according to MKL documentation).

Fixes #3303 .