### PR TITLE
Restore sparse variable transpose_() and t_()

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4097,7 +4097,7 @@
 
 [[
   name: sparse_raw_resize_
-  variants: [method, function]
+  variants: [method]
   backends:
     - SparseCPU
     - SparseCUDA

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -219,20 +219,6 @@
       wrap_dim: self
 ]]
 [[
-  name: transpose_
-  cname: transpose
-  cpu_half: True
-  auto_gpu: False
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-    - arg: long dim0
-      wrap_dim: self
-    - arg: long dim1
-      wrap_dim: self
-]]
-[[
   name: t
   variants:
     - method
@@ -251,20 +237,6 @@
       THPUtils_assert(ndim == 2, "t() expects a 2D tensor, but self is %ldD", ndim);
     }
   arguments:
-    - THTensor* self
-    - CONSTANT 0
-    - CONSTANT 1
-]]
-[[
-  name: t_
-  cname: transpose
-  auto_gpu: False
-  return: self
-  before_call: |
-    long ndim = arg_self->nDimension;
-    THPUtils_assert(ndim == 2, "t_() expects a 2D tensor, but self is %ldD", ndim);
-  arguments:
-    - THTensor* self
     - THTensor* self
     - CONSTANT 0
     - CONSTANT 1
@@ -4120,6 +4092,34 @@
       storage_offset = self_->tensor->storageOffset;
     }
     ${THTensor}_setStorage(${state,}self_->tensor, self_->tensor->storage, storage_offset, size_, stride_);
+    self_->maybeScalar(size.size() == 0);
+]]
+
+[[
+  name: sparse_raw_resize_
+  variants: [method, function]
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: argument 0
+  arguments:
+    - THTensor* self
+    - THSize* size
+    - int64_t nDimI
+    - int64_t nDimV
+  aten_custom_call: |
+    /*
+     * Sets sizes, nDimI, and nDimV of a sparse tensor directly without any
+     * safety checks. If nDimI and/or nDimV are -1, recompute them from
+     * indices and values, respectively.
+     */
+    if (nDimI == -1) {
+      nDimI = self._indices().size(0);
+    }
+    if (nDimV == -1) {
+      nDimV = self._values().dim() - 1;
+    }
+    ${THTensor}_rawResize(${state,}self_->tensor, nDimI, nDimV, (*size_).data);
     self_->maybeScalar(size.size() == 0);
 ]]
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -177,10 +177,9 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
 }
 
 Tensor & transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
-  auto ndims = self.ndimension();
-  if (dim0 < 0 || dim0 >= ndims || dim1 < 0 || dim1 >= ndims) {
-    throw std::runtime_error("dimension out of range");
-  }
+  auto ndims = self.dim();
+  dim0 = maybe_wrap_dim(dim0, ndims);
+  dim1 = maybe_wrap_dim(dim1, ndims);
   if (dim0 == dim1) {
     return self;
   }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -3,6 +3,8 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/WrapDimUtils.h"
 
