### PR TITLE
Allow torch.nn.DataParallel to take as inputs Modules which have parameters on CPU

### DIFF
--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -8,11 +8,13 @@ def replicate(network, devices):
     num_replicas = len(devices)
 
     params = list(network.parameters())
-    param_indices = {param: idx for idx, param in enumerate(params)}
-    param_copies = Broadcast.apply(devices, *params)
+    cuda_params = list(filter(lambda x: x.is_cuda, params))
+    cpu_params = list(filter(lambda x: not x.is_cuda, params))
+    cuda_param_indices = {param: idx for idx, param in enumerate(cuda_params)}
+    cuda_param_copies = Broadcast.apply(devices, *cuda_params)
     if len(params) > 0:
-        param_copies = [param_copies[i:i + len(params)]
-                        for i in range(0, len(param_copies), len(params))]
+        cuda_param_copies = [cuda_param_copies[i:i + len(cuda_params)]
+                        for i in range(0, len(cuda_param_copies), len(cuda_params))]
 
     buffers = list(network._all_buffers())
     buffer_indices = {buf: idx for idx, buf in enumerate(buffers)}
@@ -49,10 +51,15 @@ def replicate(network, devices):
                     replica = module_copies[j][i]
                     replica._parameters[key] = None
             else:
-                param_idx = param_indices[param]
-                for j in range(num_replicas):
-                    replica = module_copies[j][i]
-                    replica._parameters[key] = param_copies[j][param_idx]
+                if param.is_cuda:
+                    param_idx = cuda_param_indices[param]
+                    for j in range(num_replicas):
+                        replica = module_copies[j][i]
+                        replica._parameters[key] = cuda_param_copies[j][param_idx]
+                else:
+                    for j in range(num_replicas):
+                        replica = module_copies[j][i]
+                        replica._parameters[key] = param
         for key, buf in module._buffers.items():
             if buf is None:
                 for j in range(num_replicas):

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -9,7 +9,6 @@ def replicate(network, devices):
 
     params = list(network.parameters())
     cuda_params = list(filter(lambda x: x.is_cuda, params))
-    cpu_params = list(filter(lambda x: not x.is_cuda, params))
     cuda_param_indices = {param: idx for idx, param in enumerate(cuda_params)}
     cuda_param_copies = Broadcast.apply(devices, *cuda_params)
     if len(params) > 0:


### PR DESCRIPTION
I edited replicate.py so that I can do:
```python:
import torch.nn as nn
class DistributedModel(nn.Module):

    def __init__(self):
        super().__init__(
            embedding=nn.Embedding(1000, 10),
            rnn=nn.Linear(10, 10).cuda(0),
        )

    def forward(self, x):
        # Compute embedding on CPU
        x = self.embedding(x.cpu())

        # Transfer to GPU
        x = x.cuda(0)

        # Compute RNN on GPU
        x = self.rnn(x)
        return x

model = DistributedModel()
model = nn.DataParallel(model)
```

In this way, I can put some parameters of MyModel on a CPU and the others on Multi-GPUs by such a simple code.