### PR TITLE
Replace edge_type with FunctionPort

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -497,6 +497,7 @@ main_sources = [
     "torch/csrc/autograd/grad_mode.cpp",
     "torch/csrc/autograd/engine.cpp",
     "torch/csrc/autograd/function.cpp",
+    "torch/csrc/autograd/function_port.cpp",
     "torch/csrc/autograd/variable.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/input_buffer.cpp",

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -93,7 +93,7 @@ if (compute_requires_grad( ${args_with_derivatives} )) {
 
 ASSIGN_GRAD_FN = CodeTemplate("""\
 grad_fn = std::make_shared<${op}>(${op_ctor});
-grad_fn->next_functions = compute_next_functions( ${args_with_derivatives} );
+grad_fn->next_functions = get_next_functions( ${args_with_derivatives} );
 """)
 
 CALL_VIA_TYPE = CodeTemplate("""\

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -283,12 +283,6 @@ static void check_no_requires_grad(const Tensor& tensor, const char* name) {
   }
 }
 
-// NB: This should be called with Tensor/TensorList arguments (not Variables)
-template <typename... Args>
-static function_list compute_next_functions(Args&&... args) {
-  return Function::tensor_flags(std::forward<Args>(args)...).next_functions;
-}
-
 static void check_inplace(const Tensor& tensor) {
   auto& var = static_cast<const Variable&>(tensor);
   if (var.requires_grad() && var.is_leaf() && GradMode::is_enabled()) {
@@ -387,7 +381,7 @@ Tensor & VariableType::s_copy_(Tensor & self, const Tensor & src, bool non_block
   requires_grad &= isFloatingPoint(self.type().scalarType());
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
-    grad_fn->next_functions = compute_next_functions( self, src );
+    grad_fn->next_functions = get_next_functions(self, src);
     grad_fn->num_inputs = 1;
     grad_fn->src_type = &src.type();
     grad_fn->src_device = src.is_cuda() ? src.get_device() : -1;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -270,19 +270,16 @@ auto Engine::evaluate_function(FunctionTask& task) -> void {
   std::lock_guard<std::mutex> lock(task.base->mutex);
   for (int i = 0; i < num_outputs; ++i) {
     auto& output = outputs[i];
-    auto& next_fn = fn.next_functions[i].first;
-    int input_nr = fn.next_functions[i].second;
+    const auto& next = fn.next_functions[i];
 
-    if (!next_fn) {
-      continue;
-    }
+    if (!next.function) continue;
 
     // Check if the next function is ready to be computed
     bool is_ready = false;
     auto& dependencies = task.base->dependencies;
-    auto it = dependencies.find(next_fn.get());
+    auto it = dependencies.find(next.function.get());
     if (it == dependencies.end()) {
-      auto name = next_fn->name();
+      auto name = next.function->name();
       throw std::runtime_error(std::string("dependency not found for ") + name);
     } else if (--it->second == 0) {
       dependencies.erase(it);
@@ -290,31 +287,31 @@ auto Engine::evaluate_function(FunctionTask& task) -> void {
     }
 
     auto& not_ready = task.base->not_ready;
-    auto not_ready_it = not_ready.find(next_fn.get());
+    auto not_ready_it = not_ready.find(next.function.get());
     if (not_ready_it == not_ready.end()) {
       // Skip functions that aren't supposed to be executed
       if (!exec_info.empty()) {
-        auto it = exec_info.find(next_fn.get());
+        auto it = exec_info.find(next.function.get());
         if (it == exec_info.end() || !it->second.should_execute()) {
           continue;
         }
       }
       // No buffers have been allocated for the function
-      InputBuffer input_buffer(next_fn->num_inputs);
-      input_buffer.add(input_nr, std::move(output));
+      InputBuffer input_buffer(next.function->num_inputs);
+      input_buffer.add(next.port, std::move(output));
       if (is_ready) {
         auto& queue = ready_queue(input_buffer.device());
-        queue.push(FunctionTask(task.base, next_fn, std::move(input_buffer)));
+        queue.push(FunctionTask(task.base, next.function, std::move(input_buffer)));
       } else {
-        not_ready.emplace(next_fn.get(), std::move(input_buffer));
+        not_ready.emplace(next.function.get(), std::move(input_buffer));
       }
     } else {
       // The function already has a buffer
       auto &input_buffer = not_ready_it->second;
-      input_buffer.add(input_nr, std::move(output));
+      input_buffer.add(next.port, std::move(output));
       if (is_ready) {
         auto& queue = ready_queue(input_buffer.device());
-        queue.push(FunctionTask(task.base, next_fn, std::move(input_buffer)));
+        queue.push(FunctionTask(task.base, next.function, std::move(input_buffer)));
         not_ready.erase(not_ready_it);
       }
     }
@@ -333,12 +330,11 @@ auto Engine::compute_dependencies(Function* root, GraphTask& task) -> void {
   while (queue.size() > 0) {
     auto fn = queue.back(); queue.pop_back();
     for (auto& edge : fn->next_functions) {
-      Function* next_ptr = edge.first.get();
-      if (!next_ptr) continue;
-      dependencies[next_ptr] += 1;
-      bool inserted;
-      std::tie(std::ignore, inserted) = seen.insert(next_ptr);
-      if (inserted) queue.push_back(next_ptr);
+      if (auto next_ptr = edge.function.get()) {
+        dependencies[next_ptr] += 1;
+        const auto result = seen.insert(next_ptr);
+        if (result.second) queue.push_back(next_ptr);
+      }
     }
   }
 }
@@ -447,11 +443,11 @@ void GraphTask::init_to_execute(Function& graph_root, const function_list& outpu
 
   int output_idx = 0;
   for (auto & output_edge : outputs) {
-    Function *output = output_edge.first.get();
+    Function *output = output_edge.function.get();
     auto & info = exec_info[output];
     if (!info.captures)
       info.captures.reset(new std::vector<ExecInfo::Capture>());
-    info.captures->emplace_back(output_edge.second, output_idx++);
+    info.captures->emplace_back(output_edge.port, output_idx++);
   }
   captured_vars.resize(output_idx);
 
@@ -471,7 +467,7 @@ void GraphTask::init_to_execute(Function& graph_root, const function_list& outpu
       auto & next = fn->next_functions;
       auto num_next = next.size();
       while (next_next_fn < num_next) {
-        auto fn = next[next_next_fn++].first.get();
+        auto fn = next[next_next_fn++].function.get();
         if (fn) return fn;
       }
       return nullptr;
@@ -480,8 +476,8 @@ void GraphTask::init_to_execute(Function& graph_root, const function_list& outpu
   std::vector<Frame> stack;
   std::unordered_set<Function*> seen;
   for (const auto & input : graph_root.next_functions) {
-    if (seen.count(input.first.get()) > 0) continue;
-    stack.emplace_back(input.first.get());
+    if (seen.count(input.function.get()) > 0) continue;
+    stack.emplace_back(input.function.get());
     while (!stack.empty()) {
       auto &frame = stack.back();
       if (Function *next_fn = frame.get_next_fn()) {
@@ -494,11 +490,11 @@ void GraphTask::init_to_execute(Function& graph_root, const function_list& outpu
         // using a return value from recursive call. It would make this manually unrolled
         // version a lot more complicated, so I skipped that.
         auto & next_fns = frame.fn->next_functions;
-        bool needed = std::any_of(next_fns.begin(), next_fns.end(),
-                                  [&](const edge_type& e) -> bool {
-                                    auto it = exec_info.find(e.first.get());
-                                    return it != exec_info.end() && it->second.should_execute();
-                                  });
+        const bool needed = std::any_of(
+            next_fns.begin(), next_fns.end(), [&](const FunctionPort& port) {
+              auto it = exec_info.find(port.function.get());
+              return it != exec_info.end() && it->second.should_execute();
+            });
         exec_info[frame.fn].needed = needed;
         stack.pop_back();
       }

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,12 +1,14 @@
 #include "Python.h"
 #include "function.h"
 
-#include <string>
-
 #include "variable.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/autograd/grad_mode.h"
 #include "torch/csrc/autograd/functions/special.h"
+
+#include <string>
+#include <cstdint>
+#include <vector>
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -8,6 +8,7 @@
 
 #include "torch/csrc/assertions.h"
 #include "torch/csrc/autograd/function_hook.h"
+#include "torch/csrc/autograd/function_port.h"
 #include "torch/csrc/autograd/grad_mode.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/autograd/saved_variable.h"
@@ -28,38 +29,19 @@ namespace torch { namespace autograd {
 
 struct Function;
 struct Variable;
+struct FunctionPort;
 
 using tensor_list = std::vector<at::Tensor>;
 using variable_list = std::vector<Variable>;
-using edge_type = std::pair<std::shared_ptr<Function>, int>;
-using function_list = std::vector<edge_type>;
+using function_list = std::vector<FunctionPort>;
 using saved_variable_list = std::vector<SavedVariable>;
 
-struct edge_hasher {
-  std::size_t operator()(const edge_type& edge) const {
-#define HASH_IDX(idx) std::hash<std::tuple_element<idx, edge_type>::type>()(std::get<idx>(edge))
-    // TODO: that's probably a bad hash function, but whatever
-    return HASH_IDX(0) ^ HASH_IDX(1);
-  }
-};
-
 namespace detail {
-inline edge_type make_edge(const Variable &variable) {
-  if (variable.defined()) {
-    if (variable.grad_fn() != nullptr) {
-      return {variable.grad_fn(), variable.output_nr()};
-    } else if (variable.requires_grad()) {
-      return {variable.grad_accumulator(), 0};
-    }
-  }
-  return {nullptr, 0};
-}
-
 struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
   function_list next_functions;
   using IterArgs<MakeNextFunctionList>::operator();
   void operator()(const Variable& variable) {
-    next_functions.push_back(make_edge(variable));
+    next_functions.push_back(FunctionPort::for_gradient(variable));
   }
 };
 } // namespace detail
@@ -122,7 +104,7 @@ struct Function : std::enable_shared_from_this<Function> {
 
   bool should_compute_output(size_t index) const {
     TORCH_ASSERTM(index < next_functions.size(), "Index out of range");
-    return next_functions[index].first != nullptr;
+    return next_functions[index].function != nullptr;
   }
 
   bool should_compute_any_outputs() const {
@@ -195,5 +177,4 @@ struct TraceableFunction : public Function {
 
   virtual inline bool is_traceable() final { return true; };
 };
-
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/function_port.cpp
+++ b/torch/csrc/autograd/function_port.cpp
@@ -1,0 +1,38 @@
+#include "torch/csrc/autograd/function_port.h"
+
+#include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/variable.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace torch {
+namespace autograd {
+FunctionPort FunctionPort::for_gradient(const Variable& variable) {
+  if (variable.defined()) {
+    if (variable.grad_fn() != nullptr) {
+      return FunctionPort(variable.grad_fn(), variable.output_nr());
+    } else if (variable.requires_grad()) {
+      return FunctionPort(variable.grad_accumulator());
+    }
+  }
+  return FunctionPort();
+}
+
+FunctionPort::FunctionPort(
+    const std::shared_ptr<Function>& function_,
+    uint32_t port_)
+    : function(function_), port(port_) {}
+
+FunctionPort::~FunctionPort() = default;
+
+bool FunctionPort::operator==(const FunctionPort& other) const noexcept {
+  return this->function == other.function && this->port == other.port;
+}
+
+bool FunctionPort::operator!=(const FunctionPort& other) const noexcept {
+  return !(*this == other);
+}
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/autograd/function_port.h
+++ b/torch/csrc/autograd/function_port.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace torch {
+namespace autograd {
+
+class Function;
+class Variable;
+
+/// Represents an input or "port" of a function.
+struct FunctionPort {
+  explicit FunctionPort(
+      const std::shared_ptr<Function>& function_ = nullptr,
+      uint32_t port_ = 0);
+
+  /// Constructs a `FunctionPort` for the gradient function of a variable.
+  static FunctionPort for_gradient(const Variable& variable);
+
+  // See https://stackoverflow.com/questions/13414652/forward-declaration-with-unique-ptr
+  // for why this destructor is needed.
+  ~FunctionPort();
+
+  // Required for use in associative containers.
+  bool operator==(const FunctionPort& other) const noexcept;
+  bool operator!=(const FunctionPort& other) const noexcept;
+
+  /// The function this `FunctionPort` points to.
+  std::shared_ptr<Function> function;
+
+  /// The identifier of a particular input to the function.
+  uint32_t port;
+};
+} // namespace autograd
+} // namespace torch
+
+// The idiomatic way of enabling use of a custom type as the key of hash
+// containers in C++11. This method removes the requirement of having to pass
+// a custom hasher to std::unordered_{map, set}.
+// See http://en.cppreference.com/w/cpp/utility/hash for more information.
+namespace std {
+template <>
+struct hash<torch::autograd::FunctionPort> {
+  // These type aliases are required by the standard.
+  using argument_type = torch::autograd::FunctionPort;
+  using return_type = size_t;
+
+  return_type operator()(const argument_type& function_port) const noexcept {
+    const auto first = hash_value(function_port.function);
+    const auto second = hash_value(function_port.port);
+    // See http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html.
+    return first ^ (second + 0x9e3779b9 + (first << 6) + (first >> 2));
+  }
+
+  // Helper function to call std::hash on a value of some type.
+  template <typename T>
+  return_type hash_value(const T& value) const noexcept {
+    return hash<T>{}(value);
+  }
+};
+} // namespace std

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -1,8 +1,12 @@
 #include "basic_ops.h"
 
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
+
+#include <memory>
+#include <utility>
 
 namespace torch { namespace autograd {
 
@@ -17,8 +21,8 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
     // FIXME: share version counters
     outputs.emplace_back(var.defined() ? var.data() : Tensor());
   }
-  return wrap_outputs(inputs, std::move(outputs), [&](FunctionFlags f) {
-    return std::make_shared<Error>(msg, std::move(f));
+  return wrap_outputs(inputs, std::move(outputs), [&](function_list&& next_functions) {
+    return std::make_shared<Error>(msg, std::move(next_functions));
   });
 };
 

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -11,8 +11,8 @@
 namespace torch { namespace autograd {
 
 struct Error : public Function {
-  Error(std::string msg, FunctionFlags&& flags)
-    : Function(std::move(flags))
+  Error(std::string msg, function_list&& next_functions)
+    : Function(std::move(next_functions))
     , msg(std::move(msg)) {}
 
   Error(std::string msg)
@@ -35,9 +35,8 @@ struct DelayedError : public Function {
 
 struct GraphRoot : public Function {
   GraphRoot(function_list functions, variable_list inputs)
-    : outputs(std::move(inputs)) {
-      next_functions = std::move(functions);
-    };
+    : Function(std::move(functions)), outputs(std::move(inputs)) {
+    }
 
   virtual variable_list apply(const variable_list& inputs) {
     return outputs;

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -2,6 +2,14 @@
 
 #include "torch/csrc/assertions.h"
 #include "torch/csrc/autograd/python_engine.h"
+#include "torch/csrc/autograd/function_port.h"
+#include "torch/csrc/autograd/function.h"
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace torch { namespace autograd {
 
@@ -56,11 +64,11 @@ auto Eval::getSubgraph(const variable_list& inputs, const variable_list& outputs
   }
 
   // This is used to stop the search in situation 2 and find the corresponding placeholders.
-  std::unordered_map<edge_type, std::shared_ptr<EvalOutput>, edge_hasher> inherited_edges;
+  std::unordered_map<FunctionPort, std::shared_ptr<EvalOutput>> inherited_edges;
   inherited_edges.reserve(inherited_placeholders.size());
   for (auto & placeholder : inherited_placeholders) {
-    input_edges.emplace(placeholder->next_edge);
-    inherited_edges.emplace(placeholder->next_edge, placeholder);
+    input_edges.emplace(placeholder->next_port);
+    inherited_edges.emplace(placeholder->next_port, placeholder);
   }
 
   // Regular DFS data structures
@@ -80,7 +88,7 @@ auto Eval::getSubgraph(const variable_list& inputs, const variable_list& outputs
     int num_edges = fn->next_functions.size();
     for (int i = 0; i < num_edges; ++i) {
       auto & edge = fn->next_functions[i];
-      auto & next_fn = edge.first;
+      auto & next_fn = edge.function;
       if (!next_fn) continue; // See Note [Null-edge pruning]
       // Edge belongs to subgraph boundary. Register that and don't search along it.
       if (input_edges.count(edge) > 0) {
@@ -97,7 +105,7 @@ auto Eval::getSubgraph(const variable_list& inputs, const variable_list& outputs
       // Situation 1. If we end up in a placeholder, we need to inherit it.
       if (auto placeholder = std::dynamic_pointer_cast<EvalOutput>(next_fn)) {
         extra_placeholders.emplace(placeholder);
-        subgraph.boundary.ends.emplace(placeholder->next_edge);
+        subgraph.boundary.ends.emplace(placeholder->next_port);
         continue;
       }
       bool unseen = seen.emplace(next_fn.get()).second;
@@ -143,9 +151,10 @@ bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outpu
     // attempt the optimization in this case.  To fix it properly,
     // we'd need to filter grad_next_fns and outputs of apply in Eval::apply.
     // The check below tests if null edge pruning occurred.
-    if (!inputs[i].defined() || !grad_next_fns[i].first) return false;
+    if (!inputs[i].defined() || !grad_next_fns[i].function) return false;
     const auto& input_grad = inputs[i].grad_fn() ? inputs[i].grad_fn() : inputs[i].grad_accumulator();
-    if (grad_next_fns[i].first != input_grad || grad_next_fns[i].second != inputs[i].output_nr()) return false;
+    if (grad_next_fns[i].function != input_grad) return false;
+    if (grad_next_fns[i].port != static_cast<uint32_t>(inputs[i].output_nr())) return false;
   }
 
   // Success! We still need to set up placeholders for next stages and to drop
@@ -178,7 +187,7 @@ variable_list Eval::filterRelevantOutputs(const variable_list& inputs, const var
   for (auto& output : outputs) {
     if (!output.defined()) continue;
     if (!output.grad_fn()) continue;
-    if (ignored_grad_fns.count(std::make_pair(output.grad_fn(), output.output_nr())) > 0) continue;
+    if (ignored_grad_fns.count(FunctionPort(output.grad_fn(), output.output_nr())) > 0) continue;
     relevant_outputs.emplace_back(output);
   }
   return relevant_outputs;
@@ -189,13 +198,11 @@ auto Eval::computeInputOrder(const variable_list& inputs, const placeholder_list
   int idx = 0;
   for (auto & input : inputs) {
     if (!input.defined()) continue;
-    input_order.emplace(
-      std::make_pair(input.grad_fn() ? input.grad_fn() : input.grad_accumulator(), input.output_nr()),
-      idx++
-    );
+    auto fn = input.grad_fn() ? input.grad_fn() : input.grad_accumulator();
+    input_order.emplace(FunctionPort(fn, input.output_nr()), idx++);
   }
   for (auto & placeholder : inherited_placeholders)
-    input_order.emplace(placeholder->next_edge, idx++);
+    input_order.emplace(placeholder->next_port, idx++);
   return input_order;
 }
 
@@ -218,9 +225,9 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     auto subgraph = getSubgraph(inputs, relevant_outputs, inherited_placeholders);
 
     // Prepare output placeholder nodes for each end.
-    std::unordered_map<edge_type, std::shared_ptr<EvalOutput>, edge_hasher> ends_to_outputs;
+    std::unordered_map<FunctionPort, std::shared_ptr<EvalOutput>> ends_to_outputs;
     for (auto & placeholder : placeholders) {
-      ends_to_outputs[placeholder->next_edge] = placeholder;
+      ends_to_outputs[placeholder->next_port] = placeholder;
     }
     for (auto & end : subgraph.boundary.ends) {
       if (ends_to_outputs.count(end) == 0) {
@@ -231,10 +238,9 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
 
     // Replace begins with pointers to output nodes.
     // This detaches the subgraph from the full backward graph.
-    for (auto & begin : subgraph.boundary.begins) {
-      auto & fn = begin.first;
-      auto offset = begin.second;
-      fn->next_functions[offset] = std::make_pair(ends_to_outputs.at(fn->next_functions[offset]), 0);
+    for (auto& begin : subgraph.boundary.begins) {
+      begin.function->next_functions[begin.port] = FunctionPort(
+          ends_to_outputs.at(begin.function->next_functions[begin.port]));
     }
 
     // Replace subgraph with this node.
@@ -242,11 +248,11 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
 
     // Ensure placeholders and inputs are sorted in the same way.
     edge_order input_order = computeInputOrder(inputs, inherited_placeholders);
-    std::sort(next_functions.begin(), next_functions.end(), [&input_order](const edge_type &a, const edge_type &b) {
+    std::sort(next_functions.begin(), next_functions.end(), [&input_order](const FunctionPort &a, const FunctionPort &b) {
       return input_order.at(a) < input_order.at(b);
     });
     std::sort(placeholders.begin(), placeholders.end(), [&input_order](const std::shared_ptr<EvalOutput> &a, const std::shared_ptr<EvalOutput> &b) {
-      return input_order.at(a->next_edge) < input_order.at(b->next_edge);
+      return input_order.at(a->next_port) < input_order.at(b->next_port);
     });
   }
 
@@ -289,10 +295,9 @@ variable_list Eval::apply(const variable_list& inputs) {
   } else {
     auto& engine = python::PythonEngine::getDefaultEngine();
     auto exec_data = filterRoots(inputs);
-    function_list output_edges = fmap(placeholders,
-                                      [](const std::shared_ptr<EvalOutput>& o) -> edge_type {
-                                        return std::make_pair(o, 0);
-                                      });
+    auto output_edges = fmap(
+        placeholders,
+        [](const std::shared_ptr<EvalOutput>& o) { return FunctionPort(o); });
     outputs = engine.execute(exec_data.first, exec_data.second, true, true, output_edges);
   }
 

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -12,8 +12,8 @@
 namespace torch { namespace autograd {
 
 struct EvalOutput : Function {
-  EvalOutput(const edge_type& next_edge)
-    : next_edge(next_edge) {
+  explicit EvalOutput(const FunctionPort& next_port_)
+    : next_port(next_port_) {
     num_inputs = 1;
   }
 
@@ -21,12 +21,12 @@ struct EvalOutput : Function {
     throw std::logic_error("EvalOutput::apply() called");
   }
 
-  edge_type next_edge;
+  FunctionPort next_port;
 };
 
 struct Eval : Function {
-  using edge_set = std::unordered_set<edge_type, edge_hasher>;
-  using edge_order = std::unordered_map<edge_type, int, edge_hasher>;
+  using edge_set = std::unordered_set<FunctionPort>;
+  using edge_order = std::unordered_map<FunctionPort, int>;
   using placeholder_list = std::vector<std::shared_ptr<EvalOutput>>;
 
   // This struct has only one member, but it's useful to e.g. add a set of all

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -35,10 +35,11 @@ CopySlices::CopySlices(const Variable& base_var, at::TensorGeometry view_, std::
 
   // Take the next_functions of fn as our own, except for index 0 which goes
   // to base instead of the view.
-  next_functions.resize(fn->next_functions.size());
-  next_functions[0] = std::make_pair(base_var.grad_fn(), base_var.output_nr());
-  for (size_t i = 1; i < next_functions.size(); i++) {
-    next_functions[i] = fn->next_functions[i];
+  const auto num_connections = fn->next_functions.size();
+  next_functions.reserve(num_connections);
+  next_functions.emplace_back(base_var.grad_fn(), base_var.output_nr());
+  for (size_t i = 1; i < num_connections; i++) {
+    next_functions.push_back(fn->next_functions[i]);
   }
 }
 

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,19 +1,17 @@
 #include "torch/csrc/autograd/functions/utils.h"
-#include "torch/csrc/utils/functional.h"
-#include "torch/csrc/jit/tracer.h"
-
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
 #include <sstream>
+#include <vector>
 
 namespace torch { namespace autograd {
 
 variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
                            function_constructor ctr) {
-  auto flags = Function::flags(inputs);
   variable_list result;
   result.reserve(outputs.size());
-  if (!flags.is_executable) {
+  if (!any_variable_requires_grad(inputs)) {
     for (auto& output : outputs) {
       if (output.defined()) {
         result.emplace_back(make_variable(output, false));
@@ -22,7 +20,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
       }
     }
   } else {
-    auto grad_fn = ctr(std::move(flags));
+    auto grad_fn = ctr(get_next_functions(inputs));
     for (auto& output : outputs) {
       if (output.defined()) {
         result.emplace_back(make_variable(output, grad_fn));
@@ -53,5 +51,4 @@ void check_input_variables(const char* name, const variable_list& inputs, int ar
     }
   }
 }
-
 }}

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -3,14 +3,13 @@
 #include <Python.h>
 #include <functional>
 #include <memory>
-#include <array>
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
 namespace torch { namespace autograd {
 
-using function_constructor = std::function<std::shared_ptr<Function>(FunctionFlags)>;
+using function_constructor = std::function<std::shared_ptr<Function>(function_list&&)>;
 
 /**
  * Wraps the tensor outputs in variables and creates the grad_fn and sets the
@@ -24,5 +23,4 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
  * items are not NULL. If not specified, `required_args` defaults to `args`.
  */
 void check_input_variables(const char* name, const variable_list& inputs, int args, int required_args=-1);
-
 }}

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -105,10 +105,10 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
     auto& c_tuple = next_functions[i];
     THPObjectPtr tuple(PyTuple_New(2));
     if (!tuple) return NULL;
-    PyObject *py_fn = functionToPyObject(c_tuple.first);
+    PyObject *py_fn = functionToPyObject(c_tuple.function);
     if (!py_fn) return NULL;
     PyTuple_SET_ITEM(tuple.get(), 0, py_fn);
-    PyObject *py_idx = PyLong_FromLong(c_tuple.second);
+    PyObject *py_idx = PyLong_FromLong(c_tuple.port);
     if (!py_idx) return NULL;
     PyTuple_SET_ITEM(tuple.get(), 1, py_idx);
     PyTuple_SET_ITEM(py_functions.get(), i, tuple.release());

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Python.h>
+
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/engine.h"
 
 bool THPEngine_initModule(PyObject *module);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -94,9 +94,13 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   // leads to unexpected error messages ("no nodes require computing gradients"),
   // but I don't have a better idea. These functions would raise an error
   // in backward anyway.
-  return wrap_outputs(inputs, std::move(tensor_results), [this](FunctionFlags &&f) {
-    return std::make_shared<Error>(name() + " is not differentiable twice", std::move(f));
-  });
+  return wrap_outputs(
+      inputs,
+      std::move(tensor_results),
+      [this](function_list&& next_functions) {
+        return std::make_shared<Error>(
+            name() + " is not differentiable twice", std::move(next_functions));
+      });
 }
 
 // NOTE: this function is written in a way that assumes it's only called for backward;
@@ -566,7 +570,8 @@ struct UnpackedInput {
 };
 
 struct InputFlags {
-  FunctionFlags flags;
+  bool is_executable = false;
+  function_list next_functions;
   THPObjectPtr needs_input_grad;
   std::vector<bool> is_variable_input;
 };
@@ -606,7 +611,8 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
     PyTuple_SET_ITEM(unpacked.tensor_input.get(), i, new_arg);
   }
 
-  flags.flags = Function::flags(unpacked.input_vars);
+  flags.is_executable = any_variable_requires_grad(unpacked.input_vars);
+  flags.next_functions = get_next_functions(unpacked.input_vars);
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 
@@ -779,8 +785,8 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
   auto info_pair = unpack_input<true>(_inputs);
   auto& unpacked_input = info_pair.first;
   auto& input_info = info_pair.second;
-  bool is_executable = input_info.flags.is_executable;
-  self->cdata.set_flags(std::move(input_info.flags));
+  bool is_executable = input_info.is_executable;
+  self->cdata.set_next_functions(std::move(input_info.next_functions));
   self->needs_input_grad = input_info.needs_input_grad.release();
 
   // Now we're ready to call a forward (implemented in Python)
@@ -811,8 +817,8 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   InputFlags& input_info = info_pair.second;
 
   // Initialize backward function (and ctx)
-  bool is_executable = input_info.flags.is_executable;
-  ctx->cdata.set_flags(std::move(input_info.flags));
+  bool is_executable = input_info.is_executable;
+  ctx->cdata.set_next_functions(std::move(input_info.next_functions));
   ctx->needs_input_grad = input_info.needs_input_grad.release();
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -883,7 +883,7 @@ static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_g
 static void _trim_grad_input(THPFunction *self, THPObjectPtr& grad_input)
 {
   int num_grads = PyTuple_GET_SIZE(grad_input.get());
-  int num_next_fns = self->cdata.next_functions.size();
+  const int num_next_fns = self->cdata.next_functions.size();
   if (num_grads > num_next_fns) {
     // Check that all extra grads are none
     bool all_none = true;
@@ -1024,10 +1024,10 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
   for (int i = 0; i < size; i++) {
     THPObjectPtr fn_tuple(PyTuple_New(2));
     if (!fn_tuple) return NULL;
-    PyObject* fn = functionToPyObject(next_fns[i].first);
+    PyObject* fn = functionToPyObject(next_fns[i].function);
     if (!fn) return NULL;
     PyTuple_SET_ITEM(fn_tuple.get(), 0, fn);
-    PyTuple_SET_ITEM(fn_tuple.get(), 1, THPUtils_packInt64(next_fns[i].second));
+    PyTuple_SET_ITEM(fn_tuple.get(), 1, THPUtils_packInt64(next_fns[i].port));
     PyTuple_SET_ITEM(result.get(), i, fn_tuple.release());
   }
   return result.release();

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<Function>& VariableViewImpl::get_grad_fn() {
     fn->size = sizes();
     fn->stride = strides();
     fn->storage_offset = data.storage_offset();
-    fn->set_flags(Function::flags(base));
+    fn->set_next_functions(get_next_functions(base));
     fn->num_inputs = 1;
     _grad_fn = std::move(fn);
     attr_version = current_version;

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -1,5 +1,12 @@
 #include "Python.h"
-#include "interpreter_autograd_function.h"
+
+#include "torch/csrc/autograd/function_port.h"
+#include "torch/csrc/jit/interpreter_autograd_function.h"
+
+#include <algorithm>
+#include <memory>
+#include <tuple>
+#include <vector>
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/interpreter_autograd_function.h
+++ b/torch/csrc/jit/interpreter_autograd_function.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/function_port.h"
+#include "torch/csrc/autograd/functions/basic_ops.h"
+#include "torch/csrc/autograd/functions/utils.h"
+#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/tracer_state.h"
-#include "torch/csrc/autograd/function.h"
-#include "torch/csrc/autograd/variable.h"
-#include "torch/csrc/autograd/functions/utils.h"
-#include "torch/csrc/autograd/functions/basic_ops.h"
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -484,8 +484,8 @@ std::shared_ptr<Graph> trace(const ADTestSpec& test, const variable_list& vars_i
 }
 
 variable_list grad(const variable_list& outputs, const variable_list& inputs, const variable_list& grad_outputs) {
-  static const auto get_edge = [](const Variable& v) -> edge_type {
-    return std::make_pair(v.grad_fn() ? v.grad_fn() : v.grad_accumulator(), v.output_nr());
+  static const auto get_edge = [](const Variable& v) {
+    return FunctionPort(v.grad_fn() ? v.grad_fn() : v.grad_accumulator(), v.output_nr());
   };
   auto & engine = torch::autograd::python::PythonEngine::getDefaultEngine();
   return engine.execute(fmap(outputs, get_edge), grad_outputs, true, false, fmap(inputs, get_edge));

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -104,8 +104,8 @@ struct TraceEval : autograd::Eval {
 
     detail::_exit(tracing_state, outputs);
     auto stage = tracing_state->graph->stage();
-    tracing_state->output_edges[stage] = fmap(placeholders, [](const std::shared_ptr<autograd::EvalOutput> p) {
-      return p->next_edge;
+    tracing_state->output_edges[stage] = fmap(placeholders, [](const std::shared_ptr<autograd::EvalOutput>& p) {
+      return p->next_port;
     });
   }
 

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -2,6 +2,7 @@
 
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/assertions.h"
+#include "torch/csrc/autograd/function_port.h"
 
 #include <memory>
 #include <mutex>
@@ -21,7 +22,6 @@ namespace torch { namespace jit { namespace tracer {
 using torch::autograd::Variable;
 using torch::autograd::Function;
 using variable_list = std::vector<Variable>;
-using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 
 // TracingState tracks the necessary state when we are tracing the execution of
 // autograd code; most importantly, it holds a reference to the actual IR
@@ -60,7 +60,7 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   std::unordered_map<void*, Value*> buffer_map;
   // A pair of (input_flags, output_flags) for each stage
   io_variable_flags_list var_flags;
-  std::vector<function_list> output_edges;
+  std::vector<std::vector<autograd::FunctionPort>> output_edges;
 
   std::mutex mutex;
   variable_list inputs; // Used only for the duration of first stage


### PR DESCRIPTION
This PR is another step in the direction of improving the interface of internal autograd datastructures. It makes a small change by replacing what we previously called `edge_type` with a new struct called `FunctionPort`, since an `edge_type` really represents a particular input (or *port*) to a particular function.

Further PRs will involve changes such as renaming `function_list` and improving the interface of the `Function` class.

Note: This PR builds on https://github.com/pytorch/pytorch/pull/5018/, so please merge it first to make reviewing easier.

@zdevito @apaszke 