### PR TITLE
[jit] add a compiled script module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -569,6 +569,7 @@ main_sources = [
     "torch/csrc/jit/generated/aten_dispatch.cpp",
     "torch/csrc/jit/script/lexer.cpp",
     "torch/csrc/jit/script/compiler.cpp",
+    "torch/csrc/jit/script/module.cpp",
     "torch/csrc/jit/script/init.cpp",
     "torch/csrc/jit/script/python_tree_views.cpp",
     "torch/csrc/autograd/init.cpp",

--- a/test/expect/TestJit.test_python_frontend.expect
+++ b/test/expect/TestJit.test_python_frontend.expect
@@ -13,12 +13,14 @@
           (variable (ident x))
           (variable (ident y)))
         (apply
-          (ident sigmoid)
-          (list (variable (ident z)))
+          (.
+            (variable (ident z))
+            (ident sigmoid))
+          (list)
           (list))))
     (expression statement
       (apply
-        (ident print)
+        (variable (ident print))
         (list (variable (ident q)))
         (list)))
     (assign

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1610,8 +1610,8 @@ class TestJit(TestCase):
             return c
         ''')
         self.assertEqual(
-            str(cu.cu.get_graph('test_ternary_control')),
-            str(cu2.cu.get_graph('test_ternary')),
+            str(cu.test_ternary_control.graph()),
+            str(cu2.test_ternary.graph()),
         )
 
     def test_python_frontend_run(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1924,9 +1924,9 @@ class TestJit(TestCase):
         c = m2.weight.mm(input)
         ref = a + b + m2.bias + m2.sub.weight + a + c
         self.assertEqual(ref, m2.forward(input))
-        m2.weight.data.zero_()
-        m2.bias.data.zero_()
-        m2.sub.weight.data.zero_()
+        m2.weight = nn.Parameter(torch.zeros_like(m2.weight))
+        m2.bias = nn.Parameter(torch.zeros_like(m2.bias))
+        m2.sub.weight = nn.Parameter(torch.zeros_like(m2.sub.weight))
         self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
 
 if __name__ == '__main__':

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1693,7 +1693,7 @@ class TestJit(TestCase):
         self.assertEqual(cu.test_call_python(*inputs), outputs[0])
 
     def test_script_python_call_failure(self):
-        with self.assertRaisesRegex(RuntimeError, "Unknown function pyfunc2"):
+        with self.assertRaisesRegex(RuntimeError, "undefined value pyfunc2"):
             def pyfunc(a):
                 return a * 3.0
 
@@ -1733,7 +1733,7 @@ class TestJit(TestCase):
         self.assertEqual(foo(*inputs), outputs[0])
 
     def test_script_python_call_annotation_failure(self):
-        with self.assertRaisesRegex(RuntimeError, "Unknown function pyfunc2"):
+        with self.assertRaisesRegex(RuntimeError, "undefined value pyfunc2"):
             def pyfunc(a):
                 return a * 3.0
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1877,6 +1877,57 @@ class TestJit(TestCase):
         if not WINDOWS:
             self.assertExpected(captured[0])
 
+    def test_script_module(self):
+        class M1(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M1, self).__init__(False)
+                self.weight = nn.Parameter(torch.randn(2))
+
+            @torch.jit.script_method
+            def forward(self, thing):
+                return self.weight + thing
+
+        class M2(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M2, self).__init__(False)
+                # test submodule
+                self.sub = M1()
+                # test parameters
+                self.weight = nn.Parameter(torch.randn(2, 3))
+                self.bias = nn.Parameter(torch.randn(2))
+                # test defining a method from a string
+                self.define("""
+                    def hi(self, a):
+                        return self.weight.mm(a)
+                """)
+            # test script methods
+
+            @torch.jit.script_method
+            def doit(self, input):
+                # test use of parameter
+                return self.weight.mm(input)
+
+            @torch.jit.script_method
+            def doit2(self, input):
+                return self.weight.mm(input)
+
+            @torch.jit.script_method
+            def forward(self, input):
+                a = self.doit(input)
+                b = self.doit2(input)
+                c = self.hi(input)
+                return a + b + self.bias + self.sub(a) + c
+        m2 = M2()
+        input = torch.randn(3, 2)
+        a = m2.weight.mm(input)
+        b = m2.weight.mm(input)
+        c = m2.weight.mm(input)
+        ref = a + b + m2.bias + m2.sub.weight + a + c
+        self.assertEqual(ref, m2.forward(input))
+        m2.weight.data.zero_()
+        m2.bias.data.zero_()
+        m2.sub.weight.data.zero_()
+        self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1267,7 +1267,7 @@ repeat(*sizes) -> Tensor
 
 Repeats this tensor along the specified dimensions.
 
-Unlike :meth:`~Tensor.expand`, this function copies the tensor’s data.
+Unlike :meth:`~Tensor.expand`, this function copies the tensor's data.
 
 Args:
     sizes (torch.Size or int...): The number of times to repeat this tensor along each

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -244,7 +244,7 @@ static ReverseDetails addReverseInline(Gradient& grad_desc,
   // std::cout << *reverse_node << to view its state.
   auto reverse_node = graph.create("Reverse"_sym, 0);
   auto reverse_block = reverse_node->addBlock();
-  WithInsertPoint guard(graph, reverse_block);
+  WithInsertPoint guard(reverse_block);
 
   auto requires_grad_set = findAllRequiresGradNodes(graph, input_requires_grad);
   const auto requires_grad = [&](Value *v) { return requires_grad_set.count(v) > 0; };
@@ -433,7 +433,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
     Value * tmp_vjp_in = reverse_block->addInput()->setType(tmp->type());
     Value * tmp_vjp_prev = rev_info.grad_map.at(tmp);
     {
-      WithInsertPoint guard(graph, tmp_vjp_prev->node());
+      WithInsertPoint guard(tmp_vjp_prev->node());
       auto zeroes = createZerosLike(tmp);
       tmp_vjp_in = createUndefGuard(tmp_vjp_in, zeroes);
     }
@@ -479,7 +479,7 @@ Gradient differentiate(std::shared_ptr<Graph>& _graph, const std::vector<bool>& 
   std::swap(_graph, grad_desc.f);
   // XXX: Take care when handling outputs - they can be duplicated!
 
-  WithInsertPoint guard(*grad_desc.f, grad_desc.f->block());
+  WithInsertPoint guard(grad_desc.f->block());
   // Fills in df_input_vjps and df_output_vjps
   auto rev_info = addReverseInline(grad_desc, requires_grad);
   // addReverseInline has to call gradientForNode if *any* of the outputs

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -76,7 +76,7 @@ static std::vector<std::vector<TypePtr>> flattenStages(Graph & graph) {
   // because JIT classic needs this to fix up gradients, remove when possible
   std::vector<std::vector<TypePtr>> stage_input_types;
 
-  WithInsertPoint guard(graph, *graph.nodes().begin());
+  WithInsertPoint guard(*graph.nodes().begin());
   size_t input_pos = 0;
   size_t output_pos = 0;
   auto it = graph.nodes().begin();

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -996,15 +996,15 @@ private:
 };
 
 struct WithInsertPoint : public ResourceGuard {
-  WithInsertPoint(Graph & g, Node * n)
+  WithInsertPoint(Node * n)
   : ResourceGuard([this] {
     prev->owningGraph()->setInsertPoint(prev);
   })
-  , prev(g.insertPoint()) {
-    g.setInsertPoint(n);
+  , prev(n->owningGraph()->insertPoint()) {
+    n->owningGraph()->setInsertPoint(n);
   }
-  WithInsertPoint(Graph & g, Block * b)
-  : WithInsertPoint(g, b->return_node()) {}
+  WithInsertPoint(Block * b)
+  : WithInsertPoint(b->return_node()) {}
 private:
   Node * prev;
 };

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -293,6 +293,7 @@ void PropagateShapeOnBlock(Block * block) {
       setDynamicType(node);
     } catch(std::exception & e) {
       if(auto sl = node->getSourceLocation()) {
+        std::cout << *block->owningGraph() << "\n";
         sl->wrapAndRethrowException(e, "operation failed shape propagation");
       } else {
         throw;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -293,7 +293,6 @@ void PropagateShapeOnBlock(Block * block) {
       setDynamicType(node);
     } catch(std::exception & e) {
       if(auto sl = node->getSourceLocation()) {
-        std::cout << *block->owningGraph() << "\n";
         sl->wrapAndRethrowException(e, "operation failed shape propagation");
       } else {
         throw;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -204,12 +204,13 @@ Node* emitBuiltinCall(
         else
           n->i_(Symbol(name), v);
       } break;
-      case TK_LIST: {
+      case TK_LIST_LITERAL: {
         std::vector<double> vs{};
-        for (const auto& tree : value.get()->trees()) {
-          vs.push_back(tree->tree(0)->doubleValue());
+        std::string type = "f"; // TODO: handle possibly mixed constants better
+        for (const auto& tree : ListLiteral(value).inputs()) {
+          vs.push_back(tree.get()->tree(0)->doubleValue());
+          type = tree.get()->tree(1)->stringValue();
         }
-        const auto& type = value.get()->trees()[0]->tree(1)->stringValue();
         if(type == "f") {
           n->fs_(Symbol(name), std::move(vs));
         } else {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -245,6 +245,7 @@ struct to_ir {
       if(it == end)
         throw ErrorReport(def.params().range()) << "methods must have a self argument";
       environment_stack->setSugaredVar((*it).ident().name(), self);
+      ++it;
     }
     for(;it != end; ++it) {
       auto& name = (*it).ident().name();

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -12,20 +12,38 @@ namespace torch {
 namespace jit {
 namespace script {
 
-struct Resolver {
-  // Given an external call node where the signature does not correspond to an
-  // existing ATen operator, this function returns a new node that calls into
-  // the correct external op, or throws if that op cannot be found.
-  //
-  // The function simply instatntiates the new node and returns it. It is the
-  // responsiblity of the caller to insert the node into the graph and delete
-  // the original node.
+// The AST can contain nodes like `self`, `self.b` or `python_fn` that
+// are not first-class values in the graph representation, but instead
+// will be desugared based on how they are used in the AST.
 
-  virtual Node* resolveCall(SourceRange location, Node* n) const {
-    throw ErrorReport(location) << "Unknown function " << n->kind().toString();
+// SugaredValue is used to temporarily represent these values in a way
+// that separates their behavior from AST -> IR converter itself.
+// This allows us to keep dependencies on python minimal.
+
+
+struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
+  // what is this node? for error report (e.g. Module, python function)
+  virtual std::string kind() const = 0;
+  // what can we do with this thing?
+
+  // use it as a value e.g.  `this + 4`
+  virtual Value * asValue(SourceRange loc, Graph & g) {
+    throw ErrorReport(loc) << kind() << " cannot be used as a value";
   }
+
+  // select an attribute on it, e.g. `this.field`
+  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Graph& g, const std::string& field) {
+    throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
+  }
+
+  // call it like a function, e.g. `outputs = this(inputs)`
+  virtual std::vector<Value*> call(SourceRange loc, Graph& g, at::ArrayRef<Value*> inputs, size_t n_outputs) {
+    throw ErrorReport(loc) << "cannot call a " << kind();
+  }
+  virtual ~SugaredValue() {}
 };
 
+using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name)>;
 void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver);
 void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const Resolver& resolver);
 std::shared_ptr<Graph> defineFunction(Def def, const Resolver& resolver);

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/script/error_report.h"
 #include "torch/csrc/jit/script/tree_views.h"
+#include "torch/csrc/jit/script/module.h"
 
 namespace torch {
 namespace jit {
@@ -19,24 +20,15 @@ struct Resolver {
   // The function simply instatntiates the new node and returns it. It is the
   // responsiblity of the caller to insert the node into the graph and delete
   // the original node.
+
   virtual Node* resolveCall(SourceRange location, Node* n) const {
     throw ErrorReport(location) << "Unknown function " << n->kind().toString();
   }
 };
 
-struct CompilationUnitImpl;
-struct CompilationUnit {
-  CompilationUnit();
-  void define(const std::string& source, const Resolver& resolver);
-  void defineFunction(const Def& def, const Resolver& resolver);
-  std::shared_ptr<Graph> getGraph(const std::string& func_name);
-  ~CompilationUnit();
-
- private:
-  std::unique_ptr<CompilationUnitImpl> pImpl;
-};
-
-std::shared_ptr<Graph> jitScriptCompile(Def def, const Resolver& resolver);
+void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver);
+void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const Resolver& resolver);
+std::shared_ptr<Graph> defineFunction(Def def, const Resolver& resolver);
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -75,7 +75,7 @@ void defineMethodsInModule(
 // same as above but parse the definitions from source
 void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
 
-std::shared_ptr<Graph> defineFunction(Def def, const Resolver& resolver);
+std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
 
 
 } // namespace script

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -20,33 +20,63 @@ namespace script {
 // that separates their behavior from AST -> IR converter itself.
 // This allows us to keep dependencies on python minimal.
 
-
 struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   // what is this node? for error report (e.g. Module, python function)
   virtual std::string kind() const = 0;
   // what can we do with this thing?
 
   // use it as a value e.g.  `this + 4`
-  virtual Value * asValue(SourceRange loc, Graph & g) {
+  virtual Value * asValue(SourceRange loc, Method & m) {
     throw ErrorReport(loc) << kind() << " cannot be used as a value";
   }
 
   // select an attribute on it, e.g. `this.field`
-  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Graph& g, const std::string& field) {
+  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) {
     throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
   }
 
   // call it like a function, e.g. `outputs = this(inputs)`
-  virtual std::vector<Value*> call(SourceRange loc, Graph& g, at::ArrayRef<Value*> inputs, size_t n_outputs) {
+  virtual std::vector<Value*> call(
+    SourceRange loc,
+    Method & m,
+    at::ArrayRef<Value*> inputs,
+    List<Attribute> attributes,
+    size_t n_outputs) {
     throw ErrorReport(loc) << "cannot call a " << kind();
   }
   virtual ~SugaredValue() {}
 };
 
+// most things in the environment are just simple value types
+// and not special python syntax sugar types
+struct SimpleValue : public SugaredValue {
+  SimpleValue(Value * value)
+  : value(value) {}
+  virtual std::string kind() const override {
+    return "value";
+  }
+  virtual Value * asValue(SourceRange range, Method & m) override {
+    return value;
+  }
+  virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override;
+
+private:
+  Value* value;
+};
+
 using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name)>;
-void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver);
-void defineMethodsInModule(Module & m, const std::vector<Def>& definitions, const Resolver& resolver);
+void defineMethodsInModule(
+  Module & m,
+  const std::vector<Def>& definitions,
+  const Resolver& resolver, /* determines how we handle free variables*/
+  std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
+);
+
+// same as above but parse the definitions from source
+void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
+
 std::shared_ptr<Graph> defineFunction(Def def, const Resolver& resolver);
+
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -189,7 +189,7 @@ void initJitScriptBindings(PyObject* module) {
           case NamedMember::Module:
             return py::cast(self.get_module(name));
           case NamedMember::Method:
-            return py::cast(self.get_method(name), py::return_value_policy::reference_internal);
+            return py::cast(self.get_method(name), py::return_value_policy::reference_internal, py::cast(self));
           case NamedMember::None:
           default: {
             return py::none();

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -160,10 +160,11 @@ void initJitScriptBindings(PyObject* module) {
       .def(py::init<bool>())
       .def(
           "_define",
-          [](Module& self,
+          [](Module& m,
              const std::string& script,
-             ResolutionCallback rcb) {
-            return defineMethodsInModule(self, script, pythonResolver(rcb), nullptr);
+             ResolutionCallback rcb, bool has_self) {
+            auto self = has_self ? std::make_shared<ModuleValue>(m.shared_from_this()) : nullptr;
+            return defineMethodsInModule(m, script, pythonResolver(rcb), self);
           })
       .def("_create_method", [](Module& m, Def def, ResolutionCallback rcb) {
         defineMethodsInModule(

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -185,7 +185,7 @@ void initJitScriptBindings(PyObject* module) {
       .def("_get_attribute",[](Module& self, const std::string& name) -> py::object {
         switch(self.find_attribute(name)) {
           case NamedMember::Parameter:
-            return py::cast(self.get_parameter(name));
+            return py::cast(static_cast<const autograd::Variable&>(self.get_parameter(name)));
           case NamedMember::Module:
             return py::cast(self.get_module(name));
           case NamedMember::Method:

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -134,8 +134,8 @@ struct SharedParserData {
 
     std::stringstream ss;
     for (const char* c = valid_single_char_tokens; *c; c++) {
-      const char str[] = {*c, '\0'};
-      head->insert(str, *c);
+      std::string str(1, *c);
+      head->insert(str.c_str(), *c);
     }
 
 #define ADD_CASE(tok, _, tokstring) \

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -78,7 +78,9 @@ namespace script {
   _(TK_SLICE, "slice", "")                       \
   _(TK_VAR, "variable", "")                      \
   _(TK_GATHER, "gather", "")                     \
-  _(TK_NOTHING, "nothing", "")
+  _(TK_NOTHING, "nothing", "")                   \
+  _(TK_LIST_LITERAL, "list-literal", "")
+
 static const char* valid_single_char_tokens = "+-*/()[]:,={}><.";
 
 enum TokenKind {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -1,1 +1,40 @@
 #include "torch/csrc/jit/script/module.h"
+
+namespace torch { namespace jit { namespace script {
+
+static std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs) {
+  std::unordered_map<Value*, Value*> value_map;
+  auto value_map_func = [&](Value* v) { return value_map.at(v); };
+  JIT_ASSERT(callee.inputs().size() == inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    value_map[callee.inputs()[i]] = inputs[i];
+  }
+  for (auto* node : callee.nodes()) {
+    auto* new_node =
+        g.insertNode(g.createClone(node, value_map_func));
+    for (size_t i = 0; i < node->outputs().size(); ++i) {
+      value_map[node->outputs()[i]] = new_node->outputs()[i];
+    }
+  }
+
+  std::vector<Value*> outputs;
+  for (auto* output : callee.outputs()) {
+    outputs.push_back(value_map_func(output));
+  }
+  return outputs;
+}
+
+std::vector<Value*> Method::emit_call_to(Method & callee, ArrayRef<Value*> inputs) {
+  JIT_ASSERT(!executor);
+  auto fn = callee.graph();
+  JIT_ASSERT(inputs.size() == callee.num_inputs());
+  std::vector<Value*> all_inputs = inputs;
+  // parameters to callee method (which become parameters to _this_ method
+  // if they were not already)
+  for(at::Tensor* member : callee.member_inputs) {
+    all_inputs.push_back(get_or_add_parameter(member));
+  }
+  return inlineCallTo(*graph(), *callee.graph(), all_inputs);
+}
+
+}}}

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -1,0 +1,1 @@
+#include "torch/csrc/jit/script/module.h"

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -5,13 +5,14 @@
 namespace torch { namespace jit { namespace script {
 
 struct Method {
-  Method(std::string name, std::shared_ptr<Graph> graph, std::vector<at::Tensor*> member_inputs, bool optimize)
-  : name_(std::move(name)), graph_(std::move(graph)), member_inputs(std::move(member_inputs)) {
-    // TODO: we may want to lazily construct this since not all functions will
-    // be called and creating executors takes time in optimization
-    executor = GraphExecutor(graph_, optimize);
-  }
+  Method(std::string name, bool optimize)
+  : name_(std::move(name))
+  , graph_(std::make_shared<Graph>())
+  , optimize(optimize) {}
   variable_tensor_list run(variable_tensor_list && inputs) {
+    std::call_once(executor_init, [&]{
+      executor = GraphExecutor(graph_, optimize);
+    });
     for(auto tp : member_inputs) {
       inputs.push_back(*tp);
     }
@@ -20,12 +21,63 @@ struct Method {
   std::shared_ptr<Graph> graph() const {
     return graph_;
   }
+
   const std::string & name() const {
     return name_;
+  }
+  // emit a function call by inlining the callees Graph into this one
+  // adding any extra parameters necessary to do this call
+
+  // defined here to keep details of member_input handling confined to this class
+  std::vector<Value*> emit_call_to(Method & callee, ArrayRef<Value*> inputs) {
+    JIT_ASSERT(!executor);
+    auto fn = callee.graph();
+    JIT_ASSERT(inputs.size() == callee.num_inputs());
+    std::unordered_map<Value*, Value*> value_map;
+    auto value_map_func = [&](Value* v) { return value_map.at(v); };
+    // actual inputs
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      value_map[fn->inputs()[i]] = inputs[i];
+    }
+    // parameters to callee method (which become parameters to _this_ method
+    // if they were not already)
+    auto members_it = callee.member_inputs.begin();
+    for(size_t i = inputs.size(); i < fn->inputs().size(); i++) {
+      value_map[fn->inputs()[i]] = get_or_add_parameter(*members_it++);
+    }
+    for (auto* node : fn->nodes()) {
+      auto* new_node =
+          graph_->insertNode(graph_->createClone(node, value_map_func));
+      for (size_t i = 0; i < node->outputs().size(); ++i) {
+        value_map[node->outputs()[i]] = new_node->outputs()[i];
+      }
+    }
+
+    std::vector<Value*> outputs;
+    for (auto* output : fn->outputs()) {
+      outputs.push_back(value_map_func(output));
+    }
+    return outputs;
+  }
+  size_t num_inputs() const {
+    return graph_->inputs().size() - member_inputs.size();
+  }
+  Value * get_or_add_parameter(at::Tensor* slot) {
+    size_t first_parameter = graph()->inputs().size() - member_inputs.size();
+    for(size_t i = 0; i < member_inputs.size(); i++) {
+      // it is already a parameter
+      if(member_inputs[i] == slot) {
+        return graph()->inputs()[first_parameter + i];
+      }
+    }
+    // add it as a new parameter
+    member_inputs.push_back(slot);
+    return graph()->addInput();
   }
 private:
   std::string name_;
   std::shared_ptr<Graph> graph_; // for debugging and for inlining
+  bool optimize;
   GraphExecutor executor; // for execution
   // member_inputs are a list of additional arguments append to graph that are
   // inputs that come from the members of the Module or its submodules.
@@ -35,6 +87,7 @@ private:
   // these pointers always stay valid
   std::vector<at::Tensor*> member_inputs;
 
+
   // TODO: support that case where we allow _writes_ to parameters from
   // compiled functions.
   // This requires more sophisticated tracking of ssa values in Graphs so that
@@ -42,6 +95,8 @@ private:
   // It also adds more complexity to adding actual module invocations
   // to the executor, so currently it is not done.
   // std::vector<at::Tensor*> member_outputs;
+
+  std::once_flag executor_init;
 };
 
 struct Module;
@@ -67,7 +122,9 @@ private:
 };
 
 struct NamedMember {
-  enum Kind { Module, Parameter, Method} kind;
+  enum Kind { Module, Parameter, Method, None};
+  // note: None is used to report undefined attributes;
+  Kind kind;
   size_t offset;
 
   static const char * kind_string(Kind kind) {
@@ -75,6 +132,7 @@ struct NamedMember {
       case Module: return "Module";
       case Parameter: return "Parameter";
       case Method: return "Method";
+      case None: return "None";
       default: return "Unknown";
     }
   }
@@ -82,7 +140,8 @@ struct NamedMember {
 
 struct Module : public std::enable_shared_from_this<Module> {
   TH_DISALLOW_COPY_AND_ASSIGN(Module);
-  Module(bool optimize = true) {}
+  Module(bool optimize)
+  : optimize(optimize) {}
 
   void register_parameter(const std::string & name, at::Tensor v) {
     parameters.push_back(NamedParameter(name, std::move(v)));
@@ -93,9 +152,10 @@ struct Module : public std::enable_shared_from_this<Module> {
     add_member(name, NamedMember::Module, modules.size() - 1);
   }
 
-  void register_method(const std::string & name, std::shared_ptr<Graph> graph, std::vector<at::Tensor*> member_inputs) {
-    methods.push_back(Method(name, std::move(graph), std::move(member_inputs), optimize));
+  Method& create_method(const std::string & name) {
+    methods.emplace_back(new Method(name, optimize));
     add_member(name, NamedMember::Method, methods.size() - 1);
+    return *methods.back();
   }
 
   at::Tensor* parameter_slot(const std::string & name) {
@@ -110,12 +170,21 @@ struct Module : public std::enable_shared_from_this<Module> {
     return *parameter_slot(name);
   }
 
-  const Method& get_method(const std::string& name) const {
-    return methods.at(find_member(name, NamedMember::Method));
+  // each module owns its method. The reference returned here
+  // is guarenteed to stay valid until this module has been destoryed
+  Method& get_method(const std::string& name) const {
+    return *methods.at(find_member(name, NamedMember::Method));
   }
 
   std::shared_ptr<Module> get_module(const std::string& name) const {
     return modules.at(find_member(name, NamedMember::Module)).module;
+  }
+
+  NamedMember::Kind find_attribute(const std::string& name) {
+    auto it = members.find(name);
+    if(it == members.end())
+      return NamedMember::None;
+    return it->second.kind;
   }
 
 private:
@@ -140,7 +209,7 @@ private:
   // no such restriction exists for methods
   std::vector<NamedModule> modules;
   std::vector<NamedParameter> parameters;
-  std::vector<Method> methods;
+  std::vector<std::unique_ptr<Method>> methods;
 
   std::unordered_map<std::string, NamedMember> members;
   bool optimize;

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -3,8 +3,18 @@
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/autograd/variable.h"
 
+// This file contains classes which assist in desugaring Python style
+// modules and their methods into flattened graphs which don't have any
+// function calls.
+
 namespace torch { namespace jit { namespace script {
 
+// A method in a module, e.g. f in:
+//
+// class M(ScriptModule):
+//   @script_method
+//   def f(self, x):
+//     ...
 struct Method {
   Method(std::string name, bool optimize)
   : name_(std::move(name))
@@ -80,7 +90,7 @@ private:
   std::shared_ptr<Graph> graph_; // for debugging and for inlining
   bool optimize;
   GraphExecutor executor; // for execution
-  // member_inputs are a list of additional arguments append to graph that are
+  // member_inputs are a list of additional arguments appended to graph that are
   // inputs that come from the members of the Module or its submodules.
   // each is a pointer to a slot in the module that owns this Method or a submethod
   // of the module.
@@ -118,12 +128,12 @@ struct NamedParameter {
 private:
   // the extra level of indirection allows Methods to safely store pointers
   // to the slots where parameters are kept while also allow parameters
-  // to be reassign
+  // to be reassigned
   std::unique_ptr<at::Tensor> parameter;
 };
 
 struct NamedMember {
-  enum Kind { Module, Parameter, Method, None};
+  enum Kind { Module, Parameter, Method, None };
   // note: None is used to report undefined attributes;
   Kind kind;
   size_t offset;

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -1,0 +1,149 @@
+#pragma once
+#include "torch/csrc/jit/ir.h"
+#include "torch/csrc/jit/graph_executor.h"
+
+namespace torch { namespace jit { namespace script {
+
+struct Method {
+  Method(std::string name, std::shared_ptr<Graph> graph, std::vector<at::Tensor*> member_inputs, bool optimize)
+  : name_(std::move(name)), graph_(std::move(graph)), member_inputs(std::move(member_inputs)) {
+    // TODO: we may want to lazily construct this since not all functions will
+    // be called and creating executors takes time in optimization
+    executor = GraphExecutor(graph_, optimize);
+  }
+  variable_tensor_list run(variable_tensor_list && inputs) {
+    for(auto tp : member_inputs) {
+      inputs.push_back(*tp);
+    }
+    return executor.run(std::move(inputs));
+  }
+  std::shared_ptr<Graph> graph() const {
+    return graph_;
+  }
+  const std::string & name() const {
+    return name_;
+  }
+private:
+  std::string name_;
+  std::shared_ptr<Graph> graph_; // for debugging and for inlining
+  GraphExecutor executor; // for execution
+  // member_inputs are a list of additional arguments append to graph that are
+  // inputs that come from the members of the Module or its submodules.
+  // each is a pointer to a slot in the module that owns this Method or a submethod
+  // of the module.
+  // parameters and submodules can only be _added_ to script Modules to ensure
+  // these pointers always stay valid
+  std::vector<at::Tensor*> member_inputs;
+
+  // TODO: support that case where we allow _writes_ to parameters from
+  // compiled functions.
+  // This requires more sophisticated tracking of ssa values in Graphs so that
+  // stores to all modules can be lifted to the end of a graph execution.
+  // It also adds more complexity to adding actual module invocations
+  // to the executor, so currently it is not done.
+  // std::vector<at::Tensor*> member_outputs;
+};
+
+struct Module;
+
+struct NamedModule {
+  std::string name;
+  std::shared_ptr<Module> module;
+};
+
+struct NamedParameter {
+  NamedParameter(std::string name, at::Tensor tensor)
+  : name(std::move(name)), parameter(new at::Tensor(std::move(tensor))) {}
+
+  std::string name;
+  at::Tensor* slot() const {
+    return parameter.get();
+  }
+private:
+  // the extra level of indirection allows Methods to safely store pointers
+  // to the slots where parameters are kept while also allow parameters
+  // to be reassign
+  std::unique_ptr<at::Tensor> parameter;
+};
+
+struct NamedMember {
+  enum Kind { Module, Parameter, Method} kind;
+  size_t offset;
+
+  static const char * kind_string(Kind kind) {
+    switch(kind) {
+      case Module: return "Module";
+      case Parameter: return "Parameter";
+      case Method: return "Method";
+      default: return "Unknown";
+    }
+  }
+};
+
+struct Module : public std::enable_shared_from_this<Module> {
+  TH_DISALLOW_COPY_AND_ASSIGN(Module);
+  Module(bool optimize = true) {}
+
+  void register_parameter(const std::string & name, at::Tensor v) {
+    parameters.push_back(NamedParameter(name, std::move(v)));
+    add_member(name, NamedMember::Parameter, parameters.size() - 1);
+  }
+  void register_module(const std::string& name, std::shared_ptr<Module> module) {
+    modules.push_back(NamedModule {name, std::move(module)});
+    add_member(name, NamedMember::Module, modules.size() - 1);
+  }
+
+  void register_method(const std::string & name, std::shared_ptr<Graph> graph, std::vector<at::Tensor*> member_inputs) {
+    methods.push_back(Method(name, std::move(graph), std::move(member_inputs), optimize));
+    add_member(name, NamedMember::Method, methods.size() - 1);
+  }
+
+  at::Tensor* parameter_slot(const std::string & name) {
+    return parameters.at(find_member(name, NamedMember::Parameter)).slot();
+  }
+
+  void set_parameter(const std::string & name, at::Tensor v) {
+    *parameter_slot(name) = std::move(v);
+  }
+
+  at::Tensor get_parameter(const std::string& name) {
+    return *parameter_slot(name);
+  }
+
+  const Method& get_method(const std::string& name) const {
+    return methods.at(find_member(name, NamedMember::Method));
+  }
+
+  std::shared_ptr<Module> get_module(const std::string& name) const {
+    return modules.at(find_member(name, NamedMember::Module)).module;
+  }
+
+private:
+  size_t find_member(const std::string& name, NamedMember::Kind kind) const  {
+    auto it = members.find(name);
+    JIT_ASSERT(it != members.end() && it->second.kind == kind);
+    return it->second.offset;
+  }
+  void add_member(const std::string& name, NamedMember::Kind kind, size_t offset) {
+    auto it = members.find(name);
+    if(it != members.end()) {
+      std::stringstream ss;
+      ss << "attempting to add " << NamedMember::kind_string(kind) << " '" << name << "' but Module already contains "
+      << NamedMember::kind_string(it->second.kind) << " '" << name << "'";
+      throw std::runtime_error(ss.str());
+    }
+    members[std::move(name)] = NamedMember { kind, offset };
+  }
+  // invariant: to ensure member_inputs of Methods stay valid,
+  // it is only legal to _add_ new modules and parameters.
+  // removing them will allow member_inputs to point to invalid parameters
+  // no such restriction exists for methods
+  std::vector<NamedModule> modules;
+  std::vector<NamedParameter> parameters;
+  std::vector<Method> methods;
+
+  std::unordered_map<std::string, NamedMember> members;
+  bool optimize;
+};
+
+}}}

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/graph_executor.h"
+#include "torch/csrc/autograd/variable.h"
 
 namespace torch { namespace jit { namespace script {
 
@@ -146,6 +147,13 @@ struct Module : public std::enable_shared_from_this<Module> {
   void register_parameter(const std::string & name, at::Tensor v) {
     parameters.push_back(NamedParameter(name, std::move(v)));
     add_member(name, NamedMember::Parameter, parameters.size() - 1);
+  }
+  void register_or_set_parameter(const std::string & name, autograd::Variable v) {
+    if(find_attribute(name) == NamedMember::Parameter) {
+      set_parameter(name, v);
+    } else {
+      register_parameter(name, v);
+    }
   }
   void register_module(const std::string& name, std::shared_ptr<Module> module) {
     modules.push_back(NamedModule {name, std::move(module)});

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -130,11 +130,11 @@ struct NamedMember {
 
   static const char * kind_string(Kind kind) {
     switch(kind) {
-      case Module: return "Module";
-      case Parameter: return "Parameter";
-      case Method: return "Method";
-      case None: return "None";
-      default: return "Unknown";
+      case Module: return "module";
+      case Parameter: return "parameter";
+      case Method: return "method";
+      case None: return "none";
+      default: return "unknown";
     }
   }
 };
@@ -206,6 +206,18 @@ struct Module : public std::enable_shared_from_this<Module> {
 private:
   size_t find_member(const std::string& name, NamedMember::Kind kind) const  {
     auto it = members.find(name);
+    if(it == members.end()) {
+      std::stringstream ss;
+      ss << "unknown " << NamedMember::kind_string(kind) << " '" << name << "'";
+      throw std::runtime_error(ss.str());
+    }
+    if(it->second.kind != kind) {
+      std::stringstream ss;
+      ss << "Expected attribute '" << name << "' to be a "
+        << NamedMember::kind_string(kind) << " but found "
+        << NamedMember::kind_string(it->second.kind);
+      throw std::runtime_error(ss.str());
+    }
     JIT_ASSERT(it != members.end() && it->second.kind == kind);
     return it->second.offset;
   }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -156,6 +156,7 @@ struct Module : public std::enable_shared_from_this<Module> {
     }
   }
   void register_module(const std::string& name, std::shared_ptr<Module> module) {
+    JIT_ASSERT(module);
     modules.push_back(NamedModule {name, std::move(module)});
     add_member(name, NamedMember::Module, modules.size() - 1);
   }
@@ -185,7 +186,8 @@ struct Module : public std::enable_shared_from_this<Module> {
   }
 
   std::shared_ptr<Module> get_module(const std::string& name) const {
-    return modules.at(find_member(name, NamedMember::Module)).module;
+    auto loc = find_member(name, NamedMember::Module);
+    return modules.at(loc).module;
   }
 
   NamedMember::Kind find_attribute(const std::string& name) {
@@ -193,6 +195,12 @@ struct Module : public std::enable_shared_from_this<Module> {
     if(it == members.end())
       return NamedMember::None;
     return it->second.kind;
+  }
+
+  void dump() const {
+    for(auto entry : members) {
+      std::cout << entry.first << ": " << NamedMember::kind_string(entry.second.kind) << "\n";
+    }
   }
 
 private:

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -182,9 +182,10 @@ struct Parser {
   TreeRef parseAttributeValue() {
     int kind = L.cur().kind;
     switch (kind) {
-      case '[':
-        return parseList('[', ',', ']', &Parser::parseConst);
-      default:
+      case '[': {
+        auto list = parseList('[', ',', ']', &Parser::parseConst);
+        return ListLiteral::create(list.range(), List<Expr>(list));
+      } default:
         return parseConst();
     }
   }

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -146,10 +146,15 @@ void initTreeViewBindings(PyObject *module) {
       return UnaryOp::create(range, stringToKind(kind), expr);
     }));
   py::class_<Apply, Expr>(m, "Apply")
-    .def(py::init([](const Ident& name, std::vector<Expr> args, std::vector<Attribute> kwargs) {
-      auto r = name.range();
-      return Apply::create(name.range(), name,
+    .def(py::init([](const Expr& expr, std::vector<Expr> args, std::vector<Attribute> kwargs) {
+      auto r = expr.range();
+      return Apply::create(expr.range(), expr,
                            wrap_list(r, std::move(args)), wrap_list(r, std::move(kwargs)));
+    }));
+  py::class_<Select, Expr>(m, "Select")
+    .def(py::init([](const Expr& expr, const Ident& field) {
+      auto r = expr.range();
+      return Select::create(expr.range(), expr, field);
     }));
   py::class_<TernaryIf, Expr>(m, "TernaryIf")
     .def(py::init([](const Expr& cond, const Expr& true_expr, const Expr& false_expr) {

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -244,7 +244,7 @@ struct Expr : public TreeView {
       case TK_SLICE:
       case TK_GATHER:
       case TK_VAR:
-      case TK_LIST: /* temporarily */
+      case TK_LIST_LITERAL:
         return;
       default:
         throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Expr";
@@ -649,6 +649,19 @@ struct TernaryIf : public Expr {
                           const Expr& false_expr) {
     return TernaryIf(Compound::create(TK_IF_EXPR, range, {cond, true_expr, false_expr}));
   };
+};
+
+
+struct ListLiteral : public TreeView {
+  explicit ListLiteral(const TreeRef& tree) : TreeView(tree) {
+    tree_->match(TK_LIST_LITERAL);
+  }
+  List<Expr> inputs() const {
+    return subtree(0);
+  }
+  static ListLiteral create(const SourceRange& range, const List<Expr>& inputs) {
+    return ListLiteral(Compound::create(TK_LIST_LITERAL, range, {inputs}));
+  }
 };
 
 } // namespace script

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -534,8 +534,8 @@ struct Apply : public Expr {
   explicit Apply(const TreeRef& tree) : Expr(tree) {
     tree_->match(TK_APPLY);
   }
-  Ident name() const {
-    return Ident(subtree(0));
+  Expr callee() const {
+    return Expr(subtree(0));
   }
   List<Expr> inputs() const {
     return List<Expr>(subtree(1));
@@ -545,10 +545,10 @@ struct Apply : public Expr {
   }
   static Apply create(
       const SourceRange& range,
-      const Ident& name,
+      const Expr& callee,
       const List<Expr>& inputs,
       const List<Attribute>& attributes) {
-    return Apply(Compound::create(TK_APPLY, range, {name, inputs, attributes}));
+    return Apply(Compound::create(TK_APPLY, range, {callee, inputs, attributes}));
   }
 };
 

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -244,6 +244,7 @@ struct Expr : public TreeView {
       case TK_SLICE:
       case TK_GATHER:
       case TK_VAR:
+      case TK_LIST: /* temporarily */
         return;
       default:
         throw ErrorReport(tree) << kindToString(tree->kind()) << " is not a valid Expr";
@@ -262,8 +263,8 @@ struct Attribute : public TreeView {
   Ident name() const {
     return Ident(subtree(0));
   }
-  TreeRef value() const {
-    return subtree(1);
+  Expr value() const {
+    return Expr(subtree(1));
   }
   static Attribute create(const SourceRange& range, const Ident& name, const TreeRef& value) {
     return Attribute(Compound::create(TK_ATTRIBUTE, range, {name, value}));

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -834,8 +834,8 @@ const static auto cf_examples = R"JIT(
     return a
 )JIT";
 void testControlFlow() {
-  script::Module cu;
-  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver());
+  script::Module cu(/*optimize=*/true);
+  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver(), nullptr);
   auto run = [&](const std::string & name, std::vector<at::Tensor> stack) {
     auto graph = cu.get_method(name).graph();
     Code code(graph, /*values_are_variables=*/false);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -24,6 +24,7 @@
 
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/script/compiler.h"
+#include "torch/csrc/jit/script/module.h"
 
 #include <vector>
 #include <iostream>
@@ -791,12 +792,12 @@ void testBlocks(std::ostream & out) {
   auto then_block = r->addBlock();
   auto else_block = r->addBlock();
   {
-    WithInsertPoint guard(g, then_block);
+    WithInsertPoint guard(then_block);
     auto t = c + c;
     then_block->registerOutput(t.value());
   }
   {
-    WithInsertPoint guard(g, else_block);
+    WithInsertPoint guard(else_block);
     auto  d = b + c;
     auto e = d + c;
     else_block->registerOutput(e.value());
@@ -833,10 +834,10 @@ const static auto cf_examples = R"JIT(
     return a
 )JIT";
 void testControlFlow() {
-  script::CompilationUnit cu;
-  cu.define(cf_examples, torch::jit::script::Resolver());
+  script::Module cu;
+  script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver());
   auto run = [&](const std::string & name, std::vector<at::Tensor> stack) {
-    auto graph = cu.getGraph(name);
+    auto graph = cu.get_method(name).graph();
     Code code(graph, /*values_are_variables=*/false);
     InterpreterState interp(code);
     interp.runOneStage(stack);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -630,7 +630,7 @@ class CompilationUnit(object):
     def define(self, lang, rcb=None, frame_id=2):
         if not rcb:
             rcb = createResolutionCallback(frame_id)
-        self.module._define(lang, rcb)
+        self.module._define(lang, rcb, False)
 
     def __getattr__(self, attr):
         return self.module._get_method(attr)
@@ -683,6 +683,10 @@ class ScriptModule(torch._C.ScriptModule):
         if r is None:
             raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, attr))
         return r
+
+    def define(self, lang):
+        rcb = createResolutionCallback()
+        self._define(lang, rcb, True)
 
     # TODO: wrap in metaclass to force ScriptMethodStub to run _after_
     # subclass __init__ is finished, rather than rely on user

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -607,6 +607,25 @@ for name, method in _get_methods(torch.nn.Module):
 
 
 def createResolutionCallback(frame_id=2):
+    """
+    Creates a function which, given a string variable name,
+    returns the value of the variable in the scope of the caller of
+    the function which called createResolutionCallback (by default).
+    For example, the following program prints 2::
+    
+        def bar():
+            cb = createResolutionCallback()
+            print(x("foo"))
+
+        def baz():
+            foo = 2
+            bar()
+
+        baz()
+    
+    This is used to enable access in-scope Python variables inside
+    TorchScript fragments.
+    """
     frame = inspect.stack()[frame_id][0]
 
     def env(key):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -612,7 +612,7 @@ def createResolutionCallback(frame_id=2):
     returns the value of the variable in the scope of the caller of
     the function which called createResolutionCallback (by default).
     For example, the following program prints 2::
-    
+
         def bar():
             cb = createResolutionCallback()
             print(x("foo"))
@@ -622,7 +622,7 @@ def createResolutionCallback(frame_id=2):
             bar()
 
         baz()
-    
+
     This is used to enable access in-scope Python variables inside
     TorchScript fragments.
     """
@@ -695,9 +695,6 @@ class ScriptMeta(type(torch._C.ScriptModule)):
 
 
 class ScriptModule(with_metaclass(ScriptMeta, torch._C.ScriptModule)):
-
-    def __init__(self, optimize=True):
-        super(ScriptModule, self).__init__(optimize)
 
     def __setattr__(self, name, value):
         if isinstance(value, Parameter):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -621,7 +621,7 @@ def createResolutionCallback(frame_id=2):
 
 class CompilationUnit(object):
     def __init__(self, lang=None, optimize=True):
-        self.module = torch._C.ScriptModule()
+        self.module = torch._C.ScriptModule(optimize)
         if lang is not None:
             self.define(lang, frame_id=3)
         self.optimize = optimize

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -621,22 +621,18 @@ def createResolutionCallback(frame_id=2):
 
 class CompilationUnit(object):
     def __init__(self, lang=None, optimize=True):
-        self.cu = torch._C.CompilationUnit()
+        self.module = torch._C.ScriptModule()
         if lang is not None:
             self.define(lang, frame_id=3)
-        self.execution_engines = {}
         self.optimize = optimize
 
     def define(self, lang, rcb=None, frame_id=2):
         if not rcb:
             rcb = createResolutionCallback(frame_id)
-        self.cu.define(lang, rcb)
+        self.module.define(lang, rcb)
 
     def __getattr__(self, attr):
-        if attr not in self.execution_engines:
-            graph = self.cu.get_graph(attr)
-            self.execution_engines[attr] = torch._C.GraphExecutor(graph, self.optimize)
-        return self.execution_engines[attr]
+        return self.module.get_method(attr)
 
 
 def script(fn):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -234,11 +234,10 @@ class StmtBuilder(Builder):
         if stmt.dest:
             raise NotSupportedError(r, "print statements with non-default destinations aren't supported")
         args = [build_expr(ctx, val) for val in stmt.values]
-        return ExprStmt(Apply(Ident(r, "print"), args, []))
+        return ExprStmt(Apply(Var(Ident(r, "print")), args, []))
 
 
 class ExprBuilder(Builder):
-    _MethodRef = namedtuple('MethodRef', ['self', 'name'])
     binop_map = {
         ast.Add: '+',
         ast.Sub: '-',
@@ -278,27 +277,18 @@ class ExprBuilder(Builder):
         while source[pos] in _identifier_chars:  # Find the identifier itself
             pos += 1
         name_range = ctx.make_raw_range(start_pos, pos)
-        return ExprBuilder._MethodRef(value, Ident(name_range, expr.attr))
+        return Select(value, Ident(name_range, expr.attr))
 
     @staticmethod
     def build_Call(ctx, expr):
-        ref = build_expr(ctx, expr.func, allow_methods=True)
+        func = build_expr(ctx, expr.func)
         args = [build_expr(ctx, py_arg) for py_arg in expr.args]
         kwargs = []
         for kw in expr.keywords:
-            expr = build_expr(ctx, kw.value)
+            kw_expr = build_expr(ctx, kw.value)
             # XXX: we could do a better job at figuring out the range for the name here
-            kwargs.append(Attribute(Ident(expr.range(), kw.arg), expr))
-        if type(ref) is ExprBuilder._MethodRef:  # Method call
-            return Apply(ref.name, [ref.self] + args, kwargs)
-        elif isinstance(ref, Var):  # Top-level function call
-            return Apply(ref.name, args, kwargs)
-        else:
-            ref_range = ref.range()
-            parenthesis_range = find_after(ctx, ref_range.end, '(')
-            raise FrontendTypeError(
-                ctx.make_raw_range(ref_range.start, parenthesis_range.end),
-                "trying to call a non-function object")
+            kwargs.append(Attribute(Ident(kw_expr.range(), kw.arg), kw_expr))
+        return Apply(func, args, kwargs)
 
     @staticmethod
     def build_Name(ctx, expr):
@@ -373,14 +363,6 @@ class ExprBuilder(Builder):
         # TODO: fix this once we have a nice Number node in our AST
         err_range = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1)
         raise NotSupportedError(err_range, "scalar constants aren't supported")
-
-    def __call__(self, ctx, expr, allow_methods=False):
-        result = super(ExprBuilder, self).__call__(ctx, expr)
-        if type(result) is ExprBuilder._MethodRef and not allow_methods:
-            err_range = ctx.make_raw_range(result.self.range().start, result.name.range().end)
-            raise FrontendTypeError(err_range, "taking attributes/function values isn't supported")
-        return result
-
 
 build_expr = ExprBuilder()
 build_stmt = StmtBuilder()

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -105,7 +105,8 @@ class NotSupportedError(FrontendError):
 class UnsupportedNodeError(NotSupportedError):
     def __init__(self, ctx, offending_node):
         # If we don't have a specific token, we default to length of 1
-        range_len = len(node_start_tokens.get(type(offending_node), ' '))
+        node_type = type(offending_node)
+        range_len = len(node_start_tokens.get(node_type, ' '))
         source_range = ctx.make_range(offending_node.lineno,
                                       offending_node.col_offset,
                                       offending_node.col_offset + range_len)


### PR DESCRIPTION
* Add script::Module C++ class to represent script modules
* switch AST -> IR conversion to work on Modules/Methods rather than raw graphs
* function-only AST -> IR conversion is just a simplified case where there is
only one module with a single method and no parameters.
* introduce SugaredValue in compiler.h to represent values in scope in a script
  function that are not first-class and that get desugared. This is used to
  represent the module's self parameter, as well as python function calls, 
  and method calls on tensor
* provide a Python ScriptModule that provides a nice API on top of script::Module
  allowing for the definition of script modules with methods, parameters,
  and submodules

Not in this  PR but intended for the future:
* ScriptModule actually subclasses nn.Module, with most methods implemented
* Unification of tracedmodule and script module functionality into one container class.