### PR TITLE
[jit] Have ScriptModule inherit from Module

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1243,7 +1243,7 @@ class TestJit(TestCase):
         recording_inputs = [Variable(t, requires_grad=True)
                             for t in reference_tensors]
 
-        ge = torch._C.GraphExecutor(func, [Variable(t) for t in input_tensors], [], optimize)
+        ge = torch._C.GraphExecutor(func, [Variable(t) for t in input_tensors], optimize)
 
         # test no gradients case
 
@@ -1820,12 +1820,11 @@ class TestJit(TestCase):
             del linear_submodule.weight
 
         # Submodules can't be called
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AttributeError):
             linear_submodule(x)
 
         # Type casts
-        with self.assertRaises(RuntimeError):
-            linear_submodule.cuda()
+        linear_submodule.cuda()
         traced_model.float().cuda()
         cuda_out = traced_model(x.float().cuda())
         traced_model.cpu()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1820,7 +1820,7 @@ class TestJit(TestCase):
             del linear_submodule.weight
 
         # Submodules can't be called
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(RuntimeError):
             linear_submodule(x)
 
         # Type casts

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -84,7 +84,7 @@ void initJITBindings(PyObject *module) {
                       variable_list inputs,
                       bool optimize) {
               size_t num_inputs = inputs.size();
-              auto graph = script::createGraphByTracing(func, std::move(inputs), num_inputs);
+              auto graph = tracer::createGraphByTracing(func, std::move(inputs), num_inputs);
               return GraphExecutor(graph, optimize);
           }),
           py::arg("func"),

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -39,51 +39,6 @@ void graph_pass(const std::shared_ptr<tracer::TracingState>& state) {
   return F(state->graph);
 }
 
-struct PythonGraphExecutor : GraphExecutor {
-  using GraphExecutor::GraphExecutor;
-  variable_tensor_list run(variable_tensor_list && inputs) {
-    inputs.insert(inputs.end(), captures.begin(), captures.end());
-    return GraphExecutor::run(std::move(inputs));
-  }
-  variable_tensor_list captures;
-};
-
-// This is a temporary constructor so that we can write python tests of
-// the executor. It does not have most of the functionality of CompiledFunction
-// such as being able to hold parameters...
-PythonGraphExecutor createExecutorByTracing(
-        py::function func,
-        variable_list inputs,
-        variable_list captures,
-        bool optimize) {
-  variable_list trace_inputs;
-  trace_inputs.insert(trace_inputs.end(), inputs.begin(), inputs.end());
-  trace_inputs.insert(trace_inputs.end(), captures.begin(), captures.end());
-  auto enter_info = tracer::enter(std::move(trace_inputs), 1);
-  py::tuple py_inputs(inputs.size());
-  for(size_t i = 0; i < inputs.size(); ++i) {
-    py_inputs[i] = py::cast(enter_info.second[i]);
-  }
-  // All conditions that could trigger this should be asserted on the Python side
-  for (size_t i = 0; i < captures.size(); ++i) {
-    JIT_ASSERT(enter_info.second[i + inputs.size()].is_same(captures[i]));
-  }
-  // Call back into Python function
-  auto out = py::reinterpret_steal<py::object>(PyObject_CallObject(func.ptr(), py_inputs.ptr()));
-  if (!out)
-    throw py::error_already_set();
-  std::vector<autograd::Variable> outputs;
-  if(PyTuple_Check(out.ptr())) {
-    outputs = py::cast<std::vector<autograd::Variable>>(out);
-  } else {
-    outputs.push_back(py::cast<autograd::Variable>(out));
-  }
-  tracer::exit(outputs);
-  auto graph = enter_info.first->graph;
-  EliminateDeadCode(graph);
-  return PythonGraphExecutor(std::move(graph), optimize);
-}
-
 // we cannot use the default py:cast<autograd::Variable> because it currently
 // unwraps the data tensor in the conversion process
 // TODO: replace with bs type
@@ -123,29 +78,26 @@ void initJITBindings(PyObject *module) {
      return py::reinterpret_steal<py::object>(python::unflatten(vars, desc));
    });
 
