### PR TITLE
Fix the evaluation order problem with build_lstm_body

### DIFF
--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -51,25 +51,25 @@ graph(%0 : UNKNOWN_TYPE
       %2 : UNKNOWN_TYPE
       %3 : UNKNOWN_TYPE
       %4 : UNKNOWN_TYPE) {
-  %21 : UNKNOWN_TYPE, %22 : UNKNOWN_TYPE = GraphExecutor_0(%1, %4, %0, %3, %2)
+  %21 : UNKNOWN_TYPE, %22 : UNKNOWN_TYPE = GraphExecutor_0(%0, %3, %1, %4, %2)
   return (%22, %21);
 }
 with GraphExecutor_0 = graph(%1 : UNKNOWN_TYPE
       %2 : UNKNOWN_TYPE
       %4 : UNKNOWN_TYPE
       %5 : UNKNOWN_TYPE
-      %17 : UNKNOWN_TYPE) {
+      %16 : UNKNOWN_TYPE) {
   %0 : UNKNOWN_TYPE = mm(%1, %2)
   %3 : UNKNOWN_TYPE = mm(%4, %5)
-  %6 : UNKNOWN_TYPE = add[alpha={1}](%3, %0)
+  %6 : UNKNOWN_TYPE = add[alpha={1}](%0, %3)
   %7 : UNKNOWN_TYPE, %8 : UNKNOWN_TYPE, %9 : UNKNOWN_TYPE, %10 : UNKNOWN_TYPE = chunk[chunks=4, dim=1](%6)
   %11 : UNKNOWN_TYPE = sigmoid(%7)
   %12 : UNKNOWN_TYPE = sigmoid(%10)
   %13 : UNKNOWN_TYPE = tanh(%9)
   %14 : UNKNOWN_TYPE = sigmoid(%8)
-  %15 : UNKNOWN_TYPE = mul(%11, %13)
-  %16 : UNKNOWN_TYPE = mul(%14, %17)
-  %18 : UNKNOWN_TYPE = add[alpha={1}](%16, %15)
+  %15 : UNKNOWN_TYPE = mul(%14, %16)
+  %17 : UNKNOWN_TYPE = mul(%11, %13)
+  %18 : UNKNOWN_TYPE = add[alpha={1}](%15, %17)
   %19 : UNKNOWN_TYPE = tanh(%18)
   %20 : UNKNOWN_TYPE = mul(%12, %19)
   return (%18, %20);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -319,7 +319,8 @@ std::tuple<Var, Var> build_lstm_body(
   Var cx,
   Var w_ih,
   Var w_hh) {
-    auto gates =  input.mm(w_ih) + hx.mm(w_hh);
+    auto gates = input.mm(w_ih);
+    gates = gates + hx.mm(w_hh);
     auto outputs = gates.chunk(4, 1);
     auto ingate = outputs[0];
     auto forgetgate = outputs[1];
@@ -330,7 +331,8 @@ std::tuple<Var, Var> build_lstm_body(
     cellgate = cellgate.tanh();
     forgetgate = forgetgate.sigmoid();
 
-    auto cy = forgetgate*cx + ingate*cellgate;
+    auto cy = forgetgate*cx;
+    cy =  cy + ingate*cellgate;
     auto hy = outgate*cy.tanh();
 
     return std::make_tuple(hy,cy);


### PR DESCRIPTION
C++ argument evaluation order is undefined and leads to different
results in different platforms. This commit fixes build_lstm_body to
do the calculation slightly differently in order to avoid problems with the order.

Fixes #5055