### PR TITLE
Pad sequences and Pack sequences

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -686,6 +686,18 @@ Utilities
 .. autofunction:: torch.nn.utils.rnn.pad_packed_sequence
 
 
+:hidden:`pad_sequence`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.utils.rnn.pad_sequence
+
+
+:hidden:`pack_sequence`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.utils.rnn.pack_sequence
+
+
 torch.nn.functional
 ===================
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2166,14 +2166,14 @@ class TestNN(NNTestCase):
 
     def test_pad_sequence(self):
         def pad(tensor, length):
-            return torch.cat([tensor, tensor.new(length - tensor.size(0), *tensor.size()[1:]).zero_()])
+            return torch.cat([tensor.data, tensor.data.new(length - tensor.size(0), *tensor.size()[1:]).zero_()])
         # single dimensional
-        a = torch.Tensor([1,2,3])
-        b = torch.Tensor([4,5])
-        c = torch.Tensor([6])
+        a = Variable(torch.Tensor([1,2,3]))
+        b = Variable(torch.Tensor([4,5]))
+        c = Variable(torch.Tensor([6]))
         
         # batch_first = true
-        expected = torch.Tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]])
+        expected = Variable(torch.Tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]]))
         padded = rnn_utils.pad_sequence([a, b, c], [3, 2, 1], True)
         self.assertEqual(padded, expected)
 
@@ -2188,18 +2188,52 @@ class TestNN(NNTestCase):
         for i in reversed(range(maxlen + 1)[1:]):
             seq_len = i * i
             lengths.append(seq_len)
-            sequences.append(torch.rand(seq_len, 400))
+            sequences.append(Variable(torch.rand(seq_len, 400)))
         expected = []
         for seq in sequences:
             expected.append(pad(seq, maxlen * maxlen))
         # batch first = true
-        expected = torch.stack(expected)
+        expected = Variable(torch.stack(expected))
         padded = rnn_utils.pad_sequence(sequences, lengths, True)
         self.assertEqual(padded, expected)
 
         # batch first = false
         padded = rnn_utils.pad_sequence(sequences, lengths)
         self.assertEqual(padded, expected.transpose(0, 1))
+
+    def test_pack_sequence(self):
+        # single dimensional
+        a = Variable(torch.Tensor([1,2,3]))
+        b = Variable(torch.Tensor([4,5]))
+        c = Variable(torch.Tensor([6]))
+        packed = rnn_utils.pack_sequence([a, b, c], [3, 2, 1])
+        expected = torch.Tensor([1, 4, 6, 2, 5, 3])
+        self.assertEqual(packed.batch_sizes, [3, 2, 1])
+        self.assertEqual(packed.data.data, expected)
+
+        # more dimensions
+        ####################################
+        sequences = []
+        lengths = []
+        maxlen = 9
+        for i in reversed(range(maxlen + 1)[1:]):
+            seq_len = i * i
+            lengths.append(seq_len)
+            sequences.append(Variable(torch.rand(seq_len, 400)))
+        
+        # compatibility with other utilities
+        batch_first = True
+        padded = rnn_utils.pad_sequence(sequences, lengths, batch_first)
+        packed = rnn_utils.pack_sequence(sequences, lengths)
+        unpacked = rnn_utils.pad_packed_sequence(packed, batch_first)
+        self.assertEqual(padded, unpacked[0])
+
+        batch_first = False
+        padded = rnn_utils.pad_sequence(sequences, lengths, batch_first)
+        packed = rnn_utils.pack_sequence(sequences, lengths)
+        unpacked = rnn_utils.pad_packed_sequence(packed, batch_first)
+        self.assertEqual(padded, unpacked[0])
+        #####################################
 
     def test_pack_padded_sequence(self):
         def pad(tensor, length):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2166,12 +2166,14 @@ class TestNN(NNTestCase):
 
     def test_pad_sequence(self):
         def pad(tensor, length):
-            return torch.cat([tensor.data, tensor.data.new(length - tensor.size(0), *tensor.size()[1:]).zero_()])
+            return torch.cat(
+                [tensor.data, tensor.data.new(
+                    length - tensor.size(0), *tensor.size()[1:]).zero_()])
         # single dimensional
-        a = Variable(torch.Tensor([1,2,3]))
-        b = Variable(torch.Tensor([4,5]))
+        a = Variable(torch.Tensor([1, 2, 3]))
+        b = Variable(torch.Tensor([4, 5]))
         c = Variable(torch.Tensor([6]))
