### PR TITLE
Handle sequence lengths correctly when exporting RNNs to ONNX

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2958,9 +2958,11 @@ class TestNN(NNTestCase):
                 grad_hy = torch.randn(num_layers * num_directions, batch, hidden_size)
 
                 if variable_len:
-                    batch_sizes = [7, 5, 5, 2, 1, 1]
-                    input_val = rnn_utils.pack_padded_sequence(input_val, batch_sizes, batch_first=batch_first)
-                    grad_output = rnn_utils.pack_padded_sequence(grad_output, batch_sizes, batch_first=batch_first).data
+                    lengths = [7, 5, 5, 2, 1, 1]
+                    input_val = Variable(input_val)
+                    grad_output = Variable(grad_output)
+                    input_val = rnn_utils.pack_padded_sequence(input_val, lengths, batch_first=batch_first)
+                    grad_output = rnn_utils.pack_padded_sequence(grad_output, lengths, batch_first=batch_first).data
 
                 rnn = module(input_size,
                              hidden_size,

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -288,6 +288,8 @@ def _iter_filter(condition, skip_unknown=False, condition_msg=None):
 
 
 def _unflatten(input, proto):
+    from torch.nn.utils.rnn import PackedSequence
+
     # unflatten a list or tuple input into a nested list/tuple structure
     # specified by proto
     def unflatten_helper(input, proto):
@@ -297,6 +299,8 @@ def _unflatten(input, proto):
         for e in proto:
             res_e, input = unflatten_helper(input, e)
             res.append(res_e)
+        if isinstance(proto, PackedSequence):
+            return PackedSequence(*res), input
         return type(proto)(res), input
 
     return unflatten_helper(input, proto)[0]

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -288,8 +288,6 @@ def _iter_filter(condition, skip_unknown=False, condition_msg=None):
 
 
 def _unflatten(input, proto):
-    from torch.nn.utils.rnn import PackedSequence
-
     # unflatten a list or tuple input into a nested list/tuple structure
     # specified by proto
     def unflatten_helper(input, proto):
@@ -297,10 +295,11 @@ def _unflatten(input, proto):
         if not isinstance(proto, (list, tuple)):
             return input[0], input[1:]
         for e in proto:
-            res_e, input = unflatten_helper(input, e)
-            res.append(res_e)
-        if isinstance(proto, PackedSequence):
-            return PackedSequence(*res), input
+            if e is None:
+                res.append(e)
+            else:
+                res_e, input = unflatten_helper(input, e)
+                res.append(res_e)
         return type(proto)(res), input
 
     return unflatten_helper(input, proto)[0]

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -190,9 +190,10 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
     encodeValueInfo(v, output);
   }
   for (auto node : g->nodes()) {
-    if (node->kind() == kUndefined && !node->hasUses()) {
-      // Undefined nodes never show up in ONNX; they're just a tool
-      // to help symbolics do the right thing.
+    if (node->kind() == kUndefined) {
+      // Undefined nodes are used to implement optional inputs. One
+      // way to "not provide" an optional input is to create an
+      // Undefined node, and pass its output as that input.
       continue;
     }
     auto p_n = p_g->add_node();
@@ -200,7 +201,11 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
       p_n->set_doc_string(node->getSourceLocation()->python_traceback);
     }
     for(auto input : node->inputs()) {
-      p_n->add_input(value_name(input));
+      if (input->node()->kind() == kUndefined) {
+        p_n->add_input("");
+      } else {
+        p_n->add_input(value_name(input));
+      }
     }
     for(auto output : node->outputs()) {
       p_n->add_output(value_name(output));
@@ -243,9 +248,6 @@ void validateGraph(const std::shared_ptr<Graph>& graph) {
       // Expand is not a real ONNX operator yet, reject it
       if (node->kind() == kExpand) {
         FAIL_EXPORT("Couldn't export operator expand; this usually means you used a form of broadcasting that ONNX does not currently support");
-      }
-      if (node->kind() == kUndefined) {
-        FAIL_EXPORT("Couldn't export undefined constant tensor (please file an issue)")
       }
       std::string n = node->kind().toString();
       if (n.size() == 0) {

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -45,6 +45,8 @@ _(value) \
 _(Subgraph) \
 _(BatchNormalization) \
 _(Conv) \
+_(PackPadded) \
+_(PadPacked) \
 _(ConvTranspose) \
 _(is_test) \
 _(epsilon) \
@@ -61,6 +63,9 @@ _(strides) \
 _(stride) \
 _(pads) \
 _(pad) \
+_(RNN) \
+_(LSTM) \
+_(GRU) \
 _(beta) \
 _(alpha) \
 _(dilations) \

--- a/torch/nn/_functions/packing.py
+++ b/torch/nn/_functions/packing.py
@@ -14,7 +14,7 @@ class PackPadded(Function):
 
         steps = []
         batch_sizes = []
-        lengths_iter = reversed(lengths)
+        lengths_iter = reversed(list(lengths))
         batch_size = input.size(1)
 
         if len(lengths) != batch_size:

--- a/torch/nn/_functions/packing.py
+++ b/torch/nn/_functions/packing.py
@@ -14,7 +14,10 @@ class PackPadded(Function):
 
         steps = []
         batch_sizes = []
+
+        # lengths is a Tensor, so we must convert to list before reversed()
         lengths_iter = reversed(list(lengths))
+
         batch_size = input.size(1)
 
         if len(lengths) != batch_size:

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -70,7 +70,7 @@ def StackedRNN(inners, num_layers, lstm=False, dropout=0, train=True):
     num_directions = len(inners)
     total_layers = num_layers * num_directions
 
-    def forward(input, hidden, weight):
+    def forward(input, hidden, weight, batch_sizes):
         assert(len(weight) == total_layers)
         next_hidden = []
 
@@ -82,7 +82,7 @@ def StackedRNN(inners, num_layers, lstm=False, dropout=0, train=True):
             for j, inner in enumerate(inners):
                 l = i * num_directions + j
 
-                hy, output = inner(input, hidden[l], weight[l])
+                hy, output = inner(input, hidden[l], weight[l], batch_sizes)
                 next_hidden.append(hy)
                 all_output.append(output)
 
@@ -107,7 +107,7 @@ def StackedRNN(inners, num_layers, lstm=False, dropout=0, train=True):
 
 
 def Recurrent(inner, reverse=False):
-    def forward(input, hidden, weight):
+    def forward(input, hidden, weight, batch_sizes):
         output = []
         steps = range(input.size(0) - 1, -1, -1) if reverse else range(input.size(0))
         for i in steps:
@@ -124,17 +124,16 @@ def Recurrent(inner, reverse=False):
     return forward
 
 
-def variable_recurrent_factory(batch_sizes):
-    def fac(inner, reverse=False):
-        if reverse:
-            return VariableRecurrentReverse(batch_sizes, inner)
-        else:
-            return VariableRecurrent(batch_sizes, inner)
-    return fac
+def variable_recurrent_factory(inner, reverse=False):
+    if reverse:
+        return VariableRecurrentReverse(inner)
+    else:
+        return VariableRecurrent(inner)
 
 
-def VariableRecurrent(batch_sizes, inner):
-    def forward(input, hidden, weight):
+def VariableRecurrent(inner):
+    def forward(input, hidden, weight, batch_sizes):
+
         output = []
         input_offset = 0
         last_batch_size = batch_sizes[0]
@@ -172,8 +171,8 @@ def VariableRecurrent(batch_sizes, inner):
     return forward
 
 
-def VariableRecurrentReverse(batch_sizes, inner):
-    def forward(input, hidden, weight):
+def VariableRecurrentReverse(inner):
+    def forward(input, hidden, weight, batch_sizes):
         output = []
         input_offset = input.size(0)
         last_batch_size = batch_sizes[-1]
@@ -209,7 +208,7 @@ def VariableRecurrentReverse(batch_sizes, inner):
 
 
 def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
-                dropout=0, train=True, bidirectional=False, batch_sizes=None,
+                dropout=0, train=True, bidirectional=False, variable_length=False,
                 dropout_state=None, flat_weight=None):
 
     if mode == 'RNN_RELU':
@@ -223,10 +222,7 @@ def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
     else:
         raise Exception('Unknown mode: {}'.format(mode))
 
-    if batch_sizes is None:
-        rec_factory = Recurrent
-    else:
-        rec_factory = variable_recurrent_factory(batch_sizes)
+    rec_factory = variable_recurrent_factory if variable_length else Recurrent
 
     if bidirectional:
         layer = (rec_factory(cell), rec_factory(cell, reverse=True))
@@ -239,13 +235,13 @@ def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
                       dropout=dropout,
                       train=train)
 
-    def forward(input, weight, hidden):
-        if batch_first and batch_sizes is None:
+    def forward(input, weight, hidden, batch_sizes):
+        if batch_first and not variable_length:
             input = input.transpose(0, 1)
 
-        nexth, output = func(input, hidden, weight)
+        nexth, output = func(input, hidden, weight, batch_sizes)
 
-        if batch_first and batch_sizes is None:
+        if batch_first and not variable_length:
             output = output.transpose(0, 1)
 
         return output, nexth
@@ -255,7 +251,7 @@ def AutogradRNN(mode, input_size, hidden_size, num_layers=1, batch_first=False,
 
 def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
              batch_first=False, dropout=0, train=True, bidirectional=False,
-             batch_sizes=None, dropout_state=None, flat_weight=None):
+             variable_length=False, dropout_state=None, flat_weight=None):
     if dropout_state is None:
         dropout_state = {}
     mode = cudnn.rnn.get_cudnn_mode(mode)
@@ -266,7 +262,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
                       "at every call, possibly greatly increasing memory usage. "
                       "To compact weights again call flatten_parameters().", stacklevel=5)
 
