### PR TITLE
Improve the engine support for functional graph execution

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -116,13 +116,11 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
             be constructed, allowing to compute higher order derivative products.
             Defaults to ``False``, unless ``grad_variables`` contains at least one
             non-volatile Variable.
-        only_inputs (bool, optional): If ``True``, gradient w.r.t. leaves that are
-            part of the graph, but don't appear in ``inputs`` won't be computed
-            and accumulated. Defaults to ``True``.
-        allow_unused (bool, optional): If ``False``, specifying inputs that were not
-            used when computing outputs (and therefore their grad is always zero)
-            is an error. Defaults to ``False``.
     """
+    if not only_inputs:
+        warnings.warn("only_inputs argument is deprecated and is ignored now (defaults to True)!")
+    if allow_unused:
+        warnings.warn("allow_unused argument is deprecated and is ignored now (defaults to True)!")
 
     outputs = (outputs,) if isinstance(outputs, Variable) else tuple(outputs)
     inputs = (inputs,) if isinstance(inputs, Variable) else tuple(inputs)
@@ -139,7 +137,7 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
 
     return Variable._execution_engine.run_backward(
         outputs, grad_outputs, retain_graph, create_graph,
-        inputs, only_inputs, allow_unused)
+        inputs)
 
 
 if not torch._C._autograd_init():

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <string>
@@ -72,14 +73,31 @@ struct GraphTask {
   // Notified when a task finishes executing.  Check outstanding_tasks to see
   // if all tasks are done.
   std::condition_variable not_done;
-  const Engine::pre_callback_map& pre_callbacks;
-  const Engine::post_callback_map& post_callbacks;
   std::unordered_map<Function*, InputBuffer> not_ready;
   std::unordered_map<Function*, int> dependencies;
 
+  struct ExecInfo {
+    struct Capture {
+      Capture(int input_idx, int output_idx) : input_idx(input_idx), output_idx(output_idx) {}
+      int input_idx; // within Function inputs
+      int output_idx; // within the output vector of a GraphTask
+    };
+
+    bool needed;
+    std::unique_ptr<std::vector<Capture>> captures;
+  };
+  // Exec info has a bit complicated semantics. If it's empty, it means the task is
+  // run in a "default" mode, which means that all next_functions we encounter should
+  // get executed. If it's not empty, only functions that have an entry and this entry
+  // has needed == True should be executed.
+  std::unordered_map<Function*, ExecInfo> exec_info;
+  std::vector<Variable> captured_vars;
+
+  void init_to_execute(const std::shared_ptr<Function>& graph_root, const function_list& captures);
+
   int owner;
 
-  GraphTask(bool keep_graph, bool grad_mode, const Engine::pre_callback_map& pre_callbacks, const Engine::post_callback_map& post_callbacks)
+  GraphTask(bool keep_graph, bool grad_mode)
     : exception()
     , has_error(false)
     , outstanding_tasks(0)
@@ -87,8 +105,6 @@ struct GraphTask {
     , grad_mode(grad_mode)
     , mutex()
     , not_done()
-    , pre_callbacks(pre_callbacks)
-    , post_callbacks(post_callbacks)
     , not_ready()
     , dependencies()
     , owner(NO_DEVICE) {}
@@ -202,26 +218,28 @@ static variable_list call_function(FunctionTask& task) {
   auto& fn = *task.fn;
   auto inputs = call_pre_hooks(fn, InputBuffer::variables(std::move(task.inputs)));
 
-  auto& pre_callbacks = task.base->pre_callbacks;
-  for (auto it_p = pre_callbacks.equal_range(&fn); it_p.first != it_p.second; ++it_p.first) {
-    auto& callback = it_p.first->second;
-    if (!callback(&fn, inputs)) return variable_list(fn.next_functions.size());
-  }
   if(!task.base->keep_graph) {
     fn.willReleaseVariables();
   }
   auto outputs = fn(inputs);
 
-  auto& post_callbacks = task.base->post_callbacks;
-  for (auto it_p = post_callbacks.equal_range(&fn); it_p.first != it_p.second; ++it_p.first) {
-    auto& callback = it_p.first->second;
-    if (!callback(&fn, inputs, outputs)) return variable_list(fn.next_functions.size());
-  }
-
   return call_post_hooks(fn, std::move(outputs), std::move(inputs));
 }
 
 auto Engine::evaluate_function(FunctionTask& task) -> void {
+  // If exec_info is not empty, we have to instrument the execution
+  auto & exec_info = task.base->exec_info;
+  if (!exec_info.empty()) {
+    auto & fn_info = exec_info.at(task.fn.get());
+    if (auto *capture_vec = fn_info.captures.get()) {
+      std::lock_guard<std::mutex> lock(task.base->mutex);
+      for (auto capture : *capture_vec) {
+        task.base->captured_vars[capture.output_idx] = task.inputs[capture.input_idx];
+      }
+    }
+    if (!fn_info.needed) return;
+  }
+
   auto outputs = call_function(task);
 
   auto& fn = *task.fn;
@@ -263,6 +281,13 @@ auto Engine::evaluate_function(FunctionTask& task) -> void {
     auto& not_ready = task.base->not_ready;
     auto not_ready_it = not_ready.find(next_fn.get());
     if (not_ready_it == not_ready.end()) {
+      // Skip functions that aren't supposed to be executed
+      if (!exec_info.empty()) {
+        auto it = exec_info.find(next_fn.get());
+        if (it == exec_info.end() || (!it->second.needed && !it->second.captures)) {
+          continue;
+        }
+      }
       // No buffers have been allocated for the function
       InputBuffer input_buffer(next_fn->num_inputs);
       input_buffer.add(input_nr, std::move(output));
@@ -327,18 +352,20 @@ auto Engine::execute(const function_list& input_roots,
                      const variable_list& inputs,
                      bool keep_graph,
                      bool create_graph,
-                     const pre_callback_map& pre_callbacks,
-                     const post_callback_map& post_callbacks) -> void {
+                     const function_list& outputs) -> variable_list {
   std::call_once(start_threads_flag, &Engine::start_threads, this);
   // Callbacks are only valid for the duration of this run and should always be cleared
   ClearCallbacks _cb_guard(final_callbacks, post_callbacks_lock);
 
-  GraphTask graph_task(keep_graph, create_graph, pre_callbacks, post_callbacks);
+  GraphTask graph_task(keep_graph, create_graph);
   std::unique_lock<std::mutex> lock(graph_task.mutex);
 
   // Now compute the dependencies for all executable functions and queue the root
   auto graph_root = std::make_shared<GraphRoot>(input_roots, inputs);
   compute_dependencies(graph_root.get(), graph_task);
+  if (!outputs.empty()) {
+    graph_task.init_to_execute(graph_root, outputs);
+  }
   ready_queue(-1).push_front(FunctionTask(&graph_task, std::move(graph_root), InputBuffer(0)));
 
   // Not a worker
@@ -371,6 +398,8 @@ auto Engine::execute(const function_list& input_roots,
     final_callbacks[i]();
     cb_lock.lock();
   }
+
+  return graph_task.captured_vars;
 }
 
 void Engine::queue_callback(std::function<void()> callback) {
@@ -401,5 +430,72 @@ auto Engine::start_threads() -> void {
     t.detach();
   }
 }
+
+void GraphTask::init_to_execute(const std::shared_ptr<Function>& graph_root, const function_list& outputs) {
+  exec_info[graph_root.get()].needed = true;
+
+  int output_idx = 0;
+  for (auto & output_edge : outputs) {
+    Function *output = output_edge.first.get();
+    auto & info = exec_info[output];
+    if (!info.captures)
+      info.captures.reset(new std::vector<ExecInfo::Capture>());
+    info.captures->emplace_back(output_edge.second, output_idx++);
+  }
+  captured_vars.resize(output_idx);
+
+  // NB: this is an uglier version (recursion replaced with iteration) of the following code:
+  // is_needed = {}
+  // def compute_is_needed(fn):
+  //   if fn not in is_needed:
+  //     is_needed[fn] = any(compute_is_needed(next_fn)
+  //                         for next_fn in fn.next_functions)
+  //   return is_needed[fn]
+  struct Frame {
+    Frame (Function *fn) : fn(fn), next_next_fn(0) {}
+    Function *fn;
+    std::size_t next_next_fn;
+
+    Function* get_next_fn() {
+      auto & next = fn->next_functions;
+      auto num_next = next.size();
+      while (next_next_fn < num_next) {
+        auto fn = next[next_next_fn++].first.get();
+        if (fn) return fn;
+      }
+      return nullptr;
+    }
+  };
+  std::vector<Frame> stack;
+  std::unordered_set<Function*> seen;
+  for (auto & input : graph_root->next_functions) {
+    if (seen.count(input.first.get()) > 0) continue;
+    stack.emplace_back(input.first.get());
+    while (!stack.empty()) {
+      auto &frame = stack.back();
+      if (Function *next_fn = frame.get_next_fn()) {
+        if (/* bool unseen = */ seen.emplace(next_fn).second) {
+          stack.emplace_back(next_fn);
+          continue; // recurse
+        }
+      } else {
+        // NB: if we were using real recursion we could have saved some lookups
+        // using a return value from recursive call. It would make this manually unrolled
+        // version a lot more complicated, so I skipped that.
+        auto & next_fns = frame.fn->next_functions;
+        bool needed = std::any_of(next_fns.begin(), next_fns.end(),
+                                  [&](const edge_type& e) -> bool {
+                                    auto it = exec_info.find(e.first.get());
+                                    // It has to be either needed or be an output
+                                    return it != exec_info.end() &&
+                                            (it->second.needed || it->second.captures);
+                                  });
+        exec_info[frame.fn].needed = needed;
+        stack.pop_back();
+      }
+    }
+  }
+}
+
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -29,20 +29,14 @@ struct Engine {
   using ready_queue_type = std::deque<std::pair<std::shared_ptr<Function>, InputBuffer>>;
   using dependencies_type = std::unordered_map<Function*, int>;
 
-  using pre_callback_type = std::function<bool (Function*, variable_list&)>;
-  using pre_callback_map = std::unordered_multimap<Function*, pre_callback_type>;
-  using post_callback_type = std::function<bool (Function*, variable_list&, variable_list&)>;
-  using post_callback_map = std::unordered_multimap<Function*, post_callback_type>;
-
   // Given a list of (Function, input number) pairs computes the value of the graph
   // by following next_function references.
-  virtual void execute(
+  virtual variable_list execute(
       const function_list& roots,
       const variable_list& inputs,
       bool keep_graph,
       bool create_graph,
-      const pre_callback_map& pre_callbacks = pre_callback_map(),
-      const post_callback_map& post_callbacks = post_callback_map());
+      const function_list& outputs = {});
 
   void queue_callback(std::function<void()> callback);
 

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -86,7 +86,6 @@ struct Eval : Function {
 
 private:
   std::pair<function_list, variable_list> filterRoots(const variable_list& inputs);
-  Engine::pre_callback_map getCallbacks(variable_list& outputs, std::mutex& outputs_mutex);
 
   Subgraph getSubgraph(
       const variable_list& inputs,

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -26,6 +26,8 @@ struct InputBuffer {
 
   int device() const;
 
+  Variable operator[](std::size_t pos) { return buffer[pos]; }
+
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& buffer);
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -40,15 +40,14 @@ void PythonEngine::thread_on_exception(FunctionTask& task, std::exception& e) {
   Engine::thread_on_exception(task, e);
 }
 
-void PythonEngine::execute(
+variable_list PythonEngine::execute(
     const function_list& roots,
     const variable_list& inputs,
     bool keep_graph,
     bool create_graph,
-    const pre_callback_map& pre_callbacks,
-    const post_callback_map& post_callbacks) {
+    const function_list& outputs) {
   try {
-    Engine::execute(roots, inputs, keep_graph, create_graph, pre_callbacks, post_callbacks);
+    return Engine::execute(roots, inputs, keep_graph, create_graph, outputs);
   } catch (python_error& e) {
     e.restore();
     throw;
@@ -62,78 +61,6 @@ PythonEngine& PythonEngine::getDefaultEngine() {
 }}} // namespace torch::autograd::python
 
 PyObject *THPEngineClass = NULL;
-
-struct CallbackContext {
-  std::string error;
-  THPObjectPtr outputs;
-  // Used to determine which callback arguments should be used to
-  // fill outputs.
-  // Function -> ([grad_nr, outputs_idx], is_leaf)
-  std::unordered_map<
-    std::shared_ptr<Function>,
-    std::pair<std::vector<std::pair<int, int>>, bool>> output_map;
-};
-
-void compute_partial_exec_callbacks(const function_list& roots,
-                                    const CallbackContext& ctx,
-                                    Engine::pre_callback_map& map,
-                                    bool allow_unreachable) {
-  // This callback is used to suppress the computation of a node
-  // if it is not necessary.
-  static Engine::pre_callback_type abort_callback(
-      [](Function* fn, variable_list &vars) { return false; });
-
-  std::vector<Function*> queue;
-  std::unordered_set<Function*> seen;    // for the initial DFS
-  std::unordered_set<Function*> needed;  // functions to compute
-  std::unordered_map<Function*, std::vector<Function*>> rev_graph;
-
-  // Reverse the next_fn edges
-  queue.reserve(roots.size());
-  for (auto& root : roots) {
-    auto ptr = root.first.get();
-    bool unseen;
-    std::tie(std::ignore, unseen) = seen.insert(ptr);
-    if (unseen) queue.emplace_back(ptr);
-  }
-  while (!queue.empty()) {
-    auto fn = queue.back(); queue.pop_back();
-    for (auto& next_fn_pair : fn->next_functions) {
-      auto next_fn = next_fn_pair.first.get();
-      if (!next_fn) continue;
-      rev_graph[next_fn].push_back(fn);
-      if (seen.insert(next_fn).second) {
-        queue.push_back(next_fn);
-      }
-    }
-  }
-  auto all_functions = std::move(seen); // this is cheap and improves readability
-
-  // Find all functions we need to compute
-  queue.clear();
-  for (auto input_info: ctx.output_map) {
-    auto input = input_info.first.get();
-    auto rev_edges_it = rev_graph.find(input);
-    if (!allow_unreachable && rev_edges_it == rev_graph.end())
-      throw std::runtime_error("differentiated input is unreachable");
-    queue.emplace_back(input);
-    needed.insert(input);
-  }
-  while (!queue.empty()) {
-    auto fn = queue.back(); queue.pop_back();
-    for (auto rev_next_fn : rev_graph[fn]) {
-      if (needed.insert(rev_next_fn).second) {
-        queue.push_back(rev_next_fn);
-      }
-    }
-  }
-
-  // Prevent expansion for functions in {all_vertices} \ {needed}
-  for (auto fn : all_functions) {
-    if (needed.count(fn) > 0) continue;
-    map.emplace(fn, abort_callback);
-  }
-}
 
 static bool _reinitialize_engine = false;
 
@@ -161,16 +88,12 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
   unsigned char keep_graph = 0;
   unsigned char create_graph = 0;
   PyObject *inputs = NULL;
-  unsigned char only_inputs = 0;
-  unsigned char allow_unreachable = 0;
   const char *accepted_kwargs[] = {
       "variables", "grad_variables", "keep_graph", "create_graph", "inputs",
-      "only_inputs", "allow_unreachable",
       NULL
   };
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OObb|Obb", (char**)accepted_kwargs,
-        &variables, &grad_variables, &keep_graph, &create_graph, &inputs,
-        &only_inputs, &allow_unreachable))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OObb|O", (char**)accepted_kwargs,
+        &variables, &grad_variables, &keep_graph, &create_graph, &inputs))
     return NULL;
 
   THPUtils_assert(PyTuple_Check(variables), "variables argument is expected to "
@@ -213,72 +136,51 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     }
   }
 
-  Engine::pre_callback_map callbacks;
-  CallbackContext ctx;
+  function_list output_edges;
   if (inputs != NULL) {
-    THPUtils_assert(PyTuple_Check(inputs), "inputs argument has to be a tuple");
     int num_inputs = PyTuple_GET_SIZE(inputs);
-    ctx.outputs = PyTuple_New(num_inputs);
-    if (!ctx.outputs) return NULL;
-    // First, find all relevant functions and fill ctx.output_map
+    output_edges.reserve(num_inputs);
     for (int i = 0; i < num_inputs; ++i) {
       PyObject *input = PyTuple_GET_ITEM(inputs, i);
       THPUtils_assert(THPVariable_Check(input),
           "all inputs have to be Variables, but got %s", THPUtils_typename(input));
       THPVariable *input_var = (THPVariable*)input;
-      auto grad_fn = input_var->cdata.grad_fn();
       int output_nr = input_var->cdata.output_nr();
-      bool is_leaf = !grad_fn;
-      if (is_leaf) {
+      auto grad_fn = input_var->cdata.grad_fn();
+      if (!grad_fn) {
           grad_fn = input_var->cdata.get()->grad_accumulator.lock();
       }
       THPUtils_assert(input_var->cdata.requires_grad(),
           "One of the differentiated Variables does not require grad");
-      if (allow_unreachable && !grad_fn) continue;
-      THPUtils_assert(grad_fn,
-          "One of the differentiated Variables appears to not have been used in the graph");
-      auto& fn_info = ctx.output_map[grad_fn];
-      fn_info.first.emplace_back(output_nr, i);
-      fn_info.second = is_leaf;
-    }
-    // Register callbacks that will gather the outputs
-    for (auto& entry : ctx.output_map) {
-      auto& fn_info = entry.second;
-      callbacks.emplace(entry.first.get(), [&ctx, &fn_info](Function* _unused, variable_list& grads) {
-        auto& saved_outputs = fn_info.first;
-        bool is_leaf = fn_info.second;
-        AutoGIL gil;
-        for (auto& saved_out : saved_outputs) {
-          PyTuple_SET_ITEM(ctx.outputs.get(), saved_out.second,
-            THPVariable_Wrap(grads[saved_out.first]));
-        }
-        // Suppress grad accumulation.
-        // If the variable is a leaf, the next function to execute
-        // is a grad_accumulator.  But when inputs != NULL, we should
-        // NOT accumulate, so terminate execution.
-        return !is_leaf;
-      });
-    }
-    // Disable execution for all unneeded functions
-    if (only_inputs) {
-      compute_partial_exec_callbacks(roots, ctx, callbacks, allow_unreachable);
+      if (!grad_fn) {
+        output_edges.emplace_back();
+      } else {
+        THPUtils_assert(grad_fn,
+            "One of the differentiated Variables appears to not have been used in the graph");
+        output_edges.emplace_back(grad_fn, output_nr);
+      }
     }
   }
 
+  variable_list outputs;
   {
     AutoNoGIL no_gil;
-    engine.execute(roots, grads, keep_graph, create_graph, callbacks);
+    outputs = engine.execute(roots, grads, keep_graph, create_graph, output_edges);
   }
 
-  if (ctx.outputs) {
-    for (int i = 0; i < PyTuple_GET_SIZE(inputs); i++) {
-      // XXX: initializing tuples with NULL pointers might be a CPython
-      // implementation detail
-      if (PyTuple_GET_ITEM(ctx.outputs.get(), i)) continue;
-      Py_INCREF(Py_None);
-      PyTuple_SET_ITEM(ctx.outputs.get(), i, Py_None);
+  if (inputs != NULL) {
+    int num_inputs = PyTuple_GET_SIZE(inputs);
+    THPObjectPtr py_outputs {PyTuple_New(num_inputs)};
+    if (!py_outputs) return NULL;
+    for (int i = 0; i < num_inputs; i++) {
+      if (outputs[i].defined()) {
+        PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));
+      } else {
+        Py_INCREF(Py_None);
+        PyTuple_SET_ITEM(py_outputs.get(), i, Py_None);
+      }
     }
-    return ctx.outputs.release();
+    return py_outputs.release();
   } else {
     Py_RETURN_NONE;
   }

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -173,12 +173,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     THPObjectPtr py_outputs {PyTuple_New(num_inputs)};
     if (!py_outputs) return NULL;
     for (int i = 0; i < num_inputs; i++) {
-      if (outputs[i].defined()) {
-        PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));
-      } else {
-        Py_INCREF(Py_None);
-        PyTuple_SET_ITEM(py_outputs.get(), i, Py_None);
-      }
+      PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));
     }
     return py_outputs.release();
   } else {

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -10,13 +10,12 @@ namespace torch { namespace autograd { namespace python {
 struct PythonEngine : public Engine {
   virtual void thread_init(int device) override;
   virtual void thread_on_exception(FunctionTask& task, std::exception& e) override;
-  virtual void execute(
+  virtual variable_list execute(
       const function_list& roots,
       const variable_list& inputs,
       bool keep_graph,
       bool create_graph,
-      const pre_callback_map& pre_callbacks = pre_callback_map(),
-      const post_callback_map& post_callbacks = post_callback_map()) override;
+      const function_list& outputs = {}) override;
 
   static PythonEngine& getDefaultEngine();
 };


### PR DESCRIPTION
Previously the side-effect free grad calculation was performed
using callbacks that could also override the decision to run a
function. However this had a few problems e.g. it forced us to iterate
over pretty much all functions in the graph and drop their buffers.

This patch improves the mechanism, by adding explicit support for this
kind of evaluation in execute(). It's safer, and the algorithm used to
decide which nodes have to be evaluated was replaced with a faster one.

This unblocks #4594 (cc: @prigoyal).
It also finally allows to correctly differentiate parts of the graph, which is useful in various models (cc: @srush)