### PR TITLE
Allow torch.load and torch.save to take pathlib.Path

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -107,8 +107,9 @@ def _with_file_like(f, mode, body):
     it in 'mode' if it is a string filename.
     """
     new_fd = False
-    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)) \
-        or (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
+    if isinstance(f, str) or \
+            (sys.version_info[0] == 2 and isinstance(f, unicode)) or \
+            (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
         new_fd = True
         f = open(f, mode)
     try:
@@ -251,8 +252,9 @@ def load(f, map_location=None, pickle_module=pickle):
 
     """
     new_fd = False
-    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)) \
-        or (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
+    if isinstance(f, str) or \
+            (sys.version_info[0] == 2 and isinstance(f, unicode)) or \
+            (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
         new_fd = True
         f = open(f, 'rb')
     try:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -14,6 +14,7 @@ if sys.version_info[0] == 2:
     import cPickle as pickle
 else:
     import pickle
+    import pathlib
 
 DEFAULT_PROTOCOL = 2
 
@@ -106,7 +107,8 @@ def _with_file_like(f, mode, body):
     it in 'mode' if it is a string filename.
     """
     new_fd = False
-    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)):
+    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)) \
+        or (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
         new_fd = True
         f = open(f, mode)
     try:
@@ -249,7 +251,8 @@ def load(f, map_location=None, pickle_module=pickle):
 
     """
     new_fd = False
-    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)):
+    if isinstance(f, str) or (sys.version_info[0] == 2 and isinstance(f, unicode)) \
+        or (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
         new_fd = True
         f = open(f, 'rb')
     try:


### PR DESCRIPTION
[pathlib](https://docs.python.org/3/library/pathlib.html) has been python standard library for filesystem path since python 3.4,
and PyTorch assumes python 3 users to use python 3.5 or above.
But `torch.load` and `torch.save` currently cannot take `pathlib.Path` as its filepath of state dictionary.
I changed `torch.load` and `_with_file_like` to accept `pathlib.Path`-typed filepath when using python 3.