### PR TITLE
Further improvements to ATen convolution

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -66,6 +66,22 @@ void Context::setUserEnabledCuDNN(bool e) {
   enabled_cudnn = e;
 }
 
+bool Context::deterministicCuDNN() const {
+  return deterministic_cudnn;
+}
+
+void Context::setDeterministicCuDNN(bool b) {
+  deterministic_cudnn = b;
+}
+
+bool Context::benchmarkCuDNN() const {
+  return benchmark_cudnn;
+}
+
+void Context::setBenchmarkCuDNN(bool b) {
+  benchmark_cudnn = b;
+}
+
 bool Context::hasCUDA() const {
 #if AT_CUDA_ENABLED()
   int count;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -54,6 +54,10 @@ public:
   // to test this instead
   bool userEnabledCuDNN() const;
   void setUserEnabledCuDNN(bool e);
+  bool benchmarkCuDNN() const;
+  void setBenchmarkCuDNN(bool);
+  bool deterministicCuDNN() const;
+  void setDeterministicCuDNN(bool);
   ~Context();
   std::unique_ptr<Generator>
     generator_registry[static_cast<int>(Backend::NumOptions)];
@@ -70,6 +74,8 @@ private:
   void doInitCUDA();
   std::once_flag thc_init;
   bool enabled_cudnn = true;
+  bool deterministic_cudnn = false;
+  bool benchmark_cudnn = false;
 };
 
 AT_API Context & globalContext();

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -103,7 +103,7 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
   input = input.view({batch, 1, len, 1});
   kernel = kernel.view({return_size * 2, 1, frame_length, 1});
   // conv is actually correlation, so we are good
-  auto conv_out = at::conv2d(input, kernel, {frame_length, 1}, {}, hop).squeeze_(-1);
+  auto conv_out = at::conv2d(input, kernel, {}, hop).squeeze_(-1);
   // transpose to [batch x time x freq x (re/im)]
   auto out = conv_out.view({batch, 2, return_size, -1}).transpose_(1, -1);
   if (self.dim() == 1) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -236,6 +236,28 @@
 - func: _convolution_nogroup(Tensor input, Tensor weight, Tensor? bias, IntList stride, IntList padding, IntList dilation, bool transposed, IntList output_padding) -> Tensor
   variants: function
 
+- func: conv1d(Tensor input, Tensor weight, Tensor bias={}, IntList[1] stride=1, IntList[1] padding=0, IntList[1] dilation=1, int64_t groups=1) -> Tensor
+  variants: function
+
+- func: conv2d(Tensor input, Tensor weight, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1, int64_t groups=1) -> Tensor
+  variants: function
+
+- func: conv3d(Tensor input, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] dilation=1, int64_t groups=1) -> Tensor
+  variants: function
+
+# NB: we inherit the goofy argument order from PyTorch torch.nn.functional
+- func: conv_transpose1d(Tensor input, Tensor weight, Tensor bias={}, IntList[1] stride=1, IntList[1] padding=0, IntList[1] output_padding=0, int64_t groups=1, IntList[1] dilation=1) -> Tensor
+  variants: function
+
+- func: conv_transpose2d(Tensor input, Tensor weight, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] output_padding=0, int64_t groups=1, IntList[2] dilation=1) -> Tensor
+  variants: function
+
+- func: conv_transpose3d(Tensor input, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, int64_t groups=1, IntList[3] dilation=1) -> Tensor
+  variants: function
+
+- func: convolution(Tensor input, Tensor weight, Tensor? bias, IntList stride, IntList padding, IntList dilation, bool transposed, IntList output_padding, int64_t groups) -> Tensor
+  variants: function
+
 - func: _convolution(Tensor input, Tensor weight, Tensor? bias, IntList stride, IntList padding, IntList dilation, bool transposed, IntList output_padding, int64_t groups, bool benchmark, bool deterministic, bool cudnn_enabled) -> Tensor
   variants: function
 

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -191,30 +191,30 @@
 
 # Convolutions
 
-- name: conv_transpose2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] output_padding=0, IntList[2] dilation=1)
+- name: thnn_conv_transpose2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] output_padding=0, IntList[2] dilation=1)
   cname: SpatialFullDilatedConvolution
   buffers: [columns, ones]
 
