### PR TITLE
Fix Windows CI build / test commit hash diversion

### DIFF
--- a/.jenkins/win-build.sh
+++ b/.jenkins/win-build.sh
@@ -87,7 +87,17 @@ rd /s /q C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch
 
 set NO_CUDA=
 
-python setup.py install && 7z a %IMAGE_COMMIT_TAG%.7z C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch && python ci_scripts\\upload_image.py %IMAGE_COMMIT_TAG%.7z
+python setup.py install
+
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+if "%GIT_BRANCH%" == "origin/master" (
+    git log -n 1 --pretty=format:"%H" origin/master > C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch\\COMMIT_HASH
+)
+
+7z a %IMAGE_COMMIT_TAG%.7z C:\\Jenkins\\Miniconda3\\Lib\\site-packages\\torch
+
+python ci_scripts\\upload_image.py %IMAGE_COMMIT_TAG%.7z
 
 EOL
 

--- a/.jenkins/win-test.sh
+++ b/.jenkins/win-test.sh
@@ -73,6 +73,12 @@ cd test/
 python ..\\ci_scripts\\download_image.py %IMAGE_COMMIT_TAG%.7z
 
 7z x %IMAGE_COMMIT_TAG%.7z
+
+if "%GIT_BRANCH%" == "origin/master" (
+    set /p COMMIT_HASH=<torch\\COMMIT_HASH
+    git checkout %COMMIT_HASH%
+)
+
 python run_test.py --verbose && python ..\\ci_scripts\\delete_image.py
 
 EOL


### PR DESCRIPTION
Currently, if a commit is pushed to master before a Windows CI test is started, the test will checkout the newest commit instead of the one used in the build phase. This PR fixes the problem by checking out the right commit in Windows test.
