### PR TITLE
Embedding.from_pretrained factory

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1152,6 +1152,15 @@ class TestNN(NNTestCase):
         self.assertEqual(output[1], output[2])
         self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
 
+    def test_embedding_from_pretrained(self):
+        a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
+        embedding = nn.Embedding.from_pretrained(a)
+        self.assertEqual(a, embedding.weight.data)
+
+        input = Variable(torch.LongTensor([0, 1]))
+        output = embedding(input)
+        self.assertEqual(a, output)
+
     def test_embedding_functional(self):
         a = Variable(torch.LongTensor([
             [1, 3, 2],

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -75,7 +75,7 @@ class Embedding(Module):
 
     def __init__(self, num_embeddings, embedding_dim, padding_idx=None,
                  max_norm=None, norm_type=2, scale_grad_by_freq=False,
-                 sparse=False, weight=None):
+                 sparse=False, _weight=None):
         super(Embedding, self).__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
@@ -89,15 +89,14 @@ class Embedding(Module):
         self.max_norm = max_norm
         self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
-        if weight is None:
+        if _weight is None:
             self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
             self.reset_parameters()
         else:
-            assert list(weight.shape) == [num_embeddings, embedding_dim], \
+            assert list(_weight.shape) == [num_embeddings, embedding_dim], \
                 'Shape of weight does not match num_embeddings and embedding_dim'
-            self.weight = Parameter(weight)
+            self.weight = Parameter(_weight)
         self.sparse = sparse
-
 
     def reset_parameters(self):
         self.weight.data.normal_(0, 1)
@@ -125,10 +124,11 @@ class Embedding(Module):
         return s.format(name=self.__class__.__name__, **self.__dict__)
 
     @classmethod
-    def load_pretrained(cls, embeddings, freeze=True):
+    def from_pretrained(cls, embeddings, freeze=True):
+        assert embeddings.dim() == 2, \
+            'Embeddings parameter is expected to be 2-dimensional'
         rows, cols = embeddings.shape
-        print(embeddings)
-        embedding = cls(num_embeddings=rows, embedding_dim=cols, weight=embeddings)
+        embedding = cls(num_embeddings=rows, embedding_dim=cols, _weight=embeddings)
         embedding.weight.requires_grad = not freeze
         return embedding
 

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -125,6 +125,25 @@ class Embedding(Module):
 
     @classmethod
     def from_pretrained(cls, embeddings, freeze=True):
+        r"""Creates Embedding instance from given 2-dimensional FloatTensor.
+
+        Args:
+            embeddings (Tensor): FloatTensor containing weights for the Embedding. First dimension is being passed to Embedding as 'num_embeddings', second as 'embedding_dim'.
+            freeze (boolean, optional): If ``True``, the tensor does not get updated in the learning process. Equivalent to ``embedding.weight.requires_grad = False``. Default: ``True``
+
+        Examples::
+
+            >> # FloatTensor containing pretrained weights
+            >> weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
+            >> embedding = nn.Embedding.from_pretrained(weight)
+            >> # Get embeddings for index 1
+            >> input = Variable(torch.LongTensor([1]))
+            >> embedding(input)
+
+            Variable containing:
+             4.0000  5.1000  6.3000
+            [torch.FloatTensor of size (1,3)]
+        """
         assert embeddings.dim() == 2, \
             'Embeddings parameter is expected to be 2-dimensional'
         rows, cols = embeddings.shape

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -93,7 +93,6 @@ class Embedding(Module):
             self.weight = Parameter(torch.Tensor(num_embeddings, embedding_dim))
             self.reset_parameters()
         else:
-            assert weight.dim() == 2, 'Weight must be 2-dimensional'
             assert list(weight.shape) == [num_embeddings, embedding_dim], \
                 'Shape of weight does not match num_embeddings and embedding_dim'
             self.weight = Parameter(weight)

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -128,8 +128,10 @@ class Embedding(Module):
         r"""Creates Embedding instance from given 2-dimensional FloatTensor.
 
         Args:
-            embeddings (Tensor): FloatTensor containing weights for the Embedding. First dimension is being passed to Embedding as 'num_embeddings', second as 'embedding_dim'.
-            freeze (boolean, optional): If ``True``, the tensor does not get updated in the learning process. Equivalent to ``embedding.weight.requires_grad = False``. Default: ``True``
+            embeddings (Tensor): FloatTensor containing weights for the Embedding.
+                First dimension is being passed to Embedding as 'num_embeddings', second as 'embedding_dim'.
+            freeze (boolean, optional): If ``True``, the tensor does not get updated in the learning process.
+                Equivalent to ``embedding.weight.requires_grad = False``. Default: ``True``
 
         Examples::
 


### PR DESCRIPTION
Solves #4801 
Docs and tests to be done after maintainers review the changes.
My issues:

1. `nn.Embedding.load_pretrained` currently has only two parameters: `embeddings` and `freeze`. Should I include more? 
2. `nn.Embedding` now has weight parameter that defaults to `None` as well as `num_embeddings` and `embedding_dim` - that's redundant.
3. Considering the above, maybe it would be better to create a subclass instead of a class method?