### PR TITLE
Fix wrong learning rate evaluation in CosineAnnealingLR in Python 2

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -503,7 +503,7 @@ class TestLRScheduler(TestCase):
         epochs = 10
         eta_min = 1e-10
         single_targets = [eta_min + (0.05 - eta_min) *
-                          (1 + math.cos(x / epochs * math.pi)) / 2
+                          (1 + math.cos(math.pi * x / epochs)) / 2
                           for x in range(epochs)]
         targets = [single_targets, list(map(lambda x: x * epochs, single_targets))]
         scheduler = CosineAnnealingLR(self.opt, T_max=epochs, eta_min=eta_min)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -194,7 +194,7 @@ class CosineAnnealingLR(_LRScheduler):
 
     def get_lr(self):
         return [self.eta_min + (base_lr - self.eta_min) *
-                (1 + math.cos(self.last_epoch / self.T_max * math.pi)) / 2
+                (1 + math.cos(math.pi * self.last_epoch / self.T_max)) / 2
                 for base_lr in self.base_lrs]
 
 


### PR DESCRIPTION
Fix #4648 
In Python 2, the division operation in `self.last_epoch / self.T_max` is integer division, resulting in incorrect result. Switch the order of evaluation so that the division is true division.

