### PR TITLE
Fix some scalar issues with autograd.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2906,7 +2906,7 @@
     if (self_->isScalar()) {
       throw std::runtime_error("Input must be 1-d or 2-d");
     }
-    ${THTensor}_diag(result_->tensor, self_->tensor, diagonal);
+    ${THTensor}_diag(${state,}result_->tensor, self_->tensor, diagonal);
     result_->maybeScalar(self_->isScalar());
 ]]
 [[

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2902,6 +2902,12 @@
     - THTensor* self
     - arg: long diagonal
       default: 0
+  aten_custom_call: |
+    if (self_->isScalar()) {
+      throw std::runtime_error("Input must be 1-d or 2-d");
+    }
+    ${THTensor}_diag(result_->tensor, self_->tensor, diagonal);
+    result_->maybeScalar(self_->isScalar());
 ]]
 [[
   name: addmm

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -9,6 +9,9 @@ namespace at {
 namespace native {
 
 std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
+  if (self.dim() == 0) {
+    throw std::runtime_error("chunk expects at least a 1-dimensional tensor");
+  }
   int64_t split_size = (self.size(dim) + chunks - 1) / chunks;
   // ensure this is dispatched through Tensor/Type, rather than the native function directly.
   return self.split(split_size, dim);
@@ -125,6 +128,9 @@ Tensor slice(const Tensor& self, int64_t dim, int64_t start, int64_t end, int64_
 }
 
 std::vector<Tensor> split(const Tensor& self, int64_t split_size, int64_t dim) {
+  if (self.dim() == 0) {
+    throw std::runtime_error("split expects at least a 1-dimensional tensor");
+  }
   int64_t dim_size = self.size(dim);
   int64_t num_splits = (dim_size + split_size - 1) / split_size;
   std::vector<Tensor> splits(num_splits);

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -373,7 +373,7 @@
   other: grad.clone().masked_fill_(self > other, 0)
 
 - name: mean(Tensor self, int64_t dim, bool keepdim)
-  self: sum_backward(grad, self.sizes(), dim, keepdim) / self.size(dim)
+  self: sum_backward(grad, self.sizes(), dim, keepdim) / _safe_size(self.sizes(), dim)
 
 - name: mean(Tensor self)
   self: grad.expand(self.sizes()) / self.numel()

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -41,6 +41,11 @@ Tensor maybe_multiply(const Tensor & t, const Scalar & s) {
   }
 }
 
+int64_t _safe_size(IntList sizes, int64_t dim) {
+  dim = at::maybe_wrap_dim(dim, sizes.size());
+  return sizes.size() != 0 ? sizes[dim] : 1;
+}
+
 Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_, const Tensor & norm) {
   double p = p_.toDouble();
   Tensor self_scaled;
@@ -66,7 +71,7 @@ Tensor norm_backward(const Tensor & grad, const Tensor & self, const Scalar & p_
 
 Tensor norm_backward(Tensor grad, const Tensor & self, const Scalar & p_, Tensor norm, int64_t dim, bool keepdim) {
 #ifdef WITH_SCALARS
-  if (!keepdim) {
+  if (!keepdim && self.dim() != 0) {
 #else
   if (!keepdim && self.dim() > 1) {
 #endif
@@ -103,9 +108,9 @@ Tensor permute_backwards(const Tensor & grad, IntList fwd_dims) {
 
 Tensor sum_backward(const Tensor & grad, IntList sizes, int64_t dim, bool keepdim) {
 #ifdef WITH_SCALARS
-  if (!keepdim) {
+  if (!keepdim && sizes.size() > 0) {
 #else
-   if (!keepdim && sizes.size() > 1) {
+  if (!keepdim && sizes.size() > 1) {
 #endif
     return grad.unsqueeze(dim).expand(sizes);
   } else {
@@ -144,6 +149,9 @@ Tensor prod_safe_zeros_backward(const Tensor &grad, const Tensor& inp, int64_t d
 // product:                      [b * c, a * c, a * b]
 // and this is safe under input with 0s.
 Tensor prod_backward(const Tensor& grad, const Tensor& input, const Tensor& result) {
+  if (input.dim() == 0) {
+    return grad;
+  }
   Tensor zero_idx = (input == 0).nonzero();
   if (zero_idx.numel() == 0) {
     return (grad * result) / input;
@@ -155,6 +163,9 @@ Tensor prod_backward(const Tensor& grad, const Tensor& input, const Tensor& resu
 }
 
 Tensor prod_backward(Tensor grad, const Tensor& input, Tensor result, int64_t dim, bool keepdim) {
+  if (input.dim() == 0) {
+    return grad;
+  }
   dim = at::maybe_wrap_dim(dim, input.sizes().size());
   if (!keepdim && input.dim() != 1) {
     grad = grad.unsqueeze(dim);
@@ -255,6 +266,9 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
     dy_j / dx_k = 0, which is done right after the assert.
   */
 
+  if (input.dim() == 0) {
+    return grad;
+  }
   dim = at::maybe_wrap_dim(dim, input.sizes().size());
   int64_t dim_size = input.size(dim);
   if (dim_size == 1) {
@@ -300,6 +314,9 @@ Tensor cumprod_backward(const Tensor &grad, const Tensor &input, int64_t dim) {
 }
 
 Tensor cumsum_backward(const Tensor & x, int64_t dim) {
+  if (x.dim() == 0) {
+    return x;
+  }
   auto ret = at::cumsum(-x, dim);
   auto ret_sum = ret.narrow(dim, ret.size(dim) - 1, 1).clone();
   ret -= ret_sum.expand(ret.sizes());
@@ -333,7 +350,9 @@ Tensor unsqueeze_to(const Tensor & self, IntList sizes) {
 Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   dim = at::maybe_wrap_dim(dim, sizes.size());
 #ifdef WITH_SCALARS
-  if (sizes[dim] == 1) {
+  // in NumPy it's not an error to unsqueeze a scalar, but we still need to avoided
+  // unsqueezing in the backward.
+  if (sizes.size() > 0 && sizes[dim] == 1) {
 #else
   if (sizes[dim] == 1 && sizes.size() != 1) {
 #endif
@@ -462,6 +481,9 @@ Tensor var_backward(const Tensor & grad, const Tensor & self, bool unbiased) {
 }
 
 Tensor var_backward(Tensor grad, const Tensor & self, int64_t dim, bool unbiased, bool keepdim) {
+  if (self.dim() == 0) {
+    return var_backward(grad, self, unbiased);
+  }
   if (!keepdim && self.dim() > 1) {
     grad = grad.unsqueeze(dim);
   }


### PR DESCRIPTION
1) Better error messages in functions that don't support scalars
2) Don't access size(dim) in the backward of a function taking a scalar because the wrap fails.