### PR TITLE
Store perf numbers in AWS database

### DIFF
--- a/.jenkins/perf_test/compare_with_baseline.py
+++ b/.jenkins/perf_test/compare_with_baseline.py
@@ -24,8 +24,13 @@ data_file_path = '../perf_test_numbers_{}.json'.format(backend)
 with open(data_file_path) as data_file:
     data = json.load(data_file)
 
-mean = float(data[test_name]['mean'])
-sigma = float(data[test_name]['sigma'])
+if test_name in data:
+    mean = float(data[test_name]['mean'])
+    sigma = float(data[test_name]['sigma'])
+else:
+    # Let the test pass if baseline number doesn't exist
+    mean = sys.maxsize
+    sigma = 0.001
 
 print("population mean: ", mean)
 print("population sigma: ", sigma)
@@ -54,6 +59,7 @@ else:
         new_data_file_path = '../new_perf_test_numbers_{}.json'.format(backend)
         with open(new_data_file_path) as new_data_file:
             new_data = json.load(new_data_file)
+        new_data[test_name] = {}
         new_data[test_name]['mean'] = sample_mean
         new_data[test_name]['sigma'] = sample_sigma
         with open(new_data_file_path, 'w') as new_data_file:

--- a/.jenkins/perf_test/db_schema.py
+++ b/.jenkins/perf_test/db_schema.py
@@ -1,0 +1,22 @@
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import *
+
+Base = declarative_base()
+
+
+class PerfTestBaseline(Base):
+    __tablename__ = 'perf_test_baseline'
+
+    id = Column(String, primary_key=True)
+    commit_id = Column(String)
+    test_name = Column(String)
+    test_type = Column(String)
+    mean = Column(Float)
+    sigma = Column(Float)
+
+
+class LatestTestedCommit(Base):
+    __tablename__ = 'latest_tested_commit'
+
+    commit_id = Column(String, primary_key=True)
+    test_type = Column(String)

--- a/.jenkins/perf_test/get_baseline.py
+++ b/.jenkins/perf_test/get_baseline.py
@@ -1,0 +1,50 @@
+import argparse
+import git
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from db_schema import Base, PerfTestBaseline, LatestTestedCommit
+import json
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--username', dest='username', action='store',
+                    required=False, help='username for database')
+parser.add_argument('--password', dest='password', action='store',
+                    required=False, help='password for database')
+parser.add_argument('--hostname', dest='hostname', action='store',
+                    required=False, help='hostname for database')
+parser.add_argument('--dbname', dest='dbname', action='store',
+                    required=False, help='dbname for database')
+parser.add_argument('--testtype', dest='testtype', action='store',
+                    required=True, help='type of perf test')
+parser.add_argument('--datafile', dest='datafile', action='store',
+                    required=True, help='file to store the baseline numbers in')
+parser.add_argument('--local', dest='local', action='store_true',
+                    required=False, help='local run')
+args = parser.parse_args()
+
+if args.local:
+    engine = create_engine('sqlite:///test.db')
+else:
+    engine = create_engine('postgresql://{}:{}@{}/{}'.format(args.username, args.password, args.hostname, args.dbname))
+
+Base.metadata.create_all(engine)
+
+Session = sessionmaker(bind=engine)
+session = Session()
+
+data = {}
+
+latest_tested_commit = session.query(LatestTestedCommit).filter_by(test_type=args.testtype).first()
+if latest_tested_commit:
+    latest_tested_commit_id = latest_tested_commit.commit_id
+    data['commit'] = latest_tested_commit_id
+    baseline_list = session.query(PerfTestBaseline) \
+                           .filter_by(commit_id=latest_tested_commit_id, test_type=args.testtype) \
+                           .all()
+    for baseline in baseline_list:
+        data[baseline.test_name] = {}
+        data[baseline.test_name]['mean'] = baseline.mean
+        data[baseline.test_name]['sigma'] = baseline.sigma
+
+with open(args.datafile, 'w') as new_data_file:
+    json.dump(data, new_data_file, indent=4)

