### PR TITLE
check attribute existence in torch.legay.nn.SpatialFullConvolution

### DIFF
--- a/torch/legacy/nn/SpatialFullConvolution.py
+++ b/torch/legacy/nn/SpatialFullConvolution.py
@@ -88,14 +88,14 @@ class SpatialFullConvolution(Module):
             tW = targetTensor.size(tDims - 1)
             adjW = self._calculateAdj(tW, self.kW, self.padW, self.dW)
             adjH = self._calculateAdj(tH, self.kH, self.padH, self.dH)
-            if self.finput is None:
+            if not hasattr(self, 'finput') or self.finput is None:
                 self.finput = input[0].new()
-            if self.fgradInput is None:
+            if not hasattr(self, 'fgradInput') or self.fgradInput is None:
                 self.fgradInput = input[0].new()
         else:
-            if self.finput is None:
+            if not hasattr(self, 'finput') or self.finput is None:
                 self.finput = input.new()
-            if self.fgradInput is None:
+            if not hasattr(self, 'fgradInput') or self.fgradInput is None:
                 self.fgradInput = input.new()
 
         inputTensor = self._makeContiguous(inputTensor)


### PR DESCRIPTION
This PR will fix #968, "SpatialFullConvolution loaded from Lua doesn't have finput attribute".
Code change is same as #738

here is my short code for test.
https://gist.github.com/katotetsuro/694da6777979ca0ab9c9b6acd7c12f50

I converted torch7's model from here.
https://github.com/art-programmer/FloorplanTransformation