### PR TITLE
Simplified unpack with additional error messages

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -76,6 +76,21 @@ class BytesIOContext(io.BytesIO):
 
 
 class TestTorch(TestCase):
+    
+    def test_scalar_unpack(self):
+        SMALL_NUM = 1e+5
+        LARGE_NUM = 1e+40
+
+
+        # unpackdouble for small float
+        torch.Tensor(100).fill_(SMALL_NUM)
+        # unpacklong for small int
+        torch.Tensor(100).fill_(int(SMALL_NUM))
+
+        # Testing unpackdouble for large float, should warning precision loss
+        torch.Tensor(100).fill_(LARGE_NUM)
+        # unpacklong for large int, should raise exception
+        self.assertRaises(RuntimeError, lambda: torch.Tensor(100).fill_(int(LARGE_NUM)))
 
     def test_dot(self):
         types = {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -76,7 +76,7 @@ class BytesIOContext(io.BytesIO):
 
 
 class TestTorch(TestCase):
-    
+
     def test_scalar_unpack(self):
         SMALL_NUM = 1e+5
         LARGE_NUM = 1e+40
@@ -87,10 +87,14 @@ class TestTorch(TestCase):
         # unpacklong for small int
         torch.Tensor(100).fill_(int(SMALL_NUM))
 
-        # Testing unpackdouble for large float, should warning precision loss
+        # unpackdouble for large float
         torch.Tensor(100).fill_(LARGE_NUM)
         # unpacklong for large int, should raise exception
         self.assertRaises(RuntimeError, lambda: torch.Tensor(100).fill_(int(LARGE_NUM)))
+        # unpackdouble for larget int, should print a warning to stderr
+        with warnings.catch_warnings(record=True) as w:
+            torch.Tensor([int(LARGE_NUM)])
+        self.assertGreater(len(w), 0)
 
     def test_dot(self):
         types = {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -77,25 +77,6 @@ class BytesIOContext(io.BytesIO):
 
 class TestTorch(TestCase):
 
-    def test_scalar_unpack(self):
-        SMALL_NUM = 1e+5
-        LARGE_NUM = 1e+40
-
-
-        # unpackdouble for small float
-        torch.Tensor(100).fill_(SMALL_NUM)
-        # unpacklong for small int
-        torch.Tensor(100).fill_(int(SMALL_NUM))
-
-        # unpackdouble for large float
-        torch.Tensor(100).fill_(LARGE_NUM)
-        # unpacklong for large int, should raise exception
-        self.assertRaises(RuntimeError, lambda: torch.Tensor(100).fill_(int(LARGE_NUM)))
-        # unpackdouble for larget int, should print a warning to stderr
-        with warnings.catch_warnings(record=True) as w:
-            torch.Tensor([int(LARGE_NUM)])
-        self.assertGreater(len(w), 0)
-
     def test_dot(self):
         types = {
             'torch.DoubleTensor': 1e-8,
@@ -5572,6 +5553,28 @@ class TestTorch(TestCase):
         t /= 2
         id_after = id(t)
         self.assertEqual(id_before, id_after)
+
+    def test_scalar_unpack(self):
+        SMALL_NUM = 1e+5
+        LARGE_NUM = 1e+40
+
+        # unpackdouble for small float
+        torch.Tensor(100).fill_(SMALL_NUM)
+        # unpacklong for small int
+        torch.Tensor(100).fill_(int(SMALL_NUM))
+
+        # unpackdouble for large float
+        torch.Tensor(100).fill_(LARGE_NUM)
+        # unpacklong for large int, should raise exception
+        self.assertRaises(RuntimeError, lambda: torch.Tensor(100).fill_(int(LARGE_NUM)))
+        if sys.version_info[0] < 3:
+            self.assertRaises(RuntimeError, lambda: torch.Tensor(100).fill_(long(LARGE_NUM)))
+        # unpackdouble for larget int, should print a warning to stderr
+        with warnings.catch_warnings(record=True) as w:
+            torch.Tensor([int(LARGE_NUM)])
+            if sys.version_info[0] < 3:
+                torch.Tensor([long(LARGE_NUM)])
+        self.assertGreater(len(w), 0)
 
     def test_simple_scalar_cast(self):
         ok = [torch.Tensor([1.5]), torch.zeros(1, 1, 1, 1)]

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -70,15 +70,18 @@ inline double THPUtils_unpackDouble(PyObject* obj) {
     return PyFloat_AS_DOUBLE(obj);
   }
   if (PyLong_Check(obj)) {
-    int overflow;
-    long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
-    if (overflow != 0) {
+    double value = PyLong_AsDouble(obj);
+
+    // convert from python error to C exception
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
       throw std::runtime_error("Overflow when unpacking double");
     }
     if (value > DOUBLE_INT_MAX || value < -DOUBLE_INT_MAX) {
+      // FIXME: warning instead of raise exception
       throw std::runtime_error("Precision loss when unpacking double");
     }
-    return (double)value;
+    return value;
   }
 #if PY_MAJOR_VERSION == 2
   if (PyInt_Check(obj)) {

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -62,7 +62,7 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
   #endif
     Py_XDECREF(objRepr);
     throw std::runtime_error("Overflow when unpacking long."
-      " The int passed in (" + std::string(objString) + ") is not representable"
+      " The number passed in (" + std::string(objString) + ") is not representable"
       " by int64, maybe you should convert it to float first");
   }
   return (int64_t)value;
@@ -82,16 +82,16 @@ inline double THPUtils_unpackDouble(PyObject* obj) {
   }
   if (PyLong_Check(obj)) {
     double value = PyLong_AsDouble(obj);
-    // convert from python error to C exception
+    // raise error on overflow
     if (PyErr_Occurred() &&
      PyErr_GivenExceptionMatches(PyErr_Occurred(), PyExc_OverflowError)) {
       PyErr_Clear();
       throw std::runtime_error("Overflow when unpacking double");
     }
-    // FIXME: can't find a test case to invoke following line
+    // raise warning on precision loss
     if (value > DOUBLE_INT_MAX || value < -DOUBLE_INT_MAX) {
-      std::cerr << "WARNING: Precision loss "
-        "when converting int to double" << std::endl;
+      auto warning_message = "Precision loss when converting int to double";
+      PyErr_WarnEx(PyExc_RuntimeWarning, warning_message, 1);
     }
     return value;
   }


### PR DESCRIPTION
The original version doesn't work for `torch.Tensor`, it raises **Runtime Error: Overflow when unpacking long** from the C backend:
https://github.com/pytorch/pytorch/blob/6204877cd44594541956d164e324642cae523d59/torch/csrc/utils/python_numbers.h#L48-L58

here's a minimal snippet:

```python
import torch
a = torch.Tensor(5)
print(a)
```

Actually I don't quite understand the existing method, it's not numerical stable because some random float numbers may satisfy `value == math.ceil(value)` in python.