### PR TITLE
Cache DataParallel replicas

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -668,7 +668,7 @@ class Softmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        super(Softmax, self).__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
 
@@ -742,7 +742,7 @@ class LogSoftmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        super(LogSoftmax, self).__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
 

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -1,8 +1,67 @@
+import weakref
 import torch
+import torch.cuda.comm as comm
+from collections import OrderedDict
 from ..modules import Module
 from .scatter_gather import scatter_kwargs, gather
 from .replicate import replicate
 from .parallel_apply import parallel_apply
+
+
+# This class behaves exacly like OrderedDict, but lets you register callbacks
+# that will be triggered at every modification. This is used to invalidate
+# cached replicas in DataParallel in case the original module is modified.
+# NOTE: these callbacks are one-off
+# NOTE: they are deduplicated based on identity
+class _CallbackOrderedDict(OrderedDict):
+    @classmethod
+    def _init_class(cls):
+        mutating_methods = [
+            '__setitem__',
+            '__delitem__',
+            'pop',
+            'popitem',
+            'update',
+            'setdefault'
+        ]
+
+        def method_wrapper(name):
+            def callback_method(self, *args, **kwargs):
+                for callback in self.callbacks:
+                    callback()
+                del self.callbacks[:]
+                return getattr(super(_CallbackOrderedDict, self), name)(*args, **kwargs)
+            return callback_method
+        for name in mutating_methods:
+            setattr(cls, name, method_wrapper(name))
+
+    @classmethod
+    def from_ordered(cls, od):
+        return cls(od.items())
+
+    def __init__(self, *args, **kwargs):
+        self.callbacks = []
+        super(_CallbackOrderedDict, self).__init__(*args, **kwargs)
+
+    def register_modification_callback(self, cb):
+        if all(c is not cb for c in self.callbacks):
+            self.callbacks.append(cb)
+
+    # Don't serialize callbacks. If a module registers them on its submodules,
+    # it will have to redo it after reloading.
+    def __reduce__(self):
+        state = super(_CallbackOrderedDict, self).__reduce__()
+        # NB: 3nd element of reduce tuple is the __dict__.
+        if state[2]:
+            lstate = list(state)
+            lstate[2] = state[2].copy().pop('callbacks')
+            return tuple(lstate)
+        else:
+            return state
+
+
+_CallbackOrderedDict._init_class()
+torch._C._inherit_odict_getitem(_CallbackOrderedDict)
 
 
 class DataParallel(Module):
@@ -55,8 +114,27 @@ class DataParallel(Module):
         self.module = module
         self.device_ids = device_ids
         self.output_device = output_device
+        self._init_cache()
         if len(self.device_ids) == 1:
             self.module.cuda(device_ids[0])
+
+    def _init_cache(self):
+        self._replicas = []
+
+        # Use a weakref to avoid reference cycles
+        dp_weakref = weakref.ref(self)
+
+        def invalidate_cache():
+            dp = dp_weakref()
+            if dp is None:
+                return
+
+            # Flush the cache
+            dp._replicas = []
+            del dp._orig_params, dp._orig_buffers
+            del dp._repl_params, dp._repl_buffers
+
+        self._invalidate_cache = invalidate_cache
 
     def forward(self, *inputs, **kwargs):
         if not self.device_ids:
@@ -68,8 +146,73 @@ class DataParallel(Module):
         outputs = self.parallel_apply(replicas, inputs, kwargs)
         return self.gather(outputs, self.output_device)
 
+    def __getstate__(self):
+        state = super(DataParallel, self).__getstate__().copy()
+        del state['_invalidate_cache'], state['_replicas'], state['_orig_params'], \
+            state['_orig_buffers'], state['_repl_params'], state['_repl_buffers']
+        return state
+
+    def __setstate__(self, state):
+        super(DataParallel, self).__setstate__(state)
+        self._init_cache()
+
     def replicate(self, module, device_ids):
