### PR TITLE
[wip] Implement sparse unsqueeze

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4129,6 +4129,30 @@
 ]]
 
 [[
+  name: sparse_raw_indices
+  cname: rawIndices
+  variants: [method]
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THDenseIndexTensor*
+  arguments:
+    - THTensor* self
+]]
+
+[[
+  name: sparse_raw_values
+  cname: rawValues
+  variants: [method]
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  return: THDenseTensor*
+  arguments:
+    - THTensor* self
+]]
+
+[[
   name: sparse_raw_resize_
   variants: [method]
   backends:

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -120,6 +120,16 @@ THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor 
   return THCSTensor_(_move)(state, self, THCIndexTensor_(newClone)(state, indices), THCTensor_(newClone)(state, values));
 }
 
+THCIndexTensor* THCSTensor_(rawIndices)(THCState *state, THCSTensor *self) {
+  THCudaLongTensor_retain(state, self->indices);
+  return self->indices;
+}
+
+THCTensor* THCSTensor_(rawValues)(THCState *state, THCSTensor *self) {
+  THCTensor_(retain)(state, self->values);
+  return self->values;
+}
+
 /*** end helper methods ***/
 
 /* Empty init */
@@ -466,5 +476,6 @@ void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCST
   THCIndexTensor_(free)(state, maskIndices);
   THCTensor_(free)(state, maskValues);
 }
+
 
 #endif

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -73,6 +73,8 @@ TH_API int THCSTensor_(checkGPU)(THCState *state, unsigned int nSparseTensors, u
 
 /* internal methods */
 TH_API THCSTensor* THCSTensor_(rawResize)(THCState *state, THCSTensor *self, int nDimI, int nDimV, int64_t *size);
+TH_API THCudaLongTensor* THCSTensor_(rawIndices)(THCState *state, THCSTensor *self);
+TH_API THCTensor* THCSTensor_(rawValues)(THCState *state, THCSTensor *self);
 TH_API THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, int64_t nnz);
 TH_API THCSTensor* THCSTensor_(_move)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);
 TH_API THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor *indices, THCTensor *values);

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -551,10 +551,12 @@ void THSTensor_(retain)(THSTensor *self)
 }
 
 THLongTensor* THSTensor_(rawIndices)(THSTensor *self) {
+  THLongTensor_retain(self->indices);
   return self->indices;
 }
 
 THTensor* THSTensor_(rawValues)(THSTensor *self) {
+  THTensor_(retain)(self->values);
   return self->values;
 }
 

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -550,4 +550,12 @@ void THSTensor_(retain)(THSTensor *self)
   THAtomicIncrementRef(&self->refcount);
 }
 
+THLongTensor* THSTensor_(rawIndices)(THSTensor *self) {
+  return self->indices;
+}
+
+THTensor* THSTensor_(rawValues)(THSTensor *self) {
+  return self->values;
+}
+
 #endif

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -77,6 +77,8 @@ TH_API void THSTensor_(select)(THSTensor *self, THSTensor *src, int dimension_, 
 
 // internal methods
 TH_API THSTensor* THSTensor_(rawResize)(THSTensor *self, int nDimI, int nDimV, int64_t *size);
+TH_API THLongTensor* THSTensor_(rawIndices)(THSTensor *self);
+TH_API THTensor* THSTensor_(rawValues)(THSTensor *self);
 THSTensor* THSTensor_(_move)(THSTensor *self, THLongTensor *indices, THTensor *values);
 THSTensor* THSTensor_(_set)(THSTensor *self, THLongTensor *indices, THTensor *values);
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -374,6 +374,22 @@ class TestSparse(TestCase):
         self.assertTrue(x_coalesced.is_coalesced())
         self.assertFalse(y_uncoalesced.is_coalesced())
 
+    def test_unsqueeze(self):
+        from torch.autograd import Variable
+        x_sparse, _, _ = self._gen_sparse(3, 10, [3, 3, 3, 3, 3])
+        x_sparse = Variable(x_sparse)
+        x_dense = x_sparse.to_dense()
+        for i in range(x_dense.dim() + 1):
+            self.assertEqual(x_sparse.unsqueeze(i).to_dense(), x_dense.unsqueeze(i),
+                             'Sparse unsqueeze({})'.format(i))
+
+            y_sparse = x_sparse.clone()
+            y_dense = x_dense.clone()
+            y_sparse.unsqueeze_(i)
+            y_dense.unsqueeze_(i)
+            self.assertEqual(y_sparse.to_dense(), y_dense,
+                             'Sparse unsqueeze_({})'.format(i))
+
     @cpu_only
     def test_mm(self):
         def test_shape(di, dj, dk):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -16,7 +16,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
-    'sparse_raw_resize_',
+    'sparse_raw_*',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
Featuring:
- New functions in ATen to expose the values/indices pointers from THSTensor
- Sparse unsqueeze/unsqueeze_
- A sparse check in squeeze/squeeze_ so if someone tries to backprop they will not be very confused at the error

### Test Plan
New unit tests.