### PR TITLE
Fix reduction functions to respect the stride of the output

### DIFF
--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -75,6 +75,7 @@ TH_API void THTensor_(baddbmm)(THTensor *r_, real beta, THTensor *t, real alpha,
 TH_API void THTensor_(match)(THTensor *r_, THTensor *m1, THTensor *m2, real gain);
 
 TH_API ptrdiff_t THTensor_(numel)(THTensor *t);
+void THTensor_(preserveReduceDimSemantics)(THTensor *r_, int in_dims, int reduce_dimension, int keepdim);
 TH_API void THTensor_(max)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(min)(THTensor *values_, THLongTensor *indices_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(kthvalue)(THTensor *values_, THLongTensor *indices_, THTensor *t, int64_t k, int dimension, int keepdim);

--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -325,7 +325,14 @@ bool THC_reduceDim(THCState* state,
 
     }
   }
-  // Resize out to correspond to the reduced size
+
+  // Resize out to correspond to the reduced size with keepdim=True.
+
+  // Preserve noncontiguities by unsqueezing out if necessary
+  TensorUtils<TensorType>::preserveReduceDimSemantics(
+      state, out, TensorUtils<TensorType>::getDims(state, in), dim, keepdim);
+
+  // Resize out
   THLongStorage* sizes = TensorUtils<TensorType>::newSizeOf(state, in);
   THLongStorage_set(sizes, dim, 1);
   TensorUtils<TensorType>::resize(state, out, sizes, NULL);

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -6,6 +6,7 @@
 #include "THCNumerics.cuh"
 #include "THCReduce.cuh"
 #include "THCReduceAll.cuh"
+#include "THCTensorCopy.h"
 #include "THCThrustAllocator.cuh"
 #include <thrust/functional.h>
 #include <thrust/device_ptr.h>
@@ -703,6 +704,15 @@ THC_reduceDimIndex(THCState *state,
   THArgCheck(dimension >= 0 &&
              dimension < TensorUtils<TensorTypeK>::getDims(state, src),
              3, "dimension out of range");
+
+
+  // Unsqueeze tgt1_/tgt_2 if necessary so that their contiguity traits
+  // are preserved if they are the same size as the correct reduction output.
+  int src_dims = TensorUtils<TensorTypeK>::getDims(state, src);
+  TensorUtils<TensorTypeK>::preserveReduceDimSemantics(
+      state, tgt1_, src_dims, dimension, keepdim);
+  TensorUtils<TensorTypeIndex>::preserveReduceDimSemantics(
+      state, tgt2_, src_dims, dimension, keepdim);
 
   THLongStorage *dim = TensorUtils<TensorTypeK>::newSizeOf(state, src);
   THLongStorage_set(dim, dimension, 1);

--- a/aten/src/THC/THCTensorTypeUtils.cuh
+++ b/aten/src/THC/THCTensorTypeUtils.cuh
@@ -51,6 +51,11 @@ struct TensorUtils {
                          TENSOR_TYPE* src);                             \
     static void squeeze1d(THCState *state, TENSOR_TYPE *dst,            \
                           TENSOR_TYPE *src, int dimension);             \
+    static void unsqueeze1d(THCState *state, TENSOR_TYPE *dst,          \
+                          TENSOR_TYPE *src, int dimension);             \
+    static void preserveReduceDimSemantics(                             \
+                          THCState *state, TENSOR_TYPE *tensor,         \
+                          int in_dims, int64_t dimension, int keepdim); \
     static DATA_TYPE* getData(THCState* state, TENSOR_TYPE* t);         \
     static ptrdiff_t getNumElements(THCState* state, TENSOR_TYPE* t);   \
     static int64_t getSize(THCState* state, TENSOR_TYPE* t, int dim);   \

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -180,6 +180,10 @@ THC_API void THCTensor_(mode)(THCState *state,
 
   // Resize output value, index Tensors to appropriate sizes (i.e. the same as
   // the input Tensor, except at dim=dimension, the size is 1)
+  TensorUtils<THCTensor>::preserveReduceDimSemantics(
+      state, values, ndim, dimension, keepdim);
+  TensorUtils<THCudaLongTensor>::preserveReduceDimSemantics(
+      state, indices, ndim, dimension, keepdim);
   dim = THCTensor_(newSizeOf)(state, input);
   THLongStorage_set(dim, dimension, 1);
   THCTensor_(resize)(state, values, dim, NULL);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -370,16 +370,19 @@ class TestTorch(TestCase):
             "mean", "median", "mode", "norm", "prod",
             "std", "sum", "var", "max", "min"]
 
-        def normfn_attr(t, dim, keepdim=False):
+        def normfn_attr(t, dim, keepdim=False, out=None):
             attr = getattr(torch, "norm")
-            return attr(t, 2, dim, keepdim)
+            return attr(t, 2, dim, keepdim, out=out)
 
         for fn_name in dim_red_fns:
             fn_attr = getattr(torch, fn_name) if fn_name != "norm" else normfn_attr
 
-            def fn(x, dim, keepdim=False):
-                ans = fn_attr(x, dim, keepdim=keepdim)
+            def fn(x, dim, keepdim=False, out=None):
+                ans = fn_attr(x, dim, keepdim=keepdim, out=out)
                 return ans if not isinstance(ans, tuple) else ans[0]
+
+            def fn_tuple(x, dim, keepdim=False, out=None):
+                return fn_attr(x, dim, keepdim=keepdim, out=out)
 
             def test_multidim(x, dim):
                 self.assertEqual(fn(x, dim).unsqueeze(dim), fn(x, dim, keepdim=True))
@@ -404,6 +407,25 @@ class TestTorch(TestCase):
             dims[singleton_dim] = 1
             x = cast(torch.randn(dims))
             test_multidim(x, singleton_dim)
+
+            # check reducing with output kwargs
+            if fn_name in ['median', 'mode', 'max', 'min']:
+                y = cast(torch.randn(5, 3))
+                values = cast(torch.randn(5, 3))
+                indices = cast(torch.zeros(5, 3).long() - 1)
+                fn_tuple(y, 1, keepdim=False, out=(values[:, 1], indices[:, 1]))
+                values_expected, indices_expected = fn_tuple(y, 1, keepdim=False)
+                self.assertEqual(values[:, 1], values_expected,
+                                 '{} values with out= kwarg'.format(fn_name))
+                self.assertEqual(indices[:, 1], indices_expected,
+                                 '{} indices with out= kwarg'.format(fn_name))
+                continue
+
+            x = cast(torch.randn(5, 3))
+            y = cast(torch.randn(5, 3))
+            fn(y, 1, keepdim=False, out=x[:, 1])
+            expected = fn(y, 1, keepdim=False)
+            self.assertEqual(x[:, 1], expected, '{} with out= kwarg'.format(fn_name))
 
     def test_dim_reduction(self):
         self._test_dim_reduction(self, lambda t: t)


### PR DESCRIPTION
Fixes #4974 

Consider reduction ops like `torch.sum`, `torch.prod`, etc, of the form
`reduce_op(output, input, keepdim)`

Let `output_size` be the size of the output with `keepdim=False`, and `output_keepdim_size` be the size of the output with `keepdim=True`.

Right now, what happens in a reduce op is the following:
we have an `input` and an `output`. `output` is always resized to `output_keepdim_size`. Then, the reduction op is performed with that size, and output is finally either squeezed to `output_size` or kept at `output_keepdim_size` depending on what `keepdim` is.

The problem with what currently happens is that if `keepdim=False`and `output` initially has size `output_size` then `output` will be resized to `output_keepdim_size`, the reduce op will be performed, and then output will be squeezed to `output_size`. This resize is not a no-op and will affect `output`'s contiguity. 

This PR fixes the issue by always unsqueezing `output` to `output_keepdim_size`. This operation preserves `output`'s contiguity.

This fixes the following operations:
- mean
- median
- mode
- norm
- prod
- sum
- std
- var
- max
- min

### Test Plan
New unit tests