### PR TITLE
Enable EXPORT_ALL_SYMBOLS for CMAKE

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.0)
+if(WIN32)
+  # To enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to automatically
+  # add export decorators for all classes, structs and functions
+  cmake_minimum_required(VERSION 3.4)
+else()
+  cmake_minimum_required(VERSION 3.0)
 set(CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindCUDA

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -4,6 +4,7 @@ if(WIN32)
   cmake_minimum_required(VERSION 3.4)
 else()
   cmake_minimum_required(VERSION 3.0)
+endif(WIN32)
 set(CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindCUDA

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -2,7 +2,7 @@ if(WIN32)
   # To enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to automatically
   # add export decorators for all classes, structs and functions
   cmake_minimum_required(VERSION 3.4)
-else()
+else(WIN32)
   cmake_minimum_required(VERSION 3.0)
 endif(WIN32)
 set(CMAKE_MODULE_PATH

--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -29,7 +29,7 @@ IF "%CMAKE_GENERATOR%"=="" (
   set CMAKE_GENERATOR_COMMAND=
   set MAKE_COMMAND=msbuild INSTALL.vcxproj /p:Configuration=Release
 ) ELSE (
-  set CMAKE_GENERATOR_COMMAND=-G %CMAKE_GENERATOR%
+  set CMAKE_GENERATOR_COMMAND=-G "%CMAKE_GENERATOR%"
   IF "%CMAKE_GENERATOR%"=="Ninja" (
     set CC=cl.exe
     set CXX=cl.exe
@@ -91,6 +91,7 @@ goto:eof
                   -DTHCUNN_SO_VERSION=1 ^
                   -DNO_CUDA=%NO_CUDA% ^
                   -Dnanopb_BUILD_GENERATOR=0 ^
+                  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ^
                   -DCMAKE_BUILD_TYPE=Release
 
   %MAKE_COMMAND%
@@ -109,6 +110,7 @@ goto:eof
                   -DNO_CUDA=%NO_CUDA% ^
                   -DCUDNN_INCLUDE_DIR="%CUDNN_INCLUDE_DIR%" ^
                   -DCUDNN_LIB_DIR="%CUDNN_LIB_DIR%" ^
+                  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ^
                   -DCMAKE_BUILD_TYPE=Release
 
   %MAKE_COMMAND%

--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -64,7 +64,7 @@ goto:eof
 
 :build
   @setlocal
-  IF NOT "%PREBUILD_COMMAND%"=="" call %PREBUILD_COMMAND%
+  IF NOT "%PREBUILD_COMMAND%"=="" call "%PREBUILD_COMMAND%" %PREBUILD_COMMAND_ARGS%
   mkdir build\%~1
   cd build/%~1
   cmake ../../%~1 %CMAKE_GENERATOR_COMMAND% ^
@@ -102,7 +102,7 @@ goto:eof
 
 :build_aten
   @setlocal
-  IF NOT "%PREBUILD_COMMAND%"=="" call %PREBUILD_COMMAND%
+  IF NOT "%PREBUILD_COMMAND%"=="" call "%PREBUILD_COMMAND%" %PREBUILD_COMMAND_ARGS%
   mkdir build\%~1
   cd build/%~1
   cmake ../../../../%~1 %CMAKE_GENERATOR_COMMAND% ^


### PR DESCRIPTION
If we turn on CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS flag, we don't need to add most decorators by hand.