### PR TITLE
Relax verify of VariableFlags

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -478,6 +478,13 @@ struct InterpreterStateImpl {
       outputs.clear();
       loadTensorsFromRegisters(stage.outputs, outputs);
   }
+  const TensorType & tensorTypeForInput(size_t i) const {
+    size_t graph_i = i;
+    for(size_t s = 0; s < current_stage; s++)
+      graph_i += function->stages[s].inputs.size;
+    JIT_ASSERTM(graph_i < function->graph->inputs().size(), "Input out of range");
+    return *function->graph->inputs().at(graph_i)->type()->expect<TensorType>();
+  }
   int get(const ListHandle<int> & list, int i) {
     return int_data[list.start + i];
   };
@@ -531,6 +538,9 @@ void InterpreterState::runOneStage(
   const std::vector<at::Tensor> & inputs,
   std::vector<at::Tensor> & outputs) {
     return pImpl->runOneStage(inputs, outputs);
+}
+const TensorType & InterpreterState::tensorTypeForInput(size_t i) const {
+  return pImpl->tensorTypeForInput(i);
 }
 InterpreterState InterpreterState::clone() const {
   return InterpreterState(new InterpreterStateImpl(*pImpl));

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -6,7 +6,7 @@ namespace at {
   struct Tensor;
 }
 namespace torch { namespace jit {
-  
+
 // The interpreter run Graphs with Tensor inputs and Tensor outputs
 // a separate component in the autograd handles unwrapping and wrapping
 // variable objects for use in the interpreter.
@@ -14,6 +14,7 @@ namespace torch { namespace jit {
 struct CodeImpl;
 struct InterpreterStateImpl;
 struct Graph;
+struct TensorType;
 
 struct Code {
   Code()
@@ -36,6 +37,7 @@ struct InterpreterState {
   void runOneStage(
     const std::vector<at::Tensor> & inputs,
     std::vector<at::Tensor> & outputs);
+  const TensorType & tensorTypeForInput(size_t i) const;
   ~InterpreterState();
   // create a copy of InterpreterState with its current state
   // used when retain_graph=True so that stages can be re-run

--- a/torch/csrc/jit/interpreter_autograd_function.h
+++ b/torch/csrc/jit/interpreter_autograd_function.h
@@ -20,7 +20,11 @@ struct InterpreterAutogradFunction : public autograd::Function {
                               const std::vector<StageDetails>& stage_details)
     : interp_(code)
     , stage_details_(stage_details)
-    , stage_(0) {}
+    , stage_(0) {
+      // stage 0 isn't run through the autograd, so we set this
+      // here just in case it is used
+      num_inputs = stage_details.at(0).input_flags.size();
+    }
 
   InterpreterAutogradFunction(InterpreterState interp,
                               const std::vector<StageDetails>& stage_details,

--- a/torch/csrc/jit/variable_flags.h
+++ b/torch/csrc/jit/variable_flags.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <iostream>
 namespace torch { namespace autograd {
 struct Variable;
 }}
@@ -14,5 +14,12 @@ struct VariableFlags {
   bool is_volatile;
   bool was_null;
 };
+
+static inline std::ostream & operator<<(std::ostream & out, const VariableFlags& v) {
+  return out
+    << "(requires_grad=" << v.requires_grad
+    << ", is_volatile=" << v.is_volatile
+    << ", was_null=" << v.was_null << ")";
+}
 
 }}


### PR DESCRIPTION
If we trace with a defined tensor, but see a run with a undefined
tensors we now allow that run to happen, replacing the tensor with
zeros.

This also fixes a bug where stage 0 tensors were not
checked against their verify flags.

This change does _not_ handle all bad situations that can happen.
For instance if the first thing traced has a undefined tensor but
a later tensor is defined, then it will fail because the graph itself
does not contain the trace for the derivative of the tensor.
However it is possible to work around this later case by
dry-running the function:

   z = Variable(...,requires_grad=True)
   x,y = f(z)
   (x.sum() + y.sum()).backward()