### PR TITLE
Fix compilation with CUDA < 8.0

### DIFF
--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -791,11 +791,7 @@ struct TensorDigammaOp {
   using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
-#if (defined __CUDA_ARCH__) && (CUDART_VERSION < 8000)
     const compute_type PI = 3.14159265358979323846;
-#else
-    static const compute_type PI = 3.14159265358979323846;
-#endif
     compute_type x = ScalarConvert<real, compute_type>::to(*in);
     compute_type result = 0;
     if (x < 0.5f) {
@@ -817,11 +813,7 @@ struct TensorTrigammaOp {
   using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
-#if (defined __CUDA_ARCH__) && (CUDART_VERSION < 8000)
     const compute_type PI = 3.14159265358979323846;
-#else
-    static const compute_type PI = 3.14159265358979323846;
-#endif
     compute_type x = ScalarConvert<real, compute_type>::to(*in);
     compute_type sign = +1;
     compute_type result = 0;

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -791,7 +791,11 @@ struct TensorDigammaOp {
   using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
+#if (defined __CUDA_ARCH__) && (CUDART_VERSION < 8000)
+    const compute_type PI = 3.14159265358979323846;
+#else
     static const compute_type PI = 3.14159265358979323846;
+#endif
     compute_type x = ScalarConvert<real, compute_type>::to(*in);
     compute_type result = 0;
     if (x < 0.5f) {
@@ -813,7 +817,11 @@ struct TensorTrigammaOp {
   using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
+#if (defined __CUDA_ARCH__) && (CUDART_VERSION < 8000)
+    const compute_type PI = 3.14159265358979323846;
+#else
     static const compute_type PI = 3.14159265358979323846;
+#endif
     compute_type x = ScalarConvert<real, compute_type>::to(*in);
     compute_type sign = +1;
     compute_type result = 0;

--- a/torch/lib/nccl/Makefile
+++ b/torch/lib/nccl/Makefile
@@ -51,6 +51,12 @@ NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -lineinfo -std=c++11 -maxrregcount 9
 # Use addprefix so that we can specify more than one path
 LDFLAGS    := $(addprefix -L,${CUDA_LIB}) -lcudart -lrt
 
+# If CUDA < 8.0, add workaround C++ flags
+CUDA_MAJOR_LT_8 := $(shell [ $(CUDA_MAJOR) -lt 8 ] && echo true)
+ifeq ($(CUDA_MAJOR_LT_8), true)
+CXXFLAGS += -D_FORCE_INLINES -D_MWAITXINTRIN_H_INCLUDED -D__STRICT_ANSI__
+endif
+
 ifeq ($(DEBUG), 0)
 NVCUFLAGS += -O3
 CXXFLAGS  += -O3
@@ -252,4 +258,3 @@ fortest : forlib
 	$(MAKE) -C fortran test
 forclean :
 	$(MAKE) -C fortran clean
-


### PR DESCRIPTION
I noticed that I could not compile the master with CUDA 7.5 anymore. I know it's not officially supported anymore, but I thought this were easy fixes.

Fixed issues:
- CUDA versions prior to 8.0 do not allow static variables in device code, other than __shared__.
- nccl needed workaround flags for CUDA < 8.0 and GCC >= 4.9
