### PR TITLE
Fix memory leak when using multiple workers on Windows

### DIFF
--- a/aten/src/TH/THAllocator.c
+++ b/aten/src/TH/THAllocator.c
@@ -55,7 +55,6 @@ struct THMapAllocatorContext_ {
   HANDLE handle;
   HANDLE event;
   char *eventname;
-  void *data;
 #else
   int fd;
 #endif
@@ -98,7 +97,6 @@ THMapAllocatorContext *THMapAllocatorContext_new(const char *filename, int flags
   ctx->size = 0;
 #ifdef _WIN32
   ctx->handle = INVALID_HANDLE_VALUE;
-  ctx->data = INVALID_HANDLE_VALUE;
 #else
   ctx->fd = -1;
 #endif
@@ -572,7 +570,6 @@ static void THRefcountedMapAllocator_free(void* ctx_, void* data) {
 #ifdef _WIN32
   THMapInfo *info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
   if (THAtomicDecrementRef(&info->refcount)) {
-    ReleaseContext *cxt = (ReleaseContext *)ctx->data;
     SetEvent(ctx->event); 
   }
 #else /* _WIN32 */

--- a/aten/src/TH/THAllocator.c
+++ b/aten/src/TH/THAllocator.c
@@ -196,6 +196,7 @@ static void *_map_alloc(void* ctx_, ptrdiff_t size)
     if (ctx->filename[0] == '/') {
       filename = ctx->filename + 1;
       eventname = ctx->eventname + 1;
+    }
     else {
       filename = ctx->filename;
       eventname = ctx->eventname;

--- a/aten/src/TH/THAllocator.c
+++ b/aten/src/TH/THAllocator.c
@@ -162,10 +162,6 @@ static VOID CALLBACK WaitForReleaseHandle(PVOID lpParam, BOOLEAN TimerOrWaitFire
   if (lpParam) {
     ReleaseContext *ctx = (ReleaseContext *)lpParam;
 
-    HANDLE event = ctx->event;
-    HANDLE handle = ctx->handle;
-    HANDLE wait = ctx->wait;
-
     SetEvent(ctx->event);
     CloseHandle(ctx->event);
     CloseHandle(ctx->handle);

--- a/aten/src/TH/THAllocator.c
+++ b/aten/src/TH/THAllocator.c
@@ -162,17 +162,14 @@ static DWORD WINAPI WaitForReleaseHandle(LPVOID lpParam) {
   while (TRUE) {
     WaitForSingleObject(event, INFINITE);
 
-    THMapInfo *info = (THMapInfo*)(((char*)data) - TH_ALLOC_ALIGNMENT);
-    if (THAtomicGet(&info->refcount) == 0) {
-      SetEvent(event);
-      CloseHandle(event);
-      CloseHandle(handle);
+    SetEvent(event);
+    CloseHandle(event);
+    CloseHandle(handle);
 
-      if(UnmapViewOfFile(((char*)data) - TH_ALLOC_ALIGNMENT) == 0)
-        THError("could not unmap the shared memory file");
+    if(UnmapViewOfFile(((char*)data) - TH_ALLOC_ALIGNMENT) == 0)
+      THError("could not unmap the shared memory file");
 
-      break;
-    }
+    break;
   }
 
   THFree(cxt);
@@ -196,15 +193,13 @@ static void *_map_alloc(void* ctx_, ptrdiff_t size)
     char *eventname;
     LARGE_INTEGER hfilesz;
 
-    if (ctx->filename[0] == '/')
+    if (ctx->filename[0] == '/') {
       filename = ctx->filename + 1;
-    else
-      filename = ctx->filename;
-
-    if (ctx->eventname[0] == '/')
       eventname = ctx->eventname + 1;
-    else
+    else {
+      filename = ctx->filename;
       eventname = ctx->eventname;
+    }
 
     hfilesz.QuadPart = size;
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -413,9 +413,6 @@ class DataLoader(object):
             raise ValueError('num_workers cannot be negative; '
                              'use num_workers=0 to disable multiprocessing.')
 
-        if sys.platform == "win32" and self.num_workers > 0:
-            raise ValueError('num_workers > 0 is not supported on Windows')
-
         if batch_sampler is None:
             if sampler is None:
                 if shuffle:


### PR DESCRIPTION
The memory leak is caused by the difference in using FileMapping(mmap) on Windows. On Windows, FileMapping objects should be closed by all related processes and then it can be released. And there's no other way to explicitly delete it.(Like shm_unlink)
When multiprocessing is on, the child process will create a FileMapping and then the main process will open it. After that, at some time, the child process will try to release it but it's reference count is non-zero so it cannot be released at that time. But the current code does not provide a chance to let it close again when possible.
This PR targets #5590.
Current Progress:
The memory leak when num_worker=1 should be solved. However, further work has to be done for more workers.
Error type 1(unrelated filemapping handle get killed):
```pytb
Traceback (most recent call last):
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\process.py", line 258, in _bootstrap
    self.run()
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\utils\data\dataloader.py", line 61, in _worker_loop
    data_queue.put((idx, samples))
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\queues.py", line 344, in put
    self._writer.send_bytes(obj)
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\connection.py", line 200, in send_bytes
    self._send_bytes(m[offset:offset + size])
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\connection.py", line 280, in _send_bytes
    ov, err = _winapi.WriteFile(self._handle, buf, overlapped=True)
OSError: [WinError 6] The handle is invalid
```
Error type 2(unrelated event handle get killed):
```pytb
Traceback (most recent call last):
  File "test.py", line 22, in <module>
    memory_error()
  File "test.py", line 17, in memory_error
    for i in dl:
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\utils\data\dataloader.py", line 277, in __next__
    idx, batch = self._get_batch()
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\utils\data\dataloader.py", line 256, in _get_batch
    return self.data_queue.get()
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\queues.py", line 337, in get
    return _ForkingPickler.loads(res)
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\multiprocessing\reductions.py", line 86, in rebuild_storage_filename
    storage = cls._new_shared_filename(manager, handle, size)
RuntimeError: Couldn't open shared event: <torch_17608_4052021606_event>, error code: <2> at D:\Projects\pytorch-scripts\pytorch\aten\src\TH\THAllocator.c:245
Exception ignored in: <bound method DataLoaderIter.__del__ of <torch.utils.data.dataloader.DataLoaderIter object at 0x000002303FB255C0>>
Traceback (most recent call last):
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\utils\data\dataloader.py", line 341, in __del__
    self._shutdown_workers()
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\utils\data\dataloader.py", line 322, in _shutdown_workers
    self.data_queue.get()
  File "C:\Anaconda2\envs\test_new\lib\multiprocessing\queues.py", line 337, in get
    return _ForkingPickler.loads(res)
  File "C:\Anaconda2\envs\test_new\lib\site-packages\torch\multiprocessing\reductions.py", line 86, in rebuild_storage_filename
    storage = cls._new_shared_filename(manager, handle, size)
RuntimeError: Couldn't open shared event: <torch_18984_3257952678_event>, error code: <2> at D:\Projects\pytorch-scripts\pytorch\aten\src\TH\THAllocator.c:245
```