### PR TITLE
 add reduce=True arg to SoftMarginLoss

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -51,10 +51,10 @@
   scalar_check:
     output: reduce || self_->isScalar()
 
-- name: soft_margin_loss(Tensor self, Tensor target, bool size_average=true)
+- name: soft_margin_loss(Tensor self, Tensor target, bool size_average=true, bool reduce=true)
   cname: SoftMarginCriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 # Activation functions
 

--- a/aten/src/THCUNN/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/SoftMarginCriterion.cu
@@ -18,7 +18,7 @@ struct softmargin_functor
   }
 };
 
-template <typename Dtype>
+template <typename Dtype, typename Acctype>
 struct softmargin_no_reduce_functor
 {
   __host__ __device__ void operator()(
@@ -26,7 +26,8 @@ struct softmargin_no_reduce_functor
     const Dtype *y,
     Dtype *out) const
   {
-    *out = THCNumerics<Dtype>::log(ScalarConvert<int, Dtype>::to(1) + THCNumerics<Dtype>::exp(-*x * *y));
+    *out = ScalarConvert<Acctype, Dtype>::to(log(ScalarConvert<int, Acctype>::to(1)
+                                             + exp(ScalarConvert<Dtype, Acctype>::to(-*x) * *y)));
   }
 };
 
@@ -46,7 +47,7 @@ struct softmargin_updateGradInput_functor
     }
 };
 
-template <typename Dtype>
+template <typename Dtype, typename Acctype>
 struct softmargin_updateGradInput_no_reduce_functor
 {
   __forceinline__ __host__ __device__ void operator()(
@@ -54,8 +55,8 @@ struct softmargin_updateGradInput_no_reduce_functor
       const Dtype *y,
       Dtype *gradInput) const
   {
-      Dtype temp = exp(-*x * *y);
-      *gradInput = -*y * temp / (ScalarConvert<int, Dtype>::to(1) + temp);
+      Acctype temp = exp(ScalarConvert<Dtype, Acctype>::to(-*x) * *y);
+      *gradInput = ScalarConvert<Acctype, Dtype>::to(-*y * temp / (ScalarConvert<int, Acctype>::to(1) + temp));
   }
 };
 

--- a/aten/src/THCUNN/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/SoftMarginCriterion.cu
@@ -18,19 +18,45 @@ struct softmargin_functor
   }
 };
 
+template <typename Dtype>
+struct softmargin_no_reduce_functor
+{
+  __host__ __device__ void operator()(
+    const Dtype *x,
+    const Dtype *y,
+    Dtype *out) const
+  {
+    *out = THCNumerics<Dtype>::log(ScalarConvert<int, Dtype>::to(1) + THCNumerics<Dtype>::exp(-*x * *y));
+  }
+};
+
 template <typename Dtype, typename Acctype>
 struct softmargin_updateGradInput_functor
 {
   const Acctype norm;
+  const Dtype gradOutput;
 
-  softmargin_updateGradInput_functor(Acctype norm_) :
-    norm(norm_) {}
+  softmargin_updateGradInput_functor(Acctype norm_, Dtype gradOutput_) :
+    norm(norm_), gradOutput(gradOutput_) {}
 
   __host__ __device__ Dtype operator()(const Dtype& x, const Dtype& y) const
     {
       Acctype temp = exp(ScalarConvert<Dtype, Acctype>::to(-x)*y);
-      return ScalarConvert<Acctype, Dtype>::to(-y*temp*norm/(ScalarConvert<int, Acctype>::to(1) + temp));
+      return ScalarConvert<Acctype, Dtype>::to(-y*temp*norm/(ScalarConvert<int, Acctype>::to(1) + temp) * gradOutput);
     }
+};
+
+template <typename Dtype>
+struct softmargin_updateGradInput_no_reduce_functor
+{
+  __forceinline__ __host__ __device__ void operator()(
+      const Dtype *x,
+      const Dtype *y,
+      Dtype *gradInput) const
+  {
+      Dtype temp = exp(-*x * *y);
+      *gradInput = -*y * temp / (ScalarConvert<int, Dtype>::to(1) + temp);
+  }
 };
 
 #include "generic/SoftMarginCriterion.cu"

--- a/aten/src/THCUNN/generic/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/SoftMarginCriterion.cu
@@ -2,22 +2,32 @@
 #define THC_GENERIC_FILE "generic/SoftMarginCriterion.cu"
 #else
 
