### PR TITLE
Add single argument version of torch.arange

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -510,13 +510,22 @@
     - CPU
     - CUDA
   return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - accreal start
-    - accreal end
-    - arg: accreal step
-      default: 1
+  options:
+    - cname: arange
+      arguments:
+        - arg: THTensor* result
+          output: True
+        - accreal start
+        - accreal end
+        - arg: accreal step
+          default: 1
+    - cname: arange
+      arguments:
+        - arg: THTensor* result
+          output: True
+        - CONSTANT 0
+        - accreal end
+        - CONSTANT 1
 ]]
 [[
   name: scatter_

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -514,6 +514,7 @@
     - arg: THTensor* result
       output: True
     - accreal start
+      default: 0
     - accreal end
     - arg: accreal step
       default: 1

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1111,6 +1111,11 @@ class TestTorch(TestCase):
         torch.arange(0, 1, out=res2)
         self.assertEqual(res1, res2, 0)
 
+        # Check arange with only one argument
+        res1 = torch.arange(10)
+        res2 = torch.arange(0, 10)
+        self.assertEqual(res1, res2, 0)
+
         # Check arange for non-contiguous tensors.
         x = torch.zeros(2, 3)
         torch.arange(0, 4, out=x.narrow(1, 1, 2))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3691,7 +3691,7 @@ Example::
 
 add_docstr(torch._C.arange,
            """
-arange(start, end, step=1, out=None) -> Tensor
+arange(start=0, end, step=1, out=None) -> Tensor
 
 Returns a 1D Tensor of size :math:`floor((end - start) / step)` with values
 from the interval ``[start, end)`` taken with step :attr:`step` starting
@@ -3704,6 +3704,15 @@ Args:
     out (Tensor, optional): The result `Tensor`
 
 Example::
+
+    >>> torch.arange(5)
+
+     0
+     1
+     2
+     3
+     4
+    [torch.FloatTensor of size 5]
 
     >>> torch.arange(1, 4)
 

--- a/torch/csrc/generic/methods/Tensor.cwrap
+++ b/torch/csrc/generic/methods/Tensor.cwrap
@@ -761,6 +761,12 @@ PyObject * THPTensor_(stride)(PyObject *self, PyObject *args, PyObject *kwargs)
         - accreal start
         - accreal end
         - CONSTANT 1
+      - arguments:
+        - arg: THTensor* result
+          output: True
+        - CONSTANT 0
+        - accreal end
+        - CONSTANT 1
 ]]
 
 [[


### PR DESCRIPTION
As part of #1875 this PR adds single argument version of torch.arange. Usage:
```Python
import torch
torch.arange(5)

 0
 1
 2
 3
 4
[torch.FloatTensor of size 5]
```