### PR TITLE
fused GLU backward

### DIFF
--- a/aten/src/THCUNN/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/GatedLinearUnit.cu
@@ -15,15 +15,22 @@ struct gatedLinearCSigMul_functor
   }
 };
 
-template <typename Dtype, typename Acctype>
-struct gatedLinearDerivativeSecondHalf_functor
+
+template<typename Dtype, typename Acctype>
+struct gatedLinearDerivative
 {
-  __device__ void operator()(Dtype *target, const Dtype *sigTensor, const Dtype *mulTensor) const
-  {
-    const Acctype sigNum = Acctype(1)/(Acctype(1)+ exp(ScalarConvert<Dtype, Acctype>::to(-*sigTensor)));
-    const Dtype mulNum = *mulTensor;
-    *target *= ScalarConvert<Acctype, Dtype>::to((Acctype(1) - sigNum) * sigNum * mulNum);
-  }
+   const int64_t stride_i_;
+   const int64_t stride_gI_;
+   gatedLinearDerivative(int64_t stride_i, int64_t stride_gI)
+      :stride_i_(stride_i), stride_gI_(stride_gI){}
+   __device__ void operator()(Dtype * gI, const Dtype * gO, const Dtype * input) const
+   {
+      const Dtype * sigTensor = input + stride_i_;
+      const Acctype sigNum = Acctype(1)/(Acctype(1)+ exp(ScalarConvert<Dtype, Acctype>::to(-*sigTensor)));
+      *gI = ScalarConvert<Acctype, Dtype>::to(sigNum * *gO);
+      Dtype * gIsecond = gI + stride_gI_;
+      *gIsecond = ScalarConvert<Acctype, Dtype>::to((Acctype(1) - sigNum) * sigNum * *gO * *input);
+   }
 };
 
 #include "generic/GatedLinearUnit.cu"

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -48,19 +48,12 @@ void THNN_(GatedLinear_updateGradInput)(
   THCTensor_(resizeAs)(state, gradInput, input);
   const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
   THCTensor *firstHalf = THCTensor_(newNarrow)(state, input, dim, 0, inputSize);
-  THCTensor *secondHalf = THCTensor_(newNarrow)(state, input, dim, inputSize, inputSize);
   THCTensor *gradInputfirstHalf = THCTensor_(newNarrow)(state, gradInput, dim, 0, inputSize);
-  THCTensor *gradInputsecondHalf = THCTensor_(newNarrow)(state, gradInput, dim, inputSize, inputSize);
-  // first half of derivative
-  THC_pointwiseApply3(state, gradInputfirstHalf, secondHalf, gradOutput, gatedLinearCSigMul_functor<real, accreal>());
-  // second half of derivative
-  THCTensor_(copy)(state, gradInputsecondHalf, firstHalf);
-  THC_pointwiseApply3(state, gradInputsecondHalf, secondHalf, gradOutput, gatedLinearDerivativeSecondHalf_functor<real, accreal>());
-
+  const int64_t stride_i = THCTensor_(stride)(state, input, dim) * inputSize;
+  const int64_t stride_gI = THCTensor_(stride)(state, gradInput, dim) * inputSize;
+  THC_pointwiseApply3(state, gradInputfirstHalf, gradOutput, firstHalf, gatedLinearDerivative<real,accreal>(stride_i, stride_gI)); 
   THCTensor_(free)(state, firstHalf);
-  THCTensor_(free)(state, secondHalf);
   THCTensor_(free)(state, gradInputfirstHalf);
-  THCTensor_(free)(state, gradInputsecondHalf);
 }
 
 #endif


### PR DESCRIPTION
uses pointer arithmetic to operate on 5 tensors with pointwiseApply3. Still pretty general because tensors are guaranteed to come from splitting an original tensor, thus can be addressed by pointer arithmetic. 