### PR TITLE
[Needs test] Removing exception from the default_collate

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -136,7 +136,7 @@ def default_collate(batch):
         transposed = zip(*batch)
         return [default_collate(samples) for samples in transposed]
 
-    raise TypeError((error_msg.format(type(batch[0]))))
+    return batch
 
 
 def pin_memory_batch(batch):


### PR DESCRIPTION
The `default_collate()` function is nowadays arbitrary on which types it will be able to aggregate in a batch, handling special cases such as strings differently than other object classes for instance.
This PR will add more flexibility to the `default_collate()` function by allowing it to return a list (just like when it finds a string object) when it cannot stack using the known data types. This is very useful for many tasks when we want to propagate complex information about the samples (such as in medical imaging).
I don't see a strong reason to keep this exception here, it will just add a restriction on the batching system.