### PR TITLE
Fix torch.distributions.Gamma.rsample()

### DIFF
--- a/aten/src/ATen/native/NativeFunctions.cpp
+++ b/aten/src/ATen/native/NativeFunctions.cpp
@@ -705,14 +705,10 @@ struct StandardGammaGradOp {
   }
 };
 
-Tensor _standard_gamma_grad_cpu(const Tensor& self, const Tensor& output) {
+Tensor _standard_gamma_grad(const Tensor& self, const Tensor& output) {
   Tensor ret = self.type().tensor(self.sizes());
   dispatch_floating_types<StandardGammaGradOp>(self.type(), "_standard_gamma_grad", ret, self, output);
   return ret;
-}
-
-Tensor _standard_gamma_grad_cuda(const Tensor& self, const Tensor& output) {
-  runtime_error("_standard_gamma_grad is not implemented for CUDA types");
 }
 
 Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, int64_t pad) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -103,9 +103,6 @@
 - func: is_signed(Tensor self) -> bool
 
 - func: _standard_gamma_grad(Tensor self, Tensor output) -> Tensor
-  dispatch:
-    CPU: _standard_gamma_grad_cpu
-    CUDA: _standard_gamma_grad_cuda
 
 - func: matmul(Tensor self, Tensor other) -> Tensor
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -599,6 +599,13 @@ class TestDistributions(TestCase):
         for dist, kwargs in invalid_examples:
             self.assertRaises(RuntimeError, dist, **kwargs)
 
+    def test_rsample_backward_smoke(self):
+        for Dist, params in EXAMPLES:
+            for i, param in enumerate(params):
+                if Dist.has_rsample and all(isinstance(p, Variable) for p in param):
+                    dist = Dist(**param)
+                    dist.rsample().sum().backward()
+
 
 class TestDistributionShapes(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #4319 

This reverts parts of #4306 f5de5a8 that broke `_standard_gamma_grad()` and adds a regression test. The existing test was skipped on CI due to #4260, and local test failures were ignored.

## Tested
- Added a regression test to ensure methods can run on CI (even despite #4260)
- Ran `test/test_distributions.py` locally with Scipy