### PR TITLE
Fix output_nr not incremented correctly

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -421,7 +421,7 @@ at::Tensor _convolution_nogroup(
           stride, padding, output_padding, dilation);
     } else if (dim == 5) {
       return at::thnn_conv_transpose3d(
-        input, weight, bias,
+        input, weight, kernel_size, bias,
         stride, padding, output_padding, dilation);
       }
   } else {  /* Not transposed */

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -264,7 +264,7 @@
   cname: SpatialFullDilatedConvolution
   buffers: [columns, ones]
 
-- name: thnn_conv_transpose3d(Tensor self, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, IntList[3] dilation=1)
+- name: thnn_conv_transpose3d(Tensor self, Tensor weight, IntList[3] kernel_size, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, IntList[3] dilation=1)
   cname: VolumetricFullDilatedConvolution
   buffers: [finput, fgrad_input]
 

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -251,20 +251,20 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   THArgCheck(THCTensor_(isContiguous)(state, weight), 4,
              "weight tensor has to be contiguous");
 
+  THNN_(SpatialConvolutionMM_shapeCheck)
+       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, 0);
+
   // Params
   int nInputPlane = weight->nDimension == 2 ? weight->size[1]/(kW*kH) : weight->size[1];
   int nOutputPlane = weight->size[0];
 
   int freeWeight = 0;
-  if (weight && weight->nDimension == 4) {
+  if (weight->nDimension == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
     freeWeight = 1;
   }
-
-  THNN_(SpatialConvolutionMM_shapeCheck)
-       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -6,18 +6,21 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
                          THCState *state,
                          THCTensor *input, THCTensor *gradOutput,
                          THCTensor *weight, THCTensor *bias,
-                         int kH, int kW, int dH, int dW, int padH, int padW) {
+                         int kH, int kW, int dH, int dW, int padH, int padW,
+                         int weight_nullable) {
   THArgCheck(kW > 0 && kH > 0, 9,
              "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
   THArgCheck(dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
-  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
-             "bias tensor has to be contiguous");
-  THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
-                  "2D or 4D weight tensor expected, but got: %s");
 
-  if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
+  if (weight != NULL) {
+    THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+                    "2D or 4D weight tensor expected, but got: %s");
+    if (bias != NULL) {
+      THCUNN_check_dim_size(state, bias, 1, 0, weight->size[0]);
+    }
+  } else if (!weight_nullable) {
+    THError("weight tensor is expected to be non-nullable");
   }
 
   int ndim = input->nDimension;
@@ -34,32 +37,43 @@ static inline void THNN_(SpatialConvolutionMM_shapeCheck)(
   THCUNN_argCheck(state, ndim == 3 || ndim == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane  = weight->size[1] / (kH * kW);
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
-  int64_t nOutputPlane = weight->size[0];
 
   int64_t exactInputHeight = inputHeight + 2 * padH;
   int64_t exactInputWidth = inputWidth + 2 * padW;
 
   if (exactInputHeight < kH || exactInputWidth < kW) {
-    THError("Calculated input size: (%d x %d). "
-      "Kernel size: (%d x %d). Kernel size can't greater than actual input size",
-      exactInputHeight,exactInputWidth,kH,kW);
+    THError("Calculated padded input size per channel: (%ld x %ld). "
+      "Kernel size: (%ld x %ld). Kernel size can't greater than actual input size",
+      exactInputHeight, exactInputWidth, kH, kW);
   }
 
   int64_t outputHeight = (exactInputHeight - kH) / dH + 1;
   int64_t outputWidth  = (exactInputWidth - kW) / dW + 1;
 
-  if (outputWidth < 1 || outputHeight < 1)
-      THError("Given input size: (%d x %d x %d). "
-              "Calculated output size: (%d x %d x %d). Output size is too small",
-              nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+  if (outputWidth < 1 || outputHeight < 1) {
+    THError("Given input size per channel: (%ld x %ld). "
+      "Calculated output size per channel: (%ld x %ld). Output size is too small",
+      inputHeight, inputWidth, outputHeight, outputWidth);
+  }
 
-  THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  if (weight != NULL) {
+    int64_t nInputPlane = weight->size[1];
+    if (weight->nDimension == 2) {
+      nInputPlane /= (kH * kW);
+    }
+    THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  }
 
   if (gradOutput != NULL) {
-    THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    if (weight != NULL) {
+      int64_t nOutputPlane = weight->size[0];
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    } else if (bias != NULL) {
+      int64_t nOutputPlane = bias->size[0];
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
     THCUNN_check_dim_size(state, gradOutput, ndim, dimw, outputWidth);
   }
@@ -83,6 +97,8 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   }
   THArgCheck(THCTensor_(isContiguous)(state, weight), 4,
              "weight tensor has to be contiguous");
+  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
+             "bias tensor has to be contiguous");
 
   int freeWeight = 0;
 
@@ -98,13 +114,13 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   }
 
   THNN_(SpatialConvolutionMM_shapeCheck)
-       (state, input, NULL, weight, bias, kH, kW, dH, dW, padH, padW);
+       (state, input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, 0);
 
   input = THCTensor_(newContiguous)(state, input);
-  int batch = 1;
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
   }
 
@@ -210,7 +226,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     THCTensor_(free)(state, weight);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, output, nOutputPlane, outputHeight, outputWidth);
     THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
   }
@@ -240,7 +256,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   int nOutputPlane = weight->size[0];
 
   int freeWeight = 0;
-  if (weight->nDimension == 4) {
+  if (weight && weight->nDimension == 4) {
     int64_t s1 = weight->size[0];
     int64_t s2 = weight->size[1] * weight->size[2] * weight->size[3];
     weight = THCTensor_(newWithStorage2d)(state, weight->storage, weight->storageOffset, s1, -1, s2, -1);
@@ -248,14 +264,15 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   }
 
   THNN_(SpatialConvolutionMM_shapeCheck)
-       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW);
+       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
     THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
@@ -324,7 +341,7 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
     THCTensor_(free)(state, weight);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, gradOutput, nOutputPlane, outputHeight, outputWidth);
     THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
     THCTensor_(resize3d)(state, gradInput, nInputPlane, inputHeight, inputWidth);
@@ -348,36 +365,39 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
            accreal scale_) {
 
   real scale = ScalarConvert<accreal, real>::to(scale_);
-  THCUNN_assertSameGPU(state, 5, input, gradOutput, gradWeight, columns, ones);
-  if (gradBias) {
-   THCUNN_assertSameGPU(state, 2, gradWeight, gradBias);
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, gradWeight, gradBias, columns, ones);
+  if (gradWeight) {
+    THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4, "gradWeight needs to be contiguous");
   }
-  THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4,
-             "weight tensor has to be contiguous");
+  if (gradBias) {
+    THArgCheck(THCTensor_(isContiguous)(state, gradBias), 5, "gradBias needs to be contiguous");
+    THArgCheck(THCTensor_(isContiguous)(state, ones), 7, "ones needs to be contiguous");
+  }
+
+  THNN_(SpatialConvolutionMM_shapeCheck)
+       (state, input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW, 1);
 
   // Params
-  int nInputPlane = gradWeight->nDimension == 2 ? gradWeight->size[1]/(kW*kH) : gradWeight->size[1];
-  int nOutputPlane = gradWeight->size[0];
+  input = THCTensor_(newContiguous)(state, input);
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+
+  int is_batch = 1;
+  if (input->nDimension == 3) {
+    // Force batch
+    is_batch = 0;
+    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
+    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+  }
+
+  int64_t nInputPlane = input->size[1];
+  int64_t nOutputPlane = gradOutput->size[1];
 
   int freeWeight = 0;
