### PR TITLE
move __float2half to ScalarConvert

### DIFF
--- a/aten/src/THCUNN/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/FusedRNNKernel.cu
@@ -26,7 +26,7 @@ struct TensorSigmoidOp<half> {
     *out = hdiv(one, __hadd(one, hexp(__hneg(*in))));
 #else
     float fin = __half2float(*in);
-    *out = __float2half(1.0f / (1.0f + expf(- fin)));
+    *out = ScalarConvert<float, half>::to(1.0f / (1.0f + expf(- fin)));
 #endif
   }
 
@@ -36,7 +36,7 @@ struct TensorSigmoidOp<half> {
     *v = hdiv(one, __hadd(one, hexp(__hneg(*v))));
 #else
     float fv = __half2float(*v);
-    *v = __float2half(1.0f / (1.0f + expf(- fv)));
+    *v = ScalarConvert<float, half>::to(1.0f / (1.0f + expf(- fv)));
 #endif
   }
 };

--- a/aten/src/THCUNN/LogSigmoid.cu
+++ b/aten/src/THCUNN/LogSigmoid.cu
@@ -54,10 +54,10 @@ struct logSigmoid_updateOutput_functor<half> {
     const half z = THCNumerics<half>::exp(__hneg(max)) + THCNumerics<half>::exp(__hneg(*input) - max);
     *output = __hneg(max + THCNumerics<half>::log(z));
 #else
-    float in = __half2float(*input);
+    float in = ScalarConvert<half, float>::to(*input);
     float max = fmaxType(0.f, -in);
     float z = THCNumerics<float>::exp(-max) + THCNumerics<float>::exp(-in - max);
-    *output = __float2half(-(max + THCNumerics<float>::log(z)));
+    *output = ScalarConvert<float, half>::to(-(max + THCNumerics<float>::log(z)));
 #endif
   }
 };
@@ -78,17 +78,17 @@ struct logSigmoid_updateGradInput_functor<half> {
     }
     *gradInput = __hmul(*gradOutput, (__hneg(max_deriv) - __hmul(sign, __hdiv(z - one, z))));
 #else
-    const float in = __half2float(*input);
+    const float in = ScalarConvert<half, float>::to(*input);
     const float max = fmaxType(0.f, -in);
     const float z = THCNumerics<float>::exp(-max) + THCNumerics<float>::exp(-in - max);
-    const float go = __half2float(*gradOutput);
+    const float go = ScalarConvert<half, float>::to(*gradOutput);
     float max_deriv = 0.f;
     float sign = -1.f;
     if(in < 0.f){
         max_deriv = -1.f;
         sign = 1.f;
     }
-    *gradInput = __float2half(go * (-max_deriv - sign*((z - 1.f)/z)));
+    *gradInput = ScalarConvert<float, half>::to(go * (-max_deriv - sign*((z - 1.f)/z)));
 #endif
   }
 };

--- a/aten/src/THCUNN/Sigmoid.cu
+++ b/aten/src/THCUNN/Sigmoid.cu
@@ -18,9 +18,9 @@ struct sigmoid_updateGradInput_functor<half> {
     const half one = __float2half(1.f);
     *gradInput = __hmul(*gradOutput, __hmul(__hadd(one, __hneg(*output)), *output));
 #else
-    const float out = __half2float(*output);
-    const float go = __half2float(*gradOutput);
-    *gradInput = __float2half(go * (1.f - out) * out);
+    const float out = ScalarConvert<half, float>::to(*output);
+    const float go = ScalarConvert<half, float>::to(*gradOutput);
+    *gradInput = ScalarConvert<float, half>::to(go * (1.f - out) * out);
 #endif
   }
 };

--- a/aten/src/THCUNN/Tanh.cu
+++ b/aten/src/THCUNN/Tanh.cu
@@ -23,9 +23,9 @@ struct tanh_updateGradInput_functor<half>
     const half out_square = __hmul(*output, *output);
     *gradInput = __hmul(*gradOutput, __hadd(one, __hneg(out_square)));
 #else
-    const float out = __half2float(*output);
-    const float go = __half2float(*gradOutput);
-    *gradInput = __float2half(go * (1.f - out * out));
+    const float out = ScalarConvert<half, float>::to(*output);
+    const float go = ScalarConvert<half, float>::to(*gradOutput);
+    *gradInput = ScalarConvert<float, half>::to(go * (1.f - out * out));
 #endif
   }
 };

--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -77,8 +77,8 @@ bool THNN_(canUse32BitIndexMath)(THCState *state, int count, ...)
 #define DEVICE_LINEAR_GET(D_TENSOR, INDEX)                              \
   D_TENSOR.data[IndexToOffset<T, IndexType, Dims>::get(INDEX, D_TENSOR)]
 
-#define H2F(input) __half2float(input)
-#define F2H(input) __float2half(input)
+#define H2F(input) ScalarConvert<half, float>::to(input)
+#define F2H(input) ScalarConvert<float, half>::to(input)
 
 template <typename T, typename IndexType, int Dims>
 #if __CUDA_ARCH__ >= 350


### PR DESCRIPTION
fixes a compile issue with compiling with `3.0;3.5;5.0;5.2;6.0;6.1;6.1+PTX`