### PR TITLE
Fix test sparse

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -840,8 +840,8 @@ class TestSparse(TestCase):
             self.assertEqual(x.new(indices, values), x)
         self.assertEqual(x.new(indices, values, x.size()), x)
 
-        self.assertIs(torch.sparse.uint8, Variable(x).new(dtype=torch.sparse.uint8).dtype)
-        self.assertIs(torch.sparse.uint8, Variable(x).new(1, 2, dtype=torch.sparse.uint8).dtype)
+        self.assertIs(torch.sparse.uint8, x.new(dtype=torch.sparse.uint8).dtype)
+        self.assertIs(torch.sparse.uint8, x.new(1, 2, dtype=torch.sparse.uint8).dtype)
 
     @cpu_only  # not really, but we only really want to run this once
     def test_dtypes(self):


### PR DESCRIPTION
`python test/test_sparse.py` complains about a missing Variable import for me on master. This fixes it.