### PR TITLE
Check that parsed_args contains enough space for all parameters

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -35,7 +35,7 @@ static PyObject * ${pycname}(PyObject* self, PyObject* args, PyObject* kwargs)
     ${signatures}
   });
   ${unpack_self}
-  PyObject* parsed_args[${max_args}];
+  ParsedArgs<${max_args}> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   ${dispatch}
   Py_RETURN_NONE;

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -59,7 +59,7 @@ static PyObject * THPVariable_clamp(PyObject* module, PyObject* args, PyObject* 
   static PythonArgParser parser({
     "clamp(Tensor input, Scalar min=None, Scalar max=None)",
   });
-  PyObject* parsed_args[4];
+  ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (!r.isNone(1) && !r.isNone(2)) {
     return THPVariable_Wrap(dispatch_clamp(r.tensor(0), r.scalar(1), r.scalar(2)));

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -68,7 +68,7 @@ static PyObject * THPVariable_clamp(PyObject* self, PyObject* args, PyObject* kw
     "clamp(Scalar min=None, Scalar max=None)",
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (!r.isNone(0) && !r.isNone(1)) {
     return THPVariable_Wrap(dispatch_clamp(self_, r.scalar(0), r.scalar(1)));
@@ -105,7 +105,7 @@ static PyObject * THPVariable_clamp_(PyObject* self, PyObject* args, PyObject* k
     "clamp_(Scalar min=None, Scalar max=None)",
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (!r.isNone(0) && !r.isNone(1)) {
     return THPVariable_Wrap(dispatch_clamp_(self_, r.scalar(0), r.scalar(1)));
@@ -127,7 +127,7 @@ static PyObject * THPVariable_size(PyObject* self, PyObject* args, PyObject* kwa
     "size()",
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[3];
+  ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     return wrap(self_.size(r.toInt64(0)));
@@ -150,7 +150,7 @@ static PyObject * THPVariable_stride(PyObject* self, PyObject* args, PyObject* k
     "stride()",
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[3];
+  ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     return wrap(self_.stride(r.toInt64(0)));
@@ -206,7 +206,7 @@ static PyObject * THPVariable_copy_(PyObject* self, PyObject* args, PyObject* kw
     "copy_(Tensor other, bool async=False)|deprecated"
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   return THPVariable_Wrap(dispatch_copy_(self_, r.tensor(0), r.toBool(1)));
   END_HANDLE_TH_ERRORS
@@ -336,7 +336,7 @@ static PyObject * THPVariable_cuda(PyObject* self, PyObject* args, PyObject* kwa
     "cuda(int64_t? device=-1, bool async=False)|deprecated"
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   auto backend = self_.is_sparse() ? at::kSparseCUDA : at::kCUDA;
   auto& type = self_.type().toBackend(backend);
@@ -441,7 +441,7 @@ static PyObject * THPVariable_map_(PyObject* self, PyObject* args, PyObject* kwa
   HANDLE_TH_ERRORS
   static PythonArgParser parser({ "map_(Tensor other, PyObject* callable)" });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   Variable other = r.tensor(0);
   if (self_.requires_grad() || other.requires_grad()) {
@@ -458,7 +458,7 @@ static PyObject * THPVariable_map2_(PyObject* self, PyObject* args, PyObject* kw
   HANDLE_TH_ERRORS
   static PythonArgParser parser({ "map2_(Tensor x, Tensor y, PyObject* callable)" });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[3];
+  ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   Variable x = r.tensor(0);
   Variable y = r.tensor(1);
@@ -524,7 +524,7 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
     "type(PyObject* new_type=None, bool async=False)|deprecated"
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.isNone(0)) {
     return THPUtils_packString(torch::utils::type_to_string(self_.type()));

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -118,7 +118,7 @@ struct TypeError : public PyTorchError {
   }
 };
 
-// Translates to Python TypeError
+// Translates to Python ValueError
 struct ValueError : public PyTorchError {
   ValueError(const char *format, ...);
   virtual PyObject* python_type() override {

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -421,7 +421,7 @@ PythonArgParser::PythonArgParser(std::vector<std::string> fmts)
   }
 }
 
-PythonArgs PythonArgParser::parse(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]) {
+PythonArgs PythonArgParser::raw_parse(PyObject* args, PyObject* kwargs, PyObject* parsed_args[]) {
   if (signatures_.size() == 1) {
     auto& signature = signatures_[0];
     signature.parse(args, kwargs, parsed_args, true);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -11,7 +11,7 @@
 //     "norm(Scalar p, int64_t dim, bool keepdim=False)",
 //     "norm(Scalar p=2)",
 //   });
-//   PyObject* parsed_args[3];
+//   ParsedArgs<3> parsed_args;
 //   auto r = parser.parse(args, kwargs, parsed_args);
 //   if (r.idx == 0) {
 //     norm(r.scalar(0), r.int64(1), r.bool(0));
@@ -47,14 +47,22 @@ struct FunctionParameter;
 struct FunctionSignature;
 struct PythonArgs;
 
+// Contains bounds Python arguments
+template<int N>
+struct ParsedArgs {
+  PyObject* args[N];
+};
+
 struct PythonArgParser {
   explicit PythonArgParser(std::vector<std::string> fmts);
 
-  PythonArgs parse(PyObject* args, PyObject* kwargs, PyObject* dst[]);
+  template<int N>
+  inline PythonArgs parse(PyObject* args, PyObject* kwargs, ParsedArgs<N>& dst);
 
 private:
   [[noreturn]]
   void print_error(PyObject* args, PyObject* kwargs, PyObject* dst[]);
+  PythonArgs raw_parse(PyObject* args, PyObject* kwargs, PyObject* dst[]);
 
   std::vector<FunctionSignature> signatures_;
   std::string function_name;
@@ -133,6 +141,15 @@ struct FunctionParameter {
     at::Type* default_type;
   };
 };
+
+template<int N>
+inline PythonArgs PythonArgParser::parse(PyObject* args, PyObject* kwargs, ParsedArgs<N>& dst) {
+  if (N < max_args) {
+    throw ValueError("dst does not have enough capacity, expected %d (got %d)",
+        (int)max_args, N);
+  }
+  return raw_parse(args, kwargs, dst.args);
+}
 
 inline at::Tensor PythonArgs::tensor(int i) {
   if (!args[i]) return at::Tensor();

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -47,7 +47,7 @@ struct FunctionParameter;
 struct FunctionSignature;
 struct PythonArgs;
 
-// Contains bounds Python arguments
+// Contains bound Python arguments in declaration order
 template<int N>
 struct ParsedArgs {
   PyObject* args[N];

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -158,13 +158,13 @@ static Tensor legacy_sparse_tensor_ctor(const Type& type, PyObject* args, PyObje
     "new(Tensor indices, Tensor values, *, int64_t? device=-1)",
     "new(Tensor indices, Tensor values, IntList size, *, int64_t? device=-1)",
   });
-  PyObject* parsed_args[4];
+  ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     AutoGPU auto_gpu(r.toInt64(0));
     return type.tensor();
   } else if (r.idx == 1) {
-    PyObject* arg = parsed_args[0];
+    PyObject* arg = r.pyobject(0);
     if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
       // new(sequence) binds to this signature but should be treated differently
       // unless the sequences is a torch.Size
@@ -198,13 +198,13 @@ Tensor legacy_tensor_ctor(const Type& type, PyObject* args, PyObject* kwargs) {
     return legacy_sparse_tensor_ctor(type, args, kwargs);
   }
 
-  PyObject* parsed_args[2];
+  ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     AutoGPU auto_gpu(r.toInt64(0));
     return type.tensor();
   } else if (r.idx == 1) {
-    PyObject* arg = parsed_args[0];
+    PyObject* arg = r.pyobject(0);
     if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
       // new(sequence) binds to this signature but should be treated differently
       // unless the sequences is a torch.Size
@@ -232,7 +232,7 @@ static Tensor legacy_sparse_tensor_new(const Type& type, PyObject* args, PyObjec
     "new(Tensor indices, Tensor values, *, int64_t? device=-1)",
     "new(Tensor indices, Tensor values, IntList size, *, int64_t? device=-1)",
   });
-  PyObject* parsed_args[5];
+  ParsedArgs<5> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     const auto& actual_type = r.typeWithDefault(0, type);
@@ -241,7 +241,7 @@ static Tensor legacy_sparse_tensor_new(const Type& type, PyObject* args, PyObjec
     AutoGPU auto_gpu(r.toInt64(1));
     return actual_type.tensor();
   } else if (r.idx == 1) {
-    PyObject* arg = parsed_args[0];
+    PyObject* arg = r.pyobject(0);
     const auto& actual_type = r.typeWithDefault(1, type);
     check_is_sparse(actual_type);
     if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
@@ -281,7 +281,7 @@ Tensor legacy_tensor_new(const Type& type, PyObject* args, PyObject* kwargs) {
     return legacy_sparse_tensor_new(type, args, kwargs);
   }
 
-  PyObject* parsed_args[3];
+  ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     const auto& actual_type = r.typeWithDefault(0, type);
@@ -290,7 +290,7 @@ Tensor legacy_tensor_new(const Type& type, PyObject* args, PyObject* kwargs) {
     AutoGPU auto_gpu(r.toInt64(1));
     return actual_type.tensor();
   } else if (r.idx == 1) {
-    PyObject* arg = parsed_args[0];
+    PyObject* arg = r.pyobject(0);
     const auto& actual_type = r.typeWithDefault(1, type);
     check_is_dense(actual_type);
     if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
@@ -325,7 +325,7 @@ Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
     "new_tensor(PyObject* data, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
   });
 
-  PyObject* parsed_args[4];
+  ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
     return set_requires_grad(new_with_tensor_copy(r.typeWithDefault(1, type), r.tensor(0)), r.toBool(2));


### PR DESCRIPTION
In future PRs, I'd like to:
- Ensure that conversion functions (e.g. `r.tensor(0)`) correspond to the declared type
- Check that the size of `ParsedArgs` exactly matches `max_args` instead of `>=`