### PR TITLE
Ensure Tensors have storages in resizeNd

### DIFF
--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -824,7 +824,7 @@ void THTensor_(setStorageNd)(THTensor *self, THStorage *storage, ptrdiff_t stora
       THStorage_(retain)(self->storage);
     }
     else
-      self->storage = NULL;
+      self->storage = THStorage_(new)();
   }
 
   /* storageOffset */

--- a/aten/src/THC/generic/THCTensor.c
+++ b/aten/src/THC/generic/THCTensor.c
@@ -826,7 +826,7 @@ void THCTensor_(setStorageNd)(THCState *state, THCTensor *self, THCStorage *stor
       THCStorage_(retain)(state, self->storage);
     }
     else
-      self->storage = NULL;
+      self->storage = THCStorage_(new)(state);
   }
 
   /* storageOffset */


### PR DESCRIPTION
Follow up to #4744

This is another code-path in which storages may be null, which is not
allowed in PyTorch. The Python tensor bindings handle this in pynew, but
the ATen bindings do not.

This is caught by test_torch.py when Tensor and Variable are merged.