### PR TITLE
nn.* doc update after Variable/Tensor merge

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -232,7 +232,7 @@ def avg_pool1d(input, kernel_size, stride=None, padding=0,
 
 
 avg_pool2d = _add_docstr(torch._C._nn.avg_pool2d, r"""
-avg_pool2d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Variable
+avg_pool2d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
 Applies 2D average-pooling operation in kh x kw regions by step size
 dh x dw steps. The number of output features is equal to the number of
@@ -255,7 +255,7 @@ Args:
 """)
 
 avg_pool3d = _add_docstr(torch._C._nn.avg_pool3d, r"""
-avg_pool3d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Variable
+avg_pool3d(input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True) -> Tensor
 
 Applies 3D average-pooling operation in kt x kh x kw regions by step
 size dt x dh x dw steps. The number of output features is equal to the
@@ -325,7 +325,7 @@ def fractional_max_pool2d(input, kernel_size, output_size=None,
 
 def max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1,
                ceil_mode=False, return_indices=False):
-    """Applies a 1D max pooling over an input signal composed of several input
+    r"""Applies a 1D max pooling over an input signal composed of several input
     planes.
 
     See :class:`~torch.nn.MaxPool1d` for details.
@@ -336,7 +336,7 @@ def max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1,
 
 def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
                ceil_mode=False, return_indices=False):
-    """Applies a 2D max pooling over an input signal composed of several input
+    r"""Applies a 2D max pooling over an input signal composed of several input
     planes.
 
     See :class:`~torch.nn.MaxPool2d` for details.
@@ -347,7 +347,7 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
 
 def max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1,
                ceil_mode=False, return_indices=False):
-    """Applies a 3D max pooling over an input signal composed of several input
+    r"""Applies a 3D max pooling over an input signal composed of several input
     planes.
 
     See :class:`~torch.nn.MaxPool3d` for details.
@@ -386,7 +386,7 @@ def _unpool_output_size(input, kernel_size, stride, padding, output_size):
 
 def max_unpool1d(input, indices, kernel_size, stride=None, padding=0,
                  output_size=None):
-    """Computes a partial inverse of :class:`MaxPool1d`.
+    r"""Computes a partial inverse of :class:`MaxPool1d`.
 
     See :class:`~torch.nn.MaxUnpool1d` for details.
     """
@@ -400,7 +400,7 @@ def max_unpool1d(input, indices, kernel_size, stride=None, padding=0,
 
 def max_unpool2d(input, indices, kernel_size, stride=None, padding=0,
                  output_size=None):
-    """Computes a partial inverse of :class:`MaxPool2d`.
+    r"""Computes a partial inverse of :class:`MaxPool2d`.
 
     See :class:`~torch.nn.MaxUnpool2d` for details.
     """
@@ -414,7 +414,7 @@ def max_unpool2d(input, indices, kernel_size, stride=None, padding=0,
 
 def max_unpool3d(input, indices, kernel_size, stride=None, padding=0,
                  output_size=None):
-    """Computes a partial inverse of :class:`MaxPool3d`.
+    r"""Computes a partial inverse of :class:`MaxPool3d`.
 
     See :class:`~torch.nn.MaxUnpool3d` for details.
     """
@@ -427,7 +427,7 @@ def max_unpool3d(input, indices, kernel_size, stride=None, padding=0,
 
 
 def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
-    """Applies a 2D power-average pooling over an input signal composed of
+    r"""Applies a 2D power-average pooling over an input signal composed of
     several input planes.
 
     See :class:`~torch.nn.LPPool2d` for details.
@@ -438,7 +438,7 @@ def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
 
 
 def lp_pool1d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
-    """Applies a 1D power-average pooling over an input signal composed of
+    r"""Applies a 1D power-average pooling over an input signal composed of
     several input planes.
 
     See :class:`~torch.nn.LPPool1d` for details.
@@ -492,7 +492,7 @@ def adaptive_max_pool3d(input, output_size, return_indices=False):
 
 
 adaptive_avg_pool1d = _add_docstr(torch._C._VariableFunctions.adaptive_avg_pool1d, r"""
-adaptive_avg_pool1d(input, output_size) -> Variable
+adaptive_avg_pool1d(input, output_size) -> Tensor
 
 Applies a 1D adaptive average pooling over an input signal composed of
 several input planes.
@@ -504,7 +504,7 @@ Args:
 """)
 
 adaptive_avg_pool2d = _add_docstr(torch._C._nn.adaptive_avg_pool2d, r"""
-adaptive_avg_pool2d(input, output_size) -> Variable
+adaptive_avg_pool2d(input, output_size) -> Tensor
 
 Applies a 2D adaptive average pooling over an input signal composed of
 several input planes.
@@ -517,7 +517,7 @@ Args:
 """)
 
 adaptive_avg_pool3d = _add_docstr(torch._C._nn.adaptive_avg_pool3d, r"""
-adaptive_avg_pool3d(input, output_size) -> Variable
+adaptive_avg_pool3d(input, output_size) -> Tensor
 
 Applies a 3D adaptive average pooling over an input signal composed of
 several input planes.
@@ -576,7 +576,7 @@ def dropout3d(input, p=0.5, training=False, inplace=False):
 
 
 def threshold(input, threshold, value, inplace=False):
-    """Thresholds each element of the input Tensor.
+    r"""Thresholds each element of the input Tensor.
 
     See :class:`~torch.nn.Threshold` for more details.
     """
@@ -586,14 +586,14 @@ def threshold(input, threshold, value, inplace=False):
 
 
 threshold_ = _add_docstr(torch._C._nn.threshold_, r"""
-threshold_(input, threshold, value) -> Variable
+threshold_(input, threshold, value) -> Tensor
 
 In-place version of :func:`~threshold`.
 """)
 
 
 def relu(input, inplace=False):
-    """relu(input, threshold, value, inplace=False) -> Variable
+    r"""relu(input, threshold, value, inplace=False) -> Tensor
 
     Applies the rectified linear unit function element-wise. See
     :class:`~torch.nn.ReLU` for more details.
@@ -608,7 +608,7 @@ def relu_(input):
 
 def glu(input, dim=-1):
     r"""
-    glu(input, dim=-1) -> Variable
+    glu(input, dim=-1) -> Tensor
 
     The gated linear unit. Computes:
 
@@ -631,7 +631,7 @@ def glu(input, dim=-1):
 
 def hardtanh(input, min_val=-1., max_val=1., inplace=False):
     r"""
-    hardtanh(input, min_val=-1., max_val=1., inplace=False) -> Variable
+    hardtanh(input, min_val=-1., max_val=1., inplace=False) -> Tensor
 
     Applies the HardTanh function element-wise. See :class:`~torch.nn.Hardtanh` for more
     details.
@@ -642,14 +642,14 @@ def hardtanh(input, min_val=-1., max_val=1., inplace=False):
 
 
 hardtanh_ = _add_docstr(torch._C._nn.hardtanh_, r"""
-hardtanh_(input, min_val=-1., max_val=1.) -> Variable
+hardtanh_(input, min_val=-1., max_val=1.) -> Tensor
 
 In-place version of :func:`~hardtanh`.
 """)
 
 
 def relu6(input, inplace=False):
-    r"""relu6(input, inplace=False) -> Variable
+    r"""relu6(input, inplace=False) -> Tensor
 
     Applies the element-wise function :math:`{ReLU6}(x) = min(max(0,x), 6)`.
 
@@ -670,14 +670,14 @@ def elu(input, alpha=1., inplace=False):
 
 
 elu_ = _add_docstr(torch._C._nn.elu_, r"""
-elu_(input, alpha=1.) -> Variable
+elu_(input, alpha=1.) -> Tensor
 
 In-place verison of :func:`~elu`.
 """)
 
 
 def selu(input, inplace=False):
-    r"""selu(input, inplace=False) -> Variable
+    r"""selu(input, inplace=False) -> Tensor
 
     Applies element-wise,
     :math:`f(x) = scale * (\max(0,x) + \min(0, alpha * (\exp(x) - 1)))`,
@@ -691,7 +691,7 @@ def selu(input, inplace=False):
     return torch._C._VariableFunctions.selu(input)
 
 selu_ = _add_docstr(torch._C._VariableFunctions.selu_, r"""
-selu_(input) -> Variable
+selu_(input) -> Tensor
 
 In-place verison of :func:`~selu`.
 """)
@@ -699,7 +699,7 @@ In-place verison of :func:`~selu`.
 
 def leaky_relu(input, negative_slope=0.01, inplace=False):
     r"""
-    leaky_relu(input, negative_slope=0.01, inplace=False) -> Variable
+    leaky_relu(input, negative_slope=0.01, inplace=False) -> Tensor
 
     Applies element-wise,
     :math:`f(x) = max(0, x) + {negative\_slope} * min(0, x)`
@@ -712,14 +712,14 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
 
 
 leaky_relu_ = _add_docstr(torch._C._nn.leaky_relu_, r"""
-leaky_relu_(input, negative_slope=0.01) -> Variable
+leaky_relu_(input, negative_slope=0.01) -> Tensor
 
 In-place version of :func:`~leaky_relu`.
 """)
 
 
 prelu = _add_docstr(torch._C._nn.prelu, r"""
-prelu(input, weight) -> Variable
+prelu(input, weight) -> Tensor
 
 Applies element-wise the function
 :math:`PReLU(x) = max(0,x) + weight * min(0,x)` where weight is a
@@ -730,9 +730,11 @@ See :class:`~torch.nn.PReLU` for more details.
 
 
 def rrelu(input, lower=1. / 8, upper=1. / 3, training=False, inplace=False):
-    r"""rrelu(input, lower=1./8, upper=1./3, training=False, inplace=False) -> Variable
+    r"""rrelu(input, lower=1./8, upper=1./3, training=False, inplace=False) -> Tensor
 
     Randomized leaky ReLU.
+
+    See :class:`~torch.nn.RReLU` for more details.
     """
     if inplace:
         return torch._C._VariableFunctions.rrelu_(input, lower, upper, training)
@@ -740,13 +742,13 @@ def rrelu(input, lower=1. / 8, upper=1. / 3, training=False, inplace=False):
 
 
 rrelu_ = _add_docstr(torch._C._VariableFunctions.rrelu_, r"""
-rrelu_(input, lower=1./8, upper=1./3, training=False) -> Variable
+rrelu_(input, lower=1./8, upper=1./3, training=False) -> Tensor
 
 In-place version of :func:`~rrelu`.
 """)
 
 logsigmoid = _add_docstr(torch._C._nn.log_sigmoid, r"""
-logsigmoid(input) -> Variable
+logsigmoid(input) -> Tensor
 
 Applies element-wise :math:`LogSigmoid(x) = log( 1 / (1 + exp(-x_i)))`
 
@@ -754,7 +756,7 @@ See :class:`~torch.nn.LogSigmoid` for more details.
 """)
 
 hardshrink = _add_docstr(torch._C._nn.hardshrink, r"""
-hardshrink(input, lambd=0.5) -> Variable
+hardshrink(input, lambd=0.5) -> Tensor
 
 Applies the hard shrinkage function element-wise
 
@@ -763,7 +765,7 @@ See :class:`~torch.nn.Hardshrink` for more details.
 
 
 def tanhshrink(input):
-    r"""tanhshrink(input) -> Variable
+    r"""tanhshrink(input) -> Tensor
 
     Applies element-wise, :math:`Tanhshrink(x) = x - Tanh(x)`
 
@@ -773,7 +775,7 @@ def tanhshrink(input):
 
 
 def softsign(input):
-    r"""softsign(input) -> Variable
+    r"""softsign(input) -> Tensor
 
     Applies element-wise, the function :math:`f(x) = x / (1 + |x|)`
 
@@ -783,7 +785,7 @@ def softsign(input):
 
 
 softplus = _add_docstr(torch._C._nn.softplus, r"""
-softplus(input, beta=1, threshold=20) -> Variable
+softplus(input, beta=1, threshold=20) -> Tensor
 """)
 
 
@@ -923,7 +925,7 @@ def log_softmax(input, dim=None, _stacklevel=3):
 
 
 softshrink = _add_docstr(torch._C._nn.softshrink, r"""
-softshrink(input, lambd=0.5) -> Variable
+softshrink(input, lambd=0.5) -> Tensor
 
 Applies the soft shrinkage function elementwise
 
@@ -932,7 +934,7 @@ See :class:`~torch.nn.Softshrink` for more details.
 
 
 def tanh(input):
-    r"""tanh(input) -> Variable
+    r"""tanh(input) -> Tensor
 
     Applies element-wise,
     :math:`f(x) = (exp(x) - exp(-x)) / (exp(x) + exp(-x))`
@@ -943,7 +945,7 @@ def tanh(input):
 
 
 def sigmoid(input):
-    r"""sigmoid(input) -> Variable
+    r"""sigmoid(input) -> Tensor
 
     Applies the element-wise function :math:`f(x) = 1 / ( 1 + exp(-x))`
 
@@ -1288,7 +1290,7 @@ def layer_norm(input, normalized_shape, running_mean, running_var,
 
 
 def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):
-    """Applies local response normalization over an input signal composed of
+    r"""Applies local response normalization over an input signal composed of
     several input planes, where channels occupy the second dimension.
     Applies normalization across channels.
 
@@ -1408,7 +1410,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Tru
 
 
 kl_div = _add_docstr(torch._C._nn.kl_div, r"""
-kl_div(input, target, size_average=True) -> Variable
+kl_div(input, target, size_average=True) -> Tensor
 
 The `Kullback-Leibler divergence`_ Loss.
 
@@ -1559,7 +1561,7 @@ def _pointwise_loss(lambd, lambd_optimized, input, target, size_average=True, re
 
 
 smooth_l1_loss = _add_docstr(torch._C._nn.smooth_l1_loss, r"""
-smooth_l1_loss(input, target, size_average=True) -> Variable
+smooth_l1_loss(input, target, size_average=True) -> Tensor
 
 Function that uses a squared term if the absolute
 element-wise error falls below 1 and an L1 term otherwise.
@@ -1569,8 +1571,7 @@ See :class:`~torch.nn.SmoothL1Loss` for details.
 
 
 def l1_loss(input, target, size_average=True, reduce=True):
-    """
-    l1_loss(input, target, size_average=True, reduce=True) -> Variable
+    r"""l1_loss(input, target, size_average=True, reduce=True) -> Tensor
 
     Function that takes the mean element-wise absolute value difference.
 
@@ -1581,8 +1582,7 @@ def l1_loss(input, target, size_average=True, reduce=True):
 
 
 def mse_loss(input, target, size_average=True, reduce=True):
-    """
-    mse_loss(input, target, size_average=True, reduce=True) -> Variable
+    r"""mse_loss(input, target, size_average=True, reduce=True) -> Tensor
 
     Measures the element-wise mean squared error.
 
@@ -1593,7 +1593,7 @@ def mse_loss(input, target, size_average=True, reduce=True):
 
 
 def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):
-    """margin_ranking_loss(input1, input2, target, margin=0, size_average=True) -> Variable
+    r"""margin_ranking_loss(input1, input2, target, margin=0, size_average=True) -> Tensor
 
     See :class:`~torch.nn.MarginRankingLoss` for details.
     """
@@ -1604,7 +1604,7 @@ def margin_ranking_loss(input1, input2, target, margin=0, size_average=True):
 
 
 def hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True):
-    """hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True) -> Variable
+    r"""hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True) -> Tensor
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
     """
@@ -1612,20 +1612,20 @@ def hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=Tr
 
 
 multilabel_margin_loss = _add_docstr(torch._C._nn.multilabel_margin_loss, r"""
-multilabel_margin_loss(input, target, size_average=True, reduce=True) -> Variable
+multilabel_margin_loss(input, target, size_average=True, reduce=True) -> Tensor
 
 See :class:`~torch.nn.MultiLabelMarginLoss` for details.
 """)
 
 soft_margin_loss = _add_docstr(torch._C._nn.soft_margin_loss, r"""
-soft_margin_loss(input, target, size_average=True, reduce=True) -> Variable
+soft_margin_loss(input, target, size_average=True, reduce=True) -> Tensor
 
 See :class:`~torch.nn.SoftMarginLoss` for details.
 """)
 
 
 def multilabel_soft_margin_loss(input, target, weight=None, size_average=True, reduce=True):
-    """multilabel_soft_margin_loss(input, target, weight=None, size_average=True) -> Variable
+    r"""multilabel_soft_margin_loss(input, target, weight=None, size_average=True) -> Tensor
 
     See :class:`~torch.nn.MultiLabelSoftMarginLoss` for details.
     """
@@ -1634,7 +1634,7 @@ def multilabel_soft_margin_loss(input, target, weight=None, size_average=True, r
 
 
 def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True):
-    """cosine_embedding_loss(input1, input2, target, margin=0, size_average=True) -> Variable
+    r"""cosine_embedding_loss(input1, input2, target, margin=0, size_average=True) -> Tensor
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
     """
@@ -1642,7 +1642,7 @@ def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True):
 
 
 def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True):
-    """multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True) -> Variable
+    r"""multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True) -> Tensor
 
     See :class:`~torch.nn.MultiMarginLoss` for details.
     """

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -40,8 +40,8 @@ Args:
 
 Examples::
 
-    >>> filters = autograd.Variable(torch.randn(33, 16, 3))
-    >>> inputs = autograd.Variable(torch.randn(20, 16, 50))
+    >>> filters = torch.randn(33, 16, 3)
+    >>> inputs = torch.randn(20, 16, 50)
     >>> F.conv1d(inputs, filters)
 """)
 
@@ -69,8 +69,8 @@ Args:
 Examples::
 
     >>> # With square kernels and equal stride
-    >>> filters = autograd.Variable(torch.randn(8,4,3,3))
-    >>> inputs = autograd.Variable(torch.randn(1,4,5,5))
+    >>> filters = torch.randn(8,4,3,3)
+    >>> inputs = torch.randn(1,4,5,5)
     >>> F.conv2d(inputs, filters, padding=1)
 """)
 
@@ -97,8 +97,8 @@ Args:
 
 Examples::
 
-    >>> filters = autograd.Variable(torch.randn(33, 16, 3, 3, 3))
-    >>> inputs = autograd.Variable(torch.randn(20, 16, 50, 10, 20))
+    >>> filters = torch.randn(33, 16, 3, 3, 3)
+    >>> inputs = torch.randn(20, 16, 50, 10, 20)
     >>> F.conv3d(inputs, filters)
 """)
 
@@ -214,12 +214,12 @@ def avg_pool1d(input, kernel_size, stride=None, padding=0,
 
     Example:
         >>> # pool of square window of size=3, stride=2
-        >>> input = Variable(torch.Tensor([[[1,2,3,4,5,6,7]]]))
+        >>> input = torch.Tensor([[[1,2,3,4,5,6,7]]])
         >>> F.avg_pool1d(input, kernel_size=3, stride=2)
-        Variable containing:
+
         (0 ,.,.) =
           2  4  6
-        [torch.FloatTensor of size 1x1x3]
+        [torch.FloatTensor of size (1,1,3)]
     """
     if input.dim() != 3:
         raise ValueError('expected 3D input (got {} dimensions)'
@@ -300,7 +300,7 @@ def fractional_max_pool2d(input, kernel_size, output_size=None,
                         Useful to pass to max_unpool2d.
 
     Examples:
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 32))
+        >>> input = torch.randn(20, 16, 50, 32)
         >>> # pool of square window of size=3, and target output size 13x12
         >>> F.fractional_max_pool2d(input, 3, output_size=(13, 12))
         >>> # pool of square window and target output size being half of input image size
@@ -557,7 +557,7 @@ def alpha_dropout(input, p=0.5, training=False):
     # TODO avoid casting to byte after resize
     noise = input.data.new().resize_(input.size())
     noise.bernoulli_(p)
-    noise = Variable(noise.byte())
+    noise = noise.byte()
 
     output = input.masked_fill(noise, alpha)
 
@@ -862,7 +862,7 @@ def _gumbel_softmax_sample(logits, tau=1, eps=1e-10):
     """
     dims = logits.dim()
     gumbel_noise = _sample_gumbel(logits.size(), eps=eps, out=logits.data.new())
-    y = logits + Variable(gumbel_noise)
+    y = logits + gumbel_noise
     return softmax(y / tau, dims - 1)
 
 
@@ -1017,12 +1017,11 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
     Examples::
 
         >>> # a batch of 2 samples of 4 indices each
-        >>> input = Variable(torch.LongTensor([[1,2,4,5],[4,3,2,9]]))
+        >>> input = torch.LongTensor([[1,2,4,5],[4,3,2,9]])
         >>> # an embedding matrix containing 10 tensors of size 3
-        >>> embedding_matrix = Variable(torch.rand(10, 3))
+        >>> embedding_matrix = torch.rand(10, 3)
         >>> F.embedding(input, embedding_matrix)
 
-        Variable containing:
         (0 ,.,.) =
          -1.0822  1.2522  0.2434
           0.8393 -0.6062 -0.3348
@@ -1034,22 +1033,21 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
          -0.1527  0.0877  0.4260
           0.8393 -0.6062 -0.3348
          -0.8738 -0.9054  0.4281
-        [torch.FloatTensor of size 2x4x3]
+        [torch.FloatTensor of size (2,4,3)]
 
         >>> # example with padding_idx
         >>> weights = torch.rand(10, 3)
         >>> weights[0, :].zero_()
-        >>> embedding_matrix = Variable(weights)
-        >>> input = Variable(torch.LongTensor([[0,2,0,5]]))
+        >>> embedding_matrix = weights
+        >>> input = torch.LongTensor([[0,2,0,5]])
         >>> F.embedding(input, embedding_matrix, padding_idx=0)
 
-        Variable containing:
         (0 ,.,.) =
           0.0000  0.0000  0.0000
           0.3452  0.4937 -0.9361
           0.0000  0.0000  0.0000
           0.0706 -2.1962 -0.6276
-        [torch.FloatTensor of size 1x4x3]
+        [torch.FloatTensor of size (1,4,3)]
 
     """
     input = input.contiguous()
@@ -1111,16 +1109,15 @@ def embedding_bag(embedding_matrix, indices, offsets=None,
         Examples::
 
             >>> # an Embedding module containing 10 tensors of size 3
-            >>> embedding_matrix = Variable(torch.rand(10, 3))
+            >>> embedding_matrix = torch.rand(10, 3)
             >>> # a batch of 2 samples of 4 indices each
-            >>> input = Variable(torch.LongTensor([1,2,4,5,4,3,2,9]))
-            >>> offsets = Variable(torch.LongTensor([0,4]))
+            >>> input = torch.LongTensor([1,2,4,5,4,3,2,9])
+            >>> offsets = torch.LongTensor([0,4])
             >>> embedding_bag(embedding_matrix, input, offsets)
 
-            Variable containing:
             -1.1840 -0.2547 -0.5860
             -0.7126  0.0002 -0.3411
-            [torch.FloatTensor of size 2x3]
+            [torch.FloatTensor of size (2,3)]
 
         """
     if indices.dim() == 2:
@@ -1342,15 +1339,15 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
     Example::
 
         >>> # input is of size N x C = 3 x 5
-        >>> input = autograd.Variable(torch.randn(3, 5))
+        >>> input = torch.randn(3, 5)
         >>> # each element in target has to have 0 <= value < C
-        >>> target = autograd.Variable(torch.LongTensor([1, 0, 4]))
+        >>> target = torch.LongTensor([1, 0, 4])
         >>> output = F.nll_loss(F.log_softmax(input), target)
         >>> output.backward()
     """
     dim = input.dim()
     if torch.is_tensor(weight):
-        weight = Variable(weight)
+        weight = weight
     if dim == 2:
         return torch._C._nn.nll_loss(input, target, weight, size_average, ignore_index, reduce)
     elif dim == 4:
@@ -1456,8 +1453,8 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
 
     Examples::
 
-        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
-        >>> target = autograd.Variable(torch.LongTensor(3).random_(5))
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.LongTensor(3).random_(5)
         >>> loss = F.cross_entropy(input, target)
         >>> loss.backward()
     """
@@ -1486,8 +1483,8 @@ def binary_cross_entropy(input, target, weight=None, size_average=True, reduce=T
 
     Examples::
 
-        >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
-        >>> target = autograd.Variable(torch.LongTensor(3).random_(2))
+        >>> input = torch.randn(3, requires_grad=True)
+        >>> target = torch.LongTensor(3).random_(2)
         >>> loss = F.binary_cross_entropy(F.sigmoid(input), target)
         >>> loss.backward()
     """
@@ -1502,7 +1499,7 @@ def binary_cross_entropy(input, target, weight=None, size_average=True, reduce=T
         new_size = _infer_size(target.size(), weight.size())
         weight = weight.expand(new_size)
         if torch.is_tensor(weight):
-            weight = Variable(weight)
+            weight = weight
 
     return torch._C._nn.binary_cross_entropy(input, target, weight, size_average, reduce)
 
@@ -1529,8 +1526,8 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
 
     Examples::
 
-         >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
-         >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
+         >>> input = torch.randn(3, requires_grad=True)
+         >>> target = torch.FloatTensor(3).random_(2)
          >>> loss = F.binary_cross_entropy_with_logits(input, target)
          >>> loss.backward()
     """
@@ -1670,7 +1667,7 @@ def pixel_shuffle(input, upscale_factor):
     Examples::
 
         >>> ps = nn.PixelShuffle(3)
-        >>> input = autograd.Variable(torch.Tensor(1, 9, 4, 4))
+        >>> input = torch.Tensor(1, 9, 4, 4)
         >>> output = ps(input)
         >>> print(output.size())
         torch.Size([1, 1, 12, 12])
@@ -1958,8 +1955,8 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6):
 
     Example::
 
-        >>> input1 = autograd.Variable(torch.randn(100, 128))
-        >>> input2 = autograd.Variable(torch.randn(100, 128))
+        >>> input1 = torch.randn(100, 128)
+        >>> input2 = torch.randn(100, 128)
         >>> output = F.pairwise_distance(input1, input2, p=2)
         >>> output.backward()
     """
@@ -1989,8 +1986,8 @@ def cosine_similarity(x1, x2, dim=1, eps=1e-8):
 
     Example::
 
-        >>> input1 = autograd.Variable(torch.randn(100, 128))
-        >>> input2 = autograd.Variable(torch.randn(100, 128))
+        >>> input1 = torch.randn(100, 128)
+        >>> input2 = torch.randn(100, 128)
         >>> output = F.cosine_similarity(input1, input2)
         >>> print(output)
     """
@@ -2032,9 +2029,9 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
 
     Example::
 
-        >>> input1 = autograd.Variable(torch.randn(100, 128))
-        >>> input2 = autograd.Variable(torch.randn(100, 128))
-        >>> input3 = autograd.Variable(torch.randn(100, 128))
+        >>> input1 = torch.randn(100, 128)
+        >>> input2 = torch.randn(100, 128)
+        >>> input3 = torch.randn(100, 128)
         >>> output = F.triplet_margin_loss(input1, input2, input3, p=2)
         >>> output.backward()
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -27,9 +27,8 @@ class Threshold(Module):
     Examples::
 
         >>> m = nn.Threshold(0.1, 20)
-        >>> input = Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, threshold, value, inplace=False):
@@ -67,9 +66,8 @@ class ReLU(Threshold):
     Examples::
 
         >>> m = nn.ReLU()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, inplace=False):
@@ -82,23 +80,22 @@ class ReLU(Threshold):
 
 
 class RReLU(Module):
-    r""" Randomized leaky ReLU.
-
-    Applies the randomized leaky rectified liner unit function
-    element-wise described in the paper
+    r"""Applies the randomized leaky rectified liner unit function element-wise
+    described in the paper
     `Empirical Evaluation of Rectified Activations in Convolutional Network`_.
 
-    The function is defined as:
+    The function is defined as::
 
     .. math::
         f(x) = \begin{cases}
             ax & \text{if } x < 0 \\
-            x & \text{if } x \geq 0 , \\
-        \end{cases}
+            x & \text{if } x \geq 0 \\
+        \end{cases},
 
-    where :math:`a` is randomly sampled from uniform distribution
-    :math:`U(\text{lower}, \text{upper})`, typically
-    :math:`U\left(\frac{1}{8}, \frac{1}{3}\right)`
+     where :math:`a` is randomly sampled from uniform distribution
+    :math:`U(\text{lower}, \text{upper})`.
+
+     See: https://arxiv.org/pdf/1505.00853.pdf
 
     Args:
         lower: lower bound of the uniform distribution. Default: :math:`1/8`
@@ -109,8 +106,6 @@ class RReLU(Module):
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
-
-    .. image:: _static/img/activation/RReLU.png
 
     Examples::
 
@@ -143,11 +138,15 @@ class Hardtanh(Module):
 
     HardTanh is defined as::
 
-       f(x) = +1, if x  >  1
-       f(x) = -1, if x  < -1
-       f(x) =  x,  otherwise
+    .. math::
+        f(x) = \begin{cases}
+            1 & \text{if } x > 1 \\
+            -1 & \text{if } x < -1 \\
+            x & \text{otherwise} \\
+        \end{cases}
 
-    The range of the linear region :math:`[-1, 1]` can be adjusted
+    The range of the linear region :math:`[-1, 1]` can be adjusted using
+    :attr:`min_val` and :attr:`max_val`.
 
     .. image:: _static/img/activation/Hardtanh.png
 
@@ -157,7 +156,7 @@ class Hardtanh(Module):
         inplace: can optionally do the operation in-place. Default: ``False``
 
     Keyword arguments :attr:`min_value` and :attr:`max_value`
-    have been deprecated in favor of :attr:`min_val` and :attr:`max_val`
+    have been deprecated in favor of :attr:`min_val` and :attr:`max_val`.
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -167,9 +166,8 @@ class Hardtanh(Module):
     Examples::
 
         >>> m = nn.Hardtanh(-2, 2)
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, min_val=-1, max_val=1, inplace=False, min_value=None, max_value=None):
@@ -213,9 +211,8 @@ class ReLU6(Hardtanh):
     Examples::
 
         >>> m = nn.ReLU6()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, inplace=False):
@@ -240,9 +237,8 @@ class Sigmoid(Module):
     Examples::
 
         >>> m = nn.Sigmoid()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -266,9 +262,8 @@ class Tanh(Module):
     Examples::
 
         >>> m = nn.Tanh()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -296,9 +291,8 @@ class ELU(Module):
     Examples::
 
         >>> m = nn.ELU()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, alpha=1., inplace=False):
@@ -337,9 +331,8 @@ class SELU(Module):
     Examples::
 
         >>> m = nn.SELU()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
 
     .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515
     """
@@ -372,9 +365,8 @@ class GLU(Module):
     Examples::
 
         >>> m = nn.GLU()
-        >>> input = autograd.Variable(torch.randn(4, 2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(4, 2)
+        >>> output = m(input)
     """
 
     def __init__(self, dim=-1):
@@ -408,9 +400,8 @@ class Hardshrink(Module):
     Examples::
 
         >>> m = nn.Hardshrink()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, lambd=0.5):
@@ -443,9 +434,8 @@ class LeakyReLU(Module):
     Examples::
 
         >>> m = nn.LeakyReLU(0.1)
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, negative_slope=1e-2, inplace=False):
@@ -476,9 +466,8 @@ class LogSigmoid(Module):
     Examples::
 
         >>> m = nn.LogSigmoid()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -511,9 +500,8 @@ class Softplus(Module):
     Examples::
 
         >>> m = nn.Softplus()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, beta=1, threshold=20):
@@ -551,9 +539,8 @@ class Softshrink(Module):
     Examples::
 
         >>> m = nn.Softshrink()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, lambd=0.5):
@@ -593,9 +580,8 @@ class PReLU(Module):
     Examples::
 
         >>> m = nn.PReLU()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def __init__(self, num_parameters=1, init=0.25):
@@ -624,9 +610,8 @@ class Softsign(Module):
     Examples::
 
         >>> m = nn.Softsign()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -649,9 +634,8 @@ class Tanhshrink(Module):
     Examples::
 
         >>> m = nn.Tanhshrink()
-        >>> input = autograd.Variable(torch.randn(2))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -683,9 +667,8 @@ class Softmin(Module):
     Examples::
 
         >>> m = nn.Softmin()
-        >>> input = autograd.Variable(torch.randn(2, 3))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
     """
     def __init__(self, dim=None):
         super(Softmin, self).__init__()
@@ -726,9 +709,8 @@ class Softmax(Module):
     Examples::
 
         >>> m = nn.Softmax()
-        >>> input = autograd.Variable(torch.randn(2, 3))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
     """
 
     def __init__(self, dim=None):
@@ -766,9 +748,8 @@ class Softmax2d(Module):
 
         >>> m = nn.Softmax2d()
         >>> # you softmax over the 2nd dimension
-        >>> input = autograd.Variable(torch.randn(2, 3, 12, 13))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2, 3, 12, 13)
+        >>> output = m(input)
     """
 
     def forward(self, input):
@@ -800,9 +781,8 @@ class LogSoftmax(Module):
     Examples::
 
         >>> m = nn.LogSoftmax()
-        >>> input = autograd.Variable(torch.randn(2, 3))
-        >>> print(input)
-        >>> print(m(input))
+        >>> input = torch.randn(2, 3)
+        >>> output = m(input)
     """
 
     def __init__(self, dim=None):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -110,7 +110,7 @@ class BatchNorm1d(_BatchNorm):
         >>> m = nn.BatchNorm1d(100)
         >>> # Without Learnable Parameters
         >>> m = nn.BatchNorm1d(100, affine=False)
-        >>> input = autograd.Variable(torch.randn(20, 100))
+        >>> input = torch.randn(20, 100)
         >>> output = m(input)
 
     .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:
@@ -179,7 +179,7 @@ class BatchNorm2d(_BatchNorm):
         >>> m = nn.BatchNorm2d(100)
         >>> # Without Learnable Parameters
         >>> m = nn.BatchNorm2d(100, affine=False)
-        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45))
+        >>> input = torch.randn(20, 100, 35, 45)
         >>> output = m(input)
 
     .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:
@@ -249,7 +249,7 @@ class BatchNorm3d(_BatchNorm):
         >>> m = nn.BatchNorm3d(100)
         >>> # Without Learnable Parameters
         >>> m = nn.BatchNorm3d(100, affine=False)
-        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45, 10))
+        >>> input = torch.randn(20, 100, 35, 45, 10)
         >>> output = m(input)
 
     .. _`Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift`:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -148,7 +148,7 @@ class Conv1d(_ConvNd):
     Examples::
 
         >>> m = nn.Conv1d(16, 33, 3, stride=2)
-        >>> input = autograd.Variable(torch.randn(20, 16, 50))
+        >>> input = torch.randn(20, 16, 50)
         >>> output = m(input)
 
     .. _cross-correlation:
@@ -267,7 +267,7 @@ class Conv2d(_ConvNd):
         >>> m = nn.Conv2d(16, 33, (3, 5), stride=(2, 1), padding=(4, 2))
         >>> # non-square kernels and unequal stride and with padding and dilation
         >>> m = nn.Conv2d(16, 33, (3, 5), stride=(2, 1), padding=(4, 2), dilation=(3, 1))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 100))
+        >>> input = torch.randn(20, 16, 50, 100)
         >>> output = m(input)
 
     .. _cross-correlation:
@@ -379,7 +379,7 @@ class Conv3d(_ConvNd):
         >>> m = nn.Conv3d(16, 33, 3, stride=2)
         >>> # non-square kernels and unequal stride and with padding
         >>> m = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(4, 2, 0))
-        >>> input = autograd.Variable(torch.randn(20, 16, 10, 50, 100))
+        >>> input = torch.randn(20, 16, 10, 50, 100)
         >>> output = m(input)
 
     .. _cross-correlation:
@@ -598,10 +598,10 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
         >>> m = nn.ConvTranspose2d(16, 33, 3, stride=2)
         >>> # non-square kernels and unequal stride and with padding
         >>> m = nn.ConvTranspose2d(16, 33, (3, 5), stride=(2, 1), padding=(4, 2))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 100))
+        >>> input = torch.randn(20, 16, 50, 100)
         >>> output = m(input)
         >>> # exact output size can be also specified as an argument
-        >>> input = autograd.Variable(torch.randn(1, 16, 12, 12))
+        >>> input = torch.randn(1, 16, 12, 12)
         >>> downsample = nn.Conv2d(16, 16, 3, stride=2, padding=1)
         >>> upsample = nn.ConvTranspose2d(16, 16, 3, stride=2, padding=1)
         >>> h = downsample(input)
@@ -713,7 +713,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
         >>> m = nn.ConvTranspose3d(16, 33, 3, stride=2)
         >>> # non-square kernels and unequal stride and with padding
         >>> m = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(0, 4, 2))
-        >>> input = autograd.Variable(torch.randn(20, 16, 10, 50, 100))
+        >>> input = torch.randn(20, 16, 10, 50, 100)
         >>> output = m(input)
 
     .. _cross-correlation:

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -22,10 +22,10 @@ class PairwiseDistance(Module):
 
     Examples::
 
-    >>> pdist = nn.PairwiseDistance(p=2)
-    >>> input1 = autograd.Variable(torch.randn(100, 128))
-    >>> input2 = autograd.Variable(torch.randn(100, 128))
-    >>> output = pdist(input1, input2)
+        >>> pdist = nn.PairwiseDistance(p=2)
+        >>> input1 = torch.randn(100, 128)
+        >>> input2 = torch.randn(100, 128)
+        >>> output = pdist(input1, input2)
     """
     def __init__(self, p=2, eps=1e-6):
         super(PairwiseDistance, self).__init__()
@@ -54,11 +54,10 @@ class CosineSimilarity(Module):
 
     Examples::
 
-    >>> input1 = autograd.Variable(torch.randn(100, 128))
-    >>> input2 = autograd.Variable(torch.randn(100, 128))
-    >>> cos = nn.CosineSimilarity(dim=1, eps=1e-6)
-    >>> output = cos(input1, input2)
-    >>> print(output)
+        >>> input1 = torch.randn(100, 128)
+        >>> input2 = torch.randn(100, 128)
+        >>> cos = nn.CosineSimilarity(dim=1, eps=1e-6)
+        >>> output = cos(input1, input2)
     """
     def __init__(self, dim=1, eps=1e-8):
         super(CosineSimilarity, self).__init__()

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -27,7 +27,7 @@ class Dropout(Module):
     Examples::
 
         >>> m = nn.Dropout(p=0.2)
-        >>> input = autograd.Variable(torch.randn(20, 16))
+        >>> input = torch.randn(20, 16)
         >>> output = m(input)
 
     .. _Improving neural networks by preventing co-adaptation of feature
@@ -80,7 +80,7 @@ class Dropout2d(Module):
     Examples::
 
         >>> m = nn.Dropout2d(p=0.2)
-        >>> input = autograd.Variable(torch.randn(20, 16, 32, 32))
+        >>> input = torch.randn(20, 16, 32, 32)
         >>> output = m(input)
 
     .. _Efficient Object Localization Using Convolutional Networks:
@@ -133,7 +133,7 @@ class Dropout3d(Module):
     Examples::
 
         >>> m = nn.Dropout3d(p=0.2)
-        >>> input = autograd.Variable(torch.randn(20, 16, 4, 32, 32))
+        >>> input = torch.randn(20, 16, 4, 32, 32)
         >>> output = m(input)
 
     .. _Efficient Object Localization Using Convolutional Networks:
@@ -188,7 +188,7 @@ class AlphaDropout(Module):
     Examples::
 
         >>> m = nn.AlphaDropout(p=0.2)
-        >>> input = autograd.Variable(torch.randn(20, 16))
+        >>> input = torch.randn(20, 16)
         >>> output = m(input)
 
     .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515

--- a/torch/nn/modules/fold.py
+++ b/torch/nn/modules/fold.py
@@ -48,7 +48,7 @@ class Fold(Module):
 
         >>> # output_size (3, 3) kernel_size (2, 2), dilation (1, 1), padding (0, 0), stride (1, 1)
         >>> fold = nn.Fold((3, 3), (2, 2), (1, 1), (0, 0), (1, 1))
-        >>> input = autograd.Variable(torch.randn(1, 36, 1))
+        >>> input = torch.randn(1, 36, 1)
         >>> output = unfold(input)
 
     .. _link:
@@ -121,7 +121,7 @@ class Unfold(Module):
 
         >>> # kernel_size (2, 2), dilation (1, 1), padding (0, 0), stride (1, 1)
         >>> unfold = nn.Unfold((3, 3), (1, 1), (0, 0), (1, 1))
-        >>> input = autograd.Variable(torch.randn(2, 4, 3, 3))
+        >>> input = torch.randn(2, 4, 3, 3)
         >>> output = unfold(input)
 
     .. _link:

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -69,7 +69,7 @@ class InstanceNorm1d(_InstanceNorm):
         >>> m = nn.InstanceNorm1d(100)
         >>> # With Learnable Parameters
         >>> m = nn.InstanceNorm1d(100, affine=True)
-        >>> input = autograd.Variable(torch.randn(20, 100, 40))
+        >>> input = torch.randn(20, 100, 40)
         >>> output = m(input)
 
     .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:
@@ -132,7 +132,7 @@ class InstanceNorm2d(_InstanceNorm):
         >>> m = nn.InstanceNorm2d(100)
         >>> # With Learnable Parameters
         >>> m = nn.InstanceNorm2d(100, affine=True)
-        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45))
+        >>> input = torch.randn(20, 100, 35, 45)
         >>> output = m(input)
 
     .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:
@@ -195,7 +195,7 @@ class InstanceNorm3d(_InstanceNorm):
         >>> m = nn.InstanceNorm3d(100)
         >>> # With Learnable Parameters
         >>> m = nn.InstanceNorm3d(100, affine=True)
-        >>> input = autograd.Variable(torch.randn(20, 100, 35, 45, 10))
+        >>> input = torch.randn(20, 100, 35, 45, 10)
         >>> output = m(input)
 
     .. _`Instance Normalization: The Missing Ingredient for Fast Stylization`:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -29,7 +29,7 @@ class Linear(Module):
     Examples::
 
         >>> m = nn.Linear(20, 30)
-        >>> input = autograd.Variable(torch.randn(128, 20))
+        >>> input = torch.randn(128, 20)
         >>> output = m(input)
         >>> print(output.size())
     """
@@ -84,8 +84,8 @@ class Bilinear(Module):
     Examples::
 
         >>> m = nn.Bilinear(20, 30, 40)
-        >>> input1 = autograd.Variable(torch.randn(128, 20))
-        >>> input2 = autograd.Variable(torch.randn(128, 30))
+        >>> input1 = torch.randn(128, 20)
+        >>> input2 = torch.randn(128, 30)
         >>> output = m(input1, input2)
         >>> print(output.size())
     """

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -71,8 +71,8 @@ class L1Loss(_Loss):
     Examples::
 
         >>> loss = nn.L1Loss()
-        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
-        >>> target = autograd.Variable(torch.randn(3, 5))
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5)
         >>> output = loss(input, target)
         >>> output.backward()
     """
@@ -165,9 +165,9 @@ class NLLLoss(_WeightedLoss):
         >>> m = nn.LogSoftmax()
         >>> loss = nn.NLLLoss()
         >>> # input is of size N x C = 3 x 5
-        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
+        >>> input = torch.randn(3, 5, requires_grad=True)
         >>> # each element in target has to have 0 <= value < C
-        >>> target = autograd.Variable(torch.LongTensor([1, 0, 4]))
+        >>> target = torch.LongTensor([1, 0, 4])
         >>> output = loss(m(input), target)
         >>> output.backward()
         >>>
@@ -176,10 +176,10 @@ class NLLLoss(_WeightedLoss):
         >>> N, C = 5, 4
         >>> loss = nn.NLLLoss()
         >>> # input is of size N x C x height x width
-        >>> data = Variable(torch.randn(N, 16, 10, 10))
+        >>> data = torch.randn(N, 16, 10, 10)
         >>> m = nn.Conv2d(16, C, (3, 3))
         >>> # each element in target has to have 0 <= value < C
-        >>> target = Variable(torch.LongTensor(N, 8, 8).random_(0, C))
+        >>> target = torch.LongTensor(N, 8, 8).random_(0, C)
         >>> output = loss(m(data), target)
         >>> output.backward()
     """
@@ -235,8 +235,8 @@ class PoissonNLLLoss(_Loss):
     Examples::
 
         >>> loss = nn.PoissonNLLLoss()
-        >>> log_input = autograd.Variable(torch.randn(5, 2), requires_grad=True)
-        >>> target = autograd.Variable(torch.randn(5, 2))
+        >>> log_input = torch.randn(5, 2, requires_grad=True)
+        >>> target = torch.randn(5, 2)
         >>> output = loss(log_input, target)
         >>> output.backward()
     """
@@ -359,8 +359,8 @@ class MSELoss(_Loss):
     Examples::
 
         >>> loss = nn.MSELoss()
-        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
-        >>> target = autograd.Variable(torch.randn(3, 5))
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5)
         >>> output = loss(input, target)
         >>> output.backward()
     """
@@ -419,8 +419,8 @@ class BCELoss(_WeightedLoss):
 
         >>> m = nn.Sigmoid()
         >>> loss = nn.BCELoss()
-        >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
-        >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
+        >>> input = torch.randn(3, requires_grad=True)
+        >>> target = torch.FloatTensor(3).random_(2)
         >>> output = loss(m(input), target)
         >>> output.backward()
     """
@@ -480,11 +480,11 @@ class BCEWithLogitsLoss(Module):
 
      Examples::
 
-         >>> loss = nn.BCEWithLogitsLoss()
-         >>> input = autograd.Variable(torch.randn(3), requires_grad=True)
-         >>> target = autograd.Variable(torch.FloatTensor(3).random_(2))
-         >>> output = loss(input, target)
-         >>> output.backward()
+        >>> loss = nn.BCEWithLogitsLoss()
+        >>> input = torch.randn(3, requires_grad=True)
+        >>> target = torch.FloatTensor(3).random_(2)
+        >>> output = loss(input, target)
+        >>> output.backward()
     """
     def __init__(self, weight=None, size_average=True, reduce=True):
         super(BCEWithLogitsLoss, self).__init__()
@@ -728,8 +728,8 @@ class CrossEntropyLoss(_WeightedLoss):
     Examples::
 
         >>> loss = nn.CrossEntropyLoss()
-        >>> input = autograd.Variable(torch.randn(3, 5), requires_grad=True)
-        >>> target = autograd.Variable(torch.LongTensor(3).random_(5))
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.LongTensor(3).random_(5)
         >>> output = loss(input, target)
         >>> output.backward()
     """
@@ -914,9 +914,9 @@ class TripletMarginLoss(Module):
         - Output: :math:`(N, 1)`
 
     >>> triplet_loss = nn.TripletMarginLoss(margin=1.0, p=2)
-    >>> input1 = autograd.Variable(torch.randn(100, 128))
-    >>> input2 = autograd.Variable(torch.randn(100, 128))
-    >>> input3 = autograd.Variable(torch.randn(100, 128))
+    >>> input1 = torch.randn(100, 128, requires_grad=True)
+    >>> input2 = torch.randn(100, 128, requires_grad=True)
+    >>> input3 = torch.randn(100, 128, requires_grad=True)
     >>> output = triplet_loss(input1, input2, input3)
     >>> output.backward()
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -172,26 +172,32 @@ class Module(object):
 
         Example:
             >>> def init_weights(m):
-            >>>     print(m)
-            >>>     if type(m) == nn.Linear:
-            >>>         m.weight.data.fill_(1.0)
-            >>>         print(m.weight)
-            >>>
+                    print(m)
+                    if type(m) == nn.Linear:
+                        m.weight.data.fill_(1.0)
+                        print(m.weight)
+
             >>> net = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
             >>> net.apply(init_weights)
-            Linear (2 -> 2)
-            Parameter containing:
+            Linear(in_features=2, out_features=2, bias=True)
+
              1  1
              1  1
-            [torch.FloatTensor of size 2x2]
-            Linear (2 -> 2)
-            Parameter containing:
+            [torch.FloatTensor of size (2,2)]
+
+            Linear(in_features=2, out_features=2, bias=True)
+
              1  1
              1  1
-            [torch.FloatTensor of size 2x2]
-            Sequential (
-              (0): Linear (2 -> 2)
-              (1): Linear (2 -> 2)
+            [torch.FloatTensor of size (2,2)]
+
+            Sequential(
+              (0): Linear(in_features=2, out_features=2, bias=True)
+              (1): Linear(in_features=2, out_features=2, bias=True)
+            )
+            Sequential(
+              (0): Linear(in_features=2, out_features=2, bias=True)
+              (1): Linear(in_features=2, out_features=2, bias=True)
             )
         """
         for module in self.children():

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -24,10 +24,11 @@ class LocalResponseNorm(Module):
     Shape:
         - Input: :math:`(N, C, ...)`
         - Output: :math:`(N, C, ...)` (same shape as input)
+
     Examples:
         >>> lrn = nn.LocalResponseNorm(2)
-        >>> signal_2d = autograd.Variable(torch.randn(32, 5, 24, 24))
-        >>> signal_4d = autograd.Variable(torch.randn(16, 5, 7, 7, 7, 7))
+        >>> signal_2d = torch.randn(32, 5, 24, 24)
+        >>> signal_4d = torch.randn(16, 5, 7, 7, 7, 7)
         >>> output_2d = lrn(signal_2d)
         >>> output_4d = lrn(signal_4d)
     """
@@ -125,11 +126,16 @@ class LayerNorm(Module):
         - Output: :math:`(N, *)` (same shape as input)
 
     Examples:
-        >>> input = autograd.Variable(torch.randn(20, 5, 10, 10))
+        >>> input = torch.randn(20, 5, 10, 10)
         >>> # With Learnable Parameters
         >>> m = nn.LayerNorm(input.size()[1:])
         >>> # Without Learnable Parameters
         >>> m = nn.LayerNorm(input.size()[1:], elementwise_affine=False)
+        >>> # Normalize over last two dimensions
+        >>> m = nn.LayerNorm([10, 10])
+        >>> # Normalize over last dimension of size 10
+        >>> m = nn.LayerNorm(10)
+        >>> # Activating the module
         >>> output = m(input)
 
     .. _`Layer Normalization`: https://arxiv.org/abs/1607.06450

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -21,7 +21,7 @@ class ConstantPad1d(Module):
     Examples::
 
         >>> m = nn.ConstantPad1d(3, 3.5)
-        >>> input = autograd.Variable(torch.randn(16, 2, 480))
+        >>> input = torch.randn(16, 2, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ConstantPad1d((3, 5), 3.5)
@@ -60,7 +60,7 @@ class ConstantPad2d(Module):
     Examples::
 
         >>> m = nn.ConstantPad2d(3, 3.5)
-        >>> input = autograd.Variable(torch.randn(16, 3, 320, 480))
+        >>> input = torch.randn(16, 3, 320, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ConstantPad2d((3, 3, 6, 6), 3.5)
@@ -99,7 +99,7 @@ class ConstantPad3d(Module):
     Examples::
 
         >>> m = nn.ConstantPad3d(3, 3.5)
-        >>> input = autograd.Variable(torch.randn(16, 3, 10, 20, 30))
+        >>> input = torch.randn(16, 3, 10, 20, 30)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ConstantPad3d((3, 3, 6, 6, 0, 1), 3.5)
@@ -135,7 +135,7 @@ class ReflectionPad1d(Module):
     Examples::
 
         >>> m = nn.ReflectionPad1d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 480))
+        >>> input = torch.randn(16, 3, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ReflectionPad1d((3, 6))
@@ -171,7 +171,7 @@ class ReflectionPad2d(Module):
     Examples::
 
         >>> m = nn.ReflectionPad2d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 320, 480))
+        >>> input = torch.randn(16, 3, 320, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ReflectionPad2d((3, 3, 6, 6))
@@ -206,7 +206,7 @@ class ReplicationPad1d(Module):
     Examples::
 
         >>> m = nn.ReplicationPad1d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 480))
+        >>> input = torch.randn(16, 3, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ReplicationPad1d((3, 6))
@@ -242,7 +242,7 @@ class ReplicationPad2d(Module):
     Examples::
 
         >>> m = nn.ReplicationPad2d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 320, 480))
+        >>> input = torch.randn(16, 3, 320, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ReplicationPad2d((3, 3, 6, 6))
@@ -280,7 +280,7 @@ class ReplicationPad3d(Module):
     Examples::
 
         >>> m = nn.ReplicationPad3d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 8, 320, 480))
+        >>> input = torch.randn(16, 3, 8, 320, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ReplicationPad3d((3, 3, 6, 6, 1, 1))
@@ -316,7 +316,7 @@ class ZeroPad2d(ConstantPad2d):
     Examples::
 
         >>> m = nn.ZeroPad2d(3)
-        >>> input = autograd.Variable(torch.randn(16, 3, 320, 480))
+        >>> input = torch.randn(16, 3, 320, 480)
         >>> output = m(input)
         >>> # using different paddings
         >>> m = nn.ZeroPad2d((3, 3, 6, 6))

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -23,7 +23,7 @@ class PixelShuffle(Module):
     Examples::
 
         >>> ps = nn.PixelShuffle(3)
-        >>> input = autograd.Variable(torch.Tensor(1, 9, 4, 4))
+        >>> input = torch.Tensor(1, 9, 4, 4)
         >>> output = ps(input)
         >>> print(output.size())
         torch.Size([1, 1, 12, 12])

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -42,7 +42,7 @@ class MaxPool1d(Module):
 
         >>> # pool of size=3, stride=2
         >>> m = nn.MaxPool1d(3, stride=2)
-        >>> input = autograd.Variable(torch.randn(20, 16, 50))
+        >>> input = torch.randn(20, 16, 50)
         >>> output = m(input)
 
     .. _link:
@@ -120,7 +120,7 @@ class MaxPool2d(Module):
         >>> m = nn.MaxPool2d(3, stride=2)
         >>> # pool of non-square window
         >>> m = nn.MaxPool2d((3, 2), stride=(2, 1))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 32))
+        >>> input = torch.randn(20, 16, 50, 32)
         >>> output = m(input)
 
     .. _link:
@@ -194,28 +194,28 @@ class MaxUnpool1d(Module):
 
         >>> pool = nn.MaxPool1d(2, stride=2, return_indices=True)
         >>> unpool = nn.MaxUnpool1d(2, stride=2)
-        >>> input = Variable(torch.Tensor([[[1, 2, 3, 4, 5, 6, 7, 8]]]))
+        >>> input = torch.Tensor([[[1, 2, 3, 4, 5, 6, 7, 8]]])
         >>> output, indices = pool(input)
         >>> unpool(output, indices)
-        Variable containing:
+
         (0 ,.,.) =
            0   2   0   4   0   6   0   8
-        [torch.FloatTensor of size 1x1x8]
+        [torch.FloatTensor of size (1,1,8)]
 
         >>> # Example showcasing the use of output_size
-        >>> input = Variable(torch.Tensor([[[1, 2, 3, 4, 5, 6, 7, 8, 9]]]))
+        >>> input = torch.Tensor([[[1, 2, 3, 4, 5, 6, 7, 8, 9]]])
         >>> output, indices = pool(input)
         >>> unpool(output, indices, output_size=input.size())
-        Variable containing:
+
         (0 ,.,.) =
            0   2   0   4   0   6   0   8   0
-        [torch.FloatTensor of size 1x1x9]
+        [torch.FloatTensor of size (1,1,9)]
 
         >>> unpool(output, indices)
-        Variable containing:
+
         (0 ,.,.) =
            0   2   0   4   0   6   0   8
-        [torch.FloatTensor of size 1x1x8]
+        [torch.FloatTensor of size (1,1,8)]
 
     """
 
@@ -274,29 +274,29 @@ class MaxUnpool2d(Module):
         >>> pool = nn.MaxPool2d(2, stride=2, return_indices=True)
         >>> unpool = nn.MaxUnpool2d(2, stride=2)
         >>> input = Variable(torch.Tensor([[[[ 1,  2,  3,  4],
-        ...                                  [ 5,  6,  7,  8],
-        ...                                  [ 9, 10, 11, 12],
-        ...                                  [13, 14, 15, 16]]]]))
+                                             [ 5,  6,  7,  8],
+                                             [ 9, 10, 11, 12],
+                                             [13, 14, 15, 16]]]]))
         >>> output, indices = pool(input)
         >>> unpool(output, indices)
-        Variable containing:
+
         (0 ,0 ,.,.) =
            0   0   0   0
            0   6   0   8
            0   0   0   0
            0  14   0  16
-        [torch.FloatTensor of size 1x1x4x4]
+        [torch.FloatTensor of size (1,1,4,4)]
 
         >>> # specify a different output size than input size
         >>> unpool(output, indices, output_size=torch.Size([1, 1, 5, 5]))
-        Variable containing:
+
         (0 ,0 ,.,.) =
            0   0   0   0   0
            6   0   8   0   0
            0   0   0  14   0
           16   0   0   0   0
            0   0   0   0   0
-        [torch.FloatTensor of size 1x1x5x5]
+        [torch.FloatTensor of size (1,1,5,5)]
 
     """
 
@@ -355,7 +355,7 @@ class MaxUnpool3d(Module):
         >>> # pool of square window of size=3, stride=2
         >>> pool = nn.MaxPool3d(3, stride=2, return_indices=True)
         >>> unpool = nn.MaxUnpool3d(3, stride=2)
-        >>> output, indices = pool(Variable(torch.randn(20, 16, 51, 33, 15)))
+        >>> output, indices = pool(torch.randn(20, 16, 51, 33, 15))
         >>> unpooled_output = unpool(output, indices)
         >>> unpooled_output.size()
         torch.Size([20, 16, 51, 33, 15])
@@ -415,11 +415,11 @@ class AvgPool1d(Module):
 
         >>> # pool with window of size=3, stride=2
         >>> m = nn.AvgPool1d(3, stride=2)
-        >>> m(Variable(torch.Tensor([[[1,2,3,4,5,6,7]]])))
-        Variable containing:
+        >>> m(torch.Tensor([[[1,2,3,4,5,6,7]]]))
+
         (0 ,.,.) =
           2  4  6
-        [torch.FloatTensor of size 1x1x3]
+        [torch.FloatTensor of size (1,1,3)]
     """
 
     def __init__(self, kernel_size, stride=None, padding=0, ceil_mode=False,
@@ -488,7 +488,7 @@ class AvgPool2d(Module):
         >>> m = nn.AvgPool2d(3, stride=2)
         >>> # pool of non-square window
         >>> m = nn.AvgPool2d((3, 2), stride=(2, 1))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 32))
+        >>> input = torch.randn(20, 16, 50, 32)
         >>> output = m(input)
     """
 
@@ -562,7 +562,7 @@ class MaxPool3d(Module):
         >>> m = nn.MaxPool3d(3, stride=2)
         >>> # pool of non-square window
         >>> m = nn.MaxPool3d((3, 2, 2), stride=(2, 1, 2))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50,44, 31))
+        >>> input = torch.randn(20, 16, 50,44, 31)
         >>> output = m(input)
 
     .. _link:
@@ -637,7 +637,7 @@ class AvgPool3d(Module):
         >>> m = nn.AvgPool3d(3, stride=2)
         >>> # pool of non-square window
         >>> m = nn.AvgPool3d((3, 2, 2), stride=(2, 1, 2))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50,44, 31))
