### PR TITLE
Speed-up nn.Linear for the 3d input case

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -139,16 +139,6 @@ Tensor dot(const Tensor& self, const Tensor& tensor) {
   return self._dot(tensor);
 }
 
-static Tensor maybeSqueeze(const Tensor & tensor, int64_t dim_tensor1, int64_t dim_tensor2) {
-  if (dim_tensor1 == 1) {
-    return tensor.squeeze(-2);
-  } else if (dim_tensor2 == 1) {
-    return tensor.squeeze(-1);
-  } else {
-    return tensor;
-  }
-}
-
 /*
 Matrix product of two Tensors.
 The behavior depends on the dimensionality of the Tensors as follows:
@@ -189,16 +179,13 @@ Tensor matmul(const Tensor & tensor1, const Tensor & tensor2) {
     auto size2 = t2.sizes();
     std::vector<int64_t> output_size;
     output_size.insert(output_size.end(), size1.begin(), size1.end() - 1);
-    output_size.insert(output_size.end(), size2.end() - 1, size2.end());
+    if (dim_tensor2 > 1) {
+      output_size.push_back(size2[dim_tensor2 - 1]);
+    }
 
     // fold the batch into the first dimension
     Tensor t1 = tensor1.contiguous().view({-1, size1[size1.size() - 1]});
-
-    auto output = t1.mm(t2).view(output_size);
-    if (dim_tensor2 == 1) {
-      output = output.squeeze(-1);
-    }
-    return output;
+    return at::_unsafe_view(t1.mm(t2), output_size);
   } else if ((dim_tensor1 >= 1 && dim_tensor2 >= 1) && (dim_tensor1 >= 3 || dim_tensor2 >= 3)) {
     // We are multiplying b1 x n x m1 by x2 x m2 x p (where b1 can be a list);
     // we track m1 vs m2 separately even though they must match for nicer error messages
@@ -234,9 +221,14 @@ Tensor matmul(const Tensor & tensor1, const Tensor & tensor2) {
     Tensor output = tensor1_expanded.bmm(tensor2_expanded);
 
     // reshape batches back into result
-    std::vector<int64_t> total_expansion(expand_batch_portion);
-    total_expansion.insert(total_expansion.end(), {n, p});
-    return maybeSqueeze(output.view(total_expansion), dim_tensor1, dim_tensor2);
+    std::vector<int64_t> output_shape(expand_batch_portion);
+    if (dim_tensor1 > 1) {
+      output_shape.push_back(n);
+    }
+    if (dim_tensor2 > 1) {
+      output_shape.push_back(p);
+    }
+    return at::_unsafe_view(output, output_shape);
   }
 
   runtime_error("both arguments to matmul need to be at least 1D, but they are %dD and %dD",

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -342,6 +342,9 @@
 
 - func: type_as(Tensor self, Tensor other) -> Tensor
 
+- func: _unsafe_view(Tensor self, IntList size) -> Tensor
+  variants: function
+
 - func: unsqueeze(Tensor self, int64_t dim) -> Tensor
 
 - func: unsqueeze_(Tensor self, int64_t dim) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -637,6 +637,9 @@
 - name: uniform_(Tensor self, double from, double to, Generator generator)
   self: zeros_like(grad)
 
+- name: _unsafe_view(Tensor self, IntList size)
+  self: grad.contiguous().view(self.sizes())
+
 - name: unsqueeze(Tensor self, int64_t dim)
   self: grad.squeeze(dim)
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -16,7 +16,7 @@ CodeTemplate = import_module('code_template', 'aten/src/ATen/code_template.py').
 SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
-    'sparse_raw_resize_',
+    'sparse_raw_resize_', '_unsafe_view',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
This adds at::_unsafe_view and uses it in matmul. The _unsafe_view
function is identical to view except that the output is not treated
like a view by the automatic differentiation code. This avoids in-place
modifications triggering the more expensive CopySlices/AsStridedBackward
behavior.

The _unsafe_view function is only safe to use on temporaries that will
be immediately discarded and that do not alias other tensors. Otherwise,
in-place modificatiions may trigger incorrect gradients. The funciton is
not exposed to Python.

See #5169

cc @ngimel @csarofeen 