### PR TITLE
Fix squeeze() backward in edge case

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2324,6 +2324,7 @@ method_tests = [
     ('narrow', (S, S, S), (1, 2, 2), 'dim', [0]),
     ('slice', (S, S, S), (-2, 1, -1, 2)),
     ('squeeze', (S, 1, S, 1), NO_ARGS),
+    ('squeeze', (1, 1, 1, 1), NO_ARGS, 'size_one_result'),
     ('squeeze', (S, 1, S, 1), (1,), '1_dim', [0]),
     ('squeeze', (S, 1, S, 1), (2,), 'not_1_dim', [0]),
     ('squeeze', (1,), (0,), '1d_dim0', [0]),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2324,7 +2324,7 @@ method_tests = [
     ('narrow', (S, S, S), (1, 2, 2), 'dim', [0]),
     ('slice', (S, S, S), (-2, 1, -1, 2)),
     ('squeeze', (S, 1, S, 1), NO_ARGS),
-    ('squeeze', (1, 1, 1, 1), NO_ARGS, 'size_one_result'),
+    ('squeeze', (1, 1, 1, 1), NO_ARGS, 'input_sizes_are_ones'),
     ('squeeze', (S, 1, S, 1), (1,), '1_dim', [0]),
     ('squeeze', (S, 1, S, 1), (2,), 'not_1_dim', [0]),
     ('squeeze', (1,), (0,), '1d_dim0', [0]),

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -304,11 +304,15 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
   int64_t nDims = sizes.size();
 
   // Let's say the input had size (1, 1). input.squeeze(), with scalars
-  // disabled, produces a result of size (1,). The following for loop
-  // assumes that the result of input.squeeze() has no dimensions of
-  // size 1, but in this edge case there is 1 dimension of size 1.
-  if (self.dim() == 1 and self.size(0) == 1) {
-    --nDims;
+  // disabled, produces a result of size (1,). This needs some
+  // special handling because for all other cases we unsqueeze every
+  // dimension that has size 1; doing that here would lead to one extra
+  // unsqueezed dimension
+  if (self.sizes().equals({1})) {
+    for (int64_t dim = 0; dim < nDims - 1; dim++) {
+      result = result.unsqueeze(dim);
+    }
+    return result;
   }
 
   for (int64_t dim = 0; dim < nDims; dim++) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -302,6 +302,15 @@ Tensor cumsum_backward(const Tensor & x, int64_t dim) {
 Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
   auto result = self;
   int64_t nDims = sizes.size();
+
+  // Let's say the input had size (1, 1). input.squeeze(), with scalars
+  // disabled, produces a result of size (1,). The following for loop
+  // assumes that the result of input.squeeze() has no dimensions of
+  // size 1, but in this edge case there is 1 dimension of size 1.
+  if (self.dim() == 1 and self.size(0) == 1) {
+    --nDims;
+  }
+
   for (int64_t dim = 0; dim < nDims; dim++) {
     if (sizes[dim] == 1) {
       result = result.unsqueeze(dim);


### PR DESCRIPTION
Fixes #4778 

There was a bug where if one calls `tensor.squeeze().backward()` where `tensor` has size `(1, 1)`, `tensor.grad` doesn't match the shape of `tensor`. This is because the result of `tensor.squeeze()` has size `(1,)`, and `squeeze()`'s backwards will `unsqueeze` the grad a number of times equal to the number of dimensions in `tensor` that have size 1.

cc @gchanan -- the code should work with both scalars enabled and disabled because there's a check for `dim() == 1`.

### Test Plan
New unit test for this case