### PR TITLE
Additional sparse Variable fixes

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2596,6 +2596,7 @@
     - method
     - function
   return: argument 0
+  aten_sparse: True
   options:
     - cname: mul
       arguments:
@@ -2604,7 +2605,6 @@
         - THTensor* self
         - real other
     - cname: cmul
-      aten_sparse: True
       arguments:
         - arg: THTensor* result
           output: True
@@ -2615,6 +2615,7 @@
 [[
   name: mul_
   return: argument 0
+  aten_sparse: True
   options:
     - cname: mul
       arguments:
@@ -2622,7 +2623,6 @@
         - THTensor* self
         - real other
     - cname: cmul
-      aten_sparse: True
       arguments:
         - THTensor* self
         - arg: THTensor* self
@@ -4308,4 +4308,20 @@
   cname: newValues
   arguments:
      - THTensor* self
+]]
+[[
+  name: hspmm
+  variants:
+    - function
+  cname: hspmm
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - CONSTANT AS_REAL(1)
+    - THTensor* mat1
+    - THDenseTensor* mat2
 ]]

--- a/aten/src/ATen/native/SparseMM.cpp
+++ b/aten/src/ATen/native/SparseMM.cpp
@@ -72,6 +72,13 @@ Tensor& _sspaddmm_out_only_sparse(Tensor& result, const Tensor& self,
   return result;
 }
 
+// sparse, dense -> sparse
+Tensor smm(const Tensor& self, const Tensor& mat2) {
+  auto result = self.type().tensor();
+  self.type().sspaddmm_out(result, result, self, mat2, 0.0, 1.0);
+  return result;
+}
+
 // sparse, sparse, dense, real, real -> sparse
 Tensor sspaddmm(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
     Scalar beta, Scalar alpha) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -35,16 +35,6 @@
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
 
-- func: sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-
-- func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _sspaddmm_out_only_sparse
-    CUDA: _sspaddmm_out_only_sparse
-    SparseCPU: _sspaddmm_out_cpu
-    SparseCUDA: _sspaddmm_out_cuda
-
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
 
 - func: cudnn_is_acceptable(Tensor self) -> bool
@@ -86,7 +76,6 @@
 
 - func: conv_transpose3d(Tensor input, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, int64_t groups=1, IntList[3] dilation=1) -> Tensor
   variants: function
-
 
 - func: cudnn_affine_grid_generator(Tensor theta, int64_t N, int64_t C, int64_t H, int64_t W) -> Tensor
   return:
@@ -281,6 +270,7 @@
   variants: function
 
 - func: repeat(Tensor self, IntList repeats) -> Tensor
+  variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
 - func: RoiPooling2d_forward(Tensor input, Tensor rois, int64_t pooledHeight, int64_t pooledWidth, double spatialScale) -> (Tensor, Tensor)
   variants: function
@@ -312,6 +302,8 @@
 
 - func: slice(Tensor self, int64_t dim=0, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1) -> Tensor
 
+- func: smm(Tensor self, Tensor mat2) -> Tensor
+
 - func: split(Tensor self, int64_t split_size, int64_t dim=0) -> TensorList
 
 - func: squeeze(Tensor self) -> Tensor
@@ -321,6 +313,16 @@
 - func: squeeze_(Tensor self) -> Tensor
 
 - func: squeeze_(Tensor self, int64_t dim) -> Tensor
+
+- func: sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+
+- func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _sspaddmm_out_only_sparse
+    CUDA: _sspaddmm_out_only_sparse
+    SparseCPU: _sspaddmm_out_cpu
+    SparseCUDA: _sspaddmm_out_cuda
 
 - func: stack(TensorList tensors, int64_t dim=0) -> Tensor
   variants: function


### PR DESCRIPTION
```
 * Fix mul with dense + sparse
 * Add missing hspmm and smm

Also make repeat only a function (not a method) to match Tensor
behavior.

These were discovered by running test_torch.py and test_sparse.py after
merging Variable and Tensor
```