### PR TITLE
[WIP] Add nn.ModuleDict (#4048)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -829,7 +829,7 @@ class TestNN(NNTestCase):
         self.assertEqual(n, nn.Sequential(l1, l3))
 
     def test_ModuleDict(self):
-        modules = {'0' : nn.ReLU(), '1' : nn.Linear(5, 5)}
+        modules = {'0': nn.ReLU(), '1': nn.Linear(5, 5)}
         module_dict = nn.ModuleDict(modules)
 
         def check():
@@ -856,7 +856,7 @@ class TestNN(NNTestCase):
         module_dict['tanh'] = modules['tanh']
         check()
 
-        next_modules = {'py' : nn.Linear(5, 5), 'torch' : nn.Sigmoid()}
+        next_modules = {'py': nn.Linear(5, 5), 'torch': nn.Sigmoid()}
         modules.update(next_modules)
         module_dict.update(next_modules)
         check()

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -9,7 +9,7 @@ from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLos
     CosineEmbeddingLoss, HingeEmbeddingLoss, MarginRankingLoss, \
     MultiLabelMarginLoss, MultiLabelSoftMarginLoss, MultiMarginLoss, \
     SmoothL1Loss, SoftMarginLoss, CrossEntropyLoss, TripletMarginLoss, PoissonNLLLoss
-from .container import Container, Sequential, ModuleList, ParameterList
+from .container import Container, Sequential, ModuleDict, ModuleList, ParameterList
 from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxPool3d, \
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, LPPool1d, LPPool2d, AdaptiveMaxPool1d, \
     AdaptiveMaxPool2d, AdaptiveMaxPool3d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
@@ -35,7 +35,7 @@ __all__ = [
     'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss',
     'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',
     'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss',
-    'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList',
+    'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleDict', 'ModuleList',
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -90,6 +90,78 @@ class Sequential(Module):
         return input
 
 
+class ModuleDict(Module):
+    r"""Holds submodules in a dict.
+
+    ModuleDict can be indexed like a regular Python dict, but modules it contains
+    as values are properly registered, and will be visible by all Module methods.
+
+    Arguments:
+        modules (dict, optional): a dict of keys : modules to add
+
+    Example::
+
+        class TwoHeadedNet(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.shared_backbone = nn.Linear(10, 10)
+                self.heads = nn.ModuleDict({
+                    'task1' : nn.Linear(10, 5),
+                    'task2' : nn.Linear(10, 10),
+                })
+
+            def forward(self, x, task_name):
+                # takes an extra `task_name` argument to determine
+                # which head of the network to use
+                assert task_name in ['task1', 'task2']
+
+                x = self.shared_backbone(x)
+                x = self.heads[task_name](x)
+                return x
+    """
+
+    def __init__(self, modules=None):
+        super(ModuleDict, self).__init__()
+        if modules is not None:
+            self.update(modules)
+
+    def __getitem__(self, key):
+        return self._modules[key]
+
+    def __setitem__(self, key, module):
+        return setattr(self, key, module)
+
+    def __len__(self):
+        return len(self._modules)
+
+    def __iter__(self):
+        return iter(self._modules)
+
+    def keys(self):
+        return self._modules.keys()
+
+    def items(self):
+        return self._modules.items()
+
+    def values(self):
+        return self._modules.values()
+
+    def get(self, key, default=None):
+        return self._modules.get(key, default)
+
+    def update(self, modules):
+        r"""Updates modules from a Python dict.
+        Arguments:
+            modules (dict): dict of modules to append
+        """
+        if not isinstance(modules, dict):
+            raise TypeError("ModuleDict.update should be called with a "
+                            "dict, but got " + type(modules).__name__)
+        for key, module in modules.items():
+            self.add_module(key, module)
+        return self
+
+
 class ModuleList(Module):
     r"""Holds submodules in a list.
 


### PR DESCRIPTION
Issue #4048

This PR implements an nn.ModuleDict class. Its purpose is similar to nn.ModuleList (ensuring modules in a collection are properly registered) but it exposes a dict interface instead. See issue #4048 for discussion.

This PR is still untested as I have been unable to compile PyTorch from source on my Mac; please do not merge it yet. I am putting it out for feedback now until I find the chance to sit down and fix the compilation issues and test it myself.

This is my first contribution to PyTorch, please let me know if I should be doing anything differently. Cheers.
