### PR TITLE
Give ATen/gen.py output directory option

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -359,10 +359,12 @@ def declare_outputs():
 
 
 def filter_by_extension(files, *extensions):
+    filtered_files = []
     for file in files:
         for extension in extensions:
             if file.endswith(extension):
-                yield file
+                filtered_files.append(file)
+    return filtered_files
 
 
 def generate_outputs():

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -53,7 +53,7 @@ class FileManager(object):
         self.undeclared_files = []
 
     def will_write(self, filename):
-        filename = os.path.join(options.output_dir, filename)
+        filename = '{}/{}'.format(options.output_dir, filename)
         if self.outputs_written:
             raise Exception("'will_write' can only be called before " +
                             "the call to write_outputs, refactor so outputs are registered " +
@@ -79,7 +79,7 @@ class FileManager(object):
         self.outputs_written = True
 
     def write(self, filename, s):
-        filename = os.path.join(options.output_dir, filename)
+        filename = '{}/{}'.format(options.output_dir, filename)
         self._write_if_changed(filename, s)
         if filename not in self.filenames:
             self.undeclared_files.append(filename)


### PR DESCRIPTION
Adds `--output-dir` option to `ATen/gen.py`. We need this to generate separate CPU and GPU files within the same repository.

Also replaced optparse with argparse while I was at it, since optparse is deprecated in Python 3

@soumith @apaszke @zdevito 