### PR TITLE
Fix doc indentation of `torch.cuda.empty_cache`

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -360,10 +360,11 @@ def memory_allocated(device=None):
                                 :meth:`~torch.cuda.current_device`, if
                                 :attr:`device` is ``None`` (default).
 
-    .. note:: This is likely less than the amount shown in `nvidia-smi` since
-    some unused memory can be held by the caching allocator and some context
-    needs to be created on GPU. See :ref:`cuda-memory-management` for more
-    details about GPU memory management.
+    .. note::
+        This is likely less than the amount shown in `nvidia-smi` since some
+        unused memory can be held by the caching allocator and some context
+        needs to be created on GPU. See :ref:`cuda-memory-management` for more
+        details about GPU memory management.
     """
     if device is None:
         device = current_device()


### PR DESCRIPTION
Incorrect indentation from #4879 caused the rendered `note` to end early (http://pytorch.org/docs/master/cuda.html#torch.cuda.memory_allocated).