### PR TITLE
Neg n_workers are now the same as zero

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -219,8 +219,9 @@ class DataLoaderIter(object):
             # prime the prefetch loop
             for _ in range(2 * self.num_workers):
                 self._put_indices()
-        else:
-            self.num_workers = 0
+        elif self.num_workers < 0:
+            raise ValueError('num_workers cannot be negative; '
+                             'use num_workers=0 to disable multiprocessing.')
 
     def __len__(self):
         return len(self.batch_sampler)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -219,6 +219,8 @@ class DataLoaderIter(object):
             # prime the prefetch loop
             for _ in range(2 * self.num_workers):
                 self._put_indices()
+        else:
+            self.num_workers = 0
 
     def __len__(self):
         return len(self.batch_sampler)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -219,9 +219,6 @@ class DataLoaderIter(object):
             # prime the prefetch loop
             for _ in range(2 * self.num_workers):
                 self._put_indices()
-        elif self.num_workers < 0:
-            raise ValueError('num_workers cannot be negative; '
-                             'use num_workers=0 to disable multiprocessing.')
 
     def __len__(self):
         return len(self.batch_sampler)
@@ -363,6 +360,10 @@ class DataLoader(object):
 
         if sampler is not None and shuffle:
             raise ValueError('sampler is mutually exclusive with shuffle')
+
+        if self.num_workers < 0:
+            raise ValueError('num_workers cannot be negative; '
+                             'use num_workers=0 to disable multiprocessing.')
 
         if batch_sampler is None:
             if sampler is None:


### PR DESCRIPTION
I foolishly passed the kwarg `num_workers=-1` to a `DataLoader` expecting that it would default to serial processing (I correctly recalled that it should be a non-positive number, but failed to remember that it must be zero to get this behavior). 

Normally this would be fine, but the error message that it spat out when I did this was very confusing:

```
AttributeError: 'DataLoaderIter' object has no attribute 'rcvd_idx'
``` 

What made the matter worse is that I recently put a print statement in that file to test something, so I though I had broken pytorch, but I couldn't figure out where the difference was. After spending too much time searching for cached pyc files, I finally realized my mistake. 

I wanted to submit a patch so it would at least spit out a ValueError. However, I think it is a simpler change to have it accept negative numbers. This change simply makes it so setting num_workers to a non-positive number results in the same behavior as zero. 