### PR TITLE
Accept longs in default_collate for dataloader in python 2

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -9,7 +9,7 @@ import re
 import sys
 import traceback
 import threading
-from torch._six import string_classes
+from torch._six import string_classes, int_classes
 
 
 if sys.version_info[0] == 2:
@@ -114,7 +114,7 @@ def default_collate(batch):
         if elem.shape == ():  # scalars
             py_type = float if elem.dtype.name.startswith('float') else int
             return numpy_type_map[elem.dtype.name](list(map(py_type, batch)))
-    elif isinstance(batch[0], int):
+    elif isinstance(batch[0], int_classes):
         return torch.LongTensor(batch)
     elif isinstance(batch[0], float):
         return torch.DoubleTensor(batch)


### PR DESCRIPTION
The default collate function currently throws an error if you return a long from your data loader. This is because in Python 2 `int(2**64)` automatically converts to type `long`