### PR TITLE
Add support for squeeze and unsqueeze with IntList

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "ATen/ATen.h"
 #include "ATen/ExpandUtils.h"
 #include "ATen/NativeFunctions.h"
@@ -164,12 +166,21 @@ inferSqueezeGeometry(const Tensor &tensor) {
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >
-inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
+inferSqueezeGeometry(const Tensor& tensor, const IntList& dim_list) {
+  if (tensor.dim() == 0) {
+    throw std::runtime_error("cannot squeeze tensor without dimensions");
+  }
+
+  std::vector<bool> squeeze_mask(tensor.dim());
+  for (size_t i = 0; i < dim_list.size(); ++i) {
+    const int64_t d = maybe_wrap_dim(dim_list[i], tensor.dim());
+    if (tensor.sizes()[d] == 1) squeeze_mask[d] = true;
+  }
+
   std::vector<int64_t> sizes;
   std::vector<int64_t> strides;
-
   for(int64_t d = 0; d < tensor.dim(); d++) {
-    if(d != dim || tensor.sizes()[dim] != 1) {
+    if (!squeeze_mask[d]) {
       sizes.push_back(tensor.sizes()[d]);
       strides.push_back(tensor.strides()[d]);
     }
@@ -178,17 +189,41 @@ inferSqueezeGeometry(const Tensor& tensor, int64_t dim) {
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >
-inferUnsqueezeGeometry(const Tensor& tensor, int64_t dim) {
+inferUnsqueezeGeometry(const Tensor& tensor, const IntList& dims) {
   if (tensor.numel() == 0) {
     throw std::runtime_error("cannot unsqueeze empty tensor");
   }
 
-  std::vector<int64_t> sizes(tensor.sizes());
-  std::vector<int64_t> strides(tensor.strides());
-  int64_t new_stride = dim >= tensor.dim() - 1 ? 1 : sizes[dim] * strides[dim];
-  sizes.insert(sizes.begin() + dim, 1);
-  strides.insert(strides.begin() + dim, new_stride);
+  // Note the dims could refer to positions outside the dimensionality of the
+  // tensor. E.g., for a tensor of shape {2, 2} dims={2, 3, 4} is valid.
+  // In general, the behavior of unsqueeze is defined by behavior of squeeze
+  // in a sense, that t.unsqeeze(dims).squeeze(dims) must end up in t for all
+  // possible dims.
+  std::vector<bool> unsqueeze_mask(dims.size() + tensor.dim());
+  for (size_t i = 0; i < dims.size(); ++i) {
+    const uint64_t dim = maybe_wrap_dim(dims[i], unsqueeze_mask.size());
+    if (unsqueeze_mask[dim]) {
+      throw std::runtime_error("unsqueeze dims must be unique");
+    }
+    unsqueeze_mask[dim] = true;
+  }
 
+  std::vector<int64_t> sizes, strides;
+  sizes.reserve(unsqueeze_mask.size());
+  strides.reserve(unsqueeze_mask.size());
+  for (size_t i = 0, read_index = 0; i < unsqueeze_mask.size(); ++i) {
+    if (unsqueeze_mask[i]) {
+      sizes.push_back(1);
+      strides.push_back(read_index >= static_cast<size_t>(tensor.dim())
+                            ? 1
+                            : tensor.sizes()[read_index] *
+                                  tensor.strides()[read_index]);
+    } else {
+      sizes.push_back(tensor.sizes()[read_index]);
+      strides.push_back(tensor.strides()[read_index]);
+      ++read_index;
+    }
+  }
   return std::make_tuple(sizes, strides);
 }
 
@@ -197,15 +232,18 @@ Tensor squeeze(const Tensor& self) {
   return self.as_strided(std::get<0>(g), std::get<1>(g));
 }
 
-Tensor squeeze(const Tensor& self, int64_t dim) {
-  int64_t dims = self.dim();
-  dim = maybe_wrap_dim(dim, dims);
-
-  if (dims == 0 || self.sizes()[dim] != 1) {
-    return self.as_strided(self.sizes().vec(), self.strides().vec());
-  }
-  auto g = inferSqueezeGeometry(self, dim);
+Tensor squeeze(const Tensor& self, IntList dims) {
+  if (self.dim() == 0) return self;
+  auto g = inferSqueezeGeometry(self, dims);
   return self.as_strided(std::get<0>(g), std::get<1>(g));
+}
+
+Tensor squeeze(const Tensor& self, int64_t dim) {
+  return at::native::squeeze(self, IntList(&dim, 1));
+}
+
+Tensor & squeeze_(Tensor& self, int64_t dim) {
+  return at::native::squeeze_(self, IntList(&dim, 1));
 }
 
 Tensor & squeeze_(Tensor& self) {
@@ -213,35 +251,33 @@ Tensor & squeeze_(Tensor& self) {
   return self.as_strided_(std::get<0>(g), std::get<1>(g));
 }
 
-Tensor & squeeze_(Tensor& self, int64_t dim) {
-  int64_t dims = self.dim();
-  dim = maybe_wrap_dim(dim, self.dim());
-
-  if (dims == 0 || self.sizes()[dim] != 1) {
-    return self.as_strided_(self.sizes().vec(), self.strides().vec());
-  }
-  auto g = inferSqueezeGeometry(self, dim);
+Tensor & squeeze_(Tensor& self, IntList dims) {
+  if (self.dim() == 0) return self;
+  auto g = inferSqueezeGeometry(self, dims);
   return self.as_strided_(std::get<0>(g), std::get<1>(g));
 }
 
 Tensor unsqueeze(const Tensor& self, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim() + 1);
-
-  auto g = inferUnsqueezeGeometry(self, dim);
-  return self.as_strided(std::get<0>(g), std::get<1>(g));
+  return at::native::unsqueeze(self, IntList(&dim, 1));
 }
 
 Tensor & unsqueeze_(Tensor& self, int64_t dim) {
-  dim = maybe_wrap_dim(dim, self.dim() + 1);
-
-  auto g = inferUnsqueezeGeometry(self, dim);
-  return self.as_strided_(std::get<0>(g), std::get<1>(g));
+  return at::native::unsqueeze_(self, IntList(&dim, 1));
 }
 
+Tensor unsqueeze(const Tensor& self, IntList dims) {
+  auto g = inferUnsqueezeGeometry(self, dims);
+  return self.as_strided(std::get<0>(g), std::get<1>(g));
+}
+
+Tensor & unsqueeze_(Tensor& self, IntList dims) {
+  auto g = inferUnsqueezeGeometry(self, dims);
+  return self.as_strided_(std::get<0>(g), std::get<1>(g));
+}
 
 Tensor view_as(const Tensor& self, const Tensor& other) {
   return self.view(other.sizes());
 }
 
-}
-}
+}  // namespace native
+}  // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -265,7 +265,11 @@
 
 - func: squeeze(Tensor self, int64_t dim) -> Tensor
 
+- func: squeeze(Tensor self, IntList dims) -> Tensor
+
 - func: squeeze_(Tensor self) -> Tensor
+
+- func: squeeze_(Tensor self, IntList dims) -> Tensor
 
 - func: squeeze_(Tensor self, int64_t dim) -> Tensor
 
@@ -282,7 +286,11 @@
 
 - func: unsqueeze(Tensor self, int64_t dim) -> Tensor
 
+- func: unsqueeze(Tensor self, IntList dims) -> Tensor
+
 - func: unsqueeze_(Tensor self, int64_t dim) -> Tensor
+
+- func: unsqueeze_(Tensor self, IntList dims) -> Tensor
 
 - func: view_as(Tensor self, Tensor other) -> Tensor
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -144,16 +144,166 @@ static void test(Type & type) {
 
   {
     std::cout << "squeeze:" << std::endl;
-    Tensor a = type.rand({2, 1});
-    std::cout << a << std::endl;
-    Tensor b = squeeze(a);
-    ASSERT(b.dim() == 1);
-    std::cout << b << std::endl;
-    a = type.rand({1});
-    std::cout << a << std::endl;
-    b = squeeze(a);
-    //TODO 0-dim squeeze
-    std::cout << b << std::endl;
+
+    {
+      const Tensor a = type.rand({2, 1});
+      std::cout << a << std::endl;
+      const Tensor b = squeeze(a);
+      ASSERT(b.dim() == 1);
+      std::cout << b << std::endl;
+    }
+    {
+      const Tensor a = type.rand({2, 1, 2, 1});
+      std::cout << a << std::endl;
+      const Tensor b = squeeze(a, 2);
+      ASSERT(b.dim() == 4);
+      std::cout << b << std::endl;
+    }
+    {
+      const Tensor a = type.rand({1});
+      std::cout << a << std::endl;
+      const Tensor b = squeeze(a);
+      //TODO 0-dim squeeze
+      std::cout << b << std::endl;
+    }
+  }
+
+  {
+    std::cout << "squeeze list:" << std::endl;
+    const Tensor a = type.rand({2, 1, 1});
+    std::cout << "a: " << a << std::endl;
+    {
+      Tensor b = squeeze(a, {1});
+      std::cout << "a.squeze({1}): " << b << std::endl;
+      ASSERT(b.dim() == 2);
+    }
+    {
+      Tensor b = squeeze(a, {1, 2});
+      std::cout << "a.squeze({1, 2}): " << b << std::endl;
+      ASSERT(b.dim() == 1);
+    }
+    {
+      Tensor b = squeeze(a, {1, 0});
+      std::cout << "a.squeze({1, 0}): " << b << std::endl;
+      ASSERT(b.dim() == 2);
+    }
+    {
+      Tensor b = squeeze(a, {1, -1});
+      std::cout << "a.squeze({1, -1}): " << b << std::endl;
+      ASSERT(b.dim() == 1);
+    }
+    {
+      Tensor b = squeeze(a, {});
+      std::cout << "a.squeze({}): " << b << std::endl;
+      ASSERT(b.dim() == 3);
+    }
+  }
+
+  {
+    std::cout << "squeeze list in place:" << std::endl;
+    Tensor a = type.rand({2, 1, 1});
+    std::cout << "a: " << a << std::endl;
+    a.squeeze_({1, 2});
+    std::cout << "a.squeeze_({1, 2}): " << a << std::endl;
+    ASSERT(a.dim() == 1);
+  }
+
+  {
+    std::cout << "unsqueeze:" << std::endl;
+    const Tensor a = type.rand({2, 3});
+    std::cout << "a: " << a << std::endl;
+    {
+      Tensor b = unsqueeze(a, 1);
+      std::cout << "a.unsqueeze(1): " << b << std::endl;
+      ASSERT(b.dim() == 3);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 1);
+      ASSERT(b.sizes()[2] == 3);
+      ASSERT_EQUAL(a, squeeze(b, 1));
+    }
+    {
+      Tensor b = unsqueeze(a, -2);
+      std::cout << "a.unsqueeze(-2): " << b << std::endl;
+      ASSERT(b.dim() == 3);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 1);
+      ASSERT(b.sizes()[2] == 3);
+      ASSERT_EQUAL(a, squeeze(b, -2));
+    }
+  }
+
+  {
+    std::cout << "unsqueeze list:" << std::endl;
+    const Tensor a = type.rand({2, 3, 4});
+    std::cout << "a: " << a << std::endl;
+    {
+      const int64_t dims = 1;
+      Tensor b = unsqueeze(a, dims);
+      std::cout << "a.unsqueeze({1}): " << b << std::endl;
+      ASSERT(b.dim() == 4);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 1);
+      ASSERT(b.sizes()[2] == 3);
+      ASSERT(b.sizes()[3] == 4);
+      ASSERT_EQUAL(a, squeeze(b, dims));
+    }
+    {
+      const int64_t dims[] = {1};
+      Tensor b = unsqueeze(a, dims);
+      std::cout << "a.unsqueeze({1}): " << b << std::endl;
+      ASSERT(b.dim() == 4);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 1);
+      ASSERT(b.sizes()[2] == 3);
+      ASSERT(b.sizes()[3] == 4);
+      ASSERT_EQUAL(a, squeeze(b, dims));
+    }
+    {
+      const int64_t dims[] = {1, 2};
+      Tensor b = unsqueeze(a, dims);
+      std::cout << "a.unsqueeze({1, 2}): " << b << std::endl;
+      ASSERT(b.dim() == 5);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 1);
+      ASSERT(b.sizes()[2] == 1);
+      ASSERT(b.sizes()[3] == 3);
+      ASSERT(b.sizes()[4] == 4);
+      ASSERT_EQUAL(a, squeeze(b, dims));
+    }
+    {
+      const int64_t dims[] = {-2, -1};
+      Tensor b = unsqueeze(a, dims);
+      std::cout << "a.unsqueeze({-2, -1}): " << b << std::endl;
+      ASSERT(b.dim() == 5);
+      ASSERT(b.sizes()[0] == 2);
+      ASSERT(b.sizes()[1] == 3);
+      ASSERT(b.sizes()[2] == 4);
+      ASSERT(b.sizes()[3] == 1);
+      ASSERT(b.sizes()[4] == 1);
+      ASSERT_EQUAL(a, squeeze(b, dims));
+    }
+    {
+      IntList dims({});
+      Tensor b = unsqueeze(a, dims);
+      std::cout << "a.unsqueeze({}): " << b << std::endl;
+      ASSERT(b.dim() == 3);
+      ASSERT_EQUAL(a, squeeze(b, dims));
+    }
+  }
+
+  {
+    std::cout << "unsqueeze list in place:" << std::endl;
+    Tensor a = type.rand({2, 3, 4});
+    std::cout << "a: " << a << std::endl;
+    const int64_t dims[] = {3, 4};
+    a.unsqueeze_(dims);
+    std::cout << "a.unsqueze_({3, 4}): " << a << std::endl;
+    ASSERT(a.dim() == 5);
+    ASSERT(a.sizes()[0] == 2);
+    ASSERT(a.sizes()[1] == 3);
+    ASSERT(a.sizes()[2] == 4);
+    ASSERT(a.sizes()[3] == 1);
+    ASSERT(a.sizes()[4] == 1);
   }
 
   {

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2322,9 +2322,12 @@ method_tests = [
     ('squeeze', (S, 1, S, 1), (1,), '1_dim', [0]),
     ('squeeze', (S, 1, S, 1), (2,), 'not_1_dim', [0]),
     ('squeeze', (1,), (0,), '1d_dim0', [0]),
+    ('squeeze', (S, 1, S, 1), (dont_convert([1, 3]),), 'multi'),
+    ('squeeze', (S, 1, S, 1), (dont_convert([1, 2]),), 'multi_not_1'),
     ('unsqueeze', (S, S, S), (0,), 'first', [0]),
     ('unsqueeze', (S, S, S), (1,), 'middle', [0]),
     ('unsqueeze', (S, S, S), (3,), 'last', [0]),
+    ('unsqueeze', (S, S, S), (dont_convert([0, 1]),), 'multi'),
     ('chunk', (S, S, S), (2,)),
     ('chunk', (S, S, S), (S, 1), 'dim', [1]),
     ('split', (S, S, S), (2,)),
@@ -2487,6 +2490,12 @@ def exclude_tensor_method(name, test_name):
         'test_clamp_min',
         'test_clamp_max',
         'test_slice',
+        'test_squeeze_multi',
+        'test_squeeze_multi_neg0',
+        'test_squeeze_multi_not_1',
+        'test_squeeze_multi_not_1_neg0',
+        'test_unsqueeze_multi',
+        'test_unsqueeze_multi_neg0',
         'test_where',
         'test_where_broadcast_all',
         'test__scalar_sum_scalar_arg',
@@ -2569,6 +2578,13 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
         test_case.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
         test_case.assertTrue(self_variable.size() == self_variable.grad.size())
 
+
+def _create_copy(x):
+    if x is None or isinstance(x, dont_convert):
+        return x
+    return x + 0
+
+
 for test in method_tests:
     name, self_size, args = test[:3]
     basic_test_name = 'test_' + name
@@ -2638,11 +2654,11 @@ for test in method_tests:
                         if not isinstance(output_variable, tuple):
                             output_variable = (output_variable,)
                         inplace_self_variable = deepcopy(self_variable)
-                        inplace_self_variable_copy = tuple(i + 0 if i is not None else None
-                                                           for i in (inplace_self_variable,))
+                        inplace_self_variable_copy = tuple(
+                            [_create_copy(inplace_self_variable)])
                         inplace_args_variable = deepcopy(args_variable)
-                        inplace_args_variable_copy = tuple(i + 0 if i is not None else None
-                                                           for i in inplace_args_variable)
+                        inplace_args_variable_copy = tuple(
+                            map(_create_copy, inplace_args_variable))
 
                         inplace_output_variable = (
                             getattr(inplace_self_variable_copy[0], inplace_name)(*inplace_args_variable_copy))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -554,6 +554,9 @@
 - name: squeeze(Tensor self, int64_t dim)
   self: maybe_unsqueeze(grad, dim, self.size(dim) == 1 && self.sizes().size() != 1)
 
+- name: squeeze(Tensor self, IntList dims)
+  self: maybe_unsqueeze(grad, dims, self)
+
 - name: std(Tensor self, bool unbiased)
   self: var_backward(grad / (result * 2), self, unbiased)
 
@@ -620,6 +623,9 @@
 
 - name: unsqueeze(Tensor self, int64_t dim)
   self: grad.squeeze(dim)
+
+- name: unsqueeze(Tensor self, IntList dims)
+  self: grad.squeeze(dims)
 
 - name: var(Tensor self, bool unbiased)
   self: var_backward(grad, self, unbiased)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -317,6 +317,22 @@ Tensor maybe_unsqueeze(const Tensor & self, int64_t dim, bool unsqueeze) {
   return self;
 }
 
+Tensor maybe_unsqueeze(const Tensor & self, IntList dims, const Tensor & input) {
+  if (input.sizes().size() > 1) {
+    std::vector<int64_t> filtered_dims;
+    for (int64_t dim : dims) {
+      // Have to use input before squeezing.
+      if (input.size(dim) == 1) {
+        filtered_dims.push_back(dim);
+      }
+    }
+    if (!filtered_dims.empty()) {
+      return self.unsqueeze(filtered_dims);
+    }
+  }
+  return self;
+}
+
 variable_list cat_tensors_backward(const Tensor & grad, const std::vector<int64_t> &sizes, int64_t dim) {
   variable_list grad_inputs(sizes.size());
   int64_t accumulate = 0;


### PR DESCRIPTION
Addresses #1951
Adds support a list of dimensions for ATen and torch.Variable.
This commit doesn't add support for a list of indices to torch.Tensor in hope that the later will be replaced with torch.Variable.