### PR TITLE
Implement ConvTBC from fairseq-py in ATen 

### DIFF
--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -598,7 +598,6 @@ Tensor RoiPooling2d_backward_cpu(
 }
 
 
-
 // TODO Replace this with more accurate digamma().
 template <typename CScalar>
 static inline CScalar digamma_one(CScalar x) {
@@ -665,6 +664,104 @@ Tensor _standard_gamma_grad(const Tensor& self, const Tensor& output) {
   Tensor ret = self.type().tensor(self.sizes());
   dispatch_floating_types<StandardGammaGradOp>(self.type(), "_standard_gamma_grad", ret, self, output);
   return ret;
+}
+  
+Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, int64_t pad) {
+  AT_ASSERT(self.dim() == 3, "Input must have 3 dims: time, batch, "
+      "in_channel");
+  AT_ASSERT(weight.dim() == 3, "Weight tensor must have 3 dims: kernel_width,"
+      " in_channels, out_channels.");
+  AT_ASSERT(bias.dim() == 1, "Bias must be 1-D");
+
+  auto input_size = self.sizes();
+  auto weight_size = weight.sizes();
+
+  auto ilen = input_size[0];
+  auto batchSize = input_size[1];
+  auto inputPlanes = input_size[2];
+  auto outputPlanes = weight_size[2];
+  auto kw = weight_size[0];
+  auto olen = input_size[0] - kw + 1 + pad * 2;
+  auto real_pad = (olen - ilen + kw - 1) / 2;
+
+  // Make sure shapes are correct.
+  // Input = (time, batch, in_channels)
+  // Weight = (kernel_width, in_channels, out_channels)
+  // Bias = (out_channels)
+  AT_ASSERT(inputPlanes == weight_size[1], "Input dim 2 (input channels) "
+      "is not == dim 1 in the weight tensor");
+  AT_ASSERT(weight_size[2] == bias.sizes()[0], "Bias size must equal dim 2 in "
+      "the weight tensor (output channels).");
+
+  // input * weights + bias -> output_features
+  Tensor output = self.type().tensor({
+    olen,
+    input_size[1],
+    weight_size[2],
+  });
+  output.copy_(bias.expand(output.sizes()));
+  for (int k = 0; k < kw; k++) {
+    int iShift = std::max(0, static_cast<int>(k - real_pad));
+    int oShift = std::max(0, static_cast<int>(real_pad - k));
+    int t = std::min(ilen + real_pad - k, olen) - oShift;
+    // Note: gemm assumes column-major matrices
+    // input    is l*m (row-major)
+    // weight   is m*r (row-major)
+    // output   is l*r (row-major)
+    if (t > 0) {
+      auto W = weight[k];
+      auto I = self.narrow(0, iShift, t).view({t * batchSize, inputPlanes});
+      auto O = output.narrow(0, oShift, t).view({t * batchSize, outputPlanes});
+      O.addmm_(I, W);
+    }
+  }
+  return output;
+}
+
+std::tuple<Tensor, Tensor, Tensor> conv_tbc_backward(const Tensor& dOutput, const Tensor& input, const Tensor& weight, const Tensor& bias, int64_t pad) {
+  auto input_size = input.sizes();
+  auto weight_size = weight.sizes();
+
+  auto ilen = input_size[0];
+  auto batchSize = input_size[1];
+  auto inputPlanes = input_size[2];
+  auto outputPlanes = weight_size[2];
+  auto kw = weight.sizes()[0];
+  auto olen = input_size[0] - kw + 1 + pad * 2;
+  int real_pad = (olen - ilen + kw - 1) / 2;
+
+  Tensor dInput = zeros_like(input);
+  for (int k = 0; k < kw; k++) {
+    int iShift = std::max(0, k - real_pad);
+    int oShift = std::max(0, real_pad - k);
+    int t = std::min(ilen + real_pad - k, olen) - oShift;
+    // dOutput * T(weight) -> dInput
+    if (t > 0) {
+      auto dO = dOutput.narrow(0, oShift, t).view({t * batchSize, outputPlanes});
+      auto dI = dInput.narrow(0, iShift, t).view({t * batchSize, inputPlanes});
+      dI.addmm_(dO, weight[k].t());
+    }
+  }
+
+  Tensor dWeight = zeros_like(weight);
+  for (int k = 0; k < kw; k++) {
+    int iShift = std::max(0, k - real_pad);
+    int oShift = std::max(0, real_pad - k);
+    int t = std::min(ilen + real_pad - k, olen) - oShift;
+    // T(input) * dOutput -> dWeight
+    if (t > 0) {
+      auto dW = dWeight[k];
+      auto dO = dOutput.narrow(0, oShift, t).view({t * batchSize, outputPlanes});
+      auto I = input.narrow(0, iShift, t).view({t * batchSize, inputPlanes}).t();
+      dW.addmm_(I, dO);
+    }
+  }
+
+  Tensor dBias = zeros_like(bias); 
+  auto tmp = dOutput.sum(0, false);
+  dBias.assign_(tmp.sum(0));
+
+  return std::make_tuple(dInput, dWeight, dBias);
 }
 
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -180,3 +180,8 @@
     - type: Tensor
       name: grad_theta
   variants: function
