### PR TITLE
support for moving optimizer state to/from GPU

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -192,3 +192,32 @@ class Optimizer(object):
             else:
                 if filter_func(value):
                     state[key] = transformation(value)
+
+
+    def cuda(self, device=None):
+        """Moves all tensors in the optimizer state to the GPU specified by ``device``.
+
+        Arguments:
+            device (int, optional): if specified, all tensors will be
+                copied to that device
+
+        Returns:
+            Optimizer: self
+        """
+
+        self._transform_state(lambda t: t.cuda(device),
+                              lambda t: torch.is_tensor(t))
+
+        return self
+
+    def cpu(self):
+        """Moves all tensors in the optimizer state to the GPU specified by ``device``.
+
+        Returns:
+            Optimizer: self
+        """
+
+        self._transform_state(lambda t: t.cpu(),
+                              lambda t: torch.is_tensor(t))
+
+        return self

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -169,3 +169,26 @@ class Optimizer(object):
             raise ValueError("some parameters appear in more than one parameter group")
 
         self.param_groups.append(param_group)
+
+    def _transform_state(self, transformation, filter_func, state=None):
+        """Applies ``transformation`` recursively to each item in ``self.state``
+        for which ``filter_func`` returns True.
+
+        Arguments:
+            transformation (item -> item): function to be applied to each item passing ``filter_func``.
+
+            filter_func (item -> `bool`): function which must return True for each item to which ``transformation`` should be applied.
+
+        """
+
+        if state == None:
+            state = self.state
+
+        for key, value in state.items():
+
+            if isinstance(value, dict):
+                self._transform_state(transformation, filter_func, value)
+
+            else:
+                if filter_func(value):
+                    state[key] = transformation(value)


### PR DESCRIPTION
Here is a proposal to add public methods `cpu()` and `cuda()` to `torch.optim.Optimizer`.

This should solve problems with resuming when the optimizer whose state is loaded from a file. These methods recursively run `.cpu()` or `.cuda()` on all tensors found in the optimizer's `state`.

Should solve #1442 and #2830 and is based on code proposed in these issues.

