### PR TITLE
Squash some warnings

### DIFF
--- a/aten/src/TH/generic/THTensorRandom.c
+++ b/aten/src/TH/generic/THTensorRandom.c
@@ -132,6 +132,8 @@ void THTensor_(standard_gamma)(THTensor *self, THGenerator *gen, THTensor *alpha
   });
 }
 
+#undef TH_REAL_MIN
+
 void THTensor_(cauchy)(THTensor *self, THGenerator *_generator, double median, double sigma)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_cauchy(_generator, median, sigma););

--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -533,8 +533,8 @@ void THNN_(LSTM_forw_ind_wrap)(
 
   INDTYPE hid_size = cxI.sizes[cxI.dims-1];
   if(has_bias){
-    THAssertMsg( hid_size*4 == THCTensor_(nElement)(state, bias1) &&
-                 hid_size*4 == THCTensor_(nElement)(state, bias2),
+    THAssertMsg( hid_size*4 == static_cast<INDTYPE>(THCTensor_(nElement)(state, bias1)) &&
+                 hid_size*4 == static_cast<INDTYPE>(THCTensor_(nElement)(state, bias2)),
                  "Bias in pointwise operation is an incorrect size, must be 4 x feature size.");
   }
 
@@ -728,8 +728,8 @@ void THNN_(GRU_forw_ind_wrap)(
 
   INDTYPE hid_size = hxI.sizes[hxI.dims-1];
   if(has_bias){
-    THAssertMsg( hid_size*3 == THCTensor_(nElement)(state, bias1) &&
-                 hid_size*3 == THCTensor_(nElement)(state, bias2),
+    THAssertMsg( hid_size*3 == static_cast<INDTYPE>(THCTensor_(nElement)(state, bias1)) &&
+                 hid_size*3 == static_cast<INDTYPE>(THCTensor_(nElement)(state, bias2)),
                  "Bias in pointwise operation is an incorrect size, must be 3 x feature size.");
   }
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -97,11 +97,15 @@ if (should_compute_output(${idx})) {
 }
 """)
 
-DERIVATIVE_MULTI = CodeTemplate("""\
-if (should_compute_output({ ${idxs} })) {
+GRAD_INPUT_MASK = CodeTemplate("""\
   auto grad_input_mask = std::array<bool, ${n}>{
     ${masks}
-  };
+  };\
+""")
+
+DERIVATIVE_MULTI = CodeTemplate("""\
+if (should_compute_output({ ${idxs} })) {
+${grad_input_mask}
   std::tie(${grad_inputs}) = ${derivative};
 }
 """)
@@ -615,11 +619,15 @@ def create_autograd_functions(top_env, autogen_functions):
             elif len(idxs) == 1:
                 return DERIVATIVE_TENSOR.substitute(idx=idxs[0], derivative=formula)
             else:
+                if 'grad_input_mask' in formula:
+                    masks = ['should_compute_output({}),'.format(i) for i in idxs]
+                    grad_input_mask = GRAD_INPUT_MASK.substitute(masks=masks, n=len(idxs))
+                else:
+                    grad_input_mask = ''
                 grad_inputs = ', '.join(['grad_inputs[{}]'.format(i) for i in idxs])
-                masks = ['should_compute_output({}),'.format(i) for i in idxs]
                 return DERIVATIVE_MULTI.substitute(
                     idxs=idxs, derivative=formula, grad_inputs=grad_inputs,
-                    masks=masks, n=len(idxs))
+                    grad_input_mask=grad_input_mask)
 
         body.extend(unpack)
         for derivative in func['derivatives']:

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -26,11 +26,6 @@ Tensor not_implemented(const char* name) {
       std::string("the derivative for '") + name + "' is not implemented");
 }
 
-Tensor not_differentiable(const char* name) {
-  throw std::runtime_error(
-      std::string("'") + name + "' is not differentiable");
-}
-
 Tensor maybe_multiply(const Tensor & t, const Scalar & s) {
   bool is_one = false;
   if (s.isFloatingPoint()) {

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -72,9 +72,6 @@ using list_of_retainable = std::vector<at::Retainable*>;
 // list_of_retainable output list.
 // pack_list never operates on tensor temporaries.
 void pack_list(list_of_retainable & outputs, Tensor v) { outputs.push_back(toRetainableSteal(std::move(v))); }
-void pack_list(list_of_retainable & outputs, Scalar v) {
-  outputs.push_back(toRetainableSteal(v.toTensor()));
-}
 void pack_list(list_of_retainable & outputs, std::vector<Tensor> && ts) {
   outputs.reserve(ts.size());
   for(auto & t : ts) {

--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -29,7 +29,8 @@
 #define SIGNAL_HANDLER(SIGNAL, HANDLER_NAME, ERROR_MSG)                       \
 static void HANDLER_NAME(int sig, siginfo_t *info, void *ctx)                 \
 {                                                                             \
-  (void)write(STDERR_FILENO, ERROR_MSG, sizeof(ERROR_MSG) / sizeof(char));    \
+  auto _w = write(STDERR_FILENO, ERROR_MSG, sizeof(ERROR_MSG) / sizeof(char));\
+  (void)_w;                                                                   \
   struct sigaction sa;                                                        \
   sa.sa_handler = SIG_DFL;                                                    \
   sa.sa_flags = 0;                                                            \

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -85,15 +85,6 @@ PyObject* getTensorAttr(PyObject* obj, void* _unused)
   END_HANDLE_TH_ERRORS
 }
 
-// The type for PyInt_FromLong varies between Windows (int64_t) and
-// Linux (long).  Unfortunately, on Clang, if the template type argument
-// does not *exactly* line up, Clang discards the template
-// specialization.  So we write a little stub function which does have
-// the right type.
-static PyObject* PortablePyInt_FromLong(int64_t ival) {
-  return THPUtils_packInt64(ival);
-}
-
 static PyObject* accumulateGradVar(PyObject *_self, void* _unused)
 {
   THPCppFunction* self = (THPCppFunction*)_self;

--- a/torch/lib/THD/base/ChannelUtils.hpp
+++ b/torch/lib/THD/base/ChannelUtils.hpp
@@ -71,7 +71,7 @@ using port_type = std::uint16_t;
 using size_type = std::uint64_t;
 
 #define SYSCHECK(expr) { \
-  errno = 0; (expr);     \
+  errno = 0; auto ___output = (expr); (void)___output;     \
   if (errno != 0) throw std::system_error(errno, std::system_category()); \
 }
 

--- a/torch/lib/THD/master_worker/common/CommandChannel.cpp
+++ b/torch/lib/THD/master_worker/common/CommandChannel.cpp
@@ -96,7 +96,7 @@ bool MasterCommandChannel::init() {
   ::close(_sockets[0]);
 
   int fd[2];
-  SYSCHECK((void)::pipe(fd));
+  SYSCHECK(::pipe(fd));
   _sockets[0] = fd[0];
   _error_pipe = fd[1];
   _error_thread = std::thread(&MasterCommandChannel::errorHandler, this);


### PR DESCRIPTION
Made the build warning-free for me. They were starting to accumulate and telling them apart from legit warnings and errors in new code was increasingly hard. Most of the things are simple signed/unsigned comparisons, redefinition of a macro, some unused functions, return values that aren't ignored properly. There's one change in the codegen to prevent it from generating unused locals.