### PR TITLE
Fix ASAN detected global buffer overflows in autograd

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -56,7 +56,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 inline bool any_variable_requires_grad(const variable_list& variables) {
   return std::any_of(
       variables.begin(), variables.end(), [](const Variable& variable) {
-        return variable.requires_grad();
+        return variable.defined() && variable.requires_grad();
       });
 }
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -56,7 +56,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 inline bool any_variable_requires_grad(const variable_list& variables) {
   return std::any_of(
       variables.begin(), variables.end(), [](const Variable& variable) {
-        return variable.defined() && variable.requires_grad();
+        return variable.requires_grad();
       });
 }
 

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -13,12 +13,12 @@
 
 namespace torch { namespace autograd {
 
-SavedVariable::SavedVariable(const Variable& variable, bool is_output)
-    : output_nr_(variable.output_nr()),
-      requires_grad_(variable.requires_grad()),
-      has_grad_fn_(!variable.is_leaf()) {
+SavedVariable::SavedVariable(const Variable& variable, bool is_output) {
   if (variable.defined()) {
     was_default_constructed_ = false;
+    output_nr_ = variable.output_nr();
+    requires_grad_ = variable.requires_grad();
+    has_grad_fn_ = !variable.is_leaf();
     // These copies are all shared_ptr copies, so slightly more expensive.
     // Do them here instead of in the init list in case data is undefined.
     data_ = variable.data();


### PR DESCRIPTION
This PR fixes ASAN detected global-buffer-overflow in issue #5281 .

The fixes apply `variable.defined()` checks before reading any member variable of the `Variable`.

Tested with 

```
ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer ASAN_OPTIONS=symbolize=1 python test/test_autograd.py
```

Please review @ezyang @apaszke 

-----

EDIT : Reverted change in `any_variable_requires_grad` in function.h