### PR TITLE
Only check that arguments are Variables in VariableType

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -68,14 +68,6 @@ DONT_REQUIRE_DERIVATIVE = {
     '__lshift__', '__or__', '__rshift__', '__xor__',
 }
 
-# These functions use `unpack_any` instead of `unpack`. They don't check the
-# concrete type of arguments. Eventually all VariableType functions should only
-# check that arguments are Variables.
-USE_UNPACK_ANY = {
-    'sparse_coo_tensor', 'cudnn_batch_norm', 'cudnn_batch_norm_forward',
-    'cudnn_batch_norm_backward',
-}
-
 METHOD_DECLARATION = CodeTemplate("""\
 virtual ${return_type} ${method_prefix_derived}${api_name}(${formals}) const override;
 """)
@@ -485,25 +477,8 @@ def emit_body(declaration):
 
 
 def unpack_args(env, declaration):
-    use_unpack_any = declaration['name'] in USE_UNPACK_ANY
-
     def requires_unpack(arg):
         return 'Tensor' in arg['dynamic_type']
-
-    def get_suffix(dynamic_type, is_nullable):
-        if use_unpack_any:
-            return '_any' if not is_nullable else '_any_opt'
-        elif is_nullable:
-            assert dynamic_type == 'Tensor'
-            return '_opt'
-        elif dynamic_type == 'IndexTensor':
-            return '_long'
-        elif dynamic_type == 'IntegerTensor':
-            return '_int'
-        elif dynamic_type == 'BoolTensor':
-            return '_byte'
-        else:
-            return ''
 
     body = []
     unpacked_args = []
@@ -515,10 +490,7 @@ def unpack_args(env, declaration):
         dynamic_type = arg['dynamic_type']
         is_nullable = arg.get('is_nullable', False)
         ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensor']
