### PR TITLE
doc: Normalize all true/false in docstrings to ``True|False``

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -322,10 +322,10 @@ It may be of a different data type or reside on a different device.
 
 Args:
     src (Tensor): Source tensor to copy
-    async (bool): If True and this copy is between CPU and GPU, then the copy
+    async (bool): If ``True`` and this copy is between CPU and GPU, then the copy
         may occur asynchronously with respect to the host. For other
         copies, this argument has no effect.
-    broadcast (bool): If True, :attr:`src` will be broadcast to the shape of
+    broadcast (bool): If ``True``, :attr:`src` will be broadcast to the shape of
         the underlying tensor.
 """)
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1244,7 +1244,7 @@ Computes the eigenvalues and eigenvectors of a real square matrix.
 Args:
     a (Tensor): A square matrix for which the eigenvalues and eigenvectors will
                 be computed
-    eigenvectors (bool): `True` to compute both eigenvalues and eigenvectors.
+    eigenvectors (bool): ``True`` to compute both eigenvalues and eigenvectors.
                          Otherwise, only eigenvalues will be computed.
     out (tuple, optional): Output tensors
 
@@ -1287,7 +1287,7 @@ add_docstr(torch._C.equal,
            """
 equal(tensor1, tensor2) -> bool
 
-True if two tensors have the same size and elements, False otherwise.
+``True`` if two tensors have the same size and elements, ``False`` otherwise.
 
 Example::
 
@@ -1843,7 +1843,7 @@ If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 A tuple of `(values, indices)` is returned, where the `indices` is the indices
 of the kth-smallest element in the original `input` Tensor in dimension `dim`.
 
-If :attr:`keepdim` is true, both the :attr:`values` and :attr:`indices` Tensors
+If :attr:`keepdim` is ``True``, both the :attr:`values` and :attr:`indices` Tensors
 are the same size as :attr:`input`, except in the dimension :attr:`dim` where
 they are of size 1. Otherwise, :attr:`dim` is squeezed
 (see :func:`torch.squeeze`), resulting in both the :attr:`values` and
@@ -2230,7 +2230,7 @@ Returns the maximum value of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`. The second return value is the index location of each
 maximum value found (argmax).
 
-If :attr:`keepdim` is true, the output Tensors are of the same size
+If :attr:`keepdim` is ``True``, the output Tensors are of the same size
 as :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output Tensors having 1 fewer dimension than :attr:`input`.
@@ -2341,7 +2341,7 @@ Example::
 Returns the mean value of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensor is of the same size
+If :attr:`keepdim` is ``True``, the output Tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in the
 output Tensor having 1 fewer dimension.
@@ -2411,7 +2411,7 @@ as a `LongTensor`.
 
 By default, :attr:`dim` is the last dimension of the :attr:`input` Tensor.
 
-If :attr:`keepdim` is true, the output Tensors are of the same size
+If :attr:`keepdim` is ``True``, the output Tensors are of the same size
 as :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the outputs Tensor having 1 fewer dimension than :attr:`input`.
@@ -2486,7 +2486,7 @@ Returns the minimum value of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`. The second return value is the index location of each
 minimum value found (argmin).
 
-If :attr:`keepdim` is true, the output Tensors are of the same size as
+If :attr:`keepdim` is ``True``, the output Tensors are of the same size as
 :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the output Tensors having 1 fewer dimension than :attr:`input`.
@@ -2608,7 +2608,7 @@ as a `LongTensor`.
 
 By default, :attr:`dim` is the last dimension of the :attr:`input` Tensor.
 
-If :attr:`keepdim` is true, the output Tensors are of the same size as
+If :attr:`keepdim` is ``True``, the output Tensors are of the same size as
 :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output Tensors having 1 fewer dimension than :attr:`input`.
@@ -2756,7 +2756,7 @@ If :attr:`input` is a vector, :attr:`out` is a vector of size `num_samples`.
 If :attr:`input` is a matrix with `m` rows, :attr:`out` is an matrix of shape
 `m \u00D7 n`.
 
-If replacement is `True`, samples are drawn with replacement.
+If replacement is ``True``, samples are drawn with replacement.
 
 If not, they are drawn without replacement, which means that when a
 sample index is drawn for a row, it cannot be drawn again for that row.
@@ -2945,7 +2945,7 @@ Example::
 Returns the p-norm of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensor is of the same size as
+If :attr:`keepdim` is ``True``, the output Tensor is of the same size as
 :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output Tensor having 1 fewer dimension than :attr:`input`.
@@ -3156,9 +3156,9 @@ potrf(a, upper, out=None)
 
 Computes the Cholesky decomposition of a positive semidefinite
 matrix :attr:`a`: returns matrix `u`
-If `upper` is True or not provided, `u` is upper triangular
+If `upper` is ``True`` or not provided, `u` is upper triangular
 such that :math:`a = u^T u`.
-If `upper` is False, `u` is lower triangular
+If `upper` is ``False``, `u` is lower triangular
 such that :math:`a = u u^T`.
 
 Args:
@@ -3201,9 +3201,9 @@ potri(u, upper, out=None)
 
 Computes the inverse of a positive semidefinite matrix given its
 Cholesky factor :attr:`u`: returns matrix `inv`
-If `upper` is True or not provided, `u` is upper triangular
+If `upper` is ``True`` or not provided, `u` is upper triangular
 such that :math:`inv = (u^T u)^{-1}`.
-If `upper` is False, `u` is lower triangular
+If `upper` is ``False``, `u` is lower triangular
 such that :math:`inv = (u u^T)^{-1}`.
 
 Args:
@@ -3248,9 +3248,9 @@ potrs(b, u, upper, out=None)
 Solves a linear system of equations with a positive semidefinite
 matrix to be inverted given its given a Cholesky factor
 matrix :attr:`u`: returns matrix `c`
-If `upper` is True or not provided, `u` is and upper triangular
+If `upper` is ``True`` or not provided, `u` is and upper triangular
 such that :math:`c = (u^T u)^{-1} b`.
-If `upper` is False, `u` is and lower triangular
+If `upper` is ``False``, `u` is and lower triangular
 such that :math:`c = (u u^T)^{-1} b`.
 
 .. note:: `b` is always a 2D `Tensor`, use `b.unsqueeze(1)` to convert a vector.
@@ -3424,7 +3424,7 @@ Example::
 Returns the product of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensor is of the same size as
+If :attr:`keepdim` is ``True``, the output Tensor is of the same size as
 :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output Tensor having 1 fewer dimension than :attr:`input`.
@@ -3463,9 +3463,9 @@ pstrf(a, upper, out=None)
 
 Computes the pivoted Cholesky decomposition of a positive semidefinite
 matrix :attr:`a`: returns matrices `u` and `piv`.
