### PR TITLE
Allow target.requires_grad in l1_loss and mse_loss

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1296,7 +1296,7 @@ def l1_loss(input, target, size_average=True, reduce=True):
     See :class:`~torch.nn.L1Loss` for details.
     """
     return _pointwise_loss(lambda a, b: torch.abs(a - b), torch._C._nn.l1_loss,
-                          input, target, size_average, reduce)
+                           input, target, size_average, reduce)
 
 
 def mse_loss(input, target, size_average=True, reduce=True):
@@ -1308,7 +1308,7 @@ def mse_loss(input, target, size_average=True, reduce=True):
     See :class:`~torch.nn.MSELoss` for details.
     """
     return _pointwise_loss(lambda a, b: (a - b) ** 2, torch._C._nn.mse_loss,
-                          input, target, size_average, reduce)
+                           input, target, size_average, reduce)
 
 
 def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1267,7 +1267,7 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
         return loss.sum()
 
 
-def _poinwise_loss(lambd, lambd_optimized, input, target, size_average=True, reduce=True):
+def _pointwise_loss(lambd, lambd_optimized, input, target, size_average=True, reduce=True):
     if target.requires_grad:
         d = lambd(input, target)
         if not reduce:
@@ -1287,7 +1287,6 @@ See :class:`~torch.nn.SmoothL1Loss` for details.
 """)
 
 
-
 def l1_loss(input, target, size_average=True, reduce=True):
     """
     l1_loss(input, target, size_average=True, reduce=True) -> Variable
@@ -1296,7 +1295,7 @@ def l1_loss(input, target, size_average=True, reduce=True):
 
     See :class:`~torch.nn.L1Loss` for details.
     """
-    return _poinwise_loss(lambda a, b: torch.abs(a - b), torch._C._nn.l1_loss,
+    return _pointwise_loss(lambda a, b: torch.abs(a - b), torch._C._nn.l1_loss,
                           input, target, size_average, reduce)
 
 
@@ -1308,7 +1307,7 @@ def mse_loss(input, target, size_average=True, reduce=True):
 
     See :class:`~torch.nn.MSELoss` for details.
     """
-    return _poinwise_loss(lambda a, b: (a - b) ** 2, torch._C._nn.mse_loss,
+    return _pointwise_loss(lambda a, b: (a - b) ** 2, torch._C._nn.mse_loss,
                           input, target, size_average, reduce)
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1267,6 +1267,16 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
         return loss.sum()
 
 
+def _poinwise_loss(lambd, lambd_optimized, input, target, size_average=True, reduce=True):
+    if target.requires_grad:
+        d = lambd(input, target)
+        if not reduce:
+            return d
+        return torch.mean(d) if size_average else torch.sum(d)
+    else:
+        return lambd_optimized(input, target, size_average, reduce)
+
+
 smooth_l1_loss = _add_docstr(torch._C._nn.smooth_l1_loss, r"""
 smooth_l1_loss(input, target, size_average=True) -> Variable
 
@@ -1276,21 +1286,30 @@ element-wise error falls below 1 and an L1 term otherwise.
 See :class:`~torch.nn.SmoothL1Loss` for details.
 """)
 
-l1_loss = _add_docstr(torch._C._nn.l1_loss, r"""
-l1_loss(input, target, size_average=True, reduce=True) -> Variable
 
-Function that takes the mean element-wise absolute value difference.
 
-See :class:`~torch.nn.L1Loss` for details.
-""")
+def l1_loss(input, target, size_average=True, reduce=True):
+    """
+    l1_loss(input, target, size_average=True, reduce=True) -> Variable
 
-mse_loss = _add_docstr(torch._C._nn.mse_loss, r"""
-mse_loss(input, target, size_average=True, reduce=True) -> Variable
+    Function that takes the mean element-wise absolute value difference.
 
-Measures the element-wise mean squared error.
+    See :class:`~torch.nn.L1Loss` for details.
+    """
+    return _poinwise_loss(lambda a, b: torch.abs(a - b), torch._C._nn.l1_loss,
+                          input, target, size_average, reduce)
 
-See :class:`~torch.nn.MSELoss` for details.
-""")
+
+def mse_loss(input, target, size_average=True, reduce=True):
+    """
+    mse_loss(input, target, size_average=True, reduce=True) -> Variable
+
+    Measures the element-wise mean squared error.
+
+    See :class:`~torch.nn.MSELoss` for details.
+    """
+    return _poinwise_loss(lambda a, b: (a - b) ** 2, torch._C._nn.mse_loss,
+                          input, target, size_average, reduce)
 
 
 def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):


### PR DESCRIPTION
This bug cost me a lot of time in several projects, 0.2 would silently accept target.requires_grad and would backprop zeroes in `l1_loss` and `mse_loss`. It's fixed in master already (with exception), and this PR allows target.requires_grad by explicitly defining the loss functions.