### PR TITLE
Add torch.distributions.utils._finfo for numerical stability

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -35,7 +35,7 @@ from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  Laplace, Normal, OneHotCategorical, Pareto,
                                  StudentT, Uniform, kl_divergence)
 from torch.distributions.constraints import Constraint, is_dependent
-from torch.distributions.utils import finfo
+from torch.distributions.utils import _finfo
 
 TEST_NUMPY = True
 try:
@@ -1298,7 +1298,7 @@ class TestNumericalStability(TestCase):
             self._test_pdf_score(dist_class=Bernoulli,
                                  probs=tensor_type([0]),
                                  x=tensor_type([1]),
-                                 expected_value=tensor_type([finfo[tensor_type([]).type()].eps]).log(),
+                                 expected_value=tensor_type([_finfo(tensor_type([])).eps]).log(),
                                  expected_gradient=tensor_type([0]))
 
             self._test_pdf_score(dist_class=Bernoulli,

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1278,13 +1278,13 @@ class TestNumericalStability(TestCase):
         self.assertEqual(log_pdf.data,
                          expected_value,
                          prec=prec,
-                         message='Failed for tensor type: {}. Expected = {}, Actual = {}'
+                         message='Incorrect value for tensor type: {}. Expected = {}, Actual = {}'
                          .format(type(x), expected_value, log_pdf.data))
         if expected_gradient is not None:
             self.assertEqual(p.grad.data,
                              expected_gradient,
                              prec=prec,
-                             message='Failed for tensor type: {}. Expected = {}, Actual = {}'
+                             message='Incorrect gradient for tensor type: {}. Expected = {}, Actual = {}'
                              .format(type(x), expected_gradient, p.grad.data))
 
     def test_bernoulli_gradient(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -35,7 +35,7 @@ from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  Laplace, Normal, OneHotCategorical, Pareto,
                                  StudentT, Uniform, kl_divergence)
 from torch.distributions.constraints import Constraint, is_dependent
-from torch.distributions.utils import _get_clamping_buffer
+from torch.distributions.utils import finfo
 
 TEST_NUMPY = True
 try:
@@ -596,7 +596,7 @@ class TestDistributions(TestCase):
     def test_gamma_sample_grad(self):
         set_rng_seed(1)  # see Note [Randomized statistical tests]
         num_samples = 100
-        for alpha in [1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
+        for alpha in [1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
             alphas = Variable(torch.FloatTensor([alpha] * num_samples), requires_grad=True)
             betas = Variable(torch.ones(num_samples).type_as(alphas))
             x = Gamma(alphas, betas).rsample()
@@ -1298,7 +1298,7 @@ class TestNumericalStability(TestCase):
             self._test_pdf_score(dist_class=Bernoulli,
                                  probs=tensor_type([0]),
                                  x=tensor_type([1]),
-                                 expected_value=tensor_type([_get_clamping_buffer(tensor_type([]))]).log(),
+                                 expected_value=tensor_type([finfo[tensor_type([]).type()].eps]).log(),
                                  expected_gradient=tensor_type([0]))
 
             self._test_pdf_score(dist_class=Bernoulli,

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -5,7 +5,7 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, _finfo
+from torch.distributions.utils import _finfo, broadcast_all
 
 
 def _dirichlet_sample_nograd(alpha):

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -5,12 +5,14 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all
+from torch.distributions.utils import broadcast_all, finfo
 
 
 def _dirichlet_sample_nograd(alpha):
-    gammas = torch._C._standard_gamma(alpha)
-    return gammas / gammas.sum(-1, True)
+    probs = torch._C._standard_gamma(alpha)
+    probs /= probs.sum(-1, True)
+    f = finfo[probs.type()]
+    return probs.clamp_(min=f.tiny, max=1 - f.eps)
 
 
 class _Dirichlet(Function):

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -5,14 +5,14 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, finfo
+from torch.distributions.utils import broadcast_all, _finfo
 
 
 def _dirichlet_sample_nograd(alpha):
     probs = torch._C._standard_gamma(alpha)
     probs /= probs.sum(-1, True)
-    f = finfo[probs.type()]
-    return probs.clamp_(min=f.tiny, max=1 - f.eps)
+    eps = _finfo(probs).eps
+    return probs.clamp_(min=eps, max=1 - eps)
 
 
 class _Dirichlet(Function):

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -5,7 +5,7 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, _finfo
+from torch.distributions.utils import _finfo, broadcast_all
 
 
 def _standard_gamma(alpha):

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -5,7 +5,7 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all
+from torch.distributions.utils import broadcast_all, finfo
 
 
 def _standard_gamma(alpha):
@@ -43,7 +43,10 @@ class Gamma(Distribution):
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        return _standard_gamma(self.alpha.expand(shape)) / self.beta.expand(shape)
+        value = _standard_gamma(self.alpha.expand(shape)) / self.beta.expand(shape)
+        data = value.data if isinstance(value, Variable) else value
+        data.clamp_(min=finfo[value.type()].tiny)  # do not record in autograd graph
+        return value
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -5,7 +5,7 @@ from torch.autograd import Function, Variable
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, finfo
+from torch.distributions.utils import broadcast_all, _finfo
 
 
 def _standard_gamma(alpha):
@@ -45,7 +45,7 @@ class Gamma(Distribution):
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.alpha.expand(shape)) / self.beta.expand(shape)
         data = value.data if isinstance(value, Variable) else value
-        data.clamp_(min=finfo[value.type()].tiny)  # do not record in autograd graph
+        data.clamp_(min=_finfo(value).tiny)  # do not record in autograd graph
         return value
 
     def log_prob(self, value):

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -3,7 +3,7 @@ from numbers import Number
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all
+from torch.distributions.utils import _finfo, broadcast_all
 
 
 class Gumbel(Distribution):
@@ -35,7 +35,7 @@ class Gumbel(Distribution):
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        uni_dist = self.scale.new(shape).uniform_(1e-15, 1)
+        uni_dist = self.scale.new(shape).uniform_(_finfo(self.scale).eps, 1)
         # X ~ Uniform(0, 1)
         # Y = loc - scale * ln (-ln (X)) ~ Gumbel(loc, scale)
         return self.loc - self.scale * torch.log(-uni_dist.log())

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -3,7 +3,7 @@ from numbers import Number
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all
+from torch.distributions.utils import _finfo, broadcast_all
 
 
 class Laplace(Distribution):
@@ -35,11 +35,10 @@ class Laplace(Distribution):
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        u = self.loc.new(*shape).uniform_(-.5, .5)
-        u[u == -0.5] = 0
+        u = self.loc.new(*shape).uniform_(_finfo(self.loc).eps - 1, 1)
         # TODO: If we ever implement tensor.nextafter, below is what we want ideally.
         # u = self.loc.new(*shape).uniform_(self.loc.nextafter(-.5, 0), .5)
-        return self.loc - self.scale * u.sign() * torch.log1p(-2 * u.abs())
+        return self.loc - self.scale * u.sign() * torch.log1p(-u.abs())
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -16,6 +16,7 @@ _FINFO = {
     'torch.cuda.FloatTensor': _Finfo(eps=1.19209e-07, tiny=1.17549e-38),
     'torch.cuda.DoubleTensor': _Finfo(eps=2.22044604925e-16, tiny=2.22507385851e-308),
 }
+_FINFO_MEMOIZE = {}
 
 
 def _finfo(tensor):
@@ -24,8 +25,18 @@ def _finfo(tensor):
     - `.eps` is the smallest number that can be added to 1 without being lost.
     - `.tiny` is the smallest positive number greater than zero
       (much smaller than `.eps`).
+
+    Args:
+        tensor (Tensor or Variable): tensor or variable of floating point data.
+    Returns:
+        _Finfo: a `namedtuple` with fields `.eps` and `.tiny`.
     """
-    return _FINFO[tensor.type()]
+    try:
+        return _FINFO_MEMOIZE[tensor.storage_type()]
+    except KeyError:
+        finfo = _FINFO[tensor.type()]
+        _FINFO_MEMOIZE[tensor.storage_type()] = finfo
+        return finfo
 
 
 def expand_n(v, n):

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -9,14 +9,13 @@ from torch.autograd import Variable
 # This follows semantics of numpy.finfo.
 _Finfo = namedtuple('_Finfo', ['eps', 'tiny'])
 _FINFO = {
-    'torch.HalfTensor': _Finfo(eps=0.00097656, tiny=6.1035e-05),
-    'torch.FloatTensor': _Finfo(eps=1.19209e-07, tiny=1.17549e-38),
-    'torch.DoubleTensor': _Finfo(eps=2.22044604925e-16, tiny=2.22507385851e-308),
-    'torch.cuda.HalfTensor': _Finfo(eps=0.00097656, tiny=6.1035e-05),
-    'torch.cuda.FloatTensor': _Finfo(eps=1.19209e-07, tiny=1.17549e-38),
-    'torch.cuda.DoubleTensor': _Finfo(eps=2.22044604925e-16, tiny=2.22507385851e-308),
+    torch.HalfStorage: _Finfo(eps=0.00097656, tiny=6.1035e-05),
+    torch.FloatStorage: _Finfo(eps=1.19209e-07, tiny=1.17549e-38),
+    torch.DoubleStorage: _Finfo(eps=2.22044604925e-16, tiny=2.22507385851e-308),
+    torch.cuda.HalfStorage: _Finfo(eps=0.00097656, tiny=6.1035e-05),
+    torch.cuda.FloatStorage: _Finfo(eps=1.19209e-07, tiny=1.17549e-38),
+    torch.cuda.DoubleStorage: _Finfo(eps=2.22044604925e-16, tiny=2.22507385851e-308),
 }
-_FINFO_MEMOIZE = {}
 
 
 def _finfo(tensor):
@@ -31,12 +30,7 @@ def _finfo(tensor):
     Returns:
         _Finfo: a `namedtuple` with fields `.eps` and `.tiny`.
     """
-    try:
-        return _FINFO_MEMOIZE[tensor.storage_type()]
-    except KeyError:
-        finfo = _FINFO[tensor.type()]
-        _FINFO_MEMOIZE[tensor.storage_type()] = finfo
-        return finfo
+    return _FINFO[tensor.storage_type()]
 
 
 def expand_n(v, n):


### PR DESCRIPTION
This adds a lightweight `_finfo()` function for use in torch.distributions. Example usage:
```py
>>> _finfo(Variable(torch.HalfTensor())).eps
0.00097656
>>> _finfo(torch.HalfTensor()).tiny
6.1035e-05
>>> _finfo(torch.FloatTensor()).eps
1.19209e-07
>>> _finfo(torch.DoubleTensor()).eps
2.22044604925e-16
```
It is modeled after the [numpy.finfo](https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.finfo.html) function. This PR also uses `_finfo` to clamp the `Gamma`, `Beta`, and `Dirichlet` distributions to avoid NANs.
  