### PR TITLE
improve occupancy for cuda rngs

### DIFF
--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -12,7 +12,7 @@
 #include <curand_mtgp32_host.h>
 #include <curand_mtgp32dc_p_11213.h>
 
-#define MAX_NUM_BLOCKS 64
+#define MAX_NUM_BLOCKS 200 
 #define BLOCK_SIZE 256
 
 

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -7,7 +7,7 @@
 
 #include <curand_kernel.h>
 
-#define MAX_NUM_BLOCKS 64
+#define MAX_NUM_BLOCKS 200 
 #define BLOCK_SIZE 256
 /* Separate kernel because curand_log_normal gets extra parameters. */
 


### PR DESCRIPTION
Currentlty max 64 blocks of 256 threads are launched, which is very low occupancy and performance on Pascal and Maxwell cards. This PR increases the number of blocks to 200, current max that MTGP can handle without generating additional starting parameter sets. Longer term, core THC should probably be moving to philox (distributions are already using it) and aim for 100% occupancy.  