### PR TITLE
Remove two uses of the old Tensor class

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -178,7 +178,7 @@ PyObject * THCPModule_getRNGState(PyObject *_unused)
 PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *obj)
 {
   HANDLE_TH_ERRORS
-  if (!THPVariable_Check(obj)) {
+  if (!THPVariable_Check(obj) || THPVariable_UnpackData(obj).type().ID() != at::TypeID::CPUByte) {
     throw TypeError("set_rng_state expects a torch.ByteTensor, but got %s",
         Py_TYPE(obj)->tp_name);
   }

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -13,9 +13,12 @@
 
 #include "THCP.h"
 
+#include "torch/csrc/autograd/generated/VariableType.h"
 #include "torch/csrc/utils/python_strings.h"
 #include "torch/csrc/cuda/python_comm.h"
 #include "ModuleSparse.cpp"
+
+using namespace torch;
 
 THCState *state;
 
@@ -163,21 +166,24 @@ PyObject * THCPModule_getCompiledVersion(PyObject *self)
 
 PyObject * THCPModule_getRNGState(PyObject *_unused)
 {
+  using namespace at;
+  using namespace torch::autograd;
   HANDLE_TH_ERRORS
-  THPByteTensorPtr res((THPByteTensor *)THPByteTensor_NewEmpty());
-  if (!res) return NULL;
-  THCRandom_getRNGState(state, res->cdata);
-  return (PyObject *)res.release();
+  auto tensor = VariableType::getType(CPU(kByte))->tensor();
+  THCRandom_getRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
+  return THPVariable_Wrap(tensor);
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *_new_rng_state)
+PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *obj)
 {
   HANDLE_TH_ERRORS
-  THPUtils_assert(THPByteTensor_Check(_new_rng_state), "set_rng_state expects a "
-          "torch.ByteTensor, but got %s", THPUtils_typename(_new_rng_state));
-  THByteTensor *new_rng_state = ((THPByteTensor*)_new_rng_state)->cdata;
-  THCRandom_setRNGState(state, new_rng_state);
+  if (!THPVariable_Check(obj)) {
+    throw TypeError("set_rng_state expects a torch.ByteTensor, but got %s",
+        Py_TYPE(obj)->tp_name);
+  }
+  auto& tensor = THPVariable_UnpackData(obj);
+  THCRandom_setRNGState(state, (THByteTensor*)tensor.unsafeGetTH(false));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -13,6 +13,7 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
 
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/Exceptions.h"
+#include "torch/csrc/autograd/python_variable.h"
 
 #include <ATen/ATen.h>
 #include <memory>
@@ -25,6 +26,7 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
 #include <numpy/arrayobject.h>
 
 using namespace at;
+using namespace torch::autograd;
 
 namespace torch { namespace utils {
 
@@ -76,7 +78,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   // object of the ndarray to the tensor and disabling resizes on the storage.
   // This is not sufficient. For example, the tensor's storage may be changed
   // via Tensor.set_, which can free the underlying memory.
-  PyObject* py_tensor = createPyObject(tensor);
+  PyObject* py_tensor = THPVariable_Wrap(make_variable(tensor, false));
   if (!py_tensor) throw python_error();
   if (PyArray_SetBaseObject((PyArrayObject*)array.get(), py_tensor) == -1) {
     return NULL;


### PR DESCRIPTION
I found two uses of the old Tensor class as I was deleting dead code:

- torch.cuda.get_rng_state() was returning the old torch.ByteTensor
- tensor.numpy() was setting the base to the old Tensor object