### PR TITLE
Implement .numpy_dtype() method for Tensor, Variable

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4785,6 +4785,7 @@ class TestTorch(TestCase):
             y = x.numpy()
             for i in range(sz):
                 self.assertEqual(x[i], y[i])
+            self.assertEqual(x.numpy_dtype(), y.dtype)
 
             # 1D > 0 storage offset
             xm = torch.randn(sz * 2).mul(255).type(tp)

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -399,6 +399,15 @@ static PyObject * THPVariable_numpy(PyObject* self, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_numpy_dtype(PyObject* self, PyObject* arg)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  return torch::utils::tensor_to_numpy_dtype(self_.data());
+  END_HANDLE_TH_ERRORS
+}
+
+
 static PyObject * THPVariable_map_(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
@@ -544,6 +553,7 @@ PyMethodDef variable_methods[] = {
   {"nelement", (PyCFunction)THPVariable_numel, METH_NOARGS, NULL},
   {"new", (PyCFunction)THPVariable_new, METH_VARARGS | METH_KEYWORDS, NULL},
   {"numpy", (PyCFunction)THPVariable_numpy, METH_NOARGS, NULL},
+  {"numpy_dtype", (PyCFunction)THPVariable_numpy_dtype, METH_NOARGS, NULL},
   {"short", (PyCFunction)THPVariable_short, METH_NOARGS, NULL},
   {"size", (PyCFunction)THPVariable_size, METH_VARARGS | METH_KEYWORDS, NULL},
   {"storage", (PyCFunction)THPVariable_storage, METH_NOARGS, NULL},

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -50,6 +50,11 @@ static std::vector<int64_t> to_aten_shape(int ndim, npy_intp* values) {
 static int aten_to_dtype(const at::Type& type);
 static ScalarType dtype_to_aten(int dtype);
 
+PyObject* tensor_to_numpy_dtype(const at::Tensor& tensor) {
+  auto dtype = aten_to_dtype(tensor.type());
+  return (PyObject *)PyArray_DescrFromType(dtype);
+}
+
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   auto dtype = aten_to_dtype(tensor.type());
   auto sizes = to_numpy_shape(tensor.sizes());

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -5,6 +5,7 @@
 
 namespace torch { namespace utils {
 
+PyObject* tensor_to_numpy_dtype(const at::Tensor& tensor);
 PyObject* tensor_to_numpy(const at::Tensor& tensor);
 at::Tensor tensor_from_numpy(PyObject* obj);
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -406,6 +406,9 @@ class _TensorBase(object):
     def numpy(self):
         return torch.autograd.Variable(self).numpy()
 
+    def numpy_dtype(self):
+        return torch.autograd.Variable(self).numpy_dtype()
+
     # Numpy array interface, to support `numpy.asarray(tensor) -> ndarray`
     def __array__(self, dtype=None):
         if dtype is None:


### PR DESCRIPTION
This implements `Tensor.numpy_dtype()` method equivalent to `Tensor.numpy().dtype` but without creating the intermediate numpy array.

## Why?

I'm trying to avoid NANs in division by adding tiny numbers to tensors. Tiny numbers depend on datatype: float32 vs float64 etc. In Numpy I can add do this with
```py
x = np.zeros(1)
x += np.finfo(x.dtype).tiny
```
PyTorch currently has no way to map PyTorch dataypes to Numpy datatypes. This PR adds a `.numpy_dtype()` method to support the desired behavior via
```py
x = torch.zeros(1)
x += np.finfo(x.numpy_dtype()).tiny
```
See https://discuss.pytorch.org/t/min-positive-value-for-each-tensor-type/11215