### PR TITLE
Add cudaEvent support to the profiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,7 @@ if WITH_CUDA:
     cuda_include_path = os.path.join(CUDA_HOME, 'include')
     include_dirs.append(cuda_include_path)
     include_dirs.append(tmp_install_path + "/include/THCUNN")
-    extra_compile_args += ['-DWITH_CUDA']
+    extra_compile_args += ['-DWITH_CUDA', '-DAT_CUDA_ENABLED']
     extra_compile_args += ['-DCUDA_LIB_PATH=' + cuda_lib_path]
     main_libraries += ['cudart', nvtoolext_lib_name]
     main_sources += [

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1541,9 +1541,9 @@ class TestAutograd(TestCase):
         names = ['mul', 'add']
         self.assertEqual(len(p.function_events), len(names))
         for info, expected_name in zip(p.function_events, names):
-            self.assertGreater(info.start, last_end)
+            self.assertGreater(info.cpu_interval.start, last_end)
             self.assertEqual(info.name, expected_name)
-            last_end = info.end
+            last_end = info.cpu_interval.end
 
     def test_dir(self):
         x = Variable(torch.randn(10, 10))

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -71,7 +71,7 @@ class EventList(list):
                         name=evt.name,
                         ph='s',
                         # +1 microsecond so the arrow is drawn inside cpu block
-                        ts=evt.cpu_interval.start+1,
+                        ts=evt.cpu_interval.start + 1,
                         tid=evt.thread,
                         pid='CPU functions',
                         id=next_id,
@@ -320,6 +320,7 @@ class Interval(object):
     def elapsed_us(self):
         return self.end - self.start
 
+
 # TODO: record TID too
 class FunctionEvent(FormattedTimesMixin):
     """Profiling information about a single function."""
@@ -472,7 +473,7 @@ def parse_nvprof_trace(path):
                             name=strings[row['name']],
                             cpu_start=row['start_time'],
                             cpu_end=row['end_time'],
-                            thread=0)
+                            thread=0)  # TODO: find in sqlite database
         functions.append(evt)
         functions_map[evt.id] = evt
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -10,44 +10,6 @@
 #define ENSURE_UNREACHABLE __builtin_unreachable();
 #endif
 
-namespace pybind11 { namespace detail {
-
-template <> struct type_caster<torch::autograd::profiler::EventKind> {
-public:
-  PYBIND11_TYPE_CASTER(torch::autograd::profiler::EventKind, _("torch::autograd::profiler::EventKind"));
-
-  bool load(handle src, bool) {
-    try {
-      auto str = py::cast<std::string>(src);
-      if (str == "push") {
-        value = torch::autograd::profiler::EventKind::PushRange;
-      } else if (str == "pop") {
-        value = torch::autograd::profiler::EventKind::PopRange;
-      } else if (str == "mark") {
-        value = torch::autograd::profiler::EventKind::Mark;
-      } else {
-        return false;
-      }
-    } catch (std::exception& e) {
-      return false;
-    }
-    return true;
-  }
-  static handle cast(torch::autograd::profiler::EventKind src, return_value_policy /* policy */, handle /* parent */) {
-    switch (src) {
-      case torch::autograd::profiler::EventKind::PushRange:
-        return py::cast("push").release();
-      case torch::autograd::profiler::EventKind::PopRange:
-        return py::cast("pop").release();
-      case torch::autograd::profiler::EventKind::Mark:
-        return py::cast("mark").release();
-    }
-    ENSURE_UNREACHABLE
-  }
-};
-
-}} // namespace pybind11::detail
-
 PyObject * THPAutograd_initExtension(PyObject *_unused)
 {
   THPUtils_assert_PyImport("torch.autograd", autograd_module);
@@ -68,6 +30,14 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
           "StochasticFunction class in torch.autograd module");
 
   auto m = py::handle(autograd_module).cast<py::module>();
