### PR TITLE
Exclude attrs with invalid python variable names from __dir__

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -677,4 +677,8 @@ class Module(object):
         modules = list(self._modules.keys())
         buffers = list(self._buffers.keys())
         keys = module_attrs + attrs + parameters + modules + buffers
+
+        # Eliminate attrs that are not legal Python variable names
+        keys = [key for key in keys if not key[0].isdigit()]
+
         return sorted(keys)


### PR DESCRIPTION
Fixes #3343. This is a usability fix so that attributes like '0' don't show up in autocompletion.

### Test Plan
Run the following:
```
import torch
import torch.nn as nn
foo = nn.Sequential(*[nn.Linear(10, 100), nn.Linear(100, 5)])
assert hasattr(foo, '0')
assert not '0' in foo.__dir__()
```