### PR TITLE
Better error messages for Aten tensor types

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4473,6 +4473,19 @@ class TestTorch(TestCase):
             for i in range(len(x)):
                 self.assertEqual(geq2_x[i], geq2_array[i])
 
+    def test_error_msg_type_translation(self):
+        with self.assertRaisesRegex(
+                RuntimeError,
+                # message includes both torch.DoubleTensor and torch.LongTensor
+                '(?=.*torch\.DoubleTensor)(?=.*torch\.LongTensor)'):
+
+            # Calls model with a DoubleTensor input but LongTensor weights
+            input = torch.autograd.Variable(torch.randn(1, 1, 1, 6).double())
+            weight = torch.zeros(1, 1, 1, 3).long()
+            model = torch.nn.Conv2d(1, 1, (1, 3), stride=1, padding=0, bias=False)
+            model.weight.data = weight
+            out = model(input)
+
     def test_comparison_ops(self):
         x = torch.randn(5, 5)
         y = torch.randn(5, 5)

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -14,6 +14,8 @@ bool THPException_init(PyObject *module)
   return true;
 }
 
+namespace torch {
+
 void replaceAll(std::string & str,
     const std::string & old_str,
     const std::string & new_str) {
@@ -23,7 +25,7 @@ void replaceAll(std::string & str,
   }
 }
 
-const char * processErrorMsg(std::string str) {
+std::string processErrorMsg(std::string str) {
 
   // Translate Aten types to their respective pytorch ones
   std::map<std::string, std::string> changes = {
@@ -65,6 +67,7 @@ const char * processErrorMsg(std::string str) {
     replaceAll(str, it.first, it.second);
   }
 
-  return str.c_str();
+  return str;
+}
 }
 

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -1,5 +1,7 @@
 #include <Python.h>
 
+#include <map>
+
 #include "THP.h"
 
 PyObject *THPException_FatalError;
@@ -11,3 +13,58 @@ bool THPException_init(PyObject *module)
   ASSERT_TRUE(PyModule_AddObject(module, "FatalError", THPException_FatalError) == 0);
   return true;
 }
+
+void replaceAll(std::string & str,
+    const std::string & old_str,
+    const std::string & new_str) {
+  std::string::size_type pos = 0u;
+  while ((pos = str.find(old_str, pos)) != std::string::npos){
+     str.replace(pos, old_str.length(), new_str);
+  }
+}
+
+const char * processErrorMsg(std::string str) {
+
+  // Translate Aten types to their respective pytorch ones
+  std::map<std::string, std::string> changes = {
+    {"SparseCUDAByteType", "torch.cuda.sparse.ByteTensor"},
+    {"SparseCUDACharType", "torch.cuda.sparse.CharTensor"},
+    {"SparseCUDADoubleType", "torch.cuda.sparse.DoubleTensor"},
+    {"SparseCUDAFloatType", "torch.cuda.sparse.FloatTensor"},
+    {"SparseCUDAIntType", "torch.cuda.sparse.IntTensor"},
+    {"SparseCUDALongType", "torch.cuda.sparse.LongTensor"},
+    {"SparseCUDAShortType", "torch.cuda.sparse.ShortTensor"},
+    {"SparseCUDAHalfType", "torch.cuda.sparse.HalfTensor"},
+    {"SparseCPUByteType", "torch.sparse.ByteTensor"},
+    {"SparseCPUCharType", "torch.sparse.CharTensor"},
+    {"SparseCPUDoubleType", "torch.sparse.DoubleTensor"},
+    {"SparseCPUFloatType", "torch.sparse.FloatTensor"},
+    {"SparseCPUIntType", "torch.sparse.IntTensor"},
+    {"SparseCPULongType", "torch.sparse.LongTensor"},
+    {"SparseCPUShortType", "torch.sparse.ShortTensor"},
+    {"SparseCPUHalfType", "torch.sparse.HalfTensor"},
+    {"CUDAByteType", "torch.cuda.ByteTensor"},
+    {"CUDACharType", "torch.cuda.CharTensor"},
+    {"CUDADoubleType", "torch.cuda.DoubleTensor"},
+    {"CUDAFloatType", "torch.cuda.FloatTensor"},
+    {"CUDAIntType", "torch.cuda.IntTensor"},
+    {"CUDALongType", "torch.cuda.LongTensor"},
+    {"CUDAShortType", "torch.cuda.ShortTensor"},
+    {"CUDAHalfType", "torch.cuda.HalfTensor"},
+    {"CPUByteType", "torch.ByteTensor"},
+    {"CPUCharType", "torch.CharTensor"},
+    {"CPUDoubleType", "torch.DoubleTensor"},
+    {"CPUFloatType", "torch.FloatTensor"},
+    {"CPUIntType", "torch.IntTensor"},
+    {"CPULongType", "torch.LongTensor"},
+    {"CPUShortType", "torch.ShortTensor"},
+    {"CPUHalfType", "torch.HalfTensor"},
+  };
+
+  for (const auto & it : changes) {
+    replaceAll(str, it.first, it.second);
+  }
+
+  return str.c_str();
+}
+

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -14,7 +14,7 @@
   } catch (python_error &e) {                                                  \
     return retval;                                                             \
   } catch (std::exception &e) {                                                \
-    PyErr_SetString(PyExc_RuntimeError, e.what());                             \
+    PyErr_SetString(PyExc_RuntimeError, processErrorMsg(e.what()));            \
     return retval;                                                             \
   }
 
@@ -67,5 +67,7 @@ struct python_error : public std::exception {
 
 bool THPException_init(PyObject *module);
 #endif
+
+const char * processErrorMsg(std::string str);
 
 #endif

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -14,7 +14,8 @@
   } catch (python_error &e) {                                                  \
     return retval;                                                             \
   } catch (std::exception &e) {                                                \
-    PyErr_SetString(PyExc_RuntimeError, processErrorMsg(e.what()));            \
+    auto msg = torch::processErrorMsg(e.what());                               \
+    PyErr_SetString(PyExc_RuntimeError, msg.c_str());                          \
     return retval;                                                             \
   }
 
@@ -68,6 +69,8 @@ struct python_error : public std::exception {
 bool THPException_init(PyObject *module);
 #endif
 
-const char * processErrorMsg(std::string str);
+namespace torch {
+std::string processErrorMsg(std::string str);
+}
 
 #endif


### PR DESCRIPTION
Fixes #2138.

Right now if an type error occurs between tensors in the Aten backend an error message like the following is thrown:
`RuntimeError: Expected object of type CPUDoubleType but found type CPUFloatType for argument #3 'weight'`

This could be confusing for people who only use pytorch and don't know about Aten. This pr adds a a find & replace for those type names when error messages that are propagated to the python interpreter contain them.

### Test Plan
Run something that causes a type error and check the error message. Running the script in #2138 now gives the output
![image](https://user-images.githubusercontent.com/5652049/32345679-58d7c958-bfe1-11e7-9956-d2faff427080.png)
