### PR TITLE
Removing NCCL clear_group_cache workaround with one more check in new_group

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -551,16 +551,6 @@ def new_group(ranks=None):
         "collective only supported in process-group mode"
     if ranks is None:
         ranks = list(range(get_world_size()))
-
-    # Check for the unsupported sub-group for NCCL backend
-    elif _backend == dist_backend.NCCL and \
-            set(ranks) != set(range(get_world_size())):
-        raise RuntimeError("Currently NCCL backend only supports full group "
-                           "creation. In other words, every rank in the "
-                           "process group needs to be a member of the new "
-                           "group to be created and sub-group creation is "
-                           "currently not supported")
-
     return torch._C._dist_new_group(ranks)
 
 

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -551,6 +551,16 @@ def new_group(ranks=None):
         "collective only supported in process-group mode"
     if ranks is None:
         ranks = list(range(get_world_size()))
+
+    # Check for the unsupported sub-group for NCCL backend
+    elif _backend == dist_backend.NCCL and \
+            set(ranks) != set(range(get_world_size())):
+        raise RuntimeError("Currently NCCL backend only supports full group "
+                           "creation. In other words, every rank in the "
+                           "process group needs to be a member of the new "
+                           "group to be created and sub-group creation is "
+                           "currently not supported")
+
     return torch._C._dist_new_group(ranks)
 
 

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -619,6 +619,21 @@ void DataChannelNccl::barrier(THDGroup groupId) {
 
 
 THDGroup DataChannelNccl::newGroup(const std::vector<rank_type>& ranks) {
+  /**
+   * Check if the input rank is a full group since
+   * NCCL data channel currently doesn't support sub-group creation
+   */
+  std::vector<rank_type> ranksToCompare = std::vector<rank_type>(ranks);
+  std::sort(ranksToCompare.begin(), ranksToCompare.end());
+  for (size_t i = 0; i < ranksToCompare.size(); ++i) {
+    if (ranksToCompare[i] != static_cast<rank_type>(i)) {
+      throw std::runtime_error("NCCL backend currently only supports fullgroup "
+                               "creation. In other words, every rank in the "
+                               "process group needs to be a member of the new "
+                               "group to be created and sub-group creation is "
+                               "currently not supported.");
+    }
+  }
 
   std::unique_lock<std::mutex> channelLock(_mutex);
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -42,7 +42,7 @@ class DistributedDataParallel(Module):
     (see :func:`torch.distributed.init_process_group`).
 
     .. warning::
-        This module works only with the ``gloo`` backend.
+        This module works only with the ``nccl`` and ``gloo`` backend.
 
     .. warning::
         Constructor, forward method, and differentiation of the output (or a
@@ -62,6 +62,14 @@ class DistributedDataParallel(Module):
         This module doesn't work with :func:`torch.autograd.grad` (i.e. it will
         only work if gradients are to be accumulated in ``.grad`` attributes of
         parameters).
+
+    .. warning::
+        If you are using data loader with more than one subprocess workers
+        and this module with ``nccl`` backend, you should use ``spawn``
+        or ``forkserver`` start method instead of ``fork`` start method.
+        This module with ``nccl`` backend doesn't work well (has known issues)
+        with ``fork`` start method of torch.multiprocessing (which is used by
+        the dataloader to launch multiple subprocess workers).
 
     .. note::
         Parameters are never broadcast between processes. The module performs
@@ -95,12 +103,6 @@ class DistributedDataParallel(Module):
         # Sync params and buffers
         for p in self.module.state_dict().values():
             dist.broadcast(p, 0)
-
-        # Clear NCCL communicator and CUDA event cache of the default group ID,
-        # These cache will be recreated at the later call. This is currently a
-        # work-around for a potential NCCL deadlock.
-        if dist._backend == dist.dist_backend.NCCL:
-            dist._clear_group_cache()
 
         if len(device_ids) > 1:
             # TODO: we don't need to replicate params in here. they're always going to
@@ -182,11 +184,6 @@ class DistributedDataParallel(Module):
         return gather(outputs, output_device, dim=self.dim)
 
     def train(self, mode=True):
-        # Clear NCCL communicator and CUDA event cache of the default group ID,
-        # These cache will be recreated at the later call. This is currently a
-        # work-around for a potential NCCL deadlock.
-        if dist._backend == dist.dist_backend.NCCL:
-            dist._clear_group_cache()
         super(DistributedDataParallel, self).train(mode)
         for module in self._module_copies[1:]:
             module.train(mode)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -64,11 +64,12 @@ class DistributedDataParallel(Module):
         parameters).
 
     .. warning::
-        If you plan on using this module with a ``nccl`` backend together with
-        a DataLoader that uses multiple workers, please change the multiprocessing
-        start method to ``forkserver`` (Python 3 only) or ``spawn``. Unfortunately
-        NCCL2 isn't fork safe, and you will likely experience deadlocks if you don't
-        change this setting.
+        If you plan on using this module with a ``nccl`` backend or a ``gloo``
+        backend (that uses Infiniband), together with a DataLoader that uses
+        multiple workers, please change the multiprocessing start method to
+        ``forkserver`` (Python 3 only) or ``spawn``. Unfortunately
+        Gloo (that uses Infiniband) and NCCL2 are not fork safe, and you will
+        likely experience deadlocks if you don't change this setting.
 
     .. note::
         Parameters are never broadcast between processes. The module performs

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -64,12 +64,11 @@ class DistributedDataParallel(Module):
         parameters).
 
     .. warning::
