### PR TITLE
Propagate is_volatile to the base when performing in-place ops on views

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1591,6 +1591,15 @@ class TestAutograd(TestCase):
         x.sum().backward()
         self.assertEqual(root.grad.data.tolist(), [[1, 2], [1, 1]])
 
+    def test_inplace_view_volatile(self):
+        # an in-place operation on a view that makes the view volatile should
+        # make the base volatile too
+        base = Variable(torch.randn(2, 2))
+        view = base.narrow(0, 0, 1)
+        view.add_(Variable(torch.randn(1, 2), volatile=True))
+        self.assertTrue(view.volatile)
+        self.assertTrue(base.volatile)
+
     def test_inplace_view_gradcheck(self):
         # gradcheck modifications to views
         a = Variable(torch.randn(4, 4), requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1600,6 +1600,16 @@ class TestAutograd(TestCase):
         self.assertTrue(view.volatile)
         self.assertTrue(base.volatile)
 
+    def test_inplace_base_volatile(self):
+        # an in-place operation on a base that makes the base volatile should
+        # trigger a consistency exception if the view is used in a differentiable
+        # op
+        x = Variable(torch.randn(2, 2), requires_grad=True)
+        base = Variable(torch.randn(2, 2))
+        view = base.narrow(0, 0, 1)
+        base.add_(Variable(torch.randn(1, 2), volatile=True))
+        self.assertRaisesRegex(RuntimeError, 'is_volatile', lambda: view + x)
+
     def test_inplace_view_gradcheck(self):
         # gradcheck modifications to views
         a = Variable(torch.randn(4, 4), requires_grad=True)

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -139,6 +139,8 @@ void VariableViewImpl::rebase_history(VarFlags flags, int output_nr, std::shared
   if (grad_fn) {
     TORCH_ASSERTM(grad_fn->num_inputs == 1, "Functions which modify views in-place must return a single Variable");
   } else {
+    // TODO: perhaps we should enable this case by setting base.requires_grad=False
+    // and base.grad_fn = nullptr.
     TORCH_ASSERTM(!base.requires_grad(), "base.requires_grad does not match view.requires_grad");
   }
   this->requires_grad = flags.requires_grad;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -111,9 +111,6 @@ public:
 public:
   std::shared_ptr<Function> get_grad_accumulator();
   virtual std::shared_ptr<Function>& get_grad_fn() { return _grad_fn; }
-  virtual void rebase_grad_fn(std::shared_ptr<Function> grad_fn) {
-    _grad_fn = std::move(grad_fn);
-  }
 
   at::Tensor data;
   Variable grad;
@@ -154,7 +151,7 @@ struct VariableViewImpl : public VariableImpl {
 
   // Called after in-place modifications. Modifies the grad_fn of the base
   // Variable.
-  virtual void rebase_grad_fn(std::shared_ptr<Function> grad_fn) override;
+  void rebase_history(VarFlags flags, int output_nr, std::shared_ptr<Function> grad_fn);
 
   // The base Variable (never a view)
   Variable base;
@@ -225,10 +222,15 @@ inline const std::shared_ptr<Function>& Variable::grad_fn() const {
   return get()->get_grad_fn();
 };
 inline void Variable::rebase_history(VarFlags flags, int output_nr, std::shared_ptr<Function> grad_fn) {
-  get()->requires_grad = flags.requires_grad;
-  get()->is_volatile = flags.is_volatile;
-  get()->output_nr = output_nr;
-  get()->rebase_grad_fn(std::move(grad_fn));
+  if (is_view()) {
+    auto& impl = static_cast<VariableViewImpl&>(*get());
+    impl.rebase_history(flags, output_nr, std::move(grad_fn));
+  } else {
+    get()->requires_grad = flags.requires_grad;
+    get()->is_volatile = flags.is_volatile;
+    get()->output_nr = output_nr;
+    get()->_grad_fn = std::move(grad_fn);
+  }
 }
 inline std::shared_ptr<Function> Variable::grad_accumulator() const {
   return get()->get_grad_accumulator();


### PR DESCRIPTION
```
Previously, an in-place operation on a view that caused the view to be
volatile would not propagate up to the base. This often happens in
backward passes involving CopySlices which would increase memory usage
by making grad non-volatile.
```