### PR TITLE
Fix btrifact for variables

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3569,9 +3569,31 @@
       output: True
     - arg: THIntegerTensor* pivots
       output: True
-    - arg: THIntegerTensor* info
+    - CONSTANT NULL
+    - arg: bool pivot
       kwarg_only: True
-      default: NULL
+      default: "true"
+    - THTensor* self
+]]
+[[
+  name: btrifact_with_info
+  cname: btrifact
+  types:
+    - floating_point
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  return: argument 0,1,2
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - arg: THIntegerTensor* pivots
+      output: True
+    - arg: THIntegerTensor* info
+      output: True
     - arg: bool pivot
       kwarg_only: True
       default: "true"

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -86,7 +86,7 @@ def handle_outputs_taken_as_arguments(options):
 
     def is_nullable(arg):
         return (arg['type'] in {'THIntegerTensor*', 'THTensor*'} and
-                arg.get('default', '') in {'NULL', 'nullptr'})
+                arg.get('default', '') in {None, 'NULL', 'nullptr'})
 
     def should_generate_out_variant(option):
         if 'function' in option['variants']:

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -190,6 +190,7 @@ BLAS and LAPACK Operations
 .. autofunction:: btrifact
 .. autofunction:: btrifact_with_info
 .. autofunction:: btrisolve
+.. autofunction:: btriunpack
 .. autofunction:: dot
 .. autofunction:: eig
 .. autofunction:: gels

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -188,6 +188,7 @@ BLAS and LAPACK Operations
 .. autofunction:: baddbmm
 .. autofunction:: bmm
 .. autofunction:: btrifact
+.. autofunction:: btrifact_with_info
 .. autofunction:: btrisolve
 .. autofunction:: dot
 .. autofunction:: eig

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -690,11 +690,15 @@ class TestTorch(TestCase):
                                ((-1.6181, 0.7148),
                                 (1.3728, 0.1319))))
         a = cast(a)
-        a_LU = a.btrifact()  # test default info
+        a_LU, pivots = a.btrifact()  # test default info
         info = cast(torch.IntTensor())
-        a_LU = a.btrifact(info=info)
+        a_LU, pivots = a.btrifact(info=info)
         self.assertEqual(info.abs().sum(), 0)
-        P, a_L, a_U = torch.btriunpack(*a_LU)
+        a_LU_, pivots_, info_ = a.btrifact_with_info()
+        self.assertEqual(a_LU, a_LU_)
+        self.assertEqual(pivots, pivots_)
+        self.assertEqual(info, info_)
+        P, a_L, a_U = torch.btriunpack(a_LU, pivots)
         a_ = torch.bmm(P, torch.bmm(a_L, a_U))
         self.assertEqual(a_, a)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -690,6 +690,7 @@ class TestTorch(TestCase):
                                ((-1.6181, 0.7148),
                                 (1.3728, 0.1319))))
         a = cast(a)
+        a_LU = a.btrifact()  # test default info
         info = cast(torch.IntTensor())
         a_LU = a.btrifact(info=info)
         self.assertEqual(info.abs().sum(), 0)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -128,8 +128,11 @@
   self: grad.bmm(mat2.transpose(1, 2))
   mat2: self.transpose(1, 2).bmm(grad)
 
-- name: btrifact(Tensor self, Tensor info, bool pivot)
+- name: btrifact(Tensor self, bool pivot)
   self: not_implemented("btrifact")
