### PR TITLE
Implement Variable.new(...) overloads for sparse tensors

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -847,7 +847,10 @@ class TestSparse(TestCase):
 
     def test_new(self):
         def do_test(x, indices, values):
-            self.assertEqual(x.new(indices, values), x)
+            if not x.is_cuda:
+                # CUDA sparse tensors currently requires the size to be
+                # specified if nDimV > 0
+                self.assertEqual(x.new(indices, values), x)
             self.assertEqual(x.new(indices, values, x.size()), x)
 
         x, i, v = self._gen_sparse(3, 10, 100)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -845,6 +845,18 @@ class TestSparse(TestCase):
         self._test_new_device((30, 20), 1)
         self._test_new_device((30, 20, 10), 1)
 
+    def test_new(self):
+        def do_test(x, indices, values):
+            self.assertEqual(x.new(indices, values), x)
+            self.assertEqual(x.new(indices, values, x.size()), x)
+
+        x, i, v = self._gen_sparse(3, 10, 100)
+        do_test(x, i, v)
+
+        # TODO: simplify once Variable and Tensor are merged
+        from torch.autograd import Variable
+        do_test(Variable(x), Variable(i), Variable(v))
+
     def test_is_sparse(self):
         x = torch.randn(3, 3)
         self.assertFalse(x.is_sparse)


### PR DESCRIPTION
We were missing support for the sparse variable constructors which take
indices and values.