### PR TITLE
[fft] [3 of 3] Implements backward of fft ifft rfft irfft

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -140,14 +140,14 @@ Tensor ifft(const Tensor& self, const int64_t signal_ndim, const bool normalized
 }
 
 Tensor rfft(const Tensor& self, const int64_t signal_ndim, const bool normalized,
-           const bool onesided) {
+            const bool onesided) {
   return _fft(self, signal_ndim, /* complex_input */ false,
               /* complex_output */ true, /* inverse */ false, {}, normalized,
               onesided);
 }
 
-Tensor irfft(const Tensor& self, const int64_t signal_ndim,  IntList signal_sizes,
-            const bool normalized, const bool onesided) {
+Tensor irfft(const Tensor& self, const int64_t signal_ndim, const bool normalized,
+             const bool onesided,  IntList signal_sizes) {
   return _fft(self, signal_ndim, /* complex_input */ true,
               /* complex_output */ false, /* inverse */ true, signal_sizes,
               normalized, onesided);

--- a/aten/src/ATen/native/SpectralOpsUtils.h
+++ b/aten/src/ATen/native/SpectralOpsUtils.h
@@ -6,7 +6,7 @@
 
 namespace at { namespace native {
 
-// [ NOTE ] Fourier Transform Congjugate Symmetry
+// NOTE [ Fourier Transform Conjugate Symmetry ]
 //
 // Real-to-complex Fourier transform satisfies the conjugate symmetry. That is,
 // assuming X is the transformed K-dimensionsal signal, we have

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -35,7 +35,7 @@ static bool is_pow_of_two(long long int  x) {
 // conjugate symmetry. See native/SpectralUtils.h for more details.
 // The following structs are used to fill in the other half with symmetry in
 // case of real-to-complex transform with onesided=False flag.
-// See [ NOTE ] Fourier Transform Congjugate Symmetry in native/SpectralOpsUtils.h.
+// See NOTE [ Fourier Transform Conjugate Symmetry ] in native/SpectralOpsUtils.h.
 
 // counting_iterator => index to fill
 struct cnt_to_dst_idx_functor : public thrust::unary_function<int64_t, int64_t>
@@ -136,7 +136,7 @@ static void _fft_fill_with_conjugate_symmetry_(Tensor& input,
   });
 }
 
-// [ NOTE ] cuFFT Embedded Strides
+// NOTE [ cuFFT Embedded Strides ]
 //
 // cuFFT supports a subset of arbitrary strides via their "advanced data layout"
 // option (http://docs.nvidia.com/cuda/cufft/index.html#advanced-data-layout).
@@ -146,10 +146,10 @@ static void _fft_fill_with_conjugate_symmetry_(Tensor& input,
 //
 //     input[x, y, z] = input[((x * inembed[1] + y) * inembed[2] + z)]
 //
-// Above is the simplified the formulate ignoring the batch dimension. In fact,
-// the last dimension of the enclosing tensor doesn't have to be contiguous,
-// i.e., it can be greater than 1. Then one can set the base stride for the
-// enclosing tensor with `istride`. Then we have
+// Above is the simplified formula ignoring the batch dimension. In fact, the
+// last dimension of the enclosing tensor doesn't have to be contiguous, i.e.,
+// it can be greater than 1. Then one can set the base stride for the enclosing
+// tensor with `istride`. Then we have
 //
 //     input[x, y, z] = input[((x * inembed[1] + y) * inembed[2] + z) * istride]
 //
@@ -189,8 +189,8 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
   // we calculate the inembed. But it will benefit us in certain cases where we
   // clone the input tensor.
   //
-  // See [ NOTE ] cuFFT Embedded Strides.
-  // See [ NOTE ] Fourier Transform Congjugate Symmetry in native/SpectralOpsUtils.h.
+  // See NOTE [ cuFFT Embedded Strides ].
+  // See NOTE [ Fourier Transform Conjugate Symmetry ] in native/SpectralOpsUtils.h.
   if (complex_input && !complex_output && !onesided) {
     auto onesided_size = infer_ft_real_to_complex_onesided_size(checked_signal_sizes[signal_ndim - 1]);
     input = input.narrow(signal_ndim, 0, onesided_size);
@@ -252,13 +252,13 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
     // type, i.e., multiples of 2. We check the batch dim and last signal dim
     // here. If the input can be viewed as having embedded strides, the other
     // signal dims will also satisfy this.
-    // See [ NOTE ] cuFFT Embedded Strides.
+    // See NOTE [ cuFFT Embedded Strides ].
     clone_input |= (batch > 0 && input.stride(0) % 2 != 0) ||
                     input.stride(signal_ndim) % 2 != 0;
   }
 
   // Checks if input strides can be viewed as embedded.
-  // See [ NOTE ] cuFFT Embedded Strides.
+  // See NOTE [ cuFFT Embedded Strides ].
   //
   // TODO: Figure out why windows fails to compile
   //         at::optional<std::vector<long long int>> inembed_opt = at::nullopt;
@@ -289,7 +289,7 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
   // This just needs contiguity in cases except for twosided real-to-complex
   // transform where we won't have simple data layout as output is two sided.
   //
-  // See [ NOTE ] cuFFT Embedded Strides.
+  // See NOTE [ cuFFT Embedded Strides ].
 
   bool simple_layout = !(!complex_input && complex_output && !onesided) &&  // not twosided R2C
                        (clone_input || input.is_contiguous());              // contiguous
@@ -341,7 +341,7 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
     // In such case, cuFFT ignores base_istride, base_ostride, idist, and odist
     // by assuming base_istride = base_ostride = 1.
     //
-    // See [ NOTE ] cuFFT Embedded Strides.
+    // See NOTE [ cuFFT Embedded Strides ].
     CUFFT_CHECK(cufftXtMakePlanMany(plan.get(), signal_ndim, signal_sizes.data(),
       /* inembed */ nullptr, /* base_istride */ 1, /* idist */ 1, itype,
       /* onembed */ nullptr, /* base_ostride */ 1, /* odist */ 1, otype,

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -45,7 +45,7 @@ namespace at { namespace native {
 // conjugate symmetry. See native/SpectralUtils.h for more details.
 // The following structs are used to fill in the other half with symmetry in
 // case of real-to-complex transform with onesided=False flag.
-// See [ NOTE ] Fourier Transform Congjugate Symmetry in native/SpectralOpsUtils.h.
+// See NOTE [ Fourier Transform Conjugate Symmetry ] in native/SpectralOpsUtils.h.
 
 template <typename scalar_t>
 static inline void _fft_fill_with_conjugate_symmetry_slice(Tensor& output,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -377,7 +377,7 @@
 
 - func: rfft(Tensor self, int64_t signal_ndim, bool normalized=false, bool onesided=true) -> Tensor
 
-- func: irfft(Tensor self, int64_t signal_ndim, IntList signal_sizes={}, bool normalized=false, bool onesided=true) -> Tensor
+- func: irfft(Tensor self, int64_t signal_ndim, bool normalized=false, bool onesided=true, IntList signal_sizes={}) -> Tensor
 
 - func: _fft_with_size(Tensor self, int64_t signal_ndim, bool complex_input, bool complex_output, bool inverse, IntList checked_signal_sizes, bool normalized, bool onesided, IntList output_sizes) -> Tensor
   dispatch:

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -172,6 +172,10 @@ Comparison Ops
 
 Spectral Ops
 ~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: fft
+.. autofunction:: ifft
+.. autofunction:: rfft
+.. autofunction:: irfft
 .. autofunction:: stft
 .. autofunction:: hann_window
 .. autofunction:: hamming_window

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1860,6 +1860,7 @@ class TestAutograd(TestCase):
                 def ifft(fx):
                     return fx.ifft(signal_ndim, normalized=normalized)
 
+                # Use output of fft(x) for inverse fft, due to symmetry requirements
                 fx = fft(x).detach()
                 fx.requires_grad = True
                 gradcheck(ifft, [fx])
@@ -1903,6 +1904,7 @@ class TestAutograd(TestCase):
                         return fx.irfft(signal_ndim, normalized=normalized,
                                         onesided=onesided, signal_sizes=signal_sizes)
 
+                    # Use output of rfft(x) for inverse rfft, due to symmetry requirements
                     fx = rfft(x).detach()
                     fx.requires_grad = True
                     gradcheck(irfft, [fx])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3513,8 +3513,8 @@ class TestTorch(TestCase):
                     xc_res = xc.fft(signal_ndim, normalized=normalized)
                     self.assertEqual(res, xc_res)
                 test_input_signal_sizes = [signal_sizes]
-                rec = res.irfft(signal_ndim, signal_sizes=signal_sizes,
-                                normalized=normalized, onesided=onesided)
+                rec = res.irfft(signal_ndim, normalized=normalized,
+                                onesided=onesided, signal_sizes=signal_sizes)
                 self.assertEqual(x, rec, 1e-8, 'rfft and irfft')
                 if not onesided:  # check that we can use C2C ifft
                     rec = res.ifft(signal_ndim, normalized=normalized)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -594,6 +594,9 @@
 - name: std(Tensor self, int64_t dim, bool unbiased, bool keepdim)
   self: var_backward(grad / (result * 2), self, dim, unbiased, keepdim)
 
+- name: stft(Tensor self, int64_t frame_length, int64_t hop, int64_t fft_size, bool normalized, bool onesided, Tensor window, int64_t pad_end)
+  self: not_implemented("stft")
+
 - name: sub(Tensor self, Scalar other, *, Scalar alpha)
   self: grad
 
@@ -1129,3 +1132,7 @@
 # mkldnn
 - name: mkldnn_convolution(Tensor self, Tensor weight, Tensor bias, IntList padding, IntList stride, IntList dilation)
   self, weight, bias: mkldnn_convolution_backward(self, grad, weight, padding, stride, dilation, grad_input_mask)
+
+# fft
+- name: _fft_with_size(Tensor self, int64_t signal_ndim, bool complex_input, bool complex_output, bool inverse, IntList checked_signal_sizes, bool normalized, bool onesided, IntList output_sizes)
+  self: fft_backward(self, grad, signal_ndim, complex_input, complex_output, inverse, checked_signal_sizes, normalized, onesided, output_sizes)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1,6 +1,5 @@
 #include "Functions.h"
 #include <ATen/WrapDimUtils.h>
-#include <iostream>
 
 // define constants like M_PI and C keywords for MSVC
 #ifdef _MSC_VER
@@ -9,6 +8,7 @@
 #endif
 #include <math.h>
 #include <algorithm>
+#include <numeric>
 
 // ${generated_comment}
 
@@ -1003,6 +1003,101 @@ std::tuple<Tensor, Tensor> trtrs_backward(
   return std::tuple<Tensor, Tensor>{grad_b, grad_a};
 }
 
+// Generally speaking, fft's backward is ifft.
+Tensor fft_backward(const Tensor& self, const Tensor& grad, int64_t signal_ndim,
+                    bool complex_input, bool complex_output,
+                    bool inverse, IntList checked_signal_sizes,
+                    bool normalized, bool onesided,
+                    IntList output_sizes) {
+  Tensor gI;
+  if (!complex_input && complex_output) {
+    // Forward is R2C
+    // Do inverse C2C and project onto real plane because grad can be
+    // asymmetrical so C2R can't be used.
+    if (onesided) {
+      // if onesided, make it two sided
+      std::vector<int64_t> batched_signal_size(signal_ndim + 2);
+      batched_signal_size[0] = self.size(0);
+      for (int64_t i = 1; i <= signal_ndim; i++) {
+        batched_signal_size[i] = checked_signal_sizes[i - 1];
+      }
+      batched_signal_size[signal_ndim + 1] = 2;
+      auto complex_full_grad = grad.type().tensor(batched_signal_size);
+      int64_t last_dim_slice = grad.size(signal_ndim);
+      complex_full_grad.narrow(signal_ndim, 0, last_dim_slice).copy_(grad);
+      int64_t zero_length = checked_signal_sizes[signal_ndim - 1] - last_dim_slice;
+      if (zero_length > 0) {
+        complex_full_grad.narrow(signal_ndim, last_dim_slice, zero_length).zero_();
+      }
+      gI = _fft_with_size(complex_full_grad, signal_ndim,
+                          /* complex_input */ true, /* complex_output */ true,
+                          !inverse, checked_signal_sizes, normalized,
+                          /* onesided */ false, batched_signal_size).select(-1, 0);
+    } else {
+      gI = _fft_with_size(grad, signal_ndim, /* complex_input */ true,
+                          /* complex_output */ true, !inverse,
+                          checked_signal_sizes, normalized,
+                          /* onesided */ false, grad.sizes()).select(-1, 0);
+    }
+  } else if (complex_input && !complex_output && onesided) {
+    // Forward is C2R (onesided)
+    // Think of onesided C2R irfft as
+    //    1. fill the other half by conjugate symmetry
+    //    2. inverse C2C ifft
+    //    3. discard the complex dimension
+    // So backward is
+    //    1. R2C rfft (essentially add dummy complex dimension, and dft)
+    //    2. accumulate gradient by conjugate symmetry
+    //       since rfft results follow conjugate symmetry, we only need to
+    //       double some entries from onesided rfft results, i.e., the ones with
+    //       their reflected indices also landing out of the onesided range. So
+    //       consider the index of last dim:
+    //           i.   idx = 0.
+    //                Reflected to (N - 0) % N = 0. Not doubled.
+    //           ii   0 < idx < floor(N/2) (last).
+    //                N > N - idx > ceil(N/2)
+    //                Reflected to ()
+    //           iii. idx = floor(N/2) = N/2 (last) when N even.
+    //                Reflected to (N - N/2) % N = N/2. Not doubled.
+    //           iv.  idx = floor(N/2) = (N-1)/2 (last) when N odd.
+    //                Reflected to (N - (N-1)/2) % N = (N+1)/2. Doubled.
+    //       Therefore, needs to double
+    //           idx = 1, 2, ..., N/2 - 1     when N even
+    //           idx = 1, 2, ..., (N-1)/2     when N odd
+    //       that is
+    //           idx = 1, 2, ..., N - (floor(N/2) + 1)
+    //               = 1, 2, ..., N - onesided_length
+    gI = _fft_with_size(grad, signal_ndim, /* complex_input */ false,
+                        /* complex_output */ true, /* inverse */ false,
+                        checked_signal_sizes, normalized, /* onesided */ true,
+                        self.sizes());
+    int64_t double_length = checked_signal_sizes[signal_ndim - 1] - self.size(signal_ndim);
+    if (double_length > 0) {  // also covers case when signal size is zero
+      gI.narrow(signal_ndim, 1, double_length).mul_(2);
+    }
+  } else {
+    gI = _fft_with_size(grad, signal_ndim, complex_output, complex_input,
+                        !inverse, checked_signal_sizes, normalized, onesided,
+                        self.sizes());
+  }
+  if (normalized) {
+    // If normalized, backward is exactly calling fft with inversed argument as
+    // the forward because both are unitary.
+    return gI;
+  } else {
+    // If not normalized, in backward, we need to upscale or downscale gI basing
+    // on whether the forward is an inverse fft.
+    auto signal_numel = std::accumulate(checked_signal_sizes.begin(),
+                    checked_signal_sizes.end(), 1, std::multiplies<int64_t>());
+    if (!inverse) {
+      return gI.mul_(static_cast<double>(signal_numel));
+    } else {
+      return gI.div_(static_cast<double>(signal_numel));
+    }
+  }
+}
+
+// Helper for batchnorm_double_backward
 Tensor sum_exclude_dim1(const Tensor& to_sum, bool keepdim=true) {
   auto r = to_sum.sum(0, keepdim);
   int64_t start_point_exclusive = keepdim ? 1 : 0;
@@ -1012,6 +1107,7 @@ Tensor sum_exclude_dim1(const Tensor& to_sum, bool keepdim=true) {
   return r;
 }
 
+// Helper for batchnorm_double_backward
 // similar to expand_as below, but doesn't do the expand_as; operates as if
 // reductions were done with keepdim=True
 Tensor unsqueeze_dim1(const Tensor& src, const Tensor& target) {

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2047,6 +2047,34 @@ stft(frame_length, hop, fft_size=None, return_onesided=True, window=None, pad_en
 See :func:`torch.stft`
 """)
 
+add_docstr_all('fft',
+               r"""
+fft(signal_ndim, normalized=False) -> Tensor
+
+See :func:`torch.fft`
+""")
+
+add_docstr_all('ifft',
+               r"""
+ifft(signal_ndim, normalized=False) -> Tensor
+
+See :func:`torch.ifft`
+""")
+
+add_docstr_all('rfft',
+               r"""
+rfft(signal_ndim, normalized=False, onesided=True) -> Tensor
+
+See :func:`torch.rfft`
+""")
+
+add_docstr_all('irfft',
+               r"""
+irfft(signal_ndim, normalized=False, onesided=True, signal_sizes=None) -> Tensor
+
+See :func:`torch.irfft`
+""")
+
 add_docstr_all('det',
                r"""
 det() -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6038,7 +6038,7 @@ Ignoring the batch dimension, it computes the following expression:
         \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
          e^{-j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
 
-where :math:`d`=:attr:`signal_ndim` is number of dimensions for the
+where :math:`d` = :attr:`signal_ndim` is number of dimensions for the
 signal, and :math:`N_i` is the size of signal dimension :math:`i`.
 
 This method supports 1D, 2D and 3D complex-to-complex transforms, indicated
@@ -6046,21 +6046,22 @@ by :attr:`signal_ndim`. :attr:`input` must be a tensor with last dimension
 of size 2, representing the real and imaginary components of complex
 numbers, and should have ``signal_ndim + 1`` dimensions or ``signal_ndim + 2``
 dimensions with batched data. If :attr:`normalized` is set to ``True``, this
-returns the normalized Fourier transform results, i.e., divided by
-:math:`\sqrt{\prod_{i=1}^d N_i}`, to become a unitary operator.
+normalizes the result by dividing it with :math:`\sqrt{\prod_{i=1}^K N_i}` so
+that the operator is unitary.
 
 Returns the real and the imaginary parts together as one tensor of the same
 shape of :attr:`input`.
 
-The inverse of this function is :func:`ifft`.
+The inverse of this function is :func:`~torch.ifft`.
 
 .. warning::
     For CPU tensors, this method is currently only available with MKL. Check
-    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+    :func:`torch.backends.mkl.is_available` to check if MKL is installed.
 
 Arguments:
     input (Tensor): the input tensor
-    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    signal_ndim (int): the number of dimensions in each signal.
+        :attr:`signal_ndim` can only be 1, 2 or 3
     normalized (bool, optional): controls whether to return normalized results.
         Default: ``False``
 
@@ -6133,29 +6134,30 @@ expression:
 .. math::
     X[\omega_1, \dots, \omega_d] =
         \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
-         e^{j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
+         e^{\ j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
 
-where :math:`d`=:attr:`signal_ndim` is number of dimensions for the
+where :math:`d` = :attr:`signal_ndim` is number of dimensions for the
 signal, and :math:`N_i` is the size of signal dimension :math:`i`.
 
-The argument specifications are almost identical with :func:`fft`. However,
-if :attr:`normalized` is set to ``True``, this instead returns the results
-multiplied by :math:`\sqrt{\prod_{i=1}^d N_i}`, to become a unitary
-operator. Therefore, to invert an :func:`fft`, the :attr:`normalized`
-argument should be set identically for :func:`ifft`.
+The argument specifications are almost identical with :func:`~torch.fft`.
+However, if :attr:`normalized` is set to ``True``, this instead returns the
+results multiplied by :math:`\sqrt{\prod_{i=1}^d N_i}`, to become a unitary
+operator. Therefore, to invert a :func:`~torch.fft`, the :attr:`normalized`
+argument should be set identically for :func:`~torch.fft`.
 
 Returns the real and the imaginary parts together as one tensor of the same
 shape of :attr:`input`.
 
-The inverse of this function is :func:`fft`.
+The inverse of this function is :func:`~torch.fft`.
 
 .. warning::
     For CPU tensors, this method is currently only available with MKL. Check
-    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+    :func:`torch.backends.mkl.is_available` to check if MKL is installed.
 
 Arguments:
     input (Tensor): the input tensor
-    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    signal_ndim (int): the number of dimensions in each signal.
+        :attr:`signal_ndim` can only be 1, 2 or 3
     normalized (bool, optional): controls whether to return normalized results.
         Default: ``False``
 
@@ -6211,15 +6213,15 @@ rfft(input, signal_ndim, normalized=False, onesided=True) -> Tensor
 Real-to-complex Discrete Fourier Transform
 
 This method computes the real-to-complex discrete Fourier transform. It is
-mathematically equivalent with :func:`fft` with differences only in formats
-of the input and output.
+mathematically equivalent with :func:`~torch.fft` with differences only in
+formats of the input and output.
 
 This method supports 1D, 2D and 3D real-to-complex transforms, indicated
 by :attr:`signal_ndim`. :attr:`input` must be a tensor with ``signal_ndim``
 dimensions or ``signal_ndim + 1`` dimensions with batched data. If
-:attr:`normalized` is set to ``True``, this returns the normalized Fourier
-transform results, i.e., divided by :math:`\sqrt{\prod_{i=1}^d N_i}`, to
-become a unitary operator.
+:attr:`normalized` is set to ``True``, this normalizes the result by multiplying
+it with :math:`\sqrt{\prod_{i=1}^K N_i}` so that the operator is unitary, where
+:math:`N_i` is the size of signal dimension :math:`i`.
 
 The real-to-complex Fourier transform results follow conjugate symmetry:
 
@@ -6227,21 +6229,23 @@ The real-to-complex Fourier transform results follow conjugate symmetry:
     X[\omega_1, \dots, \omega_d] = X^*[N_1 - \omega_1, \dots, N_d - \omega_d],
 
 where the index arithmetic is computed modulus the size of the corresponding
-dimension. Therefore, :attr:`onesided` controls whether to avoid redundancy
-in the output results. If set to ``True`` (default), the output will not be
-full complex result of shape :math:`(* \times 2)`, where :math:`*` is the
-shape of :attr:`input`, but instead the last dimension will be halfed as
+dimension, :math:`\ ^*` is the conjugate operator, and
+:math:`d` = :attr:`signal_ndim`. :attr:`onesided` flag controls whether to avoid
+redundancy in the output results. If set to ``True`` (default), the output will
+not be full complex result of shape :math:`(*, 2)`, where :math:`*` is the shape
+of :attr:`input`, but instead the last dimension will be halfed as of size
 :math:`\lfloor \frac{N_d}{2} \rfloor + 1`.
 
-The inverse of this function is :func:`irfft`.
+The inverse of this function is :func:`~torch.irfft`.
 
 .. warning::
     For CPU tensors, this method is currently only available with MKL. Check
-    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+    :func:`torch.backends.mkl.is_available` to check if MKL is installed.
 
 Arguments:
     input (Tensor): the input tensor
-    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    signal_ndim (int): the number of dimensions in each signal.
+        :attr:`signal_ndim` can only be 1, 2 or 3
     normalized (bool, optional): controls whether to return normalized results.
         Default: ``False``
     onesided (bool, optional): controls whether to return half of results to
@@ -6271,44 +6275,47 @@ This method computes the complex-to-real inverse discrete Fourier transform.
 It is mathematically equivalent with :func:`ifft` with differences only in
 formats of the input and output.
 
-The argument specifications are almost identical with :func:`ifft`. Similar
-to :func:`ifft`, if :attr:`normalized` is set to ``True``, this instead
-returns the results multiplied by :math:`\sqrt{\prod_{i=1}^K N_i}`, to
-become a unitary operator.
+The argument specifications are almost identical with :func:`~torch.ifft`.
+Similar to :func:`~torch.ifft`, if :attr:`normalized` is set to ``True``,
+this normalizes the result by multiplying it with
+:math:`\sqrt{\prod_{i=1}^K N_i}` so that the operator is unitary, where
+:math:`N_i` is the size of signal dimension :math:`i`.
 
 Due to the conjugate symmetry, :attr:`input` do not need to contain the full
 complex frequency values. Roughly half of the values will be sufficient, as
-is the case when :attr:`input` is given by :func:`rfft` with
+is the case when :attr:`input` is given by :func:`~torch.rfft` with
 ``rfft(signal, onesided=True)``. In such case, set the :attr:`onesided`
 argument of this method to ``True``. Moreover, the original signal shape
 information can sometimes be lost, optionally set :attr:`signal_sizes` to be
 the size of the original signal (without batch dimension if in batched mode) to
 recover it with correct shape.
 
-Therefore, to invert an :func:`rfft`, the :attr:`normalized` and
-:attr:`onesided` arguments should be set identically for :func:`irfft`, and
-preferrably a :func:`signal_sizes` is given to avoid size mismatch. See the
+Therefore, to invert an :func:`~torch.rfft`, the :attr:`normalized` and
+:attr:`onesided` arguments should be set identically for :func:`~torch.irfft`,
+and preferrably a :attr:`signal_sizes` is given to avoid size mismatch. See the
 example below for a case of size mismatch.
 
-See :func:`rfft` for details on conjugate symmetry.
+See :func:`~torch.rfft` for details on conjugate symmetry.
 
-The inverse of this function is :func:`rfft`.
+The inverse of this function is :func:`~torch.rfft`.
 
 .. warning::
-    Genearlly speaking, the input of this function should contain values
+    Generally speaking, the input of this function should contain values
     following conjugate symmetry. Note that even if :attr:`onesided` is
     ``True``, often symmetry on some part is still needed. When this
-    requirement is not satisfied, the behavior is undefined. Since
-    :func:`torch.autograd.gradcheck` estimates numerical Jacobian with point
-    perturbations, this method will almost certainly fail the check.
+    requirement is not satisfied, the behavior of :func:`~torch.irfft` is
+    undefined. Since :func:`torch.autograd.gradcheck` estimates numerical
+    Jacobian with point perturbations, :func:`~torch.irfft` will almost
+    certainly fail the check.
 
 .. warning::
     For CPU tensors, this method is currently only available with MKL. Check
-    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+    :func:`torch.backends.mkl.is_available` to check if MKL is installed.
 
 Arguments:
     input (Tensor): the input tensor
-    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    signal_ndim (int): the number of dimensions in each signal.
+        :attr:`signal_ndim` can only be 1, 2 or 3
     normalized (bool, optional): controls whether to return normalized results.
         Default: ``False``
     onesided (bool, optional): controls whether :attr:`input` was halfed to avoid

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5824,7 +5824,7 @@ Example::
 
 add_docstr(torch.stft,
            r"""
-stft(signal, frame_length, hop, fft_size=None, return_onesided=True, window=None, pad_end=0) -> Tensor
+stft(signal, frame_length, hop, fft_size=None, normalized=False, onesided=True, window=None, pad_end=0) -> Tensor
 
 Short-time Fourier transform (STFT).
 
@@ -5832,7 +5832,7 @@ Ignoring the batch dimension, this method computes the following expression:
 
 .. math::
     X[m, \omega] = \sum_{k = 0}^{\text{frame_length}}%
-                        window[k]\ signal[m \times hop + k]\ e^{- j \frac{2 \pi \cdot \omega k}{\text{frame_length}}}
+                        window[k]\ signal[m \times hop + k]\ e^{- j \frac{2 \pi \cdot \omega k}{\text{frame_length}}},
 
 where :math:`m` is the index of the sliding window, and :math:`\omega` is
 the frequency that :math:`0 \leq \omega <` :attr:`fft_size`. When
@@ -5848,7 +5848,9 @@ default to same value as  :attr:`frame_length`. :attr:`window` can be a
 :meth:`torch.hann_window`. If :attr:`window` is the default value ``None``,
 it is treated as if having :math:`1` everywhere in the frame.
 :attr:`pad_end` indicates the amount of zero padding at the end of
-:attr:`signal` before STFT.
+:attr:`signal` before STFT. If :attr:`normalized` is set to ``True``, the
+function returns the normalized STFT results, i.e., multiplied by
+:math:`(frame\_length)^{-0.5}`.
 
 Returns the real and the imaginary parts together as one tensor of size
 :math:`(* \times N \times 2)`, where :math:`*` is the shape of input :attr:`signal`,
@@ -5861,7 +5863,10 @@ Arguments:
     frame_length (int): the size of window frame and STFT filter
     hop (int): the distance between neighboring sliding window frames
     fft_size (int, optional): size of Fourier transform. Default: ``None``
-    return_onesided (bool, optional): controls whether to avoid redundancy in the return value. Default: ``True``
+    normalized (bool, optional): controls whether to return the normalized STFT results
+         Default: ``False``
+    onesided (bool, optional): controls whether to return half of results to
+        avoid redundancy Default: ``True``
     window (Tensor, optional): the optional window function. Default: ``None``
     pad_end (int, optional): implicit zero padding at the end of :attr:`signal`. Default: 0
 
@@ -6016,5 +6021,330 @@ Example::
     -1.0402
     [torch.FloatTensor of size ()]
     )
+
+""")
+
+add_docstr(torch.fft,
+           r"""
+fft(input, signal_ndim, normalized=False) -> Tensor
+
+Complex-to-complex Discrete Fourier Transform
+
+This method computes the complex-to-complex discrete Fourier transform.
+Ignoring the batch dimension, it computes the following expression:
+
+.. math::
+    X[\omega_1, \dots, \omega_d] =
+        \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
+         e^{-j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
+
+where :math:`d`=:attr:`signal_ndim` is number of dimensions for the
+signal, and :math:`N_i` is the size of signal dimension :math:`i`.
+
+This method supports 1D, 2D and 3D complex-to-complex transforms, indicated
+by :attr:`signal_ndim`. :attr:`input` must be a tensor with last dimension
+of size 2, representing the real and imaginary components of complex
+numbers, and should have ``signal_ndim + 1`` dimensions or ``signal_ndim + 2``
+dimensions with batched data. If :attr:`normalized` is set to ``True``, this
+returns the normalized Fourier transform results, i.e., divided by
+:math:`\sqrt{\prod_{i=1}^d N_i}`, to become a unitary operator.
+
+Returns the real and the imaginary parts together as one tensor of the same
+shape of :attr:`input`.
+
+The inverse of this function is :func:`ifft`.
+
+.. warning::
+    For CPU tensors, this method is currently only available with MKL. Check
+    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+
+Arguments:
+    input (Tensor): the input tensor
+    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    normalized (bool, optional): controls whether to return normalized results.
+        Default: ``False``
+
+Returns:
+    Tensor: A tensor containing the complex-to-complex Fourier transform result
+
+Example::
+
+    >>> # unbatched 2D FFT
+    >>> x = torch.randn(4, 3, 2)
+    >>> torch.fft(x, 2)
+
+    (0 ,.,.) =
+      6.8901 -1.7571
+      0.4166 -1.1500
+      3.9736  0.5400
+
+    (1 ,.,.) =
+     -0.3050  0.4976
+      0.2072  1.1015
+      1.3850 -0.0566
+
+    (2 ,.,.) =
+      3.1463  3.3727
+      1.4051 -3.3523
+      1.5072 -4.1700
+
+    (3 ,.,.) =
+      5.1215 -2.5402
+      5.1859  1.4077
+      2.0077  1.3137
+    [torch.FloatTensor of size (4,3,2)]
+
+    >>> # batched 1D FFT
+    >>> torch.fft(x, 1)
+
+    (0 ,.,.) =
+      3.7132 -0.1067
+      1.8037 -0.4983
+      2.2184 -0.5932
+
+    (1 ,.,.) =
+      0.1765 -2.6391
+     -0.1705 -0.6941
+      0.9592  1.0218
+
+    (2 ,.,.) =
+      1.3050  0.9145
+     -0.8929 -1.7529
+      0.5220 -1.2218
+
+    (3 ,.,.) =
+      1.6954  0.0742
+     -0.3237  1.7953
+      0.2740  1.3332
+    [torch.FloatTensor of size (4,3,2)]
+
+""")
+
+add_docstr(torch.ifft,
+           r"""
+ifft(input, signal_ndim, normalized=False) -> Tensor
+
+Complex-to-complex Inverse Discrete Fourier Transform
+
+This method computes the complex-to-complex inverse discrete Fourier
+transform. Ignoring the batch dimension, it computes the following
+expression:
+
+.. math::
+    X[\omega_1, \dots, \omega_d] =
+        \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
+         e^{j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
+
+where :math:`d`=:attr:`signal_ndim` is number of dimensions for the
+signal, and :math:`N_i` is the size of signal dimension :math:`i`.
+
+The argument specifications are almost identical with :func:`fft`. However,
+if :attr:`normalized` is set to ``True``, this instead returns the results
+multiplied by :math:`\sqrt{\prod_{i=1}^d N_i}`, to become a unitary
+operator. Therefore, to invert an :func:`fft`, the :attr:`normalized`
+argument should be set identically for :func:`ifft`.
+
+Returns the real and the imaginary parts together as one tensor of the same
+shape of :attr:`input`.
+
+The inverse of this function is :func:`fft`.
+
+.. warning::
+    For CPU tensors, this method is currently only available with MKL. Check
+    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+
+Arguments:
+    input (Tensor): the input tensor
+    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    normalized (bool, optional): controls whether to return normalized results.
+        Default: ``False``
+
+Returns:
+    Tensor: A tensor containing the complex-to-complex inverse Fourier transform result
+
+Example::
+
+    >>> x = torch.randn(3, 3, 2)
+    >>> x
+
+    (0 ,.,.) =
+      1.2735 -0.9441
+     -1.0940  0.2728
+      0.8997  0.4231
+
+    (1 ,.,.) =
+     -0.5239 -1.4942
+      0.5248  3.3432
+      1.0976 -2.0426
+
+    (2 ,.,.) =
+      1.1039  1.9541
+     -0.2774  0.2631
+      0.3102  0.8129
+    [torch.FloatTensor of size (3,3,2)]
+
+    >>> y = torch.fft(x, 2)
+    >>> torch.ifft(y, 2)  # recover x
+
+    (0 ,.,.) =
+      1.2735 -0.9441
+     -1.0940  0.2728
+      0.8997  0.4231
+
+    (1 ,.,.) =
+     -0.5239 -1.4942
+      0.5248  3.3432
+      1.0976 -2.0426
+
+    (2 ,.,.) =
+      1.1039  1.9541
+     -0.2774  0.2631
+      0.3102  0.8129
+    [torch.FloatTensor of size (3,3,2)]
+
+""")
+
+add_docstr(torch.rfft,
+           r"""
+rfft(input, signal_ndim, normalized=False, onesided=True) -> Tensor
+
+Real-to-complex Discrete Fourier Transform
+
+This method computes the real-to-complex discrete Fourier transform. It is
+mathematically equivalent with :func:`fft` with differences only in formats
+of the input and output.
+
+This method supports 1D, 2D and 3D real-to-complex transforms, indicated
+by :attr:`signal_ndim`. :attr:`input` must be a tensor with ``signal_ndim``
+dimensions or ``signal_ndim + 1`` dimensions with batched data. If
+:attr:`normalized` is set to ``True``, this returns the normalized Fourier
+transform results, i.e., divided by :math:`\sqrt{\prod_{i=1}^d N_i}`, to
+become a unitary operator.
+
+The real-to-complex Fourier transform results follow conjugate symmetry:
+
+.. math::
+    X[\omega_1, \dots, \omega_d] = X^*[N_1 - \omega_1, \dots, N_d - \omega_d],
+
+where the index arithmetic is computed modulus the size of the corresponding
+dimension. Therefore, :attr:`onesided` controls whether to avoid redundancy
+in the output results. If set to ``True`` (default), the output will not be
+full complex result of shape :math:`(* \times 2)`, where :math:`*` is the
+shape of :attr:`input`, but instead the last dimension will be halfed as
+:math:`\lfloor \frac{N_d}{2} \rfloor + 1`.
+
+The inverse of this function is :func:`irfft`.
+
+.. warning::
+    For CPU tensors, this method is currently only available with MKL. Check
+    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+
+Arguments:
+    input (Tensor): the input tensor
+    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    normalized (bool, optional): controls whether to return normalized results.
+        Default: ``False``
+    onesided (bool, optional): controls whether to return half of results to
+        avoid redundancy Default: ``True``
+
+Returns:
+    Tensor: A tensor containing the real-to-complex Fourier transform result
+
+Example::
+
+    >>> x = torch.randn(5, 5)
+    >>> torch.rfft(x, 2).shape
+    torch.Size([5, 3, 2])
+    >>> torch.rfft(x, 2, onesided=False).shape
+    torch.Size([5, 5, 2])
+
+""")
+
+
+add_docstr(torch.irfft,
+           r"""
+irfft(input, signal_ndim, normalized=False, onesided=True, signal_sizes=None) -> Tensor
+
+Complex-to-real Inverse Discrete Fourier Transform
+
+This method computes the complex-to-real inverse discrete Fourier transform.
+It is mathematically equivalent with :func:`ifft` with differences only in
+formats of the input and output.
+
+The argument specifications are almost identical with :func:`ifft`. Similar
+to :func:`ifft`, if :attr:`normalized` is set to ``True``, this instead
+returns the results multiplied by :math:`\sqrt{\prod_{i=1}^K N_i}`, to
+become a unitary operator.
+
+Due to the conjugate symmetry, :attr:`input` do not need to contain the full
+complex frequency values. Roughly half of the values will be sufficient, as
+is the case when :attr:`input` is given by :func:`rfft` with
+``rfft(signal, onesided=True)``. In such case, set the :attr:`onesided`
+argument of this method to ``True``. Moreover, the original signal shape
+information can sometimes be lost, optionally set :attr:`signal_sizes` to be
+the size of the original signal (without batch dimension if in batched mode) to
+recover it with correct shape.
+
+Therefore, to invert an :func:`rfft`, the :attr:`normalized` and
+:attr:`onesided` arguments should be set identically for :func:`irfft`, and
+preferrably a :func:`signal_sizes` is given to avoid size mismatch. See the
+example below for a case of size mismatch.
+
+See :func:`rfft` for details on conjugate symmetry.
+
+The inverse of this function is :func:`rfft`.
+
+.. warning::
+    Genearlly speaking, the input of this function should contain values
+    following conjugate symmetry. Note that even if :attr:`onesided` is
+    ``True``, often symmetry on some part is still needed. When this
+    requirement is not satisfied, the behavior is undefined. Since
+    :func:`torch.autograd.gradcheck` estimates numerical Jacobian with point
+    perturbations, this method will almost certainly fail the check.
+
+.. warning::
+    For CPU tensors, this method is currently only available with MKL. Check
+    :meth:`torch.backends.mkl.is_available` to see if MKL is installed.
+
+Arguments:
+    input (Tensor): the input tensor
+    signal_ndim (int): the number of dimensions in each signal, can only be 1, 2 or 3
+    normalized (bool, optional): controls whether to return normalized results.
+        Default: ``False``
+    onesided (bool, optional): controls whether :attr:`input` was halfed to avoid
+        redundancy, e.g., by :func:`rfft`. Default: ``True``
+    signal_sizes (list or :class:`torch.Size`, optional): the size of the original
+        signal (without batch dimension). Default: ``None``
+
+Returns:
+    Tensor: A tensor containing the complex-to-real inverse Fourier transform result
+
+Example::
+
+    >>> x = torch.randn(4, 4)
+    >>> torch.rfft(x, 2, onesided=True).shape
+    torch.Size([4, 3, 2])
+    >>>
+    >>> # notice that with onesided=True, output size does not determine the original signal size
+    >>> x = torch.randn(4, 5)
+    >>> torch.rfft(x, 2, onesided=True).shape
+    torch.Size([4, 3, 2])
+    >>>
+    >>> x
+
+    -0.5052 -0.0420  0.5773 -0.2224  1.8413
+    -0.0873 -0.7571 -0.1982  0.5722 -1.8076
+    -1.5447  0.4344  0.8692  1.7930  2.6886
+     0.4674  0.0517 -0.7564 -0.5118 -0.7023
+    [torch.FloatTensor of size (4,5)]
+
+    >>> y = torch.rfft(x, 2, onesided=True)
+    >>> torch.irfft(y, 2, onesided=True, signal_sizes=x.shape)  # recover x
+
+    -0.5052 -0.0420  0.5773 -0.2224  1.8413
+    -0.0873 -0.7571 -0.1982  0.5722 -1.8076
+    -1.5447  0.4344  0.8692  1.7930  2.6886
+     0.4674  0.0517 -0.7564 -0.5118 -0.7023
+    [torch.FloatTensor of size (4,5)]
 
 """)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -166,7 +166,7 @@ def hann_window(window_length, periodic=True, dtype=torch.float32):
 
     .. math::
         w[n] = \frac{1}{2}\ \left[1 - \cos \left( \frac{2 \pi n}{N - 1} \right)\right] =
-                \sin^2 \left( \frac{\pi n}{N - 1} \right)
+                \sin^2 \left( \frac{\pi n}{N - 1} \right),
 
     where :math:`N` is the full window size.
 
@@ -180,7 +180,7 @@ def hann_window(window_length, periodic=True, dtype=torch.float32):
     ``torch.hann_window(L + 1, periodic=False)[:-1])``.
 
     .. note::
-        If :attr:`window_length` :math:`\leq 2`, the returned window contains a single value 1.
+        If :attr:`window_length` :math:`=1`, the returned window contains a single value 1.
 
     Arguments:
         window_length (int): the size of returned window
@@ -205,7 +205,7 @@ def hamming_window(window_length, periodic=True, alpha=0.54, beta=0.46, dtype=to
     This method computes the Hamming window function:
 
     .. math::
-        w[n] = \alpha - \beta\ \cos \left( \frac{2 \pi n}{N - 1} \right)
+        w[n] = \alpha - \beta\ \cos \left( \frac{2 \pi n}{N - 1} \right),
 
     where :math:`N` is the full window size.
 
@@ -219,7 +219,7 @@ def hamming_window(window_length, periodic=True, alpha=0.54, beta=0.46, dtype=to
     ``torch.hamming_window(L + 1, periodic=False)[:-1])``.
 
     .. note::
-        If :attr:`window_length` :math:`\leq 2`, the returned window contains a single value 1.
+        If :attr:`window_length` :math:`=1`, the returned window contains a single value 1.
 
     .. note::
         This is a generalized version of :meth:`torch.hann_window`.
@@ -232,7 +232,7 @@ def hamming_window(window_length, periodic=True, alpha=0.54, beta=0.46, dtype=to
             Default: `torch.float32`
 
     Returns:
-        Tensor: A 1-D tensor of size :math:`(window\_length)` containing the window
+        Tensor: A 1-D tensor of size :math:`(window\_length,)` containing the window
     """
     if not dtype.is_floating_point:
         raise ValueError("dtype must be a floating point type, but got dtype={}".format(dtype))
@@ -258,9 +258,9 @@ def bartlett_window(window_length, periodic=True, dtype=torch.float32):
         w[n] = 1 - \left| \frac{2n}{N-1} - 1 \right| = \begin{cases}
             \frac{2n}{N - 1} & \text{if } 0 \leq n \leq \frac{N - 1}{2} \\
             2 - \frac{2n}{N - 1} & \text{if } \frac{N - 1}{2} < n < N \\
-        \end{cases}
+        \end{cases},
 
-    , where :math:`N` is the full window size.
+    where :math:`N` is the full window size.
 
     The input :attr:`window_length` is a positive integer controlling the
     returned window size. :attr:`periodic` flag determines whether the returned
@@ -272,7 +272,7 @@ def bartlett_window(window_length, periodic=True, dtype=torch.float32):
     ``torch.bartlett_window(L + 1, periodic=False)[:-1])``.
 
     .. note::
-        If :attr:`window_length` :math:`\leq 2`, the returned window contains a single value 1.
+        If :attr:`window_length` :math:`=1`, the returned window contains a single value 1.
 
     Arguments:
         window_length (int): the size of returned window
@@ -282,7 +282,7 @@ def bartlett_window(window_length, periodic=True, dtype=torch.float32):
             Default: `torch.float32`
 
     Returns:
-        Tensor: A 1-D tensor of size :math:`(window\_length)` containing the window
+        Tensor: A 1-D tensor of size :math:`(window\_length,)` containing the window
     """
     if not dtype.is_floating_point:
         raise ValueError("dtype must be a floating point type, but got dtype={}".format(dtype))

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -175,7 +175,7 @@ def hann_window(window_length, periodic=True, dtype=torch.float32):
     window trims off the last duplicate value from the symmetric window and is
     ready to be used as a periodic window with functions like
     :meth:`torch.stft`. Therefore, if :attr:`periodic` is true, the :math:`N` in
-    above formula is in fact :math:`\textt{window_length} + 1`. Also, we always have
+    above formula is in fact :math:`\text{window_length} + 1`. Also, we always have
     ``torch.hann_window(L, periodic=True)`` equal to
     ``torch.hann_window(L + 1, periodic=False)[:-1])``.
 
@@ -190,7 +190,7 @@ def hann_window(window_length, periodic=True, dtype=torch.float32):
             Default: `torch.float32`
 
     Returns:
-        Tensor: A 1-D tensor of size :math:`(\text{window_length})` containing the window
+        Tensor: A 1-D tensor of size :math:`(\text{window_length},)` containing the window
     """
     if not dtype.is_floating_point:
         raise ValueError("dtype must be a floating point type, but got dtype={}".format(dtype))
@@ -232,7 +232,7 @@ def hamming_window(window_length, periodic=True, alpha=0.54, beta=0.46, dtype=to
             Default: `torch.float32`
 
     Returns:
-        Tensor: A 1-D tensor of size :math:`(window\_length,)` containing the window
+        Tensor: A 1-D tensor of size :math:`(\text{window_length},)` containing the window
     """
     if not dtype.is_floating_point:
         raise ValueError("dtype must be a floating point type, but got dtype={}".format(dtype))
@@ -282,7 +282,7 @@ def bartlett_window(window_length, periodic=True, dtype=torch.float32):
             Default: `torch.float32`
 
     Returns:
-        Tensor: A 1-D tensor of size :math:`(window\_length,)` containing the window
+        Tensor: A 1-D tensor of size :math:`(\text{window_length},)` containing the window
     """
     if not dtype.is_floating_point:
         raise ValueError("dtype must be a floating point type, but got dtype={}".format(dtype))


### PR DESCRIPTION
Commit structure:
1. move `irfft`'s `signal_sizes` arg to be the last
2. add docs for `fft, ifft, rfft, irfft`; update doc for `stft` to include the newly added `normalized` flag
3. fix typo in window function docs
4. improve gradcheck error message
5. implement backward of `fft, ifft, rfft, irfft`
6. add grad tests for `fft, ifft, rfft, irfft`

Relevant issue is #3775 .