### PR TITLE
[cpp-extensions] Create torch.h and update setup.py to enable C++ extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ test/data/linear.pt
 .ninja_deps
 .ninja_log
 compile_commands.json
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -349,17 +349,11 @@ class install(setuptools.command.install.install):
         if not self.skip_build:
             self.run_command('build_deps')
 
-        # Copy include directories necessary to compile C++ extensions.
-        def copy_and_overwrite(src, dst):
-            print('copying {} -> {}'.format(src, dst))
-            if os.path.exists(dst):
-                shutil.rmtree(dst)
-            shutil.copytree(src, dst)
-
-        copy_and_overwrite('torch/csrc', 'torch/lib/include/torch/csrc/')
-        copy_and_overwrite('torch/lib/pybind11/include/pybind11/',
-                           'torch/lib/include/pybind11')
-        shutil.copy2('torch/torch.h', 'torch/lib/include/torch/torch.h')
+        # Copy headers necessary to compile C++ extensions.
+        self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
+        self.copy_tree('torch/lib/pybind11/include/pybind11/',
+                       'torch/lib/include/pybind11')
+        self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
 
         setuptools.command.install.install.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -348,6 +348,19 @@ class install(setuptools.command.install.install):
     def run(self):
         if not self.skip_build:
             self.run_command('build_deps')
+
+        # Copy include directories necessary to compile C++ extensions.
+        def copy_and_overwrite(src, dst):
+            print('copying {} -> {}'.format(src, dst))
+            if os.path.exists(dst):
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+
+        copy_and_overwrite('torch/csrc', 'torch/lib/include/torch/csrc/')
+        copy_and_overwrite('torch/lib/pybind11/include/pybind11/',
+                           'torch/lib/include/pybind11')
+        shutil.copy2('torch/torch.h', 'torch/lib/include/torch/torch.h')
+
         setuptools.command.install.install.run(self)
 
 
@@ -736,20 +749,35 @@ cmdclass = {
 }
 cmdclass.update(build_dep_cmds)
 
-
 if __name__ == '__main__':
-    setup(name="torch", version=version,
-          description="Tensors and Dynamic neural networks in Python with strong GPU acceleration",
-          ext_modules=extensions,
-          cmdclass=cmdclass,
-          packages=packages,
-          package_data={'torch': [
-              'lib/*.so*', 'lib/*.dylib*', 'lib/*.dll', 'lib/*.lib',
-              'lib/torch_shm_manager',
-              'lib/*.h',
-              'lib/include/TH/*.h', 'lib/include/TH/generic/*.h',
-              'lib/include/THC/*.h', 'lib/include/THC/generic/*.h',
-              'lib/include/ATen/*.h',
-          ]},
-          install_requires=['pyyaml', 'numpy'],
-          )
+    setup(
+        name="torch",
+        version=version,
+        description=("Tensors and Dynamic neural networks in "
+                     "Python with strong GPU acceleration"),
+        ext_modules=extensions,
+        cmdclass=cmdclass,
+        packages=packages,
+        package_data={
+            'torch': [
+                'lib/*.so*',
+                'lib/*.dylib*',
+                'lib/*.dll',
+                'lib/*.lib',
+                'lib/torch_shm_manager',
+                'lib/*.h',
+                'lib/include/ATen/*.h',
+                'lib/include/pybind11/*.h',
+                'lib/include/pybind11/detail/*.h',
+                'lib/include/TH/*.h',
+                'lib/include/TH/generic/*.h',
+                'lib/include/THC/*.h',
+                'lib/include/THC/generic/*.h',
+                'lib/include/torch/csrc/*.h',
+                'lib/include/torch/csrc/autograd/*.h',
+                'lib/include/torch/csrc/jit/*.h',
+                'lib/include/torch/csrc/utils/*.h',
+                'lib/include/torch/torch.h',
+            ]
+        },
+        install_requires=['pyyaml', 'numpy'], )

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -1,0 +1,30 @@
+#include <torch/torch.h>
+
+using namespace at;
+
+Tensor sigmoid_add(Tensor x, Tensor y) {
+  return x.sigmoid() + y.sigmoid();
+}
+
+struct MatrixMultiplier {
+  MatrixMultiplier(int A, int B) {
+     tensor_ = CPU(kDouble).ones({A, B});
+  }
+  Tensor forward(Tensor weights) {
+    return tensor_.mm(weights);
+  }
+  Tensor get() const {
+    return tensor_;
+  }
+
+private:
+  Tensor tensor_;
+};
+
+PYBIND11_MODULE(torch_test_cpp_extensions, m) {
+  m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
+  py::class_<MatrixMultiplier>(m, "MatrixMultiplier")
+      .def(py::init<int, int>())
+      .def("forward", &MatrixMultiplier::forward)
+      .def("get", &MatrixMultiplier::get);
+}

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, Extension
+import torch.utils.cpp_extension
+
+ext_modules = [
+    Extension(
+        'torch_test_cpp_extensions', ['extension.cpp'],
+        include_dirs=torch.utils.cpp_extension.include_paths(),
+        language='c++'),
+]
+
+setup(
+    name='torch_test_cpp_extensions',
+    ext_modules=ext_modules,
+    cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension})

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -64,15 +64,19 @@ $PYCMD test_cuda.py $@
 echo "Running NCCL tests"
 $PYCMD test_nccl.py $@
 
