### PR TITLE
Implement torch.where(condition, x, y) CPU Variable.

### DIFF
--- a/aten/src/ATen/Check.cpp
+++ b/aten/src/ATen/Check.cpp
@@ -190,4 +190,19 @@ void checkAllDefined(CheckedFrom c, ArrayRef<TensorArg> ts) {
   }
 }
 
+void checkBackend(CheckedFrom c, const Tensor& t, Backend backend) {
+  if (t.type().backend() != backend) {
+    std::ostringstream oss;
+    oss << "Expected tensor to have " << toString(t.type().backend()) << " Backend, but got tensor with "
+        << toString(t.type().backend()) << " Backend "
+        << "(while checking arguments for )" << c << ")";
+  }
+}
+
+void checkBackend(CheckedFrom c, ArrayRef<Tensor> tensors, at::Backend backend) {
+  for (auto &t : tensors) {
+    checkBackend(c, t, backend);
+  }
+}
+
 }

--- a/aten/src/ATen/Check.h
+++ b/aten/src/ATen/Check.h
@@ -70,4 +70,6 @@ void checkSameSize(CheckedFrom c, const TensorArg& t1, const TensorArg& t2);
 void checkDefined(CheckedFrom c, const TensorArg& t);
 void checkAllDefined(CheckedFrom c, at::ArrayRef<TensorArg> t);
 
+// FixMe: does TensorArg slow things down?
+void checkBackend(CheckedFrom c, at::ArrayRef<Tensor> t, at::Backend backend);
 }

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -570,10 +570,16 @@ def create_generic(top_env, declarations):
 
         # ensure we get reference-type formals when appropriate
         def native_translate_formals(argument, option):
+            def translate_map(const):
+                return {
+                    'Tensor': 'const Tensor &' if const else 'Tensor &',
+                    'BoolTensor': 'const Tensor &' if const else 'Tensor &'
+                }
+
             if (option['inplace'] and argument['name'] == 'self') or argument.get('output', False):
-                argument['type'] = {'Tensor': 'Tensor &'}.get(argument['type'], argument['type'])
+                argument['type'] = translate_map(False).get(argument['type'], argument['type'])
             else:
-                argument['type'] = {'Tensor': 'const Tensor &'}.get(argument['type'], argument['type'])
+                argument['type'] = translate_map(True).get(argument['type'], argument['type'])
 
             return argument
 

--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -465,6 +465,36 @@ bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol)
   return true;
 }
 
