### PR TITLE
fix for unknown ssize_t in aten/src/TH/THMemoryFile.c

### DIFF
--- a/aten/src/TH/THDiskFile.c
+++ b/aten/src/TH/THDiskFile.c
@@ -2,6 +2,10 @@
 #include "THDiskFile.h"
 #include "THFilePrivate.h"
 
+#ifndef _WIN32
+#include <sys/types.h>
+#endif
+
 #include <stdint.h>
 #ifndef LLONG_MAX
 #define LLONG_MAX 9223372036854775807LL

--- a/aten/src/TH/THMemoryFile.c
+++ b/aten/src/TH/THMemoryFile.c
@@ -1,7 +1,10 @@
 #include "THMemoryFile.h"
 #include "THFilePrivate.h"
 #include "stdint.h"
+
+#ifndef _WIN32
 #include <sys/types.h>
+#endif
 
 typedef struct THMemoryFile__
 {

--- a/aten/src/TH/THMemoryFile.c
+++ b/aten/src/TH/THMemoryFile.c
@@ -1,6 +1,7 @@
 #include "THMemoryFile.h"
 #include "THFilePrivate.h"
 #include "stdint.h"
+#include <sys/types.h>
 
 typedef struct THMemoryFile__
 {


### PR DESCRIPTION
added `sys/types.h` include to fix unknown `ssize_t` in `aten/src/TH/THMemoryFile.c` with gcc 4.8.5 on Linux

(as reported in #3611)