### PR TITLE
Fix segfault during ONNX export

### DIFF
--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -197,9 +197,6 @@ public:
   const Node * node() const {
     return node_;
   }
-  Scope* scope();
-  void setScope(Scope* scope);
-  std::string scopeName() const;
   Graph * owningGraph();
   const Graph * owningGraph() const;
   // TODO: make this more const correct
@@ -854,18 +851,6 @@ inline Value::Value(Node * node_, size_t offset_)
   unique_(node_->graph_->next_unique_++),
   stage_(node_->graph_->new_node_stage_) {
   node_->graph_->all_values.emplace(this);
-}
-
-inline Scope* Value::scope() {
-  return node()->scope();
-}
-
-inline void Value::setScope(Scope* scope) {
-  node()->setScope(scope);
-}
-
-inline std::string Value::scopeName() const {
-  return node()->scopeName();
 }
 
 inline Graph * Value::owningGraph() {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -86,6 +86,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
         // Copy over source location information to all nodes created by
         // the symbolic
         outputs[i]->node()->setSourceLocation(node->getSourceLocation());
+        outputs[i]->node()->setScope(node->scope());
         env[old] = outputs[i];
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
@@ -135,10 +136,6 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
          << ": expected to return list of op nodes, instead received type ''"
          << py::str(raw_output.get_type()) << "': " << py::str(raw_output);
       throw std::runtime_error(ss.str());
-    }
-
-    for (auto& el: outputs) {
-      el->setScope(n->scope());
     }
 
     setOutputs(op_name, n, outputs);
@@ -213,7 +210,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state) {
       if (auto fn = std::dynamic_pointer_cast<autograd::HasSymbolic>(value->fn)) {
         auto outputs = fn->symbolic(&ctx, fmap(node->inputs(), envFn), node->getSourceLocation());
         for (auto& el: outputs) {
-          el->setScope(node->scope());
+          el->node()->setScope(node->scope());
         }
         setOutputs(value->name(), node, outputs);
       } else {


### PR DESCRIPTION
This PR fixes segfault occurring at: https://ci.pytorch.org/jenkins/job/onnx-fb-universe-builds/job/caffe2-linux-xenial/45/console
Stacktrace here: https://gist.github.com/bddppq/b90ffaa91a0415e935ffe642bb6e760c

Essentially, `Value::setScope` was implemented by relaying the call to `node()`, but `node()` was not guaranteed to be non-null.

Rather than checking for `nullptr` everywhere, I decided to just remove `Value::setScope` (and the other scope-related methods) from `Value` and have the user call the corresponding method on the value returned by `node()` (torch/csrc/jit/passes/onnx.cpp:89):
```
outputs[i]->node()->setScope(node->scope());
```

This follows the same strategy adopted for setting the source location (torch/csrc/jit/passes/onnx.cpp:88):
```
outputs[i]->node()->setSourceLocation(node->getSourceLocation());
```

/cc @ezyang @bddppq 