### PR TITLE
Fix error when default_collate is passed a collection of numpy.str_

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -4,6 +4,7 @@ import torch
 import traceback
 import unittest
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
+from torch.utils.data.dataloader import default_collate
 from common import TestCase, run_tests, TEST_NUMPY
 from common_nn import TEST_CUDA
 
@@ -275,6 +276,23 @@ class TestDataLoader(TestCase):
             loader = DataLoader(dset, batch_size=2)
             batch = next(iter(loader))
             self.assertIsInstance(batch, tt)
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_colate_bad_numpy_types(self):
+        import numpy as np
+
+        # Should be a no-op
+        arr = np.array(['a', 'b', 'c'])
+        default_collate(arr)
+
+        arr = np.array([[['a', 'b', 'c']]])
+        self.assertRaises(TypeError, lambda: default_collate(arr))
+
+        arr = np.array([object(), object(), object()])
+        self.assertRaises(TypeError, lambda: default_collate(arr))
+
+        arr = np.array([[[object(), object(), object()]]])
+        self.assertRaises(TypeError, lambda: default_collate(arr))
 
 
 class StringDataset(Dataset):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -94,7 +94,8 @@ def default_collate(batch):
             storage = batch[0].storage()._new_shared(numel)
             out = batch[0].new(storage)
         return torch.stack(batch, 0, out=out)
-    elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_':
+    elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_' \
+            and elem_type.__name__ != 'string_':
         elem = batch[0]
         if elem_type.__name__ == 'ndarray':
             # array of string classes and object

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -2,11 +2,11 @@ import torch
 import torch.multiprocessing as multiprocessing
 from .sampler import SequentialSampler, RandomSampler, BatchSampler
 import collections
+import re
 import sys
 import traceback
 import threading
 from torch._six import string_classes
-import numpy as np
 
 
 if sys.version_info[0] == 2:
@@ -97,8 +97,10 @@ def default_collate(batch):
     elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_':
         elem = batch[0]
         if elem_type.__name__ == 'ndarray':
-            if not np.issubdtype(elem.dtype, np.number):
+            # array of string classes and object
+            if re.search('[SaUO]', elem.dtype.str) is not None:
                 raise TypeError(error_msg.format(elem.dtype))
+
             return torch.stack([torch.from_numpy(b) for b in batch], 0)
         if elem.shape == ():  # scalars
             py_type = float if elem.dtype.name.startswith('float') else int

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -81,6 +81,7 @@ numpy_type_map = {
 
 def default_collate(batch):
     "Puts each data field into a tensor with outer dimension batch size"
+    elem_type = type(batch[0])
     if torch.is_tensor(batch[0]):
         out = None
         if _use_shared_memory:
@@ -90,9 +91,9 @@ def default_collate(batch):
             storage = batch[0].storage()._new_shared(numel)
             out = batch[0].new(storage)
         return torch.stack(batch, 0, out=out)
-    elif type(batch[0]).__module__ == 'numpy':
+    elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_':
         elem = batch[0]
-        if type(elem).__name__ == 'ndarray':
+        if elem_type.__name__ == 'ndarray':
             return torch.stack([torch.from_numpy(b) for b in batch], 0)
         if elem.shape == ():  # scalars
             py_type = float if elem.dtype.name.startswith('float') else int


### PR DESCRIPTION
Fixes #2914.

There was a bug that when a numpy array containing strings was passed to `default_collate`, a key error would occur because the code assumes numpy arrays contain numeric types.

### Test Plan
Make sure the following doesn't error out:
```
import torch
import numpy as np
from torch.utils.data.dataloader import default_collate

x = np.array(["foo", "bar"])
default_collate(x)
```