-- name: conv_transpose3d(Tensor self, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, IntList[3] dilation=1)
+- name: thnn_conv_transpose3d(Tensor self, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, IntList[3] dilation=1)
   cname: VolumetricFullDilatedConvolution
   buffers: [finput, fgrad_input]
 
-- name: conv2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0)
+- name: thnn_conv2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0)
   cname: SpatialConvolutionMM
   buffers: [finput, fgrad_input]
 
-- name: conv_depthwise2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1)
+- name: thnn_conv_depthwise2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1)
   cname: SpatialDepthwiseConvolution
   buffers: []
 
-- name: conv3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0)
+- name: thnn_conv3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0)
   cname: VolumetricConvolutionMM
   buffers: [finput, fgrad_input]
 
-- name: conv_dilated2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1)
+- name: thnn_conv_dilated2d(Tensor self, Tensor weight, IntList[2] kernel_size, Tensor bias={}, IntList[2] stride=1, IntList[2] padding=0, IntList[2] dilation=1)
   cname: SpatialDilatedConvolution
   buffers: [columns, ones]
 
-- name: conv_dilated3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] dilation=1)
+- name: thnn_conv_dilated3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] dilation=1)
   cname: VolumetricDilatedConvolution
   buffers: [columns, ones]

--- a/test/expect/TestJit.test_c_function.expect
+++ b/test/expect/TestJit.test_c_function.expect
@@ -1,8 +1,6 @@
 graph(%0 : Double(1, 3, 10, 10)
       %1 : Double(8, 3, 3, 3)
       %2 : Double(8)) {
-  %3 : Double(1, 8, 8, 8) = conv2d[kernel_size=[3, 3], stride=[1, 1], padding=[0, 0]](%0, %1, %2)
-  %4 : Double(1, 8, 8, 8) = _convolution_nogroup[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0]](%0, %1, %2)
-  %5 : Double(1, 8, 8, 8) = _convolution[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %2)
-  return (%5);
+  %3 : Double(1, 8, 8, 8) = _convolution[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %2)
+  return (%3);
 }

--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,10 +1,6 @@
 graph(%0 : Double(20, 16, 50, 40)
       %1 : Double(13, 16, 3, 3)) {
   %2 : UNKNOWN_TYPE = Undefined(), scope: Conv2d
-  %3 : Double(20, 13, 48, 38) = conv2d[kernel_size=[3, 3], stride=[1, 1], padding=[0, 0]](%0, %1, %2), scope: Conv2d
-  %4 : UNKNOWN_TYPE = Undefined(), scope: Conv2d
-  %5 : Double(20, 13, 48, 38) = _convolution_nogroup[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0]](%0, %1, %4), scope: Conv2d
-  %6 : UNKNOWN_TYPE = Undefined(), scope: Conv2d
-  %7 : Double(20, 13, 48, 38) = _convolution[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %6), scope: Conv2d
-  return (%7);
+  %3 : Double(20, 13, 48, 38) = _convolution[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %2), scope: Conv2d
+  return (%3);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -61,6 +61,8 @@ class TestJit(TestCase):
 
     def assertExpectedTrace(self, trace, *args, **kwargs):
         torch._C._jit_pass_lint(trace)
+        torch._C._jit_pass_dce(trace)
+        torch._C._jit_pass_lint(trace)
         torch._C._jit_pass_canonicalize(trace)
         torch._C._jit_pass_lint(trace)
         self.assertExpected(str(trace), *args, **kwargs)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2027,7 +2027,7 @@ class TestNN(NNTestCase):
         for invalid_dims, module in zip(invalid_input_dims, modules):
             for dims in invalid_dims:
                 input = Variable(torch.Tensor(torch.Size((3, ) * dims)))
-                self.assertRaises(ValueError, lambda: module(input))
+                self.assertRaises(RuntimeError, lambda: module(input))
 
     def test_ConvTranspose2d_output_size(self):
         m = nn.ConvTranspose2d(3, 4, 3, 3, 0, 2)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -821,47 +821,47 @@
   save_mean: not_implemented("thnn_batch_norm_backward save_mean")
   save_std: not_implemented("thnn_batch_norm_backward save_std")
 
