### PR TITLE
Remove unnecessary __syncthreads before reduceBlock

### DIFF
--- a/aten/src/THCUNN/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/MultiLabelMarginCriterion.cu
@@ -131,7 +131,6 @@ __global__ void cunn_MultiLabelMarginCriterion_updateGradInput_kernel(Dtype *gra
         }
       }
     }
-    __syncthreads();
 
     // reduce sum
     Acctype totalSum = reduceBlock(sums, blockDim.x, sum, thrust::plus<Acctype>(), (Acctype)0);

--- a/aten/src/THCUNN/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/SpatialClassNLLCriterion.cu
@@ -103,8 +103,6 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
     }
   }
 
-  __syncthreads();
-
   input_sum = reduceBlock(partial_sums, blockDim.x, input_sum, thrust::plus<AccumT>(), AccumT(0));
   acc_weight = reduceBlock(partial_sums, blockDim.x, acc_weight, thrust::plus<AccumT>(), AccumT(0));
 


### PR DESCRIPTION
`reduceBlock` calls `reduceNValuesInBlock` which has an [internal __syncthreads](https://github.com/pytorch/pytorch/blob/fe810edc805f5a377bdf71e71ac5eab2bb3d3566/aten/src/THC/THCReduceApplyUtils.cuh#L48) before reduction.

cc @SsnL 