### PR TITLE
Python-free build of autograd + jit

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -97,3 +97,12 @@ if [[ "$JOB_NAME" == *xenial-cuda8-cudnn6-py3* ]]; then
   make html
   popd
 fi
+
+# Test no-Python build
+if [[ "$JOB_NAME" == *pytorch-linux-xenial-cuda9-cudnn7-py3-build ]] || \
+   [[ "$JOB_NAME" == *pytorch-linux-trusty-py3.6-gcc7.2-build ]]; then
+   echo "Building libtorch with NO_PYTHON"
+   pushd tools/cpp_build || exit 1
+   bash build_all.sh
+   popd
+fi

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "VariableType.h"
 
 // ${generated_comment}

--- a/tools/cpp_build/build_all.sh
+++ b/tools/cpp_build/build_all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+cd $SCRIPTPATH
+
+PYTORCHPATH="$SCRIPTPATH/../../"
+
+if [ ! -d "$PYTORCHPATH/torch/csrc/autograd/generated" ]; then
+  echo "Generated files are not present.\nRun the generators through `python setup.py build` or copy the generated files over."
+  exit 1
+fi
+
+if [ -x "$(command -v nvcc)" ]; then
+  NO_CUDA=OFF
+else
+  NO_CUDA=ON
+fi
+
+ATEN_BUILDPATH="$SCRIPTPATH/build/aten-build"
+LIBTORCH_BUILDPATH="$SCRIPTPATH/build/libtorch-build"
+
+mkdir -p $ATEN_BUILDPATH && cd $ATEN_BUILDPATH
+cmake -DNO_CUDA:BOOL=$NO_CUDA -DAT_LINK_STYLE:STRING=SHARED -DCMAKE_INSTALL_PREFIX:PATH=$SCRIPTPATH/build/Install -DCMAKE_BUILD_TYPE:STRING=Release $PYTORCHPATH/aten
+make -j4 && make install
+
+mkdir -p $LIBTORCH_BUILDPATH && cd $LIBTORCH_BUILDPATH
+cmake -DCMAKE_BUILD_TYPE:STRING=RELEASE -DCMAKE_INSTALL_PREFIX:PATH=$SCRIPTPATH/build/Install $SCRIPTPATH/libtorch
+make -j4
+make install
+
+cd $SCRIPTPATH

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -1,0 +1,113 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0 FATAL_ERROR)
+CMAKE_POLICY(VERSION 3.0)
+
+SET(CMAKE_CXX_STANDARD 14)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+FIND_PATH(ATEN_INCLUDE_DIR ATen/ATen.h PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../build/Install/include/" NO_DEFAULT_PATH)
+FIND_LIBRARY(ATEN_LIBRARY ATen PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../build/Install/lib" NO_DEFAULT_PATH)
+
+FIND_PATH(TORCH_SRC_DIR torch.h PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../torch" NO_DEFAULT_PATH)
+
+ADD_DEFINITIONS(-DNO_PYTHON)
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORCE_INLINES")
+
+IF(NOT TORCH_INSTALL_BIN_DIR)
+  SET(TORCH_INSTALL_BIN_DIR bin)
+ENDIF(NOT TORCH_INSTALL_BIN_DIR)
+
+IF(NOT TORCH_INSTALL_INCLUDE_DIR)
+  SET(TORCH_INSTALL_INCLUDE_DIR include/libtorch)
+ENDIF(NOT TORCH_INSTALL_INCLUDE_DIR)
+
+IF(NOT TORCH_INSTALL_LIB_DIR)
+  SET(TORCH_INSTALL_LIB_DIR lib)
+ENDIF(NOT TORCH_INSTALL_LIB_DIR)
+
+# RPATH stuff
+# see https://cmake.org/Wiki/CMake_RPATH_handling
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH ON)
+endif()
+set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
+SET(TORCH_SRCS
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/saved_variable.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/grad_mode.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/function.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/functions/utils.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/functions/special.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/functions/basic_ops.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/functions/accumulate_grad.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/functions/tensor.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/variable.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/engine.cpp
+  ${TORCH_SRC_DIR}/csrc/assertions.cpp
+  ${TORCH_SRC_DIR}/csrc/utils/variadic.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/generated/aten_dispatch.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/variable_flags.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/interpreter.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/ir.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/graph_executor.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/fusion_compiler.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/graph_fuser.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/common_subexpression_elimination.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/shape_analysis.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/canonicalize.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/dead_code_elimination.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/peephole.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/inplace_check.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/create_autodiff_subgraphs.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/test_jit.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/interned_strings.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/compiler.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/tracer.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/tracer_state.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/type.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/interpreter_autograd_function.cpp
+  ${TORCH_SRC_DIR}/csrc/Exceptions.cpp
+  )
+
+ADD_LIBRARY(torch SHARED ${TORCH_SRCS})
+
+TARGET_LINK_LIBRARIES(torch ${ATEN_LIBRARY})
+
+TARGET_INCLUDE_DIRECTORIES(torch
+  PUBLIC
+  ${ATEN_INCLUDE_DIR}
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${TORCH_SRC_DIR}/../"
+  "${TORCH_SRC_DIR}/lib/nanopb"
+  )
+
+SET_TARGET_PROPERTIES(torch PROPERTIES VERSION 1 SOVERSION 1)
+
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")
+  SET_PROPERTY(TARGET torch PROPERTY CXX_STANDARD 11)
+endif(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")
+
+install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
+        DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
+        FILES_MATCHING PATTERN "*.h")
+
+INSTALL(TARGETS torch
+  RUNTIME DESTINATION "${TORCH_INSTALL_BIN_DIR}"
+  LIBRARY DESTINATION "${TORCH_INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${TORCH_INSTALL_LIB_DIR}")

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "aten_dispatch.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/jit/interned_strings.h"

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_PYTHON
 #include <Python.h>
 
 #include <utility>
@@ -101,3 +102,29 @@ ValueError::ValueError(const char *format, ...) {
 }
 
 } // namespace torch
+
+#else
+
+#include "Exceptions.h"
+
+#include <cstdarg>
+
+namespace torch {
+
+static std::string formatMessage(const char *format, va_list fmt_args) {
+  static const size_t ERROR_BUF_SIZE = 1024;
+  char error_buf[ERROR_BUF_SIZE];
+  vsnprintf(error_buf, ERROR_BUF_SIZE, format, fmt_args);
+  return std::string(error_buf);
+}
+
+ValueError::ValueError(const char *format, ...) {
+  va_list fmt_args;
+  va_start(fmt_args, format);
+  msg = formatMessage(format, fmt_args);
+  va_end(fmt_args);
+}
+
+} // namespace torch
+
+#endif

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -3,6 +3,9 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+
+#ifndef NO_PYTHON
+
 #include "THP_export.h"
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/auto_gil.h"
@@ -127,3 +130,22 @@ struct ValueError : public PyTorchError {
 };
 
 } // namespace torch
