### PR TITLE
Update sparse.py

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -41,7 +41,7 @@ class Embedding(Module):
         >>> # an Embedding module containing 10 tensors of size 3
         >>> embedding = nn.Embedding(10, 3)
         >>> # a batch of 2 samples of 4 indices each
-        >>> input = torch.LongTensor([[1,2,4,5],[4,3,2,9]])
+        >>> input = autograd.Variable(torch.LongTensor([[1,2,4,5],[4,3,2,9]]))
         >>> embedding(input)
 
         (0 ,.,.) =
@@ -59,7 +59,7 @@ class Embedding(Module):
 
         >>> # example with padding_idx
         >>> embedding = nn.Embedding(10, 3, padding_idx=0)
-        >>> input = torch.LongTensor([[0,2,0,5]])
+        >>> input = autograd.Variable(torch.LongTensor([[0,2,0,5]]))
         >>> embedding(input)
 
         (0 ,.,.) =


### PR DESCRIPTION
Change docstring so code doesn't lead to: RuntimeError: save_for_backward can only save input or output tensors, but argument 0 doesn't satisfy this condition