### PR TITLE
Release NCCL distributed backend from experimental

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -386,7 +386,7 @@ def all_gather_multigpu(output_tensor_lists,
             contain correctly-sized tensors on each GPU to be used for output of
             the collective.
 
-            e.g. output_tensor_lists[i] contrains the all_gather
+            e.g. output_tensor_lists[i] contains the all_gather
             result that resides on the GPU of input_tensor_list[i].
 
             Note that each element of output_tensor_lists[i] has the size of

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -95,14 +95,6 @@ def init_process_group(backend, init_method='env://', **kwargs):
     _initialized = _INITIALIZED_PG
 
     if _backend == dist_backend.NCCL:
-        warnings.warn("""
-        ================================================================================
-                                            WARNING
-        ================================================================================
-        NCCL backend is still experimental. The APIs will change without
-        notice and we're can't guarantee full correctness and expected performance yet.
-        We'll announce it once it's ready.
-        """)
         atexit.register(destroy_process_group)
 
     if not torch._C._dist_init_extension(False, reduce_op, group):
@@ -255,20 +247,15 @@ def broadcast_multigpu(tensor_list, src, group=group.WORLD):
             tensor_list (tensor_list[0]) will be broadcasted to all other
             tensors (on different GPUs) in the src process and all tensors in
             tensor_list of other non-src processes.
+
+            You also need to make sure that len(tensor_list) is the same for
+            all the distributed processes calling this function.
+
         src (int): Source rank.
         group (optional): Group of the collective.
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
-
-    warnings.warn("""
-    ================================================================================
-                                        WARNING
-    ================================================================================
-    broadcast_multigpu is still experimental. The API will change without
-    notice and we're can't guarantee full correctness and expected performance yet.
-    We'll announce it once it's ready.
-    """)
 
     return torch._C._dist_broadcast_multigpu(tensor_list, src, group)
 
@@ -307,21 +294,16 @@ def all_reduce_multigpu(tensor_list, op=reduce_op.SUM, group=group.WORLD):
         tensor list (List[Tensor]): List of input and output tensors of
             the collective. The function operates in-place and requires that
             each tensor to be a GPU tensor on different GPUs.
+
+            You also need to make sure that len(tensor_list) is the same for
+            all the distributed processes calling this function.
+
         op (optional): One of the values from ``torch.distributed.reduce_op``
             enum.  Specifies an operation used for element-wise reductions.
         group (optional): Group of the collective.
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
-
-    warnings.warn("""
-    ================================================================================
-                                        WARNING
-    ================================================================================
-    all_reduce_multigpu is still experimental. The API will change without
-    notice and we're can't guarantee full correctness and expected performance yet.
-    We'll announce it once it's ready.
-    """)
 
     return torch._C._dist_all_reduce_multigpu(tensor_list, op, group)
 
@@ -357,6 +339,10 @@ def reduce_multigpu(tensor_list, dst, op=reduce_op.SUM, group=group.WORLD):
     Arguments:
         tensor_list (List[Tensor]): Input and output GPU tensors of the
             collective . The function operates in-place.
+
+            You also need to make sure that len(tensor_list) is the same for
+            all the distributed processes calling this function.
+
         dst (int): Destination rank
         op (optional): One of the values from ``torch.distributed.reduce_op``
             enum.  Specifies an operation used for element-wise reductions.
@@ -364,15 +350,6 @@ def reduce_multigpu(tensor_list, dst, op=reduce_op.SUM, group=group.WORLD):
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
-
-    warnings.warn("""
-    ================================================================================
-                                        WARNING
-    ================================================================================
-    reduce__multigpu is still experimental. The API will change without
-    notice and we're can't guarantee full correctness and expected performance yet.
-    We'll announce it once it's ready.
-    """)
 
     return torch._C._dist_reduce_multigpu(tensor_list, dst, op, group)
 
@@ -408,21 +385,30 @@ def all_gather_multigpu(output_tensor_lists,
         output_tensor_lists (List[List[Tensor]]): Output lists. It should
             contain correctly-sized tensors on each GPU to be used for output of
             the collective.
+
+            e.g. output_tensor_lists[i] contrains the all_gather
+            result that resides on the GPU of input_tensor_list[i].
+
+            Note that each element of output_tensor_lists[i] has the size of
+            world_size * len(input_tensor_list), since the function all gathers
+            the result from every single GPU in the group. To interpret each
+            element of output_tensor_list[i], note that input_tensor_list[j] of
+            rank k will be appear in
+            output_tensor_list[i][rank * world_size + j]
+
+            Also note that len(output_tensor_lists), and the size of each
+            element in output_tensor_lists (each element is a list,
+            therefore len(output_tensor_lists[i])), need to be the same
+            for all the distributed processes calling this function.
+
         input_tensor_list (List[Tensor]): List of tensors(on different GPUs) to
             be broadcast from current process.
+            Note that len(input_tensor_list) needs to be the same for
+            all the distributed processes calling this function.
         group (optional): Group of the collective.
     """
     assert torch.distributed._initialized == _INITIALIZED_PG, \
         "collective only supported in process-group mode"
-
-    warnings.warn("""
-    ================================================================================
-                                        WARNING
-    ================================================================================
-    all_gather_multigpu is still experimental. The API will change without
-    notice and we're can't guarantee full correctness and expected performance yet.
-    We'll announce it once it's ready.
-    """)
 
     flatten_tensor_list = []
     for output_tensor_list in output_tensor_lists:


### PR DESCRIPTION
After removing the hacky clear NCCL communicator cache and adding all the tests. I think we are in a good shape to release the NCCL backend from experimental.