### PR TITLE
Use THPP Type in THD for RPC Message Passing (ATen in THD Part II)

### DIFF
--- a/torch/lib/THD/base/DataChannel.hpp
+++ b/torch/lib/THD/base/DataChannel.hpp
@@ -5,6 +5,7 @@
 #include "DataChannel.h"
 #include "Scalar.hpp"
 #include "init_methods/InitMethod.hpp"
+#include "../master_worker/common/RPCType.hpp"
 
 #include <ATen/ATen.h>
 
@@ -14,7 +15,7 @@
 
 
 MAKE_HASHABLE(THDReduceOp, static_cast<int>(t));
-MAKE_HASHABLE(thpp::Type, static_cast<char>(t));
+MAKE_HASHABLE(thd::RPCType, static_cast<char>(t));
 MAKE_HASHABLE(at::ScalarType, static_cast<int>(t));
 
 

--- a/torch/lib/THD/base/Scalar.hpp
+++ b/torch/lib/THD/base/Scalar.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <THPP/Traits.hpp>
+#include "../master_worker/common/RPCType.hpp"
 #include <cstddef>
 
 namespace thd {
@@ -14,7 +14,7 @@ struct Scalar {
   virtual std::size_t elementSize() const = 0;
   virtual void* data() = 0;
   virtual const void* data() const = 0;
-  virtual thpp::Type type() const = 0;
+  virtual RPCType type() const = 0;
   virtual Scalar* clone() const = 0;
 };
 
@@ -36,8 +36,8 @@ struct ScalarWrapper : Scalar {
     return &_value;
   }
 
-  virtual thpp::Type type() const override {
-    return thpp::type_traits<real>::type;
+  virtual RPCType type() const override {
+    return type_traits<real>::type;
   }
 
   virtual ScalarWrapper* clone() const override {

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -31,17 +31,6 @@
   switch (type) {                                                             \
     case ::at::ScalarType::Float: func<float>(args); break;                   \
     case ::at::ScalarType::Double: func<double>(args); break;                 \
-    /* case ::thpp::Type::CHAR: func<int8_t>(args); break; */                   \
-    /* case ::thpp::Type::UCHAR: func<uint8_t>(args); break; */         \
-    /* case ::thpp::Type::HALF: func<float>(args); break; */                  \
-    /* case ::thpp::Type::SHORT: func<int16_t>(args); break; */                 \
-    /* case ::thpp::Type::USHORT: func<uint16_t>(args); break; */       \
-    /* case ::thpp::Type::INT: func<int32_t>(args); break; */                     \
-    /* case ::thpp::Type::UINT: func<uint32_t>(args); break; */           \
-    /* case ::thpp::Type::LONG: func<int64_t>(args); break; */                   \
-    /* case ::thpp::Type::ULONG: func<uint64_t>(args); break; */         \
-    /* case ::thpp::Type::LONG_LONG: func<int64_t>(args); break; */         \
-    /* case ::thpp::Type::ULONG_LONG: func<uint64_t>(args); break; */ \
     default:                                                                  \
       throw std::runtime_error("Invalid " + std::string(#func) + " function type"); \
   }

--- a/torch/lib/THD/master_worker/common/RPC-inl.hpp
+++ b/torch/lib/THD/master_worker/common/RPC-inl.hpp
@@ -1,6 +1,6 @@
 #include <cstdint>
-#include <THPP/Traits.hpp>
 #include "TH/THStorage.h"
+#include "Type.hpp"
 #include "Traits.hpp"
 
 namespace thd { namespace rpc { namespace detail {
@@ -14,7 +14,7 @@ inline void _appendScalar(ByteArray& str, real data) {
   str.append(reinterpret_cast<char*>(&data), sizeof(data));
 }
 
-inline void _appendType(ByteArray& str, thpp::Type _type) {
+inline void _appendType(ByteArray& str, RPCType _type) {
   char type = static_cast<char>(_type);
   str.append(&type, sizeof(type));
 }
@@ -22,28 +22,28 @@ inline void _appendType(ByteArray& str, thpp::Type _type) {
 template<typename T>
 inline void __appendData(ByteArray& str, const T& arg,
     std::false_type is_generator, std::false_type is_tensor, std::false_type is_storage) {
-  _appendType(str, thpp::type_traits<T>::type);
+  _appendType(str, type_traits<T>::type);
   _appendScalar<T>(str, arg);
 }
 
 template<typename T>
 inline void __appendData(ByteArray& str, const T& arg,
     std::true_type is_generator, std::false_type is_tensor, std::false_type is_storage) {
-  _appendType(str, thpp::Type::GENERATOR);
+  _appendType(str, RPCType::GENERATOR);
   _appendScalar<object_id_type>(str, arg->generator_id);
 }
 
 template<typename T>
 inline void __appendData(ByteArray& str, const T& arg,
     std::false_type is_generator, std::true_type is_tensor, std::false_type is_storage) {
-  _appendType(str, thpp::Type::TENSOR);
+  _appendType(str, RPCType::TENSOR);
   _appendScalar<object_id_type>(str, arg->tensor_id);
 }
 
 template<typename T>
 inline void __appendData(ByteArray& str, const T& arg,
     std::false_type is_generator, std::false_type is_tensor, std::true_type is_storage) {
-  _appendType(str, thpp::Type::STORAGE);
+  _appendType(str, RPCType::STORAGE);
   _appendScalar<object_id_type>(str, arg->storage_id);
 }
 
@@ -59,7 +59,7 @@ inline void _appendData(ByteArray& str, const T& arg) {
 }
 
 inline void _appendData(ByteArray& str, THLongStorage* arg) {
-  _appendType(str, thpp::Type::LONG_STORAGE);
+  _appendType(str, RPCType::LONG_STORAGE);
   _appendScalar<char>(str, arg == NULL);
   if (!arg) return;
   _appendScalar<ptrdiff_t>(str, arg->size);
@@ -81,7 +81,7 @@ inline void _appendData(ByteArray& str, const std::vector<T>& arg) {
     );
 }
 
-inline void _appendData(ByteArray& str, thpp::Type type) {
+inline void _appendData(ByteArray& str, RPCType type) {
   _appendType(str, type);
 }
 

--- a/torch/lib/THD/master_worker/common/RPC.cpp
+++ b/torch/lib/THD/master_worker/common/RPC.cpp
@@ -66,16 +66,16 @@ inline T unpackScalar(RPCMessage& raw_message) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static_assert(sizeof(thpp::Type) == sizeof(char), "thpp::Type has to be of the "
+static_assert(sizeof(RPCType) == sizeof(char), "RPCType has to be of the "
     "same size as char");
-thpp::Type unpackType(RPCMessage& raw_message) {
-  char _type = *raw_message.read(sizeof(thpp::Type));
-  return static_cast<thpp::Type>(_type);
+RPCType unpackType(RPCMessage& raw_message) {
+  char _type = *raw_message.read(sizeof(RPCType));
+  return static_cast<RPCType>(_type);
 }
 
-thpp::Type peekType(RPCMessage& raw_message) {
+RPCType peekType(RPCMessage& raw_message) {
   char _type = *raw_message.data();
-  return static_cast<thpp::Type>(_type);
+  return static_cast<RPCType>(_type);
 }
 
 function_id_type unpackFunctionId(RPCMessage& raw_message) {
@@ -83,26 +83,26 @@ function_id_type unpackFunctionId(RPCMessage& raw_message) {
 }
 
 double unpackFloat(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type == thpp::Type::DOUBLE)
+  RPCType type = unpackType(raw_message);
+  if (type == RPCType::DOUBLE)
     return unpackScalar<double>(raw_message);
-  else if (type == thpp::Type::FLOAT)
+  else if (type == RPCType::FLOAT)
     return unpackScalar<float>(raw_message);
 
   throw std::invalid_argument("wrong real type in the raw message");
 }
 
 int64_t unpackInteger(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type == thpp::Type::CHAR)
+  RPCType type = unpackType(raw_message);
+  if (type == RPCType::CHAR)
     return unpackScalar<int8_t>(raw_message);
-  else if (type == thpp::Type::SHORT)
+  else if (type == RPCType::SHORT)
     return unpackScalar<int16_t>(raw_message);
-  else if (type == thpp::Type::INT)
+  else if (type == RPCType::INT)
     return unpackScalar<int32_t>(raw_message);
-  else if (type == thpp::Type::LONG)
+  else if (type == RPCType::LONG)
     return unpackScalar<int64_t>(raw_message);
-  else if (type == thpp::Type::LONG_LONG)
+  else if (type == RPCType::LONG_LONG)
     return unpackScalar<int64_t>(raw_message);
 
   throw std::invalid_argument(std::string("wrong integer type in the raw message (") +
@@ -110,30 +110,30 @@ int64_t unpackInteger(RPCMessage& raw_message) {
 }
 
 object_id_type unpackTensor(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type == thpp::Type::TENSOR)
+  RPCType type = unpackType(raw_message);
+  if (type == RPCType::TENSOR)
     return unpackScalar<object_id_type>(raw_message);
   throw std::invalid_argument("expected tensor in the raw message");
 }
 
 object_id_type unpackStorage(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type == thpp::Type::STORAGE)
+  RPCType type = unpackType(raw_message);
+  if (type == RPCType::STORAGE)
     return unpackScalar<object_id_type>(raw_message);
   throw std::invalid_argument("expected storage in the raw message");
 }
 
 object_id_type unpackGenerator(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type == thpp::Type::GENERATOR) {
+  RPCType type = unpackType(raw_message);
+  if (type == RPCType::GENERATOR) {
     return unpackScalar<object_id_type>(raw_message);
   }
   throw std::invalid_argument("expected generator in the raw message");
 }
 
 THLongStorage* unpackTHLongStorage(RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
-  if (type != thpp::Type::LONG_STORAGE)
+  RPCType type = unpackType(raw_message);
+  if (type != RPCType::LONG_STORAGE)
     throw std::invalid_argument("expected THLongStorage in the raw message");
   char is_null = unpackScalar<char>(raw_message);
   if (is_null) return NULL;

--- a/torch/lib/THD/master_worker/common/RPC.hpp
+++ b/torch/lib/THD/master_worker/common/RPC.hpp
@@ -2,8 +2,8 @@
 #include "../master/THDTensor.h"
 #include "ByteArray.hpp"
 #include "TH/THStorage.h"
+#include "RPCType.hpp"
 
-#include <THPP/Type.hpp>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -38,8 +38,8 @@ private:
 template <typename ...Args>
 std::unique_ptr<RPCMessage> packMessage(function_id_type fid, const Args&... args);
 
-thpp::Type unpackType(RPCMessage& raw_message);
-thpp::Type peekType(RPCMessage& raw_message);
+RPCType unpackType(RPCMessage& raw_message);
+RPCType peekType(RPCMessage& raw_message);
 double unpackFloat(RPCMessage& raw_message);
 function_id_type unpackFunctionId(RPCMessage& raw_message);
 int64_t unpackInteger(RPCMessage& raw_message);

--- a/torch/lib/THD/master_worker/common/RPCType.hpp
+++ b/torch/lib/THD/master_worker/common/RPCType.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <type_traits>
+#include <tuple>
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+
+namespace thd {
+
+/*
+ * The following notation comes from:
+ * docs.python.org/3.5/library/struct.html#module-struct
+ * except from 'T', which stands for Tensor
+ */
+
+enum class RPCType : char {
+  CHAR = 'c',
+  UCHAR = 'B',
+  FLOAT = 'f',
+  DOUBLE = 'd',
+  HALF = 'a',
+  SHORT = 'h',
+  USHORT = 'H',
+  INT = 'i',
+  UINT = 'I',
+  LONG = 'l',
+  ULONG = 'L',
+  LONG_LONG = 'q',
+  ULONG_LONG = 'Q',
+  LONG_STORAGE = 'X',
+  TENSOR = 'T',
+  STORAGE = 'S',
+  GENERATOR = 'G',
+};
+
+inline bool isFloat(RPCType t) {
+  return (t == RPCType::FLOAT || t == RPCType::DOUBLE || t == RPCType::HALF);
+}
+
+inline bool isInteger(RPCType t) {
+  return (t == RPCType::CHAR || t == RPCType::UCHAR ||
+          t == RPCType::SHORT || t == RPCType:: USHORT ||
+          t == RPCType::INT || t == RPCType::UINT ||
+          t == RPCType::LONG || t == RPCType::ULONG ||
+          t == RPCType::LONG_LONG || t == RPCType::ULONG_LONG);
+}
+
+inline const char* toString(RPCType t) {
+  switch (t) {
+    case RPCType::CHAR: return "Char";
+    case RPCType::UCHAR: return "Byte";
+    case RPCType::FLOAT: return "Float";
+    case RPCType::DOUBLE: return "Double";
+    case RPCType::HALF: return "Half";
+    case RPCType::SHORT: return "Short";
+    case RPCType::USHORT: return "UShort";
+    case RPCType::INT: return "Int";
+    case RPCType::UINT: return "UInt";
+    case RPCType::LONG: return "Long";
+    case RPCType::ULONG: return "ULong";
+    case RPCType::LONG_LONG: return "LongLong";
+    case RPCType::ULONG_LONG: return "ULongLong";
+    case RPCType::LONG_STORAGE: return "LongStorage";
+    case RPCType::TENSOR: return "Tensor";
+    case RPCType::STORAGE: return "Storage";
+    default: return "<unknown>";
+  }
+}
+
+inline bool isObject(RPCType t) {
+  return (t == RPCType::TENSOR || t == RPCType::STORAGE || t == RPCType::GENERATOR);
+}
+
+template<typename T>
+struct type_traits {};
+
+template<>
+struct type_traits<char> {
+  static constexpr RPCType type = RPCType::CHAR;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<int8_t> {
+  static constexpr RPCType type = RPCType::CHAR;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<uint8_t> {
+  static constexpr RPCType type = RPCType::UCHAR;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<float> {
+  static constexpr RPCType type = RPCType::FLOAT;
+  static constexpr bool is_floating_point = true;
+};
+
+template<>
+struct type_traits<double> {
+  static constexpr RPCType type = RPCType::DOUBLE;
+  static constexpr bool is_floating_point = true;
+};
+
+template<>
+struct type_traits<int16_t> {
+  static constexpr RPCType type = RPCType::SHORT;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<uint16_t> {
+  static constexpr RPCType type = RPCType::USHORT;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<int32_t> {
+  static constexpr RPCType type = RPCType::INT;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<uint32_t> {
+  static constexpr RPCType type = RPCType::UINT;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<int64_t> {
+  static constexpr RPCType type = std::is_same<int64_t, long>::value ? RPCType::LONG : RPCType::LONG_LONG;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<uint64_t> {
+  static constexpr RPCType type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG : RPCType::ULONG_LONG;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<std::conditional<std::is_same<int64_t, long>::value, long long, long>::type> {
+  static constexpr RPCType type = std::is_same<int64_t, long>::value ? RPCType::LONG_LONG : RPCType::LONG;
+  static constexpr bool is_floating_point = false;
+};
+
+template<>
+struct type_traits<std::conditional<std::is_same<uint64_t, unsigned long>::value, unsigned long long, unsigned long>::type> {
+  static constexpr RPCType type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG_LONG : RPCType::ULONG;
+  static constexpr bool is_floating_point = false;
+};
+
+template<typename T>
+struct type_traits<const T> : type_traits<T> {};
+
+} // thd

--- a/torch/lib/THD/master_worker/master/Utils.hpp
+++ b/torch/lib/THD/master_worker/master/Utils.hpp
@@ -6,12 +6,12 @@
 
 template<typename T>
 T receiveValueFromWorker(int worker_id) {
-  thpp::Type type = thpp::type_traits<T>::type;
-  if (thpp::isInteger(type)) {
+  thd::RPCType type = thd::type_traits<T>::type;
+  if (thd::isInteger(type)) {
     thd::IntScalar wrapped_value;
     thd::dataChannel->receive(wrapped_value, worker_id);
     return static_cast<T>(wrapped_value.value());
-  } else if (thpp::isFloat(type)) {
+  } else if (thd::isFloat(type)) {
     thd::FloatScalar wrapped_value;
     thd::dataChannel->receive(wrapped_value, worker_id);
     return static_cast<T>(wrapped_value.value());

--- a/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDStorage.cpp
@@ -26,7 +26,7 @@ size_t THDStorage_(elementSize)(void) {
 
 THDStorage* THDStorage_(new)() {
   THDStorage* storage = THDStorage_(_alloc)();
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   masterCommandChannel->sendMessage(
     packMessage(
       Functions::storageNew,
@@ -56,7 +56,7 @@ real THDStorage_(get)(const THDStorage* storage, ptrdiff_t offset) {
       Functions::storageGet,
       storage,
       offset,
-      thpp::type_traits<real>::type
+      type_traits<real>::type
     ),
     THDState::s_current_worker
   );
@@ -64,7 +64,7 @@ real THDStorage_(get)(const THDStorage* storage, ptrdiff_t offset) {
 }
 
 THDStorage* THDStorage_(newWithSize)(ptrdiff_t size) {
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   THDStorage *storage = THDStorage_(_alloc)();
   storage->size = size;
   masterCommandChannel->sendMessage(
@@ -80,7 +80,7 @@ THDStorage* THDStorage_(newWithSize)(ptrdiff_t size) {
 }
 
 THDStorage* THDStorage_(newWithSize1)(real value) {
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   THDStorage *storage = THDStorage_(_alloc)();
   storage->size = 1;
   masterCommandChannel->sendMessage(
@@ -96,7 +96,7 @@ THDStorage* THDStorage_(newWithSize1)(real value) {
 }
 
 THDStorage* THDStorage_(newWithSize2)(real value1, real value2) {
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   THDStorage *storage = THDStorage_(_alloc)();
   storage->size = 2;
   masterCommandChannel->sendMessage(
@@ -113,7 +113,7 @@ THDStorage* THDStorage_(newWithSize2)(real value1, real value2) {
 }
 
 THDStorage* THDStorage_(newWithSize3)(real value1, real value2, real value3) {
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   THDStorage *storage = THDStorage_(_alloc)();
   storage->size = 3;
   masterCommandChannel->sendMessage(
@@ -131,7 +131,7 @@ THDStorage* THDStorage_(newWithSize3)(real value1, real value2, real value3) {
 }
 
 THDStorage* THDStorage_(newWithSize4)(real value1, real value2, real value3, real value4) {
-  thpp::Type type = thpp::type_traits<real>::type;
+  RPCType type = type_traits<real>::type;
   THDStorage *storage = THDStorage_(_alloc)();
   storage->size = 4;
   masterCommandChannel->sendMessage(

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -75,7 +75,7 @@ void THDTensor_(clearFlag)(THDTensor *self, char flag) {
 
 THDTensor *THDTensor_(new)() {
   THDTensor *tensor = THDTensor_(_alloc)();
-  thpp::Type constructed_type = thpp::type_traits<real>::type;
+  RPCType constructed_type = type_traits<real>::type;
   masterCommandChannel->sendMessage(
     packMessage(
       Functions::tensorNew,
@@ -97,7 +97,7 @@ THDTensor *THDTensor_(newWithTensor)(THDTensor *self) {
     self->size,
     self->stride
   );
-  thpp::Type constructed_type = thpp::type_traits<real>::type;
+  RPCType constructed_type = type_traits<real>::type;
   masterCommandChannel->sendMessage(
     packMessage(
       Functions::tensorNewWithTensor,
@@ -115,7 +115,7 @@ THDTensor *THDTensor_(newWithSize)(THLongStorage *size, THLongStorage *stride) {
   if (size && stride)
     THArgCheck(size->size == stride->size, 4, "inconsistent size");
   THDTensor_(_resize)(tensor, size->size, size->data, stride ? stride->data : nullptr);
-  thpp::Type constructed_type = thpp::type_traits<real>::type;
+  RPCType constructed_type = type_traits<real>::type;
   masterCommandChannel->sendMessage(
     packMessage(
       Functions::tensorNewWithSize,
@@ -169,7 +169,7 @@ THDTensor *THDTensor_(newWithStorage)(THDStorage *storage, ptrdiff_t storageOffs
     (size ? size->data : nullptr),
     (stride ? stride->data : nullptr)
   );
-  thpp::Type constructed_type = thpp::type_traits<real>::type;
+  RPCType constructed_type = type_traits<real>::type;
   masterCommandChannel->sendMessage(
     packMessage(
       Functions::tensorNewWithStorage,

--- a/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
@@ -1,60 +1,60 @@
 template<typename... Ts>
-static at::Tensor createTensor(thpp::Type type, Ts &... args) {
-  if (type == thpp::Type::UCHAR)
+static at::Tensor createTensor(RPCType type, Ts &... args) {
+  if (type == RPCType::UCHAR)
     return at::CPU(at::kByte).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::CHAR)
+  else if (type == RPCType::CHAR)
     return at::CPU(at::kChar).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::SHORT)
+  else if (type == RPCType::SHORT)
     return at::CPU(at::kShort).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::INT)
+  else if (type == RPCType::INT)
     return at::CPU(at::kInt).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::LONG)
+  else if (type == RPCType::LONG)
     return at::CPU(at::kLong).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::FLOAT)
+  else if (type == RPCType::FLOAT)
     return at::CPU(at::kFloat).tensor(std::forward<Ts>(args)...);
-  else if (type == thpp::Type::DOUBLE)
+  else if (type == RPCType::DOUBLE)
     return at::CPU(at::kDouble).tensor(std::forward<Ts>(args)...);
   throw std::invalid_argument("passed character doesn't represent a tensor type");
 }
 
-static at::Tensor createTensorWithStorage(thpp::Type type, at::Storage* storage, ptrdiff_t storageOffset, at::IntList size, at::IntList stride) {
-  if (type == thpp::Type::UCHAR)
+static at::Tensor createTensorWithStorage(RPCType type, at::Storage* storage, ptrdiff_t storageOffset, at::IntList size, at::IntList stride) {
+  if (type == RPCType::UCHAR)
     return at::CPU(at::kByte).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::CHAR)
+  else if (type == RPCType::CHAR)
     return at::CPU(at::kChar).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::SHORT)
+  else if (type == RPCType::SHORT)
     return at::CPU(at::kShort).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::INT)
+  else if (type == RPCType::INT)
     return at::CPU(at::kInt).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::LONG)
+  else if (type == RPCType::LONG)
     return at::CPU(at::kLong).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::FLOAT)
+  else if (type == RPCType::FLOAT)
     return at::CPU(at::kFloat).tensor(*storage, storageOffset, size, stride);
-  else if (type == thpp::Type::DOUBLE)
+  else if (type == RPCType::DOUBLE)
     return at::CPU(at::kDouble).tensor(*storage, storageOffset, size, stride);
   throw std::invalid_argument("passed character doesn't represent a tensor type");
 }
 
-static at::Tensor createTensorWithTensor(thpp::Type type, at::Tensor& tensor) {
-  if (type == thpp::Type::UCHAR)
+static at::Tensor createTensorWithTensor(RPCType type, at::Tensor& tensor) {
+  if (type == RPCType::UCHAR)
     return at::CPU(at::kByte).alias(tensor);
-  else if (type == thpp::Type::CHAR)
+  else if (type == RPCType::CHAR)
     return at::CPU(at::kChar).alias(tensor);
-  else if (type == thpp::Type::SHORT)
+  else if (type == RPCType::SHORT)
     return at::CPU(at::kShort).alias(tensor);
-  else if (type == thpp::Type::INT)
+  else if (type == RPCType::INT)
     return at::CPU(at::kInt).alias(tensor);
-  else if (type == thpp::Type::LONG)
+  else if (type == RPCType::LONG)
     return at::CPU(at::kLong).alias(tensor);
-  else if (type == thpp::Type::FLOAT)
+  else if (type == RPCType::FLOAT)
     return at::CPU(at::kFloat).alias(tensor);
-  else if (type == thpp::Type::DOUBLE)
+  else if (type == RPCType::DOUBLE)
     return at::CPU(at::kDouble).alias(tensor);
   throw std::invalid_argument("passed character doesn't represent a tensor type");
 }
 
 static void tensorNew(rpc::RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
+  RPCType type = unpackType(raw_message);
   thd::object_id_type id = unpackTensor(raw_message);
   finalize(raw_message);
   workerTensors.emplace(
@@ -64,7 +64,7 @@ static void tensorNew(rpc::RPCMessage& raw_message) {
 }
 
 static void tensorNewWithSize(rpc::RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
+  RPCType type = unpackType(raw_message);
   thd::object_id_type id = unpackTensor(raw_message);
   THLongStorage *size = unpackTHLongStorage(raw_message);
   THLongStorage *stride = unpackTHLongStorage(raw_message);
@@ -81,7 +81,7 @@ static void tensorNewWithSize(rpc::RPCMessage& raw_message) {
 }
 
 static void tensorNewWithStorage(rpc::RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
+  RPCType type = unpackType(raw_message);
   thd::object_id_type id = unpackTensor(raw_message);
   at::Storage *storage = unpackRetrieveStorage(raw_message);
   ptrdiff_t storageOffset = unpackInteger(raw_message);
@@ -100,7 +100,7 @@ static void tensorNewWithStorage(rpc::RPCMessage& raw_message) {
 }
 
 static void tensorNewWithTensor(rpc::RPCMessage& raw_message) {
-  thpp::Type type = unpackType(raw_message);
+  RPCType type = unpackType(raw_message);
   thd::object_id_type id = unpackTensor(raw_message);
   at::Tensor self = unpackRetrieveTensor(raw_message);
   finalize(raw_message);

--- a/torch/lib/THD/master_worker/worker/dispatch/TensorLapack.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/TensorLapack.cpp
@@ -131,12 +131,12 @@ static void tensorPstrf(rpc::RPCMessage& raw_message) {
   at::Tensor rpiv = unpackRetrieveTensor(raw_message);
   at::Tensor a = unpackRetrieveTensor(raw_message);
   auto uplo = unpackInteger(raw_message);
-  thpp::Type type = peekType(raw_message);
-  if (thpp::isInteger(type)) {
+  RPCType type = peekType(raw_message);
+  if (isInteger(type)) {
     auto tol = unpackInteger(raw_message);
     finalize(raw_message);
     at::pstrf_out(ra, rpiv, a, uplo, tol);
-  } else if (thpp::isFloat(type)) {
+  } else if (isFloat(type)) {
     auto tol = unpackFloat(raw_message);
     finalize(raw_message);
     at::pstrf_out(ra, rpiv, a, uplo, tol);

--- a/torch/lib/THD/master_worker/worker/dispatch/TensorMath.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/TensorMath.cpp
@@ -1,12 +1,12 @@
 
 static void tensorFill(rpc::RPCMessage& raw_message) {
   at::Tensor t = unpackRetrieveTensor(raw_message);
-  thpp::Type type = peekType(raw_message);
-  if (thpp::isInteger(type)) {
+  RPCType type = peekType(raw_message);
+  if (isInteger(type)) {
     auto value = (int64_t) unpackInteger(raw_message);
     finalize(raw_message);
     t.fill_(value);
-  } else if (thpp::isFloat(type)) {
+  } else if (isFloat(type)) {
     auto value = unpackFloat(raw_message);
     finalize(raw_message);
     t.fill_(value);
@@ -18,12 +18,12 @@ static void tensorFill(rpc::RPCMessage& raw_message) {
 static void tensorMaskedFill(rpc::RPCMessage& raw_message) {
   at::Tensor t = unpackRetrieveTensor(raw_message);
   at::Tensor mask = unpackRetrieveTensor(raw_message);
-  thpp::Type type = peekType(raw_message);
-  if (thpp::isInteger(type)) {
+  RPCType type = peekType(raw_message);
+  if (isInteger(type)) {
     auto value = (int64_t) unpackInteger(raw_message);
     finalize(raw_message);
     t.masked_fill_(mask, value);
-  } else if (thpp::isFloat(type)) {
+  } else if (isFloat(type)) {
     auto value = unpackFloat(raw_message);
     finalize(raw_message);
     t.masked_fill_(mask, value);
@@ -88,12 +88,12 @@ static void tensorIndexFill(rpc::RPCMessage& raw_message) {
   at::Tensor tensor = unpackRetrieveTensor(raw_message);
   int dim = unpackInteger(raw_message);
   at::Tensor index = unpackRetrieveTensor(raw_message);
-  thpp::Type type = peekType(raw_message);
-  if (thpp::isInteger(type)) {
+  RPCType type = peekType(raw_message);
+  if (isInteger(type)) {
     auto val = (int64_t) unpackInteger(raw_message);
     finalize(raw_message);
     tensor.index_fill_(dim, index, val);
-  } else if (thpp::isFloat(type)) {
+  } else if (isFloat(type)) {
     auto val = unpackFloat(raw_message);
     finalize(raw_message);
     tensor.index_fill_(dim, index, val);
@@ -120,14 +120,14 @@ static void tensorEye(rpc::RPCMessage& raw_message) {
 
 static void tensorRange(rpc::RPCMessage& raw_message) {
   at::Tensor r = unpackRetrieveTensor(raw_message);
-  thpp::Type type = peekType(raw_message);
-  if (thpp::isInteger(type)) {
+  RPCType type = peekType(raw_message);
+  if (isInteger(type)) {
     int64_t xmin = unpackInteger(raw_message);
     int64_t xmax = unpackInteger(raw_message);
     int64_t step = unpackInteger(raw_message);
     finalize(raw_message);
     at::range_out(r, xmin, xmax, step);
-  } else if (thpp::isFloat(type)) {
+  } else if (isFloat(type)) {
     double xmin = unpackFloat(raw_message);
     double xmax = unpackFloat(raw_message);
     double step = unpackFloat(raw_message);


### PR DESCRIPTION
Depends on #2288. Basically we move `THPP`'s old Type enum into `THD` and rename it as `RPCType`, because it is used to indicate types across RPC calls.