### PR TITLE
Significantly speed up the incremental build using ninja

### DIFF
--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -1,0 +1,101 @@
+import os
+import sys
+
+source_files = set(['.py', '.cpp', '.h'])
+
+
+def all_generator_source():
+    r = []
+    for directory, _, filenames in os.walk('tools'):
+        for f in filenames:
+            if os.path.splitext(f)[1] in source_files:
+                full = os.path.join(directory, f)
+                r.append(full)
+    return sorted(r)
+
+
+inputs = [
+    'torch/csrc/generic/TensorMethods.cwrap',
+    'torch/csrc/cudnn/cuDNN.cwrap',
+    'torch/lib/tmp_install/share/ATen/Declarations.yaml',
+    'torch/lib/tmp_install/share/ATen/Declarations.yaml'
+]
+
+outputs = [
+    'torch/csrc/autograd/generated/Functions.cpp',
+    'torch/csrc/autograd/generated/Functions.h',
+    'torch/csrc/autograd/generated/python_functions.cpp',
+    'torch/csrc/autograd/generated/python_functions.h',
+    'torch/csrc/autograd/generated/python_nn_functions.cpp',
+    'torch/csrc/autograd/generated/python_nn_functions.h',
+    'torch/csrc/autograd/generated/python_nn_functions_dispatch.h',
+    'torch/csrc/autograd/generated/python_variable_methods.cpp',
+    'torch/csrc/autograd/generated/python_variable_methods_dispatch.h',
+    'torch/csrc/autograd/generated/VariableType.cpp',
+    'torch/csrc/autograd/generated/VariableType.h',
+    'torch/csrc/jit/generated/aten_dispatch.cpp',
+    'torch/csrc/jit/generated/aten_dispatch.h',
+]
+
+
+def generate_code_ninja(w):
+    all_inputs = all_generator_source() + inputs
+    cmd = "{} {}".format(sys.executable, 'tools/setup_helpers/generate_code.py')
+    w.writer.build(
+        outputs, 'do_cmd', all_inputs,
+        variables={
+            'cmd': cmd,
+        })
+
+
+def generate_code(ninja_global=None):
+    # if ninja is enabled, we just register this file as something
+    # ninja will need to call if needed
+    if ninja_global is not None:
+        return generate_code_ninja(ninja_global)
+
+    # cwrap depends on pyyaml, so we can't import it earlier
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    sys.path.append(root)
+    from tools.cwrap import cwrap
+    from tools.cwrap.plugins.THPPlugin import THPPlugin
+    from tools.cwrap.plugins.ArgcountSortPlugin import ArgcountSortPlugin
+    from tools.cwrap.plugins.AutoGPU import AutoGPU
+    from tools.cwrap.plugins.BoolOption import BoolOption
+    from tools.cwrap.plugins.KwargsPlugin import KwargsPlugin
+    from tools.cwrap.plugins.NullableArguments import NullableArguments
+
+    from tools.cwrap.plugins.CuDNNPlugin import CuDNNPlugin
+    from tools.cwrap.plugins.WrapDim import WrapDim
+    from tools.cwrap.plugins.AssertNDim import AssertNDim
+
+    from tools.cwrap.plugins.Broadcast import Broadcast
+    from tools.cwrap.plugins.ProcessorSpecificPlugin import ProcessorSpecificPlugin
+    from tools.autograd.gen_variable_type import gen_variable_type
+    from tools.jit.gen_jit_dispatch import gen_jit_dispatch
+    thp_plugin = THPPlugin()
+
+    cwrap('torch/csrc/generic/TensorMethods.cwrap', plugins=[
+        ProcessorSpecificPlugin(), BoolOption(), thp_plugin,
+        AutoGPU(condition='IS_CUDA'), ArgcountSortPlugin(), KwargsPlugin(),
+        AssertNDim(), WrapDim(), Broadcast()
+    ])
+    cwrap('torch/csrc/cudnn/cuDNN.cwrap', plugins=[
+        CuDNNPlugin(), NullableArguments()
+    ])
+    # Build ATen based Variable classes
+    autograd_gen_dir = 'torch/csrc/autograd/generated'
+    jit_gen_dir = 'torch/csrc/jit/generated'
+    for d in (autograd_gen_dir, jit_gen_dir):
+        if not os.path.exists(d):
+            os.mkdir(d)
+    gen_variable_type(
+        'torch/lib/tmp_install/share/ATen/Declarations.yaml',
+        autograd_gen_dir)
+    gen_jit_dispatch(
+        'torch/lib/tmp_install/share/ATen/Declarations.yaml',
+        jit_gen_dir)
+
+# called from ninja
+if __name__ == "__main__":
+    generate_code(None)

