### PR TITLE
Fix THCTensor_(max) and THCTensor_(min) initializations

### DIFF
--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -420,7 +420,7 @@ THCTensor_(max)(THCState *state,
   thrust::pair<typename TensorUtils<THCTensor>::DataType, int64_t>
     init =
     thrust::make_pair<typename TensorUtils<THCTensor>::DataType, int64_t>(
-      THCNumerics<typename TensorUtils<THCTensor>::DataType>::min(), 1);
+      THCNumerics<typename TensorUtils<THCTensor>::DataType>::min(), 0);
 
   return THC_reduceDimIndex(
     state, values, indices, src, dimension, keepdim, init,
@@ -439,7 +439,7 @@ THCTensor_(min)(THCState *state,
   thrust::pair<typename TensorUtils<THCTensor>::DataType, int64_t>
     init =
     thrust::make_pair<typename TensorUtils<THCTensor>::DataType, int64_t>(
-      THCNumerics<typename TensorUtils<THCTensor>::DataType>::max(), 1);
+      THCNumerics<typename TensorUtils<THCTensor>::DataType>::max(), 0);
 
   return THC_reduceDimIndex(
     state, values, indices, src, dimension, keepdim, init,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1232,6 +1232,19 @@ class TestCuda(TestCase):
     def test_tensor_scatterFill(self):
         TestTorch._test_scatter_base(self, lambda t: t.cuda(), 'scatter_', True, test_bounds=False)
 
+    def test_min_max_inits(self):
+        # Testing if THC_reduceAll received the correct index initialization.
+        # This affects the result of THC_reduceAll operations at extreme values
+        x = torch.cuda.ByteTensor([0])
+        y = torch.cuda.ByteTensor([255])
+        expected = torch.cuda.LongTensor([0])
+
+        _, v = x.max(dim=0)
+        self.assertEqual(v, expected)
+
+        _, v = y.min(dim=0)
+        self.assertEqual(v, expected)
+
     def test_var(self):
         cpu_tensor = torch.randn(2, 3, 3)
         gpu_tensor = cpu_tensor.cuda()


### PR DESCRIPTION
Fixes #4076.

Their cuda kernels should be initialized with (min_value, 0) and
(max_value, 0), respectively, where the second number is a default index
value. However, they were being initialized with (max, 1) and (min, 1)
instead, probably a remnant from the lua torch days where everything is 1-indexed.

This caused bugs in torch.max() and torch.min() when the input is at the
extreme value, and the max value (or min value) occurs at index 0. For example,
```
import torch
x = torch.ByteTensor([[0]])
x.cuda().max(dim=0)  # returns (0, 1) but the expected result is (0, 0)
```

### Test Plan
Add a unit test for this case.