### PR TITLE
Implement torch.util.bottleneck

### DIFF
--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -1,0 +1,32 @@
+torch.utils.bottleneck
+===============
+
+.. currentmodule:: torch.utils.bottleneck
+
+`torch.utils.bottleneck` is a tool that can be used as an initial step for
+debugging bottlenecks in your program. It summarizes runs of your script with 
+the Python profiler and PyTorch's autograd profiler. 
+
+Run it on the command line with 
+
+::
+
+    python -m torch.utils.bottleneck /path/to/source/script.py
+
+or run ``python -m torch.utils.bottleneck -h`` for more usage instructions.
+
+.. warning::
+    For ease of use and intepretability of results, `bottleneck` runs multi-GPU
+    code on only one GPU device. Internally, it sets the environment variables
+    ``CUDA_LAUNCH_BLOCKING=1`` and ``CUDA_VISIBLE_DEVICES=K``, where ``K = 0``
+    by default.
+
+.. warning::
+    Because your script will be profiled, please ensure that it exits in a 
+    finite amount of time.
+
+For more complicated uses of the profilers (like in a multi-GPU case),
+please see https://docs.python.org/3/library/profile.html
+or :func:`torch.autograd.profiler.profile()` for more information. 
+
+

--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -16,17 +16,15 @@ Run it on the command line with
 or run ``python -m torch.utils.bottleneck -h`` for more usage instructions.
 
 .. warning::
-    For ease of use and intepretability of results, `bottleneck` runs multi-GPU
-    code on only one GPU device. Internally, it sets the environment variables
-    ``CUDA_LAUNCH_BLOCKING=1`` and ``CUDA_VISIBLE_DEVICES=K``, where ``K = 0``
-    by default.
-
-.. warning::
     Because your script will be profiled, please ensure that it exits in a 
     finite amount of time.
+
+.. warning::
+    Due to the asynchronous nature of CUDA kernels, when running against
+    CUDA code, the cProfile output and CPU-mode autograd profilers may
+    not show correct timings. In this case, the CUDA-mode autograd
+    profiler is better at assigning blame to the relevant operator(s).
 
 For more complicated uses of the profilers (like in a multi-GPU case),
 please see https://docs.python.org/3/library/profile.html
 or :func:`torch.autograd.profiler.profile()` for more information. 
-
-

--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -11,9 +11,10 @@ Run it on the command line with
 
 ::
 
-    python -m torch.utils.bottleneck /path/to/source/script.py
+    python -m torch.utils.bottleneck -- /path/to/source/script.py [args]
 
-or run ``python -m torch.utils.bottleneck -h`` for more usage instructions.
+where [args] are any number of arguments to `script.py`, or run
+``python -m torch.utils.bottleneck -h`` for more usage instructions.
 
 .. warning::
     Because your script will be profiled, please ensure that it exits in a 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    data
    model_zoo
    onnx
+   bottleneck
 
 .. toctree::
    :glob:

--- a/test/bottleneck/test.py
+++ b/test/bottleneck/test.py
@@ -1,0 +1,5 @@
+import torch
+from torch.autograd import Variable
+
+x = Variable(torch.ones(3, 3), requires_grad=True)
+(3 * x).sum().backward()

--- a/test/bottleneck/test.py
+++ b/test/bottleneck/test.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 
-x = Variable(torch.ones(3, 3), requires_grad=True)
+x = torch.ones((3, 3), requires_grad=True)
 (3 * x).sum().backward()

--- a/test/bottleneck/test_args.py
+++ b/test/bottleneck/test_args.py
@@ -1,0 +1,13 @@
+import argparse
+import torch
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    # Required args. Raises error if they aren't passed.
+    parser.add_argument('--foo', help='foo', required=True)
+    parser.add_argument('--bar', help='bar', required=True)
+    _ = parser.parse_args()
+
+    x = torch.ones((3, 3), requires_grad=True)
+    (3 * x).sum().backward()

