### PR TITLE
Fix ImportError with requests in model_zoo

### DIFF
--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -9,7 +9,7 @@ import tempfile
 
 try:
     from requests.utils import urlparse
-    import requests.get as urlopen
+    from requests import get as urlopen
     requests_available = True
 except ImportError:
     requests_available = False


### PR DESCRIPTION
Not sure if this is a backwards compatibility issue: 
```
Python 2.7.9 (default, Apr  2 2015, 15:35:35) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests.get as urlopen
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named get
>>> from requests import get as urlopen
>>> 
```
I think because the `get` function lives at `requests.api` 
https://github.com/requests/requests/blob/master/requests/__init__.py#L115

I also saw this with python3.4