### PR TITLE
Move tensor.index_copy_ 's CPU path to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -283,8 +283,7 @@
     - THIndexTensor* index
 ]]
 [[
-  name: indexCopy_
-  python_name: index_copy_
+  name: _indexCopy_
   cname: indexCopy
   return: argument 0
   arguments:

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -25,6 +25,7 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/ExpandUtils.h"
+#include "ATen/WrapDimUtils.h"
 
 #include <algorithm>
 #include <functional>
@@ -248,6 +249,50 @@ Tensor & index_put_(Tensor & self, TensorList indices, const Tensor & value) {
   std::tie(src, linearIndex) = makeLinearIndex(self, indices);
   std::tie(expandedValue) = expand_inplace(linearIndex, value);
   return src.put_(linearIndex, expandedValue);
+}
+
+Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & source) {
+  dim = maybe_wrap_dim(dim, self.dim());
+
+  if (index.dim() != 1) {
+    runtime_error("index_copy_(): Index should have dimension 1 (got %d)", (int) index.dim());
+  }
+  int64_t numIndices = index.size(0);
+  if (numIndices != source.size(dim)) {
+    runtime_error("index_copy_(): Number of indices (%d) should be equal to source.size(dim) (%d)",
+        (int)numIndices, (int)source.size(dim));
+  }
+  if (index.type().scalarType() != ScalarType::Long) {
+    runtime_error("index_copy_(): Expected LongTensor for index");
+  }
+
+  auto selfSlicedSizes = std::vector<int64_t>(self.sizes());
+  selfSlicedSizes.erase(selfSlicedSizes.begin() + dim);
+  auto sourceSlicedSizes = std::vector<int64_t>(source.sizes());
+  sourceSlicedSizes.erase(sourceSlicedSizes.begin());
+  if (selfSlicedSizes.size() != sourceSlicedSizes.size() ||
+      !std::equal(selfSlicedSizes.begin(), selfSlicedSizes.end(),
+                  sourceSlicedSizes.begin())) {
+    std::stringstream ss;
+    ss << "index_copy_(): Source/destination tensor must have same slice shapes. ";
+    ss << "Destination slice shape: " << selfSlicedSizes << " at dimension " << dim;
+    ss << " and source slice shape: " << sourceSlicedSizes << " at dimension 0.";
+    throw std::runtime_error(ss.str());
+  }
+
+  // Fast path for cuda
+  if (self.is_cuda()) {
+    return self._indexCopy_(dim, index, source);
+  }
+
+  auto workingIndices = index.contiguous();
+  int64_t* index_data = reinterpret_cast<int64_t*>(workingIndices.data_ptr());
+  for (int64_t i = 0; i < numIndices; i++) {
+    auto selfSlice = self.select(dim, index_data[i]);
+    auto sourceSlice = source.select(dim, i);
+    selfSlice.copy_(sourceSlice);
+  }
+  return self;
 }
 
 }} // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -215,6 +215,9 @@
 - func: index(Tensor self, TensorList indices) -> Tensor
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
 
