### PR TITLE
Ensure lazy evaluation for probs and logits

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -46,7 +46,7 @@ class Bernoulli(Distribution):
             batch_shape = self._param.size()
         super(Bernoulli, self).__init__(batch_shape)
 
-    def new(self, *args, **kwargs):
+    def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
     @lazy_property
@@ -74,7 +74,7 @@ class Bernoulli(Distribution):
         return binary_cross_entropy_with_logits(self.logits, self.probs, reduce=False)
 
     def enumerate_support(self):
-        values = self.new((2,))
+        values = self._new((2,))
         torch.arange(2, out=values.data if isinstance(values, Variable) else values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -74,11 +74,8 @@ class Bernoulli(Distribution):
         return binary_cross_entropy_with_logits(self.logits, self.probs, reduce=False)
 
     def enumerate_support(self):
-        values = torch.arange(2)
+        values = self.new((2,))
+        torch.arange(2, out=values.data if isinstance(values, Variable) else values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
-        if self._param.is_cuda:
-            values = values.cuda(self._param.get_device())
-        if isinstance(self._param, Variable):
-            values = Variable(values)
         return values

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -41,16 +41,21 @@ class Binomial(Distribution):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
         if probs is not None:
+            is_scalar = isinstance(probs, Number)
             self.probs, = broadcast_all(probs)
         else:
+            is_scalar = isinstance(logits, Number)
             self.logits, = broadcast_all(logits)
 
-        probs_or_logits = probs if probs is not None else logits
-        if isinstance(probs_or_logits, Number):
+        self._param = self.probs if probs is not None else self.logits
+        if is_scalar:
             batch_shape = torch.Size()
         else:
-            batch_shape = probs_or_logits.size()
+            batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape)
+
+    def new(self, *args, **kwargs):
+        return self._param.new(*args, **kwargs)
 
     @constraints.dependent_property
     def support(self):
@@ -64,25 +69,30 @@ class Binomial(Distribution):
     def probs(self):
         return logits_to_probs(self.logits, is_binary=True)
 
+    @property
+    def param_shape(self):
+        return self._param.size()
+
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape) + (self.total_count,)
         return torch.bernoulli(self.probs.unsqueeze(-1).expand(shape)).sum(dim=-1)
 
     def log_prob(self, value):
         self._validate_log_prob_arg(value)
-        probs = clamp_probs(self.probs)
         log_factorial_n = math.lgamma(self.total_count + 1)
         log_factorial_k = torch.lgamma(value + 1)
         log_factorial_nmk = torch.lgamma(self.total_count - value + 1)
+        max_val = (-self.logits).clamp(min=0.0)
         return (log_factorial_n - log_factorial_k - log_factorial_nmk +
-                value * self.logits + self.total_count * torch.log1p(-probs))
+                value * self.logits + self.total_count * max_val -
+                self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))
 
     def enumerate_support(self):
         values = torch.arange(self.total_count)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
-        if self.probs.is_cuda:
-            values = values.cuda(self.probs.get_device())
-        if isinstance(self.probs, Variable):
+        if self._param.is_cuda:
+            values = values.cuda(self._param.get_device())
+        if isinstance(self._param, Variable):
             values = Variable(values)
         return values

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -54,7 +54,7 @@ class Binomial(Distribution):
             batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape)
 
-    def new(self, *args, **kwargs):
+    def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
     @constraints.dependent_property
@@ -89,7 +89,7 @@ class Binomial(Distribution):
                 self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))
 
     def enumerate_support(self):
-        values = self.new((self.total_count,))
+        values = self._new((self.total_count,))
         torch.arange(self.total_count, out=values.data if isinstance(values, Variable) else values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -88,11 +88,8 @@ class Binomial(Distribution):
                 self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))
 
     def enumerate_support(self):
-        values = torch.arange(self.total_count)
+        values = self.new((self.total_count,))
+        torch.arange(self.total_count, out=values.data if isinstance(values, Variable) else values)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
-        if self._param.is_cuda:
-            values = values.cuda(self._param.get_device())
-        if isinstance(self._param, Variable):
-            values = Variable(values)
         return values

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -83,6 +83,7 @@ class Binomial(Distribution):
         log_factorial_k = torch.lgamma(value + 1)
         log_factorial_nmk = torch.lgamma(self.total_count - value + 1)
         max_val = (-self.logits).clamp(min=0.0)
