### PR TITLE
Prefix DataLoaderIter with underscore to discourage subclassing

### DIFF
--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -149,7 +149,7 @@ static PyObject *THPModule_updateWorkerPIDs(PyObject *module, PyObject *args) {
   }
   int64_t key = THPUtils_unpackLong(PyTuple_GET_ITEM(args, 0));
   if (worker_pids.find(key) != worker_pids.end()) {
-    throw ValueError("_update_worker_pids should be called only once for each DataLoader.");
+    throw ValueError("_update_worker_pids should be called only once for each _DataLoaderIter.");
   }
   PyObject *child_pids = PyTuple_GET_ITEM(args, 1);
   if (!PyTuple_Check(child_pids)) {
@@ -176,7 +176,7 @@ static PyObject *THPModule_removeWorkerPIDs(PyObject *module, PyObject *loader_i
   int64_t key = THPUtils_unpackLong(loader_id);
   auto it = worker_pids.find(key);
   if (it == worker_pids.end()) {
-    throw ValueError("Cannot find worker information for DataLoader with id %ld.", key);
+    throw ValueError("Cannot find worker information for _DataLoaderIter with id %ld.", key);
   }
   worker_pids.erase(it);
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -182,7 +182,7 @@ def _set_SIGCHLD_handler():
     _SIGCHLD_handler_set = True
 
 
-class DataLoaderIter(object):
+class _DataLoaderIter(object):
     r"""Iterates once over the DataLoader's dataset, as specified by the sampler"""
 
     def __init__(self, loader):
@@ -309,7 +309,7 @@ class DataLoaderIter(object):
         # Probably the best way to do this is by moving the sample pushing
         # to a separate thread and then just sharing the data queue
         # but signalling the end is tricky without a non-blocking API
-        raise NotImplementedError("DataLoaderIterator cannot be pickled")
+        raise NotImplementedError("_DataLoaderIter cannot be pickled")
 
     def _shutdown_workers(self):
         try:
@@ -425,7 +425,7 @@ class DataLoader(object):
         self.batch_sampler = batch_sampler
 
     def __iter__(self):
-        return DataLoaderIter(self)
+        return _DataLoaderIter(self)
 
     def __len__(self):
         return len(self.batch_sampler)


### PR DESCRIPTION
Discourage subclassing `DataLoaderIter` so that errors like #5430 hopefully won't happen as often.

@apaszke 