### PR TITLE
add reduce arg to HingeEmbeddingLoss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1301,12 +1301,12 @@ def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):
     return _functions.loss.MarginRankingLoss.apply(input1, input2, target, margin, size_average)
 
 
-def hinge_embedding_loss(input, target, margin=1.0, size_average=True):
-    """hinge_embedding_loss(input, target, margin=1.0, size_average=True) -> Variable
+def hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True):
+    """hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True) -> Variable
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
     """
-    return _functions.loss.HingeEmbeddingLoss.apply(input, target, margin, size_average)
+    return _functions.loss.HingeEmbeddingLoss.apply(input, target, margin, size_average, reduce)
 
 
 multilabel_margin_loss = _add_docstr(torch._C._nn.multilabel_margin_loss, r"""

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -436,6 +436,7 @@ class HingeEmbeddingLoss(_Loss):
         loss(x, y) = 1/n {
                          { max(0, margin - x_i), if y_i == -1
 
+    `x` and `y` must both be of type (FloatTensor).
     `x` and `y` can be of arbitrary shapes with a total of `n` elements each.
     The sum operation operates over all the elements.
 
@@ -443,15 +444,27 @@ class HingeEmbeddingLoss(_Loss):
     variable `size_average=False`.
 
     The `margin` has a default value of `1`, or can be set in the constructor.
+
+    Args:
+        margin (float): This hyperparameter controls by how much we
+            want the tensor `x`. Default: ``1.0``
+        size_average (bool, optional: By default, the losses are averaged
+            for each minibatch over observations **as well as** over
+            dimensions. However, if ``False`` the losses are instead summed.
+        reduce (bool, optional): By default, the losses are averaged
+            over observations for each minibatch, or summed, depending on
+            size_average. When reduce is ``False``, returns a loss per batch
+            element instead and ignores size_average. Default: ``True``
     """
 
-    def __init__(self, margin=1.0, size_average=True):
-        super(HingeEmbeddingLoss, self).__init__()
+    def __init__(self, margin=1.0, size_average=True, reduce=True):
+        super(HingeEmbeddingLoss, self).__init__(size_average)
         self.margin = margin
-        self.size_average = size_average
+        self.reduce = reduce
 
     def forward(self, input, target):
-        return F.hinge_embedding_loss(input, target, self.margin, self.size_average)
+        return F.hinge_embedding_loss(input, target, self.margin, 
+            self.size_average, self.reduce)
 
 
 class MultiLabelMarginLoss(_Loss):


### PR DESCRIPTION
**EDIT**: There seems to be a mistake in the backwards pass even in the current pytorch version, am currently fixing it. The cause is the following line `grad_input[torch.mul(torch.eq(target, -1), torch.gt(input, ctx.margin))] = 0`

As per #264. When reduce is False, HingeEmbeddingLoss outputs a loss per element of the input tensor. When reduce is True (default), the current behavior is kept.

Small snippet to test forward pass:

```python
reduce = False
margin = 6

a = torch.from_numpy(np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7]]))
b = torch.from_numpy(np.array([[1, 4, 4], [4, 5, 6], [9, 2, 8]]))

a = a.float()
b = b.float()

manhattan = nn.PairwiseDistance(p=1)

x = manhattan(a, b)
y = torch.FloatTensor([-1, 1, 1])

print(nn.HingeEmbeddingLoss(margin, reduce)(x, y))
```