### PR TITLE
Fixes the InstanceNorm and LayerNorm momentum doc

### DIFF
--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -44,7 +44,7 @@ class InstanceNorm1d(_InstanceNorm):
         This :attr:`momentum` argument is different from one used in optimizer
         classes and the conventional notion of momentum. Mathematically, the
         update rule for running statistics here is
-        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x}_\text{new} + \text{momemtum} x_t`,
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x} + \text{momemtum} x_t`,
         where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
         new observed value.
 
@@ -107,7 +107,7 @@ class InstanceNorm2d(_InstanceNorm):
         This :attr:`momentum` argument is different from one used in optimizer
         classes and the conventional notion of momentum. Mathematically, the
         update rule for running statistics here is
-        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x}_\text{new} + \text{momemtum} x_t`,
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x} + \text{momemtum} x_t`,
         where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
         new observed value.
 
@@ -170,7 +170,7 @@ class InstanceNorm3d(_InstanceNorm):
         This :attr:`momentum` argument is different from one used in optimizer
         classes and the conventional notion of momentum. Mathematically, the
         update rule for running statistics here is
-        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x}_\text{new} + \text{momemtum} x_t`,
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x} + \text{momemtum} x_t`,
         where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
         new observed value.
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -103,7 +103,7 @@ class LayerNorm(Module):
         This :attr:`momentum` argument is different from one used in optimizer
         classes and the conventional notion of momentum. Mathematically, the
         update rule for running statistics here is
-        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x}_\text{new} + \text{momemtum} x_t`,
+        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \hat{x} + \text{momemtum} x_t`,
         where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
         new observed value.
 


### PR DESCRIPTION
Fixes the InstanceNorm and LayerNorm momentum doc. Similar to the the issue with BN in https://github.com/pytorch/pytorch/issues/5625.