### PR TITLE
flake8 fix

### DIFF
--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -105,7 +105,7 @@ class Bernoulli(Distribution):
 class Categorical(Distribution):
     r"""
     Creates a categorical distribution parameterized by `probs`.
-    
+
     .. note::
         It is equivalent to the distribution that ``multinomial()`` samples from.
 


### PR DESCRIPTION
Hi,

[this build](https://travis-ci.org/pytorch/pytorch/jobs/304105993) failed due to a `flake8` error:

```bash
./torch/distributions.py:108:1: W293 blank line contains whitespace
```

So this PR removes the whitespace.