### PR TITLE
Don't bind actual inplace Tensor methods to VariableFunctions.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11,6 +11,7 @@
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addmv_(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  variants: method
 
 - func: addmv_out(Tensor result, Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
@@ -26,8 +27,10 @@
   variants: function
 
 - func: bernoulli_(Tensor self, Tensor p, Generator* generator=nullptr) -> Tensor
+  variants: method
 
 - func: bernoulli_(Tensor self, double p=0.5, Generator* generator=nullptr) -> Tensor
+  variants: method
 
 - func: cat(TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
@@ -215,6 +218,7 @@
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
 
 - func: index_put_(Tensor self, TensorList indices, Tensor values) -> Tensor
+  variants: method
 
 - func: is_cuda(Tensor self) -> bool
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -165,7 +165,10 @@ def gen_py_torch_functions(out, declarations):
         return (should_generate_python_binding(declaration) and
                 declaration['mode'] != 'NN' and
                 ('namespace' in declaration['method_of'] or
-                 'Type' in declaration['method_of']))
+                 'Type' in declaration['method_of']) and not
+                # don't bind actual inplace tensor methods; we have some "fake" inplace Functions
+                # that aren't actually methods that are logically NN functions (e.g. rrelu_).
+                ('Tensor' in declaration['method_of'] and declaration['inplace']))
 
     py_torch_functions = group_declarations_by_name(declarations, should_bind)
 


### PR DESCRIPTION
This still binds "fake" inplace functions like rrelu_, selu_ to match the NN pattern, but no longer binds things like abs_.