### PR TITLE
Fix binary operations with scalars

### DIFF
--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -85,6 +85,7 @@ inline at::optional<at::Type*> unifyTypes(const Tensor& a, const Tensor& b) {
     auto result_scalar_type = promoteTypes(x.type().scalarType(), y.type().scalarType());
     return {&x.type().toScalarType(result_scalar_type)};
   };
+  if (!a.defined() || !b.defined()) return nullopt;
   if (a.type() == b.type())
     return nullopt;
   bool a_scalar = a.dim() == 0;

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -302,9 +302,6 @@ class nested_dict(object):
             return r
         return self.parent[x]
 
-    def __setitem__(self, key, value):
-        return self.base.__setitem__(key, value)
-
 
 Environment = TypedDict('Environment', {
     'ScalarName': str,

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -6,6 +6,7 @@
 #include "ATen/ExpandUtils.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/UndefinedType.h"
+#include "ATen/TensorUtils.h"
 
 #include <iostream>
 ${type_headers}

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5,6 +5,7 @@ import math
 import torch
 import unittest
 import warnings
+import operator
 from copy import deepcopy
 from collections import OrderedDict
 from itertools import product
@@ -1832,6 +1833,19 @@ class TestAutograd(TestCase):
         run_test((10,), 3)
         run_test((10,), 1)
         run_test((10,), 1.5)
+
+    def test_scalar_binop_grad(self):
+        x = torch.tensor([1, 2, 3, 4], dtype=torch.float, requires_grad=True)
+        y = torch.tensor(2., dtype=torch.double, requires_grad=True)
+
+        operators = [
+            operator.add, operator.sub, operator.mul, operator.truediv, operator.pow,
+        ]
+
+        for arg1, arg2 in [(x, y), (y, x)]:
+            for op in operators:
+                # We need a large eps, because floats are too inaccurate for gradchecks
+                gradcheck(lambda x, y: op(x, y).sum(), [arg1, arg2], raise_exception=True, eps=1e-2)
 
     def test_profiler(self):
         x = Variable(torch.randn(10, 10))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -780,6 +780,20 @@ class TestTorch(TestCase):
         long_res1 = long_m1.clone()
         long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
 
+    def test_cross_type_binary_operators(self):
+        x = torch.randn(2, 2, dtype=torch.float)
+        y = torch.tensor(2., dtype=torch.double)
+
+        operators = [
+            operator.add, operator.sub, operator.mul, operator.truediv,
+            operator.pow, operator.mod, operator.lt, operator.le, operator.gt,
+            operator.ge, operator.eq, operator.ne
+        ]
+
+        for arg1, arg2, arg_same_type in [(x, y, y.float()), (y, x, x.double())]:
+            for op in operators:
+                self.assertEqual(op(arg1, arg2), op(arg1, arg_same_type))
+
     def test_mm(self):
         # helper function
         def matrixmultiply(mat1, mat2):


### PR DESCRIPTION
A new version of #5647. Here's an example auto-generated function that uses the new path:
```cpp
Tensor Type::add(const Tensor & self, const Tensor & other, Scalar alpha) const {                                                                              
    if (auto new_type = unifyTypes(self, other)) {                                                                                                             
        return (*new_type)->add(self.type() != (**new_type) ? (**new_type).copy(self) : self, other.type() != (**new_type) ? (**new_type).copy(other) : other);
    }                                                                                                                                                          
                                                                                                                                                               
    Tensor b_self, b_other;                                                                                                                                    
    std::tie(b_self, b_other) = expand_outplace(self, other, "add");                                                                                           
    return s_add(b_self, b_other, alpha);                                                                                                                      
}                                                                                                                                                              
```

@gchanan @colesbury do you also want me to include the changes to binding code for Python operators from the previous PR (i.e. use C++ operators to dispatch them)?