-If `upper` is True or not provided, `u` is and upper triangular
+If `upper` is ``True`` or not provided, `u` is and upper triangular
 such that :math:`a = p^T u^T u p`, with `p` the permutation given by `piv`.
-If `upper` is False, `u` is and lower triangular
+If `upper` is ``False``, `u` is and lower triangular
 such that :math:`a = p^T u u^T p`.
 
 Args:
@@ -3998,7 +3998,7 @@ in ascending order by value.
 
 If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 
-If :attr:`descending` is `True` then the elements are sorted in descending
+If :attr:`descending` is ``True`` then the elements are sorted in descending
 order by value.
 
 A tuple of (sorted_tensor, sorted_indices) is returned, where the
@@ -4126,7 +4126,7 @@ add_docstr(torch._C.std,
 
 Returns the standard-deviation of all elements in the :attr:`input` Tensor.
 
-If :attr:`unbiased` is false, then the standard-deviation will be calculated via
+If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated via
 the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
@@ -4150,12 +4150,12 @@ Example::
 Returns the standard-deviation of each row of the :attr:`input` Tensor in the
 given dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensor is of the same size as
+If :attr:`keepdim` is ``True``, the output Tensor is of the same size as
 :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output Tensor having 1 fewer dimension than :attr:`input`.
 
-If :attr:`unbiased` is false, then the standard-deviation will be calculated via
+If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated via
 the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
@@ -4212,7 +4212,7 @@ Example::
 Returns the sum of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensor is of the same size
+If :attr:`keepdim` is ``True``, the output Tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the output Tensor having 1 fewer dimension than :attr:`input`.
@@ -4334,13 +4334,13 @@ such that `input = V diag(e) V'`
 The boolean argument :attr:`eigenvectors` defines computation of
 eigenvectors or eigenvalues only.
 
-If it is `False`, only eigenvalues are computed. If it is `True`,
+If it is ``False``, only eigenvalues are computed. If it is ``True``,
 both eigenvalues and eigenvectors are computed.
 
 Since the input matrix `input` is supposed to be symmetric,
 only the upper triangular portion is used by default.
 
-If :attr:`upper` is `False`, then lower triangular portion is used.
+If :attr:`upper` is ``False``, then lower triangular portion is used.
 
 Note: Irrespective of the original strides, the returned matrix `V` will
 be transposed, i.e. with strides `(1, m)` instead of `(m, 1)`.
@@ -4502,12 +4502,12 @@ a given dimension.
 
 If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 
-If :attr:`largest` is `False` then the `k` smallest elements are returned.
+If :attr:`largest` is ``False`` then the `k` smallest elements are returned.
 
 A tuple of `(values, indices)` is returned, where the `indices` are the indices
 of the elements in the original `input` Tensor.
 
-The boolean option :attr:`sorted` if `True`, will make sure that the returned
+The boolean option :attr:`sorted` if ``True``, will make sure that the returned
 `k` elements are themselves sorted
 
 Args:
@@ -4796,7 +4796,7 @@ add_docstr(torch._C.var,
 
 Returns the variance of all elements in the :attr:`input` Tensor.
 
-If :attr:`unbiased` is false, then the variance will be calculated via the
+If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
@@ -4820,12 +4820,12 @@ Example::
 Returns the variance of each row of the :attr:`input` Tensor in the given
 dimension :attr:`dim`.
 
-If :attr:`keepdim` is true, the output Tensors are of the same size
+If :attr:`keepdim` is ``True``, the output Tensors are of the same size
 as :attr:`input` except in the dimension :attr:`dim` where they are of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the outputs Tensor having 1 fewer dimension than :attr:`input`.
 
-If :attr:`unbiased` is false, then the variance will be calculated via the
+If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -12,7 +12,7 @@ def _type(self, new_type=None, async=False):
 
     Args:
         new_type (type or string): The desired type
-        async (bool): If True, and the source is in pinned memory and
+        async (bool): If ``True``, and the source is in pinned memory and
                       destination is on the GPU or vice versa, the copy is
                       performed asynchronously with respect to the host.
                       Otherwise, the argument has no effect.
@@ -46,7 +46,7 @@ def _cuda(self, device=None, async=False):
 
     Args:
         device (int): The destination GPU id. Defaults to the current device.
-        async (bool): If True and the source is in pinned memory, the copy will
+        async (bool): If ``True`` and the source is in pinned memory, the copy will
                       be asynchronous with respect to the host. Otherwise, the
                       argument has no effect.
     """

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -63,16 +63,16 @@ def backward(variables, grad_variables=None, retain_graph=None, create_graph=Non
         grad_variables (sequence of (Tensor, Variable or None)): Gradients w.r.t.
             each element of corresponding variables.  Any tensors will be
             automatically converted to Variables that are volatile unless
-            ``create_graph`` is True.  None values can be specified for scalar
+            ``create_graph`` is ``True``.  None values can be specified for scalar
             Variables or ones that don't require grad. If a None value would
             be acceptable for all grad_variables, then this argument is optional.
-        retain_graph (bool, optional): If False, the graph used to compute the grad
-            will be freed. Note that in nearly all cases setting this option to True
+        retain_graph (bool, optional): If ``False``, the graph used to compute the grad
+            will be freed. Note that in nearly all cases setting this option to ``True``
             is not needed and often can be worked around in a much more efficient
             way. Defaults to the value of ``create_graph``.
-        create_graph (bool, optional): If true, graph of the derivative will
+        create_graph (bool, optional): If ``True``, graph of the derivative will
             be constructed, allowing to compute higher order derivative products.
-            Defaults to False, unless ``grad_variables`` contains at least one
+            Defaults to ``False``, unless ``grad_variables`` contains at least one
             non-volatile Variable.
     """
     variables = (variables,) if isinstance(variables, Variable) else tuple(variables)
@@ -109,8 +109,8 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Non
     Gradients can be given as Tensors when one doesn't need the graph of the
     derivative, or as Variables, in which case the graph will be created.
 
-    If ``only_inputs`` is True, the function will only return a list of gradients
-    w.r.t the specified inputs. If it's False, then gradient w.r.t. all remaining
+    If ``only_inputs`` is ``True``, the function will only return a list of gradients
+    w.r.t the specified inputs. If it's ``False``, then gradient w.r.t. all remaining
     leaves will still be computed, and will be accumulated into their ``.grad``
     attribute.
 
@@ -120,24 +120,24 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Non
             returned (and not accumulated into ``.grad``).
         grad_outputs (sequence of Tensor or Variable): Gradients w.r.t. each output.
             Any tensors will be automatically converted to Variables that are
-            volatile unless ``create_graph`` is True.  None values can be
+            volatile unless ``create_graph`` is ``True``. None values can be
             specified for scalar Variables or ones that don't require grad.
             If a None value would be acceptable for all grad_variables, then
             this argument is optional.
-        retain_graph (bool, optional): If False, the graph used to compute the grad
-            will be freed. Note that in nearly all cases setting this option to True
+        retain_graph (bool, optional): If ``False``, the graph used to compute the grad
+            will be freed. Note that in nearly all cases setting this option to ``True``
             is not needed and often can be worked around in a much more efficient
             way. Defaults to the value of ``create_graph``.
-        create_graph (bool, optional): If True, graph of the derivative will
+        create_graph (bool, optional): If ``True``, graph of the derivative will
             be constructed, allowing to compute higher order derivative products.
-            Defaults to False, unless ``grad_variables`` contains at least one
+            Defaults to ``False``, unless ``grad_variables`` contains at least one
             non-volatile Variable.
-        only_inputs (bool, optional): If True, gradient w.r.t. leaves that are
+        only_inputs (bool, optional): If ``True``, gradient w.r.t. leaves that are
             part of the graph, but don't appear in ``inputs`` won't be computed
-            and accumulated. Defaults to True.
-        allow_unused (bool, optional): If False, specifying inputs that were not
+            and accumulated. Defaults to ``True``.
+        allow_unused (bool, optional): If ``False``, specifying inputs that were not
             used when computing outputs (and therefore their grad is always zero)
-            is an error. Default: False.
+            is an error. Defaults to ``False``.
     """
 
     outputs = (outputs,) if isinstance(outputs, Variable) else tuple(outputs)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -84,7 +84,7 @@ class profile(object):
 
     Arguments:
         enabled (bool, optional): Setting this to False makes this context manager a no-op.
-            Default: True.
+            Default: ``True``.
 
     .. warning:
         This context managers should not be called recursively, i.e. at most one
@@ -176,7 +176,7 @@ class emit_nvtx(object):
 
     Arguments:
         enabled (bool, optional): Setting this to False makes this context manager a no-op.
-            Default: True.
+            Default: ``True``.
 
     Example:
         >>> with torch.cuda.profiler.profile():

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -155,14 +155,14 @@ class Variable(_C._VariableBase):
                 None values can be specified for scalar Variables or ones that
                 don't require grad. If a None value would be acceptable then
                 this argument is optional.
-            retain_graph (bool, optional): If False, the graph used to compute
+            retain_graph (bool, optional): If ``False``, the graph used to compute
                 the grads will be freed. Note that in nearly all cases setting
                 this option to True is not needed and often can be worked around
                 in a much more efficient way. Defaults to the value of
                 ``create_graph``.
-            create_graph (bool, optional): If true, graph of the derivative will
+            create_graph (bool, optional): If ``True``, graph of the derivative will
                 be constructed, allowing to compute higher order derivative
-                products. Defaults to False, unless ``gradient`` is a volatile
+                products. Defaults to ``False``, unless ``gradient`` is a volatile
                 Variable.
         """
         torch.autograd.backward(self, gradient, retain_graph, create_graph, retain_variables)

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -107,10 +107,10 @@ class Event(object):
 
     Arguments:
         enable_timing (bool): indicates if the event should measure time
-            (default: False)
-        blocking (bool): if true, :meth:`wait` will be blocking (default: False)
-        interprocess (bool): if true, the event can be shared between processes
-            (default: False)
+            (default: ``False``)
+        blocking (bool): if ``True``, :meth:`wait` will be blocking (default: ``False``)
+        interprocess (bool): if ``True``, the event can be shared between processes
+            (default: ``False``)
     """
 
     DEFAULT = 0x0

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -58,10 +58,10 @@ def compile(arg=None, **kwargs):
             (as we always wait to see all derivatives before compiling.)
             Default: 1 (i.e., we will compile forwards and backwards, but not
             double-backwards).
-        optimize (bool, optional): whether or not to apply optimizations.  Default: True.
+        optimize (bool, optional): whether or not to apply optimizations.  Default: ``True``.
 
     Debug arguments:
-        time (bool, optional): if True, whenever we execute the model in question, we
+        time (bool, optional): if ``True``, whenever we execute the model in question, we
             will also print out some timing information for how long the model
             took to execute.  At the moment, there are three types of timings we
             emit:
@@ -76,10 +76,10 @@ def compile(arg=None, **kwargs):
                 - optimized: the time it took to execute the optimized model.
 
             At the moment, all of these timings are for the forward pass only.
-            Default: False.
-        enabled (bool, optional): if False, compilation is disabled and you
+            Default: ``False``.
+        enabled (bool, optional): if ``False``, compilation is disabled and you
             will get back your original model.  This is a convenient way to
-            disable tracing without having to delete the annotation. Default: True.
+            disable tracing without having to delete the annotation. Default: ``True``.
 
     Example: Compile as class decorator.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -241,9 +241,9 @@ def avg_pool1d(input, kernel_size, stride=None, padding=0,
         padding: implicit zero paddings on both sides of the input. Can be a
           single number or a tuple (padW,). Default: 0
         ceil_mode: when True, will use `ceil` instead of `floor` to compute the
-            output shape. Default: False
+            output shape. Default: ``False``
         count_include_pad: when True, will include the zero-padding in the
-            averaging calculation. Default: True
+            averaging calculation. Default: ``True``
 
     Example:
         >>> # pool of square window of size=3, stride=2
@@ -282,9 +282,9 @@ Args:
     padding: implicit zero paddings on both sides of the input. Can be a
       single number or a tuple (padH, padW). Default: 0
     ceil_mode: when True, will use `ceil` instead of `floor` in the formula
-        to compute the output shape. Default: False
+        to compute the output shape. Default: ``False``
     count_include_pad: when True, will include the zero-padding in th
-        averaging calculation. Default: True
+        averaging calculation. Default: ``True``
 """)
 
 avg_pool3d = _add_docstr(torch._C._nn.avg_pool3d, r"""
@@ -446,7 +446,7 @@ def adaptive_max_pool1d(input, output_size, return_indices=False):
 
     Args:
         output_size: the target output size (single integer)
-        return_indices: whether to return pooling indices. Default: False
+        return_indices: whether to return pooling indices. Default: ``False``
     """
     ret = _functions.thnn.AdaptiveMaxPool1d.apply(input, output_size)
     return ret if return_indices else ret[0]
@@ -461,7 +461,7 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
     Args:
         output_size: the target output size (single integer or
             double-integer tuple)
-        return_indices: whether to return pooling indices. Default: False
+        return_indices: whether to return pooling indices. Default: ``False``
     """
     ret = _functions.thnn.AdaptiveMaxPool2d.apply(input, output_size)
     return ret if return_indices else ret[0]
@@ -476,7 +476,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
     Args:
         output_size: the target output size (single integer or
             triple-integer tuple)
-        return_indices: whether to return pooling indices. Default: False
+        return_indices: whether to return pooling indices. Default: ``False``
     """
     ret = _functions.thnn.AdaptiveMaxPool3d.apply(input, output_size)
     return ret if return_indices else ret[0]
@@ -533,7 +533,7 @@ def alpha_dropout(input, p=0.5, training=False):
 
     Args:
         p (float, optional): the drop probability. Default: 0.5
-        training (bool, optional): switch between training and evaluation mode. Default: False
+        training (bool, optional): switch between training and evaluation mode. Default: ``False``
     """
     if p < 0 or p > 1:
         raise ValueError("dropout probability has to be between 0 and 1, "
@@ -865,7 +865,7 @@ def embedding(input, embedding_matrix,
         norm_type (float, optional): The p of the p-norm to compute for the max_norm option
         scale_grad_by_freq (boolean, optional): if given, this will scale gradients by the frequency of
                                                 the words in the mini-batch.
-        sparse (boolean, optional): if True, gradient w.r.t. weight matrix will be a sparse tensor. See Notes for
+        sparse (boolean, optional): if ``True``, gradient w.r.t. weight matrix will be a sparse tensor. See Notes for
                                     more details regarding sparse gradients.
 
     Shape:
@@ -1028,7 +1028,7 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
             class. If given, has to be a Tensor of size `C`
         size_average (bool, optional): By default, the losses are averaged
             over observations for each minibatch. If size_average
-            is False, the losses are summed for each minibatch. Default: True
+            is False, the losses are summed for each minibatch. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average is
             True, the loss is averaged over non-ignored targets. Default: -100
@@ -1061,15 +1061,15 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
     Args:
         input: expectation of underlying Poisson distribution.
         target: random sample :math:`target \sim Pois(input)`.
-        log_input: if True the loss is computed as
-            `exp(input) - target * input`, if False then loss is
-            `input - target * log(input+eps)`. Default: True
+        log_input: if ``True`` the loss is computed as
+            `exp(input) - target * input`, if ``False`` then loss is
+            `input - target * log(input+eps)`. Default: ``True``
         full: whether to compute full loss, i. e. to add the Stirling
-            approximation term. Default: False
+            approximation term. Default: ``False``
             `target * log(target) - target + 0.5 * log(2 * pi * target)`.
         size_average: By default, the losses are averaged over observations for
             each minibatch. However, if the field sizeAverage is set to False,
-            the losses are instead summed for each minibatch. Default: True
+            the losses are instead summed for each minibatch. Default: ``True``
         eps (float, optional): Small value to avoid evaluation of log(0) when
             log_input=False. Default: 1e-8
     """
@@ -1096,12 +1096,12 @@ See :class:`~torch.nn.KLDivLoss` for details.
 Args:
     input: Variable of arbitrary shape
     target: Variable of the same shape as input
-    size_average: if True the output is divided by the number of elements
-        in input tensor. Default: True
+    size_average: if ``True`` the output is divided by the number of elements
+        in input tensor. Default: ``True``
     reduce (bool, optional): By default, the losses are averaged
         over observations for each minibatch, or summed, depending on
         size_average. When reduce is False, returns a loss per batch
-        element instead and ignores size_average. Default: True
+        element instead and ignores size_average. Default: ``True``
 
 """)
 
@@ -1121,14 +1121,14 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
-                for each minibatch. Ignored if reduce is False. Default: True
+                for each minibatch. Ignored if reduce is False. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
                 and does not contribute to the input gradient. When size_average is
                 True, the loss is averaged over non-ignored targets. Default: -100
         reduce (bool, optional): By default, the losses are averaged or summed over
                 observations for each minibatch depending on size_average. When reduce
                 is False, returns a loss per batch element instead and ignores
-                size_average. Default: True
+                size_average. Default: ``True``
 
     Examples::
 
@@ -1154,7 +1154,7 @@ def binary_cross_entropy(input, target, weight=None, size_average=True):
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
-                for each minibatch. Default: True
+                for each minibatch. Default: ``True``
 
     Examples::
 
@@ -1193,7 +1193,7 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
-                for each minibatch. Default: True
+                for each minibatch. Default: ``True``
 
     Examples::
 
@@ -1623,7 +1623,7 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
         margin: the margin value. Default: 1
         p: the norm degree. Default: 2
         eps: small epsilon value to avoid numerical issues. Default: 1e-6
-        swap: compute distance swap. Default: False
+        swap: compute distance swap. Default: ``False``
 
     Shape:
         - Input: :math:`(N, D)` where `D = vector dimension`

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -17,7 +17,7 @@ class Threshold(Module):
     Args:
         threshold: The value to threshold at
         value: The value to replace with
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -55,7 +55,7 @@ class ReLU(Threshold):
     :math:`{ReLU}(x)= max(0, x)`
 
     Args:
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -112,7 +112,7 @@ class Hardtanh(Module):
     Args:
         min_val: minimum value of the linear region range. Default: -1
         max_val: maximum value of the linear region range. Default: 1
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Keyword arguments :attr:`min_value` and :attr:`max_value`
     have been deprecated in favor of :attr:`min_val` and :attr:`max_val`
@@ -159,7 +159,7 @@ class ReLU6(Hardtanh):
     r"""Applies the element-wise function :math:`{ReLU6}(x) = min(max(0,x), 6)`
 
     Args:
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -236,7 +236,7 @@ class ELU(Module):
 
     Args:
         alpha: the alpha value for the ELU formulation. Default: 1.0
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -275,7 +275,7 @@ class SELU(Module):
     More details can be found in the paper `Self-Normalizing Neural Networks`_ .
 
     Args:
-        inplace (bool, optional): can optionally do the operation in-place. Default: False
+        inplace (bool, optional): can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -377,7 +377,7 @@ class LeakyReLU(Module):
 
     Args:
         negative_slope: Controls the angle of the negative slope. Default: 1e-2
-        inplace: can optionally do the operation in-place. Default: False
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -69,8 +69,8 @@ class BatchNorm1d(_BatchNorm):
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable
-            affine parameters. Default: True
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C)` or :math:`(N, C, L)`
@@ -119,8 +119,8 @@ class BatchNorm2d(_BatchNorm):
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable
-            affine parameters. Default: True
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -170,8 +170,8 @@ class BatchNorm3d(_BatchNorm):
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable
-            affine parameters. Default: True
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -115,7 +115,7 @@ class Conv1d(_ConvNd):
             elements. Default: 1
         groups (int, optional): Number of blocked connections from input
             channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C_{in}, L_{in})`
@@ -211,7 +211,7 @@ class Conv2d(_ConvNd):
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C_{in}, H_{in}, W_{in})`
@@ -308,7 +308,7 @@ class Conv3d(_ConvNd):
         padding (int or tuple, optional): Zero-padding added to all three sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C_{in}, D_{in}, H_{in}, W_{in})`
