### PR TITLE
Implement Variable._sparse_mask

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3976,3 +3976,15 @@
     - arg: THSize* size
     - arg: THStride* stride
 ]]
+
+[[
+  name: _sparse_mask
+  return: argument 0
+  cname: sparseMask
+  aten_dense_sparse: True
+  arguments:
+    - arg: THSTensor* result
+      output: True
+    - THTensor* self
+    - THSTensor* mask
+]]

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -163,6 +163,7 @@ TYPE_FORMAL_GENERIC = {
 
 DYNAMIC_TYPE = {
     'THTensor*': 'Tensor',
+    'THSTensor*': 'SparseTensor',
     'THBoolTensor*': 'BoolTensor',
     'THIndexTensor*': 'IndexTensor',
     'THIntegerTensor*': 'IntegerTensor',

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -180,6 +180,7 @@ TYPE_RETURN = {
     'THIndexTensor*': 'Tensor',
     'THBoolTensor*': 'Tensor',
     'THIntegerTensor*': 'Tensor',
+    'THSTensor*': 'Tensor',
     'real': 'Tensor',
     'accreal': 'Tensor',
     'long': 'int64_t',
@@ -232,6 +233,7 @@ ALLOC_WRAP = {
     'THBoolTensor*': 'new ${Backend}ByteTensor(context)',
     'THIndexTensor*': 'new ${Backend}LongTensor(context)',
     'THIntegerTensor*': 'new ${Backend}IntTensor(context)',
+    'THSTensor*': 'new Sparse${Tensor}(context)',
 }
 
 # Replacements for constants when calling into TH

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -548,6 +548,26 @@ class TestSparse(TestCase):
         expected = self.SparseTensor(i, exp_v, torch.Size([5, 4]))
         self.assertEqual(res, expected)
 
+    def test_sparse_mask_variable(self):
+        # TODO: remove once variable and tensor are merged
+        i = torch.autograd.Variable(self.IndexTensor([
+            [1, 3, 0, 4],
+            [2, 1, 2, 3],
+        ]))
+        v = torch.autograd.Variable(self.ValueTensor([1, 2, 3, 4]))
+        x = torch.autograd.Variable(self.SparseTensor(i.data, v.data, torch.Size([5, 4])).coalesce())
+        dense = torch.autograd.Variable(self.ValueTensor([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+            [17, 18, 19, 20],
+        ]))
+        exp_v = torch.autograd.Variable(self.ValueTensor([7, 14, 3, 20]))
+        res = dense._sparse_mask(x)
+        expected = torch.autograd.Variable(self.SparseTensor(i.data, exp_v.data, torch.Size([5, 4])))
+        self.assertEqual(res, expected)
+
     def test_sparse_mask(self):
         self._test_sparse_mask_fixed()
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -650,6 +650,9 @@
 
 - name: zeros  # fallthrough
 
+- name: _sparse_mask(Tensor self, SparseTensor mask)
+  self: not_implemented("_sparse_mask")
+
 # NN
 
 - name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight, bool size_average)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -71,6 +71,7 @@ def create_python_bindings(
 
     unpack_methods = {
         'const Tensor &': 'tensor',
+        'SparseTensor': 'tensor',
         'Tensor &': 'tensor',
         'Generator *': 'generator',
         'Storage &': 'storage',
@@ -116,6 +117,8 @@ def create_python_bindings(
             expr = 'r.{}({})'.format(unpack, arg_idx)
             if typename == 'Storage &':
                 expr = '*' + expr
+            if typename == 'SparseTensor':
+                expr = 'SparseTensor({})'.format(expr)
             actuals.append(expr)
             dispatch_type = typename
             if dispatch_type == 'Tensor':
@@ -167,6 +170,7 @@ def create_python_bindings(
             if not is_class:
                 # Use 'input' instead of 'self' for NN functions
                 prototype = prototype.replace('Tensor self', 'Tensor input')
+            prototype = prototype.replace('SparseTensor', 'Tensor')
             if 'deprecated' in o:
                 prototype += '|deprecated'
             env['prototypes'].append('"{}",'.format(prototype))

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -747,7 +747,7 @@ def create_variable_type(top_env, aten_declarations):
 
             dynamic_type = arg['dynamic_type']
             is_nullable = arg.get('is_nullable', False)
-            ref = (not is_nullable) and dynamic_type not in ['TensorList', 'THSTensor*']
+            ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensor']
             suffix = get_suffix(dynamic_type, is_nullable)
             if dynamic_type == 'TensorList' and declaration['name'] == 'index':
                 # TODO: specify this in Declarations.yaml somehow

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -747,7 +747,7 @@ def create_variable_type(top_env, aten_declarations):
 
             dynamic_type = arg['dynamic_type']
             is_nullable = arg.get('is_nullable', False)
-            ref = (not is_nullable) and dynamic_type != 'TensorList'
+            ref = (not is_nullable) and dynamic_type not in ['TensorList', 'THSTensor*']
             suffix = get_suffix(dynamic_type, is_nullable)
             if dynamic_type == 'TensorList' and declaration['name'] == 'index':
                 # TODO: specify this in Declarations.yaml somehow

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -45,6 +45,7 @@ private:
   // checks that t is actually a Variable with the given expected_type
   static Variable & checked_cast(const Type & expected_type, const Tensor & t, const char * name, int pos);
   at::Tensor & unpack(const Tensor & t, const char * name, int pos) const;
+  at::SparseTensor unpack(SparseTensor t, const char * name, int pos) const;
   at::Tensor & unpack_long(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;


### PR DESCRIPTION
The binding is a little finicky because the signature on Tensor is `Tensor _sparse_mask(SparseTensor mask)`.

I've added a test to `test_sparse.py` that tests this code path. We can delete it once we combine Variable and Tensor, since it will be redundant with the other existing tests.