### PR TITLE
Remove setting coalesce to 0 in sparse transpose_

### DIFF
--- a/aten/src/THCS/generic/THCSTensor.cu
+++ b/aten/src/THCS/generic/THCSTensor.cu
@@ -220,7 +220,6 @@ void THCSTensor_(transpose)(THCState *state, THCSTensor *self, int d1, int d2) {
   int64_t i = self->size[d1];
   self->size[d1] = self->size[d2];
   self->size[d2] = i;
-  self->coalesced = 0;
   THCIndexTensor_(free)(state, indices);
   THCIndexTensor_(free)(state, buffer);
   THCIndexTensor_(free)(state, slice1);

--- a/aten/src/THS/generic/THSTensor.c
+++ b/aten/src/THS/generic/THSTensor.c
@@ -344,7 +344,6 @@ void THSTensor_(transpose)(THSTensor *self, int d1, int d2) {
   i = self->size[d1];
   self->size[d1] = self->size[d2];
   self->size[d2] = i;
-  self->coalesced = 0;
   THLongTensor_free(indices);
 }
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -328,6 +328,29 @@ class TestSparse(TestCase):
             y = y.transpose(i, j)
             self.assertEqual(self.safeToDense(x), y)
 
+    def test_transpose_coalesce_invariant(self):
+        # If a sparse tensor is coalesced, its transpose should be the same
+        # If a sparse tensor is uncoalesed, its transpose should be the same
+        x_coalesced = self._gen_sparse(2, 3, 4)[0].coalesce()
+        x_indices = x_coalesced._indices()
+        x_values = x_coalesced._values()
+
+        y_uncoalesced = self.SparseTensor(
+            torch.cat([x_indices, x_indices], dim=1),
+            torch.cat([x_values, x_values]),
+            x_coalesced.size())
+
+        self.assertTrue(x_coalesced.is_coalesced())
+        self.assertFalse(y_uncoalesced.is_coalesced())
+
+        self.assertTrue(x_coalesced.transpose(0, 1).is_coalesced())
+        self.assertFalse(y_uncoalesced.transpose(0, 1).is_coalesced())
+
+        x_coalesced.transpose_(0, 1)
+        y_uncoalesced.transpose_(0, 1)
+        self.assertTrue(x_coalesced.is_coalesced())
+        self.assertFalse(y_uncoalesced.is_coalesced())
+
     @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk):


### PR DESCRIPTION
`coalesced` means that the sparse tensor's `indices` are all unique. 

Let's say we transpose a sparse tensor in dimensions `d0, d1`. Let's say each index is some `x_i = (y_1, y_2, ..., y_n)` where `n` is the total number of dimensions of the sparse tensor. Transposing the sparse tensor in place is equivalent to swapping `y_{d0}, y_{d1}` for all indices `x_i`. 

If all the indices were unique before, then they will be unique after. If they were non-unique before, they will be non-unique after. 

This change removes setting `coalesced` to 0 after every transpose. In practice it doesn't affect very much but it's good for correctness.

### Test Plan
run tests