### PR TITLE
Add streams and comms as optional arguments

### DIFF
--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -14,6 +14,11 @@ if nGPUs == 0:
 
 class TestNCCL(TestCase):
 
+    def test_unique_id(self):
+        uid = nccl.unique_id()
+        self.assertIsInstance(uid, bytes)
+        self.assertGreater(len(uid), 1)
+
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_broadcast(self):
         expected = torch.FloatTensor(128).uniform_()

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -417,6 +417,9 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_lock_mutex",   (PyCFunction)THCPModule_cudaLockMutex,   METH_NOARGS,  NULL},
   {"_cuda_unlock_mutex", (PyCFunction)THCPModule_cudaUnlockMutex, METH_NOARGS,  NULL},
 #ifdef WITH_NCCL
+  {"_nccl_version", (PyCFunction)THCPModule_nccl_version, METH_NOARGS, NULL},
+  {"_nccl_unique_id", (PyCFunction)THCPModule_nccl_unique_id, METH_NOARGS, NULL},
+  {"_nccl_init_rank", (PyCFunction)THCPModule_nccl_init_rank, METH_VARARGS, NULL},
   {"_nccl_reduce", (PyCFunction)THCPModule_nccl_reduce, METH_VARARGS, NULL},
   {"_nccl_all_reduce", (PyCFunction)THCPModule_nccl_all_reduce, METH_VARARGS, NULL},
   {"_nccl_broadcast", (PyCFunction)THCPModule_nccl_broadcast, METH_VARARGS, NULL},

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -8,8 +8,11 @@
 #include <sstream>
 #include <unordered_map>
 
-static inline void CHECK(ncclResult_t status)
-{
+using namespace at;
+
+static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
+
+static inline void CHECK(ncclResult_t status) {
   if (status != ncclSuccess) {
     std::stringstream err;
     err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
@@ -35,30 +38,35 @@ struct NcclCommList {
            In these cases, skip ncclCommDestroy */
           return;
         }
-	ncclCommDestroy(comms[i]);
+        ncclCommDestroy(comms[i]);
       }
     }
+  }
+  ArrayRef<ncclComm_t> ref() const {
+    return ArrayRef<ncclComm_t>(comms.get(), ndevices);
   }
 };
 
 // accesses to this object have to be guarded by THC's CudaFreeMutex
-std::unordered_map<std::string, NcclCommList > _communicators;
+std::unordered_map<std::string, NcclCommList> _communicators;
 
