### PR TITLE
[JIT] Support shape propagation with control-flow

### DIFF
--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,6 +1,6 @@
 graph(%0 : Double(20, 16, 50, 40)
       %1 : Double(13, 16, 3, 3)) {
-  %2 : UNKNOWN_TYPE = Undefined(), scope: Conv2d
+  %2 : Dynamic = Undefined(), scope: Conv2d
   %3 : Double(20, 13, 48, 38) = _convolution[stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=0, output_padding=[0, 0], groups=1, benchmark=0, deterministic=0, cudnn_enabled=1](%0, %1, %2), scope: Conv2d
   return (%3);
 }

--- a/test/expect/TestJit.test_cpp.expect
+++ b/test/expect/TestJit.test_cpp.expect
@@ -1,77 +1,77 @@
 testBlocks
-graph(%a : UNKNOWN_TYPE
-      %b : UNKNOWN_TYPE
-      %c : UNKNOWN_TYPE) {
-  %2 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
-  %4 : UNKNOWN_TYPE = If(%c)
+graph(%a : Dynamic
+      %b : Dynamic
+      %c : Dynamic) {
+  %2 : Dynamic = add[alpha={1}](%a, %b)
+  %4 : Dynamic = If(%c)
     block0() {
-      %5 : UNKNOWN_TYPE = add[alpha={1}](%2, %2)
+      %5 : Dynamic = add[alpha={1}](%2, %2)
       -> (%5)
     }
     block1() {
-      %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
-      %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
+      %6 : Dynamic = add[alpha={1}](%b, %2)
+      %7 : Dynamic = add[alpha={1}](%6, %2)
       -> (%7)
     }
-  %8 : UNKNOWN_TYPE = add[alpha={1}](%4, %2)
+  %8 : Dynamic = add[alpha={1}](%4, %2)
   return (%8);
 }
 
-graph(%a : UNKNOWN_TYPE
-      %b : UNKNOWN_TYPE
-      %c : UNKNOWN_TYPE) {
-  %2 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
-  %4 : UNKNOWN_TYPE = If(%c)
+graph(%a : Dynamic
+      %b : Dynamic
+      %c : Dynamic) {
+  %2 : Dynamic = add[alpha={1}](%a, %b)
+  %4 : Dynamic = If(%c)
     block0() {
-      %6 : UNKNOWN_TYPE = add[alpha={1}](%b, %2)
-      %7 : UNKNOWN_TYPE = add[alpha={1}](%6, %2)
+      %6 : Dynamic = add[alpha={1}](%b, %2)
+      %7 : Dynamic = add[alpha={1}](%6, %2)
       -> (%7)
     }
-  %8 : UNKNOWN_TYPE = add[alpha={1}](%4, %2)
+  %8 : Dynamic = add[alpha={1}](%4, %2)
   return (%8);
 }
 
-graph(%a : UNKNOWN_TYPE
-      %b : UNKNOWN_TYPE
-      %c : UNKNOWN_TYPE) {
-  %3 : UNKNOWN_TYPE = add[alpha={1}](%a, %b)
-  %4 : UNKNOWN_TYPE = If(%c)
+graph(%a : Dynamic
+      %b : Dynamic
+      %c : Dynamic) {
+  %3 : Dynamic = add[alpha={1}](%a, %b)
+  %4 : Dynamic = If(%c)
     block0() {
-      %5 : UNKNOWN_TYPE = add[alpha={1}](%b, %3)
-      %6 : UNKNOWN_TYPE = add[alpha={1}](%5, %3)
+      %5 : Dynamic = add[alpha={1}](%b, %3)
+      %6 : Dynamic = add[alpha={1}](%5, %3)
       -> (%6)
     }
-  %7 : UNKNOWN_TYPE = add[alpha={1}](%4, %3)
+  %7 : Dynamic = add[alpha={1}](%4, %3)
   return (%7);
 }
 
 testCreateAutodiffSubgraphs
-graph(%0 : UNKNOWN_TYPE
-      %1 : UNKNOWN_TYPE
-      %2 : UNKNOWN_TYPE
-      %3 : UNKNOWN_TYPE
-      %4 : UNKNOWN_TYPE) {
-  %21 : UNKNOWN_TYPE, %22 : UNKNOWN_TYPE = GraphExecutor_0(%0, %3, %1, %4, %2)
+graph(%0 : Dynamic
+      %1 : Dynamic
+      %2 : Dynamic
+      %3 : Dynamic
+      %4 : Dynamic) {
+  %21 : Dynamic, %22 : Dynamic = GraphExecutor_0(%0, %3, %1, %4, %2)
   return (%22, %21);
 }
-with GraphExecutor_0 = graph(%1 : UNKNOWN_TYPE
-      %2 : UNKNOWN_TYPE
-      %4 : UNKNOWN_TYPE
-      %5 : UNKNOWN_TYPE
-      %16 : UNKNOWN_TYPE) {
-  %0 : UNKNOWN_TYPE = mm(%1, %2)
-  %3 : UNKNOWN_TYPE = mm(%4, %5)
-  %6 : UNKNOWN_TYPE = add[alpha={1}](%0, %3)
-  %7 : UNKNOWN_TYPE, %8 : UNKNOWN_TYPE, %9 : UNKNOWN_TYPE, %10 : UNKNOWN_TYPE = chunk[chunks=4, dim=1](%6)
-  %11 : UNKNOWN_TYPE = sigmoid(%7)
-  %12 : UNKNOWN_TYPE = sigmoid(%10)
-  %13 : UNKNOWN_TYPE = tanh(%9)
-  %14 : UNKNOWN_TYPE = sigmoid(%8)
-  %15 : UNKNOWN_TYPE = mul(%14, %16)
-  %17 : UNKNOWN_TYPE = mul(%11, %13)
-  %18 : UNKNOWN_TYPE = add[alpha={1}](%15, %17)
-  %19 : UNKNOWN_TYPE = tanh(%18)
-  %20 : UNKNOWN_TYPE = mul(%12, %19)
+with GraphExecutor_0 = graph(%1 : Dynamic
+      %2 : Dynamic
+      %4 : Dynamic
+      %5 : Dynamic
+      %16 : Dynamic) {
+  %0 : Dynamic = mm(%1, %2)
+  %3 : Dynamic = mm(%4, %5)
+  %6 : Dynamic = add[alpha={1}](%0, %3)
+  %7 : Dynamic, %8 : Dynamic, %9 : Dynamic, %10 : Dynamic = chunk[chunks=4, dim=1](%6)
+  %11 : Dynamic = sigmoid(%7)
+  %12 : Dynamic = sigmoid(%10)
+  %13 : Dynamic = tanh(%9)
+  %14 : Dynamic = sigmoid(%8)
+  %15 : Dynamic = mul(%14, %16)
+  %17 : Dynamic = mul(%11, %13)
+  %18 : Dynamic = add[alpha={1}](%15, %17)
+  %19 : Dynamic = tanh(%18)
+  %20 : Dynamic = mul(%12, %19)
   return (%18, %20);
 }
 
@@ -88,17 +88,17 @@ graph(%0 : Float(2, 3, 4)
       %2 : Float(2, 3, 4)
       %3 : Float(2, 3, 4)
       %4 : Float(2, 3, 4)) {
-  %5 : UNKNOWN_TYPE = Constant[value=<Tensor>, is_zero=1]()
-  %6 : UNKNOWN_TYPE = ReplaceIfUndef(%0, %5)
-  %7 : UNKNOWN_TYPE = Constant[value=<Tensor>, is_zero=1]()
-  %8 : UNKNOWN_TYPE = ReplaceIfUndef(%1, %7)
-  %9 : UNKNOWN_TYPE = mul(%6, %2)
-  %10 : UNKNOWN_TYPE = add[alpha={1}](%8, %9)
-  %11 : UNKNOWN_TYPE = mul(%6, %4)
-  %12 : UNKNOWN_TYPE = mul(%10, %3)
-  %13 : UNKNOWN_TYPE = mul(%10, %2)
-  %14 : UNKNOWN_TYPE = add[alpha={1}](%11, %12)
-  %15 : UNKNOWN_TYPE = add[alpha={1}](%6, %13)
+  %5 : Dynamic = Constant[value=<Tensor>, is_zero=1]()
+  %6 : Dynamic = ReplaceIfUndef(%0, %5)
+  %7 : Dynamic = Constant[value=<Tensor>, is_zero=1]()
+  %8 : Dynamic = ReplaceIfUndef(%1, %7)
+  %9 : Dynamic = mul(%6, %2)
+  %10 : Dynamic = add[alpha={1}](%8, %9)
+  %11 : Dynamic = mul(%6, %4)
+  %12 : Dynamic = mul(%10, %3)
+  %13 : Dynamic = mul(%10, %2)
+  %14 : Dynamic = add[alpha={1}](%11, %12)
+  %15 : Dynamic = add[alpha={1}](%6, %13)
   return (%14, %15);
 }
 
@@ -116,14 +116,14 @@ graph(%0 : Float(2, 3, 4)
       %1 : Float(2, 3, 4)
       %2 : Float(2, 3, 4)
       %3 : Float(2, 3, 4)) {
-  %4 : UNKNOWN_TYPE = Constant[value=<Tensor>, is_zero=1]()
-  %5 : UNKNOWN_TYPE = ReplaceIfUndef(%0, %4)
-  %6 : UNKNOWN_TYPE = Constant[value=<Tensor>, is_zero=1]()
-  %7 : UNKNOWN_TYPE = ReplaceIfUndef(%1, %6)
-  %8 : UNKNOWN_TYPE = mul(%5, %2)
-  %9 : UNKNOWN_TYPE = add[alpha={1}](%7, %8)
-  %10 : UNKNOWN_TYPE = mul(%5, %3)
-  %11 : UNKNOWN_TYPE = add[alpha={1}](%10, %9)
+  %4 : Dynamic = Constant[value=<Tensor>, is_zero=1]()
+  %5 : Dynamic = ReplaceIfUndef(%0, %4)
+  %6 : Dynamic = Constant[value=<Tensor>, is_zero=1]()
+  %7 : Dynamic = ReplaceIfUndef(%1, %6)
+  %8 : Dynamic = mul(%5, %2)
+  %9 : Dynamic = add[alpha={1}](%7, %8)
+  %10 : Dynamic = mul(%5, %3)
+  %11 : Dynamic = add[alpha={1}](%10, %9)
   return (%11);
 }
 

--- a/test/expect/TestJit.test_python_ir.expect
+++ b/test/expect/TestJit.test_python_ir.expect
@@ -1,9 +1,9 @@
-graph(%0 : UNKNOWN_TYPE
-      %1 : UNKNOWN_TYPE) {
+graph(%0 : Dynamic
+      %1 : Dynamic) {
   %2 : Double(1) = add[alpha={1}](%0, %1)
   %3 : Double(1) = mul(%0, %2)
   %4 : Double(1) = tanh(%3)
   %5 : Double(1) = sigmoid(%4)
-  %6 : UNKNOWN_TYPE = TensorTest[a= 1  1  1  1 [ CPUDoubleTensor{2,2} ]]()
+  %6 : Dynamic = TensorTest[a= 1  1  1  1 [ CPUDoubleTensor{2,2} ]]()
   return (%5);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1344,17 +1344,20 @@ class TestJit(TestCase):
         g2result2 = torch.autograd.grad(l3, [da2, db2])
         self.assertEqual(g2result, g2result2)
 
-    def checkScript(self, script, inputs, outputs, optimize, name='func'):
+    def checkScript(self, script, inputs, outputs, optimize, name='func', capture_output=False):
         if isinstance(script, str):
             cu = torch.jit.CompilationUnit(script, optimize)
             ge = getattr(cu, name)
         else:
             ge = torch.jit.script(script)
-        with capture_stdout() as captured:
+
+        if capture_output:
+            with capture_stdout() as captured:
+                outputs_ge = ge(*inputs)
+            self.assertExpected(captured[0], subname='stdout')
+        else:
             outputs_ge = ge(*inputs)
         self.assertEqual(outputs, outputs_ge)
-        if captured[0]:
-            self.assertExpected(captured[0], subname='stdout')
 
     def test_script_add(self):
         script = '''

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1366,7 +1366,7 @@ class TestJit(TestCase):
         a = Variable(torch.rand(1), requires_grad=True)
         b = Variable(torch.rand(1), requires_grad=True)
         outputs = a + b + a
-        self.checkScript(script, [a, b], outputs, False)
+        self.checkScript(script, [a, b], outputs, True)
 
     def test_script_mul(self):
         script = '''
@@ -1377,7 +1377,7 @@ class TestJit(TestCase):
         a = Variable(torch.rand(1), requires_grad=True)
         b = Variable(torch.rand(1), requires_grad=True)
         outputs = a * b
-        self.checkScript(script, [a, b], outputs, False)
+        self.checkScript(script, [a, b], outputs, True)
 
     def test_script_triple(self):
         script = '''
@@ -1386,7 +1386,7 @@ class TestJit(TestCase):
         '''
         x = Variable(torch.rand(1).float(), requires_grad=True)
         outputs = 3 * x
-        self.checkScript(script, [x], outputs, False)
+        self.checkScript(script, [x], outputs, True)
 
     def test_script_slice(self):
         script = '''
@@ -1395,7 +1395,7 @@ class TestJit(TestCase):
         '''
         x = Variable(torch.rand(10).float(), requires_grad=True)
         outputs = x[:5]
-        self.checkScript(script, [x], outputs, False)
+        self.checkScript(script, [x], outputs, True)
 
     def test_script_gather(self):
         script = '''
@@ -1404,7 +1404,7 @@ class TestJit(TestCase):
         '''
         x = Variable(torch.rand(10).float(), requires_grad=True)
         outputs = x[0]
-        self.checkScript(script, [x], outputs, False)
+        self.checkScript(script, [x], outputs, True)
 
     def test_script_func_call(self):
         script = '''
@@ -1422,6 +1422,8 @@ class TestJit(TestCase):
         x = Variable(torch.rand(3).float(), requires_grad=True)
         y = Variable(torch.rand(3).float(), requires_grad=True)
         outputs = alpha * x + beta * y
+        # note - cannot optimize yet because broadcasts are not inserted
+        # before the fuser runs
         self.checkScript(script, [alpha, beta, x, y], outputs, False)
 
     @unittest.skip("RuntimeError: VariableType::ID() not implemented")
@@ -1432,7 +1434,7 @@ class TestJit(TestCase):
         '''
         x = Variable(torch.FloatTensor([1.1, 2.3]), requires_grad=True)
         outputs = Variable(torch.IntTensor([1, 2]), requires_grad=True)
-        self.checkScript(script, 'to_int', [x], [outputs], False)
+        self.checkScript(script, 'to_int', [x], [outputs], True)
 
     def test_python_frontend(self):
         def fn(x, y, z):
@@ -1464,7 +1466,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([1, 1, 10], np.int32)
         outputs = self._make_scalar_vars([20], np.int32)
-        self.checkScript(script, inputs, outputs[0], False, 'test_while')
+        self.checkScript(script, inputs, outputs[0], True, 'test_while')
 
     def test_script_fibb(self):
         script = '''
@@ -1491,7 +1493,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([10], np.int32)
         outputs = self._make_scalar_vars([2, 4, 3], np.int32)
-        self.checkScript(script, inputs, outputs, False, 'test_while')
+        self.checkScript(script, inputs, outputs, True, 'test_while')
 
     def test_script_if(self):
         script = '''
@@ -1506,7 +1508,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([1, -1], np.int32)
         outputs = self._make_scalar_vars([7], np.int32)
-        self.checkScript(script, inputs, outputs[0], False, 'test_if')
+        self.checkScript(script, inputs, outputs[0], True, 'test_if')
 
     def test_script_if_noelse(self):
         script = '''
@@ -1517,7 +1519,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([-1, 1], np.int32)
         outputs = self._make_scalar_vars([0], np.int32)
-        self.checkScript(script, inputs, outputs[0], False, 'test_if_noelse')
+        self.checkScript(script, inputs, outputs[0], True, 'test_if_noelse')
 
     def test_script_while_nonexistant_value(self):
         with self.assertRaisesRegex(RuntimeError, "undefined value x"):
@@ -1549,7 +1551,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([42, 1337], np.int32)
         outputs = self._make_scalar_vars([1379], np.int32)
-        self.checkScript(script, inputs, outputs[0], False, 'test_while')
+        self.checkScript(script, inputs, outputs[0], True, 'test_while')
 
     def test_script_while_nest_if(self):
         script = '''
@@ -1579,7 +1581,7 @@ class TestJit(TestCase):
         '''
         inputs = self._make_scalar_vars([4321, 1234], np.int32)
         outputs = self._make_scalar_vars([-4321], np.int32)
-        self.checkScript(script, inputs, outputs[0], False, 'test_if_while')
+        self.checkScript(script, inputs, outputs[0], True, 'test_if_while')
 
     def test_script_ternary(self):
         cu = torch.jit.CompilationUnit('''

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "aten_dispatch.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/jit/interned_strings.h"

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -100,7 +100,7 @@ void Function::set_up_context_edge(
     const variable_list& inputs,
     const variable_list& outputs) {
   auto ctx_select = this_node->addOutput();
-  ctx_select->setType(std::make_shared<jit::HandleType>());
+  ctx_select->setType(jit::HandleType::get());
   auto backward_eval = Eval::getBackwardEval(inputs, outputs);
   if (backward_eval)
     backward_eval->forward_ctx_select = ctx_select;

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/autograd/function.h"
 

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "torch/csrc/autograd/saved_variable.h"
 
 #include "torch/csrc/autograd/edge.h"

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -142,7 +142,7 @@ struct TensorInfo {
   }
   operator TypePtr() const {
     if(!defined())
-      return nullptr;
+      return DynamicType::get();
     return std::make_shared<TensorType>(type(), device(), sizes(), strides());
   }
 private:

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -133,7 +133,6 @@ void addAttribute(onnx::NodeProto * n_p, jit::Node * n, jit::Symbol name) {
 
 void encodeTypeProtoTensorType(onnx::TypeProtoTensorTypeProto* tensor_type, Value* n) {
   onnx::TypeProtoTensorShapeProto* shape = tensor_type->mutable_shape();
-  JIT_ASSERT(n->hasType());
   TensorType* node_type = n->type()->expect<TensorType>();
   const std::vector<std::int64_t>& sizes = node_type->sizes();
   for (std::int64_t s : sizes) {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -58,12 +58,6 @@ void desugarTripCounts(Block * b) {
       n->removeInput(0);
       JIT_ASSERT(n->blocks()[0]->inputs()[0]->uses().size() == 0 &&
         "NYI - use of trip count variable");
-      JIT_ASSERT(n->blocks()[0]->inputs()[1]->uses().size() == 0 &&
-        "NYI - use of cond variable in loop");
-
-      // TODO: remove cond as input to loop carries, it just complicates this
-      // implementation
-      n->blocks()[0]->eraseInput(1);
       n->blocks()[0]->eraseInput(0);
     }
     for(auto sb : n->blocks()) {
@@ -87,7 +81,7 @@ static std::vector<std::vector<TypePtr>> flattenStages(Graph & graph) {
     while(input_pos < graph.inputs().size() && graph.inputs()[input_pos]->stage() == i) {
       auto nv = store->addOutput();
       auto old_node = graph.inputs()[input_pos];
-      stage_input_types[i].push_back(old_node->typeOption());
+      stage_input_types[i].push_back(old_node->type());
       old_node->replaceAllUsesWith(nv);
       input_pos++;
     }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -125,10 +125,7 @@ std::ostream& operator<<(std::ostream & out, const_value_list_with_types l) {
     }
     printValueRef(out, n);
     out << " : ";
-    if(n->hasType())
-      out << *n->type();
-    else
-      out << "UNKNOWN_TYPE";
+    out << *n->type();
   }
   return out;
 }
@@ -305,14 +302,12 @@ static void checkSameDevice(const Node* node) {
   bool has_device = false;
   int device;
   auto checkValue = [&](const Value* v) {
-    if(v->hasType()) {
-      if(TensorType* type = v->type()->cast<TensorType>()) {
-        if(!has_device) {
-          has_device = true;
-          device = type->device();
-        } else {
-          JIT_ASSERT(device == type->device());
-        }
+    if(TensorType* type = v->type()->cast<TensorType>()) {
+      if(!has_device) {
+        has_device = true;
+        device = type->device();
+      } else {
+        JIT_ASSERT(device == type->device());
       }
     }
   };
@@ -355,7 +350,7 @@ void Node::lint() const {
       JIT_ASSERT(graph_->all_nodes.count(this) == 1);
       // Handle invariant
       if (i != inputs_.size() - 1) {
-        JIT_ASSERT(!input->hasType() || input->type()->kind() != TypeKind::HandleType);
+        JIT_ASSERT(input->type()->kind() != TypeKind::HandleType);
       }
       i++;
     }

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -29,7 +29,7 @@ void mergeNodes(Block * block, Symbol group_node_kind, ArrayRef<Node*> nodes) {
     if(value_map.count(v) > 0) {
       return value_map[v];
     }
-    Value * nv = new_graph->addInput()->setType(v->typeOption());
+    Value * nv = new_graph->addInput()->setType(v->type());
     group_node->addInput(v);
     value_map[v] = nv;
     return nv;
@@ -55,7 +55,7 @@ void mergeNodes(Block * block, Symbol group_node_kind, ArrayRef<Node*> nodes) {
       }
       if(to_replace.size() > 0) {
         new_graph->registerOutput(new_output);
-        Value * external_output = group_node->addOutput()->setType(old_output->typeOption());
+        Value * external_output = group_node->addOutput()->setType(old_output->type());
         for(auto u : to_replace) {
           u.user->replaceInput(u.offset, external_output);
         }

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -99,9 +99,6 @@ struct GraphFuser {
   // TODO: the fusion compiler has a lot of float-specific codegen
   // so for now we only consider nodes that operate on floating point numbers
   bool hasFloatType(Value * node) {
-    if(!node->hasType()) {
-      return false;
-    }
     if(auto tt = node->type()->cast<TensorType>()) {
       return tt->scalarType() == at::kFloat;
     } else {
@@ -244,7 +241,7 @@ struct GraphFuser {
         consumer_subgraph->registerOutput(merged->outputs()[i]);
         auto new_output = consumer_group->addOutput();
         output->replaceAllUsesWith(new_output);
-        new_output->setType(output->typeOption());
+        new_output->setType(output->type());
       }
       node->destroy();
     }
@@ -265,7 +262,7 @@ struct GraphFuser {
     for (auto input : n->inputs()) {
       if (inputs_map.count(input) == 0) {
         auto in_group = subgraph.addInput();
-        in_group->setType(input->typeOption());
+        in_group->setType(input->type());
         inputs_map[input] = in_group;
         group->addInput(input);
       }

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -12,7 +12,7 @@ namespace {
 
 bool hasHandleOutput(Node *node) {
   auto last_output = node->outputs().back();
-  return last_output->typeOption() && last_output->typeOption()->kind() == TypeKind::HandleType;
+  return last_output->isHandle();
 }
 
 bool hasUsedHandle(Node *node) {
@@ -80,9 +80,7 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
         // Allow symbolic() to skip specifying the type of the return node.
         // Unfortunately, they are on the hook for all internal nodes
         // (though in practice, the types are not computed.)
-        if (!outputs[i]->hasType()) {
-          outputs[i]->setType(old->typeOption());
-        }
+        outputs[i]->setType(old->type());
         // Copy over source location information to all nodes created by
         // the symbolic
         outputs[i]->node()->setSourceLocation(node->getSourceLocation());

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -108,7 +108,7 @@ void fuseBroadcast(std::shared_ptr<Graph>& graph) {
     // always have this information (because expands are only ever traced,
     // not generated from symbolic), but if for some reason we don't
     // have it, we need to skip.
-    if (!unexpanded_rhs->hasType()) continue;
+    if (!unexpanded_rhs->isTensor()) continue;
 
     // Not all broadcasts are supported by ONNX broadcast.
     if (!fusibleExpandTo(unexpanded_rhs->type()->expect<TensorType>()->sizes(), // from

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -19,7 +19,7 @@ void PeepholeOptimize(Block * block) {
     switch (n->kind()) {
       case kexpand:
         // Eliminate redundant expand
-        if (!n->input()->hasType()) break;
+        if (!n->input()->isTensor()) break;
         if (n->is(ksize) == n->input()->type()->expect<TensorType>()->sizes()) {
           n->output()->replaceAllUsesWith(n->input());
           it.destroyCurrent();

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -9,9 +9,9 @@
 namespace torch { namespace jit {
 
 namespace {
-void SetUnknownType(Node * node) {
+void setDynamicType(Node * node) {
   for(auto o : node->outputs()) {
-    o->setType(nullptr);
+    o->setType(DynamicType::get());
   }
 }
 
@@ -21,19 +21,37 @@ at::Tensor representativeTensor(const TensorType * type) {
   return attype.tensor(type->sizes(), type->strides()).zero_();
 }
 
+void PropagateShapeOnBlock(Block * block);
+
+std::pair<std::vector<TensorType*>, bool> gatherTypes(at::ArrayRef<Value*> values) {
+  std::vector<TensorType*> types;
+  bool present = true;
+  for(auto v : values) {
+    TensorType* type = v->type()->cast<TensorType>();
+    if(!type)
+      present = false;
+    types.push_back(type);
+  }
+  return std::make_pair(std::move(types), present);
+}
+
+void mergeTypes(ArrayRef<Value*> lhs, ArrayRef<Value*> rhs, ArrayRef<Value*> outputs) {
+  JIT_ASSERT(lhs.size() == rhs.size() && rhs.size() == outputs.size());
+  for(size_t i = 0; i < lhs.size(); ++i) {
+    if(*lhs[i]->type() == *rhs[i]->type()) {
+      outputs[i]->setType(lhs[i]->type());
+    } else {
+      outputs[i]->setType(DynamicType::get());
+    }
+  }
+}
+
 void PropagateShapeOnNode(Node * node) {
   std::vector<TensorType*> types;
-  // get all the input types, propagate unknown types if we don't have
-  // valid tensor types for the inputs
-  for(auto input : node->inputs()) {
-    if(!input->hasType()) {
-      return SetUnknownType(node);
-    }
-    if(TensorType * t = input->type()->cast<TensorType>()) {
-      types.push_back(t);
-    } else {
-      return SetUnknownType(node);
-    }
+  bool present;
+  std::tie(types, present) = gatherTypes(node->inputs());
+  if(!present) {
+    return setDynamicType(node);
   }
 
   switch(node->kind()) {
@@ -117,7 +135,28 @@ void PropagateShapeOnNode(Node * node) {
       node->output()->inferTypeFrom(node->t(kvalue));
     } break;
     case kUndefined: {
-      node->output()->setType(nullptr);
+      node->output()->setType(DynamicType::get());
+    } break;
+    case kIf: {
+      auto then_block = node->blocks()[0];
+      auto else_block = node->blocks()[1];
+      PropagateShapeOnBlock(then_block);
+      PropagateShapeOnBlock(else_block);
+      mergeTypes(then_block->outputs(), else_block->outputs(), node->outputs());
+    } break;
+    case kLoop: {
+      auto body_block = node->blocks()[0];
+      // propagate counter type
+      body_block->inputs()[0]->setType(node->inputs()[0]->type());
+      // propagate loop-carried input types to block inputs
+      auto loop_carried_inputs = node->inputs().slice(2); // skip max, cond
+      auto loop_carried_block = body_block->inputs().slice(1); // skip trip
+      for(size_t i = 0; i < loop_carried_inputs.size(); ++i) {
+        loop_carried_block[i]->setType(loop_carried_inputs[i]->type());
+      }
+      PropagateShapeOnBlock(body_block);
+      auto loop_carried_outputs = body_block->outputs().slice(1); // skip cond
+      mergeTypes(loop_carried_inputs, loop_carried_outputs, node->outputs());
     } break;
     default: {
       auto op_info = getTensorOp(node);
@@ -137,9 +176,6 @@ void PropagateShapeOnNode(Node * node) {
 void PropagateShapeOnBlock(Block * block) {
   for (Node * node : block->nodes()) {
     PropagateShapeOnNode(node);
-    for (Block * sub_block : node->blocks()) {
-      PropagateShapeOnBlock(sub_block);
-    }
   }
 }
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -70,8 +70,6 @@ void initPythonIRBindings(PyObject * module_) {
       return ss.str();
     })
     .VS(type)
-    .VS(typeOption)
-    .VS(hasType)
     .VS(setType)
     .VS(inferTypeFrom)
     // skip owningGraph because it returns a raw pointer to a otherwise
@@ -87,7 +85,7 @@ void initPythonIRBindings(PyObject * module_) {
     .VS(replaceAllUsesWith)
     .def("node",[](Value &v) { return v.node(); })
     .def("setTypeAs", [](Value * node, Value * other) {
-      node->setType(other->typeOption());
+      node->setType(other->type());
       return node;
     })
     .VS(copyMetadata)
@@ -207,13 +205,17 @@ void initPythonIRBindings(PyObject * module_) {
     })
     .def("kind",[](Type& t_) {
       Type * t = &t_;
-      TYPE_IF(t, HandleType)
-        return "HandleType";
-      TYPE_ELSEIF(TensorType)
-        return "TensorType";
-      TYPE_END()
-      torch::barf("unknown type kind");
-      return "";
+      switch(t->kind()) {
+        case TypeKind::HandleType:
+          return "HandleType";
+        case TypeKind::DynamicType:
+          return "DynamicType";
+        case TypeKind::TensorType:
+          return "TensorType";
+        default:
+          torch::barf("unknown type kind");
+          return "";
+        }
     })
     .def("sizes",[](Type& t) {
       return t.expect<TensorType>()->sizes();

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -300,8 +300,7 @@ struct to_ir {
     // we'll probably have to pattern match iteration number machinery in user
     // code to conform to the spec
     body_block->addInput(); // Iteration num
-    body_block->addInput(); // Condition
-    size_t skip_inputs_num = 2;
+    size_t skip_inputs_num = 1;
 
     {
       environment_stack =

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -286,6 +286,16 @@ struct to_ir {
     // https://github.com/onnx/onnx/blob/master/docs/Operators.md#experimental-loop
     // TODO: implement scan_outputs
 
+    // the format of the Loop instruction is:
+    // loop_carried_outputs* = Loop(max_trip_count, start_condition, loop_carried_inputs*)
+    //                          block0(loop_counter, loop_carried_block*) {
+    //                             <body>
+    //                             -> (continue_condition, loop_carried_block_outputs*)
+    //                          }
+    // all loop_carried_... lists are the same length and represent the value of
+    // loop-carried variables whose definitions are updated as the loop executes
+    // in a way that ensure single static assignment.
+
     // TODO: clarify that this is an optional input that isn't needed here
     Value* max_trip_count_dummy = emitConst(INT_MAX, "i")[0];
     Value* cond_value = emitExpr(stmt.cond(), 1)[0];

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -148,8 +148,8 @@ struct SymbolicVariable {
   }
 private:
   SymbolicVariable typeLike(SymbolicVariable other) {
-    if (auto other_type = other.v->typeOption())
-      v->setType(other_type->expect<TensorType>()->contiguous());
+    if (auto other_type = other.v->type()->cast<TensorType>())
+      v->setType(other_type->contiguous());
     return *this;
   }
   static Symbol s(const char * s_) {

--- a/torch/csrc/jit/tracer_state.cpp
+++ b/torch/csrc/jit/tracer_state.cpp
@@ -1,3 +1,4 @@
+#include "Python.h"
 #include "torch/csrc/jit/tracer_state.h"
 #include "torch/csrc/autograd/edge.h"
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -38,7 +38,8 @@ TypePtr HandleType::get() {
   return value;
 }
 TypePtr DynamicType::get() {
-  return std::make_shared<DynamicType>();
+  static auto value = std::make_shared<DynamicType>();
+  return value;
 }
 
 }} // namespace torch::jit

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -5,9 +5,7 @@
 namespace torch { namespace jit {
 
 std::ostream& operator<<(std::ostream & out, const Type & t) {
-  TYPE_IF(&t, HandleType)
-    out << "Handle";
-  TYPE_ELSEIF(TensorType)
+  if(auto value = t.cast<TensorType>()) {
     out << at::toString(value->scalarType()) << "(";
     auto& sizes = value->sizes();
     auto& strides = value->strides();
@@ -25,8 +23,22 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
       }
     }
     out << ")";
-  TYPE_END()
+  } else if(t.kind() == TypeKind::HandleType) {
+    out << "Handle";
+  } else if(t.kind() == TypeKind::DynamicType) {
+    out << "Dynamic";
+  } else {
+    barf("unknown type kind");
+  }
   return out;
+}
+
+TypePtr HandleType::get() {
+  static auto value = std::make_shared<HandleType>();
+  return value;
+}
+TypePtr DynamicType::get() {
+  return std::make_shared<DynamicType>();
 }
 
 }} // namespace torch::jit

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -119,6 +119,8 @@ struct TensorType : public Type {
 private:
   static std::vector<int64_t> contiguousStridesOf(at::IntList sizes) {
     std::vector<int64_t> strides(sizes.size());
+    if(sizes.size() == 0) // zero-dim case
+      return strides;
     strides.back() = 1;
     for(std::size_t i = strides.size() - 1; i > 0; i--) {
       strides[i-1] = strides[i] * sizes[i];

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -12,6 +12,7 @@
 namespace torch { namespace jit {
 
 #define TH_FORALL_TYPES(_) \
+_(DynamicType) \
 _(TensorType) \
 _(HandleType)
 
@@ -23,6 +24,7 @@ enum class TypeKind {
 
 struct Type;
 using TypePtr = std::shared_ptr<Type>;
+
 
 struct Type : std::enable_shared_from_this<Type> {
 private:
@@ -46,13 +48,33 @@ public:
     return nullptr;
   }
   template<typename T>
+  const T* cast() const {
+    if (T::Kind == kind())
+      return static_cast<const T*>(this);
+    return nullptr;
+  }
+  template<typename T>
   T* expect() {
     JIT_ASSERT(T::Kind == kind());
     return static_cast<T*>(this);
   }
+  template<typename T>
+  const T* expect() const {
+    JIT_ASSERT(T::Kind == kind());
+    return static_cast<const T*>(this);
+  }
   std::shared_ptr<Type> asShared() {
     return shared_from_this();
   }
+};
+
+
+struct DynamicType : public Type {
+  DynamicType()
+  : Type(TypeKind::DynamicType) {}
+  static const TypeKind Kind = TypeKind::DynamicType;
+  // global singleton
+  static TypePtr get();
 };
 
 // This node represents a single Tensor value
@@ -128,20 +150,29 @@ graph(%1, %8) {
 */
 struct HandleType : public Type {
   friend struct Type;
-
   HandleType()
     : Type(TypeKind::HandleType) {}
-
-public:
   static const TypeKind Kind = TypeKind::HandleType;
+  // global singleton
+  static TypePtr get();
 };
 
-std::ostream& operator<<(std::ostream & out, const Type & t);
+static inline bool operator==(const Type & lhs, const Type & rhs) {
+  if(lhs.kind() != rhs.kind())
+    return false;
+  if(lhs.kind() != TypeKind::TensorType)
+    return true;
+  auto lt = lhs.expect<TensorType>();
+  auto rt = lhs.expect<TensorType>();
+  return lt->scalarType() == rt->scalarType() &&
+         lt->sizes() == rt->sizes() &&
+         lt->strides() == rt->strides() &&
+         lt->device() == rt->device();
+}
+inline bool operator!=(const Type & lhs, const Type & rhs) {
+  return !(lhs == rhs);
+}
 
-// Immutable case
-#define TYPE_IF(x,Kind) GENERIC_IF(const,TypeKind::Kind,x,Kind)
-#define TYPE_ELSEIF(Kind) GENERIC_ELSEIF(const,TypeKind::Kind,Kind)
-#define TYPE_ELSE() GENERIC_ELSE()
-#define TYPE_END() GENERIC_END()
+std::ostream& operator<<(std::ostream & out, const Type & t);
 
 }} // namespace torch::jit


### PR DESCRIPTION
* This allows us to enable optimization in the GraphExecutor for most
  script tests.
* Changes Type to always be present (non-null) on a Value, removing `hasType()`
  and `typeOption()`. A new type kind 'DynamicType' now represents when
  a specific type has not been determined.
* If/Loop nodes propagate shapes/types in the simple cases where types of
  outputs do not change depending on where control flows. In other
  cases, we propagate DynamicType to indicate we do not know what
  the shape will be.
* Remove the `cond` input to the body of Loop to simplify handling in
  interpreter and shape propagation.