### PR TITLE
Removing NCCL clear_group_cache workaround with one more check in new_group

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -576,7 +576,7 @@ elif BACKEND == 'mpi':
 
 elif BACKEND == 'nccl':
     dist.init_process_group(init_method=INIT_METHOD, backend='nccl')
-    # TODO
+    # TODO adding some NCCL backend test later
 
     class TestNCCL(TestCase, _DistTestBase):
         pass

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -577,6 +577,7 @@ elif BACKEND == 'mpi':
 elif BACKEND == 'nccl':
     dist.init_process_group(init_method=INIT_METHOD, backend='nccl')
     # TODO
+
     class TestNCCL(TestCase, _DistTestBase):
         pass
 

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -574,6 +574,12 @@ elif BACKEND == 'mpi':
     class TestMPI(TestCase, _DistTestBase):
         pass
 
+elif BACKEND == 'nccl':
+    dist.init_process_group(init_method=INIT_METHOD, backend='nccl')
+    # TODO
+    class TestNCCL(TestCase, _DistTestBase):
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/torch/csrc/distributed/Module.cpp
+++ b/torch/csrc/distributed/Module.cpp
@@ -374,8 +374,8 @@ PyObject* THDPModule_allReduceMultiGPU(PyObject *_unused, PyObject *args)
   PyObject* sequence = PyTuple_GET_ITEM(args, 0);
   Py_ssize_t tmp_length;
   std::size_t length;
-  std::vector<THDPTensorDesc> descriptors;
-  std::vector<THDTensorDescriptor*> raw_descriptors;
+  std::vector<at::Tensor> descriptors;
+  std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
   THDReduceOp op;
 
@@ -396,7 +396,7 @@ PyObject* THDPModule_allReduceMultiGPU(PyObject *_unused, PyObject *args)
     }
 
     descriptors.push_back(
-      THDPTensorDesc(THDPModule_makeDescriptor(PySequence_ITEM(sequence, i)))
+      THDPModule_makeDescriptor(PySequence_ITEM(sequence, i))
     );
     raw_descriptors.push_back(descriptors.back());
   }
@@ -424,8 +424,8 @@ PyObject* THDPModule_reduceMultiGPU(PyObject *_unused, PyObject *args)
   PyObject* sequence = PyTuple_GET_ITEM(args, 0);
   Py_ssize_t tmp_length;
   std::size_t length;
-  std::vector<THDPTensorDesc> descriptors;
-  std::vector<THDTensorDescriptor*> raw_descriptors;
+  std::vector<at::Tensor> descriptors;
+  std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
   THDReduceOp op;
   int dst_rank;
@@ -448,7 +448,7 @@ PyObject* THDPModule_reduceMultiGPU(PyObject *_unused, PyObject *args)
     }
 
     descriptors.push_back(
-      THDPTensorDesc(THDPModule_makeDescriptor(PySequence_ITEM(sequence, i)))
+      THDPModule_makeDescriptor(PySequence_ITEM(sequence, i))
     );
     raw_descriptors.push_back(descriptors.back());
   }
@@ -478,8 +478,8 @@ PyObject* THDPModule_broadcastMultiGPU(PyObject *_unused, PyObject *args)
   PyObject* sequence = PyTuple_GET_ITEM(args, 0);
   Py_ssize_t tmp_length;
   std::size_t length;
-  std::vector<THDPTensorDesc> descriptors;
-  std::vector<THDTensorDescriptor*> raw_descriptors;
+  std::vector<at::Tensor> descriptors;
+  std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
   int src_rank;
 
@@ -501,7 +501,7 @@ PyObject* THDPModule_broadcastMultiGPU(PyObject *_unused, PyObject *args)
     }
 
     descriptors.push_back(
-      THDPTensorDesc(THDPModule_makeDescriptor(PySequence_ITEM(sequence, i)))
+      THDPModule_makeDescriptor(PySequence_ITEM(sequence, i))
     );
     raw_descriptors.push_back(descriptors.back());
   }
@@ -535,11 +535,11 @@ PyObject* THDPModule_allGatherMultiGPU(PyObject *_unused, PyObject *args)
   size_t length_one;
   size_t length_two;
 
-  std::vector<THDPTensorDesc> output_descriptors;
-  std::vector<THDTensorDescriptor*> output_raw_descriptors;
+  std::vector<at::Tensor> output_descriptors;
+  std::vector<at::Tensor> output_raw_descriptors;
 
-  std::vector<THDPTensorDesc> input_descriptors;
-  std::vector<THDTensorDescriptor*> input_raw_descriptors;
+  std::vector<at::Tensor> input_descriptors;
+  std::vector<at::Tensor> input_raw_descriptors;
 
   THDGroup group;
 
@@ -574,14 +574,12 @@ PyObject* THDPModule_allGatherMultiGPU(PyObject *_unused, PyObject *args)
     }
 
     input_descriptors.push_back(
-      THDPTensorDesc(THDPModule_makeDescriptor(
-          PySequence_ITEM(sequence_two, i)))
+      THDPModule_makeDescriptor(PySequence_ITEM(sequence_two, i))
     );
     input_raw_descriptors.push_back(input_descriptors.back());
 
     output_descriptors.push_back(
-      THDPTensorDesc(THDPModule_makeDescriptor(
-          PySequence_ITEM(sequence_one, i)))
+      THDPModule_makeDescriptor(PySequence_ITEM(sequence_one, i))
     );
     output_raw_descriptors.push_back(output_descriptors.back());
   }

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -5,7 +5,7 @@ and initialization methods.
 """
 import torch
 import warnings
-from torch._utils import _flatten_tensors, _unflatten_tensors
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 _INITIALIZED_PG = 1
 _INITIALIZED_MW = 2
@@ -311,6 +311,7 @@ def reduce_multigpu(tensor_list, dst, op=reduce_op.SUM, group=group.WORLD):
         "Multi GPU collectives only supported in nccl backend"
     return torch._C._dist_reduce_multigpu(tensor_list, dst, op, group)
 
+
 def reduce(tensor, dst, op=reduce_op.SUM, group=group.WORLD):
     """Reduces the tensor data across all machines.
 
