### PR TITLE
Refactor CPU and GPU perf tests

### DIFF
--- a/.jenkins/perf_test/common.sh
+++ b/.jenkins/perf_test/common.sh
@@ -1,0 +1,16 @@
+run_test () {
+  rm -rf test_tmp/ && mkdir test_tmp/ && cd test_tmp/
+  "$@"
+  cd .. && rm -rf test_tmp/
+}
+
+get_runtime_of_command () {
+  TIMEFORMAT=%R
+
+  # runtime=$( { time ($1 &> /dev/null); } 2>&1 1>/dev/null)
+  runtime=$( { time $1; } 2>&1 1>/dev/null)
+  runtime=${runtime#+++ $1}
+  runtime=$(python -c "print($runtime)")
+
+  echo $runtime
+}

--- a/.jenkins/perf_test/compare_with_baseline.py
+++ b/.jenkins/perf_test/compare_with_baseline.py
@@ -1,0 +1,35 @@
+import sys
+import json
+import numpy
+from scipy import stats
+
+with open('../perf_test_numbers.json') as data_file:
+    data = json.load(data_file)
+
+test_name = sys.argv[1]
+
+mean = float(data[test_name]['mean'])
+sigma = float(data[test_name]['sigma'])
+
+print("population mean: ", mean)
+print("population sigma: ", sigma)
+
+sample_stats_data = json.loads(sys.argv[2])
+
+sample_mean = sample_stats_data['mean']
+sample_sigma = sample_stats_data['sigma']
+
+print("sample mean: ", sample_mean)
+print("sample sigma: ", sample_sigma)
+
+z_value = (sample_mean - mean) / sigma
+
+print("z-value: ", z_value)
+
+if z_value >= 3:
+    raise Exception('''\n
+z-value >= 3, there is >99.7% chance of perf regression.\n
+To reproduce this regression, run `cd .jenkins/perf_test/ && bash ''' + test_name + '''.sh` on your local machine and compare the runtime before/after your code change.
+''')
+else:
+    print("z-value < 3, no perf regression detected.")

--- a/.jenkins/perf_test/get_stats.py
+++ b/.jenkins/perf_test/get_stats.py
@@ -1,0 +1,16 @@
+import sys
+import json
+import numpy
+
+sample_data_list = sys.argv[1:]
+sample_data_list = [float(v.strip()) for v in sample_data_list]
+
+sample_mean = numpy.mean(sample_data_list)
+sample_sigma = numpy.std(sample_data_list)
+
+data = {
+    'mean': sample_mean,
+    'sigma': sample_sigma,
+}
+
+print(json.dumps(data))

--- a/.jenkins/perf_test/perf_test_numbers.json
+++ b/.jenkins/perf_test/perf_test_numbers.json
@@ -1,0 +1,41 @@
+{
+	"base-machine": "Mac Mini with 2.3 GHz i7 processors, 16GB RAM, 250GB SSD",
+	"docker-settings": "4 cores, 8GB RAM",
+	
+	"commit": "92aeca1279265d24493dc6ced7dde9a368faf048",
+
+	"test_cpu_speed_mini_sequence_labeler": {
+		"mean": "2.62557", 
+		"sigma": "0.12167"
+	}, 
+
+	"test_cpu_speed_mnist": {
+		"mean": "18.79468", 
+		"sigma": "2.37561"
+	},
+
+	"test_gpu_speed_mnist": {
+		"mean": "13.76155",
+		"sigma": "0.42087"
+	},
+
+	"test_gpu_speed_word_language_model": {
+		"mean": "115.5332",
+		"sigma": "0.10897"
+	},
+
+	"test_gpu_speed_cudnn_lstm": {
+		"mean": "4.9698",
+		"sigma": "0.03257"
+	},
+
+	"test_gpu_speed_lstm": {
+		"mean": "5.15325",
+		"sigma": "0.0725"
+	},
+
+	"test_gpu_speed_mlstm": {
+		"mean": "4.04270",
+		"sigma": "0.03276"
+	}
+}

--- a/.jenkins/perf_test/test_cpu_speed_mini_sequence_labeler.sh
+++ b/.jenkins/perf_test/test_cpu_speed_mini_sequence_labeler.sh
@@ -1,0 +1,32 @@
+. ./common.sh
+
+test_cpu_speed_mini_sequence_labeler () {
+  echo "Testing: mini sequence labeler, CPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  curl https://gist.githubusercontent.com/yf225/40c0adb8bfb2a7b774fa266fb4bc409e/raw/20c67ebadbd75f41c6c9fd2e00b4b2562b60700a/mini_sequence_labeler.py -O
+  curl https://gist.githubusercontent.com/yf225/592b39ca6a3fc835a4d1532fb1474d26/raw/76f57c198cb7afdc5122e413c2a3023ed024b643/wsj.pkl -O
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=20
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python mini_sequence_labeler.py")
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_cpu_speed_mini_sequence_labeler "$@"
+fi
+

--- a/.jenkins/perf_test/test_cpu_speed_mnist.sh
+++ b/.jenkins/perf_test/test_cpu_speed_mnist.sh
@@ -1,0 +1,41 @@
+. ./common.sh
+
+test_cpu_speed_mnist () {
+  echo "Testing: MNIST, CPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/examples.git -b benchmark_test
+
+  cd examples/mnist
+
+  pip install -r requirements.txt
+
+  # Download data
+  python main.py --epochs 0
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=20
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python main.py --epochs 1 --no-log")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_cpu_speed_mnist "$@"
+fi
+

--- a/.jenkins/perf_test/test_gpu_speed_cudnn_lstm.sh
+++ b/.jenkins/perf_test/test_gpu_speed_cudnn_lstm.sh
@@ -1,0 +1,35 @@
+. ./common.sh
+
+test_gpu_speed_cudnn_lstm () {
+  echo "Testing: CuDNN LSTM, GPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/benchmark.git
+
+  cd benchmark/scripts/
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=5
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python cudnn_lstm.py")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_gpu_speed_cudnn_lstm "$@"
+fi

--- a/.jenkins/perf_test/test_gpu_speed_lstm.sh
+++ b/.jenkins/perf_test/test_gpu_speed_lstm.sh
@@ -1,0 +1,35 @@
+. ./common.sh
+
+test_gpu_speed_lstm () {
+  echo "Testing: LSTM, GPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/benchmark.git
+
+  cd benchmark/scripts/
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=5
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python lstm.py")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_gpu_speed_lstm "$@"
+fi

--- a/.jenkins/perf_test/test_gpu_speed_mlstm.sh
+++ b/.jenkins/perf_test/test_gpu_speed_mlstm.sh
@@ -1,0 +1,35 @@
+. ./common.sh
+
+test_gpu_speed_mlstm () {
+  echo "Testing: MLSTM, GPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/benchmark.git
+
+  cd benchmark/scripts/
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=5
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python mlstm.py")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_gpu_speed_mlstm "$@"
+fi

--- a/.jenkins/perf_test/test_gpu_speed_mnist.sh
+++ b/.jenkins/perf_test/test_gpu_speed_mnist.sh
@@ -1,0 +1,40 @@
+. ./common.sh
+
+test_gpu_speed_mnist () {
+  echo "Testing: MNIST, GPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/examples.git -b benchmark_test
+
+  cd examples/mnist
+
+  pip install -r requirements.txt
+
+  # Download data
+  python main.py --epochs 0
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=5
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python main.py --epochs 1 --no-log")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_gpu_speed_mnist "$@"
+fi

--- a/.jenkins/perf_test/test_gpu_speed_word_language_model.sh
+++ b/.jenkins/perf_test/test_gpu_speed_word_language_model.sh
@@ -1,0 +1,35 @@
+. ./common.sh
+
+test_gpu_speed_word_language_model () {
+  echo "Testing: word language model on Wikitext-2, GPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/examples.git -b benchmark_test
+
+  cd examples/word_language_model
+
+  SAMPLE_ARRAY=()
+  NUM_RUNS=5
+
+  for (( i=1; i<=$NUM_RUNS; i++ )) do
+    runtime=$(get_runtime_of_command "python main.py --cuda --epochs 1")
+    echo $runtime
+    SAMPLE_ARRAY+=(${runtime})
+  done
+
+  cd ../..
+
+  stats=$(python ../get_stats.py ${SAMPLE_ARRAY[@]})
+  echo "Runtime stats in seconds:"
+  echo $stats
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    python ../compare_with_baseline.py ${FUNCNAME[0]} "${stats}"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_gpu_speed_word_language_model "$@"
+fi

--- a/.jenkins/short-perf-test-cpu.sh
+++ b/.jenkins/short-perf-test-cpu.sh
@@ -2,125 +2,20 @@
 
 set -ex
 
+cd .jenkins/perf_test
+
 export PATH=/opt/conda/bin:$PATH
 
 echo "Running CPU perf test for PyTorch..."
-export OMP_NUM_THREADS=4
-export MKL_NUM_THREADS=4
-
-cd test/
-
-# TODO: Move this into its own file
-cat >compare_with_baseline.py << EOL
-
-import sys
-import numpy
-from scipy import stats
-
-mean_values = {
-  "commit": "92aeca1279265d24493dc6ced7dde9a368faf048",
-
-  "test_cpu_speed_mini_sequence_labeler": "2.62557",
-  "test_cpu_speed_mnist": "18.79468",
-}
-
-sigma_values = {
-  "commit": "92aeca1279265d24493dc6ced7dde9a368faf048",
-
-  "test_cpu_speed_mini_sequence_labeler": "0.12167",
-  "test_cpu_speed_mnist": "2.37561",
-}
-
-mean = float(mean_values[sys.argv[1]])
-sigma = float(sigma_values[sys.argv[1]])
-
-print("population mean: ", mean)
-print("population sigma: ", sigma)
-
-sample_data_list = sys.argv[2:]
-sample_data_list = [float(v.strip()) for v in sample_data_list]
-
-sample_mean = numpy.mean(sample_data_list)
-
-print("sample mean: ", sample_mean)
-
-z_value = (sample_mean - mean) / sigma
-
-print("z-value: ", z_value)
-
-if z_value >= 3:
-  raise Exception("z-value >= 3, there is 99.7% chance of perf regression.")
-else:
-  print("z-value < 3, no perf regression detected.")
-
-EOL
-
-run_test () {
-  mkdir test_tmp/ && cd test_tmp/
-  $1
-  cd .. && rm -rf test_tmp/
-}
-
-get_runtime_of_command () {
-  TIMEFORMAT=%R
-
-  # runtime=$( { time ($1 &> /dev/null); } 2>&1 1>/dev/null)
-  runtime=$( { time $1; } 2>&1 1>/dev/null)
-  runtime=${runtime#+++ $1}
-  runtime=$(python -c "print($runtime)")
-
-  echo $runtime
-}
-
-# Define tests
-test_cpu_speed_mini_sequence_labeler () {
-  echo "Testing: mini sequence labeler, CPU"
-
-  curl https://gist.githubusercontent.com/yf225/40c0adb8bfb2a7b774fa266fb4bc409e/raw/20c67ebadbd75f41c6c9fd2e00b4b2562b60700a/mini_sequence_labeler.py -O
-  curl https://gist.githubusercontent.com/yf225/592b39ca6a3fc835a4d1532fb1474d26/raw/76f57c198cb7afdc5122e413c2a3023ed024b643/wsj.pkl -O
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=20
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python mini_sequence_labeler.py")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
-
-test_cpu_speed_mnist () {
-  echo "Testing: MNIST, CPU"
-
-  git clone https://github.com/yf225/examples.git -b benchmark_test
-
-  cd examples/mnist
-
-  pip install -r requirements.txt
-
-  # Download data
-  python main.py --epochs 0
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=20
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python main.py --epochs 1 --no-log")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
 
 echo "ENTERED_USER_LAND"
 
+# Include tests
+. ./test_cpu_speed_mini_sequence_labeler.sh
+. ./test_cpu_speed_mnist.sh
+
 # Run tests
-run_test test_cpu_speed_mini_sequence_labeler
-run_test test_cpu_speed_mnist
+run_test test_cpu_speed_mini_sequence_labeler compare_with_baseline
+run_test test_cpu_speed_mnist compare_with_baseline
 
 echo "EXITED_USER_LAND"

--- a/.jenkins/short-perf-test-gpu.sh
+++ b/.jenkins/short-perf-test-gpu.sh
@@ -2,205 +2,29 @@
 
 set -ex
 
+cd .jenkins/perf_test
+
 export PATH=/opt/conda/bin:$PATH
 
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 echo "Running GPU perf test for PyTorch..."
-export OMP_NUM_THREADS=4
-export MKL_NUM_THREADS=4
-
-cd test/
-
-# TODO: Move this into a separate file
-cat >compare_with_baseline.py << EOL
-
-import sys
-import numpy
-from scipy import stats
-
-mean_values = {
-  "commit": "e2127ef0d24103cc872a64515ce6e54f886941c5",
-
-  "test_gpu_speed_mnist": "13.76155",
-  "test_gpu_speed_word_language_model": "115.5332",
-  "test_gpu_speed_cudnn_lstm": "4.9698",
-  "test_gpu_speed_lstm": "5.15325",
-  "test_gpu_speed_mlstm": "4.04270",
-}
-
-sigma_values = {
-  "commit": "e2127ef0d24103cc872a64515ce6e54f886941c5",
-
-  "test_gpu_speed_mnist": "0.42087",
-  "test_gpu_speed_word_language_model": "0.10897",
-  "test_gpu_speed_cudnn_lstm": "0.03257",
-  "test_gpu_speed_lstm": "0.0725",
-  "test_gpu_speed_mlstm": "0.03276",
-}
-
-mean = float(mean_values[sys.argv[1]])
-sigma = float(sigma_values[sys.argv[1]])
-
-print("baseline mean: ", mean)
-print("baseline sigma: ", sigma)
-
-sample_data_list = sys.argv[2:]
-sample_data_list = [float(v.strip()) for v in sample_data_list]
-
-sample_mean = numpy.mean(sample_data_list)
-sample_sigma = numpy.std(sample_data_list)
-
-print("test mean: ", sample_mean)
-print("test sigma: ", sample_sigma)
-
-z_value = (sample_mean - mean) / sigma
-
-print("z-value: ", z_value)
-
-if z_value >= 3:
-  raise Exception("z-value >= 3, there is 99.7% chance of perf regression.")
-else:
-  print("z-value < 3, no perf regression detected.")
-
-EOL
-
-run_test () {
-  mkdir test_tmp/ && cd test_tmp/
-  $1
-  cd .. && rm -rf test_tmp/
-}
-
-get_runtime_of_command () {
-  TIMEFORMAT=%R
-
-  # runtime=$( { time ($1 &> /dev/null); } 2>&1 1>/dev/null)
-  runtime=$( { time $1; } 2>&1 1>/dev/null)
-  runtime=${runtime#+++ $1}
-  runtime=$(python -c "print($runtime)")
-
-  echo $runtime
-}
-
-# Define tests
-test_gpu_speed_mnist () {
-  echo "Testing: MNIST, GPU"
-
-  git clone https://github.com/yf225/examples.git -b benchmark_test
-
-  cd examples/mnist
-
-  pip install -r requirements.txt
-
-  # Download data
-  python main.py --epochs 0
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=5
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python main.py --epochs 1 --no-log")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
-
-test_gpu_speed_word_language_model () {
-  echo "Testing: word language model on Wikitext-2, GPU"
-
-  git clone https://github.com/yf225/examples.git -b benchmark_test
-
-  cd examples/word_language_model
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=5
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python main.py --cuda --epochs 1")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
-
-test_gpu_speed_cudnn_lstm () {
-  echo "Testing: CuDNN LSTM, GPU"
-
-  git clone https://github.com/yf225/benchmark.git
-
-  cd benchmark/scripts/
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=5
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python cudnn_lstm.py")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
-
-test_gpu_speed_lstm () {
-  echo "Testing: LSTM, GPU"
-
-  git clone https://github.com/yf225/benchmark.git
-
-  cd benchmark/scripts/
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=5
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python lstm.py")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
-
-test_gpu_speed_mlstm () {
-  echo "Testing: MLSTM, GPU"
-
-  git clone https://github.com/yf225/benchmark.git
-
-  cd benchmark/scripts/
-
-  SAMPLE_ARRAY=()
-  NUM_RUNS=5
-
-  for (( i=1; i<=$NUM_RUNS; i++ )) do
-    runtime=$(get_runtime_of_command "python mlstm.py")
-    echo $runtime
-    SAMPLE_ARRAY+=(${runtime})
-  done
-
-  cd ../..
-
-  python ../compare_with_baseline.py ${FUNCNAME[0]} "${SAMPLE_ARRAY[@]}"
-}
 
 echo "ENTERED_USER_LAND"
 
+# Include tests
+. ./test_gpu_speed_mnist.sh
+. ./test_gpu_speed_word_language_model.sh
+. ./test_gpu_speed_cudnn_lstm.sh
+. ./test_gpu_speed_lstm.sh
+. ./test_gpu_speed_mlstm.sh
+
 # Run tests
-run_test test_gpu_speed_mnist
-run_test test_gpu_speed_word_language_model
-run_test test_gpu_speed_cudnn_lstm
-run_test test_gpu_speed_lstm
-run_test test_gpu_speed_mlstm
+run_test test_gpu_speed_mnist compare_with_baseline
+run_test test_gpu_speed_word_language_model compare_with_baseline
+run_test test_gpu_speed_cudnn_lstm compare_with_baseline
+run_test test_gpu_speed_lstm compare_with_baseline
+run_test test_gpu_speed_mlstm compare_with_baseline
 
 echo "EXITED_USER_LAND"


### PR DESCRIPTION
This PR refactors CPU and GPU perf tests to make the structure more clear, and allows for easy reproduction of perf regression by providing a command such as `cd .jenkins/perf_test/ && bash test_cpu_speed_mini_sequence_labeler.sh`.

Partially addressing https://github.com/pytorch/pytorch/issues/4948.