### PR TITLE
Replace NULL with nullptr in autograd

### DIFF
--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -33,7 +33,7 @@ struct NoCtor {
 
 template<typename C, typename T>
 static void addClass(PyObject* module, PyTypeObject& type, const char* name,
-  PyGetSetDef* function_properties=NULL, PyMethodDef* function_methods=NULL)
+  PyGetSetDef* function_properties=nullptr, PyMethodDef* function_methods=nullptr)
 {
   createForwardFunctionPyTypeObject<T>(type, name, function_properties, function_methods);
   Py_INCREF(&type);
@@ -50,7 +50,7 @@ PyObject* getTupleAttr(PyObject* obj, void* _unused)
   auto& arr = ((T*)(self->cdata.get()))->*ptr;
   auto num_elems = arr.size();
   THPObjectPtr py_tuple(PyTuple_New(num_elems));
-  if (!py_tuple) return NULL;
+  if (!py_tuple) return nullptr;
   for (size_t i = 0; i < num_elems; ++i) {
     PyTuple_SET_ITEM(py_tuple.get(), i, Convert(arr[i]));
   }
@@ -95,8 +95,8 @@ static PyObject* accumulateGradVar(PyObject *_self, void* _unused)
 
 static struct PyGetSetDef accumulate_grad_properties[] = {
   THP_FUNCTION_DEFAULT_PROPERTIES,
-  {(char*)"variable", accumulateGradVar, NULL, NULL, NULL},
-  {NULL}
+  {(char*)"variable", accumulateGradVar, nullptr, nullptr, nullptr},
+  {nullptr}
 };
 
 bool THPAutograd_initFunctions(PyObject* _unused)

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -73,7 +73,7 @@ struct Eval : Function {
     return std::make_shared<Eval>();
   }
 
-  // Roots are empty if simple_graph is not NULL.
+  // Roots are empty if simple_graph is not nullptr.
   // simple_graph is an optimization of first backward stage - in this case
   // all Eval subgraphs contain only a single gradient function, and the
   // graph search on creation + call to the engine in apply can be elided

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -20,7 +20,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
 
 /**
  * Checks that inputs contains exactly `args` items and that the first `required_args`
- * items are not NULL. If not specified, `required_args` defaults to `args`.
+ * items are not nullptr. If not specified, `required_args` defaults to `args`.
  */
 void check_input_variables(const char* name, const variable_list& inputs, int args, int required_args=-1);
 }}

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -81,9 +81,9 @@ static PyObject * is_grad_enabled(PyObject* _unused, PyObject *arg) {
 
 // autograd methods on torch._C
 static PyMethodDef methods[] = {
-  {"set_grad_enabled", (PyCFunction)set_grad_enabled, METH_O, NULL},
-  {"is_grad_enabled", (PyCFunction)is_grad_enabled, METH_NOARGS, NULL},
-  {NULL, NULL, 0, NULL}
+  {"set_grad_enabled", (PyCFunction)set_grad_enabled, METH_O, nullptr},
+  {"is_grad_enabled", (PyCFunction)is_grad_enabled, METH_NOARGS, nullptr},
+  {nullptr, nullptr, 0, nullptr}
 };
 
 PyMethodDef* python_functions() {

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -100,16 +100,16 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
   auto& next_functions = self->cdata->next_functions;
   auto num_next = next_functions.size();
   THPObjectPtr py_functions(PyTuple_New(num_next));
-  if (!py_functions) return NULL;
+  if (!py_functions) return nullptr;
   for (size_t i = 0; i < num_next; ++i) {
     auto& c_tuple = next_functions[i];
     THPObjectPtr tuple(PyTuple_New(2));
-    if (!tuple) return NULL;
+    if (!tuple) return nullptr;
     PyObject *py_fn = functionToPyObject(c_tuple.function);
-    if (!py_fn) return NULL;
+    if (!py_fn) return nullptr;
     PyTuple_SET_ITEM(tuple.get(), 0, py_fn);
     PyObject *py_idx = PyLong_FromLong(c_tuple.input_nr);
-    if (!py_idx) return NULL;
+    if (!py_idx) return nullptr;
     PyTuple_SET_ITEM(tuple.get(), 1, py_idx);
     PyTuple_SET_ITEM(py_functions.get(), i, tuple.release());
   }
@@ -141,12 +141,12 @@ PyObject* THPCppFunction_register_hook(PyObject* self, PyObject* hook)
 
 static struct PyMethodDef default_methods[] = {
   THP_FUNCTION_DEFAULT_METHODS,
-  {NULL}
+  {nullptr}
 };
 
 static struct PyGetSetDef default_properties[] = {
   THP_FUNCTION_DEFAULT_PROPERTIES,
-  {NULL}
+  {nullptr}
 };
 
 PyTypeObject* _initFunctionPyTypeObject(PyTypeObject& type, const char* name,
@@ -194,7 +194,7 @@ PyObject* functionToPyObject(std::shared_ptr<Function> cdata)
 
     PyTypeObject* type = (PyTypeObject*)it->second.get();
     THPObjectPtr obj(type->tp_alloc(type, 0));
-    if (!obj) return NULL;
+    if (!obj) return nullptr;
     THPCppFunction* f = (THPCppFunction*)obj.get();
     new (&f->cdata) std::shared_ptr<Function>(cdata);
 
@@ -222,9 +222,9 @@ PyObject* registerFunctionHook(Function& fn, PyObject* hook)
   }
 
   THPObjectPtr register_fn(PyObject_GetAttrString(THPFunctionClass, "_register_hook"));
-  if (!register_fn) return NULL;
-  THPObjectPtr res(PyObject_CallFunctionObjArgs(register_fn.get(), dict, hook, NULL));
-  if (!res) return NULL;
+  if (!register_fn) return nullptr;
+  THPObjectPtr res(PyObject_CallFunctionObjArgs(register_fn.get(), dict, hook, nullptr));
+  if (!res) return nullptr;
 
   if (dict == Py_None) {
     dict = PyTuple_GET_ITEM(res.get(), 0);

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -19,24 +19,24 @@ template<typename Ctor>
 PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
   THPObjectPtr obj(type->tp_alloc(type, 0));
-  if (!obj) return NULL;
+  if (!obj) return nullptr;
   THPCppFunction* f = (THPCppFunction*)obj.get();
   HANDLE_TH_ERRORS
   new (&f->cdata) std::shared_ptr<Function>(Ctor()(args));
   END_HANDLE_TH_ERRORS
   if (!f->cdata) {
-    return NULL;
+    return nullptr;
   }
   return obj.release();
 }
 
 #define THP_FUNCTION_DEFAULT_METHODS \
-  {(char*)"_register_hook_dict", (PyCFunction)THPCppFunction_register_hook_dict, METH_O, NULL}, \
-  {(char*)"register_hook", (PyCFunction)THPCppFunction_register_hook, METH_O, NULL}
+  {(char*)"_register_hook_dict", (PyCFunction)THPCppFunction_register_hook_dict, METH_O, nullptr}, \
+  {(char*)"register_hook", (PyCFunction)THPCppFunction_register_hook, METH_O, nullptr}
 
 #define THP_FUNCTION_DEFAULT_PROPERTIES \
-  {(char*)"next_functions", (getter)THPCppFunction_next_functions, NULL, NULL, NULL}, \
-  {(char*)"requires_grad", (getter)THPCppFunction_requires_grad, NULL, NULL, NULL}
+  {(char*)"next_functions", (getter)THPCppFunction_next_functions, nullptr, nullptr, nullptr}, \
+  {(char*)"requires_grad", (getter)THPCppFunction_requires_grad, nullptr, nullptr, nullptr}
 
 PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook);
 PyObject* THPCppFunction_requires_grad(THPCppFunction* self);
@@ -50,7 +50,7 @@ PyObject* registerFunctionHook(Function& fn, PyObject* hook);
 
 template<typename Ctor>
 PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* name,
-  PyGetSetDef* function_properties=NULL, PyMethodDef* function_methods=NULL)
+  PyGetSetDef* function_properties=nullptr, PyMethodDef* function_methods=nullptr)
 {
   type.tp_new = &CppFunction_pynew<Ctor>;
   return _initFunctionPyTypeObject(type, name, function_properties, function_methods);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -62,7 +62,7 @@ PythonEngine& PythonEngine::getDefaultEngine() {
 
 }}} // namespace torch::autograd::python
 
