### PR TITLE
Provide full support for distribution shapes

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -5,7 +5,6 @@ import unittest
 from itertools import product
 from torch.autograd import Variable, gradcheck
 from torch.distributions import Bernoulli, Categorical, Normal, Gamma, Distribution
-import warnings
 
 TEST_NUMPY = True
 try:
@@ -82,6 +81,7 @@ class TestDistributions(TestCase):
         self.assertEqual(Bernoulli(p).sample_n(8).size(), (8, 3))
         self.assertEqual(Bernoulli(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Bernoulli(r).sample().size(), (1,))
+        self.assertEqual(Bernoulli(r).sample((3, 2)).size(), (3, 2, 1))
         self.assertEqual(Bernoulli(s).sample().size(), (1,))
         self._gradcheck_log_prob(Bernoulli, (p,))
 
@@ -90,10 +90,6 @@ class TestDistributions(TestCase):
             self.assertEqual(log_prob, math.log(prob if val else 1 - prob))
 
         self._check_log_prob(Bernoulli(p), ref_log_prob)
-
-        def call_sample_wshape_gt_2():
-            return Bernoulli(r).sample((1, 2))
-        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
 
         def call_rsample():
             return Bernoulli(r).rsample()
@@ -110,18 +106,17 @@ class TestDistributions(TestCase):
     def test_bernoulli_3d(self):
         p = Variable(torch.Tensor(2, 3, 5).fill_(0.5), requires_grad=True)
         self.assertEqual(Bernoulli(p).sample().size(), (2, 3, 5))
+        self.assertEqual(Bernoulli(p).sample(sample_shape=(2, 5)).size(),
+                         (2, 5, 2, 3, 5))
         self.assertEqual(Bernoulli(p).sample_n(2).size(), (2, 2, 3, 5))
 
     def test_categorical_1d(self):
         p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
         # TODO: this should return a 0-dim tensor once we have Scalar support
         self.assertEqual(Categorical(p).sample().size(), (1,))
-        self.assertEqual(Categorical(p).sample_n(1).size(), (1, 1))
+        self.assertEqual(Categorical(p).sample((2, 2)).size(), (2, 2))
+        self.assertEqual(Categorical(p).sample_n(1).size(), (1,))
         self._gradcheck_log_prob(Categorical, (p,))
-
-        def call_sample_wshape_gt_2():
-            return Categorical(p).sample((1, 2))
-        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
 
         def call_rsample():
             return Categorical(p).rsample()
@@ -129,10 +124,17 @@ class TestDistributions(TestCase):
 
     def test_categorical_2d(self):
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
+        probabilities_1 = [[1.0, 0.0], [0.0, 1.0]]
         p = Variable(torch.Tensor(probabilities), requires_grad=True)
+        s = Variable(torch.Tensor(probabilities_1), requires_grad=True)
         self.assertEqual(Categorical(p).sample().size(), (2,))
+        self.assertEqual(Categorical(p).sample(sample_shape=(3, 4)).size(), (3, 4, 2))
         self.assertEqual(Categorical(p).sample_n(6).size(), (6, 2))
         self._gradcheck_log_prob(Categorical, (p,))
+
+        # sample check for extreme value of probs
+        self.assertEqual(Categorical(s).sample(sample_shape=(2,)).data,
+                         torch.Tensor([[0, 1], [0, 1]]))
 
         def ref_log_prob(idx, val, log_prob):
             sample_prob = p.data[idx][val] / p.data[idx].sum()
@@ -152,12 +154,19 @@ class TestDistributions(TestCase):
         std = Variable(torch.randn(5, 5).abs(), requires_grad=True)
         mean_1d = Variable(torch.randn(1), requires_grad=True)
         std_1d = Variable(torch.randn(1), requires_grad=True)
+        mean_delta = torch.Tensor([1.0, 0.0])
+        std_delta = torch.Tensor([1e-5, 1e-5])
         self.assertEqual(Normal(mean, std).sample().size(), (5, 5))
         self.assertEqual(Normal(mean, std).sample_n(7).size(), (7, 5, 5))
         self.assertEqual(Normal(mean_1d, std_1d).sample_n(1).size(), (1, 1))
         self.assertEqual(Normal(mean_1d, std_1d).sample().size(), (1,))
-        self.assertEqual(Normal(0.2, .6).sample_n(1).size(), (1, 1))
-        self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1, 1))
+        self.assertEqual(Normal(0.2, .6).sample_n(1).size(), (1,))
+        self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1,))
+
+        # sample check for extreme value of mean, std
+        self.assertEqual(Normal(mean_delta, std_delta).sample(sample_shape=(1, 2)),
+                         torch.Tensor([[[1.0, 0.0], [1.0, 0.0]]]),
+                         prec=1e-4)
 
         self._gradcheck_log_prob(Normal, (mean, std))
         self._gradcheck_log_prob(Normal, (mean, 1.0))
