### PR TITLE
Replace None grad_inputs with zero tensors in some cases

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -886,6 +886,24 @@ class TestAutograd(TestCase):
         y = x.masked_fill(mask, 0)
         y.sum().backward()
 
+    def test_mark_non_differentiable_none(self):
+        # This used to segfault because MyFunction would send back null
+        # gradients to MulBackward
+        class MyFunction(Function):
+            @staticmethod
+            def forward(ctx, input):
+                output = input.clone()
+                ctx.mark_non_differentiable(output)
+                return output
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return None
+
+        x = Variable(torch.randn(5, 5), requires_grad=True)
+        r = MyFunction.apply(x * x)
+        (r * x).sum().backward()
+
     def test_resize(self):
         x = Variable(torch.ones(2, 3))
         self.assertTrue(x.resize(3, 2).size() == (3, 2))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -888,7 +888,8 @@ class TestAutograd(TestCase):
 
     def test_mark_non_differentiable_none(self):
         # This used to segfault because MyFunction would send back null
-        # gradients to MulBackward
+        # gradients to MulBackward, which is implemented in C++. C++
+        # implemented functions expect incoming  grad_ouptuts to be non-null.
         class MyFunction(Function):
             @staticmethod
             def forward(ctx, input):

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -48,6 +48,11 @@ VariableInfo::VariableInfo(const Variable& var)
   }
 }
 
+Variable VariableInfo::zeros(AutoGPU& gpu_guard) const {
+  gpu_guard.setDevice(device);
+  return type->zeros(size);
+}
+
 auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   AutoGIL gil;
 
@@ -113,15 +118,13 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   auto num_inputs = inputs.size();
   THPObjectPtr pyInputs(PyTuple_New(num_inputs));
   if (!pyInputs) throw python_error();
