### PR TITLE
Enable debugging flag for nvcc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,5 +181,15 @@ export PATH=~/ccache/lib:$PATH
 export CUDA_NVCC_EXECUTABLE=~/ccache/cuda/nvcc
 ```
 
+## CUDA Development tips
+
+If you are working on the CUDA code, here are some useful CUDA debugging tips:
+
+1. `CUDA_DEBUG=1` will enable CUDA debugging symbols (-g -G). This is particularly
+    helpful in debugging device code. However, it will slow down the build process,
+    so use wisely.
+2. `cuda-gdb` and `cuda-memcheck` are your best CUDA debuging friends. Unlike`gdb`,
+   `cuda-gdb` can display actual values in a CUDA tensor (rather than all zeros).
+
 
 Hope this helps, and thanks for considering to contribute.

--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -47,6 +47,10 @@ $BASE_DIR/torch/lib/ATen/Local.cwrap;\
 $BASE_DIR/torch/lib/THNN/generic/THNN.h;\
 $BASE_DIR/torch/lib/THCUNN/generic/THCUNN.h;\
 $BASE_DIR/torch/lib/ATen/nn.yaml"
+CUDA_NVCC_FLAGS=$C_FLAGS
+if [[ $CUDA_DEBUG -eq 1 ]]; then
+  CUDA_NVCC_FLAGS="$CUDA_NVCC_FLAGS -g -G"
+fi
 
 # Used to build an individual library, e.g. build TH
 function build() {
@@ -68,7 +72,7 @@ function build() {
               -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS" \
               -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS" \
               -DCMAKE_INSTALL_LIBDIR="$INSTALL_DIR/lib" \
-              -DCUDA_NVCC_FLAGS="$C_FLAGS" \
+              -DCUDA_NVCC_FLAGS="$CUDA_NVCC_FLAGS" \
               -Dcwrap_files="$CWRAP_FILES" \
               -DTH_INCLUDE_PATH="$INSTALL_DIR/include" \
               -DTH_LIB_PATH="$INSTALL_DIR/lib" \


### PR DESCRIPTION
Currently we don't pass `-g -G` flags to nvcc when `DEBUG=1`.  This makes using `cuda-gdb` to debug device code particularly difficult. This PR enables such flags when `CUDA_DEBUG=1`.

Tested with script in https://github.com/pytorch/pytorch/issues/3309. Verified that `cuda-gdb` can break in and display device code successfully.