### PR TITLE
CUDA mode profiler fixes

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -418,7 +418,6 @@ def parse_cpu_trace(thread_records):
         cuda_time_0 = cuda_records[cuda_record.device()]
         return cuda_time_0.cuda_elapsed_us(cuda_record) + start_record.cpu_elapsed_us(cuda_time_0)
 
-
     # '__start_profile' is not guarenteed to be first, so we must find it here
     for record in itertools.chain(*thread_records):
         if record.name() == '__start_profile':

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -64,14 +64,13 @@ class EventList(list):
                     pid='CPU functions',
                     args={},
                 ))
-                for name, cuda_interval in evt.kernels:
+                for k in evt.kernels:
                     # 's' and 'f' draw Flow arrows from
                     # the CPU launch to the GPU kernel
                     chrome_events.append(dict(
                         name=evt.name,
                         ph='s',
-                        # +1 microsecond so the arrow is drawn inside cpu block
-                        ts=evt.cpu_interval.start + 1,
+                        ts=evt.cpu_interval.start,
                         tid=evt.thread,
                         pid='CPU functions',
                         id=next_id,
@@ -79,21 +78,21 @@ class EventList(list):
                         args={},
                     ))
                     chrome_events.append(dict(
-                        name=name,
+                        name=k.name,
                         ph='f',
-                        ts=cuda_interval.start,
-                        tid=evt.thread,
+                        ts=k.interval.start,
+                        tid=k.device,
                         pid='CUDA functions',
                         id=next_id,
                         cat='cpu_to_cuda',
                         args={},
                     ))
                     chrome_events.append(dict(
-                        name=evt.name,
+                        name=k.name,
                         ph='X',
-                        ts=cuda_interval.start,
-                        dur=cuda_interval.elapsed_us(),
-                        tid=evt.thread,
+                        ts=k.interval.start,
+                        dur=k.interval.elapsed_us(),
+                        tid=k.device,
                         pid='CUDA functions',
                         args={},
                     ))
@@ -321,6 +320,13 @@ class Interval(object):
         return self.end - self.start
 
 
+class Kernel(object):
+    def __init__(self, name, device, interval):
+        self.name = name
+        self.device = device
+        self.interval = interval
+
+
 # TODO: record TID too
 class FunctionEvent(FormattedTimesMixin):
     """Profiling information about a single function."""
@@ -332,12 +338,12 @@ class FunctionEvent(FormattedTimesMixin):
         self.kernels = []
         self.count = 1
 
-    def append_kernel(self, name, start, end):
-        self.kernels.append((name, Interval(start, end)))
+    def append_kernel(self, name, device, start, end):
+        self.kernels.append(Kernel(name, device, Interval(start, end)))
 
     @property
     def cuda_time_total(self):
-        return sum(kinfo[1].elapsed_us() for kinfo in self.kernels)
+        return sum(kinfo.interval.elapsed_us() for kinfo in self.kernels)
 
     @property
     def cpu_time_total(self):
@@ -397,14 +403,29 @@ class StringTable(defaultdict):
 def parse_cpu_trace(thread_records):
     next_id = 0
     start_record = None
+    cuda_records = {}
     functions = []
     record_stack = []
     string_table = StringTable()
+
+    # cuda start events and the overall profiler start event don't happen
+    # at exactly the same time because we need to record an event on each device
+    # and each record takes ~4us. So we adjust here by the difference
+    # adding the difference in CPU time between the profiler start event
+    # and the CPU time of the cuda start event for the device
+    def adjusted_time(cuda_record):
+        assert cuda_record.device() != -1
+        cuda_time_0 = cuda_records[cuda_record.device()]
+        return cuda_time_0.cuda_elapsed_us(cuda_record) + start_record.cpu_elapsed_us(cuda_time_0)
+
+
     # '__start_profile' is not guarenteed to be first, so we must find it here
     for record in itertools.chain(*thread_records):
         if record.name() == '__start_profile':
             start_record = record
-            break
+        elif record.name() == '__cuda_start_event':
+            assert record.device() != -1
+            cuda_records[record.device()] = record
     assert start_record is not None
 
     for record in itertools.chain(*thread_records):
