### PR TITLE
Add REINFORCE rule to distributions doc

### DIFF
--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -2,16 +2,29 @@
 The ``distributions`` package contains parameterizable probability distributions
 and sampling functions.
 
-The :meth:`log_prob` method is useful for policy gradient based methods. If the
-parameters of the distribution are differentiable, then the result of ``log_prob``
-is also differentiable.
+Policy gradient methods can be implemented using the :meth:`log_prob` method,
+when the probability density function is differentiable with respect to its
+parameters. A basic method is the REINFORCE rule:
 
-Example::
+.. math::
 
-    probs = network(input)
+    \Delta\theta  = \alpha r \frac{\partial\log p(a|\pi^\theta(s))}{\partial\theta}
+
+where :math:`\theta` are the parameters, :math:`\alpha` is the learning rate,
+:math:`r` is the reward and :math:`p(a|\pi^\theta(s))` is the probability of
+taking action :math:`a` in state :math:`s` given policy :math:`\pi^\theta`.
+
+In practice we would sample an action from the output of a network, apply this
+action in an environment, and then use ``log_prob`` to construct an equivalent
+loss function. Note that we use a negative because optimisers use gradient
+descent, whilst the rule above assumes gradient ascent. With a multinomial
+policy, the code for implementing REINFORCE would be as follows::
+
+    probs = policy_network(state)
     m = Multinomial(probs)
     action = m.sample()
-    loss = -m.log_prob(action) * get_reward(env, action)
+    next_state, reward = env.step(action)
+    loss = -m.log_prob(action) * reward
     loss.backward()
 """
 import math


### PR DESCRIPTION
Adds maths and code that slightly better matches typical RL code (trade-off between readability and accuracy of things like unwrapping Variables, see https://github.com/pytorch/pytorch/pull/3165). As a bonus, people looking for `reinforce` in the docs should hit this page. cc @colesbury @hughperkins