### PR TITLE
Implement remaining Variable fallthrough methods via ATen

### DIFF
--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -49,6 +49,10 @@ bool is_same_size(const Tensor& self, const Tensor& other) {
   return self.sizes().equals(other.sizes());
 }
 
+bool is_cuda(const Tensor& self) {
+  return self.type().is_cuda();
+}
+
 Tensor permute(const Tensor& self, IntList dims) {
   auto nDims = self.dim();
   if (dims.size() != (size_t)nDims) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -42,6 +42,8 @@
 
 - func: is_same_size(Tensor self, Tensor other) -> bool
 
+- func: is_cuda(Tensor self) -> bool
+
 - func: permute(Tensor self, IntList dims) -> Tensor
 
 - func: expand(Tensor self, IntList size) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -286,8 +286,7 @@
 
 - name: is_same_size  # fallthrough
 
-- name: is_signed(Tensor self)
-  self: not_differentiable("is_signed")
+- name: is_signed  # fallthrough
 
 - name: is_set_to  # fallthrough
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -286,6 +286,9 @@
 
 - name: is_same_size  # fallthrough
 
+- name: is_signed(Tensor self)
+  self: not_differentiable("is_signed")
+
 - name: is_set_to  # fallthrough
 
 - name: kthvalue(Tensor self, int64_t k, int64_t dim, bool keepdim)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1020,7 +1020,8 @@ def gen_variable_type(declarations, out):
 
         # don't bind size or stride since the python signatures are different
         # exclude alias from Python bindings as well at least for now
-        if name in ['alias', 'size', 'stride'] or name.startswith('clamp'):
+        # exclude 'is_cuda' because for historical reasons it is a property.
+        if name in ['alias', 'size', 'stride', 'is_cuda'] or name.startswith('clamp'):
             return False
 
         if name.endswith('_backward'):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -890,8 +890,9 @@ def create_variable_type(top_env, aten_declarations):
         if skip_function(declaration):
             return
 
-        if declaration.get('derivative') is None and declaration['mode'] == 'native':
-            # native functions without a derivative don't need Type implementations
+        if not is_implemented(declaration) and declaration['mode'] == 'native':
+            # native functionsthat aren't implemented don't need Type implementations
+            # because they should dispatch to implemented functions.
             return
 
         env = {}

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -25,6 +25,11 @@ Tensor not_implemented(const char* name) {
       std::string("the derivative for '") + name + "' is not implemented");
 }
 
