### PR TITLE
Fix warnings in jit

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -374,7 +374,7 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
   if (op->tracing_autograd_python_function) {
     func = py::function(py::handle(op->pyobj.get()).attr("apply"));
   } else {
-    func = py::function(py::handle(op->pyobj.get()), /*is_borrowed=*/true);
+    func = py::reinterpret_borrow<py::function>(py::handle(op->pyobj.get()));
   }
   bool tracing_autograd_python_function = op->tracing_autograd_python_function;
   bool has_handle = hasHandleOutput(op);

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -7,7 +7,9 @@ namespace script {
 
 using ResolutionCallback = std::function<py::function(std::string)>;
 
-struct PythonResolver : public Resolver {
+// The visibility attribute is to avoid a warning about storing a field in the
+// struct that has a different visibility (from pybind) than the struct.
+struct __attribute__((visibility("hidden"))) PythonResolver : public Resolver {
   PythonResolver(ResolutionCallback rcb) : rcb(rcb) {}
 
   Node* resolveCall(SourceRange location, Node* n) const override {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -9,7 +9,13 @@ using ResolutionCallback = std::function<py::function(std::string)>;
 
 // The visibility attribute is to avoid a warning about storing a field in the
 // struct that has a different visibility (from pybind) than the struct.
-struct __attribute__((visibility("hidden"))) PythonResolver : public Resolver {
+#ifdef _WIN32
+#define VISIBILITY_HIDDEN
+#else
+#define VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
+#endif
+
+struct VISIBILITY_HIDDEN PythonResolver : public Resolver {
   PythonResolver(ResolutionCallback rcb) : rcb(rcb) {}
 
   Node* resolveCall(SourceRange location, Node* n) const override {


### PR DESCRIPTION
Fixes these warnings:

```
[80/101] gcc -Wsign-compare -DN.../usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -MMD -MF build/temp.linux-x86_64-3.6/torch/csrc/jit/script/init.d
torch/csrc/jit/script/init.cpp:10:8: warning: ‘torch::jit::script::PythonResolver’ declared with greater visibility than the type of its field ‘torch::jit::script::PythonResolver::rcb’ [-Wattributes]
 struct PythonResolver : public Resolver {
        ^
[83/101] gcc -Wsign-compare -DN.../usr/local/cuda/lib64 -DWITH_NCCL -DWITH_CUDNN -MMD -MF build/temp.linux-x86_64-3.6/torch/csrc/jit/interpreter.d
torch/csrc/jit/interpreter.cpp: In function ‘torch::jit::Operation torch::jit::createPythonOperation(torch::jit::PythonOp*, bool)’:
torch/csrc/jit/interpreter.cpp:377:74: warning: ‘pybind11::function::function(pybind11::handle, bool)’ is deprecated: Use reinterpret_borrow<function>() or reinterpret_steal<function>() [-Wdeprecated-declarations]
     func = py::function(py::handle(op->pyobj.get()), /*is_borrowed=*/true);
                                                                          ^
In file included from /home/psag/pytorch/torch/lib/pybind11/include/pybind11/cast.h:13:0,
                 from /home/psag/pytorch/torch/lib/pybind11/include/pybind11/attr.h:13,
                 from /home/psag/pytorch/torch/lib/pybind11/include/pybind11/pybind11.h:43,
                 from /home/psag/pytorch/torch/lib/pybind11/include/pybind11/functional.h:12,
                 from /home/psag/pytorch/torch/csrc/jit/pybind.h:11,
                 from torch/csrc/jit/interpreter.cpp:15:
/home/psag/pytorch/torch/lib/pybind11/include/pybind11/pytypes.h:1217:29: note: declared here
     PYBIND11_OBJECT_DEFAULT(function, object, PyCallable_Check)
                             ^
/home/psag/pytorch/torch/lib/pybind11/include/pybind11/pytypes.h:734:9: note: in definition of macro ‘PYBIND11_OBJECT_COMMON’
         Name(handle h, bool is_borrowed) : Parent(is_borrowed ? Parent(h, borrowed_t{}) : Parent(h, stolen_t{})) { } \
         ^
/home/psag/pytorch/torch/lib/pybind11/include/pybind11/pytypes.h:760:5: note: in expansion of macro ‘PYBIND11_OBJECT’
     PYBIND11_OBJECT(Name, Parent, CheckFun) \
     ^
/home/psag/pytorch/torch/lib/pybind11/include/pybind11/pytypes.h:1217:5: note: in expansion of macro ‘PYBIND11_OBJECT_DEFAULT’
     PYBIND11_OBJECT_DEFAULT(function, object, PyCallable_Check)
```

@zdevito 