### PR TITLE
Remove Function::is_executable

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -107,7 +107,6 @@ std::shared_ptr<${op}> grad_fn;
 auto flags = compute_flags({ ${args_with_derivatives} });
 if (flags.requires_grad) {
   grad_fn = std::make_shared<${op}>(${op_ctor});
-  grad_fn->is_executable = true;
   grad_fn->next_functions = compute_next_functions({ ${args_with_derivatives} });
   ${save_inputs}
 }

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -335,7 +335,6 @@ void VariableType::s_copy(const Tensor & src, Tensor & dst) const {
   if (flags.requires_grad) {
     // TODO: handle device movement
     grad_fn = std::make_shared<CopyBackwards>();
-    grad_fn->is_executable = true;
     grad_fn->next_functions = compute_next_functions({ dst, src });
     grad_fn->num_inputs = 1;
     grad_fn->src_type = &src.type();

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -55,7 +55,6 @@ struct Function : std::enable_shared_from_this<Function> {
   Function()
     : num_inputs(0)
     , next_functions()
-    , is_executable(false)
     , pre_hooks()
     , post_hooks()
     , pyobj(nullptr)
@@ -64,7 +63,6 @@ struct Function : std::enable_shared_from_this<Function> {
   Function(FunctionFlags&& flags)
     : num_inputs(0)
     , next_functions(std::move(flags.next_functions))
-    , is_executable(flags.is_executable)
     , pre_hooks()
     , post_hooks()
     , pyobj(nullptr)
@@ -109,8 +107,7 @@ struct Function : std::enable_shared_from_this<Function> {
   virtual std::string name();
 
   inline bool should_compute_output(int i) const {
-    auto& fn = next_functions[i].first;
-    return fn && fn->is_executable;
+    return bool(next_functions[i].first);
   }
 
   inline bool should_compute_any_outputs() const {
@@ -129,7 +126,6 @@ struct Function : std::enable_shared_from_this<Function> {
   }
 
   inline void set_flags(FunctionFlags&& flags) {
-    is_executable = flags.is_executable;
     next_functions = std::move(flags.next_functions);
   }
 
@@ -160,7 +156,6 @@ struct Function : std::enable_shared_from_this<Function> {
 
   int num_inputs;
   function_list next_functions;
-  bool is_executable;
   std::vector<std::shared_ptr<FunctionPreHook>> pre_hooks;
   std::vector<std::shared_ptr<FunctionPostHook>> post_hooks;
 

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -14,7 +14,6 @@ namespace torch { namespace autograd {
 AccumulateGrad::AccumulateGrad(Variable variable_)
    : variable(std::move(variable_)) {
   num_inputs = 1;
-  is_executable = 1;
 }
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -37,7 +37,6 @@ struct GraphRoot : public Function {
   GraphRoot(function_list functions, variable_list inputs)
     : outputs(std::move(inputs)) {
       next_functions = std::move(functions);
-      is_executable = true;
     };
 
   virtual variable_list apply(const variable_list& inputs) {

--- a/torch/csrc/autograd/functions/batch_normalization.h
+++ b/torch/csrc/autograd/functions/batch_normalization.h
@@ -43,13 +43,11 @@ struct BatchNormBackward : public Function, public BatchNormParams {
       Variable bias)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
-      if (is_executable) {
-        this->save_mean = std::move(save_mean);
-        this->save_std = std::move(save_std);
-        this->input = SavedVariable(input, false);
-        this->weight = SavedVariable(weight, false);
-        this->bias = SavedVariable(bias, false);
-      }
+      this->save_mean = std::move(save_mean);
+      this->save_std = std::move(save_std);
+      this->input = SavedVariable(input, false);
+      this->weight = SavedVariable(weight, false);
+      this->bias = SavedVariable(bias, false);
     }
 
   virtual variable_list apply(const variable_list& gradOutputs) override;
@@ -74,13 +72,11 @@ struct BatchNormBackwardBackward : public Function, public BatchNormParams {
       Variable grad_output)
     : Function(std::move(flags))
     , BatchNormParams(std::move(params)) {
-      if (is_executable) {
-        this->save_mean = std::move(save_mean);
-        this->save_std = std::move(save_std);
-        this->input = SavedVariable(input, false);
-        this->weight = SavedVariable(weight, false);
-        this->grad_output = SavedVariable(grad_output, false);
-      }
+      this->save_mean = std::move(save_mean);
+      this->save_std = std::move(save_std);
+      this->input = SavedVariable(input, false);
+      this->weight = SavedVariable(weight, false);
+      this->grad_output = SavedVariable(grad_output, false);
     }
 
   virtual variable_list apply(const variable_list& grad_grad_inputs) override;

--- a/torch/csrc/autograd/functions/convolution.h
+++ b/torch/csrc/autograd/functions/convolution.h
@@ -71,15 +71,13 @@ struct ConvBackward : public Function, public ConvParams {
     : Function(std::move(flags))
     , ConvParams(std::move(params))
     , convolution(std::move(convolution)) {
-      if (is_executable) {
-        this->input_ = SavedVariable(input, false);
-        this->weight_ = SavedVariable(weight, false);
-        if (bias.defined()) {
-          this->bias_ = SavedVariable(bias, false);
-        }
-        this->columns = std::move(columns);
-        this->ones = std::move(ones);
+      this->input_ = SavedVariable(input, false);
+      this->weight_ = SavedVariable(weight, false);
+      if (bias.defined()) {
+        this->bias_ = SavedVariable(bias, false);
       }
+      this->columns = std::move(columns);
+      this->ones = std::move(ones);
     }
 
   virtual variable_list apply(const variable_list& gradOutputs) override;
@@ -104,14 +102,12 @@ struct ConvBackwardBackward : public Function, public ConvParams {
       Variable grad_output)
     : Function(std::move(flags))
     , ConvParams(std::move(params)) {
-      if (is_executable) {
-        this->input_ = SavedVariable(input, false);
-        this->weight_ = SavedVariable(weight, false);
-        if (bias.defined()) {
-          this->bias_ = SavedVariable(bias, false);
-        }
-        this->grad_output_ = SavedVariable(grad_output, false);
+      this->input_ = SavedVariable(input, false);
+      this->weight_ = SavedVariable(weight, false);
+      if (bias.defined()) {
+        this->bias_ = SavedVariable(bias, false);
       }
+      this->grad_output_ = SavedVariable(grad_output, false);
     }
 
   virtual variable_list apply(const variable_list& grad_grad_inputs) override;

--- a/torch/csrc/autograd/functions/jit_closure.cpp
+++ b/torch/csrc/autograd/functions/jit_closure.cpp
@@ -24,7 +24,6 @@ using namespace torch::jit::tracer;
 // in next_functions per output).
 struct Replicate : public Function {
   Replicate() {
-    is_executable = true;
     num_inputs = 1;
   }
 
@@ -85,7 +84,6 @@ struct EvalPlaceholder : public Placeholder {};
 // Used for the graph output. Execution should be stopped by a callback before apply().
 struct Output : public Function {
   Output(int ninputs) {
-    is_executable = true;
     num_inputs = ninputs;
   }
 
@@ -107,7 +105,6 @@ struct SimpleEval : public Function {
 
 struct EmitNull : public Function {
   EmitNull() {
-    is_executable = true;
     num_inputs = 0;
   }
 
@@ -131,7 +128,6 @@ struct LambdaFunction : public Function {
 
   LambdaFunction(int num_inputs, std::function<variable_list(const variable_list&)> fn)
     : fn_(fn) {
-    this->is_executable = true;
     this->num_inputs = num_inputs;
   }
 
@@ -246,7 +242,6 @@ struct PythonCall : public Function {
 struct WrapConstant : public Function {
   WrapConstant(at::Tensor value)
     : value(std::move(value)) {
-    is_executable = true;
     num_inputs = 1;
   }
 
@@ -263,7 +258,6 @@ struct WrapConstant : public Function {
 // See Note [Handling nullary functions in the autograd engine]
 struct ConstantFactory : public Function {
   ConstantFactory() {
-    is_executable = true;
     num_inputs = 1;
   }
 
@@ -444,7 +438,6 @@ struct StageClosure {
       if (!fn) return; // This node is a no-op
 
       // Initialize function fields
-      fn->is_executable = true;
       if (fn->num_inputs == 0) {
         fn->num_inputs = node->inputs().size();
       }
@@ -466,7 +459,6 @@ struct StageClosure {
       auto fn = std::make_shared<InputPlaceholder>();
       fn->num_inputs = 1;
       // Initialize function fields
-      fn->is_executable = true;
       std::vector<std::reference_wrapper<const use_list>> output_uses_refs;
       output_uses_refs.emplace_back(input->uses());
       fillNextFunctions(input->owningGraph(), output_uses_refs, fn, node_map, output_offset, stage);
@@ -793,7 +785,6 @@ variable_list AutogradClosure::apply(const variable_list& inputs) {
     // didn't require grad, copied function can), and is always valid because we assert
     // that flags are the same as when we compiled the closure (and the tracing Eval
     // was run, so it must have been executable).
-    bw_fn->is_executable = true;
     return bw_fn;
   };
 

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -144,7 +144,6 @@ bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outpu
     grad_next_fns.emplace_back(placeholder, 0);
     placeholders.emplace_back(std::move(placeholder));
   }
-  is_executable = grad_fn->is_executable;
   simple_graph = grad_fn;
   grad_fn->tracing_state->in_eval_subgraph = true;
   return true;
@@ -226,8 +225,6 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
 
     // Replace subgraph with this node.
     next_functions.insert(next_functions.begin(), subgraph.boundary.ends.begin(), subgraph.boundary.ends.end());
-    is_executable = std::any_of(relevant_outputs.begin(), relevant_outputs.end(),
-                                [](const Variable& var) { return var.requires_grad(); });
 
     // Ensure placeholders and inputs are sorted in the same way.
     edge_order input_order = computeInputOrder(inputs, inherited_placeholders);

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -15,11 +15,6 @@ struct EvalOutput : Function {
   EvalOutput(const edge_type& next_edge)
     : next_edge(next_edge) {
     num_inputs = 1;
-    // It would be nice if we could inherit this from the function of next_edge,
-    // but we want to always run this node to capture the output. This might
-    // confuse some of the functions causing them to do unnecessary work.
-    // TODO: it should be possible to improve this once we get rid of NULL Variables
-    is_executable = true;
   }
 
   virtual variable_list apply(const variable_list& inputs) override {

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -134,7 +134,6 @@ CopySlices::CopySlices(const Variable& base_var, TensorGeometry view_, std::shar
   , view(std::move(view_))
   , fn(std::move(fn_))
 {
-  is_executable = true;
   num_inputs = 1;
 
   // Take the next_functions of fn as our own, except for index 0 which goes

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -13,10 +13,10 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   auto flags = Function::flags(inputs);
   variable_list result;
   result.reserve(outputs.size());
-  if (flags.is_volatile) {
+  if (!flags.is_executable) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(make_variable(output, false, true));
+        result.emplace_back(make_variable(output, false, flags.is_volatile));
       } else {
         result.emplace_back();
       }

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -117,7 +117,7 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
 }
 
 PyObject* THPCppFunction_requires_grad(THPCppFunction* self) {
-  return PyBool_FromLong(self->cdata->is_executable);
+  Py_RETURN_TRUE;
 }
 
 PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var)

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -214,8 +214,6 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
       if (allow_unreachable && !grad_fn) continue;
       THPUtils_assert(grad_fn,
           "One of the differentiated Variables appears to not have been used in the graph");
-      THPUtils_assert(grad_fn->is_executable,
-          "One of the differentiated Variables has a non-executable grad_fn. Submit a bug report.");
       auto& fn_info = ctx.output_map[grad_fn];
       fn_info.first.emplace_back(output_nr, i);
       fn_info.second = is_leaf;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -553,6 +553,7 @@ static void _mark_non_differentiable(THPFunction *self, t2var_type &t2var)
           "outputs");
     }
     var->cdata.requires_grad() = false;
+    var->cdata.get()->_grad_fn = nullptr;
   }
   Py_DECREF(self->non_differentiable);
   self->non_differentiable = NULL;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -356,14 +356,13 @@ static void _mark_dirty(THPFunction *self, t2var_type &t2var,
 static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
     std::unordered_set<PyObject *> &dirty_inputs,
     const t2var_type &shared_pairs,
-    PyObject *raw_output, PyObject *outputs, bool is_volatile)
+    PyObject *raw_output, PyObject *outputs, bool is_executable, bool is_volatile)
 {
-  bool is_executable = self->cdata.is_executable;
   TORCH_ASSERT(!is_volatile || !is_executable);
   auto cdata = is_executable ? THPFunction_asFunction(self) : nullptr;
   auto flags = VarFlags(is_executable, is_volatile);
   Py_ssize_t num_outputs = PyTuple_GET_SIZE(raw_output);
-  if (self->cdata.is_executable) {
+  if (is_executable) {
     self->output_info.clear();
     self->output_info.reserve(num_outputs);
   }
@@ -438,7 +437,7 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
       output2var[output] = output_var;
     }
 
-    if (self->cdata.is_executable) {
+    if (is_executable) {
       self->output_info.emplace_back(output_var->cdata);
     }
     PyTuple_SET_ITEM(outputs, i, (PyObject*)output_var);
@@ -706,7 +705,9 @@ static void _trace_create(PyObject* op_obj, THPFunction* bw_obj,
   }
 }
 
-PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const UnpackedInput& unpacked, PyObject *inputs, THPObjectPtr&& raw_output, bool is_volatile) {
+PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const UnpackedInput& unpacked,
+                          PyObject *inputs, THPObjectPtr&& raw_output, bool is_executable,
+                          bool is_volatile) {
   bool unpack_output = ensure_tuple(raw_output);
 
   auto num_outputs = PyTuple_GET_SIZE(raw_output.get());
@@ -717,7 +718,7 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   grad_fn->cdata.num_inputs = num_outputs;
 
   // Record type, device, and size information about inputs
-  if (grad_fn->cdata.is_executable) {
+  if (is_executable) {
     grad_fn->input_info.clear();
     grad_fn->input_info.reserve(unpacked.input_vars.size());
     for (auto& var : unpacked.input_vars) {
@@ -737,11 +738,11 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   _mark_dirty(grad_fn, t2var, dirty_inputs);
   _wrap_outputs(grad_fn, t2var, dirty_inputs,
       _parse_shared_pairs(grad_fn, t2var),
-      raw_output, outputs, is_volatile);
+      raw_output, outputs, is_executable, is_volatile);
   // Free shared_pairs
   Py_CLEAR(grad_fn->shared_pairs);
   // At this point, t2var contains output tensors as well
-  if (grad_fn->cdata.is_executable) {
+  if (is_executable) {
     _mark_non_differentiable(grad_fn, t2var);
   }
   // NOTE: _trace_create has to run before _save_variables, because we need
@@ -750,7 +751,7 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   // it might be wraping backwards in Evals, and _mark_non_differentiable uses
   // grad_fn pointer equality for error checking.
   _trace_create(op_obj, grad_fn, inputs, outputs, unpacked.input_vars, is_inplace);
-  if (grad_fn->cdata.is_executable) {
+  if (is_executable) {
     _save_variables(grad_fn, t2var);
   } else {
     // Remove unnecessary attributes
@@ -779,6 +780,7 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   auto info_pair = unpack_input<true>(_inputs);
   auto& unpacked_input = info_pair.first;
   auto& input_info = info_pair.second;
+  bool is_executable = input_info.flags.is_executable;
   bool is_volatile = input_info.flags.is_volatile;
   self->cdata.set_flags(std::move(input_info.flags));
   self->needs_input_grad = input_info.needs_input_grad.release();
@@ -789,7 +791,8 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   THPObjectPtr raw_output(PyObject_CallObject(forward_fn, unpacked_input.tensor_input));
   if (!raw_output) return NULL;
 
-  return process_outputs(nullptr, self, unpacked_input, _inputs, std::move(raw_output), is_volatile);
+  return process_outputs(nullptr, self, unpacked_input, _inputs, std::move(raw_output),
+                         is_executable, is_volatile);
   END_HANDLE_TH_ERRORS
 }
 
@@ -810,6 +813,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   InputFlags& input_info = info_pair.second;
 
   // Initialize backward function (and ctx)
+  bool is_executable = input_info.flags.is_executable;
   bool is_volatile = input_info.flags.is_volatile;
   ctx->cdata.set_flags(std::move(input_info.flags));
   ctx->needs_input_grad = input_info.needs_input_grad.release();
@@ -831,10 +835,8 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   THPObjectPtr tensor_outputs(PyObject_CallObject(forward_fn, ctx_tensor_input));
   if (!tensor_outputs) return NULL;
 
-  THPObjectPtr outputs {process_outputs(cls, ctx, unpacked_input, inputs,
-                                        std::move(tensor_outputs), is_volatile)};
-
-  return outputs.release();
+  return process_outputs(cls, ctx, unpacked_input, inputs, std::move(tensor_outputs),
+                         is_executable, is_volatile);
   END_HANDLE_TH_ERRORS
 }
 
@@ -1062,14 +1064,8 @@ PyObject* getImplMember(PyObject* obj, void* _unused) {
   return Convert(self->cdata.*ptr);
 }
 
-int setRequiresGrad(PyObject* obj, PyObject* value, void* _unused) {
-  auto self = (THPFunction*)obj;
-  if (!PyBool_Check(value)) {
-    PyErr_Format(PyExc_TypeError, "'is_executable' must be a bool");
-    return -1;
-  }
-  self->cdata.is_executable = (value == Py_True);
-  return 0;
+PyObject* getRequiresGrad(PyObject* obj, void* _unused) {
+  Py_RETURN_TRUE;
 }
 
 }
@@ -1083,7 +1079,7 @@ static struct PyGetSetDef THPFunction_properties[] = {
   {"non_differentiable", &getObject<&THPFunction::non_differentiable>, &setObject<&THPFunction::non_differentiable>, NULL, NULL},
   {"dirty_tensors", &getObject<&THPFunction::dirty_tensors>, &setObject<&THPFunction::dirty_tensors>, NULL, NULL},
   {"needs_input_grad", &getObject<&THPFunction::needs_input_grad>, NULL, NULL, NULL},
-  {"requires_grad", &getImplMember<bool, &Function::is_executable, PyBool_FromLong>, &setRequiresGrad, NULL, NULL},
+  {"requires_grad", getRequiresGrad, NULL, NULL, NULL},
   {"_is_tracing", &getMember<char, &THPFunction::is_traced, PyBool_FromLong>, NULL, NULL, NULL},
   {NULL}
 };

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -390,9 +390,6 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
     return -1;
   }
   var.requires_grad() = (obj == Py_True);
-  if (auto grad_accumulator = var.get()->grad_accumulator.lock()) {
-    grad_accumulator->is_executable = var.requires_grad();
-  }
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -13,7 +13,7 @@ namespace torch { namespace autograd {
 
 Variable make_variable(at::Tensor data, std::shared_ptr<Function> grad_fn) {
   TORCH_ASSERT(grad_fn);
-  auto flags = VarFlags(grad_fn->is_executable, false);
+  auto flags = VarFlags(true, false);
   int output_nr = grad_fn->num_inputs++;
   return make_variable(std::move(data), flags, output_nr, std::move(grad_fn));
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -171,12 +171,10 @@ struct VariableViewImpl : public VariableImpl {
 
 inline Variable make_variable(at::Tensor data, VarFlags flags=DEFAULT_FLAGS,
                               int output_nr=0, std::shared_ptr<Function> grad_fn=nullptr) {
+  TORCH_ASSERT(!grad_fn || flags.requires_grad);
   if (data.defined() && data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
-  }
-  if (!flags.requires_grad) {
-    grad_fn = nullptr;
   }
   return Variable(new VariableImpl(std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }
@@ -189,12 +187,10 @@ inline Variable make_variable(at::Tensor data, bool requires_grad, bool is_volat
 
 inline Variable make_variable_view(Variable base, at::Tensor data, VarFlags flags=DEFAULT_FLAGS,
                                    int output_nr=0, std::shared_ptr<Function> grad_fn=nullptr) {
+  TORCH_ASSERT(!grad_fn || flags.requires_grad);
   if (data.defined() && data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
-  }
-  if (!flags.requires_grad) {
-    grad_fn = nullptr;
   }
   return Variable(new VariableViewImpl(std::move(base), std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -175,6 +175,9 @@ inline Variable make_variable(at::Tensor data, VarFlags flags=DEFAULT_FLAGS,
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
   }
+  if (!flags.requires_grad) {
+    grad_fn = nullptr;
+  }
   return Variable(new VariableImpl(std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }
 
@@ -189,6 +192,9 @@ inline Variable make_variable_view(Variable base, at::Tensor data, VarFlags flag
   if (data.defined() && data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
+  }
+  if (!flags.requires_grad) {
+    grad_fn = nullptr;
   }
   return Variable(new VariableViewImpl(std::move(base), std::move(data), flags, output_nr, std::move(grad_fn)), false);
 }

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -53,7 +53,6 @@ autograd::variable_list InterpreterAutogradFunction::apply(
         input.grad_fn() ? input.grad_fn() : input.grad_accumulator(),
         input.output_nr());
     }
-    grad_fn->is_executable = true;
   };
 
   // Wrap the outputs


### PR DESCRIPTION
Every autograd Function is now "executable". Similarly, a Variable that has a non-null grad_fn now must have `requires_grad=True`.

There will be a few more clean-ups once volatile is replaced with scoped guard/TLs (https://github.com/pytorch/pytorch/issues/3627)