### PR TITLE
[jit] add a jit_debug_info method

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -943,5 +943,26 @@ class TestJit(TestCase):
         self.assertExpectedTrace(trace)
         # NB: Purposely NOT testing protobuf export here
 
+    def test_debug_info(self):
+        """Check that debug info doesn't crash and has some reasonable info"""
+
+        @torch.jit.compile(nderivs=1)
+        def fn(x, y):
+            return x * y + x + y
+
+        x = Variable(torch.randn(5, 5), requires_grad=True)
+        y = Variable(torch.randn(5, 5), requires_grad=True)
+
+        out = fn(x, y)
+
+        out.sum().backward()
+
+        for _ in range(0, 100):
+            out = fn(x, y)
+        info_str = fn.jit_debug_info()
+        self.assertTrue("hits: 100" in info_str)
+        self.assertTrue("stage 1" in info_str)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -61,6 +61,26 @@ struct IODescriptor {
   std::vector<VariableMetadata> metadata;
 };
 
+static inline std::ostream& operator<<(std::ostream& out, const IODescriptor::VariableMetadata& meta) {
+  auto & t = at::getType(meta.device < 0 ? at::kCPU : at::kCUDA, meta.type);
+  out << t << "(requires_grad=" << meta.requires_grad << ", " << "is_volatile=" << meta.is_volatile << ") {";
+  for(size_t i = 0; i < meta.sizes.size(); ++i) {
+    if(i > 0)
+      out << ", ";
+    out << meta.sizes[i];
+  }
+  out << "}";
+  return out;
+}
+
+static inline std::ostream& operator<<(std::ostream & out, const IODescriptor & desc) {
+  out << desc.structure << "\n";
+  for(size_t i = 0; i < desc.metadata.size(); ++i) {
+    out << "  with v" << i << " having type " << desc.metadata[i] << "\n";
+  }
+  return out;
+}
+
 struct ParsedArgs {
   // Flat vector of Variables found in arguments
   autograd::variable_list vars;


### PR DESCRIPTION
This method prints a bunch of useful debug information including
the traces that have been record, their shapes, and the traced
graphs associated with them.

Example Output: https://gist.github.com/zdevito/477d29a9590b630cb92064884bacc8bd