### PR TITLE
Create an ONNX ATen exporting mode

### DIFF
--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -24,7 +24,8 @@ bool hasUsedHandle(Node *node) {
 } // anonymous namespace
 
 // Transform PythonOps and Cpp Ops into Node's that match ONNX semantics.
-void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
+// Argument aten indicates whether we should export ops as "ATen" ONNX ops if possible.
+void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
   // Check that the tracing state is live (it should be, because
   // you were supposed to request zero derivatives.)
   if (state->is_expired()) {
@@ -150,7 +151,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
         py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
-    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs);
+    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
     processSymbolicOutput(symbolToString(n->kind()), n, raw_output);
   };

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -5,6 +5,6 @@
 
 namespace torch { namespace jit {
 
-void ToONNX(std::shared_ptr<tracer::TracingState>& state);
+void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten);
 
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -106,6 +106,9 @@ void initPythonIRBindings(PyObject * module_) {
     .def("hasMultipleOutputs",[](Node&n) {
       return n.outputs().size() > 1;
     })
+    .def("outputsSize",[](Node &n) {
+      return n.outputs().size();
+    })
     .NS(kind)
     .NS(stage)
     .NS(setStage)

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -40,7 +40,8 @@ def set_training(model, mode):
             model.train(old_mode)
 
 
-def export(model, args, f, export_params=True, verbose=False, training=False, input_names=None, output_names=None):
+def export(model, args, f, export_params=True, verbose=False, training=False,
+           input_names=None, output_names=None, aten=False):
     """
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported; at the
@@ -75,14 +76,17 @@ def export(model, args, f, export_params=True, verbose=False, training=False, in
             input nodes of the graph, in order
         output_names(list of strings, default empty list): names to assign to the
             output nodes of the graph, in order
+        aten (bool, default False): export the model in aten mode. If using aten mode,
+            all the ops original exported by the functions in symbolic.py are exported
+            as ATen ops.
     """
     _export(model, args, f, export_params, verbose, training, input_names, output_names)
 
 
-def _optimize_trace(trace):
+def _optimize_trace(trace, aten):
     torch._C._jit_pass_peephole(trace)
     torch._C._jit_pass_lint(trace)
-    torch._C._jit_pass_onnx(trace)
+    torch._C._jit_pass_onnx(trace, aten)
     torch._C._jit_pass_lint(trace)
     torch._C._jit_pass_onnx_peephole(trace)
     torch._C._jit_pass_lint(trace)
@@ -102,7 +106,8 @@ def _trace(func, args, return_outs=False):
     return trace
 
 
-def _export(model, args, f, export_params=True, verbose=False, training=False, input_names=None, output_names=None):
+def _export(model, args, f, export_params=True, verbose=False, training=False,
+            input_names=None, output_names=None, aten=False):
     # Special case for common case of passing a single Variable
     if isinstance(args, torch.autograd.Variable):
         args = (args, )
@@ -123,7 +128,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=False, i
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
-    _optimize_trace(trace)
+    _optimize_trace(trace, aten)
 
     _set_input_and_output_names(trace.graph(), input_names, output_names)
 
@@ -173,7 +178,13 @@ def _run_symbolic_method(op_name, symbolic_fn, args):
         raise
 
 
-def _add_attribute(node, key, value):
+def _is_onnx_list(value):
+    if not isinstance(value, string_classes) and not torch.is_tensor(value) and isinstance(value, collections.Iterable):
+        return True
+    return False
+
+
+def _add_attribute(node, key, value, aten):
     """ initializes the right attribute based on type of value """
     m = attr_pattern.match(key)
     if m is None:
@@ -181,15 +192,35 @@ def _add_attribute(node, key, value):
             "Invalid attribute specifier '{}' names " +
             " must be suffixed with type, e.g. 'dim_i' or 'dims_i'").format(key))
     name, kind = m.group(1), m.group(2)
-    if not isinstance(value, string_classes) and not torch.is_tensor(value) and isinstance(value, collections.Iterable):
+    if _is_onnx_list(value):
         kind += "s"
-    return getattr(node, kind + '_')(name, value)
+    if aten:
+        if torch.is_tensor(value):
+            # Caffe2 proto does not support tensor attribute.
+            if value.numel() > 1:
+                raise ValueError("Should not pass tensor attribute")
+            value = _scalar(value)
+            if isinstance(value, float):
+                kind = "f"
+            else:
+                kind = "i"
+    return getattr(node, kind + "_")(name, value)
+
+
+def _scalar(x):
+    """Convert a scalar tensor into a Python value."""
+    assert x.numel() == 1
+    return x[0]
 
 
 def _newNode(g, opname, outputs, *args, **kwargs):
+    aten = kwargs.pop("aten", False)
     n = g.create(opname, args, outputs)
     for k, v in sorted(kwargs.items()):
-        _add_attribute(n, k, v)
+        # TODO: enable inplace in aten exporting mode.
+        if k == "inplace":
+            continue
+        _add_attribute(n, k, v, aten=aten)
     return n
 
 
@@ -249,7 +280,7 @@ def _graph_op(g, opname, *raw_args, **kwargs):
 # inplace annotations, but we are losing information this way.
 
 
-def _run_symbolic_function(g, n, inputs):
+def _run_symbolic_function(g, n, inputs, aten=False):
     import torch.onnx.symbolic
 
     try:
@@ -258,12 +289,20 @@ def _run_symbolic_function(g, n, inputs):
             op_name = n.kind()[:-1]
         else:
             op_name = n.kind()
+        # Export ops in aten mode.
+        if aten:
+            attrs = {k + "_" + n.kindOf(k)[0]: n[k] for k in n.attributeNames()}
+            outputs = n.outputsSize()
+            attrs["outputs"] = outputs
+            return _graph_at(g, op_name, *inputs, aten=True, **attrs)
+
+        # Export ONNX regular ops.
+        attrs = {k: n[k] for k in n.attributeNames()}
         if not hasattr(torch.onnx.symbolic, op_name):
             warnings.warn("ONNX export failed on {} because torch.onnx.symbolic.{} does not exist"
                           .format(op_name, op_name))
             return None
         fn = getattr(torch.onnx.symbolic, op_name)
-        attrs = {k: n[k] for k in n.attributeNames()}
         return fn(g, *inputs, **attrs)
 
     except TypeError as e:
@@ -273,6 +312,7 @@ def _run_symbolic_function(g, n, inputs):
         raise
 
 
+# Generate an ONNX ATen op node.
 def _graph_at(g, opname, *args, **kwargs):
     return g.op("ATen", *args, operator_s=opname, **kwargs)
 


### PR DESCRIPTION
All ops exported in symbolic.py will be exported as ATen ops.