### PR TITLE
Implement adaptive softmax

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -658,6 +658,12 @@ Loss functions
 .. autoclass:: TripletMarginLoss
     :members:
 
+:hidden:`AdaptiveLogSoftmax`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AdaptiveLogSoftmax
+    :members:
+
 
 Vision layers
 ----------------

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -383,6 +383,12 @@ Non-linear activations (other)
 .. autoclass:: LogSoftmax
     :members:
 
+:hidden:`AdaptiveLogSoftmaxWithLoss`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AdaptiveLogSoftmaxWithLoss
+    :members:
+
 Normalization layers
 ----------------------------------
 
@@ -656,12 +662,6 @@ Loss functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: TripletMarginLoss
-    :members:
-
-:hidden:`AdaptiveLogSoftmax`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: AdaptiveLogSoftmax
     :members:
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4949,7 +4949,7 @@ class TestNN(NNTestCase):
             asfm(x, y)
 
         # cluster sizes
-        asfm = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 15])
+        asfm = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 15], return_logprob=True)
         x = Variable(torch.randn(2, 16))
         y = Variable(torch.LongTensor([0, 17]))
 
@@ -4961,7 +4961,7 @@ class TestNN(NNTestCase):
         self.assertEqual(asfm(x, y).size(), (2, ))
 
         # get_log_proba actually returns log_proba
-        asfm = nn.AdaptiveLogSoftmax(8, 4, [2])
+        asfm = nn.AdaptiveLogSoftmax(8, 4, [2], return_logprob=True)
         x = Variable(torch.randn(4, 8))
         logprob_out = asfm.get_log_proba(x)
 
@@ -4973,6 +4973,18 @@ class TestNN(NNTestCase):
             out = asfm(x, y)
 
             self.assertEqual(out, logprob_out.gather(1, y.unsqueeze(1)).squeeze())
+
+        # reduction
+        x = Variable(torch.randn(4, 8))
+        y = Variable(torch.LongTensor([0, 1, 2, 3]))
+
+        asfm = nn.AdaptiveLogSoftmax(8, 4, [2], return_logprob=False)
+        reduced = asfm(x, y)
+
+        asfm.return_logprob = True
+        logprob = -(asfm(x, y).mean())
+
+        self.assertEqual(reduced, logprob)
 
 
 class TestNNInit(TestCase):
@@ -7360,6 +7372,11 @@ add_test(NewModuleTest(
     constructor=lambda: _AdaptiveLogSoftmax(16, 10, [2, 6]),
     input_size=(4, 16),
     fullname='AdaptiveLogSoftmax'))
+
+add_test(NewModuleTest(
+    constructor=lambda: _AdaptiveLogSoftmax(16, 10, [2, 6], return_logprob=True),
+    input_size=(4, 16),
+    fullname='AdaptiveLogSoftmaxLogprob'))
 
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4926,30 +4926,30 @@ class TestNN(NNTestCase):
     def test_adaptive_log_softmax(self):
         # args validation
         with self.assertRaises(ValueError):
-            _ = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 15, 15], div_value=2.)
+            _ = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 15, 15], div_value=2.)
 
         with self.assertRaises(ValueError):
-            _ = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 15, 10], div_value=2.)
+            _ = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 15, 10], div_value=2.)
 
         with self.assertRaises(ValueError):
-            _ = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 10, 25], div_value=2.)
+            _ = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 25], div_value=2.)
 
         # input shapes
         with self.assertRaisesRegex(RuntimeError, "Input and target should have the same size"):
-            asfm = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 10, 15], div_value=2.)
+            asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
             x = Variable(torch.randn(2, 16))
             y = Variable(torch.LongTensor([0, 5, 10]))
             asfm(x, y)
 
         # out-of-bound targets
         with self.assertRaisesRegex(RuntimeError, "Target values should be in"):
-            asfm = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 10, 15], div_value=2.)
+            asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
             x = Variable(torch.randn(2, 16))
             y = Variable(torch.LongTensor([0, 20]))
             asfm(x, y)
 
         # cluster sizes