-    def forward(input, weight, hx):
+    def forward(input, weight, hx, batch_sizes):
         if mode == cudnn.CUDNN_LSTM:
             hx, cx = hx
         else:
@@ -284,7 +280,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
             hx, cx,
             mode, hidden_size, num_layers,
             batch_first, dropout, train, bool(bidirectional),
-            batch_sizes if batch_sizes else (),
+            list(batch_sizes.data) if variable_length else (),
             Variable(dropout_desc.state) if dropout_desc.state is not None else None)
 
         if cx is not None:

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -183,7 +183,8 @@ def VariableRecurrentReverse(batch_sizes, inner):
             hidden = (hidden,)
             initial_hidden = (initial_hidden,)
         hidden = tuple(h[:batch_sizes[-1]] for h in hidden)
-        for batch_size in reversed(batch_sizes):
+        for i in reversed(range(len(batch_sizes))):
+            batch_size = batch_sizes[i]
             inc = batch_size - last_batch_size
             if inc > 0:
                 hidden = tuple(torch.cat((h, ih[last_batch_size:batch_size]), 0)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -118,7 +118,7 @@ class RNNBase(Module):
                     self.input_size, input.size(-1)))
 
         if is_input_packed:
-            mini_batch = batch_sizes[0]
+            mini_batch = int(batch_sizes[0])
         else:
             mini_batch = input.size(0) if self.batch_first else input.size(1)
 
