### PR TITLE
Bind cauchy_, exponential_, normal_, uniform_ functions to THPVariable.

### DIFF
--- a/aten/src/ATen/CPUGenerator.cpp
+++ b/aten/src/ATen/CPUGenerator.cpp
@@ -29,7 +29,7 @@ uint64_t CPUGenerator::seed() {
 }
 
 uint64_t CPUGenerator::initialSeed() {
-  return THRandom_seed(generator);
+  return THRandom_initialSeed(generator);
 }
 
 CPUGenerator& CPUGenerator::manualSeed(uint64_t seed) {

--- a/aten/src/ATen/CPUGenerator.cpp
+++ b/aten/src/ATen/CPUGenerator.cpp
@@ -28,6 +28,10 @@ uint64_t CPUGenerator::seed() {
   return THRandom_seed(generator);
 }
 
+uint64_t CPUGenerator::initialSeed() {
+  return THRandom_seed(generator);
+}
+
 CPUGenerator& CPUGenerator::manualSeed(uint64_t seed) {
   THRandom_manualSeed(generator, seed);
   return *this;

--- a/aten/src/ATen/CUDAGenerator.cpp
+++ b/aten/src/ATen/CUDAGenerator.cpp
@@ -37,6 +37,10 @@ uint64_t CUDAGenerator::seed() {
   return THCRandom_initialSeed(context->thc_state);
 }
 
+uint64_t CUDAGenerator::initialSeed() {
+  return THCRandom_initialSeed(context->thc_state);
+}
+
 CUDAGenerator& CUDAGenerator::manualSeed(uint64_t seed) {
   THCRandom_manualSeed(context->thc_state, seed);
   return *this;

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3614,7 +3614,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - long n
 ]]
@@ -3628,20 +3628,20 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
     - cname: cappedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - long to
     - cname: clampedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - long from
         - long to
@@ -3661,7 +3661,7 @@
     - arg: THIndexTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - THTensor* self
     - long num_samples
@@ -3680,7 +3680,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double from
       default: 0
@@ -3703,7 +3703,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - THTensor* means
         - arg: double std
@@ -3713,7 +3713,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - arg: double mean
         - THTensor* std
@@ -3722,7 +3722,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - THTensor* means
         - THTensor* std
@@ -3739,7 +3739,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double mean
       default: 0
@@ -3758,7 +3758,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double median
       default: 0
@@ -3778,7 +3778,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double mean
       default: 1
@@ -3797,7 +3797,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double lambd
       default: 1
@@ -3816,7 +3816,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -3835,7 +3835,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -3850,7 +3850,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - double p
 ]]
@@ -3873,7 +3873,7 @@
       output: True
       resize: self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - THTensor* self
 ]]
@@ -3888,7 +3888,7 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - arg: double p
           default: 0.5
@@ -3896,14 +3896,14 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - BackendFloatTensor* float_p
     - cname: bernoulli_DoubleTensor
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - BackendDoubleTensor* float_p
 ]]

