### PR TITLE
Add border-padding for grid_sampler

### DIFF
--- a/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialGridSamplerBilinear.cu
@@ -34,7 +34,8 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
     THCState *state,
     THCTensor *input,
     THCTensor *grid,
-    THCTensor *output) {
+    THCTensor *output,
+    int padding_mode) {
 
   THCUNN_assertSameGPU(state, 3, input, grid, output);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, NULL);
@@ -55,7 +56,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
   int count = static_cast<int>(N*H*W);
   SpatialGridSamplerBilinear_updateOutput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-      count, devInput, devGrid, devOutput);
+      count, devInput, devGrid, devOutput, padding_mode);
   THCudaCheck(cudaGetLastError());
 }
 
@@ -63,7 +64,8 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
     THCState *state,
     THCTensor *input, THCTensor *gradInput,
     THCTensor *grid, THCTensor *gradGrid,
-    THCTensor *gradOutput) {
+    THCTensor *gradOutput,
+    int padding_mode) {
 
   THCUNN_assertSameGPU(state, 5, input, gradInput, grid, gradGrid, gradOutput);
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(state, input, grid, gradOutput);
@@ -88,7 +90,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
   int count = static_cast<int>(N*H*W);
   SpatialGridSamplerBilinear_updateGradInput_kernel
     <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
-      count, devInput, devGradInput, devGrid, devGradGrid, devGradOutput);
+      count, devInput, devGradInput, devGrid, devGradGrid, devGradOutput, padding_mode);
   THCudaCheck(cudaGetLastError());
 }
 

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -1025,13 +1025,15 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *grid,
-                  THCTensor *output);
+                  THCTensor *output,
+                  int padding_mode);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
                   THCState *state,
                   THCTensor *input, THCTensor *gradInput,
                   THCTensor *grid, THCTensor *gradGrid,
-                  THCTensor *gradOutput);
+                  THCTensor *gradOutput,
+                  int padding_mode);
 
 TH_API void THNN_(RReLU_updateOutput)(
                   THCState *state,

--- a/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
@@ -4,13 +4,18 @@
 
 #undef MIN
 #define MIN(a,b) ( ((a)<(b)) ? (a) : (b) )
+#undef MAX
+#define MAX(a,b) ( ((a)>(b)) ? (a) : (b) )
+
+#undef MODE_BORDER
+#define MODE_BORDER 1
 
 static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
      (THTensor *input, THTensor *grid, THTensor *gradOutput) {
   THNN_ARGCHECK(input->nDimension == 4, 2, input,
-		"4D input tensor expected but got: %s");
+    "4D input tensor expected but got: %s");
   THNN_ARGCHECK(grid->nDimension == 4, 2, grid,
-		"4D grid tensor expected but got: %s");
+    "4D grid tensor expected but got: %s");
 
   int nbatch   = THTensor_(size)(input, 0);
   int channels = THTensor_(size)(input, 1);
@@ -33,11 +38,14 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
 #define SAFE_GET(input, x, y, n, c, H, W) x >= 0 && x < W && y >=0 \
     && y < H ? THTensor_fastGet4d(input, n, c, y, x) : 0
 
+#define CLIP_COORDINATES(in, out, clip_limit) out = MIN((clip_limit-1), MAX(in, 0))
+
 TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
