### PR TITLE
Add mutex lock for CPU RNG

### DIFF
--- a/aten/src/TH/THRandom.c
+++ b/aten/src/TH/THRandom.c
@@ -1,3 +1,4 @@
+#include "pthread.h"
 #include "THGeneral.h"
 #include "THRandom.h"
 
@@ -190,9 +191,11 @@ uint64_t THRandom_random(THGenerator *_generator)
 {
   uint64_t y;
 
+  pthread_mutex_lock(&_generator->mutex);
   if (--(_generator->left) == 0)
     THRandom_nextState(_generator);
   y = *(_generator->state + (_generator->next)++);
+  pthread_mutex_unlock(&_generator->mutex);
 
   /* Tempering */
   y ^= (y >> 11);

--- a/aten/src/TH/THRandom.h
+++ b/aten/src/TH/THRandom.h
@@ -2,6 +2,7 @@
 #define TH_RANDOM_INC
 
 #include "THGeneral.h"
+#include <pthread.h>
 
 #define _MERSENNE_STATE_N 624
 #define _MERSENNE_STATE_M 397
@@ -20,6 +21,7 @@ typedef struct THGenerator {
   double normal_y;
   double normal_rho;
   int normal_is_valid; /* = 0; */
+  pthread_mutex_t mutex;
 } THGenerator;
 
 #define torch_Generator "torch.Generator"


### PR DESCRIPTION
Perhaps a simpler alternative for #4041 
I'm concerned that the shared generator will introduce extra randomness so that results are not controllable by setting random seed.