-        
+
         # batch_first = true
         expected = Variable(torch.Tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]]))
         padded = rnn_utils.pad_sequence([a, b, c], [3, 2, 1], True)
@@ -2202,12 +2204,13 @@ class TestNN(NNTestCase):
         self.assertEqual(padded, expected.transpose(0, 1))
 
         # unsorted sequences should raise exception
-        self.assertRaises(ValueError, lambda: rnn_utils.pad_sequence([b, a, c], [2, 3, 1]))
+        self.assertRaises(
+            ValueError, lambda: rnn_utils.pad_sequence([b, a, c], [2, 3, 1]))
 
     def test_pack_sequence(self):
         # single dimensional
-        a = Variable(torch.Tensor([1,2,3]))
-        b = Variable(torch.Tensor([4,5]))
+        a = Variable(torch.Tensor([1, 2, 3]))
+        b = Variable(torch.Tensor([4, 5]))
         c = Variable(torch.Tensor([6]))
         packed = rnn_utils.pack_sequence([a, b, c], [3, 2, 1])
         expected = torch.Tensor([1, 4, 6, 2, 5, 3])
@@ -2223,7 +2226,7 @@ class TestNN(NNTestCase):
             seq_len = i * i
             lengths.append(seq_len)
             sequences.append(Variable(torch.rand(seq_len, 400)))
-        
+
         # compatibility with other utilities
         batch_first = True
         padded = rnn_utils.pad_sequence(sequences, lengths, batch_first)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2176,33 +2176,31 @@ class TestNN(NNTestCase):
 
         # batch_first = true
         expected = Variable(torch.Tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]]))
-        padded = rnn_utils.pad_sequence([a, b, c], [3, 2, 1], True)
+        padded = rnn_utils.pad_sequence([a, b, c], True)
         self.assertEqual(padded, expected)
 
         # batch_first = false
-        padded = rnn_utils.pad_sequence([a, b, c], [3, 2, 1])
+        padded = rnn_utils.pad_sequence([a, b, c])
         self.assertEqual(padded, expected.transpose(0, 1))
 
         # more dimensional
         maxlen = 9
         for num_dim in (0, 1, 2, 3):
             sequences = []
-            lengths = []
             trailing_dims = [4] * num_dim
             for i in range(maxlen, 0, -1):
                 seq_len = i * i
-                lengths.append(seq_len)
                 sequences.append(Variable(torch.rand(seq_len, 5, *trailing_dims)))
             expected = []
             for seq in sequences:
                 expected.append(pad(seq, maxlen * maxlen))
             # batch first = true
             expected = Variable(torch.stack(expected))
-            padded = rnn_utils.pad_sequence(sequences, lengths, True)
+            padded = rnn_utils.pad_sequence(sequences, True)
             self.assertEqual(padded, expected)
 
             # batch first = false
-            padded = rnn_utils.pad_sequence(sequences, lengths)
+            padded = rnn_utils.pad_sequence(sequences)
             self.assertEqual(padded, expected.transpose(0, 1))
 
         # unsorted sequences should raise exception
@@ -2211,8 +2209,8 @@ class TestNN(NNTestCase):
 
     def test_pack_sequence(self):
         def _compatibility_test(sequences, lengths, batch_first):
-            padded = rnn_utils.pad_sequence(sequences, lengths, batch_first)
-            packed = rnn_utils.pack_sequence(sequences, lengths)
+            padded = rnn_utils.pad_sequence(sequences, batch_first)
+            packed = rnn_utils.pack_sequence(sequences)
             unpacked = rnn_utils.pad_packed_sequence(packed, batch_first)
             self.assertEqual(padded, unpacked[0])
             pack_padded = rnn_utils.pack_padded_sequence(padded, lengths, batch_first)
@@ -2222,7 +2220,7 @@ class TestNN(NNTestCase):
         a = Variable(torch.Tensor([1, 2, 3]))
         b = Variable(torch.Tensor([4, 5]))
         c = Variable(torch.Tensor([6]))
