### PR TITLE
Fix a bug gen_jit_dispatch.py

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -34,7 +34,7 @@ auto ${name} = ${type_cast}(node->${method}(Symbol("${name}")));\
 """)
 
 POS_ASSIGNMENT = CodeTemplate("""\
-auto ${name} = tensor_as<${type}>(std::move(fromLast(stack, ${arg_idx})));\
+auto ${name} = tensor_as<${type}>(std::move(peek(stack, ${i}, ${N})));\
 """)
 
 CALL_NAMESPACE = CodeTemplate("at::${name}(${args})")
@@ -45,14 +45,13 @@ CONSTRUCTOR = CodeTemplate("""\
   ${kw_assignments}
   return TensorOp([=](Stack & stack) {
     autograd::profiler::RecordFunction record("${name}");
-    AutoGPU device_guard(deviceForInputs(stack, ${num_inputs} + ${num_dropped_args}));
+    AutoGPU device_guard(deviceForInputs(stack, ${num_dynamic_inputs}));
     ${pos_assignments}
-    ${pos_arg_drop}
     auto result = ${call};
-    drop(stack, ${num_inputs});
+    drop(stack, ${num_dynamic_inputs});
     pack(stack, std::move(result));
     return 0;
-  }, "${name}", ${num_inputs});
+  }, "${name}", ${num_dynamic_inputs});
 }},
 """)
 
@@ -85,6 +84,104 @@ skip_scalar_overload = {
 
 
 def gen_jit_dispatch(declarations, out):
+    ops = {}
+
+    def is_tensor_arg(arg):
+        return arg['simple_type'] in {'Tensor', 'TensorList'}
+
+    def get_invocation(decl, args):
+        if 'namespace' in decl['method_of']:
+            return CALL_NAMESPACE.substitute(name=decl['name'], args=args)
+        else:
+            return CALL_METHOD.substitute(name=decl['name'], first=args[0], args=args[1:])
+
+    def emit_decl_variant(decl, is_real_input, has_tensorlist):
+        kw_assignments = []
+        attr_names = []
+        pos_assignments = []
+        arguments = []
+
+        if has_tensorlist:
+            kw_assignments.append('size_t varargs_length = node->inputs().size();')
+            # arguments look like: [tensor list], other, static, inputs
+            # we use peek(<i>, static_inputs) to read the non-vararg inputs
+            # from the end of the stack
+            static_inputs = sum(is_real_input) - 1
+            num_dynamic_inputs = 'varargs_length'
+        else:
+            static_inputs = sum(is_real_input)
+            num_dynamic_inputs = static_inputs
+
+        real_inputs = count()
+        for i, arg in enumerate(decl['arguments']):
+            # XXX: we currently support only TensorList ops that have a TensorList as
+            # the first argument, that is then followed by a number of positional args.
+            if arg['simple_type'] == 'TensorList':
+                arguments.append('peekSlice(stack, 0, varargs_length - {}, varargs_length)'.format(static_inputs))
+            elif is_tensor_arg(arg):
+                arguments.append('std::move(peek(stack, {}, {}))'.format(next(real_inputs), static_inputs))
+            elif is_real_input[i]:
+                assign = POS_ASSIGNMENT.substitute(type=arg['simple_type'],
+                                                   name=arg['name'],
+                                                   i=next(real_inputs),
+                                                   N=static_inputs)
+                pos_assignments.append(assign)
+                arguments.append(arg['name'])
+            else:
+                assign = KW_ASSIGNMENT.substitute(type_cast=TYPE_CASTS.get(arg['simple_type'], arg['simple_type']),
+                                                  name=arg['name'],
+                                                  method=ATTR_METHOD_MAP[arg['simple_type']])
+                kw_assignments.append(assign)
+                attr_names.append(arg['name'])
+                arguments.append(arg['name'])
+        call = get_invocation(decl, arguments)
+
+        # Descriptor is a unique identifier for a particular overload of an op.
+        attr_names = sorted(attr_names)
+        num_inputs = '*' if has_tensorlist else static_inputs
+        descriptor = '-'.join([decl['name'], str(num_inputs)] + attr_names)
+
+        # If there are two overloads with the same descriptor, that differ only by a type of a
+        # single argument, where one of them takes a tensor, while another one takes an
+        # at::Scalar as a positional scalar arg, then prefer the tensor overload.
+        # It should get broadcasted correctly.
+        if descriptor in skip_scalar_overload:
+            if any(decl['arguments'][idx]['simple_type'] == 'Scalar'
+                   for idx in skip_scalar_overload[descriptor]):
+                return
+
+        constructor = CONSTRUCTOR.substitute(descriptor=descriptor, name=decl['name'],
+                                             call=call,
+                                             kw_assignments=kw_assignments,
+                                             pos_assignments=pos_assignments,
+                                             num_dynamic_inputs=num_dynamic_inputs)
+
+        assert descriptor not in ops, descriptor
+        ops[descriptor] = constructor
+
+    def emit_decl(decl):
+        arguments = decl['arguments']
+        has_tensorlist = any(arg['simple_type'] == 'TensorList' for arg in arguments)
+        num_tensor_args = sum(map(is_tensor_arg, arguments))
+
+        # we currently only support vararg tensor lists when they are the _first_ argument
+        # and the only tensor argument
+        if has_tensorlist and (num_tensor_args != 1 or arguments[0]['simple_type'] != 'TensorList'):
+            return
+
+        # Right now, we generate dispatch methods that either take all non-tensor arguments
+        # as attributes, or don't use any attributes at all. In the future we might want to
+        # have something in the middle too (might be useful for e.g. constant propagation
+        # into attributes, as that would allow us to avoid reparsing tensors into scalar
+        # args at every invocation).
+
+        all_arguments_are_inputs = tuple(True for _ in arguments)
+        only_tensors_are_inputs = tuple(is_tensor_arg(arg) for arg in arguments)
+
+        # NB: if there are no scalar args then both options on LHS are equivalent, so deduplicate them.
+        for variant in set([all_arguments_are_inputs, only_tensors_are_inputs]):
+            emit_decl_variant(decl, variant, has_tensorlist)
+
     # We need to add methods implemented manually in TensorImpl
     tensor_impl_methods = [{
         'name': name,
@@ -95,117 +192,15 @@ def gen_jit_dispatch(declarations, out):
     aten_decls = load_aten_declarations(declarations) + tensor_impl_methods
     jit_decls = [d for d in aten_decls if is_jit_op(d)]
 
-    def is_tensor_arg(arg):
-        return arg['simple_type'] in {'Tensor', 'TensorList'}
-
-    ops = {}
-    names = set()
     for decl in jit_decls:
-        arguments = decl['arguments']
-        name = decl['name']
-        names.add(name)
-        has_tensorlist = any(arg['simple_type'] == 'TensorList' for arg in arguments)
-        scalar_arg_idx = [i for i, arg in enumerate(arguments) if not is_tensor_arg(arg)]
-        num_tensor_args = sum(map(is_tensor_arg, arguments))
-        # TODO: support this
-        if has_tensorlist and (num_tensor_args != 1 or not is_tensor_arg(arguments[0])):
-            continue
-
-        # Right now, we generate dispatch methods that either take all non-tensor arguments
-        # as attributes, or don't use any attributes at all. In the future we might want to
-        # have something in the middle too (might be useful for e.g. constant propagation
-        # into attributes, as that would allow us to avoid reparsing tensors into scalar
-        # args at every invocation).
-        # NB: if there are no scalar args then both options on LHS are equivalent, so deduplicate them.
-        scalar_arg_idx_iter = ([], scalar_arg_idx) if scalar_arg_idx else ([],)
-        for pos_scalar_arg_idx in scalar_arg_idx_iter:
-            num_args = len(arguments)
-            num_inputs = num_tensor_args + len(pos_scalar_arg_idx) if not has_tensorlist else '*'
-
-            # Scatter arguments into positional and keyword, and compute stack offsets
-            # of posiitional args.
-            pos_scalar_args, kw_scalar_args = [], []
-            scalar_stack_off, tensor_stack_off = [], []
-            for i, arg in enumerate(arguments):
-                # XXX: we currently support only TensorList ops that have a TensorList as
-                # the first argument, that is then followed by a number of positional args.
-                stack_off = (num_args if num_inputs == '*' else num_inputs) - i - 1
-                if is_tensor_arg(arg):
-                    tensor_stack_off.append(stack_off)
-                else:
-                    if i in pos_scalar_arg_idx:
-                        pos_scalar_args.append(arg)
-                        scalar_stack_off.append(stack_off)
-                    else:
-                        kw_scalar_args.append(arg)
-
-            # Descriptor is a unique identifier for a particular overload of an op.
-            attr_names = sorted([arg['name'] for arg in kw_scalar_args])
-            descriptor = '-'.join([decl['name'], str(num_inputs)] + attr_names)
-
-            # If there are two overloads with the same descriptor, that differ only by a type of a
-            # single argument, where one of them takes a tensor, while another one takes an
-            # at::Scalar as a positional scalar arg, then prefer the tensor overload.
-            # It should get broadcasted correctly.
-            if descriptor in skip_scalar_overload:
-                if any(arguments[idx]['simple_type'] == 'Scalar'
-                       for idx in skip_scalar_overload[descriptor]):
-                    continue
-
-            kw_assignments = [KW_ASSIGNMENT.substitute(type_cast=TYPE_CASTS.get(arg['simple_type'], arg['simple_type']),
-                                                       name=arg['name'],
-                                                       method=ATTR_METHOD_MAP[arg['simple_type']])
-                              for arg in kw_scalar_args]
-            if num_inputs == "*":
-                kw_assignments.append('size_t varargs_length = node->inputs().size();')
-                num_inputs = 'varargs_length'
-            pos_assignments = [POS_ASSIGNMENT.substitute(type=arg['simple_type'],
-                                                         name=arg['name'],
-                                                         arg_idx=arg_idx)
-                               for arg_idx, arg in zip(scalar_stack_off, pos_scalar_args)]
-
-            # Generate the actuall ATen call. This gets a bit tricky because of
-            # TensorList arguments, and functions that are only available as methods.
-            pos_arg_drop = ''
-            num_dropped_args = 0
-            if 'namespace' in decl['method_of']:
-                if has_tensorlist:
-                    # We need to drop the scalar args following varargs before we use last
-                    if pos_scalar_args:
-                        num_dropped_args = len(pos_scalar_args)
-                        pos_arg_drop = 'drop(stack, {});'.format(num_dropped_args)
-                    args = ['last(stack, varargs_length)' if is_tensor_arg(arg) else arg['name']
-                            for arg in arguments]
-                else:
-                    tensor_id = iter(tensor_stack_off)
-                    args = ['std::move(fromLast(stack, {}))'.format(1 + next(tensor_id))
-                            if is_tensor_arg(arg) else arg['name']
-                            for arg in arguments]
-                call = CALL_NAMESPACE.substitute(name=name, args=args)
-            else:
-                tensor_id = iter(tensor_stack_off)
-                args = ['std::move(fromLast(stack, {}))'.format(1 + next(tensor_id))
-                        if is_tensor_arg(arg) else arg['name']
-                        for arg in arguments]
-                call = CALL_METHOD.substitute(name=name, first=args[0], args=args[1:])
-
-            constructor = CONSTRUCTOR.substitute(descriptor=descriptor, name=name,
-                                                 num_dropped_args=num_dropped_args,
-                                                 pos_arg_drop=pos_arg_drop,
-                                                 call=call,
-                                                 kw_assignments=kw_assignments,
-                                                 pos_assignments=pos_assignments,
-                                                 num_inputs=num_inputs)
-
-            # If this assert fails, you might need to update skip_scalar_overload
-            assert descriptor not in ops, descriptor
-            ops[descriptor] = constructor
+        emit_decl(decl)
 
     # Sort the generated snippets to ensure that the generation is deterministic
     env = {'constructors': sorted(ops.values())}
     write(out, 'aten_dispatch.h', ATEN_DISPATCH_H, env)
     write(out, 'aten_dispatch.cpp', ATEN_DISPATCH_CPP, env)
 
+    names = set(decl['name'] for decl in jit_decls)
     strings_env = {'aten_symbols': ["_({}) \\".format(n) for n in sorted(names)]}
 
     write(out, 'aten_interned_strings.h', ATEN_INTERNED_STRINGS_H, strings_env)

--- a/tools/jit/templates/aten_dispatch.h
+++ b/tools/jit/templates/aten_dispatch.h
@@ -25,14 +25,21 @@ using Operation = std::function<int(Stack&)>;
 // pc += 1 + offset
 // so a return value of 0 goes to the next instruction
 
-static inline at::Tensor & fromLast(Stack & stack, size_t n) {
-  return *(stack.end() - n);
+// treat the last N elements of the stack as a list, looking up
+// element i
+static inline at::Tensor & peek(Stack & stack, size_t i, size_t N) {
+  return *(stack.end() - N + i);
+}
+// treat the last N elements of the stack as a list, looking up the
+// slice starting at index i and having length len
+static inline ArrayRef<at::Tensor> peekSlice(Stack & stack, size_t i, size_t len, size_t N) {
+  return ArrayRef<at::Tensor>(stack).slice(stack.size() - N + i, len);
+}
+static inline ArrayRef<at::Tensor> last(Stack & stack, size_t N) {
+  return peekSlice(stack, 0, N, N);
 }
 static inline void drop(Stack & stack, size_t n) {
   stack.erase(stack.end() - n, stack.end());
-}
-static inline ArrayRef<at::Tensor> last(Stack & stack, size_t N) {
-  return ArrayRef<at::Tensor>(stack).slice(stack.size() - N, N);
 }
 static inline at::Tensor pop(Stack & stack) {
   auto r = std::move(stack.back());

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -403,7 +403,7 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
         } else if (arg_type == 't') {
           py_inputs[i] = py::reinterpret_steal<py::object>(
               THPVariable_Wrap(builder.addInput(
-                  std::move(fromLast(stack, num_inputs - next_tensor)),
+                  std::move(peek(stack, next_tensor, num_inputs)),
                   op->var_flags.at(next_tensor))));
           next_tensor++;
         }
@@ -450,7 +450,7 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
           py_inputs[i] = py::reinterpret_borrow<py::object>(
               op->scalar_args[next_scalar++].get());
         } else if (arg_type == 't') {
-          auto var = fromLast(stack, num_inputs - next_tensor);
+          auto var = peek(stack, next_tensor, num_inputs);
           if (!values_are_variables) {
             var = autograd::make_variable(var);
           }
@@ -503,7 +503,7 @@ Operation createCppOperation(CppOp* op) {
     HandleBuilder builder(has_handle);
     autograd::variable_list v_inputs;
     for(size_t i = 0; i < num_inputs; i++) {
-      v_inputs.push_back(builder.addInput(std::move(fromLast(stack, num_inputs - i)), op->var_flags[i]));
+      v_inputs.push_back(builder.addInput(std::move(peek(stack, i, num_inputs)), op->var_flags[i]));
     }
     drop(stack, num_inputs);
     autograd::variable_list v_outputs = (*func)(v_inputs);
@@ -526,7 +526,7 @@ Operation createEvalOperation(CppOp * op) {
     auto& engine = autograd::python::PythonEngine::getDefaultEngine();
     autograd::variable_list v_inputs;
     for(size_t i = 0; i < num_inputs - 1; i++) {
-      v_inputs.push_back(builder.addInput(std::move(fromLast(stack, num_inputs - i)), op->var_flags[i]));
+      v_inputs.push_back(builder.addInput(std::move(peek(stack, i, num_inputs)), op->var_flags[i]));
     }
     drop(stack, num_inputs);
     // TODO: handle create_graph appropriately


### PR DESCRIPTION
The `fromLast` function is confusing to understand since `fromLast(stack, 0)`
was actually invalid whereas `fromLast(stack, 1)` was the last element.
This created off-by-one bugs in gen_jit_dispatch for some operators.

This changes it to `peek(stack, i, N)` which treats the last `N`
elements of the stack as a list, and extracts element `i` of that list.
This usage reflects how `fromLast` was actually being used in the code.

`peekSlice(stack, i, len, N)` similarly treats the last N elements
as a list but extracts a slice. This enables us to get rid of
drop calls and simplify the dispatch logic.

@jamesr66a @apaszke 