### PR TITLE
Use Variable instead of Tensor in Function.forward

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1629,7 +1629,7 @@ class TestAutograd(TestCase):
                     ctx.x = Variable(x.data, requires_grad=True)
                     ctx.y = Variable(y_data, requires_grad=True)
                     ctx.output_var = ctx.x * ctx.y
-                return ctx.output_var[:]
+                return ctx.output_var.detach()
 
             @staticmethod
             def backward(ctx, grad_output):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -133,11 +133,8 @@ class TestAutograd(TestCase):
             @staticmethod
             @once_differentiable
             def backward(ctx, grad_output):
+                self.assertFalse(torch.is_grad_enabled())
                 t1, t2 = ctx.saved_tensors
-                # NOTE: self is the test case here
-                self.assertTrue(torch.is_tensor(t1))
-                self.assertTrue(torch.is_tensor(t2))
-                self.assertTrue(torch.is_tensor(grad_output))
                 return (grad_output + grad_output * t2, None,
                         grad_output * ctx.pyscalar + grad_output * t1)
 
@@ -517,14 +514,14 @@ class TestAutograd(TestCase):
             [0, 2, 2],
         ])
         v1 = torch.DoubleTensor([[1, 2], [4, 5], [7, 8]])
-        sparse_grad1 = torch.sparse.DoubleTensor(i1, v1, size)
+        sparse_grad1 = Variable(torch.sparse.DoubleTensor(i1, v1, size))
         i2 = torch.LongTensor([
             [0, 1, 3, 4],
             [0, 1, 2, 2],
         ])
         v2 = torch.DoubleTensor([[1, 2], [4, 3], [4, 5], [7, 8]])
-        sparse_grad2 = torch.sparse.DoubleTensor(i2, v2, size)
-        dense_grad = torch.rand(size).double()
+        sparse_grad2 = Variable(torch.sparse.DoubleTensor(i2, v2, size))
+        dense_grad = Variable(torch.rand(size).double())
         sparse_fn1 = FixedGradientFunction(sparse_grad1)
         sparse_fn2 = FixedGradientFunction(sparse_grad2)
         dense_fn = FixedGradientFunction(dense_grad)
@@ -532,15 +529,15 @@ class TestAutograd(TestCase):
         # sparse first
         x = Variable(torch.randn(5, 5), requires_grad=True)
         (sparse_fn1(x) + dense_fn(x) + sparse_fn2(x)).sum().backward()
-        self.assertEqual(x.grad.data, dense_grad + sparse_grad1 + sparse_grad2)
+        self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # dense first
         x = Variable(torch.randn(5, 5), requires_grad=True)
         (dense_fn(x) + sparse_fn1(x) + sparse_fn2(x)).sum().backward()
-        self.assertEqual(x.grad.data, dense_grad + sparse_grad1 + sparse_grad2)
+        self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # sparse only
         x = Variable(torch.randn(5, 5), requires_grad=True)
         (sparse_fn1(x) + sparse_fn2(x)).sum().backward()
-        self.assertEqual(x.grad.data, sparse_grad1 + sparse_grad2)
+        self.assertEqual(x.grad, sparse_grad1 + sparse_grad2)
 
     def test_multi_backward(self):
         x = Variable(torch.randn(5, 5), requires_grad=True)
@@ -1386,26 +1383,22 @@ class TestAutograd(TestCase):
             def backward(self, grad_a, grad_b):
                 return grad_a + grad_b, grad_b
 
-        class Inplace(InplaceFunction):
-
-            def forward(self, a, b):
-                self.mark_dirty(a)
-                return a.add_(b), b + 2
-
-            def backward(self, grad_a, grad_b):
-                return grad_a, grad_a + grad_b
-
+        hook_called = [False]
         x = Variable(torch.randn(5, 5), requires_grad=True)
         y = Variable(torch.randn(5, 5), requires_grad=True)
 
         q, p = Identity()(x, y)
+
         # Make sure hooks only receive grad from usage of q, not x.
-        q.register_hook(
-            lambda grad: self.assertEqual(grad.data, torch.ones(5, 5)))
+        def hook(grad):
+            hook_called[0] = True
+            self.assertEqual(grad.data, torch.ones(5, 5))
+
+        q.register_hook(hook)
         (q + p + x).sum().backward()
         self.assertEqual(x.grad.data, torch.ones(5, 5) * 3)
         self.assertEqual(y.grad.data, torch.ones(5, 5))
-        del q, p  # these need to be freed, or next part will raise an error
+        self.assertTrue(hook_called[0])
 
     def test_return_leaf_inplace(self):
         class Inplace(InplaceFunction):
@@ -1602,7 +1595,7 @@ class TestAutograd(TestCase):
         class F1(Function):
 
             def forward(self, input):
-                out = torch.randn(input.size())
+                out = Variable(torch.randn(input.size()))
                 self.mark_non_differentiable(out)
                 return input, out
 
@@ -1631,20 +1624,22 @@ class TestAutograd(TestCase):
 
         class Reenter(Function):
             @staticmethod
-            def forward(ctx, x_data):
-                ctx.x = Variable(x_data, requires_grad=True)
-                ctx.y = Variable(y_data, requires_grad=True)
-                ctx.output_var = ctx.x * ctx.y
-                return ctx.output_var.data
+            def forward(ctx, x):
+                with torch.enable_grad():
+                    ctx.x = Variable(x.data, requires_grad=True)
+                    ctx.y = Variable(y_data, requires_grad=True)
+                    ctx.output_var = ctx.x * ctx.y
+                return ctx.output_var[:]
 
             @staticmethod
             def backward(ctx, grad_output):
-                ctx.output_var.sum().backward()
+                with torch.enable_grad():
+                    ctx.output_var.sum().backward()
                 return ctx.x.grad * grad_output
 
         x = Variable(torch.randn(2, 2), requires_grad=True)
         out = Reenter.apply(x)
