### PR TITLE
Disable test_multi_keep on Windows

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -132,6 +132,7 @@ class TestDataLoader(TestCase):
         dataiter = iter(dataloader)
         self.assertEqual(len(list(dataiter)), 1)
 
+    @unittest.skipIf(IS_WINDOWS, "FIXME: Intermittent CUDA out-of-memory error")
     def test_multi_keep(self):
         dataloader = torch.utils.data.DataLoader(self.dataset,
                                                  batch_size=self.batch_size,


### PR DESCRIPTION
`test_multi_keep` causes the same CUDA out-of-memory error as `test_multi_drop`, which showed up in this build: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test/1829/console. 

Disabling it now until we find a proper fix. Added to https://github.com/pytorch/pytorch/issues/4092.