### PR TITLE
[EASY] CUDA support for JIT-compiling C++ extensions

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -50,6 +50,26 @@ class TestCppExtension(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_jit_cuda_extension(self):
+        # NOTE: The name of the extension must equal the name of the module.
+        module = torch.utils.cpp_extension.load(
+            name='torch_test_cuda_extension',
+            sources=[
+                'cpp_extensions/cuda_extension.cpp',
+                'cpp_extensions/cuda_extension_kernel.cu'
+            ],
+            extra_cuda_cflags=['-O2'],
+            verbose=True)
+
+        x = torch.FloatTensor(100).zero_().cuda()
+        y = torch.FloatTensor(100).zero_().cuda()
+
+        z = module.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
+
 
 if __name__ == '__main__':
     common.run_tests()


### PR DESCRIPTION
This PR adds CUDA support to the JIT compilation mechanism of our C++ extensions.

This involved:
- Using different Ninja build rules for different files based on their extension,
- Conditionally passing certain library directories and libraries to the linker,
- Adding an `extra_cuda_cflags` argument to `torch.utils.cpp_extension.load()`

The mixed compilation is fairly transparent to the user, i.e. the `torch.utils.cpp_extension.load()` call is essentially the same as for pure C++.

@zdevito @apaszke @ezyang 