### PR TITLE
Disable CUDA qr_big test on Windows

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -315,11 +315,13 @@ tests = [
     ('qr', small_2d_lapack, lambda t: [], 'square', float_types),
     ('qr', small_2d_lapack_skinny, lambda t: [], 'skinny', float_types),
     ('qr', small_2d_lapack_fat, lambda t: [], 'fat', float_types),
-    ('qr', large_2d_lapack, lambda t: [], 'big', float_types),
     ('inverse', new_t(20, 20), lambda t: [], None, float_types),
     ('geqrf', new_t(20, 20), lambda t: [], None, float_types),
     # TODO: add det to here once Variable and Tensor are the same thing
 ]
+
+if not IS_WINDOWS:
+    tests.append(('qr', large_2d_lapack, lambda t: [], 'big', float_types))
 
 # TODO: random functions, cat, gather, scatter, index*, masked*,
 #       resize, resizeAs, storage_offset, storage, stride, unfold


### PR DESCRIPTION
CUDA qr_big test is known to cause several intermittent CI issues: 

- It can be stuck which leads to a build timeout (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test/494/console)

- It can have numerical errors (https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test/563/console) 

Disabling it now until we have a proper fix to this problem. Added to https://github.com/pytorch/pytorch/issues/4092.