### PR TITLE
Preprocess both inplace and non-inplace nn functions

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -695,13 +695,13 @@
   self: hardshrink_backward(grad, self, lambd)
 
 - name: hardtanh(Tensor self, Scalar min_val, Scalar max_val)
-  self: hardtanh_backward(grad, self, min_val, max_val)
+  self: hardtanh_backward(grad, output, min_val, max_val)
 
 - name: hardtanh_(Tensor self, Scalar min_val, Scalar max_val)
   self: hardtanh_backward(grad, output, min_val, max_val)
 
 - name: leaky_relu(Tensor self, Scalar negative_slope)
-  self: leaky_relu_backward(grad, self, negative_slope)
+  self: leaky_relu_backward(grad, output, negative_slope)
 
 - name: leaky_relu_(Tensor self, Scalar negative_slope)
   self: leaky_relu_backward(grad, output, negative_slope)
@@ -716,7 +716,7 @@
   self, weight: prelu_backward(grad, self, weight, grad_input_mask)
 
 - name: rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
-  self: rrelu_backward(grad, self, lower, upper, training, noise)
+  self: rrelu_backward(grad, output, lower, upper, training, noise)
 
 - name: rrelu_(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_backward(grad, output, lower, upper, training, noise)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -414,12 +414,7 @@ def load_derivatives(path, declarations_by_signature, declarations_by_name):
 
         declaration = declarations_by_name[defn_name][0]
         base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
-        fwd_name = base_name + '_forward'
-
-        if declaration['inplace']:
-            declaration['base_name'] = fwd_name + '_'
-            declaration['derivative'] = declarations_by_name[base_name][0]['derivative']
-            return None
+        fwd_name = base_name + ('_forward' if not declaration['inplace'] else '_forward_')
 
         assert len(declarations_by_name[fwd_name]) == 1
 


### PR DESCRIPTION
This PR should address #4081 (see discussion) /cc @ngimel 

After this change, generated inplace NN functions do not clone `self` and instead use the saved `output` from the forward pass as input to backward functions.