### PR TITLE
Remove THPGenerator default code for random functions in Declarations…

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3721,7 +3721,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - long n
 ]]
@@ -3735,20 +3735,20 @@
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
     - cname: cappedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - long to
     - cname: clampedRandom
       arguments:
         - THTensor* self
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - long from
         - long to
@@ -3768,7 +3768,7 @@
     - arg: THIndexTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - THTensor* self
     - long num_samples
@@ -3787,7 +3787,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: double from
       default: 0
@@ -3810,7 +3810,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - THTensor* mean
         - arg: double std
@@ -3820,7 +3820,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - arg: double mean
         - THTensor* std
@@ -3829,7 +3829,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - THTensor* mean
         - THTensor* std
@@ -3846,7 +3846,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: double mean
       default: 0
@@ -3865,7 +3865,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: double median
       default: 0
@@ -3885,7 +3885,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: double mean
       default: 1
@@ -3904,7 +3904,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: double lambd
       default: 1
@@ -3923,7 +3923,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -3942,7 +3942,7 @@
     - arg: THTensor* result
       output: True
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - arg: THSize* size
       long_args: True
@@ -3957,7 +3957,7 @@
   arguments:
     - THTensor* self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - double p
 ]]
@@ -3978,7 +3978,7 @@
       output: True
       resize: self
     - arg: THGenerator* generator
-      default: THPGenerator_TH_CData(THPDefaultGenerator)
+      default: nullptr
       kwarg_only: True
     - THTensor* self
 ]]
@@ -3998,7 +3998,7 @@
         - arg: THTensor* output
           output: True
         - arg: THGenerator* generator
-          default: THPGenerator_TH_CData(THPDefaultGenerator)
+          default: nullptr
           kwarg_only: True
         - THTensor* self
 ]]

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -250,8 +250,6 @@ ALLOC_WRAP = {
 # Replacements for constants when calling into TH
 CONSTANT_REPLACEMENTS = [
     ('AS_REAL', '${AS_REAL}'),
-    ('THPGenerator_TH_CData(THPDefaultGenerator)',
-     'dynamic_cast<${Generator}&>().generator'),
     ('__storage_size.get\\(\\)',
      'THLongStorageView::makeFromLength(static_cast<int64_t>(storage.size()))'),
     ('__last_dim', 'self.ndimension()-1'),
@@ -260,7 +258,6 @@ CONSTANT_REPLACEMENTS = [
 # Replacements for constants in header file function definitions
 HEADER_CONSTANT_REPLACEMENTS = [
     (r'AS_REAL\((.*)\)', r'\1'),
-    ('THPGenerator_TH_CData\(THPDefaultGenerator\)', 'nullptr'),
     ('__last_dim', '-1'),
 ]
 
@@ -832,8 +829,7 @@ def create_derived(backend_type_env, declarations):
 
     def drop_argument(argument, option):
         return 'CUDA' in backend_type_env['Backend'] and (
-            (option['mode'] == 'TH' and argument['type'] == 'THGenerator*') or
-            argument.get('default') == 'THPGenerator_TH_CData(THPDefaultGenerator)')
+            option['mode'] == 'TH' and argument['type'] == 'THGenerator*')
 
     def get_arguments(arguments, option):
         return [get_argument(argument, option)


### PR DESCRIPTION
….cwrap.

The specification and logic aren't necessary anymore, it's fine to specify the default as nullptr.