### PR TITLE
Handling of scalars in torch.Size

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7100,6 +7100,19 @@ class TestTorch(TestCase):
         self.assertIsInstance(x[:-1], torch.Size)
         self.assertIsInstance(x + x, torch.Size)
 
+    def test_Size_scalar(self):
+        three = torch.tensor(3)
+        two = torch.tensor(2)
+        x = torch.Size([0, 1, two, three, 4])
+        for i in range(1, 5):
+            self.assertEqual(x[i], i)
+
+    def test_Size_iter(self):
+        for sizes in [iter([1, 2, 3, 4, 5]), range(1, 6)]:
+            x = torch.Size(sizes)
+            for i in range(0, 5):
+                self.assertEqual(x[i], i + 1)
+
     def test_t_not_2d_error(self):
         self.assertRaises(RuntimeError, lambda: torch.randn(2, 3, 4).t())
         self.assertRaises(RuntimeError, lambda: torch.randn(2, 3, 4).t_())

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -50,9 +50,8 @@ static PyObject * THPSize_pynew(PyTypeObject *type, PyObject *args, PyObject *kw
   if (self) {
     for (Py_ssize_t i = 0; i < PyTuple_Size(self); ++i) {
       PyObject *item = PyTuple_GET_ITEM(self.get(), i);
-      if (!THPUtils_checkLong(item) && !isTracedVar(item)) {
-        return PyErr_Format(PyExc_TypeError, "torch.Size() takes an iterable of 'int' (item %zd is '%s')",
-            i, Py_TYPE(item)->tp_name);
+      if (isTracedVar(item)) {
+        continue;
       }
       if (THPUtils_checkLong(item)) {
         continue;

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -60,7 +60,10 @@ static PyObject * THPSize_pynew(PyTypeObject *type, PyObject *args, PyObject *kw
       THPObjectPtr number(PyNumber_Index(item));
       if (number && THPUtils_checkLong(number.get())) {
         Py_INCREF(number.get());
-        PyTuple_SetItem(self, i, number.get());
+        auto status = PyTuple_SetItem(self, i, number.get());
+        if (status != 0) {
+          throw python_error();
+        }
         continue;
       }
       return PyErr_Format(PyExc_TypeError,

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -54,6 +54,19 @@ static PyObject * THPSize_pynew(PyTypeObject *type, PyObject *args, PyObject *kw
         return PyErr_Format(PyExc_TypeError, "torch.Size() takes an iterable of 'int' (item %zd is '%s')",
             i, Py_TYPE(item)->tp_name);
       }
+      if (THPUtils_checkLong(item)) {
+        continue;
+      }
+      // item.__index__() works with 0-dim tensors and tensors with one element
+      THPObjectPtr number(PyNumber_Index(item));
+      if (number && THPUtils_checkLong(number.get())) {
+        Py_INCREF(number.get());
+        PyTuple_SetItem(self, i, number.get());
+        continue;
+      }
+      return PyErr_Format(PyExc_TypeError,
+                          "torch.Size() takes an iterable of 'int' (item %zd is '%s')",
+                          i, Py_TYPE(item)->tp_name);
     }
   }
   return self.release();


### PR DESCRIPTION
Partially fixes #5663 

Converts pytorch scalars to int64_t inside the torch.Size constructor.

cc @gchanan 