-  if (gradWeight->nDimension == 4) {
+  if (gradWeight && gradWeight->nDimension == 4) {
     int64_t s1 = gradWeight->size[0];
     int64_t s2 = gradWeight->size[1] * gradWeight->size[2] * gradWeight->size[3];
     gradWeight = THCTensor_(newWithStorage2d)(state, gradWeight->storage, gradWeight->storageOffset, s1, -1, s2, -1);
     freeWeight = 1;
-  }
-
-  THNN_(SpatialConvolutionMM_shapeCheck)
-       (state, input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW);
-
-  input = THCTensor_(newContiguous)(state, input);
-  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
-  int batch = 1;
-  if (input->nDimension == 3) {
-    // Force batch
-    batch = 0;
-    THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
-    THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
 
   int64_t inputWidth   = input->size[3];
@@ -405,49 +425,54 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   // For each elt in batch, do:
   for (int elt = 0; elt < batchSize; elt ++) {
     // Matrix mulitply per output:
-    THCTensor_(select)(state, input_n, input, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    // Extract columns:
-    im2col(
-      THCState_getCurrentStream(state),
-      THCTensor_(data)(state, input_n),
-      nInputPlane, inputHeight, inputWidth, kH, kW, padH, padW, dH, dW,
-      1, 1, THCTensor_(data)(state, columns)
-    );
+    // Do Weight:
+    if (gradWeight) {
+      // Matrix mulitply per output:
+      THCTensor_(select)(state, input_n, input, 0, elt);
 
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m = nOutputPlane;
-    int64_t n = nInputPlane*kW*kH;
-    int64_t k = columns->size[1];
+      // Extract columns:
+      im2col(
+        THCState_getCurrentStream(state),
+        THCTensor_(data)(state, input_n),
+        nInputPlane, inputHeight, inputWidth, kH, kW, padH, padW, dH, dW,
+        1, 1, THCTensor_(data)(state, columns)
+      );
 
-    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemm(
-    #elif defined(THC_REAL_IS_HALF)
-    THCudaBlas_Hgemm(
-    #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemm(
-    #endif
-        state,
-        't', 'n',
-        n, m, k,
-        scale,
-        THCTensor_(data)(state, columns), k,
-        THCTensor_(data)(state, gradOutput_n), k,
-        ScalarConvert<int, real>::to(1),
-        THCTensor_(data)(state, gradWeight), n
-    );
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t m = nOutputPlane;
+      int64_t n = nInputPlane*kW*kH;
+      int64_t k = columns->size[1];
+
+      // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+      #ifdef THC_REAL_IS_FLOAT
+      THCudaBlas_Sgemm(
+      #elif defined(THC_REAL_IS_HALF)
+      THCudaBlas_Hgemm(
+      #elif defined(THC_REAL_IS_DOUBLE)
+      THCudaBlas_Dgemm(
+      #endif
+          state,
+          't', 'n',
+          n, m, k,
+          scale,
+          THCTensor_(data)(state, columns), k,
+          THCTensor_(data)(state, gradOutput_n), k,
+          ScalarConvert<int, real>::to(1),
+          THCTensor_(data)(state, gradWeight), n
+      );
+    }
 
     // Do Bias:
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m_ = nOutputPlane;
-    int64_t k_ = outputHeight * outputWidth;
-
-    // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t m_ = nOutputPlane;
+      int64_t k_ = outputHeight * outputWidth;
+
+      // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
       #ifdef THC_REAL_IS_FLOAT
       THCudaBlas_Sgemv(
@@ -486,7 +511,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
     THCTensor_(free)(state, gradWeight);
 
   // Resize
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, gradOutput, nOutputPlane, outputHeight, outputWidth);
     THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
   }

--- a/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialFullDilatedConvolution.cu
@@ -8,7 +8,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
                          THCTensor *weight, THCTensor *bias,
                          int kH, int kW, int dH, int dW, int padH, int padW,
                          int dilationH, int dilationW,
-                         int adjH, int adjW) {
+                         int adjH, int adjW, int weight_nullable) {
   THArgCheck(kW > 0 && kH > 0, 9,
              "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
   THArgCheck(dW > 0 && dH > 0, 11,
@@ -19,15 +19,15 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THArgCheck((adjW < dW || adjW < dilationW) && (adjH < dH || adjH < dilationH), 15,
              "output padding must be smaller than either stride or dilation, but got adjH: %d adjW: %d dH: %d dW: %d dilationH: %d dilationW: %d",
              adjH, adjW, dH, dW, dilationH, dilationW);
-  THArgCheck(THCTensor_(isContiguous)(state, weight), 4,
-             "weight tensor has to be contiguous");
-  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
-             "bias tensor has to be contiguous");
-  THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
-                  "2D or 4D weight tensor expected, but got: %s");
 
-  if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size[1]);
+  if (weight != NULL) {
+    THCUNN_argCheck(state, weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+                    "2D or 4D weight tensor expected, but got: %s");
+    if (bias != NULL) {
+      THCUNN_check_dim_size(state, bias, 1, 0, weight->size[1]);
+    }
+  } else if (!weight_nullable) {
+    THError("weight tensor is expected to be non-nullable");
   }
 
   int ndim = input->nDimension;
@@ -44,22 +44,30 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THCUNN_argCheck(state, ndim == 3 || ndim == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane  = weight->size[0];
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
-  int64_t nOutputPlane = weight->size[1];
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
-  if (outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%d x %d x %d). "
-            "Calculated output size: (%d x %d x %d). Output size is too small",
-            nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+  if (outputWidth < 1 || outputHeight < 1) {
+    THError("Given input size per channel: (%ld x %ld). "
+      "Calculated output spatial size per channel: (%ld x %ld). Output size is too small",
+      inputHeight, inputWidth, outputHeight, outputWidth);
+  }
 
-  THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  if (weight != NULL) {
+    int64_t nInputPlane = weight->size[0];
+    THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  }
 
   if (gradOutput != NULL) {
-    THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    if (weight != NULL) {
+      int64_t nOutputPlane = weight->size[1];
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    } else if (bias != NULL) {
+      int64_t nOutputPlane = bias->size[0];
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
     THCUNN_check_dim_size(state, gradOutput, ndim, dimw, outputWidth);
   }
@@ -86,16 +94,17 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   THCUNN_assertSameGPU(state, 6, input, output, weight,
                        bias, columns, ones);
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
-       (state, input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, dilationH, dilationW, adjH, adjW);
+       (state, input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, dilationH, dilationW, adjH, adjW, 0);
 
+  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
+             "bias tensor has to be contiguous");
   input = THCTensor_(newContiguous)(state, input);
   weight = THCTensor_(newContiguous)(state, weight);
-  bias = bias ? THCTensor_(newContiguous)(state, bias) : bias;
 
-  int batch = 1;
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
   }
 
@@ -197,15 +206,13 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   THCTensor_(free)(state, output_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, output, nOutputPlane, outputHeight, outputWidth);
     THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, weight);
-  if (bias) THCTensor_(free)(state, bias);
-  
 }
 
 void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
@@ -227,15 +234,16 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                        gradColumns, gradInput);
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
-       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, dilationH, dilationW, adjH, adjW);
+       (state, input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, dilationH, dilationW, adjH, adjW, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   weight = THCTensor_(newContiguous)(state, weight);
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
     THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
@@ -298,13 +306,12 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
     );
   }
 
-
   // Free
   THCTensor_(free)(state, gradInput_n);
   THCTensor_(free)(state, gradOutput_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, gradOutput, nOutputPlane, outputHeight, outputWidth);
     THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
     THCTensor_(resize3d)(state, gradInput, nInputPlane, inputHeight, inputWidth);
@@ -332,23 +339,36 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
            accreal scale_)
 {
   real scale = ScalarConvert<accreal, real>::to(scale_);
-  int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
-  int nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
-
   THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
                        gradBias, columns, ones);
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
-       (state, input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW, dilationH, dilationW, adjH, adjW);
+       (state, input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW,
+        padH, padW, dilationH, dilationW, adjH, adjW, 1);
 
