### PR TITLE
Refactor generation of NN derivatives

### DIFF
--- a/aten/src/ATen/cudnn/cuDNN.yaml
+++ b/aten/src/ATen/cudnn/cuDNN.yaml
@@ -36,12 +36,6 @@
   variants: function
   dispatch: cudnn_grid_sampler_forward
 
-- func: cudnn_grid_sampler_forward(Tensor self, Tensor grid)
-  return:
-    - type: Tensor
-      name: output
-  variants: function
-
 - func: cudnn_grid_sampler_backward(Tensor self, Tensor grid, Tensor grad_output)
   return:
     - type: Tensor
@@ -56,12 +50,6 @@
       name: grid
   variants: function
   dispatch: cudnn_affine_grid_generator_forward
-
-- func: cudnn_affine_grid_generator_forward(Tensor theta, int64_t N, int64_t C, int64_t H, int64_t W) -> Tensor
-  return:
-    - type: Tensor
-      name: grid
-  variants: function
 
 # TODO: Why do I have to call this grad?!
 - func: cudnn_affine_grid_generator_backward(Tensor grad, int64_t N, int64_t C, int64_t H, int64_t W)

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -510,12 +510,15 @@ def create_generic(top_env, declarations):
                 FUNCTION_DEFINITION.substitute(env))
             method_of.append('namespace')
 
+        buffer_names = [buffer['name'] for buffer in option.get('buffers', [])]
+
         output_options.append(OrderedDict([
             ('name', option['api_name']),
             ('method_prefix_derived', option['method_prefix_derived']),
             ('arguments', formals),
             ('method_of', method_of),
             ('mode', option['mode']),
+            ('buffers', buffer_names),
             ('returns', option['returns']),
             ('inplace', option['inplace']),
         ]))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -661,6 +661,9 @@
 - name: elu(Tensor self, Scalar alpha)
   self: elu_backward(grad, alpha, output)
 
+- name: elu_(Tensor self, Scalar alpha)
+  self: elu_backward(grad, alpha, output)
+
 - name: glu(Tensor self, int64_t dim)
   self: glu_backward(grad, self, dim)
 
@@ -670,7 +673,13 @@
 - name: hardtanh(Tensor self, Scalar min_val, Scalar max_val)
   self: hardtanh_backward(grad, self, min_val, max_val)
 
+- name: hardtanh_(Tensor self, Scalar min_val, Scalar max_val)
+  self: hardtanh_backward(grad, self, min_val, max_val)
+
 - name: leaky_relu(Tensor self, Scalar negative_slope)
+  self: leaky_relu_backward(grad, self, negative_slope)
+
+- name: leaky_relu_(Tensor self, Scalar negative_slope)
   self: leaky_relu_backward(grad, self, negative_slope)
 
 - name: log_sigmoid(Tensor self)
@@ -685,6 +694,9 @@
 - name: rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_backward(grad, self, lower, upper, training, noise)
 
