### PR TITLE
Add a lookup method with auto padding for nn.Embedding

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -103,6 +103,20 @@ class Embedding(Module):
             self.scale_grad_by_freq, self.sparse
         )
 
+    def lookup_with_autopadding(self, lookup_ids):
+        if not (type(lookup_ids) is list and type(lookup_ids[0] is list)):
+            raise  ValueError("lookup_ids should be a list of list")
+        if self.padding_idx is None:
+            raise ValueError("padding_idx should not be None")
+        lengths = [len(item) for item in lookup_ids]
+        max_length = max(lengths)
+        for i, item in enumerate(lookup_ids):
+            item += [self.padding_idx for _ in range(max_length - lengths[i])]
+        lookup_ids = Variable(torch.LongTensor(lookup_ids))
+        lengths = Variable(torch.LongTensor(lengths))
+        sorted_len, indices = torch.sort(lengths, 0, descending=True)
+        return self(lookup_ids), self(lookup_ids)[indices], sorted_len
+
     def __repr__(self):
         s = '{name}({num_embeddings}, {embedding_dim}'
         if self.padding_idx is not None:


### PR DESCRIPTION
When we use RNN for sequence models, we usually need to pad the item in the batch to a same length. In this PR, I add a method for nn.Embedding, which can make a lookup operation with auto padding. It looks like this:
```
embed = nn.Embedding(11, 4, padding_idx=10)
ids = [[2, 3, 4], [2, 3]]
embeddings, sorted_embeddings, sorted_len = embed.lookup_with_autopadding(ids)

print(embeddings)
# Variable containing:
# (0 ,.,.) = 
#  -1.0276 -0.5631 -0.8923 -0.0583
#  -0.1955 -0.9656  0.4224  0.2673
#  -0.4212 -0.5107 -1.5727 -0.1232
# 
# (1 ,.,.) = 
#  -1.0276 -0.5631 -0.8923 -0.0583
#  -0.1955 -0.9656  0.4224  0.2673
#   0.0000  0.0000  0.0000  0.0000
# [torch.FloatTensor of size 2x3x4]

print(sorted_embeddings)
# Variable containing:
# (0 ,.,.) = 
#  -1.0276 -0.5631 -0.8923 -0.0583
#  -0.1955 -0.9656  0.4224  0.2673
#  -0.4212 -0.5107 -1.5727 -0.1232
# 
# (1 ,.,.) = 
#  -1.0276 -0.5631 -0.8923 -0.0583
#  -0.1955 -0.9656  0.4224  0.2673
#   0.0000  0.0000  0.0000  0.0000
# [torch.FloatTensor of size 2x3x4]

print(sorted_len)
# Variable containing:
#  3
#  2
# [torch.LongTensor of size 2]
```