### PR TITLE
Fix CUDA 9 linking issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -493,6 +493,9 @@ if WITH_CUDA:
         "torch/csrc/jit/fusion_compiler.cpp",
     ]
     main_sources += split_types("torch/csrc/cuda/Tensor.cpp")
+    if int(CUDA_VERSION.split(".")[0])>=9:
+        extra_link_args.append("-L" + cuda_lib_path)
+        main_libraries += ["cuda", "nvrtc"]
 
 if WITH_NCCL:
     if WITH_SYSTEM_NCCL:


### PR DESCRIPTION
It seems that CUDA 9 needs additional linker flags (-lcuda and -lnvrtc). Without these, importing torch results in:

> ImportError: /home/xdever/.local/lib/python3.6/site-packages/torch/_C.cpython-36m-x86_64-linux-gnu.so: undefined symbol: nvrtcGetProgramLogSize

The version check may be unnecessary, but I'm not sure about old (pre 8) CUDA releases.

With these modifications everything seems to be fine with CUDA 9 and cuDNN 7.