-        asfm = nn.AdaptiveLogSoftmaxWIthLoss(16, 20, [5, 10, 15], div_value=2.)
+        asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
         x = Variable(torch.randn(2, 16))
         y = Variable(torch.LongTensor([0, 17]))
 
@@ -4961,7 +4961,7 @@ class TestNN(NNTestCase):
         self.assertEqual(asfm(x, y).output.size(), (2, ))
 
         # log_probs actually returns log_proba
-        asfm = nn.AdaptiveLogSoftmaxWIthLoss(8, 4, [2], div_value=2.)
+        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 4, [2], div_value=2.)
         x = Variable(torch.randn(4, 8))
         logprob_out = asfm.log_prob(x)
 
@@ -7351,14 +7351,14 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 
-class _AdaptiveLogSoftmaxWIthLoss(nn.AdaptiveLogSoftmaxWIthLoss):
+class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
     def __call__(self, input):
         t = Variable(torch.LongTensor([0, 1, 4, 8]).type_as(input).long())
-        return nn.AdaptiveLogSoftmaxWIthLoss.__call__(self, input, t).output
+        return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
 
 
 add_test(NewModuleTest(
-    constructor=lambda: _AdaptiveLogSoftmaxWIthLoss(16, 10, [2, 6]),
+    constructor=lambda: _AdaptiveLogSoftmaxWithLoss(16, 10, [2, 6]),
     input_size=(4, 16),
     fullname='AdaptiveLogSoftmax'))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4980,14 +4980,18 @@ class TestNN(NNTestCase):
 
         # argmax in shortlist
         asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2.)
-        asfm.head.weight.data[:asfm.shortlist_size, :] += 100.
+        asfm.head.weight.data.abs_()
+        asfm.head.bias.data.abs_()
+        asfm.head.weight.data[asfm.shortlist_size:, :].zero_()
 
         out = asfm.predict(x)
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))
 
         # argmax outside of shortlist
         asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2.)
-        asfm.head.weight.data[asfm.shortlist_size:, :] += 100.
+        asfm.head.weight.data.abs_()
+        asfm.head.bias.data.abs_()
+        asfm.head.weight.data[:asfm.shortlist_size, :].zero_()
 
         out = asfm.predict(x)
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))
@@ -4997,11 +5001,11 @@ class TestNN(NNTestCase):
         asfm.head.weight.data.abs_()
         asfm.head.bias.data.abs_()
 
-        x[:32, :4].zero_()
-        x[32:, 4:].zero_()
+        x[:32, :asfm.shortlist_size].zero_()
+        x[32:, asfm.shortlist_size:].zero_()
 
-        asfm.head.weight.data[:asfm.shortlist_size, 4:].zero_()
-        asfm.head.weight.data[asfm.shortlist_size:, :4].zero_()
+        asfm.head.weight.data[:asfm.shortlist_size, asfm.shortlist_size:].zero_()
+        asfm.head.weight.data[asfm.shortlist_size:, :asfm.shortlist_size].zero_()
 
         out = asfm.predict(x)
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4937,21 +4937,21 @@ class TestNN(NNTestCase):
         # input shapes
         with self.assertRaisesRegex(RuntimeError, "Input and target should have the same size"):
             asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
-            x = Variable(torch.randn(2, 16))
-            y = Variable(torch.LongTensor([0, 5, 10]))
+            x = torch.randn(2, 16)
+            y = torch.tensor([0, 5, 10])
             asfm(x, y)
 
         # out-of-bound targets
         with self.assertRaisesRegex(RuntimeError, "Target values should be in"):
             asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
-            x = Variable(torch.randn(2, 16))
-            y = Variable(torch.LongTensor([0, 20]))
+            x = torch.randn(2, 16)
+            y = torch.tensor([0, 20])
             asfm(x, y)
 
         # cluster sizes
         asfm = nn.AdaptiveLogSoftmaxWithLoss(16, 20, [5, 10, 15], div_value=2.)
-        x = Variable(torch.randn(2, 16))
-        y = Variable(torch.LongTensor([0, 17]))
+        x = torch.randn(2, 16)
+        y = torch.tensor([0, 17])
 
         self.assertEqual(asfm.head.weight.size(), (5 + 3, 16))   # 5 targets in head, 3 clusters, dimensionality 16
         self.assertEqual(asfm.tail[0][1].weight.size(), (5, 8))  # 5 targets in this cluster, dimensionality 8
