### PR TITLE
Replace edge_type with Edge and create Variable::gradient_edge()

### DIFF
--- a/torch/csrc/autograd/edge.h
+++ b/torch/csrc/autograd/edge.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "torch/csrc/utils/hash.h"
+
+namespace torch {
+namespace autograd {
+
+struct Function;
+
+/// Represents a particular input of a function.
+struct Edge {
+  Edge() noexcept : function(nullptr), input_nr(0) {}
+
+  Edge(const std::shared_ptr<Function>& function_, uint32_t input_nr_) noexcept
+      : function(function_), input_nr(input_nr_) {}
+
+  /// Convenience method to test if an edge is valid.
+  bool is_valid() const noexcept {
+    return function != nullptr;
+  }
+
+  // Required for use in associative containers.
+  bool operator==(const Edge& other) const noexcept {
+    return this->function == other.function && this->input_nr == other.input_nr;
+  }
+
+  bool operator!=(const Edge& other) const noexcept {
+    return !(*this == other);
+  }
+
+  /// The function this `Edge` points to.
+  std::shared_ptr<Function> function;
+
+  /// The identifier of a particular input to the function.
+  uint32_t input_nr;
+};
+} // namespace autograd
+} // namespace torch
+
+// The idiomatic way of enabling use of a custom type as the key of hash
+// containers in C++11. This method removes the requirement of having to pass
+// a custom hasher to std::unordered_{map, set}.
+// See http://en.cppreference.com/w/cpp/utility/hash for more information.
+namespace std {
+template <>
+struct hash<torch::autograd::Edge> {
+  // These type aliases are required by the standard.
+  using argument_type = torch::autograd::Edge;
+  using return_type = size_t;
+  return_type operator()(const argument_type& edge) const noexcept {
+    return torch::get_hash(edge.function, edge.input_nr);
+  }
+};
+} // namespace std

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -12,8 +12,8 @@
 namespace torch { namespace autograd {
 
 struct EvalOutput : Function {
-  EvalOutput(const edge_type& next_edge)
-    : next_edge(next_edge) {
+  explicit EvalOutput(const Edge& next_edge_)
+    : next_edge(next_edge_) {
     num_inputs = 1;
   }
 
@@ -21,12 +21,12 @@ struct EvalOutput : Function {
     throw std::logic_error("EvalOutput::apply() called");
   }
 
-  edge_type next_edge;
+  Edge next_edge;
 };
 
 struct Eval : Function {
-  using edge_set = std::unordered_set<edge_type, edge_hasher>;
-  using edge_order = std::unordered_map<edge_type, int, edge_hasher>;
+  using edge_set = std::unordered_set<Edge>;
+  using edge_order = std::unordered_map<Edge, int>;
   using placeholder_list = std::vector<std::shared_ptr<EvalOutput>>;
 
   // This struct has only one member, but it's useful to e.g. add a set of all

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -35,10 +35,11 @@ CopySlices::CopySlices(const Variable& base_var, at::TensorGeometry view_, std::
 
   // Take the next_functions of fn as our own, except for index 0 which goes
   // to base instead of the view.
-  next_functions.resize(fn->next_functions.size());
-  next_functions[0] = std::make_pair(base_var.grad_fn(), base_var.output_nr());
-  for (size_t i = 1; i < next_functions.size(); i++) {
-    next_functions[i] = fn->next_functions[i];
+  const auto num_connections = fn->next_functions.size();
+  next_functions.reserve(num_connections);
+  next_functions.push_back(base_var.gradient_edge());
+  for (size_t i = 1; i < num_connections; i++) {
+    next_functions.push_back(fn->next_functions[i]);
   }
 }
 

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -105,10 +105,10 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
     auto& c_tuple = next_functions[i];
     THPObjectPtr tuple(PyTuple_New(2));
     if (!tuple) return NULL;
-    PyObject *py_fn = functionToPyObject(c_tuple.first);
+    PyObject *py_fn = functionToPyObject(c_tuple.function);
     if (!py_fn) return NULL;
     PyTuple_SET_ITEM(tuple.get(), 0, py_fn);
-    PyObject *py_idx = PyLong_FromLong(c_tuple.second);
+    PyObject *py_idx = PyLong_FromLong(c_tuple.input_nr);
     if (!py_idx) return NULL;
     PyTuple_SET_ITEM(tuple.get(), 1, py_idx);
     PyTuple_SET_ITEM(py_functions.get(), i, tuple.release());

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Python.h>
+
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/engine.h"
 
 bool THPEngine_initModule(PyObject *module);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -781,7 +781,7 @@ static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_g
 static void _trim_grad_input(THPFunction *self, THPObjectPtr& grad_input)
 {
   int num_grads = PyTuple_GET_SIZE(grad_input.get());
-  int num_next_fns = self->cdata.next_functions.size();
+  const int num_next_fns = self->cdata.next_functions.size();
   if (num_grads > num_next_fns) {
     // Check that all extra grads are none
     bool all_none = true;
@@ -922,10 +922,10 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
   for (int i = 0; i < size; i++) {
     THPObjectPtr fn_tuple(PyTuple_New(2));
     if (!fn_tuple) return NULL;
-    PyObject* fn = functionToPyObject(next_fns[i].first);
+    PyObject* fn = functionToPyObject(next_fns[i].function);
     if (!fn) return NULL;
     PyTuple_SET_ITEM(fn_tuple.get(), 0, fn);
-    PyTuple_SET_ITEM(fn_tuple.get(), 1, THPUtils_packInt64(next_fns[i].second));
+    PyTuple_SET_ITEM(fn_tuple.get(), 1, THPUtils_packInt64(next_fns[i].input_nr));
     PyTuple_SET_ITEM(result.get(), i, fn_tuple.release());
   }
   return result.release();

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -7,6 +7,8 @@
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
 #include "torch/csrc/autograd/functions/tensor.h"
 
+#include <memory>
+
 using namespace at;
 
 namespace torch { namespace autograd {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -15,13 +15,13 @@
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
 #include "torch/csrc/autograd/variable_version.h"
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/Types.h"
 
 namespace torch { namespace autograd {
 
 using at::Tensor;
 struct VariableImpl;
-
 
 struct Variable : public at::Tensor {
   inline Variable(VariableImpl * self, bool retain);
@@ -33,6 +33,20 @@ struct Variable : public at::Tensor {
   // Tensors which you know are actually Variables.
   /*implicit*/ Variable(Tensor const & rhs) : Tensor(rhs) {}
   /*implicit*/ Variable(Tensor && rhs) noexcept : Tensor(std::move(rhs)) {}
+
+  Edge gradient_edge() const {
+    // If grad_fn is null (as is the case for a leaf node), we instead
+    // interpret the gradient function to be a grad accumulator,
+    // which will accumulate its inputs into the grad property of the
+    // variable. These nodes get suppressed in some situations,
+    // see "suppress grad accumulation" below. Note that only variables which
+    // have `requires_grad = True` can have grad accumulators.
+    if (const auto& gradient = grad_fn()) {
+      return Edge(gradient, output_nr());
+    } else {
+      return Edge(grad_accumulator(), 0);
+    }
+  }
 
   inline VariableImpl* get() const;
 

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -69,7 +69,7 @@ struct Gradient {
   //         outputs[offset].set_grad_fn(grad_fn, output_nr=i)
   //   - Use df_output_vjps to connect next_functions of grad_fn:
   //       for idx in df_output_vjps:
-  //         grad_fn.next_functions.push_back(inputs[idx].grad_fn(), inputs[idx].output_nr)
+  //         grad_fn.next_functions.push_back(inputs[idx].gradient_edge())
   //   - Save captures for df (care needs to be taken to use SavedVariables for inputs and
   //                           outputs that we will actually return)
   //   - Return outputs[:f_real_outputs]

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -116,7 +116,8 @@ private:
       // Why do I have to care here whether v has a grad_fn or grad accumulator?
       // Why do I have to care here about output_nr? I just want to say
       // grad_fn->setOutputTo(i, v.input_port());
-      grad_fn->next_functions.emplace_back(v.grad_fn() ? v.grad_fn() : v.grad_accumulator(), v.output_nr());
+      // TODO(psag): remove above rant once Function API is improved.
+      grad_fn->next_functions.push_back(v.gradient_edge());
     }
     captureInputs(*grad_fn, inputs);
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -72,7 +72,7 @@ struct HandleBuilder {
   }
   at::Retainable* addOutput(const autograd::Variable & output) {
     if(handle) {
-      handle->forward_outputs.emplace_back(output.grad_fn(),output.output_nr());
+      handle->forward_outputs.push_back(output.gradient_edge());
     }
     at::Tensor tensor = output.data();
     return toRetainableShare(output.data());

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -1,5 +1,12 @@
 #include "Python.h"
-#include "interpreter_autograd_function.h"
+
+#include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/jit/interpreter_autograd_function.h"
+
+#include <algorithm>
+#include <memory>
+#include <tuple>
+#include <vector>
 
 namespace torch { namespace jit {
 
@@ -115,9 +122,7 @@ autograd::variable_list InterpreterAutogradFunction::apply(
         grad_fn->next_functions.emplace_back();
         continue;
       }
-      grad_fn->next_functions.emplace_back(
-        input.grad_fn() ? input.grad_fn() : input.grad_accumulator(),
-        input.output_nr());
+      grad_fn->next_functions.push_back(input.gradient_edge());
     }
   };
 

--- a/torch/csrc/jit/interpreter_autograd_function.h
+++ b/torch/csrc/jit/interpreter_autograd_function.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/autograd/functions/basic_ops.h"
+#include "torch/csrc/autograd/functions/utils.h"
+#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/tracer_state.h"
-#include "torch/csrc/autograd/function.h"
-#include "torch/csrc/autograd/variable.h"
-#include "torch/csrc/autograd/functions/utils.h"
-#include "torch/csrc/autograd/functions/basic_ops.h"
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -487,9 +487,7 @@ std::shared_ptr<Graph> trace(const ADTestSpec& test, const variable_list& vars_i
 }
 
 variable_list grad(const variable_list& outputs, const variable_list& inputs, const variable_list& grad_outputs) {
-  static const auto get_edge = [](const Variable& v) -> edge_type {
-    return std::make_pair(v.grad_fn() ? v.grad_fn() : v.grad_accumulator(), v.output_nr());
-  };
+  static const auto get_edge = [](const Variable& v) { return v.gradient_edge(); };
   auto & engine = torch::autograd::python::PythonEngine::getDefaultEngine();
   return engine.execute(fmap(outputs, get_edge), grad_outputs, true, false, fmap(inputs, get_edge));
 }

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -104,7 +104,7 @@ struct TraceEval : autograd::Eval {
 
     detail::_exit(tracing_state, outputs);
     auto stage = tracing_state->graph->stage();
-    tracing_state->output_edges[stage] = fmap(placeholders, [](const std::shared_ptr<autograd::EvalOutput> p) {
+    tracing_state->output_edges[stage] = fmap(placeholders, [](const std::shared_ptr<autograd::EvalOutput>& p) {
       return p->next_edge;
     });
   }

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -2,6 +2,7 @@
 
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/assertions.h"
+#include "torch/csrc/autograd/edge.h"
 
 #include <memory>
 #include <mutex>
@@ -20,8 +21,8 @@ namespace torch { namespace jit { namespace tracer {
 
 using torch::autograd::Variable;
 using torch::autograd::Function;
+using edge_list = std::vector<autograd::Edge>;
 using variable_list = std::vector<Variable>;
-using function_list = std::vector<std::pair<std::shared_ptr<Function>, int>>;
 
 // TracingState tracks the necessary state when we are tracing the execution of
 // autograd code; most importantly, it holds a reference to the actual IR
@@ -60,7 +61,7 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   std::unordered_map<void*, Value*> buffer_map;
   // A pair of (input_flags, output_flags) for each stage
   io_variable_flags_list var_flags;
-  std::vector<function_list> output_edges;
+  std::vector<edge_list> output_edges;
 
   std::mutex mutex;
   variable_list inputs; // Used only for the duration of first stage


### PR DESCRIPTION
Building on https://github.com/pytorch/pytorch/pull/5029, this PR moves `FunctionPort::for_gradient` into the `Variable` class directly. This makes it possible to call `variable.gradient_port()` instead of `(variable.grad_fn() ? variable.grad_fn() : variable.grad_accumulator(), variable.output_nr())`. This is a happy change.

@zdevito @apaszke 