### PR TITLE
Fix refcycles in DataParallel scatter and gather

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -37,6 +37,8 @@ torch.manual_seed(SEED)
 def run_tests():
     unittest.main(argv=UNITTEST_ARGS)
 
+PY3 = sys.version_info > (3, 0)
+
 IS_WINDOWS = sys.platform == "win32"
 
 TEST_NUMPY = True

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -22,6 +22,11 @@ def scatter(inputs, target_gpus, dim=0):
             return list(map(type(obj), zip(*map(scatter_map, obj.items()))))
         return [obj for targets in target_gpus]
 
+    # After scatter_map is called, a scatter_map cell will exist. This cell
+    # has a reference to the actual function scatter_map, which has references
+    # to a closure that has a reference to the scatter_map cell (because the
+    # fn is recursive). To avoid this reference cycle, we set the function to
+    # None, clearing the cell
     try:
         return scatter_map(inputs)
     finally:
@@ -54,6 +59,8 @@ def gather(outputs, target_device, dim=0):
             return None
         return type(out)(map(gather_map, zip(*outputs)))
 
+    # Recursive function calls like this create reference cycles.
+    # Setting the function to None clears the refcycle.
     try:
         return gather_map(outputs)
     finally:


### PR DESCRIPTION
Addresses #4865 

DataParallel's `scatter` and `gather` methods contain reference cycles; this PR removes them. I think [this](https://mail.python.org/pipermail/python-dev/2009-December/094439.html) is the explanation.

There's something up with Python 2.7 that creates reference cycles when a module is replicated, so the unit test I wrote is only for Python 3. As far as I can tell, those reference cycles are created internally by Python so I don't think there's anything we can do about that.

### Test Plan
Unit test to test the multi-gpu behavior under Python 3.