### PR TITLE
Reuse intermediate results over multiple backwards grad_inputs

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1,18 +1,4 @@
 [[
-  name: THPTensor_(elementSize)
-  python_name: element_size
-  cpu_half: True
-  auto_gpu: False
-  only_register: True
-]]
-[[
-  name: THPTensor_(storage)
-  python_name: storage
-  cpu_half: True
-  auto_gpu: False
-  only_register: True
-]]
-[[
   name: storageOffset
   python_name: storage_offset
   cpu_half: True
@@ -29,44 +15,6 @@
   return: long
   arguments:
     - THTensor* self
-]]
-[[
-  name: THPTensor_(nDimension)
-  python_name: dim
-  cpu_half: True
-  auto_gpu: False
-  only_register: True
-  method_flags: METH_KEYWORDS
-]]
-[[
-  python_name: index
-  name: THPTensor_(getValue)<true>
-  only_register: True
-  override_method_flags: METH_O
-]]
-[[
-  python_name: _set_index
-  name: THPTensor_(setIndex)
-  only_register: True
-]]
-[[
-  python_name: _check_advanced_indexing
-  name: THPTensor_(checkAdvancedIndexing)
-  cpu_half: False
-  only_register: True
-  override_method_flags: METH_O
-]]
-[[
-  python_name: _advanced_index_add
-  name: THPTensor_(advancedIndexAdd)
-  cpu_half: False
-  only_register: True
-]]
-[[
-  python_name: _advanced_index_select
-  name: THPTensor_(advancedIndexSelect)
-  cpu_half: False
-  only_register: True
 ]]
 [[
   name: resize_
@@ -142,14 +90,6 @@
     - THTensor* self
 ]]
 [[
-  name: THPTensor_(numel)
-  python_name: nelement
-  cpu_half: True
-  auto_gpu: False
-  only_register: True
-  method_flags: METH_KEYWORDS
-]]
-[[
   name: set_
   cname: set
   cpu_half: True
@@ -183,29 +123,6 @@
         - THSize* size
         - arg: THStride* stride
           default: NULL
-]]
-[[
-  name: THPTensor_(select)
-  python_name: select
-  cpu_half: True
-  auto_gpu: False
-  only_register: True
-]]
-[[
-  name: THPTensor_(size)
-  python_name: size
-  cpu_half: True
-  auto_gpu: False
-  method_flags: METH_KEYWORDS
-  only_register: True
-]]
-[[
-  name: THPTensor_(stride)
-  python_name: stride
-  cpu_half: True
-  auto_gpu: False
-  method_flags: METH_KEYWORDS
-  only_register: True
 ]]
 [[
   name: fill_
@@ -576,14 +493,6 @@
     - THIndexTensor* index
 ]]
 [[
-  name: THPTensor_stateless_(cat)
-  python_name: cat
-  method_flags: METH_KEYWORDS
-  only_register: True
-  variants:
-    - function
-]]
-[[
   name: data_ptr
   defined_if: "!IS_DISTRIBUTED"
   with_gil: True
@@ -603,13 +512,6 @@
   arguments:
     - THTensor* self
     - THTensor* other
-]]
-[[
-  python_name: copy_
-  name: THPTensor_(copy_)
-  cpu_half: True
-  method_flags: METH_KEYWORDS
-  only_register: True
 ]]
 [[
   name: __and__
@@ -810,34 +712,6 @@
         - arg: THTensor* self
           broadcast: other inplace fallback
         - THTensor* other
-]]
-[[
-  name: THPTensor_(apply)
-  python_name: apply_
-  defined_if: "!IS_DISTRIBUTED"
-  backends:
-    - CPU
-  cpu_half: True
-  only_register: True
-  override_method_flags: METH_O
-]]
-[[
-  name: THPTensor_(map)
-  python_name: map_
-  defined_if: "!IS_DISTRIBUTED"
-  backends:
-    - CPU
-  cpu_half: True
-  only_register: True
-]]
-[[
-  name: THPTensor_(map2)
-  python_name: map2_
-  defined_if: "!IS_DISTRIBUTED"
-  backends:
-    - CPU
-  cpu_half: True
-  only_register: True
 ]]
 [[
   name: lt
@@ -1262,22 +1136,6 @@
   return: long
   arguments:
     - THTensor* self
-]]
-[[
-  name: THPTensor_(new)
-  python_name: new
-  method_flags: METH_KEYWORDS
-  backends:
-    - CUDA
-  only_register: True
-]]
-[[
-  name: THPTensor_(recordStream)
-  python_name: record_stream
-  override_method_flags: METH_O
-  backends:
-    - CUDA
-  only_register: True
 ]]
 [[
   name: abs

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -12,8 +12,16 @@ import copy_wrapper
 from code_template import CodeTemplate
 
 
+# This file is the top-level entry point for code generation in ATen.
+# It takes an arbitrary number of arguments specifying metadata files to
+# process (.cwrap, .yaml and .h) and outputs a number generated header
+# and cpp files in ATen/ (see invocations of 'write' for each file that
+# is written.) It is invoked from cmake; look for the 'cwrap_files'
+# variable for an up-to-date list of files which are passed.
+
+
 parser = OptionParser()
-parser.add_option('-s', '--source-path', help='path to source director for tensorlib',
+parser.add_option('-s', '--source-path', help='path to source directory for ATen',
                   action='store', default='.')
 parser.add_option('-o', '--output-dependencies',
                   help='only output a list of dependencies', action='store')

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -61,8 +61,7 @@
   self: grad * (self * self + 1).reciprocal()
 
 - name: atan2(Tensor self, Tensor other)
-  self: grad * other * ((self * self + other * other).reciprocal())
-  other: grad * -self * ((self * self + other * other).reciprocal())
+  self, other: atan2_backward(grad, self, other, output_mask)
 
 - name: baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1)
   self: maybe_multiply(grad, beta)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1,5 +1,50 @@
 # Defines derivative formulas and Python signatures of methods on Variable
 #
+# Each entry consists of:
+#   - A 'name', which specifies the ATen name of the function you
+#     are defining derivatives for, and a C-style argument
+#     specification.
+#   - One or more gradients entries, mapping a differentiable input
+#     names to a formula specifying how to compute its gradient.
+#     Note that a single gradient entry can specify the gradient
+#     formula for multiple input names, by specifying a key
+#     "input1, input2" (see atan2 for an example).
+#
+# Gradient expressions are standard C++ expressions operating on ATen
+# variables.  In a gradient expression, the following variables are in
+# scope:
+#   - 'grad' (aka 'grad_output'), the gradient of the output which
+#     we are going to left-multiply.  When the forward returns multiple
+#     outputs, 'grad' always refers to the first output; you can refer
+#     to other outputs using 'grads'
+#   - Any of the input arguments, tensor or non-tensor
+#   - 'output', representing the result of evaluating the forward
+#     expression
+#   - 'output_mask', a std::array<bool, n> (where n is the number
+#     of differentiable inputs), specifying which inputs actually
+#     require gradient.  (This is only available when multiple
+#     derivatives are being computed by a single formula.)
+#     For double backwards, this is called 'grad_mask' (reserving
+#     'output_mask' to refer to the output_mask input of the
+#     backwards.)
+#
+# If you need a complex expression, e.g., with local variables,
+# write a _backward function in tools/autograd/templates/Function.cpp
+# and invoke it from here.  By the way, go read
+# https://github.com/zdevito/ATen/issues/163; this describes an
+# important hazard that occurs when porting backwards from Python to C++
+#
+# Double backwards gradient expressions can be somewhat confusing;
+# the most important thing to remember is: (1) you need to define a
+# derivative formula for every input, including inputs named things
+# like 'grad_output', and (2) the gradient to multiply with is always
+# called 'grad' (even though it really is a grad-grad).
+#
+# NB: There are a number of gradient definitions in here which are bogus
+# (implemented using zeros_like).  These gradients are (hopefully) not
+# used by our frontend.  You MUST check the frontend code; search for
+# OpName.apply to see if it's still using a legacy Python style API.
+#
 # NB: The parameter names here MUST be consistent with the parameter names
 # in ./torch/lib/ATen/Declarations.cwrap
 - name: abs(Tensor self)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -413,6 +413,13 @@ Tensor as_strided_backward(const Tensor & grad, TensorGeometry base, IntList siz
   return src;
 }
 
+std::tuple<Tensor, Tensor> atan2_backward(const Tensor& grad, const Tensor& self, const Tensor& other, std::array<bool, 2> output_mask) {
+  auto recip = (self * self + other * other).reciprocal();
+  return std::tuple<Tensor,Tensor>{
+            output_mask[0] ? grad * other * recip : Tensor(),
+            output_mask[1] ? grad * -self * recip : Tensor() };
+}
+
 }
 
 ${autograd_function_definitions}


### PR DESCRIPTION
The first two commits are just a little bit of refactoring.

The next two support defining gradient for multiple inputs simultaneously in `derivatives.yaml`, and then an example of how to use it via `atan2`. The basic model is, instead of saying `output1: returns a tensor` and `output2: returns a tensor`, you just say `output1, output2: returns a tuple of tensors`

I am not entirely sure I have done the `output_mask` handling idiomatically. This definitely seems like an opportunity for some compiler-y techniques. For example, one way to implement this assuming you have a working compiler is to define the computation once assuming every output is needed, and then for every output_mask permutation, DCE the unneeded outputs. (This is, of course, assuming that there isn't a totally different algorithm that is applicable when you can remove required grads; in the case of atan2, this is definitely not the case.) In any case I don't plan to do this on this PR.

Looking at derivatives.yaml, here are some more opportunities for reusing intermediate computations with addbmm and dist (which already have gradients.) I'll do these once I confirm the pattern looks good.