@@ -434,7 +434,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         output_padding (int or tuple, optional): Zero-padding added to one side of the output. Default: 0
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
 
     Shape:
@@ -513,7 +513,7 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         output_padding (int or tuple, optional): Zero-padding added to one side of the output. Default: 0
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
 
     Shape:
@@ -620,7 +620,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         padding (int or tuple, optional): Zero-padding added to all three sides of the input. Default: 0
         output_padding (int or tuple, optional): Zero-padding added to one side of the output. Default: 0
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
-        bias (bool, optional): If True, adds a learnable bias to the output. Default: True
+        bias (bool, optional): If ``True``, adds a learnable bias to the output. Default: ``True``
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
 
     Shape:

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -18,7 +18,7 @@ class Dropout(Module):
 
     Args:
         p: probability of an element to be zeroed. Default: 0.5
-        inplace: If set to True, will do this operation in-place. Default: false
+        inplace: If set to ``True``, will do this operation in-place. Default: ``False``
 
     Shape:
         - Input: `Any`. Input can be of any shape
@@ -70,7 +70,7 @@ class Dropout2d(Module):
 
     Args:
         p (float, optional): probability of an element to be zeroed.
-        inplace (bool, optional): If set to True, will do this operation
+        inplace (bool, optional): If set to ``True``, will do this operation
             in-place
 
     Shape:
