### PR TITLE
Enable OpenMP in fuser

### DIFF
--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -149,8 +149,9 @@ auto cpu_compilation_unit_template = CodeTemplate(R"(
 #include <iostream>
 ${type_declarations}
 
+#define OMP_THRESHOLD 100000
 static void ${kernelName}_kernel(IndexType totalElements, ${formals}) {
-  // TODO: parallelize with something reasonable
+  #pragma omp parallel for if(totalElements > OMP_THRESHOLD)
   for (IndexType linearIndex = 0;
         linearIndex < totalElements;
         linearIndex += 1) {
@@ -626,15 +627,21 @@ static const std::string so_template = "/tmp/pytorch_fuserXXXXXX.so";
 static const std::string cpp_template = "/tmp/pytorch_fuserXXXXXX.cpp";
 
 static const std::string compile_string =
-  "\"${cxx}\" -O3 -g -march=native -std=c++11 -fPIC -shared \"${cpp_file}\" -o \"${so_file}\"";
+  "\"${cxx}\" -O3 -g -march=native -std=c++11 -fPIC ${fopenmp} -shared \"${cpp_file}\" -o \"${so_file}\"";
 
 static void runCompiler(FusionCompilerConfig & config, const std::string & cpp_file, const std::string & so_file) {
   TemplateEnv env;
   env.s("cxx", config.cxx);
+  env.s("fopenmp", config.openmp ? "-fopenmp" : "");
   env.s("cpp_file",cpp_file);
   env.s("so_file",so_file);
   std::string result = format(compile_string,env);
   int r = system(result.c_str());
+  if(config.openmp && r != 0) {
+    std::cerr << "warning: pytorch jit fuser failed to compile with openmp, trying without it...\n";
+    config.openmp = false; // disable for future compiles
+    return runCompiler(config, cpp_file, so_file);
+  }
   JIT_ASSERT(r == 0);
 }
 

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -122,6 +122,7 @@ protected:
 struct FusionCompilerConfig {
   std::string cxx = "g++"; // compiler location
   bool debug = false; // emit debugging information about fusions
+  bool openmp = true;
 };
 
 // caching compiler


### PR DESCRIPTION
Because it is hard to know whether -fopenmp will work on a user's machine,
we just try it, and then disable it if it doesn't work.

Fused kernels are now competitive with the stuff in TH when the kernel
is flops bound, and faster when the original kernel was memory bound.