### PR TITLE
Multiple JIT-related fixes

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -115,8 +115,8 @@ ${base_impl_call}
 ${no_zero_dim}
 ${version_counter}
 ${set_flags}
-${save_outputs}
 ${record_trace}
+${save_outputs}
 return ${return_value};
 """)
 

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -77,6 +77,9 @@ std::unordered_map<NodeKind, std::string> simple_map_ops = {
   {klerp, "${0} + ${weight}*(${1} - ${0})"},
   {kclamp, "min(max(${0},${min}),${max})"},
 
+  // simple derivatives
+  {"_sigmoid_backward"_sym, "${0} * ${1} * (1.f - ${1})"},
+  {"_tanh_backward"_sym,    "${0} * (1.f - ${1} * ${1})"},
 };
 
 std::vector<bool> TensorDesc::findContiguous(
@@ -305,8 +308,8 @@ CompiledFusionFunction::CompiledFusionFunction(const std::string & name, Annotat
   if ((prop.major >= 6 && CUDA_VERSION < 8000) ||
       (prop.major >= 7 && CUDA_VERSION < 9000)) {
     std::stringstream err_string;
-    err_string << "In CompiledFusionFunction, PyTorch compiled with insufficient CUDA version: " 
-	       << CUDA_VERSION << " for the current GPU device " << prop.name 
+    err_string << "In CompiledFusionFunction, PyTorch compiled with insufficient CUDA version: "
+	       << CUDA_VERSION << " for the current GPU device " << prop.name
 	       << " with device capability " << prop.major << "." << prop.minor;
     throw std::runtime_error(err_string.str());
   }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -133,4 +133,8 @@ enum BuiltinSymbol {
 const char * symbolToString(Symbol s);
 Symbol stringToSymbol(const std::string & s);
 
+inline Symbol operator "" _sym(const char * s, unsigned long) {
+  return stringToSymbol(s);
+}
+
 }}

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -84,6 +84,9 @@ struct CompiledFunction {
       try {
         factory_ = std::make_shared<InterpreterFunctionFactory>(complete_trace.get());
       } catch(const jit::NotImplementedException & ex) {
+        PyErr_WarnEx(PyExc_UserWarning, "hitting an older JIT path that is slower than "
+            "the new one. It's close to being deleted, but the new path needs full support "
+            "for certain edge cases. Please report your use case.", 0);
         closure_ = std::make_shared<AutogradClosureFactory>(complete_trace.get());
       }
       graph_ = complete_trace->graph;


### PR DESCRIPTION
- Falling back to AutogradClosure now produces a warning (so that we can at least see if it happens and know that our perf numbers are incorrect)
- Recording the trace should happen before saving outputs (their tracing state needs to be embedded in `SavedVariable`s)
- Fixed handling ops with multiple inputs in `aten_dispatch.cpp` (currently only `cat`). Used to trigger an assertion error before
- Improved the fuser algorithm to do an extra pass and merge neighbouring fusion groups.