### PR TITLE
Delete _write_metadata and move _new_with_metadata_file into Python

### DIFF
--- a/torch/csrc/generic/methods/TensorSerialization.cwrap
+++ b/torch/csrc/generic/methods/TensorSerialization.cwrap
@@ -1,51 +1,3 @@
-#if !IS_DISTRIBUTED
-[[
-  name: THPTensor_(writeMetadata)
-  python_name: _write_metadata
-  defined_if: "!IS_DISTRIBUTED"
-  only_register: True
-]]
-PyObject * THPTensor_(writeMetadata)(THPTensor *self, PyObject *args)
-{
-  if (!args || PyTuple_Size(args) != 1) {
-    THPUtils_invalidArguments(args, NULL, "_write_metadata", 1, "a single file object");
-    return NULL;
-  }
-  int fd = PyObject_AsFileDescriptor(PyTuple_GET_ITEM(args, 0));
-  if (fd == -1) {
-    THPUtils_setError("write_file could not retrieve file descriptor from given object");
-    return NULL;
-  }
-  THPTensor_(writeMetadataRaw)(self->cdata, fd);
-  Py_RETURN_NONE;
-}
-
-[[
-  name: THPTensor_(newWithMetadataFile)
-  python_name: _new_with_metadata_file
-  defined_if: "!IS_DISTRIBUTED"
-  only_register: True
-  method_flags: METH_STATIC
-]]
-PyObject * THPTensor_(newWithMetadataFile)(PyObject *_null, PyObject *args)
-{
-  if (!args || PyTuple_Size(args) != 2 ||
-        !THPStorage_(Check)(PyTuple_GET_ITEM(args, 1))) {
-    THPUtils_invalidArguments(args, NULL, "_new_with_metadata_file", 1,
-        "single file object and a storage object");
-    return NULL;
-  }
-  int fd = PyObject_AsFileDescriptor(PyTuple_GET_ITEM(args, 0));
-  if (fd == -1) {
-    THPUtils_setError("write_file could not retrieve file descriptor from given object");
-    return NULL;
-  }
-  THStorage *storage = ((THPStorage*)PyTuple_GET_ITEM(args, 1))->cdata;
-  return THPTensor_(New)(THPTensor_(newWithMetadataFileRaw)(fd, storage));
-}
-#endif
-
-
 [[
   name: THPTensor_(toNumpy)
   python_name: numpy
@@ -121,5 +73,3 @@ PyObject * THPTensor_(toNumpy)(THPTensor *self, PyObject *args) {
   return array.release();
 #endif
 }
-
-

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -4,27 +4,6 @@
 
 #define SYSCHECK(call) { ssize_t __result = call; if (__result < 0) throw std::system_error((int) __result, std::system_category()); }
 
-void THPTensor_(writeMetadataRaw)(THTensor *self, int fd)
-{
-  SYSCHECK(write(fd, &self->nDimension, sizeof(int64_t)));
-  SYSCHECK(write(fd, self->size, sizeof(*self->size) * self->nDimension));
-  SYSCHECK(write(fd, self->stride, sizeof(*self->stride) * self->nDimension));
-  SYSCHECK(write(fd, &self->storageOffset, sizeof(self->storageOffset)));
-}
-
-THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage)
-{
-  THTensorPtr tensor(THTensor_(new)(LIBRARY_STATE_NOARGS));
-  SYSCHECK(read(fd, &tensor->nDimension, sizeof(int64_t)));
-  tensor->size = (int64_t*)THAlloc(tensor->nDimension * sizeof(*tensor->size));
-  tensor->stride = (int64_t*)THAlloc(tensor->nDimension * sizeof(*tensor->stride));
-  SYSCHECK(read(fd, tensor->size, sizeof(*tensor->size) * tensor->nDimension));
-  SYSCHECK(read(fd, tensor->stride, sizeof(*tensor->stride) * tensor->nDimension));
-  SYSCHECK(read(fd, &tensor->storageOffset, sizeof(tensor->storageOffset)));
-  THStorage_(retain)(LIBRARY_STATE storage);
-  tensor->storage = storage;
-  return tensor.release();
-}
 
 void THPStorage_(writeFileRaw)(THStorage *self, int fd)
 {

--- a/torch/csrc/generic/serialization.h
+++ b/torch/csrc/generic/serialization.h
@@ -2,8 +2,6 @@
 #define TH_GENERIC_FILE "generic/serialization.h"
 #else
 
-void THPTensor_(writeMetadataRaw)(THTensor *self, int fd);
-THTensor * THPTensor_(newWithMetadataFileRaw)(int fd, THStorage *storage);
 void THPStorage_(writeFileRaw)(THStorage *self, int fd);
 THStorage * THPStorage_(readFileRaw)(int fd, THStorage *storage);
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -355,8 +355,8 @@ def _load(f, map_location, pickle_module):
                     ndim, = struct.unpack('<i', f.read(4))
                     # skip next 4 bytes; legacy encoding treated ndim as 8 bytes
                     f.read(4)
-                    size = struct.unpack('<{}'.format('q' * ndim), f.read(8 * ndim))
-                    stride = struct.unpack('<{}'.format('q' * ndim), f.read(8 * ndim))
+                    size = struct.unpack('<{}q'.format(ndim), f.read(8 * ndim))
+                    stride = struct.unpack('<{}q'.format(ndim), f.read(8 * ndim))
                     storage_offset, = struct.unpack('<q', f.read(8))
                     tensor = tensor_type().set_(storage, storage_offset, size, stride)
                     deserialized_objects[key] = tensor

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -347,12 +347,18 @@ def _load(f, map_location, pickle_module):
             tar.extract('tensors', path=tmpdir)
             with open(os.path.join(tmpdir, 'tensors'), 'rb', 0) as f:
                 num_tensors = pickle_module.load(f)
-                for i in range(num_tensors):
+                for _ in range(num_tensors):
                     args = pickle_module.load(f)
                     key, storage_id, original_tensor_type = args
                     storage = deserialized_objects[storage_id]
                     tensor_type = storage_to_tensor_type(storage)
-                    tensor = tensor_type._new_with_metadata_file(f, storage)
+                    ndim, = struct.unpack('<i', f.read(4))
+                    # skip next 4 bytes; legacy encoding treated ndim as 8 bytes
+                    f.read(4)
+                    size = struct.unpack('<{}'.format('q' * ndim), f.read(8 * ndim))
+                    stride = struct.unpack('<{}'.format('q' * ndim), f.read(8 * ndim))
+                    storage_offset, = struct.unpack('<q', f.read(8))
+                    tensor = tensor_type().set_(storage, storage_offset, size, stride)
                     deserialized_objects[key] = tensor
 
             pickle_file = tar.extractfile('pickle')


### PR DESCRIPTION
This will make it easier to merge Variable and Tensor

Note: we were doing something weird when reading nDimension:

```
SYSCHECK(read(fd, &tensor->nDimension, sizeof(int64_t)));
```

nDimension is only 32-bits on every platform we care about, but we're reading 64 bits. We were reading and writing some extra garbage onto the next field (the `THStorage*` pointer). The `THStorage*` pointer then got fixed up via the call to `set_` later on.