--- a/test/bottleneck/test_cuda.py
+++ b/test/bottleneck/test_cuda.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn as nn
+from torch.autograd import Variable
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.linear = nn.Linear(20, 2)
+
+    def forward(self, input):
+        out = self.linear(input[:, 10:30])
+        return out.sum()
+
+
+def main():
+    data = Variable(torch.randn(10, 50).cuda())
+    model = Model().cuda()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.0001)
+    for i in range(5):
+        optimizer.zero_grad()
+        loss = model(data)
+        loss.backward()
+        optimizer.step()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/bottleneck/test_cuda.py
+++ b/test/bottleneck/test_cuda.py
@@ -6,7 +6,7 @@ from torch.autograd import Variable
 class Model(nn.Module):
     def __init__(self):
         super(Model, self).__init__()
-        self.linear = nn.Linear(20, 2)
+        self.linear = nn.Linear(20, 20)
 
     def forward(self, input):
         out = self.linear(input[:, 10:30])
@@ -17,7 +17,7 @@ def main():
     data = Variable(torch.randn(10, 50).cuda())
     model = Model().cuda()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.0001)
-    for i in range(5):
+    for i in range(10):
         optimizer.zero_grad()
         loss = model(data)
         loss.backward()

--- a/test/bottleneck/test_cuda.py
+++ b/test/bottleneck/test_cuda.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 
 
 class Model(nn.Module):
@@ -14,7 +13,7 @@ class Model(nn.Module):
 
 
 def main():
-    data = Variable(torch.randn(10, 50).cuda())
+    data = torch.randn(10, 50).cuda()
     model = Model().cuda()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.0001)
     for i in range(10):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -425,7 +425,7 @@ class TestBottleneck(TestCase):
 
         # This assumes that after the cProfile output section we have
         # the autograd profiler output
-        results = re.search(r'cProfile output.*(\n.*){6,50}\nautograd profiler output', output)
+        results = re.search(r'cProfile output.*(\n.*){6,50}\n.*autograd profiler output', output)
         self.assertIsNotNone(results, self._fail_msg(
             'Distance between cProfile and autograd prof out not in [6, 50] lines', output))
 
@@ -435,17 +435,17 @@ class TestBottleneck(TestCase):
 
         # This assumes that after the autograd profiler output is the end of the
         # output.
-        results = re.search(r'autograd profiler output.*(\n.*){6,50}', output)
+        results = re.search(r'autograd profiler output.*(\n.*){6,100}', output)
         self.assertIsNotNone(results, self._fail_msg(
-            'Distance between autograd prof output and end of output not in [6, 50] lines', output))
+            'Distance between autograd prof output and end of output not in [6, 100] lines', output))
 
-    def _check_cuda_env_vars(self, output):
+    def _check_cuda(self, output):
         if torch.cuda.is_available():
-            results = re.search('CUDA_LAUNCH_BLOCKING=1', output)
-            self.assertIsNotNone(results, self._fail_msg('Should tell users about CUDA_LAUNCH_BLOCKING', output))
+            results = re.search('CUDA', output)
+            self.assertIsNotNone(results, self._fail_msg('Should tell users CUDA', output))
         else:
-            results = re.search('CUDA_LAUNCH_BLOCKING=1', output)
-            self.assertIsNone(results, self._fail_msg('Should not tell users about CUDA_LAUNCH_BLOCKING', output))
+            results = re.search('CUDA', output)
+            self.assertIsNone(results, self._fail_msg('Should not tell users about CUDA', output))
 
     @unittest.skipIf(torch.cuda.is_available(), 'CPU-only test')
     def test_cpu_only(self):
@@ -455,7 +455,7 @@ class TestBottleneck(TestCase):
         self._check_environment_summary(out)
         self._check_autograd_summary(out)
         self._check_cprof_summary(out)
-        self._check_cuda_env_vars(out)
+        self._check_cuda(out)
 
     @unittest.skipIf(not torch.cuda.is_available(), 'No CUDA')
     def test_cuda(self):
@@ -465,7 +465,7 @@ class TestBottleneck(TestCase):
         self._check_environment_summary(out)
         self._check_autograd_summary(out)
         self._check_cprof_summary(out)
