### PR TITLE
Bilinear upsampling fix

### DIFF
--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -37,13 +37,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = rheight * h2;
+    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -89,13 +89,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = rheight * h2;
+    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -52,8 +52,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   THCDeviceTensor<real, 4> idata = toDeviceTensor<real, 4>(state, input);
   THCDeviceTensor<real, 4> odata = toDeviceTensor<real, 4>(state, output);
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rheight= (outputHeight > 1) ? (accreal)(inputHeight - 1)/(outputHeight - 1) : accreal(0);
-  const accreal rwidth = (outputWidth > 1) ? (accreal)(inputWidth - 1)/(outputWidth - 1) : accreal(0);
+  const accreal rheight= (outputHeight > 1) ? (accreal)inputHeight / outputHeight : accreal(0);
+  const accreal rwidth = (outputWidth > 1) ? (accreal)inputWidth / outputWidth : accreal(0);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
@@ -93,8 +93,8 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   int height2 = data2.getSize(2);
   int width2 = data2.getSize(3);
   assert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
-  const accreal rheight= (height2 > 1) ? (accreal)(height1 - 1)/(height2 - 1) : accreal(0);
-  const accreal rwidth = (width2 > 1) ? (accreal)(width1 - 1) / (width2 - 1) : accreal(0);
+  const accreal rheight= (height2 > 1) ? (accreal)height1 / height2 : accreal(0);
+  const accreal rwidth = (width2 > 1) ? (accreal)width1 / width2 : accreal(0);
   const int num_kernels = height2 * width2;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;

--- a/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
@@ -73,16 +73,16 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
     }
     return;
   }
-  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
-  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1) / (outputWidth - 1) : 0.f;
+  const float rheight =(outputHeight > 1) ? (float)inputHeight / outputHeight : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)inputWidth / outputWidth : 0.f;
   for (int h2 = 0; h2 < outputHeight; ++h2) {
-    const float h1r = rheight * h2;
+    const float h1r = (h2 > 0) ? rheight * (h2 - 0.5f) : 0.f;
     const int h1 = h1r;
     const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
     for (int w2 = 0; w2 < outputWidth; ++w2) {
-      const float w1r = rwidth * w2;
+      const float w1r = (w2 > 0) ? rwidth * (w2 - 0.5f) : 0.f;
       const int w1 = w1r;
       const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;
@@ -142,16 +142,16 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
     }
     return;
   }
-  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
-  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1)/(outputWidth - 1) : 0.f;
+  const float rheight =(outputHeight > 1) ? (float)inputHeight / outputHeight : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)inputWidth / outputWidth : 0.f;
   for (int h2 = 0; h2 < outputHeight; ++h2) {
-    const float h1r = rheight * h2;
+    const float h1r = (h2 > 0) ? rheight * (h2 - 0.5f) : 0.f;
     const int h1 = h1r;
     const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
     for (int w2 = 0; w2 < outputWidth; ++w2) {
-      const float w1r = rwidth * w2;
+      const float w1r = (w2 > 0) ? rwidth * (w2 - 0.5f) : 0.f;
       const int w1 = w1r;
       const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;


### PR DESCRIPTION
Hello,
While working on transferring neural network architecture from PyTorch to Caffe I noticed a serious difference between PyTorch bilinear upsampling layer and a Caffe's deconvolution with bilinear kernel.
After some research, it turned out that PyTorch bilinear upsampling code clearly has one problem: **Result depends on spatial size,** which means that, for example, two similar parts of two images won't be the same after upsampling if these images have different sizes.
This bug is caused by pixel coordinate computation trick, which is pretty, but inaccurate.
Visual example of the bug and the fix can be viewed here: [https://gist.github.com/Dorimer/e2389bfc4dd86c7ebbea3a1f45fc4327](https://gist.github.com/Dorimer/e2389bfc4dd86c7ebbea3a1f45fc4327)
