### PR TITLE
Enable the build for MSVC 2017 and Ninja 

### DIFF
--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -113,7 +113,7 @@ goto:eof
 
   %MAKE_COMMAND%
   cd ../..
-  @setlocal
+  @endlocal
 
 goto:eof
 

--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -25,6 +25,21 @@ IF "%~1"=="--with-cuda" (
   set /a NO_CUDA=1
 )
 
+IF "%CMAKE_GENERATOR%"=="" (
+  set CMAKE_GENERATOR_COMMAND=
+  set MAKE_COMMAND=msbuild INSTALL.vcxproj /p:Configuration=Release
+) ELSE (
+  set CMAKE_GENERATOR_COMMAND=-G %CMAKE_GENERATOR%
+  IF "%CMAKE_GENERATOR%"=="Ninja" (
+    set CC=cl.exe
+    set CXX=cl.exe
+    set MAKE_COMMAND=cmake --build . --target install --config Release -- -j%NUMBER_OF_PROCESSORS% || exit /b 1
+  ) ELSE (
+    set MAKE_COMMAND=msbuild INSTALL.vcxproj /p:Configuration=Release
+  )
+)
+
+
 :read_loop
 if "%1"=="" goto after_loop
 if "%1"=="ATen" (
@@ -50,7 +65,7 @@ goto:eof
 :build
   mkdir build\%~1
   cd build/%~1
-  cmake ../../%~1 -G "Visual Studio 14 2015 Win64" ^
+  cmake ../../%~1 %CMAKE_GENERATOR_COMMAND% ^
                   -DCMAKE_MODULE_PATH=%BASE_DIR%/cmake/FindCUDA ^
                   -DTorch_FOUND="1" ^
                   -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" ^
@@ -76,7 +91,7 @@ goto:eof
                   -Dnanopb_BUILD_GENERATOR=0 ^
                   -DCMAKE_BUILD_TYPE=Release
 
-  msbuild INSTALL.vcxproj /p:Configuration=Release
+  %MAKE_COMMAND%
   cd ../..
 
 goto:eof
@@ -84,12 +99,14 @@ goto:eof
 :build_aten
   mkdir build\%~1
   cd build/%~1
-  cmake ../../../../%~1 -G "Visual Studio 14 2015 Win64" ^
+  cmake ../../../../%~1 %CMAKE_GENERATOR_COMMAND% ^
                   -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" ^
                   -DNO_CUDA=%NO_CUDA% ^
+                  -DCUDNN_INCLUDE_DIR="%CUDNN_INCLUDE_DIR%" ^
+                  -DCUDNN_LIB_DIR="%CUDNN_LIB_DIR%" ^
                   -DCMAKE_BUILD_TYPE=Release
 
-  msbuild INSTALL.vcxproj /p:Configuration=Release
+  %MAKE_COMMAND%
   cd ../..
 
 goto:eof

--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -63,6 +63,8 @@ xcopy /Y ..\..\aten\src\THCUNN\generic\THCUNN.h .
 goto:eof
 
 :build
+  @setlocal
+  IF NOT "%PREBUILD_COMMAND%"=="" call %PREBUILD_COMMAND%
   mkdir build\%~1
   cd build/%~1
   cmake ../../%~1 %CMAKE_GENERATOR_COMMAND% ^
@@ -93,10 +95,13 @@ goto:eof
 
   %MAKE_COMMAND%
   cd ../..
+  @endlocal
 
 goto:eof
 
 :build_aten
+  @setlocal
+  IF NOT "%PREBUILD_COMMAND%"=="" call %PREBUILD_COMMAND%
   mkdir build\%~1
   cd build/%~1
   cmake ../../../../%~1 %CMAKE_GENERATOR_COMMAND% ^
@@ -108,6 +113,7 @@ goto:eof
 
   %MAKE_COMMAND%
   cd ../..
+  @setlocal
 
 goto:eof
 


### PR DESCRIPTION
The coming of CUDA 9 enables the build for MSVC 2017, so we should support that. And MSVC doesn't support parallel build for custom builds. We can speed up the build of CUDA libs using Ninja. In this PR, i checked the values of some env vars to enable the builds for these two toolchains.