### PR TITLE
Fix torch::hash for GCC >=6 and clang

### DIFF
--- a/torch/csrc/utils/hash.h
+++ b/torch/csrc/utils/hash.h
@@ -53,8 +53,8 @@ auto dispatch_hash(const T& o) -> decltype(std::hash<T>()(o), std::size_t()) {
   return std::hash<T>()(o);
 }
 
-#ifndef _MSC_VER
-// MSVC has this one defined already
+#if ! defined(_MSC_VER) && __GNUC__ < 6 && ! defined(__clang__)
+// MSVC, GCC >= 6 and clang have this one defined already
 template<typename T>
 typename std::enable_if<std::is_enum<T>::value, std::size_t>::type dispatch_hash(const T& o) {
   return std::hash<int>()(static_cast<int>(o));


### PR DESCRIPTION
Hi,

this is a follow-up PR for #3756 and #3767. It fixes a compilation on GCC >= 6 and clang, see #3772.

I tested this patch on following Distributions and compilers - so I hope it won't break something:

| Compiler     | Distribution
| ---------------- | -----------------
| GCC 4.9.4    | Ubuntu 16.04
| GCC 5.4.1    | Ubuntu 16.04
| GCC 6.3.0    | Ubuntu 16.04
| GCC 7.2.0    | Arch Linux
| clang 3.8.0  | Ubuntu 16.04
| clang 5.0.0  | Arch Linux

Fixes #3772.