### PR TITLE
Fix some methods not showing up in doc

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -114,6 +114,9 @@ view of a storage and defines numeric operations on it.
    .. automethod:: bernoulli_
    .. automethod:: bmm
    .. automethod:: byte
+   .. automethod:: btrifact
+   .. automethod:: btrifact_with_info
+   .. automethod:: btrisolve
    .. automethod:: cauchy_
    .. automethod:: ceil
    .. automethod:: ceil_
@@ -134,6 +137,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: cumprod
    .. automethod:: cumsum
    .. automethod:: data_ptr
+   .. automethod:: det
    .. automethod:: diag
    .. automethod:: dim
    .. automethod:: dist
@@ -196,6 +200,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: lerp
    .. automethod:: lerp_
    .. automethod:: log
+   .. automethod:: logdet
    .. automethod:: log1p
    .. automethod:: log1p_
    .. automethod:: log_
@@ -273,6 +278,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: sinh
    .. automethod:: sinh_
    .. automethod:: size
+   .. automethod:: slogdet
    .. automethod:: sort
    .. automethod:: split
    .. automethod:: sqrt

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -206,6 +206,8 @@ BLAS and LAPACK Operations
 .. autofunction:: gesv
 .. autofunction:: inverse
 .. autofunction:: det
+.. autofunction:: logdet
+.. autofunction:: slogdet
 .. autofunction:: matmul
 .. autofunction:: mm
 .. autofunction:: mv


### PR DESCRIPTION
Some methods were missing in `torch/tensors.rst`, and thus don't show up in doc. 