-echo "Running C++ Extensions tests"
-cd cpp_extensions
-$PYCMD setup.py install --root ./install
-previous_pythonpath="$PYTHONPATH"
-export PYTHONPATH="$PWD/$(find ./install -name site-packages):$PYTHONPATH"
-cd ..
-$PYCMD test_cpp_extensions.py $@
-export PYTHONPATH="$previous_pythonpath"
-rm -rf cpp_extensions/install
+# Skipping C++ extensions tests for Windows because setup.py does not link
+# the required libraries. Windows users should create their own cmake file with
+# proper linker flags.
+if [[ "$OSTYPE" != "msys" ]]; then
+  echo "Running C++ Extensions tests"
+  cd cpp_extensions
+  $PYCMD setup.py install --root ./install
+  cd ..
+  PYTHONPATH="$PWD/$(find cpp_extensions/install -name site-packages):$PYTHONPATH" \
+    $PYCMD test_cpp_extensions.py $@
+  echo "Removing cpp_extensions/install"
+  rm -rf cpp_extensions/install
+fi
 
 # Skipping test_distributed for Windows because it doesn't have fcntl
 if [[ "$OSTYPE" != "msys" ]]; then

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -64,6 +64,16 @@ $PYCMD test_cuda.py $@
 echo "Running NCCL tests"
 $PYCMD test_nccl.py $@
 