-	  THNNState *state,
-	  THTensor *input,
-	  THTensor *grid,
-	  THTensor *output) {
+    THNNState *state,
+    THTensor *input,
+    THTensor *grid,
+    THTensor *output,
+    int padding_mode) {
 
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(input, grid, NULL);
   int N = THTensor_(size)(input, 0);
@@ -46,7 +54,7 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
   int IW = THTensor_(size)(input, 3);
   int H = THTensor_(size)(grid, 1);
   int W = THTensor_(size)(grid, 2);
-	  
+
   // resize output to the same shape as input
   THTensor_(resize4d)(output, N, C, H, W);
 
@@ -56,59 +64,72 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
   for (n = 0; n < N; ++n) {
     for (h = 0; h < H; ++h) {
       for (w = 0; w < W; ++w) {
-	// get the corresponding input x, y co-ordinates from grid
-	real ix = THTensor_fastGet4d(grid, n, h, w, 0);
-	real iy = THTensor_fastGet4d(grid, n, h, w, 1);
+        // get the corresponding input x, y co-ordinates from grid
+        real ix = THTensor_fastGet4d(grid, n, h, w, 0);
+        real iy = THTensor_fastGet4d(grid, n, h, w, 1);
 
-	// normalize ix, iy from [-1, 1] to [0, IH-1] & [0, IW-1]
-	ix = ((ix + 1) / 2) * (IW-1);
-	iy = ((iy + 1) / 2) * (IH-1);
+        // normalize ix, iy from [-1, 1] to [0, IH-1] & [0, IW-1]
+        ix = ((ix + 1) / 2) * (IW-1);
+        iy = ((iy + 1) / 2) * (IH-1);
 
-	// get NE, NW, SE, SW pixel values from (x, y)
-	int ix_nw = floor(ix);
-	int iy_nw = floor(iy);
-	int ix_ne = ix_nw + 1;
-	int iy_ne = iy_nw;
-	int ix_sw = ix_nw;
-	int iy_sw = iy_nw + 1;
-	int ix_se = ix_nw + 1;
-	int iy_se = iy_nw + 1;
+        // get NE, NW, SE, SW pixel values from (x, y)
+        int ix_nw = floor(ix);
+        int iy_nw = floor(iy);
+        int ix_ne = ix_nw + 1;
+        int iy_ne = iy_nw;
+        int ix_sw = ix_nw;
+        int iy_sw = iy_nw + 1;
+        int ix_se = ix_nw + 1;
+        int iy_se = iy_nw + 1;
 
-	// get surfaces to each neighbor:
-	real nw = (ix_se - ix)    * (iy_se - iy);
-	real ne = (ix    - ix_sw) * (iy_sw - iy);
-	real sw = (ix_ne - ix)    * (iy    - iy_ne);
-	real se = (ix    - ix_nw) * (iy    - iy_nw);
-	  
-	// calculate bilinear weighted pixel value and set output pixel
-	for (c = 0; c < C; ++c) {
-	  //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
-	  // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
-	  real nw_val = SAFE_GET(input, ix_nw, iy_nw, n, c, IH, IW);
-	  real ne_val = SAFE_GET(input, ix_ne, iy_ne, n, c, IH, IW);
-	  real sw_val = SAFE_GET(input, ix_sw, iy_sw, n, c, IH, IW);
-	  real se_val = SAFE_GET(input, ix_se, iy_se, n, c, IH, IW);
-	  real out_val = nw_val * nw + ne_val * ne + sw_val * sw + se_val * se;
-	  THTensor_fastSet4d(output, n, c, h, w, out_val);
-	}
+        // get surfaces to each neighbor:
+        real nw = (ix_se - ix)    * (iy_se - iy);
+        real ne = (ix    - ix_sw) * (iy_sw - iy);
+        real sw = (ix_ne - ix)    * (iy    - iy_ne);
+        real se = (ix    - ix_nw) * (iy    - iy_nw);
+
+        if (padding_mode==MODE_BORDER){
+          // clip coordinates to image borders
+          CLIP_COORDINATES(ix_nw, ix_nw, IW);
+          CLIP_COORDINATES(iy_nw, iy_nw, IH);
+          CLIP_COORDINATES(ix_ne, ix_ne, IW);
+          CLIP_COORDINATES(iy_ne, iy_ne, IH);
+          CLIP_COORDINATES(ix_sw, ix_sw, IW);
+          CLIP_COORDINATES(iy_sw, iy_sw, IH);
+          CLIP_COORDINATES(ix_se, ix_se, IW);
+          CLIP_COORDINATES(iy_se, iy_se, IH);
+        }
+
+        // calculate bilinear weighted pixel value and set output pixel
+        for (c = 0; c < C; ++c) {
+          //   (c, iy_nw, ix_nw) * nw + (c, iy_ne, ix_ne) * ne
+          // + (c, iy_sw, ix_sw) * sw + (c, iy_se, ix_se) * se
+          real nw_val = SAFE_GET(input, ix_nw, iy_nw, n, c, IH, IW);
+          real ne_val = SAFE_GET(input, ix_ne, iy_ne, n, c, IH, IW);
+          real sw_val = SAFE_GET(input, ix_sw, iy_sw, n, c, IH, IW);
+          real se_val = SAFE_GET(input, ix_se, iy_se, n, c, IH, IW);
+          real out_val = nw_val * nw + ne_val * ne + sw_val * sw + se_val * se;
+          THTensor_fastSet4d(output, n, c, h, w, out_val);
+        }
       }
     }
   }
 }
 
