### PR TITLE
Add submodules in the ATen subtree

### DIFF
--- a/aten/.gitmodules
+++ b/aten/.gitmodules
@@ -1,0 +1,10 @@
+[submodule "src/ATen/cpu/cpuinfo"]
+	path = src/ATen/cpu/cpuinfo
+	url = https://github.com/Maratyszcza/cpuinfo
+[submodule "src/ATen/cpu/tbb/tbb_remote"]
+	path = src/ATen/cpu/tbb/tbb_remote
+	url = https://github.com/01org/tbb
+	branch = tbb_2018
+[submodule "src/ATen/utils/catch"]
+	path = src/ATen/utils/catch
+	url = https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
Right now the standalone build of ATen is broken, because it gained a few dependencies. It should be enough to add this file manually to register them over there as well. I copied it over to the standalone repo and verified that it builds fine with them.

It would be good if we had a strategy for updating this file that's better than periodical manual updates, but this is at least a start.