### PR TITLE
Fix typo in DataParallel docs

### DIFF
--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -27,7 +27,7 @@ class DataParallel(Module):
     the model's forward pass.
 
     .. warning::
-        Forward and backwrad hooks defined on :attr:`module` and its submodules
+        Forward and backward hooks defined on :attr:`module` and its submodules
         won't be invoked anymore, unless the hooks are initialized in the
         :meth:`forward` method.
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -81,7 +81,7 @@ class DistributedDataParallel(Module):
         0, to all other replicas in the system in every iteration.
 
     .. warning::
-        Forward and backwrad hooks defined on :attr:`module` and its submodules
+        Forward and backward hooks defined on :attr:`module` and its submodules
         won't be invoked anymore, unless the hooks are initialized in the
         :meth:`forward` method.
 


### PR DESCRIPTION
Replace "backwrad" with "backward"