### PR TITLE
[ready] Layer Normalization

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <sstream>
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 
 namespace at {
 

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -1,5 +1,5 @@
 #include "ATen/Config.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 
 #include "ATen/ATen.h"
 
@@ -210,4 +210,11 @@ void checkBackend(CheckedFrom c, ArrayRef<Tensor> tensors, at::Backend backend) 
   }
 }
 
+void * maybe_data_ptr(const Tensor& tensor) {
+  return tensor.defined() ? (void *)tensor.data_ptr() : nullptr;
+}
+
+void * maybe_data_ptr(const TensorArg& tensor) {
+  return tensor->defined() ? (void *)tensor->data_ptr() : nullptr;
+}
 }

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -4,13 +4,13 @@
 #include "ATen/TensorGeometry.h"
 #include "ATen/Utils.h"
 
-// This file contains utility functions for checking that arguments
-// make sense.  This is particularly useful for native functions,
-// which do NO argument checking by default.
-//
-// It's NOT in Utils.h, because this file has a dep on Tensor.h
+// These functions are NOT in Utils.h, because this file has a dep on Tensor.h
 
 namespace at {
+
+// The follwing are utility functions for checking that arguments
+// make sense.  These are particularly useful for native functions,
+// which do NO argument checking by default.
 
 struct TensorArg {
   Tensor tensor;
@@ -72,4 +72,10 @@ void checkAllDefined(CheckedFrom c, at::ArrayRef<TensorArg> t);
 
 // FixMe: does TensorArg slow things down?
 void checkBackend(CheckedFrom c, at::ArrayRef<Tensor> t, at::Backend backend);
+
+// Methods for getting data_ptr if tensor is defined
+void * maybe_data_ptr(const Tensor& tensor);
+void * maybe_data_ptr(const TensorArg& tensor);
+
 }
+

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -8,7 +8,7 @@
 
 namespace at {
 
-// The follwing are utility functions for checking that arguments
+// The following are utility functions for checking that arguments
 // make sense.  These are particularly useful for native functions,
 // which do NO argument checking by default.
 

--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "detail/IndexUtils.cuh"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 
 //
 // This file contains pointwise operation functions and kernels that

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -4,7 +4,7 @@
 
 #include "cudnn-wrapper.h"
 #include <ATen/ATen.h>
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 
 #if CUDNN_VERSION < 7000
 

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -1,5 +1,5 @@
 #include "ATen/ATen.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 #include "ATen/NativeFunctions.h"
 
 #include <cstring>

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1,5 +1,5 @@
 #include "ATen/ATen.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 #include "ATen/NativeFunctions.h"
 
 #include <cstring>

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -1,5 +1,5 @@
 #include "ATen/ATen.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 #include "ATen/NativeFunctions.h"
 
 #include <sstream>

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -1,5 +1,5 @@
 #include "ATen/ATen.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 #include "ATen/Dispatch.h"
 #include "ATen/NativeFunctions.h"
 

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -1,5 +1,5 @@
 #include "ATen/ATen.h"
-#include "ATen/Check.h"
+#include "ATen/TensorUtils.h"
 #include "ATen/Dispatch.h"
 #include "ATen/NativeFunctions.h"
 

--- a/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
+++ b/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
@@ -30,7 +30,7 @@ Tensor cudnn_affine_grid_generator_backward(
 #include <ATen/cudnn/Types.h>
 #include <ATen/cudnn/Utils.h>
 
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -31,7 +31,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm_backward(
 #include <ATen/cudnn/Types.h>
 #include <ATen/cudnn/Utils.h>
 
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -60,7 +60,10 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
   CheckedFrom c = "cudnn_batch_norm";
   setCuDNNStreamToCurrent();
 
-  checkAllDefined(c, {input, weight, bias, running_mean, running_var});
+  checkAllDefined(c, {input, weight, bias});
+  if (!training) {
+    checkAllDefined(c, {running_mean, running_var});
+  }
   checkAllSameGPU(c, {input, weight, bias, running_mean, running_var});
   if (input->type().scalarType() == ScalarType::Half) {
     checkScalarType(c, weight, ScalarType::Float);
@@ -73,7 +76,9 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
   checkDimRange(c, input, 2, 6 /* exclusive */);
   auto num_features = input->size(1);
   for (auto t : {weight, bias, running_mean, running_var}) {
-    checkNumel(c, t, num_features);
+    if (t->defined()) {
+      checkNumel(c, t, num_features);
+    }
   }
 
   cudnnBatchNormMode_t mode;
@@ -97,16 +102,12 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
-
-  // Though technically we only need to allocate this for training,
-  //  (1) THNN batch normalization expects non-undefined tensors for
-  //  backwards (which we will pass these to, if !training, because
-  //  CuDNN backwards with !training doesn't gradcheck), and
-  //  (2) These are pretty small tensors, no big deal.
-  Tensor save_mean = running_mean_t.type().tensor(running_mean_t.sizes());
-  Tensor save_var = running_var_t.type().tensor(running_var_t.sizes());
+  Tensor save_mean, save_var;
 
   if (training) {
+    int64_t num_features = input_t.size(1);
+    save_mean = weight_t.type().tensor({ num_features });
+    save_var = weight_t.type().tensor({ num_features });
     CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
       handle, mode, &one, &zero,
       idesc.desc(), input->data_ptr(),
@@ -115,8 +116,8 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
       weight->data_ptr(),
       bias->data_ptr(),
       exponential_average_factor,
-      running_mean->data_ptr(),
-      running_var->data_ptr(),
+      at::maybe_data_ptr(running_mean),
+      at::maybe_data_ptr(running_var),
       epsilon,
       save_mean.data_ptr(),
       save_var.data_ptr()));

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -80,7 +80,7 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_transpose_backwar
 #include <ATen/cudnn/Types.h>
 #include <ATen/cudnn/Utils.h>
 
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 
 #include <functional>
 #include <iterator>

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -27,7 +27,7 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
 #include <ATen/cudnn/Types.h>
 #include <ATen/cudnn/Utils.h>
 
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 
 // TODO: descriptor checking
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -22,7 +22,7 @@
 - func: addr_out(Tensor result, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
 
-- func: batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor running_mean, Tensor running_var, bool training, double momentum, double eps, bool cudnn_enabled) -> Tensor
+- func: batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, double momentum, double eps, bool cudnn_enabled) -> Tensor
   variants: function
 
 - func: bernoulli_(Tensor self, Tensor p, Generator* generator=nullptr) -> Tensor
@@ -91,11 +91,11 @@
       name: grad_theta
   variants: function
 
-- func: cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor running_mean, Tensor running_var, bool training, double exponential_average_factor, double epsilon) -> (Tensor, Tensor, Tensor)
+- func: cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, double exponential_average_factor, double epsilon) -> (Tensor, Tensor, Tensor)
   variants: function
 
 # NB: You can only use this if you used cudnn_batch_norm training=True
-- func: cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor running_mean, Tensor running_var, Tensor? save_mean, Tensor? save_var, double epsilon) -> (Tensor, Tensor, Tensor)
+- func: cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, double epsilon) -> (Tensor, Tensor, Tensor)
   variants: function
 
 - func: cudnn_convolution(Tensor self, Tensor weight, Tensor? bias, IntList padding, IntList stride, IntList dilation, int64_t groups, bool benchmark, bool deterministic) -> Tensor

