### PR TITLE
Fix creating tensors with np.longlong array

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4924,7 +4924,8 @@ class TestTorch(TestCase):
             np.int64,
             np.int32,
             np.int16,
-            np.uint8
+            np.uint8,
+            np.longlong,
         ]
         for dtype in dtypes:
             array = np.array([1, 2, 3, 4], dtype=dtype)

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -152,6 +152,7 @@ static ScalarType dtype_to_aten(int dtype) {
     case NPY_DOUBLE: return kDouble;
     case NPY_FLOAT: return kFloat;
     case NPY_HALF: return kHalf;
+    case NPY_LONGLONG:
     case NPY_INT64: return kLong;
     case NPY_INT32: return kInt;
     case NPY_INT16: return kShort;


### PR DESCRIPTION
Fixes #4363.
Fixes #4364.

When one creates an `ndarray` with `np.longlong` type, calling `.dtype` on the `ndarray` prints `np.int64`. As far as I can tell, the `np.longlong` type is equivalent to `np.int64`.

However, in C code, the `NPY_LONGLONG` macro has a different value from the `NPY_INT64` macro.

This makes it so that we treat `NPY_LONGLONG` the same way as `NPY_INT64`. Alternatively, to fix these issues, I could reject `NPY_LONGLONG` and include better error messages but as far as I can tell `np.longlong` and `np.int64` are the same.

### Test Plan
Added a unit test case for creating tensors with `np.longlong`

Run the following (each script is from a separate issue) on python 2.7 and assert output is correct:
```
import torch
import numpy as np
any_number = long(2)
a = np.arange(0, any_number)
print(a)
b = torch.Tensor(a)
print(b)
```
```
import torch
import numpy as np
any_number = long(2)
a = np.arange(0, any_number)
print(a, a.dtype)
b = torch.from_numpy(a)
print(b)
```