### PR TITLE
Various dtype improvements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -599,6 +599,7 @@ if WITH_CUDA:
         "torch/csrc/cuda/comm.cpp",
         "torch/csrc/cuda/python_comm.cpp",
         "torch/csrc/cuda/expand_utils.cpp",
+        "torch/csrc/cuda/lazy_init.cpp",
         "torch/csrc/cuda/serialization.cpp",
     ]
     main_sources += split_types("torch/csrc/cuda/Tensor.cpp", ninja_global)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1110,33 +1110,56 @@ class TestTorch(TestCase):
         res1 = torch.autograd.variable([1, 1])
         self.assertEqual(res1, expected)
 
+        res1 = torch.autograd.variable([1, 1], dtype=torch.int)
+        self.assertEqual(res1, expected)
+        self.assertIs(torch.int, res1.dtype)
+
         # test copy
         res2 = torch.autograd.variable(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
         self.assertEqual(expected, torch.ones_like(expected))
 
+        res2 = torch.autograd.variable(expected, dtype=torch.int)
+        self.assertEqual(res1, expected)
+        self.assertIs(torch.int, res1.dtype)
+
     def test_new_tensor(self):
         expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
         # test data
         res1 = expected.new_tensor([1, 1])
         self.assertEqual(res1, expected)
+        res1 = expected.new_tensor([1, 1], dtype=torch.int)
+        self.assertEqual(res1, expected)
+        self.assertIs(torch.int, res1.dtype)
 
         # test copy
         res2 = expected.new_tensor(expected)
         self.assertEqual(res2, expected)
         res2[1] = 2
         self.assertEqual(expected, torch.ones_like(expected))
+        res2 = expected.new_tensor(expected, dtype=torch.int)
+        self.assertEqual(res2, expected)
+        self.assertIs(torch.int, res2.dtype)
 
         if torch.cuda.device_count() >= 2:
             expected = expected.cuda(1)
             res1 = expected.new_tensor([1, 1])
             self.assertEqual(res1.get_device(), expected.get_device())
+            res1 = expected.new_tensor([1, 1], dtype=torch.cuda.int)
+            self.assertIs(torch.cuda.int, res1.dtype)
+            self.assertEqual(res1.get_device(), expected.get_device())
 
             res2 = expected.new_tensor(expected)
             self.assertEqual(res2.get_device(), expected.get_device())
+            res2 = expected.new_tensor(expected, dtype=torch.cuda.int)
+            self.assertIs(torch.cuda.int, res1.dtype)
+            self.assertEqual(res2.get_device(), expected.get_device())
 
             res1 = expected.new_tensor(1)
+            self.assertEqual(res1.get_device(), expected.get_device())
+            res1 = expected.new_tensor(1, dtype=torch.cuda.int)
+            self.assertIs(torch.cuda.int, res1.dtype)
             self.assertEqual(res1.get_device(), expected.get_device())
 
     def test_diag(self):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -71,7 +71,7 @@ if (r.isNone(${out_idx})) {
   ${call_dispatch}
 } else {
   if (!r.isNone(${dtype_idx})) {
-    check_out_dtype_matches(r.tensor(${out_idx}), r.dtype(${dtype_idx}));
+    check_out_dtype_matches(r.tensor(${out_idx}), r.type(${dtype_idx}));
   }
   ${call_dispatch_out}
 }
@@ -199,7 +199,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         'Tensor &': 'tensor',
         'Generator *': 'generator',
         'Storage &': 'storage',
-        'const Type &': 'dtype',
+        'const Type &': 'type',
         'int64_t': 'toInt64',
         'bool': 'toBool',
         'double': 'toDouble',
@@ -274,8 +274,6 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 dispatch_type = 'const Tensor &'
             elif dispatch_type == 'Tensor &':
                 dispatch_type = 'Tensor'
-            elif dispatch_type == 'dtype':
-                dispatch_type = 'const Type &'
             formal = '{} {}'.format(dispatch_type, name)
             return expr, formal
 
@@ -520,8 +518,6 @@ def get_python_signature(declaration, include_out):
 
     def get_typed_arg(arg):
         typename = arg['simple_type']
-        if typename == 'Type':
-            typename = 'dtype'
         if arg.get('is_nullable'):
             typename = '{}?'.format(typename)
         if arg.get('size') is not None:

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -3,6 +3,7 @@
 // ${generated_comment}
 
 #include <ATen/ATen.h>
+#include "torch/csrc/cuda/lazy_init.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
 #include "torch/csrc/autograd/generated/VariableType.h"
@@ -29,19 +30,9 @@ static at::Type& default_type() {
   return *VariableType::getType(*THPDefaultATenType);
 }
 
-static void lazy_init_cuda() {
-  static std::once_flag once;
-  std::call_once(once, []() {
-    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
-    if (!module) throw python_error();
-    auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
-    if (!res) throw python_error();
-  });
-}
-
 static void maybe_initialize_cuda(const at::Type &type) {
   if (type.is_cuda()) {
-    lazy_init_cuda();
+    torch::cuda::lazy_init();
   }
 }
 

--- a/torch/csrc/cuda/lazy_init.cpp
+++ b/torch/csrc/cuda/lazy_init.cpp
@@ -1,0 +1,23 @@
+#include "lazy_init.h"
+
+#include <Python.h>
+#include <mutex>
+
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/utils/object_ptr.h"
+
+namespace torch {
+namespace cuda {
+
+void lazy_init() {
+  static std::once_flag once;
+  std::call_once(once, []() {
+    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
+    if (!module) throw python_error();
+    auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
+    if (!res) throw python_error();
+  });
+}
+
+}
+}

--- a/torch/csrc/cuda/lazy_init.h
+++ b/torch/csrc/cuda/lazy_init.h
@@ -1,21 +1,9 @@
-#include <Python.h>
-#include <mutex>
-
-#include "torch/csrc/Exceptions.h"
-#include "torch/csrc/utils/object_ptr.h"
+#pragma once
 
 namespace torch {
 namespace cuda {
 
-static void lazy_init() {
-  static std::once_flag once;
-  std::call_once(once, []() {
-    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
-    if (!module) throw python_error();
-    auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
-    if (!res) throw python_error();
-  });
-}
+void lazy_init();
 
 }
 }

--- a/torch/csrc/cuda/lazy_init.h
+++ b/torch/csrc/cuda/lazy_init.h
@@ -1,0 +1,21 @@
+#include <Python.h>
+#include <mutex>
+
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/utils/object_ptr.h"
+
+namespace torch {
+namespace cuda {
+
+static void lazy_init() {
+  static std::once_flag once;
+  std::call_once(once, []() {
+    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
+    if (!module) throw python_error();
+    auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
+    if (!res) throw python_error();
+  });
+}
+
+}
+}

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -23,7 +23,7 @@ static std::unordered_map<std::string, ParameterType> type_map = {
   {"bool", ParameterType::BOOL},
   {"Storage", ParameterType::STORAGE},
   {"PyObject*", ParameterType::PYOBJECT},
-  {"dtype", ParameterType::DTYPE},
+  {"Type", ParameterType::TYPE},
 };
 
 FunctionParameter::FunctionParameter(const std::string& fmt, bool keyword_only)
@@ -108,7 +108,7 @@ bool FunctionParameter::check(PyObject* obj) {
     case ParameterType::BOOL: return PyBool_Check(obj);
     case ParameterType::STORAGE: return isStorage(obj);
     case ParameterType::PYOBJECT: return true;
-    case ParameterType::DTYPE: return THPDtype_Check(obj);
+    case ParameterType::TYPE: return THPDtype_Check(obj);
     default: throw std::runtime_error("unknown parameter type");
   }
 }
