### PR TITLE
Use TORCH_EXTENSION_NAME macro to avoid mismatched module/extension name

### DIFF
--- a/test/cpp_extensions/cuda_extension.cpp
+++ b/test/cpp_extensions/cuda_extension.cpp
@@ -14,6 +14,6 @@ at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
   return output;
 }
 
-PYBIND11_MODULE(torch_test_cuda_extension, m) {
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
 }

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -7,6 +7,9 @@ struct Doubler {
   at::Tensor forward() {
     return tensor_ * 2;
   }
+  at::Tensor get() const {
+    return tensor_;
+  }
 
 private:
   at::Tensor tensor_;

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -21,7 +21,7 @@ private:
   Tensor tensor_;
 };
 
-PYBIND11_MODULE(torch_test_cpp_extensions, m) {
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
   py::class_<MatrixMultiplier>(m, "MatrixMultiplier")
       .def(py::init<int, int>())

--- a/test/cpp_extensions/jit_extension.cpp
+++ b/test/cpp_extensions/jit_extension.cpp
@@ -10,7 +10,7 @@ Tensor tanh_add(Tensor x, Tensor y) {
   return x.tanh() + y.tanh();
 }
 
-PYBIND11_MODULE(jit_extension, m) {
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("tanh_add", &tanh_add, "tanh(x) + tanh(y)");
   m.def("exp_add", &exp_add, "exp(x) + exp(y)");
   py::class_<Doubler>(m, "Doubler")

--- a/test/cpp_extensions/jit_extension.cpp
+++ b/test/cpp_extensions/jit_extension.cpp
@@ -1,6 +1,10 @@
 #include <torch/torch.h>
 
+#include "doubler.h"
+
 using namespace at;
+
+Tensor exp_add(Tensor x, Tensor y);
 
 Tensor tanh_add(Tensor x, Tensor y) {
   return x.tanh() + y.tanh();
@@ -8,4 +12,9 @@ Tensor tanh_add(Tensor x, Tensor y) {
 
 PYBIND11_MODULE(jit_extension, m) {
   m.def("tanh_add", &tanh_add, "tanh(x) + tanh(y)");
+  m.def("exp_add", &exp_add, "exp(x) + exp(y)");
+  py::class_<Doubler>(m, "Doubler")
+  .def(py::init<int, int>())
+  .def("forward", &Doubler::forward)
+  .def("get", &Doubler::get);
 }

--- a/test/cpp_extensions/jit_extension2.cpp
+++ b/test/cpp_extensions/jit_extension2.cpp
@@ -1,16 +1,7 @@
 #include <torch/torch.h>
 
-#include "doubler.h"
-
 using namespace at;
 
 Tensor exp_add(Tensor x, Tensor y) {
-  return x.exp() + y.sigmoid();
-}
-
-PYBIND11_MODULE(torch_test_cpp_extensions, m) {
-  m.def("exp_add", &exp_add, "exp(x) + exp(y)");
-  py::class_<Doubler>(m, "Doubler")
-      .def(py::init<int, int>())
-      .def("forward", &Doubler::forward);
+  return x.exp() + y.exp();
 }

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -4,7 +4,7 @@ from torch.utils.cpp_extension import CppExtension, CUDAExtension
 
 ext_modules = [
     CppExtension(
-        'torch_test_cpp_extensions', ['extension.cpp'],
+        'torch_test_cpp_extension', ['extension.cpp'],
         extra_compile_args=['-g']),
 ]
 
@@ -17,6 +17,6 @@ if torch.cuda.is_available():
     ext_modules.append(extension)
 
 setup(
-    name='torch_test_cpp_extensions',
+    name='torch_test_cpp_extension',
     ext_modules=ext_modules,
     cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension})

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 import torch.utils.cpp_extension
-import torch_test_cpp_extensions as cpp_extension
+import torch_test_cpp_extension as cpp_extension
 
 import common
 
@@ -79,18 +79,6 @@ class TestCppExtension(common.TestCase):
 
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
-
-    def test_throws_when_mismatched_module_name(self):
-        def load_wrong():
-            torch.utils.cpp_extension.load(
-                name='wrong_name',
-                sources=[
-                    'cpp_extensions/jit_extension.cpp',
-                    'cpp_extensions/jit_extension2.cpp'
-                ],
-                extra_include_paths=['cpp_extensions'])
-
-        self.assertRaises(NameError, load_wrong)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For C++ extensions, currently, the module name (defined via  `PYBIND11_MODULE`) must match the extension name (defined in `setup.py` or `torch.utils.cpp_extension.load`). This can cause problems when users mistype one of them.

To fix this, I first wrote a check that would look for the `PYBIND11_MODULE` declaration in any of the provided source files, and compare the module name declared there with the extension name. This scaled fine and would work. You can find this approach in the first commit of this PR.

However, @zdevito then had a better idea of just defining a macro via a compiler flag that would contain the extension name, that users could then use. I named this `TORCH_EXTENSION_NAME` and it works very nicely.

The other changes are just fixes to the C++ extension tests.

@zdevito @fmassa @apaszke 