### PR TITLE
Enable documentation for C++ extensions on the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ test/data/linear.pt
 .ninja_log
 compile_commands.json
 *.egg-info/
+docs/source/_static/img/activation/

--- a/docs/source/cpp_extension.rst
+++ b/docs/source/cpp_extension.rst
@@ -1,0 +1,11 @@
+torch.utils.cpp_extension
+=========================
+
+.. currentmodule:: torch.utils.cpp_extension
+.. autofunction:: CppExtension
+.. autofunction:: CUDAExtension
+.. autofunction:: load
+.. autofunction:: BuildExtension
+.. autofunction:: include_paths
+.. autofunction:: check_compiler_abi_compatibility
+.. autofunction:: verify_ninja_availability

--- a/docs/source/cpp_extension.rst
+++ b/docs/source/cpp_extension.rst
@@ -4,8 +4,8 @@ torch.utils.cpp_extension
 .. currentmodule:: torch.utils.cpp_extension
 .. autofunction:: CppExtension
 .. autofunction:: CUDAExtension
-.. autofunction:: load
 .. autofunction:: BuildExtension
+.. autofunction:: load
 .. autofunction:: include_paths
 .. autofunction:: check_compiler_abi_compatibility
 .. autofunction:: verify_ninja_availability

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    torch.distributed <distributed>
    torch.legacy <legacy>
    cuda
