### PR TITLE
Deterministically seed all ATen C++ tests.

### DIFF
--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -1,5 +1,6 @@
 #include "ATen/ATen.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 #include<iostream>
 using namespace std;
@@ -23,6 +24,8 @@ void trace() {
   cout << trace << "\n" << foo << "\n";
 }
 int main() {
+  manual_seed(123);
+
   auto foo = CPU(kFloat).rand({12,6});
   ASSERT(foo.data<float>() == foo.toFloatData());
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -11,6 +11,7 @@ extern "C" void THFloatTensor_fill(THFloatTensor *, float v);
 #include <string.h>
 #include <sstream>
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
@@ -261,6 +262,8 @@ static void test(Type & type) {
 
 int main(int argc, char ** argv)
 {
+  manual_seed(123);
+
   std::cout << "=========================== CPU ===========================" << std::endl;
   test(CPU(kFloat));
   if(at::hasCUDA()) {

--- a/aten/src/ATen/test/broadcast_test.cpp
+++ b/aten/src/ATen/test/broadcast_test.cpp
@@ -1,9 +1,12 @@
 #include "ATen/ATen.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
 int main() {
+  manual_seed(123);
+
   Type & T = CPU(kFloat);
 
   // 0) pre-req tests:

--- a/aten/src/ATen/test/cudnn_test.cpp
+++ b/aten/src/ATen/test/cudnn_test.cpp
@@ -2,11 +2,14 @@
 #include "ATen/cudnn/Descriptors.h"
 #include "ATen/cudnn/Handles.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 using namespace at::native;
 
 int main() {
+  manual_seed(123);
+
 #if CUDNN_VERSION < 7000
   auto handle = getCudnnHandle();
   DropoutDescriptor desc1, desc2;

--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <sstream>
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
@@ -24,6 +25,8 @@ static void test() {
 
 int main(int argc, char ** argv)
 {
+  manual_seed(123);
+
   std::cout << "======================= CPU =====================" << std::endl;
   test();
   return 0;

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -1,5 +1,6 @@
 #include "ATen/ATen.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
@@ -176,6 +177,8 @@ void test(Type & T, Type & AccT) {
 }
 
 int main() {
+  manual_seed(123);
+
   test(CPU(kFloat), CPU(kDouble));
 
   if (at::hasCUDA()) {

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -1,5 +1,6 @@
 #include "ATen/ATen.h"
 #include "test_assert.h"
+#include "test_seed.h"
 #include <algorithm>
 #include <iostream>
 #include <numeric>
@@ -256,6 +257,8 @@ void test(Type &T) {
 }
 
 int main() {
+  manual_seed(123);
+
   test(CPU(kFloat));
 
   if (at::hasCUDA()) {

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -7,6 +7,7 @@
 #include "ATen/ATen.h"
 #include "ATen/Dispatch.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 using std::cout;
 using namespace at;
@@ -81,6 +82,8 @@ void test_overflow() {
 }
 
 int main() {
+  manual_seed(123);
+
   Scalar what = 257;
   Scalar bar = 3.0;
   Half h = bar.toHalf();

--- a/aten/src/ATen/test/test_seed.h
+++ b/aten/src/ATen/test/test_seed.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "ATen/ATen.h"
+
+void manual_seed(uint64_t seed) {
+  at::Generator & cpu_gen = at::globalContext().defaultGenerator(at::Backend::CPU);
+  cpu_gen.manualSeed(seed);
+  if (at::hasCUDA()) {
+    at::Generator & cuda_gen = at::globalContext().defaultGenerator(at::Backend::CUDA);
+    cuda_gen.manualSeed(seed);
+  }
+}

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -2,10 +2,13 @@
 #include "ATen/UndefinedTensor.h"
 #include <string>
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
 int main() {
+  manual_seed(123);
+
   // mainly test ops on undefined tensors don't segfault and give a reasonable errror message.
   Tensor und;
   Tensor ft = CPU(kFloat).ones({1});

--- a/aten/src/ATen/test/wrapdim_test.cpp
+++ b/aten/src/ATen/test/wrapdim_test.cpp
@@ -1,9 +1,12 @@
 #include "ATen/ATen.h"
 #include "test_assert.h"
+#include "test_seed.h"
 
 using namespace at;
 
 int main() {
+  manual_seed(123);
+
   Type & T = CPU(kFloat);
 
   // test simple case


### PR DESCRIPTION
Hopefully this fixes the following assertion faiulre:

/var/lib/jenkins/workspace/aten/src/ATen/test/native_test.cpp:102: test:
Assertion `d5.matmul(d1).allclose(d5.view({24, 2, 3}).bmm(d1.view({1, 3,
1}).expand({24, 3, 1})).view({3, 2, 4, 2}))` failed.

(this error seems to only occur on ASAN tests...)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>