### PR TITLE
Add libATen.so symlink.

### DIFF
--- a/torch/lib/build_libs.sh
+++ b/torch/lib/build_libs.sh
@@ -168,6 +168,10 @@ function build_aten() {
   # purpusefully not passing C_FLAGS for the same reason as above
   ${CMAKE_INSTALL} -j$(getconf _NPROCESSORS_ONLN)
   cd ../..
+
+  if [ ! -f "${INSTALL_DIR}/lib/libATen.so" ]; then
+    ln -s "${INSTALL_DIR}/lib/libATen.so.1" "${INSTALL_DIR}/lib/libATen.so"
+  fi
 }
 
 # In the torch/lib directory, create an installation directory


### PR DESCRIPTION
Right now, when you install PyTorch, only libATen.so.1 is installed, not
libATen.so.  I'm not sure this is the "right" way to fix the problem but it's
what we are doing for nccl.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>