### PR TITLE
Fix CUDA 9 builds for Windows

### DIFF
--- a/aten/src/THCUNN/THCHalfAutoNumerics.cuh
+++ b/aten/src/THCUNN/THCHalfAutoNumerics.cuh
@@ -83,12 +83,12 @@ inline __host__ __device__ half operator*(half a, half b) {
   return THCNumerics<half>::mul(a, b);
 }
 
-inline __host__ __device__ half operator*(half a, bool b) {
-  return THCNumerics<half>::mul(a, ScalarConvert<bool, half>::to(b));
-}
-
 inline __host__ __device__ float operator*(half a, float b) {
   return ScalarConvert<half, float>::to(a) * b;
+}
+
+inline __host__ __device__ double operator*(half a, double b) {
+  return ScalarConvert<half, double>::to(a) * b;
 }
 
 inline __host__ __device__ half operator*(half a, int b) {
@@ -193,8 +193,8 @@ inline __host__ __device__ double operator+(half a, double b) {
   return ScalarConvert<half, double>::to(a) + b;
 }
 
-inline __host__ __device__ double operator*(half a, double b) {
-  return ScalarConvert<half, double>::to(a) * b;
+inline __host__ __device__ half operator*(half a, bool b) {
+  return THCNumerics<half>::mul(a, ScalarConvert<bool, half>::to(b));
 }
 #endif
 

--- a/aten/src/THCUNN/THCHalfAutoNumerics.cuh
+++ b/aten/src/THCUNN/THCHalfAutoNumerics.cuh
@@ -186,7 +186,7 @@ inline __host__ __device__ half tanh(half a) {
 
 #if defined(_MSC_VER) && CUDA_VERSION >= 9000
 inline __host__ __device__ half operator+(half a, int b) {
-  return THCNumerics<half>::add(a + ScalarConvert<int, half>::to(b));
+  return THCNumerics<half>::add(a, ScalarConvert<int, half>::to(b));
 }
 
 inline __host__ __device__ double operator+(half a, double b) {

--- a/aten/src/THCUNN/THCHalfAutoNumerics.cuh
+++ b/aten/src/THCUNN/THCHalfAutoNumerics.cuh
@@ -47,14 +47,6 @@ inline __host__ __device__ double operator+(double a, half b) {
   return a + ScalarConvert<half, double>::to(b);
 }
 
-inline __host__ __device__ half operator+(half a, int b) {
-  return THCNumerics<half>::add(a + ScalarConvert<int, half>::to(b));
-}
-
-inline __host__ __device__ double operator+(half a, double b) {
-  return ScalarConvert<half, double>::to(a) + b;
-}
-
 inline __host__ __device__ half operator-(half a) {
   return THCNumerics<half>::neg(a);
 }
@@ -97,10 +89,6 @@ inline __host__ __device__ half operator*(half a, bool b) {
 
 inline __host__ __device__ float operator*(half a, float b) {
   return ScalarConvert<half, float>::to(a) * b;
-}
-
-inline __host__ __device__ double operator*(half a, double b) {
-  return ScalarConvert<half, double>::to(a) * b;
 }
 
 inline __host__ __device__ half operator*(half a, int b) {
@@ -195,6 +183,20 @@ inline __host__ __device__ half sqrt(half a) {
 inline __host__ __device__ half tanh(half a) {
   return THCNumerics<half>::tanh(a);
 }
+
+#if defined(_MSC_VER) && CUDA_VERSION >= 9000
+inline __host__ __device__ half operator+(half a, int b) {
+  return THCNumerics<half>::add(a + ScalarConvert<int, half>::to(b));
+}
+
+inline __host__ __device__ double operator+(half a, double b) {
+  return ScalarConvert<half, double>::to(a) + b;
+}
+
+inline __host__ __device__ double operator*(half a, double b) {
+  return ScalarConvert<half, double>::to(a) * b;
+}
+#endif
 
 // comparison functions
 

--- a/aten/src/THCUNN/THCHalfAutoNumerics.cuh
+++ b/aten/src/THCUNN/THCHalfAutoNumerics.cuh
@@ -47,6 +47,14 @@ inline __host__ __device__ double operator+(double a, half b) {
   return a + ScalarConvert<half, double>::to(b);
 }
 
+inline __host__ __device__ half operator+(half a, int b) {
+  return THCNumerics<half>::add(a + ScalarConvert<int, half>::to(b));
+}
+
+inline __host__ __device__ double operator+(half a, double b) {
+  return ScalarConvert<half, double>::to(a) + b;
+}
+
 inline __host__ __device__ half operator-(half a) {
   return THCNumerics<half>::neg(a);
 }
@@ -81,6 +89,10 @@ inline __host__ __device__ double operator-(double a, half b) {
 
 inline __host__ __device__ half operator*(half a, half b) {
   return THCNumerics<half>::mul(a, b);
+}
+
+inline __host__ __device__ half operator*(half a, bool b) {
+  return THCNumerics<half>::mul(a, ScalarConvert<bool, half>::to(b));
 }
 
 inline __host__ __device__ float operator*(half a, float b) {

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -72,8 +72,8 @@ else:
     if IS_LINUX or IS_DARWIN:
         CUDA_HOME = os.getenv('CUDA_HOME', LINUX_HOME)
     else:
-        CUDA_HOME = os.getenv('CUDA_PATH', None).replace('\\', '/')
-        if len(WINDOWS_HOME) > 0:
+        CUDA_HOME = os.getenv('CUDA_PATH', '').replace('\\', '/')
+        if CUDA_HOME == '' and len(WINDOWS_HOME) > 0:
             CUDA_HOME = WINDOWS_HOME[0].replace('\\', '/')
     if not os.path.exists(CUDA_HOME):
         # We use nvcc path on Linux and cudart path on macOS


### PR DESCRIPTION
The changes in CUDA 9 breaks the operators here, so some functions need to be added. There's also a fix for the wrong behaviour in cuda setup helper.