### PR TITLE
Fix a reference cycle when in-place ops on views save the output

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1682,6 +1682,25 @@ class TestAutograd(TestCase):
         x.sum().backward()
         self.assertEqual(root.grad.data.tolist(), [[1, 2], [1, 1], [1, 1]])
 
+    def test_inplace_view_saved_output(self):
+        # Test an in-place operation on a view in which the in-place op saves
+        # its output. Previously, this created a reference cycle.
+        dealloc = [0]
+
+        class IncrementOnDelete(object):
+            def __del__(self):
+                dealloc[0] += 1
+
+        def test():
+            root = Variable(torch.randn(3, 3), requires_grad=True)
+            copy = root.clone()
+            copy.grad_fn.register_hook(IncrementOnDelete())
+            view = copy.view(9)
+            torch.nn.functional.relu(view, inplace=True)
+
+        test()
+        self.assertEqual(dealloc[0], 1)
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -149,6 +149,10 @@ auto CopySlices::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("CopySlices", inputs, 1);
   auto& grad = inputs[0];
 
+  if (!fn) {
+    throw std::runtime_error(ERR_BACKWARD_TWICE);
+  }
+
   auto result = grad.type().tensor(base.sizes, base.strides);
   result.copy_(grad);
 
@@ -174,6 +178,10 @@ auto CopySlices::apply(const variable_list& inputs) -> variable_list {
   }
 
   return grad_inputs;
+}
+
+void CopySlices::releaseVariables() {
+  fn = nullptr;
 }
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -100,6 +100,7 @@ struct CopySlices : public Function {
   CopySlices(const Variable& base, TensorGeometry view, std::shared_ptr<Function> fn);
 
   virtual variable_list apply(const variable_list& grads) override;
+  virtual void releaseVariables() override;
 
   TensorGeometry base;
   TensorGeometry view;

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -27,7 +27,6 @@ struct SavedVariable {
 
   SavedVariable(const Variable& variable, Function* saved_for);
 
-
   at::Tensor data;
   // The gradient function associated with this node. If has_grad_fn
   // is false, then this is a leaf node. Note that the grad_fn is not saved if
@@ -41,7 +40,6 @@ struct SavedVariable {
   bool is_volatile;
   int expected_version;
   int output_nr;
-  Variable base;
   std::unique_ptr<jit::tracer::ValueTracingState> tracing_state;
 
   Variable unpack(std::shared_ptr<Function> saved_for=nullptr) const;


### PR DESCRIPTION
```
Previously, an in-place operation that saves its output (such as
relu/threshold) would create a reference cycle when applied to the a
view. There were two cycles created:

1) The cycle base.grad_fn.fn.input_.base
   base.grad_fn is a CopySlices
   base.grad_fn.fn is ThresholdBackward
   base.grad_fn.fn.input_ is a SavedVariable with base pointing to base

2) The cycle base.grad_fn.fn.input_.grad_fn.next_functions[0]
   base.grad_fn.fn.input_.grad_fn is AsStridedBackward
   and next_functions[0] points to base.grad_fn

Generally, we avoid cycles because the AD graph is mostly immutable. Two
notable exceptions are:

a) Variable.grad_fn can change to point to a new grad_fn
b) SavedVariables in a function can be set after the function is created

The first case is not a problem if grad_fns do not hold strong references
to Variables. Removing "base" from SavedVariable removes the strong ref.

For the second case, we need to avoid saving the grad_fn of outputs.
```

This fix is a bit hacky. I'm open to alternative solutions.