### PR TITLE
Better error msg for missing mkl headers

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -385,6 +385,11 @@ IF(BLAS_FOUND)
   SET(USE_BLAS 1)
   IF(BLAS_INFO STREQUAL "mkl")
     ADD_DEFINITIONS(-DTH_BLAS_MKL)
+    IF(NOT BLAS_INCLUDE_DIR)
+      MESSAGE(FATAL_ERROR "MKL header files not found. If using conda, please run \
+        `conda install mkl-include`. Otherwise, please make sure that CMake will \
+        search the directory containing the header files, e.g., by setting CMAKE_INCLUDE_PATH.")
+    ENDIF()
     INCLUDE_DIRECTORIES(${BLAS_INCLUDE_DIR})  # include MKL headers
     SET(AT_MKL_ENABLED 1)
   ENDIF()

--- a/aten/src/TH/cmake/FindBLAS.cmake
+++ b/aten/src/TH/cmake/FindBLAS.cmake
@@ -1,6 +1,6 @@
 # - Find BLAS library
-# This module finds an installed fortran library that implements the BLAS 
-# linear-algebra interface (see http://www.netlib.org/blas/).  
+# This module finds an installed fortran library that implements the BLAS
+# linear-algebra interface (see http://www.netlib.org/blas/).
 # The list of libraries searched for is taken
 # from the autoconf macro file, acx_blas.m4 (distributed at
 # http://ac-archive.sourceforge.net/ac-archive/acx_blas.html).
@@ -28,7 +28,7 @@ INCLUDE(CheckFortranFunctionExists)
 
 MACRO(Check_Fortran_Libraries LIBRARIES _prefix _name _flags _list)
   # This macro checks for the existence of the combination of fortran libraries
-  # given by _list.  If the combination is found, this macro checks (using the 
+  # given by _list.  If the combination is found, this macro checks (using the
   # Check_Fortran_Function_Exists macro) whether can link against that library
   # combination using the name of a routine given by _name using the linker
   # flags given by _flags.  If the combination of libraries is found and passes
@@ -36,7 +36,7 @@ MACRO(Check_Fortran_Libraries LIBRARIES _prefix _name _flags _list)
   # have been found.  Otherwise, LIBRARIES is set to NOTFOUND.
   # N.B. _prefix is the prefix applied to the names of all cached variables that
   # are generated internally and marked advanced by this macro.
-  
+
   set(__list)
   foreach(_elem ${_list})
     if(__list)
@@ -56,18 +56,18 @@ MACRO(Check_Fortran_Libraries LIBRARIES _prefix _name _flags _list)
       if ( WIN32 )
         find_library(${_prefix}_${_library}_LIBRARY
           NAMES ${_library}
-          PATHS ENV LIB 
+          PATHS ENV LIB
           PATHS ENV PATH )
       endif ( WIN32 )
-      if ( APPLE ) 
+      if ( APPLE )
         find_library(${_prefix}_${_library}_LIBRARY
           NAMES ${_library}
-          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 
+          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64
           ENV DYLD_LIBRARY_PATH )
       else ( APPLE )
         find_library(${_prefix}_${_library}_LIBRARY
           NAMES ${_library}
-          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 
+          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64
           ENV LD_LIBRARY_PATH )
       endif( APPLE )
       mark_as_advanced(${_prefix}_${_library}_LIBRARY)


### PR DESCRIPTION
Fixes #5887 .

Now it shows:
```
-- MKL library found
-- Found a library with BLAS API (mkl).
CMake Error at CMakeLists.txt:389 (MESSAGE):
  MKL header files not found.  If using conda, please run `conda install
  mkl-include`.  Otherwise, please make sure that CMake will search the
  directory containing the header files, e.g., by setting CMAKE_INCLUDE_PATH.


-- Configuring incomplete, errors occurred!
See also "/home/ssnl/sftp/pytorch/torch/lib/build/aten/CMakeFiles/CMakeOutput.log".
See also "/home/ssnl/sftp/pytorch/torch/lib/build/aten/CMakeFiles/CMakeError.log".

```

cc @zou3519 @ezyang 