### PR TITLE
Turn off unsupported multiprocessing methods for Windows

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -46,8 +46,11 @@ $PYCMD test_jit.py $@
 
 echo "Running multiprocessing tests"
 $PYCMD test_multiprocessing.py $@
-MULTIPROCESSING_METHOD=spawn $PYCMD test_multiprocessing.py $@
-MULTIPROCESSING_METHOD=forkserver $PYCMD test_multiprocessing.py $@
+# Turn off unsupported methods for Windows
+if [[ "$OSTYPE" != "msys" ]]; then
+  MULTIPROCESSING_METHOD=spawn $PYCMD test_multiprocessing.py $@
+  MULTIPROCESSING_METHOD=forkserver $PYCMD test_multiprocessing.py $@
+fi
 
 echo "Running util tests"
 $PYCMD test_utils.py $@


### PR DESCRIPTION
Following @peterjc123 's suggestion, this diff turns off unsupported multiprocessing methods for Windows. 

Test phase now takes ~15mins total (bottleneck is still at nn tests which takes 8mins to run, while it only takes 4.5mins in Linux).