### PR TITLE
Add optional "squared" argument to pairwise_distance

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1394,7 +1394,7 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6, squared=False):
     """
     assert x1.size() == x2.size(), "Input sizes must be equal."
     assert x1.dim() == 2, "Input must be a 2D matrix."
-    assert (squared and p==2) or not squared, "Squared distances applicable only if p=2."
+    assert (squared and p == 2) or not squared, "Squared distances applicable only if p=2."
     diff = torch.abs(x1 - x2)
     out = torch.pow(diff + eps, p).sum(dim=1, keepdim=True)
     if squared:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1367,7 +1367,7 @@ def pad(input, pad, mode='constant', value=0):
 
 # distance
 
-def pairwise_distance(x1, x2, p=2, eps=1e-6):
+def pairwise_distance(x1, x2, p=2, eps=1e-6, squared=False):
     r"""
     Computes the batchwise pairwise distance between vectors v1,v2:
 
@@ -1379,6 +1379,7 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6):
         x2: second input tensor
         p: the norm degree. Default: 2
         eps (float, optional): Small value to avoid division by zero. Default: 1e-6
+        squared (bool, optional): Whether to return squared distances if p==2. Default: False
 
     Shape:
         - Input: :math:`(N, D)` where `D = vector dimension`
@@ -1393,9 +1394,13 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6):
     """
     assert x1.size() == x2.size(), "Input sizes must be equal."
     assert x1.dim() == 2, "Input must be a 2D matrix."
+    assert (squared and p==2) or not squared, "Squared distances applcable only if p=2"
     diff = torch.abs(x1 - x2)
     out = torch.pow(diff + eps, p).sum(dim=1, keepdim=True)
-    return torch.pow(out, 1. / p)
+    if squared:
+        return out
+    else:
+        return torch.pow(out, 1. / p)
 
 
 def cosine_similarity(x1, x2, dim=1, eps=1e-8):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1394,7 +1394,7 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6, squared=False):
     """
     assert x1.size() == x2.size(), "Input sizes must be equal."
     assert x1.dim() == 2, "Input must be a 2D matrix."
-    assert (squared and p==2) or not squared, "Squared distances applcable only if p=2"
+    assert (squared and p==2) or not squared, "Squared distances applicable only if p=2."
     diff = torch.abs(x1 - x2)
     out = torch.pow(diff + eps, p).sum(dim=1, keepdim=True)
     if squared:


### PR DESCRIPTION
In many cases one only needs to use squared distances and can avoid taking the square roots (e.g. in k-means, nearest neighbors). This PR adds a boolean argument "squared" to `pairwise_distance` to be used only in combination with `p` = 2 if the user only needs to compute squared distances.