### PR TITLE
Allow value broadcasting in distributions.Distribution

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -96,9 +96,15 @@ class Distribution(object):
         """
         if not (torch.is_tensor(value) or isinstance(value, Variable)):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
-        expected_shape = self._batch_shape + self._event_shape
+
+        event_dim_start = len(value.size()) - len(self._event_shape)
+        if value.size()[event_dim_start:] != self._event_shape:
+            raise ValueError('The right-most size of value must match event_shape: {} vs {}.'.
+                             format(value.size(), self._event_shape))
+
         actual_shape = value.size()
+        expected_shape = self._batch_shape + self._event_shape
         for i, j in zip(reversed(actual_shape), reversed(expected_shape)):
             if i != 1 and j != 1 and i != j:
-                raise ValueError('Value is not broadcastable with params: {} vs {}.'.
+                raise ValueError('Value is not broadcastable with batch_shape+event_shape: {} vs {}.'.
                                  format(actual_shape, expected_shape))

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -96,7 +96,9 @@ class Distribution(object):
         """
         if not (torch.is_tensor(value) or isinstance(value, Variable)):
             raise ValueError('The value argument to log_prob must be a Tensor or Variable instance.')
-        batch_dim_start = len(value.size()) - len(self._batch_shape) - len(self._event_shape)
-        if value.size()[batch_dim_start:] != self._batch_shape + self._event_shape:
-            raise ValueError('The right-most size of value must match: {}.'.
-                             format(self._batch_shape + self._event_shape))
+        expected_shape = self._batch_shape + self._event_shape
+        actual_shape = value.size()
+        for i, j in zip(reversed(actual_shape), reversed(expected_shape)):
+            if i != 1 and j != 1 and i != j:
+                raise ValueError('Value is not broadcastable with params: {} vs {}.'.
+                                 format(actual_shape, expected_shape))

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import Variable, Function
 from torch.autograd.function import once_differentiable
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n, broadcast_all
+from torch.distributions.utils import broadcast_all
 
 
 class _StandardGamma(Function):

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -4,7 +4,7 @@ from numbers import Number
 import torch
 from torch.autograd import Variable
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import expand_n, broadcast_all
+from torch.distributions.utils import broadcast_all
 
 
 class Normal(Distribution):


### PR DESCRIPTION
This relaxes `Distribution._validate_log_prob_arg()` to allow broadcasting. This came up in a simple use case:
```py
p = Normal(Variable(torch.Tensor([0.0])),
           Variable(torch.Tensor([1.0])))
x = torch.arange(-2,2,0.01)
pdf = torch.exp(p.log_prob(x))  # Fails before this PR, works after.
pyplot.plot(x.numpy(), pdf.numpy())
```
This also removes two unused imports of `expand_n` from files in torch.distributions.

[Design Doc](https://docs.google.com/document/d/1wnABg0cdyaVMr-Xqz_brHBwnPJuzTeSk3Oqko2HHSfE/edit)