### PR TITLE
[JIT] add create_autodiff_subgraphs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -470,6 +470,7 @@ main_sources = [
     "torch/csrc/jit/python_arg_flatten.cpp",
     "torch/csrc/jit/python_compiled_function.cpp",
     "torch/csrc/jit/variable_flags.cpp",
+    "torch/csrc/jit/passes/create_autodiff_subgraphs.cpp",
     "torch/csrc/jit/passes/graph_fuser.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",

--- a/test/expect/TestJit.test_concat_fusion.expect
+++ b/test/expect/TestJit.test_concat_fusion.expect
@@ -1,9 +1,9 @@
 graph(%0 : Float(3, 20)
       %1 : Float(3, 20)) {
-  %2 : Float(6, 20) = fusion_group_0(%0, %1)
+  %2 : Float(6, 20) = FusionGroup_0(%0, %1)
   return (%2);
 }
-with fusion_group_0 = graph(%3 : Float(3, 20)
+with FusionGroup_0 = graph(%3 : Float(3, 20)
       %4 : Float(3, 20)) {
   %6 : Float(3, 20) = add[alpha={1}](%3, %4)
   %5 : Float(3, 20) = mul(%3, %4)

--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -1,0 +1,29 @@
+testCreateAutodiffSubgraphs
+graph(%0 : UNKNOWN_TYPE
+      %1 : UNKNOWN_TYPE
+      %2 : UNKNOWN_TYPE
+      %3 : UNKNOWN_TYPE
+      %4 : UNKNOWN_TYPE) {
+  %5 : UNKNOWN_TYPE = mm(%1, %4)
+  %6 : UNKNOWN_TYPE = mm(%0, %3)
+  %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %5)
+  %8 : UNKNOWN_TYPE, %9 : UNKNOWN_TYPE, %10 : UNKNOWN_TYPE, %11 : UNKNOWN_TYPE = chunk[chunks=4, dim=1](%7)
+  %12 : UNKNOWN_TYPE = sigmoid(%8)
+  %13 : UNKNOWN_TYPE = sigmoid(%11)
+  %14 : UNKNOWN_TYPE = tanh(%10)
+  %15 : UNKNOWN_TYPE = sigmoid(%9)
+  %21 : UNKNOWN_TYPE = GraphExecutor_0(%12, %14, %15, %2)
+  %19 : UNKNOWN_TYPE = tanh(%21)
+  %20 : UNKNOWN_TYPE = mul(%13, %19)
+  return (%20, %21);
+}
+with GraphExecutor_0 = graph(%1 : UNKNOWN_TYPE
+      %2 : UNKNOWN_TYPE
+      %4 : UNKNOWN_TYPE
+      %5 : UNKNOWN_TYPE) {
+  %0 : UNKNOWN_TYPE = mul(%1, %2)
+  %3 : UNKNOWN_TYPE = mul(%4, %5)
+  %6 : UNKNOWN_TYPE = add[alpha={1}](%3, %0)
+  return (%6);
+}
+

--- a/test/expect/TestJit.test_fusion_distribute.expect
+++ b/test/expect/TestJit.test_fusion_distribute.expect
@@ -2,10 +2,10 @@ graph(%0 : Float(4, 4)
       %1 : Float(4, 4)) {
   %2 : Float(4!, 2), %3 : Float(4!, 2) = chunk[chunks=2, dim=1](%0)
   %4 : Float(4!, 2), %5 : Float(4!, 2) = chunk[chunks=2, dim=1](%1)
-  %6 : Float(4, 2) = fusion_group_0(%2, %4, %3, %5)
+  %6 : Float(4, 2) = FusionGroup_0(%2, %4, %3, %5)
   return (%6);
 }
-with fusion_group_0 = graph(%3 : Float(4!, 2)
+with FusionGroup_0 = graph(%3 : Float(4!, 2)
       %4 : Float(4!, 2)
       %6 : Float(4!, 2)
       %7 : Float(4!, 2)) {

--- a/test/expect/TestJit.test_lstm_fusion.expect
+++ b/test/expect/TestJit.test_lstm_fusion.expect
@@ -13,10 +13,10 @@ graph(%0 : Float(3, 10)
   %12 : Float(3, 80) = addmm[beta={1}, alpha={1}](%11, %1, %10)
   %13 : Float(3!, 20), %14 : Float(3!, 20), %15 : Float(3!, 20), %16 : Float(3!, 20) = chunk[chunks=4, dim=1](%9)
   %17 : Float(3!, 20), %18 : Float(3!, 20), %19 : Float(3!, 20), %20 : Float(3!, 20) = chunk[chunks=4, dim=1](%12)
-  %21 : Float(3, 20), %22 : Float(3, 20) = fusion_group_0(%2, %16, %20, %15, %19, %14, %18, %13, %17)
+  %21 : Float(3, 20), %22 : Float(3, 20) = FusionGroup_0(%2, %16, %20, %15, %19, %14, %18, %13, %17)
   return (%21, %22);
 }
-with fusion_group_0 = graph(%12 : Float(3, 20)
+with FusionGroup_0 = graph(%12 : Float(3, 20)
       %22 : Float(3!, 20)
       %23 : Float(3!, 20)
       %25 : Float(3!, 20)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -881,7 +881,9 @@ class TestJit(TestCase):
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "cpp tests require CUDA")
     def test_cpp(self):
-        torch._C._jit_run_cpp_tests()
+        # rather than rebuild assertExpected in cpp,
+        # just glob all the cpp outputs into one file for now
+        self.assertExpected(torch._C._jit_run_cpp_tests())
 
     def test_batchnorm(self):
         x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -7,6 +7,15 @@ namespace torch { namespace jit {
 
 using value_list = std::vector<Value*>;
 
+
+std::unordered_set<Symbol> differentiable_kinds = {
+  kadd, ksub, kmul,
+};
+
+bool isDifferentiable(Node * n) {
+  return differentiable_kinds.count(n->kind()) > 0;
+}
+
 static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_values) {
   const auto build_sym_grad = [node](const std::vector<SymbolicVariable>& grads) -> std::vector<SymbolicVariable> {
     auto inputs = node->inputs();

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -12,4 +12,7 @@ namespace torch { namespace jit {
 // (aka backward) of inputs to the first stage w.r.t. the outputs of the first stage.
 void differentiate(std::shared_ptr<Graph>& graph);
 
+// can we take a derivative of this node symbolically?
+bool isDifferentiable(Node * n);
+
 }}

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -36,7 +36,7 @@ void graph_pass(const std::shared_ptr<tracer::TracingState>& state) {
 
 } // anonymous namespace
 
-extern void runJITCPPTests();
+extern std::string runJITCPPTests();
 
 void initJITBindings(PyObject *module) {
   auto m = py::handle(module).cast<py::module>();

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -224,19 +224,21 @@ std::ostream& printNode(std::ostream & out, const Node * n, std::vector<const No
       printPyObject(out, scalar);
     }
     out << ")";
-  IR_ELSEIF(FusionGroup)
-    if(groups) {
-      out << "fusion_group_" << groups->size();
-      groups->push_back(value);
-    } else {
-      out << "fusion_group[" << *n->g(kSubgraph) << "]";
-    }
   IR_ELSEIFM_CONST(CppOp)
     out << "CppOp[" << value->name() << "]";
   IR_ELSE()
-    out << n->kind().toString();
-    if(n->hasAttributes()) {
-      printAttributes(out,n);
+    if(n->hasAttribute(kSubgraph)) {
+      if(groups) {
+        out << n->kind().toString() << "_" << groups->size();
+        groups->push_back(n);
+      } else {
+        out << n->kind().toString() << "[" << *n->g(kSubgraph) << "]";
+      }
+    } else {
+      out << n->kind().toString();
+      if(n->hasAttributes()) {
+        printAttributes(out,n);
+      }
     }
   IR_END()
   out << "(" << n->inputs() << ")";
@@ -270,7 +272,7 @@ std::ostream& operator<<(std::ostream & out, const Graph & g) {
   out << "  return (" << g.outputs() << ");\n}\n";
   size_t i = 0;
   for(auto fg : groups) {
-    out << "with fusion_group_" <<i++ << " = " << *fg->g(kSubgraph);
+    out << "with " << fg->kind().toString() << "_" <<i++ << " = " << *fg->g(kSubgraph);
   }
   /*
   // Uncomment this to debug all_nodes issues

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -1,0 +1,109 @@
+#include <cstddef>
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/autodiff.h"
+
+namespace torch { namespace jit {
+
+struct Graph;
+
+namespace {
+
+// Move nodes that exist in graph g into a 'group_node_kind' node.
+// All inputs shared by the nodes become inputs to the new node.
+// Outputs from 'nodes' are redirected to outputs of the new node,
+// and the original nodes are removed.
+// prereq: it is topologically valid to place the new node
+// right before nodes[0] (i.e. it will not create cycles and all uses of
+// new node will be after this position).
+// prereq: nodes are in topological order
+void mergeNodes(Graph & g, Symbol group_node_kind, ArrayRef<Node*> nodes) {
+  JIT_ASSERT(nodes.size() > 0);
+  std::unordered_map<Value*, Value*> value_map;
+
+  auto new_graph = std::make_shared<Graph>();
+  Node * group_node = g.create(group_node_kind, 0);
+  group_node->g_(kSubgraph, new_graph);
+
+  auto getOrCreateInput = [&](Value * v) {
+    if(value_map.count(v) > 0) {
+      return value_map[v];
+    }
+    Value * nv = new_graph->addInput();
+    group_node->addInput(v);
+    value_map[v] = nv;
+    return nv;
+  };
+  std::unordered_set<Node*> group_set;
+  for(auto n : nodes) {
+    group_set.insert(n);
+  }
+  for(auto n : nodes) {
+    auto nn = new_graph->appendNode(new_graph->createClone(n, getOrCreateInput));
+    for(size_t i = 0; i < nn->outputs().size(); ++i) {
+      auto old_output = n->outputs()[i];
+      auto new_output = nn->outputs()[i];
+      value_map[old_output] = new_output;
+      std::vector<Use> to_replace;
+      for(auto u : old_output->uses()) {
+        // Uses within the set do not need to be made outputs
+        if(group_set.count(u.user) > 0)
+          continue;
+        // Other uses do, but we
+        // cannot replace them here or we invalid the uses list iterator
+        to_replace.push_back(u);
+      }
+      if(to_replace.size() > 0) {
+        new_graph->registerOutput(new_output);
+        Value * external_output = group_node->addOutput();
+        for(auto u : to_replace) {
+          u.user->replaceInput(u.offset, external_output);
+        }
+      }
+    }
+  }
+  group_node->insertBefore(nodes[0]);
+  // delete backward, so that nodes are use-free before deletion
+  for(size_t i = nodes.size(); i > 0; --i) {
+    nodes[i - 1]->destroy();
+  }
+}
+
+}
+
+void CreateAutodiffSubgraphs(Graph & g, size_t threshold) {
+
+  // This implementation is not optimal, but it is simple.
+  // It just scans through the list in order looking for runs of
+  // differentiable ops, and then grouping them together when
+  // it hits the first non-differentiable op.
+  // It cannot handle things like:
+  // a = f(x, y)
+  // b = black_box(a)
+  // c = g(a)
+  // where you could group {f, g} together if the nodes were in a different
+  // topological order
+
+  // a better strategy would be to try to treat this like a fusion problem
+  // and group maximal groups
+  Symbol graph_executor = "GraphExecutor"_sym;
+
+  std::vector<Node*> groupable;
+  for(auto n : g.nodes()) { // Note: nodes() iterator stays valid since it is
+                            // always pointing _after_ the nodes that mergeNodes
+                            // mutates.
+    if(isDifferentiable(n)) {
+      groupable.push_back(n);
+    } else {
+      if(groupable.size() >= threshold) {
+        mergeNodes(g, graph_executor, groupable);
+      }
+      groupable.clear();
+    }
+  }
+  if(groupable.size() >= threshold) {
+    mergeNodes(g, graph_executor, groupable);
+  }
+}
+
+
+}}

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.h
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstddef>
+
+namespace torch { namespace jit {
+
+struct Graph;
+
+// insert GraphExecutor nodes that group together
+// subgraphs that are differentiable by the jit's autodiff passes
+// threshold - minimum number of nodes that will appear in a block
+void CreateAutodiffSubgraphs(Graph & graph, size_t threshold = 2);
+
+}}

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -7,13 +7,13 @@
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/symbolic_variable.h"
 #include "torch/csrc/jit/autodiff.h"
+#include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
 
 #include "torch/csrc/assertions.h"
 #include "torch/csrc/utils/auto_gil.h"
 
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/python_engine.h"
-
 #include <vector>
 #include <iostream>
 
@@ -536,7 +536,16 @@ void testADFormulas() {
   }
 }
 
-void runJITCPPTests() {
+void testCreateAutodiffSubgraphs(std::ostream & out) {
+  auto graph = build_lstm();
+  CreateAutodiffSubgraphs(*graph, /*threshold=*/2);
+  out << "testCreateAutodiffSubgraphs\n";
+  out << *graph << "\n";
+}
+
+std::string runJITCPPTests() {
+  std::stringstream out;
+  testCreateAutodiffSubgraphs(out);
   testADFormulas();
   interpTest();
   interpStageTest();
@@ -544,6 +553,7 @@ void runJITCPPTests() {
   fusionTests();
   attributesTest();
   internedStringsTests();
+  return out.str();
 }
 
 }}


### PR DESCRIPTION
This pass splits differentiable subgraphs into their own Node,
similar to a fusion group.

This initial implementation does not create optimal subgraphs, but
it works well in the case where most things are differentiable,
and has the building blocks (`mergeNodes`) to extend to the
better implementation.