--- a/tools/setup_helpers/ninja_builder.py
+++ b/tools/setup_helpers/ninja_builder.py
@@ -1,0 +1,81 @@
+import os
+import setuptools
+import distutils
+from contextlib import contextmanager
+
+
+# on the fly create a ninja file in build/ and then
+# run it when run() is called.
+class NinjaBuilder(object):
+    def __init__(self, name):
+        import ninja
+        build_dir = 'build'
+        if not os.path.exists(build_dir):
+            os.mkdir(build_dir)
+        self.name = name
+        self.filename = os.path.join(build_dir, 'build.{}.ninja'.format(name))
+        print('Ninja build file at {}'.format(self.filename))
+        self.writer = ninja.Writer(open(self.filename, 'w'))
+        self.writer.rule('do_cmd', '$cmd')
+
+    def run(self):
+        import ninja
+        self.writer.close()
+        assert(0 == ninja._program('ninja', ['-f', self.filename]))
+        # weird build logic in build develop causes some things to be run
+        # twice so make sure even after we run the command we still
+        # reset this to a valid state
+        # don't use the same name or you can't inspect the real ninja files
+        self.__init__(self.name + "_")
+
+
+class ninja_build_ext(setuptools.command.build_ext.build_ext):
+    def _build_default(self, ext):
+        return setuptools.command.build_ext.build_ext.build_extension(self, ext)
+
+    def build_extension(self, ext):
+        builder = NinjaBuilder(ext.name)
+
+        @contextmanager
+        def patch(obj, attr_name, val):
+            orig_val = getattr(obj, attr_name)
+            setattr(obj, attr_name, val)
+            yield
+            setattr(obj, attr_name, orig_val)
+
+        orig_compile = distutils.unixccompiler.UnixCCompiler._compile
+        orig_link = distutils.unixccompiler.UnixCCompiler.link
+
+        def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
+            depfile = os.path.splitext(obj)[0] + '.d'
+
+            def spawn(cmd):
+                builder.writer.build(
+                    [obj], 'do_cmd', [src],
+                    variables={
+                        'cmd': cmd,
+                        'depfile': depfile,
+                        'deps': 'gcc'
+                    })
+
+            extra_postargs = extra_postargs + ['-MMD', '-MF', depfile]
+            with patch(self, 'spawn', spawn):
+                orig_compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+        def link(self, target_desc, objects,
+                 output_filename, output_dir=None, libraries=None,
+                 library_dirs=None, runtime_library_dirs=None,
+                 export_symbols=None, debug=0, extra_preargs=None,
+                 extra_postargs=None, build_temp=None, target_lang=None):
+
+            builder.run()
+            orig_link(self, target_desc, objects,
+                      output_filename, output_dir, libraries,
+                      library_dirs, runtime_library_dirs,
+                      export_symbols, debug, extra_preargs,
+                      extra_postargs, build_temp, target_lang)
+
+        with patch(distutils.unixccompiler.UnixCCompiler, '_compile', _compile):
+            with patch(distutils.unixccompiler.UnixCCompiler, 'link', link):
+                with patch(self, 'force', True):
+                    self._build_default(ext)

--- a/tools/setup_helpers/ninja_builder.py
+++ b/tools/setup_helpers/ninja_builder.py
@@ -14,9 +14,9 @@ class NinjaBuilder(object):
         import ninja
         if not os.path.exists(BUILD_DIR):
             os.mkdir(BUILD_DIR)
+        self.ninja_program = os.path.join(ninja.BIN_DIR, 'ninja')
         self.name = name
         self.filename = os.path.join(BUILD_DIR, 'build.{}.ninja'.format(name))