@@ -4962,14 +4962,14 @@ class TestNN(NNTestCase):
 
         # log_probs actually returns log_proba
         asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 4, [2], div_value=2.)
-        x = Variable(torch.randn(4, 8))
+        x = torch.randn(4, 8)
         logprob_out = asfm.log_prob(x)
 
         self.assertEqual(torch.exp(logprob_out).data.sum(1), torch.ones(4))
 
         # forward returns the same thing as log_probs
         for v in [0, 1, 2, 3]:
-            y = Variable(torch.zeros(4).fill_(v).long())
+            y = torch.full((4,), v, dtype=torch.long)
             out, loss = asfm(x, y)
 
             self.assertEqual(out, logprob_out.gather(1, y.unsqueeze(1)).squeeze())
@@ -7353,7 +7353,7 @@ add_test(NewModuleTest(
 
 class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
     def __call__(self, input):
-        t = Variable(torch.LongTensor([0, 1, 4, 8]).type_as(input).long())
+        t = torch.tensor([0, 1, 4, 8]).to(input.device)
         return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7353,7 +7353,7 @@ add_test(NewModuleTest(
 class _AdaptiveLogSoftmax(nn.AdaptiveLogSoftmax):
     def __call__(self, input):
         t = Variable(torch.LongTensor([0, 1, 4, 8]).type_as(input).long())
-        return super().__call__(input, t)
+        return nn.AdaptiveLogSoftmax.__call__(self, input, t)
 
 
 add_test(NewModuleTest(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -494,14 +494,10 @@ class TestNN(NNTestCase):
             return input.grad.data
 
     def _zero_grad_parameters(self, module):
-        if hasattr(module, 'weight') and module.weight is not None:
-            if module.weight.grad is not None:
-                module.weight.grad.data.zero_()
-                module.weight.grad.detach_()
-        if hasattr(module, 'bias') and module.bias is not None:
-            if module.bias.grad is not None:
-                module.bias.grad.data.zero_()
-                module.bias.grad.detach_()
+        for p in module.parameters():
+            if p.grad is not None:
+                p.grad.data.zero_()
+                p.grad.detach_()
 
     def _get_parameters(self, module):
         params = []
@@ -4926,6 +4922,57 @@ class TestNN(NNTestCase):
 
     def test_grad_conv3d_weight(self):
         self.run_grad_conv_test(F.conv3d, F.grad.conv3d_weight, 3, 'weight')
+        
+    def test_adaptive_log_softmax(self):
+        # args validation
+        with self.assertRaises(ValueError):
+            _ = nn.AdaptiveLogSoftmax(16, 20, [5, 15, 15])
+
+        with self.assertRaises(ValueError):
+            _ = nn.AdaptiveLogSoftmax(16, 20, [5, 15, 10])
+
+        with self.assertRaises(ValueError):
+            _ = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 25])
+
+        # input shapes
+        with self.assertRaisesRegex(RuntimeError, "Input and target should have the same size"):
+            asfm = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 15])
+            x = Variable(torch.randn(2, 16))
+            y = Variable(torch.LongTensor([0, 5, 10]))
+            asfm(x, y)
+
+        # out-of-bound targets
+        with self.assertRaisesRegex(RuntimeError, "Target values should be in"):
+            asfm = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 15])
+            x = Variable(torch.randn(2, 16))
+            y = Variable(torch.LongTensor([0, 20]))
+            asfm(x, y)
+
+        # cluster sizes
+        asfm = nn.AdaptiveLogSoftmax(16, 20, [5, 10, 15])
+        x = Variable(torch.randn(2, 16))
+        y = Variable(torch.LongTensor([0, 17]))
+
+        self.assertEqual(asfm.head.weight.size(), (5 + 3, 16))   # 5 targets in head, 3 clusters, dimensionality 16
+        self.assertEqual(asfm.tail[0][1].weight.size(), (5, 8))  # 5 targets in this cluster, dimensionality 8
+        self.assertEqual(asfm.tail[1][1].weight.size(), (5, 4))
+        self.assertEqual(asfm.tail[2][1].weight.size(), (5, 2))
+
+        self.assertEqual(asfm(x, y).size(), (2, ))
+
+        # get_log_proba actually returns log_proba
+        asfm = nn.AdaptiveLogSoftmax(8, 4, [2])
+        x = Variable(torch.randn(4, 8))
+        logprob_out = asfm.get_log_proba(x)
+
+        self.assertEqual(torch.exp(logprob_out).data.sum(1), torch.ones(4))
+
+        # forward returns the same thing as get_log_proba
+        for v in [0, 1, 2, 3]:
+            y = Variable(torch.zeros(4).fill_(v).long())
+            out = asfm(x, y)
+
+            self.assertEqual(out, logprob_out.gather(1, y.unsqueeze(1)).squeeze())
 
 
 class TestNNInit(TestCase):
