### PR TITLE
Implement indexing in ATen

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -93,4 +93,32 @@ inline std::tuple<Tensor> expand_size(const Tensor &to_expand, IntList sizes, co
   return expand_size(to_expand, sizes);
 }
 
+inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
+  // expands a list of Tensors; ignores undefined (null) tensors
+  bool first = true;
+  std::vector<int64_t> sizes;
+  for (size_t i = 0; i < to_expand.size(); ++i) {
+    if (!to_expand[i].defined()) {
+      continue;
+    } else if (first) {
+      sizes = to_expand[i].sizes();
+      first = false;
+    } else {
+      sizes = infer_size(sizes, to_expand[i].sizes());
+    }
+  }
+
+  std::vector<Tensor> result(to_expand.size());
+  for (size_t i = 0; i < to_expand.size(); ++i) {
+    if (!to_expand[i].defined()) {
+      continue;
+    } else if (to_expand[i].sizes().equals(sizes)) {
+      result[i] = to_expand[i];
+    } else {
+      result[i] = to_expand[i].expand(sizes);
+    }
+  }
+  return result;
+}
+
 }

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -17,7 +17,7 @@ static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
         << ", " << (dim_post_expr)-1 << "], but got " << dim << ")",
     throw std::runtime_error(oss.str());
   }
