### PR TITLE
Fix return type for Bernoulli enumerate_support

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -163,6 +163,12 @@ EXAMPLES = [
 ]
 
 
+def unwrap(value):
+    if isinstance(value, Variable):
+        return value.data
+    return value
+
+
 class TestDistributions(TestCase):
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):
         # performs gradient checks on log_prob
@@ -226,11 +232,23 @@ class TestDistributions(TestCase):
             actual = dist(param).enumerate_support()
             self.assertEqual(actual, expected)
 
+    def test_support_return_type(self):
+        for Dist, params in EXAMPLES:
+            for i, param in enumerate(params):
+                dist = Dist(**param)
+                try:
+                    self.assertTrue(type(unwrap(dist.sample())) is type(unwrap(dist.enumerate_support())),
+                                    msg=('{} example {}/{}, return type mismatch between ' +
+                                         'sample and enumerate_support.').format(Dist.__name__, i, len(params)))
+                except NotImplementedError:
+                    pass
+
     def test_bernoulli(self):
         p = Variable(torch.Tensor([0.7, 0.2, 0.4]), requires_grad=True)
         r = Variable(torch.Tensor([0.3]), requires_grad=True)
         s = 0.3
         self.assertEqual(Bernoulli(p).sample_n(8).size(), (8, 3))
+        self.assertTrue(isinstance(Bernoulli(p).sample().data, torch.Tensor))
         self.assertEqual(Bernoulli(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Bernoulli(r).sample().size(), (1,))
         self.assertEqual(Bernoulli(r).sample((3, 2)).size(), (3, 2, 1))
@@ -269,6 +287,7 @@ class TestDistributions(TestCase):
         p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
         # TODO: this should return a 0-dim tensor once we have Scalar support
         self.assertEqual(Categorical(p).sample().size(), (1,))
+        self.assertTrue(isinstance(Categorical(p).sample().data, torch.LongTensor))
         self.assertEqual(Categorical(p).sample((2, 2)).size(), (2, 2))
         self.assertEqual(Categorical(p).sample_n(1).size(), (1,))
         self._gradcheck_log_prob(Categorical, (p,))
@@ -310,6 +329,7 @@ class TestDistributions(TestCase):
     def test_one_hot_categorical_1d(self):
         p = Variable(torch.Tensor([0.1, 0.2, 0.3]), requires_grad=True)
         self.assertEqual(OneHotCategorical(p).sample().size(), (3,))
+        self.assertTrue(isinstance(OneHotCategorical(p).sample().data, torch.Tensor))
         self.assertEqual(OneHotCategorical(p).sample((2, 2)).size(), (2, 2, 3))
         self.assertEqual(OneHotCategorical(p).sample_n(1).size(), (1, 3))
         self._gradcheck_log_prob(OneHotCategorical, (p,))

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -232,7 +232,7 @@ class TestDistributions(TestCase):
             actual = dist(param).enumerate_support()
             self.assertEqual(actual, expected)
 
-    def test_support_return_type(self):
+    def test_enumerate_support_type(self):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):
                 dist = Dist(**param)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -64,7 +64,7 @@ class Bernoulli(Distribution):
         return binary_cross_entropy_with_logits(self.logits, self.probs, reduce=False)
 
     def enumerate_support(self):
-        values = torch.arange(2).long()
+        values = torch.arange(2)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
         if self.probs.is_cuda:


### PR DESCRIPTION
Fixes [probtorch/pytorch#68](https://github.com/probtorch/pytorch/issues/68). Only the return type for Bernoulli's `enumerate_support` needed change. 
 - We use `FloatTensor` as the default return type of distribution's samples, , as most tensor operations support `FloatTensor` without needing any casting. 
 - If the underlying torch sampler has a different tensor return type, that may be used instead. e.g. in the case of Categorical, we use `torch.multinomial` that returns a `LongTensor`. The return type of `Categorical` is therefore a `LongTensor`. This also helps in cases where the generated sample is used to index into tensors or numpy arrays. However, for the `OneHotCategorical`, we default to `FloatTensor` since the samples are more generally used as masks.