@@ -7301,6 +7348,19 @@ add_test(NewModuleTest(
     input_size=(1, 1, 2, 4, 6),
     fullname='MaxUnpool3d_net',
     check_gradgrad=False,))
+
+
+class _AdaptiveLogSoftmax(nn.AdaptiveLogSoftmax):
+    def __call__(self, input):
+        t = Variable(torch.LongTensor([0, 1, 4, 8]).type_as(input).long())
+        return super().__call__(input, t)
+
+
+add_test(NewModuleTest(
+    constructor=lambda: _AdaptiveLogSoftmax(16, 10, [2, 6]),
+    input_size=(4, 16),
+    fullname='AdaptiveLogSoftmax'))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4979,7 +4979,7 @@ class TestNN(NNTestCase):
         x = torch.randn(64, 8).abs_()
 
         # argmax in shortlist
-        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2.)
+        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2., head_bias=True)
         asfm.head.weight.data.abs_()
         asfm.head.bias.data.abs_()
         asfm.head.weight.data[asfm.shortlist_size:, :].zero_()
@@ -4988,7 +4988,7 @@ class TestNN(NNTestCase):
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))
 
         # argmax outside of shortlist
-        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2.)
+        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2., head_bias=True)
         asfm.head.weight.data.abs_()
         asfm.head.bias.data.abs_()
         asfm.head.weight.data[:asfm.shortlist_size, :].zero_()
@@ -4997,7 +4997,7 @@ class TestNN(NNTestCase):
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))
 
         # half of the argmax in shortlist, half in clusters
-        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2.)
+        asfm = nn.AdaptiveLogSoftmaxWithLoss(8, 10, [4, 8], div_value=2., head_bias=True)
         asfm.head.weight.data.abs_()
         asfm.head.bias.data.abs_()
 

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -26,7 +26,7 @@ from .pixelshuffle import PixelShuffle
 from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d, Upsample
 from .distance import PairwiseDistance, CosineSimilarity
 from .fold import Fold, Unfold
