### PR TITLE
Fix resize_as_ on Variables containing SparseTensors

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -309,6 +309,7 @@
   name: resizeAs_
   python_name: resize_as_
   cname: resizeAs
+  aten_sparse: True
   return: self
   scalar_check: the_template_->isScalar()
   arguments:
@@ -4024,8 +4025,10 @@
   variants: [function]
   options:
     - cname: new
+      aten_sparse: True
       arguments: []
     - cname: newWithSize
+      aten_sparse: True
       arguments:
         - THSize* size
         - CONSTANT NULL

--- a/aten/src/THCS/generic/THCSTensor.c
+++ b/aten/src/THCS/generic/THCSTensor.c
@@ -178,7 +178,7 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
   return self;
 }
 
-THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size)
+THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size, THLongStorage *_ignored)
 {
   THCSTensor *self = THAlloc(sizeof(THCSTensor));
   THCSTensor_(rawInit)(state, self);

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -34,7 +34,7 @@ TH_API THCSTensor *THCSTensor_(new)(THCState *state);
 TH_API THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes);
 
-TH_API THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size_);
+TH_API THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size_, THLongStorage *_ignored);
 TH_API THCSTensor *THCSTensor_(newWithSize1d)(THCState *state, int64_t size0_);
 TH_API THCSTensor *THCSTensor_(newWithSize2d)(THCState *state, int64_t size0_, int64_t size1_);
 TH_API THCSTensor *THCSTensor_(newWithSize3d)(THCState *state, int64_t size0_, int64_t size1_, int64_t size2_);

--- a/aten/src/THS/generic/THSTensor.c
+++ b/aten/src/THS/generic/THSTensor.c
@@ -176,7 +176,7 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
   return self;
 }
 
-THSTensor *THSTensor_(newWithSize)(THLongStorage *size)
+THSTensor *THSTensor_(newWithSize)(THLongStorage *size, THLongStorage *_ignored)
 {
   THSTensor *self = THAlloc(sizeof(THSTensor));
   THSTensor_(rawInit)(self);

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -36,7 +36,8 @@ TH_API THSTensor *THSTensor_(new)(void);
 TH_API THSTensor *THSTensor_(newWithTensor)(THLongTensor *indices, THTensor *values);
 TH_API THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *values, THLongStorage *sizes);
 
-TH_API THSTensor *THSTensor_(newWithSize)(THLongStorage *size_);
+// Note the second argument is ignored. It exists only to match the signature of THTensor_(new).
+TH_API THSTensor *THSTensor_(newWithSize)(THLongStorage *size_, THLongStorage *_ignored);
 TH_API THSTensor *THSTensor_(newWithSize1d)(int64_t size0_);
 TH_API THSTensor *THSTensor_(newWithSize2d)(int64_t size0_, int64_t size1_);
 TH_API THSTensor *THSTensor_(newWithSize3d)(int64_t size0_, int64_t size1_, int64_t size2_);

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -767,15 +767,16 @@ class TestSparse(TestCase):
         self.assertTrue(torch.autograd.Variable(x).is_sparse)
 
     def test_resize_as(self):
+        def do_test(t):
+            y = t.new().resize_as_(t).zero_()
+            self.assertEqual(y.shape, t.shape)
+            # Check that y can be added to t. Currently, this requires that
+            # _dimI and _dimV match.
+            self.assertEqual(t, t + y)
+
         from torch.autograd import Variable
-        x = self.SparseTensor()
-        v = Variable(x)
-
-        def empty_like(t):
-            return t.new().resize_as_(t)
-
-        self.assertEqual(empty_like(x).shape, x.shape)
-        self.assertEqual(empty_like(v).shape, v.shape)
+        do_test(self.SparseTensor())
+        do_test(Variable(self.SparseTensor()))
 
 
 class TestUncoalescedSparse(TestSparse):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -732,13 +732,17 @@ class TestSparse(TestCase):
         self.assertRaises(RuntimeError, lambda: self.SparseTensor(i, v, torch.Size([3])))
 
     def _test_new_device(self, size, device):
+        from torch.autograd import Variable
         with torch.cuda.device(device):
             x = torch.cuda.sparse.DoubleTensor(*size)
+            v = Variable(x)
         self.assertEqual(x.get_device(), device)
         x1 = x.new()
         x2 = x.new(2, 3)
         self.assertEqual(x1.get_device(), device)
         self.assertEqual(x2.get_device(), device)
+        self.assertEqual(v.new().get_device(), device)
+        self.assertEqual(v.new(2, 3).get_device(), device)
 
     @cuda_only
     def test_new_device_single_gpu(self):
@@ -761,6 +765,17 @@ class TestSparse(TestCase):
         x = self.SparseTensor()
         self.assertTrue(x.is_sparse)
         self.assertTrue(torch.autograd.Variable(x).is_sparse)
+
+    def test_resize_as(self):
+        from torch.autograd import Variable
+        x = self.SparseTensor()
+        v = Variable(x)
+
+        def empty_like(t):
+            return t.new().resize_as_(t)
+
+        self.assertEqual(empty_like(x).shape, x.shape)
+        self.assertEqual(empty_like(v).shape, v.shape)
 
 
 class TestUncoalescedSparse(TestSparse):

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -413,7 +413,13 @@ Tensor & VariableType::resize_(Tensor & self, IntList size) const {
 }
 
 Tensor & VariableType::resize_as_(Tensor & self, const Tensor & the_template) const {
-  return resize_(self, the_template.sizes());
+  auto& self_ = unpack(self, "self", 0);
+  auto& the_template_ = unpack(the_template, "the_template", 1);
+  if (static_cast<Variable&>(self).requires_grad()) {
+    at::runtime_error("cannot resize variables that require grad");
+  }
+  baseType->resize_as_(self_, the_template_);
+  return self;
 }
 
 Tensor VariableType::contiguous(const Tensor & self) const {

--- a/torch/csrc/generic/SparseTensor.cpp
+++ b/torch/csrc/generic/SparseTensor.cpp
@@ -111,7 +111,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
   // torch.SparseTensor(torch.Size sizes)
   else if (num_args == 1 && THPSize_Check(first_arg)) {
     THLongStoragePtr sizes(THPUtils_unpackSize(first_arg));
-    self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get());
+    self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get(), nullptr);
   }
   // torch.SparseTensor(torch.LongTensor indices, torch.LongTensor values)
   else if (num_args == 2 && THPIndexTensor_Check(first_arg)) {
@@ -149,7 +149,7 @@ static PyObject * THSPTensor_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
     }
     // torch.SparseTensor(int ...)
     else if (THPUtils_tryUnpackLongVarArgs(args, 0, sizes)) {
-      self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get());
+      self->cdata = THSTensor_(newWithSize)(LIBRARY_STATE sizes.get(), nullptr);
     }
     else goto invalid_arguments; // All other cases
   }


### PR DESCRIPTION
Also enable Tensor::tensor(...) on sparse types

This adds a dummy `THLongStorage*` argument to `THSTensor_(new)` to match the signature of `THTensor_(new)`. This makes the `THS` code a little uglier, but keeps the ATen bindings simple.

For sparse tensors, `resize_as_` isn't identical to `resize_(other.sizes())` since it copies the `nDimensionI` and `nDimensionV`.