### PR TITLE
add reduce=True arg to MultiMarginLoss

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -20,10 +20,10 @@
   scalar_check:
     output: reduce || self_->isScalar()
 
-- name: multi_margin_loss(Tensor self, LongTensor target, Scalar p=1, Scalar margin=1, Tensor weight={}, bool size_average=true)
+- name: multi_margin_loss(Tensor self, LongTensor target, Scalar p=1, Scalar margin=1, Tensor weight={}, bool size_average=true, bool reduce=true)
   cname: MultiMarginCriterion
   scalar_check:
-    output: 'true'
+    output: reduce || self_->isScalar()
 
 - name: multilabel_margin_loss(Tensor self, LongTensor target, bool size_average=true, bool reduce=true)
   cname: MultiLabelMarginCriterion

--- a/aten/src/THCUNN/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/MultiMarginCriterion.cu
@@ -49,7 +49,16 @@ __global__ void cunn_MultiMarginCriterion_updateOutput_kernel(Dtype *output, Dty
 }
 
 template <int P, typename Dtype, typename Acctype>
-__global__ void cunn_MultiMarginCriterion_updateGradInput_kernel(Dtype *gradInput, Dtype *input, THCIndex_t *target, Dtype *weights, int nframe, int dim, bool sizeAverage, Dtype margin)
+__global__ void cunn_MultiMarginCriterion_updateGradInput_kernel(Dtype *gradInput,
+                                                                 Dtype *gradOutput,
+                                                                 Dtype *input,
+                                                                 THCIndex_t *target,
+                                                                 Dtype *weights,
+                                                                 int nframe,
+                                                                 int dim,
+                                                                 bool sizeAverage,
+                                                                 Dtype margin,
+                                                                 int reduce)
 {
   __shared__ Acctype buffer[MULTIMARGIN_THREADS];
   int k = blockIdx.x;
@@ -57,7 +66,13 @@ __global__ void cunn_MultiMarginCriterion_updateGradInput_kernel(Dtype *gradInpu
   Dtype *gradInput_k = gradInput + k*dim;
   int target_k = ((int)target[k]) - TH_INDEX_BASE;
   Dtype input_target_k = input_k[target_k];
-  Acctype g = (sizeAverage ? 1./((Acctype)(nframe*dim)) : 1./((Acctype)dim));
+
+  Dtype *gradOutput_k = gradOutput;
+  if (!reduce) {
+    gradOutput_k += k;
+  }
+
+  Acctype g = (sizeAverage && reduce ? 1./((Acctype)(nframe*dim)) : 1./((Acctype)dim));
 
   int i_start = threadIdx.x;
   int i_end = dim;
@@ -91,6 +106,11 @@ __global__ void cunn_MultiMarginCriterion_updateGradInput_kernel(Dtype *gradInpu
     for (int i=0; i<blockDim.x; i++)
       gradInput_target_k += buffer[i];
     gradInput_k[target_k] = ScalarConvert<Acctype, Dtype>::to(gradInput_target_k);
+  }
+
+  for (int i=i_start; i<i_end; i+= i_step)
+  {
+    gradInput_k[i] *= * gradOutput_k;
   }
 }
 

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -80,7 +80,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           THCTensor_(data)(state, input),
           THCIndexTensor_(data)(state, target),
           weights ? THCTensor_(data)(state, weights) : NULL,
-          input->size[0], input->size[1],
+          nframe, input->size[1],
           false,
           margin
         );

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -11,11 +11,11 @@ void THNN_(MultiMarginCriterion_updateOutput)(
            bool sizeAverage,
            int p,
            THCTensor *weights,
-           accreal margin_)
+           accreal margin_,
+           bool reduce)
 {
   real margin = ScalarConvert<accreal, real>::to(margin_);
   THCUNN_assertSameGPU(state, 2, input, target);
-  THCTensor_(resize1d)(state, output, 1);
   input = THCTensor_(newContiguous)(state, input);
   if(weights)
     weights = THCTensor_(newContiguous)(state, weights);
@@ -23,6 +23,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   {
     dim3 blocks(1);
     dim3 threads(MULTIMARGIN_THREADS);
+    THCTensor_(resize1d)(state, output, 1);
     if (p == 1)
     {
       cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
@@ -54,37 +55,71 @@ void THNN_(MultiMarginCriterion_updateOutput)(
     int nframe = input->size[0];
     THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
                "inconsistent target size");
-    THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size[0]);  // tmp outupt buffer
     dim3 blocks(input->size[0]);
     dim3 threads(MULTIMARGIN_THREADS);
-    if (p == 1)
+
+    if (!reduce)
     {
-      cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
-        THCTensor_(data)(state, output_),
-        THCTensor_(data)(state, input),
-        THCIndexTensor_(data)(state, target),
-        weights ? THCTensor_(data)(state, weights) : NULL,
-        nframe, input->size[1],
-        sizeAverage,
-        margin
-      );
+      THCTensor_(resize1d)(state, output, input->size[0]);
+      if (p == 1)
+      {
+        cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+          THCTensor_(data)(state, output),
+          THCTensor_(data)(state, input),
+          THCIndexTensor_(data)(state, target),
+          weights ? THCTensor_(data)(state, weights) : NULL,
+          nframe, input->size[1],
+          false,
+          margin
+        );
+      }
+      else if (p == 2)
+      {
+        cunn_MultiMarginCriterion_updateOutput_kernel<2, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+          THCTensor_(data)(state, output),
+          THCTensor_(data)(state, input),
+          THCIndexTensor_(data)(state, target),
+          weights ? THCTensor_(data)(state, weights) : NULL,
+          input->size[0], input->size[1],
+          false,
+          margin
+        );
+      }
+      THCudaCheck(cudaGetLastError());
     }