-        self._check_cuda_env_vars(out)
+        self._check_cuda(out)
 
 
 class TestONNXUtils(TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -441,10 +441,10 @@ class TestBottleneck(TestCase):
 
     def _check_cuda(self, output):
         if torch.cuda.is_available():
-            results = re.search('CUDA', output)
+            results = re.search('CUDA mode', output)
             self.assertIsNotNone(results, self._fail_msg('Should tell users CUDA', output))
         else:
-            results = re.search('CUDA', output)
+            results = re.search('CUDA mode', output)
             self.assertIsNone(results, self._fail_msg('Should not tell users about CUDA', output))
 
     @unittest.skipIf(torch.cuda.is_available(), 'CPU-only test')

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -248,7 +248,8 @@ def main():
 
     env_summary = run_env_analysis()
 
-    torch.cuda.init()
+    if torch.cuda.is_available():
+        torch.cuda.init()
     cprofile_prof = run_cprofile(code, globs)
     autograd_prof_cpu, autograd_prof_cuda = run_autograd_prof(code, globs)
 

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -1,0 +1,231 @@
+import argparse
+import cProfile
+import pstats
+import subprocess
+import sys
+import os
+import re
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import torch
+from torch.autograd import profiler
+
+PY3 = sys.version_info >= (3, 0)
+
+
+def run(command):
+    """Returns (return-code, stdout, stderr)"""
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, shell=True)
+    output, err = p.communicate()
+    rc = p.returncode
+    if PY3:
+        output = output.decode("ascii")
+        err = err.decode("ascii")
+    return (rc, output, err)
+
+
+def check_running_cuda_version():
+    (rc, out, err) = run('nvcc --version')
+    if rc is not 0:
+        return None
+    m = re.search(r'V(.*)$', out)
+    assert m is not None
+    return m.group(1)
+
+
+def check_pip_packages():
+    # People generally have `pip` as `pip` or `pip3`
+    def run_with_pip(pip):
+        (rc, out, err) = run(pip + ' list --format=legacy | grep torch')
+        if rc is 0:
+            return '`{}` list truncated output:\n{}'.format(pip, out)
+        return None
+
+    result = []
+    out = run_with_pip('pip')
+    if out is not None:
+        result.append(out)
+    out_pip3 = run_with_pip('pip3')
+    if out_pip3 is not None:
+        result.append(out_pip3)
+
+    return '\n'.join(result)
+
+
+def compiled_with_cuda():
+    if torch.version.cuda:
+        return 'compiled w/ CUDA {}'.format(torch.version.cuda)
+    return 'not compiled w/ CUDA'
+
+
+def run_env_analysis():
+    print('Running environment analysis...')
+    result = []
+
+    debug_str = ''
+    if torch.version.debug:
+        debug_str = ' DEBUG'
+    result.append('PyTorch {}{} {}'.format(
+        torch.__version__, debug_str,
+        compiled_with_cuda()))
+
+    avail = 'Running with python {}.{}, '.format(sys.version_info[0], sys.version_info[1])
+    if torch.cuda.is_available():
+        cuda = check_running_cuda_version()
+        if cuda is None:
+            cuda = ''
+        avail += 'CUDA {}'.format(cuda)
+    else:
+        avail += 'CUDA unavailable'
+    result.append(avail)
+
+    result.append('')
+
+    pip = check_pip_packages()
+    if pip is not None:
+        result.append(check_pip_packages())
+
+    return '\n'.join(result)
+
+
+def set_env_variables(gpu_device):
+    # Override CUDA_LAUNCH_BLOCKING by default for more accurate profiling.
+    os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
+
+    # Only profile on one GPU for simplicity
+    os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(gpu_device)
+
+
+def get_env_variables_description(gpu_device, prefix=' '):
+    if torch.cuda.is_available():
+        return '{}with environment variables CUDA_LAUNCH_BLOCKING=1 CUDA_VISIBLE_DEVICES={}'.format(
+            prefix, gpu_device)
+    else:
+        return ''
+
+
+def run_cprofile(code, globs, gpu_device=0):
+    set_env_variables(gpu_device)
+    env_str = get_env_variables_description(gpu_device)
+    print('Running your script with cProfile{}...'.format(env_str))
+    prof = cProfile.Profile()
+    prof.enable()
+    exec(code, globs, None)
+    prof.disable()
+    return prof
+
+
+def print_line(width=80):
+    print('-' * width)
+
+
+def print_cprofile_summary(prof, gpu_device=0, sortby='tottime', topk=15):
+    print_line()
+    env_str = get_env_variables_description(gpu_device, '\n')
+    print('cProfile output{}'.format(env_str))
+    print_line()
+    cprofile_stats = pstats.Stats(prof).sort_stats(sortby)
+    cprofile_stats.print_stats(topk)
+
+
+def run_autograd_prof(code, globs, gpu_device=0):
+    set_env_variables(gpu_device)
+    env_str = get_env_variables_description(gpu_device)
+    print('Running your script with the autograd profiler{}...'.format(env_str))
+    with profiler.profile() as prof:
+        exec(code, globs, None)
+    return prof
+
+
+def print_autograd_prof_summary(prof, gpu_device=0, sortby='cpu_time', topk=15):
+    valid_sortby = ['cpu_time', 'cuda_time', 'cpu_time_total', 'cuda_time_total', 'count']
+    if sortby not in valid_sortby:
+        warn = ('WARNING: invalid sorting option for autograd profiler results: {}\n'
+                'Expected `cpu_time`, `cpu_time_total`, or `count`. '
+                'Defaulting to `cpu_time`.')
+        print(warn.format(autograd_prof_sortby))
+        sortby = 'cpu_time'
+
+    print_line()
+    env_str = get_env_variables_description(gpu_device, '\n')
+    print('autograd profiler output{}'.format(env_str))
+    print_line()
+    print('\ttop {} events sorted by {}'.format(topk, sortby))
+    ex = ('    Note that because CUDA_LAUNCH_BLOCKING=1 is set, the reported CPU time\n'
+          '    includes the CUDA time. Ignore the empty CUDA time column here.\n')
+    if torch.cuda.is_available():
+        print('')
+        print(ex)
+
+    sorted_events = sorted(prof.function_events,
+                           key=lambda x: getattr(x, sortby), reverse=True)
+    topk_events = sorted_events[:topk]
+    print(torch.autograd.profiler.build_table(topk_events))
+
+
+descript = ('`bottleneck` is a tool that can be used as an initial step for debugging '
+            'bottlenecks in your program.\n\n'
+            'It summarizes runs of your script with the Python profiler '
+            'and PyTorch\'s autograd profiler. For ease of use and intepretability of '
+            'results, `bottleneck` runs multi-GPU code on only one GPU device. '
+            'Because your script will be profiled, please ensure that it exits '
+            'in a finite amount of time. \n\n'
+            'For more complicated uses of the profilers (like in a multi-GPU case), '
+            'please see https://docs.python.org/3/library/profile.html '
+            'and http://pytorch.org/docs/master/autograd.html#profiler '
+            'for more information. \n')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=descript)
+    parser.add_argument('scriptfile', type=str,
+                        help='Path to the script to be run. '
+                        'Usually run with `python path/to/script`.')
+    parser.add_argument('--gpu', dest='gpu_device', type=int, default=0,
+                        help='If applicable, which GPU device to run '
+                        'on. Default: 0.')
+    return parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Customizable constants.
+    scriptfile = args.scriptfile
+    cprofile_sortby = 'tottime'
+    cprofile_topk = 15
+    autograd_prof_sortby = 'cpu_time'
+    autograd_prof_topk = 15
+    gpu_device = args.gpu_device
+
+    sys.path.insert(0, os.path.dirname(scriptfile))
+    with open(scriptfile, 'rb') as stream:
+        code = compile(stream.read(), scriptfile, 'exec')
+    globs = {
+        '__file__': scriptfile,
+        '__name__': '__main__',
+        '__package__': None,
+        '__cached__': None,
+    }
+
+    print(descript)
+    env_summary = run_env_analysis()
+    autograd_prof = run_autograd_prof(code, globs, gpu_device)
+    cprofile_prof = run_cprofile(code, globs, gpu_device)
+
+    print_line()
+    print('Environment Summary')
+    print_line()
+    print(env_summary)
+
+    print_cprofile_summary(cprofile_prof, gpu_device, cprofile_sortby, cprofile_topk)
+    print_autograd_prof_summary(autograd_prof, gpu_device, autograd_prof_sortby, autograd_prof_topk)
+
+if __name__ == '__main__':
+    main()

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import os
 import re
