### PR TITLE
Fix compiler error introduced in 3e856137 by PR #5074

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -346,8 +346,8 @@ struct to_ir {
       NodeKind kind,
       const std::vector<Value*> inputs,
       const size_t output_size,
-      const AttributeMap& attributes = {},
-      const ListAttributeMap& list_attributes = {}) {
+      const AttributeMap& attributes = AttributeMap{},
+      const ListAttributeMap& list_attributes = ListAttributeMap{}) {
     Node* n = def.graph->appendNode(def.graph->create(kind, output_size));
     for (auto* input_value : inputs) {
       n->addInput(input_value);


### PR DESCRIPTION
The above mentioned PR introduced new files that currently fail to compile (gcc 4.9.2 / Debian Jessie) when using the below commands:
```
mkdir pytorch && cd pytorch
git clone --recursive https://github.com/pytorch/pytorch .
git submodule update --init
export NCCL_ROOT_DIR='/usr'
export TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1+PTX"
export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
export CMAKE_PREFIX_PATH="$CONDA_HOME"
pip install -v .
```
Following is the error:
```
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/generated/aten_dispatch.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/generated/aten_dispatch.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH\
_CUDA -DCUDA_LIB_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/script/compiler.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/script/compiler.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB\
_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/passes/canonicalize.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/passes/canonicalize.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -D\
CUDA_LIB_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/autograd/init.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/autograd/init.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB_PATH=/usr/l\
ocal/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/python_arg_flatten.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/python_arg_flatten.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCU\
DA_LIB_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/autograd/engine.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/autograd/engine.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB_PATH=/u\
sr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/python_ir.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/python_ir.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB_PATH=/usr/l\
ocal/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/autograd/variable.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/autograd/variable.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB_PAT\
H=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/autograd/input_buffer.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/autograd/input_buffer.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA\
_LIB_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/autograd/python_function.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/autograd/python_function.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA \
-DCUDA_LIB_PATH=/usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/ -I/tmp/pip-zICEN5-build -I/tmp/pip-zICEN5-build/torch/csrc -I/tmp/pip-zICEN5-build/torch/lib/pybind11/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include -I/tmp/pip-zICEN5\
-build/torch/lib/tmp_install/include/TH -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THNN -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/ATen -I/opt/conda/lib/python2.7/site-packages/numpy/core/include -I/tmp/pip-zICEN5-build/torch/lib/tmp_install/include/THD -I/usr/local/cuda/include -I/tmp/pip-zICEN5-buil\
d/torch/lib/tmp_install/include/THCUNN -I/usr/include -I/opt/conda/include/python2.7 -c torch/csrc/jit/type.cpp -o build/temp.linux-x86_64-2.7/torch/csrc/jit/type.o -D_THP_CORE -std=c++11 -Wno-write-strings -fno-strict-aliasing -Wno-missing-braces -DWITH_NUMPY -DWITH_DISTRIBUTED -DWITH_CUDA -DCUDA_LIB_PATH=/usr/local/cuda/\
lib64 -DWITH_NCCL -DWITH_CUDNN -DWITH_SCALARS
    torch/csrc/jit/script/compiler.cpp:349:41: error: converting to 'const AttributeMap {aka const std::unordered_map<std::basic_string<char>, std::pair<double, std::basic_string<char> > >}' from initializer list would use explicit constructor 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(std::unorder\
ed_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Key = std::basic_string<char>; _Tp = std::pair<double, std::basic_string<char> >; _Hash = std::hash<std::basic_string<char> >; _Pred = std::equal_to<std::basic_string<char> >; _Alloc = std::allocator<std::pair\
<const std::basic_string<char>, std::pair<double, std::basic_string<char> > > >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::hasher = std::hash<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::key_equ\
al = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, std::pair<double, std::basic_string<char> > > >]'
           const AttributeMap& attributes = {},
                                             ^
    torch/csrc/jit/script/compiler.cpp:350:50: error: converting to 'const ListAttributeMap {aka const std::unordered_map<std::basic_string<char>, std::pair<const std::vector<double>, std::basic_string<char> > >}' from initializer list would use explicit constructor 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::uno\
rdered_map(std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Key = std::basic_string<char>; _Tp = std::pair<const std::vector<double>, std::basic_string<char> >; _Hash = std::hash<std::basic_string<char> >; _Pred = std::equal_to<std::basic_string<\
char> >; _Alloc = std::allocator<std::pair<const std::basic_string<char>, std::pair<const std::vector<double>, std::basic_string<char> > > >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::hasher = std::hash<std::basic_string<char> >;\
 std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<std::basic_string<char> >; std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<std::pair<const std::basic_string<char>, std::pair<const std::vector<double>, std::basic_string<char> > > >]'
           const ListAttributeMap& list_attributes = {}) {
                                                      ^
```