### PR TITLE
Disable NCCL tests for Windows

### DIFF
--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -20,6 +20,7 @@ class TestNCCL(TestCase):
         self.assertIsInstance(uid, bytes)
         self.assertGreater(len(uid), 1)
 
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_broadcast(self):
         expected = torch.FloatTensor(128).uniform_()
@@ -32,6 +33,7 @@ class TestNCCL(TestCase):
         for i in range(torch.cuda.device_count()):
             self.assertEqual(tensors[i], expected)
 
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
@@ -44,6 +46,7 @@ class TestNCCL(TestCase):
 
         self.assertEqual(tensors[0], expected)
 
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_all_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
@@ -57,6 +60,7 @@ class TestNCCL(TestCase):
         for tensor in tensors:
             self.assertEqual(tensor, expected)
 
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_all_gather(self):
         inputs = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
@@ -70,6 +74,7 @@ class TestNCCL(TestCase):
         for tensor in outputs:
             self.assertEqual(tensor, expected)
 
+    @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(nGPUs < 2, "only one GPU detected")
     def test_reduce_scatter(self):
         in_size = 32 * nGPUs


### PR DESCRIPTION
NCCL currently doesn't work with Windows (https://github.com/NVIDIA/nccl/pull/31 is the porting PR). This PR disables all related tests.

This has already been noted in https://github.com/pytorch/pytorch/issues/4092. 