### PR TITLE
Accept GPU perf test regression.

### DIFF
--- a/.jenkins/perf_test/perf_test_numbers.json
+++ b/.jenkins/perf_test/perf_test_numbers.json
@@ -22,8 +22,8 @@
 	},
 
 	"test_gpu_speed_word_language_model": {
-		"mean": "5.65807",
-		"sigma": "0.1132"
+		"mean": "5.9411499999999995",
+		"sigma": "0.02134777505971057"
 	},
 
 	"test_gpu_speed_cudnn_lstm": {


### PR DESCRIPTION
Sam says that the regression looks like it was just in the setup code, not the main loop. This should get the CI green again.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>