### PR TITLE
combine .sample() and .sample_n()

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -43,7 +43,10 @@ class TestDistributions(TestCase):
     def _check_sampler_sampler(self, torch_dist, ref_dist, message,
                                num_samples=10000, failure_rate=1e-3):
         # Checks that the .sample() method matches a reference function.
-        torch_samples = torch_dist.sample_n(num_samples).squeeze().cpu().numpy()
+        torch_samples = torch_dist.sample_n(num_samples).squeeze()
+        if isinstance(torch_samples, Variable):
+            torch_samples = torch_samples.data
+        torch_samples = torch_samples.cpu().numpy()
         ref_samples = ref_dist.rvs(num_samples)
         samples = [(x, +1) for x in torch_samples] + [(x, -1) for x in ref_samples]
         samples.sort()
@@ -160,8 +163,37 @@ class TestDistributions(TestCase):
         self._set_rng_seed()
         for alpha, beta in product([0.1, 1.0, 5.0], [0.1, 1.0, 10.0]):
             self._check_sampler_sampler(Gamma(alpha, beta),
-                                        scipy.stats.gamma(alpha, scale=1 / beta),
+                                        scipy.stats.gamma(alpha, scale=1.0 / beta),
                                         'Gamma(alpha={}, beta={})'.format(alpha, beta))
+
+    # This is a randomized test.
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_gamma_sample_grad(self):
+        self._set_rng_seed(1)
+        num_samples = 100
+        for alpha in [1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
+            alphas = Variable(torch.Tensor([alpha] * num_samples), requires_grad=True)
+            betas = Variable(torch.ones(num_samples))
+            x = Gamma(alphas, betas).sample()
+            x.sum().backward()
+            x, ind = x.data.sort()
+            x = x.numpy()
+            actual_grad = alphas.grad.data[ind].numpy()
+            # Compare with expected gradient dx/dalpha along constant cdf(x,alpha).
+            cdf = scipy.stats.gamma.cdf
+            pdf = scipy.stats.gamma.pdf
+            eps = 0.02 * alpha if alpha < 100 else 0.02 * alpha ** 0.5
+            cdf_alpha = (cdf(x, alpha + eps) - cdf(x, alpha - eps)) / (2 * eps)
+            cdf_x = pdf(x, alpha)
+            expected_grad = -cdf_alpha / cdf_x
+            rel_error = np.abs(actual_grad - expected_grad) / (expected_grad + 1e-100)
+            self.assertLess(np.max(rel_error), 0.005,
+                            '\n'.join(['Bad gradients for Gamma({}, 1)'.format(alpha),
+                                       'x {}'.format(x),
+                                       'expected {}'.format(expected_grad),
+                                       'actual {}'.format(actual_grad),
+                                       'rel error {}'.format(rel_error),
+                                       'max error {}'.format(rel_error.max())]))
 
 
 if __name__ == '__main__':

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -70,6 +70,9 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Bernoulli(r).sample().size(), (1,))
         self._gradcheck_log_prob(Bernoulli, (p,))
+        def call_sample_wshape_gt_2():
+            return Bernoulli(r).sample((1,2))
+        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
 
         def ref_log_prob(idx, val, log_prob):
             prob = p.data[idx]
@@ -82,14 +85,17 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(p).sample().size(), (2, 3, 5))
         self.assertEqual(Bernoulli(p).sample_n(2).size(), (2, 2, 3, 5))
 
-    def test_multinomial_1d(self):
+    def test_categorical_1d(self):
         p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
         # TODO: this should return a 0-dim tensor once we have Scalar support
         self.assertEqual(Categorical(p).sample().size(), (1,))
         self.assertEqual(Categorical(p).sample_n(1).size(), (1, 1))
         self._gradcheck_log_prob(Categorical, (p,))
+        def call_sample_wshape_gt_2():
+            return Categorical(p).sample((1,2))
+        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
 
-    def test_multinomial_2d(self):
+    def test_categorical_2d(self):
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
         p = Variable(torch.Tensor(probabilities), requires_grad=True)
         self.assertEqual(Categorical(p).sample().size(), (2,))
@@ -113,6 +119,10 @@ class TestDistributions(TestCase):
         self.assertEqual(Normal(mean_1d, std_1d).sample().size(), (1,))
         self.assertEqual(Normal(0.2, .6).sample_n(1).size(), (1, 1))
         self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1, 1))
+
+        def call_sample_wshape_gt_2():
+            return Normal(mean, std).sample((1,2))
+        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
 
         self._gradcheck_log_prob(Normal, (mean, std))
         self._gradcheck_log_prob(Normal, (mean, 1.0))
@@ -149,6 +159,10 @@ class TestDistributions(TestCase):
         self.assertEqual(Gamma(0.5, 0.5).sample().size(), (1,))
         self.assertEqual(Gamma(0.5, 0.5).sample_n(1).size(), (1, 1))
 
+        def call_sample_wshape_gt_2():
+            return Gamma(alpha, beta).sample((1,2))
+        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
+        
         def ref_log_prob(idx, x, log_prob):
             a = alpha.data.view(-1)[idx]
             b = beta.data.view(-1)[idx]

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -33,7 +33,7 @@ import math
 from numbers import Number
 import torch
 from torch.autograd import Variable
