### PR TITLE
Fix void* wrapping in autograd codegen

### DIFF
--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -54,6 +54,10 @@ inline PyObject* wrap(int64_t value) {
   return THPUtils_packInt64(value);
 }
 
+inline PyObject* wrap(void* value) {
+  return THPUtils_packInt64(reinterpret_cast<intptr_t>(value));
+}
+
 inline PyObject* wrap(at::Scalar scalar) {
   return wrap(scalar.toTensor());
 }


### PR DESCRIPTION
The real reason for this PR is this:

before:

```python
>>> Variable(torch.randn(5, 5)).data_ptr()
True
```

after:

```python
>>> Variable(torch.randn(5, 5)).data_ptr()
31109648
```

It used to work because `void*` would get implicitly casted to a `bool` when searching for an overload of `wrap`. This commit fixes this and adds a bunch of assertions to make sure this won't happen again. I can't think of any way to make argument implicit conversion a build failure in C++.