### PR TITLE
Fix a missing AutoGPU

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -39,6 +39,7 @@ CONSTRUCTOR = CodeTemplate("""\
   return TensorOp([=](const list_of_retainable & inputs,
                       list_of_retainable & outputs) {
     autograd::profiler::RecordFunction record("${name}");
+    AutoGPU device_guard(deviceForInputs(inputs));
     pack_list(outputs, ${call});
   }, "${name}", ${num_inputs});
 }},

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -94,6 +94,13 @@ void pack_list(list_of_retainable & outputs, std::tuple<Tensor, Tensor, Tensor, 
   outputs.push_back(toRetainableSteal(std::move(std::get<3>(v))));
 }
 
+int deviceForInputs(const list_of_retainable & inputs) {
+  if(inputs.size() == 0)
+    return -1;
+  auto t = TensorTemporary(inputs[0]);
+  return t.value().type().is_cuda() ? (int) t.value().get_device() : -1;
+}
+
 // A list of functions taking TensorList arguments (where we can't use
 // the number of inputs to choose an overload).
 std::unordered_set<Symbol> tensor_vararg_fns = {

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -63,7 +63,11 @@ struct IODescriptor {
 
 static inline std::ostream& operator<<(std::ostream& out, const IODescriptor::VariableMetadata& meta) {
   auto & t = at::getType(meta.device < 0 ? at::kCPU : at::kCUDA, meta.type);
-  out << t << "(requires_grad=" << meta.requires_grad << ") {";
+  out << t << "(requires_grad=" << meta.requires_grad;
+  if (meta.device > 0) {
+    out << ", device=" << meta.device;
+  }
+  out << ") {";
   for(size_t i = 0; i < meta.sizes.size(); ++i) {
     if(i > 0)
       out << ", ";

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -224,7 +224,7 @@ struct CompiledFunction {
 
 
 std::ostream& operator<<(std::ostream& out, const CompiledFunction::TraceForKey & trace) {
-  if(!trace.is_ready_) {
+  if(!const_cast<CompiledFunction::TraceForKey&>(trace).ready()) {
       out << "<trace has been started but has not been completed>";
       return out;
   }


### PR DESCRIPTION
ATen dispatch in the JIT interpreter needs to switch the current gpu,
but it is not handled in ATen itself, and no higher-level pathway
ensures the device is set correctly.

This also improves debugging information for cross-device issues.

Addresses #4468 