### PR TITLE
Implement remaining random methods through ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3695,7 +3695,7 @@
         - arg: THGenerator* generator
           default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
-        - THTensor* means
+        - THTensor* mean
         - arg: double std
           default: 1
     - cname: normal_stddevs
@@ -3714,7 +3714,7 @@
         - arg: THGenerator* generator
           default: THPGenerator_TH_CData(THPDefaultGenerator)
           kwarg_only: True
-        - THTensor* means
+        - THTensor* mean
         - THTensor* std
 ]]
 [[
@@ -3855,9 +3855,7 @@
   variants:
     - method
     - function
-  before_call:
-    THTensor_(resizeAs)(LIBRARY_STATE ((THPTensor*)$arg0)->cdata, ((THPTensor*)$arg2)->cdata);
-  cname: BERNOULLI_TENSOR
+  cname: bernoulli_Tensor
   arguments:
     - arg: THTensor* output
       output: True
@@ -3866,36 +3864,6 @@
       default: THPGenerator_TH_CData(THPDefaultGenerator)
       kwarg_only: True
     - THTensor* self
-]]
-[[
-  name: bernoulli_
-  backends:
-    - CPU
-    - CUDA
-  return: self
-  options:
-    - cname: bernoulli
-      arguments:
-        - THTensor* self
-        - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
-          kwarg_only: True
-        - arg: double p
-          default: 0.5
-    - cname: bernoulli_FloatTensor
-      arguments:
-        - THTensor* self
-        - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
-          kwarg_only: True
-        - BackendFloatTensor* float_p
-    - cname: bernoulli_DoubleTensor
-      arguments:
-        - THTensor* self
-        - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
-          kwarg_only: True
-        - BackendDoubleTensor* float_p
 ]]
 [[
   name: tensor

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -8,8 +8,6 @@ if sys.version_info[0] == 3:
 else:
     string_type = basestring
 
-# temporary things we cannot handle
-EXCLUDE_PATTERN = "bernoulli.*"
 # what has to be done to add a Operation ...
 # 1. if broadcasting or without the full list of arguments, add a non-virtual
 #    declaration under Type.h
@@ -426,15 +424,9 @@ def create_generic(top_env, declarations):
 
         return broadcast_actuals
 
-    excluded_names = set()
-
     def process_option(option, output_options):
         option['inplace'] = re.search(
             '(^__i|[^_]_$)', option['api_name']) is not None
-
-        if re.match(EXCLUDE_PATTERN, option['name']):
-            excluded_names.add(option['name'])
-            raise NYIError("NYI")
 
         # print(yaml.dump(option))
         formals = get_formals(option)
@@ -693,7 +685,6 @@ def create_generic(top_env, declarations):
             except NYIError:
                 option['skip'] = True
         output_declarations.extend(output_options)
-    print("ATen Excluded: {}".format(excluded_names))
     return output_declarations
 
 

--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -8,6 +8,16 @@
 namespace at {
 namespace native {
 
+Tensor& bernoulli_(Tensor& self, const Tensor& p, Generator* generator) {
+  self.copy_(at::bernoulli(std::get<0>(expand_inplace(self, p)), generator));
+  return self;
+}
+
+Tensor& bernoulli_(Tensor& self, double p, Generator* generator) {
+  Tensor probs = self.type().toScalarType(kDouble).tensor({}).fill_(p);
+  return native::bernoulli_(self, probs, generator);
+}
+
 Tensor type_as(const Tensor& self, const Tensor& other) {
   return self.toType(other.type());
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -28,6 +28,10 @@
 # recommended that you copy the generated C++ function declaration to your definition so that the two
 # match.
 
+- func: bernoulli_(Tensor self, Tensor p, Generator* generator=nullptr) -> Tensor
+
+- func: bernoulli_(Tensor self, double p, Generator* generator=nullptr) -> Tensor
+
 - func: type_as(Tensor self, Tensor other) -> Tensor
 
 - func: expand_as(Tensor self, Tensor other) -> Tensor

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -7,11 +7,13 @@ except ImportError:
     from yaml import Loader
 
 
-def python_scalar(s):
+def parse_default(s):
     if s.lower() == 'true':
         return True
     elif s.lower() == 'false':
         return False
+    elif s == 'nullptr':
+        return s
     try:
         return int(s)
     except Exception:
@@ -21,10 +23,10 @@ def python_scalar(s):
 def sanitize_types(typ):
     # split tuples into constituent list
     if typ[0] == '(' and typ[-1] == ')':
-        type_list = [x.strip() for x in typ[1:-1].split(',')]
-    else:
-        type_list = [typ]
-    return type_list
+        return [x.strip() for x in typ[1:-1].split(',')]
+    elif typ == 'Generator*':
+        return ['Generator *']
+    return [typ]
 
 
 def parse_arguments(args):
@@ -36,7 +38,7 @@ def parse_arguments(args):
 
         if '=' in name:
             ns = name.split('=', 1)
-            name, default = ns[0], python_scalar(ns[1])
+            name, default = ns[0], parse_default(ns[1])
 
         typ = sanitize_types(t)
         assert len(typ) == 1

--- a/aten/src/TH/generic/THTensorRandom.c
+++ b/aten/src/TH/generic/THTensorRandom.c
@@ -64,6 +64,16 @@ void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, 
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
+
+void THTensor_(bernoulli_Tensor)(THTensor *self, THGenerator *_generator, THTensor* p)
+{
+#if defined(TH_REAL_IS_FLOAT)
+  THTensor_(bernoulli_FloatTensor)(self, _generator, p);
+#else
+  THTensor_(bernoulli_DoubleTensor)(self, _generator, p);
+#endif
+}
+
 void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b)
 {
   #if defined(TH_REAL_IS_FLOAT)

--- a/aten/src/TH/generic/THTensorRandom.h
+++ b/aten/src/TH/generic/THTensorRandom.h
@@ -11,6 +11,7 @@ TH_API void THTensor_(bernoulli_FloatTensor)(THTensor *self, THGenerator *_gener
 TH_API void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, THDoubleTensor *p);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
+TH_API void THTensor_(bernoulli_Tensor)(THTensor *self, THGenerator *_generator, THTensor *p);
 TH_API void THTensor_(uniform)(THTensor *self, THGenerator *_generator, double a, double b);
 TH_API void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, double stdv);
 TH_API void THTensor_(normal_means)(THTensor *self, THGenerator *gen, THTensor *means, double stddev);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4167,7 +4167,25 @@ class TestTorch(TestCase):
         t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 
-        p = torch.rand(SIZE)
+        p = torch.rand(10)
+        t.bernoulli_(p)
+        self.assertTrue(isBinary(t))
+
+        q = torch.rand(5, 5)
+        self.assertTrue(isBinary(q.bernoulli()))
+
+    def test_bernoulli_variable(self):
+        # TODO: remove once we merge Variable and Tensor
+        t = torch.autograd.Variable(torch.ByteTensor(10, 10))
+
+        def isBinary(t):
+            return torch.ne(t, 0).mul_(torch.ne(t, 1)).sum() == 0
+
+        p = 0.5
+        t.bernoulli_(p)
+        self.assertTrue(isBinary(t))
+
+        p = torch.autograd.Variable(torch.rand(10))
         t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4167,7 +4167,7 @@ class TestTorch(TestCase):
         t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 
-        p = torch.rand(10)
+        p = torch.rand(10, 10)
         t.bernoulli_(p)
         self.assertTrue(isBinary(t))
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -121,6 +121,9 @@
   batch1: grad.bmm(batch2.transpose(1, 2)) * alpha
   batch2: batch1.transpose(1, 2).bmm(grad) * alpha
 
+- name: bernoulli(Tensor self, Generator generator)
+  self: zeros_like(grad)
+
 - name: bmm(Tensor self, Tensor mat2)
   self: grad.bmm(mat2.transpose(1, 2))
   mat2: self.transpose(1, 2).bmm(grad)
@@ -394,7 +397,8 @@
   self: grad * other
   other: grad * self
 
-- name: multinomial  # TODO: reinforce
+- name: multinomial(Tensor self, int64_t num_samples, bool replacement, Generator generator)
+  self: zeros_like(grad)
 
 - name: mv(Tensor self, Tensor vec)
   self: grad.ger(vec)
@@ -421,6 +425,16 @@
 
 - name: normal(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
+
+- name: normal(Tensor mean, double std, Generator generator)
+  mean: grad.type().zeros(mean.sizes())
+
+- name: normal(double mean, Tensor std, Generator generator)
+  std: grad.type().zeros(std.sizes())
+
+- name: normal(Tensor mean, Tensor std, Generator generator)
+  mean: grad.type().zeros(mean.sizes())
+  std: grad.type().zeros(std.sizes())
 
 - name: numel  # fallthrough
 - name: ones  # fallthrough
@@ -472,6 +486,16 @@
 
 - name: rand  # fallthrough
 - name: randn  # fallthrough
+
+- name: random(Tensor self, int64_t from, int64_t to, Generator generator)
+  self: zeros_like(grad)
+
+- name: random(Tensor self, int64_t to, Generator generator)
+  self: zeros_like(grad)
+
+- name: random(Tensor self, Generator generator)
+  self: zeros_like(grad)
+
 - name: randperm  # fallthrough
 
 - name: range  # fallthrough

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -307,12 +307,6 @@ class Variable(_C._VariableBase):
     def expand_as(self, tensor):
         return self.expand(tensor.size())
 
-    def multinomial(self, num_samples=1, replacement=False):
-        return Variable(torch.multinomial(self.data, num_samples, replacement))
-
-    def bernoulli(self):
-        return Variable(torch.bernoulli(self.data))
-
     def __rsub__(self, other):
         return -self + other
 
@@ -375,13 +369,8 @@ class Variable(_C._VariableBase):
         return Variable.from_numpy(array)
 
     class _torch(object):
-        @staticmethod
-        def normal(means, std=1):
-            if isinstance(means, Variable):
-                means = means.data
-            if isinstance(std, Variable):
-                std = std.data
-            return Variable(torch.normal(means, std))
+        pass
+
 
 for method in dir(Variable):
     # This will also wrap some methods that normally aren't part of the


### PR DESCRIPTION
I've renamed `means` to `mean` to be consistent with the variants which take `double`. Eventually, we should combine these signatures.

The in-place `bernoulli_` function is implemented via `copy_`.