### PR TITLE
Don't special case NN functions in gen_variable_type.py

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -518,6 +518,8 @@ def create_generic(top_env, declarations):
         mode = option['mode']
         abstract = True
         if mode == 'NN' and option.get('cimpls') is None:
+            # NN function with no _forward/_backward suffix don't have cimpls.
+            # They call the _forward function and discard any buffer returns
             abstract = False
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -53,7 +53,7 @@ virtual ${return_type} ${api_name}(${formals_with_defaults}) const;
 """)
 TYPE_METHOD_DEFINITION_CONCRETE = CodeTemplate("""\
 ${return_type} Type::${api_name}(${formals}) const {
-    ${return_call} at::native::${native_type_method_dispatch}(${actuals});
+    ${type_definition_body}
 }
 """)
 # 4. add virtual override to TypeDerived.h
@@ -73,6 +73,9 @@ TYPE_DERIVED_DEFINITION_NATIVE = CodeTemplate("""\
 ${return_type} ${Type}::${api_name}(${formals}) const {
     ${return_call} at::native::${native_type_method_dispatch}(${actuals});
 }
+""")
+TYPE_DEFINITION_BODY_NATIVE = CodeTemplate("""\
+${return_call} at::native::${native_type_method_dispatch}(${actuals});
 """)
 
 # 6. add non-virtual declaration to Tensor.h
@@ -456,6 +459,29 @@ def create_generic(top_env, declarations):
 
         return broadcast_actuals
 
+    def emit_nn_body(option):
+        # Concrete definition on Type.cpp for NN functions. Delegates to the
+        # xxx_forward variant variant after creating any necessary buffers.
+        actuals = option['actuals']
+        base_name = option['name'][:-1] if option['inplace'] else option['name']
+        fwd_name = option['api_name'].replace(base_name, base_name + '_forward')
+
+        if len(option['buffers']) == 0:
+            return 'return {}({});'.format(fwd_name, ', '.join(actuals))
+
+        body = []
+        if option['api_name'].endswith('_out'):
+            # _out variants must create buffers and insert them in the
+            # arguments list between output and input arguments
+            for buffer in option['buffers']:
+                body.append('Tensor {} = tensor();'.format(buffer['name']))
+            actuals = [arg['name'] for arg in option['arguments'] if arg.get('output')]
+            actuals += [buffer['name'] for buffer in option['buffers']]
+            actuals += [arg['name'] for arg in option['arguments'] if not arg.get('output')]
+
+        body.append('return std::get<0>({}({}));'.format(fwd_name, ', '.join(actuals)))
+        return body
+
     def process_option(option, output_options):
         option['inplace'] = re.search(
             '(^__i|[^_]_$)', option['api_name']) is not None
@@ -489,8 +515,17 @@ def create_generic(top_env, declarations):
         option['method_prefix_derived'] = '' if broadcast_arg is None else 's_'
         env = nested_dict(option, top_env)
 
+        mode = option['mode']
         abstract = True
-        if broadcast_arg is None:
+        if mode == 'NN' and option.get('cimpls') is None:
+            abstract = False
+            top_env['type_method_declarations'].append(
+                TYPE_METHOD_DECLARATION_CONCRETE.substitute(env))
+            body = emit_nn_body(option)
+            top_env['type_method_definitions'].append(
+                TYPE_METHOD_DEFINITION_CONCRETE.substitute(
+                    env, type_definition_body=body))
+        elif broadcast_arg is None:
             top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION_ABSTRACT.substitute(env))
             top_env['type_method_definitions'].append(
@@ -542,7 +577,7 @@ def create_generic(top_env, declarations):
             ('method_prefix_derived', option['method_prefix_derived']),
             ('arguments', formals),
             ('method_of', method_of),
-            ('mode', option['mode']),
+            ('mode', mode),
             ('buffers', buffer_names),
             ('returns', option['returns']),
             ('inplace', option['inplace']),
@@ -678,8 +713,10 @@ def create_generic(top_env, declarations):
                 TYPE_METHOD_DEFINITION_ABSTRACT.substitute(env))
         else:
             abstract = False
+            body = TYPE_DEFINITION_BODY_NATIVE.substitute(env)
             top_env['type_method_definitions'].append(
-                TYPE_METHOD_DEFINITION_CONCRETE.substitute(env))
+                TYPE_METHOD_DEFINITION_CONCRETE.substitute(
+                    env, type_definition_body=body))
 
         # generate the at::native function declarations (i.e. what the user will implement)
         if isinstance(dispatch, dict):
@@ -837,12 +874,6 @@ def create_derived(backend_type_env, declarations):
                           for arg in option['formals_list']]
         return [SPARSE_CHECK.substitute(env, check_name=check_name, sparse_actuals=sparse_actuals)]
 
-    def handle_buffers(env, option):
-        if 'buffers' not in option:
-            return []
-        return [BUFFER_DEFINITION.substitute(env, name=b['name'])
-                for b in option['buffers']]
-
     def allocate_arg(env, arg, output_count):
         name = arg['name']
         allocation = CodeTemplate(ALLOC_WRAP[arg['type']]).substitute(env, arguments=[])
@@ -896,7 +927,6 @@ def create_derived(backend_type_env, declarations):
             body += only_zero_dim_check
             return body
 
-        body += handle_buffers(env, option)
         # arguments are potentially duplicated because of one argument
         # referencing another
         seen_names = set()
@@ -1103,6 +1133,8 @@ def create_derived(backend_type_env, declarations):
         for option in declaration['options']:
             if not option.get('skip', False):
                 try:
+                    if option['mode'] == 'NN' and option.get('cimpls') is None:
+                        continue
                     if option['mode'] != 'native':
                         process_option(option)
                     else:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -138,7 +138,7 @@
 - name: cat(TensorList tensors, int64_t dim)
   tensors: cat_tensors_backward(grad, to_arg_sizes(tensors, dim), dim)
 
-- name: cauchy(Tensor self, double median, double sigma, Generator generator)
+- name: cauchy_(Tensor self, double median, double sigma, Generator generator)
   self: zeros_like(grad)
 
 - name: ceil(Tensor self)
@@ -225,12 +225,12 @@
 - name: expand(Tensor self, IntList size)
   self: reduce_to(grad, self.sizes())
 
-- name: exponential(Tensor self, double lambd, Generator generator)
+- name: exponential_(Tensor self, double lambd, Generator generator)
   self: zeros_like(grad)
 
 # eye
 
-- name: fill(Tensor self, Scalar value)
+- name: fill_(Tensor self, Scalar value)
   self: zeros_like(grad)
 
 - name: floor(Tensor self)
@@ -260,7 +260,7 @@
   self: not_implemented("gels")
   A: not_implemented("gels")
 
-- name: geometric(Tensor self, double p, Generator generator)
+- name: geometric_(Tensor self, double p, Generator generator)
   self: zeros_like(grad)
 
 - name: geqrf(Tensor self)
@@ -286,15 +286,15 @@
 - name: histc(Tensor self, int64_t bins, Scalar min, Scalar max)
   self: not_implemented("histc")
 
-- name: index_add(Tensor self, int64_t dim, Tensor index, Tensor source)
+- name: index_add_(Tensor self, int64_t dim, Tensor index, Tensor source)
   self: grad
   source: grad.index_select(dim, index)
 
-- name: index_copy(Tensor self, int64_t dim, Tensor index, Tensor source)
+- name: index_copy_(Tensor self, int64_t dim, Tensor index, Tensor source)
   self: grad.clone().index_fill_(dim, index, 0)
   source: grad.index_select(dim, index)
 
-- name: index_fill(Tensor self, int64_t dim, Tensor index, Scalar value)
+- name: index_fill_(Tensor self, int64_t dim, Tensor index, Scalar value)
   self: grad.clone().index_fill_(dim, index, 0)
 
 - name: index_select(Tensor self, int64_t dim, Tensor index)
@@ -339,7 +339,7 @@
 - name: log1p(Tensor self)
   self: grad / (self + 1)
 
-- name: log_normal(Tensor self, double mean, double std, Generator generator)
+- name: log_normal_(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
 
 # logspace
@@ -351,10 +351,10 @@
   self: zeros_like(self)
   other: zeros_like(other)
 
-- name: masked_fill(Tensor self, Tensor mask, Scalar value)
+- name: masked_fill_(Tensor self, Tensor mask, Scalar value)
   self: grad.clone().masked_fill_(mask, 0)
 
-- name: masked_scatter(Tensor self, Tensor mask, Tensor source)
+- name: masked_scatter_(Tensor self, Tensor mask, Tensor source)
   self: grad.clone().masked_fill_(mask, 0)
   source: masked_scatter_backward(grad, mask, source.sizes())
 
@@ -433,7 +433,7 @@
 - name: norm(Tensor self, Scalar p, int64_t dim, bool keepdim)
   self: norm_backward(grad, self, p, destination, dim, keepdim)
 
-- name: normal(Tensor self, double mean, double std, Generator generator)
+- name: normal_(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
 
 - name: normal(Tensor mean, double std, Generator generator)
@@ -487,7 +487,7 @@
 - name: pstrf(Tensor self, bool upper, Scalar tol)
   self: not_implemented("pstrf")
 
-- name: put(Tensor self, Tensor index, Tensor source, bool accumulate)
+- name: put_(Tensor self, Tensor index, Tensor source, bool accumulate)
   self: grad.clone().put_(index, zeros_like(source), accumulate)
   source: grad.take(index)
 
@@ -497,13 +497,13 @@
 # rand
 # randn
 
-- name: random(Tensor self, int64_t from, int64_t to, Generator generator)
+- name: random_(Tensor self, int64_t from, int64_t to, Generator generator)
   self: zeros_like(grad)
 
-- name: random(Tensor self, int64_t to, Generator generator)
+- name: random_(Tensor self, int64_t to, Generator generator)
   self: zeros_like(grad)
 
-- name: random(Tensor self, Generator generator)
+- name: random_(Tensor self, Generator generator)
   self: zeros_like(grad)
 
 # randperm
@@ -530,14 +530,14 @@
 - name: rsqrt(Tensor self)
   self: -0.5 * grad * result.pow(3)
 
-- name: scatter(Tensor self, int64_t dim, Tensor index, Tensor src)
+- name: scatter_(Tensor self, int64_t dim, Tensor index, Tensor src)
   self: grad.clone().scatter_(dim, index, 0)
   src: grad.gather(dim, index)
 
-- name: scatter(Tensor self, int64_t dim, Tensor index, Scalar value)
+- name: scatter_(Tensor self, int64_t dim, Tensor index, Scalar value)
   self: grad.clone().scatter_(dim, index, 0)
 
-- name: scatter_add(Tensor self, int64_t dim, Tensor index, Tensor src)
+- name: scatter_add_(Tensor self, int64_t dim, Tensor index, Tensor src)
   self: grad
   src: grad.gather(dim, index)
 
@@ -638,7 +638,7 @@
 - name: unfold(Tensor self, int64_t dimension, int64_t size, int64_t step)
   self: unfold_backward(grad, self.sizes(), dimension, size, step)
 
-- name: uniform(Tensor self, double from, double to, Generator generator)
+- name: uniform_(Tensor self, double from, double to, Generator generator)
   self: zeros_like(grad)
 
 - name: unsqueeze(Tensor self, int64_t dim)
@@ -658,7 +658,7 @@
   self: where(condition, grad, zeros_like(grad))
   other: where(condition, zeros_like(grad), grad)
 
-- name: zero(Tensor self)
+- name: zero_(Tensor self)
   self: zeros_like(grad)
 
 # zeros
@@ -674,163 +674,163 @@
 
 # NN
 
-- name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight, bool size_average, bool reduce)
+- name: binary_cross_entropy_forward(Tensor self, Tensor target, Tensor weight, bool size_average, bool reduce)
   self: binary_cross_entropy_backward(grad, self, target, weight, size_average, reduce)
 
 - name: embedding(Tensor weight, Tensor indices, int64_t padding_idx, bool scale_grad_by_freq, bool sparse)
   weight: embedding_backward(grad, indices, weight.size(0), padding_idx, scale_grad_by_freq, sparse)
 
-- name: embedding_renorm(Tensor self, Tensor indices, double max_norm, double norm_type)
+- name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   self: not_implemented("embedding_renorm")
 
-- name: kl_div(Tensor self, Tensor target, bool size_average, bool reduce)
+- name: kl_div_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: kl_div_backward(grad, self, target, size_average, reduce)
 
-- name: l1_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+- name: l1_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: l1_loss_backward(grad, self, target, size_average, reduce)
 
-- name: mse_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+- name: mse_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: mse_loss_backward(grad, self, target, size_average, reduce)
 
-- name: multi_margin_loss(Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, bool size_average)
+- name: multi_margin_loss_forward(Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, bool size_average)
   self: multi_margin_loss_backward(self, target, p, margin, weight, size_average).mul_(grad)
 
-- name: multilabel_margin_loss(Tensor self, Tensor target, bool size_average)
+- name: multilabel_margin_loss_forward(Tensor self, Tensor target, bool size_average)
   self: multilabel_margin_loss_backward(self, target, size_average, is_target).mul_(grad)
 
-- name: nll_loss(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
+- name: nll_loss_forward(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
   self: nll_loss_backward(grad, self, target, weight, size_average, ignore_index, reduce, total_weight)
 
-- name: nll_loss2d(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
+- name: nll_loss2d_forward(Tensor self, Tensor target, Tensor weight, bool size_average, int64_t ignore_index, bool reduce)
   self: nll_loss2d_backward(grad, self, target, weight, size_average, ignore_index, reduce, total_weight)
 
-- name: smooth_l1_loss(Tensor self, Tensor target, bool size_average, bool reduce)
+- name: smooth_l1_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: smooth_l1_loss_backward(grad, self, target, size_average, reduce)
 
-- name: soft_margin_loss(Tensor self, Tensor target, bool size_average)
+- name: soft_margin_loss_forward(Tensor self, Tensor target, bool size_average)
   self: soft_margin_loss_backward(self, target, size_average).mul_(grad)
 
-- name: elu(Tensor self, Scalar alpha, Scalar scale)
+- name: elu_forward(Tensor self, Scalar alpha, Scalar scale)
   self: elu_backward(grad, alpha, scale, output)
 
-- name: elu_(Tensor self, Scalar alpha, Scalar scale)
-  self: elu_backward(grad, alpha, scale, output)
+# - name: elu_forward_(Tensor self, Scalar alpha, Scalar scale)
+#   self: elu_backward(grad, alpha, scale, output)
 
-- name: glu(Tensor self, int64_t dim)
+- name: glu_forward(Tensor self, int64_t dim)
   self: glu_backward(grad, self, dim)
 
-- name: hardshrink(Tensor self, Scalar lambd)
+- name: hardshrink_forward(Tensor self, Scalar lambd)
   self: hardshrink_backward(grad, self, lambd)
 
-- name: hardtanh(Tensor self, Scalar min_val, Scalar max_val)
+- name: hardtanh_forward(Tensor self, Scalar min_val, Scalar max_val)
+  self: hardtanh_backward(grad, self, min_val, max_val)
+
+- name: hardtanh_forward_(Tensor self, Scalar min_val, Scalar max_val)
   self: hardtanh_backward(grad, output, min_val, max_val)
 
-- name: hardtanh_(Tensor self, Scalar min_val, Scalar max_val)
-  self: hardtanh_backward(grad, output, min_val, max_val)
+- name: leaky_relu_forward(Tensor self, Scalar negative_slope)
+  self: leaky_relu_backward(grad, self, negative_slope)
 
-- name: leaky_relu(Tensor self, Scalar negative_slope)
+- name: leaky_relu_forward_(Tensor self, Scalar negative_slope)
   self: leaky_relu_backward(grad, output, negative_slope)
 
-- name: leaky_relu_(Tensor self, Scalar negative_slope)
-  self: leaky_relu_backward(grad, output, negative_slope)
-
-- name: log_sigmoid(Tensor self)
+- name: log_sigmoid_forward(Tensor self)
   self: log_sigmoid_backward(grad, self, buffer)
 
-- name: log_softmax(Tensor self, int64_t dim)
+- name: log_softmax_forward(Tensor self, int64_t dim)
   self: log_softmax_backward(grad, self, dim, output)
 
-- name: prelu(Tensor self, Tensor weight)
+- name: prelu_forward(Tensor self, Tensor weight)
   self, weight: prelu_backward(grad, self, weight, grad_input_mask)
 
-- name: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
+- name: rrelu_with_noise_forward(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
+  self: rrelu_with_noise_backward(grad, self, noise, lower, upper, training)
+
+- name: rrelu_with_noise_forward_(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
   self: rrelu_with_noise_backward(grad, output, noise, lower, upper, training)
 
-- name: rrelu_with_noise_(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator)
-  self: rrelu_with_noise_backward(grad, output, noise, lower, upper, training)
-
-- name: softmax(Tensor self, int64_t dim)
+- name: softmax_forward(Tensor self, int64_t dim)
   self: softmax_backward(grad, self, dim, output)
 
-- name: softplus(Tensor self, Scalar beta, Scalar threshold)
+- name: softplus_forward(Tensor self, Scalar beta, Scalar threshold)
   self: softplus_backward(grad, self, beta, threshold, output)
 
-- name: softshrink(Tensor self, Scalar lambd)
+- name: softshrink_forward(Tensor self, Scalar lambd)
   self: softshrink_backward(grad, self, lambd)
 
-- name: threshold(Tensor self, Scalar threshold, Scalar value)
+- name: threshold_forward(Tensor self, Scalar threshold, Scalar value)
   self: threshold_backward(grad, self, threshold, value)
 
-- name: threshold_(Tensor self, Scalar threshold, Scalar value)
+- name: threshold_forward_(Tensor self, Scalar threshold, Scalar value)
   self: threshold_backward(grad, output, threshold, value)
 
-- name: reflection_pad1d(Tensor self, IntList padding)
+- name: reflection_pad1d_forward(Tensor self, IntList padding)
   self: reflection_pad1d_backward(grad, self, padding)
 
-- name: reflection_pad2d(Tensor self, IntList padding)
+- name: reflection_pad2d_forward(Tensor self, IntList padding)
   self: reflection_pad2d_backward(grad, self, padding)
 
-- name: replication_pad1d(Tensor self, IntList padding)
+- name: replication_pad1d_forward(Tensor self, IntList padding)
   self: replication_pad1d_backward(grad, self, padding)
 
-- name: replication_pad2d(Tensor self, IntList padding)
+- name: replication_pad2d_forward(Tensor self, IntList padding)
   self: replication_pad2d_backward(grad, self, padding)
 
-- name: replication_pad3d(Tensor self, IntList padding)
+- name: replication_pad3d_forward(Tensor self, IntList padding)
   self: replication_pad3d_backward(grad, self, padding)
 
-- name: upsample_linear1d(Tensor self, IntList output_size)
+- name: upsample_linear1d_forward(Tensor self, IntList output_size)
   self: upsample_linear1d_backward(grad, output_size, self.sizes())
 
-- name: upsample_bilinear2d(Tensor self, IntList output_size)
+- name: upsample_bilinear2d_forward(Tensor self, IntList output_size)
   self: upsample_bilinear2d_backward(grad, output_size, self.sizes())
 
-- name: upsample_trilinear3d(Tensor self, IntList output_size)
+- name: upsample_trilinear3d_forward(Tensor self, IntList output_size)
   self: upsample_trilinear3d_backward(grad, output_size, self.sizes())
 
-- name: upsample_nearest1d(Tensor self, int64_t scale_factor)
+- name: upsample_nearest1d_forward(Tensor self, int64_t scale_factor)
   self: upsample_nearest1d_backward(grad, self, scale_factor)
 
-- name: upsample_nearest2d(Tensor self, int64_t scale_factor)
+- name: upsample_nearest2d_forward(Tensor self, int64_t scale_factor)
   self: upsample_nearest2d_backward(grad, self, scale_factor)
 
-- name: upsample_nearest3d(Tensor self, int64_t scale_factor)
+- name: upsample_nearest3d_forward(Tensor self, int64_t scale_factor)
   self: upsample_nearest3d_backward(grad, self, scale_factor)
 
-- name: adaptive_avg_pool2d(Tensor self, IntList output_size)
+- name: adaptive_avg_pool2d_forward(Tensor self, IntList output_size)
   self: adaptive_avg_pool2d_backward(grad, self)
 
-- name: adaptive_avg_pool3d(Tensor self, IntList output_size)
+- name: adaptive_avg_pool3d_forward(Tensor self, IntList output_size)
   self: adaptive_avg_pool3d_backward(grad, self)
 
-- name: adaptive_max_pool2d(Tensor self, IntList output_size)
+- name: adaptive_max_pool2d_forward(Tensor self, IntList output_size)
   self: adaptive_max_pool2d_backward(grad, self, indices)
 
-- name: adaptive_max_pool3d(Tensor self, IntList output_size)
+- name: adaptive_max_pool3d_forward(Tensor self, IntList output_size)
   self: adaptive_max_pool3d_backward(grad, self, indices)
 
-- name: avg_pool2d(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
+- name: avg_pool2d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
   self: avg_pool2d_backward(grad, self, kernel_size, stride, padding, ceil_mode, count_include_pad)
 
-- name: avg_pool3d(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
+- name: avg_pool3d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, bool ceil_mode, bool count_include_pad)
   self: avg_pool3d_backward(grad, self, kernel_size, stride, padding, ceil_mode, count_include_pad)
 
-- name: fractional_max_pool2d(Tensor self, IntList kernel_size, IntList output_size, Tensor random_samples)
+- name: fractional_max_pool2d_forward(Tensor self, IntList kernel_size, IntList output_size, Tensor random_samples)
   self: fractional_max_pool2d_backward(grad, self, kernel_size, output_size, indices)
 
-- name: max_pool2d(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+- name: max_pool2d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
   self: max_pool2d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
 
-- name: max_pool3d(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
+- name: max_pool3d_forward(Tensor self, IntList kernel_size, IntList stride, IntList padding, IntList dilation, bool ceil_mode)
   self: max_pool3d_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
 
-- name: max_unpool2d(Tensor self, Tensor indices, IntList output_size)
+- name: max_unpool2d_forward(Tensor self, Tensor indices, IntList output_size)
   self: max_unpool2d_backward(grad, self, indices, output_size)
 
-- name: max_unpool3d(Tensor self, Tensor indices, IntList output_size, IntList stride, IntList padding)
+- name: max_unpool3d_forward(Tensor self, Tensor indices, IntList output_size, IntList stride, IntList padding)
   self: max_unpool3d_backward(grad, self, indices, output_size, stride, padding)
 
-- name: thnn_batch_norm(Tensor self, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double momentum, double eps)
+- name: thnn_batch_norm_forward(Tensor self, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double momentum, double eps)
   self, weight, bias: thnn_batch_norm_backward(grad.contiguous(), self, weight, running_mean, running_var, training, eps, save_mean, save_std, grad_input_mask)
 
 - name: thnn_batch_norm_backward(Tensor grad_output, Tensor self, Tensor weight, Tensor running_mean, Tensor running_var, bool training, double eps, Tensor save_mean, Tensor save_std, std::array<bool,3> output_mask)
@@ -838,44 +838,44 @@
   save_mean: not_implemented("thnn_batch_norm_backward save_mean")
   save_std: not_implemented("thnn_batch_norm_backward save_std")
 
-- name: thnn_conv_transpose2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+- name: thnn_conv_transpose2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
   self, weight, bias: thnn_conv_transpose2d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, columns, ones, grad_input_mask)
 
 - name: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv_transpose3d(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+- name: thnn_conv_transpose3d_forward(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
   self, weight, bias: thnn_conv_transpose3d_backward(grad, self, weight, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
 
 - name: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+- name: thnn_conv2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
   self, weight, bias: thnn_conv2d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
 
 - name: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, {{1, 1}}, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv_depthwise2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+- name: thnn_conv_depthwise2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
   self, weight: thnn_conv_depthwise2d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
   bias: grad.contiguous().view({grad.size(0), grad.size(1), -1}).sum(0).sum(1)
 
 - name: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, std::array<bool,2> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
+- name: thnn_conv3d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
   self, weight, bias: thnn_conv3d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)
 
 - name: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, {{1, 1, 1}}, false, {{0, 0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv_dilated2d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+- name: thnn_conv_dilated2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
   self, weight, bias: thnn_conv_dilated2d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
 
 - name: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv_dilated3d(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
+- name: thnn_conv_dilated3d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList dilation)
   self, weight, bias: thnn_conv_dilated3d_backward(grad, self, weight, kernel_size, stride, padding, dilation, columns, ones, grad_input_mask)
 
 - name: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -9,6 +9,10 @@
 #     formula for multiple input names, by specifying a key
 #     "input1, input2" (see atan2 for an example).
 #
+# If a function has out-of-place and in-place variants, then the derivative
+# definition for the in-place variant is optional. It will default to the
+# definition for the out-of-place variant.
+#
 # Gradient expressions are standard C++ expressions operating on ATen
 # variables.  In a gradient expression, the following variables are in
 # scope:
@@ -38,12 +42,6 @@
 # derivative formula for every input, including inputs named things
 # like 'grad_output', and (2) the gradient to multiply with is always
 # called 'grad' (even though it really is a grad-grad).
-#
-# LOOKING FOR AN THNN DEFINITION?  These are implicitly defined by
-# preprocess_nn_functions, because THNN functions follow a specific
-# convention; thus, you don't have to explicitly write it down in
-# derivatives.yaml (in fact, you MUST NOT write it down, because then
-# you'll have two derivative definitions!)
 #
 # NB: There are a number of gradient definitions in here which are bogus
 # (implemented using zeros_like).  These gradients are (hopefully) not

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -11,24 +11,32 @@ from .utils import YamlLoader
 from .gen_variable_type import IDENT_REGEX, split_name_params
 
 
-def load_derivatives(path, declarations_by_signature, declarations_by_name):
+def load_derivatives(path, declarations):
     with open(path, 'r') as f:
         definitions = yaml.load(f, Loader=YamlLoader)
 
+    declarations_by_signature = defaultdict(list)
+    for declaration in declarations:
+        declarations_by_signature[get_signature(declaration)].append(declaration)
+
     autograd_functions = [
-        process_definition(defn, declarations_by_signature, declarations_by_name)
+        process_definition(defn, declarations_by_signature)
         for defn in definitions]
     ensure_unique_names(autograd_functions)
+    match_declarations_with_autograd_functions(declarations, autograd_functions)
+
     return autograd_functions
 
 
-def create_autograd_function(name, derivatives, num_inputs, buffers=None):
+def create_autograd_function(name, derivatives, num_inputs, signature):
+    op = to_camel_case(name) + 'Backward'
+    op = op.replace('ForwardBackward', 'Backward')
     return {
         'name': name,
-        'op': to_camel_case(name) + 'Backward',
+        'op': op,
         'num_inputs': num_inputs,
+        'signature': signature,
         'derivatives': derivatives,
-        'buffers': [] if buffers is None else buffers,
         'saved_inputs': all_saved_variables(derivatives, 'saved_inputs'),
         'saved_outputs': all_saved_variables(derivatives, 'saved_outputs'),
     }
@@ -57,7 +65,7 @@ def create_derivative(declaration, formula, output_indices, var_names):
     }
 
 
-def process_definition(defn, declarations_by_signature, declarations_by_name):
+def process_definition(defn, declarations_by_signature):
     """Processes a single entry `defn` in derivatives.yaml"""
 
     def canonical_declaration(declarations, name):
@@ -115,40 +123,6 @@ def process_definition(defn, declarations_by_signature, declarations_by_name):
 
         return derivatives, num_inputs
 
-    def is_nn_fwd(defn_name, declarations_by_name):
-        """Return True if the definition is of an NN, non-double
-           backward function, False otherwise"""
-
-        if len(declarations_by_name[defn_name]) == 0:
-            return False
-        declaration = declarations_by_name[defn_name][0]
-        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
-        fwd_name = base_name + '_forward'
-        if declaration['mode'] != 'NN' or fwd_name not in declarations_by_name:
-            return False
-        return True
-
-    def preprocess_nn_function(defn_name, declarations_by_name):
-        """Set up declaration and derivative information for NN,
-           non-double backward functions"""
-
-        declaration = declarations_by_name[defn_name][0]
-        base_name = defn_name if not declaration['inplace'] else defn_name[:-1]
-        fwd_name = base_name + ('_forward' if not declaration['inplace'] else '_forward_')
-
-        assert len(declarations_by_name[fwd_name]) == 1
-
-        declaration['base_name'] = fwd_name
-        fwd = declarations_by_name[fwd_name][0]
-
-        derivatives, num_inputs = set_up_derivatives(defn, fwd)
-        buffers = declaration['buffers']
-
-        func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
-        declaration['derivative'] = func
-
-        return func
-
     def unzip(xs):
         return zip(*xs)
 
@@ -161,9 +135,6 @@ def process_definition(defn, declarations_by_signature, declarations_by_name):
                            "Please use a different name in Declarations.cwrap."
                            .format(defn_name))
     signature = '{}({})'.format(defn_name, ', '.join(param_types))
-
-    if is_nn_fwd(defn_name, declarations_by_name):
-        return preprocess_nn_function(defn_name, declarations_by_name)
 
     declarations = declarations_by_signature[signature]
     if len(declarations) == 0:
@@ -190,12 +161,7 @@ def process_definition(defn, declarations_by_signature, declarations_by_name):
                                .format(i, defn_name, x, y))
 
     derivatives, num_inputs = set_up_derivatives(defn, canonical)
-    buffers = canonical.get('buffers')
-
-    func = create_autograd_function(defn_name, derivatives, num_inputs, buffers)
-    for declaration in declarations:
-        declaration['derivative'] = func
-    return func
+    return create_autograd_function(defn_name, derivatives, num_inputs, signature)
 
 
 def ensure_unique_names(autograd_functions):
@@ -212,6 +178,15 @@ def ensure_unique_names(autograd_functions):
         if len(overloads) > 1:
             for i, func in enumerate(overloads):
                 func['op'] += str(i)
+
+
+def get_signature(declaration, ignore_inplace=False):
+    name = declaration['name']
+    if ignore_inplace and declaration['inplace']:
+        assert name.endswith('_')
+        name = name[:-1]
+    simple_types = [arg['simple_type'] for arg in declaration['arguments']]
+    return '{}({})'.format(name, ', '.join(simple_types))
 
 
 def saved_variables(formula, args):
@@ -296,3 +271,25 @@ def all_saved_variables(derivatives, key):
 
 def to_camel_case(name):
     return ''.join([p.title() for p in name.split('_')])
+
+
+def match_declarations_with_autograd_functions(declarations, autograd_functions):
+    """Sets the "derivative" key on declarations to matching autograd functions
+
+    In-place functions wil use the out-of-place derivative definition if there
+    is no in-place specific derivative.
+    """
+
+    functions_by_signature = {f['signature']: f for f in autograd_functions}
+
+    def find_function(declaration):
+        signature = get_signature(declaration)
+        if signature in functions_by_signature:
+            return functions_by_signature[signature]
+
+        # if there is no exact match look for the out-of-place signature
+        signature = get_signature(declaration, ignore_inplace=True)
+        return functions_by_signature.get(signature)
+
+    for declaration in declarations:
+        declaration['derivative'] = find_function(declaration)

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -276,7 +276,7 @@ def to_camel_case(name):
 def match_declarations_with_autograd_functions(declarations, autograd_functions):
     """Sets the "derivative" key on declarations to matching autograd functions
 
-    In-place functions wil use the out-of-place derivative definition if there
+    In-place functions will use the out-of-place derivative definition if there
     is no in-place specific derivative.
     """
 


### PR DESCRIPTION
This modifies NN binding in ATen so that the xxx_forward functions now
return buffers instead of taking them as inputs. The NN functions with
no suffix are implemented in Type.cpp. They call the xxx_forward
variants and discard any returned buffers.

This simplifies derivatives for NN functions. The derivatives are now
defined on the xxx_forward functions and buffers are treated as any
other input.