### PR TITLE
Fix use after free when advanced indexing tensors with tensors

### DIFF
--- a/torch/csrc/generic/Tensor.cpp
+++ b/torch/csrc/generic/Tensor.cpp
@@ -770,7 +770,6 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
           // Clean up Indexers
           for (auto& idx : indexers) {
-            THIndexTensor_(free)(LIBRARY_STATE idx->cdata);
             Py_DECREF(idx);
           }
           return false;
@@ -831,7 +830,6 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
           // Clean up Indexers
           for (auto& idx : indexers) {
-            THIndexTensor_(free)(LIBRARY_STATE idx->cdata);
             Py_DECREF(idx);
           }
 
@@ -850,7 +848,6 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
     // Clean up Indexers
     for (auto& idx : indexers) {
-      THIndexTensor_(free)(LIBRARY_STATE idx->cdata);
       Py_DECREF(idx);
     }
     return false;
@@ -858,7 +855,6 @@ static bool THPTensor_(_convertToTensorIndexers)(
 
   // Clean up Indexers
   for (auto& idx : indexers) {
-    THIndexTensor_(free)(LIBRARY_STATE idx->cdata);
     Py_DECREF(idx);
   }
   return true;


### PR DESCRIPTION
When indexing tensors with tensors, like the following code, a use after free occurs. This doesn't actually impact anything in practice (nothing crashes or errors out) but is theoretically undefined behavior.

Advanced indexing on Variables doesn't exhibit this behavior because it's a different codepath.

Sample code:
```
import torch
x = torch.randn(2, 2)
i = torch.Tensor([1]).long()
x[i,:]
```

### Explanation
In `THPTensor_(_convertToTensorIndexers)`, a `vector<THPIndexTensor>` is created by constructing `THPTensor`s from sequences/tensors/etc. Each `THPIndexTensor` is then freed with the following:

```
for (auto& idx : indexers) {
  THIndexTensor_(free)(LIBRARY_STATE idx->cdata);
  Py_DECREF(idx);
}
```

This is a problem because `Py_DECREF(idx)` will turn `idx->ob_refcnt` to 0 since this function created the relevant `THPIndexTensor`s and owns them, causing `THPTensor_(dealloc)` to be called. `THPTensor_(dealloc)` already has a line that calls `THIndexTensor_(free)(LIBRARY_STATE idx->cdata)`.

So `THIndexTensor_(free)(LIBRARY_STATE idx->cdata)` gets called twice on the same `cdata`. After the first call frees `cdata`, the second attempts to access flags/members of `cdata` to determine if it should free it.
  