### PR TITLE
Fix TH compile warnings

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -26,7 +26,7 @@ if("${isSystemDir}" STREQUAL "-1")
 endif()
 
 IF(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "--std=c++11 -Wall -Wno-vla -fexceptions ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "--std=c++11 -Wall -Wno-unknown-pragmas -Wno-vla -fexceptions ${CMAKE_CXX_FLAGS}")
   set(CMAKE_C_FLAGS "-fexceptions ${CMAKE_C_FLAGS}")
 ENDIF(NOT MSVC)
 
@@ -127,7 +127,7 @@ ENDIF ()
 IF (WITH_OPENMP AND NOT CHECKED_OPENMP)
   FIND_PACKAGE(OpenMP)
   SET(CHECKED_OPENMP ON CACHE BOOL "already checked for OpenMP")
-  
+
   # OPENMP_FOUND is not cached in FindOpenMP.cmake (all other variables are cached)
   # see https://github.com/Kitware/CMake/blob/master/Modules/FindOpenMP.cmake
   SET(OPENMP_FOUND ${OPENMP_FOUND} CACHE BOOL "OpenMP Support found")

--- a/aten/src/TH/THGeneral.c
+++ b/aten/src/TH/THGeneral.c
@@ -142,13 +142,6 @@ void THSetDefaultArgErrorHandler(THArgErrorHandlerFunction new_handler, void *da
 
 static __thread void (*torchGCFunction)(void *data) = NULL;
 static __thread void *torchGCData;
-static ptrdiff_t heapSize = 0;
-static __thread ptrdiff_t heapDelta = 0;
-static const ptrdiff_t heapMaxDelta = (ptrdiff_t)1e6; // limit to +/- 1MB before updating heapSize
-static const ptrdiff_t heapMinDelta = (ptrdiff_t)-1e6;
-static __thread ptrdiff_t heapSoftmax = (ptrdiff_t)3e8; // 300MB, adjusted upward dynamically
-static const double heapSoftmaxGrowthThresh = 0.8; // grow softmax if >80% max after GC
-static const double heapSoftmaxGrowthFactor = 1.4; // grow softmax by 40%
 
 /* Optional hook for integrating with a garbage-collected frontend.
  *
@@ -177,36 +170,6 @@ static ptrdiff_t getAllocSize(void *ptr) {
 #else
   return 0;
 #endif
-}
-
-static ptrdiff_t applyHeapDelta() {
-  ptrdiff_t oldHeapSize = THAtomicAddPtrdiff(&heapSize, heapDelta);
-#ifdef DEBUG
-  if (heapDelta > 0 && oldHeapSize > PTRDIFF_MAX - heapDelta)
-    THError("applyHeapDelta: heapSize(%td) + increased(%td) > PTRDIFF_MAX, heapSize overflow!", oldHeapSize, heapDelta);
-  if (heapDelta < 0 && oldHeapSize < PTRDIFF_MIN - heapDelta)
-    THError("applyHeapDelta: heapSize(%td) + decreased(%td) < PTRDIFF_MIN, heapSize underflow!", oldHeapSize, heapDelta);
-#endif
-  ptrdiff_t newHeapSize = oldHeapSize + heapDelta;
-  heapDelta = 0;
-  return newHeapSize;
-}
-
-/* (1) if the torch-allocated heap size exceeds the soft max, run GC
- * (2) if post-GC heap size exceeds 80% of the soft max, increase the
- *     soft max by 40%
- */
-static void maybeTriggerGC(ptrdiff_t curHeapSize) {
-  if (torchGCFunction && curHeapSize > heapSoftmax) {
-    torchGCFunction(torchGCData);
-
-    // ensure heapSize is accurate before updating heapSoftmax
-    ptrdiff_t newHeapSize = applyHeapDelta();
-
-    if (newHeapSize > heapSoftmax * heapSoftmaxGrowthThresh) {
-      heapSoftmax = (ptrdiff_t)(heapSoftmax * heapSoftmaxGrowthFactor);
-    }
-  }
 }
 
 static void* THAllocInternal(ptrdiff_t size)

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -42,6 +42,12 @@
 # define TH_UNREACHABLE __builtin_unreachable();
 #endif
 
+#if defined(__GNUC__) && ((__GNUC__ > 2) || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
+# define TH_UNUSED __attribute__((unused))
+#else
+# define TH_UNUSED
+#endif
+
 #ifndef M_PI
 # define M_PI 3.14159265358979323846
 #endif

--- a/aten/src/TH/THRandom.cpp
+++ b/aten/src/TH/THRandom.cpp
@@ -67,7 +67,7 @@ static uint64_t readURandomLong()
     THError("Unable to open /dev/urandom");
   }
   ssize_t readBytes = read(randDev, &randValue, sizeof(randValue));
-  if (readBytes < sizeof(randValue)) {
+  if (readBytes < (ssize_t) sizeof(randValue)) {
     THError("Unable to read from /dev/urandom");
   }
   close(randDev);

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -31,7 +31,7 @@
  */
 
 #define __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, DIM, ALLOW_CONTIGUOUS) \
-  TYPE *TENSOR##_data = NULL; \
+  __attribute__((unused)) TYPE *TENSOR##_data = NULL; \
   int64_t *TENSOR##_counter = NULL, *TENSOR##_sizes = NULL, *TENSOR##_strides = NULL, *TENSOR##_dimOffset = NULL; \
   int64_t TENSOR##_stride = 0, TENSOR##_size = 0, TENSOR##_dim = 0, TENSOR##_i, TENSOR##_n; \
   int TENSOR##_contiguous = ALLOW_CONTIGUOUS && DIM < 0; \
@@ -271,7 +271,7 @@
  *  You can get the detailes in the for-statement iterations.
  *
  * The macro is only used in the first element in each thread. For the rest, the memory offset could update
- * according to info of the tensor in order to get better performance. So we should also record the each 
+ * according to info of the tensor in order to get better performance. So we should also record the each
  * indexs in coresponding dimension of first element.
  * The recorded info is stored in the TENSOR##_counter_tmp.
  *
@@ -331,7 +331,7 @@
       CODE                                         \
     }                                              \
   } else {                                         \
-    int TH_TENSOR_APPLY_hasFinished = 0;           \
+    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0;           \
     int64_t TH_TENSOR_dim_index = 0;               \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, -1, 1);\
     PRAGMA(omp parallel if (TENSOR##Size > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(TENSOR##_sizes, TENSOR##_strides, TENSOR##_dim, TENSOR##_stride, TENSOR##_size, TENSOR##_i) reduction(OPERATION))\
@@ -394,7 +394,7 @@
      *    first one.
      * 4. iterate all elements in each thread. update the indexes in each dimension of the rest.
     */                                                                                             \
-    int TH_TENSOR_APPLY_hasFinished = 0; \
+    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0; \
     int64_t TH_TENSOR_dim_index = 0;     \
     /*step 1*/                           \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \
@@ -467,7 +467,7 @@
       } \
     }\
   } else{              \
-    int TH_TENSOR_APPLY_hasFinished = 0;\
+    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0;\
     int64_t TH_TENSOR_dim_index = 0;\
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, -1, 1) \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -31,7 +31,7 @@
  */
 
 #define __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, DIM, ALLOW_CONTIGUOUS) \
