### PR TITLE
Use ATen infer_size implementation rather than TH.

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -7,7 +7,7 @@
 
 namespace at {
 
-std::vector<int64_t> infer_size(IntList a, IntList b);
+AT_API std::vector<int64_t> infer_size(IntList a, IntList b);
 std::tuple<std::vector<int64_t>, std::vector<int64_t> > inferExpandGeometry(const Tensor &tensor, IntList sizes);
 
 // avoid copy-construction of Tensor by using a reference_wrapper.

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -10,6 +10,7 @@
 #include <libshm.h>
 #include <TH/TH.h>
 #include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/dlpack.h>
 #include <ATen/DLConvertor.h>
 #include <pybind11/pybind11.h>
@@ -460,17 +461,10 @@ PyObject *THPModule_inferSize(PyObject *_unused, PyObject *args)
   PyObject *arg2 = PyTuple_GET_ITEM(args, 1);
   THPUtils_assert(THPSize_Check(arg2), "expected a torch.Size as argument 2");
 
-  THLongStoragePtr size1_guard = THPUtils_unpackSize(arg1);
-  THLongStorage *size1 = size1_guard.get();
-  THLongStoragePtr size2_guard = THPUtils_unpackSize(arg2);
-  THLongStorage *size2 = size2_guard.get();
-  THLongStoragePtr sizes_guard(THLongStorage_new());
-  THLongStorage *sizes = sizes_guard.get();
-
-  char error_buffer[1024];
-  int ret = THLongStorage_inferSize2(sizes, size1->data, size1->size, size2->data, size2->size, error_buffer, 1024);
-  THPUtils_assert(ret == 0, error_buffer);
-  return THPSize_New(sizes->size, sizes->data);
+  auto size1 = THPUtils_tryUnpackLongs(arg1);
+  auto size2 = THPUtils_tryUnpackLongs(arg2);
+  auto sizes = at::infer_size(size1, size2);
+  return THPSize_New(sizes.size(), sizes.data());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -461,8 +461,8 @@ PyObject *THPModule_inferSize(PyObject *_unused, PyObject *args)
   PyObject *arg2 = PyTuple_GET_ITEM(args, 1);
   THPUtils_assert(THPSize_Check(arg2), "expected a torch.Size as argument 2");
 
-  auto size1 = THPUtils_tryUnpackLongs(arg1);
-  auto size2 = THPUtils_tryUnpackLongs(arg2);
+  auto size1 = THPUtils_unpackLongs(arg1);
+  auto size2 = THPUtils_unpackLongs(arg2);
   auto sizes = at::infer_size(size1, size2);
   return THPSize_New(sizes.size(), sizes.data());
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -58,7 +58,7 @@ bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {
   return false;
 }
 
-std::vector<int64_t> THPUtils_tryUnpackLongs(PyObject *arg) {
+std::vector<int64_t> THPUtils_unpackLongs(PyObject *arg) {
   bool tuple = PyTuple_Check(arg);
   bool list = PyList_Check(arg);
   if (tuple || list) {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -58,6 +58,26 @@ bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result) {
   return false;
 }
 
+std::vector<int64_t> THPUtils_tryUnpackLongs(PyObject *arg) {
+  bool tuple = PyTuple_Check(arg);
+  bool list = PyList_Check(arg);
+  if (tuple || list) {
+    int nDim = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
+    std::vector<int64_t> sizes(nDim);
+    for (int i = 0; i != nDim; ++i) {
+      PyObject* item = tuple ? PyTuple_GET_ITEM(arg, i) : PyList_GET_ITEM(arg, i);
+      if (!THPUtils_checkLong(item)) {
+        std::ostringstream oss;
+        oss << "expected long at position " << i << ", but got: " << THPUtils_typename(item);
+        throw std::runtime_error(oss.str());
+      }
+      sizes[i] = THPUtils_unpackLong(item);
+    }
+    return sizes;
+  }
+  throw std::runtime_error("Expected tuple or list");
+}
+
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result) {
   Py_ssize_t length = PyTuple_Size(args) - ignore_first;
   if (length < 1) {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -68,7 +68,7 @@ std::vector<int64_t> THPUtils_unpackLongs(PyObject *arg) {
       PyObject* item = tuple ? PyTuple_GET_ITEM(arg, i) : PyList_GET_ITEM(arg, i);
       if (!THPUtils_checkLong(item)) {
         std::ostringstream oss;
-        oss << "expected long at position " << i << ", but got: " << THPUtils_typename(item);
+        oss << "expected int at position " << i << ", but got: " << THPUtils_typename(item);
         throw std::runtime_error(oss.str());
       }
       sizes[i] = THPUtils_unpackLong(item);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -163,6 +163,7 @@ struct THPUtils_typeTraits {};
 
 THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
+std::vector<int64_t> THPUtils_tryUnpackLongs(PyObject *arg);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
 PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);
 

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -163,7 +163,7 @@ struct THPUtils_typeTraits {};
 
 THLongStoragePtr THPUtils_unpackSize(PyObject *arg);
 bool THPUtils_tryUnpackLongs(PyObject *arg, THLongStoragePtr& result);
-std::vector<int64_t> THPUtils_tryUnpackLongs(PyObject *arg);
+std::vector<int64_t> THPUtils_unpackLongs(PyObject *arg);
 bool THPUtils_tryUnpackLongVarArgs(PyObject *args, int ignore_first, THLongStoragePtr& result);
 PyObject * THPUtils_dispatchStateless(PyObject *tensor, const char *name, PyObject *args, PyObject *kwargs);
 


### PR DESCRIPTION
The only substantitive difference between the two implementations is in how empty sizes are handled; in ATen these are treated as scalars (i.e., can be expanded to anything), whereas in TH they are treated as a special case of empty tensors (i.e., can't be expanded to anything).  Therefore, this change is necessary to support scalars (0-dimensional tensors).

We could also take a bool parameter for determining how we treat empty tensors but this seems unnecessary: if one tries to expand an empty tensors (as a result of an infer_size calculation), the expansion will fail.