### PR TITLE
Check shape instead of number of elements for some losses

### DIFF
--- a/aten/src/THCUNN/generic/AbsCriterion.cu
+++ b/aten/src/THCUNN/generic/AbsCriterion.cu
@@ -12,7 +12,7 @@ void THNN_(AbsCriterion_updateOutput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 3, input, target, output);
 
   if (!reduce) {
@@ -51,13 +51,13 @@ void THNN_(AbsCriterion_updateGradInput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 4, input, target, gradOutput, gradInput);
 
   THCTensor_(resizeAs)(state, gradInput, input);
 
   if (!reduce) {
-    THCUNN_check_nElement(state, gradOutput, input);
+    THCUNN_check_shape(state, gradOutput, input);
     THC_pointwiseApply3(state, input, target, gradInput,
                         abs_updateGradInput_no_reduce_functor<real>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);

--- a/aten/src/THCUNN/generic/DistKLDivCriterion.cu
+++ b/aten/src/THCUNN/generic/DistKLDivCriterion.cu
@@ -12,7 +12,7 @@ void THNN_(DistKLDivCriterion_updateOutput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 2, input, target);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -56,7 +56,7 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -65,7 +65,7 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
   THCTensor_(resizeAs)(state, gradInput, input);
 
   if (!reduce) {
-    THCUNN_check_nElement(state, gradOutput, input);
+    THCUNN_check_shape(state, gradOutput, input);
     THC_pointwiseApply3(state, target, gradOutput, gradInput,
                         kl_updateGradInput_no_reduce_functor<real>());
     return;

--- a/aten/src/THCUNN/generic/MSECriterion.cu
+++ b/aten/src/THCUNN/generic/MSECriterion.cu
@@ -12,7 +12,7 @@ void THNN_(MSECriterion_updateOutput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 3, input, target, output);
 
   if (reduce) {
@@ -61,7 +61,7 @@ void THNN_(MSECriterion_updateGradInput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
 
   if (reduce) {

--- a/aten/src/THCUNN/generic/SmoothL1Criterion.cu
+++ b/aten/src/THCUNN/generic/SmoothL1Criterion.cu
@@ -12,7 +12,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 3, input, target, output);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -62,7 +62,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
            bool sizeAverage,
            bool reduce)
 {
-  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_shape(state, input, target);
   THCUNN_assertSameGPU(state, 4, input, target, gradInput, gradOutput);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -72,7 +72,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
   THCTensor_(resizeAs)(state, gradInput, input);
 
   if (!reduce) {
-    THCUNN_check_nElement(state, gradOutput, input);
+    THCUNN_check_shape(state, gradOutput, input);
     THC_pointwiseApply3(state, input, target, gradInput,
                         smoothl1_updateGradInput_no_reduce_functor<real>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);

--- a/aten/src/THNN/generic/AbsCriterion.c
+++ b/aten/src/THNN/generic/AbsCriterion.c
@@ -10,7 +10,7 @@ void THNN_(AbsCriterion_updateOutput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
 
   if (!reduce) {
     THTensor_(resizeAs)(output, input);
@@ -41,11 +41,11 @@ void THNN_(AbsCriterion_updateGradInput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
   THTensor_(resizeAs)(gradInput, input);
 
   if (!reduce) {
-    THNN_CHECK_NELEMENT(gradOutput, input);
+    THNN_CHECK_SHAPE(gradOutput, input);
     TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
       *gradInput_data = ((*input_data - *target_data) >= 0 ? 1 : -1);
     );

--- a/aten/src/THNN/generic/DistKLDivCriterion.c
+++ b/aten/src/THNN/generic/DistKLDivCriterion.c
@@ -10,7 +10,7 @@ void THNN_(DistKLDivCriterion_updateOutput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
 
   if (!reduce) {
     THTensor_(resizeAs)(output, input);
@@ -43,11 +43,11 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
   THTensor_(resizeAs)(gradInput, input);
 
   if (!reduce) {
-    THNN_CHECK_NELEMENT(input, gradOutput);
+    THNN_CHECK_SHAPE(input, gradOutput);
     TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, target,
       *gradInput_data = *target_data > 0 ? (-*target_data) * *gradOutput_data : 0;
     );

--- a/aten/src/THNN/generic/MSECriterion.c
+++ b/aten/src/THNN/generic/MSECriterion.c
@@ -10,7 +10,7 @@ void THNN_(MSECriterion_updateOutput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
 
   if (reduce) {
     THTensor_(resize1d)(output, 1);
@@ -45,7 +45,7 @@ void THNN_(MSECriterion_updateGradInput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
   THTensor_(resizeAs)(gradInput, input);
 
   if (reduce) {
@@ -58,7 +58,7 @@ void THNN_(MSECriterion_updateGradInput)(
     return;
   }
 
-  THNN_CHECK_NELEMENT(input, gradOutput);
+  THNN_CHECK_SHAPE(input, gradOutput);
   TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
     *gradInput_data = 2. * (*input_data - *target_data);
   );

--- a/aten/src/THNN/generic/SmoothL1Criterion.c
+++ b/aten/src/THNN/generic/SmoothL1Criterion.c
@@ -10,7 +10,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
 
   if (!reduce) {
     THTensor_(resizeAs)(output, input);
@@ -44,11 +44,11 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
           bool sizeAverage,
           bool reduce)
 {
-  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_SHAPE(input, target);
   THTensor_(resizeAs)(gradInput, input);
 
   if (!reduce) {
-    THNN_CHECK_NELEMENT(gradOutput, input);
+    THNN_CHECK_SHAPE(gradOutput, input);
     TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
       real x = *input_data - *target_data;
       if (x < -1.) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2394,6 +2394,24 @@ class TestNN(NNTestCase):
 
                 hx.sum().backward()
 
+    def _test_loss_equal_input_target_shape(self, cast):
+        # Tests losses whose inputs should have the same size.
+        losses = {
+            'mse_loss': lambda x, y: F.mse_loss(x, y),
+            'l1_loss': lambda x, y: F.l1_loss(x, y),
+            'smooth_l1_loss': lambda x, y: F.smooth_l1_loss(x, y),
+            'kl_div': lambda x, y: F.kl_div(x, y),
+            'poisson_nll_loss': lambda x, y: F.poisson_nll_loss(x, y),
+        }
+
+        input = Variable(cast(torch.randn(3, 5)))
+        target = Variable(cast(torch.randn(5, 3)))
+        for name, fn in losses.items():
+            self.assertRaises(Exception, lambda: fn(input, target))
+
+    def test_loss_equal_input_target_shape(self):
+        self._test_loss_equal_input_target_shape(lambda x: x)
+
     def test_RNN_cell_no_broadcasting(self):
         def test(cell_module, input, hx, input_size, hidden_size):
             cell = cell_module(input_size, hidden_size)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -332,8 +332,6 @@ class MSELoss(_Loss):
             \operatorname{sum}(L),  & \text{if}\; \text{size_average} = \text{False}.
         \end{cases}
 
-    `x` and `y` arbitrary shapes with a total of `n` elements each.
-
     The sum operation still operates over all the elements, and divides by `n`.
 
     The division by `n` can be avoided if one sets the internal variable


### PR DESCRIPTION
Fixes #5007 
Fixes #4938 

Removes the check that the input, target have the same number of elements and adds a shape check instead for the following:
- mse_loss
- l1_loss
- smooth_l1_loss
- kl_div

At some point it would be nice to move these to ATen and perhaps enable broadcasting on them, but right now this is just a bugfix.

### Test Plan
new unit test