### PR TITLE
Make pool export compliant with onnx spec

### DIFF
--- a/torch/nn/_functions/thnn/pooling.py
+++ b/torch/nn/_functions/thnn/pooling.py
@@ -24,7 +24,7 @@ class MaxPool1d(Function):
             stride = kernel_size
         r = g.op("MaxPool", input,
                  kernel_shape_i=_single(kernel_size),
-                 pads_i=_single(padding),
+                 pads_i=_single(padding) * 2,
                  strides_i=_single(stride))
         return r, None
 
@@ -112,7 +112,7 @@ class MaxPool3d(Function):
             stride = kernel_size
         r = g.op("MaxPool", input,
                  kernel_shape_i=_triple(kernel_size),
-                 pads_i=_triple(padding),
+                 pads_i=_triple(padding) * 2,
                  strides_i=_triple(stride))
         return r, None
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -274,7 +274,7 @@ def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
         stride = kernel_size
     r = g.op("MaxPool", input,
              kernel_shape_i=_pair(kernel_size),
-             pads_i=_pair(padding),
+             pads_i=_pair(padding) * 2,
              strides_i=_pair(stride))
     return r, None
 
@@ -288,7 +288,7 @@ def avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_
     return g.op("AveragePool", input,
                 kernel_shape_i=_pair(kernel_size),
                 strides_i=_pair(stride),
-                pads_i=_pair(padding))
+                pads_i=_pair(padding) * 2)
 
 
 def avg_pool3d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad):


### PR DESCRIPTION
Our caffe2 backend supports both symmetric and asymmetric padding, but the spec tells it should be asymmetric. Let's fix it properly.