### PR TITLE
Make dirichlet_grad and standard_gamma match ATen declarations

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -297,8 +297,8 @@ IMPLEMENT_STATELESS(bmm)
 // TODO: this doesn't implement options that return numbers!
 IMPLEMENT_STATELESS(multinomial)
 IMPLEMENT_STATELESS(normal)
-IMPLEMENT_STATELESS(standard_gamma)
-IMPLEMENT_STATELESS(dirichlet_grad)
+IMPLEMENT_STATELESS(_standard_gamma)
+IMPLEMENT_STATELESS(_dirichlet_grad)
 IMPLEMENT_STATELESS(bernoulli)
 IMPLEMENT_STATELESS(range)
 IMPLEMENT_STATELESS(arange)
@@ -716,8 +716,8 @@ static PyMethodDef TorchMethods[] = {
   {"bmm",             (PyCFunction)THPModule_bmm,               METH_VARARGS | METH_KEYWORDS, NULL},
   {"multinomial",     (PyCFunction)THPModule_multinomial,       METH_VARARGS | METH_KEYWORDS, NULL},
   {"normal",          (PyCFunction)THPModule_normal,            METH_VARARGS | METH_KEYWORDS, NULL},
-  {"_standard_gamma",  (PyCFunction)THPModule_standard_gamma,    METH_VARARGS | METH_KEYWORDS, NULL},
-  {"_dirichlet_grad", (PyCFunction)THPModule_dirichlet_grad,    METH_VARARGS | METH_KEYWORDS, NULL},
+  {"_standard_gamma", (PyCFunction)THPModule__standard_gamma,   METH_VARARGS | METH_KEYWORDS, NULL},
+  {"_dirichlet_grad", (PyCFunction)THPModule__dirichlet_grad,   METH_VARARGS | METH_KEYWORDS, NULL},
   {"bernoulli",       (PyCFunction)THPModule_bernoulli,         METH_VARARGS | METH_KEYWORDS, NULL},
   {"rand",            (PyCFunction)THPModule_rand,              METH_VARARGS | METH_KEYWORDS, NULL},
   {"randn",           (PyCFunction)THPModule_randn,             METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/csrc/generic/methods/TensorRandom.cwrap
+++ b/torch/csrc/generic/methods/TensorRandom.cwrap
@@ -211,7 +211,7 @@
 ]]
 
 [[
-  name: standard_gamma
+  name: _standard_gamma
   types:
     - floating_point
   backends:
@@ -231,7 +231,7 @@
 ]]
 
 [[
-  name: dirichlet_grad
+  name: _dirichlet_grad
   types:
     - floating_point
   backends:


### PR DESCRIPTION
The Python function has an underscore (_) prefix so the C++
IMPLEMENT_STATELESS call should have an underscore prefix as well.

This fixes these functions dispatch when called on Variables.