### PR TITLE
Fix CUDA builds for Windows

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -1,10 +1,4 @@
-if(WIN32)
-  # To enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to automatically
-  # add export decorators for all classes, structs and functions
-  cmake_minimum_required(VERSION 3.4)
-else(WIN32)
-  cmake_minimum_required(VERSION 3.0)
-endif(WIN32)
+cmake_minimum_required(VERSION 3.0)
 set(CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindCUDA

--- a/aten/src/TH/generic/THBlas.c
+++ b/aten/src/TH/generic/THBlas.c
@@ -22,7 +22,7 @@ TH_EXTERNC double ddot_(int *n, double *x, int *incx, double *y, int *incy);
 TH_EXTERNC float cblas_sdot(const int n, const float *x, const int incx, const float *y, const int incy);
 #ifndef THBlas_C_sdot_
 #define THBlas_C_sdot_
-inline ffloat sdot_(const int *n, const float *x, const int *incx, const float *y, const int *incy)
+static inline ffloat sdot_(const int *n, const float *x, const int *incx, const float *y, const int *incy)
 {
   return cblas_sdot(*n, x, *incx, y, *incy);
 }

--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -91,7 +91,6 @@ goto:eof
                   -DTHCUNN_SO_VERSION=1 ^
                   -DNO_CUDA=%NO_CUDA% ^
                   -Dnanopb_BUILD_GENERATOR=0 ^
-                  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ^
                   -DCMAKE_BUILD_TYPE=Release
 
   %MAKE_COMMAND%
@@ -110,7 +109,6 @@ goto:eof
                   -DNO_CUDA=%NO_CUDA% ^
                   -DCUDNN_INCLUDE_DIR="%CUDNN_INCLUDE_DIR%" ^
                   -DCUDNN_LIB_DIR="%CUDNN_LIB_DIR%" ^
-                  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ^
                   -DCMAKE_BUILD_TYPE=Release
 
   %MAKE_COMMAND%


### PR DESCRIPTION
1. CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS has a limitation, the maximum number of exported functions cannot exceed 65535. So it can't be used in CUDA builds. Removing this.
2. Specify static on an inline function to prevent linking errors. The MSVC uses C89 standard that will expose the inline function if it's not static.