### PR TITLE
add reduce arg to PoissonNLLLoss

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -245,6 +245,10 @@ module_tests = [
     ),
 ]
 
+def poissonnllloss_reference(input, target, log_input=True, full=False, 
+                             size_average=True, eps=1e-8, reduce=True):
+    pass
+
 
 def kldivloss_reference(input, target, size_average=True, reduce=True):
     safe_target = target * (target > 0).type_as(target)
@@ -320,6 +324,7 @@ def smoothl1loss_reference(input, target, size_average=True, reduce=True):
 
 
 loss_reference_fns = {
+    'PoissonNLLLoss': poissonnllloss_reference,
     'KLDivLoss': kldivloss_reference,
     'NLLLoss': nllloss_reference,
     'NLLLoss2d': nllloss2d_reference,

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -245,10 +245,6 @@ module_tests = [
     ),
 ]
 
-def poissonnllloss_reference(input, target, log_input=True, full=False, 
-                             size_average=True, eps=1e-8, reduce=True):
-    pass
-
 
 def kldivloss_reference(input, target, size_average=True, reduce=True):
     safe_target = target * (target > 0).type_as(target)
@@ -324,7 +320,6 @@ def smoothl1loss_reference(input, target, size_average=True, reduce=True):
 
 
 loss_reference_fns = {
-    'PoissonNLLLoss': poissonnllloss_reference,
     'KLDivLoss': kldivloss_reference,
     'NLLLoss': nllloss_reference,
     'NLLLoss2d': nllloss2d_reference,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3728,14 +3728,14 @@ new_criterion_tests = [
         module_name='PoissonNLLLoss',
         input_size=(2, 3, 4, 5),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
-        desc='no_full_loss', # without sterling approx
+        desc='no_full_loss',  # without sterling approx
     ),
     dict(
         module_name='PoissonNLLLoss',
         constructor_args=(False, True, True),
         input_fn=lambda: torch.randn(2, 3, 4, 5).abs_().add_(0.001),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
-        desc='full_loss', # with sterling approx
+        desc='full_loss',  # with sterling approx
     ),
 ]
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3732,7 +3732,7 @@ new_criterion_tests = [
     ),
     dict(
         module_name='PoissonNLLLoss',
-        constructor_args=(False, True, True, 1e-8, True),
+        constructor_args=(False, True, True),
         input_fn=lambda: torch.randn(2, 3, 4, 5).abs_().add_(0.001),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
         desc='full_loss', # with sterling approx

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3747,8 +3747,6 @@ def poissonnllloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.poisson_nll_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.rand(10, 10),
-        reference_fn=lambda i, _:
-            loss_reference_fns['PoissonNLLLoss'](i, t.data.type_as(i), reduce=False),
         pickle=False)
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3728,6 +3728,13 @@ new_criterion_tests = [
         module_name='PoissonNLLLoss',
         input_size=(2, 3, 4, 5),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
+        desc='non_full_loss',
+    ),
+    dict(
+        module_name='PoissonNLLLoss',
+        constructor_args=(True, False, True, 1e-8, False),
+        input_size=(2, 3, 4, 5),
+        target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
         desc='reduced_loss',
     ),
     dict(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3728,23 +3728,28 @@ new_criterion_tests = [
         module_name='PoissonNLLLoss',
         input_size=(2, 3, 4, 5),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
-        desc='non_full_loss',
+        desc='no_full_loss', # without sterling approx
     ),
     dict(
         module_name='PoissonNLLLoss',
-        constructor_args=(True, False, True, 1e-8, False),
-        input_size=(2, 3, 4, 5),
-        target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
-        desc='reduced_loss',
-    ),
-    dict(
-        module_name='PoissonNLLLoss',
-        constructor_args=(False, True, True),
+        constructor_args=(False, True, True, 1e-8, True),
         input_fn=lambda: torch.randn(2, 3, 4, 5).abs_().add_(0.001),
         target_fn=lambda: torch.randn(2, 3, 4, 5).floor_().abs_(),
-        desc='full_loss',
+        desc='full_loss', # with sterling approx
     ),
 ]
+
+
+def poissonnllloss_no_reduce_test():
+    t = Variable(torch.randn(10, 10))
+    return dict(
+        fullname='PoissonNLLLLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.poisson_nll_loss(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.rand(10, 10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['PoissonNLLLoss'](i, t.data.type_as(i), reduce=False),
+        pickle=False)
 
 
 def kldivloss_no_reduce_test():
@@ -3917,6 +3922,7 @@ def smoothl1loss_no_reduce_test():
 
 
 new_module_tests = [
+    poissonnllloss_no_reduce_test(),
     kldivloss_no_reduce_test(),
     l1loss_no_reduce_test(),
     mseloss_no_reduce_test(),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1135,12 +1135,10 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]
     if not reduce:
