### PR TITLE
Allow Variables in calls to NCCL bindings.

### DIFF
--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -8,6 +8,7 @@
 #include "THP.h"
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/utils/invalid_arguments.h"
+#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/DynamicTypes.h"
 
 #include "generic/utils.cpp"
@@ -209,24 +210,6 @@ bool maybeThrowBackCompatKeepdimWarn(char *func) {
     PyErr_WarnEx(PyExc_UserWarning, ss.str().c_str(), 1);
   }
   return true;
-}
-
-std::vector<at::Tensor> THPUtils_PySequence_to_TensorList(PyObject *obj) {
-  if (!PySequence_Check(obj)) {
-    throw std::runtime_error("Expected a sequence in THPUtils_PySequence_to_TensorList");
-  }
-  THPObjectPtr seq = THPObjectPtr(PySequence_Fast(obj, NULL));
-  if (seq.get() == NULL) {
-    throw std::runtime_error("expected PySequence, but got " + std::string(THPUtils_typename(obj)));
-  }
-
-  std::vector<at::Tensor> list;
-  Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
-  for (Py_ssize_t i = 0; i < length; i++) {
-    at::Tensor tensor = torch::createTensor(PySequence_Fast_GET_ITEM(seq.get(), i));
-    list.push_back(tensor);
-  }
-  return list;
 }
 
 #ifdef WITH_CUDA

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -186,8 +186,6 @@ void setBackCompatKeepdimWarn(bool warn);
 bool getBackCompatKeepdimWarn();
 bool maybeThrowBackCompatKeepdimWarn(char *func);
 
-std::vector<at::Tensor> THPUtils_PySequence_to_TensorList(PyObject *obj);
-
 #ifdef WITH_CUDA
 std::vector <THCStream*> THPUtils_PySequence_to_THCStreamList(PyObject *obj);
 #endif


### PR DESCRIPTION
The Tensor and Variable classes are being merged in Python. This means
that all interfaces to C++ must accept Variables where they previously
accepted Tensors.