### PR TITLE
fix MaxPool2d __repr__ (adds missing ceil_mode summary)

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -151,10 +151,11 @@ class MaxPool2d(Module):
             if padh != 0 and padw != 0 else ''
         dilation_str = (', dilation=(' + str(dilh) + ', ' + str(dilw) + ')'
                         if dilh != 0 and dilw != 0 else '')
+        ceil_str = ', ceil_mode=' + str(self.ceil_mode)
         return self.__class__.__name__ + '(' \
             + 'kernel_size=(' + str(kh) + ', ' + str(kw) + ')' \
             + ', stride=(' + str(dh) + ', ' + str(dw) + ')' \
-            + padding_str + dilation_str + ')'
+            + padding_str + dilation_str + ceil_str + ')'
 
 
 class MaxUnpool1d(Module):


### PR DESCRIPTION
A small fix to the `__repr__` method of `nn.MaxPool2d` to include `ceil_mode`, making it consistent with `nn.AvgPool2d`.   

The following script shows the absence of `ceil_mode` in the current repr:

```
import torch.nn as nn

pool_opts = {'kernel_size': (3,3), 'stride': (2,2),
             'padding': (1,1), 'ceil_mode': True}

max_pool = nn.MaxPool2d(**pool_opts)
print(max_pool)
avg_pool = nn.AvgPool2d(**pool_opts)
print(avg_pool)
```

Output pre-fix:
```
MaxPool2d(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), dilation=(1, 1))
AvgPool2d(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), ceil_mode=True, count_include_pad=True)
```

Output post-fix:
```
MaxPool2d(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), dilation=(1, 1), ceil_mode=True)
AvgPool2d(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), ceil_mode=True, count_include_pad=True)
```