### PR TITLE
Supporting logits as parameters in Bernoulli and Categorical

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1116,7 +1116,6 @@ class TestNumericalStability(TestCase):
             p = Variable(logits, requires_grad=True)
             dist = dist_class(logits=p)
         log_pdf = dist.log_prob(Variable(x))
-        log_pdf.retain_grad()
         log_pdf.sum().backward()
         self.assertEqual(log_pdf.data,
                          expected_value,

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -34,6 +34,8 @@ from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  Dirichlet, Exponential, Gamma, Laplace,
                                  Normal, OneHotCategorical, Pareto, Uniform)
 from torch.distributions.constraints import Constraint, is_dependent
+from torch.distributions.utils import _get_clamping_buffer
+
 
 TEST_NUMPY = True
 try:
@@ -240,7 +242,13 @@ class TestDistributions(TestCase):
             self.assertEqual(log_prob, math.log(prob if val else 1 - prob))
 
         self._check_log_prob(Bernoulli(p), ref_log_prob)
+        self._check_log_prob(Bernoulli(logits=p.log() - (-p).log1p()), ref_log_prob)
         self.assertRaises(NotImplementedError, Bernoulli(r).rsample)
+
+        # check entropy computation
+        self.assertEqual(Bernoulli(p).entropy().data, torch.Tensor([0.6108, 0.5004, 0.6730]), prec=1e-4)
+        self.assertEqual(Bernoulli(torch.Tensor([0.0])).entropy(), torch.Tensor([0.0]))
+        self.assertEqual(Bernoulli(s).entropy(), torch.Tensor([0.6108]), prec=1e-4)
 
     def test_bernoulli_enumerate_support(self):
         examples = [
@@ -286,6 +294,11 @@ class TestDistributions(TestCase):
             self.assertEqual(log_prob, math.log(sample_prob))
 
         self._check_log_prob(Categorical(p), ref_log_prob)
+        self._check_log_prob(Categorical(logits=p.log()), ref_log_prob)
+
+        # check entropy computation
+        self.assertEqual(Categorical(p).entropy().data, torch.Tensor([1.0114, 1.0297]), prec=1e-4)
+        self.assertEqual(Categorical(s).entropy().data, torch.Tensor([0.0, 0.0]))
 
     def test_categorical_enumerate_support(self):
         examples = [
@@ -1085,6 +1098,109 @@ class TestConstraints(TestCase):
                 message = '{} example {}/{} sample = {}'.format(
                     Dist.__name__, i, len(params), value)
                 self.assertTrue(constraint.check(value).all(), msg=message)
+
+
+class TestNumericalStability(TestCase):
+    def _test_pdf_score(self,
+                        dist_class,
+                        x,
+                        expected_value,
+                        probs=None,
+                        logits=None,
+                        expected_gradient=None,
+                        prec=1e-5):
+        if probs is not None:
+            p = Variable(probs, requires_grad=True)
+            dist = dist_class(p)
+        else:
+            p = Variable(logits, requires_grad=True)
+            dist = dist_class(logits=p)
+        log_pdf = dist.log_prob(Variable(x))
+        log_pdf.retain_grad()
+        log_pdf.sum().backward()
+        self.assertEqual(log_pdf.data,
+                         expected_value,
+                         prec=prec,
+                         message='Failed for tensor type: {}. Expected = {}, Actual = {}'
+                         .format(type(x), expected_value, log_pdf.data))
+        if expected_gradient is not None:
+            self.assertEqual(p.grad.data,
+                             expected_gradient,
+                             prec=prec,
+                             message='Failed for tensor type: {}. Expected = {}, Actual = {}'
+                             .format(type(x), expected_gradient, p.grad.data))
+
+    def test_bernoulli_gradient(self):
+        for tensor_type in [torch.FloatTensor, torch.DoubleTensor]:
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 probs=tensor_type([0]),
+                                 x=tensor_type([0]),
+                                 expected_value=tensor_type([0]),
+                                 expected_gradient=tensor_type([0]))
+
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 probs=tensor_type([0]),
+                                 x=tensor_type([1]),
+                                 expected_value=tensor_type([_get_clamping_buffer(tensor_type([]))]).log(),
+                                 expected_gradient=tensor_type([0]))
+
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 probs=tensor_type([1e-4]),
+                                 x=tensor_type([1]),
+                                 expected_value=tensor_type([math.log(1e-4)]),
+                                 expected_gradient=tensor_type([10000]))
+
+            # Lower precision due to:
+            # >>> 1 / (1 - torch.FloatTensor([0.9999]))
+            # 9998.3408
+            # [torch.FloatTensor of size 1]
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 probs=tensor_type([1 - 1e-4]),
+                                 x=tensor_type([0]),
+                                 expected_value=tensor_type([math.log(1e-4)]),
+                                 expected_gradient=tensor_type([-10000]),
+                                 prec=2)
+
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 logits=tensor_type([math.log(9999)]),
+                                 x=tensor_type([0]),
+                                 expected_value=tensor_type([math.log(1e-4)]),
+                                 expected_gradient=tensor_type([-1]),
+                                 prec=1e-3)
+
+    def test_bernoulli_with_logits_underflow(self):
+        for tensor_type, lim in ([(torch.FloatTensor, -1e38),
+                                  (torch.DoubleTensor, -1e308)]):
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 logits=tensor_type([lim]),
+                                 x=tensor_type([0]),
+                                 expected_value=tensor_type([0]),
+                                 expected_gradient=tensor_type([0]))
+
+    def test_bernoulli_with_logits_overflow(self):
+        for tensor_type, lim in ([(torch.FloatTensor, 1e38),
+                                  (torch.DoubleTensor, 1e308)]):
+            self._test_pdf_score(dist_class=Bernoulli,
+                                 logits=tensor_type([lim]),
+                                 x=tensor_type([1]),
+                                 expected_value=tensor_type([0]),
+                                 expected_gradient=tensor_type([0]))
+
+    def test_categorical_log_prob(self):
+        for tensor_type in ([torch.FloatTensor, torch.DoubleTensor]):
+            p = Variable(tensor_type([0, 1]), requires_grad=True)
+            categorical = OneHotCategorical(p)
+            log_pdf = categorical.log_prob(Variable(tensor_type([0, 1])))
+            self.assertEqual(log_pdf.data[0], 0)
+
+    def test_categorical_log_prob_with_logits(self):
+        for tensor_type in ([torch.FloatTensor, torch.DoubleTensor]):
+            p = Variable(tensor_type([-float('inf'), 0]), requires_grad=True)
+            categorical = OneHotCategorical(logits=p)
+            log_pdf_prob_1 = categorical.log_prob(Variable(tensor_type([0, 1])))
+            self.assertEqual(log_pdf_prob_1.data[0], 0)
+            log_pdf_prob_0 = categorical.log_prob(Variable(tensor_type([1, 0])))
+            self.assertEqual(log_pdf_prob_0.data[0], -float('inf'), allow_inf=True)
 
 
 if __name__ == '__main__':

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -36,10 +36,11 @@ class Bernoulli(Distribution):
             self.probs, = broadcast_all(probs)
         else:
             self.logits, = broadcast_all(logits)
