### PR TITLE
fix cuDNN RNN weight tying test

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2276,8 +2276,6 @@ class TestNN(NNTestCase):
 
             with warnings.catch_warnings(record=True) as w:
                 output = rnn(input, hx)
-            self.assertEqual(len(w), 1)
-            self.assertIn('weights are not part of single contiguous chunk of memory', w[0].message.args[0])
             output[0].sum().backward()
 
             opt.step()


### PR DESCRIPTION
Apparently the warnings filter behaves differently on Py2 and Py3 (or maybe CentOS vs Ubuntu, etc.) and while the warnings we check for are in fact thrown on both platforms, they aren't caught on the 2.7 conda build worker. This removes the tests for the warnings and relies solely on the final correctness check. cc @soumith 