### PR TITLE
Check if CXX compiler supports all the needed functions

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -10,32 +10,6 @@ project(ATen)
 
 cmake_policy(SET CMP0012 NEW)
 
-INCLUDE(CheckCXXSourceCompiles)
-
-#Check if certain std functions are supported. Sometimes
-#_GLIBCXX_USE_C99 macro is not defined and some functions are missing.
-CHECK_CXX_SOURCE_COMPILES("
-#include <math.h>
-#include <string>
-
-int main() {
-  int a = std::isinf(3.0);
-  int b = std::isnan(0.0);
-  std::string s = std::to_string(1);
-
-  return 0;
-  }" SUPPORT_GLIBCXX_USE_C99)
-
-if(NOT SUPPORT_GLIBCXX_USE_C99)
-  message(FATAL_ERROR
-	  "The C++ compiler does not support required functions. "
-	  "This is very likely due to a known bug in GCC 5 "
-	  "(and maybe other versions) on Ubuntu 17.10 and newer. "
-          "For more information, see: "
-	  "https://github.com/pytorch/pytorch/issues/5229"
-         )
-endif()
-
 # RPATH stuff
 # see https://cmake.org/Wiki/CMake_RPATH_handling
 if(APPLE)
@@ -56,6 +30,31 @@ IF(NOT MSVC)
   set(CMAKE_C_FLAGS "-fexceptions ${CMAKE_C_FLAGS}")
 ENDIF(NOT MSVC)
 
+INCLUDE(CheckCXXSourceCompiles)
+
+#Check if certain std functions are supported. Sometimes
+#_GLIBCXX_USE_C99 macro is not defined and some functions are missing.
+CHECK_CXX_SOURCE_COMPILES("
+#include <cmath>
+#include <string>
+
+int main() {
+  int a = std::isinf(3.0);
+  int b = std::isnan(0.0);
+  std::string s = std::to_string(1);
+
+  return 0;
+  }" SUPPORT_GLIBCXX_USE_C99)
+
+if(NOT SUPPORT_GLIBCXX_USE_C99)
+  message(FATAL_ERROR
+          "The C++ compiler does not support required functions. "
+          "This is very likely due to a known bug in GCC 5 "
+          "(and maybe other versions) on Ubuntu 17.10 and newer. "
+          "For more information, see: "
+          "https://github.com/pytorch/pytorch/issues/5229"
+         )
+endif()
 
 # Top-level build config
 ############################################

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -10,32 +10,30 @@ project(ATen)
 
 cmake_policy(SET CMP0012 NEW)
 
-# ---[ If running on Ubuntu, check system version and compiler version.
-if(EXISTS "/etc/os-release")
-  execute_process(COMMAND
-    "sed" "-ne" "s/^ID=\\([a-z]\\+\\)$/\\1/p" "/etc/os-release"
-    OUTPUT_VARIABLE OS_RELEASE_ID
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  execute_process(COMMAND
-    "sed" "-ne" "s/^VERSION_ID=\"\\([0-9\\.]\\+\\)\"$/\\1/p" "/etc/os-release"
-    OUTPUT_VARIABLE OS_RELEASE_VERSION_ID
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  if(OS_RELEASE_ID STREQUAL "ubuntu")
-    if(OS_RELEASE_VERSION_ID VERSION_GREATER "17.04")
-      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0.0"
-          AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0.0")
-            message(FATAL_ERROR
-              "Do not use GCC 5. GCC 5 has a known bug in Ubuntu 17.10"
-              " and higher, which won't be fixed. For more information, see: "
-              "https://github.com/pytorch/pytorch/issues/5229"
-              )
-        endif()
-      endif()
-    endif()
-  endif()
+INCLUDE(CheckCXXSourceCompiles)
+
+#Check if certain std functions are supported. Sometimes
+#_GLIBCXX_USE_C99 macro is not defined and some functions are missing.
+CHECK_CXX_SOURCE_COMPILES("
+#include <math.h>
+#include <string>
+
+int main() {
+  int a = std::isinf(3.0);
+  int b = std::isnan(0.0);
+  std::string s = std::to_string(1);
+
+  return 0;
+  }" SUPPORT_GLIBCXX_USE_C99)
+
+if(NOT SUPPORT_GLIBCXX_USE_C99)
+  message(FATAL_ERROR
+	  "The C++ compiler does not support required functions. "
+	  "This is very likely due to a known bug in GCC 5 "
+	  "(and maybe other versions) on Ubuntu 17.10 and newer. "
+          "For more information, see: "
+	  "https://github.com/pytorch/pytorch/issues/5229"
+         )
 endif()
 
 # RPATH stuff


### PR DESCRIPTION
This commit improves the code for PR #5230 according to
@ezyang comments. Instead of checking ubuntu/gcc versions it
checks the support for the needed functions from the C++ compiler
using CHECK_CXX_SOURCE_COMPILES.

Fixes: #5229