### PR TITLE
add momentum correction in batchnorm

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -61,12 +61,14 @@ class SGD(Optimizer):
         for group in self.param_groups:
             group.setdefault('nesterov', False)
 
-    def step(self, closure=None):
+    def step(self, closure=None, momentum_correction=None):
         """Performs a single optimization step.
 
         Arguments:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
+            momentum_correction (optional): Appy momentum correction in distributed
+                training (multi nodes).
         """
         loss = None
         if closure is not None:
@@ -91,6 +93,8 @@ class SGD(Optimizer):
                         buf.mul_(momentum).add_(d_p)
                     else:
                         buf = param_state['momentum_buffer']
+                        if momentum_correction:
+                            buf.mul_(momentum_correction)
                         buf.mul_(momentum).add_(1 - dampening, d_p)
                     if nesterov:
                         d_p = d_p.add(momentum, buf)


### PR DESCRIPTION
This is used in distributed imagenet training on resnet. It is called every time when lr is updated. (ref: https://arxiv.org/abs/1706.02677)
Tested on resnet50 model together with pytorch/example/imagenet changes:
1 node, 8 gpus, batchsize=256, lr=0.1 (Baseline): * Prec@1 76.172 Prec@5 93.090
4 nodes, 32 gpus, batchsize=1024, lr=0.1(without the tricks): * Prec@1 74.980 Prec@5 92.144
4 nodes, 32 gpus, batchsize=1024, lr=0.4( with distributed training tricks): Prec@1 76.224 Prec@5 92.962