### PR TITLE
Set python random seed in workers

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -41,6 +41,7 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, wo
     _set_worker_signal_handlers()
 
     torch.set_num_threads(1)
+    random.seed(seed)
     torch.manual_seed(seed)
 
     if init_fn is not None:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1,3 +1,4 @@
+import random
 import torch
 import torch.multiprocessing as multiprocessing
 from torch._C import _set_worker_signal_handlers, _update_worker_pids, \


### PR DESCRIPTION
A common task for each data loader worker is to compute random crops and flips on images. These operations are implemented using python's `random` module (e.g. [`RandomResizedCrop`](https://github.com/pytorch/vision/blob/a42f9d995cd000b51755c2cb40e8154c5b693825/torchvision/transforms/transforms.py#L494)). If we only set the torch seed, then threads compute different random augmentations across runs, even if `random.seed` and `torch.manual_seed` are set in the main thread. 