### PR TITLE
Ensure lazy evaluation for probs and logits

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -36,7 +36,7 @@ from torch.distributions import (Bernoulli, Beta, Categorical, Cauchy, Chi2,
                                  StudentT, Uniform, kl_divergence)
 from torch.distributions.dirichlet import _Dirichlet_backward
 from torch.distributions.constraints import Constraint, is_dependent
-from torch.distributions.utils import _finfo
+from torch.distributions.utils import _finfo, probs_to_logits
 
 TEST_NUMPY = True
 try:
@@ -1582,6 +1582,48 @@ class TestNumericalStability(TestCase):
             self.assertEqual(log_pdf_prob_1.data[0], 0)
             log_pdf_prob_0 = multinomial.log_prob(Variable(tensor_type([10, 0])))
             self.assertEqual(log_pdf_prob_0.data[0], -float('inf'), allow_inf=True)
+
+
+class TestLazyLogitsInitialization(TestCase):
+    def setUp(self):
+        self.examples = [e for e in EXAMPLES if e.Dist in
+                         (Categorical, OneHotCategorical, Bernoulli, Multinomial)]
+
+    def test_lazy_logits_initialization(self):
+        for Dist, params in self.examples:
+            param = params[0]
+            if 'probs' in param:
+                probs = param.pop('probs')
+                param['logits'] = probs_to_logits(probs)
+                dist = Dist(**param)
+                shape = (1,) if not dist.event_shape else dist.event_shape
+                dist.log_prob(Variable(torch.ones(shape)))
+                message = 'Failed for {} example 0/{}'.format(Dist.__name__, len(params))
+                self.assertFalse('probs' in vars(dist), msg=message)
+                try:
+                    dist.enumerate_support()
+                except NotImplementedError:
+                    pass
+                self.assertFalse('probs' in vars(dist), msg=message)
+                batch_shape, event_shape = dist.batch_shape, dist.event_shape
+                self.assertFalse('probs' in vars(dist), msg=message)
+
+    def test_lazy_probs_initialization(self):
+        for Dist, params in self.examples:
+            param = params[0]
+            if 'probs' in param:
+                dist = Dist(**param)
+                dist.sample()
+                message = 'Failed for {} example 0/{}'.format(Dist.__name__, len(params))
+                self.assertFalse('logits' in vars(dist), msg=message)
+                try:
+                    dist.enumerate_support()
+                except NotImplementedError:
+                    pass
+                self.assertFalse('logits' in vars(dist), msg=message)
+                batch_shape, event_shape = dist.batch_shape, dist.event_shape
+                print vars(dist)
+                self.assertFalse('logits' in vars(dist), msg=message)
 
 
 if __name__ == '__main__':

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -33,14 +33,16 @@ class Bernoulli(Distribution):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
         if probs is not None:
+            is_scalar = isinstance(probs, Number)
             self.probs, = broadcast_all(probs)
         else:
+            is_scalar = isinstance(logits, Number)
             self.logits, = broadcast_all(logits)
-        probs_or_logits = probs if probs is not None else logits
-        if isinstance(probs_or_logits, Number):
+        self.probs_or_logits = self.probs if probs is not None else self.logits
+        if is_scalar:
             batch_shape = torch.Size()
         else:
-            batch_shape = probs_or_logits.size()
+            batch_shape = self.probs_or_logits.size()
         super(Bernoulli, self).__init__(batch_shape)
 
     @lazy_property
@@ -67,8 +69,8 @@ class Bernoulli(Distribution):
         values = torch.arange(2)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
-        if self.probs.is_cuda:
-            values = values.cuda(self.probs.get_device())
-        if isinstance(self.probs, Variable):
+        if self.probs_or_logits.is_cuda:
+            values = values.cuda(self.probs_or_logits.get_device())
+        if isinstance(self.probs_or_logits, Variable):
             values = Variable(values)
         return values

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -32,8 +32,8 @@ class OneHotCategorical(Distribution):
 
     def __init__(self, probs=None, logits=None):
         self._categorical = Categorical(probs, logits)
-        batch_shape = self._categorical.probs.size()[:-1]
-        event_shape = self._categorical.probs.size()[-1:]
+        batch_shape = self._categorical.batch_shape
+        event_shape = self._categorical.probs_or_logits.size()[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape)
 
     def sample(self, sample_shape=torch.Size()):
@@ -53,11 +53,11 @@ class OneHotCategorical(Distribution):
         return self._categorical.entropy()
 
     def enumerate_support(self):
-        probs = self._categorical.probs
+        probs_or_logits = self._categorical.probs_or_logits
         n = self.event_shape[0]
-        if isinstance(probs, Variable):
-            values = Variable(torch.eye(n, out=probs.data.new(n, n)))
+        if isinstance(probs_or_logits, Variable):
+            values = Variable(torch.eye(n, out=probs_or_logits.data.new(n, n)))
         else:
-            values = torch.eye(n, out=probs.new(n, n))
+            values = torch.eye(n, out=probs_or_logits.new(n, n))
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
         return values.expand((n,) + self.batch_shape + (n,))


### PR DESCRIPTION
This makes a few modifications to ensure that `logits` and `probs` are not accessed by a method unless it needs to. e.g. accessing `probs` on a class that was initialized with `logits` only to get the batch shape or event shape. This affects Categorical, OneHotCategorical, Bernoulli and Multinomial.

**Testing:** Added some tests to prevent future regression:
 - `initializing` a distribution with `probs` and calling `sample`, `enumerate_support`, `batch_shape` and `event_shape` should not initialize `logits`.
 - Conversely, `initializing` a distribution with `logits` and calling `log_prob`, `enumerate_support`, `batch_shape` and `event_shape` should not initialize `probs`.