### PR TITLE
Added mixed-precision support in distributed training

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -250,8 +250,9 @@ class DistributedDataParallel(Module):
                                              self.device_ids,
                                              self.broadcast_bucket_size)
                 for tensors, device_id in zip(result[1:], self.device_ids[1:]):
-                    for tensor, param in zip(tensors,
-                            self.param_type_buckets[tp][device_id]):
+                    for tensor, param in \
+                            zip(tensors,
+                                self.param_type_buckets[tp][device_id]):
                         param.data.set_(tensor)
 
         # module buffer sync

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -141,6 +141,7 @@ class DistributedDataParallel(Module):
         else:
             bucket_bytes_cap = 1 * MB
 
+        # This is a triply-nested list where the "dimensions" are: devices, buckets, bucket_elems
         param_buckets = []
         # Split the parameters into buckets and by types as well
         for dev_idx, module in enumerate(self._module_copies):
@@ -150,8 +151,12 @@ class DistributedDataParallel(Module):
         self.bucket_map = {}
         param_types = set()
 
+        # We transpose param_buckets, so the loop is over buckets.
+        # param_buckets_tuple is a doubly-nested list with "dims": devices, bucket_elems
         for bucket_idx, param_buckets_tuple in enumerate(zip(*param_buckets)):
             self.bucket_sizes.append(0)
+            # Now, we transpose again, so we iterate over bucket_elems, but getting tuples
+            # of params from each device.
             for idx, param_tuple in enumerate(zip(*param_buckets_tuple)):
                 if idx == 0:
                     # Bucket parameter type tracking


### PR DESCRIPTION
This PR added mixed-precision support in distributed training.  

Basically, this is done by

1. bucketing parameters by data types so that intra-node broadcast can operate on different data types.
2. bucketing parameters by data types so that gradient all reduction can operate on different data types.

Note that the NCCL backend currently only supports a single reduction bucket, so this support will be further added with the other PR that makes NCCL backend a separate code path.

Half-precision support is only enabled for NCCL and GLOO backend.

Also added the option to the constructor to either sync or not sync the module buffers as an option since for ResNet we don't need to sync buffer and can hit the same accuracy.

Tested by running the distributed training on DGX1. Bucketing are also tested by printing out the value.

Tested mixed prevision for both Nccl and Gloo as well.