-- name: conv_transpose2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
-  self, weight, bias: conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, columns, ones, grad_input_mask)
+- name: thnn_conv_transpose2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+  self, weight, bias: thnn_conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, columns, ones, grad_input_mask)
 
-- name: conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
+- name: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
-- name: conv_transpose3d(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
-  self, weight, bias: conv_transpose3d_backward(grad, self, weight, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
+- name: thnn_conv_transpose3d(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+  self, weight, bias: thnn_conv_transpose3d_backward(grad, self, weight, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
 
-- name: conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
+- name: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
-- name: conv2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
-  self, weight, bias: conv2d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
+- name: thnn_conv2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+  self, weight, bias: thnn_conv2d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
 
-- name: conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
+- name: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, {{1, 1}}, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: conv_depthwise2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
-  self, weight: conv_depthwise2d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
+- name: thnn_conv_depthwise2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight: thnn_conv_depthwise2d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
   bias: grad.contiguous().view({grad.size(0), grad.size(1), -1}).sum(0).sum(1)
 
-- name: conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, std::array<bool,2> output_mask)
+- name: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, std::array<bool,2> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: conv3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
-  self, weight, bias: conv3d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
+- name: thnn_conv3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+  self, weight, bias: thnn_conv3d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
 
-- name: conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
+- name: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, {{1, 1, 1}}, false, {{0, 0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: conv_dilated2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
-  self, weight, bias: conv_dilated2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
+- name: thnn_conv_dilated2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight, bias: thnn_conv_dilated2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
 
-- name: conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
+- name: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: conv_dilated3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
-  self, weight, bias: conv_dilated3d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
+- name: thnn_conv_dilated3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+  self, weight, bias: thnn_conv_dilated3d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
 
-- name: conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
+- name: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0, 0}}, 1, false, false, false, grad_input_mask)
 
 # NN double backwards support
@@ -1061,10 +1061,13 @@
 - name: cudnn_affine_grid_generator(Tensor theta, int64_t N, int64_t C, int64_t H, int64_t W)
   theta: cudnn_affine_grid_generator_backward(grad, N, C, H, W)
 
-# NB: Why is the backwards here so complicated?  When we remove the special case
-# here, gradcheck fails.  It is tracked at
-# https://github.com/pytorch/pytorch/issues/4284
-# Also, the quotes around the gradient are needed to appease YAML parsing rules.
+# NB: Why is the backwards here so complicated?  CuDNN cannot be used to compute
+# backward in evaluation mode, because the math for backward in evaluation mode
+# is different (since the forward math is different), and CuDNN does not support
+# it.  And in any case, you shouldn't be using this bn in evaluation mode,
+# because it should be merged into the previous convolution (left for future
+# work.)
+# NB2: The quotes around the gradient are needed to appease YAML parsing rules.
 - name: cudnn_batch_norm(Tensor input, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double exponential_average_factor, double epsilon)
   input, weight, bias: "training ? cudnn_batch_norm_backward(input, grads[0].contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : thnn_batch_norm_backward(grads[0].contiguous(), input, weight, running_mean, running_var, training, epsilon, result1, result2, grad_input_mask)"
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -583,6 +583,34 @@ PyObject *THPModule_userEnabledCuDNN(PyObject *_unused)
   else Py_RETURN_FALSE;
 }
 
+PyObject *THPModule_setDeterministicCuDNN(PyObject *_unused, PyObject *arg)
+{
+  THPUtils_assert(PyBool_Check(arg), "set_deterministic_cudnn expects a bool, "
+          "but got %s", THPUtils_typename(arg));
+  at::globalContext().setDeterministicCuDNN(arg == Py_True);
+  Py_RETURN_NONE;
+}
+
+PyObject *THPModule_deterministicCuDNN(PyObject *_unused)
+{
+  if (at::globalContext().deterministicCuDNN()) Py_RETURN_TRUE;
+  else Py_RETURN_FALSE;
+}
+
+PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
+{
+  THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
+          "but got %s", THPUtils_typename(arg));
+  at::globalContext().setBenchmarkCuDNN(arg == Py_True);
+  Py_RETURN_NONE;
+}
+
+PyObject *THPModule_benchmarkCuDNN(PyObject *_unused)
+{
+  if (at::globalContext().benchmarkCuDNN()) Py_RETURN_TRUE;
+  else Py_RETURN_FALSE;
+}
+
 #ifdef WITH_CUDA
 extern PyObject * THCSPModule_initExtension(PyObject *self);
 #endif
