### PR TITLE
Remove as much of Python from JIT hot path as possible

### DIFF
--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -386,6 +386,7 @@ struct CrossStageStateDesc {
     for (auto output : graph->outputs())
       stage_outputs[output->stage()].push_back(output);
 
+    JIT_ASSERT(stage_begins.size() == graph->stage() + 2);
     JIT_ASSERT(prev_stage_inputs.front().empty());
     JIT_ASSERT(cur_stage_captures.back().empty());
   }

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -44,11 +44,19 @@ struct IODescriptor {
     return get_hash(o.structure, o.metadata);
   }
 
+  void extend(const autograd::variable_list& list) {
+    metadata.reserve(metadata.size() + list.size());
+    for (auto & var : list)
+      metadata.emplace_back(var);
+  }
+
   // Description of argument structure. Variables are replaced with
   // different characters, depending on their flags, beginnings and
   // ends of tuples and lists are denoted by a pair of parenthesis
   // of their corresponding kind. They should always be paired.
   // Example desc: (vv[v(v)v])
+  // NOTE: if extend() was ever called then metadata.size() can be
+  // different than the number of 'v's in structure.
   std::string structure;
   std::vector<VariableMetadata> metadata;
 };
@@ -61,6 +69,14 @@ struct ParsedArgs {
   IODescriptor desc;
   // True iff any of vars is volatile
   bool is_volatile = false;
+
+  void extend(const autograd::variable_list& list) {
+    if (list.empty()) return;
+    vars.reserve(vars.size() + list.size());
+    for (auto & var : list)
+      vars.emplace_back(var);
+    desc.extend(list);
+  }
 };
 
 

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -28,17 +28,6 @@ py::object steal(py::handle x) {
   return py::reinterpret_steal<py::object>(x);
 }
 
-py::object borrow(py::handle x) {
-  return py::reinterpret_borrow<py::object>(x);
-}
-
-py::object makePair(py::handle a, py::handle b) {
-  py::tuple result(2);
-  result[0] = borrow(a);
-  result[1] = borrow(b);
-  return result;
-}
-
 } // anonymous namespace
 
 // Lifecycle of a CompiledFunction:
@@ -102,23 +91,23 @@ struct CompiledFunction {
       return true;
     }
 
