### PR TITLE
Add proper scalar checks to functions bound by nn.yaml.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1052,14 +1052,18 @@ def create_derived(backend_type_env, declarations):
             arguments = [option['arguments'][argi]
                          for argi in arguments_indices]
             if scalar_check is not None:
-                if len(arguments) > 1:
-                    body.append("bool maybe_scalar = {};".format(scalar_check))
-                    scalar_check = 'maybe_scalar'
+                if not isinstance(scalar_check, dict):
+                    if len(arguments) > 1:
+                        body.append("bool maybe_scalar = {};".format(scalar_check))
+                        scalar_check = 'maybe_scalar'
                 for arg in arguments:
-                    stmt = "{}_->maybeScalar({});".format(arg['name'], scalar_check)
-                    if nullable_argument(arg):
-                        stmt = "if ({}_) {}".format(arg['name'], stmt)
-                    body.append(stmt)
+                    scalar_check_arg = (scalar_check if not isinstance(scalar_check, dict)
+                                        else scalar_check.get(arg['name']))
+                    if scalar_check_arg is not None:
+                        stmt = "{}_->maybeScalar({});".format(arg['name'], scalar_check_arg)
+                        if nullable_argument(arg):
+                            stmt = "if ({}_) {}".format(arg['name'], stmt)
+                        body.append(stmt)
             if len(arguments_indices) == 1:
                 arg = arguments[0]
                 body.append("return {};".format(arg['name']))

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -2,91 +2,142 @@
 
 - name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight={}, bool size_average=true, bool reduce=true)
   cname: BCECriterion
+  scalar_check:
+    output: 'true'
 
 - name: kl_div(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: DistKLDivCriterion
+  scalar_check:
+    output: 'true'
 
 - name: l1_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=True)
   cname: AbsCriterion
+  scalar_check:
+    output: 'true'
 
 - name: mse_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: MSECriterion
+  scalar_check:
+    output: 'true'
 
 - name: multi_margin_loss(Tensor self, LongTensor target, Scalar p=1, Scalar margin=1, Tensor weight={}, bool size_average=true)
   cname: MultiMarginCriterion
+  scalar_check:
+    output: 'true'
 
 - name: multilabel_margin_loss(Tensor self, LongTensor target, bool size_average=true)
   cname: MultiLabelMarginCriterion
   buffers: [is_target]
+  scalar_check:
+    output: 'true'
+    is_target: target_->isScalar()
 
 - name: nll_loss(Tensor self, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100, bool reduce=True)
   cname: ClassNLLCriterion
   buffers: [total_weight]
+  scalar_check:
+    output: 'true'
+    total_weight: 'true'
 
 - name: nll_loss2d(Tensor self, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100, bool reduce=True)
   cname: SpatialClassNLLCriterion
   buffers: [total_weight]
+  scalar_check:
+    output: 'true'
+    total_weight: 'true'
 
 - name: smooth_l1_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: SmoothL1Criterion
+  scalar_check:
+    output: 'true'
 
 - name: soft_margin_loss(Tensor self, Tensor target, bool size_average=true)
   cname: SoftMarginCriterion
+  scalar_check:
+    output: 'true'
 
 # Activation functions
 
 - name: elu(Tensor self, Scalar alpha=1, Scalar scale=1)
   cname: ELU
   has_inplace: True
+  scalar_check:
+    output: self_->isScalar()
+    grad_input: output_->isScalar()
 
 - name: glu(Tensor self, int64_t dim=-1)
   cname: GatedLinear
   wrap_dim:
     dim: self
+  scalar_check:
+    output: 'false'
 
 - name: hardshrink(Tensor self, Scalar lambd=0.5)
   cname: HardShrink
+  scalar_check:
+    output: self_->isScalar()
 
 - name: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1)
   cname: HardTanh
   has_inplace: True
+  scalar_check:
+    output: self_->isScalar()
 
 - name: leaky_relu(Tensor self, Scalar negative_slope=0.01)
   cname: LeakyReLU
   has_inplace: True
+  scalar_check:
+    output: self_->isScalar()
 
 - name: log_sigmoid(Tensor self)
   cname: LogSigmoid
   buffers: [buffer]
+  scalar_check:
+    output: self_->isScalar()
+    buffer: self_->isScalar()
 
 - name: log_softmax(Tensor self, int64_t dim)
   cname: LogSoftMax
   wrap_dim:
     dim: self
