### PR TITLE
Allow indexing tensors with both CPU and CUDA tensors

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3,7 +3,6 @@ import tempfile
 import re
 import unittest
 from itertools import repeat
-import random
 
 import torch
 import torch.cuda

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3,6 +3,7 @@ import tempfile
 import re
 import unittest
 from itertools import repeat
+import random
 
 import torch
 import torch.cuda
@@ -1345,6 +1346,36 @@ class TestCuda(TestCase):
 
     def test_advancedindex(self):
         TestTorch._test_advancedindex(self, lambda t: t.cuda())
+
+    def test_advancedindex_mixed_cpu_cuda(self):
+        def test(x, ia, ib):
+            self.assertEqual(x[:, ia, None, ib, 0].cpu(),
+                             x.cpu()[:, ia.cpu(), None, ib.cpu(), 0])
+            self.assertEqual(x[ia], x.cpu()[ia.cpu()])
+
+        # Index cpu tensor with cuda tensor
+        x = torch.randn(3, 4, 4, 4, 3)
+        ia = torch.cuda.LongTensor([0, 2, 1])
+        ib = torch.cuda.LongTensor([0, 2, 1])
+        test(x, ia, ib)
+
+        # Index cuda tensor with cpu tensor
+        x = x.cuda()
+        ia = ia.cpu()
+        ib = ib.cpu()
+        test(x, ia, ib)
+
+        # Index cpu tensor with mixed cpu, cuda tensors
+        x = x.cpu()
+        ia = ia.cpu()
+        ib = ib.cuda()
+        test(x, ia, ib)
+
+        # Index cuda tensor with mixed cpu, cuda tensors
+        x = x.cuda()
+        ia = ia.cpu()
+        ib = ib.cuda()
+        test(x, ia, ib)
 
     def test_advancedindex_big(self):
         TestTorch._test_advancedindex_big(self, lambda t: t.cuda())


### PR DESCRIPTION
This copies `indices` to the same device as `src` and then performs the indexing.

cc @colesbury 

### Test Plan
code reading
Unit test (it's a sanity test and probably doesn't hit any edge cases, but I'm not sure what those look like)