### PR TITLE
Add HANDLE_TH_ERRORS for THPFunction_saved_variables and THPFunction_…

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -993,16 +993,20 @@ static PyObject *unpack_saved_variables(
 
 PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 {
+  HANDLE_TH_ERRORS
   return unpack_saved_variables(self, [](const Variable& var) {
     return createPyObject(var.data());
   });
+  END_HANDLE_TH_ERRORS
 }
 
 PyObject *THPFunction_saved_variables(THPFunction *self, void *_unused)
 {
+  HANDLE_TH_ERRORS
   return unpack_saved_variables(self, [](const Variable& var) {
     return THPVariable_Wrap(var);
   });
+  END_HANDLE_TH_ERRORS
 }
 
 PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)


### PR DESCRIPTION
…saved_tensors

SavedVariable.unpack() may throw std::runtime_error which may lead to
program termination with SIGABRT without the exception beeing handled
in Python

Fixes #3860