### PR TITLE
make explicit about keyword-onlyness of `out`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -59,7 +59,7 @@ a real number, otherwise it should be an integer.
 Args:
     input (Tensor): the input tensor
     value (Number): the number to be added to each element of :attr:`input`
-    out (Tensor, optional): the output tensor
+    out (Tensor, optional): the output tensor. must be given as a keyword argument if present
 
 Example::
 
@@ -100,7 +100,7 @@ Args:
     input (Tensor): the first input tensor
     value (Number): the scalar multiplier for :attr:`other`
     other (Tensor): the second input tensor
-    out (Tensor, optional): the output tensor
+    out (Tensor, optional): the output tensor. must be given as a keyword argument if present
 
 Example::
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -61,7 +61,7 @@ Args:
     value (Number): the number to be added to each element of :attr:`input`
 
 Keyword arguments:
-    out (Tensor): the output tensor
+    out (Tensor, optional): the output tensor
 
 Example::
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -59,7 +59,9 @@ a real number, otherwise it should be an integer.
 Args:
     input (Tensor): the input tensor
     value (Number): the number to be added to each element of :attr:`input`
-    out (Tensor, optional): the output tensor. must be given as a keyword argument if present
+
+Keyword arguments:
+    out (Tensor): the output tensor
 
 Example::
 
@@ -100,7 +102,9 @@ Args:
     input (Tensor): the first input tensor
     value (Number): the scalar multiplier for :attr:`other`
     other (Tensor): the second input tensor
-    out (Tensor, optional): the output tensor. must be given as a keyword argument if present
+
+Keyword arguments:
+    out (Tensor, optional): the output tensor
 
 Example::
 


### PR DESCRIPTION
fix issue 2 of https://github.com/pytorch/pytorch/issues/5156#issuecomment-364521510