### PR TITLE
Restore more sparse variable methods

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4161,6 +4161,58 @@
 ]]
 
 [[
+  name: to_dense
+  cname: toDense
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THDenseTensor*
+  arguments:
+  - THTensor* self
+]]
+
+[[
+  name: _nnz
+  cname: nnz
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: int64_t
+  arguments:
+  - THTensor* self
+]]
+
+[[
+  name: coalesce 
+  cname: newCoalesce
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THTensor*
+  arguments:
+     - THTensor* self
+]]
+
+[[
+  name: is_coalesced 
+  cname: isCoalesced
+  variants:
+    - method
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: bool 
+  arguments:
+     - THTensor* self
+]]
+
+[[
   name: _indices
   variants:
     - method

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -650,11 +650,24 @@ class TestSparse(TestCase):
             'div': lambda x: x.div(2),
             'div_': lambda x: x.div_(2),
             'pow': lambda x: x.pow(2),
+            '_nnz': lambda x: x._nnz(),
+            'is_coalesced': lambda x: x.is_coalesced(),
+            'coalesce': lambda x: x.coalesce(),
+            'to_dense': lambda x: x.to_dense(),
         }
 
         for test_name, test_fn in to_test_one_arg.items():
             var1 = sparse_var.clone()
             tensor1 = sparse_mat.clone()
+
+            out_var = test_fn(var1)
+            out_tensor = test_fn(tensor1)
+
+            if isinstance(out_tensor, int) or isinstance(out_tensor, bool):
+                self.assertEqual(out_var, out_tensor)
+                continue
+
+            # Assume output is variable / tensor
             self.assertEqual(test_fn(var1).data, test_fn(tensor1),
                              test_name)
 


### PR DESCRIPTION
Partially addresses #4236 

Restores:
- _nnz
- coalesce
- to_dense
- is_coalesced

### Test Plan
new unit tests