### PR TITLE
Fix linking issue in libtorch under macOS

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -23,10 +23,6 @@ namespace py = pybind11;
 
 namespace torch { namespace jit {
 
-// Sigh, see https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
-constexpr Symbol CppOp::Kind;
-constexpr Symbol PythonOp::Kind;
-
 std::string getPythonName(const PyObject* obj, bool is_legacy) {
   AutoGIL gil;
   if (is_legacy) {
@@ -120,6 +116,10 @@ std::string PythonOp::name() const {
 
 
 namespace torch { namespace jit {
+
+// Sigh, see https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
+constexpr Symbol CppOp::Kind;
+constexpr Symbol PythonOp::Kind;
 
 constexpr int max_tensor_display_size = 10;
 


### PR DESCRIPTION
Since yesterday, building libtorch on my macOS results in the following link error:

```
Undefined symbols for architecture x86_64:
  "torch::jit::CppOp::Kind", referenced from:
      torch::jit::CppOp::cloneFrom(torch::jit::Node*) in function.cpp.o
ld: symbol(s) not found for architecture x86_64
```

~~Adding the definition for `torch::jit::CppOp::Kind` and `torch::jit::PythonOp::Kind` in `function.cpp` instead of `ir.cpp` fixes the issue, but I'm not sure it's the best solution.~~

UPDATE: `torch::jit::CppOp::Kind` and `torch::jit::PythonOp::Kind` in `ir.cpp` were inside a `NO_PYTHON` block (facepalm).