### PR TITLE
Legacy Padding: correct output size with nInputDim

### DIFF
--- a/torch/legacy/nn/Padding.py
+++ b/torch/legacy/nn/Padding.py
@@ -20,13 +20,13 @@ class Padding(Module):
         super(Padding, self).__init__()
 
     def updateOutput(self, input):
-        outputSize = list(input.size())
-        outputSize[self.dim] += abs(self.pad)
-        self.outputSize = torch.Size(outputSize)
         dim = self.dim
-
         if hasattr(self, "nInputDim") and self.nInputDim > 0 and input.dim() != self.nInputDim:
             dim = dim + 1
+
+        outputSize = list(input.size())
+        outputSize[dim] += abs(self.pad)
+        self.outputSize = torch.Size(outputSize)
 
         self.output.resize_(self.outputSize)
         self.output.fill_(self.value)


### PR DESCRIPTION
legacy.nn.Padding does not compute the correct output size when nInputDim is non zero: the output size should be computed after the padding dimension has been computed. This fixes this issue - and allow for instance to run the pretrained ENet model with legacy torch.