### PR TITLE
fix copy-paste error in #3263

### DIFF
--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -183,7 +183,7 @@ void THCTensor_(put)(THCState *state, THCTensor *dst, THCudaLongTensor *index, T
     THCTensor* sorted_src = THCTensor_(newClone)(state, src);
 
     THCTensor_(sort_indices)(state, sorted_index, sorted_src);
-    dispatchTakePut<real, TensorPutAccumulateOp>(state, dst, src, index);
+    dispatchTakePut<real, TensorPutAccumulateOp>(state, dst, sorted_src, sorted_index);
 
     THCTensor_(free)(state, sorted_src);
     THCudaLongTensor_free(state, sorted_index);


### PR DESCRIPTION
I have no idea how it worked on cuda 8, but apparently this fixes failures on cuda 9. cc @colesbury