### PR TITLE
Allow optional int tensor in Variable

### DIFF
--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -86,7 +86,7 @@ def handle_outputs_taken_as_arguments(options):
 
     def is_nullable(arg):
         return (arg['type'] in {'THIntegerTensor*', 'THTensor*'} and
-                arg.get('default', '') in {'NULL', 'nullptr'})
+                arg.get('default', '') in {None, 'NULL', 'nullptr'})
 
     def should_generate_out_variant(option):
         if 'function' in option['variants']:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -690,6 +690,7 @@ class TestTorch(TestCase):
                                ((-1.6181, 0.7148),
                                 (1.3728, 0.1319))))
         a = cast(a)
+        a_LU = a.btrifact()  # test default info
         info = cast(torch.IntTensor())
         a_LU = a.btrifact(info=info)
         self.assertEqual(info.abs().sum(), 0)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -64,7 +64,7 @@ DERIVED_CALL = CodeTemplate("""\
 baseType->${method_prefix_derived}${base_name}(${unpacked_args})""")
 
 UNPACK_TENSOR = CodeTemplate("""\
-auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
+auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos} ${,extra_args});""")
 
 FUNCTION_DECLARATION = CodeTemplate("""\
 struct ${op} : public TraceableFunction {
@@ -237,6 +237,16 @@ SKIP_PYTHON_BINDINGS = [
 # Matches "foo" in "foo, bar" but not "foobar". Used to search for the
 # occurence of a parameter in the derivative formula
 IDENT_REGEX = r'(^|\W){}($|\W)'
+
+# a mapping from dynamic type to corresponding ATen scalar type
+SCALAR_TYPE_MAP = {
+    'IndexTensor': 'at::kLong',
+    'BoolTensor': 'at::kByte',
+    'IntegerTensor': 'at::kInt',
+    'HalfTensor': 'at::kHalf',
+    'FloatTensor': 'at::kFloat',
+    'DoubleTensor': 'at::kDouble',
+}
 
 
 def format_return_type(returns):
@@ -726,17 +736,6 @@ def create_variable_type(top_env, aten_declarations):
     def requires_unpack(arg):
         return 'Tensor' in arg['dynamic_type']
 
-    def get_suffix(dynamic_type, is_nullable):
-        if is_nullable:
-            assert dynamic_type == 'Tensor'
-            return '_opt'
-        elif dynamic_type == 'IndexTensor':
-            return '_long'
-        elif dynamic_type == 'BoolTensor':
-            return '_byte'
-        else:
-            return ''
-
     def unpack_args(env, declaration):
         body = []
         unpacked_args = []
@@ -747,17 +746,25 @@ def create_variable_type(top_env, aten_declarations):
 
             dynamic_type = arg['dynamic_type']
             is_nullable = arg.get('is_nullable', False)
+            extra_args = []
             ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensor']
-            suffix = get_suffix(dynamic_type, is_nullable)
+            suffix = ''
             if dynamic_type == 'TensorList' and declaration['name'] == 'index':
                 # TODO: specify this in Declarations.yaml somehow
                 suffix = '_idxs'
+            elif dynamic_type in SCALAR_TYPE_MAP:
+                suffix = '_type'
+                extra_args.append(SCALAR_TYPE_MAP[dynamic_type])
+
+            if is_nullable:
+                suffix += '_opt'
 
             body.append(UNPACK_TENSOR.substitute(
                 arg_name=arg['name'],
                 arg_pos=i,
                 suffix=suffix,
                 ref='&' if ref else '',
+                extra_args=extra_args,
             ))
             unpacked_args.append(arg['name'] + '_')
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -113,19 +113,28 @@ Tensor & VariableType::unpack(const Tensor & t, const char * name, int pos) cons
   return checked_cast(*this, t, name, pos).data();
 }
 
+Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) const {
+  if (!t.defined()) {
+    return Tensor();
+  }
+  return unpack(t, name, pos);
+}
+
 SparseTensor VariableType::unpack(SparseTensor t, const char * name, int pos) const {
   auto backend = is_cuda() ? kSparseCUDA : kSparseCPU;
   return SparseTensor(checked_cast(this->toBackend(backend), t.tref, name, pos).data());
 }
 
-Tensor & VariableType::unpack_long(const Tensor & t, const char * name, int pos) const {
-  auto& type = *VariableImpl::getType(baseType->toScalarType(kLong));
+Tensor & VariableType::unpack_type(const Tensor & t, const char * name, int pos, ScalarType scalar_type) const {
+  auto& type = *VariableImpl::getType(baseType->toScalarType(scalar_type));
   return checked_cast(type, t, name, pos).data();
 }
 
-Tensor & VariableType::unpack_byte(const Tensor & t, const char * name, int pos) const {
-  auto& type = *VariableImpl::getType(baseType->toScalarType(kByte));
-  return checked_cast(type, t, name, pos).data();
+Tensor VariableType::unpack_type_opt(const Tensor & t, const char * name, int pos, ScalarType scalar_type) const {
+  if (!t.defined()) {
+    return Tensor();
+  }
+  return unpack_type(t, name, pos, scalar_type);
 }
 
 Tensor & VariableType::unpack_any(const Tensor & t, const char * name, int pos) const {
@@ -137,13 +146,6 @@ Tensor & VariableType::unpack_any(const Tensor & t, const char * name, int pos) 
   auto backend = t.type().backend();
   auto& type = *VariableImpl::getType(baseType->toScalarType(scalarType).toBackend(backend));
   return checked_cast(type, t, name, pos).data();
-}
-
-Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) const {
-  if(!t.defined()) {
-    return Tensor();
-  }
-  return unpack(t, name, pos);
 }
 
 std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name, int pos) const {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -46,11 +46,11 @@ private:
   // checks that t is actually a Variable with the given expected_type
   static Variable & checked_cast(const Type & expected_type, const Tensor & t, const char * name, int pos);
   at::Tensor & unpack(const Tensor & t, const char * name, int pos) const;
-  at::SparseTensor unpack(SparseTensor t, const char * name, int pos) const;
-  at::Tensor & unpack_long(const Tensor & t, const char * name, int pos) const;
-  at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
-  at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
   at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;
+  at::SparseTensor unpack(SparseTensor t, const char * name, int pos) const;
+  at::Tensor & unpack_type(const Tensor & t, const char * name, int pos, at::ScalarType scalar_type) const;
+  at::Tensor unpack_type_opt(const Tensor & t, const char * name, int pos, at::ScalarType scalar_type) const;
+  at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
   std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos) const;
   std::vector<at::Tensor> unpack_idxs(at::TensorList tl, const char *name, int pos) const;
 


### PR DESCRIPTION
Fixes #4217 .

Tests: script with #4217 now shows expected behavior. The `test_torch.py` test doesn't really test this as it operates on Tensors. But it will cover this once Tensor and Variable merge.