### PR TITLE
Ensure aten build depends on NativeFunctions.h.

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -140,12 +140,13 @@ endif()
 file(READ ${CMAKE_CURRENT_BINARY_DIR}/generated_cpp.txt generated_cpp)
 
 FILE(GLOB_RECURSE all_templates "templates/*")
+SET(native_functions ${CMAKE_CURRENT_SOURCE_DIR}/NativeFunctions.h)
 
 FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ATen)
 
 ADD_CUSTOM_COMMAND(OUTPUT ${generated_cpp}
 COMMAND ${GEN_COMMAND}
-DEPENDS ${all_python} ${all_templates} ${cwrap_files})
+DEPENDS ${all_python} ${all_templates} ${native_functions} ${cwrap_files})
 
 SET(all_cpp ${base_cpp} ${generated_cpp} ${ATen_CPU_SRCS})
 


### PR DESCRIPTION
Otherwise you can change the metadata and the code won't be re-generated.