### PR TITLE
Delete S3 image only when Windows test is successful

### DIFF
--- a/.jenkins/win-test.sh
+++ b/.jenkins/win-test.sh
@@ -70,10 +70,9 @@ set CUDNN_ROOT_DIR=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0
 cd test/
 
 python ..\\ci_scripts\\download_image.py %IMAGE_COMMIT_TAG%.7z
-python ..\\ci_scripts\\delete_image.py
 
 7z x %IMAGE_COMMIT_TAG%.7z
-sh run_test.sh -- -v
+sh run_test.sh -- -v && python ..\\ci_scripts\\delete_image.py
 
 EOL
 


### PR DESCRIPTION
Currently when a test fails on Windows CI, there is no way to recover the workspace for debugging because the image is already deleted before the tests are run. This diff moves the delete image step to be after `sh run_test.sh` so that only successful test jobs will have their images cleaned up.