### PR TITLE
Implementation of the cumulative distribution function and its inverse

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2309,6 +2309,28 @@ class TestAgainstScipy(TestCase):
                 self.assertEqual(pytorch_dist.variance, scipy_dist.var(), allow_inf=True, message=pytorch_dist)
                 self.assertEqual(pytorch_dist.stddev, scipy_dist.var() ** 0.5, message=pytorch_dist)
 
+    def test_cdf(self):
+        set_rng_seed(0)  # see Note [Randomized statistical tests]
+        for pytorch_dist, scipy_dist in self.distribution_pairs:
+            samples = pytorch_dist.sample((5,))
+            try:
+                self.assertEqual(pytorch_dist.cdf(samples),
+                                 scipy_dist.cdf(samples),
+                                 message=pytorch_dist)
+            except NotImplementedError:
+                pass
+
+    def test_icdf(self):
+        set_rng_seed(0)  # see Note [Randomized statistical tests]
+        for pytorch_dist, scipy_dist in self.distribution_pairs:
+            samples = Variable(torch.rand((5,) + pytorch_dist.batch_shape))
+            try:
+                self.assertEqual(pytorch_dist.icdf(samples),
+                                 scipy_dist.ppf(samples),
+                                 message=pytorch_dist)
+            except NotImplementedError:
+                pass
+
 
 class TestTransforms(TestCase):
     def setUp(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1185,9 +1185,7 @@ class TestDistributions(TestCase):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):
                 dist = Dist(**param)
-                samples = dist.sample()
-                if not samples.requires_grad:
-                    continue
+                samples = Variable(dist.sample().data, requires_grad=True)
                 try:
                     cdfs = dist.cdf(samples)
                     pdfs = dist.log_prob(samples).exp()
@@ -2413,13 +2411,13 @@ class TestAgainstScipy(TestCase):
 
     def test_mean(self):
         for pytorch_dist, scipy_dist in self.distribution_pairs:
-            if isinstance(pytorch_dist, Cauchy):
+            if isinstance(pytorch_dist, Cauchy):  # Cauchy distribution's mean is nan, skipping check
                 continue
             self.assertEqual(pytorch_dist.mean, scipy_dist.mean(), allow_inf=True, message=pytorch_dist)
 
     def test_variance_stddev(self):
         for pytorch_dist, scipy_dist in self.distribution_pairs:
-            if isinstance(pytorch_dist, Cauchy):
+            if isinstance(pytorch_dist, Cauchy):  # Cauchy distribution's standard deviation is nan, skipping check
                 continue
             if isinstance(pytorch_dist, (Multinomial, OneHotCategorical)):
                 self.assertEqual(pytorch_dist.variance, np.diag(scipy_dist.cov()), message=pytorch_dist)
@@ -2429,7 +2427,6 @@ class TestAgainstScipy(TestCase):
                 self.assertEqual(pytorch_dist.stddev, scipy_dist.var() ** 0.5, message=pytorch_dist)
 
     def test_cdf(self):
-        set_rng_seed(0)  # see Note [Randomized statistical tests]
         for pytorch_dist, scipy_dist in self.distribution_pairs:
             samples = pytorch_dist.sample((5,))
             try:
@@ -2439,7 +2436,6 @@ class TestAgainstScipy(TestCase):
             self.assertEqual(cdf, scipy_dist.cdf(samples), message=pytorch_dist)
 
     def test_icdf(self):
-        set_rng_seed(0)  # see Note [Randomized statistical tests]
         for pytorch_dist, scipy_dist in self.distribution_pairs:
             samples = Variable(torch.rand((5,) + pytorch_dist.batch_shape))
             try:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1158,6 +1158,20 @@ class TestDistributions(TestCase):
             x = Beta(Tensor([1e-6]), Tensor([1e-6])).sample()[0]
             self.assertTrue(np.isfinite(x) and x > 0, 'Invalid Beta.sample(): {}'.format(x))
 