+#include "THCApply.cuh"
+
 void THNN_(SoftMarginCriterion_updateOutput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
            THCTensor *output,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCTensor_(resize1d)(state, output, 1);
-  THCUNN_assertSameGPU(state, 2, input, target);
-  accreal sum;
+  THCUNN_assertSameGPU(state, 3, input, target, output);
 
+  if (!reduce) {
+    THCTensor_(resizeAs)(state, output, input);
+    THC_pointwiseApply3(state, input, target, output,
+        softmargin_no_reduce_functor<real>());
+    return;
+  }
+
+  accreal sum;
   ptrdiff_t size = THCTensor_(nElement)(state, input);
 
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);
+  THCTensor_(resize1d)(state, output, 1);
 
   thrust::device_ptr<real> input_data(THCTensor_(data)(state, input));
   thrust::device_ptr<real> target_data(THCTensor_(data)(state, target));
@@ -36,11 +46,23 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
-           bool sizeAverage)
+           bool sizeAverage,
+           bool reduce)
 {
   THCUNN_check_nElement(state, input, target);
-  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
+
+  THCTensor_(resizeAs)(state, gradInput, input);
+
+  if (!reduce) {
+    THCUNN_check_nElement(state, gradOutput, input);
+    THC_pointwiseApply3(state, input, target, gradInput,
+        softmargin_updateGradInput_no_reduce_functor<real>());
+    THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
+    return;
+  }
 
   ptrdiff_t size = THCTensor_(nElement)(state, input);
   accreal norm = (sizeAverage ? 1./size : 1.);
@@ -48,13 +70,13 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
   input = THCTensor_(newContiguous)(state, input);
   target = THCTensor_(newContiguous)(state, target);
 
-  THCTensor_(resizeAs)(state, gradInput, input);
 
   thrust::device_ptr<real> input_data(THCTensor_(data)(state, input));
   thrust::device_ptr<real> target_data(THCTensor_(data)(state, target));
   thrust::device_ptr<real> gradInput_data(THCTensor_(data)(state, gradInput));
 
-  thrust::transform(input_data, input_data+size, target_data, gradInput_data, softmargin_updateGradInput_functor<real, accreal>(norm));
+  thrust::transform(input_data, input_data+size, target_data, gradInput_data,
+                    softmargin_updateGradInput_functor<real, accreal>(norm, THCTensor_(get1d)(state, gradOutput, 0)));
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, target);

--- a/aten/src/THCUNN/generic/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/SoftMarginCriterion.cu
@@ -12,13 +12,13 @@ void THNN_(SoftMarginCriterion_updateOutput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 3, input, target, output);
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
     THC_pointwiseApply3(state, input, target, output,
-        softmargin_no_reduce_functor<real>());
+        softmargin_no_reduce_functor<real, accreal>());
     return;
   }
 
@@ -51,15 +51,15 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
 
   THCTensor_(resizeAs)(state, gradInput, input);
 
   if (!reduce) {
-    THCUNN_check_nElement(state, gradOutput, input);
+    THCUNN_check_shape(state, gradOutput, input);
     THC_pointwiseApply3(state, input, target, gradInput,
-        softmargin_updateGradInput_no_reduce_functor<real>());
+        softmargin_updateGradInput_no_reduce_functor<real, accreal>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
     return;
   }

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -1117,14 +1117,17 @@ TH_API void THNN_(SoftMarginCriterion_updateOutput)(
                   THCTensor *input,
                   THCTensor *target,
                   THCTensor *output,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(SoftMarginCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
-                  bool sizeAverage);
+                  bool sizeAverage,
+                  bool reduce);
 
 TH_API void THNN_(SoftMax_updateOutput)(
                   THCState *state,

--- a/aten/src/THNN/generic/SoftMarginCriterion.c
+++ b/aten/src/THNN/generic/SoftMarginCriterion.c
@@ -10,13 +10,13 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   bool sizeAverage,
   bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
 
   if (!reduce) {
     THTensor_(resizeAs)(output, input);
 
     TH_TENSOR_APPLY3(real, input, real, target, real, output,
-                     *output_data = log(1. + exp(-*input_data* *target_data));)
+                     *output_data = log(1. + exp(-*input_data * *target_data));)
     return;
   }
 