+template <typename scalar>
+struct WhereOp {
+  static void apply(Tensor& ret, const Tensor& condition, const Tensor& self, const Tensor& other) {
+    CPU_tensor_apply4<scalar, uint8_t, scalar, scalar>(ret, condition, self, other,
+      [](scalar& ret_val, const uint8_t& cond_val, const scalar& self_val, const scalar& other_val) {
+        ret_val = cond_val ? self_val : other_val;
+      }
+    );
+  }
+};
+
+Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
+  Tensor b_condition, b_self, b_other;
+  std::tie(b_condition, b_self, b_other) = expand_outplace(condition, self, other, "where");
+  return at::_s_where(b_condition, b_self, b_other);
+}
+
+Tensor _s_where(const Tensor& condition, const Tensor& self, const Tensor& other) {
+  if (condition.type().scalarType() != ScalarType::Byte) {
+    runtime_error("Expected condition to have ScalarType Byte, but got ScalarType %s",
+                  toString(condition.type().scalarType()));
+  }
+  if (self.type().backend() != Backend::CPU) {
+    runtime_error("where() only supported with Backend::CPU, got %s", toString(self.type().backend()));
+  }
+  Tensor ret = self.type().tensor(self.sizes());
+  dispatch_all<WhereOp>(ret.type(), "where", ret, condition, self, other);
+  return ret;
+}
+
 std::tuple<at::Tensor, at::Tensor> RoiPooling2d_forward_cpu(
 	const Tensor& input,
 	const Tensor& rois,
@@ -599,28 +629,28 @@ Tensor RoiPooling2d_backward_cpu(
 
 
 // TODO Replace this with more accurate digamma().
-template <typename CScalar>
-static inline CScalar digamma_one(CScalar x) {
-  const CScalar eps = x * 1e-2;
+template <typename scalar>
+static inline scalar digamma_one(scalar x) {
+  const scalar eps = x * 1e-2;
   return (std::lgamma(x + eps) - std::lgamma(x - eps)) / (eps + eps);
 }
 
 /** Computes the reparameterized gradient -(d/dalpha cdf(x;alpha)) / pdf(x;alpha)
     for random number x drawn from a standard Gamma distribution Gamma(alpha).
 */
-template <typename CScalar>
-static inline CScalar standard_gamma_grad_one(CScalar alpha, CScalar x) {
+template <typename scalar>
+static inline scalar standard_gamma_grad_one(scalar alpha, scalar x) {
   // Use an asymptotic approximation for small x.
   if (x < 0.2f) {
-    const CScalar a0 = 1 / alpha;
-    const CScalar a1 = 1 / (alpha + 1);
-    const CScalar a2 = 1 / (alpha + 2);
-    const CScalar pow_x_alpha = std::pow(x, alpha);
-    const CScalar gamma_pdf = std::pow(x, alpha - 1) * std::exp(-x);
-    const CScalar gamma_cdf = pow_x_alpha * (a0 - x*a1 + 0.5f*x*x*a2);
-    const CScalar gamma_cdf_alpha = (std::log(x) - digamma_one(alpha)) * gamma_cdf
+    const auto a0 = 1 / alpha;
+    const auto a1 = 1 / (alpha + 1);
+    const auto a2 = 1 / (alpha + 2);
+    const auto pow_x_alpha = std::pow(x, alpha);
+    const auto gamma_pdf = std::pow(x, alpha - 1) * std::exp(-x);
+    const auto gamma_cdf = pow_x_alpha * (a0 - x*a1 + 0.5f*x*x*a2);
+    const auto gamma_cdf_alpha = (std::log(x) - digamma_one(alpha)) * gamma_cdf
         - pow_x_alpha * (a0*a0 - x*a1*a1 + 0.5f*x*x*a2*a2);
-    const CScalar result = -gamma_cdf_alpha / gamma_pdf;
+    const auto result = -gamma_cdf_alpha / gamma_pdf;
     return std::isnan(result) ? 0 : result;
   }
 
@@ -630,9 +660,9 @@ static inline CScalar standard_gamma_grad_one(CScalar alpha, CScalar x) {
   }
 
   // Use a bivariate rational approximation to the reparameterized gradient.
-  const CScalar u = std::log(x / alpha);
-  const CScalar v = std::log(alpha);
-  static const CScalar coef_uv[3][8] = {
+  const auto u = std::log(x / alpha);
+  const auto v = std::log(alpha);
+  static const scalar coef_uv[3][8] = {
     {0.16028008, -0.088064309, 0.019630876, -0.0016920282,
      1.0, 0.36659853, 0.10843863, 0.0066895454},
     {0.521894, 0.16095838, 0.06237597, 0.0023884253,
@@ -640,20 +670,20 @@ static inline CScalar standard_gamma_grad_one(CScalar alpha, CScalar x) {
     {-0.0031143957, -0.012143877, -0.0057656484, -0.00064847254,
      0.0087262576, -0.00022820524, 1.8871047e-05, 9.6307964e-06},
   };
-  CScalar coef_v[8];
+  scalar coef_v[8];
   for (int i = 0; i < 8; ++ i) {
     coef_v[i] = coef_uv[0][i] + u * (coef_uv[1][i] + u * coef_uv[2][i]);
   }
-  const CScalar p = coef_v[0] + v * (coef_v[1] + v * (coef_v[2] + v * coef_v[3]));
-  const CScalar q = coef_v[4] + v * (coef_v[5] + v * (coef_v[6] + v * coef_v[7]));
+  const auto p = coef_v[0] + v * (coef_v[1] + v * (coef_v[2] + v * coef_v[3]));
+  const auto q = coef_v[4] + v * (coef_v[5] + v * (coef_v[6] + v * coef_v[7]));
   return std::exp(p / q);
 }
 
-template <typename CScalar>
+template <typename scalar>
 struct StandardGammaGradOp {
   static void apply(Tensor& ret, const Tensor& self, const Tensor& output) {
-    CPU_tensor_apply3<CScalar>(ret, self, output,
-      [](CScalar& ret_val, const CScalar& self_val, const CScalar &output_val) {
+    CPU_tensor_apply3<scalar, scalar, scalar>(ret, self, output,
+      [](scalar& ret_val, const scalar& self_val, const scalar &output_val) {
          ret_val = standard_gamma_grad_one(self_val, output_val);
       }
     );

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -109,6 +109,12 @@
 
 - func: matmul(Tensor self, Tensor other) -> Tensor
 
+# we define both of these because 'where' does the broadcast and '_s_where' doesn't;
+# this allows us to implicitly calculate the broadcast derivative, while only dealing with the
+# _s_where derivative.
+- func: where(BoolTensor condition, Tensor self, Tensor other) -> Tensor
+- func: _s_where(BoolTensor condition, Tensor self, Tensor other) -> Tensor
+
 - func: RoiPooling2d_forward(Tensor input, Tensor rois, int64_t pooledHeight, int64_t pooledWidth, double spatialScale) -> (Tensor, Tensor)
   variants: function
   dispatch:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2286,6 +2286,8 @@ method_tests = [
     ('topk', (S, M, S), (3, 1, True), 'dim_desc'),
     ('topk', (S, M, S), (3, 1, True, True), 'dim_desc_sort'),
     ('take', (S, S, S), (Variable(torch.LongTensor([[-3, 2], [20, 2]])),)),
+    ('where', (M, M), (Variable(mask_not_all_zeros((M, M)), requires_grad=False), (M, M))),
+    ('where', (M, 1, M), (Variable(mask_not_all_zeros((M, M)), requires_grad=False), (M, M, 1)), 'broadcast_all'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([1, 2]),)),
     ('__getitem__', torch.randn(S, S, S), (slice(0, 3),), 'slice'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([slice(0, 3), 1]),), 'slice_index'),
@@ -2406,6 +2408,8 @@ def exclude_tensor_method(name, test_name):
         'test_clamp_min',
         'test_clamp_max',
         'test_slice',
+        'test_where',
+        'test_where_broadcast_all'
     }
     # there are no out-of-place tensor equivalents for these
     exclude_outplace_tensor_method = {

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -648,6 +648,11 @@
 - name: view(Tensor self, IntList size)
   self: grad.contiguous().view(self.sizes())
 
+- name: _s_where(Tensor condition, Tensor self, Tensor other)
+  condition: zeros_like(condition)
+  self: _s_where(condition, grad, zeros_like(grad))
+  other: _s_where(condition, zeros_like(grad), grad)
+
 - name: zero(Tensor self)
   self: zeros_like(grad)
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -356,7 +356,6 @@ IMPLEMENT_STATELESS(ge)
 IMPLEMENT_STATELESS(le)
 IMPLEMENT_STATELESS(eq)
 IMPLEMENT_STATELESS(ne)
-IMPLEMENT_STATELESS(where)
 
 IMPLEMENT_STATELESS_ADDXX(addmm)
 IMPLEMENT_STATELESS_ADDXX(addmv)
@@ -671,7 +670,6 @@ static PyMethodDef TorchMethods[] = {
   {"le",              (PyCFunction)THPModule_le,                METH_VARARGS | METH_KEYWORDS, NULL},
   {"eq",              (PyCFunction)THPModule_eq,                METH_VARARGS | METH_KEYWORDS, NULL},
   {"ne",              (PyCFunction)THPModule_ne,                METH_VARARGS | METH_KEYWORDS, NULL},
-  {"where",           (PyCFunction)THPModule_where,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"kthvalue",        (PyCFunction)THPModule_kthvalue,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"mode",            (PyCFunction)THPModule_mode,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"median",          (PyCFunction)THPModule_median,            METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -356,6 +356,7 @@ IMPLEMENT_STATELESS(ge)
 IMPLEMENT_STATELESS(le)
 IMPLEMENT_STATELESS(eq)
 IMPLEMENT_STATELESS(ne)
+IMPLEMENT_STATELESS(where)
 
 IMPLEMENT_STATELESS_ADDXX(addmm)
 IMPLEMENT_STATELESS_ADDXX(addmv)
@@ -670,6 +671,7 @@ static PyMethodDef TorchMethods[] = {
   {"le",              (PyCFunction)THPModule_le,                METH_VARARGS | METH_KEYWORDS, NULL},
   {"eq",              (PyCFunction)THPModule_eq,                METH_VARARGS | METH_KEYWORDS, NULL},
   {"ne",              (PyCFunction)THPModule_ne,                METH_VARARGS | METH_KEYWORDS, NULL},
+  {"where",           (PyCFunction)THPModule_where,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"kthvalue",        (PyCFunction)THPModule_kthvalue,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"mode",            (PyCFunction)THPModule_mode,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"median",          (PyCFunction)THPModule_median,            METH_VARARGS | METH_KEYWORDS, NULL},


### PR DESCRIPTION
This does the following:
1) Adds a four-argument CPU apply template
2) Renames scalar template arguments from "CScalar" to "scalar" as previously agreed.
3) Uses auto in a bunch of places for the existing apply functions
4) Added a 'BoolTensor' specification in native_functions to indicate it should be a BoolTensor in Declarations.yaml (this matters for Variable type checking)
5) Implements 'where' using these above; it's more complex than I would like because you want to figure out the broadcasting backwards implicitly and write the derivative only in terms of same size tensors; this requires writing two different functions (where and _s_where) and writing the derivative in terms of _s_where.  I can't currently think of an easier way to do this without adding a bunch of mechanism complexity to the native_functions path.