-        suffix = get_suffix(dynamic_type, is_nullable)
-        if dynamic_type == 'TensorList' and declaration['name'] == 'index':
-            # TODO: specify this in Declarations.yaml somehow
-            suffix = '_idxs'
+        suffix = '_opt' if is_nullable else ''
 
         body.append(UNPACK_TENSOR.substitute(
             arg_name=arg['name'],

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -155,7 +155,7 @@ std::vector<at::Type*> VariableType::allTypes() {
   return res;
 }
 
-Variable & VariableType::checked_cast(const Tensor & t, const char * name, int pos) {
+Variable & VariableType::checked_cast_variable(const Tensor & t, const char * name, int pos) {
   if (!t.defined()) {
     runtime_error("Expected a Tensor of type Variable but found an undefined Tensor for argument #%d '%s'",
         pos, name);
@@ -168,11 +168,11 @@ Variable & VariableType::checked_cast(const Tensor & t, const char * name, int p
 }
 
 Tensor & VariableType::unpack(const Tensor & t, const char * name, int pos) {
-  return checked_cast(t, name, pos).data();
+  return checked_cast_variable(t, name, pos).data();
 }
 
 SparseTensor VariableType::unpack(SparseTensor t, const char * name, int pos) {
-  return SparseTensor(checked_cast(t.tref, name, pos).data());
+  return SparseTensor(checked_cast_variable(t.tref, name, pos).data());
 }
 
 Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) {

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -87,10 +87,10 @@ size_t VariableType::elementSizeInBytes() const {
   return baseType->elementSizeInBytes();
 }
 Type & VariableType::toBackend(Backend b) const {
-  return *VariableImpl::getType(baseType->toBackend(b));
+  return *getType(baseType->toBackend(b));
 }
 Type & VariableType::toScalarType(ScalarType s) const {
-  return *VariableImpl::getType(baseType->toScalarType(s));
+  return *getType(baseType->toScalarType(s));
 }
 TypeID VariableType::ID() const {
   throw std::runtime_error("VariableType::ID() not implemented");
@@ -100,103 +100,103 @@ const char * VariableType::typeString() {
   return "VariableType";
 }
 
-Variable & VariableType::checked_cast(const Type & type, const Tensor & t, const char * name, int pos) {
-  if(!t.defined()) {
-    runtime_error("Expected a Tensor of type %s but found an undefined Tensor for argument #%d '%s'",
-        type.toString(), pos, name);
+struct VariableTypeRegistry {
+  static constexpr int MaxTypes = static_cast<int>(at::TypeID::NumOptions);
+
+  VariableTypeRegistry();
+
+  std::vector<VariableType> types_vec;
+  at::Type* types[MaxTypes];
+};
+
+VariableTypeRegistry::VariableTypeRegistry() {
+  auto& context = at::globalContext();
+  types_vec.reserve(MaxTypes);
+  memset(types, 0, sizeof(VariableType) * MaxTypes);
+  for (int p = 0; p < static_cast<int>(Backend::NumOptions); ++p) {
+    for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); s++) {
+      auto baseType = context.type_registry[p][s].get();
+      if (baseType && baseType->backend() != Backend::Undefined) {
+        auto id = static_cast<int>(baseType->ID());
+        types_vec.emplace_back(&context, baseType);
+        types[id] = &types_vec.back();
+      }
+    }
   }
-  if (&t.type() != &type && &t.type() != &type.toBackend(toSparse(t.type().backend()))) {
-    runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
-        type.toString(), t.type().toString(), pos, name);
+}
+
+static VariableTypeRegistry registry;
+
+bool VariableType::isVariableType(const at::Type& type) {
+  // Since all VariableTypes are allocated contiguously in types_vec, we can
+  // just check that the pointer is inside the correct range.
+  ptrdiff_t offset = (char*)&type - (char*)registry.types_vec.data();
+  ptrdiff_t extent = VariableTypeRegistry::MaxTypes * sizeof(VariableType);
+  return offset >= 0 && offset < extent;
+}
+
+at::Type* VariableType::getType(const at::Type& baseType) {
+  return registry.types[static_cast<int>(baseType.ID())];
+}
+
+at::Type* VariableType::getType(const at::Tensor& tensor) {
+  if (!tensor.defined()) {
+    throw std::runtime_error("tensor is undefined");
   }
-  return static_cast<Variable&>(const_cast<Tensor&>(t));
+  return getType(tensor.type());
 }
 
-Tensor & VariableType::unpack(const Tensor & t, const char * name, int pos) const {
-  return checked_cast(*this, t, name, pos).data();
+std::vector<at::Type*> VariableType::allTypes() {
+  std::vector<Type*> res;
+  res.reserve(registry.types_vec.size());
+  for (auto& type : registry.types_vec) {
+    res.push_back(&type);
+  }
+  return res;
 }
 
-SparseTensor VariableType::unpack(SparseTensor t, const char * name, int pos) const {
-  auto backend = is_cuda() ? kSparseCUDA : kSparseCPU;
-  return SparseTensor(checked_cast(this->toBackend(backend), t.tref, name, pos).data());
-}
-
-Tensor & VariableType::unpack_long(const Tensor & t, const char * name, int pos) const {
-  auto& type = *VariableImpl::getType(baseType->toScalarType(kLong));
-  return checked_cast(type, t, name, pos).data();
-}
-
-Tensor & VariableType::unpack_int(const Tensor & t, const char * name, int pos) const {
-  auto& type = *VariableImpl::getType(baseType->toScalarType(kInt));
-  return checked_cast(type, t, name, pos).data();
-}
-
-Tensor & VariableType::unpack_byte(const Tensor & t, const char * name, int pos) const {
-  auto& type = *VariableImpl::getType(baseType->toScalarType(kByte));
-  return checked_cast(type, t, name, pos).data();
-}
-
-Tensor & VariableType::unpack_any(const Tensor & t, const char * name, int pos) const {
+Variable & VariableType::checked_cast(const Tensor & t, const char * name, int pos) {
   if (!t.defined()) {
     runtime_error("Expected a Tensor of type Variable but found an undefined Tensor for argument #%d '%s'",
         pos, name);
   }
-  auto scalarType = t.type().scalarType();
-  auto backend = t.type().backend();
-  auto& type = *VariableImpl::getType(baseType->toScalarType(scalarType).toBackend(backend));
-  return checked_cast(type, t, name, pos).data();
+  if (!isVariableType(t.type())) {
+    runtime_error("Expected object of type Variable but found type %s for argument #%d '%s'",
+        t.type().toString(), pos, name);
+  }
+  return static_cast<Variable&>(const_cast<Tensor&>(t));
 }
 
-Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) const {
+Tensor & VariableType::unpack(const Tensor & t, const char * name, int pos) {
+  return checked_cast(t, name, pos).data();
+}
+
+SparseTensor VariableType::unpack(SparseTensor t, const char * name, int pos) {
+  return SparseTensor(checked_cast(t.tref, name, pos).data());
+}
+
+Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) {
   if (!t.defined()) {
     return Tensor();
   }
   return unpack(t, name, pos);
 }
 
-Tensor VariableType::unpack_any_opt(const Tensor & t, const char * name, int pos) const {
-  if (!t.defined()) {
-    return Tensor();
-  }
-  return unpack_any(t, name, pos);
-}
-
-std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name, int pos) const {
+std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name, int pos) {
   std::vector<at::Tensor> ret(tl.size());
   for (size_t i = 0; i < tl.size(); ++i) {
     const auto &t = tl[i];
     if (!t.defined()) {
-      runtime_error("Expected a Tensor of type %s but found an undefined Tensor at position #%d "
+      runtime_error("Expected a Tensor of type Variable but found an undefined Tensor at position #%d "
                     "for iterable argument #%d '%s'",
-                    toString(), i, pos, name);
-    }
-    if (&t.type() == this) {
-      ret[i] = static_cast<const Variable&>(t).data();
-    } else {
-      runtime_error("Expected object of type %s but found type %s at position #%d "
-                    "for iterable argument #%d '%s'",
-                    toString(),t.type().toString(), i, pos, name);
-    }
-  }
-  return ret;
-}
-
-std::vector<at::Tensor> VariableType::unpack_idxs(at::TensorList tl, const char *name, int pos) const {
-  auto& longType = *VariableImpl::getType(baseType->toScalarType(kLong));
-  auto& byteType = *VariableImpl::getType(baseType->toScalarType(kByte));
-  std::vector<at::Tensor> ret(tl.size());
-  for (size_t i = 0; i < tl.size(); ++i) {
-    const auto &t = tl[i];
-    if (!t.defined()) {
-      continue;
-    } else if (!(t.type() == longType || t.type() == byteType)) {
-      runtime_error("Expected object of type %s or %s but found type %s at position #%d "
-                    "for iterable argument #%d '%s'",
-                    longType.toString(), byteType.toString(), t.type().toString(),
                     i, pos, name);
-    } else  {
-      ret[i] = static_cast<const Variable&>(t).data();
     }
+    if (!isVariableType(t.type())) {
+      runtime_error("Expected object of type Variable but found type %s at position #%d "
+                    "for iterable argument #%d '%s'",
+                    t.type().toString(), i, pos, name);
+    }
+    ret[i] = static_cast<const Variable&>(t).data();
   }
   return ret;
 }
@@ -380,7 +380,7 @@ Tensor & VariableType::s_copy_(Tensor & self, const Tensor & src, bool async) co
   // TODO: once copy is exposed in Declarations.yaml we may be able to bind
   // it automatically
   auto& self_ = unpack(self, "self", 0);
-  auto& src_ = unpack_any(src, "src", 1);
+  auto& src_ = unpack(src, "src", 1);
   check_inplace(self);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -50,7 +50,7 @@ struct VariableType final : public at::Type {
 
 private:
   // checks that t is actually a Variable
-  static Variable & checked_cast(const Tensor & t, const char * name, int pos);
+  static Variable & checked_cast_variable(const Tensor & t, const char * name, int pos);
   static at::Tensor & unpack(const Tensor & t, const char * name, int pos);
   static at::SparseTensor unpack(SparseTensor t, const char * name, int pos);
   static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -4,6 +4,7 @@
 
 #include <ATen/ATen.h>
 #include <string>
+#include <vector>
 
 namespace torch { namespace autograd {
 
@@ -39,22 +40,21 @@ struct VariableType final : public at::Type {
   virtual std::unique_ptr<at::Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const override;
   virtual at::Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const override;
 
+  static at::Type* getType(const at::Type& baseType);
+  static at::Type* getType(const at::Tensor& tensor);
+  static bool isVariableType(const at::Type& type);
+  static std::vector<at::Type*> allTypes();
+
   virtual Tensor & s_copy_(Tensor & self, const Tensor & src, bool async) const override;
   ${type_derived_method_declarations}
 
 private:
-  // checks that t is actually a Variable with the given expected_type
-  static Variable & checked_cast(const Type & expected_type, const Tensor & t, const char * name, int pos);
-  at::Tensor & unpack(const Tensor & t, const char * name, int pos) const;
-  at::SparseTensor unpack(SparseTensor t, const char * name, int pos) const;
-  at::Tensor & unpack_long(const Tensor & t, const char * name, int pos) const;
-  at::Tensor & unpack_int(const Tensor & t, const char * name, int pos) const;
-  at::Tensor & unpack_byte(const Tensor & t, const char * name, int pos) const;
-  at::Tensor & unpack_any(const Tensor & t, const char * name, int pos) const;
-  at::Tensor unpack_opt(const Tensor & t, const char * name, int pos) const;
-  at::Tensor unpack_any_opt(const Tensor & t, const char * name, int pos) const;
-  std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos) const;
-  std::vector<at::Tensor> unpack_idxs(at::TensorList tl, const char *name, int pos) const;
+  // checks that t is actually a Variable
+  static Variable & checked_cast(const Tensor & t, const char * name, int pos);
+  static at::Tensor & unpack(const Tensor & t, const char * name, int pos);
+  static at::SparseTensor unpack(SparseTensor t, const char * name, int pos);
+  static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);
+  static std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos);
 
 private:
   at::Type* baseType;

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -5,6 +5,7 @@
 #include <ATen/ATen.h>
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
+#include "torch/csrc/autograd/generated/VariableType.h"
 
 // Contains inline wrappers around ATen functions that release the GIL and
 // switch to the correct CUDA device.
@@ -25,7 +26,7 @@ static at::Type& default_type() {
   if (!THPDefaultATenType) {
     throw std::runtime_error("THPDefaultATenType not initialized");
   }
-  return *VariableImpl::getType(*THPDefaultATenType);
+  return *VariableType::getType(*THPDefaultATenType);
 }
 
 ${py_method_dispatch}

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -16,6 +16,7 @@
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/Size.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/generated/VariableType.h"
 
 using namespace at;
 using namespace torch::autograd;
@@ -280,7 +281,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   Tensor tensor = torch::createTensor(data);
   if (&self->cdata.data().type() != &tensor.type()) {
     // we change the type of var.data so we must change the type of var
-    auto newType = VariableImpl::getType(tensor);
+    auto newType = VariableType::getType(tensor);
     self->cdata.get()->*get(TensorImpl_Type()) = newType;
   }
   self->cdata.data() = tensor;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -22,7 +22,7 @@ Variable make_variable(at::Tensor data, std::shared_ptr<Function> grad_fn) {
 }
 
 VariableImpl::VariableImpl(Tensor data_, bool requires_grad, int output_nr, std::shared_ptr<Function> grad_fn)
-  : TensorImpl(getType(data_))
+  : TensorImpl(VariableType::getType(data_))
   , data(std::move(data_))
   , grad()
   , _grad_fn(std::move(grad_fn))
@@ -134,52 +134,6 @@ void VariableViewImpl::rebase_history(int output_nr, std::shared_ptr<Function> g
   base.get()->_grad_fn = std::make_shared<CopySlices>(
       base, TensorGeometry(data), std::move(grad_fn));
   get_grad_fn();  // trigger an update to the view's grad_fn
-}
-
-namespace {
-
-struct VariableTypes {
-  VariableTypes() {
-    auto& context = at::globalContext();
-    for (int p = 0; p < static_cast<int>(Backend::NumOptions); ++p) {
-      for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); s++) {
-        auto baseType = context.type_registry[p][s].get();
-        if (baseType && baseType->backend() != Backend::Undefined) {
-          auto id = static_cast<int>(baseType->ID());
-          types[id].reset(new VariableType(&context, baseType));
-        }
-      }
-    }
-  }
-
-  std::unique_ptr<Type> types[static_cast<int>(TypeID::NumOptions)];
-};
-
-} // anonymous namespace
-
-Type* VariableImpl::getType(const Tensor& tensor)
-{
-  if (!tensor.defined()) {
-    throw std::runtime_error("tensor is undefined");
-  }
-  return getType(tensor.type());
-}
-
-static VariableTypes vt;
-
-Type* VariableImpl::getType(const Type& baseType)
-{
-  return vt.types[static_cast<int>(baseType.ID())].get();
-}
-
-std::vector<Type*> VariableImpl::allTypes() {
-  std::vector<Type*> types;
-  for (int i = 0; i < static_cast<int>(TypeID::NumOptions); i++) {
-    if (vt.types[i]) {
-      types.push_back(vt.types[i].get());
-    }
-  }
-  return types;
 }
 
 Variable Variable::detach() const {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -96,11 +96,6 @@ public:
   virtual std::unique_ptr<at::Storage> storage() override;
   static const char * typeString();
 
-  // Get the VariableType for a base Tensor type
-  static at::Type* getType(const at::Type& baseType);
-  static at::Type* getType(const at::Tensor& tensor);
-  static std::vector<at::Type*> allTypes();
-
 public:
   std::shared_ptr<Function> get_grad_accumulator();
   virtual std::shared_ptr<Function>& get_grad_fn() { return _grad_fn; }

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 #include <unordered_map>
 
-#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/generated/VariableType.h"
 #include "torch/csrc/Exceptions.h"
 
 using namespace at;
@@ -30,7 +30,7 @@ at::Type& type_from_string(const std::string& str) {
   static std::once_flag once;
   static std::unordered_map<std::string, Type*> map;
   std::call_once(once, []() {
-    for (auto type : autograd::VariableImpl::allTypes()) {
+    for (auto type : autograd::VariableType::allTypes()) {
       map.emplace(type_to_string(*type), type);
     }
   });


### PR DESCRIPTION
Don't check the ScalarType and Backend of arguments in VariableType.
Instead, only check that arguments are Variables of any type. The
precise type checks are handled by the base type.

Many of our functions take heterogeneous types. There isn't enough
information in Declarations.yaml to ensure the precise types of
arguments in VariableType, which makes it difficult to add new methods.