### PR TITLE
Implement reduce keyword for SmoothL1Loss

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -308,6 +308,13 @@ def smoothl1loss_reference(input, target, size_average=True, reduce=True):
     return output
 
 
+loss_reference_fns = {
+    'NLLLoss': nllloss_reference,
+    'NLLLoss2d': nllloss2d_reference,
+    'SmoothL1Loss': smoothl1loss_reference,
+}
+
+
 criterion_tests = [
     dict(
         module_name='L1Loss',

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -296,6 +296,18 @@ def nllloss_reference(input, target, weight=None, ignore_index=-100,
         return losses_tensor
 
 
+def smoothl1loss_reference(input, target, size_average=True, reduce=True):
+    abs_diff = (input - target).abs()
+    ge_one_mask = (abs_diff >= 1).type_as(abs_diff)
+    lt_one_mask = (abs_diff < 1).type_as(abs_diff)
+    output = ge_one_mask * (abs_diff - 0.5) + lt_one_mask * 0.5 * (abs_diff ** 2)
+    if reduce and size_average:
+        return output.mean()
+    elif reduce:
+        return output.sum()
+    return output
+
+
 criterion_tests = [
     dict(
         module_name='L1Loss',
@@ -457,6 +469,8 @@ criterion_tests = [
         input_size=(5, 10),
         target_size=(5, 10),
         check_no_size_average=True,
+        reference_fn=lambda i, t, m:
+            smoothl1loss_reference(i, t, size_average=get_size_average(m)),
     ),
     dict(
         module_name='SoftMarginLoss',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,7 +27,8 @@ from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
-    TEST_CUDNN_VERSION, nllloss_reference, nllloss2d_reference
+    TEST_CUDNN_VERSION, nllloss_reference, nllloss2d_reference, \
+    smoothl1loss_reference
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
     TEST_SCIPY, download_file
 
@@ -3797,6 +3798,18 @@ def nllloss2d_no_reduce_weights_test():
         pickle=False)
 
 
+def smoothl1loss_no_reduce_test():
+    t = Variable(torch.randn(2, 3, 4))
+    return dict(
+        fullname='SmoothL1Loss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.smooth_l1_loss(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.randn(2, 3, 4),
+        reference_fn=lambda i, _:
+            smoothl1loss_reference(i, t.data.type_as(i), reduce=False),
+        pickle=False)
+
+
 new_module_tests = [
     mseloss_no_reduce_test(),
     nllloss_no_reduce_test(),
@@ -3807,6 +3820,7 @@ new_module_tests = [
     nllloss2d_no_reduce_test(),
     nllloss2d_no_reduce_weights_test(),
     nllloss2d_no_reduce_ignore_index_test(),
+    smoothl1loss_no_reduce_test(),
     dict(
         module_name='BatchNorm1d',
         constructor_args=(10,),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,8 +27,7 @@ from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
-    TEST_CUDNN_VERSION, nllloss_reference, nllloss2d_reference, \
-    smoothl1loss_reference
+    TEST_CUDNN_VERSION, loss_reference_fns
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
     TEST_SCIPY, download_file
 
@@ -3685,7 +3684,7 @@ def nllloss_no_reduce_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs)),
         input_fn=lambda: torch.rand(15, 10).log(),
         reference_fn=lambda i, _:
-            nllloss_reference(i, t.type_as(i).long(), **kwargs),
+            loss_reference_fns['NLLLoss'](i, t.type_as(i).long(), **kwargs),
         pickle=False)
 
 
@@ -3698,7 +3697,7 @@ def nllloss_no_reduce_ignore_index_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs)),
         input_fn=lambda: torch.rand(15, 10).log(),
         reference_fn=lambda i, _:
-            nllloss_reference(i, t.type_as(i).long(), **kwargs),
+            loss_reference_fns['NLLLoss'](i, t.type_as(i).long(), **kwargs),
         pickle=False)
 
 
@@ -3715,7 +3714,7 @@ def nllloss_no_reduce_weights_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs(i.data))),
         input_fn=lambda: torch.rand(15, 10).add(1e-2).log(),
         reference_fn=lambda i, _:
-            nllloss_reference(i, t.type_as(i).long(), **kwargs(i)),
+            loss_reference_fns['NLLLoss'](i, t.type_as(i).long(), **kwargs(i)),
         pickle=False)
 
 
