### PR TITLE
[ATen] Support wrapping dimensions over scalars.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -961,7 +961,7 @@
       - THTensor* other
     - cname: min
       return: argument 0,1
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* min
           output: True
@@ -993,7 +993,7 @@
       - THTensor* other
     - cname: max
       return: argument 0,1
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* max
           output: True
@@ -1013,7 +1013,7 @@
     - method
     - function
   return: argument 0,1
-  scalar_check: keepdim == false && self_->dim() == 1
+  scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
   arguments:
     - arg: THTensor* values
       output: True
@@ -1033,7 +1033,7 @@
     - method
     - function
   return: argument 0,1
-  scalar_check: keepdim == false && self_->dim() == 1
+  scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
   arguments:
     - arg: THTensor* values
       output: True
@@ -1058,7 +1058,7 @@
       arguments:
         - THTensor* self
     - cname: median
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* values
           output: True
@@ -1952,7 +1952,7 @@
         - THTensor* self
     - cname: mean
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True
@@ -1983,7 +1983,7 @@
           default: 0
     - cname: var
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True
@@ -2018,7 +2018,7 @@
           default: 0
     - cname: std
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True
@@ -2051,7 +2051,7 @@
           default: AS_REAL(2)
     - cname: norm
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True
@@ -2382,7 +2382,7 @@
         - THTensor* self
     - cname: sum
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True
@@ -2404,7 +2404,7 @@
         - THTensor* self
     - cname: prod
       return: argument 0
-      scalar_check: keepdim == false && self_->dim() == 1
+      scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)
       arguments:
         - arg: THTensor* result
           output: True

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -5,16 +5,22 @@
 
 namespace at {
 
-static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
+static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr, bool wrap_scalar=true) {
   if (dim_post_expr <= 0) {
-    std::ostringstream oss;
-    oss << "dimension specified as " << dim << " but tensor has no dimensions";
-    throw std::runtime_error(oss.str());
+    if (!wrap_scalar) {
+      std::ostringstream oss;
+      oss << "dimension specified as " << dim << " but tensor has no dimensions";
+      throw std::runtime_error(oss.str());
+    }
+    dim_post_expr = 1; // this will make range [-1, 0]
   }
-  if (dim < -(dim_post_expr) || dim >= (dim_post_expr)) {
+
+  int64_t min = -dim_post_expr;
+  int64_t max = dim_post_expr - 1;
+  if (dim < min || dim > max) {
     std::ostringstream oss;
-    oss << "dimension out of range (expected to be in range of [" << -(dim_post_expr)
-        << ", " << (dim_post_expr)-1 << "], but got " << dim << ")",
+    oss << "dimension out of range (expected to be in range of [" << min
+        << ", " << max << "], but got " << dim << ")",
     throw std::runtime_error(oss.str());
   }
   if (dim < 0) dim += dim_post_expr;

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -10,14 +10,14 @@ bool is_same_size(const Tensor& self, const Tensor& other) {
 }
 
 int64_t size(const Tensor& self, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim());
-  // wrap_dim guarantees bounds are correct.
+  // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
+  dim = maybe_wrap_dim(dim, self.dim(), false);
   return self.sizes()[dim];
 }
 
 int64_t stride(const Tensor& self, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim());
-  // wrap_dim guarantees bounds are correct.
+  // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
+  dim = maybe_wrap_dim(dim, self.dim(), false);
   return self.strides()[dim];
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -198,9 +198,10 @@ Tensor squeeze(const Tensor& self) {
 }
 
 Tensor squeeze(const Tensor& self, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim());
+  int64_t dims = self.dim();
+  dim = maybe_wrap_dim(dim, dims);
 
-  if (self.sizes()[dim] != 1) {
+  if (dims == 0 || self.sizes()[dim] != 1) {
     return self.as_strided(self.sizes().vec(), self.strides().vec());
   }
   auto g = inferSqueezeGeometry(self, dim);
@@ -213,9 +214,10 @@ Tensor & squeeze_(Tensor& self) {
 }
 
 Tensor & squeeze_(Tensor& self, int64_t dim) {
+  int64_t dims = self.dim();
   dim = maybe_wrap_dim(dim, self.dim());
 
-  if (self.sizes()[dim] != 1) {
+  if (dims == 0 || self.sizes()[dim] != 1) {
     return self.as_strided_(self.sizes().vec(), self.strides().vec());
   }
   auto g = inferSqueezeGeometry(self, dim);

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -37,6 +37,6 @@ int main() {
     ASSERT(a.prod(0).equal(a.prod(-1)));
     a.get()->maybeScalar(true);
     ASSERT(a.get()->isScalar());
-    ASSERT_THROWS(a.prod(0));
+    ASSERT(a.prod(0).equal(a.prod(-1)));
   }
 }


### PR DESCRIPTION
This follows the behavior of numpy in that you can wrap dimensions over a scalar (0-dimensional
tensor) in the range [-1, 0].  I.e. scalarTensor.prod(0) and scalarTensor.prod(-1) works, but
scalarTensor.prod(2) does not.

The only current exception to this is with size(dim) and stride(dim);
there are no numpy equivalents of these (they are attributes), so it seems cleaner to just have
these as (dimensional wrapping) sugar for sizes()[dim] and strides()[dim]; otherwise there are
subtle differences in semantics, e.g. you have to use size(dim) when you want it to directly
apply to scalars, if the default value (1?) makes sense in that case.  Simpler to just not have
that difference.

Note that this change can cause problems if code assumed that maybe_wrap_dim would throw an
exception in this case and then called sizes()[dim] or size(dim) without checking; I went
through the code and only found this case in squeeze/squeeze_.