### PR TITLE
Alias torch.diagonal, torch.diagflat

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -38,7 +38,7 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
 }
 
 Tensor diagflat(const Tensor& self, int64_t offset) {
-  return self.view(-1).diag(offset);
+  return self.contiguous().view(-1).diag(offset);
 }
 
 Tensor diagonal(const Tensor& self, int64_t offset) {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -37,6 +37,17 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
   return self.split(split_size, dim);
 }
 
+Tensor diagflat(const Tensor& self, int64_t offset) {
+  return self.view(-1).diag(offset);
+}
+
+Tensor diagonal(const Tensor& self, int64_t offset) {
+  if (self.dim() != 2) {
+    throw std::runtime_error("diagonal expects a 2-dimensional tensor");
+  }
+  return self.diag(offset);
+}
+
 Tensor expand(const Tensor& self, IntList size) {
   if (size.size() < (size_t)self.dim()) {
     std::ostringstream ss;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -151,6 +151,12 @@
 - func: det(Tensor self) -> Tensor
 - func: _det_with_svd(Tensor self) -> (Tensor, Tensor, Tensor, Tensor)
 
+- func: diagflat(Tensor self, int64_t offset=0) -> Tensor
+  variants: function
+
+- func: diagonal(Tensor self, int64_t offset=0) -> Tensor
+  variants: function
+
 - func: dot(Tensor self, Tensor tensor) -> Tensor
 
 - func: embedding(Tensor weight, IndexTensor indices, int64_t padding_idx=-1, bool scale_grad_by_freq=false, bool sparse=false) -> Tensor

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1517,6 +1517,12 @@ class TestCuda(TestCase):
             torch.arange(0, 10, out=b)
             self.assertEqual(a, b.cuda())
 
+    def test_diagonal(self):
+        TestTorch._test_diagonal(self, dtype=torch.cuda.float32)
+
+    def test_diagflat(self):
+        TestTorch._test_diagflat(self, dtype=torch.cuda.float32)
+
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
     def test_get_set_rng_state_all(self):
         states = torch.cuda.get_rng_state_all()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1198,6 +1198,51 @@ class TestTorch(TestCase):
         torch.diag(x, out=res2)
         self.assertEqual(res1, res2)
 
+    @staticmethod
+    def _test_diagonal(self, dtype=torch.float32):
+        x = torch.randn((100, 100), dtype=dtype)
+        result = torch.diagonal(x)
+        expected = torch.diag(x)
+        self.assertEqual(result, expected)
+
+        x = torch.randn((100, 100), dtype=dtype)
+        result = torch.diagonal(x, 17)
+        expected = torch.diag(x, 17)
+        self.assertEqual(result, expected)
+
+    def test_diagonal(self):
+        self._test_diagonal(self, dtype=torch.float32)
+
+    @staticmethod
+    def _test_diagflat(self, dtype=torch.float32):
+        # Basic sanity test
+        x = torch.randn((100,), dtype=dtype)
+        result = torch.diagflat(x)
+        expected = torch.diag(x)
+        self.assertEqual(result, expected)
+
+        # Test offset
+        x = torch.randn((100,), dtype=dtype)
+        result = torch.diagflat(x, 17)
+        expected = torch.diag(x, 17)
+        self.assertEqual(result, expected)
+
+        # Test where input has more than one dimension
+        x = torch.randn((2, 3, 4), dtype=dtype)
+        result = torch.diagflat(x)
+        expected = torch.diag(x.contiguous().view(-1))
+        self.assertEqual(result, expected)
+
+        # Noncontig input
+        x = torch.randn((2, 3, 4), dtype=dtype).transpose(2, 0)
+        self.assertFalse(x.is_contiguous())
+        result = torch.diagflat(x)
+        expected = torch.diag(x.contiguous().view(-1))
+        self.assertEqual(result, expected)
+
+    def test_diagflat(self):
+        self._test_diagflat(self, dtype=torch.float32)
+
     def test_eye(self):
         res1 = torch.eye(100, 100)
         res2 = torch.Tensor()

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1217,7 +1217,7 @@ Examples:
     -1.0817
     [torch.FloatTensor of size 3]
 
-    >>> torch.diag(a, 1)
+    >>> torch.diagonal(a, 1)
 
     -1.3210
     -0.2239

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1062,7 +1062,14 @@ Args:
     diagonal (int, optional): the diagonal to consider
     out (Tensor, optional): the output tensor
 
-Example:
+.. seealso::
+
+        :func:`torch.diagonal` always returns the diagonal of its input.
+
+        :func:`torch.diagflat` always constructs a tensor with diagonal elements
+        specified by the input.
+
+Examples:
 
 Get the square matrix where the input vector is the diagonal::
 
@@ -1101,6 +1108,109 @@ Get the k-th diagonal of a given matrix::
     [torch.FloatTensor of size 3x3]
 
     >>> torch.diag(a, 0)
+
+    -1.5328
+     0.0471
+    -1.0817
+    [torch.FloatTensor of size 3]
+
+    >>> torch.diag(a, 1)
+
+    -1.3210
+    -0.2239
+    [torch.FloatTensor of size 2]
+
+""")
+
+add_docstr(torch.diagflat,
+           r"""
+diagflat(input, diagonal=0) -> Tensor
+
+- If :attr:`input` is a vector (1-D tensor), then returns a 2-D square tensor
+  with the elements of :attr:`input` as the diagonal.
+- If :attr:`input` is a tensor with more than one dimension, then returns a
+  2-D tensor with diagonal elements equal to a flattened :attr:`input`.
+
+The argument :attr:`offset` controls which diagonal to consider:
+
+- If :attr:`offset` = 0, it is the main diagonal.
+- If :attr:`offset` > 0, it is above the main diagonal.
+- If :attr:`offset` < 0, it is below the main diagonal.
+
+Args:
+    input (Tensor): the input tensor
+    offset (int, optional): the diagonal to consider. Default: 0 (main
+        diagonal).
+
+Examples:
+
+    >>> a = torch.randn(3)
+    >>> a
+
+     1.0480
+    -2.3405
+    -1.1138
+    [torch.FloatTensor of size 3]
+
+    >>> torch.diagflat(a)
+
+     1.0480  0.0000  0.0000
+     0.0000 -2.3405  0.0000
+     0.0000  0.0000 -1.1138
+    [torch.FloatTensor of size 3x3]
+
+    >>> torch.diagflat(a, 1)
+
+     0.0000  1.0480  0.0000  0.0000
+     0.0000  0.0000 -2.3405  0.0000
+     0.0000  0.0000  0.0000 -1.1138
+     0.0000  0.0000  0.0000  0.0000
+    [torch.FloatTensor of size 4x4]
+
+    >>> a = torch.randn(2, 2)
+    >>> a
+
+     0.1761 -0.9121
+    -0.5722  1.5219
+    [torch.FloatTensor of size (2,2)]
+
+    >>> torch.diagflat(a)
+
+     0.1761  0.0000  0.0000  0.0000
+     0.0000 -0.9121  0.0000  0.0000
+     0.0000  0.0000 -0.5722  0.0000
+     0.0000  0.0000  0.0000  1.5219
+    [torch.FloatTensor of size (4,4)]
+
+""")
+
+add_docstr(torch.diagonal,
+           r"""
+diagonal(input, offset=0) -> Tensor
+
+Returns a 1-D tensor with the diagonal elements of :attr:`input`.
+
+The argument :attr:`offset` controls which diagonal to consider:
+
+- If :attr:`offset` = 0, it is the main diagonal.
+- If :attr:`offset` > 0, it is above the main diagonal.
+- If :attr:`offset` < 0, it is below the main diagonal.
+
+Args:
+    input (Tensor): the input tensor. Must be 2-dimensional.
+    offset (int, optional): which diagonal to consider. Default: 0
+        (main diagonal).
+
+Examples:
+    >>> a = torch.randn(3, 3)
+    >>> a
+
+    -1.5328 -1.3210 -1.5204
+     0.8596  0.0471 -0.2239
+    -0.6617  0.0146 -1.0817
+    [torch.FloatTensor of size 3x3]
+
+    >>> torch.diagonal(a, 0)
 
     -1.5328
      0.0471


### PR DESCRIPTION
Fixes #3213

This adds `torch.diagonal` and `torch.diagflat` (like in numpy) to solve the problem that `torch.diag` is unintuitive to users and performs two functions. The implementations of `torch.diagonal` and `torch.diagflat` just call `torch.diag`.

I'm not sure if this is the best idea to solve the problem of `torch.diag` being weird to users because this does complicate the API (with this change, there will be 3 diag functions). If we think this is a good idea, I'll add some quick sanity tests to test_torch and test_cuda to check that `torch.diagonal` and `torch.diagflat` do what they're supposed to.

cc @gchanan @colesbury 
