### PR TITLE
tbb set_num_threads

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ATen/ATenGeneral.h"
+#include "ATen/CPUGeneral.h"
 #include "ATen/Allocator.h"
 #include "ATen/Scalar.h"
 #include "ATen/Type.h"

--- a/aten/src/ATen/CPUGeneral.cpp
+++ b/aten/src/ATen/CPUGeneral.cpp
@@ -1,0 +1,16 @@
+#include <ATen/CPUGeneral.h>
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace at {
+// Lock free atomic type
+std::atomic<int> num_threads(-1);
+
+void set_num_threads(int num_threads_) {
+  if (num_threads_ >= 0)
+    num_threads.store(num_threads_);
+}
+
+int get_num_threads() { return num_threads.load(); }
+}

--- a/aten/src/ATen/CPUGeneral.h
+++ b/aten/src/ATen/CPUGeneral.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Using AT_API is crucial as otherwise you'll see
+// linking errors using MSVC
+// See https://msdn.microsoft.com/en-us/library/a90k134d.aspx
+// This header adds this if using AT_API
+#include "ATen/ATenGeneral.h"
+
+namespace at {
+AT_API void set_num_threads(int);
+AT_API int get_num_threads();
+}

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ATen/ATenGeneral.h"
+#include <ATen/CPUGeneral.h>
 #include "ATen/Generator.h"
 #include "ATen/Type.h"
 #include "ATen/Utils.h"
