### PR TITLE
converted cudaMalloc to cudaMallocManaged

### DIFF
--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -360,14 +360,14 @@ struct THCCachingAllocator
   {
     // Try cudaMalloc. If cudaMalloc fails, frees all non-split cached blocks
     // and retries.
-    cudaError_t err = cudaMalloc(devPtr, size);
+    cudaError_t err = cudaMallocManaged(devPtr, size, CU_MEM_ATTACH_GLOBAL);
     if (err != cudaSuccess) {
       cudaGetLastError();
       err = free_cached_blocks(device);
       if (err != cudaSuccess) {
         return err;
       }
-      err = cudaMalloc(devPtr, size);
+      err = cudaMallocManaged(devPtr, size, CU_MEM_ATTACH_GLOBAL);
       if (err != cudaSuccess) {
         return err;
       }

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -37,7 +37,7 @@ void THCState_free(THCState* state)
 
 static cudaError_t cudaMallocWrapper(void* ctx, void** devPtr, size_t size, cudaStream_t stream)
 {
-  return cudaMalloc(devPtr, size);
+  return cudaMallocManaged(devPtr, size, CU_MEM_ATTACH_GLOBAL);
 }
 
 static cudaError_t cudaFreeWrapper(void* ctx, void* devPtr)


### PR DESCRIPTION
This PR enables CPU ram as a swap for GPU ram. I have simply changed  `cudaMalloc ` with `cudaMallocManaged`.  I tested it with a simple gemm on a pascal GPU with 2G ram with the following code:

```python
import numpy as np
import torch

my_list = []
for i in range(N):
    a = np.random.rand(4096, 4096).astype('float32')
    a = torch.Tensor(a).cuda()
    torch.mm(a, a)
    my_list.append(a)
```
It breaks with an ` N = 30` when the GPU ram is filled with the current pytorch implementation. But, with the new changes, when the GPU ram is at max, it stays at max and uses the cpu ram and it doesn't break even with `N = 100`.
@nouiz 