### PR TITLE
Split off load_derivatives and gen_autograd_functions from gen_variable_type

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -98,11 +98,9 @@
 - name: alias(Tensor self)
   self: grad
 
-- name: all  # fallthrough
-
-- name: any  # fallthrough
-
-- name: arange  # fallthrough
+# all
+# any
+# arange
 
 - name: as_strided(Tensor self, IntList size, IntList stride, int64_t storage_offset)
   self: as_strided_backward(grad, TensorGeometry(self), size, stride, storage_offset)
@@ -177,7 +175,7 @@
 - name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad)
   self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)
 
-- name: data_ptr  # fallthrough
+# data_ptr
 
 - name: _det_with_svd(Tensor self)
   self: _det_with_svd_backward(grads, self, result0, result1, result2, result3)
@@ -210,7 +208,7 @@
   self: zeros_like(self)
   other: zeros_like(other)
 
-- name: equal  # fallthrough
+# equal
 
 - name: erf(Tensor self)
   self: 2.0 / sqrt(M_PI) * exp(-(self.pow(2))) * grad
@@ -227,7 +225,7 @@
 - name: exponential(Tensor self, double lambd, Generator generator)
   self: zeros_like(grad)
 
-- name: eye  # fallthrough
+# eye
 
 - name: fill(Tensor self, Scalar value)
   self: zeros_like(grad)
@@ -273,7 +271,7 @@
   self: std::get<0>(gesv(grad, A.t()))
   A: -at::mm(std::get<0>(gesv(grad, A.t())), solution.t())
 
-- name: get_device  # fallthrough
+# get_device
 
 - name: gt(Tensor self, Scalar other)
   self: zeros_like(self)
@@ -302,13 +300,10 @@
 - name: inverse(Tensor self)
   self: -at::mm(output.t(), at::mm(grad, output.t()))
 
-- name: is_contiguous  # fallthrough
-
-- name: is_same_size  # fallthrough
-
-- name: is_signed  # fallthrough
-
-- name: is_set_to  # fallthrough
+# is_contiguous
+# is_same_size
+# is_signed
+# is_set_to
 
 - name: kthvalue(Tensor self, int64_t k, int64_t dim, bool keepdim)
   self: select_backward(grad, dim, indices, self.sizes(), keepdim)