-  THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4, "gradWeight needs to be contiguous");
-  if (gradBias)
+  int nOutputPlane;
+  if (gradWeight != NULL) {
+    nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
+  } else if (gradBias != NULL) {
+    nOutputPlane = THCTensor_(size)(state, gradBias, 0);
+  } else {
+    return;
+  }
+
+  if (gradWeight) {
+    THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4, "gradWeight needs to be contiguous");
+  }
+  THArgCheck(THCTensor_(isContiguous)(state, columns), 6, "columns needs to be contiguous");
+  if (gradBias) {
     THArgCheck(THCTensor_(isContiguous)(state, gradBias), 5, "gradBias needs to be contiguous");
+    THArgCheck(THCTensor_(isContiguous)(state, ones), 7, "ones needs to be contiguous");
+  }
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
     THCTensor_(resize4d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
@@ -378,49 +398,54 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   // For each elt in batch, do:
   for (int elt = 0; elt < batchSize; elt ++) {
     // Matrix mulitply per output:
-    THCTensor_(select)(state, input_n, input, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    // Extract columns:
-    im2col(
-      THCState_getCurrentStream(state),
-      THCTensor_(data)(state, gradOutput_n),
-      nOutputPlane, outputHeight, outputWidth, kH, kW, padH, padW, dH, dW,
-      dilationH, dilationW, THCTensor_(data)(state, columns)
-    );
+    // Do Weight:
+    if (gradWeight) {
+      // Matrix mulitply per output:
+      THCTensor_(select)(state, input_n, input, 0, elt);
 
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t n = columns->size[0];   // nOutputPlane * kh * kw
-    int64_t m = input_n->size[0];   // nInputPlane
-    int64_t k = columns->size[1];   // inputHeight * inputWidth
+      // Extract columns:
+      im2col(
+        THCState_getCurrentStream(state),
+        THCTensor_(data)(state, gradOutput_n),
+        nOutputPlane, outputHeight, outputWidth, kH, kW, padH, padW, dH, dW,
+        dilationH, dilationW, THCTensor_(data)(state, columns)
+      );
 
-    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemm(
-    #elif defined(THC_REAL_IS_HALF)
-    THCudaBlas_Hgemm(
-    #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemm(
-    #endif
-        state,
-        't', 'n',
-        n, m, k,
-        scale,
-        THCTensor_(data)(state, columns), k,
-        THCTensor_(data)(state, input_n), k,
-        ScalarConvert<int, real>::to(1),
-        THCTensor_(data)(state, gradWeight), n
-    );
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t n = columns->size[0];   // nOutputPlane * kh * kw
+      int64_t m = input_n->size[0];   // nInputPlane
+      int64_t k = columns->size[1];   // inputHeight * inputWidth
+
+      // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+      #ifdef THC_REAL_IS_FLOAT
+      THCudaBlas_Sgemm(
+      #elif defined(THC_REAL_IS_HALF)
+      THCudaBlas_Hgemm(
+      #elif defined(THC_REAL_IS_DOUBLE)
+      THCudaBlas_Dgemm(
+      #endif
+          state,
+          't', 'n',
+          n, m, k,
+          scale,
+          THCTensor_(data)(state, columns), k,
+          THCTensor_(data)(state, input_n), k,
+          ScalarConvert<int, real>::to(1),
+          THCTensor_(data)(state, gradWeight), n
+      );
+    }
 
     // Do Bias:
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m_ = nOutputPlane;
-    int64_t k_ = outputHeight * outputWidth;
-
-    // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t m_ = nOutputPlane;
+      int64_t k_ = outputHeight * outputWidth;
+
+      // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
       #ifdef THC_REAL_IS_FLOAT
       THCudaBlas_Sgemv(
@@ -457,9 +482,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   THCTensor_(free)(state, gradOutput_n);
 
   // Resize
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize3d)(state, gradOutput, nOutputPlane, outputHeight, outputWidth);
-    THCTensor_(resize3d)(state, input, nInputPlane, inputHeight, inputWidth);
+    THCTensor_(resize3d)(state, input, input->size[1], inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -1456,6 +1456,7 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
                   THCTensor  *bias,        // [OPTIONAL]
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int dilationT, int dilationW, int dilationH,
@@ -1469,6 +1470,7 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
                   THCTensor  *weight,
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int dilationT, int dilationW, int dilationH,
@@ -1478,10 +1480,11 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
                   THCState *state,
                   THCTensor  *input,
                   THCTensor  *gradOutput,
-                  THCTensor  *gradWeight,
+                  THCTensor  *gradWeight,  // [OPTIONAL]
                   THCTensor  *gradBias,    // [OPTIONAL]
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int dilationT, int dilationW, int dilationH,
@@ -1537,6 +1540,7 @@ TH_API void THNN_(VolumetricFullConvolution_updateOutput)(
                   THCTensor  *bias,        // [OPTIONAL]
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int adjT, int adjW, int adjH);
@@ -1549,6 +1553,7 @@ TH_API void THNN_(VolumetricFullConvolution_updateGradInput)(
                   THCTensor  *weight,
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int adjT, int adjW, int adjH);
@@ -1557,10 +1562,11 @@ TH_API void THNN_(VolumetricFullConvolution_accGradParameters)(
                   THCState *state,
                   THCTensor  *input,
                   THCTensor  *gradOutput,
-                  THCTensor  *gradWeight,
+                  THCTensor  *gradWeight,  // [OPTIONAL]
                   THCTensor  *gradBias,    // [OPTIONAL]
                   THCTensor  *finput,
                   THCTensor  *fgradInput,
+                  int kT, int kW, int kH,
                   int dT, int dW, int dH,
                   int padT, int padW, int padH,
                   int adjT, int adjW, int adjH,

--- a/aten/src/THCUNN/generic/VolumetricFullConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricFullConvolution.cu
@@ -10,13 +10,14 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
        THCTensor  *bias,
        THCTensor  *finput,
        THCTensor  *fgradInput,
+       int kT, int kW, int kH,
        int dT, int dW, int dH,
        int padT, int padW, int padH,
        int adjT, int adjW, int adjH)
 {
   THNN_(VolumetricFullDilatedConvolution_updateOutput)(
        state, input, output, weight, bias, finput, fgradInput,
-       dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH);
+       kT, kW, kH, dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH);
 }
 
 void THNN_(VolumetricFullConvolution_updateGradInput)(
@@ -27,13 +28,14 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
        THCTensor  *weight,
        THCTensor  *finput,
        THCTensor  *fgradInput,
+       int kT, int kW, int kH,
        int dT, int dW, int dH,
        int padT, int padW, int padH,
        int adjT, int adjW, int adjH)
 {
   THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
        state, input, gradOutput, gradInput, weight, finput, fgradInput,
-       dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH);
+       kT, kW, kH, dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH);
 }
 
 
@@ -45,6 +47,7 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
            THCTensor  *gradBias,
            THCTensor  *finput,
            THCTensor  *fgradInput,
+           int kT, int kW, int kH,
            int dT, int dW, int dH,
            int padT, int padW, int padH,
            int adjT, int adjW, int adjH,
@@ -52,7 +55,7 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
 {
   THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
        state, input, gradOutput, gradWeight, gradBias, finput, fgradInput,
-       dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH, scale_);
+       kT, kW, kH, dT, dW, dH, padT, padW, padH, 1, 1, 1, adjT, adjW, adjH, scale_);
 }
 
 #endif

--- a/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
+++ b/aten/src/THCUNN/generic/VolumetricFullDilatedConvolution.cu
@@ -8,20 +8,13 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
                THCTensor *gradOutput,
                THCTensor *weight,
                THCTensor *bias,
+               int kT, int kW, int kH,
                int dT, int dW, int dH,
                int padT, int padW, int padH,
                int dilationT, int dilationW, int dilationH,
-               int adjT, int adjW, int adjH) {
+               int adjT, int adjW, int adjH, int weight_nullable) {
   THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
             "4D or 5D (batch mode) tensor expected for input, but got: %s");
-   // number of input & output planes and kernel size is indirectly defined by the weight tensor
-  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
-            "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
-            "expected for weight, but got: %s");
-  THArgCheck(THCTensor_(isContiguous)(state, weight), 4,
-         "weight tensor has to be contiguous");
-  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
-         "bias tensor has to be contiguous");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 8,
          "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
   THArgCheck(dilationT > 0 && dilationW > 0 && dilationH > 0, 15,
@@ -35,17 +28,19 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
              "dilationT: %d dilationH: %d dilationW: %d",
              adjT, adjH, adjW, dT, dH, dW, dilationT, dilationH, dilationW);
 
