### PR TITLE
Two NNPACK build fixes.

### DIFF
--- a/aten/cmake/FindNNPACK.cmake
+++ b/aten/cmake/FindNNPACK.cmake
@@ -12,6 +12,7 @@
 #  NNPACK_LIBRARYRARY_DIRS
 
 include(FindPackageHandleStandardArgs)
+include(CheckSymbolExists)
 
 set(NNPACK_ROOT_DIR "" CACHE PATH "Folder contains NNPACK")
 
@@ -26,17 +27,31 @@ find_library(NNPACK_LIBRARY nnpack
     PATHS ${NNPACK_ROOT_DIR}
     PATH_SUFFIXES lib lib64)
 
+find_library(CPUINFO_LIBRARY cpuinfo
+    PATHS ${NNPACK_ROOT_DIR}
+    PATH_SUFFIXES lib lib64)
+
 find_library(PTHREADPOOL_LIBRARY pthreadpool
     PATHS ${NNPACK_ROOT_DIR}
     PATH_SUFFIXES lib lib64)
 
-find_package_handle_standard_args(NNPACK DEFAULT_MSG NNPACK_INCLUDE_DIR NNPACK_LIBRARY PTHREADPOOL_LIBRARY)
+find_package_handle_standard_args(NNPACK DEFAULT_MSG NNPACK_INCLUDE_DIR NNPACK_LIBRARY CPUINFO_LIBRARY PTHREADPOOL_LIBRARY)
 
 if(NNPACK_FOUND)
   set(NNPACK_INCLUDE_DIRS ${NNPACK_INCLUDE_DIR})
-  set(NNPACK_LIBRARIES ${NNPACK_LIBRARY} ${PTHREADPOOL_LIBRARY})
-  message(STATUS "Found NNPACK    (include: ${NNPACK_INCLUDE_DIR}, library: ${NNPACK_LIBRARY})")
-  message(STATUS "Found PTHREADPOOL (library: ${PTHREADPOOL_LIBRARY})")
-  mark_as_advanced(NNPACK_ROOT_DIR NNPACK_LIBRARY_RELEASE NNPACK_LIBRARY_DEBUG
-                                 NNPACK_LIBRARY NNPACK_INCLUDE_DIR)
+  set(NNPACK_LIBRARIES ${NNPACK_LIBRARY} ${CPUINFO_LIBRARY} ${PTHREADPOOL_LIBRARY})
+
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${NNPACK_LIBRARIES})
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${NNPACK_INCLUDE_DIRS})
+  check_symbol_exists(nnp_convolution_kernel_gradient "nnpack.h" NNPACK_HAS_INFERENCE)
+
+  if(NNPACK_HAS_INFERENCE)
+    message(STATUS "Found NNPACK      (include: ${NNPACK_INCLUDE_DIR}, library: ${NNPACK_LIBRARY})")
+    message(STATUS "Found CPUINFO     (library: ${CPUINFO_LIBRARY})")
+    message(STATUS "Found PTHREADPOOL (library: ${PTHREADPOOL_LIBRARY})")
+    mark_as_advanced(NNPACK_ROOT_DIR NNPACK_LIBRARY_RELEASE NNPACK_LIBRARY_DEBUG
+                                   NNPACK_LIBRARY NNPACK_INCLUDE_DIR)
+  else()
+    message(STATUS "Refusing to use incomplete NNPACK (include: ${NNPACK_INCLUDE_DIR}, library: ${NNPACK_LIBRARY}); try reinstalling NNPACK without --inference-only")
+  endif()
 endif()


### PR DESCRIPTION
1. master NNPACK now uses cpuinfo library, so we detect it and
add it to the list of libraries.

2. If a user builds nnpack with --inference-only, there won't
actually be enough symbols to successfully link against NNPACK.
This won't manifest until quite late in the build process.
So we now explicitly test that the gradient functions are
available in the library.

Upstream bug: https://github.com/Maratyszcza/NNPACK/issues/123

Fixes #4336

Signed-off-by: Edward Z. Yang <ezyang@fb.com>