-#define SAFE_ADD(input, x, y, n, c, H, W, value)		\
-  do {								\
-    if (x >= 0 && x < W && y >=0 && y < H) {			\
-      real old_value = THTensor_fastGet4d(input, n, c, y, x);	\
-      THTensor_fastSet4d(input, n, c, y, x, value + old_value);	\
-    }								\
+#define SAFE_ADD(input, x, y, n, c, H, W, value)    \
+  do {                \
+    if (x >= 0 && x < W && y >=0 && y < H) {      \
+      real old_value = THTensor_fastGet4d(input, n, c, y, x); \
+      THTensor_fastSet4d(input, n, c, y, x, value + old_value); \
+    }               \
   } while(0)
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
-	  THNNState *state,
-	  THTensor *input, THTensor *gradInput,
-	  THTensor *grid, THTensor *gradGrid,
-	  THTensor *gradOutput) {
+    THNNState *state,
+    THTensor *input, THTensor *gradInput,
+    THTensor *grid, THTensor *gradGrid,
+    THTensor *gradOutput,
+    int padding_mode) {
 
   THNN_(SpatialGridSamplerBilinear_shapeCheck)(input, grid, gradOutput);
   int N = THTensor_(size)(input, 0);
@@ -129,76 +150,103 @@ TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
   for (n = 0; n < N; ++n) {
     for (h = 0; h < H; ++h) {
       for (w = 0; w < W; ++w) {
-	// get the corresponding input x, y co-ordinates from grid
-	real ix = THTensor_fastGet4d(grid, n, h, w, 0);
-	real iy = THTensor_fastGet4d(grid, n, h, w, 1);
+        // get the corresponding input x, y co-ordinates from grid
+        real ix = THTensor_fastGet4d(grid, n, h, w, 0);
+        real iy = THTensor_fastGet4d(grid, n, h, w, 1);
 
-	real gix = 0;
-	real giy = 0;
+        real gix = 0;
+        real giy = 0;
 
-	// normalize ix, iy from [-1, 1] to [0, H-1] & [0, W-1]
-	ix = ((ix + 1) / 2) * (IW-1);
-	iy = ((iy + 1) / 2) * (IH-1);
+        // normalize ix, iy from [-1, 1] to [0, H-1] & [0, W-1]
+        ix = ((ix + 1) / 2) * (IW-1);
+        iy = ((iy + 1) / 2) * (IH-1);
 
-	// get NE, NW, SE, SW pixel values from (x, y)
-	int ix_nw = floor(ix);
-	int iy_nw = floor(iy);
-	int ix_ne = ix_nw + 1;
-	int iy_ne = iy_nw;
-	int ix_sw = ix_nw;
-	int iy_sw = iy_nw + 1;
-	int ix_se = ix_nw + 1;
-	int iy_se = iy_nw + 1;
+        // get NE, NW, SE, SW pixel values from (x, y)
+        int ix_nw = floor(ix);
+        int iy_nw = floor(iy);
+        int ix_ne = ix_nw + 1;
+        int iy_ne = iy_nw;
+        int ix_sw = ix_nw;
+        int iy_sw = iy_nw + 1;
+        int ix_se = ix_nw + 1;
+        int iy_se = iy_nw + 1;
 
-	// get surfaces to each neighbor:
-	real nw = (ix_se - ix)    * (iy_se - iy);
-	real ne = (ix    - ix_sw) * (iy_sw - iy);
-	real sw = (ix_ne - ix)    * (iy    - iy_ne);
-	real se = (ix    - ix_nw) * (iy    - iy_nw);
-	  
-	for (int c = 0; c < C; ++c) {
-	  real gradout = THTensor_fastGet4d(gradOutput, n, c, h, w);
+        // get surfaces to each neighbor:
+        real nw = (ix_se - ix)    * (iy_se - iy);
+        real ne = (ix    - ix_sw) * (iy_sw - iy);
+        real sw = (ix_ne - ix)    * (iy    - iy_ne);
+        real se = (ix    - ix_nw) * (iy    - iy_nw);
 
-	  // calculate and set gradInput
-	  SAFE_ADD(gradInput, ix_nw, iy_nw, n, c, IH, IW, nw * gradout);
-	  SAFE_ADD(gradInput, ix_ne, iy_ne, n, c, IH, IW, ne * gradout);
-	  SAFE_ADD(gradInput, ix_sw, iy_sw, n, c, IH, IW, sw * gradout);
-	  SAFE_ADD(gradInput, ix_se, iy_se, n, c, IH, IW, se * gradout);
+        int ix_nw_cl, iy_nw_cl, ix_ne_cl, iy_ne_cl, ix_sw_cl, iy_sw_cl, ix_se_cl, iy_se_cl;
 
-	  // calculate gradGrid
-	  real nw_val = SAFE_GET(input, ix_nw, iy_nw, n, c, IH, IW);
-	  real ne_val = SAFE_GET(input, ix_ne, iy_ne, n, c, IH, IW);
-	  real sw_val = SAFE_GET(input, ix_sw, iy_sw, n, c, IH, IW);
-	  real se_val = SAFE_GET(input, ix_se, iy_se, n, c, IH, IW);
+        if (padding_mode==MODE_BORDER){
+          // get clipped NE, NW, SE, SW pixel values from (x, y)
+          CLIP_COORDINATES(ix_nw, ix_nw_cl, IW);
+          CLIP_COORDINATES(iy_nw, iy_nw_cl, IH);
+          CLIP_COORDINATES(ix_ne, ix_ne_cl, IW);
+          CLIP_COORDINATES(iy_ne, iy_ne_cl, IH);
+          CLIP_COORDINATES(ix_sw, ix_sw_cl, IW);
+          CLIP_COORDINATES(iy_sw, iy_sw_cl, IH);
+          CLIP_COORDINATES(ix_se, ix_se_cl, IW);
+          CLIP_COORDINATES(iy_se, iy_se_cl, IH);
+        }
+        else {
+          ix_nw_cl = ix_nw;
+          iy_nw_cl = iy_nw;
+          ix_ne_cl = ix_ne;
+          iy_ne_cl = iy_ne;
+          ix_sw_cl = ix_sw;
+          iy_sw_cl = iy_sw;
+          ix_se_cl = ix_se;
+          iy_se_cl = iy_se;
+        }
 
-	  gix -= nw_val * (iy_se - iy) * gradout;
-	  gix += ne_val * (iy_sw - iy) * gradout;
-	  gix -= sw_val * (iy - iy_ne) * gradout;
-	  gix += se_val * (iy - iy_nw) * gradout;
+        for (int c = 0; c < C; ++c) {
+          real gradout = THTensor_fastGet4d(gradOutput, n, c, h, w);
 
-	  giy -= nw_val * (ix_se - ix) * gradout;
-	  giy -= ne_val * (ix - ix_sw) * gradout;
-	  giy += sw_val * (ix_ne - ix) * gradout;
-	  giy += se_val * (ix - ix_nw) * gradout;
-	}
+          // calculate and set gradInput
+          SAFE_ADD(gradInput, ix_nw_cl, iy_nw_cl, n, c, IH, IW, nw * gradout);
+          SAFE_ADD(gradInput, ix_ne_cl, iy_ne_cl, n, c, IH, IW, ne * gradout);
+          SAFE_ADD(gradInput, ix_sw_cl, iy_sw_cl, n, c, IH, IW, sw * gradout);
+          SAFE_ADD(gradInput, ix_se_cl, iy_se_cl, n, c, IH, IW, se * gradout);
 
-	// un-normalize gradGrid values back to [-1, 1] constraints
-	gix = gix * (IW - 1) / 2;
-	giy = giy * (IH - 1) / 2;
+          // calculate gradGrid
+          real nw_val = SAFE_GET(input, ix_nw_cl, iy_nw_cl, n, c, IH, IW);
+          real ne_val = SAFE_GET(input, ix_ne_cl, iy_ne_cl, n, c, IH, IW);
+          real sw_val = SAFE_GET(input, ix_sw_cl, iy_sw_cl, n, c, IH, IW);
+          real se_val = SAFE_GET(input, ix_se_cl, iy_se_cl, n, c, IH, IW);
 
-	real gix_old = THTensor_fastGet4d(gradGrid, n, h, w, 0);
-	real giy_old = THTensor_fastGet4d(gradGrid, n, h, w, 1);
+          gix -= nw_val * (iy_se - iy) * gradout;
+          gix += ne_val * (iy_sw - iy) * gradout;
+          gix -= sw_val * (iy - iy_ne) * gradout;
+          gix += se_val * (iy - iy_nw) * gradout;
 
-	THTensor_fastSet4d(gradGrid, n, h, w, 0, gix_old + gix);
-	THTensor_fastSet4d(gradGrid, n, h, w, 1, giy_old + giy);
+          giy -= nw_val * (ix_se - ix) * gradout;
+          giy -= ne_val * (ix - ix_sw) * gradout;
+          giy += sw_val * (ix_ne - ix) * gradout;
+          giy += se_val * (ix - ix_nw) * gradout;
+        }
 
+        // un-normalize gradGrid values back to [-1, 1] constraints
+        gix = gix * (IW - 1) / 2;
+        giy = giy * (IH - 1) / 2;
+
+        real gix_old = THTensor_fastGet4d(gradGrid, n, h, w, 0);
+        real giy_old = THTensor_fastGet4d(gradGrid, n, h, w, 1);
+
+        THTensor_fastSet4d(gradGrid, n, h, w, 0, gix_old + gix);
+        THTensor_fastSet4d(gradGrid, n, h, w, 1, giy_old + giy);
       }
     }
   }
 }
 
