### PR TITLE
Added explicit tuple dimensions to doc for Conv1d.

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -31,11 +31,11 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
         weight: filters of shape (out_channels x in_channels x kW)
         bias: optional bias of shape (out_channels). Default: None
         stride: the stride of the convolving kernel. Can be a single number or
-          a tuple (sW,). Default: 1
+          a one-dimensional tuple (sW,). Default: 1
         padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padW,). Default: 0
+          single number or a one-dimensional tuple (padW,). Default: 0
         dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dW,). Default: 1
+          a one-dimensional tuple (dW,). Default: 1
         groups: split input into groups, in_channels should be divisible by
           the number of groups. Default: 1
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -31,11 +31,11 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
         weight: filters of shape (out_channels x in_channels x kW)
         bias: optional bias of shape (out_channels). Default: None
         stride: the stride of the convolving kernel. Can be a single number or
-          a one-dimensional tuple (sW,). Default: 1
+          a one-element tuple (sW,). Default: 1
         padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a one-dimensional tuple (padW,). Default: 0
+          single number or a one-element tuple (padW,). Default: 0
         dilation: the spacing between kernel elements. Can be a single number or
-          a one-dimensional tuple (dW,). Default: 1
+          a one-element tuple (dW,). Default: 1
         groups: split input into groups, in_channels should be divisible by
           the number of groups. Default: 1
 

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -83,7 +83,7 @@ class Conv1d(_ConvNd):
     :math:`L` is a length of signal sequence.
 
     | :attr:`stride` controls the stride for the cross-correlation, a single
-      number or a tuple.
+      number or a one-dimensional tuple.
     | :attr:`padding` controls the amount of implicit zero-paddings on both
     |  sides for :attr:`padding` number of points.
     | :attr:`dilation` controls the spacing between the kernel points; also

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -83,7 +83,7 @@ class Conv1d(_ConvNd):
     :math:`L` is a length of signal sequence.
 
     | :attr:`stride` controls the stride for the cross-correlation, a single
-      number or a one-dimensional tuple.
+      number or a one-element tuple.
     | :attr:`padding` controls the amount of implicit zero-paddings on both
     |  sides for :attr:`padding` number of points.
     | :attr:`dilation` controls the spacing between the kernel points; also


### PR DESCRIPTION
Added explicit tuple dimensions to doc for Conv1d, since it was [causing confusion](https://discuss.pytorch.org/t/semantics-of-passing-tuple-for-stride-in-nn-conv1d/11076). 