@@ -353,7 +354,7 @@ def all_gather_multigpu(output_tensor_lists,
 
     flatten_tensor_list = []
     for output_tensor_list in output_tensor_lists:
-        flatten_tensor_list.append(_flatten_tensors(output_tensor_list))
+        flatten_tensor_list.append(_flatten_dense_tensors(output_tensor_list))
 
     ret = torch._C._dist_all_gather_multigpu(flatten_tensor_list,
                                              input_tensor_list,
@@ -362,8 +363,8 @@ def all_gather_multigpu(output_tensor_lists,
     for output_tensor_list, flatten_tensor in zip(output_tensor_lists,
                                                   flatten_tensor_list):
         for tensor, value in zip(output_tensor_list,
-                                 _unflatten_tensors(flatten_tensor,
-                                                    output_tensor_list)):
+                                 _unflatten_dense_tensors(flatten_tensor,
+                                                          output_tensor_list)):
             tensor.copy_(value)
 
     return ret

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -67,6 +67,14 @@ def init_process_group(backend, init_method='env://', **kwargs):
     global _backend
     _backend = backend
     if backend == "nccl":
+        warnings.warn("""
+        ================================================================================
+                                            WARNING
+        ================================================================================
+        NCCL backend is still experimental. The APIs will change without
+        notice and we're can't guarantee full correctness and expected performance yet.
+        We'll announce it once it's ready.
+        """)
         atexit.register(destroy_process_group)
 
 
@@ -221,6 +229,16 @@ def broadcast_multigpu(tensor_list, src, group=group.WORLD):
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
+
+    warnings.warn("""
+    ================================================================================
+                                        WARNING
+    ================================================================================
+    broadcast_multigpu is still experimental. The API will change without
+    notice and we're can't guarantee full correctness and expected performance yet.
+    We'll announce it once it's ready.
+    """)
+
     return torch._C._dist_broadcast_multigpu(tensor_list, src, group)
 
 
@@ -264,6 +282,16 @@ def all_reduce_multigpu(tensor_list, op=reduce_op.SUM, group=group.WORLD):
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
+
+    warnings.warn("""
+    ================================================================================
+                                        WARNING
+    ================================================================================
+    all_reduce_multigpu is still experimental. The API will change without
+    notice and we're can't guarantee full correctness and expected performance yet.
+    We'll announce it once it's ready.
+    """)
+
     return torch._C._dist_all_reduce_multigpu(tensor_list, op, group)
 
 
@@ -305,6 +333,16 @@ def reduce_multigpu(tensor_list, dst, op=reduce_op.SUM, group=group.WORLD):
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
+
+    warnings.warn("""
+    ================================================================================
+                                        WARNING
+    ================================================================================
+    reduce__multigpu is still experimental. The API will change without
+    notice and we're can't guarantee full correctness and expected performance yet.
+    We'll announce it once it's ready.
+    """)
+
     return torch._C._dist_reduce_multigpu(tensor_list, dst, op, group)
 
 
@@ -345,6 +383,15 @@ def all_gather_multigpu(output_tensor_lists,
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
+
+    warnings.warn("""
+    ================================================================================
+                                        WARNING
+    ================================================================================
+    all_gather_multigpu is still experimental. The API will change without
+    notice and we're can't guarantee full correctness and expected performance yet.
+    We'll announce it once it's ready.
+    """)
 
     flatten_tensor_list = []
     for output_tensor_list in output_tensor_lists:

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -378,7 +378,7 @@ def all_gather(tensor_list, tensor, group=group.WORLD):
     if _backend != "nccl":
         return torch._C._dist_all_gather(tensor_list, tensor, group)
     else:
-        return all_gather_multigpu(tensor_list, list[tensor], group)
+        return all_gather_multigpu([tensor_list], [tensor], group)
 
 
 def gather(tensor, **kwargs):

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -85,7 +85,7 @@ def init_process_group(backend, init_method='env://', **kwargs):
     elif backend == "nccl":
         _backend = dist_backend.NCCL
     else:
-        raise RuntimeError("Invalid distributed backend name detected")
+        raise RuntimeError("Invalid distributed backend name: " + backend)
 
     if _backend == dist_backend.NCCL:
         warnings.warn("""

--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -38,6 +38,8 @@ IF(NOT HAS_THREAD_LOCAL)
                         "XCode 8 or newer.")
 ENDIF(NOT HAS_THREAD_LOCAL)
 
+FIND_PACKAGE(NCCL)
+
 FIND_PACKAGE(MPI)
 
 FIND_PACKAGE(Gloo)
@@ -65,6 +67,11 @@ ENDIF()
 
 IF(GLOO_FOUND)
   ADD_DEFINITIONS(-DWITH_GLOO=1)
+ENDIF()
+
+IF(NCCL_FOUND)
+  MESSAGE(STATUS "NCCL_LIBRARIES: ${NCCL_LIBRARIES}")
+  ADD_DEFINITIONS(-DWITH_SYSTEM_NCCL=1)
 ENDIF()
 
 ADD_DEFINITIONS(-D_THD_CORE=1)
@@ -96,12 +103,22 @@ IF(NOT GLOO_FOUND)
   LIST(REMOVE_ITEM test_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/data_channel_gloo_cache.cpp")
 ENDIF()
 
+IF(NOT NCCL_FOUND)
+  LIST(REMOVE_ITEM base_cpp "${CMAKE_CURRENT_SOURCE_DIR}/base/data_channels/DataChannelNccl.cpp")
+ENDIF()
+
 EXCLUDE_DIR(master_worker_cpp ".*/dispatch/.*\\.cpp$")
 
 SET(all_cpp ${base_cpp} ${process_group_cpp} ${master_worker_cpp})
 SET(all_h THD.h ${base_h} ${process_group_h} ${master_worker_h})
 
 EXCLUDE_DIR(all_cpp ".*/generic/.*\\.cpp$")
+
+# Need to include external NCCL first
+IF(NCCL_FOUND)
+  INCLUDE_DIRECTORIES(${NCCL_INCLUDE_DIR})
+  FILE(APPEND "${CMAKE_INSTALL_PREFIX}/THD_deps.txt" "${NCCL_LIBRARIES};")
+ENDIF()
 
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -71,7 +71,19 @@ ENDIF()
 
 IF(NCCL_FOUND)
   MESSAGE(STATUS "NCCL_LIBRARIES: ${NCCL_LIBRARIES}")
-  ADD_DEFINITIONS(-DWITH_SYSTEM_NCCL=1)
+  IF(NCCL_MAJOR_VERSION AND NOT (NCCL_MAJOR_VERSION LESS 2))
+    MESSAGE(STATUS "NCCL Version 2 or higher found, will "
+                   "compile with NCCL distributed backend")
+    SET(DISTRIBUTED_NCCL_FOUND TRUE)
+    ADD_DEFINITIONS(-DWITH_DISTRIBUTED_NCCL=1)
+  ELSE()
+    MESSAGE(STATUS "Found NCCL, but the NCCL version is either not 2+ or not "
+                   "determinable, will not compile with NCCL distributed "
+                   "backend")
+  ENDIF()
+ELSE()
+  MESSAGE(STATUS "Not able to find NCCL, will not "
+                 "compile with NCCL distributed backend")
 ENDIF()
 
 ADD_DEFINITIONS(-D_THD_CORE=1)
@@ -103,7 +115,7 @@ IF(NOT GLOO_FOUND)
   LIST(REMOVE_ITEM test_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/data_channel_gloo_cache.cpp")
 ENDIF()
 
-IF(NOT NCCL_FOUND)
+IF(NOT DISTRIBUTED_NCCL_FOUND)
   LIST(REMOVE_ITEM base_cpp "${CMAKE_CURRENT_SOURCE_DIR}/base/data_channels/DataChannelNccl.cpp")
 ENDIF()
 
@@ -115,7 +127,7 @@ SET(all_h THD.h ${base_h} ${process_group_h} ${master_worker_h})
 EXCLUDE_DIR(all_cpp ".*/generic/.*\\.cpp$")
 
 # Need to include external NCCL first
-IF(NCCL_FOUND)
+IF(DISTRIBUTED_NCCL_FOUND)
   INCLUDE_DIRECTORIES(${NCCL_INCLUDE_DIR})
   FILE(APPEND "${CMAKE_INSTALL_PREFIX}/THD_deps.txt" "${NCCL_LIBRARIES};")
 ENDIF()

--- a/torch/lib/THD/base/ChannelType.h
+++ b/torch/lib/THD/base/ChannelType.h
@@ -3,5 +3,6 @@
 enum THDChannelType {
   THDChannelTCP = 0,
   THDChannelMPI,
-  THDChannelGloo
+  THDChannelGloo,
+  THDChannelNccl
 };

--- a/torch/lib/THD/base/DataChannel.cpp
+++ b/torch/lib/THD/base/DataChannel.cpp
@@ -6,9 +6,9 @@
 #ifdef WITH_MPI
 #include "data_channels/DataChannelMPI.hpp"
 #endif // WITH_MPI
-#if defined(WITH_CUDA) && defined(WITH_SYSTEM_NCCL)
+#if defined(WITH_CUDA) && defined(WITH_DISTRIBUTED_NCCL)
 #include "data_channels/DataChannelNccl.hpp"
-#endif // WITH_SYSTEM_NCCL
+#endif // WITH_DISTRIBUTED_NCCL
 #include "data_channels/DataChannelTCP.hpp"
 
 #include <algorithm>
@@ -44,7 +44,7 @@ DataChannel* DataChannel::newChannel(THDChannelType type, std::string init_metho
       );
 
     case THDChannelNccl:
-#if defined(WITH_CUDA) && defined(WITH_SYSTEM_NCCL)
+#if defined(WITH_CUDA) && defined(WITH_DISTRIBUTED_NCCL)
       return new DataChannelNccl(GET_CONFIG);
 #endif
       throw std::runtime_error(

--- a/torch/lib/THD/base/DataChannel.cpp
+++ b/torch/lib/THD/base/DataChannel.cpp
@@ -1,3 +1,4 @@
+/* definition to expand macro then apply to pragma message */
 #include "DataChannel.hpp"
 #ifdef WITH_GLOO
 #include "data_channels/DataChannelGloo.hpp"
@@ -5,6 +6,9 @@
 #ifdef WITH_MPI
 #include "data_channels/DataChannelMPI.hpp"
 #endif // WITH_MPI
+#if defined(WITH_CUDA) && defined(WITH_SYSTEM_NCCL)
+#include "data_channels/DataChannelNccl.hpp"
+#endif // WITH_SYSTEM_NCCL
 #include "data_channels/DataChannelTCP.hpp"
 
 #include <algorithm>
@@ -37,6 +41,15 @@ DataChannel* DataChannel::newChannel(THDChannelType type, std::string init_metho
       throw std::runtime_error(
         "the Gloo backend is not available; "
         "try to recompile the THD package with Gloo support"
+      );
+
+    case THDChannelNccl:
+#if defined(WITH_CUDA) && defined(WITH_SYSTEM_NCCL)
+      return new DataChannelNccl(GET_CONFIG);
+#endif
+      throw std::runtime_error(
+        "the distributed NCCL backend is not available; "
+        "try to recompile the THD package with CUDA and NCCL 2+ support"
       );
 
     default:

--- a/torch/lib/THD/base/DataChannel.cpp
+++ b/torch/lib/THD/base/DataChannel.cpp
@@ -1,4 +1,3 @@
-/* definition to expand macro then apply to pragma message */
 #include "DataChannel.hpp"
 #ifdef WITH_GLOO
 #include "data_channels/DataChannelGloo.hpp"

--- a/torch/lib/THD/base/DataChannel.hpp
+++ b/torch/lib/THD/base/DataChannel.hpp
@@ -74,6 +74,11 @@ struct DataChannel {
   virtual ~DataChannel() {};
 
   virtual bool init() = 0;
+
+  /**
+   * This is required for NCCL backend, since the destroy cannot be done before
+   * CUDA is unloaded since DataChannel is a static object.
+   */
   virtual void destroy() = 0;
 
   virtual rank_type getRank() = 0;

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -268,8 +268,7 @@ auto DataChannelGloo::ireceive(at::Tensor& data, rank_type src_rank) -> RequestG
 }
 
 
-void DataChannelGloo::allReduce(std::vector<at::Tensor>& input,
-                                std::vector<at::Tensor>& output,
+void DataChannelGloo::allReduce(std::vector<at::Tensor>& data,
                                 THDReduceOp operation,
                                 THDGroup groupId) {
 
@@ -278,8 +277,8 @@ void DataChannelGloo::allReduce(std::vector<at::Tensor>& input,
 }
 
 
-void DataChannelGloo::allGather(std::vector<at::Tensor>& input,
-                                std::vector<at::Tensor>& output,
+void DataChannelGloo::allGather(std::vector<at::Tensor>& output,
+                                std::vector<at::Tensor>& input,
                                 THDGroup groupId) {
 
   throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
@@ -306,8 +305,9 @@ void DataChannelGloo::broadcast(std::vector<at::Tensor>& data,
 }
 
 
-void DataChannelGloo::destroyGroup(THDGroup group_id) {
-  throw std::runtime_error("DataChannelGloo does not support destroy group");
+void DataChannelGloo::clearGroupCache(THDGroup group_id) {
+  throw std::runtime_error("DataChannelGloo does not support clear "
+                           "group cache");
 }
 
 

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -87,6 +87,7 @@ DataChannelGloo::DataChannelGloo(InitMethod::Config config)
 
 DataChannelGloo::~DataChannelGloo() {}
 
+void DataChannelGloo::destroy() {}
 
 bool DataChannelGloo::init() {
   _cache = std::unique_ptr<GlooCache>(new GlooCache(_rank, _device));
@@ -264,6 +265,49 @@ auto DataChannelGloo::isend(at::Tensor& data, rank_type dst_rank) -> RequestGloo
 
 auto DataChannelGloo::ireceive(at::Tensor& data, rank_type src_rank) -> RequestGloo* {
   throw std::runtime_error("DataChannelGloo does not support ireceive");
+}
+
+
+void DataChannelGloo::allReduce(std::vector<thpp::Tensor*>& input,
+                                std::vector<thpp::Tensor*>& output,
+                                THDReduceOp operation,
+                                THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
+                           "node allreduce");
+}
+
+
+void DataChannelGloo::allGather(std::vector<thpp::Tensor*>& input,
+                                std::vector<thpp::Tensor*>& output,
+                                THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
+                           "node allgather");
+}
+
+
+void DataChannelGloo::reduce(std::vector<thpp::Tensor*>& data,
+                             THDReduceOp operation,
+                             rank_type dstRank,
+                             THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
+                           "node reduce");
+}
+
+
+void DataChannelGloo::broadcast(std::vector<thpp::Tensor*>& data,
+                                rank_type srcRank,
+                                THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
+                           "node broadcast");
+}
+
+
+void DataChannelGloo::destroyGroup(THDGroup group_id) {
+  throw std::runtime_error("DataChannelGloo does not support destroy group");
 }
 
 

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -268,8 +268,8 @@ auto DataChannelGloo::ireceive(at::Tensor& data, rank_type src_rank) -> RequestG
 }
 
 
-void DataChannelGloo::allReduce(std::vector<thpp::Tensor*>& input,
-                                std::vector<thpp::Tensor*>& output,
+void DataChannelGloo::allReduce(std::vector<at::Tensor>& input,
+                                std::vector<at::Tensor>& output,
                                 THDReduceOp operation,
                                 THDGroup groupId) {
 
@@ -278,8 +278,8 @@ void DataChannelGloo::allReduce(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelGloo::allGather(std::vector<thpp::Tensor*>& input,
-                                std::vector<thpp::Tensor*>& output,
+void DataChannelGloo::allGather(std::vector<at::Tensor>& input,
+                                std::vector<at::Tensor>& output,
                                 THDGroup groupId) {
 
   throw std::runtime_error("DataChannelGloo does not support mult-GPU cross "
@@ -287,7 +287,7 @@ void DataChannelGloo::allGather(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelGloo::reduce(std::vector<thpp::Tensor*>& data,
+void DataChannelGloo::reduce(std::vector<at::Tensor>& data,
                              THDReduceOp operation,
                              rank_type dstRank,
                              THDGroup groupId) {
@@ -297,7 +297,7 @@ void DataChannelGloo::reduce(std::vector<thpp::Tensor*>& data,
 }
 
 
-void DataChannelGloo::broadcast(std::vector<thpp::Tensor*>& data,
+void DataChannelGloo::broadcast(std::vector<at::Tensor>& data,
                                 rank_type srcRank,
                                 THDGroup groupId) {
 

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.hpp
@@ -46,8 +46,8 @@ struct DataChannelGloo : DataChannel {
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
-  void allGather(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allGather(std::vector<at::Tensor>& output,
+                 std::vector<at::Tensor>& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
@@ -55,8 +55,7 @@ struct DataChannelGloo : DataChannel {
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
-  void allReduce(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allReduce(std::vector<at::Tensor>& data,
                  THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
@@ -83,7 +82,7 @@ struct DataChannelGloo : DataChannel {
   void barrier(THDGroup group_id = THDGroupWORLD) override;
 
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
-  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
+  void clearGroupCache(THDGroup group_id = THDGroupWORLD) override;
 
 
 private:

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.hpp
@@ -41,20 +41,35 @@ struct DataChannelGloo : DataChannel {
   virtual ~DataChannelGloo();
 
   bool init() override;
+  void destroy() override;
 
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
+  void allGather(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void gather(std::vector<at::Tensor>& output, at::Tensor& input,
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
+  void allReduce(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDReduceOp operation,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
+  void reduce(std::vector<at::Tensor>& data,
+              THDReduceOp operation,
+              rank_type dstRank,
+              THDGroup group_id = THDGroupWORLD) override;
   void reduce(at::Tensor& data, THDReduceOp operation, rank_type dst_rank,
               THDGroup group_id = THDGroupWORLD) override;
+  void broadcast(std::vector<at::Tensor>& data,
+                 rank_type srcRank,
+                 THDGroup group_id = THDGroupWORLD) override;
   void broadcast(at::Tensor& data, rank_type src_id,
                  THDGroup group_id = THDGroupWORLD) override;
   void send(Scalar& data, rank_type dst_id) override;
@@ -68,6 +83,8 @@ struct DataChannelGloo : DataChannel {
   void barrier(THDGroup group_id = THDGroupWORLD) override;
 
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
+  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
+
 
 private:
 

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -508,8 +508,8 @@ THDGroup DataChannelMPI::newGroup(const std::vector<rank_type>& ranks) {
   return new_group_id;
 }
 
-void DataChannelMPI::allReduce(std::vector<thpp::Tensor*>& input,
-                               std::vector<thpp::Tensor*>& output,
+void DataChannelMPI::allReduce(std::vector<at::Tensor>& input,
+                               std::vector<at::Tensor>& output,
                                THDReduceOp operation,
                                THDGroup groupId) {
 
@@ -518,8 +518,8 @@ void DataChannelMPI::allReduce(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelMPI::allGather(std::vector<thpp::Tensor*>& input,
-                               std::vector<thpp::Tensor*>& output,
+void DataChannelMPI::allGather(std::vector<at::Tensor>& input,
+                               std::vector<at::Tensor>& output,
                                THDGroup groupId) {
 
   throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
@@ -527,7 +527,7 @@ void DataChannelMPI::allGather(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelMPI::reduce(std::vector<thpp::Tensor*>& data,
+void DataChannelMPI::reduce(std::vector<at::Tensor>& data,
                             THDReduceOp operation,
                             rank_type dstRank,
                             THDGroup groupId) {
@@ -537,7 +537,7 @@ void DataChannelMPI::reduce(std::vector<thpp::Tensor*>& data,
 }
 
 
-void DataChannelMPI::broadcast(std::vector<thpp::Tensor*>& data,
+void DataChannelMPI::broadcast(std::vector<at::Tensor>& data,
                                rank_type srcRank,
                                THDGroup groupId) {
 

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -80,6 +80,11 @@ DataChannelMPI::DataChannelMPI()
 
 
 DataChannelMPI::~DataChannelMPI() {
+  destroy();
+}
+
+
+void DataChannelMPI::destroy() {
   for (auto& group : _groups) {
     auto comm = group.second.first;
     if (comm != MPI_COMM_WORLD && comm != MPI_COMM_NULL)
@@ -501,6 +506,48 @@ THDGroup DataChannelMPI::newGroup(const std::vector<rank_type>& ranks) {
   THDGroup new_group_id = static_cast<THDGroup>(_groups.size());
   _groups.insert({new_group_id, std::make_pair(new_comm, new_group)});
   return new_group_id;
+}
+
+void DataChannelMPI::allReduce(std::vector<thpp::Tensor*>& input,
+                               std::vector<thpp::Tensor*>& output,
+                               THDReduceOp operation,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
+                           "node allreduce");
+}
+
+
+void DataChannelMPI::allGather(std::vector<thpp::Tensor*>& input,
+                               std::vector<thpp::Tensor*>& output,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
+                           "node allgather");
+}
+
+
+void DataChannelMPI::reduce(std::vector<thpp::Tensor*>& data,
+                            THDReduceOp operation,
+                            rank_type dstRank,
+                            THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
+                           "node reduce");
+}
+
+
+void DataChannelMPI::broadcast(std::vector<thpp::Tensor*>& data,
+                               rank_type srcRank,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
+                           "node broadcast");
+}
+
+
+void DataChannelMPI::destroyGroup(THDGroup group_id) {
+  throw std::runtime_error("DataChannelMPI does not support destroy group");
 }
 
 } // namespace thd

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -508,8 +508,7 @@ THDGroup DataChannelMPI::newGroup(const std::vector<rank_type>& ranks) {
   return new_group_id;
 }
 
-void DataChannelMPI::allReduce(std::vector<at::Tensor>& input,
-                               std::vector<at::Tensor>& output,
+void DataChannelMPI::allReduce(std::vector<at::Tensor>& data,
                                THDReduceOp operation,
                                THDGroup groupId) {
 
@@ -518,8 +517,8 @@ void DataChannelMPI::allReduce(std::vector<at::Tensor>& input,
 }
 
 
-void DataChannelMPI::allGather(std::vector<at::Tensor>& input,
-                               std::vector<at::Tensor>& output,
+void DataChannelMPI::allGather(std::vector<at::Tensor>& output,
+                               std::vector<at::Tensor>& input,
                                THDGroup groupId) {
 
   throw std::runtime_error("DataChannelMPI does not support mult-GPU cross "
@@ -546,8 +545,9 @@ void DataChannelMPI::broadcast(std::vector<at::Tensor>& data,
 }
 
 
-void DataChannelMPI::destroyGroup(THDGroup group_id) {
-  throw std::runtime_error("DataChannelMPI does not support destroy group");
+void DataChannelMPI::clearGroupCache(THDGroup group_id) {
+  throw std::runtime_error("DataChannelMPI does not support clear "
+                           "group cache");
 }
 
 } // namespace thd

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
@@ -40,8 +40,8 @@ struct DataChannelMPI : DataChannel {
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
-  void allGather(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allGather(std::vector<at::Tensor>& output,
+                 std::vector<at::Tensor>& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
@@ -49,8 +49,7 @@ struct DataChannelMPI : DataChannel {
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
-  void allReduce(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allReduce(std::vector<at::Tensor>& data,
                  THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
@@ -76,7 +75,7 @@ struct DataChannelMPI : DataChannel {
 
   void barrier(THDGroup group_id = THDGroupWORLD) override;
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
-  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
+  void clearGroupCache(THDGroup group_id = THDGroupWORLD) override;
 
 private:
   void _broadcastPack(at::Tensor& data, rank_type src_rank, MPI_Comm comm) const;

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.hpp
@@ -35,20 +35,35 @@ struct DataChannelMPI : DataChannel {
   virtual ~DataChannelMPI();
 
   bool init() override;
+  void destroy() override;
 
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
+  void allGather(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void gather(std::vector<at::Tensor>& output, at::Tensor& input,
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
+  void allReduce(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDReduceOp operation,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
+  void reduce(std::vector<at::Tensor>& data,
+              THDReduceOp operation,
+              rank_type dstRank,
+              THDGroup group_id = THDGroupWORLD) override;
   void reduce(at::Tensor& data, THDReduceOp operation, rank_type dst_rank,
               THDGroup group_id = THDGroupWORLD) override;
+  void broadcast(std::vector<at::Tensor>& data,
+                 rank_type srcRank,
+                 THDGroup group_id = THDGroupWORLD) override;
   void broadcast(at::Tensor& data, rank_type src_rank,
                  THDGroup group_id = THDGroupWORLD) override;
   void send(Scalar& data, rank_type dst_rank) override;
@@ -61,6 +76,7 @@ struct DataChannelMPI : DataChannel {
 
   void barrier(THDGroup group_id = THDGroupWORLD) override;
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
+  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
 
 private:
   void _broadcastPack(at::Tensor& data, rank_type src_rank, MPI_Comm comm) const;

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -1,0 +1,741 @@
+#include "../Cuda.hpp"
+#include "DataChannelNccl.hpp"
+#include "DataChannelUtils.hpp"
+
+#include <cuda.h>
+#include <THC/THC.h>
+
+#include <unistd.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <unordered_set>
+#include <sstream>
+
+namespace thd {
+
+namespace {
+
+
+std::unordered_map<THDReduceOp, ncclRedOp_t> ncclOp = {
+  {THDReduceOp::THDReduceMIN, ncclMin},
+  {THDReduceOp::THDReduceMAX, ncclMax},
+  {THDReduceOp::THDReduceSUM, ncclSum},
+  {THDReduceOp::THDReducePRODUCT, ncclProd},
+};
+
+
+std::unordered_map<thpp::Type, ncclDataType_t> ncclDatatype = {
+  {thpp::Type::CHAR, ncclInt8},
+  {thpp::Type::UCHAR, ncclUint8},
+  {thpp::Type::FLOAT, ncclFloat},
+  {thpp::Type::DOUBLE, ncclDouble},
+  {thpp::Type::INT, ncclInt32},
+  {thpp::Type::UINT, ncclUint32},
+  {thpp::Type::LONG_LONG, ncclInt64},
+  {thpp::Type::ULONG_LONG, ncclUint64},
+};
+
+
+// Helper function that gets the data type and issues error if not supported
+static ncclDataType_t _getNcclDataType(thpp::Type type) {
+  if (ncclDatatype.find(type) == ncclDatatype.end()) {
+    throw std::runtime_error("Unsupported data type for NCCL");
+  }
+  return ncclDatatype[type];
+}
+
+
+// Helper function that gets the device list to determine the CUDA devices
+std::vector<int> getDevicesList(const std::string& deviceSeq) {
+
+  std::stringstream ss(deviceSeq);
+  std::string device;
+  std::vector<int> devices;
+  while (std::getline(ss, device, ',')) {
+    devices.push_back(stoi(device));
+  }
+  return devices;
+}
+
+} // namespace
+
+
+// RequestNccl
+DataChannelNccl::RequestNccl::RequestNccl(QueueWorker::Request&& request)
+ : _request(std::move(request)) {
+}
+
+
+DataChannelNccl::RequestNccl::~RequestNccl() {}
+
+
+bool DataChannelNccl::RequestNccl::isCompleted() {
+  return _request.isCompleted();
+}
+
+void DataChannelNccl::RequestNccl::wait() {
+  _request.wait();
+}
+
+// End of RequestNccl
+
+// DataChannelNccl
+DataChannelNccl::DataChannelNccl(InitMethod::Config config, int timeout)
+  : _rank(config.rank)
+  , _numProcesses(config.world_size)
+  , _timeout(timeout)
+  , _masterListeningSocket(-1)
+{
+  if (_rank == 0) {
+    _masterListeningSocket = config.master.listen_socket;
+  } else {
+    _masterAddr = config.worker.master_addr;
+    _masterPort = config.worker.master_port;
+  }
+}
+
+
+// Use the socket to broadcast NCCL ID
+void DataChannelNccl::broadcastUniqueNcclId(ncclUniqueId* srcNcclId,
+                                            ncclUniqueId* dstNcclId) {
+  // Send the unique NCCL id to every rank
+  if (_rank == 0) {
+    std::vector<int> sockets(_numProcesses - 1);
+    for (rank_type i = 0; i < _numProcesses - 1; ++i) {
+      std::tie(sockets[i], std::ignore) = accept(_masterListeningSocket,
+                                                 _timeout);
+    }
+    for (auto socket : sockets) {
+      ResourceGuard socket_guard([socket]() { ::close(socket); });
+      send_bytes<uint8_t>(socket,
+                          reinterpret_cast<uint8_t*>(srcNcclId),
+                          NCCL_UNIQUE_ID_BYTES);
+    }
+  } else {
+    int socket;
+    try {
+      socket = connect(_masterAddr, _masterPort, true, _timeout);
+    } catch (...) {
+      std::string errStr = "Rank: " + std::to_string(_rank) + " cannot "
+                           "connect to the master: " + _masterAddr + ":" +
+                           std::to_string(_masterPort);
+      throw std::runtime_error(errStr);
+    }
+    ResourceGuard socket_guard([socket]() { ::close(socket); });
+    recv_bytes<uint8_t>(socket,
+                        reinterpret_cast<uint8_t*>(dstNcclId),
+                        NCCL_UNIQUE_ID_BYTES);
+  }
+}
+
+
+// Destructor that closes the master's listening socket
+DataChannelNccl::~DataChannelNccl() {
+  // Destroy the master listening socket
+  if (_masterListeningSocket != -1) {
+    ::close(_masterListeningSocket);
+    _masterListeningSocket = -1;
+  }
+  /**
+   * Note that destructor will be called after cudaruntime being unloaded since
+   * DataChannel is a global variable.
+   */
+}
+
+
+// Destroy the data channel
+void DataChannelNccl::destroy() {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  // Destroy the master listening socket
+  if (_masterListeningSocket != -1) {
+    ::close(_masterListeningSocket);
+    _masterListeningSocket = -1;
+  }
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  // Destroy the CUDA and NCCL resources
+  for (auto& itemPair : _ncclCommsAndEvents) {
+
+    auto devices = getDevicesList(_groupDevices[itemPair.first]);
+
+    // Destroy the CUDA events
+    size_t idx = 0;
+    for (auto& event : *(itemPair.second.second)) {
+      THCudaCheck(cudaSetDevice(devices[idx++]));
+      THCudaCheck(cudaEventSynchronize(event));
+      THCudaCheck(cudaEventDestroy(event));
+    }
+    // Destroy the communicators
+    for (auto& comm : *(itemPair.second.first)) {
+      NCCL_CHECK(ncclCommDestroy(comm));
+    }
+
+  }
+  _ncclCommsAndEvents.clear();
+  _groups.clear();
+  _groupDevices.clear();
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+
+// Destroy the resource for a single thread group
+void DataChannelNccl::destroyGroup(THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  if (_ncclCommsAndEvents.find(groupId) != _ncclCommsAndEvents.end()) {
+    int curDevice = 0;
+    THCudaCheck(cudaGetDevice(&curDevice));
+
+    // Destroy the CUDA events
+    size_t idx = 0;
+    for (auto& event : *(_ncclCommsAndEvents[groupId].second)) {
+      auto devices = getDevicesList(_groupDevices[groupId]);
+      THCudaCheck(cudaSetDevice(devices[idx++]));
+      THCudaCheck(cudaEventSynchronize(event));
+      THCudaCheck(cudaEventDestroy(event));
+    }
+    // Destroy the communicators
+    for (auto& comm : *(_ncclCommsAndEvents[groupId].first)) {
+      NCCL_CHECK(ncclCommDestroy(comm));
+    }
+    // Restore to previous device
+    THCudaCheck(cudaSetDevice(curDevice));
+    _ncclCommsAndEvents.erase(groupId);
+  }
+  if (_groups.find(groupId) != _groups.end()) {
+    _groups.erase(groupId);
+  }
+  if (_groupDevices.find(groupId) != _groupDevices.end()) {
+    _groupDevices.erase(groupId);
+  }
+}
+
+
+// Initialization function
+bool DataChannelNccl::init() {
+
+  std::vector<rank_type> ranks;
+  ranks.reserve(_numProcesses);
+
+  for (rank_type rank = 0; rank < _numProcesses; ++rank) {
+    ranks.push_back(rank);
+  }
+
+  // Insert the current group
+  _groups.insert({
+    THDGroupWORLD,
+    DataChannel::Group(ranks, _numProcesses - 1)
+  });
+
+  // Get the GPU count
+  THCudaCheck(cudaGetDeviceCount(&_numGPUs));
+
+  return true;
+}
+
+
+rank_type DataChannelNccl::getRank() {
+  return _rank;
+}
+
+
+rank_type DataChannelNccl::getNumProcesses() {
+  return _numProcesses;
+}
+
+
+std::pair<std::vector<ncclComm_t>*, std::vector<cudaEvent_t>*>
+DataChannelNccl::_getNcclCommsAndEvents(
+    std::vector<thpp::Tensor*>& input,
+    THDGroup groupId) {
+
+  if (input.empty()) {
+    throw std::runtime_error("Not able to create/get the Nccl Comm since "
+                             "input tensor is empty");
+  }
+  // Get the deviceList String
+  std::string deviceList;
+  for (auto tensor : input) {
+    if (deviceList.empty()) {
+      deviceList = std::to_string(tensor->getDevice());
+    } else {
+      deviceList += "," + std::to_string(tensor->getDevice());
+    }
+  }
+
+  if (_groupDevices.find(groupId) != _groupDevices.end() &&
+      deviceList != _groupDevices[groupId]) {
+    std::string errMsg;
+    errMsg = "The current group: " + std::to_string(groupId) +
+            " has already got a GPU device list: " + _groupDevices[groupId]
+            + " associated with. Each group should only be associated with a "
+            + "given device list. Please create a new group for your provided "
+            + "device list: " + deviceList;
+    throw std::runtime_error(errMsg);
+  }
+
+  if (_ncclCommsAndEvents.find(groupId) != _ncclCommsAndEvents.end()) {
+    return std::make_pair(_ncclCommsAndEvents[groupId].first.get(),
+                          _ncclCommsAndEvents[groupId].second.get());
+  }
+
+  // Add in the device list of the group
+  _groupDevices[groupId] = deviceList;
+
+  // NCCL communication world
+  std::unique_ptr<std::vector<ncclComm_t>> comms =
+    std::unique_ptr<std::vector<ncclComm_t>>(new std::vector<ncclComm_t>());
+
+  comms->resize(input.size());
+
+  // Corresponding CUDA events
+  std::unique_ptr<std::vector<cudaEvent_t>> events =
+    std::unique_ptr<std::vector<cudaEvent_t>>(new std::vector<cudaEvent_t>());
+
+  events->resize(input.size());
+
+  // Create the unique NCCL ID and broadcast it
+  ncclUniqueId ncclId;
+  NCCL_CHECK(ncclGetUniqueId(&ncclId));
+
+  // Broadcast so that each process can have a unique NCCL ID
+  broadcastUniqueNcclId(&ncclId, &ncclId);
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  // Now creating the CUDA events
+  for (size_t i = 0; i < input.size(); ++i) {
+    THCudaCheck(cudaSetDevice(input[i]->getDevice()));
+    THCudaCheck(cudaEventCreate(&((*events)[i])));
+  }
+  // Create the communicator on each device of the input
+  NCCL_CHECK(ncclGroupStart());
+  for (size_t i = 0; i < input.size(); ++i) {
+    int nRanks = int(_numProcesses) * input.size();
+    THCudaCheck(cudaSetDevice(input[i]->getDevice()));
+    NCCL_CHECK(ncclCommInitRank(&((*comms)[i]),
+                                nRanks,
+                                ncclId,
+                                _rank * input.size() + i));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+
+  // Move into the hash table
+  _ncclCommsAndEvents[groupId] = std::move(std::make_pair(std::move(comms),
+                                                          std::move(events)));
+
+  return std::make_pair(_ncclCommsAndEvents[groupId].first.get(),
+                        _ncclCommsAndEvents[groupId].second.get());
+}
+
+
+// Helper function that checks the input and output tensors for validity
+void DataChannelNccl::_tensorCheckHelper(
+    const std::vector<thpp::Tensor*>& input,
+    const std::vector<thpp::Tensor*>& output,
+    size_t outputOverInput) {
+
+  if (input.size() <= 0) {
+    throw std::runtime_error("Input tensor sequence cannot be empty");
+  }
+  if (input.size() != output.size()) {
+    throw std::runtime_error("Input tensor sequence should have the same size "
+                             "as output tensor sequence");
+  }
+  if (input.size() > _numGPUs) {
+    throw std::runtime_error("The number of input tensors is larger than "
+                             "the number of available GPUs");
+  }
+
+  // To make sure each tensor is on separate devices
+  std::unordered_set<int> usedDevices;
+  usedDevices.reserve(input.size());
+
+  uint64_t inputNumElement = input[0]->numel();
+  auto elementType = input[0]->type();
+
+  for (size_t i = 0; i < input.size(); ++i) {
+
+    //  Check to make sure it's a GPU dense tensor
+    if (!(input[i]->isCuda() && !input[i]->isSparse() &&
+          output[i]->isCuda()  && !output[i]->isSparse())) {
+      throw std::runtime_error("Only CUDA dense tensor is supported for NCCL "
+                               "collective operations");
+    }
+    // Check the tensor type is identical
+    if (input[i]->type() != elementType || output[i]->type() != elementType) {
+      throw std::runtime_error("Expecting all GPU tensors to have identical "
+                               "type");
+    }
+    // Check the input tensor size is identical
+    if (input[i]->numel() != inputNumElement) {
+      throw std::runtime_error("Expecting all input tensors to have identical "
+                               "number of elements");
+    }
+    // Check the output tensor size equals to input tensor size
+    if (output[i]->numel() != inputNumElement * outputOverInput) {
+      throw std::runtime_error("The number of elements of output tensor does "
+                               "not match the number of elements of the input "
+                               "tensor");
+    }
+    // Contiguous verification
+    if (!input[i]->isContiguous() || !output[i]->isContiguous()) {
+      throw std::runtime_error("Expecting all GPU tensors to be contiguous");
+    }
+    // Device verification
+    if (usedDevices.find(input[i]->getDevice()) != usedDevices.end()) {
+      throw std::runtime_error("Expecting inputs on different GPU devices");
+    }
+
+    usedDevices.insert(input[i]->getDevice());
+
+    // Now check the output device
+    if (input[i]->getDevice() != output[i]->getDevice()) {
+      throw std::runtime_error("Expecting input and output tensors to be on "
+                               "the same device");
+    }
+  }
+}
+
+
+void DataChannelNccl::allReduce(std::vector<thpp::Tensor*>& input,
+                                std::vector<thpp::Tensor*>& output,
+                                THDReduceOp operation,
+                                THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+  // Check the tensor vector for consistency
+  _tensorCheckHelper(input, output);
+  _checkGroupIdValid(groupId);
+
+  auto commsAndEvents = _getNcclCommsAndEvents(input, groupId);
+  auto comms = commsAndEvents.first;
+  auto events = commsAndEvents.second;
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  NCCL_CHECK(ncclGroupStart());
+  for (size_t i = 0; i < input.size(); ++i) {
+
+    THCudaCheck(cudaSetDevice(input[i]->getDevice()));
+    auto stream = THCState_getCurrentStream(THDGetCudaState());
+
+    NCCL_CHECK(ncclAllReduce(input[i]->data(),
+                             output[i]->data(),
+                             input[i]->numel(),
+                             _getNcclDataType(input[i]->type()),
+                             ncclOp[operation],
+                             (*comms)[i],
+                             stream));
+    THCudaCheck(cudaEventRecord((*events)[i], stream));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  cudaFreeMutexLock.unlock();
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+
+void DataChannelNccl::allReduce(thpp::Tensor& data,
+                                THDReduceOp operation,
+                                THDGroup groupId) {
+
+  std::vector<thpp::Tensor*> dataVec;
+  dataVec.push_back(&data);
+  allReduce(dataVec, dataVec, operation, groupId);
+}
+
+
+void DataChannelNccl::allGather(std::vector<thpp::Tensor*>& input,
+                                std::vector<thpp::Tensor*>& output,
+                                THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  _tensorCheckHelper(input, output, _numProcesses * input.size());
+  _checkGroupIdValid(groupId);
+
+  auto commsAndEvents = _getNcclCommsAndEvents(input, groupId);
+  auto comms = commsAndEvents.first;
+  auto events = commsAndEvents.second;
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  NCCL_CHECK(ncclGroupStart());
+  for (size_t i = 0; i < input.size(); ++i) {
+
+    THCudaCheck(cudaSetDevice(input[i]->getDevice()));
+    auto stream = THCState_getCurrentStream(THDGetCudaState());
+
+    NCCL_CHECK(ncclAllGather(input[i]->data(),
+                             output[i]->data(),
+                             input[i]->numel(),
+                             _getNcclDataType(input[i]->type()),
+                             (*comms)[i],
+                             stream));
+    THCudaCheck(cudaEventRecord((*events)[i], stream));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  cudaFreeMutexLock.unlock();
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+
+void DataChannelNccl::allGather(std::vector<thpp::Tensor*>& output,
+                                thpp::Tensor& input,
+                                THDGroup groupId) {
+
+  std::vector<thpp::Tensor*> inputDataVec;
+  inputDataVec.push_back(&input);
+  allGather(inputDataVec, output, groupId);
+}
+
+
+void DataChannelNccl::reduce(std::vector<thpp::Tensor*>& data,
+                             THDReduceOp operation,
+                             rank_type dstRank,
+                             THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  // Check the tensor vector for consistency
+  _tensorCheckHelper(data, data);
+  _checkGroupIdValid(groupId);
+
+  auto commsAndEvents = _getNcclCommsAndEvents(data, groupId);
+  auto comms = commsAndEvents.first;
+  auto events = commsAndEvents.second;
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  NCCL_CHECK(ncclGroupStart());
+  for (size_t i = 0; i < data.size(); ++i) {
+
+    THCudaCheck(cudaSetDevice(data[i]->getDevice()));
+    auto stream = THCState_getCurrentStream(THDGetCudaState());
+
+    NCCL_CHECK(ncclReduce(data[i]->data(),
+                          data[i]->data(),
+                          data[i]->numel(),
+                          _getNcclDataType(data[i]->type()),
+                          ncclOp[operation],
+                          dstRank * data.size(),
+                          (*comms)[i],
+                          stream));
+    THCudaCheck(cudaEventRecord((*events)[i], stream));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  cudaFreeMutexLock.unlock();
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+void DataChannelNccl::reduce(thpp::Tensor& data,
+                             THDReduceOp operation,
+                             rank_type dstRank,
+                             THDGroup groupId) {
+
+  std::vector<thpp::Tensor*> dataVec;
+  dataVec.push_back(&data);
+  reduce(dataVec, operation, dstRank, groupId);
+}
+
+void DataChannelNccl::broadcast(std::vector<thpp::Tensor*>& data,
+                                rank_type srcRank,
+                                THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  // Check the tensor vector for consistency
+  _tensorCheckHelper(data, data);
+  _checkGroupIdValid(groupId);
+
+  auto commsAndEvents = _getNcclCommsAndEvents(data, groupId);
+  auto comms = commsAndEvents.first;
+  auto events = commsAndEvents.second;
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  std::unique_lock<std::mutex> cudaFreeMutexLock(
+      *(THCCachingAllocator_getCudaFreeMutex()));
+
+  NCCL_CHECK(ncclGroupStart());
+  for (size_t i = 0; i < data.size(); ++i) {
+
+    THCudaCheck(cudaSetDevice(data[i]->getDevice()));
+    auto stream = THCState_getCurrentStream(THDGetCudaState());
+
+    NCCL_CHECK(ncclBcast(data[i]->data(),
+                         data[i]->numel(),
+                         _getNcclDataType(data[i]->type()),
+                         srcRank * data.size(),
+                         (*comms)[i],
+                         stream));
+    THCudaCheck(cudaEventRecord((*events)[i], stream));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  cudaFreeMutexLock.unlock();
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+
+void DataChannelNccl::broadcast(thpp::Tensor& data,
+                                rank_type srcRank,
+                                THDGroup groupId) {
+
+  std::vector<thpp::Tensor*> dataVec;
+  dataVec.push_back(&data);
+  broadcast(dataVec, srcRank, groupId);
+}
+
+
+void DataChannelNccl::barrier(THDGroup groupId) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  _checkGroupIdValid(groupId);
+
+  if (_ncclCommsAndEvents.find(groupId) == _ncclCommsAndEvents.end() ||
+      _groupDevices.find(groupId) == _groupDevices.end()) {
+    return;
+  }
+
+  auto devices = getDevicesList(_groupDevices[groupId]);
+
+  int curDevice = 0;
+  THCudaCheck(cudaGetDevice(&curDevice));
+
+  int idx = 0;
+  // Synchronize on the CUDA events
+  for (auto& event : *(_ncclCommsAndEvents[groupId].second)) {
+    THCudaCheck(cudaSetDevice(devices[idx++]));
+    THCudaCheck(cudaEventSynchronize(event));
+  }
+
+  // Restore to previous device
+  THCudaCheck(cudaSetDevice(curDevice));
+}
+
+
+THDGroup DataChannelNccl::newGroup(const std::vector<rank_type>& ranks) {
+
+  std::unique_lock<std::mutex> channelLock(_mutex);
+
+  auto newGroup = DataChannel::Group(ranks, _numProcesses - 1);
+  THDGroup newGroupId = static_cast<THDGroup>(_groups.size());
+
+  // Insert the current group
+  _groups.insert({
+    newGroupId,
+    newGroup
+  });
+
+  return newGroupId;
+}
+
+
+// Helper function that checks if the given groupId is valid
+void DataChannelNccl::_checkGroupIdValid(THDGroup groupId) {
+
+  if (_groups.find(groupId) == _groups.end()) {
+    std::string errMsg = "Group ID: " + std::to_string(groupId) +
+                         " is not valid";
+    throw std::runtime_error(errMsg);
+  }
+}
+
+
+void DataChannelNccl::gather(std::vector<thpp::Tensor*>& output,
+                             thpp::Tensor& input,
+                             rank_type dstRank,
+                             THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelNccl does not support gather");
+}
+
+
+void DataChannelNccl::scatter(std::vector<thpp::Tensor*>& input,
+                              thpp::Tensor& output,
+                              rank_type srcRank,
+                              THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelNccl does not support scatter");
+}
+
+
+void DataChannelNccl::send(Scalar& data, rank_type dstRank) {
+  throw std::runtime_error("DataChannelNccl does not support send");
+}
+
+
+void DataChannelNccl::send(thpp::Tensor& data, rank_type dstRank) {
+  throw std::runtime_error("DataChannelNccl does not support send");
+}
+
+
+void DataChannelNccl::receive(Scalar& data, rank_type srcRank) {
+  throw std::runtime_error("DataChannelNccl does not support receive");
+}
+
+
+rank_type DataChannelNccl::receive(thpp::Tensor& data) {
+  throw std::runtime_error("DataChannelNccl does not support receive "
+                           "from any source");
+}
+
+
+void DataChannelNccl::receive(thpp::Tensor& data, rank_type srcRank) {
+  throw std::runtime_error("DataChannelNccl does not support receive");
+}
+
+
+
+DataChannelNccl::RequestNccl* DataChannelNccl::isend(thpp::Tensor& data,
+                                                     rank_type dstRank) {
+
+  throw std::runtime_error("DataChannelNccl does not support isend");
+}
+
+
+DataChannelNccl::RequestNccl* DataChannelNccl::ireceive(thpp::Tensor& data,
+                                                        rank_type srcRank) {
+
+  throw std::runtime_error("DataChannelNccl does not support ireceive");
+}
+
+
+} // namespace thd

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -209,7 +209,9 @@ void DataChannelNccl::destroyGroup(THDGroup groupId) {
     }
     _groupNcclResources.erase(groupId);
   }
-  if (_groups.find(groupId) != _groups.end()) {
+  // Will keep the default group and only destroy its CUDA resources.
+  if (groupId != THDGroupWORLD &&
+      _groups.find(groupId) != _groups.end()) {
     _groups.erase(groupId);
   }
   if (_groupDevices.find(groupId) != _groupDevices.end()) {
@@ -368,8 +370,8 @@ bool DataChannelNccl::_tensorCheckHelper(
   for (size_t i = 0; i < input.size(); ++i) {
 
     //  Check to make sure it's a GPU dense tensor
-    if (!(input[i].type().isCuda() && !input[i].type().isSparse() &&
-          output[i].type().isCuda()  && !output[i].type().isSparse())) {
+    if (!(input[i].type().is_cuda() && !input[i].type().is_sparse() &&
+          output[i].type().is_cuda()  && !output[i].type().is_sparse())) {
       throw std::runtime_error("Only CUDA dense tensor is supported for NCCL "
                                "collective operations");
     }

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -619,27 +619,7 @@ void DataChannelNccl::broadcast(at::Tensor& data,
 
 
 void DataChannelNccl::barrier(THDGroup groupId) {
-
-  std::unique_lock<std::mutex> channelLock(_mutex);
-
-  _checkGroupIdValid(groupId);
-
-  if (_groupNcclResources.find(groupId) == _groupNcclResources.end() ||
-      _groupDevices.find(groupId) == _groupDevices.end()) {
-    return;
-  }
-
-  auto devices = getDevicesList(_groupDevices[groupId]);
-
-  // Guard GPU device
-  AutoGPU gpuGuard;
-
-  int idx = 0;
-  // Synchronize on the CUDA events
-  for (auto& event : *(_groupNcclResources[groupId].ncclCudaEvents())) {
-    gpuGuard.setDevice(devices[idx++]);
-    THCudaCheck(cudaEventSynchronize(event));
-  }
+  throw std::runtime_error("DataChannelNccl does not support barrier");
 }
 
 

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -103,18 +103,17 @@ DataChannelNccl::DataChannelNccl(InitMethod::Config config, int timeout)
 
 
 // Use the socket to broadcast NCCL ID
-void DataChannelNccl::broadcastUniqueNcclId(ncclUniqueId* srcNcclId,
-                                            ncclUniqueId* dstNcclId) {
+void DataChannelNccl::broadcastUniqueNcclId(ncclUniqueId* ncclId) {
   // Send the unique NCCL id to every rank
   if (_rank == 0) {
     for (auto socket : _masterSendingSockets) {
       send_bytes<uint8_t>(socket,
-                          reinterpret_cast<uint8_t*>(srcNcclId),
+                          reinterpret_cast<uint8_t*>(ncclId),
                           NCCL_UNIQUE_ID_BYTES);
     }
   } else {
     recv_bytes<uint8_t>(_slaveSocket,
-                        reinterpret_cast<uint8_t*>(dstNcclId),
+                        reinterpret_cast<uint8_t*>(ncclId),
                         NCCL_UNIQUE_ID_BYTES);
   }
 }
@@ -306,7 +305,7 @@ NcclResourcePair DataChannelNccl::_getNcclResourcePair(
   NCCL_CHECK(ncclGetUniqueId(&ncclId));
 
   // Broadcast so that each process can have a unique NCCL ID
-  broadcastUniqueNcclId(&ncclId, &ncclId);
+  broadcastUniqueNcclId(&ncclId);
 
   // Guard GPU device
   AutoGPU gpuGuard;

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
@@ -162,7 +162,7 @@ private:
                              ncclUniqueId* dstNcclId);
 
   // Helper that checks the input and output tensors
-  void _tensorCheckHelper(const std::vector<at::Tensor>& input,
+  bool _tensorCheckHelper(const std::vector<at::Tensor>& input,
                           const std::vector<at::Tensor>& output,
                           size_t outputOverInput = 1);
 

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+#include "../DataChannel.hpp"
+#include "DataChannelUtils.hpp"
+
+#include <nccl.h>
+
+#include <utility>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+
+#define NCCL_CHECK(cmd) do {                                  \
+  ncclResult_t error = cmd;                                   \
+  if (error != ncclSuccess) {                                 \
+    std::string err = "NCCL error in: " +                     \
+                      std::string(__FILE__) + ":" +           \
+                      std::to_string(__LINE__) + ", " +       \
+                      std::string(ncclGetErrorString(error)); \
+    throw std::runtime_error(err);                            \
+  }                                                           \
+} while (0)
+
+
+namespace thd {
+
+struct DataChannelNccl : DataChannel {
+  struct RequestNccl : DataChannel::Request {
+
+    RequestNccl(QueueWorker::Request&& request);
+    virtual ~RequestNccl();
+
+    virtual bool isCompleted() override;
+    virtual void wait() override;
+
+  private:
+    QueueWorker::Request _request;
+  };
+
+  DataChannelNccl(InitMethod::Config config, int timeout = -1);
+  virtual ~DataChannelNccl();
+
+  bool init() override;
+  void destroy() override;
+
+  rank_type getRank() override;
+  rank_type getNumProcesses() override;
+
+  void allReduce(std::vector<thpp::Tensor*>& input,
+                 std::vector<thpp::Tensor*>& output,
+                 THDReduceOp operation,
+                 THDGroup = THDGroupWORLD) override;
+
+  void allReduce(thpp::Tensor& data,
+                 THDReduceOp operation,
+                 THDGroup groupId = THDGroupWORLD) override;
+
+  void allGather(std::vector<thpp::Tensor*>& input,
+                 std::vector<thpp::Tensor*>& output,
+                 THDGroup groupId = THDGroupWORLD) override;
+
+  void allGather(std::vector<thpp::Tensor*>& output,
+                 thpp::Tensor& input,
+                 THDGroup groupId = THDGroupWORLD) override;
+
+  void reduce(std::vector<thpp::Tensor*>& input,
+              THDReduceOp operation,
+              rank_type dstRank,
+              THDGroup groupId = THDGroupWORLD) override;
+
+  void reduce(thpp::Tensor& data,
+              THDReduceOp operation,
+              rank_type dstRank,
+              THDGroup groupId = THDGroupWORLD) override;
+
+  void broadcast(std::vector<thpp::Tensor*>& data,
+                 rank_type srcRank,
+                 THDGroup groupId = THDGroupWORLD) override;
+
+  void broadcast(thpp::Tensor& data,
+                 rank_type srcRank,
+                 THDGroup groupId = THDGroupWORLD) override;
+
+  void barrier(THDGroup groupId = THDGroupWORLD) override;
+
+  THDGroup newGroup(const std::vector<rank_type>& ranks) override;
+
+  void destroyGroup(THDGroup groupId = THDGroupWORLD) override;
+
+  // Not supported functions
+  void gather(std::vector<thpp::Tensor*>& output,
+              thpp::Tensor& input,
+              rank_type dstRank,
+              THDGroup groupId = THDGroupWORLD) override;
+
+  void scatter(std::vector<thpp::Tensor*>& input,
+               thpp::Tensor& output,
+               rank_type srcRank,
+               THDGroup groupId = THDGroupWORLD) override;
+
+  void send(Scalar& data, rank_type dstRank) override;
+
+  void send(thpp::Tensor& data, rank_type dstRank) override;
+
+  void receive(Scalar& data, rank_type srcRank) override;
+
+  rank_type receive(thpp::Tensor& data) override;
+
+  void receive(thpp::Tensor& data, rank_type srcRank) override;
+
+  RequestNccl* isend(thpp::Tensor& data, rank_type dstRank) override;
+
+  RequestNccl* ireceive(thpp::Tensor& data, rank_type srcRank) override;
+
+private:
+
+  // Current process' rank
+  rank_type _rank;
+  // Number of processes in network
+  rank_type _numProcesses;
+  // Accept waiting timeout in milliseconds, optional
+  int _timeout;
+  // Master's address
+  std::string _masterAddr;
+  // Master's port
+  port_type _masterPort;
+  // Socket on which the master is listening
+  int _masterListeningSocket;
+  // Number of GPUs on each node
+  int _numGPUs;
+  // Mutex for Nccl Data Channel
+  std::mutex _mutex;
+
+  /**
+   * GPU device ID list for each group, each group should only have one device
+   * list be associated with
+   */
+  std::unordered_map<THDGroup, std::string> _groupDevices;
+  /**
+   * Communicator for each THDGroup
+   * Cuda Events for all GPUs for NCCL operations
+   * Each communicator vector will be operating on a different set of
+   * CUDA events
+   */
+  std::unordered_map<THDGroup,
+                     std::pair<std::unique_ptr<std::vector<ncclComm_t>>,
+                               std::unique_ptr<std::vector<cudaEvent_t>>>>
+                    _ncclCommsAndEvents;
+
+  // Existing groups
+  std::unordered_map<THDGroup, DataChannel::Group> _groups;
+
+  // Helper function that gets the NCCL communicator
+  std::pair<std::vector<ncclComm_t>*, std::vector<cudaEvent_t>*>
+    _getNcclCommsAndEvents(std::vector<thpp::Tensor*>& input,
+                           THDGroup groupId);
+
+  // Helper function that broadcasts the NCCL unique ID to everyone in the rank
+  void broadcastUniqueNcclId(ncclUniqueId* srcNcclId,
+                             ncclUniqueId* dstNcclId);
+
+  // Helper that checks the input and output tensors
+  void _tensorCheckHelper(const std::vector<thpp::Tensor*>& input,
+                          const std::vector<thpp::Tensor*>& output,
+                          size_t outputOverInput = 1);
+
+  // Group validity checker
+  void _checkGroupIdValid(THDGroup groupId);
+};
+
+} // namespace thd

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
@@ -210,9 +210,12 @@ private:
   NcclResourcePair _getNcclResourcePair(std::vector<at::Tensor>& input,
                                         THDGroup groupId);
 
-  // Helper function that broadcasts the NCCL unique ID to everyone in the rank
-  void broadcastUniqueNcclId(ncclUniqueId* srcNcclId,
-                             ncclUniqueId* dstNcclId);
+  /**
+   * Helper function that broadcasts the NCCL unique ID to everyone in the rank
+   * NCCLID pointed by ncclId of Rank 0 will be sent to other ranks' NCCID
+   * pointed by ncclId
+   */
+  void broadcastUniqueNcclId(ncclUniqueId* ncclId);
 
   // Helper that checks the input and output tensors
   bool _tensorCheckHelper(const std::vector<at::Tensor>& input,

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
@@ -48,38 +48,38 @@ struct DataChannelNccl : DataChannel {
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
-  void allReduce(std::vector<thpp::Tensor*>& input,
-                 std::vector<thpp::Tensor*>& output,
+  void allReduce(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
                  THDReduceOp operation,
                  THDGroup = THDGroupWORLD) override;
 
-  void allReduce(thpp::Tensor& data,
+  void allReduce(at::Tensor& data,
                  THDReduceOp operation,
                  THDGroup groupId = THDGroupWORLD) override;
 
-  void allGather(std::vector<thpp::Tensor*>& input,
-                 std::vector<thpp::Tensor*>& output,
+  void allGather(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
                  THDGroup groupId = THDGroupWORLD) override;
 
-  void allGather(std::vector<thpp::Tensor*>& output,
-                 thpp::Tensor& input,
+  void allGather(std::vector<at::Tensor>& output,
+                 at::Tensor& input,
                  THDGroup groupId = THDGroupWORLD) override;
 
-  void reduce(std::vector<thpp::Tensor*>& input,
+  void reduce(std::vector<at::Tensor>& input,
               THDReduceOp operation,
               rank_type dstRank,
               THDGroup groupId = THDGroupWORLD) override;
 
-  void reduce(thpp::Tensor& data,
+  void reduce(at::Tensor& data,
               THDReduceOp operation,
               rank_type dstRank,
               THDGroup groupId = THDGroupWORLD) override;
 
-  void broadcast(std::vector<thpp::Tensor*>& data,
+  void broadcast(std::vector<at::Tensor>& data,
                  rank_type srcRank,
                  THDGroup groupId = THDGroupWORLD) override;
 
-  void broadcast(thpp::Tensor& data,
+  void broadcast(at::Tensor& data,
                  rank_type srcRank,
                  THDGroup groupId = THDGroupWORLD) override;
 
@@ -90,29 +90,29 @@ struct DataChannelNccl : DataChannel {
   void destroyGroup(THDGroup groupId = THDGroupWORLD) override;
 
   // Not supported functions
-  void gather(std::vector<thpp::Tensor*>& output,
-              thpp::Tensor& input,
+  void gather(std::vector<at::Tensor>& output,
+              at::Tensor& input,
               rank_type dstRank,
               THDGroup groupId = THDGroupWORLD) override;
 
-  void scatter(std::vector<thpp::Tensor*>& input,
-               thpp::Tensor& output,
+  void scatter(std::vector<at::Tensor>& input,
+               at::Tensor& output,
                rank_type srcRank,
                THDGroup groupId = THDGroupWORLD) override;
 
   void send(Scalar& data, rank_type dstRank) override;
 
-  void send(thpp::Tensor& data, rank_type dstRank) override;
+  void send(at::Tensor& data, rank_type dstRank) override;
 
   void receive(Scalar& data, rank_type srcRank) override;
 
-  rank_type receive(thpp::Tensor& data) override;
+  rank_type receive(at::Tensor& data) override;
 
-  void receive(thpp::Tensor& data, rank_type srcRank) override;
+  void receive(at::Tensor& data, rank_type srcRank) override;
 
-  RequestNccl* isend(thpp::Tensor& data, rank_type dstRank) override;
+  RequestNccl* isend(at::Tensor& data, rank_type dstRank) override;
 
-  RequestNccl* ireceive(thpp::Tensor& data, rank_type srcRank) override;
+  RequestNccl* ireceive(at::Tensor& data, rank_type srcRank) override;
 
 private:
 
@@ -154,7 +154,7 @@ private:
 
   // Helper function that gets the NCCL communicator
   std::pair<std::vector<ncclComm_t>*, std::vector<cudaEvent_t>*>
-    _getNcclCommsAndEvents(std::vector<thpp::Tensor*>& input,
+    _getNcclCommsAndEvents(std::vector<at::Tensor>& input,
                            THDGroup groupId);
 
   // Helper function that broadcasts the NCCL unique ID to everyone in the rank
@@ -162,8 +162,8 @@ private:
                              ncclUniqueId* dstNcclId);
 
   // Helper that checks the input and output tensors
-  void _tensorCheckHelper(const std::vector<thpp::Tensor*>& input,
-                          const std::vector<thpp::Tensor*>& output,
+  void _tensorCheckHelper(const std::vector<at::Tensor>& input,
+                          const std::vector<at::Tensor>& output,
                           size_t outputOverInput = 1);
 
   // Group validity checker

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
@@ -790,8 +790,7 @@ void DataChannelTCP::_reduce(at::Tensor& result, at::Tensor& data,
   }
 }
 
-void DataChannelTCP::allReduce(std::vector<at::Tensor>& input,
-                               std::vector<at::Tensor>& output,
+void DataChannelTCP::allReduce(std::vector<at::Tensor>& data,
                                THDReduceOp operation,
                                THDGroup groupId) {
 
@@ -800,8 +799,8 @@ void DataChannelTCP::allReduce(std::vector<at::Tensor>& input,
 }
 
 
-void DataChannelTCP::allGather(std::vector<at::Tensor>& input,
-                               std::vector<at::Tensor>& output,
+void DataChannelTCP::allGather(std::vector<at::Tensor>& output,
+                               std::vector<at::Tensor>& input,
                                THDGroup groupId) {
 
   throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
@@ -828,8 +827,9 @@ void DataChannelTCP::broadcast(std::vector<at::Tensor>& data,
 }
 
 
-void DataChannelTCP::destroyGroup(THDGroup group_id) {
-  throw std::runtime_error("DataChannelTCP does not support destroy group");
+void DataChannelTCP::clearGroupCache(THDGroup group_id) {
+  throw std::runtime_error("DataChannelTCP does not support clear "
+                           "group cache");
 }
 
 

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
@@ -94,9 +94,13 @@ DataChannelTCP::DataChannelTCP(InitMethod::Config config, int timeout)
 }
 
 
-DataChannelTCP::~DataChannelTCP()
-{
-  if (_socket != -1)
+DataChannelTCP::~DataChannelTCP() {
+  destroy();
+}
+
+
+void DataChannelTCP::destroy() {
+ if (_socket != -1)
     ::close(_socket);
 
   for (const auto& process : _processes) {
@@ -785,5 +789,48 @@ void DataChannelTCP::_reduce(at::Tensor& result, at::Tensor& data,
     throw std::logic_error("unsupported reduce operation");
   }
 }
+
+void DataChannelTCP::allReduce(std::vector<thpp::Tensor*>& input,
+                               std::vector<thpp::Tensor*>& output,
+                               THDReduceOp operation,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
+                           "node allreduce");
+}
+
+
+void DataChannelTCP::allGather(std::vector<thpp::Tensor*>& input,
+                               std::vector<thpp::Tensor*>& output,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
+                           "node allgather");
+}
+
+
+void DataChannelTCP::reduce(std::vector<thpp::Tensor*>& data,
+                            THDReduceOp operation,
+                            rank_type dstRank,
+                            THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
+                           "node reduce");
+}
+
+
+void DataChannelTCP::broadcast(std::vector<thpp::Tensor*>& data,
+                               rank_type srcRank,
+                               THDGroup groupId) {
+
+  throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
+                           "node broadcast");
+}
+
+
+void DataChannelTCP::destroyGroup(THDGroup group_id) {
+  throw std::runtime_error("DataChannelTCP does not support destroy group");
+}
+
 
 } // namespace thd

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
@@ -790,8 +790,8 @@ void DataChannelTCP::_reduce(at::Tensor& result, at::Tensor& data,
   }
 }
 
-void DataChannelTCP::allReduce(std::vector<thpp::Tensor*>& input,
-                               std::vector<thpp::Tensor*>& output,
+void DataChannelTCP::allReduce(std::vector<at::Tensor>& input,
+                               std::vector<at::Tensor>& output,
                                THDReduceOp operation,
                                THDGroup groupId) {
 
@@ -800,8 +800,8 @@ void DataChannelTCP::allReduce(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelTCP::allGather(std::vector<thpp::Tensor*>& input,
-                               std::vector<thpp::Tensor*>& output,
+void DataChannelTCP::allGather(std::vector<at::Tensor>& input,
+                               std::vector<at::Tensor>& output,
                                THDGroup groupId) {
 
   throw std::runtime_error("DataChannelTCP does not support mult-GPU cross "
@@ -809,7 +809,7 @@ void DataChannelTCP::allGather(std::vector<thpp::Tensor*>& input,
 }
 
 
-void DataChannelTCP::reduce(std::vector<thpp::Tensor*>& data,
+void DataChannelTCP::reduce(std::vector<at::Tensor>& data,
                             THDReduceOp operation,
                             rank_type dstRank,
                             THDGroup groupId) {
@@ -819,7 +819,7 @@ void DataChannelTCP::reduce(std::vector<thpp::Tensor*>& data,
 }
 
 
-void DataChannelTCP::broadcast(std::vector<thpp::Tensor*>& data,
+void DataChannelTCP::broadcast(std::vector<at::Tensor>& data,
                                rank_type srcRank,
                                THDGroup groupId) {
 

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.hpp
@@ -36,8 +36,8 @@ struct DataChannelTCP : DataChannel {
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
-  void allGather(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allGather(std::vector<at::Tensor>& output,
+                 std::vector<at::Tensor>& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
@@ -45,8 +45,7 @@ struct DataChannelTCP : DataChannel {
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
-  void allReduce(std::vector<at::Tensor>& input,
-                 std::vector<at::Tensor>& output,
+  void allReduce(std::vector<at::Tensor>& data,
                  THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
@@ -73,7 +72,7 @@ struct DataChannelTCP : DataChannel {
   void barrier(THDGroup group_id = THDGroupWORLD) override;
 
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
-  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
+  void clearGroupCache(THDGroup group_id = THDGroupWORLD) override;
 
 private:
   using req_ptr = std::unique_ptr<RequestTCP>;

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.hpp
@@ -31,20 +31,35 @@ struct DataChannelTCP : DataChannel {
   virtual ~DataChannelTCP();
 
   bool init() override;
+  void destroy() override;
 
   rank_type getRank() override;
   rank_type getNumProcesses() override;
 
+  void allGather(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allGather(std::vector<at::Tensor>& output, at::Tensor& input,
                  THDGroup group_id = THDGroupWORLD) override;
   void gather(std::vector<at::Tensor>& output, at::Tensor& input,
               rank_type dst_rank, THDGroup group_id = THDGroupWORLD) override;
   void scatter(std::vector<at::Tensor>& input, at::Tensor& output,
                rank_type src_rank, THDGroup group_id = THDGroupWORLD) override;
+  void allReduce(std::vector<at::Tensor>& input,
+                 std::vector<at::Tensor>& output,
+                 THDReduceOp operation,
+                 THDGroup group_id = THDGroupWORLD) override;
   void allReduce(at::Tensor& data, THDReduceOp operation,
                  THDGroup group_id = THDGroupWORLD) override;
+  void reduce(std::vector<at::Tensor>& data,
+              THDReduceOp operation,
+              rank_type dstRank,
+              THDGroup group_id = THDGroupWORLD) override;
   void reduce(at::Tensor& data, THDReduceOp operation, rank_type dst_rank,
               THDGroup group_id = THDGroupWORLD) override;
+  void broadcast(std::vector<at::Tensor>& data,
+                 rank_type srcRank,
+                 THDGroup group_id = THDGroupWORLD) override;
   void broadcast(at::Tensor& data, rank_type src_id,
                  THDGroup group_id = THDGroupWORLD) override;
   void send(Scalar& data, rank_type dst_id) override;
@@ -58,6 +73,7 @@ struct DataChannelTCP : DataChannel {
   void barrier(THDGroup group_id = THDGroupWORLD) override;
 
   THDGroup newGroup(const std::vector<rank_type>& ranks) override;
+  void destroyGroup(THDGroup group_id = THDGroupWORLD) override;
 
 private:
   using req_ptr = std::unique_ptr<RequestTCP>;
@@ -96,6 +112,7 @@ private:
 
   // Workers
   QueueWorker _send_worker, _receive_worker;
+
 };
 
 } // namespace thd

--- a/torch/lib/THD/cmake/FindNCCL.cmake
+++ b/torch/lib/THD/cmake/FindNCCL.cmake
@@ -1,0 +1,35 @@
+# - Try to find NCCL
+#
+# The following variables are optionally searched for defaults
+#  NCCL_ROOT_DIR: Base directory where all NCCL components are found
+#
+# The following are set after configuration is done:
+#  NCCL_FOUND
+#  NCCL_INCLUDE_DIRS
+#  NCCL_LIBRARIES
+
+set (NCCL_ROOT_DIR $ENV{NCCL_ROOT_DIR})
+
+find_path (NCCL_INCLUDE_DIR
+  NAMES nccl.h
+  HINTS
+  ${NCCL_ROOT_DIR}
+  ${NCCL_ROOT_DIR}/include)
+
+find_library (NCCL_LIBRARY
+  NAMES nccl
+  HINTS
+  ${NCCL_ROOT_DIR}
+  ${NCCL_ROOT_DIR}/lib
+  ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
+  ${NCCL_ROOT_DIR}/lib64)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (NCCL DEFAULT_MSG NCCL_INCLUDE_DIR NCCL_LIBRARY)
+
+if (NCCL_FOUND)
+  set (NCCL_INCLUDE_DIRS ${NCCL_INCLUDE_DIR})
+  set (NCCL_LIBRARIES ${NCCL_LIBRARY})
+  message (STATUS "Found NCCL (include: ${NCCL_INCLUDE_DIRS}, library: ${NCCL_LIBRARIES})")
+  mark_as_advanced (NCCL_ROOT_DIR NCCL_INCLUDE_DIRS NCCL_LIBRARIES)
+endif ()

--- a/torch/lib/THD/cmake/FindNCCL.cmake
+++ b/torch/lib/THD/cmake/FindNCCL.cmake
@@ -28,6 +28,15 @@ include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (NCCL DEFAULT_MSG NCCL_INCLUDE_DIR NCCL_LIBRARY)
 
 if (NCCL_FOUND)
+  set (NCCL_HEADER_FILE "${NCCL_INCLUDE_DIR}/nccl.h")
+  message (STATUS "Determining NCCL version from the header file: ${NCCL_HEADER_FILE}")
+  file (STRINGS ${NCCL_HEADER_FILE} NCCL_MAJOR_VERSION_DEFINED
+        REGEX "^[ \t]*#define[ \t]+NCCL_MAJOR[ \t]+[0-9]+.*$" LIMIT_COUNT 1)
+  if (NCCL_MAJOR_VERSION_DEFINED)
+    string (REGEX REPLACE "^[ \t]*#define[ \t]+NCCL_MAJOR[ \t]+" ""
+            NCCL_MAJOR_VERSION ${NCCL_MAJOR_VERSION_DEFINED})
+    message (STATUS "NCCL_MAJOR_VERSION: ${NCCL_MAJOR_VERSION}")
+  endif ()
   set (NCCL_INCLUDE_DIRS ${NCCL_INCLUDE_DIR})
   set (NCCL_LIBRARIES ${NCCL_LIBRARY})
   message (STATUS "Found NCCL (include: ${NCCL_INCLUDE_DIRS}, library: ${NCCL_LIBRARIES})")

--- a/torch/lib/THD/process_group/Collectives.cpp
+++ b/torch/lib/THD/process_group/Collectives.cpp
@@ -19,7 +19,7 @@ void THDAllReduceMultiGPU(THDTensorDescriptor* data,
                           THDReduceOp operation,
                           THDGroup group) {
   std::vector<at::Tensor> dataVec(data, data + len);
-  dataChannel->allReduce(dataVec, dataVec, operation, group);
+  dataChannel->allReduce(dataVec, operation, group);
 }
 
 
@@ -80,7 +80,7 @@ void THDAllGatherMultiGPU(THDTensorDescriptor* output,
                           THDGroup group) {
   std::vector<at::Tensor> outputVec(output, output + outputLen);
   std::vector<at::Tensor> inputVec(input, input + inputLen);
-  dataChannel->allGather(inputVec, outputVec, group);
+  dataChannel->allGather(outputVec, inputVec, group);
 }
 
 void THDAllGather(THDTensorDescriptor* output, size_t len,

--- a/torch/lib/THD/process_group/Collectives.cpp
+++ b/torch/lib/THD/process_group/Collectives.cpp
@@ -14,13 +14,39 @@ int THDGetNumProcesses() {
   return static_cast<int>(dataChannel->getNumProcesses());
 }
 
+void THDAllReduceMultiGPU(THDTensorDescriptor* data,
+                          size_t len,
+                          THDReduceOp operation,
+                          THDGroup group) {
+  std::vector<at::Tensor> dataVec(data, data + len);
+  dataChannel->allReduce(dataVec, dataVec, operation, group);
+}
+
+
 void THDAllReduce(THDTensorDescriptor& desc, THDReduceOp operation, THDGroup group) {
   dataChannel->allReduce(desc, operation, group);
+}
+
+void THDReduceMultiGPU(THDTensorDescriptor* desc,
+                       size_t len,
+                       THDReduceOp operation,
+                       int dst_rank,
+                       THDGroup group) {
+  std::vector<at::Tensor> dataVec(desc, desc + len);
+  dataChannel->reduce(dataVec, operation, convertToRank(dst_rank), group);
 }
 
 void THDReduce(THDTensorDescriptor& desc, THDReduceOp operation,
                int dst_rank, THDGroup group) {
   dataChannel->reduce(desc, operation, convertToRank(dst_rank), group);
+}
+
+void THDBroadcastMultiGPU(THDTensorDescriptor* desc,
+                          size_t len,
+                          int src_rank,
+                          THDGroup group) {
+  std::vector<at::Tensor> dataVec(desc, desc + len);
+  dataChannel->broadcast(dataVec, convertToRank(src_rank), group);
 }
 
 void THDBroadcast(THDTensorDescriptor& desc, int src_rank, THDGroup group) {
@@ -45,6 +71,16 @@ int THDRecvAnySource(THDTensorDescriptor& desc) {
 
 void THDRecv(THDTensorDescriptor& desc, int src_rank) {
   dataChannel->receive(desc, convertToRank(src_rank));
+}
+
+void THDAllGatherMultiGPU(THDTensorDescriptor* output,
+                          size_t outputLen,
+                          THDTensorDescriptor* input,
+                          size_t inputLen,
+                          THDGroup group) {
+  std::vector<at::Tensor> outputVec(output, output + outputLen);
+  std::vector<at::Tensor> inputVec(input, input + inputLen);
+  dataChannel->allGather(inputVec, outputVec, group);
 }
 
 void THDAllGather(THDTensorDescriptor* output, size_t len,

--- a/torch/lib/THD/process_group/Collectives.h
+++ b/torch/lib/THD/process_group/Collectives.h
@@ -5,16 +5,34 @@
 
 THD_API int THDGetRank();
 THD_API int THDGetNumProcesses();
+THD_API void THDAllReduceMultiGPU(THDTensorDescriptor* data,
+                                  size_t len,
+                                  THDReduceOp operation,
+                                  THDGroup group);
 THD_API void THDAllReduce(THDTensorDescriptor& desc, THDReduceOp operation,
                           THDGroup group);
+THD_API void THDReduceMultiGPU(THDTensorDescriptor* desc,
+                               size_t len,
+                               THDReduceOp operation,
+                               int dst_rank,
+                               THDGroup group);
 THD_API void THDReduce(THDTensorDescriptor& desc, THDReduceOp operation,
                        int dst_rank, THDGroup group);
+THD_API void THDBroadcastMultiGPU(THDTensorDescriptor* desc,
+                                  size_t len,
+                                  int src_rank,
+                                  THDGroup group);
 THD_API void THDBroadcast(THDTensorDescriptor& desc, int src_rank, THDGroup group);
 THD_API THDRequest* THDIsend(THDTensorDescriptor& desc, int dst_rank);
 THD_API THDRequest* THDIrecv(THDTensorDescriptor& desc, int src_rank);
 THD_API void THDSend(THDTensorDescriptor& desc, int dst_rank);
 THD_API int THDRecvAnySource(THDTensorDescriptor& desc);
 THD_API void THDRecv(THDTensorDescriptor& desc, int src_rank);
+THD_API void THDAllGatherMultiGPU(THDTensorDescriptor* output,
+                                  size_t outputLen,
+                                  THDTensorDescriptor* input,
+                                  size_t inputLen,
+                                  THDGroup group);
 THD_API void THDAllGather(THDTensorDescriptor* output, size_t len,
                           THDTensorDescriptor& input, THDGroup group);
 THD_API void THDGatherSend(THDTensorDescriptor& input, int dst_rank, THDGroup group);

--- a/torch/lib/THD/process_group/General.cpp
+++ b/torch/lib/THD/process_group/General.cpp
@@ -16,3 +16,20 @@ void THDProcessGroupInit(THDChannelType channel_type, std::string init_method = 
   dataChannel->init();
   END_HANDLE_EXCEPTIONS
 }
+
+void THDProcessGroupDestroy() {
+  HANDLE_EXCEPTIONS
+  if (dataChannel) {
+    dataChannel->destroy();
+    dataChannel.reset(nullptr);
+  }
+  END_HANDLE_EXCEPTIONS
+}
+
+void THDGroupDestroy(THDGroup group) {
+  HANDLE_EXCEPTIONS
+  if (dataChannel) {
+    dataChannel->destroyGroup(group);
+  }
+  END_HANDLE_EXCEPTIONS
+}

--- a/torch/lib/THD/process_group/General.cpp
+++ b/torch/lib/THD/process_group/General.cpp
@@ -26,10 +26,10 @@ void THDProcessGroupDestroy() {
   END_HANDLE_EXCEPTIONS
 }
 
-void THDGroupDestroy(THDGroup group) {
+void THDClearGroupCache(THDGroup group) {
   HANDLE_EXCEPTIONS
   if (dataChannel) {
-    dataChannel->destroyGroup(group);
+    dataChannel->clearGroupCache(group);
   }
   END_HANDLE_EXCEPTIONS
 }

--- a/torch/lib/THD/process_group/General.h
+++ b/torch/lib/THD/process_group/General.h
@@ -7,5 +7,5 @@
 THD_API void THDProcessGroupInit(THDChannelType channel_type, std::string init_method,
                                  int world_size, std::string group_name, int rank);
 THD_API void THDProcessGroupDestroy();
-THD_API void THDGroupDestroy(THDGroup group);
+THD_API void THDClearGroupCache(THDGroup group);
 

--- a/torch/lib/THD/process_group/General.h
+++ b/torch/lib/THD/process_group/General.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "../base/DataChannel.h"
 #include "../THD.h"
 #include <string>
 
 THD_API void THDProcessGroupInit(THDChannelType channel_type, std::string init_method,
                                  int world_size, std::string group_name, int rank);
+THD_API void THDProcessGroupDestroy();
+THD_API void THDGroupDestroy(THDGroup group);
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -22,7 +22,7 @@ else:
 
 
 class DistributedDataParallel(Module):
-    """Implements distributed data parallelism at the module level.
+    r"""Implements distributed data parallelism at the module level.
 
     This container parallelizes the application of the given module by
     splitting the input across the specified devices by chunking in the batch

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -100,7 +100,6 @@ class DistributedDataParallel(Module):
             grp = dist.new_group()
             for p in self.module.state_dict().values():
                 dist.broadcast(p, 0, grp)
-            dist.barrier(grp)
             dist.destroy_group(grp)
             self.bcast_grp = dist.new_group()
             self.reduce_grp = set()
@@ -193,7 +192,7 @@ class DistributedDataParallel(Module):
         for module in self._module_copies[1:]:
             module.train(mode)
 
-    def recreate_groups(self):
+    def _recreate_groups(self):
         """ Function that is only supposed to use with NCCL backend.
         Currently experimental only
         """


### PR DESCRIPTION
Removed hack clear_group_cache workaround in DDP module for NCCL backend after root-causing the NCCL deadlock problem, which is caused by the weirdness of multiprocessing fork (we have already had GitHub issues tracking this). Tested with both fork server and spawn method and they both work well without any deadlock or issues.

The NCCL backend with DDP module has been tested well enough (with good accuracy for ResNet50 and reliability on Infiniband) to be added as one of the supported backend for DDP.

The fork warning has also been added to DDP warnings

Added an unsupported new_group check since NCCL backend currently doesn't support subgroup creation. Tested the code path as well:

```
/private/home/tengli/miniconda3/envs/cuda9/lib/python3.6/site-packages/torch/distributed/__init__.py:105: UserWarning:
        ================================================================================
                                            WARNING
        ================================================================================
        NCCL backend is still experimental. The APIs will change without
        notice and we're can't guarantee full correctness and expected performance yet.
        We'll announce it once it's ready.

  """)
Traceback (most recent call last):
  File "nccl2_test/test_nccl2.py", line 20, in <module>
    c= dist.new_group([0])
  File "/private/home/tengli/miniconda3/envs/cuda9/lib/python3.6/site-packages/torch/distributed/__init__.py", line 558, in new_group
    raise RuntimeError("Currently NCCL backend only supports full group "
RuntimeError: Currently NCCL backend only supports full group creation. In other words, every rank in the process group needs to be a member of the new group to be created and sub-group creation is currently not supported
```