-static ncclComm_t* _get_communicator(std::vector<at::Tensor>& inputs) {
-  int ndevices = inputs.size();
+static ArrayRef<ncclComm_t> _get_communicators(TensorList inputs, ArrayRef<ncclComm_t> user_comms) {
+  if (user_comms.size() == inputs.size()) {
+    return user_comms;
+  }
   std::stringstream hash_stream;
   std::vector<int> devs;
-  for (int i = 0; i < ndevices; i++) {
-    int dev = inputs[i].get_device();
-    hash_stream <<  dev << ",";
+  for (auto& input : inputs) {
+    int dev = input.get_device();
+    hash_stream << dev << ",";
     devs.push_back(dev);
   }
   std::string hash = hash_stream.str();
   auto it = _communicators.find(hash);
   if (it == _communicators.end()) {
-    return _communicators.emplace_hint(it, hash, devs)->second.comms.get();
+    return _communicators.emplace_hint(it, hash, devs)->second.ref();
   } else {
-    return it->second.comms.get();
+    return it->second.ref();
   }
 }
 
@@ -79,18 +87,18 @@ static void _check_inputs(std::vector<at::Tensor> &inputs, std::vector<at::Tenso
   std::unordered_set<int> devices;
   devices.reserve(len);
   int64_t numel = inputs[0].numel();
-  auto type = inputs[0].type().ID();
+  auto& type = inputs[0].type();
 
   for (size_t i = 0; i < len; i++) {
     auto input = inputs[i];
     auto output = outputs[i];
 
     if (!(input.type().is_cuda() && !input.type().is_sparse()
-	  && output.type().is_cuda()  && !output.type().is_sparse())) {
+        && output.type().is_cuda()  && !output.type().is_sparse())) {
       throw std::runtime_error("input and output elements have to be cuda dense Tensors");
     }
 
-    if (type != input.type().ID() || type != output.type().ID()) {
+    if (!(type == input.type() && type == output.type())) {
       throw std::runtime_error("all inputs and outputs must be of the same Tensor type");
     }
 
@@ -121,61 +129,161 @@ static void _check_inputs(std::vector<at::Tensor> &inputs, std::vector<at::Tenso
   }
 }
 
-static ncclDataType_t _get_data_type(at::TypeID type) {
-  switch(type) {
-  case at::TypeID::CUDAFloat   : return ncclFloat;
-  case at::TypeID::CUDAHalf    : return ncclHalf;
-  case at::TypeID::CUDADouble  : return ncclDouble;
-  case at::TypeID::CUDALong    : return ncclInt64;
-  case at::TypeID::CUDAInt     : return ncclInt;
-  case at::TypeID::CUDAChar    : return ncclChar;
-  case at::TypeID::CUDAByte    : return ncclChar;
+static ncclDataType_t _get_data_type(const Type& type) {
+  if (type.backend() != kCUDA) {
+    throw std::runtime_error("Unconvertible NCCL type");
+  }
+  switch (type.scalarType()) {
+  case at::kFloat   : return ncclFloat;
+  case at::kHalf    : return ncclHalf;
+  case at::kDouble  : return ncclDouble;
+  case at::kLong    : return ncclInt64;
+  case at::kInt     : return ncclInt;
+  case at::kChar    : return ncclChar;
+  case at::kByte    : return ncclChar;
   default: throw std::runtime_error("Unconvertible NCCL type");
   }
 }
 
+static void _start_group() {
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+  CHECK(ncclGroupStart());
+#endif
+}
+
+static void _end_group() {
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+  CHECK(ncclGroupEnd());
+#endif
+}
+
+PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args) {
+#if defined(NCCL_MAJOR)
+  return PyInt_FromLong(NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH);
+#else
+  return PyInt_FromLong(1000);  // assume NCCL 1.0
+#endif
+}
+
+PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  ncclUniqueId id;
+  CHECK(ncclGetUniqueId(&id));
+  return PyBytes_FromStringAndSize((char*)&id, NCCL_UNIQUE_ID_BYTES);
+  END_HANDLE_TH_ERRORS
+}
+
+static ncclComm_t unpack_nccl_comm(PyObject* capsule) {
+  ncclComm_t comm = (ncclComm_t)PyCapsule_GetPointer(capsule, COMM_CAPSULE_NAME);
+  if (!comm) throw python_error();
+  return comm;
+}
+
+static void destroy_nccl_comm(PyObject* capsule) {
+  HANDLE_TH_ERRORS
+  ncclComm_t comm = unpack_nccl_comm(capsule);
+  with_no_gil([&]{
+    ncclCommDestroy(comm);
+  });
+  END_HANDLE_TH_ERRORS_RET()
+}
+
+static std::vector<THCStream*> unpack_streams(PyObject* obj, size_t size) {
+  if (obj == Py_None) {
+    return std::vector<THCStream*>(size, nullptr);
+  }
+  auto streams = THPUtils_PySequence_to_THCStreamList(obj);
+  if (streams.size() != size) {
+    throw std::runtime_error("number of streams is not equal to number of inputs");
+  }
+  return streams;
+}
+
+static std::vector<ncclComm_t> unpack_comms(PyObject* obj, size_t size) {
+  if (obj == Py_None) {
+    return std::vector<ncclComm_t>();
+  }
+  std::vector<ncclComm_t> comms;
+  if (PyCapsule_CheckExact(obj)) {
+    comms = { unpack_nccl_comm(obj) };
+  } else {
+    auto seq = THPObjectPtr(PySequence_Fast(obj, "comm is not a sequence"));
+    if (!seq) throw python_error();
+    auto size = PySequence_Fast_GET_SIZE(seq.get());
+    comms = std::vector<ncclComm_t>(size);
+    for (int64_t i = 0; i < size; i++) {
+      comms[i] = unpack_nccl_comm(PySequence_Fast_GET_ITEM(seq.get(), i));
+    }
+  }
+  if (comms.size() != size) {
+    throw std::runtime_error("number of communicators is not equal to number of inputs");
+  }
+  return comms;
+}
+
+PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  int nranks;
+  const char* id;
+  Py_ssize_t id_len;
+  int rank;
+
+  if (!PyArg_ParseTuple(args, "is#i:nccl_init_rank", &nranks, &id, &id_len, &rank)) {
+    return NULL;
+  }
+  THPUtils_assert(id_len == NCCL_UNIQUE_ID_BYTES,
+      "invalid unqiue_id (expected %d bytes, got %zd)",
+      NCCL_UNIQUE_ID_BYTES, id_len);
+
+  ncclUniqueId commId;
+  memcpy(&commId, id, NCCL_UNIQUE_ID_BYTES);
+  ncclComm_t comm;
+  with_no_gil([&]{
+    CHECK(ncclCommInitRank(&comm, nranks, commId, rank));
+  });
+  return PyCapsule_New(comm, COMM_CAPSULE_NAME, &destroy_nccl_comm);
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
   HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs, *_streams;
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
   int root, op;
 
-  if (!PyArg_ParseTuple(args, "OOOii", &_inputs, &_outputs, &_streams, &root, &op)) {
+  if (!PyArg_ParseTuple(args, "OOiiOO", &_inputs, &_outputs, &root, &op, &_streams, &_comms)) {
     THPUtils_invalidArguments(args, NULL, "nccl_reduce", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor]"
-			      " outputs, sequence[torch.cuda.Stream or None], int root, int op");
+			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int root,"
+            " int op, sequence[torch.cuda.Stream or None]");
     return NULL;
   }
 
   std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
   std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
-  std::vector<THCStream*> streams = THPUtils_PySequence_to_THCStreamList(_streams);
+  std::vector<THCStream*> streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
 
-  THPUtils_assert(inputs.size() == streams.size(), "number of streams is not equal to number of inputs");
+  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
 
-  // we can safely release GIL after this line, no python API used
-  AutoNoGIL no_gil;
-  _check_inputs(inputs, outputs, 1, 1);
-  size_t len = inputs.size();
+  with_no_gil([&]{
+    _check_inputs(inputs, outputs, 1, 1);
+    size_t len = inputs.size();
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
 
-  int64_t count = inputs[0].numel();
-  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  ncclComm_t *comm = _get_communicator(inputs);
-  AutoGPU gpu_guard;
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupStart());
-#endif
-  for (size_t i = 0; i < len; i++) {
-    int device = inputs[i].get_device();
-    gpu_guard.setDevice(device);
-    auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-    CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-		     count, data_type, (ncclRedOp_t) op, root, comm[i], stream));
-  }
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupEnd());
-#endif
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = _get_communicators(inputs, user_comms);
+    AutoGPU gpu_guard;
+    _start_group();
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
+           count, data_type, (ncclRedOp_t) op, root, comms[i], stream));
+    }
+    _end_group();
+  });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -183,42 +291,42 @@ PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
 
 PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
   HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs;
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
   int op;
 
