### PR TITLE
Implement _values() and _indices() methods for sparse variables in python (and sparse tensors in aten)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4013,3 +4013,29 @@
     - THTensor* self
     - THSTensor* mask
 ]]
+
+[[
+  name: _indices
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THDenseIndexTensor*
+  cname: newIndices
+  arguments:
+     - THTensor* self
+]]
+
+[[
+  name: _values
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THDenseTensor*
+  cname: newValues
+  arguments:
+     - THTensor* self
+]]

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4028,7 +4028,7 @@
   aten_custom_call: |
     if (self_->isScalar()) {
       // Empty tensor
-      return self_->type().toScalarType(kLong).zeros({});
+      return self_->type().toScalarType(kLong).tensor({0});
     }
 ]]
 

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4025,6 +4025,11 @@
   cname: newIndices
   arguments:
      - THTensor* self
+  aten_custom_call: |
+    if (self_->isScalar()) {
+      // Empty tensor
+      return self_->type().toScalarType(kLong).zeros({});
+    }
 ]]
 
 [[

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1035,6 +1035,12 @@ def create_derived(backend_type_env, declarations):
         elif ret['kind'] == 'type':
             assert len(calls) == 1
             call = calls[0]
+            if 'aten_custom_call' in option:
+                # all aten_custom_call bodies handle settings on their own.
+                scalar_check = None
+                body.append(CodeTemplate(
+                    option['aten_custom_call']).substitute(env))
+
             if ret['type'] in ALLOC_WRAP.keys():
                 maybe_scalar = "->maybeScalar({})".format(scalar_check) \
                                if scalar_check is not None \

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -193,8 +193,10 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
     env['Storage'] = "{}{}Storage".format(backend, scalar_name)
     env['Type'] = "{}{}{}Type".format(density_tag, backend, scalar_name)
     env['Tensor'] = "{}{}{}Tensor".format(density_tag, backend, scalar_name)
+    env['DenseTensor'] = "{}{}Tensor".format(backend, scalar_name)
     env['SparseTensor'] = "Sparse{}{}Tensor".format(backend, scalar_name)
     env['Backend'] = density_tag + backend
+    env['DenseBackend'] = backend
 
     # used for generating switch logic for external functions
     tag = density_tag + backend + scalar_name

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -11,6 +11,8 @@
 #include "ATen/${Backend}IntTensor.h"
 #include "ATen/${Backend}LongTensor.h"
 #include "ATen/${SparseTensor}.h"
+#include "ATen/${DenseTensor}.h"
+#include "ATen/${DenseBackend}LongTensor.h"
 #include "ATen/Allocator.h"
 #include "ATen/Utils.h"
 #include "ATen/WrapDimUtils.h"

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -215,7 +215,7 @@ deprecated_path = os.path.join(os.path.dirname(__file__), 'deprecated.yaml')
 FALLTHROUGH_RETURN_TYPES = {'int64_t', 'void*', 'bool', 'IntList'}
 FALLTHROUGH_FUNCTIONS = {
     'arange', 'eye', 'linspace', 'logspace', 'tensor', 'ones', 'ones_like',
-    'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros',
+    'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros', '_indices', '_values',
     # these are only implemented on integral types
     '__and__', '__iand__', '__ilshift__', '__ior__', '__irshift__', '__ixor__',
     '__lshift__', '__or__', '__rshift__', '__xor__',

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -215,7 +215,8 @@ deprecated_path = os.path.join(os.path.dirname(__file__), 'deprecated.yaml')
 FALLTHROUGH_RETURN_TYPES = {'int64_t', 'void*', 'bool', 'IntList'}
 FALLTHROUGH_FUNCTIONS = {
     'arange', 'eye', 'linspace', 'logspace', 'tensor', 'ones', 'ones_like',
-    'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros', '_indices', '_values',
+    'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros',
+    'zeros_like', 'set_', '_indices', '_values',
     # these are only implemented on integral types
     '__and__', '__iand__', '__ilshift__', '__ior__', '__irshift__', '__ixor__',
     '__lshift__', '__or__', '__rshift__', '__xor__',

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -216,7 +216,6 @@ FALLTHROUGH_RETURN_TYPES = {'int64_t', 'void*', 'bool', 'IntList'}
 FALLTHROUGH_FUNCTIONS = {
     'arange', 'eye', 'linspace', 'logspace', 'tensor', 'ones', 'ones_like',
     'rand', 'randn', 'randperm', 'range', 'tensor', 'zeros',
-    'zeros_like', 'set_',
     # these are only implemented on integral types
     '__and__', '__iand__', '__ilshift__', '__ior__', '__irshift__', '__ixor__',
     '__lshift__', '__or__', '__rshift__', '__xor__',


### PR DESCRIPTION
This is a part of making sparse tensors work with dataloader (#3898)

This exposes `_values()` and `_indices()` for sparse variables in python (and sparse tensors in Aten).

To do this, I added THDenseTensor* and THDenseIndexTensor* return value functionality to Declarations.cwrap. These should always mean "the dense equivalent of THTensor*" and "the dense equivalent of THIndexTensor*" respectively. 
 
cc @zdevito for the THDenseTensor in cwrap addition

### Test Plan
Run the following:
```
import torch
from torch.autograd import Variable
v = torch.FloatTensor([3, 4, 5])
i = torch.LongTensor([[0, 1, 1], [2, 0, 2]])
x = Variable(torch.sparse.FloatTensor(i, v, torch.Size([2,3])))

x._indices()
x.data._indices()

x._values()
x.data._values()
```