### PR TITLE
Change Windows CI conda install path

### DIFF
--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -42,9 +42,10 @@ set MAGMA_HOME=%cd%\\magma_cuda90_release
 aws s3 cp s3://ossci-windows/clcache.7z clcache.7z && 7z x -aoa clcache.7z -oclcache
 
 :: Install Miniconda3
+rm -rf C:\\Jenkins\\Miniconda3
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
-start /wait "" Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=%cd%\\Miniconda3
-call %cd%\\Miniconda3\\Scripts\\activate.bat %cd%\\Miniconda3
+.\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
+call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
 call conda install -y numpy mkl cffi pyyaml boto3
 
 :: Install ninja
@@ -75,7 +76,7 @@ set CMAKE_GENERATOR=Ninja
 
 xcopy /Y aten\\src\\ATen\\common_with_cwrap.py tools\\shared\\cwrap_common.py
 
-python setup.py install && 7z a %IMAGE_COMMIT_TAG%.7z %cd%\\Miniconda3\\Lib\\site-packages\\torch && python ci_scripts\\upload_image.py %IMAGE_COMMIT_TAG%.7z
+python setup.py install && 7z a %IMAGE_COMMIT_TAG%.7z C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch && python ci_scripts\\upload_image.py %IMAGE_COMMIT_TAG%.7z
 
 EOL
 

--- a/.jenkins/win-test.sh
+++ b/.jenkins/win-test.sh
@@ -53,9 +53,10 @@ cat >ci_scripts/test_pytorch.bat <<EOL
 set PATH=C:\\Program Files\\CMake\\bin;C:\\Program Files\\7-Zip;C:\\curl-7.57.0-win64-mingw\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLI;%PATH%
 
 :: Install Miniconda3
+rm -rf C:\\Jenkins\\Miniconda3
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
-start /wait "" Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=%cd%\\Miniconda3
-call %cd%\\Miniconda3\\Scripts\\activate.bat %cd%\\Miniconda3
+.\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
+call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
 call conda install -y numpy mkl cffi pyyaml boto3
 
 set PATH=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0\\bin;C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0\\libnvvp;%PATH%


### PR DESCRIPTION
The current conda install path is too long to work on Windows Server 2012 R2, which will be used as base image for the auto-scaled CPU and GPU workers.