### PR TITLE
Remove MSELoss test module in favor of wrap_functional

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3653,26 +3653,16 @@ new_criterion_tests = [
 ]
 
 
-class TestMSELoss(torch.nn.modules.module.Module):
-    def __init__(self, target, *args, **kwargs):
-        super(TestMSELoss, self).__init__()
-        self.mseloss = torch.nn.MSELoss(*args, **kwargs)
-        self.target = target
-
-    def forward(self, input):
-        return self.mseloss.forward(input, self.target.type_as(input))
-
-
 def mseloss_no_reduce_test():
     input_size = (2, 3, 4, 5)
     target = torch.randn(*input_size)
     return dict(
         fullname='MSELoss_no_reduce',
-        module_name='TestMSELoss',
-        constructor=TestMSELoss,
-        constructor_args=(Variable(target, requires_grad=False), False, False),
+        constructor=wrap_functional(
+            lambda i: F.mse_loss(i, Variable(target.type_as(i.data)), reduce=False)),
         input_size=input_size,
-        reference_fn=lambda i, m: (i - target).pow(2))
+        reference_fn=lambda i, m: (i - target).pow(2),
+        pickle=False)
 
 
 def nllloss_no_reduce_test():


### PR DESCRIPTION
Addresses a comment made in #3080. 

Removes the wrapper module around MSELoss and instead uses wrap_functional to provide the wrapper. This makes the code nicer and more consistent.

### Test Plan
`test/run_test.sh`