### PR TITLE
Fix broken test_beta_log_prob in Python 3.6

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -357,7 +357,7 @@ class TestDistributions(TestCase):
             dist = Beta(alpha, beta)
             x = dist.sample()
             actual_log_prob = dist.log_prob(x).sum()
-            expected_log_prob = scipy.stats.beta.logpdf(x, alpha, beta)
+            expected_log_prob = scipy.stats.beta.logpdf(x, alpha, beta)[0]
             self.assertAlmostEqual(actual_log_prob, expected_log_prob, places=3)
 
     # This is a randomized test.


### PR DESCRIPTION
Addresses #4260 

Thanks to @ngimel who noticed the breakage due to #4117!

Tested with Numpy 1.13.3 and SciPy 1.0.0:
- Python 2.7
- Python 3.6