### PR TITLE
[JIT] Add the ability to change the insert point Graphs

### DIFF
--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -11,9 +11,10 @@ graph(%a : UNKNOWN_TYPE
     block1() {
       %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
       %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
-      -> (%6)
+      -> (%7)
     }
-  return (%4);
+  %8 : UNKNOWN_TYPE = add[alpha={1}](%4, %2)
+  return (%8);
 }
 
 graph(%a : UNKNOWN_TYPE
@@ -24,9 +25,10 @@ graph(%a : UNKNOWN_TYPE
     block0() {
       %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
       %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
-      -> (%6)
+      -> (%7)
     }
-  return (%4);
+  %8 : UNKNOWN_TYPE = add[alpha={1}](%4, %2)
+  return (%8);
 }
 
 graph(%a : UNKNOWN_TYPE
@@ -37,9 +39,10 @@ graph(%a : UNKNOWN_TYPE
     block0() {
       %5 : UNKNOWN_TYPE = add[alpha={1}](%b, %3)
       %6 : UNKNOWN_TYPE = add[alpha={1}](%5, %3)
-      -> (%5)
+      -> (%6)
     }
-  return (%4);
+  %7 : UNKNOWN_TYPE = add[alpha={1}](%4, %3)
+  return (%7);
 }
 
 testCreateAutodiffSubgraphs

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -150,8 +150,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
         py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
-    auto scope_guard = ctx.graph->set_current_scope_temporary(n->scope());
-
+    WithCurrentScope scope_guard(*ctx.graph, n->scope());
     py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
     processSymbolicOutput(n->kind().toString(), n, raw_output);
@@ -188,8 +187,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
       py_symbolic_args[input_nr++] = obj;
     }
 
-    auto scope_guard = ctx.graph->set_current_scope_temporary(op->scope());
-
+    WithCurrentScope scope_guard(*ctx.graph, op->scope());
     // Call the symbolic function
     // Use a little trampoline function so we can give good error messages
     // upon argument mismatch

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -23,7 +23,7 @@ struct SymbolicVariable {
       if(g == nullptr) {
         g = inputs.at(0).value()->owningGraph();
       }
-      Node * n = g->appendNode(g->create(kind, num_outputs));
+      Node * n = g->insertNode(g->create(kind, num_outputs));
       for(auto i : inputs) {
         n->addInput(i.value());
       }


### PR DESCRIPTION
In lieu of a more complicated builder object, this commit adds
an 'insert point' to Graph and a method 'insertNode' which inserts
nodes at that insert point. setInsertPoint can be used to change
the insert point on the graph to the end of a block or to any point
inside a current block. The resource guard `WithInsertPoint`
can be used to temporarily change it to, for example, insert
into the "then" branch of an If statement.

This commit also updates the resource guard for scopes. It previously
relied on return value optimization to work correctly which is
not guaranteed to be applied until C++17.