### PR TITLE
fixed ONNX softmax support documentation

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -148,7 +148,7 @@ The following operators are supported:
 * threshold (non-zero threshold/non-zero value not supported)
 * leaky_relu
 * glu
-* softmax
+* softmax (only dim=-1 supported)
 * avg_pool2d (ceil_mode not supported)
 * log_softmax
 * unfold (experimental support with ATen-Caffe2 integration)


### PR DESCRIPTION
When exporting PyTorch models to ONNX, softmax is not fully supported:

https://github.com/pytorch/pytorch/pull/4592/commits/2ad535974d35d2a014320401e54c7ee9a653e3d9

https://github.com/onnx/onnx-caffe2/blob/master/tests/ONNXOpCoverage.md

Updated ONNX docs stating that softmax only works when dim=-1.