### PR TITLE
Make pin_memory not cast namedtuples to lists

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -524,10 +524,11 @@ class TestDictDataLoader(TestCase):
         from collections import namedtuple
         from pprint import pprint
         Batch = namedtuple('Batch', ['data', 'labels'])
-        print(self.dataset)
+
         def collate(x):
             data, labels = zip(*[(e['a_tensor'], e['another_dict']) for e in x])
             return Batch(data=torch.cat(data), labels=labels)
+
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True, collate_fn=collate)
         for batch in loader:
             self.assertTrue(isinstance(batch, Batch))

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -518,7 +518,7 @@ class TestDictDataLoader(TestCase):
         for batch_ndx, sample in enumerate(loader):
             self.assertTrue(sample['a_tensor'].is_pinned())
             self.assertTrue(sample['another_dict']['a_number'].is_pinned())
-            
+
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_with_collate(self):
         from collections import namedtuple

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -522,7 +522,6 @@ class TestDictDataLoader(TestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_with_collate(self):
         from collections import namedtuple
-        from pprint import pprint
         Batch = namedtuple('Batch', ['data', 'labels'])
 
         def collate(x):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -146,10 +146,7 @@ def pin_memory_batch(batch):
     elif isinstance(batch, collections.Mapping):
         return {k: pin_memory_batch(sample) for k, sample in batch.items()}
     elif isinstance(batch, collections.Sequence):
-        try:
-            return type(batch)(*(pin_memory_batch(sample) for sample in batch))
-        except AttributeError:
-            return [pin_memory_batch(sample) for sample in batch]
+        return type(batch)(*(pin_memory_batch(sample) for sample in batch))
     else:
         return batch
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -147,7 +147,7 @@ def pin_memory_batch(batch):
         return {k: pin_memory_batch(sample) for k, sample in batch.items()}
     elif isinstance(batch, collections.Sequence):
         try:
-            return batch._make([pin_memory_batch(sample) for sample in batch])
+            return type(batch)(*(pin_memory_batch(sample) for sample in batch))
         except AttributeError:
             return [pin_memory_batch(sample) for sample in batch]
     else:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -146,7 +146,10 @@ def pin_memory_batch(batch):
     elif isinstance(batch, collections.Mapping):
         return {k: pin_memory_batch(sample) for k, sample in batch.items()}
     elif isinstance(batch, collections.Sequence):
-        return [pin_memory_batch(sample) for sample in batch]
+        try:
+            return batch._make([pin_memory_batch(sample) for sample in batch])
+        except AttributeError:
+            return [pin_memory_batch(sample) for sample in batch]
     else:
         return batch
 


### PR DESCRIPTION
**The Problem:**
Currently if you implement a nonstandard collate function, for the ``DataLoader``, which, for example returns a namedtuple and set ``pin_memory=True`` the namedtuple would be "casted" to a list.

Relevant discussion here: https://github.com/pytorch/pytorch/issues/3281