### PR TITLE
Fix kldiv backward on CUDA

### DIFF
--- a/aten/src/THCUNN/DistKLDivCriterion.cu
+++ b/aten/src/THCUNN/DistKLDivCriterion.cu
@@ -55,7 +55,7 @@ struct kl_updateGradInput_functor
 
   __host__ __device__ Dtype operator()(const Dtype& x, const Dtype& y) const
   {
-      return y > 0 ? norm * (-y) : ScalarConvert<int, Dtype>::to(0) * gradOutput;
+      return y > 0 ? norm * (-y) * gradOutput : ScalarConvert<int, Dtype>::to(0);
   }
 };
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -1115,8 +1115,9 @@ class CriterionTest(TestBase):
             gpu_output = test_case._forward_criterion(gpu_module, gpu_input, gpu_target)
             test_case.assertEqual(cpu_output, gpu_output, 4e-4)
 
-            cpu_gradInput = test_case._backward_criterion(cpu_module, cpu_input, cpu_target)
-            gpu_gradInput = test_case._backward_criterion(gpu_module, gpu_input, gpu_target)
+            gradOutput = torch.randn(())
+            cpu_gradInput = test_case._backward_criterion(cpu_module, cpu_input, cpu_target, gradOutput)
+            gpu_gradInput = test_case._backward_criterion(gpu_module, gpu_input, gpu_target, gradOutput)
             test_case.assertEqual(cpu_gradInput, gpu_gradInput, 4e-4)
         except NotImplementedError:
             pass

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -690,7 +690,8 @@ class TestNN(NNTestCase):
         with torch.no_grad():
             return criterion.forward(input, target)
 
-    def _backward_criterion(self, criterion, input, target):
+    def _backward_criterion(self, criterion, input, target, gradOutput=None):
+        # Ignore gradOutput. It's used for non-legacy tests.
         with torch.no_grad():
             return criterion.backward(input, target)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -333,13 +333,13 @@ class TestNN(NNTestCase):
             output = criterion(input, target)
         return output.item()
 
-    def _backward_criterion(self, criterion, input, target):
+    def _backward_criterion(self, criterion, input, target, gradOutput=torch.ones(())):
         input_tuple = input if isinstance(input, tuple) else (input,)
         for i in input_tuple:
             if i.grad is not None:
                 i.grad.data.zero_()
         args = input_tuple + (target,)
-        criterion(*args).backward()
+        criterion(*args).backward(gradOutput.type_as(input_tuple[0]))
         if isinstance(input, tuple):
             return tuple(map(lambda i: i.grad.data, input))
         else:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -333,12 +333,14 @@ class TestNN(NNTestCase):
             output = criterion(input, target)
         return output.item()
 
-    def _backward_criterion(self, criterion, input, target, gradOutput=torch.ones(())):
+    def _backward_criterion(self, criterion, input, target, gradOutput=None):
         input_tuple = input if isinstance(input, tuple) else (input,)
         for i in input_tuple:
             if i.grad is not None:
                 i.grad.data.zero_()
         args = input_tuple + (target,)
+        if gradOutput is None:
+            gradOutput = torch.ones(())
         criterion(*args).backward(gradOutput.type_as(input_tuple[0]))
         if isinstance(input, tuple):
             return tuple(map(lambda i: i.grad.data, input))


### PR DESCRIPTION
Fixes #5801 

Two fixes:
1) Fix incorrect kldiv backward on CUDA
2) Change Criterion testing to test that the criterion uses gradOutput. The problem with KLDiv is that it was not using gradOutput but we didn't have a test for this.