--- a/aten/src/THCUNN/BatchNormalization.cu
+++ b/aten/src/THCUNN/BatchNormalization.cu
@@ -141,8 +141,8 @@ template <typename Dtype, typename Acctype, typename DeviceTensor1, typename Dev
 __global__ void BatchNormalizationUpdateOutputInference_kernel(
     const DeviceTensor3 input,
     DeviceTensor3 output,
-    DeviceTensor1 runningMean,
-    DeviceTensor1 runningVar,
+    const DeviceTensor1 runningMean,
+    const DeviceTensor1 runningVar,
     const DeviceTensor1 weight,
     const DeviceTensor1 bias,
     Acctype epsilon) {
@@ -196,8 +196,12 @@ __global__ void BatchNormalizationUpdateOutput_kernel(
     Acctype unbiasedVar = varN / (N - 1);
     saveMean[plane] = ScalarConvert<Acctype, Dtype>::to(mean);
     saveStd[plane] = ScalarConvert<Acctype, Dtype>::to(invStd);
-    runningMean[plane] = ScalarConvert<Acctype, Dtype>::to((1 - momentum) * runningMean[plane] + momentum * mean);
-    runningVar[plane] = ScalarConvert<Acctype, Dtype>::to((1 - momentum) * runningVar[plane] + momentum * unbiasedVar);
+    if (runningMean.data() != NULL) {
+      runningMean[plane] = ScalarConvert<Acctype, Dtype>::to((1 - momentum) * runningMean[plane] + momentum * mean);
+    }
+    if (runningVar.data() != NULL) {
+      runningVar[plane] = ScalarConvert<Acctype, Dtype>::to((1 - momentum) * runningVar[plane] + momentum * unbiasedVar);
+    }
   }
 
   // Write normalized and update the output

--- a/aten/src/THCUNN/generic/BatchNormalization.cu
+++ b/aten/src/THCUNN/generic/BatchNormalization.cu
@@ -39,8 +39,9 @@ void THNN_(BatchNormalization_updateOutput)(
 
   THCTensor_(resizeAs)(state, output_, input_);
   if (train) {
-    THCTensor_(resizeAs)(state, saveMean_, runningMean_);
-    THCTensor_(resizeAs)(state, saveStd_, runningVar_);
+    int64_t nInput = THCTensor_(size)(state, input_, 1);
+    THCTensor_(resize1d)(state, saveMean_, nInput);
+    THCTensor_(resize1d)(state, saveStd_, nInput);
   }
   DeviceTensor3 input = devicetensor<3>(state, input_);
   DeviceTensor3 output = devicetensor<3>(state, output_);

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -36,8 +36,8 @@ TH_API void THNN_(BatchNormalization_updateOutput)(
                   THCTensor *output_,
                   THCTensor *weight_,        // [OPTIONAL]
                   THCTensor *bias_,          // [OPTIONAL]
-                  THCTensor *runningMean_,
-                  THCTensor *runningVar_,
+                  THCTensor *runningMean_,   // [OPTIONAL] if train
+                  THCTensor *runningVar_,    // [OPTIONAL] if train
                   THCTensor *saveMean_,
                   THCTensor *saveStd_,
                   bool train,
@@ -52,10 +52,10 @@ TH_API void THNN_(BatchNormalization_backward)(
                   THCTensor *gradWeight_,       // [OPTIONAL]
                   THCTensor *gradBias_,         // [OPTIONAL]
                   THCTensor *weight_,           // [OPTIONAL]
-                  THCTensor *runningMean_,
-                  THCTensor *runningVar_,
-                  THCTensor *saveMean_,
-                  THCTensor *saveStd_,
+                  THCTensor *runningMean_,      // [OPTIONAL] if train
+                  THCTensor *runningVar_,       // [OPTIONAL] if train
+                  THCTensor *saveMean_,         // [OPTIONAL] if !train
+                  THCTensor *saveStd_,          // [OPTIONAL] if !train
                   bool train,
                   double scale,
                   double eps);

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -814,8 +814,8 @@ TH_API void THNN_(BatchNormalization_updateOutput)(
           THTensor *output,
           THTensor *weight,       // [OPTIONAL]
           THTensor *bias,         // [OPTIONAL]
-          THTensor *running_mean,
-          THTensor *running_var,
+          THTensor *running_mean, // [OPTIONAL] if train
+          THTensor *running_var,  // [OPTIONAL] if train
           THTensor *save_mean,
           THTensor *save_std,
           bool train,
@@ -829,10 +829,10 @@ TH_API void THNN_(BatchNormalization_backward)(
           THTensor *gradWeight,   // [OPTIONAL]
           THTensor *gradBias,     // [OPTIONAL]
           THTensor *weight,       // [OPTIONAL]
-          THTensor *running_mean,
-          THTensor *running_var,
-          THTensor *save_mean,
-          THTensor *save_std,
+          THTensor *running_mean, // [OPTIONAL] if train
+          THTensor *running_var,  // [OPTIONAL] if train
+          THTensor *save_mean,    // [OPTIONAL] if !train
+          THTensor *save_std,     // [OPTIONAL] if !train
           bool train,
           double scale,
           double eps);

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -378,6 +378,12 @@ Normalization layers
 .. autoclass:: InstanceNorm3d
     :members:
 
+:hidden:`LayerNorm`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: LayerNorm
+    :members:
+
 :hidden:`LocalResponseNorm`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -949,6 +949,16 @@ Normalization functions
 
 .. autofunction:: batch_norm
 
+:hidden:`instance_norm`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: instance_norm
+
+:hidden:`layer_norm`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: layer_norm
+
 :hidden:`local_response_norm`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/common.py
+++ b/test/common.py
@@ -4,6 +4,7 @@ import re
 import argparse
 import unittest
 import warnings
+import random
 import contextlib
 from functools import wraps
 from itertools import product
@@ -106,6 +107,7 @@ def to_gpu(obj, type_map={}):
 
 def set_rng_seed(seed):
     torch.manual_seed(seed)
+    random.seed(seed)
     if TEST_NUMPY:
         numpy.random.seed(seed)
 

--- a/test/expect/TestJit.test_batchnorm.expect
+++ b/test/expect/TestJit.test_batchnorm.expect
@@ -1,8 +1,8 @@
-graph(%0 : Double(2, 2)
+graph(%0 : Double(2, 2, 2, 2)
       %1 : Double(2)
       %2 : Double(2)
       %3 : Double(2)
       %4 : Double(2)) {
-  %5 : Double(2, 2) = batch_norm[training=1, momentum=0.1, eps=1e-05, cudnn_enabled=1](%0, %1, %2, %3, %4), scope: BatchNorm2d
+  %5 : Double(2, 2, 2, 2) = batch_norm[training=1, momentum=0.1, eps=1e-05, cudnn_enabled=1](%0, %1, %2, %3, %4), scope: BatchNorm2d
   return (%5);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -884,7 +884,7 @@ class TestJit(TestCase):
         self.assertExpected(torch._C._jit_run_cpp_tests())
 
     def test_batchnorm(self):
-        x = Variable(torch.randn(2, 2).fill_(1.0), requires_grad=True)
+        x = Variable(torch.randn(2, 2, 2, 2).fill_(1.0), requires_grad=True)
         trace, _ = torch.jit.trace(nn.BatchNorm2d(2), x)
         self.assertExpectedTrace(trace)
 
@@ -899,7 +899,7 @@ class TestJit(TestCase):
             pass
 
         bn = MyBatchNorm2d(1)
-        x = Variable(torch.randn(5, 1))
+        x = Variable(torch.randn(5, 1, 2, 1))
         z = bn(x)
         with self.assertCompiled(bn):
             z2 = bn(x)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -828,7 +828,7 @@
   self, weight, bias: thnn_batch_norm_backward(grad.contiguous(), self, weight, running_mean, running_var, training, eps, save_mean, save_std, grad_input_mask)
 
 - name: thnn_batch_norm_backward(Tensor grad_output, Tensor self, Tensor weight, Tensor running_mean, Tensor running_var, bool training, double eps, Tensor save_mean, Tensor save_std, std::array<bool,3> output_mask)
-  self, weight, grad_output: batchnorm_double_backward(self, weight, grads[0], grads[1], grads[2], grad_output, eps, save_mean, save_std, running_mean, running_var, training)
+  self, weight, grad_output: batchnorm_double_backward(self, weight, grads[0], grads[1], grads[2], grad_output, running_mean, running_var, training, eps, save_mean, save_std, grad_input_mask)
   save_mean: not_implemented("thnn_batch_norm_backward save_mean")
   save_std: not_implemented("thnn_batch_norm_backward save_std")
 
@@ -1093,7 +1093,7 @@
 - name: cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor running_mean, Tensor running_var, Tensor save_mean, Tensor save_var, double epsilon)
   save_mean: not_implemented("cudnn_batch_norm_backward save_mean")
   save_var: not_implemented("cudnn_batch_norm_backward save_var")
-  input, weight, grad_output: batchnorm_double_backward(input, weight, grads[0], grads[1], grads[2], grad_output, epsilon, save_mean, save_var, running_mean, running_var, true)
+  input, weight, grad_output: batchnorm_double_backward(input, weight, grads[0], grads[1], grads[2], grad_output, running_mean, running_var, true, epsilon, save_mean, save_var, grad_input_mask)
 
 # nnpack
 

--- a/torch/csrc/utils/tensor_apply.cpp
+++ b/torch/csrc/utils/tensor_apply.cpp
@@ -1,6 +1,6 @@
 #include "tensor_apply.h"
 
-#include <ATen/Check.h>
+#include <ATen/TensorUtils.h>
 #include <ATen/ExpandUtils.h>
 
 #include "torch/csrc/Exceptions.h"

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1173,7 +1173,7 @@ def embedding_bag(embedding_matrix, indices, offsets=None,
 
 def batch_norm(input, running_mean, running_var, weight=None, bias=None,
                training=False, momentum=0.1, eps=1e-5):
-    """Applies Batch Normalization for each channel across a batch of data.
+    r"""Applies Batch Normalization for each channel across a batch of data.
 
     See :class:`~torch.nn.BatchNorm1d`, :class:`~torch.nn.BatchNorm2d`,
     :class:`~torch.nn.BatchNorm3d` for details.
@@ -1194,7 +1194,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
 
 def instance_norm(input, running_mean, running_var, weight=None, bias=None,
                   use_input_stats=True, momentum=0.1, eps=1e-5):
-    """Applies Instance Normalization for each channel in each data sample in a
+    r"""Applies Instance Normalization for each channel in each data sample in a
     batch.
 
     See :class:`~torch.nn.InstanceNorm1d`, :class:`~torch.nn.InstanceNorm2d`,
@@ -1245,7 +1245,7 @@ def instance_norm(input, running_mean, running_var, weight=None, bias=None,
 def layer_norm(input, normalized_shape, running_mean, running_var,
                weight=None, bias=None, use_input_stats=True,
                momentum=0.1, eps=1e-5):
-    """Applies Layer Normalization for last certain number of dimensions.
+    r"""Applies Layer Normalization for last certain number of dimensions.
 
     See :class:`~torch.nn.LayerNorm` for details.
     """

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -15,10 +15,10 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     AdaptiveMaxPool2d, AdaptiveMaxPool3d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
+from .normalization import LocalResponseNorm, CrossMapLRN2d, LayerNorm
 from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
 from .padding import ReflectionPad1d, ReflectionPad2d, ReplicationPad1d, ReplicationPad2d, \
     ReplicationPad3d, ZeroPad2d, ConstantPad1d, ConstantPad2d, ConstantPad3d
-from .normalization import LocalResponseNorm, CrossMapLRN2d
 from .sparse import Embedding, EmbeddingBag
 from .rnn import RNNBase, RNN, LSTM, GRU, \
     RNNCell, LSTMCell, GRUCell
@@ -39,9 +39,9 @@ __all__ = [
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
-    'InstanceNorm2d', 'InstanceNorm3d', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'ReflectionPad1d',
-    'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d', 'CrossMapLRN2d',
-    'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
+    'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout',
+    'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d',
+    'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -8,43 +8,56 @@ from .. import functional as F
 # TODO: use separate backend functions?
 class _BatchNorm(Module):
 
-    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True):
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
+                 track_running_stats=True):
         super(_BatchNorm, self).__init__()
         self.num_features = num_features
-        self.affine = affine
         self.eps = eps
         self.momentum = momentum
+        self.affine = affine
+        self.track_running_stats = track_running_stats
         if self.affine:
             self.weight = Parameter(torch.Tensor(num_features))
             self.bias = Parameter(torch.Tensor(num_features))
         else:
             self.register_parameter('weight', None)
             self.register_parameter('bias', None)
-        self.register_buffer('running_mean', torch.zeros(num_features))
-        self.register_buffer('running_var', torch.ones(num_features))
+        if self.track_running_stats:
+            self.register_buffer('running_mean', torch.zeros(num_features))
+            self.register_buffer('running_var', torch.ones(num_features))
+        else:
+            self.register_parameter('running_mean', None)
+            self.register_parameter('running_var', None)
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.running_mean.zero_()
-        self.running_var.fill_(1)
+        if self.track_running_stats:
+            self.running_mean.zero_()
+            self.running_var.fill_(1)
         if self.affine:
             self.weight.data.uniform_()
             self.bias.data.zero_()
 
+    def _check_input_dim(self, input):
+        return NotImplemented
+
     def forward(self, input):
+        self._check_input_dim(input)
+
         return F.batch_norm(
             input, self.running_mean, self.running_var, self.weight, self.bias,
-            self.training, self.momentum, self.eps)
+            self.training or not self.track_running_stats, self.momentum, self.eps)
 
     def __repr__(self):
         return ('{name}({num_features}, eps={eps}, momentum={momentum},'
-                ' affine={affine})'
+                ' affine={affine}, track_running_stats={track_running_stats})'
                 .format(name=self.__class__.__name__, **self.__dict__))
 
 
 class BatchNorm1d(_BatchNorm):
-    r"""Applies Batch Normalization over a 2d or 3d input that is seen as a
-    mini-batch.
+    r"""Applies Batch Normalization over a 3d input (a mini-batch of 2d inputs)
+    as described in the paper
+    `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
 
@@ -54,23 +67,39 @@ class BatchNorm1d(_BatchNorm):
     the mini-batches and gamma and beta are learnable parameter vectors
     of size C (where C is the input size).
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, during training this layer keeps running estimates of its
+    computed mean and variance, which are then used for normalization during
+    evaluation. The running estimates are kept with a default :attr:`momentum`
+    of 0.1.
 
-    During evaluation, this running mean/variance is used for normalization.
+    If :attr:`track_running_stats` is set to ``False``, this layer then does not
+    keep running estimates, and batch statistics are instead used during
+    evaluation time as well.
+
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
     on `(N, L)` slices, it's common terminology to call this Temporal BatchNorm
 
     Args:
         num_features: num_features from an expected input of size
-            `batch_size x num_features [x width]`
+            `[batch_size x num_features (x width)]`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``True``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C)` or :math:`(N, C, L)`
@@ -83,18 +112,21 @@ class BatchNorm1d(_BatchNorm):
         >>> m = nn.BatchNorm1d(100, affine=False)
         >>> input = autograd.Variable(torch.randn(20, 100))
         >>> output = m(input)
+
+    .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:
+        https://arxiv.org/abs/1502.03167
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 2 and input.dim() != 3:
             raise ValueError('expected 2D or 3D input (got {}D input)'
                              .format(input.dim()))
-        super(BatchNorm1d, self)._check_input_dim(input)
 
 
 class BatchNorm2d(_BatchNorm):
-    r"""Applies Batch Normalization over a 4d input that is seen as a mini-batch
-    of 3d inputs
+    r"""Applies Batch Normalization over a 4d input (a mini-batch of 3d inputs)
+    as described in the paper
+    `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
 
@@ -104,23 +136,39 @@ class BatchNorm2d(_BatchNorm):
     the mini-batches and gamma and beta are learnable parameter vectors
     of size C (where C is the input size).
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, during training this layer keeps running estimates of its
+    computed mean and variance, which are then used for normalization during
+    evaluation. The running estimates are kept with a default :attr:`momentum`
+    of 0.1.
 
-    During evaluation, this running mean/variance is used for normalization.
+    If :attr:`track_running_stats` is set to ``False``, this layer then does not
+    keep running estimates, and batch statistics are instead used during
+    evaluation time as well.
+
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
     on `(N, H, W)` slices, it's common terminology to call this Spatial BatchNorm
 
     Args:
         num_features: num_features from an expected input of
-            size batch_size x num_features x height x width
+            size `[batch_size x num_features x height x width]`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``True``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -133,18 +181,21 @@ class BatchNorm2d(_BatchNorm):
         >>> m = nn.BatchNorm2d(100, affine=False)
         >>> input = autograd.Variable(torch.randn(20, 100, 35, 45))
         >>> output = m(input)
+
+    .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:
+        https://arxiv.org/abs/1502.03167
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 4:
             raise ValueError('expected 4D input (got {}D input)'
                              .format(input.dim()))
-        super(BatchNorm2d, self)._check_input_dim(input)
 
 
 class BatchNorm3d(_BatchNorm):
-    r"""Applies Batch Normalization over a 5d input that is seen as a mini-batch
-    of 4d inputs
+    r"""Applies Batch Normalization over a 5d input (a mini-batch of 4d inputs)
+    as described in the paper
+    `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
 
@@ -154,10 +205,22 @@ class BatchNorm3d(_BatchNorm):
     the mini-batches and gamma and beta are learnable parameter vectors
     of size C (where C is the input size).
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, during training this layer keeps running estimates of its
+    computed mean and variance, which are then used for normalization during
+    evaluation. The running estimates are kept with a default :attr:`momentum`
+    of 0.1.
 
-    During evaluation, this running mean/variance is used for normalization.
+    If :attr:`track_running_stats` is set to ``False``, this layer then does not
+    keep running estimates, and batch statistics are instead used during
+    evaluation time as well.
+
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
     on `(N, D, H, W)` slices, it's common terminology to call this Volumetric BatchNorm
@@ -165,13 +228,17 @@ class BatchNorm3d(_BatchNorm):
 
     Args:
         num_features: num_features from an expected input of
-            size batch_size x num_features x depth x height x width
+            `[size batch_size x num_features x depth x height x width]`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
             computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``True``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`
@@ -184,10 +251,12 @@ class BatchNorm3d(_BatchNorm):
         >>> m = nn.BatchNorm3d(100, affine=False)
         >>> input = autograd.Variable(torch.randn(20, 100, 35, 45, 10))
         >>> output = m(input)
+
+    .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:
+        https://arxiv.org/abs/1502.03167
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 5:
             raise ValueError('expected 5D input (got {}D input)'
                              .format(input.dim()))
-        super(BatchNorm3d, self)._check_input_dim(input)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -55,8 +55,8 @@ class _BatchNorm(Module):
 
 
 class BatchNorm1d(_BatchNorm):
-    r"""Applies Batch Normalization over a 3d input (a mini-batch of 2d inputs)
-    as described in the paper
+    r"""Applies Batch Normalization over a 2d or 3d input (a mini-batch of 1d
+    inputs with optional additional channel dimension) as described in the paper
     `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
@@ -89,7 +89,7 @@ class BatchNorm1d(_BatchNorm):
 
     Args:
         num_features: num_features from an expected input of size
-            `[batch_size x num_features (x width)]`
+            :math:`(N, C, L)` or :math:`(N, L)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
@@ -124,8 +124,8 @@ class BatchNorm1d(_BatchNorm):
 
 
 class BatchNorm2d(_BatchNorm):
-    r"""Applies Batch Normalization over a 4d input (a mini-batch of 3d inputs)
-    as described in the paper
+    r"""Applies Batch Normalization over a 4d input (a mini-batch of 2d inputs
+    with additional channel dimension) as described in the paper
     `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
@@ -157,8 +157,8 @@ class BatchNorm2d(_BatchNorm):
     on `(N, H, W)` slices, it's common terminology to call this Spatial BatchNorm
 
     Args:
-        num_features: num_features from an expected input of
-            size `[batch_size x num_features x height x width]`
+        num_features: num_features from an expected input of size
+            :math:`(N, C, H, W)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
@@ -193,8 +193,8 @@ class BatchNorm2d(_BatchNorm):
 
 
 class BatchNorm3d(_BatchNorm):
-    r"""Applies Batch Normalization over a 5d input (a mini-batch of 4d inputs)
-    as described in the paper
+    r"""Applies Batch Normalization over a 5d input (a mini-batch of 3d inputs
+    with additional channel dimension) as described in the paper
     `Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`_ .
 
     .. math::
@@ -227,8 +227,8 @@ class BatchNorm3d(_BatchNorm):
     or Spatio-temporal BatchNorm
 
     Args:
-        num_features: num_features from an expected input of
-            `[size batch_size x num_features x depth x height x width]`
+        num_features: num_features from an expected input of size
+            :math:`(N, C, D, H, W)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -85,11 +85,11 @@ class BatchNorm1d(_BatchNorm):
         new observed value.
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
-    on `(N, L)` slices, it's common terminology to call this Temporal BatchNorm
+    on `(N, L)` slices, it's common terminology to call this Temporal BatchNorm.
 
     Args:
-        num_features: num_features from an expected input of size
-            :math:`(N, C, L)` or :math:`(N, L)`
+        num_features: :math:`C` from an expected input of size
+            :math:`(N, C, L)` or :math:`L` from input of size :math:`(N, L)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
         momentum: the value used for the running_mean and running_var
@@ -154,10 +154,10 @@ class BatchNorm2d(_BatchNorm):
         new observed value.
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
-    on `(N, H, W)` slices, it's common terminology to call this Spatial BatchNorm
+    on `(N, H, W)` slices, it's common terminology to call this Spatial BatchNorm.
 
     Args:
-        num_features: num_features from an expected input of size
+        num_features: :math:`C` from an expected input of size
             :math:`(N, C, H, W)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5
@@ -224,10 +224,10 @@ class BatchNorm3d(_BatchNorm):
 
     Because the BatchNorm is done over the `C` dimension, computing statistics
     on `(N, D, H, W)` slices, it's common terminology to call this Volumetric BatchNorm
-    or Spatio-temporal BatchNorm
+    or Spatio-temporal BatchNorm.
 
     Args:
-        num_features: num_features from an expected input of size
+        num_features: :math:`C` from an expected input of size
             :math:`(N, C, D, H, W)`
         eps: a value added to the denominator for numerical stability.
             Default: 1e-5

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -14,16 +14,13 @@ class _InstanceNorm(_BatchNorm):
     def forward(self, input):
         self._check_input_dim(input)
 
-        training = self.training or not self.track_running_stats
-        return F.instance_norm(input, weight=weight, bias=bias,
-                               saved_running_mean=self.running_mean,
-                               saved_running_var=self.running_var,
-                               training=training, momentum=self.momentum,
-                               eps=self.eps, affine=self.affine)
+        return F.instance_norm(
+            input, self.running_mean, self.running_var, self.weight, self.bias,
+            self.training or not self.track_running_stats, self.momentum, self.eps)
 
 
 class InstanceNorm1d(_InstanceNorm):
-    r"""Applies Batch Normalization over a 3d input (a mini-batch of 2d inputs)
+    r"""Applies Instance Normalization over a 3d input (a mini-batch of 2d inputs)
     as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
@@ -86,7 +83,7 @@ class InstanceNorm1d(_InstanceNorm):
 
 
 class InstanceNorm2d(_InstanceNorm):
-    r"""Applies Batch Normalization over a 4d input (a mini-batch of 3d inputs)
+    r"""Applies Instance Normalization over a 4d input (a mini-batch of 3d inputs)
     as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
@@ -149,7 +146,7 @@ class InstanceNorm2d(_InstanceNorm):
 
 
 class InstanceNorm3d(_InstanceNorm):
-    r"""Applies Batch Normalization over a 5d input (a mini-batch of 4d inputs)
+    r"""Applies Instance Normalization over a 5d input (a mini-batch of 4d inputs)
     as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -49,8 +49,8 @@ class InstanceNorm1d(_InstanceNorm):
         new observed value.
 
     Args:
-        num_features: num_features from an expected input of size
-            :math:`(N, C, L)` or :math:`(N, L)`
+        num_features: :math:`C` from an expected input of size
+            :math:`(N, C, L)` or :math:`L` from input of size :math:`(N, L)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
@@ -112,7 +112,7 @@ class InstanceNorm2d(_InstanceNorm):
         new observed value.
 
     Args:
-        num_features: num_features from an expected input of size
+        num_features: :math:`C` from an expected input of size
             :math:`(N, C, H, W)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
@@ -175,7 +175,7 @@ class InstanceNorm3d(_InstanceNorm):
         new observed value.
 
     Args:
-        num_features: num_features from an expected input of size
+        num_features: :math:`C` from an expected input of size
             :math:`(N, C, D, H, W)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -20,8 +20,8 @@ class _InstanceNorm(_BatchNorm):
 
 
 class InstanceNorm1d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 3d input (a mini-batch of 2d inputs)
-    as described in the paper
+    r"""Applies Instance Normalization over a 2d or 3d input (a mini-batch of 1d
+    inputs with optional additional channel dimension) as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
@@ -50,7 +50,7 @@ class InstanceNorm1d(_InstanceNorm):
 
     Args:
         num_features: num_features from an expected input of size
-            `[batch_size x num_features x width]`
+            :math:`(N, C, L)` or :math:`(N, L)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
@@ -83,8 +83,8 @@ class InstanceNorm1d(_InstanceNorm):
 
 
 class InstanceNorm2d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 4d input (a mini-batch of 3d inputs)
-    as described in the paper
+    r"""Applies Instance Normalization over a 4d input (a mini-batch of 2d inputs
+    with additional channel dimension) as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
@@ -113,7 +113,7 @@ class InstanceNorm2d(_InstanceNorm):
 
     Args:
         num_features: num_features from an expected input of size
-            `[batch_size x num_features x height x width]`
+            :math:`(N, C, H, W)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has
@@ -146,8 +146,8 @@ class InstanceNorm2d(_InstanceNorm):
 
 
 class InstanceNorm3d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 5d input (a mini-batch of 4d inputs)
-    as described in the paper
+    r"""Applies Instance Normalization over a 5d input (a mini-batch of 3d inputs
+    with additional channel dimension) as described in the paper
     `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
@@ -176,7 +176,7 @@ class InstanceNorm3d(_InstanceNorm):
 
     Args:
         num_features: num_features from an expected input of size
-            `[batch_size x num_features x depth x height x width]`
+            :math:`(N, C, D, H, W)`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         affine: a boolean value that when set to ``True``, this module has

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -3,38 +3,29 @@ from .. import functional as F
 
 
 class _InstanceNorm(_BatchNorm):
-    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=False):
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=False,
+                 track_running_stats=False):
         super(_InstanceNorm, self).__init__(
-            num_features, eps, momentum, affine)
-        self._use_running_stats = False
+            num_features, eps, momentum, affine, track_running_stats)
+
+    def _check_input_dim(self, input):
+        return NotImplemented
 
     def forward(self, input):
-        b = input.size(0)
+        self._check_input_dim(input)
 
-        weight, bias = None, None
-        if self.affine:
-            weight = self.weight.repeat(b)
-            bias = self.bias.repeat(b)
-
-        training = not self._use_running_stats
+        training = self.training or not self.track_running_stats
         return F.instance_norm(input, weight=weight, bias=bias,
                                saved_running_mean=self.running_mean,
                                saved_running_var=self.running_var,
                                training=training, momentum=self.momentum,
                                eps=self.eps, affine=self.affine)
 
-    def use_running_stats(self, mode=True):
-        r"""Set using running statistics or instance statistics.
-
-        Instance normalization usually use instance statistics in both training
-        and evaluation modes. But users can set this method to use running
-        statistics in the fashion similar to batch normalization in eval mode.
-        """
-        self._use_running_stats = mode
-
 
 class InstanceNorm1d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 3d input that is seen as a mini-batch.
+    r"""Applies Batch Normalization over a 3d input (a mini-batch of 2d inputs)
+    as described in the paper
+    `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
 
@@ -42,22 +33,35 @@ class InstanceNorm1d(_InstanceNorm):
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. Gamma and beta are learnable parameter vectors
-    of size C (where C is the input size).
+    of size C (where C is the input size) if :attr:`affine` is ``True``.
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, this layer uses instance statistics computed from input data in
+    both training and evaluation modes.
 
-    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
-    i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.use_running_stats(mode=True)` method, and switch back to normal
-    behavior with `.use_running_stats(mode=False)` method.
+    If :attr:`track_running_stats` is set to ``True``, during training this
+    layer keeps running estimates of its computed mean and variance, which are
+    then used for normalization during evaluation. The running estimates are
+    kept with a default :attr:`momentum` of 0.1.
+
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Args:
-        num_features: num_features from an expected input of size `batch_size x num_features x width`
+        num_features: num_features from an expected input of size
+            `[batch_size x num_features x width]`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, L)`
@@ -70,17 +74,21 @@ class InstanceNorm1d(_InstanceNorm):
         >>> m = nn.InstanceNorm1d(100, affine=True)
         >>> input = autograd.Variable(torch.randn(20, 100, 40))
         >>> output = m(input)
+
+    .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:
+        https://arxiv.org/abs/1607.08022
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 3:
             raise ValueError('expected 3D input (got {}D input)'
                              .format(input.dim()))
-        super(InstanceNorm1d, self)._check_input_dim(input)
 
 
 class InstanceNorm2d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 4d input that is seen as a mini-batch of 3d inputs
+    r"""Applies Batch Normalization over a 4d input (a mini-batch of 3d inputs)
+    as described in the paper
+    `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
 
@@ -88,22 +96,35 @@ class InstanceNorm2d(_InstanceNorm):
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. Gamma and beta are learnable parameter vectors
-    of size C (where C is the input size).
+    of size C (where C is the input size) if :attr:`affine` is ``True``.
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, this layer uses instance statistics computed from input data in
+    both training and evaluation modes.
 
-    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
-    i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.use_running_stats(mode=True)` method, and switch back to normal
-    behavior with `.use_running_stats(mode=False)` method.
+    If :attr:`track_running_stats` is set to ``True``, during training this
+    layer keeps running estimates of its computed mean and variance, which are
+    then used for normalization during evaluation. The running estimates are
+    kept with a default :attr:`momentum` of 0.1.
+
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Args:
-        num_features: num_features from an expected input of size batch_size x num_features x height x width
+        num_features: num_features from an expected input of size
+            `[batch_size x num_features x height x width]`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -116,41 +137,57 @@ class InstanceNorm2d(_InstanceNorm):
         >>> m = nn.InstanceNorm2d(100, affine=True)
         >>> input = autograd.Variable(torch.randn(20, 100, 35, 45))
         >>> output = m(input)
+
+    .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:
+        https://arxiv.org/abs/1607.08022
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 4:
             raise ValueError('expected 4D input (got {}D input)'
                              .format(input.dim()))
-        super(InstanceNorm2d, self)._check_input_dim(input)
 
 
 class InstanceNorm3d(_InstanceNorm):
-    r"""Applies Instance Normalization over a 5d input that is seen as a mini-batch of 4d inputs
+    r"""Applies Batch Normalization over a 5d input (a mini-batch of 4d inputs)
+    as described in the paper
+    `Instance Normalization: The Missing Ingredient for Fast Stylization`_ .
 
     .. math::
 
         y = \frac{x - mean[x]}{ \sqrt{Var[x]} + \epsilon} * gamma + beta
 
-    The mean and standard-deviation are calculated per-dimension separately for each object in a mini-batch.
-    Gamma and beta are learnable parameter vectors
-    of size C (where C is the input size).
+    The mean and standard-deviation are calculated per-dimension separately
+    for each object in a mini-batch. Gamma and beta are learnable parameter vectors
+    of size C (where C is the input size) if :attr:`affine` is ``True``.
 
-    During training, this layer keeps a running estimate of its computed mean
-    and variance. The running sum is kept with a default momentum of 0.1.
+    By default, this layer uses instance statistics computed from input data in
+    both training and evaluation modes.
 
-    At evaluation time (`.eval()`), the default behaviour of the InstanceNorm module stays the same
-    i.e. running mean/variance is NOT used for normalization. One can force using stored
-    mean and variance with `.use_running_stats(mode=True)` method, and switch back to normal
-    behavior with `.use_running_stats(mode=False)` method.
+    If :attr:`track_running_stats` is set to ``True``, during training this
+    layer keeps running estimates of its computed mean and variance, which are
+    then used for normalization during evaluation. The running estimates are
+    kept with a default :attr:`momentum` of 0.1.
 
+    .. note::
+        This :attr:`momentum` argument is different from one used in optimizer
+        classes and the conventional notion of momentum. Mathematically, the
+        update rule for running statistics here is
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x}_\text{new} + \text{momemtum} \times x_t`,
+        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
+        new observed value.
 
     Args:
-        num_features: num_features from an expected input of size batch_size x num_features x depth x height x width
+        num_features: num_features from an expected input of size
+            `[batch_size x num_features x depth x height x width]`
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
-        affine: a boolean value that when set to ``True``, gives the layer learnable
-            affine parameters. Default: ``False``
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics and always uses batch
+            statistics in both training and eval modes. Default: ``False``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`
@@ -163,10 +200,12 @@ class InstanceNorm3d(_InstanceNorm):
         >>> m = nn.InstanceNorm3d(100, affine=True)
         >>> input = autograd.Variable(torch.randn(20, 100, 35, 45, 10))
         >>> output = m(input)
+
+    .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:
+        https://arxiv.org/abs/1607.08022
     """
 
     def _check_input_dim(self, input):
         if input.dim() != 5:
             raise ValueError('expected 5D input (got {}D input)'
                              .format(input.dim()))
-        super(InstanceNorm3d, self)._check_input_dim(input)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -11,7 +11,6 @@ class LocalResponseNorm(Module):
     Applies normalization across channels.
 
     .. math::
-
         b_{c} = a_{c}\left(k + \frac{\alpha}{n}
         \sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}a_{c'}^2\right)^{-\beta}
 
@@ -24,7 +23,7 @@ class LocalResponseNorm(Module):
     Shape:
         - Input: :math:`(N, C, ...)`
         - Output: :math:`(N, C, ...)` (same shape as input)
-    Examples::
+    Examples:
         >>> lrn = nn.LocalResponseNorm(2)
         >>> signal_2d = autograd.Variable(torch.randn(32, 5, 24, 24))
         >>> signal_4d = autograd.Variable(torch.randn(16, 5, 7, 7, 7, 7))

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 The torch.onnx module contains functions to export models into the ONNX
 IR format.  These models can be loaded with the ONNX library and then
 converted to models which run on other deep learning frameworks.
@@ -22,7 +22,7 @@ from torch.jit import _unique_state_dict
 
 @contextlib.contextmanager
 def set_training(model, mode):
-    """
+    r"""
     A context manager to temporarily set the training mode of 'model'
     to 'mode', resetting it when we exit the with-block.  A no-op if
     mode is None.
@@ -42,7 +42,7 @@ def set_training(model, mode):
 
 def export(model, args, f, export_params=True, verbose=False, training=False,
            input_names=None, output_names=None, aten=False):
-    """
+    r"""
     Export a model into ONNX format.  This exporter runs your model
     once in order to get a trace of its execution to be exported;
     at the moment, it supports a limited set of dynamic models (e.g., RNNs.)
@@ -172,7 +172,7 @@ attr_pattern = re.compile("^(.+)_([ifstgz])$")
 
 
 def _run_symbolic_method(op_name, symbolic_fn, args):
-    """
+    r"""
     This trampoline function gets invoked for every symbolic method
     call from C++.
     """
@@ -193,7 +193,7 @@ def _is_onnx_list(value):
 
 
 def _add_attribute(node, key, value, aten):
-    """ initializes the right attribute based on type of value """
+    r""" initializes the right attribute based on type of value """
     m = attr_pattern.match(key)
     if m is None:
         raise IndexError((
@@ -233,7 +233,7 @@ def _newNode(g, opname, outputs, *args, **kwargs):
 
 
 def _graph_op(g, opname, *raw_args, **kwargs):
-    """
+    r"""
     Create an ONNX operator 'opname', taking 'args' as inputs and attributes
     'kwargs'; returning the node representing the single output of this operator
     (see the `outputs` keyword argument for multi-return nodes).
@@ -364,7 +364,7 @@ def _graph_constant(g, value, dims, type, *args, **kwargs):
 
 
 def _node_getitem(self, k):
-    """
+    r"""
     Accessor for attributes of a node which is polymorphic over
     return type.
 
@@ -418,7 +418,7 @@ def _symbolic_override_wrapper_maker(symbolic_fn, first_arg_only, fn):
 
 
 def symbolic_override(symbolic_fn):
-    """
+    r"""
     Decorator to override ONNX export of the a function with specified subgraph.
 
     Effectively allows to attach symbolic() implementation to an arbitrary
@@ -429,7 +429,8 @@ def symbolic_override(symbolic_fn):
        them (similar requirement to NestedIOFunction)
      - outputs are similarly Variables/Tensors or (nested) lists or tuples of
        them
-     - keyword arguments are of non-tensor type
+     - non-tensor typed values should be keyword arguments both in definition
+       and when called
 
     Example usage:
 
@@ -447,12 +448,12 @@ def symbolic_override(symbolic_fn):
 
 
 def symbolic_override_first_arg_based(symbolic_fn):
-    """
+    r"""
     Decorator to override ONNX export of the a function with specified subgraph.
 
-    Equivalent to `symbolic_override` but checks only the first argument of the
-    function to figure out whether the tracing is on. Thus the first arg needs
-    to be a Variable.
+    Equivalent to :func:`symbolic_override` but checks only the first argument
+    of the function to figure out whether the tracing is on. Thus the first arg
+    needs to be a Variable.
     """
 
     return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, True)


### PR DESCRIPTION
Commits:
1. Renames `ATen/Check.h` to `ATen/TensorUtils.h` with an additional method `at::maybe_data_ptr` added. #4851 
2. THNN BN code so that `running_mean` and `running_var` can be optional when `training=True`. #4509 
3. ATen changes and cuDNN changes. Still #4509 
4. Python nn.* changes, including changing `InstanceNorm*d`'s `use_running_stats` from #4444 to the new option `track_running_stats` on BN. Improves IN and BN docs.
5. Adds test for the new option for IN and BN. Improves other IN tests.
6. Adds Layer Normalization #1959  .
7. Fixes LRN doc.
8. Functional interface for IN and LN. 
9. Tests for LN. 
10. Fix BN double backward returning undefined tensor when it shouldn't.
11. Fix Jit tests that use wrong dim inputs for BN
12. Add/Improve BN, IN and LN GPU tests with half.
13. Update IN BN docs to be consistent with conv notation; Fix onnx failures.