### PR TITLE
fix Nesterov Momentum Bug

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -93,7 +93,7 @@ class SGD(Optimizer):
                         buf = param_state['momentum_buffer']
                         buf.mul_(momentum).add_(1 - dampening, d_p)
                     if nesterov:
-                        d_p = d_p.add(momentum, buf)
+                        d_p.add_(momentum, buf)
                     else:
                         d_p = buf
 

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -93,7 +93,7 @@ class SGD(Optimizer):
                         buf = param_state['momentum_buffer']
                         buf.mul_(momentum).add_(1 - dampening, d_p)
                     if nesterov:
-                        d_p.add_(momentum, buf)
+                        d_p = buf.add(momentum, buf)
                     else:
                         d_p = buf
 


### PR DESCRIPTION
According to Nesterov momentum formula from 'On the importance of initialization and momentum in deep learning', the update can be written as (with PyTorch's subtly differs):

(1) v_{t+1} = \mu * v_t + g(\theta_t - lr * \mu * v_t),
(2) \theta_{t+1} = \theta_{t} - lr * v_{t+1}.

If we unroll the above equations, we have:

(1) v_{t+1} = \mu * v_t + g(\theta_t - lr * \mu * v_t),
(2) \theta_{t+1} = \theta_t - lr * v_{t+1},
(3) \theta'_{t+1} = \theta_{t+1} - lr * \mu * v_{t+1} = \theta_{t+1} - lr * (1 + \mu) * v_{t+1}.

Therefore, the 96th line in sgd.py should be modified like commit, and the actual output model of NAG is \theta'_{t+1}.


