### PR TITLE
[ready] Add logdet and slogdet

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -193,7 +193,6 @@
   variants: function
 
 - func: det(Tensor self) -> Tensor
-- func: _det_with_svd(Tensor self) -> (Tensor, Tensor, Tensor, Tensor)
 
 - func: diagflat(Tensor self, int64_t offset=0) -> Tensor
   variants: function
@@ -313,6 +312,8 @@
 
 - func: linspace_out(Tensor result, Scalar start, Scalar end, int64_t steps=100) -> Tensor
   variants: function
+
+- func: logdet(Tensor self) -> Tensor
 
 - func: logspace(Type dtype, Scalar start, Scalar end, int64_t steps=100) -> Tensor
   variants: function
@@ -443,6 +444,8 @@
 
 - func: slice(Tensor self, int64_t dim=0, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1) -> Tensor
 
+- func: slogdet(Tensor self) -> (Tensor, Tensor)
+
 - func: smm(Tensor self, Tensor mat2) -> Tensor
 
 - func: split(Tensor self, int64_t split_size, int64_t dim=0) -> TensorList
@@ -480,6 +483,8 @@
     fft_size: frame_length
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
+
+- func: _svd_with_positive_UV_det(Tensor self, double det_sign) -> (Tensor, Tensor, Tensor)
 
 - func: sum(Tensor self) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -484,8 +484,6 @@
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
 
-- func: _svd_with_positive_UV_det(Tensor self, double det_sign) -> (Tensor, Tensor, Tensor)
-
 - func: sum(Tensor self) -> Tensor
   dispatch:
     CPU: _sum_cpu

--- a/aten/src/TH/generic/THTensorLapack.c
+++ b/aten/src/TH/generic/THTensorLapack.c
@@ -460,14 +460,14 @@ void THTensor_(gesvd2)(THTensor *ru_, THTensor *rs_, THTensor *rv_, THTensor *ra
 		   THTensor_(data)(rv__), ldvt,
 		   THTensor_(data)(work),lwork, &info);
 