--- a/aten/src/ATen/Generator.h
+++ b/aten/src/ATen/Generator.h
@@ -14,6 +14,7 @@ struct Generator {
   virtual Generator& free() = 0;
 
   virtual uint64_t seed() = 0;
+  virtual uint64_t initialSeed() = 0;
   virtual Generator& manualSeed(uint64_t seed) = 0;
   virtual void * unsafeGetTH() = 0;
 };

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -221,7 +221,7 @@ ALLOC_WRAP = {
 # Replacements for constants when calling into TH
 CONSTANT_REPLACEMENTS = [
     ('AS_REAL', '${AS_REAL}'),
-    ('THPDefaultGenerator->cdata',
+    ('THPGenerator_TH_CData(THPDefaultGenerator)',
      'dynamic_cast<${Generator}&>().generator'),
     ('__storage_size.get\\(\\)',
      'THLongStorageView::makeFromLength(static_cast<int64_t>(storage.size()))'),
@@ -231,7 +231,7 @@ CONSTANT_REPLACEMENTS = [
 # Replacements for constants in header file function definitions
 HEADER_CONSTANT_REPLACEMENTS = [
     (r'AS_REAL\((.*)\)', r'\1'),
-    ('THPDefaultGenerator->cdata', 'nullptr'),
+    ('THPGenerator_TH_CData\(THPDefaultGenerator\)', 'nullptr'),
     ('__last_dim', '-1'),
 ]
 
@@ -753,7 +753,7 @@ def create_derived(backend_type_env, declarations):
     def drop_argument(argument, option):
         return 'CUDA' in backend_type_env['Backend'] and (
             (option['mode'] == 'TH' and argument['type'] == 'THGenerator*') or
-            argument.get('default') == 'THPDefaultGenerator->cdata')
+            argument.get('default') == 'THPGenerator_TH_CData(THPDefaultGenerator)')
 
     def get_arguments(arguments, option):
         return [get_argument(argument, option)

--- a/aten/src/ATen/templates/GeneratorDerived.h
+++ b/aten/src/ATen/templates/GeneratorDerived.h
@@ -15,6 +15,7 @@ struct ${name}Generator : public Generator {
   virtual ${name}Generator& free() override;
 
   virtual uint64_t seed() override;
+  virtual uint64_t initialSeed() override;
   virtual ${name}Generator& manualSeed(uint64_t seed) override;
   virtual void * unsafeGetTH() override;
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -134,7 +134,8 @@
 - name: cat(TensorList tensors, int64_t dim)
   tensors: cat_tensors_backward(grad, to_arg_sizes(tensors, dim), dim)
 
-- name: cauchy  # TODO: reinforce
+- name: cauchy(Tensor self, double median, double sigma, Generator generator)
+  self: zeros_like(grad)
 
 - name: ceil(Tensor self)
   self: zeros_like(grad)
@@ -213,6 +214,9 @@
 
 - name: expand(Tensor self, IntList size)
   self: reduce_to(grad, self.sizes())
+
+- name: exponential(Tensor self, double lambd, Generator generator)
+  self: zeros_like(grad)
 
 - name: eye  # fallthrough
 
@@ -415,6 +419,9 @@
 - name: norm(Tensor self, Scalar p, int64_t dim, bool keepdim)
   self: norm_backward(grad, self, p, destination, dim, keepdim)
 
+- name: normal(Tensor self, double mean, double std, Generator generator)
+  self: zeros_like(grad)
+
 - name: numel  # fallthrough
 - name: ones  # fallthrough
 
@@ -466,6 +473,7 @@
 - name: rand  # fallthrough
 - name: randn  # fallthrough
 - name: randperm  # fallthrough
+
 - name: range  # fallthrough
 
 - name: reciprocal(Tensor self)
@@ -598,7 +606,8 @@
 - name: unfold(Tensor self, int64_t dimension, int64_t size, int64_t step)
   self: unfold_backward(grad, self.sizes(), dimension, size, step)
 
-- name: uniform  # fallthrough
+- name: uniform(Tensor self, double from, double to, Generator generator)
+  self: zeros_like(grad)
 
 - name: unsqueeze(Tensor self, int64_t dim)
   self: grad.squeeze(dim)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -176,7 +176,7 @@ deprecated_path = os.path.join(os.path.dirname(__file__), 'deprecated.yaml')
 FALLTHROUGH_RETURN_TYPES = {'int64_t', 'void*', 'bool', 'IntList'}
 FALLTHROUGH_FUNCTIONS = {
     'arange', 'eye', 'linspace', 'logspace', 'tensor', 'ones', 'ones_like',
-    'rand', 'randn', 'randperm', 'range', 'tensor', 'uniform', 'zeros',
+    'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros',
     'zeros_like', 'set_',
     # these are only implemented on integral types
     '__and__', '__iand__', '__ilshift__', '__ior__', '__irshift__', '__ixor__',

--- a/tools/cwrap/plugins/StandaloneExtension.py
+++ b/tools/cwrap/plugins/StandaloneExtension.py
@@ -42,7 +42,7 @@ class StandaloneExtension(CWrapPlugin):
         'long': Template('THPUtils_unpackLong($arg)'),
         'int64_t': Template('THPUtils_unpackLong($arg)'),
         'void*': Template('(void*)THPUtils_unpackLong($arg)'),
-        'THGenerator*': Template('THPGenerator_CData((THPGenerator*)$arg)'),
+        'THGenerator*': Template('THPGenerator_TH_CData((THPGenerator*)$arg)'),
     }
 
     TYPE_CHECK = {

--- a/tools/cwrap/plugins/THPPlugin.py
+++ b/tools/cwrap/plugins/THPPlugin.py
@@ -32,7 +32,7 @@ class THPPlugin(CWrapPlugin):
 
         'THLongStorage*': Template('((THPLongStorage*)$arg)->cdata'),
         'THStorage*': Template('((THPStorage*)$arg)->cdata'),
-        'THGenerator*': Template('((THPGenerator*)$arg)->cdata'),
+        'THGenerator*': Template('THPGenerator_TH_CData($arg)'),
         'THSize*': Template('__size.get()'),
         'THStride*': Template('__stride.get()'),
         'void*': Template('THPUtils_unpackLong($arg)'),

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -1,24 +1,26 @@
 #ifndef THP_GENERATOR_H
 #define THP_GENERATOR_H
 
+#include <ATen/ATen.h>
+
 struct THPGenerator {
   PyObject_HEAD
-  THGenerator *cdata;
+  at::Generator *cdata;
   bool owner;  // if true, frees cdata in destructor
 };
 
 #define THPGenerator_Check(obj) \
   PyObject_IsInstance(obj, THPGeneratorClass)
 
-#define THPGenerator_CData(obj) \
-  ((THPGenerator*)obj)->cdata
+#define THPGenerator_TH_CData(obj) \
+  (THGenerator*)((THPGenerator*)obj)->cdata->unsafeGetTH()
 
 THP_API PyObject * THPGenerator_New();
 
-// Creates a new Python object wrapping the THGenerator. The reference is
+// Creates a new Python object wrapping the at::Generator. The reference is
 // borrowed. The caller should ensure that the THGenerator* object lifetime
 // last at least as long as the Python wrapper.
-THP_API PyObject * THPGenerator_NewWithGenerator(THGenerator *cdata);
+THP_API PyObject * THPGenerator_NewWithGenerator(at::Generator& cdata);
 
 THP_API PyObject *THPGeneratorClass;
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -923,7 +923,7 @@ static PyObject* initModule() {
 
   auto& defaultGenerator = at::globalContext().defaultGenerator(at::kCPU);
   THPDefaultGenerator = (THPGenerator*)THPGenerator_NewWithGenerator(
-    (THGenerator*)defaultGenerator.unsafeGetTH());
+    defaultGenerator);
   ASSERT_TRUE(PyModule_AddObject(module, "default_generator", (PyObject*)THPDefaultGenerator) == 0);
 
 #ifdef WITH_NUMPY

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -65,7 +65,7 @@ static std::string THPStorage_(__newHandle)() {
   handle += std::to_string(getpid());
 #endif
   handle += "_";
-  handle += std::to_string(THRandom_random(THPDefaultGenerator->cdata));
+  handle += std::to_string(THRandom_random(THPGenerator_TH_CData(THPDefaultGenerator)));
   return handle;
 }
 

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -10,7 +10,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - int64_t n
 ]]
@@ -27,20 +27,20 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
     - cname: cappedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - int64_t to
     - cname: clampedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - int64_t from
         - int64_t to
@@ -61,7 +61,7 @@
     - arg: THIndexTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - THTensor* self
     - int num_samples
@@ -81,7 +81,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double from
       default: 0
@@ -105,7 +105,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - THTensor* means
         - arg: double std
@@ -115,7 +115,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - arg: double mean
           default: 0
@@ -125,7 +125,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - THTensor* means
         - THTensor* std
@@ -143,7 +143,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double mean
       default: 0
@@ -163,7 +163,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double median
       default: 0
@@ -184,7 +184,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double mean
       default: 1
@@ -204,7 +204,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: double lambd
       default: 1
@@ -244,7 +244,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -264,7 +264,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -281,7 +281,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - double p
 ]]
@@ -312,7 +312,7 @@
       output: True
       resize: self
     - arg: THGenerator* generator
-      default: THPDefaultGenerator->cdata
+      default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - THTensor* self
 ]]
