### PR TITLE
Improve float precision stability of `linspace` op, fix 4419.

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -3383,7 +3383,7 @@ void THTensor_(linspace)(THTensor *r_, real a, real b, int64_t n)
     THTensor_(set1d)(r_, 0, a);
   } else {
      TH_TENSOR_APPLY(real, r_,
-             *r__data = a + i*(b-a)/((real)(n-1));
+             *r__data = a + (b-a)/((real)(n-1))*i;
              i++;
            );
   }


### PR DESCRIPTION
This patch swap the order `*` and `/` operation in `linspace` to improve float precision stability. This patch should fix the issue #4419 .