@@ -3733,7 +3732,7 @@ def nllloss_no_reduce_weights_ignore_index_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs(i.data))),
         input_fn=lambda: torch.rand(15, 10).add(1e-2).log(),
         reference_fn=lambda i, _:
-            nllloss_reference(i, t.type_as(i).long(), **kwargs(i)),
+            loss_reference_fns['NLLLoss'](i, t.type_as(i).long(), **kwargs(i)),
         pickle=False)
 
 
@@ -3751,7 +3750,7 @@ def nllloss_no_reduce_weights_ignore_index_neg_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs(i.data))),
         input=torch.rand(15, 10).add(1e-2).log(),
         reference_fn=lambda i, _:
-            nllloss_reference(i, t.type_as(i).long(), **kwargs(i)),
+            loss_reference_fns['NLLLoss'](i, t.type_as(i).long(), **kwargs(i)),
         pickle=False)
 
 
@@ -3764,7 +3763,7 @@ def nllloss2d_no_reduce_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs)),
         input_fn=lambda: torch.rand(2, 3, 5, 5).log(),
         reference_fn=lambda i, _:
-            nllloss2d_reference(i, t.type_as(i).long(), **kwargs),
+            loss_reference_fns['NLLLoss2d'](i, t.type_as(i).long(), **kwargs),
         pickle=False)
 
 
@@ -3777,7 +3776,7 @@ def nllloss2d_no_reduce_ignore_index_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs)),
         input_fn=lambda: torch.rand(2, 3, 5, 5).log(),
         reference_fn=lambda i, _:
-            nllloss2d_reference(i, t.type_as(i).long(), **kwargs),
+            loss_reference_fns['NLLLoss2d'](i, t.type_as(i).long(), **kwargs),
         pickle=False)
 
 
@@ -3794,7 +3793,7 @@ def nllloss2d_no_reduce_weights_test():
             lambda i: F.nll_loss(i, t.type_as(i).long(), **kwargs(i.data))),
         input_fn=lambda: torch.rand(2, 3, 5, 5).log(),
         reference_fn=lambda i, _:
-            nllloss2d_reference(i, t.type_as(i).long(), **kwargs(i)),
+            loss_reference_fns['NLLLoss2d'](i, t.type_as(i).long(), **kwargs(i)),
         pickle=False)
 
 
@@ -3806,7 +3805,7 @@ def smoothl1loss_no_reduce_test():
             lambda i: F.smooth_l1_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(2, 3, 4),
         reference_fn=lambda i, _:
-            smoothl1loss_reference(i, t.data.type_as(i), reduce=False),
+            loss_reference_fns['SmoothL1Loss'](i, t.data.type_as(i), reduce=False),
         pickle=False)
 
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -613,8 +613,9 @@
   grad_output: rrelu_backward(grad, input, lower, upper, training, false, noise)
   input: zeros_like(grad)
 
-- name: smooth_l1_loss_backward(Tensor input, Tensor target, bool size_average)
-  input: smooth_l1_loss_double_backward(grad, input, target, size_average)
+- name: smooth_l1_loss_backward(Tensor grad_output, Tensor input, Tensor target, bool size_average, bool reduce)
+  grad_output: smooth_l1_loss_double_backward_grad_output(grad, grad_output, input, target, size_average, reduce)
+  input: smooth_l1_loss_double_backward(grad * grad_output, input, target, size_average, reduce)
 
 - name: softplus_backward(Tensor grad_output, Tensor input, Scalar beta, Scalar threshold, Tensor output)
   grad_output: softplus_backward(grad, input, beta, threshold, output)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -325,13 +325,21 @@ Tensor log_softmax_double_backward(const Tensor & grad, const Tensor & grad_outp
   return z * grad_output.sum(dim, true) * ((grad * z).sum(dim, true) - grad);
 }
 
