### PR TITLE
Cast tensors when loading optimizer state dicts

### DIFF
--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -93,7 +93,9 @@ class LBFGS(Optimizer):
         line_search_fn = group['line_search_fn']
         history_size = group['history_size']
 
-        state = self.state['global_state']
+        # NOTE: LBFGS has only global state, but we register it as state for
+        # the first param, because this helps with casting in load_state_dict
+        state = self.state[self._params[0]]
         state.setdefault('func_evals', 0)
         state.setdefault('n_iter', 0)
 


### PR DESCRIPTION
Right now optimizers can load state dicts of other optimizers only if all parameters are matching in type and device (in contrast to `nn.Modules`). This is too strict for many use cases, and is addresses in this patch.

The only problem is that optimizer state isn't typed in any way, so code from this PR tries to make reasonable guesses - only state that's bound to certain parameters is casted (with parameter being the template), and we assume that floating point tensors in the state should match the type of parameter (I can't think of better way to handle load_state_dict across sets of parameters with different fp types). All other types are only moved to a different device.

Fixes #2830, #1442.