### PR TITLE
Implement no-attribute dispatch of ATen ops from the JIT

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -28,8 +28,12 @@ TYPE_CASTS = {
     'IntList': 'std::vector<int64_t>',
 }
 
-ATTR_ASSIGNMENT = CodeTemplate("""\
+KW_ASSIGNMENT = CodeTemplate("""\
 auto ${name} = ${type_cast}(node->${method}(Symbol("${name}")));\
+""")
+
+POS_ASSIGNMENT = CodeTemplate("""\
+auto ${name} = tensor_as<${type}>(std::move(fromLast(stack, ${arg_idx})));\
 """)
 
 CALL_NAMESPACE = CodeTemplate("at::${name}(${args})")
@@ -37,10 +41,12 @@ CALL_METHOD = CodeTemplate("(${first}).${name}(${args})")
 
 CONSTRUCTOR = CodeTemplate("""\
 {"${descriptor}", [](Node *node) {
-  ${assignments}
+  ${kw_assignments}
   return TensorOp([=](Stack & stack) {
     autograd::profiler::RecordFunction record("${name}");
-    AutoGPU device_guard(deviceForInputs(stack, ${num_inputs}));
+    AutoGPU device_guard(deviceForInputs(stack, ${num_inputs} + ${num_dropped_args}));
+    ${pos_assignments}
+    ${pos_arg_drop}
     auto result = ${call};
     drop(stack, ${num_inputs});
     pack(stack, std::move(result));
@@ -51,18 +57,33 @@ CONSTRUCTOR = CodeTemplate("""\
 
 
 def is_jit_op(decl):
+    uses_tensors = any(arg['simple_type'] in {'Tensor', 'TensorList'} for arg in decl['arguments']) or \
+        'Tensor' in decl['method_of']
     return (not decl['api_name'].endswith('_') and
             not decl['name'].endswith('_out') and
             not any(arg['simple_type'] == 'Generator' for arg in decl['arguments']) and
             not any(arg['simple_type'] == 'SparseTensor' for arg in decl['arguments']) and
             not any(arg['simple_type'] == 'Storage' for arg in decl['arguments']) and
             not any(arg['simple_type'] == 'Type' for arg in decl['arguments']) and
-            any(arg['simple_type'] in {'Tensor', 'TensorList'} for arg in decl['arguments']) and
-            'Tensor' in decl['return_type'])
+            uses_tensors)
+
+
+skip_scalar_overload = {
+    'lt-2': [1], 'gt-2': [1], 'le-2': [1], 'ge-2': [1], 'eq-2': [1], 'ne-2': [1],
+    'pow-2': [0, 1], 'add-3': [1], 'sub-3': [1], 'mul-2': [1], 'div-2': [1],
+    'fmod-2': [1], 'remainder-2': [1]
+}
 
 
 def gen_jit_dispatch(declarations, out):
-    aten_decls = load_aten_declarations(declarations)
+    # We need to add methods implemented manually in TensorImpl
+    tensor_impl_methods = [{
+        'name': name,
+        'api_name': name,
+        'method_of': ['Tensor'],
+        'arguments': [{'name': 'self', 'simple_type': 'Tensor'}],
+    } for name in ['sizes', 'strides', 'dim']]
+    aten_decls = load_aten_declarations(declarations) + tensor_impl_methods
     jit_decls = [d for d in aten_decls if is_jit_op(d)]
 
     def is_tensor_arg(arg):
@@ -72,54 +93,104 @@ def gen_jit_dispatch(declarations, out):
     for decl in jit_decls:
         arguments = decl['arguments']
         name = decl['name']
-        scalar_args = [arg for arg in arguments if not is_tensor_arg(arg)]
         has_tensorlist = any(arg['simple_type'] == 'TensorList' for arg in arguments)
+        scalar_arg_idx = [i for i, arg in enumerate(arguments) if not is_tensor_arg(arg)]
+        num_tensor_args = sum(map(is_tensor_arg, arguments))
+        # TODO: support this
+        if has_tensorlist and (num_tensor_args != 1 or not is_tensor_arg(arguments[0])):
+            continue
 
-        # Descriptor is a unique identified for a particular overload of an op
-        attr_names = sorted([arg['name'] for arg in scalar_args])
-        num_inputs = len(arguments) - len(scalar_args) if not has_tensorlist else "*"
-        descriptor = '-'.join([decl['name'], str(num_inputs)] + attr_names)
+        # Right now, we generate dispatch methods that either take all non-tensor arguments
+        # as attributes, or don't use any attributes at all. In the future we might want to
+        # have something in the middle too (might be useful for e.g. constant propagation
+        # into attributes, as that would allow us to avoid reparsing tensors into scalar
+        # args at every invocation).
+        # NB: if there are no scalar args then both options on LHS are equivalent, so deduplicate them.
+        scalar_arg_idx_iter = ([], scalar_arg_idx) if scalar_arg_idx else ([],)
+        for pos_scalar_arg_idx in scalar_arg_idx_iter:
+            num_args = len(arguments)
+            num_inputs = num_tensor_args + len(pos_scalar_arg_idx) if not has_tensorlist else '*'
 
-        # All scalar args need to be assigned, so they can be captured by a lambda
-        assignments = [ATTR_ASSIGNMENT.substitute(type=arg['simple_type'],
-                                                  type_cast=TYPE_CASTS.get(arg['simple_type'], arg['simple_type']),
-                                                  name=arg['name'],
-                                                  method=ATTR_METHOD_MAP[arg['simple_type']])
-                       for arg in scalar_args]
-        if num_inputs == "*":
-            assignments.append('auto varargs_length = node->inputs().size();')
-            num_inputs = 'varargs_length'
+            # Scatter arguments into positional and keyword, and compute stack offsets
+            # of posiitional args.
+            pos_scalar_args, kw_scalar_args = [], []
+            scalar_stack_off, tensor_stack_off = [], []
+            for i, arg in enumerate(arguments):
+                # XXX: we currently support only TensorList ops that have a TensorList as
+                # the first argument, that is then followed by a number of positional args.
+                stack_off = (num_args if num_inputs == '*' else num_inputs) - i - 1
+                if is_tensor_arg(arg):
+                    tensor_stack_off.append(stack_off)
+                else:
+                    if i in pos_scalar_arg_idx:
+                        pos_scalar_args.append(arg)
+                        scalar_stack_off.append(stack_off)
+                    else:
+                        kw_scalar_args.append(arg)
 
-        # Generate the actuall ATen call. This gets a bit tricky because of
-        # TensorList arguments, and functions that are only available as methods.
-        if 'namespace' in decl['method_of']:
-            if has_tensorlist:
-                if sum(map(is_tensor_arg, arguments)) != 1:
-                    # TODO: support this
+            # Descriptor is a unique identifier for a particular overload of an op.
+            attr_names = sorted([arg['name'] for arg in kw_scalar_args])
+            descriptor = '-'.join([decl['name'], str(num_inputs)] + attr_names)
+
+            # If there are two overloads with the same descriptor, that differ only by a type of a
+            # single argument, where one of them takes a tensor, while another one takes an
+            # at::Scalar as a positional scalar arg, then prefer the tensor overload.
+            # It should get broadcasted correctly.
+            if descriptor in skip_scalar_overload:
+                if any(arguments[idx]['simple_type'] == 'Scalar'
+                       for idx in skip_scalar_overload[descriptor]):
                     continue
 
-                args = ['last(stack, varargs_length)' if is_tensor_arg(arg) else arg['name']
-                        for arg in arguments]
-            else:
-                tensor_id = iter(count(start=num_inputs, step=-1))
-                args = ['std::move(fromLast(stack,{}))'.format(
-                    next(tensor_id)) if is_tensor_arg(arg) else arg['name']
-                    for arg in arguments]
-            call = CALL_NAMESPACE.substitute(name=name, args=args)
-        else:
-            tensor_id = iter(count(start=num_inputs, step=-1))
-            args = ['std::move(fromLast(stack,{}))'.format(next(tensor_id)) if is_tensor_arg(arg) else arg['name']
-                    for arg in arguments]
-            call = CALL_METHOD.substitute(name=name, first=args[0], args=args[1:])
+            kw_assignments = [KW_ASSIGNMENT.substitute(type_cast=TYPE_CASTS.get(arg['simple_type'], arg['simple_type']),
+                                                       name=arg['name'],
+                                                       method=ATTR_METHOD_MAP[arg['simple_type']])
+                              for arg in kw_scalar_args]
+            if num_inputs == "*":
+                kw_assignments.append('size_t varargs_length = node->inputs().size();')
+                num_inputs = 'varargs_length'
+            pos_assignments = [POS_ASSIGNMENT.substitute(type=arg['simple_type'],
+                                                         name=arg['name'],
+                                                         arg_idx=arg_idx)
+                               for arg_idx, arg in zip(scalar_stack_off, pos_scalar_args)]
 
-        constructor = CONSTRUCTOR.substitute(descriptor=descriptor, name=name, call=call,
-                                             assignments=assignments,
-                                             num_inputs=num_inputs)
-        assert descriptor not in ops, descriptor
-        ops[descriptor] = constructor
+            # Generate the actuall ATen call. This gets a bit tricky because of
+            # TensorList arguments, and functions that are only available as methods.
+            pos_arg_drop = ''
+            num_dropped_args = 0
+            if 'namespace' in decl['method_of']:
+                if has_tensorlist:
+                    # We need to drop the scalar args following varargs before we use last
+                    if pos_scalar_args:
+                        num_dropped_args = len(pos_scalar_args)
+                        pos_arg_drop = 'drop(stack, {});'.format(num_dropped_args)
+                    args = ['last(stack, varargs_length)' if is_tensor_arg(arg) else arg['name']
+                            for arg in arguments]
+                else:
+                    tensor_id = iter(tensor_stack_off)
+                    args = ['std::move(fromLast(stack, {}))'.format(1 + next(tensor_id))
+                            if is_tensor_arg(arg) else arg['name']
+                            for arg in arguments]
+                call = CALL_NAMESPACE.substitute(name=name, args=args)
+            else:
+                tensor_id = iter(tensor_stack_off)
+                args = ['std::move(fromLast(stack, {}))'.format(1 + next(tensor_id))
+                        if is_tensor_arg(arg) else arg['name']
+                        for arg in arguments]
+                call = CALL_METHOD.substitute(name=name, first=args[0], args=args[1:])
+
+            constructor = CONSTRUCTOR.substitute(descriptor=descriptor, name=name,
+                                                 num_dropped_args=num_dropped_args,
+                                                 pos_arg_drop=pos_arg_drop,
+                                                 call=call,
+                                                 kw_assignments=kw_assignments,
+                                                 pos_assignments=pos_assignments,
+                                                 num_inputs=num_inputs)
+
+            assert descriptor not in ops, descriptor
+            ops[descriptor] = constructor
 
     # Sort the generated snippets to ensure that the generation is deterministic
-    env = {'constructors': sorted(list(ops.values()))}
+    env = {'constructors': sorted(ops.values())}
     write(out, 'aten_dispatch.h', ATEN_DISPATCH_H, env)
     write(out, 'aten_dispatch.cpp', ATEN_DISPATCH_CPP, env)
 

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -1,6 +1,7 @@
 #include "aten_dispatch.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/jit/interned_strings.h"
+#include "torch/csrc/jit/tensor_conversions.h"
 #include "torch/csrc/utils/functional.h"
 
 #include <unordered_map>
@@ -25,9 +26,15 @@ namespace {
 // copies.
 
 // pack takes the return values of aten functions pushes them onto the stack
+template<typename T>
+void pack(Stack & stack, T&& v) {
+  stack.push_back(as_tensor(std::move(v)));
+}
+template<>
 void pack(Stack & stack, Tensor&& v) {
   stack.push_back(std::move(v));
 }
+template<>
 void pack(Stack & stack, std::vector<Tensor>&& ts) {
   for(auto& t : ts) {
     stack.push_back(std::move(t));

--- a/torch/csrc/jit/tensor_conversions.h
+++ b/torch/csrc/jit/tensor_conversions.h
@@ -1,15 +1,90 @@
 #pragma once
 #include "ATen/ATen.h"
 
+#include <array>
+#include <type_traits>
+
+namespace torch { namespace jit {
+
+//////////////////////////////////////////////////////////////////////////////////
+// Tensor -> T conversion
+//////////////////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+template<typename T, typename EnableIf = void>
+struct tensor_as_impl {};
+
 template<typename T>
-static inline T tensor_as(at::Tensor&& t) = delete;
+struct tensor_as_impl<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+  T operator()(at::Tensor&& t) {
+    // workaround for 1-dim 1-element pytorch tensors until zero-dim
+    // tensors are fully supported
+    if(t.ndimension() == 1 && t.size(0) == 1) {
+      t = t[0];
+    }
+    return at::Scalar(t).to<T>();
+  }
+};
+
+template<size_t N>
+struct tensor_as_impl<std::array<bool, N>> {
+  std::array<bool, N> operator()(at::Tensor&& t) {
+    throw std::runtime_error("tensor_as<std::array<bool, N>>: NYI");
+  }
+};
 
 template<>
-inline int64_t tensor_as(at::Tensor&& t) {
-  // workaround for 1-dim 1-element pytorch tensors until zero-dim
-  // tensors are fully supported
-  if(t.ndimension() == 1 && t.size(0) == 1) {
-    t = t[0];
+struct tensor_as_impl<at::IntList> {
+  at::IntList operator()(at::Tensor&& t) {
+    if (t.type().scalarType() != at::ScalarType::Long)
+      throw std::runtime_error("Expected a LongTensor");
+    if (t.dim() != 1)
+      throw std::runtime_error("Expected a 1D LongTensor");
+    if (!t.is_contiguous())
+      throw std::runtime_error("Expected a contiguous LongTensor");
+    return at::IntList{t.data<int64_t>(), static_cast<size_t>(t.numel())};
   }
-  return at::Scalar(t).to<int64_t>();
+};
+
+template<>
+struct tensor_as_impl<at::Scalar> {
+  at::Scalar operator()(at::Tensor&& t) {
+    return at::Scalar(t.view({}));
+  }
+};
+
 }
+
+template<typename T>
+inline T tensor_as(at::Tensor&& t) {
+  return detail::tensor_as_impl<T>()(std::move(t));
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// T -> Tensor conversion
+//////////////////////////////////////////////////////////////////////////////////
+
+inline at::Tensor as_tensor(int64_t v) {
+  return at::Scalar(v).toTensor();
+}
+
+inline at::Tensor as_tensor(double v) {
+  return at::Scalar(v).toTensor();
+}
+
+inline at::Tensor as_tensor(bool v) {
+  return at::Scalar(v).toTensor();
+}
+
+inline at::Tensor as_tensor(at::IntList l) {
+  return at::CPU(at::kLong).tensorFromBlob(const_cast<void*>(reinterpret_cast<const void*>(l.data())),
+                                           {static_cast<int64_t>(l.size())}).clone();
+}
+
+
+inline at::Tensor as_tensor(at::Scalar&& s) {
+  return s.toTensor();
+}
+
+}} // namespace torch::jit


### PR DESCRIPTION
This will be needed to e.g. dynamically specify scalar arguments in JIT script.