-  auto& output_info = *py_fn->output_info;
+  auto& output_info = py_fn->output_info;
   for (size_t i = 0; i < num_inputs; ++i) {
     PyObject* input;
     if (inputs[i].defined()) {
       input = THPVariable_Wrap(inputs[i]);
     } else {
-      auto& info = output_info[i];
-      _gpu_guard.setDevice(info.device);
-      input = THPVariable_Wrap(info.type->zeros(info.size));
+      input = THPVariable_Wrap(output_info[i].zeros(_gpu_guard));
     }
     if (!input) throw python_error();
     PyTuple_SET_ITEM(pyInputs.get(), i, input);
@@ -133,7 +136,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   if (!r) throw python_error();
   ensure_tuple(r);
 
-  auto& is_variable_input = *py_fn->is_variable_input;
+  auto& is_variable_input = py_fn->is_variable_input;
   int num_outputs = PyTuple_GET_SIZE(r.get());
   int num_forward_inputs = is_variable_input.size();
   // Returning too many results is ok, but only as long as they're all None.
@@ -162,7 +165,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
   // Massage the Python results tuple back into a C++ variable_list
   variable_list results;
   results.reserve(num_outputs);
-  auto& input_info = *py_fn->input_info;
+  auto& input_info = py_fn->input_info;
   for (int i = 0; i != num_outputs; ++i) {
     PyObject* output = PyTuple_GET_ITEM(r.get(), i);
     bool was_variable = is_variable_input[i];
@@ -178,8 +181,7 @@ auto PyFunction::apply(const variable_list& inputs) -> variable_list {
     if (output == Py_None) {
       auto& info = input_info[results.size()];
       if (info.requires_grad) {
-        _gpu_guard.setDevice(info.device);
-        results.emplace_back(info.type->zeros(info.size));
+        results.emplace_back(info.zeros(_gpu_guard));
       } else {
         results.emplace_back();
       }
@@ -209,8 +211,7 @@ auto PyFunction::is_traceable() -> bool {
 auto PyFunction::releaseVariables() -> void {
   AutoGIL gil;
   auto f = (THPFunction*) obj;
-  delete f->saved_variables;
-  f->saved_variables = nullptr;
+  f->saved_variables.clear();
   f->has_freed_buffers = 1;
 }
 
@@ -262,21 +263,10 @@ static int THPFunction_clear(THPFunction *self)
   Py_CLEAR(self->non_differentiable);
   Py_CLEAR(self->dirty_tensors);
 
-  auto saved_variables = self->saved_variables;
-  self->saved_variables = NULL;
-  delete saved_variables;
-
-  auto output_info = self->output_info;
-  self->output_info = NULL;
-  delete output_info;
-
-  auto input_info = self->input_info;
-  self->input_info = NULL;
-  delete input_info;
-
-  auto is_variable_input = self->is_variable_input;
-  self->is_variable_input = NULL;
-  delete is_variable_input;
+  self->output_info.clear();
+  self->input_info.clear();
+  self->saved_variables.clear();
+  self->is_variable_input.clear();
 
   // XXX: this will clear all hooks (not only Python ones)
   // I guess it's ok to leave it as is for now.
@@ -291,6 +281,10 @@ static void THPFunction_dealloc(THPFunction* self)
   PyObject_GC_UnTrack(self);
   THPFunction_clear(self);
   self->cdata.~PyFunction();
+  self->output_info.~vector();
+  self->input_info.~vector();
+  self->saved_variables.~vector();
+  self->is_variable_input.~vector();
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -302,6 +296,10 @@ PyObject *THPFunction_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
   // most fields
   THPFunction* self = (THPFunction*)obj;
   new (&self->cdata) PyFunction(obj);
+  new (&self->output_info) std::vector<VariableInfo>();
+  new (&self->input_info) std::vector<VariableInfo>();
+  new (&self->saved_variables) std::vector<SavedVariable>();
+  new (&self->is_variable_input) std::vector<bool>();
   self->cdata.num_inputs = -1;
   self->cdata.is_stochastic = PyObject_IsInstance(obj, THPStochasticFunctionClass);
   return obj;
@@ -390,8 +388,8 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
   auto cdata = is_volatile ? nullptr : THPFunction_asFunction(self);
   Py_ssize_t num_outputs = PyTuple_GET_SIZE(raw_output);
   if (self->cdata.is_executable) {
-    self->output_info = new std::vector<VariableInfo>();
-    self->output_info->reserve(num_outputs);
+    self->output_info.clear();
+    self->output_info.reserve(num_outputs);
   }
   for (int i = 0; i < num_outputs; i++) {
     PyObject *output = PyTuple_GET_ITEM(raw_output, i);
@@ -458,8 +456,8 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
     }
     if (!output_var) throw python_error();
 
-    if (self->output_info) {
-      self->output_info->emplace_back(output_var->cdata);
+    if (self->cdata.is_executable) {
+      self->output_info.emplace_back(output_var->cdata);
     }
     t2var[output] = output_var;
     output_var->cdata.get()->output_nr = i;
@@ -476,13 +474,13 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
       "error: to_save attribute is expected to be a tuple but is %s",
       THPUtils_typename(self->to_save));
   Py_ssize_t num_saved = PyTuple_GET_SIZE(self->to_save);
-  self->saved_variables = new std::vector<torch::autograd::SavedVariable>();
-  self->saved_variables->reserve(num_saved);
+  self->saved_variables.clear();
+  self->saved_variables.reserve(num_saved);
   auto cdata_ptr = &self->cdata;
   for (int i = 0; i < num_saved; i++) {
     PyObject *tensor = PyTuple_GET_ITEM(self->to_save, i);
     if (tensor == Py_None) {
-      self->saved_variables->emplace_back();
+      self->saved_variables.emplace_back();
       continue;
     }
 
@@ -497,7 +495,7 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
           "tensors, but argument %d doesn't satisfy this condition", i);
     }
 
-    self->saved_variables->emplace_back(variable->cdata, cdata_ptr);
+    self->saved_variables.emplace_back(variable->cdata, cdata_ptr);
   }
   // Free .to_save
   Py_DECREF(self->to_save);
@@ -736,10 +734,10 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
 
   // Record type, device, and size information about inputs
   if (grad_fn->cdata.is_executable) {
-    grad_fn->input_info = new std::vector<VariableInfo>();
-    grad_fn->input_info->reserve(unpacked.input_vars.size());
+    grad_fn->input_info.clear();
+    grad_fn->input_info.reserve(unpacked.input_vars.size());
     for (auto& var : unpacked.input_vars) {
-      grad_fn->input_info->emplace_back(var);
+      grad_fn->input_info.emplace_back(var);
     }
   }
 
@@ -828,7 +826,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   bool is_volatile = input_info.flags.is_volatile;
   ctx->cdata.set_flags(std::move(input_info.flags));
   ctx->needs_input_grad = input_info.needs_input_grad.release();
-  ctx->is_variable_input = new std::vector<bool>(std::move(input_info.is_variable_input));
+  ctx->is_variable_input = std::move(input_info.is_variable_input);
 
   // Prepend ctx to tensor_input, in preparation for static method call
   auto num_args = PyTuple_GET_SIZE(inputs);
@@ -875,14 +873,11 @@ static void _prepare_grad_output(THPFunction *self, THPObjectPtr& raw_grad_outpu
   if (!grad_output) throw python_error();
 
   // Look for Nones and replace them with new buffers
-  auto& output_info = *self->output_info;
+  auto& output_info = self->output_info;
   for (int i = 0; i < num_grad_output; i++) {
-    auto& info = output_info[i];
     PyObject *grad = PyTuple_GET_ITEM(raw_grad_output.get(), i);
     if (grad == Py_None) {
-      gpu_guard.setDevice(info.device);
-      Variable var = info.type->zeros(info.size);
-      grad = createPyObject(var.data());
+      grad = createPyObject(output_info[i].zeros(gpu_guard).data());
       if (!grad) throw python_error();
     } else {
       Py_INCREF(grad);
@@ -983,15 +978,15 @@ static PyObject *unpack_saved_variables(
     std::function<PyObject*(const Variable&)> unpack_fn)
 {
   THPUtils_assert(!self->has_freed_buffers, ERR_BACKWARD_TWICE);
-  if (!self->saved_variables)
+  auto& saved_variables = self->saved_variables;
+  if (saved_variables.empty())
     return PyTuple_New(0);
 
-  int num_saved = self->saved_variables->size();
+  int num_saved = saved_variables.size();
   THPObjectPtr saved(PyTuple_New(num_saved));
   if (!saved)
     return NULL;
   auto saved_for = THPFunction_asFunction(self);
-  auto& saved_variables = *self->saved_variables;
   for (int i = 0; i < num_saved; i++) {
     auto unpacked_var = saved_variables[i].unpack(saved_for);
     THPObjectPtr value;

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -12,11 +12,19 @@
 #include "torch/csrc/utils/object_ptr.h"
 
 // (class, gpu id, sizes)
-using output_info_type = std::tuple<PyObject *, int, std::vector<int64_t>>;
+using tensor_info_type = std::tuple<at::Type*, int, std::vector<int64_t>>;
 
 
 namespace torch { namespace jit { struct Graph; }}
 namespace torch { namespace autograd {
+
+struct VariableInfo {
+  explicit VariableInfo(const Variable& var);
+  at::Type* type;
+  int device;
+  std::vector<int64_t> size;
+  bool requires_grad;
+};
 
 // A Function which is implemented by a Python object (i.e., a THPFunction).
 // Calls to 'apply' are forwarded to the Python method implementation.
@@ -74,7 +82,8 @@ struct THPFunction {
     // modified inplace.
     PyObject *dirty_tensors;
 
-    std::vector<output_info_type> *output_info;
+    std::vector<torch::autograd::VariableInfo> *output_info;
+    std::vector<torch::autograd::VariableInfo> *input_info;
     std::vector<torch::autograd::SavedVariable> *saved_variables;
     // For each input, true if the input is a THPVariable
     std::vector<bool> *is_variable_input;

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -11,15 +11,15 @@
 #include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/utils/object_ptr.h"
 
-// (class, gpu id, sizes)
-using tensor_info_type = std::tuple<at::Type*, int, std::vector<int64_t>>;
-
 
 namespace torch { namespace jit { struct Graph; }}
 namespace torch { namespace autograd {
 
 struct VariableInfo {
   explicit VariableInfo(const Variable& var);
+
+  Variable zeros(AutoGPU& gpu_guard) const;
+
   at::Type* type;
   int device;
   std::vector<int64_t> size;
@@ -82,11 +82,11 @@ struct THPFunction {
     // modified inplace.
     PyObject *dirty_tensors;
 
-    std::vector<torch::autograd::VariableInfo> *output_info;
-    std::vector<torch::autograd::VariableInfo> *input_info;
-    std::vector<torch::autograd::SavedVariable> *saved_variables;
+    std::vector<torch::autograd::VariableInfo> output_info;
+    std::vector<torch::autograd::VariableInfo> input_info;
+    std::vector<torch::autograd::SavedVariable> saved_variables;
     // For each input, true if the input is a THPVariable
-    std::vector<bool> *is_variable_input;
+    std::vector<bool> is_variable_input;
     char has_freed_buffers;
     char is_traced;
 


### PR DESCRIPTION
In Python-implemented autograd functions, we sometimes return None as
the grad_input if the output is marked "non-differentiable". This
replaces those None values with zero-filled Variables if the
corresponding input has requires_grad=True.

C++ implemented autograd functions expect the input (grad_outputs) to
be defined if they're executed. They always return non-null grad_inputs
if should_compute_output(i) is true. This could lead to segfaults if a
subsequent Python-implemented function returned None.

See #3412, #3241