### PR TITLE
Allow assertEqual checks with mixed Tensors, Variables, numbers.

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -191,10 +191,10 @@ class TestCase(unittest.TestCase):
         return tg
 
     def unwrapVariables(self, x, y):
-        if isinstance(x, Variable) and isinstance(y, Variable):
-            return x.data, y.data
-        elif isinstance(x, Variable) or isinstance(y, Variable):
-            raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
+        if isinstance(x, Variable):
+            x = x.data
+        if isinstance(y, Variable):
+            y = y.data
         return x, y
 
     def assertEqual(self, x, y, prec=None, message='', allow_inf=False):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4807,6 +4807,14 @@ class TestTorch(TestCase):
         self.assertIsInstance(x.char().sum(), int)
         self.assertIsInstance(x.byte().sum(), int)
 
+    def test_assertEqual(self):
+        x = torch.FloatTensor([0])
+        self.assertEqual(x, 0)
+        xv = torch.autograd.Variable(x)
+        self.assertEqual(xv, 0)
+        self.assertEqual(x, xv)
+        self.assertEqual(xv, x)
+
     def test_new(self):
         x = torch.autograd.Variable(torch.Tensor())
         y = torch.autograd.Variable(torch.randn(4, 4))


### PR DESCRIPTION
Currently, a Variable can only be compared with a Variable, but a Tensor can be compared with Tensors or numbers.  Relax this constraint so Variables behave identically to Tensors.

This won't matter once we merge Variables and Tensors, but is useful along that path.