### PR TITLE
CUDA multinomial fix

### DIFF
--- a/aten/src/THC/THCReduceApplyUtils.cuh
+++ b/aten/src/THC/THCReduceApplyUtils.cuh
@@ -22,6 +22,7 @@ __device__ __forceinline__ IndexType getLinearBlockId() {
 // Reduce N values concurrently, i.e. suppose N = 2, and there are 4 threads:
 // (1, 2), (3, 4), (5, 6), (7, 8), then the return in threadVals for thread 0
 // is (1 + 3 + 5 + 7, 2 + 4 + 6 + 8) = (16, 20)
+// no need to __syncthreads before this call
 template <typename T, typename ReduceOp, int N>
 __device__ void reduceNValuesInBlock(T *smem,
                              T threadVals[N],
@@ -95,6 +96,7 @@ __device__ void reduceNValuesInBlock(T *smem,
 
 // Block-wide reduction in shared memory helper; only threadIdx.x == 0 will
 // return the reduced value
+// no need to __syncthreads before this call
 template <typename T, typename ReduceOp>
 __device__ T reduceBlock(T* smem,
                          int numVals,
@@ -109,6 +111,7 @@ __device__ T reduceBlock(T* smem,
 // Block-wide reduction where each thread locally reduces N
 // values before letting a single warp take over - assumes
 // threadVals is in registers, not shared memory
+// no need to __syncthreads before this call
 template <typename T, typename ReduceOp, int N>
 __device__ T reduceBlockWithNThreadLocalReductions(T *smem,
                          T threadVals[N],

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -178,7 +178,7 @@ sampleMultinomialOnce(int64_t* dest,
     AccT sum = accZero;
     T val;
     for (int cat = threadIdx.x; cat < categories; cat += blockDim.x) {
-      val = dist[curDist * categories * stride_dist + cat * stride_categories];
+      val = dist[curDist * stride_dist + cat * stride_categories];
       assert(THCNumerics<T>::ge(val, zero));
       sum = THCNumerics<AccT>::add(sum, ScalarConvert<T, AccT>::to(val));
     }
@@ -221,7 +221,7 @@ sampleMultinomialOnce(int64_t* dest,
       AccT val =
         cat < categories ?
           THCNumerics<AccT>::div(
-              ScalarConvert<T, AccT>::to(dist[curDist * categories * stride_dist + cat * stride_categories]),
+              ScalarConvert<T, AccT>::to(dist[curDist * stride_dist + cat * stride_categories]),
               sum) :
           accZero;
 
@@ -275,7 +275,7 @@ sampleMultinomialOnce(int64_t* dest,
       // where the distribution is non-zero. This is obviously terribly inefficient, but due to the
       // rarity in which this occurs, this should not be an issue.
       for (int cat = categories - 1; cat >= 0; --cat) {
-        if (THCNumerics<T>::gt(dist[curDist * categories * stride_dist + cat * stride_categories], zero)) {
+        if (THCNumerics<T>::gt(dist[curDist * stride_dist + cat * stride_categories], zero)) {
           dest[curDist] = cat + TH_INDEX_BASE;
           break;
         }


### PR DESCRIPTION
Previously failing on 
```
x = torch.cuda.FloatTensor([[0.5, 0.5], [0, 1]])
x.multinomial(1)
```
by triggering device side assert or returning wrong results (always 1 for 2nd sample).

Cause: I incorrectly used both stride and num_categories in a previous PR. This fixes it.

1. Fix THC multinomial stride usage
2. Improve multinomial test
