### PR TITLE
Fix cosine_similarity's output shape

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2895,6 +2895,13 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=0), (input1, input2)))
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
 
+        # Check cosine_similarity input/output shapes
+        input_size = (1, 3, 2, 1)
+        expected_size = (1, 2, 1)
+        input1 = Variable(torch.randn(input_size), requires_grad=True)
+        input2 = Variable(torch.randn(input_size), requires_grad=True)
+        self.assertEqual(F.cosine_similarity(input1, input2, dim=1).size(), expected_size)
+
     def test_grid_sample(self):
         def test_cpu_against_cuda(N, C, H, W, padding_mode):
             def test_shape(N, C, IH, IW, H, W, padding_mode):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1650,7 +1650,7 @@ def cosine_similarity(x1, x2, dim=1, eps=1e-8):
     w12 = torch.sum(x1 * x2, dim)
     w1 = torch.norm(x1, 2, dim)
     w2 = torch.norm(x2, 2, dim)
-    return (w12 / (w1 * w2).clamp(min=eps)).squeeze()
+    return w12 / (w1 * w2).clamp(min=eps)
 
 
 def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, swap=False):


### PR DESCRIPTION
Fixes #3797. 1's in the input size would get squeezed (ie, cosine similarity between two inputs of size (1, 3, 2, 1) would result in an output shape of (2,) instead of (1, 2, 1). This makes it so that those dimensions are not squeezed.

### Test Plan
`python test/test_nn.py TestNN.test_cosine_similarity`