### PR TITLE
Signal handling in DataLoader workers; Timeout option

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -179,8 +179,8 @@ class TestDataLoader(TestCase):
             self.assertTrue(target.is_pinned())
 
     def test_multiple_dataloaders(self):
-        loader1_it = iter(DataLoader(self.dataset, num_workers = 1))
-        loader2_it = iter(DataLoader(self.dataset, num_workers = 2))
+        loader1_it = iter(DataLoader(self.dataset, num_workers=1))
+        loader2_it = iter(DataLoader(self.dataset, num_workers=2))
         next(loader1_it)
         next(loader1_it)
         next(loader2_it)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -192,7 +192,7 @@ class TestDataLoader(TestCase):
         def _test_segfault():
             sys.stderr.close()
             dataset = SegfaultDataset(10)
-            dataloader = DataLoader(dataset, batch_size=2, num_workers=1)
+            dataloader = DataLoader(dataset, batch_size=2, num_workers=2)
             _ = next(iter(dataloader))
 
         p = multiprocessing.Process(target=_test_segfault)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1,8 +1,12 @@
 import math
 import sys
+import os
+import ctypes
 import torch
+import time
 import traceback
 import unittest
+from torch import multiprocessing
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataloader import default_collate
 from common import TestCase, run_tests, TEST_NUMPY
@@ -83,6 +87,32 @@ class ErrorDataset(Dataset):
         return self.size
 
 
+class SegfaultDataset(Dataset):
+
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, idx):
+        return ctypes.string_at(0)
+
+    def __len__(self):
+        return self.size
+
+
+class SleepDataset(Dataset):
+
+    def __init__(self, size, sleep_sec):
+        self.size = size
+        self.sleep_sec = sleep_sec
+
+    def __getitem__(self, idx):
+        time.sleep(self.sleep_sec)
+        return idx
+
+    def __len__(self):
+        return self.size
+
+
 class TestDataLoader(TestCase):
 
     def setUp(self):
@@ -148,6 +178,38 @@ class TestDataLoader(TestCase):
         for input, target in loader:
             self.assertTrue(input.is_pinned())
             self.assertTrue(target.is_pinned())
+
+    def test_segfault(self):
+        def _test_segfault():
+            dataset = SegfaultDataset(10)
+            dataloader = DataLoader(dataset, batch_size=2, num_workers=1)
+            _ = next(iter(dataloader))
+
+        p = multiprocessing.Process(target=_test_segfault)
+        p.start()
+        p.join(1.0)
+        try:
+            self.assertFalse(p.is_alive())
+            self.assertNotEqual(p.exitcode, 0)
+        finally:
+            p.terminate()
+
+    def test_timeout(self):
+        def _test_timeout():
+            sys.stderr = open(os.devnull,'wb')
+            dataset = SleepDataset(10, 10)
+            dataloader = DataLoader(dataset, batch_size=2, num_workers=2, timeout=1)
+            _ = next(iter(dataloader))
+
+
+        p = multiprocessing.Process(target=_test_timeout)
+        p.start()
+        p.join(3.0)
+        try:
+            self.assertFalse(p.is_alive())
+            self.assertNotEqual(p.exitcode, 0)
+        finally:
+            p.terminate()
 
     def test_shuffle(self):
         self._test_shuffle(DataLoader(self.dataset, shuffle=True))
@@ -224,7 +286,7 @@ class TestDataLoader(TestCase):
         "check that workers exit even if the iterator is not exhausted"
         loader = iter(DataLoader(self.dataset, batch_size=2, num_workers=4, pin_memory=True))
         workers = loader.workers
-        pin_thread = loader.pin_thread
+        process_thread = loader.process_thread
         for i, sample in enumerate(loader):
             if i == 3:
                 break
@@ -233,8 +295,8 @@ class TestDataLoader(TestCase):
             w.join(1.0)  # timeout of one second
             self.assertFalse(w.is_alive(), 'subprocess not terminated')
             self.assertEqual(w.exitcode, 0)
