### PR TITLE
Add a Number node to the JIT AST and unify script syntax with Python

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1387,7 +1387,7 @@ class TestJit(TestCase):
     def test_script_triple(self):
         script = '''
         def func(x):
-            return 3f * x
+            return 3. * x
         '''
         x = Variable(torch.rand(1).float(), requires_grad=True)
         outputs = 3 * x
@@ -1859,8 +1859,8 @@ class TestJit(TestCase):
     def test_fuser_multiple_blocks(self):
         cu = torch.jit.CompilationUnit('''
         def test_fuser_multiple_blocks(this, that, theother, meme):
-            i = 0LL
-            while i < 20LL:
+            i = 0
+            while i < 20:
                 this = cat(this, meme, dim=0)
                 that = cat(that, meme, dim=0)
                 theother = cat(theother, meme, dim=0)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -191,7 +191,7 @@ Node* emitBuiltinCall(
     const auto& name = Symbol(attr.name().name());
     const Expr& value_expr = attr.value();
     switch (value_expr.kind()) {
-      case TK_NUMBER: {
+      case TK_CONST: {
         Const value {value_expr};
         if (value.isFloatingPoint()) {
           n->f_(name, value.asFloatingPoint());
@@ -631,7 +631,7 @@ private:
         const auto cast = Cast(tree);
         return emitCast(cast.input(), cast.type());
       } break;
-      case TK_NUMBER: {
+      case TK_CONST: {
         expectOutputs(tree, output_size, 1);
         return emitConst(Const(tree));
       } break;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -14,11 +14,8 @@ namespace script {
 using SugaredValuePtr = std::shared_ptr<SugaredValue>;
 using FunctionTable = std::unordered_map<std::string, Method&>;
 using ValueTable = std::unordered_map<std::string, SugaredValuePtr>;
-using AttributeMap =
-    std::unordered_map<std::string, std::pair<double, std::string>>;
-using ListAttributeMap = std::unordered_map<
-    std::string,
-    std::pair<const std::vector<double>, std::string>>;
+using AttributeMap = std::unordered_map<std::string, Const>;
+using ListAttributeMap = std::unordered_map<std::string, std::vector<Const>>;
 
 // Auxiliary data structure for desugaring variable binding into our always
 // explicitly scoped language as we descend down
@@ -191,33 +188,32 @@ Node* emitBuiltinCall(
                 ->setSourceLocation(std::make_shared<SourceRange>(loc));
 
   for (const auto& attr : attributes) {
-    const auto& name = attr.name().name();
-    const Expr& value = attr.value();
-    // TODO: handle non-float attributes
-    switch (value.kind()) {
-      case TK_CONST: {
-        auto v = value.get()->tree(0)->doubleValue();
-        const auto& type = value.get()->tree(1)->stringValue();
-        if(type == "f")
-          n->f_(Symbol(name), v);
-        else
-          n->i_(Symbol(name), v);
+    const auto& name = Symbol(attr.name().name());
+    const Expr& value_expr = attr.value();
+    switch (value_expr.kind()) {
+      case TK_NUMBER: {
+        Const value {value_expr};
+        if (value.isFloatingPoint()) {
+          n->f_(name, value.asFloatingPoint());
+        } else {
+          n->i_(name, value.asIntegral());
+        }
       } break;
       case TK_LIST_LITERAL: {
-        std::vector<double> vs{};
-        std::string type = "f"; // TODO: handle possibly mixed constants better
-        for (const auto& tree : ListLiteral(value).inputs()) {
-          vs.push_back(tree.get()->tree(0)->doubleValue());
-          type = tree.get()->tree(1)->stringValue();
-        }
-        if(type == "f") {
-          n->fs_(Symbol(name), std::move(vs));
+        List<Const> value_list {ListLiteral(value_expr).inputs()};
+        std::vector<Const> values;
+        for (Const number : value_list)
+          values.push_back(std::move(number));
+        bool is_float = std::any_of(values.begin(), values.end(),
+                                    [](const Const& c) { return c.isFloatingPoint(); });
+        if (is_float) {
+          n->fs_(name, fmap(values, [](const Const& c) { return c.asFloatingPoint(); }));
         } else {
-          n->is_(Symbol(name), std::vector<int64_t>(vs.begin(), vs.end()));
+          n->is_(name, fmap(values, [](const Const& c) { return c.asIntegral(); }));
         }
       } break;
     default:
-        throw ErrorReport(attr) << "Unexpected kind of attribute value: " << value.kind();
+        throw ErrorReport(attr) << "Unexpected kind of attribute value: " << value_expr.kind();
         break;
     }
   }
@@ -418,7 +414,7 @@ private:
     // in a way that ensure single static assignment.
 
     // TODO: clarify that this is an optional input that isn't needed here
-    Value* max_trip_count_dummy = emitConst(stmt.range(), INT_MAX, "i")[0];
+    Value* max_trip_count_dummy = emitConst(Const::create(stmt.range(), std::to_string(INT_MAX)))[0];
     Value* cond_value = emitExpr(stmt.cond(), 1)[0];
 
     Node* n = graph->insertNode(create(kLoop, stmt.range(), 0));
@@ -635,10 +631,9 @@ private:
         const auto cast = Cast(tree);
         return emitCast(cast.input(), cast.type());
       } break;
-      case TK_CONST: {
+      case TK_NUMBER: {
         expectOutputs(tree, output_size, 1);
-        return emitConst(tree->range(),
-            tree->tree(0)->doubleValue(), tree->tree(1)->stringValue());
+        return emitConst(Const(tree));
       } break;
       case TK_SLICE: {
         expectOutputs(tree, output_size, 1);
@@ -690,17 +685,11 @@ private:
         ->outputs();
   }
 
-  std::vector<Value*> emitConst(const SourceRange& loc, const double val, const std::string& type) {
-    if (type == "f") {
-      return {createConstant(loc, at::CPU(at::kFloat).scalarTensor(val))};
-    } else if (type == "LL") {
-      return {createConstant(loc, at::CPU(at::kLong).scalarTensor(val))};
-    } else if (type == "b") {
-      return {createConstant(loc, at::CPU(at::kByte).scalarTensor(val))};
-    } else if (type == "i") {
-      return {createConstant(loc, at::CPU(at::kInt).scalarTensor(val))};
+  std::vector<Value*> emitConst(const Const& c) {
+    if (c.isFloatingPoint()) {
+      return {createConstant(c.range(), at::CPU(at::kFloat).scalarTensor(c.asFloatingPoint()))};
     } else {
-      throw std::runtime_error("unknown const type " + type);
+      return {createConstant(c.range(), at::CPU(at::kLong).scalarTensor(c.asIntegral()))};
     }
   }
 

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -39,6 +39,7 @@ namespace script {
   _(TK_EQUIVALENT, "equivalent", "<=>")          \
   _(TK_IDENT, "ident", "")                       \
   _(TK_STRING, "string", "")                     \
+  _(TK_CONST, "const", "")                       \
   _(TK_LIST, "list", "")                         \
   _(TK_OPTION, "option", "")                     \
   _(TK_APPLY, "apply", "")                       \

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -39,7 +39,6 @@ namespace script {
   _(TK_EQUIVALENT, "equivalent", "<=>")          \
   _(TK_IDENT, "ident", "")                       \
   _(TK_STRING, "string", "")                     \
-  _(TK_CONST, "const", "")                       \
   _(TK_LIST, "list", "")                         \
   _(TK_OPTION, "option", "")                     \
   _(TK_APPLY, "apply", "")                       \
@@ -362,13 +361,6 @@ struct Token {
   int kind;
   SourceRange range;
   Token(int kind, const SourceRange& range) : kind(kind), range(range) {}
-  double doubleValue() {
-    assert(TK_NUMBER == kind);
-    size_t idx;
-    double r = stod(text(), &idx);
-    assert(idx == range.size());
-    return r;
-  }
   std::string text() {
     return range.text();
   }

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -149,16 +149,16 @@ struct Parser {
       L.expect(end);
     return List<T>::create(r, elements);
   }
-  TreeRef parseConst() {
+  Const parseConst() {
     auto range = L.cur().range;
     if (L.nextIf(TK_TRUE)) {
-      return Number::create(range, "1");
+      return Const::create(range, "1");
     } else if (L.nextIf(TK_FALSE)) {
-      return Number::create(range, "0");
+      return Const::create(range, "0");
     }
     std::string unary_prefix = L.nextIf('-') ? "-" : "";
     auto t = L.expect(TK_NUMBER);
-    return Number::create(t.range, unary_prefix + t.text());
+    return Const::create(t.range, unary_prefix + t.text());
   }
   TreeRef parseAttributeValue() {
     int kind = L.cur().kind;

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -44,10 +44,7 @@ struct Tree : std::enable_shared_from_this<Tree> {
     throw std::runtime_error("is an Atom");
   }
   virtual const std::string& stringValue() const {
-    throw std::runtime_error("not a TK_STRING");
-  }
-  virtual bool boolValue() const {
-    throw std::runtime_error("not a TK_BOOL");
+    throw std::runtime_error("stringValue can only be called on TK_STRING");
   }
   virtual const TreeList& trees() const {
     return empty_trees;
@@ -111,26 +108,6 @@ struct String : public Tree {
  private:
   std::string value_;
 };
-struct Number : public Tree {
-  Number(SourceRange range, std::string value)
-    : Tree(TK_NUMBER)
-    , range_(std::move(range))
-    , value_(std::move(value)) {}
-  virtual const std::string& stringValue() const override {
-    return value_;
-  }
-  virtual const SourceRange& range() const override {
-    return range_;
-  }
-  template <typename... Args>
-  static TreeRef create(Args&&... args) {
-    return std::make_shared<Number>(std::forward<Args>(args)...);
-  }
-
- private:
-  SourceRange range_;
-  std::string value_;
-};
 
 static SourceRange mergeRanges(SourceRange c, const TreeList& others) {
   for (auto t : others) {
@@ -188,9 +165,6 @@ struct pretty_tree {
 
     std::stringstream out;
     switch (t->kind()) {
-      case TK_NUMBER:
-        out << t->stringValue();
-        break;
       case TK_STRING:
         out << t->stringValue();
         break;

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -15,12 +15,11 @@ namespace script {
 // A few notes on types and their aliases:
 // - List<T> is really a Tree with kind TK_LIST and elements as subtrees
 // - Maybe<T> is really a Tree with kind TK_OPTION that has 0 or 1 subtree of type T
-// - Builtin types are: Ident (TK_IDENT), String (TK_STRING) and Number (TK_NUMBER)
+// - Builtin types are: Ident (TK_IDENT), String (TK_STRING)
 //
 // Type  = TensorType()                                                 TK_TENSOR_TYPE
 // Param = Param(Type type, Ident name)                                 TK_PARAM
 //
-// -- TODO: change returns to be a list of expressions
 // Def   = Def(Ident name, List<Param> params, List<Stmt> body)         TK_DEF
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF
@@ -47,7 +46,7 @@ namespace script {
 //       | UnaryOp(Expr expr)
 //       |     Not                                                      TK_NOT
 //       |     USub                                                     '-'
-//       | Const()                                                      TK_NUMBER
+//       | Const(String value)                                          TK_CONST
 //       | Cast(ScalarType type, Expr expr)                             TK_CAST
 //       -- NB: x.name(y) is desugared into name(x, y)
 //       | Apply(Ident name, List<Expr> args, List<Attribute> kwargs)   TK_APPLY
@@ -233,7 +232,7 @@ struct Expr : public TreeView {
       case '/':
       case TK_NOT:
       /* case '-': - unary minus */
-      case TK_NUMBER:
+      case TK_CONST:
       case TK_CAST:
       case TK_APPLY:
       case '.':
@@ -514,22 +513,22 @@ struct UnaryOp : public Expr {
 
 struct Const : public Expr {
   explicit Const(const TreeRef& tree) : Expr(tree) {
-    tree_->match(TK_NUMBER);
+    tree_->matchNumSubtrees(TK_CONST, 1);
   }
   bool isFloatingPoint() const {
-    return tree_->stringValue().find_first_of(".eE") != std::string::npos;
+    return subtree(0)->stringValue().find_first_of(".eE") != std::string::npos;
   }
   bool isIntegral() const {
     return !isFloatingPoint();
   }
   int64_t asIntegral() const {
-    return std::stoll(tree_->stringValue());
+    return std::stoll(subtree(0)->stringValue());
   }
   double asFloatingPoint() const {
-    return std::stod(tree_->stringValue());
+    return std::stod(subtree(0)->stringValue());
   }
-  static Const create(const SourceRange& range, std::string value) {
-    return Const(Number::create(range, std::move(value)));
+  static Const create(const SourceRange& range, const std::string& value) {
+    return Const(Compound::create(TK_CONST, range, {String::create(value)}));
   }
 };
 
@@ -615,7 +614,7 @@ struct Slice : public Expr {
   }
 private:
   Expr createInt(int value) const {
-    return Expr(Number::create(range(), std::to_string(value)));
+    return Expr(Const::create(range(), std::to_string(value)));
   }
 };
 


### PR DESCRIPTION
As discussed in the today's meeting. For now we always emit floating point literals as float tensors, and int literals as long tensors. I haven't added the casts yet, but it should be fairly straightforward to do so in the future if we will need it.