### PR TITLE
Exposing emptyCache from allocator

### DIFF
--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -495,3 +495,9 @@ THC_API std::mutex* THCCachingAllocator_getCudaFreeMutex()
 {
   return &caching_allocator.cuda_free_mutex;
 }
+
+THC_API cudaError_t THCCachingAllocator_emptyCache(void)
+{
+  return caching_allocator.emptyCache();
+}
+

--- a/aten/src/THC/THCCachingAllocator.h
+++ b/aten/src/THC/THCCachingAllocator.h
@@ -11,6 +11,7 @@
 THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
 THC_API void THCCachingAllocator_recordStream(void *ptr, THCStream* stream);
+THC_API cudaError_t THCCachingAllocator_emptyCache(void);
 
 #if (__cplusplus >= 201103L) || (defined(_MSC_VER) && defined(__cplusplus))
 THC_API std::mutex* THCCachingAllocator_getCudaFreeMutex();

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -37,6 +37,10 @@ Streams and events
 .. autoclass:: Event
    :members:
 
+Memory management
+-----------------
+.. autofunction:: empty_cache
+
 NVIDIA Tools Extension (NVTX)
 -----------------------------
 

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -46,10 +46,10 @@ Memory management
 -----------------
 
 PyTorch use a caching memory allocator to speed up memory allocations. This
-allows very fast memory allocation for small sizes. However, the unused memory
-managed by the allocator will still show as if used in `nvidia-smi`. Calling
-:meth:`~torch.cuda.empty_cache` can release all unused cached memory from
-PyTorch so that those can be used by other GPU applications.
+allows fast memory deallocation without device synchronizations. However, the
+unused memory managed by the allocator will still show as if used in
+`nvidia-smi`. Calling :meth:`~torch.cuda.empty_cache` can release all unused
+cached memory from PyTorch so that those can be used by other GPU applications.
 
 
 Best practices

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -42,6 +42,16 @@ Below you can find a small example showcasing this::
         d = torch.randn(2).cuda(2)
         # d.get_device() == 2
 
+Memory management
+-----------------
+
+PyTorch use a caching memory allocator to speed up memory allocations. This
+allows very fast memory allocation for small sizes. However, the unused memory
+managed by the allocator will still show as if used in `nvidia-smi`. Calling
+:meth:`~torch.cuda.empty_cache` can release all unused cached memory from
+PyTorch so that those can be used by other GPU applications.
+
+
 Best practices
 --------------
 
@@ -50,7 +60,7 @@ Device-agnostic code
 
 Due to the structure of PyTorch, you may need to explicitly write
 device-agnostic (CPU or GPU) code; an example may be creating a new tensor as
-the initial hidden state of a recurrent neural network. 
+the initial hidden state of a recurrent neural network.
 
 The first step is to determine whether the GPU should be used or not. A common
 pattern is to use Python's ``argparse`` module to read in user arguments, and

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -297,6 +297,15 @@ PyObject * THCPModule_cudaUnlockMutex(PyObject *module)
   Py_RETURN_NONE;
 }
 
+PyObject * THCPModule_emptyCache(PyObject *_unused)
+{
+  HANDLE_TH_ERRORS
+  auto device_allocator = THCState_getDeviceAllocator(state);
+  THCudaCheck(device_allocator->emptyCache(device_allocator->state));
+  END_HANDLE_TH_ERRORS
+  Py_RETURN_NONE;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Cuda module initialization
 ////////////////////////////////////////////////////////////////////////////////
@@ -376,6 +385,7 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_getDriverVersion", (PyCFunction)THCPModule_getDriverVersion, METH_NOARGS, NULL},
   {"_cuda_getRNGState", (PyCFunction)THCPModule_getRNGState,      METH_NOARGS,  NULL},
   {"_cuda_setRNGState", (PyCFunction)THCPModule_setRNGState,      METH_O,       NULL},
+  {"_cuda_emptyCache", (PyCFunction) THCPModule_emptyCache,       METH_NOARGS,  NULL},
   {"_cuda_manualSeed",  (PyCFunction)THCPModule_manualSeed,       METH_O,       NULL},
   {"_cuda_manualSeedAll", (PyCFunction)THCPModule_manualSeedAll,  METH_O,       NULL},
   {"_cuda_seed",        (PyCFunction)THCPModule_seed,             METH_NOARGS,  NULL},

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -267,6 +267,11 @@ def current_blas_handle():
     return torch._C._cuda_getCurrentBlasHandle()
 
 
+def empty_cache():
+    """Frees all unused memory currently held by the cache allocator"""
+    return torch._C._cuda_emptyCache()
+
+
 def _host_allocator():
     _lazy_init()
     return torch._C._cuda_cudaHostAllocator()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -268,7 +268,9 @@ def current_blas_handle():
 
 
 def empty_cache():
-    """Frees all unused memory currently held by the cache allocator"""
+    """Releases all unoccupied cached memory currently held by the caching
+    allocator so that those can be used in other GPU application and visible in
+    `nvidia-smi`."""
     return torch._C._cuda_emptyCache()
 
 


### PR DESCRIPTION
Relevant thread: https://github.com/pytorch/pytorch/issues/1529#issuecomment-339649776

As described in the updated docs, this function will let PyTorch caching allocator release all unused cached memory so that other GPU applications can use those.

Test plan:
```
import torch

x = torch.cuda.DoubleTensor(10000, 10000).normal_()
import pdb; pdb.set_trace()
del x
torch.cuda.empty_cache()
```
Observed that the final call reduces GPU memory usage shown in `nvidia-smi`.

Credit: the implementation is by @tibuch . 

Sorry that I submitted this PR on your behalf. I contacted you on the aforementioned thread, but you didn't reply for several days. Let me know if you want to submit your own PR, and I will close this one. :)