-      return loss
-    else:
-      if size_average:
-          return torch.mean(loss)
-      else:
-          return torch.sum(loss)
+      return torch.mean(loss, 1)
+    if size_average:
+        return torch.mean(loss)
+    return torch.sum(loss)
 
 
 kl_div = _add_docstr(torch._C._nn.kl_div, r"""

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1103,7 +1103,7 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
         raise ValueError('Expected 2 or 4 dimensions (got {})'.format(dim))
 
 
-def poisson_nll_loss(input, target, log_input=True, full=False, size_average=True, eps=1e-8):
+def poisson_nll_loss(input, target, log_input=True, full=False, size_average=True, eps=1e-8, reduce=True):
     r"""Poisson negative log likelihood loss.
 
     See :class:`~torch.nn.PoissonNLLLoss` for details.
@@ -1122,6 +1122,10 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
             the losses are instead summed for each minibatch. Default: ``True``
         eps (float, optional): Small value to avoid evaluation of log(0) when
             log_input=False. Default: 1e-8
+        reduce (bool, optional): By default, the losses are averaged
+            over observations for each minibatch, or summed, depending on
+            size_average. When reduce is False, returns a loss per batch
+            element instead and ignores size_average. Default: ``True``
     """
     if log_input:
         loss = torch.exp(input) - target * input
@@ -1130,10 +1134,13 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
     if full:
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]
-    if size_average:
-        return torch.mean(loss)
+    if not reduce:
+      return loss
     else:
-        return torch.sum(loss)
+      if size_average:
+          return torch.mean(loss)
+      else:
+          return torch.sum(loss)
 
 
 kl_div = _add_docstr(torch._C._nn.kl_div, r"""

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1135,7 +1135,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]
     if not reduce:
-      return loss
+        return loss
     if size_average:
         return torch.mean(loss)
     return torch.sum(loss)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1135,7 +1135,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
         mask = target > 1
         loss[mask] += (target * torch.log(target) - target + 0.5 * torch.log(2 * math.pi * target))[mask]
     if not reduce:
-      return torch.mean(loss, 1)
+      return loss
     if size_average:
         return torch.mean(loss)
     return torch.sum(loss)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1124,7 +1124,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
             log_input=False. Default: 1e-8
         reduce (bool, optional): By default, the losses are averaged
             over observations for each minibatch, or summed, depending on
-            size_average. When reduce is False, returns a loss per batch
+            size_average. When reduce is ``False``, returns a loss per batch
             element instead and ignores size_average. Default: ``True``
     """
     if log_input:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -230,8 +230,8 @@ class PoissonNLLLoss(_Loss):
 
     def forward(self, log_input, target):
         _assert_no_grad(target)
-        return F.poisson_nll_loss(log_input, target, self.log_input, self.full, 
-            self.size_average, self.eps, self.reduce)
+        return F.poisson_nll_loss(log_input, target, self.log_input, self.full,
+                                  self.size_average, self.eps, self.reduce)
 
 
 class KLDivLoss(_Loss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -208,6 +208,10 @@ class PoissonNLLLoss(_Loss):
             is set to ``False``, the losses are instead summed for each minibatch.
         eps (float, optional): Small value to avoid evaluation of log(0) when
             log_input==``False``. Default: 1e-8
+        reduce (bool, optional): By default, the losses are averaged
+            over observations for each minibatch, or summed, depending on
+            size_average. When reduce is ``False``, returns a loss per batch
+            element instead and ignores size_average. Default: ``True``
 
     Examples::
 
@@ -217,16 +221,17 @@ class PoissonNLLLoss(_Loss):
         >>> output = loss(log_input, target)
         >>> output.backward()
     """
-    def __init__(self, log_input=True, full=False, size_average=True, eps=1e-8):
-        super(PoissonNLLLoss, self).__init__()
+    def __init__(self, log_input=True, full=False, size_average=True, eps=1e-8, reduce=True):
+        super(PoissonNLLLoss, self).__init__(size_average)
         self.log_input = log_input
         self.full = full
-        self.size_average = size_average
         self.eps = eps
+        self.reduce = reduce
 
     def forward(self, log_input, target):
         _assert_no_grad(target)
-        return F.poisson_nll_loss(log_input, target, self.log_input, self.full, self.size_average, self.eps)
+        return F.poisson_nll_loss(log_input, target, self.log_input, self.full, 
+            self.size_average, self.eps, self.reduce)
 
 
 class KLDivLoss(_Loss):


### PR DESCRIPTION
As per #264. When reduce is False, PoissonNLLLoss outputs a loss per element of the input tensor. When reduce is True (default), the current behavior is kept.

This did not require changing any C or CUDA files as PoissonNLLLoss is implemented purely in python.