### PR TITLE
Allow larger margin for perf test runtime variation

### DIFF
--- a/.jenkins/perf_test/compare_with_baseline.py
+++ b/.jenkins/perf_test/compare_with_baseline.py
@@ -55,6 +55,6 @@ else:
         with open(new_data_file_path) as new_data_file:
             new_data = json.load(new_data_file)
         new_data[test_name]['mean'] = sample_mean
-        new_data[test_name]['sigma'] = sample_sigma
+        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.01)
         with open(new_data_file_path, 'w') as new_data_file:
             json.dump(new_data, new_data_file, indent=4)


### PR DESCRIPTION
GPU perf tests typically have very small standard deviation in runtime (<0.3% of mean runtime) on a single machine, but when testing across multiple machines the runtime variation will be larger. This PR increases the margin of error for the runtime, thus making the GPU perf tests more reliable.