### PR TITLE
Fix segfault in test_dep_nograd

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -358,7 +358,7 @@ inline void create_gradient_edge(
 inline bool any_variable_requires_grad(const variable_list& variables) {
   return std::any_of(
       variables.begin(), variables.end(), [](const Variable& variable) {
-        return variable.requires_grad();
+        return variable.defined() && variable.requires_grad();
       });
 }
 


### PR DESCRIPTION
This was originally merged but another PR overwrote the change. This should fix segfaults in test_dep_nograd.

At some point I'll change it so that any_variable_requires_grad doesn't check variable.defined() because it will probably become redundant, but right now this is a good place to put the check because:
- any_variable_requires_grad is only called from the following 2 locations:
   - python_function
   - wrap_outputs
      - wrap_outputs is only used by python functions and an error function somewhere

cc @ezyang 