### PR TITLE
Record stack traces for CppOp's

### DIFF
--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -67,6 +67,9 @@ variable_list Function::tracedApply(variable_list inputs) {
   // Insert a CppOp in the trace.
   auto& graph = state->graph;
   auto* this_node = graph->createCppOp(getSharedPtr());
+  this_node->setSourceLocation(std::make_shared<SourceLocation>(
+        jit::tracer::getPythonInterpreterStackTrace()
+  ));
   for (auto& input: inputs) {
     this_node->addInput(tracer::getValueTrace(state, input));
   }

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -51,7 +51,11 @@ struct Add : public ForwardFunction<true>, public HasSymbolic {
   Add() {}
 
   virtual variable_list apply(const variable_list& inputs) override;
-  virtual jit::value_list symbolic(SymbolicContext* ctx, jit::value_list inputs) override;
+  virtual jit::value_list symbolic(
+      SymbolicContext* ctx,
+      jit::value_list inputs,
+      std::shared_ptr<jit::SourceLocation> sl
+  ) override;
 };
 
 

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -25,7 +25,11 @@ struct BatchNormForward : public ForwardFunction<>, public BatchNormParams, publ
     : BatchNormParams(std::move(params)) {}
 
   virtual variable_list apply(const variable_list& inputs) override;
-  virtual jit::value_list symbolic(SymbolicContext* ctx, jit::value_list inputs) override;
+  virtual jit::value_list symbolic(
+      SymbolicContext* ctx,
+      jit::value_list inputs,
+      std::shared_ptr<jit::SourceLocation> sl
+    ) override;
 };
 
 struct BatchNormBackward : public Function, public BatchNormParams {

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -49,7 +49,11 @@ struct ConvForward : public ForwardFunction<>, public ConvParams, public HasSymb
 
   virtual std::string name() override;
   virtual variable_list apply(const variable_list& inputs) override;
-  virtual jit::value_list symbolic(SymbolicContext* ctx, jit::value_list inputs) override;
+  virtual jit::value_list symbolic(
+      SymbolicContext* ctx,
+      jit::value_list inputs,
+      std::shared_ptr<jit::SourceLocation> sl
+  ) override;
 
   std::vector<int64_t> output_size(at::Tensor& input, at::Tensor& weight) const;
 };

