### PR TITLE
Fix a leak in JIT interpreter + improve dropout

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -108,8 +108,8 @@ Operation createPythonOperation(PythonOp* op) {
       if(arg_type == 's') {
         py_inputs[i] = py::reinterpret_borrow<py::object>(op->scalar_args[next_scalar++].get());
       } else if(arg_type == 't') {
-        py_inputs[i] = THPVariable_Wrap(
-          builder.addInput(inputs.at(next_tensor), op->var_flags.at(next_tensor)));
+        py_inputs[i] = py::reinterpret_steal<py::object>(THPVariable_Wrap(
+          builder.addInput(inputs.at(next_tensor), op->var_flags.at(next_tensor))));
         next_tensor++;
       }
       i++;

--- a/torch/nn/_functions/dropout.py
+++ b/torch/nn/_functions/dropout.py
@@ -25,20 +25,22 @@ class Dropout(InplaceFunction):
         ctx.train = train
         ctx.inplace = inplace
 
+        if ctx.p == 0 or not ctx.train:
+            return input
+
         if ctx.inplace:
             ctx.mark_dirty(input)
             output = input
         else:
             output = input.clone()
 
-        if ctx.p > 0 and ctx.train:
-            ctx.noise = cls._make_noise(input)
-            if ctx.p == 1:
-                ctx.noise.fill_(0)
-            else:
-                ctx.noise.bernoulli_(1 - ctx.p).div_(1 - ctx.p)
-            ctx.noise = ctx.noise.expand_as(input)
-            output.mul_(ctx.noise)
+        ctx.noise = cls._make_noise(input)
+        if ctx.p == 1:
+            ctx.noise.fill_(0)
+        else:
+            ctx.noise.bernoulli_(1 - ctx.p).div_(1 - ctx.p)
+        ctx.noise = ctx.noise.expand_as(input)
+        output.mul_(ctx.noise)
 
         return output
 


### PR DESCRIPTION
Fixes #4396. This wasn't caused by dropout, but by the handling of Python functions in the JIT interpreter (implicit conversions of `PyObject*` to `py::object` that assume borrowing semantics, yay).

While fixing that I also noticed that dropout is unnecessarily cloning the input in `eval` mode.
  