### PR TITLE
Disallow num_workers > 0 for DataLoader on Windows

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -410,6 +410,9 @@ class DataLoader(object):
             raise ValueError('num_workers cannot be negative; '
                              'use num_workers=0 to disable multiprocessing.')
 
+        if sys.platform == "win32" and self.num_workers > 0:
+            raise ValueError('num_workers > 0 is not supported on Windows')
+
         if batch_sampler is None:
             if sampler is None:
                 if shuffle:


### PR DESCRIPTION
Using DataLoader with num_workers > 0 is known to cause CUDA out-of-memory issue on Windows. 

Example: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-test/2436//console

This issue has already been noted in https://github.com/pytorch/pytorch/issues/4092.