### PR TITLE
Fix python gc race condition with THPVariable_traverse

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -372,32 +372,6 @@ class TestAutograd(TestCase):
         self.assertEqual(counter[0], 1, 'bw_hook not called')
         self.assertEqual(x.grad.data, torch.ones(5, 5) * 2)
 
-    @unittest.skipIf(sys.version_info[0] == 2, "Python 2 doesn't collect cycles involving __del__")
-    def test_hooks_cycle(self):
-        import gc
-        counter = [0]
-
-        class GradHook(object):
-            def __init__(self, var):
-                self.var = var
-
-            def __del__(self):
-                counter[0] += 1
-
-            def __call__(self, *args):
-                pass
-
-        def run_test():
-            x = Variable(torch.ones(5, 5), requires_grad=True)
-            y = x * 2
-            x.register_hook(GradHook(x))
-            y.register_hook(GradHook(y))
-            y._backward_hooks[1] = GradHook(y)
-
-        run_test()
-        gc.collect()
-        self.assertEqual(counter[0], 3)
-
     def test_hook_none(self):
         # WARNING: this is a test for autograd internals.
         # You should never have to use such things in your code.

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -67,25 +67,6 @@ static int THPVariable_traverse(THPVariable *self, visitproc visit, void *arg)
   Py_VISIT(self->data);
   Py_VISIT(self->backward_hooks);
   if (self->cdata.defined()) {
-    // Only visit this if we actually own it (no one else use the shared pointer)
-    auto& grad_fn = self->cdata.grad_fn();
-    if (grad_fn.use_count() == 1) {
-      if (auto fn = dynamic_cast<PyFunction*>(grad_fn.get())) {
-        Py_VISIT(fn->obj);
-      } else {
-        // visit hooks in C++ implemented autograd functions
-        for (auto& hook : grad_fn->pre_hooks) {
-          if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
-            Py_VISIT(pyhook->dict);
-          }
-        }
-        for (auto& hook : grad_fn->post_hooks) {
-          if (auto pyhook = dynamic_cast<PyFunctionPostHook*>(hook.get())) {
-            Py_VISIT(pyhook->dict);
-          }
-        }
-      }
-    }
     for (auto& hook : self->cdata.hooks()) {
       if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
         Py_VISIT(pyhook->dict);


### PR DESCRIPTION
Fixes #3883: asserts being triggered in DataParallel for long training regiments like imagenet.

The bug is that a python Function in the computation graph gets garbage collected due to a C++ shared pointer to the C++ Function it wraps changing `use_count()` from 1 to more than 1 during python garbage collection. This happens because the "python state" of Variable changes: the `THPVariable_traverse` method indicates that when the shared pointer's `use_count()` is 1, the python Variable holds a python reference to the python Function, but not when `use_count() > 1`. See this [gist](https://gist.github.com/zou3519/7ac92b84dd7d206dcc6eae55fee8372c) for a more detailed exploration of the diagnosis. 

The bug could be fixed by treating the shared pointer (a Variable's `grad_fn`) as part of the python state and intelligently grabbing the GIL when necessary. The downside to this approach is the complexity and potential overhead.

Alternatively, after talking with @colesbury, we think it might be better to remove the checking of the shared pointer's `use_count()` in `THPVariable_traverse`. This effectively disables reference cycle garbage collection for python Functions.