### PR TITLE
Move broadcasting code to C++

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4034,11 +4034,16 @@
     - SparseCPU
     - SparseCUDA
   variants: [function]
-  cname: newWithTensorAndSize
-  arguments:
-    - THDenseIndexTensor* indices
-    - THDenseTensor* values
-    - THSize* size
+  options:
+    - cname: newWithTensor
+      arguments:
+        - THDenseIndexTensor* indices
+        - THDenseTensor* values
+    - cname: newWithTensorAndSize
+      arguments:
+        - THDenseIndexTensor* indices
+        - THDenseTensor* values
+        - THSize* size
 ]]
 
 # In theory, this could be a part of the above declaration. But in

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -25,9 +25,19 @@ Tensor & Type::copy_(Tensor & self, const Tensor & src, bool async) const {
 
 Tensor Type::copy(const Tensor & src, bool async) const {
   AT_ASSERT(src.defined(), "attempt to copy an undefined tensor");
-  Tensor r = this->tensor(src.sizes());
-  r.copy_(src, async);
-  return r;
+  if (is_sparse()) {
+    auto indices = src._indices();
+    auto values = src._values();
+    auto & this_dense = toBackend(is_cuda() ? Backend::CUDA : Backend::CPU);
+    auto & this_dense_idx = this_dense.toScalarType(ScalarType::Long);
+    auto indices_copy = this_dense_idx.copy(indices, async);
+    auto values_copy = this_dense.copy(values, async);
+    return sparse_coo_tensor(indices_copy, values_copy, src.sizes());
+  } else {
+    Tensor r = this->tensor(src.sizes());
+    r.copy_(src, async);
+    return r;
+  }
 }
 
 Type & Type::toBackend(Backend b) const {

--- a/setup.py
+++ b/setup.py
@@ -583,6 +583,7 @@ if WITH_NCCL:
     extra_compile_args += ['-DWITH_NCCL']
     main_sources += [
         "torch/csrc/cuda/nccl.cpp",
+        "torch/csrc/cuda/python_nccl.cpp",
     ]
 if WITH_CUDNN:
     main_libraries += ['cudnn']

--- a/setup.py
+++ b/setup.py
@@ -449,6 +449,7 @@ main_sources = [
     "torch/csrc/utils/tensor_types.cpp",
     "torch/csrc/utils/tuple_parser.cpp",
     "torch/csrc/utils/tensor_apply.cpp",
+    "torch/csrc/utils/tensor_flatten.cpp",
     "torch/csrc/allocators.cpp",
     "torch/csrc/serialization.cpp",
     "torch/csrc/jit/init.cpp",
@@ -569,6 +570,8 @@ if WITH_CUDA:
         "torch/csrc/cuda/Stream.cpp",
         "torch/csrc/cuda/AutoGPU.cpp",
         "torch/csrc/cuda/utils.cpp",
+        "torch/csrc/cuda/comm.cpp",
+        "torch/csrc/cuda/python_comm.cpp",
         "torch/csrc/cuda/expand_utils.cpp",
         "torch/csrc/cuda/serialization.cpp",
     ]

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -696,7 +696,7 @@ class TestCuda(TestCase):
         self._test_broadcast(torch.randn(5, 5))
 
     def test_broadcast_gpu(self):
-        self._test_broadcast(torch.randn(5, 5))
+        self._test_broadcast(torch.randn(5, 5).cuda())
 
     @staticmethod
     def _test_broadcast_coalesced(self, tensors, buffer_size):

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -817,6 +817,11 @@ bool THCPStream_init(PyObject *module);
 
 #ifdef WITH_CUDA
 PyMethodDef* THCPModule_methods();
+namespace torch { namespace cuda {
+
+void initModule(PyObject *module);
+
+}} // namespace torch::cuda
 #endif
 
 bool THCSPDoubleTensor_init(PyObject *module);
@@ -910,6 +915,9 @@ static PyObject* initModule() {
   torch::autograd::initAutogradClosureBindings(module);
   torch::jit::initJITBindings(module);
   torch::autograd::initNNFunctions(module);
+#ifdef WITH_CUDA
+  torch::cuda::initModule(module);
+#endif
   ASSERT_TRUE(THPDoubleStorage_init(module));
   ASSERT_TRUE(THPFloatStorage_init(module));
   ASSERT_TRUE(THPHalfStorage_init(module));

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -412,7 +412,7 @@ PyObject * THCPModule_initExtension(PyObject *self)
 }
 
 #ifdef WITH_NCCL
-#include "nccl.h"
+#include "python_nccl.h"
 
 void THCPModule_useNccl()
 {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -14,6 +14,7 @@
 #include "THCP.h"
 
 #include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/cuda/python_comm.h"
 #include "ModuleSparse.cpp"
 
 THCState *state;
@@ -476,3 +477,11 @@ static struct PyMethodDef _THCPModule_methods[] = {
 PyMethodDef* THCPModule_methods() {
   return _THCPModule_methods;
 }
+
+namespace torch { namespace cuda {
+
+void initModule(PyObject *module) {
+  python::initCommMethods(module);
+}
+
+}}

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -1,0 +1,105 @@
+#include "comm.h"
+
+#include "torch/csrc/utils/tensor_flatten.h"
+#include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/cuda/device_set.h"
+#ifdef WITH_NCCL
+#include "torch/csrc/cuda/nccl.h"
+#endif
+
+#include <ATen/ATen.h>
+
+namespace torch { namespace cuda {
+
+using namespace at;
+
+// Some operations can be performed more efficiently if we're handling tensors
+// of a single type only. Adding this logic directly in the loop makes it a bit
+// ugly, so here's a helper for it.
+struct unique_type_checker {
+  void show(const at::Type& t) {
+    if (!unique) return;
+    if (!type) type = &t;
+    unique = (type == &t);
+  }
+
+  const at::Type *type = nullptr;
+  bool unique = true;
+};
+
+std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
+  auto & type = tensor.type();
+  if (type.is_cuda() && tensor.get_device() != devices[0])
+    throw std::runtime_error("device of broadcasted tensor must appear as the "
+                             "first on devices list");
+  std::vector<Tensor> tensors;
+  tensors.reserve(devices.size());
+#ifdef WITH_NCCL
+  if (nccl::is_available({tensor})) {
+    tensors.push_back(tensor);
+    for (auto device : devices.slice(1)) {
+      AutoGPU _gpu_guard(device);
+      tensors.push_back(type.tensor(tensor.sizes()));
+    }
+    nccl::broadcast(tensors);
+  } else {
+#else
+  {
+#endif
+    auto & gpu_type = type.toBackend(type.is_sparse() ? at::kSparseCUDA : at::kCUDA);
+    for (auto device : devices) {
+      AutoGPU _gpu_guard(device);
+      tensors.push_back(gpu_type.copy(tensor, true));
+    }
+  }
+  return tensors;
+}
+
+tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, std::size_t buffer_size) {
+  if (!std::all_of(tensors.begin(), tensors.end(),
+                   [&](const at::Tensor& t) { return t.get_device() == devices[0]; })) {
+    throw std::runtime_error("all tensors must be on devices[0]");
+  }
+
+  tensor_list2d outputs(devices.size());
+  outputs[0] = tensors;
+  for (auto & o : outputs)
+    o.reserve(tensors.size());
+
+  unique_type_checker type_checker;
+  for (auto & chunk : utils::take_tensors(tensors, buffer_size)) {
+    auto & type = chunk.type();
+    type_checker.show(type);
+    std::vector<at::Tensor> results;
+    if (chunk.type().is_sparse()) {
+      auto flat_tuple = utils::flatten_sparse_tensors(chunk.tensors);
+      std::vector<at::Tensor> broadcast_indices = broadcast(flat_tuple.first, devices);
+      std::vector<at::Tensor> broadcast_values = broadcast(flat_tuple.second, devices);
+      results.reserve(devices.size());
+      for (std::size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
+        auto & device_outputs = outputs[i];
+        auto & inds = broadcast_indices[i];
+        auto & vals = broadcast_values[i];
+        for (auto & t : utils::unflatten_sparse_tensors(inds, vals, chunk.tensors))
+          device_outputs.push_back(std::move(t));
+      }
+    } else {
+      std::vector<Tensor> results = broadcast(utils::flatten_dense_tensors(chunk.tensors),
+                                              devices);
+      for (std::size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
+        auto & device_outputs = outputs[i];
+        for (auto & t : utils::unflatten_dense_tensors(results[i], chunk.tensors))
+          device_outputs.push_back(std::move(t));
+      }
+    }
+  }
+
+  // If we only saw a single tensor type, then we can skip expensive reordering
+  if (!type_checker.unique) {
+    for (auto & o : outputs)
+      utils::reorder_tensors_like(o, tensors);
+  }
+  return outputs;
+}
+
+}}

--- a/torch/csrc/cuda/comm.h
+++ b/torch/csrc/cuda/comm.h
@@ -1,0 +1,14 @@
+#include "torch/csrc/assertions.h"
+
+#include <ATen/ATen.h>
+#include <unordered_map>
+
+namespace torch { namespace cuda {
+
+using tensor_list2d = std::vector<std::vector<at::Tensor>>;
+
+std::vector<at::Tensor> broadcast(const at::Tensor& tensor, at::IntList devices);
+tensor_list2d broadcast_coalesced(at::TensorList tensors, at::IntList devices,
+                                  std::size_t buffer_size);
+
+}}

--- a/torch/csrc/cuda/device_set.h
+++ b/torch/csrc/cuda/device_set.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <bitset>
+
+namespace torch {
+
+static constexpr std::size_t MAX_CUDA_DEVICES = 64;
+using device_set = std::bitset<MAX_CUDA_DEVICES>;
+
+}

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -1,16 +1,19 @@
 #include "nccl.h"
-#include "torch/csrc/THP.h"
-#include "torch/csrc/Types.h"
-#include "torch/csrc/DynamicTypes.h"
-#include "torch/csrc/cuda/THCP.h"
+#include "torch/csrc/cuda/device_set.h"
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/utils/hash.h"
 
-#include <nccl.h>
-#include <sstream>
 #include <unordered_map>
+#include <sstream>
+#include <ATen/ATen.h>
+#include <THC/THC.h>
+
+namespace torch { namespace cuda { namespace nccl {
 
 using namespace at;
 
-static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
+namespace detail {
 
 static inline void CHECK(ncclResult_t status) {
   if (status != ncclSuccess) {
@@ -47,40 +50,36 @@ struct NcclCommList {
   }
 };
 
-struct AutoNcclGroup {
-  AutoNcclGroup() {
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-    CHECK(ncclGroupStart());
-#endif
-  }
-  ~AutoNcclGroup() {
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-    CHECK(ncclGroupEnd());
-#endif
-  }
-};
-
+using device_list = std::vector<int>;
 // accesses to this object have to be guarded by THC's CudaFreeMutex
-std::unordered_map<std::string, NcclCommList> _communicators;
+static std::unordered_map<device_list, NcclCommList, torch::hash<device_list>> _communicators;
 
-static ArrayRef<ncclComm_t> _get_communicators(TensorList inputs) {
-  std::stringstream hash_stream;
-  std::vector<int> devs;
-  for (auto& input : inputs) {
-    int dev = input.get_device();
-    hash_stream << dev << ",";
-    devs.push_back(dev);
+ArrayRef<ncclComm_t> _get_communicators(TensorList inputs) {
+  static auto get_device = [](const at::Tensor& t) -> int { return t.get_device(); };
+  device_list devices = fmap(inputs, get_device);
+  auto it = _communicators.find(devices);
+  if (it == _communicators.end())
+    std::tie(it, std::ignore) = _communicators.emplace(devices, devices);
+  return it->second.ref();
+}
+
+ncclDataType_t _get_data_type(const Type& type) {
+  if (type.backend() != kCUDA) {
+    throw std::runtime_error("Unconvertible NCCL type");
   }
-  std::string hash = hash_stream.str();
-  auto it = _communicators.find(hash);
-  if (it == _communicators.end()) {
-    return _communicators.emplace_hint(it, hash, devs)->second.ref();
-  } else {
-    return it->second.ref();
+  switch (type.scalarType()) {
+  case at::kFloat   : return ncclFloat;
+  case at::kHalf    : return ncclHalf;
+  case at::kDouble  : return ncclDouble;
+  case at::kLong    : return ncclInt64;
+  case at::kInt     : return ncclInt;
+  case at::kChar    : return ncclChar;
+  case at::kByte    : return ncclChar;
+  default: throw std::runtime_error("Unconvertible NCCL type");
   }
 }
 
-static void _check_inputs(TensorList inputs, TensorList outputs, int input_multiplier, int output_multiplier) {
+void _check_inputs(TensorList inputs, TensorList outputs, int input_multiplier, int output_multiplier) {
   // len(inputs) == len(outputs)
   size_t len = inputs.size();
 
@@ -94,8 +93,7 @@ static void _check_inputs(TensorList inputs, TensorList outputs, int input_multi
     throw std::runtime_error(err.str());
   }
 
-  std::unordered_set<int> devices;
-  devices.reserve(len);
+  device_set devices;
   int64_t numel = inputs[0].numel();
   auto& type = inputs[0].type();
 
@@ -118,10 +116,10 @@ static void _check_inputs(TensorList inputs, TensorList outputs, int input_multi
 
     auto input_device = input.get_device();
     // inputs must be on unique devices
-    if (devices.find(input_device) != devices.end()) {
+    if (devices.test(input_device)) {
       throw std::runtime_error("inputs must be on unique devices");
     }
-    devices.insert(input_device);
+    devices.set(input_device);
 
     // inputs and outputs must be on same device respectively
     if (input_device != output.get_device()) {
@@ -139,314 +137,58 @@ static void _check_inputs(TensorList inputs, TensorList outputs, int input_multi
   }
 }
 
-static ncclDataType_t _get_data_type(const Type& type) {
-  if (type.backend() != kCUDA) {
-    throw std::runtime_error("Unconvertible NCCL type");
-  }
-  switch (type.scalarType()) {
-  case at::kFloat   : return ncclFloat;
-  case at::kHalf    : return ncclHalf;
-  case at::kDouble  : return ncclDouble;
-  case at::kLong    : return ncclInt64;
-  case at::kInt     : return ncclInt;
-  case at::kChar    : return ncclChar;
-  case at::kByte    : return ncclChar;
-  default: throw std::runtime_error("Unconvertible NCCL type");
-  }
-}
+} // namespace detail
 
-PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args) {
-#if defined(NCCL_MAJOR)
-  return PyInt_FromLong(NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH);
+bool is_available(TensorList tensors) {
+#ifdef WITH_NCCL
+  device_set devices;
+  for (auto & tensor : tensors) {
+    auto & type = tensor.type();
+    if (!type.is_cuda() || type.is_sparse())
+      return false;
+    if (!tensor.is_contiguous())
+      return false;
+    auto device = tensor.get_device();
+    if (devices[device])
+      return false;
+    devices[device] = true;
+  }
+  return true;
 #else
-  return PyInt_FromLong(1000);  // assume NCCL 1.0
+  return false;
 #endif
 }
 
-PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  ncclUniqueId id;
-  CHECK(ncclGetUniqueId(&id));
-  return PyBytes_FromStringAndSize((char*)&id, NCCL_UNIQUE_ID_BYTES);
-  END_HANDLE_TH_ERRORS
+std::uint64_t version() {
+#if defined(NCCL_MAJOR)
+  return NCCL_MAJOR * 1000 + NCCL_MINOR * 100 + NCCL_PATCH;
+#elif defined(WITH_NCCL)
+  return 1000;
+#else
+  return 0;
+#endif
 }
 
-static ncclComm_t unpack_nccl_comm(PyObject* capsule) {
-  ncclComm_t comm = (ncclComm_t)PyCapsule_GetPointer(capsule, COMM_CAPSULE_NAME);
-  if (!comm) throw python_error();
-  return comm;
+void broadcast(TensorList tensors, const stream_list& streams, const comm_list& user_comms) {
+#ifdef WITH_NCCL
+  using namespace torch::cuda::nccl::detail;
+  _check_inputs(tensors, tensors, 1, 1);
+  ncclDataType_t data_type = _get_data_type(tensors[0].type());
+  int64_t numel = tensors[0].numel();
+
+  std::lock_guard<std::mutex> free_mutex(*(THCCachingAllocator_getCudaFreeMutex()));
+  const auto comms = user_comms.empty() ? _get_communicators(tensors) : ArrayRef<ncclComm_t>(user_comms);
+  AutoGPU gpu_guard;
+  AutoNcclGroup nccl_group_guard;
+  for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; i++) {
+    gpu_guard.setDevice(tensors[i].get_device());
+    // TODO: use current stream
+    const auto stream = (streams.empty() || !streams[i]) ? NULL : streams[i]->stream;
+    CHECK(ncclBcast(tensors[i].data_ptr(), numel, data_type, 0, comms[i], stream));
+  }
+#else
+  throw std::runtime_error("PyTorch built without NCCL support");
+#endif
 }
 
-static void destroy_nccl_comm(PyObject* capsule) {
-  HANDLE_TH_ERRORS
-  ncclComm_t comm = unpack_nccl_comm(capsule);
-  with_no_gil([&]{
-    ncclCommDestroy(comm);
-  });
-  END_HANDLE_TH_ERRORS_RET()
-}
-
-static std::vector<THCStream*> unpack_streams(PyObject* obj, size_t size) {
-  if (obj == Py_None) {
-    return std::vector<THCStream*>(size, nullptr);
-  }
-  auto streams = THPUtils_PySequence_to_THCStreamList(obj);
-  if (streams.size() != size) {
-    throw std::runtime_error("number of streams is not equal to number of inputs");
-  }
-  return streams;
-}
-
-static std::vector<ncclComm_t> unpack_comms(PyObject* obj, size_t size) {
-  if (obj == Py_None) {
-    return std::vector<ncclComm_t>();
-  }
-  std::vector<ncclComm_t> comms;
-  if (PyCapsule_CheckExact(obj)) {
-    comms = { unpack_nccl_comm(obj) };
-  } else {
-    auto seq = THPObjectPtr(PySequence_Fast(obj, "comm is not a sequence"));
-    if (!seq) throw python_error();
-    auto size = PySequence_Fast_GET_SIZE(seq.get());
-    comms = std::vector<ncclComm_t>(size);
-    for (int64_t i = 0; i < size; i++) {
-      comms[i] = unpack_nccl_comm(PySequence_Fast_GET_ITEM(seq.get(), i));
-    }
-  }
-  if (comms.size() != size) {
-    throw std::runtime_error("number of communicators is not equal to number of inputs");
-  }
-  return comms;
-}
-
-PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  int nranks;
-  const char* id;
-  Py_ssize_t id_len;
-  int rank;
-
-  if (!PyArg_ParseTuple(args, "is#i:nccl_init_rank", &nranks, &id, &id_len, &rank)) {
-    return NULL;
-  }
-  THPUtils_assert(id_len == NCCL_UNIQUE_ID_BYTES,
-      "invalid unqiue_id (expected %d bytes, got %zd)",
-      NCCL_UNIQUE_ID_BYTES, id_len);
-
-  ncclUniqueId commId;
-  memcpy(&commId, id, NCCL_UNIQUE_ID_BYTES);
-  ncclComm_t comm;
-  with_no_gil([&]{
-    CHECK(ncclCommInitRank(&comm, nranks, commId, rank));
-  });
-  return PyCapsule_New(comm, COMM_CAPSULE_NAME, &destroy_nccl_comm);
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs, *_streams, *_comms;
-  int root, op;
-
-  if (!PyArg_ParseTuple(args, "OOiiOO", &_inputs, &_outputs, &root, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, NULL, "nccl_reduce", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int root,"
-            " int op, sequence[torch.cuda.Stream or None]");
-    return NULL;
-  }
-
-  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
-  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
-  std::vector<THCStream*> streams = unpack_streams(_streams, inputs.size());
-  auto user_comms = unpack_comms(_comms, inputs.size());
-
-  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
-
-  with_no_gil([&]{
-    _check_inputs(inputs, outputs, 1, 1);
-    size_t len = inputs.size();
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel();
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    AutoGPU gpu_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      gpu_guard.setDevice(device);
-      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-      CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-           count, data_type, (ncclRedOp_t) op, root, comms[i], stream));
-    }
-  });
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs, *_streams, *_comms;
-  int op;
-
-  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, NULL, "nccl_all_reduce", 1,
-        "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op,"
-        " sequence[torch.cuda.Stream] streams,"
-        " sequence[torch.cuda.nccl.Communicator] comms)");
-    return NULL;
-  }
-
-  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
-  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
-  auto streams = unpack_streams(_streams, inputs.size());
-  auto user_comms = unpack_comms(_comms, inputs.size());
-
-  with_no_gil([&]{
-    _check_inputs(inputs, outputs, 1, 1);
-    size_t len = inputs.size();
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel();
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    AutoGPU gpu_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      gpu_guard.setDevice(device);
-      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-      CHECK(ncclAllReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
-          count, data_type, (ncclRedOp_t) op, comms[i], stream));
-    }
-  });
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  PyObject *_inputs, *_streams, *_comms;
-  int root;
-
-  if (!PyArg_ParseTuple(args, "OiOO", &_inputs, &root, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, NULL, "nccl_broadcast", 1,
-			      "(sequence[Tensor] inputs, int root)");
-    return NULL;
-  }
-
-  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
-  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
-  auto streams = unpack_streams(_streams, inputs.size());
-  auto user_comms = unpack_comms(_comms, inputs.size());
-
-  with_no_gil([&]{
-    _check_inputs(inputs, inputs, 1, 1);
-    size_t len = inputs.size();
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel();
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    AutoGPU gpu_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      gpu_guard.setDevice(device);
-      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-      CHECK(ncclBcast(inputs[i].data_ptr(), count, data_type, root, comms[i], stream));
-    }
-  });
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs, *_streams, *_comms;
-
-  if (!PyArg_ParseTuple(args, "OOOO", &_inputs, &_outputs, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, NULL, "nccl_all_gather", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs");
-    return NULL;
-  }
-
-  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
-  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
-  auto streams = unpack_streams(_streams, inputs.size());
-  auto user_comms = unpack_comms(_comms, inputs.size());
-
-  with_no_gil([&]{
-    size_t len = inputs.size();
-    _check_inputs(inputs, outputs, len, 1);
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel();
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    AutoGPU gpu_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      gpu_guard.setDevice(device);
-      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-    #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
-      CHECK(ncclAllGather(inputs[i].data_ptr(), outputs[i].data_ptr(),
-        count, data_type, comms[i], stream));
-    #else
-      CHECK(ncclAllGather(inputs[i].data_ptr(), count, data_type,
-        outputs[i].data_ptr(), comms[i], stream));
-    #endif
-    }
-  });
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
-  HANDLE_TH_ERRORS
-  PyObject *_inputs, *_outputs, *_streams, *_comms;
-  int op;
-
-  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
-    THPUtils_invalidArguments(args, NULL, "nccl_reduce_scatter", 1,
-			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op");
-    return NULL;
-  }
-
-  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
-  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
-  auto streams = unpack_streams(_streams, inputs.size());
-  auto user_comms = unpack_comms(_comms, inputs.size());
-
-  with_no_gil([&]{
-    size_t len = inputs.size();
-    _check_inputs(inputs, outputs, 1, len);
-
-    ncclDataType_t data_type = _get_data_type(inputs[0].type());
-
-    int64_t count = inputs[0].numel() / len;
-    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
-    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
-    AutoGPU gpu_guard;
-    AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < len; i++) {
-      int device = inputs[i].get_device();
-      gpu_guard.setDevice(device);
-      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
-      CHECK(ncclReduceScatter(inputs[i].data_ptr(), outputs[i].data_ptr(),
-          count, data_type, (ncclRedOp_t) op, comms[i], stream));
-    }
-  });
-
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
+}}}

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -1,14 +1,42 @@
-#ifndef THCP_CUDA_NCCL_INC
-#define THCP_CUDA_NCCL_INC
-#include <Python.h>
+#pragma once
 
-PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args);
-PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args);
+#include <nccl.h>
+#include <ATen/ATen.h>
+#include <THC/THC.h>
 
