### PR TITLE
Hot patch ONNX _run_symbolic_function

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -297,6 +297,10 @@ def _run_symbolic_function(g, n, inputs, aten=False):
         # See Note [Export inplace]
         if n.kind().endswith('_'):
             op_name = n.kind()[:-1]
+        elif n.kind().endswith('_forward'):
+            # NB: it seems the tracing generates duplicate ops,
+            # such as both threshold and threshold_forward, introduced in #4395.
+            return inputs
         else:
             op_name = n.kind()
         # Export ops in aten mode.


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/4395, in tracing, we have some duplicate ops, for example, threshold_forward appears after threshold. leaky_relu has the same problem. 
These duplicate ops break the exporting, so test_models.py and test_caffe2.py fail.
So I just skip all the ops ending with _forward in _run_symbolic_function.

@colesbury, @ezyang, @zdevito 