### PR TITLE
Make conda install and s3 cp in Windows build more quiet

### DIFF
--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -46,7 +46,7 @@ rm -rf C:\\Jenkins\\Miniconda3
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
 .\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
 call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
-call conda install -y numpy mkl cffi pyyaml boto3
+call conda install -y -q numpy mkl cffi pyyaml boto3
 
 :: Install ninja
 pip install ninja

--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -31,15 +31,15 @@ cat >ci_scripts/build_pytorch.bat <<EOL
 set PATH=C:\\Program Files\\CMake\\bin;C:\\Program Files\\7-Zip;C:\\curl-7.57.0-win64-mingw\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLI;%PATH%
 
 :: Install MKL
-aws s3 cp s3://ossci-windows/mkl.7z mkl.7z && 7z x -aoa mkl.7z -omkl
+aws s3 cp s3://ossci-windows/mkl.7z mkl.7z --quiet && 7z x -aoa mkl.7z -omkl
 set LIB=%cd%\\mkl;%LIB%
 
 :: Install MAGMA
-aws s3 cp s3://ossci-windows/magma_cuda90_release.7z magma_cuda90_release.7z && 7z x -aoa magma_cuda90_release.7z -omagma_cuda90_release
+aws s3 cp s3://ossci-windows/magma_cuda90_release.7z magma_cuda90_release.7z --quiet && 7z x -aoa magma_cuda90_release.7z -omagma_cuda90_release
 set MAGMA_HOME=%cd%\\magma_cuda90_release
 
 :: Install clcache
-aws s3 cp s3://ossci-windows/clcache.7z clcache.7z && 7z x -aoa clcache.7z -oclcache
+aws s3 cp s3://ossci-windows/clcache.7z clcache.7z --quiet && 7z x -aoa clcache.7z -oclcache
 
 :: Install Miniconda3
 rm -rf C:\\Jenkins\\Miniconda3

--- a/.jenkins/win-test.sh
+++ b/.jenkins/win-test.sh
@@ -57,7 +57,7 @@ rm -rf C:\\Jenkins\\Miniconda3
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O
 .\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=C:\\Jenkins\\Miniconda3
 call C:\\Jenkins\\Miniconda3\\Scripts\\activate.bat C:\\Jenkins\\Miniconda3
-call conda install -y numpy mkl cffi pyyaml boto3
+call conda install -y -q numpy mkl cffi pyyaml boto3
 
 set PATH=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0\\bin;C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0\\libnvvp;%PATH%
 set CUDA_PATH=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0


### PR DESCRIPTION
Currently it's hard to find the true failure in Windows build because the log is too long. This PR turns off the logging for `conda install` and `aws s3 cp` to make the build more quiet. 

Partially addressing #4990. 