### PR TITLE
Documentation cleanup for activation functions

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,9 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+figures:
+	python source/scripts/build_activation_images.py
+
 docset: html
 	doc2dash --name $(SPHINXPROJ) --icon $(SOURCEDIR)/_static/img/pytorch-logo-flame.png --enable-js --online-redirect-url http://pytorch.org/docs/ --force $(BUILDDIR)/html/
 
@@ -23,5 +26,5 @@ docset: html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile figures
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -221,8 +221,44 @@ Padding Layers
     :members:
 
 
-Non-linear Activations
-----------------------------------
+Non-linear Activations (weighed sum+nonlinearity)
+-------------------------------------------------
+
+:hidden:`ELU`
+~~~~~~~~~~~~~
+
+.. autoclass:: ELU
+    :members:
+
+:hidden:`Hardshrink`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Hardshrink
+    :members:
+
+:hidden:`Hardtanh`
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Hardtanh
+    :members:
+
+:hidden:`LeakyReLU`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: LeakyReLU
+    :members:
+
+:hidden:`LogSigmoid`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: LogSigmoid
+    :members:
+
+:hidden:`PReLU`
+~~~~~~~~~~~~~~~
+
+.. autoclass:: PReLU
+    :members:
 
 :hidden:`ReLU`
 ~~~~~~~~~~~~~~
@@ -236,10 +272,10 @@ Non-linear Activations
 .. autoclass:: ReLU6
     :members:
 
-:hidden:`ELU`
-~~~~~~~~~~~~~
+:hidden:`RReLU`
+~~~~~~~~~~~~~~~
 
-.. autoclass:: ELU
+.. autoclass:: RReLU
     :members:
 
 :hidden:`SELU`
@@ -248,46 +284,10 @@ Non-linear Activations
 .. autoclass:: SELU
     :members:
 
-:hidden:`PReLU`
-~~~~~~~~~~~~~~~
-
-.. autoclass:: PReLU
-    :members:
-
-:hidden:`LeakyReLU`
-~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: LeakyReLU
-    :members:
-
-:hidden:`Threshold`
-~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: Threshold
-    :members:
-
-:hidden:`Hardtanh`
-~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: Hardtanh
-    :members:
-
 :hidden:`Sigmoid`
 ~~~~~~~~~~~~~~~~~
 
 .. autoclass:: Sigmoid
-    :members:
-
-:hidden:`Tanh`
-~~~~~~~~~~~~~~
-
-.. autoclass:: Tanh
-    :members:
-
-:hidden:`LogSigmoid`
-~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: LogSigmoid
     :members:
 
 :hidden:`Softplus`
@@ -308,11 +308,26 @@ Non-linear Activations
 .. autoclass:: Softsign
     :members:
 
+:hidden:`Tanh`
+~~~~~~~~~~~~~~
+
+.. autoclass:: Tanh
+    :members:
+
 :hidden:`Tanhshrink`
 ~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: Tanhshrink
     :members:
+
+:hidden:`Threshold`
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Threshold
+    :members:
+
+Non-linear Activations (Other)
+------------------------------
 
 :hidden:`Softmin`
 ~~~~~~~~~~~~~~~~~
@@ -337,7 +352,6 @@ Non-linear Activations
 
 .. autoclass:: LogSoftmax
     :members:
-
 
 Normalization layers
 ----------------------------------

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -41,7 +41,7 @@ functions = [
     'Softsign',
     'Tanh',
     'Tanhshrink'
-    #'Threshold'  Omit, pending cleanup. See PR5457
+    # 'Threshold'  Omit, pending cleanup. See PR5457
 ]
 
 

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -1,0 +1,91 @@
+"""
+This script will generate input-out plots for all of the activation
+functions. These are for use in the documentation, and potentially in
+online tutorials.
+"""
+
+import os.path
+import torch.nn.modules.activation
+import torch.autograd
+import pylab
+
+
+# Create a directory for the images, if it doesn't exist
+DOCS_PATH = os.path.realpath(os.path.join(__file__, "../../.."))
+ACTIVATION_IMAGE_PATH = os.path.join(
+    DOCS_PATH,
+    "source/_static/img/activation/"
+)
+
+print(ACTIVATION_IMAGE_PATH)
+
+if not os.path.exists(ACTIVATION_IMAGE_PATH):
+    os.mkdir(ACTIVATION_IMAGE_PATH)
+
+# In a refactor, these ought to go into their own module or entry
+# points so we can generate this list programmaticly
+functions = [
+    'ELU',
+    'Hardshrink',
+    'Hardtanh',
+    'LeakyReLU',  # Perhaps we should add text explaining slight slope?
+    'LogSigmoid',
+    'PReLU',
+    'ReLU',
+    'ReLU6',
+    'RReLU',
+    'SELU',
+    'Sigmoid',
+    'Softplus',
+    'Softshrink',
+    'Softsign',
+    'Tanh',
+    'Tanhshrink',
+    'Threshold'
+]
+
+
+def plot_function(function, **args):
+    """
+    Plot a function on the current plot. The additional arguments may
+    be used to specify color, alpha, etc.
+    """
+    xrange = torch.arange(-7.0, 7.0, 0.01)  # We need to go beyond 6 for ReLU6
+    pylab.plot(
+        xrange.numpy(),
+        function(torch.autograd.Variable(xrange)).data.numpy(),
+        **args
+    )
+
+
+# Step through all the functions
+for function_name in functions:
+    plot_path = os.path.join(ACTIVATION_IMAGE_PATH, function_name + ".png")
+    if not os.path.exists(plot_path):
+        function = torch.nn.modules.activation.__dict__[function_name]()
+        print(function)
+
+        # Start a new plot
+        pylab.clf()
+
+        # Add an overlay on the background of faint traces of all the other
+        # functions. This is nice when flipping through images
+        for background_function in functions:
+            plot_function(
+                torch.nn.modules.activation.__dict__[background_function](),
+                alpha=0.03, color='k'
+            )
+
+        # Plot the current function
+        plot_function(function)
+
+        # The titles are a little redundant, given context?
+        pylab.title(function_name + " activation function")
+        pylab.xlabel("Input")
+        pylab.ylabel("Output")
+        pylab.xlim([-7, 7])
+        pylab.ylim([-7, 7])
+
+        # And save it
+        print(plot_path)
+        pylab.savefig(plot_path)

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -40,8 +40,8 @@ functions = [
     'Softshrink',
     'Softsign',
     'Tanh',
-    'Tanhshrink',
-    'Threshold'
+    'Tanhshrink'
+    #'Threshold'  Omit, pending cleanup. See PR5457
 ]
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -90,7 +90,7 @@ class RReLU(Module):
        {RReLU}(x) = \left\{
        \begin{eqnarray}
         x \textrm{ if } x \geq 0 \\
-       ax \textrm{ if } x < 0
+       ax \textrm{ if } x < 0 ,
        \end{eqnarray}
        \right.
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -14,6 +14,8 @@ class Threshold(Module):
          y =  x        if x >  threshold
               value    if x <= threshold
 
+    .. image:: _static/img/activation/Threshold.png
+
     Args:
         threshold: The value to threshold at
         value: The value to replace with
@@ -32,7 +34,7 @@ class Threshold(Module):
         >>> print(m(input))
     """
 
-    def __init__(self, threshold, value, inplace=False):
+    def __init__(self, threshold=0.0, value=0.0, inplace=False):
         super(Threshold, self).__init__()
         self.threshold = threshold
         self.value = value
@@ -53,6 +55,8 @@ class Threshold(Module):
 class ReLU(Threshold):
     r"""Applies the rectified linear unit function element-wise
     :math:`{ReLU}(x)= max(0, x)`
+
+    .. image:: _static/img/activation/ReLU.png
 
     Args:
         inplace: can optionally do the operation in-place. Default: ``False``
@@ -80,7 +84,24 @@ class ReLU(Threshold):
 
 
 class RReLU(Module):
+    r""" Randomized leaky ReLU.
 
+    .. math::
+       {RReLU}(x) = \left\{
+       \begin{eqnarray}
+        x \textrm{ if } x \geq 0 \\
+       ax \textrm{ if } x < 0
+       \end{eqnarray}
+       \right.
+
+    where :math:`a` is a random number between some threshold (typically :math:`\frac{1}{8}` and :math:`\frac{1}{3}`).
+
+    More details can be found in the paper `Empirical Evaluation of Rectified Activations in Convolutional Network`_ .
+
+    .. image:: _static/img/activation/RReLU.png
+
+    .. _Empirical Evaluation of Rectified Activations in Convolutional Network: https://arxiv.org/abs/1505.00853
+    """
     def __init__(self, lower=1. / 8, upper=1. / 3, inplace=False):
         super(RReLU, self).__init__()
         self.lower = lower
@@ -108,6 +129,8 @@ class Hardtanh(Module):
        f(x) =  x,  otherwise
 
     The range of the linear region :math:`[-1, 1]` can be adjusted
+
+    .. image:: _static/img/activation/Hardtanh.png
 
     Args:
         min_val: minimum value of the linear region range. Default: -1
@@ -166,6 +189,8 @@ class ReLU6(Hardtanh):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/ReLU6.png
+
     Examples::
 
         >>> m = nn.ReLU6()
@@ -191,6 +216,8 @@ class Sigmoid(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/Sigmoid.png
+
     Examples::
 
         >>> m = nn.Sigmoid()
@@ -214,6 +241,8 @@ class Tanh(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: _static/img/activation/Tanh.png
 
     Examples::
 
@@ -243,6 +272,8 @@ class ELU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/ELU.png
+
     Examples::
 
         >>> m = nn.ELU()
@@ -271,6 +302,8 @@ class SELU(Module):
     :math:`f(x) = scale * (\max(0,x) + \min(0, alpha * (\exp(x) - 1)))`,
     with ``alpha=1.6732632423543772848170429916717`` and
     ``scale=1.0507009873554804934193349852946``.
+
+    .. image:: _static/img/activation/SELU.png
 
     More details can be found in the paper `Self-Normalizing Neural Networks`_ .
 
@@ -351,6 +384,8 @@ class Hardshrink(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/Hardshrink.png
+
     Examples::
 
         >>> m = nn.Hardshrink()
@@ -384,6 +419,8 @@ class LeakyReLU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/LeakyReLU.png
+
     Examples::
 
         >>> m = nn.LeakyReLU(0.1)
@@ -414,6 +451,8 @@ class LogSigmoid(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: _static/img/activation/LogSigmoid.png
 
     Examples::
 
@@ -447,6 +486,8 @@ class Softplus(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: _static/img/activation/Softplus.png
 
     Examples::
 
@@ -485,6 +526,8 @@ class Softshrink(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: _static/img/activation/Softshrink.png
 
     Examples::
 
@@ -526,6 +569,8 @@ class PReLU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/PReLU.png
+
     Examples::
 
         >>> m = nn.PReLU()
@@ -555,6 +600,8 @@ class Softsign(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
+    .. image:: _static/img/activation/Softsign.png
+
     Examples::
 
         >>> m = nn.Softsign()
@@ -577,6 +624,8 @@ class Tanhshrink(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
+
+    .. image:: _static/img/activation/Tanhshrink.png
 
     Examples::
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -14,8 +14,6 @@ class Threshold(Module):
          y =  x        if x >  threshold
               value    if x <= threshold
 
-    .. image:: _static/img/activation/Threshold.png
-
     Args:
         threshold: The value to threshold at
         value: The value to replace with
@@ -34,7 +32,7 @@ class Threshold(Module):
         >>> print(m(input))
     """
 
-    def __init__(self, threshold=0.0, value=0.0, inplace=False):
+    def __init__(self, threshold, value, inplace=False):
         super(Threshold, self).__init__()
         self.threshold = threshold
         self.value = value

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -86,21 +86,42 @@ class ReLU(Threshold):
 class RReLU(Module):
     r""" Randomized leaky ReLU.
 
+    Applies the randomized leaky rectified liner unit function
+    element-wise described in the paper
+    `Empirical Evaluation of Rectified Activations in Convolutional Network`_.
+
+    The function is defined as:
+
     .. math::
-       {RReLU}(x) = \left\{
-       \begin{eqnarray}
-        x \textrm{ if } x \geq 0 \\
-       ax \textrm{ if } x < 0 ,
-       \end{eqnarray}
-       \right.
+        f(x) = \begin{cases}
+            ax & \text{if } x < 0 \\
+            x & \text{if } x \geq 0 , \\
+        \end{cases}
 
-    where :math:`a` is a random number between some threshold (typically :math:`\frac{1}{8}` and :math:`\frac{1}{3}`).
+    where :math:`a` is randomly sampled from uniform distribution
+    :math:`U(\text{lower}, \text{upper})`, typically
+    :math:`U\left(\frac{1}{8}, \frac{1}{3}\right)`
 
-    More details can be found in the paper `Empirical Evaluation of Rectified Activations in Convolutional Network`_ .
+    Args:
+        lower: lower bound of the uniform distribution. Default: :math:`1/8`
+        upper: upper bound of the uniform distribution. Default: :math:`1/3`
+        inplace: can optionally do the operation in-place. Default: ``False``
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(N, *)`, same shape as the input
 
     .. image:: _static/img/activation/RReLU.png
 
-    .. _Empirical Evaluation of Rectified Activations in Convolutional Network: https://arxiv.org/abs/1505.00853
+    Examples::
+
+        >>> m = nn.RReLU(0.1, 0.3)
+        >>> input = torch.randn(2)
+        >>> output = m(input)
+
+    .. _`Empirical Evaluation of Rectified Activations in Convolutional Network`:
+        https://arxiv.org/abs/1505.00853
     """
     def __init__(self, lower=1. / 8, upper=1. / 3, inplace=False):
         super(RReLU, self).__init__()


### PR DESCRIPTION
This pull request improves documentation for the activation functions. 

Specifically, it:

* Splits activation functions into those which are a weighed sum+nonlinearity and the others
* Adds an image for each activation function so one can tell at-a-glance what it does
* Adds documentation for RReLU (which was previously undocumented)
* Adds default parameters for 'Threshold' so that optimizers may instantiate it in the same way as any other activation function (and so we have a default for what to plot)

Potential issues:

* This is a first pull request to this project. I am unfamiliar with community conventions
* I seem to be the first person adding images to docs. Are these where you'd like them?
* Are the sizes appropriate? Should I be concerned about interactions with specific IDEs?
* Are there better labels for the section headers? I considered using the language of generalized linear models and more background, but decided jargon may be less helpful to less experienced users