+
 #undef MIN
+#undef MAX
 #undef SAFE_GET
+#undef CLIP_COORDINATES
 #undef SAFE_ADD
+#undef MODE_BORDER
 
 #endif

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -1223,16 +1223,18 @@ TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
           int outputWidth);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
-	  THNNState *state,
-	  THTensor *input,
-	  THTensor *grid,
-	  THTensor *output);
+          THNNState *state,
+          THTensor *input,
+          THTensor *grid,
+          THTensor *output,
+          int padding_mode);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateGradInput)(
-	  THNNState *state,
-	  THTensor *input, THTensor *gradInput,
-	  THTensor *grid, THTensor *gradGrid,
-	  THTensor *gradOutput);
+          THNNState *state,
+          THTensor *input, THTensor *gradInput,
+          THTensor *grid, THTensor *gradGrid,
+          THTensor *gradOutput,
+          int padding_mode);
 
 TH_API void THNN_(unfolded_acc)(
           THTensor *finput,
@@ -1634,7 +1636,7 @@ TH_API void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
           THNNState *state,
           THTensor *input,
           THTensor *output,
-	  int outputDepth,
+          int outputDepth,
           int outputHeight,
           int outputWidth);
 TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2864,38 +2864,17 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
 
     def test_grid_sample(self):
