### PR TITLE
disable test_gamma_sample_grad until it's fixed

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -405,6 +405,7 @@ class TestDistributions(TestCase):
 
     # This is a randomized test.
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    @unittest.expectedFailure
     def test_gamma_sample_grad(self):
         self._set_rng_seed(1)
         num_samples = 100

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -404,8 +404,8 @@ class TestDistributions(TestCase):
                                         'Gamma(alpha={}, beta={})'.format(alpha, beta))
 
     # This is a randomized test.
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    @unittest.expectedFailure
+    # @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    @unittest.skip("TODO: fix this test with SciPy installed")
     def test_gamma_sample_grad(self):
         self._set_rng_seed(1)
         num_samples = 100


### PR DESCRIPTION
`test_gamma_sample_grad` currently raises a RuntimeError when SciPy is installed, which breaks the Trusty builds in Jenkins CI.

See detailed discussion at https://github.com/pytorch/pytorch/issues/4260.