### PR TITLE
Add Variable.item()

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -796,6 +796,21 @@ Returns True if this object refers to the same ``THTensor`` object from the
 Torch C API as the given tensor.
 """)
 
+# TODO (sgross): move to Tensor once Variable and Tensor are merged
+add_docstr(torch.autograd.Variable.item, r"""
+item() -> number
+
+Returns the value of this tensor as a standard Python number. This only works
+for tensors with one element.
+
+This operation is not differentiable.
+
+Example:
+    >>> x = torch.Tensor([1.0])
+    >>> x.item()
+    1.0
+""")
+
 add_docstr_all('kthvalue',
                r"""
 kthvalue(k, dim=None, keepdim=False) -> (Tensor, LongTensor)


### PR DESCRIPTION
Variable.item() converts one-element tensors to standard Python numbers.
This operates like float(var) or int(var) depending on
the data type of the Variable.

The name is take from NumPy's `ndarray.item()` function:

https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html