### PR TITLE
Fix _trace function in torch.onnx (clean up of #4436)

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -100,13 +100,13 @@ def _optimize_trace(trace, aten):
     torch._C._jit_pass_lint(trace)
 
 
-def _trace(func, args, return_outs=False):
+def _trace(func, args, return_outs=False, aten=False):
     # Special case for common case of passing a single Variable
     if isinstance(args, torch.autograd.Variable):
         args = (args, )
 
     trace, torch_out = torch.jit.trace(func, args)
-    _optimize_trace(trace)
+    _optimize_trace(trace, aten)
     if return_outs:
         return trace, torch_out
     return trace


### PR DESCRIPTION
Found this bug while trying to call it directly, an argument is missing.

This function was introduced in 47ac468. Looks like it's not covered by unit test.