-
 try:
     from StringIO import StringIO
 except ImportError:
@@ -41,26 +40,48 @@ def check_running_cuda_version():
 def check_pip_packages():
     # People generally have `pip` as `pip` or `pip3`
     def run_with_pip(pip):
-        (rc, out, err) = run(pip + ' list --format=legacy | grep torch')
+        rc, out, _ = run(pip + ' list --format=legacy | grep torch')
         if rc is 0:
-            return '`{}` list truncated output:\n{}'.format(pip, out)
+            return out
         return None
 
-    result = []
-    out = run_with_pip('pip')
-    if out is not None:
-        result.append(out)
-    out_pip3 = run_with_pip('pip3')
-    if out_pip3 is not None:
-        result.append(out_pip3)
+    if not PY3:
+        return 'pip', run_with_pip('pip')
 
-    return '\n'.join(result)
+    # Try to figure out if the user is running pip or pip3.
+    out2 = run_with_pip('pip')
+    out3 = run_with_pip('pip3')
+
+    num_pips = len([x for x in [out2, out3] if x is not None])
+    if num_pips is 0:
+        return 'pip', out2
+
+    if num_pips == 1:
+        if out2 is not None:
+            return 'pip', out2
+        return 'pip3', out3
+
+    # num_pips is 2. Return pip3 by default b/c that most likely
+    # is the one associated with Python 3
+    return 'pip3', out3
 
 
 def compiled_with_cuda():
     if torch.version.cuda:
         return 'compiled w/ CUDA {}'.format(torch.version.cuda)
     return 'not compiled w/ CUDA'
