### PR TITLE
Fix typo in fusion compiler

### DIFF
--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -77,7 +77,7 @@ std::unordered_map<NodeKind, std::string> simple_map_ops = {
 
   //alpha
   {kadd, "${0} + ${alpha}*${1}"},
-  {ksub, "${0} - ${alpha}*${1})"},
+  {ksub, "(${0} - ${alpha}*${1})"},
 
   // special
   {klerp, "${0} + ${weight}*(${1} - ${0})"},


### PR DESCRIPTION
This mismatched paren causes a syntax error in generated code. I'm guessing the parentheses are worth keeping, since there was one in there before, but I don't actually know whether the compiler can produce things like a - (b - c) that would make them required.
  