### PR TITLE
Remove deprecated references to volatile in documentation

### DIFF
--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -11,9 +11,8 @@ programs, and can aid you in debugging.
 Excluding subgraphs from backward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Every Variable has two flags: :attr:`requires_grad` and :attr:`volatile`.
-They both allow for fine grained exclusion of subgraphs from gradient
-computation and can increase efficiency.
+Every Variable has a flag: :attr:`requires_grad` that allows for fine grained
+exclusion of subgraphs from gradient computation and can increase efficiency.
 
 .. _excluding-requires_grad:
 

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -155,8 +155,7 @@ This is how a ``Linear`` module can be implemented::
             # they won't appear in .parameters() (doesn't apply to buffers), and
             # won't be converted when e.g. .cuda() is called. You can use
             # .register_buffer() to register buffers.
-            # nn.Parameters can never be volatile and, different than Variables,
-            # they require gradients by default.
+            # nn.Parameters require gradients by default.
             self.weight = nn.Parameter(torch.Tensor(output_features, input_features))
             if bias:
                 self.bias = nn.Parameter(torch.Tensor(output_features))


### PR DESCRIPTION
Commit 65353f13 left some references to volatile in the documentation, this pull request removes them.