### PR TITLE
Fix crash in new cuda tensor with numpy array

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -76,9 +76,9 @@ static Tensor new_with_type_conversion(const Type& type, Tensor other, int64_t d
 }
 
 static Tensor new_with_tensor_copy(const Type& type, Tensor other, int64_t device) {
-  AutoGPU auto_gpu(device);
-  AutoNoGIL no_gil;
   maybe_initialize_cuda(type);
+  AutoNoGIL no_gil;
+  AutoGPU auto_gpu(device);
   return type.copy(other);
 }
 


### PR DESCRIPTION
Fixes segfault in #5821 .  Releasing the Global Interpreter Lock after `maybe_initialize_cuda`.


**Test ::** 

```
In [3]: data = np.array([1.0])

In [4]: torch.tensor(data, dtype=torch.float32)
Out[4]:
 1
[torch.FloatTensor of size (1,)]

In [5]: torch.tensor(data, dtype=torch.cuda.float32)
Out[5]:

 1
[torch.cuda.FloatTensor of size (1,) (GPU 0)]

```

Please review @colesbury @gchanan 