### PR TITLE
Fix links in distribution docs (no code changes)

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -10,142 +10,236 @@ Probability distributions - torch.distributions
 :hidden:`Distribution`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.distribution
 .. autoclass:: Distribution
     :members:
+    :show-inheritance:
 
 :hidden:`ExponentialFamily`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.exp_family
 .. autoclass:: ExponentialFamily
     :members:
+    :show-inheritance:
 
 :hidden:`Bernoulli`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.bernoulli
 .. autoclass:: Bernoulli
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Beta`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.beta
 .. autoclass:: Beta
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Binomial`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.binomial
 .. autoclass:: Binomial
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Categorical`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.categorical
 .. autoclass:: Categorical
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Cauchy`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.cauchy
 .. autoclass:: Cauchy
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Chi2`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.chi2
 .. autoclass:: Chi2
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Dirichlet`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.dirichlet
 .. autoclass:: Dirichlet
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Exponential`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.exponential
 .. autoclass:: Exponential
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`FisherSnedecor`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.fishersnedecor
 .. autoclass:: FisherSnedecor
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Gamma`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.gamma
 .. autoclass:: Gamma
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Geometric`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.geometric
 .. autoclass:: Geometric
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Gumbel`
 ~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.gumbel
 .. autoclass:: Gumbel
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Laplace`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.laplace
 .. autoclass:: Laplace
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`LogNormal`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.log_normal
 .. autoclass:: LogNormal
     :members:
+    :undoc-members:
+    :show-inheritance:
+
+:hidden:`Multinomial`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.multinomial
+.. autoclass:: Multinomial
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Normal`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.normal
 .. autoclass:: Normal
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`OneHotCategorical`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.one_hot_categorical
 .. autoclass:: OneHotCategorical
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Pareto`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.pareto
 .. autoclass:: Pareto
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Poisson`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.poisson
 .. autoclass:: Poisson
     :members:
+    :undoc-members:
+    :show-inheritance:
+
+:hidden:`RelaxedBernoulli`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.relaxed_bernoulli
+.. autoclass:: RelaxedBernoulli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:hidden:`RelaxedOneHotCategorical`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.relaxed_categorical
+.. autoclass:: RelaxedOneHotCategorical
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`StudentT`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.studentT
 .. autoclass:: StudentT
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`TransformedDistribution`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.transformed_distribution
 .. autoclass:: TransformedDistribution
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Uniform`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.uniform
 .. autoclass:: Uniform
     :members:
+    :undoc-members:
+    :show-inheritance:
 
-`KL Divergence`
+KL Divergence
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.kl
@@ -154,21 +248,21 @@ Probability distributions - torch.distributions
 .. autofunction:: kl_divergence
 .. autofunction:: register_kl
 
-`Transforms`
+Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.transforms
     :members:
     :member-order: bysource
 
-`Constraints`
+Constraints
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.constraints
     :members:
     :member-order: bysource
 
-`Constraint Registry`
+Constraint Registry
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: torch.distributions.constraint_registry


### PR DESCRIPTION
This registers more things in the sphinx docs for torch.distributions:
- adds `:undoc-members:` to indicate which methods each distribution implements
- adds `:show-inheritance:` to link to base classes
- sets `currentmodule` so that base class links work
- adds missing `RelaxedBernoulli` and `RelaxedOneHotCategorical`

## Tested

I generated docs locally and tested that links work.