### PR TITLE
Fixed failing docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN conda install --name pytorch-py$PYTHON_VERSION -c soumith magma-cuda80
 WORKDIR /opt/pytorch
 COPY . .
 
-RUN git submodule update --init
 RUN TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1+PTX" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     pip install -v .

--- a/tools/docker/Dockerfile9
+++ b/tools/docker/Dockerfile9
@@ -30,7 +30,6 @@ RUN conda install --name pytorch-py$PYTHON_VERSION -c soumith magma-cuda90
 WORKDIR /opt/pytorch
 COPY . .
 
-RUN git submodule update --init
 RUN TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0+PTX" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     pip install -v .


### PR DESCRIPTION
The dockerfile builds would fail to build with ```git submodule update --init``` I was able to bypass this by removing this line and using --recursive when I cloned the repo. 

