### PR TITLE
add get_total_memory to return a GPU's memory capacity

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -126,7 +126,7 @@ PyObject * THCPModule_getDeviceName_wrap(PyObject *self, PyObject *arg)
 {
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to getDeviceName");
-  long device = THPUtils_unpackLong(arg);
+  int64_t device = THPUtils_unpackLong(arg);
 
   cudaDeviceProp prop;
   THCudaCheck(cudaGetDeviceProperties(&prop, device));
@@ -138,7 +138,7 @@ PyObject * THCPModule_getDeviceCapability_wrap(PyObject *self, PyObject *arg)
 {
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to getDeviceCapability");
-  long device = THPUtils_unpackLong(arg);
+  int64_t device = THPUtils_unpackLong(arg);
 
   cudaDeviceProp prop;
   THCudaCheck(cudaGetDeviceProperties(&prop, device));
@@ -146,6 +146,17 @@ PyObject * THCPModule_getDeviceCapability_wrap(PyObject *self, PyObject *arg)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject * THCPModule_getTotalMemory_wrap(PyObject *self, PyObject *arg)
+{
+  HANDLE_TH_ERRORS
+  THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to getTotalMemory");
+  int64_t device = THPUtils_unpackLong(arg);
+  THCPAutoGPU gpu_guard(device);
+  size_t free, total;
+  THCudaCheck(cudaMemGetInfo(&free, &total));
+  return PyLong_FromLong(total);
+  END_HANDLE_TH_ERRORS
+}
 
 PyObject * THCPModule_getCurrentStream_wrap(PyObject *self)
 {
@@ -438,6 +449,7 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_getDeviceCount", (PyCFunction)THCPModule_getDeviceCount_wrap, METH_NOARGS, NULL},
   {"_cuda_getDeviceName", (PyCFunction)THCPModule_getDeviceName_wrap, METH_O,   NULL},
   {"_cuda_getDeviceCapability", (PyCFunction)THCPModule_getDeviceCapability_wrap, METH_O,   NULL},
+  {"_cuda_getTotalMemory", (PyCFunction)THCPModule_getTotalMemory_wrap, METH_O,   NULL},
   {"_cuda_getCurrentStream", (PyCFunction)THCPModule_getCurrentStream_wrap, METH_NOARGS, NULL},
   {"_cuda_getCurrentBlasHandle", (PyCFunction)THCPModule_getCurrentBlasHandle_wrap, METH_NOARGS, NULL},
   {"_cuda_setStream",    (PyCFunction)THCPModule_setStream_wrap,  METH_O, NULL},

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -287,6 +287,19 @@ def get_device_capability(device):
         return torch._C._cuda_getDeviceCapability(device)
 
 
+def get_total_memory(device):
+    r"""Gets the total memory capacity of the device in bytes
+
+    Arguments:
+        device (int): device for which to return the name. This function is a
+            no-op if this argument is negative.
+    Returns:
+        int : the memory capacity in total bytes
+    """
+    if device >= 0:
+        return torch._C._cuda_getTotalMemory(device)
+
+
 @contextlib.contextmanager
 def stream(stream):
     r"""Context-manager that selects a given stream.


### PR DESCRIPTION
```
In [6]: torch.cuda.get_total_memory(1)
Out[6]: 17069309952
```