+
+- func: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad) -> Tensor
+
+- func: conv_tbc_backward(Tensor self, Tensor input, Tensor weight, Tensor bias, int64_t pad) -> (Tensor, Tensor, Tensor)
+

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3354,6 +3354,13 @@ class TestNN(NNTestCase):
         _assertGradAndGradgradChecks(self, lambda x1, x2: F.bilinear(x1, x2, module.weight, module.bias),
                                      (input1_1, input2_1))
 
+    def test_conv_tbc(self):
+        inp = Variable(torch.randn(9, 4, 5), requires_grad=True)
+        weight = Variable(torch.randn(3, 5, 6), requires_grad=True)
+        bias = Variable(torch.randn(6), requires_grad=True)
+
+        gradcheck(lambda i, w, b, pad: F.conv_tbc(i, w, b, pad), (inp, weight, bias, 3))
+
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size,
                                   inp_size, dilation, no_weight, groups=1, use_cuda=False, use_bias=True):
         tensor = torch.Tensor(1)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -171,6 +171,9 @@
 - name: cumsum(Tensor self, int64_t dim)
   self: cumsum_backward(grad, dim)
 
+- name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad)
+  self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)
+
 - name: data_ptr  # fallthrough
 
 - name: _det_with_svd(Tensor self)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -224,6 +224,19 @@ def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
     return f(input, weight, bias)
 
 
+def conv_tbc(input, weight, bias, pad=0):
+    r"""Applies a 1-dimensional sequence convolution over an input sequence.
+    Input and output dimensions are (Time, Batch, Channels) hence TBC.
+
+    Args:
+        input: input tensor of shape (sequence length x batch x channels)
+        weight: filter of shape (kernel width x input channels x output channels)
+        bias: bias of shape (output channels)
+        pad: number of timesteps to pad
+    """
+    return input.conv_tbc(weight, bias, pad)
+
+
 # Pooling
 def avg_pool1d(input, kernel_size, stride=None, padding=0,
                ceil_mode=False, count_include_pad=True):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -376,3 +376,7 @@ def eq(g, self, other):
 
 def exp(g, self):
     return g.op("Exp", self)
+
+
+def conv_tbc(g, input, weight, bias, pad):
+    return g.op("ATen", input, weight, bias, operator_s="conv_tbc", pad_i=pad)


### PR DESCRIPTION
Original: https://github.com/facebookresearch/fairseq-py/blob/master/fairseq/clib/temporal_convolution_tbc/temporal_convolution_tbc.cpp

Testing: https://github.com/facebookresearch/fairseq-py/blob/master/tests/test_convtbc.py

Notes:
- Temporary exception in `tools/autograd/gen_variable_type.py` that we need to address later.

Follow-up:
- New PR to https://github.com/facebookresearch/fairseq-py to switch over to this implementation: https://github.com/facebookresearch/fairseq-py/pull/66