### PR TITLE
Avoid using output in inplace derivatives unless THNN signature matches

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -704,13 +704,13 @@
   self: hardshrink_backward(grad, self, lambd)
 
 - name: hardtanh(Tensor self, Scalar min_val, Scalar max_val)
-  self: hardtanh_backward(grad, output, min_val, max_val)
+  self: hardtanh_backward(grad, self, min_val, max_val)
 
 - name: hardtanh_(Tensor self, Scalar min_val, Scalar max_val)
   self: hardtanh_backward(grad, output, min_val, max_val)
 
 - name: leaky_relu(Tensor self, Scalar negative_slope)
-  self: leaky_relu_backward(grad, output, negative_slope)
+  self: leaky_relu_backward(grad, self, negative_slope)
 
 - name: leaky_relu_(Tensor self, Scalar negative_slope)
   self: leaky_relu_backward(grad, output, negative_slope)
@@ -725,7 +725,7 @@
   self, weight: prelu_backward(grad, self, weight, grad_input_mask)
 
 - name: rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
-  self: rrelu_backward(grad, output, lower, upper, training, noise)
+  self: rrelu_backward(grad, self, lower, upper, training, noise)
 
 - name: rrelu_(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_backward(grad, output, lower, upper, training, noise)


### PR DESCRIPTION
Following this discussion https://github.com/pytorch/pytorch/pull/4184#discussion_r157152028 with @apaszke , we decided to avoid replacing `self` with `output` in `derivatives.yaml` unless the corresponding THNN signature uses `output` explicitly (just `elu_` in NN at the moment).

This means that we go back to cloning in #4081, except for `elu_`.

/cc @colesbury @ngimel @ezyang 