-        # test known input on CPU
-        input = Variable(torch.arange(1, 11).view(1, 1, 2, 5))
-        grid = Variable(torch.Tensor(
-            [[-1, -0.5, 0, 0.2, 1],
-             [-1, -0.333, 0, 0.5, 1],
-             [-1, -0.5, 0, 0.3333, 1],
-             [-1, -0.2, 0, 0.2, 1]]).view(1, 2, 5, 2))
-        output = F.grid_sample(input, grid)
-        groundtruth = torch.Tensor(
-            [[2.2500, 6.0000000000, 5.0000, 4.8340, 9.0000],
-             [2.2500, 6.333250045, 5.0000, 5.1000, 8.4000]]).view(1, 1, 2, 5)
-        self.assertEqual(output.data, groundtruth)
+        def test_cpu_against_cuda(N, C, H, W, padding_mode):
+            def test_shape(N, C, IH, IW, H, W, padding_mode):
 
-        # do gradcheck
-        N = random.randint(1, 8)
-        C = random.randint(1, 8)
-        H = random.randint(1, 8)
-        W = random.randint(1, 8)
-        input = Variable(torch.randn(N, C, H, W), requires_grad=True)
-        grid = Variable(torch.randn(N, H, W, 2), requires_grad=True)
-        self.assertTrue(gradcheck(lambda inp, grid: F.grid_sample(inp, grid), (input, grid)))
-
-        def test_cpu_against_cuda(N, C, H, W):
-            def test_shape(N, C, IH, IW, H, W):
                 input_cpu = Variable(torch.randn(C, N, IH, IW).transpose(0, 1), requires_grad=True)
                 grid_cpu = Variable(torch.randn(H, N, W, 2).transpose(0, 1), requires_grad=True)
