### PR TITLE
Remove FunctionFlags

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -93,7 +93,7 @@ if (compute_requires_grad( ${args_with_derivatives} )) {
 
 ASSIGN_GRAD_FN = CodeTemplate("""\
 grad_fn = std::make_shared<${op}>(${op_ctor});
-grad_fn->next_functions = compute_next_functions( ${args_with_derivatives} );
+grad_fn->next_functions = get_next_functions( ${args_with_derivatives} );
 """)
 
 CALL_VIA_TYPE = CodeTemplate("""\

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -283,12 +283,6 @@ static void check_no_requires_grad(const Tensor& tensor, const char* name) {
   }
 }
 
-// NB: This should be called with Tensor/TensorList arguments (not Variables)
-template <typename... Args>
-static function_list compute_next_functions(Args&&... args) {
-  return Function::tensor_flags(std::forward<Args>(args)...).next_functions;
-}
-
 static void check_inplace(const Tensor& tensor) {
   auto& var = static_cast<const Variable&>(tensor);
   if (var.requires_grad() && var.is_leaf() && GradMode::is_enabled()) {
@@ -387,7 +381,7 @@ Tensor & VariableType::s_copy_(Tensor & self, const Tensor & src, bool non_block
   requires_grad &= isFloatingPoint(self.type().scalarType());
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
-    grad_fn->next_functions = compute_next_functions( self, src );
+    grad_fn->next_functions = get_next_functions(self, src);
     grad_fn->num_inputs = 1;
     grad_fn->src_type = &src.type();
     grad_fn->src_device = src.is_cuda() ? src.get_device() : -1;

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,12 +1,14 @@
 #include "Python.h"
 #include "function.h"
 
-#include <string>
-
 #include "variable.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/autograd/grad_mode.h"
 #include "torch/csrc/autograd/functions/special.h"
+
+#include <string>
+#include <cstdint>
+#include <vector>
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -1,8 +1,12 @@
 #include "basic_ops.h"
 
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
+
+#include <memory>
+#include <utility>
 
 namespace torch { namespace autograd {
 
@@ -17,8 +21,8 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
     // FIXME: share version counters
     outputs.emplace_back(var.defined() ? var.data() : Tensor());
   }
-  return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
-    return std::make_shared<Error>(msg, std::move(f));
+  return wrap_outputs(inputs, std::move(outputs), [&](function_list&& next_functions) {
+    return std::make_shared<Error>(msg, std::move(next_functions));
   });
 };
 

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -11,8 +11,8 @@
 namespace torch { namespace autograd {
 
 struct Error : public Function {
-  Error(std::string msg, FunctionFlags&& flags)
-    : Function(std::move(flags))
+  Error(std::string msg, function_list&& next_functions)
+    : Function(std::move(next_functions))
     , msg(std::move(msg)) {}
 
   Error(std::string msg)
@@ -35,9 +35,8 @@ struct DelayedError : public Function {
 
 struct GraphRoot : public Function {
   GraphRoot(function_list functions, variable_list inputs)
-    : outputs(std::move(inputs)) {
-      next_functions = std::move(functions);
-    };
+    : Function(std::move(functions)), outputs(std::move(inputs)) {
+    }
 
   virtual variable_list apply(const variable_list& inputs) {
     return outputs;

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,19 +1,17 @@
 #include "torch/csrc/autograd/functions/utils.h"
-#include "torch/csrc/utils/functional.h"
-#include "torch/csrc/jit/tracer.h"
-
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
 #include <sstream>
+#include <vector>
 
 namespace torch { namespace autograd {
 
 variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
                            function_constructor ctr) {
-  auto flags = Function::flags(inputs);
   variable_list result;
   result.reserve(outputs.size());
-  if (!flags.is_executable) {
+  if (!any_variable_requires_grad(inputs)) {
     for (auto& output : outputs) {
       if (output.defined()) {
         result.emplace_back(make_variable(output, false));
@@ -22,7 +20,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
       }
     }
   } else {
-    auto grad_fn = ctr(std::move(flags));
+    auto grad_fn = ctr(get_next_functions(inputs));
     for (auto& output : outputs) {
       if (output.defined()) {
         result.emplace_back(make_variable(output, grad_fn));
@@ -53,5 +51,4 @@ void check_input_variables(const char* name, const variable_list& inputs, int ar
     }
   }
 }
-
 }}

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -3,14 +3,13 @@
 #include <Python.h>
 #include <functional>
 #include <memory>
-#include <array>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
 namespace torch { namespace autograd {
 
-using function_constructor = std::function<std::shared_ptr<Function>(FunctionFlags)>;
+using function_constructor = std::function<std::shared_ptr<Function>(function_list&&)>;
 
 /**
  * Wraps the tensor outputs in variables and creates the grad_fn and sets the
@@ -24,5 +23,4 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
  * items are not NULL. If not specified, `required_args` defaults to `args`.
  */
 void check_input_variables(const char* name, const variable_list& inputs, int args, int required_args=-1);
-
 }}

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -94,9 +94,13 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   // leads to unexpected error messages ("no nodes require computing gradients"),
   // but I don't have a better idea. These functions would raise an error
   // in backward anyway.
-  return wrap_outputs(inputs, std::move(tensor_results), [this](FunctionFlags &&f) {
-    return std::make_shared<Error>(name() + " is not differentiable twice", std::move(f));
-  });
+  return wrap_outputs(
+      inputs,
+      std::move(tensor_results),
+      [this](function_list&& next_functions) {
+        return std::make_shared<Error>(
+            name() + " is not differentiable twice", std::move(next_functions));
+      });
 }
 
 // NOTE: this function is written in a way that assumes it's only called for backward;
@@ -566,7 +570,8 @@ struct UnpackedInput {
 };
 
 struct InputFlags {
-  FunctionFlags flags;
+  bool is_executable = false;
+  function_list next_functions;
   THPObjectPtr needs_input_grad;
   std::vector<bool> is_variable_input;
 };
@@ -606,7 +611,8 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
     PyTuple_SET_ITEM(unpacked.tensor_input.get(), i, new_arg);
   }
 
-  flags.flags = Function::flags(unpacked.input_vars);
+  flags.is_executable = any_variable_requires_grad(unpacked.input_vars);
+  flags.next_functions = get_next_functions(unpacked.input_vars);
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 
@@ -779,8 +785,8 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   auto info_pair = unpack_input<true>(_inputs);
   auto& unpacked_input = info_pair.first;
   auto& input_info = info_pair.second;
-  bool is_executable = input_info.flags.is_executable;
-  self->cdata.set_flags(std::move(input_info.flags));
+  bool is_executable = input_info.is_executable;
+  self->cdata.set_next_functions(std::move(input_info.next_functions));
   self->needs_input_grad = input_info.needs_input_grad.release();
 
   // Now we're ready to call a forward (implemented in Python)
@@ -811,8 +817,8 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   InputFlags& input_info = info_pair.second;
 
   // Initialize backward function (and ctx)
-  bool is_executable = input_info.flags.is_executable;
-  ctx->cdata.set_flags(std::move(input_info.flags));
+  bool is_executable = input_info.is_executable;
+  ctx->cdata.set_next_functions(std::move(input_info.next_functions));
   ctx->needs_input_grad = input_info.needs_input_grad.release();
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<Function>& VariableViewImpl::get_grad_fn() {
     fn->size = sizes();
     fn->stride = strides();
     fn->storage_offset = data.storage_offset();
-    fn->set_flags(Function::flags(base));
+    fn->set_next_functions(get_next_functions(base));
     fn->num_inputs = 1;
     _grad_fn = std::move(fn);
     attr_version = current_version;


### PR DESCRIPTION
I am helping @zdevito improve the interface of `Function` and `Variable` to make them easier and safer to work with. As part of this, I noticed there was a `TODO` over the `FunctionFlags` struct in `autograd/function.h`, saying it should be split up. Indeed, it looked like a needless aggregation of two totally unrelated things. Further, in many places we were just using one of the two members, and constructing the entire struct just to use one of them.

I simplified this by splitting up the functionality of determining whether a function "is_executable", and computing the list of next functions. As a result, the code is shorter, clearer and more efficient.

@colesbury @apaszke @ezyang 