### PR TITLE
Adding Uniform distribution to PyTorch

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -37,7 +37,7 @@ class Distribution(object):
         parameters are batched.
         """
         warnings.warn('sample_n will be deprecated. Use .sample((n,)) instead', UserWarning)
-        return self.sample((n,))
+        return self.sample(torch.Size((n,)))
 
     def log_prob(self, value):
         """

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -9,8 +9,8 @@ from torch.distributions.utils import broadcast_all
 
 class Uniform(Distribution):
     r"""
-    Creates a uniform random distribution parameterized by
-    `low` and `high`.
+    Generates uniformly distributed random samples from the half-open interval
+    `[low, high)`.
 
     Example::
 

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -1,0 +1,48 @@
+import math
+from numbers import Number
+
+import torch
+from torch.autograd import Variable
+from torch.distributions.distribution import Distribution
+from torch.distributions.utils import broadcast_all
+
+
+class Uniform(Distribution):
+    r"""
+    Creates a uniform random distribution parameterized by
+    `low` and `high`.
+
+    Example::
+
+        >>> m = Uniform(torch.Tensor([0.0]), torch.Tensor([5.0]))
+        >>> m.sample()  # uniformly distributed in the range [0.0, 5.0)
+         2.3418
+        [torch.FloatTensor of size 1]
+
+    Args:
+        low (float or Tensor or Variable): lower range (inclusive).
+        high (float or Tensor or Variable): upper range (exclusive).
+    """
+    has_rsample = True
+
+    def __init__(self, low, high):
+        self.low, self.high = broadcast_all(low, high)
+        if isinstance(low, Number) and isinstance(high, Number):
+            batch_shape = torch.Size()
+        else:
+            batch_shape = self.low.size()
+        super(Uniform, self).__init__(batch_shape)
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        rand = self.low.new(shape).uniform_()
+        return self.low + rand * (self.high - self.low)
+
+    def log_prob(self, value):
+        self._validate_log_prob_arg(value)
+        lb = value.ge(self.low).type_as(self.low)
+        ub = value.lt(self.high).type_as(self.low)
+        return torch.log(lb.mul(ub)) - torch.log(self.high - self.low)
+
+    def entropy(self):
+        return torch.log(self.high - self.low)


### PR DESCRIPTION
The implementation is straightforward. A couple of notes:
 - In our discussions, we had discussed throwing an error if `log_prob` got a value outside the distribution's support. This returns `-inf` instead. I thought that throwing an error does not seem to be a good response for a perfectly valid query. For reference, Tensorflow return `-inf` for uniform but throws an error for Bernoulli (scoring `[1]` with `Bernoulli([0.0])` for example). We should be consistent with whatever convention we choose.
 - Modified `sample_n()` to use `torch.Size` instead of a tuple `(n,)`. The reason is that `tensor.new(tuple)` just takes the last dim, as compared to `tensor.new(torch.Size)`. Not sure if that's expected. cc. @apaszke. 

```
In [7]: torch.zeros(2, 2).new((3, 2)).size()
Out[7]: torch.Size([2])

In [8]: torch.zeros(2, 2).new(torch.Size((3, 2))).size()
Out[8]: torch.Size([3, 2])
```