### PR TITLE
Fix floor latex rendering

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -715,7 +715,7 @@ Returns a new tensor with the ceil of the elements of :attr:`input`,
 the smallest integer greater than or equal to each element.
 
 .. math::
-    \text{out}_{i} = \lceil \text{input}_{i} \rceil = \left\lfloor \text{input}_{i} \right\rfloor + 1
+    \text{out}_{i} = \left\lceil \text{input}_{i} \right\rceil = \left\lfloor \text{input}_{i} \right\rfloor + 1
 
 Args:
     input (Tensor): the input tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -715,7 +715,7 @@ Returns a new tensor with the ceil of the elements of :attr:`input`,
 the smallest integer greater than or equal to each element.
 
 .. math::
-    \text{out}_{i} = \lceil \text{input}_{i} \rceil = \lfloor \text{input}_{i} \rfloor + 1
+    \text{out}_{i} = \lceil \text{input}_{i} \rceil = \left\lfloor \text{input}_{i} \right\rfloor + 1
 
 Args:
     input (Tensor): the input tensor
@@ -1546,7 +1546,7 @@ Returns a new tensor with the floor of the elements of :attr:`input`,
 the largest integer less than or equal to each element.
 
 .. math::
-    \text{out}_{i} = \lfloor \text{input}_{i} \rfloor
+    \text{out}_{i} = \left\lfloor \text{input}_{i} \right\rfloor
 
 Args:
     input (Tensor): the input tensor
@@ -1625,7 +1625,7 @@ frac(tensor, out=None) -> Tensor
 Computes the fractional portion of each element in :attr:`tensor`.
 
 .. math::
-    \text{out}_{i} = \text{input}_{i} - \lfloor \text{input}_{i} \rfloor
+    \text{out}_{i} = \text{input}_{i} - \left\lfloor \text{input}_{i} \right\rfloor
 
 Example::
 
@@ -4017,7 +4017,7 @@ add_docstr(torch.range,
            r"""
 range(start, end, step=1, out=None) -> Tensor
 
-Returns a 1-D tensor of size :math:`\lfloor \frac{end - start}{step} \rfloor + 1`
+Returns a 1-D tensor of size :math:`\left\lfloor \frac{end - start}{step} \right\rfloor + 1`
 with values from :attr:`start` to :attr:`end` with step :attr:`step`. Step is
 the gap between two values in the tensor. :math:`x_{i+1} = x_i + step`.
 
@@ -4057,7 +4057,7 @@ add_docstr(torch.arange,
            r"""
 arange(start=0, end, step=1, out=None) -> Tensor
 
-Returns a 1-D tensor of size :math:`\lfloor \frac{end - start}{step} \rfloor`
+Returns a 1-D tensor of size :math:`\left\lfloor \frac{end - start}{step} \right\rfloor`
 with values from the interval ``[start, end)`` taken with common difference
 :attr:`step` beginning from `start`.
 
@@ -5563,7 +5563,7 @@ Ignoring the batch dimension, this method computes the following expression:
 , where :math:`m` is the index of the sliding window, and :math:`\omega` is
 the frequency that :math:`0 \leq \omega < fft\_size`. When
 :attr:`return_onsesided` is the default value True, only values for
-:math:`\omega` in range :math:`[0, 1, 2, \dots, \lfloor \frac{fft\_size}{2} \rfloor + 1]`
+:math:`\omega` in range :math:`[0, 1, 2, \dots, \left\lfloor \frac{fft\_size}{2} \right\rfloor + 1]`
 are returned because the real-to-complex transform satisfies the Hermitian
 symmetry, i.e., :math:`X[m, \omega] = X[m, fft\_length - \omega]^*`.
 

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -102,7 +102,7 @@ class Conv1d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor \frac{\text{out_channels}}{\text{in_channels}} \rfloor`).
+          its own set of filters (of size :math:`\left\lfloor \frac{\text{out_channels}}{\text{in_channels}} \right\rfloor`).
 
     .. note::
 
@@ -139,8 +139,8 @@ class Conv1d(_ConvNd):
         - Output: :math:`(N, C_{out}, L_{out})` where
 
           .. math::
-              L_{out} = \lfloor(\frac{L_{in} + 2 * \text{padding} - \text{dilation}
-                        * (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\rfloor
+              L_{out} = \left\lfloor(\frac{L_{in} + 2 * \text{padding} - \text{dilation}
+                        * (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -216,7 +216,7 @@ class Conv2d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor\frac{\text{out_channels}}{\text{in_channels}}\rfloor`).
+          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -256,11 +256,11 @@ class Conv2d(_ConvNd):
         - Output: :math:`(N, C_{out}, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor\frac{H_{in}  + 2 * \text{padding}[0] - \text{dilation}[0]
-                        * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in}  + 2 * \text{padding}[0] - \text{dilation}[0]
+                        * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in}  + 2 * \text{padding}[1] - \text{dilation}[1]
-                        * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in}  + 2 * \text{padding}[1] - \text{dilation}[1]
+                        * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -334,7 +334,7 @@ class Conv3d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor\frac{\text{out_channels}}{\text{in_channels}}\rfloor`).
+          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -374,14 +374,14 @@ class Conv3d(_ConvNd):
         - Output: :math:`(N, C_{out}, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = \lfloor\frac{D_{in} + 2 * \text{padding}[0] - \text{dilation}[0]
-                    * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\rfloor
+              D_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[0] - \text{dilation}[0]
+                    * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              H_{out} = \lfloor\frac{D_{in} + 2 * \text{padding}[1] - \text{dilation}[1]
-                    * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[1] - \text{dilation}[1]
+                    * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{D_{in} + 2 * \text{padding}[2] - \text{dilation}[2]
-                    * (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[2] - \text{dilation}[2]
+                    * (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\right\rfloor
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape
@@ -490,7 +490,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor\frac{\text{out_channels}}{\text{in_channels}}\rfloor`).
+          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     .. note::
 