@@ -125,7 +125,7 @@ std::string FunctionParameter::type_name() const {
     case ParameterType::BOOL: return "bool";
     case ParameterType::STORAGE: return "torch.Storage";
     case ParameterType::PYOBJECT: return "object";
-    case ParameterType::DTYPE: return "torch.dtype";
+    case ParameterType::TYPE: return "torch.dtype";
     default: throw std::runtime_error("unknown parameter type");
   }
 }
@@ -156,9 +156,9 @@ void FunctionParameter::set_default_str(const std::string& str) {
     if (str != "None") {
       default_intlist.assign(size, std::stoi(str));
     }
-  } else if (type_ == ParameterType::DTYPE) {
+  } else if (type_ == ParameterType::TYPE) {
     if (str != "None") {
-      throw std::runtime_error("default value for dtype must be none, got: " + str);
+      throw std::runtime_error("default value for Type must be none, got: " + str);
     }
   }
 }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 
 #include "torch/csrc/Exceptions.h"
+#include "torch/csrc/cuda/lazy_init.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"
 #include "torch/csrc/utils/python_arg_parser.h"
@@ -18,6 +19,12 @@ static const int MAX_DIMS = 128;
 using namespace at;
 
 namespace torch { namespace utils {
+
+static void maybe_initialize_cuda(const at::Type &type) {
+  if (type.is_cuda()) {
+    torch::cuda::lazy_init();
+  }
+}
 
 static Tensor new_with_sizes(const Type& type, int device, IntList sizes) {
   AutoNoGIL no_gil;
@@ -39,9 +46,7 @@ static Tensor new_with_tensor(const Type& type, Tensor other) {
 }
 
 static Tensor new_with_tensor_copy(const Type& type, Tensor other) {
-  if (other.type() != type) {
-    throw TypeError("expected %s (got %s)", type.toString(), other.type().toString());
-  }
+  maybe_initialize_cuda(type);
   return type.copy(other);
 }
 
@@ -98,11 +103,9 @@ static Tensor new_from_data(ScalarType scalarType, PyObject* data) {
 #endif
 
   auto sizes = compute_sizes(data);
-  // TODO: we should pass tensor.sizes() rather than sizes, but this doesn't works
-  // if scalars are disabled because the size changes without WITH_SCALARS.
   auto tensor = autograd::make_variable(CPU(scalarType).tensor(sizes), /*requires_grad=*/false);
   recursive_store(
-      (char*)tensor.data_ptr(), sizes, tensor.strides(), 0,
+      (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
       scalarType, tensor.type().elementSizeInBytes(), data);
   return tensor;
 }
@@ -110,6 +113,7 @@ static Tensor new_from_data(ScalarType scalarType, PyObject* data) {
 Tensor new_from_data(const Type & type, int device, PyObject *data) {
   auto tensor = new_from_data(type.scalarType(), data);
   if (tensor.type() != type) {
+    maybe_initialize_cuda(type);
     AutoNoGIL no_gil;
     AutoGPU auto_gpu(device);
     tensor = tensor.toType(type);
@@ -204,16 +208,16 @@ static Tensor set_requires_grad(Tensor self, bool requires_grad) {
 
 Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
   static PythonArgParser parser({
-    "new(Tensor other, *, bool requires_grad=False)",
-    "new(PyObject* data, *, int64_t? device=-1, bool requires_grad=False)",
+    "new_tensor(Tensor other, *, Type dtype=None, bool requires_grad=False)",
+    "new_tensor(PyObject* data, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
   });
 
   PyObject* parsed_args[3];
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
-    return set_requires_grad(new_with_tensor_copy(type, r.tensor(0)), r.toBool(1));
+    return set_requires_grad(new_with_tensor_copy(r.typeWithDefault(1, type), r.tensor(0)), r.toBool(2));
   } else if (r.idx == 1) {
-    return set_requires_grad(new_from_data(type, r.toInt64(1), r.pyobject(0)), r.toBool(2));
+    return set_requires_grad(new_from_data(r.typeWithDefault(1, type), r.toInt64(2), r.pyobject(0)), r.toBool(3));
   }
   throw std::runtime_error("new_tensor(): invalid arguments");
 }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -212,7 +212,7 @@ Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
     "new_tensor(PyObject* data, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
   });
 
-  PyObject* parsed_args[3];
+  PyObject* parsed_args[4];
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     return set_requires_grad(new_with_tensor_copy(r.typeWithDefault(1, type), r.tensor(0)), r.toBool(2));


### PR DESCRIPTION
1) Add dtypes to the new data-based constructors: Variable.new_tensor and torch.autograd.variable.
2) In the python signatures, use Type instead of Dtype to match the C++	signatures; the error messages still print as dtype.
3) Handle / add a better error message when a dtype is used when ATen was not compiled with that type (e.g. cuda types).
4) Move cuda_lazy_init to its own file.

A later commit will add support to the legacy constructors as well.