+echo "Running C++ Extensions tests"
+cd cpp_extensions
+$PYCMD setup.py install --root ./install
+previous_pythonpath="$PYTHONPATH"
+export PYTHONPATH="$PWD/$(find ./install -name site-packages):$PYTHONPATH"
+cd ..
+$PYCMD test_cpp_extensions.py $@
+export PYTHONPATH="$previous_pythonpath"
+rm -rf cpp_extensions/install
+
 # Skipping test_distributed for Windows because it doesn't have fcntl
 if [[ "$OSTYPE" != "msys" ]]; then
     distributed_set_up() {

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -1,0 +1,23 @@
+import torch
+import torch_test_cpp_extensions as cpp_extension
+
+import common
+
+
+class TestCppExtension(common.TestCase):
+    def test_extension_function(self):
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+        z = cpp_extension.sigmoid_add(x, y)
+        self.assertEqual(z, x.sigmoid() + y.sigmoid())
+
+    def test_extension_module(self):
+        mm = cpp_extension.MatrixMultiplier(4, 8)
+        weights = torch.rand(8, 4)
+        expected = mm.get().mm(weights)
+        result = mm.forward(weights)
+        self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
+    common.run_tests()

--- a/torch/torch.h
+++ b/torch/torch.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <Python.h>
+#include <ATen/ATen.h>
+#include <pybind11/pybind11.h>
+#include <torch/csrc/utils/pybind.h>

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,0 +1,18 @@
+import os.path
+
+from setuptools.command.build_ext import build_ext
+
+
+class BuildExtension(build_ext):
+    """A custom build extension for adding compiler-specific options."""
+
+    def build_extensions(self):
+        for extension in self.extensions:
+            extension.extra_compile_args = ['-std=c++11']
+        build_ext.build_extensions(self)
+
+
+def include_paths():
+    here = os.path.abspath(__file__)
+    torch_path = os.path.dirname(os.path.dirname(here))
+    return [os.path.join(torch_path, 'lib', 'include')]

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,12 +1,61 @@
-import os.path
-
+import os
+import re
+import subprocess
+import sys
+import warnings
 from setuptools.command.build_ext import build_ext
+
+MINIMUM_GCC_VERSION = (4, 9)
+ABI_INCOMPATIBILITY_WARNING = '''
+Your compiler ({}) may be ABI-incompatible with PyTorch.
+Please use a compiler that is ABI-compatible with GCC 4.9 and above.
+See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html.'''
+
+
+def check_compiler_abi_compatibility(compiler):
+    '''
+    Verifies that the given compiler is ABI-compatible with PyTorch.
+
+    Arguments:
+        compiler (str): The compiler executable name to check (e.g. 'g++')
+
+    Returns:
+        False if the compiler is (likely) ABI-incompatible with PyTorch,
+        else True.
+    '''
+    try:
+        info = subprocess.check_output('{} --version'.format(compiler).split())
+    except Exception:
+        _, error, _ = sys.exc_info()
+        warnings.warn('Error checking compiler version: {}'.format(error))
+    else:
+        info = info.decode().lower()
+        if 'gcc' in info:
+            # Sometimes the version is given as "major.x" instead of semver.
+            version = re.search(r'(\d+)\.(\d+|x)', info)
+            if version is not None:
+                major, minor = version.groups()
+                minor = 0 if minor == 'x' else int(minor)
+                if (int(major), minor) >= MINIMUM_GCC_VERSION:
+                    return True
+                else:
+                    # Append the detected version for the warning.
+                    compiler = '{} {}'.format(compiler, version.group(0))
+
+    warnings.warn(ABI_INCOMPATIBILITY_WARNING.format(compiler))
+    return False
 
 
 class BuildExtension(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     def build_extensions(self):
+        # On some platforms, like Windows, compiler_cxx is not available.
+        if hasattr(self.compiler, 'compiler_cxx'):
+            compiler = self.compiler.compiler_cxx[0]
+        else:
+            compiler = os.environ.get('CXX', 'c++')
+        check_compiler_abi_compatibility(compiler)
         for extension in self.extensions:
             extension.extra_compile_args = ['-std=c++11']
         build_ext.build_extensions(self)


### PR DESCRIPTION
This PR introduces a simple aggregate header, `torch/torch.h`, that pulls in all other headers necessary to create a C++ module that can very easily be integrated with PyTorch without having to modify the core library.

For this, I edited `setup.py` to ship some more files with the `torch` install:
- The new `torch/torch.h`,
- *All* `torch/csrc/` headers,
- `torch/lib/pybind11/include/pybind11/`

One discussion point here is that we technically don't need all of `torch/csrc`. The whole folder is 8 MB, while for cpp-extensions to work we only need around half of that. I'm dumping all of them for now for simplicity (and considering the PyTorch wheel is still 85% smaller than TensorFlow), but happy to take thoughts here.

Right now, creating a C++ extension means setting up a very small `setup.py` and using the header locations we provide via `torch.cpp_build.include_paths()` and then calling `python setup.py install`. That's it. I've provided a small test case.

@zdevito @soumith 