### PR TITLE
Add symbolic_override_first_arg_based

### DIFF
--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -344,15 +344,6 @@ class CudnnRNN(NestedIOFunction):
 
 def RNN(*args, **kwargs):
 
-    # Hack for the tracer that allows us to represent RNNs as single
-    # nodes and export them to ONNX in this form
-    # Check the first argument explicitly to reduce the overhead of creating
-    # the lambda
-    #import torch.onnx.symbolic
-
-    #@torch.onnx.symbolic_override_first_arg_based(
-    #    torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)
-    #)
     def forward(input, *fargs, **fkwargs):
         if cudnn.is_acceptable(input.data):
             func = CudnnRNN(*args, **kwargs)

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -344,21 +344,20 @@ class CudnnRNN(NestedIOFunction):
 
 def RNN(*args, **kwargs):
 
+    # Hack for the tracer that allows us to represent RNNs as single
+    # nodes and export them to ONNX in this form
+    # Check the first argument explicitly to reduce the overhead of creating
+    # the lambda
+    import torch.onnx.symbolic
+
+    @torch.onnx.symbolic_override_first_arg_based(
+        torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)
+    )
     def forward(input, *fargs, **fkwargs):
         if cudnn.is_acceptable(input.data):
             func = CudnnRNN(*args, **kwargs)
         else:
             func = AutogradRNN(*args, **kwargs)
-
-        # Hack for the tracer that allows us to represent RNNs as single
-        # nodes and export them to ONNX in this form
-        # It can be also used as a decorator at the higher level
-        # Check the first argument explicitly to reduce the overhead of creating
-        # the lambda
-        import torch
-        if torch._C._jit_is_tracing(input):
-            import torch.onnx.symbolic
-            func = torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)(func)
 
         return func(input, *fargs, **fkwargs)
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -420,6 +420,7 @@ def _symbolic_override_wrapper_maker(symbolic_fn, first_arg_only, fn):
 
     return wrapper
 
+
 def symbolic_override(symbolic_fn):
     """
     Decorator to override ONNX export of the a function with specified subgraph.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -378,6 +378,48 @@ def _node_getitem(self, k):
     return getattr(self, sel)(k)
 
 
+def _symbolic_override_wrapper_maker(symbolic_fn, first_arg_only, fn):
+
+    def wrapper(*args, **kwargs):
+        output = fn(*args, **kwargs)
+        # fast pass
+        if first_arg_only and not torch._C._jit_is_tracing(args[0]):
+            return output
+
+        flat_args = tuple(function._iter_variables(args))
+        if not any(map(torch._C._jit_is_tracing, flat_args)):
+            return output
+        flat_output_tensors = tuple(
+            v.data for v in function._iter_variables(output))
+        assert len(list(function._iter_variables_permissive(
+            list(kwargs.values())))) == 0, \
+            "Passing Variable through kwargs is not supported"
+
+        class ExportProxy(Function):
+            @staticmethod
+            def symbolic(g, *flat_args):
+                symbolic_args = function._unflatten(flat_args, args)
+                symbolic_output = symbolic_fn(g, *symbolic_args, **kwargs)
+                return tuple(function._iter_jit_values(symbolic_output))
+
+            @staticmethod
+            def forward(ctx, *unused_args):
+                return flat_output_tensors
+
+            @staticmethod
+            def backward(ctx, *unused_args, **unused_kwargs):
+                raise RuntimeError(
+                    "symbolic_override is meant for inference export only")
+
+        flat_proxy_output = ExportProxy.apply(*flat_args)
+        return function._unflatten(flat_proxy_output, output)
+
+    # fn might be autograd.Function too, in this case wrapping doesn't work
+    if isinstance(fn, types.FunctionType):
+        wrapper = functools.wraps(fn)(wrapper)
+
+    return wrapper
+
 def symbolic_override(symbolic_fn):
     """
     Decorator to override ONNX export of the a function with specified subgraph.
