### PR TITLE
fix issue 5556: arange floating point error

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -2818,7 +2818,7 @@ void THTensor_(range)(THTensor *r_, accreal xmin, accreal xmax, accreal step)
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
 
-  size = (ptrdiff_t) (((xmax - xmin) / step) + 1);
+  size = (ptrdiff_t) ((xmax / step - xmin / step) + 1);
 
   if (THTensor_(nElement)(r_) != size) {
     THTensor_(resize1d)(r_, size);

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -478,7 +478,7 @@ void THCTensor_(range)(THCState *state, THCTensor *r_, accreal xmin, accreal xma
   THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin))
               , 2, "upper bound and larger bound incoherent with step sign");
-  ptrdiff_t size = (ptrdiff_t) (((xmax - xmin) / step) + 1);
+  ptrdiff_t size = (ptrdiff_t) ((xmax / step - xmin / step) + 1);
   if (THCTensor_(nElement)(state, r_) != size) THCTensor_(resize1d)(state, r_, size);
   THCTensor *r = THCTensor_(isContiguous)(state, r_)
                  ? r_

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1421,6 +1421,10 @@ class TestTorch(TestCase):
         self.assertEqual(r1, r2, 0)
         self.assertEqual(r2, r3[:-1], 0)
 
+        # check floating point error
+        r = torch.arange(0.1, 0.50, 0.05)
+        self.assertEqual(r.size(0), 8)
+
     @staticmethod
     def _select_broadcastable_dims(dims_full=None):
         # select full dimensionality

--- a/torch/lib/THD/master_worker/master/generic/THDTensorMath.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensorMath.cpp
@@ -359,7 +359,7 @@ void THDTensor_(range)(THDTensor *r_, accreal xmin,
   THArgCheck(((step > 0) && (xmax >= xmin)) || ((step < 0) && (xmax <= xmin)),
               2, "upper bound and larger bound incoherent with step sign");
 
-  ptrdiff_t size = static_cast<ptrdiff_t>((((xmax - xmin) / step) + 1));
+  ptrdiff_t size = static_cast<ptrdiff_t>(((xmax / step - xmin / step) + 1));
 
   if (THDTensor_(nElement)(r_) != size)
     THDTensor_(resize1d)(r_, size);


### PR DESCRIPTION
One can use `a / c - b / c` to reduce floating point error of `(a - b) / c`