### PR TITLE
Expose resize_ and resize_as_ to Python

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2522,8 +2522,10 @@ for test in method_tests:
                     # compare grads to inplace grads
                     inplace_name = name + '_'
                     # can't broadcast inplace to left hand side
-                    broadcast_skip_inplace = 'broadcast_lhs' in test_name or 'broadcast_all' in test_name
-                    if hasattr(Variable(torch.ones(1)), inplace_name) and not broadcast_skip_inplace:
+                    skip_inplace = ('broadcast_lhs' in test_name or
+                                    'broadcast_all' in test_name or
+                                    test_name.startswith('test_resize'))
+                    if hasattr(Variable(torch.ones(1)), inplace_name) and not skip_inplace:
                         output_variable = getattr(self_variable, name)(*args_variable)
                         if not isinstance(output_variable, tuple):
                             output_variable = (output_variable,)

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -356,13 +356,8 @@ void VariableType::s_copy(const Tensor & src, Tensor & dst) const {
 
 Tensor & VariableType::resize_(Tensor & self, IntList size) const {
   auto& self_ = unpack(self, "self", 0);
-  check_inplace(self);
-  auto& self_var = static_cast<Variable&>(self);
-  if (self_var.grad_fn()) {
-    at::runtime_error("cannot resize non-leaf variables");
-  }
-  if (self_var.requires_grad()) {
-    at::runtime_error("cannot resize variables which require grad");
+  if (static_cast<Variable&>(self).requires_grad()) {
+    at::runtime_error("cannot resize variables that require grad");
   }
   baseType->resize_(self_, size);
   return self;


### PR DESCRIPTION
We'll need these functions when we merge Variable and Tensor. They throw
an exception if called on a Variable that requires grad. As of now,
every Variable that has a grad_fn also requires grad, so we can simplify that check.