### PR TITLE
Implement sparse tensor and variable norm(value)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2027,11 +2027,19 @@
     - function
   options:
     - cname: normall
+      aten_sparse: True
       return: accreal
       arguments:
         - THTensor* self
         - arg: real p
           default: AS_REAL(2)
+      aten_custom_call: |
+        // norm(value) for a sparse tensor returns a DENSE 0-dim tensor
+        if (self.is_sparse()) {
+          auto result = ${THTensor}_normall(${state,} self_->tensor, convert<${THScalarType}>(p_));
+          return toBackend(toDense(backend())).tensor({}).fill_(result);
+        }
+        // aten_custom_call is followed by the generated call to normall
     - cname: norm
       return: argument 0
       scalar_check: self_->isScalar() || (keepdim == false && self_->dim() == 1)

--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -51,6 +51,16 @@ static inline Backend toSparse(Backend b) {
   }
 }
 
+static inline Backend toDense(Backend b) {
+  switch (b) {
+    case Backend::CPU: return Backend::CPU;
+    case Backend::CUDA: return Backend::CUDA;
+    case Backend::SparseCPU: return Backend::CPU;
+    case Backend::SparseCUDA: return Backend::CUDA;
+    default: throw std::runtime_error("Unknown backend");
+  }
+}
+
 static inline const char * toString(Backend b) {
   switch(b) {
     case Backend::CPU: return "CPU";

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -505,6 +505,15 @@ void THCSTensor_(pow)(THCState *state, THCSTensor *r_, THCSTensor *t_, real valu
 }
 #endif
 
+#if defined(THCS_REAL_IS_FLOAT) || defined(THCS_REAL_IS_DOUBLE) || defined(THCS_REAL_IS_HALF)
+accreal THCSTensor_(normall)(THCState *state, THCSTensor *self, real value) {
+  THCSTensor* self_coalesced = THCSTensor_(newCoalesce)(state, self);
+  accreal result = THCTensor_(normall)(state, self_coalesced->values, value); 
+  THCSTensor_(free)(state, self_coalesced);
+  return result;
+}
+#endif
+
 #undef ROW_PTR2
 #undef COL_PTR2
 

--- a/aten/src/THCS/generic/THCSTensorMath.h
+++ b/aten/src/THCS/generic/THCSTensorMath.h
@@ -34,4 +34,8 @@ TH_API void THCSTensor_(cmul)(THCState *state, THCSTensor *r_, THCSTensor *t, TH
 TH_API void THCSTensor_(pow)(THCState *state, THCSTensor *r_, THCSTensor *t, real value);
 #endif
 
+#if defined(THCS_REAL_IS_FLOAT) || defined(THCS_REAL_IS_DOUBLE) || defined(THCS_REAL_IS_HALF)
+TH_API accreal THCSTensor_(normall)(THCState *state, THCSTensor *self, real value);
+#endif
+
 #endif

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -53,7 +53,6 @@ void THSTensor_(mul)(THSTensor *r_, THSTensor *t, real value) {
   }
 }
 
-/* floating point only, because that is what TH supports */
 /* TODO: add in-place support */
 #if defined(THS_REAL_IS_FLOAT) || defined(THS_REAL_IS_DOUBLE)
 void THSTensor_(pow)(THSTensor *r_, THSTensor *t_, real value) {
@@ -83,6 +82,17 @@ void THSTensor_(pow)(THSTensor *r_, THSTensor *t_, real value) {
 
   THSTensor_(free)(t);
 }
+
+accreal THSTensor_(normall)(THSTensor *self, real value) {
+  THSTensor* self_coalesced = THSTensor_(newCoalesce)(self);
+  THTensor *self_coalesced_values = THSTensor_(newValues)(self_coalesced);
+  accreal result = THTensor_(normall)(self_coalesced_values, value);
+  THSTensor_(free)(self_coalesced);
+  THTensor_(free)(self_coalesced_values);
+  return result;
+}
+
+/* floating point only, because that is what TH supports */
 #endif
 
 void THSTensor_(div)(THSTensor *r_, THSTensor *t, real value) {

--- a/aten/src/THS/generic/THSTensorMath.h
+++ b/aten/src/THS/generic/THSTensorMath.h
@@ -32,6 +32,7 @@ TH_API void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTen
 
 #if defined(THS_REAL_IS_FLOAT) || defined(THS_REAL_IS_DOUBLE)
 TH_API void THSTensor_(pow)(THSTensor *r_, THSTensor *t, real value);
+TH_API accreal THSTensor_(normall)(THSTensor *self, real value);
 #endif
 
 #endif

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -465,6 +465,11 @@ class TestSparse(TestCase):
         self._test_spadd_shape([50, 30, 20], [2])
         self._test_spadd_shape([5, 5, 5, 5, 5, 5], [2])
 
+    def test_norm(self):
+        x, _, _ = self._gen_sparse(3, 10, 100)
+        y = x.coalesce()
+        self.assertEqual(x.norm(), y._values().norm())
+
     def _test_basic_ops_shape(self, shape_i, shape_v=None):
         shape = shape_i + (shape_v or [])
         x1, _, _ = self._gen_sparse(len(shape_i), 9, shape)
@@ -681,6 +686,7 @@ class TestSparse(TestCase):
             'to_dense': lambda x: x.to_dense(),
             '_dimI': lambda x: x._dimI(),
             '_dimV': lambda x: x._dimV(),
+            'norm': lambda x: x.norm(),
         }
 
         for test_name, test_fn in to_test_one_arg.items():
@@ -691,6 +697,10 @@ class TestSparse(TestCase):
             out_tensor = test_fn(tensor1)
 
             if isinstance(out_tensor, int) or isinstance(out_tensor, bool):
+                if not isinstance(out_var, int) and not isinstance(out_var, bool):
+                    check_var = out_var.data[0]
+                else:
+                    check_var = out_var
                 self.assertEqual(out_var, out_tensor)
                 continue
 

--- a/torch/csrc/generic/methods/SparseTensor.cwrap
+++ b/torch/csrc/generic/methods/SparseTensor.cwrap
@@ -484,6 +484,26 @@ PyObject * THSPTensor_(new)(THPTensor *self, PyObject *args, PyObject *kwargs)
 ]]
 
 [[
+  name: norm
+  types:
+    - float
+    - double
+  backends:
+    - CPU
+    - CUDA
+  sparse: yes
+  cname: normall
+  variants:
+    - method
+    - function
+  return: real
+  arguments:
+    - THSTensor* self
+    - arg: real value
+      default: AS_REAL(2)
+]]
+
+[[
   name: pow
   types:
     - float


### PR DESCRIPTION
(probably) needed for #4829 

This implements `tensor.norm(value)` and `variable.norm(value)` for sparse tensors/variables.

### Test Plan
Two new unit tests:
- test that norm() works for sparse tensors
- test that norm() works for sparse variables (by testing against sparse tensor)