### PR TITLE
Add return statement to the JIT AST

### DIFF
--- a/test/expect/TestJit.test_python_frontend.expect
+++ b/test/expect/TestJit.test_python_frontend.expect
@@ -5,10 +5,6 @@
     (param (ident y) (tensor_type))
     (param (ident z) (tensor_type)))
   (list
-    (param
-      (ident __jit_0)
-      (tensor_type)))
-  (list
     (assign
       (list (ident q))
       (=)
@@ -57,7 +53,5 @@
           (list (ident q))
           (=)
           (variable (ident x)))))
-    (assign
-      (list (ident __jit_0))
-      (=)
-      (variable (ident x)))))
+    (return
+      (list (variable (ident x))))))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1362,9 +1362,10 @@ class TestJit(TestCase):
 
     def test_script_add(self):
         script = '''
-        def func(a, b) -> (c):
+        def func(a, b):
             c = a + b
             c += a
+            return c
         '''
 
         a = Variable(torch.rand(1), requires_grad=True)
@@ -1374,8 +1375,8 @@ class TestJit(TestCase):
 
     def test_script_mul(self):
         script = '''
-        def func(a, b) -> (c):
-            c = a * b
+        def func(a, b):
+            return a * b
         '''
 
         a = Variable(torch.rand(1), requires_grad=True)
@@ -1385,8 +1386,8 @@ class TestJit(TestCase):
 
     def test_script_triple(self):
         script = '''
-        def func(x) -> (y):
-            y = 3f * x
+        def func(x):
+            return 3f * x
         '''
         x = Variable(torch.rand(1).float(), requires_grad=True)
         outputs = 3 * x
@@ -1394,8 +1395,8 @@ class TestJit(TestCase):
 
     def test_script_slice(self):
         script = '''
-        def func(x) -> (head):
-            head = x[:5]
+        def func(x):
+            return x[:5]
         '''
         x = Variable(torch.rand(10).float(), requires_grad=True)
         outputs = x[:5]
@@ -1403,8 +1404,8 @@ class TestJit(TestCase):
 
     def test_script_gather(self):
         script = '''
-        def func(x) -> (y):
-            y = x[0]
+        def func(x):
+            return x[0]
         '''
         x = Variable(torch.rand(10).float(), requires_grad=True)
         outputs = x[0]
@@ -1412,14 +1413,14 @@ class TestJit(TestCase):
 
     def test_script_func_call(self):
         script = '''
-        def add(a, b) -> (c):
-            c = a + b
+        def add(a, b):
+            return a + b
 
-        def mul(a, x) -> (y):
-            y = a * x
+        def mul(a, x):
+            return a * x
 
-        def func(alpha, beta, x, y) -> (z):
-            z = add(mul(alpha, x), mul(beta, y))
+        def func(alpha, beta, x, y):
+            return add(mul(alpha, x), mul(beta, y))
         '''
         alpha = Variable(torch.rand(1).float(), requires_grad=True)
         beta = Variable(torch.rand(1).float(), requires_grad=True)
@@ -1433,8 +1434,8 @@ class TestJit(TestCase):
     @unittest.skip("RuntimeError: VariableType::ID() not implemented")
     def test_script_cast(self):
         script = '''
-        def to_int(x) -> (y):
-            y = int(x)
+        def to_int(x):
+            return int(x)
         '''
         x = Variable(torch.FloatTensor([1.1, 2.3]), requires_grad=True)
         outputs = Variable(torch.IntTensor([1, 2]), requires_grad=True)
@@ -1462,11 +1463,12 @@ class TestJit(TestCase):
 
     def test_script_while(self):
         script = '''
-        def test_while(a, b, max) -> (c):
+        def test_while(a, b, max):
             while a < max:
                 a = a + 1
                 b = b + 1
             c = a + b
+            return c
         '''
         inputs = self._make_scalar_vars([1, 1, 10], np.int32)
         outputs = self._make_scalar_vars([20], np.int32)
