### PR TITLE
Save self.numel() for backward computation instead of self

### DIFF
--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -289,6 +289,11 @@ def saved_variables(formula, args):
             'suffix': lambda m: '_argsize_{}'.format(*m.groups()),
             'type': 'int64_t',
         }),
+        # replace self.numel() with self_numel
+        (r'{}.numel\(\)', {
+            'suffix': '_numel',
+            'type': 'int64_t',
+        }),
         # replace to_arg_sizes(self, 2) with self_argsizes_2
         (r'to_arg_sizes\({}, (\w+)\)', {
             'suffix': lambda m: '_sizes_{}'.format(*m.groups()),


### PR DESCRIPTION
Fixes #5741

The only operation that really benefits from this right now is `tensor.mean()`.

cc @gchanan @colesbury  

### Test Plan
python test/test_autograd.py