### PR TITLE
Fix training behavior of InstanceNorm

### DIFF
--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -25,7 +25,7 @@ class _InstanceNorm(_BatchNorm):
 
         out = F.batch_norm(
             input_reshaped, running_mean, running_var, weight, bias,
-            not self.use_running_stats, self.momentum, self.eps)
+            self.training or not self.use_running_stats, self.momentum, self.eps)
 
         # Reshape back
         self.running_mean.copy_(running_mean.view(b, c).mean(0, keepdim=False))


### PR DESCRIPTION
The `_InstanceNorm` class in the master branch currently determines whether to use running statistics or current statistics based solely on the attribute `use_running_stats`. That is inconsistent with what other norm layers, e.g. `BatchNorm2d` do. This PR fixes it.
  
This PR is too simple to warrant a separate issue for discussion.