-        print('Ninja build file at {}'.format(self.filename))
         self.writer = ninja.Writer(open(self.filename, 'w'))
         self.writer.rule('do_cmd', '$cmd')
         self.writer.rule('compile', '$cmd')
@@ -25,10 +25,11 @@ class NinjaBuilder(object):
     def run(self):
         import ninja
         self.writer.close()
-        subprocess.check_call(['ninja', '-f', self.filename])
+        subprocess.check_call([self.ninja_program, '-f', self.filename])
         compile_db_path = os.path.join(BUILD_DIR, '{}_compile_commands.json'.format(self.name))
         with open(compile_db_path, 'w') as compile_db:
-            subprocess.check_call(['ninja', '-f', self.filename, '-t', 'compdb', 'compile'], stdout=compile_db)
+            subprocess.check_call([self.ninja_program, '-f', self.filename,
+                                   '-t', 'compdb', 'compile'], stdout=compile_db)
 
         # weird build logic in build develop causes some things to be run
         # twice so make sure even after we run the command we still

--- a/tools/setup_helpers/split_types.py
+++ b/tools/setup_helpers/split_types.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 this_file = os.path.dirname(os.path.abspath(__file__))
 generated_dir = os.path.abspath(os.path.join(this_file, '..', '..', 'torch', 'csrc', 'generated'))
@@ -20,7 +21,30 @@ generic_include = '#define {lib}_GENERIC_FILE "{path}"'
 generate_include = '#include "{lib}/{lib}Generate{type}Type.h"'
 
 
-def split_types(file_name):
+def get_gen_path_prefix(file_name):
+    gen_name_prefix = file_name[len('torch/csrc/'):].replace('/', '_').replace('.cpp', '')
+    gen_path_prefix = os.path.join(generated_dir, gen_name_prefix)
+    return gen_path_prefix
+
+
+def split_types_ninja(file_name, w):
+    gen_path_prefix = get_gen_path_prefix(file_name)
+    to_build = [gen_path_prefix + t + '.cpp' for t in types]
+    myself = 'tools/setup_helpers/split_types.py'
+    cmd = "{} {} '{}'".format(sys.executable, myself, file_name)
+    w.writer.build(
+        to_build, 'do_cmd', [file_name, myself],
+        variables={
+            'cmd': cmd,
+        })
+    return to_build
+
+
+def split_types(file_name, ninja_global):
+    # when ninja is enabled we just generate the build rule here
+    if ninja_global is not None:
+        return split_types_ninja(file_name, ninja_global)
+
     assert file_name.startswith('torch/csrc/')
     if not os.path.exists(generated_dir):
         os.makedirs(generated_dir)
@@ -56,3 +80,7 @@ def split_types(file_name):
                     t_include + '\n' +
                     suffix)
     return to_build
+
+# when called from ninja
+if __name__ == '__main__':
+    split_types(sys.argv[1], None)

--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -97,7 +97,8 @@ function build() {
               -Dnanopb_BUILD_GENERATOR=0 \
               -DCMAKE_DEBUG_POSTFIX="" \
               -DCMAKE_BUILD_TYPE=$([ $DEBUG ] && echo Debug || echo Release) \
-              ${@:2}
+              ${@:2} \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   make install -j$(getconf _NPROCESSORS_ONLN)
   cd ../..
 
@@ -150,7 +151,8 @@ function build_aten() {
   -DCUDNN_INCLUDE_DIR=$CUDNN_INCLUDE_DIR \
   -DCUDNN_LIB_DIR=$CUDNN_LIB_DIR \
   -DATEN_NO_CONTRIB=1 \
-  -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+  -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   # purpusefully not passing C_FLAGS for the same reason as above
   make -j$(getconf _NPROCESSORS_ONLN) install
   cd ../..


### PR DESCRIPTION
This commit adds code to setup.py to use ninja to manage
C++ and code generator dependencies rather than use raw setuptools.
This is based on similar code added to ONNX.

Enabled optionally when ninja is installed.

On my computer speed for a do-nothing build drops from 10s to 1.5 seconds.
Speed of other compilation steps is significantly improved as well.
Dependencies are tracked correctly so the need for ccache is reduced.