@@ -123,7 +123,7 @@ class Dropout3d(Module):
 
     Args:
         p (float, optional): probability of an element to be zeroed.
-        inplace (bool, optional): If set to True, will do this operation
+        inplace (bool, optional): If set to ``True``, will do this operation
             in-place
 
     Shape:

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -58,7 +58,7 @@ class InstanceNorm1d(_InstanceNorm):
         num_features: num_features from an expected input of size `batch_size x num_features x width`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable affine parameters. Default: False
+        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, L)`
@@ -102,7 +102,7 @@ class InstanceNorm2d(_InstanceNorm):
         num_features: num_features from an expected input of size batch_size x num_features x height x width
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable affine parameters. Default: False
+        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -147,7 +147,7 @@ class InstanceNorm3d(_InstanceNorm):
         num_features: num_features from an expected input of size batch_size x num_features x depth x height x width
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to true, gives the layer learnable affine parameters. Default: False
+        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -58,7 +58,8 @@ class InstanceNorm1d(_InstanceNorm):
         num_features: num_features from an expected input of size `batch_size x num_features x width`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, L)`
@@ -102,7 +103,8 @@ class InstanceNorm2d(_InstanceNorm):
         num_features: num_features from an expected input of size batch_size x num_features x height x width
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -147,7 +149,8 @@ class InstanceNorm3d(_InstanceNorm):
         num_features: num_features from an expected input of size batch_size x num_features x depth x height x width
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, gives the layer learnable
+            affine parameters. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -13,7 +13,7 @@ class Linear(Module):
         in_features: size of each input sample
         out_features: size of each output sample
         bias: If set to False, the layer will not learn an additive bias.
