### PR TITLE
improve PackedSequence docs to explain batch_sizes

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -15,6 +15,11 @@ class PackedSequence(PackedSequence_):
         Instances of this class should never be created manually. They are meant
         to be instantiated by functions like :func:`pack_padded_sequence`.
 
+        Batch sizes represent the number elements at each sequence step in
+        the batch, not the varying sequence lengths passed to 
+        :func:`pack_padded_sequence`.  For instance, given data  ``abc`` and `d`
+        the ``PackedSequence`` would be ``adbc`` with ``batch_sizes=[2,1,1]``.
+
     Attributes:
         data (Variable): Variable containing packed sequence
         batch_sizes (list[int]): list of integers holding information about

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -16,7 +16,7 @@ class PackedSequence(PackedSequence_):
         to be instantiated by functions like :func:`pack_padded_sequence`.
 
         Batch sizes represent the number elements at each sequence step in
-        the batch, not the varying sequence lengths passed to 
+        the batch, not the varying sequence lengths passed to
         :func:`pack_padded_sequence`.  For instance, given data  ``abc`` and `d`
         the ``PackedSequence`` would be ``adbc`` with ``batch_sizes=[2,1,1]``.
 


### PR DESCRIPTION
There has been some confusion on http://discuss.pytorch.org and Github Issues (e.g. https://github.com/pytorch/pytorch/issues/1820) related to the meaning of `batch_sizes` in PackedSequence representation.  This tries to improve the docs slightly.