### PR TITLE
Initialize cuda before setting cuda tensor types as default

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -129,6 +129,11 @@ def set_default_tensor_type(t):
     global Storage
     Tensor = _import_dotted_name(t)
     Storage = _import_dotted_name(t.replace('Tensor', 'Storage'))
+
+    if 'cuda' in t:
+        import torch.cuda
+        torch.cuda.init()
+
     _C._set_default_tensor_type(Tensor)
 
 


### PR DESCRIPTION
Fixes #4784.

If CUDA hasn't been initialized yet, the following fails with a weird error:
```
import torch
torch.set_default_tensor_type("torch.cuda.FloatTensor")
```

This fixes that.

### Test Plan
I'm not sure how to write unit tests for this because CUDA is probably initialized by the time a unit test is called.

Ran the above script on a CPU only installation and a CUDA enabled installation.