### PR TITLE
Traceable dispatch for cast methods

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -1,11 +1,15 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
+<<<<<<< 582d0450922c6178920d2401751adce02cd34fbb
 #include "TH/THRandom.h"
 #include "ATen/CheckGenerator.h"
 #include "ATen/CPUGenerator.h"
 #include "ATen/Dispatch.h"
 #include <algorithm>
 #include <sstream>
+=======
+#include "ATen/ScalarType.h"
+>>>>>>> Traceable dispatch for Variable cast methods
 
 namespace at {
 namespace native {
@@ -38,6 +42,15 @@ Tensor& empty_out(Tensor& result, IntList size) {
   }
   return result;
 }
+
+#define DEFINE_CAST_OP(_1, n, _2)                                            \
+  Tensor cast_##_1(const Tensor& self, bool non_blocking) {                  \
+    return self.type().toScalarType(ScalarType::n).copy(self, non_blocking); \
+  }
+
+AT_FORALL_SCALAR_TYPES(DEFINE_CAST_OP)
+
+#undef DEFINE_CAST_OP
 
 Tensor empty_like(const Tensor& self) {
   return at::native::empty_like(self, self.type());

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -1,17 +1,14 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
-<<<<<<< 582d0450922c6178920d2401751adce02cd34fbb
 #include "TH/THRandom.h"
 #include "ATen/CheckGenerator.h"
 #include "ATen/CPUGenerator.h"
 #include "ATen/Dispatch.h"
+#include "ATen/ScalarType.h"
 #include <algorithm>
 #include <sstream>
-=======
-#include "ATen/ScalarType.h"
->>>>>>> Traceable dispatch for Variable cast methods
 
-namespace at {
+    namespace at {
 namespace native {
 
 Tensor arange(const Type& dtype, Scalar start, Scalar end, Scalar step) {
@@ -43,12 +40,12 @@ Tensor& empty_out(Tensor& result, IntList size) {
   return result;
 }
 
-#define DEFINE_CAST_OP(_1, n, _2)                                            \
-  Tensor _cast_##_1(const Tensor& self, bool non_blocking) {                  \
-    auto& target_type = self.type().toScalarType(ScalarType::n);             \
-    if (self.type() == target_type)                                          \
-      return self;                                                           \
-    return target_type.copy(self, non_blocking);                             \
+#define DEFINE_CAST_OP(_1, n, _2)                                \
+  Tensor _cast_##_1(const Tensor& self, bool non_blocking) {     \
+    auto& target_type = self.type().toScalarType(ScalarType::n); \
+    if (self.type() == target_type)                              \
+      return self;                                               \
+    return target_type.copy(self, non_blocking);                 \
   }
 
 AT_FORALL_SCALAR_TYPES(DEFINE_CAST_OP)

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -44,7 +44,7 @@ Tensor& empty_out(Tensor& result, IntList size) {
 }
 
 #define DEFINE_CAST_OP(_1, n, _2)                                            \
-  Tensor cast_##_1(const Tensor& self, bool non_blocking) {                  \
+  Tensor _cast_##_1(const Tensor& self, bool non_blocking) {                  \
     auto& target_type = self.type().toScalarType(ScalarType::n);             \
     if (self.type() == target_type)                                          \
       return self;                                                           \

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -45,7 +45,10 @@ Tensor& empty_out(Tensor& result, IntList size) {
 
 #define DEFINE_CAST_OP(_1, n, _2)                                            \
   Tensor cast_##_1(const Tensor& self, bool non_blocking) {                  \
-    return self.type().toScalarType(ScalarType::n).copy(self, non_blocking); \
+    auto& target_type = self.type().toScalarType(ScalarType::n);             \
+    if (self.type() == target_type)                                          \
+      return self;                                                           \
+    return target_type.copy(self, non_blocking);                             \
   }
 
 AT_FORALL_SCALAR_TYPES(DEFINE_CAST_OP)

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -40,6 +40,11 @@ Tensor& empty_out(Tensor& result, IntList size) {
   return result;
 }
 
+// Temporary type cast operators. These are needed to trace type-casts now since
+// Type's are not supported in the IR. Instead, we call down to these
+// specialized operators for each datatype.
+// TODO: remove when we have Type support in the IR
+
 #define DEFINE_CAST_OP(_1, n, _2)                                \
   Tensor _cast_##_1(const Tensor& self, bool non_blocking) {     \
     auto& target_type = self.type().toScalarType(ScalarType::n); \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1,5 +1,29 @@
 # See README.md in this directory for more guidance
 
+- func: cast_uint8_t(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_int8_t(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_double(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_float(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_int(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_int64_t(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_int16_t(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
+- func: cast_Half(Tensor self, bool non_blocking=false) -> Tensor
+  variants: function, method
+
 - func: adaptive_avg_pool1d(Tensor self, IntList[1] output_size) -> Tensor
   variants: function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1,27 +1,27 @@
 # See README.md in this directory for more guidance
 
-- func: cast_uint8_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_uint8_t(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_int8_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_int8_t(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_double(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_double(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_float(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_float(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_int(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_int(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_int64_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_int64_t(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_int16_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_int16_t(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: cast_Half(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Half(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
 - func: adaptive_avg_pool1d(Tensor self, IntList[1] output_size) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1,5 +1,10 @@
 # See README.md in this directory for more guidance
 
+
+# Temporary type cast operators. These are needed to trace type-casts now since
+# Type's are not supported in the IR. Instead, we call down to these
+# specialized operators for each datatype.
+# TODO: remove when we have Type support in the IR
 - func: _cast_uint8_t(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -317,7 +317,8 @@ static Tensor dispatch_type(const Tensor & self, const at::Type & type, int devi
   // Dispatch to specialized, traceable cast operators for the JIT. These
   // specialized ops are ATen native and thus have the tracing mechanisms auto-
   // generated, whereas the default case is not traceable since it requires a
-  // Type as a parameter/attribute. TODO: support Types in the JIT
+  // Type as a parameter/attribute. TODO: support Types in the JIT and remove
+  // this once we have that
   switch (type.scalarType()) {
 #define DEFINE_CAST_DISPATCH(_1, n, _2)   \
   case ScalarType::n: {                   \

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -319,9 +319,9 @@ static Tensor dispatch_type(const Tensor & self, const at::Type & type, int devi
   // generated, whereas the default case is not traceable since it requires a
   // Type as a parameter/attribute. TODO: support Types in the JIT
   switch (type.scalarType()) {
-#define DEFINE_CAST_DISPATCH(_1, n, _2)  \
-  case ScalarType::n: {                  \
-    return self.cast_##_1(non_blocking); \
+#define DEFINE_CAST_DISPATCH(_1, n, _2)   \
+  case ScalarType::n: {                   \
+    return self._cast_##_1(non_blocking); \
   } break;
     AT_FORALL_SCALAR_TYPES(DEFINE_CAST_DISPATCH)
 #undef DEFINE_CAST_DISPATCH

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -308,7 +308,16 @@ static Tensor dispatch_type(const Tensor & self, const at::Type & type, int devi
     // copy if the devices are different even if the types are the same
     return type.copy(self, non_blocking);
   }
-  return self.toType(type, non_blocking);
+  // return self.toType(type, non_blocking);
+  switch (type.scalarType()) {
+#define DEFINE_CAST_DISPATCH(_1, n, _2)  \
+  case ScalarType::n: {                  \
+    return self.cast_##_1(non_blocking); \
+  } break;
+    AT_FORALL_SCALAR_TYPES(DEFINE_CAST_DISPATCH)
+#undef DEFINE_CAST_DISPATCH
+    default: { return self.toType(type, non_blocking); } break;
+  }
 }
 
 static Tensor dispatch_type(const Tensor & self, const at::Type & type) {

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -542,6 +542,9 @@ def conv_tbc(g, input, weight, bias, pad):
 # Metaprogram symbolics for each ATen native specialized cast operator.
 # For e.g. we specify a function named `_cast_uint8_t` that instantiates an
 # ONNX cast node with `to` attribute 'UINT8'
+#
+# TODO: remove these once we support Type's in the JIT IR and we can once again
+# use the unified toType operator
 cast_pytorch_to_onnx = {
     'uint8_t': 'UINT8',
     'int8_t': 'INT8',

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -537,6 +537,39 @@ def conv_tbc(g, input, weight, bias, pad):
     return g.op("ATen", input, weight, bias, operator_s="conv_tbc", pad_i=pad)
 
 
+# Cast operators
+def cast_uint8_t(g, input, non_blocking):
+    return g.op("Cast", input, to_s="UINT8")
+
+
+def cast_int8_t(g, input, non_blocking):
+    return g.op("Cast", input, to_s="INT8")
+
+
+def cast_double(g, input, non_blocking):
+    return g.op("Cast", input, to_s="DOUBLE")
+
+
+def cast_float(g, input, non_blocking):
+    return g.op("Cast", input, to_s="FLOAT")
+
+
+def cast_Half(g, input, non_blocking):
+    return g.op("Cast", input, to_s="FLOAT16")
+
+
+def cast_int(g, input, non_blocking):
+    return g.op("Cast", input, to_s="INT32")
+
+
+def cast_int64_t(g, input, non_blocking):
+    return g.op("Cast", input, to_s="INT64")
+
+
+def cast_int16_t(g, input, non_blocking):
+    return g.op("Cast", input, to_s="INT16")
+
+
 def slice(g, self, dim, start, end, step):
     if step != 1:
         _unimplemented("slice", "step!=1 is currently not supported")

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -543,14 +543,14 @@ def conv_tbc(g, input, weight, bias, pad):
 # For e.g. we specify a function named `_cast_uint8_t` that instantiates an
 # ONNX cast node with `to` attribute 'UINT8'
 cast_pytorch_to_onnx = {
-    'uint8_t':  'UINT8',
-    'int8_t':   'INT8',
-    'double':   'DOUBLE',
-    'float':    'FLOAT',
-    'Half':     'FLOAT16',
-    'int':      'INT32',
-    'int64_t':  'INT64',
-    'int16_t':  'INT16',
+    'uint8_t': 'UINT8',
+    'int8_t': 'INT8',
+    'double': 'DOUBLE',
+    'float': 'FLOAT',
+    'Half': 'FLOAT16',
+    'int': 'INT32',
+    'int64_t': 'INT64',
+    'int16_t': 'INT16',
 }
 
 


### PR DESCRIPTION
Previously, methods like `int()` and `long()` would fail tracing because they eventually dispatch down to `toType`, which takes a `Type` as a parameter. We don't (currently) support tracing ops with Type inputs[0], so this PR adds specializations for the ATen scalar types and dispatches to those directly. These specialized ops can be traced into the IR without needing a Type argument.

A more long-term solution would be to add support for `Type`s in the IR.


[0] https://github.com/pytorch/pytorch/blob/master/tools/autograd/gen_variable_type.py#L319

https://github.com/pytorch/pytorch/issues/5536