-    else if (p == 2)
+    else
     {
-      cunn_MultiMarginCriterion_updateOutput_kernel<2, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
-        THCTensor_(data)(state, output_),
-        THCTensor_(data)(state, input),
-        THCIndexTensor_(data)(state, target),
-        weights ? THCTensor_(data)(state, weights) : NULL,
-        input->size[0], input->size[1],
-        sizeAverage,
-        margin
-      );
+      THCTensor_(resize1d)(state, output, 1);
+      THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size[0]);  // tmp output buffer
+      if (p == 1)
+      {
+        cunn_MultiMarginCriterion_updateOutput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+          THCTensor_(data)(state, output_),
+          THCTensor_(data)(state, input),
+          THCIndexTensor_(data)(state, target),
+          weights ? THCTensor_(data)(state, weights) : NULL,
+          nframe, input->size[1],
+          sizeAverage,
+          margin
+        );
+      }
+      else if (p == 2)
+      {
+        cunn_MultiMarginCriterion_updateOutput_kernel<2, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+          THCTensor_(data)(state, output_),
+          THCTensor_(data)(state, input),
+          THCIndexTensor_(data)(state, target),
+          weights ? THCTensor_(data)(state, weights) : NULL,
+          input->size[0], input->size[1],
+          sizeAverage,
+          margin
+        );
+      }
+      THCudaCheck(cudaGetLastError());
+      float sum = THCTensor_(sumall)(state, output_);
+      THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, real>::to(sum));
+      THCTensor_(free)(state, output_);
     }
-    THCudaCheck(cudaGetLastError());
-    float sum = THCTensor_(sumall)(state, output_);
-    THCTensor_(set1d)(state, output, 0, ScalarConvert<accreal, real>::to(sum));
-    THCTensor_(free)(state, output_);
   }
   else
   {
@@ -100,15 +135,18 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
            THCState *state,
            THCTensor *input,
            THCIndexTensor *target,
+           THCTensor *gradOutput,
            THCTensor *gradInput,
            bool sizeAverage,
            int p,
            THCTensor *weights,
-           accreal margin_)
+           accreal margin_,
+           bool reduce)
 {
   real margin = ScalarConvert<accreal, real>::to(margin_);
   THCUNN_assertSameGPU(state, 3, input, gradInput, target);
   input = THCTensor_(newContiguous)(state, input);
+  gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   THCTensor_(resizeAs)(state, gradInput, input);
   if(weights)
     weights = THCTensor_(newContiguous)(state, weights);
@@ -122,24 +160,28 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
     {
       cunn_MultiMarginCriterion_updateGradInput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
         THCTensor_(data)(state, gradInput),
+        THCTensor_(data)(state, gradOutput),
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
         1, gradInput->size[0],
         sizeAverage,
-        margin
+        margin,
+        reduce
       );
     }
     else if (p == 2)
     {
       cunn_MultiMarginCriterion_updateGradInput_kernel<2, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
         THCTensor_(data)(state, gradInput),
+        THCTensor_(data)(state, gradOutput),
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
         1, gradInput->size[0],
         sizeAverage,
-        margin
+        margin,
+        reduce
       );
     }
     THCudaCheck(cudaGetLastError());
