### PR TITLE
Fix multi-gpu fuser bug

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -27,6 +27,8 @@ if torch.cuda.is_available():
         if (CUDA_VERSION < 8000 and major >= 6) or (CUDA_VERSION < 9000 and major >= 7):
             RUN_CUDA = False
 
+RUN_CUDA_MULTI_GPU = RUN_CUDA and torch.cuda.device_count() > 1
+
 
 def LSTMCell(input, hidden, w_ih, w_hh, b_ih=None, b_hh=None):
     hx, cx = hidden
@@ -328,6 +330,23 @@ class TestJit(TestCase):
     def test_compile_addc(self):
         x = Variable(torch.Tensor([0.4]), requires_grad=True).float().cuda()
         y = Variable(torch.Tensor([0.7]), requires_grad=True).float().cuda()
+
+        @torch.jit.compile(nderivs=0)
+        def doit(x, y):
+            return torch.sigmoid(torch.tanh(x * (x + y) + 1))
+
+        z = doit(x, y)
+        with self.assertCompiled(doit):
+            z2 = doit(x, y)
+        self.assertEqual(z, torch.sigmoid(torch.tanh(x * (x + y) + 1)))
+        self.assertEqual(z, z2)
+
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA_MULTI_GPU, "needs non-zero device")
+    def test_compile_fuse_last_device(self):
+        max_device = torch.cuda.device_count() - 1
+        x = Variable(torch.Tensor([0.4]), requires_grad=True).float().cuda(max_device)
+        y = Variable(torch.Tensor([0.7]), requires_grad=True).float().cuda(max_device)
 
         @torch.jit.compile(nderivs=0)
         def doit(x, y):

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "accumulate_grad.h"
 #include "basic_ops.h"
 #include "tensor.h"

--- a/torch/csrc/jit/fusion_compiler.h
+++ b/torch/csrc/jit/fusion_compiler.h
@@ -46,15 +46,13 @@ private:
   size_t nDim_;
 };
 
-// short-term storage only, so it borrows Graph.
-// this type is probably temporary.
-// it will be replaced when the needed TensorDesc information is encoded
-// directly in the information in the IR (e.g. in the Type object)
+constexpr int kCPUDevice = -1;
 struct AnnotatedGraph {
-  AnnotatedGraph(Graph & graph, bool is_cuda)
-  : graph(&graph), is_cuda(is_cuda) {}
+  // short-term storage only, so it borrows Graph.
+  AnnotatedGraph(Graph & graph, int device)
+  : graph(&graph), device(device) {}
   Graph* graph = nullptr;
-  bool is_cuda = false;
+  int device = kCPUDevice;
   std::vector<TensorDesc> input_desc;
   std::vector<TensorDesc> output_desc;
 };
@@ -137,14 +135,14 @@ struct FusionCompiler {
 
   // uses inputs/outputs as examples to infer continuity, does not run the graph
   std::shared_ptr<CompiledFusionFunction> getOrCompile(Graph & graph,
-                                                       bool is_cuda,
+                                                       int device,
                                                        at::ArrayRef<at::Tensor> inputs,
                                                        at::ArrayRef<at::Tensor> outputs);
   // debugging function that lets you do everything from compilation to execution
   // in one step.
   // this should not be used in the hot path of execution because it has to serialize
   // the graph each time
-  void debugLaunchGraph(Graph & graph, bool is_cuda, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs);
+  void debugLaunchGraph(Graph & graph, int device, at::ArrayRef<at::Tensor> inputs, at::ArrayRef<at::Tensor> outputs);
   bool canCompileOnCPU() const {
     return config_.cxx.size() > 0;
   }

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -125,7 +125,7 @@ _(tan) \
 _(trunc) \
 _(zeros) \
 _(exponent) \
-_(is_cuda)
+_(device)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -767,10 +767,10 @@ public:
     n->t_(kvalue, ref.clone());
     return n;
   }
-  Node * createFusionGroup(bool is_cuda) {
+  Node * createFusionGroup(int device) {
     auto n = create(kFusionGroup, 0);
     n->g_(kSubgraph,std::make_shared<Graph>(scope_root_));
-    n->i_(kis_cuda, is_cuda);
+    n->i_(kdevice, device);
     return n;
   }
   Node * createPythonOp(THPObjectPtr&& pyobj, const std::string & cconv, bool is_legacy, std::vector<VariableFlags> && var_flags, pyobj_list&& scalar_args);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -167,7 +167,7 @@ static void fusionTests() {
     auto a = at::CUDA(at::kFloat).rand({3,4});
     auto b = at::CUDA(at::kFloat).rand({4,3}).transpose(0,1);
     auto o = at::CUDA(at::kFloat).zeros({3,4});
-    comp.debugLaunchGraph(graph, true, {a,b}, {o});
+    comp.debugLaunchGraph(graph, 0, {a,b}, {o});
     auto o2 = a*b;
     float max_diff = (o2 - o).abs().max().toCDouble();
     //std::cout << "max diff: " << max_diff << "\n";
@@ -228,7 +228,7 @@ static void fusionTests() {
 
 
     //auto out0 = inputs[0]*inputs[1];
-    comp.debugLaunchGraph(graph, true, inputs, outputs);
+    comp.debugLaunchGraph(graph, 0, inputs, outputs);
     JIT_ASSERT(out0.is_same_size(outputs.front()));
     float max_diff = (outputs.front() - out0).abs().max().toCDouble();
     JIT_ASSERT(max_diff < 1e-6);
@@ -260,7 +260,7 @@ static void fusionTests() {
     auto o_r = a*b;
     auto o2_r = at::cat({a, o_r}, dim);
     auto o2 = at::CUDA(at::kFloat).zeros(o2_r.sizes());
-    comp.debugLaunchGraph(graph, true, {a,b}, {o, o2});
+    comp.debugLaunchGraph(graph, 0, {a,b}, {o, o2});
 
     float max_diff = (o_r - o).abs().max().toCDouble();
     JIT_ASSERT(max_diff == 0);


### PR DESCRIPTION
cuModuleLoad is only valid for a single device so we need to
compile for the particular device that the fusion group will run on.
CompiledFunction already specializes different traces for tensors,
so we just need to have fusion_compiler produce the cuFunction on
the right device.