### PR TITLE
Conv doc and GPU matmul error message improvements

### DIFF
--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -238,13 +238,23 @@ THCTensor_(addmm)(THCState *state, THCTensor *r_, real beta, THCTensor *t, real 
   THCTensor *r__, *m1_, *m2_;
 
   if( (m1->nDimension != 2) || (m2->nDimension != 2) )
-    THError("matrix and matrix expected");
+    THError("matrices expected, got %dD, %dD tensors", m1->nDimension, m2->nDimension);
 
   if(t->nDimension != 2)
-    THError("size mismatch");
+    THError("matrix expected, got %dD tensor for t", t->nDimension);
 
-  if( (t->size[0] != m1->size[0]) || (t->size[1] != m2->size[1]) || (m1->size[1] != m2->size[0]) )
-    THError("size mismatch");
+  if(m1->size[1] != m2->size[0]) {
+    THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
+    THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
+    THError("size mismatch, m1: %s, m2: %s", bm1.str, bm2.str);
+  }
+
+  if( (t->size[0] != m1->size[0]) || (t->size[1] != m2->size[1]) ) {
+    THCDescBuff bt  = THCTensor_(sizeDesc)(state, t);
+    THCDescBuff bm1 = THCTensor_(sizeDesc)(state, m1);
+    THCDescBuff bm2 = THCTensor_(sizeDesc)(state, m2);
+    THError("size mismatch, t: %s, m1: %s, m2: %s", bt.str, bm1.str, bm2.str);
+  }
 
   if(t != r_)
   {

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -76,28 +76,33 @@ class Conv1d(_ConvNd):
         \begin{array}{ll}
         out(N_i, C_{out_j})  = bias(C_{out_j})
                        + \sum_{{k}=0}^{C_{in}-1} weight(C_{out_j}, k)  \star input(N_i, k)
-        \end{array}
+        \end{array},
 
     where :math:`\star` is the valid `cross-correlation`_ operator,
     :math:`N` is a batch size, :math:`C` denotes a number of channels,
     :math:`L` is a length of signal sequence.
 
-    | :attr:`stride` controls the stride for the cross-correlation, a single
+    * :attr:`stride` controls the stride for the cross-correlation, a single
       number or a one-element tuple.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points.
-    | :attr:`dilation` controls the spacing between the kernel points; also
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both sides
+      for :attr:`padding` number of points.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also
       known as the à trous algorithm. It is harder to describe, but this `link`_
       has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs.
-      `in_channels` and `out_channels` must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv
-                 layers side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently
-                 concatenated.
-            At groups=`in_channels`, each input channel is convolved with its
-                 own set of filters (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     .. note::
 
@@ -181,29 +186,34 @@ class Conv2d(_ConvNd):
         \begin{array}{ll}
         out(N_i, C_{out_j})  = bias(C_{out_j})
                        + \sum_{{k}=0}^{C_{in}-1} weight(C_{out_j}, k)  \star input(N_i, k)
-        \end{array}
+        \end{array},
 
     where :math:`\star` is the valid 2D `cross-correlation`_ operator,
     :math:`N` is a batch size, :math:`C` denotes a number of channels,
     :math:`H` is a height of input planes in pixels, and :math:`W` is
     width in pixels.
 
-    | :attr:`stride` controls the stride for the cross-correlation, a single
+    * :attr:`stride` controls the stride for the cross-correlation, a single
       number or a tuple.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points for each dimension.
-    | :attr:`dilation` controls the spacing between the kernel points; also
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also
       known as the à trous algorithm. It is harder to describe, but this `link`_
       has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs.
-      `in_channels` and `out_channels` must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv
-                 layers side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently
-                 concatenated.
-            At groups=`in_channels`, each input channel is convolved with its
-                 own set of filters (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -294,23 +304,29 @@ class Conv3d(_ConvNd):
         \begin{array}{ll}
         out(N_i, C_{out_j})  = bias(C_{out_j})
                        + \sum_{{k}=0}^{C_{in}-1} weight(C_{out_j}, k)  \star input(N_i, k)
-        \end{array}
+        \end{array},
 
     where :math:`\star` is the valid 3D `cross-correlation`_ operator
 
-    | :attr:`stride` controls the stride for the cross-correlation.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points for each dimension.
-    | :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+    * :attr:`stride` controls the stride for the cross-correlation.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
       It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs. `in_channels` and `out_channels`
-      must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv layers
-                 side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently concatenated.
-            At groups=`in_channels`, each input channel is convolved with its own set of filters
-                 (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -437,22 +453,29 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
     It is also known as a fractionally-strided convolution or
     a deconvolution (although it is not an actual deconvolution operation).
 
-    | :attr:`stride` controls the stride for the cross-correlation.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points.
-    | :attr:`output_padding` controls the amount of implicit zero-paddings on
-    | both sides of the output for :attr:`output_padding` number of points.
-    | number of points.
-    | :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+    * :attr:`stride` controls the stride for the cross-correlation.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points.
+
+    * :attr:`output_padding` controls the amount of implicit zero-paddings on
+      both sides of the output for :attr:`output_padding` number of points.
+      number of points.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
       It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs. `in_channels` and `out_channels`
-      must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv layers
-                 side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently concatenated.
-            At groups=`in_channels`, each input channel is convolved with its own set of filters
-                 (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     .. note::
 
@@ -509,22 +532,29 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
     It is also known as a fractionally-strided convolution or
     a deconvolution (although it is not an actual deconvolution operation).
 
-    | :attr:`stride` controls the stride for the cross-correlation.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points for each dimension.
-    | :attr:`output_padding` controls the amount of implicit zero-paddings on
-    | both sides of the output for :attr:`output_padding` number of points for
-    | each dimension.
-    | :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+    * :attr:`stride` controls the stride for the cross-correlation.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension.
+
+    * :attr:`output_padding` controls the amount of implicit zero-paddings on
+      both sides of the output for :attr:`output_padding` number of points for
+      each dimension.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
       It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs. `in_channels` and `out_channels`
-      must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv layers
-                 side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently concatenated.
-            At groups=`in_channels`, each input channel is convolved with its own set of filters
-                 (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:
@@ -616,22 +646,29 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
     It is also known as a fractionally-strided convolution or
     a deconvolution (although it is not an actual deconvolution operation).
 
-    | :attr:`stride` controls the stride for the cross-correlation.
-    | :attr:`padding` controls the amount of implicit zero-paddings on both
-    |  sides for :attr:`padding` number of points for each dimension.
-    | :attr:`output_padding` controls the amount of implicit zero-paddings on
-    | both sides of the output for :attr:`output_padding` number of points for
-    | each dimension.
-    | :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
+    * :attr:`stride` controls the stride for the cross-correlation.
+
+    * :attr:`padding` controls the amount of implicit zero-paddings on both
+      sides for :attr:`padding` number of points for each dimension.
+
+    * :attr:`output_padding` controls the amount of implicit zero-paddings on
+      both sides of the output for :attr:`output_padding` number of points for
+      each dimension.
+
+    * :attr:`dilation` controls the spacing between the kernel points; also known as the à trous algorithm.
       It is harder to describe, but this `link`_ has a nice visualization of what :attr:`dilation` does.
-    | :attr:`groups` controls the connections between inputs and outputs. `in_channels` and `out_channels`
-      must both be divisible by `groups`.
-    |       At groups=1, all inputs are convolved to all outputs.
-    |       At groups=2, the operation becomes equivalent to having two conv layers
-                 side by side, each seeing half the input channels,
-                 and producing half the output channels, and both subsequently concatenated.
-            At groups=`in_channels`, each input channel is convolved with its own set of filters
-                 (of size `out_channels // in_channels`).
+
+    * :attr:`groups` controls the connections between inputs and outputs.
+      :attr:`in_channels` and :attr:`out_channels` must both be divisible by
+      :attr:`groups`. For example,
+
+        * At groups=1, all inputs are convolved to all outputs.
+        * At groups=2, the operation becomes equivalent to having two conv
+          layers side by side, each seeing half the input channels,
+          and producing half the output channels, and both subsequently
+          concatenated.
+        * At groups= :attr:`in_channels`, each input channel is convolved with
+          its own set of filters (of size :attr:`out_channels` // :attr:`in_channels`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:


### PR DESCRIPTION
Improves Conv*d(Transposed) docs to have correct newline and formatting

Improves CUDA matmul error message by basically copying the CPU error message  (#5135 )

e.g.,
Old doc:
<img width="740" alt="screenshot 2018-02-08 14 05 39" src="https://user-images.githubusercontent.com/5674597/35992827-64d3dedc-0cd9-11e8-80a0-6fc6e514acbc.png">

New doc:
<img width="744" alt="screenshot 2018-02-08 14 05 26" src="https://user-images.githubusercontent.com/5674597/35992829-6bf7efb4-0cd9-11e8-8d73-3b7777a79be7.png">