@@ -1474,7 +1476,7 @@ class TestJit(TestCase):
 
     def test_script_fibb(self):
         script = '''
-        def test_while(lim) -> (third, st, fs):
+        def test_while(lim):
             first = 1
             second = 1
             i = 1
@@ -1494,6 +1496,7 @@ class TestJit(TestCase):
 
             st = second + third
             fs = first + second
+            return third, st, fs
         '''
         inputs = self._make_scalar_vars([10], np.int32)
         outputs = self._make_scalar_vars([2, 4, 3], np.int32)
@@ -1501,7 +1504,7 @@ class TestJit(TestCase):
 
     def test_script_if(self):
         script = '''
-        def test_if(a, b) -> (c):
+        def test_if(a, b):
             d = 3
             if a > 10:
                 a = 3 + d
@@ -1509,6 +1512,7 @@ class TestJit(TestCase):
                 b = 3 + d
                 d = 4
             c = a + b
+            return c
         '''
         inputs = self._make_scalar_vars([1, -1], np.int32)
         outputs = self._make_scalar_vars([7], np.int32)
@@ -1516,10 +1520,11 @@ class TestJit(TestCase):
 
     def test_script_if_noelse(self):
         script = '''
-        def test_if_noelse(a, b) -> (c):
+        def test_if_noelse(a, b):
             if a > 10:
                 a = 3 + b
             c = a + b
+            return c
         '''
         inputs = self._make_scalar_vars([-1, 1], np.int32)
         outputs = self._make_scalar_vars([0], np.int32)
@@ -1528,30 +1533,30 @@ class TestJit(TestCase):
     def test_script_while_nonexistant_value(self):
         with self.assertRaisesRegex(RuntimeError, "undefined value x"):
             torch.jit.CompilationUnit('''
-            def test_while(a, b) -> (c):
+            def test_while(a, b):
                 while a < 10:
                     a = a + x
                     b = b + 1
-                c = a + b
+                return a + b
             ''')
 
     def test_script_while_nonexistant_cond_value(self):
         with self.assertRaisesRegex(RuntimeError, "undefined value x"):
             torch.jit.CompilationUnit('''
-            def test_while(a, b) -> (c):
+            def test_while(a, b):
                 while a < x:
                     a = a + 1
                     b = b + 1
-                c = a + b
+                return a + b
             ''')
 
     def test_script_while_write_outer_then_read(self):
         script = '''
-        def test_while(a, b) -> (c):
+        def test_while(a, b):
             while a < 10:
                 a = a + 1
                 b = a + 1
-            c = a + b
+            return a + b
         '''
         inputs = self._make_scalar_vars([42, 1337], np.int32)
         outputs = self._make_scalar_vars([1379], np.int32)
@@ -1559,7 +1564,7 @@ class TestJit(TestCase):
 
     def test_script_while_nest_if(self):
         script = '''
-        def test_while_if(a, b) -> (c):
+        def test_while_if(a, b):
             c = 0
             while a < 10:
                 a = a + 1
@@ -1568,7 +1573,7 @@ class TestJit(TestCase):
                     c = -a
                 else:
                     c = -b
-            c = c + 1
+            return c + 1
         '''
         inputs = self._make_scalar_vars([-1234, 4321], np.int32)
         outputs = self._make_scalar_vars([-5564], np.int32)
@@ -1576,12 +1581,13 @@ class TestJit(TestCase):
 
     def test_script_if_nest_while(self):
         script = '''
-        def test_if_while(a, b) -> (c):
+        def test_if_while(a, b):
             c = 0
             if a > b:
                 while a > b:
                     b = b + 1
                     c = -b
+            return c
         '''
         inputs = self._make_scalar_vars([4321, 1234], np.int32)
         outputs = self._make_scalar_vars([-4321], np.int32)
