### PR TITLE
Implement a (data-only) Variable factory

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1044,6 +1044,18 @@ class TestTorch(TestCase):
         output = torch.ones_like(x)
         self.assertEqual(output, expected)
 
+    def test_variable_factory(self):
+        expected = torch.autograd.Variable(torch.Tensor([1, 1]))
+        # test data
+        res1 = torch.autograd.variable([1, 1])
+        self.assertEqual(res1, expected)
+
+        # test copy
+        res2 = torch.autograd.variable(expected)
+        self.assertEqual(res2, expected)
+        res2[1] = 2
+        self.assertEqual(expected, torch.ones_like(expected))
+
     def test_diag(self):
         x = torch.rand(100, 100)
         res1 = torch.diag(x)

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -11,6 +11,7 @@
 #include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/autograd/utils/wrap_outputs.h"
 #include "torch/csrc/utils/python_arg_parser.h"
+#include "torch/csrc/utils/tensor_new.h"
 #include "torch/csrc/utils/tensor_numpy.h"
 
 #include "python_torch_functions_dispatch.h"
@@ -68,6 +69,13 @@ static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_variable(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  return THPVariable_Wrap(torch::utils::variable_data_factory(default_type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
 // generated methods start here
 
 ${py_methods}
@@ -75,6 +83,7 @@ ${py_methods}
 static PyMethodDef torch_functions[] = {
   {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"from_numpy", (PyCFunction)THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
+  {"variable", (PyCFunction)THPVariable_variable, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   ${py_method_defs}
   {NULL}
 };

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -13,7 +13,7 @@ from .gradcheck import gradcheck
 from .grad_mode import no_grad, enable_grad
 from . import profiler
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'variable']
 
 
 def _make_grads(outputs, grads):
@@ -139,6 +139,7 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
         outputs, grad_outputs, retain_graph, create_graph,
         inputs)
 
+variable = torch._C._VariableFunctions.variable
 
 if not torch._C._autograd_init():
     raise RuntimeError("autograd initialization failed")

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -6,5 +6,6 @@
 namespace torch { namespace utils {
 
 at::Tensor tensor_new(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor variable_data_factory(const at::Type& type, PyObject* args, PyObject* kwargs);
 
 }} // namespace torch::utils


### PR DESCRIPTION
Implements a function, torch.autograd.variable that is modeled after np.array.  The main difference between it and new() and the tensor constructors is it inteprets a python number as data, i.e. as a 0-dimensional tensor (we currently don't expose that at the pytorchl level, so it will temporarily end up as a 1-dimensional tensor), rather than a size.

The main difference currently between torch.autograd.variable and np.array is that np.autograd.variable is stricter, e.g. passing a PyFloat when an integral type is the default tensor type will result in an array; np.array basically lets anything through (floating-point / integral mismatch, overflow, etc).  This is to keep it consistent with Variable.new when called with a sequence, although we can loosen the checks later.

This will be renamed to torch.tensor once we merge Variable and tensor.