### PR TITLE
Allow indexing by scalars and zero-dim tensors

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -48,9 +48,13 @@ inline Tensor Tensor::operator[](Scalar index) const {
   return select(0, index.toLong());
 }
 inline Tensor Tensor::operator[](Tensor index) const {
-  // The Scalar(Tensor) constructor is explicit, so we need to actually call
-  // it. This constructor will also throw if the tensor is not zero-dim or
-  // undefined.
+  // These properties are checked in the Scalar constructor, but we already
+  // check them here to provide more useful diagnostics for the user.
+  AT_ASSERT(index.defined(), "Can only index with tensors that are defined");
+  AT_ASSERT(
+      index.dim() == 0,
+      "Can only index with tensors that are scalars (zero-dim)");
+  // The Scalar(Tensor) constructor is explicit, so we need to call it.
   return this->operator[](Scalar(index));
 }
 

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -48,6 +48,9 @@ inline Tensor Tensor::operator[](Scalar index) const {
   return select(0, index.toLong());
 }
 inline Tensor Tensor::operator[](Tensor index) const {
+  // The Scalar(Tensor) constructor is explicit, so we need to actually call
+  // it. This constructor will also throw if the tensor is not zero-dim or
+  // undefined.
   return this->operator[](Scalar(index));
 }
 

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "ATen/Tensor.h"
 #include "ATen/Scalar.h"
+#include "ATen/Tensor.h"
+#include "ATen/Type.h"
 
+#include <string>
+#include <stdexcept>
 
 namespace at {
 
@@ -37,8 +40,15 @@ inline Tensor& Tensor::operator/=(const Tensor & other) {
 inline Tensor& Tensor::operator/=(Scalar other) {
   return div_(other);
 }
-inline Tensor Tensor::operator[](int64_t idx) const {
-  return select(0, idx);
+inline Tensor Tensor::operator[](Scalar index) const {
+  AT_ASSERT(
+      index.local().isIntegral(),
+      "Can only index tensors with integral scalars (got %s)",
+      index.toTensor().type().toString());
+  return select(0, index.toLong());
+}
+inline Tensor Tensor::operator[](Tensor index) const {
+  return this->operator[](Scalar(index));
 }
 
 #define AT_FORALL_BINARY_OPS(_) \

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -116,7 +116,8 @@ struct Tensor : public detail::TensorBase {
   Tensor& operator*=(Scalar other);
   Tensor& operator/=(const Tensor & other);
   Tensor& operator/=(Scalar other);
-  Tensor operator[](int64_t idx) const;
+  Tensor operator[](Scalar index) const;
+  Tensor operator[](Tensor index) const;
 
   // STOP.  Thinking of adding a method here, which only makes use
   // of other ATen methods?  Define it in native_functions.yaml.

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -261,16 +261,16 @@ static void test(Type & type) {
     // Indexing by Scalar
     Tensor tensor = CPU(kInt).arange(0, 10);
     Tensor one = CPU(kInt).ones({1});
-    for (long i = 0; i < tensor.numel(); ++i) {
+    for (int64_t i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }
     for (int i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }
-    for (short i = 0; i < tensor.numel(); ++i) {
+    for (int16_t i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }
-    for (char i = 0; i < tensor.numel(); ++i) {
+    for (int8_t i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }
     try {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -257,7 +257,54 @@ static void test(Type & type) {
     std::string expect = "1e-07 *";
     ASSERT(s.str().substr(0,expect.size()) == expect);
   }
-
+  {
+    // Indexing by Scalar
+    Tensor tensor = CPU(kInt).arange(0, 10);
+    Tensor one = CPU(kInt).ones({1});
+    for (long i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[i].equal(one * i));
+    }
+    for (int i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[i].equal(one * i));
+    }
+    for (short i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[i].equal(one * i));
+    }
+    for (char i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[i].equal(one * i));
+    }
+    try {
+      ASSERT(tensor[Scalar(3.14)].equal(one));
+    } catch (const std::runtime_error& error) {
+      ASSERT(
+          std::string(error.what())
+              .find("Can only index tensors with integral scalars") !=
+          std::string::npos);
+    }
+  }
+  {
+    // Indexing by zero-dim tensor
+    Tensor tensor = CPU(kInt).arange(0, 10);
+    Tensor one = CPU(kInt).ones({});
+    for (int i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[one * i].equal(one * i));
+    }
+    try {
+      ASSERT(tensor[CPU(kFloat).ones({}) * 3.14].equal(one));
+    } catch (const std::runtime_error& error) {
+      ASSERT(
+          std::string(error.what())
+              .find("Can only index tensors with integral scalars") !=
+          std::string::npos);
+    }
+    try {
+      ASSERT(tensor[Scalar(CPU(kInt).ones({2, 3, 4}))].equal(one));
+    } catch (const std::runtime_error& error) {
+      ASSERT(
+          std::string(error.what()) ==
+          "Attempting to create a Scalar from a 3 dim tensor");
+    }
+  }
 }
 
 int main(int argc, char ** argv)

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -296,11 +296,18 @@ static void test(Type & type) {
           "Can only index tensors with integral scalars (got CPUFloatType)");
     }
     try {
-      ASSERT(tensor[Scalar(CPU(kInt).ones({2, 3, 4}))].equal(one));
+      ASSERT(tensor[Tensor()].equal(one));
     } catch (const std::runtime_error& error) {
       ASSERT(
           std::string(error.what()) ==
-          "Attempting to create a Scalar from a 3 dim tensor");
+          "Can only index with tensors that are defined");
+    }
+    try {
+      ASSERT(tensor[CPU(kInt).ones({2, 3, 4})].equal(one));
+    } catch (const std::runtime_error& error) {
+      ASSERT(
+        std::string(error.what()) ==
+        "Can only index with tensors that are scalars (zero-dim)");
     }
   }
 }

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -277,9 +277,8 @@ static void test(Type & type) {
       ASSERT(tensor[Scalar(3.14)].equal(one));
     } catch (const std::runtime_error& error) {
       ASSERT(
-          std::string(error.what())
-              .find("Can only index tensors with integral scalars") !=
-          std::string::npos);
+          std::string(error.what()) ==
+          "Can only index tensors with integral scalars (got CPUDoubleType)");
     }
   }
   {
@@ -293,9 +292,8 @@ static void test(Type & type) {
       ASSERT(tensor[CPU(kFloat).ones({}) * 3.14].equal(one));
     } catch (const std::runtime_error& error) {
       ASSERT(
-          std::string(error.what())
-              .find("Can only index tensors with integral scalars") !=
-          std::string::npos);
+          std::string(error.what()) ==
+          "Can only index tensors with integral scalars (got CPUFloatType)");
     }
     try {
       ASSERT(tensor[Scalar(CPU(kInt).ones({2, 3, 4}))].equal(one));


### PR DESCRIPTION
This now works:

```
Tensor x = ...;
Scalar i(5);
x[i]
```

and more importantly

```
Tensor x = ...;
Tensor i = CPU(kInt).ones({});
x[i]
```

Since integral literals convert implicitly to `Scalar`, the old behavior of `x[5]` is preserved.

Proper error checking should be taken care of.

Fixes https://github.com/pytorch/pytorch/issues/3971
Part of https://github.com/pytorch/pytorch/issues/4619

@colesbury @zdevito @apaszke @ezyang 

CC @ebetica 