### PR TITLE
DDP: 10% of NCCL backend perf improvements with mixed-prec support

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -112,6 +112,10 @@ class DistributedDataParallel(Module):
         self.output_device = output_device
         self.broadcast_buffers = broadcast_buffers
 
+        # Flag used by the NCCL backend to make sure we only reduce gradients
+        # one time in the execution engine
+        self.need_reduction = False
+
         MB = 1024 * 1024
         # used for intra-node param sync and inter-node sync as well
         self.broadcast_bucket_size = 10 * MB
@@ -135,11 +139,15 @@ class DistributedDataParallel(Module):
         else:
             self._module_copies = [self.module]
 
-        # Currently NCCL backend only supports single reduction thread/bucket
+        # For NCCL backend, since every single NCCL call is asynchoronous, we
+        # therefore directly enqueue all the NCCL reduction calls to the
+        # default CUDA stream without spawning up other reduction threads.
+        # This achieves the best performance.
         if dist._backend == dist.dist_backend.NCCL:
-            bucket_bytes_cap = float('inf')
-        else:
-            bucket_bytes_cap = 1 * MB
+            self._register_nccl_grad_hook()
+            return
+
+        bucket_bytes_cap = 1 * MB
 
         # This is a triply-nested list where the "dimensions" are: devices, buckets, bucket_elems
         param_buckets = []
@@ -149,7 +157,6 @@ class DistributedDataParallel(Module):
 
         self.bucket_sizes = []
         self.bucket_map = {}
-        param_types = set()
 
         # We transpose param_buckets, so the loop is over buckets.
         # param_buckets_tuple is a doubly-nested list with "dims": devices, bucket_elems
@@ -161,7 +168,6 @@ class DistributedDataParallel(Module):
                 if idx == 0:
                     # Bucket parameter type tracking
                     bucket_param_type = param_tuple[0].type()
-                    param_types.add(bucket_param_type)
                     # Only gloo and nccl support half-precision
                     if bucket_param_type == torch.cuda.HalfTensor and \
                             dist._backend != dist.dist_backend.NCCL and \
@@ -175,13 +181,6 @@ class DistributedDataParallel(Module):
                     self.bucket_map[p] = bucket_idx
                 self.bucket_sizes[bucket_idx] += 1
 
-        # TODO, adding mixed precision support in NCCL reduction code path
-        # This is because NCCL backend doesn't support multiple reduction
-        # bucket.
-        if len(param_types) > 1 and dist._backend == dist.dist_backend.NCCL:
-            raise RuntimeError("DistributedDataParallel currently doesn't "
-                               "support mixed precision type for NCCL backend")
-
         self.buckets = [[[] for _ in range(len(self.device_ids))] for _ in range(len(self.bucket_sizes))]
         self.bucket_events = [[None] * len(self.device_ids) for _ in range(len(self.bucket_sizes))]
         self.reduced = [False] * len(self.bucket_sizes)
@@ -193,16 +192,22 @@ class DistributedDataParallel(Module):
 
     def __getstate__(self):
         attrs = copy.copy(self.__dict__)
-        del attrs['_grad_accs'], attrs['_reduction_queues'], attrs['_reduction_streams'], \
-            attrs['_reduction_threads'], attrs['_nccl_streams'], attrs['_default_streams']
+        if dist._backend != dist.dist_backend.NCCL:
+            del attrs['_grad_accs'], attrs['_reduction_queues'], \
+                attrs['_reduction_streams'], attrs['_reduction_threads'], \
+                attrs['_nccl_streams'], attrs['_default_streams']
         return attrs
 
     def __setstate__(self, state):
         super(DistributedDataParallel, self).__setstate__(state)
-        self._register_grad_hooks()
-        self._start_reduction_threads()
+        if dist._backend == dist.dist_backend.NCCL:
+            self._register_nccl_grad_hook()
+        else:
+            self._register_grad_hooks()
+            self._start_reduction_threads()
 
     def forward(self, *inputs, **kwargs):
+        self.need_reduction = True
         inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
         self._sync_params()
         if len(self.device_ids) == 1:
@@ -273,6 +278,66 @@ class DistributedDataParallel(Module):
                     grad_acc = p_tmp.grad_fn.next_functions[0][0]
                     grad_acc.register_hook(self._make_param_hook(p, device_idx))
                     self._grad_accs.append(grad_acc)