-
+import warnings
 
 __all__ = ['Distribution', 'Bernoulli', 'Categorical', 'Normal', 'Gamma']
 
@@ -42,6 +42,8 @@ def _expand_n(v, n):
     r"""
     Cleanly expand float or Tensor or Variable parameters.
     """
+    if n is None:
+        return v
     if isinstance(v, Number):
         return torch.Tensor([v]).expand(n, 1)
     else:
@@ -53,7 +55,7 @@ class Distribution(object):
     Distribution is the abstract base class for probability distributions.
     """
 
-    def sample(self):
+    def sample(self, n):
         """
         Generates a single sample or single batch of samples if the distribution
         parameters are batched.
@@ -65,7 +67,8 @@ class Distribution(object):
         Generates n samples or n batches of samples if the distribution parameters
         are batched.
         """
-        raise NotImplementedError
+        warnings.warn('sample_n will be deprecated. Use .sample(n) instead', PendingDeprecationWarning)
+        return self.sample(n)
 
     def log_prob(self, value):
         """
@@ -99,11 +102,11 @@ class Bernoulli(Distribution):
     def __init__(self, probs):
         self.probs = probs
 
-    def sample(self):
-        return torch.bernoulli(self.probs)
-
-    def sample_n(self, n):
-        return torch.bernoulli(self.probs.expand(n, *self.probs.size()))
+    def sample(self, n=None):
+        if n is None:
+            return torch.bernoulli(self.probs)
+        else:
+            return torch.bernoulli(self.probs.expand(n, *self.probs.size()))
 
     def log_prob(self, value):
         # compute the log probabilities for 0 and 1
@@ -146,11 +149,10 @@ class Categorical(Distribution):
             raise ValueError("probs must be 1D or 2D")
         self.probs = probs
 
-    def sample(self):
-        return torch.multinomial(self.probs, 1, True).squeeze(-1)
-
-    def sample_n(self, n):
-        if n == 1:
+    def sample(self, n=None):
+        if n is None:
+            return torch.multinomial(self.probs, 1, True).squeeze(-1)
+        elif n == 1:
             return self.sample().expand(1, 1)
         else:
             return torch.multinomial(self.probs, n, True).t()
@@ -185,10 +187,7 @@ class Normal(Distribution):
         self.mean = mean
         self.std = std
 
-    def sample(self):
-        return torch.normal(self.mean, self.std)
-
-    def sample_n(self, n):
+    def sample(self, n=None):
         return torch.normal(_expand_n(self.mean, n), _expand_n(self.std, n))
 
     def log_prob(self, value):
@@ -236,10 +235,7 @@ class Gamma(Distribution):
         self.alpha = alpha
         self.beta = beta
 
-    def sample(self):
-        return _standard_gamma(self.alpha) / self.beta
-
-    def sample_n(self, n):
+    def sample(self, n=None):
         return _standard_gamma(_expand_n(self.alpha, n)) / self.beta
 
     def log_prob(self, value):

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -55,9 +55,9 @@ class Distribution(object):
     Distribution is the abstract base class for probability distributions.
     """
 
-    def sample(self, n):
+    def sample(self, n=None):
         """
-        Generates a single sample or single batch of samples if the distribution
+        Generates n samples or n batches of samples of samples if the distribution
         parameters are batched.
         """
         raise NotImplementedError

--- a/torch/distributions.py
+++ b/torch/distributions.py
@@ -32,8 +32,9 @@ policy, the code for implementing REINFORCE would be as follows::
 import math
 from numbers import Number
 import torch
-from torch.autograd import Variable
 import warnings
+from torch.autograd import Function, Variable
+from torch.autograd.function import once_differentiable
 
 __all__ = ['Distribution', 'Bernoulli', 'Categorical', 'Normal', 'Gamma']
 
@@ -205,10 +206,25 @@ class Normal(Distribution):
         return -((value - self.mean) ** 2) / (2 * var) - log_std - math.log(math.sqrt(2 * math.pi))
 
 
+class _StandardGamma(Function):
+    @staticmethod
+    def forward(ctx, alpha):
+        x = torch._C._standard_gamma(alpha)
+        ctx.save_for_backward(x, alpha)
+        return x
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_output):
+        x, alpha = ctx.saved_tensors
+        grad = torch._C._standard_gamma_grad(x, alpha)
+        return grad_output * grad
+
+
 def _standard_gamma(alpha):
     if not isinstance(alpha, Variable):
         return torch._C._standard_gamma(alpha)
-    return Variable(torch._C._standard_gamma(alpha.data))
+    return _StandardGamma.apply(alpha)
 
 
 class Gamma(Distribution):
@@ -226,6 +242,7 @@ class Gamma(Distribution):
         alpha (float or Tensor or Variable): shape parameter of the distribution
         beta (float or Tensor or Variable): rate = 1 / scale of the distribution
     """
+    has_rsample = True
 
     def __init__(self, alpha, beta):
         # TODO handle (Variable, Number) cases


### PR DESCRIPTION
@apaszke we (mostly @fritzo, I just had some free time to code 😃 ) thought if we combine `.sample_n` and `sample`, we can make `.rsample(n)` in #3886 and avoid implementing a separate `.rsample_n`.  