### PR TITLE
fixes serialization error with state file > 4GiB

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -195,7 +195,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
     pickle_module.dump(sys_info, f, protocol=pickle_protocol)
     pickler = pickle_module.Pickler(f, protocol=pickle_protocol)
     pickler.persistent_id = persistent_id
-    pickler.dump(obj)
+    pickler.dump(obj, protocol=pickle_protocol)
 
     serialized_storage_keys = sorted(serialized_storages.keys())
     pickle_module.dump(serialized_storage_keys, f, protocol=pickle_protocol)


### PR DESCRIPTION
Improved code consistency to make use of higher pickle protocol version for serializing large files.