### PR TITLE
Test both CPU build and CUDA build for Windows

### DIFF
--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -76,6 +76,16 @@ set CMAKE_GENERATOR=Ninja
 
 xcopy /Y aten\\src\\ATen\\common_with_cwrap.py tools\\shared\\cwrap_common.py
 
+set NO_CUDA=1
+
+python setup.py install
+
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+rd /s /q C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch
+
+set NO_CUDA=
+
 python setup.py install && 7z a %IMAGE_COMMIT_TAG%.7z C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch && python ci_scripts\\upload_image.py %IMAGE_COMMIT_TAG%.7z
 
 EOL


### PR DESCRIPTION
CPU build for Windows is currently not tested which causes us to miss some error cases such as https://github.com/pytorch/pytorch/pull/5321#issuecomment-367887126. This diff adds CPU build to Windows CI, which should only add ~4min to the build time.

Currently the Windows CI will fail for this PR because of the issue in https://github.com/pytorch/pytorch/pull/5321#issuecomment-367887126. After it is fixed we can merge this PR to master.