### PR TITLE
Pixelshuffle for volumetric convolutions

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1550,6 +1550,35 @@ def pixel_shuffle(input, upscale_factor):
     return shuffle_out.view(batch_size, channels, out_height, out_width)
 
 
+def pixel_shuffle_3d(input, upscale_factor):
+    r"""Rearranges elements in a tensor of shape ``[*, C*r^3, H, W, D]`` to a
+    tensor of shape ``[C, H*r, W*r, D*r]``.
+    See :class:`~torch.nn.PixelShuffle3D` for details.
+    Args:
+        input (Variable): Input
+        upscale_factor (int): factor to increase spatial resolution by
+    Examples::
+        >>> ps = nn.PixelShuffle3D(2)
+        >>> input = autograd.Variable(torch.Tensor(1, 8, 4, 4, 4))
+        >>> output = ps(input)
+        >>> print(output.size())
+        torch.Size([1, 1, 8, 8, 8])
+    """
+    batch_size, channels, in_height, in_width, in_depth = input.size()
+    channels //= upscale_factor ** 3
+
+    out_height = in_height * upscale_factor
+    out_width = in_width * upscale_factor
+    out_depth = in_depth * upscale_factor
+
+    input_view = input.contiguous().view(
+        batch_size, channels, upscale_factor, upscale_factor, upscale_factor,
+        in_height, in_width, in_depth)
+
+    shuffle_out = input_view.permute(0, 1, 5, 2, 6, 3, 7, 4).contiguous()
+    return shuffle_out.view(batch_size, channels, out_height, out_width, out_depth)
+
+
 def upsample(input, size=None, scale_factor=None, mode='nearest'):
     r"""Upsamples the input to either the given :attr:`size` or the given
     :attr:`scale_factor`

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -22,7 +22,7 @@ from .normalization import LocalResponseNorm, CrossMapLRN2d
 from .sparse import Embedding, EmbeddingBag
 from .rnn import RNNBase, RNN, LSTM, GRU, \
     RNNCell, LSTMCell, GRUCell
-from .pixelshuffle import PixelShuffle
+from .pixelshuffle import PixelShuffle, PixelShuffle3D
 from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d, Upsample
 from .distance import PairwiseDistance, CosineSimilarity
 from .fold import Fold, Unfold

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -41,3 +41,37 @@ class PixelShuffle(Module):
 
     def __repr__(self):
         return self.__class__.__name__ + '(upscale_factor=' + str(self.upscale_factor) + ')'
+
+
+class PixelShuffle3D(Module):
+    r"""Rearranges elements in a Tensor of shape :math:`(*, C * r^3, H, W, D]` to a
+    tensor of shape :math:`(C, H * r, W * r, D * r)`.
+    This is useful for implementing efficient sub-pixel convolution
+    with a stride of :math:`1/r`.
+    Look at the paper:
+    `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
+    by Shi et. al (2016) for more details
+    Args:
+        upscale_factor (int): factor to increase spatial resolution by
+    Shape:
+        - Input: :math:`(N, C * {upscale\_factor}^3, H, W, D)`
+        - Output: :math:`(N, C, H * {upscale\_factor}, W * {upscale\_factor}, D * * {upscale\_factor})`
+    Examples::
+        >>> ps = nn.PixelShuffle(2)
+        >>> input = autograd.Variable(torch.Tensor(1, 8, 4, 4, 4))
+        >>> output = ps(input)
+        >>> print(output.size())
+        torch.Size([1, 1, 8, 8, 8])
+    .. _Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network:
+        https://arxiv.org/abs/1609.05158
+    """
+
+    def __init__(self, upscale_factor):
+        super(PixelShuffle3D, self).__init__()
+        self.upscale_factor = upscale_factor
+
+    def forward(self, input):
+        return F.pixel_shuffle_3d(input, self.upscale_factor)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(upscale_factor=' + str(self.upscale_factor) + ')'


### PR DESCRIPTION
I work alot with volumetric datasets for GANs and always wanted to implement a 3D version of PixelShuffle. The code in this pull request is a derivation of the existing 2D pixel shuffle code.
I have tested this empirically on a volumetric GAN test case but it needs a proper test.