### PR TITLE
Remove hard file offset reset in load()

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8,6 +8,7 @@ import torch.cuda
 import tempfile
 import unittest
 import warnings
+import pickle
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from itertools import product, combinations
 from common import TestCase, iter_indices, TEST_NUMPY, run_tests, download_file, skipIfNoLapack, \
@@ -4133,6 +4134,17 @@ class TestTorch(TestCase):
 
             rootview = c[8]
             self.assertEqual(rootview.data_ptr(), c[0].data_ptr())
+
+    def test_serialization_offset(self):
+        a = torch.randn(5, 5)
+        with tempfile.TemporaryFile() as f:            
+            i = 41
+            pickle.dump(i, f)
+            torch.save(a, f)
+            f.seek(0)
+            j = pickle.load(f)
+            b = torch.load(f)
+            self.assertTrue(torch.equal(a, b))
 
     def test_half_tensor(self):
         x = torch.randn(5, 5).float()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4137,7 +4137,7 @@ class TestTorch(TestCase):
 
     def test_serialization_offset(self):
         a = torch.randn(5, 5)
-        with tempfile.TemporaryFile() as f:            
+        with tempfile.TemporaryFile() as f:
             i = 41
             pickle.dump(i, f)
             torch.save(a, f)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4137,14 +4137,15 @@ class TestTorch(TestCase):
 
     def test_serialization_offset(self):
         a = torch.randn(5, 5)
+        i = 41
         with tempfile.TemporaryFile() as f:
-            i = 41
             pickle.dump(i, f)
             torch.save(a, f)
             f.seek(0)
             j = pickle.load(f)
             b = torch.load(f)
             self.assertTrue(torch.equal(a, b))
+            self.assertEqual(i, j)
 
     def test_half_tensor(self):
         x = torch.randn(5, 5).float()

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -389,14 +389,9 @@ def _load(f, map_location, pickle_module):
         else:
             raise RuntimeError("Unknown saved id type: %s" % saved_id[0])
 
-    # on windows this can return invalid values
-    try:
-        foffset = int(f.tell())
-    except ValueError as verr:
-        raise RuntimeError("Invalid file offset.")
-
-    # only if offset is zero we can attempt the legacy tar file loader
+    foffset = f.tell()
     if foffset == 0:
+        # only if offset is zero we can attempt the legacy tar file loader
         try:
             return legacy_load(f)
         except tarfile.TarError:

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -396,8 +396,8 @@ def _load(f, map_location, pickle_module):
         raise RuntimeError("Invalid file offset.")
 
     # only if offset is zero we can attempt the legacy tar file loader
-    if foffset == 0:    
-        try:        
+    if foffset == 0:
+        try:
             return legacy_load(f)
         except tarfile.TarError:
             # if not a tarfile, reset file offset and proceed


### PR DESCRIPTION
Slight improvement in file offset handling to be consistent with save() and pickle API, enables loading from arbitrary offsets.

#3694 