### PR TITLE
[wip] Add batched linear system of equations support to `torch.gesv`

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3193,7 +3193,8 @@
     - THTensor* tensor2
 ]]
 [[
-  name: gesv
+  name: _th_gesv
+  cname: gesv
   types:
     - Float
     - Double

--- a/aten/src/ATen/Utils.cpp
+++ b/aten/src/ATen/Utils.cpp
@@ -17,4 +17,14 @@ void runtime_error(const char *format, ...) {
   throw std::runtime_error(error_buf);
 }
 
+std::vector<int64_t> defaultStrides(IntList sizes) {
+  std::vector<int64_t> strides(sizes.size());
+  int64_t stride = 1;
+  for(size_t i = sizes.size(); i > 0; --i) {
+    strides[i-1] = stride;
+    stride *= sizes[i-1];
+  }
+  return strides;
+}
+
 } // at

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -66,4 +66,6 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
   return res;
 }
 
+std::vector<int64_t> defaultStrides(IntList sizes);
+
 } // at

--- a/aten/src/ATen/native/Gesv.cpp
+++ b/aten/src/ATen/native/Gesv.cpp
@@ -1,0 +1,115 @@
+#include "ATen/ATen.h"
+#include "ATen/Check.h"
+#include "ATen/CPUApplyUtils.h"
+#include "ATen/Dispatch.h"
+#include "ATen/ExpandUtils.h"
+#include "ATen/NativeFunctions.h"
+
+#include "ATen/native/LinearAlgebraUtils.h"
+#include "ATen/native/Gesv.h"
+
+#include "TH.h"  // for USE_LAPACK
+
+#include <vector>
+
+#ifdef USE_LAPACK
+extern "C" void dgesv_(
+    int* n, int* nrhs, double* a, int* lda,
+    int *ipiv, double* b, int* ldb, int* info);
+extern "C" void sgesv_(
+    int* n, int* nrhs, float* a, int* lda,
+    int* ipiv, float* b, int* ldb, int* info);
+#endif
+
+namespace at { namespace native {
+
+template<class real>
+void lapackGesv(
+    int n, int nrhs, real* a, int lda, int* ipiv,
+    real* b, int ldb, int* info) {
+  runtime_error("gesv only takes float or double Tensors");
+}
+
+#ifdef USE_LAPACK
+template<> void lapackGesv<float>(
+    int n, int nrhs, float* a, int lda, int* ipiv,
+    float* b, int ldb, int* info) {
+  sgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, info);
+}
+
+template<> void lapackGesv<double>(
+    int n, int nrhs, double* a, int lda, int* ipiv,
+    double* b, int ldb, int* info) {
+  dgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, info);
+}
+#endif
+
+template <typename real>
+struct SolveOp {
+  static void apply(Tensor& b, Tensor& A, std::vector<int64_t> infos) {
+#ifndef USE_LAPACK
+    runtime_error("gesv: LAPACK library not found in compilation");
+#endif
+    real* A_data = (real*)A.data_ptr();
+    real* b_data = (real*)b.data_ptr();
+    auto A_mat_stride = matrixStride(A);
+    auto b_mat_stride = matrixStride(b);
+
+    auto batch_size = batchCount(A);
+    auto n = A.size(-2);
+    auto nrhs = b.size(-1);
+
+    auto ipiv = b.type().toScalarType(kLong).tensor(n);
+
+    for (int64_t i = 0; i < batch_size; i++) {
+      int info;
+      real* A_working_ptr = &A_data[i * A_mat_stride];
+      real* b_working_ptr = &b_data[i * b_mat_stride];
+      lapackGesv<real>(n, nrhs, A_working_ptr, n, (int*)ipiv.data_ptr(),
+          b_working_ptr, n, &info);
+      infos[i] = info;
+      if (info != 0) {
+        return;
+      }
+    }
+  }
+};
+
+std::tuple<Tensor,Tensor> _gesv_helper_cpu(const Tensor& self, const Tensor& A) {
+  if (self.ndimension() <= 2 && A.ndimension() <= 2) {
+    return at::_th_gesv(self, A);
+  }
+
+  checkInputs(self, A);
+
+  std::vector<int64_t> infos(batchCount(A), 0);
+  auto A_working_copy = cloneBatchedColumnMajor(A);
+  auto b_working_copy = cloneBatchedColumnMajor(self);
+  dispatch_floating_types<void, SolveOp>(b_working_copy.type(),
+        "_gesv_helper_cpu", b_working_copy, A_working_copy, infos);
+
+  checkErrors(infos);
+  return std::tuple<Tensor,Tensor>(b_working_copy, A_working_copy);
+}
+
+std::tuple<Tensor,Tensor> gesv(const Tensor& self, const Tensor& A) {
+  // broadcast the batch dimensions of self and A.
+  IntList batch_tensor_self(self.sizes().data(), self.ndimension() - 2);
+  IntList batch_tensor_A(A.sizes().data(), A.ndimension() - 2);
+  std::vector<int64_t> expand_batch_portion =
+      infer_size(batch_tensor_self, batch_tensor_A);
+
+  std::vector<int64_t> self_expand_size({expand_batch_portion});
+  self_expand_size.insert(self_expand_size.end(),
+      { self.size(-2), self.size(-1) });
+
+  std::vector<int64_t> A_expand_size({expand_batch_portion});
+  A_expand_size.insert(A_expand_size.end(),
+      { A.size(-2), A.size(-1) });
+
+  Tensor self_expanded = self.expand(self_expand_size);
+  Tensor A_expanded = A.expand(A_expand_size);
+  return self.type()._gesv_helper(self_expanded, A_expanded);
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/Gesv.h
+++ b/aten/src/ATen/native/Gesv.h
@@ -1,0 +1,45 @@
+#include "ATen/ATen.h"
+
+namespace at { namespace native {
+
+static inline void checkInputs(const Tensor& self, const Tensor& A) {
+  if (A.size(-1) != A.size(-2)) {
+    runtime_error("A must be batches of square matrices, "
+        "but they are %llu by %llu matrices",
+        (long long)A.size(-1), (long long)A.size(-2));
+  }
+  if (A.size(-1) != self.size(-2)) {
+    runtime_error("Incompatible matrix sizes for matmul: each A "
+        "matrix is %llu by %llu but each b matrix is %llu by %llu.",
+        (long long)A.size(-1), (long long)A.size(-1),
+        (long long)self.size(-2), (long long)self.size(-1));
+  }
+  if (A.ndimension() != self.ndimension()) {
+    runtime_error("arguments have differing number "
+        "of dimensions: got %llu and %llu",
+        (long long)A.ndimension(), (long long)self.ndimension());
+  }
+  for (int64_t i = 0; i < A.ndimension() - 1; i++) {
+    if (A.size(i) == self.size(i)) {
+      continue;
+    }
+    runtime_error("Incompatible batch size at dimension %llu: "
+        "got size %llu for A and %llu for b",
+        i, (long long)A.size(i), self.size(i));
+  }
+}
+
+static inline void checkErrors(std::vector<int64_t> infos) {
+  for (size_t i = 0; i < infos.size(); i++) {
+    auto info = infos[i];
+    if (info < 0) {
+      runtime_error("gesv: For batch %llu: Argument %llu has illegal value",
+          (long long)i, -info);
+    } else if (info > 0) {
+      runtime_error("gesv: For batch %llu: U(%llu,%llu) is zero, singular U.",
+          (long long)i, info, info);
+    }
+  }
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/LinearAlgebraUtils.cpp
+++ b/aten/src/ATen/native/LinearAlgebraUtils.cpp
@@ -1,0 +1,18 @@
+#include "ATen/native/LinearAlgebraUtils.h"
+
+namespace at { namespace native {
+
+Tensor cloneBatchedColumnMajor(const Tensor& src) {
+  auto second_to_last_dim = src.ndimension() - 2;
+  auto last_dim = src.ndimension() - 1;
+
+  auto desired_strides = defaultStrides(src.sizes());
+  desired_strides[last_dim] = src.size(second_to_last_dim);
+  desired_strides[second_to_last_dim] = 1;
+
+  auto result = src.type().tensor(src.sizes(), desired_strides);
+  result.copy_(src);
+  return result;
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -1,0 +1,34 @@
+#include "ATen/ATen.h"
+
+namespace at { namespace native {
+
+/*
+ * Clones a Tensor so that the following conditions hold:
+ * If we think of a Tensor of having size (B, M, N), where B is any number
+ * of batch dimensions, then:
+ * - Each (M, N) matrix is in column major form
+ * - Let Tensor P have size (B, M, N) and Q have size (B, M', N').
+ *   Then when laid out in memory, the M by N matrix starting at
+ *   P.data_ptr()[b * M * N] is of the same corresponding batch as the M' by N'
+ *   matrix starting at Q.data_ptr()[b * M' * N'].
+ */
+Tensor cloneBatchedColumnMajor(const Tensor& src);
+
+/*
+ * Given batches of matrices with arbitrary batch dim,
+ * computes the number of batches.
+ */
+static inline int64_t batchCount(const Tensor& batched_matrices) {
+  int64_t result = 1;
+  for (int64_t i = 0; i < batched_matrices.ndimension() - 2; i++) {
+    result *= batched_matrices.size(i);
+  }
+  return result;
+}
+
+// Computes the number of elements of a matrix in a batched matrix tensor
+static inline int64_t matrixStride(const Tensor& batched_matrices) {
+  return batched_matrices.size(-1) * batched_matrices.size(-2);
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Gesv.cu
+++ b/aten/src/ATen/native/cuda/Gesv.cu
@@ -1,0 +1,141 @@
+#include "ATen/Context.h"
+#include "ATen/Dispatch.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/PinnedMemoryAllocator.h"
+#include "ATen/cuda/CUDAApplyUtils.cuh"
+
+#include "ATen/native/LinearAlgebraUtils.h"
+#include "ATen/native/Gesv.h"
+
+#include "THC.h" // for USE_MAGMA
+
+#ifdef USE_MAGMA
+#include <magma.h>
+#include <magma_types.h>
+#endif
+
+namespace at {
+namespace native {
+
+#ifdef USE_MAGMA
+template<class real>
+void magmaGesvBatched(
+    magma_int_t n, magma_int_t nrhs, real** dA_array, magma_int_t ldda,
+    magma_int_t** dipiv_array, real** dB_array, magma_int_t lddb,
+    magma_int_t* dinfo_array, magma_int_t batch_count, magma_queue_t queue) {
+  runtime_error("gesv only takes float or double Tensors");
+}
+
+template<>
+void magmaGesvBatched<float>(
+    magma_int_t n, magma_int_t nrhs, float** dA_array, magma_int_t ldda,
+    magma_int_t** dipiv_array, float** dB_array, magma_int_t lddb,
+    magma_int_t* dinfo_array, magma_int_t batch_count, magma_queue_t queue) {
+  magma_sgesv_batched(
+      n, nrhs, dA_array, ldda, dipiv_array,
+      dB_array, lddb, dinfo_array, batch_count, queue);
+}
+
+template<>
+void magmaGesvBatched<double>(
+    magma_int_t n, magma_int_t nrhs, double** dA_array, magma_int_t ldda,
+    magma_int_t** dipiv_array, double** dB_array, magma_int_t lddb,
+    magma_int_t* dinfo_array, magma_int_t batch_count, magma_queue_t queue) {
+  magma_dgesv_batched(
+      n, nrhs, dA_array, ldda, dipiv_array,
+      dB_array, lddb, dinfo_array, batch_count, queue);
+}
+#endif
+
+// Creates an array of size elements of type T, backed by pinned memory
+// wrapped in a Storage
+template<class T>
+static inline std::unique_ptr<Storage> pin_memory(int64_t size, Tensor dummy) {
+  int64_t adjusted_size = size * sizeof(T);
+  auto allocator = std::unique_ptr<Allocator>(new PinnedMemoryAllocator());
+  auto& backend = dummy.type().toBackend(kCPU).toScalarType(kByte);
+  return backend.storageWithAllocator(adjusted_size, std::move(allocator));
+}
+
+#define ALLOCATE_ARRAY(name, type, size, dummy_tensor) \
+  auto storage_##name = pin_memory<type>(size, dummy_tensor); \
+  name = reinterpret_cast<type*>(storage_##name->data());
+
+static inline magma_queue_t create_magma_queue_for(const Tensor& tensor) {
+  auto& context = tensor.type().get_context();
+  magma_queue_t magma_queue;
+  magma_queue_create_from_cuda(
+      tensor.get_device(),
+      context.getCurrentCUDAStream(),
+      THCState_getCurrentBlasHandle(context.thc_state),
+      THCState_getCurrentSparseHandle(context.thc_state),
+      &magma_queue);
+  return magma_queue;
+}
+
+template <typename real>
+struct SolveOpCUDA {
+  static void apply(Tensor& b, Tensor& A, std::vector<int64_t> infos) {
+#ifndef USE_MAGMA
+  runtime_error("gesv: MAGMA library not found in "
+      "compilation. Please rebuild with MAGMA.");
+#else
+    real* A_data = static_cast<real*>(A.data_ptr());
+    real* b_data = static_cast<real*>(b.data_ptr());
+    auto A_mat_stride = matrixStride(A);
+    auto b_mat_stride = matrixStride(b);
+
+    magma_int_t batch_size = batchCount(A);
+    magma_int_t n = A.size(-2);
+    magma_int_t nrhs = b.size(-1);
+
+    magma_int_t* info_array;
+    magma_int_t* ipiv_data;
+    magma_int_t** ipiv_array;
+    real** A_array;
+    real** b_array;
+
+    ALLOCATE_ARRAY(info_array, magma_int_t, batch_size, b);
+    ALLOCATE_ARRAY(ipiv_data, magma_int_t, batch_size * n, b);
+    ALLOCATE_ARRAY(ipiv_array, magma_int_t*, batch_size, b);
+    ALLOCATE_ARRAY(A_array, real*, batch_size, b);
+    ALLOCATE_ARRAY(b_array, real*, batch_size, b);
+
+    // Set up the created arrays
+    for (int64_t i = 0; i < batch_size; i++) {
+      A_array[i] = &A_data[i * A_mat_stride];
+      b_array[i] = &b_data[i * b_mat_stride];
+      ipiv_array[i] = &ipiv_data[i * n];
+    }
+
+    magmaGesvBatched<real>(
+        n, nrhs, A_array, n, ipiv_array, b_array, n,
+        info_array, batch_size, create_magma_queue_for(b));
+
+    for (int64_t i = 0; i < batch_size; i++) {
+      infos[i] = info_array[i];
+    }
+#endif
+  }
+};
+
+std::tuple<Tensor,Tensor> _gesv_helper_cuda(const Tensor& self, const Tensor& A) {
+  if (self.ndimension() <= 2 && A.ndimension() <= 2) {
+    return at::_th_gesv(self, A);
+  }
+
+  checkInputs(self, A);
+
+  std::vector<int64_t> infos(batchCount(A), 0);
+  auto A_working_copy = cloneBatchedColumnMajor(A);
+  auto b_working_copy = cloneBatchedColumnMajor(self);
+  dispatch_floating_types<void, SolveOpCUDA>(b_working_copy.type(),
+        "_gesv_helper_cuda", b_working_copy, A_working_copy, infos);
+
+  checkErrors(infos);
+  return std::tuple<Tensor,Tensor>(b_working_copy, A_working_copy);
+}
+
+}}  // namespace at::native
+
+#undef ALLOCATE_ARRAY

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -368,6 +368,10 @@
 - func: matmul(Tensor self, Tensor other) -> Tensor
 
 - func: gesv(Tensor self, Tensor A) -> (Tensor, Tensor)
+
+- func: gesv_out(Tensor solution, Tensor lu, Tensor self, Tensor A) -> (Tensor, Tensor)
+  variants: function
+
 - func: _gesv_helper(Tensor self, Tensor A) -> (Tensor, Tensor) 
   dispatch:
     CPU: _gesv_helper_cpu

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -367,6 +367,12 @@
 
 - func: matmul(Tensor self, Tensor other) -> Tensor
 
+- func: gesv(Tensor self, Tensor A) -> (Tensor, Tensor)
+- func: _gesv_helper(Tensor self, Tensor A) -> (Tensor, Tensor) 
+  dispatch:
+    CPU: _gesv_helper_cpu
+    CUDA: _gesv_helper_cuda
+
 - func: max_pool1d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> (Tensor, Tensor)
   variants: function
 

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -46,15 +46,6 @@ Type & Type::toBackend(Backend b) const {
 Type & Type::toScalarType(ScalarType s) const {
   return context->getType(backend(),s);
 }
-static std::vector<int64_t> defaultStrides(IntList sizes) {
-  std::vector<int64_t> strides(sizes.size());
-  int64_t stride = 1;
-  for(size_t i = sizes.size(); i > 0; --i) {
-    strides[i-1] = stride;
-    stride *= sizes[i-1];
-  }
-  return strides;
-}
 static int64_t computeStorageSize(IntList sizes, IntList strides) {
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2666,6 +2666,10 @@ method_tests = [
     ('fill_', (), (1,), 'number_scalar'),
     # FIXME: we should compute the derivative w.r.t torch.tensor(1)
     ('fill_', (S, S, S), (non_differentiable(torch.tensor(1)),), 'variable'),
+    ('gesv', (S, S, S), ((S, S, S),), 'batched', NO_ARGS, [skipIfNoLapack]),
+    ('gesv', (2, 3, S, S), ((2, 3, S, S),), 'batched_dims', NO_ARGS, [skipIfNoLapack]),
+    ('gesv', (2, 2, S, S), ((1, S, S),), 'batched_broadcast_A', NO_ARGS, [skipIfNoLapack]),
+    ('gesv', (1, S, S), ((2, 2, S, S),), 'batched_broadcast_b', NO_ARGS, [skipIfNoLapack]),
     ('eq_', (S, S, S), ((S, S, S),)),
     ('eq_', (S, S, S), ((1,),), 'broadcast_rhs'),
     ('eq_', (), ((),), 'scalar'),
@@ -2910,6 +2914,7 @@ def exclude_tensor_method(name, test_name):
         'scatter',
         'scatter_add',
         'det',
+        'gesv'
     }
     if test_name in exclude_all_tensor_method_by_test_name:
         return True

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2662,14 +2662,14 @@ method_tests = [
     ('svd', lambda: random_fullrank_matrix_distinct_singular_value(S), NO_ARGS, '', NO_ARGS, [skipIfNoLapack]),
     ('svd', lambda: random_fullrank_matrix_distinct_singular_value(M), NO_ARGS, 'large', NO_ARGS, [skipIfNoLapack]),
     ('gesv', (S, S), ((S, S),), '', NO_ARGS, [skipIfNoLapack]),
-    ('fill_', (S, S, S), (1,), 'number'),
-    ('fill_', (), (1,), 'number_scalar'),
-    # FIXME: we should compute the derivative w.r.t torch.tensor(1)
-    ('fill_', (S, S, S), (non_differentiable(torch.tensor(1)),), 'variable'),
     ('gesv', (S, S, S), ((S, S, S),), 'batched', NO_ARGS, [skipIfNoLapack]),
     ('gesv', (2, 3, S, S), ((2, 3, S, S),), 'batched_dims', NO_ARGS, [skipIfNoLapack]),
     ('gesv', (2, 2, S, S), ((1, S, S),), 'batched_broadcast_A', NO_ARGS, [skipIfNoLapack]),
     ('gesv', (1, S, S), ((2, 2, S, S),), 'batched_broadcast_b', NO_ARGS, [skipIfNoLapack]),
+    ('fill_', (S, S, S), (1,), 'number'),
+    ('fill_', (), (1,), 'number_scalar'),
+    # FIXME: we should compute the derivative w.r.t torch.tensor(1)
+    ('fill_', (S, S, S), (non_differentiable(torch.tensor(1)),), 'variable'),
     ('eq_', (S, S, S), ((S, S, S),)),
     ('eq_', (S, S, S), ((1,),), 'broadcast_rhs'),
     ('eq_', (), ((),), 'scalar'),
@@ -2914,7 +2914,6 @@ def exclude_tensor_method(name, test_name):
         'scatter',
         'scatter_add',
         'det',
-        'gesv'
     }
     if test_name in exclude_all_tensor_method_by_test_name:
         return True

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1319,6 +1319,14 @@ class TestCuda(TestCase):
     def test_det_logdet_slogdet(self):
         TestTorch._test_det_logdet_slogdet(self, lambda t: t.cuda())
 
+    @unittest.skipIf(not HAS_MAGMA, "no MAGMA library detected")
+    def test_gesv_batched(self):
+        TestTorch._test_gesv_batched(self, lambda t: t.cuda())
+
+    @unittest.skipIf(not HAS_MAGMA, "no MAGMA library detected")
+    def test_gesv_batched_dims(self):
+        TestTorch._test_gesv_batched_dims(self, lambda t: t.cuda())
+
     def test_view(self):
         TestTorch._test_view(self, lambda t: t.cuda())
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -287,9 +287,9 @@
   self: grad.mv(vec2)
   vec2: grad.t().mv(self)
 
-- name: gesv(Tensor self, Tensor A)
-  self: std::get<0>(gesv(grad, A.t()))
-  A: -at::mm(std::get<0>(gesv(grad, A.t())), solution.t())
+- name: _gesv_helper(Tensor self, Tensor A)
+  self: gesv_backward_self(grad, self, A)
+  A: gesv_backward_A(grad, self, A, result0)
 
 - name: gt_(Tensor self, Scalar other)
   self: zeros_like(self)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -18,6 +18,7 @@ SKIP_PYTHON_BINDINGS = [
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
     'sparse_raw_resize_', '_unsafe_view', 'tensor', 'sparse_coo_tensor',
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*', '_indexCopy_',
+    '_th_gesv.*',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -332,6 +332,24 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
   return grad_input;
 }
 
+static inline Tensor transpose_last_two_dims(const Tensor & tensor) {
+  auto ndimension = tensor.ndimension();
+  TORCH_ASSERT(ndimension >= 2);
+  return tensor.transpose(ndimension - 2, ndimension - 1);
+}
+
+Tensor gesv_backward_self(const Tensor & grad, const Tensor & self, const Tensor & A) {
+  return std::get<0>(at::gesv(grad, transpose_last_two_dims(A)));
+}
+
+Tensor gesv_backward_A(const Tensor & grad, const Tensor & self, const Tensor & A, const Tensor & solution) {
+  Tensor grad_self = gesv_backward_self(grad, self, A);
+  if (self.ndimension() == 2 && A.ndimension() == 2) {
+    return -at::mm(grad_self, transpose_last_two_dims(solution));
+  }
+  return -at::matmul(grad_self, transpose_last_two_dims(solution));
+}
+
 Tensor cumsum_backward(const Tensor & x, int64_t dim) {
   if (x.dim() == 0) {
     return x;

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -587,6 +587,7 @@ PyMethodDef variable_methods[] = {
   {"__invert__", (PyCFunction)THPVariable_invert, METH_NOARGS, NULL},
   {"__nonzero__", (PyCFunction)THPVariable_is_nonzero, METH_NOARGS, NULL},
   {"__matmul__", (PyCFunction)THPVariable_matmul, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"gesv", (PyCFunction)THPVariable_gesv, METH_VARARGS | METH_KEYWORDS, NULL},
   {"apply_", (PyCFunction)THPVariable_apply_, METH_O, NULL},
   {"byte", (PyCFunction)THPVariable_byte, METH_NOARGS, NULL},
   {"char", (PyCFunction)THPVariable_char, METH_NOARGS, NULL},

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1962,7 +1962,7 @@ Example::
 
 add_docstr(torch.gesv,
            r"""
-gesv(B, A, out=None) -> (Tensor, Tensor)
+torch.gesv(B, A) -> (Variable, Variable)
 
 This function returns the solution to the system of linear
 equations represented by :math:`AX = B` and the LU factorization of
@@ -1970,21 +1970,27 @@ A, in order as a tuple `X, LU`.
 
 `LU` contains `L` and `U` factors for LU factorization of `A`.
 
-:attr:`A` has to be a square and non-singular matrix (2-D tensor).
+`torch.gesv(B, A)` can take in 2D inputs `B, A` or inputs that are
+batches of 2D matrices. If the inputs are batches, then returns
+batched outputs `X, LU`.
 
-If `A` is an :math:`(m \times m)` matrix and `B` is :math:`(m \times k)`,
-the result `LU` is :math:`(m \times m)` and `X` is :math:`(m \times k)`.
+.. note::
+
+    Calling `torch.gesv` on `Tensor` only supports 2D matrix inputs.
+    `torch.gesv` for `Variable`s supports both 2D and batched inputs.
 
 .. note::
 
     Irrespective of the original strides, the returned matrices
-    `X` and `LU` will be transposed, i.e. with strides `(1, m)`
-    instead of `(m, 1)`.
+    `X` and `LU` will be transposed, i.e. with strides
+    `B.contiguous().transpose(-1, -2).strides()` and
+    `A.contiguous().transpose(-1, -2).strides()` respectively.
 
 Args:
-    B (Tensor): input matrix of :math:`(m \times k)` dimensions
-    A (Tensor): input square matrix of :math:`(m \times m)` dimensions
-    out (Tensor, optional): optional output matrix
+    B (Variable): input matrix of size :math:`(..., m, k)` , where `...`
+    is any number of batch dimensions.
+    A (Variable): input square matrix of size :math:`(..., m \times m)`, where
+    `...` is any number of batch dimensions.
 
 Example::
 
@@ -2003,6 +2009,11 @@ Example::
       7.0977
     [torch.FloatTensor of size ()]
 
+    >>> # Batched solver example
+    >>> A = Variable(torch.randn(2, 3, 1, 4, 4))
+    >>> B = Variable(torch.randn(2, 3, 1, 4, 6))
+    >>> X, LU = torch.gesv(B, A)
+    >>> torch.dist(B, A.matmul(X))  # should be small
 """)
 
 add_docstr(torch.get_num_threads,


### PR DESCRIPTION
Fixes #3164

Picks up from https://github.com/pytorch/pytorch/pull/4502. I rewrote the code in ATen, which led to nice support for the following features:
- can take in non-batched matrices as well as batched matrices
- arbitrary batched dims
- broadcasting of arbitrary batch dims

A side note:
- `torch.gesv()` on tensors is different from `torch.gesv` on Variable. On tensor, the behavior falls back to `THTensor_(gesv)` because ATen doesn't support dispatching to tensors yet. When tensors/variables merge this should be fixed.

### Test Plan
New unit tests to test arbitrary batched dimensions and broadcasting.