### PR TITLE
Make torch.cuda.empty_cache() a no-op when cuda is not initialized

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -348,8 +348,8 @@ def empty_cache():
         memory available for PyTorch. See :ref:`cuda-memory-management` for
         more details about GPU memory management.
     """
-    _lazy_init()
-    return torch._C._cuda_emptyCache()
+    if _initialized:
+        torch._C._cuda_emptyCache()
 
 
 def memory_allocated(device=None):


### PR DESCRIPTION
cc: @ngimel @apaszke 

`current_blas_handle()` still calls `_lazy_init()` as all the `current_*()` functions that return something corresponding to the currently set device.