### PR TITLE
Fix padding_idx getting ignored in backward for Embedding(sparse=True)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -939,6 +939,12 @@ class TestNN(NNTestCase):
         self.assertEqual(output[0][0].sum().data[0], 0)
         self.assertEqual(output[1][2].sum().data[0], 0)
 
+        embedding = nn.Embedding(10, 20, padding_idx=0, sparse=True)
+        input = Variable(torch.LongTensor([[0, 2, 4, 5], [4, 3, 0, 9]]))
+        output = embedding(input)
+        self.assertEqual(output[0][0].sum().data[0], 0)
+        self.assertEqual(output[1][2].sum().data[0], 0)
+
     def test_embedding_max_norm(self):
         embedding = nn.Embedding(22, 5, max_norm=1.0)
         input = Variable(torch.LongTensor([2, 8, 8, 6]))

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -103,9 +103,16 @@ class Embedding(Function):
                 SparseTensor = getattr(torch.cuda.sparse, tensor_type)
             else:
                 SparseTensor = getattr(torch.sparse, tensor_type)
+            padding_idx = ctx.padding_idx
+            indices = indices.view(1, -1)
+            grad_output = grad_output.view(-1, ctx._weight_size[1])
+            if padding_idx is not None:
+                nonpadding_indices_indices = (indices.view(-1) != padding_idx).nonzero().view(-1)
+                indices = indices.index_select(1, nonpadding_indices_indices)
+                grad_output = grad_output.index_select(0, nonpadding_indices_indices)
             grad_weight = SparseTensor(
-                indices.view(1, -1),
-                grad_output.view(-1, ctx._weight_size[1]),
+                indices,
+                grad_output,
                 ctx._weight_size,
             )
         return None, grad_weight, None, None, None, None, None


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/3506

Verified that gradients are identical for sparse and dense in `Embedding(padding_idx=(not None), sparse=True)` with same weight matrix.