### PR TITLE
Allow for broadcasting of distribution parameters

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -66,9 +66,11 @@ class TestDistributions(TestCase):
     def test_bernoulli(self):
         p = Variable(torch.Tensor([0.7, 0.2, 0.4]), requires_grad=True)
         r = Variable(torch.Tensor([0.3]), requires_grad=True)
+        s = 0.3
         self.assertEqual(Bernoulli(p).sample_n(8).size(), (8, 3))
         self.assertEqual(Bernoulli(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Bernoulli(r).sample().size(), (1,))
+        self.assertEqual(Bernoulli(s).sample().size(), (1,))
         self._gradcheck_log_prob(Bernoulli, (p,))
 
         def ref_log_prob(idx, val, log_prob):
@@ -200,6 +202,10 @@ class TestDistributions(TestCase):
         # parameters.
         # example type (distribution instance, expected sample shape)
         valid_examples = [
+            (Normal(mean=torch.Tensor([0, 0]), std=1),
+             (2,)),
+            (Normal(mean=0, std=torch.Tensor([1, 1])),
+             (2,)),
             (Normal(mean=torch.Tensor([0, 0]), std=torch.Tensor([1])),
              (2,)),
             (Normal(mean=torch.Tensor([0, 0]), std=torch.Tensor([[1], [1]])),
@@ -208,13 +214,17 @@ class TestDistributions(TestCase):
              (1, 2)),
             (Normal(mean=torch.Tensor([0]), std=torch.Tensor([[1]])),
              (1, 1)),
-            (Gamma(alpha=torch.Tensor([0, 0]), beta=torch.Tensor([[1], [1], [1]])),
+            (Gamma(alpha=torch.Tensor([1, 1]), beta=1),
+             (2,)),
+            (Gamma(alpha=1, beta=torch.Tensor([1, 1])),
+             (2,)),
+            (Gamma(alpha=torch.Tensor([1, 1]), beta=torch.Tensor([[1], [1], [1]])),
              (3, 2)),
-            (Gamma(alpha=torch.Tensor([0, 0]), beta=torch.Tensor([[1], [1]])),
+            (Gamma(alpha=torch.Tensor([1, 1]), beta=torch.Tensor([[1], [1]])),
              (2, 2)),
-            (Gamma(alpha=torch.Tensor([0, 0]), beta=torch.Tensor([[1]])),
+            (Gamma(alpha=torch.Tensor([1, 1]), beta=torch.Tensor([[1]])),
              (1, 2)),
-            (Gamma(alpha=torch.Tensor([0]), beta=torch.Tensor([[1]])),
+            (Gamma(alpha=torch.Tensor([1]), beta=torch.Tensor([[1]])),
              (1, 1)),
         ]
 
@@ -242,7 +252,7 @@ class TestDistributions(TestCase):
         ]
 
         for dist, kwargs in invalid_examples:
-            self.assertRaises(ValueError, dist, **kwargs)
+            self.assertRaises(RuntimeError, dist, **kwargs)
 
 
 if __name__ == '__main__':

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -1,5 +1,6 @@
 import torch
 from torch.distributions.distribution import Distribution
+from torch.distributions.utils import broadcast_all
 
 
 class Bernoulli(Distribution):
@@ -17,10 +18,11 @@ class Bernoulli(Distribution):
         [torch.FloatTensor of size 1]
 
     Args:
-        probs (Tensor or Variable): the probabilty of sampling `1`
+        probs (Number, Tensor or Variable): the probabilty of sampling `1`
     """
 
     def __init__(self, probs):
+        probs, = broadcast_all(probs)
         self.probs = probs
 
     def sample(self):

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -22,8 +22,7 @@ class Bernoulli(Distribution):
     """
 
     def __init__(self, probs):
-        probs, = broadcast_all(probs)
-        self.probs = probs
+        self.probs, = broadcast_all(probs)
 
     def sample(self):
         return torch.bernoulli(self.probs)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -46,9 +46,7 @@ class Gamma(Distribution):
     has_rsample = True
 
     def __init__(self, alpha, beta):
-        alpha, beta = broadcast_all(alpha, beta)
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha, self.beta = broadcast_all(alpha, beta)
 
     def sample(self):
         return _standard_gamma(self.alpha) / self.beta

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import Variable, Function
 from torch.autograd.function import once_differentiable
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n, broadcast_shape
+from torch.distributions.utils import expand_n, broadcast_all
 
 
 class _StandardGamma(Function):
@@ -46,19 +46,7 @@ class Gamma(Distribution):
     has_rsample = True
 
     def __init__(self, alpha, beta):
-        # TODO handle (Variable, Number) cases
-        alpha_num = isinstance(alpha, Number)
-        beta_num = isinstance(beta, Number)
-        if alpha_num and not beta_num:
-            alpha = beta.new(beta.size()).fill_(alpha)
-        elif not alpha_num and beta_num:
-            beta = alpha.new(alpha.size()).fill_(beta)
-        elif alpha_num and beta_num:
-            alpha, beta = torch.Tensor([alpha]), torch.Tensor([beta])
-        elif alpha.size() != beta.size():
-            param_shape = broadcast_shape(alpha.size(), beta.size())
-            alpha = alpha.expand(param_shape)
-            beta = beta.expand(param_shape)
+        alpha, beta = broadcast_all(alpha, beta)
         self.alpha = alpha
         self.beta = beta
 

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import Variable, Function
 from torch.autograd.function import once_differentiable
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n
+from torch.distributions.utils import expand_n, broadcast_shape
 
 
 class _StandardGamma(Function):
@@ -56,8 +56,9 @@ class Gamma(Distribution):
         elif alpha_num and beta_num:
             alpha, beta = torch.Tensor([alpha]), torch.Tensor([beta])
         elif alpha.size() != beta.size():
-            raise ValueError('Expected alpha.size() == beta.size(), actual {} vs {}'.format(
-                alpha.size(), beta.size()))
+            param_shape = broadcast_shape(alpha.size(), beta.size())
+            alpha = alpha.expand(param_shape)
+            beta = beta.expand(param_shape)
         self.alpha = alpha
         self.beta = beta
 

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -3,7 +3,7 @@ from numbers import Number
 
 import torch
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n, broadcast_shape
+from torch.distributions.utils import expand_n, broadcast_all
 
 
 class Normal(Distribution):
@@ -24,10 +24,7 @@ class Normal(Distribution):
     """
 
     def __init__(self, mean, std):
-        if mean.size() != std.size():
-            param_shape = broadcast_shape(mean.size(), std.size())
-            mean = mean.expand(param_shape)
-            std = std.expand(param_shape)
+        mean, std = broadcast_all(mean, std)
         self.mean = mean
         self.std = std
 

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -3,7 +3,7 @@ from numbers import Number
 
 import torch
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n
+from torch.distributions.utils import expand_n, broadcast_shape
 
 
 class Normal(Distribution):
@@ -24,6 +24,10 @@ class Normal(Distribution):
     """
 
     def __init__(self, mean, std):
+        if mean.size() != std.size():
+            param_shape = broadcast_shape(mean.size(), std.size())
+            mean = mean.expand(param_shape)
+            std = std.expand(param_shape)
         self.mean = mean
         self.std = std
 

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -24,9 +24,7 @@ class Normal(Distribution):
     """
 
     def __init__(self, mean, std):
-        mean, std = broadcast_all(mean, std)
-        self.mean = mean
-        self.std = std
+        self.mean, self.std = broadcast_all(mean, std)
 
     def sample(self):
         return torch.normal(self.mean, self.std)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -50,7 +50,7 @@ def broadcast_all(*values):
     scalars = [(idx, v) for idx, v in enumerate(values) if isinstance(v, Number)]
     tensors = [(idx, v) for idx, v in enumerate(values) if isinstance(v, (torch.Tensor, torch.autograd.Variable))]
     if len(scalars) + len(tensors) != len(values):
-        raise ValueError('Input arguments must all be instances of numbers.Number, torch.Tensor or '+
+        raise ValueError('Input arguments must all be instances of numbers.Number, torch.Tensor or ' +
                          'torch.autograd.Variable.')
     if tensors:
         broadcast_shape = _broadcast_shape([t.size() for _, t in tensors])

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -31,18 +31,21 @@ def broadcast_all(*values):
     """
     Given a list of values (possibly containing numbers), returns a list where each
     value is broadcasted based on the following rules:
-      - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as per
-        the `broadcasting rules <http://pytorch.org/docs/master/notes/broadcasting.html>`_
-      - numbers.Number instances (scalars) are upcast to Tensor/Variable having the same
-        size and type as the first tensor passed to `values`. If all the values are scalars,
-        then they are upcasted to `torch.Tensor` having size `(1,)`.
+      - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as
+        per the `broadcasting rules
+        <http://pytorch.org/docs/master/notes/broadcasting.html>`_
+      - numbers.Number instances (scalars) are upcast to Tensor/Variable having
+        the same size and type as the first tensor passed to `values`. If all the
+        values are scalars, then they are upcasted to `torch.Tensor` having size
+        `(1,)`.
 
     Args:
-        values (list of `numbers.Number`, `torch.autograd.Variable` or `torch.Tensor`)
+        values (list of `numbers.Number`, `torch.autograd.Variable` or
+        `torch.Tensor`)
 
     Raises:
-        ValueError: if any of the values is not a `numbers.Number`, `torch.Tensor` or
-            `torch.autograd.Variable` instance
+        ValueError: if any of the values is not a `numbers.Number`, `torch.Tensor`
+            or `torch.autograd.Variable` instance
     """
     scalars = [(idx, v) for idx, v in enumerate(values) if isinstance(v, Number)]
     tensors = [(idx, v) for idx, v in enumerate(values) if isinstance(v, (torch.Tensor, torch.autograd.Variable))]

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -11,3 +11,27 @@ def expand_n(v, n):
         return torch.Tensor([v]).expand(n, 1)
     else:
         return v.expand(n, *v.size())
+
+
+def broadcast_shape(*shapes):
+    r"""
+    If the tensor sizes given by `*shapes` are
+    `broadcastable <http://pytorch.org/docs/master/notes/broadcasting.html>`_ ,
+    this returns the size of the resulting tensor. Raises `ValueError`, otherwise.
+
+    :param tuple shapes: shapes of tensors.
+    :returns: broadcasted shape
+    :rtype: tuple
+    :raises: ValueError
+    """
+    reversed_shape = []
+    for shape in shapes:
+        for i, size in enumerate(reversed(shape)):
+            if i >= len(reversed_shape):
+                reversed_shape.append(size)
+            elif reversed_shape[i] == 1:
+                reversed_shape[i] = size
+            elif reversed_shape[i] != size and size != 1:
+                raise ValueError('shape mismatch: objects cannot be broadcast to a single shape: {}'.format(
+                    ' vs '.join(map(str, shapes))))
+    return tuple(reversed(reversed_shape))

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -62,4 +62,4 @@ def broadcast_all(*values):
     broadcasted_tensors = scalars + tensors
     # return the input arguments in the same order
     broadcasted_tensors.sort()
-    return zip(*broadcasted_tensors)[1]
+    return list(zip(*broadcasted_tensors))[1]

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -31,11 +31,11 @@ def broadcast_all(*values):
     """
     Given a list of values (possibly containing numbers), returns a list where each
     value is broadcasted based on the following rules:
-        - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as per
-          the `broadcasting rules <http://pytorch.org/docs/master/notes/broadcasting.html>`_
-        - numbers.Number instances (scalars) are upcast to Tensors / Variables depending
-          on the type of the first tensor passed to values. If all the values are scalars,
-          then the type is `torch.Tensor` having size `(1,)`.
+      - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as per
+        the `broadcasting rules <http://pytorch.org/docs/master/notes/broadcasting.html>`_
+      - numbers.Number instances (scalars) are upcast to Tensor/Variable having the same
+        size and type as the first tensor passed to `values`. If all the values are scalars,
+        then they are upcasted to `torch.Tensor` having size `(1,)`.
 
     Args:
         values (list of `numbers.Number`, `torch.autograd.Variable` or `torch.Tensor`)


### PR DESCRIPTION
This ensures consistent broadcasting of parameters passed to distribution classes:
 - all scalars are upcast to Tensors / Variables. 
 - all Tensors / Variable arguments are broadcasted to the inferred shape in the constructor.
 - the Bernoulli distribution also supports scalar parameters now to keep it consistent with Gamma and Normal.

Note that this is needed for consistent handling of batch and event shapes [probtorch#30](https://github.com/probtorch/pytorch/issues/30). 

**Testing:** Unit test cases added for asserting on valid / invalid examples of parameter broadcasting.

**Issue:** Refer to [probtorch#32](https://github.com/probtorch/pytorch/issues/32) for more details. [Distribution design doc](https://docs.google.com/document/d/1wnABg0cdyaVMr-Xqz_brHBwnPJuzTeSk3Oqko2HHSfE/edit?usp=sharing)

**Note to reviewers** - This change is not backwards compatible. e.g. 
```
Normal(torch.Tensor([[0, 0]]), torch.Tensor([[1], [1]])).sample()
earlier -> Tensor of shape (1, 2); same as mean.size()
now -> Tensor of shape (2, 2); with full broadcasting
```
Also, let us get outstanding PRs, namely #3886 and #4129 merged first, so as to avoid creating further merge conflicts.
