### PR TITLE
Fix BCELoss test precision issues that can show up with certain random seeds

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4088,7 +4088,7 @@ def bceloss_no_reduce_test():
         fullname='BCELoss_no_reduce',
         constructor=wrap_functional(
             lambda i: F.binary_cross_entropy(i, Variable(t.type_as(i.data)), reduce=False)),
-        input_fn=lambda: torch.rand(15, 10).clamp_(2e-2, 1 - 2e-2),
+        input_fn=lambda: torch.rand(15, 10).clamp_(2.8e-2, 1 - 2.8e-2),
         reference_fn=lambda i, m: -(t * i.log() + (1 - t) * (1 - i).log()),
         check_gradgrad=False,
         pickle=False)
@@ -4102,7 +4102,7 @@ def bceloss_weights_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.binary_cross_entropy(i, Variable(t.type_as(i.data)),
                                              weight=weights.type_as(i.data), reduce=False)),
-        input_fn=lambda: torch.rand(15, 10).clamp_(2e-2, 1 - 2e-2),
+        input_fn=lambda: torch.rand(15, 10).clamp_(2.8e-2, 1 - 2.8e-2),
         reference_fn=lambda i, m: -(t * i.log() + (1 - t) * (1 - i).log()) * weights,
         check_gradgrad=False,
         pickle=False)


### PR DESCRIPTION
BCELoss's outputs and gradInput computations are accurate to around 1e-6 on float types (as a relative value, not absolute), which is reasonable. However, the tests use absolute thresholds: the accumulation of 5 gradInputs has to have error less than 0.0002.

The worse case for BCELoss's gradInput for each element may be described as `1 / ( (1-x) * x )`. Previously, the input to the test was restricted to [0.02, 1- 0.02], resulting in worse-case largest gradInput of 50, resulting in a total accumulated grad of 50*5 = 250, resulting in an error of 250 * 1e-6 = 0.00025, which was too big.

By restricting x to [0.028, 1- 0.028] we get a worse case of 36.74, resulting in a total accumulated grad of 184, which is less than the 200 needed to have error less than 0.0002.

cc @ezyang 