### PR TITLE
Add efficient isVariable test to ATen.

### DIFF
--- a/aten/src/ATen/UndefinedType.cpp
+++ b/aten/src/ATen/UndefinedType.cpp
@@ -3,7 +3,7 @@
 namespace at {
 
 UndefinedType::UndefinedType(Context* context)
-: Type(context) {}
+: Type(context, true) {}
 ScalarType UndefinedType::scalarType() const {
   return ScalarType::Undefined;
 }

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -75,6 +75,8 @@ struct Tensor : public detail::TensorBase {
   inline Tensor toType(ScalarType t) const;
   inline Tensor toBackend(Backend b) const;
 
+  inline bool isVariable() const;
+
   template<typename T>
   T * data() const;
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -52,14 +52,15 @@ enum class TypeID {
 
 
 struct AT_API Type {
-  explicit Type(Context * context)
-  : context(context) {}
+  explicit Type(Context * context, bool is_variable)
+  : context(context), is_variable_(is_variable) {}
   virtual ~Type() {}
   virtual ScalarType scalarType() const = 0;
   virtual Backend backend() const = 0;
   virtual bool is_cuda() const = 0;
   virtual bool is_sparse() const = 0;
   virtual bool is_distributed() const = 0;
+  inline bool is_variable() const { return is_variable_; }
   static void registerAll(Context * context);
   virtual std::unique_ptr<Storage> storage() const = 0;
   virtual std::unique_ptr<Storage> storage(size_t size) const = 0;
@@ -96,7 +97,13 @@ struct AT_API Type {
   ${type_method_declarations}
 protected:
   Context* context;
+  bool is_variable_ = false;
 };
+
+bool Tensor::isVariable() const {
+  return type().is_variable();
+}
+
 
 
 }

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -31,7 +31,7 @@ $extra_cuda_headers
 namespace at {
 
 ${Type}::${Type}(Context* context)
-: Type(context) {}
+: Type(context, false) {}
 ScalarType ${Type}::scalarType() const {
   return ScalarType::${ScalarName};
 }

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -43,7 +43,7 @@ template<std::size_t N>
 static void setattr(jit::Node* n, jit::Symbol name, std::array<bool, N> v) { n->is_(name, std::vector<int64_t>(v.begin(), v.end())); }
 
 VariableType::VariableType(Context* context, Type* baseType)
-  : Type(context)
+  : Type(context, true)
   , baseType(baseType) {
   str = std::string("Variable[") + baseType->toString() + "]";
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -31,8 +31,12 @@ struct Variable : public at::Tensor {
 
   // Implicitly casts a Tensor to a Variable. This should only be called on
   // Tensors which you know are actually Variables.
-  /*implicit*/ Variable(Tensor const & rhs) : Tensor(rhs) {}
-  /*implicit*/ Variable(Tensor && rhs) noexcept : Tensor(std::move(rhs)) {}
+  /*implicit*/ Variable(Tensor const & rhs) : Tensor(rhs) {
+    AT_ASSERT(rhs.isVariable(), "not variable");
+  }
+  /*implicit*/ Variable(Tensor && rhs) noexcept : Tensor(std::move(rhs)) {
+    AT_ASSERT(rhs.isVariable(), "not variable");
+  }
 
   inline VariableImpl* get() const;
 
@@ -202,6 +206,7 @@ inline Variable::Variable(VariableImpl * self, bool retain) : Tensor(self, retai
 }
 
 inline VariableImpl* Variable::get() const {
+  AT_ASSERT(defined(), "Variable::get() !defined()");
   return static_cast<VariableImpl*>(pImpl);
 }
 


### PR DESCRIPTION
This is done as a field on Type so that we can define a
non-virtual, inlinable function.  The added ASSERTs probalby
affect runtime performance, we may need to toggle them off
on non-DEBUG builds.

Fixes #4814.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>