### PR TITLE
Modest refactor of .jenkins scripts

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
 # Required environment variables:
 #   $JOB_NAME
 #   $PYTHON_VERSION
@@ -8,8 +10,6 @@
 # TODO: change this script to make use of $BUILD_ENVIRONMENT,
 # which we can hard code into Docker images and then these scripts
 # will work out of the box without having to set any env vars.
-
-set -ex
 
 export PATH=/opt/conda/bin:$PATH
 
@@ -39,11 +39,6 @@ python --version
 
 pip install -r requirements.txt || true
 
-# This token is used by a parser on Jenkins logs for determining
-# if a failure is a legitimate problem, or a problem with the build
-# system; to find out more, grep for this string in ossci-job-dsl.
-echo "ENTERED_USER_LAND"
-
 time python setup.py install
 
 if [[ "$JOB_NAME" != *cuda* ]]; then
@@ -59,5 +54,3 @@ if [[ "$JOB_NAME" != *pynightly* ]]; then
    cd extension-ffi/script
    python build.py
 fi
-
-echo "EXITED_USER_LAND"

--- a/.jenkins/common.sh
+++ b/.jenkins/common.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Common setup for all Jenkins scripts
+
+# NB: define this function before set -x, so that we don't
+# pollute the log with a premature EXITED_USER_LAND ;)
+function cleanup {
+  # Note that if you've exited user land, then CI will conclude that
+  # any failure is the CI's fault.  So we MUST only output this
+  # string
+  retcode=$?
+  set +x
+  if [ $retcode -eq 0 ]; then
+    echo "EXITED_USER_LAND"
+  fi
+}
+
+set -ex
+
+# Required environment variables:
+#   $JOB_NAME
+
+# This token is used by a parser on Jenkins logs for determining
+# if a failure is a legitimate problem, or a problem with the build
+# system; to find out more, grep for this string in ossci-job-dsl.
+echo "ENTERED_USER_LAND"
+
+trap cleanup EXIT
+
+# Converts:
+# pytorch-builds/pytorch-macos-10.13-py3-build-test ==> pytorch-macos-10.13-py3-build-test
+#
+# We don't match the full path so that you can make a job in a subfolder
+# that will trigger this checking.
+#
+# NB: This greedily matches until the last /, so if you ever decide to
+# restructure the PyTorch jobs to have some more directory hierarchy,
+# you will have to adjust this.
+COMPACT_JOB_NAME="$(echo "$JOB_NAME" | perl -pe 's{^(?:.+/)?(.+)$}{$1}o')"
+
+if grep --line-regexp -q "$COMPACT_JOB_NAME" "$(dirname "${BASH_SOURCE[0]}")/enabled-configs.txt"; then
+  echo "Test is enabled, proceeding"
+else
+  echo "Test is disabled, FAILING now (revert changes to enabled-configs.txt to fix this)"
+  exit 1
+fi

--- a/.jenkins/enabled-configs.txt
+++ b/.jenkins/enabled-configs.txt
@@ -1,0 +1,30 @@
+# This file contains a list of enabled configurations
+# to perform tests on.  If you want to run tests on CI on
+# a limited set of tests before enabling the full test suite,
+# you can delete lines from this file.  Any test that is not
+# in this file will report a failure (so you don't forget to
+# reenable the tests on merge ;)
+
+pytorch-linux-xenial-cuda8-cudnn6-py3-build
+pytorch-linux-xenial-cuda8-cudnn6-py3-test
+pytorch-linux-xenial-cuda9-cudnn7-py2-build
+pytorch-linux-xenial-cuda9-cudnn7-py2-test
+pytorch-linux-xenial-cuda9-cudnn7-py3-build
+pytorch-linux-xenial-cuda9-cudnn7-py3-test
+pytorch-linux-trusty-py2.7.9-build
+pytorch-linux-trusty-py2.7.9-test
+pytorch-linux-trusty-py2.7-build
+pytorch-linux-trusty-py2.7-test
+pytorch-linux-trusty-py3.5-build
+pytorch-linux-trusty-py3.5-test
+pytorch-linux-trusty-py3.6-gcc4.8-build
+pytorch-linux-trusty-py3.6-gcc4.8-test
+pytorch-linux-trusty-py3.6-gcc5.4-build
+pytorch-linux-trusty-py3.6-gcc5.4-test
+pytorch-linux-trusty-py3.6-gcc7.2-build
+pytorch-linux-trusty-py3.6-gcc7.2-test
+pytorch-linux-trusty-pynightly-build
+pytorch-linux-trusty-pynightly-test
+pytorch-win-ws2016-cuda9-cudnn7-py3-build
+pytorch-win-ws2016-cuda9-cudnn7-py3-test
+pytorch-macos-10.13-py3-build-test