-        if isinstance(probs, Number) or isinstance(logits, Number):
+        probs_or_logits = probs if probs is not None else logits
+        if isinstance(probs_or_logits, Number):
             batch_shape = torch.Size()
         else:
-            batch_shape = self.probs.size() if probs is not None else self.logits.size()
+            batch_shape = probs_or_logits.size()
         super(Bernoulli, self).__init__(batch_shape)
 
     @lazy_property

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, get_logits, get_probs
+from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs
 
 
 class Bernoulli(Distribution):
@@ -34,10 +34,10 @@ class Bernoulli(Distribution):
                              "but not both.".format(probs, logits))
         if probs is not None:
             self.probs, = broadcast_all(probs)
-            self.logits = get_logits(self.probs, is_binary=True)
+            self.logits = probs_to_logits(self.probs, is_binary=True)
         else:
             self.logits, = broadcast_all(logits)
-            self.probs = get_probs(self.logits, is_binary=True)
+            self.probs = logits_to_probs(self.logits, is_binary=True)
         if isinstance(probs, Number):
             batch_shape = torch.Size()
         else:

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -31,8 +31,7 @@ class Bernoulli(Distribution):
 
     def __init__(self, probs=None, logits=None):
         if (probs is None) == (logits is None):
-            raise ValueError("Got probs={}, logits={}. Either `probs` or `logits` must be specified, "
-                             "but not both.".format(probs, logits))
+            raise ValueError("Either `probs` or `logits` must be specified, but not both.")
         if probs is not None:
             self.probs, = broadcast_all(probs)
             self.logits = probs_to_logits(self.probs, is_binary=True)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -51,7 +51,7 @@ class Bernoulli(Distribution):
     def _binary_cross_entropy(self, value):
         max_val = (-self.logits).clamp(min=0)
         return self.logits - self.logits * value + max_val + \
