### PR TITLE
Clear out eigenvector tensor when eigenvector=F for symeig

### DIFF
--- a/torch/lib/TH/generic/THTensorLapack.c
+++ b/torch/lib/TH/generic/THTensorLapack.c
@@ -387,6 +387,11 @@ void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a, const char *jobz
                                      THTensor_(free)(work);),
                            "syev", info,"");
 
+  // No eigenvectors specified
+  if (*jobz == 'N') {
+    THTensor_(fill)(rv_, 0);
+  }
+
   THTensor_(freeCopyTo)(rv__, rv_);
   THTensor_(freeCopyTo)(re__, re_);
   THTensor_(free)(work);


### PR DESCRIPTION
Fixes #2088. 

Previously when eigenvector=False symeig returns some value for the eigenvectors. This zeros them out. Not sure if this is 100% necessary because it does impact performance a little, but it is nice if someone makes a mistake and tries to use them.

### Test Plan
```
import torch as th
x = th.ones(10,10)
[e,V] = th.symeig(x, eigenvectors=True)
print(V) # presumably the eigenvectors
[e,V] = th.symeig(x, eigenvectors=False) 
print(V) # assert prints zeros
```