-  py::class_<PythonGraphExecutor>(m, "GraphExecutor")
+  py::class_<GraphExecutor>(m, "GraphExecutor")
       .def(
           py::init([](py::function func,
                       variable_list inputs,
-                      variable_list captures,
                       bool optimize) {
-            return createExecutorByTracing(func, std::move(inputs), std::move(captures), optimize);
+              size_t num_inputs = inputs.size();
+              auto graph = script::createGraphByTracing(func, std::move(inputs), num_inputs);
+              return GraphExecutor(graph, optimize);
           }),
           py::arg("func"),
           py::arg("inputs"),
-          py::arg("captures") = variable_list{},
           py::arg("optimize") = true)
       .def(
           py::init([](std::shared_ptr<Graph> graph, bool optimize) {
-            return PythonGraphExecutor(std::move(graph), optimize);
+            return GraphExecutor(std::move(graph), optimize);
           }),
           py::arg("graph"),
           py::arg("optimize") = true)
-      .def("set_captures", [](PythonGraphExecutor& ge, py::args args) {
-        ge.captures = createVariableTensorList(args);
-      })
-      .def("__call__", [](PythonGraphExecutor& ge, py::args args) -> py::object {
-        auto inputs = createVariableTensorList(args, ge.captures.size());
+      .def("__call__", [](GraphExecutor& ge, py::args args) -> py::object {
+        auto inputs = createVariableTensorList(args);
         auto outputs = ge.run(std::move(inputs));
         // if we don't tell pybind these are variables it chokes on the
         // conversion.

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -801,7 +801,7 @@ void defineMethodsInModule(Module & m, const std::string& source, const Resolver
 }
 
 std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver) {
-  Module m(/*optimize=*/false); //note: we don't use 'm' to execute so this setting is unused
+  Module m; //note: we don't use 'm' to execute so this setting is unused
   defineMethodsInModule(m, {def}, resolver, nullptr);
   return m.get_method(def.name().name()).graph();
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -579,7 +579,7 @@ private:
     return sv->call(callee.range(), method, inputs, attributes, output_size);
   }
 
-  // any expression that can produce a SugaredValue are handled here
+  // any expression that can produce a SugaredValue is handled here
   // with emitExpr falling back to this function to handle them
   // the kinds handled here should be kept in sync with [SUGARED VALUES]
   // in emitExpr

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -17,14 +17,14 @@ namespace script {
 // will be desugared based on how they are used in the AST.
 
 // SugaredValue is used to temporarily represent these values in a way
-// that separates their behavior from AST -> IR converter itself.
+// that separates their behavior from the AST -> IR converter itself.
 // This allows us to keep dependencies on python minimal.
 
 struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
-  // what is this node? for error report (e.g. Module, python function)
+  // what is this node? for error reporting (e.g. Module, python function)
   virtual std::string kind() const = 0;
-  // what can we do with this thing?
 
+  // what can we do with this thing?
   // use it as a value e.g.  `this + 4`
   virtual Value * asValue(SourceRange loc, Method & m) {
     throw ErrorReport(loc) << kind() << " cannot be used as a value";

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -283,6 +283,8 @@ void initJitScriptBindings(PyObject* module) {
         py::function func,
         tracer::variable_list inputs) {
           size_t num_inputs = inputs.size();
+          // prereq: Module's buffers and parameters are unique
+          // this was ensured in python before calling this function
           std::vector<at::Tensor*> parameters;
           gatherParametersAndBuffers(parameters, self);
           for(at::Tensor* param : parameters) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -142,9 +142,15 @@ struct ModuleValue : public SugaredValue {
       return std::make_shared<MethodValue>(module, *v);
     } else if(auto v = module->find_parameter(field)) {
       return std::make_shared<SimpleValue>(m.get_or_add_parameter(v->slot()));
-    } else {
-      throw ErrorReport(loc) << "module has no attribute '" << field << "'";
     }
+    // this can also be a call to a non-script module, if so return this as a python value
+    py::object py_module = py::cast(module);
+    if(py::object attr = py::getattr(py_module, field.c_str(), py::none())) {
+      if(py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
+        return std::make_shared<PythonValue>(attr);
+      }
+    }
+    throw ErrorReport(loc) << "module has no attribute '" << field << "'";
   }
   // call module.forward
   virtual std::vector<Value*> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_outputs) override {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -271,11 +271,9 @@ void initJitScriptBindings(PyObject* module) {
         return bool(self.find_method(name));
       })
       .def("_method_names", [](Module& self) {
-        std::vector<std::string> r;
-        for(auto& m : self.get_methods()) {
-          r.push_back(m->name());
-        }
-        return r;
+        return fmap(self.get_methods(), [](const std::unique_ptr<Method> & m) {
+          return m->name();
+        });
       })
       .def("_create_method_from_trace", [](
         Module& self,

--- a/torch/csrc/jit/script/init.h
+++ b/torch/csrc/jit/script/init.h
@@ -6,6 +6,11 @@ namespace torch {
 namespace jit {
 namespace script {
 void initJitScriptBindings(PyObject* module);
+std::shared_ptr<Graph> createGraphByTracing(
+        py::function func,
+        std::vector<tracer::TraceInput> inputs,
+        size_t num_inputs);
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/init.h
+++ b/torch/csrc/jit/script/init.h
@@ -6,10 +6,6 @@ namespace torch {
 namespace jit {
 namespace script {
 void initJitScriptBindings(PyObject* module);
-std::shared_ptr<Graph> createGraphByTracing(
-        py::function func,
-        std::vector<tracer::TraceInput> inputs,
-        size_t num_inputs);
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -2,6 +2,7 @@
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/autograd/variable.h"
+#include <ATen/optional.h>
 
 // This file contains classes which assist in desugaring Python style
 // modules and their methods into flattened graphs which don't have any
@@ -15,11 +16,24 @@ namespace torch { namespace jit { namespace script {
 //   @script_method
 //   def f(self, x):
 //     ...
+// Note: because Method/Module are exposed to python these
+// classes use python method naming conventions
+
 struct Method {
-  Method(std::string name, bool optimize)
+  Method(std::string name, bool optimize,
+         std::shared_ptr<Graph> graph,
+         std::vector<at::Tensor*> initial_members)
   : name_(std::move(name))
-  , graph_(std::make_shared<Graph>())
-  , optimize(optimize) {}
+  , graph_(std::move(graph))
+  , optimize(optimize)
+  , member_inputs(std::move(initial_members)) {
+    JIT_ASSERT(graph_->inputs().size() >= member_inputs.size());
+    int i = graph_->inputs().size() - member_inputs.size();
+    for(at::Tensor* member : member_inputs) {
+      member_input_index[member] = i++;
+    }
+  }
+
   variable_tensor_list run(variable_tensor_list && inputs) {
     std::call_once(executor_init, [&]{
       executor = GraphExecutor(graph_, optimize);
@@ -41,7 +55,7 @@ struct Method {
 
   // defined here to keep details of member_input handling confined to this class
   std::vector<Value*> emit_call_to(Method & callee, ArrayRef<Value*> inputs);
-  
+
   size_t num_inputs() const {
     return graph_->inputs().size() - member_inputs.size();
   }
@@ -62,8 +76,7 @@ private:
   GraphExecutor executor; // for execution
   // member_inputs are a list of additional arguments appended to graph that are
   // inputs that come from the members of the Module or its submodules.
-  // each is a pointer to a slot in the module that owns this Method or a submethod
-  // of the module.
+  // each is a pointer to a slot in the module that owns this parameter
   // parameters and submodules can only be _added_ to script Modules to ensure
   // these pointers always stay valid
   std::vector<at::Tensor*> member_inputs;
@@ -91,10 +104,14 @@ struct NamedModule {
 };
 
 struct NamedParameter {
-  NamedParameter(std::string name, at::Tensor tensor)
-  : name(std::move(name)), parameter(new at::Tensor(std::move(tensor))) {}
+  NamedParameter(std::string name, at::Tensor tensor, bool is_buffer)
+  : name(std::move(name))
+  , is_buffer(is_buffer)
+  , parameter(new at::Tensor(std::move(tensor))) {}
 
-  std::string name;
+  const std::string name;
+  bool is_buffer; // buffers are part of the module state but
+                        // are not modified by optimizers during SGD
   at::Tensor* slot() const {
     return parameter.get();
   }
@@ -105,21 +122,55 @@ private:
   std::unique_ptr<at::Tensor> parameter;
 };
 
-struct NamedMember {
-  enum Kind { Module, Parameter, Method, None };
-  // note: None is used to report undefined attributes;
-  Kind kind;
-  size_t offset;
-
-  static const char * kind_string(Kind kind) {
-    switch(kind) {
-      case Module: return "module";
-      case Parameter: return "parameter";
-      case Method: return "method";
-      case None: return "none";
-      default: return "unknown";
+// simple ordered dict used only in Module
+// contains only the minimum necessary functionality for Module
+template<typename T>
+struct OrderedDict {
+  OrderedDict() {}
+  T& insert(const std::string& name,  T&& value, const char* what) {
+    if(index_.count(name) != 0) {
+      std::stringstream ss;
+      ss << "module " << what << "'" << name << "' already defined.";
+      throw std::runtime_error(ss.str());
     }
+    values_.push_back(std::move(value));
+    index_[name] = values_.size() - 1;
+    return values_.back();
   }
+  at::optional<T&> find(const std::string& str) {
+    auto it = index_.find(str);
+    if(it == index_.end())
+      return at::nullopt;
+    return at::optional<T&>(values_.at(it->second));
+  }
+  at::optional<const T&> find(const std::string& str) const {
+    auto it = index_.find(str);
+    if(it == index_.end())
+      return at::nullopt;
+    return at::optional<const T&>(values_.at(it->second));
+  }
+  T& get(const std::string& name, const char * what) {
+    if(auto v = find(name)) {
+      return *v;
+    }
+    std::stringstream ss;
+    ss << "module " << what << "'" << name << "' is not defined.";
+    throw std::runtime_error(ss.str());
+  }
+  const T& get(const std::string& name, const char * what) const {
+    if(auto v = find(name)) {
+      return *v;
+    }
+    std::stringstream ss;
+    ss << "module " << what << "'" << name << "' is not defined.";
+    throw std::runtime_error(ss.str());
+  }
+  const std::vector<T>& values() const {
+    return values_;
+  }
+private:
+  std::unordered_map<std::string, size_t> index_;
+  std::vector<T> values_;
 };
 
 struct Module : public std::enable_shared_from_this<Module> {
@@ -127,102 +178,77 @@ struct Module : public std::enable_shared_from_this<Module> {
   Module(bool optimize)
   : optimize(optimize) {}
 
-  void register_parameter(const std::string & name, at::Tensor v) {
-    parameters.push_back(NamedParameter(name, std::move(v)));
-    add_member(name, NamedMember::Parameter, parameters.size() - 1);
-  }
-  void register_or_set_parameter(const std::string & name, autograd::Variable v) {
-    if(find_attribute(name) == NamedMember::Parameter) {
-      set_parameter(name, v);
-    } else {
-      register_parameter(name, v);
+  void register_parameter(const std::string & name, autograd::Variable v, bool is_buffer) {
+    if(auto p = parameters.find(name)){
+      *p->slot() = v;
+      p->is_buffer = is_buffer;
+      return;
     }
+    parameters.insert(name, NamedParameter(name, std::move(v), is_buffer), "parameter");
   }
   void register_module(const std::string& name, std::shared_ptr<Module> module) {
-    JIT_ASSERT(module);
-    modules.push_back(NamedModule {name, std::move(module)});
-    add_member(name, NamedMember::Module, modules.size() - 1);
+    modules.insert(name, {name, std::move(module)}, "module");
   }
 
-  Method& create_method(const std::string & name) {
-    methods.emplace_back(new Method(name, optimize));
-    add_member(name, NamedMember::Method, methods.size() - 1);
-    return *methods.back();
+  Method& create_method(const std::string & name, std::shared_ptr<Graph> graph = nullptr, std::vector<at::Tensor*> member_inputs = {}) {
+    if(!graph)
+      graph = std::make_shared<Graph>();
+    std::unique_ptr<Method> method(new Method(name, optimize, std::move(graph), std::move(member_inputs)));
+
+    return *methods.insert(name, std::move(method), "method");
   }
 
-  at::Tensor* parameter_slot(const std::string & name) {
-    return parameters.at(find_member(name, NamedMember::Parameter)).slot();
+  at::Tensor* parameter_slot(const std::string & name) const {
+    return parameters.get(name, "parameter").slot();
   }
 
   void set_parameter(const std::string & name, at::Tensor v) {
     *parameter_slot(name) = std::move(v);
   }
 
-  at::Tensor get_parameter(const std::string& name) {
-    return *parameter_slot(name);
+  autograd::Variable get_parameter(const std::string& name) const {
+    return static_cast<autograd::Variable&>(*parameter_slot(name));
   }
 
   // each module owns its method. The reference returned here
   // is guarenteed to stay valid until this module has been destoryed
   Method& get_method(const std::string& name) const {
-    return *methods.at(find_member(name, NamedMember::Method));
+    return *methods.get(name, "method");
   }
 
   std::shared_ptr<Module> get_module(const std::string& name) const {
-    auto loc = find_member(name, NamedMember::Module);
-    return modules.at(loc).module;
+    return modules.get(name, "module").module;
   }
 
-  NamedMember::Kind find_attribute(const std::string& name) {
-    auto it = members.find(name);
-    if(it == members.end())
-      return NamedMember::None;
-    return it->second.kind;
+  const std::vector<NamedModule>& get_modules() const {
+    return modules.values();
+  }
+  const  std::vector<NamedParameter>& get_parameters() const {
+    return parameters.values();
   }
 
-  void dump() const {
-    for(auto entry : members) {
-      std::cout << entry.first << ": " << NamedMember::kind_string(entry.second.kind) << "\n";
-    }
+
+  at::optional<NamedParameter&> find_parameter(const std::string& name) {
+    return parameters.find(name);
+  }
+  at::optional<NamedModule&> find_module(const std::string& name) {
+    return modules.find(name);
+  }
+  at::optional<Method&> find_method(const std::string& name) {
+    if(auto pm = methods.find(name))
+      return at::optional<Method&>(**pm);
+    return at::nullopt;
   }
 
 private:
-  size_t find_member(const std::string& name, NamedMember::Kind kind) const  {
-    auto it = members.find(name);
-    if(it == members.end()) {
-      std::stringstream ss;
-      ss << "unknown " << NamedMember::kind_string(kind) << " '" << name << "'";
-      throw std::runtime_error(ss.str());
-    }
-    if(it->second.kind != kind) {
-      std::stringstream ss;
-      ss << "Expected attribute '" << name << "' to be a "
-        << NamedMember::kind_string(kind) << " but found "
-        << NamedMember::kind_string(it->second.kind);
-      throw std::runtime_error(ss.str());
-    }
-    JIT_ASSERT(it != members.end() && it->second.kind == kind);
-    return it->second.offset;
-  }
-  void add_member(const std::string& name, NamedMember::Kind kind, size_t offset) {
-    auto it = members.find(name);
-    if(it != members.end()) {
-      std::stringstream ss;
-      ss << "attempting to add " << NamedMember::kind_string(kind) << " '" << name << "' but Module already contains "
-      << NamedMember::kind_string(it->second.kind) << " '" << name << "'";
-      throw std::runtime_error(ss.str());
-    }
-    members[std::move(name)] = NamedMember { kind, offset };
-  }
+
   // invariant: to ensure member_inputs of Methods stay valid,
   // it is only legal to _add_ new modules and parameters.
   // removing them will allow member_inputs to point to invalid parameters
   // no such restriction exists for methods
-  std::vector<NamedModule> modules;
-  std::vector<NamedParameter> parameters;
-  std::vector<std::unique_ptr<Method>> methods;
-
-  std::unordered_map<std::string, NamedMember> members;
+  OrderedDict<NamedModule> modules;
+  OrderedDict<NamedParameter> parameters;
+  OrderedDict<std::unique_ptr<Method>> methods;
   bool optimize;
 };
 

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -862,7 +862,7 @@ const static auto cf_examples = R"JIT(
     return a
 )JIT";
 void testControlFlow() {
-  script::Module cu(/*optimize=*/true);
+  script::Module cu;
   script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver(), nullptr);
   auto run = [&](const std::string & name, std::vector<at::Tensor> stack) {
     auto graph = cu.get_method(name).graph();

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -8,7 +8,6 @@
 #include "torch/csrc/autograd/engine.h"
 #include "torch/csrc/autograd/functions/special.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
-#include "torch/csrc/jit/pybind.h"
 
 #include <string>
 #include <sstream>
@@ -17,6 +16,7 @@
 #ifndef NO_PYTHON
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/jit/pybind.h"
 #include <frameobject.h>
 #include <patchlevel.h>
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -40,6 +40,30 @@ std::string torch::jit::tracer::getPythonInterpreterStackTrace() {
   }
   return stack_trace.str();
 }
+// This is a temporary constructor so that we can write python tests of
+// the executor. It does not have most of the functionality of CompiledFunction
+// such as being able to hold parameters...
+std::shared_ptr<torch::jit::Graph> torch::jit::tracer::createGraphByTracing(
+        py::function func,
+        tracer::variable_list trace_inputs,
+        size_t num_func_inputs) {
+  auto enter_info = tracer::enter(std::move(trace_inputs), 1);
+  py::tuple py_inputs(num_func_inputs);
+  for(size_t i = 0; i < num_func_inputs; ++i) {
+    py_inputs[i] = py::cast(enter_info.second[i]);
+  }
+  auto out = func(*py_inputs);
+  std::vector<autograd::Variable> outputs;
+  if(PyTuple_Check(out.ptr())) {
+    outputs = py::cast<std::vector<autograd::Variable>>(out);
+  } else {
+    outputs.push_back(py::cast<autograd::Variable>(out));
+  }
+  tracer::exit(outputs);
+  auto graph = enter_info.first->graph;
+  EliminateDeadCode(graph);
+  return graph;
+}
 #endif
 
 namespace torch { namespace jit { namespace tracer {
@@ -211,31 +235,5 @@ void postRecordTrace(const PreTraceInfo& info,
     assignOutput(outputs[i], info.n->addOutput());
   }
 }
-
-// This is a temporary constructor so that we can write python tests of
-// the executor. It does not have most of the functionality of CompiledFunction
-// such as being able to hold parameters...
-std::shared_ptr<Graph> createGraphByTracing(
-        py::function func,
-        tracer::variable_list trace_inputs,
-        size_t num_func_inputs) {
-  auto enter_info = tracer::enter(std::move(trace_inputs), 1);
-  py::tuple py_inputs(num_func_inputs);
-  for(size_t i = 0; i < num_func_inputs; ++i) {
-    py_inputs[i] = py::cast(enter_info.second[i]);
-  }
-  auto out = func(*py_inputs);
-  std::vector<autograd::Variable> outputs;
-  if(PyTuple_Check(out.ptr())) {
-    outputs = py::cast<std::vector<autograd::Variable>>(out);
-  } else {
-    outputs.push_back(py::cast<autograd::Variable>(out));
-  }
-  tracer::exit(outputs);
-  auto graph = enter_info.first->graph;
-  EliminateDeadCode(graph);
-  return graph;
-}
-
 
 }}}

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -8,8 +8,9 @@
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
+#ifndef NO_PYTHON
 #include "torch/csrc/utils/pybind.h"
-
+#endif
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -247,12 +248,15 @@ PreTraceInfo preRecordTrace(Symbol op, at::ArrayRef<Variable> inputs);
 PreTraceInfo preRecordPythonTrace(
     THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<Variable> inputs,
     pyobj_list scalar_args);
-#endif
-void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
 
 std::shared_ptr<Graph> createGraphByTracing(
         py::function func,
         variable_list inputs,
         size_t num_inputs);
+#endif
+void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
+
+
+
 
 }}} // namespace torch::jit::tracer

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -8,6 +8,7 @@
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
+#include "torch/csrc/utils/pybind.h"
 
 #include <memory>
 #include <mutex>
@@ -15,7 +16,6 @@
 #include <iostream>
 #include <cstdint>
 #include <unordered_map>
-
 
 namespace torch { namespace jit { namespace tracer {
 
@@ -249,5 +249,10 @@ PreTraceInfo preRecordPythonTrace(
     pyobj_list scalar_args);
 #endif
 void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
+
+std::shared_ptr<Graph> createGraphByTracing(
+        py::function func,
+        variable_list inputs,
+        size_t num_inputs);
 
 }}} // namespace torch::jit::tracer

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -463,7 +463,7 @@ def trace(*args, **kwargs):
         for name in executor_options:
             executor_options[name] = kwargs.pop(name, executor_options[name])
         if len(kwargs) != 0:
-            raise TypeError("got unexpected keyword arguments: {}".format(",".join(kwargs.keys())))
+            raise TypeError("got unexpected keyword arguments: {}".format(", ".join(kwargs.keys())))
 
         if isinstance(func, torch.nn.Module):
             module = TracedModule(func, **executor_options)


### PR DESCRIPTION
  This is accomplished by created replacement _parameters, _buffers,
  and _modules which implement the OrderedDict APIs but which
  actually get/set their members inside script::Module

* Merge TracedModule with ScriptModule
* Move logic of attribute handling into Python bindings rather than
  make script::Module handle it. This was redundant with nn.Module,
  which already handles attribute.

Make TracedModule a subclass of ScriptModule

Move handling of attribute kind logic into bindings.

Port back in TracedModule functionality to ScriptModule