### PR TITLE
Check that indices and values are on the same device

### DIFF
--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -137,7 +137,10 @@ THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices,
 }
 
 THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes)
-{  // If sizes are not given, it is inferred as max index of each dim.
+{
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
+
+  // If sizes are not given, it is inferred as max index of each dim.
   int64_t nDimI, nDimV;
 
   THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -77,6 +77,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, std::size
       std::vector<at::Tensor> broadcast_values = broadcast(flat_tuple.second, devices);
       results.reserve(devices.size());
       for (std::size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
+        AutoGPU auto_gpu(devices[i]);
         auto & device_outputs = outputs[i];
         auto & inds = broadcast_indices[i];
         auto & vals = broadcast_values[i];


### PR DESCRIPTION
We perform this check in the generic/SparseTensor.cpp (the Python binding),
but the ATen bindings don't use that code path