### PR TITLE
Allow zero-dim tensors to be bound to at::Scalar

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1490,6 +1490,17 @@ class TestTorch(TestCase):
     def test_contiguous(self):
         return self._test_contiguous(self, lambda t: t)
 
+    @unittest.skipIf(not torch._C._with_scalars(), "scalars not enabled")
+    def test_scalars_as_floats(self):
+        "zero-dim variables that don't require grad should bind to scalar arguments"
+        x = torch.autograd.variable(2)
+        y = torch.autograd.variable(3)
+        # 3 + (3 * 3) * 2
+        self.assertEqual(y.addcmul(y, y, value=x), 21)
+
+        x = torch.autograd.variable(2, requires_grad=True)
+        self.assertRaises(Exception, lambda: y.addcmul(y, y, value=x))
+
     @staticmethod
     def _test_broadcast_fallback(self, cast):
         # functions that should fallback to pointwise behavior
@@ -4935,6 +4946,10 @@ class TestTorch(TestCase):
         self.assertEqual(x.new([3, 4]).shape, [2])
         self.assertEqual(x.new([3, 4]).tolist(), [3, 4])
         self.assertEqual(x.new((3, 4)).tolist(), [3, 4])
+        if TEST_NUMPY:
+            self.assertEqual(x.new([np.int32(3), np.float64(4)]).tolist(), [3, 4])
+        if torch._C._with_scalars():
+            self.assertEqual(x.new([z[2], z[0] + 3]).tolist(), [3, 4])
         self.assertEqual(x.new(size=(3, 4)).shape, [3, 4])
         self.assertEqual(x.new(tuple()).shape, [0])
         self.assertEqual(x.new(y.storage()).data_ptr(), y.data_ptr())

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -80,7 +80,16 @@ bool FunctionParameter::check(PyObject* obj) {
     case ParameterType::TENSOR: {
       return THPVariable_Check(obj);
     }
-    case ParameterType::SCALAR: return THPUtils_checkDouble(obj);
+    case ParameterType::SCALAR: {
+      if (THPUtils_checkDouble(obj)) {
+        return true;
+      }
+      if (THPVariable_Check(obj)) {
+        auto& var = ((THPVariable*)obj)->cdata;
+        return !var.requires_grad() && var.dim() == 0;
+      }
+      return false;
+    }
     case ParameterType::INT64: return THPUtils_checkLong(obj);
     case ParameterType::DOUBLE: return THPUtils_checkDouble(obj);
     case ParameterType::TENSOR_LIST: return PyTuple_Check(obj) || PyList_Check(obj);

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -81,6 +81,9 @@ bool FunctionParameter::check(PyObject* obj) {
       return THPVariable_Check(obj);
     }
     case ParameterType::SCALAR: {
+      // NOTE: we don't currently accept most NumPy types as Scalars. np.float64
+      // is okay because it's a subclass of PyFloat. We may want to change this
+      // in the future.
       if (THPUtils_checkDouble(obj)) {
         return true;
       }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -147,10 +147,10 @@ inline at::Scalar PythonArgs::scalar(int i) {
 
 inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar) {
   if (!args[i]) return default_scalar;
-  if (PyFloat_Check(args[i])) {
-    return at::Scalar(THPUtils_unpackDouble(args[i]));
+  if (PyLong_CheckExact(args[i])) {
+    return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));
   }
-  return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));
+  return at::Scalar(THPUtils_unpackDouble(args[i]));
 }
 
 inline std::vector<at::Tensor> PythonArgs::tensorlist(int i) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -147,7 +147,12 @@ inline at::Scalar PythonArgs::scalar(int i) {
 
 inline at::Scalar PythonArgs::scalarWithDefault(int i, at::Scalar default_scalar) {
   if (!args[i]) return default_scalar;
-  if (PyLong_CheckExact(args[i])) {
+  // Zero-dim tensors are converted to Scalars as-is. Note this doesn't currently
+  // handle most NumPy scalar types except np.float64.
+  if (THPVariable_Check(args[i])) {
+    return at::Scalar(((THPVariable*)args[i])->cdata);
+  }
+  if (THPUtils_checkLong(args[i])) {
     return at::Scalar(static_cast<int64_t>(THPUtils_unpackLong(args[i])));
   }
   return at::Scalar(THPUtils_unpackDouble(args[i]));


### PR DESCRIPTION
```
This relaxes THPUtils_unpackLong and THPUtils_unpackDouble to allow
values convertable to PyLong and PyFloat objects. This includes NumPy
scalars and zero-dim tensors (Variables).

This is important to maintain backwards compatibility in the Tensor
constructors once scalars are enabled and Variable and Tensor are
merged.
```