### PR TITLE
Fix default device for Variable.new()

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -449,6 +449,9 @@ class TestCuda(TestCase):
         x = torch.autograd.Variable(torch.randn(3, 3).cuda())
         self.assertEqual(x.new([0, 1, 2]).get_device(), 0)
         self.assertEqual(x.new([0, 1, 2], device=1).get_device(), 1)
+        with torch.cuda.device(1):
+            self.assertEqual(x.new([0, 1, 2]).get_device(), 0)
+            self.assertEqual(x.new([0, 1, 2], device=1).get_device(), 1)
 
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
     def test_copy_device(self):

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -438,6 +438,7 @@ static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwar
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
   return THPVariable_Wrap(torch::utils::tensor_new(self_.type(), args, kwargs));
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
Variable.new() should default to the device of "self" if no device is
specified. Previously, we were using the current device. This now
matches Tensor.new().