### PR TITLE
CPU all/any should work with empty tensors.

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -3010,7 +3010,6 @@ LAB_IMPLEMENT_BASIC_FUNCTION(neg,-)
 #define TENSOR_IMPLEMENT_LOGICAL_SUM(NAME, OP, INIT_VALUE) \
   int THTensor_(NAME)(THTensor *tensor) \
   { \
-    THArgCheck(tensor->nDimension > 0, 1, "empty Tensor"); \
     int sum = INIT_VALUE;                               \
     TH_TENSOR_APPLY(real, tensor, sum = sum OP *tensor_data;); \
     return sum; \

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -408,6 +408,17 @@ class TestTorch(TestCase):
         test((10,))
         test((5, 5))
 
+    def test_all_any_empty(self):
+        x = torch.ByteTensor()
+        self.assertTrue(x.all())
+        self.assertFalse(x.any())
+
+    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
+    def test_all_any_empty_cuda(self):
+        x = torch.cuda.ByteTensor()
+        self.assertTrue(x.all())
+        self.assertFalse(x.any())
+
     def test_mv(self):
         m1 = torch.randn(100, 100)
         v1 = torch.randn(100)


### PR DESCRIPTION
This was already the case on GPU and with numpy.