### PR TITLE
Fix a reference cycle when in-place ops on views save the output

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2686,6 +2686,19 @@ class TestNN(NNTestCase):
         output.backward(output.data)
         self.assertEqual(input.data, input.grad.data)
 
+    def test_elu_inplace_view(self):
+        v = Variable(torch.Tensor([1.0, -1.0, 1.0, -1.0]), requires_grad=True)
+
+        def func(root):
+            x = root.clone()
+            view = x.narrow(0, 1, 2)
+            res = F.elu(view, inplace=True)
+            self.assertIs(res, view)
+            return x
+
+        gradcheck(func, [v])
+        gradgradcheck(func, [v])
+
     def test_relu_inplace_view(self):
         v = Variable(torch.Tensor([1.0, -1.0, 1.0, -1.0]), requires_grad=True)
 
@@ -2696,9 +2709,8 @@ class TestNN(NNTestCase):
             self.assertIs(res, view)
             return x
 
-        go = Variable(torch.randn(v.size()), requires_grad=True)
         gradcheck(func, [v])
-        gradgradcheck(func, [v], [go])
+        gradgradcheck(func, [v])
 
     def test_bce_with_logits_raises_if_target_and_input_are_different_size(self):
         target = Variable(torch.rand(5))

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -653,8 +653,7 @@ def create_variable_type(top_env, aten_declarations):
                     assert not is_output
                 if option['inplace'] and is_output:
                     var = 'self'
-                ptr = 'grad_fn.get()' if is_output else 'nullptr'
-                expr = 'SavedVariable({}, {})'.format(var, ptr)
+                expr = 'SavedVariable({}, {})'.format(var, str(is_output).lower())
             stmts.append('grad_fn->{} = {};'.format(name, expr))
         return stmts
 

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -42,9 +42,9 @@ struct BatchNormBackward : public Function, public BatchNormParams {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = SavedVariable(input, this);
-        this->weight = SavedVariable(weight, this);
-        this->bias = SavedVariable(bias, this);
+        this->input = SavedVariable(input, false);
+        this->weight = SavedVariable(weight, false);
+        this->bias = SavedVariable(bias, false);
       }
     }
 
