### PR TITLE
Ensure gamma samples are positive

### DIFF
--- a/aten/src/TH/generic/THTensorRandom.c
+++ b/aten/src/TH/generic/THTensorRandom.c
@@ -64,6 +64,11 @@ void THTensor_(bernoulli_DoubleTensor)(THTensor *self, THGenerator *_generator, 
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
+#if defined(TH_REAL_IS_FLOAT)
+#define TH_REAL_MIN FLT_MIN
+#elif defined(TH_REAL_IS_DOUBLE)
+#define TH_REAL_MIN DBL_MIN
+#endif
 
 void THTensor_(bernoulli_Tensor)(THTensor *self, THGenerator *_generator, THTensor* p)
 {
@@ -122,7 +127,8 @@ void THTensor_(standard_gamma)(THTensor *self, THGenerator *gen, THTensor *alpha
 {
   THTensor_(resizeAs)(self, alpha);
   TH_TENSOR_APPLY2(real, self, real, alpha, {
-    *self_data = THRandom_standard_gamma(gen, *alpha_data);
+    const real sample = THRandom_standard_gamma(gen, *alpha_data);
+    *self_data = sample > 0 ? sample : TH_REAL_MIN;
   });
 }
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -368,6 +368,10 @@ class TestDistributions(TestCase):
             self._check_sampler_sampler(Beta(alpha, beta),
                                         scipy.stats.beta(alpha, beta),
                                         'Beta(alpha={}, beta={})'.format(alpha, beta))
+        # Check that small alphas do not cause NANs.
+        for Tensor in [torch.FloatTensor, torch.DoubleTensor]:
+            x = Beta(Tensor([1e-6]), Tensor([1e-6])).sample()[0]
+            self.assertTrue(np.isfinite(x) and x > 0, 'Invalid Beta.sample(): {}'.format(x))
 
     # This is a randomized test.
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")


### PR DESCRIPTION
This ensures random Gamma samples are positive by clamping results to at least `DBL_MIN` or `FLT_MIN`. This is needed to avoid NANs in `Beta` and `Dirichlet` samples for small `alpha` (e.g. < 0.001).

This is a low-level alternative to `Tensor.numpy_dtype()` in https://github.com/pytorch/pytorch/pull/4256 , which would require a dependency on Numpy's `np.finfo` in torch.distributions.

## Tested

- Added a regression test
- Tested locally with Scipy in Python 2.7
- Tested locally with Scipy in Python 3.6