@@ -142,7 +142,7 @@ class RNNBase(Module):
         is_packed = isinstance(input, PackedSequence)
         if is_packed:
             input, batch_sizes = input
-            max_batch_size = batch_sizes[0]
+            max_batch_size = int(batch_sizes[0])
         else:
             batch_sizes = None
             max_batch_size = input.size(0) if self.batch_first else input.size(1)
@@ -174,11 +174,11 @@ class RNNBase(Module):
             dropout=self.dropout,
             train=self.training,
             bidirectional=self.bidirectional,
-            batch_sizes=batch_sizes,
             dropout_state=self.dropout_state,
+            variable_length=is_packed,
             flat_weight=flat_weight
         )
-        output, hidden = func(input, self.all_weights, hx)
+        output, hidden = func(input, self.all_weights, hx, batch_sizes)
         if is_packed:
             output = PackedSequence(output, batch_sizes)
         return output, hidden

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1,6 +1,7 @@
 import torch
 from torch.autograd._functions.utils import check_onnx_broadcast  # TODO: move me
 from torch.nn.modules.utils import _single, _pair, _triple
+from torch.nn.utils.rnn import PackedSequence
 import warnings
 
 import torch.onnx
@@ -113,6 +114,10 @@ _onnx_opset_version = 2
 #     By having the argument name line up with the name of the scalar attribute
 #     if it exists, we can write a single function for both overloads.
 #
+
+# used to represent "missing" optional inputs
+def unused(g):
+    return g.op("Undefined")
 
 
 def add(g, self, other, alpha):
@@ -547,23 +552,19 @@ def reform_weights(g, w, n, intervals):
 
 def Elman_RNN_symbolic_builder(
         nonlinearity, input_size, hidden_size, num_layers, batch_first, dropout, bidirectional, **kwargs):
