### PR TITLE
Local Response Normalization

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4893,15 +4893,22 @@ new_module_tests = [
         input_size=(1, 3, 7),
     ),
     dict(
-        module_name='LocalResponseNorm2d',
+        module_name='LocalResponseNorm',
         constructor_args=(3, ),
-        input_size=(1, 5, 7, 7)
+        input_size=(1, 5, 7),
+        desc='1d'
     ),
     dict(
-        module_name='LocalResponseNorm2d',
-        constructor_args=(1, 1, 0.5, 2),
+        module_name='LocalResponseNorm',
+        constructor_args=(2, ),
         input_size=(1, 5, 7, 7),
-        desc='custom_params'
+        desc='2d_uneven_pad'
+    ),
+    dict(
+        module_name='LocalResponseNorm',
+        constructor_args=(1, 1, 0.5, 2),
+        input_size=(1, 5, 7, 7, 7),
+        desc='3d_custom_params'
     ),
     dict(
         module_name='ReflectionPad1d',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4893,6 +4893,17 @@ new_module_tests = [
         input_size=(1, 3, 7),
     ),
     dict(
+        module_name='LocalResponseNorm2d',
+        constructor_args=(3, ),
+        input_size=(1, 5, 7, 7)
+    ),
+    dict(
+        module_name='LocalResponseNorm2d',
+        constructor_args=(1, 1, 0.5, 2),
+        input_size=(1, 5, 7, 7),
+        desc='custom_params'
+    ),
+    dict(
         module_name='ReflectionPad1d',
         constructor_args=((1, 2),),
         input_size=(2, 3, 8),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1153,7 +1153,15 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
     )
 
 
+def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):
+    div = avg_pool3d(input.pow(2).unsqueeze(1), (size, 1, 1),
+                     stride=1, padding=(size // 2, 0, 0)).squeeze(1)
+    div.mul_(alpha).add_(k).pow_(beta)
+    return input / div
+
+
 # loss
+
 
 def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, reduce=True):
     r"""The negative log likelihood loss.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1155,7 +1155,8 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
 
 def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):
     """Applies local response normalization over an input signal composed of
-    several input planes.
+    several input planes, where channels occupy the second dimension.
+    Applies normalization across channels.
 
     See :class:`~torch.nn.LocalResponseNorm` for details.
     """
@@ -1173,7 +1174,7 @@ def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):
         div = pad(div, (0, 0, 0, 0, size // 2, (size - 1) // 2))
         div = avg_pool3d(div, (size, 1, 1), stride=1).squeeze(1)
         div = div.view(sizes)
-    div = div.mul(input.size(1)).mul(alpha).add(k).pow(beta)
+    div = div.mul(alpha).add(k).pow(beta)
     return input / div
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1160,22 +1160,19 @@ def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):
     See :class:`~torch.nn.LocalResponseNorm` for details.
     """
     dim = input.dim()
-    if dim < 3 or dim > 5:
-        raise ValueError('Expected {3,4,5}D input (got {} dimensions)'
-                         .format(dim))
+    if dim < 3:
+        raise ValueError('Expected 3D or higher dimensionality \
+                         input (got {} dimensions)'.format(dim))
     div = input.mul(input).unsqueeze(1)
     if dim == 3:
         div = pad(div, (0, 0, size // 2, (size - 1) // 2))
         div = avg_pool2d(div, (size, 1), stride=1).squeeze(1)
-    elif dim == 4:
-        div = pad(div, (0, 0, 0, 0, size // 2, (size - 1) // 2))
-        div = avg_pool3d(div, (size, 1, 1), stride=1).squeeze(1)
-    elif dim == 5:
+    else:
         sizes = input.size()
-        div = div.view(sizes[0], 1, sizes[1], sizes[2], sizes[3] * sizes[4])
+        div = div.view(sizes[0], 1, sizes[1], sizes[2], -1)
         div = pad(div, (0, 0, 0, 0, size // 2, (size - 1) // 2))
         div = avg_pool3d(div, (size, 1, 1), stride=1).squeeze(1)
-        div = div.view(sizes[0], sizes[1], sizes[2], sizes[3], sizes[4])
+        div = div.view(sizes)
     div = div.mul(input.size(1)).mul(alpha).add(k).pow(beta)
     return input / div
 

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -18,7 +18,7 @@ from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
 from .padding import ReflectionPad1d, ReflectionPad2d, ReplicationPad1d, ReplicationPad2d, \
     ReplicationPad3d, ZeroPad2d, ConstantPad1d, ConstantPad2d, ConstantPad3d
-from .normalization import CrossMapLRN2d
+from .normalization import LocalResponseNorm2d, CrossMapLRN2d
 from .sparse import Embedding, EmbeddingBag
 from .rnn import RNNBase, RNN, LSTM, GRU, \
     RNNCell, LSTMCell, GRUCell
@@ -38,8 +38,8 @@ __all__ = [
     'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList',
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
-    'LPPool1d', 'LPPool2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d', 'InstanceNorm2d',
-    'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'ReflectionPad1d',
+    'LPPool1d', 'LPPool2d', 'LocalResponseNorm2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
+    'InstanceNorm2d', 'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'ReflectionPad1d',
     'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -18,7 +18,7 @@ from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
 from .padding import ReflectionPad1d, ReflectionPad2d, ReplicationPad1d, ReplicationPad2d, \
     ReplicationPad3d, ZeroPad2d, ConstantPad1d, ConstantPad2d, ConstantPad3d
-from .normalization import LocalResponseNorm2d, CrossMapLRN2d
+from .normalization import LocalResponseNorm, CrossMapLRN2d
 from .sparse import Embedding, EmbeddingBag
 from .rnn import RNNBase, RNN, LSTM, GRU, \
     RNNCell, LSTMCell, GRUCell
@@ -38,7 +38,7 @@ __all__ = [
     'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList',
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
-    'LPPool1d', 'LPPool2d', 'LocalResponseNorm2d', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
+    'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
     'InstanceNorm2d', 'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'ReflectionPad1d',
     'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d', 'CrossMapLRN2d',
     'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -4,19 +4,20 @@ from .. import functional as F
 
 class LocalResponseNorm(Module):
     def __init__(self, size, alpha=1e-4, beta=0.75, k=1):
-        r"""Applies local response normalization to a 3D or higher dimensional
-        signal, where channels occupy the second dimension:
+        r"""Applies local response normalization over an input signal composed
+        of several input planes, where channels occupy the second dimension.
+        Applies normalization across channels.
 
         .. math::
 
-            `b_{c} = a_{c}\left(k + \alpha\sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}
-            a_{c'}^2\right)^{-\beta}`
+            `b_{c} = a_{c}\left(k + \frac{\alpha}{n}
+            \sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}a_{c'}^2\right)^{-\beta}`
 
         Args:
             size: amount of neighbouring channels used for normalization
-            alpha: multiplicative factor
-            beta: exponenent
-            k: additive factor
+            alpha: multiplicative factor. Default: 0.0001
+            beta: exponent. Default: 0.75
+            k: additive factor. Default: 1
 
         Shape:
             - Input: :math:`(N, C, ...)`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -4,7 +4,8 @@ from .. import functional as F
 
 class LocalResponseNorm(Module):
     def __init__(self, size, alpha=1e-4, beta=0.75, k=1):
-        r"""Applies local response normalization:
+        r"""Applies local response normalization to a 3D or higher dimensional
+        signal, where channels occupy the second dimension:
 
         .. math::
 
@@ -18,14 +19,14 @@ class LocalResponseNorm(Module):
             k: additive factor
 
         Shape:
-            - Input: :math:`(N, C, L)` or :math:`(N, C, H, W)`
-              or :math:`(N, C, D, H, W)`
-            - Output: :math:`(N, C, L)` or :math:`(N, C, H, W)`
-              or :math:`(N, C, D, H, W)` (same shape as input)
+            - Input: :math:`(N, C, ...)`
+            - Output: :math:`(N, C, ...)` (same shape as input)
         Examples::
             >>> lrn = nn.LocalResponseNorm(2)
-            >>> input = autograd.Variable(torch.randn(32, 5, 24, 24))
-            >>> output = lrn(input)
+            >>> 2d_signal = autograd.Variable(torch.randn(32, 5, 24, 24))
+            >>> 4d_signal = autograd.Variable(torch.randn(16, 5, 7, 7, 7, 7))
+            >>> 2d_output = lrn(2d_signal)
+            >>> 4d_output = lrn(4d_signal)
         """
         super(LocalResponseNorm, self).__init__()
         self.size = size

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -2,30 +2,32 @@ from .module import Module
 from .. import functional as F
 
 
-class LocalResponseNorm2d(Module):
+class LocalResponseNorm(Module):
     def __init__(self, size, alpha=1e-4, beta=0.75, k=1):
         r"""Applies local response normalization:
 
         .. math::
 
-            `b_{c,i,j} = a_{c,i,j}\left(k + \alpha\sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}
-            a_{c',i,j}^2\right)^{-\beta}`
+            `b_{c} = a_{c}\left(k + \alpha\sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}
+            a_{c'}^2\right)^{-\beta}`
 
         Args:
             size: amount of neighbouring channels used for normalization
             alpha: multiplicative factor
-            beta: root factor
+            beta: exponenent
             k: additive factor
 
         Shape:
-            - Input: :math:`(N, C, H, W)`
-            - Output: :math:`(N, C, H, W)`
+            - Input: :math:`(N, C, L)` or :math:`(N, C, H, W)`
+              or :math:`(N, C, D, H, W)`
+            - Output: :math:`(N, C, L)` or :math:`(N, C, H, W)`
+              or :math:`(N, C, D, H, W)` (same shape as input)
         Examples::
-            >>> lrn = nn.LocalResponseNorm2d(3)
+            >>> lrn = nn.LocalResponseNorm(2)
             >>> input = autograd.Variable(torch.randn(32, 5, 24, 24))
             >>> output = lrn(input)
         """
-        super(LocalResponseNorm2d, self).__init__()
+        super(LocalResponseNorm, self).__init__()
         self.size = size
         self.alpha = alpha
         self.beta = beta

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -1,4 +1,46 @@
 from .module import Module
+from .. import functional as F
+
+
+class LocalResponseNorm2d(Module):
+    def __init__(self, size, alpha=1e-4, beta=0.75, k=1):
+        r"""Applies local response normalization:
+
+        .. math::
+
+            `b_{c,i,j} = a_{c,i,j}\left(k + \alpha\sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}
+            a_{c',i,j}^2\right)^{-\beta}`
+
+        Args:
+            size: amount of neighbouring channels used for normalization
+            alpha: multiplicative factor
+            beta: root factor
+            k: additive factor
+
+        Shape:
+            - Input: :math:`(N, C, H, W)`
+            - Output: :math:`(N, C, H, W)`
+        Examples::
+            >>> lrn = nn.LocalResponseNorm2d(3)
+            >>> input = autograd.Variable(torch.randn(32, 5, 24, 24))
+            >>> output = lrn(input)
+        """
+        super(LocalResponseNorm2d, self).__init__()
+        self.size = size
+        self.alpha = alpha
+        self.beta = beta
+        self.k = k
+
+    def forward(self, input):
+        return F.local_response_norm(input, self.size, self.alpha, self.beta,
+                                     self.k)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(' \
+            + str(self.size) \
+            + ', alpha=' + str(self.alpha) \
+            + ', beta=' + str(self.beta) \
+            + ', k=' + str(self.k) + ')'
 
 
 class CrossMapLRN2d(Module):


### PR DESCRIPTION
Functional implementation + module for LRN based on @jiecaoyu's [implementation](https://github.com/pytorch/pytorch/issues/653#issuecomment-326851808). Let me know if there should be any naming changes/if we want an across/within channel flag like Caffe/what to do with CrossMapLRN2d etc.

Originally [AlexNet](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf) doesn't seem to do an average (just sums), whilst [Caffe](http://caffe.berkeleyvision.org/tutorial/layers/lrn.html) does do an average... I've written the docs as a sum as in the original, so will either need to change the docs or implementation depending on which one we want (or even make it another option).