+        >>> input = torch.randn(20, 16, 50,44, 31)
         >>> output = m(input)
     """
 
@@ -693,7 +693,7 @@ class FractionalMaxPool2d(Module):
         >>> m = nn.FractionalMaxPool2d(3, output_size=(13, 12))
         >>> # pool of square window and target output size being half of input image size
         >>> m = nn.FractionalMaxPool2d(3, output_ratio=(0.5, 0.5))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 32))
+        >>> input = torch.randn(20, 16, 50, 32)
         >>> output = m(input)
 
     .. _Fractional MaxPooling:
@@ -719,7 +719,7 @@ class FractionalMaxPool2d(Module):
                                  .format(output_ratio))
 
     def forward(self, input):
-        samples = None if self._random_samples is None else Variable(self._random_samples)
+        samples = None if self._random_samples is None else self._random_samples
         return F.fractional_max_pool2d(
             input, self.kernel_size, self.output_size, self.output_ratio,
             self.return_indices,
@@ -758,7 +758,7 @@ class LPPool2d(Module):
         >>> m = nn.LPPool2d(2, 3, stride=2)
         >>> # pool of non-square window of power 1.2
         >>> m = nn.LPPool2d(1.2, (3, 2), stride=(2, 1))
-        >>> input = autograd.Variable(torch.randn(20, 16, 50, 32))
+        >>> input = torch.randn(20, 16, 50, 32)
         >>> output = m(input)
 
     """
