### PR TITLE
introduce shape_as_tensor and reshape_from_tensor_shape

### DIFF
--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -1,0 +1,20 @@
+import torch
+import torch.onnx
+
+
+def _shape_as_tensor(g, input):
+    return g.op('Shape', input)
+
+
+@torch.onnx.symbolic_override(_shape_as_tensor)
+def shape_as_tensor(x):
+    return torch.LongTensor(tuple(x.shape))
+
+
+def _reshape_from_tensor_shape(g, input, shape):
+    return g.op('Reshape', input, shape)
+
+
+@torch.onnx.symbolic_override(_reshape_from_tensor_shape)
+def reshape_from_tensor_shape(x, shape):
+    return x.reshape(shape.tolist())


### PR DESCRIPTION
for now, I guess we can just leave these in torch/onnx, even if there's an argument they don't strictly belong there. It's straightforward to move them later.

overall motivation: this provides variants of size() and view() which operate on Variable sizes rather than [int] sizes. This allows us to attach a symbolic override and trace them.