### PR TITLE
Ensure that Variables are at least one-dim in VariableType

### DIFF
--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -174,14 +174,6 @@ std::vector<Variable> VariableType::as_variable(TensorList tl) const {
   return variables;
 }
 
-Variable VariableType::as_variable(const Scalar & scalar) const {
-  auto tensor = scalar.toTensor();
-  if (&tensor.type() != baseType) {
-    tensor = tensor.toType(*baseType);
-  }
-  return make_variable(std::move(tensor));
-}
-
 Variable VariableType::maybe_wrap(Tensor data, const Variable & self, bool inplace) const {
   if (inplace) {
     return self;
@@ -194,6 +186,12 @@ static Variable as_view(Variable base, Tensor tensor) {
     base = base.base();
   }
   return make_variable_view(std::move(base), std::move(tensor));
+}
+
+static void ensure_no_aten_scalars(Tensor & data) {
+  if (data.defined() && data.dim() == 0) {
+    data.as_strided_({1}, {1});
+  }
 }
 
 template<typename T>

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -48,7 +48,6 @@ private:
   at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;
   std::vector<at::Tensor> unpack(const at::TensorList &tl, const char *name, int pos) const;
 
-  Variable as_variable(const Scalar & scalar) const;
   Variable as_variable(Tensor tensor) const;
   std::tuple<Variable, Variable> as_variable(std::tuple<Tensor, Tensor> tensor) const;
   std::tuple<Variable, Variable, Variable> as_variable(std::tuple<Tensor, Tensor, Tensor> tensor) const;

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -13,10 +13,6 @@
 namespace torch { namespace autograd { namespace utils {
 
 inline PyObject* wrap(at::Tensor tensor) {
-  if (tensor.defined() && tensor.dim() == 0) {
-    // don't expose 0-dim tensors to Variable API.
-    Variable(tensor).data().as_strided_({1}, {1});
-  }
   return THPVariable_Wrap(Variable(std::move(tensor)));
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -166,6 +166,10 @@ struct VariableViewImpl : public VariableImpl {
 
 inline Variable make_variable(at::Tensor data, VarFlags flags=DEFAULT_FLAGS,
                               int output_nr=0, std::shared_ptr<Function> grad_fn=nullptr) {
+  if (data.defined() && data.dim() == 0) {
+    // don't expose 0-dim tensors to Variable API.
+    data = data.as_strided_({1}, {1});
+  }
   return Variable(new VariableImpl(std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }
 
@@ -177,6 +181,10 @@ inline Variable make_variable(at::Tensor data, bool requires_grad, bool is_volat
 
 inline Variable make_variable_view(Variable base, at::Tensor data, VarFlags flags=DEFAULT_FLAGS,
                                    int output_nr=0, std::shared_ptr<Function> grad_fn=nullptr) {
+  if (data.defined() && data.dim() == 0) {
+    // don't expose 0-dim tensors to Variable API.
+    data = data.as_strided_({1}, {1});
+  }
   return Variable(new VariableViewImpl(std::move(base), std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }
 


### PR DESCRIPTION
Previously, we checked that Variables were at least one dimensional in
the Python binding (wrap_outputs.h) and in the backwards functions. This
was necessary because some Tensor functions returned Scalar types, which
must be zero dimensional. This moves the wrapping logic into
VariableType.