+
+  py::class_<torch::autograd::profiler::Event>(m,"ProfilerEvent")
+  .def("kind",&torch::autograd::profiler::Event::kind)
+  .def("name",&torch::autograd::profiler::Event::name)
+  .def("thread_id",&torch::autograd::profiler::Event::thread_id)
+  .def("cpu_elapsed_us",&torch::autograd::profiler::Event::cpu_elapsed_us)
+  .def("cuda_elapsed_us",&torch::autograd::profiler::Event::cuda_elapsed_us)
+  .def("has_cuda",&torch::autograd::profiler::Event::has_cuda);
   m.def("_enable_profiler", torch::autograd::profiler::enableProfiler);
   m.def("_disable_profiler", torch::autograd::profiler::disableProfiler);
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -38,17 +38,23 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
   .def("cpu_elapsed_us",&torch::autograd::profiler::Event::cpu_elapsed_us)
   .def("cuda_elapsed_us",&torch::autograd::profiler::Event::cuda_elapsed_us)
   .def("has_cuda",&torch::autograd::profiler::Event::has_cuda);
+  py::enum_<torch::autograd::profiler::ProfilerState>(m,"ProfilerState")
+  .value("Disabled", torch::autograd::profiler::ProfilerState::Disabled)
+  .value("CPU", torch::autograd::profiler::ProfilerState::CPU)
+  .value("CUDA", torch::autograd::profiler::ProfilerState::CUDA)
+  .value("NVTX", torch::autograd::profiler::ProfilerState::NVTX);
+
   m.def("_enable_profiler", torch::autograd::profiler::enableProfiler);
   m.def("_disable_profiler", torch::autograd::profiler::disableProfiler);
 
   m.def("_push_range", [](const char *name) {
     using namespace torch::autograd::profiler;
-    if (!profiling) return;
+    if (state  == ProfilerState::Disabled) return;
     pushRange(name);
   });
   m.def("_pop_range", []() {
     using namespace torch::autograd::profiler;
-    if (!profiling) return;
+    if (state  == ProfilerState::Disabled) return;
     popRange();
   });
 

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -11,8 +11,13 @@
 #include <cstdint>
 #include <string>
 #include <list>
+#include <sstream>
 #include <forward_list>
 #include <tuple>
