### PR TITLE
Fix perf baseline number update

### DIFF
--- a/.jenkins/short-perf-test-cpu.sh
+++ b/.jenkins/short-perf-test-cpu.sh
@@ -22,6 +22,7 @@ fi
 if [[ "$GIT_COMMIT" == *origin/master* ]]; then
     # Prepare new baseline file
     cp perf_test_numbers_cpu.json new_perf_test_numbers_cpu.json
+    export TEST_DIR=$PWD
     python update_commit_hash.py new_perf_test_numbers_cpu.json ${PYTORCH_COMMIT_ID}
 fi
 
@@ -38,12 +39,15 @@ else
     run_test test_cpu_speed_mnist 20 compare_with_baseline
 fi
 
+# Make sure perf repo local checkout is up-to-date
+cd /var/lib/jenkins/host-workspace
+git config --global user.email jenkins@ci.pytorch.org
+git config --global user.name Jenkins
+git pull origin cpu
+
 if [[ "$GIT_COMMIT" == *origin/master* ]]; then
     # Push new baseline file
-    cp new_perf_test_numbers_cpu.json /var/lib/jenkins/host-workspace/perf_test_numbers_cpu.json
-    cd /var/lib/jenkins/host-workspace
-    git config --global user.email jenkins@ci.pytorch.org
-    git config --global user.name Jenkins
+    cp $TEST_DIR/new_perf_test_numbers_cpu.json /var/lib/jenkins/host-workspace/perf_test_numbers_cpu.json
     git add perf_test_numbers_cpu.json
     git commit -m "New CPU perf test baseline from ${PYTORCH_COMMIT_ID}"
 fi

--- a/.jenkins/short-perf-test-gpu.sh
+++ b/.jenkins/short-perf-test-gpu.sh
@@ -25,6 +25,7 @@ fi
 if [[ "$GIT_COMMIT" == *origin/master* ]]; then
     # Prepare new baseline file
     cp perf_test_numbers_gpu.json new_perf_test_numbers_gpu.json
+    export TEST_DIR=$PWD
     python update_commit_hash.py new_perf_test_numbers_gpu.json ${PYTORCH_COMMIT_ID}
 fi
 
@@ -50,12 +51,15 @@ else
     run_test test_gpu_speed_mlstm 20 compare_with_baseline
 fi
 
+# Make sure perf repo local checkout is up-to-date
+cd /var/lib/jenkins/host-workspace
+git config --global user.email jenkins@ci.pytorch.org
+git config --global user.name Jenkins
+git pull origin gpu
+
 if [[ "$GIT_COMMIT" == *origin/master* ]]; then
     # Push new baseline file
-    cp new_perf_test_numbers_gpu.json /var/lib/jenkins/host-workspace/perf_test_numbers_gpu.json
-    cd /var/lib/jenkins/host-workspace
-    git config --global user.email jenkins@ci.pytorch.org
-    git config --global user.name Jenkins
+    cp $TEST_DIR/new_perf_test_numbers_gpu.json /var/lib/jenkins/host-workspace/perf_test_numbers_gpu.json
     git add perf_test_numbers_gpu.json
     git commit -m "New GPU perf test baseline from ${PYTORCH_COMMIT_ID}"
 fi


### PR DESCRIPTION
To avoid race condition with other running perf tests, we need to make sure that the local perf repo is up-to-date before adding new commits to it, so that the post-build git push will be successful.