### PR TITLE
Add print support for sparse variables

### DIFF
--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -70,7 +70,13 @@ class Variable(_C._VariableBase):
         self.requires_grad, _, self._backward_hooks = state
 
     def __repr__(self):
-        strt = 'Variable containing:' + torch._tensor_str._str(self.data, False)
+        if self.is_sparse:
+            data_str = ' \n{} with indices:\n{}and values:\n{}'.format(
+                torch.typename(self.data), self._indices().data,
+                self._values().data)
+        else:
+            data_str = torch._tensor_str._str(self.data, False)
+        strt = 'Variable containing:' + data_str
         # let's make our own Variable-specific footer
         size_str = '(' + ','.join(str(size) for size in self.size()) + (',)' if len(self.size()) == 1 else ')')
         device_str = '' if not self.is_cuda else \


### PR DESCRIPTION
Adds python `print()` support for sparse variables.

### Test Plan
- Run script to test that printing other variables still works
- Run script to test printing sparse variables
```
import torch
from torch.autograd import Variable

x = Variable(torch.randn(5, 5))
print(x)

i = torch.LongTensor([[0, 1, 1], [2, 0, 2]])
v = torch.FloatTensor([3, 4, 5])
sparse_mat = torch.sparse.FloatTensor(i, v, torch.Size([2,3]))
sparse_var = Variable(sparse_mat)
print(sparse_var)

>>>
Variable containing:
 0.6359 -0.9694  0.5876  1.6723  0.9509
-2.1022  1.0072  0.7337 -0.6104 -0.5547
-1.6389  0.6581 -0.1139 -0.4083 -1.1276
-0.5260 -0.1056 -2.0238 -1.0931  0.0287
-0.5863  1.4535 -0.7411 -0.3802  1.0380
[torch.FloatTensor of size (5,5)]

Variable containing:
torch.sparse.FloatTensor with indices:

 0  1  1
 2  0  2
[torch.LongTensor of size 2x3]
and values:

 3
 4
 5
[torch.FloatTensor of size 3]
[torch.sparse.FloatTensor of size (2,3)]
```