### PR TITLE
TensorGeometry: add transpose() and wrap_dim behavior

### DIFF
--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/Type.h>
+#include <ATen/WrapDimUtils.h>
 
 namespace at {
 
@@ -19,8 +20,15 @@ struct AT_API TensorGeometry {
   Tensor zeros_with_stride(const Type& type) const;
 
   int64_t dim() const { return sizes_.size(); }
-  int64_t size(int64_t dim) const { return sizes_.at(static_cast<size_t>(dim)); }
+  int64_t size(int64_t dim) const {
+    dim = maybe_wrap_dim(dim, this->dim());
+    return sizes_.at(static_cast<size_t>(dim));
+  }
   IntList sizes() const { return IntList{ sizes_ }; }
+  int64_t stride(int64_t dim) const {
+    dim = maybe_wrap_dim(dim, this->dim());
+    return strides_.at(static_cast<size_t>(dim));
+  }
   IntList strides() const { return IntList{ strides_ }; }
   int64_t storage_offset() const { return storage_offset_; }
   int64_t numel() const {
@@ -28,6 +36,15 @@ struct AT_API TensorGeometry {
     for (auto s : sizes()) {
       r *= s;
     }
+    return r;
+  }
+
+  TensorGeometry transpose(int64_t dim0, int64_t dim1) {
+    TensorGeometry r = *this; // copy
+    AT_ASSERT(dim0 < dim(), "transpose: dim0=%d out of range (dim=%d)", dim0, dim())
+    AT_ASSERT(dim1 < dim(), "transpose: dim1=%d out of range (dim=%d)", dim1, dim())
+    std::swap(r.sizes_[dim0], r.sizes_[dim1]);
+    std::swap(r.strides_[dim0], r.strides_[dim1]);
     return r;
   }
 


### PR DESCRIPTION
- Add a transpose() geometry which returns a modified
  geometry corresponding to what would have happened if
  you transposed.

- Make size() and stride() in TensorGeometry behave
  similarly to size()/stride() in Tensor, having wrap_dim
  behavior.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>