### PR TITLE
Make torch.arange consistent with numpy.arange

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2828,14 +2828,20 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
 }
 
 void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step) {
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-  int m = fmod(xmax - xmin, step) == 0;
-#else
-  int m = (xmax - xmin) % step == 0;
-#endif
-  if (m)
-    xmax -= step;
-  THTensor_(range)(r_, xmin, xmax, step);
+  ptrdiff_t size;
+  real i = 0;
+
+  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
+              , 2, "upper bound and larger bound incoherent with step sign");
+
+  size = (ptrdiff_t) ceil((xmax - xmin) / step);
+
+  if (THTensor_(nElement)(r_) != size) {
+    THTensor_(resize1d)(r_, size);
+  }
+
+  TH_TENSOR_APPLY(real, r_, *r__data = xmin + (i++)*step;);
 }
 
 void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n)

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2835,7 +2835,7 @@ void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step) {
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
 
-  size = (ptrdiff_t) ceil((float)(xmax - xmin) / step);
+  size = (ptrdiff_t) ceil((double)(xmax - xmin) / step);
 
   if (THTensor_(nElement)(r_) != size) {
     THTensor_(resize1d)(r_, size);

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2816,7 +2816,7 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
 
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
-              , 2, "upper bound and larger bound incoherent with step sign");
+              , 2, "upper bound and larger bound inconsistent with step sign");
 
   size = (ptrdiff_t) (((xmax - xmin) / step) + 1);
 
