### PR TITLE
add reduce=True arg to MultiLabelSoftMarginLoss

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -558,6 +558,8 @@ criterion_tests = [
         module_name='MultiLabelSoftMarginLoss',
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
+        reference_fn=lambda i, t, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum() /
+            (i.numel() if get_size_average(m) else 1),
         check_gradgrad=False,
     ),
     dict(
@@ -565,6 +567,8 @@ criterion_tests = [
         constructor_args_fn=lambda: (torch.rand(10),),
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
+        reference_fn=lambda i, t, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * get_weight(m)).sum() /
+            (i.numel() if get_size_average(m) else 1),
         desc='weights',
         check_gradgrad=False,
     ),

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -558,18 +558,7 @@ criterion_tests = [
         module_name='MultiLabelSoftMarginLoss',
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
-        reference_fn=lambda i, t, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum() /
-            (i.numel() if get_size_average(m) else 1),
-        check_gradgrad=False,
-    ),
-    dict(
-        module_name='MultiLabelSoftMarginLoss',
-        constructor_args_fn=lambda: (torch.rand(10),),
-        input_size=(5, 10),
-        target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
-        reference_fn=lambda i, t, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * get_weight(m)).sum() /
-            (i.numel() if get_size_average(m) else 1),
-        desc='weights',
+        reference_fn=lambda i, t, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()).sum() / i.numel(),
         check_gradgrad=False,
     ),
     dict(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4916,6 +4916,32 @@ def softmarginloss_no_reduce_test():
         pickle=False)
 
 
+def multilabelsoftmarginloss_no_reduce_test():
+    t = Variable(torch.rand(5, 10).mul(2).floor())
+    return dict(
+        fullname='MultiLabelSoftMarginLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduce=False)),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()),
+        check_gradgrad=False,
+        pickle=False)
+
+
+def multilabelsoftmarginloss_weights_no_reduce_test():
+    t = Variable(torch.rand(5, 10).mul(2).floor())
+    weights = Variable(torch.rand(10))
+    return dict(
+        fullname='MultiLabelSoftMarginLoss_weights_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
+                                                    weight=weights.type_as(i), reduce=False)),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights),
+        check_gradgrad=False,
+        pickle=False)
+
+
 new_module_tests = [
     poissonnllloss_no_reduce_test(),
     bceloss_no_reduce_test(),
@@ -4949,6 +4975,8 @@ new_module_tests = [
     hingeembeddingloss_no_reduce_test(),
     hingeembeddingloss_margin_no_reduce_test(),
     softmarginloss_no_reduce_test(),
+    multilabelsoftmarginloss_no_reduce_test(),
+    multilabelsoftmarginloss_weights_no_reduce_test(),
     dict(
         module_name='BatchNorm1d',
         constructor_args=(10,),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4485,6 +4485,17 @@ new_criterion_tests = [
             smoothl1loss_reference(i, t, size_average=get_size_average(m)),
         desc='scalar',
     ),
+    dict(
+        module_name='MultiLabelSoftMarginLoss',
+        constructor_args=(torch.rand(10),),
+        input_fn=lambda: torch.randn(5, 10),
+        target_fn=lambda: torch.rand(5, 10).mul(2).floor(),
+        reference_fn=lambda i, t, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * get_weight(m)).sum() /
+            (i.numel() if get_size_average(m) else 1),
+        desc='weights',
+        check_no_size_average=True,
+        check_gradgrad=False,
+    ),
 ]
 
 
@@ -4913,21 +4924,6 @@ def softmarginloss_no_reduce_test():
         reference_fn=lambda i, _:
             loss_reference_fns['SoftMarginLoss'](i, t.type_as(i), reduce=False),
         check_no_size_average=True,
-        pickle=False)
-
-
-def multilabelsoftmarginloss_weights_test():
-    t = Variable(torch.rand(5, 10).mul(2).floor())
-    weights = Variable(torch.rand(10))
-    return dict(
-        fullname='MultiLabelSoftMarginLoss_weights',
-        constructor=wrap_functional(
-            lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i))),
-        input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: (-((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
-                                   (i.numel() if get_size_average(m) else 1)),
-        check_no_size_average=True,
-        check_gradgrad=False,
         pickle=False)
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4916,6 +4916,21 @@ def softmarginloss_no_reduce_test():
         pickle=False)
 
 
+def multilabelsoftmarginloss_weights_test():
+    t = Variable(torch.rand(5, 10).mul(2).floor())
+    weights = Variable(torch.rand(10))
+    return dict(
+        fullname='MultiLabelSoftMarginLoss_weights',
+        constructor=wrap_functional(
+            lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i))),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
+            (i.numel() if get_size_average(m) else 1),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
 def multilabelsoftmarginloss_no_reduce_test():
     t = Variable(torch.rand(5, 10).mul(2).floor())
     return dict(
@@ -4923,7 +4938,9 @@ def multilabelsoftmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()),
+        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) /
+            (i.numel() if get_size_average(m) else 1),
+        check_no_size_average=True,
         check_gradgrad=False,
         pickle=False)
 
@@ -4937,7 +4954,9 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
                                                     weight=weights.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights),
+        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
+            (i.numel() if get_size_average(m) else 1),
+        check_no_size_average=True,
         check_gradgrad=False,
         pickle=False)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4924,8 +4924,8 @@ def multilabelsoftmarginloss_weights_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i))),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
