### PR TITLE
make CUDA_VERSION available in cudnn/Descriptors.h

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -5,6 +5,7 @@
 #include "cudnn-wrapper.h"
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
+#include <cuda.h>
 
 #if CUDNN_VERSION < 7000
 


### PR DESCRIPTION
Otherwise hmma is not called in rnns on volta. cc @ezyang 