### PR TITLE
Fix CUDA double backwards

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -395,10 +395,7 @@ at::Tensor _convolution_nogroup(
     if (dim == 4) {
       if (dilated) {
         return at::thnn_conv_dilated2d(
-            // TODO: This might not be necessary in the non-CUDA case,
-            // as we only triggered a failure here with
-            // test_ConvTranspose1d_cuda.  Very unsatisfactory...
-            input, weight.contiguous(), kernel_size, bias,
+            input, weight, kernel_size, bias,
             stride, padding, dilation);
       } else {  /* dim == 4, non-dilated */
         if (params.use_nnpack(input)) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -395,7 +395,10 @@ at::Tensor _convolution_nogroup(
     if (dim == 4) {
       if (dilated) {
         return at::thnn_conv_dilated2d(
-            input, weight, kernel_size, bias,
+            // TODO: This might not be necessary in the non-CUDA case,
+            // as we only triggered a failure here with
+            // test_ConvTranspose1d_cuda.  Very unsatisfactory...
+            input, weight.contiguous(), kernel_size, bias,
             stride, padding, dilation);
       } else {  /* dim == 4, non-dilated */
         if (params.use_nnpack(input)) {

--- a/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedConvolution.cu
@@ -16,8 +16,6 @@ static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
 	           "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
   THArgCheck(dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
-  THArgCheck(THCTensor_(isContiguous)(state, weight), 4,
-             "weight tensor has to be contiguous");
   THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
              "bias tensor has to be contiguous");
   THArgCheck(dilationW > 0 && dilationH > 0, 14,

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -15,6 +15,8 @@ class OldModuleTest(ModuleTest):
     def __init__(self, *args, **kwargs):
         super(OldModuleTest, self).__init__(*args, **kwargs)
         self.check_inplace = kwargs.get('check_inplace', False)
+        # Never check gradgrad for legacy NN
+        self.check_gradgrad = False
 
     def _do_test(self, test_case, module, input):
         # TODO: check update parameters
@@ -633,7 +635,7 @@ class TestNN(NNTestCase):
         with freeze_rng_state():
             return module.forward(input)
 
-    def _backward(self, module, input, output, grad_output):
+    def _backward(self, module, input, output, grad_output, create_graph=False):
         return module.backward(input, grad_output)
 
     def _forward_criterion(self, criterion, input, target):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -110,6 +110,9 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
         module.__repr__()
 
         if self.check_inplace:
+            # check if the inplace variant of the module gives the same result
+            # as the out-of-place
+
             module_ip = self.constructor(*self.constructor_args, inplace=True)
 
             input_version = input._version
@@ -130,6 +133,9 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
             test_case.assertEqual(input.grad, input_ip.grad)
 
         if type(input.data) == torch.LongTensor and TEST_CUDA:
+            # check that cuda() moves module parameters to correct GPU device,
+            # and that float() casts parameters correctly
+
             input = input.cuda()
             module.float().cuda()
             module(input)
@@ -146,6 +152,8 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
                     test_case.assertEqual(type(p.data), torch.cuda.FloatTensor)
                     test_case.assertEqual(p.get_device(), 1)
         else:
+            # check that float()/double() casters work correctly
+
             # to float
             if type(input.data) != torch.LongTensor:
                 input = input.float()
@@ -164,6 +172,9 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
 
             # TODO: Hardshrink is lacking a CUDA implementation
             if TEST_CUDA and self.should_test_cuda and type(module) != nn.Hardshrink:
+                # check that cuda() moves module parameters to correct GPU device,
+                # and that float() casts parameters correctly
+
                 # to GPU0
                 input = input.float().cuda()
                 module.float().cuda()
@@ -187,6 +198,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
                     test_case.assertEqual(type(p.data), torch.cuda.FloatTensor)
                     test_case.assertEqual(p.get_device(), 0)
 
+                # test that forwards of module runs correctly without cuDNN
                 if self.cudnn:
                     torch.backends.cudnn.enabled = False
                     try:
@@ -198,6 +210,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
                         torch.backends.cudnn.enabled = True
 
                 if torch.cuda.device_count() >= 2:
+                    # test cross-GPU transfer works
                     # to GPU1
                     input = input.cuda(1)
                     module.cuda(1)
@@ -234,8 +247,8 @@ class TestNN(NNTestCase):
         with freeze_rng_state():
             return module(input)
 
-    def _backward(self, module, input, output, grad_output):
-        output.backward(grad_output, retain_graph=True)
+    def _backward(self, module, input, output, grad_output, create_graph=False):
+        output.backward(grad_output, retain_graph=True, create_graph=create_graph)
         if input.grad is None:
             return None
         return input.grad.data
@@ -4429,6 +4442,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='affine',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4437,6 +4451,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='3d_input',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4445,6 +4460,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4453,6 +4469,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='3d_input_not_affine',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4460,6 +4477,7 @@ new_module_tests = [
         input_size=(2, 3, 6, 6),
         cudnn=True,
         check_eval=True,
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4468,6 +4486,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='momentum',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4476,6 +4495,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4483,6 +4503,7 @@ new_module_tests = [
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
         check_eval=True,
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4491,6 +4512,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='momentum',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4499,6 +4521,7 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='Conv1d',
@@ -4571,6 +4594,7 @@ new_module_tests = [
         input_size=(1, 3, 6),
         cudnn=True,
         desc='dilated',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4500
     ),
     dict(
         fullname='ConvTranspose1d_groups',
@@ -4646,6 +4670,7 @@ new_module_tests = [
         input_size=(1, 3, 6, 7),
         cudnn=True,
         desc='dilated',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4500
     ),
     dict(
         module_name='ConvTranspose2d',
@@ -4659,6 +4684,7 @@ new_module_tests = [
         constructor=lambda: nn.ConvTranspose2d(2, 4, (2, 3), groups=2),
         input_size=(1, 2, 4, 5),
         cudnn=True,
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4500
     ),
     dict(
         fullname='Conv2d_depthwise',
@@ -4840,6 +4866,7 @@ new_module_tests = [
         constructor_args=(2, 3, (2, 3, 2)),
         cudnn=True,
         input_size=(1, 2, 4, 5, 4),
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4500
     ),
     dict(
         module_name='ConvTranspose3d',
@@ -4847,6 +4874,7 @@ new_module_tests = [
         cudnn=True,
         input_size=(1, 2, 4, 5, 4),
         desc='dilated',
+        FIXME_no_cuda_gradgrad_comparison=True,  # See #4500
     ),
     dict(
         module_name='MaxPool3d',

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -859,7 +859,7 @@
   bias: grad.contiguous().view({grad.size(0), grad.size(1), -1}).sum(0).sum(1)
 
 - name: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList dilation, std::array<bool,2> output_mask)
-  grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, 1, false, false, false, grad_input_mask)
+  grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], {}, grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, self.size(1), false, false, false, grad_input_mask)
 
 - name: thnn_conv3d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)
   self, weight, bias: thnn_conv3d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask)

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -5,7 +5,7 @@
 #  python_functions.h/cpp: Python bindings for the above classes
 #
 from .utils import nested_dict, CodeTemplate, write
-from .gen_variable_type import VIEW_FUNCTIONS, uses_grad, template_path
+from .gen_variable_type import VIEW_FUNCTIONS, uses_single_grad, template_path
 
 FUNCTIONS_H = CodeTemplate.from_file(template_path + '/Functions.h')
 FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/Functions.cpp')
@@ -127,7 +127,7 @@ def process_function(func):
 
     body = []
 
-    if uses_grad(func):
+    if uses_single_grad(func):
         body.append('auto& grad = grads[0];')
 
     def emit_derivative(derivative):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -204,7 +204,7 @@ def split_name_params(prototype):
     return name, params.split(', ')
 
 
-def uses_grad(func):
+def uses_single_grad(func):
     if func is None:
         return False
     for derivative in func['derivatives']:
@@ -515,7 +515,7 @@ def create_variable_type(top_env, aten_declarations):
             # I don't think this is a good way to implement this, but
             # there doesn't seem to be a good place to mark things as
             # differentiable or non-differentiable at the moment.
-            if uses_grad(declaration.get('derivative')):
+            if uses_single_grad(declaration.get('derivative')):
                 env['result'] = "std::get<0>(ret)" if len(declaration['returns']) > 1 else 'ret'
             else:
                 env['result'] = CodeTemplate("{ ${outs} }").substitute(outs=diff_outs)


### PR DESCRIPTION
CUDA double backwards was broken, and we didn't know about it. Fix it.

Each commit is a logical unit of work.

```
commit 9ae56c3bb4a26e01269031d4205263952ceadc79
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed Jan 3 09:27:24 2018 -0800

    Actually test CUDA double-backwards codepath.
    
    Previously, we only tested CPU double-backwards, which is bad!
    This would have caught #4422 (still not fixed, so those tests
    are manually disabled.)
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit e80a9949c19ba979b63e8faeb984b34c6929d4c2
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed Jan 3 08:14:51 2018 -0800

    Check for out of bounds grads access in derivatives.yaml
    
    This test would have caught the OOB in thnn_conv_depthwise2d_backward
    
    Fixes #4457
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit c8b34c46b508c3636d60a9bd297e755baeff7b20
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed Jan 3 08:14:27 2018 -0800

    s/uses_grad/uses_single_grad/ for more clarity.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit 563936c3b81b4c0a37e4348d36af2265f98feabf
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed Jan 3 09:18:18 2018 -0800

    Fix 'invalid argument 4: weight tensor has to be contiguous'
    
    Weight can be non-contiguous due to double backwards, where
    we transpose the weight.  I'm not very happy with this fix
    but it seems to make the tests pass.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit af1283c24c9d39465342654cd4b9b2eca6d1d9c6
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Wed Jan 3 08:39:04 2018 -0800

    Fix two bugs in thnn_conv_depthwise2d_backward gradient.
    
    - Out of bounds grads[2] access (thnn_conv_depthwise2d_backward
      doesn't compute bias gradient)
    
    - Groups was not set appropriately for depthwise convolution
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```