### PR TITLE
[ppc64le] Fix test_torch.py test for Power see issue #3277

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4500,7 +4500,7 @@ class TestTorch(TestCase):
 
         # Test __array__ with dtype argument
         for dtype in dtypes:
-            x = torch.Tensor([1, -2, 3, -4])
+            x = torch.IntTensor([1, -2, 3, -4])
             asarray = np.asarray(x, dtype=dtype)
             self.assertEqual(asarray.dtype, dtype)
             if np.dtype(dtype).kind == 'u':


### PR DESCRIPTION
test_torch.py fails with 

```
Running torch tests
/Pytorch/pytorch/test/common.py:211: RuntimeWarning: overflow encountered in ubyte_scalars
  self.assertLessEqual(abs(x - y), prec, message)
======================================================================
FAIL: test_numpy_array_interface (__main__.TestTorch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_torch.py", line 4349, in test_numpy_array_interface
    self.assertEqual(asarray[i], wrapped_x[i])
  File "/home/aditi/Pytorch/pytorch/test/common.py", line 215, in assertEqual
    super(TestCase, self).assertEqual(x, y, message)
AssertionError: 0 != 254
----------------------------------------------------------------------
Ran 217 tests in 1.275s

Casting a FloatTensor which is the default tensor to a unit8 is an invalid test.

    Floating–integral conversions

    ...
    If the value cannot fit into the destination type, the behavior is undefined (even when the destination type is unsigned, modulo arithmetic does not apply).
    ...
```