@@ -804,7 +804,7 @@ class LPPool1d(Module):
     Examples::
         >>> # power-2 pool of window of length 3, with stride 2.
         >>> m = nn.LPPool1d(2, 3, stride=2)
-        >>> input = autograd.Variable(torch.randn(20, 16, 50))
+        >>> input = torch.randn(20, 16, 50)
         >>> output = m(input)
     """
 
@@ -841,7 +841,7 @@ class AdaptiveMaxPool1d(Module):
     Examples:
         >>> # target output size of 5
         >>> m = nn.AdaptiveMaxPool1d(5)
-        >>> input = autograd.Variable(torch.randn(1, 64, 8))
+        >>> input = torch.randn(1, 64, 8)
         >>> output = m(input)
 
     """
@@ -876,15 +876,15 @@ class AdaptiveMaxPool2d(Module):
     Examples:
         >>> # target output size of 5x7
         >>> m = nn.AdaptiveMaxPool2d((5,7))
-        >>> input = autograd.Variable(torch.randn(1, 64, 8, 9))
+        >>> input = torch.randn(1, 64, 8, 9)
         >>> output = m(input)
         >>> # target output size of 7x7 (square)
         >>> m = nn.AdaptiveMaxPool2d(7)
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9))
+        >>> input = torch.randn(1, 64, 10, 9)
         >>> output = m(input)
         >>> # target output size of 10x7
         >>> m = nn.AdaptiveMaxPool2d((None, 7))
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9))
+        >>> input = torch.randn(1, 64, 10, 9)
         >>> output = m(input)
 
     """
@@ -920,15 +920,15 @@ class AdaptiveMaxPool3d(Module):
     Examples:
         >>> # target output size of 5x7x9
         >>> m = nn.AdaptiveMaxPool3d((5,7,9))
-        >>> input = autograd.Variable(torch.randn(1, 64, 8, 9, 10))
+        >>> input = torch.randn(1, 64, 8, 9, 10)
         >>> output = m(input)
         >>> # target output size of 7x7x7 (cube)
         >>> m = nn.AdaptiveMaxPool3d(7)
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9, 8))
+        >>> input = torch.randn(1, 64, 10, 9, 8)
         >>> output = m(input)
         >>> # target output size of 7x9x8
         >>> m = nn.AdaptiveMaxPool3d((7, None, None))
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9, 8))
+        >>> input = torch.randn(1, 64, 10, 9, 8)
         >>> output = m(input)
 
     """
