### PR TITLE
Fix type check in `checked_cast`.

### DIFF
--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -104,7 +104,14 @@ Variable & VariableType::checked_cast(const Type & type, const Tensor & t, const
     runtime_error("Expected a Tensor of type %s but found an undefined Tensor for argument #%d '%s'",
         type.toString(), pos, name);
   }
-  if (&t.type() != &type && &t.type() != &type.toBackend(toSparse(t.type().backend()))) {
+
+  // Not all types have a matching sparse type
+  Type* sparse_type = &type.toScalarType(ScalarType::Undefined);
+  try {
+    sparse_type = &type.toBackend(toSparse(t.type().backend()));
+  } catch (std::runtime_error &e) { }
+
+  if (&t.type() != &type && &t.type() != sparse_type) {
     runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
         type.toString(), t.type().toString(), pos, name);
   }


### PR DESCRIPTION
`type.toBackend(toSparse(t.type().backend()))` can crash when `type` does not have a matching sparse type. For now, Half type does not have sparse support.