@@ -156,24 +198,28 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
     {
       cunn_MultiMarginCriterion_updateGradInput_kernel<1, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
         THCTensor_(data)(state, gradInput),
+        THCTensor_(data)(state, gradOutput),
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
         nframe, gradInput->size[1],
         sizeAverage,
-        margin
+        margin,
+        reduce
       );
     }
     else if (p == 2)
     {
       cunn_MultiMarginCriterion_updateGradInput_kernel<2, real, accreal> <<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
         THCTensor_(data)(state, gradInput),
+        THCTensor_(data)(state, gradOutput),
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
         nframe, gradInput->size[1],
         sizeAverage,
-        margin
+        margin,
+        reduce
       );
     }
     THCudaCheck(cudaGetLastError());

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -417,17 +417,20 @@ TH_API void THNN_(MultiMarginCriterion_updateOutput)(
                   bool sizeAverage,
                   int p,
                   THCTensor *weights,           // [OPTIONAL]
-                  accreal margin);
+                  accreal margin,
+                  bool reduce);
 
 TH_API void THNN_(MultiMarginCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
+                  THCTensor *gradOutput,
                   THCTensor *gradInput,
                   bool sizeAverage,
                   int p,
                   THCTensor *weights,           // [OPTIONAL]
-                  accreal margin);
+                  accreal margin,
+                  bool reduce);
 
 TH_API void THNN_(PReLU_updateOutput)(
                   THCState *state,

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -161,7 +161,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   input_data = THTensor_(data)(input);
 
   THTensor_(resizeAs)(gradInput, input);
-  gradInput = THTensor_(newContiguous)(gradInput);
+  THArgCheck(THTensor_(isContiguous)(gradInput), 5, "gradInput must be contiguous");
   gradInput_data = THTensor_(data)(gradInput);
 
   target_data = THIndexTensor_(data)(target);

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -218,7 +218,6 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
 
   THTensor_(free)(input);
   THIndexTensor_(free)(target);
-  THTensor_(free)(gradInput);
   if(weights)
     THTensor_(free)(weights);
 }

--- a/aten/src/THNN/generic/MultiMarginCriterion.c
+++ b/aten/src/THNN/generic/MultiMarginCriterion.c
@@ -11,7 +11,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           bool sizeAverage,
           int p,
           THTensor *weights,
