### PR TITLE
[distributions] Support pickling of constraint objects

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -35,21 +35,21 @@ from torch.autograd import Variable, grad, gradcheck, variable
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, Dirichlet, Distribution,
                                  Exponential, ExponentialFamily,
-                                 FisherSnedecor, Gamma, Geometric,
-                                 Gumbel, Laplace, LogNormal, Multinomial, MultivariateNormal,
-                                 Normal, OneHotCategorical, Pareto, Poisson,
-                                 RelaxedBernoulli, RelaxedOneHotCategorical, StudentT,
+                                 FisherSnedecor, Gamma, Geometric, Gumbel,
+                                 Laplace, LogNormal, Multinomial,
+                                 MultivariateNormal, Normal, OneHotCategorical,
+                                 Pareto, Poisson, RelaxedBernoulli,
+                                 RelaxedOneHotCategorical, StudentT,
                                  TransformedDistribution, Uniform, constraints,
                                  kl_divergence)
-from torch.distributions.kl import _kl_expfamily_expfamily
 from torch.distributions.constraint_registry import biject_to, transform_to
 from torch.distributions.constraints import Constraint, is_dependent
 from torch.distributions.dirichlet import _Dirichlet_backward
+from torch.distributions.kl import _kl_expfamily_expfamily
 from torch.distributions.transforms import (AbsTransform, AffineTransform,
-                                            BoltzmannTransform,
                                             ComposeTransform, ExpTransform,
                                             LowerCholeskyTransform,
-                                            SigmoidTransform,
+                                            SigmoidTransform, SoftmaxTransform,
                                             StickBreakingTransform,
                                             identity_transform)
 from torch.distributions.utils import _finfo, probs_to_logits, softmax
@@ -2944,7 +2944,7 @@ class TestTransforms(TestCase):
                 AffineTransform(variable(torch.Tensor(4, 5).normal_()),
                                 variable(torch.Tensor(4, 5).normal_()),
                                 cache_size=cache_size),