-        If you are using data loader with more than one subprocess workers
-        and this module with ``nccl`` backend, you should use ``spawn``
-        or ``forkserver`` start method instead of ``fork`` start method.
-        This module with ``nccl`` backend doesn't work well (has known issues)
-        with ``fork`` start method of torch.multiprocessing (which is used by
-        the dataloader to launch multiple subprocess workers).
+        If you plan on using this module with a ``nccl`` backend together with
+        a DataLoader that uses multiple workers, please change the multiprocessing
+        start method to ``forkserver`` (Python 3 only) or ``spawn``. Unfortunately
+        NCCL2 isn't fork safe, and you will likely experience deadlocks if you don't
+        change this setting.
 
     .. note::
         Parameters are never broadcast between processes. The module performs

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -42,7 +42,7 @@ class DistributedDataParallel(Module):
     (see :func:`torch.distributed.init_process_group`).
 
     .. warning::
-        This module works only with the ``nccl`` and ``gloo`` backend.
+        This module works only with the ``nccl`` and ``gloo`` backends.
 
     .. warning::
         Constructor, forward method, and differentiation of the output (or a


### PR DESCRIPTION
Removed the hacky clear_group_cache workaround in DDP module for NCCL backend after root-causing the NCCL deadlock problem, which is caused by the weirdness of multiprocessing fork (we have already had GitHub issues tracking this). Tested with both fork server and spawn method and they both work well without any deadlock or issues.

The NCCL backend with DDP module has been tested well enough (with good accuracy for ResNet50 and reliability on Infiniband) to be added as one of the supported backend for DDP.

The fork warning has also been added to DDP warnings

Added an unsupported new_group check since NCCL backend currently doesn't support subgroup creation. Tested the code path as well:

```
/private/home/tengli/miniconda3/envs/cuda9/lib/python3.6/site-packages/torch/distributed/__init__.py:105: UserWarning:
        ================================================================================
                                            WARNING
        ================================================================================
        NCCL backend is still experimental. The APIs will change without
        notice and we're can't guarantee full correctness and expected performance yet.
        We'll announce it once it's ready.

  """)
Traceback (most recent call last):
  File "/private/home/tengli/nccl2_test/test_nccl2.py", line 22, in <module>
    c = dist.new_group([1])
  File "/private/home/tengli/miniconda3/envs/cuda9/lib/python3.6/site-packages/torch/distributed/__init__.py", line 554, in new_group
    return torch._C._dist_new_group(ranks)
RuntimeError: NCCL backend currently only supports fullgroup creation. In other words, every rank in the process group needs to be a member of the new group to be created and sub-group creation is currently not supported.
```