### PR TITLE
add some onnx exported supports

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -424,10 +424,10 @@ def upsample_bilinear2d(g, input, output_size):
     w_scale = float(output_size[-1])/input.type().sizes()[-1]
     h_scale = float(output_size[-2])/input.type().sizes()[-2]
     return g.op("Upsample", input, width_scale_f=w_scale,
-                height_scale_f = h_scale, mode_s="bilinear")
+                height_scale_f=h_scale, mode_s="bilinear")
 
 def stack(g, *tensors, dim=0):
-    return g.op("ATen", *tensors, operator_s = "stack", dim_i=dim)
+    return g.op("ATen", *tensors, operator_s="stack", dim_i=dim)
 
 def nonzero(g, input):
     return g.op("ATen", input, operator_s="nonzero")

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -420,6 +420,23 @@ def upsample_nearest2d(g, input, scale_factor):
     return g.op("Upsample", input, width_scale_f=scale_factor,
                 height_scale_f=scale_factor, mode_s="nearest")
 
+def upsample_bilinear2d(g, input, output_size):
+    w_scale = float(output_size[-1])/input.type().sizes()[-1]
+    h_scale = float(output_size[-2])/input.type().sizes()[-2]
+    return g.op("Upsample", input, width_scale_f=w_scale,
+                height_scale_f = h_scale, mode_s="bilinear")
+
+def stack(g, *tensors, dim=0):
+    return g.op("ATen", *tensors, operator_s = "stack", dim_i=dim)
+
+def nonzero(g, input):
+    return g.op("ATen", input, operator_s="nonzero")
+
+def round(g, input):
+    return g.op("ATen", input, operator_s="round")
+
+def gt(g, input, other):
+    return g.op("ATen", input, _if_scalar_type_as(other, input), operator_s="gt")
 
 def log_softmax(g, input, dim=None):
     return g.op("LogSoftmax", input, axis_i=dim)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -420,23 +420,29 @@ def upsample_nearest2d(g, input, scale_factor):
     return g.op("Upsample", input, width_scale_f=scale_factor,
                 height_scale_f=scale_factor, mode_s="nearest")
 
+
 def upsample_bilinear2d(g, input, output_size):
-    w_scale = float(output_size[-1])/input.type().sizes()[-1]
-    h_scale = float(output_size[-2])/input.type().sizes()[-2]
+    w_scale = float(output_size[-1]) / input.type().sizes()[-1]
+    h_scale = float(output_size[-2]) / input.type().sizes()[-2]
     return g.op("Upsample", input, width_scale_f=w_scale,
                 height_scale_f=h_scale, mode_s="bilinear")
+
 
 def stack(g, *tensors, dim=0):
     return g.op("ATen", *tensors, operator_s="stack", dim_i=dim)
 
+
 def nonzero(g, input):
     return g.op("ATen", input, operator_s="nonzero")
+
 
 def round(g, input):
     return g.op("ATen", input, operator_s="round")
 
+
 def gt(g, input, other):
     return g.op("ATen", input, _if_scalar_type_as(other, input), operator_s="gt")
+
 
 def log_softmax(g, input, dim=None):
     return g.op("LogSoftmax", input, axis_i=dim)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -428,7 +428,7 @@ def upsample_bilinear2d(g, input, output_size):
                 height_scale_f=h_scale, mode_s="bilinear")
 
 
-def stack(g, *tensors, dim=0):
+def stack(g, *tensors, dim):
     return g.op("ATen", *tensors, operator_s="stack", dim_i=dim)
 
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -428,20 +428,12 @@ def upsample_bilinear2d(g, input, output_size):
                 height_scale_f=h_scale, mode_s="bilinear")
 
 
-def stack(g, *tensors, dim):
-    return g.op("ATen", *tensors, operator_s="stack", dim_i=dim)
-
-
-def nonzero(g, input):
-    return g.op("ATen", input, operator_s="nonzero")
-
-
-def round(g, input):
-    return g.op("ATen", input, operator_s="round")
-
-
 def gt(g, input, other):
-    return g.op("ATen", input, _if_scalar_type_as(other, input), operator_s="gt")
+    return g.op("Greater", input, _if_scalar_type_as(other, input), **_broadcast_if_scalar(other))
+
+
+def lt(g, input, other):
+    return g.op("Less", input, _if_scalar_type_as(other, input), **_broadcast_if_scalar(other))
 
 
 def log_softmax(g, input, dim=None):


### PR DESCRIPTION
Hi, when I tried to export my PyTorch model to ONNX format, I found that there were a few operators missing in `torch/onnx/symbolic.py` : 
```
1.   upsample_bilinear2d 
2.   stack
3.   nonzero
4.   round
5.   gt
```
Aside from `upsample_bilinear2d`, which is already a ONNX standardized operator, I added all the rest operators using ATen. I have tested the ONNX exported protobuf with [Caffe2](https://github.com/caffe2/caffe2) and I think this modification would work.