-        pin_thread.join(1.0)
-        self.assertFalse(pin_thread.is_alive())
+        process_thread.join(1.0)
+        self.assertFalse(process_thread.is_alive())
 
     def test_len(self):
         def check_len(dl, expected):

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -1,0 +1,191 @@
+#include <sys/wait.h>
+#include <set>
+#include <signal.h>
+
+#include "THP.h"
+
+// In cases like data loader, if a worker process die due to bus error/segfault
+// or just hang, the main process, if implemented with
+// multiprocessing.queue.SimpleQueue, will hang waiting for data. This is
+// difficult to avoid on PyTorch side as it can be caused by limited shm, or
+// other libraries users call in the workers. The following methods is an effort
+// to do our best provide some error message to users when such unfortunate
+// events happen.
+
+// TODO: The following don't work on Windows. Specifically, waitpid calls and
+// SIGCHLD handler.
+
+#ifndef _WIN32
+
+// Critical signal handlers should be registered on worker processes before
+// doing work.
+// Python handle is _set_worker_signal_handlers().
+#define SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_MSG)                       \
+static void HANDLER_NAME(int sig)                                             \
+{                                                                             \
+    write(STDERR_FILENO, ERROR_MSG, sizeof(ERROR_MSG) / sizeof(char));        \
+    _exit(EXIT_FAILURE);                                                      \
+}
+
+// signal(2) is really not portable. So use sigaction.
+// http://man7.org/linux/man-pages/man2/signal.2.html
+#define SET_SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_FLAG)                  \
+{                                                                             \
+  struct sigaction sa;                                                        \
+  sa.sa_handler = HANDLER_NAME;                                               \
+  sa.sa_flags = SA_RESTART;                                                   \
+  sigemptyset(&sa.sa_mask);                                                   \
+  ERROR_FLAG |= sigaction(SIGNAL, &sa, NULL) != 0;                            \
+}
+
+SIGNAL_HANDLER(SIGBUS, handler_SIGBUS, "ERROR: Unexpected bus error encountered in worker. "
+  "This might be caused by insufficient shared memory (shm).\n");
+SIGNAL_HANDLER(SIGSEGV, handler_SIGSEGV, "ERROR: Unexpected segmentation fault encountered in worker.\n");
+
+static std::vector<pid_t> worker_pid_vec = {};
+// The following are needed since std::vector is not asynchronous safe.
+static std::atomic<pid_t *> worker_pids;
+static std::atomic<size_t> num_worker_pids(0);
+static std::atomic<size_t> num_dataloaders(0);
+
+PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  int error = 0;
+  SET_SIGNAL_HANDLER(SIGBUS, &handler_SIGBUS, error);
+  SET_SIGNAL_HANDLER(SIGSEGV, &handler_SIGSEGV, error);
+  if (error == 0) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+// SIGCHLD hander should be registered on main loader process to catch any
+// worker failing. SIGALRM handler is needed for implementing timeout.
+// Python handles are _set_main_signal_handers() and
+// _remove_main_signal_handers().
+static void handler_SIGCHLD_main(int sig) {
+  int status;
+  pid_t p;
+  pid_t *pid_ptr = worker_pids;
+
+  // Only check the pids we care about so that Python can see other processes'
+  // status.
+  for (size_t i = 0; i < num_worker_pids; i++) {
+    // The flags and status checks ensure that we are really observing a child
+    // exiting, rather than other cases such as SIGSTOP and SIGCONT.
+    // https://stackoverflow.com/a/40707100
+    p = waitpid(*pid_ptr, &status, WNOHANG|WUNTRACED|WCONTINUED);
+    // Ignore errors / no changes
+    if (p <= 0)
+      continue;
+    if (WIFCONTINUED(status) || WIFSTOPPED(status))
+      continue;
+    if (WIFEXITED(status) != 0 && WEXITSTATUS(status) == 0)
+      continue;
+    _exit(EXIT_FAILURE);
+    pid_ptr++;
+  }
+}
+
+// We don't want to exit on any SIGCHLD from any child. child_pids is a sequence
+// of pids we are interested in.
+PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids) {
+  HANDLE_TH_ERRORS
+  // assert these types are lock free, just to be safe
+  THPUtils_assert(worker_pids.is_lock_free(), "worker_pids is not lock free");
+  THPUtils_assert(num_worker_pids.is_lock_free(), "num_worker_pids is not lock free");
+
+  THPUtils_assert(PyTuple_Check(child_pids), "_set_main_signal_handler "
+        "expects a list, but got %s", THPUtils_typename(child_pids));
+
+  num_dataloaders++;
+  auto size = PyTuple_GET_SIZE(child_pids);
+  for (int idx = 0; idx < size; idx++) {
+    PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
+    worker_pid_vec.push_back((pid_t) THPUtils_unpackLong(obj));
+  }
+  worker_pids = &worker_pid_vec[0];
+  num_worker_pids = worker_pid_vec.size();
+
+  int error = 0;
+  SET_SIGNAL_HANDLER(SIGCHLD, &handler_SIGCHLD_main, error);
+  if (error == 0) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_pids) {
+  HANDLE_TH_ERRORS
+  THPUtils_assert(PyTuple_Check(child_pids), "_remove_main_signal_handler "
+        "expects a tuple or list, but got %s", THPUtils_typename(child_pids));
+
+  auto size = PyTuple_GET_SIZE(child_pids);
+  std::set<pid_t> pid_set;
+  for (int idx = 0; idx < size; idx++) {
+    PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
+    pid_set.insert((pid_t) THPUtils_unpackLong(obj));
+  }
+  // During the following, worker_pids and num_worker_pids will likely not have
+  // correct values. However, it is guaranteed that all values in this array are
+  // child pids and contain all alive child pids.
+  auto write_it = worker_pid_vec.begin();
+  auto read_it = worker_pid_vec.begin();
+  size_t remaining_num = 0;
+  for (; read_it != worker_pid_vec.end(); read_it++) {
+    if (pid_set.find(*read_it) == pid_set.end()) {
+      *write_it = *read_it;
+      write_it++;
+      remaining_num++;
+    }
+  }
+  worker_pids = &worker_pid_vec[0];
+  num_worker_pids = remaining_num;
+  worker_pid_vec.resize(remaining_num);
+
+  int error = 0;
+
+  // Need to restore original handler so that in case DataLoader errors, the
+  // waitpids in hander won't block Python from updating Process.is_alive() and
+  // Process.exitcode, etc.
+  if (--num_dataloaders == 0)
+    SET_SIGNAL_HANDLER(SIGCHLD, SIG_DFL, error);
+
+  if (error == 0) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+#undef SIGNAL_HANDLER
+#undef SET_SIGNAL_HANDLER
+
+#else
+// dummy implementations for eindows
+
+PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *_ignored) {
+    Py_RETURN_TRUE;
+}
+
+PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *_ignored) {
+    Py_RETURN_TRUE;
+}
+
+PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *_ignored) {
+    Py_RETURN_TRUE;
+}
+
+#endif
+
+PyMethodDef DataLoaderMethods[] = {
+  {"_set_worker_signal_handlers",    (PyCFunction)THPModule_setWorkerSignalHandlers,    METH_NOARGS,  NULL},
+  {"_set_main_signal_handlers",      (PyCFunction)THPModule_setMainSignalHandlers,      METH_O,       NULL},
+  {"_remove_main_signal_handlers",   (PyCFunction)THPModule_removeMainSignalHandlers,   METH_O,       NULL},
+  {NULL, NULL, 0, NULL}
+};

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -1,10 +1,10 @@
 #include <sys/wait.h>
 #include <set>
+#include <atomic>
 #include <signal.h>
-
 #include "THP.h"
 
-// In cases like data loader, if a worker process die due to bus error/segfault
+// In cases like DataLoader, if a worker process die due to bus error/segfault
 // or just hang, the main process, if implemented with
 // multiprocessing.queue.SimpleQueue, will hang waiting for data. This is
 // difficult to avoid on PyTorch side as it can be caused by limited shm, or
@@ -21,7 +21,7 @@
 // doing work.
 // Python handle is _set_worker_signal_handlers().
 #define SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_MSG)                       \