-            Default: True
+            Default: ``True``
 
     Shape:
         - Input: :math:`(N, *, in\_features)` where `*` means any number of
@@ -69,7 +69,7 @@ class Bilinear(Module):
         in2_features: size of each second input sample
         out_features: size of each output sample
         bias: If set to False, the layer will not learn an additive bias.
-            Default: True
+            Default: ``True``
 
     Shape:
         - Input: :math:`(N, in1\_features)`, :math:`(N, in2\_features)`

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -40,18 +40,18 @@ class L1Loss(_Loss):
     Args:
         size_average (bool, optional): By default, the losses are averaged
            over observations for each minibatch. However, if the field
-           size_average is set to False, the losses are instead summed for
-           each minibatch. Ignored when reduce is False. Default: True
+           size_average is set to ``False``, the losses are instead summed for
+           each minibatch. Ignored when reduce is ``False``. Default: ``True``
         reduce (bool, optional): By default, the losses are averaged or summed
-           for each minibatch. When reduce is False, the loss function returns
+           for each minibatch. When reduce is ``False``, the loss function returns
            a loss per batch element instead and ignores size_average.
-           Default: True
+           Default: ``True``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Target: :math:`(N, *)`, same shape as the input
-        - Output: scalar. If reduce is False, then
+        - Output: scalar. If reduce is ``False``, then
           :math:`(N, *)`, same shape as the input
 
     Examples::
@@ -109,20 +109,20 @@ class NLLLoss(_WeightedLoss):
            class. If given, has to be a Tensor of size `C`
         size_average (bool, optional): By default, the losses are averaged
            over observations for each minibatch. However, if the field
-           size_average is set to False, the losses are instead summed for
-           each minibatch. Ignored when reduce is False. Default: True
+           size_average is set to ``False``, the losses are instead summed for
+           each minibatch. Ignored when reduce is ``False``. Default: ``True``
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average
-            is True, the loss is averaged over non-ignored targets.
+            is ``True``, the loss is averaged over non-ignored targets.
         reduce (bool, optional): By default, the losses are averaged or summed
-            for each minibatch. When reduce is False, the loss function returns
+            for each minibatch. When reduce is ``False``, the loss function returns
             a loss per batch element instead and ignores size_average.
-            Default: True
+            Default: ``True``
 
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
         - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
-        - Output: scalar. If reduce is False, then :math:`(N)` instead.
+        - Output: scalar. If reduce is ``False``, then :math:`(N)` instead.
 
     Examples::
 
@@ -157,18 +157,18 @@ class NLLLoss2d(NLLLoss):
             as there are classes.
         size_average: By default, the losses are averaged over observations
             for each minibatch. However, if the field size_average is set to
-            False, the losses are instead summed for each minibatch.
-            Ignored when reduce is False. Default: True
+            ``False``, the losses are instead summed for each minibatch.
+            Ignored when reduce is ``False``. Default: ``True``
         reduce (bool, optional): By default, the losses are averaged or summed
-            for each minibatch depending on size_average. When reduce is False,
+            for each minibatch depending on size_average. When reduce is ``False``,
             the loss function returns a loss per batch element instead and
