### PR TITLE
Fix #4422, use grad instead of grads[0] for cudnn_batch_norm derivative.

### DIFF
--- a/aten/src/ATen/Tensor.cpp
+++ b/aten/src/ATen/Tensor.cpp
@@ -6,7 +6,7 @@ namespace at {
 
 void Tensor::print() const {
   if (defined()) {
-    std::cerr << "[" << toString() << " " << sizes() << "]" << std::endl;
+    std::cerr << "[" << type().toString() << " " << sizes() << "]" << std::endl;
   } else {
     std::cerr << "[UndefinedTensor]" << std::endl;
   }

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -834,17 +834,19 @@ class ModuleTest(TestBase):
 
             # Run double-backwards on CPU and GPU and compare results
             if self.check_gradgrad and not self.FIXME_no_cuda_gradgrad_comparison:
-                cpu_output_t = cpu_output.data if isinstance(cpu_output, Variable) else cpu_output
-                cpu_gradOutput = Variable(cpu_output_t.clone().normal_(), requires_grad=True)
-                gpu_gradOutput = Variable(cpu_gradOutput.type('torch.cuda.FloatTensor').data, requires_grad=True)
+                cpu_output = cpu_module(cpu_input)
+                gpu_output = gpu_module(gpu_input)
+
+                cpu_gradOutput = Variable(cpu_output.data.clone().normal_(), requires_grad=True)
+                gpu_gradOutput = Variable(cpu_gradOutput.data.type_as(gpu_output), requires_grad=True)
 
                 cpu_gradInputs = torch.autograd.grad(
-                    cpu_module(cpu_input),
+                    cpu_output,
                     (cpu_input,) + tuple(cpu_module.parameters()),
                     cpu_gradOutput,
                     create_graph=True)
                 gpu_gradInputs = torch.autograd.grad(
-                    gpu_module(gpu_input),
+                    gpu_output,
                     (gpu_input,) + tuple(gpu_module.parameters()),
                     gpu_gradOutput,
                     create_graph=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4530,7 +4530,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='affine',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4539,7 +4538,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='3d_input',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4548,7 +4546,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm1d',
@@ -4557,7 +4554,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='3d_input_not_affine',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4565,7 +4561,6 @@ new_module_tests = [
         input_size=(2, 3, 6, 6),
         cudnn=True,
         check_eval=True,
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4574,7 +4569,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='momentum',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm2d',
@@ -4583,7 +4577,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4591,7 +4584,6 @@ new_module_tests = [
         input_size=(2, 3, 4, 4, 4),
         cudnn=True,
         check_eval=True,
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4600,7 +4592,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='momentum',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='BatchNorm3d',
@@ -4609,7 +4600,6 @@ new_module_tests = [
         cudnn=True,
         check_eval=True,
         desc='not_affine',
-        FIXME_no_cuda_gradgrad_comparison=True,  # See #4422
     ),
     dict(
         module_name='Conv1d',

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -16,16 +16,27 @@
 # Gradient expressions are standard C++ expressions operating on ATen
 # variables.  In a gradient expression, the following variables are in
 # scope:
-#   - 'grad' (aka 'grad_output'), the gradient of the output which
-#     we are going to left-multiply.  When the forward returns multiple
-#     outputs, 'grad' always refers to the first output; you can refer
-#     to other outputs using 'grads'
+#
+#   - 'grad', the gradient of the output (often spelled grad_output
+#     in Python) which we are going to left-multiply.
+#
+#     When a function returns multiple *differentiable* outputs,
+#     you can refer to the gradients of each outputs using 'grads',
+#     e.g., 'grads[0]', 'grads[1]'
+#
+#     When a function returns *one* differentiable output (the
+#     first output) and some more nondifferentiable outputs,
+#     you MUST refer to the gradient of the differentiable output with
+#     'grad' (this case is special-cased in our code generation).
+#
 #   - Any of the input arguments, tensor or non-tensor, including
 #     argument names tha only appear in Declarations.cwrap, e.g. 'output'.
+#
 #   - 'result', representing the result of evaluating the forward
 #     expression for ATen native function declarations. If the forward
 #     expression outputs a tuple, use 'resultX' instead to access the
 #     X-th entry
+#
 #   - 'grad_input_mask', a std::array<bool, n> (where n is the number
 #     of differentiable inputs), specifying which inputs actually
 #     require gradient.  (This is only available when multiple
@@ -1035,7 +1046,7 @@
 # work.)
 # NB2: The quotes around the gradient are needed to appease YAML parsing rules.
 - name: cudnn_batch_norm(Tensor input, Tensor weight, Tensor bias, Tensor running_mean, Tensor running_var, bool training, double exponential_average_factor, double epsilon)
-  input, weight, bias: "training ? cudnn_batch_norm_backward(input, grads[0].contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : thnn_batch_norm_backward(grads[0].contiguous(), input, weight, running_mean, running_var, training, epsilon, result1, result2, grad_input_mask)"
+  input, weight, bias: "training ? cudnn_batch_norm_backward(input, grad.contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : thnn_batch_norm_backward(grad.contiguous(), input, weight, running_mean, running_var, training, epsilon, result1, result2, grad_input_mask)"
 
 # HACK: save_mean and save_var are going to be passed in as
 # requires_grad variables (even though we'll never backprop through

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -939,7 +939,7 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   }
   auto mu = unsqueeze_dim1(make_variable(training ? save_mean : running_mean), input);
   auto input_sub_mu = input - mu;
-  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(make_variable(training ? save_std : (running_var + Scalar(eps).toTensor()).pow(-0.5)), input);
+  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(make_variable(training ? save_std : running_var.add(Scalar(eps)).pow(-0.5)), input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);
   auto sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3);
 


### PR DESCRIPTION
The fix proper is very simple: use 'grad' instead of 'grads[0]' in
cudnn_batch_norm's backward definition.

However, the problem was annoyingly subtle and I nearly went off
and implemented a big pile of infrastructure to "tell" the codegen
how to distinguish between differentiable and non-differentiable
outputs before realizing that there must be a way we do this
legitimately, because it works for THNN.  I documented this in
derivatives.yaml, and also added tests for the problem in
load_derivatives.py to catch the various ways you could "get it
wrong".  Hope this helps someone else.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @elbaro