-  __attribute__((unused)) TYPE *TENSOR##_data = NULL; \
+  TH_UNUSED TYPE *TENSOR##_data = NULL; \
   int64_t *TENSOR##_counter = NULL, *TENSOR##_sizes = NULL, *TENSOR##_strides = NULL, *TENSOR##_dimOffset = NULL; \
   int64_t TENSOR##_stride = 0, TENSOR##_size = 0, TENSOR##_dim = 0, TENSOR##_i, TENSOR##_n; \
   int TENSOR##_contiguous = ALLOW_CONTIGUOUS && DIM < 0; \
@@ -331,7 +331,7 @@
       CODE                                         \
     }                                              \
   } else {                                         \
-    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0;           \
+    TH_UNUSED int TH_TENSOR_APPLY_hasFinished = 0;           \
     int64_t TH_TENSOR_dim_index = 0;               \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE, TENSOR, -1, 1);\
     PRAGMA(omp parallel if (TENSOR##Size > TH_OMP_OVERHEAD_THRESHOLD_OMP) firstprivate(TENSOR##_sizes, TENSOR##_strides, TENSOR##_dim, TENSOR##_stride, TENSOR##_size, TENSOR##_i) reduction(OPERATION))\
@@ -394,7 +394,7 @@
      *    first one.
      * 4. iterate all elements in each thread. update the indexes in each dimension of the rest.
     */                                                                                             \
-    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0; \
+    TH_UNUSED int TH_TENSOR_APPLY_hasFinished = 0; \
     int64_t TH_TENSOR_dim_index = 0;     \
     /*step 1*/                           \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \
@@ -467,7 +467,7 @@
       } \
     }\
   } else{              \
-    __attribute__((unused)) int TH_TENSOR_APPLY_hasFinished = 0;\
+    TH_UNUSED int TH_TENSOR_APPLY_hasFinished = 0;\
     int64_t TH_TENSOR_dim_index = 0;\
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE1, TENSOR1, -1, 1) \
     __TH_TENSOR_APPLYX_PREAMBLE(TYPE2, TENSOR2, -1, 1) \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -34,11 +34,11 @@
 #define TH_TENSOR_DIM_APPLY3(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, DIMENSION, SIZE_CHECK, CODE) \
 { \
   TYPE1 *TENSOR1##_data = NULL; \
-  __attribute__((unused)) int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
+  TH_UNUSED int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
   TYPE2 *TENSOR2##_data = NULL; \
-  __attribute__((unused)) int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
+  TH_UNUSED int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
   TYPE3 *TENSOR3##_data = NULL; \
-  __attribute__((unused)) int64_t TENSOR3##_stride = 0, TENSOR3##_size = 0; \
+  TH_UNUSED int64_t TENSOR3##_stride = 0, TENSOR3##_size = 0; \
   int64_t *TH_TENSOR_DIM_APPLY_counter = NULL; \
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
@@ -143,9 +143,9 @@
 #define TH_TENSOR_DIM_APPLY2(TYPE1, TENSOR1, TYPE2, TENSOR2, DIMENSION, CODE) \
 { \
   TYPE1 *TENSOR1##_data = NULL; \
-  __attribute__((unused)) int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
+  TH_UNUSED int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
   TYPE2 *TENSOR2##_data = NULL; \
-  __attribute__((unused)) int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
+  TH_UNUSED int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
   int64_t *TH_TENSOR_DIM_APPLY_counter = NULL; \
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
@@ -158,7 +158,7 @@
     THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
             "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str);        \
   }                                                                     \
-  __attribute__((unused)) int shape_check_flag = 0;                                             \
+  TH_UNUSED int shape_check_flag = 0;                                             \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
   { \
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -34,11 +34,11 @@
 #define TH_TENSOR_DIM_APPLY3(TYPE1, TENSOR1, TYPE2, TENSOR2, TYPE3, TENSOR3, DIMENSION, SIZE_CHECK, CODE) \
 { \
   TYPE1 *TENSOR1##_data = NULL; \
-  int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
+  __attribute__((unused)) int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
   TYPE2 *TENSOR2##_data = NULL; \
-  int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
+  __attribute__((unused)) int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
   TYPE3 *TENSOR3##_data = NULL; \
-  int64_t TENSOR3##_stride = 0, TENSOR3##_size = 0; \
+  __attribute__((unused)) int64_t TENSOR3##_stride = 0, TENSOR3##_size = 0; \
   int64_t *TH_TENSOR_DIM_APPLY_counter = NULL; \
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
@@ -143,9 +143,9 @@
 #define TH_TENSOR_DIM_APPLY2(TYPE1, TENSOR1, TYPE2, TENSOR2, DIMENSION, CODE) \
 { \
   TYPE1 *TENSOR1##_data = NULL; \
-  int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
+  __attribute__((unused)) int64_t TENSOR1##_stride = 0, TENSOR1##_size = 0; \
   TYPE2 *TENSOR2##_data = NULL; \
-  int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
+  __attribute__((unused)) int64_t TENSOR2##_stride = 0, TENSOR2##_size = 0; \
   int64_t *TH_TENSOR_DIM_APPLY_counter = NULL; \
   int TH_TENSOR_DIM_APPLY_hasFinished = 0; \
   int TH_TENSOR_DIM_APPLY_i; \
@@ -158,7 +158,7 @@
     THError("inconsistent tensor size, expected %s %s and %s %s to have the same " \
             "number of dimensions", #TENSOR1, T1buff.str, #TENSOR2, T2buff.str);        \
   }                                                                     \
-  int shape_check_flag = 0;                                             \
+  __attribute__((unused)) int shape_check_flag = 0;                                             \
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
   { \
     if(TH_TENSOR_DIM_APPLY_i == DIMENSION) \

--- a/aten/src/TH/generic/THTensorConv.cpp
+++ b/aten/src/TH/generic/THTensorConv.cpp
@@ -582,7 +582,7 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
 {
   int64_t nInputPlane, nInputRows, nInputCols;
   int64_t nKernelPlane, nKernelRows, nKernelCols;
-  int64_t nOutputPlane, nOutputRows, nOutputCols;
+  int64_t nOutputRows, nOutputCols;
   int64_t istride0, kstride0;
   THTensor *input;
   THTensor *kernel;
@@ -609,7 +609,6 @@ void THTensor_(conv2DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   nKernelPlane = kernel->size[0];
   nKernelRows = kernel->size[1];
   nKernelCols = kernel->size[2];
-  nOutputPlane = nInputPlane * kernel->size[0];
 
   THArgCheck(nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "covn2DRevger : Input image is smaller than kernel");
 
@@ -800,7 +799,7 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
 {
   int64_t nInputPlane, nInputRows, nInputCols;
   int64_t nKernelPlane, nKernelRows, nKernelCols;
-  int64_t nOutputPlane, nOutputRows, nOutputCols;
+  int64_t nOutputRows, nOutputCols;
   int64_t istride0, kstride0;
 
   THTensor *input;
@@ -830,7 +829,6 @@ void THTensor_(conv2Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   nKernelPlane = kernel->size[0];
   nKernelRows = kernel->size[1];
   nKernelCols = kernel->size[2];
-  nOutputPlane = nInputPlane * kernel->size[0];
 
   THArgCheck((nInputRows >= nKernelRows && nInputCols >= nKernelCols) || *vf == 'F', 2, "conv2Dger : Input image is smaller than kernel");
 
@@ -1445,7 +1443,7 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
 {
   int64_t nInputPlane, nInputDepth, nInputRows, nInputCols;
   int64_t nKernelPlane, nKernelDepth, nKernelRows, nKernelCols;
-  int64_t nOutputPlane, nOutputDepth, nOutputRows, nOutputCols;
+  int64_t nOutputDepth, nOutputRows, nOutputCols;
   int64_t istride0, kstride0;
   THTensor *input;
   THTensor *kernel;
@@ -1475,7 +1473,6 @@ void THTensor_(conv3DRevger)(THTensor *r_, real beta, real alpha, THTensor *t_, 
   nKernelDepth= kernel->size[1];
   nKernelRows = kernel->size[2];
   nKernelCols = kernel->size[3];
-  nOutputPlane = nInputPlane * kernel->size[0];
 
   THArgCheck(nInputDepth >= nKernelDepth && nInputRows >= nKernelRows && nInputCols >= nKernelCols , 2, "conv3DRevger : Input image is smaller than kernel");
 
@@ -1532,7 +1529,7 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
 {
   int64_t nInputPlane, nInputDepth, nInputRows, nInputCols;
   int64_t nKernelPlane, nKernelDepth, nKernelRows, nKernelCols;
-  int64_t nOutputPlane, nOutputDepth, nOutputRows, nOutputCols;
+  int64_t nOutputDepth, nOutputRows, nOutputCols;
   int64_t istride0, kstride0;
   THTensor *input;
   THTensor *kernel;
@@ -1564,7 +1561,6 @@ void THTensor_(conv3Dger)(THTensor *r_, real beta, real alpha, THTensor *t_, THT
   nKernelDepth = kernel->size[1];
   nKernelRows  = kernel->size[2];
   nKernelCols  = kernel->size[3];
-  nOutputPlane = nInputPlane * kernel->size[0];
 
   THArgCheck((nInputDepth >= nKernelDepth
               && nInputRows >= nKernelRows

--- a/aten/src/TH/generic/THTensorLapack.c
+++ b/aten/src/TH/generic/THTensorLapack.c
@@ -857,7 +857,6 @@ void THTensor_(orgqr)(THTensor *ra_, THTensor *a, THTensor *tau)
   ra__ = THTensor_(cloneColumnMajor)(ra_, a);
 
   int m = ra__->size[0];
-  int n = ra__->size[1];
   int k = tau->size[0];
   int lda = m;
 

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -3092,7 +3092,7 @@ Adapted similarly to the above Quicksort algorithm.
 This version does not produce indices along with values. */
 static void THTensor_(quickselectnoidx)(real *arr, int64_t k, int64_t elements, int64_t stride)
 {
-  int64_t P, L, R, i, j, swap;
+  int64_t P, L, R, i, j;
   real rswap, piv;
   L = 0;
   R = elements-1;
@@ -3138,7 +3138,7 @@ public domain implementation at http://ndevilla.free.fr/median/median/
 Adapted similarly to the above Quicksort algorithm. */
 static void THTensor_(quickselect)(real *arr, int64_t *idx, int64_t k, int64_t elements, int64_t stride)
 {
-  int64_t P, L, R, i, j, swap, pid;
+  int64_t P, L, R, i, j, swap;
   real rswap, piv;
   L = 0;
   R = elements-1;
@@ -3164,7 +3164,6 @@ static void THTensor_(quickselect)(real *arr, int64_t *idx, int64_t k, int64_t e
     i = L+1;
     j = R;
     piv = ARR(L);
-    pid = IDX(L);
     do {
       do i++; while(ARR(i) < piv);
       do j--; while(ARR(j) > piv);
@@ -4082,7 +4081,6 @@ void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, real min
 
   real minval;
   real maxval;
-  real *h_data;
 
   THTensor_(resize2d)(hist, tensor->size[0], nbins);
   THTensor_(zero)(hist);

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -256,7 +256,7 @@ void THTensor_(multinomialAliasDraw)(THLongTensor *self, THGenerator *_generator
   int64_t output_nelem = THLongTensor_nElement(self);
   int64_t i = 0, _mask=0;
   real _q;
-  int64_t rand_ind, sample_idx, J_sample, kk_sample;
+  int64_t rand_ind, sample_idx, J_sample;
 
   for (i=0; i < output_nelem; i++)
     {

--- a/aten/src/TH/generic/simd/simd.h
+++ b/aten/src/TH/generic/simd/simd.h
@@ -22,7 +22,7 @@
 
 #define INIT_DISPATCH_PTR(OP)    \
   do {                           \
-    int i;                       \
+    size_t i;                       \
     for (i = 0; i < sizeof(THVector_(OP ## _DISPATCHTABLE)) / sizeof(FunctionDescription); ++i) { \
       THVector_(OP ## _DISPATCHPTR) = reinterpret_cast<decltype(THVector_(OP ## _DISPATCHPTR))>(THVector_(OP ## _DISPATCHTABLE)[i].function);                     \
       if (THVector_(OP ## _DISPATCHTABLE)[i].supportedSimdExt & hostSimdExts) {                       \

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -827,12 +827,6 @@ void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line
   }
 }
 
-static ptrdiff_t heapSize = 0; // not thread-local
-static const ptrdiff_t heapMaxDelta = (ptrdiff_t)1e6;
-static const ptrdiff_t heapMinDelta = (ptrdiff_t)-1e6;
-static const double heapSoftmaxGrowthThresh = 0.8; // grow softmax if >80% max after GC
-static const double heapSoftmaxGrowthFactor = 1.4; // grow softmax by 40%
-
 void THCSetGCHandler(THCState *state, void (*cutorchGCFunction_)(void *data), void *data )
 {
   state->cutorchGCFunction = cutorchGCFunction_;
@@ -911,29 +905,6 @@ cudaError_t THCudaMemGetInfoCached(THCState *state,  size_t* freeBytes, size_t* 
   /* Adjust resulting free bytes number. largesBlock unused for now */
   *freeBytes += cachedBytes;
   return cudaSuccess;
-}
-
-static ptrdiff_t applyHeapDelta(THCState *state) {
-  ptrdiff_t newHeapSize = THAtomicAddPtrdiff(&heapSize, state->heapDelta) + state->heapDelta;
-  state->heapDelta = 0;
-  return newHeapSize;
-}
-
-// Here we maintain a dynamic softmax threshold for THC-allocated storages.
-// When THC heap size goes above this softmax, the GC hook is triggered.
-// If heap size is above 80% of the softmax after GC, then the softmax is
-// increased.
-static void maybeTriggerGC(THCState *state, ptrdiff_t curHeapSize) {
-  if (state->cutorchGCFunction != NULL && curHeapSize > state->heapSoftmax) {
-    (state->cutorchGCFunction)(state->cutorchGCData);
-
-    // ensure heapSize is accurate before updating heapSoftmax
-    ptrdiff_t newHeapSize = applyHeapDelta(state);
-
-    if (newHeapSize > state->heapSoftmax * heapSoftmaxGrowthThresh) {
-      state->heapSoftmax = (ptrdiff_t)state->heapSoftmax * heapSoftmaxGrowthFactor;
-    }
-  }
 }
 
 #undef MIN_GLOBAL_SCRATCH_SPACE_PER_SM_STREAM

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -377,7 +377,6 @@ int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, unsigned
   va_list(args);
   va_start(args, nTensors);
   int valid = 1;
-  int sparse = 1;
   for (unsigned int i = 0; i < nSparseTensors + nDenseTensors; i++) {
     THCSTensor *sparseTensor;
     THCTensor *denseTensor;

--- a/aten/src/THNN/generic/FeatureLPPooling.c
+++ b/aten/src/THNN/generic/FeatureLPPooling.c
@@ -197,7 +197,7 @@ THNN_(FeatureLPPooling_updateOutput)(
     THNN_(FeatureLPPooling_upcastCPU)(input, batchMode);
 
   // Make sure the feature dimension is properly sized
-  THArgCheck(inputDesc.size[1] >= width, 3,
+  THArgCheck(inputDesc.size[1] >= (FEATURE_LP_SIZE_TYPE) width, 3,
              "input: feature dimension must be >= width");
 
   // Make sure that width and stride are within range
@@ -228,7 +228,7 @@ THNN_(FeatureLPPooling_updateOutput)(
              outputFeature < FEATURE_LP_CAST_TYPE outputDesc.size[1]; ++outputFeature) {
 
           accreal v = (accreal) 0;
-          for (i = 0; i < width; ++i) {
+          for (i = 0; i < (FEATURE_LP_SIZE_TYPE) width; ++i) {
             FEATURE_LP_SIZE_TYPE inputFeature = outputFeature * stride + i;
             if (inputFeature >= FEATURE_LP_CAST_TYPE inputDesc.size[1]) {
               break;
@@ -279,7 +279,7 @@ THNN_(FeatureLPPooling_updateGradInput)(
     THNN_(FeatureLPPooling_upcastCPU)(output, batchMode);
 
   // Make sure the feature dimension is properly sized
-  THArgCheck(inputDesc.size[1] >= width, 3,
+  THArgCheck(inputDesc.size[1] >= (FEATURE_LP_SIZE_TYPE) width, 3,
              "input: feature dimension must be >= width");
 
   // Make sure that width and stride are within range
@@ -333,7 +333,7 @@ THNN_(FeatureLPPooling_updateGradInput)(
             continue;
           }
 
-          for (i = 0; i < width; ++i) {
+          for (i = 0; i < (FEATURE_LP_SIZE_TYPE) width; ++i) {
             FEATURE_LP_SIZE_TYPE inputFeature = outputFeature * stride + i;
             THAssert(inputFeature < inputDesc.size[1]);
 

--- a/aten/src/THNN/generic/LogSoftMax.c
+++ b/aten/src/THNN/generic/LogSoftMax.c
@@ -14,17 +14,16 @@ void THNN_(LogSoftMax_updateOutput)(
           THNNState *state,
           THTensor *input,
           THTensor *output,
-          int dim)
-{
+          int64_t dim) {
   THArgCheck(dim >= 0 && dim < input->nDimension, 4,
 	     "dim out of range (got %d, but input has %d dims)", dim, input->nDimension);
 
   uint64_t outer_size = 1;
   uint64_t dim_size = input->size[dim];
   uint64_t inner_size = 1;
-  for (uint64_t i = 0; i < dim; ++i)
+  for (int64_t i = 0; i < dim; ++i)
     outer_size *= input->size[i];
-  for (uint64_t i = dim + 1; i < input->nDimension; ++i)
+  for (int64_t i = dim + 1; i < input->nDimension; ++i)
     inner_size *= input->size[i];
 
   input = THTensor_(newContiguous)(input);
@@ -68,7 +67,7 @@ void THNN_(LogSoftMax_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output,
-          int dim)
+          int64_t dim)
 {
   THNN_CHECK_SHAPE(output, gradOutput);
   THArgCheck(dim >= 0 && dim < output->nDimension, 6,
@@ -77,9 +76,9 @@ void THNN_(LogSoftMax_updateGradInput)(
   uint64_t outer_size = 1;
   uint64_t dim_size = output->size[dim];
   uint64_t inner_size = 1;
-  for (uint64_t i = 0; i < dim; ++i)
+  for (int64_t i = 0; i < dim; ++i)
     outer_size *= output->size[i];
-  for (uint64_t i = dim + 1; i < output->nDimension; ++i)
+  for (int64_t i = dim + 1; i < output->nDimension; ++i)
     inner_size *= output->size[i];
 
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/MultiLabelMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiLabelMarginCriterion.c
@@ -12,7 +12,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
           bool sizeAverage,
           bool reduce)
 {
-  real *input_data, *output_data, *isTarget_data;
+  real *input_data, *isTarget_data;
   THIndex_t *target_data;
   int64_t nframe, dim;
   int64_t t, d, dt, ddt;

--- a/aten/src/THNN/generic/PReLU.c
+++ b/aten/src/THNN/generic/PReLU.c
@@ -174,7 +174,6 @@ void THNN_(PReLU_accGradParameters)(
 
   const real *input_data = THTensor_(data)(input);
   const real *gradOutput_data = THTensor_(data)(gradOutput);
-  const real *weight_data = THTensor_(data)(weight);
   real *gradWeight_data = THTensor_(data)(gradWeight);
 
   THIndex_t i, j, k;

--- a/aten/src/THNN/generic/SoftMax.c
+++ b/aten/src/THNN/generic/SoftMax.c
@@ -14,16 +14,16 @@ void THNN_(SoftMax_updateOutput)(
           THNNState *state,
           THTensor *input,
           THTensor *output,
-          int dim) {
+          int64_t dim) {
   THArgCheck(dim >= 0 && dim < input->nDimension, 4,
 	     "dim out of range (got %d, but input has %d dims)", dim, input->nDimension);
 
   uint64_t outer_size = 1;
   uint64_t dim_size = input->size[dim];
   uint64_t inner_size = 1;
-  for (uint64_t i = 0; i < dim; ++i)
+  for (int64_t i = 0; i < dim; ++i)
     outer_size *= input->size[i];
-  for (uint64_t i = dim + 1; i < input->nDimension; ++i)
+  for (int64_t i = dim + 1; i < input->nDimension; ++i)
     inner_size *= input->size[i];
 
   input = THTensor_(newContiguous)(input);
@@ -71,7 +71,7 @@ void THNN_(SoftMax_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output,
-          int dim)
+          int64_t dim)
 {
   THNN_CHECK_SHAPE(output, gradOutput);
   THArgCheck(dim >= 0 && dim < output->nDimension, 6,
@@ -80,9 +80,9 @@ void THNN_(SoftMax_updateGradInput)(
   uint64_t outer_size = 1;
   uint64_t dim_size = output->size[dim];
   uint64_t inner_size = 1;
-  for (uint64_t i = 0; i < dim; ++i)
+  for (int64_t i = 0; i < dim; ++i)
     outer_size *= output->size[i];
-  for (uint64_t i = dim + 1; i < output->nDimension; ++i)
+  for (int64_t i = dim + 1; i < output->nDimension; ++i)
     inner_size *= output->size[i];
 
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/aten/src/THNN/generic/SparseLinear.c
+++ b/aten/src/THNN/generic/SparseLinear.c
@@ -48,7 +48,7 @@ void THNN_(SparseLinear_updateOutput)(
           THTensor *weight,
           THTensor *bias)
 {
-  int64_t h, i, j, hp0, hp1;
+  int64_t h, i, hp0, hp1;
   int64_t outDim = THTensor_(size)(weight, 0);
   int64_t inDim = THTensor_(size)(weight, 1);
   int64_t batchSize = THTensor_(size)(output, 0);
@@ -323,7 +323,7 @@ void THNN_(SparseLinear_updateParameters)(
           accreal learningRate_)
 {
   real learningRate = TH_CONVERT_ACCREAL_TO_REAL(learningRate_);
-  int64_t h, i;
+  int64_t i;
   int64_t outDim = weight->size[0];
   int64_t inDim = weight->size[1];
 
@@ -469,7 +469,7 @@ void THNN_(SparseLinear_zeroGradParameters)(
           THTensor *gradBias,
           THTensor *lastInput)
 {
-  int64_t h, i, j;
+  int64_t i, j;
 
   int64_t outDim = gradWeight->size[0];
   int64_t inDim = gradWeight->size[1];

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -48,7 +48,6 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(
         /* compute local max: */
         int64_t maxindex = -1;
         real maxval = -FLT_MAX;
-        int64_t tcntr = 0;
         int ih, iw;
         for(ih = 0; ih < kH; ih++)
         {

--- a/aten/src/THNN/generic/SpatialAveragePooling.c
+++ b/aten/src/THNN/generic/SpatialAveragePooling.c
@@ -223,7 +223,7 @@ void THNN_(SpatialAveragePooling_updateGradInput)(
   int64_t nInputPlane; // number of channels (or colors)
 
   real *gradOutput_data;
-  real *input_data, *gradInput_data;
+  real *gradInput_data;
 
   int64_t k;
 

--- a/aten/src/THNN/generic/SpatialConvolutionLocal.c
+++ b/aten/src/THNN/generic/SpatialConvolutionLocal.c
@@ -73,7 +73,6 @@ static void THNN_(SpatialConvolutionLocal_updateOutput_frame)
       int64_t nInputPlane, int64_t inputWidth, int64_t inputHeight,
       int64_t nOutputPlane, int64_t outputWidth, int64_t outputHeight)
 {
-  int64_t i;
   THTensor *output3d, *finput3d;
 
   THNN_(unfolded_copy)(finput, input, kW, kH, dW, dH, padW, padH,

--- a/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
+++ b/aten/src/THNN/generic/SpatialGridSamplerBilinear.c
@@ -19,14 +19,12 @@ static inline void THNN_(SpatialGridSamplerBilinear_shapeCheck)
 
   int nbatch   = THTensor_(size)(input, 0);
   int channels = THTensor_(size)(input, 1);
-  int iheight   = THTensor_(size)(input, 2);
-  int iwidth    = THTensor_(size)(input, 3);
   int oheight   = THTensor_(size)(grid, 1);
   int owidth    = THTensor_(size)(grid, 2);
 
   THNN_CHECK_DIM_SIZE(grid, 4, 0, nbatch);
   THNN_CHECK_DIM_SIZE(grid, 4, 3, 2);
-  
+
   if (gradOutput != NULL) {
     THNN_CHECK_DIM_SIZE(gradOutput, 4, 0, nbatch);
     THNN_CHECK_DIM_SIZE(gradOutput, 4, 1, channels);

--- a/aten/src/THNN/generic/SpatialSubSampling.c
+++ b/aten/src/THNN/generic/SpatialSubSampling.c
@@ -7,7 +7,6 @@ static inline void THNN_(SpatialSubSampling_shapeCheck)(
                          THTensor *gradOutput,
                          THTensor *weight,
                          int kW, int kH) {
-  int ndims = input->nDimension;
   THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
@@ -148,7 +147,7 @@ void THNN_(SpatialSubSampling_updateGradInput)(
 
   real *weight_data;
   real *gradOutput_data;
-  real *input_data, *gradInput_data;
+  real *gradInput_data;
 
   int64_t k;
 
@@ -166,8 +165,6 @@ void THNN_(SpatialSubSampling_updateGradInput)(
   weight_data = THTensor_(data)(weight);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   gradOutput_data = THTensor_(data)(gradOutput);
-
-  input_data = THTensor_(data)(input);
 
   THTensor_(resizeAs)(gradInput, input);
   gradInput_data = THTensor_(data)(gradInput);

--- a/aten/src/THNN/generic/Sqrt.c
+++ b/aten/src/THNN/generic/Sqrt.c
@@ -8,7 +8,6 @@ void THNN_(Sqrt_updateOutput)(
           THTensor *output,
           accreal eps_)
 {
-  real eps = TH_CONVERT_ACCREAL_TO_REAL(eps_);
   THTensor_(resizeAs)(output, input);
   THTensor_(sqrt)(output, input);
 }

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -278,14 +278,14 @@ TH_API void THNN_(LogSoftMax_updateOutput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor
           THTensor *output,            // [OUT] output tensor
-          int dim);
+          int64_t dim);
 TH_API void THNN_(LogSoftMax_updateGradInput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor
           THTensor *gradOutput,        // gradient w.r.t. module's output
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
           THTensor *output,            // module's output
-          int dim);
+          int64_t dim);
 
 TH_API void THNN_(LookupTable_accGradParameters)(
           THNNState *state,
@@ -485,14 +485,14 @@ TH_API void THNN_(SoftMax_updateOutput)(
           THNNState *state,
           THTensor *input,
           THTensor *output,
-          int dim);
+          int64_t dim);
 TH_API void THNN_(SoftMax_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THTensor *gradOutput,
           THTensor *gradInput,
           THTensor *output,
-          int dim);
+          int64_t dim);
 
 TH_API void THNN_(SoftPlus_updateOutput)(
           THNNState *state,

--- a/aten/src/THNN/generic/TemporalConvolution.c
+++ b/aten/src/THNN/generic/TemporalConvolution.c
@@ -50,12 +50,10 @@ void THNN_(TemporalConvolution_updateOutput)(
   int64_t k, i;
 
   int dimS = 0; // sequence dimension
-  int dimF = 1; // feature dimension
 
   if (input->nDimension == 3)
   {
     dimS = 1;
-    dimF = 2;
   }
 
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
@@ -181,12 +179,10 @@ void THNN_(TemporalConvolution_updateGradInput)(
   int64_t k, i;
 
   int dimS = 0; // sequence dimension
-  int dimF = 1; // feature dimension
 
   if (gradOutput->nDimension == 3)
   {
     dimS = 1;
-    dimF = 2;
   }
 
   THArgCheck(THTensor_(isContiguous)(weight), 4, "weight must be contiguous");
@@ -290,12 +286,10 @@ void THNN_(TemporalConvolution_accGradParameters)(
   int64_t k, i;
 
   int dimS = 0; // sequence dimension
-  int dimF = 1; // feature dimension
 
   if (gradOutput->nDimension == 3)
   {
     dimS = 1;
-    dimF = 2;
   }
 
   THNN_(TemporalConvolution_shapeCheck)(

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -66,14 +66,14 @@ static void THNN_(unfolded_acc_row)(
 	int64_t nInputFrame,
 	int64_t nOutputFrame) {
 
-	size_t c;
+	int64_t c;
 	real *input_data = THTensor_(data)(input);
 	real *finput_data = THTensor_(data)(finput);
 
 // #pragma omp parallel for private(c)
 	for (c = 0; c < inputFrameSize; c++) {
-		size_t kw, x;
-		size_t ix = 0;
+		int64_t kw, x;
+		int64_t ix = 0;
 
 		for (kw = 0; kw < kW; kw++) {
 			real *src = finput_data
@@ -112,11 +112,11 @@ static void THNN_(unfolded_copy_row)(
 
 // #pragma omp parallel for private(k)
 	for (k = 0; k < inputFrameSize * kW; k++) {
-		size_t c = k / kW;
-		size_t rest = k % kW;
-		size_t kw = rest % kW;
-		size_t x;
-		size_t ix;
+		int64_t c = k / kW;
+		int64_t rest = k % kW;
+		int64_t kw = rest % kW;
+		int64_t x;
+		int64_t ix;
 		real *dst = finput_data + c * (kW * nOutputFrame) + kw * (nOutputFrame);
 		real *src = input_data + c * (nInputFrame);
 
@@ -436,10 +436,6 @@ void THNN_(TemporalRowConvolution_accGradParameters)(
 
 	THNN_(TemporalRowConvolution_shapeCheck)
 	        (state, input, gradOutput, gradWeight, gradBias, kW, dW, padW);
-
-	int64_t inputFrameSize = gradWeight->size[0];
-	int64_t nInputFrame = input->size[ndim - 1];
-	int64_t nOutputFrame = (nInputFrame + 2 * padW - kW) / dW + 1;
 
 	if (ndim == 2) {
 		THNN_(TemporalRowConvolution_accGradParameters_frame)(

--- a/aten/src/THNN/generic/TemporalUpSamplingNearest.c
+++ b/aten/src/THNN/generic/TemporalUpSamplingNearest.c
@@ -45,7 +45,7 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   if (input->nDimension == 2) {
     THTensor_(resize2d)(output,
 			THTensor_(size)(input, 0),
-      outputWidth);    
+      outputWidth);
   } else {
     THTensor_(resize3d)(output,
 			THTensor_(size)(input, 0),
@@ -60,7 +60,7 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   int idim = input->nDimension;
   int osz0 = output->size[0];
   int osz1 = output->size[1];
-  int osz2 = 1;  
+  int osz2 = 1;
   if (idim > 2) {
     osz2 = output->size[2];
   }
@@ -135,7 +135,7 @@ void THNN_(TemporalUpSamplingNearest_updateGradInput)(
   real *pout = THTensor_(data)(gradOutput);
 
   // perform the upsampling
-  int i0, i1, i2, isrc, idst, x, y;
+  int i0, i1, i2, isrc, idst, x;
   int iin[3];  // Input indices
   int iout[3];  // Output indices
 

--- a/aten/src/THNN/generic/Threshold.c
+++ b/aten/src/THNN/generic/Threshold.c
@@ -39,7 +39,6 @@ void THNN_(Threshold_updateGradInput)(
           bool inplace)
 {
   real threshold = TH_CONVERT_ACCREAL_TO_REAL(threshold_);
-  real val = TH_CONVERT_ACCREAL_TO_REAL(val_);
   THNN_CHECK_NELEMENT(input, gradOutput);
   if (inplace)
   {

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -505,8 +505,6 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
           int pW,
           int pH)
 {
-  int nOutputPlane = (int)weight->size[0];
-
   THNN_(VolumetricConvolutionMM_shapeCheck)(
         state, input, gradOutput, weight, NULL,
         kT, kW, kH, dT, dW, dH, pT, pW, pH, 0);
@@ -615,7 +613,6 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
           accreal scale_)
 {
   real scale = TH_CONVERT_ACCREAL_TO_REAL(scale_);
-  int nOutputPlane = (int)gradWeight->size[0];
 
   THNN_(VolumetricConvolutionMM_shapeCheck)(
         state, input, gradOutput, gradWeight, gradBias,

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -176,14 +176,14 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
     for (int d = 0; d < nDimI; d++) {
       int64_t max_index_in_dim = THTensor_fastGet1d(max_indices, d);
       int64_t dim_size = sizes->data[d];
-      THArgCheck(max_index_in_dim <= dim_size, 2, 
+      THArgCheck(max_index_in_dim <= dim_size, 2,
           "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
           d, (long long)dim_size, (long long)max_index_in_dim);
     }
     for (int d = 0; d < nDimV; d++) {
       int64_t values_size = THTensor_(size)(values, d + 1);
       int64_t specified_size = sizes->data[nDimI + d];
-      THArgCheck(values_size <= specified_size, 2, 
+      THArgCheck(values_size <= specified_size, 2,
           "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
           d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
     }
@@ -353,7 +353,6 @@ void THSTensor_(copy)(THSTensor *self, THSTensor *src) {
 // In place transpose
 void THSTensor_(transpose)(THSTensor *self, int d1, int d2) {
   int64_t nDimI = THSTensor_(nDimensionI)(self);
-  int64_t nDimV = THSTensor_(nDimensionV)(self);
   THArgCheck(d1 < nDimI && d2 < nDimI, 0, "Transposed dimensions should be sparse. Got nDimI: %" PRId64 ", d1: %" PRId64 ", d2: %" PRId64, nDimI, d1, d2);
   THLongTensor *indices = THSTensor_(newIndices)(self);
   ptrdiff_t i;
@@ -497,7 +496,6 @@ void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask) {
   }
   int64_t nDim = THTensor_(nDimension)(t);
   int64_t nDimI = THSTensor_(nDimensionI)(mask);
-  int64_t nDimV = THSTensor_(nDimensionV)(mask);
   THLongTensor *mask_indices_ = THSTensor_(newIndices)(mask);
   THTensor *mask_values_ = THSTensor_(newValues)(mask);
   THTensor *r_values_ = THTensor_(new)();

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -129,7 +129,6 @@ void THSTensor_(cadd)(THSTensor *r_, THSTensor *t, real value, THSTensor *src) {
   ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz, max_nnz = t_nnz + s_nnz;
   int t_coalesced = t->coalesced, s_coalesced = src->coalesced;
   int64_t nDimI = THSTensor_(nDimensionI)(src);
-  int64_t nDimV = THSTensor_(nDimensionV)(src);
   THLongTensor *t_indices_ = THSTensor_(newIndices)(t);
   THTensor *t_values_ = THSTensor_(newValues)(t);
   THLongTensor *src_indices_ = THSTensor_(newIndices)(src);
@@ -216,7 +215,6 @@ void THSTensor_(cmul)(THSTensor *r_, THSTensor *t_, THSTensor *src_) {
   ptrdiff_t t_nnz = t->nnz, s_nnz = src->nnz;
   ptrdiff_t max_nnz = t_nnz < s_nnz ? t_nnz : s_nnz;
   int64_t nDimI = THSTensor_(nDimensionI)(src);
-  int64_t nDimV = THSTensor_(nDimensionV)(src);
   THLongTensor *t_indices_ = THSTensor_(newIndices)(t);
   THTensor *t_values_ = THSTensor_(newValues)(t);
   THLongTensor *src_indices_ = THSTensor_(newIndices)(src);
@@ -525,7 +523,6 @@ void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sp
   THLongTensor  *indices = THSTensor_(newIndices)(sparse);
   THTensor      *values = THSTensor_(newValues)(sparse);
   THLongStorage *storage = THSTensor_(newSizeOf)(sparse);
-  int64_t       *sizes = storage->data;
   int64_t       nDim = THTensor_(nDimension)(dense);
   int64_t       nDimI = THSTensor_(nDimensionI)(sparse);
 


### PR DESCRIPTION
Compiling from scratch prints a lot of warnings from TH files, making it impossible to identify which one is the error that stops compilation. Most of these warnings are unused variables, and comparing signed and unsigned types. This PR fixes all of compile warnings except for unknown pragma, which is suppressed via `-Wno-unknown-pragmas`.