### PR TITLE
Fix abs specialization for `uint8_t` type.

### DIFF
--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -30,7 +30,7 @@ struct THCNumerics<uint8_t> {
   static inline __host__ __device__  uint8_t mul(uint8_t a, uint8_t b) { return a * b; }
   static inline __host__ __device__  uint8_t sub(uint8_t a, uint8_t b) { return a - b; }
   static inline __host__ __device__  uint8_t div(uint8_t a, uint8_t b) { return a / b; }
-  static inline __host__ __device__  uint8_t abs(uint8_t a) { return abs(a); }
+  static inline __host__ __device__  uint8_t abs(uint8_t a) { return a; }
 };
 
 template <>


### PR DESCRIPTION
Fixes #4520 