### PR TITLE
fix NameError in torch/nn/modules/rnn.py

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -138,7 +138,7 @@ class RNNBase(Module):
         if self.input_size != input.size(-1):
             raise RuntimeError(
                 'input.size(-1) must be equal to input_size. Expected {}, got {}'.format(
-                    fn.input_size, input.size(-1)))
+                    self.input_size, input.size(-1)))
 
         if is_input_packed:
             mini_batch = batch_sizes[0]


### PR DESCRIPTION
Current code raises `NameError: name 'fn' is not defined` instead of the desired exception.