### PR TITLE
Move jit test order from beginning to right before multiprocessing.

### DIFF
--- a/test/run_test.bat
+++ b/test/run_test.bat
@@ -2,9 +2,6 @@
 
 set PYCMD=python
 
-echo Running JIT tests
-%PYCMD% test_jit.py
-
 echo Running torch tests
 %PYCMD% test_torch.py
 
@@ -23,6 +20,9 @@ echo Running legacy nn tests
 
 echo Running optim tests
 %PYCMD% test_optim.py
+
+echo Running JIT tests
+%PYCMD% test_jit.py
 
 echo Running multiprocessing tests
 %PYCMD% test_multiprocessing.py

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -20,9 +20,6 @@ fi
 
 pushd "$(dirname "$0")"
 
-echo "Running JIT tests"
-$PYCMD test_jit.py $@
-
 echo "Running torch tests"
 $PYCMD test_torch.py $@
 
@@ -44,6 +41,9 @@ $PYCMD test_legacy_nn.py $@
 
 echo "Running optim tests"
 $PYCMD test_optim.py $@
+
+echo "Running JIT tests"
+$PYCMD test_jit.py $@
 
 echo "Running multiprocessing tests"
 $PYCMD test_multiprocessing.py $@


### PR DESCRIPTION
These fail more frequently than others and block information about whether basic functionality is working or not.