### PR TITLE
[RFC] E2E test for script python frontend compilation + hacky fix for bug in compiler

### DIFF
--- a/test/expect/TestJit.test_e2e_compilation.expect
+++ b/test/expect/TestJit.test_e2e_compilation.expect
@@ -1,0 +1,30 @@
+graph(%x : UNKNOWN_TYPE
+      %y : UNKNOWN_TYPE
+      %z : UNKNOWN_TYPE) {
+  %3 : UNKNOWN_TYPE = add[alpha={1}](%x, %y)
+  %4 : UNKNOWN_TYPE = sub[alpha={1}](%3, %z)
+  %5 : UNKNOWN_TYPE = neg[alpha={1}](%z)
+  %6 : UNKNOWN_TYPE = __not__(%x)
+  %7 : UNKNOWN_TYPE = __not__(%y)
+  %8 : UNKNOWN_TYPE = __and__(%6, %7)
+  %9 : UNKNOWN_TYPE = __and__(%8, %z)
+  %10 : UNKNOWN_TYPE = If(%9)
+    block0() {
+      -> (%x)
+    }
+    block1() {
+      -> (%y)
+    }
+  %11 : UNKNOWN_TYPE = Constant[value={2147483647}]()
+  %12 : UNKNOWN_TYPE = lt(%x, %y)
+  %13 : UNKNOWN_TYPE = gt(%y, %z)
+  %14 : UNKNOWN_TYPE = __and__(%12, %13)
+  %24 : UNKNOWN_TYPE = Loop(%11, %14, %4)
+    block0(%15 : UNKNOWN_TYPE, %16 : UNKNOWN_TYPE, %18 : UNKNOWN_TYPE) {
+      %20 : UNKNOWN_TYPE = lt(%x, %y)
+      %22 : UNKNOWN_TYPE = gt(%y, %z)
+      %23 : UNKNOWN_TYPE = __and__(%20, %22)
+      -> (%23, %x)
+    }
+  return (%x);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1401,6 +1401,22 @@ class TestJit(TestCase):
         ast = torch.jit.frontend.get_jit_ast(fn)
         self.assertExpected(str(ast))
 
+    def test_e2e_compilation(self):
+        def fn(x, y, z):
+            q = x + y - z
+            w = -z
+            m = y
+            if not x and not y and z:
+                m = x
+            while x < y > z:
+                q = x
+            return x
+
+        ast = torch.jit.frontend.get_jit_ast(fn)
+        cu = torch.jit._jit_script_compile('')
+        cu.define_function(ast)
+        self.assertExpected(str(cu.get_graph('fn')))
+
     def test_script_while(self):
         cu = torch.jit._jit_script_compile('''
         def test_while(a, b) -> (c):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -160,6 +160,11 @@ struct Environment {
       // Actually remove the input
       b->eraseInput(*ritr);
       captured_inputs.erase(captured_inputs.begin() + *ritr - skip_num);
+      for (const auto& kv : value_table) {
+        if (kv.second == v) {
+          value_table[kv.first] = orig;
+        }
+      }
     }
   }
 };
@@ -293,6 +298,7 @@ struct to_ir {
 
       // Add block outputs
       auto curr_frame = environment_stack;
+
       for (const auto& x : curr_frame->captured_inputs) {
         body_block->registerOutput(curr_frame->value_table[x]);
       }
@@ -679,6 +685,10 @@ CompilationUnit::CompilationUnit() : pImpl(new CompilationUnitImpl()) {}
 
 void CompilationUnit::define(const std::string& script) {
   return pImpl->define(script);
+}
+
+void CompilationUnit::defineFunction(const Def& fn_def) {
+  pImpl->defineFunction(fn_def);
 }
 
 std::shared_ptr<Graph> CompilationUnit::getGraph(const std::string& func_name) {

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/script/tree_views.h"
 
 namespace torch {
 namespace jit {
@@ -12,6 +13,7 @@ struct CompilationUnitImpl;
 struct CompilationUnit {
   CompilationUnit();
   void define(const std::string& str);
+  void defineFunction(const Def& fn_def);
   std::shared_ptr<Graph> getGraph(const std::string& func_name);
   ~CompilationUnit();
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -11,7 +11,10 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "get_graph",
           &CompilationUnit::getGraph,
-          py::return_value_policy::reference);
+          py::return_value_policy::reference)
+      .def(
+          "define_function",
+          &CompilationUnit::defineFunction);
   m.def("_jit_script_compile", jitScriptCompile);
 }
 


### PR DESCRIPTION
- Expose CompilationUnit::defineFunction so we can directly pass in the Def from AST parsing
- Add a new test for e2e compilation (not using old one since i still need to put out the PR for ternary ops, will merge later)
- [RFC] There's a bug where an assignment to an LCD (e.g. `q = x`) causes a segfault when the rhs was deleted because it had no mutations. Right now I loop over the value table and change *all* symbols that refer to that value to the value in the enclosing scope. Request for ideas on a better overall design to avoid this

TODO arising from this: we should do the dataflow analysis to allow assignment to a value not in scope a la python scoping. I hack around this in the test