-                out_cpu = F.grid_sample(input_cpu, grid_cpu)
+                out_cpu = F.grid_sample(input_cpu, grid_cpu, padding_mode=padding_mode)
                 self.assertTrue(out_cpu.size() == torch.Size([N, C, H, W]))
 
                 input_cuda = Variable(input_cpu.data.transpose(0, 1).cuda().transpose(0, 1), requires_grad=True)
                 grid_cuda = Variable(grid_cpu.data.transpose(0, 1).cuda().transpose(0, 1), requires_grad=True)
-                out_cuda = F.grid_sample(input_cuda, grid_cuda)
+                out_cuda = F.grid_sample(input_cuda, grid_cuda, padding_mode=padding_mode)
                 self.assertEqual(out_cpu, out_cuda)
 
                 gradients = out_cpu.data.new(out_cpu.size()).normal_()
@@ -2908,15 +2887,15 @@ class TestNN(NNTestCase):
                 base_input = torch.randn(C, IH, IW)
                 input_cpu = Variable(base_input.expand(input_cuda.size()), requires_grad=True)
                 grid_cpu = Variable(torch.randn(N, H, W, 2), requires_grad=True)
-                out_cpu = F.grid_sample(input_cpu, grid_cpu)
+                out_cpu = F.grid_sample(input_cpu, grid_cpu, padding_mode=padding_mode)
 
                 input_cuda = Variable(base_input.cuda().expand(input_cuda.size()), requires_grad=True)
                 grid_cuda = Variable(grid_cpu.data.cuda(), requires_grad=True)
-                out_cuda = F.grid_sample(input_cuda, grid_cuda)
+                out_cuda = F.grid_sample(input_cuda, grid_cuda, padding_mode=padding_mode)
                 self.assertEqual(out_cpu, out_cuda)
 
             # test same size output
-            test_shape(N, C, H, W, H, W)
+            test_shape(N, C, H, W, H, W, padding_mode)
 
             # test larger output
             N = random.randint(1, 8)
@@ -2925,7 +2904,7 @@ class TestNN(NNTestCase):
             IW = random.randint(1, 8)
             H = random.randint(IH + 1, 12)
             W = random.randint(IH + 1, 12)
-            test_shape(N, C, IH, IW, H, W)
+            test_shape(N, C, IH, IW, H, W, padding_mode)
 
             # test smaller output
             N = random.randint(1, 8)
@@ -2934,21 +2913,42 @@ class TestNN(NNTestCase):
             IW = random.randint(1, 8)
             H = random.randint(1, IH)
             W = random.randint(1, IW)
-            test_shape(N, C, IH, IW, H, W)
+            test_shape(N, C, IH, IW, H, W, padding_mode)
 
-        # test CUDNN against CPU
-        if TEST_CUDNN:
-            test_cpu_against_cuda(N, C, H, W)
+        # test known input on CPU
+        for padding_mode in ['zeros', 'border']:
 
-        # test CUDA (without CUDNN) against CPU
-        if TEST_CUDA:
+            input = Variable(torch.arange(1, 11).view(1, 1, 2, 5))
+            grid = Variable(torch.Tensor(
+                [[-0.9, -1.4, 0, 0.2, 1],
+                [-1, -0.333, 0, 0.5, 1],
+                [-1, -0.5, 0, 0.3333, 1],
+                [-1, -0.2, 0, 1.1, 0.5]]).view(1, 2, 5, 2))
+            output = F.grid_sample(input, grid, padding_mode=padding_mode)
 
