### PR TITLE
Avoid OOM when running ASAN by splitting nn tests.

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -33,7 +33,11 @@ echo "Running sparse tests"
 $PYCMD test_sparse.py $@
 
 echo "Running nn tests"
-$PYCMD test_nn.py $@
+# These tests are split up in order to avoid OOMing when
+# we have ASAN, see https://github.com/pytorch/pytorch/issues/5522
+$PYCMD test_nn.py $@ TestNN
+$PYCMD test_nn.py $@ TestNNInit
+$PYCMD test_nn.py $@ PackedSequenceTest
 
 echo "Running legacy nn tests"
 $PYCMD test_legacy_nn.py $@

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -37,6 +37,11 @@ if TEST_SCIPY:
     from scipy import stats
 
 
+# WARNING: If you add a new top-level test case to this file, you MUST
+# update test/run_test.sh to list it, otherwise it will NOT be run in
+# CI.
+
+
 class PackedSequenceTest(TestCase):
 
     _type_by_name = {


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@fb.com>