### PR TITLE
Fix Variable conversion on the way to/from Python

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -115,4 +115,4 @@ static inline int64_t current_device() {
   return globalContext().current_device();
 }
 
-}
+} // namespace at

--- a/setup.py
+++ b/setup.py
@@ -401,13 +401,13 @@ class install(setuptools.command.install.install):
         if not self.skip_build:
             self.run_command('build_deps')
 
+        setuptools.command.install.install.run(self)
+
         # Copy headers necessary to compile C++ extensions.
         self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
         self.copy_tree('torch/lib/pybind11/include/pybind11/',
                        'torch/lib/include/pybind11')
         self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
-
-        setuptools.command.install.install.run(self)
 
 
 class clean(distutils.command.clean.clean):

--- a/setup.py
+++ b/setup.py
@@ -401,13 +401,13 @@ class install(setuptools.command.install.install):
         if not self.skip_build:
             self.run_command('build_deps')
 
-        setuptools.command.install.install.run(self)
-
         # Copy headers necessary to compile C++ extensions.
         self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
         self.copy_tree('torch/lib/pybind11/include/pybind11/',
                        'torch/lib/include/pybind11')
         self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
+
+        setuptools.command.install.install.run(self)
 
 
 class clean(distutils.command.clean.clean):

--- a/setup.py
+++ b/setup.py
@@ -806,6 +806,7 @@ if __name__ == '__main__':
                 'lib/include/THCUNN/*.cuh',
                 'lib/include/torch/csrc/*.h',
                 'lib/include/torch/csrc/autograd/*.h',
+                'lib/include/torch/csrc/autograd/generated/VariableType.h',
                 'lib/include/torch/csrc/jit/*.h',
                 'lib/include/torch/csrc/utils/*.h',
                 'lib/include/torch/torch.h',

--- a/setup.py
+++ b/setup.py
@@ -806,7 +806,6 @@ if __name__ == '__main__':
                 'lib/include/THCUNN/*.cuh',
                 'lib/include/torch/csrc/*.h',
                 'lib/include/torch/csrc/autograd/*.h',
-                'lib/include/torch/csrc/autograd/generated/VariableType.h',
                 'lib/include/torch/csrc/jit/*.h',
                 'lib/include/torch/csrc/utils/*.h',
                 'lib/include/torch/torch.h',

