### PR TITLE
Have __sizeof__ account for size of stored elements

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4350,15 +4350,15 @@ class TestTorch(TestCase):
         str(x),
 
     def test_sizeof(self):
-        sizeof_empty = torch.randn(0).__sizeof__()
-        sizeof_10 = torch.randn(10).__sizeof__()
-        sizeof_100 = torch.randn(100).__sizeof__()
+        sizeof_empty = torch.randn(0).storage().__sizeof__()
+        sizeof_10 = torch.randn(10).storage().__sizeof__()
+        sizeof_100 = torch.randn(100).storage().__sizeof__()
         self.assertEqual((sizeof_100 - sizeof_empty) // (sizeof_10 - sizeof_empty), 10)
         self.assertEqual((sizeof_100 - sizeof_empty) % (sizeof_10 - sizeof_empty), 0)
 
-        sizeof_empty = torch.randn(0).type(torch.ByteTensor).__sizeof__()
-        sizeof_10 = torch.randn(10).type(torch.ByteTensor).__sizeof__()
-        sizeof_100 = torch.randn(100).type(torch.ByteTensor).__sizeof__()
+        sizeof_empty = torch.randn(0).type(torch.ByteTensor).storage().__sizeof__()
+        sizeof_10 = torch.randn(10).type(torch.ByteTensor).storage().__sizeof__()
+        sizeof_100 = torch.randn(100).type(torch.ByteTensor).storage().__sizeof__()
         self.assertEqual((sizeof_100 - sizeof_empty) // (sizeof_10 - sizeof_empty), 10)
         self.assertEqual((sizeof_100 - sizeof_empty) % (sizeof_10 - sizeof_empty), 0)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4349,6 +4349,19 @@ class TestTorch(TestCase):
         x.__repr__()
         str(x),
 
+    def test_sizeof(self):
+        sizeof_empty = torch.randn(0).__sizeof__()
+        sizeof_10 = torch.randn(10).__sizeof__()
+        sizeof_100 = torch.randn(100).__sizeof__()
+        self.assertEqual((sizeof_100 - sizeof_empty) // (sizeof_10 - sizeof_empty), 10)
+        self.assertEqual((sizeof_100 - sizeof_empty) % (sizeof_10 - sizeof_empty), 0)
+
+        sizeof_empty = torch.randn(0).type(torch.ByteTensor).__sizeof__()
+        sizeof_10 = torch.randn(10).type(torch.ByteTensor).__sizeof__()
+        sizeof_100 = torch.randn(100).type(torch.ByteTensor).__sizeof__()
+        self.assertEqual((sizeof_100 - sizeof_empty) // (sizeof_10 - sizeof_empty), 10)
+        self.assertEqual((sizeof_100 - sizeof_empty) % (sizeof_10 - sizeof_empty), 0)
+
     def test_unsqueeze(self):
         x = torch.randn(2, 3, 4)
         y = x.unsqueeze(1)

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -30,6 +30,9 @@ class _StorageBase(object):
     def __reduce__(self):
         return type(self), (self.tolist(),)
 
+    def __sizeof__(self):
+        return super(_StorageBase, self).__sizeof__() + self.element_size() * self.size()
+
     def clone(self):
         """Returns a copy of this storage"""
         return type(self)(self.size()).copy_(self)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -120,9 +120,6 @@ class _TensorBase(object):
         args = self.__getstate__()
         return (_rebuild_tensor, args)
 
-    def __sizeof__(self):
-        return super(_TensorBase, self).__sizeof__() + self.storage().__sizeof__()
-
     def __getstate__(self):
         return (self.storage(),
                 self.storage_offset(),

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -120,6 +120,9 @@ class _TensorBase(object):
         args = self.__getstate__()
         return (_rebuild_tensor, args)
 
+    def __sizeof__(self):
+        return super(_TensorBase, self).__sizeof__() + self.storage().__sizeof__()
+
     def __getstate__(self):
         return (self.storage(),
                 self.storage_offset(),


### PR DESCRIPTION
This PR addresses #3655.

`__sizeof__` now accounts for the size of data in `Tensor` as well as `Storage`:
```
s0 = torch.randn(0).__sizeof__()           # 80L
s10 = torch.randn(10).__sizeof__()        # 120L
s100 = torch.randn(100).__sizeof__()   # 480L
(s100 - s0) / (s10 - s0)                          # 10

s0 = torch.randn(0).storage().__sizeof__()           # 40L
s10 = torch.randn(10).storage().__sizeof__()        # 80L
s100 = torch.randn(100).storage().__sizeof__()   # 440L
(s100 - s0) / (s10 - s0)                                          # 10
```

Note that the reported size is indicative: it only accounts for the size of the data and disregards other attributes (e.g. `Size`).