### PR TITLE
Previous PyTorch version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ We are in an early-release beta. Expect some adventures and rough edges.
   - [Binaries](#binaries)
   - [From Source](#from-source)
   - [Docker Image](#docker-image)
+  - [Previous Versions](#previous-versions)
 - [Getting Started](#getting-started)
 - [Communication](#communication)
 - [Releases and Contributing](#releases-and-contributing)
@@ -210,6 +211,11 @@ nvidia-docker run --rm -ti --ipc=host pytorch/pytorch:latest
 Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
 for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you
 should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `nvidia-docker run`.
+
+### Previous Versions
+
+Installation instructions and binaries for previous PyTorch versions may be found
+on [our website](http://pytorch.org/previous-versions/).
 
 
 ## Getting Started


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/2689
Adds a link to info about previous pytorch versions to the README.