### PR TITLE
Define CHECK in torch/csrc/cuda/nccl.h

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -15,12 +15,10 @@ using namespace at;
 
 namespace detail {
 
-static inline void CHECK(ncclResult_t status) {
-  if (status != ncclSuccess) {
-    std::stringstream err;
-    err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
-    throw std::runtime_error(err.str());
-  }
+void throw_nccl_error(ncclResult_t status) {
+  std::ostringstream err;
+  err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
+  throw std::runtime_error(err.str());
 }
 
 struct NcclCommList {

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -10,6 +10,14 @@ namespace torch { namespace cuda { namespace nccl {
 // Don't use them outside of these files.
 namespace detail {
 
+void throw_nccl_error(ncclResult_t status);
+
+static inline void CHECK(ncclResult_t status) {
+  if (status != ncclSuccess) {
+    throw_nccl_error(status);
+  }
+}
+
 struct AutoNcclGroup {
   AutoNcclGroup() {
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -1,3 +1,5 @@
+#include "python_nccl.h"
+
 #include "nccl.h"
 #include "torch/csrc/THP.h"
 #include "torch/csrc/Types.h"
@@ -13,14 +15,6 @@
 using namespace at;
 using namespace torch::cuda::nccl;
 using namespace torch::cuda::nccl::detail;
-
-static inline void CHECK(ncclResult_t status) {
-  if (status != ncclSuccess) {
-    std::stringstream err;
-    err << "NCCL Error " << status << ": " << ncclGetErrorString(status);
-    throw std::runtime_error(err.str());
-  }
-}
 
 static const char* COMM_CAPSULE_NAME = "torch.cuda.nccl.Communicator";
 


### PR DESCRIPTION
The CHECK function was used but not defined in `AutoNcclGroup` in the nccl.h header file.