@@ -2833,7 +2833,7 @@ void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step) {
 
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
-              , 2, "upper bound and larger bound incoherent with step sign");
+              , 2, "upper bound and larger bound inconsistent with step sign");
 
   size = (ptrdiff_t) ceil((float)(xmax - xmin) / step);
 

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2835,7 +2835,7 @@ void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step) {
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
 
-  size = (ptrdiff_t) ceil((xmax - xmin) / step);
+  size = (ptrdiff_t) ceil((float)(xmax - xmin) / step);
 
   if (THTensor_(nElement)(r_) != size) {
     THTensor_(resize1d)(r_, size);

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2814,7 +2814,7 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
   ptrdiff_t size;
   real i = 0;
 
-  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck(step > 0 || step < 0, 3, "step must be nonzero");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
 
@@ -2831,7 +2831,7 @@ void THTensor_(arange)(THTensor *r_, accreal xmin, accreal xmax, accreal step) {
   ptrdiff_t size;
   real i = 0;
 
-  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck(step > 0 || step < 0, 3, "step must be nonzero");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
 

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -495,7 +495,7 @@ void THCTensor_(arange)(THCState* state, THCTensor *r_, accreal xmin, accreal xm
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
-  ptrdiff_t size = (ptrdiff_t) ceil(ScalarConvert<accreal, float>::to(xmax - xmin) / step);
+  ptrdiff_t size = (ptrdiff_t) ceil(ScalarConvert<accreal, double>::to(xmax - xmin) / step);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
   THCTensor *r = THCTensor_(isContiguous)(state, r_)
                  ? r_

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -477,7 +477,7 @@ void THCTensor_(range)(THCState *state, THCTensor *r_, accreal xmin, accreal xma
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
-              , 2, "upper bound and larger bound incoherent with step sign");
+              , 2, "upper bound and larger bound inconsistent with step sign");
   ptrdiff_t size = (ptrdiff_t) (((xmax - xmin) / step) + 1);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
   THCTensor *r = THCTensor_(isContiguous)(state, r_)
@@ -494,7 +494,7 @@ void THCTensor_(arange)(THCState* state, THCTensor *r_, accreal xmin, accreal xm
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
-              , 2, "upper bound and larger bound incoherent with step sign");
+              , 2, "upper bound and larger bound inconsistent with step sign");
   ptrdiff_t size = (ptrdiff_t) ceil(ScalarConvert<accreal, float>::to(xmax - xmin) / step);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
   THCTensor *r = THCTensor_(isContiguous)(state, r_)

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -495,7 +495,7 @@ void THCTensor_(arange)(THCState* state, THCTensor *r_, accreal xmin, accreal xm
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
-  ptrdiff_t size = (ptrdiff_t) ceil((xmax - xmin) / step);
+  ptrdiff_t size = (ptrdiff_t) ceil(ScalarConvert<accreal, float>::to(xmax - xmin) / step);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
   THCTensor *r = THCTensor_(isContiguous)(state, r_)
                  ? r_

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -475,35 +475,31 @@ void THCTensor_(logspace)(THCState *state, THCTensor *r_, real a, real b, int64_
 
 void THCTensor_(range)(THCState *state, THCTensor *r_, accreal xmin, accreal xmax, accreal step) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck(step > 0 || step < 0, 3, "step must be nonzero");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
   ptrdiff_t size = (ptrdiff_t) (((xmax - xmin) / step) + 1);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
-  THCTensor *r = THCTensor_(isContiguous)(state, r_)
-                 ? r_
-                 : THCTensor_(newContiguous)(state, r_);
+  THCTensor *r = THCTensor_(newContiguous)(state, r_);
   LinspaceOp<real,accreal> linspace_method(xmin, step);
   thrust::device_ptr<real> data_(THCTensor_(data)(state, r));
   thrust::tabulate(data_, data_ + size, linspace_method);
-  if (!THCTensor_(isContiguous)(state, r_)) THCTensor_(freeCopyTo)(state, r, r_);
+  THCTensor_(freeCopyTo)(state, r, r_);
   THCudaCheck(cudaGetLastError());
 }
 
 void THCTensor_(arange)(THCState* state, THCTensor *r_, accreal xmin, accreal xmax, accreal step) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, r_));
-  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck(step > 0 || step < 0, 3, "step must be nonzero");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound inconsistent with step sign");
   ptrdiff_t size = (ptrdiff_t) ceil(ScalarConvert<accreal, double>::to(xmax - xmin) / step);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
-  THCTensor *r = THCTensor_(isContiguous)(state, r_)
-                 ? r_
-                 : THCTensor_(newContiguous)(state, r_);
+  THCTensor *r = THCTensor_(newContiguous)(state, r_);
   LinspaceOp<real,accreal> linspace_method(xmin, step);
   thrust::device_ptr<real> data_(THCTensor_(data)(state, r));
   thrust::tabulate(data_, data_ + size, linspace_method);
-  if (!THCTensor_(isContiguous)(state, r_)) THCTensor_(freeCopyTo)(state, r, r_);
+  THCTensor_(freeCopyTo)(state, r, r_);
   THCudaCheck(cudaGetLastError());
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1361,13 +1361,13 @@ class TestTorch(TestCase):
         res1 = torch.arange(0.6, 0.89, 0.1, out=torch.FloatTensor())
         self.assertEqual(res1.size(0), 3)
         res1 = torch.arange(1, 10, 0.3, out=torch.FloatTensor())
-        self.assertEqual(res1.size(0), 31)
+        self.assertEqual(res1.size(0), 30)
 
         # DoubleTensor
         res1 = torch.arange(0.6, 0.89, 0.1, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 3)
         res1 = torch.arange(1, 10, 0.3, out=torch.DoubleTensor())
-        self.assertEqual(res1.size(0), 31)
+        self.assertEqual(res1.size(0), 30)
 
         # Check that it's exclusive
         r = torch.arange(0, 5)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1359,15 +1359,19 @@ class TestTorch(TestCase):
 
         # FloatTensor
         res1 = torch.arange(0.6, 0.89, 0.1, out=torch.FloatTensor())
-        self.assertEqual(res1.size(0), 3)
+        self.assertEqual(res1, [0.6, 0.7, 0.8])
         res1 = torch.arange(1, 10, 0.3, out=torch.FloatTensor())
         self.assertEqual(res1.size(0), 30)
+        self.assertEqual(res1[0], 1)
+        self.assertEqual(res1[29], 9.7)
 
         # DoubleTensor
         res1 = torch.arange(0.6, 0.89, 0.1, out=torch.DoubleTensor())
-        self.assertEqual(res1.size(0), 3)
+        self.assertEqual(res1, [0.6, 0.7, 0.8])
         res1 = torch.arange(1, 10, 0.3, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 30)
+        self.assertEqual(res1[0], 1)
+        self.assertEqual(res1[29], 9.7)
 
         # Check that it's exclusive
         r = torch.arange(0, 5)


### PR DESCRIPTION
This should fix #5556. I couldn't reproduce on CUDA, but I changed that as well anyways.

```
>>> torch.arange(0.1, 0.50, 0.05)

 0.1000
 0.1500
 0.2000
 0.2500
 0.3000
 0.3500
 0.4000
 0.4500
[torch.FloatTensor of size 8]
```