### PR TITLE
Don't allow scalars in torch.dot for Variables.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2812,9 +2812,9 @@
     - real max
 ]]
 [[
-  name: dot
+  name: _dot
   backend_type_pairs: [[CUDA,floating_point], [CPU,all]]
-
+  cname: dot
   variants:
     - method
     - function

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -54,6 +54,16 @@ Tensor det(const Tensor& self) {
   return std::get<0>(self._det_with_svd());
 }
 
+Tensor dot(const Tensor& self, const Tensor& tensor) {
+  if (self.dim() != 1) {
+    runtime_error("Expected argument self to have 1 dimension, but has %d", self.dim());
+  }
+  if (tensor.dim() != 1) {
+    runtime_error("Expected argument tensor to have 1 dimension, but has %d", tensor.dim());
+  }
+  return self._dot(tensor);
+}
+
 static Tensor maybeSqueeze(const Tensor & tensor, int64_t dim_tensor1, int64_t dim_tensor2) {
   if (dim_tensor1 == 1) {
     return tensor.squeeze(-2);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -163,6 +163,8 @@
 - func: det(Tensor self) -> Tensor
 - func: _det_with_svd(Tensor self) -> (Tensor, Tensor, Tensor, Tensor)
 
+- func: dot(Tensor self, Tensor tensor) -> Tensor
+
 - func: embedding(Tensor weight, IndexTensor indices, int64_t padding_idx=-1, bool scale_grad_by_freq=false, bool sparse=false) -> Tensor
   variants: function
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -36,8 +36,8 @@ static void test(Type & type) {
     ASSERT(24 == (b+b).sum().toCDouble());
     std::cout << b.numel() << std::endl;
     ASSERT(12 == b.numel());
-    std::cout << b.dot(b) << std::endl;
-    ASSERT(b.dot(b).toCDouble() == 12);
+    std::cout << b.view(-1).dot(b.view(-1)) << std::endl;
+    ASSERT(b.view(-1).dot(b.view(-1)).toCDouble() == 12);
   }
 
   {


### PR DESCRIPTION
There is no dot_out, so the lack of _out isn't an issue.