### PR TITLE
Put accumulate test fix

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -254,7 +254,7 @@ tests = [
     ('ones', small_3d, lambda t: [1, 2, 3, 4, 5],),
     ('permute', new_t(1, 2, 3, 4), lambda t: [2, 1, 3, 0],),
     ('put_', new_t(2, 5, 3), lambda t: [long_type(t)([[0], [-2]]), t([[3], [4]])],),
-    ('put_', new_t(2, 2), lambda t: [long_type(t)([[1], [-3]]), t([[1], [2]]), True], 'accumulate'),
+    ('put_', new_t(2, 2), lambda t: [long_type(t)([[1], [-2]]), t([[1], [2]]), True], 'accumulate'),
     ('prod', small_2d_oneish, lambda t: [],),
     ('prod', small_3d, lambda t: [1], 'dim'),
     ('prod', small_3d, lambda t: [-1], 'neg_dim'),


### PR DESCRIPTION
Cannot write to the same index from multiple threads. Changing test to not have duplicate indices. Similar issue to https://github.com/pytorch/pytorch/issues/1953