@@ -44,11 +44,11 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
   bool sizeAverage,
   bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
   THTensor_(resizeAs)(gradInput, input);
 
   if (!reduce) {
-    THNN_CHECK_NELEMENT(gradOutput, input);
+    THNN_CHECK_SHAPE(gradOutput, input);
 
     TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
                      real z = exp(-*target_data * *input_data);

--- a/aten/src/THNN/generic/SoftMarginCriterion.c
+++ b/aten/src/THNN/generic/SoftMarginCriterion.c
@@ -7,9 +7,19 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   THTensor *input,
   THTensor *target,
   THTensor *output,
-  bool sizeAverage)
+  bool sizeAverage,
+  bool reduce)
 {
   THNN_CHECK_NELEMENT(input, target);
+
+  if (!reduce) {
+    THTensor_(resizeAs)(output, input);
+
+    TH_TENSOR_APPLY3(real, input, real, target, real, output,
+                     *output_data = log(1. + exp(-*input_data* *target_data));)
+    return;
+  }
+
   THTensor_(resize1d)(output, 1);
 
   real sum;
@@ -29,16 +39,29 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
   THNNState *state,
   THTensor *input,
   THTensor *target,
+  THTensor *gradOutput,
   THTensor *gradInput,
-  bool sizeAverage)
+  bool sizeAverage,
+  bool reduce)
 {
   THNN_CHECK_NELEMENT(input, target);
+  THTensor_(resizeAs)(gradInput, input);
+
+  if (!reduce) {
+    THNN_CHECK_NELEMENT(gradOutput, input);
+
+    TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
+                     real z = exp(-*target_data * *input_data);
+                     *gradInput_data = -*target_data * z/(1. + z);)
+    THTensor_(cmul)(gradInput, gradInput, gradOutput);
+    return;
+  }
+
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
-  THTensor_(resizeAs)(gradInput, input);
   TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
                    real z = exp(-*target_data * *input_data);
