### PR TITLE
Replace more sample_n calls in test_distributions.py

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -309,7 +309,7 @@ class TestDistributions(TestCase):
     def _check_sampler_sampler(self, torch_dist, ref_dist, message, multivariate=False,
                                num_samples=10000, failure_rate=1e-3):
         # Checks that the .sample() method matches a reference function.
-        torch_samples = torch_dist.sample_n(num_samples).squeeze()
+        torch_samples = torch_dist.sample((num_samples,)).squeeze()
         if isinstance(torch_samples, Variable):
             torch_samples = torch_samples.data
         torch_samples = torch_samples.cpu().numpy()
@@ -340,7 +340,7 @@ class TestDistributions(TestCase):
     def _check_sampler_discrete(self, torch_dist, ref_dist, message,
                                 num_samples=10000, failure_rate=1e-3):
         """Runs a Chi2-test for the support, but ignores tail instead of combining"""
-        torch_samples = torch_dist.sample_n(num_samples).squeeze()
+        torch_samples = torch_dist.sample((num_samples,)).squeeze()
         if isinstance(torch_samples, Variable):
             torch_samples = torch_samples.data
         torch_samples = torch_samples.cpu().numpy()


### PR DESCRIPTION
Two more occurences of `sample_n` popped up that should be replaced with `sample`.

@SsnL 