+  scalar_check:
+    output: self_->isScalar()
 
 - name: prelu(Tensor self, Tensor weight)
   cname: PReLU
+  scalar_check:
+    output: self_->isScalar()
 
 # NOTE: we treat noise as an input (it's really a buffer) because the codegen
 # can't handle in-place functions that have buffers
 - name: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=false, Generator* generator=nullptr)
   cname: RReLU
   has_inplace: True
+  scalar_check:
+    output: self_->isScalar()
 
 - name: softmax(Tensor self, int64_t dim)
   cname: SoftMax
   wrap_dim:
     dim: self
+  scalar_check:
+    output: self_->isScalar()
 
 - name: softplus(Tensor self, Scalar beta=1, Scalar threshold=20)
   cname: SoftPlus
+  scalar_check:
+    output: self_->isScalar()
 
 - name: softshrink(Tensor self, Scalar lambd=0.5)
   cname: SoftShrink
+  scalar_check:
+    output: self_->isScalar()
 
 - name: threshold(Tensor self, Scalar threshold, Scalar value)
   cname: Threshold
   has_inplace: True
+  scalar_check:
+    output: self_->isScalar()
 
 # Pooling
 
@@ -114,6 +165,8 @@
 
 - name: fractional_max_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] output_size, Tensor random_samples)
   cname: SpatialFractionalMaxPooling
+  scalar_check:
+    output: 'false'
 
 - name: max_pool2d(Tensor self, IntList[2] kernel_size, IntList[2] stride={}, IntList[2] padding=0, IntList[2] dilation=1, bool ceil_mode=false)
   cname: SpatialDilatedMaxPooling
@@ -155,12 +208,18 @@
 
 - name: upsample_linear1d(Tensor self, IntList[1] output_size)
   cname: TemporalUpSamplingLinear
+  scalar_check:
+    grad_input: 'false'
 
 - name: upsample_bilinear2d(Tensor self, IntList[2] output_size)
   cname: SpatialUpSamplingBilinear
+  scalar_check:
+    grad_input: 'false'
 
 - name: upsample_trilinear3d(Tensor self, IntList[3] output_size)
   cname: VolumetricUpSamplingTrilinear
+  scalar_check:
+    grad_input: 'false'
 
 - name: upsample_nearest1d(Tensor self, int64_t scale_factor)
   cname: TemporalUpSamplingNearest
@@ -177,9 +236,15 @@
 
 - name: _sigmoid(Tensor self)
   cname: Sigmoid
+  scalar_check:
+    output: self_->isScalar()
+    grad_input: output_->isScalar()
 
 - name: _tanh(Tensor self)
   cname: Tanh
+  scalar_check:
+    output: self_->isScalar()
+    grad_input: output_->isScalar()
 
 # Batch normalization
 

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -3,22 +3,22 @@
 - name: binary_cross_entropy(Tensor self, Tensor target, Tensor weight={}, bool size_average=true, bool reduce=true)
   cname: BCECriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: kl_div(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: DistKLDivCriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: l1_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=True)
   cname: AbsCriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: mse_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: MSECriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: multi_margin_loss(Tensor self, LongTensor target, Scalar p=1, Scalar margin=1, Tensor weight={}, bool size_average=true)
   cname: MultiMarginCriterion
@@ -36,20 +36,20 @@
   cname: ClassNLLCriterion
   buffers: [total_weight]
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
     total_weight: 'true'
 
 - name: nll_loss2d(Tensor self, LongTensor target, Tensor weight={}, bool size_average=true, int64_t ignore_index=-100, bool reduce=True)
   cname: SpatialClassNLLCriterion
   buffers: [total_weight]
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
     total_weight: 'true'
 
 - name: smooth_l1_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: SmoothL1Criterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: soft_margin_loss(Tensor self, Tensor target, bool size_average=true)
   cname: SoftMarginCriterion


### PR DESCRIPTION
By default, the forward functions use the default ATen scalar checks and the backward functions
use x_->isScalar() for grad_x (with grad_input mapping to self).

These can also be overridden by specifying a dict of arg_name -> scalar_check.

If the argument is not overridden and the default mapping cannot work (because x for grad_x is not
passed to the backward), an error is raised and the scalar_check must be explicitly specified.