### PR TITLE
Expose sparse variable sspaddmm

### DIFF
--- a/aten/src/ATen/native/SparseMM.cpp
+++ b/aten/src/ATen/native/SparseMM.cpp
@@ -57,24 +57,19 @@ struct SspaddmmOp {
   }
 };
 
-// sparse, real, sparse, real, sparse, dense -> sparse
-Tensor& _sspaddmm_out_cpu(Tensor& result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+// sparse, sparse, sparse, dense, real, real -> sparse
+Tensor& _sspaddmm_out_cpu(Tensor& result, const Tensor& self,
+    const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   dispatch_floating_types<void, SspaddmmOp>(self.type(), "sspaddmm",
       result, beta, self, alpha, mat1, mat2);
   return result;
 }
 
-Tensor& _sspaddmm_out_nyi(Tensor& result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+// sparse, sparse, sparse, dense, real, real -> sparse
+Tensor& _sspaddmm_out_nyi(Tensor& result, const Tensor& self,
+    const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   runtime_error("tensor.sspaddmm(...) can only be called on sparse tensors");
   return result;
-}
-
-// sparse, sparse, sparse, dense, real, real -> sparse
-Tensor& sspaddmm_out(Tensor& result, const Tensor& self, const Tensor& mat1,
-    const Tensor& mat2, Scalar beta, Scalar alpha) {
-  return self.type()._sspaddmm_out(result, beta, self, alpha, mat1, mat2);
 }
 
 // sparse, sparse, dense, real, real -> sparse

--- a/aten/src/ATen/native/SparseMM.cpp
+++ b/aten/src/ATen/native/SparseMM.cpp
@@ -1,0 +1,85 @@
+#include "ATen/ATen.h"
+#include "ATen/Dispatch.h"
+#include "ATen/NativeFunctions.h"
+
+#include <TH/TH.h>
+#include <THNN/THNN.h>
+#undef THNN_
+#include <THS/THS.h>
+
+#include "ATen/CPUFloatTensor.h"
+#include "ATen/CPUDoubleTensor.h"
+#include "ATen/SparseCPUFloatTensor.h"
+#include "ATen/SparseCPUDoubleTensor.h"
+
+namespace at {
+namespace native {
+
+// Calling into TH for sspaddmm because ATen code generation currently
+// doesn't support Sparse x Dense operations on Sparse tensors
+template <class scalar>
+void TH_sspaddmm(Tensor & result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  runtime_error("sspaddmm NYI for passed in types\n");
+}
+
+template <>
+void TH_sspaddmm<float>(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  auto result_ = checked_cast_tensor<SparseCPUFloatTensor>(result.pImpl,"result",0, false);
+  auto beta_ = beta.toFloat();
+  auto self_ = checked_cast_tensor<SparseCPUFloatTensor>(self.pImpl,"self",2, false);
+  auto alpha_ = alpha.toFloat();
+  auto mat1_ = checked_cast_tensor<SparseCPUFloatTensor>(mat1.pImpl,"mat1",4, false);
+  auto mat2_ = checked_cast_tensor<CPUFloatTensor>(mat2.pImpl,"mat2",5, false);
+  THSFloatTensor_sspaddmm(result_->tensor, beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
+  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
+}
+
+template <>
+void TH_sspaddmm<double>(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  auto result_ = checked_cast_tensor<SparseCPUDoubleTensor>(result.pImpl,"result",0, false);
+  auto beta_ = beta.toDouble();
+  auto self_ = checked_cast_tensor<SparseCPUDoubleTensor>(self.pImpl,"self",2, false);
+  auto alpha_ = alpha.toDouble();
+  auto mat1_ = checked_cast_tensor<SparseCPUDoubleTensor>(mat1.pImpl,"mat1",4, false);
+  auto mat2_ = checked_cast_tensor<CPUDoubleTensor>(mat2.pImpl,"mat2",5, false);
+  THSDoubleTensor_sspaddmm(result_->tensor, beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
+  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
+}
+
+template <typename scalar>
+struct SspaddmmOp {
+  static void apply(Tensor& result, Scalar beta, const Tensor& self,
+      Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+    TH_sspaddmm<scalar>(result, beta, self, alpha, mat1, mat2);
+  }
+};
+
+// sparse, real, sparse, real, sparse, dense -> sparse
+Tensor& _sspaddmm_out_cpu(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  dispatch_floating_types<void, SspaddmmOp>(self.type(), "sspaddmm",
+      result, beta, self, alpha, mat1, mat2);
+  return result;
+}
+
+// sparse, real, sparse, real, sparse, dense -> sparse
+Tensor& sspaddmm_out(Tensor& result, const Tensor& self, const Tensor& mat1,
+    const Tensor& mat2, Scalar beta, Scalar alpha) {
+  return mat2.type()._sspaddmm_out(result, beta, self, alpha, mat1, mat2);
+}
+
+// real, sparse, real, sparse, dense -> sparse
+Tensor sspaddmm(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
+    Scalar beta, Scalar alpha) {
+  // There's no easy way to make an empty sparse tensor right now
+  auto result = self.clone();
+  // Dispatch on the DENSE type, because native_functions.yaml
+  // doesn't support specifying sparse backend dispatch
+  mat2.type().sspaddmm_out(result, self, mat1, mat2, beta, alpha);
+  return result;
+}
+
+}}

--- a/aten/src/ATen/native/SparseMM.cpp
+++ b/aten/src/ATen/native/SparseMM.cpp
@@ -66,7 +66,7 @@ Tensor& _sspaddmm_out_cpu(Tensor& result, const Tensor& self,
 }
 
 // sparse, sparse, sparse, dense, real, real -> sparse
-Tensor& _sspaddmm_out_nyi(Tensor& result, const Tensor& self,
+Tensor& _sspaddmm_out_only_sparse(Tensor& result, const Tensor& self,
     const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   runtime_error("tensor.sspaddmm(...) can only be called on sparse tensors");
   return result;

--- a/aten/src/ATen/native/cuda/SparseMM.cu
+++ b/aten/src/ATen/native/cuda/SparseMM.cu
@@ -1,70 +1,12 @@
 #include "ATen/ATen.h"
-#include "ATen/Dispatch.h"
 #include "ATen/NativeFunctions.h"
-
-#include <THC/THC.h>
-#include <THCUNN/THCUNN.h>
-#undef THNN_
-#undef THCIndexTensor_
-#include <THCS/THCS.h>
-#undef THCIndexTensor_
-
-#include "ATen/CUDAFloatTensor.h"
-#include "ATen/CUDADoubleTensor.h"
-#include "ATen/SparseCUDAFloatTensor.h"
-#include "ATen/SparseCUDADoubleTensor.h"
 
 namespace at {
 namespace native {
 
-// Calling into TH for sspaddmm because ATen code generation currently
-// doesn't support Sparse x Dense operations
-template <class scalar>
-void TH_cuda_sspaddmm(Tensor & result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
-  runtime_error("sspaddmm NYI for passed in types\n");
-}
-
-template <>
-void TH_cuda_sspaddmm<float>(Tensor& result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
-  auto result_ = checked_cast_tensor<SparseCUDAFloatTensor>(result.pImpl,"result",0, false);
-  auto beta_ = beta.toFloat();
-  auto self_ = checked_cast_tensor<SparseCUDAFloatTensor>(self.pImpl,"self",2, false);
-  auto alpha_ = alpha.toFloat();
-  auto mat1_ = checked_cast_tensor<SparseCUDAFloatTensor>(mat1.pImpl,"mat1",4, false);
-  auto mat2_ = checked_cast_tensor<CUDAFloatTensor>(mat2.pImpl,"mat2",5, false);
-  THCSFloatTensor_sspaddmm(result.type().get_context().thc_state, result_->tensor,
-      beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
-  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
-}
-
-template <>
-void TH_cuda_sspaddmm<double>(Tensor& result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
-  auto result_ = checked_cast_tensor<SparseCUDADoubleTensor>(result.pImpl,"result",0, false);
-  auto beta_ = beta.toDouble();
-  auto self_ = checked_cast_tensor<SparseCUDADoubleTensor>(self.pImpl,"self",2, false);
-  auto alpha_ = alpha.toDouble();
-  auto mat1_ = checked_cast_tensor<SparseCUDADoubleTensor>(mat1.pImpl,"mat1",4, false);
-  auto mat2_ = checked_cast_tensor<CUDADoubleTensor>(mat2.pImpl,"mat2",5, false);
-  THCSDoubleTensor_sspaddmm(result.type().get_context().thc_state, result_->tensor,
-      beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
-  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
-}
-
-template <typename scalar>
-struct SspaddmmCUDAOp {
-  static void apply(Tensor& result, Scalar beta, const Tensor& self,
-      Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
-    TH_cuda_sspaddmm<scalar>(result, beta, self, alpha, mat1, mat2);
-  }
-};
-
 Tensor& _sspaddmm_out_cuda(Tensor& result, Scalar beta, const Tensor& self,
     Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
-  dispatch_floating_types<void, SspaddmmCUDAOp>(self.type(), "sspaddmm_cuda",
-      result, beta, self, alpha, mat1, mat2);
+  runtime_error("NYI: CUDA sspaddmm is not implemented");
   return result;
 }
 

--- a/aten/src/ATen/native/cuda/SparseMM.cu
+++ b/aten/src/ATen/native/cuda/SparseMM.cu
@@ -1,0 +1,71 @@
+#include "ATen/ATen.h"
+#include "ATen/Dispatch.h"
+#include "ATen/NativeFunctions.h"
+
+#include <THC/THC.h>
+#include <THCUNN/THCUNN.h>
+#undef THNN_
+#undef THCIndexTensor_
+#include <THCS/THCS.h>
+#undef THCIndexTensor_
+
+#include "ATen/CUDAFloatTensor.h"
+#include "ATen/CUDADoubleTensor.h"
+#include "ATen/SparseCUDAFloatTensor.h"
+#include "ATen/SparseCUDADoubleTensor.h"
+
+namespace at {
+namespace native {
+
+// Calling into TH for sspaddmm because ATen code generation currently
+// doesn't support Sparse x Dense operations
+template <class scalar>
+void TH_cuda_sspaddmm(Tensor & result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  runtime_error("sspaddmm NYI for passed in types\n");
+}
+
+template <>
+void TH_cuda_sspaddmm<float>(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  auto result_ = checked_cast_tensor<SparseCUDAFloatTensor>(result.pImpl,"result",0, false);
+  auto beta_ = beta.toFloat();
+  auto self_ = checked_cast_tensor<SparseCUDAFloatTensor>(self.pImpl,"self",2, false);
+  auto alpha_ = alpha.toFloat();
+  auto mat1_ = checked_cast_tensor<SparseCUDAFloatTensor>(mat1.pImpl,"mat1",4, false);
+  auto mat2_ = checked_cast_tensor<CUDAFloatTensor>(mat2.pImpl,"mat2",5, false);
+  THCSFloatTensor_sspaddmm(result.type().get_context().thc_state, result_->tensor,
+      beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
+  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
+}
+
+template <>
+void TH_cuda_sspaddmm<double>(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  auto result_ = checked_cast_tensor<SparseCUDADoubleTensor>(result.pImpl,"result",0, false);
+  auto beta_ = beta.toDouble();
+  auto self_ = checked_cast_tensor<SparseCUDADoubleTensor>(self.pImpl,"self",2, false);
+  auto alpha_ = alpha.toDouble();
+  auto mat1_ = checked_cast_tensor<SparseCUDADoubleTensor>(mat1.pImpl,"mat1",4, false);
+  auto mat2_ = checked_cast_tensor<CUDADoubleTensor>(mat2.pImpl,"mat2",5, false);
+  THCSDoubleTensor_sspaddmm(result.type().get_context().thc_state, result_->tensor,
+      beta_, self_->tensor, alpha_, mat1_->tensor, mat2_->tensor);
+  result_->maybeScalar(self_->isScalar() && mat1_->isScalar() && mat2_->isScalar());
+}
+
+template <typename scalar>
+struct SspaddmmCUDAOp {
+  static void apply(Tensor& result, Scalar beta, const Tensor& self,
+      Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+    TH_cuda_sspaddmm<scalar>(result, beta, self, alpha, mat1, mat2);
+  }
+};
+
+Tensor& _sspaddmm_out_cuda(Tensor& result, Scalar beta, const Tensor& self,
+    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+  dispatch_floating_types<void, SspaddmmCUDAOp>(self.type(), "sspaddmm_cuda",
+      result, beta, self, alpha, mat1, mat2);
+  return result;
+}
+
+}}

--- a/aten/src/ATen/native/cuda/SparseMM.cu
+++ b/aten/src/ATen/native/cuda/SparseMM.cu
@@ -4,8 +4,8 @@
 namespace at {
 namespace native {
 
-Tensor& _sspaddmm_out_cuda(Tensor& result, Scalar beta, const Tensor& self,
-    Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
+Tensor& _sspaddmm_out_cuda(Tensor& result, const Tensor& self,
+    const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   runtime_error("NYI: CUDA sspaddmm is not implemented");
   return result;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -39,10 +39,6 @@
 
 - func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
-
-# This is separate from sspaddmm_out because we can't currently specify a sparse backend for dispatch
-- func: _sspaddmm_out(Tensor result, Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
-  variants: function
   dispatch:
     CPU: _sspaddmm_out_nyi
     CUDA: _sspaddmm_out_nyi

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -40,8 +40,8 @@
 - func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
   dispatch:
-    CPU: _sspaddmm_out_nyi
-    CUDA: _sspaddmm_out_nyi
+    CPU: _sspaddmm_out_only_sparse
+    CUDA: _sspaddmm_out_only_sparse
     SparseCPU: _sspaddmm_out_cpu
     SparseCUDA: _sspaddmm_out_cuda
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -44,8 +44,10 @@
 - func: _sspaddmm_out(Tensor result, Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
   variants: function
   dispatch:
-    CPU: _sspaddmm_out_cpu
-    CUDA: _sspaddmm_out_cuda
+    CPU: _sspaddmm_out_nyi
+    CUDA: _sspaddmm_out_nyi
+    SparseCPU: _sspaddmm_out_cpu
+    SparseCUDA: _sspaddmm_out_cuda
 
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -35,6 +35,18 @@
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
 
+- func: sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+
+- func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  variants: function
+
+# This is separate from sspaddmm_out because we can't currently specify a sparse backend for dispatch
+- func: _sspaddmm_out(Tensor result, Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _sspaddmm_out_cpu
+    CUDA: _sspaddmm_out_cuda
+
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
 
 - func: cudnn_is_acceptable(Tensor self) -> bool

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -81,6 +81,13 @@ def parse_arguments(args, func_decl, func_name, func_return):
     return arguments
 
 
+def has_sparse_dispatches(dispatches):
+    for dispatch in dispatches:
+        if 'Sparse' in dispatch:
+            return True
+    return False
+
+
 def parse_native_yaml(path):
     with open(path, 'r') as f:
         return yaml.load(f, Loader=Loader)
@@ -105,6 +112,8 @@ def run(paths):
             declaration['arguments'] = func.get('arguments', parse_arguments(arguments, func,
                                                 declaration['name'], declaration['return']))
             declaration['type_method_definition_dispatch'] = func.get('dispatch', declaration['name'])
+            declaration['aten_sparse'] = has_sparse_dispatches(
+                declaration['type_method_definition_dispatch'])
             declarations.append(declaration)
 
     return declarations

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -741,12 +741,16 @@ class TestSparse(TestCase):
             self.assertEqual(test_fn(var1, var2).data,
                              test_fn(tensor1, tensor2), test_name)
 
-        to_test_mixed = {
-            'addmm': lambda sp, de: de.addmm(sp, de),
-            'addmm_': lambda sp, de: de.addmm(sp, de),
-            'mm': lambda sp, de: torch.mm(sp, de),
-            'mm_out': lambda sp, de: torch.mm(sp, de, out=de),
-        }
+        to_test_mixed = [
+            # test name, lambda expression, should_run_when_cuda
+            ('sspaddmm', lambda sp, de: sp.sspaddmm(sp, de), False),
+            ('sspaddmm_b', lambda sp, de: sp.sspaddmm(2, sp, de), False),
+            ('sspaddmm_b_a', lambda sp, de: sp.sspaddmm(3, 2, sp, de), False),
+            ('addmm', lambda sp, de: de.addmm(sp, de), True),
+            ('addmm_', lambda sp, de: de.addmm(sp, de), True),
+            ('mm', lambda sp, de: torch.mm(sp, de), True),
+            ('mm_out', lambda sp, de: torch.mm(sp, de, out=de), True),
+        ]
 
         i = self.IndexTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])
         v = self.ValueTensor([3, 3, 4, 1, 2])
@@ -755,7 +759,9 @@ class TestSparse(TestCase):
         dense_mat = sparse_mat.to_dense().random_(0, 5)
         dense_var = Variable(dense_mat)
 
-        for test_name, test_fn in to_test_mixed.items():
+        for test_name, test_fn, test_cuda in to_test_mixed:
+            if sparse_var.is_cuda and not test_cuda:
+                continue
             sp_var = sparse_var.clone()
             de_var = dense_var.clone()
             sp_mat = sparse_mat.clone()

--- a/tools/autograd/deprecated.yaml
+++ b/tools/autograd/deprecated.yaml
@@ -25,6 +25,12 @@
 - name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
   aten: addmm(self, mat1, mat2, beta, 1)
 
+- name: sspaddmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2)
+  aten: sspaddmm(self, mat1, mat2, beta, alpha)
+
+- name: sspaddmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
+  aten: sspaddmm(self, mat1, mat2, beta, 1)
+
 - name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec)
   aten: addmv(self, mat, vec, beta, alpha)
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -16,7 +16,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
-    'sparse_raw_resize_',
+    'sparse_raw_resize_', '_sspaddmm.*',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -16,7 +16,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
-    'sparse_raw_resize_', '_sspaddmm.*',
+    'sparse_raw_resize_',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
Exposes sparse variable sspaddmm. I did this by exposing the THS sspaddmm directly in a native function because Declarations.cwrap can't handle dense tensor arguments on a dispatched sparse tensor method.

cc @colesbury 

### Test Plan
Unit tests.