@@ -571,7 +571,7 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor\frac{\text{out_channels}}{\text{in_channels}}\rfloor`).
+          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:
@@ -690,7 +690,7 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\lfloor\frac{\text{out_channels}}{\text{in_channels}}\rfloor`).
+          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -102,7 +102,8 @@ class Conv1d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor \frac{\text{out_channels}}{\text{in_channels}} \right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor \frac{\text{out_channels}}{\text{in_channels}} \right\rfloor`).
 
     .. note::
 
@@ -216,7 +217,8 @@ class Conv2d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -334,7 +336,8 @@ class Conv3d(_ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`dilation` can either be:
 
@@ -490,7 +493,8 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     .. note::
 
@@ -571,7 +575,8 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:
@@ -690,7 +695,8 @@ class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
-          its own set of filters (of size :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
+          its own set of filters (of size
+          :math:`\left\lfloor\frac{\text{out_channels}}{\text{in_channels}}\right\rfloor`).
 
     The parameters :attr:`kernel_size`, :attr:`stride`, :attr:`padding`, :attr:`output_padding`
     can either be:

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -38,8 +38,8 @@ class MaxPool1d(Module):
         - Output: :math:`(N, C, L_{out})` where
 
           .. math::
-              L_{out} = \lfloor \frac{L_{in} + 2 * \text{padding} - \text{dilation}
-                    * (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\rfloor
+              L_{out} = \left\lfloor \frac{L_{in} + 2 * \text{padding} - \text{dilation}
+                    * (\text{kernel_size} - 1) - 1}{\text{stride}} + 1\right\rfloor
 
     Examples::
 
@@ -115,11 +115,11 @@ class MaxPool2d(Module):
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor\frac{H_{in} + 2 * \text{padding}[0] - \text{dilation}[0]
-                    * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in} + 2 * \text{padding}[0] - \text{dilation}[0]
+                    * (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in} + 2 * \text{padding}[1] - \text{dilation}[1]
-                    * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in} + 2 * \text{padding}[1] - \text{dilation}[1]
+                    * (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
     Examples::
 
@@ -430,7 +430,7 @@ class AvgPool1d(Module):
         - Output: :math:`(N, C, L_{out})` where
 
           .. math::
-              L_{out} = \lfloor \frac{L_{in}  + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\rfloor
+              L_{out} = \left\lfloor \frac{L_{in}  + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
 
     Examples::
 
@@ -502,11 +502,11 @@ class AvgPool2d(Module):
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor\frac{H_{in}  + 2 * \text{padding}[0] -
-                \text{kernel_size}[0]}{\text{stride}[0]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in}  + 2 * \text{padding}[0] -
+                \text{kernel_size}[0]}{\text{stride}[0]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in}  + 2 * \text{padding}[1] -
-                \text{kernel_size}[1]}{\text{stride}[1]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in}  + 2 * \text{padding}[1] -
+                \text{kernel_size}[1]}{\text{stride}[1]} + 1\right\rfloor
 
     Examples::
 
@@ -579,14 +579,14 @@ class MaxPool3d(Module):
         - Output: :math:`(N, C, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = \lfloor\frac{D_{in} + 2 * \text{padding}[0] - \text{dilation}[0] *
-                (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\rfloor
+              D_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[0] - \text{dilation}[0] *
+                (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              H_{out} = \lfloor\frac{H_{in} + 2 * \text{padding}[1] - \text{dilation}[1] *
-                (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in} + 2 * \text{padding}[1] - \text{dilation}[1] *
+                (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in} + 2 * \text{padding}[2] - \text{dilation}[2] *
-                (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in} + 2 * \text{padding}[2] - \text{dilation}[2] *
+                (\text{kernel_size}[2] - 1) - 1}{\text{stride}[2]} + 1\right\rfloor
 
     Examples::
 
@@ -663,14 +663,14 @@ class AvgPool3d(Module):
         - Output: :math:`(N, C, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = \lfloor\frac{D_{in} + 2 * \text{padding}[0] -
-                    \text{kernel_size}[0]}{\text{stride}[0]} + 1\rfloor
+              D_{out} = \left\lfloor\frac{D_{in} + 2 * \text{padding}[0] -
+                    \text{kernel_size}[0]}{\text{stride}[0]} + 1\right\rfloor
 
-              H_{out} = \lfloor\frac{H_{in} + 2 * \text{padding}[1] -
-                    \text{kernel_size}[1]}{\text{stride}[1]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in} + 2 * \text{padding}[1] -
+                    \text{kernel_size}[1]}{\text{stride}[1]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in} + 2 * \text{padding}[2] -
-                    \text{kernel_size}[2]}{\text{stride}[2]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in} + 2 * \text{padding}[2] -
+                    \text{kernel_size}[2]}{\text{stride}[2]} + 1\right\rfloor
 
     Examples::
 
@@ -795,11 +795,11 @@ class LPPool2d(Module):
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor\frac{H_{in}  + 2 * \text{padding}[0] - \text{dilation}[0] *
-                    (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\rfloor
+              H_{out} = \left\lfloor\frac{H_{in}  + 2 * \text{padding}[0] - \text{dilation}[0] *
+                    (\text{kernel_size}[0] - 1) - 1}{\text{stride}[0]} + 1\right\rfloor
 
-              W_{out} = \lfloor\frac{W_{in}  + 2 * \text{padding}[1] - \text{dilation}[1] *
-                    (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\rfloor
+              W_{out} = \left\lfloor\frac{W_{in}  + 2 * \text{padding}[1] - \text{dilation}[1] *
+                    (\text{kernel_size}[1] - 1) - 1}{\text{stride}[1]} + 1\right\rfloor
 
     Examples::
 
@@ -853,7 +853,7 @@ class LPPool1d(Module):
         - Output: :math:`(N, C, L_{out})` where
 
           .. math::
-              L_{out} = \lfloor\frac{L_{in} + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\rfloor
+              L_{out} = \left\lfloor\frac{L_{in} + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
 
     Examples::
         >>> # power-2 pool of window of length 3, with stride 2.

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -430,7 +430,8 @@ class AvgPool1d(Module):
         - Output: :math:`(N, C, L_{out})` where
 
           .. math::
-              L_{out} = \left\lfloor \frac{L_{in}  + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
+              L_{out} = \left\lfloor \frac{L_{in} +
+              2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
 
     Examples::
 
@@ -853,7 +854,8 @@ class LPPool1d(Module):
         - Output: :math:`(N, C, L_{out})` where
 
           .. math::
-              L_{out} = \left\lfloor\frac{L_{in} + 2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
+              L_{out} = \left\lfloor\frac{L_{in} +
+              2 * \text{padding} - \text{kernel_size}}{\text{stride}} + 1\right\rfloor
 
     Examples::
         >>> # power-2 pool of window of length 3, with stride 2.

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -29,11 +29,11 @@ class Upsample(Module):
           or :math:`(N, C, D_{out}, H_{out}, W_{out})` where
 
           .. math::
-              D_{out} = \lfloor D_{in} * scale\_factor \rfloor or \text{size}[-3]
+              D_{out} = \left\lfloor D_{in} * scale\_factor \right\rfloor or \text{size}[-3]
 
-              H_{out} = \lfloor H_{in} * scale\_factor \rfloor or \text{size}[-2]
+              H_{out} = \left\lfloor H_{in} * scale\_factor \right\rfloor or \text{size}[-2]
 
-              W_{out} = \lfloor W_{in} * scale\_factor \rfloor or \text{size}[-1]
+              W_{out} = \left\lfloor W_{in} * scale\_factor \right\rfloor or \text{size}[-1]
 
     Examples::
 
@@ -110,9 +110,9 @@ class UpsamplingNearest2d(Upsample):
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor H_{in} * scale\_factor \rfloor
+              H_{out} = \left\lfloor H_{in} * scale\_factor \right\rfloor
 
-              W_{out} = \lfloor W_{in} * scale\_factor \rfloor
+              W_{out} = \left\lfloor W_{in} * scale\_factor \right\rfloor
 
     Examples::
 
@@ -161,9 +161,9 @@ class UpsamplingBilinear2d(Upsample):
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \lfloor H_{in} * scale\_factor \rfloor
+              H_{out} = \left\lfloor H_{in} * scale\_factor \right\rfloor
 
-              W_{out} = \lfloor W_{in} * scale\_factor \rfloor
+              W_{out} = \left\lfloor W_{in} * scale\_factor \right\rfloor
 
     Examples::
 


### PR DESCRIPTION
\left\lfloor ... \right\rfloor is strictly better than \lfloor ... \rfloor

Before (example):
![image](https://user-images.githubusercontent.com/5652049/37234249-b05e5f7e-23c4-11e8-8064-ecdc3708b178.png)

After:
![image](https://user-images.githubusercontent.com/5652049/37234254-b609ac4e-23c4-11e8-8f48-b64ae7b04be0.png)