-static void HANDLER_NAME(int sig)                                             \
+static void HANDLER_NAME(int sig, siginfo_t *info, void *ctx)                 \
 {                                                                             \
     write(STDERR_FILENO, ERROR_MSG, sizeof(ERROR_MSG) / sizeof(char));        \
     _exit(EXIT_FAILURE);                                                      \
@@ -29,63 +29,96 @@ static void HANDLER_NAME(int sig)                                             \
 
 // signal(2) is really not portable. So use sigaction.
 // http://man7.org/linux/man-pages/man2/signal.2.html
-#define SET_SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_FLAG)                  \
-{                                                                             \
-  struct sigaction sa;                                                        \
-  sa.sa_handler = HANDLER_NAME;                                               \
-  sa.sa_flags = SA_RESTART;                                                   \
-  sigemptyset(&sa.sa_mask);                                                   \
-  ERROR_FLAG |= sigaction(SIGNAL, &sa, NULL) != 0;                            \
+static int setSignalHandler(int signal, void(*handler)(int, siginfo_t *, void *), struct sigaction *old_sa_ptr)
+{
+  struct sigaction sa;
+  sa.sa_sigaction = handler;
+  sa.sa_flags = SA_RESTART|SA_SIGINFO|SA_NOCLDSTOP;
+  sigemptyset(&sa.sa_mask);
+  return sigaction(signal, &sa, old_sa_ptr);
 }
 
 SIGNAL_HANDLER(SIGBUS, handler_SIGBUS, "ERROR: Unexpected bus error encountered in worker. "
   "This might be caused by insufficient shared memory (shm).\n");
 SIGNAL_HANDLER(SIGSEGV, handler_SIGSEGV, "ERROR: Unexpected segmentation fault encountered in worker.\n");
 
+PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  int error = 0;
+  error |= setSignalHandler(SIGBUS, &handler_SIGBUS, NULL) != 0;
+  error |= setSignalHandler(SIGSEGV, &handler_SIGSEGV, NULL) != 0;
+  return PyBool_FromLong(!error);
+  END_HANDLE_TH_ERRORS
+}
+
 static std::vector<pid_t> worker_pid_vec = {};
 // The following are needed since std::vector is not asynchronous safe.
 static std::atomic<pid_t *> worker_pids;
 static std::atomic<size_t> num_worker_pids(0);
-static std::atomic<size_t> num_dataloaders(0);
 
-PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
-  HANDLE_TH_ERRORS
-  int error = 0;
-  SET_SIGNAL_HANDLER(SIGBUS, &handler_SIGBUS, error);
-  SET_SIGNAL_HANDLER(SIGSEGV, &handler_SIGSEGV, error);
-  if (error == 0) {
-    Py_RETURN_TRUE;
-  } else {
-    Py_RETURN_FALSE;
+static void updatePIDsArray() {
+  size_t new_size =  worker_pid_vec.size();
+  auto new_ptr = (pid_t *)malloc(sizeof(pid_t) * new_size);
+  for (size_t idx = 0; idx < new_size; idx++) {
+    new_ptr[idx] = worker_pid_vec[idx];
   }
-  END_HANDLE_TH_ERRORS
+  pid_t *old_ptr = worker_pids;
+  if (new_size < num_worker_pids) {
+    num_worker_pids = new_size;
+    worker_pids = new_ptr;
+  } else {
+    worker_pids = new_ptr;
+    num_worker_pids = new_size;
+  }
+  free(old_ptr);
 }
 
+static struct sigaction orig_SIGCHLD_sa;
+
 // SIGCHLD hander should be registered on main loader process to catch any
-// worker failing. SIGALRM handler is needed for implementing timeout.
-// Python handles are _set_main_signal_handers() and
-// _remove_main_signal_handers().
-static void handler_SIGCHLD_main(int sig) {
-  int status;
-  pid_t p;
-  pid_t *pid_ptr = worker_pids;
+// worker failing.
+// Python handles are _set_main_signal_handers_for_workers() and
+// _remove_main_signal_handers_for_workers().
+static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
+  int error;
+  siginfo_t infop;
 
   // Only check the pids we care about so that Python can see other processes'
   // status.
   for (size_t i = 0; i < num_worker_pids; i++) {
-    // The flags and status checks ensure that we are really observing a child
-    // exiting, rather than other cases such as SIGSTOP and SIGCONT.
-    // https://stackoverflow.com/a/40707100
-    p = waitpid(*pid_ptr, &status, WNOHANG|WUNTRACED|WCONTINUED);
-    // Ignore errors / no changes
-    if (p <= 0)
+    // Use waitid rather than waitpid so that we can set NOWAIT, and that Python
+    // can get whatever info it wants about the child process.
+    error = waitid(P_PID, worker_pids[i], &infop, WEXITED|WNOHANG|WNOWAIT);
+    if (error < 0)  // ignore errors
       continue;
-    if (WIFCONTINUED(status) || WIFSTOPPED(status))
+    if (infop.si_code == CLD_EXITED && infop.si_status == 0)  // ignore ones that exited w/o error
       continue;
-    if (WIFEXITED(status) != 0 && WEXITSTATUS(status) == 0)
+    if (infop.si_code == CLD_TRAPPED || infop.si_code == CLD_CONTINUED)
       continue;
     _exit(EXIT_FAILURE);
-    pid_ptr++;
+  }
+
+  // Call the overridden handler.
+  if ((orig_SIGCHLD_sa.sa_flags | SA_SIGINFO) != 0) {
+    orig_SIGCHLD_sa.sa_sigaction(sig, info, ctx);
+  } else if (orig_SIGCHLD_sa.sa_handler == SIG_DFL) {
+    // SIG_DFL for SIGCHLD is to leave the child as a zombie.. so do thing
+  } else if (orig_SIGCHLD_sa.sa_handler == SIG_IGN) {
+    // SIG_IGN for SIGCHLD is to reap the child and do nothing else.
+    while (waitpid(-1, 0, WNOHANG) > 0) {}
+  } else {
+    orig_SIGCHLD_sa.sa_handler(sig);
+  }
+}
+
+// returns -1 on error.
+static int isSIGCHLDHanderSet() {
+  struct sigaction sa;
+  int error = sigaction(SIGCHLD, NULL, &sa);
+  if (error == 0) {
+    return ((sa.sa_flags | SA_SIGINFO) != 0) && (sa.sa_sigaction == &handler_SIGCHLD_main);
+  } else {
+    return -1;
   }
 }
 
@@ -97,32 +130,32 @@ PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids
   THPUtils_assert(worker_pids.is_lock_free(), "worker_pids is not lock free");
   THPUtils_assert(num_worker_pids.is_lock_free(), "num_worker_pids is not lock free");
 
-  THPUtils_assert(PyTuple_Check(child_pids), "_set_main_signal_handler "
-        "expects a list, but got %s", THPUtils_typename(child_pids));
+  THPUtils_assert(PyTuple_Check(child_pids), "_set_main_signal_handlers_for_workers "
+        "expects a tuple, but got %s", THPUtils_typename(child_pids));
 
-  num_dataloaders++;
   auto size = PyTuple_GET_SIZE(child_pids);
   for (int idx = 0; idx < size; idx++) {
     PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
     worker_pid_vec.push_back((pid_t) THPUtils_unpackLong(obj));
   }
-  worker_pids = &worker_pid_vec[0];
-  num_worker_pids = worker_pid_vec.size();
+  updatePIDsArray();
 
+  // To avoid chain calling our handler, check if the current handler is already
+  // set as ours.
   int error = 0;
-  SET_SIGNAL_HANDLER(SIGCHLD, &handler_SIGCHLD_main, error);
-  if (error == 0) {
-    Py_RETURN_TRUE;
-  } else {
-    Py_RETURN_FALSE;
+  int set = isSIGCHLDHanderSet();
+  error |= set < 0;
+  if (set == 0) {
+    error |= setSignalHandler(SIGCHLD, &handler_SIGCHLD_main, &orig_SIGCHLD_sa) != 0;
   }
+  return PyBool_FromLong(!error);
   END_HANDLE_TH_ERRORS
 }
 
 PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_pids) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(PyTuple_Check(child_pids), "_remove_main_signal_handler "
-        "expects a tuple or list, but got %s", THPUtils_typename(child_pids));
+  THPUtils_assert(PyTuple_Check(child_pids), "_remove_main_signal_handlers_for_workers "
+        "expects a tuple, but got %s", THPUtils_typename(child_pids));
 
   auto size = PyTuple_GET_SIZE(child_pids);
   std::set<pid_t> pid_set;
@@ -130,44 +163,24 @@ PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_p
     PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
     pid_set.insert((pid_t) THPUtils_unpackLong(obj));
   }
-  // During the following, worker_pids and num_worker_pids will likely not have
-  // correct values. However, it is guaranteed that all values in this array are
-  // child pids and contain all alive child pids.
-  auto write_it = worker_pid_vec.begin();
-  auto read_it = worker_pid_vec.begin();
-  size_t remaining_num = 0;
-  for (; read_it != worker_pid_vec.end(); read_it++) {
-    if (pid_set.find(*read_it) == pid_set.end()) {
-      *write_it = *read_it;
-      write_it++;
-      remaining_num++;
-    }
-  }
-  worker_pids = &worker_pid_vec[0];
-  num_worker_pids = remaining_num;
-  worker_pid_vec.resize(remaining_num);
+  worker_pid_vec.erase(std::remove_if(worker_pid_vec.begin(), worker_pid_vec.end(),
+     [&](pid_t p){return pid_set.find(p) != pid_set.end();}), worker_pid_vec.end());
+  updatePIDsArray();
 
   int error = 0;
