### PR TITLE
Add size checks for sparse tensor constructor

### DIFF
--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -189,6 +189,7 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
     }
 
     THSTensor_(rawResize)(self, nDimI, nDimV, THLongStorage_data(sizes));
+    THLongTensor_free(max_indices);
   }
   // NB: by default, we do NOT clone indices/values into the sparse tensor.
   // Efficient API by default!

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -168,6 +168,26 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
   else {
     THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 2,
         "number of dimensions must be nDimI + nDimV");
+
+    THLongTensor *max_indices = THLongTensor_new();
+    ignore = THLongTensor_new();
+    THLongTensor_max(max_indices, ignore, indices, 1, 0);
+    THLongTensor_free(ignore);
+    for (int d = 0; d < nDimI; d++) {
+      int64_t max_index_in_dim = THTensor_fastGet1d(max_indices, d);
+      int64_t dim_size = sizes->data[d];
+      THArgCheck(max_index_in_dim <= dim_size, 2, 
+          "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
+          d, (long long)dim_size, (long long)max_index_in_dim);
+    }
+    for (int d = 0; d < nDimV; d++) {
+      int64_t values_size = THTensor_(size)(values, d + 1);
+      int64_t specified_size = sizes->data[nDimI + d];
+      THArgCheck(values_size <= specified_size, 2, 
+          "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
+          d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
+    }
+
     THSTensor_(rawResize)(self, nDimI, nDimV, THLongStorage_data(sizes));
   }
   // NB: by default, we do NOT clone indices/values into the sparse tensor.

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -127,18 +127,27 @@ class TestSparse(TestCase):
         self.assertEqual(x._values().numel(), 0)
 
     def test_ctor_size_checks(self):
-        indices = torch.zeros(3, 4).long()
-        indices[1, 0] = 3
+        indices = self.IndexTensor([
+            [0, 0, 0],
+            [0, 3, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ])
+        values = self.ValueTensor([2, 1, 3, 4])
 
         # indices inconsistent with size
         self.assertRaises(
             RuntimeError,
-            lambda: self.SparseTensor(indices, torch.randn(4), torch.Size([2, 1, 1])))
+            lambda: self.SparseTensor(indices, values, torch.Size([2, 1, 1])))
 
         # values inconsistent with size
+        values = self.ValueTensor([
+            [2, 1, 2, 1],
+            [1, 0, 5, 2],
+        ])
         self.assertRaises(
             RuntimeError,
-            lambda: self.SparseTensor(indices, torch.randn(4, 2), torch.Size([2, 4, 2, 1])))
+            lambda: self.SparseTensor(indices, values, torch.Size([2, 4, 2, 1])))
 
     def test_to_dense(self):
         i = self.IndexTensor([

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -126,6 +126,20 @@ class TestSparse(TestCase):
         self.assertEqual(x._indices().numel(), 0)
         self.assertEqual(x._values().numel(), 0)
 
+    def test_ctor_size_checks(self):
+        indices = torch.zeros(3, 4).long()
+        indices[1, 0] = 3
+
+        # indices inconsistent with size
+        self.assertRaises(
+            RuntimeError,
+            lambda: self.SparseTensor(indices, torch.randn(4), torch.Size([2, 1, 1])))
+
+        # values inconsistent with size
+        self.assertRaises(
+            RuntimeError,
+            lambda: self.SparseTensor(indices, torch.randn(4, 2), torch.Size([2, 4, 2, 1])))
+
     def test_to_dense(self):
         i = self.IndexTensor([
             [0, 1, 2, 2],


### PR DESCRIPTION
Fixes #4093

There was a bug where users could pass in indices to the sparse tensor constructor that imply tensors that have larger sizes than the size that was passed to the constructor. This adds error checking for that.