+namespace torch { namespace cuda { namespace nccl {
+
+// NOTE: this is exposed only so that python_nccl.cpp can some of these helpers.
+// Don't use them outside of these files.
+namespace detail {
+
+struct AutoNcclGroup {
+  AutoNcclGroup() {
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+    CHECK(ncclGroupStart());
 #endif
+  }
+  ~AutoNcclGroup() {
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+    CHECK(ncclGroupEnd());
+#endif
+  }
+};
+
+at::ArrayRef<ncclComm_t> _get_communicators(at::TensorList inputs);
+void _check_inputs(at::TensorList inputs, at::TensorList outputs,
+                   int input_multiplier, int output_multiplier);
+ncclDataType_t _get_data_type(const at::Type& type);
+
+} // namespace detail
+
+using comm_list = std::vector<ncclComm_t>;
+using stream_list = std::vector<THCStream*>;
+
+std::uint64_t version();
+bool is_available(at::TensorList tensors);
+void broadcast(at::TensorList tensors,
+               const stream_list& streams = {},
+               const comm_list& user_comms = {});
+
+}}}

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -1,0 +1,19 @@
+#include "torch/csrc/utils/pybind.h"
+#include "torch/csrc/cuda/comm.h"
+
+#include <chrono>
+
+namespace torch { namespace cuda { namespace python {
+
+void initCommMethods(PyObject *module) {
+  auto m = py::cast<py::module>(module);
+  m.def("_broadcast_coalesced", [](std::vector<at::Tensor>& tensors, std::vector<int64_t> devices, std::size_t buffer_size) {
+     return broadcast_coalesced(tensors, devices, buffer_size);
+   }, py::arg("tensors"), py::arg("devices"), py::arg("buffer_size") = 10 * 1024 * 1024,
+      py::call_guard<py::gil_scoped_release>())
+   .def("_broadcast", [](at::Tensor& tensor, std::vector<int64_t> devices) {
+     return broadcast(tensor, devices);
+   }, py::call_guard<py::gil_scoped_release>());
+}
+
+}}}