+    def test_cdf_icdf_inverse(self):
+        for Dist, params in EXAMPLES:
+            for i, param in enumerate(params):
+                dist = Dist(**param)
+                samples = dist.sample(sample_shape=(20,))
+                try:
+                    cdf = dist.cdf(samples)
+                    actual = dist.icdf(cdf)
+                except NotImplementedError:
+                    continue
+                self.assertEqual(actual, samples,
+                                 message='{} example {}/{},\
+                                 icdf(cdf(x)) != x'.format(Dist.__name__, i + 1, len(params)))
+
     def test_valid_parameter_broadcasting(self):
         # Test correct broadcasting of parameter sizes for distributions that have multiple
         # parameters.

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -53,5 +53,13 @@ class Cauchy(Distribution):
         self._validate_log_prob_arg(value)
         return -math.log(math.pi) - self.scale.log() - (1 + ((value - self.loc) / self.scale)**2).log()
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        return torch.atan((value - self.loc) / self.scale) / math.pi + 0.5
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        return torch.tan(math.pi * (value - 0.5)) * self.scale + self.loc
+
     def entropy(self):
         return math.log(4 * math.pi) + self.scale.log()

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -101,6 +101,26 @@ class Distribution(object):
         """
         raise NotImplementedError
 
+    def cdf(self, value):
+        """
+        Returns the cumulative density/mass function evaluated at
+        `value`.
+
+        Args:
+            value (Tensor or Variable):
+        """
+        raise NotImplementedError
+
+    def icdf(self, value):
+        """
+        Returns the inverse cumulative density/mass function evaluated at
+        `value`.
+
+        Args:
+            value (Tensor or Variable):
+        """
+        raise NotImplementedError
+
     def enumerate_support(self):
         """
         Returns tensor containing all values supported by a discrete

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -49,5 +49,13 @@ class Exponential(Distribution):
         self._validate_log_prob_arg(value)
         return self.rate.log() - self.rate * value
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        return 1 - torch.exp(-self.rate * value)
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        return -torch.log(1 - value) / self.rate
+
     def entropy(self):
         return 1.0 - torch.log(self.rate)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -55,5 +55,14 @@ class Laplace(Distribution):
         self._validate_log_prob_arg(value)
         return -torch.log(2 * self.scale) - torch.abs(value - self.loc) / self.scale
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        return 0.5 - 0.5 * (value - self.loc).sign() * torch.expm1(-(value - self.loc).abs() / self.scale)
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        term = value - 0.5
+        return self.loc - self.scale * (term).sign() * torch.log1p(-2 * term.abs())
+
     def entropy(self):
         return 1 + torch.log(2 * self.scale)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -55,5 +55,13 @@ class Laplace(Distribution):
         self._validate_log_prob_arg(value)
         return -torch.log(2 * self.scale) - torch.abs(value - self.loc) / self.scale
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        term = torch.exp((value - self.loc) / self.scale)
+        result = value.new()
+        result[value < self.loc] = 0.5 * term
+        result[value >= self.loc] = 1 - 0.5 / term
+        return result
+
     def entropy(self):
         return 1 + torch.log(2 * self.scale)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -55,13 +55,5 @@ class Laplace(Distribution):
         self._validate_log_prob_arg(value)
         return -torch.log(2 * self.scale) - torch.abs(value - self.loc) / self.scale
 
-    def cdf(self, value):
-        self._validate_log_prob_arg(value)
-        term = torch.exp((value - self.loc) / self.scale)
-        result = value.new()
-        result[value < self.loc] = 0.5 * term
-        result[value >= self.loc] = 1 - 0.5 / term
-        return result
-
     def entropy(self):
         return 1 + torch.log(2 * self.scale)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -64,5 +64,13 @@ class Normal(Distribution):
         log_scale = math.log(self.scale) if isinstance(self.scale, Number) else self.scale.log()
         return -((value - self.loc) ** 2) / (2 * var) - log_scale - math.log(math.sqrt(2 * math.pi))
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        return 0.5 * (1 + torch.erf((value - self.loc) * self.scale.reciprocal() / math.sqrt(2)))
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        return self.loc + self.scale * torch.erfinv(2 * value - 1) * math.sqrt(2)
+
     def entropy(self):
         return 0.5 + 0.5 * math.log(2 * math.pi) + torch.log(self.scale)

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -4,11 +4,13 @@ import math
 
 import torch
 from torch.distributions import constraints
-from torch.distributions.distribution import Distribution
+from torch.distributions.exponential import Exponential
+from torch.distributions.transformed_distribution import TransformedDistribution
+from torch.distributions.transforms import AffineTransform, ExpTransform
 from torch.distributions.utils import broadcast_all
 
 
-class Pareto(Distribution):
+class Pareto(TransformedDistribution):
     r"""
     Samples from a Pareto Type 1 distribution.
 
@@ -23,7 +25,6 @@ class Pareto(Distribution):
         scale (float or Tensor or Variable): Scale parameter of the distribution
         alpha (float or Tensor or Variable): Shape parameter of the distribution
     """
-    has_rsample = True
     params = {'alpha': constraints.positive, 'scale': constraints.positive}
 
     def __init__(self, scale, alpha):
