### PR TITLE
[ATen] Make size/stride native functions.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3903,27 +3903,6 @@
         - BackendDoubleTensor* float_p
 ]]
 [[
-  name: size
-  return: int64_t
-  cpu_half: True
-  arguments:
-    - THTensor* self
-    - arg: int64_t dim
-      wrap_dim: self
-]]
-
-[[
-  name: stride
-  return: int64_t
-  cpu_half: True
-  arguments:
-    - THTensor* self
-    - arg: int64_t dim
-      wrap_dim: self
-]]
-
-
-[[
   name: tensor
   return: THTensor*
   cpu_half: True

--- a/aten/src/ATen/NativeFunctions.h
+++ b/aten/src/ATen/NativeFunctions.h
@@ -53,6 +53,40 @@ static inline std::vector<Tensor> chunk(const Tensor &self, int64_t chunks, int6
 
 /*
 [NativeFunction]
+name: size
+arg: Tensor self
+arg: int64_t dim
+return: int64_t
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::size
+[/NativeFunction]
+*/
+static inline int64_t size(const Tensor &self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim());
+  // wrap_dim guarantees bounds are correct.
+  return self.sizes()[dim];
+}
+
+/*
+[NativeFunction]
+name: stride
+arg: Tensor self
+arg: int64_t dim
+return: int64_t
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::stride
+[/NativeFunction]
+*/
+static inline int64_t stride(const Tensor &self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim());
+  // wrap_dim guarantees bounds are correct.
+  return self.strides()[dim];
+}
+
+/*
+[NativeFunction]
 name: is_same_size
 arg: Tensor self
 arg: Tensor other

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -60,5 +60,20 @@ int main() {
     }
   }
 
+  // size / stride
+  {
+    auto scalar = T.randn({});
+    ASSERT_THROWS(scalar.size(0), "dimension specified as 0 but tensor has no dimensions");
+    ASSERT_THROWS(scalar.size(-1), "dimension specified as -1 but tensor has no dimensions");
+    ASSERT_THROWS(scalar.stride(0), "dimension specified as 0 but tensor has no dimensions");
+    ASSERT_THROWS(scalar.stride(-1), "dimension specified as -1 but tensor has no dimensions");
+
+    auto empty = T.randn({0});
+    ASSERT(empty.size(0) == 0);
+    ASSERT(empty.size(-1) == 0);
+    ASSERT(empty.stride(0) == 1);
+    ASSERT(empty.stride(-1) == 1);
+  }
+
   return 0;
 }

--- a/aten/src/ATen/test/test_assert.h
+++ b/aten/src/ATen/test/test_assert.h
@@ -28,3 +28,11 @@ static inline void barf(const char *fmt, ...) {
   if (AT_EXPECT(!(cond), 0)) { \
     barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond,##__VA_ARGS__); \
   }
+
+#define ASSERT_THROWS(fn, message)                                  \
+try {                                                               \
+  fn;                                                               \
+  ASSERT(false);                                                    \
+} catch(std::runtime_error &e) {                                    \
+  ASSERT(std::string(e.what()).find(message) != std::string::npos); \
+}

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -3,17 +3,7 @@
 #include <string>
 #include "test_assert.h"
 
-
 using namespace at;
-
-#define ASSERT_THROWS(fn, message)                                  \
-try {                                                               \
-  fn;                                                               \
-  ASSERT(false);                                                    \
-} catch(std::runtime_error &e) {                                    \
-  ASSERT(std::string(e.what()).find(message) != std::string::npos); \
-}
-
 
 int main() {
   // mainly test ops on undefined tensors don't segfault and give a reasonable errror message.


### PR DESCRIPTION
Previously, sizes/strides() would give you the ATen view of the shape, while size(dim), stride(dim) would give you the TH view.

This was unnecessarily confusing and there was no automatic way to get dim wrapping on the ATen view.