### PR TITLE
ATen conv param expansion; InstanceNorm use_running_stats fix

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -266,7 +266,7 @@ at::Tensor convolution(
 }
 
 static inline std::vector<int64_t> convolution_expand_param_if_needed(
-  IntList &list_param, std::string param_name, size_t expected_dim) {
+  IntList list_param, const char *param_name, size_t expected_dim) {
   if (list_param.size() == 1) {
     return std::vector<int64_t>(expected_dim, list_param[0]);
   } else if (list_param.size() != expected_dim) {
@@ -290,7 +290,11 @@ at::Tensor _convolution(
   auto weight = weight_r;
   auto bias = bias_r;
   auto k = input.ndimension();
-  size_t dim = k - 2;
+  int64_t dim = k - 2;
+
+  if (dim <= 0) {
+    throw std::runtime_error("input has less dimensions than expected");
+  }
 
   ConvParams params;
   params.stride = convolution_expand_param_if_needed(stride_, "stride", dim);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -265,6 +265,20 @@ at::Tensor convolution(
                           ctx.benchmarkCuDNN(), ctx.deterministicCuDNN(), ctx.userEnabledCuDNN());
 }
 
+static inline std::vector<int64_t> convolution_expand_param_if_needed(
+  IntList &list_param, std::string param_name, size_t expected_dim) {
+  if (list_param.size() == 1) {
+    return std::vector<int64_t>(expected_dim, list_param[0]);
+  } else if (list_param.size() != expected_dim) {
+    std::ostringstream ss;
+    ss << "expected " << param_name << " to be a single integer value or a "
+       << "list of " << expected_dim << " values to match the convolution "
+       << "dimensions, but got " << param_name << "=" << list_param.size();
+    throw std::runtime_error(ss.str());
+  } else {
+    return list_param.vec();
+  }
+}
 
 at::Tensor _convolution(
     const Tensor& input_r, const Tensor& weight_r, const Tensor& bias_r,
@@ -275,13 +289,15 @@ at::Tensor _convolution(
   auto input = input_r.contiguous();
   auto weight = weight_r;
   auto bias = bias_r;
+  auto k = input.ndimension();
+  size_t dim = k - 2;
 
   ConvParams params;
-  params.stride = stride_;
-  params.padding = padding_;
-  params.dilation = dilation_;
+  params.stride = convolution_expand_param_if_needed(stride_, "stride", dim);
+  params.padding = convolution_expand_param_if_needed(padding_, "padding", dim);
+  params.dilation = convolution_expand_param_if_needed(dilation_, "dilation", dim);
   params.transposed = transposed_;
-  params.output_padding = output_padding_;
+  params.output_padding = convolution_expand_param_if_needed(output_padding_, "output_padding", dim);
   params.groups = groups_;
   params.benchmark = benchmark;
   params.deterministic = deterministic;
@@ -291,8 +307,6 @@ at::Tensor _convolution(
   if (params.is_output_padding_neg()) throw std::runtime_error("negative output_padding is not supported");
 
   check_input_shape_forward(input, weight, bias, params.groups, params.transposed);
-
-  auto k = input.ndimension();
 
   if (k == 3) {
     params.view1d_as_2d();
@@ -357,7 +371,6 @@ at::Tensor _convolution(
 
   return output;
 }
-
 
 // A generic function for convolution implementations which don't
 // natively implement groups (e.g., not CuDNN).

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -141,14 +141,15 @@ auto ConvParams::is_depthwise(
 static void check_input_shape_forward(const at::Tensor& input,
                                       const at::Tensor& weight, const at::Tensor& bias,
                                       int64_t groups, bool transposed) {
-  int k = input.ndimension();
+  int64_t k = input.ndimension();
+  int64_t weight_dim = weight.ndimension();
 
-  if (weight.ndimension() != k) {
-      std::stringstream ss;
-      ss << "Expected " << k << "-dimensional input for " << k
-         << "-dimensional weight " << weight.sizes() << ", but got input of size "
-         << input.sizes() << " instead";
-      throw std::runtime_error(ss.str());
+  if (weight_dim != k) {
+    std::stringstream ss;
+    ss << "Expected " << weight_dim << "-dimensional input for " << weight_dim
+       << "-dimensional weight " << weight.sizes() << ", but got input of size "
+       << input.sizes() << " instead";
+    throw std::runtime_error(ss.str());
   }
   if (weight.size(0) < groups) {
     std::stringstream ss;
@@ -266,10 +267,10 @@ at::Tensor convolution(
 }
 
 static inline std::vector<int64_t> convolution_expand_param_if_needed(
-  IntList list_param, const char *param_name, size_t expected_dim) {
+  IntList list_param, const char *param_name, int64_t expected_dim) {
   if (list_param.size() == 1) {
     return std::vector<int64_t>(expected_dim, list_param[0]);
-  } else if (list_param.size() != expected_dim) {
+  } else if ((int64_t) list_param.size() != expected_dim) {
     std::ostringstream ss;
     ss << "expected " << param_name << " to be a single integer value or a "
        << "list of " << expected_dim << " values to match the convolution "

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2696,7 +2696,7 @@ class TestTorch(TestCase):
             if expected_error is None:
                 result = x.stft(frame_length, hop, fft_size, return_onesided, window, pad_end)
                 ref_result = naive_stft(x, frame_length, hop, fft_size, return_onesided, window, pad_end)
-                self.assertEqual(result.data, ref_result, 1e-8, 'stft result')
+                self.assertEqual(result.data, ref_result, 5e-6, 'stft result')
             else:
                 self.assertRaises(expected_error,
                                   lambda: x.stft(frame_length, hop, fft_size, return_onesided, window, pad_end))

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -6,7 +6,7 @@ class _InstanceNorm(_BatchNorm):
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=False):
         super(_InstanceNorm, self).__init__(
             num_features, eps, momentum, affine)
-        self.use_running_stats = False
+        self._use_running_stats = False
 
     def forward(self, input):
         b, c = input.size(0), input.size(1)
@@ -25,7 +25,7 @@ class _InstanceNorm(_BatchNorm):
 
         out = F.batch_norm(
             input_reshaped, running_mean, running_var, weight, bias,
-            not self.use_running_stats, self.momentum, self.eps)
+            not self._use_running_stats, self.momentum, self.eps)
 
         # Reshape back
         self.running_mean.copy_(running_mean.view(b, c).mean(0, keepdim=False))
@@ -40,7 +40,7 @@ class _InstanceNorm(_BatchNorm):
         and evaluation modes. But users can set this method to use running
         statistics in the fashion similar to batch normalization in eval mode.
         """
-        self.use_running_stats = mode
+        self._use_running_stats = mode
 
 
 class InstanceNorm1d(_InstanceNorm):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,9 +313,9 @@ class DataLoaderIter(object):
             # done_event should be sufficient to exit worker_manager_thread, but
             # be safe here and put another None
             self.worker_result_queue.put(None)
-        if self.worker_pids_set:
-            _remove_worker_pids(id(self))
-            self.worker_pids_set = False
+            if self.worker_pids_set:
+                _remove_worker_pids(id(self))
+                self.worker_pids_set = False
 
     def __del__(self):
         if self.num_workers > 0:


### PR DESCRIPTION
1. Switched to `conv1d` in `stft`.
2. Added code to do param expansion in `_convolution` in ATen, fixing #4464 
3. @myleott noticed a bug in #4444 where names of a attr and a method collide in `instancenorm.py`. This fixes it.
4. Made an err msg in `check_input_shape_forward` clearer to prevent confusing err msg like 
```
Expected 4-dimensional input for 4-dimensional weight [10], 
but got input of size [11, 1, 32, 32] instead
``` 
from https://discuss.pytorch.org/t/autograd-grad-dimension-error/12083.
