### PR TITLE
if git is not installed at all, no subprocess exception will be raised

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -615,7 +615,7 @@ else:
     try:
         sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=cwd).decode('ascii').strip()
         version += '+' + sha[:7]
-    except subprocess.CalledProcessError:
+    except Exception:
         pass
 
 cmdclass = {


### PR DESCRIPTION
subprocess crashes with different exception is "git" binary is not installed at all.