### PR TITLE
Generate native functions with const ref Tensor arguments.

### DIFF
--- a/aten/src/ATen/NativeFunctions.h
+++ b/aten/src/ATen/NativeFunctions.h
@@ -213,7 +213,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::squeeze_
 [/NativeFunction]
 */
-static inline Tensor squeeze_(Tensor & self) {
+static inline Tensor & squeeze_(Tensor & self) {
   auto g = inferSqueezeGeometry(self);
   return self.as_strided_(std::get<0>(g), std::get<1>(g));
 }
@@ -229,7 +229,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::squeeze_
 [/NativeFunction]
 */
-static inline Tensor squeeze_(Tensor & self, int64_t dim) {
+static inline Tensor & squeeze_(Tensor & self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim());
 
   if (self.sizes()[dim] != 1) {
@@ -268,7 +268,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::unsqueeze_
 [/NativeFunction]
 */
-static inline Tensor unsqueeze_(Tensor & self, int64_t dim) {
+static inline Tensor & unsqueeze_(Tensor & self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim() + 1);
 
   auto g = inferUnsqueezeGeometry(self, dim);

--- a/aten/src/ATen/NativeFunctions.h
+++ b/aten/src/ATen/NativeFunctions.h
@@ -213,7 +213,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::squeeze_
 [/NativeFunction]
 */
-static inline Tensor squeeze_(Tensor self) {
+static inline Tensor squeeze_(Tensor & self) {
   auto g = inferSqueezeGeometry(self);
   return self.as_strided_(std::get<0>(g), std::get<1>(g));
 }
@@ -229,7 +229,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::squeeze_
 [/NativeFunction]
 */
-static inline Tensor squeeze_(Tensor self, int64_t dim) {
+static inline Tensor squeeze_(Tensor & self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim());
 
   if (self.sizes()[dim] != 1) {
@@ -268,7 +268,7 @@ type_method_definition_level: base
 type_method_definition_dispatch: at::native::unsqueeze_
 [/NativeFunction]
 */
-static inline Tensor unsqueeze_(Tensor self, int64_t dim) {
+static inline Tensor unsqueeze_(Tensor & self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim() + 1);
 
   auto g = inferUnsqueezeGeometry(self, dim);

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -521,6 +521,7 @@ def create_generic(top_env, declarations):
         result = pos_args + kwd_args
         result = [add_type_as_dynamic_type(argument, option) for argument in result]
 
+        # ensure we get reference-type formals when appropriate
         def native_translate_formals(argument, option):
             if option['inplace']:
                 argument['type'] = {'Tensor': 'Tensor &'}.get(argument['type'], argument['type'])
@@ -539,6 +540,9 @@ def create_generic(top_env, declarations):
 
         # can't actually return a TensorList (since it's a reference object)
         actual_return_type = {'TensorList': 'std::vector<Tensor>'}.get(ret['type'], ret['type'])
+        if actual_return_type == 'Tensor' and option['inplace']:
+            # follow normal ATen convention of returning Tensor & for inplace functions.
+            actual_return_type = 'Tensor &'
         return [{
             'type': actual_return_type,
             'dynamic_type': ret['type'],

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -519,7 +519,14 @@ def create_generic(top_env, declarations):
             return argument
 
         result = pos_args + kwd_args
-        return [add_type_as_dynamic_type(argument, option) for argument in result]
+        result = [add_type_as_dynamic_type(argument, option) for argument in result]
+
+        def native_translate_formals(argument, option):
+            argument['type'] = {'Tensor': 'const Tensor &'}.get(argument['type'], argument['type'])
+            return argument
+
+        result = [native_translate_formals(argument, option) for argument in result]
+        return result
 
     def native_get_return_types(option):
         ret = option['return']

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -522,7 +522,11 @@ def create_generic(top_env, declarations):
         result = [add_type_as_dynamic_type(argument, option) for argument in result]
 
         def native_translate_formals(argument, option):
-            argument['type'] = {'Tensor': 'const Tensor &'}.get(argument['type'], argument['type'])
+            if option['inplace']:
+                argument['type'] = {'Tensor': 'Tensor &'}.get(argument['type'], argument['type'])
+            else:
+                argument['type'] = {'Tensor': 'const Tensor &'}.get(argument['type'], argument['type'])
+
             return argument
 
         result = [native_translate_formals(argument, option) for argument in result]


### PR DESCRIPTION
This matches the non-native functions and avoids unnecessary ref counts.