### PR TITLE
Add upsample_bilinear2d to onnx/symbolic.py

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -416,6 +416,14 @@ def upsample_nearest2d(g, input, scale_factor):
                 height_scale_f=scale_factor, mode_s="nearest")
 
 
+def upsample_bilinear2d(g, input, output_size):
+    input_width, input_height = input.type().sizes()[2:]
+    width_scale = input_width / output_size[0]
+    height_scale = input_height / output_size[1]
+    return g.op("Upsample", input, width_scale_f=width_scale,
+                height_scale_f=height_scale, mode_s="bilinear")
+
+
 def log_softmax(g, input, dim=None):
     return g.op("LogSoftmax", input, axis_i=dim)
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -418,8 +418,8 @@ def upsample_nearest2d(g, input, scale_factor):
 
 def upsample_bilinear2d(g, input, output_size):
     input_width, input_height = input.type().sizes()[2:]
-    width_scale = input_width / output_size[0]
-    height_scale = input_height / output_size[1]
+    width_scale = output_size[0] / input_width
+    height_scale = output_size[1] / input_height
     return g.op("Upsample", input, width_scale_f=width_scale,
                 height_scale_f=height_scale, mode_s="bilinear")
 


### PR DESCRIPTION
This function is needed to convert a PyTorch model that uses `UpsamplingBilinear2d` to an ONNX one.

However the ONNX's operator `Upsample` is experimental now, the nearest mode is already used in PyTorch [here](https://github.com/pytorch/pytorch/blob/847fad70a9846e9005867ea7ce000d564b5af708/torch/onnx/symbolic.py#L415), so I think this change should be no problem.