### PR TITLE
Fix maxpool3d / avgpool3d crashs

### DIFF
--- a/aten/src/THC/generic/THCTensor.c
+++ b/aten/src/THC/generic/THCTensor.c
@@ -280,6 +280,20 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   return self;
 }
 
+// Collapses the first two dimensions of a tensor
+THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
+  int in_dims = THCTensor_(nDimension)(state, input);
+  THArgCheck(in_dims >= 2, 1, "Tensor needs to have at least two dimensions");
+  THLongStorage *newSize = THLongStorage_newWithSize(in_dims - 1);
+  newSize->data[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
+  for (int i = 2; i < in_dims; i++) {
+    newSize->data[i - 1] = THCTensor_(size)(state, input, i);
+  }
+  THCTensor *output = THCTensor_(newView)(state, input, newSize);
+  THLongStorage_free(newSize);
+  return output;
+}
+
 /* Resize */
 void THCTensor_(resize)(THCState *state, THCTensor *self, THLongStorage *size, THLongStorage *stride)
 {

--- a/aten/src/THC/generic/THCTensor.c
+++ b/aten/src/THC/generic/THCTensor.c
@@ -280,10 +280,13 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage
   return self;
 }
 
-// Collapses the first two dimensions of a tensor
+// Collapses the first two dimensions of a tensor.
+// Assumes the input tensor is contiguous.
 THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
   int in_dims = THCTensor_(nDimension)(state, input);
   THArgCheck(in_dims >= 2, 1, "Tensor needs to have at least two dimensions");
+  THArgCheck(THCTensor_(isContiguous)(state, input), 1,
+             "Tensor must be contiguous");
   THLongStorage *newSize = THLongStorage_newWithSize(in_dims - 1);
   newSize->data[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
   for (int i = 2; i < in_dims; i++) {

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -67,6 +67,7 @@ THC_API THCTensor *THCTensor_(newNarrow)(THCState *state, THCTensor *tensor, int
 THC_API THCTensor *THCTensor_(newTranspose)(THCState *state, THCTensor *tensor, int dimension1_, int dimension2_);
 THC_API THCTensor *THCTensor_(newUnfold)(THCState *state, THCTensor *tensor, int dimension_, int64_t size_, int64_t step_);
 THC_API THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, THLongStorage *size);
+THC_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input);
 THC_API THCTensor *THCTensor_(newExpand)(THCState *state, THCTensor *tensor, THLongStorage *size);
 
 THC_API void THCTensor_(expand)(THCState *state, THCTensor *r, THCTensor *tensor, THLongStorage *sizes);

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -121,17 +121,17 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
 
   if (fiveDimensionalInput) {
     // Collapse batch and feature dimensions
-    input = THCTensor_(newFoldBatchDim)(state, input);
-
-    THCTensor *old_output = output;
     output = THCTensor_(newFoldBatchDim)(state, output);
-    THCTensor_(free)(state, old_output);
+
+    THCTensor *old_input = input;
+    input = THCTensor_(newFoldBatchDim)(state, input);
+    THCTensor_(free)(state, old_input);
     
     THCIndexTensor *old_indices = indices;
     indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
     THCIndexTensor_(free)(state, old_indices);
   } else {
-    THCTensor_(retain)(state, input);
+    THCTensor_(retain)(state, output);
   }
 
   THCDeviceTensor<real, 4> cudaInput;
@@ -232,21 +232,9 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   THCDeviceTensor<real, 4> cudaGradOutput;
   THCDeviceTensor<THCIndex_t, 4> cudaIndices;
 
-  if (THCTensor_(nDimension)(state, input) == 4)
-  {
-    cudaGradInput  = toDeviceTensor<real, 4>(state, gradInput);
-    cudaGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
-    cudaIndices = toDeviceTensor<THCIndex_t, 4>(state, indices);
-  }
-  else
-  {
-    cudaGradInput =
-      toDeviceTensor<real, 5>(state, gradInput).downcastOuter<4>();
-    cudaGradOutput =
-      toDeviceTensor<real, 5>(state, gradOutput).downcastOuter<4>();
-    cudaIndices =
-      toDeviceTensor<THCIndex_t, 5>(state, indices).downcastOuter<4>();
-  }
+  cudaGradInput  = toDeviceTensor<real, 4>(state, gradInput);
+  cudaGradOutput = toDeviceTensor<real, 4>(state, gradOutput);
+  cudaIndices = toDeviceTensor<THCIndex_t, 4>(state, indices);
 
   int totalZ = inputTime * inputSlices * batchSize;
   int offsetZ = 0;

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -83,6 +83,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
         dT, dW, dH, padT, padW, padH);
   THCUNN_assertSameGPU(state, 3, input, indices, output);
 
+  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
   if (THCTensor_(nDimension)(state, input) == 4)
   {
     /* sizes */
@@ -92,7 +93,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
     inputHeight = THCTensor_(size)(state, input, 2);
     inputWidth  = THCTensor_(size)(state, input, 3);
   }
