### PR TITLE
import torch.jit in torch/__init__.py

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -240,6 +240,7 @@ import torch.multiprocessing
 import torch.sparse
 import torch.utils.backcompat
 import torch.onnx
+import torch.jit
 import torch.random
 import torch.distributions
 import torch.testing

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -335,7 +335,6 @@ class Module(object):
         return None
 
     def _slow_forward(self, *input, **kwargs):
-        import torch.jit
         input_vars = tuple(torch.autograd.function._iter_variables(input))
         tracing_state = torch.jit.get_tracing_state(input_vars)
         if not tracing_state:
@@ -356,7 +355,6 @@ class Module(object):
         return result
 
     def __call__(self, *input, **kwargs):
-        import torch.jit
         for hook in self._forward_pre_hooks.values():
             hook(self, input)
         if torch.jit._tracing:


### PR DESCRIPTION
previously, it was being implicitly imported via the import of
torch.onnx

this is no longer the case, and is a hacky thing to depend on anyway,
so import it explicitly