### PR TITLE
Remove redundant dim check that produces maybe-uninitialized warnings

### DIFF
--- a/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricAveragePooling.cu
@@ -148,7 +148,7 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
     inputHeight = THCTensor_(size)(state, input, 2);
     inputWidth  = THCTensor_(size)(state, input, 3);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else /* 5D */
   {
     /* sizes */
     batchSize   = THCTensor_(size)(state, input, 0);

--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -163,7 +163,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
     inputHeight = THCTensor_(size)(state, input, 2);
     inputWidth  = THCTensor_(size)(state, input, 3);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else /* 5D */
   {
     /* sizes */
     batchSize   = THCTensor_(size)(state, input, 0);


### PR DESCRIPTION
While building fresh with CUDA on, I get a bunch of these warnings:
```
/home/ubuntu/src/pytorch/aten/src/THCUNN/generic/VolumetricAveragePooling.cu: In function ‘void THNN_CudaHalfVolumetricAveragePooling_updateOutput(THCState*, THCudaHalfTensor*, THCudaHalfTensor*, int, int, int, int, int, int, int, int, int, bool, bool)’:
/home/ubuntu/src/pytorch/aten/src/THCUNN/generic/VolumetricAveragePooling.cu:185:45: warning: ‘inputWidth’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if ((outputWidth  - 1)*dW >= inputWidth  + padW)
                                             ^
/home/ubuntu/src/pytorch/aten/src/THCUNN/generic/VolumetricAveragePooling.cu:125:5: note: ‘inputWidth’ was declared here
   int inputWidth;
     ^
```
from `VolumetricAveragePooling.cu` and `VolumetricDilatedMaxPooling.cu`.

This is due to variables being initialized in the body of conditionals without a final `else` clause:
```
if (THCTensor_(nDimension)(state, input) == 4) {
   // someVar = x;
}
else if (THCTensor_(nDimension)(state, input) == 5) {
   // someVar = y;
}
```

Since `input` is already shape-checked at the beginning of both `updateOutput` and `updateGradInput`, there's no need for the second if clause.