### PR TITLE
Add ReLU to ATen

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -6,6 +6,14 @@ namespace at { namespace native {
 static const double SELU_ALPHA = 1.6732632423543772848170429916717;
 static const double SELU_SCALE = 1.0507009873554804934193349852946;
 
+Tensor relu(const Tensor & self) {
+  return self.clamp_min(0.0);
+}
+
+Tensor & relu_(Tensor & self) {
+  return self.clamp_min_(0.0);
+}
+
 Tensor selu(const Tensor & self) {
   return at::elu(self, SELU_ALPHA, SELU_SCALE);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -398,6 +398,10 @@
 
 - func: select(Tensor self, int64_t dim, int64_t index) -> Tensor
 
+- func: relu(Tensor self) -> Tensor
+
+- func: relu_(Tensor self) -> Tensor
+
 - func: selu(Tensor self) -> Tensor
   variants: function
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -717,7 +717,7 @@
   self: soft_margin_loss_backward(grad, self, target, size_average, reduce)
 
 - name: relu(Tensor self)
-  self: grad * (self > 0).type_as(self)
+  self: threshold_backward(grad, self, 0, 0)
 
 - name: elu_forward(Tensor self, Scalar alpha, Scalar scale)
   self: elu_backward(grad, alpha, scale, output)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -716,6 +716,9 @@
 - name: soft_margin_loss_forward(Tensor self, Tensor target, bool size_average, bool reduce)
   self: soft_margin_loss_backward(grad, self, target, size_average, reduce)
 
+- name: relu(Tensor self)
+  self: grad * (self > 0).type_as(self)
+
 - name: elu_forward(Tensor self, Scalar alpha, Scalar scale)
   self: elu_backward(grad, alpha, scale, output)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -598,12 +598,16 @@ def relu(input, inplace=False):
     Applies the rectified linear unit function element-wise. See
     :class:`~torch.nn.ReLU` for more details.
     """
-    return threshold(input, 0, 0, inplace)
+    if inplace:
+        return torch.relu_(input)
+    return torch.relu(input)
 
 
-def relu_(input):
-    r"""In-place version of :func:`~relu`."""
-    return threshold_(input, 0, 0)
+relu_ = _add_docstr(torch.relu_, r"""
+relu_(input) -> Tensor
+
+In-place verison of :func:`~relu`.
+""")
 
 
 def glu(input, dim=-1):


### PR DESCRIPTION
Adds relu to ATen. There's `clamp_min()`, but `relu()` makes sense given that we have `selu()`, `prelu()`, `rrelu()` etc. (working through https://github.com/pytorch/pytorch/issues/4619)

Fixes https://github.com/pytorch/pytorch/issues/3847