-  int ndim = input->nDimension;
-  int nInputPlane = THCTensor_(size)(state, weight, 0);
-  int nOutputPlane = THCTensor_(size)(state, weight, 1);
-  const int kT       = (int)weight->size[2];
-  const int kH       = (int)weight->size[3];
-  const int kW       = (int)weight->size[4];
-
-  if (bias != NULL) {
-    THCUNN_check_dim_size(state, bias, 1, 0, weight->size[1]);
+   // number of input & output planes and kernel size is indirectly defined by the weight tensor
+  if (weight != NULL) {
+    THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for weight, but got: %s");
+    if (bias != NULL) {
+      THCUNN_check_dim_size(state, bias, 1, 0, weight->size[1]);
+    }
+  } else if (!weight_nullable) {
+    THError("weight tensor is expected to be non-nullable");
   }
 
+  int ndim = input->nDimension;
   int dimf = 0;
   int dimd = 1;
   int dimh = 2;
@@ -58,19 +53,32 @@ static inline void THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
     dimw++;
   }
 
+  if (weight != NULL) {
+    const int64_t nInputPlane = THCTensor_(size)(state, weight, 0);
+    THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  }
+
   int64_t inputWidth   = input->size[dimw];
   int64_t inputHeight  = input->size[dimh];
   int64_t inputDepth  = input->size[dimd];
   int64_t outputDepth  = (inputDepth - 1) * dT - 2*padT + (dilationT * (kT - 1) + 1) + adjT;
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
-  if (outputDepth < 1 || outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%dx%dx%dx%d). Calculated output size: (%dx%dx%dx%d). Output size is too small",
-        nInputPlane,inputDepth,inputHeight,inputWidth,nOutputPlane,outputDepth,outputHeight,outputWidth);
 
-  THCUNN_check_dim_size(state, input, ndim, dimf, nInputPlane);
+  if (outputDepth < 1 || outputWidth < 1 || outputHeight < 1) {
+    THError("Given input size per channel: (%ld x %ld x %ld). "
+      "Calculated output size per channel: (%ld x %ld x %ld). Output size is too small",
+      inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
+  }
+
   if (gradOutput != NULL) {
-    THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    if (weight != NULL) {
+      const int64_t nOutputPlane = THCTensor_(size)(state, weight, 1);
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    } else if (bias != NULL) {
+      const int64_t nOutputPlane = THCTensor_(size)(state, bias, 0);
+      THCUNN_check_dim_size(state, gradOutput, ndim, dimf, nOutputPlane);
+    }
     THCUNN_check_dim_size(state, gradOutput, ndim, dimd, outputDepth);
     THCUNN_check_dim_size(state, gradOutput, ndim, dimh, outputHeight);
     THCUNN_check_dim_size(state, gradOutput, ndim, dimw, outputWidth);
@@ -85,6 +93,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
        THCTensor  *bias,
        THCTensor  *finput,
        THCTensor  *fgradInput,
+       int kT, int kW, int kH,
        int dT, int dW, int dH,
        int padT, int padW, int padH,
        int dilationT, int dilationW, int dilationH,
@@ -96,25 +105,23 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
 
   int nInputPlane = THCTensor_(size)(state, weight, 0);
   int nOutputPlane = THCTensor_(size)(state, weight, 1);
-  const int kT       = (int)weight->size[2];
-  const int kH       = (int)weight->size[3];
-  const int kW       = (int)weight->size[4];
 
   THCUNN_assertSameGPU(state, 6, input, output, weight,
                bias, columns, ones);
   THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
-      state, input, NULL, weight, bias,
+      state, input, NULL, weight, bias, kT, kW, kH,
       dT, dW, dH, padT, padW, padH, dilationT, dilationW, dilationH,
-      adjT, adjW, adjH);
+      adjT, adjW, adjH, 0);
 
+  THArgCheck(!bias || THCTensor_(isContiguous)(state, bias), 5,
+         "bias tensor has to be contiguous");
   input = THCTensor_(newContiguous)(state, input);
   weight = THCTensor_(newContiguous)(state, weight);
-  bias = bias ? THCTensor_(newContiguous)(state, bias) : bias;
 
-  int batch = 1;
+  int is_batch = 1;
   if (input->nDimension == 4) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
   }
 
@@ -221,14 +228,13 @@ void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
   THCTensor_(free)(state, output_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize4d)(state, output, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THCTensor_(resize4d)(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, weight);
-  if (bias) THCTensor_(free)(state, bias);
 
 }
 
@@ -240,6 +246,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
        THCTensor  *weight,
        THCTensor  *finput,
        THCTensor  *fgradInput,
+       int kT, int kW, int kH,
        int dT, int dW, int dH,
        int padT, int padW, int padH,
        int dilationT, int dilationW, int dilationH,
@@ -249,25 +256,22 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
 
   int nInputPlane = THCTensor_(size)(state, weight, 0);
   int nOutputPlane = THCTensor_(size)(state, weight, 1);
-  const int kT       = (int)weight->size[2];
-  const int kH       = (int)weight->size[3];
-  const int kW       = (int)weight->size[4];
 
   THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                gradColumns, gradInput);
   THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
-      state, input, gradOutput, weight, NULL,
+      state, input, gradOutput, weight, NULL, kT, kW, kH,
       dT, dW, dH, padT, padW, padH, dilationT, dilationW, dilationH,
-      adjT, adjW, adjH);
+      adjT, adjW, adjH, 0);
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   weight = THCTensor_(newContiguous)(state, weight);
-  
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 4) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
     THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
   }
@@ -339,7 +343,7 @@ void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
   THCTensor_(free)(state, gradOutput_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize4d)(state, gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THCTensor_(resize4d)(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
     THCTensor_(resize4d)(state, gradInput, nInputPlane, inputDepth, inputHeight, inputWidth);
@@ -359,40 +363,48 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
            THCTensor  *gradBias,
            THCTensor  *finput,
            THCTensor  *fgradInput,
+           int kT, int kW, int kH,
            int dT, int dW, int dH,
            int padT, int padW, int padH,
            int dilationT, int dilationW, int dilationH,
            int adjT, int adjW, int adjH,
            accreal scale_)
 {
-  real scale = ScalarConvert<accreal, real>::to(scale_);
   THCTensor  *columns = finput;
   THCTensor  *ones = fgradInput;
 
-  int nInputPlane = THCTensor_(size)(state, gradWeight, 0);
-  int nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
-  const int kT       = (int)gradWeight->size[2];
-  const int kH       = (int)gradWeight->size[3];
-  const int kW       = (int)gradWeight->size[4];
-
+  real scale = ScalarConvert<accreal, real>::to(scale_);
   THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
                gradBias, columns, ones);
   THNN_(VolumetricFullDilatedConvolution_shapeCheck)(
-      state, input, gradOutput, gradWeight,
-      gradBias, dT, dW, dH, padT, padW, padH, dilationT, dilationW, dilationH,
-      adjT, adjW, adjH);
+      state, input, gradOutput, gradWeight, gradBias, kT, kW, kH,
+      dT, dW, dH, padT, padW, padH, dilationT, dilationW, dilationH,
+      adjT, adjW, adjH, 1);
 
-  THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4, "gradWeight needs to be contiguous");
-  if (gradBias)
+  int nOutputPlane;
+  if (gradWeight) {
+    nOutputPlane = THCTensor_(size)(state, gradWeight, 1);
+  } else if (gradBias) {
+    nOutputPlane = THCTensor_(size)(state, gradBias, 0);
+  } else {
+    return;
+  }
+
+  if (gradWeight) {
+    THArgCheck(THCTensor_(isContiguous)(state, gradWeight), 4, "gradWeight needs to be contiguous");
+  }
+  if (gradBias) {
     THArgCheck(THCTensor_(isContiguous)(state, gradBias), 5, "gradBias needs to be contiguous");
+    THArgCheck(THCTensor_(isContiguous)(state, ones), 7, "ones needs to be contiguous");
+  }
 
   input = THCTensor_(newContiguous)(state, input);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
 