-        out.sum().backward(create_graph=True)
+        out.sum().backward()
         self.assertEqual(x.grad.data, y_data)
 
     def test_cat(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -560,7 +560,6 @@ class TestJit(TestCase):
         torch._C._tracer_exit((y,))
         self.assertExpectedTrace(trace)
 
-    @unittest.expectedFailure
     def test_inplace_flags(self):
         class InplaceFn(Function):
             @staticmethod
@@ -592,6 +591,7 @@ class TestJit(TestCase):
             return y
         y = fn(*inputs)
         torch._C._tracer_exit((y,))
+        torch._C._jit_pass_dce(trace)
         ops = [n for n in trace.graph().nodes()]
         for op in ops:
             self.assertTrue(op.hasAttribute('inplace'))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -560,6 +560,7 @@ class TestJit(TestCase):
         torch._C._tracer_exit((y,))
         self.assertExpectedTrace(trace)
 
+    @unittest.expectedFailure
     def test_inplace_flags(self):
         class InplaceFn(Function):
             @staticmethod

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -236,7 +236,7 @@ def _take_tensors(tensors, size_limit):
     """
     buf_dict = defaultdict(lambda: [[], 0])
     for tensor in tensors:
-        t = type(tensor)
+        t = tensor.type()
         if tensor.is_sparse:
             indices = tensor._indices()
             values = tensor._values()

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -38,7 +38,6 @@ class Resize(Function):
         ctx.input_sizes = tensor.size()
         if tensor.is_contiguous():
             result = tensor.new(tensor).contiguous().view(*sizes)
-            ctx.mark_shared_storage((tensor, result))
             return result
         else:
             return tensor.contiguous().view(*sizes)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -3,6 +3,7 @@ import torch._C as _C
 import torch.utils.hooks as hooks
 from torch._six import with_metaclass
 import functools
+import warnings
 from collections import OrderedDict
 
 
@@ -38,24 +39,9 @@ class _ContextMethodMixin(object):
         self.dirty_tensors = args
 
     def mark_shared_storage(self, *pairs):
-        """Marks that given pairs of distinct tensors are sharing storage.
-
-        **This should be called at most once, only from inside the**
-        :func:`forward` **method, and all arguments should be pairs of
-        (input, output).**
-
-        If some of the outputs are going to be tensors sharing storage with
-        some of the inputs, all pairs of (input_arg, output_arg) should be
-        given to this function, to ensure correctness checking of in-place
-        modification. The only exception is when an output is exactly the same
-        tensor as input (e.g. in-place ops). In such case it's easy to conclude
-        that they're sharing data, so we don't require specifying such
-        dependencies.
-
-        This function is not needed in most functions. It's primarily used in
-        indexing and transpose ops.
-        """
-        self.shared_pairs = pairs
+        warnings.warn(
+            'mark_shared_storage is deprecated. '
+            'Tensors with shared storages are automatically tracked')
 
     def mark_non_differentiable(self, *args):
         """Marks outputs as non-differentiable.
@@ -200,30 +186,43 @@ def once_differentiable(fn):
 
     @functools.wraps(fn)
     def wrapper(ctx, *args):
-        tensor_args = [arg.data if isinstance(arg, Variable) else arg
-                       for arg in args]
-        outputs = fn(ctx, *tensor_args)
-        # XXX: this is only an approximation of these flags - there's no way
+        with torch.no_grad():
+            outputs = fn(ctx, *args)
+
+        if not torch.is_grad_enabled():
+            return outputs
+
+        # If any of the inputs have requires_grad=True, we force the outputs
+        # to have requires_grad=True but point to a grad_fn which throws an
+        # error message during (double) back-propagation.
+        # XXX: this is only an approximation of requires_grad - there's no way
         # to figure out if fn didn't use ctx.saved_variables and as a result
         # some Variables might require grad, even if no args do.
         # Unfortunately, this leads to unexpected error messages ("no nodes
         # require computing gradients"), but I don't have a better idea.
         # These functions would raise an error in backward anyway.
-        requires_grad = any(arg.requires_grad if isinstance(arg, Variable) else False
+        requires_grad = any(isinstance(arg, Variable) and arg.requires_grad
                             for arg in args)
-        if not torch.is_grad_enabled():
-            def err_fn(*args):
-                return args
-        else:
-            err_fn = torch._C._functions.DelayedError(
-                b"trying to differentiate twice a function that was marked"
-                b"with @once_differentiable")
+        if not requires_grad:
+            return outputs
+
+        err_fn = torch._C._functions.DelayedError(
+            b"trying to differentiate twice a function that was marked"
+            b"with @once_differentiable")
+
         if not isinstance(outputs, tuple):
-            var = (Variable(outputs, requires_grad=requires_grad)
-                   if outputs is not None else None)
-            return err_fn(var)
-        return err_fn(*[Variable(o, requires_grad=requires_grad) if o is not None else None
-                      for o in outputs])
+            outputs = (outputs,)
+
+        # Create aliases of each output that has requires_grad=True. We need
+        # at least one of the inputs to err_fn to require grad so that the
+        # output will have a grad_fn.
+        def fake_requires_grad(var):
+            if var is not None:
+                var = var.detach()
+                var.requires_grad = True
+            return var
+
+        return err_fn(*[fake_requires_grad(v) for v in outputs])
     return wrapper
 
 
@@ -307,7 +306,9 @@ _iter_variables_permissive = _iter_filter(lambda o: isinstance(o, torch.autograd
 _iter_jit_values = _iter_filter(lambda o: o is None or isinstance(o, torch._C.Value),
                                 condition_msg="jit's Values or None")
 _iter_tensors = _iter_filter(torch.is_tensor, condition_msg="Tensors")
-_iter_None_tensors = _iter_filter(lambda o: o is None or torch.is_tensor(o), condition_msg="Tensors or None")
+_iter_None_tensors = _iter_filter(
+    lambda o: o is None or torch.is_tensor(o) or isinstance(o, torch.autograd.Variable),
+    condition_msg="Tensors or None")
 _map_variable_tensor = _nested_map(lambda o: isinstance(o, torch.autograd.Variable),
                                    lambda o: o.data, condition_msg="Variables")
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -41,7 +41,8 @@ class _ContextMethodMixin(object):
     def mark_shared_storage(self, *pairs):
         warnings.warn(
             'mark_shared_storage is deprecated. '
-            'Tensors with shared storages are automatically tracked')
+            'Tensors with shared storages are automatically tracked. Note '
+            'that calls to `set_()` are not tracked')
 
     def mark_non_differentiable(self, *args):
         """Marks outputs as non-differentiable.

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -67,12 +67,17 @@ def version():
     return __cudnn_version
 
 
+CUDNN_TENSOR_TYPES = {
+    'torch.cuda.HalfTensor',
+    'torch.cuda.FloatTensor',
+    'torch.cuda.DoubleTensor',
+}
+
+
 def is_acceptable(tensor):
     if not torch._C._get_cudnn_enabled():
         return False
-    if not (isinstance(tensor, torch.cuda.HalfTensor) or
-            isinstance(tensor, torch.cuda.FloatTensor) or
-            isinstance(tensor, torch.cuda.DoubleTensor)):
+    if tensor.type() not in CUDNN_TENSOR_TYPES:
         return False
     if not torch._C.has_cudnn:
         warnings.warn(

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -8,13 +8,14 @@
 #include <ATen/ATen.h>
 
 #include "THP.h"
+#include "torch/csrc/autograd/grad_mode.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
 #include "torch/csrc/autograd/functions/basic_ops.h"
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
-#include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/autograd/saved_variable.h"
+#include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
@@ -58,15 +59,7 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   if (!pyInputs) throw python_error();
 
   for (size_t i = 0; i != inputs.size(); ++i) {
-    PyObject* input;
-    if (inputs[i].defined()) {
-      input = createPyObject(inputs[i].data());
-      if (!input) throw python_error();
-    } else {
-      input = Py_None;
-      Py_INCREF(input);
-    }
-    PyTuple_SET_ITEM(pyInputs.get(), i, input);
+    PyTuple_SET_ITEM(pyInputs.get(), i, THPVariable_Wrap(inputs[i]));
   }
 
   THPObjectPtr r(PyObject_CallMethod(
@@ -78,13 +71,13 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   for (int i = 0; i != num_outputs; ++i) {
     PyObject* obj = PyTuple_GET_ITEM(r.get(), i);
     if (obj != Py_None) {
-      if (!THPModule_isTensor(obj)) {
-        std::string msg("expected Tensor (got '");
+      if (!THPVariable_Check(obj)) {
+        std::string msg("expected Variable (got '");
         msg += THPUtils_typename(obj);
         msg += "')'";
         throw std::runtime_error(msg);
       }
-      tensor_results[i] = createTensor(obj);
+      tensor_results[i] = ((THPVariable*)obj)->cdata.data();
     }
   }
 
@@ -248,7 +241,6 @@ static int THPFunction_traverse(THPFunction *self, visitproc visit, void *arg)
     }
   }
   Py_VISIT(self->to_save);
-  Py_VISIT(self->shared_pairs);
   Py_VISIT(self->non_differentiable);
   Py_VISIT(self->dirty_tensors);
   return 0;
@@ -261,7 +253,6 @@ static int THPFunction_clear(THPFunction *self)
   Py_CLEAR(self->needs_input_grad);
 
   Py_CLEAR(self->to_save);
-  Py_CLEAR(self->shared_pairs);
   Py_CLEAR(self->non_differentiable);
   Py_CLEAR(self->dirty_tensors);
 
@@ -314,38 +305,31 @@ using t2var_type = std::unordered_map<PyObject *, THPVariable *>;
 
 // Bump the counters of all recorded dirty input tensors, adding each of them
 // into dirty_inputs.  Also does some sanity checking.
-static void _mark_dirty(THPFunction *self, t2var_type &t2var,
-        std::unordered_set<PyObject *> &dirty_inputs)
+static std::unordered_set<PyObject*> _parse_dirty_inputs(THPFunction *self)
 {
   // Increase versions of modified tensors
-  if (!self->dirty_tensors) return;
+  std::unordered_set<PyObject*> dirty_inputs;
+  if (!self->dirty_tensors) return dirty_inputs;
 
   THPFunction_assert(PyTuple_Check(self->dirty_tensors), "autograd "
       "internal error: dirty_tensors attribute is expected to be a tuple "
       "but is %s", THPUtils_typename(self->dirty_tensors));
   Py_ssize_t num_dirty = PyTuple_GET_SIZE(self->dirty_tensors);
   for (int i = 0; i < num_dirty; i++) {
-    PyObject *tensor = PyTuple_GET_ITEM(self->dirty_tensors, i);
-    dirty_inputs.insert(tensor);
-    THPVariable *variable;
-    try {
-      variable = t2var.at(tensor);
-    } catch (std::out_of_range &e) {
-      THPFunction_assert(THPModule_isTensor(tensor), "mark_dirty can "
-          "only accept tensors, but argument %d is of type %s", i,
-          THPUtils_typename(tensor));
-      THPFunction_assert(false, "mark_dirty only accepts input tensors, but "
-          "argument %d isn't one", i);
-    }
-    auto& version_counter = variable->cdata.version_counter();
-    version_counter.increment();
+    PyObject *obj = PyTuple_GET_ITEM(self->dirty_tensors, i);
+    THPFunction_assert(THPVariable_Check(obj), "mark_dirty can "
+        "only accept variables, but argument %d is of type %s", i,
+        THPUtils_typename(obj));
+
+    dirty_inputs.insert(obj);
+    auto variable = (THPVariable*)obj;
+    variable->cdata.version_counter().increment();
   }
   // We're not going to ever need this so let's remove references now
-  Py_DECREF(self->dirty_tensors);
-  self->dirty_tensors = NULL;
+  Py_CLEAR(self->dirty_tensors);
+  return dirty_inputs;
 }
 
-static t2var_type _parse_shared_pairs(THPFunction *self, t2var_type &t2var);
 static std::unordered_set<PyObject*> _parse_non_differentiable(THPFunction *self);
 
 // Given a Python tuple of raw output tensors (raw_output), set each of
@@ -359,9 +343,8 @@ static std::unordered_set<PyObject*> _parse_non_differentiable(THPFunction *self
 // the set of dirty tensors (dirty_inputs) is used to figure out what to
 // do in this case.  After this method is run, t2var is extended with
 // mappings for output tensors as well.
-static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
-    std::unordered_set<PyObject *> &dirty_inputs,
-    PyObject *raw_output, PyObject *outputs, bool is_executable)
+static void _wrap_outputs(THPFunction *self,
+    PyObject* inputs_tuple, PyObject *raw_output, PyObject *outputs, bool is_executable)
 {
   auto cdata = is_executable ? THPFunction_asFunction(self) : nullptr;
   Py_ssize_t num_outputs = PyTuple_GET_SIZE(raw_output);
@@ -370,100 +353,82 @@ static void _wrap_outputs(THPFunction *self, t2var_type &t2var,
     self->output_info.reserve(num_outputs);
   }
 
-  auto shared_pairs = _parse_shared_pairs(self, t2var);
-  auto non_differentiable = _parse_non_differentiable(self);
+  std::unordered_set<PyObject*> inputs;
+  int num_inputs = PyTuple_GET_SIZE(inputs_tuple);
+  for (int i = 0; i < num_inputs; i++) {
+    inputs.emplace(PyTuple_GET_ITEM(inputs_tuple, i));
+  }
 
-  // Given an output tensor, find the input Variable with which it shares storage
-  auto get_shared_base = [&](PyObject* tensor) -> Variable {
-    auto input_it = t2var.find(tensor);
-    if (input_it != t2var.end()) {
-      // If the output is an input treat that as the base
-      return input_it->second->cdata;
+  auto non_differentiable = _parse_non_differentiable(self);
+  auto dirty_inputs = _parse_dirty_inputs(self);
+
+  auto as_variable = [&](PyObject* obj, int i) -> Variable {
+    if (THPVariable_Check(obj)) {
+      return ((THPVariable*)obj)->cdata;
     }
-    auto it = shared_pairs.find(tensor);
-    if (it != shared_pairs.end()) {
-      // It's explicitly marked as shared via mark_shared_storage
-      return it->second->cdata;
+    if (THPModule_isTensor(obj)) {
+      // temporarily wrap tensors as variables until the classes are merged
+      return make_variable(createTensor(obj));
     }
-    return Variable();
+    throw TypeError("%s.forward: expected Variable (got %s) for return value %d",
+        Py_TYPE(self)->tp_name, Py_TYPE(obj)->tp_name, i);
   };
 
   // Wraps an output Tensor in a Variable or returns the previous wrapper in
   // the case of in-place modification.
-  auto wrap_output = [&](at::Tensor data, Variable prev, int output_nr, bool is_modified, bool is_non_differentiable) -> Variable {
+  auto set_history = [&](Variable& var, int output_nr, bool is_input, bool is_modified,
+                         bool is_non_differentiable) {
     if (is_non_differentiable) {
-      return make_variable(std::move(data));
-    }
-    if (!prev.defined()) {
-      return make_variable(std::move(data), output_nr, cdata);
-    }
-    if (is_modified) {
-      if (prev.is_leaf() && prev.requires_grad()) {
+      var.detach_();
+    } else if (is_modified) {
+      if (var.is_leaf() && var.requires_grad()) {
         throw std::runtime_error("a leaf Variable that requires grad has been used in an in-place operation.");
       }
       // If the input was modified, transplant the grad_fn in the graph:
       // grad_fn <- variable <- self  ==>  grad_fn <- self <- variable
-      prev.get()->grad.reset();
-      prev.get()->hooks.clear();
-      if (auto grad_acc_fn = prev.get()->grad_accumulator.lock()) {
+      var.get()->grad.reset();
+      var.get()->hooks.clear();
+      if (auto grad_acc_fn = var.get()->grad_accumulator.lock()) {
         auto grad_acc = dynamic_cast<AccumulateGrad*>(grad_acc_fn.get());
         grad_acc->variable.reset();
       }
       if (cdata) {
-        prev.rebase_history(output_nr, cdata);
+        var.rebase_history(output_nr, cdata);
       }
-      return prev;
+    } else if (is_input) {
+      // An input has been returned, but it wasn't modified. Return it as a view
+      // so that we can attach a new grad_fn to the Variable.
+      // return make_variable_view(std::move(prev), std::move(data), output_nr, cdata);
+      var = var.slice();
+      var.get()->output_nr = output_nr;
+      var.get()->_grad_fn = cdata;
+    } else if (cdata) {
+      var.get()->output_nr = output_nr;
+      var.get()->_grad_fn = cdata;
     }
-    // An input has been returned, but it wasn't modified. Return it as a view
-    // so that we can attach a new grad_fn to the Variable.
-    return make_variable_view(std::move(prev), std::move(data), output_nr, cdata);
   };
 
-  t2var_type output2var;
+  std::unordered_set<PyObject*> seen;
   for (int i = 0; i < num_outputs; i++) {
-    PyObject *output = PyTuple_GET_ITEM(raw_output, i);
+    PyObject* obj = PyTuple_GET_ITEM(raw_output, i);
 
-    THPVariable* output_var;
-    auto it = output2var.find(output);
-    if (it != output2var.end()) {
-      output_var = it->second;
-      Py_INCREF(output_var);
-    } else {
-      // Wrap the output in a Variable
-      bool is_modified = dirty_inputs.count(output) > 0;
-      bool is_non_differentiable = non_differentiable.count(output) > 0;
-      Variable var = wrap_output(
-          torch::createTensor(output),
-          get_shared_base(output),
-          i,
-          is_modified,
-          is_non_differentiable);
+    bool is_input = inputs.count(obj) > 0;
+    bool is_modified = dirty_inputs.count(obj) > 0;
+    bool is_non_differentiable = non_differentiable.count(obj) > 0;
 
-      output_var = (THPVariable*)THPVariable_Wrap(var);
-      if (!output_var) throw python_error();
-
-      // We already have the data tensor wrapped as a PyObject*
-      Py_INCREF(output);
-      Py_CLEAR(output_var->data);
-      output_var->data = output;
-
-      output2var[output] = output_var;
-    }
+    auto var = as_variable(obj, i);
+    set_history(var, i, is_input, is_modified, is_non_differentiable);
 
     if (is_executable) {
-      self->output_info.emplace_back(output_var->cdata);
+      self->output_info.emplace_back(var);
     }
-    PyTuple_SET_ITEM(outputs, i, (PyObject*)output_var);
-  }
 
-  // Add every entry in output2var to t2var
-  for (auto& entry : output2var) {
-    t2var[entry.first] = entry.second;
+    PyTuple_SET_ITEM(outputs, i, THPVariable_Wrap(var));
   }
 }
 
 // Save any variables that requested by to_save
-static void _save_variables(THPFunction* self, t2var_type &t2var)
+static void _save_variables(THPFunction* self)
 {
   if (!self->to_save) return;
 
@@ -475,71 +440,26 @@ static void _save_variables(THPFunction* self, t2var_type &t2var)
   self->saved_variables.reserve(num_saved);
   auto cdata_ptr = &self->cdata;
   for (int i = 0; i < num_saved; i++) {
-    PyObject *tensor = PyTuple_GET_ITEM(self->to_save, i);
-    if (tensor == Py_None) {
+    PyObject *obj = PyTuple_GET_ITEM(self->to_save, i);
+    if (obj == Py_None) {
       self->saved_variables.emplace_back();
       continue;
+    } else if (THPVariable_Check(obj)) {
+      auto variable = (THPVariable*)obj;
+      bool is_output = variable->cdata.grad_fn().get() == cdata_ptr;
+      self->saved_variables.emplace_back(variable->cdata, is_output);
+    } else if (THPModule_isTensor(obj)) {
+      // TODO: remove once Variable and Tensor classes are merged
+      auto var = make_variable(createTensor(obj), false);
+      self->saved_variables.emplace_back(std::move(var), false);
+    } else {
+      throw TypeError(
+          "save_for_backward can only save variables, but argument %d is of "
+          "type %s", i, Py_TYPE(obj)->tp_name);
     }
-
-    THPVariable *variable;
-    try {
-      variable = t2var.at(tensor);
-    } catch(std::out_of_range &e) {
-      THPFunction_assert(THPModule_isTensor(tensor),
-          "save_for_backward can only save tensors, but argument %d is of "
-          "type %s", i, THPUtils_typename(tensor));
-      THPFunction_assert(false, "save_for_backward can only save input or output "
-          "tensors, but argument %d doesn't satisfy this condition", i);
-    }
-
-    bool is_output = variable->cdata.grad_fn().get() == cdata_ptr;
-    self->saved_variables.emplace_back(variable->cdata, is_output);
   }
   // Free .to_save
-  Py_DECREF(self->to_save);
-  self->to_save = NULL;
-}
-
-// t2var maps input and output tensors to variables
-static t2var_type _parse_shared_pairs(THPFunction *self, t2var_type &t2var)
-{
-  t2var_type map;
-  if (!self->shared_pairs) return map;
-  THPFunction_assert(PyTuple_Check(self->shared_pairs), "autograd internal "
-      "error: shared_pairs attribute is expected to be a tuple but is %s",
-      THPUtils_typename(self->shared_pairs));
-  Py_ssize_t num_shared = PyTuple_GET_SIZE(self->shared_pairs);
-  for (int i = 0; i < num_shared; i++) {
-    PyObject *shared_tuple = PyTuple_GET_ITEM(self->shared_pairs, i);
-    THPFunction_assert(PyTuple_Check(shared_tuple), "mark_shared_storages "
-        "accepts a number of pairs, but one of the arguments is of type %s",
-        THPUtils_typename(shared_tuple));
-    THPFunction_assert(PyTuple_GET_SIZE(shared_tuple) == 2,
-        "mark_shared_storages accepts pairs, but argument %d is a tuple of "
-        "%d elements", i, PyTuple_GET_SIZE(shared_tuple));
-
-    // Now we're sure it's really a pair!
-    // NB: According to the documentation, v1 is an input tensor, and v2
-    // is an output tensor, but we don't actually check this
-    PyObject* t1 = PyTuple_GET_ITEM(shared_tuple, 0);
-    PyObject* t2 = PyTuple_GET_ITEM(shared_tuple, 1);
-    THPFunction_assert(THPModule_isTensor(t1) && THPModule_isTensor(t2),
-      "mark_shared_storages accepts pairs of tensors, but one of them "
-      "contains %s and %s", THPUtils_typename(t1), THPUtils_typename(t2));
-
-    auto it = t2var.find(t1);
-    THPFunction_assert(it != t2var.end(),
-        "mark_shared_storages only accepts pairs of input "
-        "and output tensors, but argument %d doesn't satify this "
-        "condition", i);
-
-    bool inserted;
-    std::tie(std::ignore, inserted) = map.emplace(t2, it->second);
-    THPFunction_assert(inserted,
-        "mark_shared_storages got a duplicate pair for an output tensor at "
-        "argument %d", i);
-  }
-  return map;
+  Py_CLEAR(self->to_save);
 }
 
 // Mark requires_grad = 0 on non-differentiable variables (as per non_differentiable)
@@ -556,8 +476,8 @@ _parse_non_differentiable(THPFunction *self)
   set.reserve(num_nondiff);
   for (int i = 0; i < num_nondiff; i++) {
     PyObject *t = PyTuple_GET_ITEM(self->non_differentiable, i);
-    THPFunction_assert(THPModule_isTensor(t), "mark_non_differentiable "
-        "only accepts tensor arguments, but got %s", THPUtils_typename(t));
+    THPFunction_assert(THPVariable_Check(t), "mark_non_differentiable "
+        "only accepts variable arguments, but got %s", THPUtils_typename(t));
     set.insert(t);
   }
   Py_CLEAR(self->non_differentiable);
@@ -565,7 +485,7 @@ _parse_non_differentiable(THPFunction *self)
 }
 
 struct UnpackedInput {
-  THPObjectPtr tensor_input;
+  THPObjectPtr input_tuple;
   variable_list input_vars;
 };
 
@@ -582,33 +502,31 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
   InputFlags flags;
 
   auto num_args = PyTuple_GET_SIZE(args);
-  unpacked.tensor_input = PyTuple_New(num_args);
+  unpacked.input_tuple = PyTuple_New(num_args);
   flags.needs_input_grad = PyTuple_New(num_args);
   for (int i = 0; i < num_args; i++) {
     PyObject *arg = PyTuple_GET_ITEM(args, i);
-    PyObject *new_arg;
 
     bool is_variable = THPVariable_Check(arg);
     flags.is_variable_input.push_back(is_variable);
     if (!is_variable) {
+      // TODO: remove this code path once Variable and Tensor are merged in Python
       if (enforce_variables) {
         THPUtils_setError("expected a Variable argument, but got %s",
                           THPUtils_typename(arg));
         throw python_error();
       }
-      Py_INCREF(arg);
-      new_arg = arg;
       Py_INCREF(Py_False);
       PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, Py_False);
     } else {
       THPVariable* variable = (THPVariable*)arg;
-      new_arg = THPVariable_get_data(variable);
       unpacked.input_vars.push_back(variable->cdata);
       PyObject* needs_grad = variable->cdata.requires_grad() ? Py_True : Py_False;
       Py_INCREF(needs_grad);
       PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, needs_grad);
     }
-    PyTuple_SET_ITEM(unpacked.tensor_input.get(), i, new_arg);
+    Py_INCREF(arg);
+    PyTuple_SET_ITEM(unpacked.input_tuple.get(), i, arg);
   }
 
   flags.is_executable = any_variable_requires_grad(unpacked.input_vars);
@@ -737,19 +655,8 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
     }
   }
 
-  // Initialize t2var map with input tensors
-  t2var_type t2var;
-  for (auto& c_var : unpacked.input_vars) {
-    THPVariable* py_var = (THPVariable*)c_var.get()->pyobj;
-    t2var.emplace(py_var->data, py_var);
-  }
-
-  std::unordered_set<PyObject *> dirty_inputs;
   bool is_inplace = static_cast<bool>(grad_fn->dirty_tensors);
-  _mark_dirty(grad_fn, t2var, dirty_inputs);
-  _wrap_outputs(grad_fn, t2var, dirty_inputs, raw_output, outputs, is_executable);
-  // Free shared_pairs
-  Py_CLEAR(grad_fn->shared_pairs);
+  _wrap_outputs(grad_fn, inputs, raw_output, outputs, is_executable);
   // NOTE: _trace_create has to run before _save_variables, because we need
   // to assign traces to outputs before we convert them to SavedVariables.
   // On the other hand, it needs to go after _mark_non_differentiable, because
@@ -757,7 +664,7 @@ PyObject* process_outputs(PyObject *op_obj, THPFunction* grad_fn, const Unpacked
   // grad_fn pointer equality for error checking.
   _trace_create(op_obj, grad_fn, inputs, outputs, unpacked.input_vars, is_inplace);
   if (is_executable) {
-    _save_variables(grad_fn, t2var);
+    _save_variables(grad_fn);
   } else {
     // Remove unnecessary attributes
     Py_XDECREF(grad_fn->to_save);
@@ -790,9 +697,10 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   self->needs_input_grad = input_info.needs_input_grad.release();
 
   // Now we're ready to call a forward (implemented in Python)
+  AutoGradMode grad_mode(false);
   THPObjectPtr forward_fn(PyObject_GetAttrString((PyObject*)self, "forward"));
   if (!forward_fn) return NULL;
-  THPObjectPtr raw_output(PyObject_CallObject(forward_fn, unpacked_input.tensor_input));
+  THPObjectPtr raw_output(PyObject_CallObject(forward_fn, unpacked_input.input_tuple));
   if (!raw_output) return NULL;
 
   return process_outputs(nullptr, self, unpacked_input, _inputs, std::move(raw_output),
@@ -822,20 +730,21 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   ctx->needs_input_grad = input_info.needs_input_grad.release();
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 
-  // Prepend ctx to tensor_input, in preparation for static method call
+  // Prepend ctx to input_tuple, in preparation for static method call
   auto num_args = PyTuple_GET_SIZE(inputs);
-  THPObjectPtr ctx_tensor_input(PyTuple_New(num_args + 1));
-  PyTuple_SET_ITEM(ctx_tensor_input.get(), 0, ctx_obj.release());
+  THPObjectPtr ctx_input_tuple(PyTuple_New(num_args + 1));
+  PyTuple_SET_ITEM(ctx_input_tuple.get(), 0, ctx_obj.release());
   for (int i = 0; i < num_args; ++i) {
-    PyObject *arg = PyTuple_GET_ITEM(unpacked_input.tensor_input.get(), i);
+    PyObject *arg = PyTuple_GET_ITEM(unpacked_input.input_tuple.get(), i);
     Py_INCREF(arg);
-    PyTuple_SET_ITEM(ctx_tensor_input.get(), i + 1, arg);
+    PyTuple_SET_ITEM(ctx_input_tuple.get(), i + 1, arg);
   }
 
   // Call forward
+  AutoGradMode grad_mode(false);
   THPObjectPtr forward_fn(PyObject_GetAttrString(cls, "forward"));
   if (!forward_fn) return NULL;
-  THPObjectPtr tensor_outputs(PyObject_CallObject(forward_fn, ctx_tensor_input));
+  THPObjectPtr tensor_outputs(PyObject_CallObject(forward_fn, ctx_input_tuple));
   if (!tensor_outputs) return NULL;
 
   return process_outputs(cls, ctx, unpacked_input, inputs, std::move(tensor_outputs),
@@ -870,7 +779,7 @@ static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_g
   for (int i = 0; i < num_grads; i++) {
     PyObject *grad = PyTuple_GET_ITEM(raw_grads.get(), i);
     if (grad == Py_None) {
-      grad = createPyObject(grads_info[i].zeros(gpu_guard).data());
+      grad = THPVariable_Wrap(grads_info[i].zeros(gpu_guard));
       if (!grad) throw python_error();
     } else {
       Py_INCREF(grad);
@@ -1000,7 +909,7 @@ PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 {
   HANDLE_TH_ERRORS
   return unpack_saved_variables(self, [](const Variable& var) {
-    return createPyObject(var.data());
+    return THPVariable_Wrap(var);
   });
   END_HANDLE_TH_ERRORS
 }
@@ -1085,7 +994,6 @@ static struct PyGetSetDef THPFunction_properties[] = {
   {"saved_variables", (getter)THPFunction_saved_variables, NULL, NULL, NULL},
   {"next_functions", (getter)THPFunction_next_functions, NULL, NULL, NULL},
   {"to_save", &getObject<&THPFunction::to_save>, &setObject<&THPFunction::to_save>, NULL, NULL},
-  {"shared_pairs", &getObject<&THPFunction::shared_pairs>, &setObject<&THPFunction::shared_pairs>, NULL, NULL},
   {"non_differentiable", &getObject<&THPFunction::non_differentiable>, &setObject<&THPFunction::non_differentiable>, NULL, NULL},
   {"dirty_tensors", &getObject<&THPFunction::dirty_tensors>, &setObject<&THPFunction::dirty_tensors>, NULL, NULL},
   {"needs_input_grad", &getObject<&THPFunction::needs_input_grad>, NULL, NULL, NULL},

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -69,10 +69,6 @@ struct THPFunction {
     // by Python with 'save_for_backward'.  If NULL, no tensors were
     // saved.
     PyObject *to_save;
-    // Python pairs of distinct tensors which share storage.  Set by
-    // Python with 'mark_shared_storage'.  If NULL, no tensors share
-    // storage.
-    PyObject *shared_pairs;
     // Python tuple of tensors which are not differentiable.  Set by
     // Python with 'mark_non_differentiable'.  If NULL, no tensors were
     // non-differentiable.

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -114,6 +114,9 @@ static Variable valueToTensor(const Type & type, PyObject* value) {
   if (PyFloat_Check(value)) {
     return type.scalarTensor(Scalar(THPUtils_unpackDouble(value)));
   }
+  if (THPModule_isTensor(value)) {
+    return make_variable(createTensor(value));
+  }
   throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
 }
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -131,50 +131,14 @@ void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_li
 // We must record the nodes of inputs before we actually carry out
 // the operation, because an inplace operation may destroy the information
 // we're interested in.  See #4480.
-PreTraceInfo preRecordTrace(std::string op, // TODO: make this a Symbol
-                            at::ArrayRef<Variable> inputs) {
+template<typename F>
+PreTraceInfo makePreTraceInfo(at::ArrayRef<Variable> inputs, F ctor) {
   PreTraceInfo info;
   info.state = getTracingState(inputs);
   auto& graph = info.state->graph;
   auto state_lock = info.state->lock();
 
-  Node *n = graph->create(Symbol(op), 0 /* initial outputs */);
-  auto sl = std::make_shared<SourceLocation>(getPythonInterpreterStackTrace());
-  n->setSourceLocation(sl);
-
-  for (Variable input : inputs) {
-    n->addInput(getValueTrace(info.state, input));
-  }
-
-  // NB: Order matters. This must append after inputs but before outputs.
-  graph->appendNode(n);
-
-  info.n = n;
-
-  return info;  // RVO
-}
-
-PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
-                                  std::string arg_types,
-                                  at::ArrayRef<Variable> inputs,
-                                  pyobj_list scalar_args) {
-  PreTraceInfo info;
-  info.state = getTracingState(inputs);
-  auto& graph = info.state->graph;
-  auto state_lock = info.state->lock();
-
-  std::vector<VariableFlags> var_flags(inputs.size());
-  for (size_t i = 0; i < inputs.size(); i++) {
-    var_flags[i] = VariableFlags::of(inputs[i]);
-  }
-
-  const bool is_legacy = false;
-  Node *n = graph->createPythonOp(
-      std::move(pyobj),
-      arg_types,
-      is_legacy,
-      std::move(var_flags),
-      std::move(scalar_args));
+  Node *n = ctor(*graph);
   auto sl = std::make_shared<SourceLocation>(getPythonInterpreterStackTrace());
   n->setSourceLocation(sl);
 
@@ -188,6 +152,33 @@ PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
   info.n = n;
 
   return info;
+}
+
+PreTraceInfo preRecordTrace(std::string op, // TODO: make this a Symbol
+                            at::ArrayRef<Variable> inputs) {
+  return makePreTraceInfo(inputs, [&op](Graph& graph) {
+    return graph.create(Symbol(op), 0 /* initial outputs */);
+  });
+}
+
+PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
+                                  std::string arg_types,
+                                  at::ArrayRef<Variable> inputs,
+                                  pyobj_list scalar_args) {
+  std::vector<VariableFlags> var_flags(inputs.size());
+  for (size_t i = 0; i < inputs.size(); i++) {
+    var_flags[i] = VariableFlags::of(inputs[i]);
+  }
+
+  return makePreTraceInfo(inputs, [&](Graph& graph) {
+    const bool is_legacy = false;
+    return graph.createPythonOp(
+        std::move(pyobj),
+        arg_types,
+        is_legacy,
+        std::move(var_flags),
+        std::move(scalar_args));
+  });
 }
 
 void postRecordTrace(const PreTraceInfo& info,

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -279,6 +279,9 @@ struct PreTraceInfo {
 };
 
 PreTraceInfo preRecordTrace(std::string op, at::ArrayRef<Variable> inputs);
+PreTraceInfo preRecordPythonTrace(
+    THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<Variable> inputs,
+    pyobj_list scalar_args);
 void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
 
 }}} // namespace torch::jit::tracer

--- a/torch/cuda/comm.py
+++ b/torch/cuda/comm.py
@@ -190,6 +190,7 @@ def gather(tensors, dim=0, destination=None):
     if destination is None:
         destination = torch.cuda.current_device()
     if destination == -1:
+        # TODO (sgross): clean-up once Variable and Tensor are merged
         if isinstance(tensors[0], torch.autograd.Variable):
             data = getattr(torch, type(tensors[0].data).__name__)(expected_size)
             result = torch.autograd.Variable(data)

--- a/torch/cuda/comm.py
+++ b/torch/cuda/comm.py
@@ -59,7 +59,6 @@ def reduce_add(inputs, destination=None):
     if destination is None:
         destination = torch.cuda.current_device()
     input_size = inputs[0].size()
-    is_sparse = inputs[0].is_sparse
     nccl_root = None
     for i, inp in enumerate(inputs):
         assert inp.is_cuda, "reduce_add expects all inputs to be on GPUs"
@@ -70,9 +69,9 @@ def reduce_add(inputs, destination=None):
             expected = 'x'.join(str(x) for x in input_size)
             raise ValueError("input {} has invalid size: got {}, but expected "
                              "{}".format(i, got, expected))
-    assert nccl_root is not None, "reduce_add expects destination to be on the same GPU with one of the tensors"
-    with torch.cuda.device(destination):
-        result = type(inp)().resize_as_(inp).zero_()
+    if nccl_root is None:
+        raise RuntimeError("reduce_add expects destination to be on the same GPU with one of the tensors")
+    result = inp.new(device=destination).resize_as_(inp).zero_()
 
     if nccl.is_available(inputs) and inputs[0].get_device() == destination:
         outputs = [result] + [t.new(t.size()) for t in inputs[1:]]
@@ -191,10 +190,13 @@ def gather(tensors, dim=0, destination=None):
     if destination is None:
         destination = torch.cuda.current_device()
     if destination == -1:
-        result = getattr(torch, type(tensors[0]).__name__)(expected_size)
+        if isinstance(tensors[0], torch.autograd.Variable):
+            data = getattr(torch, type(tensors[0].data).__name__)(expected_size)
+            result = torch.autograd.Variable(data)
+        else:
+            result = getattr(torch, type(tensors[0]).__name__)(expected_size)
     else:
-        with torch.cuda.device(destination):
-            result = type(tensors[0])(expected_size)
+        result = tensors[0].new(expected_size, device=destination)
 
     chunk_start = 0
     # TODO: if copying to CPU, allocate a pinned buffer, do async copies to it,

--- a/torch/nn/_functions/dropout.py
+++ b/torch/nn/_functions/dropout.py
@@ -47,7 +47,7 @@ class Dropout(InplaceFunction):
     @staticmethod
     def backward(ctx, grad_output):
         if ctx.p > 0 and ctx.train:
-            return grad_output.mul(Variable(ctx.noise)), None, None, None
+            return grad_output * ctx.noise, None, None, None
         else:
             return grad_output, None, None, None
 

--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -47,7 +47,7 @@ class CosineEmbeddingLoss(Function):
             output = output / y.size(0)
 
         ctx.save_for_backward(input1, input2, y)
-        return input1.new((output,))
+        return output
 
     @staticmethod
     @once_differentiable
@@ -108,7 +108,7 @@ class MarginRankingLoss(Function):
             output = output / y.size(0)
 
         ctx.save_for_backward(input1, input2, y)
-        return input1.new((output,))
+        return output
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/torch/nn/_functions/thnn/fold.py
+++ b/torch/nn/_functions/thnn/fold.py
@@ -15,7 +15,7 @@ class Col2Im(Function):
         ctx.padding = padding
         ctx.stride = stride
 
-        ctx._backend = type2backend[type(input)]
+        ctx._backend = type2backend[input.type()]
 
         output = input.new()
 
@@ -57,7 +57,7 @@ class Im2Col(Function):
         ctx.stride = stride
         ctx.input_size = (input.size(2), input.size(3))
 
-        ctx._backend = type2backend[type(input)]
+        ctx._backend = type2backend[input.type()]
 
         output = input.new()
 

--- a/torch/nn/parallel/_functions.py
+++ b/torch/nn/parallel/_functions.py
@@ -1,6 +1,12 @@
 import torch
 import torch.cuda.comm as comm
-from torch.autograd import Function
+from torch.autograd import Function, Variable
+
+
+def wrap_output(x):
+    if torch.is_tensor(x):
+        return Variable(x)
+    return [wrap_output(o) for o in x]
 
 
 class Broadcast(Function):
@@ -15,6 +21,8 @@ class Broadcast(Function):
         ctx.num_inputs = len(inputs)
         ctx.input_device = inputs[0].get_device()
         outputs = comm.broadcast_coalesced(inputs, ctx.target_gpus)
+        # TODO (sgross): remove once Variable and Tensor are merged
+        outputs = wrap_output(outputs)
         non_differentiables = []
         for idx, input_requires_grad in enumerate(ctx.needs_input_grad[1:]):
             if not input_requires_grad:


### PR DESCRIPTION
The Tensor and Variable classes are being merged.
autograd.Function.forward is now called on Variables, but with "no-grad"
mode (torch.no_grad()) enabled.

One benefit is that we no longer have to explicitly track shared
storages.