-  THLapackCheckWithCleanup(" Lapack Error %s : %d superdiagonals failed to converge.",
+  THLapackCheckWithCleanup("Lapack Error %s : %d superdiagonals failed to converge.",
                            THCleanup(
                                THTensor_(free)(ru__);
                                THTensor_(free)(rs__);
                                THTensor_(free)(rv__);
                                THTensor_(free)(ra__);
                                THTensor_(free)(work);),
-                           "gesvd", info,"");
+                           "gesvd", info, "");
 
   if (*jobu == 'S')
     THTensor_(narrow)(rv__,NULL,1,0,k);

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2584,6 +2584,7 @@ method_tests = [
     ('index_fill', (), (0, torch.tensor(0, dtype=torch.int64), 2), 'scalar_both_dim', [0]),
     ('inverse', (S, S), NO_ARGS, '', NO_ARGS, [skipIfNoLapack]),
     ('det', (S, S), NO_ARGS, '', NO_ARGS, [skipIfNoLapack]),
+    ('det', (1, 1), NO_ARGS, '1x1', NO_ARGS, [skipIfNoLapack]),
     ('det', lambda: random_symmetric_matrix(S), NO_ARGS, 'symmetric', NO_ARGS, [skipIfNoLapack]),
     ('det', lambda: random_symmetric_psd_matrix(S), NO_ARGS, 'symmetric_psd', NO_ARGS, [skipIfNoLapack]),
     ('det', lambda: random_symmetric_pd_matrix(S), NO_ARGS, 'symmetric_pd', NO_ARGS, [skipIfNoLapack]),
@@ -2598,12 +2599,16 @@ method_tests = [
     # `logdet`, we also set `make_nonzero_det(matrix, sign=1)` to make the
     # matrix have positive det.
     ('logdet', lambda: make_nonzero_det(torch.randn(S, S), 1), NO_ARGS, '', NO_ARGS, [skipIfNoLapack]),
+    ('logdet', lambda: make_nonzero_det(torch.randn(1, 1), 1), NO_ARGS, '1x1', NO_ARGS, [skipIfNoLapack]),
     ('logdet', lambda: make_nonzero_det(random_symmetric_matrix(S), 1), NO_ARGS,
      'symmetric', NO_ARGS, [skipIfNoLapack]),
     ('logdet', lambda: make_nonzero_det(random_symmetric_pd_matrix(S), 1), NO_ARGS,
      'symmetric_pd', NO_ARGS, [skipIfNoLapack]),
     ('logdet', lambda: make_nonzero_det(random_fullrank_matrix_distinct_singular_value(S), 1, 0), NO_ARGS,
      'distinct_singular_values', NO_ARGS, [skipIfNoLapack]),
+    ('slogdet', lambda: make_nonzero_det(torch.randn(1, 1), 1), NO_ARGS, '1x1_pos_det', NO_ARGS, [skipIfNoLapack], [1]),
+    ('slogdet', lambda: make_nonzero_det(torch.randn(1, 1), -1), NO_ARGS,
+     '1x1_neg_det', NO_ARGS, [skipIfNoLapack], [1]),
     ('slogdet', lambda: make_nonzero_det(torch.randn(S, S), 1), NO_ARGS, 'pos_det', NO_ARGS, [skipIfNoLapack], [1]),
     ('slogdet', lambda: make_nonzero_det(torch.randn(S, S), -1), NO_ARGS, 'neg_det', NO_ARGS, [skipIfNoLapack], [1]),
     ('slogdet', lambda: make_nonzero_det(random_symmetric_matrix(S)), NO_ARGS,
@@ -2612,6 +2617,7 @@ method_tests = [
     ('slogdet', lambda: random_fullrank_matrix_distinct_singular_value(S), NO_ARGS,
      'distinct_singular_values', NO_ARGS, [skipIfNoLapack], [1]),
     ('svd', lambda: random_fullrank_matrix_distinct_singular_value(S), NO_ARGS, '', NO_ARGS, [skipIfNoLapack]),
+    ('svd', lambda: random_fullrank_matrix_distinct_singular_value(M), NO_ARGS, 'large', NO_ARGS, [skipIfNoLapack]),
     ('gesv', (S, S), ((S, S),), '', NO_ARGS, [skipIfNoLapack]),
     ('fill_', (S, S, S), (1,), 'number'),
     ('fill_', (), (1,), 'number_scalar'),
@@ -2815,22 +2821,23 @@ EXCLUDE_GRADCHECK = {
 EXCLUDE_GRADGRADCHECK = {
 }
 EXCLUDE_GRADGRADCHECK_BY_TEST_NAME = {
-    # Some of the following det ones pass because random matrix has full rank
-    # with high probability. But we can't rely on this. So only test gradgrad on
+    # *det methods uses svd in backward when matrix is not invertible. However,
+    # svd backward is unstable unless the matrix has positive distinct singular
+    # values. Generated random matrices satisfy this with high probability, but
+    # we can't rely on it. So only test gradgrad on invertible test cases and
     # _distinct_singular_values.
     'test_det',
+    'test_det_1x1',
     'test_det_symmetric',
-    'test_det_symmetric_pd',
     'test_det_symmetric_psd',
     'test_det_dim2_null',
     'test_det_rank1',
     'test_det_rank2',
     'test_logdet',
-    'test_logdet_symmetric_pd',
+    'test_logdet_1x1',
     'test_logdet_symmetric',
-    'test_slogdet_pos_det',
+    'test_slogdet_1x1_neg_det',
     'test_slogdet_neg_det',
-    'test_slogdet_symmetric_pd',
     'test_slogdet_symmetric',
 }
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -302,12 +302,12 @@ class TestAutograd(TestCase):
             self.assertEqual(l.grad.data, i * i * (1 + l.data))
 
     def test_backward_badcalls(self):
-        x = Variable(torch.ones(1))
+        x = torch.ones(1)
         with self.assertRaisesRegex(RuntimeError, 'does not require grad'):
             x.backward()
 
     def test_grad_badcalls(self):
-        x = Variable(torch.ones(1))
+        x = torch.ones(1)
         y = x ** 2
         with self.assertRaisesRegex(RuntimeError, 'does not require grad'):
             torch.autograd.grad(x, y)
@@ -2692,10 +2692,9 @@ method_tests = [
      'broadcast_all'),
     ('masked_select', (), (torch.tensor(1, dtype=torch.uint8),), 'scalar'),
     ('masked_select', (M, M), (torch.tensor(1, dtype=torch.uint8),), 'scalar_broadcast_rhs'),
-    ('masked_select', (), (Variable(mask_not_all_zeros((M, M)), requires_grad=False),), 'scalar_broadcast_lhs'),
-    ('masked_fill', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), 10)),
-    ('masked_fill', (M, M), (Variable(torch.ByteTensor(M, M).bernoulli_(), requires_grad=False), torch.tensor(10)),
-     'tensor'),
+    ('masked_select', (), (mask_not_all_zeros((M, M)),), 'scalar_broadcast_lhs'),
+    ('masked_fill', (M, M), (torch.ByteTensor(M, M).bernoulli_(), 10)),
+    ('masked_fill', (M, M), (torch.ByteTensor(M, M).bernoulli_(), torch.tensor(10)), 'tensor'),
     # no lhs or all broadcast on masked_fill or masked_scatter because it's always inplace
     ('masked_fill', (M, M), (torch.ByteTensor(M,).bernoulli_(), 10), 'broadcast_rhs'),
     ('masked_fill', (), (torch.tensor(0, dtype=torch.uint8, requires_grad=False).bernoulli_(), 10), 'scalar'),
@@ -2731,13 +2730,13 @@ method_tests = [
     ('topk', (), (1, 0, True, True), 'dim_desc_sort_scalar', [1]),
     ('take', (S, S, S), (torch.LongTensor([[-3, 2], [20, 2]]),)),
     ('take', (S, S, S), (torch.tensor(0, dtype=torch.int64),), 'scalar_index'),
-    ('take', (), (Variable(torch.LongTensor([0])),), 'scalar_data'),
+    ('take', (), (torch.LongTensor([0]),), 'scalar_data'),
     ('take', (), (torch.tensor(0, dtype=torch.int64),), 'scalar_both'),
     ('where', (M, M), (mask_not_all_zeros((M, M)), (M, M))),
     ('where', (M, 1, M), (mask_not_all_zeros((M, M)), (M, M, 1)), 'broadcast_all'),
     ('where', (), (bernoulli_scalar(), ()), 'scalar'),
     ('where', (M, 1, M), (bernoulli_scalar(), (M, M, 1)), 'scalar_broadcast_mask'),
-    ('where', (), (Variable(mask_not_all_zeros((M, M)), requires_grad=False), ()), 'scalar_broadcast_non_mask'),
+    ('where', (), (mask_not_all_zeros((M, M)), ()), 'scalar_broadcast_non_mask'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([1, 2]),)),
     ('__getitem__', torch.randn(S, S, S), (slice(0, 3),), 'slice'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([slice(0, 3), 1]),), 'slice_index'),
@@ -2751,7 +2750,7 @@ method_tests = [
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], slice(None)]),), 'adv_index_sub_2'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 3], Ellipsis]),), 'adv_index_sub_3'),
     ('__getitem__', torch.randn(S, S, S), (dont_convert([[0, 2, 3], [1, 3, 3],
-     Variable(torch.LongTensor([0, 0, 2]))]),), 'adv_index_var'),
+     torch.LongTensor([0, 0, 2])]),), 'adv_index_var'),
 ]
 # TODO: clamp with min/max
 