+- name: rrelu_(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
+  self: rrelu_backward(grad, self, lower, upper, training, noise)
+
 - name: softmax(Tensor self, int64_t dim)
   self: softmax_backward(grad, self, dim, output)
 
@@ -695,6 +707,9 @@
   self: softshrink_backward(grad, self, lambd)
 
 - name: threshold(Tensor self, Scalar threshold, Scalar value)
+  self: threshold_backward(grad, self, threshold, value)
+
+- name: threshold_(Tensor self, Scalar threshold, Scalar value)
   self: threshold_backward(grad, self, threshold, value)
 
 - name: adaptive_max_pool2d(Tensor self, IntList output_size)
@@ -717,12 +732,6 @@
 
 - name: max_unpool3d(Tensor self, Tensor indices, IntList output_size, IntList stride, IntList padding)
   self: max_unpool3d_backward(grad, self, indices, output_size, stride, padding)
-
-- name: _sigmoid(Tensor self)
-  self: _sigmoid_backward(grad, output)
-
-- name: _tanh(Tensor self)
-  self: _tanh_backward(grad, output)
 
 # - name: batch_norm(Tensor self, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double momentum, double eps)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -858,3 +858,8 @@
 - name: _tanh_backward(Tensor grad_output, Tensor output)
   grad_output: _tanh_backward(grad, output)
   output: -2 * output * grad * grad_output
+
+# vision
+
+- name: cudnn_grid_sampler_forward(Tensor self, Tensor grid)
+  self, grid: cudnn_grid_sampler_backward(self, grid, grad)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -674,13 +674,13 @@
   self: hardtanh_backward(grad, self, min_val, max_val)
 
 - name: hardtanh_(Tensor self, Scalar min_val, Scalar max_val)
-  self: hardtanh_backward(grad, self, min_val, max_val)
+  self: hardtanh_backward(grad, output, min_val, max_val)
 
 - name: leaky_relu(Tensor self, Scalar negative_slope)
   self: leaky_relu_backward(grad, self, negative_slope)
 
 - name: leaky_relu_(Tensor self, Scalar negative_slope)
-  self: leaky_relu_backward(grad, self, negative_slope)
+  self: leaky_relu_backward(grad, output, negative_slope)
 
 - name: log_sigmoid(Tensor self)
   self: log_sigmoid_backward(grad, self, buffer)
@@ -695,7 +695,7 @@
   self: rrelu_backward(grad, self, lower, upper, training, noise)
 
 - name: rrelu_(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
-  self: rrelu_backward(grad, self, lower, upper, training, noise)
+  self: rrelu_backward(grad, output, lower, upper, training, noise)
 
 - name: softmax(Tensor self, int64_t dim)
   self: softmax_backward(grad, self, dim, output)
@@ -710,7 +710,7 @@
   self: threshold_backward(grad, self, threshold, value)
 
 - name: threshold_(Tensor self, Scalar threshold, Scalar value)
-  self: threshold_backward(grad, self, threshold, value)
+  self: threshold_backward(grad, output, threshold, value)
 
 - name: adaptive_max_pool2d(Tensor self, IntList output_size)
   self: adaptive_max_pool2d_backward(grad, self, indices)
@@ -745,7 +745,7 @@
   self, weight, bias: conv2d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
 
 - name: conv_depthwise2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
-  self, weight, bias: conv_depthwise2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
+  self, weight: conv_depthwise2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
 
 #- name: conv3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -861,5 +861,8 @@
 
 # vision
 
-- name: cudnn_grid_sampler_forward(Tensor self, Tensor grid)
+- name: cudnn_grid_sampler(Tensor self, Tensor grid)
   self, grid: cudnn_grid_sampler_backward(self, grid, grad)
+
+- name: cudnn_affine_grid_generator(Tensor theta, int64_t N, int64_t C, int64_t H, int64_t W)
+  theta: cudnn_affine_grid_generator_backward(grad, N, C, H, W)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -626,6 +626,126 @@
 
 - name: zeros  # fallthrough
 
+# NN
+
+- name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight, bool size_average)
+  self: binary_cross_entropy_backward(self, target, weight, size_average).mul_(grad)
+
+- name: kl_div(Tensor self, Tensor target, bool size_average, bool reduce)
+  self: kl_div_backward(grad, self, target, size_average, reduce)
+
+- name: l1_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+  self: l1_loss_backward(grad, self, target, size_average, reduce)
+
+- name: mse_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+  self: mse_loss_backward(grad, self, target, size_average, reduce)
+
+- name: multi_margin_loss(Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, bool size_average)
+  self: multi_margin_loss_backward(self, target, p, margin, weight, size_average).mul_(grad)
+
+- name: multilabel_margin_loss(Tensor self, Tensor target, bool size_average)
+  self: multilabel_margin_loss_backward(self, target, size_average, is_target).mul_(grad)
+
+- name: nll_loss(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
+  self: nll_loss_backward(grad, self, target, weight, size_average, ignore_index, reduce, total_weight)
+
+- name: nll_loss2d(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
+  self: nll_loss2d_backward(grad, self, target, weight, size_average, ignore_index, reduce, total_weight)
+
+- name: smooth_l1_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+  self: smooth_l1_loss_backward(grad, self, target, size_average, reduce)
+
+- name: soft_margin_loss(Tensor self, Tensor target, bool size_average)
+  self: soft_margin_loss_backward(self, target, size_average).mul_(grad)
+
+- name: elu(Tensor self, Scalar alpha)
+  self: elu_backward(grad, alpha, output)
+
+- name: glu(Tensor self, int64_t dim)
+  self: glu_backward(grad, self, dim)
+
+- name: hardshrink(Tensor self, Scalar lambd)
+  self: hardshrink_backward(grad, self, lambd)
+
+- name: hardtanh(Tensor self, Scalar min_val, Scalar max_val)
+  self: hardtanh_backward(grad, self, min_val, max_val)
+
+- name: leaky_relu(Tensor self, Scalar negative_slope)
+  self: leaky_relu_backward(grad, self, negative_slope)
+
+- name: log_sigmoid(Tensor self)
+  self: log_sigmoid_backward(grad, self, buffer)
+
+- name: log_softmax(Tensor self, int64_t dim)
+  self: log_softmax_backward(grad, self, dim, output)
+
+- name: prelu(Tensor self, Tensor weight)
+  self, weight: prelu_backward(grad, self, weight, grad_input_mask)
+
+- name: rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
+  self: rrelu_backward(grad, self, lower, upper, training, noise)
+
+- name: softmax(Tensor self, int64_t dim)
+  self: softmax_backward(grad, self, dim, output)
+
+- name: softplus(Tensor self, Scalar beta, Scalar threshold)
+  self: softplus_backward(grad, self, beta, threshold, output)
+
+- name: softshrink(Tensor self, Scalar lambd)
+  self: softshrink_backward(grad, self, lambd)
+
+- name: threshold(Tensor self, Scalar threshold, Scalar value)
+  self: threshold_backward(grad, self, threshold, value)
+
+- name: adaptive_max_pool2d(Tensor self, IntList output_size)
+  self: adaptive_max_pool2d_backward(grad, self, indices)
+
+- name: avg_pool2d(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
+  self: avg_pool2d_backward(grad, self, kernel_size, stride, padding, ceil_mode, count_include_pad)
+
+- name: avg_pool3d(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
+  self: avg_pool3d_backward(grad, self, kernel_size, stride, padding, ceil_mode, count_include_pad)
+
+- name: max_pool2d(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+  self: max_pool2d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+
+- name: max_pool3d(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+  self: max_pool3d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+
+- name: max_unpool2d(Tensor self, Tensor indices, IntList output_size)
+  self: max_unpool2d_backward(grad, self, indices, output_size)
+
+- name: max_unpool3d(Tensor self, Tensor indices, IntList output_size, IntList stride, IntList padding)
+  self: max_unpool3d_backward(grad, self, indices, output_size, stride, padding)
+
+- name: _sigmoid(Tensor self)
+  self: _sigmoid_backward(grad, output)
+
+- name: _tanh(Tensor self)
+  self: _tanh_backward(grad, output)
+
+# - name: batch_norm(Tensor self, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double momentum, double eps)
+
+- name: conv_transpose2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+  self, weight, bias: conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, columns, ones, grad_input_mask)
+
+- name: conv_transpose3d(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+  self, weight, bias: conv_transpose3d_backward(grad, self, weight, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
+
+- name: conv2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+  self, weight, bias: conv2d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
+
+- name: conv_depthwise2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight, bias: conv_depthwise2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
+
+#- name: conv3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+
+- name: conv_dilated2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight, bias: conv_dilated2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
+
+- name: conv_dilated3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight, bias: conv_dilated3d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
+
 # NN double backwards support
 
 - name: avg_pool2d_backward(Tensor grad_output, Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -376,8 +376,8 @@ def load_derivatives(path, declarations_by_signature, declarations_by_name):
 
         if defn_name in declarations_by_name and len(declarations_by_name[defn_name][0]) > 0:
             declaration = declarations_by_name[defn_name][0]
-            name = defn_name if defn_name[-1] != '_' else defn_name[:-1]
-            if declaration['mode'] == 'NN' and name + '_backward' in declarations_by_name:
+            base_name = defn_name if defn_name[-1] != '_' else defn_name[:-1]
+            if declaration['mode'] == 'NN' and base_name + '_backward' in declarations_by_name:
                 func = preprocess_nn_functions(declaration, declarations_by_name)
                 if func is not None:
                     autograd_functions.append(func)

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -11,7 +11,7 @@ MODE_BORDER = 1
 
 def grid_sampler(input, grid, padding_mode):
     if cudnn.is_acceptable(input.data) and padding_mode == 'zeros':
-        return torch._C._VariableBase.cudnn_grid_sampler(input, grid)
+        return torch._C._VariableBase.cudnn_grid_sampler_forward(input, grid)
     else:
         return GridSampler.apply(input, grid, padding_mode)
 

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -11,7 +11,7 @@ MODE_BORDER = 1
 
 def grid_sampler(input, grid, padding_mode):
     if cudnn.is_acceptable(input.data) and padding_mode == 'zeros':
-        return torch._C._VariableBase.cudnn_grid_sampler_forward(input, grid)
+        return torch._C._VariableBase.cudnn_grid_sampler(input, grid)
     else:
         return GridSampler.apply(input, grid, padding_mode)
 


### PR DESCRIPTION
This PR addresses #3874 (also, /cc #4081).

Derivatives for NN functions now have to be specified in https://github.com/pytorch/pytorch/blob/master/tools/autograd/derivatives.yaml. Leaving a function out will result in that function not being available in autograd.

Note that `_backward` declarations used in `derivatives.yaml` are auto-generated by https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/nn_parse.py
so the content of https://github.com/pytorch/pytorch/blob/master/tools/autograd/derivatives.yaml has to reflect the generated declarations.
This is an inconvenience, although it's smaller than it looks: future kernels will be implemented directly as ATen native functions.

As a help to the user, we could eventually save declarations generated in `nn_parse.py` to a file.