### PR TITLE
Restore tensor.type, tensor.type_as docs

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1775,6 +1775,40 @@ trunc_() -> Tensor
 In-place version of :meth:`~Tensor.trunc`
 """)
 
+add_docstr_all('type',
+               r"""
+type(dtype=None, non_blocking=False, **kwargs) -> str or Tensor
+Returns the type if `dtype` is not provided, else casts this object to
+the specified type.
+
+If this is already of the correct type, no copy is performed and the
+original object is returned.
+
+Args:
+    dtype (type or string): The desired type
+    non_blocking (bool): If ``True``, and the source is in pinned memory
+        and destination is on the GPU or vice versa, the copy is performed
+        asynchronously with respect to the host. Otherwise, the argument
+        has no effect.
+    **kwargs: For compatibility, may contain the key ``async`` in place of
+        the ``non_blocking`` argument. The ``async`` arg is deprecated.
+""")
+
+add_docstr_all('type_as',
+               r"""
+type_as(tensor) -> Tensor
+
+Returns this tensor cast to the type of the given tensor.
+
+This is a no-op if the tensor is already of the correct type. This is
+equivalent to::
+
+    self.type(tensor.type())
+
+Params:
+    tensor (Tensor): the tensor which has the desired type
+""")
+
 add_docstr_all('unfold',
                r"""
 unfold(dim, size, step) -> Tensor

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -18,7 +18,7 @@ def _type(self, dtype=None, non_blocking=False, **kwargs):
             asynchronously with respect to the host. Otherwise, the argument
             has no effect.
         **kwargs: For compatibility, may contain the key ``async`` in place of
-            the ``non_blocking`` argument.
+            the ``non_blocking`` argument. The ``async`` arg is deprecated.
     """
     non_blocking = _get_async_or_non_blocking('type', non_blocking, kwargs)
     if dtype is None:


### PR DESCRIPTION
~~Also delete the now unused _type() method in _utils.py~~ nevermind, looks like that's still used by storages.

There are some other things that are missing in the tensor docs but I'll handle those in another PR.

Fixes #5598 

cc @colesbury 