### PR TITLE
[ATen] Improve ASSERT test infra.

### DIFF
--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -31,14 +31,10 @@ int main() {
   foo = foo+foo*3;
   foo -= 4;
 
-  bool threw = false;
-  try {
+  {
     Tensor no;
-    add_out(no,foo,foo);
-  } catch (std::runtime_error&) {
-    threw = true;
+    ASSERT_THROWS(add_out(no,foo,foo));
   }
-  check(threw);
   Scalar a = 4;
 
   float b = a.to<float>();
@@ -70,13 +66,7 @@ int main() {
 
   cout << f << endl;
   cout << f.strides() << " " << f.sizes() << endl;
-  threw = false;
-  try {
-    f.resize_({3,4,5});
-  } catch(std::runtime_error&) {
-    threw = true;
-  }
-  check(threw);
+  ASSERT_THROWS(f.resize_({3,4,5}));
   {
     int isgone = 0;
     {

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -8,11 +8,10 @@ int main() {
 
   // 0) pre-req tests:
   // can't expand empty tensor
-  try {
+  {
     auto empty = T.randn({0});
-    empty.expand({3});
-    ASSERT(false);
-  } catch(std::runtime_error &e) {}
+    ASSERT_THROWS(empty.expand({3}));
+  }
 
   // 1) out-place function with 2 args
   {
@@ -29,20 +28,18 @@ int main() {
     ASSERT((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
 
     // old fallback behavior yields error
-    try {
+    {
       auto a = T.randn({3, 5});
       auto b = T.randn({5, 3});
-      a + b;
-      ASSERT(false);
-    } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(a + b);
+    }
 
     // with mismatched sizes
-    try {
+    {
       auto a = T.randn({3, 5});
       auto b = T.randn({7, 5});
-      a + b;
-      ASSERT(false);
-    } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(a + b);
+    }
   }
 
   // 2) out-place function with 3 args
@@ -63,20 +60,18 @@ int main() {
            aTensorScalar.expand(expanded_sizes).addcmul(b.expand(expanded_sizes), c.expand(expanded_sizes))));
 
     // old fallback behavior yields error
-    try {
+    {
       auto a = T.randn({3, 2, 5});
       auto b = T.randn({2, 3, 5});
       auto c = T.randn({5, 3, 2});
-      a.addcmul(b, c);
-      ASSERT(false);
-    } catch(std::runtime_error &e) {}
+      ASSERT_THROWS(a.addcmul(b, c));
+    }
 
     // with mismatched sizes
-    try {
+    {
       auto c = T.randn({5, 5, 5});
-      a.addcmul(b, c);
-      ASSERT(false);
-    } catch(std::runtime_error &e) {}
+      ASSERT_THROWS(a.addcmul(b, c));
+    }
   }
 
   // 3) in-place function with 2 args
@@ -92,12 +87,11 @@ int main() {
     ASSERT((a + bScalar).equal(a + bScalar.expand(a.sizes())));
 
     // error: would have to expand inplace arg
-    try {
+    {
       auto a = T.randn({1, 5});
       auto b = T.randn({3, 1});
-      a.add_(b);
-      ASSERT(false);
-    } catch(std::runtime_error &e) {}
+      ASSERT_THROWS(a.add_(b));
+    }
   }
 
   // 4) in-place function with 3 args
@@ -116,13 +110,12 @@ int main() {
     ASSERT(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
 
     // error: would have to expand inplace arg
-    try {
+    {
       auto a = T.randn({1, 3, 5});
       auto b = T.randn({4, 1, 1});
       auto c = T.randn({1, 3, 1});
-      a.addcmul_(b, c);
-      ASSERT(false);
-    } catch(std::runtime_error &e) {}
+      ASSERT_THROWS(a.addcmul_(b, c));
+    }
   }
 
   // explicit dim specification
@@ -139,11 +132,10 @@ int main() {
     ASSERT(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
 
     // with mismatched sizes
-    try {
+    {
       auto a = T.randn({3, 3});
-      a.addmm(b, c);
-      ASSERT(false);
-    } catch(std::runtime_error &e) {}
+      ASSERT_THROWS(a.addmm(b, c));
+    }
   }
 
   return 0;

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -61,10 +61,10 @@ void test(Type & T, Type & AccT) {
   // size / stride
   {
     auto scalar = T.randn({});
-    ASSERT_THROWS(scalar.size(0), "dimension specified as 0 but tensor has no dimensions");
-    ASSERT_THROWS(scalar.size(-1), "dimension specified as -1 but tensor has no dimensions");
-    ASSERT_THROWS(scalar.stride(0), "dimension specified as 0 but tensor has no dimensions");
-    ASSERT_THROWS(scalar.stride(-1), "dimension specified as -1 but tensor has no dimensions");
+    ASSERT_THROWSM(scalar.size(0), "dimension specified as 0 but tensor has no dimensions");
+    ASSERT_THROWSM(scalar.size(-1), "dimension specified as -1 but tensor has no dimensions");
+    ASSERT_THROWSM(scalar.stride(0), "dimension specified as 0 but tensor has no dimensions");
+    ASSERT_THROWSM(scalar.stride(-1), "dimension specified as -1 but tensor has no dimensions");
 
     auto empty = T.randn({0});
     ASSERT(empty.size(0) == 0);
@@ -80,8 +80,8 @@ void test(Type & T, Type & AccT) {
     auto d2 = T.randn({2, 3});
 
     // 0-d
-    ASSERT_THROWS(scalar.matmul(d2), "both arguments to matmul need to be at least 1D");
-    ASSERT_THROWS(d2.matmul(scalar), "both arguments to matmul need to be at least 1D");
+    ASSERT_THROWSM(scalar.matmul(d2), "both arguments to matmul need to be at least 1D");
+    ASSERT_THROWSM(d2.matmul(scalar), "both arguments to matmul need to be at least 1D");
 
     // 1-d
     ASSERT_ALLCLOSE(d1.matmul(d1), d1.dot(d1));
@@ -126,7 +126,7 @@ void test(Type & T, Type & AccT) {
 
     // non-expandable case
     auto d5wrong = T.randn({2, 4, 2, 4, 3, 2});
-    ASSERT_THROWS(d5.matmul(d5wrong), "must match the size");
+    ASSERT_THROWSM(d5.matmul(d5wrong), "must match the size");
   }
 
   // _standard_gamma_grad
@@ -145,14 +145,14 @@ void test(Type & T, Type & AccT) {
     Type & DT = CPU(kDouble);
     auto t1 = T.randn({3, 4});
     auto t2 = DT.randn({3, 4});
-    ASSERT_THROWS(t1._standard_gamma_grad(t2), "expected scalar type");
+    ASSERT_THROWSM(t1._standard_gamma_grad(t2), "expected scalar type");
   } else {
     auto ct1 = T.randn({3, 4});
     auto ct2 = T.randn({3, 4});
     auto t1 = T.toBackend(Backend::CPU).randn({3, 4});
-    ASSERT_THROWS(ct1._standard_gamma_grad(ct2), "not implemented");
-    ASSERT_THROWS(ct1._standard_gamma_grad(t1), "not implemented");
-    ASSERT_THROWS(t1._standard_gamma_grad(ct2), "CUDA Backend");
+    ASSERT_THROWSM(ct1._standard_gamma_grad(ct2), "not implemented");
+    ASSERT_THROWSM(ct1._standard_gamma_grad(t1), "not implemented");
+    ASSERT_THROWSM(t1._standard_gamma_grad(ct2), "CUDA Backend");
   }
 
   // where

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -49,11 +49,7 @@ void test(Type &T) {
     if (t.numel() != 0) {
       ASSERT(t.unsqueeze(0).dim() == t.dim() + 1);
     } else {
-      try {
-        // can't unsqueeze empty tensor
-        t.unsqueeze(0);
-        assert (false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.unsqueeze(0));
     }
 
     // unsqueeze_
@@ -63,11 +59,7 @@ void test(Type &T) {
         auto r = t2.unsqueeze_(0);
         ASSERT(r.dim() == t.dim() + 1);
       } else {
-        try {
-          // can't unsqueeze empty tensor
-          t2.unsqueeze_(0);
-          assert (false);
-        } catch (std::runtime_error &e) {}
+        ASSERT_THROWS(t2.unsqueeze_(0));
       }
     }
 
@@ -75,10 +67,7 @@ void test(Type &T) {
     if (t.dim() > 0 && t.sizes()[0] == 1) {
       ASSERT(t.squeeze(0).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
-      try {
-        t.squeeze(0);
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.squeeze(0));
     } else {
       // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
       // in NumPy this is an error.
@@ -103,10 +92,7 @@ void test(Type &T) {
       if (t2.dim() > 0 && t2.sizes()[0] == 1) {
         ASSERT(t2.squeeze_(0).dim() == t.dim() - 1);
       } else if (t2.dim() == 0) {
-        try {
-          t2.squeeze_(0);
-          ASSERT(false);
-        } catch (std::runtime_error &e) {}
+        ASSERT_THROWS(t2.squeeze_(0));
       } else {
         // In PyTorch, it is a no-op to try to squeeze a dimension that has size != 1;
         // in NumPy this is an error.
@@ -131,16 +117,10 @@ void test(Type &T) {
     if (t.dim() > 0 && t.numel() != 0) {
       ASSERT(t.sum(0).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
-      try {
-        t.sum(0);
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.sum(0));
     } else {
       // FIXME: you should be able to reduce over size {0}
-      try {
-        t.sum(0);
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.sum(0));
     }
 
     // reduce (with dimension argument and with 2 return arguments)
@@ -149,37 +129,25 @@ void test(Type &T) {
       ASSERT(std::get<0>(ret).dim() == t.dim() - 1);
       ASSERT(std::get<1>(ret).dim() == t.dim() - 1);
     } else if (t.dim() == 0) {
-      try {
-        t.sum(0);
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.min(0));
     } else {
       // FIXME: you should be able to reduce over size {0}
-      try {
-        t.sum(0);
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t.min(0));
     }
 
     // simple indexing
     if (t.dim() > 0 && t.numel() != 0) {
       ASSERT(t[0].dim() == std::max<int64_t>(t.dim() - 1, 0));
     } else if (t.dim() == 0) {
-      try {
-        t[0];
-        ASSERT(false);
-      } catch (std::runtime_error &e) {}
+      ASSERT_THROWS(t[0]);
     }
 
     // fill_
     if (t.dim() > 0 && t.numel() != 0) {
-      try {
-        // can only fill_ 0-dim tensors
-        t.fill_(t.sum(0));
-        assert(t.dim() == 1);
-      } catch (std::runtime_error &e) {
-        assert(t.dim() != 1);
-      }
+      // can only fill_ 0-dim tensors
+      TRY_CATCH_ELSE(t.fill_(t.sum(0)),
+                     ASSERT(t.dim() != 1),
+                     ASSERT(t.dim() == 1));
     }
   }
 
@@ -244,25 +212,18 @@ void test(Type &T) {
         auto lhs = T.ones(*lhs_it);
         auto rhs = T.ones(*rhs_it);
         auto rhs_size = *rhs_it;
-        try {
-          auto result = lhs.view(rhs_size);
-          ASSERT(lhs.numel() == rhs.numel());
-          assert_equal_size_dim(result, rhs);
-        } catch (std::runtime_error &e) {
-          ASSERT(lhs.numel() != rhs.numel());
-        }
+        TRY_CATCH_ELSE(auto result = lhs.view(rhs_size),
+                       ASSERT(lhs.numel() != rhs.numel()),
+                       ASSERT(lhs.numel() == rhs.numel()); assert_equal_size_dim(result, rhs););
       }
 
       // take
       {
         auto lhs = T.ones(*lhs_it);
         auto rhs = T.zeros(*rhs_it).toType(ScalarType::Long);
-        try {
-          auto result = lhs.take(rhs);
-          assert_equal_size_dim(result, rhs);
-        } catch (std::runtime_error &e) {
-          ASSERT(lhs.numel() == 0 && rhs.numel() != 0);
-        }
+        TRY_CATCH_ELSE(auto result = lhs.take(rhs),
+                       ASSERT(lhs.numel() == 0 && rhs.numel() != 0),
+                       assert_equal_size_dim(result, rhs));
       }
 
 
@@ -270,14 +231,13 @@ void test(Type &T) {
       {
         auto lhs = T.ones(*lhs_it);
         auto rhs = T.ones(*rhs_it);
-        try {
-          auto result = lhs.ger(rhs);
-          int64_t dim0 = lhs.dim() == 0 ? 1 : lhs.size(0);
-          int64_t dim1 = rhs.dim() == 0 ? 1 : rhs.size(0);
-          assert_equal_size_dim(result, result.type().tensor({dim0, dim1}));
-        } catch (std::runtime_error &e) {
-          ASSERT(lhs.numel() == 0 || rhs.numel() == 0 || lhs.dim() > 1 || rhs.dim() > 1);
-        }
+        TRY_CATCH_ELSE(auto result = lhs.ger(rhs),
+                       ASSERT(lhs.numel() == 0 || rhs.numel() == 0 || lhs.dim() > 1 || rhs.dim() > 1),
+                       [&]() {
+                         int64_t dim0 = lhs.dim() == 0 ? 1 : lhs.size(0);
+                         int64_t dim1 = rhs.dim() == 0 ? 1 : rhs.size(0);
+                         assert_equal_size_dim(result, result.type().tensor({dim0, dim1}));
+                       }(););
       }
 
       // expand
@@ -287,26 +247,18 @@ void test(Type &T) {
         auto rhs = T.ones(*rhs_it);
         auto rhs_size = *rhs_it;
         bool should_pass = should_expand(lhs_size, rhs_size);
-        try {
-          auto result = lhs.expand(rhs_size);
-          ASSERT(should_pass);
-          assert_equal_size_dim(result, rhs);
-        } catch (std::runtime_error &e) {
-          ASSERT(!should_pass);
-        }
+        TRY_CATCH_ELSE(auto result = lhs.expand(rhs_size),
+                       ASSERT(!should_pass),
+                       ASSERT(should_pass); assert_equal_size_dim(result, rhs););
 
         // in-place functions (would be good if we can also do a non-broadcasting one, b/c
         // broadcasting functions will always end up operating on tensors of same size;
         // is there an example of this outside of assign_ ?)
         {
           bool should_pass_inplace = should_expand(rhs_size, lhs_size);
-          try {
-            lhs.add_(rhs);
-            ASSERT(should_pass_inplace);
-            assert_equal_size_dim(lhs, T.ones(*lhs_it));
-          } catch (std::runtime_error &e) {
-            ASSERT(!should_pass_inplace);
-          }
+          TRY_CATCH_ELSE(lhs.add_(rhs),
+                         ASSERT(!should_pass_inplace),
+                         ASSERT(should_pass_inplace); assert_equal_size_dim(lhs, T.ones(*lhs_it)););
         }
       }
     }

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -116,13 +116,7 @@ int main() {
   Tensor next_h = i2h.add(h2h);
   next_h = next_h.tanh();
 
-  bool threw = false;
-  try {
-    Scalar{Tensor{}};
-  } catch (std::runtime_error& e) {
-    threw = true;
-  }
-  ASSERT(threw);
+  ASSERT_THROWS(Scalar{Tensor{}});
 
   test_ctors();
   test_overflow();
@@ -142,11 +136,10 @@ int main() {
   dispatch_all<void, Foo>(x.type(),"foo",x,prev_h);
 
   // test direct C-scalar type conversions
-  try {
+  {
     auto x = T.ones({1,2});
-    x.toCFloat();
-    ASSERT(false);
-  } catch (std::runtime_error &e) {}
+    ASSERT_THROWS(x.toCFloat());
+  }
   auto float_one = T.ones({});
   ASSERT(float_one.toCFloat() == 1);
   ASSERT(float_one.toCInt() == 1);

--- a/aten/src/ATen/test/test_assert.h
+++ b/aten/src/ATen/test/test_assert.h
@@ -29,13 +29,25 @@ static inline void barf(const char *fmt, ...) {
     barf("%s:%u: %s: Assertion `%s` failed: " msg , __FILE__, __LINE__, __func__, #cond,##__VA_ARGS__); \
   }
 
-#define ASSERT_THROWS(fn, message)                                  \
-try {                                                               \
-  fn;                                                               \
-  ASSERT(false);                                                    \
-} catch(std::runtime_error &e) {                                    \
-  ASSERT(std::string(e.what()).find(message) != std::string::npos); \
-}
+#define TRY_CATCH_ELSE(fn, catc, els)                           \
+  {                                                             \
+    /* avoid mistakenly passing if els code throws exception*/  \
+    bool _passed = false;                                       \
+    try {                                                       \
+      fn;                                                       \
+      _passed = true;                                           \
+      els;                                                      \
+    } catch (std::runtime_error &e) {                           \
+      ASSERT(!_passed);                                         \
+      catc;                                                     \
+    }                                                           \
+  }
+
+#define ASSERT_THROWSM(fn, message)     \
+  TRY_CATCH_ELSE(fn, ASSERT(std::string(e.what()).find(message) != std::string::npos), ASSERT(false))
+
+#define ASSERT_THROWS(fn)  \
+  ASSERT_THROWSM(fn, "");
 
 #define ASSERT_EQUAL(t1, t2) \
   ASSERT(t1.equal(t2));

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -14,31 +14,31 @@ int main() {
   ASSERT(!und.defined());
   ASSERT(std::string("UndefinedTensor") == und.toString());
 
-  ASSERT_THROWS(und.strides(), "strides");
-  ASSERT_THROWS(und.dim(), "dim");
-  ASSERT_THROWS([]() {return Tensor();}() = Scalar(5), "UndefinedType");
-  ASSERT_THROWS(und.unsafeGetTH(true), "unsafeGetTH");
-  ASSERT_THROWS(und.add(und), "add");
-  ASSERT_THROWS(und.add(ft), "add");
-  ASSERT_THROWS(ft.add(und), "add");
-  ASSERT_THROWS(und.add(5), "add");
-  ASSERT_THROWS(und.mm(und), "mm");
+  ASSERT_THROWSM(und.strides(), "strides");
+  ASSERT_THROWSM(und.dim(), "dim");
+  ASSERT_THROWSM([]() {return Tensor();}() = Scalar(5), "UndefinedType");
+  ASSERT_THROWSM(und.unsafeGetTH(true), "unsafeGetTH");
+  ASSERT_THROWSM(und.add(und), "add");
+  ASSERT_THROWSM(und.add(ft), "add");
+  ASSERT_THROWSM(ft.add(und), "add");
+  ASSERT_THROWSM(und.add(5), "add");
+  ASSERT_THROWSM(und.mm(und), "mm");
 
   und.toType(und.type());
-  ASSERT_THROWS(und.toType(ft.type()), "attempt to copy an undefined tensor");
-  ASSERT_THROWS(ft.toType(und.type()), "UndefinedType");
+  ASSERT_THROWSM(und.toType(ft.type()), "attempt to copy an undefined tensor");
+  ASSERT_THROWSM(ft.toType(und.type()), "UndefinedType");
   und.toType(ScalarType::Undefined);
-  ASSERT_THROWS(und.toType(ScalarType::Float), "toScalarType");
-  ASSERT_THROWS(ft.toType(ScalarType::Undefined), "UndefinedType");
+  ASSERT_THROWSM(und.toType(ScalarType::Float), "toScalarType");
+  ASSERT_THROWSM(ft.toType(ScalarType::Undefined), "UndefinedType");
 
   // copy_
-  ASSERT_THROWS(und.copy_(und), "copy");
-  ASSERT_THROWS(und.copy_(ft), "copy");
-  ASSERT_THROWS(ft.copy_(und), "copy");
+  ASSERT_THROWSM(und.copy_(und), "copy");
+  ASSERT_THROWSM(und.copy_(ft), "copy");
+  ASSERT_THROWSM(ft.copy_(und), "copy");
 
   und.toBackend(Backend::Undefined);
-  ASSERT_THROWS(und.toBackend(Backend::CPU), "toBackend");
-  ASSERT_THROWS(ft.toBackend(Backend::Undefined), "UndefinedType");
+  ASSERT_THROWSM(und.toBackend(Backend::CPU), "toBackend");
+  ASSERT_THROWSM(ft.toBackend(Backend::Undefined), "UndefinedType");
 
   Tensor to_move = CPU(kFloat).ones({1});
   Tensor m(std::move(to_move));

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -28,10 +28,7 @@ int main() {
   // test case with empty tensor
   {
     auto a = T.randn(0);
-    try {
-      a.prod(0);
-      ASSERT(false);
-    } catch (std::runtime_error &e) {}
+    ASSERT_THROWS(a.prod(0));
   }
 
   // test case with scalar vs 1-dim, 1-size
@@ -40,9 +37,6 @@ int main() {
     ASSERT(a.prod(0).equal(a.prod(-1)));
     a.get()->maybeScalar(true);
     ASSERT(a.get()->isScalar());
-    try {
-      a.prod(0);
-      ASSERT(false);
-    } catch (std::runtime_error &e) {}
+    ASSERT_THROWS(a.prod(0));
   }
 }


### PR DESCRIPTION
1) Separates ASSERT_THROWS and ASSERT_THROWSM for checking messages vs not.
2) ADDS TRY_CATCH_ELSE for python-style error checking
3) Uses ASSERT_THROWS and TRY_CATCH_ELSE more generally

The previous more ad-hoc constructions were often wrong, i.e. an assert could
pass if the logical else threw an exception if it passed the assert in the catch.