+Tensor not_differentiable(const char* name) {
+  throw std::runtime_error(
+      std::string("'") + name + "' is not differentiable");
+}
+
 Tensor maybe_multiply(const Tensor & t, const Scalar & s) {
   bool is_one = false;
   if (s.isFloatingPoint()) {

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -90,6 +90,14 @@ PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* kwargs)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
+{
+   HANDLE_TH_ERRORS
+   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+   return THPUtils_packInt64(self_.dim());
+   END_HANDLE_TH_ERRORS
+}
+
 static Tensor dispatch_contiguous(const Tensor & self) {
   AutoNoGIL no_gil;
   AutoGPU auto_gpu(self);
@@ -154,6 +162,8 @@ PyMethodDef variable_methods[] = {
   {"__mod__", (PyCFunction)THPVariable_remainder, METH_VARARGS | METH_KEYWORDS, NULL},
   {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS, NULL},
   {"clamp_", (PyCFunction)THPVariable_clamp_, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"dim", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
+  {"ndimension", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
   {"contiguous", (PyCFunction)THPVariable_contiguous, METH_NOARGS, NULL},
   {"detach", (PyCFunction)THPVariable_detach, METH_NOARGS, NULL},
   {"detach_", (PyCFunction)THPVariable_detach_, METH_NOARGS, NULL},

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -153,7 +153,7 @@ static PyObject * THPVariable_stride(PyObject* self, PyObject* args, PyObject* k
     // torch.Size and tuple in python
     IntList strides = dispatch_stride(self_);
     THPObjectPtr py_stride(PyTuple_New(strides.size()));
-    for (int i = 0; i != strides.size(); ++i) {
+    for (size_t i = 0; i != strides.size(); ++i) {
       PyTuple_SET_ITEM(py_stride.get(), i, PyLong_FromLong(strides[i]));
     }
     return py_stride.release();

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -9,6 +9,7 @@
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_arg_parser.h"
 #include "torch/csrc/utils/python_numbers.h"
+#include "torch/csrc/utils/python_tuples.h"
 
 #include "python_variable_methods_dispatch.h"
 
@@ -132,11 +133,7 @@ static PyObject * THPVariable_stride(PyObject* self, PyObject* args, PyObject* k
     IntList strides = self_.strides();
     // we can't do the normal wrapping here because IntList maps to both
     // torch.Size and tuple in python
-    THPObjectPtr py_stride(PyTuple_New(strides.size()));
-    for (size_t i = 0; i != strides.size(); ++i) {
-      PyTuple_SET_ITEM(py_stride.get(), i, PyLong_FromLong(strides[i]));
-    }
-    return py_stride.release();
+    return THPUtils_packInt64Array(strides.size(), strides.data());
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -49,8 +49,6 @@ class Variable(_C._VariableBase):
     _fallthrough_methods = {
         'size',
         'stride',
-        'ndimension',
-        'dim',
         'shape'
     }
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -47,8 +47,6 @@ class Variable(_C._VariableBase):
     """
 
     _fallthrough_methods = {
-        'size',
-        'stride',
         'shape'
     }
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -46,9 +46,6 @@ class Variable(_C._VariableBase):
         volatile (bool): Value of the volatile flag. **Keyword only.**
     """
 
-    def __getattr__(self, name):
-        return object.__getattribute__(self, name)
-
     def __getitem__(self, key):
         if torch.is_tensor(key):
             key = Variable(key)  # auto-wrap tensors

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -51,7 +51,6 @@ class Variable(_C._VariableBase):
         'stride',
         'ndimension',
         'dim',
-        'is_cuda',
         'shape'
     }
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -50,7 +50,6 @@ class Variable(_C._VariableBase):
         'size',
         'stride',
         'ndimension',
-        'is_signed',
         'dim',
         'is_cuda',
         'shape'

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -46,13 +46,7 @@ class Variable(_C._VariableBase):
         volatile (bool): Value of the volatile flag. **Keyword only.**
     """
 
-    _fallthrough_methods = {
-        'shape'
-    }
-
     def __getattr__(self, name):
-        if name in self._fallthrough_methods:
-            return getattr(self.data, name)
         return object.__getattribute__(self, name)
 
     def __getitem__(self, key):
@@ -434,7 +428,7 @@ class Variable(_C._VariableBase):
     def __dir__(self):
         variable_methods = dir(self.__class__)
         attrs = list(self.__dict__.keys())
-        keys = variable_methods + attrs + list(self._fallthrough_methods)
+        keys = variable_methods + attrs
         return sorted(keys)
 
     class _torch(object):

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/utils/python_tuples.h"
 #include "THP.h"
 
 PyObject* THPSizeClass = NULL;
@@ -17,9 +18,7 @@ PyObject * THPSize_New(int dim, const int64_t *sizes)
   if (!self) {
     return NULL;
   }
-  for (int i = 0; i < dim; ++i) {
-    PyTuple_SET_ITEM(self, i, PyLong_FromLong(sizes[i]));
-  }
+  THPUtils_packInt64Array(self, dim, sizes);
   return self;
 }
 

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -10,7 +10,7 @@ struct THPSize {
   PyTupleObject tuple;
 };
 
-PyObject * THPSize_New(int dim, int64_t *sizes)
+PyObject * THPSize_New(int dim, const int64_t *sizes)
 {
   PyTypeObject* type = (PyTypeObject*)THPSizeClass;
   PyObject* self = type->tp_alloc(type, dim);

--- a/torch/csrc/Size.h
+++ b/torch/csrc/Size.h
@@ -8,7 +8,7 @@ extern PyObject *THPSizeClass;
 
 #define THPSize_Check(obj) ((PyObject*)Py_TYPE(obj) == THPSizeClass)
 
-PyObject * THPSize_New(int dim, int64_t *sizes);
+PyObject * THPSize_New(int dim, const int64_t *sizes);
 
 #ifdef _THP_CORE
 bool THPSize_init(PyObject *module);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -8,6 +8,7 @@
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
+#include "torch/csrc/autograd/utils/wrap_outputs.h"
 #include "torch/csrc/cuda/AutoGPU.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
@@ -449,6 +450,14 @@ PyObject *THPVariable_get_shape(THPVariable *self)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject *THPVariable_is_cuda(THPVariable *self)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = self->cdata;
+  return torch::autograd::utils::wrap(self_.is_cuda());
+  END_HANDLE_TH_ERRORS
+}
+
 static struct PyGetSetDef THPVariable_properties[] = {
   {"_version", (getter)THPVariable_get_version, NULL, NULL, NULL},
   {"grad_fn", (getter)THPVariable_get_grad_fn, NULL, NULL, NULL},
@@ -464,6 +473,7 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {"_backward_hooks", (getter)THPVariable_get_backwards_hooks, (setter)THPVariable_set_backwards_hooks, NULL, NULL},
   {"name", (getter)THPVariable_get_name, NULL, NULL, NULL},
   {"shape", (getter)THPVariable_get_shape, NULL, NULL, NULL},
+  {"is_cuda", (getter)THPVariable_is_cuda, NULL, NULL, NULL},
   {NULL}
 };
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -12,6 +12,7 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/Exceptions.h"
+#include "torch/csrc/Size.h"
 #include "torch/csrc/autograd/variable.h"
 
 using namespace at;
@@ -439,6 +440,15 @@ PyObject *THPVariable_get_base(THPVariable *self)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject *THPVariable_get_shape(THPVariable *self)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = self->cdata;
+  auto sizes = self_.sizes();
+  return THPSize_New(sizes.size(), (int64_t *)sizes.data());
+  END_HANDLE_TH_ERRORS
+}
+
 static struct PyGetSetDef THPVariable_properties[] = {
   {"_version", (getter)THPVariable_get_version, NULL, NULL, NULL},
   {"grad_fn", (getter)THPVariable_get_grad_fn, NULL, NULL, NULL},
@@ -453,6 +463,7 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {"requires_grad", (getter)THPVariable_get_requires_grad, (setter)THPVariable_set_requires_grad, NULL, NULL},
   {"_backward_hooks", (getter)THPVariable_get_backwards_hooks, (setter)THPVariable_set_backwards_hooks, NULL, NULL},
   {"name", (getter)THPVariable_get_name, NULL, NULL, NULL},
+  {"shape", (getter)THPVariable_get_shape, NULL, NULL, NULL},
   {NULL}
 };
 

--- a/torch/csrc/utils/python_tuples.h
+++ b/torch/csrc/utils/python_tuples.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Python.h>
-#include <sstream>
+#include "torch/csrc/Exceptions.h"
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_numbers.h"
 
@@ -9,9 +9,7 @@ inline void THPUtils_packInt64Array(PyObject *tuple, size_t size, const int64_t 
   for (size_t i = 0; i != size; ++i) {
     PyObject *i64 = THPUtils_packInt64(sizes[i]);
     if (!i64) {
-      std::ostringstream oss;
-      oss << "Could not pack int64 at position " << i;
-      throw std::runtime_error(oss.str());
+      throw python_error();
     }
     PyTuple_SET_ITEM(tuple, i, THPUtils_packInt64(sizes[i]));
   }
@@ -19,6 +17,7 @@ inline void THPUtils_packInt64Array(PyObject *tuple, size_t size, const int64_t 
 
 inline PyObject* THPUtils_packInt64Array(size_t size, const int64_t *sizes) {
   THPObjectPtr tuple(PyTuple_New(size));
+  if (!tuple) throw python_error();
   THPUtils_packInt64Array(tuple.get(), size, sizes);
   return tuple.release();
 }

--- a/torch/csrc/utils/python_tuples.h
+++ b/torch/csrc/utils/python_tuples.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Python.h>
+#include <sstream>
+#include "torch/csrc/utils/object_ptr.h"
+#include "torch/csrc/utils/python_numbers.h"
+
+inline void THPUtils_packInt64Array(PyObject *tuple, size_t size, const int64_t *sizes) {
+  for (size_t i = 0; i != size; ++i) {
+    PyObject *i64 = THPUtils_packInt64(sizes[i]);
+    if (!i64) {
+      std::ostringstream oss;
+      oss << "Could not pack int64 at position " << i;
+      throw std::runtime_error(oss.str());
+    }
+    PyTuple_SET_ITEM(tuple, i, THPUtils_packInt64(sizes[i]));
+  }
+}
+
+inline PyObject* THPUtils_packInt64Array(size_t size, const int64_t *sizes) {
+  THPObjectPtr tuple(PyTuple_New(size));
+  THPUtils_packInt64Array(tuple.get(), size, sizes);
+  return tuple.release();
+}


### PR DESCRIPTION
These are: is_signed, is_cuda (now a native function), dim, ndimension, size, stride, shape (property).