### PR TITLE
Fix error message for type mismatches with sparse tensors

### DIFF
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -63,8 +63,8 @@ std::string processErrorMsg(std::string str) {
     {"CPUHalfType", "torch.HalfTensor"},
   };
 
-  for (const auto & it : changes) {
-    replaceAll(str, it.first, it.second);
+  for (auto it = changes.rbegin(); it != changes.rend(); ++it) {
+    replaceAll(str, it->first, it->second);
   }
 
   return str;

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -1,6 +1,7 @@
 #include <Python.h>
 
-#include <map>
+#include <utility>
+#include <vector>
 
 #include "THP.h"
 
@@ -28,7 +29,7 @@ void replaceAll(std::string & str,
 std::string processErrorMsg(std::string str) {
 
   // Translate Aten types to their respective pytorch ones
-  std::map<std::string, std::string> changes = {
+  std::vector<std::pair<std::string, std::string>> changes {
     {"SparseCUDAByteType", "torch.cuda.sparse.ByteTensor"},
     {"SparseCUDACharType", "torch.cuda.sparse.CharTensor"},
     {"SparseCUDADoubleType", "torch.cuda.sparse.DoubleTensor"},
@@ -63,8 +64,8 @@ std::string processErrorMsg(std::string str) {
     {"CPUHalfType", "torch.HalfTensor"},
   };
 
-  for (auto it = changes.rbegin(); it != changes.rend(); ++it) {
-    replaceAll(str, it->first, it->second);
+  for (const auto & it : changes) {
+    replaceAll(str, it.first, it.second);
   }
 
   return str;


### PR DESCRIPTION
There was a bug that SparseCPUFloatType would be translated to "Sparsetorch.FloatTensor". This happened because the find and replace code would iterate through the map of find and replaces from shortest key to longest key, replacing CPUFloatType with "torch.FloatTensor" before SparseCPUFloatType was found and replaced with "torch.sparse.FloatTensor".

This makes it so that the map is iterated through in reverse order.

### Test Plan
Is there a conventional way in pytorch for unit tests in C++?

Run code to trigger the Sparse tensor type mismatch:
```
import torch
x = torch.sparse.FloatTensor(5, 5)
y = torch.FloatTensor(5, 5)

torch.mm(x, y) # works

xx = torch.autograd.Variable(x)
xy = torch.autograd.Variable(y)
print(type(x), type(xx))

torch.mm(xx, xy) 
```
Assert that the error message is better:
![image](https://user-images.githubusercontent.com/5652049/32448282-83c583be-c2dc-11e7-9b8c-91cd2e7bd02d.png)
