### PR TITLE
About #4990, Makes Window build fail quicker

### DIFF
--- a/torch/lib/build_libs.bat
+++ b/torch/lib/build_libs.bat
@@ -46,7 +46,7 @@ IF "%CMAKE_GENERATOR%"=="" (
   IF "%CMAKE_GENERATOR%"=="Ninja" (
     IF "%CC%"== "" set CC=cl.exe
     IF "%CXX%"== "" set CXX=cl.exe
-    set MAKE_COMMAND=cmake --build . --target install --config %BUILD_TYPE% -- -j%NUMBER_OF_PROCESSORS% || exit /b 1
+    set MAKE_COMMAND=cmake --build . --target install --config %BUILD_TYPE% -- -j%NUMBER_OF_PROCESSORS%
   ) ELSE (
     set MAKE_COMMAND=msbuild INSTALL.vcxproj /p:Configuration=%BUILD_TYPE%
   )
@@ -108,6 +108,7 @@ goto:eof
                   -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
 
   %MAKE_COMMAND%
+  IF NOT %ERRORLEVEL%==0 exit 1
   cd ../..
   @endlocal
 
@@ -128,6 +129,7 @@ goto:eof
                   -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
 
   %MAKE_COMMAND%
+  IF NOT %ERRORLEVEL%==0 exit 1
   cd ../..
   @endlocal
 


### PR DESCRIPTION
The reason that it continues to build when error occurs is the use of `exit /b 1`, which is not sufficient for returning error code to python. According to the [post](https://stackoverflow.com/questions/6637468/incorrect-exit-code-in-python-when-calling-windows-script) here, it can be replaced by `exit 1` to generate the correct error code.