### PR TITLE
Check GCC version on Ubuntu

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -28,7 +28,7 @@ if(EXISTS "/etc/os-release")
         if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0"
           AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0.0")
             message(FATAL_ERROR
-              "Do not use GCC 5. GCC 5 has a known bug in Ubuntu 17.04"
+              "Do not use GCC 5. GCC 5 has a known bug in Ubuntu 17.10"
               " and higher, which won't be fixed. For more information, see: "
               "https://github.com/pytorch/pytorch/issues/5229"
               )

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -10,6 +10,34 @@ project(ATen)
 
 cmake_policy(SET CMP0012 NEW)
 
+# ---[ If running on Ubuntu, check system version and compiler version.
+if(EXISTS "/etc/os-release")
+  execute_process(COMMAND
+    "sed" "-ne" "s/^ID=\\([a-z]\\+\\)$/\\1/p" "/etc/os-release"
+    OUTPUT_VARIABLE OS_RELEASE_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  execute_process(COMMAND
+    "sed" "-ne" "s/^VERSION_ID=\"\\([0-9\\.]\\+\\)\"$/\\1/p" "/etc/os-release"
+    OUTPUT_VARIABLE OS_RELEASE_VERSION_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(OS_RELEASE_ID STREQUAL "ubuntu")
+    if(OS_RELEASE_VERSION_ID VERSION_GREATER "17.04")
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0"
+          AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0.0")
+            message(FATAL_ERROR
+              "Do not use GCC 5. GCC 5 has a known bug in Ubuntu 17.04"
+              " and higher, which won't be fixed. For more information, see: "
+              "https://github.com/pytorch/pytorch/issues/5229"
+              )
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
 # RPATH stuff
 # see https://cmake.org/Wiki/CMake_RPATH_handling
 if(APPLE)


### PR DESCRIPTION
GCC 5 in Ubuntu 17.10 and newer doesn't define the macro _GLIBCXX_USE_C99
and causes std::to_string, std::isnan, std::isinf (and more) functions
not to be defined neither. This fix checks if GCC 5 is used on Ubuntu 17.10
or later and shows an error message describing the problem.

Fixes #5229 