### PR TITLE
Add a CPU Fuser (single core)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -440,6 +440,7 @@ main_sources = [
     "torch/csrc/jit/init.cpp",
     "torch/csrc/jit/interpreter.cpp",
     "torch/csrc/jit/ir.cpp",
+    "torch/csrc/jit/fusion_compiler.cpp",
     "torch/csrc/jit/python_ir.cpp",
     "torch/csrc/jit/test_jit.cpp",
     "torch/csrc/jit/tracer.cpp",
@@ -558,7 +559,6 @@ if WITH_CUDA:
         "torch/csrc/cuda/utils.cpp",
         "torch/csrc/cuda/expand_utils.cpp",
         "torch/csrc/cuda/serialization.cpp",
-        "torch/csrc/jit/fusion_compiler.cpp",
     ]
     main_sources += split_types("torch/csrc/cuda/Tensor.cpp", ninja_global)
 

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -569,7 +569,6 @@ struct TempFile {
   }
   void sync() {
     fflush(file_);
-    fsync(fileno(file_));
   }
   void write(const std::string & str) {
     size_t result = fwrite(str.c_str(), 1, str.size(), file_);
@@ -636,9 +635,9 @@ static void runCompiler(const std::string & cpp, const std::string so) {
 
 struct CPUFusionFunction : public CompiledFusionFunction {
   CPUFusionFunction(const std::string & name, AnnotatedGraph & agraph)
-  : CompiledFusionFunction(name, agraph)
-  , so_file(so_template, 3)
-  , cpp_file(cpp_template, 4) {
+  : CompiledFusionFunction(name, agraph) {
+    TempFile so_file(so_template, 3);
+    TempFile cpp_file(cpp_template, 4);
 
     std::stringstream cu;
     concat_desc = codegen::emitCompilationUnit(cu, name, agraph, false);
@@ -656,8 +655,6 @@ protected:
   virtual void launch_raw(uint32_t numel, void ** arguments) override {
     kernel(numel, arguments);
   }
-  TempFile so_file;
-  TempFile cpp_file;
   std::unique_ptr<DynamicLibrary> so_lib;
   void (*kernel)(uint32_t, void**) = nullptr;
 };

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -3,17 +3,21 @@
 #include "torch/csrc/jit/code_template.h"
 #include "torch/csrc/jit/resource_guard.h"
 #include "torch/csrc/utils/disallow_copy.h"
-#include "torch/csrc/cuda/cuda_check.h"
 #include "ATen/ATen.h"
+#ifdef WITH_CUDA
+#include "torch/csrc/cuda/cuda_check.h"
 #include <nvrtc.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#endif
 #include <string>
 #include <algorithm>
 #include <unordered_map>
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <dlfcn.h>
+#include <unistd.h>
 
 namespace torch { namespace jit {
 
@@ -113,7 +117,7 @@ std::ostream& operator<<(std::ostream & out, const TensorDesc & d) {
 
 namespace codegen {
 
-auto compilation_unit_template = CodeTemplate(R"(
+auto type_declarations_template = CodeTemplate(R"(
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {
@@ -121,6 +125,10 @@ struct TensorInfo {
   IndexType sizes[N];
   IndexType strides[N];
 };
+)");
+
+auto cuda_compilation_unit_template = CodeTemplate(R"(
+${type_declarations}
 
 extern "C" __global__
 void ${kernelName}(IndexType totalElements, ${formals}) {
@@ -132,6 +140,30 @@ void ${kernelName}(IndexType totalElements, ${formals}) {
       // calculate the results
       ${kernelBody}
     }
+}
+)");
+
+auto cpu_compilation_unit_template = CodeTemplate(R"(
+#include <cstddef>
+#include <math.h>
+#include <iostream>
+${type_declarations}
+
+static void ${kernelName}_kernel(IndexType totalElements, ${formals}) {
+  // TODO: parallelize with something reasonable
+  for (IndexType linearIndex = 0;
+        linearIndex < totalElements;
+        linearIndex += 1) {
+      // Convert `linearIndex` into an offset of tensor:
+      ${tensorOffsets}
+      // calculate the results
+      ${kernelBody}
+    }
+}
+
+extern "C"
+void ${kernelName}(IndexType totalElements, void ** args) {
+  ${kernelName}_kernel(totalElements ${,argument_loads});
 }
 )");
 
@@ -210,7 +242,8 @@ std::string encodeRHS(Node * n) {
 
 std::vector<ConcatDesc> emitCompilationUnit(std::ostream & out,
                                             const std::string & name,
-                                            AnnotatedGraph & agraph) {
+                                            AnnotatedGraph & agraph,
+                                            bool use_cuda) {
   Graph& subgraph = *agraph.graph;
   TemplateEnv env;
   env.s("kernelName",name);
@@ -220,14 +253,17 @@ std::vector<ConcatDesc> emitCompilationUnit(std::ostream & out,
   std::stringstream body;
   std::stringstream tensorOffsets;
   std::vector<std::string> formals;
+  std::vector<std::string> argument_loads;
   auto emitFormal = [&](Value * n, const TensorDesc & desc) {
     std::string tensor = "t" + std::to_string(formals.size()); //can't be unique() because Param may be an output
     size_t nDim = desc.nDim();
     emitIndexingFor(tensorOffsets, tensor, nDim,  desc.lastIsContiguous());
     env.s("tensor",tensor);
+    env.d("formal_index", formals.size() + 1); // + 1 because the first argument is the linearIndex
     env.d("nDim",nDim);
     env.s("scalar_type",scalarTypeName(desc.scalar_type));
     formals.push_back(format("TensorInfo<${scalar_type},${nDim}> ${tensor}",env));
+    argument_loads.push_back(format("*static_cast<TensorInfo<${scalar_type},${nDim}>*>(args[${formal_index}])",env));
   };
   {
     size_t i = 0;
@@ -279,7 +315,13 @@ std::vector<ConcatDesc> emitCompilationUnit(std::ostream & out,
   env.s("tensorOffsets",tensorOffsets.str());
   env.s("kernelBody",body.str());
   env.v("formals",formals);
-  out << compilation_unit_template.format(env);
+  env.v("argument_loads",argument_loads);
+  env.s("type_declarations", type_declarations_template.format(env));
+  if(use_cuda) {
+    out << cuda_compilation_unit_template.format(env);
+  } else {
+    out << cpu_compilation_unit_template.format(env);
+  }
   return concat_desc;
 }
 
@@ -301,57 +343,7 @@ struct TensorInfo {
 CompiledFusionFunction::CompiledFusionFunction(const std::string & name, AnnotatedGraph & agraph)
   : name(name)
   , input_desc(agraph.input_desc)
-  , output_desc(agraph.output_desc) {
-  TORCH_CUDA_CHECK(cudaGetDevice(&device));
-  TORCH_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
-
-  if ((prop.major >= 6 && CUDA_VERSION < 8000) ||
-      (prop.major >= 7 && CUDA_VERSION < 9000)) {
-    std::stringstream err_string;
-    err_string << "In CompiledFusionFunction, PyTorch compiled with insufficient CUDA version: "
-	       << CUDA_VERSION << " for the current GPU device " << prop.name
-	       << " with device capability " << prop.major << "." << prop.minor;
-    throw std::runtime_error(err_string.str());
-  }
-
-  std::stringstream cu;
-  concat_desc = codegen::emitCompilationUnit(cu, name, agraph);
-  compilation_unit = cu.str();
-  nvrtcProgram program;
-  TORCH_NVRTC_CHECK(nvrtcCreateProgram(&program, compilation_unit.c_str(), NULL, 0, nullptr, nullptr));
-
-  std::string compute = "--gpu-architecture=compute_" + std::to_string(prop.major) + std::to_string(prop.minor);
-  std::vector<const char *> args = {"--std=c++11", compute.c_str()};
-  nvrtcResult result = nvrtcCompileProgram(program, args.size(), args.data());
-  if (result == NVRTC_ERROR_COMPILATION) {
-    size_t logsize;
-    nvrtcGetProgramLogSize(program, &logsize);
-    std::vector<char> log(logsize);
-    nvrtcGetProgramLog(program, log.data());
-    cu << log.data();
-    throw std::runtime_error(cu.str());
-  }
-  ResourceGuard holdProgram([&] {
-    TORCH_NVRTC_CHECK(nvrtcDestroyProgram(&program));
-  });
-  TORCH_NVRTC_CHECK(result);
-
-  size_t ptx_size;
-  TORCH_NVRTC_CHECK(nvrtcGetPTXSize(program, &ptx_size));
-  ptx.resize(ptx_size);
-  TORCH_NVRTC_CHECK(nvrtcGetPTX(program, ptx.data()));
-
-  TORCH_CU_CHECK(cuModuleLoadData(&module, ptx.data()));
-  TORCH_CU_CHECK(cuModuleGetFunction(&function, module, name.c_str()));
-
-  TORCH_CU_CHECK(cuOccupancyMaxActiveBlocksPerMultiprocessor(
-    &maxBlocks, function, 128, 0));
-  maxBlocks *= prop.multiProcessorCount;
-}
-
-CompiledFusionFunction::~CompiledFusionFunction() {
-  TORCH_CU_CHECK(cuModuleUnload(module));
-}
+  , output_desc(agraph.output_desc) {}
 
 namespace {
 
@@ -460,7 +452,7 @@ void CompiledFusionFunction::launch_with_tensors(at::ArrayRef<at::Tensor> inputs
       }
     }
   }
-  launch(numel, arguments.data());
+  launch_raw(numel, arguments.data());
 }
 
 void CompiledFusionFunction::launch(at::ArrayRef<at::Tensor> inputs, std::vector<at::Tensor> & outputs) {
@@ -468,36 +460,221 @@ void CompiledFusionFunction::launch(at::ArrayRef<at::Tensor> inputs, std::vector
   outputs.clear();
   outputs.reserve(outputDescriptors().size());
   for(auto & od : outputDescriptors()) {
-    outputs.push_back(at::CUDA(od.scalar_type).tensor());
+    outputs.push_back(at::getType(backend(),od.scalar_type).tensor());
   }
   launch_with_tensors(inputs, outputs);
 }
 
-void CompiledFusionFunction::launch(uint32_t numel, void ** arguments) {
-  int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
-  //std::cout << "maxBlocks = " << maxBlocks << " needed blocks: " << ceilDiv(numel,blockSize)
-  //          << " numblocks =  " << numBlocks;
+#ifdef WITH_CUDA
 
-  // it is possible that this is the first cuda call on this thread
-  // so make sure we initialize the Driver API's context
-  // cudaFree(0) accomplishes this.
-  cudaFree(0);
+struct CUDAFusionFunction : public CompiledFusionFunction {
+  CUDAFusionFunction(const std::string & name, AnnotatedGraph & agraph)
+  : CompiledFusionFunction(name, agraph) {
+    TORCH_CUDA_CHECK(cudaGetDevice(&device));
+    TORCH_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
 
-  TORCH_CU_CHECK(cuLaunchKernel(
-    function,
-    numBlocks, 1, 1,
-    blockSize, 1, 1,
-    0, nullptr,
-    arguments,
-    nullptr));
+    if ((prop.major >= 6 && CUDA_VERSION < 8000) ||
+        (prop.major >= 7 && CUDA_VERSION < 9000)) {
+      std::stringstream err_string;
+      err_string << "In CompiledFusionFunction, PyTorch compiled with insufficient CUDA version: "
+  	       << CUDA_VERSION << " for the current GPU device " << prop.name
+  	       << " with device capability " << prop.major << "." << prop.minor;
+      throw std::runtime_error(err_string.str());
+    }
+
+    std::stringstream cu;
+    concat_desc = codegen::emitCompilationUnit(cu, name, agraph, true);
+    compilation_unit = cu.str();
+    nvrtcProgram program;
+    TORCH_NVRTC_CHECK(nvrtcCreateProgram(&program, compilation_unit.c_str(), NULL, 0, nullptr, nullptr));
+
+    std::string compute = "--gpu-architecture=compute_" + std::to_string(prop.major) + std::to_string(prop.minor);
+    std::vector<const char *> args = {"--std=c++11", compute.c_str()};
+    nvrtcResult result = nvrtcCompileProgram(program, args.size(), args.data());
+    if (result == NVRTC_ERROR_COMPILATION) {
+      size_t logsize;
+      nvrtcGetProgramLogSize(program, &logsize);
+      std::vector<char> log(logsize);
+      nvrtcGetProgramLog(program, log.data());
+      cu << log.data();
+      throw std::runtime_error(cu.str());
+    }
+    ResourceGuard holdProgram([&] {
+      TORCH_NVRTC_CHECK(nvrtcDestroyProgram(&program));
+    });
+    TORCH_NVRTC_CHECK(result);
+
+    size_t ptx_size;
+    TORCH_NVRTC_CHECK(nvrtcGetPTXSize(program, &ptx_size));
+    ptx.resize(ptx_size);
+    TORCH_NVRTC_CHECK(nvrtcGetPTX(program, ptx.data()));
+
+    TORCH_CU_CHECK(cuModuleLoadData(&module, ptx.data()));
+    TORCH_CU_CHECK(cuModuleGetFunction(&function, module, name.c_str()));
+
+    TORCH_CU_CHECK(cuOccupancyMaxActiveBlocksPerMultiprocessor(
+      &maxBlocks, function, 128, 0));
+    maxBlocks *= prop.multiProcessorCount;
+  }
+  virtual ~CUDAFusionFunction() override {
+    TORCH_CU_CHECK(cuModuleUnload(module));
+  }
+protected:
+  virtual at::Backend backend() const override {
+    return at::kCUDA;
+  }
+  virtual void launch_raw(uint32_t numel, void ** arguments) override {
+     int numBlocks = std::min(maxBlocks, ceilDiv(numel, blockSize));
+     //std::cout << "maxBlocks = " << maxBlocks << " needed blocks: " << ceilDiv(numel,blockSize)
+     //          << " numblocks =  " << numBlocks;
+
+     // it is possible that this is the first cuda call on this thread
+     // so make sure we initialize the Driver API's context
+     // cudaFree(0) accomplishes this.
+     cudaFree(0);
+
+     TORCH_CU_CHECK(cuLaunchKernel(
+       function,
+       numBlocks, 1, 1,
+       blockSize, 1, 1,
+       0, nullptr,
+       arguments,
+       nullptr));
+  }
+  std::vector<char> ptx;
+  CUmodule module;
+  CUfunction function;
+
+  // we record prop/device so if they are availiable for launch heuristics
+  // querying at launch is too slow for device properties.
+  int device;
+  cudaDeviceProp prop;
+  int blockSize = 128;
+  int maxBlocks;
+};
+
+#endif
+
+struct TempFile {
+  TH_DISALLOW_COPY_AND_ASSIGN(TempFile);
+  TempFile(const std::string & t, int suffix) {
+    std::vector<char> tt(t.c_str(), t.c_str() + t.size() + 1);
+    int fd = mkstemps(tt.data(), suffix);
+    JIT_ASSERT(fd != -1);
+    file_ = fdopen(fd, "r+");
+    name_ = std::string(tt.begin(), tt.end() - 1);
+  }
+  const std::string & name() const {
+    return name_;
+  }
+  void sync() {
+    fflush(file_);
+    fsync(fileno(file_));
+  }
+  void write(const std::string & str) {
+    size_t result = fwrite(str.c_str(), 1, str.size(), file_);
+    JIT_ASSERT(str.size() == result);
+  }
+  FILE* file()  {
+    return file_;
+  }
+  ~TempFile() {
+    if(file_ != nullptr) {
+      // unlink first to ensure another mkstemps doesn't
+      // race between close and unlink
+      unlink(name_.c_str());
+      fclose(file_);
+    }
+  }
+private:
+  FILE * file_ = nullptr;
+  std::string name_;
+};
+
+static void* checkDL(void * x) {
+  if(!x) {
+    barf("error in dlopen or dlsym: %s", dlerror());
+  }
+  return x;
 }
+
+struct DynamicLibrary {
+  TH_DISALLOW_COPY_AND_ASSIGN(DynamicLibrary);
+  DynamicLibrary(const char * name) {
+    handle = checkDL(dlopen(name, RTLD_LOCAL | RTLD_NOW));
+  }
+  void * sym(const char * name) {
+    JIT_ASSERT(handle);
+    return checkDL(dlsym(handle, name));
+  }
+  ~DynamicLibrary() {
+    if(!handle) return;
+    int r = dlclose(handle);
+    if(r) {
+      barf("error in dlclose: %s", dlerror());
+    }
+  }
+private:
+  void * handle = nullptr;
+};
+
+static const std::string so_template = "/tmp/pytorch_fuserXXXXXX.so";
+static const std::string cpp_template = "/tmp/pytorch_fuserXXXXXX.cpp";
+
+// TODO: have python tell us what this is...
+static const std::string compile_string =
+  "g++ -O3 -g -march=native -std=c++11 -fPIC -shared \"${cpp_file}\" -o \"${so_file}\"";
+
+static void runCompiler(const std::string & cpp, const std::string so) {
+  TemplateEnv env;
+  env.s("cpp_file",cpp);
+  env.s("so_file",so);
+  std::string result = format(compile_string,env);
+  int r = system(result.c_str());
+  JIT_ASSERT(r == 0);
+}
+
+struct CPUFusionFunction : public CompiledFusionFunction {
+  CPUFusionFunction(const std::string & name, AnnotatedGraph & agraph)
+  : CompiledFusionFunction(name, agraph)
+  , so_file(so_template, 3)
+  , cpp_file(cpp_template, 4) {
+
+    std::stringstream cu;
+    concat_desc = codegen::emitCompilationUnit(cu, name, agraph, false);
+    compilation_unit = cu.str();
+    cpp_file.write(compilation_unit);
+    cpp_file.sync();
+    runCompiler(cpp_file.name(), so_file.name());
+    so_lib.reset(new DynamicLibrary(so_file.name().c_str()));
+    kernel = reinterpret_cast<void(*)(uint32_t, void**)>(so_lib->sym(name.c_str()));
+  }
+protected:
+  virtual at::Backend backend() const override {
+    return at::kCPU;
+  }
+  virtual void launch_raw(uint32_t numel, void ** arguments) override {
+    kernel(numel, arguments);
+  }
+  TempFile so_file;
+  TempFile cpp_file;
+  std::unique_ptr<DynamicLibrary> so_lib;
+  void (*kernel)(uint32_t, void**) = nullptr;
+};
 
 std::shared_ptr<CompiledFusionFunction> FusionCompiler::getOrCompile(AnnotatedGraph & agraph) {
   std::stringstream key;
   key << *agraph.graph << "\n";
-  int device;
-  TORCH_CUDA_CHECK(cudaGetDevice(&device));
-  key << "Device " << device << "\n";
+  key << "is_cuda " << agraph.is_cuda << "\n";
+  if(agraph.is_cuda) {
+#ifdef WITH_CUDA
+    int device;
+    TORCH_CUDA_CHECK(cudaGetDevice(&device));
+    key << "Device " << device << "\n";
+#else
+    throw std::runtime_error("cannot compile a CUDA fusion group, CUDA is not enabled.");
+#endif
+  }
   for(auto & i : agraph.input_desc)
     key << i << "\n";
   for(auto & i : agraph.output_desc)
@@ -507,25 +684,37 @@ std::shared_ptr<CompiledFusionFunction> FusionCompiler::getOrCompile(AnnotatedGr
   auto it = cache.find(key_);
   if (it == cache.end()) {
     std::string name = "kernel_" + std::to_string(cache.size());
-    auto func = std::make_shared<CompiledFusionFunction>(name, agraph);
-    it = cache.emplace(key_, std::move(func)).first;
+    CompiledFusionFunction * raw_func;
+    if(agraph.is_cuda) {
+#ifdef WITH_CUDA
+      raw_func = new CUDAFusionFunction(name, agraph);
+#else
+      throw std::runtime_error("cannot compile a CUDA fusion group, CUDA is not enabled.");
+#endif
+    } else {
+      raw_func = new CPUFusionFunction(name, agraph);
+    }
+    it = cache.emplace(key_, std::shared_ptr<CompiledFusionFunction>(raw_func)).first;
   }
   return it->second;
 }
 
-std::shared_ptr<CompiledFusionFunction> FusionCompiler::getOrCompile(Graph & graph) {
-  AnnotatedGraph agraph { &graph };
+std::shared_ptr<CompiledFusionFunction> FusionCompiler::getOrCompile(Node* fusion_group) {
+  auto & graph = *fusion_group->g(kSubgraph);
+  AnnotatedGraph agraph(graph, fusion_group->i(kis_cuda));
   for(auto & input : graph.inputs()) {
-    agraph.input_desc.emplace_back(input->type()->expect<TensorType>());
+    auto t = input->type()->expect<TensorType>();
+    agraph.input_desc.emplace_back(t);
   }
   for(auto & output : graph.outputs()) {
-    agraph.output_desc.emplace_back(output->type()->expect<TensorType>());
+    auto t = output->type()->expect<TensorType>();
+    agraph.output_desc.emplace_back(t);
   }
   return getOrCompile(agraph);
 }
 
-void FusionCompiler::debugLaunchGraph(Graph & graph, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs) {
-  AnnotatedGraph agraph { &graph };
+void FusionCompiler::debugLaunchGraph(Graph & graph, bool is_cuda, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs) {
+  AnnotatedGraph agraph(graph, is_cuda);
   for(auto & i : inputs) {
     agraph.input_desc.emplace_back(i);
   }

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -122,7 +122,7 @@ protected:
 // caching compiler
 struct FusionCompiler {
   TH_DISALLOW_COPY_AND_ASSIGN(FusionCompiler);
-  FusionCompiler() {}
+  FusionCompiler();
 
   // ignores types in graph, and uses specific contiguity annotations
   std::shared_ptr<CompiledFusionFunction> getOrCompile(AnnotatedGraph & agraph);
@@ -134,7 +134,11 @@ struct FusionCompiler {
   // this should not be used in the hot path of execution because it has to serialize
   // the graph each time
   void debugLaunchGraph(Graph & graph, bool is_cuda, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs);
+  bool canCompileOnCPU() const {
+    return cxx.size() > 0;
+  }
 private:
+  std::string cxx; // compiler location
   std::unordered_map<std::string, std::shared_ptr<CompiledFusionFunction>> cache;
 };
 

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -122,7 +122,8 @@ _(sub) \
 _(tan) \
 _(trunc) \
 _(zeros) \
-_(exponent)
+_(exponent) \
+_(is_cuda)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -770,10 +770,10 @@ public:
     n->t_(kvalue, ref.clone());
     return n;
   }
-  Node * createFusionGroup() {
+  Node * createFusionGroup(bool is_cuda) {
     auto n = create(kFusionGroup, 0);
-    auto subgraph = std::make_shared<Graph>(scope_root_);
-    n->g_(kSubgraph, subgraph);
+    n->g_(kSubgraph,std::make_shared<Graph>(scope_root_));
+    n->i_(kis_cuda, is_cuda);
     return n;
   }
   Node * createPythonOp(THPObjectPtr&& pyobj, const std::string & cconv, bool is_legacy, std::vector<VariableFlags> && var_flags, pyobj_list&& scalar_args);

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -89,6 +89,9 @@ struct GraphFuser {
   : graph(graph) {}
 
   bool isCuda(Node * node) {
+    if(node->kind() == kFusionGroup) {
+      return node->i(kis_cuda);
+    }
     return node->output()->type()->expect<TensorType>()->device() != -1;
   }
   // TODO: the fusion compiler has a lot of float-specific codegen
@@ -118,7 +121,7 @@ struct GraphFuser {
   }
   bool isFusable(Node * node) {
     if (node->kind() == kFusionGroup) return true;
-    return isSimpleMap(node) && allFloatIO(node) && isCuda(node);
+    return isSimpleMap(node) && allFloatIO(node);
   }
 
   // Can this node produce an _output_ of a fusion group?
@@ -128,7 +131,7 @@ struct GraphFuser {
   bool isFusableAsExitNode(Node * node) {
     if(isFusable(node))
       return true;
-    if(node->kind() != kcat || !isCuda(node))
+    if(node->kind() != kcat)
       return false;
 
     // this concat fusion only works when all the inputs are the same size
@@ -168,7 +171,9 @@ struct GraphFuser {
     // if the consumer allInputsAreThisProducer(consumer,producer)
     // we can move the consumer up into the producer.
     // but this requires better handling of merging fusion groups so it is not done now
-    return isFusable(producer->node()) && allUsersAreThisConsumerOrOccurAfterIt(consumer, producer);
+    return isFusable(producer->node()) &&
+      allUsersAreThisConsumerOrOccurAfterIt(consumer, producer) &&
+      isCuda(consumer) == isCuda(producer->node());
   }
 
   // insert a producer node into a consuming fusion group.
@@ -276,7 +281,7 @@ struct GraphFuser {
   // turn consumer node n into a fusion group with just n inside
   // to prepare for fusion and replace uses of n with the new group
   Node * createSingletonFusionGroup(Node * n) {
-    auto group = graph->createFusionGroup();
+    auto group = graph->createFusionGroup(isCuda(n));
     // propogate position information for the new node so we can always
     // have a valid mapping
     topological_index[group] = topological_index[n];

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -97,7 +97,7 @@ static void fusionTests() {
     auto a = at::CUDA(at::kFloat).rand({3,4});
     auto b = at::CUDA(at::kFloat).rand({4,3}).transpose(0,1);
     auto o = at::CUDA(at::kFloat).zeros({3,4});
-    comp.debugLaunchGraph(graph, {a,b}, {o});
+    comp.debugLaunchGraph(graph, true, {a,b}, {o});
     auto o2 = a*b;
     float max_diff = (o2 - o).abs().max().toCDouble();
     //std::cout << "max diff: " << max_diff << "\n";
@@ -160,7 +160,7 @@ static void fusionTests() {
 
 
     //auto out0 = inputs[0]*inputs[1];
-    comp.debugLaunchGraph(graph, inputs, outputs);
+    comp.debugLaunchGraph(graph, true, inputs, outputs);
     JIT_ASSERT(out0.is_same_size(outputs.front()));
     float max_diff = (outputs.front() - out0).abs().max().toCDouble();
     JIT_ASSERT(max_diff < 1e-6);
@@ -191,7 +191,7 @@ static void fusionTests() {
     auto o_r = a*b;
     auto o2_r = at::cat({a, o_r}, dim);
     auto o2 = at::CUDA(at::kFloat).zeros(o2_r.sizes());
-    comp.debugLaunchGraph(graph, {a,b}, {o, o2});
+    comp.debugLaunchGraph(graph, true, {a,b}, {o, o2});
 
     float max_diff = (o_r - o).abs().max().toCDouble();
     JIT_ASSERT(max_diff == 0);


### PR DESCRIPTION
This adds a simple fusion backend for the CPU.
* Refactors CompiledFusionFunction to have two subclasses that handle
  the compilation details of each backend.
* emit-compile-link-run cycle for the CPU
* simple single core loop to run the operation
* lift CUDA-only restrictions in the fuser, checks that fusion groups
  are only on a single backend.

Perf tests need to be done to see if this is a lot slower than current CPU maps.
We need some reasonable way to do threading for parallelization (pthreads, tbb, openmp, etc.), but that can be a different commit.