+
+- name: btrifact_with_info(Tensor self, bool pivot)
+  self: not_implemented("btrifact_with_info")
 
 - name: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots)
   self: not_implemented("btrisolve")

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -254,6 +254,20 @@ bmm(batch2) -> Tensor
 See :func:`torch.bmm`
 """)
 
+add_docstr_all('btrifact',
+               r"""
+btrifact(info=None, pivot=True) -> (Tensor, Tensor)
+
+See :func:`torch.btrifact`
+""")
+
+add_docstr_all('btrifact_with_info',
+               r"""
+btrifact_with_info(pivot=True) -> (Tensor, Tensor, Tensor)
+
+See :func:`torch.btrifact_with_info`
+""")
+
 add_docstr_all('cauchy_',
                r"""
 cauchy_(median=0, sigma=1, *, generator=None) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3706,7 +3706,7 @@ Returns a 1-D tensor of size :math:`\lfloor \frac{end - start}{step} \rfloor + 1
 with values from :attr:`start` to :attr:`end` with step :attr:`step`. Step is
 the gap between two values in the tensor. :math:`x_{i+1} = x_i + step`.
 
-Warning:
+.. warning::
     This function is deprecated in favor of :func:`torch.arange`.
 
 Args:
@@ -5025,24 +5025,61 @@ Example::
 
 add_docstr(torch._C.btrifact,
            r"""
-btrifact(A, info=None, pivot=True) -> Tensor, IntTensor
+btrifact(A, info=None, pivot=True) -> (Tensor, IntTensor)
 
 Batch LU factorization.
 
-Returns a tuple containing the LU factorization and pivots.
-The optional argument `info` provides information if the
-factorization succeeded for each minibatch example.
-The info values are from dgetrf and a non-zero value indicates an error
-occurred. The specific values are from cublas if cuda is being used, otherwise
-LAPACK. Pivoting is done if pivot is set.
+Returns a tuple containing the LU factorization and pivots. Pivoting is done if
+:attr:`pivot` is set.
+
+The optional argument :attr:`info` stores information if the factorization
+succeeded for each minibatch example. The :attr:`info` is provided as an
+`IntTensor`, its values will be filled from dgetrf and a non-zero value
+indicates an error occurred. Specifically, the values are from cublas if cuda is
+being used, otherwise LAPACK.
+
+.. warning::
+    The :attr:`info` argument is deprecated in favor of :meth:`torch.btrifact_with_info`.
 
 Arguments:
     A (Tensor): the tensor to factor
+    info (IntTensor, optional): an `IntTensor` to store values indicating whether
+        factorization succeeds
+    pivot (bool, optional): controls whether pivoting is done
+
+Returns:
+    A tuple containing factorization and pivots.
 
 Example::
 
     >>> A = torch.randn(2, 3, 3)
-    >>> A_LU = A.btrifact()
+    >>> A_LU, pivots = A.btrifact()
+
+""")
+
+add_docstr(torch._C.btrifact_with_info,
+           r"""
+btrifact_with_info(A, pivot=True) -> (Tensor, IntTensor, IntTensor)
+
+Batch LU factorization with additional error information.
+
+This is a version of :meth:`torch.btrifact` that always creates an info
+`IntTensor`, and returns it as the third return value
+
+Arguments:
+    A (Tensor): the tensor to factor
+    pivot (bool, optional): controls whether pivoting is done
+
+Returns:
+    A tuple containing factorization, pivots, and an `IntTensor` where nonzero
+    values indicate whether factorization for each minibatch sample succeeds.
+
+Example::
+
+    >>> A = torch.randn(2, 3, 3)
+    >>> A_LU, pivots, info = A.btrifact_with_info()
+    >>> if info.nonzero.size(0) == 0:
+    >>>   print('LU factorization succeeded for all samples!')
 
 """)
 

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -252,6 +252,18 @@ class Variable(_C._VariableBase):
             repeats = torch.Size(repeats)
         return Repeat.apply(self, repeats)
 
+    def btrifact(self, info=None, pivot=True):
+        if info is not None:
+            warnings.warn("info option in btrifact is deprecated and will be removed in v0.4, "
+                          "consider using btrifact_with_info instead")
+            factorization, pivots, _info = super(Variable, self).btrifact_with_info(pivot=pivot)
+            if not isinstance(info, Variable) or info.type() != _info.type():
+                raise ValueError('btrifact expects info to be a Variable of IntTenor')
+            info.data.copy_(_info.data)
+            return factorization, pivots
+        else:
+            return super(Variable, self).btrifact(pivot=pivot)
+
     def cumprod(self, dim):
         return Cumprod.apply(self, dim)
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -349,6 +349,7 @@ IMPLEMENT_STATELESS(geqrf)
 IMPLEMENT_STATELESS(orgqr)
 IMPLEMENT_STATELESS(ormqr)
 IMPLEMENT_STATELESS(btrifact)
+IMPLEMENT_STATELESS(btrifact_with_info)
 IMPLEMENT_STATELESS(btrisolve)
 IMPLEMENT_STATELESS(gt)
 IMPLEMENT_STATELESS(lt)
@@ -735,6 +736,7 @@ static PyMethodDef TorchMethods[] = {
   {"orgqr",           (PyCFunction)THPModule_orgqr,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"ormqr",           (PyCFunction)THPModule_ormqr,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"btrifact",        (PyCFunction)THPModule_btrifact,          METH_VARARGS | METH_KEYWORDS, NULL},
+  {"btrifact_with_info", (PyCFunction)THPModule_btrifact_with_info, METH_VARARGS | METH_KEYWORDS, NULL},
   {"btrisolve",       (PyCFunction)THPModule_btrisolve,         METH_VARARGS | METH_KEYWORDS, NULL},
 
   // Sparse functions

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -2632,6 +2632,31 @@ static const char *R = &__R;
 ]]
 
 [[
+  name: btrifact_with_info
+  cname: btrifact
+  types:
+    - floating_point
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  return: argument 0,1,2
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - arg: THIntegerTensor* pivots
+      output: True
+    - arg: THIntegerTensor* info
+      output: True
+    - arg: bool pivot
+      kwarg_only: True
+      default: "true"
+    - THTensor* self
+]]
+
+[[
   name: btrisolve
   cname: btrisolve
   types:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -93,6 +93,16 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
         LU_pivots (Tensor): the packed LU factorization pivots
         unpack_data (bool): flag indicating if the data should be unpacked
         unpack_pivots (bool): tlag indicating if the pivots should be unpacked
+
+    Example::
+
+        >>> A = torch.randn(2, 3, 3)
+        >>> A_LU, pivots = A.btrifact()
+        >>> P, a_L, a_U = torch.btriunpack(A_LU, pivots)
+        >>>
+        >>> # test that (P, A_L, A_U) gives LU factorization
+        >>> A_ = torch.bmm(P, torch.bmm(A_L, A_U))
+        >>> assert torch.equal(A_, A) == True  # can recover A
     """
 
     nBatch, sz, _ = LU_data.size()


### PR DESCRIPTION
Fixes #4217 

This PR breaks `btrifact` into `btrifact` and `btrifact_with_info`. The cwrap declarations for for tensor and variable are different in that the `tensor.btrifact` in `TensorMath.cwrap` still allows `info` optional argument, and `var.btrifact` in `Decalaration.cwrap` always sets `info` as NULL. In `variable.py`, a python method `btrifact` is added to support old `info` optional argument behavior, but I added deprecation warning in favor of `btrifact_with_info`.

I also modified `preprocess_declarations.py`'s `is_nullable` for optional tensor arguments with NULL default values. An example of input declarations is the old `btrifact`in `Declaration.cwrap`:
```[[
  name: btrifact
  cname: btrifact
  types:
    - floating_point
  backends:
    - CPU
    - CUDA
  variants:
    - method
    - function
  return: argument 0,1
  arguments:
    - arg: THTensor* result
      output: True
    - arg: THIntegerTensor* pivots
      output: True
    - arg: THIntegerTensor* info
      kwarg_only: True
      default: NULL
    - arg: bool pivot
      kwarg_only: True
      default: "true"
    - THTensor* self
]]
```

, which gets parsed into the following:

```
{..., 'options': [{'arguments': [..., 
{'kwarg_only': True, 'default': None, 'type': 'THInteger Tensor*', 'name': 'info'}, 
...] ...}
```