### PR TITLE
replace ExportProxy

### DIFF
--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -63,6 +63,12 @@ void initPythonTracerBindings(PyObject* module_) {
   m.def("_get_tracing_state", [](const variable_list& vars) {
     return getTracingState(vars);
   });
+  m.def("_get_value_trace", [](std::shared_ptr<TracingState>& state, const Variable& var) {
+    return getValueTrace(state, var);
+  });
+  m.def("_set_value_trace", [](std::shared_ptr<TracingState>& state, const Variable& var, Value* value) {
+    return setValueTrace(state, var, value);
+  });
   m.def("_is_tracing", [](const variable_list& vars) {
     return isTracingVar(vars);
   });


### PR DESCRIPTION
```
do away with ExportProxy hack in onnx export

ExportProxy was a mechanism to reuse the code that supported exporting
autograd Functions to support overriding arbitrary python
functions. However, it had some serious downsides

- only works on some functions (all args must be Variable)
- complicated
- bad error messages in some cases

Instead, just expose enough functionality to python to perform the
necessary logic explicitly.
```