### PR TITLE
Disable tests and fix issues with Windows CUDA build

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -1,3 +1,9 @@
+// define constants like M_PI and C keywords for MSVC
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#include <math.h>
+#endif
+
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/WrapDimUtils.h"

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -14,6 +14,7 @@
 #include "ATen/ScalarType.h"
 #include "ATen/Scalar.h"
 #include "ATen/Tensor.h"
+#include "ATen/Allocator.h"
 
 // To solve the conflict of s_addr in inaddr.h
 #ifdef _MSC_VER

--- a/test/common.py
+++ b/test/common.py
@@ -32,6 +32,7 @@ torch.manual_seed(SEED)
 def run_tests():
     unittest.main(argv=UNITTEST_ARGS)
 
+IS_WINDOWS = sys.platform == "win32"
 
 TEST_NUMPY = True
 try:
@@ -338,7 +339,7 @@ class TestCase(unittest.TestCase):
                      "python {} {} --accept").format(munged_id, s, __main__.__file__, munged_id))
 
         # a hack for JIT tests
-        if sys.platform == 'win32':
+        if IS_WINDOWS:
             expected = re.sub(r'CppOp\[(.+?)\]', 'CppOp[]', expected)
             s = re.sub(r'CppOp\[(.+?)\]', 'CppOp[]', s)
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -8,7 +8,7 @@ import unittest
 from torch import multiprocessing
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataloader import default_collate
-from common import TestCase, run_tests, TEST_NUMPY
+from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 from common_nn import TEST_CUDA
 
 
@@ -223,7 +223,7 @@ class TestDataLoader(TestCase):
         next(loader1_it)
         next(loader2_it)
 
-    @unittest.skipIf(sys.platform == "win32", "TODO: need to fix this test case for Windows")
+    @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this test case for Windows")
     def test_segfault(self):
         def _test_segfault():
             sys.stderr.close()
@@ -240,7 +240,7 @@ class TestDataLoader(TestCase):
         finally:
             p.terminate()
 
-    @unittest.skipIf(sys.platform == "win32", "TODO: need to fix this test case for Windows")
+    @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this test case for Windows")
     def test_timeout(self):
         def _test_timeout():
             sys.stderr.close()
@@ -266,6 +266,7 @@ class TestDataLoader(TestCase):
             seeds.add(batch[0])
         self.assertEqual(len(seeds), num_workers)
 
+    @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this test case for Windows")
     def test_worker_init_fn(self):
         # test custom init function
         def init_fn(worker_id):
@@ -348,6 +349,7 @@ class TestDataLoader(TestCase):
     def test_error_workers(self):
         self._test_error(DataLoader(ErrorDataset(41), batch_size=2, shuffle=True, num_workers=4))
 
+    @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this test case for Windows")
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_partial_workers(self):
         "check that workers exit even if the iterator is not exhausted"

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from itertools import product
 from torch.autograd import Variable, Function
 from torch.autograd.function import traceable
-from common import TestCase, run_tests
+from common import TestCase, run_tests, IS_WINDOWS
 import io
 import sys
 
@@ -26,8 +26,6 @@ if torch.cuda.is_available():
         major = torch.cuda.get_device_capability(d)[0]
         if (CUDA_VERSION < 8000 and major >= 6) or (CUDA_VERSION < 9000 and major >= 7):
             RUN_CUDA = False
-
-IS_WINDOWS = sys.platform == "win32"
 
 
 def LSTMCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
@@ -295,6 +293,7 @@ class TestJit(TestCase):
         self.assertEqual(z, torch.sigmoid(torch.tanh(x * (x + y))))
         self.assertEqual(z, z2)
 
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_compile_addc(self):
         x = Variable(torch.Tensor([0.4]), requires_grad=True).float().cuda()
@@ -767,6 +766,7 @@ class TestJit(TestCase):
         assert(torch.equal(torch.ones([2, 2]), t_node.t("a")))
         self.assertExpected(str(g2))
 
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "cpp tests require CUDA")
     def test_cpp(self):
         torch._C._jit_run_cpp_tests()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -11,7 +11,7 @@ import torch.cuda
 import torch.multiprocessing as mp
 from torch.autograd import Variable
 from torch.nn import Parameter
