### PR TITLE
Use ASSERT(...) rather than assert(...) in ATen tests.

### DIFF
--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -1,4 +1,5 @@
 #include "ATen/ATen.h"
+#include "test_assert.h"
 
 #include<iostream>
 using namespace std;
@@ -12,7 +13,7 @@ void check(bool c) {
 void trace() {
   Tensor foo = CPU(kFloat).rand({12,12});
 
-  // assert foo is 2-dimensional and holds floats.
+  // ASSERT foo is 2-dimensional and holds floats.
   auto foo_a = foo.accessor<float,2>();
   float trace = 0;
 
@@ -23,7 +24,7 @@ void trace() {
 }
 int main() {
   auto foo = CPU(kFloat).rand({12,6});
-  assert(foo.data<float>() == foo.toFloatData());
+  ASSERT(foo.data<float>() == foo.toFloatData());
 
   cout << foo << "\n" << foo.size(0) << " " << foo.size(1) << endl;
 

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -1,4 +1,5 @@
 #include "ATen/ATen.h"
+#include "test_assert.h"
 
 using namespace at;
 
@@ -10,7 +11,7 @@ int main() {
   try {
     auto empty = T.randn({0});
     empty.expand({3});
-    assert(false);
+    ASSERT(false);
   } catch(std::runtime_error &e) {}
 
   // 1) out-place function with 2 args
@@ -19,20 +20,20 @@ int main() {
     auto a = T.randn({3, 1});
     auto b = T.randn({5});
     std::vector<int64_t> expanded_sizes = {3, 5};
-    assert((a + b).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes)));
+    ASSERT((a + b).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes)));
 
     // with scalar
     auto aScalar = T.ones({1});
     aScalar.get()->maybeScalar(true);
     b = T.randn({3, 5});
-    assert((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
+    ASSERT((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
 
     // old fallback behavior yields error
     try {
       auto a = T.randn({3, 5});
       auto b = T.randn({5, 3});
       a + b;
-      assert(false);
+      ASSERT(false);
     } catch (std::runtime_error &e) {}
 
     // with mismatched sizes
@@ -40,7 +41,7 @@ int main() {
       auto a = T.randn({3, 5});
       auto b = T.randn({7, 5});
       a + b;
-      assert(false);
+      ASSERT(false);
     } catch (std::runtime_error &e) {}
   }
 
@@ -51,14 +52,14 @@ int main() {
     auto b = T.randn({1, 2, 1});
     auto c = T.randn({1, 1, 5});
     std::vector<int64_t> expanded_sizes = {3, 2, 5};
-    assert((a + b + c).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes) + c.expand(expanded_sizes)));
+    ASSERT((a + b + c).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes) + c.expand(expanded_sizes)));
 
     // with scalar
     auto aTensorScalar = T.ones({1});
     aTensorScalar.get()->maybeScalar(true);
     b = T.randn({3, 2, 1});
     c = T.randn({1, 2, 5});
-    assert(aTensorScalar.addcmul(b, c).equal(
+    ASSERT(aTensorScalar.addcmul(b, c).equal(
            aTensorScalar.expand(expanded_sizes).addcmul(b.expand(expanded_sizes), c.expand(expanded_sizes))));
 
     // old fallback behavior yields error
@@ -67,14 +68,14 @@ int main() {
       auto b = T.randn({2, 3, 5});
       auto c = T.randn({5, 3, 2});
       a.addcmul(b, c);
-      assert(false);
+      ASSERT(false);
     } catch(std::runtime_error &e) {}
 
     // with mismatched sizes
     try {
       auto c = T.randn({5, 5, 5});
       a.addcmul(b, c);
-      assert(false);
+      ASSERT(false);
     } catch(std::runtime_error &e) {}
   }
 
@@ -83,19 +84,19 @@ int main() {
     // basic
     auto a = T.randn({3, 5});
     auto b = T.randn({3, 1});
-    assert((a + b).equal(a + b.expand({3, 5})));
+    ASSERT((a + b).equal(a + b.expand({3, 5})));
 
     // with scalar
     auto bScalar = T.ones({1});
     bScalar.get()->maybeScalar(true);
-    assert((a + bScalar).equal(a + bScalar.expand(a.sizes())));
+    ASSERT((a + bScalar).equal(a + bScalar.expand(a.sizes())));
 
     // error: would have to expand inplace arg
     try {
       auto a = T.randn({1, 5});
       auto b = T.randn({3, 1});
       a.add_(b);
-      assert(false);
+      ASSERT(false);
     } catch(std::runtime_error &e) {}
   }
 
@@ -107,12 +108,12 @@ int main() {
     auto b = T.randn({3, 1, 2});
     auto c = T.randn({1, 5, 1});
 
-    assert(a.addcmul_(b, c).equal(aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
+    ASSERT(a.addcmul_(b, c).equal(aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
 
     // with scalar
     auto bScalar = T.ones({1});
     bScalar.get()->maybeScalar(true);
-    assert(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
+    ASSERT(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
 
     // error: would have to expand inplace arg
     try {
@@ -120,7 +121,7 @@ int main() {
       auto b = T.randn({4, 1, 1});
       auto c = T.randn({1, 3, 1});
       a.addcmul_(b, c);
-      assert(false);
+      ASSERT(false);
     } catch(std::runtime_error &e) {}
   }
 
@@ -130,18 +131,18 @@ int main() {
     auto a = T.randn({1});
     auto b = T.randn({5, 3});
     auto c = T.randn({3, 7});
-    assert(a.addmm(b, c).equal(a.expand({5,7}).addmm(b, c)));
+    ASSERT(a.addmm(b, c).equal(a.expand({5,7}).addmm(b, c)));
 
     // with scalar
     Tensor aScalar = T.ones({1});
     aScalar.get()->maybeScalar(true);
-    assert(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
+    ASSERT(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
 
     // with mismatched sizes
     try {
       auto a = T.randn({3, 3});
       a.addmm(b, c);
-      assert(false);
+      ASSERT(false);
     } catch(std::runtime_error &e) {}
   }
 

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -1,11 +1,12 @@
 #include "ATen/ATen.h"
+#include "test_assert.h"
 
 using namespace at;
 
 void assertEqualTensorList(TensorList t1, TensorList t2) {
-  assert(t1.size() == t2.size());
+  ASSERT(t1.size() == t2.size());
   for (size_t i = 0; i < t1.size(); ++i) {
-    assert(t1[ i ].equal(t2[ i ]));
+    ASSERT(t1[ i ].equal(t2[ i ]));
   }
 }
 
@@ -23,7 +24,7 @@ int main() {
     assertEqualTensorList(splitMethod, splitNs);
 
     // test rebuilding with cat
-    assert(at::cat(splitMethod, 0).equal(t));
+    ASSERT(at::cat(splitMethod, 0).equal(t));
   }
 
   {
@@ -35,7 +36,7 @@ int main() {
     assertEqualTensorList(chunkMethod, chunkNs);
 
     // test rebuilding with cat
-    assert(at::cat(chunkMethod, 0).equal(t));
+    ASSERT(at::cat(chunkMethod, 0).equal(t));
   }
 
   // stack
@@ -51,11 +52,11 @@ int main() {
       expected_size.insert(expected_size.end(), 3);
       expected_size.insert(expected_size.end(), x.sizes().begin() + dim, x.sizes().end());
 
-      assert(res.equal(res_neg));
-      assert(res.sizes().equals(expected_size));
-      assert(res.select(dim, 0).equal(x));
-      assert(res.select(dim, 1).equal(y));
-      assert(res.select(dim, 2).equal(z));
+      ASSERT(res.equal(res_neg));
+      ASSERT(res.sizes().equals(expected_size));
+      ASSERT(res.select(dim, 0).equal(x));
+      ASSERT(res.select(dim, 1).equal(y));
+      ASSERT(res.select(dim, 2).equal(z));
     }
   }
 

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -1,12 +1,13 @@
 #include "ATen/ATen.h"
+#include "test_assert.h"
 #include <iostream>
 #include <numeric>
 
 using namespace at;
 
 void assert_equal_size_dim(const Tensor &lhs, const Tensor &rhs) {
-  assert(lhs.dim() == rhs.dim());
-  assert(lhs.sizes().equals(rhs.sizes()));
+  ASSERT(lhs.dim() == rhs.dim());
+  ASSERT(lhs.sizes().equals(rhs.sizes()));
 }
 
 bool should_expand(const IntList &from_size, const IntList &to_size) {
@@ -32,12 +33,12 @@ int main() {
   for (auto s = sizes.begin(); s != sizes.end(); ++s) {
     // verify that the dim, sizes, strides, etc match what was requested.
     auto t = T.ones(*s);
-    assert(t.dim() == s->size());
-    assert(t.ndimension() == s->size());
-    assert(t.sizes().equals(*s));
-    assert(t.strides().size() == s->size());
+    ASSERT(t.dim() == s->size());
+    ASSERT(t.ndimension() == s->size());
+    ASSERT(t.sizes().equals(*s));
+    ASSERT(t.strides().size() == s->size());
     auto numel = std::accumulate(s->begin(), s->end(), 1, std::multiplies<int64_t>());
-    assert(t.numel() == numel);
+    ASSERT(t.numel() == numel);
     // verify we can output
     std::cout << t << std::endl;
 
@@ -48,7 +49,7 @@ int main() {
 
     // unsqueeze
     if (t.numel() != 0) {
-      assert(t.unsqueeze(0).dim() == t.dim() + 1);
+      ASSERT(t.unsqueeze(0).dim() == t.dim() + 1);
     } else {
       try {
         // can't unsqueeze empty tensor
@@ -62,7 +63,7 @@ int main() {
       auto t2 = T.ones(*s);
       if (t2.numel() != 0) {
         auto r = t2.unsqueeze_(0);
-        assert(r.dim() == t.dim() + 1);
+        ASSERT(r.dim() == t.dim() + 1);
       } else {
         try {
           // can't unsqueeze empty tensor
@@ -74,16 +75,16 @@ int main() {
 
     // squeeze (with dimension argument)
     if (t.dim() > 0 && t.sizes()[0] == 1) {
-      assert(t.squeeze(0).dim() == t.dim() - 1);
+      ASSERT(t.squeeze(0).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
       try {
         t.squeeze(0);
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     } else {
       // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
       // in NumPy this is an error.
-      assert(t.squeeze(0).dim() == t.dim());
+      ASSERT(t.squeeze(0).dim() == t.dim());
     }
 
     // squeeze (with no dimension argument)
@@ -102,16 +103,16 @@ int main() {
       // squeeze_ (with dimension argument)
       auto t2 = T.ones(*s);
       if (t2.dim() > 0 && t2.sizes()[0] == 1) {
-        assert(t2.squeeze_(0).dim() == t.dim() - 1);
+        ASSERT(t2.squeeze_(0).dim() == t.dim() - 1);
       } else if (t2.dim() == 0) {
         try {
           t2.squeeze_(0);
-          assert(false);
+          ASSERT(false);
         } catch (std::runtime_error &e) {}
       } else {
         // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
         // in NumPy this is an error.
-        assert(t2.squeeze_(0).dim() == t.dim());
+        ASSERT(t2.squeeze_(0).dim() == t.dim());
       }
     }
 
@@ -130,45 +131,45 @@ int main() {
 
     // reduce (with dimension argument and with 1 return argument)
     if (t.dim() > 0 && t.numel() != 0) {
-      assert(t.sum(0).dim() == t.dim() - 1);
+      ASSERT(t.sum(0).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
       try {
         t.sum(0);
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     } else {
       // FIXME: you should be able to reduce over size {0}
       try {
         t.sum(0);
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     }
 
     // reduce (with dimension argument and with 2 return arguments)
     if (t.dim() > 0 && t.numel() != 0) {
       auto ret = t.min(0);
-      assert(std::get<0>(ret).dim() == t.dim() - 1);
-      assert(std::get<1>(ret).dim() == t.dim() - 1);
+      ASSERT(std::get<0>(ret).dim() == t.dim() - 1);
+      ASSERT(std::get<1>(ret).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
       try {
         t.sum(0);
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     } else {
       // FIXME: you should be able to reduce over size {0}
       try {
         t.sum(0);
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     }
 
     // simple indexing
     if (t.dim() > 0 && t.numel() != 0) {
-      assert(t[0].dim() == std::max<int64_t>(t.dim() - 1, 0));
+      ASSERT(t[0].dim() == std::max<int64_t>(t.dim() - 1, 0));
     } else if (t.dim() == 0) {
       try {
         t[0];
-        assert(false);
+        ASSERT(false);
       } catch (std::runtime_error &e) {}
     }
   }
@@ -180,8 +181,8 @@ int main() {
           auto lhs = T.ones(*lhs_it);
           auto rhs = T.ones(*rhs_it);
           if(*lhs_it != *rhs_it) {
-            assert(!lhs.is_same_size(rhs));
-            assert(!rhs.is_same_size(lhs));
+            ASSERT(!lhs.is_same_size(rhs));
+            ASSERT(!rhs.is_same_size(lhs));
           }
       }
       // forced size functions (resize_, resize_as, set_)
@@ -216,7 +217,7 @@ int main() {
             auto storage = T.storage(rhs.numel());
             lhs.set_(*storage);
             // should not be dim 0 because an empty storage is dim 1; all other storages aren't scalars
-            assert(lhs.dim() != 0);
+            ASSERT(lhs.dim() != 0);
           }
           {
             // with storage, offset, sizes, strides
@@ -235,11 +236,11 @@ int main() {
           auto rhs = T.ones(*rhs_it);
           try {
             lhs.assign_(rhs);
-            assert(lhs_save.numel() == rhs.numel());
+            ASSERT(lhs_save.numel() == rhs.numel());
             // ensure didn't change shape
             assert_equal_size_dim(lhs, lhs_save);
           } catch (std::runtime_error &e) {
-            assert(lhs_save.numel() != rhs.numel());
+            ASSERT(lhs_save.numel() != rhs.numel());
           }
         }
       }
@@ -251,10 +252,10 @@ int main() {
         auto rhs_size = *rhs_it;
         try {
           auto result = lhs.view(rhs_size);
-          assert(lhs.numel() == rhs.numel());
+          ASSERT(lhs.numel() == rhs.numel());
           assert_equal_size_dim(result, rhs);
         } catch (std::runtime_error &e) {
-          assert(lhs.numel() != rhs.numel());
+          ASSERT(lhs.numel() != rhs.numel());
         }
       }
 
@@ -267,10 +268,10 @@ int main() {
         bool should_pass = should_expand(lhs_size, rhs_size);
         try {
           auto result = lhs.expand(rhs_size);
-          assert(should_pass);
+          ASSERT(should_pass);
           assert_equal_size_dim(result, rhs);
         } catch (std::runtime_error &e) {
-          assert(!should_pass);
+          ASSERT(!should_pass);
         }
 
         // in-place functions (would be good if we can also do a non-broadcasting one, b/c
@@ -280,10 +281,10 @@ int main() {
           bool should_pass_inplace = should_expand(rhs_size, lhs_size);
           try {
             lhs.add_(rhs);
-            assert(should_pass_inplace);
+            ASSERT(should_pass_inplace);
             assert_equal_size_dim(lhs, T.ones(*lhs_it));
           } catch (std::runtime_error &e) {
-            assert(!should_pass_inplace);
+            ASSERT(!should_pass_inplace);
           }
         }
       }

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -1,4 +1,5 @@
 #include "ATen/ATen.h"
+#include "test_assert.h"
 
 using namespace at;
 
@@ -8,20 +9,20 @@ int main() {
   // test simple case
   {
     auto a = T.randn({2, 3, 4, 5});
-    assert(a.prod(-4).equal(a.prod(0)));
-    assert(a.prod(3).equal(a.prod(-1)));
+    ASSERT(a.prod(-4).equal(a.prod(0)));
+    ASSERT(a.prod(3).equal(a.prod(-1)));
   }
 
   // test case with expression specification
   {
     auto a = T.randn({2, 3, 4, 5});
-    assert(a.unsqueeze(-5).equal(a.unsqueeze(0)));
-    assert(a.unsqueeze(4).equal(a.unsqueeze(-1)));
+    ASSERT(a.unsqueeze(-5).equal(a.unsqueeze(0)));
+    ASSERT(a.unsqueeze(4).equal(a.unsqueeze(-1)));
 
     // can unsqueeze scalar
     auto b = T.randn(1);
     b.get()->maybeScalar(true);
-    assert(b.unsqueeze(0).equal(b.unsqueeze(-1)));
+    ASSERT(b.unsqueeze(0).equal(b.unsqueeze(-1)));
   }
 
   // test case with empty tensor
@@ -29,19 +30,19 @@ int main() {
     auto a = T.randn(0);
     try {
       a.prod(0);
-      assert(false);
+      ASSERT(false);
     } catch (std::runtime_error &e) {}
   }
 
   // test case with scalar vs 1-dim, 1-size
   {
     auto a = T.randn(1);
-    assert(a.prod(0).equal(a.prod(-1)));
+    ASSERT(a.prod(0).equal(a.prod(-1)));
     a.get()->maybeScalar(true);
-    assert(a.get()->isScalar());
+    ASSERT(a.get()->isScalar());
     try {
       a.prod(0);
-      assert(false);
+      ASSERT(false);
     } catch (std::runtime_error &e) {}
   }
 }


### PR DESCRIPTION
Since ATen build no longer relies on NDEBUG from pytorch, this ensures the asserts will still fire.