### PR TITLE
Fix export for recent changes in ONNX

### DIFF
--- a/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
@@ -9,7 +9,7 @@ namespace autograd {
 jit::node_list BatchNormForward::symbolic(SymbolicContext* ctx, jit::node_list inputs) {
   auto & g = ctx->graph;
   // X, Scale, Bias
-  auto bn = g->appendNode(g->create(jit::kSpatialBN,{inputs.at(0),inputs.at(1),inputs.at(2)}));
+  auto bn = g->appendNode(g->create(jit::kBatchNormalization, {inputs.at(0),inputs.at(1),inputs.at(2)}));
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, running_mean));
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, running_var));
   bn->i_(jit::kis_test, !this->training);

--- a/torch/csrc/autograd/functions/onnx/convolution.cpp
+++ b/torch/csrc/autograd/functions/onnx/convolution.cpp
@@ -18,7 +18,7 @@ namespace torch { namespace autograd {
 jit::node_list ConvForward::symbolic(SymbolicContext* ctx, jit::node_list inputs) {
   auto & g = ctx->graph;
   // See Note [Caffe2ConvTranspose]
-  auto n = g->create(!transposed ? jit::kConv : jit::kCaffe2ConvTranspose,
+  auto n = g->create(!transposed ? jit::kConv : jit::kConvTranspose,
                                    {inputs.at(0), inputs.at(1)});
 
   // Irritatingly, Caffe2 requires us to specify kernels,
@@ -55,6 +55,8 @@ jit::node_list ConvForward::symbolic(SymbolicContext* ctx, jit::node_list inputs
   n->i_(jit::kgroup,groups);
 
   // Not in ONNX?
+  // TODO: implement it once ConvTranspose in ONNX gets `adj` argument instead
+  // of providing `output_shape`
   for (int p : output_padding) {
     JIT_EXPECTM(p == 0, "output padding is not supported.");
   }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -43,9 +43,8 @@ _(split) \
 _(Offset) \
 _(value) \
 _(Subgraph) \
-_(SpatialBN) \
+_(BatchNormalization) \
 _(Conv) \
-_(Caffe2ConvTranspose) \
 _(ConvTranspose) \
 _(is_test) \
 _(epsilon) \

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -208,7 +208,7 @@ def prelu(g, input, weight):
     return g.op("PRelu", input, weight)
 
 
-def threshold(g, input, threshold, value, inplace):
+def threshold(g, input, threshold, value, inplace=False):
     # See Note [Export inplace]
     if _scalar(threshold) != 0:
         return _unimplemented("threshold", "non-zero threshold")
@@ -217,7 +217,7 @@ def threshold(g, input, threshold, value, inplace):
     return g.op("Relu", input)
 
 
-def leaky_relu(g, input, negative_slope, inplace):
+def leaky_relu(g, input, negative_slope, inplace=False):
     # See Note [Export inplace]
     # TODO: Talk to ONNX about unconditional cast of scalar to float
     return g.op("LeakyRelu", input, alpha_f=_scalar(negative_slope))
@@ -268,6 +268,6 @@ def unfold(g, input, dimension, size, step):
     return g.op("ATen", input, operator_s="unfold", dimension_i=dimension, size_i=size, step_i=step)
 
 
-def elu(g, input, alpha, inplace):
+def elu(g, input, alpha, inplace=False):
     # See Note [Export inplace]
     return g.op("Elu", input, alpha_f=_scalar(alpha))


### PR DESCRIPTION
Caffe2ConvTranspose and SpatialBN got renamed in https://github.com/onnx/onnx/commit/f16f6c67042fbb1af9b439204d0e1457bbd76d26

As for inplace=False - I'm not sure it's the right fix. But it seems that we stopped passing that last argument in.