--- a/setup.py
+++ b/setup.py
@@ -504,6 +504,7 @@ main_sources = [
     "torch/csrc/DynamicTypes.cpp",
     "torch/csrc/assertions.cpp",
     "torch/csrc/byte_order.cpp",
+    "torch/csrc/torch.cpp",
     "torch/csrc/utils.cpp",
     "torch/csrc/utils/cuda_lazy_init.cpp",
     "torch/csrc/utils/invalid_arguments.cpp",

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -11,6 +11,6 @@ struct Doubler {
     return tensor_;
   }
 
-private:
+ private:
   at::Tensor tensor_;
 };

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -2,7 +2,7 @@
 
 struct Doubler {
   Doubler(int A, int B) {
-    tensor_ = at::ones(at::CPU(at::kDouble), {A, B});
+    tensor_ = at::ones(torch::CPU(at::kDouble), {A, B});
     torch::set_requires_grad(tensor_, true);
   }
   at::Tensor forward() {

--- a/test/cpp_extensions/doubler.h
+++ b/test/cpp_extensions/doubler.h
@@ -2,7 +2,8 @@
 
 struct Doubler {
   Doubler(int A, int B) {
-     tensor_ = at::ones(at::CPU(at::kDouble), {A, B});
+    tensor_ = at::ones(at::CPU(at::kDouble), {A, B});
+    torch::set_requires_grad(tensor_, true);
   }
   at::Tensor forward() {
     return tensor_ * 2;

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -6,7 +6,7 @@ at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
 
 struct MatrixMultiplier {
   MatrixMultiplier(int A, int B) {
-    tensor_ = at::ones(at::CPU(at::kDouble), {A, B});
+    tensor_ = at::ones(torch::CPU(at::kDouble), {A, B});
     torch::set_requires_grad(tensor_, true);
   }
   at::Tensor forward(at::Tensor weights) {

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -6,7 +6,7 @@ at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
 
 struct MatrixMultiplier {
   MatrixMultiplier(int A, int B) {
-    tensor_ = at::ones(CPU(kDouble), {A, B});
+    tensor_ = at::ones(at::CPU(at::kDouble), {A, B});
     torch::set_requires_grad(tensor_, true);
   }
   at::Tensor forward(at::Tensor weights) {

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -1,24 +1,23 @@
 #include <torch/torch.h>
 
-using namespace at;
-
-Tensor sigmoid_add(Tensor x, Tensor y) {
+at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
   return x.sigmoid() + y.sigmoid();
 }
 
 struct MatrixMultiplier {
   MatrixMultiplier(int A, int B) {
-     tensor_ = at::ones(CPU(kDouble), {A, B});
+    tensor_ = at::ones(CPU(kDouble), {A, B});
+    torch::set_requires_grad(tensor_, true);
   }
-  Tensor forward(Tensor weights) {
+  at::Tensor forward(at::Tensor weights) {
     return tensor_.mm(weights);
   }
-  Tensor get() const {
+  at::Tensor get() const {
     return tensor_;
   }
 
  private:
-  Tensor tensor_;
+  at::Tensor tensor_;
 };
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -8,7 +8,7 @@ Tensor sigmoid_add(Tensor x, Tensor y) {
 
 struct MatrixMultiplier {
   MatrixMultiplier(int A, int B) {
-     tensor_ = ones(CPU(kDouble), {A, B});
+     tensor_ = at::ones(CPU(kDouble), {A, B});
   }
   Tensor forward(Tensor weights) {
     return tensor_.mm(weights);
@@ -17,7 +17,7 @@ struct MatrixMultiplier {
     return tensor_;
   }
 
-private:
+ private:
   Tensor tensor_;
 };
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -435,11 +435,8 @@ inline bool is_variable(const at::Tensor& tensor) noexcept {
 /// Downcasts the `Tensor` reference to a `Variable` reference. If compiling
 /// in DEBUG mode and the tensor's dynamic type is not in fact `Variable`,
 /// throws a `std::invalid_argument` exception.
-inline Variable& as_variable_ref(at::Tensor& tensor, bool check = false) {
-#ifdef DEBUG
-  check = true;
-#endif
-  if (check && !is_variable(tensor)) {
+inline Variable& as_variable_ref(at::Tensor& tensor) {
+  if (!is_variable(tensor)) {
     throw std::invalid_argument(
         "Attempted to cast a Tensor to a Variable, but "
         "the dynamic type of the value is not Variable.");
@@ -447,13 +444,8 @@ inline Variable& as_variable_ref(at::Tensor& tensor, bool check = false) {
   return static_cast<Variable&>(tensor);
 }
 
-inline const Variable& as_variable_ref(
-    const at::Tensor& tensor,
-    bool check = false) {
-#ifdef DEBUG
-  check = true;
-#endif
-  if (check && !is_variable(tensor)) {
+inline const Variable& as_variable_ref(const at::Tensor& tensor) {
+  if (!is_variable(tensor)) {
     throw std::invalid_argument(
         "Attempted to cast a Tensor to a Variable, but "
         "the dynamic type of the value is not Variable.");

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -158,14 +158,14 @@ void initPythonIRBindings(PyObject * module_) {
     .CREATE_ACCESSOR(Graph,g)
     .CREATE_ACCESSOR(Graphs,gs)
 #undef CREATE_ACCESSOR
-    // Tensor (t_)
+    // Tensor (t_) -- manually written to unwrap the variable into a tensor.
     .def("t_",[](Node & n, const char * name, torch::autograd::Variable v) {
       return n.t_(Symbol(name), std::move(v.data()));
     })
     .def("t", [](Node & n, const char * name) {
       return torch::autograd::make_variable(n.t(Symbol(name)), /*requires_grad=*/false);
     })
-    // Tensors (ts_)
+    // Tensors (ts_) -- manually written to unwrap variables into tensors.
     .def("ts_",[](Node & n, const char * name, std::vector<torch::autograd::Variable> vs) {
       std::vector<at::Tensor> tensors;
       tensors.reserve(vs.size());

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -2,7 +2,25 @@
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
-at::Tensor as_variable(at::Tensor tensor, bool requires_grad) {
-  return autograd::make_variable(tensor, requires_grad);
+autograd::VariableType getType(at::Backend backend, at::ScalarType type) {
+  return autograd::VariableType(
+      &at::globalContext(), &at::getType(backend, type));
+}
+
+autograd::VariableType CPU(at::ScalarType type) {
+  return torch::getType(at::kCPU, type);
+}
+
+autograd::VariableType CUDA(at::ScalarType type) {
+  return torch::getType(at::kCUDA, type);
+}
+
+void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept {
+  autograd::as_variable_ref(tensor, /*check=*/true)
+      .set_requires_grad(requires_grad);
+}
+
+bool requires_grad(const at::Tensor& tensor) noexcept {
+  return autograd::as_variable_ref(tensor, /*check=*/true).requires_grad();
 }
 } // namespace torch

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -1,0 +1,8 @@
+#include <torch/torch.h>
+#include <torch/csrc/autograd/variable.h>
+
+namespace torch {
+at::Tensor as_variable(at::Tensor tensor, bool requires_grad) {
+  return autograd::make_variable(tensor, requires_grad);
+}
+} // namespace torch

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -1,17 +1,17 @@
 #include <torch/torch.h>
+#include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
-autograd::VariableType getType(at::Backend backend, at::ScalarType type) {
-  return autograd::VariableType(
-      &at::globalContext(), &at::getType(backend, type));
+at::Type& getType(at::Backend backend, at::ScalarType type) {
+  return *autograd::VariableType::getType(at::getType(backend, type));
 }
 
-autograd::VariableType CPU(at::ScalarType type) {
+at::Type& CPU(at::ScalarType type) {
   return torch::getType(at::kCPU, type);
 }
 
-autograd::VariableType CUDA(at::ScalarType type) {
+at::Type& CUDA(at::ScalarType type) {
   return torch::getType(at::kCUDA, type);
 }
 

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -16,11 +16,10 @@ at::Type& CUDA(at::ScalarType type) {
 }
 
 void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept {
-  autograd::as_variable_ref(tensor, /*check=*/true)
-      .set_requires_grad(requires_grad);
+  autograd::as_variable_ref(tensor).set_requires_grad(requires_grad);
 }
 
 bool requires_grad(const at::Tensor& tensor) noexcept {
-  return autograd::as_variable_ref(tensor, /*check=*/true).requires_grad();
+  return autograd::as_variable_ref(tensor).requires_grad();
 }
 } // namespace torch

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -32,12 +32,10 @@ struct type_caster<at::Tensor> {
 
   static handle
   cast(at::Tensor src, return_value_policy /* policy */, handle /* parent */) {
-#ifdef DEBUG
     if (!torch::autograd::is_variable(src)) {
       throw std::runtime_error(
           "Expected tensor's dynamic type to be Variable, not Tensor");
     }
-#endif
     return handle(THPVariable_Wrap(torch::autograd::Variable(src)));
   }
 };

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Python.h>
+
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -8,26 +9,36 @@
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/autograd/python_variable.h"
 
+#include <stdexcept>
+
 namespace py = pybind11;
 
 namespace pybind11 { namespace detail {
 
-// handle Tensor <-> at::Tensor conversions
-// Python Variables are unpacked into Tensors
-template <> struct type_caster<at::Tensor> {
-public:
+// torch.autograd.Variable <-> at::Tensor conversions (without unwrapping)
+template <>
+struct type_caster<at::Tensor> {
+ public:
   PYBIND11_TYPE_CASTER(at::Tensor, _("at::Tensor"));
 
   bool load(handle src, bool) {
     PyObject* obj = src.ptr();
     if (THPVariable_Check(obj)) {
-      value = ((THPVariable*)obj)->cdata.data();
+      value = reinterpret_cast<THPVariable*>(obj)->cdata;
       return true;
     }
     return false;
   }
-  static handle cast(at::Tensor src, return_value_policy /* policy */, handle /* parent */) {
-    return handle(THPVariable_Wrap(torch::autograd::make_variable(src, false)));
+
+  static handle
+  cast(at::Tensor src, return_value_policy /* policy */, handle /* parent */) {
+#ifdef DEBUG
+    if (!torch::autograd::is_variable(src)) {
+      throw std::runtime_error(
+          "Expected tensor's dynamic type to be Variable, not Tensor");
+    }
+#endif
+    return handle(THPVariable_Wrap(torch::autograd::Variable(src)));
   }
 };
 

--- a/torch/torch.h
+++ b/torch/torch.h
@@ -1,10 +1,28 @@
 #pragma once
 
 #include <Python.h>
+
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
+#include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/utils/pybind.h>
 
 namespace torch {
-at::Tensor as_variable(at::Tensor tensor, bool requires_grad = false);
+/// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
+/// `ScalarType` (e.g. `at::kDouble`).
+autograd::VariableType getType(at::Backend backend, at::ScalarType type);
+
+/// Returns a `Type` object for the CPU backend and the given `ScalarType`
+/// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
+autograd::VariableType CPU(at::ScalarType type);
+
+/// Returns a `Type` object for the CUDA backend and the given `ScalarType`
+/// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
+autograd::VariableType CUDA(at::ScalarType type);
+
+/// Sets the `requires_grad` property of the given `Tensor`.
+void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept;
+
+/// Returns the `requires_grad` of the given `Tensor`.
+bool requires_grad(const at::Tensor& tensor) noexcept;
 } // namespace torch

--- a/torch/torch.h
+++ b/torch/torch.h
@@ -4,21 +4,20 @@
 
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
-#include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/utils/pybind.h>
 
 namespace torch {
 /// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
 /// `ScalarType` (e.g. `at::kDouble`).
-autograd::VariableType getType(at::Backend backend, at::ScalarType type);
+at::Type& getType(at::Backend backend, at::ScalarType type);
 
 /// Returns a `Type` object for the CPU backend and the given `ScalarType`
 /// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
-autograd::VariableType CPU(at::ScalarType type);
+at::Type& CPU(at::ScalarType type);
 
 /// Returns a `Type` object for the CUDA backend and the given `ScalarType`
 /// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
-autograd::VariableType CUDA(at::ScalarType type);
+at::Type& CUDA(at::ScalarType type);
 
 /// Sets the `requires_grad` property of the given `Tensor`.
 void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept;

--- a/torch/torch.h
+++ b/torch/torch.h
@@ -4,3 +4,7 @@
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/utils/pybind.h>
+
+namespace torch {
+at::Tensor as_variable(at::Tensor tensor, bool requires_grad = false);
+} // namespace torch

--- a/torch/torch.h
+++ b/torch/torch.h
@@ -7,6 +7,10 @@
 #include <torch/csrc/utils/pybind.h>
 
 namespace torch {
+
+// NOTE: This API is currently highly experimental and may change drastically
+// in the near future.
+
 /// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
 /// `ScalarType` (e.g. `at::kDouble`).
 at::Type& getType(at::Backend backend, at::ScalarType type);


### PR DESCRIPTION
This PR changes the behavior of how Python variables (`torch.tensor`) are converted to ATen Tensors/autograd Variables. Previously, we were unwrapping variables into plain tensors on the Python->C++ path, therefore losing autograd history. We would then create *new* variables from the tensors on the C++ -> Python path. The major drawback of this is that it is currently not possible for users to define tensors from C++ (e.g. in extensions) and have them work with the autograd.

Now, Python variables are dynamically converted (i.e. "upcast") to tensors on the Python->C++ path, and then re-wrapped into variables (i.e. without creating a new variable, just using the `Variable` constructor).

For this, I had to add a function to our public C++ api that wraps tensors into variables. To avoid confusion, we want to keep users unaware of the concept of a Variable in C++. Therefore we're not using `torch::autograd::make_variable` which returns a `Variable`, but instead `torch::as_variable()` which returns a `Tensor` and is declared inside `torch/torch.h` and defined out-of-sight in `torch/csrc/torch.cpp` (new file). I went for `as_variable` because it's a bit clearer and also to avoid confusion with `make_variable` on our side (users never see `torch::autograd::make_variable`). Happy to hear thoughts on this.

In the JIT we do want to unwrap/rewrap (according to @zdevito), so we do that manually there.

@zdevito @colesbury @ezyang @apaszke 