### PR TITLE
release() does not need to be virtual

### DIFF
--- a/aten/src/ATen/Retainable.h
+++ b/aten/src/ATen/Retainable.h
@@ -11,7 +11,7 @@ struct Retainable {
   void retain() {
     ++refcount;
   }
-  virtual void release() {
+  void release() {
     if(--refcount == 0) {
       delete this;
     }


### PR DESCRIPTION
Only the destructor `~Retainable()` needs to be virtual.