@@ -3042,7 +3041,7 @@ for test in method_tests:
             inplace_name = name + '_'
             # can't broadcast inplace to left hand side
             broadcast_skip_inplace = 'broadcast_lhs' in test_name or 'broadcast_all' in test_name
-            if hasattr(Variable(torch.ones(1)), inplace_name) and not broadcast_skip_inplace:
+            if hasattr(torch.ones(1), inplace_name) and not broadcast_skip_inplace:
                 check(inplace_name)
 
         assert not hasattr(TestAutograd, test_name), 'Two tests have the same name: ' + test_name

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1314,8 +1314,8 @@ class TestCuda(TestCase):
         return TestTorch._select_broadcastable_dims(dims_full)
 
     @unittest.skipIf(not HAS_MAGMA, "no MAGMA library detected")
-    def test_det(self):
-        TestTorch._test_det(self, lambda t: t.cuda())
+    def test_det_logdet_slogdet(self):
+        TestTorch._test_det_logdet_slogdet(self, lambda t: t.cuda())
 
     def test_view(self):
         TestTorch._test_view(self, lambda t: t.cuda())

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -406,7 +406,6 @@ tests = [
     ('qr', large_2d_lapack, lambda t: [], 'big', float_types),
     ('inverse', new_t(20, 20), lambda t: [], None, float_types),
     ('geqrf', new_t(20, 20), lambda t: [], None, float_types),
-    # TODO: add det to here once Variable and Tensor are the same thing
 ]
 
 # TODO: random functions, cat, gather, scatter, index*, masked*,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -219,9 +219,8 @@ class TestTorch(TestCase):
             self.assertEqual(res1, res2)
 
     def test_linear_algebra_scalar_raises(self):