@@ -73,9 +73,9 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
       if (is_executable) {
         this->save_mean = std::move(save_mean);
         this->save_std = std::move(save_std);
-        this->input = SavedVariable(input, this);
-        this->weight = SavedVariable(weight, this);
-        this->grad_output = SavedVariable(grad_output, this);
+        this->input = SavedVariable(input, false);
+        this->weight = SavedVariable(weight, false);
+        this->grad_output = SavedVariable(grad_output, false);
       }
     }
 

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -68,10 +68,10 @@ struct ConvBackward : public Function, public ConvParams {
     , ConvParams(std::move(params))
     , convolution(std::move(convolution)) {
       if (is_executable) {
-        this->input_ = SavedVariable(input, this);
-        this->weight_ = SavedVariable(weight, this);
+        this->input_ = SavedVariable(input, false);
+        this->weight_ = SavedVariable(weight, false);
         if (bias.defined()) {
-          this->bias_ = SavedVariable(bias, this);
+          this->bias_ = SavedVariable(bias, false);
         }
         this->columns = std::move(columns);
         this->ones = std::move(ones);
@@ -101,12 +101,12 @@ struct ConvBackwardBackward : public Function, public ConvParams {
     : Function(std::move(flags))
     , ConvParams(std::move(params)) {
       if (is_executable) {
-        this->input_ = SavedVariable(input, this);
-        this->weight_ = SavedVariable(weight, this);
+        this->input_ = SavedVariable(input, false);
+        this->weight_ = SavedVariable(weight, false);
         if (bias.defined()) {
-          this->bias_ = SavedVariable(bias, this);
+          this->bias_ = SavedVariable(bias, false);
         }
-        this->grad_output_ = SavedVariable(grad_output, this);
+        this->grad_output_ = SavedVariable(grad_output, false);
       }
     }
 

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -143,20 +143,6 @@ CopySlices::CopySlices(const Variable& base_var, TensorGeometry view_, std::shar
   for (size_t i = 1; i < next_functions.size(); i++) {
     next_functions[i] = fn->next_functions[i];
   }
-
-  // Hook up the wrapped function to point through an AsStridedBackward to
-  // the base's grad_fn. This is necessary for double backwards in-case the
-  // wrapped fn contains a saved output variable.
-  auto asb = std::make_shared<generated::AsStridedBackward>();
-  asb->num_inputs = 1;
-  asb->self_geometry = base;
-  asb->size = view.sizes;
-  asb->stride = view.strides;
-  asb->storage_offset = view.storage_offset;
-  asb->is_executable = true;
-  asb->next_functions = { next_functions[0] };
-
-  fn->next_functions[0] = std::make_pair(std::move(asb), 0);
 }
 
 auto CopySlices::apply(const variable_list& inputs) -> variable_list {

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -3,6 +3,7 @@
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/functions/basic_ops.h"
 #include "torch/csrc/autograd/functions/utils.h"
+#include "torch/csrc/autograd/generated/Functions.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
 namespace torch { namespace autograd {
@@ -127,9 +128,9 @@ auto Chunk::apply(const variable_list& inputs) -> variable_list {
   });
 }
 
-CopySlices::CopySlices(const Variable& base_var, TensorGeometry view, std::shared_ptr<Function> fn_)
+CopySlices::CopySlices(const Variable& base_var, TensorGeometry view_, std::shared_ptr<Function> fn_)
   : base(base_var)
-  , view(std::move(view))
+  , view(std::move(view_))
   , fn(std::move(fn_))
 {
   is_executable = true;
@@ -139,15 +140,32 @@ CopySlices::CopySlices(const Variable& base_var, TensorGeometry view, std::share
   // to base instead of the view.
   next_functions.resize(fn->next_functions.size());
   next_functions[0] = std::make_pair(base_var.grad_fn(), base_var.output_nr());
-  fn->next_functions[0] = next_functions[0];
   for (size_t i = 1; i < next_functions.size(); i++) {
     next_functions[i] = fn->next_functions[i];
   }
+
+  // Hook up the wrapped function to point through an AsStridedBackward to
+  // the base's grad_fn. This is necessary for double backwards in-case the
+  // wrapped fn contains a saved output variable.
+  auto asb = std::make_shared<generated::AsStridedBackward>();
+  asb->num_inputs = 1;
+  asb->self_geometry = base;
+  asb->size = view.sizes;
+  asb->stride = view.strides;
+  asb->storage_offset = view.storage_offset;
+  asb->is_executable = true;
+  asb->next_functions = { next_functions[0] };
+
+  fn->next_functions[0] = std::make_pair(std::move(asb), 0);
 }
 
 auto CopySlices::apply(const variable_list& inputs) -> variable_list {
   check_input_variables("CopySlices", inputs, 1);
   auto& grad = inputs[0];
+
+  if (!fn) {
+    throw std::runtime_error(ERR_BACKWARD_TWICE);
+  }
 
   auto result = grad.type().tensor(base.sizes, base.strides);
   result.copy_(grad);
@@ -174,6 +192,10 @@ auto CopySlices::apply(const variable_list& inputs) -> variable_list {
   }
 
   return grad_inputs;
+}
+
+void CopySlices::releaseVariables() {
+  fn = nullptr;
 }
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -100,6 +100,7 @@ struct CopySlices : public Function {
   CopySlices(const Variable& base, TensorGeometry view, std::shared_ptr<Function> fn);
 
   virtual variable_list apply(const variable_list& grads) override;
+  virtual void releaseVariables() override;
 
   TensorGeometry base;
   TensorGeometry view;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -482,7 +482,8 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
           "tensors, but argument %d doesn't satisfy this condition", i);
     }
 
-    self->saved_variables.emplace_back(variable->cdata, cdata_ptr);
+    bool is_output = variable->cdata.grad_fn().get() == cdata_ptr;
+    self->saved_variables.emplace_back(variable->cdata, is_output);
   }
   // Free .to_save
   Py_DECREF(self->to_save);

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -8,6 +8,7 @@
 #include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/variable_version.h"
+#include "torch/csrc/utils/tensor_geometry.h"
 #include "torch/csrc/Types.h"
 
 namespace torch { namespace autograd {
@@ -25,8 +26,7 @@ struct SavedVariable {
     , is_volatile(false)
     , expected_version(-1) {}
 
-  SavedVariable(const Variable& variable, Function* saved_for);
-
+  SavedVariable(const Variable& variable, bool is_output);
 
   at::Tensor data;
   // The gradient function associated with this node. If has_grad_fn
@@ -41,7 +41,6 @@ struct SavedVariable {
   bool is_volatile;
   int expected_version;
   int output_nr;
-  Variable base;
   std::unique_ptr<jit::tracer::ValueTracingState> tracing_state;
 
   Variable unpack(std::shared_ptr<Function> saved_for=nullptr) const;


### PR DESCRIPTION
```
Previously, an in-place operation that saves its output (such as
relu/threshold) would create a reference cycle when applied to the a
view. There were two cycles created:

1) The cycle base.grad_fn.fn.input_.base
   base.grad_fn is a CopySlices
   base.grad_fn.fn is ThresholdBackward
   base.grad_fn.fn.input_ is a SavedVariable with base pointing to base

2) The cycle base.grad_fn.fn.input_.grad_fn.next_functions[0]
   base.grad_fn.fn.input_.grad_fn is AsStridedBackward
   and next_functions[0] points to base.grad_fn

Generally, we avoid cycles because the AD graph is mostly immutable. Two
notable exceptions are:

a) Variable.grad_fn can change to point to a new grad_fn
b) SavedVariables in a function can be set after the function is created

The first case is not a problem if grad_fns do not hold strong references
to Variables. Removing "base" from SavedVariable removes the strong ref.

For the second case, we need to avoid saving the grad_fn of outputs. We
were incorrectly saving the grad_fns of outputs when they were the
result of in-place ops on views.
```