### PR TITLE
Fix cuDNN batch norm overload in VariableType for half precision

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3325,6 +3325,15 @@ class TestNN(NNTestCase):
         gradcheck(func, [v])
         gradgradcheck(func, [v])
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDNN, "cuDNN unavailable")
+    def test_batchnorm_cudnn_half(self):
+        input = Variable(torch.rand(2, 3, 2, 2).half().cuda())
+        m = nn.BatchNorm2d(3).float().cuda()
+        output = m(input)
+        output.sum().backward()
+        self.assertEqual(output.type(), input.type())
+
     def test_batchnorm_raises_error_if_running_mean_is_not_same_size_as_input(self):
         input = Variable(torch.rand(2, 10))
         running_var = torch.rand(10)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -71,7 +71,8 @@ DONT_REQUIRE_DERIVATIVE = {
 # concrete type of arguments. Eventually all VariableType functions should only
 # check that arguments are Variables.
 USE_UNPACK_ANY = {
-    'sparse_coo_tensor',
+    'sparse_coo_tensor', 'cudnn_batch_norm', 'cudnn_batch_norm_forward',
+    'cudnn_batch_norm_backward',
 }
 
 METHOD_DECLARATION = CodeTemplate("""\
@@ -442,11 +443,11 @@ def unpack_args(env, declaration):
         return 'Tensor' in arg['dynamic_type']
 
     def get_suffix(dynamic_type, is_nullable):
-        if is_nullable:
+        if use_unpack_any:
+            return '_any' if not is_nullable else '_any_opt'
+        elif is_nullable:
             assert dynamic_type == 'Tensor'
             return '_opt'
-        elif use_unpack_any:
-            return '_any'
         elif dynamic_type == 'IndexTensor':
             return '_long'
         elif dynamic_type == 'BoolTensor':

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -142,10 +142,17 @@ Tensor & VariableType::unpack_any(const Tensor & t, const char * name, int pos) 
 }
 
 Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) const {
-  if(!t.defined()) {
+  if (!t.defined()) {
     return Tensor();
   }
   return unpack(t, name, pos);
+}
+
+Tensor VariableType::unpack_any_opt(const Tensor & t, const char * name, int pos) const {
+  if (!t.defined()) {
+    return Tensor();
+  }
+  return unpack_any(t, name, pos);
 }
 
 std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name, int pos) const {

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -51,6 +51,7 @@ private:
   at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
   at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;
+  at::Tensor unpack_any_opt(const Tensor & t, const char * name, int pos) const;
   std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos) const;
   std::vector<at::Tensor> unpack_idxs(at::TensorList tl, const char *name, int pos) const;
 


### PR DESCRIPTION
cuDNN batch norm uses mixed half/float precision in batch norm. This
changes the overload to only check that the arguments are of
VariableType and does not check their concrete type (scalar/backend).

Fixes #4547