### PR TITLE
Enable resetting of batchnorm running stats and cumulative ("simple") moving average

### DIFF
--- a/test/expect/TestJit.test_batchnorm.expect
+++ b/test/expect/TestJit.test_batchnorm.expect
@@ -2,7 +2,8 @@ graph(%0 : Double(2, 2, 2, 2)
       %1 : Double(2)
       %2 : Double(2)
       %3 : Double(2)
-      %4 : Double(2)) {
-  %5 : Double(2, 2, 2, 2) = aten::batch_norm[training=1, momentum=0.1, eps=1e-05, cudnn_enabled=1](%0, %1, %2, %3, %4), scope: BatchNorm2d
-  return (%5);
+      %4 : Double(2)
+      %5 : Long(1)) {
+  %6 : Double(2, 2, 2, 2) = aten::batch_norm[training=1, momentum=0.1, eps=1e-05, cudnn_enabled=1](%0, %1, %2, %3, %4), scope: BatchNorm2d
+  return (%6);
 }


### PR DESCRIPTION
This is a proposed implementation of ``reset_running_stats``, which I discussed with @soumith earlier today. In addition, it enables the use of the simple moving average for running stats in place of the exponential moving average, with a ``momentum=None`` setting.

The motivation behind these changes is to faithfully execute the moment estimation of [the original batchnorm paper](https://arxiv.org/abs/1502.03167) (line 10 in Algorithm 2). To do this, you would do:

    bn_layer = BatchNorm(..., momentum=None)
    
    # construct the rest of the network and train
    
    bn_layer.reset_running_stats()
    for i in range(num_bn_meanvar_batches):
        model.forward(get_new_batch())

    bn_layer.eval()

    # use the model