-        packed = rnn_utils.pack_sequence([a, b, c], [3, 2, 1])
+        packed = rnn_utils.pack_sequence([a, b, c])
         expected = torch.Tensor([1, 4, 6, 2, 5, 3])
         self.assertEqual(packed.batch_sizes, [3, 2, 1])
         self.assertEqual(packed.data.data, expected)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2201,6 +2201,9 @@ class TestNN(NNTestCase):
         padded = rnn_utils.pad_sequence(sequences, lengths)
         self.assertEqual(padded, expected.transpose(0, 1))
 
+        # unsorted sequences should raise exception
+        self.assertRaises(ValueError, lambda: rnn_utils.pad_sequence([b, a, c], [2, 3, 1]))
+
     def test_pack_sequence(self):
         # single dimensional
         a = Variable(torch.Tensor([1,2,3]))

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -245,6 +245,7 @@ class RNN(RNNBase):
         - **input** (seq_len, batch, input_size): tensor containing the features
           of the input sequence. The input can also be a packed variable length
           sequence. See :func:`torch.nn.utils.rnn.pack_padded_sequence`
+          or :func:`torch.nn.utils.rnn.pack_sequence`
           for details.
         - **h_0** (num_layers * num_directions, batch, hidden_size): tensor
           containing the initial hidden state for each element in the batch.
@@ -332,7 +333,8 @@ class LSTM(RNNBase):
         - **input** (seq_len, batch, input_size): tensor containing the features
           of the input sequence.
           The input can also be a packed variable length sequence.
-          See :func:`torch.nn.utils.rnn.pack_padded_sequence` for details.
+          See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
+          :func:`torch.nn.utils.rnn.pack_sequence` for details.
         - **h_0** (num_layers \* num_directions, batch, hidden_size): tensor
           containing the initial hidden state for each element in the batch.
         - **c_0** (num_layers \* num_directions, batch, hidden_size): tensor

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -133,7 +133,8 @@ def pad_sequence(sequences, lengths, batch_first=False):
     stack all the sequences on zeroth dimension. For example, if the input is
     list of sequences with size `` Lx*`` and if batch_first is False, the
     output will be of size `` TxBx* `` and if batch_first is True,
-    output will be of size ``BxTx* ``.
+    output will be of size ``BxTx* ``. The ``pad_sequence`` accepts list of
+    sequences and its lengths which should be sorted in decreasing order
 
     B is batch size
     T is length longest sequence
@@ -165,14 +166,15 @@ def pad_sequence(sequences, lengths, batch_first=False):
     if len(lengths) != len(sequences):
         raise ValueError("number of elements in lengths and sequences didn't match")
 
-    # if not popped, iteration with longest sentence creates a no dimensional tensor
     out_variable = []
     max_len = lengths[0]
     prev_l = lengths[0]
     for variable, length in zip(sequences, lengths):
-        if length < max_len:
-            if prev_l < length:
+        # temperory sort check, will be removed when we handle sorting internally
+        if prev_l < length:
                 raise ValueError("lengths array has to be sorted in decreasing order")
+        prev_l = length
+        if length < max_len:
             prev_l = length
             padding_shape = [lengths[0] - length] + list(variable.size()[1:])
             filler = Variable(torch.Tensor(*padding_shape).type_as(variable.data).zero_())

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -176,34 +176,18 @@ def pad_sequence(sequences, lengths, batch_first=False):
     if batch_first:
         out_dims = [len(sequences), max_len] + trailing_dims
         out_variable = Variable(sequences[0].data.new(*out_dims).zero_())
-        for i, variable, length in zip(range(len(lengths)), sequences, lengths):
-            # temperory sort check, can be removed when we handle sorting internally
-            if prev_l < length:
-                    raise ValueError("lengths array has to be sorted in decreasing order")
-            prev_l = length
-            if length < max_len:
-                prev_l = length
-                padding_dims = [lengths[0] - length] + trailing_dims
-                filler = Variable(variable.data.new(*padding_dims).zero_())
-                out_variable[i] = torch.cat((variable, filler))
-            else:
-                out_variable[i] = variable
+        batch_dim = 0
     else:
-        # repeating the same logic but with T as first dimension
         out_dims = [max_len, len(sequences)] + trailing_dims
         out_variable = Variable(sequences[0].data.new(*out_dims).zero_())
