### PR TITLE
Remove _out variants of like functions.

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -16,20 +16,12 @@ Tensor ones_like(const Tensor& self) {
   return self.type().ones(self.sizes());
 }
 
-Tensor& ones_like_out(Tensor& result, const Tensor& self) {
-  return self.type().ones_out(result, self.sizes());
-}
-
 Tensor ones_like(const Tensor& self, const Type& dtype) {
   return dtype.ones(self.sizes());
 }
 
 Tensor rand_like(const Tensor& self) {
   return self.type().rand(self.sizes());
-}
-
-Tensor& rand_like_out(Tensor& result, const Tensor& self) {
-  return self.type().rand_out(result, self.sizes());
 }
 
 Tensor rand_like(const Tensor& self, const Type& dtype) {
@@ -40,20 +32,12 @@ Tensor randn_like(const Tensor& self) {
   return self.type().randn(self.sizes());
 }
 
-Tensor& randn_like_out(Tensor& result, const Tensor& self) {
-  return self.type().randn_out(result, self.sizes());
-}
-
 Tensor randn_like(const Tensor& self, const Type& dtype) {
   return dtype.randn(self.sizes());
 }
 
 Tensor zeros_like(const Tensor& self) {
   return self.type().zeros(self.sizes());
-}
-
-Tensor& zeros_like_out(Tensor& result, const Tensor& self) {
-  return self.type().zeros_out(result, self.sizes());
 }
 
 Tensor zeros_like(const Tensor& self, const Type& dtype) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -264,9 +264,6 @@
 - func: ones_like(Tensor self) -> Tensor
   variants: function
 
-- func: ones_like_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-
 - func: ones_like(Tensor self, Type dtype) -> Tensor
   variants: function
 
@@ -278,16 +275,10 @@
 - func: rand_like(Tensor self) -> Tensor
   variants: function
 
-- func: rand_like_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-
 - func: rand_like(Tensor self, Type dtype) -> Tensor
   variants: function
 
 - func: randn_like(Tensor self) -> Tensor
-  variants: function
-
-- func: randn_like_out(Tensor result, Tensor self) -> Tensor
   variants: function
 
 - func: randn_like(Tensor self, Type dtype) -> Tensor
@@ -385,9 +376,6 @@
     CUDA: _s_where_cuda
 
 - func: zeros_like(Tensor self) -> Tensor
-  variants: function
-
-- func: zeros_like_out(Tensor result, Tensor self) -> Tensor
   variants: function
 
 - func: zeros_like(Tensor self, Type dtype) -> Tensor


### PR DESCRIPTION
These now have dtypes, which matches the numpy API.