-    if batch_first:
-        return _unimplemented("RNN", "batch_first")
-    if dropout:
-        return _unimplemented("RNN", "dropout")
-    if bidirectional:
-        return _unimplemented("RNN", "bidirectional")
-
-    def symbolic(g, input, all_weights, h0, **fkwargs):
-        # TODO elide this argument to increase parametricity. This is
-        # nontrivial because we provide subsequent optional arguments,
-        # and ONNX does not have a mechanism for skipping non-trailing
-        # optional arguments.
-        sequence_len, batch_size = input.type().sizes()[0:2]
-        sequence_lens = g.op('Constant', value_t=torch.IntTensor(batch_size).fill_(sequence_len))
+    def symbolic(g, input, all_weights, h0, batch_sizes):
+        if batch_first:
+            return _unimplemented("RNN", "batch_first")
+        if dropout:
+            return _unimplemented("RNN", "dropout")
+        if bidirectional:
+            return _unimplemented("RNN", "bidirectional")
 
         prev_output = input
         h_outs = []
+
+        sequence_lens = unused(g) if batch_sizes is None else batch_sizes
+
         for i in range(num_layers):
             weight_ih, weight_hh, bias_ih, bias_hh = all_weights[i]
 
@@ -579,11 +580,11 @@ def Elman_RNN_symbolic_builder(
         h_outs = h_out if num_layers == 1 else g.op('Concat', *h_outs, axis_i=0)
         return prev_output, h_outs
 
-    return torch.onnx.symbolic_override(symbolic)
+    return symbolic
 
 
 def LSTM_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropout, bidirectional, **kwargs):
-    def symbolic(g, input, all_weights, h0_and_c0, **fkwargs):
+    def symbolic(g, input, all_weights, h0_and_c0, batch_sizes):
         if batch_first:
             return _unimplemented("LSTM", "batch_first")
         if dropout:
@@ -593,15 +594,11 @@ def LSTM_symbolic_builder(input_size, hidden_size, num_layers, batch_first, drop
 
         h0, c0 = h0_and_c0
 
-        # TODO elide this argument to increase parametricity. This is
-        # nontrivial because we provide subsequent optional arguments,
-        # and ONNX does not have a mechanism for skipping non-trailing
-        # optional arguments.
-        sequence_len, batch_size = input.type().sizes()[0:2]
-        sequence_lens = g.op('Constant', value_t=torch.IntTensor(batch_size).fill_(sequence_len))
-
         prev_output = input
         h_outs = []
+
+        sequence_lens = unused(g) if batch_sizes is None else batch_sizes
+
         for i in range(num_layers):
             # pytorch is input, forget, cell, output.
             # onnx is    input, output, forget, cell.
@@ -623,7 +620,7 @@ def LSTM_symbolic_builder(input_size, hidden_size, num_layers, batch_first, drop
 
 
 def GRU_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropout, bidirectional, **kwargs):
-    def symbolic(g, input, all_weights, h0, **fkwargs):
+    def symbolic(g, input, all_weights, h0, batch_sizes):
         if batch_first:
             return _unimplemented("GRU", "batch_first")
         if dropout:
@@ -631,15 +628,11 @@ def GRU_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropo
         if bidirectional:
             return _unimplemented("GRU", "bidirectional")
 
-        # TODO elide this argument to increase parametricity. This is
-        # nontrivial because we provide subsequent optional arguments,
-        # and ONNX does not have a mechanism for skipping non-trailing
-        # optional arguments.
-        sequence_len, batch_size = input.type().sizes()[0:2]
-        sequence_lens = g.op('Constant', value_t=torch.IntTensor(batch_size).fill_(sequence_len))
-
         prev_output = input
         h_outs = []
+
+        sequence_lens = unused(g) if batch_sizes is None else batch_sizes
+
         for i in range(num_layers):
             # pytorch is reset, input, hidden
             # onnx is    input, reset, hidden


### PR DESCRIPTION
PackedSequence: store batch_sizes as tensor rather 
than converting to a list of python integers. This maintains
the invariant that module's inputs/outputs are collections of
Variables.

In particular, this causes the JIT to no longer choke when flattening
and unflattening arguments.

--------------

- when uniform sequence lengths are provided, correctly omit the
  argument when constructing the ONNX graph, so as to not fix the
  graph to the batch size.

- handle PackedSequences by floating them through the graph and
  eliminating them in an optimization pass. ONNX does not have packed
  sequences, but operates on a representation equivalent to
  PaddedSequence, so we hide the representation-switching from ONNX

- as a preliminary step towards handling PackedSequences, not directly
  tied to ONNX export, change batch_sizes from being an argument to
  the RNN operators into being an argument to the forward() function
  of those RNN operators. This more closely models the reality that
  batch_sizes are effectively part of the input sequences.