### PR TITLE
fix for compilation problems with PRId64 format specifier

### DIFF
--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -1,3 +1,5 @@
+#define __STDC_FORMAT_MACROS
+
 #include <Python.h>
 #ifdef _MSC_VER
 #include <Windows.h>

--- a/torch/csrc/Tensor.cpp
+++ b/torch/csrc/Tensor.cpp
@@ -1,3 +1,5 @@
+#define __STDC_FORMAT_MACROS
+
 #include <Python.h>
 #include <structmember.h>
 

--- a/torch/csrc/cuda/Storage.cpp
+++ b/torch/csrc/cuda/Storage.cpp
@@ -1,3 +1,5 @@
+#define __STDC_FORMAT_MACROS
+
 #include <Python.h>
 #include <structmember.h>
 

--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -1,3 +1,5 @@
+#define __STDC_FORMAT_MACROS
+
 #include <Python.h>
 #include <structmember.h>
 


### PR DESCRIPTION
fixes #3628 (at least for gcc 4.8.5 where I see the same problem for the recent HEAD 02450fff3): added #define __STDC_FORMAT_MACROS to tensor and storage code templates 

This fix is the same as #3574 but for different files.