### PR TITLE
Add optimization to norm for common norms

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -3935,27 +3935,36 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension, int k
   THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
+  #define DIM_REDUCE(reduce, transform) \
+    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,      \
+                         accreal sum = 0;                   \
+                         int64_t i;                         \
+                         for(i = 0; i < t_size; i++) {      \
+                           (reduce);                        \
+                         }                                  \
+                         (transform);)                      \
+
   if(value == 0) {
-    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
-                         accreal sum = 0;
-                         int64_t i;
-                         for(i = 0; i < t_size; i++)
-                           sum += t_data[i*t_stride] != 0.0;
-                         *r__data = sum;)
+    DIM_REDUCE(sum += t_data[i*t_stride] != 0.0,
+               *r__data = sum);
+  } else if (value == 1) {
+    DIM_REDUCE(sum += TH_MATH_NAME(fabs)(t_data[i*t_stride]),
+               *r__data = sum);
+  } else if (value == 2) {
+    DIM_REDUCE(sum += t_data[i*t_stride] * t_data[i*t_stride],
+               *r__data = TH_MATH_NAME(sqrt)(sum));
+  } else if (value == 3) {
+    DIM_REDUCE(sum += TH_MATH_NAME(fabs)(t_data[i*t_stride] * t_data[i*t_stride] * t_data[i*t_stride]),
+               *r__data = TH_MATH_NAME(pow)(sum, 1.0/3));
   } else {
-    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
-                         accreal sum = 0;
-                         int64_t i;
-                         for(i = 0; i < t_size; i++) {
-                           sum += TH_MATH_NAME(pow)(
-                             TH_MATH_NAME(fabs)(t_data[i*t_stride]), value);
-                         }
-                         *r__data = TH_MATH_NAME(pow)(sum, 1.0/value);)
+    DIM_REDUCE(sum += TH_MATH_NAME(pow)(TH_MATH_NAME(fabs)(t_data[i*t_stride]), value),
+               *r__data = TH_MATH_NAME(pow)(sum, 1.0/value));
   }
 
   if (!keepdim) {
     THTensor_(squeeze1d)(r_, r_, dimension);
   }
+  #undef DIM_REDUCE
 }
 
 accreal THTensor_(normall)(THTensor *tensor, real value)
@@ -3970,6 +3979,9 @@ accreal THTensor_(normall)(THTensor *tensor, real value)
   } else if(value == 2) {
     TH_TENSOR_APPLY(real, tensor, accreal z = *tensor_data; sum += z*z;);
     return sqrt(sum);
+  } else if(value == 3) {
+    TH_TENSOR_APPLY(real, tensor, accreal z = *tensor_data; sum += TH_MATH_NAME(fabs)(z*z*z););
+    return TH_MATH_NAME(pow)(sum, 1.0/3);
   } else {
     TH_TENSOR_APPLY(real, tensor, sum += TH_MATH_NAME(pow)(TH_MATH_NAME(fabs)(*tensor_data), value););
     return TH_MATH_NAME(pow)(sum, 1.0/value);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4636,6 +4636,34 @@ class TestTorch(TestCase):
         b = pickle.loads(serialized)
         self.assertEqual(a, b)
 
+    def test_norm_fastpaths(self):
+        x = torch.randn(3, 5)
+
+        # slow path
+        result = torch.norm(x, 4.5, 1)
+        expected = torch.pow(x.abs().pow(4.5).sum(1), 1.0 / 4.5)
+        self.assertEqual(result, expected)
+
+        # fast 0-norm
+        result = torch.norm(x, 0, 1)
+        expected = (x != 0).type_as(x).sum(1)
+        self.assertEqual(result, expected)
+
+        # fast 1-norm
+        result = torch.norm(x, 1, 1)
+        expected = x.abs().sum(1)
+        self.assertEqual(result, expected)
+
+        # fast 2-norm
+        result = torch.norm(x, 2, 1)
+        expected = torch.sqrt(x.pow(2).sum(1))
+        self.assertEqual(result, expected)
+
+        # fast 3-norm
+        result = torch.norm(x, 3, 1)
+        expected = torch.pow(x.pow(3).abs().sum(1), 1.0 / 3.0)
+        self.assertEqual(result, expected)
+
     def test_bernoulli(self):
         t = torch.ByteTensor(10, 10)
 


### PR DESCRIPTION
Fixes #5671 

The reported issue is that on the CPU path, norm(value, dim) is slower than manually using pow, sqrt, and summing.

It turns out that the CPU path for norm(value, dim) is missing optimizations in the `value=1, 2` cases. I added those in as well as an optimization for `value = 3` (not sure if this is necessary, but this optimization is used for `tensor.pow(3)`).

@li-roy could you take a look?

Perf numbers:
```

In [1]: import torch
   ...: x = torch.randn(1024, 256)
   ...: y = torch.randn(1024, 256)
   ...:
   ...: %timeit torch.norm(x-y, 1, 1)
   ...: %timeit (x-y).sum(1)
   ...:
   ...: %timeit torch.norm(x-y, 2, 1)
   ...: %timeit torch.sqrt((x-y).pow(2).sum(1))
   ...:
   ...: %timeit torch.norm(x-y, 3, 1)
   ...: %timeit torch.pow((x - y).abs().pow(3).sum(1), 1/3)
   ...:
362 µs ± 56.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
332 µs ± 33.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

340 µs ± 8.42 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
358 µs ± 5.87 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

352 µs ± 4.55 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
691 µs ± 49.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```