@@ -334,7 +334,7 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - arg: double p
           default: 0.5
@@ -342,14 +342,14 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - BackendFloatTensor* float_p
     - cname: bernoulli_DoubleTensor
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - BackendDoubleTensor* float_p
 ]]

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -225,7 +225,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPDefaultGenerator->cdata
+          default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
         - THTensor* alpha
 ]]

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -82,7 +82,7 @@ bool FunctionParameter::check(PyObject* obj) {
       // if a size is specified (e.g. IntList[2]) we also allow passing a single int
       return size > 0 && THPUtils_checkLong(obj);
     }
-    case ParameterType::GENERATOR: return false;
+    case ParameterType::GENERATOR: return THPGenerator_Check(obj);
     case ParameterType::BOOL: return PyBool_Check(obj);
     case ParameterType::STORAGE: return false;
     default: throw std::runtime_error("unknown parameter type");

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -201,7 +201,7 @@ inline bool PythonArgs::isNone(int i) {
 
 inline at::Generator* PythonArgs::generator(int i) {
   if (!args[i]) return nullptr;
-  throw std::runtime_error("PythonArgs::generator not implemented");
+  throw std::runtime_error("PythonArgs::generator not implemented (only None allowed)");
 }
 
 inline at::Storage& PythonArgs::storage(int i) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -201,7 +201,10 @@ inline bool PythonArgs::isNone(int i) {
 
 inline at::Generator* PythonArgs::generator(int i) {
   if (!args[i]) return nullptr;
-  throw std::runtime_error("PythonArgs::generator not implemented (only None allowed)");
+  if (!THPGenerator_Check(args[i])) {
+    type_error("expected Generator as argument %d, but got %s", i, THPUtils_typename(args[i]));
+  }
+  return reinterpret_cast<THPGenerator*>(args[i])->cdata;
 }
 
 inline at::Storage& PythonArgs::storage(int i) {


### PR DESCRIPTION
Also changes the error messages around Generator parser; previously, you'd get an error
like: torch._C.Generator is not a torch.Generator; now the check is proper but returns
that only None is supported.  We likely need to change THPGenerator to have an at::Generator rather than a THGenerator to support non-None.