### PR TITLE
Fix stride checks in gemm dispatch

### DIFF
--- a/aten/src/TH/generic/THBlas.c
+++ b/aten/src/TH/generic/THBlas.c
@@ -322,8 +322,8 @@ void THBlas_(gemm)(char transa, char transb, int64_t m, int64_t n, int64_t k, re
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
   if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) &&
-      (lda >= THMax(1, (transa_ ? m : k))) && (lda <= INT_MAX) &&
-      (ldb >= THMax(1, (transb_ ? k : n))) && (ldb <= INT_MAX) &&
+      (lda >= THMax(1, (transa_ ? k : m))) && (lda <= INT_MAX) &&
+      (ldb >= THMax(1, (transb_ ? n : k))) && (ldb <= INT_MAX) &&
       (ldc >= THMax(1, n)) && (ldc <= INT_MAX) )
   {
     int i_m = (int)m;


### PR DESCRIPTION
```
From https://software.intel.com/en-us/mkl-developer-reference-fortran-gemm:

 lda: "When transa = 'N' or 'n', then lda must be at least max(1, m),
       otherwise lda must be at least max(1, k)."

 ldb: "When transb = 'N' or 'n', then ldb must be at least max(1, k),
       otherwise ldb must be at least max(1, n)."
```

Partly addresses #3525 

`transa = 'N'` corresponds to `transa_ = false` in our case.

Thanks @MlWoo for figuring out the problem and the fix!