### PR TITLE
Change the public API of Symbol, but don't change internal representa…

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -119,7 +119,7 @@ profiler::RecordFunction profiler("${name}");""")
 PRE_RECORD_TRACE = CodeTemplate("""\
 jit::tracer::PreTraceInfo trace_info;
 if (jit::tracer::isTracing( ${tensor_args} )) {
-  trace_info = jit::tracer::preRecordTrace( "${trace_name}", ${trace_inputs} );
+  trace_info = jit::tracer::preRecordTrace( jit::Symbol::attr("${trace_name}"), ${trace_inputs} );
   ${record_attributes}
 }
 """)
@@ -131,7 +131,7 @@ if (trace_info.state != nullptr) {
 """)
 
 RECORD_ATTRIBUTE = CodeTemplate("""\
-setattr(trace_info.n, jit::Symbol("${name}"), ${name});""")
+setattr(trace_info.n, jit::Symbol::attr("${name}"), ${name});""")
 
 
 def gen_variable_type(out, aten_declarations):

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -30,7 +30,7 @@ TYPE_CASTS = {
 }
 
 KW_ASSIGNMENT = CodeTemplate("""\
-auto ${name} = ${type_cast}(node->${method}(Symbol("${name}")));\
+auto ${name} = ${type_cast}(node->${method}(Symbol::attr("${name}")));\
 """)
 
 POS_ASSIGNMENT = CodeTemplate("""\

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -92,12 +92,14 @@ ConstructorsMap constructors = {
 
 std::string getDescriptor(jit::Node* n) {
   std::stringstream s;
-  s << n->kind().toString();
+  // TODO: Only ATen operators get JIT dispatchers.  Test if this is the case
+  // and complain if it's not.
+  s << n->kind().toUnqualString();
   if (tensor_vararg_fns.count(n->kind()) == 0)
     s << "-" << n->inputs().size();
   else
     s << "-*";
-  std::vector<const char*> attr_names = fmap(n->attributeNames(), [](Symbol x) { return x.toString(); });
+  std::vector<const char*> attr_names = fmap(n->attributeNames(), [](Symbol x) { return x.toUnqualString(); });
   std::sort(attr_names.begin(), attr_names.end(), [](const char *a, const char *b) {
     return std::strcmp(a, b) < 0;
   });

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -18,6 +18,8 @@ static inline const char * toString(AttributeKind kind) {
   return names[int(kind)];
 }
 
+// TODO: Assert all Symbols are attribute nodes
+
 struct AttributeValue {
   AttributeValue(Symbol name)
   : name(name) {}
@@ -171,7 +173,7 @@ private:
       return v->name == name;
     });
     if(required && it == values_.end()) {
-      ::torch::barf("%s:%u: %s: required undefined attribute '%s'", __FILE__, __LINE__, __func__, name.toString());
+      ::torch::barf("%s:%u: %s: required undefined %s", __FILE__, __LINE__, __func__, name.toDisplayString());
     }
     JIT_ASSERT(!required || it != values_.end());
     return it;

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -152,11 +152,11 @@ static std::vector<Value*> gradientForNode(Node* node, ArrayRef<Value*> grad_val
       }
     }
     throw std::runtime_error(std::string("don't support differentiation of `") +
-                            node->kind().toString() + "`");
+                            node->kind().toDisplayString() + "`");
   };
   const auto has_tensor_type = [](Value *v) { return v->isTensor(); };
   if (!isDifferentiable(node)) {
-    throw std::runtime_error(std::string("differentiation of ") + node->kind().toString() + " "
+    throw std::runtime_error(std::string("differentiation of ") + node->kind().toDisplayString() + " "
                              "is not supported, or it is missing necessary type information");
   }
   if (!std::all_of(node->inputs().begin(), node->inputs().end(), has_tensor_type) ||

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -70,7 +70,8 @@ void encodeTensor(onnx::TensorProto * p, const at::Tensor & tensor) {
 
 void addAttribute(onnx::NodeProto * n_p, jit::Node * n, jit::Symbol name) {
   auto attr = n_p->add_attribute();
-  attr->set_name(name.toString());
+  // TODO: Test name is attribute namespace
+  attr->set_name(name.toUnqualString());
   switch(n->kindOf(name)) {
     case AttributeKind::f:
       attr->set_f(n->f(name));
@@ -206,7 +207,8 @@ void encodeGraph(onnx::GraphProto * p_g, const std::shared_ptr<Graph> & g, const
     for(auto output : node->outputs()) {
       p_n->add_output(value_name(output));
     }
-    p_n->set_op_type(node->kind().toString());
+    // TODO: Assert this is an ONNX node
+    p_n->set_op_type(node->kind().toUnqualString());
     for(auto attr_name : node->attributeNames()) {
       addAttribute(p_n, node, attr_name);
     }
@@ -259,7 +261,8 @@ void validateGraph(const std::shared_ptr<Graph>& graph) {
             "Couldn't export operator expand; this usually means you used a form of broadcasting that ONNX does not currently support. Node defined at:\n" +
             getNodeStackTraceString(node));
       }
-      std::string n = node->kind().toString();
+      // TODO: Replace this with a proper namespace check!
+      std::string n = node->kind().toUnqualString();
       if (n.size() == 0) {
         FAIL_EXPORT("Operator to export had empty name (please file an issue)")
       }

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -235,7 +235,8 @@ std::string encodeRHS(Node * n) {
     if(n->kindOf(a) == AttributeKind::t) {
       auto v = n->t(a);
       if(v.dim() == 0) {
-        env.s(a.toString(), scalarValue(v));
+        // TODO: test a is attribute namespace
+        env.s(a.toUnqualString(), scalarValue(v));
       }
     }
   }

--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include <mutex>
+#include <sstream>
 #include "torch/csrc/assertions.h"
 #include "torch/csrc/jit/interned_strings.h"
 
@@ -59,7 +60,72 @@ static InternedStrings & globalStrings() {
   return s;
 }
 
-const char * Symbol::toString() const {
+Symbol Symbol::parseQualString(const std::string & s) {
+  return Symbol(s);
+
+  /*
+  size_t colon_pos = s.find(':');
+  if (colon_pos == std::string::npos) {
+    std::ostringstream ss;
+    ss << "Symbol: illegal unqualified string '" << s << "'; "
+       << "all symbols must be qualified, e.g., 'ns::" << s << "'. "
+       << "Valid namespaces are: " << detail::valid_namespaces_str();
+    throw std::runtime_error(ss.str());
+  }
+  if (colon_pos == 0) {
+    std::ostringstream ss;
+    ss << "Symbol: illegal leading colon in '" << s << "'; "
+       << "all symbols must have a non-empty namespace. "
+       << "Valid namespaces are: " << detail::valid_namespaces_str();
+    throw std::runtime_error(ss.str());
+  }
+  // attr::x
+  //     ^___ colon_pos
+  //        ^___ s.size()
+  if (colon_pos + 2 >= s.size()) {
+    std::ostringstream ss;
+    ss << "Symbol: underlong string '" << s << "'; "
+       << "namespace must be followed by double colon and a "
+       << "non-empty string.";
+    throw std::runtime_error(ss.str());
+  }
+  if (s[colon_pos + 1] != ':') {
+    std::ostringstream ss;
+    ss << "Symbol: invalid use of colons in '" << s << "'; "
+       << "namespace must be followed by double colon, not a"
+       << "single colon.";
+    throw std::runtime_error(ss.str());
+  }
+  auto ns = s.substr(0, colon_pos - 1);
+  auto unqual_name = s.substr(colon_pos + 2);
+  if (ns == "unknown") {
+    // OK
+  } else {
+    std::ostringstream ss;
+    ss << "Symbol: invalid namespace in '" << s << "'. "
+       << "Valid namespaces are: " << detail::valid_namespaces_str();
+    throw std::runtime_error(ss.str());
+  }
+
+  return Symbol(unqual_name);
+  */
+}
+
+const char * Symbol::toUnqualString() const {
+  return globalStrings().string(*this);
+}
+
+std::string Symbol::toQualString() const {
+  std::ostringstream oss;
+  // oss << "unknown::" << globalStrings().string(*this);
+  return globalStrings().string(*this);
+}
+
+const char * Symbol::toRawString() const {
+  return globalStrings().string(*this);
+}
+
+const char * Symbol::toDisplayString() const {
   return globalStrings().string(*this);
 }
 

--- a/torch/csrc/jit/interned_strings.cpp
+++ b/torch/csrc/jit/interned_strings.cpp
@@ -62,53 +62,6 @@ static InternedStrings & globalStrings() {
 
 Symbol Symbol::parseQualString(const std::string & s) {
   return Symbol(s);
-
-  /*
-  size_t colon_pos = s.find(':');
-  if (colon_pos == std::string::npos) {
-    std::ostringstream ss;
-    ss << "Symbol: illegal unqualified string '" << s << "'; "
-       << "all symbols must be qualified, e.g., 'ns::" << s << "'. "
-       << "Valid namespaces are: " << detail::valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-  if (colon_pos == 0) {
-    std::ostringstream ss;
-    ss << "Symbol: illegal leading colon in '" << s << "'; "
-       << "all symbols must have a non-empty namespace. "
-       << "Valid namespaces are: " << detail::valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-  // attr::x
-  //     ^___ colon_pos
-  //        ^___ s.size()
-  if (colon_pos + 2 >= s.size()) {
-    std::ostringstream ss;
-    ss << "Symbol: underlong string '" << s << "'; "
-       << "namespace must be followed by double colon and a "
-       << "non-empty string.";
-    throw std::runtime_error(ss.str());
-  }
-  if (s[colon_pos + 1] != ':') {
-    std::ostringstream ss;
-    ss << "Symbol: invalid use of colons in '" << s << "'; "
-       << "namespace must be followed by double colon, not a"
-       << "single colon.";
-    throw std::runtime_error(ss.str());
-  }
-  auto ns = s.substr(0, colon_pos - 1);
-  auto unqual_name = s.substr(colon_pos + 2);
-  if (ns == "unknown") {
-    // OK
-  } else {
-    std::ostringstream ss;
-    ss << "Symbol: invalid namespace in '" << s << "'. "
-       << "Valid namespaces are: " << detail::valid_namespaces_str();
-    throw std::runtime_error(ss.str());
-  }
-
-  return Symbol(unqual_name);
-  */
 }
 
 const char * Symbol::toUnqualString() const {
@@ -117,7 +70,6 @@ const char * Symbol::toUnqualString() const {
 
 std::string Symbol::toQualString() const {
   std::ostringstream oss;
-  // oss << "unknown::" << globalStrings().string(*this);
   return globalStrings().string(*this);
 }
 

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -8,6 +8,28 @@
 
 namespace torch { namespace jit {
 
+/*
+Intended symbol namespace structure:
+
+enum class SymbolNamespace : char {
+  ONNXOperator = 'o',
+  JITOperator = 'j',
+  ATenOperator = 't',
+  // NB: ONNX and ATen attributes all live in a global namespace, as
+  // their interpretation depends on the operator name (which is namespaced)
+  Attribute = 'a',
+};
+
+namespace detail {
+
+  // TODO: programatically generate this
+  inline std::string valid_namespaces_str() {
+    return "'onnx', 'jit', 'aten', 'attr'";
+  }
+
+}
+*/
+
 // JIT symbols are synthetic operators that occur only in the JIT IR
 // and don't have corresponding implementations in ATen.
 //
@@ -119,15 +141,46 @@ struct Symbol {
   Symbol() {}
   /*implicit*/ Symbol(BuiltinSymbol value)
   : value(value) {}
-  explicit Symbol(const std::string & s);
   explicit Symbol(uint32_t value)
   : value(value) {}
+
+  // Parse a string in the toQualString format to Symbol.  This is a proper
+  // parser, so avoid using it in a hotpath.
+  static Symbol parseQualString(const std::string & s);
+
+  // Constructors for our various namespaced strings.  ATM these don't do
+  // anything but they will soon.
+  static Symbol attr(const std::string & s) { return Symbol(s); };
+  static Symbol aten(const std::string & s) { return Symbol(s); };
+  static Symbol onnx(const std::string & s) { return Symbol(s); };
+  static Symbol jit(const std::string & s) { return Symbol(s); };
+  // TODO: eliminate me
+  static Symbol scope(const std::string & s) { return Symbol(s); };
 
   operator uint32_t() const {
     return value;
   }
-  const char * toString() const;
+
+  // Give a string corresponding to the unqualified version of this name, e.g.,
+  // "mm". Use this in a context where the intended namespace of the string is
+  // obvious; this is a *lossy* conversion.
+  const char * toUnqualString() const;
+
+  // Give a string corresponding to the qualified version of this name,
+  // e.g., "aten::mm".  This string format is made available to Python bindings
+  // (so we know how to parse it.)  THIS FUNCTION DOES AN ALLOCATION, DON'T USE
+  // IT IN A TIGHT LOOP.
+  std::string toQualString() const;
+
+  // Give an unambiguous, machine readable description of the name.
+  const char * toRawString() const;
+
+  // This describes a symbol in human readable form.  DO NOT use
+  // this for uses-cases that are intended to be machine-readable.
+  const char * toDisplayString() const;
+
 private:
+  explicit Symbol(const std::string & s);
   uint32_t value;
 };
 

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -172,11 +172,13 @@ struct Symbol {
   // IT IN A TIGHT LOOP.
   std::string toQualString() const;
 
-  // Give an unambiguous, machine readable description of the name.
+  // Give an unambiguous, machine readable description of the name.  This
+  // is strictly an implementation, but it will look something like "tmm"
   const char * toRawString() const;
 
   // This describes a symbol in human readable form.  DO NOT use
   // this for uses-cases that are intended to be machine-readable.
+  // This will look something like "ATen operator 'mm'"
   const char * toDisplayString() const;
 
 private:

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -8,28 +8,6 @@
 
 namespace torch { namespace jit {
 
-/*
-Intended symbol namespace structure:
-
-enum class SymbolNamespace : char {
-  ONNXOperator = 'o',
-  JITOperator = 'j',
-  ATenOperator = 't',
-  // NB: ONNX and ATen attributes all live in a global namespace, as
-  // their interpretation depends on the operator name (which is namespaced)
-  Attribute = 'a',
-};
-
-namespace detail {
-
-  // TODO: programatically generate this
-  inline std::string valid_namespaces_str() {
-    return "'onnx', 'jit', 'aten', 'attr'";
-  }
-
-}
-*/
-
 // JIT symbols are synthetic operators that occur only in the JIT IR
 // and don't have corresponding implementations in ATen.
 //

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -949,9 +949,9 @@ struct CodeImpl {
     };
     auto & inst = instructions.at(pc);
     writeList(inst.outputs);
-    // TODO: Maybe this wants to be unqualified.  Not sure what is going on
-    // with debug_name
-    out << " = " << inst.debug_name.toQualString() << " ";
+    // NB: debug names are the kind of operator used to select
+    // dispatch
+    out << " = " << inst.debug_name.toUnqualString() << " ";
     writeUseList(inst.inputs);
   }
   void dump(std::ostream & out) const {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -949,7 +949,9 @@ struct CodeImpl {
     };
     auto & inst = instructions.at(pc);
     writeList(inst.outputs);
-    out << " = " << inst.debug_name.toString() << " ";
+    // TODO: Maybe this wants to be unqualified.  Not sure what is going on
+    // with debug_name
+    out << " = " << inst.debug_name.toQualString() << " ";
     writeUseList(inst.inputs);
   }
   void dump(std::ostream & out) const {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -190,7 +190,8 @@ void printAttributes(std::ostream & out, const Node * n) {
   for(auto name : names) {
     if(i++ > 0)
       out << ", ";
-    out << name.toString() <<"=";
+    // TODO: debugging mode to see the qualifier
+    out << name.toUnqualString() <<"=";
     switch(n->kindOf(name)) {
       case AttributeKind::f:
         out << n->f(name);
@@ -275,13 +276,16 @@ std::ostream& printNode(std::ostream & out, size_t level, const Node * n, std::v
   IR_ELSE()
     if(n->hasAttribute(kSubgraph)) {
       if(groups) {
-        out << n->kind().toString() << "_" << groups->size();
+        // TODO: This should be a toQualString
+        out << n->kind().toUnqualString() << "_" << groups->size();
         groups->push_back(n);
       } else {
-        out << n->kind().toString() << "[" << *n->g(kSubgraph) << "]";
+        // TODO: This should be a toQualString
+        out << n->kind().toUnqualString() << "[" << *n->g(kSubgraph) << "]";
       }
     } else {
-      out << n->kind().toString();
+      // TODO: This should be a toQualString
+      out << n->kind().toUnqualString();
       if(n->hasAttributes()) {
         printAttributes(out,n);
       }
@@ -326,7 +330,8 @@ std::ostream& operator<<(std::ostream & out, const Graph & g) {
   out << "  return (" << g.outputs() << ");\n}\n";
   size_t i = 0;
   for(auto fg : groups) {
-    out << "with " << fg->kind().toString() << "_" <<i++ << " = " << *fg->g(kSubgraph);
+    // TODO: This should be a toQualString
+    out << "with " << fg->kind().toUnqualString() << "_" <<i++ << " = " << *fg->g(kSubgraph);
   }
   /*
   // Uncomment this to debug all_nodes issues

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -85,7 +85,7 @@ private:
   std::vector<std::unique_ptr<Scope> > children_;
 public:
   Scope() {
-    name_ = Symbol("");
+    name_ = Symbol::scope("");
     parent_ = NULL;
   }
   Scope(Scope* parent, Symbol name) {
@@ -116,13 +116,14 @@ public:
     return name_;
   }
   std::string namesFromRoot(const std::string& separator="/") {
-    std::string out = this->name_.toString();
+    // TODO: I think the answer is we shouldn't have used Symbol here
+    std::string out = this->name_.toUnqualString();
     if (this->isRoot()) {
       return out;
     }
     Scope* parent = this->parent_;
     while (!parent->isRoot()) {
-      out = std::string(parent->name_.toString()) + separator + out;
+      out = std::string(parent->name_.toUnqualString()) + separator + out;
       parent = parent->parent_;
     }
     return out;
@@ -582,7 +583,7 @@ public:
   }
   template<typename T>
   T* expect() {
-    JIT_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", Symbol(T::Kind).toString(), kind().toString());
+    JIT_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", Symbol(T::Kind).toDisplayString(), kind().toDisplayString());
     return static_cast<T*>(this);
   }
 
@@ -806,7 +807,7 @@ public:
     return block_->return_node();
   }
   void push_scope(const std::string& scope_name) {
-    current_scope_ = current_scope_->push(Symbol(scope_name));
+    current_scope_ = current_scope_->push(Symbol::scope(scope_name));
   }
   void pop_scope() {
     current_scope_ = current_scope_->parent();

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -151,7 +151,9 @@ void ToONNX(std::shared_ptr<tracer::TracingState>& state, bool aten) {
     WithCurrentScope scope_guard(*ctx.graph, n->scope());
     py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
 
-    processSymbolicOutput(n->kind().toString(), n, raw_output);
+    // TODO: Assert it's an ATen identifier???
+    // (Sometimes it's not...)
+    processSymbolicOutput(n->kind().toUnqualString(), n, raw_output);
   };
 
   auto callPySymbolicMethod = [&](PythonOp* op) {

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -60,7 +60,9 @@ public:
 
   bool load(handle src, bool) {
     try {
-      value = torch::jit::Symbol(py::cast<std::string>(src));
+      // URK, isn't this suppressing errors from parseQualString?  What is going
+      // on here?
+      value = torch::jit::Symbol::parseQualString(py::cast<std::string>(src));
     } catch (std::exception& e) {
       return false;
     }
@@ -68,7 +70,7 @@ public:
   }
 
   static handle cast(torch::jit::Symbol src, return_value_policy /* policy */, handle /* parent */) {
-    return py::cast(std::string(src.toString()), return_value_policy::copy).release();
+    return py::cast(std::string(src.toQualString()), return_value_policy::copy).release();
   }
 };
 

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -59,13 +59,15 @@ public:
   PYBIND11_TYPE_CASTER(torch::jit::Symbol, _("Symbol"));
 
   bool load(handle src, bool) {
+    // TODO: Is there a way to py::cast that doesn't raise an exception on
+    // failure?  Can we catch pybind11::cast_error here instead?
+    std::string src_str;
     try {
-      // URK, isn't this suppressing errors from parseQualString?  What is going
-      // on here?
-      value = torch::jit::Symbol::parseQualString(py::cast<std::string>(src));
+      src_str = py::cast<std::string>(src);
     } catch (std::exception& e) {
       return false;
     }
+    value = torch::jit::Symbol::parseQualString(src_str);
     return true;
   }
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -141,7 +141,6 @@ void initPythonIRBindings(PyObject * module_) {
     .AS(removeAttribute)
     .AS(hasAttributes)
     .AS(attributeNames)
-    // TODO: These can be reasonably implemented by assuming
 #undef AS
 #define CREATE_ACCESSOR(Kind,method) \
     def(#method "_",[](Node & n, const char * name, Kind##Attr::ValueType v) { \

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -80,11 +80,11 @@ struct SymbolicVariable {
     return create(kneg, {*this})[0].typeLike(*this);
   }
   SymbolicVariable mm(const SymbolicVariable rhs) const {
-    auto r = create(s("mm"), {*this, rhs})[0];
+    auto r = create(t("mm"), {*this, rhs})[0];
     return r;
   }
   SymbolicVariable t() const {
-    auto r = create(s("t"), {*this})[0];
+    auto r = create(t("t"), {*this})[0];
     return r;
   }
   SymbolicVariable sigmoid() const {
@@ -95,17 +95,17 @@ struct SymbolicVariable {
   }
   std::vector<SymbolicVariable> chunk(int32_t chunks, uint32_t dim) const {
     Node * n;
-    auto r = create(s("chunk"), { *this }, chunks, &n);
-    n->i_(s("chunks"), chunks)
-     ->i_(s("dim"), dim);
+    auto r = create(t("chunk"), { *this }, chunks, &n);
+    n->i_(a("chunks"), chunks)
+     ->i_(a("dim"), dim);
     return r;
   }
   SymbolicVariable narrow(int dim, int64_t start, int64_t length) const {
     Node * n;
-    auto r = create(s("narrow"), { *this }, 1, &n)[0];
-    n->i_(s("dim"), dim)
-     ->i_(s("start"), start)
-     ->i_(s("length"), length);
+    auto r = create(t("narrow"), { *this }, 1, &n)[0];
+    n->i_(a("dim"), dim)
+     ->i_(a("start"), start)
+     ->i_(a("length"), length);
     return r;
   }
   static SymbolicVariable cat(ArrayRef<SymbolicVariable> inputs, int32_t dim) {
@@ -115,32 +115,32 @@ struct SymbolicVariable {
     return r;
   }
   SymbolicVariable sum() const {
-    auto r = create(s("sum"), {*this})[0];
+    auto r = create(t("sum"), {*this})[0];
     return r;
   }
   SymbolicVariable sum(int dim, bool keepdim) const {
     Node * n;
-    auto r = create(s("sum"), {*this}, 1, &n)[0];
-    n->i_(s("dim"), dim)
-     ->i_(s("keepdim"), keepdim);
+    auto r = create(t("sum"), {*this}, 1, &n)[0];
+    n->i_(a("dim"), dim)
+     ->i_(a("keepdim"), keepdim);
     return r;
   }
   SymbolicVariable squeeze(int dim) const {
     Node * n;
-    auto r = create(s("squeeze"), {*this}, 1, &n)[0];
-    n->i_(s("dim"), dim);
+    auto r = create(t("squeeze"), {*this}, 1, &n)[0];
+    n->i_(a("dim"), dim);
     return r;
   }
   SymbolicVariable unsqueeze(int dim) const {
     Node * n;
-    auto r = create(s("unsqueeze"), {*this}, 1, &n)[0];
-    n->i_(s("dim"), dim);
+    auto r = create(t("unsqueeze"), {*this}, 1, &n)[0];
+    n->i_(a("dim"), dim);
     return r;
   }
   SymbolicVariable view(std::vector<std::int64_t> sizes) const {
     Node *n;
     auto r =  create(kview, {*this}, 1, &n)[0];
-    n->is_(s("size"), std::move(sizes));
+    n->is_(a("size"), std::move(sizes));
     return r;
   }
   Value * value() const {
@@ -152,8 +152,11 @@ private:
       v->setType(other_type->contiguous());
     return *this;
   }
-  static Symbol s(const char * s_) {
-    return Symbol(s_);
+  static Symbol a(const char * s_) {
+    return Symbol::attr(s_);
+  }
+  static Symbol t(const char * s_) {
+    return Symbol::aten(s_);
   }
   Value * v;
 };

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -258,16 +258,18 @@ void attributesTest() {
 
 void internedStringsTests () {
 
-  JIT_ASSERT(kParam == Symbol("Param"));
-  JIT_ASSERT(kReturn == Symbol("Return"));
-  JIT_ASSERT(Symbol(kReturn).toString() == std::string("Return"));
-  size_t symstart = Symbol("__NEW_SYMBOL");
-  JIT_ASSERT(Symbol("What") == symstart+1);
-  JIT_ASSERT(Symbol("What2") == symstart+2);
-  JIT_ASSERT(Symbol("What") == symstart+1);
-  JIT_ASSERT(Symbol("What2") == symstart+2);
-  JIT_ASSERT(Symbol(symstart+2).toString() == std::string("What2"));
+  JIT_ASSERT(kParam == Symbol::jit("Param"));
+  JIT_ASSERT(kReturn == Symbol::jit("Return"));
+  JIT_ASSERT(Symbol(kReturn).toUnqualString() == std::string("Return"));
+  size_t symstart = Symbol::aten("__NEW_SYMBOL");
+  JIT_ASSERT(Symbol::aten("What") == symstart+1);
+  JIT_ASSERT(Symbol::aten("What2") == symstart+2);
+  JIT_ASSERT(Symbol::aten("What") == symstart+1);
+  JIT_ASSERT(Symbol::aten("What2") == symstart+2);
+  JIT_ASSERT(Symbol(symstart+2).toUnqualString() == std::string("What2"));
 }
+
+// TODO: parseQualString tests
 
 
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -165,10 +165,10 @@ PreTraceInfo makePreTraceInfo(at::ArrayRef<Variable> inputs, F ctor) {
   return info;
 }
 
-PreTraceInfo preRecordTrace(std::string op, // TODO: make this a Symbol
+PreTraceInfo preRecordTrace(Symbol op,
                             at::ArrayRef<Variable> inputs) {
   return makePreTraceInfo(inputs, [&op](Graph& graph) {
-    return graph.create(Symbol(op), 0 /* initial outputs */);
+    return graph.create(op, 0 /* initial outputs */);
   });
 }
 

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -282,7 +282,7 @@ struct PreTraceInfo {
   Node *n;
 };
 
-PreTraceInfo preRecordTrace(std::string op, at::ArrayRef<Variable> inputs);
+PreTraceInfo preRecordTrace(Symbol op, at::ArrayRef<Variable> inputs);
 #ifndef NO_PYTHON
 PreTraceInfo preRecordPythonTrace(
     THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<Variable> inputs,


### PR DESCRIPTION
…tion.

This commit moves us towards having namespaced symbols by removing
the Symbol(const std::string&) constructor and replacing it with
a quintet of static functions to notate what kind of symbol in question
is being used.  However, it doesn't actually change the internal
representation nor the printed output.

This also introduces a bunch of TODOs for the actual conversion.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>