-from common import TestCase, run_tests
+from common import TestCase, run_tests, IS_WINDOWS
 
 
 TEST_REPEATS = 30
@@ -290,6 +290,7 @@ class TestMultiprocessing(TestCase):
         p.join(1)
         self.assertEqual(t, torch.ones(5, 5) * 3, 0)
 
+    @unittest.skipIf(IS_WINDOWS, 'NYI: not supported on Windows')
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     def test_cuda(self):
         torch.cuda.FloatTensor([1])  # initialize CUDA outside of leak checker
@@ -324,6 +325,7 @@ class TestMultiprocessing(TestCase):
             self.assertEqual(tensor_size, 5)
             self.assertEqual(storage_size, 5)
 
+    @unittest.skipIf(IS_WINDOWS, 'NYI: not supported on Windows')
     @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
     def test_cuda_bad_call(self):
         # Initialize CUDA
@@ -336,6 +338,7 @@ class TestMultiprocessing(TestCase):
         p.join()
         self.assertIsInstance(outq.get(), RuntimeError)
 
+    @unittest.skipIf(IS_WINDOWS, 'NYI: not supported on Windows')
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     def test_event(self):
         ctx = mp.get_context('spawn')

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -14,6 +14,7 @@ if nGPUs == 0:
 
 class TestNCCL(TestCase):
 
+    @unittest.skipIf(sys.platform == "win32", "NCCL doesn't support Windows")
     def test_unique_id(self):
         uid = nccl.unique_id()
         self.assertIsInstance(uid, bytes)

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -4,7 +4,7 @@ import torch
 import torch.cuda.nccl as nccl
 import torch.cuda
 
-from common import TestCase, run_tests
+from common import TestCase, run_tests, IS_WINDOWS
 
 nGPUs = torch.cuda.device_count()
 if nGPUs == 0:
@@ -14,7 +14,7 @@ if nGPUs == 0:
 
 class TestNCCL(TestCase):
 
-    @unittest.skipIf(sys.platform == "win32", "NCCL doesn't support Windows")
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self):
         uid = nccl.unique_id()
         self.assertIsInstance(uid, bytes)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -230,7 +230,6 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
 
 class TestNN(NNTestCase):
-
     def _forward(self, module, input):
         with freeze_rng_state():
             return module(input)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2109,7 +2109,7 @@ class TestNN(NNTestCase):
                  torch.cuda.HalfTensor]
         precs = [1e-5, 1e-5, 1e-2]
         for tp, prec in zip(types, precs):
-            if IS_WINDOWS and tp == torch.cuda.HalfTensor: # CUDA HalfTensor is not supported on Windows yet
+            if IS_WINDOWS and tp == torch.cuda.HalfTensor:  # CUDA HalfTensor is not supported on Windows yet
                 continue
             for depth_multiplier in [1, 2]:
                 m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).type(tp)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -30,7 +30,7 @@ from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     TEST_CUDNN_VERSION, loss_reference_fns, get_size_average
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, download_file
+    TEST_SCIPY, download_file, IS_WINDOWS
 
 if TEST_SCIPY:
     from scipy import stats
@@ -230,6 +230,7 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
 
 class TestNN(NNTestCase):
+
     def _forward(self, module, input):
         with freeze_rng_state():
             return module(input)
@@ -2109,6 +2110,8 @@ class TestNN(NNTestCase):
                  torch.cuda.HalfTensor]
         precs = [1e-5, 1e-5, 1e-2]
         for tp, prec in zip(types, precs):
+            if IS_WINDOWS and tp == torch.cuda.HalfTensor: # CUDA HalfTensor is not supported on Windows yet
+                continue
             for depth_multiplier in [1, 2]:
                 m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).type(tp)
                 i = Variable(torch.randn(2, 2, 6, 6).type(tp), requires_grad=True)


### PR DESCRIPTION
This diff disables some of the test cases to make CUDA build/test work on Windows. The remaining issues are documented in https://github.com/pytorch/pytorch/issues/4092.  