-                BoltzmannTransform(cache_size=cache_size),
+                SoftmaxTransform(cache_size=cache_size),
                 StickBreakingTransform(cache_size=cache_size),
                 LowerCholeskyTransform(cache_size=cache_size),
                 ComposeTransform([
@@ -3089,7 +3089,7 @@ class TestTransforms(TestCase):
 
     def test_transform_shapes(self):
         transform0 = ExpTransform()
-        transform1 = BoltzmannTransform()
+        transform1 = SoftmaxTransform()
         transform2 = LowerCholeskyTransform()
 
         self.assertEqual(transform0.event_dim, 0)
@@ -3101,7 +3101,7 @@ class TestTransforms(TestCase):
 
     def test_transformed_distribution_shapes(self):
         transform0 = ExpTransform()
-        transform1 = BoltzmannTransform()
+        transform1 = SoftmaxTransform()
         transform2 = LowerCholeskyTransform()
         base_dist0 = Normal(variable(torch.zeros(4, 4)), variable(torch.ones(4, 4)))
         base_dist1 = Dirichlet(variable(torch.ones(4, 4)))

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -184,9 +184,10 @@ def _transform_to_less_than(constraint):
 @transform_to.register(constraints.interval)
 def _transform_to_interval(constraint):
     # Handle the special case of the unit interval.
-    if isinstance(constraint.lower_bound, numbers.Number) and constraint.lower_bound == 0:
-        if isinstance(constraint.upper_bound, numbers.Number) and constraint.upper_bound == 1:
-            return transforms.SigmoidTransform()
+    lower_is_0 = isinstance(constraint.lower_bound, numbers.Number) and constraint.lower_bound == 0
+    upper_is_1 = isinstance(constraint.upper_bound, numbers.Number) and constraint.upper_bound == 1
+    if lower_is_0 and upper_is_1:
+        return transforms.SigmoidTransform()
 
     loc = constraint.lower_bound
     scale = constraint.upper_bound - constraint.lower_bound

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -39,7 +39,7 @@ invariant.::
 
     An example where ``transform_to`` and ``biject_to`` differ is
     ``constraints.simplex``: ``transform_to(constraints.simplex)`` returns a
-    :class:`~torch.distributions.transforms.BoltzmannTransform` that simply
+    :class:`~torch.distributions.transforms.SoftmaxTransform` that simply
     exponentiates and normalizes its inputs; this is a cheap and mostly
     coordinate-wise operation appropriate for algorithms like SVI. In
     contrast, ``biject_to(constraints.simplex)`` returns a
@@ -65,7 +65,10 @@ You can create your own registry by creating a new :class:`ConstraintRegistry`
 object.
 """
 
+import numbers
+
 from torch.distributions import constraints, transforms
+from torch.distributions.utils import broadcast_all
 
 __all__ = [
     'ConstraintRegistry',
@@ -81,42 +84,37 @@ class ConstraintRegistry(object):
     def __init__(self):
         self._registry = {}
 
-    def register(self, constraint, transform=None):
+    def register(self, constraint, factory=None):
         """
         Registers a :class:`~torch.distributions.constraints.Constraint`
-        subclass or singleton object in this registry. Usage as decorator::
+        subclass in this registry. Usage::
 
             @my_registry.register(MyConstraintClass)
             def construct_transform(constraint):
                 assert isinstance(constraint, MyConstraint)
                 return MyTransform(constraint.params)
 
-        Usage on singleton instances::
-
-            my_registry.register(my_constraint_singleton, MyTransform())
-
         Args:
-            constraint (:class:`~torch.distributions.constraints.Constraint`):
-                Either a specific constraint instance or a subclass of
-                constraints.
-            transform (:class:`~torch.distributions.transforms.Transform`):
-                Either a transform object or a callable that inputs a
-                constraint object and returns a transform object.
+            constraint (subclass of :class:`~torch.distributions.constraints.Constraint`):
+                A subclass of :class:`~torch.distributions.constraints.Constraint`, or
+                a singleton object of the desired class.
+            factory (callable): A callable that inputs a constraint object and returns
+                a  :class:`~torch.distributions.transforms.Transform` object.
         """
         # Support use as decorator.
-        if transform is None:
-            return lambda transform: self.register(constraint, transform)
+        if factory is None:
+            return lambda factory: self.register(constraint, factory)
 
+        # Support calling on singleton instances.
         if isinstance(constraint, constraints.Constraint):
-            # Register singleton instances.
-            self._registry[constraint] = transform
-        elif issubclass(constraint, constraints.Constraint):
-            # Register Constraint subclass.
-            self._registry[constraint] = transform
-        else:
+            constraint = type(constraint)
+
+        if not isinstance(constraint, type) or not issubclass(constraint, constraints.Constraint):
             raise TypeError('Expected constraint to be either a Constraint subclass or instance, '
                             'but got {}'.format(constraint))
-        return transform
+
+        self._registry[constraint] = factory
+        return factory
 
     def __call__(self, constraint):
         """
@@ -137,11 +135,6 @@ class ConstraintRegistry(object):
         Raises:
             `NotImplementedError` if no transform has been registered.
         """
-        # Look up by singleton instance.
-        try:
-            return self._registry[constraint]
-        except KeyError:
-            pass
         # Look up by Constraint subclass.
         try:
             factory = self._registry[type(constraint)]
@@ -154,22 +147,27 @@ class ConstraintRegistry(object):
 biject_to = ConstraintRegistry()
 transform_to = ConstraintRegistry()
 
+
 ################################################################################
 # Registration Table
 ################################################################################
 
-biject_to.register(constraints.real, transforms.identity_transform)
-transform_to.register(constraints.real, transforms.identity_transform)
+@biject_to.register(constraints.real)
+@transform_to.register(constraints.real)
+def _transform_to_real(constraint):
+    return transforms.identity_transform
 
-biject_to.register(constraints.positive, transforms.ExpTransform())
-transform_to.register(constraints.positive, transforms.ExpTransform())
+
+@biject_to.register(constraints.positive)
+@transform_to.register(constraints.positive)
+def _transform_to_positive(constraint):
+    return transforms.ExpTransform()
 
 
 @biject_to.register(constraints.greater_than)
 @transform_to.register(constraints.greater_than)
 def _transform_to_greater_than(constraint):
-    loc = constraint.lower_bound
-    scale = loc.new([1]).expand_as(loc)
+    loc, scale = broadcast_all(constraint.lower_bound, 1)
     return transforms.ComposeTransform([transforms.ExpTransform(),
                                         transforms.AffineTransform(loc, scale)])
 
@@ -177,27 +175,36 @@ def _transform_to_greater_than(constraint):
 @biject_to.register(constraints.less_than)
 @transform_to.register(constraints.less_than)
 def _transform_to_less_than(constraint):
-    loc = constraint.upper_bound
-    scale = loc.new([-1]).expand_as(loc)
+    loc, scale = broadcast_all(constraint.upper_bound, -1)
     return transforms.ComposeTransform([transforms.ExpTransform(),
                                         transforms.AffineTransform(loc, scale)])
-
-
-biject_to.register(constraints.unit_interval, transforms.SigmoidTransform())
-transform_to.register(constraints.unit_interval, transforms.SigmoidTransform())
 
 
 @biject_to.register(constraints.interval)
 @transform_to.register(constraints.interval)
 def _transform_to_interval(constraint):
+    # Handle the special case of the unit interval.
+    if isinstance(constraint.lower_bound, numbers.Number) and constraint.lower_bound == 0:
+        if isinstance(constraint.upper_bound, numbers.Number) and constraint.upper_bound == 1:
+            return transforms.SigmoidTransform()
+
     loc = constraint.lower_bound
     scale = constraint.upper_bound - constraint.lower_bound
     return transforms.ComposeTransform([transforms.SigmoidTransform(),
                                         transforms.AffineTransform(loc, scale)])
 
 
-biject_to.register(constraints.simplex, transforms.StickBreakingTransform())
-transform_to.register(constraints.simplex, transforms.BoltzmannTransform())
+@biject_to.register(constraints.simplex)
+def _biject_to_simplex(constraint):
+    return transforms.StickBreakingTransform()
+
+
+@transform_to.register(constraints.simplex)
+def _transform_to_simplex(constraint):
+    return transforms.SoftmaxTransform()
+
 
 # TODO define a bijection for LowerCholeskyTransform
-transform_to.register(constraints.lower_cholesky, transforms.LowerCholeskyTransform())
+@transform_to.register(constraints.lower_cholesky)
+def _transform_to_lower_cholesky(constraint):
+    return transforms.LowerCholeskyTransform()

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -10,11 +10,11 @@ from torch.nn.functional import sigmoid
 __all__ = [
     'AbsTransform',
     'AffineTransform',
-    'BoltzmannTransform',
     'ComposeTransform',
     'ExpTransform',
     'LowerCholeskyTransform',
     'SigmoidTransform',
+    'SoftmaxTransform',
     'StickBreakingTransform',
     'Transform',
     'identity_transform',
@@ -385,7 +385,7 @@ class AffineTransform(Transform):
         return result.expand(shape)
 
 
-class BoltzmannTransform(Transform):
+class SoftmaxTransform(Transform):
     """
     Transform from unconstrained space to the simplex via `y = exp(x)` then
     normalizing.
@@ -399,7 +399,7 @@ class BoltzmannTransform(Transform):
     event_dim = 1
 
     def __eq__(self, other):
-        return isinstance(other, BoltzmannTransform)
+        return isinstance(other, SoftmaxTransform)
 
     def _call(self, x):
         logprobs = x


### PR DESCRIPTION
This PR adds support for pickling of `Constraint` objects. Previously the pickle-unpickle process broke constraint registration due to our use of hashing by singleton instance. To fix this, we now hash only by `Constraint` type, which is preserved by unpickled. The constraint registration table should remain semantically unchanged in this PR; only the registration syntax changes.

This PR also renames `BotlzmannTransform` to a more familiar `SoftmaxTransform`.

## Tested

- existing unit tests
- verified that constraints can now be pickled when used in Pyro