### PR TITLE
print warning and ignore .cuda() if not .cuda.is_available()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -7,6 +7,7 @@ from ..parameter import Parameter
 from torch.autograd import Variable
 import torch.utils.hooks as hooks
 
+import warnings
 
 def _addindent(s_, numSpaces):
     s = s_.split('\n')
@@ -213,6 +214,10 @@ class Module(object):
         Returns:
             Module: self
         """
+        if not torch.cuda.is_available():
+            warnings.warn('.cuda() called but cuda is not available')
+            return self
+
         return self._apply(lambda t: t.cuda(device))
 
     def cpu(self):
@@ -221,6 +226,10 @@ class Module(object):
         Returns:
             Module: self
         """
+        if not torch.cuda.is_available():
+            warnings.warn('.cuda() called but cuda is not available')
+            return self
+
         return self._apply(lambda t: t.cpu())
 
     def type(self, dst_type):


### PR DESCRIPTION
this is a preliminary stab at making .cuda() to fall back to cpu when there's no gpu available. the current implementation prints a warning. 

for a quick test, use 

https://gist.github.com/kyunghyuncho/2448d9705d4eeb17261ddc8e3be5692e

this is related to 

https://github.com/pytorch/pytorch/issues/3600