### PR TITLE
updated documentation for Embedding layer

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -34,7 +34,7 @@ class Embedding(Module):
     Notes:
         Keep in mind that only a limited number of optimizers support
         sparse gradients: currently it's `optim.SGD` (`cuda` and `cpu`),
-        and `optim.Adagrad` (`cpu`)
+        `optim.SparseAdam` (`cuda` and `cpu`) and `optim.Adagrad` (`cpu`)
 
     Examples::
 


### PR DESCRIPTION
The documentation corresponding torch.nn.Embedding mentions that Keep in mind that only a limited number of optimizers support sparse gradients: currently it’s optim.SGD (cuda and cpu), and optim.Adagrad (cpu). This is outdated and now SparseAdam is also supported. Updated the document to reflect the same. This fixes #4682