### PR TITLE
Implementation of the logit-normal distribution

### DIFF
--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -86,6 +86,7 @@ from .gumbel import Gumbel
 from .kl import kl_divergence, register_kl
 from .laplace import Laplace
 from .log_normal import LogNormal
+from .logit_normal import LogitNormal
 from .multinomial import Multinomial
 from .normal import Normal
 from .one_hot_categorical import OneHotCategorical
@@ -114,6 +115,7 @@ __all__ = [
     'Gumbel',
     'Laplace',
     'LogNormal',
+    'LogitNormal',
     'Multinomial',
     'Normal',
     'OneHotCategorical',

--- a/torch/distributions/logit_normal.py
+++ b/torch/distributions/logit_normal.py
@@ -1,0 +1,41 @@
+from torch.distributions import constraints
+from torch.distributions.transforms import InvertableBoltzmannTransform
+from torch.distributions.normal import Normal
+from torch.distributions.transformed_distribution import TransformedDistribution
+
+
+class LogitNormal(TransformedDistribution):
+    r"""
+    Creates a logit-normal distribution parameterized by
+    `mean` and `std` where::
+
+        X ~ LogitNormal(loc, scale)
+        Y = log(X / (1 - X)) ~ Normal(loc, scale)
+
+    Example::
+
+        >>> m = LogitNormal(torch.Tensor([0.0]), torch.Tensor([1.0]))
+        >>> m.sample()  # logit-normal distributed with mean=0 and stddev=1
+         0.4655
+         0.5345
+        [torch.FloatTensor of size (2,)]
+
+    Args:
+        loc (float or Tensor): mean
+        scale (float or Tensor): standard deviation
+    """
+    params = {'loc': constraints.real, 'scale': constraints.positive}
+    support = constraints.positive
+    has_rsample = True
+
+    def __init__(self, loc, scale):
+        super(LogitNormal, self).__init__(
+            Normal(loc, scale), InvertableBoltzmannTransform())
+
+    @property
+    def loc(self):
+        return self.base_dist.loc
+
+    @property
+    def scale(self):
+        return self.base_dist.scale

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -412,6 +412,28 @@ class BoltzmannTransform(Transform):
         return probs.log()
 
 
+class InvertableBoltzmannTransform(Transform):
+    """
+    Transform from unconstrained space to the simplex via `y = [exp(x), 1]` and
+    then normalizing. Note that dimensionality of `y.dim() == x.dim() + 1`.
+    """
+    domain = constraints.real
+    codomain = constraints.simplex
+    event_dim = 1
+
+    def __eq__(self, other):
+        return isinstance(other, InvertableBoltzmannTransform)
+
+    def _call(self, x):
+        probs = torch.cat([x.exp(), torch.ones(*x.size()[:-1], 1)], dim=-1)
+        probs /= probs.sum(-1, True)
+        return probs
+
+    def _inverse(self, y):
+        logprobs = y[:, :-1].log() - y[:, -1:].log()
+        return logprobs
+
+
 class StickBreakingTransform(Transform):
     """
     Transform from unconstrained space to the simplex of one additional


### PR DESCRIPTION
Implements the [logit-normal distribution](https://en.wikipedia.org/wiki/Logit-normal_distribution).

**Note:** the moments of the distribution don't have an analytical form, hence the class will throw `NotImplementedError` when `mean` or `variance` is called.  Perhaps it would be better to throw a more specific exception (please suggest).