-
-  // Need to restore original handler so that in case DataLoader errors, the
-  // waitpids in hander won't block Python from updating Process.is_alive() and
-  // Process.exitcode, etc.
-  if (--num_dataloaders == 0)
-    SET_SIGNAL_HANDLER(SIGCHLD, SIG_DFL, error);
-
-  if (error == 0) {
-    Py_RETURN_TRUE;
-  } else {
-    Py_RETURN_FALSE;
+  int set = isSIGCHLDHanderSet();
+  error |= set < 0;
+  if (set == 1) {
+    error |= sigaction(SIGCHLD, &orig_SIGCHLD_sa, NULL) != 0;
   }
+  return PyBool_FromLong(!error);
   END_HANDLE_TH_ERRORS
 }
 
 #undef SIGNAL_HANDLER
-#undef SET_SIGNAL_HANDLER
 
 #else
-// dummy implementations for eindows
+// dummy implementations for windows
 
 PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *_ignored) {
     Py_RETURN_TRUE;
@@ -184,8 +197,8 @@ PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *_ignore
 #endif
 
 PyMethodDef DataLoaderMethods[] = {
-  {"_set_worker_signal_handlers",    (PyCFunction)THPModule_setWorkerSignalHandlers,    METH_NOARGS,  NULL},
-  {"_set_main_signal_handlers",      (PyCFunction)THPModule_setMainSignalHandlers,      METH_O,       NULL},
-  {"_remove_main_signal_handlers",   (PyCFunction)THPModule_removeMainSignalHandlers,   METH_O,       NULL},
+  {"_set_worker_signal_handlers",                (PyCFunction)THPModule_setWorkerSignalHandlers,    METH_NOARGS,  NULL},
+  {"_set_main_signal_handlers_for_workers",      (PyCFunction)THPModule_setMainSignalHandlers,      METH_O,       NULL},
+  {"_remove_main_signal_handlers_for_workers",   (PyCFunction)THPModule_removeMainSignalHandlers,   METH_O,       NULL},
   {NULL, NULL, 0, NULL}
 };

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -1,4 +1,5 @@
 #include <sys/wait.h>
+#include <map>
 #include <set>
 #include <atomic>
 #include <signal.h>
@@ -12,8 +13,9 @@
 // to do our best provide some error message to users when such unfortunate
 // events happen.
 
-// TODO: The following don't work on Windows. Specifically, waitid calls and
-// SIGCHLD handler. Currently, dummy implementation is provided for Windows.
+// TODO: The following don't work on Windows. Specifically, sigaction, waitid
+// calls ,and SIGCHLD handler. Currently, dummy implementations are provided
+// for Windows.
 
 #ifndef _WIN32
 
@@ -37,7 +39,7 @@ static void setSignalHandler(int signal, void(*handler)(int, siginfo_t *, void *
   sigemptyset(&sa.sa_mask);
   if (sigaction(signal, &sa, old_sa_ptr) != 0) {
     std::ostringstream oss;
-    oss << "An error occurred while setting handler for " << strsignal(signal);
+    oss << "An error occurred while setting handler for " << strsignal(signal) << ".";
     throw std::runtime_error(oss.str());
   }
 }
@@ -54,166 +56,75 @@ PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
   END_HANDLE_TH_ERRORS
 }
 
-static std::set<pid_t> worker_pid_set = {};
-// The following are needed since std::set is not asynchronous safe.
-static std::atomic<pid_t *> worker_pids;
-static std::atomic<size_t> num_worker_pids(0);
-// Pipe used as a lock to avoid update of the above and SIGCHLD handler in parallel.
-static int comm_pipe[2] = {-1, -1};
+static std::map<int64_t, std::set<pid_t>> worker_pids = {};
 
-static void updatePIDsArray() {
-  size_t new_size =  worker_pid_set.size();
-  auto new_ptr = (pid_t *)malloc(sizeof(pid_t) * new_size);
-  size_t idx = 0;
-  for (auto it = worker_pid_set.begin(); it != worker_pid_set.end(); it++, idx++) {
-    new_ptr[idx] = *it;
-  }
-
-  // Block SIGCHLD handler for this thread so SIGCHLD handler can't interrupt
-  // from this thread
-  sigset_t sigset, old_sigset;
-  sigemptyset(&sigset);
-  sigaddset(&sigset, SIGCHLD);
-  if (sigprocmask(SIG_BLOCK, &sigset, &old_sigset) != 0) {
-    throw std::runtime_error("An error occurred while setting worker information "
-      "for DataLoader SIGCHLD handler");
-  }
-  // Acquire ``lock'' so handlers on other threads can't interrupt
-  char c;
-  read(comm_pipe[0], &c, 1);
-
-  pid_t *old_ptr = worker_pids;
-  num_worker_pids = new_size;
-  worker_pids = new_ptr;
-  free(old_ptr);
-
-  // Release ``lock''
-  write(comm_pipe[1], &c, 1);
-  // Restore handler for this thread.
-  if (sigprocmask(SIG_SETMASK, &old_sigset, NULL) != 0) {
-    throw std::runtime_error("An error occurred while setting DataLoader SIGCHLD handler");
-  }
-}
-
-static struct sigaction orig_SIGCHLD_sa;
-
-// SIGCHLD hander should be registered on main loader process to catch any
-// worker failing.
-// Python handles are _set_main_signal_handers_for_workers() and
-// _remove_main_signal_handers_for_workers().
-static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
-  // Acquire ``lock'' so make sure that worker_pids won't change
-  char c;
-  read(comm_pipe[0], &c, 1);
-
+PyObject *THPModule_errorIfAnyWorkerFails(PyObject *module) {
+  HANDLE_TH_ERRORS
   int error;
+  std::set<pid_t> pid_set;
+  pid_t pid;
   siginfo_t infop;
 
-  // Only check the pids we care about so that Python can see other processes'
-  // status.
-  for (size_t i = 0; i < num_worker_pids; i++) {
-    // Use waitid rather than waitpid so that we can set NOWAIT, and that Python
-    // can get whatever info it wants about the child process.
-    error = waitid(P_PID, worker_pids[i], &infop, WEXITED|WNOHANG|WNOWAIT);
-    if (error < 0)  // ignore errors
-      continue;
-    if ((infop.si_code == CLD_EXITED && infop.si_status != 0) ||  // exit with error
-        (infop.si_code == CLD_KILLED) ||
-        (infop.si_code == CLD_DUMPED)) {
-      _exit(EXIT_FAILURE);
+  // Only check the pids we care about
+  for (auto it = worker_pids.begin(); it != worker_pids.end(); ++it) {
+    pid_set = it->second;
+    for (auto pid_it = pid_set.begin(); pid_it != pid_set.end(); ++pid_it) {
+      pid = *pid_it;
+      // Use waitid rather than waitpid so that we can set NOWAIT, and that Python
+      // and other handlers can get whatever info they want about the child.
+      error = waitid(P_PID, pid, &infop, WEXITED|WNOHANG|WNOWAIT);
+      if (error < 0)  // ignore errors
+        continue;
+      if ((infop.si_code == CLD_EXITED && infop.si_status != 0) ||  // exit with error
+          (infop.si_code == CLD_KILLED) ||
+          (infop.si_code == CLD_DUMPED)) {
+        std::ostringstream oss;
+        oss << "DataLoader worker (pid " << pid << ") exited unexpectedly.";
+        pid_set.clear();
+        throw std::runtime_error(oss.str());
+      }
     }
   }
-
-  // Release ``lock''
-  write(comm_pipe[1], &c, 1);
-
-  // Call the overridden handler.
-  if ((orig_SIGCHLD_sa.sa_flags | SA_SIGINFO) != 0) {
-    // handler is sa_sigaction, this shouldn't really be SIG_IGN or SIG_DFL, but
-    // sa_sigaction and sa_handler happen to be a union, and this fact is
-    // apparently used by Python, so check here.
-    // https://stackoverflow.com/a/24080440
-    if (orig_SIGCHLD_sa.sa_sigaction == (void (*)(int, siginfo_t *, void *)) SIG_IGN) {
-      // SIG_IGN for SIGCHLD is to reap the child and do nothing else.
-      while (waitpid(-1, 0, WNOHANG) > 0) {}
-    } else if (orig_SIGCHLD_sa.sa_sigaction != (void (*)(int, siginfo_t *, void *)) SIG_DFL) {
-      // SIG_DFL for SIGCHLD is to leave the child as a zombie (do nothing)
-      orig_SIGCHLD_sa.sa_sigaction(sig, info, ctx);
-    }
-  } else {
-    // handler is sa_handler
-    if (orig_SIGCHLD_sa.sa_handler == SIG_IGN) {
-      while (waitpid(-1, 0, WNOHANG) > 0) {}
-    } else if (orig_SIGCHLD_sa.sa_handler != SIG_DFL) {
-      orig_SIGCHLD_sa.sa_handler(sig);
-    }
-  }
-}
-
-static int isSIGCHLDHanderSet() {
-  struct sigaction sa;
-  int error = sigaction(SIGCHLD, NULL, &sa);
-  if (error == 0) {
-    return ((sa.sa_flags | SA_SIGINFO) != 0) && (sa.sa_sigaction == &handler_SIGCHLD_main);
-  } else {
-    throw std::runtime_error("An error occurred while checking DataLoader SIGCHLD handler");
-  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
 }
 
 // We don't want to exit on any SIGCHLD from any child. child_pids is a tuple
 // of pids we are interested in.
-PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids) {
+PyObject *THPModule_updateWorkerPIDs(PyObject *module, PyObject *args) {
   HANDLE_TH_ERRORS
-  // assert these types are lock free, just to be safe
-  THPUtils_assert(worker_pids.is_lock_free(), "worker_pids is not lock free");
-  THPUtils_assert(num_worker_pids.is_lock_free(), "num_worker_pids is not lock free");
+  Py_ssize_t num_args = args ? (Py_ssize_t) PyTuple_Size(args) : 0;
+  THPUtils_assert(num_args == 2, "_update_worker_pids expectes exactly 2 arguments.");
+  int64_t key = THPUtils_unpackLong(PyTuple_GET_ITEM(args, 0));
+  THPUtils_assert(worker_pids.find(key) == worker_pids.end(), "_update_worker_pids "
+        "should be called only once for each DataLoader.");
+  PyObject *child_pids = PyTuple_GET_ITEM(args, 1);
+  THPUtils_assert(PyTuple_Check(child_pids), "_update_worker_pids "
+        "expects a tuple for child_pids, but got %s.", THPUtils_typename(child_pids));
 
-  THPUtils_assert(PyTuple_Check(child_pids), "_set_main_signal_handlers_for_workers "
-        "expects a tuple, but got %s", THPUtils_typename(child_pids));
-
-  if (comm_pipe[0] == -1) {
-    // we have GIL here so we are fine
-    if (pipe(comm_pipe) != 0) {
-      throw std::runtime_error("An error occurred while setting DataLoader SIGCHLD handler");
-    }
-    char c = '_';
-    write(comm_pipe[1], &c, 1);
-  }
-
+  std::set<pid_t> pids_set = {};
   auto size = PyTuple_GET_SIZE(child_pids);
   for (int idx = 0; idx < size; idx++) {
     PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
-    worker_pid_set.insert((pid_t) THPUtils_unpackLong(obj));
+    pids_set.insert((pid_t) THPUtils_unpackLong(obj));
   }
-  updatePIDsArray();
 
-  // To avoid chain calling our handler, check if the current handler is already
-  // set as ours.
-  if (!isSIGCHLDHanderSet()) {
-    setSignalHandler(SIGCHLD, &handler_SIGCHLD_main, &orig_SIGCHLD_sa);
-  }
-  Py_RETURN_TRUE;
+  worker_pids[key] = pids_set;
+
+  Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_pids) {
+PyObject *THPModule_removeWorkerPIDs(PyObject *module, PyObject *loader_id) {
   HANDLE_TH_ERRORS
-  THPUtils_assert(PyTuple_Check(child_pids), "_remove_main_signal_handlers_for_workers "
-        "expects a tuple, but got %s", THPUtils_typename(child_pids));
 
-  auto size = PyTuple_GET_SIZE(child_pids);
-  for (int idx = 0; idx < size; idx++) {
-    PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
-    worker_pid_set.erase((pid_t) THPUtils_unpackLong(obj));
-  }
-  updatePIDsArray();
+  int64_t key = THPUtils_unpackLong(loader_id);
+  THPUtils_assert(worker_pids.find(key) != worker_pids.end(), "Cannot find worker "
+        "information for DataLoader with id %ld.", key);
 
-  if (isSIGCHLDHanderSet()) {
-    if (sigaction(SIGCHLD, &orig_SIGCHLD_sa, NULL) != 0) {
-      throw std::runtime_error("An error occurred while restoring DataLoader SIGCHLD handler");
-    }
-  }
-  Py_RETURN_TRUE;
+  worker_pids.erase(key);
+
+  Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
@@ -226,19 +137,24 @@ PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *_ignored
     Py_RETURN_TRUE;
 }
 
-PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *_ignored) {
+PyObject *THPModule_updateWorkerPIDs(PyObject *module, PyObject *_ignored) {
     Py_RETURN_TRUE;
 }
 
-PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *_ignored) {
-    Py_RETURN_TRUE;
+PyObject *THPModule_removeWorkerPIDs(PyObject *module, PyObject *_ignored) {
+    Py_RETURN_NONE;
+}
+
+PyObject *THPModule_exitIfAnyWorkerFails(PyObject *module, PyObject *_ignored) {
+    Py_RETURN_NONE;
 }
 
 #endif
 
 PyMethodDef DataLoaderMethods[] = {
-  {"_set_worker_signal_handlers",                (PyCFunction)THPModule_setWorkerSignalHandlers,    METH_NOARGS,  NULL},
-  {"_set_main_signal_handlers_for_workers",      (PyCFunction)THPModule_setMainSignalHandlers,      METH_O,       NULL},
-  {"_remove_main_signal_handlers_for_workers",   (PyCFunction)THPModule_removeMainSignalHandlers,   METH_O,       NULL},
+  {"_set_worker_signal_handlers",  (PyCFunction)THPModule_setWorkerSignalHandlers,  METH_NOARGS,   NULL},
+  {"_update_worker_pids",          (PyCFunction)THPModule_updateWorkerPIDs,         METH_VARARGS,  NULL},
+  {"_remove_worker_pids",          (PyCFunction)THPModule_removeWorkerPIDs,         METH_O,        NULL},
+  {"_error_if_any_worker_fails",   (PyCFunction)THPModule_errorIfAnyWorkerFails,    METH_NOARGS,   NULL},
   {NULL, NULL, 0, NULL}
 };

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -12,8 +12,8 @@
 // to do our best provide some error message to users when such unfortunate
 // events happen.
 
-// TODO: The following don't work on Windows. Specifically, waitpid calls and
-// SIGCHLD handler.
+// TODO: The following don't work on Windows. Specifically, waitid calls and
+// SIGCHLD handler. Currently, dummy implementation is provided for Windows.
 
 #ifndef _WIN32
 
@@ -29,13 +29,17 @@ static void HANDLER_NAME(int sig, siginfo_t *info, void *ctx)                 \
 
 // signal(2) is really not portable. So use sigaction.
 // http://man7.org/linux/man-pages/man2/signal.2.html
-static int setSignalHandler(int signal, void(*handler)(int, siginfo_t *, void *), struct sigaction *old_sa_ptr)
+static void setSignalHandler(int signal, void(*handler)(int, siginfo_t *, void *), struct sigaction *old_sa_ptr)
 {
   struct sigaction sa;
   sa.sa_sigaction = handler;
   sa.sa_flags = SA_RESTART|SA_SIGINFO|SA_NOCLDSTOP;
   sigemptyset(&sa.sa_mask);
-  return sigaction(signal, &sa, old_sa_ptr);
+  if (sigaction(signal, &sa, old_sa_ptr) != 0) {
+    std::ostringstream oss;
+    oss << "An error occurred while setting handler for " << strsignal(signal);
+    throw std::runtime_error(oss.str());
+  }
 }
 
 SIGNAL_HANDLER(SIGBUS, handler_SIGBUS, "ERROR: Unexpected bus error encountered in worker. "
@@ -44,26 +48,25 @@ SIGNAL_HANDLER(SIGSEGV, handler_SIGSEGV, "ERROR: Unexpected segmentation fault e
 
 PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
   HANDLE_TH_ERRORS
-  int error = 0;
-  error |= setSignalHandler(SIGBUS, &handler_SIGBUS, NULL) != 0;
-  error |= setSignalHandler(SIGSEGV, &handler_SIGSEGV, NULL) != 0;
-  return PyBool_FromLong(!error);
+  setSignalHandler(SIGBUS, &handler_SIGBUS, NULL);
+  setSignalHandler(SIGSEGV, &handler_SIGSEGV, NULL);
+  Py_RETURN_TRUE;
   END_HANDLE_TH_ERRORS
 }
 
-static std::vector<pid_t> worker_pid_vec = {};
-// The following are needed since std::vector is not asynchronous safe.
+static std::set<pid_t> worker_pid_set = {};
+// The following are needed since std::set is not asynchronous safe.
 static std::atomic<pid_t *> worker_pids;
 static std::atomic<size_t> num_worker_pids(0);
 // Pipe used as a lock to avoid update of the above and SIGCHLD handler in parallel.
 static int comm_pipe[2] = {-1, -1};
 
-static int updatePIDsArray() {
-
-  size_t new_size =  worker_pid_vec.size();
+static void updatePIDsArray() {
+  size_t new_size =  worker_pid_set.size();
   auto new_ptr = (pid_t *)malloc(sizeof(pid_t) * new_size);
-  for (size_t idx = 0; idx < new_size; idx++) {
-    new_ptr[idx] = worker_pid_vec[idx];
+  size_t idx = 0;
+  for (auto it = worker_pid_set.begin(); it != worker_pid_set.end(); it++, idx++) {
+    new_ptr[idx] = *it;
   }
 
   // Block SIGCHLD handler for this thread so SIGCHLD handler can't interrupt
@@ -72,29 +75,24 @@ static int updatePIDsArray() {
   sigemptyset(&sigset);
   sigaddset(&sigset, SIGCHLD);
   if (sigprocmask(SIG_BLOCK, &sigset, &old_sigset) != 0) {
-    return -1;
+    throw std::runtime_error("An error occurred while setting worker information "
+      "for DataLoader SIGCHLD handler");
   }
   // Acquire ``lock'' so handlers on other threads can't interrupt
   char c;
   read(comm_pipe[0], &c, 1);
 
   pid_t *old_ptr = worker_pids;
-  if (new_size < num_worker_pids) {
-    num_worker_pids = new_size;
-    worker_pids = new_ptr;
-  } else {
-    worker_pids = new_ptr;
-    num_worker_pids = new_size;
-  }
+  num_worker_pids = new_size;
+  worker_pids = new_ptr;
   free(old_ptr);
 
   // Release ``lock''
   write(comm_pipe[1], &c, 1);
   // Restore handler for this thread.
   if (sigprocmask(SIG_SETMASK, &old_sigset, NULL) != 0) {
-    return -1;
+    throw std::runtime_error("An error occurred while setting DataLoader SIGCHLD handler");
   }
-  return 0;
 }
 
 static struct sigaction orig_SIGCHLD_sa;
@@ -121,8 +119,7 @@ static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
       continue;
     if ((infop.si_code == CLD_EXITED && infop.si_status != 0) ||  // exit with error
         (infop.si_code == CLD_KILLED) ||
-        (infop.si_code == CLD_DUMPED) ||
-        (infop.si_code == CLD_TRAPPED)) {
+        (infop.si_code == CLD_DUMPED)) {
       _exit(EXIT_FAILURE);
     }
   }
@@ -133,8 +130,9 @@ static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
   // Call the overridden handler.
   if ((orig_SIGCHLD_sa.sa_flags | SA_SIGINFO) != 0) {
     // handler is sa_sigaction, this shouldn't really be SIG_IGN or SIG_DFL, but
-    // they happen to be a union, and this fact is apparently used in Python,
-    // so check here.
+    // sa_sigaction and sa_handler happen to be a union, and this fact is
+    // apparently used by Python, so check here.
+    // https://stackoverflow.com/a/24080440
     if (orig_SIGCHLD_sa.sa_sigaction == (void (*)(int, siginfo_t *, void *)) SIG_IGN) {
       // SIG_IGN for SIGCHLD is to reap the child and do nothing else.
       while (waitpid(-1, 0, WNOHANG) > 0) {}
@@ -144,7 +142,6 @@ static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
     }
   } else {
     // handler is sa_handler
-    // https://stackoverflow.com/a/24080440
     if (orig_SIGCHLD_sa.sa_handler == SIG_IGN) {
       while (waitpid(-1, 0, WNOHANG) > 0) {}
     } else if (orig_SIGCHLD_sa.sa_handler != SIG_DFL) {
@@ -153,18 +150,15 @@ static void handler_SIGCHLD_main(int sig, siginfo_t *info, void *ctx) {
   }
 }
 
-// returns -1 on error.
 static int isSIGCHLDHanderSet() {
   struct sigaction sa;
   int error = sigaction(SIGCHLD, NULL, &sa);
   if (error == 0) {
     return ((sa.sa_flags | SA_SIGINFO) != 0) && (sa.sa_sigaction == &handler_SIGCHLD_main);
   } else {
-    return -1;
+    throw std::runtime_error("An error occurred while checking DataLoader SIGCHLD handler");
   }
 }
-
-#define SAFECALL(CALL) if ((CALL) == -1) Py_RETURN_FALSE
 
 // We don't want to exit on any SIGCHLD from any child. child_pids is a tuple
 // of pids we are interested in.
@@ -179,7 +173,9 @@ PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids
 
   if (comm_pipe[0] == -1) {
     // we have GIL here so we are fine
-    SAFECALL(pipe(comm_pipe));
+    if (pipe(comm_pipe) != 0) {
+      throw std::runtime_error("An error occurred while setting DataLoader SIGCHLD handler");
+    }
     char c = '_';
     write(comm_pipe[1], &c, 1);
   }
@@ -187,16 +183,14 @@ PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids
   auto size = PyTuple_GET_SIZE(child_pids);
   for (int idx = 0; idx < size; idx++) {
     PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
-    worker_pid_vec.push_back((pid_t) THPUtils_unpackLong(obj));
+    worker_pid_set.insert((pid_t) THPUtils_unpackLong(obj));
   }
-  SAFECALL(updatePIDsArray());
+  updatePIDsArray();
 
   // To avoid chain calling our handler, check if the current handler is already
   // set as ours.
-  int set = 0;
-  SAFECALL(set = isSIGCHLDHanderSet());
-  if (set == 0) {
-    SAFECALL(setSignalHandler(SIGCHLD, &handler_SIGCHLD_main, &orig_SIGCHLD_sa));
+  if (!isSIGCHLDHanderSet()) {
+    setSignalHandler(SIGCHLD, &handler_SIGCHLD_main, &orig_SIGCHLD_sa);
   }
   Py_RETURN_TRUE;
   END_HANDLE_TH_ERRORS
@@ -208,19 +202,16 @@ PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_p
         "expects a tuple, but got %s", THPUtils_typename(child_pids));
 
   auto size = PyTuple_GET_SIZE(child_pids);
-  std::set<pid_t> pid_set;
   for (int idx = 0; idx < size; idx++) {
     PyObject* obj = PyTuple_GET_ITEM(child_pids, idx);
-    pid_set.insert((pid_t) THPUtils_unpackLong(obj));
+    worker_pid_set.erase((pid_t) THPUtils_unpackLong(obj));
   }
-  worker_pid_vec.erase(std::remove_if(worker_pid_vec.begin(), worker_pid_vec.end(),
-     [&](pid_t p){return pid_set.find(p) != pid_set.end();}), worker_pid_vec.end());
   updatePIDsArray();
 
-  int set = 0;
-  SAFECALL(set = isSIGCHLDHanderSet());
-  if (set == 1) {
-    SAFECALL(sigaction(SIGCHLD, &orig_SIGCHLD_sa, NULL));
+  if (isSIGCHLDHanderSet()) {
+    if (sigaction(SIGCHLD, &orig_SIGCHLD_sa, NULL) != 0) {
+      throw std::runtime_error("An error occurred while restoring DataLoader SIGCHLD handler");
+    }
   }
   Py_RETURN_TRUE;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -5,8 +5,6 @@
 #include <sys/socket.h>
 #endif
 
-#include <set>
-#include <signal.h>
 #include <stdbool.h>
 #include <unordered_map>
 #include <libshm.h>
@@ -30,6 +28,7 @@
 #include "THP.h"
 
 #include "ModuleSparse.cpp"
+#include "DataLoader.cpp"
 
 PyObject* module;
 PyObject* tensor_classes;
@@ -577,118 +576,6 @@ PyObject *THPModule_fromDLPack(PyObject *_unused, PyObject *data)
   return torch::createPyObject(atensor);
 }
 
-// In cases like data loader, if a worker process die due to bus error/segfault
-// or just hang, the main process, if implemented with multiprocessing.queue.,
-// will hang waiting for data. This is difficult to avoid on PyTorch side as it
-// can be caused by limited shm, other libraries users call in the workers. The
-// following methods is an effort to do our best provide some error message to
-// users when such unfortunate events happen.
-
-// Critical signal handlers should be registered on worker processes before
-// doing work.
-// Python handle is _set_worker_signal_handlers().
-#define SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_MSG)                       \
-static void HANDLER_NAME(int sig)                                             \
-{                                                                             \
-    write(fileno(stderr), ERROR_MSG, strlen(ERROR_MSG));                      \
-    _exit(EXIT_FAILURE);                                                      \
-}
-
-SIGNAL_HANDLER(SIGBUS, handler_SIGBUS, "ERROR: Unexpected bus error encountered in worker. "
-  "This might be caused by insufficient shared memory (shm).\n");
-SIGNAL_HANDLER(SIGSEGV, handler_SIGSEGV, "ERROR: Unexpected segmentation fault encountered in worker.\n");
-
-static std::mutex worker_pid_mutex;
-static std::vector<pid_t> worker_pid_vec = {};
-// The following are needed since std::vector is not asynchronous safe.
-static pid_t *worker_pids;
-static size_t num_worker_pids = 0;
-
-PyObject *THPModule_setWorkerSignalHandlers(PyObject *module, PyObject *arg) {
-    signal(SIGBUS, handler_SIGBUS);
-    signal(SIGSEGV, handler_SIGSEGV);
-    Py_RETURN_NONE;
-}
-
-// SIGCHLD hander should be registered on main loader process to catch any
-// worker failing. SIGALRM handler is needed for implementing timeout.
-// Python handles are _set_main_signal_handers() and
-// _remove_main_signal_handers().
-static void handler_SIGCHLD_main(int sig) {
-  int status;
-  pid_t p;
-  pid_t *pid_ptr;
-
-  // The flags and status checks ensure that we are really observing a child
-  // exiting, rather than other cases such as SIGSTOP and SIGCONT.
-  // https://stackoverflow.com/a/40707100
-  while ((p = waitpid(-1, &status, WNOHANG|WUNTRACED|WCONTINUED)) > 0) {
-    if (WIFCONTINUED(status) || WIFSTOPPED(status))
-      continue;
-    if (WIFEXITED(status) != 0 && WEXITSTATUS(status) == 0)
-      continue;
-    // child must have exited with signal/error, check if it is one of the pid
-    // we care about.
-    pid_ptr = worker_pids;
-    for (size_t i = 0; i < num_worker_pids; i++) {
-      if (*pid_ptr == p)
-        _exit(EXIT_FAILURE);
-      pid_ptr++;
-    }
-  }
-}
-
-SIGNAL_HANDLER(SIGALRM, handler_SIGALRM, "ERROR: Time out when fetching data in DataLoader.\n")
-
-// We don't want to exit on any SIGCHLD from any child. child_pids is a sequence
-// of pids we are interested in.
-PyObject *THPModule_setMainSignalHandlers(PyObject *module, PyObject *child_pids) {
-  auto tuple = PyTuple_Check(child_pids);
-  THPUtils_assert(tuple || PyList_Check(child_pids), "_set_main_signal_handler "
-        "expects a tuple or list, but got %s", THPUtils_typename(child_pids));
-
-  auto size = tuple ? PyTuple_GET_SIZE(child_pids) : PyList_GET_SIZE(child_pids);
-  {
-    std::unique_lock<std::mutex> lock(worker_pid_mutex);
-    for (int idx = 0; idx < size; idx++) {
-      PyObject* obj = tuple ? PyTuple_GET_ITEM(child_pids, idx) : PyList_GET_ITEM(child_pids, idx);
-      worker_pid_vec.push_back((pid_t) THPUtils_unpackLong(obj));
-    }
-    worker_pids = &worker_pid_vec[0];
-    num_worker_pids = worker_pid_vec.size();
-  }
-
-  signal(SIGCHLD, handler_SIGCHLD_main);
-  signal(SIGALRM, handler_SIGALRM);
-  Py_RETURN_NONE;
-}
-
-PyObject *THPModule_removeMainSignalHandlers(PyObject *module, PyObject *child_pids) {
-  auto tuple = PyTuple_Check(child_pids);
-  THPUtils_assert(tuple || PyList_Check(child_pids), "_remove_main_signal_handler "
-        "expects a tuple or list, but got %s", THPUtils_typename(child_pids));
-
-  auto size = tuple ? PyTuple_GET_SIZE(child_pids) : PyList_GET_SIZE(child_pids);
-  std::set<pid_t> pid_set;
-  for (int idx = 0; idx < size; idx++) {
-    PyObject* obj = tuple ? PyTuple_GET_ITEM(child_pids, idx) : PyList_GET_ITEM(child_pids, idx);
-    pid_set.insert((pid_t) THPUtils_unpackLong(obj));
-  }
-  {
-    std::unique_lock<std::mutex> lock(worker_pid_mutex);
-    worker_pid_vec.erase(std::remove_if(worker_pid_vec.begin(), worker_pid_vec.end(),
-      [&](pid_t p){return pid_set.find(p) != pid_set.end();}), worker_pid_vec.end());
-    worker_pids = &worker_pid_vec[0];
-    num_worker_pids = worker_pid_vec.size();
-  }
-
-  signal(SIGCHLD, SIG_DFL);
-  signal(SIGALRM, SIG_DFL);
-  Py_RETURN_NONE;
-}
-
-#undef SIGNAL_HANDLER
-
 #ifdef WITH_CUDA
 extern PyObject * THCSPModule_initExtension(PyObject *self);
 #endif
@@ -715,9 +602,6 @@ static PyMethodDef TorchMethods[] = {
   {"from_numpy",      (PyCFunction)THPModule_fromNumpy,         METH_O,       NULL},
   {"_to_dlpack",      (PyCFunction)THPModule_toDLPack,          METH_O,       NULL},
   {"_from_dlpack",    (PyCFunction)THPModule_fromDLPack,        METH_O,       NULL},
-  {"_set_worker_signal_handlers",    (PyCFunction)THPModule_setWorkerSignalHandlers,    METH_NOARGS,  NULL},
-  {"_set_main_signal_handlers",      (PyCFunction)THPModule_setMainSignalHandlers,      METH_O,       NULL},
-  {"_remove_main_signal_handlers",   (PyCFunction)THPModule_removeMainSignalHandlers,   METH_O,       NULL},
 
   {"sigmoid",         (PyCFunction)THPModule_sigmoid,           METH_VARARGS | METH_KEYWORDS, NULL},
   {"log",             (PyCFunction)THPModule_log,               METH_VARARGS | METH_KEYWORDS, NULL},
@@ -914,6 +798,7 @@ static PyObject* initModule() {
 #define ASSERT_TRUE(cmd) if (!(cmd)) return NULL
 
   THPUtils_addPyMethodDefs(methods, TorchMethods);
+  THPUtils_addPyMethodDefs(methods, DataLoaderMethods);
 #ifdef WITH_CUDA
   THPUtils_addPyMethodDefs(methods, THCPModule_methods());
 #endif

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -281,8 +281,7 @@ class DataLoaderIter(object):
 
     def _remove_handers(self):
         if self.handlers_set:
-            _remove_main_signal_handlers_for_workers(self.worker_pids)
-            self.handlers_set = False
+            self.handlers_set = not _remove_main_signal_handlers_for_workers(self.worker_pids)
 
     def __del__(self):
         if self.num_workers > 0:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -35,9 +35,9 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn):
     global _use_shared_memory
     _use_shared_memory = True
 
-    # Intialize C side signal handlers because Python signal handler on things
-    # like SIGBUS and SIGSEGV will still be executed in C and likely cause error
-    # again.
+    # Intialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
+    # module's handlers are executed after Python returns from C low-level
+    # handlers, likely when the same fatal signal happened again already.
     # https://docs.python.org/3/library/signal.html Sec. 18.8.1.1
     _set_worker_signal_handlers()
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -7,7 +7,6 @@ import signal
 import collections
 import re
 import sys
-import signal
 import traceback
 import threading
 from torch._six import string_classes
@@ -144,11 +143,13 @@ def pin_memory_batch(batch):
     else:
         return batch
 
+
 def _set_SIGCHLD_handler():
     global _SIGCHLD_handler_set
     if _SIGCHLD_handler_set:
         return
     previous_handler = signal.getsignal(signal.SIGCHLD)
+
     def handler(signum, frame):
         _error_if_any_worker_fails()
         if callable(previous_handler):


### PR DESCRIPTION
1. Make DataLoader workers a bit more verbose on bus error and segfault, implemented with C++ signal handlers. Partially addresses https://github.com/pytorch/pytorch/issues/1355
2. Adding timeout option to DataLoader, implemented with SIGALRM. https://github.com/pytorch/pytorch/issues/2474 

Test plan (modified from script by @fmassa in #1595 ):
1. Segfault case:
script: 
```
class DS(object):
    def __getitem__(self, idx):
        import ctypes;ctypes.string_at(0)
        return torch.rand(1000000)
    def __len__(self):
        return 200

ds = DS()
it = torch.utils.data.DataLoader(ds, batch_size=10, num_workers=10)

for i, data in enumerate(it):
    print(i)
```
output: 
```
[~] python ds.py
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
ERROR: Unexpected segmentation fault encountered in worker.
[~] # Doesn't hang anymore
```

2. Timeout:
script:
```
import time

class DS(object):
    def __getitem__(self, idx):
        time.sleep(10)
        return torch.rand(1000000)
    def __len__(self):
        return 200

ds = DS()
it = torch.utils.data.DataLoader(ds, batch_size=10, num_workers=10, timeout=2)

for i, data in enumerate(it):
    print(i)
```
output:
```
[~] python ds.py
ERROR: Time out when fetching data in DataLoader.
[~]
```

Since this is deep into multiprocessing and low level signal handling, there might be cases/things I haven't considered. I'll also leave some comment below.

cc @apaszke @colesbury 