### PR TITLE
Add torch.sparse_coo_tensor factory.

### DIFF
--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -82,6 +82,13 @@ static PyObject * THPVariable_from_numpy(PyObject* module, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_sparse_coo_tensor(PyObject* self, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  return THPVariable_Wrap(torch::utils::new_sparse_coo_tensor(default_type(), args, kwargs));
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * THPVariable_tensor(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
@@ -99,6 +106,7 @@ static PyMethodDef torch_functions[] = {
   {"from_numpy", (PyCFunction)THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
   {"hsmm", (PyCFunction)THPVariable_hspmm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"saddmm", (PyCFunction)THPVariable_sspaddmm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
+  {"sparse_coo_tensor", (PyCFunction)THPVariable_sparse_coo_tensor, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"spmm", (PyCFunction)THPVariable_mm, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"tensor", (PyCFunction)THPVariable_tensor, METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   ${py_method_defs}

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -129,14 +129,25 @@ static void recursive_store(char* data, IntList sizes, IntList strides, int64_t 
   }
 }
 
-static Tensor internal_new_from_data(const Type & type, int device, PyObject* data, bool always_copy) {
+static Tensor internal_new_from_data(const Type & type, int device, PyObject* data,
+                                     bool allow_variables, bool copy_variables, bool copy_numpy) {
   if (THPUtils_checkString(data)) {
     throw TypeError("new(): invalid data type '%s'", Py_TYPE(data)->tp_name);
   }
+
+  if (allow_variables) {
+    if (THPVariable_Check(data)) {
+      auto var = reinterpret_cast<THPVariable*>(data)->cdata;
+      return copy_variables ? new_with_tensor_copy(type, var, device) :
+                              new_with_type_conversion(type, var, device);
+    }
+  }
+
 #ifdef WITH_NUMPY
   if (PyArray_Check(data)) {
     auto tensor = autograd::make_variable(tensor_from_numpy(data), /*requires_grad=*/false);
-    return always_copy ? new_with_tensor_copy(type, tensor, device) : new_with_type_conversion(type, tensor, device);
+    return copy_numpy ? new_with_tensor_copy(type, tensor, device) :
+                        new_with_type_conversion(type, tensor, device);
   }
 #endif
 
@@ -149,11 +160,11 @@ static Tensor internal_new_from_data(const Type & type, int device, PyObject* da
 }
 
 Tensor legacy_new_from_data(const Type & type, int device, PyObject *data) {
-  return internal_new_from_data(type, device, data, false);
+  return internal_new_from_data(type, device, data, false, false, false);
 }
 
 static Tensor new_from_data_copy(const Type & type, int device, PyObject *data) {
-  return internal_new_from_data(type, device, data, true);
+  return internal_new_from_data(type, device, data, true, true, true);
 }
 
 static Tensor legacy_new_from_sequence(const Type & type, int device, PyObject* data) {
@@ -350,17 +361,48 @@ static Tensor set_requires_grad(Tensor self, bool requires_grad) {
   return self;
 }
 
+Tensor new_sparse_coo_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
+  Backend sparse_backend = type.is_cuda() ? kSparseCUDA : kSparseCPU;
+  Backend dense_backend = type.is_cuda() ? kCUDA : kCPU;
+  const auto& default_sparse_type = type.toBackend(sparse_backend);
+
+  static PythonArgParser parser({
+    "new_sparse_coo_tensor(PyObject* indices, PyObject* values, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+    "new_sparse_coo_tensor(PyObject* indices, PyObject* values, IntList size, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
+  });
+
+  ParsedArgs<6> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0) {
+    const auto& sparse_type = r.typeWithDefault(2, default_sparse_type);
+    check_is_sparse(sparse_type);
+    const auto& dense_type = sparse_type.toBackend(dense_backend);
+    const auto& index_type = dense_type.toScalarType(kLong);
+    // explanation of booleans: allow variables, do type conversion of them, copy numpy data
+    Tensor indices = internal_new_from_data(index_type, r.toInt64(3), r.pyobject(0), true, false, true);
+    Tensor values = internal_new_from_data(dense_type, r.toInt64(3), r.pyobject(1), true, false, true);
+    return set_requires_grad(sparse_type.sparse_coo_tensor(indices, values), r.toBool(4));
+  } else if (r.idx == 1) {
+    const auto& sparse_type = r.typeWithDefault(3, default_sparse_type);
+    check_is_sparse(sparse_type);
+    const auto& dense_type = sparse_type.toBackend(dense_backend);
+    const auto& index_type = dense_type.toScalarType(kLong);
+    // explanation of booleans: allow variables, do type conversion of them, copy numpy data
+    Tensor indices = internal_new_from_data(index_type, r.toInt64(4), r.pyobject(0), true, false, true);
+    Tensor values = internal_new_from_data(dense_type, r.toInt64(4), r.pyobject(1), true, false, true);
+    return set_requires_grad(sparse_type.sparse_coo_tensor(indices, values, r.intlist(2)), r.toBool(5));
+  }
+  throw std::runtime_error("new_sparse_coo_tensor(): invalid arguments");
+}
+
 Tensor new_tensor(const Type& type, PyObject* args, PyObject* kwargs) {
   static PythonArgParser parser({
-    "new_tensor(Tensor other, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
     "new_tensor(PyObject* data, *, Type dtype=None, int64_t? device=-1, bool requires_grad=False)",
   });
 
   ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
-    return set_requires_grad(new_with_tensor_copy(r.typeWithDefault(1, type), r.tensor(0), r.toInt64(2)), r.toBool(3));
-  } else if (r.idx == 1) {
     return set_requires_grad(new_from_data_copy(r.typeWithDefault(1, type), r.toInt64(2), r.pyobject(0)), r.toBool(3));
   }
   throw std::runtime_error("new_tensor(): invalid arguments");

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -8,6 +8,7 @@ namespace torch { namespace utils {
 at::Tensor legacy_tensor_ctor(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor legacy_tensor_new(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor legacy_new_from_data(const at::Type& type, int device, PyObject *data);
+at::Tensor new_sparse_coo_tensor(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor new_tensor(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor new_empty(const at::Type& type, PyObject* args, PyObject* kwargs);
 at::Tensor new_full(const at::Type& type, PyObject* args, PyObject* kwargs);


### PR DESCRIPTION
Notes:
1) I didn't add Tensor.new_sparse_coo_tensor; it didn't seem particularly useful, but it's easy to add
2) This doesn't do the type inference, i.e. torch.sparse_coo_tensor(indices=LongTensor, values=IntTensor) will return a sparse tensor corresponding to the default type rather than a sparse IntTensor.  We can add type inference later when we add it to other factories.