### PR TITLE
CUDA support for C++ extensions with setuptools

### DIFF
--- a/.jenkins/test.sh
+++ b/.jenkins/test.sh
@@ -12,6 +12,8 @@ export PATH=/opt/conda/bin:$PATH
 if [[ "$JOB_NAME" == *cuda* ]]; then
    export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
    export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+   # The ccache wrapper should be able to find the real nvcc
+   export PATH="/usr/local/cuda/bin:$PATH"
 else
    export PATH=/opt/python/${PYTHON_VERSION}/bin:$PATH
    export LD_LIBRARY_PATH=/opt/python/${PYTHON_VERSION}/lib:$LD_LIBRARY_PATH

--- a/test/cpp_extensions/cuda_extension.cpp
+++ b/test/cpp_extensions/cuda_extension.cpp
@@ -1,0 +1,19 @@
+#include <torch/torch.h>
+
+// Declare the function from cuda_extension_kernel.cu. It will be compiled
+// separately with nvcc and linked with the object file of cuda_extension.cpp
+// into one shared library.
+void sigmoid_add_cuda(const float* x, const float* y, float* output, int size);
+
+at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
+  AT_ASSERT(x.type().is_cuda(), "x must be a CUDA tensor");
+  AT_ASSERT(y.type().is_cuda(), "y must be a CUDA tensor");
+  auto output = at::zeros_like(x);
+  sigmoid_add_cuda(
+      x.data<float>(), y.data<float>(), output.data<float>(), output.numel());
+  return output;
+}
+
+PYBIND11_MODULE(torch_test_cuda_extension, m) {
+  m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
+}