@@ -32,7 +33,9 @@ class Pareto(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.scale.size()
-        super(Pareto, self).__init__(batch_shape)
+        base_dist = Exponential(alpha)
+        transforms = [ExpTransform(), AffineTransform(loc=0, scale=scale)]
+        super(Pareto, self).__init__(base_dist, transforms)
 
     @property
     def mean(self):
@@ -49,23 +52,6 @@ class Pareto(Distribution):
     @constraints.dependent_property
     def support(self):
         return constraints.greater_than(self.scale)
-
-    def rsample(self, sample_shape=torch.Size()):
-        shape = self._extended_shape(sample_shape)
-        exp_dist = self.alpha.new(shape).exponential_()
-        return self.scale * torch.exp(exp_dist / self.alpha)
-
-    def log_prob(self, value):
-        self._validate_log_prob_arg(value)
-        return torch.log(self.alpha / value) + self.alpha * (self.scale / value).log()
-
-    def cdf(self, value):
-        self._validate_log_prob_arg(value)
-        return 1 - (self.scale / value).pow(self.alpha)
-
-    def icdf(self, value):
-        self._validate_log_prob_arg(value)
-        return self.scale / (1 - value).pow(self.alpha.reciprocal())
 
     def entropy(self):
         return ((self.scale / self.alpha).log() + (1 + self.alpha.reciprocal()))

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -59,5 +59,13 @@ class Pareto(Distribution):
         self._validate_log_prob_arg(value)
         return torch.log(self.alpha / value) + self.alpha * (self.scale / value).log()
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        return 1 - (self.scale / value).pow(self.alpha)
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        return self.scale / (1 - value).pow(self.alpha.reciprocal())
+
     def entropy(self):
         return ((self.scale / self.alpha).log() + (1 + self.alpha.reciprocal()))

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -29,10 +29,6 @@ class Pareto(TransformedDistribution):
 
     def __init__(self, scale, alpha):
         self.scale, self.alpha = broadcast_all(scale, alpha)
-        if isinstance(scale, Number) and isinstance(alpha, Number):
-            batch_shape = torch.Size()
-        else:
-            batch_shape = self.scale.size()
         base_dist = Exponential(alpha)
         transforms = [ExpTransform(), AffineTransform(loc=0, scale=scale)]
         super(Pareto, self).__init__(base_dist, transforms)

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -74,6 +74,7 @@ class TransformedDistribution(Distribution):
         Scores the sample by inverting the transform(s) and computing the score using the score
         of the base distribution and the log abs det jacobian
         """
+        self.base_dist._validate_log_prob_arg(value)
         event_dim = len(self.event_shape)
         log_prob = 0.0
         y = value
@@ -101,7 +102,6 @@ class TransformedDistribution(Distribution):
         Computes the inverse cumulative distribution function using transform(s) and computing
         the score of the base distribution
         """
-        self.base_dist._validate_log_prob_arg(value)
         value = self.base_dist.icdf(value)
         for transform in self.transforms:
             value = transform(value)

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -85,3 +85,24 @@ class TransformedDistribution(Distribution):
         log_prob += _sum_rightmost(self.base_dist.log_prob(y),
                                    event_dim - len(self.base_dist.event_shape))
         return log_prob
+
+    def cdf(self, value):
+        """
+        Computes the cumulative distribution function by inverting the transform(s) and computing
+        the score of the base distribution
+        """
+        self.base_dist._validate_log_prob_arg(value)
+        for transform in self.transforms[::-1]:
+            value = transform.inv(value)
+        return self.base_dist.cdf(value)
+
+    def icdf(self, value):
+        """
+        Computes the inverse cumulative distribution function using transform(s) and computing
+        the score of the base distribution
+        """
+        self.base_dist._validate_log_prob_arg(value)
+        value = self.base_dist.icdf(value)
+        for transform in self.transforms:
+            value = transform(value)
+        return value

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -63,5 +63,15 @@ class Uniform(Distribution):
         ub = value.lt(self.high).type_as(self.low)
         return torch.log(lb.mul(ub)) - torch.log(self.high - self.low)
 
+    def cdf(self, value):
+        self._validate_log_prob_arg(value)
+        result = (value - self.low) / (self.high - self.low)
+        return result
+
+    def icdf(self, value):
+        self._validate_log_prob_arg(value)
+        result = value * (self.high - self.low) + self.low
+        return result
+
     def entropy(self):
         return torch.log(self.high - self.low)


### PR DESCRIPTION
This PR adds the `.cdf` and `.icdf` methods for distributions. @alicanb implemented these in the `Distribution` base class.

Furthermore, this PR adds these methods for `Exponential`, `Normal`, `Cauchy` and for `TransformedDistribution`. `Pareto` and `Gumbel` are converted to `TransformedDistribution` with base classes as `Exponential` and `Uniform` respectively.

Tests for checking the correctness of `.cdf` and `.icdf` methods have also been added. An autograd based check is added to check the correctness of `.cdf` and `.log_prob` as well (this doesn't depend on `TEST_NUMPY`).

Joint work with @fritzo and @alicanb . Checked and approved by @fritzo .