-Tensor smooth_l1_loss_double_backward(const Tensor & grad, const Tensor & input, const Tensor & target, bool size_average) {
+Tensor smooth_l1_loss_double_backward(const Tensor & grad, const Tensor & input, const Tensor & target, bool size_average, bool reduce) {
   auto d = (input - target).abs();
   auto grad_input = grad * (d < 1).toType(grad.type());
-  if (size_average) {
+  if (size_average && reduce) {
     grad_input /= input.numel();
   }
   return grad_input;
+}
+
+Tensor smooth_l1_loss_double_backward_grad_output(const Tensor & grad, const Tensor & grad_output, const Tensor & input, const Tensor & target, bool size_average, bool reduce) {
+  if (!reduce) {
+    return smooth_l1_loss_backward(grad, input, target, size_average, reduce);
+  }
+  auto r = smooth_l1_loss_backward(ones_like(grad_output), input, target, size_average, true);
+  return (r * grad).sum().toTensor().view({1});
 }
 
 Tensor max_pool2d_double_backward(const Tensor & grad, const Tensor & indices) {

--- a/torch/legacy/nn/SmoothL1Criterion.py
+++ b/torch/legacy/nn/SmoothL1Criterion.py
@@ -17,17 +17,21 @@ class SmoothL1Criterion(Criterion):
             input,
             target,
             self.output_tensor,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         self.output = self.output_tensor[0]
         return self.output
 
     def updateGradInput(self, input, target):
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.SmoothL1Criterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         return self.gradInput

--- a/torch/lib/ATen/nn.yaml
+++ b/torch/lib/ATen/nn.yaml
@@ -27,7 +27,7 @@
   cname: SpatialClassNLLCriterion
   buffers: [total_weight]
 
-- name: smooth_l1_loss(Tensor input, Tensor target, bool size_average=true)
+- name: smooth_l1_loss(Tensor input, Tensor target, bool size_average=true, bool reduce=true)
   cname: SmoothL1Criterion
 
 - name: soft_margin_loss(Tensor input, Tensor target, bool size_average=true)

--- a/torch/lib/THCUNN/SmoothL1Criterion.cu
+++ b/torch/lib/THCUNN/SmoothL1Criterion.cu
@@ -26,11 +26,11 @@ struct smoothl1_functor
 };
 
 template <typename Dtype>
-struct smoothl1_update_functor
+struct smoothl1_updateOutput_no_reduce_functor
 {
-  smoothl1_update_functor() {}
+  smoothl1_updateOutput_no_reduce_functor() {}
 
-  __host__ __device__ void operator()(
+  __forceinline__ __host__ __device__ void operator()(
       const Dtype *x, 
       const Dtype *y,
       Dtype *out) const
@@ -65,21 +65,12 @@ struct smoothl1_updateGradInput_no_reduce_functor
 };
 
 template <typename Dtype>
-struct multiply_and_store_functor
-{
-  __host__ __device__ void operator()(const Dtype *x, Dtype *y)
-  {
-    *y *= *x;
-  }
-};
-
-template <typename Dtype>
 struct smoothl1_updateGradInput_functor
 {
   const Dtype norm;
-  const Dtype *gradOutput;
+  const Dtype gradOutput;
 
-  smoothl1_updateGradInput_functor(Dtype norm_, Dtype *gradOutput_)
+  smoothl1_updateGradInput_functor(Dtype norm_, Dtype gradOutput_)
     : norm(norm_), gradOutput(gradOutput_)
   {}
 
@@ -87,11 +78,11 @@ struct smoothl1_updateGradInput_functor
   {
     Dtype z = x - y;
     if (z < ScalarConvert<int, Dtype>::to(-1))
-      return -norm * *gradOutput;
+      return -norm * gradOutput;
     else if (z > ScalarConvert<int, Dtype>::to(1))
-      return norm * *gradOutput;
+      return norm * gradOutput;
     else
-      return norm * z * *gradOutput;
+      return norm * z * gradOutput;
   }
 };
 

--- a/torch/lib/THCUNN/SmoothL1Criterion.cu
+++ b/torch/lib/THCUNN/SmoothL1Criterion.cu
@@ -26,23 +26,72 @@ struct smoothl1_functor
 };
 
 template <typename Dtype>
+struct smoothl1_update_functor
+{
+  smoothl1_update_functor() {}
+
+  __host__ __device__ void operator()(
+      const Dtype *x, 
+      const Dtype *y,
+      Dtype *out) const
+  {
+    Dtype oneHalf = ScalarConvert<float, Dtype>::to(0.5f);
+    Dtype z = THCNumerics<Dtype>::abs(*x - *y);
+    *out = z < ScalarConvert<int, Dtype>::to(1) ? oneHalf * z * z : z - oneHalf;
+  }
+};
+
+template <typename Dtype>
+struct smoothl1_updateGradInput_no_reduce_functor
+{
+  smoothl1_updateGradInput_no_reduce_functor() {}
+
+  __host__ __device__ void operator()(
+      const Dtype *x, 
+      const Dtype *y,
+      Dtype *gradInput) const
+  {
+    Dtype z = *x - *y;
+    Dtype one = ScalarConvert<int, Dtype>::to(1);
+    Dtype minusOne = ScalarConvert<int, Dtype>::to(-1);
+    if (z < minusOne) {
+      *gradInput = minusOne;
+    } else if (z > one) {
+      *gradInput = one;
+    } else {
+      *gradInput = z;
+    }
+  }
+};
+
+template <typename Dtype>
+struct multiply_and_store_functor
+{
+  __host__ __device__ void operator()(const Dtype *x, Dtype *y)
+  {
+    *y *= *x;
+  }
+};
+
+template <typename Dtype>
 struct smoothl1_updateGradInput_functor
 {
   const Dtype norm;
+  const Dtype *gradOutput;
 
-  smoothl1_updateGradInput_functor(Dtype norm_)
-    : norm(norm_)
+  smoothl1_updateGradInput_functor(Dtype norm_, Dtype *gradOutput_)
+    : norm(norm_), gradOutput(gradOutput_)
   {}
 
   __host__ __device__ Dtype operator()(const Dtype &x, const Dtype &y) const
   {
     Dtype z = x - y;
     if (z < ScalarConvert<int, Dtype>::to(-1))
-      return -norm;
+      return -norm * *gradOutput;
     else if (z > ScalarConvert<int, Dtype>::to(1))
-      return norm;
+      return norm * *gradOutput;
     else
-      return norm * z;
+      return norm * z * *gradOutput;
   }
 };
 

--- a/torch/lib/THCUNN/generic/SmoothL1Criterion.cu
+++ b/torch/lib/THCUNN/generic/SmoothL1Criterion.cu
@@ -2,20 +2,31 @@
 #define THC_GENERIC_FILE "generic/SmoothL1Criterion.cu"
 #else
 
+#include "THCApply.cuh"
+
 void THNN_(SmoothL1Criterion_updateOutput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
            THCTensor *output,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCTensor_(resize1d)(state, output, 1);
-  THCUNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 3, input, target, output);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
     "input and target need to have the same number of elements"
   );
+
+  if (!reduce) {
+    THCTensor_(resizeAs)(state, output, input);
+    THC_pointwiseApply3(state, input, target, output,
+                        smoothl1_update_functor<real>());
+    return;
+  }
+
+  THCTensor_(resize1d)(state, output, 1);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
 
@@ -46,23 +57,36 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
     "input and target need to have the same number of elements"
   );
