### PR TITLE
Batched linear system of equations solver (torch.bgesv)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3325,6 +3325,26 @@
     - THTensor* A
 ]]
 [[
+  name: bgesv
+  types:
+    - Float
+    - Double
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  return: argument 0,1
+  arguments:
+    - arg: THTensor* solution
+      output: True
+    - arg: THTensor* lu
+      output: True
+    - THTensor* self
+    - THTensor* A
+]]
+[[
   name: gels
   types:
     - Float

--- a/aten/src/TH/generic/THTensorLapack.c
+++ b/aten/src/TH/generic/THTensorLapack.c
@@ -108,9 +108,10 @@ static THTensor *THTensor_(cloneColumnMajor)(THTensor *self, THTensor *src)
 static THTensor *THTensor_(cloneBatchedColumnMajor)(THTensor *self, THTensor *src)
 {
   THAssert(src->nDimension == 3);
-  int64_t matrix_size = src->size[1] * src->size[2];
-  if (self == src && self->stride[0] == matrix_size && 
-      self->stride[1] == 1 && self->stride[2] == self->size[1]) {
+  int64_t stride[3] = { src->size[1] * src->size[2], 1, src->size[1] };
+
+  if (self == src && self->stride[0] == stride[0] &&
+      self->stride[1] == stride[1] && self->stride[2] == stride[2]) {
     THTensor_(retain)(self);
     return self;
   }
@@ -120,11 +121,7 @@ static THTensor *THTensor_(cloneBatchedColumnMajor)(THTensor *self, THTensor *sr
   } else {
     THTensor_(retain)(self);
   }
-
-  int64_t size[3] = { src->size[0], src->size[1], src->size[2] };
-  int64_t stride[3] = { matrix_size, 1, src->size[1] };
-
-  THTensor_(resizeNd)(self, 3, size, stride);
+  THTensor_(resizeNd)(self, 3, src->size, stride);
   THTensor_(copy)(self, src);
   return self;
 }

--- a/aten/src/TH/generic/THTensorLapack.c
+++ b/aten/src/TH/generic/THTensorLapack.c
@@ -101,6 +101,34 @@ static THTensor *THTensor_(cloneColumnMajor)(THTensor *self, THTensor *src)
   return THTensor_(cloneColumnMajorNrows)(self, src, src->size[0]);
 }
 
+/*
+ * Creates a clone of a 3D tensor such that each 2D batch is in column major
+ * format and each batch is contiguous WRT itself in memory.
+ */
+static THTensor *THTensor_(cloneBatchedColumnMajor)(THTensor *self, THTensor *src)
+{
+  THAssert(src->nDimension == 3);
+  int64_t matrix_size = src->size[1] * src->size[2];
+  if (self == src && self->stride[0] == matrix_size && 
+      self->stride[1] == 1 && self->stride[2] == self->size[1]) {
+    THTensor_(retain)(self);
+    return self;
+  }
+
+  if (self == src) {
+    self = THTensor_(new)();
+  } else {
+    THTensor_(retain)(self);
+  }
+
+  int64_t size[3] = { src->size[0], src->size[1], src->size[2] };
+  int64_t stride[3] = { matrix_size, 1, src->size[1] };
+
+  THTensor_(resizeNd)(self, 3, size, stride);
+  THTensor_(copy)(self, src);
+  return self;
+}
+
 void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
 {
   int free_b = 0;
@@ -151,6 +179,48 @@ void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
   THTensor_(freeCopyTo)(rb__, rb_);
   THIntTensor_free(ipiv);
   if (free_b) THTensor_(free)(b);
+}
+
+void THTensor_(bgesv)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a)
+{
+  if (a == NULL) a = ra_;
+  if (b == NULL) b = rb_;
+
+  THArgCheck(a->nDimension == 3, 1, "A should be 3 dimensional");
+  THArgCheck(b->nDimension == 3, 2, "b should be 3 dimensional");
+  THArgCheck(a->size[1] == a->size[2], 1, "A should be batches of square matrices");
+  THArgCheck(b->size[0] == a->size[0], 2, "A, b batch_count incompatible");
+  THArgCheck(b->size[1] == a->size[1], 2, "A, b size incompatible");
+
+  int64_t batch_count = a->size[0];
+  int64_t n = a->size[1];
+  int64_t nrhs = b->size[2];
+
+  THTensor *a_copy = THTensor_(cloneBatchedColumnMajor)(ra_, a);
+  THTensor *b_copy = THTensor_(cloneBatchedColumnMajor)(rb_, b);
+  real *a_copy_data = THTensor_(data)(a_copy);
+  real *b_copy_data = THTensor_(data)(b_copy);
+
+  THIntTensor *ipiv = THIntTensor_newWithSize1d(n);
+  int info;
+
+  for (int64_t i = 0; i < batch_count; i++) {
+    real *a_working_copy = &a_copy_data[i * n * n];
+    real *b_working_copy = &b_copy_data[i * n * nrhs];
+    THLapack_(gesv)(n, nrhs, a_working_copy, n, THIntTensor_data(ipiv),
+        b_working_copy, n, &info);
+    THLapackCheckWithCleanup(
+        "Lapack Error in %s : U(%d,%d) is zero, singular U for batch element %lld.",
+        THCleanup(
+            THTensor_(free)(a_copy);
+            THTensor_(free)(b_copy);
+            THIntTensor_free(ipiv);),
+        "bgesv", info, info, (long long)i);
+  }
+
+  THTensor_(freeCopyTo)(a_copy, ra_);
+  THTensor_(freeCopyTo)(b_copy, rb_);
+  THIntTensor_free(ipiv);
 }
 
 void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b, THTensor *a,

--- a/aten/src/TH/generic/THTensorLapack.h
+++ b/aten/src/TH/generic/THTensorLapack.h
@@ -3,6 +3,7 @@
 #else
 
 TH_API void THTensor_(gesv)(THTensor *rb_, THTensor *ra_, THTensor *b_, THTensor *a_);
+TH_API void THTensor_(bgesv)(THTensor *rb_, THTensor *ra_, THTensor *b_, THTensor *a_);
 TH_API void THTensor_(trtrs)(THTensor *rb_, THTensor *ra_, THTensor *b_, THTensor *a_, const char *uplo, const char *trans, const char *diag);
 TH_API void THTensor_(gels)(THTensor *rb_, THTensor *ra_, THTensor *b_, THTensor *a_);
 TH_API void THTensor_(syev)(THTensor *re_, THTensor *rv_, THTensor *a_, const char *jobz, const char *uplo);

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -179,10 +179,10 @@ THC_API void THCTensor_(bgesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
     int info = info_array[i];
     if (info < 0) {
       THError("MAGMA bgesv (gesv_batched) : For batch number %lld: Argument %d : illegal value",
-          (long long)batch_count, -info);
+          (long long)i, -info);
     } else if (info > 0) {
       THError("MAGMA bgesv (gesv_batched) : For batch number %lld: U(%d,%d) is zero, singular U.",
-          (long long)batch_count, info, info);
+          (long long)i, info, info);
     }
   }
 

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -59,6 +59,29 @@ static THCTensor* THCTensor_(newColumnMajor)(THCState *state, THCTensor *self, T
   return self;
 }
 