@@ -421,11 +442,15 @@ def parse_cpu_trace(thread_records):
                 thread=start.thread_id(),
                 cpu_start=start_record.cpu_elapsed_us(start),
                 cpu_end=start_record.cpu_elapsed_us(record))
-            if start_record.has_cuda():
+            if start.has_cuda():
+                cuda_start = adjusted_time(start)
+                cuda_end = adjusted_time(record)
                 fe.append_kernel(start.name(),
-                                 start_record.cuda_elapsed_us(start),
-                                 start_record.cuda_elapsed_us(record))
+                                 start.device(),
+                                 cuda_start,
+                                 cuda_end)
             functions.append(fe)
+
     functions.sort(key=lambda evt: evt.cpu_interval.start)
     return functions
 
@@ -498,6 +523,7 @@ def parse_nvprof_trace(path):
         assert row['cbid'] == 13  # 13 == Launch
         evt = functions_map[row['marker_id']]
         evt.append_kernel(row['kernel_name'],
+                          0,
                           row['kernel_start'],
                           row['kernel_end'])
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -32,6 +32,7 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
   .def("kind",&torch::autograd::profiler::Event::kind)
   .def("name",&torch::autograd::profiler::Event::name)
   .def("thread_id",&torch::autograd::profiler::Event::thread_id)
+  .def("device",&torch::autograd::profiler::Event::device)
   .def("cpu_elapsed_us",&torch::autograd::profiler::Event::cpu_elapsed_us)
   .def("cuda_elapsed_us",&torch::autograd::profiler::Event::cuda_elapsed_us)
   .def("has_cuda",&torch::autograd::profiler::Event::has_cuda);

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -14,6 +14,16 @@ void RecordFunction::pushFunctionRange(Function* fn) {
   pushRange(fn->name());
 }
 
+static void onEachDevice(std::function<void(int)> op) {
+  AutoGPU gpu_guard;
+  int count;
+  TORCH_CUDA_CHECK(cudaGetDeviceCount(&count));
+  for(int i = 0; i < count; i++) {
+    gpu_guard.setDevice(i);
+    op(i);
+  }
+}
+
 void enableProfiler(ProfilerState new_state) {
   TORCH_ASSERT(new_state != ProfilerState::Disabled);
 #ifndef WITH_CUDA
@@ -24,7 +34,27 @@ void enableProfiler(ProfilerState new_state) {
       throw std::runtime_error("can't change kind of profiling (e.g. NVTX to CPU) while profiler is running");
   }
   state = new_state;
-  mark("__start_profile");
+
+#ifdef WITH_CUDA
+  if(state == ProfilerState::CUDA) {
+    // event recording appears to have some startup overhead, so we need to
+    // to generate some dummy events first before recording syncrhonization events
+    for(int i = 0; i < 5; i++) {
+      onEachDevice([](int d) {
+          mark("__cuda_startup");
+          cudaDeviceSynchronize();
+      });
+    }
+
+    // cuda events must be on the same device, so we need a start event recorded
+    // for each gpu. we then use this event to synchronize time on the GPU
+    // with the CPU clock.
+    onEachDevice([](int d) {
+        mark("__cuda_start_event");
+    });
+  }
+#endif
+  mark("__start_profile", false);
 }
 
 thread_event_lists disableProfiler() {

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -14,6 +14,7 @@ void RecordFunction::pushFunctionRange(Function* fn) {
   pushRange(fn->name());
 }
 
+#ifdef WITH_CUDA
 static void onEachDevice(std::function<void(int)> op) {
   AutoGPU gpu_guard;
   int count;
@@ -23,6 +24,7 @@ static void onEachDevice(std::function<void(int)> op) {
     op(i);
   }
 }
+#endif
 
 void enableProfiler(ProfilerState new_state) {
   TORCH_ASSERT(new_state != ProfilerState::Disabled);


### PR DESCRIPTION
* Because we don't have a correlation between CPU time and CUDA time,
we can sometimes end up with cuda timings happening before the CPU time,
which is not possible. So we shift the cuda timings so they do not
violate causality. Future: we should establish a way to sync the
clocks.

* Enable multi-gpu CUDA tracing

We need to record per-device start events because event timing
comparison only works for events on the same device.