+   cpp_extension
    ffi
    data
    model_zoo

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -290,6 +290,14 @@ def load(name,
 
     Returns:
         The loaded PyTorch extension as a Python module.
+
+    Example:
+        >>> from torch.utils.cpp_extension import load
+        >>> module = load(
+                name='extension',
+                sources=['extension.cpp', 'extension_kernel.cu'],
+                extra_cflags=['-O2'],
+                verbose=True)
     '''
 
     verify_ninja_availability()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -82,17 +82,17 @@ def check_compiler_abi_compatibility(compiler):
 
 class BuildExtension(build_ext):
     '''
-    A custom `setuptools` build extension .
+    A custom :mod:`setuptools` build extension .
 
-    This `setuptools.build_ext` subclass takes care of passing the minimum
-    required compiler flags (e.g. `-std=c++11`) as well as mixed C++/CUDA
-    compilation (and support for CUDA files in general).
+    This :class:`setuptools.build_ext` subclass takes care of passing the
+    minimum required compiler flags (e.g. ``-std=c++11``) as well as mixed
+    C++/CUDA compilation (and support for CUDA files in general).
 
-    When using `BuildExtension`, it is allowed to supply a dictionary for
-    `extra_compile_args` (rather than the usual list) that maps from languages
-    (`cxx` or `cuda`) to a list of additional compiler flags to supply to the
-    compiler. This makes it possible to supply different flags to the C++ and
-    CUDA compiler during mixed compilation.
+    When using :class:`BuildExtension`, it is allowed to supply a dictionary
+    for ``extra_compile_args`` (rather than the usual list) that maps from
+    languages (``cxx`` or ``cuda``) to a list of additional compiler flags to
+    supply to the compiler. This makes it possible to supply different flags to
+    the C++ and CUDA compiler during mixed compilation.
     '''
 
     def build_extensions(self):
@@ -152,12 +152,13 @@ class BuildExtension(build_ext):
 
 def CppExtension(name, sources, *args, **kwargs):
     '''
-    Create a `setuptools.Extension` for C++.
+    Creates a :class:`setuptools.Extension` for C++.
 
-    Convenience method that creates a `setuptools.Extension` with the bare
-    minimum (but often sufficient) arguments to build a C++ extension.
+    Convenience method that creates a :class:`setuptools.Extension` with the
+    bare minimum (but often sufficient) arguments to build a C++ extension.
 
-    All arguments are forwarded to the `setuptools.Extension` constructor.
+    All arguments are forwarded to the :class:`setuptools.Extension`
+    constructor.
 
     Example:
         >>> from setuptools import setup
@@ -183,13 +184,15 @@ def CppExtension(name, sources, *args, **kwargs):
 
 def CUDAExtension(name, sources, *args, **kwargs):
     '''
-    Create a `setuptools.Extension` for CUDA/C++.
+    Creates a :class:`setuptools.Extension` for CUDA/C++.
 
-    Convenience method that creates a `setuptools.Extension` with the bare
-    minimum (but often sufficient) arguments to build a CUDA/C++ extension.
-    This includes the CUDA include path, library path and runtime library.
+    Convenience method that creates a :class:`setuptools.Extension` with the
+    bare minimum (but often sufficient) arguments to build a CUDA/C++
+    extension. This includes the CUDA include path, library path and runtime
+    library.
 
-    All arguments are forwarded to the `setuptools.Extension` constructor.
+    All arguments are forwarded to the :class:`setuptools.Extension`
+    constructor.
 
     Example:
         >>> from setuptools import setup
@@ -226,7 +229,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
 def include_paths(cuda=False):
     '''
-    Return include paths required to build a C++ extension.
+    Get the include paths required to build a C++ or CUDA extension.
 
     Args:
         cuda: If `True`, includes CUDA-specific include paths.
@@ -258,7 +261,7 @@ def load(name,
          build_directory=None,
          verbose=False):
     '''
-    Loads a C++ PyTorch extension.
+    Loads a PyTorch C++ extension just-in-time (JIT).
 
     To load an extension, a Ninja build file is emitted, which is used to
     compile the given sources into a dynamic library. This library is
@@ -266,30 +269,31 @@ def load(name,
     returned from this function, ready for use.
 
     By default, the directory to which the build file is emitted and the
-    resulting library compiled to is `<tmp>/torch_extensions/<name>`, where
-    `<tmp>` is the temporary folder on the current platform and `<name>` the
-    name of the extension. This location can be overriden in two ways. First,
-    if the `TORCH_EXTENSIONS_DIR` environment variable is set, it replaces
-    `<tmp>/torch_extensions` and all extensions will be compiled into
-    subfolders of this directory. Second, if the `build_directory` argument to
-    this function is supplied, it overrides the entire path, i.e. the library
-    will be compiled into that folder directly.
+    resulting library compiled to is ``<tmp>/torch_extensions/<name>``, where
+    ``<tmp>`` is the temporary folder on the current platform and ``<name>``
+    the name of the extension. This location can be overriden in two ways.
+    First, if the ``TORCH_EXTENSIONS_DIR`` environment variable is set, it
+    replaces ``<tmp>/torch_extensions`` and all extensions will be compiled
+    into subfolders of this directory. Second, if the ``build_directory``
+    argument to this function is supplied, it overrides the entire path, i.e.
+    the library will be compiled into that folder directly.
 
-    To compile the sources, the default system compiler (`c++`) is used, which
-    can be overriden by setting the CXX environment variable. To pass
-    additional arguments to the compilation process, `extra_cflags` or
-    `extra_ldflags` can be provided. For example, to compile your extension
-    with optimizations, pass `extra_cflags=['-O3']`. You can also use
-    `extra_cflags` to pass further include directories (`-I`).
+    To compile the sources, the default system compiler (``c++``) is used,
+    which can be overriden by setting the ``CXX`` environment variable. To pass
+    additional arguments to the compilation process, ``extra_cflags`` or
+    ``extra_ldflags`` can be provided. For example, to compile your extension
+    with optimizations, pass ``extra_cflags=['-O3']``. You can also use
+    ``extra_cflags`` to pass further include directories.
 
     CUDA support with mixed compilation is provided. Simply pass CUDA source
-    files (`.cu` or `.cuh`) along with other sources. Such files will be
+    files (``.cu`` or ``.cuh``) along with other sources. Such files will be
     detected and compiled with nvcc rather than the C++ compiler. This includes
     passing the CUDA lib64 directory as a library directory, and linking
-    `cudart`. You can pass additional flags to nvcc via `extra_cuda_cflags`,
-    just like with `extra_cflags` for C++. Various heuristics for finding the
-    CUDA install directory are used, which usually work fine. If not, setting
-    the `CUDA_HOME` environment variable is the safest option.
+    ``cudart``. You can pass additional flags to nvcc via
+    ``extra_cuda_cflags``, just like with ``extra_cflags`` for C++. Various
+    heuristics for finding the CUDA install directory are used, which usually
+    work fine. If not, setting the ``CUDA_HOME`` environment variable is the
+    safest option.
 
     Args:
         name: The name of the extension to build. This MUST be the same as the
@@ -302,7 +306,7 @@ def load(name,
         extra_include_paths: optional list of include directories to forward
             to the build.
         build_directory: optional path to use as build workspace.
-        verbose: If `True`, turns on verbose logging of load steps.
+        verbose: If ``True``, turns on verbose logging of load steps.
 
     Returns:
         The loaded PyTorch extension as a Python module.
@@ -358,6 +362,10 @@ def load(name,
 
 
 def verify_ninja_availability():
+    '''
+    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
+    available on the system.
+    '''
     with open(os.devnull, 'wb') as devnull:
         try:
             subprocess.check_call('ninja --version'.split(), stdout=devnull)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -50,7 +50,7 @@ def check_compiler_abi_compatibility(compiler):
     Verifies that the given compiler is ABI-compatible with PyTorch.
 
     Arguments:
-        compiler (str): The compiler executable name to check (e.g. 'g++').
+        compiler (str): The compiler executable name to check (e.g. ``g++``).
             Must be executable in a shell process.
 
     Returns:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -160,11 +160,19 @@ def CppExtension(name, sources, *args, **kwargs):
     All arguments are forwarded to the `setuptools.Extension` constructor.
 
     Example:
-        >>> from torch.utils.cpp_extension import CppExtension
-        >>> CppExtension(
+        >>> from setuptools import setup
+        >>> from torch.utils.cpp_extension import BuildExtension, CppExtension
+        >>> setup(
                 name='extension',
-                sources=['extension.cpp'],
-                extra_compile_args=['-g'])
+                ext_modules=[
+                    CppExtension(
+                        name='extension',
+                        sources=['extension.cpp'],
+                        extra_compile_args=['-g'])),
+                ],
+                cmdclass={
+                    'build_ext': BuildExtension
+                })
     '''
     include_dirs = kwargs.get('include_dirs', [])
     include_dirs += include_paths()
@@ -184,12 +192,20 @@ def CUDAExtension(name, sources, *args, **kwargs):
     All arguments are forwarded to the `setuptools.Extension` constructor.
 
     Example:
-        >>> from torch.utils.cpp_extension import CUDAExtension
-        >>> CUDAExtension(
+        >>> from setuptools import setup
+        >>> from torch.utils.cpp_extension import BuildExtension, CppExtension
+        >>> setup(
                 name='cuda_extension',
-                sources=['extension.cpp', 'extension_kernel.cu'],
-                extra_compile_args={'cxx': ['-g'],
-                                    'nvcc': ['-O2']})
+                ext_modules=[
+                    CUDAExtension(
+                            name='cuda_extension',
+                            sources=['extension.cpp', 'extension_kernel.cu'],
+                            extra_compile_args={'cxx': ['-g'],
+                                                'nvcc': ['-O2']})
+                ],
+                cmdclass={
+                    'build_ext': BuildExtension
+                })
     '''
     library_dirs = kwargs.get('library_dirs', [])
     library_dirs.append(_join_cuda_home('lib64'))


### PR DESCRIPTION
This PR adds `docs/source/cpp_extension.rst` which exposes Python documentation into our public docs.

Also brushes up some documentation.

This is independent of the tutorial I submitted in an earlier PR (I will move it into `pytorch/tutorials`).

@apaszke @soumith @SsnL 