### PR TITLE
Make Symbol a true struct

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -127,7 +127,7 @@ if (jit::tracer::isTracing( ${tensor_args} )) {
 """)
 
 RECORD_ATTRIBUTE = CodeTemplate("""\
-setattr(n, jit::stringToSymbol("${name}"), ${name});""")
+setattr(n, jit::Symbol("${name}"), ${name});""")
 
 
 def gen_variable_type(out, aten_declarations):

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -27,7 +27,7 @@ TYPE_CASTS = {
 }
 
 ATTR_ASSIGNMENT = CodeTemplate("""\
-auto ${name} = ${type_cast}(node->${method}(stringToSymbol("${name}")));\
+auto ${name} = ${type_cast}(node->${method}(Symbol("${name}")));\
 """)
 
 CALL_NAMESPACE = CodeTemplate("at::${name}(${args})")

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -121,12 +121,12 @@ std::unordered_map<std::string, operator_constructor> constructors = {
 
 std::string getDescriptor(jit::Node* n) {
   std::stringstream s;
-  s << symbolToString(n->kind());
+  s << n->kind().toString();
   if (tensor_vararg_fns.count(n->kind()) == 0)
     s << "-" << n->inputs().size();
   else
     s << "-*";
-  std::vector<const char*> attr_names = fmap(n->attributeNames(), &symbolToString);
+  std::vector<const char*> attr_names = fmap(n->attributeNames(), [](Symbol x) { return x.toString(); });
   std::sort(attr_names.begin(), attr_names.end(), [](const char *a, const char *b) {
     return std::strcmp(a, b) < 0;
   });

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -171,7 +171,7 @@ private:
       return v->name == name;
     });
     if(required && it == values_.end()) {
-      ::torch::barf("%s:%u: %s: required undefined attribute '%s'", __FILE__, __LINE__, __func__, symbolToString(name));
+      ::torch::barf("%s:%u: %s: required undefined attribute '%s'", __FILE__, __LINE__, __func__, name.toString());
     }
     JIT_ASSERT(!required || it != values_.end());
     return it;

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -75,7 +75,7 @@ void encodeTensor(onnx::TensorProto * p, const at::Tensor & tensor) {
 
 void addAttribute(onnx::NodeProto * n_p, jit::Node * n, jit::Symbol name) {
   auto attr = n_p->add_attribute();
-  attr->set_name(jit::symbolToString(name));
+  attr->set_name(name.toString());
   switch(n->kindOf(name)) {
     case AttributeKind::f:
       attr->set_f(n->f(name));
@@ -205,7 +205,7 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
     for(auto output : node->outputs()) {
       p_n->add_output(value_name(output));
     }
-    p_n->set_op_type(symbolToString(node->kind()));
+    p_n->set_op_type(node->kind().toString());
     for(auto attr_name : node->attributeNames()) {
       addAttribute(p_n, node, attr_name);
     }
@@ -247,7 +247,7 @@ void validateGraph(const std::shared_ptr<Graph>& graph) {
       if (it->kind() == kUndefined) {
         FAIL_EXPORT("Couldn't export undefined constant tensor (please file an issue)")
       }
-      std::string n = symbolToString(it->kind());
+      std::string n = it->kind().toString();
       if (n.size() == 0) {
         FAIL_EXPORT("Operator to export had empty name (please file an issue)")
       }

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -235,7 +235,7 @@ std::string encodeRHS(Node * n) {
     if(n->kindOf(a) == AttributeKind::t) {
       auto v = n->t(a);
       if(v.dim() == 0) {
-        env.s(symbolToString(a), scalarValue(v));
+        env.s(a.toString(), scalarValue(v));
       }
     }
   }

--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -17,12 +17,12 @@ struct InternedStrings {
     FORALL_BUILTIN_SYMBOLS(REGISTER_SYMBOL)
     #undef REGISTER_SYMBOL
   }
-  Symbol symbol(const std::string & s) {
+  uint32_t symbol(const std::string & s) {
     std::lock_guard<std::mutex> guard(mutex_);
     auto it = string_to_sym_.find(s);
     if(it != string_to_sym_.end())
       return it->second;
-    Symbol k = next_sym++;
+    uint32_t k = next_sym++;
     string_to_sym_[s] = k;
     sym_to_string_[k] = s;
     return k;
@@ -48,9 +48,9 @@ private:
     JIT_ASSERT(it != sym_to_string_.end());
     return it->second.c_str();
   }
-  std::unordered_map<std::string, Symbol> string_to_sym_;
-  std::unordered_map<Symbol, std::string> sym_to_string_;
-  Symbol next_sym;
+  std::unordered_map<std::string, uint32_t> string_to_sym_;
+  std::unordered_map<uint32_t, std::string> sym_to_string_;
+  uint32_t next_sym;
   std::mutex mutex_;
 };
 
@@ -59,11 +59,12 @@ static InternedStrings & globalStrings() {
   return s;
 }
 
-const char * symbolToString(Symbol s) {
-  return globalStrings().string(s);
+const char * Symbol::toString() const {
+  return globalStrings().string(*this);
 }
-Symbol stringToSymbol(const std::string & s) {
-  return globalStrings().symbol(s);
+
+Symbol::Symbol(const std::string & s)
+: value(globalStrings().symbol(s)) {
 }
 
 }}

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -150,7 +150,7 @@ void printAttributes(std::ostream & out, const Node * n) {
   for(auto name : names) {
     if(i++ > 0)
       out << ", ";
-    out << symbolToString(name) <<"=";
+    out << name.toString() <<"=";
     switch(n->kindOf(name)) {
       case AttributeKind::f:
         out << n->f(name);
@@ -234,7 +234,7 @@ std::ostream& printNode(std::ostream & out, const Node * n, std::vector<const No
   IR_ELSEIFM_CONST(CppOp)
     out << "CppOp[" << value->name() << "]";
   IR_ELSE()
-    out << symbolToString(n->kind());
+    out << n->kind().toString();
     if(n->hasAttributes()) {
       printAttributes(out,n);
     }

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -84,7 +84,7 @@ private:
   std::vector<std::unique_ptr<Scope> > children_;
 public:
   Scope() {
-    name_ = stringToSymbol("");
+    name_ = Symbol("");
     parent_ = NULL;
   }
   Scope(Scope* parent, Symbol name) {
@@ -115,13 +115,13 @@ public:
     return name_;
   }
   std::string namesFromRoot(const std::string& separator="/") {
-    std::string out = std::string(symbolToString(this->name_));
+    std::string out = this->name_.toString();
     if (this->isRoot()) {
       return out;
     }
     Scope* parent = this->parent_;
     while (!parent->isRoot()) {
-      out = std::string(symbolToString(parent->name_)) + separator + out;
+      out = std::string(parent->name_.toString()) + separator + out;
       parent = parent->parent_;
     }
     return out;
@@ -545,7 +545,7 @@ public:
   }
   template<typename T>
   T* expect() {
-    JIT_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", symbolToString(T::Kind), symbolToString(kind()));
+    JIT_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", Symbol(T::Kind).toString(), kind().toString());
     return static_cast<T*>(this);
   }
 
@@ -703,7 +703,7 @@ public:
     return output_;
   }
   void push_scope(const std::string& scope_name) {
-    current_scope_ = current_scope_->push(stringToSymbol(scope_name));
+    current_scope_ = current_scope_->push(Symbol(scope_name));
   }
   void pop_scope() {
     current_scope_ = current_scope_->parent();
@@ -969,7 +969,7 @@ std::ostream& operator<<(std::ostream & out, const Node & t);
 
  // execute a Python function, used for Ops we can't optimize but that we want to optimize around
 struct PythonOp : public Node {
-  static const NodeKind Kind = kPythonOp;
+  static const BuiltinSymbol Kind = kPythonOp;
   PythonOp(Graph * graph)
   : Node(graph,kPythonOp) {}
   PythonOp* init(THPObjectPtr&& pyobj, const std::string & cconv, bool is_legacy, std::vector<VariableFlags> && var_flags, pyobj_list&& scalar_args) {
@@ -1010,7 +1010,7 @@ inline Node * Graph::createPythonOp(THPObjectPtr&& pyobj, const std::string & cc
 // A Cpp operator is an operator which dispatches directly to an autograd function.
 // TODO: These are not executable without reentrant engine.
 struct CppOp : public Node {
-  static const NodeKind Kind = kCppOp;
+  static const BuiltinSymbol Kind = kCppOp;
   CppOp(Graph * g)
   : Node(g,kCppOp) {}
   std::shared_ptr<torch::autograd::Function> fn;

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -154,7 +154,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
 
     py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
-    processSymbolicOutput(symbolToString(n->kind()), n, raw_output);
+    processSymbolicOutput(n->kind().toString(), n, raw_output);
   };
 
   auto callPySymbolicMethod = [&](PythonOp* op) {

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -58,7 +58,7 @@ public:
 
   bool load(handle src, bool) {
     try {
-      value = torch::jit::stringToSymbol(py::cast<std::string>(src));
+      value = torch::jit::Symbol(py::cast<std::string>(src));
     } catch (std::exception& e) {
       return false;
     }
@@ -66,7 +66,7 @@ public:
   }
 
   static handle cast(torch::jit::Symbol src, return_value_policy /* policy */, handle /* parent */) {
-    return py::cast(std::string(torch::jit::symbolToString(src)), return_value_policy::copy).release();
+    return py::cast(std::string(src.toString()), return_value_policy::copy).release();
   }
 };
 
@@ -95,4 +95,3 @@ template<> struct type_caster<std::vector<torch::jit::Node *>> : ListCasterBase 
 };
 
 }} // namespace pybind11::detail
-

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -37,16 +37,16 @@ void initPythonIRBindings(PyObject * module_) {
     .GS(eraseInput)
     .GS(registerOutput)
     .def("create",[](Graph & g, const char * str) {
-      return g.create(stringToSymbol(str));
+      return g.create(Symbol(str));
     })
     .def("create",[](Graph & g, const char * str, size_t noutputs) {
-      return g.create(stringToSymbol(str), noutputs);
+      return g.create(Symbol(str), noutputs);
     })
     .def("create",[](Graph & g, const char * str, const std::vector<Value*> & inputs) {
-      return g.create(stringToSymbol(str),inputs);
+      return g.create(Symbol(str),inputs);
     })
     .def("create",[](Graph & g, const char * str, const std::vector<Value*> & inputs, size_t noutputs) {
-      return g.create(stringToSymbol(str),inputs, noutputs);
+      return g.create(Symbol(str),inputs, noutputs);
     })
     .GS(createConstant)
     .GS(createFusionGroup)
@@ -146,10 +146,10 @@ void initPythonIRBindings(PyObject * module_) {
 #undef AS
 #define CREATE_ACCESSOR(Kind,method) \
     def(#method "_",[](Node & n, const char * name, Kind##Attr::ValueType v) { \
-      return n . method ## _(stringToSymbol(name), std::move(v)); \
+      return n . method ## _(Symbol(name), std::move(v)); \
     }) \
     .def(#method, [](Node & n, const char * name) { \
-      return n.method(stringToSymbol(name)); \
+      return n.method(Symbol(name)); \
     })
     .CREATE_ACCESSOR(Float,f)
     .CREATE_ACCESSOR(Floats,fs)
@@ -163,19 +163,19 @@ void initPythonIRBindings(PyObject * module_) {
     .CREATE_ACCESSOR(Graphs,gs)
 #undef CREATE_ACCESSOR
     .def("z_",[](Node & n, const char * name, at::Tensor v) {
-        return n.t_(stringToSymbol(name), std::move(v.view({})));
+        return n.t_(Symbol(name), std::move(v.view({})));
     })
     .def("z",[](Node & n, const char * name) {
-        return n.t(stringToSymbol(name));
+        return n.t(Symbol(name));
     })
     .def("zs_",[](Node & n, const char * name, TensorsAttr::ValueType v) {
         for (size_t i = 0; i < v.size(); ++ i) {
             v[i] = v[i].view({});
         }
-        return n.ts_(stringToSymbol(name), std::move(v));
+        return n.ts_(Symbol(name), std::move(v));
     })
     .def("zs",[](Node & n, const char * name) {
-        return n.ts(stringToSymbol(name));
+        return n.ts(Symbol(name));
     })
     .def("pyobj",[](Node & n) {
       return py::handle(n.expect<PythonOp>()->pyobj.get()).cast<py::object>();

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -79,7 +79,7 @@ struct Var {
   }
 private:
   static Symbol s(const char * s_) {
-    return stringToSymbol(s_);
+    return Symbol(s_);
   }
   Value * v;
 };
@@ -301,15 +301,15 @@ void attributesTest() {
 
 void internedStringsTests () {
 
-  JIT_ASSERT(kParam == stringToSymbol("Param"));
-  JIT_ASSERT(kReturn == stringToSymbol("Return"));
-  JIT_ASSERT(symbolToString(kReturn) == std::string("Return"));
-  size_t symstart = stringToSymbol("__NEW_SYMBOL");
-  JIT_ASSERT(stringToSymbol("What") == symstart+1);
-  JIT_ASSERT(stringToSymbol("What2") == symstart+2);
-  JIT_ASSERT(stringToSymbol("What") == symstart+1);
-  JIT_ASSERT(stringToSymbol("What2") == symstart+2);
-  JIT_ASSERT(symbolToString(symstart+2) == std::string("What2"));
+  JIT_ASSERT(kParam == Symbol("Param"));
+  JIT_ASSERT(kReturn == Symbol("Return"));
+  JIT_ASSERT(Symbol(kReturn).toString() == std::string("Return"));
+  size_t symstart = Symbol("__NEW_SYMBOL");
+  JIT_ASSERT(Symbol("What") == symstart+1);
+  JIT_ASSERT(Symbol("What2") == symstart+2);
+  JIT_ASSERT(Symbol("What") == symstart+1);
+  JIT_ASSERT(Symbol("What2") == symstart+2);
+  JIT_ASSERT(Symbol(symstart+2).toString() == std::string("What2"));
 }
 
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -137,7 +137,7 @@ Node* recordTrace(std::string op, // TODO: make this a Symbol
   // haven't actually specified what the locking contract is, be conservative.
   auto state_lock = state->lock();
 
-  Node *n = graph->create(stringToSymbol(op), 0 /* initial outputs */);
+  Node *n = graph->create(Symbol(op), 0 /* initial outputs */);
   auto sl = std::make_shared<SourceLocation>(getPythonInterpreterStackTrace());
   n->setSourceLocation(sl);
 


### PR DESCRIPTION
Previous Symbol was just a uint32_t and we converts symbolToString and
stringToSymbol. Now Symbol is a struct with a toString method, and
constructors from either BuiltinSymbols enums (e.g. kParam) or strings.

Symbol is convertible to a uint32_t to ensure it can still be used in
switch statement BuiltinSymbol case branches.