+- func: index_copy_(Tensor self, int64_t dim, IndexTensor index, Tensor source) -> Tensor
+  variants: method
+
 - func: index_put_(Tensor self, TensorList indices, Tensor values) -> Tensor
 
 - func: is_cuda(Tensor self) -> bool

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -325,41 +325,11 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
 
 void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
 {
-  ptrdiff_t i, numel;
-  THTensor *tSlice, *sSlice;
-  int64_t *index_data;
-
-  numel = THLongTensor_nElement(index);
-  THArgCheck(index->nDimension == 1, 3, "Index is supposed to be a vector");
-  THArgCheck(dim < src->nDimension, 4, "Indexing dim %d is out of bounds of tensor", dim + TH_INDEX_BASE);
-  THArgCheck(numel == src->size[dim],4,"Number of indices should be equal to source:size(dim)");
-
-  index = THLongTensor_newContiguous(index);
-  index_data = THLongTensor_data(index);
-
-  if (tensor->nDimension > 1 )
-  {
-    tSlice = THTensor_(new)();
-    sSlice = THTensor_(new)();
-
-    for (i=0; i<numel; i++)
-    {
-      THTensor_(select)(tSlice, tensor, dim, index_data[i] - TH_INDEX_BASE);
-      THTensor_(select)(sSlice, src, dim, i);
-      THTensor_(copy)(tSlice, sSlice);
-    }
-
-    THTensor_(free)(tSlice);
-    THTensor_(free)(sSlice);
-  }
-  else
-  {
-    for (i=0; i<numel; i++)
-    {
-      THTensor_(set1d)(tensor, index_data[i] - TH_INDEX_BASE, THTensor_(get1d)(src,i));
-    }
-  }
-  THLongTensor_free(index);
+  (void)tensor;
+  (void)dim;
+  (void)index;
+  (void)src;
+  THError("THTensor_(indexCopy)'s implementation has moved to ATen (see index_copy_)");
 }
 
 static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1094,6 +1094,9 @@ class TestCuda(TestCase):
         z = torch.randn(2, 2, 1).cuda()
         self.assertRaises(RuntimeError, lambda: torch.cat([x, y, z], dim=1))
 
+    def test_index_copy(self):
+        TestTorch._test_index_copy(self, lambda x: x.cuda())
+
     def test_serialization(self):
         x = torch.randn(4, 4).cuda()
         with tempfile.NamedTemporaryFile() as f:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3841,25 +3841,29 @@ class TestTorch(TestCase):
         with self.assertRaises(IndexError):
             reference[0.0, :, 0.0] = 1
 
-    def test_index_copy(self):
+    @staticmethod
+    def _test_index_copy(self, cast):
         num_copy, num_dest = 3, 20
-        dest = torch.randn(num_dest, 4, 5)
-        src = torch.randn(num_copy, 4, 5)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
+        dest = cast(torch.randn(num_dest, 4, 5))
+        src = cast(torch.randn(num_copy, 4, 5))
+        idx = cast(torch.randperm(num_dest).narrow(0, 0, num_copy))
         dest2 = dest.clone()
         dest.index_copy_(0, idx, src)
         for i in range(idx.size(0)):
             dest2[idx[i]] = src[i]
         self.assertEqual(dest, dest2, 0)
 
-        dest = torch.randn(num_dest)
-        src = torch.randn(num_copy)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
+        dest = cast(torch.randn(num_dest))
+        src = cast(torch.randn(num_copy))
+        idx = cast(torch.randperm(num_dest).narrow(0, 0, num_copy))
         dest2 = dest.clone()
         dest.index_copy_(0, idx, src)
         for i in range(idx.size(0)):
             dest2[idx[i]] = src[i]
         self.assertEqual(dest, dest2, 0)
+
+    def test_index_copy(self):
+        return self._test_index_copy(self, lambda x: x)
 
     def test_index_add(self):
         num_copy, num_dest = 3, 3

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -17,6 +17,7 @@ SKIP_PYTHON_BINDINGS = [
     'alias', 'contiguous', 'clamp.*', 'is_cuda', 'is_sparse', 'size', 'stride',
     '.*_backward', '.*_backward_out', '.*_forward', '.*_forward_out',
     'sparse_raw_resize_', '_unsafe_view', 'tensor', 'sparse_coo_tensor',
+    '_indexCopy_',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
Fixes #1777.

Previously, there was a bug where index_copy on CUDA would not error out if the shape of the source slice (in dimension 0) is not equal to the shape of the destination slice (in the specified dimension).
For example,
```
x = torch.zeros(3, 1)
t = torch.arange(3)
index = torch.LongTensor([2, 1, 0])
x.index_copy_(0, index, t) # x has slizes of size (1, 1) in dimension 0 but t has zero-dim slices in dimension 0.
```
would work on CUDA but not on CPU. This PR changes it so that both the CPU and CUDA paths use the same error checking so that the above code will error out on both CPU and CUDA.

To do this, I moved the CPU implementation of index_copy_ to ATen.