### PR TITLE
Fixes UB when using legacy python functions and mark_non_differentiable

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -56,7 +56,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 inline bool any_variable_requires_grad(const variable_list& variables) {
   return std::any_of(
       variables.begin(), variables.end(), [](const Variable& variable) {
-        return variable.requires_grad();
+        return variable.defined() and variable.requires_grad();
       });
 }
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -56,7 +56,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 inline bool any_variable_requires_grad(const variable_list& variables) {
   return std::any_of(
       variables.begin(), variables.end(), [](const Variable& variable) {
-        return variable.defined() and variable.requires_grad();
+        return variable.defined() && variable.requires_grad();
       });
 }
 


### PR DESCRIPTION
This should fix the flaky segfaults I was seeing in `test_autograd/test_dep_nograd`.

If an output of a python Function is marked as non_differentiable,
autograd won't save a gradfn for that output. During the backward
pass, this translates to autograd passing an undefined tensor to the
backward of the Function. The legacy python Function path checks
if *any* of the inputs to backward requires_grad, here:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/functions/utils.cpp#L16

This requires_grad check uses Variable::get(), which casts the
undefined tensor to a VariableImpl and then accesses the _requires_grad
member. This is UB because the undefined tensor is NOT a VariableImpl.

The fix I did here is to add a check for if the variable/tensor is defined
in the legacy python Function code path.

The other that that I could do is to reevaluate how autograd treats outputs marked as non_differentiable. The inputs to the legacy python function are already zero-filled, but they don't get zero-filled early enough to avoid `requires_grad` being called on them right now.

cc @ezyang 

### Test Plan
I should probably figure out how to use ASAN and run my code on an ASAN build... TBD in progress.