### PR TITLE
Fix JIT tracing in autograd codegen

### DIFF
--- a/test/expect/TestJit.test_saved_output.expect
+++ b/test/expect/TestJit.test_saved_output.expect
@@ -1,0 +1,8 @@
+graph(%0 : Double(4, 4)
+      -------- stage 1 --------
+      %2 : Double(4, 4!)) {
+  %1 : Double(4, 4) = sigmoid(%0)
+  ---------------- stage 1 ----------------
+  %3 : Double(4, 4) = _sigmoid_backward(%2, %1)
+  return (%1, %3);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1149,6 +1149,15 @@ class TestJit(TestCase):
         torch._C._jit_pass_dce(trace)
         self.assertExpectedTrace(trace)
 
+    def test_saved_output(self):
+        x = Variable(torch.randn(4, 4), requires_grad=True)
+        @torch.jit.compile(nderivs=1)
+        def fn(x):
+            return x.sigmoid()
+
+        fn(x).sum().backward()
+        self.assertExpected(str(fn.graph_for(x)))
+
     def test_shared_param(self):
 
         class MyModule(torch.nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1151,6 +1151,7 @@ class TestJit(TestCase):
 
     def test_saved_output(self):
         x = Variable(torch.randn(4, 4), requires_grad=True)
+
         @torch.jit.compile(nderivs=1)
         def fn(x):
             return x.sigmoid()

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -477,8 +477,8 @@ def emit_body(declaration):
         # requires that the counter is incremented before it is called
         body.extend(emit_increment_version())
         body.append(emit_history())
-    # post_record_trace has to happen before we save outputs, because it will
-    # change their tracing state!
+    # post_record_trace must appear before save_outputs so that saved outputs
+    # have their tracing state saved (that is setup by recordTrace)
     body.append(post_record_trace)
     if requires_derivative:
         body.append(emit_save_outputs())

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -477,9 +477,11 @@ def emit_body(declaration):
         # requires that the counter is incremented before it is called
         body.extend(emit_increment_version())
         body.append(emit_history())
+    # post_record_trace has to happen before we save outputs, because it will
+    # change their tracing state!
+    body.append(post_record_trace)
     if requires_derivative:
         body.append(emit_save_outputs())
-    body.append(post_record_trace)
     body.append('return {};'.format(get_return_value()))
     return body
 


### PR DESCRIPTION
`recordTracePost` should be called *before* outputs are saved.