### PR TITLE
Moved torch headers copy to build_deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,6 +271,12 @@ class build_deps(Command):
             libs += ['THD']
         build_libs(libs)
 
+        # Copy headers necessary to compile C++ extensions.
+        self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
+        self.copy_tree('torch/lib/pybind11/include/pybind11/',
+                       'torch/lib/include/pybind11')
+        self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
+
 
 build_dep_cmds = {}
 
@@ -416,12 +422,6 @@ class install(setuptools.command.install.install):
     def run(self):
         if not self.skip_build:
             self.run_command('build_deps')
-
-        # Copy headers necessary to compile C++ extensions.
-        self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
-        self.copy_tree('torch/lib/pybind11/include/pybind11/',
-                       'torch/lib/include/pybind11')
-        self.copy_file('torch/torch.h', 'torch/lib/include/torch/torch.h')
 
         setuptools.command.install.install.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,13 @@ class build_deps(Command):
         build_libs(libs)
 
         # Copy headers necessary to compile C++ extensions.
+        #
+        # This is not perfect solution as build does not depend on any of
+        # the auto-generated code and auto-generated files will not be
+        # included in this copy. If we want to use auto-generated files,
+        # we need to find a batter way to do this.
+        # More information can be found in conversation thread of PR #5772
+
         self.copy_tree('torch/csrc', 'torch/lib/include/torch/csrc/')
         self.copy_tree('torch/lib/pybind11/include/pybind11/',
                        'torch/lib/include/pybind11')


### PR DESCRIPTION
PR #5706 initially moved headers under build_ext to fix bdist_wheel and
build develop. This broke install and #5755 moved them back to install
which broke bdist_wheel and build develop. Looks like build_ext is called
from install after it already tried to copy the headers to the python install
dir and the headers were not installed correctly. Using build_deps works
correct with all setup.py install, bdist_wheel and build develop.

@goldsborough 