### PR TITLE
Add promoteTypes to ATen and torch._promote_types to python.

### DIFF
--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -11,12 +11,12 @@ namespace at {
 #define AT_FORALL_SCALAR_TYPES(_) \
 _(uint8_t,Byte,i) \
 _(int8_t,Char,i) \
-_(double,Double,d) \
-_(float,Float,d) \
+_(int16_t,Short,i) \
 _(int,Int,i) \
 _(int64_t,Long,i) \
-_(int16_t,Short,i) \
-_(Half,Half,d)
+_(Half,Half,d) \
+_(float,Float,d) \
+_(double,Double,d)
 
 enum class ScalarType {
 #define DEFINE_ENUM(_1,n,_2) \
@@ -101,6 +101,43 @@ static inline bool isFloatingType(ScalarType t) {
   return (t == ScalarType::Double ||
           t == ScalarType::Float ||
           t == ScalarType::Half);
+}
+
+static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
+  // This is generated according to NumPy's promote_types
+#define u1 ScalarType::Byte
+#define i1 ScalarType::Char
+#define i2 ScalarType::Short
+#define i4 ScalarType::Int
+#define i8 ScalarType::Long
+#define f2 ScalarType::Half
+#define f4 ScalarType::Float
+#define f8 ScalarType::Double
+#define ud ScalarType::Undefined
+  static constexpr ScalarType _promoteTypesLookup
+      [static_cast<int>(ScalarType::NumOptions)]
+      [static_cast<int>(ScalarType::NumOptions)] = {
+            /* u1  i1  i2  i4  i8  f2  f4  f8, ud */
+    /* u1 */ { u1, i2, i2, i4, i8, f2, f4, f8, ud },
+    /* i1 */ { i2, i1, i2, i4, i8, f2, f4, f8, ud },
+    /* i2 */ { i2, i2, i2, i4, i8, f4, f4, f8, ud },
+    /* i4 */ { i4, i4, i4, i4, i8, f8, f8, f8, ud },
+    /* i8 */ { i8, i8, i8, i8, i8, f8, f8, f8, ud },
+    /* f2 */ { f2, f2, f4, f8, f8, f2, f4, f8, ud },
+    /* f4 */ { f4, f4, f4, f8, f8, f4, f4, f8, ud },
+    /* f8 */ { f8, f8, f8, f8, f8, f8, f8, f8, ud },
+    /* ud */ { ud, ud, ud, ud, ud, ud, ud, ud, ud },
+  };
+#undef u1
+#undef i1
+#undef i2
+#undef i4
+#undef i8
+#undef f2
+#undef f4
+#undef f8
+#undef ud
+  return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
 }
 
 struct Tensor;


### PR DESCRIPTION
This isn't hooked up to anything yet, but is necessary for both scalar binary ops in ATen and tensor constructor type inference in PyTorch.