### PR TITLE
Fix tracking of tracing scopes during ONNX pass

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -158,6 +158,47 @@ class TestJit(TestCase):
         trace, z = torch.jit.trace(f, (x, y), nderivs=0)
         self.assertExpectedTrace(trace)
 
+        class Net(nn.Module):
+            def forward(self, x):
+                return F.log_softmax(x, dim=0)
+
+        net = Net()
+        t = Variable(torch.ones(2), requires_grad=True)
+        trace, _ = torch.jit.trace(net, (t, ))
+        torch.onnx._optimize_trace(trace, False)
+        g = torch._C._jit_get_graph(trace)
+        for node in g.nodes():
+            self.assertTrue(node.scopeName() == 'Net')
+
+        class Net(nn.Module):
+
+            def __init__(self, num_classes=1000):
+                super(Net, self).__init__()
+                self.features = nn.Sequential(
+                    nn.Conv2d(3, 64, kernel_size=11, stride=4, padding=2),
+                    nn.ReLU(inplace=True),
+                    nn.MaxPool2d(kernel_size=3, stride=2),
+                )
+
+            def forward(self, x):
+                x = self.features(x)
+                return x
+
+        model = Net()
+
+        t = Variable(torch.ones(1, 3, 227, 227), requires_grad=True)
+
+        with torch.onnx.set_training(model, False):
+            trace, _ = torch.jit.trace(model, (t, ))
+
+        torch.onnx._optimize_trace(trace, False)
+        graph = torch._C._jit_get_graph(trace)
+        nodes = list(graph.nodes())
+
+        self.assertTrue(nodes[0].scopeName() == 'Net/Sequential[features]/Conv2d[0]')
+        self.assertTrue(nodes[1].scopeName() == 'Net/Sequential[features]/ReLU[1]')
+        self.assertTrue(nodes[2].scopeName() == 'Net/Sequential[features]/MaxPool2d[2]')
+
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_lstm_fusion(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -172,7 +172,7 @@ class TestJit(TestCase):
 
         class Net(nn.Module):
 
-            def __init__(self, num_classes=1000):
+            def __init__(self):
                 super(Net, self).__init__()
                 self.features = nn.Sequential(
                     nn.Conv2d(3, 64, kernel_size=11, stride=4, padding=2),

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -711,11 +711,16 @@ public:
   Scope * current_scope() {
     return current_scope_;
   }
-  Scope * set_current_scope(Scope* scope) {
+  void set_current_scope(Scope* scope) {
     if (scope->getRoot() != scope_root_.get()) {
       throw std::runtime_error("trying to set a scope as current that does not belong to the Graph's scope trie");
     }
-    return current_scope_ = scope;
+    current_scope_ = scope;
+  }
+  ResourceGuard set_current_scope_temporary(Scope* scope) {
+    auto prev_scope = current_scope_;
+    this->set_current_scope(scope);
+    return ResourceGuard([prev_scope, this]() { this->current_scope_ = prev_scope; });
   }
   std::shared_ptr<Scope> scope_root() {
     return scope_root_;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -711,6 +711,12 @@ public:
   Scope * current_scope() {
     return current_scope_;
   }
+  Scope * set_current_scope(Scope* scope) {
+    if (scope->getRoot() != scope_root_.get()) {
+      throw std::runtime_error("trying to set a scope as current that does not belong to the Graph's scope trie");
+    }
+    return current_scope_ = scope;
+  }
   std::shared_ptr<Scope> scope_root() {
     return scope_root_;
   }

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -86,7 +86,6 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
         // Copy over source location information to all nodes created by
         // the symbolic
         outputs[i]->node()->setSourceLocation(node->getSourceLocation());
-        outputs[i]->node()->setScope(node->scope());
         env[old] = outputs[i];
       } else {
         // Null output means that the ONNX op doesn't have outputs corresponding
@@ -151,9 +150,14 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
         py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
+    Scope* current_scope = ctx.graph->current_scope();
+    ctx.graph->set_current_scope(n->scope());
+
     py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
     processSymbolicOutput(symbolToString(n->kind()), n, raw_output);
+
+    ctx.graph->set_current_scope(current_scope);
   };
 
   auto callPySymbolicMethod = [&](PythonOp* op) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -150,14 +150,11 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
         py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
-    Scope* current_scope = ctx.graph->current_scope();
-    ctx.graph->set_current_scope(n->scope());
+    auto scope_guard = ctx.graph->set_current_scope_temporary(n->scope());
 
     py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
     processSymbolicOutput(symbolToString(n->kind()), n, raw_output);
-
-    ctx.graph->set_current_scope(current_scope);
   };
 
   auto callPySymbolicMethod = [&](PythonOp* op) {


### PR DESCRIPTION
This PR addresses #4495 

During the ONNX pass, the strategy for preserving correct scopes in the new symbolic nodes was to copy the scope from the original nodes to the outputs. This lead to two issues:
- intermediate nodes did not have a chance to receive a scope (see `log_softmax` issue in #4495)
- short-circuited symbolic functions (i.e. `_forward` symbolic functions simply returning their inputs) were effectively returning the output of the previous op, so copying the scope to those outputs ended up overwriting the scope of the previous op.

This PR introduces a `set_current_scope` method in `Graph`, which first checks that the scope trie node being set as current belongs to the scope trie of the Graph, and then sets it as current.

We use this mechanism to set the current scope of the symbolic graph (which already inherited the scope trie of the previous graph) before calling the symbolic functions, so all nodes created within those functions (outputs or intermediate) will get the same scope of the corresponding non-symbolic node.

Also, if no nodes are created (like in the short-circuited functions), no scopes are set, thus preserving the scope of the node preceding a short-circuited function (i.e. `Conv` in #4495).