### PR TITLE
Allow Variables in calls to type2backend

### DIFF
--- a/torch/legacy/nn/Criterion.py
+++ b/torch/legacy/nn/Criterion.py
@@ -9,7 +9,7 @@ class Criterion(object):
     def __init__(self):
         self.gradInput = torch.Tensor()
         self.output = 0
-        self._backend = torch._thnn.type2backend[type(self.gradInput)]
+        self._backend = torch._thnn.type2backend[self.gradInput.type()]
 
     def updateOutput(self, input, target):
         raise NotImplementedError

--- a/torch/legacy/nn/Module.py
+++ b/torch/legacy/nn/Module.py
@@ -9,7 +9,7 @@ class Module(object):
         self.gradInput = torch.Tensor()
         self.output = torch.Tensor()
         self._type = self.output.type()
-        self._backend = torch._thnn.type2backend[type(self.output)]
+        self._backend = torch._thnn.type2backend[self.output.type()]
 
     def __repr__(self):
         return 'nn.' + self.__class__.__name__

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -40,7 +40,7 @@ def _make_function_class_criterion(class_name, update_output, update_grad_input,
 
     @staticmethod
     def forward(ctx, input, target, *args):
-        ctx._backend = type2backend[type(input)]
+        ctx._backend = type2backend[input.type()]
         ctx.save_for_backward(input, target)
         if weight_arg_idx >= 0:
             ctx.weight = args[0]
@@ -146,7 +146,7 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
 
     @staticmethod
     def forward(ctx, input, *params):
-        ctx._backend = type2backend[type(input)]
+        ctx._backend = type2backend[input.type()]
 
         ctx.additional_args = []
         tensor_param_list = []

--- a/torch/nn/_functions/thnn/normalization.py
+++ b/torch/nn/_functions/thnn/normalization.py
@@ -22,7 +22,7 @@ class CrossMapLRN2d(Function):
         self.scale = self.scale or input.new()
         output = input.new()
 
-        backend = type2backend[type(input)]
+        backend = type2backend[input.type()]
         if backend is not None:
             try:
                 backend.SpatialCrossMapLRN_updateOutput

--- a/torch/nn/_functions/thnn/rnnFusedPointwise.py
+++ b/torch/nn/_functions/thnn/rnnFusedPointwise.py
@@ -6,7 +6,7 @@ from torch._thnn import type2backend
 class GRUFused(Function):
     @staticmethod
     def forward(ctx, input_gate, hidden_gate, hx, ibias=None, hbias=None):
-        ctx.backend = type2backend[type(input_gate)]
+        ctx.backend = type2backend[input_gate.type()]
 
         hy = input_gate.new()
         workspace = input_gate.new(hx.numel() * 5)
@@ -32,7 +32,7 @@ class GRUFused(Function):
     @staticmethod
     @once_differentiable
     def backward(ctx, gradOutput):
-        ctx.backend = type2backend[type(gradOutput)]
+        ctx.backend = type2backend[gradOutput.type()]
 
         gradInputHx = gradOutput.new()
         gradInInput = gradOutput.new(*ctx.igate_size)
@@ -52,7 +52,7 @@ class GRUFused(Function):
 class LSTMFused(Function):
     @staticmethod
     def forward(ctx, input_gate, hidden_gate, cx, ibias=None, hbias=None):
-        ctx.backend = type2backend[type(input_gate)]
+        ctx.backend = type2backend[input_gate.type()]
         hy = input_gate.new()
         cy = input_gate.new()
 
@@ -79,7 +79,7 @@ class LSTMFused(Function):
     @staticmethod
     @once_differentiable
     def backward(ctx, *gradOutput):
-        ctx.backend = type2backend[type(gradOutput[0])]
+        ctx.backend = type2backend[gradOutput[0].type()]
         gradInputCx = gradOutput[0].new()
         gradInGates = gradOutput[0].new(*ctx.hgate_size)
 

--- a/torch/nn/_functions/thnn/sparse.py
+++ b/torch/nn/_functions/thnn/sparse.py
@@ -58,7 +58,7 @@ class EmbeddingBag(Function):
                              " ({}), but got offsets[-1] of {}"
                              .format(indices.size(0), offsets[-1]))
 
-        ctx._backend = type2backend[type(weight)]
+        ctx._backend = type2backend[weight.type()]
         ctx._weight_size = weight.size()
         ctx._offset2bag = offsets.new()
 

--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -47,7 +47,7 @@ class GridSampler(Function):
                              .format(padding_mode))
 
         grid_sz = grid.size()
-        backend = type2backend[type(input)]
+        backend = type2backend[input.type()]
         output = input.new(grid_sz[0], input.size(1), grid_sz[1], grid_sz[2])
         backend.SpatialGridSamplerBilinear_updateOutput(backend.library_state, input, grid, output, ctx.padding_mode)
         return output
@@ -58,7 +58,7 @@ class GridSampler(Function):
         input, grid = ctx.saved_tensors
         padding_mode = ctx.padding_mode
 
-        backend = type2backend[type(input)]
+        backend = type2backend[input.type()]
         grad_input = input.new(input.size())
         grad_grid = grid.new(grid.size())
         backend.SpatialGridSamplerBilinear_updateGradInput(

--- a/torch/utils/serialization/read_lua_file.py
+++ b/torch/utils/serialization/read_lua_file.py
@@ -221,7 +221,7 @@ def _load_backend(obj):
         attr = getattr(obj, key)
         if torch.is_tensor(attr):
             try:
-                obj._backend = type2backend[type(attr)]
+                obj._backend = type2backend[attr.type()]
             except KeyError:
                 pass
     # Monkey patch the forward to capture the type of input
@@ -231,7 +231,7 @@ def _load_backend(obj):
         input = args[0]
         while not torch.is_tensor(input):
             input = input[0]
-        obj._backend = type2backend[type(input)]
+        obj._backend = type2backend[input.type()]
         obj.updateOutput = updateOutput_orig
         return obj.updateOutput(*args)
     obj.updateOutput = updateOutput_patch


### PR DESCRIPTION
Use x.type() instead of type(x) when accessing type2backend to support
Variables as well as Tensors.