-  if (!PyArg_ParseTuple(args, "OOi", &_inputs, &_outputs, &op)) {
+  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
     THPUtils_invalidArguments(args, NULL, "nccl_all_reduce", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor]"
-			      " outputs, int op");
+        "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op,"
+        " sequence[torch.cuda.Stream] streams,"
+        " sequence[torch.cuda.nccl.Communicator] comms)");
     return NULL;
   }
 
   std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
   std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
 
-  // we can safely release GIL after this line, no python API used
-  AutoNoGIL no_gil;
-  _check_inputs(inputs, outputs, 1, 1);
-  size_t len = inputs.size();
+  with_no_gil([&]{
+    _check_inputs(inputs, outputs, 1, 1);
+    size_t len = inputs.size();
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
 
-  int64_t count = inputs[0].numel();
-  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  ncclComm_t *comm = _get_communicator(inputs);
-  AutoGPU gpu_guard;
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupStart());
-#endif
-  for (size_t i = 0; i < len; i++) {
-    int device = inputs[i].get_device();
-    gpu_guard.setDevice(device);
-    CHECK(ncclAllReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-			count, data_type, (ncclRedOp_t) op, comm[i], NULL));
-  }
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupEnd());
-#endif
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = _get_communicators(inputs, user_comms);
+    AutoGPU gpu_guard;
+    _start_group();
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclAllReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
+          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+    }
+    _end_group();
+  });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -226,39 +334,39 @@ PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
 
 PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
   HANDLE_TH_ERRORS