@@ -93,6 +94,12 @@ AT_API Context & globalContext();
 
 static inline void init() {
   globalContext();
+  if (const char *env_p = std::getenv("OMP_NUM_THREADS")) {
+    at::set_num_threads(std::stoi(env_p));
+  }
+  if (const char *env_p = std::getenv("MKL_NUM_THREADS")) {
+    at::set_num_threads(std::stoi(env_p));
+  }
 }
 
 static inline Type& getType(Backend p, ScalarType s) {

--- a/aten/src/ATen/Parallel.cpp
+++ b/aten/src/ATen/Parallel.cpp
@@ -1,0 +1,55 @@
+#include <ATen/CPUGeneral.h>
+#include <ATen/Parallel.h>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_reduce.h>
+#include <tbb/partitioner.h>
+#include <tbb/tbb.h>
+#include <thread>
+#include <cassert>
+
+namespace at {
+namespace internal {
+
+// thread_local variable with internal linkage
+// requires no guarding as it's storage duration is defined to be per thread
+static thread_local tbb::task_scheduler_init tbbinit(tbb::task_scheduler_init::deferred);
+// Tracks number of threads uses which TBB doesn't track.
+static thread_local int num_threads_ = -1;
+
+// Negative number of threads means default value
+void init_tbb_num_threads() {
+  static thread_local bool first_call = true;
+  int num_threads = at::get_num_threads();
+  // In order to have control over the number of threads this function
+  // must be called first before any other tbb parallel construct is
+  // excercised within a particular thread. Otherwise the default 
+  // scheduler will be created over which we do not have control. 
+  // The following code will and must throw an error if tbb has 
+  // already been initialized before this function was called.
+  if (!tbbinit.is_active() && !first_call)
+    throw std::runtime_error(
+        "tbb initialization failed: scheduler not active after first call");
+  if (first_call) {
+    if (tbbinit.is_active())
+      throw std::runtime_error(
+          "tbb initialization failed: scheduler active on first call");
+    if (num_threads < 0) {
+      int max_threads = tbbinit.default_num_threads();
+      tbbinit.initialize(max_threads);
+    } else {
+      tbbinit.initialize(num_threads);
+    }
+    first_call = false;
+  }
+  if (num_threads == 0) {
+    // TODO: For PyTorch 0 means 1
+    num_threads = 1;
+  }
+  if (num_threads > 0 && (num_threads_ != num_threads)) {
+    tbbinit.terminate();
+    tbbinit.initialize(num_threads);
+    num_threads_ = num_threads;
+  }
+}
+}
+}

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,29 +1,41 @@
 #pragma once
-#include <tbb/blocked_range.h>
-#include <tbb/parallel_reduce.h>
-#include <tbb/partitioner.h>
+#include <cstddef>
 #include <tbb/tbb.h>
 
 namespace at {
-namespace native {
-
+namespace internal {
+// This needs to be called before the first use of any algorithm such as
+// parallel or it will have no effect and the default task scheduler is
+// created which uses all available cores.
+// See
+// https://www.threadingbuildingblocks.org/docs/help/reference/task_scheduler/task_scheduler_init_cls.html
+// This does not initializes the number of workers in the market (the overall
+// of workers available to a process). It is merely a request to the market
+// for a certain number of workers. If there are multiple threads making
+// a request at the size of the maximum number of threads, they will
+// be allocated a number proportional to the other requests.
+void init_tbb_num_threads();
 // This parameter is heuristically chosen to determine the minimum number of
 // work that warrants paralellism. For example, when summing an array, it is
 // deemed inefficient to parallelise over arrays shorter than 32768. Further,
 // no parallel algorithm (such as parallel_reduce) should split work into
 // smaller than GRAIN_SIZE chunks.
-constexpr size_t GRAIN_SIZE = 32768;
+constexpr size_t TBB_GRAIN_SIZE = 32768;
+}
 
 template <class T, template <class> class OP>
 T parallel_reduce(T (*f)(const T *, size_t, size_t, T), const T *data,
                   size_t start, size_t end, T init_) {
+
+  internal::init_tbb_num_threads();
+
   T result_;
   static tbb::affinity_partitioner ap;
-  if ((size_t)(end - start) < GRAIN_SIZE) {
+  if ((size_t)(end - start) < internal::TBB_GRAIN_SIZE) {
     result_ = f(data, start, end, init_);
   } else {
     result_ = tbb::parallel_reduce(
-        tbb::blocked_range<size_t>(start, end, GRAIN_SIZE), init_,
+        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE), init_,
         [&data, &f](const tbb::blocked_range<size_t> r, T init) -> T {
           return f(data, r.begin(), r.end(), init);
         },
@@ -36,11 +48,13 @@ template <class T>
 void parallel_for_2d(void (*f)(const T *, T *, size_t, size_t), size_t num_rows,
                      size_t num_cols, size_t numel, const T *arr_, T *outarr_) {
 
+  internal::init_tbb_num_threads();
+
   static tbb::affinity_partitioner ap;
 
   size_t max_i_ =
       (numel && num_rows && num_cols) ? numel / (num_rows * num_cols) : 0;
-  if (numel < GRAIN_SIZE) {
+  if (numel < internal::TBB_GRAIN_SIZE) {
     for (size_t i_ = 0; i_ < max_i_; i_++) {
       int64_t i = i_ * num_rows * num_cols;
       int64_t i_r = i_ * num_cols;
@@ -50,7 +64,7 @@ void parallel_for_2d(void (*f)(const T *, T *, size_t, size_t), size_t num_rows,
     }
   } else {
     tbb::parallel_for(tbb::blocked_range2d<size_t, size_t>(
-                          0, num_cols, GRAIN_SIZE, 0, max_i_, 1),
+                          0, num_cols, internal::TBB_GRAIN_SIZE, 0, max_i_, 1),
                       [&arr_, &outarr_, num_rows, num_cols,
                        &f](const tbb::blocked_range2d<size_t, size_t> r) {
                         for (size_t i_ = r.cols().begin(); i_ < r.cols().end();
@@ -65,6 +79,5 @@ void parallel_for_2d(void (*f)(const T *, T *, size_t, size_t), size_t num_rows,
                       },
                       ap);
   }
-}
 }
 }

--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -24,13 +24,15 @@ struct DispatchStub<void(ArgTypes...)> {
   template <template <CPUCapability> class allImpl,
             FnType **dispatch_ptr>
   static void init(ArgTypes... args) {
-    cpuinfo_initialize();
     *dispatch_ptr = allImpl<CPUCapability::DEFAULT>::function;
-    if (cpuinfo_has_x86_avx2()) {
-      *dispatch_ptr = allImpl<CPUCapability::AVX2>::function;
-    } else if (cpuinfo_has_x86_avx()) {
-      *dispatch_ptr = allImpl<CPUCapability::AVX>::function;
-    } 
+    // Check if platform is supported
+    if (cpuinfo_initialize()) {
+      if (cpuinfo_has_x86_avx2()) {
+        *dispatch_ptr = allImpl<CPUCapability::AVX2>::function;
+      } else if (cpuinfo_has_x86_avx()) {
+        *dispatch_ptr = allImpl<CPUCapability::AVX>::function;
+      }
+    }
     (*dispatch_ptr)(args...);
   }
 };

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -1,10 +1,10 @@
 #pragma once
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
 #include "CapabilityDispatch.h"
-#include "Parallel.h"
 #include "Vec256.h"
 #include <stdexcept>
 
-#include "ATen/ATen.h"
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(undefined_tensor_test ATen)
 add_executable(verify_api_visibility verify_api_visibility.cpp)
 target_link_libraries(verify_api_visibility ATen)
 
+add_executable(tbb_init_test tbb_init_test.cpp)
+target_link_libraries(tbb_init_test ATen)
+
 if(NOT NO_CUDA)
   cuda_add_executable(integer_divider_test integer_divider_test.cu)
   target_link_libraries(integer_divider_test ATen)

--- a/aten/src/ATen/test/tbb_init_test.cpp
+++ b/aten/src/ATen/test/tbb_init_test.cpp
@@ -1,0 +1,43 @@
+#include "ATen/ATen.h"
+#include "ATen/Parallel.h"
+#include "test_assert.h"
+#include "test_seed.h"
+#include <thread>
+
+using namespace at;
+
+// This checks whether threads can see the global
+// numbers of threads set and also whether the scheduler
+// will throw an exception when multiple threads call 
+// their first parallel construct.
+void test(int given_num_threads) {
+  auto t = ones(CPU(kFloat), {1000 * 1000});
+  if (given_num_threads >= 0) {
+    ASSERT(at::get_num_threads() == given_num_threads);
+  } else {
+    ASSERT(at::get_num_threads() == -1);
+  }
+  auto t_sum = t.sum();
+  for (int i = 0; i < 1000; i ++) {
+    t_sum = t_sum + t.sum();
+  }
+}
+
+int main() {
+  manual_seed(123);
+
+  test(-1);
+  std::thread t1(test, -1);
+  t1.join();
+  at::set_num_threads(4);
+  std::thread t2(test, 4);
+  std::thread t3(test, 4);
+  std::thread t4(test, 4);
+  t4.join();
+  t3.join();
+  t2.join();
+  at::set_num_threads(5);
+  test(5);
+
+  return 0;
+}

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -110,6 +110,7 @@ static PyObject * THPModule_setNumThreads(PyObject *module, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg), "set_num_threads expects an int, "
           "but got %s", THPUtils_typename(arg));
   THSetNumThreads((int)THPUtils_unpackLong(arg));
+  at::set_num_threads((int)THPUtils_unpackLong(arg));
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
This PR hooks up TBB with set_num_threads and also cleans up the code within ReduceOps.cpp a bit.

You can see that the restriction works using the following script

```
import torch
import argparse

if __name__ == "__main__":
    parser = argparse.ArgumentParser(description='Process some integers.')
    parser.add_argument('threads', type=int)
    args = parser.parse_args()

    tv = torch.randn(1000 * 1000 * 10)
    if args.threads > 0:
        torch.set_num_threads(args.threads)
    for _ in range(10000):
        tv.sum()
```

```
(base) [16:44:39: cpuhrsch@devfair0129 benchmarks]$ perf stat python sum_stress.py 5

 Performance counter stats for 'python sum_stress.py 5':

      17327.154266      task-clock (msec)         #    3.721 CPUs utilized          
               962      context-switches          #    0.056 K/sec                  
                90      cpu-migrations            #    0.005 K/sec                  
            22,517      page-faults               #    0.001 M/sec                  
    38,071,989,548      cycles                    #    2.197 GHz                    
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
    31,333,390,416      instructions              #    0.82  insns per cycle        
     3,732,742,496      branches                  #  215.427 M/sec                  
         8,014,202      branch-misses             #    0.21% of all branches        

       4.656548693 seconds time elapsed

(base) [16:44:44: cpuhrsch@devfair0129 benchmarks]$ perf stat python sum_stress.py 2

 Performance counter stats for 'python sum_stress.py 2':

      16708.310926      task-clock (msec)         #    1.780 CPUs utilized          
             1,893      context-switches          #    0.113 K/sec                  
                85      cpu-migrations            #    0.005 K/sec                  
            21,486      page-faults               #    0.001 M/sec                  
    36,683,508,608      cycles                    #    2.196 GHz                    
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
    30,414,604,047      instructions              #    0.83  insns per cycle        
     3,536,252,326      branches                  #  211.646 M/sec                  
         5,265,418      branch-misses             #    0.15% of all branches        

       9.386758238 seconds time elapsed

(base) [16:51:54: cpuhrsch@devfair0129 benchmarks]$ perf stat python sum_stress.py 0

 Performance counter stats for 'python sum_stress.py 0':

      47343.842407      task-clock (msec)         #   19.877 CPUs utilized          
           135,891      context-switches          #    0.003 M/sec                  
               623      cpu-migrations            #    0.013 K/sec                  
            21,791      page-faults               #    0.460 K/sec                  
   104,047,864,558      cycles                    #    2.198 GHz                    
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
    46,576,686,318      instructions              #    0.45  insns per cycle        
     7,054,117,917      branches                  #  148.998 M/sec                  
        33,104,250      branch-misses             #    0.47% of all branches        

       2.381825636 seconds time elapsed

(base) [16:52:18: cpuhrsch@devfair0129 benchmarks]$ perf stat python sum_stress.py 1

 Performance counter stats for 'python sum_stress.py 1':

      16819.557761      task-clock (msec)         #    0.991 CPUs utilized          
               905      context-switches          #    0.054 K/sec                  
                79      cpu-migrations            #    0.005 K/sec                  
            23,798      page-faults               #    0.001 M/sec                  
    36,957,423,434      cycles                    #    2.197 GHz                    
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
    30,260,079,596      instructions              #    0.82  insns per cycle        
     3,503,067,589      branches                  #  208.273 M/sec                  
         5,049,148      branch-misses             #    0.14% of all branches        

      16.969856749 seconds time elapsed
```