### PR TITLE
Allow Variables in the (legacy) THNN bindings.

### DIFF
--- a/tools/cwrap/plugins/StandaloneExtension.py
+++ b/tools/cwrap/plugins/StandaloneExtension.py
@@ -8,6 +8,7 @@ MODULE_HEAD = """
 #include <exception>
 
 #include "THP_API.h"
+#include "torch/csrc/nn/type_checks.h"
 
 """
 with open(os.path.join(os.path.dirname(__file__), 'templates', 'module_tail.cpp'), 'r') as f:
@@ -26,14 +27,14 @@ $METHODS
 class StandaloneExtension(CWrapPlugin):
 
     TYPE_UNPACK = {
-        'THFloatTensor*': Template('THPFloatTensor_CData((THPFloatTensor*)$arg)'),
-        'THDoubleTensor*': Template('THPDoubleTensor_CData((THPDoubleTensor*)$arg)'),
-        'THLongTensor*': Template('THPLongTensor_CData((THPLongTensor*)$arg)'),
-        'THIntTensor*': Template('THPIntTensor_CData((THPIntTensor*)$arg)'),
-        'THCudaHalfTensor*': Template('THCPHalfTensor_CData((THCPHalfTensor*)$arg)'),
-        'THCudaTensor*': Template('THCPFloatTensor_CData((THCPFloatTensor*)$arg)'),
-        'THCudaDoubleTensor*': Template('THCPDoubleTensor_CData((THCPDoubleTensor*)$arg)'),
-        'THCudaLongTensor*': Template('THCPLongTensor_CData((THCPLongTensor*)$arg)'),
+        'THFloatTensor*': Template('THNN_FloatTensor_Unpack($arg)'),
+        'THDoubleTensor*': Template('THNN_DoubleTensor_Unpack($arg)'),
+        'THLongTensor*': Template('THNN_LongTensor_Unpack($arg)'),
+        'THIntTensor*': Template('THNN_IntTensor_Unpack($arg)'),
+        'THCudaHalfTensor*': Template('THNN_CudaHalfTensor_Unpack($arg)'),
+        'THCudaTensor*': Template('THNN_CudaFloatTensor_Unpack($arg)'),
+        'THCudaDoubleTensor*': Template('THNN_CudaDoubleTensor_Unpack($arg)'),
+        'THCudaLongTensor*': Template('THNN_CudaLongTensor_Unpack($arg)'),
         'half': Template('THPHalfUtils_unpackReal($arg)'),
         'float': Template('THPFloatUtils_unpackReal($arg)'),
         'double': Template('THPDoubleUtils_unpackReal($arg)'),
@@ -46,14 +47,14 @@ class StandaloneExtension(CWrapPlugin):
     }
 
     TYPE_CHECK = {
-        'THDoubleTensor*': Template('(PyObject*)Py_TYPE($arg) == THPDoubleTensorClass'),
-        'THFloatTensor*': Template('(PyObject*)Py_TYPE($arg) == THPFloatTensorClass'),
-        'THLongTensor*': Template('(PyObject*)Py_TYPE($arg) == THPLongTensorClass'),
-        'THIntTensor*': Template('(PyObject*)Py_TYPE($arg) == THPIntTensorClass'),
-        'THCudaHalfTensor*': Template('THCPHalfTensor_Check($arg)'),
-        'THCudaTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPFloatTensorClass'),
-        'THCudaDoubleTensor*': Template('THCPDoubleTensor_Check($arg)'),
-        'THCudaLongTensor*': Template('(PyObject*)Py_TYPE($arg) == THCPLongTensorClass'),
+        'THFloatTensor*': Template('THNN_FloatTensor_Check($arg)'),
+        'THDoubleTensor*': Template('THNN_DoubleTensor_Check($arg)'),
+        'THLongTensor*': Template('THNN_LongTensor_Check($arg)'),
+        'THIntTensor*': Template('THNN_IntTensor_Check($arg)'),
+        'THCudaHalfTensor*': Template('THNN_CudaHalfTensor_Check($arg)'),
+        'THCudaTensor*': Template('THNN_CudaFloatTensor_Check($arg)'),
+        'THCudaDoubleTensor*': Template('THNN_CudaDoubleTensor_Check($arg)'),
+        'THCudaLongTensor*': Template('THNN_CudaLongTensor_Check($arg)'),
         'half': Template('THPHalfUtils_checkReal($arg)'),
         'float': Template('THPFloatUtils_checkReal($arg)'),
         'double': Template('THPDoubleUtils_checkReal($arg)'),

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -8,7 +8,7 @@
 #include "torch/csrc/THP_export.h"
 
 // Python object that backs torch.autograd.Variable
