### PR TITLE
Add nested Blocks in IR

### DIFF
--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -10,6 +10,7 @@ graph(%a : UNKNOWN_TYPE
     }
     block1() {
       %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
+      %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
       -> (%6)
     }
   return (%4);
@@ -21,7 +22,21 @@ graph(%a : UNKNOWN_TYPE
   %2 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
   %4 : UNKNOWN_TYPE = If(%c)
     block0() {
-      %5 : UNKNOWN_TYPE = add[alpha={1}](%2, %2)
+      %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
+      %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
+      -> (%6)
+    }
+  return (%4);
+}
+
+graph(%a : UNKNOWN_TYPE
+      %b : UNKNOWN_TYPE
+      %c : UNKNOWN_TYPE) {
+  %3 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
+  %4 : UNKNOWN_TYPE = If(%c)
+    block0() {
+      %5 : UNKNOWN_TYPE = add[alpha={1}](%b, %3)
+      %6 : UNKNOWN_TYPE = add[alpha={1}](%5, %3)
       -> (%5)
     }
   return (%4);

--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -1,3 +1,32 @@
+testBlocks
+graph(%a : UNKNOWN_TYPE
+      %b : UNKNOWN_TYPE
+      %c : UNKNOWN_TYPE) {
+  %2 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
+  %4 : UNKNOWN_TYPE = If(%c)
+    block0() {
+      %5 : UNKNOWN_TYPE = add[alpha={1}](%2, %2)
+      -> (%5)
+    }
+    block1() {
+      %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
+      -> (%6)
+    }
+  return (%4);
+}
+
+graph(%a : UNKNOWN_TYPE
+      %b : UNKNOWN_TYPE
+      %c : UNKNOWN_TYPE) {
+  %2 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
+  %4 : UNKNOWN_TYPE = If(%c)
+    block0() {
+      %5 : UNKNOWN_TYPE = add[alpha={1}](%2, %2)
+      -> (%5)
+    }
+  return (%4);
+}
+
 testCreateAutodiffSubgraphs
 graph(%0 : UNKNOWN_TYPE
       %1 : UNKNOWN_TYPE

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -170,7 +170,7 @@ static ReverseDetails addReverseInline(Graph& graph, Gradient& grad_desc,
     grad_desc.df_input_vjps.push_back(i);
   }
 
-  for (auto it = graph.rbegin(), end = graph.rend(); it != end; ++it) {
+  for (auto it = graph.nodes().rbegin(), end = graph.nodes().rend(); it != end; ++it) {
     Node *node = *it;
     auto inputs = node->inputs();
     if (std::none_of(inputs.begin(), inputs.end(), requires_grad)) continue;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -52,6 +52,8 @@ std::ostream& operator<<(std::ostream & out, const Graph & g);
 std::ostream& operator<<(std::ostream & out, const Type & t);
 std::ostream& operator<<(std::ostream & out, const Node & t);
 
+// A list of nodes, with inputs and outputs
+struct Block;
 
 // Each use is represented by this type, see Node::uses()
 // 'user' is the consumer of the value, offset is the index into
@@ -232,6 +234,7 @@ public:
 struct Node : public Attributes<Node> {
   TH_DISALLOW_COPY_AND_ASSIGN(Node);
   friend struct Graph;
+  friend struct Block;
   friend struct Value;
   friend graph_node_list;
   friend const_graph_node_list;
@@ -257,7 +260,10 @@ private:
   const NodeKind kind_;
   std::vector<Value*> inputs_;
   std::vector<Value*> outputs_;
+  // subblocks
+  std::vector<Block*> blocks_;
   Graph* graph_;
+  Block* owning_block_;
   std::shared_ptr<SourceLocation> source_location_;
   size_t stage_;
   Scope* scope_;
@@ -279,6 +285,9 @@ public:
   }
   const Graph * owningGraph() const {
     return graph_;
+  }
+  Block * owningBlock() {
+    return owning_block_;
   }
   size_t stage() const {
     return stage_;
@@ -425,8 +434,35 @@ public:
     outputs_.push_back(new Value(this, outputs_.size()));
     return outputs_.back();
   }
-
   void eraseOutput(size_t i);
+
+  Block * addBlock();
+  void eraseBlock(size_t i);
+
+  // Each Node can have a list of subblocks. These are used to define structured
+  // nested control flow operators such as If and Loop.
+  // The meaning of a block is specific to the kind of node it is in, but
+  // all blocks share these semantics:
+  // * Nested lexical scoping: If a node 'Parent' has a subblock which contains a
+  //   node 'Child', Child can use any value that was in scope for the Parent
+  //   node in addition to any values defined before 'Child' in the subblock.
+  // * The list of inputs to the block are in scope for the duration of the block
+  // * the outputs of the Parent node are not in scope for the subblocks
+  // Typically the inputs to a block that represents control flow act as
+  // as the equivalents phi-nodes in standard SSA form,
+  // defining a new Value to represent any term that has multiple
+  // definitions depending on how control flowed. Outputs of the node containing
+  // control flow serve a similiar purpose defining new values for variables
+  // that would have different defintions depending on which way control flowed.
+
+  at::ArrayRef<Block*> blocks() {
+    return blocks_;
+  }
+  at::ArrayRef<const Block*> blocks() const {
+    // Vectors are not convertible in const-ness of elements, but
+    // raw pointers are.
+    return {blocks_.data(), blocks_.size()};
+  }
 
   // Insert unattached 'this' node after 'n' in the topological order.
   // Returns this (for chaining).
@@ -439,7 +475,7 @@ public:
   //          %5 = h(%1)
   //          %4 = g(%3)
   Node* insertBefore(Node * n) {
-    JIT_ASSERT(n->inGraphList());
+    JIT_ASSERT(n->inBlockList());
     insertAfter(n->prev());
     return this;
   }
@@ -455,7 +491,9 @@ public:
   //          %4 = g(%3)
   //          %5 = h(%1)
   Node* insertAfter(Node * n) {
-    JIT_ASSERT(!inGraphList() && n->inGraphList());
+    JIT_ASSERT(!inBlockList() && n->inBlockList());
+    JIT_ASSERT(n->owningBlock());
+    this->owning_block_ = n->owningBlock();
     Node * next = n->next();
     n->next() = this;
     this->prev() = n;
@@ -578,12 +616,15 @@ private:
     return input_node;
   }
 
-  bool inGraphList() const {
-    JIT_ASSERT(next() != nullptr || prev() == nullptr);
+  bool inBlockList() const {
+    if(next() == nullptr) {
+      JIT_ASSERT(prev() == nullptr);
+    }
     return next() != nullptr;
   }
   void removeFromList() {
-    JIT_ASSERT(inGraphList());
+    JIT_ASSERT(inBlockList());
+    this->owning_block_ = nullptr;
     Node * next = this->next();
     Node * prev = this->prev();
     prev->next() = next;
@@ -611,46 +652,11 @@ protected:
   virtual void cloneFrom(Node * s);
 };
 
-struct Graph {
-TH_DISALLOW_COPY_AND_ASSIGN(Graph);
-friend struct Node;
-friend struct Value;
-private:
-
-  // only used to keep track of allocated nodes
-  // actual representation of Graph is done with
-  // inputs, outputs, nodes
-
-  std::unordered_set<const Node*> all_nodes;
-  std::unordered_set<const Value*> all_values;
-  size_t next_unique_;
-
-  std::unordered_set<std::string> unique_names_;
-
-  size_t new_node_stage_;
-
-  std::shared_ptr<Scope> scope_root_;
-  Scope * current_scope_;
-
-  // holds outputs in a way that can be reflected
-  // as a Use object
-  // also used as the beginning/end of the circular node list to avoid
-  // having corner cases where the list is empty.
-  Node * const output_;
-  Node * const input_;
-
-public:
-
-  Graph(std::shared_ptr<Scope> scope_root)
-  : next_unique_(0)
-  , new_node_stage_(0)
-  , scope_root_(scope_root)
-  , current_scope_(scope_root_.get())
-  , output_(initOutput(create(kReturn, 0))), input_(create(kParam, 0)) {}
-
-  Graph()
-  : Graph( std::make_shared<Scope>()) {}
-
+struct Block {
+  friend struct Node;
+  friend struct Graph;
+  TH_DISALLOW_COPY_AND_ASSIGN(Block);
+  Block(Graph * graph_, Node * node_);
   at::ArrayRef<Value*> inputs() {
     return input_->outputs();
   }
@@ -670,38 +676,128 @@ public:
   const_graph_node_list nodes() const {
     return const_graph_node_list(output_, kNextDirection);
   }
-  // These invocations of begin() on output of function are OK
-  // because graph_node_list is non-owning, so it doesn't matter
-  // if it immediately dies after the invocation.
-  graph_node_list_iterator begin() {
-    return nodes().begin();
-  }
-  const_graph_node_list_iterator begin() const {
-    return nodes().begin();
-  }
-  graph_node_list_iterator end() {
-    return nodes().end();
-  }
-  const_graph_node_list_iterator end() const {
-    return nodes().end();
-  }
-  graph_node_list_iterator rbegin() {
-    return nodes().rbegin();
-  }
-  const_graph_node_list_iterator rbegin() const {
-    return nodes().rbegin();
-  }
-  graph_node_list_iterator rend() {
-    return nodes().rend();
-  }
-  const_graph_node_list_iterator rend() const {
-    return nodes().rend();
-  }
   Node * return_node() {
     return output_;
   }
   const Node * return_node() const {
     return output_;
+  }
+  Value * addInput(std::string name="") {
+    Value * v = input_->addOutput();
+    if (name != "") v->setUniqueName(name);
+    return v;
+  }
+  void eraseInput(size_t i) {
+    input_->eraseOutput(i);
+  }
+  size_t registerOutput(Value * n) {
+    output_->addInput(n);
+    return outputs().size() - 1;
+  }
+  Node * appendNode(Node * n) {
+    JIT_ASSERT(n->graph_ == graph_ && !n->inBlockList());
+    n->insertBefore(output_);
+    return n;
+  }
+
+  Node * prependNode(Node * n) {
+    JIT_ASSERT(n->graph_ == graph_ && !n->inBlockList());
+    n->insertAfter(output_);
+    return n;
+  }
+  Graph * owningGraph() {
+    return graph_;
+  }
+  Node * owningNode() {
+    return owning_node_;
+  }
+private:
+  // should only be called in the constructor
+  Node* initOutput(Node* p) {
+    p->next() = p;
+    p->prev() = p;
+    p->setStage(std::numeric_limits<size_t>::max());
+    return p;
+  }
+
+  // get rid of all nodes
+  // destroys in reverse order so that uses internal to this block
+  // do not have to be removed before you can destroy the block
+  void destroy();
+
+  Graph * const graph_;
+  // holds outputs in a way that can be reflected
+  // as a Use object
+  // also used as the beginning/end of the circular node list to avoid
+  // having corner cases where the list is empty.
+  Node * const output_;
+  Node * const input_;
+  Node * const owning_node_; // either the node that has this block or nullptr for root
+};
+
+struct Graph {
+TH_DISALLOW_COPY_AND_ASSIGN(Graph);
+friend struct Node;
+friend struct Value;
+friend struct Block;
+private:
+
+  // only used to keep track of allocated nodes
+  // actual representation of Graph is done with
+  // inputs, outputs, nodes
+
+  std::unordered_set<const Node*> all_nodes;
+  std::unordered_set<const Value*> all_values;
+  std::unordered_set<const Block*> all_blocks;
+  size_t next_unique_;
+
+  std::unordered_set<std::string> unique_names_;
+
+  size_t new_node_stage_;
+
+  std::shared_ptr<Scope> scope_root_;
+  Scope * current_scope_;
+
+  Block* const block_;
+
+public:
+
+  Graph(std::shared_ptr<Scope> scope_root)
+  : next_unique_(0)
+  , new_node_stage_(0)
+  , scope_root_(scope_root)
+  , current_scope_(scope_root_.get())
+  , block_(new Block(this, nullptr)) {}
+
+  Graph()
+  : Graph( std::make_shared<Scope>()) {}
+
+  at::ArrayRef<Value*> inputs() {
+    return block_->inputs();
+  }
+  at::ArrayRef<const Value*> inputs() const {
+    const auto & block = *block_;
+    return block.inputs();
+  }
+  at::ArrayRef<Value*> outputs() {
+    return block_->outputs();
+  }
+  at::ArrayRef<const Value*> outputs() const {
+    const auto & block = *block_;
+    return block.outputs();
+  }
+  graph_node_list nodes() {
+    return block_->nodes();
+  }
+  const_graph_node_list nodes() const {
+    const auto & block = *block_;
+    return block.nodes();
+  }
+  Node * return_node() {
+    return block_->return_node();
+  }
+  const Node * return_node() const {
+    return block_->return_node();
   }
   void push_scope(const std::string& scope_name) {
     current_scope_ = current_scope_->push(Symbol(scope_name));
@@ -727,12 +823,10 @@ public:
     return scope_root_;
   }
   Value * addInput(std::string name="") {
-    Value * v = input_->addOutput();
-    if (name != "") v->setUniqueName(name);
-    return v;
+    return block_->addInput(std::move(name));
   }
   void eraseInput(size_t i) {
-    input_->eraseOutput(i);
+    block_->eraseInput(i);
   }
   void advanceStage() {
     new_node_stage_++;
@@ -750,8 +844,7 @@ public:
   }
 
   size_t registerOutput(Value * n) {
-    output_->addInput(n);
-    return outputs().size() - 1;
+    return block_->registerOutput(n);
   }
 
   Node * create(NodeKind kind, size_t num_outputs=1) {
@@ -799,19 +892,27 @@ public:
     for(auto i : n->inputs()) {
       r->addInput(value_map(i));
     }
+    // it is not clear whether createClone should copy the blocks
+    // or if it should allow the caller to do it
+    // so for now we disallow it until we have an example where we need it
+    JIT_ASSERTM(n->blocks().size() == 0, "NYI - createClone with Blocks");
     return r;
   }
 
   Node * appendNode(Node * n) {
-    JIT_ASSERT(n->graph_ == this && !n->inGraphList());
-    n->insertBefore(output_);
-    return n;
+    return block_->appendNode(n);
   }
 
   Node * prependNode(Node * n) {
-    JIT_ASSERT(n->graph_ == this && !n->inGraphList());
-    n->insertAfter(output_);
-    return n;
+    return block_->prependNode(n);
+  }
+
+  // the top level block
+  Block * block() {
+    return block_;
+  }
+  const Block * block() const {
+    return block_;
   }
 
   // Checks well-formedness and invariants of graph
@@ -824,6 +925,8 @@ public:
       delete n;
     for (const Value * v : all_values)
       delete v;
+    for (const Block * b : all_blocks)
+      delete b;
   }
 
   std::string toString() const {
@@ -837,14 +940,6 @@ public:
 
 private:
 
-  // should only be called in the constructor
-  Node* initOutput(Node* p) {
-    p->next() = p;
-    p->prev() = p;
-    p->setStage(std::numeric_limits<size_t>::max());
-    return p;
-  }
-
   void freeNode(Node * n) {
     auto it = all_nodes.find(n);
     JIT_ASSERT(it != all_nodes.end());
@@ -854,7 +949,14 @@ private:
   void freeValue(Value * v) {
     auto it = all_values.find(v);
     JIT_ASSERT(it != all_values.end());
+    delete *it;
     all_values.erase(it);
+  }
+  void freeBlock(Block * b) {
+    auto it = all_blocks.find(b);
+    JIT_ASSERT(it != all_blocks.end());
+    delete *it;
+    all_blocks.erase(it);
   }
 };
 
@@ -886,6 +988,7 @@ inline void Value::replaceAllUsesWith(Value * newValue) {
 inline Node::Node(Graph * graph_, NodeKind kind_) :
   kind_(kind_),
   graph_(graph_),
+  owning_block_(nullptr),
   stage_(graph_->new_node_stage_),
   scope_(graph_->current_scope_) {
   graph_->all_nodes.emplace(this);
@@ -902,12 +1005,26 @@ inline void Node::eraseOutput(size_t i) {
   }
 }
 
+inline Block * Node::addBlock() {
+  blocks_.push_back(new Block(owningGraph(), this));
+  return blocks_.back();
+}
+
+inline void Node::eraseBlock(size_t i) {
+  JIT_ASSERT(i < blocks_.size());
+  Block * n = blocks_[i];
+  blocks_.erase(blocks_.begin() + i);
+  n->destroy();
+}
+
 inline void Node::destroy() {
-  JIT_ASSERT(inGraphList());
   while(outputs().size() > 0)
     eraseOutput(outputs().size() - 1);
+  while(blocks().size() > 0)
+    eraseBlock(blocks().size() - 1);
   removeAllInputs();
-  removeFromList();
+  if(inBlockList())
+    removeFromList();
   graph_->freeNode(this);
 }
 
@@ -929,6 +1046,30 @@ inline Value* Value::setUniqueName(const std::string & name) {
   node_->graph_->unique_names_.insert(name);
   unique_name_ = name;
   return this;
+}
+
+inline Block::Block(Graph * graph_, Node * node_)
+: graph_(graph_)
+, output_(initOutput(graph_->create(kReturn, 0)))
+, input_(graph_->create(kParam,0))
+, owning_node_(node_) {
+  graph_->all_blocks.emplace(this);
+  output_->owning_block_ = this;
+  input_->owning_block_ = this;
+}
+
+inline void Block::destroy() {
+  // we cannot destroy the output because it is used as the sentinel
+  // for the nodes() list and has to remain valid for the loop
+  output_->removeAllInputs();
+  for(auto it = this->nodes().reverse().begin(),
+      end = this->nodes().reverse().end();
+      it != end; ++it) {
+    it.destroyCurrent();
+  }
+  output_->destroy();
+  input_->destroy();
+  graph_->freeBlock(this);
 }
 
 // Helper macros for constructing switch statements over Node types

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -111,7 +111,7 @@ struct EqualNodeCSE {
 // Since the nodes are visited in topological order, one pass is enough.
 void EliminateCommonSubexpression(std::shared_ptr<Graph>& graph) {
   std::unordered_set<Node*, HashNodeCSE, EqualNodeCSE> subexprs;
-  for (auto it = graph->begin(); it != graph->end(); ++ it) {
+  for (auto it = graph->nodes().begin(); it != graph->nodes().end(); ++ it) {
     auto node = *it;
     if (node->kind() == kPythonOp
         || node->kind() == kCppOp

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -209,7 +209,7 @@ struct GraphFuser {
     }
 
     // Clone all nodes
-    for (auto inner : *producer_subgraph) {
+    for (auto inner : producer_subgraph->nodes()) {
       Node * outer = graph->createClone(inner, [&](Value * k) -> Value* {
         return inner_to_outer.at(k);
       });

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -79,8 +79,7 @@ bool fusibleExpandTo(at::IntList from, at::IntList to) {
 }
 
 void fuseBroadcast(std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
-    auto* n = *it;
+  for(auto n : graph->nodes()) {
 
     // Can't fuse into nodes that don't support broadcasting
     if (!isBroadcasting(n)) continue;
@@ -120,8 +119,7 @@ void fuseBroadcast(std::shared_ptr<Graph>& graph) {
 }
 
 void fuseConsecutiveTransposes(std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
-    auto* n = *it;
+  for(auto n : graph->nodes()) {
 
     if (n->kind() == kTranspose && n->input()->node()->kind() == kTranspose) {
       auto origInput = n->input();
@@ -136,9 +134,8 @@ void fuseConsecutiveTransposes(std::shared_ptr<Graph>& graph) {
 }
 
 void eliminateNopTranspose(std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
-    auto* n = *it;
-
+  for(auto it = graph->nodes().begin(), end = graph->nodes().end(); it != end; ++it) {
+    auto n = *it;
     if (n->kind() == kTranspose) {
       if (isNopTranspose(n->is(kperm))) {
         n->replaceAllUsesWith(n->input()->node());
@@ -152,8 +149,7 @@ void eliminateNopTranspose(std::shared_ptr<Graph>& graph) {
 void fuseTransposeIntoGemm(std::shared_ptr<Graph>& graph) {
   static const std::vector<int64_t> simpleTransPerm({1,0});
 
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
-    auto* n = *it;
+  for(auto n : graph->nodes()) {
 
     if (n->kind() == kGemm) {
       for (size_t i : {0,1}) {

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -10,7 +10,7 @@ namespace torch { namespace jit {
 //
 // TODO: Decide what kind of fixed point strategy we will have
 void PeepholeOptimize(std::shared_ptr<Graph>& graph) {
-  for (auto it = graph->begin(); it != graph->end(); ++it) {
+  for (auto it = graph->nodes().begin(); it != graph->nodes().end(); ++it) {
     auto* n = *it;
 
     // eliminate redundant expand

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -29,7 +29,7 @@ void initPythonIRBindings(PyObject * module_) {
     })
     // TODO: Iterator invalidation might make this hazardous
     .def("nodes",[](Graph &g) {
-      return py::make_iterator(g.begin(), g.end());
+      return py::make_iterator(g.nodes().begin(), g.nodes().end());
     })
     .def("addInput",[](Graph &g) { return g.addInput(); })
     .GS(advanceStage)

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -16,7 +16,6 @@ struct SymbolicVariable {
   void addAsOutput() {
     v->owningGraph()->registerOutput(v);
   }
-
   static std::vector<SymbolicVariable> create(Symbol kind, ArrayRef<SymbolicVariable> inputs,
                                  int num_outputs = 1,
                                  Node** created_node = nullptr,

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -784,13 +784,19 @@ void testBlocks(std::ostream & out) {
   auto  d = b + c;
   auto dn = d.value()->node();
   dn->moveBefore(else_block->return_node());
+  auto e = d + c;
+  auto en = e.value()->node();
+  en->moveAfter(dn);
   else_block->registerOutput(d.value());
   g.registerOutput(r->output());
   g.lint();
   out << "testBlocks\n" << g << "\n";
-  r->eraseBlock(1);
+  r->eraseBlock(0);
   out << g << "\n";
   g.lint();
+  // test recursive copy of blocks works
+  auto g2 = g.copy();
+  out << *g2 << "\n";
 }
 
 std::string runJITCPPTests() {


### PR DESCRIPTION
This commit is getting the IR ready for representing ONNX control flow.
It adds nested blocks to the IR.

* Each node now has blocks(), addBlock(), and eraseBlock() similar to a node's
  output list.
* Blocks are a property of every node rather than an attribute because
  to make it easier to manage the lifetime of the containing nodes and because
  the behavior of cloning Blocks will likely be different from the way we clone other
  attributes.
* A block itself has a list of nodes, as well as inputs and outputs.
  The meaning of the nested input/output nodes are specific to the particular
  node kind containing the block. It is safe to assume inputs to a block will be
  in scope in the block.
* Each Block has an owningNode() and each node has an owningBlock().
  The owningNode of the top-most block is null.
* Values are lexically scoped: nested blocks can use values from outer blocks
  that have been defined in previous nodes. Lint has been updated with these
  new scoping rules.
* This change preserves almost all of the pre-Block API. No attempt has been made
  to make optimizations aware of Blocks. This will need to be done on a case-by-case
  basis as we make optimizations capable of handling Blocks.