+
+
+env_summary = """
+--------------------------------------------------------------------------------
+  Environment Summary
+--------------------------------------------------------------------------------
+PyTorch {pytorch_version}{debug_str} {cuda_compiled}
+Running with Python {py_version} and {cuda_runtime}
+
+`{pip_version} list` truncated output:
+{pip_list_output}
+""".strip()
 
 
 def run_env_analysis():
@@ -70,49 +91,34 @@ def run_env_analysis():
     debug_str = ''
     if torch.version.debug:
         debug_str = ' DEBUG'
-    result.append('PyTorch {}{} {}'.format(
-        torch.__version__, debug_str,
-        compiled_with_cuda()))
 
-    avail = 'Running with python {}.{}, '.format(sys.version_info[0], sys.version_info[1])
+    cuda_avail = ''
     if torch.cuda.is_available():
         cuda = check_running_cuda_version()
-        if cuda is None:
-            cuda = ''
-        avail += 'CUDA {}'.format(cuda)
+        if cuda is not None:
+            cuda_avail = 'CUDA ' + cuda
     else:
-        avail += 'CUDA unavailable'
-    result.append(avail)
+        cuda = 'CUDA unavailable'
 
-    result.append('')
+    pip_version, pip_list_output = check_pip_packages()
+    if pip_list_output is None:
+        pip_list_output = 'Unable to fetch'
 
-    pip = check_pip_packages()
-    if pip is not None:
-        result.append(check_pip_packages())
+    result = {
+        'debug_str': debug_str,
+        'pytorch_version': torch.__version__,
+        'cuda_compiled': compiled_with_cuda(),
+        'py_version': '{}.{}'.format(sys.version_info[0], sys.version_info[1]),
+        'cuda_runtime': cuda_avail,
+        'pip_version': pip_version,
+        'pip_list_output': pip_list_output,
+    }
 
-    return '\n'.join(result)
-
-
-def set_env_variables(gpu_device):
-    # Override CUDA_LAUNCH_BLOCKING by default for more accurate profiling.
-    os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
-
-    # Only profile on one GPU for simplicity
-    os.environ['CUDA_VISIBLE_DEVICES'] = '{}'.format(gpu_device)
-
-
-def get_env_variables_description(gpu_device, prefix=' '):
-    if torch.cuda.is_available():
-        return '{}with environment variables CUDA_LAUNCH_BLOCKING=1 CUDA_VISIBLE_DEVICES={}'.format(
-            prefix, gpu_device)
-    else:
-        return ''
+    return env_summary.format(**result)
 
 
-def run_cprofile(code, globs, gpu_device=0):
-    set_env_variables(gpu_device)
-    env_str = get_env_variables_description(gpu_device)
-    print('Running your script with cProfile{}...'.format(env_str))
+def run_cprofile(code, globs, launch_blocking=False):
+    print('Running your script with cProfile')
     prof = cProfile.Profile()
     prof.enable()
     exec(code, globs, None)