-            # GridSampler will automatically use CUDNN if it is available
-            # so we disable CUDNN temporarily
-            original_cudnn_enabled = cudnn.enabled
-            cudnn.enabled = False
-            test_cpu_against_cuda(N, C, H, W)
-            cudnn.enabled = original_cudnn_enabled
+            if padding_mode == 'zeros':
+                groundtruth = torch.Tensor(
+                    [[0.9600, 6.0000000000, 5.0000, 4.8340, 9.0000],
+                    [2.2500, 6.333250045, 5.0000, 5.1000, 7.0000]]).view(1, 1, 2, 5)
+            else:
+                groundtruth = torch.Tensor(
+                    [[1.2000, 6.0000000000, 5.0000, 4.8340, 9.0000],
+                    [2.2500, 6.333250045, 5.0000, 5.1000, 8.7500]]).view(1, 1, 2, 5)
+
+            self.assertEqual(output.data, groundtruth)
+
+            # do gradcheck
+            N = random.randint(1, 8)
+            C = random.randint(1, 8)
+            H = random.randint(1, 8)
+            W = random.randint(1, 8)
+            input = Variable(torch.randn(N, C, H, W), requires_grad=True)
+            grid = Variable(torch.randn(N, H, W, 2), requires_grad=True)
+            self.assertTrue(gradcheck(lambda inp, grid: F.grid_sample(inp, grid, padding_mode=padding_mode), (input, grid)))
+
+            # test CUDA against CPU
+            if TEST_CUDA:
+                test_cpu_against_cuda(N, C, H, W, padding_mode)
 
     def test_affine_grid(self):
         # test known input on CPU

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2921,19 +2921,19 @@ class TestNN(NNTestCase):
             input = Variable(torch.arange(1, 11).view(1, 1, 2, 5))
             grid = Variable(torch.Tensor(
                 [[-0.9, -1.4, 0, 0.2, 1],
-                [-1, -0.333, 0, 0.5, 1],
-                [-1, -0.5, 0, 0.3333, 1],
-                [-1, -0.2, 0, 1.1, 0.5]]).view(1, 2, 5, 2))
+                 [-1, -0.333, 0, 0.5, 1],
+                 [-1, -0.5, 0, 0.3333, 1],
+                 [-1, -0.2, 0, 1.1, 0.5]]).view(1, 2, 5, 2))
             output = F.grid_sample(input, grid, padding_mode=padding_mode)
 
             if padding_mode == 'zeros':
                 groundtruth = torch.Tensor(
                     [[0.9600, 6.0000000000, 5.0000, 4.8340, 9.0000],
-                    [2.2500, 6.333250045, 5.0000, 5.1000, 7.0000]]).view(1, 1, 2, 5)
+                     [2.2500, 6.333250045, 5.0000, 5.1000, 7.0000]]).view(1, 1, 2, 5)
             else:
                 groundtruth = torch.Tensor(
                     [[1.2000, 6.0000000000, 5.0000, 4.8340, 9.0000],
-                    [2.2500, 6.333250045, 5.0000, 5.1000, 8.7500]]).view(1, 1, 2, 5)
+                     [2.2500, 6.333250045, 5.0000, 5.1000, 8.7500]]).view(1, 1, 2, 5)
 
             self.assertEqual(output.data, groundtruth)
 
@@ -2944,7 +2944,9 @@ class TestNN(NNTestCase):
             W = random.randint(1, 8)
             input = Variable(torch.randn(N, C, H, W), requires_grad=True)
             grid = Variable(torch.randn(N, H, W, 2), requires_grad=True)
-            self.assertTrue(gradcheck(lambda inp, grid: F.grid_sample(inp, grid, padding_mode=padding_mode), (input, grid)))
+            self.assertTrue(gradcheck(
+                lambda inp, grid: F.grid_sample(inp, grid, padding_mode=padding_mode),
+                (input, grid)))
 
             # test CUDA against CPU
             if TEST_CUDA:

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -5,14 +5,25 @@ from torch._thnn import type2backend
 from .thnn.auto import function_by_name
 import torch.backends.cudnn as cudnn
 
+MODE_ZEROS = 0
+MODE_BORDER = 1
 
 class GridSampler(Function):
 
     @staticmethod
-    def forward(ctx, input, grid):
+    def forward(ctx, input, grid, padding_mode='zeros'):
         ctx.save_for_backward(input, grid)
+
+        if padding_mode == 'zeros':
+            ctx.padding_mode = MODE_ZEROS
+        elif padding_mode == 'border':
+            ctx.padding_mode = MODE_BORDER
+        else:
+            raise ValueError("padding_mode needs to be 'zeros' or 'border', but got {}"
+                             .format(padding_mode))
+
         grid_sz = grid.size()
-        if cudnn.is_acceptable(input):
+        if cudnn.is_acceptable(input) and padding_mode=='zeros':
             output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
             grid = grid.contiguous()
             if 0 in input.stride():
@@ -21,14 +32,16 @@ class GridSampler(Function):
         else:
             backend = type2backend[type(input)]
             output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
