### PR TITLE
Add torch.empty, torch.full and new_ size Tensor factory methods.

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -260,7 +260,6 @@ Tensor zeros_like(const Tensor& self, const Type& dtype) {
     auto res = dtype.tensor();
     // resize_as_ requires the same exact type.
     res.sparse_raw_resize_(self.sizes(), self._dimI(), self._dimV());
-    res.zero_();
     return res;
   }
   return at::native::zeros(dtype, self.sizes());

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -26,12 +26,31 @@ Tensor& arange_out(Tensor& result, Scalar end) {
   return at::_arange_out(result, end);
 }
 
+Tensor empty(const Type& dtype, IntList size) {
+  return dtype.tensor(size);
+}
+
+Tensor& empty_out(Tensor& result, IntList size) {
+  if (result.is_sparse()) {
+    result.sparse_raw_resize_(size, size.size(), 0);
+  } else {
+    result.resize_(size);
+  }
+  return result;
+}
+
 Tensor empty_like(const Tensor& self) {
-  return self.type().tensor(self.sizes());
+  return at::native::empty_like(self, self.type());
 }
 
 Tensor empty_like(const Tensor& self, const Type& dtype) {
-  return dtype.tensor(self.sizes());
+  if (dtype.is_sparse() && self.type().is_sparse()) {
+    auto res = dtype.tensor();
+    // resize_as_ requires the same exact type.
+    res.sparse_raw_resize_(self.sizes(), self._dimI(), self._dimV());
+    return res;
+  }
+  return at::native::empty(dtype, self.sizes());
 }
 
 Tensor eye(const Type& dtype, int64_t n, int64_t m) {
@@ -61,6 +80,30 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
   });
 
   return result;
