### PR TITLE
Fix elu double-backwards when applied in-place

### DIFF
--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -171,6 +171,8 @@ def get_thnn_args(thnn_function, params):
             thnn_args.append(arg_expr(name[0], name[1:]))
         elif name == 'scale':
             thnn_args.append({'type': 'EXPRESSION', 'name': '1'})
+        elif name == 'inplace':
+            thnn_args.append({'type': 'EXPRESSION', 'name': 'false'})
         else:
             raise RuntimeError("{}: can't find binding for '{}'"
                                .format(thnn_function.name, name))
@@ -261,7 +263,8 @@ def backward_declaration(base, thnn_functions):
 
     arguments = []
     arguments.append({'type': 'THTensor*', 'name': 'grad_output'})
-    arguments += [copy.deepcopy(arg) for arg in base['arguments']]
+    arguments += [copy.deepcopy(arg) for arg in base['arguments']
+                  if arg['name'] != 'inplace']
     arguments += base['buffers']
 
     for arg in arguments:

--- a/aten/src/THCUNN/generic/ELU.cu
+++ b/aten/src/THCUNN/generic/ELU.cu
@@ -30,7 +30,6 @@ void THNN_(ELU_updateOutput)(
 
 void THNN_(ELU_updateGradInput)(
            THCState *state,
-           THCTensor *input,
            THCTensor *gradOutput,
            THCTensor *gradInput,
            THCTensor *output,
@@ -38,7 +37,7 @@ void THNN_(ELU_updateGradInput)(
            bool inplace)
 {
   real alpha = ScalarConvert<accreal, real>::to(alpha_);
-  THCUNN_check_nElement(state, input, gradOutput);
+  THCUNN_check_nElement(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
 
   if (inplace)

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -125,7 +125,6 @@ TH_API void THNN_(ELU_updateOutput)(
 
 TH_API void THNN_(ELU_updateGradInput)(
                   THCState *state,
-                  THCTensor *input,
                   THCTensor *gradOutput,
                   THCTensor *gradInput,
                   THCTensor *output,

--- a/aten/src/THNN/generic/ELU.c
+++ b/aten/src/THNN/generic/ELU.c
@@ -27,7 +27,6 @@ void THNN_(ELU_updateOutput)(
 
 void THNN_(ELU_updateGradInput)(
           THNNState *state,
-          THTensor *input,
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output,
@@ -35,7 +34,7 @@ void THNN_(ELU_updateGradInput)(
           bool inplace)
 {
   real alpha = TH_CONVERT_ACCREAL_TO_REAL(alpha_);
-  THNN_CHECK_NELEMENT(input, gradOutput);
+  THNN_CHECK_NELEMENT(output, gradOutput);
   if(inplace) {
     TH_TENSOR_APPLY2(real, gradOutput, real, output,
       if(*output_data <= 0) {

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -96,7 +96,6 @@ TH_API void THNN_(ELU_updateOutput)(
           bool inplace);               // if true, modifies gradOutput and sets gradInput onto it (no additional memory is allocated)
 TH_API void THNN_(ELU_updateGradInput)(
           THNNState *state,            // library's state
-          THTensor *input,             // input tensor
           THTensor *gradOutput,        // gradient w.r.t. output
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
           THTensor *output,            // output from a forward pass

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2778,6 +2778,26 @@ class TestNN(NNTestCase):
 
         self.assertEqual(out1, out2)
 
+    def test_elu_inplace_gradgrad(self):
+        v = Variable(torch.randn(8), requires_grad=True)
+
+        def func(root):
+            x = root.clone()
+            return F.elu(x, inplace=True)
+
+        gradcheck(func, [v])
+        gradgradcheck(func, [v])
+
+    def test_hardtanh_inplace_gradgrad(self):
+        v = Variable(torch.randn(8), requires_grad=True)
+
+        def func(root):
+            x = root.clone()
+            return F.hardtanh(x, inplace=True)
+
+        gradcheck(func, [v])
+        gradgradcheck(func, [v])
+
     def test_batchnorm_raises_error_if_running_mean_is_not_same_size_as_input(self):
         input = Variable(torch.rand(2, 10))
         running_var = torch.rand(10)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -602,9 +602,9 @@
   grad_output: avg_pool3d(grad, kernel_size, stride, padding, ceil_mode, count_include_pad)
   input: zeros_like(input)
 
-- name: elu_backward(Tensor grad_output, Tensor input, Scalar alpha, bool inplace, Tensor output)
-  grad_output: elu_backward(grad, input, alpha, inplace, output)
-  input: grad * grad_input * (input < 0).toType(grad.type())
+- name: elu_backward(Tensor grad_output, Scalar alpha, Tensor output)
+  grad_output: elu_backward(grad, alpha, output)
+  output: grad * grad_output * (output < 0).toType(grad.type())
 
 - name: glu_backward(Tensor grad_output, Tensor input, int64_t dim)
   grad_output: glu_double_backward_grad_output(grad, input, dim)
@@ -614,8 +614,8 @@
   grad_output: hardshrink_backward(grad, input, lambd)
   input: zeros_like(grad)
 
-- name: hardtanh_backward(Tensor grad_output, Tensor input, Scalar min_val, Scalar max_val, bool inplace)
-  grad_output: hardtanh_backward(grad, input, min_val, max_val, false)
+- name: hardtanh_backward(Tensor grad_output, Tensor input, Scalar min_val, Scalar max_val)
+  grad_output: hardtanh_backward(grad, input, min_val, max_val)
   input: zeros_like(grad)
 
 - name: kl_div_backward(Tensor grad_output, Tensor input, Tensor target, bool size_average, bool reduce)
@@ -634,8 +634,8 @@
   grad_output: grad - (grad * output.exp()).sum(dim, true)
   input: log_softmax_double_backward(grad, grad_output, dim, output)
 
-- name: leaky_relu_backward(Tensor grad_output, Tensor input, Scalar negative_slope, bool inplace)
-  grad_output: leaky_relu_backward(grad, input, negative_slope, false)
+- name: leaky_relu_backward(Tensor grad_output, Tensor input, Scalar negative_slope)
+  grad_output: leaky_relu_backward(grad, input, negative_slope)
   input: zeros_like(grad)
 
 - name: max_pool2d_backward(Tensor grad_output, Tensor input, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode, Tensor indices)
@@ -661,8 +661,8 @@
 - name: prelu_backward(Tensor grad_output, Tensor input, Tensor weight, std::array<bool,2> output_mask)
   grad_output, input, weight: prelu_double_backward(grads[0], grads[1], grad_output, input, weight, grad_input_mask)
 
-- name: rrelu_backward(Tensor grad_output, Tensor input, Scalar lower, Scalar upper, bool training, bool inplace, Tensor noise)
-  grad_output: rrelu_backward(grad, input, lower, upper, training, false, noise)
+- name: rrelu_backward(Tensor grad_output, Tensor input, Scalar lower, Scalar upper, bool training, Tensor noise)
+  grad_output: rrelu_backward(grad, input, lower, upper, training, noise)
   input: zeros_like(grad)
 
 - name: smooth_l1_loss_backward(Tensor grad_output, Tensor input, Tensor target, bool size_average, bool reduce)
@@ -684,8 +684,8 @@
   grad_output: softshrink_backward(grad, input, lambd)
   input: zeros_like(grad)
 
-- name: threshold_backward(Tensor grad_output, Tensor input, Scalar threshold, Scalar value, bool inplace)
-  grad_output: threshold_backward(grad, input, threshold, value, false)
+- name: threshold_backward(Tensor grad_output, Tensor input, Scalar threshold, Scalar value)
+  grad_output: threshold_backward(grad, input, threshold, value)
   input: zeros_like(grad)
 
 - name: _sigmoid_backward(Tensor grad_output, Tensor output)

--- a/torch/legacy/nn/ELU.py
+++ b/torch/legacy/nn/ELU.py
@@ -29,7 +29,6 @@ class ELU(Module):
     def updateGradInput(self, input, gradOutput):
         self._backend.ELU_updateGradInput(
             self._backend.library_state,
-            input,
             gradOutput,
             self.gradInput,
             self.output,

--- a/torch/nn/_functions/thnn/activation.py
+++ b/torch/nn/_functions/thnn/activation.py
@@ -111,7 +111,6 @@ class SELU(InplaceFunction):
             backend = type2backend[type(input.data)]
             backend.ELU_updateGradInput(
                 backend.library_state,
-                input.data,
                 grad_output.data.mul(SELU.scale),
                 grad_input.data,
                 output.data.div(SELU.scale),


### PR DESCRIPTION
Removed unused "input" argument to elu_backwards. Also removed 'inplace'
argument from backwards functions, since we don't ever want to use it.