### PR TITLE
Restores some sparse variable methods

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2228,15 +2228,13 @@
   name: pow
   types:
     - floating_point
-  backends:
-    - CPU
-    - CUDA
   variants:
     - method
     - function
   return: argument 0
   options:
     - cname: pow
+      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -35,6 +35,7 @@
   name: zeros
   variants:
     - function
+  aten_sparse: True
   auto_gpu: False
   return: argument 0
   arguments:
@@ -46,6 +47,7 @@
 [[
   name: zeros_like
   cname: zerosLike
+  aten_sparse: True
   variants:
     - function
   return: argument 0
@@ -205,6 +207,7 @@
     - method
     - function
   cname: newTranspose
+  aten_sparse: True
   cpu_half: True
   auto_gpu: False
   return: THTensor*
@@ -235,11 +238,18 @@
     - method
     - function
   auto_gpu: False
-  cname: newTranspose
   return: THTensor*
+  cname: newTranspose
+  aten_sparse: True
   before_call: |
-    long ndim = arg_self->nDimension;
-    THPUtils_assert(ndim == 2, "t() expects a 2D tensor, but self is %ldD", ndim);
+    if (self.is_sparse) {
+      int64_t nDimI = arg_self->nDimensionI;
+      int64_t nDimV = arg_self->nDimensionV;
+      THPUtils_assert(nDimI == 2 && nDimV == 0, "t() expects a 2D sparse tensor, but self is %ldD indices and %ldD values", nDimI, nDimV);
+    } else {
+      long ndim = arg_self->nDimension;
+      THPUtils_assert(ndim == 2, "t() expects a 2D tensor, but self is %ldD", ndim);
+    }
   arguments:
     - THTensor* self
     - CONSTANT 0
@@ -2557,6 +2567,7 @@
           default: AS_REAL(1)
           kwarg_only: True
     - cname: csub
+      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -2580,6 +2591,7 @@
           default: AS_REAL(1)
           kwarg_only: True
     - cname: csub
+      aten_sparse: True
       arguments:
         - THTensor* self
         - arg: THTensor* self
@@ -2603,6 +2615,7 @@
         - THTensor* self
         - real other
     - cname: cmul
+      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -2620,6 +2633,7 @@
         - THTensor* self
         - real other
     - cname: cmul
+      aten_sparse: True
       arguments:
         - THTensor* self
         - arg: THTensor* self
@@ -2634,6 +2648,7 @@
   return: argument 0
   options:
     - cname: div
+      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -2652,6 +2667,7 @@
   return: argument 0
   options:
     - cname: div
+      aten_sparse: True
       arguments:
         - THTensor* self
         - THTensor* self

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -635,6 +635,48 @@ class TestSparse(TestCase):
         expected = self.SparseTensor(i, exp_v, torch.Size([5, 4, 2]))
         self.assertEqual(res, expected)
 
+    def test_sparse_variable_methods(self):
+        # TODO: delete when tensor/variable are merged
+        from torch.autograd import Variable
+        i = self.IndexTensor([[0, 1, 1], [2, 0, 2]])
+        v = self.ValueTensor([3, 4, 5])
+        sparse_mat = self.SparseTensor(i, v, torch.Size([2, 3]))
+        sparse_var = Variable(sparse_mat)
+
+        to_test_one_arg = {
+            'zeros_like': lambda x: torch.zeros_like(x),
+            'transpose': lambda x: x.transpose(0, 1),
+            't': lambda x: x.t(),
+            'div': lambda x: x.div(2),
+            'div_': lambda x: x.div_(2),
+        }
+
+        for test_name, test_fn in to_test_one_arg.items():
+            var1 = sparse_var.clone()
+            tensor1 = sparse_mat.clone()
+            self.assertEqual(test_fn(var1).data, test_fn(tensor1),
+                             test_name)
+
+        i = self.IndexTensor([[0, 0, 1], [1, 2, 1]])
+        v = self.ValueTensor([3, 3, 4])
+        sparse_mat2 = self.SparseTensor(i, v, torch.Size([2, 3]))
+        sparse_var2 = Variable(sparse_mat2)
+
+        to_test_two_arg = {
+            'sub': lambda x, y: x.sub(y),
+            'sub_': lambda x, y: x.sub_(y),
+            'mul': lambda x, y: x.mul(y),
+            'mul_': lambda x, y: x.mul_(y),
+        }
+
+        for test_name, test_fn in to_test_two_arg.items():
+            var1 = sparse_var.clone()
+            var2 = sparse_var2.clone()
+            tensor1 = sparse_mat.clone()
+            tensor2 = sparse_mat2.clone()
+            self.assertEqual(test_fn(var1, var2).data,
+                             test_fn(tensor1, tensor2), test_name)
+
     def test_sparse_mask_hybrid(self):
         self._test_sparse_mask_hybrid_fixed()
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -649,6 +649,7 @@ class TestSparse(TestCase):
             't': lambda x: x.t(),
             'div': lambda x: x.div(2),
             'div_': lambda x: x.div_(2),
+            'pow': lambda x: x.pow(2),
         }
 
         for test_name, test_fn in to_test_one_arg.items():


### PR DESCRIPTION
Partially addresses #4236.

Restores the following for sparse variables:
- transpose
- t
- zeros
- zeros_like
- sub
- sub_
- div
- div_
- mul
- mul_
- pow

`t_` and `transpose_` are a little more involved and so will come in a later PR.

### Test Plan
Unit tests for all of the above.