### PR TITLE
Assert MKL ld* conditions for ger, gemm, and gemv

### DIFF
--- a/aten/src/TH/generic/THBlas.c
+++ b/aten/src/TH/generic/THBlas.c
@@ -201,11 +201,12 @@ void THBlas_(gemv)(char trans, int64_t m, int64_t n, real alpha, real *a, int64_
     lda = m;
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
-  if( (m <= INT_MAX) && (n <= INT_MAX) &&
-      (lda >= THMax(1, m)) && (lda <= INT_MAX) &&
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (lda <= INT_MAX) &&
       (incx > 0) && (incx <= INT_MAX) &&
       (incy > 0) && (incy <= INT_MAX) )
   {
+    THArgCheck(lda >= THMax(1, m), 6,
+      "lda should be at least max(1, m=%d), but have %d", m, lda);
     int i_m = (int)m;
     int i_n = (int)n;
     int i_lda = (int)lda;
@@ -259,11 +260,12 @@ void THBlas_(ger)(int64_t m, int64_t n, real alpha, real *x, int64_t incx, real 
     lda = m;
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
-  if( (m <= INT_MAX) && (n <= INT_MAX) &&
-      (lda >= THMax(1, m)) && (lda <= INT_MAX) &&
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (lda <= INT_MAX) &&
       (incx > 0) && (incx <= INT_MAX) &&
       (incy > 0) && (incy <= INT_MAX) )
   {
+    THArgCheck(lda >= THMax(1, m), 9,
+      "lda should be at least max(1, m=%d), but have %d", m, lda);
     int i_m = (int)m;
     int i_n = (int)n;
     int i_lda = (int)lda;
@@ -322,10 +324,14 @@ void THBlas_(gemm)(char transa, char transb, int64_t m, int64_t n, int64_t k, re
 
 #if defined(USE_BLAS) && (defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_FLOAT))
   if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) &&
-      (lda >= THMax(1, (transa_ ? k : m))) && (lda <= INT_MAX) &&
-      (ldb >= THMax(1, (transb_ ? n : k))) && (ldb <= INT_MAX) &&
-      (ldc >= THMax(1, m)) && (ldc <= INT_MAX) )
+      (lda <= INT_MAX) && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
   {
+    THArgCheck(lda >= THMax(1, (transa_ ? k : m)), 8,
+      "lda should be at least max(1, %d), but have %d", (transa_ ? k : m), lda);
+    THArgCheck(ldb >= THMax(1, (transb_ ? n : k)), 10,
+      "ldb should be at least max(1, %d), but have %d", (transb_ ? n : k), ldb);
+    THArgCheck(ldc >= THMax(1, m), 13,
+      "ldc should be at least max(1, m=%d), but have %d", m, ldc);
     int i_m = (int)m;
     int i_n = (int)n;
     int i_k = (int)k;

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -138,7 +138,11 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
-  bias = bias ? THTensor_(newContiguous)(bias) : bias;
+  THArgCheck(THTensor_(isContiguous)(columns), 5, "columns needs to be contiguous");
+  if (bias) {
+    bias = THTensor_(newContiguous)(bias);
+    THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
+  }
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -265,6 +269,7 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   weight = THTensor_(newContiguous)(weight);
+  THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -370,8 +375,11 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   THArgCheck(THTensor_(isContiguous)(gradWeight), 4, "gradWeight needs to be contiguous");
-  if (gradBias)
+  THArgCheck(THTensor_(isContiguous)(columns), 6, "columns needs to be contiguous");
+  if (gradBias) {
     THArgCheck(THTensor_(isContiguous)(gradBias), 5, "gradBias needs to be contiguous");
+    THArgCheck(THTensor_(isContiguous)(ones), 7, "ones needs to be contiguous");
+  }
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch

--- a/aten/src/THNN/generic/VolumetricDilatedConvolution.c
+++ b/aten/src/THNN/generic/VolumetricDilatedConvolution.c
@@ -85,7 +85,11 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
 
   input = THTensor_(newContiguous)(input);
   weight = THTensor_(newContiguous)(weight);
-  bias = bias ? THTensor_(newContiguous)(bias) : bias;
+  THArgCheck(THTensor_(isContiguous)(columns), 5, "columns needs to be contiguous");
+  if (bias) {
+    bias = THTensor_(newContiguous)(bias);
+    THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
+  }
   int batch = 1;
   if (input->nDimension == 4) {
     // Force batch
@@ -189,7 +193,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
 
   THTensor_(free)(input);
   THTensor_(free)(weight);
-  if (bias) THTensor_(free)(bias);  
+  if (bias) THTensor_(free)(bias);
 }
 
 void THNN_(VolumetricDilatedConvolution_updateGradInput)(
@@ -216,7 +220,8 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   weight = THTensor_(newContiguous)(weight);
-  
+  THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
+
   int batch = 1;
   if (input->nDimension == 4) {
     // Force batch
@@ -321,7 +326,13 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
-  
+  THArgCheck(THTensor_(isContiguous)(gradWeight), 4, "gradWeight needs to be contiguous");
+  THArgCheck(THTensor_(isContiguous)(columns), 6, "columns needs to be contiguous");
+  if (gradBias) {
+    THArgCheck(THTensor_(isContiguous)(gradBias), 5, "gradBias needs to be contiguous");
+    THArgCheck(THTensor_(isContiguous)(ones), 7, "ones needs to be contiguous");
+  }
+
   int batch = 1;
   if (input->nDimension == 4) {
     // Force batch


### PR DESCRIPTION
Issue #3606 .

Changes are mainly:

1. in `THBlas.c`, use assert rather than `if`.
2. in relevant caller functions in `THTensorMath.c`, make tensors contiguous if those checks aren't met.
3. add contiguity checks in 4 legacy kernels (\[Spatial|Volumetric\](Full)?DilatedConvolution) that calls these methods. They are contiguous before, but the logic involves both Python and C++, and is a bit complicated, so I add the check to be clear, and to be safe.