### PR TITLE
Fix non-determinism in code generation scripts

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -644,7 +644,8 @@ def create_generic(top_env, declarations):
         # generate the at::native function declarations (i.e. what the user will implement)
         if isinstance(dispatch, dict):
             generated_native_functions = []
-            for _, value in dispatch.items():
+            for key in sorted(dispatch.keys()):
+                value = dispatch[key]
                 if value not in generated_native_functions:
                     option['native_type_method_dispatch'] = value
                     top_env['native_function_declarations'].append(

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -304,7 +304,7 @@ def declare_outputs():
              'Dispatch.h', 'Copy.cpp', 'NativeFunctions.h']
     for f in files:
         file_manager.will_write(f)
-    for fname in generators.keys():
+    for fname in sorted(generators.keys()):
         file_manager.will_write(fname)
     for backend, density, scalar_types in iterate_types():
         scalar_name = scalar_types[0]

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -417,7 +417,8 @@ def load_derivatives(path, declarations_by_signature):
 
         # Finally, let us set up the derivative information
         derivatives = []
-        for raw_names, formula in defn.items():
+        for raw_names in sorted(defn.keys()):
+            formula = defn[raw_names]
             names = split_names(raw_names)
             output_indices = []
             args = []


### PR DESCRIPTION
This was causing Functions.h to change with every compilation, which resulted in ccache misses (slower incremental builds).