### PR TITLE
Add missing async deprecated wrapper to tools/autograd/templates/pyth…

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -339,7 +339,8 @@ static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwa
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "cuda(int64_t? device=-1, bool non_blocking=False)"
+    "cuda(int64_t? device=-1, bool non_blocking=False)",
+    "cuda(int64_t? device=-1, bool async=False)|deprecated"
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   PyObject* parsed_args[2];


### PR DESCRIPTION
…on_variable_methods.cpp

Fixes #5174 

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>