### PR TITLE
Add factory Type::sparse_coo_tensor(indices, values)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3913,6 +3913,18 @@
         - arg: THStride* stride
           default: NULL
 ]]
+[[
+  name: sparse_coo_tensor
+  return: THTensor*
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  variants: [function]
+  cname: newWithTensor
+  arguments:
+    - THDenseIndexTensor* indices
+    - THDenseTensor* values
+]]
 
 # In theory, this could be a part of the above declaration. But in
 # practice this leads to all sorts of problems with ambiguous overloads.

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -143,6 +143,8 @@ TYPE_FORMAL_GENERIC = {
     'THBoolTensor*': 'Tensor &',
     'THIndexTensor*': 'Tensor &',
     'THIntegerTensor*': 'Tensor &',
+    'THDenseTensor*': 'Tensor &',
+    'THDenseIndexTensor*': 'Tensor &',
     'THStorage*': 'Storage &',
     'THGenerator*': 'Generator *',
     'THSize*': 'IntList',
@@ -158,6 +160,8 @@ DYNAMIC_TYPE = {
     'THBoolTensor*': 'BoolTensor',
     'THIndexTensor*': 'IndexTensor',
     'THIntegerTensor*': 'IntegerTensor',
+    'THDenseTensor*': 'Tensor',
+    'THDenseIndexTensor*': 'IntegerTensor',
     'THStorage*': 'Storage',
     'THGenerator*': 'Generator*',
     'THSize*': 'IntList',
@@ -196,6 +200,12 @@ CHECKED_CAST = {
     'THIntegerTensor*':
         CodeTemplate(
             'checked_cast_tensor<${Backend}IntTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
+    'THDenseTensor*':
+        CodeTemplate(
+            'checked_cast_tensor<${DenseTensor}>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
+    'THDenseIndexTensor*':
+        CodeTemplate(
+            'checked_cast_tensor<${DenseBackend}LongTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
     'THStorage*': CodeTemplate('checked_cast_storage<${Storage}>(&${arg_name},"${arg_name}",${arg_pos})'),
     'THGenerator*':
         CodeTemplate(
@@ -215,6 +225,8 @@ CHECKED_USE = {
     'THIndexTensor*': '{}_->tensor',
     'THBoolTensor*': '{}_->tensor',
     'THIntegerTensor*': '{}_->tensor',
+    'THDenseTensor*': '{}_->tensor',
+    'THDenseIndexTensor*': '{}_->tensor',
     'THStorage*': '{}_->storage',
     'THGenerator*': '{}_->generator',
     'TensorList': "{0}_.data(), {0}_.size()",


### PR DESCRIPTION
Adds a factory function to to construct sparse tensors from ATen. For example,

```c++
auto tensor = sparse_type.sparse_coo_tensor(index, values);
```