### PR TITLE
Add faq on cuda memory management and dataloder worker seeds

### DIFF
--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -100,7 +100,7 @@ Memory management
 PyTorch use a caching memory allocator to speed up memory allocations. This
 allows fast memory deallocation without device synchronizations. However, the
 unused memory managed by the allocator will still show as if used in
-`nvidia-smi`. You can use :meth:`~torch.cuda.memory_allocated` and
+``nvidia-smi``. You can use :meth:`~torch.cuda.memory_allocated` and
 :meth:`~torch.cuda.max_memory_allocated` to monitor memory occupied by
 tensors, and use :meth:`~torch.cuda.memory_cached` and
 :meth:`~torch.cuda.max_memory_cached` to monitor memory managed by the caching

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -76,9 +76,27 @@ BPTT, including in the `word language model <https://github.com/pytorch/examples
 `this forum post <https://discuss.pytorch.org/t/help-clarifying-repackage-hidden-in-word-language-model/226>`_.
 
 **Don't use linear layers that are too large.**
-A linear layer ``nn.Linear(m, n)`` uses O(nm) memory: that is to say, the
-memory requirements of the weights
+A linear layer ``nn.Linear(m, n)`` uses :math:`O(nm)` memory: that is to say,
+the memory requirements of the weights
 scales quadratically with the number of features.  It is very easy
 to `blow through your memory <https://github.com/pytorch/pytorch/issues/958>`_
 this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
+
+My GPU memory isn't freed properly
+-------------------------------------------------------
+PyTorch use a caching memory allocator to speed up memory allocations. As a
+result, the values shown in ``nvidia-smi`` usually don't reflect the true
+memory usage. See :ref:`cuda-memory-management` for more details about GPU
+memory management.
+
+If your GPU memory isn't freed even after Python quits, it is very likely that
+some Python subprocesses are still alive. You may find them via
+``ps -elfx | grep python`` and manually kill them with ``kill -9 [pid]``.
+
+My data loader workers return identical random numbers
+-------------------------------------------------------
+You are likely using other libraries to generate random numbers in the dataset.
+For example, NumPy's RNG is duplicated when worker subprocesses are started via
+``fork``. See :class:`torch.utils.data.DataLoader`'s document for how to
+properly set up random seeds in workers.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -19,7 +19,7 @@ else:
 
 
 class ExceptionWrapper(object):
-    r"Wraps an exception plus traceback to communicate across threads"
+    r"""Wraps an exception plus traceback to communicate across threads"""
 
     def __init__(self, exc_info):
         self.exc_type = exc_info[0]
@@ -27,7 +27,7 @@ class ExceptionWrapper(object):
 
 
 _use_shared_memory = False
-"""Whether to use shared memory in default_collate"""
+r"""Whether to use shared memory in default_collate"""
 
 
 def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, worker_id):
@@ -97,7 +97,7 @@ numpy_type_map = {
 
 
 def default_collate(batch):
-    "Puts each data field into a tensor with outer dimension batch size"
+    r"""Puts each data field into a tensor with outer dimension batch size"""
 
     error_msg = "batch must contain tensors, numbers, dicts or lists; found {}"
     elem_type = type(batch[0])
@@ -151,7 +151,7 @@ def pin_memory_batch(batch):
 
 
 _SIGCHLD_handler_set = False
-"""Whether SIGCHLD handler is set for DataLoader worker failures. Only one
+r"""Whether SIGCHLD handler is set for DataLoader worker failures. Only one
 handler needs to be set for all DataLoaders in a process."""
 
 
@@ -181,7 +181,7 @@ def _set_SIGCHLD_handler():
 
 
 class DataLoaderIter(object):
-    "Iterates once over the DataLoader's dataset, as specified by the sampler"
+    r"""Iterates once over the DataLoader's dataset, as specified by the sampler"""
 
     def __init__(self, loader):
         self.dataset = loader.dataset
@@ -334,7 +334,7 @@ class DataLoaderIter(object):
 
 
 class DataLoader(object):
-    """
+    r"""
     Data loader. Combines a dataset and a sampler, and provides
     single- or multi-process iterators over the dataset.
 
@@ -371,7 +371,7 @@ class DataLoader(object):
               this value in :attr:`worker_init_fn`, which can be used to set other seeds
               (e.g. NumPy) before data loading.
 
-    .. warning:: If ``spawn'' start method is used, :attr:`worker_init_fn` cannot be an
+    .. warning:: If ``spawn`` start method is used, :attr:`worker_init_fn` cannot be an
                  unpicklable object, e.g., a lambda function.
     """
 


### PR DESCRIPTION
Add faq sections on 
1. memory not seeming to be freed properly
2. dataloader workers return identical random numbers (e.g. due to numpy rng and `fork`).