-  else if (THCTensor_(nDimension)(state, input) == 5)
+  else if (fiveDimensionalInput)
   {
     /* sizes */
     batchSize   = THCTensor_(size)(state, input, 0);
@@ -102,7 +103,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
     inputWidth  = THCTensor_(size)(state, input, 4);
   }
 
-  if (input->nDimension == 4) /* 4D */
+  if (!fiveDimensionalInput) /* 4D */
   {
     /* resize output */
     THCTensor_(resize4d)(state, output, inputSlices,
@@ -118,23 +119,28 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   indices = THCIndexTensor_(newContiguous)(state, indices);
   THCTensor_(zero)(state, output);
 
-  // Collapse batch and feature dimensions
+  if (fiveDimensionalInput) {
+    // Collapse batch and feature dimensions
+    input = THCTensor_(newFoldBatchDim)(state, input);
+
+    THCTensor *old_output = output;
+    output = THCTensor_(newFoldBatchDim)(state, output);
+    THCTensor_(free)(state, old_output);
+    
+    THCIndexTensor *old_indices = indices;
+    indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
+    THCIndexTensor_(free)(state, old_indices);
+  } else {
+    THCTensor_(retain)(state, input);
+  }
+
   THCDeviceTensor<real, 4> cudaInput;
   THCDeviceTensor<real, 4> cudaOutput;
   THCDeviceTensor<THCIndex_t, 4> cudaIndices;
 
-  if (THCTensor_(nDimension)(state, input) == 4)
-  {
-    cudaInput  = toDeviceTensor<real, 4>(state, input);
-    cudaOutput = toDeviceTensor<real, 4>(state, output);
-    cudaIndices = toDeviceTensor<THCIndex_t, 4>(state, indices);
-  }
-  else
-  {
-    cudaInput  = toDeviceTensor<real, 5>(state, input).downcastOuter<4>();
-    cudaOutput = toDeviceTensor<real, 5>(state, output).downcastOuter<4>();
-    cudaIndices = toDeviceTensor<THCIndex_t, 5>(state, indices).downcastOuter<4>();
-  }
+  cudaInput  = toDeviceTensor<real, 4>(state, input);
+  cudaOutput = toDeviceTensor<real, 4>(state, output);
+  cudaIndices = toDeviceTensor<THCIndex_t, 4>(state, indices);
 
   int totalZ = inputTime * inputSlices * batchSize;
   int offsetZ = 0;
@@ -156,6 +162,7 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   }
 
   THCTensor_(free)(state, input);
+  THCTensor_(free)(state, output);
   THCIndexTensor_(free)(state, indices);
 }
 
@@ -182,7 +189,8 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
         dT, dW, dH, padT, padW, padH);
   THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
 
-  if (THCTensor_(nDimension)(state, input) == 4) /* 4D */
+  int fiveDimensionalInput = THCTensor_(nDimension)(state, input) == 5;
+  if (!fiveDimensionalInput) /* 4D */
   {
     batchSize = 1;
     inputSlices  = THCTensor_(size)(state, input, 0);
@@ -200,10 +208,24 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   }
 
   input = THCTensor_(newContiguous)(state, input);
-  indices = THCIndexTensor_(newContiguous)(state, indices);
-  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);
+  indices = THCIndexTensor_(newContiguous)(state, indices);
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
+
+  if (fiveDimensionalInput) {
+    gradInput = THCTensor_(newFoldBatchDim)(state, gradInput);
+
+    THCIndexTensor *old_indices = indices;
+    indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
+    THCIndexTensor_(free)(state, old_indices);
+  
+    THCTensor *old_gradOutput = gradOutput;
+    gradOutput = THCTensor_(newFoldBatchDim)(state, gradOutput);
+    THCTensor_(free)(state, old_gradOutput);
+  } else {
+    THCTensor_(retain)(state, gradInput);
+  }
 
   // Collapse batch and feature dimensions
   THCDeviceTensor<real, 4> cudaGradInput;
@@ -248,9 +270,10 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   }
 
   // cleanup
-  THCTensor_(free)(state, input);
   THCTensor_(free)(state, gradOutput);
+  THCTensor_(free)(state, gradInput);
   THCIndexTensor_(free)(state, indices);
+  THCTensor_(free)(state, input);
 }
 
 #endif


### PR DESCRIPTION
Fixes #4835. This PR picks up from #4848

There's a bug in `THCDeviceTensor::downcastOuter` where it sometimes doesn't recognize a contiguous tensor as being contiguous. This leads to crashes in `maxpool3d`, `avgpool3d`.

This PR removes usages of `THCDeviceTensor::downcastOuter` and replaces it with a call to `newFoldBatchDim`, which performs the same behavior of collapsing the batch and feature dims but uses `newView` internally.

cc @SsnL

### Test Plan
New unit tests for maxpool3d and avgpool3d crashes. Run `test_nn` to make sure maxpool3d, avgpool3d, and maxunpool3d still work.