### PR TITLE
Fix CharType min and max values

### DIFF
--- a/aten/src/TH/THGenerateCharType.h
+++ b/aten/src/TH/THGenerateCharType.h
@@ -6,7 +6,7 @@
 #define ureal uint8_t
 #define accreal int64_t
 #define Real Char
-#define THInf CHAR_MAX
+#define THInf 127
 #define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
 #define TH_CONVERT_ACCREAL_TO_REAL(_val) (real)(_val)
 #define TH_REAL_IS_CHAR

--- a/aten/src/TH/THGenerateCharType.h
+++ b/aten/src/TH/THGenerateCharType.h
@@ -6,7 +6,7 @@
 #define ureal uint8_t
 #define accreal int64_t
 #define Real Char
-#define THInf 127
+#define THInf SCHAR_MAX 
 #define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
 #define TH_CONVERT_ACCREAL_TO_REAL(_val) (real)(_val)
 #define TH_REAL_IS_CHAR

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -34,8 +34,8 @@ struct THCNumerics<uint8_t> {
 
 template <>
 struct THCNumerics<int8_t> {
-  static inline __host__ __device__ int8_t min() { return CHAR_MIN; }
-  static inline __host__ __device__ int8_t max() { return CHAR_MAX; }
+  static inline __host__ __device__ int8_t min() { return -128; }
+  static inline __host__ __device__ int8_t max() { return 127; }
 
   static inline __host__ __device__ bool lt(int8_t a, int8_t b) { return a < b; }
   static inline __host__ __device__ bool le(int8_t a, int8_t b) { return a <= b; }

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -34,8 +34,8 @@ struct THCNumerics<uint8_t> {
 
 template <>
 struct THCNumerics<int8_t> {
-  static inline __host__ __device__ int8_t min() { return -128; }
-  static inline __host__ __device__ int8_t max() { return 127; }
+  static inline __host__ __device__ int8_t min() { return SCHAR_MIN; }
+  static inline __host__ __device__ int8_t max() { return SCHAR_MAX; }
 
   static inline __host__ __device__ bool lt(int8_t a, int8_t b) { return a < b; }
   static inline __host__ __device__ bool le(int8_t a, int8_t b) { return a <= b; }

--- a/torch/lib/THD/base/THDGenerateAllTypes.h
+++ b/torch/lib/THD/base/THDGenerateAllTypes.h
@@ -18,7 +18,7 @@
 #define real int8_t
 #define accreal int64_t
 #define Real Char
-#define THDInf 127
+#define THDInf SCHAR_MAX
 #define THD_REAL_IS_CHAR
 #line 1 THD_GENERIC_FILE
 #include THD_GENERIC_FILE

--- a/torch/lib/THD/base/THDGenerateAllTypes.h
+++ b/torch/lib/THD/base/THDGenerateAllTypes.h
@@ -18,7 +18,7 @@
 #define real int8_t
 #define accreal int64_t
 #define Real Char
-#define THDInf CHAR_MAX
+#define THDInf 127
 #define THD_REAL_IS_CHAR
 #line 1 THD_GENERIC_FILE
 #include THD_GENERIC_FILE


### PR DESCRIPTION
CharType is int8_t and this is not same as char. CHAR_MIN and CHAR_MAX cannot be used reliably to specify min and max values for int8_t. Using CHAR_MIN/MAX breaks some functions when used on a platform where the char type is unsigned (0-255 value) such as PowerPC and ARM. 
