### PR TITLE
Use actual identifiers in script + supporting changes/fixes in IR

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1316,6 +1316,25 @@ class TestJit(TestCase):
         outputs = a + b
         self.checkScript(script, [a, b], [outputs], False)
 
+    def test_script_ssa(self):
+        script = '''
+        def nested(a) -> (b, c):
+            a = a + a
+            b = a + a
+            b = b + a
+            c = b + a
+            c = c + b
+
+        def func(a) -> (a):
+            a = a + a
+            b, c = nested(a)
+            c = c * c
+        '''
+
+        a = Variable(torch.rand(1), requires_grad=True)
+        outputs = a + a
+        self.checkScript(script, [a], [outputs], False)
+
     def test_script_mul(self):
         script = '''
         def func(a, b) -> (c):


### PR DESCRIPTION
IR changes
- Keep track of value versions in graph representation. This makes it much easier to maintain SSA when merging graphs with unique names
- Expose interface on Graph to retrieve the latest version of a value for a given identifier
- Add flag to copyMetadata to skip setUniqueName in contexts where this has been done already

Compiler changes
- For all inputs and assignments, take the known identifier and call setUniqueName on the Value. This returns a truly unique name which we store away in the values map
- Keep track of the latest version for each identifier *in the base scope*. This helps us resolve references after we've applied a function (i.e. inlined the graph).
- Test case involving reassignment to the same identifier as well as function application

Example from test_script_ssa:

```
graph(%a : UNKNOWN_TYPE) {
  %a1 : UNKNOWN_TYPE = add[alpha={1}](%a, %a)
  %a2 : UNKNOWN_TYPE = add[alpha={1}](%a1, %a1)
  %b : UNKNOWN_TYPE = add[alpha={1}](%a2, %a2)
  %b2 : UNKNOWN_TYPE = add[alpha={1}](%b, %a2)
  %c : UNKNOWN_TYPE = add[alpha={1}](%b2, %a2)
  %c2 : UNKNOWN_TYPE = add[alpha={1}](%c, %b2)
  %c3 : UNKNOWN_TYPE = mul(%c2, %c2)
  return (%a1);
}
```