### PR TITLE
parallelize vol2col and col2vol of Conv3D with CPU backend

### DIFF
--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -130,13 +130,13 @@ static void THNN_(unfolded_acc_vol)(
           int pT,
           int pW,
           int pH,
-          int64_t nInputPlane,
-          int64_t inputDepth,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputDepth,
-          int64_t outputWidth,
-          int64_t outputHeight)
+          long nInputPlane,
+          long inputDepth,
+          long inputWidth,
+          long inputHeight,
+          long outputDepth,
+          long outputWidth,
+          long outputHeight)
 {
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);
@@ -283,13 +283,13 @@ static void THNN_(unfolded_copy_vol)(
           int pT,
           int pW,
           int pH,
-          int64_t nInputPlane,
-          int64_t inputDepth,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputDepth,
-          int64_t outputWidth,
-          int64_t outputHeight)
+          long nInputPlane,
+          long inputDepth,
+          long inputWidth,
+          long inputHeight,
+          long outputDepth,
+          long outputWidth,
+          long outputHeight)
 {
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -130,13 +130,13 @@ static void THNN_(unfolded_acc_vol)(
           int pT,
           int pW,
           int pH,
-          long nInputPlane,
-          long inputDepth,
-          long inputWidth,
-          long inputHeight,
-          long outputDepth,
-          long outputWidth,
-          long outputHeight)
+          int64_t nInputPlane,
+          int64_t inputDepth,
+          int64_t inputWidth,
+          int64_t inputHeight,
+          int64_t outputDepth,
+          int64_t outputWidth,
+          int64_t outputHeight)
 {
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);
@@ -283,13 +283,13 @@ static void THNN_(unfolded_copy_vol)(
           int pT,
           int pW,
           int pH,
-          long nInputPlane,
-          long inputDepth,
-          long inputWidth,
-          long inputHeight,
-          long outputDepth,
-          long outputWidth,
-          long outputHeight)
+          int64_t nInputPlane,
+          int64_t inputDepth,
+          int64_t inputWidth,
+          int64_t inputHeight,
+          int64_t outputDepth,
+          int64_t outputWidth,
+          int64_t outputHeight)
 {
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -237,9 +237,9 @@ static void THNN_(unfolded_acc_vol)(
 }
 
 /*
-  Modified from the version of CUDA implementation, the loop iterations is larger than that one.
-  The large loop could lower the proportion of openmp overhead. And the inner part in loop is simpler.
-  The more simpler code is below:
+  Modified from the version of CUDA implementation, but the loop iterations is larger than that one.
+  The larger loop could lower the proportion of openmp overhead. And the inner part in loop is simpler.
+  The naive code is below:
 
   real *input_data = THTensor_(data)(input);
   real *finput_data = THTensor_(data)(finput);
@@ -269,7 +269,7 @@ static void THNN_(unfolded_acc_vol)(
   }
 
   However, there are 6 quotient and 6 module operations which are very time-consuming. So we choose relatively
-  more complex but efficient pattern.
+  more complex but more efficient pattern.
 */
 static void THNN_(unfolded_copy_vol)(
           THTensor *finput,


### PR DESCRIPTION
Refer to the [Issue](https://github.com/pytorch/pytorch/issues/4738).
Vol2col and col2vol in Conv3D could not be parallelized with [CPU backend](https://github.com/pytorch/pytorch/blob/master/aten/src/THNN/generic/VolumetricConvolutionMM.c#L114). Actually `THNN_(unfolded_copy_vol)` function is OK to use OpenMP. But test case will fail when using OpenMP in `THNN_(unfolded_acc_vol)` function . The reason why the transforms could not be parallized with CPU backend is  read-write confict with multi-thread.  However, it will avert the problem if we adopt another coding strategy as that in [GPU backend](https://github.com/pytorch/pytorch/blob/master/aten/src/THCUNN/VolumetricConvolution.cu#L9). 
