### PR TITLE
[ATen] Get rid of assign_(Tensor), use copy_ instead.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3992,17 +3992,6 @@
 ]]
 
 [[
-  name: assign_
-  cname: copy
-  cpu_half: True
-  aten_sparse: True
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* src
-]]
-
-[[
   name: _copy_ignoring_overlaps_
   cname: copyIgnoringOverlaps
   return: self

--- a/aten/src/ATen/native/ConvolutionTBC.cpp
+++ b/aten/src/ATen/native/ConvolutionTBC.cpp
@@ -46,7 +46,7 @@ std::tuple<Tensor, Tensor, Tensor> conv_tbc_backward(const Tensor& dOutput, cons
 
   Tensor dBias = zeros_like(bias); 
   auto tmp = dOutput.sum(0, false);
-  dBias.assign_(tmp.sum(0));
+  dBias.copy_(tmp.sum(0));
 
   return std::make_tuple(dInput, dWeight, dBias);
 }

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -52,9 +52,7 @@ struct Tensor : public detail::TensorBase {
       return *this;
   }
 
-  Tensor & operator=(Tensor const & rhs) && {
-    return assign_(rhs);
-  }
+  inline Tensor & operator=(Tensor const & rhs) &&;
   Tensor & operator=(Scalar v) &&;
   Tensor & assign_(Scalar v);
   const char * toString() const {
@@ -117,8 +115,7 @@ struct Tensor : public detail::TensorBase {
   Tensor operator[](int64_t idx) const;
 
   // STOP.  Thinking of adding a method here, which only makes use
-  // of other ATen methods?  Define it in ATen/NativeFunctions.h
-  // instead.
+  // of other ATen methods?  Define it in native_functions.yaml.
 
   //example
   //Tensor * add(Tensor & b);

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -6,6 +6,10 @@
 
 namespace at {
 
+inline Tensor & Tensor::operator=(Tensor const & rhs) && {
+  return copy_(rhs);
+}
+
 inline Tensor Tensor::toType(const Type & t) const {
   if(type() == t)
     return *this;

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -239,21 +239,6 @@ int main() {
             assert_equal_size_dim(lhs, rhs);
           }
         }
-
-        // copy_
-        {
-          auto lhs = T.ones(*lhs_it);
-          auto lhs_save = T.ones(*lhs_it);
-          auto rhs = T.ones(*rhs_it);
-          try {
-            lhs.copy_(rhs);
-            ASSERT(lhs_save.numel() == rhs.numel());
-            // ensure didn't change shape
-            assert_equal_size_dim(lhs, lhs_save);
-          } catch (std::runtime_error &e) {
-            ASSERT(lhs_save.numel() != rhs.numel());
-          }
-        }
       }
 
       // view

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -240,13 +240,13 @@ int main() {
           }
         }
 
-        // assign_
+        // copy_
         {
           auto lhs = T.ones(*lhs_it);
           auto lhs_save = T.ones(*lhs_it);
           auto rhs = T.ones(*rhs_it);
           try {
-            lhs.assign_(rhs);
+            lhs.copy_(rhs);
             ASSERT(lhs_save.numel() == rhs.numel());
             // ensure didn't change shape
             assert_equal_size_dim(lhs, lhs_save);


### PR DESCRIPTION
Note: assign_(Scalar) still exists.