-            ignores size_average. Default: True
+            ignores size_average. Default: ``True``
 
 
     Shape:
         - Input: :math:`(N, C, H, W)` where `C = number of classes`
         - Target: :math:`(N, H, W)` where each value is `0 <= targets[i] <= C-1`
-        - Output: scalar. If reduce is False, then :math:`(N, H, W)` instead.
+        - Output: scalar. If reduce is ``False``, then :math:`(N, H, W)` instead.
 
     Examples::
 
@@ -197,17 +197,17 @@ class PoissonNLLLoss(_Loss):
     equal to 1 zeros are added to the loss.
 
     Args:
-        log_input (bool, optional): if True the loss is computed as
-            `exp(input) - target * input`, if False the loss is
+        log_input (bool, optional): if ``True`` the loss is computed as
+            `exp(input) - target * input`, if ``False`` the loss is
             `input - target * log(input+eps)`.
         full (bool, optional): whether to compute full loss, i. e. to add the
             Stirling approximation term
             `target * log(target) - target + 0.5 * log(2 * pi * target)`.
         size_average (bool, optional): By default, the losses are averaged over
             observations for each minibatch. However, if the field size_average
-            is set to False, the losses are instead summed for each minibatch.
+            is set to ``False``, the losses are instead summed for each minibatch.
         eps (float, optional): Small value to avoid evaluation of log(0) when
-            log_input=False. Default: 1e-8
+            log_input==``False``. Default: 1e-8
 
     Examples::
 
@@ -249,7 +249,7 @@ class KLDivLoss(_Loss):
 
     By default, the losses are averaged for each minibatch over observations
     **as well as** over dimensions. However, if the field
-    `size_average` is set to `False`, the losses are instead summed.
+    `size_average` is set to ``False``, the losses are instead summed.
 
     .. _Kullback-Leibler divergence:
         https://en.wikipedia.org/wiki/Kullback-Leibler_divergence
