### PR TITLE
use CUDA_HOST_COMPILER to detect installed GPU

### DIFF
--- a/aten/cmake/FindCUDA/FindCUDA/select_compute_arch.cmake
+++ b/aten/cmake/FindCUDA/FindCUDA/select_compute_arch.cmake
@@ -62,11 +62,11 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
       "  return 0;\n"
       "}\n")
 
-    if(MSVC AND NOT "${CMAKE_C_COMPILER}" MATCHES "/cl.exe")
+    if(MSVC AND NOT "${CUDA_HOST_COMPILER}" MATCHES "/cl.exe")
       find_program(REAL_MSVC_COMPILER cl.exe)
       set(CCBIN "${REAL_MSVC_COMPILER}")
     else()
-      set(CCBIN "${CMAKE_C_COMPILER}")
+      set(CCBIN "${CUDA_HOST_COMPILER}")
     endif()
 
     execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${cufile}"


### PR DESCRIPTION
When CUDA_HOST_COMPILER needs to set (for example when using CUDA 8.0
and CMAKE_C_COMPILER is a gcc 6 or newer), then it also needs to be
used to detect the installed GPU.


see https://github.com/zdevito/ATen/issues/192 for original patch