### PR TITLE
Improve matmul native test tolerance.

### DIFF
--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -10,7 +10,7 @@ void assertEqualTensorList(TensorList t1, TensorList t2) {
   }
 }
 
-void test(Type & T) {
+void test(Type & T, Type & AccT) {
   auto t = T.randn({3, 3});
   // split
   {
@@ -103,12 +103,19 @@ void test(Type & T) {
     ASSERT_ALLCLOSE(d1o.matmul(d5), d1o.expand({24, 1, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 3}));
 
     // > 2-d, 2-d
+    // we use a "folding" algorithm in this case of matmul, so the direct comparison to bmm doesn't work;
+    // instead, compare to the higher precision computation (technically, we should always do this).
+    // tolerancecs are selected empirically.
+    double atol = 1e-04;
+    double rtol = 1e-06;
     d2 = T.randn({3, 4});
     d2o = T.randn({4, 2});
-    ASSERT_ALLCLOSE(d3.matmul(d2), d3.bmm(d2.expand({5, 3, 4})));
-    ASSERT_ALLCLOSE(d2o.matmul(d3), d2o.expand({5, 4, 2}).bmm(d3));
+    auto result = d5.matmul(d2).toType(AccT);
 
-    ASSERT_ALLCLOSE(d5.matmul(d2), d5.view({24, 2, 3}).bmm(d2.expand({24, 3, 4})).view({3, 2, 4, 2, 4}));
+    auto d5Acc = d5.toType(AccT);
+    auto d2Acc = d2.toType(AccT);
+    auto acc_result = d5Acc.view({24, 2, 3}).bmm(d2Acc.expand({24, 3, 4})).view({3, 2, 4, 2, 4});
+    ASSERT_ALLCLOSE_TOLERANCES(result, acc_result, atol, rtol);
     ASSERT_ALLCLOSE(d2o.matmul(d5), d2o.expand({24, 4, 2}).bmm(d5.view({24, 2, 3})).view({3, 2, 4, 4, 3}));
 
     // > 2-d, > 2-d
@@ -169,12 +176,10 @@ void test(Type & T) {
 }
 
 int main() {
-  Type & T = CPU(kFloat);
-  test(T);
+  test(CPU(kFloat), CPU(kDouble));
 
   if (at::hasCUDA()) {
-    Type & CT = CUDA(kFloat);
-    test(CT);
+    test(CUDA(kFloat), CUDA(kDouble));
   }
 
   return 0;

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -105,7 +105,7 @@ void test(Type & T, Type & AccT) {
     // > 2-d, 2-d
     // we use a "folding" algorithm in this case of matmul, so the direct comparison to bmm doesn't work;
     // instead, compare to the higher precision computation (technically, we should always do this).
-    // tolerancecs are selected empirically.
+    // Tolerances are selected empirically.
     double atol = 1e-04;
     double rtol = 1e-06;
     d2 = T.randn({3, 4});

--- a/aten/src/ATen/test/test_assert.h
+++ b/aten/src/ATen/test/test_assert.h
@@ -44,3 +44,8 @@ try {                                                               \
 #define ASSERT_ALLCLOSE(t1, t2)   \
   ASSERT(t1.is_same_size(t2));    \
   ASSERT(t1.allclose(t2));
+
+// allclose broadcasts, so check same size before allclose.
+#define ASSERT_ALLCLOSE_TOLERANCES(t1, t2, atol, rtol)   \
+  ASSERT(t1.is_same_size(t2));    \
+  ASSERT(t1.allclose(t2, atol, rtol));


### PR DESCRIPTION
Because we don't directly use bmm in one case of matmul, a comparison to bmm doesn't make sense; instead, we compare to the double result.

Previous test failed every ~50 repetitions, new test didn't fail in 100,000 repetitions.