### PR TITLE
Change `wrap_dim` semantics for TensorList

### DIFF
--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -36,7 +36,17 @@ static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors) {
     // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
     return dim;
   }
-  return maybe_wrap_dim(dim, tensors[0].dim());
+  // In an ideal world empty tensors should be broadcastable to any number of dims.
+  // Because that's not the case, we have to special case them to do the following:
+  // - we should wrap to the dim() of the first non-empty tensor.
+  // - If all tensors are empty, wrap_dim should return 0.
+  for (auto& tensor : tensors) {
+    if (tensor.numel() == 0) {
+      continue;
+    }
+    return maybe_wrap_dim(dim, tensor.dim());
+  }
+  return 0;
 }
 
 }

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -155,7 +155,7 @@
   self: not_implemented("btrisolve")
 
 - name: cat(TensorList tensors, int64_t dim)
-  tensors: cat_tensors_backward(grad, to_arg_sizes(tensors, dim), dim)
+  tensors: cat_tensors_backward(grad, to_arg_sizes(tensors, dim), at::maybe_wrap_dim(dim, tensors))
 
 - name: cauchy_(Tensor self, double median, double sigma, Generator generator)
   self: zeros_like(grad)

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -299,6 +299,11 @@ def saved_variables(formula, args):
             'suffix': lambda m: '_sizes_{}'.format(*m.groups()),
             'type': 'IntList',
         }),
+        # replace at::maybe_wrap_dim(dim, tensors) with dim_wrapped_by_tensors
+        (r'at::maybe_wrap_dim\({}, (\w+)\)', {
+            'suffix': lambda m: '_wrapped_by_{}'.format(*m.groups()),
+            'type': 'int64_t',
+        }),
         # replace TensorGeometry(self) with self_geometry
         (r'TensorGeometry\({}\)', {
             'suffix': '_geometry',


### PR DESCRIPTION
Should fix https://github.com/pytorch/pytorch/issues/5332. 

When wrapping `dim` for a TensorList, right now we take the first element of the TensorList, look at its dimension, and use that to wrap `dim`.

This approach doesn't work for `torch.cat`, which takes empty tensors. Un-intuitively, `torch.cat([empty, notempty], dim=1)` and `torch.cat([notempty, empty], dim=1)` behave differently because we don't support empty tensors very well. I think a better fix would be to ensure that empty tensors are broadcastable to arbitrary dimensions, but we don't support arbitrary empty dimensions.

I made the following changes:
- wrap `dim` to the first non-empty tensor in a TensorList
- If the TensorList is empty, the output of wrapping `dim` is 0.

cc @gchanan @colesbury 

### Test Plan
I haven't written any tests yet because this PR depends on #5552 to fix #5332 completely. When that is merged I'll put in tests here.