### PR TITLE
Implemented RelaxedOneHotCategorical + RelaxedBernoulli distributions

### DIFF
--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -54,6 +54,8 @@ from .normal import Normal
 from .one_hot_categorical import OneHotCategorical
 from .pareto import Pareto
 from .poisson import Poisson
+from .relaxed_bernoulli import RelaxedBernoulli
+from .relaxed_categorical import RelaxedOneHotCategorical
 from .studentT import StudentT
 from .transformed_distribution import TransformedDistribution
 from .uniform import Uniform
@@ -79,6 +81,8 @@ __all__ = [
     'Normal',
     'OneHotCategorical',
     'Pareto',
+    'RelaxedBernoulli',
+    'RelaxedOneHotCategorical',
     'StudentT',
     'Poisson',
     'Uniform',

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -1,0 +1,117 @@
+import torch
+from numbers import Number
+from torch.autograd import Variable
+from torch.distributions import constraints
+from torch.distributions.distribution import Distribution
+from torch.distributions.transformed_distribution import TransformedDistribution
+from torch.distributions.transforms import SigmoidTransform
+from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property, clamp_probs
+
+
+class LogitRelaxedBernoulli(Distribution):
+    r"""
+    Creates a LogitRelaxedBernoulli distribution parameterized by `probs` or `logits`,
+    which is the logit of a RelaxedBernoulli distribution.
+
+    Samples are logits of values in (0, 1). See [1] for more details.
+
+    Args:
+        temperature (Tensor or Variable):
+        probs (Number, Tensor or Variable): the probabilty of sampling `1`
+        logits (Number, Tensor or Variable): the log-odds of sampling `1`
+
+    [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random Variables
+    (Maddison et al, 2017)
+
+    [2] Categorical Reparametrization with Gumbel-Softmax
+    (Jang et al, 2017)
+    """
+    params = {'probs': constraints.unit_interval}
+    support = constraints.real
+
+    def __init__(self, temperature, probs=None, logits=None):
+        self.temperature = temperature
+        if (probs is None) == (logits is None):
+            raise ValueError("Either `probs` or `logits` must be specified, but not both.")
+        if probs is not None:
+            is_scalar = isinstance(probs, Number)
+            self.probs, = broadcast_all(probs)
+        else:
+            is_scalar = isinstance(logits, Number)
+            self.logits, = broadcast_all(logits)
+        self._param = self.probs if probs is not None else self.logits
+        if is_scalar:
+            batch_shape = torch.Size()
+        else:
+            batch_shape = self._param.size()
+        super(LogitRelaxedBernoulli, self).__init__(batch_shape)
+
+    def _new(self, *args, **kwargs):
+        return self._param.new(*args, **kwargs)
+
+    @lazy_property
+    def logits(self):
+        return probs_to_logits(self.probs, is_binary=True)
+
+    @lazy_property
+    def probs(self):
+        return logits_to_probs(self.logits, is_binary=True)
+
+    @property
+    def param_shape(self):
+        return self._param.size()
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        probs = clamp_probs(self.probs.expand(shape))
+        uniforms = clamp_probs(self.probs.new(shape).uniform_())
+        return (uniforms.log() - (-uniforms).log1p() + probs.log() - (-probs).log1p()) / self.temperature
+
+    def log_prob(self, value):
+        self._validate_log_prob_arg(value)
+        logits, value = broadcast_all(self.logits, value)
+        diff = logits - value.mul(self.temperature)
+        return self.temperature.log() + diff - 2 * diff.exp().log1p()
+
+
+class RelaxedBernoulli(TransformedDistribution):
+    r"""
+    Creates a RelaxedBernoulli distribution, parametrized by `temperature`, and either
+    `probs` or `logits`. This is a relaxed version of the `Bernoulli` distribution, so
+    the values are in (0, 1), and has reparametrizable samples.
+
+    Example::
+
+        >>> m = RelaxedBernoulli(torch.Tensor([2.2]),
+                                 torch.Tensor([0.1, 0.2, 0.3, 0.99]))
+        >>> m.sample()
+         0.2951
+         0.3442
+         0.8918
+         0.9021
+        [torch.FloatTensor of size 4]
+
+    Args:
+        temperature (Tensor or Variable):
+        probs (Number, Tensor or Variable): the probabilty of sampling `1`
+        logits (Number, Tensor or Variable): the log-odds of sampling `1`
+    """
+    params = {'probs': constraints.unit_interval}
+    support = constraints.unit_interval
+    has_rsample = True
+
+    def __init__(self, temperature, probs=None, logits=None):
+        super(RelaxedBernoulli, self).__init__(LogitRelaxedBernoulli(temperature, probs, logits),
+                                               SigmoidTransform())
+
+    @property
+    def temperature(self):
+        return self.base_dist.temperature
+
+    @property
+    def logits(self):
+        return self.base_dist.logits
+
+    @property
+    def probs(self):
+        return self.base_dist.probs

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -1,0 +1,115 @@
+import torch
+from torch.autograd import Variable
+from torch.distributions import constraints
+from torch.distributions.categorical import Categorical
+from torch.distributions.utils import clamp_probs, broadcast_all, log_sum_exp
+from torch.distributions.distribution import Distribution
+from torch.distributions.transformed_distribution import TransformedDistribution
+from torch.distributions.transforms import ExpTransform
+
+
+class ExpRelaxedCategorical(Distribution):
+    r"""
+    Creates a ExpRelaxedCategorical parameterized by `probs` and `temperature`.
+    Returns the log of a point in the simplex. Based on the interface to OneHotCategorical.
+
+    Implementation based on [1].
+
+    See also: :func:`torch.distributions.OneHotCategorical`
+
+    Args:
+        temperature (Tensor or Variable): relaxation temperature
+        probs (Tensor or Variable): event probabilities
+        logits (Tensor or Variable): the log probability of each event.
+
+    [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random Variables
+    (Maddison et al, 2017)
+
+    [2] Categorical Reparametrization with Gumbel-Softmax
+    (Jang et al, 2017)
+    """
+    params = {'probs': constraints.simplex}
+    support = constraints.real
+    has_rsample = True
+
+    def __init__(self, temperature, probs=None, logits=None):
+        self._categorical = Categorical(probs, logits)
+        self.temperature = temperature
+        batch_shape = self._categorical.batch_shape
+        event_shape = self._categorical.param_shape[-1:]
+        super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape)
+
+    def _new(self, *args, **kwargs):
+        return self._categorical._new(*args, **kwargs)
+
+    @property
+    def param_shape(self):
+        return self._categorical.param_shape
+
+    @property
+    def logits(self):
+        return self._categorical.logits
+
+    @property
+    def probs(self):
+        return self._categorical.probs
+
+    def rsample(self, sample_shape=torch.Size()):
+        sample_shape = torch.Size(sample_shape)
+        uniforms = clamp_probs(self.logits.new(self._extended_shape(sample_shape)).uniform_())
+        gumbels = -((-(uniforms.log())).log())
+        scores = (self.logits + gumbels) / self.temperature
+        return scores - log_sum_exp(scores)
+
+    def log_prob(self, value):
+        K = self._categorical._num_events
+        self._validate_log_prob_arg(value)
+        logits, value = broadcast_all(self.logits, value)
+        log_scale = (self.logits.new(1).fill_(K).lgamma() -
+                     self.temperature.log().mul(-(K - 1)))
+        score = logits - value.mul(self.temperature)
+        score = (score - log_sum_exp(score)).sum(-1)
+        return score + log_scale
+
+
+class RelaxedOneHotCategorical(TransformedDistribution):
+    r"""
+    Creates a RelaxedOneHotCategorical distribution parametrized by `temperature` and either `probs` or `logits`.
+    This is a relaxed version of the `OneHotCategorical` distribution, so its
+    values are on simplex, and has reparametrizable samples.
+
+    Example::
+
+        >>> m = RelaxedOneHotCategorical(torch.Tensor([2.2]),
+                                         torch.Tensor([0.1, 0.2, 0.3, 0.4]))
+        >>> m.sample()  # equal probability of 1, 1, 2, 3
+         0.1294
+         0.2324
+         0.3859
+         0.2523
+        [torch.FloatTensor of size 4]
+
+    Args:
+        temperature (Tensor or Variable): relaxation temperature
+        probs (Tensor or Variable): event probabilities
+        logits (Tensor or Variable): the log probability of each event.
+    """
+    params = {'probs': constraints.simplex}
+    support = constraints.simplex
+    has_rsample = True
+
+    def __init__(self, temperature, probs=None, logits=None):
+        super(RelaxedOneHotCategorical, self).__init__(ExpRelaxedCategorical(temperature, probs, logits),
+                                                       ExpTransform())
+
+    @property
+    def temperature(self):
+        return self.base_dist.temperature
+
+    @property
+    def logits(self):
+        return self.base_dist.logits
+
+    @property
+    def probs(self):
+        return self.base_dist.probs


### PR DESCRIPTION
This implements the Gumbel-Softmax / Concrete distributions, which are continuous relaxations of discrete distributions, with reparametrizable gradients (i.e. for use in discrete VAEs).

Included are tests that:
1. Check that rounding samples from the `RelaxedBernoulli` gives samples from the corresponding `Bernoulli` distribution.
2. Check that taking the argmax of samples from `RelaxedOneHotCategorical` gives samples from the corresponding `OneHotCategorical` distribution.
3. Taking the `temperature -> \infty` gives a single point as samples.

Some math checked by @fritzo in https://github.com/probtorch/pytorch/pull/113