+
+  THCTensor_(resizeAs)(state, gradInput, input);
+
+  if (!reduce) {
+    THCUNN_check_nElement(state, gradOutput, input);
+    THC_pointwiseApply3(state, input, target, gradInput,
+                        smoothl1_updateGradInput_no_reduce_functor<real>());
+    THC_pointwiseApply2(state, gradOutput, gradInput,
+                        multiply_and_store_functor<real>());
+    return;
+  }
+
+  THCUNN_check_dim_size(state, gradOutput, 1, 0, 1);
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
   real norm = ScalarConvert<accreal, real>::to(sizeAverage ? accreal(1)/size : accreal(1));
 
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);
-
-  THCTensor_(resizeAs)(state, gradInput, input);
 
   THCThrustAllocator thrustAlloc(state);
   thrust::device_ptr<real> input_data(THCTensor_(data)(state, input));
@@ -74,7 +98,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     input_data, input_data+size, target_data, gradInput_data,
-    smoothl1_updateGradInput_functor<real>(norm)
+    smoothl1_updateGradInput_functor<real>(norm, THCTensor_(data)(state, gradOutput))
   );
 
   THCTensor_(free)(state, input);

--- a/torch/lib/THCUNN/generic/THCUNN.h
+++ b/torch/lib/THCUNN/generic/THCUNN.h
@@ -406,14 +406,17 @@ TH_API void THNN_(SmoothL1Criterion_updateOutput)(
                   THCTensor *input,
                   THCTensor *target,
                   THCTensor *output,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(SmoothL1Criterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(SparseLinear_updateOutput)(
                   THCState *state,

--- a/torch/lib/THNN/generic/SmoothL1Criterion.c
+++ b/torch/lib/THNN/generic/SmoothL1Criterion.c
@@ -7,9 +7,20 @@ void THNN_(SmoothL1Criterion_updateOutput)(
           THTensor *input,
           THTensor *target,
           THTensor *output,
-          bool sizeAverage)
+          bool sizeAverage,
+          bool reduce)
 {
   THNN_CHECK_NELEMENT(input, target);
+
+  if (!reduce) {
+    THTensor_(resizeAs)(output, input);
+    TH_TENSOR_APPLY3(real, input, real, target, real, output,
+      real z = fabs(*input_data - *target_data);
+      *output_data = z < 1 ? 0.5 * z * z : z - 0.5;
+    );
+    return;
+  }
+
   THTensor_(resize1d)(output, 1);
 
   real sum = 0;
@@ -28,13 +39,35 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
-          bool sizeAverage)
+          bool sizeAverage,
+          bool reduce)
 {
   THNN_CHECK_NELEMENT(input, target);
-  real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
-
   THTensor_(resizeAs)(gradInput, input);
+
+  if (!reduce) {
+    THNN_CHECK_NELEMENT(gradOutput, input);
+    TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
+      real x = *input_data - *target_data;
+      if (x < -1.) {
+        *gradInput_data = -1.;
+      } else if (x > 1.) {
+        *gradInput_data = 1.;
+      } else {
+        *gradInput_data = x;
+      }
+    );
+    TH_TENSOR_APPLY2(real, gradInput, real, gradOutput,
+      *gradInput_data *= *gradOutput_data;
+    );
+    return;
+  }
+
+  THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, 1);
+  real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.) * THTensor_fastGet1d(gradOutput, 0);
+
   TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
     real x = *input_data - *target_data;
     if (x < -1.)