-          accreal margin_)
+          accreal margin_,
+          bool reduce)
 {
   real margin = TH_CONVERT_ACCREAL_TO_REAL(margin_);
   real *input_data, *weights_data;
@@ -22,7 +23,6 @@ void THNN_(MultiMarginCriterion_updateOutput)(
 
   THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
 	     "vector or matrix expected");
-  THTensor_(resize1d)(output, 1);
 
   if (input->nDimension == 1)
   {
@@ -51,32 +51,65 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   target_data = THIndexTensor_(data)(target);
   weights_data = weights ? THTensor_(data)(weights) : NULL;
 
-  sum = 0;
-  for (t = 0; t < nframe; t++)
+  if (!reduce)
   {
-    THIndex_t target_idx = target_data[t] - TH_INDEX_BASE;
-    real input_target = input_data[target_idx];
-    for (d = 0; d < dim; d++)
+    THTensor_(resize1d)(output, nframe);
+
+    for (t = 0; t < nframe; t++)
     {
-      real z = margin - input_target + input_data[d];
-      if (d == target_idx)
-        continue;
+      sum = 0;
+      THIndex_t target_idx = target_data[t] - TH_INDEX_BASE;
+      real input_target = input_data[target_idx];
+      for (d = 0; d < dim; d++)
+      {
+        real z = margin - input_target + input_data[d];
+        if (d == target_idx)
+          continue;
 
-      if (z > 0) {
-        real h = (p==1) ? z : z*z;
-        if(weights_data)
-          h *= weights_data[target_idx];
-        sum += h;
+        if (z > 0) {
+          real h = (p==1) ? z : z*z;
+          if(weights_data)
+            h *= weights_data[target_idx];
+          sum += h;
+        }
       }
+
+      sum /= dim;
+      THTensor_fastSet1d(output, t, sum);
+      input_data += dim;
     }
-    input_data += dim;
   }
+  else
+  {
+    THTensor_(resize1d)(output, 1);
 
-  sum /= dim;
-  if(sizeAverage)
-    sum /= nframe;
+    sum = 0;
+    for (t = 0; t < nframe; t++)
+    {
+      THIndex_t target_idx = target_data[t] - TH_INDEX_BASE;
+      real input_target = input_data[target_idx];
+      for (d = 0; d < dim; d++)
+      {
+        real z = margin - input_target + input_data[d];
+        if (d == target_idx)
+          continue;
 
-  THTensor_(set1d)(output, 0, sum);
+        if (z > 0) {
+          real h = (p==1) ? z : z*z;
+          if(weights_data)
+            h *= weights_data[target_idx];
+          sum += h;
+        }
+      }
+      input_data += dim;
+    }
+
+    sum /= dim;
+    if(sizeAverage)
+      sum /= nframe;
+
+    THTensor_(set1d)(output, 0, sum);
+  }
 
   THTensor_(free)(input);
   THIndexTensor_(free)(target);
@@ -88,11 +121,13 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THIndexTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
           bool sizeAverage,
           int p,
           THTensor *weights,
-          accreal margin_)
+          accreal margin_,
+          bool reduce)
 {
   real margin = TH_CONVERT_ACCREAL_TO_REAL(margin_);
   real *input_data;
@@ -119,13 +154,14 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
 	       "inconsistent target size");
   }
 
-  g = (sizeAverage ? 1./((real)(nframe*dim)) : 1./((real)dim));
+  g = (sizeAverage && reduce ? 1./((real)(nframe*dim)) : 1./((real)dim));
 
   input = THTensor_(newContiguous)(input);
   target = THIndexTensor_(newContiguous)(target);
   input_data = THTensor_(data)(input);
 
   THTensor_(resizeAs)(gradInput, input);
+  gradInput = THTensor_(newContiguous)(gradInput);
   gradInput_data = THTensor_(data)(gradInput);
 
   target_data = THIndexTensor_(data)(target);
@@ -159,9 +195,30 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
     input_data += dim;
     gradInput_data += dim;
   }
+  gradInput_data = THTensor_(data)(gradInput);
+
+  if (reduce)
+  {
+    THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, 1);
+    for (t = 0; t < nframe * dim; t++) {
+      gradInput_data[t] *= THTensor_fastGet1d(gradOutput, 0);
+    }
+  }
+  else
+  {
+    THNN_CHECK_DIM_SIZE(gradOutput, 1, 0, nframe);
+    for (t = 0; t < nframe; t++)
+    {
+      for (d = 0; d < dim; d++)
+      {
+        gradInput_data[t * dim + d] *= THTensor_fastGet1d(gradOutput, t);
+      }
+    }
+  }
 
   THTensor_(free)(input);
   THIndexTensor_(free)(target);
