### PR TITLE
Move repeat to torch/_utils.py

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -1,7 +1,6 @@
 import math
 import torch
 from functools import reduce
-from ._utils import _range
 from sys import float_info
 
 
@@ -159,7 +158,7 @@ def _tensor_str(self):
     while True:
         nrestarted = [False for i in counter]
         nskipped = [False for i in counter]
-        for i in _range(counter_dim - 1, -1, -1):
+        for i in range(counter_dim - 1, -1, -1):
             counter[i] += 1
             if print_dots and counter[i] == n and self.size(i) > 2 * n:
                 counter[i] = self.size(i) - n
@@ -230,7 +229,7 @@ def _matrix_str(self, indent='', formatter=None, force_truncate=False):
                     firstColumn, lastColumn, indent)
             if scale != 1:
                 strt += SCALE_FORMAT.format(scale)
-            for l in _range(self.size(0)):
+            for l in range(self.size(0)):
                 strt += indent + (' ' if scale != 1 else '')
                 row_slice = self[l, firstColumn:lastColumn + 1]
                 strt += ' '.join(fmt.format(val / scale) for val in row_slice)

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -1,8 +1,7 @@
 from functools import reduce
 import torch
-
+import torch._utils
 from ..function import Function
-from ..variable import Variable
 
 
 class Type(Function):
@@ -56,7 +55,7 @@ class Repeat(Function):
     def forward(ctx, input, repeats):
         ctx.repeats = repeats
         ctx.input_dims = input.dim()
-        return input.repeat(repeats)
+        return torch._utils._repeat(input, repeats)
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1,5 +1,4 @@
 import torch
-from ._utils import _range
 from operator import mul
 from functools import reduce
 import math
@@ -38,7 +37,7 @@ def split(tensor, split_size_or_sections, dim=0):
         def get_split_size(i):
             return split_size if i < num_splits - 1 else last_split_size
         return tuple(tensor.narrow(int(dim), int(i * split_size), int(get_split_size(i))) for i
-                     in _range(0, num_splits))
+                     in range(0, num_splits))
 
     else:
         if dim_size != sum(split_size_or_sections):
@@ -95,7 +94,7 @@ def unbind(tensor, dim=0):
         tensor (Tensor): the tensor to unbind
         dim (int): dimension to remove
     """
-    return tuple(tensor.select(dim, i) for i in _range(tensor.size(dim)))
+    return tuple(tensor.select(dim, i) for i in range(tensor.size(dim)))
 
 
 def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -1,5 +1,5 @@
 import torch
-from ._utils import _type, _cuda, _range
+from ._utils import _type, _cuda
 
 
 class _StorageBase(object):
@@ -7,14 +7,14 @@ class _StorageBase(object):
     is_sparse = False
 
     def __str__(self):
-        content = ' ' + '\n '.join(str(self[i]) for i in _range(len(self)))
+        content = ' ' + '\n '.join(str(self[i]) for i in range(len(self)))
         return content + '\n[{} of size {}]'.format(torch.typename(self), len(self))
 
     def __repr__(self):
         return str(self)
 
     def __iter__(self):
-        return iter(map(lambda i: self[i], _range(self.size())))
+        return iter(map(lambda i: self[i], range(self.size())))
 
     def __copy__(self):
         return self.clone()


### PR DESCRIPTION
This moves the implementation of repeat to _utils so that the autograd
function can call it directly instead of relying on forward being called
on tensors.

This also removes _range, which was previously necessary because we
shadowed the built-in range() function.