### PR TITLE
Fix layer_norm initialization and nn.Module docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyTorch'
-copyright = '2017, Torch Contributors'
+copyright = '2018, Torch Contributors'
 author = 'Torch Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -97,6 +97,9 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# Disable docstring inheritance
+autodoc_inherit_docstrings = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -950,7 +950,7 @@ Normalization functions
 .. autofunction:: batch_norm
 
 :hidden:`instance_norm`
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: instance_norm
 

--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -21,7 +21,7 @@ Sometimes, it can be non-obvious when differentiable variables can
 occur.  Consider the following training loop (abridged from `source
 <https://discuss.pytorch.org/t/high-memory-usage-while-training/162>`_):
 
-.. code::
+.. code-block:: python
 
     total_loss = 0
     for i in range(10000):
@@ -52,7 +52,8 @@ you don't need.
 
 The scopes of locals can be larger than you expect.  For example:
 
-.. code::
+.. code-block:: python
+
     for i in range(5):
         intermediate = f(input[i])
         result += g(intermediate)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -1,4 +1,5 @@
 import torch
+import numbers
 from torch.nn.parameter import Parameter
 from .module import Module
 from .batchnorm import _BatchNorm
@@ -106,8 +107,10 @@ class LayerNorm(Module):
         new observed value.
 
     Args:
-        normalized_shape (list or torch.Size): input shape from an expected input of size
-            `[* x normalized_shape[0] x normalized_shape[1] x ... x normalized_shape[-1]]`
+        normalized_shape (int or list or torch.Size): input shape from an expected input
+            of size `[* x normalized_shape[0] x normalized_shape[1] x ... x normalized_shape[-1]]`.
+            If a single integer is used, it is treated as a singleton list, and this module will
+            normalize over the last dimension with that specific size.
         eps: a value added to the denominator for numerical stability. Default: 1e-5
         momentum: the value used for the running_mean and running_var computation. Default: 0.1
         elementwise_affine: a boolean value that when set to ``True``, this module
@@ -134,6 +137,8 @@ class LayerNorm(Module):
     def __init__(self, normalized_shape, eps=1e-5, momentum=0.1,
                  elementwise_affine=True, track_running_stats=False):
         super(LayerNorm, self).__init__()
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (normalized_shape,)
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.momentum = momentum
@@ -158,7 +163,7 @@ class LayerNorm(Module):
             self.running_mean.zero_()
             self.running_var.fill_(1)
         if self.elementwise_affine:
-            self.weight.data.uniform_()
+            self.weight.data.fill_(1)
             self.bias.data.zero_()
 
     def forward(self, input):


### PR DESCRIPTION
1. Fix LN initialization. cc @avati
2. Support single int normalized_shape. cc @meder411 
3. Sphinx introduced an annoying feature in 1.7 that automatically inherits docstring. So all our nn module docs now look like:
![image](https://user-images.githubusercontent.com/5674597/36702785-8a167942-1b26-11e8-87dd-3e9c4775dd08.png)
Notice the `forward()` doc. This PR disables this feature by setting `autodoc_inherit_docstrings = False`.
4. Fix some Sphinx warnings.