--- a/test/cpp_extensions/cuda_extension_kernel.cu
+++ b/test/cpp_extensions/cuda_extension_kernel.cu
@@ -1,6 +1,5 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <stdio.h>
 
 __global__ void sigmoid_add_kernel(
     const float* __restrict__ x,
@@ -18,10 +17,5 @@ __global__ void sigmoid_add_kernel(
 void sigmoid_add_cuda(const float* x, const float* y, float* output, int size) {
   const int threads = 1024;
   const int blocks = (size + threads - 1) / threads;
-  printf(
-      "Launching kernel with %d block(s) x %d thread(s) for %d values\n",
-      blocks,
-      threads,
-      size);
   sigmoid_add_kernel<<<blocks, threads>>>(x, y, output, size);
 }

--- a/test/cpp_extensions/cuda_extension_kernel.cu
+++ b/test/cpp_extensions/cuda_extension_kernel.cu
@@ -1,0 +1,27 @@
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+__global__ void sigmoid_add_kernel(
+    const float* __restrict__ x,
+    const float* __restrict__ y,
+    float* __restrict__ output,
+    const int size) {
+  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index < size) {
+    const float sigmoid_x = 1.0f / (1.0f + __expf(-x[index]));
+    const float sigmoid_y = 1.0f / (1.0f + __expf(-y[index]));
+    output[index] = sigmoid_x + sigmoid_y;
+  }
+}
+
+void sigmoid_add_cuda(const float* x, const float* y, float* output, int size) {
+  const int threads = 1024;
+  const int blocks = (size + threads - 1) / threads;
+  printf(
+      "Launching kernel with %d block(s) x %d thread(s) for %d values\n",
+      blocks,
+      threads,
+      size);
+  sigmoid_add_kernel<<<blocks, threads>>>(x, y, output, size);
+}

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -13,7 +13,7 @@ if torch.cuda.is_available():
         'torch_test_cuda_extension',
         ['cuda_extension.cpp', 'cuda_extension_kernel.cu'],
         extra_compile_args={'cxx': ['-g'],
-                            'nvcc': ['-arch=sm_30']})
+                            'nvcc': ['-O2']})
     ext_modules.append(extension)
 
 setup(

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -1,12 +1,20 @@
-from setuptools import setup, Extension
-import torch.utils.cpp_extension
+import torch.cuda
+from setuptools import setup
+from torch.utils.cpp_extension import CppExtension, CUDAExtension
 
 ext_modules = [
-    Extension(
+    CppExtension(
         'torch_test_cpp_extensions', ['extension.cpp'],
-        include_dirs=torch.utils.cpp_extension.include_paths(),
-        language='c++'),
+        extra_compile_args=['-g']),
 ]
+
+if torch.cuda.is_available():
+    extension = CUDAExtension(
+        'torch_test_cuda_extension',
+        ['cuda_extension.cpp', 'cuda_extension_kernel.cu'],
+        extra_compile_args={'cxx': ['-g'],
+                            'nvcc': ['-arch=sm_30']})
+    ext_modules.append(extension)
 
 setup(
     name='torch_test_cpp_extensions',

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -1,8 +1,12 @@
+import unittest
+
 import torch
 import torch.utils.cpp_extension
 import torch_test_cpp_extensions as cpp_extension
 
 import common
+
+TEST_CUDA = torch.cuda.is_available()
 
 
 class TestCppExtension(common.TestCase):
@@ -33,6 +37,18 @@ class TestCppExtension(common.TestCase):
         y = torch.randn(4, 4)
         z = module.tanh_add(x, y)
         self.assertEqual(z, x.tanh() + y.tanh())
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_cuda_extension(self):
+        import torch_test_cuda_extension as cuda_extension
+
+        x = torch.FloatTensor(100).zero_().cuda()
+        y = torch.FloatTensor(100).zero_().cuda()
+
+        z = cuda_extension.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
 
 
 if __name__ == '__main__':

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -20,11 +20,11 @@ def _find_cuda_home():
     cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
     if cuda_home is None:
         # Guess #2
-        if sys.platform in ['darwin', 'linux']:
-            cuda_home = '/usr/local/cuda'
-        elif sys.platform == 'win32':
+        if sys.platform == 'win32':
             cuda_home = glob.glob(
                 'C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v*.*')
+        else:
+            cuda_home = '/usr/local/cuda'
         if not os.path.exists(cuda_home):
             # Guess #3
             try:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2,18 +2,36 @@ import imp
 import os
 import re
 import subprocess
+import setuptools
 import sys
 import sysconfig
 import tempfile
 import warnings
 
+import torch
+
 from setuptools.command.build_ext import build_ext
+
+
+def _find_cuda_home():
+    '''Finds the CUDA install path.'''
+    cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
+    if cuda_home is None:
+        try:
+            which = 'where' if sys.platform == 'win32' else 'which'
+            nvcc = subprocess.check_output([which, 'nvcc']).decode()
+            cuda_home = os.path.dirname(os.path.dirname(nvcc))
+        except Exception:
+            cuda_home = None
+    return cuda_home
+
 
 MINIMUM_GCC_VERSION = (4, 9)
 ABI_INCOMPATIBILITY_WARNING = '''
 Your compiler ({}) may be ABI-incompatible with PyTorch.
 Please use a compiler that is ABI-compatible with GCC 4.9 and above.
 See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html.'''
+CUDA_HOME = _find_cuda_home() if torch.cuda.is_available() else None
 
 
 def check_compiler_abi_compatibility(compiler):
@@ -51,7 +69,7 @@ def check_compiler_abi_compatibility(compiler):
 
 
 class BuildExtension(build_ext):
-    """A custom build extension for adding compiler-specific options."""
+    '''A custom build extension for adding compiler-specific options.'''
 
     def build_extensions(self):
         # On some platforms, like Windows, compiler_cxx is not available.
@@ -60,15 +78,77 @@ class BuildExtension(build_ext):
         else:
             compiler = os.environ.get('CXX', 'c++')
         check_compiler_abi_compatibility(compiler)
-        for extension in self.extensions:
-            extension.extra_compile_args = ['-std=c++11']
+
+        # Register .cu and .cuh as valid source extensions.
+        self.compiler.src_extensions += ['.cu', '.cuh']
+        # Store the compiler instance on the function (to retrieve it inside).
+        _wrap_compile.compiler_object = self.compiler
+        # Monkey-patch the _compile method.
+        self.compiler._original_compile = self.compiler._compile
+        self.compiler._compile = _wrap_compile
+
         build_ext.build_extensions(self)
 
 
-def include_paths():
+def CppExtension(name, sources, *args, **kwargs):
+    '''
+    Create a setuptools.Extension instance for C++.
+
+    Convenience method that creates a `setuptools.Extension` with the bare
+    minimum (but often sufficient) arguments to build a C++ extension.
+
+    All arguments are forwarded to the setuptools.Extension constructor.
+    '''
+    include_dirs = kwargs.get('include_dirs', [])
+    include_dirs += include_paths()
+    kwargs['include_dirs'] = include_dirs
+    kwargs['language'] = 'c++'
+    return setuptools.Extension(name, sources, *args, **kwargs)
+
+
+def CUDAExtension(name, sources, *args, **kwargs):
+    '''
+    Create a setuptools.Extension instance for CUDA/C++.
+
+    Convenience method that creates a `setuptools.Extension` with the bare
+    minimum (but often sufficient) arguments to build a CUDA/C++ extension.
+    This includes the CUDA include path, library path and runtime library.
+
+    All arguments are forwarded to the setuptools.Extension constructor.
+    '''
+    library_dirs = kwargs.get('library_dirs', [])
+    library_dirs.append(_join_cuda_home('lib64'))
+    kwargs['library_dirs'] = library_dirs
+
+    libraries = kwargs.get('libraries', [])
+    libraries.append('cudart')
+    kwargs['libraries'] = libraries
+
+    include_dirs = kwargs.get('include_dirs', [])
+    include_dirs += include_paths(cuda=True)
+    kwargs['include_dirs'] = include_dirs
+
+    kwargs['language'] = 'c++'
+
+    return setuptools.Extension(name, sources, *args, **kwargs)
+
+
+def include_paths(cuda=False):
+    '''
+    Return include paths required to build a C++ extension.
+
+    Args:
+        cuda: If `True`, includes CUDA include paths.
+
+    Returns:
+        A list of include path strings.
+    '''
     here = os.path.abspath(__file__)
     torch_path = os.path.dirname(os.path.dirname(here))
-    return [os.path.join(torch_path, 'lib', 'include')]
+    paths = [os.path.join(torch_path, 'lib', 'include')]
+    if cuda:
+        paths.append(_join_cuda_home('include'))
+    return paths
 
 
 def load(name,
@@ -250,3 +330,38 @@ def _write_ninja_file(path, name, sources, extra_cflags, extra_ldflags,
         for block in blocks:
             lines = '\n'.join(block)
             build_file.write('{}\n\n'.format(lines))
+
+
+def _wrap_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
+    # Recover the original compiler instance that we are monkey-patching.
+    self = _wrap_compile.compiler_object
+
+    # Store the original compiler for later.
+    original_compiler = self.compiler_so
+    if os.path.splitext(src)[1].startswith('.cu'):
+        self.set_executable('compiler_so', _join_cuda_home('bin', 'nvcc'))
+        if isinstance(extra_postargs, dict):
+            extra_postargs = extra_postargs['nvcc']
+        extra_postargs += ['-c', '--compiler-options', "'-fPIC'"]
+    else:
+        if isinstance(extra_postargs, dict):
+            extra_postargs = extra_postargs['cxx']
+        extra_postargs.append('-std=c++11')
+
+    self._original_compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+    # Put the original compiler back in place.
+    self.set_executable('compiler_so', original_compiler)
+
+
+def _join_cuda_home(*paths):
+    '''
+    Joins paths with CUDA_HOME, or raises an error if it CUDA_HOME is not set.
+
+    This is basically a lazy way of raising an error for missing $CUDA_HOME
+    only once we need to get any CUDA-specific path.
+    '''
+    if CUDA_HOME is None:
+        raise EnvironmentError('CUDA_HOME environment variable is not set. '
+                               'Please set it to your CUDA install root.')
+    return os.path.join(CUDA_HOME, *paths)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,8 +1,9 @@
+import glob
 import imp
 import os
 import re
-import subprocess
 import setuptools
+import subprocess
 import sys
 import sysconfig
 import tempfile
@@ -15,14 +16,23 @@ from setuptools.command.build_ext import build_ext
 
 def _find_cuda_home():
     '''Finds the CUDA install path.'''
+    # Guess #1
     cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
     if cuda_home is None:
-        try:
-            which = 'where' if sys.platform == 'win32' else 'which'
-            nvcc = subprocess.check_output([which, 'nvcc']).decode()
-            cuda_home = os.path.dirname(os.path.dirname(nvcc))
-        except Exception:
-            cuda_home = None
+        # Guess #2
+        if sys.platform in ['darwin', 'linux']:
+            cuda_home = '/usr/local/cuda'
+        elif sys.platform == 'win32':
+            cuda_home = glob.glob(
+                'C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v*.*')
+        if not os.path.exists(cuda_home):
+            # Guess #3
+            try:
+                which = 'where' if sys.platform == 'win32' else 'which'
+                nvcc = subprocess.check_output([which, 'nvcc']).decode()
+                cuda_home = os.path.dirname(os.path.dirname(nvcc))
+            except Exception:
+                cuda_home = None
     return cuda_home
 
 


### PR DESCRIPTION
This PR adds support for convenient CUDA integration in our C++ extension mechanism. This mainly involved figuring out how to get setuptools to use nvcc for CUDA files and the regular C++ compiler for C++ files. I've added a mixed C++/CUDA test case which works great.

I've also added a `CUDAExtension` and `CppExtension` function that constructs a `setuptools.Extension` with "usually the right" arguments, which reduces the required boilerplate to write an extension even more. Especially for CUDA, where `library_dir` (`CUDA_HOME/lib64`) and `libraries` (`cudart`) have to be specified as well.

Next step is to enable this with our "JIT" mechanism.

NOTE: I've had to write a small `find_cuda_home` function to find the CUDA install directory. This logic is kind of a duplicate of `tools/setup_helpers/cuda.py`, but that's not available in the shipped PyTorch distribution. The function is also fairly short. Let me know if it's fine to duplicate this logic.

@zdevito @apaszke @ezyang 