+
+#else
+
+namespace torch {
+
+struct PyTorchError : public std::exception {
+  virtual const char* what() const noexcept override {
+    return msg.c_str();
+  }
+  std::string msg;
+};
+
+struct ValueError : public PyTorchError {
+  ValueError(const char *format, ...);
+};
+
+} // namespace torch
+
+#endif

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -411,6 +411,13 @@ auto Engine::execute(const edge_list& input_roots,
   return graph_task.captured_vars;
 }
 
+#ifdef NO_PYTHON
+Engine& Engine::getDefaultEngine() {
+  static Engine engine;
+  return engine;
+}
+#endif
+
 void Engine::queue_callback(std::function<void()> callback) {
   std::lock_guard<std::mutex> lock(post_callbacks_lock);
   final_callbacks.emplace_back(std::move(callback));

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -3,7 +3,6 @@
 // Engine implements backpropagation from output variables and their gradients
 // to "root" variables (variables created by the user with requires_grad=True).
 
-#include <Python.h>
 #include <deque>
 #include <memory>
 #include <unordered_map>
@@ -39,6 +38,8 @@ struct Engine {
       const edge_list& outputs = {});
 
   void queue_callback(std::function<void()> callback);
+
+  static Engine& getDefaultEngine();
 
 protected:
   void compute_dependencies(Function* root, GraphTask& task);

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,5 +1,3 @@
-#include <Python.h>
-
 #include "torch/csrc/autograd/function.h"
 
 #include "torch/csrc/autograd/functions/special.h"
@@ -43,9 +41,11 @@ variable_list Function::traced_apply(variable_list inputs) {
     var_flags.push_back(VariableFlags::of(input));
   }
   auto* this_node = graph->createCppOp(get_shared_ptr(), std::move(var_flags));
+#ifndef NO_PYTHON
   this_node->setSourceLocation(std::make_shared<StringSourceLocation>(
         jit::tracer::getPythonInterpreterStackTrace()
   ));
+#endif
   for (auto& input: inputs) {
     this_node->addInput(tracer::getValueTrace(state, input));
   }

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -1,5 +1,3 @@
-#include <Python.h>
-
 #include "torch/csrc/autograd/functions/accumulate_grad.h"
 
 #include "torch/csrc/autograd/grad_mode.h"

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Python.h>
-
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/symbolic.h"

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -1,6 +1,3 @@
-#ifndef NO_PYTHON
-#include <Python.h>
-#endif
 #include "torch/csrc/autograd/functions/special.h"
 
 #include "torch/csrc/assertions.h"

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -1,10 +1,12 @@
+#ifndef NO_PYTHON
+#include <Python.h>
+#endif
 #include "torch/csrc/autograd/functions/special.h"
 
 #include "torch/csrc/assertions.h"
-#include "torch/csrc/autograd/python_engine.h"
+#include "torch/csrc/autograd/engine.h"
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function.h"
-#include "torch/csrc/autograd/edge.h"
 
 #include <cstdint>
 #include <memory>
@@ -289,7 +291,7 @@ variable_list Eval::apply(const variable_list& inputs) {
   if (simple_graph) {
     outputs = (*simple_graph)(inputs);
   } else {
-    auto& engine = python::PythonEngine::getDefaultEngine();
+    auto& engine = Engine::getDefaultEngine();
     auto exec_data = filterRoots(inputs);
     auto next_edges = fmap(
         placeholders,

--- a/torch/csrc/autograd/functions/special.h
+++ b/torch/csrc/autograd/functions/special.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Python.h>
-
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/autograd/engine.h"

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Python.h>
-
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Python.h>
-
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"
 

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -5,7 +5,6 @@
 // values in-place (adding an input twice will accumulate the result).
 // This behaviour needed and used only in backward graphs.
 
-#include <Python.h>
 #include <vector>
 #include <utility>
 #include <memory>

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/autograd/function.h"
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -23,6 +23,12 @@ struct THPEngine {
 
 static torch::autograd::python::PythonEngine engine;
 
+// Here we add a method of Engine so that we can use Engine::getDefaultEngine
+// throughout the code in both NO_PYTHON builds and regular builds
+Engine& torch::autograd::Engine::getDefaultEngine() {
+  return engine;
+}
+
 namespace torch { namespace autograd { namespace python {
 
 void PythonEngine::thread_init(int device) {
@@ -54,10 +60,6 @@ variable_list PythonEngine::execute(
     e.restore();
     throw;
   }
-}
-
-PythonEngine& PythonEngine::getDefaultEngine() {
-  return engine;
 }
 
 }}} // namespace torch::autograd::python

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -18,8 +18,6 @@ struct PythonEngine : public Engine {
       bool keep_graph,
       bool create_graph,
       const edge_list& outputs = {}) override;
-
-  static PythonEngine& getDefaultEngine();
 };
 
 }}} // namespace torch::autograd::python

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "torch/csrc/autograd/saved_variable.h"
 
 #include "torch/csrc/autograd/edge.h"

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/utils/python_stub.h"
 
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function_hook.h"

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include <iostream>
 #include <vector>
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/argument_spec.h"

--- a/torch/csrc/jit/interpreter_autograd_function.cpp
+++ b/torch/csrc/jit/interpreter_autograd_function.cpp
@@ -1,5 +1,3 @@
-#include <Python.h>
-
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1,11 +1,9 @@
+#ifndef NO_PYTHON
 #include <Python.h>
+#endif
 #include "ir.h"
 
-#include "torch/csrc/utils/auto_gil.h"
-#include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/autograd/function.h"
-
-#include "pybind11/pybind11.h"
 
 #include <iostream>
 #include <unordered_map>
@@ -16,11 +14,14 @@
 #include <algorithm>
 #include <string>
 
+#ifndef NO_PYTHON
+#include "torch/csrc/utils/auto_gil.h"
+#include "torch/csrc/utils/python_strings.h"
+#include "pybind11/pybind11.h"
+
 namespace py = pybind11;
 
 namespace torch { namespace jit {
-
-constexpr int max_tensor_display_size = 10;
 
 std::string getPythonName(const PyObject* obj, bool is_legacy) {
   AutoGIL gil;
@@ -34,26 +35,7 @@ std::string getPythonName(const PyObject* obj, bool is_legacy) {
     return THPUtils_unpackString(name.get());
   }
 }
-void printValueRef(std::ostream & out, const Value * n) {
-  out << "%" << n->uniqueName();
-}
 
-template <typename T>
-std::ostream& operator<<(std::ostream & out, const std::vector<T> & nodes) {
-  out << at::ArrayRef<T>{nodes};
-  return out;
-}
-
-template <typename T>
-std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
-  size_t i = 0;
-  for(auto n : nodes) {
-    if(i++ > 0)
-      out << ", ";
-    printValueRef(out, n);
-  }
-  return out;
-}
 std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
   AutoGIL gil;
   auto pyobj = py::handle(const_cast<PyObject*>(obj.get()));
@@ -95,6 +77,67 @@ std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
 
 std::string PythonOp::name() const {
   return getPythonName(pyobj.get(),is_legacy);
+}
+
+void PythonOp::cloneFrom(Node * other_) {
+  Node::cloneFrom(other_);
+  auto other = other_->cast<PythonOp>();
+  this->cconv = other->cconv;
+  this->is_legacy = other->is_legacy;
+  Py_INCREF(other->pyobj.get());
+  this->pyobj = THPObjectPtr(other->pyobj.get());
+  this->var_flags = other->var_flags;
+  for(auto & sa : other->scalar_args) {
+    Py_INCREF(sa.get());
+    this->scalar_args.emplace_back(sa.get());
+  }
+  this->tracing_autograd_python_function =
+      other->tracing_autograd_python_function;
+}
+
+}} // namespace torch::jit
+
+#else
+
+namespace torch { namespace jit {
+
+std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
+  throw std::runtime_error("Trying to print Python object from a C++ build");
+}
+
+std::string PythonOp::name() const {
+  throw std::runtime_error("Trying to call PythonOp::name from a C++ build");
+  return std::string();
+}
+
+}} // namespace torch::jit
+
+#endif
+
+
+namespace torch { namespace jit {
+
+constexpr int max_tensor_display_size = 10;
+
+void printValueRef(std::ostream & out, const Value * n) {
+  out << "%" << n->uniqueName();
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream & out, const std::vector<T> & nodes) {
+  out << at::ArrayRef<T>{nodes};
+  return out;
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream & out, const at::ArrayRef<T> & nodes) {
+  size_t i = 0;
+  for(auto n : nodes) {
+    if(i++ > 0)
+      out << ", ";
+    printValueRef(out, n);
+  }
+  return out;
 }
 
 std::string CppOp::name() const {
@@ -555,23 +598,6 @@ void LintGraph(std::shared_ptr<Graph>& graph) {
   graph->lint();
 }
 
-
-void PythonOp::cloneFrom(Node * other_) {
-  Node::cloneFrom(other_);
-  auto other = other_->cast<PythonOp>();
-  this->cconv = other->cconv;
-  this->is_legacy = other->is_legacy;
-  Py_INCREF(other->pyobj.get());
-  this->pyobj = THPObjectPtr(other->pyobj.get());
-  this->var_flags = other->var_flags;
-  for(auto & sa : other->scalar_args) {
-    Py_INCREF(sa.get());
-    this->scalar_args.emplace_back(sa.get());
-  }
-  this->tracing_autograd_python_function =
-      other->tracing_autograd_python_function;
-}
-
 void Block::cloneFrom(Block * src, std::function<Value*(Value*)> outer_map) {
   std::unordered_map<Value*, Value*> local_map;
   auto env = [&](Value * v) {
@@ -612,4 +638,4 @@ std::shared_ptr<Graph> Graph::copy() {
   return new_g;
 }
 
-}}
+}} // namespace torch::jit

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/argument_spec.h"

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "torch/csrc/jit/ir.h"
-#include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/jit/script/error_report.h"
 #include "torch/csrc/jit/script/tree_views.h"
 

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -22,7 +22,9 @@ namespace torch { namespace jit { namespace tracer {
 using torch::autograd::Variable;
 using variable_list = std::vector<Variable>;
 
+#ifndef NO_PYTHON
 std::string getPythonInterpreterStackTrace();
+#endif
 
 namespace detail {
 
@@ -281,9 +283,11 @@ struct PreTraceInfo {
 };
 
 PreTraceInfo preRecordTrace(std::string op, at::ArrayRef<Variable> inputs);
+#ifndef NO_PYTHON
 PreTraceInfo preRecordPythonTrace(
     THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<Variable> inputs,
     pyobj_list scalar_args);
+#endif
 void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
 
 }}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/tracer_state.cpp
+++ b/torch/csrc/jit/tracer_state.cpp
@@ -1,4 +1,3 @@
-#include "Python.h"
 #include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/utils/tensor_types.h
+++ b/torch/csrc/utils/tensor_types.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Python.h>
 #include <ATen/ATen.h>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
This PR adds the possibility to build the C++ parts of autograd and jit, with no dependency on Python.
The goal is to allow taking a PyTorch IR representation (a tree s-expr) and running it with provided inputs.

Prerequisite: build PyTorch so that codegen runs once.
Instructions:
```
cd tools/cpp_build
bash build_all.sh
```
This will build `libtorchjit` and `torchjit_test` in `tools/cpp_build/build/torchjit-build`. The latter basically runs the code in `test_jit.cpp` for now.

While writing the PR, it turned out that a few of `Python.h` includes were redundant. They were removed here (PyTorch tests still pass on my machine, we'll see CI).

TODOs:
- [x] test with CUDA, Linux, Windows - only tested on a CPU build on macOS ~~(note: I have a CPU version of `text_jit.cpp` that I didn't include to check if tests pass - they do except fuser which requires CUDA)~~
- [x] add proper C++ testing infrastructure
- ~~add example that takes the PyTorch IR S-expr as a string and runs it with provided tensor inputs~~ In the interest of getting the PR sooner than later, this will be added in a subsequent PR
- [x] Updated: reduce ifdefs and split off code depending on python in separate files that can be included conditionally
- ~~add codegen step to build~~ Separate PR
- ~~add tests to Jenkins~~ Separate PR
- [x] get rid of warnings related to XOPEN_SOURCE, etc (see comment in https://github.com/pytorch/pytorch/pull/5391)

I'm volunteering for making sure cpp builds work as new PRs are merged.

/cc @apaszke 