### PR TITLE
THTensor_varOuterDim numeric stability

### DIFF
--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -88,7 +88,7 @@ THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   if (dimension == THCTensor_(nDimension)(state, src) - 1) {
     THCTensor_varInnermostDim<THCTensor, real, accreal, true>(state, self, src, biased);
   } else {
-    THCTensor_varOuterDim<THCTensor, real, true>(state, self, src, dimension, biased);
+    THCTensor_varOuterDim<THCTensor, real, accreal, true>(state, self, src, dimension, biased);
   }
 
   THCTensor_(free)(state, src);
@@ -114,7 +114,7 @@ THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension
   if (dimension == THCTensor_(nDimension)(state, src) - 1) {
     THCTensor_varInnermostDim<THCTensor, real, accreal, false>(state, self, src, biased);
   } else {
-    THCTensor_varOuterDim<THCTensor, real, false>(state, self, src, dimension, biased);
+    THCTensor_varOuterDim<THCTensor, real, accreal, false>(state, self, src, dimension, biased);
   }
 
   THCTensor_(free)(state, src);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1009,8 +1009,16 @@ class TestCuda(TestCase):
 
     def test_var_stability(self):
         tensor = torch.FloatTensor([2281.5, 2281.25]).cuda()
+
+        # Stability for inner dim
         self.assertEqual(tensor.var(0)[0], 0.03125)
+
+        # General stability
         self.assertEqual(tensor.var(), 0.03125)
+
+        # Stability for outer dimensions
+        tensor = tensor.unsqueeze(1)
+        self.assertEqual(tensor.var(0)[0], 0.03125)
 
     def test_arange(self):
         for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:


### PR DESCRIPTION
Use Welford's algorithm for numeric stability to compute the variance of an outer dimension of a CUDA tensor. Similar to #3425.

### Test Plan
`test/run_test.sh`

Added a numeric stability test case for varOuterDim

Got [some numbers](https://gist.github.com/zou3519/88c0b89ad958049548454247d3545a4c) for performance before/after the changes. The largest after_time / before_time is 3.8, which doesn't look that great