### PR TITLE
Implement VariableType::alias

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3932,7 +3932,7 @@
   options:
     - cname: newWithTensor
       arguments:
-        - THTensor* tensor
+        - THTensor* self
 ]]
 
 [[

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -92,6 +92,9 @@
   vec1: grad.mv(vec2) * alpha
   vec2: grad.t().mv(vec1) * alpha
 
+- name: alias(Tensor self)
+  self: grad
+
 - name: all  # fallthrough
 
 - name: any  # fallthrough

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -183,8 +183,8 @@ FALLTHROUGH_FUNCTIONS = {
     '__lshift__', '__or__', '__rshift__', '__xor__',
 }
 VIEW_FUNCTIONS = {
-    'as_strided', 'expand', 'narrow', 'permute', 'select', 'squeeze', 't',
-    'transpose', 'unfold', 'unsqueeze', 'view',
+    'alias', 'as_strided', 'expand', 'narrow', 'permute', 'select', 'squeeze',
+    't', 'transpose', 'unfold', 'unsqueeze', 'view',
 }
 MANUAL_IMPLEMENTATIONS = {
     'contiguous', 'resize_', 'resize_as_'
@@ -1025,7 +1025,8 @@ def gen_variable_type(declarations, out):
             return False
 
         # don't bind size or stride since the python signatures are different
-        if name in ['size', 'stride']:
+        # exclude alias from Python bindings as well at least for now
+        if name in ['alias', 'size', 'stride']:
             return False
 
         if name.endswith('_backward'):


### PR DESCRIPTION
```
This isn't exposed to Python directly. Instead Python code can use
variable[:], which will be implemented in terms of alias.
```