-  PyObject *_inputs;
+  PyObject *_inputs, *_streams, *_comms;
   int root;
 
-  if (!PyArg_ParseTuple(args, "Oi", &_inputs, &root)) {
+  if (!PyArg_ParseTuple(args, "OiOO", &_inputs, &root, &_streams, &_comms)) {
     THPUtils_invalidArguments(args, NULL, "nccl_broadcast", 1,
-			      "(sequence[Tensor] inputs, int root");
+			      "(sequence[Tensor] inputs, int root)");
     return NULL;
   }
 
   std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
 
-  // we can safely release GIL after this line, no python API used
-  AutoNoGIL no_gil;
-  _check_inputs(inputs, inputs, 1, 1);
-  size_t len = inputs.size();
+  with_no_gil([&]{
+    _check_inputs(inputs, inputs, 1, 1);
+    size_t len = inputs.size();
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
 
-  int64_t count = inputs[0].numel();
-  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  ncclComm_t *comm = _get_communicator(inputs);
-  AutoGPU gpu_guard;
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupStart());
-#endif
-  for (size_t i = 0; i < len; i++) {
-    int device = inputs[i].get_device();
-    gpu_guard.setDevice(device);
-    CHECK(ncclBcast(inputs[i].data_ptr(), count, data_type, root, comm[i], NULL));
-  }
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupEnd());
-#endif
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = _get_communicators(inputs, user_comms);
+    AutoGPU gpu_guard;
+    _start_group();
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclBcast(inputs[i].data_ptr(), count, data_type, root, comms[i], stream));
+    }
+    _end_group();
+  });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -266,9 +374,9 @@ PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
 
 PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
   HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs;
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
 
-  if (!PyArg_ParseTuple(args, "OO", &_inputs, &_outputs)) {
+  if (!PyArg_ParseTuple(args, "OOOO", &_inputs, &_outputs, &_streams, &_comms)) {
     THPUtils_invalidArguments(args, NULL, "nccl_all_gather", 1,
 			      "(sequence[Tensor] inputs, sequence[Tensor] outputs");
     return NULL;
@@ -276,35 +384,34 @@ PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
 
   std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
   std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
 
-  // we can safely release GIL after this line, no python API used
-  AutoNoGIL no_gil;
-  size_t len = inputs.size();
-  _check_inputs(inputs, outputs, len, 1);
+  with_no_gil([&]{
+    size_t len = inputs.size();
+    _check_inputs(inputs, outputs, len, 1);
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
 
-  int64_t count = inputs[0].numel();
-  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  ncclComm_t *comm = _get_communicator(inputs);
-  AutoGPU gpu_guard;
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupStart());
-#endif
-  for (size_t i = 0; i < len; i++) {
-    int device = inputs[i].get_device();
-    gpu_guard.setDevice(device);
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-    CHECK(ncclAllGather(inputs[i].data_ptr(), outputs[i].data_ptr(),
-			count, data_type, comm[i], NULL));
-#else
-    CHECK(ncclAllGather(inputs[i].data_ptr(), count, data_type,
-			outputs[i].data_ptr(), comm[i], NULL));
-#endif
-  }
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupEnd());
-#endif
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = _get_communicators(inputs, user_comms);
+    AutoGPU gpu_guard;
+    _start_group();
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+    #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+      CHECK(ncclAllGather(inputs[i].data_ptr(), outputs[i].data_ptr(),
+        count, data_type, comms[i], stream));
+    #else
+      CHECK(ncclAllGather(inputs[i].data_ptr(), count, data_type,
+        outputs[i].data_ptr(), comms[i], stream));
+    #endif
+    }
+    _end_group();
+  });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -312,10 +419,10 @@ PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
 
 PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
   HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs;
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
   int op;
 