@@ -608,6 +636,10 @@ static PyMethodDef TorchMethods[] = {
   {"set_num_threads", (PyCFunction)THPModule_setNumThreads,     METH_O,       NULL},
   {"_get_cudnn_enabled", (PyCFunction)THPModule_userEnabledCuDNN, METH_NOARGS,     NULL},
   {"_set_cudnn_enabled", (PyCFunction)THPModule_setUserEnabledCuDNN, METH_O,  NULL},
+  {"_get_cudnn_benchmark", (PyCFunction)THPModule_benchmarkCuDNN, METH_NOARGS,     NULL},
+  {"_set_cudnn_benchmark", (PyCFunction)THPModule_setBenchmarkCuDNN, METH_O,  NULL},
+  {"_get_cudnn_deterministic", (PyCFunction)THPModule_deterministicCuDNN, METH_NOARGS,     NULL},
+  {"_set_cudnn_deterministic", (PyCFunction)THPModule_setDeterministicCuDNN, METH_O,  NULL},
   {"from_numpy",      (PyCFunction)THPModule_fromNumpy,         METH_O,       NULL},
   {"_to_dlpack",      (PyCFunction)THPModule_toDLPack,          METH_O,       NULL},
   {"_from_dlpack",    (PyCFunction)THPModule_fromDLPack,        METH_O,       NULL},

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -15,211 +15,166 @@ from ._functions import vision
 from torch.autograd import Variable
 from .modules.utils import _single, _pair, _triple
 
-# Convolutions
-_ConvNd = torch._C._VariableBase._convolution
 
+conv1d = _add_docstr(torch._C._VariableBase.conv1d, r"""
+conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
-def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1,
-           groups=1):
-    r"""Applies a 1D convolution over an input signal composed of several input
-    planes.
+Applies a 1D convolution over an input signal composed of several input
+planes.
 
-    See :class:`~torch.nn.Conv1d` for details and output shape.
+See :class:`~torch.nn.Conv1d` for details and output shape.
 
-    Args:
-        input: input tensor of shape (minibatch x in_channels x iW)
-        weight: filters of shape (out_channels x in_channels x kW)
-        bias: optional bias of shape (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or
-          a one-element tuple (sW,). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a one-element tuple (padW,). Default: 0
-        dilation: the spacing between kernel elements. Can be a single number or
-          a one-element tuple (dW,). Default: 1
-        groups: split input into groups, in_channels should be divisible by
-          the number of groups. Default: 1
+Args:
+    input: input tensor of shape (minibatch x in_channels x iW)
+    weight: filters of shape (out_channels x in_channels x kW)
+    bias: optional bias of shape (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or
+      a one-element tuple (sW,). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a one-element tuple (padW,). Default: 0
+    dilation: the spacing between kernel elements. Can be a single number or
+      a one-element tuple (dW,). Default: 1
+    groups: split input into groups, in_channels should be divisible by
+      the number of groups. Default: 1
 
-    Examples::
+Examples::
 
-        >>> filters = autograd.Variable(torch.randn(33, 16, 3))
-        >>> inputs = autograd.Variable(torch.randn(20, 16, 50))
-        >>> F.conv1d(inputs, filters)
-    """
-    if input is not None and input.dim() != 3:
-        raise ValueError("Expected 3D tensor as input, got {}D tensor instead.".format(input.dim()))
+    >>> filters = autograd.Variable(torch.randn(33, 16, 3))
+    >>> inputs = autograd.Variable(torch.randn(20, 16, 50))
+    >>> F.conv1d(inputs, filters)
+""")
 
-    return _ConvNd(input, weight, bias,
-                   _single(stride), _single(padding), _single(dilation), False,
-                   _single(0), groups, torch.backends.cudnn.benchmark,
-                   torch.backends.cudnn.deterministic, torch.backends.cudnn.enabled)
+conv2d = _add_docstr(torch._C._VariableBase.conv2d, r"""
+conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
+Applies a 2D convolution over an input image composed of several input
+planes.
 
-def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
-           groups=1):
-    r"""Applies a 2D convolution over an input image composed of several input
-    planes.
+See :class:`~torch.nn.Conv2d` for details and output shape.
 
-    See :class:`~torch.nn.Conv2d` for details and output shape.
+Args:
+    input: input tensor (minibatch x in_channels x iH x iW)
+    weight: filters tensor (out_channels x in_channels/groups x kH x kW)
+    bias: optional bias tensor (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or a
+      tuple (sH, sW). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple (padH, padW). Default: 0
+    dilation: the spacing between kernel elements. Can be a single number or
+      a tuple (dH, dW). Default: 1
+    groups: split input into groups, in_channels should be divisible by the
+      number of groups. Default: 1
 
-    Args:
-        input: input tensor (minibatch x in_channels x iH x iW)
-        weight: filters tensor (out_channels x in_channels/groups x kH x kW)
-        bias: optional bias tensor (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or a
-          tuple (sH, sW). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padH, padW). Default: 0
-        dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dH, dW). Default: 1
-        groups: split input into groups, in_channels should be divisible by the
-          number of groups. Default: 1
+Examples::
 
-    Examples::
+    >>> # With square kernels and equal stride
+    >>> filters = autograd.Variable(torch.randn(8,4,3,3))
+    >>> inputs = autograd.Variable(torch.randn(1,4,5,5))
+    >>> F.conv2d(inputs, filters, padding=1)
+""")
 
-        >>> # With square kernels and equal stride
-        >>> filters = autograd.Variable(torch.randn(8,4,3,3))
-        >>> inputs = autograd.Variable(torch.randn(1,4,5,5))
-        >>> F.conv2d(inputs, filters, padding=1)
-    """
-    if input is not None and input.dim() != 4:
-        raise ValueError("Expected 4D tensor as input, got {}D tensor instead.".format(input.dim()))
+conv3d = _add_docstr(torch._C._VariableBase.conv3d, r"""
+conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
-    return _ConvNd(input, weight, bias, _pair(stride), _pair(padding), _pair(dilation), False,
-                   _pair(0), groups, torch.backends.cudnn.benchmark,
-                   torch.backends.cudnn.deterministic, torch.backends.cudnn.enabled)
+Applies a 3D convolution over an input image composed of several input
+planes.
 
+See :class:`~torch.nn.Conv3d` for details and output shape.
 
-def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1,
-           groups=1):
-    r"""Applies a 3D convolution over an input image composed of several input
-    planes.
+Args:
+    input: input tensor of shape (minibatch x in_channels x iT x iH x iW)
+    weight: filters tensor of shape (out_channels x in_channels x kT x kH x kW)
+    bias: optional bias tensor of shape (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or a
+      tuple (sT, sH, sW). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple (padT, padH, padW). Default: 0
+    dilation: the spacing between kernel elements. Can be a single number or
+      a tuple (dT, dH, dW). Default: 1
+    groups: split input into groups, in_channels should be divisible by
+      the number of groups. Default: 1
 
-    See :class:`~torch.nn.Conv3d` for details and output shape.
+Examples::
 
-    Args:
-        input: input tensor of shape (minibatch x in_channels x iT x iH x iW)
-        weight: filters tensor of shape (out_channels x in_channels x kT x kH x kW)
-        bias: optional bias tensor of shape (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or a
-          tuple (sT, sH, sW). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padT, padH, padW). Default: 0
-        dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dT, dH, dW). Default: 1
-        groups: split input into groups, in_channels should be divisible by
-          the number of groups. Default: 1
+    >>> filters = autograd.Variable(torch.randn(33, 16, 3, 3, 3))
+    >>> inputs = autograd.Variable(torch.randn(20, 16, 50, 10, 20))
+    >>> F.conv3d(inputs, filters)
+""")
 
-    Examples::
+conv_transpose1d = _add_docstr(torch._C._VariableBase.conv_transpose1d, r"""
+conv_transpose1d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
-        >>> filters = autograd.Variable(torch.randn(33, 16, 3, 3, 3))
-        >>> inputs = autograd.Variable(torch.randn(20, 16, 50, 10, 20))
-        >>> F.conv3d(inputs, filters)
-    """
+Applies a 1D transposed convolution operator over an input signal
+composed of several input planes, sometimes also called "deconvolution".
 
-    if input is not None and input.dim() != 5:
-        raise ValueError("Expected 5D tensor as input, got {}D tensor instead.".format(input.dim()))
+See :class:`~torch.nn.ConvTranspose1d` for details and output shape.
 
-    return _ConvNd(input, weight, bias,
-                   _triple(stride), _triple(padding), _triple(dilation), False,
-                   _triple(0), groups, torch.backends.cudnn.benchmark,
-                   torch.backends.cudnn.deterministic, torch.backends.cudnn.enabled)
+Args:
+    input: input tensor of shape (minibatch x in_channels x iW)
+    weight: filters of shape (in_channels x out_channels x kW)
+    bias: optional bias of shape (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or a
+      tuple (sW,). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple (padW,). Default: 0
+    output_padding: implicit zero-paddings of 0 <= padding < stride on both
+      sides of the output. Can be a single number or a tuple (out_padW,).
+      Default: 0
+    groups: split input into groups, in_channels should be divisible by the
+      number of groups. Default: 1
+    dilation: the spacing between kernel elements. Can be a single number or
+      a tuple (dW,). Default: 1
+""")
 
+conv_transpose2d = _add_docstr(torch._C._VariableBase.conv_transpose2d, r"""
+conv_transpose2d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
-def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1, dilation=1):
-    r"""Applies a 1D transposed convolution operator over an input signal
-    composed of several input planes, sometimes also called "deconvolution".
+Applies a 2D transposed convolution operator over an input image
+composed of several input planes, sometimes also called "deconvolution".
 
-    See :class:`~torch.nn.ConvTranspose1d` for details and output shape.
+See :class:`~torch.nn.ConvTranspose2d` for details and output shape.
 
-    Args:
-        input: input tensor of shape (minibatch x in_channels x iW)
-        weight: filters of shape (in_channels x out_channels x kW)
-        bias: optional bias of shape (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or a
-          tuple (sW,). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padW,). Default: 0
-        output_padding: implicit zero-paddings of 0 <= padding < stride on both
-          sides of the output. Can be a single number or a tuple (out_padW,).
-          Default: 0
-        groups: split input into groups, in_channels should be divisible by the
-          number of groups. Default: 1
-        dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dW,). Default: 1
-    """
-    if input is not None and input.dim() != 3:
-        raise ValueError("Expected 3D tensor as input, got {}D tensor instead.".format(input.dim()))
+Args:
+    input: input tensor of shape (minibatch x in_channels x iH x iW)
+    weight: filters of shape (in_channels x out_channels x kH x kW)
+    bias: optional bias of shape (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or a
+      tuple (sH, sW). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple (padH, padW). Default: 0
+    output_padding: implicit zero-paddings of 0 <= padding < stride on both
+      sides of the output. Can be a single number or a tuple
+      (out_padH, out_padW). Default: 0
+    groups: split input into groups, in_channels should be divisible by the
+      number of groups. Default: 1
+    dilation: the spacing between kernel elements. Can be a single number or
+      a tuple (dH, dW). Default: 1
+""")
 
-    return _ConvNd(input, weight, bias, _single(stride), _single(padding), _single(dilation), True,
-                   _single(output_padding),
-                   groups, torch.backends.cudnn.benchmark, torch.backends.cudnn.deterministic,
-                   torch.backends.cudnn.enabled)
+conv_transpose3d = _add_docstr(torch._C._VariableBase.conv_transpose3d, r"""
+conv_transpose3d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
+Applies a 3D transposed convolution operator over an input image
+composed of several input planes, sometimes also called "deconvolution"
 
-def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1, dilation=1):
-    r"""Applies a 2D transposed convolution operator over an input image
-    composed of several input planes, sometimes also called "deconvolution".
+See :class:`~torch.nn.ConvTranspose3d` for details and output shape.
 
-    See :class:`~torch.nn.ConvTranspose2d` for details and output shape.
-
-    Args:
-        input: input tensor of shape (minibatch x in_channels x iH x iW)
-        weight: filters of shape (in_channels x out_channels x kH x kW)
-        bias: optional bias of shape (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or a
-          tuple (sH, sW). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padH, padW). Default: 0
-        output_padding: implicit zero-paddings of 0 <= padding < stride on both
-          sides of the output. Can be a single number or a tuple
-          (out_padH, out_padW). Default: 0
-        groups: split input into groups, in_channels should be divisible by the
-          number of groups. Default: 1
-        dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dH, dW). Default: 1
-    """
-
-    if input is not None and input.dim() != 4:
-        raise ValueError("Expected 4D tensor as input, got {}D tensor instead.".format(input.dim()))
-
-    return _ConvNd(input, weight, bias,
-                   _pair(stride), _pair(padding), _pair(dilation), True,
-                   _pair(output_padding), groups, torch.backends.cudnn.benchmark,
-                   torch.backends.cudnn.deterministic, torch.backends.cudnn.enabled)
-
-
-def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
-                     output_padding=0, groups=1, dilation=1):
-    r"""Applies a 3D transposed convolution operator over an input image
-    composed of several input planes, sometimes also called "deconvolution"
-
-    See :class:`~torch.nn.ConvTranspose3d` for details and output shape.
-
-    Args:
-        input: input tensor of shape (minibatch x in_channels x iT x iH x iW)
-        weight: filters of shape (in_channels x out_channels x kH x kW)
-        bias: optional bias of shape (out_channels). Default: None
-        stride: the stride of the convolving kernel. Can be a single number or a
-          tuple (sT, sH, sW). Default: 1
-        padding: implicit zero paddings on both sides of the input. Can be a
-          single number or a tuple (padT, padH, padW). Default: 0
-        output_padding: implicit zero-paddings of 0 <= padding < stride on both
-          sides of the output. Can be a single number or a tuple
-          (out_padT, out_padH, out_padW). Default: 0
-        groups: split input into groups, in_channels should be divisible by the
-          number of groups. Default: 1
-        dilation: the spacing between kernel elements. Can be a single number or
-          a tuple (dT, dH, dW). Default: 1
-    """
-    if input is not None and input.dim() != 5:
-        raise ValueError("Expected 5D tensor as input, got {}D tensor instead.".format(input.dim()))
-
-    return _ConvNd(input, weight, bias,
-                   _triple(stride), _triple(padding), _triple(dilation), True,
-                   _triple(output_padding), groups, torch.backends.cudnn.benchmark,
-                   torch.backends.cudnn.deterministic, torch.backends.cudnn.enabled)
+Args:
+    input: input tensor of shape (minibatch x in_channels x iT x iH x iW)
+    weight: filters of shape (in_channels x out_channels x kH x kW)
+    bias: optional bias of shape (out_channels). Default: None
+    stride: the stride of the convolving kernel. Can be a single number or a
+      tuple (sT, sH, sW). Default: 1
+    padding: implicit zero paddings on both sides of the input. Can be a
+      single number or a tuple (padT, padH, padW). Default: 0
+    output_padding: implicit zero-paddings of 0 <= padding < stride on both
+      sides of the output. Can be a single number or a tuple
+      (out_padT, out_padH, out_padW). Default: 0
+    groups: split input into groups, in_channels should be divisible by the
+      number of groups. Default: 1
+    dilation: the spacing between kernel elements. Can be a single number or
+      a tuple (dT, dH, dW). Default: 1
+""")
 
 
 def conv_tbc(input, weight, bias, pad=0):


### PR DESCRIPTION
Stacked on top of #4285

- Rename THNN convolution to have thnn_ prefix.
- Propagate CuDNN benchmark, deterministic to at::Context
- Add 'convolution', 'convNd' and 'conv_transposeNd' native wrappers, with defaults
- Make it possible to turn off tracing for some native wrappers, so I don't have to write symbolics for all the functions above
- Spectral ops can now make use of CuDNN convolution if possible
- torch.nn.functional directly dispatches to this now