### PR TITLE
Make Variable.is_sparse an attribute

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -697,6 +697,15 @@ class TestSparse(TestCase):
         self._test_new_device((30, 20), 1)
         self._test_new_device((30, 20, 10), 1)
 
+    def test_is_sparse(self):
+        x = torch.randn(3, 3)
+        self.assertFalse(x.is_sparse)
+        self.assertFalse(torch.autograd.Variable(x).is_sparse)
+
+        x = self.SparseTensor()
+        self.assertTrue(x.is_sparse)
+        self.assertTrue(torch.autograd.Variable(x).is_sparse)
+
 
 class TestUncoalescedSparse(TestSparse):
     def setUp(self):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -236,7 +236,7 @@ MANUAL_IMPLEMENTATIONS = {
 }
 # These functions require manual Python bindings or are not exposed to Python
 SKIP_PYTHON_BINDINGS = [
-    'alias', 'contiguous', 'clamp.*', 'is_cuda', 'size', 'stride',
+    'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward'
 ]
 # These functions have backwards which cannot be traced, and so must have

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -437,6 +437,14 @@ PyObject *THPVariable_is_cuda(THPVariable *self)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject *THPVariable_is_sparse(THPVariable *self)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = self->cdata;
+  return torch::autograd::utils::wrap(self_.is_sparse());
+  END_HANDLE_TH_ERRORS
+}
+
 static struct PyGetSetDef THPVariable_properties[] = {
   {"_cdata", (getter)THPVariable_get_cdata, NULL, NULL, NULL},
   {"_version", (getter)THPVariable_get_version, NULL, NULL, NULL},
@@ -454,6 +462,7 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {"name", (getter)THPVariable_get_name, NULL, NULL, NULL},
   {"shape", (getter)THPVariable_get_shape, NULL, NULL, NULL},
   {"is_cuda", (getter)THPVariable_is_cuda, NULL, NULL, NULL},
+  {"is_sparse", (getter)THPVariable_is_sparse, NULL, NULL, NULL},
   {NULL}
 };
 


### PR DESCRIPTION
This matches Tensor.is_sparse, which makes it easier to replace Tensor with Variable.

We only recently added `Variable.is_sparse` (after 0.3), so I'm less worried about break backwards compatibility with this change than if we had changed Tensor.is_sparse to a method.