-  int batch = 1;
+  int is_batch = 1;
   if (input->nDimension == 4) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THCTensor_(resize5d)(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
     THCTensor_(resize5d)(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
   }
@@ -424,50 +436,55 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   // For each elt in batch, do:
   for (int elt = 0; elt < batchSize; elt ++) {
     // Matrix mulitply per output:
-    THCTensor_(select)(state, input_n, input, 0, elt);
     THCTensor_(select)(state, gradOutput_n, gradOutput, 0, elt);
 
-    // Extract columns:
-    vol2col(
-      THCState_getCurrentStream(state),
-      THCTensor_(data)(state, gradOutput_n),
-      nOutputPlane, outputDepth, outputHeight, outputWidth, kT, kH, kW, padT, padH, padW, dT, dH, dW,
-      dilationT, dilationH, dilationW,
-      THCTensor_(data)(state, columns)
-    );
+    // Do Weight:
+    if (gradWeight) {
+      // Matrix mulitply per output:
+      THCTensor_(select)(state, input_n, input, 0, elt);
 
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t n = columns->size[0];   // nOutputPlane * kt * kh * kw
-    int64_t m = input_n->size[0];   // nInputPlane
-    int64_t k = columns->size[1];   // inputHeight * inputWidth
+      // Extract columns:
+      vol2col(
+        THCState_getCurrentStream(state),
+        THCTensor_(data)(state, gradOutput_n),
+        nOutputPlane, outputDepth, outputHeight, outputWidth, kT, kH, kW, padT, padH, padW, dT, dH, dW,
+        dilationT, dilationH, dilationW,
+        THCTensor_(data)(state, columns)
+      );
 
-    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    #ifdef THC_REAL_IS_FLOAT
-    THCudaBlas_Sgemm(
-    #elif defined(THC_REAL_IS_HALF)
-    THCudaBlas_Hgemm(
-    #elif defined(THC_REAL_IS_DOUBLE)
-    THCudaBlas_Dgemm(
-    #endif
-      state,
-      't', 'n',
-      n, m, k,
-      scale,
-      THCTensor_(data)(state, columns), k,
-      THCTensor_(data)(state, input_n), k,
-      ScalarConvert<int, real>::to(1),
-      THCTensor_(data)(state, gradWeight), n
-    );
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t n = columns->size[0];   // nOutputPlane * kt * kh * kw
+      int64_t m = input_n->size[0];   // nInputPlane
+      int64_t k = columns->size[1];   // inputHeight * inputWidth
+
+      // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+      #ifdef THC_REAL_IS_FLOAT
+      THCudaBlas_Sgemm(
+      #elif defined(THC_REAL_IS_HALF)
+      THCudaBlas_Hgemm(
+      #elif defined(THC_REAL_IS_DOUBLE)
+      THCudaBlas_Dgemm(
+      #endif
+        state,
+        't', 'n',
+        n, m, k,
+        scale,
+        THCTensor_(data)(state, columns), k,
+        THCTensor_(data)(state, input_n), k,
+        ScalarConvert<int, real>::to(1),
+        THCTensor_(data)(state, gradWeight), n
+      );
+    }
 
     // Do Bias:
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m_ = nOutputPlane;
-    int64_t k_ = outputDepth * outputHeight * outputWidth;
-
-    // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t m_ = nOutputPlane;
+      int64_t k_ = outputDepth * outputHeight * outputWidth;
+
+      // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
       #ifdef THC_REAL_IS_FLOAT
       THCudaBlas_Sgemv(
@@ -504,9 +521,9 @@ void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
   THCTensor_(free)(state, gradOutput_n);
 
   // Resize
-  if (batch == 0) {
+  if (is_batch == 0) {
     THCTensor_(resize4d)(state, gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
-    THCTensor_(resize4d)(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
+    THCTensor_(resize4d)(state, input, input->size[1], inputDepth, inputHeight, inputWidth);
   }
 
   THCTensor_(free)(state, input);

--- a/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
+++ b/aten/src/THNN/generic/SpatialFullDilatedConvolution.c
@@ -6,7 +6,7 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
 	THTensor *input, THTensor *gradOutput,
 	THTensor *weight, THTensor *bias,
 	int kH, int kW, int dH, int dW, int padH, int padW,
-	int dilationH, int dilationW, int adjH, int adjW) {
+	int dilationH, int dilationW, int adjH, int adjW, int weight_nullable) {
 
   THArgCheck(kW > 0 && kH > 0, 9,
              "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
@@ -18,11 +18,15 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THArgCheck((adjW < dW || adjW < dilationW) && (adjH < dH || adjH < dilationH), 15,
              "output padding must be smaller than either stride or dilation, but got adjH: %d adjW: %d dH: %d dW: %d dilationH: %d dilationW: %d",
              adjH, adjW, dH, dW, dilationH, dilationW);
-  THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
-		"2D or 4D weight tensor expected, but got: %s");
 
-  if (bias != NULL) {
-    THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
+  if (weight != NULL) {
+    THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+  		"2D or 4D weight tensor expected, but got: %s");
+    if (bias != NULL) {
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
+    }
+  } else if (!weight_nullable) {
+    THError("weight tensor is expected to be non-nullable");
   }
 
   int ndim = input->nDimension;
@@ -39,22 +43,30 @@ static inline void THNN_(SpatialFullDilatedConvolution_shapeCheck)(
   THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
 		"3D or 4D input tensor expected but got: %s");
 
-  int64_t nInputPlane  = weight->size[0];
   int64_t inputHeight  = input->size[dimh];
   int64_t inputWidth   = input->size[dimw];
-  int64_t nOutputPlane = weight->size[1];
   int64_t outputHeight = (inputHeight - 1) * dH - 2*padH + (dilationH * (kH - 1) + 1) + adjH;
   int64_t outputWidth  = (inputWidth - 1) * dW - 2*padW + (dilationW * (kW - 1) + 1) + adjW;
 
-  if (outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%d x %d x %d). "
-	    "Calculated output size: (%d x %d x %d). Output size is too small",
-	    nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+  if (outputWidth < 1 || outputHeight < 1) {
+    THError("Given input size per channel: (%ld x %ld). "
+	    "Calculated output size per channel: (%ld x %ld). Output size is too small",
+	    inputHeight, inputWidth, outputHeight, outputWidth);
+  }
 
-  THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
+  if (weight != NULL) {
+    int64_t nInputPlane = weight->size[0];
+    THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
+  }
 
   if (gradOutput != NULL) {
-    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    if (weight != NULL) {
+      int64_t nOutputPlane = weight->size[1];
+      THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    } else if (bias != NULL) {
+      int64_t nOutputPlane = bias->size[0];
+      THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimw, outputWidth);
   }
@@ -76,7 +88,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
 {
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
     (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW,
-     dilationH, dilationW, adjH, adjW);
+     dilationH, dilationW, adjH, adjW, 0);
 
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
@@ -88,10 +100,11 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
     bias = THTensor_(newContiguous)(bias);
     THArgCheck(THTensor_(isContiguous)(ones), 6, "ones needs to be contiguous");
   }
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
   }
 
@@ -181,7 +194,7 @@ void THNN_(SpatialFullDilatedConvolution_updateOutput)(
   THTensor_(free)(output_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
   }
@@ -206,7 +219,7 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
 {
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
     (input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW,
-     dilationH, dilationW, adjH, adjW);
+     dilationH, dilationW, adjH, adjW, 0);
 
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
@@ -215,10 +228,11 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
   gradOutput = THTensor_(newContiguous)(gradOutput);
   weight = THTensor_(newContiguous)(weight);
   THArgCheck(THTensor_(isContiguous)(gradColumns), 5, "gradColumns needs to be contiguous");
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
     THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
@@ -257,7 +271,6 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
       THTensor_(data)(gradColumns)
     );
 
-
     // M,N,K are dims of matrix A and B
     // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
     int64_t m = weight->size[0];
@@ -276,13 +289,12 @@ void THNN_(SpatialFullDilatedConvolution_updateGradInput)(
     );
   }
 
-
   // Free
   THTensor_(free)(gradInput_n);
   THTensor_(free)(gradOutput_n);
 
   // Resize output
-  if (batch == 0) {
+  if (is_batch == 0) {
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
     THTensor_(resize3d)(gradInput, nInputPlane, inputHeight, inputWidth);
@@ -312,23 +324,32 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
   THNN_(SpatialFullDilatedConvolution_shapeCheck)
     (input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW,
-     dilationH, dilationW, adjH, adjW);
+     dilationH, dilationW, adjH, adjW, 1);
 
-  int nInputPlane = THTensor_(size)(gradWeight,0);
-  int nOutputPlane = THTensor_(size)(gradWeight,1);
+  int nOutputPlane;
+  if (gradWeight) {
+    nOutputPlane = THTensor_(size)(gradWeight, 1);
+  } else if (gradBias) {
+    nOutputPlane = THTensor_(size)(gradBias, 0);
+  } else {
+    return;
+  }
 
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
-  THArgCheck(THTensor_(isContiguous)(gradWeight), 4, "gradWeight needs to be contiguous");
+  if (gradWeight) {
+    THArgCheck(THTensor_(isContiguous)(gradWeight), 4, "gradWeight needs to be contiguous");
+  }
   THArgCheck(THTensor_(isContiguous)(columns), 6, "columns needs to be contiguous");
   if (gradBias) {
     THArgCheck(THTensor_(isContiguous)(gradBias), 5, "gradBias needs to be contiguous");
     THArgCheck(THTensor_(isContiguous)(ones), 7, "ones needs to be contiguous");
   }
-  int batch = 1;
+
+  int is_batch = 1;
   if (input->nDimension == 3) {
     // Force batch
-    batch = 0;
+    is_batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
     THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
   }
@@ -359,43 +380,47 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   // For each elt in batch, do:
   for (elt = 0; elt < batchSize; elt ++) {
     // Matrix mulitply per output:
-    THTensor_(select)(input_n, input, 0, elt);
     THTensor_(select)(gradOutput_n, gradOutput, 0, elt);
 
-    // Extract columns:
-    THNN_(im2col)(
-      THTensor_(data)(gradOutput_n),
-      nOutputPlane, outputHeight, outputWidth, kH, kW, padH, padW, dH, dW,
-      dilationH, dilationW,
-      THTensor_(data)(columns)
-    );
+    // Do Weight:
+    if (gradWeight) {
+      // Matrix mulitply per output:
+      THTensor_(select)(input_n, input, 0, elt);
 
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t n = columns->size[0];   // nOutputPlane * kh * kw
-    int64_t m = input_n->size[0];   // nInputPlane
-    int64_t k = columns->size[1];   // inputHeight * inputWidth
+      // Extract columns:
+      THNN_(im2col)(
+        THTensor_(data)(gradOutput_n),
+        nOutputPlane, outputHeight, outputWidth, kH, kW, padH, padW, dH, dW,
+        dilationH, dilationW,
+        THTensor_(data)(columns)
+      );
 
-    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THBlas_(gemm)(
-        't', 'n',
-        n, m, k,
-        scale,
-        THTensor_(data)(columns), k,
-        THTensor_(data)(input_n), k,
-        1,
-        THTensor_(data)(gradWeight), n
-    );
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t n = columns->size[0];   // nOutputPlane * kh * kw
+      int64_t m = input_n->size[0];   // nInputPlane
+      int64_t k = columns->size[1];   // inputHeight * inputWidth
 
+      // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+      THBlas_(gemm)(
+          't', 'n',
+          n, m, k,
+          scale,
+          THTensor_(data)(columns), k,
+          THTensor_(data)(input_n), k,
+          1,
+          THTensor_(data)(gradWeight), n
+      );
+    }
 
     // Do Bias:
-    // M,N,K are dims of matrix A and B
-    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
-    int64_t m_ = nOutputPlane;
-    int64_t k_ = outputHeight * outputWidth;
-
-    // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
+      // M,N,K are dims of matrix A and B
+      // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+      int64_t m_ = nOutputPlane;
+      int64_t k_ = outputHeight * outputWidth;
+
+      // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
       THBlas_(gemv)(
           't',
           k_, m_,
@@ -413,9 +438,9 @@ void THNN_(SpatialFullDilatedConvolution_accGradParameters)(
   THTensor_(free)(gradOutput_n);
 
   // Resize
-  if (batch == 0) {
+  if (is_batch == 0) {
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
-    THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
+    THTensor_(resize3d)(input, input->size[1], inputHeight, inputWidth);
   }
 
   THTensor_(free)(input);

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -1406,6 +1406,7 @@ TH_API void THNN_(VolumetricFullConvolution_updateOutput)(
           THTensor *bias,           // [OPTIONAL] gradBias tensor (nOutputPlane)
           THTensor *finput,         // [OUT] internal columns buffer
           THTensor *fgradInput,     // [OUT] internal ones buffer
+          int kT, int kW, int kH,   // kenerl size
           int dT, int dW, int dH,   // stride of the convolution
           int pT, int pW, int pH,   // padding
           int aT, int aW, int aH);  // extra output adjustment
@@ -1417,6 +1418,7 @@ TH_API void THNN_(VolumetricFullConvolution_updateGradInput)(
           THTensor *weight,         // weight tensor (nInputPlane x nOutputPlane x kT x kH x kW)
           THTensor *finput,         // internal columns buffer
           THTensor *fgradInput,     // internal ones buffer
+          int kT, int kW, int kH,   // kenerl size
           int dT, int dW, int dH,   // stride
           int pT, int pW, int pH,   // padding
           int aT, int aW, int aH);  // extra output adjustment
@@ -1428,6 +1430,7 @@ TH_API void THNN_(VolumetricFullConvolution_accGradParameters)(
           THTensor *gradBias,       // [OPTIONAL] gradBias tensor (nOutputPlane)
           THTensor *finput,         // internal columns buffer
           THTensor *fgradInput,     // internal ones buffer
+          int kT, int kW, int kH,   // kenerl size
           int dT, int dW, int dH,   // stride
           int pT, int pW, int pH,   // padding
           int aT, int aW, int aH,   // extra output adjustment
@@ -1480,6 +1483,7 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_updateOutput)(
           THTensor *bias,           // [OPTIONAL] gradBias tensor (nOutputPlane)
           THTensor *finput,         // [OUT] internal columns buffer
           THTensor *fgradInput,     // [OUT] internal ones buffer
+          int kT, int kW, int kH,   // kernel size
           int dT, int dW, int dH,   // stride of the convolution
           int pT, int pW, int pH,   // padding
           int dilationT, int dilationW, int dilationH,
@@ -1492,6 +1496,7 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
           THTensor *weight,         // weight tensor (nInputPlane x nOutputPlane x kT x kH x kW)
           THTensor *finput,         // internal columns buffer
           THTensor *fgradInput,     // internal ones buffer
+          int kT, int kW, int kH,   // kernel size
           int dT, int dW, int dH,   // stride
           int pT, int pW, int pH,   // padding
           int dilationT, int dilationW, int dilationH,
@@ -1505,6 +1510,7 @@ TH_API void THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
           THTensor *gradBias,       // [OPTIONAL] gradBias tensor (nOutputPlane)
           THTensor *finput,         // internal columns buffer
           THTensor *fgradInput,     // internal ones buffer
+          int kT, int kW, int kH,   // kernel size
           int dT, int dW, int dH,   // stride
           int pT, int pW, int pH,   // padding
           int dilationT, int dilationW, int dilationH,

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -16,13 +16,24 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
                          int dH,
                          int pT,
                          int pW,
-                         int pH) {
+                         int pH,
+                         int weight_nullable) {
   THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
                 "4D or 5D (batch mode) tensor expected for input, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8,
              "kernel size should be greater than zero, but got kT: %d kH: %d kW: %d", kT, kH, kW);
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 11,
              "stride should be greater than zero, but got dT: %d dH: %d dW: %d", dT, dH, dW);
+
+  if (weight != NULL) {
+    THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 5, 5, weight,
+                    "2D or 5D weight tensor expected, but got: %s");
+    if (bias != NULL) {
+      THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+    }
+  } else if (!weight_nullable) {
+    THError("weight tensor is expected to be non-nullable");
+  }
 
   int ndim = input->nDimension;
   int dimf = 0;
@@ -38,11 +49,9 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
     dimw++;
   }
 
-  int64_t nInputPlane;
   int64_t inputDepth;
   int64_t inputHeight;
   int64_t inputWidth;
-  int64_t nOutputPlane;
 
   int64_t exactInputDepth;
   int64_t exactInputHeight;
@@ -51,53 +60,54 @@ static void inline THNN_(VolumetricConvolutionMM_shapeCheck)(
   int64_t outputHeight;
   int64_t outputWidth;
 
-  nInputPlane = input->size[dimf];
   inputDepth = input->size[dimt];
   inputHeight  = input->size[dimh];
   inputWidth   = input->size[dimw];
-  nOutputPlane = weight->size[0];
 
   exactInputDepth = inputDepth + 2*pT;
   exactInputHeight = inputHeight + 2*pH;
   exactInputWidth = inputWidth + 2*pW;
 
   if (exactInputDepth < kT || exactInputHeight < kH || exactInputWidth < kW) {
-    THError("Calculated input size: (%d x %d x %d). "
-      "Kernel size: (%d x %d x %d). Kernel size can't greater than actual input size",
-      exactInputDepth,exactInputHeight,exactInputWidth,kT,kH,kW);
+    THError("Calculated padded input size per channel: (%ld x %ld x %ld). "
+      "Kernel size: (%ld x %ld x %ld). Kernel size can't greater than actual input size",
+      exactInputDepth, exactInputHeight, exactInputWidth, kT, kH, kW);
   }
 
   outputDepth  = (exactInputDepth - kT) / dT + 1;
   outputHeight = (exactInputHeight - kH) / dH + 1;
   outputWidth  = (exactInputWidth - kW) / dW + 1;
 
-  if (outputWidth < 1 || outputHeight < 1 || outputDepth < 1)
-  {
-    THError(
-      "Given input size: (%dx%dx%dx%d). Calculated output size: (%dx%dx%dx%d). Output size is too small",
-      nInputPlane, inputDepth, inputHeight, inputWidth,
-      nOutputPlane, outputDepth, outputHeight, outputWidth
-    );
+
+  if (outputDepth < 1 || outputWidth < 1 || outputHeight < 1) {
+    THError("Given input size per channel: (%ld x %ld x %ld). "
+      "Calculated output size per channel: (%ld x %ld x %ld). Output size is too small",
+      inputDepth, inputHeight, inputWidth, outputDepth, outputHeight, outputWidth);
   }
 
-  THArgCheck(weight->nDimension == 2 || weight->nDimension == 5, 4,
-             "weight tensor should be 2D or 5D - got %d", weight->nDimension);
-
-  if (bias != NULL) {
-    THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+  if (weight != NULL) {
+    int64_t nInputPlane = weight->size[1];
+    if (weight->nDimension == 2) {
+      nInputPlane /= (kT * kH * kW);
+    }
+    THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
   }
-
-  THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
 
   if (gradOutput != NULL) {
-    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    if (weight != NULL) {
+      int64_t nOutputPlane = weight->size[0];
+      THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    } else if (bias != NULL) {
+      int64_t nOutputPlane = bias->size[0];
+      THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    }
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimt, outputDepth);
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
     THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimw, outputWidth);
   }
 }
 
-static THTensor* THNN_(view_weight)(THTensor *weight)
+static THTensor* THNN_(newViewWeight)(THTensor *weight)
 {
   weight = THTensor_(newContiguous)(weight);
   if (weight->nDimension == 5) {
@@ -371,7 +381,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
 
   THNN_(VolumetricConvolutionMM_shapeCheck)(
         state, input, NULL, weight, bias,
-        kT, kW, kH, dT, dW, dH, pT, pW, pH);
+        kT, kW, kH, dT, dW, dH, pT, pW, pH, 0);
   input = THTensor_(newContiguous)(input);
 
   if (input->nDimension == 5)
@@ -391,7 +401,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
   outputHeight = (inputHeight + 2*pH - kH) / dH + 1;
   outputWidth  = (inputWidth + 2*pW - kW) / dW + 1;
 
-  weight = THNN_(view_weight)(weight);
+  weight = THNN_(newViewWeight)(weight);
 
   if (input->nDimension == 4)
   {
@@ -499,11 +509,11 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
 
   THNN_(VolumetricConvolutionMM_shapeCheck)(
         state, input, gradOutput, weight, NULL,
-        kT, kW, kH, dT, dW, dH, pT, pW, pH);
+        kT, kW, kH, dT, dW, dH, pT, pW, pH, 0);
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
-  weight = THNN_(view_weight)(weight);
+  weight = THNN_(newViewWeight)(weight);
 
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(resizeAs)(fgradInput, finput);
@@ -558,7 +568,7 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
           THTensor *gradOutput,
           THTensor *gradWeight,
           THTensor *gradBias,
-          THTensor *finput,
+          THTensor *finput,  // can be NULL if gradWeight = NULL
           real scale)
 {
   int64_t i;
@@ -568,10 +578,12 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
     gradOutput->size[1]*gradOutput->size[2]*gradOutput->size[3], -1
   );
 
-  THTensor *tfinput = THTensor_(new)();
-  THTensor_(transpose)(tfinput, finput, 0, 1);
-  THTensor_(addmm)(gradWeight, 1, gradWeight, scale, gradOutput2d, tfinput);
-  THTensor_(free)(tfinput);
+  if (gradWeight){
+    THTensor *tfinput = THTensor_(new)();
+    THTensor_(transpose)(tfinput, finput, 0, 1);
+    THTensor_(addmm)(gradWeight, 1, gradWeight, scale, gradOutput2d, tfinput);
+    THTensor_(free)(tfinput);
+  }
 
   if (gradBias) {
     for (i = 0; i < gradBias->size[0]; i++)
@@ -607,11 +619,13 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
 
   THNN_(VolumetricConvolutionMM_shapeCheck)(
         state, input, gradOutput, gradWeight, gradBias,
-        kT, kW, kH, dT, dW, dH, pT, pW, pH);
+        kT, kW, kH, dT, dW, dH, pT, pW, pH, 1);
   input = THTensor_(newContiguous)(input);
   gradOutput = THTensor_(newContiguous)(gradOutput);
 
-  gradWeight = THNN_(view_weight)(gradWeight);
+  if (gradWeight) {
+    gradWeight = THNN_(newViewWeight)(gradWeight);
+  }
 
   if (input->nDimension == 4)   // non-batch mode
   {
@@ -625,18 +639,25 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
     for (t = 0; t < T; t++)
     {
       THTensor *gradOutput_t = THTensor_(newSelect)(gradOutput, 0, t);
-      THTensor *finput_t = THTensor_(newSelect)(finput, 0, t);
+      THTensor *finput_t = NULL;
+      if (gradWeight) {
+        finput_t = THTensor_(newSelect)(finput, 0, t);
+      }
 
       THNN_(VolumetricConvolutionMM_accGradParameters_frame)(gradOutput_t, gradWeight, gradBias, finput_t, scale);
 
       THTensor_(free)(gradOutput_t);
-      THTensor_(free)(finput_t);
+      if (gradWeight) {
+        THTensor_(free)(finput_t);
+      }
     }
   }
 
   THTensor_(free)(input);
   THTensor_(free)(gradOutput);
-  THTensor_(free)(gradWeight);
+  if (gradWeight) {
+    THTensor_(free)(gradWeight);
+  }
 }
 
 #endif

--- a/aten/src/THNN/generic/VolumetricFullConvolution.c
+++ b/aten/src/THNN/generic/VolumetricFullConvolution.c
@@ -10,13 +10,14 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
   THTensor *bias,
   THTensor *finput,         // internal columns buffer
   THTensor *fgradInput,     // internal ones buffer
+  int kT, int kW, int kH,   // kenerl size
   int dT, int dW, int dH,   // stride of the convolution
   int pT, int pW, int pH,   // padding
   int aT, int aW, int aH)   // extra output adjustment
 {
   THNN_(VolumetricFullDilatedConvolution_updateOutput)(
       state, input, output, weight, bias, finput, fgradInput,
-      dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH);
+      kT, kW, kH, dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH);
 }
 
 void THNN_(VolumetricFullConvolution_updateGradInput)(
@@ -27,13 +28,14 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
   THTensor *weight,
   THTensor *finput,
   THTensor *fgradInput,     // only used by cuda impl
+  int kT, int kW, int kH,   // kenerl size
   int dT, int dW, int dH,   // stride
   int pT, int pW, int pH,   // padding
   int aT, int aW, int aH)   // extra output adjustment
 {
   THNN_(VolumetricFullDilatedConvolution_updateGradInput)(
       state, input, gradOutput, gradInput, weight, finput, fgradInput,
-      dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH);
+      kT, kW, kH, dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH);
 }
 
 void THNN_(VolumetricFullConvolution_accGradParameters)(
@@ -44,6 +46,7 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
   THTensor *gradBias,
   THTensor *finput,
   THTensor *fgradInput,
+  int kT, int kW, int kH,   // kenerl size
   int dT, int dW, int dH,   // stride
   int pT, int pW, int pH,   // padding
   int aT, int aW, int aH,   // extra output adjustment
@@ -51,7 +54,7 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
 {
   THNN_(VolumetricFullDilatedConvolution_accGradParameters)(
       state, input, gradOutput, gradWeight, gradBias, finput, fgradInput,
-      dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH, scale_);
+      kT, kW, kH, dT, dW, dH, pT, pW, pH, 1, 1, 1, aT, aW, aH, scale_);
 }
 
 #endif

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -816,10 +816,10 @@
 - name: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
-- name: thnn_conv_transpose3d_forward(Tensor self, Tensor weight, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
-  self, weight, bias: thnn_conv_transpose3d_backward(grad, self, weight, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
+- name: thnn_conv_transpose3d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding, IntList output_padding, IntList dilation)
+  self, weight, bias: thnn_conv_transpose3d_backward(grad, self, weight, kernel_size, stride, padding, output_padding, dilation, finput, fgrad_input, grad_input_mask)
 
-- name: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
+- name: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, IntList kernel_size, IntList stride, IntList padding, IntList output_padding, IntList dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, true, output_padding, 1, false, false, false, grad_input_mask)
 
 - name: thnn_conv2d_forward(Tensor self, Tensor weight, IntList kernel_size, Tensor bias, IntList stride, IntList padding)

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -320,8 +320,8 @@ static void rebase_history(TensorList tensors, std::shared_ptr<Function> grad_fn
       if (tensor.defined()) {
         auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
         var.rebase_history(output_nr, grad_fn);
-        output_nr++;
       }
+      output_nr++;
     }
   }
 }
@@ -346,8 +346,8 @@ static void set_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
         auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
         var.get()->output_nr = output_nr;
         var.get()->_grad_fn = grad_fn;
-        output_nr++;
       }
+      output_nr++;
     }
   }
 }

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -182,7 +182,8 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
         for j, (a, n) in enumerate(zip(analytical, numerical)):
             if a.numel() != 0 or n.numel() != 0:
                 if not ((a - n).abs() <= (atol + rtol * n.abs())).all():