-struct THP_CLASS THPVariable {
+struct THPVariable {
     PyObject_HEAD
     // Payload
     torch::autograd::Variable cdata;
@@ -22,7 +22,7 @@ struct THP_CLASS THPVariable {
     PyObject* backward_hooks;
 };
 
-extern PyObject *THPVariableClass;
+THP_API PyObject *THPVariableClass;
 
 bool THPVariable_initModule(PyObject *module);
 // FixMe: remove allow_scalar when scalars are fully supported.

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -7,7 +7,7 @@
 #include "torch/csrc/autograd/variable.h"
 
 // Python object that backs torch.autograd.Variable
-struct THPVariable {
+struct THP_CLASS THPVariable {
     PyObject_HEAD
     // Payload
     torch::autograd::Variable cdata;

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -5,6 +5,7 @@
 #include <ATen/ATen.h>
 
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/THP_export.h"
 
 // Python object that backs torch.autograd.Variable
 struct THP_CLASS THPVariable {

--- a/torch/csrc/nn/type_checks.h
+++ b/torch/csrc/nn/type_checks.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Defines type checks and unpacking code for the legacy THNN/THCUNN bindings.
+// These checks accept Tensors and Variables.
+
+#include <ATen/ATen.h>
+
+#include "THP_API.h"
+#include "torch/csrc/autograd/python_variable.h"
+
+namespace torch { namespace nn {
+
+inline bool check_type(PyObject* obj, PyObject* cls, at::TypeID typeID) {
+  if ((PyObject*)Py_TYPE(obj) == cls) {
+    return true;
+  }
+  if (THPVariable_Check(obj)) {
+    return ((THPVariable*)obj)->cdata.data().type().ID() == typeID;
+  }
+  return false;
+}
+
+template<typename TP, typename T>
+inline T* unpack(PyObject* obj, PyObject* cls) {
+  if ((PyObject*)Py_TYPE(obj) == cls) {
+    return ((TP*)obj)->cdata;
+  }
+  return (T*) ((THPVariable*)obj)->cdata.data().unsafeGetTH(false);
+}
+
+}} // namespace torch::nn
+
+
+static inline bool THNN_FloatTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THPFloatTensorClass, at::TypeID::CPUFloat);
+}
+
+static inline bool THNN_DoubleTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THPDoubleTensorClass, at::TypeID::CPUDouble);
+}
+
+static inline bool THNN_LongTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THPLongTensorClass, at::TypeID::CPULong);
+}
+
+static inline bool THNN_IntTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THPIntTensorClass, at::TypeID::CPUInt);
+}
+
+static inline bool THNN_CudaHalfTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPHalfTensorClass, at::TypeID::CUDAHalf);
+}
+
+static inline bool THNN_CudaFloatTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPFloatTensorClass, at::TypeID::CUDAFloat);
+}
+
+static inline bool THNN_CudaDoubleTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPDoubleTensorClass, at::TypeID::CUDADouble);
+}
+
+static inline bool THNN_CudaLongTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPLongTensorClass, at::TypeID::CUDALong);
+}
+
+static inline THFloatTensor* THNN_FloatTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THPFloatTensor, THFloatTensor>(obj, THPFloatTensorClass);
+}
+
+static inline THDoubleTensor* THNN_DoubleTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THPDoubleTensor, THDoubleTensor>(obj, THPDoubleTensorClass);
+}
+
+static inline THLongTensor* THNN_LongTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THPLongTensor, THLongTensor>(obj, THPLongTensorClass);
+}
+
+static inline THIntTensor* THNN_IntTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THPIntTensor, THIntTensor>(obj, THPIntTensorClass);
+}
+
+static inline THCudaHalfTensor* THNN_CudaHalfTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THCPHalfTensor, THCudaHalfTensor>(obj, THCPHalfTensorClass);
+}
+
+static inline THCudaTensor* THNN_CudaFloatTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THCPFloatTensor, THCudaTensor>(obj, THCPFloatTensorClass);
+}
+
+static inline THCudaDoubleTensor* THNN_CudaDoubleTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THCPDoubleTensor, THCudaDoubleTensor>(obj, THCPDoubleTensorClass);
+}
+
+static inline THCudaLongTensor* THNN_CudaLongTensor_Unpack(PyObject* obj) {
+  return torch::nn::unpack<THCPLongTensor, THCudaLongTensor>(obj, THCPLongTensorClass);
+}

