### PR TITLE
Fix module load_state_dict error information.

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -475,8 +475,8 @@ class Module(object):
                 try:
                     own_state[name].copy_(param)
                 except Exception:
-                    raise RuntimeError('While copying the parameter named {}, ' +
-                                       'whose dimensions in the model are {} and ' +
+                    raise RuntimeError('While copying the parameter named {}, '
+                                       'whose dimensions in the model are {} and '
                                        'whose dimensions in the checkpoint are {}.'
                                        .format(name, own_state[name].size(), param.size()))
             elif strict:


### PR DESCRIPTION
Before:
```
import torch
x = torch.nn.Linear(3,4)
y = torch.nn.Linear(3,3)
y.load_state_dict(x.state_dict())
```
You get:
> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "/Users/rluo/pytorch-1/torch/nn/modules/module.py", line 481, in load_state_dict
>     .format(name, own_state[name].size(), param.size()))
> RuntimeError: While copying the parameter named {}, whose dimensions in the model are {} and whose dimensions in the checkpoint are weight.

Now:

> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "/Users/rluo/pytorch-1/torch/nn/modules/module.py", line 481, in load_state_dict
>     .format(name, own_state[name].size(), param.size()))
> RuntimeError: While copying the parameter named weight, whose dimensions in the model are torch.Size([3, 3]) and whose dimensions in the checkpoint are torch.Size([4, 3]).
