### PR TITLE
Fixes to aten/Declarations.cwrap

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -220,13 +220,14 @@
 ]]
 [[
   name: t
+  cname: newTranspose
+  cpu_half: True
+  aten_sparse: True
   variants:
     - method
     - function
   auto_gpu: False
   return: THTensor*
-  cname: newTranspose
-  aten_sparse: True
   before_call: |
     if (self.is_sparse) {
       int64_t nDimI = arg_self->nDimensionI;
@@ -2220,6 +2221,15 @@
         - arg: THTensor* self
           broadcast: exponent fallback
         - THTensor* exponent
+]]
+[[
+  name: pow
+  types:
+    - floating_point
+  variants:
+    - function
+  return: argument 0
+  options:
     - cname: tpow
       arguments:
         - arg: THTensor* result
@@ -2888,7 +2898,7 @@
       output: True
     - long n
     - arg: long m
-      default: 1
+      default: -1
 ]]
 [[
   name: diag
@@ -3990,6 +4000,24 @@
         - THTensor* self
 ]]
 [[
+  name: _dirichlet_grad
+  types:
+    - floating_point
+  backends:
+    - CPU
+  return: argument 0
+  variants:
+    - function
+  options:
+    - cname: dirichlet_grad
+      arguments:
+        - arg: THTensor* output
+          output: True
+        - THTensor* x
+        - THTensor* alpha
+        - THTensor* total
+]]
+[[
   name: tensor
   return: THTensor*
   cpu_half: True
@@ -4062,6 +4090,7 @@
 [[
   name: as_strided
   variants: [method,function]
+  cpu_half: True
   return: argument 0
   arguments:
     - arg: THTensor* result
@@ -4082,6 +4111,7 @@
 [[
   name: as_strided_
   variants: [method,function]
+  cpu_half: True
   return: argument 0
   arguments:
     - THTensor* self


### PR DESCRIPTION
 - Make transpose and as_strided work on CPU half
 - Bind at::pow(float, Tensor)
 - Add _dirichlet_grad from TensorRandom.cwrap