-        for i, variable, length in zip(range(len(lengths)), sequences, lengths):
-            # temperory sort check, can be removed when we handle sorting internally
-            if prev_l < length:
-                    raise ValueError("lengths array has to be sorted in decreasing order")
-            prev_l = length
-            if length < max_len:
-                prev_l = length
-                padding_dims = [lengths[0] - length] + trailing_dims
-                filler = Variable(variable.data.new(*padding_dims).zero_())
-                out_variable[:, i] = torch.cat((variable, filler))
-            else:
-                out_variable[:, i] = variable
+        batch_dim = 1
+
+    for i, variable, length in zip(range(len(lengths)), sequences, lengths):
+        # temperory sort check, can be removed when we handle sorting internally
+        if prev_l < length:
+                raise ValueError("lengths array has to be sorted in decreasing order")
+        prev_l = length
+        out_variable.select(batch_dim, i)[:length] = variable
     return out_variable
 
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -136,32 +136,31 @@ def pad_sequence(sequences, lengths, batch_first=False):
     output will be of size ``BxTx* ``. The ``pad_sequence`` accepts list of
     sequences and its lengths which should be sorted in decreasing order
 
-    B is batch size
+    B is batch size - Number of elements in ``sequences``
     T is length longest sequence
     L is length of the sequence
-    * is any trailing dimension including zero
+    * is any number of trailing dimensions, including none
 
     >>> from torch.nn.utils.rnn import pad_sequence
     >>> a = Variable(torch.ones(25, 300))
-    >>> b = Variable(torch.ones(15, 300))
-    >>> c = Variable(torch.ones(22, 300))
-    >>> pad_sequence([a, b, c], [25, 15, 22]).size()
+    >>> b = Variable(torch.ones(22, 300))
+    >>> c = Variable(torch.ones(15, 300))
+    >>> pad_sequence([a, b, c], [25, 22, 15]).size()
     torch.Size([25, 3, 300])
 
     Note:
-        This function returns a Variable of size LxBx* or BxLx* where L is the
+        This function returns a Variable of size TxBx* or BxTx* where T is the
         length of longest sequence (lengths[0])
 
     Arguments:
-        sequences (list(Variable)): list of variable length sequences.
+        sequences (list[Variable]): list of variable length sequences.
         lengths (list[int]): list of sequences lengths of each batch element.
         batch_first (bool, optional): if True, the input is expected in Bx*x*
             format.
 
     Returns:
-        Variable of size ``seq_len x len(sequences) x * ``
-            if batch_first = False
-        Variable of size ``len(sequences) x seq_len x * `` otherwise
+        Variable of size ``T x B x * `` if batch_first = False
+        Variable of size ``B x T x * `` otherwise
     """
 
     if len(lengths) != len(sequences):
@@ -171,7 +170,7 @@ def pad_sequence(sequences, lengths, batch_first=False):
     max_len = lengths[0]
     prev_l = lengths[0]
     for variable, length in zip(sequences, lengths):
-        # temperory sort check, will be removed when we handle sorting internally
+        # temperory sort check, can be removed when we handle sorting internally
         if prev_l < length:
                 raise ValueError("lengths array has to be sorted in decreasing order")
         prev_l = length
@@ -182,6 +181,7 @@ def pad_sequence(sequences, lengths, batch_first=False):
             out_variable.append(torch.cat((variable, filler)))
         else:
             out_variable.append(variable)
+    # return torch.stack(out_variable, 0 if batch_first else 1)
     if batch_first:
         return torch.stack(out_variable)
     else:
@@ -203,6 +203,7 @@ def pack_sequence(sequences, lengths):
         retrieved from a :class:`PackedSequence` object by accessing
         its ``.data`` attribute.
     Ex.
+        >>> from torch.nn.utils.rnn import pack_sequence
         >>> a = Variable(torch.Tensor([1,2,3]))
         >>> b = Variable(torch.Tensor([4,5]))
         >>> c = Variable(torch.Tensor([6]))

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -175,7 +175,7 @@ def pad_sequence(sequences, batch_first=False):
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
         batch_dim = 1
-    
+
     out_variable = Variable(sequences[0].data.new(*out_dims).zero_())
     for i, variable in enumerate(sequences):
         length = variable.size(0)
@@ -193,7 +193,7 @@ def pack_sequence(sequences):
     ``sequences`` should be a list of Variables of size ``Lx*``, where L is
     the length of a sequence and * is any number of trailing dimensions,
     including zero. They should be sorted in the order of decreasing length.
-        
+
     Example:
         >>> from torch.nn.utils.rnn import pack_sequence
         >>> a = Variable(torch.Tensor([1,2,3]))

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -142,9 +142,9 @@ def pad_sequence(sequences, lengths, batch_first=False):
     * is any trailing dimension including zero
 
     >>> from torch.nn.utils.rnn import pad_sequence
-    >>> a = torch.ones(25, 300)
-    >>> b = torch.ones(15, 300)
-    >>> c = torch.ones(22, 300)
+    >>> a = Variable(torch.ones(25, 300))
+    >>> b = Variable(torch.ones(15, 300))
+    >>> c = Variable(torch.ones(22, 300))
     >>> pad_sequence([a, b, c], [25, 15, 22]).size()
     torch.Size([25, 3, 300])
 
@@ -176,7 +176,8 @@ def pad_sequence(sequences, lengths, batch_first=False):
     out_variable = []
     for variable, length in zip(sequence_arr, lenth_arr):
         padding_shape = [max_len - length] + list(variable.size()[1:])
-        out_variable.append(torch.cat((variable, variable.new(*padding_shape).zero_())))
+        filler_variable = Variable(torch.Tensor(*padding_shape).type_as(variable.data).zero_())
+        out_variable.append(torch.cat((variable, filler_variable)))
     # inserting the longest sentence back to its position
     out_variable = out_variable[:long_seq_index] + [longest] + out_variable[long_seq_index:]
     if batch_first:
@@ -200,9 +201,9 @@ def pack_sequence(sequences, lengths):
         retrieved from a :class:`PackedSequence` object by accessing
         its ``.data`` attribute.
     Ex.
-        >>> a = torch.Tensor([1,2,3])
-        >>> b = torch.Tensor([4,5])
-        >>> c = torch.Tensor([6])
+        >>> a = Variable(torch.Tensor([1,2,3]))
+        >>> b = Variable(torch.Tensor([4,5]))
+        >>> c = Variable(torch.Tensor([6]))
         >>> pack_sequence([a, b, c], [3, 2, 1])
         PackedSequence(data=
          1

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -159,8 +159,9 @@ def pad_sequence(sequences, lengths, batch_first=False):
             format.
 
     Returns:
-        a Variable of size ``seq_len x len(sequences) x * `` if batch_first = False
-        a Variable of size ``len(sequences) x seq_len x * `` otherwise
+        Variable of size ``seq_len x len(sequences) x * ``
+            if batch_first = False
+        Variable of size ``len(sequences) x seq_len x * `` otherwise
     """
 
     if len(lengths) != len(sequences):

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -183,3 +183,44 @@ def pad_sequence(sequences, lengths, batch_first=False):
         return torch.stack(out_variable)
     else:
         return torch.stack(out_variable).transpose(0, 1)
+
+
+def pack_sequence(sequences, lengths):
+    r"""Packs a list of variable length Variables
+
+    sequences should be a list of Variables each has size `` Lx* `` where
+    L is length of the sequence and * is any trailing dimension including zero
+    ``pack_sequence`` assumes each Variable is of different length and pack them
+
+    Note:
+        sequences can have any input that has at least one dimension.
+        But ``pack_sequence`` assumes, first dimension has varaible length
+        sequences. You can apply it to pack the labels, and use the output of
+        the RNN with them to compute the loss directly. A Variable can be
+        retrieved from a :class:`PackedSequence` object by accessing
+        its ``.data`` attribute.
+    Ex.
+        >>> a = torch.Tensor([1,2,3])
+        >>> b = torch.Tensor([4,5])
+        >>> c = torch.Tensor([6])
+        >>> pack_sequence([a, b, c], [3, 2, 1])
+        PackedSequence(data=
+         1
+         4
+         6
+         2
+         5
+         3
+        [torch.FloatTensor of size 6]
+        , batch_sizes=[3, 2, 1])
+
+
+    Arguments:
+        sequences (list[Variable]): variable length sequences.
+        lengths (list[int]): list of sequence's lengths of each batch element.
+
+    Returns:
+        a :class:`PackedSequence` object
+    """
+
+    return pack_padded_sequence(pad_sequence(sequences, lengths), lengths)


### PR DESCRIPTION
PR resolves  [#1128](https://github.com/pytorch/pytorch/issues/1128)

- Handling sort internally was supposed to be in this PR but I couldn't decide how we keep track of the actual order in case user needs the sequence in that order.