-               ((-max_val).exp() + (-self.logits - max_val).exp()).log()
+            ((-max_val).exp() + (-self.logits - max_val).exp()).log()
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -2,6 +2,7 @@ import torch
 from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
+from torch.distributions.utils import get_logits, get_probs, log_sum_exp
 
 
 class Categorical(Distribution):
@@ -33,8 +34,16 @@ class Categorical(Distribution):
     params = {'probs': constraints.simplex}
     has_enumerate_support = True
 
-    def __init__(self, probs):
-        self.probs = probs
+    def __init__(self, probs=None, logits=None):
+        if (probs is None) == (logits is None):
+            raise ValueError("Got probs={}, logits={}. Either `probs` or `logits` must be specified, "
+                             "but not both.".format(probs, logits))
+        if probs is not None:
+            self.probs = probs / probs.sum(-1, keepdim=True)
+            self.logits = get_logits(self.probs)
+        else:
+            self.logits = logits - log_sum_exp(logits)
+            self.probs = get_probs(self.logits)
         batch_shape = self.probs.size()[:-1]
         super(Categorical, self).__init__(batch_shape)
 
@@ -54,13 +63,11 @@ class Categorical(Distribution):
     def log_prob(self, value):
         self._validate_log_prob_arg(value)
         param_shape = value.size() + self.probs.size()[-1:]
-        log_pmf = (self.probs / self.probs.sum(-1, keepdim=True)).log()
-        log_pmf = log_pmf.expand(param_shape)
+        log_pmf = self.logits.expand(param_shape)
         return log_pmf.gather(-1, value.unsqueeze(-1).long()).squeeze(-1)
 
     def entropy(self):
-        p_log_p = torch.log(self.probs) * self.probs
-        p_log_p[self.probs == 0] = 0
+        p_log_p = self.logits * self.probs
         return -p_log_p.sum(-1)
 
     def enumerate_support(self):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -2,7 +2,7 @@ import torch
 from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import get_logits, get_probs, log_sum_exp
+from torch.distributions.utils import probs_to_logits, logits_to_probs, log_sum_exp
 
 
 class Categorical(Distribution):
@@ -40,10 +40,10 @@ class Categorical(Distribution):
                              "but not both.".format(probs, logits))
         if probs is not None:
             self.probs = probs / probs.sum(-1, keepdim=True)
-            self.logits = get_logits(self.probs)
+            self.logits = probs_to_logits(self.probs)
         else:
             self.logits = logits - log_sum_exp(logits)
-            self.probs = get_probs(self.logits)
+            self.probs = logits_to_probs(self.logits)
         batch_shape = self.probs.size()[:-1]
         super(Categorical, self).__init__(batch_shape)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -36,8 +36,7 @@ class Categorical(Distribution):
 
     def __init__(self, probs=None, logits=None):
         if (probs is None) == (logits is None):
-            raise ValueError("Got probs={}, logits={}. Either `probs` or `logits` must be specified, "
-                             "but not both.".format(probs, logits))
+            raise ValueError("Either `probs` or `logits` must be specified, but not both.")
         if probs is not None:
             self.probs = probs / probs.sum(-1, keepdim=True)
             self.logits = probs_to_logits(self.probs)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -30,10 +30,10 @@ class OneHotCategorical(Distribution):
     support = constraints.simplex
     has_enumerate_support = True
 
-    def __init__(self, probs):
-        self._categorical = Categorical(probs)
-        batch_shape = probs.size()[:-1]
-        event_shape = probs.size()[-1:]
+    def __init__(self, probs=None, logits=None):
+        self._categorical = Categorical(probs, logits)
+        batch_shape = self._categorical.probs.size()[:-1]
+        event_shape = self._categorical.probs.size()[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape)
 
     def sample(self, sample_shape=torch.Size()):

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -1,3 +1,4 @@
+from functools import update_wrapper
 from numbers import Number
 
 import torch
