### PR TITLE
add more fusable nodes to the graph compiler

### DIFF
--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -75,7 +75,53 @@ _(shape) \
 _(axes) \
 _(group) \
 _(inplace) \
-_(other)
+_(other) \
+_(__and__) \
+_(__lshift__) \
+_(__or__) \
+_(__rshift__) \
+_(__xor__) \
+_(abs) \
+_(acos) \
+_(asin) \
+_(atan) \
+_(atan2) \
+_(ceil) \
+_(clamp) \
+_(cos) \
+_(cosh) \
+_(div) \
+_(eq) \
+_(equal) \
+_(exp) \
+_(floor) \
+_(fmod) \
+_(frac) \
+_(ge) \
+_(gt) \
+_(le) \
+_(lerp) \
+_(lgamma) \
+_(log) \
+_(log1p) \
+_(lt) \
+_(max) \
+_(min) \
+_(ne) \
+_(ones) \
+_(pow) \
+_(reciprocal) \
+_(remainder) \
+_(round) \
+_(rsqrt) \
+_(sin) \
+_(sinh) \
+_(sqrt) \
+_(sub) \
+_(tan) \
+_(trunc) \
+_(zeros) \
+_(exponent)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -121,6 +121,7 @@ static void fusionTests() {
     auto p14 = appendNewNode(kmul,graph,{p20, i0});
     auto p11 = appendNewNode(kmul,graph,{p22, p18});
     auto o1 = appendNewNode(kadd,graph,{p14, p11});
+    o1->t_(kalpha, at::Scalar(1).toTensor());
     auto p5 = appendNewNode(ktanh,graph,{o1});
     auto o0 = appendNewNode(kmul,graph,{p16, p5});
 


### PR DESCRIPTION
Adding more simple map nodes to the graph compiler. I just extracted any op that reasonably looked like a map. 

In a future commit, I will add single-op tests. I am waiting for now until we have an interpreter checked in, since those tests will be easier to write if we can construct on graph and run it through the fusion compiler and through the interpreter to check for equal behavior.

I added an isFloat check to the fusion pass as well since the fuser is still specific to floats.