--- a/torch/csrc/nn/type_checks.h
+++ b/torch/csrc/nn/type_checks.h
@@ -47,22 +47,6 @@ static inline bool THNN_IntTensor_Check(PyObject* obj) {
   return torch::nn::check_type(obj, THPIntTensorClass, at::TypeID::CPUInt);
 }
 
-static inline bool THNN_CudaHalfTensor_Check(PyObject* obj) {
-  return torch::nn::check_type(obj, THCPHalfTensorClass, at::TypeID::CUDAHalf);
-}
-
-static inline bool THNN_CudaFloatTensor_Check(PyObject* obj) {
-  return torch::nn::check_type(obj, THCPFloatTensorClass, at::TypeID::CUDAFloat);
-}
-
-static inline bool THNN_CudaDoubleTensor_Check(PyObject* obj) {
-  return torch::nn::check_type(obj, THCPDoubleTensorClass, at::TypeID::CUDADouble);
-}
-
-static inline bool THNN_CudaLongTensor_Check(PyObject* obj) {
-  return torch::nn::check_type(obj, THCPLongTensorClass, at::TypeID::CUDALong);
-}
-
 static inline THFloatTensor* THNN_FloatTensor_Unpack(PyObject* obj) {
   return torch::nn::unpack<THPFloatTensor, THFloatTensor>(obj, THPFloatTensorClass);
 }
@@ -77,6 +61,24 @@ static inline THLongTensor* THNN_LongTensor_Unpack(PyObject* obj) {
 
 static inline THIntTensor* THNN_IntTensor_Unpack(PyObject* obj) {
   return torch::nn::unpack<THPIntTensor, THIntTensor>(obj, THPIntTensorClass);
+}
+
+#ifdef WITH_CUDA
+
+static inline bool THNN_CudaHalfTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPHalfTensorClass, at::TypeID::CUDAHalf);
+}
+
+static inline bool THNN_CudaFloatTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPFloatTensorClass, at::TypeID::CUDAFloat);
+}
+
+static inline bool THNN_CudaDoubleTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPDoubleTensorClass, at::TypeID::CUDADouble);
+}
+
+static inline bool THNN_CudaLongTensor_Check(PyObject* obj) {
+  return torch::nn::check_type(obj, THCPLongTensorClass, at::TypeID::CUDALong);
 }
 
 static inline THCudaHalfTensor* THNN_CudaHalfTensor_Unpack(PyObject* obj) {
@@ -94,3 +96,5 @@ static inline THCudaDoubleTensor* THNN_CudaDoubleTensor_Unpack(PyObject* obj) {
 static inline THCudaLongTensor* THNN_CudaLongTensor_Unpack(PyObject* obj) {
   return torch::nn::unpack<THCPLongTensor, THCudaLongTensor>(obj, THCPLongTensorClass);
 }
+
+#endif  // WITH_CUDA


### PR DESCRIPTION
The legacy NN bindings currently operate only on Tensors. We are slowly
replacing all uses of Tensor with Variable in Python code so that there
will only be one user-visible class. This changes the NN bindings
accessed through type2backend to accept either Tensors or Variables.

This does not affect the NN bindings that go through ATen.