### PR TITLE
Add missing _lazy_init in cuda python module

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -334,6 +334,7 @@ def current_stream():
 
 def current_blas_handle():
     r"""Returns cublasHandle_t pointer to current cuBLAS handle"""
+    _lazy_init()
     return torch._C._cuda_getCurrentBlasHandle()
 
 
@@ -347,6 +348,7 @@ def empty_cache():
         memory available for PyTorch. See :ref:`cuda-memory-management` for
         more details about GPU memory management.
     """
+    _lazy_init()
     return torch._C._cuda_emptyCache()
 
 
@@ -372,7 +374,7 @@ def memory_allocated(device=None):
 
 
 def max_memory_allocated(device=None):
-    r"""Returns the maxium GPU memory usage by tensors in bytes for a given
+    r"""Returns the maximum GPU memory usage by tensors in bytes for a given
     device.
 
     Arguments:


### PR DESCRIPTION
Current master raises an error for the blas handle (asking to set the blas handle, which sounds like the wrong error message as it cannot be set from python) and segfaults for the `empty_cache()` function.