+}
+
+Tensor full(const Type& dtype, IntList size, Scalar fill_value) {
+  if (dtype.is_sparse()) {
+    at::runtime_error("full(...) is not implemented for sparse types, got: %s", dtype.toString());
+  }
+  auto result = dtype.tensor(size);
+  return result.fill_(fill_value);
+}
+
+Tensor& full_out(Tensor& result, IntList size, Scalar fill_value) {
+  if (result.is_sparse()) {
+    at::runtime_error("full(...) is not implemented for sparse types, got: %s", result.type().toString());
+  }
+  result.resize_(size);
+  return result.fill_(fill_value);
+}
+
+Tensor full_like(const Tensor& self, Scalar fill_value) {
+  return at::native::full_like(self, fill_value, self.type());
+}
+
+Tensor full_like(const Tensor& self, Scalar fill_value, const Type& dtype) {
+  return at::native::full(dtype, self.sizes(), fill_value);
 }
 
 Tensor linspace(const Type& dtype, Scalar start, Scalar end, int64_t steps) {
@@ -215,7 +258,8 @@ Tensor zeros_like(const Tensor& self) {
 Tensor zeros_like(const Tensor& self, const Type& dtype) {
   if (dtype.is_sparse() && self.type().is_sparse()) {
     auto res = dtype.tensor();
-    res.resize_as_(self);
+    // resize_as_ requires the same exact type.
+    res.sparse_raw_resize_(self.sizes(), self._dimI(), self._dimV());
     res.zero_();
     return res;
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -189,12 +189,6 @@
 - func: embedding_sparse_backward(Tensor grad, IndexTensor indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq) -> Tensor
   variants: function
 
-- func: empty_like(Tensor self) -> Tensor
-  variants: function
-
-- func: empty_like(Tensor self, *, Type dtype) -> Tensor
-  variants: function
-
 - func: embedding_bag(Tensor weight, IndexTensor indices, IndexTensor offsets, bool scale_grad_by_freq=false, int64_t mode=0, bool sparse=false) -> (Tensor, Tensor, Tensor)
   variants: function
   dispatch:
@@ -213,6 +207,18 @@
     CPU: embedding_bag_backward_cpu
     CUDA: embedding_bag_backward_cuda
 
+- func: empty(Type dtype, IntList size) -> Tensor
+  variants: function
+
+- func: empty_out(Tensor result, IntList size) -> Tensor
+  variants: function
+
+- func: empty_like(Tensor self) -> Tensor
+  variants: function
+
+- func: empty_like(Tensor self, *, Type dtype) -> Tensor
+  variants: function
+
 - func: expand(Tensor self, IntList size) -> Tensor
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
@@ -227,6 +233,18 @@
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
+
+- func: full(Type dtype, IntList size, Scalar fill_value) -> Tensor
+  variants: function
+
+- func: full_out(Tensor result, IntList size, Scalar fill_value) -> Tensor
+  variants: function
+
+- func: full_like(Tensor self, Scalar fill_value) -> Tensor
+  variants: function
+
+- func: full_like(Tensor self, Scalar fill_value, *, Type dtype) -> Tensor
+  variants: function
 
 - func: hinge_embedding_loss(Tensor self, Tensor target, double margin, bool size_average, bool reduce) -> Tensor
   variants: function

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -845,13 +845,17 @@ class TestSparse(TestCase):
 
     @cpu_only  # not really, but we only really want to run this once
     def test_dtypes(self):
-        cpum = torch.sparse
-        cpu_dtypes = [cpum.uint8, cpum.int8, cpum.int16, cpum.int32, cpum.int64,
-                      cpum.float32, cpum.float64]
-        cudam = torch.cuda.sparse
-        cuda_dtypes = [cudam.uint8, cudam.int8, cudam.int16, cudam.int32, cudam.int64,
-                       cudam.float32, cudam.float64]
+        all_dtypes = torch.testing.get_all_dtypes()
+        cpu_dtypes = [d for d in all_dtypes if d.is_sparse and not d.is_cuda]
+        cuda_dtypes = [d for d in all_dtypes if d.is_sparse and d.is_cuda]
         TestTorch._test_dtypes(self, cpu_dtypes, cuda_dtypes, True)
+
+    @cpu_only  # not really, but we only really want to run this once
+    def test_empty_full(self):
+        all_dtypes = torch.testing.get_all_dtypes()
+        cpu_dtypes = [d for d in all_dtypes if d.is_sparse and not d.is_cuda]
+        cuda_dtypes = [d for d in all_dtypes if d.is_sparse and d.is_cuda]
+        TestTorch._test_empty_full(self, cpu_dtypes, cuda_dtypes)
 
     def test_is_sparse(self):
         x = torch.randn(3, 3)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3,6 +3,7 @@ import io
 import os
 import math
 import random
+import operator
 import copy
 import torch
 import torch.cuda
@@ -1172,12 +1173,69 @@ class TestTorch(TestCase):
             self.assertEqual(is_sparse, dtype.is_sparse)
 
     def test_dtypes(self):
-        cpu_dtypes = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
-                      torch.float16, torch.float32, torch.float64]
-        cuda_dtypes = [torch.cuda.uint8, torch.cuda.int8, torch.cuda.int16, torch.cuda.int32, torch.cuda.int64,
-                       torch.cuda.float32, torch.cuda.float64]
-        cuda_dtypes.append(torch.cuda.float16)
+        all_dtypes = torch.testing.get_all_dtypes()
+        cpu_dtypes = [d for d in all_dtypes if not d.is_cuda and not d.is_sparse]
+        cuda_dtypes = [d for d in all_dtypes if d.is_cuda and not d.is_sparse]
         self._test_dtypes(self, cpu_dtypes, cuda_dtypes, False)
+
+    @staticmethod
+    def _test_empty_full(self, cpu_dtypes, cuda_dtypes):
+        dtypes = cpu_dtypes + (cuda_dtypes if torch.cuda.is_available() else [])
+        shape = torch.Size([2, 3])
+
+        def check_value(tensor, dtype, device, value, requires_grad):
+            self.assertEqual(shape, tensor.shape)
+            self.assertIs(dtype, tensor.dtype)
+            self.assertEqual(tensor.requires_grad, requires_grad)
+            if tensor.is_cuda:
+                self.assertEqual(device, tensor.get_device())
+            if value is not None:
+                fill = tensor.new(shape).fill_(value)
+                self.assertEqual(tensor, fill)
+
+        def get_int64_dtype(dtype):
+            module = '.'.join(str(dtype).split('.')[1:-1])
+            if not module:
+                return torch.int64
+            return operator.attrgetter(module)(torch).int64
+
+        check_value(torch.empty(shape), torch.Tensor.dtype, -1, None, False)
+        check_value(torch.full(shape, -5), torch.Tensor.dtype, -1, None, False)
+        for dtype in dtypes:
+            for rg in [True, False]:
+                int64_dtype = get_int64_dtype(dtype)
+                device = -1 if not (dtype.is_cuda and torch.cuda.device_count() > 1) else 1
+                v = torch.empty(shape, dtype=dtype, device=device, requires_grad=rg)
+                check_value(v, dtype, device, None, rg)
+                out = v.new()
+                check_value(torch.empty(shape, out=out, device=device, requires_grad=rg),
+                            dtype, device, None, rg)
+                check_value(v.new_empty(shape), dtype, device, None, False)
+                check_value(v.new_empty(shape, dtype=int64_dtype, device=device, requires_grad=rg),
+                            int64_dtype, device, None, rg)
+                check_value(torch.empty_like(v), dtype, device, None, False)
+                check_value(torch.empty_like(v, dtype=int64_dtype, device=device, requires_grad=rg),
+                            int64_dtype, device, None, rg)
+
+                if dtype is not torch.float16 and not dtype.is_sparse:
+                    fv = 3
+                    v = torch.full(shape, fv, dtype=dtype, device=device, requires_grad=rg)
+                    check_value(v, dtype, device, fv, rg)
+                    check_value(v.new_full(shape, fv + 1), dtype, device, fv + 1, False)
+                    out = v.new()
+                    check_value(torch.full(shape, fv + 2, out=out, device=device, requires_grad=rg),
+                                dtype, device, fv + 2, rg)
+                    check_value(v.new_full(shape, fv + 3, dtype=int64_dtype, device=device, requires_grad=rg),
+                                int64_dtype, device, fv + 3, rg)
+                    check_value(torch.full_like(v, fv + 4), dtype, device, fv + 4, False)
+                    check_value(torch.full_like(v, fv + 5, dtype=int64_dtype, device=device, requires_grad=rg),
+                                int64_dtype, device, fv + 5, rg)
+
+    def test_empty_full(self):
+        all_dtypes = torch.testing.get_all_dtypes()
+        cpu_dtypes = [d for d in all_dtypes if not d.is_cuda and not d.is_sparse]
+        cuda_dtypes = [d for d in all_dtypes if d.is_cuda and not d.is_sparse]
+        self._test_empty_full(self, cpu_dtypes, cuda_dtypes)
 
     def test_dtype_out_match(self):
         d = torch.autograd.Variable(torch.DoubleTensor(2, 3))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1187,7 +1187,7 @@ class TestTorch(TestCase):
             self.assertEqual(shape, tensor.shape)
             self.assertIs(dtype, tensor.dtype)
             self.assertEqual(tensor.requires_grad, requires_grad)
-            if tensor.is_cuda:
+            if tensor.is_cuda and device != -1:
                 self.assertEqual(device, tensor.get_device())
             if value is not None:
                 fill = tensor.new(shape).fill_(value)

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -478,12 +478,48 @@ static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwar
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_new_empty(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
+  return THPVariable_Wrap(torch::utils::new_empty(self_.type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_new_full(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
+  return THPVariable_Wrap(torch::utils::new_full(self_.type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_new_ones(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
+  return THPVariable_Wrap(torch::utils::new_ones(self_.type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * THPVariable_new_tensor(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   AutoGPU auto_gpu(self_);
   return THPVariable_Wrap(torch::utils::new_tensor(self_.type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_new_zeros(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  AutoGPU auto_gpu(self_);
+  return THPVariable_Wrap(torch::utils::new_zeros(self_.type(), args, kwargs));
   END_HANDLE_TH_ERRORS
 }
 
@@ -593,7 +629,11 @@ PyMethodDef variable_methods[] = {
   {"ndimension", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
   {"nelement", (PyCFunction)THPVariable_numel, METH_NOARGS, NULL},
   {"new", (PyCFunction)THPVariable_new, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"new_empty", (PyCFunction)THPVariable_new_empty, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"new_full", (PyCFunction)THPVariable_new_full, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"new_ones", (PyCFunction)THPVariable_new_ones, METH_VARARGS | METH_KEYWORDS, NULL},
   {"new_tensor", (PyCFunction)THPVariable_new_tensor, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"new_zeros", (PyCFunction)THPVariable_new_zeros, METH_VARARGS | METH_KEYWORDS, NULL},
   {"numpy", (PyCFunction)THPVariable_numpy, METH_NOARGS, NULL},
   {"record_stream", (PyCFunction)THPVariable_record_stream, METH_O, NULL},
   {"short", (PyCFunction)THPVariable_short, METH_NOARGS, NULL},

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -29,6 +29,27 @@ static void maybe_initialize_cuda(const at::Type &type) {
   }
 }
 
+static Tensor dispatch_zeros(const Type& type, int device, IntList sizes) {
+  maybe_initialize_cuda(type);
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(device);
+  return type.zeros(sizes);
+}
+
+static Tensor dispatch_ones(const Type& type, int device, IntList sizes) {
+  maybe_initialize_cuda(type);
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(device);
+  return type.ones(sizes);
+}
+
+static Tensor dispatch_full(const Type& type, Scalar fill_value, int device, IntList sizes) {
+  maybe_initialize_cuda(type);
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(device);
+  return type.full(sizes, fill_value);
+}
+
 static Tensor new_with_sizes(const Type& type, int device, IntList sizes) {
   maybe_initialize_cuda(type);
   AutoNoGIL no_gil;
@@ -333,6 +354,62 @@ Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
     return set_requires_grad(new_from_data(r.typeWithDefault(1, type), r.toInt64(2), r.pyobject(0)), r.toBool(3));
   }
   throw std::runtime_error("new_tensor(): invalid arguments");
+}
+
+Tensor new_empty(const at::Type& type, PyObject* args, PyObject* kwargs) {
+  static PythonArgParser parser({
+    "new_empty(IntList size, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+  });
+
+  ParsedArgs<4> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    const auto& actual_type = r.typeWithDefault(1, type);
+    return set_requires_grad(new_with_sizes(actual_type, r.toInt64(2), r.intlist(0)), r.toBool(3));
+  }
+  throw std::runtime_error("new_empty(): invalid arguments");
+}
+
+Tensor new_full(const at::Type& type, PyObject* args, PyObject* kwargs) {
+  static PythonArgParser parser({
+    "new_full(IntList size, Scalar fill_value, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+  });
+
+  ParsedArgs<5> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    const auto& actual_type = r.typeWithDefault(2, type);
+    return set_requires_grad(dispatch_full(actual_type, r.scalar(1), r.toInt64(3), r.intlist(0)), r.toBool(4));
+  }
+  throw std::runtime_error("new_full(): invalid arguments");
+}
+
+Tensor new_ones(const at::Type& type, PyObject* args, PyObject* kwargs) {
+  static PythonArgParser parser({
+    "new_ones(IntList size, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+  });
+
+  ParsedArgs<4> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    const auto& actual_type = r.typeWithDefault(1, type);
+    return set_requires_grad(dispatch_ones(actual_type, r.toInt64(2), r.intlist(0)), r.toBool(3));
+  }
+  throw std::runtime_error("new_ones(): invalid arguments");
+}
+
+Tensor new_zeros(const at::Type& type, PyObject* args, PyObject* kwargs) {
+  static PythonArgParser parser({
+    "new_zeros(IntList size, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+  });
+
+  ParsedArgs<4> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    const auto& actual_type = r.typeWithDefault(1, type);
+    return set_requires_grad(dispatch_zeros(actual_type, r.toInt64(2), r.intlist(0)), r.toBool(3));
+  }
+  throw std::runtime_error("new_zeros(): invalid arguments");
 }
 
 }} // namespace torch::utils

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -8,6 +8,10 @@ namespace torch { namespace utils {
 at::Tensor legacy_tensor_ctor(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor legacy_tensor_new(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor new_tensor(const at::Type& type, PyObject* args, PyObject* kwargs);
-at::Tensor new_from_data(const at::Type & type, int device, PyObject *data);
+at::Tensor new_from_data(const at::Type& type, int device, PyObject *data);
+at::Tensor new_empty(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor new_full(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor new_ones(const at::Type& type, PyObject* args, PyObject* kwargs);
+at::Tensor new_zeros(const at::Type& type, PyObject* args, PyObject* kwargs);
 
 }} // namespace torch::utils

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -37,5 +37,18 @@ def make_non_contiguous(tensor):
     return input
 
 
+def get_all_dtypes():
+    cpu_dtypes = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
+                  torch.float16, torch.float32, torch.float64]
+    cuda_dtypes = [torch.cuda.uint8, torch.cuda.int8, torch.cuda.int16, torch.cuda.int32, torch.cuda.int64,
+                   torch.cuda.float16, torch.cuda.float32, torch.cuda.float64]
+    cpum = torch.sparse
+    cpu_sparse_dtypes = [cpum.uint8, cpum.int8, cpum.int16, cpum.int32, cpum.int64,
+                         cpum.float32, cpum.float64]
+    cudam = torch.cuda.sparse
+    cuda_sparse_dtypes = [cudam.uint8, cudam.int8, cudam.int16, cudam.int32, cudam.int64,
+                          cudam.float32, cudam.float64]
+    return cpu_dtypes + cuda_dtypes + cpu_sparse_dtypes + cuda_sparse_dtypes
+
 rand_like = torch._C._VariableFunctions.rand_like
 randn_like = torch._C._VariableFunctions.randn_like


### PR DESCRIPTION
This adds torch.full, torch.empty equivalents of np.full, np.empty.
In addition, this adds size-based Tensor factory methods new_empty, new_ones, new_full, new_zeros,
which is meant to complete the separation of the legacy "new" method into data-based and size-based
functions.

This also fixes an issue in sparse zeros_like when the dtype didn't match the argument dtype.