### PR TITLE
Fix DataLoader errors on Windows

### DIFF
--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -22,7 +22,8 @@ class ConnectionWrapper(object):
         return pickle.loads(buf)
 
     def __getattr__(self, name):
-        return getattr(self.conn, name)
+        conn = object.__getattribute__(self, 'conn')
+        return getattr(conn, name)
 
 
 class Queue(multiprocessing.queues.Queue):


### PR DESCRIPTION
When calling Data.DataLoader(dataset=torch_dataset, batch_size=BATCH_SIZE, shuffle=True, num_workers=2,) on windows, it will raise errors: "RuntimeError: maximum recursion depth exceeded".