### PR TITLE
Further fix to tracing scope

### DIFF
--- a/test/expect/TestJit.test_scopes_identity_node.expect
+++ b/test/expect/TestJit.test_scopes_identity_node.expect
@@ -1,0 +1,8 @@
+graph(%0 : Double(1, 3, 227, 227)
+      %1 : Double(64, 3, 11, 11)
+      %2 : Double(64)) {
+  %3 : Double(1, 64, 56, 56) = Conv[dilations=[1, 1], group=1, kernel_shape=[11, 11], pads=[2, 2, 2, 2], strides=[4, 4]](%0, %1, %2), scope: Net/Sequential[features]/Conv2d[0]
+  %4 : Double(1, 64, 56, 56) = Relu(%3), scope: Net/Sequential[features]/ReLU[1]
+  %5 : Double(1, 64, 27, 27) = MaxPool[kernel_shape=[3, 3], pads=[0, 0, 0, 0], strides=[2, 2]](%4), scope: Net/Sequential[features]/MaxPool2d[2]
+  return (%5);
+}

--- a/test/expect/TestJit.test_scopes_intermediate_node.expect
+++ b/test/expect/TestJit.test_scopes_intermediate_node.expect
@@ -1,0 +1,5 @@
+graph(%0 : Double(2)) {
+  %1 : Double(2) = Softmax[axis=0](%0), scope: Net
+  %2 : Double(2) = Log(%1), scope: Net
+  return (%2);
+}

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -188,6 +188,8 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
       py_symbolic_args[input_nr++] = obj;
     }
 
+    auto scope_guard = ctx.graph->set_current_scope_temporary(op->scope());
+
     // Call the symbolic function
     // Use a little trampoline function so we can give good error messages
     // upon argument mismatch


### PR DESCRIPTION
This PR addresses the second issue arisen in #4495 (Dropout not showing up).

As pointed out by @ezyang, the temporary scope was not set before `callPySymbolicMethod`. This is now fixed.

I also changed scope tests to use the expect framework and added the respective expected files.