### PR TITLE
Add additional deprecated overloads with out kwarg

### DIFF
--- a/tools/autograd/deprecated.yaml
+++ b/tools/autograd/deprecated.yaml
@@ -10,20 +10,38 @@
 - name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2)
   aten: addbmm(self, batch1, batch2, beta, alpha)
 
+- name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor out)
+  aten: addbmm_out(out, self, batch1, batch2, beta, alpha)
+
 - name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2)
   aten: addbmm(self, batch1, batch2, beta, 1)
+
+- name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor out)
+  aten: addbmm_out(out, self, batch1, batch2, beta, 1)
 
 - name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2)
   aten: addcdiv(self, tensor1, tensor2, value)
 
+- name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor out)
+  aten: addcdiv_out(out, self, tensor1, tensor2, value)
+
 - name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2)
   aten: addcmul(self, tensor1, tensor2, value)
+
+- name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor out)
+  aten: addcmul_out(out, self, tensor1, tensor2, value)
 
 - name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2)
   aten: addmm(self, mat1, mat2, beta, alpha)
 
+- name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2, *, Tensor out)
+  aten: addmm_out(out, self, mat1, mat2, beta, alpha)
+
 - name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
   aten: addmm(self, mat1, mat2, beta, 1)
+
+- name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2, *, Tensor out)
+  aten: addmm_out(out, self, mat1, mat2, beta, 1)
 
 - name: sspaddmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2)
   aten: sspaddmm(self, mat1, mat2, beta, alpha)
@@ -34,20 +52,41 @@
 - name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec)
   aten: addmv(self, mat, vec, beta, alpha)
 
+- name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec, *, Tensor out)
+  aten: addmv_out(out, self, mat, vec, beta, alpha)
+
 - name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec)
   aten: addmv(self, mat, vec, beta, 1)
+
+- name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec, *, Tensor out)
+  aten: addmv_out(out, self, mat, vec, beta, 1)
 
 - name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2)
   aten: addr(self, vec1, vec2, beta, alpha)
 
+- name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2, *, Tensor out)
+  aten: addr_out(out, self, vec1, vec2, beta, alpha)
+
 - name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2)
   aten: addr(self, vec1, vec2, beta, 1)
+
+- name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2, *, Tensor out)
+  aten: addr_out(out, self, vec1, vec2, beta, 1)
 
 - name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2)
   aten: baddbmm(self, batch1, batch2, beta, alpha)
 
+- name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor out)
+  aten: baddbmm_out(out, self, batch1, batch2, beta, alpha)
+
 - name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2)
   aten: baddbmm(self, batch1, batch2, beta, 1)
 
+- name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor out)
+  aten: baddbmm_out(out, self, batch1, batch2, beta, 1)
+
 - name: sub(Tensor self, Scalar alpha, Tensor other)
   aten: sub(self, other, alpha)
+
+- name: sub(Tensor self, Scalar alpha, Tensor other, *, Tensor out)
+  aten: sub_out(out, self, other, alpha)


### PR DESCRIPTION
This improves backwards compatiblity with 0.3. It adds support for
the out kwarg for the deprecated overloads that have optional
positional alpha/beta/scale arguments.

The addcmul(self, value, tensor1, tensor2, out=self) syntax is used by
gpytorch.