### PR TITLE
Inside conda, prefer conda versions of libraries.

### DIFF
--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -33,8 +33,9 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         'CPLUS_INCLUDE_PATH',
     ])))
     if IS_CONDA:
-        lib_paths.append(os.path.join(CONDA_DIR, 'lib'))
-        include_paths.append(os.path.join(CONDA_DIR, 'include'))
+        # Prefer conda libs over system ones.
+        lib_paths.insert(0, os.path.join(CONDA_DIR, 'lib'))
+        include_paths.insert(0, os.path.join(CONDA_DIR, 'include'))
     for path in lib_paths:
         if path is None or not os.path.exists(path):
             continue
@@ -47,6 +48,7 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
         else:
             libraries = sorted(glob.glob(os.path.join(path, 'libcudnn*')))
             if libraries:
+                # Prefer, e.g., 'libcudnn.so' without a version number.
                 CUDNN_LIBRARY = libraries[0]
                 CUDNN_LIB_DIR = path
                 break

--- a/tools/setup_helpers/dist_check.py
+++ b/tools/setup_helpers/dist_check.py
@@ -82,8 +82,9 @@ def should_build_ib():
     ]
 
     if IS_CONDA:
-        lib_paths.append(os.path.join(CONDA_DIR, "lib"))
-        include_paths.append(os.path.join(CONDA_DIR, "include"))
+        # Prefer conda libs over system ones.
+        lib_paths.insert(0, os.path.join(CONDA_DIR, 'lib'))
+        include_paths.insert(0, os.path.join(CONDA_DIR, "include"))
 
     for path in lib_paths:
         if path is None or not os.path.exists(path):

--- a/tools/setup_helpers/nccl.py
+++ b/tools/setup_helpers/nccl.py
@@ -44,7 +44,8 @@ if WITH_CUDA and not check_env_flag('NO_SYSTEM_NCCL'):
     ]))
 
     if IS_CONDA:
-        lib_paths.append(os.path.join(CONDA_DIR, 'lib'))
+        # Prefer conda libs over system ones.
+        lib_paths.insert(0, os.path.join(CONDA_DIR, 'lib'))
     for path in lib_paths:
         path = os.path.expanduser(path)
         if path is None or not os.path.exists(path):


### PR DESCRIPTION
Fixes #4860 when building inside a conda enviornment.

When libcudnn is provided by anaconda and also available on the system, it causes linking problems to link with the system versions.  This change changes the search order to prefer the anaconda versions if present.  Other libraries with a similar search are similarly changed to prefer anaconda versions.