### PR TITLE
Record stack traces during JIT tracing

### DIFF
--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -201,7 +201,9 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
       continue;
     }
     auto p_n = p_g->add_node();
-    p_n->set_doc_string(node->debugName());
+    if (node->getSourceLocation()) {
+      p_n->set_doc_string(node->getSourceLocation()->python_traceback);
+    }
     for(auto input : node->inputs()) {
       p_n->add_input(node_name(input));
     }

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -201,6 +201,7 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
       continue;
     }
     auto p_n = p_g->add_node();
+    p_n->set_doc_string(node->debugName());
     for(auto input : node->inputs()) {
       p_n->add_input(node_name(input));
     }

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -65,7 +65,7 @@ struct Param;
 // node in the trace.
 struct SourceLocation {
   SourceLocation(std::string python_traceback)
-  : python_traceback(python_traceback) {}
+  : python_traceback(std::move(python_traceback)) {}
   std::string python_traceback;
 };
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -531,6 +531,7 @@ protected:
   virtual void cloneFrom(Node * s) {
     if (s->hasType()) setType(s->type());
     setDebugName(s->debugName());
+    setSourceLocation(s->getSourceLocation());
     copyAttributes(*s);
   }
 };

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -60,6 +60,15 @@ static inline bool operator==(const Use & a, const Use & b) {
 // Graph holds a list of parameters.
 struct Param;
 
+// SourceLocation represents source code-level debug information for a node.
+// It contains a Python stack trace that represents the provenance of a given
+// node in the trace.
+struct SourceLocation {
+  SourceLocation(std::string python_traceback)
+  : python_traceback(python_traceback) {}
+  std::string python_traceback;
+};
+
 // the list types are intentionally simple, but we type-def
 // them here so if we need to change them, refactoring will be easier
 using node_list = std::vector<Node*>;
@@ -113,6 +122,7 @@ private:
   size_t unique_ = 0;          // unique id
   size_t stage_ = 0;           // 0-forward, 1-backward, 2-double-backward,...
   std::string debug_name_;
+  std::shared_ptr<SourceLocation> source_location_;
 protected:
   TypePtr type_;
   Node(Graph * graph_, NodeKind kind_); //defined after graph
@@ -149,6 +159,13 @@ public:
   }
   const std::string & debugName() const {
     return debug_name_;
+  }
+  Node* setSourceLocation(std::shared_ptr<SourceLocation> sl) {
+    source_location_ = sl;
+    return this;
+  }
+  std::shared_ptr<SourceLocation> getSourceLocation() const {
+    return source_location_;
   }
   Graph * owningGraph() {
     return graph_;

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -86,6 +86,9 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
         if (!outputs[i]->hasType()) {
           outputs[i]->setType(old->typeOption());
         }
+        // Copy over source location information to all nodes created by
+        // the symbolic
+        outputs[i]->setSourceLocation(node->getSourceLocation());
         env[old] = outputs[i];
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
@@ -140,14 +143,8 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
       node_list outputs;
       if (py::isinstance<Node>(raw_output)) {
         outputs = node_list{py::cast<Node*>(raw_output)};
-        outputs[0]->setDebugName(n->debugName());
-        outputs[0]->setSourceLocation(n->getSourceLocation());
       } else {
         outputs = py::cast<std::vector<Node*>>(raw_output);
-        for (Node* node : outputs) {
-          node->setDebugName(n->debugName());
-          node->setSourceLocation(n->getSourceLocation());
-        }
       }
 
       setOutputs(symbolToString(n->kind()), n, outputs);

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -141,10 +141,12 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
       if (py::isinstance<Node>(raw_output)) {
         outputs = node_list{py::cast<Node*>(raw_output)};
         outputs[0]->setDebugName(n->debugName());
+        outputs[0]->setSourceLocation(n->getSourceLocation());
       } else {
         outputs = py::cast<std::vector<Node*>>(raw_output);
         for (Node* node : outputs) {
           node->setDebugName(n->debugName());
+          node->setSourceLocation(n->getSourceLocation());
         }
       }
 

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -140,8 +140,12 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
       node_list outputs;
       if (py::isinstance<Node>(raw_output)) {
         outputs = node_list{py::cast<Node*>(raw_output)};
+        outputs[0]->setDebugName(n->debugName());
       } else {
         outputs = py::cast<std::vector<Node*>>(raw_output);
+        for (Node* node : outputs) {
+          node->setDebugName(n->debugName());
+        }
       }
 
       setOutputs(symbolToString(n->kind()), n, outputs);

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -22,9 +22,9 @@ bool isBroadcasting(Node *node) {
 // When iterating over the dimension sizes, starting at the trailing dimension,
 // the dimension sizes must either be equal, or one of them does not exist.
 //
-// Note that this is NOT equivalent to numpy broadcasting semantics, and do
-// not represent that generalized broadcasting that Pytorch implements in
-// general. Rather, this is Caffe2-style broadcasting.
+//  equivalently:
+//
+// Test that 'from' is a suffix of 'to'.
 bool fusibleExpandTo(at::IntList from, at::IntList to) {
   auto f = from.rbegin();
   auto t = to.rbegin();

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -22,9 +22,9 @@ bool isBroadcasting(Node *node) {
 // When iterating over the dimension sizes, starting at the trailing dimension,
 // the dimension sizes must either be equal, or one of them does not exist.
 //
-//  equivalently:
-//
-// Test that 'from' is a suffix of 'to'.
+// Note that this is NOT equivalent to numpy broadcasting semantics, and do
+// not represent that generalized broadcasting that Pytorch implements in
+// general. Rather, this is Caffe2-style broadcasting.
 bool fusibleExpandTo(at::IntList from, at::IntList to) {
   auto f = from.rbegin();
   auto t = to.rbegin();

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -8,7 +8,6 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
 
-#include <Python.h>
 #include <frameobject.h>
 #include <patchlevel.h>
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -5,6 +5,8 @@
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/python_engine.h"
 #include "torch/csrc/autograd/functions/special.h"
+#include "torch/csrc/utils/auto_gil.h"
+#include "torch/csrc/utils/python_strings.h"
 
 #include <Python.h>
 #include <frameobject.h>
@@ -95,39 +97,23 @@ void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_li
 }
 
 namespace {
-// https://stackoverflow.com/a/38600095
-std::string pyObjToString(PyObject *in) {
-  PyObject *s;
-  if (PyUnicode_Check(in)) {
-    s = PyUnicode_AsUTF8String(in);
-  } else if PyBytes_Check(in) {
-    s = PyObject_Bytes(in);
-  } else {
-    // TODO: bail
-  }
-  const char* retval = PyBytes_AsString(s);
-  Py_XDECREF(s);
-  return retval;
-}
-
 // Python interpreter retrieval routine adapted from
 // https://stackoverflow.com/a/8706144
 std::string getPythonInterpreterStackTrace() {
   std::stringstream stack_trace;
-  PyGILState_STATE state = PyGILState_Ensure();
+  AutoGIL gil;
   PyThreadState *tstate = PyThreadState_GET();
   if (NULL != tstate && NULL != tstate->frame) {
     PyFrameObject *frame = tstate->frame;
 
     while (NULL != frame) {
       int line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
-      std::string filename = pyObjToString(frame->f_code->co_filename);
-      std::string funcname = pyObjToString(frame->f_code->co_name);
+      std::string filename = THPUtils_unpackString(frame->f_code->co_filename);
+      std::string funcname = THPUtils_unpackString(frame->f_code->co_name);
       stack_trace << filename << "(" << line << "): " << funcname << "\n";
       frame = frame->f_back;
     }
   }
-  PyGILState_Release(state);
   return stack_trace.str();
 }
 }  // namespace

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -128,7 +128,8 @@ Node* recordTrace(std::string op, // TODO: make this a Symbol
   auto state_lock = state->lock();
 
   Node *n = graph->create(stringToSymbol(op));
-  n->setDebugName(getPythonInterpreterStackTrace());
+  auto sl = std::make_shared<SourceLocation>(getPythonInterpreterStackTrace());
+  n->setSourceLocation(sl);
 
   for (Variable input : inputs) {
     n->addInput(getValueTrace(state, input));

--- a/torch/csrc/onnx/onnx.h
+++ b/torch/csrc/onnx/onnx.h
@@ -306,6 +306,7 @@ public:
 class NodeProto : public MicroProto<onnx_NodeProto> {
 private:
   std::string op_type;
+  std::string doc_string;
   unique_vector<std::string> inputs;
   unique_vector<std::string> outputs;
   unique_vector<AttributeProto> attributes;
@@ -325,6 +326,7 @@ public:
     return ptr;
   }
   void set_op_type(const std::string& s) { proto.op_type= string(&op_type, s); }
+  void set_doc_string(const std::string& s) { proto.doc_string = string(&doc_string, s); }
 };
 
 class GraphProto : public MicroProto<onnx_GraphProto> {


### PR DESCRIPTION
Open questions:

1) Should i gate this behind a flag? If so, where would that flag be and what's the interface for enabling this debug information?
2) Where should this information reside s.t. it is associated with each Node? Right now it's in the debugName and fills in the doc_string field in the ONNX proto. The downside here is that the stack trace is prepended to the unique name, which is probably A Bad Thing™. 