### PR TITLE
Bind functions with out= arguments in VariableType

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -492,6 +492,7 @@ main_sources = [
     "torch/csrc/autograd/python_hook.cpp",
     "torch/csrc/autograd/generated/VariableType.cpp",
     "torch/csrc/autograd/generated/Functions.cpp",
+    "torch/csrc/autograd/generated/python_torch_functions.cpp",
     "torch/csrc/autograd/generated/python_variable_methods.cpp",
     "torch/csrc/autograd/generated/python_functions.cpp",
     "torch/csrc/autograd/generated/python_nn_functions.cpp",

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1922,25 +1922,25 @@ class TestAutograd(TestCase):
         test()
         self.assertEqual(dealloc[0], 1)
 
-    def test_out_argument(self):
-        # Gradcheck torch.mul with an out= parameter
-        a = Variable(torch.randn(2, 2), requires_grad=True)
-        b = Variable(torch.randn(2, 2), requires_grad=True)
-
-        def fn(a, b):
-            x = torch.zeros_like(a)
-            torch.mul(a, b, out=x)
-            return x
-
-        gradcheck(fn, [a, b])
-        gradgradcheck(fn, [a, b])
-
-    def test_out_argument_view(self):
-        # out= with a view should raise an exception if the inputs require grad
+    def test_mul_out(self):
         a = Variable(torch.randn(2, 2), requires_grad=True)
         b = Variable(torch.randn(2, 2), requires_grad=True)
         x = torch.zeros_like(a)
-        self.assertRaises(RuntimeError, lambda: torch.mul(a, b, out=x[:]))
+
+        # out=... functions don't support automatic differentiation currently
+        self.assertRaisesRegex(RuntimeError, 'out=', lambda: torch.mul(a, b, out=x))
+
+        # the inputs can require grad if we're in no_grad() mode
+        with torch.no_grad():
+            torch.mul(a, b, out=x)
+            self.assertEqual(x, a * b)
+
+    def test_mul_out_result_requires_grad(self):
+        a = Variable(torch.randn(2, 2))
+        b = Variable(torch.randn(2, 2))
+        x = Variable(torch.zeros(2, 2), requires_grad=True)
+        # we should throw an exception if the output requires grad
+        self.assertRaisesRegex(RuntimeError, 'out=', lambda: torch.mul(a, b, out=x))
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1922,6 +1922,26 @@ class TestAutograd(TestCase):
         test()
         self.assertEqual(dealloc[0], 1)
 
+    def test_out_argument(self):
+        # Gradcheck torch.mul with an out= parameter
+        a = Variable(torch.randn(2, 2), requires_grad=True)
+        b = Variable(torch.randn(2, 2), requires_grad=True)
+
+        def fn(a, b):
+            x = torch.zeros_like(a)
+            torch.mul(a, b, out=x)
+            return x
+
+        gradcheck(fn, [a, b])
+        gradgradcheck(fn, [a, b])
+
+    def test_out_argument_view(self):
+        # out= with a view should raise an exception if the inputs require grad
+        a = Variable(torch.randn(2, 2), requires_grad=True)
+        b = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.zeros_like(a)
+        self.assertRaises(RuntimeError, lambda: torch.mul(a, b, out=x[:]))
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4996,7 +4996,7 @@ class TestTorch(TestCase):
         # check zero dimensional
         x = np.zeros((0, 2))
         self.assertEqual(torch.from_numpy(x).shape, tuple())
-        self.assertEqual(torch.autograd.Variable.from_numpy(x).shape, [0])
+        self.assertEqual(torch._C._VariableFunctions.from_numpy(x).shape, [0])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_ctor_with_numpy_array(self):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -11,7 +11,8 @@
 #
 # If a function has out-of-place and in-place variants, then the derivative
 # definition for the in-place variant is optional. It will default to the
-# definition for the out-of-place variant.
+# definition for the out-of-place variant. Similarly, _out variants will
+# default to the derivative for the non _out variant.
 #
 # Gradient expressions are standard C++ expressions operating on ATen
 # variables.  In a gradient expression, the following variables are in
@@ -630,7 +631,6 @@
   self: grad.contiguous().view(self.sizes())
 
 - name: _s_where(Tensor condition, Tensor self, Tensor other)
-  condition: zeros_like(condition)
   self: where(condition, grad, zeros_like(grad))
   other: where(condition, zeros_like(grad), grad)
 
@@ -639,6 +639,7 @@
 
 - name: _sparse_mask(Tensor self, SparseTensor mask)
   self: not_implemented("_sparse_mask")
+  mask: not_implemented("_sparse_mask")
 
 - name: _standard_gamma(Tensor self, Generator generator)
   self: grad * self._standard_gamma_grad(output)

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -10,23 +10,11 @@
 import argparse
 import copy
 import os
-import re
 import yaml
 from collections import defaultdict
-from .utils import CodeTemplate, YamlLoader, split_name_params, write
-
-
-FUNCTION_PROTOTYPE = CodeTemplate("""\
-${name}(${typed_args})""")
+from .utils import YamlLoader, split_name_params
 
 template_path = os.path.join(os.path.dirname(__file__), 'templates')
-
-PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')
-PY_VARIABLE_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_variable_methods_dispatch.h')
-PY_NN_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_nn_functions.cpp')
-PY_NN_FUNCTIONS_H = CodeTemplate.from_file(template_path + '/python_nn_functions.h')
-PY_NN_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_nn_functions_dispatch.h')
-
 derivatives_path = os.path.join(os.path.dirname(__file__), 'derivatives.yaml')
 deprecated_path = os.path.join(os.path.dirname(__file__), 'deprecated.yaml')
 
@@ -34,11 +22,6 @@ VIEW_FUNCTIONS = {
     'alias', 'as_strided', 'expand', 'narrow', 'permute', 'select', 'slice',
     'squeeze', 't', 'transpose', 'unfold', 'unsqueeze', 'view',
 }
-# These functions require manual Python bindings or are not exposed to Python
-SKIP_PYTHON_BINDINGS = [
-    'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
-    'slice_dim', '.*_backward'
-]
 
 
 def format_return_type(returns):
@@ -69,38 +52,6 @@ def load_aten_declarations(path):
         declaration['return_type'] = format_return_type(declaration['returns'])
 
         declaration['base_name'] = declaration['name']
-
-        # Compute the Python function prototype for argument parsing
-        typed_args = []
-        positional = True
-        for arg in declaration['arguments']:
-            if arg.get('kwarg_only', False) and positional:
-                typed_args.append('*')
-                positional = False
-            typename = arg['simple_type']
-            if arg.get('is_nullable'):
-                typename = '{}?'.format(typename)
-            if arg.get('size') is not None:
-                typename = '{}[{}]'.format(typename, arg['size'])
-            param = typename + ' ' + arg['name']
-            default = None
-            if arg.get('default') is not None:
-                default = arg['default']
-                if default == 'nullptr' or default == '{}':
-                    default = 'None'
-            if arg.get('python_default_init') is not None:
-                default = 'None'
-            if default is not None:
-                param += '=' + str(default)
-            typed_args.append(param)
-
-        # Python function prototype.
-        # This is the string that we give to FunctionParameter, which is
-        # then parsed into the actual structure which we do parsing
-        # with.
-        declaration['typed_args'] = typed_args
-        declaration['prototype'] = FUNCTION_PROTOTYPE.substitute(declaration)
-
     return declarations
 
 
@@ -152,76 +103,29 @@ def load_deprecated_signatures(aten_decls):
     return declarations
 
 
-def gen_autograd(declarations, out):
-    aten_decls = load_aten_declarations(declarations)
+def gen_autograd(aten_path, out):
+    aten_decls = load_aten_declarations(aten_path)
 
+    # Parse and load derivatives.yaml
     from .load_derivatives import load_derivatives
     autograd_functions = load_derivatives(derivatives_path, aten_decls)
 
-    def should_generate_python_binding(declaration):
-        name = declaration['name']
-        for pattern in SKIP_PYTHON_BINDINGS:
-            if re.match('^' + pattern + '$', name):
-                return False
-
-        # we don't currently support functions which are only defined on Type
-        # such as zeros(), randn(), etc.
-        method_of = declaration['method_of']
-        if 'Tensor' not in method_of and 'namespace' not in method_of:
-            return False
-
-        return True
-
-    py_variable_methods = defaultdict(list)
-    py_nn_functions = defaultdict(list)
-    for declaration in aten_decls:
-        name = declaration['name']
-        if not should_generate_python_binding(declaration):
-            continue
-        if declaration['mode'] == 'NN':
-            py_nn_functions[name].append(declaration)
-        else:
-            py_variable_methods[name].append(declaration)
-
-    for declaration in load_deprecated_signatures(aten_decls):
-        py_variable_methods[declaration['name']].append(declaration)
-
-    env = {
-        'py_methods': [],
-        'py_method_defs': [],
-        'py_method_dispatch': [],
-        'py_function_initializers': [],
-        'py_nn_functions': [],
-        'py_nn_function_defs': [],
-        'py_nn_function_dispatch': [],
-    }
-
+    # Generate VariableType.h/cpp
     from .gen_variable_type import gen_variable_type
     gen_variable_type(out, aten_decls)
 
+    # Generate Functions.h/cpp
     from .gen_autograd_functions import gen_autograd_functions
     gen_autograd_functions(out, autograd_functions)
 
-    from .gen_python_functions import create_python_bindings
-    create_python_bindings(
-        py_variable_methods,
-        env['py_methods'],
-        env['py_method_defs'],
-        env['py_method_dispatch'],
-        is_class=True)
+    # Load deprecated signatures
+    deprecated = load_deprecated_signatures(aten_decls)
 
-    create_python_bindings(
-        py_nn_functions,
-        env['py_nn_functions'],
-        env['py_nn_function_defs'],
-        env['py_nn_function_dispatch'],
-        is_class=False)
-
-    write(out, 'python_variable_methods.cpp', PY_VARIABLE_METHODS_CPP, env)
-    write(out, 'python_variable_methods_dispatch.h', PY_VARIABLE_DISPATCH_H, env)
-    write(out, 'python_nn_functions.cpp', PY_NN_FUNCTIONS_CPP, env)
-    write(out, 'python_nn_functions.h', PY_NN_FUNCTIONS_H, env)
-    write(out, 'python_nn_functions_dispatch.h', PY_NN_DISPATCH_H, env)
+    # Genereate Python bindings
+    from . import gen_python_functions
+    gen_python_functions.gen_py_variable_methods(out, aten_decls + deprecated)
+    gen_python_functions.gen_py_torch_functions(out, aten_decls + deprecated)
+    gen_python_functions.gen_py_nn_functions(out, aten_decls)
 
 
 def main():

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -80,9 +80,9 @@ def load_deprecated_signatures(aten_decls):
         return '{}({})'.format(name, ', '.join(rearranged_types))
 
     for deprecated in deprecated_defs:
-        prototype = deprecated['name']
+        python_signature = deprecated['name']
         call_args = split_name_params(deprecated['aten'])[1]
-        name, params = split_name_params(prototype)
+        name, params = split_name_params(python_signature)
         signature = get_signature(name, params, call_args)
 
         for declaration in declarations_by_signature[signature]:
@@ -90,9 +90,9 @@ def load_deprecated_signatures(aten_decls):
             declaration['deprecated'] = True
             declaration['call_args'] = call_args
             if declaration['inplace']:
-                declaration['prototype'] = prototype.replace(name, name + '_')
+                declaration['python_signature'] = python_signature.replace(name, name + '_')
             else:
-                declaration['prototype'] = prototype
+                declaration['python_signature'] = python_signature
 
             args_by_name = {arg['name']: arg for arg in declaration['arguments']}
             declaration['arguments'] = []

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -102,8 +102,13 @@ def should_generate_python_binding(declaration):
         if re.match('^' + pattern + '$', name):
             return False
 
+    # TODO: fix handling of SparseTensor. We don't want to generate Python
+    # bindings to SparseTensor overloads, such as add(Tensor, SparseTensor),
+    # since the Tensor-based signature already dynamically dispatches correctly.
+    # However, _sparse_mask only has a SparseTensor signature so we need to bind
+    # that function.
     for arg in declaration['arguments']:
-        if arg['type'] == 'SparseTensor':
+        if arg['type'] == 'SparseTensor' and declaration['name'] != '_sparse_mask':
             return False
 
     # we don't currently support functions which are only defined on Type

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -2,12 +2,29 @@
 #
 # The bindings are generated as methods on python_variable or functions on the
 # torch._C._nn object.
-
+#
+from collections import defaultdict
+import re
 from .nested_dict import nested_dict
 from tools.shared.module_loader import import_module
+from .gen_autograd import template_path
+from .utils import write
 
 CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').CodeTemplate
 
+# These functions require manual Python bindings or are not exposed to Python
+SKIP_PYTHON_BINDINGS = [
+    'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
+    'slice_dim', '.*_backward'
+]
+
+PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')
+PY_VARIABLE_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_variable_methods_dispatch.h')
+PY_TORCH_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_torch_functions.cpp')
+PY_TORCH_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_torch_functions_dispatch.h')
+PY_NN_FUNCTIONS_CPP = CodeTemplate.from_file(template_path + '/python_nn_functions.cpp')
+PY_NN_FUNCTIONS_H = CodeTemplate.from_file(template_path + '/python_nn_functions.h')
+PY_NN_DISPATCH_H = CodeTemplate.from_file(template_path + '/python_nn_functions_dispatch.h')
 
 PY_VARIABLE_METHOD_VARARGS = CodeTemplate("""\
 static PyObject * ${pycname}(PyObject* self, PyObject* args, PyObject* kwargs)
@@ -37,14 +54,19 @@ static PyObject * ${pycname}(PyObject* self, PyObject* args)
 
 PY_VARIABLE_CASE = CodeTemplate("""\
 ${cond} (r.idx == ${i}) {
-  return wrap(${dispatch_name}(${actuals}));
+  ${call_dispatch}
 """)
 
-PY_VARIABLE_CASE_WITH_UNPACK = CodeTemplate("""\
-${cond} (r.idx == ${i}) {
-  ${unpack_args}
-  return wrap(${dispatch_name}(${actuals}));
+PY_VARIABLE_OUT = CodeTemplate("""\
+if (r.isNone(${out_idx})) {
+  ${call_dispatch}
+} else {
+  ${call_dispatch_out}
+}
 """)
+
+PY_VARIABLE_CALL_DISPATCH = CodeTemplate("""\
+return wrap(${dispatch_name}(${actuals}));""")
 
 PY_VARIABLE_DISPATCH = CodeTemplate("""\
 inline ${return_type} ${dispatch_name}(${formal_args}) {
@@ -57,10 +79,10 @@ inline ${return_type} ${dispatch_name}(${formal_args}) {
 PY_VARIABLE_METHOD_DEF = CodeTemplate("""\
 {"${name}", (PyCFunction)${pycname}, ${flags}, NULL},""")
 
-UNPACK_ARG = CodeTemplate("""\
-${formal_arg} = ${actual};""")
-
 UNPACK_SELF = "auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;"
+
+FUNCTION_PROTOTYPE = CodeTemplate("""\
+${name}(${typed_args})""")
 
 # XXX: if you got here because of an assertion failure, it doesn't mean
 # it's enough to just extend the list here. Before you do this, make sure
@@ -74,13 +96,82 @@ SUPPORTED_RETURN_TYPES = {
 }
 
 
-def create_python_bindings(
-        python_functions, py_methods, py_method_defs, py_method_dispatch,
-        is_class):
-    """python_variable_methods.cpp
+def should_generate_python_binding(declaration):
+    name = declaration['name']
+    for pattern in SKIP_PYTHON_BINDINGS:
+        if re.match('^' + pattern + '$', name):
+            return False
 
-    Generates Python bindings to Variable methods
-    """
+    for arg in declaration['arguments']:
+        if arg['type'] == 'SparseTensor':
+            return False
+
+    # we don't currently support functions which are only defined on Type
+    # such as zeros(), randn(), etc.
+    method_of = declaration['method_of']
+    if 'Tensor' not in method_of and 'namespace' not in method_of:
+        return False
+
+    return True
+
+
+def gen_py_variable_methods(out, declarations):
+    def should_bind(declaration):
+        return (should_generate_python_binding(declaration) and
+                declaration['mode'] != 'NN' and
+                'Tensor' in declaration['method_of'])
+
+    py_variable_methods = defaultdict(list)
+    for declaration in declarations:
+        if should_bind(declaration):
+            py_variable_methods[declaration['name']].append(declaration)
+
+    env = create_python_bindings(py_variable_methods, True)
+    write(out, 'python_variable_methods.cpp', PY_VARIABLE_METHODS_CPP, env)
+    write(out, 'python_variable_methods_dispatch.h', PY_VARIABLE_DISPATCH_H, env)
+
+
+def gen_py_nn_functions(out, declarations):
+    def should_bind(declaration):
+        return (should_generate_python_binding(declaration) and
+                declaration['mode'] == 'NN')
+
+    py_nn_functions = defaultdict(list)
+    for declaration in declarations:
+        if should_bind(declaration):
+            py_nn_functions[declaration['name']].append(declaration)
+
+    env = create_python_bindings(py_nn_functions, has_self=False, is_module=True)
+    write(out, 'python_nn_functions.cpp', PY_NN_FUNCTIONS_CPP, env)
+    write(out, 'python_nn_functions.h', PY_NN_FUNCTIONS_H, env)
+    write(out, 'python_nn_functions_dispatch.h', PY_NN_DISPATCH_H, env)
+
+
+def gen_py_torch_functions(out, declarations):
+    def should_bind(declaration):
+        return (should_generate_python_binding(declaration) and
+                declaration['mode'] != 'NN' and
+                'namespace' in declaration['method_of'])
+
+    py_torch_functions = defaultdict(list)
+    for declaration in declarations:
+        name = declaration['name']
+        if should_bind(declaration):
+            if name.endswith('_out'):
+                py_torch_functions[name[:-4]].append(declaration)
+            else:
+                py_torch_functions[name].append(declaration)
+
+    env = create_python_bindings(py_torch_functions, has_self=False)
+    write(out, 'python_torch_functions.cpp', PY_TORCH_FUNCTIONS_CPP, env)
+    write(out, 'python_torch_functions_dispatch.h', PY_TORCH_DISPATCH_H, env)
+
+
+def create_python_bindings(python_functions, has_self, is_module=False):
+    """Generates Python bindings to ATen functions"""
+    py_methods = []
+    py_method_defs = []
+    py_method_dispatch = []
 
     unpack_methods = {
         'const Tensor &': 'tensor',
@@ -113,23 +204,25 @@ def create_python_bindings(
             return ''
         return 'AutoGPU auto_gpu({});'.format(tensor_arg)
 
-    def emit_dispatch(i, function):
+    def emit_single_dispatch(declaration, base_env):
         env = {}
-        simple_return_type = function['return_type'].replace(' &', '')
+        simple_return_type = declaration['return_type'].replace(' &', '')
         assert simple_return_type in SUPPORTED_RETURN_TYPES, \
-            function['name'] + ' returns unsupported type: ' + simple_return_type
+            declaration['name'] + ' returns unsupported type: ' + simple_return_type
 
+        body = []
         actuals = []
-        unpack_args = False
         formal_args = []
         arg_idx = 0
-        for arg in function['arguments']:
-            name = arg['name']
-            if 'Tensor' in function['method_of'] and name == 'self':
-                formal_args.append('Tensor & {}'.format(name))
-                actuals.append('self_')
-                continue
 
+        def is_output(arg):
+            return arg.get('output', False)
+
+        inputs = [arg for arg in declaration['arguments'] if not is_output(arg)]
+        outputs = [arg for arg in declaration['arguments'] if is_output(arg)]
+
+        def parse_arg(arg, unpack_args=False):
+            name = arg['name']
             typename = arg['type']
             if typename.startswith('IntList['):
                 typename = 'IntList'
@@ -137,7 +230,6 @@ def create_python_bindings(
                 typename = 'Tensor'
 
             if arg.get('python_default_init'):
-                unpack_args = True
                 assert typename in unpack_with_default_methods, \
                     '`{}` type is not supported in python_default_init'.format(typename)
                 unpack_with_default = unpack_with_default_methods.get(typename)
@@ -146,6 +238,10 @@ def create_python_bindings(
             else:
                 unpack = unpack_methods.get(typename, typename.lower())
                 expr = 'r.{}({})'.format(unpack, arg_idx)
+
+            if unpack_args:
+                body.append('auto {} = {};'.format(name, expr))
+                expr = name
 
             if typename == 'Storage &':
                 expr = '*' + expr
@@ -159,78 +255,91 @@ def create_python_bindings(
             elif dispatch_type == 'Tensor &':
                 dispatch_type = 'Tensor'
             formal_args.append('{} {}'.format(dispatch_type, name))
+
+        unpack = any(arg.get('python_default_init') for arg in inputs)
+        for arg in inputs:
+            if has_self and arg['name'] == 'self':
+                formal_args.append('Tensor & self')
+                actuals.append('self_')
+                continue
+            parse_arg(arg, unpack)
             arg_idx += 1
 
-        env['i'] = i
+        if len(outputs) == 1:
+            parse_arg(outputs[0])
+        elif len(outputs) > 1:
+            N = len(outputs)
+            body.append('auto results = r.tensorlist_n<{}>({});'.format(N, arg_idx))
+            for i, arg in enumerate(outputs):
+                formal_args.append('Tensor & {}'.format(arg['name']))
+                actuals.append('results[{}]'.format(i))
+
         env['unpack_args'] = []
         env['formal_args'] = formal_args
-        if unpack_args:
-            unpack_statements_no_default = []
-            unpack_statements_with_default = []
-            actual_names = []
-            for arg, formal_arg, actual in zip(function['arguments'], formal_args, actuals):
-                name = arg['name']
-                actual_names.append(name)
-                unpack_expr = UNPACK_ARG.substitute(formal_arg=formal_arg, actual=actual)
-                if arg.get('python_default_init'):
-                    unpack_statements_with_default.append(unpack_expr)
-                else:
-                    unpack_statements_no_default.append(unpack_expr)
-            env['unpack_args'] = unpack_statements_no_default + unpack_statements_with_default
-            env['actuals'] = actual_names
-            code_template = PY_VARIABLE_CASE_WITH_UNPACK
+        env['actuals'] = actuals
+        if 'call_args' in declaration:
+            env['dispatch_args'] = declaration['call_args']
         else:
-            env['actuals'] = actuals
-            code_template = PY_VARIABLE_CASE
-        if 'call_args' in function:
-            env['dispatch_args'] = function['call_args']
-        else:
-            env['dispatch_args'] = [arg['name'] for arg in function['arguments']]
-        if 'Tensor' in function['method_of']:
+            env['dispatch_args'] = [arg['name'] for arg in declaration['arguments']]
+        if 'Tensor' in declaration['method_of']:
             env['dispatch_args'] = [arg for arg in env['dispatch_args'] if arg != 'self']
-            env['dispatch_call'] = 'self.{}'.format(function['name'])
+            env['dispatch_call'] = 'self.{}'.format(declaration['name'])
         else:
-            env['dispatch_call'] = 'at::{}'.format(function['name'])
+            env['dispatch_call'] = 'at::{}'.format(declaration['name'])
         env['AutoNoGIL'] = 'AutoNoGIL no_gil;'
-        env['AutoGPU'] = auto_gpu(function)
-        env['cond'] = 'if' if i == 0 else '} else if'
-        env = nested_dict(env, function)
+        env['AutoGPU'] = auto_gpu(declaration)
+        env = nested_dict(env, nested_dict(base_env, declaration))
+        body.append(PY_VARIABLE_CALL_DISPATCH.substitute(env))
         py_method_dispatch.append(PY_VARIABLE_DISPATCH.substitute(env))
-        return code_template.substitute(env)
+        return body
 
-    def process_function(name, functions):
+    def emit_dispatch(i, declarations, base_env):
+        if len(declarations) == 1:
+            body = emit_single_dispatch(declarations[0], base_env)
+        else:
+            assert len(declarations) == 2
+            env = {
+                'call_dispatch_out': emit_single_dispatch(declarations[0], base_env),
+                'call_dispatch': emit_single_dispatch(declarations[1], base_env),
+            }
+            out_idx = len([arg for arg in declarations[0]['arguments']
+                           if not arg.get('output', False)])
+            body = PY_VARIABLE_OUT.substitute(env, out_idx=out_idx).split('\n')
+        cond = 'if' if i == 0 else '} else if'
+        return PY_VARIABLE_CASE.substitute(i=i, cond=cond, call_dispatch=body)
+
+    def process_function(name, declarations):
         env = {
             'name': name,
             'dispatch_name': 'dispatch_{}'.format(name),
             'pycname': 'THPVariable_{}'.format(name),
             'prototypes': [],
-            'max_args': max(len(o['arguments']) for o in functions),
+            'max_args': max(len(o['arguments']) for o in declarations),
             'unpack_self': [],
             'dispatch': [],
         }
 
-        is_method = 'Tensor' in functions[0]['method_of']
-        if is_method:
+        if has_self:
             env['unpack_self'] = [UNPACK_SELF]
 
-        for o in functions:
-            prototype = o['prototype']
-            if is_method:
+        grouped = group_declarations(declarations)
+        for prototype, decls in grouped:
+            if has_self:
                 prototype = prototype.replace('Tensor self, ', '')
                 prototype = prototype.replace('Tensor self', '')
-            if not is_class:
+            if not has_self:
                 # Use 'input' instead of 'self' for NN functions
                 prototype = prototype.replace('Tensor self', 'Tensor input')
             prototype = prototype.replace('SparseTensor', 'Tensor')
-            if 'deprecated' in o:
+            if all('deprecated' in o for o in decls):
                 prototype += '|deprecated'
             env['prototypes'].append('"{}",'.format(prototype))
 
-        for i, option in enumerate(functions):
-            env['dispatch'].append(emit_dispatch(i, nested_dict(env, option)))
+        for i, (_, decls) in enumerate(grouped):
+            env['dispatch'].append(emit_dispatch(i, decls, env))
         env['dispatch'].append('}')
 
-        if len(functions) == 1 and len(functions[0]['args']) == 1 and is_method:
+        if len(declarations) == 1 and len(declarations[0]['args']) == 1 and has_self:
             tmpl = PY_VARIABLE_METHOD_NOARGS
             env['actuals'] = ['self_']
             env['flags'] = 'METH_NOARGS'
@@ -238,7 +347,7 @@ def create_python_bindings(
             tmpl = PY_VARIABLE_METHOD_VARARGS
             env['flags'] = 'METH_VARARGS | METH_KEYWORDS'
 
-        if is_class and not is_method:
+        if not is_module and not has_self:
             env['flags'] += ' | METH_STATIC'
 
         py_methods.append(tmpl.substitute(env))
@@ -246,3 +355,83 @@ def create_python_bindings(
 
     for name in sorted(python_functions.keys()):
         process_function(name, python_functions[name])
+
+    return {
+        'py_methods': py_methods,
+        'py_method_defs': py_method_defs,
+        'py_method_dispatch': py_method_dispatch,
+    }
+
+
+def group_declarations(declarations):
+    grouped = defaultdict(list)
+
+    # first group by prototype ignoring out arguments
+    for declaration in declarations:
+        grouped[get_prototype(declaration, False)].append(declaration)
+
+    result = []
+    for prototype in sorted(grouped.keys()):
+        group = grouped[prototype]
+        assert len(group) <= 2
+        if len(group) == 2:
+            assert group[0]['name'].endswith('_out')
+        result.append((get_prototype(group[0], True), group))
+    return result
+
+
+def get_prototype(declaration, include_out):
+    # Use the saved prototype for deprecated pseudo-declarations
+    if 'prototype' in declaration:
+        return declaration['prototype']
+
+    # Compute the Python function prototype for argument parsing
+    typed_args = []
+    output_args = []
+    positional = True
+    for arg in declaration['arguments']:
+        if arg.get('output', False):
+            output_args.append(arg)
+            continue
+        if arg.get('kwarg_only', False) and positional:
+            typed_args.append('*')
+            positional = False
+        typename = arg['simple_type']
+        if arg.get('is_nullable'):
+            typename = '{}?'.format(typename)
+        if arg.get('size') is not None:
+            typename = '{}[{}]'.format(typename, arg['size'])
+        param = typename + ' ' + arg['name']
+        default = None
+        if arg.get('default') is not None:
+            default = arg['default']
+            if default == 'nullptr' or default == '{}':
+                default = 'None'
+        if arg.get('python_default_init') is not None:
+            default = 'None'
+        if default is not None:
+            param += '=' + str(default)
+        typed_args.append(param)
+
+    # add output arguments
+    name = declaration['name']
+    if name.endswith('_out'):
+        name = name[:-4]
+
+    if len(output_args) > 0 and include_out:
+        assert declaration['name'].endswith('_out')
+        if positional:
+            typed_args.append('*')
+            positional = False
+        typenames = [arg['simple_type'] for arg in output_args]
+        if len(typenames) > 1:
+            typename = 'TensorList[{}]'.format(len(typenames))
+        else:
+            typename = typenames[0]
+        typed_args.append(typename + ' out=None')
+
+    # Python function prototype.
+    # This is the string that we give to FunctionParameter, which is
+    # then parsed into the actual structure which we do parsing
+    # with.
+    return FUNCTION_PROTOTYPE.substitute(name=name, typed_args=typed_args)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -15,7 +15,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 # These functions require manual Python bindings or are not exposed to Python
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
-    'slice_dim', '.*_backward'
+    '.*_backward'
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -24,8 +24,8 @@
 #
 from __future__ import print_function
 import sys
-from .utils import CodeTemplate, nested_dict
-from .gen_autograd import VIEW_FUNCTIONS, template_path, write
+from .utils import CodeTemplate, nested_dict, write
+from .gen_autograd import VIEW_FUNCTIONS, template_path
 from .gen_autograd_functions import uses_single_grad
 
 VARIABLE_TYPE_H = CodeTemplate.from_file(template_path + '/VariableType.h')
@@ -85,19 +85,19 @@ ${return_type} VariableType::${method_prefix_derived}${api_name}(${formals}) con
 }
 """)
 
-METHOD_DEFINITION_NYI = CodeTemplate("""\
-throw std::runtime_error("VariableType::${api_name} NYI");""")
-
 UNPACK_TENSOR = CodeTemplate("""\
 auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
 
 SETUP_DERIVATIVE = CodeTemplate("""\
 std::shared_ptr<${op}> grad_fn;
 if (compute_requires_grad({ ${args_with_derivatives} })) {
-  grad_fn = std::make_shared<${op}>(${op_ctor});
-  grad_fn->next_functions = compute_next_functions({ ${args_with_derivatives} });
-  ${save_inputs}
+  ${setup}
 }
+""")
+
+ASSIGN_GRAD_FN = CodeTemplate("""\
+grad_fn = std::make_shared<${op}>(${op_ctor});
+grad_fn->next_functions = compute_next_functions({ ${args_with_derivatives} });
 """)
 
 CALL_VIA_TYPE = CodeTemplate("""\
@@ -142,9 +142,6 @@ def gen_variable_type(out, aten_declarations):
     type_definitions = []
 
     for declaration in aten_declarations:
-        if declaration['name'].endswith('_out'):
-            # TODO: implement _out functions
-            continue
         type_declarations.append(METHOD_DECLARATION.substitute(declaration))
         if declaration['name'] not in MANUAL_IMPLEMENTATIONS:
             type_definitions.append(emit_method_definition(declaration))
@@ -170,8 +167,9 @@ def emit_body(declaration):
     func = declaration['derivative']
     name = declaration['name']
     inplace = declaration['inplace']
+    is_out_fn = name.endswith('_out')
 
-    base_name = name[:-1] if inplace else name
+    base_name = name[:-1] if inplace else name[:-4] if is_out_fn else name
     is_view = base_name in VIEW_FUNCTIONS
 
     # These exclude things like BoolTensor, int64_t, and Scalar
@@ -182,7 +180,8 @@ def emit_body(declaration):
             return False
         return True
 
-    differentiable_inputs = list(filter(is_differentiable, arguments))
+    inputs = [arg for arg in arguments if not arg.get('output', False)]
+    differentiable_inputs = list(filter(is_differentiable, inputs))
     differentiable_outputs = list(filter(is_differentiable, returns))
 
     if uses_single_grad(func):
@@ -192,7 +191,7 @@ def emit_body(declaration):
         differentiable_outputs = differentiable_outputs[:1]
 
     requires_derivative = (
-        name not in DONT_REQUIRE_DERIVATIVE and
+        base_name not in DONT_REQUIRE_DERIVATIVE and
         len(differentiable_inputs) > 0 and len(differentiable_outputs) > 0 and
         strategy == 'use_derived')
 
@@ -200,34 +199,44 @@ def emit_body(declaration):
         print('WARNING: derivative ignored for {}'.format(name), file=sys.stderr)
 
     def setup_derivative():
-        env = {}
-        body = []
+        def error_msg():
+            name = declaration['api_name']
+            return '"the derivative for {} is not implemented"'.format(name)
 
-        tensor_args = [arg for arg in arguments if arg['simple_type'] in {'Tensor', 'TensorList'}]
-        tensor_arg_names = [arg['name'] for arg in tensor_args]
-        args_with_derivatives = (
-            tensor_arg_names if func is None else
-            find_args_with_derivatives(tensor_arg_names))
-        body.extend(emit_check_no_requires_grad(tensor_args, args_with_derivatives))
+        args_with_derivatives = find_args_with_derivatives()
+
+        env = {}
+        env['args_with_derivatives'] = reference_args(args_with_derivatives)
+        env['op'] = func['op'] if func is not None else 'Error'
+        env['op_ctor'] = '' if func is not None else error_msg()
+
+        setup = []
+        setup.extend(emit_check_output_args())
+        setup.extend(ASSIGN_GRAD_FN.substitute(env).split('\n'))
         if func is not None:
-            env['op'] = func['op']
-            env['op_ctor'] = ''
-            env['save_inputs'] = save_variables(func['saved_inputs'], False)
-            env['args_with_derivatives'] = args_with_derivatives
-        else:
-            env['op'] = 'Error'
-            env['op_ctor'] = '"the derivative for {} is not implemented"'.format(declaration['api_name'])
-            env['save_inputs'] = []
-            env['args_with_derivatives'] = tensor_arg_names
-        body.append(SETUP_DERIVATIVE.substitute(env))
+            setup.extend(save_variables(func['saved_inputs'], False))
+
+        body = []
+        body.extend(emit_check_no_requires_grad(differentiable_inputs, args_with_derivatives))
+        body.append(SETUP_DERIVATIVE.substitute(env, setup=setup))
         return body
 
-    def find_args_with_derivatives(tensor_arg_names):
+    def emit_check_output_args():
+        if not is_out_fn:
+            return []
+        name = declaration['name']
+        args = [arg['name'] for arg in differentiable_outputs]
+        args = '{ ' + ', '.join(args) + ' }'
+        return ['check_output_args("{}", {});'.format(name, args)]
+
+    def find_args_with_derivatives():
         """Find arguments that have derivative definitions"""
+        if func is None:
+            return differentiable_inputs
         names = set(name for d in func['derivatives'] for name in d['var_names'])
-        differentiable = [arg for arg in tensor_arg_names if arg in names]
+        differentiable = [arg for arg in differentiable_inputs if arg['name'] in names]
         if len(differentiable) != len(names):
-            missing = names - set(differentiable)
+            missing = names - set(arg['name'] for arg in differentiable)
             raise RuntimeError('Missing arguments for derivatives: {} in {}'.format(missing, func['name']))
         return differentiable
 
@@ -235,9 +244,9 @@ def emit_body(declaration):
         """Checks that arguments without derivatives don't require grad"""
         body = []
         for arg in tensor_args:
-            name = arg['name']
-            if name in args_with_derivatives:
+            if arg in args_with_derivatives:
                 continue
+            name = arg['name']
             if name == 'output':
                 # Double-backwards definitions sometimes take in 'input' and
                 # 'output', but only define the derivative for input.
@@ -265,6 +274,15 @@ def emit_body(declaration):
             stmts.append('grad_fn->{} = {};'.format(name, expr))
         return stmts
 
+    def reference_args(args):
+        res = []
+        for arg in args:
+            if arg['type'] == 'SparseTensor':
+                res.append('{}.tref'.format(arg['name']))
+            else:
+                res.append(arg['name'])
+        return res
+
     def get_trace_outputs(declaration):
         if declaration['return_type'] == 'std::vector<Tensor>':
             return 'flatten({})'.format(declaration['returns'][0]['name'])
@@ -286,7 +304,7 @@ def emit_body(declaration):
         tensor_args = [arg for arg in arguments if arg['simple_type'] in {'Tensor', 'TensorList'}]
         if len(tensor_args) == 0:
             return ''
-        if name in DONT_RECORD_TRACE:
+        if base_name in DONT_RECORD_TRACE:
             return ''
 
         # Note [clang-802.0.42 tuple overload bug]
@@ -338,7 +356,7 @@ def emit_body(declaration):
         return RECORD_TRACE.substitute(combined)
 
     def declare_returned_variables():
-        if inplace or name.endswith('_out'):
+        if inplace or is_out_fn:
             return ''
         if len(declaration['returns']) == 1:
             return ''
@@ -357,11 +375,11 @@ def emit_body(declaration):
         combined = nested_dict(env, declaration)
         if strategy == 'use_derived':
             call = CALL_VIA_DERIVED.substitute(combined)
-            if not inplace:
+            if not (inplace or is_out_fn):
                 call = wrap_output(call)
         else:
             call = CALL_VIA_TYPE.substitute(declaration)
-        if not inplace:
+        if not (inplace or is_out_fn):
             call = '{} = {}'.format(tie_return_values(), call)
         return call + ';'
 
@@ -374,7 +392,7 @@ def emit_body(declaration):
     def get_return_value():
         if inplace:
             return 'self'
-        if name.endswith('_out'):
+        if is_out_fn:
             return_names = [arg['name'] for arg in arguments
                             if arg.get('output', False)]
             if len(return_names) == 1:
@@ -388,7 +406,7 @@ def emit_body(declaration):
         return 'std::make_tuple({})'.format(', '.join(moved))
 
     def emit_history():
-        fn = 'rebase' if inplace and not is_view else 'set'
+        fn = 'rebase' if (inplace or is_out_fn) and not is_view else 'set'
         output_names = [r['name'] for r in differentiable_outputs]
         if len(output_names) == 1:
             outs = output_names[0]
@@ -405,17 +423,26 @@ def emit_body(declaration):
             return CONDITIONAL.substitute(cond='grad_fn', statements=stmts)
         return ''
 
+    def emit_check_inplace():
+        if not inplace and not is_out_fn:
+            return []
+        return ['check_inplace({});'.format(arg['name']) for arg in differentiable_outputs]
+
+    def emit_increment_version():
+        if not inplace and not is_out_fn:
+            return []
+        return ['increment_version({});'.format(arg['name']) for arg in differentiable_outputs]
+
     env = {}
     combined = nested_dict(env, declaration)
 
     body = []
-    if name not in DONT_PROFILE:
+    if base_name not in DONT_PROFILE:
         body.append(RECORD_FUNCTION.substitute(combined))
     if strategy != 'use_type':
         body.extend(unpack_args(env, declaration))
     if requires_derivative:
-        if inplace:
-            body.append('check_inplace(self);')
+        body.extend(emit_check_inplace())
         body.extend(setup_derivative())
     body.append(declare_returned_variables())
     body.append(emit_call(env))
@@ -424,8 +451,7 @@ def emit_body(declaration):
             body.append('ensure_no_aten_scalars(self);')
         # set_flags has to appear after version_counter, because rebase_history
         # requires that the counter is incremented before it is called
-        if inplace:
-            body.append('increment_version(self);')
+        body.extend(emit_increment_version())
         body.append(emit_history())
     # record_trace must appear before save_outputs so that saved outputs
     # have their tracing_state saved

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -215,7 +215,7 @@ def emit_body(declaration):
         env['op_ctor'] = '' if func is not None else error_msg()
 
         if is_out_fn:
-            setup = ['throw_out_requires_grad("{}");'.format(base_name)]
+            setup = ['throw_error_out_requires_grad("{}");'.format(base_name)]
             body = []
             body.append(DECLARE_GRAD_FN.substitute(op='Function'))
             body.append(SETUP_DERIVATIVE.substitute(

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -321,6 +321,7 @@ static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
 
 static void rebase_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
   if (grad_fn) {
+    grad_fn->num_inputs = tensors.size();
     int output_nr = 0;
     for (auto& tensor : tensors) {
       if (tensor.defined()) {
@@ -329,7 +330,6 @@ static void rebase_history(TensorList tensors, std::shared_ptr<Function> grad_fn
         output_nr++;
       }
     }
-    grad_fn->num_inputs = output_nr;
   }
 }
 
@@ -346,6 +346,7 @@ static void set_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
 
 static void set_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
   if (grad_fn) {
+    grad_fn->num_inputs = tensors.size();
     int64_t output_nr = 0;
     for (auto& tensor : tensors) {
       if (tensor.defined()) {
@@ -355,7 +356,6 @@ static void set_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
         output_nr++;
       }
     }
-    grad_fn->num_inputs = output_nr;
   }
 }
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -296,7 +296,7 @@ static void check_inplace(const Tensor& tensor) {
   }
 }
 
-static void throw_out_requires_grad(const char* name) {
+static void throw_error_out_requires_grad(const char* name) {
   at::runtime_error(
       "%s(): functions with out=... arguments don't support automatic differentiation, "
       "but one of the arguments requires grad.", name);

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -296,40 +296,66 @@ static void check_inplace(const Tensor& tensor) {
   }
 }
 
-static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn, int output_nr=0) {
-  if (!tensor.defined()) {
-    return;
+static void check_output_args(const char* name, TensorList tensors) {
+  // Our logic for modifications to views only works for in-place functions,
+  // not out=... functions. Checks that no output arguments are views.
+  for (auto& tensor : tensors) {
+    if (tensor.defined()) {
+      auto& var = static_cast<const Variable&>(tensor);
+      if (var.is_view()) {
+        at::runtime_error(
+          "%s(): output arguments (out=...) must not be views in "
+          "differentiable functions", name);
+      }
+    }
   }
-  auto& var = static_cast<Variable&>(tensor);
-  if (grad_fn) {
+}
+
+static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
+  if (grad_fn && tensor.defined()) {
+    auto& var = static_cast<Variable&>(tensor);
     grad_fn->num_inputs = 1;
-    var.rebase_history(output_nr, std::move(grad_fn));
+    var.rebase_history(0, std::move(grad_fn));
+  }
+}
+
+static void rebase_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
+  if (grad_fn) {
+    int output_nr = 0;
+    for (auto& tensor : tensors) {
+      if (tensor.defined()) {
+        auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
+        var.rebase_history(output_nr, grad_fn);
+        output_nr++;
+      }
+    }
+    grad_fn->num_inputs = output_nr;
   }
 }
 
 // var must be the only differentiable output of the function. Use the ArrayRef
 // overload for functions with multiple differentiable outputs.
-static void set_history(Tensor& t, std::shared_ptr<Function> grad_fn, int output_nr=0) {
-  auto& var = static_cast<Variable&>(t);
-  if (grad_fn) {
+static void set_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
+  if (grad_fn && tensor.defined()) {
+    auto& var = static_cast<Variable&>(tensor);
     grad_fn->num_inputs = 1;
-    var.get()->output_nr = output_nr;
+    var.get()->output_nr = 0;
     var.get()->_grad_fn = std::move(grad_fn);
   }
 }
 
-static void set_history(at::ArrayRef<Tensor> tl, std::shared_ptr<Function> grad_fn) {
+static void set_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
   if (grad_fn) {
-    grad_fn->num_inputs = tl.size();
     int64_t output_nr = 0;
-    for (auto& t : tl) {
-      if (!t.defined()) continue;
-      // TODO: combine this with the Variable construction
-      auto& var = static_cast<const Variable&>(t);
-      var.get()->output_nr = output_nr;
-      var.get()->_grad_fn = grad_fn;
-      output_nr++;
+    for (auto& tensor : tensors) {
+      if (tensor.defined()) {
+        auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
+        var.get()->output_nr = output_nr;
+        var.get()->_grad_fn = grad_fn;
+        output_nr++;
+      }
     }
+    grad_fn->num_inputs = output_nr;
   }
 }
 
@@ -382,7 +408,7 @@ Tensor & VariableType::s_copy_(Tensor & self, const Tensor & src, bool async) co
   }
   baseType->s_copy_(self_, src_, async);
   increment_version(self);
-  rebase_history(static_cast<Variable&>(self), std::move(grad_fn));
+  rebase_history(self, std::move(grad_fn));
   return self;
 }
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -296,19 +296,10 @@ static void check_inplace(const Tensor& tensor) {
   }
 }
 
-static void check_output_args(const char* name, TensorList tensors) {
-  // Our logic for modifications to views only works for in-place functions,
-  // not out=... functions. Checks that no output arguments are views.
-  for (auto& tensor : tensors) {
-    if (tensor.defined()) {
-      auto& var = static_cast<const Variable&>(tensor);
-      if (var.is_view()) {
-        at::runtime_error(
-          "%s(): output arguments (out=...) must not be views in "
-          "differentiable functions", name);
-      }
-    }
-  }
+static void throw_out_requires_grad(const char* name) {
+  at::runtime_error(
+      "%s(): functions with out=... arguments don't support automatic differentiation, "
+      "but one of the arguments requires grad.", name);
 }
 
 static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {

--- a/tools/autograd/templates/python_nn_functions.cpp
+++ b/tools/autograd/templates/python_nn_functions.cpp
@@ -15,10 +15,10 @@ using namespace torch::autograd::utils;
 
 namespace torch { namespace autograd {
 
-${py_nn_functions}
+${py_methods}
 
 static PyMethodDef nn_functions[] = {
-  ${py_nn_function_defs}
+  ${py_method_defs}
   {NULL}
 };
 

--- a/tools/autograd/templates/python_nn_functions_dispatch.h
+++ b/tools/autograd/templates/python_nn_functions_dispatch.h
@@ -6,7 +6,7 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
-// Contains inline wrappers around ATen functions which release the GIL and
+// Contains inline wrappers around ATen functions that release the GIL and
 // switch to the correct CUDA device.
 
 namespace torch { namespace autograd {

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -1,5 +1,10 @@
 // ${generated_comment}
 
+// Python bindings for torch.* functions implemented through ATen.
+//
+// The functions are bound as static methods on a class
+// torch._C._VariableFunctions which is also aliased as Variable._torch.
+
 #include <Python.h>
 
 #include "torch/csrc/Exceptions.h"
@@ -34,6 +39,7 @@ static Tensor dispatch_clamp_max(const Tensor & self, Scalar max) {
   return self.clamp_max(max);
 }
 
+// The Python clamp() syntax has to be mapped to one of three C++ functions
 static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -1,0 +1,127 @@
+// ${generated_comment}
+
+#include <Python.h>
+
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/autograd/utils/wrap_outputs.h"
+#include "torch/csrc/utils/python_arg_parser.h"
+#include "torch/csrc/utils/tensor_numpy.h"
+
+#include "python_torch_functions_dispatch.h"
+
+using at::Tensor;
+using at::Scalar;
+using at::ScalarType;
+using at::Backend;
+using namespace torch::autograd::utils;
+
+namespace torch { namespace autograd {
+
+static Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(self);
+  return self.clamp(min, max);
+}
+static Tensor dispatch_clamp_min(const Tensor & self, Scalar min) {
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(self);
+  return self.clamp_min(min);
+}
+static Tensor dispatch_clamp_max(const Tensor & self, Scalar max) {
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(self);
+  return self.clamp_max(max);
+}
+
+static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  static PythonArgParser parser({
+    "clamp(Tensor input, Scalar min=None, Scalar max=None)",
+  });
+  PyObject* parsed_args[4];
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (!r.isNone(1) && !r.isNone(2)) {
+    return THPVariable_Wrap(dispatch_clamp(r.tensor(0), r.scalar(1), r.scalar(2)));
+  } else if (!r.isNone(1)) {
+    return THPVariable_Wrap(dispatch_clamp_min(r.tensor(0), r.scalar(1)));
+  } else if (!r.isNone(2)) {
+    return THPVariable_Wrap(dispatch_clamp_max(r.tensor(0), r.scalar(2)));
+  } else {
+    throw std::runtime_error("At least one of 'min' or 'max' must not be None");
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
+{
+  HANDLE_TH_ERRORS
+  auto data = torch::utils::tensor_from_numpy(arg);
+  return THPVariable_Wrap(make_variable(std::move(data)));
+  END_HANDLE_TH_ERRORS
+}
+
+// generated methods start here
+
+${py_methods}
+
+static PyMethodDef torch_functions[] = {
+  {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
+  {"from_numpy", (PyCFunction)THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
+  ${py_method_defs}
+  {NULL}
+};
+
+static PyTypeObject THPVariableFunctions = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "torch._C._VariableFunctions",         /* tp_name */
+  0,                                     /* tp_basicsize */
+  0,                                     /* tp_itemsize */
+  0,                                     /* tp_dealloc */
+  0,                                     /* tp_print */
+  0,                                     /* tp_getattr */
+  0,                                     /* tp_setattr */
+  0,                                     /* tp_reserved */
+  0,                                     /* tp_repr */
+  0,                                     /* tp_as_number */
+  0,                                     /* tp_as_sequence */
+  0,                                     /* tp_as_mapping */
+  0,                                     /* tp_hash  */
+  0,                                     /* tp_call */
+  0,                                     /* tp_str */
+  0,                                     /* tp_getattro */
+  0,                                     /* tp_setattro */
+  0,                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT,                    /* tp_flags */
+  NULL,                                  /* tp_doc */
+  0,                                     /* tp_traverse */
+  0,                                     /* tp_clear */
+  0,                                     /* tp_richcompare */
+  0,                                     /* tp_weaklistoffset */
+  0,                                     /* tp_iter */
+  0,                                     /* tp_iternext */
+  torch_functions,                       /* tp_methods */
+  0,                                     /* tp_members */
+  0,                                     /* tp_getset */
+  0,                                     /* tp_base */
+  0,                                     /* tp_dict */
+  0,                                     /* tp_descr_get */
+  0,                                     /* tp_descr_set */
+  0,                                     /* tp_dictoffset */
+  0,                                     /* tp_init */
+  0,                                     /* tp_alloc */
+  0                                      /* tp_new */
+};
+
+void initTorchFunctions(PyObject* module) {
+  if (PyType_Ready(&THPVariableFunctions) < 0) {
+    throw python_error();
+  }
+  Py_INCREF(&THPVariableFunctions);
+  if (PyModule_AddObject(module, "_VariableFunctions", (PyObject*)&THPVariableFunctions) < 0) {
+    throw python_error();
+  }
+}
+
+}} // namespace torch::autograd

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -9,6 +9,8 @@
 // Contains inline wrappers around ATen functions that release the GIL and
 // switch to the correct CUDA device.
 
+extern at::Type* THPDefaultATenType;
+
 namespace torch { namespace autograd {
 
 using at::Tensor;
@@ -18,6 +20,13 @@ using at::IntList;
 using at::Generator;
 using at::SparseTensor;
 using at::Storage;
+
+static at::Type& default_type() {
+  if (!THPDefaultATenType) {
+    throw std::runtime_error("THPDefaultATenType not initialized");
+  }
+  return *VariableImpl::getType(*THPDefaultATenType);
+}
 
 ${py_method_dispatch}
 

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -6,7 +6,7 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
-// Contains inline wrappers around ATen functions which release the GIL and
+// Contains inline wrappers around ATen functions that release the GIL and
 // switch to the correct CUDA device.
 
 namespace torch { namespace autograd {

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -11,8 +11,13 @@
 
 namespace torch { namespace autograd {
 
-using namespace at;
+using at::Tensor;
+using at::Scalar;
+using at::TensorList;
+using at::IntList;
 using at::Generator;
+using at::SparseTensor;
+using at::Storage;
 
 ${py_method_dispatch}
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -57,7 +57,7 @@ static Tensor dispatch_clamp_max(const Tensor & self, Scalar max) {
   return self.clamp_max(max);
 }
 
-PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kwargs)
+static PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
@@ -94,7 +94,7 @@ static Tensor & dispatch_clamp_max_(Tensor & self, Scalar max) {
   return self.clamp_max_(max);
 }
 
-PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* kwargs)
+static PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
@@ -204,14 +204,6 @@ static PyObject * THPVariable_copy_(PyObject* self, PyObject* args, PyObject* kw
   PyObject* parsed_args[2];
   auto r = parser.parse(args, kwargs, parsed_args);
   return THPVariable_Wrap(dispatch_copy_(self_, r.tensor(0), r.toBool(1)));
-  END_HANDLE_TH_ERRORS
-}
-
-static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
-{
-  HANDLE_TH_ERRORS
-  auto data = torch::utils::tensor_from_numpy(arg);
-  return THPVariable_Wrap(make_variable(std::move(data)));
   END_HANDLE_TH_ERRORS
 }
 
@@ -561,7 +553,6 @@ PyMethodDef variable_methods[] = {
   {"double", (PyCFunction)THPVariable_double, METH_NOARGS, NULL},
   {"element_size", (PyCFunction)THPVariable_element_size, METH_NOARGS, NULL},
   {"float", (PyCFunction)THPVariable_float, METH_NOARGS, NULL},
-  {"from_numpy", (PyCFunction)THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
   {"half", (PyCFunction)THPVariable_half, METH_NOARGS, NULL},
   {"int", (PyCFunction)THPVariable_int, METH_NOARGS, NULL},
   {"long", (PyCFunction)THPVariable_long, METH_NOARGS, NULL},

--- a/tools/autograd/templates/python_variable_methods_dispatch.h
+++ b/tools/autograd/templates/python_variable_methods_dispatch.h
@@ -6,7 +6,7 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
-// Contains inline wrappers around ATen functions which release the GIL and
+// Contains inline wrappers around ATen functions that release the GIL and
 // switch to the correct CUDA device.
 
 namespace torch { namespace autograd {

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -271,7 +271,6 @@ _integer_tensor_classes = {
     LongTensor, IntTensor, ShortTensor, CharTensor, ByteTensor
 }
 
-set_default_tensor_type('torch.FloatTensor')
 
 ################################################################################
 # Import interface functions defined in Python
@@ -297,6 +296,8 @@ def manager_path():
 # Shared memory manager needs to know the exact location of manager executable
 _C._initExtension(manager_path())
 del manager_path
+
+set_default_tensor_type('torch.FloatTensor')
 
 ################################################################################
 # Remove unnecessary members

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -257,6 +257,7 @@ class Variable(_C._VariableBase):
         return self.view(tensor.size())
 
     def repeat(self, *repeats):
+        from ._functions import Repeat
         if len(repeats) == 1 and isinstance(repeats[0], torch.Size):
             repeats = repeats[0]
         else:
@@ -276,9 +277,11 @@ class Variable(_C._VariableBase):
             return super(Variable, self).btrifact(pivot=pivot)
 
     def resize(self, *sizes):
+        from ._functions import Resize
         return Resize.apply(self, sizes)
 
     def resize_as(self, variable):
+        from ._functions import Resize
         return Resize.apply(self, variable.size())
 
     def index_add(self, dim, index, tensor):
@@ -375,21 +378,8 @@ class Variable(_C._VariableBase):
             array = array.astype('uint8')
         return Variable.from_numpy(array)
 
-    class _torch(object):
-        pass
+    _torch = torch._C._VariableFunctions
 
 
-for method in dir(Variable):
-    # This will also wrap some methods that normally aren't part of the
-    # functional interface, but we don't care, as they won't ever be used
-    if method.startswith('_') or method.endswith('_'):
-        continue
-    if hasattr(Variable._torch, method):
-        continue
-    as_static = staticmethod(getattr(Variable, method))
-    setattr(Variable._torch, method, as_static)
-
-
-from ._functions import *
 from torch._C import _ImperativeEngine as ImperativeEngine
 Variable._execution_engine = ImperativeEngine()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -39,6 +39,7 @@ PyObject* module;
 PyObject* tensor_classes;
 
 PyObject *THPDefaultTensorClass = NULL;
+at::Type *THPDefaultATenType = nullptr;
 THPGenerator *THPDefaultGenerator   = NULL;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -165,6 +166,7 @@ bool THPModule_isTensor(PyObject *obj)
 PyObject * THPModule_setDefaultTensorType(PyObject *_unused, PyObject *type)
 {
   THPDefaultTensorClass = type;
+  THPDefaultATenType = &torch::getATenType((PyTypeObject*)type);
   Py_RETURN_NONE;
 }
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -198,37 +198,9 @@ static PyObject * findTensor(PyObject *args, PyObject *kwargs) {
   return THPDefaultTensorClass;
 }
 
-static PyObject * swapFirstTwoItems(PyObject *args) {
-  // Returns a tuple with the first two items swapped
-  auto size = PyTuple_GET_SIZE(args);
-  auto r = THPObjectPtr{PyTuple_New(size)};
-  if (!r) return nullptr;
-  for (Py_ssize_t i = 0; i < size; i++) {
-    PyObject* obj = PyTuple_GET_ITEM(args, (i <= 1 ? 1 - i : i));
-    Py_INCREF(obj);
-    PyTuple_SET_ITEM(r.get(), i, obj);
-  }
-  return r.release();
-}
-
 static PyObject * dispatchStateless(PyObject *args, PyObject *kwargs, const char *name) {
   PyObject *tensor = findTensor(args, kwargs);
   return THPUtils_dispatchStateless(tensor, name, args, kwargs);
-}
-
-static PyObject * dispatchStatelessSwap(PyObject *args, PyObject *kwargs, const char *name) {
-  PyObject *tensor = findTensor(args, kwargs);
-  if (THPVariable_Check(tensor) && PyTuple_GET_SIZE(args) >= 2 && tensor == PyTuple_GET_ITEM(args, 1)) {
-    // Unlike tensors, the stateless methods on Variables are dispatched in a different manner.
-    // On Variables, the `self` argument must be at the first argument when dispatching.
-    // For stateless methods which has more than one arguments and the `self` comes second,
-    // (e.g., `polygamma(n, x)`, etc.), the `self` argument needs to be swapped to the
-    // first position before dispatching.
-    auto newArgs = THPObjectPtr{swapFirstTwoItems(args)};
-    return THPUtils_dispatchStateless(tensor, name, newArgs.get(), kwargs);
-  } else {
-    return THPUtils_dispatchStateless(tensor, name, args, kwargs);
-  }
 }
 
 #define IMPLEMENT_STATELESS(name)                                              \
@@ -237,21 +209,12 @@ static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *arg
   return dispatchStateless(args, kwargs, #name);                               \
 }
 
-#define IMPLEMENT_STATELESS_SWAP(name)                                         \
-static PyObject * TH_CONCAT_2(THPModule_, name)(PyObject *_unused, PyObject *args, PyObject *kwargs) \
-{                                                                              \
-  return dispatchStatelessSwap(args, kwargs, #name);                           \
-}
-
-// This handles the deprecated torch.addxx signatures. For example,
-// torch.addmm(1, var, 2, a, b) -> var.addmm(1, 2, a, b)
-#define IMPLEMENT_STATELESS_ADDXX IMPLEMENT_STATELESS_SWAP
-
 IMPLEMENT_STATELESS(sigmoid)
 IMPLEMENT_STATELESS(log)
 IMPLEMENT_STATELESS(log1p)
 IMPLEMENT_STATELESS(lgamma)
 IMPLEMENT_STATELESS(digamma)
+IMPLEMENT_STATELESS(polygamma)
 IMPLEMENT_STATELESS(erf)
 IMPLEMENT_STATELESS(erfinv)
 IMPLEMENT_STATELESS(exp)
@@ -366,21 +329,15 @@ IMPLEMENT_STATELESS(le)
 IMPLEMENT_STATELESS(eq)
 IMPLEMENT_STATELESS(ne)
 
-// For torch.polygamma(n, x), the `self` argument comes second, the
-// first two arguments needs to be swapped before dispatch.
-IMPLEMENT_STATELESS_SWAP(polygamma)
-
-IMPLEMENT_STATELESS_ADDXX(addmm)
-IMPLEMENT_STATELESS_ADDXX(addmv)
-IMPLEMENT_STATELESS_ADDXX(addr)
-IMPLEMENT_STATELESS_ADDXX(addbmm)
-IMPLEMENT_STATELESS_ADDXX(baddbmm)
-IMPLEMENT_STATELESS_ADDXX(addcmul)
-IMPLEMENT_STATELESS_ADDXX(addcdiv)
+IMPLEMENT_STATELESS(addmm)
+IMPLEMENT_STATELESS(addmv)
+IMPLEMENT_STATELESS(addr)
+IMPLEMENT_STATELESS(addbmm)
+IMPLEMENT_STATELESS(baddbmm)
+IMPLEMENT_STATELESS(addcmul)
+IMPLEMENT_STATELESS(addcdiv)
 
 #undef IMPLEMENT_STATELESS
-#undef IMPLEMENT_STATELESS_SWAP
-#undef IMPLEMENT_STATELESS_ADDXX
 
 // In nonzero, the first argument might be a LongTensor that will be used
 // for indices output, so we should pick a function based on second

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -511,6 +511,7 @@ PyTypeObject THPVariableType = {
 namespace torch { namespace autograd {
 
 extern PyMethodDef variable_methods[];
+extern void initTorchFunctions(PyObject *module);
 
 }}
 
@@ -523,5 +524,6 @@ bool THPVariable_initModule(PyObject *module)
     return false;
   Py_INCREF(&THPVariableType);
   PyModule_AddObject(module, "_VariableBase", (PyObject *)&THPVariableType);
+  torch::autograd::initTorchFunctions(module);
   return true;
 }

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -11,7 +11,7 @@ MODE_BORDER = 1
 
 def grid_sampler(input, grid, padding_mode):
     if cudnn.is_acceptable(input.data) and padding_mode == 'zeros':
-        return torch._C._VariableBase.cudnn_grid_sampler(input, grid)
+        return torch._C._VariableFunctions.cudnn_grid_sampler(input, grid)
     else:
         return GridSampler.apply(input, grid, padding_mode)
 
@@ -24,7 +24,7 @@ def affine_grid_generator(theta, size):
         if not cudnn.is_acceptable(theta.data):
             raise RuntimeError("AffineGridGenerator generator theta not acceptable for CuDNN")
         N, C, H, W = size
-        return torch._C._VariableBase.cudnn_affine_grid_generator(theta, N, C, H, W)
+        return torch._C._VariableFunctions.cudnn_affine_grid_generator(theta, N, C, H, W)
     else:
         return AffineGridGenerator.apply(theta, size)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -16,7 +16,7 @@ from torch.autograd import Variable
 from .modules.utils import _single, _pair, _triple
 
 
-conv1d = _add_docstr(torch._C._VariableBase.conv1d, r"""
+conv1d = _add_docstr(torch._C._VariableFunctions.conv1d, r"""
 conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 1D convolution over an input signal composed of several input
@@ -44,7 +44,7 @@ Examples::
     >>> F.conv1d(inputs, filters)
 """)
 
-conv2d = _add_docstr(torch._C._VariableBase.conv2d, r"""
+conv2d = _add_docstr(torch._C._VariableFunctions.conv2d, r"""
 conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 2D convolution over an input image composed of several input
@@ -73,7 +73,7 @@ Examples::
     >>> F.conv2d(inputs, filters, padding=1)
 """)
 
-conv3d = _add_docstr(torch._C._VariableBase.conv3d, r"""
+conv3d = _add_docstr(torch._C._VariableFunctions.conv3d, r"""
 conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> Tensor
 
 Applies a 3D convolution over an input image composed of several input
@@ -101,7 +101,7 @@ Examples::
     >>> F.conv3d(inputs, filters)
 """)
 
-conv_transpose1d = _add_docstr(torch._C._VariableBase.conv_transpose1d, r"""
+conv_transpose1d = _add_docstr(torch._C._VariableFunctions.conv_transpose1d, r"""
 conv_transpose1d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 1D transposed convolution operator over an input signal
@@ -126,7 +126,7 @@ Args:
       a tuple (dW,). Default: 1
 """)
 
-conv_transpose2d = _add_docstr(torch._C._VariableBase.conv_transpose2d, r"""
+conv_transpose2d = _add_docstr(torch._C._VariableFunctions.conv_transpose2d, r"""
 conv_transpose2d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 2D transposed convolution operator over an input image
@@ -151,7 +151,7 @@ Args:
       a tuple (dH, dW). Default: 1
 """)
 
-conv_transpose3d = _add_docstr(torch._C._VariableBase.conv_transpose3d, r"""
+conv_transpose3d = _add_docstr(torch._C._VariableFunctions.conv_transpose3d, r"""
 conv_transpose3d(input, weight, bias=None, stride=1, padding=0, output_padding=0, groups=1, dilation=1) -> Tensor
 
 Applies a 3D transposed convolution operator over an input image
@@ -329,7 +329,7 @@ def max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1,
 
     See :class:`~torch.nn.MaxPool1d` for details.
     """
-    ret = torch._C._VariableBase.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)
+    ret = torch._C._VariableFunctions.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)
     return ret if return_indices else ret[0]
 
 
@@ -456,7 +456,7 @@ def adaptive_max_pool1d(input, output_size, return_indices=False):
         output_size: the target output size (single integer)
         return_indices: whether to return pooling indices. Default: ``False``
     """
-    ret = torch._C._VariableBase.adaptive_max_pool1d(input, output_size)
+    ret = torch._C._VariableFunctions.adaptive_max_pool1d(input, output_size)
     return ret if return_indices else ret[0]
 
 
@@ -490,7 +490,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
     return ret if return_indices else ret[0]
 
 
-adaptive_avg_pool1d = _add_docstr(torch._C._VariableBase.adaptive_avg_pool1d, r"""
+adaptive_avg_pool1d = _add_docstr(torch._C._VariableFunctions.adaptive_avg_pool1d, r"""
 adaptive_avg_pool1d(input, output_size) -> Variable
 
 Applies a 1D adaptive average pooling over an input signal composed of
@@ -682,10 +682,10 @@ def selu(input, inplace=False):
     See :class:`~torch.nn.SELU` for more details.
     """
     if inplace:
-        return torch._C._VariableBase.selu_(input)
-    return torch._C._VariableBase.selu(input)
+        return torch._C._VariableFunctions.selu_(input)
+    return torch._C._VariableFunctions.selu(input)
 
-selu_ = _add_docstr(torch._C._VariableBase.selu_, r"""
+selu_ = _add_docstr(torch._C._VariableFunctions.selu_, r"""
 selu_(input) -> Variable
 
 In-place verison of :func:`~selu`.
@@ -730,11 +730,11 @@ def rrelu(input, lower=1. / 8, upper=1. / 3, training=False, inplace=False):
     Randomized leaky ReLU.
     """
     if inplace:
-        return torch._C._VariableBase.rrelu_(input, lower, upper, training)
-    return torch._C._VariableBase.rrelu(input, lower, upper, training)
+        return torch._C._VariableFunctions.rrelu_(input, lower, upper, training)
+    return torch._C._VariableFunctions.rrelu(input, lower, upper, training)
 
 
-rrelu_ = _add_docstr(torch._C._VariableBase.rrelu_, r"""
+rrelu_ = _add_docstr(torch._C._VariableFunctions.rrelu_, r"""
 rrelu_(input, lower=1./8, upper=1./3, training=False) -> Variable
 
 In-place version of :func:`~rrelu`.
@@ -1058,8 +1058,8 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
             padding_idx = -1
     if max_norm is not None:
         with torch.no_grad():
-            torch._C._VariableBase.embedding_renorm_(weight, input, max_norm, norm_type)
-    return torch._C._VariableBase.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
+            torch._C._VariableFunctions.embedding_renorm_(weight, input, max_norm, norm_type)
+    return torch._C._VariableFunctions.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
 
 
 def embedding_bag(embedding_matrix, indices, offsets=None,
@@ -1147,7 +1147,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
         size = list(input.size())
         if reduce(mul, size[2:], size[0]) == 1:
             raise ValueError('Expected more than 1 value per channel when training, got input size {}'.format(size))
-    return torch._C._VariableBase.batch_norm(
+    return torch._C._VariableFunctions.batch_norm(
         input, weight, bias,
         Variable(running_mean), Variable(running_var), training, momentum, eps, torch.backends.cudnn.enabled
     )


### PR DESCRIPTION
This adds overrides in VariableType for the xxx_out ATen functions and
implements Python bindings. There is **no** support for automatic
differentiation. If any of the inputs (or outputs) requires grad, then the
function will throw an exception unless it's running in "no-grad" mode.

The bindings for calling torch.xxx functions on Variables are moved to a
different object. Previously, they were static method on VariableBase.
This change prevents users from accidentally calling static methods as if
they were instance methods.

Generated files:

[VariableType.cpp](https://gist.github.com/colesbury/b20a992d9ae8ee0cf041a1ef47928487)
[VariableType.cpp.diff](https://gist.github.com/colesbury/435bc8efb7841012478d508bc9a50566)
[python_torch_functions.cpp](https://gist.github.com/colesbury/d8716729a91d378927cd57966de15c9f)