### PR TITLE
Fix some scalar checks

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3060,6 +3060,7 @@
     - method
     - function
   return: argument 0
+  scalar_check: False
   before_call: |
     long s1 = THTensor_(size)(LIBRARY_STATE ((THPTensor*)$arg4)->cdata, 0);
     long s2 = THTensor_(size)(LIBRARY_STATE ((THPTensor*)$arg5)->cdata, 0);

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -339,6 +339,7 @@
     - method
     - function
   return: argument 0
+  scalar_check: index_->isScalar()
   arguments:
     - arg: THTensor* result
       output: True

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -24,9 +24,7 @@ bool should_expand(const IntList &from_size, const IntList &to_size) {
   return true;
 }
 
-int main() {
-  Type & T = CPU(kFloat);
-
+void test(Type &T) {
   std::vector<std::vector<int64_t> > sizes = { {}, {0}, {1}, {1, 1}, {2}};
 
   // single-tensor/size tests
@@ -285,6 +283,14 @@ int main() {
         }
       }
     }
+  }
+}
+
+int main() {
+  test(CPU(kFloat));
+
+  if (at::hasCUDA()) {
+    test(CUDA(kFloat));
   }
 
   return 0;

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -253,6 +253,18 @@ void test(Type &T) {
         }
       }
 
+      // take
+      {
+        auto lhs = T.ones(*lhs_it);
+        auto rhs = T.zeros(*rhs_it).toType(ScalarType::Long);
+        try {
+          auto result = lhs.take(rhs);
+          assert_equal_size_dim(result, rhs);
+        } catch (std::runtime_error &e) {
+          ASSERT(lhs.numel() == 0 && rhs.numel() != 0);
+        }
+      }
+
       // expand
       {
         auto lhs = T.ones(*lhs_it);

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -138,10 +138,15 @@ void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLon
   THArgCheck(THCTensor_(nDimension)(state, src) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
   THArgCheck(THCTensor_(nDimension)(state, dst) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
   THArgCheck(THCudaLongTensor_nDimension(state, index) <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  THArgCheck(!(THCTensor_(nDimension)(state, src) == 0 && THCudaLongTensor_nDimension(state, index) != 0), 2,
+             "tried to take from an empty tensor");
 
   THCTensor_(resizeNd)(state, dst, index->nDimension, index->size, NULL);
 
-  dispatchTakePut<real, TensorTakeOp>(state, src, dst, index);
+  // dispatchTakePut only handles non-empty tensors;
+  if (index->nDimension > 0) {
+    dispatchTakePut<real, TensorTakeOp>(state, src, dst, index);
+  }
 }
 
 static void THCTensor_(sort_indices)(THCState *state, THCudaLongTensor *index, THCTensor *src) {


### PR DESCRIPTION
I did a quick-ish pass over scalar checks over in https://github.com/zdevito/ATen/issues/130 and found problems with `take` and `ger` not matching numpy semantics.  These are fixed, although `ger` isn't testable yet because it requires https://github.com/zdevito/ATen/issues/157 (or accepting more restrictive [0,-1]) to pass the resize call.

Also fixes an issue with `take` on empty tensors (there doesn't seem to be a corresponding issue with `put` because `put` is more restrictive); `put` and `take` should probably be moved to be ATen native functions because the dispatch code handles scalars and empty tensors correctly but TH/THC does not.

Also runs scalar_tensor_tests for CUDA, if available.