### PR TITLE
[ATen] have ger handle scalars like np.outer.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3069,6 +3069,7 @@
     - arg: THTensor* result
       output: True
       resize: [ [self,0], [vec2,0] ]
+      resize_scalar: True
     - CONSTANT AS_REAL(0)
     - argument 0
     - CONSTANT AS_REAL(1)

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -894,7 +894,11 @@ def create_derived(backend_type_env, declarations):
         if isinstance(resize, str):
             return "{}.resize_({}.sizes());".format(arg['name'], resize)
         else:
-            dims = ['{}.size({})'.format(name, dim) for name, dim in resize]
+            resize_scalar = arg.get('resize_scalar', False)
+            if resize_scalar:
+                dims = ['{}.dim() == 0 ? 1 : {}.size({})'.format(name, name, dim) for name, dim in resize]
+            else:
+                dims = ['{}.size({})'.format(name, dim) for name, dim in resize]
             return "{}.resize_({{ {} }});".format(arg['name'], ','.join(dims))
 
     def handle_call(env, option, cimpl):

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -265,6 +265,21 @@ void test(Type &T) {
         }
       }
 
+
+      // ger
+      {
+        auto lhs = T.ones(*lhs_it);
+        auto rhs = T.ones(*rhs_it);
+        try {
+          auto result = lhs.ger(rhs);
+          int64_t dim0 = lhs.dim() == 0 ? 1 : lhs.size(0);
+          int64_t dim1 = rhs.dim() == 0 ? 1 : rhs.size(0);
+          assert_equal_size_dim(result, result.type().tensor({dim0, dim1}));
+        } catch (std::runtime_error &e) {
+          ASSERT(lhs.numel() == 0 || rhs.numel() == 0 || lhs.dim() > 1 || rhs.dim() > 1);
+        }
+      }
+
       // expand
       {
         auto lhs = T.ones(*lhs_it);


### PR DESCRIPTION
Basically, scalars are implicitly unsqueezed; this is called "resize_scalar" because what's required is that the "resize" code handle scalars properly.  We should probably get rid of all the resize code eventually (either just implement it natively or push down the resizing to TH/THC), but this is the path of least resistance.