--- a/.jenkins/macos-build-test.sh
+++ b/.jenkins/macos-build-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Set up conda environment
 curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $PWD/miniconda3.sh
@@ -14,8 +14,6 @@ conda install -y numpy pyyaml setuptools cmake cffi ninja
 git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=$PWD/miniconda3/
 
-echo "ENTERED_USER_LAND"
-
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
@@ -25,5 +23,4 @@ python setup.py install
 cd test/
 echo "Ninja version: $(ninja --version)"
 sh run_test.sh
-echo "EXITED_USER_LAND"
 echo "BUILD PASSED"

--- a/.jenkins/short-perf-test-cpu.sh
+++ b/.jenkins/short-perf-test-cpu.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 cd .jenkins/perf_test
 
 export PATH=/opt/conda/bin:$PATH
 
 echo "Running CPU perf test for PyTorch..."
-
-echo "ENTERED_USER_LAND"
 
 # Include tests
 . ./test_cpu_speed_mini_sequence_labeler.sh
@@ -17,5 +15,3 @@ echo "ENTERED_USER_LAND"
 # Run tests
 run_test test_cpu_speed_mini_sequence_labeler compare_with_baseline
 run_test test_cpu_speed_mnist compare_with_baseline
-
-echo "EXITED_USER_LAND"

--- a/.jenkins/short-perf-test-gpu.sh
+++ b/.jenkins/short-perf-test-gpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 cd .jenkins/perf_test
 
@@ -10,8 +10,6 @@ export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 echo "Running GPU perf test for PyTorch..."
-
-echo "ENTERED_USER_LAND"
 
 # Include tests
 . ./test_gpu_speed_mnist.sh
@@ -26,5 +24,3 @@ run_test test_gpu_speed_word_language_model compare_with_baseline
 run_test test_gpu_speed_cudnn_lstm compare_with_baseline
 run_test test_gpu_speed_lstm compare_with_baseline
 run_test test_gpu_speed_mlstm compare_with_baseline
-
-echo "EXITED_USER_LAND"

--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Required environment variables:
 #   $JOB_NAME
@@ -34,8 +34,6 @@ else
    pip install pillow
 fi
 
-echo "ENTERED_USER_LAND"
-
 echo "Testing pytorch"
 export OMP_NUM_THREADS=4
 export MKL_NUM_THREADS=4
@@ -54,5 +52,3 @@ rm -rf ninja
 pushd vision
 time python setup.py install
 popd
-
-echo "EXITED_USER_LAND"

--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
 if [[ ${JOB_NAME} == *"develop"* ]]; then
@@ -80,4 +80,4 @@ python setup.py install && 7z a %IMAGE_COMMIT_TAG%.7z C:\\Jenkins\\Miniconda3\\L
 
 EOL
 
-echo "ENTERED_USER_LAND" && ci_scripts/build_pytorch.bat && echo "EXITED_USER_LAND" && echo "BUILD PASSED"
+ci_scripts/build_pytorch.bat && echo "BUILD PASSED"

--- a/.jenkins/win-test.sh
+++ b/.jenkins/win-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
 if [[ ${JOB_NAME} == *"develop"* ]]; then
@@ -77,4 +77,4 @@ sh run_test.sh
 
 EOL
 
-echo "ENTERED_USER_LAND" && ci_scripts/test_pytorch.bat && echo "EXITED_USER_LAND" && echo "TEST PASSED"
+ci_scripts/test_pytorch.bat && echo "TEST PASSED"


### PR DESCRIPTION
- Create a new common.sh to put common bash stanzas in
- Create a new enabled-configs.txt file, which you can use
  to selectively disable tests when running CI
- Specify exited user land via trap, which means early successful
  exit will correctly print the end sigil.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>