-        from torch.autograd import Variable
-        m = Variable(torch.randn(5, 5))
-        v = Variable(torch.randn(5))
+        m = torch.randn(5, 5)
+        v = torch.randn(5)
         s = torch.tensor(7)
         self.assertRaises(RuntimeError, lambda: torch.mv(m, s))
         self.assertRaises(RuntimeError, lambda: torch.addmv(v, m, s))
@@ -270,10 +269,8 @@ class TestTorch(TestCase):
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_polygamma(self):
         from scipy.special import polygamma
-        from torch.autograd import Variable
         for n in [0, 1]:
             self._testMath(lambda x: torch.polygamma(n, x), lambda x: polygamma(n, x)[()])
-            self._testMath(lambda x: torch.polygamma(n, Variable(x)).data, lambda x: polygamma(n, x)[()])
 
     def test_asin(self):
         self._testMath(torch.asin, lambda x: math.asin(x) if abs(x) <= 1 else float('nan'))
@@ -359,8 +356,7 @@ class TestTorch(TestCase):
         self.assertIsNotNone(torch.Tensor([]).storage())
         self.assertIsNotNone(torch.Tensor().clone().storage())
         self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
-        from torch.autograd import Variable
-        self.assertIsNotNone(Variable(torch.Tensor()).new().storage())
+        self.assertIsNotNone(torch.Tensor().new().storage())
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_has_storage_numpy(self):
@@ -2326,10 +2322,9 @@ class TestTorch(TestCase):
             self.assertEqual(res.select(dim, 2), z, 0)
 
     def test_stack_out(self):
-        from torch.autograd import Variable
-        x = Variable(torch.rand(2, 3, 4))
-        y = Variable(torch.rand(2, 3, 4))
-        z = Variable(torch.rand(2, 3, 4))
+        x = torch.rand(2, 3, 4)
+        y = torch.rand(2, 3, 4)
+        z = torch.rand(2, 3, 4)
         for dim in range(4):
             expected_size = x.size()[:dim] + (3,) + x.size()[dim:]
             res_out = x.new(expected_size)
@@ -4786,8 +4781,7 @@ class TestTorch(TestCase):
         self.assertEqual(x.size(), orig)
 
     def test_storage(self):
-        from torch.autograd import Variable
-        v = Variable(torch.randn(3, 5))
+        v = torch.randn(3, 5)
         self.assertEqual(v.storage()[0], v.data[0][0])
         self.assertEqual(v.storage()[14], v.data[2][4])
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2918,7 +2918,7 @@ class TestTorch(TestCase):
         self.assertEqual(MII, MI, 0, 'inverse value in-place')
 
     @staticmethod
-    def _test_det(self, conv_fn):
+    def _test_det_logdet_slogdet(self, conv_fn):
         def reference_det(M):
             # naive row reduction
             M = M.clone()
