### PR TITLE
Fix triu and tril for zero-strided inputs on gpu

### DIFF
--- a/aten/src/THC/THCTensorMathPairwise.cu
+++ b/aten/src/THC/THCTensorMathPairwise.cu
@@ -375,8 +375,8 @@ struct TensorTriOp {
   TensorTriOp(T *start_, int64_t stride0_, int64_t stride1_, int64_t k_)
     : start(start_), stride0(stride0_), stride1(stride1_), k(k_) {}
 
-  __device__ __forceinline__ int mask(T *in) {
-    ptrdiff_t n = in - start;
+  __device__ __forceinline__ int mask(T *out) {
+    ptrdiff_t n = out - start;
     int64_t row, col;
     if (stride0 > stride1)
     {
@@ -393,7 +393,7 @@ struct TensorTriOp {
   }
 
   __device__ __forceinline__ void operator()(T* out, T* in) {
-    *out = mask(in) ? *in : ScalarConvert<int, T>::to(0);
+    *out = mask(out) ? *in : ScalarConvert<int, T>::to(0);
   }
 
   __device__ __forceinline__ void operator()(T* v) {

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -193,30 +193,26 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   THArgCheck(src_->nDimension == 2, 1, "expected a matrix");
 
-  THCTensor *src = src_;
-  if (self_ == src_)
-    src = THCTensor_(newContiguous)(state, src_);
+  if (self_ != src_)
+    THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = src->stride[0];
-  int64_t stride1 = src->stride[1];
-  real *start = THCTensor_(data)(state, src);
+  int64_t stride0 = self_->stride[0];
+  int64_t stride1 = self_->stride[1];
+  real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 0> op(start, stride0, stride1, k);
 
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, src, op)) {
+    if (!THC_pointwiseApply1(state, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
-    THCTensor_(resizeAs)(state, self_, src);
+    THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src, op)) {
+    if (!THC_pointwiseApply2(state, self_, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
-
-  if (self_ == src_)
-    THCTensor_(freeCopyTo)(state, src, src_);
 
   THCudaCheck(cudaGetLastError());
 }
@@ -226,30 +222,25 @@ void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   THArgCheck(src_->nDimension == 2, 1, "expected a matrix");
 
-  THCTensor *src = src_;
-  if (self_ == src_)
-    src = THCTensor_(newContiguous)(state, src_);
+  if (self_ != src_)
+    THCTensor_(resizeAs)(state, self_, src_);
 
-  int64_t stride0 = src->stride[0];
-  int64_t stride1 = src->stride[1];
-  real *start = THCTensor_(data)(state, src);
+  int64_t stride0 = self_->stride[0];
+  int64_t stride1 = self_->stride[1];
+  real *start = THCTensor_(data)(state, self_);
 
   TensorTriOp<real, 1> op(start, stride0, stride1, k);
 
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, src, op)) {
+    if (!THC_pointwiseApply1(state, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
-    THCTensor_(resizeAs)(state, self_, src);
 
-    if (!THC_pointwiseApply2(state, self_, src, op)) {
+    if (!THC_pointwiseApply2(state, self_, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
-
-  if (self_ == src_)
-    THCTensor_(freeCopyTo)(state, src, src_);
 
   THCudaCheck(cudaGetLastError());
 }


### PR DESCRIPTION
Fix #4840 

This assumes that the output tensor for the operation (if you do inplace operation or if you used the `out=` flag) does not have a zero-strided dimension.
@apaszke iirc this is an assumption that we make all the time right? If so, do we want to explicitly enforce it  at the python api level (one linear check of the stride compared to the python wrapping should be small)? Or do we want to say it explicitly in the documentation somewhere?