### PR TITLE
Delete ""_sym literal form.

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -242,7 +242,7 @@ static ReverseDetails addReverseInline(Gradient& grad_desc,
   // note: reverse_node is intentionally not inserted to avoid
   // accidentally acting on it (e.g. in elminate dead code),
   // std::cout << *reverse_node << to view its state.
-  auto reverse_node = graph.create("Reverse"_sym, 0);
+  auto reverse_node = graph.create(kReverse, 0);
   auto reverse_block = reverse_node->addBlock();
   WithInsertPoint guard(reverse_block);
 

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -84,8 +84,8 @@ std::unordered_map<NodeKind, std::string> simple_map_ops = {
   {kclamp, "min(max(${0},${min}),${max})"},
 
   // simple derivatives
-  {"_sigmoid_backward"_sym, "${0} * ${1} * (1.f - ${1})"},
-  {"_tanh_backward"_sym,    "${0} * (1.f - ${1} * ${1})"},
+  {k_sigmoid_backward, "${0} * ${1} * (1.f - ${1})"},
+  {k_tanh_backward,    "${0} * (1.f - ${1} * ${1})"},
 };
 
 std::vector<bool> TensorDesc::findContiguous(

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -8,6 +8,15 @@
 
 namespace torch { namespace jit {
 
+enum class SymbolNamespace : char {
+  ONNXOperator = 'o',
+  JITOperator = 'j',
+  ATenOperator = 't',
+  // NB: ONNX and ATen attributes all live in a global namespace, as
+  // their interpretation depends on the operator name (which is namespaced)
+  Attribute = 'a',
+};
+
 // JIT symbols are synthetic operators that occur only in the JIT IR
 // and don't have corresponding implementations in ATen.
 //
@@ -33,6 +42,7 @@ _(Placeholder) \
 _(Print) \
 _(PythonOp) \
 _(ReplaceIfUndef) \
+_(Reverse) \
 _(Return) \
 _(Store) \
 _(Undefined) \
@@ -136,10 +146,6 @@ static inline bool operator==(BuiltinSymbol lhs, Symbol rhs) {
 }
 static inline bool operator==(Symbol lhs, BuiltinSymbol rhs) {
   return static_cast<uint32_t>(lhs) == static_cast<uint32_t>(rhs);
-}
-
-inline Symbol operator "" _sym(const char * s, size_t) {
-  return Symbol(s);
 }
 
 }}

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -90,6 +90,7 @@ _(axis) \
 _(broadcast) \
 _(device) \
 /* _(dim) conflicts with ATen */ \
+_(end) \
 _(exponent) \
 _(inplace) \
 _(is_zero) \
@@ -99,6 +100,8 @@ _(other) \
 _(perm) \
 /* _(size) conflicts with ATen */ \
 /* _(sizes) conflicts with ATen */ \
+_(start) \
+_(step) \
 _(transA) \
 _(transB) \
 _(value) \

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -8,15 +8,6 @@
 
 namespace torch { namespace jit {
 
-enum class SymbolNamespace : char {
-  ONNXOperator = 'o',
-  JITOperator = 'j',
-  ATenOperator = 't',
-  // NB: ONNX and ATen attributes all live in a global namespace, as
-  // their interpretation depends on the operator name (which is namespaced)
-  Attribute = 'a',
-};
-
 // JIT symbols are synthetic operators that occur only in the JIT IR
 // and don't have corresponding implementations in ATen.
 //

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -124,7 +124,7 @@ struct TreeToken {
   }
 
   std::vector<Node*> gatherMatMuls() {
-    static const Symbol mm_kind = "mm"_sym;
+    static const Symbol mm_kind = kmm;
     std::vector<Node*> matmuls;
     std::vector<Node*> queue {node};
     while (!queue.empty()) {
@@ -142,10 +142,10 @@ struct TreeToken {
 
 void BatchMMBlock(Block* block) {
   enum class Side { LHS, RHS };
-  static const Symbol mm_kind = "mm"_sym;
-  static const Symbol add_kind = "add"_sym;
-  static const Symbol cat_kind = "cat"_sym;
-  static const Symbol dim_sym = "dim"_sym;
+  static const Symbol mm_kind = kmm;
+  static const Symbol add_kind = kadd;
+  static const Symbol cat_kind = kcat;
+  static const Symbol dim_sym = kdim;
   auto graph = block->owningGraph();
 
   // Look for trees in the block

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -64,8 +64,8 @@ std::unordered_set<NodeKind> simple_mappable = {
   ktanh,
   ktrunc,
   kzeros,
-  "_sigmoid_backward"_sym,
-  "_tanh_backward"_sym,
+  k_sigmoid_backward,
+  k_tanh_backward,
 };
 
 bool isSimpleMap(Node *node) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -734,9 +734,9 @@ private:
                {tensor},
                output_size)
                ->i_(kdim, 0)
-               ->i_("step"_sym, 1)
-               ->i_("start"_sym, begin)
-               ->i_("end"_sym, end)->outputs();
+               ->i_(kstep, 1)
+               ->i_(kstart, begin)
+               ->i_(kend, end)->outputs();
   }
 
   // Desugars gather syntactic sugar tensor[idx] -> tensor.select(idx).


### PR DESCRIPTION
Two reasons:

1. It's unnecessary now; all of the uses of the literal form would
   be better directly referring to the interned string (esp. since
   now we are autogenerating symbols.)

2. When I add namespacing, there will be no convenient way to specify
   the desired namespace with just _sym.  If we add it back, we would
   need distinct suffixes for each different type.  Easiest to delete
   it while we don't need it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>