@@ -1589,17 +1595,19 @@ class TestJit(TestCase):
 
     def test_script_ternary(self):
         cu = torch.jit.CompilationUnit('''
-        def test_ternary_control(a, b) -> (c):
+        def test_ternary_control(a, b):
             c = 3
             if a > 3:
                 c = a + b
             else:
                 c = b
+            return c
         ''')
         cu2 = torch.jit.CompilationUnit('''
-        def test_ternary(a, b) -> (c):
+        def test_ternary(a, b):
             c = 3
             c = a + b if a > 3 else b
+            return c
         ''')
         self.assertEqual(
             str(cu.cu.get_graph('test_ternary_control')),
@@ -1629,8 +1637,9 @@ class TestJit(TestCase):
 
     def test_script_cu(self):
         cu = torch.jit.CompilationUnit('''
-            def foo(a) -> (b):
+            def foo(a):
                 b = a
+                return b
         ''')
         a = Variable(torch.rand(1))
         self.assertEqual(a, cu.foo(a))
@@ -1662,10 +1671,10 @@ class TestJit(TestCase):
             return a * 3.0
 
         cu = torch.jit.CompilationUnit('''
-        def other_func(a) -> (b):
-            b = a + a
+        def other_func(a):
+            return a + a
 
-        def test_call_python(a) -> (b):
+        def test_call_python(a):
             b = pyfunc(a)
             b = other_func(b)
             i = 0
@@ -1675,6 +1684,7 @@ class TestJit(TestCase):
                 if b > 3.0:
                     b = pyfunc(b)
                 i = 11
+            return b
         ''')
         inputs = self._make_scalar_vars([1], np.float32)
         outputs = self._make_scalar_vars([54], np.float32)
@@ -1687,10 +1697,10 @@ class TestJit(TestCase):
                 return a * 3.0
 
             cu = torch.jit.CompilationUnit('''
-            def other_func(a) -> (b):
-                b = a + a
+            def other_func(a):
+                return a + a
 
-            def test_call_python(a) -> (b):
+            def test_call_python(a):
                 b = pyfunc(a)
                 b = other_func(b)
                 i = 0
@@ -1700,6 +1710,7 @@ class TestJit(TestCase):
                     if b > 3.0:
                         b = pyfunc(b)
                     i = 11
+                return b
             ''')
             inputs = self._make_scalar_vars([1], np.float32)
             outputs = self._make_scalar_vars([54], np.float32)
@@ -1800,9 +1811,10 @@ class TestJit(TestCase):
     def test_shape_prop_mismatch_output(self):
         with self.assertRaises(RuntimeError):
             cu = torch.jit.CompilationUnit('''
-            def test_shape_prop_mismatch_output(a) -> (b):
+            def test_shape_prop_mismatch_output(a):
                 b = slice(a, dim=0, end=-2, start=2, step=1)
                 b = topk(a, dim=0, k=2, largest=True, sorted=True)
+                return b
             ''')
             inputs = [torch.zeros(10)]
             outputs = [torch.zeros(2), torch.from_numpy(np.array([1, 5])).long()]
@@ -1812,8 +1824,8 @@ class TestJit(TestCase):
 
     def test_view_shape_prop(self):
         cu = torch.jit.CompilationUnit('''
-        def test_view_shape_prop(a) -> (b):
-            b = view(a, size=[-1])
+        def test_view_shape_prop(a):
+            return view(a, size=[-1])
         ''')
         inputs = [torch.zeros(10, 10)]
         outputs = torch.zeros(100)
@@ -1823,8 +1835,8 @@ class TestJit(TestCase):
 
     def test_integral_shape_inference(self):
         cu = torch.jit.CompilationUnit('''
-        def test_integral_shape_inference(a) -> (b):
-            b = a / a
+        def test_integral_shape_inference(a):
+            return a / a
         ''')
         inputs = [torch.ones(10, 10).type(torch.LongTensor)]
         outputs = torch.ones(10, 10)
@@ -1833,13 +1845,14 @@ class TestJit(TestCase):
 
     def test_fuser_multiple_blocks(self):
         cu = torch.jit.CompilationUnit('''
-        def test_fuser_multiple_blocks(this, that, theother, meme) -> (this, that, theother):
+        def test_fuser_multiple_blocks(this, that, theother, meme):
             i = 0LL
             while i < 20LL:
                 this = cat(this, meme, dim=0)
                 that = cat(that, meme, dim=0)
                 theother = cat(theother, meme, dim=0)
                 i = i + 1
+            return this, that, theother
         ''')
 
         inputs = [torch.ones(0, 10, 10)] * 3
@@ -1850,8 +1863,9 @@ class TestJit(TestCase):
 
     def test_print_graph_executor(self):
         cu = torch.jit.CompilationUnit('''
-        def test_print_graph_executor(meme) -> ():
+        def test_print_graph_executor(meme):
             print(meme)
+            return meme
         ''')
 
         inputs = [torch.ones(5, 5)]

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -180,13 +180,27 @@ struct to_ir {
       auto& name = input.ident().name();
       environment_stack->setVar(name, def.graph->addInput(name));
     }
-    emitStatements(tree.statements());
-    for (auto output : tree.returns()) {
-      def.graph->registerOutput(environment_stack->getVar(output.ident()));
+
+    auto stmts = tree.statements();
+    auto stmts_begin = stmts.begin();
+    auto stmts_end = stmts.end();
+    if (stmts_begin == stmts_end)
+      throw ErrorReport(tree) << "functions need to have a non-empty body";
+    --stmts_end;
+    if ((*stmts_end).kind() != TK_RETURN)
+      throw ErrorReport(*stmts_end) << "functions need to end with a return statement";
+
+    emitStatements(stmts_begin, stmts_end);
+    for (auto output : Return(*stmts_end).values()) {
+      def.graph->registerOutput(emitExpr(output, 1)[0]);
     }
   }
   void emitStatements(const List<Stmt>& statements) {
-    for (auto stmt : statements) {
+    return emitStatements(statements.begin(), statements.end());
+  }
+  void emitStatements(List<Stmt>::const_iterator begin, List<Stmt>::const_iterator end) {
+    for (; begin != end; ++begin) {
+      auto stmt = *begin;
       switch (stmt.kind()) {
         case TK_IF:
           emitIf(If(stmt));
@@ -205,6 +219,10 @@ struct to_ir {
           break;
         case TK_EXPR_STMT:
           emitExpr(ExprStmt(stmt).expr(), 0);
+          break;
+        case TK_RETURN:
+          throw ErrorReport(stmt) << "return statements can appear only at the end "
+                                  << "of the function body";
           break;
       }
     }

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -41,7 +41,6 @@ namespace script {
   _(TK_STRING, "string", "")                     \
   _(TK_CONST, "const", "")                       \
   _(TK_LIST, "list", "")                         \
-  _(TK_OPTION, "option", "")                     \
   _(TK_APPLY, "apply", "")                       \
   _(TK_COMPREHENSION, "comprehension", "")       \
   _(TK_TENSOR_TYPE, "tensor_type", "")           \

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -36,7 +36,6 @@ namespace script {
   _(TK_LONG, "long", "long")                     \
   _(TK_INT, "int", "int")                        \
   _(TK_DEF, "def", "def")                        \
-  _(TK_ARROW, "arrow", "->")                     \
   _(TK_EQUIVALENT, "equivalent", "<=>")          \
   _(TK_IDENT, "ident", "")                       \
   _(TK_STRING, "string", "")                     \
@@ -58,6 +57,7 @@ namespace script {
   _(TK_ELIF, "elif", "elif")                     \
   _(TK_WHILE, "while", "while")                  \
   _(TK_EXPR_STMT, "expression statement", "")    \
+  _(TK_RETURN, "return", "return")               \
   _(TK_NE, "ne", "!=")                           \
   _(TK_EQ, "eq", "==")                           \
   _(TK_LE, "le", "<=")                           \
@@ -77,7 +77,8 @@ namespace script {
   _(TK_BUILT_IN, "built-in", "")                 \
   _(TK_SLICE, "slice", "")                       \
   _(TK_VAR, "variable", "")                      \
-  _(TK_GATHER, "gather", "")
+  _(TK_GATHER, "gather", "")                     \
+  _(TK_NOTHING, "nothing", "")
 static const char* valid_single_char_tokens = "+-*/()[]:,={}><.";
 
 enum TokenKind {

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -107,7 +107,8 @@ struct Parser {
   // precedence strictly greater than 'precedence'
   // precedence == 0 will parse _all_ expressions
   // this is the core loop of 'top-down precedence parsing'
-  TreeRef parseExp(int precedence = 0) {
+  Expr parseExp() { return parseExp(0); }
+  Expr parseExp(int precedence) {
     TreeRef prefix = nullptr;
     int unary_prec;
     if (shared.isUnary(L.cur().kind, &unary_prec)) {
@@ -138,32 +139,22 @@ struct Parser {
 
       prefix = c(kind, pos, {prefix, parseExp(binary_prec)});
     }
-    return prefix;
+    return Expr(prefix);
   }
-  TreeRef
-  parseList(int begin, int sep, int end, std::function<TreeRef(int)> parse) {
+  template<typename T>
+  List<T> parseList(int begin, int sep, int end, T (Parser::*parse)()) {
     auto r = L.cur().range;
-    L.expect(begin);
-    TreeList elements;
+    if (begin != TK_NOTHING)
+      L.expect(begin);
+    std::vector<T> elements;
     if (L.cur().kind != end) {
-      int i = 0;
       do {
-        elements.push_back(parse(i++));
+        elements.push_back((this->*parse)());
       } while (L.nextIf(sep));
     }
-    L.expect(end);
-    return c(TK_LIST, r, std::move(elements));
-  }
-  TreeRef parseNonEmptyList(int sep, std::function<TreeRef(int)> parse) {
-    TreeList elements;
-    int i = 0;
-    do {
-      elements.push_back(parse(i++));
-    } while (L.nextIf(sep));
-    return c(TK_LIST, elements[0]->range(), std::move(elements));
-  }
-  TreeRef parseExpList() {
-    return parseList('(', ',', ')', [&](int i) { return parseExp(); });
+    if (end != TK_NOTHING)
+      L.expect(end);
+    return List<T>::create(r, elements);
   }
   TreeRef parseConst() {
     // 'b' - boolean
@@ -199,7 +190,7 @@ struct Parser {
     int kind = L.cur().kind;
     switch (kind) {
       case '[':
-        return parseList('[', ',', ']', [&](int i) { return parseConst(); });
+        return parseList('[', ',', ']', &Parser::parseConst);
       default:
         return parseConst();
     }
@@ -253,9 +244,6 @@ struct Parser {
 
     return Slice::create(range, Expr(value), Maybe<Expr>(first), Maybe<Expr>(second));
   }
-  TreeRef parseIdentList() {
-    return parseList('(', ',', ')', [&](int i) { return parseIdent(); });
-  }
   TreeRef parseParam() {
     auto typ = parseType();
     if (L.cur().kind != TK_IDENT && typ->trees()[0]->kind() == TK_IDENT) {
@@ -297,12 +285,17 @@ struct Parser {
         return parseWhile();
       case TK_GLOBAL: {
         auto range = L.next().range;
-        std::vector<TreeRef> idents;
-        do {
-          idents.push_back(parseIdent());
-        } while (L.nextIf(','));
-        expectEndOfLine();
-        return c(TK_GLOBAL, range, std::move(idents));
+        auto idents = parseList(TK_NOTHING, ',', TK_NOTHING, &Parser::parseIdent);
+        if (idents.empty())
+          throw ErrorReport(range) << "global statement needs a list of variable names";
+        return Global::create(range, idents);
+      }
+      case TK_RETURN: {
+        auto range = L.next().range;
+        auto values = parseList(TK_NOTHING, ',', TK_NOTHING, &Parser::parseExp);
+        if (values.empty())
+          throw ErrorReport(range) << "return statement needs a list of variable names";
+        return Return::create(range, values);
       }
       default: {
         Expr r = Expr(parseExp());
@@ -331,7 +324,7 @@ struct Parser {
   TreeRef parseOptionalIdentList() {
     TreeRef list = nullptr;
     if (L.cur().kind == '(') {
-      list = parseIdentList();
+      list = parseList('(', ',', ')', &Parser::parseIdent);
     } else {
       list = c(TK_LIST, L.cur().range, {});
     }
@@ -385,15 +378,11 @@ struct Parser {
   TreeRef parseFunction() {
     L.expect(TK_DEF);
     auto name = parseIdent();
-    auto paramlist =
-        parseList('(', ',', ')', [&](int i) { return parseParam(); });
-    L.expect(TK_ARROW);
-    auto retlist =
-        parseList('(', ',', ')', [&](int i) { return parseParam(); });
+    auto paramlist = parseList('(', ',', ')', &Parser::parseParam);
     L.expect(':');
     auto stmts_list = parseStatements();
     return Def::create(name.range(), Ident(name), List<Param>(paramlist),
-                                      List<Param>(retlist), List<Stmt>(stmts_list));
+                       List<Stmt>(stmts_list));
   }
   Lexer& lexer() {
     return L;

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -228,17 +228,17 @@ struct Parser {
       if (L.nextIf(']')) {
         return Gather::create(range, Expr(value), Expr(first));
       } else {
-        first = c(TK_OPTION, range, {first});
+        first = c(TK_NOTHING, range, {first});
       }
     } else {
-      first = c(TK_OPTION, range, {});
+      first = c(TK_NOTHING, range, {});
     }
     L.expect(':');
     // Now we *may* have an expression.
     if (L.cur().kind != ']') {
-      second = c(TK_OPTION, range, {parseExp()});
+      second = c(TK_NOTHING, range, {parseExp()});
     } else {
-      second = c(TK_OPTION, range, {});
+      second = c(TK_NOTHING, range, {});
     }
     L.expect(']');
 
@@ -286,15 +286,11 @@ struct Parser {
       case TK_GLOBAL: {
         auto range = L.next().range;
         auto idents = parseList(TK_NOTHING, ',', TK_NOTHING, &Parser::parseIdent);
-        if (idents.empty())
-          throw ErrorReport(range) << "global statement needs a list of variable names";
         return Global::create(range, idents);
       }
       case TK_RETURN: {
         auto range = L.next().range;
         auto values = parseList(TK_NOTHING, ',', TK_NOTHING, &Parser::parseExp);
-        if (values.empty())
-          throw ErrorReport(range) << "return statement needs a list of variable names";
         return Return::create(range, values);
       }
       default: {

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -97,13 +97,11 @@ void initTreeViewBindings(PyObject *module) {
   py::class_<Def, TreeView>(m, "Def")
     .def(py::init([](const Ident& name,
                      std::vector<Param> params,
-                     std::vector<Param> returns,
                      std::vector<Stmt> body) {
       auto r = name.range();
       return Def::create(r,
                          name,
                          wrap_list(r, std::move(params)),
-                         wrap_list(r, std::move(returns)),
                          wrap_list(r, std::move(body)));
     }));
 
@@ -113,6 +111,10 @@ void initTreeViewBindings(PyObject *module) {
       auto r = lhs.at(0).range();
       auto kind = AssignKind(Compound::create(stringToKind(kind_str), r, {}));
       return Assign::create(r, List<Ident>::create(r, std::move(lhs)), kind, rhs);
+    }));
+  py::class_<Return, Stmt>(m, "Return")
+    .def(py::init([](const SourceRange& range, std::vector<Expr> values) {
+      return Return::create(range, wrap_list(range, std::move(values)));
     }));
   py::class_<If, Stmt>(m, "If")
     .def(py::init([](const SourceRange& range, const Expr& cond, std::vector<Stmt> true_branch, std::vector<Stmt> false_branch) {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -21,12 +21,13 @@ namespace script {
 // Param = Param(Type type, Ident name)                                 TK_PARAM
 //
 // -- TODO: change returns to be a list of expressions
-// Def   = Def(Ident name, List<Param> params, List<Param> returns, List<Stmt> body) TK_DEF
+// Def   = Def(Ident name, List<Param> params, List<Stmt> body)         TK_DEF
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF
 //       | While(Expr cond, List<Stmt> body)                            TK_WHILE
 //       | Global(List<Ident> idents)                                   TK_GLOBAL
 //       | Assign(List<Ident> lhs, AssignType maybe_reduce, Expr rhs)   TK_ASSIGN
+//       | Return(List<Expr> values)                                    TK_RETURN
 //       | ExprStmt(Expr expr)                                          TK_EXPR_STMT
 //
 // Expr  = TernaryIf(Expr cond, Expr true_expr, Expr false_expr)        TK_IF_EXPR
@@ -114,6 +115,7 @@ struct List : public TreeView {
   struct Iterator {
     Iterator(TreeList::const_iterator it) : it(it) {}
     bool operator!=(const Iterator& rhs) const { return it != rhs.it; }
+    bool operator==(const Iterator& rhs) const { return it == rhs.it; }
     T operator*() const { return T(*it); }
     void operator++() { ++it; }
     void operator--() { --it; }
@@ -209,6 +211,7 @@ struct Stmt : public TreeView {
       case TK_WHILE:
       case TK_GLOBAL:
       case TK_ASSIGN:
+      case TK_RETURN:
       case TK_EXPR_STMT:
         return;
       default:
@@ -330,20 +333,16 @@ struct Def : public TreeView {
   List<Param> params() const {
     return List<Param>(subtree(1));
   }
-  List<Param> returns() const {
-    return List<Param>(subtree(2));
-  }
   List<Stmt> statements() const {
-    return List<Stmt>(subtree(3));
+    return List<Stmt>(subtree(2));
   }
   static Def create(
       const SourceRange& range,
       const Ident& name,
       const List<Param>& params,
-      const List<Param>& returns,
       const List<Stmt>& stmts) {
     return Def(Compound::create(
-        TK_DEF, range, {name, params, returns, stmts}));
+        TK_DEF, range, {name, params, stmts}));
   }
 };
 
@@ -435,6 +434,18 @@ struct Assign : public Stmt {
   }
   Expr rhs() const {
     return Expr(subtree(2));
+  }
+};
+
+struct Return : public Stmt {
+  explicit Return(const TreeRef& tree) : Stmt(tree) {
+    tree_->match(TK_RETURN);
+  }
+  List<Expr> values() const {
+    return List<Expr>(subtree(0));
+  }
+  static Return create(const SourceRange& range, const List<Expr>& values) {
+    return Return(Compound::create(TK_RETURN, range, {values}));
   }
 };
 

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -13,7 +13,7 @@ namespace script {
 //
 // A few notes on types and their aliases:
 // - List<T> is really a Tree with kind TK_LIST and elements as subtrees
-// - Maybe<T> is really either a Tree with kind TK_OPTION or T
+// - Maybe<T> is really either a Tree with kind TK_NOTHING or T
 // - Builtin types are: Ident (TK_IDENT), String (TK_STRING),
 //                      Number (TK_NUMBER) and Bool (TK_BOOL)
 //
@@ -160,7 +160,7 @@ struct List : public TreeView {
 template <typename T>
 struct Maybe : public TreeView {
   explicit Maybe(const TreeRef& tree) : TreeView(tree) {
-    if (tree->kind() != TK_OPTION) {
+    if (tree->kind() != TK_NOTHING) {
       std::cout << kindToString(tree->kind()) << std::endl;
       T{tree}; // invoke the constructor to check the type
     }

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -807,21 +807,23 @@ void testBlocks(std::ostream & out) {
 
 
 const static auto cf_examples = R"JIT(
-  def if_test(a, b) -> (c):
+  def if_test(a, b):
       c = 0
       if a < b:
         c = b
       else:
         c = a
-  def if_one(a, b) -> (c):
+      return c
+  def if_one(a, b):
     c = b
     if a < b:
       c = a
-  def while_test(a, i) -> (c):
+    return c
+  def while_test(a, i):
     while i < 3:
       a *= a
       i += 1
-    c = a
+    return a
 )JIT";
 void testControlFlow() {
   script::CompilationUnit cu;


### PR DESCRIPTION
This also makes the syntax recognized by the parser compatible with Python syntax, so it will allow us to reuse Python functions for script tests as well.