### PR TITLE
Fix sign error in TransformedDistribution.cdf() and .icdf()

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -285,9 +285,9 @@ EXAMPLES = [
             'transforms': ExpTransform(),
         },
         {
-            'base_distribution': Normal(Variable(torch.randn(2, 3), requires_grad=True),
-                                        Variable(torch.randn(2, 3).abs(), requires_grad=True)),
-            'transforms': [AffineTransform(Variable(torch.randn(1)), Variable(torch.randn(1))),
+            'base_distribution': Normal(Variable(torch.randn(2, 3, 5), requires_grad=True),
+                                        Variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+            'transforms': [AffineTransform(Variable(torch.randn(3, 5)), Variable(torch.randn(3, 5))),
                            ExpTransform()],
         },
     ]),
@@ -1317,7 +1317,7 @@ class TestDistributions(TestCase):
                     pdfs = dist.log_prob(samples).exp()
                 except NotImplementedError:
                     continue
-                cdfs_derivative = grad(cdfs.sum(), [samples])[0]
+                cdfs_derivative = grad(cdfs.sum(), [samples])[0]  # this should not be wrapped in torch.abs()
                 self.assertEqual(cdfs_derivative, pdfs, message='\n'.join([
                     '{} example {}/{}, d(cdf)/dx != pdf(x)'.format(Dist.__name__, i + 1, len(params)),
                     'x = {}'.format(samples),

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -70,7 +70,6 @@ class Transform(object):
             transforms that act jointly on matrices, etc.
     """
     bijective = False
-    sign = float('nan')
     event_dim = 0
 
     def __init__(self, cache_size=0):
@@ -96,6 +95,14 @@ class Transform(object):
             inv = _InverseTransform(self)
             self._inv = weakref.ref(inv)
         return inv
+
+    @property
+    def sign(self):
+        """
+        Returns the sign of the determinant of the Jacobian, if applicable.
+        In general this only makes sense for bijective transforms.
+        """
+        raise NotImplementedError
 
     def __eq__(self, other):
         return self is other


### PR DESCRIPTION
Fixes probtorch#127, a sign error in the `.cdf()` method of univariate `TransformedDistribuitons` that reverse direction of input.

I also wrapped some docstrings to fit in 80 characters so they print correctly in Jupyter notebooks.

Note this has a one-line merge conflict with #4950 in test_distributions.py. To resolve the conflict, accept changes from this PR and revert the workaround in #4950.

Previous review by @vishwakftw https://github.com/probtorch/pytorch/pull/128

## Tested

- Added a larger grid of random inputs for `AffineTransform` so that it is much more likely that tests include a direction-reversed example.