### PR TITLE
Add kwarg-only 'requires_grad' parameter to Variable factories.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -800,6 +800,13 @@ class TestAutograd(TestCase):
         with self.assertRaises(RuntimeError):
             b.add_(5)
 
+    def test_requires_grad_factory(self):
+        x = Variable(torch.randn(2, 3))
+        fns = [torch.ones_like, torch.testing.randn_like]
+        for fn in fns:
+            for val in [True, False]:
+                self.assertEqual(val, fn(x, requires_grad=val).requires_grad)
+
     def test_grad_assignment(self):
         x = Variable(torch.randn(5, 5))
         a = Variable(torch.randn(2, 2))  # size mismatch

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -307,15 +307,18 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 raise RuntimeError("found more than 1 entry in python_binding_arguments")
             for arg in declaration['python_binding_arguments']:
                 if not arg['name'] == 'requires_grad' or not arg['type'] == 'bool':
-                    raise RuntimeError("found {} in python_binding_arugments but only bool requires_grad is supported".format(arg))
-                # we have to use out_idx if there is an out variant because the base variant won't have the full arg_idx count
+                    raise RuntimeError(("found {} in python_binding_arguments but only "
+                                        "bool requires_grad is supported".format(arg)))
+                # we have to use out_idx if there is an out variant because the base variant
+                # won't have the full arg_idx count
                 requires_grad_idx = arg_idx if out_idx is None else out_idx + 1
                 requires_grad = parse_arg(arg, requires_grad_idx)[0]
 
         env = nested_dict(env, nested_dict(base_env, declaration))
         call_dispatch = PY_VARIABLE_CALL_DISPATCH.substitute(env)
         if requires_grad:
-            call_dispatch = PY_VARIABLE_SET_REQUIRES_GRAD.substitute(env, call_dispatch=call_dispatch, requires_grad=requires_grad)
+            call_dispatch = PY_VARIABLE_SET_REQUIRES_GRAD.substitute(env, call_dispatch=call_dispatch,
+                                                                     requires_grad=requires_grad)
         body.append(PY_VARIABLE_WRAP.substitute(env, call_dispatch=call_dispatch))
         py_method_dispatch.append(PY_VARIABLE_DISPATCH.substitute(env))
         return body
@@ -462,6 +465,7 @@ def get_python_signature(declaration, include_out):
     typed_args = []
     output_args = []
     positional = True
+
     def get_typed_arg(arg):
         typename = arg['simple_type']
         if arg.get('is_nullable'):
@@ -489,7 +493,6 @@ def get_python_signature(declaration, include_out):
             positional = False
         param = get_typed_arg(arg)
         typed_args.append(param)
-
 
     # add output arguments
     name = declaration['name']

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -302,17 +302,16 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         env['AutoGPU'] = auto_gpu(declaration)
 
         requires_grad = None
