### PR TITLE
Re-enable some CUDA tests on Windows

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9,7 +9,7 @@ import torch.cuda
 import torch.cuda.comm as comm
 
 from test_torch import TestTorch
-from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, IS_WINDOWS
+from common import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests
 
 HAS_CUDA = True
 if not torch.cuda.is_available():
@@ -403,13 +403,11 @@ tests = [
     ('qr', small_2d_lapack, lambda t: [], 'square', float_types),
     ('qr', small_2d_lapack_skinny, lambda t: [], 'skinny', float_types),
     ('qr', small_2d_lapack_fat, lambda t: [], 'fat', float_types),
+    ('qr', large_2d_lapack, lambda t: [], 'big', float_types),
     ('inverse', new_t(20, 20), lambda t: [], None, float_types),
     ('geqrf', new_t(20, 20), lambda t: [], None, float_types),
     # TODO: add det to here once Variable and Tensor are the same thing
 ]
-
-if not IS_WINDOWS:
-    tests.append(('qr', large_2d_lapack, lambda t: [], 'big', float_types))
 
 # TODO: random functions, cat, gather, scatter, index*, masked*,
 #       resize, resizeAs, storage_offset, storage, stride, unfold

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2596,8 +2596,6 @@ class TestNN(NNTestCase):
                  torch.cuda.HalfTensor]
         precs = [1e-5, 1e-5, 1e-2]
         for tp, prec in zip(types, precs):
-            if IS_WINDOWS and tp == torch.cuda.HalfTensor:  # CUDA HalfTensor is not supported on Windows yet
-                continue
             for depth_multiplier in [1, 2]:
                 m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).type(tp)
                 i = Variable(torch.randn(2, 2, 6, 6).type(tp) / 2, requires_grad=True)
@@ -6416,4 +6414,22 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 if __name__ == '__main__':
+
+    enabled_tests = ['test_Conv2d_depthwise_naive_groups']
+    all_methods = dir(TestNN())
+    all_tests = [x for x in all_methods if x.startswith("test_")]
+    for test_name in all_tests:
+        if not test_name in enabled_tests:
+            delattr(TestNN, test_name)
+    all_methods = dir(TestNNInit())
+    all_tests = [x for x in all_methods if x.startswith("test_")]
+    for test_name in all_tests:
+        if not test_name in enabled_tests:
+            delattr(TestNNInit, test_name)
+    all_methods = dir(PackedSequenceTest())
+    all_tests = [x for x in all_methods if x.startswith("test_")]
+    for test_name in all_tests:
+        if not test_name in enabled_tests:
+            delattr(PackedSequenceTest, test_name)
+
     run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -31,7 +31,7 @@ from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     TEST_CUDNN_VERSION, loss_reference_fns, get_size_average, get_weight, torch_rand, torch_randn, \
     smoothl1loss_reference, kldivloss_reference
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, download_file, IS_WINDOWS, PY3
+    TEST_SCIPY, download_file, PY3
 
 if TEST_SCIPY:
     from scipy import stats
@@ -2422,7 +2422,6 @@ class TestNN(NNTestCase):
             # but it should work with the same type
             nn.functional.conv2d(inputs.float(), weights.float(), bias.float())
 
-    @unittest.skipIf(IS_WINDOWS, 'TODO: fix this test for Windows')
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_Conv2d_deterministic_cudnn(self):
@@ -6414,22 +6413,4 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 if __name__ == '__main__':
-
-    enabled_tests = ['test_Conv2d_depthwise_naive_groups']
-    all_methods = dir(TestNN())
-    all_tests = [x for x in all_methods if x.startswith("test_")]
-    for test_name in all_tests:
-        if not test_name in enabled_tests:
-            delattr(TestNN, test_name)
-    all_methods = dir(TestNNInit())
-    all_tests = [x for x in all_methods if x.startswith("test_")]
-    for test_name in all_tests:
-        if not test_name in enabled_tests:
-            delattr(TestNNInit, test_name)
-    all_methods = dir(PackedSequenceTest())
-    all_tests = [x for x in all_methods if x.startswith("test_")]
-    for test_name in all_tests:
-        if not test_name in enabled_tests:
-            delattr(PackedSequenceTest, test_name)
-
     run_tests()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1085,8 +1085,7 @@ class TestTorch(TestCase):
                       torch.float16, torch.float32, torch.float64]
         cuda_dtypes = [torch.cuda.uint8, torch.cuda.int8, torch.cuda.int16, torch.cuda.int32, torch.cuda.int64,
                        torch.cuda.float32, torch.cuda.float64]
-        if not IS_WINDOWS:  # cuda.float16 doesn't work on windows
-            cuda_dtypes.append(torch.cuda.float16)
+        cuda_dtypes.append(torch.cuda.float16)
         self._test_dtypes(self, cpu_dtypes, cuda_dtypes, False)
 
     def test_dtype_out_match(self):
@@ -4675,7 +4674,6 @@ class TestTorch(TestCase):
             xh2 = torch.load(f)
             self.assertEqual(xh.float(), xh2.float())
 
-    @unittest.skipIf(IS_WINDOWS, 'NYI: CUDA HalfTensor support on Windows')
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_half_tensor_cuda(self):
         x = torch.randn(5, 5).half()
@@ -4817,8 +4815,6 @@ class TestTorch(TestCase):
 
     def test_print(self):
         for t in torch._tensor_classes:
-            if IS_WINDOWS and t == torch.cuda.HalfTensor:
-                return  # CUDA HalfTensor is not supported on Windows yet
             if t == torch.HalfTensor:
                 continue  # HalfTensor does not support fill
             if t.is_sparse:
@@ -5130,11 +5126,9 @@ class TestTorch(TestCase):
                 for i in range(len(array)):
                     self.assertEqual(tensor[i], array[i])
 
-                # CUDA HalfTensor is not supported on Windows yet
-                if not IS_WINDOWS:
-                    tensor = torch.cuda.HalfTensor(array)
-                    for i in range(len(array)):
-                        self.assertEqual(tensor[i], array[i])
+                tensor = torch.cuda.HalfTensor(array)
+                for i in range(len(array)):
+                    self.assertEqual(tensor[i], array[i])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_numpy_index(self):


### PR DESCRIPTION
This PR enables the following tests on Windows again:

 - CUDA HalfTensor tests in `test_torch.py` and `test_nn.py`
- `test_Conv2d_deterministic_cudnn` in `test_nn.py`
- `test_*Tensor_qr_big` in `test_cuda.py`

The issues are no longer reproducible, possibly because of an upgrade to the display driver. 

Removed from #4092.