### PR TITLE
Softmax symbolic should account for negative dim

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -355,7 +355,9 @@ def softmax(g, input, dim=None):
     #           [0.167, 0.167, 0.167]]
     # So only when dim and axis both equal to ndim - 1 (the last dimension),
     # their semantics are equivalent.
-    if len(input.type().sizes()) != dim + 1:
+    if dim < 0:
+        check_dim = len(input.type().sizes()) + dim
+    if len(input.type().sizes()) != check_dim + 1:
         return _unimplemented("dim", "ONNX and PyTorch use different strategies to split the input.")
     return g.op('Softmax', input, axis_i=dim)
 


### PR DESCRIPTION
Previously export of softmax with `dim=-1` would fail because the check within the symbolic did not account for if the dimension was negative