### PR TITLE
Define RPC types out of source

### DIFF
--- a/torch/lib/THD/master_worker/common/RPC.cpp
+++ b/torch/lib/THD/master_worker/common/RPC.cpp
@@ -7,7 +7,21 @@
 #include <memory>
 #include <stdexcept>
 
-namespace thd { namespace rpc {
+namespace thd {
+RPCType type_traits<char>::type = RPCType::CHAR;
+RPCType type_traits<int8_t>::type = RPCType::CHAR;
+RPCType type_traits<uint8_t>::type = RPCType::UCHAR;
+RPCType type_traits<float>::type = RPCType::FLOAT;
+RPCType type_traits<double>::type = RPCType::DOUBLE;
+RPCType type_traits<int16_t>::type = RPCType::SHORT;
+RPCType type_traits<int32_t>::type = RPCType::INT;
+RPCType type_traits<uint32_t>::type = RPCType::UINT;
+RPCType type_traits<uint16_t>::type = RPCType::USHORT;
+RPCType type_traits<int64_t>::type = std::is_same<int64_t, long>::value ? RPCType::LONG : RPCType::LONG_LONG;
+RPCType type_traits<uint64_t>::type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG : RPCType::ULONG_LONG;
+RPCType type_traits<std::conditional<std::is_same<int64_t, long>::value, long long, long>::type>::type = std::is_same<int64_t, long>::value ? RPCType::LONG_LONG : RPCType::LONG;
+RPCType type_traits<std::conditional<std::is_same<uint64_t, unsigned long>::value, unsigned long long, unsigned long>::type>::type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG_LONG : RPCType::ULONG;
+namespace rpc {
 
 RPCMessage::RPCMessage()
   : _msg(0)

--- a/torch/lib/THD/master_worker/common/RPCType.hpp
+++ b/torch/lib/THD/master_worker/common/RPCType.hpp
@@ -77,79 +77,79 @@ struct type_traits {};
 
 template<>
 struct type_traits<char> {
-  static constexpr RPCType type = RPCType::CHAR;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<int8_t> {
-  static constexpr RPCType type = RPCType::CHAR;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<uint8_t> {
-  static constexpr RPCType type = RPCType::UCHAR;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<float> {
-  static constexpr RPCType type = RPCType::FLOAT;
+  static RPCType type;
   static constexpr bool is_floating_point = true;
 };
 
 template<>
 struct type_traits<double> {
-  static constexpr RPCType type = RPCType::DOUBLE;
+  static RPCType type;
   static constexpr bool is_floating_point = true;
 };
 
 template<>
 struct type_traits<int16_t> {
-  static constexpr RPCType type = RPCType::SHORT;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<uint16_t> {
-  static constexpr RPCType type = RPCType::USHORT;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<int32_t> {
-  static constexpr RPCType type = RPCType::INT;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<uint32_t> {
-  static constexpr RPCType type = RPCType::UINT;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<int64_t> {
-  static constexpr RPCType type = std::is_same<int64_t, long>::value ? RPCType::LONG : RPCType::LONG_LONG;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<uint64_t> {
-  static constexpr RPCType type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG : RPCType::ULONG_LONG;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<std::conditional<std::is_same<int64_t, long>::value, long long, long>::type> {
-  static constexpr RPCType type = std::is_same<int64_t, long>::value ? RPCType::LONG_LONG : RPCType::LONG;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 
 template<>
 struct type_traits<std::conditional<std::is_same<uint64_t, unsigned long>::value, unsigned long long, unsigned long>::type> {
-  static constexpr RPCType type = std::is_same<uint64_t, unsigned long>::value ? RPCType::ULONG_LONG : RPCType::ULONG;
+  static RPCType type;
   static constexpr bool is_floating_point = false;
 };
 


### PR DESCRIPTION
Ran into nasty linker errors with clang-6 in fbcode. It doesn't seem to understand `static constexpr` when the value is an enum and gives me linker errors. Definining them out of source fixes the problem. Probably a compiler/linker bug

![screen shot 2018-03-14 at 17 34 53](https://user-images.githubusercontent.com/6429851/37438481-ed033816-27af-11e8-8177-30285497ea03.png)

@soumith 
