### PR TITLE
Support legacy empty tensor behavior in cat

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -4062,7 +4062,6 @@
       output: True
     - TensorList tensors
     - arg: int64_t dim
-      wrap_dim: tensors
       default: 0
 ]]
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -18,27 +18,6 @@ static void check_cat_no_zero_dim(TensorList tensors) {
   }
 }
 
-// FIXME when empty tensors with arbitrary shapes is implemented
-// When using cat on empty tensors, the following is legacy behavior
-// when the non-empty `tensor` and `empty` do not have matching sizes:
-// 1) torch.cat([empty, tensor]) should ignore empty tensors
-// 2) torch.cat([tensor, empty]) should ignore empty tensors
-// 3) torch.cat([empty, empty, ..., empty]) should be empty
-// The following function wraps dim on the first non-empty tensor
-// to preserve legacy behavior.
-static inline int64_t legacy_cat_wrap_dim(int64_t dim, TensorList tensors) {
-  if (tensors.size() == 0) {
-    return dim;
-  }
-  for (auto& tensor : tensors) {
-    if (tensor.numel() == 0) {
-      continue;
-    }
-    return at::maybe_wrap_dim(dim, tensor.dim());
-  }
-  return 0;
-}
-
 Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim) {
   check_cat_no_zero_dim(tensors);
   dim = legacy_cat_wrap_dim(dim, tensors);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -18,13 +18,36 @@ static void check_cat_no_zero_dim(TensorList tensors) {
   }
 }
 
+// FIXME when empty tensors with arbitrary shapes is implemented
+// When using cat on empty tensors, the following is legacy behavior
+// when the non-empty `tensor` and `empty` do not have matching sizes:
+// 1) torch.cat([empty, tensor]) should ignore empty tensors
+// 2) torch.cat([tensor, empty]) should ignore empty tensors
+// 3) torch.cat([empty, empty, ..., empty]) should be empty
+// The following function wraps dim on the first non-empty tensor
+// to preserve legacy behavior.
+static inline int64_t legacy_cat_wrap_dim(int64_t dim, TensorList tensors) {
+  if (tensors.size() == 0) {
+    return dim;
+  }
+  for (auto& tensor : tensors) {
+    if (tensor.numel() == 0) {
+      continue;
+    }
+    return at::maybe_wrap_dim(dim, tensor.dim());
+  }
+  return 0;
+}
+
 Tensor & cat_out(Tensor & result, TensorList tensors, int64_t dim) {
   check_cat_no_zero_dim(tensors);
+  dim = legacy_cat_wrap_dim(dim, tensors);
   return at::_cat_out(result, tensors, dim);
 }
 
 Tensor cat(TensorList tensors, int64_t dim) {
   check_cat_no_zero_dim(tensors);
+  dim = legacy_cat_wrap_dim(dim, tensors);
   return at::_cat(tensors, dim);
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2327,6 +2327,10 @@ class TestTorch(TestCase):
         res1 = torch.cat([empty, empty], dim=1)
         self.assertEqual(res1, empty)
 
+        with self.assertRaisesRegexp(RuntimeError,
+                                     'expected a non-empty list of Tensors'):
+            torch.cat([], dim=1)
+
     def test_stack(self):
         x = torch.rand(2, 3, 4)
         y = torch.rand(2, 3, 4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2309,6 +2309,24 @@ class TestTorch(TestCase):
                                      'zero-dimensional.*cannot be concatenated'):
             torch.cat([x, y])
 
+    def test_cat_empty(self):
+        # FIXME: this is legacy behavior and should be removed
+        # when we support empty tensors with arbitrary sizes
+        x = torch.randn(4, 3, 32, 32)
+        empty = torch.randn(0)
+
+        res1 = torch.cat([x, empty], dim=1)
+        res2 = torch.cat([empty, x], dim=1)
+        self.assertEqual(res1, res2)
+
+        conv = torch.nn.Conv2d(3, 3, kernel_size=1)
+        res1 = torch.cat([conv(x), empty], dim=1)
+        res2 = torch.cat([empty, conv(x)], dim=1)
+        self.assertEqual(res1, res2)
+
+        res1 = torch.cat([empty, empty], dim=1)
+        self.assertEqual(res1, empty)
+
     def test_stack(self):
         x = torch.rand(2, 3, 4)
         y = torch.rand(2, 3, 4)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -364,30 +364,8 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   return self;
 }
 
-
-// FIXME when empty tensors with arbitrary shapes is implemented
-// When using cat on empty tensors, the following is legacy behavior
-// when the non-empty `tensor` and `empty` do not have matching sizes:
-// 1) torch.cat([empty, tensor]) should ignore empty tensors
-// 2) torch.cat([tensor, empty]) should ignore empty tensors
-// 3) torch.cat([empty, empty, ..., empty]) should be empty
-// The following function wraps dim on the first non-empty shape
-// to preserve legacy behavior.
-static inline int64_t legacy_cat_wrap_dim(int64_t dim, const std::vector<std::vector<int64_t>>& tensor_sizes) {
-  if (tensor_sizes.size() == 0) {
-    return dim;
-  }
-  for (auto& sizes : tensor_sizes) {
-    if (sizes == std::vector<int64_t>({0})) {
-      continue;
-    }
-    return at::maybe_wrap_dim(dim, sizes.size());
-  }
-  return 0;
-}
-
 std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
-  dim = legacy_cat_wrap_dim(dim, sizes);
+  dim = at::legacy_cat_wrap_dim(dim, sizes);
   std::vector<Tensor> grad_inputs(sizes.size());
   int64_t accumulate = 0;
   for (size_t i = 0; i < sizes.size(); ++i) {


### PR DESCRIPTION
Continuing from #5837:
Fixes #5332.

Currently, the following behavior happens with `torch.cat`:
```
import torch

x = torch.randn(4, 3, 32, 32)
empty = torch.Tensor([])

# Doesn't error out
res1 = torch.cat([x, empty], dim=1)

# Errors out
res2 = torch.cat([empty, x], dim=1)
```

However, at some point in the past, `res1` and `res2` were equal. This PR supports the legacy behavior of ignoring empty tensors when concatenating a list of tensors, until we have empty tensors that can have arbitrary shape, at which point we'll stop supporting this behavior.

cc @gchanan 

### Test Plan
New test