-from .adaptive import AdaptiveLogSoftmax
+from .adaptive import AdaptiveLogSoftmaxWIthLoss
 
 __all__ = [
     'Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
@@ -46,5 +46,6 @@ __all__ = [
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
-    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold', 'AdaptiveLogSoftmax',
+    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
+    'AdaptiveLogSoftmaxWIthLoss',
 ]

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -26,6 +26,7 @@ from .pixelshuffle import PixelShuffle
 from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d, Upsample
 from .distance import PairwiseDistance, CosineSimilarity
 from .fold import Fold, Unfold
+from .adaptive import AdaptiveLogSoftmax
 
 __all__ = [
     'Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
@@ -45,5 +46,5 @@ __all__ = [
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
-    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
+    'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold', 'AdaptiveLogSoftmax',
 ]

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -26,7 +26,7 @@ from .pixelshuffle import PixelShuffle
 from .upsampling import UpsamplingNearest2d, UpsamplingBilinear2d, Upsample
 from .distance import PairwiseDistance, CosineSimilarity
 from .fold import Fold, Unfold
-from .adaptive import AdaptiveLogSoftmaxWIthLoss
+from .adaptive import AdaptiveLogSoftmaxWithLoss
 
 __all__ = [
     'Module', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
@@ -47,5 +47,5 @@ __all__ = [
     'AdaptiveMaxPool1d', 'AdaptiveMaxPool2d', 'AdaptiveMaxPool3d', 'AdaptiveAvgPool1d', 'AdaptiveAvgPool2d',
     'AdaptiveAvgPool3d', 'TripletMarginLoss', 'ZeroPad2d', 'ConstantPad1d', 'ConstantPad2d',
     'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
-    'AdaptiveLogSoftmaxWIthLoss',
+    'AdaptiveLogSoftmaxWithLoss',
 ]

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -211,19 +211,18 @@ class AdaptiveLogSoftmaxWithLoss(Module):
 
         """
 
-        with torch.no_grad():
-            out = input.new_empty((input.size(0), self.n_classes))
+        out = input.new_empty((input.size(0), self.n_classes))
 
-            head_output = self.head(input)
-            head_logprob = log_softmax(head_output, dim=1)
+        head_output = self.head(input)
+        head_logprob = log_softmax(head_output, dim=1)
 
-            out[:, :self.shortlist_size] = head_logprob[:, :self.shortlist_size]
+        out[:, :self.shortlist_size] = head_logprob[:, :self.shortlist_size]
 
-            for i, (start_idx, stop_idx) in enumerate(zip(self.cutoffs, self.cutoffs[1:])):
-                cluster_output = self.tail[i](input)
-                cluster_logprob = log_softmax(cluster_output, dim=1)
-                output_logprob = cluster_logprob + head_logprob[:, self.shortlist_size + i].unsqueeze(1)
+        for i, (start_idx, stop_idx) in enumerate(zip(self.cutoffs, self.cutoffs[1:])):
+            cluster_output = self.tail[i](input)
+            cluster_logprob = log_softmax(cluster_output, dim=1)
+            output_logprob = cluster_logprob + head_logprob[:, self.shortlist_size + i].unsqueeze(1)
 
-                out[:, start_idx:stop_idx] = output_logprob
+            out[:, start_idx:stop_idx] = output_logprob
 
         return out

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -147,8 +147,8 @@ class AdaptiveLogSoftmaxWithLoss(Module):
         used_rows = 0
         batch_size = target.size(0)
 
-        output = input.new(batch_size).zero_()
-        gather_inds = target.new(batch_size).zero_()
+        output = input.new_zeros(batch_size)
+        gather_inds = target.new_zeros(batch_size)
 
         cutoff_values = [0] + self.cutoffs
         for i in range(len(cutoff_values) - 1):
@@ -212,7 +212,7 @@ class AdaptiveLogSoftmaxWithLoss(Module):
         """
 
         with torch.no_grad():
-            out = input.new(input.size(0), self.n_classes).zero_()
+            out = input.new_zeros((input.size(0), self.n_classes))
 
             head_output = self.head(input)
             head_logprob = log_softmax(head_output, dim=1)

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -1,0 +1,191 @@
+import torch
+
+from . import Sequential, ModuleList, Linear
+from .module import Module
+from ..functional import log_softmax
+
+
+class AdaptiveLogSoftmax(Module):
+    r"""Efficient softmax approximation as described in
+    `Efficient softmax approximation for GPUs`_ by Edouard Grave, Armand Joulin,
+     Moustapha Cissé, David Grangier, and Hervé Jégou.
+
+    Adaptive softmax is an approximate strategy for training models with large
+    output spaces. It is most effective when the label distribution is highly
+    imbalanced, for example in natural language modelling, where the word
+    frequency distribution approximately follows the `Zipf's law`_.
+
+    Adaptive softmax partitions the labels into several clusters, according to
+    their frequency. These clusters may contain different number of targets
+    each.
+    Additionally, clusters containig less frequent labels assign lower
+    dimensional embeddings to those labels, which speeds up the computation.
+    For each minibatch, only clusters for which at least one target is
+    present are used.
+
+    The idea is that the cluster that the clusters that are accessed often
+    (like the first one, containing most frequent labels), should also be cheap
+    to compute -- that is, contain a small number of assigned targets.
+
+    We highly recommend taking a look at the original paper for more details.
+
+    ``cutoffs`` should be a Sequence of integers. It controls number of clusters
+    and the partitioning of targets into clusters. For example setting
+    ``cutoffs = [10, 100, 1000]`` means that first `10` targets will be assigned
+    to the 'head' of the adaptive softmax, targets `11, 12, ..., 100` will be
+    assigned to the first cluster, and targets `101, 102, ..., 1000` will be
+    assigned to the second cluster, while targets
+    `1001, 1002, ..., n_classes - 1` will be assigned to the last, third cluster
+
+    ``div_value`` is used to compute the size of each additional cluster,
+    which is given as :math:`\lfloor \frac{in\_features}{div\_value^i} \rfloor`,
+    where :math:`i` is the cluster index (with clusters for less frequent words
+    having larger indices, and indices starting at :math:`1`).
+
+    .. warning::
+        Targets passed as inputs to this module should be sorted accoridng to
+        their frequency. This means that the most frequent target should be
+        represented by the index `0`, and the least frequent
+        target should be represented by the index `n_classes - 1`.
+
+    .. note::
+        To compute log-probabilities for all classes, the `predict_log_proba`
+        method can be used.
+
+    Args:
+        in_features (int): Number of features in the input tensor
+        n_classes (int): Number of classes in the dataset.
+        cutoffs (Sequence): Cutoffs used to assign targets to their buckets.
+        div_value (float, optional): value used as an exponent to compute sizes
+        of the clusters. Default: 2.0
+
+    Returns:
+        A Variable of size ``N``, containing computed target log probabilities
+        for each example
+
+    Shape:
+        - Input: :math:`(N, in\_features)`
+        - Target: :math:`(N)` where each value is `0 <= targets[i] <= C - 1`
+        - Output: :math:`(N)`
+
+    .. _Efficient softmax approximation for GPUs:
+        https://arxiv.org/abs/1609.04309
+
+    .. _Zipf's law:
+        https://en.wikipedia.org/wiki/Zipf%27s_law
+    """
+
+    def __init__(self, in_features, n_classes, cutoffs, div_value=2.):
+        super(AdaptiveLogSoftmax, self).__init__()
+
+        cutoffs = list(cutoffs)
+
+        if (cutoffs != sorted(cutoffs)):
+            raise ValueError('Cutoffs should be a list of unique, positive in')
+
+        if (cutoffs != sorted(cutoffs)) \
+                or (max(cutoffs) >= (n_classes - 1)) \
+                or (len(set(cutoffs)) != len(cutoffs)):
+
+            raise ValueError("Cutoffs should be a sequence of unique, positive "
+                             "integers sorted in an increasing order, where "
+                             "each value is between 1 and n_classes-1")
+
+        self.in_features = in_features
+        self.n_classes = n_classes
+        self.cutoffs = cutoffs + [n_classes]
+        self.div_value = div_value
+
+        self.shortlist_size = self.cutoffs[0]
+        self.n_clusters = len(self.cutoffs) - 1
+        self.head_size = self.shortlist_size + self.n_clusters
+
+        self.head = Linear(self.in_features, self.head_size)
+        self.tail = ModuleList()
+
+        for i in range(self.n_clusters):
+
+            hsz = int(self.in_features // (self.div_value ** (i + 1)))
+            osz = self.cutoffs[i + 1] - self.cutoffs[i]
+
+            projection = Sequential(
+                Linear(self.in_features, hsz, bias=False),
+                Linear(hsz, osz)
+            )
+
+            self.tail.append(projection)
+
+    def reset_parameters(self):
+        self.head.reset_parameters()
+        for i2h, h2o in self.tail:
+            i2h.reset_parameters()
+            h2o.reset_parameters()
+
+    def forward(self, input, target):
+        if input.size(0) != target.size(0):
+            raise RuntimeError('Input and target should have the same size '
+                               'in the batch dimension.')
+
+        used_rows = 0
+        batch_size = target.size(0)
+
+        output = input.new(batch_size).zero_()
+        gather_inds = target.new(batch_size).zero_()
+        head_logprob = log_softmax(self.head(input), dim=1)
+
+        cutoff_values = [0] + self.cutoffs
+        for i in range(len(cutoff_values) - 1):
+
+            low_idx = cutoff_values[i]
+            high_idx = cutoff_values[i + 1]
+
+            target_mask = (target >= low_idx) & (target < high_idx)
+            row_indices = target_mask.nonzero().squeeze()
+
+            if row_indices.numel() == 0:
+                continue
+
+            relative_target = target[target_mask] - cutoff_values[i]
+
+            if i == 0:
+                gather_inds.index_copy_(0, row_indices, relative_target)
+
+            else:
+                input_subset = input.index_select(0, row_indices)
+                cluster_output = self.tail[i - 1](input_subset)
+                cluster_logprob = log_softmax(cluster_output, dim=1)
+                local_logprob = cluster_logprob.gather(1, relative_target.unsqueeze(1))
+
+                cluster_index = self.shortlist_size + i - 1
+                gather_inds.index_fill_(0, row_indices, cluster_index)
+                output.index_copy_(0, row_indices, local_logprob.squeeze(1))
+
+            used_rows += row_indices.numel()
+
+        if used_rows != batch_size:
+            raise RuntimeError("Target values should be in [0, {}], "
+                               "but values in range [{}, {}] "
+                               "were found. ".format(self.n_classes - 1,
+                                                     int(target.min()),
+                                                     int(target.max())))
+
+        output += head_logprob.gather(1, gather_inds.unsqueeze(1)).squeeze()
+        return output
+
+    def get_log_proba(self, input):
+        with torch.no_grad():
+            out = input.new(input.size(0), self.n_classes).zero_()
+
+            head_output = self.head(input)
+            head_logprob = log_softmax(head_output, dim=1)
+
+            out[:, :self.shortlist_size] += head_logprob[:, :self.shortlist_size]
+
+            for i, (start_idx, stop_idx) in enumerate(zip(self.cutoffs, self.cutoffs[1:])):
+                cluster_output = self.tail[i](input)
+                cluster_logprob = log_softmax(cluster_output, dim=1)
+                output_logprob = cluster_logprob + head_logprob[:, self.shortlist_size + i].unsqueeze(1)
+
+                out[:, start_idx:stop_idx] += output_logprob
+
+        return out

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -52,6 +52,10 @@ class AdaptiveLogSoftmaxWithLoss(Module):
       for less frequent words having larger indices,
       and indices starting from :math:`1`).
 
+    * :attr:`head_bias` if set to True, adds a bias term to the 'head' of the
+      adaptive softmax. See paper for details. Set to False in the official
+      implementation.
+
     .. warning::
         Labels passed as inputs to this module should be sorted accoridng to
         their frequency. This means that the most frequent label should be
@@ -94,7 +98,7 @@ class AdaptiveLogSoftmaxWithLoss(Module):
         https://en.wikipedia.org/wiki/Zipf%27s_law
     """
 
-    def __init__(self, in_features, n_classes, cutoffs, div_value=4.):
+    def __init__(self, in_features, n_classes, cutoffs, div_value=4., head_bias=False):
         super(AdaptiveLogSoftmaxWithLoss, self).__init__()
 
         cutoffs = list(cutoffs)
@@ -113,12 +117,13 @@ class AdaptiveLogSoftmaxWithLoss(Module):
         self.n_classes = n_classes
         self.cutoffs = cutoffs + [n_classes]
         self.div_value = div_value
+        self.head_bias = head_bias
 
         self.shortlist_size = self.cutoffs[0]
         self.n_clusters = len(self.cutoffs) - 1
         self.head_size = self.shortlist_size + self.n_clusters
 
-        self.head = Linear(self.in_features, self.head_size)
+        self.head = Linear(self.in_features, self.head_size, bias=self.head_bias)
         self.tail = ModuleList()
 
         for i in range(self.n_clusters):


### PR DESCRIPTION
This PR implements [Efficient softmax approximation for GPUs
](https://arxiv.org/abs/1609.04309)

Briefly discussed in https://github.com/pytorch/pytorch/issues/4659

It is kind currently takes `input` and `targets` in `forward` pass, and returns the `log probabilities` of these targets.

I think the class description could be improved. 

I also didn't know how to add a test for a module that eats two inputs, instead of a single one, hence the hack with a dummy class in `test_nn`.

Let me know what you think.