### PR TITLE
extern C guards around some TH headers

### DIFF
--- a/aten/src/TH/THLapack.h
+++ b/aten/src/TH/THLapack.h
@@ -21,7 +21,14 @@ if (info < 0) {                                                     \
   THError(fmt, func, info, ##__VA_ARGS__);                          \
 }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "generic/THLapack.h"
 #include "THGenerateAllTypes.h"
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/aten/src/TH/THRandom.h
+++ b/aten/src/TH/THRandom.h
@@ -3,6 +3,9 @@
 
 #include "THGeneral.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define _MERSENNE_STATE_N 624
 #define _MERSENNE_STATE_M 397
 
@@ -85,4 +88,7 @@ TH_API int THRandom_geometric(THGenerator *_generator, double p);
 
 /* Returns true with probability $p$ and false with probability $1-p$ (p > 0). */
 TH_API int THRandom_bernoulli(THGenerator *_generator, double p);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -7,6 +7,9 @@
 #define THTensor          TH_CONCAT_3(TH,Real,Tensor)
 #define THTensor_(NAME)   TH_CONCAT_4(TH,Real,Tensor_,NAME)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* basics */
 #include "generic/THTensor.h"
 #include "THGenerateAllTypes.h"
@@ -38,5 +41,7 @@
 /* lapack support */
 #include "generic/THTensorLapack.h"
 #include "THGenerateFloatTypes.h"
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/aten/src/TH/THVector.h
+++ b/aten/src/TH/THVector.h
@@ -6,9 +6,14 @@
 
 #define THVector_(NAME) TH_CONCAT_4(TH,Real,Vector_,NAME)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* We are going to use dynamic dispatch, and want only to generate declarations
  * of the vector functions */
 #include "generic/THVector.h"
 #include "THGenerateAllTypes.h"
-
+#ifdef __cplusplus
+}
+#endif
 #endif // TH_VECTOR_INC

--- a/aten/src/TH/vector/AVX.h
+++ b/aten/src/TH/vector/AVX.h
@@ -3,6 +3,9 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void THDoubleVector_copy_AVX(double *y, const double *x, const ptrdiff_t n);
 void THDoubleVector_fill_AVX(double *x, const double c, const ptrdiff_t n);
 void THDoubleVector_cdiv_AVX(double *z, const double *x, const double *y, const ptrdiff_t n);
@@ -19,5 +22,7 @@ void THFloatVector_cmul_AVX(float *z, const float *x, const float *y, const ptrd
 void THFloatVector_muls_AVX(float *y, const float *x, const float c, const ptrdiff_t n);
 void THFloatVector_cadd_AVX(float *z, const float *x, const float *y, const float c, const ptrdiff_t n);
 void THFloatVector_adds_AVX(float *y, const float *x, const float c, const ptrdiff_t n);
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/aten/src/TH/vector/AVX2.h
+++ b/aten/src/TH/vector/AVX2.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct THGenerator;
 
 void THDoubleVector_cadd_AVX2(double *z, const double *x, const double *y, const double c, const ptrdiff_t n);
@@ -13,5 +16,7 @@ void THFloatVector_normal_fill_AVX2(float *data,
                                     struct THGenerator *generator,
                                     const float mean,
                                     const float stddev);
-
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
The order in which certain files are compiled / included (in a custom build system) matters between resolving these declarations as C or C++, because TH now has .cpp files