### PR TITLE
Fix binary operations with scalars

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -55,14 +55,20 @@ _(==,x.eq(y), y.eq(x)) \
 _(!=,x.ne(y), y.ne(x))
 
 #define DEFINE_OPERATOR(op,body,reverse_scalar_body) \
-static inline Tensor operator op(const Tensor & x, const Tensor & y) { \
-  return body; \
-} \
 static inline Tensor operator op(const Tensor & x, Scalar y) { \
   return body; \
 } \
 static inline Tensor operator op(Scalar x, const Tensor & y) { \
   return reverse_scalar_body; \
+} \
+static inline Tensor operator op(const Tensor & x, const Tensor & y) { \
+  /* XXX: it is important that we avoid casting tensors to scalars here, \
+   * because this code is also used for autograd, and that would \
+   * break differentiation */ \
+  if (x.dim() == 0) { \
+    return reverse_scalar_body; \
+  } \
+  return body; \
 }
 
 

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -1,6 +1,7 @@
 import re
 from copy import deepcopy
 from function_wrapper import TYPE_FORMAL_GENERIC
+from function_wrapper import signature as signature_base
 import common_with_cwrap
 
 type_map = {
@@ -141,6 +142,7 @@ def sanitize_return(option):
 def set_mode(option):
     option['mode'] = option.get('mode', 'TH')
 
+
 # To enable 0-dim support in TH operations
 # we find all places where a single Scalar replaced with a Tensor
 # as an argument is still a valid function
@@ -153,11 +155,8 @@ def discover_zero_dim_tensor_operations(declaration):
         return arg.get('ignore_check')
 
     def signature(option, i=None, value=None):
-        elements = [TYPE_FORMAL_GENERIC.get(arg['type'], arg['type'])
-                    if i is None or j != i else value
-                    for j, arg in enumerate(option['arguments'])
-                    if not exclude(arg)]
-        return '#'.join(elements)
+        return signature_base(option['arguments'], i, value, exclude)
+
     signature_to_option = {signature(option): option
                            for option in declaration['options']}
 
@@ -178,11 +177,7 @@ def discover_sparse_tensor_operations(declaration):
         return arg.get('ignore_check')
 
     def signature(option, i=None, value=None):
-        elements = [TYPE_FORMAL_GENERIC.get(arg['type'], arg['type'])
-                    if i is None or j != i else value
-                    for j, arg in enumerate(option['arguments'])
-                    if not exclude(arg)]
-        return '#'.join(elements)
+        return signature_base(option['arguments'], i, value, exclude)
 
     # Determine if any options have the 'aten_dense_sparse' flag
     dense_sparse_options = [option

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -148,8 +148,6 @@ def set_mode(option):
 # where 'name' is the name of the argument that should be a scalar
 # during dispatch, if that argument is marked internally as holding a scalar
 # then the method will dispatch to that function.
-
-
 def discover_zero_dim_tensor_operations(declaration):
     def exclude(arg):
         return arg.get('ignore_check')
@@ -173,12 +171,6 @@ def discover_zero_dim_tensor_operations(declaration):
                     names = [arg['name'] for arg in tensor_version['arguments']
                              if not exclude(arg)]
                     tensor_version['zero_dim_dispatch_when_scalar'] = names[i]
-                    # print("FOUND "+str(i)   )
-                    # print("Scalar Version ===== ")
-                    # print(yaml.dump(option))
-                    # print("Tensor Version ===== ")
-                    # print(yaml.dump(tensor_version))
-                    # print("SHARED "+names[i])
 
 
 def discover_sparse_tensor_operations(declaration):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5,6 +5,7 @@ import math
 import torch
 import unittest
 import warnings
+import operator
 from copy import deepcopy
 from collections import OrderedDict
 from itertools import product
@@ -1816,6 +1817,20 @@ class TestAutograd(TestCase):
         run_test((10,), 3)
         run_test((10,), 1)
         run_test((10,), 1.5)
+
+    def test_scalar_binop_grad(self):
+        x = torch.randn(2, 2, dtype=torch.float, requires_grad=True)
+        y = torch.tensor(2., dtype=torch.double, requires_grad=True)
+
+        operators = [
+            operator.add, operator.sub, operator.mul, operator.truediv, operator.pow,
+        ]
+
+        for arg1, arg2, arg_same_type in [(x, y, y.float()), (y, x, x.double())]:
+            for op in operators:
+                g1, g2 = torch.autograd.grad(op(arg1, arg2).sum(), (arg1, arg2))
+                self.assertIsNotNone(g1)
+                self.assertIsNotNone(g2)
 
     def test_profiler(self):
         x = Variable(torch.randn(10, 10))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 import warnings
 import pickle
+import operator
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from itertools import product, combinations
 from functools import reduce
@@ -688,6 +689,22 @@ class TestTorch(TestCase):
         # Divisor is a tensor case
         long_res1 = long_m1.clone()
         long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
+
+    def test_cross_type_binary_operators(self):
+        x = torch.randn(2, 2, dtype=torch.float)
+        y = torch.tensor(2., dtype=torch.double)
+
+        operators = [
+            operator.add, operator.sub, operator.mul, operator.floordiv, operator.truediv,
+            operator.pow, operator.mod, operator.lt, operator.le, operator.gt,
+            operator.ge, operator.eq, operator.ne
+        ]
+
+        x + y
+        y + x
+        # for arg1, arg2, arg_same_type in [(x, y, y.float()), (y, x, x.double())]:
+            # for op in operators:
+                # self.assertEqual(op(arg1, arg2), op(arg1, arg_same_type))
 
     def test_mm(self):
         # helper function

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -695,16 +695,14 @@ class TestTorch(TestCase):
         y = torch.tensor(2., dtype=torch.double)
 
         operators = [
-            operator.add, operator.sub, operator.mul, operator.floordiv, operator.truediv,
+            operator.add, operator.sub, operator.mul, operator.truediv,
             operator.pow, operator.mod, operator.lt, operator.le, operator.gt,
             operator.ge, operator.eq, operator.ne
         ]
 
-        x + y
-        y + x
-        # for arg1, arg2, arg_same_type in [(x, y, y.float()), (y, x, x.double())]:
-            # for op in operators:
-                # self.assertEqual(op(arg1, arg2), op(arg1, arg_same_type))
+        for arg1, arg2, arg_same_type in [(x, y, y.float()), (y, x, x.double())]:
+            for op in operators:
+                self.assertEqual(op(arg1, arg2), op(arg1, arg_same_type))
 
     def test_mm(self):
         # helper function

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -328,12 +328,6 @@ class Variable(_C._VariableBase):
 
     __neg__ = _C._VariableBase.neg
 
-    __eq__ = _C._VariableBase.eq
-    __ne__ = _C._VariableBase.ne
-    __lt__ = _C._VariableBase.lt
-    __le__ = _C._VariableBase.le
-    __gt__ = _C._VariableBase.gt
-    __ge__ = _C._VariableBase.ge
     __abs__ = _C._VariableBase.abs
 
     def __len__(self):

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -313,8 +313,6 @@ class Variable(_C._VariableBase):
     __rtruediv__ = __rdiv__
     __itruediv__ = _C._VariableBase.__idiv__
 
-    __pow__ = _C._VariableBase.pow
-
     def __format__(self, format_spec):
         if self.dim() == 0:
             return self.item().__format__(format_spec)


### PR DESCRIPTION
If you have a double scalar and float tensor, then we currently allow doing `tensor + scalar` (and correctly cast the scalar), while `scalar + tensor` fails and complains that the types don't match. This commit also unifies ATen C++ operators with Python operators to make sure that they will always have the same semantics (this is useful in the JIT too).

There's a bit of awkwardness when dealing with these situations because we generally want to treat scalars as tensors in autograd (to record their history), but we want 0d tensors to behave like scalars in ATen (to allow implicit type casts). I've played with it for a while, but it's hard to disentangle them and come up with a good solution.