### PR TITLE
Distributed test fix

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -49,6 +49,8 @@ def skip_if_no_multigpu(func):
             sys.exit(SKIP_IF_NO_CUDA_EXIT_CODE)
         if torch.cuda.device_count() < 2:
             sys.exit(SKIP_IF_NO_MULTIGPU_EXIT_CODE)
+        if torch.cuda.device_count() < int(os.environ['WORLD_SIZE']):
+            sys.exit(SKIP_IF_NO_MULTIGPU_EXIT_CODE)
 
         return func(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
`test_distributed.py` fails when `world_size` is set to something > than NGPU's you have locally. Unless you only have 1 GPU. For example it fails if you have 2 GPU's by default with run_tests.sh because default world_size is 3. This PR will have it skip the multi-gpu tests when `world_size > device_count`