@@ -958,7 +958,7 @@ class AdaptiveAvgPool1d(Module):
     Examples:
         >>> # target output size of 5
         >>> m = nn.AdaptiveAvgPool1d(5)
-        >>> input = autograd.Variable(torch.randn(1, 64, 8))
+        >>> input = torch.randn(1, 64, 8)
         >>> output = m(input)
 
     """
@@ -990,15 +990,15 @@ class AdaptiveAvgPool2d(Module):
     Examples:
         >>> # target output size of 5x7
         >>> m = nn.AdaptiveAvgPool2d((5,7))
-        >>> input = autograd.Variable(torch.randn(1, 64, 8, 9))
+        >>> input = torch.randn(1, 64, 8, 9)
         >>> output = m(input)
         >>> # target output size of 7x7 (square)
         >>> m = nn.AdaptiveAvgPool2d(7)
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9))
+        >>> input = torch.randn(1, 64, 10, 9)
         >>> output = m(input)
         >>> # target output size of 10x7
         >>> m = nn.AdaptiveMaxPool2d((None, 7))
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9))
+        >>> input = torch.randn(1, 64, 10, 9)
         >>> output = m(input)
 
     """
@@ -1030,15 +1030,15 @@ class AdaptiveAvgPool3d(Module):
     Examples:
         >>> # target output size of 5x7x9
         >>> m = nn.AdaptiveAvgPool3d((5,7,9))
