### PR TITLE
Fix for cuDNN half precision RNN for pre-volta archs

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -276,7 +276,8 @@ class RNNDescriptor(object):
                 CUDNN_RNN_ALGO_STANDARD,
                 datatype
             ))
-            if version() >= 7000 and int(cuda[0]) >= 9 and torch.cuda.get_device_capability(torch.cuda.current_device())[0]>=7:
+            if version() >= 7000 and int(cuda[0]) >= 9 and (
+                    torch.cuda.get_device_capability(torch.cuda.current_device())[0] >= 7):
                 lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
                 if datatype == CUDNN_DATA_HALF:
                     lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -276,10 +276,10 @@ class RNNDescriptor(object):
                 CUDNN_RNN_ALGO_STANDARD,
                 datatype
             ))
-        if version() >= 7000 and int(cuda[0]) >= 9 and torch.cuda.get_device_capability(torch.cuda.current_device())[0]>=7:
-            lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
-            if datatype == CUDNN_DATA_HALF:
-                lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
+            if version() >= 7000 and int(cuda[0]) >= 9 and torch.cuda.get_device_capability(torch.cuda.current_device())[0]>=7:
+                lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
+                if datatype == CUDNN_DATA_HALF:
+                    lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)
         else:
             check_error(lib.cudnnSetRNNDescriptor(
                 self,

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -276,7 +276,7 @@ class RNNDescriptor(object):
                 CUDNN_RNN_ALGO_STANDARD,
                 datatype
             ))
-        if version() >= 7000 and int(cuda[0]) >= 9:
+        if version() >= 7000 and int(cuda[0]) >= 9 and torch.cuda.get_device_capability(torch.cuda.current_device())[0]>=7:
             lib.cudnnSetRNNMatrixMathType(self, CUDNN_DEFAULT_MATH)
             if datatype == CUDNN_DATA_HALF:
                 lib.cudnnSetRNNMatrixMathType(self, CUDNN_TENSOR_OP_MATH)


### PR DESCRIPTION
At the moment any attempts to use half precision RNN on pre-volta archs will return a cudnn error. This will fix it.