### PR TITLE
Add scalar criterion tests

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -372,6 +372,7 @@ loss_reference_fns = {
     'MultiLabelMarginLoss': multilabelmarginloss_reference,
 }
 
+
 # TODO: replace this with torch.rand() when Variables and tensors are merged;
 # this function will correctly handle scalars (i.e. empty tuple sizes) for now.
 def torch_rand(sizes):

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -372,6 +372,22 @@ loss_reference_fns = {
     'MultiLabelMarginLoss': multilabelmarginloss_reference,
 }
 
+# TODO: replace this with torch.rand() when Variables and tensors are merged;
+# this function will correctly handle scalars (i.e. empty tuple sizes) for now.
+def torch_rand(sizes):
+    if len(sizes) == 0:
+        return variable(0).uniform_()
+    else:
+        return Variable(torch.rand(*sizes))
+
+
+# TODO: replace this with torch.randn() when Variables and tensors are merged;
+# this function will correctly handle scalars (i.e. empty tuple sizes) for now.
+def torch_randn(sizes):
+    if len(sizes) == 0:
+        return variable(0).normal_()
+    else:
+        return Variable(torch.randn(*sizes))
 
 criterion_tests = [
     dict(
@@ -440,11 +456,28 @@ criterion_tests = [
         check_no_size_average=True,
     ),
     dict(
+        module_name='KLDivLoss',
+        input_fn=lambda: torch_rand(()).log(),
+        target_fn=lambda: torch_rand(()),
+        reference_fn=lambda i, t, m:
+            kldivloss_reference(i, t, get_size_average(m), reduce=True),
+        check_no_size_average=True,
+        desc='scalar',
+    ),
+    dict(
         module_name='MSELoss',
         input_size=(2, 3, 4, 5),
         target_size=(2, 3, 4, 5),
         reference_fn=lambda i, t, m: (i - t).abs().pow(2).sum() / (i.numel() if get_size_average(m) else 1),
         check_no_size_average=True,
+    ),
+    dict(
+        module_name='MSELoss',
+        input_size=(),
+        target_size=(),
+        reference_fn=lambda i, t, m: (i - t).abs().pow(2).sum() / (i.numel() if get_size_average(m) else 1),
+        check_no_size_average=True,
+        desc='scalar'
     ),
     dict(
         module_name='BCELoss',
@@ -462,6 +495,16 @@ criterion_tests = [
         reference_fn=lambda i, t, m: -((t * i.log() + (1 - t) * (1 - i).log()) * get_weight(m)).sum() /
             (i.numel() if get_size_average(m) else 1),
         desc='weights',
+        check_gradgrad=False,
+    ),
+    dict(
+        module_name='BCELoss',
+        constructor_args_fn=lambda: (torch_rand(()),),
+        input_fn=lambda: torch_rand(()).clamp_(1e-2, 1 - 1e-2),
+        target_fn=lambda: torch_rand(()).gt(0).double(),
+        reference_fn=lambda i, t, m: -((t * i.log() + (1 - t) * (1 - i).log()) * get_weight(m)).sum() /
+            (i.numel() if get_size_average(m) else 1),
+        desc='scalar_weights',
         check_gradgrad=False,
     ),
     dict(
@@ -487,6 +530,14 @@ criterion_tests = [
         input_size=(10,),
         target_fn=lambda: torch.randn(10).gt(0).double().mul_(2).sub(1),
         desc='margin',
+        check_no_size_average=True,
+    ),
+    dict(
+        module_name='HingeEmbeddingLoss',
+        constructor_args=(0.5,),
+        input_size=(),
+        target_fn=lambda: torch_randn(()).gt(0).double().mul_(2).sub(1),
+        desc='scalar_margin',
         check_no_size_average=True,
     ),
     dict(
@@ -535,6 +586,15 @@ criterion_tests = [
         check_no_size_average=True,
         reference_fn=lambda i, t, m:
             smoothl1loss_reference(i, t, size_average=get_size_average(m)),
+    ),
+    dict(
+        module_name='SmoothL1Loss',
+        input_size=(),
+        target_size=(),
+        check_no_size_average=True,
+        reference_fn=lambda i, t, m:
+            smoothl1loss_reference(i, t, size_average=get_size_average(m)),
+        desc='scalar',
     ),
     dict(
         module_name='SoftMarginLoss',
@@ -774,10 +834,7 @@ class TestBase(object):
                     elif torch.is_tensor(sizes):
                         return Variable(sizes.double())
                     else:
-                        if len(sizes) == 0:
-                            return torch.testing.randn_like(variable(0))
-                        else:
-                            return Variable(torch.randn(*sizes))
+                        return torch_randn(sizes)
 
                 self._arg_cache[name] = map_tensor_sizes(self._extra_kwargs[size_name])
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -28,7 +28,7 @@ from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
-    TEST_CUDNN_VERSION, loss_reference_fns, get_size_average, get_weight
+    TEST_CUDNN_VERSION, loss_reference_fns, get_size_average, get_weight, torch_rand, torch_randn
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
     TEST_SCIPY, download_file, IS_WINDOWS, PY3
 
@@ -4288,6 +4288,13 @@ new_criterion_tests = [
         input_fn=lambda: torch.rand(15, 10).clamp_(1e-2, 1 - 1e-2),
         target_fn=lambda: torch.randn(15, 10).gt(0).double(),
         desc='weights'
+    ),
+    dict(
+        module_name='BCEWithLogitsLoss',
+        constructor_args=(torch_rand(()),),
+        input_fn=lambda: torch_rand(()).clamp_(1e-2, 1 - 1e-2),
+        target_fn=lambda: torch_randn(()).gt(0).double(),
+        desc='scalar_weights'
     ),
     dict(
         module_name='NLLLoss',

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1464,6 +1464,9 @@ def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):
 
     See :class:`~torch.nn.MarginRankingLoss` for details.
     """
+    if input1.dim() == 0 or input2.dim() == 0 or target.dim() == 0:
+        raise RuntimeError(("margin_ranking_loss does not support scalars, got sizes: "
+                            "input1: {}, input2: {}, target: {} ".format(input1.size(), input2.size(), target.size())))
     return _functions.loss.MarginRankingLoss.apply(input1, input2, target, margin, size_average)
 
 


### PR DESCRIPTION
Also adds an error message for MarginRankingLoss, which doesn't work with scalars, but currently blows up in the backward.