### PR TITLE
Create issue template with guidelines for issue submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+PyTorch GitHub Issues Guidelines
+--------------------------------
+
+We like to limit our issues to bug reports and feature requests. If you have a question or would like help and support, please visit our forums: https://discuss.pytorch.org/
+
+If you are submitting a feature request, please preface the title with [feature request].
+
+When submitting a bug report, please include the following information (where relevant):
+- OS:
+- PyTorch version:
+- How you installed PyTorch (conda, pip, source):
+- Python version:
+- CUDA/cuDNN version:
+- GPU models and configuration:
+- GCC version (if compiling from source):
+
+In addition, including the following information will also be very helpful for us to diagnose the problem:
+- A script to reproduce the bug. Please try to provide as minimal of a test case as possible.
+- Error messages and/or stack traces of the bug
+- Context around what you are trying to do
+


### PR DESCRIPTION
The issue template is populated with guidelines. These are mostly questions that I find myself asking in follow-up comments to issue submissions.

cc @soumith 