+  THTensor_(free)(gradInput);
   if(weights)
     THTensor_(free)(weights);
 }

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -381,16 +381,19 @@ TH_API void THNN_(MultiMarginCriterion_updateOutput)(
           bool sizeAverage,
           int p,
           THTensor* weights,      // [OPTIONAL]
-          accreal margin);
+          accreal margin,
+          bool reduce);
 TH_API void THNN_(MultiMarginCriterion_updateGradInput)(
           THNNState *state,
           THTensor *input,
           THIndexTensor *target,
+          THTensor *gradOutput,
           THTensor *gradInput,
           bool sizeAverage,
           int p,
           THTensor *weights,      // [OPTIONAL]
-          accreal margin);
+          accreal margin,
+          bool reduce);
 
 TH_API void THNN_(PReLU_updateOutput)(
           THNNState *state,

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -407,11 +407,11 @@ def multimarginloss_reference(input, target, p=1, margin=1, weight=None, size_av
         for x in range(0, n):
             output[x] = _multimarginloss_reference(input[x], target[x], p, margin, weight)
 
-    if reduce and size_average:
-        return output.mean() / dim
-    elif reduce:
-        return output.sum() / dim
-    return output / dim
+        if reduce and size_average:
+            return output.mean() / dim
+        elif reduce:
+            return output.sum() / dim
+        return output / dim
 
 
 loss_reference_fns = {

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -619,6 +619,7 @@ criterion_tests = [
     dict(
         module_name='MultiMarginLoss',
         constructor_args=(1, 0.5),
+        legacy_constructor_args=(1, None, 0.5),
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5).mul(8).floor().long(),
         reference_fn=lambda i, t, m:
@@ -630,6 +631,7 @@ criterion_tests = [
     dict(
         module_name='MultiMarginLoss',
         constructor_args=(1, 1, torch.rand(10)),
+        legacy_constructor_args=(1, torch.rand(10)),
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5).mul(8).floor().long(),
         reference_fn=lambda i, t, m:

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -382,6 +382,38 @@ def softmarginloss_reference(input, target, size_average=True, reduce=True):
     return output
 
 
+def _multimarginloss_reference(input, target_idx, p, margin, weight):
+    if weight is None:
+        weight = input.new(len(input)).fill_(1)
+
+    output = 0
+    for i in range(0, len(input)):
+        if i != target_idx:
+            output += max(0, weight[target_idx] * (margin - input[target_idx] + input[i]) ** p)
+    return output
+
+
+def multimarginloss_reference(input, target, p=1, margin=1, weight=None, size_average=True,
+                              reduce=True):
+    if input.dim() == 1:
+        n = 1
+        dim = input.size(0)
+        output = 0
+        return _multimarginloss_reference(input, target[0], p, margin, weight) / dim
+    else:
+        n = input.size(0)
+        dim = input.size(1)
+        output = input.new(n).zero_()
+        for x in range(0, n):
+            output[x] = _multimarginloss_reference(input[x], target[x], p, margin, weight)
+
+    if reduce and size_average:
+        return output.mean() / dim
+    elif reduce:
+        return output.sum() / dim
+    return output / dim
+
+
 loss_reference_fns = {
     'KLDivLoss': kldivloss_reference,
     'NLLLoss': nllloss_reference,
@@ -390,6 +422,7 @@ loss_reference_fns = {
     'MultiLabelMarginLoss': multilabelmarginloss_reference,
     'HingeEmbeddingLoss': hingeembeddingloss_reference,
     'SoftMarginLoss': softmarginloss_reference,
+    'MultiMarginLoss': multimarginloss_reference,
 }
 
 
@@ -557,6 +590,52 @@ criterion_tests = [
         module_name='MultiMarginLoss',
         input_size=(5, 10),
         target_fn=lambda: torch.rand(5).mul(8).floor().long(),
+        reference_fn=lambda i, t, m:
+            multimarginloss_reference(i, t, size_average=get_size_average(m)),
+        check_no_size_average=True,
+        check_gradgrad=False,
+    ),
+    dict(
+        module_name='MultiMarginLoss',
+        input_size=(10,),
+        target_fn=lambda: torch.rand(1).mul(8).floor().long(),
+        reference_fn=lambda i, t, m:
+            multimarginloss_reference(i, t, size_average=get_size_average(m)),
+        desc='1d',
+        check_no_size_average=True,
+        check_gradgrad=False,
+    ),
+    dict(
+        module_name='MultiMarginLoss',
+        constructor_args=(2,),
+        input_fn=lambda: torch.rand(5, 10).clamp_(1e-2, 1 - 1e-2),
+        target_fn=lambda: torch.rand(5).mul(8).floor().long(),
+        reference_fn=lambda i, t, m:
+            multimarginloss_reference(i, t, p=2, size_average=get_size_average(m)),
+        desc='p',
+        check_no_size_average=True,
+        check_gradgrad=False,
+    ),
+    dict(
+        module_name='MultiMarginLoss',
+        constructor_args=(1, 0.5),
+        input_size=(5, 10),
+        target_fn=lambda: torch.rand(5).mul(8).floor().long(),
+        reference_fn=lambda i, t, m:
+            multimarginloss_reference(i, t, margin=0.5, size_average=get_size_average(m)),
+        desc='margin',
+        check_no_size_average=True,
+        check_gradgrad=False,
+    ),
+    dict(
+        module_name='MultiMarginLoss',
+        constructor_args=(1, 1, torch.rand(10)),
+        input_size=(5, 10),
+        target_fn=lambda: torch.rand(5).mul(8).floor().long(),
+        reference_fn=lambda i, t, m:
+            multimarginloss_reference(i, t, weight=get_weight(m), size_average=get_size_average(m)),
+        desc='weights',
+        check_no_size_average=True,
         check_gradgrad=False,
     ),
     dict(

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -398,12 +398,13 @@ def multimarginloss_reference(input, target, p=1, margin=1, weight=None, size_av
     if input.dim() == 1:
         n = 1
         dim = input.size(0)
-        output = 0
-        return _multimarginloss_reference(input, target[0], p, margin, weight) / dim
+        output = input.new(1)
+        output[0] = _multimarginloss_reference(input, target[0], p, margin, weight) / dim
+        return output
     else:
         n = input.size(0)
         dim = input.size(1)
-        output = input.new(n).zero_()
+        output = input.new(n)
         for x in range(0, n):
             output[x] = _multimarginloss_reference(input[x], target[x], p, margin, weight)
 

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -631,6 +631,12 @@ def prepare_tests():
             name = 'SpatialClassNLLCriterion'
 
         test_params['constructor'] = getattr(nn, name)
+
+        # If legacy constructor args are specified, use them instead
+        legacy_args = test_params.pop('legacy_constructor_args', None)
+        if legacy_args != None:
+            test_params['constructor_args'] = legacy_args
+
         test = CriterionTest(**test_params)
         add_test(test)
 

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -634,7 +634,7 @@ def prepare_tests():
 
         # If legacy constructor args are specified, use them instead
         legacy_args = test_params.pop('legacy_constructor_args', None)
-        if legacy_args != None:
+        if legacy_args is not None:
             test_params['constructor_args'] = legacy_args
 
         test = CriterionTest(**test_params)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5195,6 +5195,80 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
         pickle=False)
 
 
+def multimarginloss_no_reduce_test():
+    t = Variable(torch.rand(5).mul(8).floor().long())
+    return dict(
+        fullname='MultiMarginLoss_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), reduce=False)),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(), reduce=False),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
+def multimarginloss_1d_no_reduce_test():
+    t = Variable(torch.rand(1).mul(8).floor().long())
+    return dict(
+        fullname='MultiMarginLoss_1d_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), reduce=False)),
+        input_fn=lambda: torch.randn(10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(), reduce=False),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
+def multimarginloss_p_no_reduce_test():
+    t = Variable(torch.rand(5).mul(8).floor().long())
+    return dict(
+        fullname='MultiMarginLoss_p_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), p=2, reduce=False)),
+        input_fn=lambda: torch.randn(5, 10).clamp_(1e-2, 1 - 1e-2),
+        reference_fn=lambda i, _:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(), p=2, reduce=False),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
+def multimarginloss_margin_no_reduce_test():
+    t = Variable(torch.rand(5).mul(8).floor().long())
+    return dict(
+        fullname='MultiMarginLoss_margin_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), margin=0.5, reduce=False)),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(),
+                                                  margin=0.5, reduce=False),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
+def multimarginloss_weights_no_reduce_test():
+    t = Variable(torch.rand(5).mul(8).floor().long())
+    weights = Variable(torch.rand(10))
+    return dict(
+        fullname='MultiMarginLoss_weights_no_reduce',
+        constructor=wrap_functional(
+            lambda i: F.multi_margin_loss(i, t.type_as(i).long(), weight=weights.type_as(i),
+                                          reduce=False)),
+        input_fn=lambda: torch.randn(5, 10),
+        reference_fn=lambda i, _:
+            loss_reference_fns['MultiMarginLoss'](i, t.data.type_as(i).long(),
+                                                  weight=weights, reduce=False),
+        check_no_size_average=True,
+        check_gradgrad=False,
+        pickle=False)
+
+
 new_module_tests = [
     poissonnllloss_no_reduce_test(),
     bceloss_no_reduce_test(),
@@ -5230,6 +5304,11 @@ new_module_tests = [
     softmarginloss_no_reduce_test(),
     multilabelsoftmarginloss_no_reduce_test(),
     multilabelsoftmarginloss_weights_no_reduce_test(),
+    multimarginloss_no_reduce_test(),
+    multimarginloss_1d_no_reduce_test(),
+    multimarginloss_p_no_reduce_test(),
+    multimarginloss_margin_no_reduce_test(),
+    multimarginloss_weights_no_reduce_test(),
     dict(
         module_name='BatchNorm1d',
         constructor_args=(10,),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -692,8 +692,8 @@
 - name: mse_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: mse_loss_backward(grad, self, target, size_average, reduce)
 
-- name: multi_margin_loss_forward(Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, bool size_average)
-  self: multi_margin_loss_backward(self, target, p, margin, weight, size_average).mul_(grad)
+- name: multi_margin_loss_forward(Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, bool size_average, bool reduce)
+  self: multi_margin_loss_backward(grad, self, target, p, margin, weight, size_average, reduce)
 
 - name: multilabel_margin_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: multilabel_margin_loss_backward(grad, self, target, size_average, reduce, is_target)

--- a/torch/legacy/nn/MultiMarginCriterion.py
+++ b/torch/legacy/nn/MultiMarginCriterion.py
@@ -4,7 +4,7 @@ from .Criterion import Criterion
 
 class MultiMarginCriterion(Criterion):
 
-    def __init__(self, p=1, weights=None, margin=1, sizeAverage=True):
+    def __init__(self, p=1, margin=1, weights=None, sizeAverage=True):
         super(MultiMarginCriterion, self).__init__()
         if p != 1 and p != 2:
             raise ValueError("only p == 1 and p == 2 supported")
@@ -28,21 +28,25 @@ class MultiMarginCriterion(Criterion):
             self.sizeAverage,
             self.p,
             self.weights,
-            self.margin
+            self.margin,
+            True,  # reduce
         )
         self.output = self.output_tensor[0].item()
         return self.output
 
     def updateGradInput(self, input, target):
         target = target.long()
+        implicit_gradOutput = torch.ones(1).type_as(input)
         self._backend.MultiMarginCriterion_updateGradInput(
             self._backend.library_state,
             input,
             target,
+            implicit_gradOutput,
             self.gradInput,
             self.sizeAverage,
             self.p,
             self.weights,
-            self.margin
+            self.margin,
+            True,  # reduce
         )
         return self.gradInput

--- a/torch/legacy/nn/MultiMarginCriterion.py
+++ b/torch/legacy/nn/MultiMarginCriterion.py
@@ -4,7 +4,7 @@ from .Criterion import Criterion
 
 class MultiMarginCriterion(Criterion):
 
-    def __init__(self, p=1, margin=1, weights=None, sizeAverage=True):
+    def __init__(self, p=1, weights=None, margin=1, sizeAverage=True):
         super(MultiMarginCriterion, self).__init__()
         if p != 1 and p != 2:
             raise ValueError("only p == 1 and p == 2 supported")

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1644,8 +1644,8 @@ def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True):
     return _functions.loss.CosineEmbeddingLoss.apply(input1, input2, target, margin, size_average)
 
 
-def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True):
-    """multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True) -> Variable
+def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True):
+    """multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True) -> Variable
 
     See :class:`~torch.nn.MultiMarginLoss` for details.
     """
@@ -1654,7 +1654,7 @@ def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=Tr
     if weight is not None and weight.dim() != 1:
         raise ValueError('weight must be one-dimensional')
 
-    return torch._C._nn.multi_margin_loss(input, target, p, margin, weight, size_average)
+    return torch._C._nn.multi_margin_loss(input, target, p, margin, weight, size_average, reduce)
 
 
 def pixel_shuffle(input, upscale_factor):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -842,7 +842,7 @@ class MarginRankingLoss(Module):
         return F.margin_ranking_loss(input1, input2, target, self.margin, self.size_average)
 
 
-class MultiMarginLoss(Module):
+class MultiMarginLoss(_WeightedLoss):
     r"""Creates a criterion that optimizes a multi-class classification hinge
     loss (margin-based loss) between input `x` (a 2D mini-batch `Tensor`) and
     output `y` (which is a 1D tensor of target class indices,
@@ -850,34 +850,39 @@ class MultiMarginLoss(Module):
 
     For each mini-batch sample::
 
-        loss(x, y) = sum_i(max(0, (margin - x[y] + x[i]))^p) / x.size(0)
+        loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] + x[i]))^p) / x.size(0)
                      where `i == 0` to `x.size(0)` and `i != y`.
 
-    Optionally, you can give non-equal weighting on the classes by passing
-    a 1D `weight` tensor into the constructor.
+    Args:A
+        p (int, optional): Has a default value of `1`. `1` and `2` are the only
+            supported values
+        margin (float, optional): Has a default value of `1`.
+        weight (Tensor, optional): a manual rescaling weight given to each
+            class. If given, it has to be a Tensor of size `C`. Otherwise, it is
+            treated as if having all ones.
+        size_average (bool, optional): By default, the losses are averaged over
+            observations for each minibatch. However, if the field :attr:`size_average`
+            is set to ``False``, the losses are instead summed for each minibatch.
+            Default: ``True``
+        reduce (bool, optional): By default, the losses are averaged or summed over
+            observations for each minibatch depending on :attr:`size_average`. When
+            :attr:`reduce` is ``False``, returns a loss per batch element instead and
+            ignores :attr:`size_average`. Default: ``True``
 
-    The loss function then becomes:
-
-        loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] - x[i]))^p) / x.size(0)
-
-    By default, the losses are averaged over observations for each minibatch.
-    However, if the field `size_average` is set to ``False``,
-    the losses are instead summed.
     """
 
-    def __init__(self, p=1, margin=1, weight=None, size_average=True):
-        super(MultiMarginLoss, self).__init__()
+    def __init__(self, p=1, margin=1, weight=None, size_average=True, reduce=True):
+        super(MultiMarginLoss, self).__init__(weight, size_average)
         if p != 1 and p != 2:
             raise ValueError("only p == 1 and p == 2 supported")
         assert weight is None or weight.dim() == 1
         self.p = p
         self.margin = margin
-        self.size_average = size_average
-        self.weight = weight
+        self.reduce = reduce
 
     def forward(self, input, target):
-        return F.multi_margin_loss(input, target, self.p, self.margin,
-                                   self.weight, self.size_average)
+        return F.multi_margin_loss(input, target, self.p, self.margin, self.weight,
+                                   self.size_average, self.reduce)
 
 
 class TripletMarginLoss(Module):

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -853,7 +853,7 @@ class MultiMarginLoss(_WeightedLoss):
         loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] + x[i]))^p) / x.size(0)
                      where `i == 0` to `x.size(0)` and `i != y`.
 
-    Args:A
+    Args:
         p (int, optional): Has a default value of `1`. `1` and `2` are the only
             supported values
         margin (float, optional): Has a default value of `1`.

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -848,7 +848,8 @@ class MultiMarginLoss(_WeightedLoss):
     output `y` (which is a 1D tensor of target class indices,
     `0` <= `y` <= `x.size(1)`):
 
-    For each mini-batch sample::
+    For each mini-batch sample, the loss in terms of the 1D input `x` and scalar
+    output `y` is::
 
         loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] + x[i]))^p) / x.size(0)
                      where `i == 0` to `x.size(0)` and `i != y`.


### PR DESCRIPTION
As per #264. When reduce is False, MultiMarginLoss outputs a loss per sample in minibatch. When reduce is True (default), the current behavior is kept.

Test Plan
test/run_test.sh
Added unit tests for the reduce=False case as well as unit tests for optional parameters. Added a reference function.