### PR TITLE
Fix cuda symeig

### DIFF
--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -157,7 +157,7 @@ THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
 
   // eigen values and workspace
   real *w = th_magma_malloc_pinned<real>(n);
-  real *wA = th_magma_malloc_pinned<real>(lda);
+  real *wA = th_magma_malloc_pinned<real>(lda * n);
 
   // compute optimal size of work array
   int info;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -19,12 +19,8 @@ if not torch.cuda.is_available():
 
 HAS_MAGMA = HAS_CUDA
 if HAS_CUDA:
-    try:
-        x = torch.ones(1, 1).cuda()
-        x.symeig()
-    except RuntimeError as err:
-        if re.search("No CUDA implementation of '\w+'. Install MAGMA and", str(err)) is not None:
-            HAS_MAGMA = False
+    torch.ones(1).cuda()  # has_magma shows up after cuda is initialized
+    HAS_MAGMA = torch.cuda.has_magma
 
 
 def is_floating(t):


### PR DESCRIPTION
Fixes #3563.

The bug is that not enough space was being allocated for the workspace, causing some undefined behavior.

### Test Plan
Run the code that previously produced a CUBLAS memory mapping error and assert that it doesn't anymore.
```
import torch

size = 129
print('generating random symmetric matrix {0:}x{0:} on gpu'.format(size))
a = torch.randn(size, size)
cov = torch.mm(a, a.transpose(1,0))
tcov = torch.Tensor(cov).cuda()
print('computing symmetric eigenvectors')
teigval, teigvec = torch.symeig(tcov, eigenvectors=True)
print('first 5 eigenvals')
print(teigval[None,:5])
print('---')
```

Added a unit test for symeig. It has a small case (3x3) and a large case (257 x 257). Ran it on pytorch with magma and without magma to test the HAS_MAGMA flag.