@@ -120,29 +126,49 @@ def run_cprofile(code, globs, gpu_device=0):
     return prof
 
 
-def print_line(width=80):
-    print('-' * width)
+cprof_summary = """
+--------------------------------------------------------------------------------
+  cProfile output
+--------------------------------------------------------------------------------
+""".strip()
 
 
-def print_cprofile_summary(prof, gpu_device=0, sortby='tottime', topk=15):
-    print_line()
-    env_str = get_env_variables_description(gpu_device, '\n')
-    print('cProfile output{}'.format(env_str))
-    print_line()
+def print_cprofile_summary(prof, sortby='tottime', topk=15):
+    result = {}
+
+    print(cprof_summary.format(**result))
+
     cprofile_stats = pstats.Stats(prof).sort_stats(sortby)
     cprofile_stats.print_stats(topk)
 
 
-def run_autograd_prof(code, globs, gpu_device=0):
-    set_env_variables(gpu_device)
-    env_str = get_env_variables_description(gpu_device)
-    print('Running your script with the autograd profiler{}...'.format(env_str))
-    with profiler.profile() as prof:
-        exec(code, globs, None)
-    return prof
+def run_autograd_prof(code, globs):
+    def run_prof(use_cuda=False):
+        with profiler.profile(use_cuda=use_cuda) as prof:
+            exec(code, globs, None)
+        return prof
+
+    print('Running your script with the autograd profiler...')
+    result = [run_prof(use_cuda=False)]
+    if torch.cuda.is_available():
+        result.append(run_prof(use_cuda=True))
+    else:
+        result.append(None)
+
+    return result
 
 
-def print_autograd_prof_summary(prof, gpu_device=0, sortby='cpu_time', topk=15):
+autograd_prof_summary = """
+--------------------------------------------------------------------------------
+  autograd profiler output ({mode} mode)
+--------------------------------------------------------------------------------
+        {description}
+{cuda_warning}
+{output}
+""".strip()
+
+
+def print_autograd_prof_summary(prof, mode, sortby='cpu_time', topk=15):
     valid_sortby = ['cpu_time', 'cuda_time', 'cpu_time_total', 'cuda_time_total', 'count']
     if sortby not in valid_sortby:
         warn = ('WARNING: invalid sorting option for autograd profiler results: {}\n'
@@ -151,34 +177,39 @@ def print_autograd_prof_summary(prof, gpu_device=0, sortby='cpu_time', topk=15):
         print(warn.format(autograd_prof_sortby))
         sortby = 'cpu_time'
 
-    print_line()
-    env_str = get_env_variables_description(gpu_device, '\n')
-    print('autograd profiler output{}'.format(env_str))
-    print_line()
-    print('\ttop {} events sorted by {}'.format(topk, sortby))
-    ex = ('    Note that because CUDA_LAUNCH_BLOCKING=1 is set, the reported CPU time\n'
-          '    includes the CUDA time. Ignore the empty CUDA time column here.\n')
-    if torch.cuda.is_available():
-        print('')
-        print(ex)
+    if mode is 'CUDA':
+        cuda_warning = ('\n\tBecause the autograd profiler uses the CUDA event API,\n'
+                        '\tthe CUDA time column reports approximately max(cuda_time, cpu_time).\n'
+                        '\tPlease ignore this output if your code does not use CUDA.\n')
+    else:
+        cuda_warning = ''
 
     sorted_events = sorted(prof.function_events,
                            key=lambda x: getattr(x, sortby), reverse=True)
     topk_events = sorted_events[:topk]
-    print(torch.autograd.profiler.build_table(topk_events))
+
+    result = {
+        'mode': mode,
+        'description': 'top {} events sorted by {}'.format(topk, sortby),
+        'output': torch.autograd.profiler.build_table(topk_events),
+        'cuda_warning': cuda_warning
+    }
+
+    print(autograd_prof_summary.format(**result))
 
 
-descript = ('`bottleneck` is a tool that can be used as an initial step for debugging '
-            'bottlenecks in your program.\n\n'
-            'It summarizes runs of your script with the Python profiler '
-            'and PyTorch\'s autograd profiler. For ease of use and intepretability of '
-            'results, `bottleneck` runs multi-GPU code on only one GPU device. '
-            'Because your script will be profiled, please ensure that it exits '
-            'in a finite amount of time. \n\n'
-            'For more complicated uses of the profilers (like in a multi-GPU case), '
-            'please see https://docs.python.org/3/library/profile.html '
-            'and http://pytorch.org/docs/master/autograd.html#profiler '
-            'for more information. \n')
+descript = """
+`bottleneck` is a tool that can be used as an initial step for debugging
+bottlenecks in your program.
+
+It summarizes runs of your script with the Python profiler and PyTorch\'s
+autograd profiler. Because your script will be profiled, please ensure that it
+exits in a finite amount of time.
+
+For more complicated uses of the profilers, please see
+https://docs.python.org/3/library/profile.html and
+http://pytorch.org/docs/master/autograd.html#profiler for more information.
+""".strip()
 
 
 def parse_args():
@@ -186,11 +217,11 @@ def parse_args():
     parser.add_argument('scriptfile', type=str,
                         help='Path to the script to be run. '
                         'Usually run with `python path/to/script`.')
-    parser.add_argument('--gpu', dest='gpu_device', type=int, default=0,
-                        help='If applicable, which GPU device to run '
-                        'on. Default: 0.')
     return parser.parse_args()
-    return parser.parse_args()
+
+
+def cpu_time_total(autograd_prof):
+    return sum([event.cpu_time_total for event in autograd_prof.function_events])
 
 
 def main():
@@ -200,9 +231,8 @@ def main():
     scriptfile = args.scriptfile
     cprofile_sortby = 'tottime'
     cprofile_topk = 15
-    autograd_prof_sortby = 'cpu_time'
+    autograd_prof_sortby = 'cpu_time_total'
     autograd_prof_topk = 15
-    gpu_device = args.gpu_device
 
     sys.path.insert(0, os.path.dirname(scriptfile))
     with open(scriptfile, 'rb') as stream:
@@ -215,17 +245,28 @@ def main():
     }
 
     print(descript)
