### PR TITLE
Enable fixed tests again in Windows

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -290,7 +290,6 @@ class TestJit(TestCase):
         torch._C._jit_pass_fuse(trace)
         self.assertExpectedTrace(trace)
 
-    @unittest.skipIf(IS_WINDOWS, "Mysteriously fails on Windows")
     def test_arg_configurations(self):
         """Different arg configurations should trigger different traces"""
         x = Variable(torch.FloatTensor(4, 4).uniform_())
@@ -731,7 +730,6 @@ class TestJit(TestCase):
         del z
         check(False, True)
 
-    @unittest.skipIf(IS_WINDOWS, "Mysteriously fails on Windows")
     def test_multiuse_fn(self):
         x = Variable(torch.randn(2, 2), requires_grad=True)
         w = Variable(torch.randn(2, 2), requires_grad=True)
@@ -748,7 +746,6 @@ class TestJit(TestCase):
 
         torch.jit.verify(cell, (x, w), devices=[])
 
-    @unittest.skipIf(IS_WINDOWS, "Mysteriously fails on Windows")
     def test_output_unflatten(self):
         """Check that outputs of traced functions retain the original structure and nesting"""
         x = Variable(torch.randn(2, 2), requires_grad=True)


### PR DESCRIPTION
The jit test seems to be working after @apaszke 's commit on JIT's fix in #4759. Let's enable the jit tests for Windows again. And then we can mark it completed in #4092.