### PR TITLE
Ensure RNNCell variants don't broadcast

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2193,19 +2193,32 @@ class TestNN(NNTestCase):
                 hx.sum().backward()
 
     def test_RNN_cell_no_broadcasting(self):
-        def test(cell_module, hx, output_size):
-            input = Variable(torch.randn(3, 10))
-            cell = cell_module(10, hidden_size)
+        def test(cell_module, input, hx, input_size, hidden_size):
+            cell = cell_module(input_size, hidden_size)
             self.assertRaises(RuntimeError, lambda: cell(input, hx))
 
-        for hidden_size in [20, 1]:
-            bad_hx = Variable(torch.randn(1, hidden_size))
-            good_hx = Variable(torch.randn(3, hidden_size))
+        def test_all(hidden_size, bad_hx, good_hx, input_size, input):
+            test(nn.RNNCell, input, bad_hx, input_size, hidden_size)
+            test(nn.GRUCell, input, bad_hx, input_size, hidden_size)
+            test(nn.LSTMCell, input, (bad_hx, good_hx), input_size, hidden_size)
+            test(nn.LSTMCell, input, (good_hx, bad_hx), input_size, hidden_size)
 
-            test(nn.RNNCell, bad_hx, hidden_size)
-            test(nn.GRUCell, bad_hx, hidden_size)
-            test(nn.LSTMCell, (bad_hx, good_hx), hidden_size)
-            test(nn.LSTMCell, (good_hx, bad_hx), hidden_size)
+        hidden_size = 20
+        input_size = 10
+        input = Variable(torch.randn(3, input_size))
+        bad_hx = Variable(torch.randn(1, hidden_size))
+        good_hx = Variable(torch.randn(3, hidden_size))
+
+        # Test hidden/input batch size broadcasting
+        test_all(hidden_size, bad_hx, good_hx, input_size, input)
+
+        # Test hx's hidden_size vs module's hidden_size broadcasting
+        bad_hx = Variable(torch.randn(3, 1))
+        test_all(hidden_size, bad_hx, good_hx, input_size, input)
+
+        # Test input's input_size vs module's input_size broadcasting
+        bad_input = Variable(torch.randn(3, 1))
+        test_all(hidden_size, good_hx, good_hx, input_size, bad_input)
 
     def test_invalid_dropout_p(self):
         v = Variable(torch.ones(1))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2198,14 +2198,14 @@ class TestNN(NNTestCase):
             cell = cell_module(10, hidden_size)
             self.assertRaises(RuntimeError, lambda: cell(input, hx))
 
-        hidden_size = 20
-        bad_hx = Variable(torch.randn(1, hidden_size))
-        good_hx = Variable(torch.randn(3, hidden_size))
+        for hidden_size in [20, 1]:
+            bad_hx = Variable(torch.randn(1, hidden_size))
+            good_hx = Variable(torch.randn(3, hidden_size))
 
-        test(nn.RNNCell, bad_hx, hidden_size)
-        test(nn.GRUCell, bad_hx, hidden_size)
-        test(nn.LSTMCell, (bad_hx, good_hx), hidden_size)
-        test(nn.LSTMCell, (good_hx, bad_hx), hidden_size)
+            test(nn.RNNCell, bad_hx, hidden_size)
+            test(nn.GRUCell, bad_hx, hidden_size)
+            test(nn.LSTMCell, (bad_hx, good_hx), hidden_size)
+            test(nn.LSTMCell, (good_hx, bad_hx), hidden_size)
 
     def test_invalid_dropout_p(self):
         v = Variable(torch.ones(1))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2207,7 +2207,6 @@ class TestNN(NNTestCase):
         test(nn.LSTMCell, (bad_hx, good_hx), hidden_size)
         test(nn.LSTMCell, (good_hx, bad_hx), hidden_size)
 
-
     def test_invalid_dropout_p(self):
         v = Variable(torch.ones(1))
         self.assertRaises(ValueError, lambda: nn.Dropout(-0.1))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2192,6 +2192,22 @@ class TestNN(NNTestCase):
 
                 hx.sum().backward()
 
+    def test_RNN_cell_no_broadcasting(self):
+        def test(cell_module, hx, output_size):
+            input = Variable(torch.randn(3, 10))
+            cell = cell_module(10, hidden_size)
+            self.assertRaises(RuntimeError, lambda: cell(input, hx))
+
+        hidden_size = 20
+        bad_hx = Variable(torch.randn(1, hidden_size))
+        good_hx = Variable(torch.randn(3, hidden_size))
+
+        test(nn.RNNCell, bad_hx, hidden_size)
+        test(nn.GRUCell, bad_hx, hidden_size)
+        test(nn.LSTMCell, (bad_hx, good_hx), hidden_size)
+        test(nn.LSTMCell, (good_hx, bad_hx), hidden_size)
+
+
     def test_invalid_dropout_p(self):
         v = Variable(torch.ones(1))
         self.assertRaises(ValueError, lambda: nn.Dropout(-0.1))

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -457,6 +457,12 @@ class RNNCellBase(Module):
         s += ')'
         return s.format(name=self.__class__.__name__, **self.__dict__)
 
+    def check_batch_size(self, input, hx, hidden_label=''):
+        if input.size(0) != hx.size(0):
+            raise RuntimeError(
+                "Input batch size {} doesn't match hidden{} batch size {}".format(
+                    input.size(0), hidden_label, hx.size(0)))
+
 
 class RNNCell(RNNCellBase):
     r"""An Elman RNN cell with tanh or ReLU non-linearity.
@@ -524,6 +530,7 @@ class RNNCell(RNNCellBase):
             weight.data.uniform_(-stdv, stdv)
 
     def forward(self, input, hx):
+        self.check_batch_size(input, hx)
         if self.nonlinearity == "tanh":
             func = self._backend.RNNTanhCell
         elif self.nonlinearity == "relu":
@@ -615,6 +622,8 @@ class LSTMCell(RNNCellBase):
             weight.data.uniform_(-stdv, stdv)
 
     def forward(self, input, hx):
+        self.check_batch_size(input, hx[0], '[0]')
+        self.check_batch_size(input, hx[1], '[1]')
         return self._backend.LSTMCell(
             input, hx,
             self.weight_ih, self.weight_hh,
@@ -691,6 +700,7 @@ class GRUCell(RNNCellBase):
             weight.data.uniform_(-stdv, stdv)
 
     def forward(self, input, hx):
+        self.check_batch_size(input, hx)
         return self._backend.GRUCell(
             input, hx,
             self.weight_ih, self.weight_hh,


### PR DESCRIPTION
Fixes #3789.

Before this change the following behavior occurs:

RNNCell supports input/hidden broadcasting on CPU and GPU
GRUCell and LSTMCell support input/hidden broadcasting on CPU but not GPU

This makes it so that none of them support broadcasting and that a clear error message is thrown.

### Test Plan
Unit test to check that runtime error is thrown