-        >>> input = autograd.Variable(torch.randn(1, 64, 8, 9, 10))
+        >>> input = torch.randn(1, 64, 8, 9, 10)
         >>> output = m(input)
         >>> # target output size of 7x7x7 (cube)
         >>> m = nn.AdaptiveAvgPool3d(7)
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9, 8))
+        >>> input = torch.randn(1, 64, 10, 9, 8)
         >>> output = m(input)
         >>> # target output size of 7x9x8
         >>> m = nn.AdaptiveMaxPool3d((7, None, None))
-        >>> input = autograd.Variable(torch.randn(1, 64, 10, 9, 8))
+        >>> input = torch.randn(1, 64, 10, 9, 8)
         >>> output = m(input)
 
     """

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -285,8 +285,8 @@ class RNN(RNNBase):
     Examples::
 
         >>> rnn = nn.RNN(10, 20, 2)
-        >>> input = Variable(torch.randn(5, 3, 10))
-        >>> h0 = Variable(torch.randn(2, 3, 20))
+        >>> input = torch.randn(5, 3, 10)
+        >>> h0 = torch.randn(2, 3, 20)
         >>> output, hn = rnn(input, h0)
     """
 
@@ -380,9 +380,9 @@ class LSTM(RNNBase):
     Examples::
 
         >>> rnn = nn.LSTM(10, 20, 2)