--- a/torch/csrc/cuda/python_comm.h
+++ b/torch/csrc/cuda/python_comm.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace torch { namespace cuda { namespace python {
+
+void initCommMethods(PyObject *module);
+
+}}}

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -14,6 +14,14 @@ using namespace at;
 using namespace torch::cuda::nccl;
 using namespace torch::cuda::nccl::detail;
 
+static inline void CHECK(ncclResult_t status) {
+  if (status != ncclSuccess) {
+    std::stringstream err;
+    err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
+    throw std::runtime_error(err.str());
+  }
+}
+
 static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
 
 PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args) {

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -1,0 +1,294 @@
+#include "nccl.h"
+#include "torch/csrc/THP.h"
+#include "torch/csrc/Types.h"
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/cuda/THCP.h"
+
+#include "torch/csrc/cuda/nccl.h"
+
+#include <nccl.h>
+#include <sstream>
+#include <unordered_map>
+
+using namespace at;
+using namespace torch::cuda::nccl;
+using namespace torch::cuda::nccl::detail;
+
+static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
+
+PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args) {
+  return PyInt_FromLong(version());
+}
+
+PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  ncclUniqueId id;
+  CHECK(ncclGetUniqueId(&id));
+  return PyBytes_FromStringAndSize((char*)&id, NCCL_UNIQUE_ID_BYTES);
+  END_HANDLE_TH_ERRORS
+}
+
+static ncclComm_t unpack_nccl_comm(PyObject* capsule) {
+  ncclComm_t comm = (ncclComm_t)PyCapsule_GetPointer(capsule, COMM_CAPSULE_NAME);
+  if (!comm) throw python_error();
+  return comm;
+}
+
+static void destroy_nccl_comm(PyObject* capsule) {
+  HANDLE_TH_ERRORS
+  ncclComm_t comm = unpack_nccl_comm(capsule);
+  with_no_gil([&]{
+    ncclCommDestroy(comm);
+  });
+  END_HANDLE_TH_ERRORS_RET()
+}
+
+static std::vector<THCStream*> unpack_streams(PyObject* obj, size_t size) {
+  if (obj == Py_None) {
+    return std::vector<THCStream*>(size, nullptr);
+  }
+  auto streams = THPUtils_PySequence_to_THCStreamList(obj);
+  if (streams.size() != size) {
+    throw std::runtime_error("number of streams is not equal to number of inputs");
+  }
+  return streams;
+}
+
+static std::vector<ncclComm_t> unpack_comms(PyObject* obj, size_t size) {
+  if (obj == Py_None) {
+    return std::vector<ncclComm_t>();
+  }
+  std::vector<ncclComm_t> comms;
+  if (PyCapsule_CheckExact(obj)) {
+    comms = { unpack_nccl_comm(obj) };
+  } else {
+    auto seq = THPObjectPtr(PySequence_Fast(obj, "comm is not a sequence"));
+    if (!seq) throw python_error();
+    auto size = PySequence_Fast_GET_SIZE(seq.get());
+    comms = std::vector<ncclComm_t>(size);
+    for (int64_t i = 0; i < size; i++) {
+      comms[i] = unpack_nccl_comm(PySequence_Fast_GET_ITEM(seq.get(), i));
+    }
+  }
+  if (comms.size() != size) {
+    throw std::runtime_error("number of communicators is not equal to number of inputs");
+  }
+  return comms;
+}
+
+PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  int nranks;
+  const char* id;
+  Py_ssize_t id_len;
+  int rank;
+
+  if (!PyArg_ParseTuple(args, "is#i:nccl_init_rank", &nranks, &id, &id_len, &rank)) {
+    return NULL;
+  }
+  THPUtils_assert(id_len == NCCL_UNIQUE_ID_BYTES,
+      "invalid unqiue_id (expected %d bytes, got %zd)",
+      NCCL_UNIQUE_ID_BYTES, id_len);
+
+  ncclUniqueId commId;
+  memcpy(&commId, id, NCCL_UNIQUE_ID_BYTES);
+  ncclComm_t comm;
+  with_no_gil([&]{
+    CHECK(ncclCommInitRank(&comm, nranks, commId, rank));
+  });
+  return PyCapsule_New(comm, COMM_CAPSULE_NAME, &destroy_nccl_comm);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
+  int root, op;
+
+  if (!PyArg_ParseTuple(args, "OOiiOO", &_inputs, &_outputs, &root, &op, &_streams, &_comms)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_reduce", 1,
+			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int root,"
+            " int op, sequence[torch.cuda.Stream or None]");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  std::vector<THCStream*> streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
+
+  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
+
+  with_no_gil([&]{
+    _check_inputs(inputs, outputs, 1, 1);
+    size_t len = inputs.size();
+
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
+
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    AutoGPU gpu_guard;
+    AutoNcclGroup nccl_group_guard;
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
+           count, data_type, (ncclRedOp_t) op, root, comms[i], stream));
+    }
+  });
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
+  int op;
+
+  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_all_reduce", 1,
+        "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op,"
+        " sequence[torch.cuda.Stream] streams,"
+        " sequence[torch.cuda.nccl.Communicator] comms)");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
+
+  with_no_gil([&]{
+    _check_inputs(inputs, outputs, 1, 1);
+    size_t len = inputs.size();
+
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
+
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    AutoGPU gpu_guard;
+    AutoNcclGroup nccl_group_guard;
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclAllReduce(inputs[i].data_ptr(), outputs[i].data_ptr(),
+          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+    }
+  });
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_streams, *_comms;
+  int root;
+
+  if (!PyArg_ParseTuple(args, "OiOO", &_inputs, &root, &_streams, &_comms)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_broadcast", 1,
+			      "(sequence[Tensor] inputs, int root)");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  THPUtils_assert(root >= 0 && (size_t)root < inputs.size(), "invalid root");
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
+
+  with_no_gil([&]{
+    torch::cuda::nccl::broadcast(inputs, streams, user_comms);
+  });
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
+
+  if (!PyArg_ParseTuple(args, "OOOO", &_inputs, &_outputs, &_streams, &_comms)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_all_gather", 1,
+			      "(sequence[Tensor] inputs, sequence[Tensor] outputs");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
+
+  with_no_gil([&]{
+    size_t len = inputs.size();
+    _check_inputs(inputs, outputs, len, 1);
+
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
+
+    int64_t count = inputs[0].numel();
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    AutoGPU gpu_guard;
+    AutoNcclGroup nccl_group_guard;
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+    #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+      CHECK(ncclAllGather(inputs[i].data_ptr(), outputs[i].data_ptr(),
+        count, data_type, comms[i], stream));
+    #else
+      CHECK(ncclAllGather(inputs[i].data_ptr(), count, data_type,
+        outputs[i].data_ptr(), comms[i], stream));
+    #endif
+    }
+  });
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args) {
+  HANDLE_TH_ERRORS
+  PyObject *_inputs, *_outputs, *_streams, *_comms;
+  int op;
+
+  if (!PyArg_ParseTuple(args, "OOiOO", &_inputs, &_outputs, &op, &_streams, &_comms)) {
+    THPUtils_invalidArguments(args, NULL, "nccl_reduce_scatter", 1,
+			      "(sequence[Tensor] inputs, sequence[Tensor] outputs, int op");
+    return NULL;
+  }
+
+  std::vector<at::Tensor> inputs = THPUtils_PySequence_to_TensorList(_inputs);
+  std::vector<at::Tensor> outputs = THPUtils_PySequence_to_TensorList(_outputs);
+  auto streams = unpack_streams(_streams, inputs.size());
+  auto user_comms = unpack_comms(_comms, inputs.size());
+
+  with_no_gil([&]{
+    size_t len = inputs.size();
+    _check_inputs(inputs, outputs, 1, len);
+
+    ncclDataType_t data_type = _get_data_type(inputs[0].type());
+
+    int64_t count = inputs[0].numel() / len;
+    std::lock_guard<std::mutex> lock(*(THCCachingAllocator_getCudaFreeMutex()));
+    auto comms = user_comms.empty() ? _get_communicators(inputs) : ArrayRef<ncclComm_t>(user_comms);
+    AutoGPU gpu_guard;
+    AutoNcclGroup nccl_group_guard;
+    for (size_t i = 0; i < len; i++) {
+      int device = inputs[i].get_device();
+      gpu_guard.setDevice(device);
+      auto stream = (streams[i] == NULL) ? NULL : streams[i]->stream;
+      CHECK(ncclReduceScatter(inputs[i].data_ptr(), outputs[i].data_ptr(),
+          count, data_type, (ncclRedOp_t) op, comms[i], stream));
+    }
+  });
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}