+#include "ATen/ATen.h"
+#ifdef WITH_CUDA
+#include <cuda_runtime.h>
+#endif
 
 namespace torch { namespace autograd {
 
@@ -24,16 +29,89 @@ constexpr inline std::size_t ceilToMultiple(std::size_t a, std::size_t b) {
   return ((a + b - 1) / b) * b;
 }
 
+inline uint64_t getTime() {
+  using namespace std::chrono;
+  using clock = std::conditional<high_resolution_clock::is_steady, high_resolution_clock, steady_clock>::type;
+  return duration_cast<nanoseconds>(clock::now().time_since_epoch()).count();
+}
+
 enum class EventKind {
   Mark,
   PushRange,
   PopRange
 };
+#ifdef WITH_CUDA
+static void cudaCheck(cudaError_t result, const char * file, int line) {
+  if(result != cudaSuccess) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << cudaGetErrorString(result);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define PROFILER_CUDA_CHECK(result) cudaCheck(result,__FILE__,__LINE__);
+#endif
 
-// NOTE: we don't need a flag saying if an event is a kernel, because it's
-// used only for the CPU-side perf recording.
-using Event = std::tuple<std::string, uint64_t, EventKind>; // (name, time, kind)
+struct Event {
+  Event(EventKind kind, std::string name, uint32_t thread_id, bool record_cuda)
+  : kind_(kind),
+  name_(std::move(name)),
+  thread_id_(thread_id),
+  cpu_ns(getTime()) {
+#ifdef WITH_CUDA
+    if(record_cuda) {
+      PROFILER_CUDA_CHECK(cudaEventCreate(&event));
+      PROFILER_CUDA_CHECK(cudaEventRecord(event, at::globalContext().getCurrentCUDAStream()));
+    }
+#endif
+  }
+  std::string kind() const {
+    switch(kind_) {
+      case EventKind::Mark: return "mark";
+      case EventKind::PushRange: return "push";
+      case EventKind::PopRange: return "pop";
+    }
+    throw std::runtime_error("unknown EventKind");
+  }
+  const std::string & name() const {
+    return name_;
+  }
+  uint32_t thread_id() const {
+    return thread_id_;
+  }
+  double cpu_elapsed_us(const Event & e) {
+    return (e.cpu_ns - cpu_ns)/(1000.0);
+  }
+  double cuda_elapsed_us(const Event & e) {
+#ifdef WITH_CUDA
+    if(!e.has_cuda() || !has_cuda()) {
+      throw std::logic_error("Events were not recorded for CUDA");
+    }
+    PROFILER_CUDA_CHECK(cudaEventSynchronize(event));
+    PROFILER_CUDA_CHECK(cudaEventSynchronize(e.event));
+    float ms;
+    PROFILER_CUDA_CHECK(cudaEventElapsedTime(&ms, event, e.event));
+    return ms*1000.0;
+#else
+    throw std::logic_error("CUDA not enabled");
+#endif
+  }
+  bool has_cuda() const {
+    return event != nullptr;
+  }
 
+private:
+  EventKind kind_;
+  std::string name_;
+  uint32_t thread_id_;
+  uint64_t cpu_ns;
+#ifdef WITH_CUDA
+  cudaEvent_t event = nullptr;
+#endif
+};
+
+// a linked-list of fixed sized vectors, to avoid
+// a std::vector resize from taking a large amount of time inside
+// a profiling  event
 struct RangeEventList {
   constexpr static std::size_t MB = 1024 * 1024;
   constexpr static std::size_t event_block_size = 16 * MB;
@@ -71,59 +149,58 @@ struct RangeEventList {
 };
 
 extern bool profiling;
+extern bool using_nvprof;
 extern bool using_cuda;
+extern uint32_t next_thread_id;
 extern std::mutex all_event_lists_mutex;
 extern std::list<std::shared_ptr<RangeEventList>> all_event_lists;
+
 extern thread_local std::shared_ptr<RangeEventList> event_list;
+extern thread_local int32_t thread_id;
 
 inline RangeEventList& getEventList() {
   if (!event_list) {
     std::lock_guard<std::mutex> guard(all_event_lists_mutex);
     event_list = std::make_shared<RangeEventList>();
+    thread_id = next_thread_id++;
     all_event_lists.emplace_front(event_list);
   }
   return *event_list;
 }
 
-inline uint64_t getTime() {
-  using namespace std::chrono;
-  using clock = std::conditional<high_resolution_clock::is_steady, high_resolution_clock, steady_clock>::type;
-  return duration_cast<nanoseconds>(clock::now().time_since_epoch()).count();
-}
-
 inline void mark(std::string name) {
-  if (using_cuda) {
+  if (using_nvprof) {
 #ifdef WITH_CUDA
     nvtxMarkA(name.c_str());
 #else
-    throw std::logic_error("mark called with use_cuda=True, but compiled without CUDA");
+    throw std::logic_error("mark called with use_nvprof=True, but compiled without CUDA");
 #endif
   } else {
-    getEventList().record(std::move(name), getTime(), EventKind::Mark);
+    getEventList().record(EventKind::Mark, std::move(name), thread_id, using_cuda);
   }
 }
 
 inline void pushRange(std::string name) {
-  if (using_cuda) {
+  if (using_nvprof) {
 #ifdef WITH_CUDA
     nvtxRangePushA(name.c_str());
 #else
-    throw std::logic_error("pushRange called with use_cuda=True, but compiled without CUDA");
+    throw std::logic_error("pushRange called with use_nvprof=True, but compiled without CUDA");
 #endif
   } else {
-    getEventList().record(std::move(name), getTime(), EventKind::PushRange);
+    getEventList().record(EventKind::PushRange, std::move(name), thread_id, using_cuda);
   }
 }
 
 inline void popRange() {
-  if (using_cuda) {
+  if (using_nvprof) {
 #ifdef WITH_CUDA
     nvtxRangePop();
 #else
-    throw std::logic_error("popRange called with use_cuda=True, but compiled without CUDA");
+    throw std::logic_error("popRange called with use_nvprof=True, but compiled without CUDA");
 #endif
   } else {
-    getEventList().record(std::string(), getTime(), EventKind::PopRange);
+    getEventList().record(EventKind::PopRange, std::string(), thread_id, using_cuda);
   }
 }
 
@@ -155,7 +232,7 @@ struct RecordFunction {
 using thread_event_lists = std::vector<std::vector<Event>>;
 // NOTE: changing profiler modes is **NOT THREAD SAFE**. You should ensure that
 // there no autograd functions are being executed when these function are used.
-void enableProfiler(bool use_cuda);
+void enableProfiler(bool use_nvprof, bool use_cuda);
 thread_event_lists disableProfiler();
 
 } // namespace profiler

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -96,7 +96,11 @@ struct Event {
 #endif
   }
   bool has_cuda() const {
+#ifdef WITH_CUDA
     return event != nullptr;
+#else
+    return false;
+#endif
   }
 
 private:

--- a/torch/csrc/cuda/cuda_check.h
+++ b/torch/csrc/cuda/cuda_check.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#ifdef WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+namespace torch {
+// We're using three CUDA APIs, so define a few helpers for error handling
+static inline void nvrtcCheck(nvrtcResult result,const char * file, int line) {
+  if(result != NVRTC_SUCCESS) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << nvrtcGetErrorString(result);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define TORCH_NVRTC_CHECK(result) ::torch::nvrtcCheck(result,__FILE__,__LINE__);
+
+static inline void cuCheck(CUresult result, const char * file, int line) {
+  if(result != CUDA_SUCCESS) {
+    const char * str;
+    cuGetErrorString(result, &str);
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << str;
+    throw std::runtime_error(ss.str());
+  }
+}
+#define TORCH_CU_CHECK(result) ::torch::cuCheck(result,__FILE__,__LINE__);
+
+static inline void cudaCheck(cudaError_t result, const char * file, int line) {
+  if(result != cudaSuccess) {
+    std::stringstream ss;
+    ss << file << ":" << line << ": " << cudaGetErrorString(result);
+    throw std::runtime_error(ss.str());
+  }
+}
+#define TORCH_CUDA_CHECK(result) ::torch::cudaCheck(result,__FILE__,__LINE__);
+
+}
+
+#endif

--- a/torch/csrc/cudnn/Conv.cpp
+++ b/torch/csrc/cudnn/Conv.cpp
@@ -1,5 +1,6 @@
 #include "Conv.h"
 
+#include "torch/csrc/cuda/cuda_check.h"
 #include "THC/THC.h"
 #include "Exceptions.h"
 #include "Types.h"
@@ -98,7 +99,7 @@ BenchmarkCache<cudnnConvolutionBwdFilterAlgo_t> bwd_filter_algos;
 
 struct Workspace {
   Workspace(THCState* state, size_t size) : state(state), size(size), data(NULL) {
-    CUDA_CHECK(THCudaMalloc(state, &data, size));
+    TORCH_CUDA_CHECK(THCudaMalloc(state, &data, size));
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
@@ -453,7 +454,7 @@ void findAlgorithm(
   cache.insert(conv.params, *algo);
 
   THCDeviceAllocator* allocator = THCCachingAllocator_get();
-  CUDA_CHECK(allocator->emptyCache(allocator->state));
+  TORCH_CUDA_CHECK(allocator->emptyCache(allocator->state));
 }
 
 template<typename algo_t>


### PR DESCRIPTION
This adds the ability to record cuda timings using cudaEventRecord
in the profiler. Since it doesn't require nvprof it is easier
to run than the nvprof path.

This also records a thread id for each event, which will make
tracing results easier to understand