@@ -2939,16 +2939,37 @@ class TestTorch(TestCase):
                 M[i] = row
             return M.diag().prod() * multiplier
 
-        eye_det = conv_fn(torch.eye(5)).det()
-        self.assertEqual(eye_det, eye_det.clone().fill_(1), 1e-8, 'determinant of identity')
+        def test_single_det(M, target, desc):
+            det = M.det()
+            logdet = M.logdet()
+            sdet, logabsdet = M.slogdet()
+            self.assertEqual(det, target, 1e-7, '{} (det)'.format(desc))
+            if det.item() < 0:
+                self.assertTrue(logdet.item() != logdet.item(), '{} (logdet negative case)'.format(desc))
+                self.assertTrue(sdet.item() == -1, '{} (slogdet sign negative case)'.format(desc))
+                self.assertEqual(logabsdet.exp(), det.abs(), 1e-7, '{} (slogdet logabsdet negative case)'.format(desc))
+            elif det.item() == 0:
+                self.assertEqual(logdet.exp().item(), 0, 1e-7, '{} (logdet zero case)'.format(desc))
+                self.assertTrue(sdet.item() == 0, '{} (slogdet sign zero case)'.format(desc))
+                self.assertEqual(logabsdet.exp().item(), 0, 1e-7, '{} (slogdet logabsdet zero case)'.format(desc))
+            else:
+                self.assertEqual(logdet.exp(), det, 1e-7, '{} (logdet positive case)'.format(desc))
+                self.assertTrue(sdet.item() == 1, '{} (slogdet sign  positive case)'.format(desc))
+                self.assertEqual(logabsdet.exp(), det, 1e-7, '{} (slogdet logabsdet positive case)'.format(desc))
+
+        eye = conv_fn(torch.eye(5))
+        test_single_det(eye, torch.tensor(1, dtype=eye.dtype), 'identity')
 
         def test(M):
+            assert M.size(0) >= 5, 'this helper fn assumes M to be at least 5x5'
             M = conv_fn(M)
-            M_det = M.det().data
+            M_det = M.det()
+            ref_M_det = reference_det(M)
 
-            self.assertEqual(M_det, M_det.clone().fill_(reference_det(M)), 1e-8, 'determinant')
-            self.assertEqual(M_det, M.inverse().det().data.pow_(-1), 1e-8, 'determinant after transpose')
-            self.assertEqual(M_det, M.transpose(0, 1).det().data, 1e-8, 'determinant after transpose')
+            test_single_det(M, ref_M_det, 'basic')
+            if abs(ref_M_det.item()) >= 1e-10:  # skip singular
+                test_single_det(M, M.inverse().det().pow_(-1), 'inverse')
+            test_single_det(M, M.t().det(), 'transpose')
 
             for x in [0, 2, 4]:
                 for scale in [-2, -0.1, 0, 10]:
@@ -2956,13 +2977,11 @@ class TestTorch(TestCase):
                     # dim 0
                     M_clone = M.clone()
                     M_clone[:, x] *= scale
-                    det = M_clone.det()
-                    self.assertEqual(target, det, 1e-8, 'determinant after scaling a row')
+                    test_single_det(M_clone, target, 'scale a row')
                     # dim 1
                     M_clone = M.clone()
                     M_clone[x, :] *= scale
-                    det = M_clone.det()
-                    self.assertEqual(target, det, 1e-8, 'determinant after scaling a column')
+                    test_single_det(M_clone, target, 'scale a column')
 
             for x1, x2 in [(0, 3), (4, 1), (3, 2)]:
                 assert x1 != x2, 'x1 and x2 needs to be different for this test'
@@ -2970,13 +2989,11 @@ class TestTorch(TestCase):
                 # dim 0
                 M_clone = M.clone()
                 M_clone[:, x2] = M_clone[:, x1]
-                det = M_clone.det()
-                self.assertEqual(target, det, 1e-8, 'determinant when two rows are same')
+                test_single_det(M_clone, target, 'two rows are same')
                 # dim 1
                 M_clone = M.clone()
                 M_clone[x2, :] = M_clone[x1, :]