+static THCTensor* THCTensor_(newBatchedColumnMajor)(THCState *state, THCTensor *self, THCTensor *src)
+{
+  THAssert(src->nDimension == 3);
+  int64_t matrix_size = src->size[1] * src->size[2];
+  if (self == src && self->stride[0] == matrix_size && 
+      self->stride[1] == 1 && self->stride[2] == self->size[1])
+  {
+    THCTensor_(retain)(state, self);
+    return self;
+  }
+
+  if (self == src)
+    self = THCTensor_(new)(state);
+  else
+    THCTensor_(retain)(state, self);
+
+  int64_t size[3] = { src->size[0], src->size[1], src->size[2] };
+  int64_t stride[3] = { matrix_size, 1, src->size[1] };
+
+  THCTensor_(resizeNd)(state, self, 3, size, stride);
+  THCTensor_(copy)(state, self, src);
+  return self;
+}
 
 THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
 {
@@ -97,6 +120,76 @@ THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
   THError(NoMagma(gesv));
 #endif
 }
+
+THC_API void THCTensor_(bgesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
+{
+#ifdef USE_MAGMA
+  THArgCheck(a_->nDimension == 3, 1, "A should be 3 dimensional");
+  THArgCheck(b_->nDimension == 3, 2, "b should be 3 dimensional");
+  THArgCheck(a_->size[1] == a_->size[2], 1, "A should be batches of square matrices");
+  THArgCheck(b_->size[0] == a_->size[0], 2, "A, b batch_count incompatible");
+  THArgCheck(b_->size[1] == a_->size[1], 2, "A, b size incompatible");
+
+  int64_t batch_count = a_->size[0];
+  int64_t n = a_->size[1];
+  int64_t nrhs = b_->size[2];
+
+  THCTensor *a = THCTensor_(newBatchedColumnMajor)(state, ra_, a_);
+  THCTensor *b = THCTensor_(newBatchedColumnMajor)(state, rb_, b_);
+  real *a_data = THCTensor_(data)(state, a);
+  real *b_data = THCTensor_(data)(state, b);
+
+  real **a_array = th_magma_malloc_pinned<real *>(batch_count);
+  real **b_array = th_magma_malloc_pinned<real *>(batch_count);
+
+  int *info_array = th_magma_malloc_pinned<int>(batch_count);
+  int *ipiv_data = th_magma_malloc_pinned<int>(batch_count * n);
+  int **ipiv_array = th_magma_malloc_pinned<int *>(batch_count);
+
+  for (int64_t i = 0; i < batch_count; i++) {
+    a_array[i] = &a_data[i * n * n];
+    b_array[i] = &b_data[i * n * nrhs]; 
+    ipiv_array[i] = &ipiv_data[i * n];
+  }
+
+  magma_queue_t magma_queue;
+  magma_queue_create_from_cuda(
+      THCTensor_(getDevice)(state, a_),
+      THCState_getCurrentStream(state),
+      THCState_getCurrentBlasHandle(state),
+      THCState_getCurrentSparseHandle(state),
+      &magma_queue);
+
+#if defined(THC_REAL_IS_FLOAT)
+  magma_sgesv_batched(n, nrhs, a_array, n, ipiv_array, b_array, n, info_array, batch_count, magma_queue);
+#else
+  magma_dgesv_batched(n, nrhs, a_array, n, ipiv_array, b_array, n, info_array, batch_count, magma_queue);
+#endif
+
+  for (int64_t i = 0; i < batch_count; i++) {
+    int info = info_array[i];
+    if (info < 0) {
+      THError("MAGMA bgesv (gesv_batched) : For batch number %lld: Argument %d : illegal value",
+          (long long)batch_count, -info);
+    } else if (info > 0) {
+      THError("MAGMA bgesv (gesv_batched) : For batch number %lld: U(%d,%d) is zero, singular U.",
+          (long long)batch_count, info, info);
+    }
+  }
+
+  magma_queue_destroy(magma_queue);
+  magma_free_pinned(ipiv_array);
+  magma_free_pinned(ipiv_data);
+  magma_free_pinned(info_array);
+  magma_free_pinned(a_array);
+  magma_free_pinned(b_array);
+  THCTensor_(freeCopyTo)(state, a, ra_);
+  THCTensor_(freeCopyTo)(state, b, rb_);
+#else
+  THError(NoMagma(bgesv));
+#endif
+}
+
 
 THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
 {

--- a/aten/src/THC/generic/THCTensorMathMagma.h
+++ b/aten/src/THC/generic/THCTensorMathMagma.h
@@ -6,6 +6,7 @@
 
 // MAGMA (i.e. CUDA implementation of LAPACK functions)
 THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
+THC_API void THCTensor_(bgesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
 THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
 THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a_, const char *jobz, const char *uplo);
 THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a_, const char *jobvr);

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2225,6 +2225,7 @@ method_tests = [
     ('det', lambda: random_fullrank_matrix_distinct_singular_value(S), (), 'distinct_postive_s', (), [skipIfNoLapack]),
     ('svd', lambda: random_fullrank_matrix_distinct_singular_value(S), (), '', (), [skipIfNoLapack]),
     ('gesv', (S, S), ((S, S),), '', (), [skipIfNoLapack]),
+    ('bgesv', (S, S, S), ((S, S, S),), '', (), [skipIfNoLapack]),
     ('eq', (S, S, S), ((S, S, S),)),
     ('eq', (S, S, S), ((1,),), 'broadcast_rhs'),
     ('eq', (1,), ((S, S, S),), 'broadcast_lhs'),

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1033,6 +1033,9 @@ class TestCuda(TestCase):
     def test_btrisolve(self):
         TestTorch._test_btrisolve(self, lambda t: t.cuda())
 
+    def test_bgesv(self):
+        TestTorch._test_bgesv(self, lambda t: t.cuda())
+
     def test_dim_reduction(self):
         TestTorch._test_dim_reduction(self, lambda t: t.cuda())
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2093,13 +2093,30 @@ class TestTorch(TestCase):
         self.assertEqual(res1, tb)
 
     def _test_bgesv(self, cast):
-        # test against gesv
+        # test against gesv: one batch
         A = cast(torch.randn(1, 5, 5))
         b = cast(torch.randn(1, 5, 10))
         x_exp, LU_exp = torch.gesv(b.squeeze(0), A.squeeze(0))
         x, LU = torch.bgesv(b, A)
         self.assertEqual(x, x_exp.unsqueeze(0))
         self.assertEqual(LU, LU_exp.unsqueeze(0))
+
+        # test against gesv in a loop: four batches
+        A = cast(torch.randn(4, 5, 5))
+        b = cast(torch.randn(4, 5, 10))
+
+        x_exp_list = list()
+        LU_exp_list = list()
+        for i in range(4):
+            x_exp, LU_exp = torch.gesv(b[i], A[i])
+            x_exp_list.append(x_exp)
+            LU_exp_list.append(LU_exp)
+        x_exp = torch.stack(x_exp_list)
+        LU_exp = torch.stack(LU_exp_list)
+
+        x, LU = torch.bgesv(b, A)
+        self.assertEqual(x, x_exp)
+        self.assertEqual(LU, LU_exp)
 
         # basic correctness test
         A = cast(torch.randn(3, 5, 5))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2092,6 +2092,37 @@ class TestTorch(TestCase):
         torch.gesv(b, a, out=(tb, ta))[0]
         self.assertEqual(res1, tb)
 
+    def _test_bgesv(self, cast):
+        # test against gesv
+        A = cast(torch.randn(1, 5, 5))
+        b = cast(torch.randn(1, 5, 10))
+        x_exp, LU_exp = torch.gesv(b.squeeze(0), A.squeeze(0))
+        x, LU = torch.bgesv(b, A)
+        self.assertEqual(x, x_exp.unsqueeze(0))
+        self.assertEqual(LU, LU_exp.unsqueeze(0))
+
+        # basic correctness test
+        A = cast(torch.randn(3, 5, 5))
+        b = cast(torch.randn(3, 5, 10))
+        x, LU = torch.bgesv(b, A)
+        self.assertEqual(torch.bmm(A, x), b)
+
+        # specified outputs
+        tA = cast(torch.Tensor())
+        tb = cast(torch.Tensor())
+        x1, LU1 = torch.bgesv(b, A, out=(tb, tA))
+        self.assertEqual(x1, x)
+        self.assertEqual(LU1, LU)
+
+        # self output
+        x2, LU2 = torch.bgesv(b, A, out=(b, A))
+        self.assertEqual(x1, x)
+        self.assertEqual(LU1, LU)
+
+    @skipIfNoLapack
+    def test_bgesv(self):
+        self._test_bgesv(lambda t: t)
+
     @skipIfNoLapack
     def test_qr(self):
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -274,6 +274,10 @@
   self: std::get<0>(gesv(grad, A.t()))
   A: -at::mm(std::get<0>(gesv(grad, A.t())), solution.t())
 
+- name: bgesv(Tensor self, Tensor A)
+  self: std::get<0>(bgesv(grad, A.transpose(1, 2)))
+  A: -at::bmm(std::get<0>(bgesv(grad, A.transpose(1, 2))), solution.transpose(1, 2))
+
 # get_device
 
 - name: gt(Tensor self, Scalar other)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1703,6 +1703,51 @@ Example::
 
 """)
 
+add_docstr(torch._C.bgesv,
+           r"""
+bgesv(B, A, out=None) -> (Tensor, Tensor)
+
+A batched system of linear equations solver.
+`X, LU = torch.bgesv(B, A)` returns the solution to the system of linear
+equations represented by :math:`A_i X_i = B_i`.
+
+`LU_i` contains `L` and `U` factors for LU factorization of `A_i`.
+
+:attr:Each `A_i` has to be a square and non-singular matrix. As a result,
+`A` must be a 3D tensor.
+
+If `A` is an :math:`(n \times m \times m)` tensor and `B` is :math:`(n \times m \times k)`,
+the result `LU` is :math:`(n \times m \times m)` and `X_i` is :math:`(n \times m \times k)`.
+
+.. note::
+
+    Irrespective of the original strides, the returned matrices
+    `X` and `LU` will be transposed. `X` has strides :math:`(m * k, 1, m)`
+    and `LU` has strides :math:`(m * m, 1, m)`.
+
+Args:
+    B (Tensor): input tensor of :math:`(n \times m \times k)` dimensions.
+        B is a batch of :math:`(m \times k)` matrices.
+    A (Tensor): input tensor of :math:`(n \times m \times m)` dimensions
+        A is a batch of :math:`(m \times m)` square matrices.
+    out (Tensor, optional): optional output tensors
+
+Example::
+
+    >>> A = torch.Tensor([[[1.4, 2.6],
+    ...                    [3.1, 4.4]],
+    ...                   [[0.5, 0.2],
+    ...                    [0.1, 5.2]]])
+    >>> B = torch.Tensor([[[1, 2, 5],
+    ...                    [3, 4, 6]],
+    ...                   [[0.5, 0.2, 0.1],
+    ...                    [0.1, 5.2, 3.1]]])
+    >>> X, LU = torch.bgesv(B, A)
+    >>> torch.dist(B, torch.bmm(A, X))
+    1.099080577660061e-06
+
+""")
+
 add_docstr(torch._C.get_num_threads,
            r"""
 get_num_threads() -> int

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -337,6 +337,7 @@ IMPLEMENT_STATELESS(rand)
 IMPLEMENT_STATELESS(randn)
 IMPLEMENT_STATELESS(masked_select)
 IMPLEMENT_STATELESS(gesv)
+IMPLEMENT_STATELESS(bgesv)
 IMPLEMENT_STATELESS(gels)
 IMPLEMENT_STATELESS(trtrs)
 IMPLEMENT_STATELESS(symeig)
@@ -759,6 +760,7 @@ static PyMethodDef TorchMethods[] = {
   {"cat",             (PyCFunction)THPModule_cat,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"masked_select",   (PyCFunction)THPModule_masked_select,     METH_VARARGS | METH_KEYWORDS, NULL},
   {"gesv",            (PyCFunction)THPModule_gesv,              METH_VARARGS | METH_KEYWORDS, NULL},
+  {"bgesv",           (PyCFunction)THPModule_bgesv,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"gels",            (PyCFunction)THPModule_gels,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"trtrs",           (PyCFunction)THPModule_trtrs,             METH_VARARGS | METH_KEYWORDS, NULL},
   {"symeig",          (PyCFunction)THPModule_symeig,            METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/TensorMath.cwrap
+++ b/torch/csrc/generic/methods/TensorMath.cwrap
@@ -2368,6 +2368,27 @@ static const char *R = &__R;
 ]]
 
 [[
+  name: bgesv
+  types:
+    - Float
+    - Double
+  backends:
+    - CPU
+    - CUDA
+  variants:
+    - method
+    - function
+  return: argument 0,1
+  arguments:
+    - arg: THTensor* solution
+      output: True
+    - arg: THTensor* lu
+      output: True
+    - THTensor* self
+    - THTensor* A
+]]
+
+[[
   name: gels
   types:
     - Float


### PR DESCRIPTION
Implements torch.bgesv, a batched linear system of equations solver.

Adds bindings for MAGMA's gesv_batched function for CUDA.
For CPU, runs THLapack(gesv) in a for loop.

I decided to not build this into `torch.gesv` but if we want to I can change that.

cc @apaszke 

### Test Plan
New unit tests:
- CPU test against `torch.gesv` and specifying outputs
- GPU test for the same thing
- autograd test for derivative