+
     env_summary = run_env_analysis()
-    autograd_prof = run_autograd_prof(code, globs, gpu_device)
-    cprofile_prof = run_cprofile(code, globs, gpu_device)
 
-    print_line()
-    print('Environment Summary')
-    print_line()
+    torch.cuda.init()
+    cprofile_prof = run_cprofile(code, globs)
+    autograd_prof_cpu, autograd_prof_cuda = run_autograd_prof(code, globs)
+
     print(env_summary)
+    print_cprofile_summary(cprofile_prof, cprofile_sortby, cprofile_topk)
 
-    print_cprofile_summary(cprofile_prof, gpu_device, cprofile_sortby, cprofile_topk)
-    print_autograd_prof_summary(autograd_prof, gpu_device, autograd_prof_sortby, autograd_prof_topk)
+    if not torch.cuda.is_available():
+        print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
+        return
+
+    # Print both the result of the CPU-mode and CUDA-mode autograd profilers
+    # if their execution times are very different.
+    cuda_prof_exec_time = cpu_time_total(autograd_prof_cuda)
+    cpu_prof_exec_time = cpu_time_total(autograd_prof_cpu)
+    pct_diff = cuda_prof_exec_time - cpu_prof_exec_time / cuda_prof_exec_time
+    if abs(pct_diff) > 0.05:
+        print_autograd_prof_summary(autograd_prof_cpu, 'CPU', autograd_prof_sortby, autograd_prof_topk)
+    print_autograd_prof_summary(autograd_prof_cuda, 'CUDA', autograd_prof_sortby, autograd_prof_topk)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is a tool that is intended to be used as initial exploratory debugging of bottlenecks in user scripts. Run it with

    python -m torch.utils.bottleneck /path/to/source/script.py

Internally it runs the script once with the python profiler and once with the autograd profiler and prints the top 15 hits sorted by cpu time (for both profilers).

[Sample Output](https://gist.github.com/zou3519/cebc5a4d2962b68d995b944641045ead)

cc @soumith 

### Test Plan
Really basic tests to check that the output of `torch.util.bottleneck` isn't completely empty. Taking suggestions on how to write better tests.

Built the new docs page:
![image](https://user-images.githubusercontent.com/5652049/36560568-13019ebc-17df-11e8-9bbc-31d8029316c9.png)