-  if (dim  < 0) dim += dim_post_expr;
+  if (dim < 0) dim += dim_post_expr;
   return dim;
 }
 

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -1,0 +1,219 @@
+// Indexing tensors by by tensors
+//
+// This corresponds to "advanced indexing" in NumPy. The two operations are:
+//
+//  index(Tensor self, indices) -> Tensor
+//  index_put_(Tensor self, indices, value)
+//
+// The index is a TensorList containg kLong or kByte tensors or nulls. Byte
+// tensors (boolean masks) are expanded to long tensors via nonzero(). Null
+// tensors signify that the dimension is not indexed.
+//
+// All indexes are broadcast together and iterated as *one*. From NumPy:
+//
+// result[i_1, ..., i_M] == x[ind_1[i_1, ..., i_M], ind_2[i_1, ..., i_M],
+//                           ..., ind_N[i_1, ..., i_M]]
+//
+// Note 1: ByteTensors expand to index as many dimensions as there are in the
+// mask.
+//
+// Note 2: The behavior is more complicated when the index tensors are not all
+// adjacent (e.g. x[[0, 1], :, [2, 3]]). In this case, self and the index
+// tensors are transposed to the front: x.transpose(1, 2)[[0, 1], [2, 3]]
+
+
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/ExpandUtils.h"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <vector>
+
+namespace at { namespace native {
+
+static bool isByteTensor(const Tensor & t) {
+  return t.defined() && t.type().scalarType() == kByte;
+}
+
+[[noreturn]]
+static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, int64_t maskIdx) {
+  std::stringstream ss;
+  ss << "The shape of the mask " << mask.sizes() << " at index " << maskIdx;
+  ss << " does not match the indexed tensor " << self.sizes() << " at index ";
+  ss << idx;
+  throw std::runtime_error(ss.str());
+}
+
+static std::vector<Tensor> expandByteTensors(const Tensor & self, TensorList indices) {
+  // Expands byte tensors (masks) into the equivalent indexing by LongTensors
+  std::vector<Tensor> result;
+  for (auto & index : indices) {
+    if (isByteTensor(index)) {
+      // The sizes of the ByteTensor mask must match the sizes of the
+      // corresponding dimensions in self
+      for (int64_t j = 0; j < index.dim(); j++) {
+        int64_t srcIdx = result.size() + j;
+        if (index.size(j) != self.size(srcIdx)) {
+          invalid_mask(self, srcIdx, index, j);
+        }
+      }
+      // Replace with nonzeros
+      auto nonzero = index.nonzero();
+      for (int64_t j = 0; j < nonzero.size(1); j++) {
+        result.emplace_back(nonzero.select(1, j));
+      }
+    } else {
+      result.emplace_back(index);
+    }
+  }
+  return result;
+}
+
+static bool hasContiguousSubspace(TensorList tl) {
+  // true if all the non-null tensors are adjacent
+  auto isDefined = [](const Tensor & tensor){ return tensor.defined(); };
+  auto isNull = [](const Tensor & tensor){ return !tensor.defined(); };
+  auto start = std::find_if(tl.begin(), tl.end(), isDefined);
+  auto stop = std::find_if(tl.rbegin(), tl.rend(), isDefined);
+  auto it = std::find_if(start, stop.base(), isNull);
+  return it == stop.base();
+}
+
+static std::tuple<Tensor, std::vector<Tensor>>
+transposeToFront(Tensor self, TensorList indices) {
+  std::vector<int64_t> dims;
+  std::vector<Tensor> transposedIndices;
+  dims.reserve(self.dim());
+  for (int64_t i = 0; i < self.dim(); i++) {
+    if (indices[i].defined()) {
+      dims.push_back(i);
+      transposedIndices.emplace_back(indices[i]);
+    }
+  }
+  for (int64_t i = 0; i < self.dim(); i++) {
+    if (!indices[i].defined()) {
+      dims.push_back(i);
+      transposedIndices.emplace_back();
+    }
+  }
+  return std::make_tuple<>(self.permute(dims), std::move(transposedIndices));
+}
+
+static std::vector<int64_t> computeLinearStride(const Tensor & tensor) {
+  // computes the stride as if tensor were contigous
+  auto sizes = tensor.sizes();
+  std::vector<int64_t> stride(tensor.dim());
+  stride[tensor.dim() - 1] = 1;
+  std::partial_sum(sizes.rbegin(), sizes.rend() - 1, stride.rbegin() + 1, std::multiplies<int64_t>());
+  return stride;
+}
+
+static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
+  auto srcSizes = src.sizes();
+  auto nDim = src.dim();
+  std::vector<int64_t> sizes(nDim + before + after, 1);
+  for (int64_t i = 0; i < nDim; i++) {
+    sizes[i + before] = srcSizes[i];
+  }
+  return src.view(sizes);
+}
+
+static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
+  auto strides = computeLinearStride(src);
+
+  // Compute the linear index by multiplying the indexing tensors by the
+  // stride and summing them. All the indexing tensors have the same shape at
+  // this point. We also compute the number of dimensions before and after that
+  // are not being index.
+  Tensor linearIndex;
+  int64_t emptyBefore = 0, emptyAfter = 0, nElemBefore = 1, nElemAfter = 1;
+  for (int64_t i = 0; i < src.dim(); i++) {
+    if (indices[i].defined()) {
+      Tensor index = indices[i] * strides[i];
+      if (linearIndex.defined()) {
+        linearIndex += index;
+      } else {
+        linearIndex = index;
+      }
+    } else if (linearIndex.defined()) {
+      emptyAfter++;
+      nElemAfter *= src.size(i);
+    } else {
+      emptyBefore++;
+      nElemBefore *= src.size(i);
+    }
+  }
+
+  Type& longType = src.type().toScalarType(kLong);
+
+  // Compute the linear indices for the parts of the tensor not being indexed
+  Tensor beforeIndex;
+  if (emptyBefore > 0) {
+    auto index = longType.arange(0, nElemBefore) * strides[emptyBefore - 1];
+    index = index.view(src.sizes().slice(0, emptyBefore));
+    beforeIndex = unsqueezeN(index, 0, linearIndex.dim() + emptyAfter);
+  }
+  Tensor afterIndex;
+  if (emptyAfter > 0) {
+    auto index = longType.arange(0, nElemAfter);
+    index = index.view(src.sizes().slice(src.dim() - emptyAfter, emptyAfter));
+    afterIndex = unsqueezeN(index, linearIndex.dim() + emptyBefore, 0);
+  }
+
+  // Sum with broadcasting to compute the full index
+  linearIndex = unsqueezeN(linearIndex, emptyBefore, emptyAfter);
+  if (beforeIndex.defined()) {
+    linearIndex = linearIndex + beforeIndex;
+  }
+  if (afterIndex.defined()) {
+    linearIndex = linearIndex + afterIndex;
+  }
+  return linearIndex;
+}
+
+static std::tuple<Tensor, Tensor> makeLinearIndex(Tensor self, TensorList orig) {
+  // first expand ByteTensor (boolean masks) into 1 or more LongTensors
+  auto indices = expandByteTensors(self, orig);
+  // next broadcast all index tensors together
+  indices = expand_outplace(indices);
+  // add missing null Tensors so that it matches self.dim()
+  while (indices.size() < (size_t)self.dim()) {
+    indices.emplace_back();
+  }
+  // if the non-null indices are not all adjacent, transpose self and indices
+  // together so that they're adjacent at the frot
+  if (!hasContiguousSubspace(indices)) {
+    std::tie(self, indices) = transposeToFront(self, indices);
+  }
+  auto linearIndex = computeLinearIndex(self, indices);
+  return std::make_tuple<>(self, linearIndex);
+}
+
+Tensor index(const Tensor & self, TensorList indices) {
+  // TODO: check types
+  if (indices.size() > (size_t)self.dim()) {
+    runtime_error("too many indices for tensor of dimension %d (got %d)",
+      (int)self.dim(), (int)indices.size());
+  }
+
+  Tensor src, linearIndex;
+  std::tie(src, linearIndex) = makeLinearIndex(self, indices);
+  return src.take(linearIndex);
+}
+
+Tensor & index_put_(Tensor & self, TensorList indices, const Tensor & value) {
+  // TODO: check types
+  if (indices.size() > (size_t)self.dim()) {
+    runtime_error("too many indices for tensor of dimension %d (got %d)",
+      (int)self.dim(), (int)indices.size());
+  }
+
+  Tensor src, linearIndex, expandedValue;
+  std::tie(src, linearIndex) = makeLinearIndex(self, indices);
+  std::tie(expandedValue) = expand_inplace(linearIndex, value);
+  return src.put_(linearIndex, expandedValue);
+}
+
+}} // at::native

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -33,10 +33,6 @@
 
 namespace at { namespace native {
 
-static bool isByteTensor(const Tensor & t) {
-  return t.defined() && t.type().scalarType() == kByte;
-}
-
 [[noreturn]]
 static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, int64_t maskIdx) {
   std::stringstream ss;
@@ -50,7 +46,7 @@ static std::vector<Tensor> expandByteTensors(const Tensor & self, TensorList ind
   // Expands byte tensors (masks) into the equivalent indexing by LongTensors
   std::vector<Tensor> result;
   for (auto & index : indices) {
-    if (isByteTensor(index)) {
+    if (index.type().scalarType() == kByte) {
       // The sizes of the ByteTensor mask must match the sizes of the
       // corresponding dimensions in self
       for (int64_t j = 0; j < index.dim(); j++) {
@@ -199,7 +195,6 @@ static std::tuple<Tensor, Tensor> makeLinearIndex(Tensor self, TensorList orig) 
 }
 
 Tensor index(const Tensor & self, TensorList indices) {
-  // TODO: check types
   if (indices.size() > (size_t)self.dim()) {
     runtime_error("too many indices for tensor of dimension %d (got %d)",
       (int)self.dim(), (int)indices.size());
@@ -211,7 +206,6 @@ Tensor index(const Tensor & self, TensorList indices) {
 }
 
 Tensor & index_put_(Tensor & self, TensorList indices, const Tensor & value) {
-  // TODO: check types
   if (indices.size() > (size_t)self.dim()) {
     runtime_error("too many indices for tensor of dimension %d (got %d)",
       (int)self.dim(), (int)indices.size());

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -41,8 +41,8 @@ static bool isByteTensor(const Tensor & t) {
 static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, int64_t maskIdx) {
   std::stringstream ss;
   ss << "The shape of the mask " << mask.sizes() << " at index " << maskIdx;
-  ss << " does not match the indexed tensor " << self.sizes() << " at index ";
-  ss << idx;
+  ss << " does not match the shape of the indexed tensor " << self.sizes();
+  ss << " at index " << idx;
   throw std::runtime_error(ss.str());
 }
 
@@ -81,6 +81,12 @@ static bool hasContiguousSubspace(TensorList tl) {
   return it == stop.base();
 }
 
+// Transposes the tensor and indices together so that all the non-null indices
+// index the first k dimensions of the tensor. Returns the transposed tensor
+// and the reordered indices. For example:
+//  transposeToFront(tensor, {nullptr, a, nullptr, b})
+// returns
+//  tensor.permute([1, 3, 0, 2]), {a, b, nullptr, nullptr}
 static std::tuple<Tensor, std::vector<Tensor>>
 transposeToFront(Tensor self, TensorList indices) {
   std::vector<int64_t> dims;
@@ -110,6 +116,7 @@ static std::vector<int64_t> computeLinearStride(const Tensor & tensor) {
   return stride;
 }
 
+// Unsqueezes src `before` times at the front and `after` times at the end
 static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
   auto srcSizes = src.sizes();
   auto nDim = src.dim();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -40,6 +40,10 @@
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
 
+- func: index(Tensor self, TensorList indices) -> Tensor
+
+- func: index_put_(Tensor self, TensorList indices, Tensor values) -> Tensor
+
 - func: is_same_size(Tensor self, Tensor other) -> bool
 
 - func: is_cuda(Tensor self) -> bool

--- a/setup.py
+++ b/setup.py
@@ -465,6 +465,7 @@ main_sources = [
     "torch/csrc/autograd/python_function.cpp",
     "torch/csrc/autograd/python_cpp_function.cpp",
     "torch/csrc/autograd/python_variable.cpp",
+    "torch/csrc/autograd/python_variable_indexing.cpp",
     "torch/csrc/autograd/python_engine.cpp",
     "torch/csrc/autograd/python_hook.cpp",
     "torch/csrc/autograd/functions/jit_closure.cpp",

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -967,11 +967,11 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, expected_grad_input)
         self.assertEqual(value.grad.data, torch.ones(value.size()))
 
-        # case when x is not same shape as y[1]
-        x = Variable(torch.randn(1, 2), requires_grad=True)
-        y = Variable(torch.zeros(10, 2))
+        # case when x broadcasts to as y[1]
+        x = Variable(torch.randn(4), requires_grad=True)
+        y = Variable(torch.zeros(2, 3, 4))
         y[1] = x
-        y.backward(torch.randn(10, 2))
+        y.backward(torch.randn(2, 3, 4))
         self.assertEqual(x.size(), x.grad.size())
 
     def test_setitem(self):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -20,6 +20,20 @@ class TestIndexing(TestCase):
         self.assertEqual(v[:, None, None].shape, (5, 1, 1, 7, 3))
         self.assertEqual(v[..., None].shape, (5, 7, 3, 1))
 
+    def test_step(self):
+        v = Variable(torch.arange(10))
+        self.assertEqual(v[::1], v)
+        self.assertEqual(v[::2].data.tolist(), [0, 2, 4, 6, 8])
+        self.assertEqual(v[::3].data.tolist(), [0, 3, 6, 9])
+        self.assertEqual(v[::11].data.tolist(), [0])
+        self.assertEqual(v[1:6:2].data.tolist(), [1, 3, 5])
+
+    def test_step_assignment(self):
+        v = Variable(torch.zeros(4, 4))
+        v[0, 1::2] = Variable(torch.Tensor([3, 4]))
+        self.assertEqual(v[0].data.tolist(), [0, 3, 0, 4])
+        self.assertEqual(v[1:].data.sum(), 0)
+
     def test_byte_mask(self):
         v = Variable(torch.randn(5, 7, 3))
         mask = Variable(torch.ByteTensor([1, 0, 1, 1, 0]))
@@ -243,8 +257,7 @@ class NumpyTests(TestCase):
                     [7, 8, 9]])
 
         self.assertEqual(a[True], a[None])
-        # self.assertEqual(a[False], a[None][0:0])  # TODO: empty tensors
-        self.assertEqual(a[False].dim(), 0)
+        self.assertEqual(a[False], a[None][0:0])
 
     def test_boolean_shape_mismatch(self):
         arr = ones((5, 4, 3))

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,0 +1,346 @@
+from common import TestCase, run_tests
+import torch
+from torch.autograd import Variable
+
+
+class TestIndexing(TestCase):
+    def test_single_int(self):
+        v = Variable(torch.randn(5, 7, 3))
+        self.assertEqual(v[4].shape, (7, 3))
+
+    def test_multiple_int(self):
+        v = Variable(torch.randn(5, 7, 3))
+        self.assertEqual(v[4].shape, (7, 3))
+        self.assertEqual(v[4, :, 1].shape, (7,))
+
+    def test_none(self):
+        v = Variable(torch.randn(5, 7, 3))
+        self.assertEqual(v[None].shape, (1, 5, 7, 3))
+        self.assertEqual(v[:, None].shape, (5, 1, 7, 3))
+        self.assertEqual(v[:, None, None].shape, (5, 1, 1, 7, 3))
+        self.assertEqual(v[..., None].shape, (5, 7, 3, 1))
+
+    def test_byte_mask(self):
+        v = Variable(torch.randn(5, 7, 3))
+        mask = Variable(torch.ByteTensor([1, 0, 1, 1, 0]))
+        self.assertEqual(v[mask].shape, (3, 7, 3))
+        self.assertEqual(v[mask], torch.stack([v[0], v[2], v[3]]))
+
+    def test_multiple_byte_mask(self):
+        v = Variable(torch.randn(5, 7, 3))
+        # note: these broadcast together and are transposed to the first dim
+        mask1 = Variable(torch.ByteTensor([1, 0, 1, 1, 0]))
+        mask2 = Variable(torch.ByteTensor([1, 1, 1]))
+        self.assertEqual(v[mask1, :, mask2].shape, (3, 7))
+
+    def test_byte_mask2d(self):
+        v = Variable(torch.randn(5, 7, 3))
+        c = Variable(torch.randn(5, 7))
+        num_ones = (c > 0).data.sum()
+        r = v[c > 0]
+        self.assertEqual(r.shape, (num_ones, 3))
+
+    def test_int_indices(self):
+        v = Variable(torch.randn(5, 7, 3))
+        self.assertEqual(v[[0, 4, 2]].shape, (3, 7, 3))
+        self.assertEqual(v[:, [0, 4, 2]].shape, (5, 3, 3))
+        self.assertEqual(v[:, [[0, 1], [4, 3]]].shape, (5, 2, 2, 3))
+
+    def test_int_indices2d(self):
+        # From the NumPy indexing example
+        x = Variable(torch.arange(0, 12).view(4, 3))
+        rows = Variable(torch.LongTensor([[0, 0], [3, 3]]))
+        columns = Variable(torch.LongTensor([[0, 2], [0, 2]]))
+        self.assertEqual(x[rows, columns].data.tolist(), [[0, 2], [9, 11]])
+
+    def test_int_indices_broadcast(self):
+        # From the NumPy indexing example
+        x = Variable(torch.arange(0, 12).view(4, 3))
+        rows = Variable(torch.LongTensor([0, 3]))
+        columns = Variable(torch.LongTensor([0, 2]))
+        result = x[rows[:, None], columns]
+        self.assertEqual(result.data.tolist(), [[0, 2], [9, 11]])
+
+    def test_basic_advanced_combined(self):
+        # From the NumPy indexing example
+        x = Variable(torch.arange(0, 12).view(4, 3))
+        self.assertEqual(x[1:2, 1:3], x[1:2, [1, 2]])
+        self.assertEqual(x[1:2, 1:3].data.tolist(), [[4, 5]])
+
+        # Check that it is a copy
+        unmodified = x.clone()
+        x[1:2, [1, 2]].zero_()
+        self.assertEqual(x, unmodified)
+
+        # But assignment should modify the original
+        unmodified = x.clone()
+        x[1:2, [1, 2]] = 0
+        self.assertNotEqual(x, unmodified)
+
+    def test_int_assignment(self):
+        x = Variable(torch.arange(0, 4).view(2, 2))
+        x[1] = 5
+        self.assertEqual(x.data.tolist(), [[0, 1], [5, 5]])
+
+        x = Variable(torch.arange(0, 4).view(2, 2))
+        x[1] = Variable(torch.arange(5, 7))
+        self.assertEqual(x.data.tolist(), [[0, 1], [5, 6]])
+
+    def test_byte_tensor_assignment(self):
+        x = Variable(torch.arange(0, 16).view(4, 4))
+        b = Variable(torch.ByteTensor([True, False, True, False]))
+        value = Variable(torch.Tensor([3, 4, 5, 6]))
+        x[b] = value
+        self.assertEqual(x[0], value)
+        self.assertEqual(x[1].data, torch.arange(4, 8))
+        self.assertEqual(x[2], value)
+        self.assertEqual(x[3].data, torch.arange(12, 16))
+
+
+def tensor(*args, **kwargs):
+    return Variable(torch.Tensor(*args, **kwargs))
+
+
+def byteTensor(data):
+    return Variable(torch.ByteTensor(data))
+
+
+def ones(*args):
+    return Variable(torch.ones(*args))
+
+
+def zeros(*args):
+    return Variable(torch.zeros(*args))
+
+
+# The tests below are from NumPy test_indexing.py with some modifications to
+# make them compatible with PyTorch. It's licensed under the BDS license below:
+#
+# Copyright (c) 2005-2017, NumPy Developers.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#
+#     * Neither the name of the NumPy Developers nor the names of any
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+class NumpyTests(TestCase):
+    def test_index_no_floats(self):
+        a = Variable(torch.Tensor([[[5]]]))
+
+        self.assertRaises(IndexError, lambda: a[0.0])
+        self.assertRaises(IndexError, lambda: a[0, 0.0])
+        self.assertRaises(IndexError, lambda: a[0.0, 0])
+        self.assertRaises(IndexError, lambda: a[0.0, :])
+        self.assertRaises(IndexError, lambda: a[:, 0.0])
+        self.assertRaises(IndexError, lambda: a[:, 0.0, :])
+        self.assertRaises(IndexError, lambda: a[0.0, :, :])
+        self.assertRaises(IndexError, lambda: a[0, 0, 0.0])
+        self.assertRaises(IndexError, lambda: a[0.0, 0, 0])
+        self.assertRaises(IndexError, lambda: a[0, 0.0, 0])
+        self.assertRaises(IndexError, lambda: a[-1.4])
+        self.assertRaises(IndexError, lambda: a[0, -1.4])
+        self.assertRaises(IndexError, lambda: a[-1.4, 0])
+        self.assertRaises(IndexError, lambda: a[-1.4, :])
+        self.assertRaises(IndexError, lambda: a[:, -1.4])
+        self.assertRaises(IndexError, lambda: a[:, -1.4, :])
+        self.assertRaises(IndexError, lambda: a[-1.4, :, :])
+        self.assertRaises(IndexError, lambda: a[0, 0, -1.4])
+        self.assertRaises(IndexError, lambda: a[-1.4, 0, 0])
+        self.assertRaises(IndexError, lambda: a[0, -1.4, 0])
+        # self.assertRaises(IndexError, lambda: a[0.0:, 0.0])
+        # self.assertRaises(IndexError, lambda: a[0.0:, 0.0,:])
+
+    def test_none_index(self):
+        # `None` index adds newaxis
+        a = tensor([1, 2, 3])
+        self.assertEqual(a[None].dim(), a.dim() + 1)
+
+    def test_empty_tuple_index(self):
+        # Empty tuple index creates a view
+        a = tensor([1, 2, 3])
+        self.assertEqual(a[()], a)
+        self.assertEqual(a[()].data_ptr(), a.data_ptr())
+
+    # @unittest.skip('failing')
+    def test_empty_fancy_index(self):
+        # Empty list index creates an empty array
+        a = tensor([1, 2, 3])
+        self.assertEqual(a[[]], Variable(torch.Tensor()))
+
+        b = tensor([]).long()
+        self.assertEqual(a[[]], Variable(torch.LongTensor()))
+
+        b = tensor([]).float()
+        self.assertRaises(RuntimeError, lambda: a[b])
+
+    def test_ellipsis_index(self):
+        a = tensor([[1, 2, 3],
+                    [4, 5, 6],
+                    [7, 8, 9]])
+        self.assertIsNot(a[...], a)
+        self.assertEqual(a[...], a)
+        # `a[...]` was `a` in numpy <1.9.
+        self.assertEqual(a[...].data_ptr(), a.data_ptr())
+
+        # Slicing with ellipsis can skip an
+        # arbitrary number of dimensions
+        self.assertEqual(a[0, ...], a[0])
+        self.assertEqual(a[0, ...], a[0, :])
+        self.assertEqual(a[..., 0], a[:, 0])
+
+        # Slicing with ellipsis always results
+        # in an array, not a scalar
+        self.assertEqual(a[0, ..., 1], tensor([2]))
+
+        # Assignment with `(Ellipsis,)` on 0-d arrays
+        # b = np.array(1)
+        # b[(Ellipsis,)] = 2
+        # self.assertEqual(b, 2)
+
+    def test_single_int_index(self):
+        # Single integer index selects one row
+        a = tensor([[1, 2, 3],
+                    [4, 5, 6],
+                    [7, 8, 9]])
+
+        self.assertEqual(a[0].data, [1, 2, 3])
+        self.assertEqual(a[-1].data, [7, 8, 9])
+
+        # Index out of bounds produces IndexError
+        self.assertRaises(IndexError, a.__getitem__, 1 << 30)
+        # Index overflow produces Exception  NB: different exception type
+        self.assertRaises(Exception, a.__getitem__, 1 << 64)
+
+    def test_single_bool_index(self):
+        # Single boolean index
+        a = tensor([[1, 2, 3],
+                    [4, 5, 6],
+                    [7, 8, 9]])
+
+        self.assertEqual(a[True], a[None])
+        # self.assertEqual(a[False], a[None][0:0])  # TODO: empty tensors
+        self.assertEqual(a[False].dim(), 0)
+
+    def test_boolean_shape_mismatch(self):
+        arr = ones((5, 4, 3))
+
+        # TODO: prefer IndexError
+        index = byteTensor([True])
+        self.assertRaisesRegex(RuntimeError, 'mask', lambda: arr[index])
+
+        index = byteTensor([False] * 6)
+        self.assertRaisesRegex(RuntimeError, 'mask', lambda: arr[index])
+
+        index = Variable(torch.ByteTensor(4, 4)).zero_()
+        self.assertRaisesRegex(RuntimeError, 'mask', lambda: arr[index])
+
+        self.assertRaisesRegex(RuntimeError, 'mask', lambda: arr[(slice(None), index)])
+
+    def test_boolean_indexing_onedim(self):
+        # Indexing a 2-dimensional array with
+        # boolean array of length one
+        a = tensor([[0., 0., 0.]])
+        b = byteTensor([True])
+        self.assertEqual(a[b], a)
+        # boolean assignment
+        a[b] = 1.
+        self.assertEqual(a, tensor([[1., 1., 1.]]))
+
+    def test_boolean_assignment_value_mismatch(self):
+        # A boolean assignment should fail when the shape of the values
+        # cannot be broadcast to the subscription. (see also gh-3458)
+        a = Variable(torch.arange(0, 4))
+
+        def f(a, v):
+            a[a > -1] = tensor(v)
+
+        self.assertRaisesRegex(Exception, "expand", f, a, [])
+        self.assertRaisesRegex(Exception, 'expand', f, a, [1, 2, 3])
+        self.assertRaisesRegex(Exception, 'expand', f, a[:1], [1, 2, 3])
+
+    def test_boolean_indexing_twodim(self):
+        # Indexing a 2-dimensional array with
+        # 2-dimensional boolean array
+        a = tensor([[1, 2, 3],
+                    [4, 5, 6],
+                    [7, 8, 9]])
+        b = byteTensor([[True, False, True],
+                        [False, True, False],
+                        [True, False, True]])
+        self.assertEqual(a[b], tensor([1, 3, 5, 7, 9]))
+        self.assertEqual(a[b[1]], tensor([[4, 5, 6]]))
+        self.assertEqual(a[b[0]], a[b[2]])
+
+        # boolean assignment
+        a[b] = 0
+        self.assertEqual(a, tensor([[0, 2, 0],
+                                    [4, 0, 6],
+                                    [0, 8, 0]]))
+
+    def test_everything_returns_views(self):
+        # Before `...` would return a itself.
+        a = tensor(5)
+
+        self.assertIsNot(a, a[()])
+        self.assertIsNot(a, a[...])
+        self.assertIsNot(a, a[:])
+
+    def test_broaderrors_indexing(self):
+        a = zeros(5, 5)
+        self.assertRaisesRegex(RuntimeError, 'match the size', a.__getitem__, ([0, 1], [0, 1, 2]))
+        self.assertRaisesRegex(RuntimeError, 'match the size', a.__setitem__, ([0, 1], [0, 1, 2]), 0)
+
+    def test_trivial_fancy_out_of_bounds(self):
+        a = zeros(5)
+        ind = ones(20).long()
+        ind[-1] = 10
+        self.assertRaises(RuntimeError, a.__getitem__, ind)
+        self.assertRaises(RuntimeError, a.__setitem__, ind, 0)
+        ind = ones(20).long()
+        ind[0] = 11
+        self.assertRaises(RuntimeError, a.__getitem__, ind)
+        self.assertRaises(RuntimeError, a.__setitem__, ind, 0)
+
+    def test_index_is_larger(self):
+        # Simple case of fancy index broadcasting of the index.
+        a = zeros((5, 5))
+        a[[[0], [1], [2]], [0, 1, 2]] = tensor([2, 3, 4])
+
+        self.assertTrue((a[:3, :3] == tensor([2, 3, 4])).all())
+
+    def test_broadcast_subspace(self):
+        a = zeros((100, 100))
+        v = Variable(torch.arange(0, 100))[:, None]
+        b = Variable(torch.arange(99, -1, -1).long())
+        a[b] = v
+        expected = b.double().unsqueeze(1).expand(100, 100)
+        self.assertEqual(a, expected)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -259,12 +259,6 @@ static void check_no_requires_grad(const Tensor& tensor, const char* name) {
   }
 }
 
-static void check_no_requires_grad(TensorList tl, const char* name) {
-  for (auto & tensor : tl) {
-    check_no_requires_grad(tensor, name);
-  }
-}
-
 static function_list compute_next_functions(const std::initializer_list<Tensor>& tensors) {
   return Function::flags(tensors).next_functions;
 }

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -133,7 +133,7 @@ Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) co
   return unpack(t, name, pos);
 }
 
-std::vector<at::Tensor> VariableType::unpack(const at::TensorList &tl, const char *name, int pos) const {
+std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name, int pos) const {
   std::vector<at::Tensor> ret(tl.size());
   for (size_t i = 0; i < tl.size(); ++i) {
     const auto &t = tl[i];
@@ -143,11 +143,31 @@ std::vector<at::Tensor> VariableType::unpack(const at::TensorList &tl, const cha
                     toString(), i, pos, name);
     }
     if (&t.type() == this) {
-      ret[i] = static_cast<VariableImpl*>(t.pImpl)->data;
+      ret[i] = static_cast<const Variable&>(t).data();
     } else {
       runtime_error("Expected object of type %s but found type %s at position #%d "
                     "for iterable argument #%d '%s'",
                     toString(),t.type().toString(), i, pos, name);
+    }
+  }
+  return ret;
+}
+
+std::vector<at::Tensor> VariableType::unpack_idxs(at::TensorList tl, const char *name, int pos) const {
+  auto& longType = *VariableImpl::getType(baseType->toScalarType(kLong));
+  auto& byteType = *VariableImpl::getType(baseType->toScalarType(kByte));
+  std::vector<at::Tensor> ret(tl.size());
+  for (size_t i = 0; i < tl.size(); ++i) {
+    const auto &t = tl[i];
+    if (!t.defined()) {
+      continue;
+    } else if (!(t.type() == longType || t.type() == byteType)) {
+      runtime_error("Expected object of type %s or %s but found type %s at position #%d "
+                    "for iterable argument #%d '%s'",
+                    longType.toString(), byteType.toString(), t.type().toString(),
+                    i, pos, name);
+    } else  {
+      ret[i] = static_cast<const Variable&>(t).data();
     }
   }
   return ret;
@@ -236,6 +256,12 @@ static void check_no_requires_grad(const Tensor& tensor, const char* name) {
     msg += name;
     msg += "' is not implemented";
     throw std::runtime_error(msg);
+  }
+}
+
+static void check_no_requires_grad(TensorList tl, const char* name) {
+  for (auto & tensor : tl) {
+    check_no_requires_grad(tensor, name);
   }
 }
 

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -48,7 +48,8 @@ private:
   at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
   at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;
-  std::vector<at::Tensor> unpack(const at::TensorList &tl, const char *name, int pos) const;
+  std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos) const;
+  std::vector<at::Tensor> unpack_idxs(at::TensorList tl, const char *name, int pos) const;
 
   Variable as_variable(Tensor tensor) const;
   std::tuple<Variable, Variable> as_variable(std::tuple<Tensor, Tensor> tensor) const;

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -168,6 +168,26 @@ static PyObject * THPVariable_contiguous(PyObject* self, PyObject* args)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_copy_(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  static PythonArgParser parser({
+    "copy_(Tensor other)"
+  });
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  PyObject* parsed_args[1];
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    Tensor other = r.tensor(0);
+    AutoNoGIL no_gil;
+    AutoGPU gpu(self_);
+    self_.copy_(other);
+  }
+  Py_INCREF(self);
+  return self;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * THPVariable_detach(PyObject* self, PyObject* args)
 {
   HANDLE_TH_ERRORS
@@ -270,6 +290,7 @@ PyMethodDef variable_methods[] = {
   {"clamp_", (PyCFunction)THPVariable_clamp_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"dim", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
   {"contiguous", (PyCFunction)THPVariable_contiguous, METH_NOARGS, NULL},
+  {"copy_", (PyCFunction)THPVariable_copy_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"detach", (PyCFunction)THPVariable_detach, METH_NOARGS, NULL},
   {"detach_", (PyCFunction)THPVariable_detach_, METH_NOARGS, NULL},
   {"double", (PyCFunction)THPVariable_double, METH_NOARGS, NULL},

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -85,7 +85,9 @@ def gen_jit_dispatch(declarations, out):
         # TensorList arguments, and functions that are only available as methods.
         if 'namespace' in decl['method_of']:
             if any(arg['simple_type'] == 'TensorList' for arg in arguments):
-                assert sum(map(is_tensor_arg, arguments)) == 1
+                if sum(map(is_tensor_arg, arguments)) != 1:
+                    # TODO: support this
+                    continue
                 args = ['inputs' if is_tensor_arg(arg) else arg['name']
                         for arg in arguments]
             else:

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -46,26 +46,6 @@ class Variable(_C._VariableBase):
         volatile (bool): Value of the volatile flag. **Keyword only.**
     """
 
-    def __getitem__(self, key):
-        if torch.is_tensor(key):
-            key = Variable(key)  # auto-wrap tensors
-        if isinstance(key, Variable):
-            if type(key.data).__name__ == 'ByteTensor':
-                return MaskedSelect.apply(self, key)
-            elif type(key.data).__name__ == 'LongTensor':
-                return IndexSelect.apply(self, 0, key)
-            # else fall through and raise an error in Index
-        return Index.apply(self, key)
-
-    def __setitem__(self, key, value):
-        if isinstance(key, Variable) and type(key.data).__name__ == 'ByteTensor':
-            if isinstance(value, Variable):
-                return MaskedScatter.apply(self, key, value, True)
-            else:
-                return MaskedFill.apply(self, key, value, True)
-        else:
-            return SetItem.apply(self, key, value)
-
     def __deepcopy__(self, memo):
         if not self.is_leaf:
             raise RuntimeError("Only Variables created explicitly by the user "
@@ -316,9 +296,6 @@ class Variable(_C._VariableBase):
 
     def index_add(self, dim, index, tensor):
         return self.clone().index_add_(dim, index, tensor)
-
-    def _advanced_index_add(self, index, tensor):
-        return AdvancedIndexAdd.apply(self, index, tensor)
 
     def index_copy(self, dim, index, tensor):
         return self.clone().index_copy_(dim, index, tensor)

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 #include <vector>
+#include <cstdarg>
 
 #include "THP.h"
 
@@ -21,8 +22,8 @@ void replaceAll(std::string & str,
     const std::string & old_str,
     const std::string & new_str) {
   std::string::size_type pos = 0u;
-  while ((pos = str.find(old_str, pos)) != std::string::npos){
-     str.replace(pos, old_str.length(), new_str);
+  while ((pos = str.find(old_str, pos)) != std::string::npos) {
+    str.replace(pos, old_str.length(), new_str);
   }
 }
 
@@ -70,5 +71,26 @@ std::string processErrorMsg(std::string str) {
 
   return str;
 }
+
+static std::string formatMessage(const char *format, va_list fmt_args) {
+  static const size_t ERROR_BUF_SIZE = 1024;
+  char error_buf[ERROR_BUF_SIZE];
+  vsnprintf(error_buf, ERROR_BUF_SIZE, format, fmt_args);
+  return std::string(error_buf);
 }
 
+IndexError::IndexError(const char *format, ...) {
+  va_list fmt_args;
+  va_start(fmt_args, format);
+  msg = formatMessage(format, fmt_args);
+  va_end(fmt_args);
+}
+
+TypeError::TypeError(const char *format, ...) {
+  va_list fmt_args;
+  va_start(fmt_args, format);
+  msg = formatMessage(format, fmt_args);
+  va_end(fmt_args);
+}
+
+} // namespace torch

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/Types.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
+#include "torch/csrc/autograd/python_variable_indexing.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
 #include "torch/csrc/autograd/utils/wrap_outputs.h"
 #include "torch/csrc/cuda/AutoGPU.h"
@@ -477,6 +478,12 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {NULL}
 };
 
+static PyMappingMethods THPVariable_as_mapping = {
+  THPVariable_length,
+  THPVariable_getitem,
+  THPVariable_setitem,
+};
+
 PyTypeObject THPVariableType = {
   PyVarObject_HEAD_INIT(NULL, 0)
   "torch._C._VariableBase",              /* tp_name */
@@ -490,7 +497,7 @@ PyTypeObject THPVariableType = {
   0,                                     /* tp_repr */
   0,                                     /* tp_as_number */
   0,                                     /* tp_as_sequence */
-  0,                                     /* tp_as_mapping */
+  &THPVariable_as_mapping,               /* tp_as_mapping */
   0,                                     /* tp_hash  */
   0,                                     /* tp_call */
   0,                                     /* tp_str */

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -185,6 +185,7 @@ static bool treatSequenceAsTuple(PyObject* index) {
   //  sequences - otherwise we treat it like any other scalar."
   auto n = PySequence_Size(index);
   if (n < 0) {
+    // Negative size indicates a Python error in the PySequence_Size call.
     PyErr_Clear();
     return false;
   }
@@ -251,6 +252,8 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
     }
     return wrap(sliced);
   }
+
+  // indexing by tensors ("advanced" indexing)
   return wrap(dispatch_index(sliced, variableIndices));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -285,6 +288,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
     return 0;
   }
 
+  // indexing by tensors ("advanced" indexing)
   dispatch_index_put_(sliced, variableIndices, value);
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -92,7 +92,7 @@ static Variable applySelect(const Variable& self, int64_t dim, int64_t index) {
 static Variable sequenceToVariable(const Type& type, PyObject* seq) {
   PyObject* ctor = THPLongTensorClass;
 #ifdef WITH_CUDA
-  if (type.isCuda()) ctor = THCPLongTensorClass;
+  if (type.is_cuda()) ctor = THCPLongTensorClass;
 #endif
   auto obj = THPObjectPtr(PyObject_CallFunctionObjArgs(ctor, seq, NULL));
   if (!obj) throw python_error();

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -73,7 +73,10 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
     }
     return self;
   }
-  // TODO: step
+  if (step != 1) {
+    // TODO: implement step for narrow
+    throw IndexError("only step size 1 is supported");
+  }
   return self.narrow(dim, start, stop - start);
 }
 
@@ -132,10 +135,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       result = applySlice(result, dim, obj);
       dim++;
     } else if (obj == Py_Ellipsis) {
-      int64_t unspecified_dims = self.dim() - count_specified_dimensions(index);
-      for(; unspecified_dims > 0; unspecified_dims--) {
-        dim++;
-      }
+      dim += self.dim() - count_specified_dimensions(index);
     } else if (obj == Py_None) {
       result = result.unsqueeze(dim);
       dim++;

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -1,0 +1,293 @@
+#include "torch/csrc/autograd/python_variable_indexing.h"
+
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/autograd/utils/wrap_outputs.h"
+#include "torch/csrc/utils/python_compat.h"
+#include "torch/csrc/utils/python_numbers.h"
+
+#include <vector>
+
+using namespace at;
+using namespace torch::autograd::utils;
+
+extern PyObject* THPLongTensorClass;
+#ifdef WITH_CUDA
+extern PyObject* THCPLongTensorClass;
+#endif
+
+extern bool THPModule_isTensor(PyObject *obj);
+
+namespace torch { namespace autograd {
+
+Py_ssize_t THPVariable_length(PyObject* self) {
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  if (self_.dim() == 0) {
+    return 0;
+  }
+  return (Py_ssize_t)self_.size(0);
+  END_HANDLE_TH_ERRORS_RET(-1)
+}
+
+
+// We allow indexing by integers, slices, ellipsis, None, Variables,
+// and tuples of those types. We also handle bools as if they were a
+// Variable[ByteTensor].
+
+static int64_t count_specified_dimensions(PyObject* index) {
+  // Count the number of indexed dimensions (everything but ellipsis and None)
+  int64_t count = 0;
+  auto size = PyTuple_GET_SIZE(index);
+  for (Py_ssize_t i = 0; i < size; i++) {
+    PyObject* obj = PyTuple_GET_ITEM(index, i);
+    if (THPVariable_Check(obj)) {
+      auto& var = reinterpret_cast<THPVariable*>(obj)->cdata;
+      if (var.type().scalarType() == kByte) {
+        count += var.dim();
+      }
+    } else if (obj != Py_None && obj != Py_Ellipsis) {
+      count++;
+    }
+  }
+  return count;
+}
+
+[[noreturn]]
+static void invalid_index(PyObject* obj) {
+  throw IndexError(
+    "only integers, slices (`:`), ellipsis (`...`), None and long or byte "
+    "Variables are valid indices (got %s)", Py_TYPE(obj)->tp_name);
+}
+
+static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, bool ensure_view=false) {
+  Py_ssize_t start, stop, step, slicelength;
+  auto length = self.size(dim);
+  if (THPUtils_parseSlice(slice, length, &start, &stop, &step, &slicelength) < 0) {
+    throw python_error();
+  }
+  if (start == 0 && stop == length && step == 1) {
+    if (ensure_view) {
+      return at::alias(self);
+    }
+    return self;
+  }
+  // TODO: step
+  return self.narrow(dim, start, stop - start);
+}
+
+static Variable applySelect(const Variable& self, int64_t dim, int64_t index) {
+  int64_t size = self.size(dim);
+  if (index < -size || index >= size) {
+    throw IndexError("index %lld is out of bounds for dimension %lld with size %lld",
+      index, dim, size);
+  }
+  if (index < 0) {
+    index += size;
+  }
+  return self.select(dim, index);
+}
+
+static Variable sequenceToVariable(const Type& type, PyObject* seq) {
+  PyObject* ctor = THPLongTensorClass;
+#ifdef WITH_CUDA
+  if (type.isCuda()) ctor = THCPLongTensorClass;
+#endif
+  auto obj = THPObjectPtr(PyObject_CallFunctionObjArgs(ctor, seq, NULL));
+  if (!obj) throw python_error();
+  return make_variable(createTensor(obj.get()));
+}
+
+static Variable valueToTensor(const Type & type, PyObject* value) {
+  if (THPVariable_Check(value)) {
+    return reinterpret_cast<THPVariable*>(value)->cdata;
+  }
+  if (THPUtils_checkLong(value)) {
+    return type.scalarTensor(Scalar(THPUtils_unpackLong(value)));
+  }
+  if (PyFloat_Check(value)) {
+    return type.scalarTensor(Scalar(THPUtils_unpackDouble(value)));
+  }
+  throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
+}
+
+static Variable applySlicing(const Variable& self, PyObject* index, variable_list& outIndices) {
+  int64_t size = PyTuple_GET_SIZE(index);
+  int64_t dim = 0;
+
+  auto handle_var = [&](const Variable& var) {
+    // TODO: check scalarType
+    outIndices.resize(dim + 1);
+    outIndices[dim] = var;
+    dim++;
+  };
+
+  Variable result = self;
+  for (int64_t i = 0; i < size; i++) {
+    PyObject* obj = PyTuple_GET_ITEM(index, i);
+    if (THPUtils_checkLong(obj)) {
+      result = applySelect(result, dim, THPUtils_unpackLong(obj));
+    } else if (PySlice_Check(obj)) {
+      result = applySlice(result, dim, obj);
+      dim++;
+    } else if (obj == Py_Ellipsis) {
+      int64_t unspecified_dims = self.dim() - count_specified_dimensions(index);
+      for(; unspecified_dims > 0; unspecified_dims--) {
+        dim++;
+      }
+    } else if (obj == Py_None) {
+      result = result.unsqueeze(dim);
+      dim++;
+    } else if (THPVariable_Check(obj)) {
+      handle_var(reinterpret_cast<THPVariable*>(obj)->cdata);
+    } else if (THPModule_isTensor(obj)) {
+      handle_var(make_variable(createTensor(obj)));
+    } else if (PySequence_Check(obj)) {
+      handle_var(sequenceToVariable(self.type(), obj));
+    } else {
+      invalid_index(obj);
+    }
+  }
+  return result;
+}
+
+static std::vector<Tensor> asTensorList(const variable_list& v) {
+  return std::vector<Tensor>(v.begin(), v.end());
+}
+
+static Variable dispatch_index(const Variable& self, const variable_list& indices) {
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(self);
+  return self.index(asTensorList(indices));
+}
+
+static Variable dispatch_index_put_(Variable& self, const variable_list& indices, const Variable& value) {
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(self);
+  return self.index_put_(asTensorList(indices), value);
+}
+
+static bool treatSequenceAsTuple(PyObject* index) {
+  if (PyTuple_Check(index)) {
+    return true;
+  }
+  if (!PySequence_Check(index)) {
+    return false;
+  }
+  // This uses a heuristics from NumPy for determining whether to treat
+  // non-tuple sequences as if they were a tuple. From the NumPy code comments:
+  //
+  // "At this point, we're left with a non-tuple, non-array, sequence:
+  //  typically, a list. We use some somewhat-arbitrary heuristics from here
+  //  onwards to decided whether to treat that list as a single index, or a
+  //  list of indices. Backwards compatibility only takes effect for short
+  //  sequences - otherwise we treat it like any other scalar."
+  auto n = PySequence_Size(index);
+  if (n < 0) {
+    PyErr_Clear();
+    return false;
+  }
+  if (n >= 32) {
+    return false;
+  }
+  for (Py_ssize_t i = 0; i < n; i++) {
+    auto obj = THPObjectPtr{PySequence_GetItem(index, i)};
+    if (!obj.get()) {
+      PyErr_Clear();
+      return false;
+    }
+    if (THPVariable_Check(obj.get()) || PySequence_Check(obj.get()) || PySlice_Check(obj.get())) {
+      return true;
+    }
+    if (obj.get() == Py_Ellipsis || obj.get() == Py_None) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static THPObjectPtr wrapTuple(PyObject* index) {
+  THPObjectPtr res;
+  if (treatSequenceAsTuple(index)) {
+    res = PySequence_Tuple(index);
+  } else {
+    res = PyTuple_Pack(1, index);
+  }
+  if (!res) throw python_error();
+  return res;
+}
+
+PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+
+  // handle simple types: integers, slices, ellipsis
+  if (index == Py_None) {
+    return wrap(self_.unsqueeze(0));
+  } else if (index == Py_Ellipsis) {
+    return wrap(at::alias(self_));
+  } else if (THPUtils_checkLong(index)) {
+    return wrap(applySelect(self_, 0, THPUtils_unpackLong(index)));
+  } else if (PyBool_Check(index)) {
+    if (index == Py_True) {
+      return wrap(self_.unsqueeze(0));
+    } else {
+      return wrap(self_.type().tensor({0}));
+    }
+  } else if (PySlice_Check(index)) {
+    return wrap(applySlice(self_, 0, index, true));
+  }
+
+  // wrap index in a tuple if it's not already one
+  THPObjectPtr holder = wrapTuple(index);
+
+  variable_list variableIndices;
+  Variable sliced = applySlicing(self_, holder.get(), variableIndices);
+  if (variableIndices.empty()) {
+    if (sliced.get() == self_.get()) {
+      // ensure we return a shallow copy for things like x[...]
+      sliced = at::alias(sliced);
+    }
+    return wrap(sliced);
+  }
+  return wrap(dispatch_index(sliced, variableIndices));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  auto value = valueToTensor(self_.type(), py_value);
+
+  // handle simple types: integers, slices, ellipsis, bool
+  if (index == Py_False) {
+    return 0;
+  } else if (index == Py_None || index == Py_Ellipsis || index == Py_True) {
+    self_.copy_(value);
+    return 0;
+  } else if (THPUtils_checkLong(index)) {
+    applySelect(self_, 0, THPUtils_unpackLong(index)).copy_(value);
+    return 0;
+  } else if (PySlice_Check(index)) {
+    applySlice(self_, 0, index).copy_(value);
+    return 0;
+  }
+
+  // wrap index in a tuple if it's not already one
+  THPObjectPtr holder = wrapTuple(index);
+
+  variable_list variableIndices;
+  Variable sliced = applySlicing(self_, holder.get(), variableIndices);
+  if (variableIndices.empty()) {
+    sliced.copy_(value);
+    return 0;
+  }
+
+  dispatch_index_put_(sliced, variableIndices, value);
+  return 0;
+  END_HANDLE_TH_ERRORS_RET(-1)
+}
+
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -67,17 +67,17 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
   if (THPUtils_parseSlice(slice, length, &start, &stop, &step, &slicelength) < 0) {
     throw python_error();
   }
-  if (start == 0 && stop == length && step == 1) {
-    if (ensure_view) {
-      return at::alias(self);
-    }
+  if (step == 0) {
+    throw IndexError("step cannot be zero");
+  }
+  if (step < 0) {
+    // TODO: implement negative step
+    throw IndexError("negative step not yet supported");
+  }
+  if (!ensure_view && start == 0 && stop == length && step == 1) {
     return self;
   }
-  if (step != 1) {
-    // TODO: implement step for narrow
-    throw IndexError("only step size 1 is supported");
-  }
-  return self.narrow(dim, start, stop - start);
+  return self.slice(start, stop, step, dim);
 }
 
 static Variable applySelect(const Variable& self, int64_t dim, int64_t index) {

--- a/torch/csrc/autograd/python_variable_indexing.h
+++ b/torch/csrc/autograd/python_variable_indexing.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Python.h>
+
+namespace torch { namespace autograd {
+
+Py_ssize_t THPVariable_length(PyObject* self);
+PyObject* THPVariable_getitem(PyObject* self, PyObject* index);
+int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* value);
+
+}} // namespace torch::autograd

--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -488,8 +488,9 @@ static PyObject * THPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObject
         }
         if (!PySequence_Check(sequences[i])) {
           std::string index_str = THPTensor_(indicesToString)(indices, i);
-          THPUtils_setError("an item of time %s at index %s doesn't implement "
-              "a sequence protocol");
+          THPUtils_setError(
+              "an item of type %s at index %s doesn't implement a sequence protocol",
+              THPUtils_typename(sequences[i].get()), index_str.c_str());
           return NULL;
         }
         Py_ssize_t length = PySequence_Length(sequences[i]);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -7,6 +7,7 @@
 #include <ATen/ATen.h>
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_numbers.h"
+#include "torch/csrc/utils/python_compat.h"
 
 #ifdef WITH_CUDA
 #include <THC/THC.h>
@@ -141,14 +142,6 @@ std::vector<int> THPUtils_unpackIntTuple(PyObject *arg);
 void THPUtils_addPyMethodDefs(std::vector<PyMethodDef>& vector, PyMethodDef* methods);
 
 int THPUtils_getCallable(PyObject *arg, PyObject **result);
-// https://bugsfiles.kde.org/attachment.cgi?id=61186
-#if PY_VERSION_HEX >= 0x03020000
-#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
-  (PySlice_GetIndicesEx(SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
-#else
-#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
-  (PySlice_GetIndicesEx((PySliceObject*)SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
-#endif
 
 #define THStoragePtr TH_CONCAT_3(TH,Real,StoragePtr)
 #define THTensorPtr  TH_CONCAT_3(TH,Real,TensorPtr)

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Python.h>
+
+// https://bugsfiles.kde.org/attachment.cgi?id=61186
+#if PY_VERSION_HEX >= 0x03020000
+#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
+  (PySlice_GetIndicesEx(SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#else
+#define THPUtils_parseSlice(SLICE, LEN, START, STOP, LENGTH, STEP) \
+  (PySlice_GetIndicesEx((PySliceObject*)SLICE, LEN, START, STOP, LENGTH, STEP) == 0)
+#endif

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -106,10 +106,11 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0):
     data_offset = 0
     prev_batch_size = batch_sizes[0]
     prev_i = 0
-    for i, batch_size in enumerate(batch_sizes):
+    for i, batch_size in enumerate(batch_sizes + [0]):
         if batch_size != prev_batch_size:
             l = prev_batch_size * (i - prev_i)
-            output[prev_i:i, :prev_batch_size] = var_data[data_offset:data_offset + l]
+            tmp = var_data[data_offset:data_offset + l]
+            output[prev_i:i, :prev_batch_size] = tmp.view(i - prev_i, prev_batch_size, *tmp.size()[1:])
             data_offset += l
             prev_i = i
         dec = prev_batch_size - batch_size
@@ -117,10 +118,6 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0):
             lengths.extend((i,) * dec)
         prev_batch_size = batch_size
 
-    l = prev_batch_size * (len(batch_sizes) - prev_i)
-    output[prev_i:, :prev_batch_size] = var_data[data_offset:data_offset + l]
-
-    lengths.extend((i + 1,) * batch_size)
     lengths.reverse()
 
     if batch_first:


### PR DESCRIPTION
```
Implements basic and advanced indexing using ATen tensors/variables.
Basic indexing is translated at the Python-binding level
(python_variable_indexing.cpp) to narrow/squeeze/unsqueeze/select calls.
Advanced indexing is implemented in ATen in terms of take() and put()
calls.
```