### PR TITLE
Improve Variable interface

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,6 +37,7 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -16,6 +16,10 @@ struct Storage;
 struct TensorImpl : public Retainable {
   explicit TensorImpl(Type * type)
   : is_scalar(false), type_(type) {}
+
+  void setType(Type* type) {
+    type_ = type;
+  }
   Type & type() const {
     return *type_;
   }

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -17,9 +17,6 @@ struct TensorImpl : public Retainable {
   explicit TensorImpl(Type * type)
   : is_scalar(false), type_(type) {}
 
-  void setType(Type* type) noexcept {
-    type_ = type;
-  }
   Type & type() const {
     return *type_;
   }
@@ -53,7 +50,7 @@ struct TensorImpl : public Retainable {
   void setScalar(bool s) {
     is_scalar = s;
   }
-private:
+protected:
   bool is_scalar;
   Type * type_;
 };

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -17,7 +17,7 @@ struct TensorImpl : public Retainable {
   explicit TensorImpl(Type * type)
   : is_scalar(false), type_(type) {}
 
-  void setType(Type* type) {
+  void setType(Type* type) noexcept {
     type_ = type;
   }
   Type & type() const {

--- a/setup.py
+++ b/setup.py
@@ -474,6 +474,7 @@ main_sources = [
     "torch/csrc/jit/python_ir.cpp",
     "torch/csrc/jit/test_jit.cpp",
     "torch/csrc/jit/tracer.cpp",
+    "torch/csrc/jit/tracer_state.cpp",
     "torch/csrc/jit/python_tracer.cpp",
     "torch/csrc/jit/passes/shape_analysis.cpp",
     "torch/csrc/jit/interned_strings.cpp",

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -129,7 +129,7 @@ def process_function(func):
         name = arg['name']
         if arg['type'] == 'Tensor' or (arg['type'] == 'Scalar' and is_output):
             saved_variables.append('SavedVariable {}_;'.format(name))
-            release_variables.append('{}_.data.reset();'.format(name))
+            release_variables.append('{}_.reset_data();'.format(name))
             ptr = 'shared_from_this()' if is_output else ''
             unpack.append('auto {} = {}_.unpack({});'.format(name, name, ptr))
         elif arg['type'] == 'TensorList':

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1088,9 +1088,9 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   for (auto s : input.sizes().slice(2)) {
     M *= s;
   }
-  auto mu = unsqueeze_dim1(Variable(training ? save_mean : running_mean, /*requires_grad=*/false), input);
+  auto mu = unsqueeze_dim1(make_variable(training ? save_mean : running_mean, /*requires_grad=*/false), input);
   auto input_sub_mu = input - mu;
-  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(Variable(training ? save_std : running_var.add(Scalar(eps)).pow(-0.5), /*requires_grad=*/false), input);
+  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(make_variable(training ? save_std : running_var.add(Scalar(eps)).pow(-0.5), /*requires_grad=*/false), input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);
   auto sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3);
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1088,9 +1088,9 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   for (auto s : input.sizes().slice(2)) {
     M *= s;
   }
-  auto mu = unsqueeze_dim1(make_variable(training ? save_mean : running_mean), input);
+  auto mu = unsqueeze_dim1(Variable(training ? save_mean : running_mean, /*requires_grad=*/false), input);
   auto input_sub_mu = input - mu;
-  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(make_variable(training ? save_std : running_var.add(Scalar(eps)).pow(-0.5)), input);
+  auto sigma2_eps_neg_1_2 = unsqueeze_dim1(Variable(training ? save_std : running_var.add(Scalar(eps)).pow(-0.5), /*requires_grad=*/false), input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);
   auto sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3);
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -478,7 +478,7 @@ Tensor select_backward_scalar(Tensor grad, const Tensor & input, const Tensor & 
 #ifdef WITH_SCALARS
   grad_input.masked_fill_(input == value, grad);
 #else
-  auto grad_data = static_cast<Variable&>(grad).data();
+  auto grad_data = as_variable_ref(grad).data();
   grad_input.masked_fill_(input == value, Scalar(grad_data[0]));
 #endif
   return grad_input;

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<Storage> VariableType::storageWithAllocator(int64_t size, std::u
   return baseType->storageWithAllocator(size, std::move(allocator));
 }
 Tensor VariableType::unsafeTensorFromTH(void * th_pointer, bool retain) const {
-  return Variable(baseType->unsafeTensorFromTH(th_pointer, retain), /*requires_grad=*/false);
+  return make_variable(baseType->unsafeTensorFromTH(th_pointer, retain), /*requires_grad=*/false);
 }
 std::unique_ptr<Generator> VariableType::generator() const {
   return baseType->generator();
@@ -215,7 +215,7 @@ std::tuple<Tensors...> as_variable_impl(
   // constructions. This turns into (boolean omitted):
   // Variable(std::get<0>(tensors)), Variable(std::get<1>(tensors)), ...
   return std::tuple<Tensors...>(
-      Variable(std::get<Is>(tensors), /*requires_grad=*/false)...);
+      make_variable(std::get<Is>(tensors), /*requires_grad=*/false)...);
 }
 
 template <typename... Tensors>
@@ -229,13 +229,13 @@ std::tuple<Tensors...> as_variable(std::tuple<Tensors...> tensors) {
 }
 
 static Tensor as_variable(Tensor tensor) {
-  return Variable(std::move(tensor), /*requires_grad=*/false);
+  return make_variable(std::move(tensor), /*requires_grad=*/false);
 }
 
 static std::vector<Tensor> as_variable(TensorList tl) {
   std::vector<Tensor> variables;
   for (auto& t : tl) {
-    variables.emplace_back(Variable(std::move(t), /*requires_grad=*/false));
+    variables.emplace_back(make_variable(std::move(t), /*requires_grad=*/false));
   }
   return variables;
 }
@@ -245,7 +245,7 @@ static Tensor as_view(const Tensor & base, Tensor tensor) {
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
-  return Variable::as_view(std::move(base_var), std::move(tensor));
+  return make_variable_view(std::move(base_var), std::move(tensor));
 }
 
 #ifndef WITH_SCALARS

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -28,7 +28,6 @@ using namespace at;
 using namespace torch::autograd::generated;
 
 namespace torch { namespace autograd {
-
 // Helper methods for working with Attributes (torch/csrc/jit/attributes.h)
 
 // The overloaded accessors are convenient for the generated code (since we
@@ -74,7 +73,7 @@ std::unique_ptr<Storage> VariableType::storageWithAllocator(int64_t size, std::u
   return baseType->storageWithAllocator(size, std::move(allocator));
 }
 Tensor VariableType::unsafeTensorFromTH(void * th_pointer, bool retain) const {
-  return make_variable(baseType->unsafeTensorFromTH(th_pointer, retain), false);
+  return Variable(baseType->unsafeTensorFromTH(th_pointer, retain), /*requires_grad=*/false);
 }
 std::unique_ptr<Generator> VariableType::generator() const {
   return baseType->generator();
@@ -207,49 +206,35 @@ static std::vector<SavedVariable> make_saved_variable_list(TensorList tensors) {
       return SavedVariable{tensor, false /* is output */}; });
 }
 
+template <typename... Tensors, size_t... Is>
+std::tuple<Tensors...> as_variable_impl(
+    std::tuple<Tensors...> tensors,
+    Indices<Is...>) {
+  // Expand the integer parameter pack into a sequence of Variable
+  // constructions. This turns into (boolean omitted):
+  // Variable(std::get<0>(tensors)), Variable(std::get<1>(tensors)), ...
+  return std::tuple<Tensors...>(
+      Variable(std::get<Is>(tensors), /*requires_grad=*/false)...);
+}
+
+template <typename... Tensors>
+std::tuple<Tensors...> as_variable(std::tuple<Tensors...> tensors) {
+  // `sizeof...(Tensors)` gets us the size of the `Tensors` parameter pack at
+  // compile time. We use it to parameterize a `MakeIndices` class, which will
+  // expand into an Indices object containing the numbers 0 to
+  // sizeof...(Tensors) - 1.
+  return as_variable_impl(
+      tensors, typename MakeIndices<sizeof...(Tensors)>::indices());
+}
+
 static Tensor as_variable(Tensor tensor) {
-  return make_variable(std::move(tensor));
-}
-
-static std::tuple<Tensor, Tensor>
-as_variable(std::tuple<Tensor, Tensor> tensors) {
-  return std::make_tuple<>(
-      make_variable(std::move(std::get<0>(tensors))),
-      make_variable(std::move(std::get<1>(tensors))));
-}
-
-static std::tuple<Tensor, Tensor, Tensor>
-as_variable(std::tuple<Tensor, Tensor, Tensor> tensors) {
-  return std::make_tuple<>(
-      make_variable(std::move(std::get<0>(tensors))),
-      make_variable(std::move(std::get<1>(tensors))),
-      make_variable(std::move(std::get<2>(tensors))));
-}
-
-static std::tuple<Tensor, Tensor, Tensor, Tensor>
-as_variable(std::tuple<Tensor, Tensor, Tensor, Tensor> tensors) {
-  return std::make_tuple<>(
-      make_variable(std::move(std::get<0>(tensors))),
-      make_variable(std::move(std::get<1>(tensors))),
-      make_variable(std::move(std::get<2>(tensors))),
-      make_variable(std::move(std::get<3>(tensors))));
-}
-
-static std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor>
-as_variable(std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> tensors) {
-  return std::make_tuple<>(
-      make_variable(std::move(std::get<0>(tensors))),
-      make_variable(std::move(std::get<1>(tensors))),
-      make_variable(std::move(std::get<2>(tensors))),
-      make_variable(std::move(std::get<3>(tensors))),
-      make_variable(std::move(std::get<4>(tensors)))
-      );
+  return Variable(std::move(tensor), /*requires_grad=*/false);
 }
 
 static std::vector<Tensor> as_variable(TensorList tl) {
   std::vector<Tensor> variables;
   for (auto& t : tl) {
-    variables.emplace_back(make_variable(std::move(t)));
+    variables.emplace_back(Variable(std::move(t), /*requires_grad=*/false));
   }
   return variables;
 }
@@ -259,7 +244,7 @@ static Tensor as_view(const Tensor & base, Tensor tensor) {
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
-  return make_variable_view(std::move(base_var), std::move(tensor));
+  return Variable::as_view(std::move(base_var), std::move(tensor));
 }
 
 #ifndef WITH_SCALARS
@@ -342,20 +327,18 @@ static void set_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
   if (grad_fn && tensor.defined()) {
     auto& var = static_cast<Variable&>(tensor);
     grad_fn->num_inputs = 1;
-    var.get()->output_nr = 0;
-    var.get()->_grad_fn = std::move(grad_fn);
+    var.set_gradient_edge({std::move(grad_fn), 0});
   }
 }
 
 static void set_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
   if (grad_fn) {
     grad_fn->num_inputs = tensors.size();
-    int64_t output_nr = 0;
+    uint32_t output_nr = 0;
     for (auto& tensor : tensors) {
       if (tensor.defined()) {
         auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
-        var.get()->output_nr = output_nr;
-        var.get()->_grad_fn = grad_fn;
+        var.set_gradient_edge({grad_fn, output_nr});
       }
       output_nr++;
     }
@@ -378,9 +361,8 @@ template<typename... Args> inline variable_list flatten(Args&&... args) {
   return out; // RVO
 }
 
-static void increment_version(const Tensor & t) {
-  auto& var = static_cast<const Variable&>(t);
-  var.version_counter().increment();
+static void increment_version(Tensor & t) {
+  static_cast<Variable&>(t).bump_version();
 }
 
 static bool isFloatingPoint(ScalarType s) {

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -5,6 +5,7 @@
 
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/grad_mode.h"
 #include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/autograd/generated/Functions.h"
@@ -303,18 +304,18 @@ static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {
   if (grad_fn && tensor.defined()) {
     auto& var = static_cast<Variable&>(tensor);
     grad_fn->num_inputs = 1;
-    var.rebase_history(0, std::move(grad_fn));
+    var.rebase_history({std::move(grad_fn), 0});
   }
 }
 
 static void rebase_history(TensorList tensors, std::shared_ptr<Function> grad_fn) {
   if (grad_fn) {
     grad_fn->num_inputs = tensors.size();
-    int output_nr = 0;
+    uint32_t output_nr = 0;
     for (auto& tensor : tensors) {
       if (tensor.defined()) {
         auto& var = static_cast<Variable&>(const_cast<Tensor&>(tensor));
-        var.rebase_history(output_nr, grad_fn);
+        var.rebase_history({grad_fn, output_nr});
       }
       output_nr++;
     }

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -3,12 +3,16 @@
 // ${generated_comment}
 
 #include <ATen/ATen.h>
+
+#include <cstdint> // for size_t
+#include <functional> // for function
+#include <memory> // for unique_ptr
 #include <string>
 #include <vector>
 
 namespace torch { namespace autograd {
 
-class Variable;
+struct Variable;
 using at::Context;
 using at::Generator;
 using at::IntList;
@@ -56,7 +60,6 @@ private:
   static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);
   static std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos);
 
-private:
   at::Type* baseType;
   std::string str;
 };

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -8,7 +8,7 @@
 
 namespace torch { namespace autograd {
 
-struct Variable;
+class Variable;
 using at::Context;
 using at::Generator;
 using at::IntList;

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -70,7 +70,7 @@ static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto data = torch::utils::tensor_from_numpy(arg);
-  return THPVariable_Wrap(Variable(std::move(data), /*requires_grad=*/false));
+  return THPVariable_Wrap(make_variable(std::move(data), /*requires_grad=*/false));
   END_HANDLE_TH_ERRORS
 }
 

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -25,7 +25,7 @@ using namespace torch::autograd::utils;
 namespace torch { namespace autograd {
 
 static Tensor set_requires_grad(Tensor self, bool requires_grad) {
-  static_cast<Variable&>(self).set_requires_grad(requires_grad);
+  as_variable_ref(self).set_requires_grad(requires_grad);
   return self;
 }
 

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -25,7 +25,7 @@ using namespace torch::autograd::utils;
 namespace torch { namespace autograd {
 
 static Tensor set_requires_grad(Tensor self, bool requires_grad) {
-  static_cast<Variable&>(self).get()->_requires_grad = requires_grad;
+  static_cast<Variable&>(self).set_requires_grad(requires_grad);
   return self;
 }
 
@@ -70,7 +70,7 @@ static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto data = torch::utils::tensor_from_numpy(arg);
-  return THPVariable_Wrap(make_variable(std::move(data)));
+  return THPVariable_Wrap(Variable(std::move(data), /*requires_grad=*/false));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/edge.h
+++ b/torch/csrc/autograd/edge.h
@@ -6,8 +6,7 @@
 
 #include "torch/csrc/utils/hash.h"
 
-namespace torch {
-namespace autograd {
+namespace torch { namespace autograd {
 
 struct Function;
 
@@ -15,8 +14,8 @@ struct Function;
 struct Edge {
   Edge() noexcept : function(nullptr), input_nr(0) {}
 
-  Edge(const std::shared_ptr<Function>& function_, uint32_t input_nr_) noexcept
-      : function(function_), input_nr(input_nr_) {}
+  Edge(std::shared_ptr<Function> function_, uint32_t input_nr_) noexcept
+      : function(std::move(function_)), input_nr(input_nr_) {}
 
   /// Convenience method to test if an edge is valid.
   bool is_valid() const noexcept {
@@ -38,8 +37,7 @@ struct Edge {
   /// The identifier of a particular input to the function.
   uint32_t input_nr;
 };
-} // namespace autograd
-} // namespace torch
+}} // namespace torch::autograd
 
 // The idiomatic way of enabling use of a custom type as the key of hash
 // containers in C++11. This method removes the requirement of having to pass

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -29,7 +29,7 @@
 namespace torch { namespace autograd {
 
 struct Function;
-struct Variable;
+class Variable;
 struct Edge;
 
 using tensor_list = std::vector<at::Tensor>;

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -29,7 +29,7 @@
 namespace torch { namespace autograd {
 
 struct Function;
-class Variable;
+struct Variable;
 struct Edge;
 
 using tensor_list = std::vector<at::Tensor>;

--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 
 // A hook that's called on gradients

--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -7,7 +7,7 @@
 
 namespace torch { namespace autograd {
 
-struct Variable;
+class Variable;
 using variable_list = std::vector<Variable>;
 
 struct FunctionPreHook {

--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -6,7 +6,7 @@
 
 namespace torch { namespace autograd {
 
-class Variable;
+struct Variable;
 using variable_list = std::vector<Variable>;
 
 struct FunctionPreHook {

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -5,7 +5,7 @@
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
-#include <ATen/Tensor.h>
+#include <ATen/ATen.h>
 
 #include <memory>
 #include <utility>

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -5,6 +5,8 @@
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
+#include <ATen/Tensor.h>
+
 #include <memory>
 #include <utility>
 
@@ -19,7 +21,7 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   outputs.reserve(inputs.size());
   for (auto& var : inputs) {
     // FIXME: share version counters
-    outputs.emplace_back(var.defined() ? var.data() : Tensor());
+    outputs.emplace_back(var.defined() ? var.data() : at::Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](function_list&& next_functions) {
     return std::make_shared<Error>(msg, std::move(next_functions));

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -4,6 +4,7 @@
 #include "torch/csrc/autograd/python_engine.h"
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/edge.h"
 
 #include <cstdint>
 #include <memory>
@@ -264,11 +265,10 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     // This output is already rebased. This happens when there
     // the same Variable has been returned multiple times, and
     // is repeated in this list.
-    if (output.get()->_grad_fn.get() == this) {
+    if (output.grad_fn().get() == this) {
       auto replicate = std::make_shared<Replicate>();
       replicate->next_functions.emplace_back(this_shared, output.output_nr());
-      output.get()->_grad_fn = replicate;
-      output.get()->output_nr = 0;
+      output.set_gradient_edge({std::move(replicate), 0});
       repeated_outputs.emplace(&output);
     }
     // NOTE: this check should be fairly cheap, and the set shouldn't
@@ -277,8 +277,7 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
       auto & replicate = output.grad_fn();
       replicate->next_functions.emplace_back(this_shared, num_inputs++);
     } else {
-      output.get()->_grad_fn = this_shared;
-      output.get()->output_nr = num_inputs++;
+      output.set_gradient_edge(Edge(this_shared, num_inputs++));
     }
   }
 

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -265,7 +265,7 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     // This output is already rebased. This happens when there
     // the same Variable has been returned multiple times, and
     // is repeated in this list.
-    if (output.grad_fn().get() == this) {
+    if (output.grad_fn_ptr() == this) {
       auto replicate = std::make_shared<Replicate>();
       replicate->next_functions.emplace_back(this_shared, output.output_nr());
       output.set_gradient_edge({std::move(replicate), 0});

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -265,7 +265,7 @@ bool Eval::replaceSubgraph(const variable_list& inputs, const variable_list& _ou
     // This output is already rebased. This happens when there
     // the same Variable has been returned multiple times, and
     // is repeated in this list.
-    if (output.grad_fn_ptr() == this) {
+    if (output.grad_fn_unsafe() == this) {
       auto replicate = std::make_shared<Replicate>();
       replicate->next_functions.emplace_back(this_shared, output.output_nr());
       output.set_gradient_edge({std::move(replicate), 0});

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -16,7 +16,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   if (!any_variable_requires_grad(inputs)) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(Variable(output, false));
+        result.push_back(make_variable(output, /*requires_grad=*/false));
       } else {
         result.emplace_back();
       }
@@ -25,7 +25,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
     auto grad_fn = ctr(get_next_functions(inputs));
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(output, Edge(grad_fn, grad_fn->num_inputs++));
+        result.push_back(make_variable(output, Edge(grad_fn, grad_fn->num_inputs++)));
       } else {
         ++grad_fn->num_inputs;
         result.emplace_back();

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,4 +1,6 @@
 #include "torch/csrc/autograd/functions/utils.h"
+
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 
@@ -14,7 +16,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
   if (!any_variable_requires_grad(inputs)) {
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(make_variable(output, false));
+        result.emplace_back(Variable(output, false));
       } else {
         result.emplace_back();
       }
@@ -23,7 +25,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
     auto grad_fn = ctr(get_next_functions(inputs));
     for (auto& output : outputs) {
       if (output.defined()) {
-        result.emplace_back(make_variable(output, grad_fn));
+        result.emplace_back(output, Edge(grad_fn, grad_fn->num_inputs++));
       } else {
         ++grad_fn->num_inputs;
         result.emplace_back();

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -145,7 +145,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
       int output_nr = input_var->cdata.output_nr();
       auto grad_fn = input_var->cdata.grad_fn();
       if (!grad_fn) {
-          grad_fn = input_var->cdata.get()->grad_accumulator.lock();
+          grad_fn = input_var->cdata.try_get_grad_accumulator();
       }
       THPUtils_assert(input_var->cdata.requires_grad(),
           "One of the differentiated Variables does not require grad");

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -142,7 +142,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
       THPUtils_assert(THPVariable_Check(input),
           "all inputs have to be Variables, but got %s", THPUtils_typename(input));
       THPVariable *input_var = (THPVariable*)input;
-      int output_nr = input_var->cdata.output_nr();
+      const auto output_nr = input_var->cdata.output_nr();
       auto grad_fn = input_var->cdata.grad_fn();
       if (!grad_fn) {
           grad_fn = input_var->cdata.try_get_grad_accumulator();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -400,7 +400,7 @@ static void _wrap_outputs(THPFunction *self,
         grad_acc->variable.reset();
       }
       if (cdata) {
-        var.rebase_history(output_nr, cdata);
+        var.rebase_history({cdata, output_nr});
       }
     } else if (is_input) {
       // An input has been returned, but it wasn't modified. Return it as a view

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -323,7 +323,7 @@ static std::vector<PyObject*> _mark_dirty(THPFunction *self)
 
     dirty_inputs.push_back(obj);
     auto variable = (THPVariable*)obj;
-    variable->cdata.version_counter().increment();
+    variable->cdata.bump_version();
   }
   // We're not going to ever need this so let's remove references now
   Py_CLEAR(self->dirty_tensors);
@@ -368,14 +368,14 @@ static void _wrap_outputs(THPFunction *self,
     }
     if (THPModule_isTensor(obj)) {
       // temporarily wrap tensors as variables until the classes are merged
-      return make_variable(createTensor(obj));
+      return Variable(createTensor(obj), /*requires_grad=*/false);
     }
     throw TypeError("%s.forward: expected Variable (got %s) for return value %d",
         Py_TYPE(self)->tp_name, Py_TYPE(obj)->tp_name, i);
   };
 
   // Sets the grad_fn and output_nr of an output Variable.
-  auto set_history = [&](Variable& var, int output_nr, bool is_input, bool is_modified,
+  auto set_history = [&](Variable& var, uint32_t output_nr, bool is_input, bool is_modified,
                          bool is_differentiable) {
     if (!is_differentiable) {
       if (!var.requires_grad()) return;
@@ -393,9 +393,9 @@ static void _wrap_outputs(THPFunction *self,
       }
       // If the input was modified, transplant the grad_fn in the graph:
       // grad_fn <- variable <- self  ==>  grad_fn <- self <- variable
-      var.get()->grad.reset();
-      var.get()->hooks.clear();
-      if (auto grad_acc_fn = var.get()->grad_accumulator.lock()) {
+      var.reset_grad();
+      var.clear_hooks();
+      if (auto grad_acc_fn = var.try_get_grad_accumulator()) {
         auto grad_acc = dynamic_cast<AccumulateGrad*>(grad_acc_fn.get());
         grad_acc->variable.reset();
       }
@@ -406,11 +406,9 @@ static void _wrap_outputs(THPFunction *self,
       // An input has been returned, but it wasn't modified. Return it as a view
       // so that we can attach a new grad_fn to the Variable.
       var = var.slice();
-      var.get()->output_nr = output_nr;
-      var.get()->_grad_fn = cdata;
+      var.set_gradient_edge({cdata, output_nr});
     } else if (cdata) {
-      var.get()->output_nr = output_nr;
-      var.get()->_grad_fn = cdata;
+      var.set_gradient_edge({cdata, output_nr});
     }
   };
 
@@ -457,7 +455,7 @@ static void _save_variables(THPFunction* self)
       self->saved_variables.emplace_back(variable->cdata, is_output);
     } else if (THPModule_isTensor(obj)) {
       // TODO: remove once Variable and Tensor classes are merged
-      auto var = make_variable(createTensor(obj), false);
+      auto var = Variable(createTensor(obj), /*requires_grad=*/false);
       self->saved_variables.emplace_back(std::move(var), false);
     } else {
       throw TypeError(

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -368,7 +368,7 @@ static void _wrap_outputs(THPFunction *self,
     }
     if (THPModule_isTensor(obj)) {
       // temporarily wrap tensors as variables until the classes are merged
-      return Variable(createTensor(obj), /*requires_grad=*/false);
+      return make_variable(createTensor(obj), /*requires_grad=*/false);
     }
     throw TypeError("%s.forward: expected Variable (got %s) for return value %d",
         Py_TYPE(self)->tp_name, Py_TYPE(obj)->tp_name, i);
@@ -455,7 +455,7 @@ static void _save_variables(THPFunction* self)
       self->saved_variables.emplace_back(variable->cdata, is_output);
     } else if (THPModule_isTensor(obj)) {
       // TODO: remove once Variable and Tensor classes are merged
-      auto var = Variable(createTensor(obj), /*requires_grad=*/false);
+      auto var = make_variable(createTensor(obj), /*requires_grad=*/false);
       self->saved_variables.emplace_back(std::move(var), false);
     } else {
       throw TypeError(

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -163,9 +163,9 @@ PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   if (grad_fn) {
     auto grad_fn_ = THPFunction_asFunction((THPFunction*)grad_fn);
     Edge edge(grad_fn_, grad_fn_->num_inputs++);
-    var = Variable(torch::createTensor(data), std::move(edge));
+    var = make_variable(torch::createTensor(data), std::move(edge));
   } else {
-    var = Variable(torch::createTensor(data), requires_grad);
+    var = make_variable(torch::createTensor(data), requires_grad);
   }
 
   if (name) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -42,7 +42,7 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
     auto v = (THPVariable*) obj;
     new (&v->cdata) Variable(std::move(var));
     v->cdata.set_pyobj(obj);
-    if (auto fn = std::dynamic_pointer_cast<PyFunction>(v->cdata.grad_fn())) {
+    if (auto fn = dynamic_cast<PyFunction*>(v->cdata.grad_fn_ptr())) {
       // Create a new reference to the THPFunction. This ensures that ref count
       // of the THPFunction is at least the number of referring THPVariables.
       const auto output_nr = static_cast<uint32_t>(v->cdata.output_nr());

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/Types.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include "torch/csrc/autograd/python_hook.h"
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/python_variable_indexing.h"
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
 #include "torch/csrc/autograd/utils/wrap_outputs.h"
@@ -16,7 +17,12 @@
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/Size.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/generated/VariableType.h"
+#include "torch/csrc/jit/tracer_state.h"
+
+#include <list>
+#include <memory>
 
 using namespace at;
 using namespace torch::autograd;
@@ -35,11 +41,13 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
   if (obj) {
     auto v = (THPVariable*) obj;
     new (&v->cdata) Variable(std::move(var));
-    v->cdata.get()->pyobj = obj;
-    if (auto fn = dynamic_cast<PyFunction*>(v->cdata.get()->_grad_fn.get())) {
+    v->cdata.set_pyobj(obj);
+    if (auto fn = std::dynamic_pointer_cast<PyFunction>(v->cdata.grad_fn())) {
       // Create a new reference to the THPFunction. This ensures that ref count
       // of the THPFunction is at least the number of referring THPVariables.
-      v->cdata.get()->_grad_fn = THPFunction_asFunction((THPFunction*)fn->obj);
+      const auto output_nr = static_cast<uint32_t>(v->cdata.output_nr());
+      v->cdata.set_gradient_edge(
+          {THPFunction_asFunction((THPFunction*)fn->obj), output_nr});
     }
   }
   return obj;
@@ -57,7 +65,7 @@ PyObject * THPVariable_Wrap(Variable var)
   }
 #endif
 
-  if (auto obj = var.get()->pyobj) {
+  if (auto obj = var.pyobj()) {
     Py_INCREF(obj);
     return obj;
   }
@@ -84,7 +92,7 @@ static int THPVariable_traverse(THPVariable *self, visitproc visit, void *arg)
   // for more details about the race condition involving traversing the grad_fn
   // and the python GC.
   if (self->cdata.defined()) {
-    for (auto& hook : self->cdata.hooks()) {
+    for (const auto& hook : self->cdata.hooks()) {
       if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
         Py_VISIT(pyhook->dict);
       }
@@ -98,10 +106,10 @@ static int THPVariable_clear(THPVariable *self)
   Py_CLEAR(self->data);
   Py_CLEAR(self->backward_hooks);
   if (self->cdata.defined()) {
-    if (auto grad_acc = self->cdata.get()->grad_accumulator.lock()) {
+    if (auto grad_acc = self->cdata.try_get_grad_accumulator()) {
       grad_acc->pre_hooks.clear();
     }
-    self->cdata.get()->pyobj = nullptr;
+    self->cdata.set_pyobj(nullptr);
   }
   self->cdata.reset();
   return 0;
@@ -154,13 +162,15 @@ PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   Variable var;
   if (grad_fn) {
     auto grad_fn_ = THPFunction_asFunction((THPFunction*)grad_fn);
-    var = make_variable(torch::createTensor(data), grad_fn_);
+    Edge edge(grad_fn_, grad_fn_->num_inputs++);
+    var = Variable(torch::createTensor(data), std::move(edge));
   } else {
-    var = make_variable(torch::createTensor(data), requires_grad);
+    var = Variable(torch::createTensor(data), requires_grad);
   }
 
-  if (name)
-    var.name() = std::string(name);
+  if (name) {
+    var.set_name(name);
+  }
 
   PyObject* self = THPVariable_NewWithVar(type, std::move(var));
   if (self) {
@@ -223,7 +233,7 @@ int THPVariable_set_grad_fn(THPVariable *self, PyObject *obj)
 {
   HANDLE_TH_ERRORS
   THPUtils_assertRet(-1, obj == Py_None, "_grad_fn can be only set to None");
-  self->cdata.get()->_grad_fn = nullptr;
+  self->cdata.set_gradient_edge(Edge());
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }
@@ -282,7 +292,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   if (&self->cdata.data().type() != &tensor.type()) {
     // we change the type of var.data so we must change the type of var
     auto newType = VariableType::getType(tensor);
-    self->cdata.get()->*get(TensorImpl_Type()) = newType;
+    self->cdata.set_type(newType);
   }
   self->cdata.data() = tensor;
   return 0;
@@ -301,7 +311,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
   HANDLE_TH_ERRORS
   auto& var = self->cdata;
   if (py_grad == Py_None) {
-    var.grad().reset();
+    var.reset_grad();
     return 0;
   }
 
@@ -368,7 +378,7 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
     THPUtils_setError("you can only change requires_grad flags of leaf variables.%s", hint);
     return -1;
   }
-  var.get()->_requires_grad = (obj == Py_True);
+  var.set_requires_grad(obj == Py_True);
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }
@@ -400,9 +410,9 @@ int THPVariable_set_backwards_hooks(THPVariable *self, PyObject *obj)
   Py_XINCREF(obj);
   Py_XDECREF(self->backward_hooks);
   self->backward_hooks = obj;
-  self->cdata.hooks().clear();
+  self->cdata.clear_hooks();
   if (obj) {
-    self->cdata.hooks().emplace_back(new PyFunctionPreHook(obj, 0));
+    self->cdata.add_hook(std::make_shared<PyFunctionPreHook>(obj, 0));
   }
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -42,7 +42,7 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
     auto v = (THPVariable*) obj;
     new (&v->cdata) Variable(std::move(var));
     v->cdata.set_pyobj(obj);
-    if (auto fn = dynamic_cast<PyFunction*>(v->cdata.grad_fn_ptr())) {
+    if (auto fn = dynamic_cast<PyFunction*>(v->cdata.grad_fn_unsafe())) {
       // Create a new reference to the THPFunction. This ensures that ref count
       // of the THPFunction is at least the number of referring THPVariables.
       const auto output_nr = static_cast<uint32_t>(v->cdata.output_nr());

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -46,7 +46,7 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
     if (auto fn = dynamic_cast<PyFunction*>(v->cdata.grad_fn_unsafe())) {
       // Create a new reference to the THPFunction. This ensures that ref count
       // of the THPFunction is at least the number of referring THPVariables.
-      const auto output_nr = static_cast<uint32_t>(v->cdata.output_nr());
+      const auto output_nr = v->cdata.output_nr();
       v->cdata.set_gradient_edge(
           {THPFunction_asFunction((THPFunction*)fn->obj), output_nr});
     }
@@ -329,7 +329,8 @@ int THPVariable_set_volatile(THPVariable *self, PyObject *obj)
 PyObject *THPVariable_get_output_nr(THPVariable *self)
 {
   HANDLE_TH_ERRORS
-  return PyInt_FromLong(self->cdata.output_nr());
+  const auto output_nr = static_cast<long>(self->cdata.output_nr());
+  return PyInt_FromLong(output_nr);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -117,7 +117,7 @@ static Variable valueToTensor(const Type & type, PyObject* value) {
     return type.scalarTensor(Scalar(THPUtils_unpackDouble(value)));
   }
   if (THPModule_isTensor(value)) {
-    return Variable(createTensor(value), /*requires_grad=*/false);
+    return make_variable(createTensor(value), /*requires_grad=*/false);
   }
   throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
 }
@@ -154,7 +154,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (THPVariable_Check(obj)) {
       handle_var(reinterpret_cast<THPVariable*>(obj)->cdata);
     } else if (THPModule_isTensor(obj)) {
-      handle_var(Variable(createTensor(obj), /*requires_grad=*/false));
+      handle_var(make_variable(createTensor(obj), /*requires_grad=*/false));
     } else if (PySequence_Check(obj)) {
       handle_var(sequenceToVariable(self.type(), obj));
     } else {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -3,8 +3,10 @@
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/THP_export.h"
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/autograd/utils/wrap_outputs.h"
+#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/utils/python_compat.h"
 #include "torch/csrc/utils/python_numbers.h"
 #include "torch/csrc/utils/tensor_new.h"
@@ -115,7 +117,7 @@ static Variable valueToTensor(const Type & type, PyObject* value) {
     return type.scalarTensor(Scalar(THPUtils_unpackDouble(value)));
   }
   if (THPModule_isTensor(value)) {
-    return make_variable(createTensor(value));
+    return Variable(createTensor(value), /*requires_grad=*/false);
   }
   throw TypeError("can't assign a %s to a %s", Py_TYPE(value)->tp_name, type.toString());
 }
@@ -152,7 +154,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (THPVariable_Check(obj)) {
       handle_var(reinterpret_cast<THPVariable*>(obj)->cdata);
     } else if (THPModule_isTensor(obj)) {
-      handle_var(make_variable(createTensor(obj)));
+      handle_var(Variable(createTensor(obj), /*requires_grad=*/false));
     } else if (PySequence_Check(obj)) {
       handle_var(sequenceToVariable(self.type(), obj));
     } else {
@@ -270,7 +272,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   variable_list variableIndices;
   Variable sliced = applySlicing(self_, holder.get(), variableIndices);
   if (variableIndices.empty()) {
-    if (sliced.get() == self_.get()) {
+    if (sliced == self_) {
       // ensure we return a shallow copy for things like x[...]
       sliced = at::alias(sliced);
     }

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -272,7 +272,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   variable_list variableIndices;
   Variable sliced = applySlicing(self_, holder.get(), variableIndices);
   if (variableIndices.empty()) {
-    if (sliced == self_) {
+    if (sliced.is_same(self_)) {
       // ensure we return a shallow copy for things like x[...]
       sliced = at::alias(sliced);
     }

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -1,49 +1,61 @@
 #include "torch/csrc/autograd/saved_variable.h"
 
 #include "torch/csrc/autograd/function.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/jit/tracer_state.h"
 
-using namespace at;
+#include <ATen/Tensor.h>
 
-namespace torch { namespace autograd {
+#include <cstdint>
+#include <list>
+#include <memory>
 
-SavedVariable::SavedVariable(const Variable& variable, bool is_output)
-  : SavedVariable() {
+namespace torch {
+namespace autograd {
+
+SavedVariable::SavedVariable(const Variable& variable, bool is_output) {
   if (!variable.defined()) {
     return;
   }
-  data = variable.data();
-  requires_grad = variable.requires_grad();
-  expected_version = variable.current_version();
-  version = variable.get()->version_counter.save();
-  has_grad_fn = !variable.is_leaf();
-  output_nr = variable.output_nr();
-  if (!has_grad_fn) {
-    grad_accumulator = variable.grad_accumulator();
+  was_default_constructed_ = false;
+
+  data_ = variable.data();
+  requires_grad_ = variable.requires_grad();
+  version_counter_ = variable.version_counter();
+  saved_version_ = version_counter_.current_version();
+  has_grad_fn_ = !variable.is_leaf();
+  output_nr_ = variable.output_nr();
+  if (!has_grad_fn_) {
+    grad_accumulator_ = variable.grad_accumulator();
   }
   if (!is_output) {
-    _grad_fn = variable.grad_fn();
+    grad_fn_ = variable.grad_fn();
   }
-  if (variable.tracing_state()) {
-    tracing_state.reset(new jit::tracer::ValueTracingState(*variable.tracing_state()));
+  if (variable.has_tracing_state()) {
+    tracing_state_.reset(
+        new jit::tracer::ValueTracingState(variable.tracing_state()));
   }
 }
 
-auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) const -> Variable {
-  if (!data.defined()) {
-    if (version.defined()) {
+SavedVariable::~SavedVariable() = default;
+
+Variable SavedVariable::unpack(std::shared_ptr<Function> saved_for) const {
+  if (!data_.defined()) {
+    if (!was_default_constructed_) {
       throw std::runtime_error(ERR_BACKWARD_TWICE);
     }
     return Variable();
   }
 
-  if (version.is_modified()) {
+  if (saved_version_ != version_counter_.current_version()) {
     throw std::runtime_error(
         "one of the variables needed for gradient computation has been "
         "modified by an inplace operation");
   }
 
-  auto grad_fn = _grad_fn;
-  if (has_grad_fn && !grad_fn) {
+  auto grad_fn = grad_fn_;
+  if (has_grad_fn_ && !grad_fn) {
     if (!saved_for) {
       // If saving the grad_fn would create a circular reference, then it must
       // be passed in to the unpack function.
@@ -57,20 +69,22 @@ auto SavedVariable::unpack(std::shared_ptr<Function> saved_for) const -> Variabl
   // in-place functions on unpacked variables.
   Variable var;
   if (grad_fn) {
-    var = make_variable(data, output_nr, std::move(grad_fn));
+    var = Variable(data_, Edge(std::move(grad_fn), output_nr_));
   } else {
-    var = make_variable(data, requires_grad);
+    var = Variable(data_, requires_grad_);
   }
-  var.version_counter() = version;
+  var.set_version(saved_version_);
 
   // If a Variable is a leaf (no grad_fn saved), and it requires_grad, then we
   // should have saved the grad accumulator. Even if the Variable no longer
-  // alive, the accumulator should be kept alive by the references in the graph).
-  if (requires_grad && !var.grad_fn() && grad_accumulator.expired())
+  // alive, the accumulator should be kept alive by the references in the
+  // graph).
+  if (requires_grad_ && !var.grad_fn() && grad_accumulator_.expired())
     throw std::logic_error("No grad accumulator for a saved leaf!");
-  var.get()->grad_accumulator = grad_accumulator;
-  if (tracing_state)
-    var.tracing_state().reset(new jit::tracer::ValueTracingState(*tracing_state));
+  var.set_grad_accumulator(grad_accumulator_);
+  if (tracing_state_) {
+    var.set_tracing_state(new jit::tracer::ValueTracingState(*tracing_state_));
+  }
 
   return var;
 }
@@ -80,4 +94,5 @@ const char* ERR_BACKWARD_TWICE =
     "already been freed. Specify retain_graph=True when calling backward "
     "the first time.";
 
-}} // namespace torch::autograd
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -69,7 +69,7 @@ Variable SavedVariable::unpack(std::shared_ptr<Function> saved_for) const {
   } else {
     var = make_variable(data_, requires_grad_);
   }
-  var.set_version(saved_version_);
+  var.set_version_counter(saved_version_);
 
   // If a Variable is a leaf (no grad_fn saved), and it requires_grad, then we
   // should have saved the grad accumulator. Even if the Variable no longer

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -69,9 +69,9 @@ Variable SavedVariable::unpack(std::shared_ptr<Function> saved_for) const {
   // in-place functions on unpacked variables.
   Variable var;
   if (grad_fn) {
-    var = Variable(data_, Edge(std::move(grad_fn), output_nr_));
+    var = make_variable(data_, Edge(std::move(grad_fn), output_nr_));
   } else {
-    var = Variable(data_, requires_grad_);
+    var = make_variable(data_, requires_grad_);
   }
   var.set_version(saved_version_);
 

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -51,7 +51,7 @@ class SavedVariable {
   VariableVersion version_counter_;
 
   uint32_t saved_version_ = 0;
-  int output_nr_ = -1;
+  uint32_t output_nr_ = 0;
   bool was_default_constructed_ = true;
   bool requires_grad_ = false;
   bool has_grad_fn_ = false;

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -2,7 +2,7 @@
 
 #include "torch/csrc/autograd/variable_version.h"
 
-#include <ATen/Tensor.h>
+#include <ATen/ATen.h>
 
 #include <cstdint>
 #include <list>

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "torch/csrc/autograd/variable_version.h"
+#include "torch/csrc/jit/tracer_state.h"
 
 #include <ATen/ATen.h>
 
@@ -8,18 +9,10 @@
 #include <list>
 #include <memory>
 
-namespace torch {
-namespace autograd {
+namespace torch { namespace autograd {
+
 class Variable;
 struct Function;
-} // namespace autograd
-namespace jit { namespace tracer {
-struct ValueTracingStateElem;
-using ValueTracingState = std::list<ValueTracingStateElem>;
-}} // namespace jit::tracer
-} // namespace torch
-
-namespace torch { namespace autograd {
 
 extern const char* ERR_BACKWARD_TWICE;
 

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -1,46 +1,68 @@
 #pragma once
 
-#include <mutex>
-#include <memory>
-#include <functional>
-#include <ATen/ATen.h>
-
-#include "torch/csrc/jit/tracer_state.h"
-#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/variable_version.h"
-#include "torch/csrc/Types.h"
+
+#include <ATen/Tensor.h>
+
+#include <cstdint>
+#include <list>
+#include <memory>
+
+namespace torch {
+namespace autograd {
+class Variable;
+struct Function;
+} // namespace autograd
+namespace jit { namespace tracer {
+struct ValueTracingStateElem;
+using ValueTracingState = std::list<ValueTracingStateElem>;
+}} // namespace jit::tracer
+} // namespace torch
 
 namespace torch { namespace autograd {
 
-struct Function;
-
 extern const char* ERR_BACKWARD_TWICE;
 
-struct SavedVariable {
-  SavedVariable()
-    : data()
-    , has_grad_fn(false)
-    , version()
-    , requires_grad(false)
-    , expected_version(-1) {}
-
+/// A snapshot of a variable at a certain version. A `SavedVariable` stores
+/// enough information to reconstruct a variable from a certain point in time.
+class SavedVariable {
+ public:
+  SavedVariable() = default;
   SavedVariable(const Variable& variable, bool is_output);
+  SavedVariable(SavedVariable&&) = default;
+  SavedVariable& operator=(SavedVariable&&) = default;
 
-  at::Tensor data;
+  // Must be defined externally to avoid it being inlined by the compiler,
+  // which would require it to see the definition of ValueTracingState.
+  ~SavedVariable();
+
+  /// Reconstructs the saved variable. Pass `saved_for` as the gradient
+  /// function if constructing the `SavedVariable` with it would have caused a
+  /// circular reference.
+  Variable unpack(std::shared_ptr<Function> saved_for = nullptr) const;
+
+  void reset_data() {
+    return data_.reset();
+  }
+
+ private:
+  bool was_default_constructed_ = true;
+  at::Tensor data_;
+
   // The gradient function associated with this node. If has_grad_fn
   // is false, then this is a leaf node. Note that the grad_fn is not saved if
   // it would create a circular reference. In that case, the grad_fn must be
   // passed in to the unpack function when reconstructing the Variable.
-  bool has_grad_fn;
-  std::shared_ptr<Function> _grad_fn;
-  std::weak_ptr<Function> grad_accumulator;
-  SavedVersion version;
-  bool requires_grad;
-  int expected_version;
-  int output_nr;
-  std::unique_ptr<jit::tracer::ValueTracingState> tracing_state;
+  std::shared_ptr<Function> grad_fn_;
+  bool has_grad_fn_ = false;
+  std::weak_ptr<Function> grad_accumulator_;
 
-  Variable unpack(std::shared_ptr<Function> saved_for=nullptr) const;
+  VariableVersion version_counter_;
+  uint32_t saved_version_ = 0;
+
+  bool requires_grad_ = false;
+  int output_nr_ = -1;
+
+  std::unique_ptr<jit::tracer::ValueTracingState> tracing_state_;
 };
-
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -25,10 +25,6 @@ class SavedVariable {
   SavedVariable(SavedVariable&&) = default;
   SavedVariable& operator=(SavedVariable&&) = default;
 
-  // Must be defined externally to avoid it being inlined by the compiler,
-  // which would require it to see the definition of ValueTracingState.
-  ~SavedVariable();
-
   /// Reconstructs the saved variable. Pass `saved_for` as the gradient
   /// function if constructing the `SavedVariable` with it would have caused a
   /// circular reference.
@@ -50,10 +46,10 @@ class SavedVariable {
   std::unique_ptr<jit::tracer::ValueTracingState> tracing_state_;
   VariableVersion version_counter_;
 
-  uint32_t saved_version_ = 0;
-  uint32_t output_nr_ = 0;
+  uint32_t saved_version_;
+  uint32_t output_nr_;
   bool was_default_constructed_ = true;
-  bool requires_grad_ = false;
-  bool has_grad_fn_ = false;
+  bool requires_grad_;
+  bool has_grad_fn_;
 };
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -11,7 +11,7 @@
 
 namespace torch { namespace autograd {
 
-class Variable;
+struct Variable;
 struct Function;
 
 extern const char* ERR_BACKWARD_TWICE;
@@ -39,7 +39,6 @@ class SavedVariable {
   }
 
  private:
-  bool was_default_constructed_ = true;
   at::Tensor data_;
 
   // The gradient function associated with this node. If has_grad_fn
@@ -47,15 +46,14 @@ class SavedVariable {
   // it would create a circular reference. In that case, the grad_fn must be
   // passed in to the unpack function when reconstructing the Variable.
   std::shared_ptr<Function> grad_fn_;
-  bool has_grad_fn_ = false;
   std::weak_ptr<Function> grad_accumulator_;
-
-  VariableVersion version_counter_;
-  uint32_t saved_version_ = 0;
-
-  bool requires_grad_ = false;
-  int output_nr_ = -1;
-
   std::unique_ptr<jit::tracer::ValueTracingState> tracing_state_;
+  VariableVersion version_counter_;
+
+  uint32_t saved_version_ = 0;
+  int output_nr_ = -1;
+  bool was_default_constructed_ = true;
+  bool requires_grad_ = false;
+  bool has_grad_fn_ = false;
 };
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -163,4 +163,13 @@ void Variable::detach_() {
   set_requires_grad(false);
   set_gradient_edge(Edge());
 }
+
+void Variable::set_tracing_state(
+    jit::tracer::ValueTracingState* new_tracing_state) {
+  get()->tracing_state.reset(new_tracing_state);
+}
+
+jit::tracer::ValueTracingState& Variable::tracing_state() const noexcept {
+  return *get()->tracing_state;
+}
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -151,7 +151,7 @@ void Variable::rebase_history(Edge gradient_edge) {
 
 Variable Variable::detach() const {
   auto detached = make_variable(data(), /*requires_grad=*/false);
-  detached.set_version(version_counter());
+  detached.set_version_counter(version_counter());
   return detached;
 }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -83,8 +83,7 @@ std::shared_ptr<Function> Variable::Impl::get_grad_accumulator() {
   std::lock_guard<std::mutex> lock(mutex);
 
   auto result = grad_accumulator.lock();
-  if (result)
-    return result;
+  if (result) return result;
 
   result = std::make_shared<AccumulateGrad>(Variable(this, true));
   grad_accumulator = result;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -11,12 +11,7 @@
 #include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
 
-#include <ATen/Scalar.h>
-#include <ATen/ScalarType.h>
-#include <ATen/Storage.h>
-#include <ATen/Tensor.h>
-#include <ATen/TensorImpl.h>
-#include <ATen/Type.h>
+#include <ATen/ATen.h>
 
 #include <list>
 #include <memory>
@@ -38,13 +33,13 @@ at::Tensor handle_scalars(at::Tensor& data) {
 }
 } // namespace
 
-Variable::Impl::Impl(at::Tensor data_, bool requires_grad_, Edge gradient_edge)
+Variable::Impl::Impl(at::Tensor data_, bool requires_grad_, Edge gradient_edge_)
     : TensorImpl(VariableType::getType(data_)),
       data(std::move(data_)),
-      grad_fn(std::move(gradient_edge.function)),
+      grad_fn(std::move(gradient_edge_.function)),
       requires_grad(requires_grad_),
       is_view(false),
-      output_nr(gradient_edge.input_nr),
+      output_nr(gradient_edge_.input_nr),
       pyobj(nullptr) {
   TORCH_ASSERTM(
       !grad_fn || !requires_grad,
@@ -134,8 +129,8 @@ std::shared_ptr<Function> Variable::Impl::get_grad_accumulator() {
 Variable::ViewImpl::ViewImpl(
     Variable base_,
     at::Tensor data_,
-    Edge gradient_edge)
-    : Variable::Impl(std::move(data_), false, std::move(gradient_edge)),
+    Edge gradient_edge_)
+    : Variable::Impl(std::move(data_), false, std::move(gradient_edge_)),
       base(std::move(base_)) {
   TORCH_ASSERTM(base.defined(), "base is undefined");
   if (base.is_view()) {
@@ -204,5 +199,4 @@ void Variable::detach_() {
   set_requires_grad(false);
   set_gradient_edge(Edge());
 }
-
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -5,7 +5,6 @@
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable_version.h"
-#include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
 
 #include <ATen/ATen.h>
@@ -17,9 +16,19 @@
 #include <string>
 #include <vector>
 
-namespace torch { namespace autograd {
-
+namespace torch {
+namespace autograd {
 struct Function;
+} // namespace autograd
+namespace jit { namespace tracer {
+// Has to be forward declared because tracer_state.h has a dependency on
+// variable.h
+struct ValueTracingStateElem;
+using ValueTracingState = std::list<ValueTracingStateElem>;
+}} // namespace jit::tracer
+} // namespace torch
+
+namespace torch { namespace autograd {
 
 //===----------------------------------------------------------------------===//
 //                                Variable
@@ -397,16 +406,6 @@ inline const std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks()
 
 inline void Variable::clear_hooks() {
   get()->hooks.clear();
-}
-
-inline void Variable::set_tracing_state(
-    jit::tracer::ValueTracingState* new_tracing_state) {
-  get()->tracing_state.reset(new_tracing_state);
-}
-
-inline jit::tracer::ValueTracingState& Variable::tracing_state() const
-    noexcept {
-  return *get()->tracing_state;
 }
 
 inline bool Variable::has_tracing_state() const noexcept {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -22,7 +22,7 @@ struct Function;
 } // namespace autograd
 namespace jit { namespace tracer {
 // Has to be forward declared because tracer_state.h has a dependency on
-// variable.h
+// variable.h.
 struct ValueTracingStateElem;
 using ValueTracingState = std::list<ValueTracingStateElem>;
 }} // namespace jit::tracer
@@ -30,36 +30,85 @@ using ValueTracingState = std::list<ValueTracingStateElem>;
 
 namespace torch { namespace autograd {
 
-//===----------------------------------------------------------------------===//
-//                                Variable
-//===----------------------------------------------------------------------===//
-
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+///                                Variable
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// A `Variable` augments a `Tensor` with the ability to interact in our
-/// autograd machinery. `Variable` inherits from `Tensor` and may be converted
-/// to and from `Tensor` implicitly.
+/// autograd machinery. Conceptually, `Variable`s travel along `Edge`s between
+/// `Function`s in the autograd graph. A `Variable` can either be a leaf, like a
+/// weight in a neural network, or an interior variable, when it is the result
+/// of an operation between variables. Every `Variable` also stores another
+/// `Variable` (recursively) called its `grad` (gradient). If the variable is a
+/// leaf, its gradient will be accumulated into this variable.
+///
+///                             Gradient Edges
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// Furthermore, `Variable`s have the notion of a `gradient_edge`, which is the
+/// edge in the autograd graph that connects the variable to a particular input
+/// of the gradient function that will be invoked with the variable during the
+/// backward pass. More precisely, this gradient function can be one of two
+/// things:
+/// 1. A `grad_fn`, if the variable is in the interior of the graph. This is the
+///    gradient of the function that produced the variable.
+/// 2. A `grad_accumulator`, if the variable is a leaf, which accumulates a
+///    scalar gradient value into its `grad` variable.
+///
+///                               Versioning
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// Another major feature of `Variable`s are *versions*. Versions are
+/// incremented when an in-place mutation of a variable occurs. Versions are
+/// useful when constructing `SavedVariable`s, which take a snapshot of a
+/// `Variable` at a certain version. You can retrieve a `Variable`'s version
+/// through its `current_version()` method.
+///
+///                                Views
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// It is possible for a  `Variable` to be a *view* of another `Variable`, in
+/// which case it tracks that `Variable`'s data and autograd history. Beyond
+/// construction, the interface of a view is identical to that of a regular
+/// `Variable`. You can determine whether `Variable` is in fact a view by
+/// probing its `is_view()` method.
+///
+///                               Interface
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// `Variable` inherits from `Tensor` and thus its API is a superset of that of
+/// `Tensor`. This means you can perform all the usual mathematical and other
+/// operations you can perform on `Tensor`s also on `Variable`s. Furthermore,
+/// `Variable` and `Tensor` actually convert implicitly between each other. You
+/// can thus call functions defined on `Tensor`s also with `Variable`s. Besides
+/// the constructor of `Variable` that converts to it from `Tensor`, you can use
+/// the `make_variable` free functions to create variables. To create views,
+/// use `make_variable_view` instead.
+///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 struct Variable : public at::Tensor {
- public:
   /// Default constructor.
   Variable() = default;
+
+  // Factory Functions
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   // NOTE: These factory functions have to be friends to access the
   // `Variable::Impl`. As a side effect, it allows us to keep them in the class.
 
-  /// Create a Variable that is a *view* of another (*base*) variable.
+  /// Creates a `Variable` that is a *view* of another (*base*) variable.
   /// The `gradient_edge` is an optional (gradient_function, input_number) pair.
   friend Variable
   make_variable_view(Variable base, at::Tensor data, Edge gradient_edge);
 
-  /// Create a `Variable` from the given `Tensor`. `requires_grad` should be set
+  /// Creates a `Variable` from the given `Tensor`. `requires_grad` should be set
   /// only for leaves, and determines whether the `Variable` will accumulate
   /// gradients.
   friend Variable make_variable(at::Tensor data, bool requires_grad);
 
-  /// Create a `Variable` from the given `Tensor` and specify a `gradient_edge`,
+  /// Creates a `Variable` from the given `Tensor` and specify a `gradient_edge`,
   /// i.e. a (function, input_nr) pair specifying the function in the autograd
   /// graph, and what particular input of that function, this variable is
   /// connected to.
   friend Variable make_variable(at::Tensor data, Edge gradient_edge);
+
+  // Tensor Conversions
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   // "Downcasts" a `Tensor` into a `Variable`. Only call this on tensors you
   // know are Variables.
@@ -69,45 +118,42 @@ struct Variable : public at::Tensor {
 
   // NOTE: Assignment operators to Tensor come for free from the constructors.
 
-  /// Downcast the `Tensor` reference to a `Variable` reference. If compiling in
-  /// DEBUG mode and the tensor's dynamic type is not in fact `Variable`, throw
-  /// a `std::runtime_error` exception.
+  /// Downcasts the `Tensor` reference to a `Variable` reference. If compiling
+  /// in DEBUG mode and the tensor's dynamic type is not in fact `Variable`,
+  /// throws a `std::runtime_error` exception.
   /// NOTE: Has to be a friend function because runtime type information is
   /// available only for `TensorImpl`/`Impl` and not the `Tensor`/`Variable`
   /// classes, as the latter are not polymorphic classes (`Tensor` has no
   /// virtual methods).
   friend Variable& as_variable_ref(at::Tensor& tensor);
 
-  /// Compare this `Variable` to another `Variable` (or `Tensor`) via
-  /// pointer-equality.
-  bool is_same(const Variable& other) const noexcept {
-    return this->pImpl == other.pImpl;
-  }
+  const at::Tensor& data() const noexcept;
+  at::Tensor& data() noexcept;
 
-  void set_name(const std::string& name);
-  const std::string& name() const noexcept;
+  // Gradient Function and Edges
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  /// Get the gradient function of the `Variable`. If this is a leaf variable,
+  /// Gets the gradient function of the `Variable`. If this is a leaf variable,
   /// the pointer returned will be null.
   const std::shared_ptr<Function>& grad_fn() const;
 
-  /// Get the raw gradient function pointer, whatever it currently is.
+  /// Gets the raw gradient function pointer, whatever it currently is.
   Function* grad_fn_unsafe() const;
 
-  /// Set the gradient accumulator of the `Variable`. This is only applicable
+  /// Sets the gradient accumulator of the `Variable`. This is only applicable
   /// to leaf variables. Interior variables should call `set_gradient_edge()`.
   void set_grad_accumulator(std::weak_ptr<Function> grad_accumulator);
 
-  /// Attempt to get a pointer to the gradient accumulator of the `Variable`,
+  /// Attempts to get a pointer to the gradient accumulator of the `Variable`,
   /// if it still exists. If the gradient accumulator function has been
   /// destroyed, returns a `nullptr`.
   std::shared_ptr<Function> try_get_grad_accumulator() const;
 
-  /// Get the gradient accumulator of the `Variable` if it has one, or else
+  /// Gets the gradient accumulator of the `Variable` if it has one, or else
   /// create one on the fly and return it.
   std::shared_ptr<Function> grad_accumulator() const;
 
-  /// Set the gradient edge -- i.e. `grad_fn` and `input_nr` -- of the
+  /// Sets the gradient edge -- i.e. `grad_fn` and `input_nr` -- of the
   /// `Variable`.
   /// NOTE: This will always set the `grad_fn`, even if this is a leaf
   /// variable, and never the `grad_accumulator`. For the latter, use
@@ -115,7 +161,7 @@ struct Variable : public at::Tensor {
   /// `Variable`.
   void set_gradient_edge(Edge&& edge) noexcept;
 
-  /// Return the "canonical" gradient edge of this `Variable`, i.e. either the
+  /// Returns the "canonical" gradient edge of this `Variable`, i.e. either the
   /// gradient function if this is an interior `Variable`, or the gradient
   /// accumulator otherwise. If the `Variable` is interior, the returned `Edge`
   /// will store the input index of the `Function` to which this variable is
@@ -137,32 +183,49 @@ struct Variable : public at::Tensor {
     }
   }
 
-  /// Return the input index of the gradient `Function` to which this `Variable`
+  /// Returns the input index of the gradient `Function` to which this `Variable`
   /// is connected.
   uint32_t output_nr() const noexcept;
 
-  void set_requires_grad(bool requires_grad) noexcept;
-  bool requires_grad() const noexcept;
+  /// True if this `Variable` is a leaf and thus does not have a `grad_fn`.
+  bool is_leaf() const noexcept;
 
-  PyObject* pyobj() const noexcept;
-  void set_pyobj(PyObject* pyobj) noexcept;
+  // The Grad Variable
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  const at::Tensor& data() const noexcept;
-  at::Tensor& data() noexcept;
-
-  /// Access the gradient `Variable` of this `Variable`.
+  /// Accesses the gradient `Variable` of this `Variable`.
   const Variable& grad() const noexcept;
   Variable& grad() noexcept;
   void reset_grad() noexcept;
 
-  /// True if this `Variable` is a leaf and thus does not have a `grad_fn`.
-  bool is_leaf() const noexcept;
+  /// Sets the `requires_grad` property of `Variable`. This should be true for
+  /// leaf variables that want to accumulate gradients, and false for all other
+  /// variables.
+  void set_requires_grad(bool requires_grad) noexcept;
+  bool requires_grad() const noexcept;
+
+  // Versions
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Increments the version count of this `Variable`.
+  void bump_version() noexcept;
+  void set_version(const VariableVersion& version) noexcept;
+
+  /// Retrieves this `Variable`s version counter.
+  const VariableVersion& version_counter() const noexcept;
+
+  /// Retrieves the current value of the `Variable`'s version counter.
+  /// Equivalent to calling `version_counter().current_version()`.
+  uint32_t current_version() const noexcept;
+
+  // Autograd Graph Interaction
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   /// Update the grad_fn of an existing Variable. Called after in-place
   /// modifications.
   void rebase_history(Edge gradient_edge);
 
-  /// Return a copy of this `Variable` that is detached from its autograd graph
+  /// Returns a copy of this `Variable` that is detached from its autograd graph
   /// and has a blank version. This method is OK to call if the `Variable` is a
   /// view.
   Variable detach() const;
@@ -172,35 +235,51 @@ struct Variable : public at::Tensor {
   /// this. If this `Variable` is a view, throws an `std::runtime_error()`.
   void detach_();
 
-  /// Increment the version count of this `Variable`.
-  void bump_version() noexcept;
-  void set_version(const VariableVersion& version) noexcept;
-
-  /// Return true if this `Variable` is a view of another `Variable`.
-  bool is_view() const noexcept;
-
-  /// Return the `Variable` that this `Variable` is a view of. If this
-  /// `Variable` is not a view, throw a `std::runtime_error`.
-  const Variable& base() const;
-
-  /// Retrieve this `Variable`s version counter.
-  const VariableVersion& version_counter() const noexcept;
-
-  /// Retrieve the current value of the `Variable`'s version counter. Equivalent
-  /// to calling `version_counter().current_version()`.
-  uint32_t current_version() const noexcept;
+  // Hooks
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   void add_hook(std::shared_ptr<FunctionPreHook> hook);
   const std::vector<std::shared_ptr<FunctionPreHook>>& hooks() const noexcept;
   void clear_hooks();
 
+  // JIT Tracing
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
   void set_tracing_state(jit::tracer::ValueTracingState* new_tracing_state);
   jit::tracer::ValueTracingState& tracing_state() const noexcept;
 
-  /// Return true if the `Variable`'s tracing state is not null.
+  /// Returns true if the `Variable`'s tracing state is not null.
   bool has_tracing_state() const noexcept;
 
-  /// Set the type of the underlying `Tensor`. Used for a bad (hopefully)
+  // View Variables
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Returns true if this `Variable` is a view of another `Variable`.
+  bool is_view() const noexcept;
+
+  /// Returns the `Variable` that this `Variable` is a view of. If this
+  /// `Variable` is not a view, throw a `std::runtime_error`.
+  const Variable& base() const;
+
+  // Miscellaneous
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Compares this `Variable` to another `Variable` (or `Tensor`) via
+  /// pointer-equality.
+  bool is_same(const Variable& other) const noexcept {
+    return this->pImpl == other.pImpl;
+  }
+
+  void set_name(const std::string& name);
+  const std::string& name() const noexcept;
+
+  PyObject* pyobj() const noexcept;
+  void set_pyobj(PyObject* pyobj) noexcept;
+
+  // Hacks!
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Sets the type of the underlying `Tensor`. Used for a bad (hopefully)
   /// temporary hack in python_variable.h. If removed, also remove the `using
   /// at::TensorImpl::type_;` in `Variable::Impl`.
   void temporary_hack_set_type(at::Type*) noexcept;
@@ -211,13 +290,17 @@ struct Variable : public at::Tensor {
   /// never be exposed to the public interface of this class.
   struct Impl;
   struct ViewImpl;
+
+  // Private Methods
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
   Variable(Variable::Impl* self, bool retain);
   Impl* get() const noexcept;
 };
 
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //                            Variable::Impl
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 struct Variable::Impl : public at::TensorImpl {
   explicit Impl(
@@ -274,38 +357,38 @@ struct Variable::Impl : public at::TensorImpl {
   auto_unique_ptr<jit::tracer::ValueTracingState> tracing_state;
 };
 
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //                          Variable::ViewImpl
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// A Variable that is a view on another Variable. The base and view share the
-// same version_counter. The grad_fn field of the Variable may become stale
-// due to in-place modifications of the shared data. Accesses should go
-// through get_grad_fn(). All other fields are always valid.
+/// A Variable that is a view on another Variable. The base and view share the
+/// same version_counter. The grad_fn field of the Variable may become stale
+/// due to in-place modifications of the shared data. Accesses should go
+/// through get_grad_fn(). All other fields are always valid.
 struct Variable::ViewImpl : public Variable::Impl {
   ViewImpl(Variable base_, at::Tensor data_, Edge gradient_edge);
 
-  // Gets the up-to-date grad_fn. If the shared data or base was modified, we
-  // re-create the grad_fn to express the up-to-date view relationship between
-  // this and the base Variable.
+  /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
+  /// re-create the grad_fn to express the up-to-date view relationship between
+  /// this and the base Variable.
   virtual std::shared_ptr<Function>& get_grad_fn() override;
 
-  // Called after in-place modifications. Modifies the grad_fn of the base
-  // Variable.
+  /// Called after in-place modifications. Modifies the grad_fn of the base
+  /// Variable.
   void rebase_history(Edge gradient_edge);
 
-  // The base Variable (never a view)
+  /// The base `Variable` (never a view).
   Variable base;
 
-  // The value of the version_counter at the time grad_fn was created. The
-  // grad_fn field is stale if attr_version !=
-  // version_counter.current_version()
+  /// The value of the version_counter at the time grad_fn was created. The
+  /// grad_fn field is stale if attr_version !=
+  /// version_counter.current_version().
   uint32_t attr_version;
 };
 
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //                        Variable Implementation
-//===----------------------------------------------------------------------===//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 namespace detail {
 inline at::Tensor handle_scalars(at::Tensor& data) {
@@ -319,139 +402,8 @@ inline at::Tensor handle_scalars(at::Tensor& data) {
 }
 } // namespace detail
 
-inline Variable::Variable(Variable::Impl* self, bool retain)
-    : at::Tensor(self, retain) {}
-
-inline const std::shared_ptr<Function>& Variable::grad_fn() const {
-  return get()->get_grad_fn();
-}
-
-inline Function* Variable::grad_fn_unsafe() const {
-  return get()->grad_fn.get();
-}
-
-inline void Variable::set_grad_accumulator(
-    std::weak_ptr<Function> grad_accumulator) {
-  get()->grad_accumulator = std::move(grad_accumulator);
-}
-
-inline std::shared_ptr<Function> Variable::try_get_grad_accumulator() const {
-  return get()->grad_accumulator.lock();
-}
-
-inline std::shared_ptr<Function> Variable::grad_accumulator() const {
-  return get()->get_grad_accumulator();
-}
-
-inline void Variable::set_gradient_edge(Edge&& edge) noexcept {
-  get()->grad_fn = std::move(edge.function);
-  get()->output_nr = edge.input_nr;
-}
-
-inline uint32_t Variable::output_nr() const noexcept {
-  return get()->output_nr;
-}
-
-inline void Variable::set_requires_grad(bool requires_grad) noexcept {
-  get()->requires_grad = requires_grad;
-}
-
-inline bool Variable::requires_grad() const noexcept {
-  return get()->requires_grad || get()->grad_fn ||
-      (is_view() && base().requires_grad());
-}
-
-inline void Variable::set_pyobj(PyObject* pyobj) noexcept {
-  get()->pyobj = pyobj;
-}
-
-inline PyObject* Variable::pyobj() const noexcept {
-  return get()->pyobj;
-}
-
-inline void Variable::temporary_hack_set_type(at::Type* new_type) noexcept {
-  get()->type_ = new_type;
-}
-
-inline void Variable::reset_grad() noexcept {
-  get()->grad.reset();
-}
-
-inline const at::Tensor& Variable::data() const noexcept {
-  return get()->data;
-}
-
-inline at::Tensor& Variable::data() noexcept {
-  return get()->data;
-}
-
-inline const Variable& Variable::grad() const noexcept {
-  return get()->grad;
-}
-
-inline Variable& Variable::grad() noexcept {
-  return get()->grad;
-}
-
-inline bool Variable::is_leaf() const noexcept {
-  return get()->grad_fn == nullptr;
-}
-
-inline void Variable::add_hook(std::shared_ptr<FunctionPreHook> hook) {
-  get()->hooks.push_back(std::move(hook));
-}
-
-inline const std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks()
-    const noexcept {
-  return get()->hooks;
-}
-
-inline void Variable::clear_hooks() {
-  get()->hooks.clear();
-}
-
-inline bool Variable::has_tracing_state() const noexcept {
-  return get()->tracing_state != nullptr;
-}
-
-inline void Variable::set_version(const VariableVersion& version) noexcept {
-  get()->version_counter = version;
-}
-
-inline void Variable::bump_version() noexcept {
-  get()->version_counter.bump();
-}
-
-inline uint32_t Variable::current_version() const noexcept {
-  return get()->version_counter.current_version();
-}
-
-inline const VariableVersion& Variable::version_counter() const noexcept {
-  return get()->version_counter;
-}
-
-inline bool Variable::is_view() const noexcept {
-  return get()->is_view;
-}
-
-inline const Variable& Variable::base() const {
-  if (is_view()) {
-    return static_cast<Variable::ViewImpl*>(get())->base;
-  }
-  throw std::runtime_error("Can't get base of non-view");
-}
-
-inline void Variable::set_name(const std::string& name) {
-  get()->name = name;
-}
-
-inline const std::string& Variable::name() const noexcept {
-  return get()->name;
-}
-
-inline Variable::Impl* Variable::get() const noexcept {
-  return static_cast<Variable::Impl*>(pImpl);
-}
+// Factory Functions
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 inline Variable make_variable_view(
     Variable base,
@@ -483,6 +435,9 @@ inline Variable make_variable(at::Tensor data, Edge gradient_edge) {
   return Variable();
 }
 
+// Tensor Conversion
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 inline Variable& as_variable_ref(at::Tensor& tensor) {
 #ifdef DEBUG
   // dynamic_cast will return a nullptr if the `TensorImpl`'s dynamic type is
@@ -495,4 +450,166 @@ inline Variable& as_variable_ref(at::Tensor& tensor) {
 #endif
   return static_cast<Variable&>(tensor);
 }
+
+inline const at::Tensor& Variable::data() const noexcept {
+  return get()->data;
+}
+
+inline at::Tensor& Variable::data() noexcept {
+  return get()->data;
+}
+
+// Gradient Function and Edges
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline const std::shared_ptr<Function>& Variable::grad_fn() const {
+  return get()->get_grad_fn();
+}
+
+inline Function* Variable::grad_fn_unsafe() const {
+  return get()->grad_fn.get();
+}
+
+inline void Variable::set_grad_accumulator(
+    std::weak_ptr<Function> grad_accumulator) {
+  get()->grad_accumulator = std::move(grad_accumulator);
+}
+
+inline std::shared_ptr<Function> Variable::try_get_grad_accumulator() const {
+  return get()->grad_accumulator.lock();
+}
+
+inline std::shared_ptr<Function> Variable::grad_accumulator() const {
+  return get()->get_grad_accumulator();
+}
+
+inline void Variable::set_gradient_edge(Edge&& edge) noexcept {
+  get()->grad_fn = std::move(edge.function);
+  get()->output_nr = edge.input_nr;
+}
+
+inline uint32_t Variable::output_nr() const noexcept {
+  return get()->output_nr;
+}
+
+inline bool Variable::is_leaf() const noexcept {
+  return get()->grad_fn == nullptr;
+}
+
+// The Grad Variable
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline const Variable& Variable::grad() const noexcept {
+  return get()->grad;
+}
+
+inline Variable& Variable::grad() noexcept {
+  return get()->grad;
+}
+
+inline void Variable::reset_grad() noexcept {
+  get()->grad.reset();
+}
+
+inline void Variable::set_requires_grad(bool requires_grad) noexcept {
+  get()->requires_grad = requires_grad;
+}
+
+inline bool Variable::requires_grad() const noexcept {
+  return get()->requires_grad || get()->grad_fn ||
+      (is_view() && base().requires_grad());
+}
+
+// Versions
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline void Variable::set_version(const VariableVersion& version) noexcept {
+  get()->version_counter = version;
+}
+
+inline void Variable::bump_version() noexcept {
+  get()->version_counter.bump();
+}
+
+inline uint32_t Variable::current_version() const noexcept {
+  return get()->version_counter.current_version();
+}
+
+inline const VariableVersion& Variable::version_counter() const noexcept {
+  return get()->version_counter;
+}
+
+// Hooks
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline void Variable::add_hook(std::shared_ptr<FunctionPreHook> hook) {
+  get()->hooks.push_back(std::move(hook));
+}
+
+inline const std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks()
+    const noexcept {
+  return get()->hooks;
+}
+
+inline void Variable::clear_hooks() {
+  get()->hooks.clear();
+}
+
+// JIT Tracing
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline bool Variable::has_tracing_state() const noexcept {
+  return get()->tracing_state != nullptr;
+}
+
+// View Variables
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline bool Variable::is_view() const noexcept {
+  return get()->is_view;
+}
+
+inline const Variable& Variable::base() const {
+  if (is_view()) {
+    return static_cast<Variable::ViewImpl*>(get())->base;
+  }
+  throw std::runtime_error("Can't get base of non-view");
+}
+
+// Miscellaneous
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline void Variable::set_name(const std::string& name) {
+  get()->name = name;
+}
+
+inline const std::string& Variable::name() const noexcept {
+  return get()->name;
+}
+
+inline void Variable::set_pyobj(PyObject* pyobj) noexcept {
+  get()->pyobj = pyobj;
+}
+
+inline PyObject* Variable::pyobj() const noexcept {
+  return get()->pyobj;
+}
+
+// Hacks!
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline void Variable::temporary_hack_set_type(at::Type* new_type) noexcept {
+  get()->type_ = new_type;
+}
+
+// Private Methods
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+inline Variable::Variable(Variable::Impl* self, bool retain)
+    : at::Tensor(self, retain) {}
+
+inline Variable::Impl* Variable::get() const noexcept {
+  return static_cast<Variable::Impl*>(pImpl);
+}
+
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -53,7 +53,7 @@ class Variable : public at::Tensor {
     return this->pImpl == other.pImpl;
   }
 
-  void set_name(const std::string& name) noexcept;
+  void set_name(const std::string& name);
   const std::string& name() const noexcept;
 
   /// Get the gradient function of the `Variable`. If this is a leaf variable,
@@ -400,7 +400,7 @@ inline const Variable& Variable::base() const {
   throw std::runtime_error("Can't get base of non-view");
 }
 
-inline void Variable::set_name(const std::string& name) noexcept {
+inline void Variable::set_name(const std::string& name) {
   get()->name = name;
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -196,6 +196,8 @@ struct Variable : public at::Tensor {
 
   void set_tracing_state(jit::tracer::ValueTracingState* new_tracing_state);
   jit::tracer::ValueTracingState& tracing_state() const noexcept;
+
+  /// Return true if the `Variable`'s tracing state is not null.
   bool has_tracing_state() const noexcept;
 
   /// Set the type of the underlying `Tensor`. Used for a bad (hopefully)

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -215,7 +215,7 @@ struct Variable : public at::Tensor {
 
   /// Increments the version count of this `Variable`.
   void bump_version() noexcept;
-  void set_version(const VariableVersion& version) noexcept;
+  void set_version_counter(const VariableVersion& version_counter) noexcept;
 
   /// Retrieves this `Variable`s version counter.
   const VariableVersion& version_counter() const noexcept;
@@ -529,8 +529,9 @@ inline bool Variable::requires_grad() const noexcept {
 // Versions
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-inline void Variable::set_version(const VariableVersion& version) noexcept {
-  get()->version_counter = version;
+inline void Variable::set_version_counter(
+    const VariableVersion& version_counter) noexcept {
+  get()->version_counter = version_counter;
 }
 
 inline void Variable::bump_version() noexcept {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -139,7 +139,7 @@ struct Variable : public at::Tensor {
 
   /// Return the input index of the gradient `Function` to which this `Variable`
   /// is connected.
-  int output_nr() const noexcept;
+  uint32_t output_nr() const noexcept;
 
   void set_requires_grad(bool requires_grad) noexcept;
   bool requires_grad() const noexcept;
@@ -260,7 +260,7 @@ struct Variable::Impl : public at::TensorImpl {
   // was the second output of a function, then output_nr == 1.
   // We use this to make sure we can setup the backwards trace
   // correctly when this variable is passed to another function.
-  int output_nr;
+  uint32_t output_nr;
   PyObject* pyobj; // weak reference
 
   // Mutex to ensure that concurrent read operations that modify internal
@@ -346,7 +346,7 @@ inline void Variable::set_gradient_edge(Edge&& edge) noexcept {
   get()->output_nr = edge.input_nr;
 }
 
-inline int Variable::output_nr() const noexcept {
+inline uint32_t Variable::output_nr() const noexcept {
   return get()->output_nr;
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -83,7 +83,7 @@ struct Variable : public at::Tensor {
   const std::shared_ptr<Function>& grad_fn() const;
 
   /// Get the raw gradient function pointer, whatever it currently is.
-  Function* grad_fn_ptr() const;
+  Function* grad_fn_unsafe() const;
 
   /// Set the gradient accumulator of the `Variable`. This is only applicable
   /// to leaf variables. Interior variables should call `set_gradient_edge()`.
@@ -309,7 +309,7 @@ inline const std::shared_ptr<Function>& Variable::grad_fn() const {
   return get()->get_grad_fn();
 }
 
-inline Function* Variable::grad_fn_ptr() const {
+inline Function* Variable::grad_fn_unsafe() const {
   return get()->grad_fn.get();
 }
 

--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -14,8 +14,7 @@
 // 2. Detached variables share the version counter of the source,
 // 3. Unpacked saved variables share the version counter of the source.
 
-namespace torch {
-namespace autograd {
+namespace torch { namespace autograd {
 
 class VariableVersion {
  public:
@@ -25,7 +24,7 @@ class VariableVersion {
   VariableVersion(uint32_t version = 0)
       : version_block_(std::make_shared<std::atomic<uint32_t>>(version)) {}
 
-  void bump() {
+  void bump() noexcept {
     version_block_->fetch_add(1);
   }
 
@@ -36,5 +35,4 @@ class VariableVersion {
  private:
   std::shared_ptr<std::atomic<uint32_t>> version_block_;
 };
-} // namespace autograd
-} // namespace torch
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -1,96 +1,40 @@
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include <memory>
 
 // Every Variable has a version counter. Version counters are incremented
-// whenever  the data or shape of a tensor changes through Variable operations.
+// whenever the data or shape of a tensor changes through Variable operations.
 // These are typicallly in-place operations. Version counters are used to
-// detect modifications to saved varaibles which would result in incorrect
+// detect modifications to saved variables which would result in incorrect
 // gradient calculations. Version counters may be shared between Variables:
 //
-// 1. A view shares the version counter of the base Variable
-// 2. Detached variables share the version counter of the source
-// 3. Unpacked saved variables share the version counter of the source
+// 1. A view shares the version counter of the base Variable,
+// 2. Detached variables share the version counter of the source,
+// 3. Unpacked saved variables share the version counter of the source.
 
-namespace torch { namespace autograd {
+namespace torch {
+namespace autograd {
 
-struct VersionBlock {
-  VersionBlock() : version() {}
+class VariableVersion {
+ public:
+  // NOTE: As of C++11 and 14, default-constructing a std::atomic variable
+  // leaves it in a persistently undefined state. See
+  // https://cplusplus.github.io/LWG/issue2334.
+  VariableVersion(uint32_t version = 0)
+      : version_block_(std::make_shared<std::atomic<uint32_t>>(version)) {}
 
-  // monotonically increasing version
-  std::atomic<int> version;
+  void bump() {
+    version_block_->fetch_add(1);
+  }
+
+  uint32_t current_version() const noexcept {
+    return version_block_->load();
+  }
+
+ private:
+  std::shared_ptr<std::atomic<uint32_t>> version_block_;
 };
-
-struct SavedVersion;
-
-struct VariableVersion {
-  VariableVersion() : version_block(std::make_shared<VersionBlock>()) {}
-  VariableVersion(const VariableVersion&) = delete;
-  VariableVersion(VariableVersion&&) = delete;
-
-  // increment the version counter
-  void increment() { version_block->version++; }
-
-  // current version
-  int current_version() const { return version_block->version.load(); }
-
-  // creates a saved reference with the current version and the counter
-  inline SavedVersion save() const;
-
-  // Uses another variable's version counter. Used for variables which share storages
-  // NOTE: not thread-safe to call this from multiple threads without synchronization
-  // because shared_ptr assignment isn't thread-safe.
-  VariableVersion& operator=(const VariableVersion& other) {
-    version_block = other.version_block;
-    return *this;
-  }
-
-  // Uses the version counter from a SavedVariable
-  // NOTE: not thread-safe to call this from multiple threads without synchronization
-  inline VariableVersion& operator=(const SavedVersion& other);
-
-private:
-  friend struct SavedVersion;
-  std::shared_ptr<VersionBlock> version_block; // always non-null
-};
-
-// The version counter used in SavedVariables. Saves the expected_version (the
-// version at the time of save) and a reference to the version counter's
-// version_block.
-struct SavedVersion {
-  SavedVersion() {}
-  SavedVersion(const VariableVersion& version)
-    : expected_version(version.current_version())
-    , version_block(version.version_block) {}
-
-  // if the version_block has been modified since when it was saved
-  bool is_modified() const {
-    return expected_version != version_block->version.load();
-  }
-
-  // true if the version_block is defined
-  bool defined() const {
-    return static_cast<bool>(version_block);
-  }
-
-private:
-  friend struct VariableVersion;
-  int expected_version;
-  std::shared_ptr<VersionBlock> version_block;  // may be null
-};
-
-SavedVersion VariableVersion::save() const {
-  return SavedVersion(*this);
-}
-
-VariableVersion& VariableVersion::operator=(const SavedVersion& other) {
-  if (!other.version_block) {
-    throw std::runtime_error(
-        "Can't take version counter from empty SavedVersion. File a bug report.");
-  }
-  version_block = other.version_block;
-  return *this;
-}
-
-
-}} // namespace torch::autograd
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/autograd/variable_version.h
+++ b/torch/csrc/autograd/variable_version.h
@@ -16,7 +16,7 @@
 
 namespace torch { namespace autograd {
 
-class VariableVersion {
+struct VariableVersion {
  public:
   // NOTE: As of C++11 and 14, default-constructing a std::atomic variable
   // leaves it in a persistently undefined state. See

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -134,6 +134,9 @@ private:
     // this is currently intentionally not done here so we can get an idea of our
     // perf before introducing overhead for correctness
     for(auto idx : grad.df_input_vjps) {
+      // Note: we have to set this up in place, or we have to throw away and
+      // reallocate variables that were already created in wrapTensors. We
+      // should add an API for this.
       auto& output = autograd::as_variable_ref(outputs[idx]);
       output.set_gradient_edge(autograd::Edge(grad_fn, grad_fn->num_inputs++));
       output.set_requires_grad(true);

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -90,7 +90,7 @@ private:
   // inplace to avoid allocations
   variable_tensor_list wrapTensors(tensor_list && list) const {
     for(auto & v : list) {
-      v = autograd::Variable(v, /*requires_grad=*/false);
+      v = autograd::make_variable(v, /*requires_grad=*/false);
     }
     return variable_tensor_list(std::move(list));
   }

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1,11 +1,13 @@
 #include "Python.h"
 #include "interpreter.h"
+
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/jit/generated/aten_dispatch.h"
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/python_variable.h"
 #include "torch/csrc/autograd/python_engine.h"
 #include "torch/csrc/autograd/functions/special.h"
@@ -62,12 +64,12 @@ struct HandleBuilder {
   }
   autograd::Variable addInput(at::Retainable* input, const VariableFlags & flags_) {
     if(handle && flags_.requires_grad) {
-      return autograd::make_variable(
-        unsafeToTensorShare(input),
-        handle->forward_inputs->num_inputs++,
-        handle->forward_inputs);
+      auto gradient_edge = autograd::Edge(
+          handle->forward_inputs, handle->forward_inputs->num_inputs++);
+      return autograd::Variable(
+          unsafeToTensorShare(input), std::move(gradient_edge));
     } else {
-      return autograd::make_variable(unsafeToTensorShare(input));
+      return autograd::Variable(unsafeToTensorShare(input), /*requires_grad=*/false);
     }
   }
   at::Retainable* addOutput(const autograd::Variable & output) {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -66,10 +66,10 @@ struct HandleBuilder {
     if(handle && flags_.requires_grad) {
       auto gradient_edge = autograd::Edge(
           handle->forward_inputs, handle->forward_inputs->num_inputs++);
-      return autograd::Variable(
+      return autograd::make_variable(
           unsafeToTensorShare(input), std::move(gradient_edge));
     } else {
-      return autograd::Variable(unsafeToTensorShare(input), /*requires_grad=*/false);
+      return autograd::make_variable(unsafeToTensorShare(input), /*requires_grad=*/false);
     }
   }
   at::Retainable* addOutput(const autograd::Variable & output) {

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -1,7 +1,12 @@
 #include "Python.h"
 
 #include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/jit/interpreter_autograd_function.h"
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/tracer_state.h"
+
+#include <ATen/ATen.h>
 
 #include <algorithm>
 #include <memory>

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -135,9 +135,10 @@ autograd::variable_list InterpreterAutogradFunction::apply(
     auto & flags = details.output_flags[i];
     if (flags.requires_grad) { // See Note [Null-edge pruning]
       if (!grad_fn) make_grad_fn();
-      result.push_back(autograd::make_variable(toutputs[i], grad_fn));
+      autograd::Edge edge(grad_fn, grad_fn->num_inputs++);
+      result.emplace_back(toutputs[i], std::move(edge));
     } else {
-      result.push_back(autograd::make_variable(toutputs[i], false));
+      result.emplace_back(toutputs[i], false);
     }
   }
 

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -2,6 +2,7 @@
 
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/autograd/function.h"
 #include "torch/csrc/jit/interpreter_autograd_function.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/tracer_state.h"
@@ -141,9 +142,9 @@ autograd::variable_list InterpreterAutogradFunction::apply(
     if (flags.requires_grad) { // See Note [Null-edge pruning]
       if (!grad_fn) make_grad_fn();
       autograd::Edge edge(grad_fn, grad_fn->num_inputs++);
-      result.emplace_back(toutputs[i], std::move(edge));
+      result.push_back(autograd::make_variable(toutputs[i], std::move(edge)));
     } else {
-      result.emplace_back(toutputs[i], false);
+      result.push_back(autograd::make_variable(toutputs[i], /*requires_grad=*/false));
     }
   }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -27,9 +27,7 @@
 #include "torch/csrc/jit/variable_flags.h"
 
 namespace torch { namespace autograd {
-
 struct Function;
-
 }} // namespace torch::autograd
 
 namespace torch { namespace jit {
@@ -437,7 +435,7 @@ public:
     return outputs_.back();
   }
   void eraseOutput(size_t i);
-  
+
   Block * addBlock();
   void eraseBlock(size_t i);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -27,7 +27,9 @@
 #include "torch/csrc/jit/variable_flags.h"
 
 namespace torch { namespace autograd {
+
 struct Function;
+
 }} // namespace torch::autograd
 
 namespace torch { namespace jit {

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include <Python.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/THP.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/interned_strings.h"
+#include "torch/csrc/jit/tracer.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -113,7 +113,7 @@ struct CompiledFunction {
       std::size_t num_captured = fn_.captured_vars_.size();
       // Check that no captured Variables were replaced by enter. It's hard to handle that.
       for (std::size_t i = num_all_inputs - num_captured; i < num_all_inputs; ++i) {
-        TORCH_EXPECTM(input_info.vars[i] == new_vars[i],
+        TORCH_EXPECTM(input_info.vars[i].is_same(new_vars[i]),
                       "Some of the Variables captured by the JIT are repeated");
       }
       // Now only arguments to this function could have changed. Slice their vars out, and

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -113,7 +113,7 @@ struct CompiledFunction {
       std::size_t num_captured = fn_.captured_vars_.size();
       // Check that no captured Variables were replaced by enter. It's hard to handle that.
       for (std::size_t i = num_all_inputs - num_captured; i < num_all_inputs; ++i) {
-        TORCH_EXPECTM(input_info.vars[i].get() == new_vars[i].get(),
+        TORCH_EXPECTM(input_info.vars[i] == new_vars[i],
                       "Some of the Variables captured by the JIT are repeated");
       }
       // Now only arguments to this function could have changed. Slice their vars out, and

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -463,7 +463,7 @@ struct ADTestSpec {
   std::vector<Variable> make_vars() const {
     std::vector<Variable> out;
     for (const auto & m : input_meta) {
-      out.emplace_back(make_variable(at::CPU(at::kFloat).tensor(m).normal_(), true));
+      out.emplace_back(Variable(at::CPU(at::kFloat).tensor(m).normal_(), /*requires_grad=*/true));
     }
     return out;
   }
@@ -642,7 +642,7 @@ void testCreateAutodiffSubgraphs(std::ostream & out) {
 }
 
 autograd::Variable var(at::Type & t, at::IntList sizes, bool requires_grad) {
-  return autograd::make_variable(t.rand(sizes), requires_grad);
+  return autograd::Variable(t.rand(sizes), requires_grad);
 }
 autograd::Variable undef() {
   return autograd::Variable();
@@ -725,7 +725,7 @@ void shapeAnalysisTest() {
 
   int hidden_size = 2*input_size;
 
-  auto v = [](at::Tensor t) { return autograd::make_variable(t, false); };
+  auto v = [](at::Tensor t) { return autograd::Variable(t, false); };
 
   auto input = at::CUDA(at::kFloat).randn({batch_size, input_size});
   auto hx    = at::CUDA(at::kFloat).randn({batch_size, hidden_size});
@@ -751,7 +751,7 @@ void testGraphExecutor() {
 
   int hidden_size = 2*input_size;
 
-  auto v = [](at::Tensor t) { return autograd::make_variable(t, false); };
+  auto v = [](at::Tensor t) { return autograd::Variable(t, false); };
 
   auto input = at::CUDA(at::kFloat).randn({batch_size, input_size});
   auto hx    = at::CUDA(at::kFloat).randn({batch_size, hidden_size});

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -463,7 +463,7 @@ struct ADTestSpec {
   std::vector<Variable> make_vars() const {
     std::vector<Variable> out;
     for (const auto & m : input_meta) {
-      out.emplace_back(Variable(at::CPU(at::kFloat).tensor(m).normal_(), /*requires_grad=*/true));
+      out.emplace_back(autograd::make_variable(at::CPU(at::kFloat).tensor(m).normal_(), /*requires_grad=*/true));
     }
     return out;
   }
@@ -642,7 +642,7 @@ void testCreateAutodiffSubgraphs(std::ostream & out) {
 }
 
 autograd::Variable var(at::Type & t, at::IntList sizes, bool requires_grad) {
-  return autograd::Variable(t.rand(sizes), requires_grad);
+  return autograd::make_variable(t.rand(sizes), requires_grad);
 }
 autograd::Variable undef() {
   return autograd::Variable();
@@ -725,7 +725,7 @@ void shapeAnalysisTest() {
 
   int hidden_size = 2*input_size;
 
-  auto v = [](at::Tensor t) { return autograd::Variable(t, false); };
+  auto v = [](at::Tensor t) { return autograd::make_variable(t, false); };
 
   auto input = at::CUDA(at::kFloat).randn({batch_size, input_size});
   auto hx    = at::CUDA(at::kFloat).randn({batch_size, hidden_size});
@@ -751,7 +751,7 @@ void testGraphExecutor() {
 
   int hidden_size = 2*input_size;
 
-  auto v = [](at::Tensor t) { return autograd::Variable(t, false); };
+  auto v = [](at::Tensor t) { return autograd::make_variable(t, false); };
 
   auto input = at::CUDA(at::kFloat).randn({batch_size, input_size});
   auto hx    = at::CUDA(at::kFloat).randn({batch_size, hidden_size});

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -8,6 +8,9 @@
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
 
+#include <string>
+#include <sstream>
+#include <memory>
 #include <frameobject.h>
 #include <patchlevel.h>
 

--- a/torch/csrc/jit/tracer_state.cpp
+++ b/torch/csrc/jit/tracer_state.cpp
@@ -1,0 +1,38 @@
+#include "torch/csrc/jit/tracer_state.h"
+#include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/ir.h"
+
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace torch { namespace jit { namespace tracer {
+TracingState::TracingState(size_t num_stages)
+    : graph(new Graph()),
+      active(false),
+      num_stages(num_stages),
+      eval_count(0),
+      var_flags(num_stages),
+      output_edges(num_stages) {}
+
+TracingState::~TracingState() = default;
+
+bool TracingState::is_complete() const {
+  return !is_expired() && graph->stage() == num_stages - 1;
+}
+
+void TracingState::push_scope(const std::string& scope_name) {
+  graph->push_scope(scope_name);
+}
+
+void TracingState::pop_scope() {
+  graph->pop_scope();
+}
+}}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -12,7 +12,7 @@
 
 namespace torch {
 namespace autograd {
-class Variable;
+struct Variable;
 struct Edge;
 } // namespace autograd
 namespace jit {

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -12,7 +12,7 @@
 
 namespace torch { namespace autograd {
 
-struct Variable;
+class Variable;
 struct Function;
 
 }}

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "torch/csrc/autograd/edge.h"
+#include "torch/csrc/autograd/variable.h"
+
 #include <atomic>
 #include <cstdint>
 #include <list>
@@ -10,17 +13,11 @@
 #include <utility>
 #include <vector>
 
-namespace torch {
-namespace autograd {
-struct Variable;
-struct Edge;
-} // namespace autograd
-namespace jit {
+namespace torch { namespace jit {
 struct Graph;
 struct Value;
 struct VariableFlags;
-} // namespace jit
-} // namespace torch
+}} // namespace torch::jit
 
 namespace torch { namespace jit { namespace tracer {
 

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -1,28 +1,31 @@
 #pragma once
 
-#include "torch/csrc/jit/ir.h"
-#include "torch/csrc/assertions.h"
-#include "torch/csrc/autograd/edge.h"
-
-#include <memory>
-#include <mutex>
-#include <vector>
+#include <atomic>
 #include <cstdint>
 #include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-namespace torch { namespace autograd {
-
+namespace torch {
+namespace autograd {
 class Variable;
-struct Function;
-
-}}
+struct Edge;
+} // namespace autograd
+namespace jit {
+struct Graph;
+struct Value;
+struct VariableFlags;
+} // namespace jit
+} // namespace torch
 
 namespace torch { namespace jit { namespace tracer {
 
-using torch::autograd::Variable;
-using torch::autograd::Function;
 using edge_list = std::vector<autograd::Edge>;
-using variable_list = std::vector<Variable>;
+using variable_list = std::vector<autograd::Variable>;
 
 // TracingState tracks the necessary state when we are tracing the execution of
 // autograd code; most importantly, it holds a reference to the actual IR
@@ -34,26 +37,19 @@ using variable_list = std::vector<Variable>;
 // from arising when a variable that participated in a trace outlives the
 // actual trace itself.
 
-using io_variable_flags_list =
-  std::vector<std::pair<std::vector<VariableFlags>, std::vector<VariableFlags>>>;
+using io_variable_flags_list = std::vector<
+    std::pair<std::vector<VariableFlags>, std::vector<VariableFlags>>>;
 
 struct TracingState : public std::enable_shared_from_this<TracingState> {
-  TracingState(std::size_t num_stages)
-    : graph(new Graph())
-    , active(false)
-    , num_stages(num_stages)
-    , eval_count(0)
-    , var_flags(num_stages)
-    , output_edges(num_stages) {}
+  explicit TracingState(size_t num_stages);
+  ~TracingState();
 
-  // XXX: graph can be NULL if it's a failed trace (failed = didn't capture all
-  // the stages we care about)
   std::shared_ptr<Graph> graph;
   bool active;
 
   // Used to free the Graph as soon as we know this trace will fail
-  std::size_t num_stages;
-  std::atomic<std::size_t> eval_count;
+  size_t num_stages;
+  std::atomic<size_t> eval_count;
 
   // void* is an unsafe TH.  NON-OWNING, so it might get invalidated.
   // TODO: Perhaps, turn this into an owning reference.  The buffers
@@ -66,23 +62,17 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   std::mutex mutex;
   variable_list inputs; // Used only for the duration of first stage
 
-  std::unique_lock<std::mutex> lock() { return std::unique_lock<std::mutex>(mutex); };
+  std::unique_lock<std::mutex> lock() {
+    return std::unique_lock<std::mutex>(mutex);
+  }
 
-  bool is_expired() const {
+  bool is_expired() const noexcept {
     return !graph;
   }
 
-  bool is_complete() const {
-    return !is_expired() && graph->stage() == num_stages - 1;
-  }
-
-  void push_scope(const std::string& scope_name) {
-    graph->push_scope(scope_name);
-  }
-
-  void pop_scope() {
-    graph->pop_scope();
-  }
+  bool is_complete() const;
+  void push_scope(const std::string& scope_name);
+  void pop_scope();
 };
 
 struct ValueTracingStateElem {
@@ -102,4 +92,4 @@ struct FunctionTracingState {
   bool in_eval_subgraph = false;
 };
 
-}}}
+}}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/variable_flags.cpp
+++ b/torch/csrc/jit/variable_flags.cpp
@@ -1,5 +1,7 @@
 #include "torch/csrc/jit/variable_flags.h"
+
 #include "torch/csrc/autograd/variable.h"
+#include "torch/csrc/jit/tracer_state.h"
 
 using torch::autograd::Variable;
 

--- a/torch/csrc/jit/variable_flags.h
+++ b/torch/csrc/jit/variable_flags.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <iostream>
 namespace torch { namespace autograd {
-class Variable;
+struct Variable;
 }}
 
 namespace torch { namespace jit {

--- a/torch/csrc/jit/variable_flags.h
+++ b/torch/csrc/jit/variable_flags.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <iostream>
 namespace torch { namespace autograd {
-struct Variable;
+class Variable;
 }}
 
 namespace torch { namespace jit {

--- a/torch/csrc/utils/hash.h
+++ b/torch/csrc/utils/hash.h
@@ -2,7 +2,6 @@
 
 #include <functional>
 #include <vector>
-#include <ATen/ATen.h>
 
 namespace torch {
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -93,7 +93,7 @@ static Tensor new_from_data(ScalarType scalarType, PyObject* data) {
   }
 #ifdef WITH_NUMPY
   if (PyArray_Check(data)) {
-    return autograd::Variable(tensor_from_numpy(data), /*requires_grad=*/false);
+    return autograd::make_variable(tensor_from_numpy(data), /*requires_grad=*/false);
   }
 #endif
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -93,14 +93,14 @@ static Tensor new_from_data(ScalarType scalarType, PyObject* data) {
   }
 #ifdef WITH_NUMPY
   if (PyArray_Check(data)) {
-    return autograd::make_variable(tensor_from_numpy(data), false);
+    return autograd::Variable(tensor_from_numpy(data), /*requires_grad=*/false);
   }
 #endif
 
   auto sizes = compute_sizes(data);
-  auto tensor = autograd::make_variable(CPU(scalarType).tensor(sizes), false);
   // TODO: we should pass tensor.sizes() rather than sizes, but this doesn't works
   // if scalars are disabled because the size changes without WITH_SCALARS.
+  auto tensor = autograd::make_variable(CPU(scalarType).tensor(sizes), /*requires_grad=*/false);
   recursive_store(
       (char*)tensor.data_ptr(), sizes, tensor.strides(), 0,
       scalarType, tensor.type().elementSizeInBytes(), data);
@@ -198,7 +198,7 @@ Tensor legacy_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
 }
 
 static Tensor set_requires_grad(Tensor self, bool requires_grad) {
-  static_cast<torch::autograd::Variable&>(self).get()->_requires_grad = requires_grad;
+  static_cast<torch::autograd::Variable&>(self).set_requires_grad(requires_grad);
   return self;
 }
 

--- a/torch/csrc/utils/tuple_parser.cpp
+++ b/torch/csrc/utils/tuple_parser.cpp
@@ -1,11 +1,15 @@
 #include "tuple_parser.h"
 
-#include <string>
 
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/autograd/python_variable.h"
 #include "python_strings.h"
 #include "python_numbers.h"
+
+#include <string>
+#include <list>
+#include <stdexcept>
+#include <vector>
 
 namespace torch {
 

--- a/torch/csrc/utils/tuple_parser.cpp
+++ b/torch/csrc/utils/tuple_parser.cpp
@@ -7,7 +7,6 @@
 #include "python_numbers.h"
 
 #include <string>
-#include <list>
 #include <stdexcept>
 #include <vector>
 

--- a/torch/csrc/utils/variadic.h
+++ b/torch/csrc/utils/variadic.h
@@ -3,6 +3,11 @@
 #include <ATen/ATen.h>
 #include "torch/csrc/autograd/variable.h"
 
+#include <cstdint>
+#include <utility>
+#include <tuple>
+#include <type_traits>
+
 namespace torch {
 
 // This class allows you to write variadic functions which
@@ -84,4 +89,23 @@ inline size_t count_variables(Args&&... args) {
   return CountVariables().apply(std::forward<Args>(args)...).out;
 }
 
+//===----------------------------------------------------------------------===//
+//                std::index_sequence shim for C++11
+//===----------------------------------------------------------------------===//
+
+// A container of type-template parameter indices.
+template<size_t... Is>
+struct Indices {};
+
+// Decrements the index N, adds N-1 to the list of indices and forwards
+// whatever we arleady have.
+template<size_t N, size_t... Is>
+struct MakeIndices : MakeIndices<N-1, N-1, Is...> {};
+
+// Partial specialization that forms our base case. When N is zero, we stop
+// and define a typedef that will be visible to earlier classes due to
+// inheritance. The typedef we define is an index list containing the numbers
+// 0 through N-1.
+template<size_t... Is>
+struct MakeIndices<0, Is...> { using indices = Indices<Is...>; };
 } // namespace torch


### PR DESCRIPTION
This PR is a large change that revamps the `autograd::Variable` interface to provide a clean API that encapsulates implementation details and reduces code required to interact with `Variable`s.

A large part of this PR are small changes to update use-sites to use the new API. I would recommend beginning by taking a look at `variable.h` and `variable.cpp`, as well as `variable_version.h`, which have large changes.

I've also attempted to improve documentation of the `Variable`. Please let me know if either the API or the documentation does not make sense, or if either could be improved.

@zdevito @apaszke @colesbury 