### PR TITLE
Add CPU and GPU perf tests in enabled-configs.txt

### DIFF
--- a/.jenkins/enabled-configs.txt
+++ b/.jenkins/enabled-configs.txt
@@ -28,3 +28,5 @@ pytorch-linux-trusty-pynightly-test
 pytorch-win-ws2016-cuda9-cudnn7-py3-build
 pytorch-win-ws2016-cuda9-cudnn7-py3-test
 pytorch-macos-10.13-py3-build-test
+short-perf-test-cpu
+short-perf-test-gpu


### PR DESCRIPTION
After this is merged, CPU perf test will be enabled by a commit to ossci-job-dsl, and GPU perf test will be enabled after we collect the new baseline numbers on it.