+
+    def _register_nccl_grad_hook(self):
+        """
+        This function registers the callback all-reduction function for the
+        NCCL backend. All gradients will be all reduced in one single step.
+        The NCCL reduction will directly be enqueued into the
+        default CUDA stream. Therefore, no synchronization is needed.
+        """
+        # creating a new group
+        self.nccl_reduction_group_id = dist.new_group()
+
+        def reduction_fn_nccl():
+            # This function only needs to be called once
+            if not self.need_reduction:
+                return
+            self.need_reduction = False
+            all_grads = [[] for _ in range(len(self._module_copies))]
+            all_grads_coalesced = []
+
+            # Coalesce all the gradients
+            # TODO: Add mixed precision support here
+            for idx, module in enumerate(self._module_copies):
+                for param in module.parameters():
+                    if not param.requires_grad or param.grad is None:
+                        continue
+                    if param.grad.requires_grad:
+                        raise RuntimeError("DistributedDataParallel only works "
+                                           "with gradients that don't require "
+                                           "grad")
+                    # Adding the gradients for reduction
+                    all_grads[idx].append(param.grad.data)
+                with torch.cuda.device(self.device_ids[idx]):
+                    dev_grads_coalesced = _flatten_dense_tensors(all_grads[idx])
+                    all_grads_coalesced.append(dev_grads_coalesced)
+
+            # This single op will do all-reduce on all GPUs utilizing multiple
+            # all reduce rings when we have more than one fast IB interfaces.
+            # We will only use device 0's results, but this single op should be
+            # faster than doing the following two operation sequentially:
+            # (1) intra-node reduce to lead GPU, followed by
+            # (2) inter-node allreduce for all the first lead GPUs in all nodes
+            dist.all_reduce_multigpu(all_grads_coalesced,
+                                     group=self.nccl_reduction_group_id)
+
+            # Now only work on the first lead GPU
+            all_grads_coalesced[0] /= dist.get_world_size()
+            for grad, reduced in \
+                    zip(all_grads[0],
+                        _unflatten_dense_tensors(all_grads_coalesced[0],
+                                                 all_grads[0])):
+                grad.copy_(reduced)
+
+        # Now register the reduction function in the execution engine
+        for module in self._module_copies:
+            for p in module.parameters():
+                if p.requires_grad:
+                    def allreduce_hook(*unused):
+                        Variable._execution_engine.\
+                            queue_callback(reduction_fn_nccl)
+                    p.register_hook(allreduce_hook)
 
     def _make_param_hook(self, param, device_idx):
         bucket_idx = self.bucket_map[param]
@@ -349,10 +414,7 @@ class DistributedDataParallel(Module):
             # We only use the first device for distributed reductions
             dist._register_stream(reduction_streams[0])
 
-            if dist._backend == dist.dist_backend.NCCL:
-                group_id = dist.group.WORLD
-            else:
-                group_id = dist.new_group()
+            group_id = dist.new_group()
 
             self._reduction_threads.append(threading.Thread(
                 target=self._reduction_thread_fn,


### PR DESCRIPTION
This PR lets NCCL backend to directly enqueue the NCCL reduction kernels in the same thread since it's an async call by nature, and everything now goes to the default stream. This essentially gets rid of the overheads of python thread synchronization, stream synchronization, as well as bucketing map lookup overheads.  

For DDP with multiple GPU (the default use case), instead of doing a two step reduction, we use the new NCCL backend API to all-reduce all GPU at one time, this is basically 4 times all-reduce throughput on DGX1s compared to the all-reduce(single GPU version) plus the intra-node reduce overheads.

As a results, we have the following perf improvements.

For DDP with 8 GPU (default use case):

On two DGX1s with 8 V100s, 256 batch size / process, single process / node
ResNet50
**0.139 sec / iter** reduced from **0.154 sec / iter** (about 10 percent improvements)
ResNet101
**0.247 sec / iter** reduced from **0.272 sec / iter** (about 10 percent improvements)

For DDP with 1 GPU (multi-process use case)

On singe DGX1s with 8 V100s, ResNet50, 32 batch size per GPU and process, 8 processes distributed training 
**0.109 sec / iter** reduced from **0.116 sec / iter** (about 6 percent improvement)

In addition,  added bucketing to limit the memory usage, added mixed precision support.

