### PR TITLE
Minor changes to test utils to catch type errors

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -188,7 +188,7 @@ class TestCase(unittest.TestCase):
             raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
         return x, y
 
-    def assertEqual(self, x, y, prec=None, message=''):
+    def assertEqual(self, x, y, prec=None, message='', allow_inf=False):
         if isinstance(prec, str) and message == '':
             message = prec
             prec = None
@@ -229,8 +229,13 @@ class TestCase(unittest.TestCase):
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, prec, message)
         elif isinstance(x, Number) and isinstance(y, Number):
-            if x != y:
-                super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
+            if abs(x) == float('inf') or abs(y) == float('inf'):
+                if allow_inf:
+                    super(TestCase, self).assertEqual(x, y, message)
+                else:
+                    self.fail("Expected finite numeric values - x={}, y={}".format(x, y))
+                return
+            super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
         else:
             super(TestCase, self).assertEqual(x, y, message)
 

--- a/test/common.py
+++ b/test/common.py
@@ -210,7 +210,7 @@ class TestCase(unittest.TestCase):
                         diff = diff.abs()
                     max_err = diff.max()
                     self.assertLessEqual(max_err, prec, message)
-            self.assertEqual(x.is_sparse, y.is_sparse, message)
+            super(TestCase, self).assertEqual(x.is_sparse, y.is_sparse, message)
             if x.is_sparse:
                 x = self.safeCoalesce(x)
                 y = self.safeCoalesce(y)

--- a/test/common.py
+++ b/test/common.py
@@ -8,6 +8,8 @@ import contextlib
 from functools import wraps
 from itertools import product
 from copy import deepcopy
+from numbers import Number
+
 import __main__
 import errno
 
@@ -197,7 +199,7 @@ class TestCase(unittest.TestCase):
 
         if torch.is_tensor(x) and torch.is_tensor(y):
             def assertTensorsEqual(a, b):
-                super(TestCase, self).assertEqual(a.size(), b.size())
+                super(TestCase, self).assertEqual(a.size(), b.size(), message)
                 if a.numel() > 0:
                     b = b.type_as(a)
                     b = b.cuda(device=a.get_device()) if a.is_cuda else b.cpu()
@@ -219,20 +221,25 @@ class TestCase(unittest.TestCase):
             else:
                 assertTensorsEqual(x, y)
         elif isinstance(x, string_classes) and isinstance(y, string_classes):
-            super(TestCase, self).assertEqual(x, y)
+            super(TestCase, self).assertEqual(x, y, message)
         elif type(x) == set and type(y) == set:
-            super(TestCase, self).assertEqual(x, y)
+            super(TestCase, self).assertEqual(x, y, message)
         elif is_iterable(x) and is_iterable(y):
-            super(TestCase, self).assertEqual(len(x), len(y))
+            super(TestCase, self).assertEqual(len(x), len(y), message)
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, prec, message)
-        else:
-            try:
-                self.assertLessEqual(abs(x - y), prec, message)
+        elif isinstance(x, Number) and isinstance(y, Number):
+            if abs(x) == float('inf') and abs(y) == float('inf'):
                 return
-            except (TypeError, AssertionError):
-                pass
+            super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
+        else:
             super(TestCase, self).assertEqual(x, y, message)
+
+    def assertAlmostEqual(self, x, y, places=None, msg=None, delta=None):
+        prec = delta
+        if places:
+            prec = 10**(-places)
+        self.assertEqual(x, y, prec, msg)
 
     def assertNotEqual(self, x, y, prec=None, message=''):
         if prec is None:

--- a/test/common.py
+++ b/test/common.py
@@ -229,9 +229,8 @@ class TestCase(unittest.TestCase):
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, prec, message)
         elif isinstance(x, Number) and isinstance(y, Number):
-            if abs(x) == float('inf') and abs(y) == float('inf'):
-                return
-            super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
+            if x != y:
+                super(TestCase, self).assertLessEqual(abs(x - y), prec, message)
         else:
             super(TestCase, self).assertEqual(x, y, message)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1268,9 +1268,9 @@ class TestAutograd(TestCase):
         f[0] = float('nan')
         self.assertTrue(math.isnan(float(f)))
         f[0] = float('inf')
-        self.assertEqual(float(f), float('inf'))
+        self.assertEqual(float(f), float('inf'), allow_inf=True)
         f[0] = float('-inf')
-        self.assertEqual(float(f), float('-inf'))
+        self.assertEqual(float(f), float('-inf'), allow_inf=True)
 
         # integral -> floating point
         # check we can convert something that loses precision

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,6 +1,5 @@
 import math
 import unittest
-import warnings
 from collections import namedtuple
 from itertools import product
 


### PR DESCRIPTION
Some minor changes to test utils to have consistent behavior between python 2/3 and to catch type mismatch errors.
 - do not swallow `TypeError` in `assertEqual`.
 - override `assertAlmostEqual` to handle iterables, tensors and numeric types.

Tested locally on python 2.7 and 3.6.