--- a/torch/lib/THNN/generic/THNN.h
+++ b/torch/lib/THNN/generic/THNN.h
@@ -420,13 +420,16 @@ TH_API void THNN_(SmoothL1Criterion_updateOutput)(
           THTensor *input,
           THTensor *target,
           THTensor *output,
-          bool sizeAverage);
+          bool sizeAverage,
+          bool reduce);
 TH_API void THNN_(SmoothL1Criterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
-          bool sizeAverage);
+          bool sizeAverage,
+          bool reduce);
 
 TH_API void THNN_(SoftMax_updateOutput)(
           THNNState *state,

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -450,10 +450,31 @@ class SmoothL1Loss(_Loss):
 
     The division by `n` can be avoided if one sets the internal variable
     `size_average` to `False`
+
+    Args:
+        size_average (bool, optional): By default, the losses are averaged
+           over all elements. However, if the field size_average is set to False,
+           the losses are instead summed. Ignored when reduce is False. Default: True
+        reduce (bool, optional): By default, the losses are averaged or summed
+           over elements. When reduce is False, the loss function returns
+           a loss per element instead and ignores size_average. Default: True
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Target: :math:`(N, *)`, same shape as the input
+        - Output: scalar. If reduce is False, then
+          :math:`(N, *)`, same shape as the input
+
     """
+    def __init__(self, size_average=True, reduce=True):
+        super(SmoothL1Loss, self).__init__(size_average)
+        self.reduce = reduce
+
     def forward(self, input, target):
         _assert_no_grad(target)
-        return F.smooth_l1_loss(input, target, size_average=self.size_average)
+        return F.smooth_l1_loss(input, target, size_average=self.size_average,
+                                reduce=self.reduce)
 
 
 class SoftMarginLoss(_Loss):


### PR DESCRIPTION
As per #264. When reduce is False, SmoothL1Loss outputs a loss per element of the input tensor. When reduce is True (default), the current behavior is kept.

### Test Plan
`test/run_test.sh`
Added unit test for the reduce=False case. Also added a reference function to the reduce=True unit test.