-        >>> input = Variable(torch.randn(5, 3, 10))
-        >>> h0 = Variable(torch.randn(2, 3, 20))
-        >>> c0 = Variable(torch.randn(2, 3, 20))
+        >>> input = torch.randn(5, 3, 10)
+        >>> h0 = torch.randn(2, 3, 20)
+        >>> c0 = torch.randn(2, 3, 20)
         >>> output, hn = rnn(input, (h0, c0))
     """
 
@@ -452,8 +452,8 @@ class GRU(RNNBase):
     Examples::
 
         >>> rnn = nn.GRU(10, 20, 2)
-        >>> input = Variable(torch.randn(5, 3, 10))
-        >>> h0 = Variable(torch.randn(2, 3, 20))
+        >>> input = torch.randn(5, 3, 10)
+        >>> h0 = torch.randn(2, 3, 20)
         >>> output, hn = rnn(input, h0)
     """
 
@@ -526,12 +526,12 @@ class RNNCell(RNNCellBase):
     Examples::
 
         >>> rnn = nn.RNNCell(10, 20)
-        >>> input = Variable(torch.randn(6, 3, 10))
-        >>> hx = Variable(torch.randn(3, 20))
+        >>> input = torch.randn(6, 3, 10)
+        >>> hx = torch.randn(3, 20)
         >>> output = []
         >>> for i in range(6):
