### PR TITLE
JIT compile C++ extensions

### DIFF
--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -39,7 +39,17 @@ echo "ENTERED_USER_LAND"
 echo "Testing pytorch"
 export OMP_NUM_THREADS=4
 export MKL_NUM_THREADS=4
+
+# JIT C++ extensions require ninja.
+git clone https://github.com/ninja-build/ninja --quiet
+pushd ninja
+python ./configure.py --bootstrap
+export PATH="$PWD:$PATH"
+popd
+
 time test/run_test.sh
+
+rm -rf ninja
 
 pushd vision
 time python setup.py install

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -1,0 +1,13 @@
+#include <torch/torch.h>
+
+struct Doubler {
+  Doubler(int A, int B) {
+     tensor_ = at::CPU(at::kDouble).ones({A, B});
+  }
+  at::Tensor forward() {
+    return tensor_ * 2;
+  }
+
+private:
+  at::Tensor tensor_;
+};

--- a/test/cpp_extensions/jit_extension.cpp
+++ b/test/cpp_extensions/jit_extension.cpp
@@ -1,0 +1,11 @@
+#include <torch/torch.h>
+
+using namespace at;
+
+Tensor tanh_add(Tensor x, Tensor y) {
+  return x.tanh() + y.tanh();
+}
+
+PYBIND11_MODULE(jit_extension, m) {
+  m.def("tanh_add", &tanh_add, "tanh(x) + tanh(y)");
+}

--- a/test/cpp_extensions/jit_extension2.cpp
+++ b/test/cpp_extensions/jit_extension2.cpp
@@ -1,0 +1,16 @@
+#include <torch/torch.h>
+
+#include "doubler.h"
+
+using namespace at;
+
+Tensor exp_add(Tensor x, Tensor y) {
+  return x.exp() + y.sigmoid();
+}
+
+PYBIND11_MODULE(torch_test_cpp_extensions, m) {
+  m.def("exp_add", &exp_add, "exp(x) + exp(y)");
+  py::class_<Doubler>(m, "Doubler")
+      .def(py::init<int, int>())
+      .def("forward", &Doubler::forward);
+}

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -72,7 +72,7 @@ if [[ "$OSTYPE" != "msys" ]]; then
   cd cpp_extensions
   $PYCMD setup.py install --root ./install
   cd ..
-  PYTHONPATH="$PWD/$(find cpp_extensions/install -name site-packages):$PYTHONPATH" \
+  PYTHONPATH="$PWD/$(find cpp_extensions/install -name '*-packages'):$PYTHONPATH" \
     $PYCMD test_cpp_extensions.py $@
   echo "Removing cpp_extensions/install"
   rm -rf cpp_extensions/install

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -1,4 +1,5 @@
 import torch
+import torch.utils.cpp_extension
 import torch_test_cpp_extensions as cpp_extension
 
 import common
@@ -17,6 +18,21 @@ class TestCppExtension(common.TestCase):
         expected = mm.get().mm(weights)
         result = mm.forward(weights)
         self.assertEqual(expected, result)
+
+    def test_jit_compile_extension(self):
+        module = torch.utils.cpp_extension.load(
+            name='jit_extension',
+            sources=[
+                'cpp_extensions/jit_extension.cpp',
+                'cpp_extensions/jit_extension2.cpp'
+            ],
+            extra_include_paths=['cpp_extensions'],
+            extra_cflags=['-g'],
+            verbose=True)
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+        z = module.tanh_add(x, y)
+        self.assertEqual(z, x.tanh() + y.tanh())
 
 
 if __name__ == '__main__':

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,8 +1,12 @@
+import imp
 import os
 import re
 import subprocess
 import sys
+import sysconfig
+import tempfile
 import warnings
+
 from setuptools.command.build_ext import build_ext
 
 MINIMUM_GCC_VERSION = (4, 9)
