### PR TITLE
Put torch header install back into the install command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -395,12 +395,6 @@ class build_ext(build_ext_parent):
         else:
             print('-- Building without distributed package')
 
-        # Copy headers necessary to compile C++ extensions.
-        self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
-        self.copy_tree('torch/lib/pybind11/include/pybind11/',
-                       'torch/lib/include/pybind11')
-        self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
-
         generate_code(ninja_global)
 
         if WITH_NINJA:
@@ -423,6 +417,12 @@ class install(setuptools.command.install.install):
     def run(self):
         if not self.skip_build:
             self.run_command('build_deps')
+
+        # Copy headers necessary to compile C++ extensions.
+        self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
+        self.copy_tree('torch/lib/pybind11/include/pybind11/',
+                       'torch/lib/include/pybind11')
+        self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
 
         setuptools.command.install.install.run(self)
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/5706 broke C++ extension tests in CI. I believe it's because we run `python setup.py install` which does not invoke `build_ext`, which is where that PR put the copy commands for `torch.h` et al. Need to revert this behavior for now.

@sdmonov 