### PR TITLE
Port cuDNN RNN dropout state initialization to ATen and make Python c…

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -44,6 +44,10 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
   throw std::runtime_error("_cudnn_rnn_backward: ATen not compiled with cuDNN support");
 }
 
+Tensor _cudnn_init_dropout_state(const Type& ty, double dropout, bool train, int64_t dropout_seed) {
+  throw std::runtime_error("_cudnn_init_dropout_state: ATen not compiled with cuDNN support");
+}
+
 }} // namespace at::native
 
 #else // AT_CUDNN_ENABLED()
@@ -982,6 +986,16 @@ std::tuple<Tensor, Tensor, Tensor, std::vector<Tensor>> _cudnn_rnn_backward(
     dw = at::native::_cudnn_rnn_backward_weight(input, weight, weight_stride0, weight_buf, hx, cx, output, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, reserve);
   }
   return std::tuple<Tensor, Tensor, Tensor, TensorList>{dx, dhx, dcx, dw};
+}
+
+// TODO: I am not sure if we actually need the 'dropout' and 'train' parameters
+// to initialize just the state tensor
+Tensor _cudnn_init_dropout_state(const Type& ty, double dropout, bool train, int64_t dropout_seed) {
+  auto handle = getCudnnHandle();
+  DropoutDescriptor dropout_desc;
+  auto dropout_p = train ? dropout : 0;
+  dropout_desc.initialize_rng(ty, handle, dropout_p, dropout_seed);
+  return dropout_desc.state;
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -408,3 +408,6 @@
 
 - func: _cudnn_rnn_backward(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor grad_output, Tensor grad_hy, Tensor? grad_cy, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntList batch_sizes, BoolTensor? dropout_state, Tensor reserve, std::array<bool,4> output_mask) -> (Tensor, Tensor, Tensor, TensorList)
   variants: function
+
+- func: _cudnn_init_dropout_state(Type ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
+  variants: function

--- a/aten/src/ATen/test/cudnn_test.cpp
+++ b/aten/src/ATen/test/cudnn_test.cpp
@@ -10,7 +10,7 @@ int main() {
 #if CUDNN_VERSION < 7000
   auto handle = getCudnnHandle();
   DropoutDescriptor desc1, desc2;
-  desc1.initialize_rng(handle, 0.5, 42);
+  desc1.initialize_rng(at::CUDA(kByte), handle, 0.5, 42);
   desc2.set(handle, 0.5, desc1.state);
 
   ASSERT(desc1.desc()->dropout == desc2.desc()->dropout);

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -255,7 +255,8 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
     if dropout_state is None:
         dropout_state = {}
     mode = cudnn.rnn.get_cudnn_mode(mode)
-    dropout_seed = torch.IntTensor(1).random_()[0]
+    # TODO: This is really goofy way of using the Torch RNG to get a random number
+    dropout_seed = int(torch.IntTensor(1).random_())
     if flat_weight is None:
         warnings.warn("RNN module weights are not part of single contiguous "
                       "chunk of memory. This means they need to be compacted "

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -269,7 +269,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
             cx = None
 
         handle = cudnn.get_handle()
-        dropout_desc = cudnn.rnn.init_dropout_descriptor(handle, dropout, train, dropout_seed, dropout_state)
+        dropout_ts = cudnn.rnn.init_dropout_state(torch.cuda.uint8, dropout, train, dropout_seed, dropout_state)
 
         weight_arr = list(itertools.chain.from_iterable(weight))
         weight_stride0 = len(weight[0])
@@ -281,7 +281,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
             mode, hidden_size, num_layers,
             batch_first, dropout, train, bool(bidirectional),
             list(batch_sizes.data) if variable_length else (),
-            Variable(dropout_desc.state) if dropout_desc.state is not None else None)
+            dropout_ts)
 
         if cx is not None:
             return (output, (hy, cy))


### PR DESCRIPTION
…ode use it.

Fixes #5138.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @ebetica; this changes the API so instead of calling the initialization function with `input` you just call it with `input.type()`.