### PR TITLE
add bias term to linear __repr__ functions, fix spacing

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -47,7 +47,7 @@ class _ConvNd(Module):
             self.bias.data.uniform_(-stdv, stdv)
 
     def __repr__(self):
-        s = ('{name} ({in_channels}, {out_channels}, kernel_size={kernel_size}'
+        s = ('{name}({in_channels}, {out_channels}, kernel_size={kernel_size}'
              ', stride={stride}')
         if self.padding != (0,) * len(self.padding):
             s += ', padding={padding}'

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -57,7 +57,8 @@ class Linear(Module):
     def __repr__(self):
         return self.__class__.__name__ + '(' \
             + 'in_features=' + str(self.in_features) \
-            + ', out_features=' + str(self.out_features) + ')'
+            + ', out_features=' + str(self.out_features) \
+            + ', bias=' + str(self.bias is not None) + ')'
 
 
 class Bilinear(Module):
@@ -115,6 +116,7 @@ class Bilinear(Module):
         return self.__class__.__name__ + '(' \
             + 'in1_features=' + str(self.in1_features) \
             + ', in2_features=' + str(self.in2_features) \
-            + ', out_features=' + str(self.out_features) + ')'
+            + ', out_features=' + str(self.out_features) \
+            + ', bias=' + str(self.bias is not None) + ')'
 
 # TODO: PartialLinear - maybe in sparse?


### PR DESCRIPTION
Adds a missing bias term to the `__repr__` functions of the `Linear` and `Bilinear` modules and fixes the spacing in the `__repr__` for `Conv2d` to make it consistent with other modules.

Demo script:

```
import torch.nn as nn

linear = nn.Linear(1, 1, bias=True)
bilinear = nn.Bilinear(1, 1, 1, bias=True)
conv = nn.Conv2d(10,10,4)

print(linear)
print(bilinear)
print(conv)
```

Output pre-fix:

```
Linear(in_features=1, out_features=1)
Bilinear(in1_features=1, in2_features=1, out_features=1)
Conv2d (10, 10, kernel_size=(4, 4), stride=(1, 1))
```

Output post-fix:

```
Linear(in_features=1, out_features=1, bias=True)
Bilinear(in1_features=1, in2_features=1, out_features=1, bias=True)
Conv2d(10, 10, kernel_size=(4, 4), stride=(1, 1))
```