### PR TITLE
Add a new_tensor instance method to Variable that takes only data.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1091,6 +1091,26 @@ class TestTorch(TestCase):
         res2[1] = 2
         self.assertEqual(expected, torch.ones_like(expected))
 
+    def test_tensor_new(self):
+        expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
+        # test data
+        res1 = expected.new_tensor([1, 1])
+        self.assertEqual(res1, expected)
+
+        # test copy
+        res2 = expected.new_tensor(expected)
+        self.assertEqual(res2, expected)
+        res2[1] = 2
+        self.assertEqual(expected, torch.ones_like(expected))
+
+        if torch.cuda.device_count() >= 2:
+            expected = expected.cuda(1)
+            res1 = expected.new_tensor([1, 1])
+            self.assertEqual(res1.get_device(), expected.get_device())
+
+            res2 = expected.new_tensor(expected)
+            self.assertEqual(res2.get_device(), expected.get_device())
+
     def test_diag(self):
         x = torch.rand(100, 100)
         res1 = torch.diag(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1091,7 +1091,7 @@ class TestTorch(TestCase):
         res2[1] = 2
         self.assertEqual(expected, torch.ones_like(expected))
 
-    def test_tensor_new(self):
+    def test_new_tensor(self):
         expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
         # test data
         res1 = expected.new_tensor([1, 1])
@@ -1110,6 +1110,9 @@ class TestTorch(TestCase):
 
             res2 = expected.new_tensor(expected)
             self.assertEqual(res2.get_device(), expected.get_device())
+
+            res1 = expected.new_tensor(1)
+            self.assertEqual(res1.get_device(), expected.get_device())
 
     def test_diag(self):
         x = torch.rand(100, 100)

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -77,7 +77,7 @@ static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
 static PyObject * THPVariable_variable(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
-  return THPVariable_Wrap(torch::utils::variable_data_factory(default_type(), args, kwargs));
+  return THPVariable_Wrap(torch::utils::new_tensor(default_type(), args, kwargs));
   END_HANDLE_TH_ERRORS
 }
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -485,7 +485,16 @@ static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwar
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   AutoGPU auto_gpu(self_);
-  return THPVariable_Wrap(torch::utils::tensor_new(self_.type(), args, kwargs));
+  return THPVariable_Wrap(torch::utils::legacy_tensor_ctor(self_.type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_new_tensor(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
+  return THPVariable_Wrap(torch::utils::new_tensor(self_.type(), args, kwargs));
   END_HANDLE_TH_ERRORS
 }
 
@@ -592,6 +601,7 @@ PyMethodDef variable_methods[] = {
   {"ndimension", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
   {"nelement", (PyCFunction)THPVariable_numel, METH_NOARGS, NULL},
   {"new", (PyCFunction)THPVariable_new, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"new_tensor", (PyCFunction)THPVariable_new_tensor, METH_VARARGS | METH_KEYWORDS, NULL},
   {"numpy", (PyCFunction)THPVariable_numpy, METH_NOARGS, NULL},
   {"record_stream", (PyCFunction)THPVariable_record_stream, METH_O, NULL},
   {"short", (PyCFunction)THPVariable_short, METH_NOARGS, NULL},

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -99,8 +99,10 @@ static Tensor new_from_data(ScalarType scalarType, PyObject* data) {
 
   auto sizes = compute_sizes(data);
   auto tensor = autograd::make_variable(CPU(scalarType).tensor(sizes), false);
+  // TODO: we should pass tensor.sizes() rather than sizes, but this doesn't works
+  // if scalars are disabled because the size changes without WITH_SCALARS.
   recursive_store(
-      (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
+      (char*)tensor.data_ptr(), sizes, tensor.strides(), 0,
       scalarType, tensor.type().elementSizeInBytes(), data);
   return tensor;
 }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -130,7 +130,7 @@ static Tensor new_from_data(const Type & type, int device, PyObject *data) {
   }
 }
 
-Tensor tensor_new(const Type& type, PyObject* args, PyObject* kwargs) {
+Tensor legacy_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
   static PythonArgParser parser({
     "new(*, int64_t device=-1)",
     "new(IntList size, *, int64_t device=-1)",
@@ -171,7 +171,7 @@ static Tensor set_requires_grad(Tensor self, bool requires_grad) {
   return self;
 }
 
-Tensor variable_data_factory(const Type& type, PyObject* args, PyObject* kwargs) {
+Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
   static PythonArgParser parser({
     "new(Tensor other, *, bool requires_grad=False)",
     "new(PyObject* data, *, int64_t device=-1, bool requires_grad=False)",
@@ -185,7 +185,7 @@ Tensor variable_data_factory(const Type& type, PyObject* args, PyObject* kwargs)
   } else if (r.idx == 1) {
     return set_requires_grad(new_from_data(type, r.toInt64(1), r.pyobject(0)), r.toBool(2));
   }
-  throw std::runtime_error("variable(): invalid arguments");
+  throw std::runtime_error("new_tensor(): invalid arguments");
 }
 
 }} // namespace torch::utils

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -181,7 +181,6 @@ Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     return set_requires_grad(new_with_tensor_copy(type, r.tensor(0)), r.toBool(1));
-    return set_requires_grad(new_with_tensor(type, r.tensor(0)), r.toBool(1));
   } else if (r.idx == 1) {
     return set_requires_grad(new_from_data(type, r.toInt64(1), r.pyobject(0)), r.toBool(2));
   }

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -5,7 +5,7 @@
 
 namespace torch { namespace utils {
 
-at::Tensor tensor_new(const at::Type& type, PyObject* args, PyObject* kwargs);
-at::Tensor variable_data_factory(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor legacy_tensor_ctor(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor new_tensor(const at::Type& type, PyObject* args, PyObject* kwargs);
 
 }} // namespace torch::utils


### PR DESCRIPTION
This is to work around the legacy problems of new, where e.g.
new(5) will give you an unfilled tensor rather than a scalar.