### PR TITLE
Fix input size checks in ATen for SpatialFractionalMaxPooling

### DIFF
--- a/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialFractionalMaxPooling.cu
@@ -32,10 +32,10 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int64_t inputH = THCTensor_(size)(state, input, dimh);
   int64_t inputW = THCTensor_(size)(state, input, dimw);
 
-  THArgCheck(outputH + poolSizeH - 1 < inputH, 6,
+  THArgCheck(outputH + poolSizeH - 1 <= inputH, 6,
              "poolSizeH (%d) too large relative to input height (%d)",
              poolSizeH, inputH);
-  THArgCheck(outputW + poolSizeW - 1 < inputW, 5,
+  THArgCheck(outputW + poolSizeW - 1 <= inputW, 5,
              "poolSizeW (%d) too large relative to input width (%d)",
              poolSizeW, inputW);
 

--- a/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialFractionalMaxPooling.c
@@ -118,10 +118,10 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int64_t inputH = THTensor_(size)(input, heightDim);
   int64_t inputW = THTensor_(size)(input, widthDim);
 
-  THArgCheck(outputH + poolSizeH - 1 < inputH, 7,
+  THArgCheck(outputH + poolSizeH - 1 <= inputH, 7,
              "poolSizeH (%d) too large relative to input height (%d)",
 	     poolSizeH, inputH);
-  THArgCheck(outputW + poolSizeW - 1 < inputW, 6,
+  THArgCheck(outputW + poolSizeW - 1 <= inputW, 6,
              "poolSizeW (%d) too large relative to input width (%d)",
 	     poolSizeW, inputW);
 


### PR DESCRIPTION
The THArgChecks in ATen/THNN/THCUNN for PyTorch's nn.FractionalMaxPool2d are tighter than necessary, using '<' rather than '<='. This makes it impossible for example to downsample from say (5,7) to (1,2) with poolSize=(5,5). 