-        return replicate(module, device_ids)
+        if not self._replicas:
+            self._replicas = replicate(module, device_ids)
+
+            def register_callbacks(m, module_cb, param_cb, buffer_cb):
+                for sm in m.modules():
+                    sm._modules = _CallbackOrderedDict.from_ordered(sm._modules)
+                    sm._modules.register_modification_callback(module_cb)
+                    sm._parameters = _CallbackOrderedDict.from_ordered(sm._parameters)
+                    sm._parameters.register_modification_callback(param_cb)
+                    sm._buffers = _CallbackOrderedDict.from_ordered(sm._buffers)
+                    sm._buffers.register_modification_callback(buffer_cb)
+
+            # Cache has to be invalidated if any of modules, parameters or dicts
+            # are modified in **any** of the submodules. Note, that we don't need to
+            # ensure the same for __dict__ because it is shared with the original module.
+            register_callbacks(module, self._invalidate_cache,
+                               self._invalidate_cache, self._invalidate_cache)
+
+            # Modification of these dicts in replicas is forbidden. They should always
+            # mirror the original module exactly.
+            def make_error(name):
+                def callback():
+                    raise RuntimeError("DataParallel replicas can't have their " + name + " modified")
+                return callback
+            for replica in self._replicas:
+                register_callbacks(replica, make_error('modules'),
+                                   make_error('parameters'), make_error('buffers'))
+
+            # Cache information to speed up processing in the fast path
+            self._orig_params = list(module.parameters())
+            self._orig_buffers = list(module._all_buffers())
+            self._repl_params = [list(r.parameters()) for r in self._replicas]
+            self._repl_buffers = [list(r._all_buffers()) for r in self._replicas]
+        else:
+            # Param flags are the only things that we can't get callbacks for.
+            # Everything is fine as long as it's never the case that a replica doesn't
+            # require grad, while the original parameter does.
+            requires_grad_valid = all(rp.requires_grad >= p.requires_grad
+                                      for rp, p in zip(self._repl_params[0], self._orig_params))
+            if not requires_grad_valid:
+                self._replicas = []  # Flush the cache
+                return self.replicate(module, device_ids)
+
+            # NB: we "misuse" the fact that you can safely backprop through broadcasts
+            # multiple times, because they hold no buffers
+            param_copies = comm.broadcast_coalesced([p.data for p in self._orig_params], device_ids)
+            for replica_params, copies in zip(self._repl_params, param_copies):
+                for p, cp in zip(replica_params, copies):
+                    p.data.set_(cp)
+
+            buffer_copies = comm.broadcast_coalesced(self._orig_buffers, device_ids)
+            for replica_buffers, copies in zip(self._repl_buffers, buffer_copies):
+                for b, cb in zip(replica_buffers, copies):
+                    b.set_(cb)
+
+        return self._replicas
 
     def scatter(self, inputs, kwargs, device_ids):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -154,10 +154,12 @@ class DistributedDataParallel(Module):
         self._start_reduction_threads()
 
     def __getstate__(self):
-        attrs = copy.copy(self.__dict__)
+        state = list(super(DistributedDataParallel, self).__getstate__())
+        state[0] = state[0].copy()
+        attrs = state[0]
         del attrs['_grad_accs'], attrs['_reduction_queues'], attrs['_reduction_streams'], \
             attrs['_reduction_threads'], attrs['_nccl_streams'], attrs['_default_streams']
-        return attrs
+        return tuple(state)
 
     def __setstate__(self, state):
         super(DistributedDataParallel, self).__setstate__(state)

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -26,10 +26,12 @@ def replicate(network, devices):
         module_indices[module] = i
         for j in range(num_replicas):
             replica = module.__new__(type(module))
-            replica.__dict__ = module.__dict__.copy()
-            replica._parameters = replica._parameters.copy()
-            replica._buffers = replica._buffers.copy()
-            replica._modules = replica._modules.copy()
+            replica._parameters = module._parameters.copy()
+            replica._buffers = module._buffers.copy()
+            replica._modules = module._modules.copy()
+            # NOTE: This line doesn't undo the previous ones, because
+            # those attributes are stored in slots and not the dict
+            replica.__dict__ = module.__dict__
             module_copies[j].append(replica)
 
     for i, module in enumerate(modules):


### PR DESCRIPTION
This commits makes DataParallel cache the wrapped module replicas, and helps bring down overhead of `replicate` on ResNet1001 from ~140ms to 42ms. Remaining time is spent mostly in `broadcast_coalesced`, so moving it to C++ is the next step.

This commit really starts to push Python to the limit, which can be seen in two places:
* There's this ugly odict hack, because Python inheritance does weird things, and selects a much slower implementation of `__getitem__` for OrderedDict subclasses than it could. I'm going to post to Python's mailing lists and clarify why is this happening, but I'm not aware of any reason why this hack would not work. This might seem like a silly thing, but removing this hack costs us 30ms at each forward.
* I was forced to change the implementation of `torch.jit.compile` for modules, and implement this poor man's inheritance-like thing (including the `__instancecheck__` hack so these object still appear to belong to subclasses)... I've tried a few other things, but I can't come up with anything else that wouldn't break. The problem is that having one superclass with `__slots__`, and another one in C++ confuses Python, and it complains that it can't figure out how to lay them out in memory. I'm happy to discuss alternative solutions.