-                   *gradInput_data = -norm*(*target_data)*z/(1. + z);)
+                   *gradInput_data = -norm*(*target_data)*z/(1. + z) * THTensor_fastGet1d(gradOutput, 0);)
 }
 
 #endif

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -327,14 +327,17 @@ TH_API void THNN_(SoftMarginCriterion_updateOutput)(
           THTensor *input,
           THTensor *target,
           THTensor *output,
-          bool sizeAverage);
+          bool sizeAverage,
+          bool reduce);
 
 TH_API void THNN_(SoftMarginCriterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
-          bool sizeAverage);
+          bool sizeAverage,
+          bool reduce);
 
 TH_API void THNN_(MSECriterion_updateOutput)(
           THNNState *state,

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -705,8 +705,8 @@ criterion_tests = [
     ),
     dict(
         module_name='MultiLabelSoftMarginLoss',
-        input_size=(5, 10),
-        target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
+        input_size=(10,),
+        target_fn=lambda: torch.rand(10).mul(2).floor(),
         check_gradgrad=False,
     ),
     dict(

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -491,6 +491,10 @@ def hingeembeddingloss_reference(input, target, margin=1.0, size_average=True, r
     margin_clamp = (margin - input).clamp(min=0).type_as(input)
     output = torch.where(target == 1, input, margin_clamp)
 
+
+def softmarginloss_reference(input, target, size_average=True, reduce=True):
+    output = (1 + (-input * target).exp()).log()
+
     if reduce and size_average:
         return output.mean()
     elif reduce:
@@ -505,6 +509,7 @@ loss_reference_fns = {
     'SmoothL1Loss': smoothl1loss_reference,
     'MultiLabelMarginLoss': multilabelmarginloss_reference,
     'HingeEmbeddingLoss': hingeembeddingloss_reference,
+    'SoftMarginLoss': softmarginloss_reference,
 }
 
 
@@ -744,6 +749,8 @@ criterion_tests = [
         module_name='SoftMarginLoss',
         input_size=(5, 5),
         target_fn=lambda: torch.randn(5, 5).sign(),
+        reference_fn=lambda i, t, m:
+            softmarginloss_reference(i, t, size_average=get_size_average(m)),
         check_no_size_average=True,
     ),
     dict(

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -491,6 +491,12 @@ def hingeembeddingloss_reference(input, target, margin=1.0, size_average=True, r
     margin_clamp = (margin - input).clamp(min=0).type_as(input)
     output = torch.where(target == 1, input, margin_clamp)
 
+    if reduce and size_average:
+        return output.mean()
+    elif reduce:
+        return output.sum()
+    return output
+
 
 def softmarginloss_reference(input, target, size_average=True, reduce=True):
     output = (1 + (-input * target).exp()).log()

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -710,8 +710,8 @@ criterion_tests = [
     ),
     dict(
         module_name='MultiLabelSoftMarginLoss',
-        input_size=(10,),
-        target_fn=lambda: torch.rand(10).mul(2).floor(),
+        input_size=(5, 10),
+        target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
         check_gradgrad=False,
     ),
     dict(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4847,6 +4847,15 @@ def hingeembeddingloss_margin_no_reduce_test():
         input_fn=lambda: torch.randn(10),
         reference_fn=lambda i, _:
             loss_reference_fns['HingeEmbeddingLoss'](i, t.type_as(i), margin=0.5, reduce=False),
+
+
+def softmarginloss_no_reduce_test():
+    t = Variable(torch.randn(10))
+    return dict(
+        fullname='SoftMarginLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.soft_margin_loss(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.randn(10),
         check_no_size_average=True,
         pickle=False)
 
@@ -4883,6 +4892,7 @@ new_module_tests = [
     multilabelmarginloss_no_reduce_test(),
     hingeembeddingloss_no_reduce_test(),
     hingeembeddingloss_margin_no_reduce_test(),
+    softmarginloss_no_reduce_test(),
     dict(
         module_name='BatchNorm1d',
         constructor_args=(10,),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4857,7 +4857,7 @@ def softmarginloss_no_reduce_test():
             lambda i: F.soft_margin_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(10),
         reference_fn=lambda i, _:
-            loss_reference_fns['SoftMarginLoss'](i, t.data.type_as(i), reduce=False),
+            loss_reference_fns['SoftMarginLoss'](i, t.type_as(i), reduce=False),
         check_no_size_average=True,
         pickle=False)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4847,6 +4847,8 @@ def hingeembeddingloss_margin_no_reduce_test():
         input_fn=lambda: torch.randn(10),
         reference_fn=lambda i, _:
             loss_reference_fns['HingeEmbeddingLoss'](i, t.type_as(i), margin=0.5, reduce=False),
+        check_no_size_average=True,
+        pickle=False)
 
 
 def softmarginloss_no_reduce_test():

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4856,6 +4856,8 @@ def softmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.soft_margin_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['SoftMarginLoss'](i, t.data.type_as(i), reduce=False),
         check_no_size_average=True,
         pickle=False)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4850,12 +4850,12 @@ def hingeembeddingloss_margin_no_reduce_test():
 
 
 def softmarginloss_no_reduce_test():
-    t = Variable(torch.randn(10))
+    t = Variable(torch.randn(5, 5))
     return dict(
         fullname='SoftMarginLoss_no_reduce',
         constructor=wrap_functional(
             lambda i: F.soft_margin_loss(i, t.type_as(i), reduce=False)),
-        input_fn=lambda: torch.randn(10),
+        input_fn=lambda: torch.randn(5, 5),
         reference_fn=lambda i, _:
             loss_reference_fns['SoftMarginLoss'](i, t.type_as(i), reduce=False),
         check_no_size_average=True,

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -704,8 +704,8 @@
 - name: smooth_l1_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: smooth_l1_loss_backward(grad, self, target, size_average, reduce)
 
-- name: soft_margin_loss_forward(Tensor self, Tensor target, bool size_average)
-  self: soft_margin_loss_backward(self, target, size_average).mul_(grad)
+- name: soft_margin_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
+  self: soft_margin_loss_backward(grad, self, target, size_average, reduce)
 
 - name: elu_forward(Tensor self, Scalar alpha, Scalar scale)
   self: elu_backward(grad, alpha, scale, output)
@@ -1000,8 +1000,9 @@
   grad_output: softmax_backward(grad, self, dim, output)
   self: softmax_double_backward(grad, grad_output, dim, output)
 
-- name: soft_margin_loss_backward(Tensor self, Tensor target, bool size_average)
-  self: soft_margin_loss_double_backward(grad, self, target, size_average)
+- name: soft_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, bool size_average, bool reduce)
+  grad_output: soft_margin_loss_double_backward_grad_output(grad, grad_output, self, target, size_average, reduce)
+  self: soft_margin_loss_double_backward(grad * grad_output, self, target, size_average, reduce)
 
 - name: softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd)
   grad_output: softshrink_backward(grad, self, lambd)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -781,7 +781,7 @@ Tensor soft_margin_loss_double_backward_grad_output(const Tensor & grad, const T
     return soft_margin_loss_backward(grad, input, target, size_average, reduce);
   }
   auto r = soft_margin_loss_backward(ones_like(grad_output), input, target, size_average, true);
-  return (r * grad).sum().view({1});
+  return (r * grad).sum();
 }
 
 Tensor softplus_double_backward(const Tensor & grad, const Tensor & input, Scalar beta, Scalar threshold) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -766,14 +766,22 @@ Tensor mse_loss_double_backward_grad_output(const Tensor & grad, const Tensor & 
   return (r * grad).sum();
 }
 
-Tensor soft_margin_loss_double_backward(const Tensor & grad, const Tensor & input, const Tensor & target, bool size_average) {
+Tensor soft_margin_loss_double_backward(const Tensor & grad, const Tensor & input, const Tensor & target, bool size_average, bool reduce) {
   auto z = (input * -target).exp();
   auto zplus1 = z + 1;
   auto grad_input = grad * (target * target) * z / (zplus1 * zplus1);
-  if (size_average) {
+  if (size_average && reduce) {
     grad_input /= input.numel();
   }
   return grad_input;
+}
+
+Tensor soft_margin_loss_double_backward_grad_output(const Tensor & grad, const Tensor & grad_output, const Tensor & input, const Tensor & target, bool size_average, bool reduce) {
+  if (!reduce) {
+    return soft_margin_loss_backward(grad, input, target, size_average, reduce);
+  }
+  auto r = soft_margin_loss_backward(ones_like(grad_output), input, target, size_average, true);
+  return (r * grad).sum().view({1});
 }
 
 Tensor softplus_double_backward(const Tensor & grad, const Tensor & input, Scalar beta, Scalar threshold) {

--- a/torch/legacy/nn/SoftMarginCriterion.py
+++ b/torch/legacy/nn/SoftMarginCriterion.py
@@ -17,17 +17,21 @@ class SoftMarginCriterion(Criterion):
             input,
             target,
             self.output_tensor,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         self.output = self.output_tensor[0]
         return self.output
 
     def updateGradInput(self, input, target):
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.SoftMarginCriterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
-            self.sizeAverage
+            self.sizeAverage,
+            True,  # reduce
         )
         return self.gradInput

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1552,7 +1552,7 @@ See :class:`~torch.nn.MultiLabelMarginLoss` for details.
 """)
 
 soft_margin_loss = _add_docstr(torch._C._nn.soft_margin_loss, r"""
-soft_margin_loss(input, target, size_average=True) -> Variable
+soft_margin_loss(input, target, size_average=True, reduce=True) -> Variable
 
 See :class:`~torch.nn.SoftMarginLoss` for details.
 """)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -646,19 +646,37 @@ class SmoothL1Loss(_Loss):
 
 class SoftMarginLoss(_Loss):
     r"""Creates a criterion that optimizes a two-class classification
-    logistic loss between input `x` (a 2D mini-batch Tensor) and
-    target `y` (which is a tensor containing either `1` or `-1`).
+    logistic loss between input tensor `x` and target tensor `y` (containing 1 or
+    -1).
 
     ::
 
         loss(x, y) = sum_i (log(1 + exp(-y[i]*x[i]))) / x.nelement()
 
-    The normalization by the number of elements in the input can be disabled by
-    setting `self.size_average` to ``False``.
+    Args:
+        size_average (bool, optional): By default, the losses are averaged over
+            observations for each minibatch. However, if the field :attr:`size_average`
+            is set to ``False``, the losses are instead summed for each minibatch.
+            Default: ``True``
+        reduce (bool, optional): By default, the losses are averaged or summed over
+            observations for each minibatch depending on :attr:`size_average`. When
+            :attr:`reduce` is ``False``, returns a loss per batch element instead and
+            ignores :attr:`size_average`. Default: ``True``
+
+    Shape:
+        - Input: Tensor of arbitrary shape.
+        - Target: Same shape as input.
+        - Output: scalar. If reduce is ``False``, then same shape as the input
+
     """
+    def __init__(self, size_average=True, reduce=True):
+        super(SoftMarginLoss, self).__init__(size_average)
+        self.reduce = reduce
+
     def forward(self, input, target):
         _assert_no_grad(target)
-        return F.soft_margin_loss(input, target, size_average=self.size_average)
+        return F.soft_margin_loss(input, target, size_average=self.size_average,
+                                  reduce=self.reduce)
 
 
 class CrossEntropyLoss(_WeightedLoss):


### PR DESCRIPTION
As per #264. When reduce is False, SoftMarginLoss outputs a loss per sample in minibatch. When reduce is True (default), the current behavior is kept.

Test Plan
test/run_test.sh
Added unit test for the reduce=False case. Added a reference function.