### PR TITLE
Improve wording of Sequential docs

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -21,7 +21,7 @@ class Sequential(Module):
     Modules will be added to it in the order they are passed in the constructor.
     Alternatively, an ordered dict of modules can also be passed in.
 
-    To make it easier to understand, given is a small example::
+    To make it easier to understand, here is a small example::
 
         # Example of using Sequential
         model = nn.Sequential(


### PR DESCRIPTION
```
To make it easier to understand, given is a small example::
```
is now
```
To make it easier to understand, here is a small example::
```