### PR TITLE
Implement hinge_embedding_loss as a native function.

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -1,0 +1,20 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+
+
+namespace at { namespace native {
+
+Tensor hinge_embedding_loss(const Tensor& self, const Tensor& target, double margin, bool size_average) {
+  auto zeros = at::zeros_like(self);
+  auto margin_clamp = (margin - self).clamp_min_(0);
+  auto output_margin = at::where(target != 1, margin_clamp, zeros);
+  auto output_self = at::where(target != -1, self, zeros);
+  auto output = (output_margin + output_self).sum();
+
+  if (size_average) {
+    output = output / self.numel();
+  }
+  return output;
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -183,6 +183,9 @@
 - func: expand_as(Tensor self, Tensor other) -> Tensor
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
+- func: hinge_embedding_loss(Tensor self, Tensor target, double margin, bool size_average) -> Tensor
+  variants: function
+
 - func: ger(Tensor self, Tensor vec2) -> Tensor
 
 - func: ger_out(Tensor result, Tensor self, Tensor vec2) -> Tensor

--- a/torch/nn/_functions/loss.py
+++ b/torch/nn/_functions/loss.py
@@ -92,65 +92,6 @@ class CosineEmbeddingLoss(Function):
         return gw1, gw2, None, None, None
 
 
-class HingeEmbeddingLoss(Function):
-    @staticmethod
-    def forward(ctx, input, target, margin, size_average):
-        ctx.margin = margin
-        ctx.size_average = size_average
-        buffer = input.new()
-        buffer.resize_as_(input).copy_(input)
-        buffer[torch.eq(target, -1.)] = 0
-        output = buffer.sum()
-
-        buffer.fill_(ctx.margin).add_(-1, input)
-        buffer.clamp_(min=0)
-        buffer[torch.eq(target, 1.)] = 0
-        output += buffer.sum()
-
-        if ctx.size_average:
-            output = output / input.nelement()
-
-        ctx.save_for_backward(input, target)
-        return input.new((output,))
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        input, target = ctx.saved_variables
-        return (HingeEmbeddingLossBackward.apply(input, target, grad_output, ctx.margin, ctx.size_average),
-                None, None, None, None)
-
-
-class HingeEmbeddingLossBackward(Function):
-    @staticmethod
-    def forward(ctx, input, target, grad_output, margin, size_average):
-        ctx.margin = margin
-        ctx.size_average = size_average
-        ctx.save_for_backward(input, target, grad_output)
-        grad_input = input.new().resize_as_(input).copy_(target)
-        grad_input[torch.mul(torch.eq(target, -1), torch.gt(input, ctx.margin))] = 0
-
-        if ctx.size_average:
-            grad_input.mul_(1. / input.nelement())
-
-        if grad_output[0] != 1:
-            grad_input.mul_(grad_output[0])
-
-        return grad_input
-
-    @staticmethod
-    def backward(ctx, ggI):
-        input, target, gO = ctx.saved_variables
-        div_factor = input.nelement() if ctx.size_average else 1
-
-        gI = None
-
-        target_1_mask = Variable(ggI.data.new(ggI.size()).zero_()).masked_fill_(target == 1, 1)
-        target_neg_1_and_input_used = ((target == -1) + ((ctx.margin - input) >= 0) == 2).type_as(ggI)
-        ggO = (ggI * target_1_mask - ggI * target_neg_1_and_input_used).sum() / div_factor
-
-        return gI, None, ggO, None, None
-
-
 class MarginRankingLoss(Function):
     @staticmethod
     def forward(ctx, input1, input2, y, margin, size_average):

--- a/torch/nn/backends/thnn.py
+++ b/torch/nn/backends/thnn.py
@@ -23,8 +23,7 @@ def _initialize_backend():
     from .._functions.rnn import RNN, \
         RNNTanhCell, RNNReLUCell, GRUCell, LSTMCell
     from .._functions.dropout import Dropout, FeatureDropout
-    from .._functions.loss import CosineEmbeddingLoss, \
-        HingeEmbeddingLoss, HingeEmbeddingLossBackward, MarginRankingLoss
+    from .._functions.loss import CosineEmbeddingLoss, MarginRankingLoss
 
     backend.register_function('RNN', RNN)
     backend.register_function('RNNTanhCell', RNNTanhCell)
@@ -35,8 +34,6 @@ def _initialize_backend():
     backend.register_function('Dropout2d', FeatureDropout)
     backend.register_function('Dropout3d', FeatureDropout)
     backend.register_function('CosineEmbeddingLoss', CosineEmbeddingLoss)
-    backend.register_function('HingeEmbeddingLoss', HingeEmbeddingLoss)
-    backend.register_function('HingeEmbeddingLossBackward', HingeEmbeddingLossBackward)
     backend.register_function('MarginRankingLoss', MarginRankingLoss)
     for cls in _thnn_functions:
         name = cls.__name__

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1472,7 +1472,7 @@ def hinge_embedding_loss(input, target, margin=1.0, size_average=True):
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
     """
-    return _functions.loss.HingeEmbeddingLoss.apply(input, target, margin, size_average)
+    return torch._C._VariableFunctions.hinge_embedding_loss(input, target, margin, size_average)
 
 
 multilabel_margin_loss = _add_docstr(torch._C._nn.multilabel_margin_loss, r"""


### PR DESCRIPTION
Hinge embedding currently fails nn tests when WITH_SCALARS is enabled due to some python function implementation details (that should go away soon when variable and tensor are merged).  In addition, this is simpler and faster.