### PR TITLE
Fix run_test.sh mpiexec failures under virtual python envs

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -98,12 +98,12 @@ distributed_tear_down
 if [ -x "$(command -v mpiexec)" ]; then
   echo "Running distributed tests for the MPI backend"
   distributed_set_up
-  BACKEND=mpi mpiexec -n 3 $PYCMD ./test_distributed.py
+  BACKEND=mpi mpiexec -n 3 --noprefix $PYCMD ./test_distributed.py
   distributed_tear_down
 
   echo "Running distributed tests for the MPI backend with file init_method"
   distributed_set_up
-  BACKEND=mpi INIT_METHOD='file://'$TEMP_DIR'/shared_init_file' mpiexec -n 3 $PYCMD ./test_distributed.py
+  BACKEND=mpi INIT_METHOD='file://'$TEMP_DIR'/shared_init_file' mpiexec -n 3 --noprefix $PYCMD ./test_distributed.py
   distributed_tear_down
 else
   echo "Skipping MPI backend tests (MPI not found)"


### PR DESCRIPTION
If virtual python environment is in use (e.g. conda) and mpiexec was compiled with --enable-mpirun-prefix-by-default option, it will fail in run_test.sh as the path is updated to the prefix and different python (most cases /usr/bin/python) will be used. 
When openmpi is compiled with --enable-mpirun-prefix-by-default option, by default it will set the prefix for the jobs to the --prefix provided during compilation. In cases it is a system package the prefix will point to /usr which will make mpiexec update the path of the new job to /usr/bin:$PATH. This leads to executing wrong version of python when system python is installed and failing the run_test.sh script.