@@ -183,10 +192,6 @@ class TestDistributions(TestCase):
 
         self._check_log_prob(Normal(mean, std), ref_log_prob)
 
-        def call_sample_wshape_gt_2():
-            return Normal(mean, std).sample((1, 2))
-        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
-
     # This is a randomized test.
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_normal_sample(self):
@@ -207,11 +212,7 @@ class TestDistributions(TestCase):
         self.assertEqual(Gamma(alpha_1d, beta_1d).sample_n(1).size(), (1, 1))
         self.assertEqual(Gamma(alpha_1d, beta_1d).sample().size(), (1,))
         self.assertEqual(Gamma(0.5, 0.5).sample().size(), (1,))
-        self.assertEqual(Gamma(0.5, 0.5).sample_n(1).size(), (1, 1))
-
-        def call_sample_wshape_gt_2():
-            return Gamma(alpha, beta).sample((1, 2))
-        self.assertRaises(NotImplementedError, call_sample_wshape_gt_2)
+        self.assertEqual(Gamma(0.5, 0.5).sample_n(1).size(), (1,))
 
         def ref_log_prob(idx, x, log_prob):
             a = alpha.data.view(-1)[idx]
@@ -315,6 +316,79 @@ class TestDistributions(TestCase):
 
         for dist, kwargs in invalid_examples:
             self.assertRaises(RuntimeError, dist, **kwargs)