-PyObject *THPEngineClass = NULL;
+PyObject *THPEngineClass = nullptr;
 
 static bool _reinitialize_engine = false;
 
@@ -85,18 +85,18 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
 {
   HANDLE_TH_ERRORS
   _maybe_reinitialize_engine_after_fork();
-  PyObject *variables = NULL;
-  PyObject *grad_variables = NULL;
+  PyObject *variables = nullptr;
+  PyObject *grad_variables = nullptr;
   unsigned char keep_graph = 0;
   unsigned char create_graph = 0;
-  PyObject *inputs = NULL;
+  PyObject *inputs = nullptr;
   const char *accepted_kwargs[] = {
       "variables", "grad_variables", "keep_graph", "create_graph", "inputs",
-      NULL
+      nullptr
   };
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OObb|O", (char**)accepted_kwargs,
         &variables, &grad_variables, &keep_graph, &create_graph, &inputs))
-    return NULL;
+    return nullptr;
 
   THPUtils_assert(PyTuple_Check(variables), "variables argument is expected to "
       "be a tuple, but got %s", THPUtils_typename(variables));
@@ -134,7 +134,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
   }
 
   function_list output_edges;
-  if (inputs != NULL) {
+  if (inputs != nullptr) {
     int num_inputs = PyTuple_GET_SIZE(inputs);
     output_edges.reserve(num_inputs);
     for (int i = 0; i < num_inputs; ++i) {
@@ -165,10 +165,10 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     outputs = engine.execute(roots, grads, keep_graph, create_graph, output_edges);
   }
 
-  if (inputs != NULL) {
+  if (inputs != nullptr) {
     int num_inputs = PyTuple_GET_SIZE(inputs);
     THPObjectPtr py_outputs {PyTuple_New(num_inputs)};
-    if (!py_outputs) return NULL;
+    if (!py_outputs) return nullptr;
     for (int i = 0; i < num_inputs; i++) {
       PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));
     }
@@ -186,7 +186,7 @@ PyObject* THPEngine_queue_callback(PyObject *self, PyObject *_callback) {
   Py_INCREF(_callback);
   engine.queue_callback([callback]() {
     AutoGIL gil;
-    THPObjectPtr result {PyObject_CallFunctionObjArgs(callback.get(), NULL)};
+    THPObjectPtr result {PyObject_CallFunctionObjArgs(callback.get(), nullptr)};
     if (!result) throw python_error();
   });
   Py_RETURN_NONE;
@@ -199,14 +199,14 @@ PyObject *THPEngine_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 }
 
 static struct PyMethodDef THPEngine_methods[] = {
-  {(char*)"run_backward", (PyCFunction)THPEngine_run_backward, METH_VARARGS | METH_KEYWORDS, NULL},
-  {(char*)"queue_callback", (PyCFunction)THPEngine_queue_callback, METH_O, NULL},
-  {NULL}
+  {(char*)"run_backward", (PyCFunction)THPEngine_run_backward, METH_VARARGS | METH_KEYWORDS, nullptr},
+  {(char*)"queue_callback", (PyCFunction)THPEngine_queue_callback, METH_O, nullptr},
+  {nullptr}
 };
 
 
 PyTypeObject THPEngineType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
+  PyVarObject_HEAD_INIT(nullptr, 0)
   "torch._C._EngineBase",                /* tp_name */
   sizeof(THPEngine),                     /* tp_basicsize */
   0,                                     /* tp_itemsize */
@@ -226,7 +226,7 @@ PyTypeObject THPEngineType = {
   0,                                     /* tp_setattro */
   0,                                     /* tp_as_buffer */
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-  NULL,                                  /* tp_doc */
+  nullptr,                               /* tp_doc */
   0,                                     /* tp_traverse */
   0,                                     /* tp_clear */
   0,                                     /* tp_richcompare */
@@ -253,7 +253,7 @@ static void child_atfork() {
 bool THPEngine_initModule(PyObject *module)
 {
 #ifndef _WIN32
-  if (pthread_atfork(NULL, NULL, child_atfork) != 0) {
+  if (pthread_atfork(nullptr, nullptr, child_atfork) != 0) {
     throw std::runtime_error("unable to set pthread_atfork handler");
   }
 #endif

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -66,15 +66,15 @@ struct THPFunction {
     PyObject *needs_input_grad;
 
     // Python tuple of tensors whose variables we should save.  Set
-    // by Python with 'save_for_backward'.  If NULL, no tensors were
+    // by Python with 'save_for_backward'.  If nullptr, no tensors were
     // saved.
     PyObject *to_save;
     // Python tuple of tensors which are not differentiable.  Set by
-    // Python with 'mark_non_differentiable'.  If NULL, no tensors were
+    // Python with 'mark_non_differentiable'.  If nullptr, no tensors were
     // non-differentiable.
     PyObject *non_differentiable;
     // Python tuple of tensors which had inplace updates in the forward()
-    // pass.  Set by Python with 'mark_dirty'.  If NULL, no tensors were
+    // pass.  Set by Python with 'mark_dirty'.  If nullptr, no tensors were
     // modified inplace.
     PyObject *dirty_tensors;
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -21,7 +21,7 @@
 using namespace at;
 using namespace torch::autograd;
 
-PyObject *THPVariableClass = NULL;
+PyObject *THPVariableClass = nullptr;
 
 static const char* VOLATILE_WARNING =
     "volatile was removed and now has no effect. Use "
@@ -118,21 +118,21 @@ static void THPVariable_dealloc(THPVariable* self)
 PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
   THPObjectPtr _data;
-  PyObject *data = NULL;
-  PyObject *grad_fn = NULL;
+  PyObject *data = nullptr;
+  PyObject *grad_fn = nullptr;
   char is_volatile = 0;
   char requires_grad = 0;
-  const char* name = NULL;
+  const char* name = nullptr;
 
-  const char *accepted_args[] = {"data", "requires_grad", "volatile", "_grad_fn", "name", NULL};
+  const char *accepted_args[] = {"data", "requires_grad", "volatile", "_grad_fn", "name", nullptr};
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ObbOz", (char**)accepted_args,
       &data, &requires_grad, &is_volatile, &grad_fn, &name))
-    return NULL;
+    return nullptr;
 
   if (grad_fn == Py_None)
-    grad_fn = NULL;
+    grad_fn = nullptr;
 
-  if (data == NULL || data == Py_None) {
+  if (data == nullptr || data == Py_None) {
     // For legacy serialization code, create an empty tensor temporarily.
     at::Tensor tensor = at::CPU(at::kFloat).tensor();
     _data = torch::createPyObject(tensor);
@@ -176,12 +176,12 @@ int THPVariable_pyinit(PyObject *self, PyObject *args, PyObject *kwds)
   // The 'data' argument is optional in __new__ to handle legacy serialized
   // Variables.
   PyObject *data;
-  PyObject *grad_fn = NULL;
+  PyObject *grad_fn = nullptr;
   char is_volatile = 0;
   char requires_grad = 0;
-  const char* name = NULL;
+  const char* name = nullptr;
 
-  const char *accepted_args[] = {"data", "requires_grad", "volatile", "_grad_fn", "name", NULL};
+  const char *accepted_args[] = {"data", "requires_grad", "volatile", "_grad_fn", "name", nullptr};
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ObbOz", (char**)accepted_args,
       &data, &requires_grad, &is_volatile, &grad_fn, &name))
     return -1;
@@ -444,24 +444,24 @@ PyObject *THPVariable_is_sparse(THPVariable *self)
 }
 
 static struct PyGetSetDef THPVariable_properties[] = {
-  {"_cdata", (getter)THPVariable_get_cdata, NULL, NULL, NULL},
-  {"_version", (getter)THPVariable_get_version, NULL, NULL, NULL},
-  {"grad_fn", (getter)THPVariable_get_grad_fn, NULL, NULL, NULL},
-  {"_grad_fn", (getter)THPVariable_get_grad_fn, (setter)THPVariable_set_grad_fn, NULL, NULL},
-  {"is_leaf", (getter)THPVariable_is_leaf, NULL, NULL, NULL},
-  {"data", (getter)THPVariable_get_data, (setter)THPVariable_set_data, NULL, NULL},
-  {"_grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, NULL, NULL}, // only for legacy reasons
-  {"grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, NULL, NULL},
-  {"_base", (getter)THPVariable_get_base, NULL, NULL, NULL},
-  {"volatile", (getter)THPVariable_get_volatile, (setter)THPVariable_set_volatile, NULL, NULL},
-  {"output_nr", (getter)THPVariable_get_output_nr, NULL, NULL, NULL},
-  {"requires_grad", (getter)THPVariable_get_requires_grad, (setter)THPVariable_set_requires_grad, NULL, NULL},
-  {"_backward_hooks", (getter)THPVariable_get_backwards_hooks, (setter)THPVariable_set_backwards_hooks, NULL, NULL},
-  {"name", (getter)THPVariable_get_name, NULL, NULL, NULL},
-  {"shape", (getter)THPVariable_get_shape, NULL, NULL, NULL},
-  {"is_cuda", (getter)THPVariable_is_cuda, NULL, NULL, NULL},
-  {"is_sparse", (getter)THPVariable_is_sparse, NULL, NULL, NULL},
-  {NULL}
+  {"_cdata", (getter)THPVariable_get_cdata, nullptr, nullptr, nullptr},
+  {"_version", (getter)THPVariable_get_version, nullptr, nullptr, nullptr},
+  {"grad_fn", (getter)THPVariable_get_grad_fn, nullptr, nullptr, nullptr},
+  {"_grad_fn", (getter)THPVariable_get_grad_fn, (setter)THPVariable_set_grad_fn, nullptr, nullptr},
+  {"is_leaf", (getter)THPVariable_is_leaf, nullptr, nullptr, nullptr},
+  {"data", (getter)THPVariable_get_data, (setter)THPVariable_set_data, nullptr, nullptr},
+  {"_grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, nullptr, nullptr}, // only for legacy reasons
+  {"grad", (getter)THPVariable_get_grad, (setter)THPVariable_set_grad, nullptr, nullptr},
+  {"_base", (getter)THPVariable_get_base, nullptr, nullptr, nullptr},
+  {"volatile", (getter)THPVariable_get_volatile, (setter)THPVariable_set_volatile, nullptr, nullptr},
+  {"output_nr", (getter)THPVariable_get_output_nr, nullptr, nullptr, nullptr},
+  {"requires_grad", (getter)THPVariable_get_requires_grad, (setter)THPVariable_set_requires_grad, nullptr, nullptr},
+  {"_backward_hooks", (getter)THPVariable_get_backwards_hooks, (setter)THPVariable_set_backwards_hooks, nullptr, nullptr},
+  {"name", (getter)THPVariable_get_name, nullptr, nullptr, nullptr},
+  {"shape", (getter)THPVariable_get_shape, nullptr, nullptr, nullptr},
+  {"is_cuda", (getter)THPVariable_is_cuda, nullptr, nullptr, nullptr},
+  {"is_sparse", (getter)THPVariable_is_sparse, nullptr, nullptr, nullptr},
+  {nullptr}
 };
 
 static PyMappingMethods THPVariable_as_mapping = {
@@ -471,7 +471,7 @@ static PyMappingMethods THPVariable_as_mapping = {
 };
 
 PyTypeObject THPVariableType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
+  PyVarObject_HEAD_INIT(nullptr, 0)
   "torch._C._VariableBase",              /* tp_name */
   sizeof(THPVariable),                   /* tp_basicsize */
   0,                                     /* tp_itemsize */
@@ -491,7 +491,7 @@ PyTypeObject THPVariableType = {
   0,                                     /* tp_setattro */
   0,                                     /* tp_as_buffer */
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-  NULL,                                  /* tp_doc */
+  nullptr,                               /* tp_doc */
   (traverseproc)THPVariable_traverse,    /* tp_traverse */
   (inquiry)THPVariable_clear,            /* tp_clear */
   0,                                     /* tp_richcompare */

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -99,7 +99,7 @@ static Variable sequenceToVariable(const Type& type, PyObject* seq) {
 #ifdef WITH_CUDA
   if (type.is_cuda()) ctor = THCPLongTensorClass;
 #endif
-  auto obj = THPObjectPtr(PyObject_CallFunctionObjArgs(ctor, seq, NULL));
+  auto obj = THPObjectPtr(PyObject_CallFunctionObjArgs(ctor, seq, nullptr));
   if (!obj) throw python_error();
   return make_variable(createTensor(obj.get()));
 }


### PR DESCRIPTION
This is a small codemod to replace all occurences of `NULL` with `nullptr` in the autograd codebase. We compile with a C++11 compiler and `nullptr` is a safer, drop-in replacement for `NULL` so there is no reason to not use `nullptr`. It adds safety because `NULL` is often defined as `0` and thus causes ambiguity in a case like this:
```
void f(int) {}
void f(int*) {}
f(NULL); // compiler error: ambiguous (could not determine overload)
f(nullptr); // calls pointer overload
```

@apaszke @ezyang @colesbury @zdevito 