### PR TITLE
fix warnings about _XOPEN_SOURCE redefinition.

### DIFF
--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "VariableType.h"
 
 // ${generated_comment}

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "function.h"
 
 #include <string>

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "accumulate_grad.h"
 
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "torch/csrc/autograd/variable.h"
 
 #include "torch/csrc/assertions.h"

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -289,7 +289,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   ptrdiff_t offset = (ptrdiff_t)THPUtils_unpackLong(_offset);
   size_t view_size =  (size_t)THPUtils_unpackLong(_view_size);
 
-  int device = THPUtils_unpackLong(_device);
+  int64_t device = THPUtils_unpackLong(_device);
   THCPAutoGPU __autogpu(device);
 
   char *buffer;

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "torch/csrc/jit/tracer.h"
 
 #include "torch/csrc/autograd/variable.h"


### PR DESCRIPTION
 Every compilation unit whose headers recursively include Python.h need to include Python.h first. This is a known limitation of the Python headers. This patch works around it by adding Python.h in the right places. Also fixes a int->void* cast warning by making the int an int64_t.