--- a/torch/csrc/cuda/python_nccl.h
+++ b/torch/csrc/cuda/python_nccl.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Python.h>
+
+PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_init_rank(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_reduce(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_all_reduce(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_broadcast(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_all_gather(PyObject *self, PyObject *args);
+PyObject * THCPModule_nccl_reduce_scatter(PyObject *self, PyObject *args);

--- a/torch/csrc/utils/functional.h
+++ b/torch/csrc/utils/functional.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <ATen/ATen.h>
 
 namespace torch {
 

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -1,0 +1,95 @@
+#include "torch/csrc/utils/tensor_flatten.h"
+
+#include <unordered_map>
+
+namespace torch { namespace utils {
+
+using namespace at;
+
+std::vector<TensorGroup> take_tensors(TensorList tensors, std::size_t size_limit) {
+  std::vector<TensorGroup> results;
+  results.reserve(tensors.size()); // an overapproximation, but at least we won't have to copy stuff around
+  std::unordered_map<at::Type*, TensorGroup> groups;
+  for (const auto & tensor : tensors) {
+    auto & type = tensor.type();
+    std::size_t tensor_size;
+    if (type.is_sparse()) {
+      const auto& indices = tensor._indices();
+      const auto& values = tensor._values();
+      tensor_size = indices.numel() * indices.type().elementSizeInBytes() +
+                    values.numel() * indices.type().elementSizeInBytes();
+    } else {
+      tensor_size = tensor.numel() * type.elementSizeInBytes();
+    }
+    auto & type_group = groups[&type];
+    type_group.tensors.push_back(tensor);
+    type_group.size += tensor_size;
+    if (type_group.size + tensor_size >= size_limit) {
+      results.emplace_back();
+      std::swap(results.back(), type_group);
+    }
+  }
+  // End case. Look for any remaining groups and return them.
+  for (auto & entry : groups) {
+    auto & group = entry.second;
+    if (group.size > 0) {
+      results.emplace_back(std::move(group));
+    }
+  }
+  return results;
+}
+
+void reorder_tensors_like(std::vector<Tensor>& tensors, TensorList order) {
+  TORCH_ASSERT(tensors.size() == order.size());
+  std::unordered_map<at::Type*, std::vector<std::size_t>> type_indices;
+  for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
+    type_indices[&tensors[i].type()].push_back(i);
+
+  std::unordered_map<at::Type*, std::size_t> type_used;
+  std::vector<Tensor> ordered_tensors;
+  ordered_tensors.reserve(tensors.size());
+  for (auto & tmpl_tensor : order) {
+    auto * type = &tmpl_tensor.type();
+    auto & indices = type_indices[type];
+    auto & used = type_used[type];
+    ordered_tensors.push_back(tensors[indices[used++]]);
+  }
+  std::swap(tensors, ordered_tensors);
+}
+
+namespace {
+
+at::Tensor get_indices(const at::Tensor& t) {
+  return t._indices();
+}
+
+at::Tensor get_values(const at::Tensor& t) {
+  return t._values();
+}
+
+}
+
+std::pair<at::Tensor, at::Tensor> flatten_sparse_tensors(at::TensorList tensors) {
+  auto flat_indices = flatten_dense_tensors(fmap(tensors, &get_indices));
+  auto flat_values = flatten_dense_tensors(fmap(tensors, &get_values));
+  return std::make_pair(flat_indices, flat_values);
+}
+
+std::vector<at::Tensor> unflatten_sparse_tensors(
+        const at::Tensor& flat_indices, const at::Tensor& flat_values,
+        at::TensorList tensors) {
+  if (tensors.size() == 0) return {};
+
+  auto indices = unflatten_dense_tensors(flat_indices, fmap(tensors, &get_indices));
+  auto values = unflatten_dense_tensors(flat_values, fmap(tensors, &get_values));
+
+  std::vector<at::Tensor> outputs;
+  outputs.reserve(tensors.size());
+  auto & type = tensors[0].type();
+  for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
+    outputs.emplace_back(type.sparse_coo_tensor(indices[i], values[i], tensors[i].sizes()));
+  return outputs;
+}
+
+
+}}

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "torch/csrc/utils/functional.h"
+#include "torch/csrc/assertions.h"
+
+#include <ATen/ATen.h>
+#include <utility>
+
+namespace torch { namespace utils {
+
+inline at::Tensor flatten_dense_tensors(at::TensorList tensors) {
+  static auto flatten = [](const at::Tensor &t) { return t.contiguous().view({-1}); };
+  if (tensors.size() == 1)
+    return flatten(tensors[0]);
+  return at::cat(fmap(tensors, flatten));
+}
+
+inline std::vector<at::Tensor> unflatten_dense_tensors(const at::Tensor& flat, at::TensorList tensors) {
+  std::vector<at::Tensor> outputs;
+  outputs.reserve(tensors.size());
+  std::size_t offset = 0;
+  for (const auto & tensor : tensors) {
+    auto numel = tensor.numel();
+    outputs.push_back(flat.narrow(0, offset, numel).view(tensor.sizes()));
+    offset += numel;
+  }
+  return outputs;
+}
+
+
+struct TensorGroup {
+  std::vector<at::Tensor> tensors;
+  std::size_t size = 0;
+
+  at::Type& type() {
+    TORCH_ASSERT(!tensors.empty());
+    return tensors[0].type();
+  }
+};
+
+std::vector<TensorGroup> take_tensors(at::TensorList tensors, std::size_t size_limit);
+void reorder_tensors_like(std::vector<at::Tensor>& tensors, at::TensorList order);
+
+std::pair<at::Tensor, at::Tensor> flatten_sparse_tensors(at::TensorList tensors);
+
+std::vector<at::Tensor> unflatten_sparse_tensors(
+    const at::Tensor& flat_indices,
+    const at::Tensor& flat_values,
+    at::TensorList tensors);
+
+}}


### PR DESCRIPTION
Times for 2-GPU training of ResNet1001 (speedups are likely larger for more GPUs):

| Patches         | Time / batch |
|-----------------|--------------|
| -               | 615ms        |
| this PR         | 569ms (-46ms)        |
| #4216           | 499ms (-116ms)       |
| #4216 + this PR | 465ms (-150ms)       |

This improves the perf, and also unlocks new possibilities like moving the loops for `set_` to C++, which might save us creating a lot of short-lived Python wrappers for tensors.