### PR TITLE
Heuristic-based autograd execution order

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -375,6 +375,7 @@ struct Workspace {
   }
   Workspace(const Workspace&) = delete;
   Workspace(Workspace&&) = default;
+  Workspace& operator=(Workspace&&) = default;
   ~Workspace() {
     if (data) {
       THCudaFree(globalContext().lazyInitCUDA(), data);

--- a/test/expect/TestJit.test_input_pruning.expect
+++ b/test/expect/TestJit.test_input_pruning.expect
@@ -7,6 +7,6 @@ graph(%0 : Double(5, 5)
   %3 : Double(5, 5) = add[alpha={1}](%0, %1)
   ---------------- stage 1 ----------------
   %6 : Double(5, 5) = mul(%4, %1)
-  %7 : Double(5, 5) = add[alpha={1}](%6, %5)
+  %7 : Double(5, 5) = add[alpha={1}](%5, %6)
   return (%2, %3, %7);
 }

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -10,6 +10,8 @@
 
 namespace torch { namespace autograd {
 
+thread_local uint64_t Function::function_counter = 0;
+
 template<typename T>
 auto makeFlags(const T &inputs) -> FunctionFlags {
   int num_inputs = inputs.size();

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -50,8 +50,11 @@ struct FunctionFlags {
 };
 
 struct Function : std::enable_shared_from_this<Function> {
+  static thread_local uint64_t function_counter;
+
   Function()
     : num_inputs(0)
+    , time(function_counter++)
     , next_functions()
     , pre_hooks()
     , post_hooks()
@@ -60,6 +63,7 @@ struct Function : std::enable_shared_from_this<Function> {
 
   Function(FunctionFlags&& flags)
     : num_inputs(0)
+    , time(function_counter++)
     , next_functions(std::move(flags.next_functions))
     , pre_hooks()
     , post_hooks()
@@ -152,6 +156,7 @@ struct Function : std::enable_shared_from_this<Function> {
                                const variable_list& inputs, const variable_list& outputs);
 
   int num_inputs;
+  uint64_t time;
   function_list next_functions;
   std::vector<std::shared_ptr<FunctionPreHook>> pre_hooks;
   std::vector<std::shared_ptr<FunctionPostHook>> post_hooks;

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -20,6 +20,7 @@ struct InputBuffer {
     : buffer(size) {}
   InputBuffer(const InputBuffer& other) = delete;
   InputBuffer(InputBuffer&& other) = default;
+  InputBuffer& operator=(InputBuffer&& other) = default;
 
   // Accumulates the variable at a specified index.
   void add(size_t idx, Variable var);


### PR DESCRIPTION
**tl;dr**: This PR implements the heuristic-based autograd execution order, where the tasks for each thread are ordered by the time the `Function` is created. `Function`s created later are executed earlier.

The current breadth-first (BFS) order can cause huge memory usage in certain models. This was discovered using a real model that uses a `Linear` module multiple times in forward. After `Linear` is decomposed into `Transpose`+`Addmm` (https://github.com/pytorch/pytorch/pull/1935), the BFS orders all `TBackward` tasks at last to execute, causing huge amount of memory occupied by intermediate results. 

With help from @ezyang , @apaszke , @zdevito and @colesbury , I have benchmarked three autograd execution orders:

1. BFS (the current scheme): 
  Within a thread, tasks are fetched from a FIFO queue.
  Sample diff: None.

2. DFS:
  Within a thread, tasks are fetched from a LIFO stack.
  Sample diff: https://github.com/SsnL/pytorch/commit/ac5a97dca0caef88ed0c2d00e9c4b90663a3f2cc

3. HEAP (Heuristic based):
  Within a thread, tasks are fetched from a max-heap, ordered by the time each autograd Function is created.
  Sample diff: https://github.com/SsnL/pytorch/commit/44d91b1ea11b0cda2487d9f0ef68706365aabd94

The benchmark code is applying the above diffs on master at https://github.com/pytorch/pytorch/commit/2dd7039b6badcc362fb6da62a33c49418acd5c5d, with code from [#4511 (Methods for checking CUDA memory usage)](https://github.com/pytorch/pytorch/pull/4511) manually added.

The benchmarked tasks include: ImageNet on ResNet50, Open-NMT, word language model, CycleGAN, the mini-model with which we discovered the issue (*), and a model specifically crafted to make DFS and HEAP perform worse (**).

The benchmark details and results can be found [here](https://github.com/pytorch/pytorch/files/1647739/autograd.pdf). Roughly speaking, the performance for three approaches are similar, except on (*) and (**).

Basing on the results and following discussions, we think it would be reasonable to switch to HEAP ordering, because:

1. There is no substantial slowdown in some common models from benchmark results.

2. All three orders have edges cases that make them bad. But HEAP and DFS need a particular bad way of creating multi-device graph, which should be very uncommon. Yet BFS case can be encountered in real models, especially for models with many Linear layers (T+Addmm). HEAP generally performs slightly better than DFS in benchmark results.

3. This is probably a weaker point. For BFS and DFS, the actual backward order depends on the order of operator args. For HEAP, it instead depends on the creation order of ops, which I think is easier to reason about. Although we probably shouldn't encourage user to tune the ordering, it will be helpful for us to fix some OOM models without releasing new binaries.

Furthermore, after benchmarking on a tiny CPU model, we don't see obvious overheads for maintaining the heap.