+#include <algorithm>
+
 namespace at {
 namespace native {
 
@@ -146,6 +148,60 @@ Tensor stack(TensorList tensors, int64_t dim) {
     inputs[i] = tensors[i].unsqueeze(dim);
   }
   return at::cat(inputs, dim);
+}
+
+
+static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
+  int64_t ndimI = self._indices().size(0);
+  if (dim0 >= ndimI || dim1 >= ndimI) {
+    runtime_error(
+        "sparse transpose_: transposed dimensions must be sparse ",
+        "Got nDimI: %llu, d0: %llu, d1: %llu",
+        (long long)ndimI, (long long)dim0, (long long)dim1);
+  }
+
+  auto indices = self._indices();
+  auto row0 = indices.select(0, dim0);
+  auto row1 = indices.select(0, dim1);
+
+  // swap row0 and row1
+  auto tmp = at::zeros_like(row0);
+  tmp.copy_(row0);
+  row0.copy_(row1);
+  row1.copy_(tmp);
+
+  std::vector<int64_t> sizes(self.sizes());
+  std::swap(sizes[dim0], sizes[dim1]);
+
+  return self.sparse_raw_resize_(sizes, -1, -1);
+}
+
+Tensor & transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
+  auto ndims = self.ndimension();
+  if (dim0 < 0 || dim0 >= ndims || dim1 < 0 || dim1 >= ndims) {
+    throw std::runtime_error("dimension out of range");
+  }
+  if (dim0 == dim1) {
+    return self;
+  }
+
+  if (self.is_sparse()) {
+    return sparse_transpose_(self, dim0, dim1);
+  }
+
+  std::vector<int64_t> strides(self.strides());
+  std::vector<int64_t> sizes(self.sizes());
+  std::swap(strides[dim0], strides[dim1]);
+  std::swap(sizes[dim0], sizes[dim1]);
+  return self.as_strided_(sizes, strides);
+}
+
+Tensor & t_(Tensor & self) {
+  if (self.ndimension() != 2) {
+    runtime_error("t_() expects a 2D tensor, but self is %llu",
+                  (long long)self.ndimension());
+  }
+  return self.transpose_(0, 1);
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -287,6 +287,10 @@
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
 
+- func: transpose_(Tensor self, int64_t dim0, int64_t dim1) -> Tensor
+
+- func: t_(Tensor self) -> Tensor
+
 - func: type_as(Tensor self, Tensor other) -> Tensor
 
 - func: unsqueeze(Tensor self, int64_t dim) -> Tensor

--- a/aten/src/THCS/generic/THCSTensor.c
+++ b/aten/src/THCS/generic/THCSTensor.c
@@ -77,7 +77,7 @@ static void THCSTensor_(rawInit)(THCState *state, THCSTensor *self)
   self->refcount = 1;
 }
 
-void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size) {
+THCSTensor* THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size) {
   // Only resize valid sizes into tensor.
   self->size = THRealloc(self->size, sizeof(int64_t)*(nDimI + nDimV));
 
@@ -86,7 +86,7 @@ void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nD
   }
   self->nDimensionI = nDimI;
   self->nDimensionV = nDimV;
-  self->coalesced = 0;
+  return self;
 }
 
 // directly assign without cloning or retaining (internal method)

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -72,7 +72,7 @@ TH_API int THCSTensor_(getDevice)(THCState *state, const THCSTensor *self);
 TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned int nTensors, ...);
 
 /* internal methods */
-TH_API void THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size);
+TH_API THCSTensor* THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, int64_t nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);

--- a/aten/src/THS/generic/THSTensor.c
+++ b/aten/src/THS/generic/THSTensor.c
@@ -76,7 +76,7 @@ static void THSTensor_(rawInit)(THSTensor *self)
   // self->flag = TH_TENSOR_REFCOUNTED;
 }
 
-static void THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t *size) {
+THSTensor* THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t *size) {
   // Only resize valid sizes into tensor.
   self->size = THRealloc(self->size, sizeof(int64_t)*(nDimI + nDimV));
 
@@ -85,7 +85,8 @@ static void THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t
   }
   self->nDimensionI = nDimI;
   self->nDimensionV = nDimV;
-  self->coalesced = 0;
+
+  return self;
 }
 
 // directly assign without cloning or retaining (internal method)

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -75,6 +75,7 @@ TH_API void THSTensor_(select)(THSTensor *self, THSTensor *src, int dimension_, 
 */
 
 // internal methods
+TH_API THSTensor* THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t *size);
 THSTensor* THSTensor_(_move)(THSTensor *self, THLongTensor *indices, THTensor *values);
 THSTensor* THSTensor_(_set)(THSTensor *self, THLongTensor *indices, THTensor *values);
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -646,7 +646,9 @@ class TestSparse(TestCase):
         to_test_one_arg = {
             'zeros_like': lambda x: torch.zeros_like(x),
             'transpose': lambda x: x.transpose(0, 1),
+            'transpose_': lambda x: x.transpose(0, 1),
             't': lambda x: x.t(),
+            't_': lambda x: x.t_(),
             'div': lambda x: x.div(2),
             'div_': lambda x: x.div_(2),
             'pow': lambda x: x.pow(2),

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -16,6 +16,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
+    'sparse_raw_resize_',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
Partially addresses #4236 

Adds the following:
- migrates regular Variable transpose_() and t_() to ATen
- exposes sparse_raw_resize_ (which is called rawResize in TH*)
- Before when rawResize was called, `coalesced` would be set to 0. Removes that because doing the rawResize doesn't add or subtract extra elements to the sparse tensor.
- sparse variable transpose_() and t_()

### Test Plan
Unit tests for transpose_() and t_()