@@ -338,7 +333,7 @@
 - name: log_normal(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
 
-- name: logspace  # fallthrough
+# logspace
 
 - name: lt(Tensor self, Scalar other)
   self: zeros_like(self)
@@ -442,8 +437,8 @@
   mean: grad.type().zeros(mean.sizes())
   std: grad.type().zeros(std.sizes())
 
-- name: numel  # fallthrough
-- name: ones  # fallthrough
+# numel
+# ones
 
 - name: orgqr(Tensor self, Tensor input2)
   self: not_implemented("orgqr")
@@ -490,8 +485,8 @@
 - name: qr(Tensor self)
   self: not_implemented("qr")
 
-- name: rand  # fallthrough
-- name: randn  # fallthrough
+# rand
+# randn
 
 - name: random(Tensor self, int64_t from, int64_t to, Generator generator)
   self: zeros_like(grad)
@@ -502,9 +497,8 @@
 - name: random(Tensor self, Generator generator)
   self: zeros_like(grad)
 
-- name: randperm  # fallthrough
-
-- name: range  # fallthrough
+# randperm
+# range
 
 - name: reciprocal(Tensor self)
   self: grad / -(self * self)
@@ -538,7 +532,7 @@
   self: grad
   src: grad.gather(dim, index)
 
-- name: set  # fallthrough
+# set
 
 - name: sigmoid(Tensor self)
   self: _sigmoid_backward(grad, result)
@@ -552,7 +546,7 @@
 - name: sinh(Tensor self)
   self: grad * self.cosh()
 
-- name: size  # fallthrough
+# size
 
 - name: sort(Tensor self, int64_t dim, bool descending)
   self: select_backward(grad, dim, indices, self.sizes(), true)
@@ -575,9 +569,8 @@
 - name: std(Tensor self, int64_t dim, bool unbiased, bool keepdim)
   self: var_backward(grad * (destination * 2).reciprocal(), self, dim, unbiased, keepdim)
 
-- name: storage_offset  # fallthrough
-
-- name: stride  # fallthrough
+# storage_offset
+# stride
 
 - name: sub(Tensor self, Scalar other, *, Scalar alpha)
   self: grad
@@ -610,7 +603,7 @@
 - name: tanh(Tensor self)
   self: _tanh_backward(grad, result)
 
-- name: tensor  # fallthrough
+# tensor
 
 - name: topk(Tensor self, int64_t k, int64_t dim, bool largest, bool sorted)
   self: select_backward(grad, dim, indices, self.sizes(), true)
@@ -659,7 +652,7 @@
 - name: zero(Tensor self)
   self: zeros_like(grad)
 
-- name: zeros  # fallthrough
+# zeros
 
 - name: _sparse_mask(Tensor self, SparseTensor mask)
   self: not_implemented("_sparse_mask")

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -1,0 +1,160 @@
+# Generates C++ autograd functions for the derivatives of ATen operations
+#
+# This writes two files:
+#  Functions.h/cpp: subclasses of autograd::Function
+#  python_functions.h/cpp: Python bindings for the above classes
+#
+from .utils import nested_dict, CodeTemplate, write
+from .gen_variable_type import VIEW_FUNCTIONS, uses_grad, template_path
+
+FUNCTIONS_H = CodeTemplate.from_file(template_path + '/Functions.h')
+FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/Functions.cpp')
+PY_FUNCTIONS_H = CodeTemplate.from_file(template_path + '/python_functions.h')
+PY_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_functions.cpp')
+
+FUNCTION_DECLARATION = CodeTemplate("""\
+struct ${op} : public ${superclass} {
+  using ${superclass}::${superclass};
+  variable_list apply(const variable_list& grads) override;
+  std::string name() override { return "${op}"; }
+  void releaseVariables() override {
+    ${release_variables}
+  }
+  ${saved_variables}
+};
+""")
+
+FUNCTION_DEFINITION = CodeTemplate("""\
+variable_list ${op}::apply(const variable_list& grads) {
+  variable_list grad_inputs{${num_inputs}};
+  ${body}
+  return grad_inputs;
+}
+""")
+
+PY_FUNCTION_DEFINITION = CodeTemplate("""\
+static PyTypeObject ${op}Class;
+addClass<${op}>(${op}Class, "${op}");
+""")
+
+DERIVATIVE_TENSOR = CodeTemplate("""\
+if (should_compute_output(${idx})) {
+  grad_inputs[${idx}] = ${derivative};
+}
+""")
+
+GRAD_INPUT_MASK = CodeTemplate("""\
+  auto grad_input_mask = std::array<bool, ${n}>{
+    ${masks}
+  };\
+""")
+
+DERIVATIVE_MULTI = CodeTemplate("""\
+if (should_compute_output({ ${idxs} })) {
+${grad_input_mask}
+  std::tie(${grad_inputs}) = ${derivative};
+}
+""")
+
+DERIVATIVE_TENSORLIST = CodeTemplate("""\
+if (should_compute_any_outputs()) {
+  grad_inputs = ${derivative};
+}
+""")
+
+# These functions have backwards which cannot be traced, and so must have
+# their backward functions traced opaquely.
+# VIEW_FUNCTIONS are not traceable because they use as_strided, which
+# has an untraceable backwards, see
+# https://github.com/pytorch/pytorch/issues/4250
+# TODO: This is probably not exhaustive, but it's a start
+UNTRACEABLE_FUNCTIONS = VIEW_FUNCTIONS
+
+
+def gen_autograd_functions(out, autograd_functions):
+    """Functions.h and Functions.cpp body
+
+    These contain the auto-generated subclasses of torch::autograd::Function
+    for each every differentiable torch function.
+    """
+    function_definitions = []
+    function_declarations = []
+    py_function_initializers = []
+
+    for func in autograd_functions:
+        env = process_function(func)
+
+        function_declarations.append(FUNCTION_DECLARATION.substitute(env))
+        function_definitions.append(FUNCTION_DEFINITION.substitute(env))
+        py_function_initializers.append(PY_FUNCTION_DEFINITION.substitute(env))
+
+    top_env = {
+        'autograd_function_definitions': function_definitions,
+        'autograd_function_declarations': function_declarations,
+        'py_function_initializers': py_function_initializers,
+    }
+
+    write(out, 'Functions.h', FUNCTIONS_H, top_env)
+    write(out, 'Functions.cpp', FUNCTIONS_CPP, top_env)
+    write(out, 'python_functions.h', PY_FUNCTIONS_H, top_env)
+    write(out, 'python_functions.cpp', PY_FUNCTIONS_CPP, top_env)
+
+
+def process_function(func):
+    env = {}
+    saved_variables = []
+    release_variables = []
+    unpack = []
+
+    def save_arg(arg, is_output):
+        name = arg['name']
+        if arg['type'] == 'Tensor' or (arg['type'] == 'Scalar' and is_output):
+            saved_variables.append('SavedVariable {}_;'.format(name))
+            release_variables.append('{}_.data.reset();'.format(name))
+            ptr = 'shared_from_this()' if is_output else ''
+            unpack.append('auto {} = {}_.unpack({});'.format(name, name, ptr))
+        elif arg['type'] == 'IntList':
+            saved_variables.append('std::vector<int64_t> {};'.format(name))
+        else:
+            saved_variables.append('{} {};'.format(arg['type'], name))
+
+    for arg in func['saved_inputs']:
+        save_arg(arg, is_output=False)
+    for arg in func['saved_outputs']:
+        save_arg(arg, is_output=True)
+    env['saved_variables'] = saved_variables
+    env['release_variables'] = release_variables
+
+    body = []
+
+    if uses_grad(func):
+        body.append('auto& grad = grads[0];')
+
+    def emit_derivative(derivative):
+        formula = derivative['formula']
+        idxs = derivative['output_indices']
+        if idxs == ['*']:
+            return DERIVATIVE_TENSORLIST.substitute(derivative=formula)
+        elif len(idxs) == 1:
+            return DERIVATIVE_TENSOR.substitute(idx=idxs[0], derivative=formula)
+        else:
+            if 'grad_input_mask' in formula:
+                masks = ['should_compute_output({}),'.format(i) for i in idxs]
+                grad_input_mask = GRAD_INPUT_MASK.substitute(masks=masks, n=len(idxs))
+            else:
+                grad_input_mask = ''
+            grad_inputs = ', '.join(['grad_inputs[{}]'.format(i) for i in idxs])
+            return DERIVATIVE_MULTI.substitute(
+                idxs=idxs, derivative=formula, grad_inputs=grad_inputs,
+                grad_input_mask=grad_input_mask)
+
+    body.extend(unpack)
+    for derivative in func['derivatives']:
+        body.append(emit_derivative(derivative))
+
+    env['body'] = body
+    if func['name'] in UNTRACEABLE_FUNCTIONS:
+        env['superclass'] = 'Function'
+    else:
+        env['superclass'] = 'TraceableFunction'
+    return nested_dict(env, func)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1,3 +1,8 @@
+# Generates Python bindings for ATen functions
+#
+# The bindings are generated as methods on python_variable or functions on the
+# torch._C._nn object.
+
 from .nested_dict import nested_dict
 from tools.shared.module_loader import import_module
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -32,19 +32,8 @@ import copy
 import os
 import re
 import yaml
-import warnings
 from collections import defaultdict
-from tools.shared.module_loader import import_module
-from .nested_dict import nested_dict
-
-CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').CodeTemplate
-
-
-try:
-    # use faster C loader if available
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
+from .utils import CodeTemplate, write, nested_dict, YamlLoader
 
 
 METHOD_DECLARATION = CodeTemplate("""\
@@ -65,56 +54,6 @@ baseType->${method_prefix_derived}${base_name}(${unpacked_args})""")
 
 UNPACK_TENSOR = CodeTemplate("""\
 auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
-
-FUNCTION_DECLARATION = CodeTemplate("""\
-struct ${op} : public ${superclass} {
-  using ${superclass}::${superclass};
-  variable_list apply(const variable_list& grads) override;
-  std::string name() override { return "${op}"; }
-  void releaseVariables() override {
-    ${release_variables}
-  }
-  ${saved_variables}
-};
-""")
-
-FUNCTION_DEFINITION = CodeTemplate("""\
-variable_list ${op}::apply(const variable_list& grads) {
-  variable_list grad_inputs{${num_inputs}};
-  ${body}
-  return grad_inputs;
-}
-""")
-
-PY_FUNCTION_DEFINITION = CodeTemplate("""\
-static PyTypeObject ${op}Class;
-addClass<${op}>(${op}Class, "${op}");
-""")
-
-DERIVATIVE_TENSOR = CodeTemplate("""\
-if (should_compute_output(${idx})) {
-  grad_inputs[${idx}] = ${derivative};
-}
-""")
-
-GRAD_INPUT_MASK = CodeTemplate("""\
-  auto grad_input_mask = std::array<bool, ${n}>{
-    ${masks}
-  };\
-""")
-
-DERIVATIVE_MULTI = CodeTemplate("""\
-if (should_compute_output({ ${idxs} })) {
-${grad_input_mask}
-  std::tie(${grad_inputs}) = ${derivative};
-}
-""")
-
-DERIVATIVE_TENSORLIST = CodeTemplate("""\
-if (should_compute_any_outputs()) {
-  grad_inputs = ${derivative};
-}
-""")
 
 # NB: both fallthrough and derivative dispatch via derived (aka baseType).
 # That is why all of these paths need unpack_args.
@@ -200,22 +139,15 @@ BUFFER_DECLARATION = CodeTemplate("""\
 auto ${name} = tensor();
 auto& ${name}_ = static_cast<VariableImpl*>(${name}.get())->data;""")
 
-GENERATED_COMMENT = CodeTemplate("""\
-generated from tools/autograd/templates/${filename}""")
-
 template_path = os.path.join(os.path.dirname(__file__), 'templates')
 
 VARIABLE_TYPE_H = CodeTemplate.from_file(template_path + '/VariableType.h')
 VARIABLE_TYPE_CPP = CodeTemplate.from_file(template_path + '/VariableType.cpp')
-FUNCTIONS_H = CodeTemplate.from_file(template_path + '/Functions.h')
-FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/Functions.cpp')
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')
 PY_VARIABLE_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_variable_methods_dispatch.h')
 PY_NN_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_nn_functions.cpp')
 PY_NN_FUNCTIONS_H = CodeTemplate.from_file(template_path + '/python_nn_functions.h')
 PY_NN_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_nn_functions_dispatch.h')
-PY_FUNCTIONS_H = CodeTemplate.from_file(template_path + '/python_functions.h')
-PY_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_functions.cpp')
 
 derivatives_path = os.path.join(os.path.dirname(__file__), 'derivatives.yaml')
 deprecated_path = os.path.join(os.path.dirname(__file__), 'deprecated.yaml')
@@ -243,13 +175,6 @@ SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward'
 ]
-# These functions have backwards which cannot be traced, and so must have
-# their backward functions traced opaquely.
-# VIEW_FUNCTIONS are not traceable because they use as_strided, which
-# has an untraceable backwards, see
-# https://github.com/pytorch/pytorch/issues/4250
-# TODO: This is probably not exhaustive, but it's a start
-UNTRACEABLE_FUNCTIONS = VIEW_FUNCTIONS
 # These functions we don't want to record for tracing, because we always want
 # to trace their constituent parts.  This is a temporary hack in lieue
 # of proper scopes, where subsequent compilation passes can ask for the unfolding
@@ -273,299 +198,11 @@ def format_return_type(returns):
         return 'std::tuple<{}>'.format(','.join(return_types))
 
 
-def write(dirname, name, template, env):
-    env['generated_comment'] = GENERATED_COMMENT.substitute(filename=name)
-    path = os.path.join(dirname, name)
-    with open(path, 'w') as f:
-        f.write(template.substitute(env))
-
-
-def saved_variables(formula, args):
-    # find which arguments need to be saved
-    saved = []
-
-    REPLACEMENTS = [
-        # replace self.sizes() with self_sizes
-        (r'{}.sizes\(\)', {
-            'suffix': '_sizes',
-            'type': 'IntList',
-        }),
-        # replace zeros_like(self) with self_info
-        (r'zeros_like\({}\)', {
-            'suffix': '_info',
-            'type': 'TypeAndSize',
-            'expr': lambda name: name,  # at save-time
-            'res': lambda name: name + '_info.zeros()',  # at eval-time
-        }),
-        # replace self.size(2) with self_size_2
-        (r'{}.size\((\w+)\)', {
-            'suffix': lambda m: '_argsize_{}'.format(*m.groups()),
-            'type': 'int64_t',
-        }),
-        # replace to_arg_sizes(self, 2) with self_argsizes_2
-        (r'to_arg_sizes\({}, (\w+)\)', {
-            'suffix': lambda m: '_sizes_{}'.format(*m.groups()),
-            'type': 'IntList',
-        }),
-        # replace TensorGeometry(self) with self_geometry
-        (r'TensorGeometry\({}\)', {
-            'suffix': '_geometry',
-            'type': 'TensorGeometry',
-        }),
-    ]
-
-    for arg in args:
-        if 'name' not in arg:
-            # some returned arguments do not have names
-            continue
-
-        name = arg['name']
-
-        # First search the formula for expressions which can be evaluated
-        # when the autograd Function is created to avoid saving variables
-        for regex, info in REPLACEMENTS:
-            def repl(m):
-                suffix = info['suffix']
-                suffix = suffix(m) if callable(suffix) else suffix
-                expr = info['expr'](name) if 'expr' in info else m.group(0)
-                saved.append({
-                    'name': name + suffix,
-                    'type': info['type'],
-                    'expr': expr,
-                })
-                if 'res' in info:
-                    return info['res'](name)
-                return name + suffix
-
-            formula = re.sub(regex.format(name), repl, formula)
-
-        # Find any variables which remain in the formula and save them
-        if re.search(IDENT_REGEX.format(name), formula):
-            arg = copy.deepcopy(arg)
-            arg['type'] = arg['type'].replace('const ', '').replace(' &', '')
-            saved.append(arg)
-
-    return formula, saved
-
-
-def create_derivative(declaration, formula, output_indices, var_names):
-    returns = [r for r in declaration['returns'] if r.get('name') != 'self']
-    arguments = declaration['arguments']
-    formula, saved_inputs = saved_variables(formula, arguments)
-    formula, saved_outputs = saved_variables(formula, returns)
-
-    return {
-        'formula': formula,
-        'output_indices': output_indices,
-        'saved_inputs': saved_inputs,
-        'saved_outputs': saved_outputs,
-        'var_names': var_names,
-    }
-
-
-def create_autograd_function(name, derivatives, num_inputs, buffers=None):
-    return {
-        'name': name,
-        'op': to_camel_case(name) + 'Backward',
-        'num_inputs': num_inputs,
-        'derivatives': derivatives,
-        'buffers': [] if buffers is None else buffers,
-        'saved_inputs': all_saved_variables(derivatives, 'saved_inputs'),
-        'saved_outputs': all_saved_variables(derivatives, 'saved_outputs'),
-    }
-
-
-def all_saved_variables(derivatives, key):
-    seen = set()
-    saved = []
-    for d in derivatives:
-        for saved_arg in d[key]:
-            if saved_arg['name'] in seen:
-                continue
-            seen.add(saved_arg['name'])
-            saved.append(saved_arg)
-    return saved
-
-
-def to_camel_case(name):
-    return ''.join([p.title() for p in name.split('_')])
-
-
 # TODO: Use a real parser here; this will get bamboozled
 # by signatures that contain things like std::array<bool, 2> (note the space)
 def split_name_params(prototype):
     name, params = re.match('(\w+)\((.*)\)', prototype).groups()
     return name, params.split(', ')
-
-
-def load_derivatives(path, declarations_by_signature, declarations_by_name):
-    with open(path, 'r') as f:
-        definitions = yaml.load(f, Loader=Loader)
-
-    def canonical_declaration(declarations, name):
-        for declaration in declarations:
-            if declaration['name'] == name:
-                return declaration
-        # some functions only have in-place variants
-        assert name + '_' == declarations[0]['name']
-        return declarations[0]
-
-    def split_names(raw_names):
-        """Given "foo, bar", return ["foo", "bar"]."""
-        return [x.strip() for x in raw_names.split(',')]
-
-    def lookup_pred(pred, xs):
-        """Return the index of the first element of xs matching pred."""
-        return next((i, x) for i, x in enumerate(xs) if pred(x))
-
-    def set_up_derivatives(defn, declaration):
-
-        # First, let us determine the set of inputs for which gradients
-        # were specified in declarations.  We'll use this in layout
-        # computation.
-        args_with_gradients = set()
-        for raw_names in defn:
-            args_with_gradients |= set(split_names(raw_names))
-
-        # Next, let us compute the layout of the grad_inputs we will
-        # return.  In general this is not in one-to-one correspondence
-        # with the inputs, because some will not have gradients, and we
-        # will not bother allocating an undefined tensor for them.
-        num_inputs = 0  # number of grad_inputs to return
-        arg_name_to_output_index = {}
-        for arg in declaration['arguments']:
-            if arg['name'] not in args_with_gradients:
-                continue
-            if arg['type'] == 'TensorList':
-                num_inputs = ''
-                output_index = '*'  # variable length thing
-            else:
-                output_index = num_inputs  # the current index
-                num_inputs += 1
-            arg_name_to_output_index[arg['name']] = output_index
-
-        # Finally, let us set up the derivative information
-        derivatives = []
-        for raw_names in sorted(defn.keys()):
-            formula = defn[raw_names]
-            names = split_names(raw_names)
-            output_indices = []
-            args = []
-            for name in names:
-                output_indices.append(arg_name_to_output_index[name])
-                args.append(name)
-            derivatives.append(create_derivative(declaration, formula, output_indices, args))
-
-        return derivatives, num_inputs
-
-    def is_nn_fwd(defn_name, declarations_by_name):
-        """Return True if the definition is of an NN, non-double
-           backward function, False otherwise"""
-
-        if len(declarations_by_name[defn_name]) == 0:
-            return False
-        declaration = declarations_by_name[defn_name][0]
-        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
-        fwd_name = base_name + '_forward'
-        if declaration['mode'] != 'NN' or fwd_name not in declarations_by_name:
-            return False
-        return True
-
-    def preprocess_nn_function(defn_name, declarations_by_name):
-        """Set up declaration and derivative information for NN,
-           non-double backward functions"""
-
-        declaration = declarations_by_name[defn_name][0]
-        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
-        fwd_name = base_name + ('_forward' if not declaration['inplace'] else '_forward_')
-
-        assert len(declarations_by_name[fwd_name]) == 1
-
-        declaration['base_name'] = fwd_name
-        fwd = declarations_by_name[fwd_name][0]
-
-        derivatives, num_inputs = set_up_derivatives(defn, fwd)
-        buffers = declaration['buffers']
-
-        func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
-        declaration['derivative'] = func
-
-        return func
-
-    # Parse each entry from derivatives.yaml
-    autograd_functions = []
-    for defn in definitions:
-        if '(' not in defn['name']:
-            continue
-
-        def unzip(xs):
-            return zip(*xs)
-
-        # NB: Removes 'name' from defn dictionary
-        defn_name, params = split_name_params(defn.pop('name'))
-        param_types, param_names = unzip([p.split(' ') for p in params if p != '*'])
-        if 'grad_input_mask' in param_names:
-            raise RuntimeError("Signature for {} has an argument named grad_input_mask, "
-                               "but this name would be shadowed by our codegen. "
-                               "Please use a different name in Declarations.cwrap."
-                               .format(defn_name))
-        signature = '{}({})'.format(defn_name, ', '.join(param_types))
-
-        if is_nn_fwd(defn_name, declarations_by_name):
-            func = preprocess_nn_function(defn_name, declarations_by_name)
-            if func is not None:
-                autograd_functions.append(func)
-            continue
-
-        declarations = declarations_by_signature[signature]
-        if len(declarations) == 0:
-            avail = [k for k, v in declarations_by_signature.items()
-                     if k.startswith(defn_name + '(') and len(v) > 0]
-            raise RuntimeError('no ATen declaration found for: {}.  '
-                               'Available signatures: {}'.format(signature, ', '.join(avail)))
-        canonical = canonical_declaration(declarations, defn_name)
-
-        # TODO: Check the types line up
-        if len(param_names) != len(canonical['args']):
-            raise RuntimeError('Signature for {} has {} arguments ({}), but '
-                               'Declarations.yaml records {} arguments ({})'
-                               .format(defn_name,
-                                       len(param_names),
-                                       ', '.join(param_names),
-                                       len(canonical['args']),
-                                       ', '.join(canonical['args'])))
-        for i, (x, y) in enumerate(zip(param_names, canonical['args'])):
-            if x != y:
-                raise RuntimeError('Argument {} of {} has different names in '
-                                   'derivatives.yaml ({}) and '
-                                   'Declarations.yaml ({})'
-                                   .format(i, defn_name, x, y))
-
-        derivatives, num_inputs = set_up_derivatives(defn, canonical)
-        buffers = canonical.get('buffers')
-
-        func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
-        autograd_functions.append(func)
-        for declaration in declarations:
-            declaration['derivative'] = func
-
-    return autograd_functions
-
-
-def ensure_unique_names(autograd_functions):
-    # de-duplicate operation names
-    # you end up with something like:
-    #   AddBackward0
-    #   AddBackward1
-    # one for each overload
-    functions_by_name = defaultdict(list)
-    for func in autograd_functions:
-        functions_by_name[func['op']].append(func)
-    for op in functions_by_name.keys():
-        overloads = functions_by_name[op]
-        if len(overloads) > 1:
-            for i, func in enumerate(overloads):
-                func['op'] += str(i)
 
 
 def uses_grad(func):
@@ -576,82 +213,6 @@ def uses_grad(func):
         if re.search(IDENT_REGEX.format('grad'), formula):
             return True
     return False
-
-
-def create_autograd_functions(top_env, autogen_functions):
-    """Functions.h and Functions.cpp body
-
-    These contain the auto-generated subclasses of torch::autograd::Function
-    for each every differentiable torch function.
-    """
-    function_definitions = top_env['autograd_function_definitions']
-    function_declarations = top_env['autograd_function_declarations']
-    py_function_initializers = top_env['py_function_initializers']
-
-    def process_function(func):
-        env = {}
-        saved_variables = []
-        release_variables = []
-        unpack = []
-
-        def save_arg(arg, is_output):
-            name = arg['name']
-            if arg['type'] == 'Tensor' or (arg['type'] == 'Scalar' and is_output):
-                saved_variables.append('SavedVariable {}_;'.format(name))
-                release_variables.append('{}_.data.reset();'.format(name))
-                ptr = 'shared_from_this()' if is_output else ''
-                unpack.append('auto {} = {}_.unpack({});'.format(name, name, ptr))
-            elif arg['type'] == 'IntList':
-                saved_variables.append('std::vector<int64_t> {};'.format(name))
-            else:
-                saved_variables.append('{} {};'.format(arg['type'], name))
-
-        for arg in func['saved_inputs']:
-            save_arg(arg, is_output=False)
-        for arg in func['saved_outputs']:
-            save_arg(arg, is_output=True)
-        env['saved_variables'] = saved_variables
-        env['release_variables'] = release_variables
-
-        body = []
-
-        if uses_grad(func):
-            body.append('auto& grad = grads[0];')
-
-        def emit_derivative(derivative):
-            formula = derivative['formula']
-            idxs = derivative['output_indices']
-            if idxs == ['*']:
-                return DERIVATIVE_TENSORLIST.substitute(derivative=formula)
-            elif len(idxs) == 1:
-                return DERIVATIVE_TENSOR.substitute(idx=idxs[0], derivative=formula)
-            else:
-                if 'grad_input_mask' in formula:
-                    masks = ['should_compute_output({}),'.format(i) for i in idxs]
-                    grad_input_mask = GRAD_INPUT_MASK.substitute(masks=masks, n=len(idxs))
-                else:
-                    grad_input_mask = ''
-                grad_inputs = ', '.join(['grad_inputs[{}]'.format(i) for i in idxs])
-                return DERIVATIVE_MULTI.substitute(
-                    idxs=idxs, derivative=formula, grad_inputs=grad_inputs,
-                    grad_input_mask=grad_input_mask)
-
-        body.extend(unpack)
-        for derivative in func['derivatives']:
-            body.append(emit_derivative(derivative))
-
-        env['body'] = body
-        if func['name'] in UNTRACEABLE_FUNCTIONS:
-            env['superclass'] = 'Function'
-        else:
-            env['superclass'] = 'TraceableFunction'
-        env = nested_dict(env, func)
-        function_declarations.append(FUNCTION_DECLARATION.substitute(env))
-        function_definitions.append(FUNCTION_DEFINITION.substitute(env))
-        py_function_initializers.append(PY_FUNCTION_DEFINITION.substitute(env))
-
-    for func in autogen_functions:
-        process_function(func)
 
 
 def dispatch_strategy(declaration):
@@ -1057,7 +618,7 @@ def create_variable_type(top_env, aten_declarations):
 
 def load_aten_declarations(path):
     with open(path, 'r') as f:
-        declarations = yaml.load(f, Loader=Loader)
+        declarations = yaml.load(f, Loader=YamlLoader)
 
     # enrich declarations with additional information
     for declaration in declarations:
@@ -1110,7 +671,7 @@ def load_aten_declarations(path):
 
 def load_deprecated_signatures(declarations_by_signature):
     with open(deprecated_path, 'r') as f:
-        deprecated_defs = yaml.load(f, Loader=Loader)
+        deprecated_defs = yaml.load(f, Loader=YamlLoader)
     declarations = []
 
     def get_signature(name, params, call_args):
@@ -1164,8 +725,8 @@ def gen_variable_type(declarations, out):
     for d in aten_decls:
         declarations_by_name[d['name']].append(d)
 
+    from .load_derivatives import load_derivatives
     autograd_functions = load_derivatives(derivatives_path, declarations_by_signature, declarations_by_name)
-    ensure_unique_names(autograd_functions)
 
     def should_generate_python_binding(declaration):
         name = declaration['name']
@@ -1213,8 +774,10 @@ def gen_variable_type(declarations, out):
         'py_nn_function_dispatch': [],
     }
 
-    create_autograd_functions(env, autograd_functions)
     create_variable_type(env, aten_decls)
+
+    from .gen_autograd_functions import gen_autograd_functions
+    gen_autograd_functions(out, autograd_functions)
 
     from .gen_python_functions import create_python_bindings
     create_python_bindings(
@@ -1233,15 +796,11 @@ def gen_variable_type(declarations, out):
 
     write(out, 'VariableType.h', VARIABLE_TYPE_H, env)
     write(out, 'VariableType.cpp', VARIABLE_TYPE_CPP, env)
-    write(out, 'Functions.h', FUNCTIONS_H, env)
-    write(out, 'Functions.cpp', FUNCTIONS_CPP, env)
     write(out, 'python_variable_methods.cpp', PY_VARIABLE_METHODS_CPP, env)
     write(out, 'python_variable_methods_dispatch.h', PY_VARIABLE_DISPATCH_H, env)
     write(out, 'python_nn_functions.cpp', PY_NN_FUNCTIONS_CPP, env)
     write(out, 'python_nn_functions.h', PY_NN_FUNCTIONS_H, env)
     write(out, 'python_nn_functions_dispatch.h', PY_NN_DISPATCH_H, env)
-    write(out, 'python_functions.h', PY_FUNCTIONS_H, env)
-    write(out, 'python_functions.cpp', PY_FUNCTIONS_CPP, env)
 
 
 def main():

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -1,0 +1,290 @@
+# Parses derivatives.yaml into autograd functions
+#
+# Each autograd function is represented by dictionary containing a list of
+# derivatives (also a dictionary). See `create_autograd_function` and
+# `create_derivative` for the keys.
+from collections import defaultdict
+import copy
+import re
+import yaml
+from .utils import YamlLoader
+from .gen_variable_type import IDENT_REGEX, split_name_params
+
+
+def load_derivatives(path, declarations_by_signature, declarations_by_name):
+    with open(path, 'r') as f:
+        definitions = yaml.load(f, Loader=YamlLoader)
+
+    autograd_functions = [
+        process_definition(defn, declarations_by_signature, declarations_by_name)
+        for defn in definitions]
+    ensure_unique_names(autograd_functions)
+    return autograd_functions
+
+
+def create_autograd_function(name, derivatives, num_inputs, buffers=None):
+    return {
+        'name': name,
+        'op': to_camel_case(name) + 'Backward',
+        'num_inputs': num_inputs,
+        'derivatives': derivatives,
+        'buffers': [] if buffers is None else buffers,
+        'saved_inputs': all_saved_variables(derivatives, 'saved_inputs'),
+        'saved_outputs': all_saved_variables(derivatives, 'saved_outputs'),
+    }
+
+
+def create_derivative(declaration, formula, output_indices, var_names):
+    returns = [r for r in declaration['returns'] if r.get('name') != 'self']
+    arguments = declaration['arguments']
+    formula, saved_inputs = saved_variables(formula, arguments)
+    formula, saved_outputs = saved_variables(formula, returns)
+
+    return {
+        'formula': formula,
+        'output_indices': output_indices,
+        'saved_inputs': saved_inputs,
+        'saved_outputs': saved_outputs,
+        'var_names': var_names,
+    }
+
+
+def process_definition(defn, declarations_by_signature, declarations_by_name):
+    """Processes a single entry `defn` in derivatives.yaml"""
+
+    def canonical_declaration(declarations, name):
+        for declaration in declarations:
+            if declaration['name'] == name:
+                return declaration
+        # some functions only have in-place variants
+        assert name + '_' == declarations[0]['name']
+        return declarations[0]
+
+    def split_names(raw_names):
+        """Given "foo, bar", return ["foo", "bar"]."""
+        return [x.strip() for x in raw_names.split(',')]
+
+    def lookup_pred(pred, xs):
+        """Return the index of the first element of xs matching pred."""
+        return next((i, x) for i, x in enumerate(xs) if pred(x))
+
+    def set_up_derivatives(defn, declaration):
+        # First, let us determine the set of inputs for which gradients
+        # were specified in declarations.  We'll use this in layout
+        # computation.
+        args_with_gradients = set()
+        for raw_names in defn:
+            args_with_gradients |= set(split_names(raw_names))
+
+        # Next, let us compute the layout of the grad_inputs we will
+        # return.  In general this is not in one-to-one correspondence
+        # with the inputs, because some will not have gradients, and we
+        # will not bother allocating an undefined tensor for them.
+        num_inputs = 0  # number of grad_inputs to return
+        arg_name_to_output_index = {}
+        for arg in declaration['arguments']:
+            if arg['name'] not in args_with_gradients:
+                continue
+            if arg['type'] == 'TensorList':
+                num_inputs = ''
+                output_index = '*'  # variable length thing
+            else:
+                output_index = num_inputs  # the current index
+                num_inputs += 1
+            arg_name_to_output_index[arg['name']] = output_index
+
+        # Finally, let us set up the derivative information
+        derivatives = []
+        for raw_names in sorted(defn.keys()):
+            formula = defn[raw_names]
+            names = split_names(raw_names)
+            output_indices = []
+            args = []
+            for name in names:
+                output_indices.append(arg_name_to_output_index[name])
+                args.append(name)
+            derivatives.append(create_derivative(declaration, formula, output_indices, args))
+
+        return derivatives, num_inputs
+
+    def is_nn_fwd(defn_name, declarations_by_name):
+        """Return True if the definition is of an NN, non-double
+           backward function, False otherwise"""
+
+        if len(declarations_by_name[defn_name]) == 0:
+            return False
+        declaration = declarations_by_name[defn_name][0]
+        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
+        fwd_name = base_name + '_forward'
+        if declaration['mode'] != 'NN' or fwd_name not in declarations_by_name:
+            return False
+        return True
+
+    def preprocess_nn_function(defn_name, declarations_by_name):
+        """Set up declaration and derivative information for NN,
+           non-double backward functions"""
+
+        declaration = declarations_by_name[defn_name][0]
+        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
+        fwd_name = base_name + ('_forward' if not declaration['inplace'] else '_forward_')
+
+        assert len(declarations_by_name[fwd_name]) == 1
+
+        declaration['base_name'] = fwd_name
+        fwd = declarations_by_name[fwd_name][0]
+
+        derivatives, num_inputs = set_up_derivatives(defn, fwd)
+        buffers = declaration['buffers']
+
+        func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
+        declaration['derivative'] = func
+
+        return func
+
+    def unzip(xs):
+        return zip(*xs)
+
+    # NB: Removes 'name' from defn dictionary
+    defn_name, params = split_name_params(defn.pop('name'))
+    param_types, param_names = unzip([p.split(' ') for p in params if p != '*'])
+    if 'grad_input_mask' in param_names:
+        raise RuntimeError("Signature for {} has an argument named grad_input_mask, "
+                           "but this name would be shadowed by our codegen. "
+                           "Please use a different name in Declarations.cwrap."
+                           .format(defn_name))
+    signature = '{}({})'.format(defn_name, ', '.join(param_types))
+
+    if is_nn_fwd(defn_name, declarations_by_name):
+        return preprocess_nn_function(defn_name, declarations_by_name)
+
+    declarations = declarations_by_signature[signature]
+    if len(declarations) == 0:
+        avail = [k for k, v in declarations_by_signature.items()
+                 if k.startswith(defn_name + '(') and len(v) > 0]
+        raise RuntimeError('no ATen declaration found for: {}.  '
+                           'Available signatures: {}'.format(signature, ', '.join(avail)))
+    canonical = canonical_declaration(declarations, defn_name)
+
+    # TODO: Check the types line up
+    if len(param_names) != len(canonical['args']):
+        raise RuntimeError('Signature for {} has {} arguments ({}), but '
+                           'Declarations.yaml records {} arguments ({})'
+                           .format(defn_name,
+                                   len(param_names),
+                                   ', '.join(param_names),
+                                   len(canonical['args']),
+                                   ', '.join(canonical['args'])))
+    for i, (x, y) in enumerate(zip(param_names, canonical['args'])):
+        if x != y:
+            raise RuntimeError('Argument {} of {} has different names in '
+                               'derivatives.yaml ({}) and '
+                               'Declarations.yaml ({})'
+                               .format(i, defn_name, x, y))
+
+    derivatives, num_inputs = set_up_derivatives(defn, canonical)
+    buffers = canonical.get('buffers')
+
+    func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
+    for declaration in declarations:
+        declaration['derivative'] = func
+    return func
+
+
+def ensure_unique_names(autograd_functions):
+    # de-duplicate operation names
+    # you end up with something like:
+    #   AddBackward0
+    #   AddBackward1
+    # one for each overload
+    functions_by_name = defaultdict(list)
+    for func in autograd_functions:
+        functions_by_name[func['op']].append(func)
+    for op in functions_by_name.keys():
+        overloads = functions_by_name[op]
+        if len(overloads) > 1:
+            for i, func in enumerate(overloads):
+                func['op'] += str(i)
+
+
+def saved_variables(formula, args):
+    # find which arguments need to be saved
+    saved = []
+
+    REPLACEMENTS = [
+        # replace self.sizes() with self_sizes
+        (r'{}.sizes\(\)', {
+            'suffix': '_sizes',
+            'type': 'IntList',
+        }),
+        # replace zeros_like(self) with self_info
+        (r'zeros_like\({}\)', {
+            'suffix': '_info',
+            'type': 'TypeAndSize',
+            'expr': lambda name: name,  # at save-time
+            'res': lambda name: name + '_info.zeros()',  # at eval-time
+        }),
+        # replace self.size(2) with self_size_2
+        (r'{}.size\((\w+)\)', {
+            'suffix': lambda m: '_argsize_{}'.format(*m.groups()),
+            'type': 'int64_t',
+        }),
+        # replace to_arg_sizes(self, 2) with self_argsizes_2
+        (r'to_arg_sizes\({}, (\w+)\)', {
+            'suffix': lambda m: '_sizes_{}'.format(*m.groups()),
+            'type': 'IntList',
+        }),
+        # replace TensorGeometry(self) with self_geometry
+        (r'TensorGeometry\({}\)', {
+            'suffix': '_geometry',
+            'type': 'TensorGeometry',
+        }),
+    ]
+
+    for arg in args:
+        if 'name' not in arg:
+            # some returned arguments do not have names
+            continue
+
+        name = arg['name']
+
+        # First search the formula for expressions which can be evaluated
+        # when the autograd Function is created to avoid saving variables
+        for regex, info in REPLACEMENTS:
+            def repl(m):
+                suffix = info['suffix']
+                suffix = suffix(m) if callable(suffix) else suffix
+                expr = info['expr'](name) if 'expr' in info else m.group(0)
+                saved.append({
+                    'name': name + suffix,
+                    'type': info['type'],
+                    'expr': expr,
+                })
+                if 'res' in info:
+                    return info['res'](name)
+                return name + suffix
+
+            formula = re.sub(regex.format(name), repl, formula)
+
+        # Find any variables which remain in the formula and save them
+        if re.search(IDENT_REGEX.format(name), formula):
+            arg = copy.deepcopy(arg)
+            arg['type'] = arg['type'].replace('const ', '').replace(' &', '')
+            saved.append(arg)
+
+    return formula, saved
+
+
+def all_saved_variables(derivatives, key):
+    seen = set()
+    saved = []
+    for d in derivatives:
+        for saved_arg in d[key]:
+            if saved_arg['name'] in seen:
+                continue
+            seen.add(saved_arg['name'])
+            saved.append(saved_arg)
+    return saved
+
+
+def to_camel_case(name):
+    return ''.join([p.title() for p in name.split('_')])

--- a/tools/autograd/utils.py
+++ b/tools/autograd/utils.py
@@ -1,0 +1,26 @@
+import os
+from tools.shared.module_loader import import_module
+from .nested_dict import nested_dict
+
+
+__all__ = ['CodeTemplate', 'nested_dict', 'write']
+
+
+CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').CodeTemplate
+
+try:
+    # use faster C loader if available
+    from yaml import CLoader as YamlLoader
+except ImportError:
+    from yaml import YamlLoader
+
+
+GENERATED_COMMENT = CodeTemplate("""\
+generated from tools/autograd/templates/${filename}""")
+
+
+def write(dirname, name, template, env):
+    env['generated_comment'] = GENERATED_COMMENT.substitute(filename=name)
+    path = os.path.join(dirname, name)
+    with open(path, 'w') as f:
+        f.write(template.substitute(env))

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -1,10 +1,9 @@
 import os
 import argparse
-from collections import defaultdict
-from tools.shared.module_loader import import_module
 from itertools import count
-from ..autograd.gen_variable_type import load_aten_declarations, CodeTemplate, write, \
-    FALLTHROUGH_RETURN_TYPES, FALLTHROUGH_FUNCTIONS, GENERATED_COMMENT
+from ..autograd.utils import CodeTemplate, write
+from ..autograd.gen_variable_type import load_aten_declarations, \
+    FALLTHROUGH_RETURN_TYPES, FALLTHROUGH_FUNCTIONS
 
 template_path = os.path.join(os.path.dirname(__file__), 'templates')
 


### PR DESCRIPTION
`load_derivatives.py`: parses `derivatives.yaml` into autograd functions
`gen_autograd_functions`: writes `Functions.h/.cpp` from parsed autograd functions

There are no functional changes in this PR -- it generates exactly the same code. I also tried to avoid any complicated refactoring beyond moving the files in this PR since it's mostly cut-and-paste.

I got rid of the stubs in `derivatives.yaml` so everything listed in that file can be parsed.