-                    return fail_test('for output no. %d,\n numerical:%s\nanalytical:%s\n' % (j, numerical, analytical))
+                    return fail_test('Jacobian mismatch for output %d with respect to input %d,\n'
+                                     'numerical:%s\nanalytical:%s\n' % (i, j, n, a))
 
         if not reentrant:
             return fail_test('not reentrant')
@@ -207,7 +208,8 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     return True
 
 
-def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3, gen_non_contig_grad_outputs=False):
+def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-3,
+                  gen_non_contig_grad_outputs=False, raise_exception=True):
     """Check gradients of gradients computed via small finite differences
        against analytical gradients
     This function checks that backpropagating through the gradients computed
@@ -228,6 +230,12 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         eps (float, optional): perturbation for finite differences
         atol (float, optional): absolute tolerance
         rtol (float, optional): relative tolerance
+        gen_non_contig_grad_outputs (bool, optional): if :attr:`grad_outputs` is
+            ``None`` and :attr:`gen_non_contig_grad_outputs` is ``True``, the
+            randomly generated gradient outputs are made to be noncontiguous
+        raise_exception: bool indicating whether to raise an exception if
+            gradcheck fails. The exception gives more information about the
+            exact nature of the failure. This is helpful when debugging gradchecks.
 
     Returns:
         True if all differences satisfy allclose condition. Raises an exception
@@ -253,4 +261,4 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         grad_inputs = torch.autograd.grad(outputs, input_args, grad_outputs, create_graph=True)
         return grad_inputs
 
-    return gradcheck(new_func, inputs + grad_outputs, eps, atol, rtol)
+    return gradcheck(new_func, inputs + grad_outputs, eps, atol, rtol, raise_exception)

--- a/torch/legacy/nn/VolumetricFullConvolution.py
+++ b/torch/legacy/nn/VolumetricFullConvolution.py
@@ -102,6 +102,7 @@ class VolumetricFullConvolution(Module):
             self.bias,
             self.finput,
             self.fgradInput,
+            self.kT, self.kW, self.kH,
             self.dT, self.dW, self.dH,
             self.padT, self.padW, self.padH,
             adjT, adjW, adjH
@@ -138,6 +139,7 @@ class VolumetricFullConvolution(Module):
             self.weight,
             self.finput,
             self.fgradInput,
+            self.kT, self.kW, self.kH,
             self.dT, self.dW, self.dH,
             self.padT, self.padW, self.padH,
             adjT, adjW, adjH
@@ -179,6 +181,7 @@ class VolumetricFullConvolution(Module):
             self.gradBias,
             self.finput,
             self.fgradInput,
+            self.kT, self.kW, self.kH,
             self.dT, self.dW, self.dH,
             self.padT, self.padW, self.padH,
             adjT, adjW, adjH,


### PR DESCRIPTION
`output_nr` is not incremented properly in `rebase_history` and `set_history` when some tensors are undefined. This causes the autograd engine incorrectly putting input tensors at wrong indices in `InputBuffer`. See the following extremely simple double backward example that reproduces the bug:

```
import torch
import torch.nn as nn
from torch.autograd import Variable, grad

conv = nn.Conv2d(1, 10, 5)
input = Variable(torch.randn(1,1,32,32))
loss1 = conv(input).sum()
grad_bias, = grad(loss1, conv.bias, create_graph=True)
loss2 = grad_bias.sum()
loss2.backward()
```
Because `input` doesn't require gradient, the `ggW` and `ggb` terms are set to incorrect indices, and it throws this weird error message: 
```
RuntimeError: Expected 1-dimensional input for 1-dimensional weight [10], but got 
input of size [1, 1, 32, 32] instead
```

Why is this not detected in our tests: our double backward tests usually sets all parameters to `requires_grad=True`. Therefore the case where a backward function call returns an undefined tensor is not tested.

An issue has been submitted on testing with more diverse configurations: https://github.com/pytorch/pytorch/issues/4813.

Thanks @ezyang for helping me finding the cause.

Relevant forum post: https://discuss.pytorch.org/t/autograd-grad-dimension-error/12083/8