### PR TITLE
Revert "Fix ImportError with requests in model_zoo"

### DIFF
--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -9,7 +9,7 @@ import tempfile
 
 try:
     from requests.utils import urlparse
-    from requests import get as urlopen
+    import requests.get as urlopen
     requests_available = True
 except ImportError:
     requests_available = False


### PR DESCRIPTION
Reverts pytorch/pytorch#5896. I merged the commit because the CI was all green, but only travis run, and the commit broke ONNX tests. We should really get some indication that CI was incomplete...