### PR TITLE
Restore cuda variable.bernoulli()

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3981,8 +3981,6 @@
   types:
     - Float
     - Double
-  backends:
-    - CPU
   return: argument 0
   variants:
     - method

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -417,6 +417,15 @@ THC_API void THCTensor_(bernoulli)(THCState* state, THCTensor *self_, double p)
   THCTensor_(freeCopyTo)(state, self, self_);
 };
 
+void THCTensor_(bernoulli_Tensor)(THCState *state, THCTensor *self, THCTensor* p)
+{
+#if defined(THC_REAL_IS_FLOAT)
+  THCTensor_(bernoulli_FloatTensor)(state, self, p);
+#elif defined(THC_REAL_IS_DOUBLE)
+  THCTensor_(bernoulli_DoubleTensor)(state, self, p);
+#endif
+}
+
 #define DEFINE_BERNOULLI_TENSOR(NAME, PROB_TYPE, PROB_DATA_TYPE)               \
 THC_API void THCTensor_(NAME)(THCState* state,                                 \
         THCTensor *self_, PROB_TYPE *probs_)                                   \

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -26,6 +26,7 @@ THC_API void THCTensor_(cappedRandom)(struct THCState *state, THCTensor *self, i
 THC_API void THCTensor_(bernoulli)(struct THCState *state, THCTensor *self, double p);
 THC_API void THCTensor_(bernoulli_FloatTensor)(struct THCState *state, THCTensor *self, THCudaTensor *p);
 THC_API void THCTensor_(bernoulli_DoubleTensor)(struct THCState *state, THCTensor *self, THCudaDoubleTensor *p);
+THC_API void THCTensor_(bernoulli_Tensor)(THCState *state, THCTensor *self, THCTensor* p);
 THC_API void THCTensor_(geometric)(struct THCState *state, THCTensor *self, double p);
 
 #endif

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -928,6 +928,13 @@ class TestCuda(TestCase):
         z = torch.cat([x, y])
         self.assertEqual(z.size(), (21, SIZE, SIZE))
 
+    def test_bernoulli_variable(self):
+        # TODO: delete when tensor/variable are merged
+        from torch.autograd import Variable
+        x = torch.cuda.FloatTensor([0, 1]).cuda()
+        x_var = Variable(x)
+        self.assertEqual(x_var.bernoulli().data, x.bernoulli())
+
     def test_cat_bad_input_sizes(self):
         x = torch.randn(2, 1).cuda()
         y = torch.randn(2, 1, 1).cuda()


### PR DESCRIPTION
Fixes #4715 

Variable bernoulli() was previously set to only CPU in Declarations.cwrap. This PR enables the cuda backend for that.

### Test Plan
new unit test