-        ...     hx = rnn(input[i], hx)
-        ...     output.append(hx)
+                hx = rnn(input[i], hx)
+                output.append(hx)
     """
 
     def __init__(self, input_size, hidden_size, bias=True, nonlinearity="tanh"):
@@ -619,13 +619,13 @@ class LSTMCell(RNNCellBase):
     Examples::
 
         >>> rnn = nn.LSTMCell(10, 20)
-        >>> input = Variable(torch.randn(6, 3, 10))
-        >>> hx = Variable(torch.randn(3, 20))
-        >>> cx = Variable(torch.randn(3, 20))
+        >>> input = torch.randn(6, 3, 10)
+        >>> hx = torch.randn(3, 20)
+        >>> cx = torch.randn(3, 20)
         >>> output = []
         >>> for i in range(6):
-        ...     hx, cx = rnn(input[i], (hx, cx))
-        ...     output.append(hx)
+                hx, cx = rnn(input[i], (hx, cx))
+                output.append(hx)
     """
 
     def __init__(self, input_size, hidden_size, bias=True):
@@ -699,12 +699,12 @@ class GRUCell(RNNCellBase):
     Examples::
 
         >>> rnn = nn.GRUCell(10, 20)
-        >>> input = Variable(torch.randn(6, 3, 10))
-        >>> hx = Variable(torch.randn(3, 20))
+        >>> input = torch.randn(6, 3, 10)
+        >>> hx = torch.randn(3, 20)
         >>> output = []
         >>> for i in range(6):
