### PR TITLE
Desugar torch.* and F.* functions in JIT script

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1747,6 +1747,21 @@ class TestJit(TestCase):
 
             self.assertEqual(foo(*inputs), outputs)
 
+    def test_desugar_module(self):
+        import torch.nn.functional as F
+
+        def fn(x, slope):
+            a = torch.abs(x)
+            b = torch.nn.functional.prelu(x, slope)
+            c = F.prelu(x, slope)
+            return a, b, c
+
+        x = torch.arange(-3, 4)
+        slope = torch.tensor([0.5])
+        outputs = fn(x, slope)
+        print(outputs)
+        self.checkScript(fn, [x, slope], outputs, True)
+
     @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     @unittest.skipIf(not RUN_CUDA, "calls .cuda()")
     def test_traced_module(self):

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -64,6 +64,23 @@ private:
   Value* value;
 };
 
+struct BuiltinFunction : public SugaredValue {
+  BuiltinFunction(const std::string& name, Value* value=nullptr)
+    : name(name), value(value) {}
+  std::string name;
+  Value* value;
+
+  virtual std::string kind() const override {
+    return "builtin";
+  }
+  virtual std::vector<Value*> call(
+    SourceRange loc,
+    Method & m,
+    at::ArrayRef<Value*> inputs_,
+    List<Attribute> attributes,
+    size_t n_outputs) override;
+};
+
 using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name)>;
 void defineMethodsInModule(
   Module & m,


### PR DESCRIPTION
Script functions can now use functions from the torch and functional namespace. It's not 100% robust, because `torch.nn.functional` doesn't have 100% parity with what we have in ATen, but the most important functions are there.