### PR TITLE
Add build support for Python 2.7 using MSVC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -370,6 +370,10 @@ if IS_WINDOWS:
                           # structured exception handling (SEH)
                           # /DNOMINMAX removes builtin min/max functions
                           ]
+    if sys.version_info[0] == 2:
+        # /bigobj increases number of sections in .obj file, which is needed to link
+        # against libaries in Python 2.7 under Windows
+        extra_compile_args.append('/bigobj')
 else:
     extra_compile_args = ['-std=c++11', '-Wno-write-strings',
                           # Python 2.6 requires -fno-strict-aliasing, see

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -93,14 +93,14 @@ static PyObject * THPGenerator_manualSeed(THPGenerator *self, PyObject *seed)
 static PyObject * THPGenerator_seed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUInt64(self->cdata->seed());
+  return THPUtils_packUnsignedInt64(self->cdata->seed());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject * THPGenerator_initialSeed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUInt64(self->cdata->initialSeed());
+  return THPUtils_packUnsignedInt64(self->cdata->initialSeed());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -93,14 +93,14 @@ static PyObject * THPGenerator_manualSeed(THPGenerator *self, PyObject *seed)
 static PyObject * THPGenerator_seed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUnsignedLong(self->cdata->seed());
+  return PyLong_FromUInt64(self->cdata->seed());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject * THPGenerator_initialSeed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUnsignedLong(self->cdata->initialSeed());
+  return PyLong_FromUInt64(self->cdata->initialSeed());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -93,14 +93,14 @@ static PyObject * THPGenerator_manualSeed(THPGenerator *self, PyObject *seed)
 static PyObject * THPGenerator_seed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return THPUtils_packUnsignedInt64(self->cdata->seed());
+  return THPUtils_packUInt64(self->cdata->seed());
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject * THPGenerator_initialSeed(THPGenerator *self)
 {
   HANDLE_TH_ERRORS
-  return THPUtils_packUnsignedInt64(self->cdata->initialSeed());
+  return THPUtils_packUInt64(self->cdata->initialSeed());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -6,25 +6,6 @@
 #include <TH/TH.h>
 #include <THS/THS.h>
 
-// macros for Windows compatibility
-#ifdef _WIN32
-#undef PyLong_FromLong
-#undef PyLong_AsLong
-#undef PyLong_FromUnsignedLong
-
-#define PyLong_FromLong         PyLong_FromLongLong
-#define PyLong_AsLong           PyLong_AsLongLong
-#define PyLong_FromUnsignedLong PyLong_FromUnsignedLongLong
-
-#ifdef PyInt_Check
-#undef PyInt_FromLong
-#undef PyInt_AsLong
-
-#define PyInt_FromLong          PyLong_FromLong
-#define PyInt_AsLong            PyLong_AsLong
-#endif
-#endif
-
 #include "THP_export.h"
 
 // Back-compatibility macros, Thanks to http://cx-oracle.sourceforge.net/
@@ -35,6 +16,17 @@
 #define PyInt_FromLong          PyLong_FromLong
 #define PyInt_AsLong            PyLong_AsLong
 #define PyInt_Type              PyLong_Type
+#endif
+
+// macros for Windows compatibility
+#ifdef _WIN32
+#define PyInt_FromInt64         PyLong_FromLongLong
+#define PyInt_AsInt64           PyLong_AsLongLong
+#define PyLong_FromUInt64       PyLong_FromUnsignedLongLong
+#else
+#define PyInt_FromInt64         PyInt_FromLong
+#define PyInt_AsInt64           PyInt_AsLong
+#define PyLong_FromUInt64       PyLong_FromUnsignedLong
 #endif
 
 // By default, don't specify library state (TH doesn't use one)

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -15,6 +15,14 @@
 #define PyLong_FromLong         PyLong_FromLongLong
 #define PyLong_AsLong           PyLong_AsLongLong
 #define PyLong_FromUnsignedLong PyLong_FromUnsignedLongLong
+
+#ifdef PyInt_Check
+#undef PyInt_FromLong
+#undef PyInt_AsLong
+
+#define PyInt_FromLong          PyLong_FromLong
+#define PyInt_AsLong            PyLong_AsLong
+#endif
 #endif
 
 #include "THP_export.h"

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -18,17 +18,6 @@
 #define PyInt_Type              PyLong_Type
 #endif
 
-// macros for Windows compatibility
-#ifdef _WIN32
-#define PyInt_FromInt64         PyLong_FromLongLong
-#define PyInt_AsInt64           PyLong_AsLongLong
-#define PyLong_FromUInt64       PyLong_FromUnsignedLongLong
-#else
-#define PyInt_FromInt64         PyInt_FromLong
-#define PyInt_AsInt64           PyInt_AsLong
-#define PyLong_FromUInt64       PyLong_FromUnsignedLong
-#endif
-
 // By default, don't specify library state (TH doesn't use one)
 #define LIBRARY_STATE
 #define LIBRARY_STATE_NOARGS

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -128,7 +128,7 @@ PyObject* getTensorAttr(PyObject* obj, void* _unused)
 // specialization.  So we write a little stub function which does have
 // the right type.
 static PyObject* PortablePyInt_FromLong(int64_t ival) {
-  return PyInt_FromLong(ival);
+  return PyInt_FromInt64(ival);
 }
 
 static struct PyGetSetDef batch_norm_forward_properties[] = {

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -128,7 +128,7 @@ PyObject* getTensorAttr(PyObject* obj, void* _unused)
 // specialization.  So we write a little stub function which does have
 // the right type.
 static PyObject* PortablePyInt_FromLong(int64_t ival) {
-  return PyInt_FromInt64(ival);
+  return THPUtils_packInt64(ival);
 }
 
 static struct PyGetSetDef batch_norm_forward_properties[] = {

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1025,7 +1025,7 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
     PyObject* fn = functionToPyObject(next_fns[i].first);
     if (!fn) return NULL;
     PyTuple_SET_ITEM(fn_tuple.get(), 0, fn);
-    PyTuple_SET_ITEM(fn_tuple.get(), 1, PyInt_FromLong(next_fns[i].second));
+    PyTuple_SET_ITEM(fn_tuple.get(), 1, PyInt_FromInt64(next_fns[i].second));
     PyTuple_SET_ITEM(result.get(), i, fn_tuple.release());
   }
   return result.release();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1025,7 +1025,7 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
     PyObject* fn = functionToPyObject(next_fns[i].first);
     if (!fn) return NULL;
     PyTuple_SET_ITEM(fn_tuple.get(), 0, fn);
-    PyTuple_SET_ITEM(fn_tuple.get(), 1, PyInt_FromInt64(next_fns[i].second));
+    PyTuple_SET_ITEM(fn_tuple.get(), 1, THPUtils_packInt64(next_fns[i].second));
     PyTuple_SET_ITEM(result.get(), i, fn_tuple.release());
   }
   return result.release();

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -236,21 +236,21 @@ PyObject * THCPModule_manualSeedAll(PyObject *_unused, PyObject *seed)
 PyObject * THCPModule_seed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return THPUtils_packUnsignedInt64(THCRandom_seed(state));
+  return THPUtils_packUInt64(THCRandom_seed(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_seedAll(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return THPUtils_packUnsignedInt64(THCRandom_seedAll(state));
+  return THPUtils_packUInt64(THCRandom_seedAll(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_initialSeed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return THPUtils_packUnsignedInt64(THCRandom_initialSeed(state));
+  return THPUtils_packUInt64(THCRandom_initialSeed(state));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -236,21 +236,21 @@ PyObject * THCPModule_manualSeedAll(PyObject *_unused, PyObject *seed)
 PyObject * THCPModule_seed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUInt64(THCRandom_seed(state));
+  return THPUtils_packUnsignedInt64(THCRandom_seed(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_seedAll(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUInt64(THCRandom_seedAll(state));
+  return THPUtils_packUnsignedInt64(THCRandom_seedAll(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_initialSeed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUInt64(THCRandom_initialSeed(state));
+  return THPUtils_packUnsignedInt64(THCRandom_initialSeed(state));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -236,21 +236,21 @@ PyObject * THCPModule_manualSeedAll(PyObject *_unused, PyObject *seed)
 PyObject * THCPModule_seed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUnsignedLong(THCRandom_seed(state));
+  return PyLong_FromUInt64(THCRandom_seed(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_seedAll(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUnsignedLong(THCRandom_seedAll(state));
+  return PyLong_FromUInt64(THCRandom_seedAll(state));
   END_HANDLE_TH_ERRORS
 }
 
 PyObject * THCPModule_initialSeed(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromUnsignedLong(THCRandom_initialSeed(state));
+  return PyLong_FromUInt64(THCRandom_initialSeed(state));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -18,6 +18,18 @@ inline PyObject* THPUtils_packInt64(int64_t value) {
   return PyLong_FromLongLong(value);
 }
 
+inline PyObject* THPUtils_packUnsignedInt64(uint64_t value) {
+#if PY_MAJOR_VERSION == 2
+  if (value <= INT32_MAX) {
+    return PyInt_FromLong(static_cast<long>(value));
+  }
+#endif
+  if (sizeof(unsigned long) == sizeof(uint64_t)) {
+    return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
+  }
+  return PyLong_FromUnsignedLongLong(value);
+}
+
 inline PyObject* THPUtils_packDoubleAsInt(double value) {
 #if PY_MAJOR_VERSION == 2
   if (value <= INT32_MAX && value >= INT32_MIN) {

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -18,15 +18,12 @@ inline PyObject* THPUtils_packInt64(int64_t value) {
   return PyLong_FromLongLong(value);
 }
 
-inline PyObject* THPUtils_packUnsignedInt64(uint64_t value) {
+inline PyObject* THPUtils_packUInt64(uint64_t value) {
 #if PY_MAJOR_VERSION == 2
   if (value <= INT32_MAX) {
     return PyInt_FromLong(static_cast<long>(value));
   }
 #endif
-  if (sizeof(unsigned long) == sizeof(uint64_t)) {
-    return PyLong_FromUnsignedLong(static_cast<unsigned long>(value));
-  }
   return PyLong_FromUnsignedLongLong(value);
 }
 

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -22,7 +22,9 @@ class ConnectionWrapper(object):
         return pickle.loads(buf)
 
     def __getattr__(self, name):
-        return getattr(self.conn, name)
+        if 'conn' in self.__dict__:
+            return getattr(self.conn, name)
+        raise AttributeError('no attribute: ' + name)
 
 
 class Queue(multiprocessing.queues.Queue):

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -22,13 +22,10 @@ class ConnectionWrapper(object):
         return pickle.loads(buf)
 
     def __getattr__(self, name):
-        return getattr(self.conn, name)
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-
-    def __getstate__(self):
-        return self.__dict__
+        if 'conn' in self.__dict__:
+            return getattr(self.conn, name)
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+            type(self).__name__, 'conn'))
 
 
 class Queue(multiprocessing.queues.Queue):

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -22,10 +22,13 @@ class ConnectionWrapper(object):
         return pickle.loads(buf)
 
     def __getattr__(self, name):
-        if 'conn' in self.__dict__:
-            return getattr(self.conn, name)
-        raise AttributeError("'{}' object has no attribute '{}'".format(
-            type(self).__name__, 'conn'))
+        return getattr(self.conn, name)
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+
+    def __getstate__(self):
+        return self.__dict__
 
 
 class Queue(multiprocessing.queues.Queue):

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -24,7 +24,8 @@ class ConnectionWrapper(object):
     def __getattr__(self, name):
         if 'conn' in self.__dict__:
             return getattr(self.conn, name)
-        raise AttributeError('no attribute: ' + name)
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+            type(self).__name__, 'conn'))
 
 
 class Queue(multiprocessing.queues.Queue):


### PR DESCRIPTION
Inspired by @Giszy, I found a way to build with Python 2.7 using MSVC without modification to distutils under Windows. This PR adds the build support for Python 2.7 using the latest MSVC compiler. Some networks are able to run now. However, there're still some tests that can't pass in the CPU build, including:
- [ ] crash when excuting `test_torch.py`
- [ ] crash when excuting `test_autograd.py`
- [ ] crash when excuting `test_legacy_nn.py`
- [ ] errors when excuting `test_cuda.py`
- [ ] Although the test passes, I don't know whether `load_lua` is working as it should be, which has been discussed [here](https://github.com/pytorch/pytorch/pull/2941#discussion_r142378429) previously.