### PR TITLE
Keep type of tensors when indexing into a TensorDataset

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -36,7 +36,14 @@ class TensorDataset(Dataset):
         self.target_tensor = target_tensor
 
     def __getitem__(self, index):
-        return self.data_tensor[index], self.target_tensor[index]
+        def select_and_keep_type(tensor, idx):
+            if tensor.dim() is 1:
+                return tensor.unsqueeze(1)[idx]
+            else:
+                return tensor[idx]
+
+        return (select_and_keep_type(self.data_tensor, index),
+                select_and_keep_type(self.target_tensor, index))
 
     def __len__(self):
         return self.data_tensor.size(0)


### PR DESCRIPTION
Fixes #2539. 

Previously, when one indexes into a TensorDataset, if either the data_tensor or target_tensor has size `(n,)`, then a scalar is returned. When combined with other operations with dataloader this can get converted to a `torch.DoubleTensor` when the user expects a tensor of the original type (ie, `torch.cuda.FloatTensor`. This fixes it so that indexing into TensorDataset always returns tensors of the same type as the respective data/target.

### Test Plan
```
import torch
from torch.utils.data import *
X = torch.rand(64,8).cuda()
y = torch.rand(64).cuda().unsqueeze(1)
dataset = TensorDataset(X,y)
dataset[0]  # confirm this returns a tupple of torch.cuda.FloatTensor
loader = DataLoader(dataset)
next((y for (X,y) in loader))  # confirm this is a torch.cuda.FloatTensor
```