### PR TITLE
Ensure that Tensors always have Storages

### DIFF
--- a/aten/src/TH/generic/THTensor.c
+++ b/aten/src/TH/generic/THTensor.c
@@ -802,7 +802,7 @@ void THTensor_(freeCopyTo)(THTensor *self, THTensor *dst)
 static void THTensor_(rawInit)(THTensor *self)
 {
   self->refcount = 1;
-  self->storage = NULL;
+  self->storage = THStorage_(new)();
   self->storageOffset = 0;
   self->size = NULL;
   self->stride = NULL;

--- a/aten/src/THC/generic/THCTensor.c
+++ b/aten/src/THC/generic/THCTensor.c
@@ -787,7 +787,7 @@ void THCTensor_(freeCopyTo)(THCState *state, THCTensor *self, THCTensor *dst)
 static void THCTensor_(rawInit)(THCState *state, THCTensor *self)
 {
   self->refcount = 1;
-  self->storage = NULL;
+  self->storage = THCStorage_(new)(state);
   self->storageOffset = 0;
   self->size = NULL;
   self->stride = NULL;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -294,6 +294,8 @@ class TestTorch(TestCase):
         self.assertIsNotNone(torch.Tensor([]).storage())
         self.assertIsNotNone(torch.Tensor().clone().storage())
         self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
+        from torch.autograd import Variable
+        self.assertIsNotNone(Variable(torch.Tensor()).new().storage())
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_has_storage_numpy(self):


### PR DESCRIPTION
We've had the guarantee in PyTorch that every Tensor has an associated Storage, even empty ones. This important because the CUDA device is stored on the Storage object.

We had a regression in some Variable functions that are routed through ATen. This fixes the problem in TH/THC. We didn't do this previously because TH/THC were shared with Lua Torch.