### PR TITLE
Add operator[](int64_t) overload

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -57,6 +57,9 @@ inline Tensor Tensor::operator[](Tensor index) const {
   // The Scalar(Tensor) constructor is explicit, so we need to call it.
   return this->operator[](Scalar(index));
 }
+inline Tensor Tensor::operator[](size_t index) const {
+  return this->operator[](static_cast<int64_t>(index));
+}
 
 #define AT_FORALL_BINARY_OPS(_) \
 _(+,x.add(y), y.add(x)) \

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -57,8 +57,8 @@ inline Tensor Tensor::operator[](Tensor index) const {
   // The Scalar(Tensor) constructor is explicit, so we need to call it.
   return this->operator[](Scalar(index));
 }
-inline Tensor Tensor::operator[](size_t index) const {
-  return this->operator[](static_cast<int64_t>(index));
+inline Tensor Tensor::operator[](int64_t index) const {
+  return select(0, index);
 }
 
 #define AT_FORALL_BINARY_OPS(_) \

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -118,6 +118,7 @@ struct Tensor : public detail::TensorBase {
   Tensor& operator/=(Scalar other);
   Tensor operator[](Scalar index) const;
   Tensor operator[](Tensor index) const;
+  Tensor operator[](size_t index) const;
 
   // STOP.  Thinking of adding a method here, which only makes use
   // of other ATen methods?  Define it in native_functions.yaml.

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -118,7 +118,7 @@ struct Tensor : public detail::TensorBase {
   Tensor& operator/=(Scalar other);
   Tensor operator[](Scalar index) const;
   Tensor operator[](Tensor index) const;
-  Tensor operator[](size_t index) const;
+  Tensor operator[](int64_t index) const;
 
   // STOP.  Thinking of adding a method here, which only makes use
   // of other ATen methods?  Define it in native_functions.yaml.

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -272,6 +272,9 @@ static void test(Type & type) {
     for (int64_t i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }
+    for (size_t i = 0; i < tensor.numel(); ++i) {
+      ASSERT(tensor[i].equal(one * static_cast<int64_t>(i)));
+    }
     for (int i = 0; i < tensor.numel(); ++i) {
       ASSERT(tensor[i].equal(one * i));
     }


### PR DESCRIPTION
Added an overload of `Tensor::operator[]` for `int64_t`. Note that numeric types will always prefer to be converted to another numeric type than constructing a different object (`Scalar`). So we're back to old behavior, just that indexing with `Scalar` and scalar `Tensor`s works *additionally*.

I don't know why all the CI tests built before. I added a test case that fails before and passes after though.

@apaszke 

Fixes #5816 