### PR TITLE
add CMake flag for disabling ATen contrib builds

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -70,5 +70,10 @@ include_directories(
 ${CMAKE_CURRENT_SOURCE_DIR}/src
 ${CMAKE_CURRENT_BINARY_DIR}/src/ATen)
 add_subdirectory(src/ATen/test)
-add_subdirectory(contrib/data)
-add_subdirectory(contrib/meter)
+
+if(ATEN_NO_CONTRIB)
+  message("disable contrib because ATEN_NO_CONTRIB is set")
+else()
+  add_subdirectory(contrib/data)
+  add_subdirectory(contrib/meter)
+endif()

--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -143,6 +143,7 @@ function build_aten() {
   ${CMAKE_VERSION} ../../../../aten \
   -DCMAKE_BUILD_TYPE=Release \
   -DNO_CUDA=$((1-$WITH_CUDA)) \
+  -DATEN_NO_CONTRIB=1 \
   -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
   # purpusefully not passing C_FLAGS for the same reason as above
   make -j$(getconf _NPROCESSORS_ONLN) install


### PR DESCRIPTION
We don't need to build these libraries when building inside PyTorch.