@@ -125,3 +126,21 @@ def probs_to_logits(probs, is_binary=False):
     if is_binary:
         return torch.log(ps_clamped) - torch.log1p(-ps_clamped)
     return torch.log(ps_clamped)
+
+
+class lazy_property(object):
+    """
+    Non-data descriptor that calls the wrapped method to compute the property
+    on first call; thereafter replacing the wrapped method into an instance
+    attribute.
+    """
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+        update_wrapper(self, wrapped)
+
+    def __get__(self, instance, obj_type=None):
+        if instance is None:
+            return self
+        value = self.wrapped(instance)
+        setattr(instance, self.wrapped.__name__, value)
+        return value

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -88,18 +88,22 @@ def softmax(tensor):
     return F.softmax(tensor, -1)
 
 
-def log_sum_exp(tensor):
+def log_sum_exp(tensor, keepdim=True):
     """
     Numerically stable implementation for the `LogSumExp` operation. The
     summing is done along the last dimension.
+
+    Args:
+        tensor (torch.Tensor or torch.autograd.Variable)
+        keepdim (Boolean): Whether to retain the last dimension on summing.
     """
     max_val = tensor.max(dim=-1, keepdim=True)[0]
-    return max_val + (tensor - max_val).exp().sum(dim=-1, keepdim=True).log()
+    return max_val + (tensor - max_val).exp().sum(dim=-1, keepdim=keepdim).log()
 
 
-def get_probs(logits, is_binary=False):
+def logits_to_probs(logits, is_binary=False):
     """
-    Convert a tensor of logits into probabilities. Note that for the
+    Converts a tensor of logits into probabilities. Note that for the
     binary case, each value denotes log odds, whereas for the
     multi-dimensional case, the values along the last dimension denote
     the log probabilities (possibly unnormalized) of the events.
@@ -109,7 +113,7 @@ def get_probs(logits, is_binary=False):
     return softmax(logits)
 
 
-def get_logits(probs, is_binary=False):
+def probs_to_logits(probs, is_binary=False):
     """
     Converts a tensor of probabilities into logits. For the binary case,
     this denotes the probability of occurrence of the event indexed by `1`.

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -130,8 +130,9 @@ def probs_to_logits(probs, is_binary=False):
 
 class lazy_property(object):
     """
-    Non-data descriptor that calls the wrapped method to compute the property
-    on first call; thereafter replacing the wrapped method into an instance
+    Used as a decorator for lazy loading of class attributes. This uses a
+    non-data descriptor that calls the wrapped method to compute the property on
+    first call; thereafter replacing the wrapped method into an instance
     attribute.
     """
     def __init__(self, wrapped):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1338,7 +1338,7 @@ def binary_cross_entropy(input, target, weight=None, size_average=True, reduce=T
     return torch._C._nn.binary_cross_entropy(input, target, weight, size_average, reduce)
 
 
-def binary_cross_entropy_with_logits(input, target, weight=None, size_average=True):
+def binary_cross_entropy_with_logits(input, target, weight=None, size_average=True, reduce=True):
     r"""Function that measures Binary Cross Entropy between target and output
     logits.
 
@@ -1370,7 +1370,9 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
     if weight is not None:
         loss = loss * weight
 
-    if size_average:
+    if not reduce:
+        return loss
+    elif size_average:
         return loss.mean()
     else:
         return loss.sum()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1353,6 +1353,10 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
                 over observations for each minibatch. However, if the field
                 sizeAverage is set to False, the losses are instead summed
                 for each minibatch. Default: ``True``
+        reduce (bool, optional): By default, the losses are averaged or summed over
+                observations for each minibatch depending on size_average. When reduce
+                is False, returns a loss per batch element instead and ignores
+                size_average. Default: True
 
     Examples::
 


### PR DESCRIPTION
This allows for using logits directly as parameters in Bernoulli and Categorical distributions. 

**Details:**
 - Uses the binary cross entropy operation to score Bernoulli samples. This makes the `log_prob` computation differentiable.
 - Categorical normalizes the probs/logits parameters provided in the constructor and stores these as attributes, so that other methods do not need to bother with normalizing unnormalized probabilities/logits.
 - Simplifies entropy computation (and corrects it for the case of Categorical with unnormalized probability values as parameters).