-        if len(declaration.get('python_binding_arguments', [])) > 0:
-            if len(declaration['python_binding_arguments']) > 1:
-                raise RuntimeError("found more than 1 entry in python_binding_arguments")
-            for arg in declaration['python_binding_arguments']:
-                if not arg['name'] == 'requires_grad' or not arg['type'] == 'bool':
-                    raise RuntimeError(("found {} in python_binding_arguments but only "
-                                        "bool requires_grad is supported".format(arg)))
-                # we have to use out_idx if there is an out variant because the base variant
-                # won't have the full arg_idx count
-                requires_grad_idx = arg_idx if out_idx is None else out_idx + 1
-                requires_grad = parse_arg(arg, requires_grad_idx)[0]
+        if len(declaration.get('python_binding_arguments', [])) > 1:
+            raise RuntimeError("found more than 1 entry in python_binding_arguments")
+        for arg in declaration.get('python_binding_arguments', []):
+            if not arg['name'] == 'requires_grad' or not arg['type'] == 'bool':
+                raise RuntimeError(("found {} in python_binding_arguments but only "
+                                    "bool requires_grad is supported".format(arg)))
+            # we have to use out_idx if there is an out variant because the base variant
+            # won't have the full arg_idx count
+            requires_grad_idx = arg_idx if out_idx is None else out_idx + 1
+            requires_grad = parse_arg(arg, requires_grad_idx)[0]
 
         env = nested_dict(env, nested_dict(base_env, declaration))
         call_dispatch = PY_VARIABLE_CALL_DISPATCH.substitute(env)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -66,7 +66,13 @@ if (r.isNone(${out_idx})) {
 """)
 
 PY_VARIABLE_CALL_DISPATCH = CodeTemplate("""\
-return wrap(${dispatch_name}(${actuals}));""")
+${dispatch_name}(${actuals})""")
+
+PY_VARIABLE_SET_REQUIRES_GRAD = CodeTemplate("""\
+set_requires_grad(${call_dispatch}, ${requires_grad})""")
+
+PY_VARIABLE_WRAP = CodeTemplate("""\
+return wrap(${call_dispatch});""")
 
 PY_VARIABLE_DISPATCH = CodeTemplate("""\
 inline ${return_type} ${dispatch_name}(${formal_args}) {
@@ -204,7 +210,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             return ''
         return 'AutoGPU auto_gpu({});'.format(tensor_arg)
 
-    def emit_single_dispatch(declaration, base_env):
+    def emit_single_dispatch(declaration, out_idx, base_env):
         env = {}
         simple_return_type = declaration['return_type'].replace(' &', '')
         assert simple_return_type in SUPPORTED_RETURN_TYPES, \
@@ -221,7 +227,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         inputs = [arg for arg in declaration['arguments'] if not is_output(arg)]
         outputs = [arg for arg in declaration['arguments'] if is_output(arg)]
 
-        def parse_arg(arg, unpack_args=False):
+        def parse_arg(arg, arg_index, unpack_args=False):
             name = arg['name']
             typename = arg['type']
             if typename.startswith('IntList['):
@@ -234,10 +240,10 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                     '`{}` type is not supported in python_default_init'.format(typename)
                 unpack_with_default = unpack_with_default_methods.get(typename)
                 default_expr = arg.get('python_default_init')
-                expr = 'r.{}({}, {})'.format(unpack_with_default, arg_idx, default_expr)
+                expr = 'r.{}({}, {})'.format(unpack_with_default, arg_index, default_expr)
             else:
                 unpack = unpack_methods.get(typename, typename.lower())
-                expr = 'r.{}({})'.format(unpack, arg_idx)
+                expr = 'r.{}({})'.format(unpack, arg_index)
 
             if unpack_args:
                 body.append('auto {} = {};'.format(name, expr))
@@ -248,13 +254,17 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             if typename == 'SparseTensor':
                 expr = 'SparseTensor({})'.format(expr)
 
-            actuals.append(expr)
             dispatch_type = typename
             if dispatch_type == 'Tensor':
                 dispatch_type = 'const Tensor &'
             elif dispatch_type == 'Tensor &':
                 dispatch_type = 'Tensor'
-            formal_args.append('{} {}'.format(dispatch_type, name))
+            formal = '{} {}'.format(dispatch_type, name)
+            return expr, formal
+
+        def append_actuals_formals(actual, formal):
+            actuals.append(actual)
+            formal_args.append(formal)
 
         unpack = any(arg.get('python_default_init') for arg in inputs)
         for arg in inputs:
@@ -262,11 +272,11 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 formal_args.append('Tensor & self')
                 actuals.append('self_')
                 continue
-            parse_arg(arg, unpack)
+            append_actuals_formals(*parse_arg(arg, arg_idx, unpack))
             arg_idx += 1
 
         if len(outputs) == 1:
-            parse_arg(outputs[0])
+            append_actuals_formals(*parse_arg(outputs[0], arg_idx))
         elif len(outputs) > 1:
             N = len(outputs)
             body.append('auto results = r.tensorlist_n<{}>({});'.format(N, arg_idx))
@@ -290,8 +300,23 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             env['dispatch_call'] = 'default_type().{}'.format(declaration['name'])
         env['AutoNoGIL'] = 'AutoNoGIL no_gil;'
         env['AutoGPU'] = auto_gpu(declaration)
+
+        requires_grad = None
+        if len(declaration.get('python_binding_arguments', [])) > 0:
+            if len(declaration['python_binding_arguments']) > 1:
+                raise RuntimeError("found more than 1 entry in python_binding_arguments")
+            for arg in declaration['python_binding_arguments']:
+                if not arg['name'] == 'requires_grad' or not arg['type'] == 'bool':
+                    raise RuntimeError("found {} in python_binding_arugments but only bool requires_grad is supported".format(arg))
+                # we have to use out_idx if there is an out variant because the base variant won't have the full arg_idx count
+                requires_grad_idx = arg_idx if out_idx is None else out_idx + 1
+                requires_grad = parse_arg(arg, requires_grad_idx)[0]
+
         env = nested_dict(env, nested_dict(base_env, declaration))
-        body.append(PY_VARIABLE_CALL_DISPATCH.substitute(env))
+        call_dispatch = PY_VARIABLE_CALL_DISPATCH.substitute(env)
+        if requires_grad:
+            call_dispatch = PY_VARIABLE_SET_REQUIRES_GRAD.substitute(env, call_dispatch=call_dispatch, requires_grad=requires_grad)
+        body.append(PY_VARIABLE_WRAP.substitute(env, call_dispatch=call_dispatch))
         py_method_dispatch.append(PY_VARIABLE_DISPATCH.substitute(env))
         return body
 
@@ -300,22 +325,57 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             out_idx = len([arg for arg in dictionary['out']['arguments']
                            if not arg.get('output', False)])
             env = {}
-            env['call_dispatch_out'] = emit_single_dispatch(dictionary['out'], base_env)
-            env['call_dispatch'] = emit_single_dispatch(dictionary['base'], base_env)
+            env['call_dispatch_out'] = emit_single_dispatch(dictionary['out'], out_idx, base_env)
+            env['call_dispatch'] = emit_single_dispatch(dictionary['base'], out_idx, base_env)
             body = PY_VARIABLE_OUT.substitute(env, out_idx=out_idx).split('\n')
         else:
-            body = emit_single_dispatch(dictionary['base'], base_env)
+            body = emit_single_dispatch(dictionary['base'], None, base_env)
 
         cond = 'if' if i == 0 else '} else if'
         return PY_VARIABLE_CASE.substitute(i=i, cond=cond, call_dispatch=body)
 
+    def get_requires_grad_argument(declaration):
+        requires_grad_arg = []
+        has_tensor_input_arg = False
+        for arg in declaration['arguments']:
+            if arg.get('output', False):
+                continue
+            typename = arg['simple_type']
+            if typename in ['Tensor', 'TensorList']:
+                has_tensor_input_arg = True
+            if arg['name'] == 'requires_grad':
+                raise ValueError("argument named requires_grad not supported")
+
+        has_tensor_return = False
+        for ret in declaration['returns']:
+            if ret['dynamic_type'] in ['Tensor', 'TensorList']:
+                # this probably won't work if one of the returns is not a tensor, but it will
+                # produce a compile-time error that is obvious
+                has_tensor_return = True
+
+        if (not has_tensor_input_arg or name.endswith('_like')) and has_tensor_return:
+            arg = {
+                'default': False,
+                'default_init': False,
+                'dynamic_type': 'bool',
+                'kwarg_only': True,
+                'name': 'requires_grad',
+                'type': 'bool',
+                'simple_type': 'bool',
+            }
+            requires_grad_arg.append(arg),
+        return requires_grad_arg
+
     def process_function(name, declarations):
+        for declaration in declarations:
+            declaration['python_binding_arguments'] = get_requires_grad_argument(declaration)
+
         env = {
             'name': name,
             'dispatch_name': 'dispatch_{}'.format(name),
             'pycname': 'THPVariable_{}'.format(name),
             'signatures': [],
-            'max_args': max(len(o['arguments']) for o in declarations),
+            'max_args': max(len(o['arguments']) + len(o['python_binding_arguments']) for o in declarations),
             'unpack_self': [],
             'dispatch': [],
         }
@@ -402,13 +462,7 @@ def get_python_signature(declaration, include_out):
     typed_args = []
     output_args = []
     positional = True
-    for arg in declaration['arguments']:
-        if arg.get('output', False):
-            output_args.append(arg)
-            continue
-        if arg.get('kwarg_only', False) and positional:
-            typed_args.append('*')
-            positional = False
+    def get_typed_arg(arg):
         typename = arg['simple_type']
         if arg.get('is_nullable'):
             typename = '{}?'.format(typename)
@@ -424,7 +478,18 @@ def get_python_signature(declaration, include_out):
             default = 'None'
         if default is not None:
             param += '=' + str(default)
+        return param
+
+    for arg in declaration['arguments']:
+        if arg.get('output', False):
+            output_args.append(arg)
+            continue
+        if arg.get('kwarg_only', False) and positional:
+            typed_args.append('*')
+            positional = False
+        param = get_typed_arg(arg)
         typed_args.append(param)
+
 
     # add output arguments
     name = declaration['name']
@@ -442,6 +507,14 @@ def get_python_signature(declaration, include_out):
         else:
             typename = typenames[0]
         typed_args.append(typename + ' out=None')
+
+    # we could put this in the loop above but we want to ensure it is after the out argument
+    if len(declaration['python_binding_arguments']) > 0:
+        for arg in declaration['python_binding_arguments']:
+            if arg.get('kwarg_only', False) and positional:
+                typed_args.append('*')
+                positional = False
+            typed_args.append(get_typed_arg(arg))
 
     # Python function signature.
     # This is the string that we give to FunctionParameter, which is

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -23,8 +23,8 @@ using namespace torch::autograd::utils;
 
 namespace torch { namespace autograd {
 
-static const Tensor & set_requires_grad(const Tensor &self, bool requires_grad) {
-  Variable(self).get()->_requires_grad = requires_grad;
+static Tensor set_requires_grad(Tensor self, bool requires_grad) {
+  static_cast<Variable&>(self).get()->_requires_grad = requires_grad;
   return self;
 }
 

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -23,6 +23,11 @@ using namespace torch::autograd::utils;
 
 namespace torch { namespace autograd {
 
+static const Tensor & set_requires_grad(const Tensor &self, bool requires_grad) {
+  Variable(self).get()->_requires_grad = requires_grad;
+  return self;
+}
+
 static Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
   AutoNoGIL no_gil;
   AutoGPU auto_gpu(self);

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -37,5 +37,4 @@ def make_non_contiguous(tensor):
     return input
 
 
-def randn_like(variable):
-    return torch._C._VariableFunctions.randn_like(variable)
+randn_like = torch._C._VariableFunctions.randn_like


### PR DESCRIPTION
Functions that create variables, e.g. torch.ones_like currently always return Variables with requires_grad=False; this is less convenient than the existing Variable constructor that has a requires_grad parameter.  This commit adds the parameter at the python binding level.