-                det = M_clone.det()
-                self.assertEqual(target, det, 1e-8, 'determinant when two columns are same')
+                test_single_det(M_clone, target, 'two columns are same')
 
                 for scale1, scale2 in [(0.3, -1), (0, 2), (10, 0.1)]:
                     target = -M_det * scale1 * scale2
@@ -2985,24 +3002,63 @@ class TestTorch(TestCase):
                     t = M_clone[:, x1] * scale1
                     M_clone[:, x1] += M_clone[:, x2] * scale2
                     M_clone[:, x2] = t
-                    det = M_clone.det()
-                    self.assertEqual(target, det, 1e-8, 'determinant after exchanging rows')
+                    test_single_det(M_clone, target, 'exchanging rows')
                     # dim 1
                     M_clone = M.clone()
                     t = M_clone[x1, :] * scale1
                     M_clone[x1, :] += M_clone[x2, :] * scale2
                     M_clone[x2, :] = t
-                    det = M_clone.det()
-                    self.assertEqual(target, det, 1e-8, 'determinant after exchanging columns')
+                    test_single_det(M_clone, target, 'exchanging columns')
 
-        test(torch.randn(5, 5))
-        r = torch.randn(5, 5)
-        test(r.mm(r.transpose(0, 1)))  # symmetric
-        test(torch.randn(5, 5, 5)[:, 2, :])  # non-contiguous
+        def get_random_mat_scale(n):
+            # For matrices with values i.i.d. with 0 mean, unit variance, and
+            # subexponential tail, we have:
+            #   E[log det(A^2)] \approx log((n-1)!)
+            #
+            # Notice:
+            #   log Var[det(A)] = log E[det(A^2)] >= E[log det(A^2)]
+            #
+            # So:
+            #   stddev[det(A)] >= sqrt( (n-1)! )
+            #
+            # We use this as an intuitive guideline to scale random generated
+            # matrices so our closeness tests can work more robustly:
+            #   scale by sqrt( (n-1)! )^(-1/n) = ( (n-1)! )^(-1/(2n))
+            #
+            # source: https://arxiv.org/pdf/1112.0752.pdf
+            return math.factorial(n - 1) ** (-1.0 / (2 * n))
+
+        for n in [5, 10, 25]:
+            scale = get_random_mat_scale(n)
+            test(torch.randn(n, n) * scale)
+            r = torch.randn(n, n) * scale
+            # symmetric psd
+            test(r.mm(r.t()))
+            # symmetric pd
+            r = torch.randn(n, n) * scale
+            test(r.mm(r.t()) + torch.eye(n) * 1e-6)
+            # symmetric
+            r = torch.randn(n, n) * scale
+            for i in range(n):
+                for j in range(i):
+                    r[i, j] = r[j, i]
+            test(r)
+            # non-contiguous
+            test((torch.randn(n, n, n + 1) * scale)[:, 2, 1:])
+            # det = 0
+            r = torch.randn(n, n) * scale
+            u, s, v = r.svd()
+            if reference_det(u) < 0:
+                u = -u
+            if reference_det(v) < 0:
+                v = -v
+            s[0] *= -1
+            s[-1] = 0
+            test(u.mm(s.diag()).mm(v))
 
     @skipIfNoLapack
-    def test_det(self):
-        self._test_det(self, lambda x: x)
+    def test_det_logdet_slogdet(self):
+        self._test_det_logdet_slogdet(self, lambda x: x)
 
     @staticmethod
     def _test_stft(self, conv_fn):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -194,8 +194,8 @@
 - name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad)
   self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)
 
-- name: _det_with_svd(Tensor self)
-  self: _det_with_svd_backward(grads, self, result0, result1, result2, result3)
+- name: det(Tensor self)
+  self: det_backward(grad, self, result)
 
 - name: diag(Tensor self, int64_t diagonal)
   self: diag_backward(grad, self.sizes(), diagonal)
