### PR TITLE
More Misc. Build Fixes

### DIFF
--- a/tools/setup_helpers/ninja_builder.py
+++ b/tools/setup_helpers/ninja_builder.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import setuptools
 import distutils
 from contextlib import contextmanager
@@ -25,7 +26,13 @@ class NinjaBuilder(object):
     def run(self):
         import ninja
         self.writer.close()
-        subprocess.check_call([self.ninja_program, '-f', self.filename])
+        try:
+            subprocess.check_call([self.ninja_program, '-f', self.filename])
+        except subprocess.CalledProcessError as err:
+            # avoid printing the setup.py stack trace because it obscures the
+            # C++ errors.
+            sys.stderr.write(str(err) + '\n')
+            sys.exit(1)
         compile_db_path = os.path.join(BUILD_DIR, '{}_compile_commands.json'.format(self.name))
         with open(compile_db_path, 'w') as compile_db:
             subprocess.check_call([self.ninja_program, '-f', self.filename,

--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -123,6 +123,7 @@ function build_nccl() {
    mkdir -p build/nccl
    cd build/nccl
    ${CMAKE_VERSION} ../../nccl -DCMAKE_MODULE_PATH="$BASE_DIR/cmake/FindCUDA" \
+               ${CMAKE_GENERATOR} \
                -DCMAKE_BUILD_TYPE=Release \
                -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
                -DCMAKE_C_FLAGS="$C_FLAGS" \


### PR DESCRIPTION
* added missing ${CMAKE_GENERATOR} to nccl. CI didn't catch because CI doesn't use ninja
* Make it so that C++ errors are not covered by a long setup.py stack trace.