@@ -65,3 +69,178 @@ def include_paths():
     here = os.path.abspath(__file__)
     torch_path = os.path.dirname(os.path.dirname(here))
     return [os.path.join(torch_path, 'lib', 'include')]
+
+
+def load(name,
+         sources,
+         extra_cflags=None,
+         extra_ldflags=None,
+         extra_include_paths=None,
+         build_directory=None,
+         verbose=False):
+    '''
+    Loads a C++ PyTorch extension.
+
+    To load an extension, a Ninja build file is emitted, which is used to
+    compile the given sources into a dynamic library. This library is
+    subsequently loaded into the current Python process as a module and
+    returned from this function, ready for use.
+
+    By default, the directory to which the build file is emitted and the
+    resulting library compiled to is `<tmp>/torch_extensions`, where `<tmp>` is
+    the temporary folder on the current platform. This location can be
+    overriden in two ways. First, if the `TORCH_EXTENSIONS_DIR` environment
+    variable is set, it replaces `<tmp>` and all extensions will be compiled
+    into subfolders of this directory. Second, if the `build_directory`
+    argument to this function is supplied, it overrides the entire path, i.e.
+    the library will be compiled into that folder directly.
+
+    To compile the sources, the default system compiler (`c++`) is used, which
+    can be overriden by setting the CXX environment variable. To pass
+    additional arguments to the compilation process, `extra_cflags` or
+    `extra_ldflags` can be provided. For example, to compile your extension
+    with optimizations, pass `extra_cflags=['-O3']`. You can also use
+    `extra_cflags` to pass further include directories (`-I`).
+
+    Args:
+        name: The name of the module to build.
+        sources: A list of relative or absolute paths to C++ source files.
+        extra_cflags: optional list of compiler flags to forward to the build.
+        extra_ldflags: optional list of linker flags to forward to the build.
+        extra_include_paths: optional list of include directories to forward
+            to the build.
+        build_directory: optional path to use as build workspace.
+        verbose: If `True`, turns on verbose logging of load steps.
+
+    Returns:
+        The loaded PyTorch extension as a Python module.
+    '''
+
+    # Allows sources to be a single path or a list of paths.
+    if isinstance(sources, str):
+        sources = [sources]
+
+    if build_directory is None:
+        build_directory = _get_build_directory(name, verbose)
+
+    build_file_path = os.path.join(build_directory, 'build.ninja')
+    if verbose:
+        print('Emitting ninja build file {}...'.format(build_file_path))
+    # NOTE: Emitting a new ninja build file does not cause re-compilation if
+    # the sources did not change, so it's ok to re-emit (and it's fast).
+    _write_ninja_file(build_file_path, name, sources, extra_cflags or [],
+                      extra_ldflags or [], extra_include_paths or [])
+
+    if verbose:
+        print('Building extension module {}...'.format(name))
+    _build_extension_module(name, build_directory)
+
+    if verbose:
+        print('Loading extension module {}...'.format(name))
+    return _import_module_from_library(name, build_directory)
+
+
+def _get_build_directory(name, verbose):
+    root_extensions_directory = os.environ.get('TORCH_EXTENSIONS_DIR')
+    if root_extensions_directory is None:
+        # tempfile.gettempdir() will be /tmp on UNIX and \TEMP on Windows.
+        root_extensions_directory = os.path.join(tempfile.gettempdir(),
+                                                 'torch_extensions')
+
+    if verbose:
+        print('Using {} as PyTorch extensions root...'.format(
+            root_extensions_directory))
+
+    build_directory = os.path.join(root_extensions_directory, name)
+    if not os.path.exists(build_directory):
+        if verbose:
+            print('Creating extension directory {}...'.format(build_directory))
+        # This is like mkdir -p, i.e. will also create parent directories.
+        os.makedirs(build_directory)
+
+    return build_directory
+
+
+def _build_extension_module(name, build_directory):
+    try:
+        subprocess.check_output(
+            ['ninja', '-v'], stderr=subprocess.STDOUT, cwd=build_directory)
+    except subprocess.CalledProcessError:
+        # Python 2 and 3 compatible way of getting the error object.
+        _, error, _ = sys.exc_info()
+        # error.output contains the stdout and stderr of the build attempt.
+        raise RuntimeError("Error building extension '{}': {}".format(
+            name, error.output.decode()))
+
+
+def _import_module_from_library(module_name, path):
+    # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
+    file, path, description = imp.find_module(module_name, [path])
+    # Close the .so file after load.
+    with file:
+        return imp.load_module(module_name, file, path, description)
+
+
+def _write_ninja_file(path, name, sources, extra_cflags, extra_ldflags,
+                      extra_include_paths):
+    try:
+        import ninja
+    except ImportError:
+        raise RuntimeError("Ninja is required to load C++ extensions. "
+                           "Install it with 'pip install ninja'.")
+    with open(path, 'w') as build_file:
+        writer = ninja.Writer(build_file)
+        # Version 1.3 is required for the `deps` directive.
+        writer.variable('ninja_required_version', '1.3')
+        writer.variable('cxx', os.environ.get('CXX', 'c++'))
+        writer.newline()
+
+        # Turn into absolute paths so we can emit them into the ninja build
+        # file wherever it is.
+        sources = [os.path.abspath(file) for file in sources]
+        includes = [os.path.abspath(file) for file in extra_include_paths]
+
+        # include_paths() gives us the location of torch/torch.h
+        includes += include_paths()
+        # sysconfig.get_paths()['include'] gives us the location of Python.h
+        includes.append(sysconfig.get_paths()['include'])
+
+        cflags = ['-fPIC', '-std=c++11']
+        cflags += ['-I{}'.format(include) for include in includes]
+        cflags += extra_cflags
+        writer.variable('cflags', ' '.join(cflags))
+
+        ldflags = ['-shared'] + extra_ldflags
+        # The darwin linker needs explicit consent to ignore unresolved symbols
+        if sys.platform == 'darwin':
+            ldflags.append('-undefined dynamic_lookup')
+        writer.variable('ldflags', ' '.join(ldflags))
+        writer.newline()
+
+        # See https://ninja-build.org/build.ninja.html for reference.
+        writer.rule(
+            'compile',
+            command='$cxx -MMD -MF $out.d $cflags -c $in -o $out',
+            depfile='$out.d',
+            deps='gcc')
+        writer.newline()
+
+        writer.rule('link', command='$cxx $ldflags $in -o $out')
+        writer.newline()
+
+        # Emit one build rule per source to enable incremental build.
+        object_files = []
+        for source_file in sources:
+            # '/path/to/file.cpp' -> 'file'
+            file_name = os.path.splitext(os.path.basename(source_file))[0]
+            target = '{}.o'.format(file_name)
+            object_files.append(target)
+            writer.build(outputs=target, rule='compile', inputs=source_file)
+        writer.newline()
+
+        library_target = '{}.so'.format(name)
+        writer.build(outputs=library_target, rule='link', inputs=object_files)
+        writer.newline()
+
+        writer.default(library_target)
+        writer.close()


### PR DESCRIPTION
This PR builds on top of https://github.com/pytorch/pytorch/pull/4818 to provide `torch.utils.cpp_extension.load()`, which will:

1. Take a bunch of source files,
2. Emit (approximately) `/tmp/torch_extensions/<module_name>/build.ninja`,
3. Call `ninja` in that directory to produce a dynamic library,
4. Load that dynamic library as a Python module.

See `test/test_cpp_extensions.py` for an example of this. I've also tried to document `torch.utils.cpp_extension.load` fairly well.

It's not quite yet complete, but looking for feedback. What's missing is mainly a way to inform the user about ABI incompatibilities between the PyTorch install and whatever `CXX` is for the user, in a more friendly way than `SEGFAULT`.

@zdevito @soumith @ezyang @apaszke 