+        # Note that: torch.log1p(-self.probs)) = max_val - torch.log1p((self.logits + 2 * max_val).exp()))
         return (log_factorial_n - log_factorial_k - log_factorial_nmk +
                 value * self.logits + self.total_count * max_val -
                 self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -49,7 +49,7 @@ class Categorical(Distribution):
         batch_shape = self._param.size()[:-1]
         super(Categorical, self).__init__(batch_shape)
 
-    def new(self, *args, **kwargs):
+    def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
     @constraints.dependent_property

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -44,13 +44,17 @@ class Categorical(Distribution):
             self.probs = probs / probs.sum(-1, keepdim=True)
         else:
             self.logits = logits - log_sum_exp(logits)
-        self._num_events = self.probs.size()[-1] if self.probs is not None else self.logits.size()[-1]
-        batch_shape = self.probs.size()[:-1] if probs is not None else self.logits.size()[:-1]
+        self._param = self.probs if probs is not None else self.logits
+        self._num_events = self._param.size()[-1]
+        batch_shape = self._param.size()[:-1]
         super(Categorical, self).__init__(batch_shape)
+
+    def new(self, *args, **kwargs):
+        return self._param.new(*args, **kwargs)
 
     @constraints.dependent_property
     def support(self):
-        return constraints.integer_interval(0, self.probs.size()[-1] - 1)
+        return constraints.integer_interval(0, self._num_events - 1)
 
     @lazy_property
     def logits(self):
@@ -60,12 +64,15 @@ class Categorical(Distribution):
     def probs(self):
         return logits_to_probs(self.logits)
 
+    @property
+    def param_shape(self):
+        return self._param.size()
+
     def sample(self, sample_shape=torch.Size()):
-        num_events = self.probs.size()[-1]
         sample_shape = self._extended_shape(sample_shape)
-        param_shape = sample_shape + self.probs.size()[-1:]
+        param_shape = sample_shape + torch.Size((self._num_events,))
         probs = self.probs.expand(param_shape)
-        probs_2d = probs.contiguous().view(-1, num_events)
+        probs_2d = probs.contiguous().view(-1, self._num_events)
         sample_2d = torch.multinomial(probs_2d, 1, True)
         return sample_2d.contiguous().view(sample_shape)
 
@@ -82,12 +89,12 @@ class Categorical(Distribution):
         return -p_log_p.sum(-1)
 
     def enumerate_support(self):
-        num_events = self.probs.size()[-1]
+        num_events = self._num_events
         values = torch.arange(num_events).long()
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
-        if self.probs.is_cuda:
-            values = values.cuda(self.probs.get_device())
-        if isinstance(self.probs, Variable):
+        if self._param.is_cuda:
+            values = values.cuda(self._param.get_device())
+        if isinstance(self._param, Variable):
             values = Variable(values)
         return values

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -51,8 +51,8 @@ class Multinomial(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape)
 
-    def new(self, *args, **kwargs):
-        return self._categorical.new(*args, **kwargs)
+    def _new(self, *args, **kwargs):
+        return self._categorical._new(*args, **kwargs)
 
     @constraints.dependent_property
     def support(self):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -4,7 +4,7 @@ from torch.autograd import Variable
 from torch.distributions import Categorical
 from numbers import Number
 from torch.distributions import constraints
-from torch.distributions.utils import log_sum_exp, broadcast_all
+from torch.distributions.utils import broadcast_all
 
 
 class Multinomial(Distribution):
@@ -47,9 +47,12 @@ class Multinomial(Distribution):
             raise NotImplementedError('inhomogeneous total_count is not supported')
         self.total_count = total_count
         self._categorical = Categorical(probs=probs, logits=logits)
-        batch_shape = probs.size()[:-1] if probs is not None else logits.size()[:-1]
-        event_shape = probs.size()[-1:] if probs is not None else logits.size()[-1:]
+        batch_shape = self._categorical.batch_shape
+        event_shape = self._categorical.param_shape[-1:]
         super(Multinomial, self).__init__(batch_shape, event_shape)
+
+    def new(self, *args, **kwargs):
+        return self._categorical.new(*args, **kwargs)
 
     @constraints.dependent_property
     def support(self):
@@ -62,6 +65,10 @@ class Multinomial(Distribution):
     @property
     def probs(self):
         return self._categorical.probs
+
+    @property
+    def param_shape(self):
+        return self._categorical.param_shape
 
     def sample(self, sample_shape=torch.Size()):
         sample_shape = torch.Size(sample_shape)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -36,8 +36,8 @@ class OneHotCategorical(Distribution):
         event_shape = self._categorical.param_shape[-1:]
         super(OneHotCategorical, self).__init__(batch_shape, event_shape)
 
-    def new(self, *args, **kwargs):
-        return self._categorical.new(*args, **kwargs)
+    def _new(self, *args, **kwargs):
+        return self._categorical._new(*args, **kwargs)
 
     @property
     def param_shape(self):
@@ -61,7 +61,7 @@ class OneHotCategorical(Distribution):
 
     def enumerate_support(self):
         n = self.event_shape[0]
-        values = self._categorical.new((n, n))
+        values = self._new((n, n))
         torch.eye(n, out=values.data if isinstance(values, Variable) else values)
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
         return values.expand((n,) + self.batch_shape + (n,))

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -61,12 +61,7 @@ class OneHotCategorical(Distribution):
 
     def enumerate_support(self):
         n = self.event_shape[0]
-        out = self._categorical.new((n, n))
-        if isinstance(out, Variable):
-            values = Variable(torch.eye(n, out=out.data))
-        else:
-            values = torch.eye(n, out=out)
-        if out.is_cuda:
-            values = values.cuda(out.get_device())
+        values = self._categorical.new((n, n))
+        torch.eye(n, out=values.data if isinstance(values, Variable) else values)
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
         return values.expand((n,) + self.batch_shape + (n,))


### PR DESCRIPTION
This makes a few modifications to ensure that `logits` and `probs` are not accessed by a method unless it needs to. e.g. accessing `probs` on a class that was initialized with `logits` only to get the batch shape or event shape. This affects Categorical, OneHotCategorical, Bernoulli, Binomial and Multinomial. 
 - Added `.new()` methods to these distributions that can help with generating tensors/variables of the right type and placing it on the correct CUDA device.

**Testing:** Added some tests to prevent future regression:
 - `initializing` a distribution with `probs` and calling `sample`, `enumerate_support`, `batch_shape` and `event_shape` should not initialize `logits`.
 - Conversely, `initializing` a distribution with `logits` and calling `log_prob`, `enumerate_support`, `batch_shape` and `event_shape` should not initialize `probs`.