### PR TITLE
ICNR inizialization

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -355,3 +355,47 @@ def sparse(tensor, sparsity, std=0.01):
                 tensor[row_idx, col_idx] = 0
 
     return tensor
+
+
+def ICNR(tensor, upscale_factor=2, inizializer=nn.init.kaiming_normal):
+    """Fills the input Tensor or Variable with values according to the method
+    described in "Checkerboard artifact free sub-pixel convolution"
+    - Andrew Aitken et al. (2017), this inizialization should be used in the
+    last convolutional layer before a PixelShuffle operation
+
+    Args:
+        tensor: an n-dimensional torch.Tensor or autograd.Variable
+        upscale_factor: factor to increase spatial resolution by
+        inizializer: inizializer to be used for sub_kernel inizialization
+
+    Examples:
+        >>> upscale = 8
+        >>> num_classes = 10
+        >>> previous_layer_features = Variable(torch.Tensor(8, 64, 32, 32))
+        >>> conv_shuffle = Conv2d(64, num_classes * (upscale ** 2), 3, padding=1, bias=0)
+        >>> ps = PixelShuffle(upscale)
+        >>> kernel = ICNR(conv_shuffle.weight, scale_factor=upscale)
+        >>> conv_shuffle.weight.data.copy_(kernel)
+        >>> output = ps(conv_shuffle(previous_layer_features))
+        >>> print(output.shape)
+        torch.Size([8, 10, 256, 256])
+
+    .. _Checkerboard artifact free sub-pixel convolution:
+        https://arxiv.org/abs/1707.02937
+    """
+    new_shape = [int(tensor.shape[0] / (upscale_factor ** 2))] + list(tensor.shape[1:])
+    subkernel = torch.zeros(new_shape)
+    subkernel = inizializer(subkernel)
+    subkernel = subkernel.transpose(0, 1)
+
+    subkernel = subkernel.contiguous().view(subkernel.shape[0],
+                                            subkernel.shape[1], -1)
+
+    kernel = subkernel.repeat(1, 1, upscale_factor ** 2)
+
+    transposed_shape = [tensor.shape[1]] + [tensor.shape[0]] + list(tensor.shape[2:])
+    kernel = kernel.contiguous().view(transposed_shape)
+
+    kernel = kernel.transpose(0, 1)
+
+    return kernel


### PR DESCRIPTION
ICNR inizialization from "Checkerboard artifact free sub-pixel convolution" - Andrew Aitken et al. (2017) - https://arxiv.org/abs/1707.02937

This inizialization should be used in the last Conv2d layer before PixelShuffle