### PR TITLE
Add Tensor.slice()

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -392,20 +392,6 @@
         - THTensor* value
 ]]
 [[
-  name: narrow
-  cpu_half: True
-  auto_gpu: False
-  return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-    - arg: long dimension
-      wrap_dim: self
-    - long start
-    - long length
-]]
-[[
   name: unfold
   cpu_half: True
   auto_gpu: False
@@ -3957,52 +3943,6 @@
     - cname: newWithTensor
       arguments:
         - THTensor* self
-]]
-
-[[
-  name: select
-  cpu_half: True
-  variants: [method,function]
-  return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-    - arg: int64_t dim
-      wrap_dim: self
-    - int64_t sliceIndex
-  aten_custom_call: |
-    int64_t ndim = self.dim();
-    AT_ASSERT(ndim > 0, "select() cannot be applied to a 0-dim tensor.");
-    if(ndim == 1) {
-      ${THTensor}_narrow(${state,}result_->tensor, self_->tensor, dim, sliceIndex,1);
-      result_->setScalar(true);
-    } else {
-      ${THTensor}_select(${state,}result_->tensor, self_->tensor, dim, sliceIndex);
-    }
-]]
-
-[[
-  name: _unnarrow
-  variants: [method,function]
-  return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-    - arg: int64_t dimension
-      wrap_dim: self
-    - int64_t offset
-    - int64_t dimSize
-  aten_custom_call: |
-    int64_t ndim = self.dim();
-    AT_ASSERT(ndim > 0, "unnarrow() cannot be applied to a 0-dim tensor.");
-    std::vector<int64_t> self_sizes = self.sizes();
-    self_sizes[dimension] = dimSize;
-    auto self_sizes_ = THLongStorageView::makeFromSize(self_sizes);
-    ${THTensor}_zeros(${state,}result_->tensor, self_sizes_);
-    auto narrowed_result = result.narrow(dimension, offset, self.size(dimension));
-    narrowed_result.copy_(self);
 ]]
 
 [[

--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -28,7 +28,9 @@ std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
 }
 
 Tensor slice(const Tensor& self, int64_t start, int64_t end, int64_t step, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim());
+  int64_t ndim = self.dim();
+  AT_ASSERT(ndim > 0, "slice() cannot be applied to a 0-dim tensor.");
+  dim = maybe_wrap_dim(dim, ndim);
   auto sizes = std::vector<int64_t>(self.sizes());
   auto strides = std::vector<int64_t>(self.strides());
   if (step <= 0) {
@@ -59,7 +61,7 @@ Tensor slice(const Tensor& self, int64_t start, int64_t end, int64_t step, int64
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
-  dim = maybe_wrap_dim(dim, self.dim());
+  AT_ASSERT(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   auto cur_size = self.size(dim);
   if (start < 0 || start >= cur_size) {
     runtime_error("start out of range");
@@ -71,7 +73,9 @@ Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
 }
 
 Tensor select(const Tensor& self, int64_t dim, int64_t index) {
-  dim = maybe_wrap_dim(dim, self.dim());
+  int64_t ndim = self.dim();
+  AT_ASSERT(ndim > 0, "select() cannot be applied to a 0-dim tensor.");
+  dim = maybe_wrap_dim(dim, ndim);
   auto size = self.size(dim);
   if (index < -size || index >= size) {
     std::stringstream ss;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -44,6 +44,12 @@
 
 - func: is_cuda(Tensor self) -> bool
 
+- func: select(Tensor self, int64_t dim, int64_t index) -> Tensor
+
+- func: narrow(Tensor self, int64_t dim, int64_t start, int64_t length) -> Tensor
+
+- func: slice(Tensor self, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1, int64_t dim=0) -> Tensor
+
 - func: permute(Tensor self, IntList dims) -> Tensor
 
 - func: expand(Tensor self, IntList size) -> Tensor

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2081,7 +2081,7 @@ method_tests = [
     ('select', (S, S, S), (1, 2), 'dim', [0]),
     ('select', (S,), (0, 2), '1d'),
     ('narrow', (S, S, S), (1, 2, 2), 'dim', [0]),
-    ('_unnarrow', (S, S, S), (0, 2, M), 'dim', [0]),
+    ('slice', (S, S, S), (1, -1, 2, -2)),
     ('squeeze', (S, 1, S, 1), ()),
     ('squeeze', (S, 1, S, 1), (1,), '1_dim', [0]),
     ('squeeze', (S, 1, S, 1), (2,), 'not_1_dim', [0]),
@@ -2225,8 +2225,7 @@ def exclude_tensor_method(name, test_name):
     exclude_all_tensor_method_by_test_name = {
         'test_clamp_min',
         'test_clamp_max',
-        'test__unnarrow_dim',
-        'test__unnarrow_dim_neg0',
+        'test_slice',
     }
     # there are no out-of-place tensor equivalents for these
     exclude_outplace_tensor_method = {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2001,8 +2001,9 @@ class TestTorch(TestCase):
         self.assertEqual(x.slice(0, 4), x)
         # start and stop are clamped to the size of dim
         self.assertEqual(x.slice(0, 5), x)
-        # if start > stop then the result is empty
+        # if start >= stop then the result is empty
         self.assertEqual(x.slice(2, 1), empty)
+        self.assertEqual(x.slice(2, 2), empty)
         # out of bounds is also empty
         self.assertEqual(x.slice(10, 12), empty)
         # additional correctness checks

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1992,6 +1992,25 @@ class TestTorch(TestCase):
         torch.randn(SIZE, SIZE, out=res2)
         self.assertEqual(res1, res2)
 
+    def test_slice(self):
+        # TODO: remove the Variable wrapper once we merge Variable and Tensor
+        from torch.autograd import Variable
+        empty = Variable(torch.Tensor())
+        x = Variable(torch.arange(0, 16).view(4, 4))
+        self.assertEqual(x.slice(), x)
+        self.assertEqual(x.slice(0, 4), x)
+        # start and stop are clamped to the size of dim
+        self.assertEqual(x.slice(0, 5), x)
+        # if start > stop then the result is empty
+        self.assertEqual(x.slice(2, 1), empty)
+        # out of bounds is also empty
+        self.assertEqual(x.slice(10, 12), empty)
+        # additional correctness checks
+        self.assertEqual(x.slice(0, 1).data.tolist(), [[0, 1, 2, 3]])
+        self.assertEqual(x.slice(0, -3).data.tolist(), [[0, 1, 2, 3]])
+        self.assertEqual(x.slice(-2, 3, dim=1).data.tolist(), [[2], [6], [10], [14]])
+        self.assertEqual(x.slice(0, -1, 2).data.tolist(), [[0, 1, 2, 3], [8, 9, 10, 11]])
+
     @skipIfNoLapack
     def test_gesv(self):
         a = torch.Tensor(((6.80, -2.11, 5.66, 5.97, 8.23),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -389,12 +389,6 @@
   self: grad.ger(vec)
   vec: self.t().mv(grad)
 
-- name: narrow(Tensor self, int64_t dimension, int64_t start, int64_t length)
-  self: grad._unnarrow(dimension, start, self.size(dimension))
-
-- name: _unnarrow(Tensor self, int64_t dimension, int64_t offset, int64_t dimSize)
-  self: grad.narrow(dimension, offset, self.size(dimension))
-
 - name: ne(Tensor self, Scalar other)
   self: zeros_like(self)
 
@@ -496,9 +490,6 @@
 - name: scatter_add(Tensor self, int64_t dim, Tensor index, Tensor src)
   self: grad
   src: grad.gather(dim, index)
-
-- name: select(Tensor self, int64_t dim, int64_t sliceIndex)
-  self: maybe_unsqueeze(grad, dim, self.sizes().size() != 1)._unnarrow(dim, sliceIndex, self.size(dim))
 
 - name: set  # fallthrough
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -183,8 +183,8 @@ FALLTHROUGH_FUNCTIONS = {
     '__lshift__', '__or__', '__rshift__', '__xor__',
 }
 VIEW_FUNCTIONS = {
-    'alias', 'as_strided', 'expand', 'narrow', 'permute', 'select', 'squeeze',
-    't', 'transpose', 'unfold', 'unsqueeze', 'view',
+    'alias', 'as_strided', 'expand', 'narrow', 'permute', 'select', 'slice',
+    'squeeze', 't', 'transpose', 'unfold', 'unsqueeze', 'view',
 }
 MANUAL_IMPLEMENTATIONS = {
     'contiguous', 'resize_', 'resize_as_'

--- a/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
@@ -304,7 +304,7 @@ static void tensorSelect(rpc::RPCMessage& raw_message) {
   int dimension = unpackInteger(raw_message);
   int64_t sliceIndex = unpackInteger(raw_message);
   finalize(raw_message);
-  at::select_out(tensor, src, dimension, sliceIndex);
+  tensor = src.select(dimension, sliceIndex);
 }
 
 static void tensorTranspose(rpc::RPCMessage& raw_message) {


### PR DESCRIPTION
```
The slice function is very similar to narrow, except that it takes an
optional "step" argument. Unlike narrow, the arguments use the same
conventions as Python indexing: negative values wrap around and start
and stop are clamped to the size of the Tensor.
```

I will update the ATen indexing code in #3725 to use this for things like `x[::2]`

I was originally going to add `step` to narrow, but it's awkward because the caller has to compute the correct length of the result after the step is applied to the stride. Python-style array slicing is nice because you specify `stop` instead of `length`. The handling of `start` >= `stop` is also nice -- you just end up with an empty tensor, the same as if you index a Python array.