### PR TITLE
Allow empty index tensor for index_select

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -245,9 +245,9 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   int64_t *index_data;
   real *tensor_data, *src_data;
 
-  THArgCheck(index->nDimension == 1, 3, "Index is supposed to be a vector");
-  THArgCheck(dim < src->nDimension, 4,"Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
-  THArgCheck(src->nDimension > 0,2,"Source tensor is empty");
+  THArgCheck(index->nDimension <= 1, 3, "Index is supposed to be an empty tensor or a vector");
+  THArgCheck(dim < src->nDimension, 4, "Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
+  THArgCheck(src->nDimension > 0, 2, "Source tensor is empty");
 
   numel = THLongTensor_nElement(index);
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -941,6 +941,9 @@ class TestCuda(TestCase):
     def test_broadcast_batched_matmul(self):
         TestTorch._test_broadcast_batched_matmul(self, lambda t: t.cuda())
 
+    def test_index(self):
+        TestTorch._test_index(self, lambda t: t.cuda())
+
     def test_advancedindex(self):
         TestTorch._test_advancedindex(self, lambda t: t.cuda())
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2724,6 +2724,10 @@ class TestTorch(TestCase):
 
     def test_index(self):
         reference = self._consecutive((3, 3, 3))
+
+        # empty tensor indexing
+        self.assertEqual(reference[torch.LongTensor()], reference.new())
+
         self.assertEqual(reference[0], self._consecutive((3, 3)), 0)
         self.assertEqual(reference[1], self._consecutive((3, 3), 10), 0)
         self.assertEqual(reference[2], self._consecutive((3, 3), 19), 0)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2722,19 +2722,26 @@ class TestTorch(TestCase):
         sequence.add_(start - 1)
         return sequence.resize_(*size)
 
-    def test_index(self):
-        reference = self._consecutive((3, 3, 3))
+    @staticmethod
+    def _test_index(self, conv_fn):
+
+        def consec(size, start=1):
+            sequence = torch.ones(int(torch.Tensor(size).prod(0)[0])).cumsum(0)
+            sequence.add_(start - 1)
+            return sequence.view(*size)
+
+        reference = conv_fn(consec((3, 3, 3)))
 
         # empty tensor indexing
-        self.assertEqual(reference[torch.LongTensor()], reference.new())
+        self.assertEqual(reference[conv_fn(torch.LongTensor())], reference.new())
 
-        self.assertEqual(reference[0], self._consecutive((3, 3)), 0)
-        self.assertEqual(reference[1], self._consecutive((3, 3), 10), 0)
-        self.assertEqual(reference[2], self._consecutive((3, 3), 19), 0)
-        self.assertEqual(reference[0, 1], self._consecutive((3,), 4), 0)
-        self.assertEqual(reference[0:2], self._consecutive((2, 3, 3)), 0)
+        self.assertEqual(reference[0], consec((3, 3)), 0)
+        self.assertEqual(reference[1], consec((3, 3), 10), 0)
+        self.assertEqual(reference[2], consec((3, 3), 19), 0)
+        self.assertEqual(reference[0, 1], consec((3,), 4), 0)
+        self.assertEqual(reference[0:2], consec((2, 3, 3)), 0)
         self.assertEqual(reference[2, 2, 2], 27, 0)
-        self.assertEqual(reference[:], self._consecutive((3, 3, 3)), 0)
+        self.assertEqual(reference[:], consec((3, 3, 3)), 0)
 
         # indexing with Ellipsis
         self.assertEqual(reference[..., 2], torch.Tensor([[3, 6, 9],
@@ -2750,15 +2757,15 @@ class TestTorch(TestCase):
         self.assertEqual(reference[2, 2, 2, ...], 27, 0)
         self.assertEqual(reference[...], reference, 0)
 
-        reference_5d = self._consecutive((3, 3, 3, 3, 3))
+        reference_5d = conv_fn(consec((3, 3, 3, 3, 3)))
         self.assertEqual(reference_5d[..., 1, 0], reference_5d[:, :, :, 1, 0], 0)
         self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
         self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
         self.assertEqual(reference_5d[...], reference_5d, 0)
 
         # LongTensor indexing
-        reference = self._consecutive((5, 5, 5))
-        idx = torch.LongTensor([2, 4])
+        reference = conv_fn(consec((5, 5, 5)))
+        idx = conv_fn(torch.LongTensor([2, 4]))
         self.assertEqual(reference[idx], torch.stack([reference[2], reference[4]]))
         # TODO: enable one indexing is implemented like in numpy
         # self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
@@ -2772,7 +2779,7 @@ class TestTorch(TestCase):
         self.assertEqual(reference[None, 2:5, None, None], reference.unsqueeze(0)[:, 2:5].unsqueeze(2).unsqueeze(2))
 
         # indexing with step
-        reference = self._consecutive((10, 10, 10))
+        reference = consec((10, 10, 10))
         self.assertEqual(reference[1:5:2], torch.stack([reference[1], reference[3]], 0))
         self.assertEqual(reference[1:6:2], torch.stack([reference[1], reference[3], reference[5]], 0))
         self.assertEqual(reference[1:9:4], torch.stack([reference[1], reference[5]], 0))
@@ -2783,7 +2790,7 @@ class TestTorch(TestCase):
                          torch.stack([reference[:, 2, 1], reference[:, 2, 3], reference[:, 2, 5]], 1))
 
         lst = [list(range(i, i + 10)) for i in range(0, 100, 10)]
-        tensor = torch.DoubleTensor(lst)
+        tensor = conv_fn(torch.DoubleTensor(lst))
         for _i in range(100):
             idx1_start = random.randrange(10)
             idx1_end = idx1_start + random.randrange(1, 10 - idx1_start + 1)
@@ -2814,6 +2821,9 @@ class TestTorch(TestCase):
         self.assertRaises(TypeError, lambda: reference[0.0, :, 0.0:2.0])
         self.assertRaises(TypeError, lambda: reference[0.0, ..., 0.0:2.0])
         self.assertRaises(TypeError, lambda: reference[0.0, :, 0.0])
+
+    def test_index(self):
+        self._test_index(self, lambda x: x)
 
     @staticmethod
     def _test_advancedindex(self, conv_fn):

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -1486,15 +1486,15 @@ static PyObject * THPTensor_(getValue)(THPTensor *self, PyObject *index)
 
     // TH will also throw an error, but its a Runtime Error that is less interpretable
     // than doing it at this layer
-    if (THIndexTensor_(nDimension)(LIBRARY_STATE index_t) != 1) {
+    if (THIndexTensor_(nDimension)(LIBRARY_STATE index_t) > 1) {
       PyErr_Format(PyExc_IndexError, "Indexing a Tensor with a "
 #ifndef THC_GENERIC_FILE
       "torch.LongTensor "
 #else
       "torch.cuda.LongTensor "
 #endif
-      "triggers index_select semantics, and thus we expect a vector, but the indexing "
-      "Tensor passed has %lld dimensions",
+      "triggers index_select semantics, and thus we expect an empty tensor or a vector, "
+      "but the indexing Tensor passed has %lld dimensions",
       (long long) THIndexTensor_(nDimension)(LIBRARY_STATE index_t));
       throw python_error();
     }


### PR DESCRIPTION
Fixes #3416 .

Test:
Verified the snippet in #3416 runs on both cpu and cuda. Verified that `TestTorch.test_advancedindex` and `TestCuda.test_advancedindex` passes with the new inserted assertion.