### PR TITLE
Fix build failures in MSVC

### DIFF
--- a/aten/src/ATen/Half.h
+++ b/aten/src/ATen/Half.h
@@ -71,10 +71,10 @@ typedef struct  AT_ALIGN(2) {
   operator double();
 } Half;
 
-template<> Half convert(double f);
-template<> double convert(Half f);
-template<> Half convert(int64_t f);
-template<> int64_t convert(Half f);
+template<> AT_API Half convert(double f);
+template<> AT_API double convert(Half f);
+template<> AT_API Half convert(int64_t f);
+template<> AT_API int64_t convert(Half f);
 
 template<> bool overflows<Half, double>(double f);
 template<> bool overflows<Half, int64_t>(int64_t f);

--- a/aten/src/ATen/UndefinedTensor.h
+++ b/aten/src/ATen/UndefinedTensor.h
@@ -4,7 +4,7 @@
 
 namespace at {
 
-struct UndefinedTensor final : public TensorImpl {
+struct AT_API UndefinedTensor final : public TensorImpl {
 public:
   static inline UndefinedTensor * singleton() {
     return &_singleton;

--- a/aten/src/TH/generic/THTensorRandom.c
+++ b/aten/src/TH/generic/THTensorRandom.c
@@ -66,12 +66,13 @@ void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, 
 
 void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)
 {
+  #if defined(TH_REAL_IS_FLOAT)
   TH_TENSOR_APPLY(real, self, *self_data =
-    #if defined(TH_REAL_IS_FLOAT)
     (real)THRandom_uniformFloat(_generator, (real)a, (real)b););
-    #else
+  #else
+  TH_TENSOR_APPLY(real, self, *self_data =
     (real)THRandom_uniform(_generator, a, b););
-    #endif
+  #endif
 }
 
 void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv)


### PR DESCRIPTION
The ATen commits are breaking MSVC builds. Some issues should be addressed.
1. Export some functions and classes
2. Modify the `#ifdef` macro to make it pass build 