### PR TITLE
Restore torch.mm behavior for sparse variables

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3108,7 +3108,7 @@
     - THTensor* vec
 ]]
 [[
-  name: mm
+  name: _mm
   variants:
     - method
     - function
@@ -3131,15 +3131,6 @@
         - argument 0
         - CONSTANT AS_REAL(1)
         - THTensor* self
-        - THTensor* mat2
-    - cname: spaddmm
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - CONSTANT AS_REAL(0)
-        - argument 0
-        - CONSTANT AS_REAL(1)
-        - THSTensor* self
         - THTensor* mat2
 ]]
 [[

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -74,14 +74,14 @@ Tensor& ger_out(Tensor& result, const Tensor& self, const Tensor& vec2) {
 
 Tensor mm(const Tensor& self, const Tensor& mat2) {
   if (self.is_sparse()) {
-    return mat2.type().addmm(mat2.type().zeros({1}), self, mat2, 0, 1);
+    return mat2.type().addmm(mat2.type().zeros({}), self, mat2, 0, 1);
   }
   return self.type()._mm(self, mat2);
 }
 
 Tensor& mm_out(Tensor& result, const Tensor& self, const Tensor& mat2) {
   if (self.is_sparse()) {
-    return mat2.type().addmm_out(result, mat2.type().zeros({1}), self, mat2, 0, 1);
+    return mat2.type().addmm_out(result, mat2.type().zeros({}), self, mat2, 0, 1);
   }
   return self.type()._mm_out(result, self, mat2);
 }

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -72,6 +72,20 @@ Tensor& ger_out(Tensor& result, const Tensor& self, const Tensor& vec2) {
   return at::_ger_out(result, self, vec2);
 }
 
+Tensor mm(const Tensor& self, const Tensor& mat2) {
+  if (self.is_sparse()) {
+    return mat2.type().addmm(mat2.type().zeros({1}), self, mat2, 0, 1);
+  }
+  return self.type()._mm(self, mat2);
+}
+
+Tensor& mm_out(Tensor& result, const Tensor& self, const Tensor& mat2) {
+  if (self.is_sparse()) {
+    return mat2.type().addmm_out(result, mat2.type().zeros({1}), self, mat2, 0, 1);
+  }
+  return self.type()._mm_out(result, self, mat2);
+}
+
 Tensor mv(const Tensor& self, const Tensor& vec) {
   check_1d(vec, "vec", "mv");
   return at::_mv(self, vec);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -212,6 +212,11 @@
 - func: max_pool1d(Tensor self, IntList[1] kernel_size, IntList[1] stride={}, IntList[1] padding=0, IntList[1] dilation=1, bool ceil_mode=false) -> (Tensor, Tensor)
   variants: function
 
+- func: mm(Tensor self, Tensor mat2) -> Tensor
+
+- func: mm_out(Tensor result, Tensor self, Tensor mat2) -> Tensor
+  variants: function
+
 - func: mv(Tensor self, Tensor vec) -> Tensor
 
 - func: mv_out(Tensor result, Tensor self, Tensor vec) -> Tensor

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -744,6 +744,8 @@ class TestSparse(TestCase):
         to_test_mixed = {
             'addmm': lambda sp, de: de.addmm(sp, de),
             'addmm_': lambda sp, de: de.addmm(sp, de),
+            'mm': lambda sp, de: torch.mm(sp, de),
+            'mm_out': lambda sp, de: torch.mm(sp, de, out=de),
         }
 
         i = self.IndexTensor([[0, 0, 1, 2, 2], [1, 2, 1, 0, 1]])

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -401,7 +401,7 @@
   self: grad.clone().masked_fill_(self >= other, 0)
   other: grad.clone().masked_fill_(self < other, 0)
 
-- name: mm(Tensor self, Tensor mat2)
+- name: _mm(Tensor self, Tensor mat2)
   self: mm_mat1_backward(grad, mat2, self.sizes(), self.strides(), 1)
   mat2: mm_mat2_backward(grad, self, mat2.sizes(), mat2.strides(), 1)
 


### PR DESCRIPTION
`torch.mm(sparse, dense) -> dense` works for tensors. This PR makes it work for variables as well.

I renamed `mm` to `_mm` in Declarations.cwrap and wrote a native `mm` function that wraps `_mm` for the dense case and `addmm` for the sparse case.

cc @colesbury 

### Test Plan
Unit tests