### PR TITLE
Make import work even if 'tools' is available in Python path

### DIFF
--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -56,7 +56,7 @@ def generate_code(ninja_global=None):
 
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    sys.path.append(root)
+    sys.path.insert(0, root)
     from tools.cwrap import cwrap
     from tools.cwrap.plugins.THPPlugin import THPPlugin
     from tools.cwrap.plugins.ArgcountSortPlugin import ArgcountSortPlugin


### PR DESCRIPTION
sys.path is searched from first to last, which means that if there is already
a 'tools' directory in the existing python path, we will fail to find the root
directory of PyTorch. Better to put it first.