-    variable_list run(const variable_list& in_vars) {
+    variable_list run(variable_list inputs) {
       JIT_ASSERT(is_ready_);
       AutoNoGIL _gil_guard;
       if (closure_) {
         auto fn = closure_->construct();
-        return (*fn)(in_vars);
+        return (*fn)(inputs);
       } else {
         auto fn = factory_->construct();
         fn->willReleaseVariables(); // forward pass is never reused, so it is safe to release anything it can
-        return fn->apply(in_vars);
+        return fn->apply(inputs);
       }
     }
 
-    PyObject* add_trace(PyObject *args, const variable_list& in_vars) {
+    PyObject* add_trace(PyObject *args, variable_list inputs) {
       JIT_ASSERT(!is_ready_);
       // Start tracing
-      auto trace = tracer::enter(fmap<TraceInput>(in_vars), is_volatile_ ? 1 : (fn_.nderivs_ + 1));
+      auto trace = tracer::enter(fmap<TraceInput>(inputs), is_volatile_ ? 1 : (fn_.nderivs_ + 1));
 
       // Call back into Python function
       auto out = PyObject_CallObject(fn_.function_.get(), args);
@@ -158,21 +147,27 @@ struct CompiledFunction {
     return it->second;
   }
 
-  py::object call(py::handle pyargs, py::handle pyparams) {
+  ParsedArgs flattenArgs(py::handle pyargs) {
+    auto args = flatten(pyargs);
+    // We need to take captured_var types into account when choosing the trace
+    args.extend(captured_vars_);
+    return args;
+  }
+
+  py::object call(py::handle pyargs) {
     if (!enabled_) {
       return steal(PyObject_CallObject(function_.get(), pyargs.ptr()));
     }
-    auto all_pyargs = makePair(pyargs, pyparams);
-    auto args = flatten(all_pyargs);
+    auto args = flattenArgs(pyargs);
     auto& ktrace = getTrace(args);
 
     variable_list out_vars;
     if (ktrace.ready()) {
       hits_++;
-      return steal(unflatten(ktrace.run(args.vars), ktrace.out_desc_));
+      return steal(unflatten(ktrace.run(std::move(args.vars)), ktrace.out_desc_));
     } else {
       misses_++;
-      return steal(ktrace.add_trace(pyargs.ptr(), args.vars));
+      return steal(ktrace.add_trace(pyargs.ptr(), std::move(args.vars)));
     }
   }
 
@@ -180,15 +175,16 @@ struct CompiledFunction {
     ktraces_.clear();
   }
 
-  CompiledFunction(int nderivs, bool optimize, py::object function,
+  CompiledFunction(int nderivs, bool optimize, bool enabled, py::object function,
                    std::string name)
     : nderivs_(nderivs)
     , optimize_(optimize)
-    , enabled_(true)
+    , enabled_(enabled)
     , hits_(0)
     , misses_(0)
     , function_(function.release().ptr())
     , name_(std::move(name))
+    , captured_vars_()
     , ktraces_() {}
 
   int nderivs_;
@@ -198,16 +194,15 @@ struct CompiledFunction {
   std::atomic<uint64_t> misses_;
   THPObjectPtr function_;
   std::string name_;
+  variable_list captured_vars_;
   std::unordered_map<IODescriptor, TraceForKey, torch::hash<IODescriptor>> ktraces_;
 };
 
 namespace {
 
 CompiledFunction::TraceForKey* getTraceFor(CompiledFunction& fn,
-                                           py::handle pyargs,
-                                           py::handle pyparams) {
-  auto all_pyargs = makePair(pyargs, pyparams);
-  auto args = flatten(all_pyargs);
+                                           py::handle pyargs) {
+  auto args = fn.flattenArgs(pyargs);
   auto it = fn.ktraces_.find(args.desc);
   if (it == fn.ktraces_.end())
     return nullptr;
@@ -218,20 +213,23 @@ CompiledFunction::TraceForKey* getTraceFor(CompiledFunction& fn,
 
 void initCompilerMixin(PyObject *module) {
   auto m = py::handle(module).cast<py::module>();
-  py::class_<CompiledFunction>(m, "CompiledFunction")
-    .def(py::init<int, bool, py::object, std::string>())
-    .def("__call__", [](CompiledFunction& fn, py::handle args, py::handle parameters) -> py::object {
-      return fn.call(args, parameters);
+  py::class_<CompiledFunction>(m, "CompiledFunction", py::dynamic_attr())
+    .def(py::init<int, bool, bool, py::object, std::string>())
+    .def("__call__", [](CompiledFunction& fn, py::args args) -> py::object {
+      return fn.call(args);
     })
-    .def("has_trace_for", [](CompiledFunction& fn, py::handle args, py::handle parameters) -> bool {
-      return getTraceFor(fn, args, parameters) != nullptr;
+    .def("has_trace_for", [](CompiledFunction& fn, py::args args) -> bool {
+      return getTraceFor(fn, args) != nullptr;
     })
-    .def("graph_for", [](CompiledFunction& fn, py::handle pyargs, py::handle pyparameters) -> py::object {
-      auto trace = getTraceFor(fn, pyargs, pyparameters);
+    .def("graph_for", [](CompiledFunction& fn, py::args args) -> py::object {
+      auto trace = getTraceFor(fn, args);
       return trace ? py::cast(trace->graph_) : py::none();
     })
     .def("clear_cache", [](CompiledFunction& fn) {
       fn.clearCache();
+    })
+    .def("set_captured_vars", [](CompiledFunction& fn, variable_list vars) {
+      fn.captured_vars_ = std::move(vars);
     })
     .def_property_readonly("hits", [](CompiledFunction& fn) {
       return fn.hits_.load();

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -4,7 +4,8 @@ from torch import Tensor
 from torch.autograd import Variable
 from torch.nn import Module, ParameterList, Parameter
 from torch._six import raise_from
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
+import sys
 import warnings
 import itertools
 import types
@@ -109,32 +110,6 @@ def compile(arg=None, nderivs=1, optimize=True, enabled=True):
     """
     def _compile(arg):
         if inspect.isclass(arg):
-            class CompiledModuleMeta(type):
-                def __call__(cls, *args, **kwargs):
-                    # NOTE: this is called whenever an instance of this class is created
-                    # The super call below will call __new__ and __init__, and we will
-                    # patch things later.
-                    try:
-                        obj = super(CompiledModuleMeta, cls).__call__(*args, **kwargs)
-                    except TypeError as e:
-                        # If this fails here, the user probably didn't use this as a class decorator
-                        if "super" in str(e):
-                            raise_from(TypeError("torch.jit.compile must be used as a class decorator; "
-                                                 "using it on an already defined class is not valid."
-                                                 "\n\nOriginal error: {}".format(str(e))), e)
-                        else:
-                            raise
-
-                    compiled_fn = torch._C.CompiledFunction(nderivs, optimize,
-                                                            obj.forward,
-                                                            arg.__name__)
-                    compiled_fn.enabled = enabled
-                    obj.compiled_fn = compiled_fn
-                    obj.forward = lambda *args: compiled_fn(args, list(obj.parameters()))
-                    obj.has_trace_for = lambda *args: compiled_fn.has_trace_for(args, list(obj.parameters()))
-                    obj.graph_for = lambda *args: compiled_fn.graph_for(args, list(obj.parameters()))
-                    return obj
-
             # NB: It might seem natural to create a subclass here, rather than
             # make a copy of the class to insert the mixin.  Unfortunately, this
             # will break many user classes.  Suppose you have:
@@ -155,9 +130,43 @@ def compile(arg=None, nderivs=1, optimize=True, enabled=True):
             # user passed in), this problem goes away, because the class
             # __init__ is a part of is indeed Foo.
 
+            old_init = arg.__init__
+            # Python 2 has a concept of unbound methods, which are returned when
+            # you take a method form a class. They behave just like regular functions,
+            # but check the type of the first argument (self). We don't want this here,
+            # because self in our __init__ will be an instance of this new class.
+            # Python 3 already returns a plain function, so nothing has to be done.
+            if sys.version_info[0] == 2:
+                old_init = old_init.im_func
+
+            def __init__(self, *args, **kwargs):
+                torch._C.CompiledFunction.__init__(self,
+                                                   nderivs, optimize, enabled,
+                                                   self.forward,
+                                                   arg.__name__)
+                try:
+                    old_init(self, *args, **kwargs)
+                except TypeError as e:
+                    # If this fails here, the user probably didn't use this as a class decorator
+                    if "super" in str(e):
+                        raise_from(TypeError("torch.jit.compile must be used as a class decorator; "
+                                             "using it on an already defined class is not valid."
+                                             "\n\nOriginal error: {}".format(str(e))), e)
+                    else:
+                        raise
+                # NOTE: This can't be done in CompiledFunction constructor,
+                # because self.parameters() isn't well defined by then
+                # (Module constructor hasn't run yet).
+                self.set_captured_vars(list(self.parameters()))
+
+            new_dict = dict(arg.__dict__)
+            new_dict['__init__'] = __init__
+            new_dict['__call__'] = torch._C.CompiledFunction.__call__
+            # NOTE: we don't need to override casting methods, because we only capture
+            # parameters, and they mutate their data in-place.
             return type(arg.__name__,
-                        (torch._six.with_metaclass(CompiledModuleMeta, *arg.__bases__),),
-                        dict(arg.__dict__))
+                        arg.__bases__ + (torch._C.CompiledFunction,),
+                        new_dict)
         elif isinstance(arg, Module):
             # It requires work to compile module instances, because you would
             # like the resulting compiled module to look just like the uncompiled
@@ -166,8 +175,9 @@ def compile(arg=None, nderivs=1, optimize=True, enabled=True):
             raise TypeError("Compiling model instances is not supported.  "
                             "Use @torch.jit.compile on a class instead.")
         elif callable(arg):
-            module = type(arg.__name__, (torch.nn.Module,), {'forward': lambda self, *args: arg(*args)})
-            return _compile(module)()
+            compiled_fn = torch._C.CompiledFunction(nderivs, optimize, enabled,
+                                                    arg, arg.__name__)
+            return compiled_fn
         else:
             raise TypeError("Cannot handle arg with type {}".format(type(arg)))
     # Make empty parenthesis optional
@@ -325,19 +335,22 @@ def verify(model, args, loss_fn=torch.sum, devices=None):
 
     # TODO: Consider adding a utility function to torch.jit to test
     # for this case
-    if not hasattr(model, 'compiled_fn') or not isinstance(model.compiled_fn, torch._C.CompiledFunction):
+    if not isinstance(model, torch._C.CompiledFunction):
         raise TypeError("Cannot verify an uncompiled module.  Add @torch.jit.compile to compile it")
+    is_module = isinstance(model, Module)
 
     if not isinstance(args, tuple):
         args = (args,)
 
     saved_args = _clone_inputs(args)
-    saved_state = copy.deepcopy(model.state_dict())
+    if is_module:
+        saved_state = copy.deepcopy(model.state_dict())
 
     def run_fwd_bwd(args, force_trace=False, assert_compiled=False):
-        in_vars = _flatten((args, list(model.parameters())))
+        params = list(model.parameters()) if is_module else []
+        in_vars = _flatten((args, params))
         # We use a special API to reset the trace and compile it from scratch.
-        compiled_fn = model.compiled_fn
+        compiled_fn = model
         if force_trace:
             compiled_fn.clear_cache()
         if assert_compiled:
@@ -362,7 +375,8 @@ def verify(model, args, loss_fn=torch.sum, devices=None):
         uncompiled_outs, uncompiled_grads = run_fwd_bwd(args, force_trace=True)
         assert model.has_trace_for(*args)
 
-    model.load_state_dict(saved_state)
+    if is_module:
+        model.load_state_dict(saved_state)
     compiled_outs, compiled_grads = run_fwd_bwd(args, assert_compiled=True)
 
     _verify_equal(uncompiled_outs, compiled_outs)


### PR DESCRIPTION
This patch reduces the amount of Python code we have to hit when actually calling JIT-compiled modules or functions to 0, bringing some nice speedups.

Time for single application of a JIT-fused LSTM cell in a loop for 512 steps (forward only - with autograd enabled):
- before - 35us
- after - 26us
- cuDNN (nn.LSTM) - 28us?? The possible reasons for this might be that the JIT cell was specialized to never run backward, so it can save a bunch of memory bandwidth, or I did sth wrong in my benchmarking script). However, cuDNN is the only one of these which is not CPU-bound (only 15us on CPU).