@@ -257,17 +257,17 @@ class KLDivLoss(_Loss):
     Args:
         size_average (bool, optional: By default, the losses are averaged
             for each minibatch over observations **as well as** over
-            dimensions. However, if False the losses are instead summed.
+            dimensions. However, if ``False`` the losses are instead summed.
         reduce (bool, optional): By default, the losses are averaged
             over observations for each minibatch, or summed, depending on
-            size_average. When reduce is False, returns a loss per batch
-            element instead and ignores size_average. Default: True
+            size_average. When reduce is ``False``, returns a loss per batch
+            element instead and ignores size_average. Default: ``True``
 
     Shape:
         - input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - target: :math:`(N, *)`, same shape as the input
-        - output: scalar. If `reduce` is True, then :math:`(N, *)`,
+        - output: scalar. If `reduce` is ``True``, then :math:`(N, *)`,
             same shape as the input
 
     """
@@ -291,21 +291,21 @@ class MSELoss(_Loss):
     The sum operation still operates over all the elements, and divides by `n`.
 
     The division by `n` can be avoided if one sets the internal variable
-    `size_average` to `False`.
+    `size_average` to ``False``.
 
     To get a batch of losses, a loss per batch element, set `reduce` to
-    `False`. These losses are not averaged and are not affected by
+    ``False``. These losses are not averaged and are not affected by
     `size_average`.
 
     Args:
         size_average (bool, optional): By default, the losses are averaged
            over observations for each minibatch. However, if the field
-           size_average is set to False, the losses are instead summed for
-           each minibatch. Only applies when reduce is True. Default: True
+           size_average is set to ``False``, the losses are instead summed for
+           each minibatch. Only applies when reduce is ``True``. Default: ``True``
         reduce (bool, optional): By default, the losses are averaged
            over observations for each minibatch, or summed, depending on
-           size_average. When reduce is False, returns a loss per batch
-           element instead and ignores size_average. Default: True
+           size_average. When reduce is ``False``, returns a loss per batch
+           element instead and ignores size_average. Default: ``True``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -349,8 +349,8 @@ class BCELoss(_WeightedLoss):
             "nbatch".
         size_average (bool, optional): By default, the losses are averaged
             over observations for each minibatch. However, if the field
-            size_average is set to False, the losses are instead summed for
-            each minibatch. Default: True
+            size_average is set to ``False``, the losses are instead summed for
+            each minibatch. Default: ``True``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -397,8 +397,8 @@ class BCEWithLogitsLoss(Module):
             "nbatch".
         size_average (bool, optional): By default, the losses are averaged
             over observations for each minibatch. However, if the field
-            size_average is set to False, the losses are instead summed for
-            each minibatch. Default: True
+            size_average is set to ``False``, the losses are instead summed for
+            each minibatch. Default: ``True``
 
      Shape:
          - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -491,21 +491,21 @@ class SmoothL1Loss(_Loss):
     the sum operation still operates over all the elements, and divides by `n`.
 
     The division by `n` can be avoided if one sets the internal variable
-    `size_average` to `False`
+    `size_average` to ``False``
 
     Args:
         size_average (bool, optional): By default, the losses are averaged
-           over all elements. However, if the field size_average is set to False,
-           the losses are instead summed. Ignored when reduce is False. Default: True
+           over all elements. However, if the field size_average is set to ``False``,
+           the losses are instead summed. Ignored when reduce is ``False``. Default: ``True``
         reduce (bool, optional): By default, the losses are averaged or summed
-           over elements. When reduce is False, the loss function returns
-           a loss per element instead and ignores size_average. Default: True
+           over elements. When reduce is ``False``, the loss function returns
+           a loss per element instead and ignores size_average. Default: ``True``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Target: :math:`(N, *)`, same shape as the input
-        - Output: scalar. If reduce is False, then
+        - Output: scalar. If reduce is ``False``, then
           :math:`(N, *)`, same shape as the input
 
     """
@@ -529,7 +529,7 @@ class SoftMarginLoss(_Loss):
         loss(x, y) = sum_i (log(1 + exp(-y[i]*x[i]))) / x.nelement()
 
     The normalization by the number of elements in the input can be disabled by
-    setting `self.size_average` to `False`.
+    setting `self.size_average` to ``False``.
     """
     def forward(self, input, target):
         _assert_no_grad(target)
@@ -566,20 +566,20 @@ class CrossEntropyLoss(_WeightedLoss):
         weight (Tensor, optional): a manual rescaling weight given to each class.
            If given, has to be a Tensor of size "C"
         size_average (bool, optional): By default, the losses are averaged over observations for each minibatch.
-           However, if the field size_average is set to False, the losses are
-           instead summed for each minibatch. Ignored if reduce is False.
+           However, if the field size_average is set to ``False``, the losses are
+           instead summed for each minibatch. Ignored if reduce is ``False``.
         ignore_index (int, optional): Specifies a target value that is ignored
             and does not contribute to the input gradient. When size_average is
-            True, the loss is averaged over non-ignored targets.
+            ``True``, the loss is averaged over non-ignored targets.
         reduce (bool, optional): By default, the losses are averaged or summed over
             observations for each minibatch depending on size_average. When reduce
-            is False, returns a loss per batch element instead and ignores
-            size_average. Default: True
+            is ``False``, returns a loss per batch element instead and ignores
+            size_average. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C)` where `C = number of classes`
         - Target: :math:`(N)` where each value is `0 <= targets[i] <= C-1`
-        - Output: scalar. If reduce is False, then :math:`(N)` instead.
+        - Output: scalar. If reduce is ``False``, then :math:`(N)` instead.
 
     Examples::
 
@@ -633,9 +633,9 @@ class CosineEmbeddingLoss(Module):
         loss(x, y) = {
                      { max(0, cos(x1, x2) - margin), if y == -1
 
-    If the internal variable `size_average` is equal to `True`,
+    If the internal variable `size_average` is equal to ``True``,
     the loss function averages the loss over the batch samples;
-    if `size_average` is `False`, then the loss function sums over the
+    if `size_average` is ``False``, then the loss function sums over the
     batch samples. By default, `size_average = True`.
     """
 
@@ -664,7 +664,7 @@ class MarginRankingLoss(Module):
     the loss function averages the loss over the batch samples;
     if `size_average = False`, then the loss function sums over the batch
     samples.
-    By default, `size_average` equals to `True`.
+    By default, `size_average` equals to ``True``.
     """
 
     def __init__(self, margin=0, size_average=True):
@@ -695,7 +695,7 @@ class MultiMarginLoss(Module):
         loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] - x[i]))^p) / x.size(0)
 
     By default, the losses are averaged over observations for each minibatch.
-    However, if the field `size_average` is set to `False`,
+    However, if the field `size_average` is set to ``False``,
     the losses are instead summed.
     """
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -419,7 +419,7 @@ class Module(object):
         Both parameters and persistent buffers (e.g. running averages) are
         included. Keys are corresponding parameter and buffer names.
 
-        When keep_vars is true, it returns a Variable for each parameter
+        When keep_vars is ``True``, it returns a Variable for each parameter
         (rather than a Tensor).
 
         Args:
@@ -428,9 +428,9 @@ class Module(object):
                 Default: None
             prefix (string, optional): Adds a prefix to the key (name) of every
                 parameter and buffer in the result dictionary. Default: ''
-            keep_vars (bool, optional): if true, returns a Variable for each
-                parameter. If false, returns a Tensor for each parameter.
-                Default: False
+            keep_vars (bool, optional): if ``True``, returns a Variable for each
+                parameter. If ``False``, returns a Tensor for each parameter.
+                Default: ``False``
 
         Returns:
             dict:
@@ -455,7 +455,7 @@ class Module(object):
 
     def load_state_dict(self, state_dict, strict=True):
         """Copies parameters and buffers from :attr:`state_dict` into
-        this module and its descendants. If :attr:`strict` is `True` then
+        this module and its descendants. If :attr:`strict` is ``True`` then
         the keys of :attr:`state_dict` must exactly match the keys returned
         by this module's :func:`state_dict()` function.
 

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -29,7 +29,7 @@ class MaxPool1d(Module):
         stride: the stride of the window. Default value is :attr:`kernel_size`
         padding: implicit zero padding to be added on both sides
         dilation: a parameter that controls the stride of elements in the window
-        return_indices: if True, will return the max indices along with the outputs.
+        return_indices: if ``True``, will return the max indices along with the outputs.
                         Useful when Unpooling later
         ceil_mode: when True, will use `ceil` instead of `floor` to compute the output shape
 
@@ -104,7 +104,7 @@ class MaxPool2d(Module):
         stride: the stride of the window. Default value is :attr:`kernel_size`
         padding: implicit zero padding to be added on both sides
         dilation: a parameter that controls the stride of elements in the window
-        return_indices: if True, will return the max indices along with the outputs.
+        return_indices: if ``True``, will return the max indices along with the outputs.
                         Useful when Unpooling later
         ceil_mode: when True, will use `ceil` instead of `floor` to compute the output shape
 
@@ -544,7 +544,7 @@ class MaxPool3d(Module):
         stride: the stride of the window. Default value is :attr:`kernel_size`
         padding: implicit zero padding to be added on all three sides
         dilation: a parameter that controls the stride of elements in the window
-        return_indices: if True, will return the max indices along with the outputs.
+        return_indices: if ``True``, will return the max indices along with the outputs.
                         Useful when Unpooling later
         ceil_mode: when True, will use `ceil` instead of `floor` to compute the output shape
 
@@ -684,8 +684,8 @@ class FractionalMaxPool2d(Module):
                      Can be a tuple (oH, oW) or a single number oH for a square image oH x oH
         output_ratio: If one wants to have an output size as a ratio of the input size, this option can be given.
                       This has to be a number or tuple in the range (0, 1)
-        return_indices: if True, will return the indices along with the outputs.
-                        Useful to pass to nn.MaxUnpool2d. Default: False
+        return_indices: if ``True``, will return the indices along with the outputs.
+                        Useful to pass to nn.MaxUnpool2d. Default: ``False``
 
     Examples:
         >>> # pool of square window of size=3, and target output size 13x12
@@ -839,8 +839,8 @@ class AdaptiveMaxPool1d(Module):
 
     Args:
         output_size: the target output size H
-        return_indices: if True, will return the indices along with the outputs.
-                        Useful to pass to nn.MaxUnpool1d. Default: False
+        return_indices: if ``True``, will return the indices along with the outputs.
+                        Useful to pass to nn.MaxUnpool1d. Default: ``False``
 
     Examples:
         >>> # target output size of 5
@@ -872,8 +872,8 @@ class AdaptiveMaxPool2d(Module):
     Args:
         output_size: the target output size of the image of the form H x W.
                      Can be a tuple (H, W) or a single number H for a square image H x H
-        return_indices: if True, will return the indices along with the outputs.
-                        Useful to pass to nn.MaxUnpool2d. Default: False
+        return_indices: if ``True``, will return the indices along with the outputs.
+                        Useful to pass to nn.MaxUnpool2d. Default: ``False``
 
     Examples:
         >>> # target output size of 5x7
@@ -909,8 +909,8 @@ class AdaptiveMaxPool3d(Module):
     Args:
         output_size: the target output size of the image of the form D x H x W.
                      Can be a tuple (D, H, W) or a single number D for a cube D x D x D
-        return_indices: if True, will return the indices along with the outputs.
-                        Useful to pass to nn.MaxUnpool3d. Default: False
+        return_indices: if ``True``, will return the indices along with the outputs.
+                        Useful to pass to nn.MaxUnpool3d. Default: ``False``
 
     Examples:
         >>> # target output size of 5x7x9

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -224,13 +224,13 @@ class RNN(RNNBase):
         hidden_size: The number of features in the hidden state h
         num_layers: Number of recurrent layers.
         nonlinearity: The non-linearity to use ['tanh'|'relu']. Default: 'tanh'
-        bias: If False, then the layer does not use bias weights b_ih and b_hh.
-            Default: True
-        batch_first: If True, then the input and output tensors are provided
+        bias: If ``False``, then the layer does not use bias weights b_ih and b_hh.
+            Default: ``True``
+        batch_first: If ``True``, then the input and output tensors are provided
             as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each
             RNN layer except the last layer
-        bidirectional: If True, becomes a bidirectional RNN. Default: False
+        bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features
@@ -311,13 +311,13 @@ class LSTM(RNNBase):
         input_size: The number of expected features in the input x
         hidden_size: The number of features in the hidden state h
         num_layers: Number of recurrent layers.
-        bias: If False, then the layer does not use bias weights b_ih and b_hh.
-            Default: True
-        batch_first: If True, then the input and output tensors are provided
+        bias: If ``False``, then the layer does not use bias weights b_ih and b_hh.
+            Default: ``True``
+        batch_first: If ``True``, then the input and output tensors are provided
             as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each
             RNN layer except the last layer
-        bidirectional: If True, becomes a bidirectional RNN. Default: False
+        bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
     Inputs: input, (h_0, c_0)
         - **input** (seq_len, batch, input_size): tensor containing the features
@@ -388,13 +388,13 @@ class GRU(RNNBase):
         input_size: The number of expected features in the input x
         hidden_size: The number of features in the hidden state h
         num_layers: Number of recurrent layers.
-        bias: If False, then the layer does not use bias weights b_ih and b_hh.
-            Default: True
-        batch_first: If True, then the input and output tensors are provided
+        bias: If ``False``, then the layer does not use bias weights b_ih and b_hh.
+            Default: ``True``
+        batch_first: If ``True``, then the input and output tensors are provided
             as (batch, seq, feature)
         dropout: If non-zero, introduces a dropout layer on the outputs of each
             RNN layer except the last layer
-        bidirectional: If True, becomes a bidirectional RNN. Default: False
+        bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
     Inputs: input, h_0
         - **input** (seq_len, batch, input_size): tensor containing the features
@@ -457,8 +457,8 @@ class RNNCell(RNNCellBase):
     Args:
         input_size: The number of expected features in the input x
         hidden_size: The number of features in the hidden state h
-        bias: If False, then the layer does not use bias weights b_ih and b_hh.
-            Default: True
+        bias: If ``False``, then the layer does not use bias weights b_ih and b_hh.
+            Default: ``True``
         nonlinearity: The non-linearity to use ['tanh'|'relu']. Default: 'tanh'
 
     Inputs: input, hidden
@@ -544,7 +544,7 @@ class LSTMCell(RNNCellBase):
         input_size: The number of expected features in the input x
         hidden_size: The number of features in the hidden state h
         bias: If `False`, then the layer does not use bias weights `b_ih` and
-            `b_hh`. Default: True
+            `b_hh`. Default: ``True``
 
     Inputs: input, (h_0, c_0)
         - **input** (batch, input_size): tensor containing input features

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -21,7 +21,7 @@ class Embedding(Module):
         norm_type (float, optional): The p of the p-norm to compute for the max_norm option
         scale_grad_by_freq (boolean, optional): if given, this will scale gradients by the frequency of
                                                 the words in the mini-batch.
-        sparse (boolean, optional): if True, gradient w.r.t. weight matrix will be a sparse tensor. See Notes for
+        sparse (boolean, optional): if ``True``, gradient w.r.t. weight matrix will be a sparse tensor. See Notes for
                                     more details regarding sparse gradients.
 
     Attributes:

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -44,7 +44,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     Arguments:
         input (Variable): padded batch of variable length sequences.
         lengths (list[int]): list of sequences lengths of each batch element.
-        batch_first (bool, optional): if True, the input is expected in BxTx*
+        batch_first (bool, optional): if ``True``, the input is expected in BxTx*
             format.
 
     Returns:
@@ -89,7 +89,7 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0):
 
     Arguments:
         sequence (PackedSequence): batch to pad
-        batch_first (bool, optional): if True, the output will be in BxTx*
+        batch_first (bool, optional): if ``True``, the output will be in BxTx*
             format.
         padding_value (float, optional): values for padded elements
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -177,8 +177,8 @@ class ReduceLROnPlateau(object):
             reduced. new_lr = lr * factor. Default: 0.1.
         patience (int): Number of epochs with no improvement after
             which learning rate will be reduced. Default: 10.
-        verbose (bool): If True, prints a message to stdout for
-            each update. Default: False.
+        verbose (bool): If ``True``, prints a message to stdout for
+            each update. Default: ``False``.
         threshold (float): Threshold for measuring the new optimum,
             to only focus on significant changes. Default: 1e-4.
         threshold_mode (str): One of `rel`, `abs`. In `rel` mode,

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -19,7 +19,7 @@ class RMSprop(Optimizer):
         alpha (float, optional): smoothing constant (default: 0.99)
         eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
-        centered (bool, optional) : if True, compute the centered RMSProp,
+        centered (bool, optional) : if ``True``, compute the centered RMSProp,
             the gradient is normalized by an estimation of its variance
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
 

--- a/torch/random.py
+++ b/torch/random.py
@@ -56,7 +56,7 @@ def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="device
             on all devices, but will emit a warning if your machine has a lot
             of devices, since this function will run very slowly in that case.
             If you explicitly specify devices, this warning will be supressed
-        enabled (bool): if False, the RNG is not forked.  This is a convenience
+        enabled (bool): if ``False``, the RNG is not forked.  This is a convenience
             argument for easily disabling the context manager without having
             to reindent your Python code.
     """

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -273,7 +273,7 @@ class DataLoader(object):
         pin_memory (bool, optional): If ``True``, the data loader will copy tensors
             into CUDA pinned memory before returning them.
         drop_last (bool, optional): set to ``True`` to drop the last incomplete batch,
-            if the dataset size is not divisible by the batch size. If False and
+            if the dataset size is not divisible by the batch size. If ``False`` and
             the size of dataset is not divisible by the batch size, then the last batch
             will be smaller. (default: False)
     """


### PR DESCRIPTION
Before, there was italic, inline code and plain text usages all around. This also makes them more apparent in the documentation. 