@@ -404,45 +446,19 @@ def symbolic_override(symbolic_fn):
     ```
     """
 
-    def wrapper_maker(fn):
+    return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, False)
 
-        def wrapper(*args, **kwargs):
-            output = fn(*args, **kwargs)
-            flat_args = tuple(function._iter_variables(args))
-            if not any(map(torch._C._jit_is_tracing, flat_args)):
-                return output
-            flat_output_tensors = tuple(
-                v.data for v in function._iter_variables(output))
-            assert len(list(function._iter_variables_permissive(
-                list(kwargs.values())))) == 0, \
-                "Passing Variable through kwargs is not supported"
 
-            class ExportProxy(Function):
-                @staticmethod
-                def symbolic(g, *flat_args):
-                    symbolic_args = function._unflatten(flat_args, args)
-                    symbolic_output = symbolic_fn(g, *symbolic_args, **kwargs)
-                    return tuple(function._iter_jit_values(symbolic_output))
+def symbolic_override_first_arg_based(symbolic_fn):
+    """
+    Decorator to override ONNX export of the a function with specified subgraph.
 
-                @staticmethod
-                def forward(ctx, *unused_args):
-                    return flat_output_tensors
+    Equivalent to `symbolic_override` but checks only the first argument of the
+    function to figure out whether the tracing is on. Thus the first arg needs
+    to be a Variable.
+    """
 
-                @staticmethod
-                def backward(ctx, *unused_args, **unused_kwargs):
-                    raise RuntimeError(
-                        "symbolic_override is meant for inference export only")
-
-            flat_proxy_output = ExportProxy.apply(*flat_args)
-            return function._unflatten(flat_proxy_output, output)
-
-        # fn might be autograd.Function too, in this case wrapping doesn't work
-        if isinstance(fn, types.FunctionType):
-            wrapper = functools.wraps(fn)(wrapper)
-
-        return wrapper
-
-    return wrapper_maker
+    return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, True)
 
 
 torch._C.Graph.op = _graph_op

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -535,7 +535,7 @@ def RNN_symbolic_builder(cell_type, *args, **kwargs):
     elif cell_type == 'GRU':
         return GRU_symbolic_builder(*args, **kwargs)
     else:
-        return _unimplemented("RNN", "cell type " + cell_type)
+        return lambda *args, **kwargs: _unimplemented("RNN", "cell type " + cell_type)
 
 
 def reform_weights(g, w, n, intervals):
@@ -544,14 +544,14 @@ def reform_weights(g, w, n, intervals):
 
 
 def LSTM_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropout, bidirectional, **kwargs):
-    if batch_first:
-        return _unimplemented("LSTM", "batch_first")
-    if dropout:
-        return _unimplemented("LSTM", "dropout")
-    if bidirectional:
-        return _unimplemented("LSTM", "bidirectional")
-
     def symbolic(g, input, all_weights, h0_and_c0, **fkwargs):
+        if batch_first:
+            return _unimplemented("LSTM", "batch_first")
+        if dropout:
+            return _unimplemented("LSTM", "dropout")
+        if bidirectional:
+            return _unimplemented("LSTM", "bidirectional")
+
         h0, c0 = h0_and_c0
 
         # TODO elide this argument to increase parametricity. This is
@@ -580,18 +580,18 @@ def LSTM_symbolic_builder(input_size, hidden_size, num_layers, batch_first, drop
         h_outs = h_out if num_layers == 1 else g.op('Concat', *h_outs, axis_i=0)
         return prev_output, h_outs, None
 
-    return torch.onnx.symbolic_override(symbolic)
+    return symbolic
 
 
 def GRU_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropout, bidirectional, **kwargs):
-    if batch_first:
-        return _unimplemented("GRU", "batch_first")
-    if dropout:
-        return _unimplemented("GRU", "dropout")
-    if bidirectional:
-        return _unimplemented("GRU", "bidirectional")
-
     def symbolic(g, input, all_weights, h0, **fkwargs):
+        if batch_first:
+            return _unimplemented("GRU", "batch_first")
+        if dropout:
+            return _unimplemented("GRU", "dropout")
+        if bidirectional:
+            return _unimplemented("GRU", "bidirectional")
+
         # TODO elide this argument to increase parametricity. This is
         # nontrivial because we provide subsequent optional arguments,
         # and ONNX does not have a mechanism for skipping non-trailing
@@ -618,4 +618,4 @@ def GRU_symbolic_builder(input_size, hidden_size, num_layers, batch_first, dropo
         h_outs = h_out if num_layers == 1 else g.op('Concat', *h_outs, axis_i=0)
         return prev_output, h_outs
 
-    return torch.onnx.symbolic_override(symbolic)
+    return symbolic


### PR DESCRIPTION
Simplify symbolic_override a bit as checking the first arg is a common pattern. It allows us to use the proper decorator.

For perf - did non-scientific benchmark with %timeit around small RNN execution on CPU - this change doesn't make execution slower.

Also changes RNN's symbolics to produce warnings on actual symbolic unrolling step, not during forward execution.