### PR TITLE
Fix MultiLabelMarginLoss docs

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -467,7 +467,7 @@ class MultiLabelMarginLoss(_Loss):
 
     `y` and `x` must have the same size.
 
-    The criterion only considers the first non zero `y[j]` targets.
+    The criterion only considers the first non-negative `y[j]` targets.
 
     This allows for different samples to have variable amounts of target classes
     """


### PR DESCRIPTION
Fixes #3796.

The following line hasn't been changed from the (lua) torch days. In pytorch tensors are now zero-indexed instead of one-indexed. I've verified that in the [source code](https://github.com/pytorch/pytorch/blob/fd7bfaf4e411ebb3d0aba371e7d39d22debf00a8/aten/src/THNN/generic/MultiLabelMarginCriterion.c#L57), negative values target values are ignored.