### PR TITLE
Use enabled argument in torch.autograd.profiler.emit_nvtx

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -250,7 +250,7 @@ class emit_nvtx(object):
         ...         model(x)
     """
     def __init__(self, enabled=True):
-        self.enabled = True
+        self.enabled = enabled
         self.entered = False
 
     def __enter__(self):


### PR DESCRIPTION
Or else it's always enabled, and fails on CPU when ``enabled=False``