### PR TITLE
Solved boolean ambiguity for variables and tensors which contain one value.

### DIFF
--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -120,10 +120,11 @@ class Variable(_C._VariableBase):
         return 'Variable containing:' + self.data.__repr__()
 
     def __bool__(self):
-        if self.data.numel() == 0:
-            return False
-        raise RuntimeError("bool value of Variable objects containing non-empty " +
-                           torch.typename(self.data) + " is ambiguous")
+        if self.data.numel() <= 1:
+            return self.data.__bool__()
+        raise RuntimeError("bool value of Variable containing " +
+                           torch.typename(self.data) +
+                           " with more than one object is ambiguous")
 
     __nonzero__ = __bool__
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -124,7 +124,7 @@ class Variable(_C._VariableBase):
             return self.data.__bool__()
         raise RuntimeError("bool value of Variable containing " +
                            torch.typename(self.data) +
-                           " with more than one object is ambiguous")
+                           " with more than one value is ambiguous")
 
     __nonzero__ = __bool__
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -151,7 +151,7 @@ class _TensorBase(object):
         elif self.numel() == 1:
             return torch.squeeze(self)[0] != 0
         raise RuntimeError("bool value of " + torch.typename(self) +
-                           " containing more than one object is ambiguous")
+                           " containing more than one value is ambiguous")
 
     __nonzero__ = __bool__
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -148,8 +148,10 @@ class _TensorBase(object):
     def __bool__(self):
         if self.numel() == 0:
             return False
-        raise RuntimeError("bool value of non-empty " + torch.typename(self) +
-                           " objects is ambiguous")
+        elif self.numel() == 1:
+            return torch.squeeze(self)[0] != 0
+        raise RuntimeError("bool value of " + torch.typename(self) +
+                           " containing more than one object is ambiguous")
 
     __nonzero__ = __bool__
 


### PR DESCRIPTION
Corrected according exception messages. Fixed some linter's code style warnings.
Resolves #3652.