+
+
+class TestDistributionShapes(TestCase):
+    def setUp(self):
+        self.scalar_sample = 1
+        self.tensor_sample_1 = torch.ones(3, 2)
+        self.tensor_sample_2 = torch.ones(3, 2, 3)
+
+    def test_bernoulli_shape_scalar_params(self):
+        bernoulli = Bernoulli(0.3)
+        self.assertEqual(bernoulli._batch_shape, torch.Size())
+        self.assertEqual(bernoulli._event_shape, torch.Size())
+        self.assertEqual(bernoulli.sample().size(), torch.Size((1,)))
+        self.assertEqual(bernoulli.sample((3, 2)).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, bernoulli.log_prob, self.scalar_sample)
+        self.assertEqual(bernoulli.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertEqual(bernoulli.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
+
+    def test_bernoulli_shape_tensor_params(self):
+        bernoulli = Bernoulli(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        self.assertEqual(bernoulli._batch_shape, torch.Size((3, 2)))
+        self.assertEqual(bernoulli._event_shape, torch.Size(()))
+        self.assertEqual(bernoulli.sample().size(), torch.Size((3, 2)))
+        self.assertEqual(bernoulli.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
+        self.assertEqual(bernoulli.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, bernoulli.log_prob, self.tensor_sample_2)
+
+    def test_categorical_shape(self):
+        categorical = Categorical(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        self.assertEqual(categorical._batch_shape, torch.Size((3,)))
+        self.assertEqual(categorical._event_shape, torch.Size(()))
+        self.assertEqual(categorical.sample().size(), torch.Size((3,)))
+        self.assertEqual(categorical.sample((3, 2)).size(), torch.Size((3, 2, 3,)))
+        self.assertRaises(ValueError, categorical.log_prob, self.tensor_sample_1)
+        self.assertEqual(categorical.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
+
+    def test_gamma_shape_scalar_params(self):
+        gamma = Gamma(1, 1)
+        self.assertEqual(gamma._batch_shape, torch.Size())
+        self.assertEqual(gamma._event_shape, torch.Size())
+        self.assertEqual(gamma.sample().size(), torch.Size((1,)))
+        self.assertEqual(gamma.sample((3, 2)).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, gamma.log_prob, self.scalar_sample)
+        self.assertEqual(gamma.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertEqual(gamma.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
+
+    def test_gamma_shape_tensor_params(self):
+        gamma = Gamma(torch.Tensor([1, 1]), torch.Tensor([1, 1]))
+        self.assertEqual(gamma._batch_shape, torch.Size((2,)))
+        self.assertEqual(gamma._event_shape, torch.Size(()))
+        self.assertEqual(gamma.sample().size(), torch.Size((2,)))
+        self.assertEqual(gamma.sample((3, 2)).size(), torch.Size((3, 2, 2)))
+        self.assertEqual(gamma.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, gamma.log_prob, self.tensor_sample_2)
+
+    def test_normal_shape_scalar_params(self):
+        normal = Normal(0, 1)
+        self.assertEqual(normal._batch_shape, torch.Size())
+        self.assertEqual(normal._event_shape, torch.Size())
+        self.assertEqual(normal.sample().size(), torch.Size((1,)))
+        self.assertEqual(normal.sample((3, 2)).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, normal.log_prob, self.scalar_sample)
+        self.assertEqual(normal.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertEqual(normal.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
+
+    def test_normal_shape_tensor_params(self):
+        normal = Normal(torch.Tensor([0, 0]), torch.Tensor([1, 1]))
+        self.assertEqual(normal._batch_shape, torch.Size((2,)))
+        self.assertEqual(normal._event_shape, torch.Size(()))
+        self.assertEqual(normal.sample().size(), torch.Size((2,)))
+        self.assertEqual(normal.sample((3, 2)).size(), torch.Size((3, 2, 2)))
+        self.assertEqual(normal.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
+        self.assertRaises(ValueError, normal.log_prob, self.tensor_sample_2)
 
 
 if __name__ == '__main__':

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -133,6 +133,7 @@ class TestDistributions(TestCase):
         self._gradcheck_log_prob(Categorical, (p,))
 
         # sample check for extreme value of probs
+        self._set_rng_seed(0)
         self.assertEqual(Categorical(s).sample(sample_shape=(2,)).data,
                          torch.Tensor([[0, 1], [0, 1]]))
 
@@ -164,6 +165,7 @@ class TestDistributions(TestCase):
         self.assertEqual(Normal(-0.7, 50.0).sample_n(1).size(), (1,))
 
         # sample check for extreme value of mean, std
+        self._set_rng_seed(1)
         self.assertEqual(Normal(mean_delta, std_delta).sample(sample_shape=(1, 2)),
                          torch.Tensor([[[1.0, 0.0], [1.0, 0.0]]]),
                          prec=1e-4)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -33,7 +33,7 @@ class Bernoulli(Distribution):
             batch_shape = self.probs.size()
         super(Bernoulli, self).__init__(batch_shape)
 
-    def sample(self, sample_shape=()):
+    def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         return torch.bernoulli(self.probs.expand(shape))
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -1,3 +1,5 @@
+from numbers import Number
+
 import torch
 from torch.autograd import Variable
 from torch.distributions.distribution import Distribution
@@ -25,27 +27,29 @@ class Bernoulli(Distribution):
 
     def __init__(self, probs):
         self.probs, = broadcast_all(probs)
+        if isinstance(probs, Number):
+            batch_shape = ()
+        else:
+            batch_shape = self.probs.size()
+        super(Bernoulli, self).__init__(batch_shape)
 
     def sample(self, sample_shape=()):
-        if len(sample_shape) == 0:
-            return torch.bernoulli(self.probs)
-        elif len(sample_shape) == 1:
-            return torch.bernoulli(self.probs.expand(sample_shape[0], *self.probs.size()))
-        else:
-            raise NotImplementedError("sample is not implemented for len(sample_shape)>1")
+        shape = self._extended_shape(sample_shape)
+        return torch.bernoulli(self.probs.expand(shape))
 
     def log_prob(self, value):
+        self._validate_log_prob_arg(value)
+        param_shape = value.size()
+        probs = self.probs.expand(param_shape)
         # compute the log probabilities for 0 and 1
-        log_pmf = (torch.stack([1 - self.probs, self.probs])).log()
-
+        log_pmf = (torch.stack([1 - probs, probs], dim=-1)).log()
         # evaluate using the values
-        return log_pmf.gather(0, value.unsqueeze(0).long()).squeeze(0)
+        return log_pmf.gather(-1, value.unsqueeze(-1).long()).squeeze(-1)
 
     def enumerate_support(self):
-        batch_shape = self.probs.shape
         values = torch.arange(2).long()
-        values = values.view((-1,) + (1,) * len(batch_shape))
-        values = values.expand((-1,) + batch_shape)
+        values = values.view((-1,) + (1,) * len(self._batch_shape))
+        values = values.expand((-1,) + self._batch_shape)
         if self.probs.is_cuda:
             values = values.cuda(self.probs.get_device())
         if isinstance(self.probs, Variable):

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -28,7 +28,7 @@ class Bernoulli(Distribution):
     def __init__(self, probs):
         self.probs, = broadcast_all(probs)
         if isinstance(probs, Number):
-            batch_shape = ()
+            batch_shape = torch.Size()
         else:
             batch_shape = self.probs.size()
         super(Bernoulli, self).__init__(batch_shape)

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -36,7 +36,7 @@ class Categorical(Distribution):
         batch_shape = self.probs.size()[:-1]
         super(Categorical, self).__init__(batch_shape)
 
-    def sample(self, sample_shape=()):
+    def sample(self, sample_shape=torch.Size()):
         num_events = self.probs.size()[-1]
         sample_shape = self._extended_shape(sample_shape)
         param_shape = sample_shape + self.probs.size()[-1:]

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -32,35 +32,31 @@ class Categorical(Distribution):
     has_enumerate_support = True
 
     def __init__(self, probs):
-        if probs.dim() != 1 and probs.dim() != 2:
-            # TODO: treat higher dimensions as part of the batch
-            raise ValueError("probs must be 1D or 2D")
         self.probs = probs
+        batch_shape = self.probs.size()[:-1]
+        super(Categorical, self).__init__(batch_shape)
 
     def sample(self, sample_shape=()):
-        if len(sample_shape) == 0:
-            return torch.multinomial(self.probs, 1, True).squeeze(-1)
-        elif len(sample_shape) == 1:
-            if sample_shape[0] == 1:
-                return self.sample().expand(1, 1)
-            else:
-                return torch.multinomial(self.probs, sample_shape[0], True).t()
-        else:
-            raise NotImplementedError("sample is not implemented for len(sample_shape)>1")
+        num_events = self.probs.size()[-1]
+        sample_shape = self._extended_shape(sample_shape)
+        param_shape = sample_shape + self.probs.size()[-1:]
+        probs = self.probs.expand(param_shape)
+        probs_2d = probs.contiguous().view(-1, num_events)
+        sample_2d = torch.multinomial(probs_2d, 1, True)
+        return sample_2d.contiguous().view(sample_shape)
 
     def log_prob(self, value):
-        p = self.probs / self.probs.sum(-1, keepdim=True)
-        if value.dim() == 1 and self.probs.dim() == 1:
-            # special handling until we have 0-dim tensor support
-            return p.gather(-1, value).log()
-
-        return p.gather(-1, value.unsqueeze(-1)).squeeze(-1).log()
+        self._validate_log_prob_arg(value)
+        param_shape = value.size() + self.probs.size()[-1:]
+        log_pmf = (self.probs / self.probs.sum(-1, keepdim=True)).log()
+        log_pmf = log_pmf.expand(param_shape)
+        return log_pmf.gather(-1, value.unsqueeze(-1).long()).squeeze(-1)
 
     def enumerate_support(self):
-        batch_shape, event_size = self.probs.shape[:-1], self.probs.shape[-1]
-        values = torch.arange(event_size).long()
-        values = values.view((-1,) + (1,) * len(batch_shape))
-        values = values.expand((-1,) + batch_shape)
+        num_events = self.probs.size()[-1]
+        values = torch.arange(num_events).long()
+        values = values.view((-1,) + (1,) * len(self._batch_shape))
+        values = values.expand((-1,) + self._batch_shape)
         if self.probs.is_cuda:
             values = values.cuda(self.probs.get_device())
         if isinstance(self.probs, Variable):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -1,3 +1,4 @@
+import torch
 from torch.autograd import Variable
 import warnings
 
@@ -9,6 +10,10 @@ class Distribution(object):
 
     has_rsample = False
     has_enumerate_support = False
+
+    def __init__(self, batch_shape=torch.Size(), event_shape=torch.Size()):
+        self._batch_shape = batch_shape
+        self._event_shape = event_shape
 
     def sample(self, sample_shape=()):
         """
@@ -60,3 +65,37 @@ class Distribution(object):
             Variable or Tensor iterating over dimension 0.
         """
         raise NotImplementedError
+
+    def _extended_shape(self, sample_shape=()):
+        """
+        Returns the size of the sample returned by the distribution, given
+        a `sample_shape`. Note, that the batch and event shapes of a distribution
+        instance are fixed at the time of construction. If this is empty, the
+        returned shape is upcast to (1,).
+
+        Args:
+            sample_shape (torch.Size): the size of the sample to be drawn.
+        """
+        shape = sample_shape + self._batch_shape + self._event_shape
+        if not shape:
+            shape = (1,)
+        return shape
+
+    def _validate_log_prob_arg(self, value):
+        """
+        Argument validation for `log_prob` methods. The rightmost dimensions
+        of a value to be scored via `log_prob` must agree with the distribution's
+        batch and event shapes.
+
+        Args:
+            value (Tensor or Variable): the tensor whose log probability is to be
+                computed by the `log_prob` method.
+        Raises
+            ValueError: when the rightmost dimensions of `value` do not match the
+                distribution's batch and event shapes.
+        """
+        if not isinstance(value, (torch.Tensor, Variable)):
+            raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
+        batch_dim_start = len(value.size()) - len(self._batch_shape)
+        if value.size()[batch_dim_start:] != self._batch_shape:
+            raise ValueError('The right-most size of value must match: {}.'.format(self._batch_shape))

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -98,4 +98,5 @@ class Distribution(object):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
         batch_dim_start = len(value.size()) - len(self._batch_shape) - len(self._event_shape)
         if value.size()[batch_dim_start:] != self._batch_shape:
-            raise ValueError('The right-most size of value must match: {}.'.format(self._batch_shape))
+            raise ValueError('The right-most size of value must match: {}.'.
+                             format(self._batch_shape + self._event_shape))

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -94,7 +94,7 @@ class Distribution(object):
             ValueError: when the rightmost dimensions of `value` do not match the
                 distribution's batch and event shapes.
         """
-        if not isinstance(value, (torch.Tensor, Variable)):
+        if not (torch.is_tensor(value) or isinstance(value, Variable)):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
         batch_dim_start = len(value.size()) - len(self._batch_shape)
         if value.size()[batch_dim_start:] != self._batch_shape:

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -97,6 +97,6 @@ class Distribution(object):
         if not (torch.is_tensor(value) or isinstance(value, Variable)):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
         batch_dim_start = len(value.size()) - len(self._batch_shape) - len(self._event_shape)
-        if value.size()[batch_dim_start:] != self._batch_shape:
+        if value.size()[batch_dim_start:] != self._batch_shape + self._event_shape:
             raise ValueError('The right-most size of value must match: {}.'.
                              format(self._batch_shape + self._event_shape))

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -78,7 +78,7 @@ class Distribution(object):
         """
         shape = sample_shape + self._batch_shape + self._event_shape
         if not shape:
-            shape = (1,)
+            shape = torch.Size((1,))
         return shape
 
     def _validate_log_prob_arg(self, value):
@@ -96,6 +96,6 @@ class Distribution(object):
         """
         if not (torch.is_tensor(value) or isinstance(value, Variable)):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
-        batch_dim_start = len(value.size()) - len(self._batch_shape)
+        batch_dim_start = len(value.size()) - len(self._batch_shape) - len(self._event_shape)
         if value.size()[batch_dim_start:] != self._batch_shape:
             raise ValueError('The right-most size of value must match: {}.'.format(self._batch_shape))

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -48,7 +48,7 @@ class Gamma(Distribution):
     def __init__(self, alpha, beta):
         self.alpha, self.beta = broadcast_all(alpha, beta)
         if isinstance(alpha, Number) and isinstance(beta, Number):
-            batch_shape = ()
+            batch_shape = torch.Size()
         else:
             batch_shape = self.alpha.size()
         super(Gamma, self).__init__(batch_shape)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -47,16 +47,18 @@ class Gamma(Distribution):
 
     def __init__(self, alpha, beta):
         self.alpha, self.beta = broadcast_all(alpha, beta)
+        if isinstance(alpha, Number) and isinstance(beta, Number):
+            batch_shape = ()
+        else:
+            batch_shape = self.alpha.size()
+        super(Gamma, self).__init__(batch_shape)
 
     def rsample(self, sample_shape=()):
-        if len(sample_shape) == 0:
-            return _standard_gamma(self.alpha) / self.beta
-        elif len(sample_shape) == 1:
-            return _standard_gamma(expand_n(self.alpha, sample_shape[0])) / self.beta
-        else:
-            raise NotImplementedError("rsample is not implemented for len(sample_shape)>1")
+        shape = self._extended_shape(sample_shape)
+        return _standard_gamma(self.alpha.expand(shape)) / self.beta.expand(shape)
 
     def log_prob(self, value):
+        self._validate_log_prob_arg(value)
         return (self.alpha * torch.log(self.beta) +
                 (self.alpha - 1) * torch.log(value) -
                 self.beta * value - torch.lgamma(self.alpha))

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -53,7 +53,7 @@ class Gamma(Distribution):
             batch_shape = self.alpha.size()
         super(Gamma, self).__init__(batch_shape)
 
-    def rsample(self, sample_shape=()):
+    def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         return _standard_gamma(self.alpha.expand(shape)) / self.beta.expand(shape)
 

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -33,16 +33,14 @@ class Normal(Distribution):
             batch_shape = self.mean.size()
         super(Normal, self).__init__(batch_shape)
 
-    def sample(self, sample_shape=()):
+    def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         return torch.normal(self.mean.expand(shape), self.std.expand(shape))
 
-    def rsample(self, sample_shape=()):
+    def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        mean = self.mean.expand(shape)
-        std = self.std.expand(shape)
-        eps = mean.new(mean.size()).normal_()
-        return mean + eps * std
+        eps = self.mean.new(shape).normal_()
+        return self.mean + eps * self.std
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -28,7 +28,7 @@ class Normal(Distribution):
     def __init__(self, mean, std):
         self.mean, self.std = broadcast_all(mean, std)
         if isinstance(mean, Number) and isinstance(std, Number):
-            batch_shape = ()
+            batch_shape = torch.Size()
         else:
             batch_shape = self.mean.size()
         super(Normal, self).__init__(batch_shape)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -2,6 +2,7 @@ import math
 from numbers import Number
 
 import torch
+from torch.autograd import Variable
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import expand_n, broadcast_all
 
@@ -26,30 +27,25 @@ class Normal(Distribution):
 
     def __init__(self, mean, std):
         self.mean, self.std = broadcast_all(mean, std)
+        if isinstance(mean, Number) and isinstance(std, Number):
+            batch_shape = ()
+        else:
+            batch_shape = self.mean.size()
+        super(Normal, self).__init__(batch_shape)
 
     def sample(self, sample_shape=()):
-        if len(sample_shape) == 0:
-            return torch.normal(self.mean, self.std)
-        elif len(sample_shape) == 1:
-            return torch.normal(expand_n(self.mean, sample_shape[0]), expand_n(self.std, sample_shape[0]))
-        else:
-            raise NotImplementedError("sample is not implemented for len(sample_shape)>1")
+        shape = self._extended_shape(sample_shape)
+        return torch.normal(self.mean.expand(shape), self.std.expand(shape))
 
     def rsample(self, sample_shape=()):
-        if len(sample_shape) == 0:
-            eps = self.mean.new((self.mean + self.std).size())
-            eps.normal_()
-            return self.mean + self.std * eps
-        elif len(sample_shape) == 1:
-            expanded_mean = expand_n(self.mean, sample_shape[0])
-            expanded_std = expand_n(self.std, sample_shape[0])
-            eps = expanded_mean.new()
-            eps.normal_()
-            return expanded_mean + expanded_std * eps
-        else:
-            raise NotImplementedError("rsample is not implemented for len(sample_shape)>1")
+        shape = self._extended_shape(sample_shape)
+        mean = self.mean.expand(shape)
+        std = self.std.expand(shape)
+        eps = mean.new(mean.size()).normal_()
+        return mean + eps * std
 
     def log_prob(self, value):
+        self._validate_log_prob_arg(value)
         # compute the variance
         var = (self.std ** 2)
         log_std = math.log(self.std) if isinstance(self.std, Number) else self.std.log()

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -50,7 +50,8 @@ def broadcast_all(*values):
     """
     values = list(values)
     scalar_idxs = [i for i in range(len(values)) if isinstance(values[i], Number)]
-    tensor_idxs = [i for i in range(len(values)) if isinstance(values[i], (torch.Tensor, Variable))]
+    tensor_idxs = [i for i in range(len(values)) if
+                   torch.is_tensor(values[i]) or isinstance(values[i], Variable)]
     if len(scalar_idxs) + len(tensor_idxs) != len(values):
         raise ValueError('Input arguments must all be instances of numbers.Number, torch.Tensor or ' +
                          'torch.autograd.Variable.')


### PR DESCRIPTION
This allows us to support all the distribution shape semantics for sampling and scoring that we have discussed. 
 - distributions have internal `_batch_shape` and `_event_shape` attributes which are set at the time of construction. 
 - allows for arbitrary sample shapes (removing restriction for only a single dimensional `batch_shape` argument).
 - allows for scoring of arbitrary shaped samples. Some resulting minor change in `log_prob` methods. One such change is the part that calls `torch.multinomial` (which only supports up to 2d tensors) in `Categorical.log_prob`.

**Testing:** Unit test cases added to validate batch/event shapes are correctly determined internally, and the correct shapes for generated samples and log prob scores. Refer to similar [examples](https://docs.google.com/spreadsheets/d/11ULwArylCjdlk4qW2tin0dY2jZ5iRQ0xjtQHvTFmFgs/edit?usp=sharing) discussed.

**Note:** Some minor changes are not backwards compatible. Refer to the tests.

**Ref:** 
 - Issue [probtorch#30](https://github.com/probtorch/pytorch/issues/30)
 - [Distribution design doc](https://docs.google.com/document/d/1wnABg0cdyaVMr-Xqz_brHBwnPJuzTeSk3Oqko2HHSfE/edit?usp=sharing)
