### PR TITLE
Add a disabled-configs.txt interlock.

### DIFF
--- a/.jenkins/common.sh
+++ b/.jenkins/common.sh
@@ -72,9 +72,16 @@ trap_add cleanup EXIT
 # you will have to adjust this.
 COMPACT_JOB_NAME="$(echo "$JOB_NAME" | perl -pe 's{^(?:.+/)?(.+)$}{$1}o')"
 
+if grep --line-regexp -q "$COMPACT_JOB_NAME" "$(dirname "${BASH_SOURCE[0]}")/disabled-configs.txt"; then
+  echo "Test is explicitly disabled, SKIPPING"
+  exit 0
+else
+  echo "Test is not disabled, proceeding"
+fi
+
 if grep --line-regexp -q "$COMPACT_JOB_NAME" "$(dirname "${BASH_SOURCE[0]}")/enabled-configs.txt"; then
   echo "Test is enabled, proceeding"
 else
-  echo "Test is disabled, FAILING now (revert changes to enabled-configs.txt to fix this)"
+  echo "Test not enabled, FAILING now (revert changes to enabled-configs.txt to fix this)"
   exit 1
 fi

--- a/.jenkins/disabled-configs.txt
+++ b/.jenkins/disabled-configs.txt
@@ -1,0 +1,9 @@
+# This file contains a list of disabled configurations.  Disabled
+# configurations are skipped and not considered a failure if they
+# fail.  You can use this to temporarily reserve a test name to
+# turn on CI side before PyTorch repository supports it.  This
+# file has the same format as .jenkins/enabled-configs.txt
+
+pytorch-linux-xenial-py3-clang5-asan
+pytorch-linux-xenial-py3-clang5-asan-build
+pytorch-linux-xenial-py3-clang5-asan-test


### PR DESCRIPTION
This will make it easier to bring online new CI configurations
without temporarily breaking the CI, since you can mark it
as disabled in PyTorch HEAD first and then bring the job online.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>