--- a/torch/csrc/autograd/functions/onnx/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/onnx/basic_ops.cpp
@@ -2,9 +2,15 @@
 
 namespace torch { namespace autograd {
 
-jit::value_list Add::symbolic(SymbolicContext* ctx, jit::value_list inputs) {
+jit::value_list Add::symbolic(
+    SymbolicContext* ctx,
+    jit::value_list inputs,
+    std::shared_ptr<jit::SourceLocation> sl
+) {
   auto & g = ctx->graph;
-  auto node = g->appendNode(g->create(jit::kAdd, inputs))->output();
+  auto op_node = g->create(jit::kAdd, inputs);
+  op_node->setSourceLocation(sl);
+  auto node = g->appendNode(op_node)->output();
   return {node};
 }
 

--- a/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
+++ b/torch/csrc/autograd/functions/onnx/batch_normalization.cpp
@@ -6,10 +6,16 @@
 namespace torch {
 namespace autograd {
 
-jit::value_list BatchNormForward::symbolic(SymbolicContext* ctx, jit::value_list inputs) {
+jit::value_list BatchNormForward::symbolic(
+    SymbolicContext* ctx,
+    jit::value_list inputs,
+    std::shared_ptr<jit::SourceLocation> sl
+) {
   auto & g = ctx->graph;
   // X, Scale, Bias
-  auto bn = g->appendNode(g->create(jit::kBatchNormalization, {inputs.at(0),inputs.at(1),inputs.at(2)}, 0));
+  auto bn_node = g->create(jit::kBatchNormalization,{inputs.at(0),inputs.at(1),inputs.at(2)}, 0);
+  bn_node->setSourceLocation(sl);
+  auto bn = g->appendNode(bn_node);
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, running_mean));
   bn->addInput(jit::tracer::getBufferTrace(*ctx->buffer_map, running_var));
   bn->i_(jit::kis_test, !this->training);

--- a/torch/csrc/autograd/functions/onnx/convolution.cpp
+++ b/torch/csrc/autograd/functions/onnx/convolution.cpp
@@ -15,7 +15,11 @@ namespace torch { namespace autograd {
 // passed here; it's done as an external addition.  This is less efficient
 // but this code should be temporary anyway.
 
-jit::value_list ConvForward::symbolic(SymbolicContext* ctx, jit::value_list inputs) {
+jit::value_list ConvForward::symbolic(
+    SymbolicContext* ctx,
+    jit::value_list inputs,
+    std::shared_ptr<jit::SourceLocation> sl
+) {
   auto & g = ctx->graph;
   // See Note [Caffe2ConvTranspose]
   auto n = g->create(!transposed ? jit::kConv : jit::kConvTranspose,
@@ -32,10 +36,12 @@ jit::value_list ConvForward::symbolic(SymbolicContext* ctx, jit::value_list inpu
 
   // See Note [Caffe2ConvTranspose]
   if(transposed) {
-    auto tn = g->appendNode(g->createConstant(at::CPU(at::kFloat).zeros({weight_size[1]})));
-    n->addInput(tn->output());
+    auto const_node = g->createConstant(at::CPU(at::kFloat).zeros({weight_size[1]}));
+    const_node->setSourceLocation(sl);
+    n->addInput(g->appendNode(const_node)->output());
   }
 
+  n->setSourceLocation(sl);
   g->appendNode(n);
 
   std::vector<int64_t> kernel_size(weight_size.begin() + 2, weight_size.end());
@@ -69,6 +75,7 @@ jit::value_list ConvForward::symbolic(SymbolicContext* ctx, jit::value_list inpu
     auto a_n = g->create(jit::kAdd, {n->output(), inputs.at(2)});
     a_n->i_(jit::kbroadcast, 1);
     a_n->i_(jit::kaxis, 1);
+    a_n->setSourceLocation(sl);
     g->appendNode(a_n);
     return {a_n->output()};
   } else {

--- a/torch/csrc/autograd/symbolic.h
+++ b/torch/csrc/autograd/symbolic.h
@@ -21,7 +21,11 @@ struct HasSymbolic {
   // Add some nodes to the ONNX protobuf, under the assumption that this node
   // as a whole has the represented inputs and outputs.  Raises a
   // symbolic_unconvertible exception if conversion is not supported.
-  virtual jit::value_list symbolic(SymbolicContext* ctx, jit::value_list inputs) = 0;
+  virtual jit::value_list symbolic(
+      SymbolicContext* ctx,
+      jit::value_list inputs,
+      std::shared_ptr<jit::SourceLocation> sl
+  ) = 0;
 };
 
 }} // namespace torch::autograd

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -207,7 +207,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
     auto stage_guard = new_graph->setStageTemporary(node->stage());
     IR_IFM(node, CppOp)
       if (auto fn = std::dynamic_pointer_cast<autograd::HasSymbolic>(value->fn)) {
-        auto outputs = fn->symbolic(&ctx, fmap(node->inputs(), envFn));
+        auto outputs = fn->symbolic(&ctx, fmap(node->inputs(), envFn), node->getSourceLocation());
         setOutputs(value->name(), node, outputs);
       } else {
         cloneNode(node);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -20,6 +20,8 @@ namespace torch { namespace jit { namespace tracer {
 using torch::autograd::Variable;
 using variable_list = std::vector<Variable>;
 
+std::string getPythonInterpreterStackTrace();
+
 namespace detail {
 
 inline ValueTracingStateElem* getValueState(const std::shared_ptr<TracingState>& state, const Variable& var, bool alloc = true) {


### PR DESCRIPTION
While inspecting SqueezeNet, the stack traces for the Conv operators were not being recorded because they were part of a CppOp, and the code path for tracing those did not stack traces in the graph.