### PR TITLE
make CuDNN finders respect library major version

### DIFF
--- a/aten/cmake/FindCuDNN.cmake
+++ b/aten/cmake/FindCuDNN.cmake
@@ -15,13 +15,21 @@ include(FindPackageHandleStandardArgs)
 
 set(CUDNN_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA cuDNN")
 
-find_path(CUDNN_INCLUDE_DIR cudnn.h
+if($ENV{CUDNN_INCLUDE_DIR})
+  SET(CUDNN_INCLUDE_DIR $ENV{CUDNN_INCLUDE_DIR})
+else($ENV{CUDNN_INCLUDE_DIR})
+  find_path(CUDNN_INCLUDE_DIR cudnn.h
     HINTS ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES cuda/include include)
+endif($ENV{CUDNN_INCLUDE_DIR})
 
-find_library(CUDNN_LIBRARY cudnn
+if($ENV{CUDNN_LIBRARY})
+  SET(CUDNN_LIBRARY $ENV{CUDNN_LIBRARY})
+else($ENV{CUDNN_LIBRARY})
+  find_library(CUDNN_LIBRARY cudnn
     HINTS ${CUDNN_LIB_DIR} ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
+endif($ENV{CUDNN_LIBRARY})
 
 find_package_handle_standard_args(
     CUDNN DEFAULT_MSG CUDNN_INCLUDE_DIR CUDNN_LIBRARY)

--- a/setup.py
+++ b/setup.py
@@ -708,8 +708,7 @@ if WITH_NCCL:
         "torch/csrc/cuda/python_nccl.cpp",
     ]
 if WITH_CUDNN:
-    main_libraries += ['cudnn']
-    library_dirs.insert(0, CUDNN_LIB_DIR)
+    main_libraries += [CUDNN_LIBRARY]
     # NOTE: these are at the front, in case there's another cuDNN in CUDA path
     include_dirs.insert(0, CUDNN_INCLUDE_DIR)
     if not IS_WINDOWS:


### PR DESCRIPTION
- FindCuDNN.cmake wasn't respecting `setup.py`'s found CUDNN_INCLUDE_DIR and CUDNN_LIBRARY
- CUDNN_INCLUDE_DIR wasn't respecting path order (a `break` on found was missing)
- There was no `setup_helpers/cudnn.py` check to make sure that the header `cudnn.h` that is found is paired with the corresponding `libcudnn.so`.

All these three issues have been fixed.

Fixes https://github.com/pytorch/pytorch/issues/5369

cc: @ezyang 