### PR TITLE
Raise an error if target is out-of-bounds in ClassNLLCriterion

### DIFF
--- a/aten/src/THCUNN/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/ClassNLLCriterion.cu
@@ -44,6 +44,7 @@ __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
     THCDeviceTensor<THCIndex_t, 1> target,
     THCDeviceTensor<Dtype, 1> output,
     Dtype *weights,
+    int n_classes,
     int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
@@ -52,6 +53,7 @@ __global__ void ClassNLLCriterion_updateOutput_no_reduce_kernel(
       output[index] = ScalarConvert<int, Dtype>::to(0);
       continue;
     }
+    assert(cur_target  >= 0 && cur_target  < n_classes);
     Dtype weight =
        weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1);
     output[index] = -weight * input[index][cur_target];
@@ -65,6 +67,7 @@ __global__ void ClassNLLCriterion_updateGradInput_no_reduce_kernel(
     THCDeviceTensor<Dtype, 1> gradOutput,
     THCDeviceTensor<Dtype, 2> gradInput,
     Dtype *weights,
+    int n_classes,
     int ignore_index) {
 
   CUDA_KERNEL_LOOP(index, batch_size) {
@@ -72,6 +75,7 @@ __global__ void ClassNLLCriterion_updateGradInput_no_reduce_kernel(
     if (cur_target == ignore_index) {
       continue;
     }
+    assert(cur_target  >= 0 && cur_target  < n_classes);
     Dtype weight =
        weights ? weights[cur_target] : ScalarConvert<int, Dtype>::to(1);
     gradInput[index][cur_target] = -weight * gradOutput[index];

--- a/aten/src/THCUNN/generic/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/ClassNLLCriterion.cu
@@ -57,7 +57,10 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         toDeviceTensor<THCIndex_t, 1>(state, target),
         toDeviceTensor<real, 1>(state, output),
         weights ? THCTensor_(data)(state, weights) : NULL,
+        n_classes,
         ignore_index);
+
+    THCudaCheck(cudaGetLastError());
 
     if (weights) {
       THCTensor_(free)(state, weights);
@@ -177,8 +180,11 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         toDeviceTensor<real, 1>(state, gradOutput),
         toDeviceTensor<real, 2>(state, gradInput),
         weights ? THCTensor_(data)(state, weights) : NULL,
+        n_classes,
         ignore_index);
- 
+
+    THCudaCheck(cudaGetLastError());
+
     if (weights) {
       THCTensor_(free)(state, weights);
     }


### PR DESCRIPTION
This PR is supposed to fix https://github.com/pytorch/pytorch/issues/5296

New behaviour:

```python
>>> import torch
>>> from torch.autograd import Variable
>>> import torch.nn.functional as F

>>> p = Variable(torch.randn(3, 3), requires_grad=True)
>>> y = Variable(torch.LongTensor([99, 100, 101]))
>>> l = F.cross_entropy(p, y, reduce=False)

RuntimeError: Target 100 out of bounds at /.../pytorch/aten/src/THNN/generic/ClassNLLCriterion.c:56
```

I'm not sure why `*_no_reduce` cuda kernels did not take `n_classes` as argument, was it meant to be that way? 