### PR TITLE
Favor Variables over Tensors for scalar constructors in torch.distrib…

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -29,7 +29,7 @@ from itertools import product
 
 import torch
 from common import TestCase, run_tests, set_rng_seed
-from torch.autograd import Variable, grad, gradcheck
+from torch.autograd import Variable, grad, gradcheck, variable
 from torch.distributions import Distribution
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical, Cauchy, Chi2,
                                  Dirichlet, Exponential, FisherSnedecor, Gamma, Geometric,
@@ -53,7 +53,7 @@ def pairwise(Dist, *params):
     Creates a pair of distributions `Dist` initialzed to test each element of
     param with each other.
     """
-    params1 = [torch.Tensor([p] * len(p)) for p in params]
+    params1 = [variable([p] * len(p)) for p in params]
     params2 = [p.transpose(0, 1) for p in params1]
     return Dist(*params1), Dist(*params2)
 
@@ -191,7 +191,7 @@ EXAMPLES = [
             'alpha': Variable(torch.randn(5, 5).abs(), requires_grad=True)
         },
         {
-            'scale': torch.Tensor([1.0]),
+            'scale': variable([1.0]),
             'alpha': 1.0
         }
     ]),
@@ -345,8 +345,8 @@ class TestDistributions(TestCase):
         s = 0.3
         self.assertEqual(Geometric(p).sample_n(8).size(), (8, 3))
         self.assertEqual(Geometric(1).sample(), 0)
-        self.assertEqual(Geometric(1).log_prob(torch.Tensor([1])), -float('inf'), allow_inf=True)
-        self.assertEqual(Geometric(1).log_prob(torch.Tensor([0])), 0)
+        self.assertEqual(Geometric(1).log_prob(variable(1)), -float('inf'), allow_inf=True)
+        self.assertEqual(Geometric(1).log_prob(variable(0)), 0)
         self.assertTrue(isinstance(Geometric(p).sample().data, torch.Tensor))
         self.assertEqual(Geometric(r).sample_n(8).size(), (8, 1))
         self.assertEqual(Geometric(r).sample().size(), (1,))
@@ -398,12 +398,12 @@ class TestDistributions(TestCase):
         total_count = 100
         bin0 = Binomial(total_count, 0)
         self.assertEqual(bin0.sample(), 0)
-        self.assertAlmostEqual(bin0.log_prob(torch.Tensor([0]))[0], 0, places=3)
-        self.assertEqual(bin0.log_prob(torch.Tensor([1])).exp()[0], 0, allow_inf=True)
+        self.assertAlmostEqual(bin0.log_prob(variable([0]))[0], 0, places=3)
+        self.assertEqual(bin0.log_prob(variable([1])).exp().data[0], 0, allow_inf=True)
         bin1 = Binomial(total_count, 1)
         self.assertEqual(bin1.sample(), total_count)
-        self.assertAlmostEqual(bin1.log_prob(torch.Tensor([total_count]))[0], 0, places=3)
-        self.assertEqual(bin1.log_prob(torch.Tensor([total_count - 1])).exp()[0], 0, allow_inf=True)
+        self.assertAlmostEqual(bin1.log_prob(variable([total_count]))[0], 0, places=3)
+        self.assertEqual(bin1.log_prob(variable([total_count - 1])).exp().data[0], 0, allow_inf=True)
 
     def test_multinomial_1d(self):
         total_count = 10
@@ -970,89 +970,89 @@ class TestDistributions(TestCase):
         # parameters.
         # example type (distribution instance, expected sample shape)
         valid_examples = [
-            (Normal(loc=torch.Tensor([0, 0]), scale=1),
+            (Normal(loc=variable([0, 0]), scale=1),
              (2,)),
-            (Normal(loc=0, scale=torch.Tensor([1, 1])),
+            (Normal(loc=0, scale=variable([1, 1])),
              (2,)),
-            (Normal(loc=torch.Tensor([0, 0]), scale=torch.Tensor([1])),
+            (Normal(loc=variable([0, 0]), scale=variable([1])),
              (2,)),
-            (Normal(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1], [1]])),
+            (Normal(loc=variable([0, 0]), scale=variable([[1], [1]])),
              (2, 2)),
-            (Normal(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1]])),
+            (Normal(loc=variable([0, 0]), scale=variable([[1]])),
              (1, 2)),
-            (Normal(loc=torch.Tensor([0]), scale=torch.Tensor([[1]])),
+            (Normal(loc=variable([0]), scale=variable([[1]])),
              (1, 1)),
-            (FisherSnedecor(df1=torch.Tensor([1, 1]), df2=1),
+            (FisherSnedecor(df1=variable([1, 1]), df2=1),
              (2,)),
-            (FisherSnedecor(df1=1, df2=torch.Tensor([1, 1])),
+            (FisherSnedecor(df1=1, df2=variable([1, 1])),
              (2,)),
-            (FisherSnedecor(df1=torch.Tensor([1, 1]), df2=torch.Tensor([1])),
+            (FisherSnedecor(df1=variable([1, 1]), df2=variable([1])),
              (2,)),
-            (FisherSnedecor(df1=torch.Tensor([1, 1]), df2=torch.Tensor([[1], [1]])),
+            (FisherSnedecor(df1=variable([1, 1]), df2=variable([[1], [1]])),
              (2, 2)),
-            (FisherSnedecor(df1=torch.Tensor([1, 1]), df2=torch.Tensor([[1]])),
+            (FisherSnedecor(df1=variable([1, 1]), df2=variable([[1]])),
              (1, 2)),
-            (FisherSnedecor(df1=torch.Tensor([1]), df2=torch.Tensor([[1]])),
+            (FisherSnedecor(df1=variable([1]), df2=variable([[1]])),
              (1, 1)),
-            (Gamma(concentration=torch.Tensor([1, 1]), rate=1),
+            (Gamma(concentration=variable([1, 1]), rate=1),
              (2,)),
-            (Gamma(concentration=1, rate=torch.Tensor([1, 1])),
+            (Gamma(concentration=1, rate=variable([1, 1])),
              (2,)),
-            (Gamma(concentration=torch.Tensor([1, 1]), rate=torch.Tensor([[1], [1], [1]])),
+            (Gamma(concentration=variable([1, 1]), rate=variable([[1], [1], [1]])),
              (3, 2)),
-            (Gamma(concentration=torch.Tensor([1, 1]), rate=torch.Tensor([[1], [1]])),
+            (Gamma(concentration=variable([1, 1]), rate=variable([[1], [1]])),
              (2, 2)),
-            (Gamma(concentration=torch.Tensor([1, 1]), rate=torch.Tensor([[1]])),
+            (Gamma(concentration=variable([1, 1]), rate=variable([[1]])),
              (1, 2)),
-            (Gamma(concentration=torch.Tensor([1]), rate=torch.Tensor([[1]])),
+            (Gamma(concentration=variable([1]), rate=variable([[1]])),
              (1, 1)),
-            (Gumbel(loc=torch.Tensor([0, 0]), scale=1),
+            (Gumbel(loc=variable([0, 0]), scale=1),
              (2,)),
-            (Gumbel(loc=0, scale=torch.Tensor([1, 1])),
+            (Gumbel(loc=0, scale=variable([1, 1])),
              (2,)),
-            (Gumbel(loc=torch.Tensor([0, 0]), scale=torch.Tensor([1])),
+            (Gumbel(loc=variable([0, 0]), scale=variable([1])),
              (2,)),
-            (Gumbel(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1], [1]])),
+            (Gumbel(loc=variable([0, 0]), scale=variable([[1], [1]])),
              (2, 2)),
-            (Gumbel(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1]])),
+            (Gumbel(loc=variable([0, 0]), scale=variable([[1]])),
              (1, 2)),
-            (Gumbel(loc=torch.Tensor([0]), scale=torch.Tensor([[1]])),
+            (Gumbel(loc=variable([0]), scale=variable([[1]])),
              (1, 1)),
-            (Laplace(loc=torch.Tensor([0, 0]), scale=1),
+            (Laplace(loc=variable([0, 0]), scale=1),
              (2,)),
-            (Laplace(loc=0, scale=torch.Tensor([1, 1])),
+            (Laplace(loc=0, scale=variable([1, 1])),
              (2,)),
-            (Laplace(loc=torch.Tensor([0, 0]), scale=torch.Tensor([1])),
+            (Laplace(loc=variable([0, 0]), scale=variable([1])),
              (2,)),
-            (Laplace(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1], [1]])),
+            (Laplace(loc=variable([0, 0]), scale=variable([[1], [1]])),
              (2, 2)),
-            (Laplace(loc=torch.Tensor([0, 0]), scale=torch.Tensor([[1]])),
+            (Laplace(loc=variable([0, 0]), scale=variable([[1]])),
              (1, 2)),
-            (Laplace(loc=torch.Tensor([0]), scale=torch.Tensor([[1]])),
+            (Laplace(loc=variable([0]), scale=variable([[1]])),
              (1, 1)),
-            (Pareto(scale=torch.Tensor([1, 1]), alpha=1),
+            (Pareto(scale=variable([1, 1]), alpha=1),
              (2,)),
-            (Pareto(scale=1, alpha=torch.Tensor([1, 1])),
+            (Pareto(scale=1, alpha=variable([1, 1])),
              (2,)),
-            (Pareto(scale=torch.Tensor([1, 1]), alpha=torch.Tensor([1])),
+            (Pareto(scale=variable([1, 1]), alpha=variable([1])),
              (2,)),
-            (Pareto(scale=torch.Tensor([1, 1]), alpha=torch.Tensor([[1], [1]])),
+            (Pareto(scale=variable([1, 1]), alpha=variable([[1], [1]])),
              (2, 2)),
-            (Pareto(scale=torch.Tensor([1, 1]), alpha=torch.Tensor([[1]])),
+            (Pareto(scale=variable([1, 1]), alpha=variable([[1]])),
              (1, 2)),
-            (Pareto(scale=torch.Tensor([1]), alpha=torch.Tensor([[1]])),
+            (Pareto(scale=variable([1]), alpha=variable([[1]])),
              (1, 1)),
-            (StudentT(df=torch.Tensor([1, 1]), loc=1),
+            (StudentT(df=variable([1, 1]), loc=1),
              (2,)),
-            (StudentT(df=1, scale=torch.Tensor([1, 1])),
+            (StudentT(df=1, scale=variable([1, 1])),
              (2,)),
-            (StudentT(df=torch.Tensor([1, 1]), loc=torch.Tensor([1])),
+            (StudentT(df=variable([1, 1]), loc=variable([1])),
              (2,)),
-            (StudentT(df=torch.Tensor([1, 1]), scale=torch.Tensor([[1], [1]])),
+            (StudentT(df=variable([1, 1]), scale=variable([[1], [1]])),
              (2, 2)),
-            (StudentT(df=torch.Tensor([1, 1]), loc=torch.Tensor([[1]])),
+            (StudentT(df=variable([1, 1]), loc=variable([[1]])),
              (1, 2)),
-            (StudentT(df=torch.Tensor([1]), scale=torch.Tensor([[1]])),
+            (StudentT(df=variable([1]), scale=variable([[1]])),
              (1, 1)),
         ]
 
@@ -1066,44 +1066,44 @@ class TestDistributions(TestCase):
         # example type (distribution class, distribution params)
         invalid_examples = [
             (Normal, {
-                'loc': torch.Tensor([[0, 0]]),
-                'scale': torch.Tensor([1, 1, 1, 1])
+                'loc': variable([[0, 0]]),
+                'scale': variable([1, 1, 1, 1])
             }),
             (Normal, {
-                'loc': torch.Tensor([[[0, 0, 0], [0, 0, 0]]]),
-                'scale': torch.Tensor([1, 1])
+                'loc': variable([[[0, 0, 0], [0, 0, 0]]]),
+                'scale': variable([1, 1])
             }),
             (FisherSnedecor, {
-                'df1': torch.Tensor([1, 1]),
-                'df2': torch.Tensor([1, 1, 1]),
+                'df1': variable([1, 1]),
+                'df2': variable([1, 1, 1]),
             }),
             (Gumbel, {
-                'loc': torch.Tensor([[0, 0]]),
-                'scale': torch.Tensor([1, 1, 1, 1])
+                'loc': variable([[0, 0]]),
+                'scale': variable([1, 1, 1, 1])
             }),
             (Gumbel, {
-                'loc': torch.Tensor([[[0, 0, 0], [0, 0, 0]]]),
-                'scale': torch.Tensor([1, 1])
+                'loc': variable([[[0, 0, 0], [0, 0, 0]]]),
+                'scale': variable([1, 1])
             }),
             (Gamma, {
-                'concentration': torch.Tensor([0, 0]),
-                'rate': torch.Tensor([1, 1, 1])
+                'concentration': variable([0, 0]),
+                'rate': variable([1, 1, 1])
             }),
             (Laplace, {
-                'loc': torch.Tensor([0, 0]),
-                'scale': torch.Tensor([1, 1, 1])
+                'loc': variable([0, 0]),
+                'scale': variable([1, 1, 1])
             }),
             (Pareto, {
-                'scale': torch.Tensor([1, 1]),
-                'alpha': torch.Tensor([1, 1, 1])
+                'scale': variable([1, 1]),
+                'alpha': variable([1, 1, 1])
             }),
             (StudentT, {
-                'df': torch.Tensor([1, 1]),
-                'scale': torch.Tensor([1, 1, 1])
+                'df': variable([1, 1]),
+                'scale': variable([1, 1, 1])
             }),
             (StudentT, {
-                'df': torch.Tensor([1, 1]),
-                'loc': torch.Tensor([1, 1, 1])
+                'df': variable([1, 1]),
+                'loc': variable([1, 1, 1])
             })
         ]
 
@@ -1328,8 +1328,8 @@ class TestDistributionShapes(TestCase):
     def setUp(self):
         super(TestCase, self).setUp()
         self.scalar_sample = 1
-        self.tensor_sample_1 = torch.ones(3, 2)
-        self.tensor_sample_2 = torch.ones(3, 2, 3)
+        self.tensor_sample_1 = Variable(torch.ones(3, 2))
+        self.tensor_sample_2 = Variable(torch.ones(3, 2, 3))
 
     def test_entropy_shape(self):
         for Dist, params in EXAMPLES:
@@ -1357,14 +1357,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(bernoulli.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_bernoulli_shape_tensor_params(self):
-        bernoulli = Bernoulli(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        bernoulli = Bernoulli(variable([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(bernoulli._batch_shape, torch.Size((3, 2)))
         self.assertEqual(bernoulli._event_shape, torch.Size(()))
         self.assertEqual(bernoulli.sample().size(), torch.Size((3, 2)))
         self.assertEqual(bernoulli.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(bernoulli.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, bernoulli.log_prob, self.tensor_sample_2)
-        self.assertEqual(bernoulli.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(bernoulli.log_prob(Variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
 
     def test_geometric_shape_scalar_params(self):
         geometric = Geometric(0.3)
@@ -1377,14 +1377,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(geometric.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_geometric_shape_tensor_params(self):
-        geometric = Geometric(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        geometric = Geometric(variable([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(geometric._batch_shape, torch.Size((3, 2)))
         self.assertEqual(geometric._event_shape, torch.Size(()))
         self.assertEqual(geometric.sample().size(), torch.Size((3, 2)))
         self.assertEqual(geometric.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(geometric.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, geometric.log_prob, self.tensor_sample_2)
-        self.assertEqual(geometric.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(geometric.log_prob(Variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
 
     def test_beta_shape_scalar_params(self):
         dist = Beta(0.1, 0.1)
@@ -1397,18 +1397,18 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_beta_shape_tensor_params(self):
-        dist = Beta(torch.Tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
-                    torch.Tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]))
+        dist = Beta(variable([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
+                    variable([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]))
         self.assertEqual(dist._batch_shape, torch.Size((3, 2)))
         self.assertEqual(dist._event_shape, torch.Size(()))
         self.assertEqual(dist.sample().size(), torch.Size((3, 2)))
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        self.assertEqual(dist.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(dist.log_prob(Variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
 
     def test_binomial_shape(self):
-        dist = Binomial(10, torch.Tensor([0.6, 0.3]))
+        dist = Binomial(10, variable([0.6, 0.3]))
         self.assertEqual(dist._batch_shape, torch.Size((2,)))
         self.assertEqual(dist._event_shape, torch.Size(()))
         self.assertEqual(dist.sample().size(), torch.Size((2,)))
@@ -1417,27 +1417,27 @@ class TestDistributionShapes(TestCase):
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
 
     def test_multinomial_shape(self):
-        dist = Multinomial(10, torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        dist = Multinomial(10, variable([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(dist._batch_shape, torch.Size((3,)))
         self.assertEqual(dist._event_shape, torch.Size((2,)))
         self.assertEqual(dist.sample().size(), torch.Size((3, 2)))
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        self.assertEqual(dist.log_prob(torch.ones(3, 1, 2)).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(Variable(torch.ones(3, 1, 2))).size(), torch.Size((3, 3)))
 
     def test_categorical_shape(self):
-        dist = Categorical(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        dist = Categorical(variable([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(dist._batch_shape, torch.Size((3,)))
         self.assertEqual(dist._event_shape, torch.Size(()))
         self.assertEqual(dist.sample().size(), torch.Size((3,)))
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_1)
         self.assertEqual(dist.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
-        self.assertEqual(dist.log_prob(torch.ones(3, 1)).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(Variable(torch.ones(3, 1))).size(), torch.Size((3, 3)))
 
     def test_one_hot_categorical_shape(self):
-        dist = OneHotCategorical(torch.Tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
+        dist = OneHotCategorical(variable([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(dist._batch_shape, torch.Size((3,)))
         self.assertEqual(dist._event_shape, torch.Size((2,)))
         self.assertEqual(dist.sample().size(), torch.Size((3, 2)))
@@ -1445,7 +1445,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
         self.assertEqual(dist.log_prob(dist.enumerate_support()).size(), torch.Size((2, 3)))
-        self.assertEqual(dist.log_prob(torch.ones((3, 1, 2))).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(Variable(torch.ones((3, 1, 2)))).size(), torch.Size((3, 3)))
 
     def test_cauchy_shape_scalar_params(self):
         cauchy = Cauchy(0, 1)
@@ -1458,24 +1458,24 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(cauchy.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_cauchy_shape_tensor_params(self):
-        cauchy = Cauchy(torch.Tensor([0, 0]), torch.Tensor([1, 1]))
+        cauchy = Cauchy(variable([0, 0]), variable([1, 1]))
         self.assertEqual(cauchy._batch_shape, torch.Size((2,)))
         self.assertEqual(cauchy._event_shape, torch.Size(()))
         self.assertEqual(cauchy.sample().size(), torch.Size((2,)))
         self.assertEqual(cauchy.sample(torch.Size((3, 2))).size(), torch.Size((3, 2, 2)))
         self.assertEqual(cauchy.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, cauchy.log_prob, self.tensor_sample_2)
-        self.assertEqual(cauchy.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(cauchy.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_dirichlet_shape(self):
-        dist = Dirichlet(torch.Tensor([[0.6, 0.3], [1.6, 1.3], [2.6, 2.3]]))
+        dist = Dirichlet(variable([[0.6, 0.3], [1.6, 1.3], [2.6, 2.3]]))
         self.assertEqual(dist._batch_shape, torch.Size((3,)))
         self.assertEqual(dist._event_shape, torch.Size((2,)))
         self.assertEqual(dist.sample().size(), torch.Size((3, 2)))
         self.assertEqual(dist.sample((5, 4)).size(), torch.Size((5, 4, 3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        self.assertEqual(dist.log_prob(torch.ones((3, 1, 2))).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(Variable(torch.ones((3, 1, 2)))).size(), torch.Size((3, 3)))
 
     def test_gamma_shape_scalar_params(self):
         gamma = Gamma(1, 1)
@@ -1488,14 +1488,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(gamma.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_gamma_shape_tensor_params(self):
-        gamma = Gamma(torch.Tensor([1, 1]), torch.Tensor([1, 1]))
+        gamma = Gamma(variable([1, 1]), variable([1, 1]))
         self.assertEqual(gamma._batch_shape, torch.Size((2,)))
         self.assertEqual(gamma._event_shape, torch.Size(()))
         self.assertEqual(gamma.sample().size(), torch.Size((2,)))
         self.assertEqual(gamma.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(gamma.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, gamma.log_prob, self.tensor_sample_2)
-        self.assertEqual(gamma.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(gamma.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_chi2_shape_scalar_params(self):
         chi2 = Chi2(1)
@@ -1508,14 +1508,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(chi2.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_chi2_shape_tensor_params(self):
-        chi2 = Chi2(torch.Tensor([1, 1]))
+        chi2 = Chi2(variable([1, 1]))
         self.assertEqual(chi2._batch_shape, torch.Size((2,)))
         self.assertEqual(chi2._event_shape, torch.Size(()))
         self.assertEqual(chi2.sample().size(), torch.Size((2,)))
         self.assertEqual(chi2.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(chi2.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, chi2.log_prob, self.tensor_sample_2)
-        self.assertEqual(chi2.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(chi2.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_studentT_shape_scalar_params(self):
         st = StudentT(1)
@@ -1528,14 +1528,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(st.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_studentT_shape_tensor_params(self):
-        st = StudentT(torch.Tensor([1, 1]))
+        st = StudentT(variable([1, 1]))
         self.assertEqual(st._batch_shape, torch.Size((2,)))
         self.assertEqual(st._event_shape, torch.Size(()))
         self.assertEqual(st.sample().size(), torch.Size((2,)))
         self.assertEqual(st.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(st.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, st.log_prob, self.tensor_sample_2)
-        self.assertEqual(st.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(st.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_pareto_shape_scalar_params(self):
         pareto = Pareto(1, 1)
@@ -1558,14 +1558,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(normal.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_normal_shape_tensor_params(self):
-        normal = Normal(torch.Tensor([0, 0]), torch.Tensor([1, 1]))
+        normal = Normal(variable([0, 0]), variable([1, 1]))
         self.assertEqual(normal._batch_shape, torch.Size((2,)))
         self.assertEqual(normal._event_shape, torch.Size(()))
         self.assertEqual(normal.sample().size(), torch.Size((2,)))
         self.assertEqual(normal.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(normal.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, normal.log_prob, self.tensor_sample_2)
-        self.assertEqual(normal.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(normal.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_uniform_shape_scalar_params(self):
         uniform = Uniform(0, 1)
@@ -1578,14 +1578,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(uniform.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_uniform_shape_tensor_params(self):
-        uniform = Uniform(torch.Tensor([0, 0]), torch.Tensor([1, 1]))
+        uniform = Uniform(variable([0, 0]), variable([1, 1]))
         self.assertEqual(uniform._batch_shape, torch.Size((2,)))
         self.assertEqual(uniform._event_shape, torch.Size(()))
         self.assertEqual(uniform.sample().size(), torch.Size((2,)))
         self.assertEqual(uniform.sample(torch.Size((3, 2))).size(), torch.Size((3, 2, 2)))
         self.assertEqual(uniform.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, uniform.log_prob, self.tensor_sample_2)
-        self.assertEqual(uniform.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(uniform.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
     def test_exponential_shape_scalar_param(self):
         expon = Exponential(1.)
@@ -1598,14 +1598,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(expon.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_exponential_shape_tensor_param(self):
-        expon = Exponential(torch.Tensor([1, 1]))
+        expon = Exponential(variable([1, 1]))
         self.assertEqual(expon._batch_shape, torch.Size((2,)))
         self.assertEqual(expon._event_shape, torch.Size(()))
         self.assertEqual(expon.sample().size(), torch.Size((2,)))
         self.assertEqual(expon.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(expon.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, expon.log_prob, self.tensor_sample_2)
-        self.assertEqual(expon.log_prob(torch.ones(2, 2)).size(), torch.Size((2, 2)))
+        self.assertEqual(expon.log_prob(Variable(torch.ones(2, 2))).size(), torch.Size((2, 2)))
 
     def test_laplace_shape_scalar_params(self):
         laplace = Laplace(0, 1)
@@ -1618,14 +1618,14 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(laplace.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
 
     def test_laplace_shape_tensor_params(self):
-        laplace = Laplace(torch.Tensor([0, 0]), torch.Tensor([1, 1]))
+        laplace = Laplace(variable([0, 0]), variable([1, 1]))
         self.assertEqual(laplace._batch_shape, torch.Size((2,)))
         self.assertEqual(laplace._event_shape, torch.Size(()))
         self.assertEqual(laplace.sample().size(), torch.Size((2,)))
         self.assertEqual(laplace.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(laplace.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, laplace.log_prob, self.tensor_sample_2)
-        self.assertEqual(laplace.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
+        self.assertEqual(laplace.log_prob(Variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
 
 
 class TestKL(TestCase):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -370,7 +370,7 @@ class TestDistributions(TestCase):
 
         # check entropy computation
         self.assertEqual(Geometric(p).entropy().data, scipy.stats.geom(p.data.numpy(), loc=-1).entropy(), prec=1e-3)
-        self.assertEqual(Geometric(s).entropy()[0], scipy.stats.geom(s, loc=-1).entropy().item(), prec=1e-3)
+        self.assertEqual(float(Geometric(s).entropy()[0]), scipy.stats.geom(s, loc=-1).entropy().item(), prec=1e-3)
 
     def test_binomial(self):
         p = Variable(torch.arange(0.05, 1, 0.1), requires_grad=True)
@@ -399,11 +399,11 @@ class TestDistributions(TestCase):
         bin0 = Binomial(total_count, 0)
         self.assertEqual(bin0.sample(), 0)
         self.assertAlmostEqual(bin0.log_prob(variable([0]))[0], 0, places=3)
-        self.assertEqual(bin0.log_prob(variable([1])).exp().data[0], 0, allow_inf=True)
+        self.assertEqual(float(bin0.log_prob(variable([1])).exp()), 0, allow_inf=True)
         bin1 = Binomial(total_count, 1)
         self.assertEqual(bin1.sample(), total_count)
         self.assertAlmostEqual(bin1.log_prob(variable([total_count]))[0], 0, places=3)
-        self.assertEqual(bin1.log_prob(variable([total_count - 1])).exp().data[0], 0, allow_inf=True)
+        self.assertEqual(float(bin1.log_prob(variable([total_count - 1])).exp()), 0, allow_inf=True)
 
     def test_multinomial_1d(self):
         total_count = 10
@@ -951,7 +951,7 @@ class TestDistributions(TestCase):
             x = dist.sample()
             actual_log_prob = dist.log_prob(x).sum()
             expected_log_prob = scipy.stats.beta.logpdf(x, con1, con0)[0]
-            self.assertAlmostEqual(actual_log_prob, expected_log_prob, places=3, allow_inf=True)
+            self.assertAlmostEqual(float(actual_log_prob), expected_log_prob, places=3, allow_inf=True)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_beta_sample(self):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,6 +1,7 @@
 from numbers import Number
 
 import torch
+from torch.autograd import variable
 from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.distribution import Distribution
@@ -30,7 +31,7 @@ class Beta(Distribution):
 
     def __init__(self, concentration1, concentration0):
         if isinstance(concentration1, Number) and isinstance(concentration0, Number):
-            concentration1_concentration0 = torch.Tensor([concentration1, concentration0])
+            concentration1_concentration0 = variable([concentration1, concentration0])
         else:
             concentration1, concentration0 = broadcast_all(concentration1, concentration0)
             concentration1_concentration0 = torch.stack([concentration1, concentration0], -1)

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -4,7 +4,7 @@ from numbers import Number
 import math
 import torch
 import torch.nn.functional as F
-from torch.autograd import Variable
+from torch.autograd import Variable, variable
 
 # This follows semantics of numpy.finfo.
 _Finfo = namedtuple('_Finfo', ['eps', 'tiny'])
@@ -64,9 +64,9 @@ def broadcast_all(*values):
       - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as
         per the `broadcasting rules
         <http://pytorch.org/docs/master/notes/broadcasting.html>`_
-      - numbers.Number instances (scalars) are upcast to Tensor/Variable having
-        the same size and type as the first tensor passed to `values`. If all the
-        values are scalars, then they are upcasted to `torch.Tensor` having size
+      - numbers.Number instances (scalars) are upcast to Variables having
+        the same size and type as the first tensor passed to `values`.  If all the
+        values are scalars, then they are upcasted to Variables having size
         `(1,)`.
 
     Args:
@@ -89,11 +89,14 @@ def broadcast_all(*values):
         for idx in tensor_idxs:
             values[idx] = values[idx].expand(broadcast_shape)
         template = values[tensor_idxs[0]]
+        if len(scalar_idxs) > 0 and not isinstance(template, torch.autograd.Variable):
+            raise ValueError(('Input arguments containing instances of numbers.Number and torch.Tensor '
+                              'are not currently supported.  Use torch.autograd.Variable instead of torch.Tensor'))
         for idx in scalar_idxs:
             values[idx] = template.new(template.size()).fill_(values[idx])
     else:
         for idx in scalar_idxs:
-            values[idx] = torch.Tensor([values[idx]])
+            values[idx] = variable(values[idx])
     return values
 
 


### PR DESCRIPTION
…utions.

Current behvior:
1) distribution constructors containing only python number elements will have their python numbers upcasted to Tensors.
2) Python number arguments of distribution constructors that also contain tensors and variables will be upcasted
to the first tensor/variable type.

This PR changes the above to favor Variables as follows:
1) The python numbers will now be upcasted to Variables
2) An error will be raised if the first tensor/variable type is not a Variable.

This is done in preparation for the introduction of Scalars (0-dimensional tensors), which are only available on the Variable API.

Note that we are (separately) merging Variable and Tensor, so this PR should have no real long-term effect.

Also note that the above means we don't change the behavior of constructors without python number arguments.