-        ...     hx = rnn(input[i], hx)
-        ...     output.append(hx)
+                hx = rnn(input[i], hx)
+                output.append(hx)
     """
 
     def __init__(self, input_size, hidden_size, bias=True):

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -41,10 +41,9 @@ class Embedding(Module):
         >>> # an Embedding module containing 10 tensors of size 3
         >>> embedding = nn.Embedding(10, 3)
         >>> # a batch of 2 samples of 4 indices each
-        >>> input = Variable(torch.LongTensor([[1,2,4,5],[4,3,2,9]]))
+        >>> input = torch.LongTensor([[1,2,4,5],[4,3,2,9]])
         >>> embedding(input)
 
-        Variable containing:
         (0 ,.,.) =
          -1.0822  1.2522  0.2434
           0.8393 -0.6062 -0.3348
@@ -56,20 +55,19 @@ class Embedding(Module):
          -0.1527  0.0877  0.4260
           0.8393 -0.6062 -0.3348
          -0.8738 -0.9054  0.4281
-        [torch.FloatTensor of size 2x4x3]
+        [torch.FloatTensor of size (2,4,3)]
 
         >>> # example with padding_idx
         >>> embedding = nn.Embedding(10, 3, padding_idx=0)
-        >>> input = Variable(torch.LongTensor([[0,2,0,5]]))
+        >>> input = torch.LongTensor([[0,2,0,5]])
         >>> embedding(input)
 
-        Variable containing:
         (0 ,.,.) =
           0.0000  0.0000  0.0000
           0.3452  0.4937 -0.9361
           0.0000  0.0000  0.0000
           0.0706 -2.1962 -0.6276
-        [torch.FloatTensor of size 1x4x3]
+        [torch.FloatTensor of size (1,4,3)]
 
     """
 
@@ -139,10 +137,9 @@ class Embedding(Module):
             >> weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
             >> embedding = nn.Embedding.from_pretrained(weight)
             >> # Get embeddings for index 1
-            >> input = Variable(torch.LongTensor([1]))
+            >> input = torch.LongTensor([1])
             >> embedding(input)
 
-            Variable containing:
              4.0000  5.1000  6.3000
             [torch.FloatTensor of size (1,3)]
         """
@@ -208,14 +205,13 @@ class EmbeddingBag(Module):
         >>> # an Embedding module containing 10 tensors of size 3
         >>> embedding_sum = nn.EmbeddingBag(10, 3, mode='sum')
         >>> # a batch of 2 samples of 4 indices each
-        >>> input = Variable(torch.LongTensor([1,2,4,5,4,3,2,9]))
-        >>> offsets = Variable(torch.LongTensor([0,4]))
+        >>> input = torch.LongTensor([1,2,4,5,4,3,2,9])
+        >>> offsets = torch.LongTensor([0,4])
         >>> embedding_sum(input, offsets)
 
-        Variable containing:
         -0.7296 -4.6926  0.3295
         -0.5186 -0.5631 -0.2792
-        [torch.FloatTensor of size 2x3]
+        [torch.FloatTensor of size (2,3)]
 
     """
 

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -118,7 +118,7 @@ class UpsamplingNearest2d(Upsample):
 
         >>> m = nn.UpsamplingNearest2d(scale_factor=2)
         >>> m(input)
-\
+
         (0 ,0 ,.,.) =
           1  1  2  2
           1  1  2  2

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -32,40 +32,40 @@ class Upsample(Module):
 
     Examples::
 
-        >>> inp
-        Variable containing:
+        >>> input = torch.arange(1, 5).view(1, 1, 2, 2)
+        >>> input
+
         (0 ,0 ,.,.) =
           1  2
           3  4
-        [torch.FloatTensor of size 1x1x2x2]
+        [torch.FloatTensor of size (1,1,2,2)]
 
         >>> m = nn.Upsample(scale_factor=2, mode='bilinear')
-        >>> m(inp)
-        Variable containing:
+        >>> m(input)
+
         (0 ,0 ,.,.) =
           1.0000  1.3333  1.6667  2.0000
           1.6667  2.0000  2.3333  2.6667
           2.3333  2.6667  3.0000  3.3333
           3.0000  3.3333  3.6667  4.0000
-        [torch.FloatTensor of size 1x1x4x4]
+        [torch.FloatTensor of size (1,1,4,4)]
 
-        >>> inp
-        Variable containing:
+        >>> input
+
         (0 ,0 ,.,.) =
           1  2
           3  4
-        [torch.FloatTensor of size 1x1x2x2]
+        [torch.FloatTensor of size (1,1,2,2)]
 
         >>> m = nn.Upsample(scale_factor=2, mode='nearest')
-        >>> m(inp)
-        Variable containing:
+        >>> m(input)
+
         (0 ,0 ,.,.) =
           1  1  2  2
           1  1  2  2
           3  3  4  4
           3  3  4  4
-        [torch.FloatTensor of size 1x1x4x4]
-
+        [torch.FloatTensor of size (1,1,4,4)]
 
     """
 
@@ -108,22 +108,23 @@ class UpsamplingNearest2d(Upsample):
 
     Examples::
 
-        >>> inp
-        Variable containing:
+        >>> input = torch.arange(1, 5).view(1, 1, 2, 2)
+        >>> input
+
         (0 ,0 ,.,.) =
           1  2
           3  4
-        [torch.FloatTensor of size 1x1x2x2]
+        [torch.FloatTensor of size (1,1,2,2)]
 
         >>> m = nn.UpsamplingNearest2d(scale_factor=2)
-        >>> m(inp)
-        Variable containing:
+        >>> m(input)
+\
         (0 ,0 ,.,.) =
           1  1  2  2
           1  1  2  2
           3  3  4  4
           3  3  4  4
-        [torch.FloatTensor of size 1x1x4x4]
+        [torch.FloatTensor of size (1,1,4,4)]
 
     """
     def __init__(self, size=None, scale_factor=None):
@@ -155,22 +156,23 @@ class UpsamplingBilinear2d(Upsample):
 
     Examples::
 
-        >>> inp
-        Variable containing:
+        >>> input = torch.arange(1, 5).view(1, 1, 2, 2)
+        >>> input
+
         (0 ,0 ,.,.) =
           1  2
           3  4
-        [torch.FloatTensor of size 1x1x2x2]
+        [torch.FloatTensor of size (1,1,2,2)]
 
         >>> m = nn.UpsamplingBilinear2d(scale_factor=2)
-        >>> m(inp)
-        Variable containing:
+        >>> m(input)
+
         (0 ,0 ,.,.) =
           1.0000  1.3333  1.6667  2.0000
           1.6667  2.0000  2.3333  2.6667
           2.3333  2.6667  3.0000  3.3333
           3.0000  3.3333  3.6667  4.0000
-        [torch.FloatTensor of size 1x1x4x4]
+        [torch.FloatTensor of size (1,1,4,4)]
 
     """
     def __init__(self, size=None, scale_factor=None):


### PR DESCRIPTION
The `nn.*` counterpart of #5443 . Mostly removed Variable wrapper. Also added doc for `nn.RReLU`.

Notice that `torch.randn(*, requires_grad=True)` isn't documented until #5462 is done.