@@ -350,6 +350,9 @@
 
 - name: log1p(Tensor self)
   self: grad / (self + 1)
+
+- name: logdet(Tensor self)
+  self: logdet_backward(grad, self, result)
 
 - name: log_normal_(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
@@ -558,6 +561,9 @@
 - name: sinh(Tensor self)
   self: grad * self.cosh()
 
+- name: slogdet(Tensor self)
+  self: slogdet_backward(grads, self, result0, result1)
+
 - name: sort(Tensor self, int64_t dim, bool descending)
   self: select_backward(grad, dim, indices, self.sizes(), true)
 
@@ -596,7 +602,10 @@
   self: sum_backward(grad, self.sizes(), dim, keepdim)
 
 - name: svd(Tensor self, bool some)
-  self: svd_backward(grads, self, some, res1, res2, res3)
+  self: svd_backward(grads, self, some, res1, res2, res3)  # resX are defined in Declarations.cwrap
+
+- name: _svd_with_positive_UV_det(Tensor self, double det_sign)
+  self: svd_backward(grads, self, true, result0, result1, result2)
 
 - name: symeig(Tensor self, bool eigenvectors, bool upper)
   self: not_implemented("symeig")

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -604,9 +604,6 @@
 - name: svd(Tensor self, bool some)
   self: svd_backward(grads, self, some, res1, res2, res3)  # resX are defined in Declarations.cwrap
 
-- name: _svd_with_positive_UV_det(Tensor self, double det_sign)
-  self: svd_backward(grads, self, true, result0, result1, result2)
-
 - name: symeig(Tensor self, bool eigenvectors, bool upper)
   self: not_implemented("symeig")
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2018,3 +2018,17 @@ where(condition, y) -> Tensor
 ``self.where(condition, y)`` is equivalent to ``torch.where(condition, self, y)``.
 See :func:`torch.where`
 """)
+
+add_docstr_all('logdet',
+               r"""
+logdet() -> Tensor
+
+See :func:`torch.logdet`
+""")
+
+add_docstr_all('slogdet',
+               r"""
+slogdet() -> (Tensor, Tensor)
+
+See :func:`torch.slogdet`
+""")

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3985,16 +3985,16 @@ add_docstr(torch.qr,
            r"""
 qr(input, out=None) -> (Tensor, Tensor)
 
-Computes the QR decomposition of a matrix :attr:`input`: returns matrices
-`Q` and `R` such that :math:`\text{input} = Q R`, with `Q` being an orthogonal matrix
-and `R` being an upper triangular matrix.
+Computes the QR decomposition of a matrix :attr:`input`, and returns matrices
+`Q` and `R` such that :math:`\text{input} = Q R`, with :math:`Q` being an
+orthogonal matrix and :math:`R` being an upper triangular matrix.
 
 This returns the thin (reduced) QR factorization.
 
 .. note:: precision may be lost if the magnitudes of the elements of :attr:`input`
           are large
 
-.. note:: while it should always give you a valid decomposition, it may not
+.. note:: While it should always give you a valid decomposition, it may not
           give you the same one across platforms - it will depend on your
           LAPACK implementation.
 
@@ -4847,7 +4847,7 @@ real matrix `A` of size `(n x m)` such that :math:`A = USV^T`.
 `U` is of shape :math:`(n \times n)`.
 
 `S` is a diagonal matrix of shape :math:`(n \times m)`, represented as a vector
-of size :math:`\min(n, m)` containing the diagonal entries.
+of size :math:`\min(n, m)` containing the non-negative diagonal entries.
 
 `V` is of shape :math:`(m \times m)`.
 
@@ -4859,13 +4859,11 @@ contain only :math:`min(n, m)` orthonormal columns.
 
 .. note:: Extra care needs to be taken when backward through `U` and `V`
           outputs. Such operation is really only stable when :attr:`input` is
-          full rank with all distinct singular values. Otherwise, `NaN` can
+          full rank with all distinct singular values. Otherwise, ``NaN`` can
           appear as the gradients are not properly defined. Also, when
-          :attr:`some` = `False`, the gradients on `U[:, min(n, m):]` and
-          `V[:, min(n, m):]` will be ignored as those vectors can be arbitrary
+          :attr:`some` = ``False``, the gradients on ``U[:, min(n, m):]`` and
+          ``V[:, min(n, m):]`` will be ignored as those vectors can be arbitrary
           bases of the subspaces.
-
-.. note:: Double backward through :meth:`~torch.svd` is not supported currently.
 
 Args:
     input (Tensor): the input 2-D tensor
@@ -5635,7 +5633,7 @@ btrifact_with_info(A, pivot=True) -> (Tensor, IntTensor, IntTensor)
 Batch LU factorization with additional error information.
 
 This is a version of :meth:`torch.btrifact` that always creates an info
-`IntTensor`, and returns it as the third return value
+`IntTensor`, and returns it as the third return value.
 
 Arguments:
     A (Tensor): the tensor to factor
@@ -5817,5 +5815,85 @@ Excemple::
      1.0000  1.0000
      1.0000  0.5734
     [torch.FloatTensor of size (3,2)]
+
+""")
+
+add_docstr(torch.logdet,
+           r"""
+logdet(A) -> Tensor
+
+Calculates log determinant of a 2D square tensor.
+
+.. note::
+    Result is ``-inf`` if :attr:`A` has zero log determinant, and is ``nan`` if
+    :attr:`A` has negative determinant.
+
+.. note::
+    Backward through :meth:`logdet` internally uses SVD results. So double
+    backward through :meth:`logdet` will need to backward through
+    :meth:`~Tensor.svd`. This can be unstable in certain cases. Please see
+    :meth:`~torch.svd` for details.
+
+Arguments:
+    A (Tensor): The input 2D square tensor
+
+Example::
+
+    >>> A = torch.randn(3, 3)
+    >>> torch.det(A)
+
+    1.9386
+    [torch.FloatTensor of size ()]
+
+    >>> torch.logdet(A)
+
+    0.6620
+    [torch.FloatTensor of size ()]
+
+""")
+
+add_docstr(torch.slogdet,
+           r"""
+slogdet(A) -> (Tensor, Tensor)
+
+Calculates the sign and log value of a 2D square tensor's determinant.
+
+.. note::
+    If ``A`` has zero determinant, this returns ``(0, -inf)``.
+
+.. note::
+    Backward through :meth:`slogdet` internally uses SVD results. So double
+    backward through :meth:`slogdet` will need to backward through
+    :meth:`~Tensor.svd`. This can be unstable in certain cases. Please see
+    :meth:`~torch.svd` for details.
+
+Arguments:
+    A (Tensor): The input 2D square tensor
+
+Returns:
+    A tuple containing the sign of the determinant, and the log value of the
+    absolute determinant.
+
+Example::
+
+    >>> A = torch.randn(3, 3)
+    >>> torch.det(A)
+
+    -0.3534
+    [torch.FloatTensor of size ()]
+
+    >>> torch.logdet(A)
+
+    nan
+    [torch.FloatTensor of size ()]
+
+    >>> torch.slogdet(A)
+    (
+    -1
+    [torch.FloatTensor of size ()]
+    ,
+    -1.0402
+    [torch.FloatTensor of size ()]
+    )
 
 """)


### PR DESCRIPTION
See commit messages for details of each commit. Notice that the last commit changes the QR based approach to LU based.

Some comments about switching from QR to LU:

1. QR (`geqrf`) is generally more stable than LU (`getrf`).
2. But `getrf` gives specific information about matrix being singular or not. Furthermore, the backward (when det > 0) uses matrix inverse (`getrf` + `getri`), so using `getrf` in forward makes sense.
3. Finally, this is also more consistent with many other libraries (including NumPy and MATLAB) that use LU factorization (`getrf`) to compute determinant. 

Therefore, in this PR, det is computed using `btrtifact` (batched `getrf`). However, the backward still uses `inverse` (`getrf` + `getri`). So future work include:
1. expose `getri` and cache `getrf` results to speed up backward.
2. implement batched `getri` to support batched det methods.