### PR TITLE
Register VariableType calls in autograd profiler

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1457,7 +1457,8 @@ class TestAutograd(TestCase):
             y = x * 2 + 4
 
         last_end = 0
-        names = ['MulConstant', 'AddConstant']
+        names = ['mul', 'add']
+        self.assertEqual(len(p.function_events), len(names))
         for info, expected_name in zip(p.function_events, names):
             self.assertGreater(info.start, last_end)
             self.assertEqual(info.name, expected_name)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -28,7 +28,7 @@ ${return_type} VariableType::${method_prefix}${api_name}(${formals}) const {
 """)
 
 METHOD_DEFINITION_NYI = CodeTemplate("""\
-throw std::runtime_error("${api_name}: NYI");""")
+throw std::runtime_error("VariableType::${api_name} NYI");""")
 
 BASE_CALL = CodeTemplate("""\
 baseType->${method_prefix}${base_name}(${unpacked_args})""")

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -34,12 +34,15 @@ BASE_CALL = CodeTemplate("""\
 baseType->${method_prefix}${base_name}(${unpacked_args})""")
 
 METHOD_DEFINITION_FALLTHROUGH = CodeTemplate("""\
+${unpack_args}
 return baseType->${method_prefix}${api_name}(${unpacked_args});""")
 
 METHOD_DEFINITION_FALLTHROUGH_VARIABLE = CodeTemplate("""\
+${unpack_args}
 return as_variable(baseType->${method_prefix}${api_name}(${unpacked_args}));""")
 
 METHOD_DEFINITION_FALLTHROUGH_INPLACE = CodeTemplate("""\
+${unpack_args}
 baseType->${method_prefix}${api_name}(${unpacked_args});
 increment_version(self);
 return self;
@@ -95,6 +98,8 @@ if (should_compute_any_outputs()) {
 """)
 
 METHOD_DEFINITION_DERIVATIVE = CodeTemplate("""\
+profiler::RecordFunction profiler("${name}");
+${unpack_args}
 ${buffers}
 ${check_inplace}
 ${check_no_requires_grad}
@@ -671,7 +676,7 @@ def create_variable_type(top_env, aten_declarations):
 
         env = {}
         body = []
-        body += unpack_args(env, declaration)
+        env['unpack_args'] = unpack_args(env, declaration)
 
         combined = nested_dict(env, declaration)
         if declaration['return_type'] in FALLTHROUGH_RETURN_TYPES:


### PR DESCRIPTION
Also improve NYI error message to give a hint that it's an error from VariableType and not any other place in the codebase (hit when running some of the C++ hacky benchmarks).