-            backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output)
+            backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output, ctx.padding_mode)
         return output
 
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_output):
         input, grid = ctx.saved_tensors
-        if cudnn.is_acceptable(input):
+        padding_mode = ctx.padding_mode
+
+        if cudnn.is_acceptable(input) and padding_mode=='zeros':
             grad_input = input.new(input.size())
             grad_grid = grid.new(grid.size())
             grid = grid.contiguous()
@@ -47,8 +60,8 @@ class GridSampler(Function):
             grad_grid = grid.new(grid.size())
             backend.SpatialGridSamplerBilinear_updateGradInput(
                 backend.library_state, input, grad_input,
-                grid, grad_grid, grad_output)
-        return grad_input, grad_grid
+                grid, grad_grid, grad_output, padding_mode)
+        return grad_input, grad_grid, None
 
 
 class AffineGridGenerator(Function):

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -8,6 +8,7 @@ import torch.backends.cudnn as cudnn
 MODE_ZEROS = 0
 MODE_BORDER = 1
 
+
 class GridSampler(Function):
 
     @staticmethod
@@ -23,7 +24,7 @@ class GridSampler(Function):
                              .format(padding_mode))
 
         grid_sz = grid.size()
-        if cudnn.is_acceptable(input) and padding_mode=='zeros':
+        if cudnn.is_acceptable(input) and padding_mode == 'zeros':
             output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
             grid = grid.contiguous()
             if 0 in input.stride():
@@ -32,7 +33,8 @@ class GridSampler(Function):
         else:
             backend = type2backend[type(input)]
             output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
-            backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output, ctx.padding_mode)
+            backend.SpatialGridSamplerBilinear_updateOutput(
+                backend.library_state, input, grid, output, ctx.padding_mode)
         return output
 
     @staticmethod
@@ -41,7 +43,7 @@ class GridSampler(Function):
         input, grid = ctx.saved_tensors
         padding_mode = ctx.padding_mode
 
-        if cudnn.is_acceptable(input) and padding_mode=='zeros':
+        if cudnn.is_acceptable(input) and padding_mode == 'zeros':
             grad_input = input.new(input.size())
             grad_grid = grid.new(grid.size())
             grid = grid.contiguous()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1424,7 +1424,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     return upsample(input, size, scale_factor, mode='bilinear')
 
 
-def grid_sample(input, grid, mode='bilinear'):
+def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     r"""Given an :attr:`input` and a flow-field :attr:`grid`, computes the
     `output` using input pixel locations from the grid.
 
@@ -1454,7 +1454,7 @@ def grid_sample(input, grid, mode='bilinear'):
 
     """
     batch_size, channels, in_height, in_width = input.size()
-    return GridSampler.apply(input, grid)
+    return GridSampler.apply(input, grid, padding_mode)
 
 
 def affine_grid(theta, size):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1441,13 +1441,17 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
                  values: x: 1, y: 1 is the right-bottom pixel of the input
 
     If :attr:`grid` has values outside the range of `[-1, 1]`, those locations
-    are ignored (i.e. 0 is used as a contribution to the bilinear interpolation)
+    are handled as defined by `padding_mode`. Options are `zeros` or `border`,
+    defining those locations to use 0 or image border values as contribution
+    to the bilinear interpolation.
 
     .. Note:: This function is used in building Spatial Transformer Networks
 
     Args:
         input (Variable): input batch of images (N x C x IH x IW)
         grid (Variable): flow-field of size (N x OH x OW x 2)
+        padding_mode (str): padding mode for outside grid values
+            'zeros' | 'border'. Default: 'zeros'
 
     Returns:
         output (Variable): output Tensor


### PR DESCRIPTION
Adds support for border padding in the `grid_sampler`. 

The grid sampler is well-defined for coordinates falling within the grid bounds [-1, 1]. Values falling outside these bounds need special treatment. The default behaviour is the original zero padding of borders, which uses value 0 in the bilinear interpolation of the sampler for values outside the grid. This PR extends the sampler to also accept border padding, which instead of 0 will use the value of the image border closest to the coordinate outside the grid.

The sampler test in `test_nn.py` has been extended to cover the new padding mode. It has additionally been changed to check behaviour of sampling outside the grid.

_NOTE_ Some large blocks of changes in the PR are related to the previous use of tabs for indentation, which have been corrected.