### PR TITLE
Various testing and utility improvements including torch.testing module.

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -4,6 +4,10 @@
 namespace at {
 namespace native {
 
+Tensor empty_like(const Tensor& self) {
+  return self.type().tensor(self.sizes());
+}
+
 Tensor randn_like(const Tensor& self) {
   return self.type().randn(self.sizes());
 }

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -14,6 +14,10 @@ bool is_distributed(const Tensor& self) {
   return self.type().is_distributed();
 }
 
+bool is_floating_point(const Tensor& self) {
+  return at::isFloatingType(self.type().scalarType());
+}
+
 template <typename scalar>
 struct IsSigned {
   static bool apply() { return std::is_signed<scalar>(); }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -181,6 +181,9 @@
 - func: embedding_sparse_backward(Tensor grad, IndexTensor indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq) -> Tensor
   variants: function
 
+- func: empty_like(Tensor self) -> Tensor
+  variants: function
+
 - func: expand(Tensor self, IntList size) -> Tensor
 
 - func: expand_as(Tensor self, Tensor other) -> Tensor
@@ -193,6 +196,8 @@
 - func: is_cuda(Tensor self) -> bool
 
 - func: is_distributed(Tensor self) -> bool
+
+- func: is_floating_point(Tensor self) -> bool
 
 - func: is_nonzero(Tensor self) -> bool
 
@@ -228,6 +233,7 @@
 - func: pin_memory(Tensor self) -> Tensor
 
 - func: randn_like(Tensor self) -> Tensor
+  variants: function
 
 - func: RoiPooling2d_forward(Tensor input, Tensor rois, int64_t pooledHeight, int64_t pooledWidth, double spatialScale) -> (Tensor, Tensor)
   variants: function

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2504,9 +2504,9 @@ def run_grad_and_gradgrad_checks(test_case, name, test_name, apply_method, outpu
         atol = gradgradcheck_precision_override['atol']
         rtol = gradgradcheck_precision_override['rtol']
         test_case.assertTrue(gradgradcheck(apply_method, input_variables, None, atol=atol, rtol=rtol,
-                                           gen_grad_outputs_non_contig=True))
+                                           gen_non_contig_grad_outputs=True))
     else:
-        test_case.assertTrue(gradgradcheck(apply_method, input_variables, gen_grad_outputs_non_contig=True))
+        test_case.assertTrue(gradgradcheck(apply_method, input_variables, gen_non_contig_grad_outputs=True))
 
 
 def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4,7 +4,6 @@ import sys
 import math
 import torch
 import unittest
-import random
 import warnings
 from copy import deepcopy
 from collections import OrderedDict
@@ -18,6 +17,7 @@ from torch.autograd.profiler import profile
 from common import TestCase, run_tests, skipIfNoLapack
 from torch.autograd import Variable, Function
 from torch.autograd.function import InplaceFunction
+from torch.testing import make_non_contiguous, randn_like
 
 if sys.version_info[0] == 2:
     import cPickle as pickle
@@ -2376,33 +2376,6 @@ method_tests = [
 # TODO: clamp with min/max
 
 
-def make_non_contiguous(tensor):
-    if tensor.numel() <= 1:  # can't make non-contiguous
-        return tensor.new(tensor.size())
-    osize = list(tensor.size())
-
-    # randomly inflate a few dimensions in osize
-    for _ in range(2):
-        dim = random.randint(0, len(osize) - 1)
-        add = random.randint(4, 15)
-        osize[dim] = osize[dim] + add
-
-    # narrow doesn't make a non-contiguous tensor if we only narrow the 0-th dimension,
-    # (which will always happen with a 1-dimensional tensor), so let's make a new
-    # right-most dimension and cut it off
-
-    input = tensor.new(torch.Size(osize + [random.randint(2, 3)]))
-    input = input.select(len(input.size()) - 1, random.randint(0, 1))
-    # now extract the input of correct size from 'input'
-    for i in range(len(osize)):
-        if input.size(i) != tensor.size(i):
-            bounds = random.randint(1, input.size(i) - tensor.size(i))
-            input = input.narrow(i, bounds, tensor.size(i))
-
-    input.copy_(tensor)
-    return input
-
-
 def create_input(call_args, requires_grad=True, non_contiguous=False):
     if not isinstance(call_args, tuple):
         call_args = (call_args,)
@@ -2441,20 +2414,6 @@ def unpack_variables(args):
     else:
         return args
 
-
-def generate_gradoutput(dummy_out, non_contiguous=False):
-    def maybe_non_contig(tensor, requires_grad):
-        ret = make_non_contiguous(tensor) if non_contiguous else tensor.new(tensor.size())
-        ret.requires_grad = requires_grad
-        return ret
-
-    if isinstance(dummy_out, tuple):
-        grad_y = tuple(maybe_non_contig(x.double().randn_like(), x.requires_grad)
-                       for x in dummy_out if isinstance(x, Variable))
-    else:
-        grad_y = (maybe_non_contig(dummy_out.double().randn_like(), dummy_out.requires_grad),)
-
-    return grad_y
 
 EXCLUDE_FUNCTIONAL = {
     'addmm',
@@ -2540,14 +2499,14 @@ def run_grad_and_gradgrad_checks(test_case, name, test_name, apply_method, outpu
     test_case.assertTrue(gradcheck(apply_method, input_variables, eps=1e-6, atol=PRECISION))
     if name in EXCLUDE_GRADGRADCHECK or test_name in EXCLUDE_GRADGRADCHECK_BY_TEST_NAME:
         return
-    grad_y = generate_gradoutput(output_variable, non_contiguous=True)
     gradgradcheck_precision_override = gradgradcheck_method_precision_override(test_name)
     if gradgradcheck_precision_override is not None:
         atol = gradgradcheck_precision_override['atol']
         rtol = gradgradcheck_precision_override['rtol']
-        test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y, atol=atol, rtol=rtol))
+        test_case.assertTrue(gradgradcheck(apply_method, input_variables, None, atol=atol, rtol=rtol,
+                                           gen_grad_outputs_non_contig=True))
     else:
-        test_case.assertTrue(gradgradcheck(apply_method, input_variables, grad_y))
+        test_case.assertTrue(gradgradcheck(apply_method, input_variables, gen_grad_outputs_non_contig=True))
 
 
 def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
@@ -2565,7 +2524,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 
     self_variable = f_args_variable[0]
     if isinstance(output_variable, torch.autograd.Variable) and self_variable is not None:
-        output_variable.backward(output_variable.randn_like())
+        output_variable.backward(randn_like(output_variable))
         test_case.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
         test_case.assertTrue(self_variable.size() == self_variable.grad.size())
 
@@ -2623,7 +2582,7 @@ for test in method_tests:
                     args_variable = create_input(args, requires_grad=False)
                     output_variable = getattr(self_variable, name)(*args_variable)
                     if isinstance(output_variable, torch.autograd.Variable):
-                        output_variable.backward(output_variable.randn_like())
+                        output_variable.backward(randn_like(output_variable))
                         self.assertTrue(type(self_variable.data) == type(self_variable.grad.data))
                         self.assertTrue(self_variable.size() == self_variable.grad.size())
 
@@ -2660,7 +2619,7 @@ for test in method_tests:
                             if i.grad is not None:
                                 i.grad.data.zero_()
                         for io, o in zip(inplace_output_variable, output_variable):
-                            grad = io.randn_like().double()
+                            grad = randn_like(io).double()
                             io.backward(grad)
                             o.backward(grad)
                         for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -117,21 +117,7 @@ def _assertGradAndGradgradChecks(test_case, apply_fn, inputs):
     # call assert function rather than returning a bool since it's nicer
     # if we get whether this failed on the gradcheck or the gradgradcheck.
     test_case.assertTrue(gradcheck(apply_fn, inputs))
-    dummy_out = apply_fn(*inputs)
-
-    def randn_match_cpu_gpu(x):
-        a = torch.randn(x.size())
-        if x.is_cuda:
-            a = a.cuda(x.get_device())
-        return a
-
-    if isinstance(dummy_out, tuple):
-        grad_y = tuple(Variable(randn_match_cpu_gpu(x), requires_grad=x.requires_grad)
-                       for x in dummy_out if isinstance(x, Variable))
-    else:
-        grad_y = (Variable(randn_match_cpu_gpu(dummy_out), requires_grad=dummy_out.requires_grad),)
-
-    test_case.assertTrue(gradgradcheck(apply_fn, inputs, grad_y,))
+    test_case.assertTrue(gradgradcheck(apply_fn, inputs))
 
 
 class InputVariableMixin(object):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4826,6 +4826,14 @@ class TestTorch(TestCase):
         # TypeError would be better
         self.assertRaises(RuntimeError, lambda: x.new(z.storage()))
 
+    def test_empty_like(self):
+        x = torch.autograd.Variable(torch.Tensor())
+        y = torch.autograd.Variable(torch.randn(4, 4))
+        z = torch.autograd.Variable(torch.IntTensor([1, 2, 3]))
+        for a in (x, y, z):
+            self.assertEqual(torch.empty_like(a).shape, a.shape)
+            self.assertEqual(torch.empty_like(a).type(), a.type())
+
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_pin_memory(self):
         x = torch.randn(3, 5)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -340,6 +340,7 @@ import torch.utils.backcompat
 import torch.onnx
 import torch.random
 import torch.distributions
+import torch.testing
 from torch.autograd import no_grad, enable_grad
 
 _C._init_names(list(torch._tensor_classes) + list(torch._storage_classes))

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -207,7 +207,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     return True
 
 
-def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3, gen_grad_outputs_non_contig=False):
+def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3, gen_non_contig_grad_outputs=False):
     """Check gradients of gradients computed via small finite differences
        against analytical gradients
     This function checks that backpropagating through the gradients computed
@@ -238,7 +238,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # shape, type, and device as the outputs
         def randn_like(x):
             var = torch.testing.randn_like(x if x.is_floating_point() else x.double())
-            if gen_grad_outputs_non_contig:
+            if gen_non_contig_grad_outputs:
                 var = torch.testing.make_non_contiguous(var)
             var.requires_grad = True
             return var

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1,6 +1,7 @@
 import torch
 from torch.autograd import Variable
 from collections import Iterable
+import torch.testing
 import sys
 
 
@@ -206,7 +207,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     return True
 
 
-def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3):
+def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3, gen_grad_outputs_non_contig=False):
     """Check gradients of gradients computed via small finite differences
        against analytical gradients
     This function checks that backpropagating through the gradients computed
@@ -236,11 +237,14 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # If grad_outputs is not specified, create random variables of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            var = x.randn_like()
+            var = torch.testing.randn_like(x if x.is_floating_point() else x.double())
+            if gen_grad_outputs_non_contig:
+                var = torch.testing.make_non_contiguous(var)
             var.requires_grad = True
             return var
         outputs = _as_tuple(func(*inputs))
-        grad_outputs = [randn_like(x) for x in outputs]
+        grad_outputs_gen = (randn_like(x) for x in outputs)
+        grad_outputs = list(grad_outputs_gen) if not isinstance(inputs, tuple) else tuple(grad_outputs_gen)
 
     def new_func(*input_args):
         input_args = input_args[:-len(grad_outputs)]

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -4,7 +4,7 @@ from functools import reduce
 import math
 
 __all__ = [
-    'split', 'chunk', 'stack', 'unbind', 'btriunpack', 'matmul', 'det', 'stft',
+    'split', 'chunk', 'empty_like', 'stack', 'unbind', 'btriunpack', 'matmul', 'det', 'stft',
     'hann_window', 'hamming_window', 'bartlett_window', 'where',
 ]
 
@@ -62,6 +62,26 @@ def chunk(tensor, chunks, dim=0):
         dim += tensor.dim()
     split_size = (tensor.size(dim) + chunks - 1) // chunks
     return split(tensor, split_size, dim)
+
+
+def empty_like(input):
+    r"""empty_like(input) -> Tensor
+
+    Returns an uninitialized tensor with the same size as :attr:`input`.
+
+    Args:
+        input (Tensor): the size of :attr:`input` will determine size of the output tensor
+
+    Example::
+
+        >>> input = torch.LongTensor(2,3)
+        >>> input.new(input.size())
+
+        1.3996e+14  1.3996e+14  1.3996e+14
+        4.0000e+00  0.0000e+00  0.0000e+00
+        [torch.LongTensor of size 2x3]
+    """
+    return input.new(input.size())
 
 
 def stack(sequence, dim=0, out=None):

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -1,0 +1,41 @@
+"""
+The testing package contains testing-specific utilities.
+"""
+
+import torch
+import random
+
+__all__ = [
+    'make_non_contiguous', 'randn_like'
+]
+
+
+def make_non_contiguous(tensor):
+    if tensor.numel() <= 1:  # can't make non-contiguous
+        return tensor.new(tensor.size())
+    osize = list(tensor.size())
+
+    # randomly inflate a few dimensions in osize
+    for _ in range(2):
+        dim = random.randint(0, len(osize) - 1)
+        add = random.randint(4, 15)
+        osize[dim] = osize[dim] + add
+
+    # narrow doesn't make a non-contiguous tensor if we only narrow the 0-th dimension,
+    # (which will always happen with a 1-dimensional tensor), so let's make a new
+    # right-most dimension and cut it off
+
+    input = tensor.new(torch.Size(osize + [random.randint(2, 3)]))
+    input = input.select(len(input.size()) - 1, random.randint(0, 1))
+    # now extract the input of correct size from 'input'
+    for i in range(len(osize)):
+        if input.size(i) != tensor.size(i):
+            bounds = random.randint(1, input.size(i) - tensor.size(i))
+            input = input.narrow(i, bounds, tensor.size(i))
+
+    input.copy_(tensor)
+    return input
+
+
+def randn_like(variable):
+    return torch._C._VariableFunctions.randn_like(variable)


### PR DESCRIPTION
1) Remove method definition for randn_like since ones_like, zeros_like do not have methods.
2) Add an empty_like native function for creating a tensor with uninitialized values.
3) Add an is_floating_point() native function, similar to is_signed().
4) Add a torch.testing module loosely modeled after numpy.testing; currently it contains make_non_contiguous (moved from test_autograd) and randn_like (wrapper around the VariableFunction).
5) Remove code from test_autograd and test_nn that is responsible for generating grad_outputs to use with gradgradcheck.  These now use gradgradcheck's own generating code.  This fixes test_nn.py with scalars because gradgradcheck does the right thing here already.