### PR TITLE
Added check and test for betas parameter in Adam optimizer

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -230,15 +230,6 @@ class TestOptim(TestCase):
             constructor
         )
 
-    def _test_error_scenarios(self, constructor, error_msg):
-        with self.assertRaisesRegexp(ValueError, error_msg):
-            self._test_basic_cases_template(
-                torch.randn(10, 5),
-                torch.randn(10),
-                torch.randn(5),
-                constructor
-            )
-
     def _build_params_dict(self, weight, bias, **kwargs):
         return [dict(params=[weight]), dict(params=[bias], **kwargs)]
 
@@ -301,11 +292,8 @@ class TestOptim(TestCase):
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3, amsgrad=True)
         )
-        self._test_error_scenarios(
-            lambda weight, bias: optim.Adam(
-                [weight, bias], lr=1e-2, betas=(1.0, 0.0), amsgrad=True),
-            "Invalid beta parameter at index 0: 1.0"
-        )
+        with self.assertRaisesRegexp(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            optim.Adam(None, lr=1e-2, betas=(1.0, 0.0))
 
     def test_sparse_adam(self):
         self._test_rosenbrock_sparse(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -230,6 +230,15 @@ class TestOptim(TestCase):
             constructor
         )
 
+    def _test_error_scenarios(self, constructor, error_msg):
+        with self.assertRaisesRegexp(ValueError, error_msg):
+            self._test_basic_cases_template(
+                torch.randn(10, 5),
+                torch.randn(10),
+                torch.randn(5),
+                constructor
+            )
+
     def _build_params_dict(self, weight, bias, **kwargs):
         return [dict(params=[weight]), dict(params=[bias], **kwargs)]
 
@@ -291,6 +300,11 @@ class TestOptim(TestCase):
             lambda weight, bias: optim.Adam(
                 self._build_params_dict(weight, bias, lr=1e-2),
                 lr=1e-3, amsgrad=True)
+        )
+        self._test_error_scenarios(
+            lambda weight, bias: optim.Adam(
+                [weight, bias], lr=1e-2, betas=(1.0, 0.0), amsgrad=True),
+            "Invalid beta parameter at index 0: 1.0"
         )
 
     def test_sparse_adam(self):

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -28,6 +28,10 @@ class Adam(Optimizer):
 
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
                  weight_decay=0, amsgrad=False):
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, amsgrad=amsgrad)
         super(Adam, self).__init__(params, defaults)


### PR DESCRIPTION
This PR adds a check to prevent division by zero errors and give users friendlier error messages when using the Adam optimizer.

Currently, if one specifies the beta value of the Adam optimizer as `1.0` for the first parameter, the program fails with the error message, `ZeroDivisionError: float division by zero`. According to the definition of [Adam](https://arxiv.org/abs/1412.6980), beta values should be in the range \[0, 1\).

Also referring [#751](https://github.com/uber/pyro/pull/751) where I encountered and tried to fix this issue in the first place. I believe this would benefit all clients using pytorch as backend.