### PR TITLE
[distributions] Avoid in-place ops in BoltzmannTransform

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -404,8 +404,7 @@ class BoltzmannTransform(Transform):
     def _call(self, x):
         logprobs = x
         probs = (logprobs - logprobs.max(-1, True)[0]).exp()
-        probs /= probs.sum(-1, True)
-        return probs
+        return probs / probs.sum(-1, True)
 
     def _inverse(self, y):
         probs = y


### PR DESCRIPTION
This avoids the following error in `.backward()`:
```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation
```