### PR TITLE
Translate None to zeros for old-style autograd functions

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -144,6 +144,20 @@ class TestAutograd(TestCase):
         MyFunction.apply(v.clone()).backward()
         self.assertEqual(v.grad.data.tolist(), [2])
 
+    def test_legacy_function_none_grad(self):
+        class MyFunction(Function):
+            def forward(self, x):
+                return torch.zeros(2, 2, 2)
+
+            def backward(self, grad_output):
+                return None
+
+        shape = (2, 3)
+        v = Variable(torch.ones(shape), requires_grad=True)
+        y = v[0, 0].expand(3, 5).t().sum()
+        MyFunction()(y).sum().backward()
+        self.assertEqual(v.grad.data, torch.zeros(shape))
+
     def test_accumulate_grad(self):
         grad_output = Variable(torch.ones(5, 5))
         for start_volatile, end_volatile in product((True, False), repeat=2):
@@ -407,7 +421,7 @@ class TestAutograd(TestCase):
             self.assertIsInstance(grad_input, tuple)
             self.assertIsInstance(grad_output, tuple)
             self.assertIsNotNone(grad_input[0])
-            self.assertIsNone(grad_input[1])
+            self.assertIsNotNone(grad_input[1])
             self.assertIsNotNone(grad_output[0])
             self.assertIsNotNone(grad_output[1])
             was_called[0] = True

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -867,6 +867,7 @@ static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_g
 
   // Look for Nones and replace them with new buffers
   auto& grads_info = is_grad_output ? self->output_info : self->input_info;
+  TORCH_ASSERT(grads_info.size() == (size_t)num_grads);
   for (int i = 0; i < num_grads; i++) {
     PyObject *grad = PyTuple_GET_ITEM(raw_grads.get(), i);
     if (grad == Py_None) {

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -849,35 +849,35 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
 // Backward
 ////////////////////////////////////////////////////////////////////////////////
 
-static void _prepare_grad_output(THPFunction *self, THPObjectPtr& raw_grad_output)
+static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_grad_output)
 {
   AutoGPU gpu_guard(-1);
-  int num_grad_output = PyTuple_GET_SIZE(raw_grad_output.get());
-  // First, check if any of grad_outputs is None. If not, there's nothing to do
+  int num_grads = PyTuple_GET_SIZE(raw_grads.get());
+  // First, check if any of grads is None. If not, there's nothing to do
   bool has_none = false;
-  for (int i = 0; i < num_grad_output; i++) {
-    has_none |= PyTuple_GET_ITEM(raw_grad_output.get(), i) == Py_None;
+  for (int i = 0; i < num_grads; i++) {
+    has_none |= PyTuple_GET_ITEM(raw_grads.get(), i) == Py_None;
   }
   if (!has_none)
       return;
 
-  THPObjectPtr grad_output;
-  grad_output = PyTuple_New(num_grad_output);
-  if (!grad_output) throw python_error();
+  THPObjectPtr grads;
+  grads = PyTuple_New(num_grads);
+  if (!grads) throw python_error();
 
   // Look for Nones and replace them with new buffers
-  auto& output_info = self->output_info;
-  for (int i = 0; i < num_grad_output; i++) {
-    PyObject *grad = PyTuple_GET_ITEM(raw_grad_output.get(), i);
+  auto& grads_info = is_grad_output ? self->output_info : self->input_info;
+  for (int i = 0; i < num_grads; i++) {
+    PyObject *grad = PyTuple_GET_ITEM(raw_grads.get(), i);
     if (grad == Py_None) {
-      grad = createPyObject(output_info[i].zeros(gpu_guard).data());
+      grad = createPyObject(grads_info[i].zeros(gpu_guard).data());
       if (!grad) throw python_error();
     } else {
       Py_INCREF(grad);
     }
-    PyTuple_SET_ITEM(grad_output.get(), i, grad);
+    PyTuple_SET_ITEM(grads.get(), i, grad);
   }
-  raw_grad_output = grad_output.release();
+  raw_grads = grads.release();
 }
 
 static void _trim_grad_input(THPFunction *self, THPObjectPtr& grad_input)
@@ -920,7 +920,7 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
     // zero-filled buffers instead
     Py_INCREF(raw_grad_output);
     THPObjectPtr grad_output(raw_grad_output);
-    _prepare_grad_output(self, grad_output);
+    _prepare_grads(self, grad_output, true);
 
     // self.backward(*grad_output)
     THPObjectPtr backward_fn(PyObject_GetAttrString((PyObject*)self, "backward"));
@@ -939,6 +939,8 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
         "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
         num_next_fns, num_grads);
 
+    // If any of the remaining grad_inputs are None, zero them.
+    _prepare_grads(self, grad_input, false);
     return grad_input.release();
 
   } catch (python_error& e) {


### PR DESCRIPTION
Fixes #4198. This changes None elements of grad_input tuples to zeros in "old-style" autograd functions, to match "new-style" autograd function behavior.

I reused a function that changes grad_outputs to zeroes if any of them are None. I'm not sure if this function has other side effects that should only apply to grad_outputs only but it doesn't look like it does.

### Test Plan
New unit test in test_autograd