### PR TITLE
adds reduce argument to BCEWithLogitsLoss interface

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3254,6 +3254,9 @@ class TestNN(NNTestCase):
 
         self.assertEqual(nn.BCEWithLogitsLoss()(output, target), nn.BCELoss()(sigmoid(output), target))
 
+        self.assertEqual(nn.BCEWithLogitsLoss(reduce=False)(output, target),
+                         nn.BCELoss(reduce=False)(sigmoid(output), target))
+
         weight = torch.FloatTensor(1).uniform_()
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
 
@@ -4341,6 +4344,7 @@ def bceloss_weights_no_reduce_test():
         reference_fn=lambda i, m: -(t * i.log() + (1 - t) * (1 - i).log()) * weights,
         check_gradgrad=False,
         pickle=False)
+
 
 def bce_with_logistic_no_reduce_test():
     t = torch.randn(15, 10).gt(0).double()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4342,6 +4342,18 @@ def bceloss_weights_no_reduce_test():
         check_gradgrad=False,
         pickle=False)
 
+def bce_with_logistic_no_reduce_test():
+    t = torch.randn(15, 10).gt(0).double()
+    sigmoid = nn.Sigmoid()
+    return dict(
+        fullname='BCEWithLogitsLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.binary_cross_entropy_with_logits(i, Variable(t.type_as(i.data)), reduce=False)),
+        input_fn=lambda: torch.rand(15, 10).clamp_(2.8e-2, 1 - 2.8e-2),
+        reference_fn=lambda i, m: -(t * sigmoid(i).log() + (1 - t) * (1 - sigmoid(i)).log()),
+        check_gradgrad=False,
+        pickle=False)
+
 
 def kldivloss_no_reduce_test():
     t = Variable(torch.randn(10, 10))
@@ -4559,6 +4571,7 @@ new_module_tests = [
     poissonnllloss_no_reduce_test(),
     bceloss_no_reduce_test(),
     bceloss_weights_no_reduce_test(),
+    bce_with_logistic_no_reduce_test(),
     kldivloss_no_reduce_test(),
     l1loss_no_reduce_test(),
     mseloss_no_reduce_test(),

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -470,6 +470,10 @@ class BCEWithLogitsLoss(Module):
             over observations for each minibatch. However, if the field
             size_average is set to ``False``, the losses are instead summed for
             each minibatch. Default: ``True``
+        reduce (bool, optional): By default, the losses are averaged or summed over
+            observations for each minibatch depending on size_average. When reduce
+            is False, returns a loss per batch element instead and ignores
+            size_average. Default: True
 
      Shape:
          - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -484,16 +488,19 @@ class BCEWithLogitsLoss(Module):
          >>> output = loss(input, target)
          >>> output.backward()
     """
-    def __init__(self, weight=None, size_average=True):
+    def __init__(self, weight=None, size_average=True, reduce=True):
         super(BCEWithLogitsLoss, self).__init__()
         self.size_average = size_average
+        self.reduce = reduce
         self.register_buffer('weight', weight)
 
     def forward(self, input, target):
         if self.weight is not None:
-            return F.binary_cross_entropy_with_logits(input, target, Variable(self.weight), self.size_average)
+            return F.binary_cross_entropy_with_logits(input, target,
+                    Variable(self.weight), self.size_average, reduce=self.reduce)
         else:
-            return F.binary_cross_entropy_with_logits(input, target, size_average=self.size_average)
+            return F.binary_cross_entropy_with_logits(input, target,
+                           size_average=self.size_average, reduce=self.reduce)
 
 
 class HingeEmbeddingLoss(_Loss):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -497,10 +497,13 @@ class BCEWithLogitsLoss(Module):
     def forward(self, input, target):
         if self.weight is not None:
             return F.binary_cross_entropy_with_logits(input, target,
-                    Variable(self.weight), self.size_average, reduce=self.reduce)
+                                                      Variable(self.weight),
+                                                      self.size_average,
+                                                      reduce=self.reduce)
         else:
             return F.binary_cross_entropy_with_logits(input, target,
-                           size_average=self.size_average, reduce=self.reduce)
+                                                      size_average=self.size_average,
+                                                      reduce=self.reduce)
 
 
 class HingeEmbeddingLoss(_Loss):


### PR DESCRIPTION
Adds the missing `reduce` argument for the BCEWithLogitsLoss module
so that it matches the functional interface.