### PR TITLE
add mpi support for DDP

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -46,7 +46,9 @@ DISTRIBUTED_TESTS_CONFIG = {
     'nccl': {
         'WORLD_SIZE': '2'
     },
-    'mpi': {},
+    'mpi': {
+        'WORLD_SIZE': '3'
+    },
 }
 
 

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -836,9 +836,9 @@ class _DistTestBase(object):
         model = self._create_Net()
 
         # single gpu training setup
-        model_base = copy.deepcopy(model)
-        gpu_subset = list(rankToGPUMapping[rank])
-        model_base.cuda(gpu_subset[0])
+        model_gpu = copy.deepcopy(model)
+        gpu_subset = list(rank_to_GPU[rank])
+        model_gpu.cuda(gpu_subset[0])
 
         # DDP training setup
         model_DDP = copy.deepcopy(model)
@@ -850,7 +850,7 @@ class _DistTestBase(object):
         global_bs, input_cpu, target, loss = self._prepare_dummy_data(local_bs)
 
         # check two model parameters over 2 iterations
-        self._test_DDP_2iter(model_base,
+        self._test_DDP_2iter(model_gpu,
                              model_DDP,
                              input_cpu.cuda(gpu_subset[0]),
                              target.cuda(gpu_subset[0]),

--- a/torch/nn/parallel/__init__.py
+++ b/torch/nn/parallel/__init__.py
@@ -3,6 +3,7 @@ from .replicate import replicate
 from .data_parallel import DataParallel, data_parallel
 from .scatter_gather import scatter, gather
 from .distributed import DistributedDataParallel
+from .distributed_cpu import DistributedDataParallelCPU
 
 __all__ = ['replicate', 'scatter', 'parallel_apply', 'gather', 'data_parallel',
-           'DataParallel', 'DistributedDataParallel']
+           'DataParallel', 'DistributedDataParallel', 'DistributedDataParallelCPU']

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -248,7 +248,7 @@ class DistributedDataParallel(Module):
             outputs = self.parallel_apply(self._module_copies, inputs, kwargs)
             return self.gather(outputs, self.output_device)
         else:
-            #for cpu only with mpi backend
+            # for cpu only with mpi backend
             if self.first_call:
                 print("first broadcast start")
                 for param in self.module.parameters():

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -44,7 +44,7 @@ class DistributedDataParallel(Module):
     (see :func:`torch.distributed.init_process_group`).
 
     .. warning::
-        This module works only with the ``nccl``,``gloo``,``mpi`` backends.
+        This module works only with the ``nccl`` and ``gloo`` backends.
 
     .. warning::
         Constructor, forward method, and differentiation of the output (or a
@@ -102,125 +102,94 @@ class DistributedDataParallel(Module):
     def __init__(self, module, device_ids=None, output_device=None, dim=0,
                  broadcast_buffers=True):
         super(DistributedDataParallel, self).__init__()
-        if torch.cuda.is_available():
-            if device_ids is None:
-                device_ids = list(range(torch.cuda.device_count()))
-            if output_device is None:
-                output_device = device_ids[0]
-            self.dim = dim
-            self.module = module
-            self.device_ids = device_ids
-            self.output_device = output_device
-            self.broadcast_buffers = broadcast_buffers
+        if device_ids is None:
+            device_ids = list(range(torch.cuda.device_count()))
+        if output_device is None:
+            output_device = device_ids[0]
+        self.dim = dim
+        self.module = module
+        self.device_ids = device_ids
+        self.output_device = output_device
+        self.broadcast_buffers = broadcast_buffers
 
-            # Flag used by the NCCL backend to make sure we only reduce gradients
-            # one time in the execution engine
-            self.need_reduction = False
+        # Flag used by the NCCL backend to make sure we only reduce gradients
+        # one time in the execution engine
+        self.need_reduction = False
 
-            MB = 1024 * 1024
-            # used for intra-node param sync and inter-node sync as well
-            self.broadcast_bucket_size = 10 * MB
-            self.nccl_reduce_bucket_size = 256 * MB
+        MB = 1024 * 1024
+        # used for intra-node param sync and inter-node sync as well
+        self.broadcast_bucket_size = 10 * MB
+        self.nccl_reduce_bucket_size = 256 * MB
 
-            # Sync params and buffers
-            module_states = list(self.module.state_dict().values())
-            if len(module_states) > 0:
-                self._dist_broadcast_coalesced(module_states,
-                                               self.broadcast_bucket_size)
+        # Sync params and buffers
+        module_states = list(self.module.state_dict().values())
+        if len(module_states) > 0:
+            self._dist_broadcast_coalesced(module_states,
+                                           self.broadcast_bucket_size)
 
-            if len(device_ids) > 1:
-                # TODO: we don't need to replicate params in here. they're always going to
-                # be broadcasted using larger blocks in broadcast_coalesced, so it might be
-                # better to not pollute the caches with these small blocks
-                self._module_copies = replicate(self.module, self.device_ids, detach=True)
-                self._module_copies[0] = self.module
+        if len(device_ids) > 1:
+            # TODO: we don't need to replicate params in here. they're always going to
+            # be broadcasted using larger blocks in broadcast_coalesced, so it might be
+            # better to not pollute the caches with these small blocks
+            self._module_copies = replicate(self.module, self.device_ids, detach=True)
+            self._module_copies[0] = self.module
 
-                for module_copy in self._module_copies[1:]:
-                    for param, copy_param in zip(self.module.parameters(), module_copy.parameters()):
-                        copy_param.requires_grad = param.requires_grad
+            for module_copy in self._module_copies[1:]:
+                for param, copy_param in zip(self.module.parameters(), module_copy.parameters()):
+                    copy_param.requires_grad = param.requires_grad
 
-            else:
-                self._module_copies = [self.module]
-
-            # For NCCL backend, since every single NCCL call is asynchoronous, we
-            # therefore directly enqueue all the NCCL reduction calls to the
-            # default CUDA stream without spawning up other reduction threads.
-            # This achieves the best performance.
-            if dist._backend == dist.dist_backend.NCCL:
-                self._register_nccl_grad_hook()
-                return
-
-            bucket_bytes_cap = 1 * MB
-
-            # This is a triply-nested list where the "dimensions" are: devices, buckets, bucket_elems
-            param_buckets = []
-            # Split the parameters into buckets and by types as well
-            for dev_idx, module in enumerate(self._module_copies):
-                param_buckets.append(list(_take_tensors(module.parameters(), bucket_bytes_cap)))
-
-            self.bucket_sizes = []
-            self.bucket_map = {}
-
-            # We transpose param_buckets, so the loop is over buckets.
-            # param_buckets_tuple is a doubly-nested list with "dims": devices, bucket_elems
-            for bucket_idx, param_buckets_tuple in enumerate(zip(*param_buckets)):
-                self.bucket_sizes.append(0)
-                # Now, we transpose again, so we iterate over bucket_elems, but getting tuples
-                # of params from each device.
-                for idx, param_tuple in enumerate(zip(*param_buckets_tuple)):
-                    if idx == 0:
-                        # Bucket parameter type tracking
-                        bucket_param_type = param_tuple[0].type()
-                        # Only gloo and nccl support half-precision
-                        if bucket_param_type == torch.cuda.HalfTensor and \
-                                dist._backend != dist.dist_backend.GLOO:
-                            raise RuntimeError("DistributedDataParallel currently only "
-                                               "supports half precision parameters "
-                                               "with Nccl and Gloo backend")
-                    if not param_tuple[0].requires_grad:
-                        continue
-                    for p in param_tuple:
-                        self.bucket_map[p] = bucket_idx
-                    self.bucket_sizes[bucket_idx] += 1
-
-            self.buckets = [[[] for _ in range(len(self.device_ids))] for _ in range(len(self.bucket_sizes))]
-            self.bucket_events = [[None] * len(self.device_ids) for _ in range(len(self.bucket_sizes))]
-            self.reduced = [False] * len(self.bucket_sizes)
-
-            self._register_grad_hooks()
-
-            self.dispatch_lock = threading.Lock()
-            self._start_reduction_threads()
         else:
-            # for cpu only with mpi backend
-            self.first_call = True
-            self.module = module
+            self._module_copies = [self.module]
 
-            def allreduce_params():
-                if (self.needs_reduction):
-                    self.needs_reduction = False
-                    buckets = {}
-                    for param in self.module.parameters():
-                        if param.requires_grad and param.grad is not None:
-                            tp = type(param.data)
-                            if tp not in buckets:
-                                buckets[tp] = []
-                            buckets[tp].append(param)
+        # For NCCL backend, since every single NCCL call is asynchoronous, we
+        # therefore directly enqueue all the NCCL reduction calls to the
+        # default CUDA stream without spawning up other reduction threads.
+        # This achieves the best performance.
+        if dist._backend == dist.dist_backend.NCCL:
+            self._register_nccl_grad_hook()
+            return
 
-                    for tp in buckets:
-                        bucket = buckets[tp]
-                        grads = [param.grad.data for param in bucket]
-                        coalesced = _flatten_dense_tensors(grads)
-                        dist.all_reduce(coalesced)
-                        coalesced /= dist.get_world_size()
-                        for buf, synced in zip(grads, _unflatten_dense_tensors(coalesced, grads)):
-                            buf.copy_(synced)
+        bucket_bytes_cap = 1 * MB
 
-            for param in list(self.module.parameters()):
-                def allreduce_hook(*unused):
-                    param._execution_engine.queue_callback(allreduce_params)
-                if param.requires_grad:
-                    param.register_hook(allreduce_hook)
+        # This is a triply-nested list where the "dimensions" are: devices, buckets, bucket_elems
+        param_buckets = []
+        # Split the parameters into buckets and by types as well
+        for dev_idx, module in enumerate(self._module_copies):
+            param_buckets.append(list(_take_tensors(module.parameters(), bucket_bytes_cap)))
+
+        self.bucket_sizes = []
+        self.bucket_map = {}
+
+        # We transpose param_buckets, so the loop is over buckets.
+        # param_buckets_tuple is a doubly-nested list with "dims": devices, bucket_elems
+        for bucket_idx, param_buckets_tuple in enumerate(zip(*param_buckets)):
+            self.bucket_sizes.append(0)
+            # Now, we transpose again, so we iterate over bucket_elems, but getting tuples
+            # of params from each device.
+            for idx, param_tuple in enumerate(zip(*param_buckets_tuple)):
+                if idx == 0:
+                    # Bucket parameter type tracking
+                    bucket_param_type = param_tuple[0].type()
+                    # Only gloo and nccl support half-precision
+                    if bucket_param_type == torch.cuda.HalfTensor and \
+                            dist._backend != dist.dist_backend.GLOO:
+                        raise RuntimeError("DistributedDataParallel currently only "
+                                           "supports half precision parameters "
+                                           "with Nccl and Gloo backend")
+                if not param_tuple[0].requires_grad:
+                    continue
+                for p in param_tuple:
+                    self.bucket_map[p] = bucket_idx
+                self.bucket_sizes[bucket_idx] += 1
+
+        self.buckets = [[[] for _ in range(len(self.device_ids))] for _ in range(len(self.bucket_sizes))]
+        self.bucket_events = [[None] * len(self.device_ids) for _ in range(len(self.bucket_sizes))]
+        self.reduced = [False] * len(self.bucket_sizes)
+
+        self._register_grad_hooks()
+
+        self.dispatch_lock = threading.Lock()
+        self._start_reduction_threads()
 
     def __getstate__(self):
         attrs = copy.copy(self.__dict__)
@@ -239,24 +208,13 @@ class DistributedDataParallel(Module):
             self._start_reduction_threads()
 
     def forward(self, *inputs, **kwargs):
-        if torch.cuda.is_available():
-            self.need_reduction = True
-            inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
-            self._sync_params()
-            if len(self.device_ids) == 1:
-                return self.module(*inputs[0], **kwargs[0])
-            outputs = self.parallel_apply(self._module_copies, inputs, kwargs)
-            return self.gather(outputs, self.output_device)
-        else:
-            # for cpu only with mpi backend
-            if self.first_call:
-                print("first broadcast start")
-                for param in self.module.parameters():
-                    dist.broadcast(param.data, 0)
-                self.first_call = False
-                print("first broadcast done")
-            self.needs_reduction = True
-            return self.module(*inputs, **kwargs)
+        self.need_reduction = True
+        inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+        self._sync_params()
+        if len(self.device_ids) == 1:
+            return self.module(*inputs[0], **kwargs[0])
+        outputs = self.parallel_apply(self._module_copies, inputs, kwargs)
+        return self.gather(outputs, self.output_device)
 
     def scatter(self, inputs, kwargs, device_ids):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -1,0 +1,112 @@
+import torch
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
+import torch.distributed as dist
+from torch.nn.modules import Module
+
+
+class DistributedDataParallelCPU(Module):
+    r"""Implements distributed data parallelism for CPU at the module level.
+
+    This container parallelizes the application of the given module by
+    splitting the input across the specified devices by chunking in the batch
+    dimension. The module is replicated on each machine, and each such replica 
+    handles a portion of the input. During the backwards pass, gradients from 
+    each node are averaged.
+
+    This module should be used in conjunction with the DistributedSampler,
+    (see :class `torch.utils.data.distributed.DistributedSampler`)
+    which will load a subset of the original datset for each node with the same
+    batch size. So weak scaling should be configed like this:
+        n = 1, batch size = 128
+        n = 2, batch size = 64
+        n = 4, batch size = 32
+        n = 8, batch size = 16
+
+    Creation of this class requires the distributed package to be already
+    initialized in the process group mode
+    (see :func:`torch.distributed.init_process_group`).
+
+    .. warning::
+        This module works only with the ``mpi`` backends.
+        The other backends like ``gloo``, ``tcp`` are not tested yet.
+
+    .. warning::
+        Constructor, forward method, and differentiation of the output (or a
+        function of the output of this module) is a distributed synchronization
+        point. Take that into account in case different processes might be
+        executing different code.
+
+    .. warning::
+        This module assumes all parameters are registered in the model by the
+        time it is created. No parameters should be added nor removed later.
+
+    .. warning::
+        This module assumes all gradients are dense.
+
+    .. warning::
+        This module doesn't work with :func:`torch.autograd.grad` (i.e. it will
+        only work if gradients are to be accumulated in ``.grad`` attributes of
+        parameters).
+
+    .. note::
+        Parameters are broadcast between nodes in the first forward. The
+        module performs an all-reduce step on gradients and assumes that they 
+        will be modified by the optimizer in all processes in the same way.
+
+    .. warning::
+        Forward and backward hooks defined on :attr:`module` and its submodules
+        won't be invoked anymore, unless the hooks are initialized in the
+        :meth:`forward` method.
+
+    Args:
+        module: module to be parallelized
+
+    Example::
+
+        >>> torch.distributed.init_process_group(world_size=4, init_method='...')
+        >>> net = torch.nn.DistributedDataParallelCPU(model)
+    """
+
+    def __init__(self, module):
+        super(DistributedDataParallelCPU, self).__init__()
+        self.module = module
+        self.first_call = True
+
+        def allreduce_params():
+            if (self.needs_reduction):
+                self.needs_reduction = False
+                buckets = {}
+                for param in self.module.parameters():
+                    if param.requires_grad and param.grad is not None:
+                        tp = type(param.data)
+                        if tp not in buckets:
+                            buckets[tp] = []
+                        buckets[tp].append(param)
+
+                for tp in buckets:
+                    bucket = buckets[tp]
+                    grads = [param.grad.data for param in bucket]
+                    coalesced = _flatten_dense_tensors(grads)
+                    dist.all_reduce(coalesced)
+                    coalesced /= dist.get_world_size()
+                    for buf, synced in zip(grads, _unflatten_dense_tensors(coalesced, grads)):
+                        buf.copy_(synced)
+
+        for param in list(self.module.parameters()):
+            def allreduce_hook(*unused):
+                param._execution_engine.queue_callback(allreduce_params)
+
+            if param.requires_grad:
+                param.register_hook(allreduce_hook)
+
+    def weight_broadcast(self):
+        # broadcase the wight in the first call
+        for param in self.module.parameters():
+            dist.broadcast(param.data, 0)
+
+    def forward(self, *inputs, **kwargs):
+        if self.first_call:
+            self.weight_broadcast()
+            self.first_call = False
+        self.needs_reduction = True
+        return self.module(*inputs, **kwargs)

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -17,10 +17,10 @@ class DistributedDataParallelCPU(Module):
     handles a portion of the input. During the backwards pass, gradients from
     each node are averaged.
 
-    This module should be used in conjunction with the DistributedSampler,
+    This module could be used in conjunction with the DistributedSampler,
     (see :class `torch.utils.data.distributed.DistributedSampler`)
     which will load a subset of the original datset for each node with the same
-    batch size. So weak scaling should be configed like this:
+    batch size. So strong scaling should be configured like this:
         n = 1, batch size = 128
         n = 2, batch size = 64
         n = 4, batch size = 32
@@ -33,7 +33,7 @@ class DistributedDataParallelCPU(Module):
     .. warning::
         Constructor, forward method, and differentiation of the output (or a
         function of the output of this module) is a distributed synchronization
-        point. Take that into account in case different processes might be
+        point. Take that into account in case different node might be
         executing different code.
 
     .. warning::
@@ -51,7 +51,7 @@ class DistributedDataParallelCPU(Module):
     .. note::
         Parameters are broadcast between nodes in the __init__() function. The
         module performs an all-reduce step on gradients and assumes that they
-        will be modified by the optimizer in all processes in the same way.
+        will be modified by the optimizer in all nodes in the same way.
 
     .. warning::
         Forward and backward hooks defined on :attr:`module` and its submodules

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -4,6 +4,7 @@ import torch.distributed as dist
 from torch.nn.modules import Module
 from collections import defaultdict
 
+
 class DistributedDataParallelCPU(Module):
     r"""Implements distributed data parallelism for CPU at the module level.
 

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -9,8 +9,8 @@ class DistributedDataParallelCPU(Module):
 
     This container parallelizes the application of the given module by
     splitting the input across the specified devices by chunking in the batch
-    dimension. The module is replicated on each machine, and each such replica 
-    handles a portion of the input. During the backwards pass, gradients from 
+    dimension. The module is replicated on each machine, and each such replica
+    handles a portion of the input. During the backwards pass, gradients from
     each node are averaged.
 
     This module should be used in conjunction with the DistributedSampler,
@@ -50,7 +50,7 @@ class DistributedDataParallelCPU(Module):
 
     .. note::
         Parameters are broadcast between nodes in the first forward. The
-        module performs an all-reduce step on gradients and assumes that they 
+        module performs an all-reduce step on gradients and assumes that they
         will be modified by the optimizer in all processes in the same way.
 
     .. warning::

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -3,6 +3,7 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 import torch.distributed as dist
 from torch.nn.modules import Module
 from collections import defaultdict
+from torch.autograd import Variable
 
 
 class DistributedDataParallelCPU(Module):
@@ -90,7 +91,7 @@ class DistributedDataParallelCPU(Module):
 
         for param in list(self.module.parameters()):
             def allreduce_hook(*unused):
-                param._execution_engine.queue_callback(allreduce_params)
+                Variable._execution_engine.queue_callback(allreduce_params)
 
             if param.requires_grad:
                 param.register_hook(allreduce_hook)

--- a/torch/nn/parallel/distributed_cpu.py
+++ b/torch/nn/parallel/distributed_cpu.py
@@ -70,7 +70,7 @@ class DistributedDataParallelCPU(Module):
     def __init__(self, module):
         super(DistributedDataParallelCPU, self).__init__()
         self.module = module
-        self.weight_broadcast()
+        self.sync_parameters()
 
         def allreduce_params():
             if self.needs_reduction:
@@ -96,8 +96,7 @@ class DistributedDataParallelCPU(Module):
             if param.requires_grad:
                 param.register_hook(allreduce_hook)
 
-    def weight_broadcast(self):
-        # broadcase the wight in the __init__ function
+    def sync_parameters(self):
         for param in self.module.parameters():
             dist.broadcast(param.data, 0)
 


### PR DESCRIPTION
- overview
this PR target is to add mpi support for torch.nn.parallel.DistributedDataParallel().
AFAIK, PyTorch DDP only support nccl and gloo backend, and i think it would be great to support mpi backend when the user get CPU only, especially for the researcher with supper computer access.
reference [issue](https://github.com/pytorch/pytorch/issues/5868)

- code change:
i only add some lines in the __init__() and forward() function, without any change for the cuda code (except for the indent).

- validation:
this code passed my test case for the mnist example: https://github.com/xhzhao/examples/tree/master/mnist
i'm also looking to add one more case in [pytorch/test/test_distributed.py](https://github.com/pytorch/pytorch/blob/master/test/test_distributed.py), but i could not find a method to launch mpi task from python. hope this problem will be fixed in the future.