### PR TITLE
ignore digit in container's `__dir__`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -584,13 +584,18 @@ class TestNN(NNTestCase):
         linear._test_submodule = nn.Linear(2, 2)
         linear._test_parameter = Parameter(torch.Tensor(2, 2))
         linear.register_buffer('_test_buffer', torch.Tensor(2, 2))
-        keys = linear.__dir__()
+        keys = dir(linear)
         self.assertIn('_test_submodule', keys)
         self.assertIn('_test_parameter', keys)
         self.assertIn('_test_buffer', keys)
 
         for key in keys:
             self.assertTrue(hasattr(linear, key))
+
+    def test_dir_digit(self):
+        model = nn.Sequential(nn.Linear(2, 2))
+        keys = dir(model)
+        self.assertNotIn('0', keys)
 
     def test_named_children(self):
         l1 = nn.Linear(2, 2)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -62,6 +62,11 @@ class Sequential(Module):
     def __len__(self):
         return len(self._modules)
 
+    def __dir__(self):
+        keys = super(Sequential, self).__dir__()
+        keys = [key for key in keys if not key.isdigit()]
+        return keys
+
     def forward(self, input):
         for module in self._modules.values():
             input = module(input)
@@ -114,6 +119,11 @@ class ModuleList(Module):
 
     def __iadd__(self, modules):
         return self.extend(modules)
+
+    def __dir__(self):
+        keys = super(ModuleList, self).__dir__()
+        keys = [key for key in keys if not key.isdigit()]
+        return keys
 
     def append(self, module):
         r"""Appends a given module at the end of the list.
@@ -185,6 +195,11 @@ class ParameterList(Module):
 
     def __iadd__(self, parameters):
         return self.extend(parameters)
+
+    def __dir__(self):
+        keys = super(ParameterList, self).__dir__()
+        keys = [key for key in keys if not key.isdigit()]
+        return keys
 
     def append(self, parameter):
         """Appends a given parameter at the end of the list.


### PR DESCRIPTION
in the previous implementation, `__dir__`would yield numbers if `self` is an instance of `nn.Sequential`.
![_2017-11-06_14-15-11](https://user-images.githubusercontent.com/9301117/32440098-a429f446-c32c-11e7-9fa8-f2fc1cba9e43.png)