-            (i.numel() if get_size_average(m) else 1),
+        reference_fn=lambda i, m: (-((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
+                                   (i.numel() if get_size_average(m) else 1)),
         check_no_size_average=True,
         check_gradgrad=False,
         pickle=False)
@@ -4938,8 +4938,8 @@ def multilabelsoftmarginloss_no_reduce_test():
         constructor=wrap_functional(
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) /
-            (i.numel() if get_size_average(m) else 1),
+        reference_fn=lambda i, m: (-(t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) /
+                                   (i.numel() if get_size_average(m) else 1)),
         check_no_size_average=True,
         check_gradgrad=False,
         pickle=False)
@@ -4954,8 +4954,8 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
             lambda i: F.multilabel_soft_margin_loss(i, t.type_as(i),
                                                     weight=weights.type_as(i), reduce=False)),
         input_fn=lambda: torch.randn(5, 10),
-        reference_fn=lambda i, m: -((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
-            (i.numel() if get_size_average(m) else 1),
+        reference_fn=lambda i, m: (-((t * i.sigmoid().log() + (1 - t) * (-i).sigmoid().log()) * weights) /
+                                   (i.numel() if get_size_average(m) else 1)),
         check_no_size_average=True,
         check_gradgrad=False,
         pickle=False)

--- a/torch/legacy/nn/MultiLabelSoftMarginCriterion.py
+++ b/torch/legacy/nn/MultiLabelSoftMarginCriterion.py
@@ -18,10 +18,8 @@ class MultiLabelSoftMarginCriterion(Criterion):
 
     """
 
-    def __init__(self, weights=None, sizeAverage=True):
+    def __init__(self, weights=None):
         super(MultiLabelSoftMarginCriterion, self).__init__()
-        self.weights = weights
-        self.sizeAverage = sizeAverage
         self.lsm = Sigmoid()
         self.nll = BCECriterion(weights)
 

--- a/torch/legacy/nn/MultiLabelSoftMarginCriterion.py
+++ b/torch/legacy/nn/MultiLabelSoftMarginCriterion.py
@@ -18,8 +18,10 @@ class MultiLabelSoftMarginCriterion(Criterion):
 
     """
 
-    def __init__(self, weights=None):
+    def __init__(self, weights=None, sizeAverage=True):
         super(MultiLabelSoftMarginCriterion, self).__init__()
+        self.weights = weights
+        self.sizeAverage = sizeAverage
         self.lsm = Sigmoid()
         self.nll = BCECriterion(weights)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1558,13 +1558,13 @@ See :class:`~torch.nn.SoftMarginLoss` for details.
 """)
 
 
-def multilabel_soft_margin_loss(input, target, weight=None, size_average=True):
+def multilabel_soft_margin_loss(input, target, weight=None, size_average=True, reduce=True):
     """multilabel_soft_margin_loss(input, target, weight=None, size_average=True) -> Variable
 
     See :class:`~torch.nn.MultiLabelSoftMarginLoss` for details.
     """
     input = torch.sigmoid(input)
-    return binary_cross_entropy(input, target, weight, size_average)
+    return binary_cross_entropy(input, target, weight, size_average, reduce)
 
 
 def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -747,18 +747,40 @@ class CrossEntropyLoss(_WeightedLoss):
 
 class MultiLabelSoftMarginLoss(_WeightedLoss):
     r"""Creates a criterion that optimizes a multi-label one-versus-all
-    loss based on max-entropy, between input `x`  (a 2D mini-batch `Tensor`) and
-    target `y` (a binary 2D `Tensor`). For each sample in the minibatch::
+    loss based on max-entropy, between input `x` and target `y` of size `(N, C)`.
+    For each sample in the minibatch::
 
        loss(x, y) = - sum_i (y[i] * log( 1 / (1 + exp(-x[i])) )
                          + ( (1-y[i]) * log(exp(-x[i]) / (1 + exp(-x[i])) ) )
 
     where `i == 0` to `x.nElement()-1`, `y[i]  in {0,1}`.
-    `y` and `x` must have the same size.
+
+    Args:
+        weight (Tensor, optional): a manual rescaling weight given to each
+           class. If given, it has to be a Tensor of size `C`. Otherwise, it is
+           treated as if having all ones.
+        size_average (bool, optional): By default, the losses are averaged over
+            observations for each minibatch. However, if the field :attr:`size_average`
+            is set to ``False``, the losses are instead summed for each minibatch.
+            Default: ``True``
+        reduce (bool, optional): By default, the losses are averaged or summed over
+            observations for each minibatch depending on :attr:`size_average`. When
+            :attr:`reduce` is ``False``, returns a loss per batch element instead and
+            ignores :attr:`size_average`. Default: ``True``
+
+    Shape:
+        - Input: :math:`(N, C)` where `N` is the batch size and `C` is the number of classes.
+        - Target: :math:`(N, C)`, same shape as the input.
+        - Output: scalar. If `reduce` is False, then `(N)`.
     """
 
+    def __init__(self, weight=None, size_average=True, reduce=True):
+        super(MultiLabelSoftMarginLoss, self).__init__(weight, size_average)
+        self.reduce = reduce
+
     def forward(self, input, target):
-        return F.multilabel_soft_margin_loss(input, target, self.weight, self.size_average)
+        return F.multilabel_soft_margin_loss(input, target, self.weight, self.size_average,
+                                             self.reduce)
 
 
 class CosineEmbeddingLoss(Module):


### PR DESCRIPTION
As per #264. When reduce is False, MultiLabelSoftMarginLoss outputs a loss per sample in minibatch. When reduce is True (default), the current behavior is kept.

Test Plan
test/run_test.sh
Added unit tests for the reduce=False case. Added a reference function.