### PR TITLE
Fix memory leak in JIT

### DIFF
--- a/torch/csrc/jit/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python_arg_flatten.cpp
@@ -88,7 +88,7 @@ py::object unflatten_rec(variable_list::iterator& var_it,
     if (var_it == var_it_end)
       throw std::runtime_error("Not enough Variables given to unflatten");
     auto var = *var_it++;
-    return py::reinterpret_borrow<py::object>(THPVariable_Wrap(var));
+    return py::reinterpret_steal<py::object>(THPVariable_Wrap(var));
   }
 }
 


### PR DESCRIPTION
THPVariable_Wrap creates a new PyObject with refcount 1.
py::reinterpret_borrow<py::object>() would then bump it to 2,
causing it to leak.

Pybind11 reinterprets are poorly named:

py::reinterpret_borrow<py::object>(x) means to retain the PyObject on creation and release on delete.

py::reinterpret_borrow<py::object>(x) means to do nothing to the the PyObject on creation and release on delete.

To me 'borrow' implies to do nothing on creation and do nothing on delete, but no reinterpret call actually does that.