### PR TITLE
Fix torch.pstrf on Variables

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3536,8 +3536,6 @@
     - method
     - function
   return: argument 0,1
-  after_call:
-    THIntTensor_sub(((THPIntTensor*)$arg1)->cdata, ((THPIntTensor*)$arg1)->cdata, 1);
   arguments:
     - arg: THTensor* res1
       output: True
@@ -3550,6 +3548,9 @@
       default: U
     - arg: real tol
       default: -1
+  aten_custom_call: |
+    ${THTensor}_pstrf(res1_->tensor, res2_->tensor, self_->tensor, (upper) ? "U" : "L", tol_);
+    res2 -= 1;  // LAPACK returns 1-indexed pivots
 ]]
 [[
   name: qr
@@ -4214,7 +4215,7 @@
 ]]
 
 [[
-  name: coalesce 
+  name: coalesce
   cname: newCoalesce
   variants:
     - method
@@ -4227,14 +4228,14 @@
 ]]
 
 [[
-  name: is_coalesced 
+  name: is_coalesced
   cname: isCoalesced
   variants:
     - method
   backends:
     - SparseCPU
     - SparseCUDA
-  return: bool 
+  return: bool
   arguments:
      - THTensor* self
 ]]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3022,8 +3022,8 @@ class TestTorch(TestCase):
     def test_pstrf(self):
         def checkPsdCholesky(a, uplo, inplace):
             if inplace:
-                u = torch.Tensor(a.size())
-                piv = torch.IntTensor(a.size(0))
+                u = torch.empty_like(a)
+                piv = a.new(a.size(0)).int()
                 kwargs = {'out': (u, piv)}
             else:
                 kwargs = {}
@@ -3053,6 +3053,8 @@ class TestTorch(TestCase):
             for inplace in (True, False):
                 for uplo in (None, True, False):
                     checkPsdCholesky(a, uplo, inplace)
+                    # TODO: remove once Variable and Tensor are merged
+                    checkPsdCholesky(torch.autograd.Variable(a), uplo, inplace)
 
     def test_numel(self):
         b = torch.ByteTensor(3, 100, 100)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -495,6 +495,8 @@ def unpack_args(env, declaration):
             return '_opt'
         elif dynamic_type == 'IndexTensor':
             return '_long'
+        elif dynamic_type == 'IntegerTensor':
+            return '_int'
         elif dynamic_type == 'BoolTensor':
             return '_byte'
         else:

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -126,6 +126,11 @@ Tensor & VariableType::unpack_long(const Tensor & t, const char * name, int pos)
   return checked_cast(type, t, name, pos).data();
 }
 
+Tensor & VariableType::unpack_int(const Tensor & t, const char * name, int pos) const {
+  auto& type = *VariableImpl::getType(baseType->toScalarType(kInt));
+  return checked_cast(type, t, name, pos).data();
+}
+
 Tensor & VariableType::unpack_byte(const Tensor & t, const char * name, int pos) const {
   auto& type = *VariableImpl::getType(baseType->toScalarType(kByte));
   return checked_cast(type, t, name, pos).data();

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -48,6 +48,7 @@ private:
   at::Tensor & unpack(const Tensor & t, const char * name, int pos) const;
   at::SparseTensor unpack(SparseTensor t, const char * name, int pos) const;
   at::Tensor & unpack_long(const Tensor & t, const char * name, int pos) const;
+  at::Tensor & unpack_int(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
   at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
   at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;


### PR DESCRIPTION
The LAPACK function returns one-indexed pivots. We need to convert them
to zero indexed.