-  if (!PyArg_ParseTuple(args, "OOi", &_inputs, &_outputs, &op)) {
+  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
     THPUtils_invalidArguments(args, NULL, "nccl_reduce_scatter", 1,
 			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op");
     return NULL;
@@ -323,30 +430,29 @@ PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
 
   std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
   std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
 
-  // we can safely release GIL after this line, no python API used
-  AutoNoGIL no_gil;
-  size_t len = inputs.size();
-  _check_inputs(inputs, outputs, 1, len);
+  with_no_gil([&]{
+    size_t len = inputs.size();
+    _check_inputs(inputs, outputs, 1, len);
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type().ID());
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
 
-  int64_t count = inputs[0].numel() / len;
-  std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-  ncclComm_t *comm = _get_communicator(inputs);
-  AutoGPU gpu_guard;
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupStart());
-#endif
-  for (size_t i = 0; i < len; i++) {
-    int device = inputs[i].get_device();
-    gpu_guard.setDevice(device);
-    CHECK(ncclReduceScatter(inputs[i].data_ptr(), outputs[i].data_ptr(),
-			    count, data_type, (ncclRedOp_t) op, comm[i], NULL));
-  }
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-  CHECK(ncclGroupEnd());
-#endif
+    int64_t count = inputs[0].numel() / len;
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = _get_communicators(inputs, user_comms);
+    AutoGPU gpu_guard;
+    _start_group();
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclReduceScatter(inputs[i].data_ptr(), outputs[i].data_ptr(),
+          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+    }
+    _end_group();
+  });
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -2,7 +2,10 @@
 #define THCP_CUDA_NCCL_INC
 #include <Python.h>
 
-PyObject* THCPModule_nccl_reduce(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args);
 PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args);
 PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args);
 PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args);

--- a/torch/csrc/utils/auto_gil.h
+++ b/torch/csrc/utils/auto_gil.h
@@ -25,3 +25,10 @@ struct AutoNoGIL {
 
   PyThreadState* save;
 };
+
+// Runs the function without the GIL
+template<typename F>
+inline void with_no_gil(F f) {
+  AutoNoGIL no_gil;
+  f();
+}

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -1,8 +1,5 @@
-import os
-import ctypes
 import warnings
 import torch.cuda
-from torch.backends.cudnn import int_array
 
 __all__ = ['all_reduce', 'reduce', 'broadcast', 'all_gather', 'reduce_scatter']
 
@@ -30,29 +27,37 @@ def is_available(tensors):
     return True
 
 
-def all_reduce(inputs, outputs=None, op=SUM):
+def version():
+    return torch._C._nccl_version()
+
+
+def unique_id():
+    return torch._C._nccl_unique_id()
+
+
+def init_rank(num_ranks, uid, rank):
+    return torch._C._nccl_init_rank(num_ranks, uid, rank)
+
+
+def all_reduce(inputs, outputs=None, op=SUM, streams=None, comms=None):
     if outputs is None:
         outputs = inputs
-    torch._C._nccl_all_reduce(inputs, outputs, op)
+    torch._C._nccl_all_reduce(inputs, outputs, op, streams, comms)
 
 
-def reduce(inputs, outputs=None, root=0, op=SUM, streams=None):
-    assert(root >= 0 and root < len(inputs))
+def reduce(inputs, outputs=None, root=0, op=SUM, streams=None, comms=None):
     if outputs is None:
         outputs = inputs
-    if streams is None:
-        streams = [None] * len(inputs)
-    torch._C._nccl_reduce(inputs, outputs, streams, root, op)
+    torch._C._nccl_reduce(inputs, outputs, root, op, streams, comms)
 
 
-def broadcast(inputs, root=0):
-    assert(root >= 0 and root < len(inputs))
-    torch._C._nccl_broadcast(inputs, root)
+def broadcast(inputs, root=0, streams=None, comms=None):
+    torch._C._nccl_broadcast(inputs, root, streams, comms)
 
 
-def all_gather(inputs, outputs):
-    torch._C._nccl_all_gather(inputs, outputs)
+def all_gather(inputs, outputs, streams=None, comms=None):
+    torch._C._nccl_all_gather(inputs, outputs, streams, comms)
 
 
-def reduce_scatter(inputs, outputs, op=SUM):
-    torch._C._nccl_reduce_scatter(inputs, outputs, op)
+def reduce_scatter(inputs, outputs, op=SUM, streams=None, comms=None):
+    torch._C._nccl_reduce_scatter(inputs, outputs, op, streams, comms)


### PR DESCRIPTION
Adds streams and comms as optional arguments to the NCCL calls in
torch.cuda.nccl. Also exposes ncclUniqueId and ncclCommInitRank for
multi-process mode.

Moves Py_RETURN_NONE statements after the GIL is re-acquired.