--- a/.jenkins/perf_test/update_baseline.py
+++ b/.jenkins/perf_test/update_baseline.py
@@ -1,0 +1,82 @@
+import argparse
+import git
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from db_schema import Base, PerfTestBaseline, LatestTestedCommit
+from sqlalchemy.dialects.postgresql import insert
+import json
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--username', dest='username', action='store',
+                    required=False, help='username for database')
+parser.add_argument('--password', dest='password', action='store',
+                    required=False, help='password for database')
+parser.add_argument('--hostname', dest='hostname', action='store',
+                    required=False, help='hostname for database')
+parser.add_argument('--dbname', dest='dbname', action='store',
+                    required=False, help='dbname for database')
+parser.add_argument('--testtype', dest='testtype', action='store',
+                    required=True, help='type of perf test')
+parser.add_argument('--datafile', dest='datafile', action='store',
+                    required=True, help='file that contains the new baseline numbers')
+parser.add_argument('--local', dest='local', action='store_true',
+                    required=False, help='local run')
+args = parser.parse_args()
+
+if args.local:
+    engine = create_engine('sqlite:///test.db')
+else:
+    engine = create_engine('postgresql://{}:{}@{}/{}'.format(args.username, args.password, args.hostname, args.dbname))
+
+Base.metadata.create_all(engine)
+
+if args.datafile:
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    new_baseline_list = []
+    old_baseline_list = []
+    current_commit_id = None
+    with open(args.datafile) as data_file:
+        data = json.load(data_file)
+        current_commit_id = data['commit']
+
+        # Delete all existing baseline numbers from this commit
+        for baseline in session.query(PerfTestBaseline).filter_by(commit_id=current_commit_id).all():
+            session.delete(baseline)
+
+        for key in data:
+            if 'mean' in data[key] and 'sigma' in data[key]:
+                test_name = key
+                mean = float(data[key]['mean'])
+                sigma = float(data[key]['sigma'])
+
+                new_baseline_list.append(
+                    PerfTestBaseline(
+                        id=current_commit_id + '_' + args.testtype + '_' + test_name,
+                        commit_id=current_commit_id,
+                        test_name=test_name,
+                        test_type=args.testtype,
+                        mean=float(mean),
+                        sigma=float(sigma)
+                    )
+                )
+
+        session.add_all(new_baseline_list)
+
+    latest_tested_commit = session.query(LatestTestedCommit).filter_by(test_type=args.testtype).first()
+    if not latest_tested_commit:
+        latest_tested_commit = LatestTestedCommit(commit_id=current_commit_id, test_type=args.testtype)
+        session.add(latest_tested_commit)
+    else:
+        latest_tested_commit_id = latest_tested_commit.commit_id
+
+        repo = git.Repo('../../')
+        commit_ids = repo.git.rev_list('HEAD').splitlines()
+
+        # if latest_tested_commit_id is in commit history, that means the current commit is newer
+        if latest_tested_commit_id in commit_ids:
+            latest_tested_commit.commit_id = current_commit_id
+            session.add(latest_tested_commit)
+
+    session.commit()

--- a/.jenkins/short-perf-test-cpu.sh
+++ b/.jenkins/short-perf-test-cpu.sh
@@ -7,19 +7,21 @@ cd .jenkins/perf_test
 
 export PATH=/opt/conda/bin:$PATH
 
+pip install GitPython sqlalchemy psycopg2-binary
+
 echo "Running CPU perf test for PyTorch..."
 
 # Get last master commit hash
 export PYTORCH_COMMIT_ID=$(git log --format="%H" -n 1)
 
-# Get baseline file from https://github.com/yf225/perf-tests
-if [ -f /var/lib/jenkins/host-workspace/perf_test_numbers_cpu.json ]; then
-    cp /var/lib/jenkins/host-workspace/perf_test_numbers_cpu.json perf_test_numbers_cpu.json
+# Get baseline data from database
+if [ -z ${BUILD_ID} ]; then
+    python get_baseline.py --local --testtype cpu_runtime --datafile perf_test_numbers_cpu.json
 else
-    curl https://raw.githubusercontent.com/yf225/perf-tests/master/perf_test_numbers_cpu.json -O
+    python get_baseline.py --username ${USERNAME} --password ${PASSWORD} --hostname ${DBHOSTNAME} --dbname ${DBNAME} --testtype cpu_runtime --datafile perf_test_numbers_cpu.json
 fi
 
-if [[ "$GIT_COMMIT" == *origin/master* ]]; then
+if [[ "$COMMIT_SOURCE" == *master* ]]; then
     # Prepare new baseline file
     cp perf_test_numbers_cpu.json new_perf_test_numbers_cpu.json
     python update_commit_hash.py new_perf_test_numbers_cpu.json ${PYTORCH_COMMIT_ID}
@@ -30,7 +32,7 @@ fi
 . ./test_cpu_speed_mnist.sh
 
 # Run tests
-if [[ "$GIT_COMMIT" == *origin/master* ]]; then
+if [[ "$COMMIT_SOURCE" == *master* ]]; then
     run_test test_cpu_speed_mini_sequence_labeler 20 compare_and_update
     run_test test_cpu_speed_mnist 20 compare_and_update
 else
@@ -38,12 +40,11 @@ else
     run_test test_cpu_speed_mnist 20 compare_with_baseline
 fi
 
-if [[ "$GIT_COMMIT" == *origin/master* ]]; then
-    # Push new baseline file
-    cp new_perf_test_numbers_cpu.json /var/lib/jenkins/host-workspace/perf_test_numbers_cpu.json
-    cd /var/lib/jenkins/host-workspace
-    git config --global user.email jenkins@ci.pytorch.org
-    git config --global user.name Jenkins
-    git add perf_test_numbers_cpu.json
-    git commit -m "New CPU perf test baseline from ${PYTORCH_COMMIT_ID}"
+# Push new baseline data to database
+if [[ "$COMMIT_SOURCE" == *master* ]]; then
+    if [ -z ${BUILD_ID} ]; then
+        python update_baseline.py --local --testtype cpu_runtime --datafile new_perf_test_numbers_cpu.json
+    else
+        python update_baseline.py --username ${USERNAME} --password ${PASSWORD} --hostname ${DBHOSTNAME} --dbname ${DBNAME} --testtype cpu_runtime --datafile new_perf_test_numbers_cpu.json
+    fi
 fi


### PR DESCRIPTION
Previously the perf numbers are stored in https://github.com/yf225/perf-tests/tree/cpu, but we couldn't figure out a way to push the perf numbers only from master builds. This PR moves the perf number storage to AWS RDS, which allows us to have finer control over when to push the new numbers.