### PR TITLE
Include __delitem__ for Sequential

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -816,6 +816,18 @@ class TestNN(NNTestCase):
         self.assertEqual(n.linear1, l4)
         self.assertEqual(n.linear3, l4)
 
+    def test_Sequential_delitem(self):
+        l1 = nn.Linear(10, 20)
+        l2 = nn.Linear(20, 30)
+        l3 = nn.Linear(30, 40)
+        l4 = nn.Linear(40, 50)
+        l5 = nn.Linear(50, 60)
+        n = nn.Sequential(l1, l2, l3, l4)
+        del n[-1]
+        self.assertEqual(n, nn.Sequential(l1, l2, l3))
+        del n[1::2]
+        self.assertEqual(n, nn.Sequential(l1, l3))
+
     def test_ModuleList(self):
         modules = [nn.ReLU(), nn.Linear(5, 5)]
         module_list = nn.ModuleList(modules)
@@ -848,6 +860,10 @@ class TestNN(NNTestCase):
         self.assertEqual(module_list[:-1], nn.ModuleList(modules[:-1]))
         self.assertEqual(module_list[:-3], nn.ModuleList(modules[:-3]))
         self.assertEqual(module_list[::-1], nn.ModuleList(modules[::-1]))
+        del module_list[-1]
+        self.assertEqual(module_list, nn.ModuleList(modules[:-1]))
+        del module_list[1::2]
+        self.assertEqual(module_list, nn.ModuleList(modules[:-1][0::2]))
 
         with self.assertRaises(TypeError):
             module_list += nn.ReLU()

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -70,8 +70,7 @@ class Sequential(Module):
 
     def __delitem__(self, idx):
         if isinstance(idx, slice):
-            del_keys = list(self._modules.keys())[idx]
-            for key in del_keys:
+            for key in list(self._modules.keys())[idx]:
                 delattr(self, key)
         else:
             key = self._get_item_by_idx(self._modules.keys(), idx)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -68,6 +68,15 @@ class Sequential(Module):
         key = self._get_item_by_idx(self._modules.keys(), idx)
         return setattr(self, key, module)
 
+    def __delitem__(self, idx):
+        if isinstance(idx, slice):
+            del_keys = list(self._modules.keys())[idx]
+            for key in del_keys:
+                delattr(self, key)
+        else:
+            key = self._get_item_by_idx(self._modules.keys(), idx)
+            delattr(self, key)
+
     def __len__(self):
         return len(self._modules)
 
@@ -110,18 +119,32 @@ class ModuleList(Module):
         if modules is not None:
             self += modules
 
+    def _get_abs_string_index(self, idx):
+        """Get the absolute index for the list of modules"""
+        if not (-len(self) <= idx < len(self)):
+            raise IndexError('index {} is out of range'.format(idx))
+        if idx < 0:
+            idx += len(self)
+        return str(idx)
+
     def __getitem__(self, idx):
         if isinstance(idx, slice):
             return ModuleList(list(self._modules.values())[idx])
         else:
-            if not (-len(self) <= idx < len(self)):
-                raise IndexError('index {} is out of range'.format(idx))
-            if idx < 0:
-                idx += len(self)
-            return self._modules[str(idx)]
+            return self._modules[self._get_abs_string_index(idx)]
 
     def __setitem__(self, idx, module):
         return setattr(self, str(idx), module)
+
+    def __delitem__(self, idx):
+        if isinstance(idx, slice):
+            for k in range(len(self._modules))[idx]:
+                delattr(self, str(k))
+        else:
+            delattr(self, self._get_abs_string_index(idx))
+        # To preserve numbering, self._modules is being reconstructed with modules after deletion
+        str_indices = [str(i) for i in range(len(self._modules))]
+        self._modules = OrderedDict(list(zip(str_indices, self._modules.values())))
 
     def __len__(self):
         return len(self._modules)


### PR DESCRIPTION
This PR closes feature request https://github.com/pytorch/pytorch/issues/5206 .

Additions:
1. `__delitem__` for `Sequential` and `ModuleList`
2. Tests for `__delitem__`.

For `ModuleList` after deletion is performed, the `_modules` attribute is recreated to preserve continuous numbering. This is not taken care of in `Sequential`.