### PR TITLE
Enable scalars if compiled with WITH_SCALAR environment variable.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ IS_LINUX = (platform.system() == 'Linux')
 WITH_DISTRIBUTED = not check_env_flag('NO_DISTRIBUTED') and not IS_WINDOWS
 WITH_DISTRIBUTED_MW = WITH_DISTRIBUTED and check_env_flag('WITH_DISTRIBUTED_MW')
 
+WITH_SCALARS = check_env_flag('WITH_SCALARS')
+
 try:
     import ninja
     WITH_NINJA = True
@@ -605,6 +607,9 @@ if DEBUG:
     else:
         extra_compile_args += ['-O0', '-g']
         extra_link_args += ['-O0', '-g']
+
+if WITH_SCALARS:
+    extra_compile_args += ['-DWITH_SCALARS']
 
 if os.getenv('PYTORCH_BINARY_BUILD') and platform.system() == 'Linux':
     print('PYTORCH_BINARY_BUILD found. Static linking libstdc++ on Linux')

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -552,7 +552,7 @@
   self: unsqueeze_to(grad, self.sizes());
 
 - name: squeeze(Tensor self, int64_t dim)
-  self: maybe_unsqueeze(grad, dim, self.size(dim) == 1 && self.sizes().size() != 1)
+  self: maybe_unsqueeze(grad, dim, self.size(dim))
 
 - name: std(Tensor self, bool unbiased)
   self: var_backward(grad / (result * 2), self, unbiased)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -552,7 +552,7 @@
   self: unsqueeze_to(grad, self.sizes());
 
 - name: squeeze(Tensor self, int64_t dim)
-  self: maybe_unsqueeze(grad, dim, self.size(dim))
+  self: unsqueeze_to(grad, dim, self.sizes())
 
 - name: std(Tensor self, bool unbiased)
   self: var_backward(grad / (result * 2), self, unbiased)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -23,6 +23,7 @@
 #     differentiable subcomponents.
 #
 from __future__ import print_function
+import os
 import sys
 from .utils import CodeTemplate, nested_dict, write
 from .gen_autograd import VIEW_FUNCTIONS, template_path
@@ -458,7 +459,7 @@ def emit_body(declaration):
     body.append(declare_returned_variables())
     body.append(emit_call(env))
     if requires_derivative:
-        if inplace and is_view:
+        if inplace and is_view and not os.environ.get('WITH_SCALARS'):
             body.append('ensure_no_aten_scalars(self);')
         # set_flags has to appear after version_counter, because rebase_history
         # requires that the counter is incremented before it is called

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -65,7 +65,11 @@ Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_
 }
 
 Tensor norm_backward(Tensor grad, const Tensor & self, const Scalar & p_, Tensor norm, int64_t dim, bool keepdim) {
+#ifdef WITH_SCALARS
+  if (!keepdim) {
+#else
   if (!keepdim && self.dim() > 1) {
+#endif
     grad = grad.unsqueeze(dim);
     norm = norm.unsqueeze(dim);
   }
@@ -98,7 +102,11 @@ Tensor permute_backwards(const Tensor & grad, IntList fwd_dims) {
 }
 
 Tensor sum_backward(const Tensor & grad, IntList sizes, int64_t dim, bool keepdim) {
-  if (!keepdim && sizes.size() > 1) {
+#ifdef WITH_SCALARS
+  if (!keepdim) {
+#else
+   if (!keepdim && sizes.size() > 1) {
+#endif
     return grad.unsqueeze(dim).expand(sizes);
   } else {
     return grad.expand(sizes);
@@ -303,6 +311,7 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
   auto result = self;
   int64_t nDims = sizes.size();
 
+#ifndef WITH_SCALARS
   // Let's say the input had size (1, 1). input.squeeze(), with scalars
   // disabled, produces a result of size (1,). This needs some
   // special handling because for all other cases we unsqueeze every
@@ -314,6 +323,7 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
     }
     return result;
   }
+#endif
 
   for (int64_t dim = 0; dim < nDims; dim++) {
     if (sizes[dim] == 1) {
@@ -323,8 +333,12 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
   return result;
 }
 
-Tensor maybe_unsqueeze(const Tensor & self, int64_t dim, bool unsqueeze) {
-  if (unsqueeze) {
+Tensor maybe_unsqueeze(const Tensor & self, int64_t dim, int64_t dim_size) {
+#ifdef WITH_SCALARS
+  if (self.size(dim) == 1) {
+#else
+  if (self.size(dim) == 1 && self.sizes().size() != 1) {
+#endif
     return self.unsqueeze(dim);
   }
   return self;
@@ -390,14 +404,22 @@ Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64
 }
 
 Tensor select_backward_scalar(Tensor grad, const Tensor & input, const Tensor & value) {
-  auto grad_data = static_cast<Variable&>(grad).data();
   auto grad_input = zeros_like(input);
+#ifdef WITH_SCALARS
+  grad_input.masked_fill_(input == value, grad);
+#else
+  auto grad_data = static_cast<Variable&>(grad).data();
   grad_input.masked_fill_(input == value, Scalar(grad_data[0]));
+#endif
   return grad_input;
 }
 
 Tensor select_backward(Tensor grad, int64_t dim, Tensor indices, IntList sizes, bool keepdim) {
+#ifdef WITH_SCALARS
+  if (!keepdim) {
+#else
   if (!keepdim && sizes.size() > 1) {
+#endif
     grad = grad.unsqueeze(dim);
     indices = indices.unsqueeze(dim);
   }
@@ -409,13 +431,16 @@ Tensor trace_backward(const Tensor & grad, IntList sizes) {
     throw std::runtime_error("expected matrix input");
   }
 
-  // TODO: simplify once index_fill_(Tensor) is implemented on Variable
-  auto grad_data = static_cast<const Variable&>(grad).data();
   auto& long_type = grad.type().toScalarType(at::kLong);
 
   auto grad_input = grad.type().zeros(sizes[0] * sizes[1]);
   auto indices = long_type.arange(0, grad_input.numel(), sizes[1] + 1);
-  grad_input.index_fill_(0, indices, Scalar(grad_data[0]));
+#ifdef WITH_SCALARS
+  grad_input.index_fill_(0, indices, grad);
+#else
+  auto grad_data = static_cast<const Variable&>(grad).data();
+  grad_input.index_fill_(0, indices, grad);
+#endif
   return grad_input.view(sizes);
 }
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -333,11 +333,11 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
   return result;
 }
 
-Tensor maybe_unsqueeze(const Tensor & self, int64_t dim, int64_t dim_size) {
+Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
 #ifdef WITH_SCALARS
-  if (self.size(dim) == 1) {
+  if (sizes[dim] == 1) {
 #else
-  if (self.size(dim) == 1 && self.sizes().size() != 1) {
+  if (sizes[dim] == 1 && sizes.size() != 1) {
 #endif
     return self.unsqueeze(dim);
   }

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -334,6 +334,7 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
 }
 
 Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
+  dim = at::maybe_wrap_dim(dim, sizes.size());
 #ifdef WITH_SCALARS
   if (sizes[dim] == 1) {
 #else
@@ -439,7 +440,7 @@ Tensor trace_backward(const Tensor & grad, IntList sizes) {
   grad_input.index_fill_(0, indices, grad);
 #else
   auto grad_data = static_cast<const Variable&>(grad).data();
-  grad_input.index_fill_(0, indices, grad);
+  grad_input.index_fill_(0, indices, Scalar(grad_data[0]));
 #endif
   return grad_input.view(sizes);
 }

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -239,11 +239,13 @@ static Tensor as_view(const Tensor & base, Tensor tensor) {
   return make_variable_view(std::move(base_var), std::move(tensor));
 }
 
+#ifndef WITH_SCALARS
 static void ensure_no_aten_scalars(Tensor & data) {
   if (data.defined() && data.dim() == 0) {
     data.as_strided_({1}, {1});
   }
 }
+#endif
 
 template<typename T>
 static bool computes_grad_tmpl(T tensors) {

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -523,32 +523,6 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
   END_HANDLE_TH_ERRORS
 }
 
-// FixMe: remove when scalars fully supported
-inline PyObject* _wrap_scalar(at::Tensor tensor) {
-  if (!tensor.sizes().equals({1})) {
-    throw std::runtime_error("tried to wrap scalar of non-scalar size");
-  }
-  auto v = Variable(std::move(tensor));
-  v.data().squeeze_();
-  return THPVariable_Wrap(v, true);
-}
-
-static PyObject * THPVariable__scalar_sum(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "sum()",
-  });
-  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[3];
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (r.idx == 0) {
-    return _wrap_scalar(dispatch_sum(self_));
-  }
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
 // generated methods start here
 
 ${py_methods}
@@ -606,7 +580,6 @@ PyMethodDef variable_methods[] = {
   {"stride", (PyCFunction)THPVariable_stride, METH_VARARGS | METH_KEYWORDS, NULL},
   {"tolist", (PyCFunction)THPVariable_tolist, METH_NOARGS, NULL},
   {"type", (PyCFunction)THPVariable_type, METH_VARARGS | METH_KEYWORDS, NULL},
-  {"_scalar_sum", (PyCFunction)THPVariable__scalar_sum,  METH_VARARGS | METH_KEYWORDS, NULL},
   ${py_method_defs}
   {NULL}
 };

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -468,6 +468,14 @@ PyObject *THPModule_inferSize(PyObject *_unused, PyObject *args)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject *THPModule_with_scalars(PyObject *_unused, PyObject *args) {
+#ifdef WITH_SCALARS
+  Py_RETURN_TRUE;
+#else
+  Py_RETURN_FALSE;
+#endif
+}
+
 static PyObject *THPModule_setBackcompatBroadcastWarn(PyObject *module, PyObject *arg) {
   THPUtils_assert(PyBool_Check(arg), "set_backcompat_broadcast_warn expects a bool, "
           "but got %s", THPUtils_typename(arg));
@@ -595,6 +603,7 @@ static PyMethodDef TorchMethods[] = {
   {"_safe_call",      (PyCFunction)THPModule_safeCall,          METH_VARARGS | METH_KEYWORDS, NULL},
   {"_set_default_tensor_type", (PyCFunction)THPModule_setDefaultTensorType, METH_O, NULL},
   {"_infer_size",     (PyCFunction)THPModule_inferSize,         METH_VARARGS, NULL},
+  {"_with_scalars",(PyCFunction)THPModule_with_scalars, METH_NOARGS,  NULL},
   {"_set_backcompat_broadcast_warn", (PyCFunction)THPModule_setBackcompatBroadcastWarn, METH_O, NULL},
   {"_get_backcompat_broadcast_warn", (PyCFunction)THPModule_getBackcompatBroadcastWarn, METH_NOARGS, NULL},
   {"_set_backcompat_keepdim_warn", (PyCFunction)THPModule_setBackcompatKeepdimWarn, METH_O, NULL},

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -44,15 +44,17 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
   return obj;
 }
 
-PyObject * THPVariable_Wrap(Variable var, bool allow_scalar)
+PyObject * THPVariable_Wrap(Variable var)
 {
   if (!var.defined()) {
     Py_RETURN_NONE;
   }
 
-  if (!allow_scalar && var.dim() == 0) {
+#ifndef WITH_SCALARS
+  if (var.dim() == 0) {
     throw std::runtime_error("Variable API does not support Scalars");
   }
+#endif
 
   if (auto obj = var.get()->pyobj) {
     Py_INCREF(obj);

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -25,8 +25,7 @@ struct THPVariable {
 THP_API PyObject *THPVariableClass;
 
 bool THPVariable_initModule(PyObject *module);
-// FixMe: remove allow_scalar when scalars are fully supported.
-PyObject * THPVariable_Wrap(torch::autograd::Variable var, bool allow_scalar=false);
+PyObject * THPVariable_Wrap(torch::autograd::Variable var);
 PyObject * THPVariable_get_data(THPVariable *self);
 
 inline bool THPVariable_Check(PyObject *obj)

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -158,10 +158,14 @@ inline Variable make_variable(at::Tensor data, bool requires_grad=false) {
   if (!data.defined()) {
     return Variable();
   }
+
+#ifndef WITH_SCALARS
   if (data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
   }
+#endif
+
   return Variable(new VariableImpl(std::move(data), requires_grad), false);
 }
 
@@ -169,10 +173,14 @@ inline Variable make_variable(at::Tensor data, int output_nr, std::shared_ptr<Fu
   if (!data.defined()) {
     return Variable();
   }
-  if (data.defined() && data.dim() == 0) {
+
+#ifndef WITH_SCALARS
+  if (data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
   }
+#endif
+
   return Variable(new VariableImpl(std::move(data), false, output_nr, std::move(grad_fn)), false);
 }
 
@@ -183,10 +191,14 @@ inline Variable make_variable_view(Variable base, at::Tensor data, int output_nr
   if (!data.defined()) {
     return Variable();
   }
+
+#ifndef WITH_SCALARS
   if (data.dim() == 0) {
     // don't expose 0-dim tensors to Variable API.
     data = data.as_strided_({1}, {1});
   }
+#endif
+
   return Variable(new VariableViewImpl(std::move(base), std::move(data), output_nr, std::move(grad_fn)), false);
 }
 


### PR DESCRIPTION
We are pretty close to enabling scalars (0-dimensional arrays); this allows turning them on
for development purposes and to be able to write code that works both with and without scalars enabled by using the preprocessor.

WITH_SCALARS is currently broken with distributions, but should work for test_torch, test_autograd, test_nn.