### PR TITLE
Fused fp16 lstm backward math fix.

### DIFF
--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -419,18 +419,21 @@ __global__ void
 
     *gi = gcx;
 #else
-    float gcx = THCNumerics<float>::tanh(H2F(cy));
+    float gcx = THCNumerics<T>::tanh(H2F(cy));
+
     float gog = H2F(go) * gcx;
     gcx = H2F(go) * H2F(og) * ( 1 - gcx*gcx) + H2F(goc);
 
-    float gcg = gcx * H2F(fg);
-    float gfg = gcx * H2F(cg);
-    float gig = gcx * H2F(cx);
+    float gig = gcx * H2F(cg);
+    float gfg = gcx * H2F(cx);
+    float gcg = gcx * H2F(ig);
 
-    gog = gog * ( (1-H2F(og))*H2F(og) );
+    gcx = gcx * H2F(fg);
+
+    gig = gig * (1-H2F(ig)) * H2F(ig);
+    gfg = gfg * (1-H2F(fg)) * H2F(fg);
     gcg = gcg * (1-H2F(cg)*H2F(cg));
-    gfg = gfg * ( (1-H2F(fg))*H2F(fg) );
-    gig = gig * ( (1-H2F(ig))*H2F(ig) );
+    gog = gog * (1-H2F(og)) * H2F(og);
 
     *ih = F2H(gig);
     *fh = F2H(gfg);
@@ -439,6 +442,7 @@ __global__ void
 
     *gi = F2H(gcx);
 #endif
+
   }
 }
 

--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -419,7 +419,7 @@ __global__ void
 
     *gi = gcx;
 #else
-    float gcx = THCNumerics<T>::tanh(H2F(cy));
+    float gcx = THCNumerics<float>::tanh(H2F(cy));
 
     float gog = H2F(go) * gcx;
     gcx = H2F(go) * H2F(og) * ( 1 - gcx*gcx) + H2F(goc);


### PR DESCRIPTION
Math was wrong for fp16 fused LSTM cell in backend, this simple PR will fix it and make the math consistent with fp32.