### PR TITLE
Deprecate ctx.saved_variables via python warning.

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -60,7 +60,7 @@ additional comments::
             # None. Thanks to the fact that additional trailing Nones are
             # ignored, the return statement is simple even when the function has
             # optional inputs.
-            input, weight, bias = ctx.saved_variables
+            input, weight, bias = ctx.saved_tensors
             grad_input = grad_weight = grad_bias = None
 
             # These needs_input_grad checks are optional and there only to

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -96,7 +96,7 @@ class TestAutograd(TestCase):
 
             @staticmethod
             def backward(ctx, grad_output):
-                var1, var2 = ctx.saved_variables
+                var1, var2 = ctx.saved_tensors
                 # NOTE: self is the test case here
                 self.assertIsInstance(var1, Variable)
                 self.assertIsInstance(var2, Variable)
@@ -606,7 +606,7 @@ class TestAutograd(TestCase):
 
             @staticmethod
             def backward(ctx, grad_b):
-                b, = ctx.saved_variables
+                b, = ctx.saved_tensors
                 self.assertEqual(b.output_nr, 1)
 
         TestFn.apply(b).sum().backward()

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -445,7 +445,7 @@ class TestJit(TestCase):
 
             @staticmethod
             def backward(ctx, grad_a):
-                a, = ctx.saved_variables
+                a, = ctx.saved_tensors
                 return a * grad_a
 
         x = Variable(torch.randn(10, 10), requires_grad=True)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -140,7 +140,7 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
         >>>
         >>>     @staticmethod
         >>>     def backward(ctx, grad_output):
-        >>>         result, = ctx.saved_variables
+        >>>         result, = ctx.saved_tensors
         >>>         return grad_output * result
     """
 
@@ -197,7 +197,7 @@ def once_differentiable(fn):
         # to have requires_grad=True but point to a grad_fn which throws an
         # error message during (double) back-propagation.
         # XXX: this is only an approximation of requires_grad - there's no way
-        # to figure out if fn didn't use ctx.saved_variables and as a result
+        # to figure out if fn didn't use ctx.saved_tensors and as a result
         # some Variables might require grad, even if no args do.
         # Unfortunately, this leads to unexpected error messages ("no nodes
         # require computing gradients"), but I don't have a better idea.

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -918,11 +918,9 @@ PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 PyObject *THPFunction_saved_variables(THPFunction *self, void *_unused)
 {
   HANDLE_TH_ERRORS
-  THPObjectPtr warnings(PyImport_ImportModule("warnings"));
-  if (!warnings) throw python_error();
-  THPObjectPtr result(PyObject_CallMethod(warnings.get(), "warn", "s",
-      "'saved_variables' is deprecated; use 'saved_tensors'"));
-  if (!result) throw python_error();
+  auto r = PyErr_WarnEx(PyExc_DeprecationWarning,
+      "'saved_variables' is deprecated; use 'saved_tensors'", 0);
+  if (r != 0) throw python_error();
   return unpack_saved_variables(self, [](const Variable& var) {
     return THPVariable_Wrap(var);
   });

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -78,7 +78,7 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
   }
 
   // XXX: this might get requires_grad wrong - there's no way to figure out
-  // if _do_backward didn't use ctx.saved_variables and as a result some
+  // if _do_backward didn't use ctx.saved_tensors and as a result some
   // Variables might require grad, even if no args do. Unfortunately, this
   // leads to unexpected error messages ("no nodes require computing gradients"),
   // but I don't have a better idea. These functions would raise an error
@@ -918,6 +918,11 @@ PyObject *THPFunction_saved_tensors(THPFunction *self, void *_unused)
 PyObject *THPFunction_saved_variables(THPFunction *self, void *_unused)
 {
   HANDLE_TH_ERRORS
+  THPObjectPtr warnings(PyImport_ImportModule("warnings"));
+  if (!warnings) throw python_error();
+  THPObjectPtr result(PyObject_CallMethod(warnings.get(), "warn", "s",
+      "'saved_variables' is deprecated; use 'saved_tensors'"));
+  if (!result) throw python_error();
   return unpack_saved_variables(self, [](const Variable& var) {
     return THPVariable_Wrap(var);
   });

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -61,7 +61,7 @@ def _make_function_class_criterion(class_name, update_output, update_grad_input,
 
     @staticmethod
     def backward(ctx, grad_output):
-        input, target = ctx.saved_variables
+        input, target = ctx.saved_tensors
         # apply returns grad_input, so we need to return Nones for target (1) + 1 for each extra arg passed to forward.
         return ((backward_cls.apply(input, target, grad_output, ctx.additional_args, ctx._backend),) +
                 (None,) * (ctx.forward_args_count + 1))
@@ -199,7 +199,7 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
 
     @staticmethod
     def backward(ctx, grad_output):
-        t = ctx.saved_variables
+        t = ctx.saved_tensors
         input, tensor_params = t[0], t[1:]
         # Some notes on this function call:
         # 1) We need to pass params as *params so they are unwrapped correctly in backward_cls_forward.

--- a/torch/nn/_functions/thnn/auto_double_backwards.py
+++ b/torch/nn/_functions/thnn/auto_double_backwards.py
@@ -3,7 +3,7 @@ import torch
 
 
 def elu_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input, grad_output = t[0], t[1]
     alpha = ctx.additional_args[0]
 
@@ -17,7 +17,7 @@ def elu_double_backwards(ctx, ggI):
 
 
 def gatedlinear_double_backwards(ctx, ggI):
-    input, gO = ctx.saved_variables
+    input, gO = ctx.saved_tensors
     dim = ctx.additional_args[0]
 
     input_size = input.size(dim) // 2
@@ -43,7 +43,7 @@ def gatedlinear_double_backwards(ctx, ggI):
 
 
 def hardshrink_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input = t[0]
     lambd = ctx.additional_args[0]
     gI = None
@@ -55,7 +55,7 @@ def hardshrink_double_backwards(ctx, ggI):
 
 
 def hardtanh_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input, grad_output = t[0], t[1]
     min_val, max_val = ctx.additional_args[0:2]
 
@@ -67,7 +67,7 @@ def hardtanh_double_backwards(ctx, ggI):
 
 
 def leakyrelu_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input = t[0]
     negative_slope = ctx.additional_args[0]
 
@@ -79,7 +79,7 @@ def leakyrelu_double_backwards(ctx, ggI):
 
 
 def logsigmoid_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     # maybe more efficient in terms of output, but save_output is False
     input, gO = t[0], t[1]
 
@@ -92,7 +92,7 @@ def logsigmoid_double_backwards(ctx, ggI):
 
 
 def softplus_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input, gO, output = t[0], t[1], t[2]
     beta, threshold = ctx.additional_args[0], ctx.additional_args[1]
 
@@ -115,7 +115,7 @@ def softshrink_double_backwards(ctx, ggI):
 
 
 def threshold_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     input = t[0]
     threshold, value = ctx.additional_args[0:2]
 
@@ -127,7 +127,7 @@ def threshold_double_backwards(ctx, ggI):
 
 def klddivloss_double_backwards(ctx, ggI):
     size_average = ctx.additional_args[0]
-    input, target, gO = ctx.saved_variables
+    input, target, gO = ctx.saved_tensors
     div_factor = input.nelement() if size_average else 1
 
     gI = None
@@ -138,7 +138,7 @@ def klddivloss_double_backwards(ctx, ggI):
 
 def l1loss_double_backwards(ctx, ggI):
     size_average = ctx.additional_args[0]
-    input, target, grad_output = ctx.saved_variables
+    input, target, grad_output = ctx.saved_tensors
     gI = Variable(ggI.data.new(ggI.size()).zero_())
 
     positive_mask = (input > target).type_as(ggI)
@@ -152,7 +152,7 @@ def l1loss_double_backwards(ctx, ggI):
 def mseloss_double_backwards(ctx, ggI):
     size_average = ctx.additional_args[0]
     reduce = ctx.additional_args[1]
-    input, target, gO = ctx.saved_variables
+    input, target, gO = ctx.saved_tensors
     div_factor = input.nelement() if size_average and reduce else 1
 
     gI = ggI * (gO * 2. / div_factor).expand_as(input)
@@ -165,7 +165,7 @@ def mseloss_double_backwards(ctx, ggI):
 
 
 def nllloss_double_backwards(ctx, ggI):
-    t = ctx.saved_variables
+    t = ctx.saved_tensors
     target = t[1]
     weights = Variable(ctx.additional_args[1])
     size_average = ctx.additional_args[0]
@@ -206,7 +206,7 @@ def nllloss_double_backwards(ctx, ggI):
 
 def smoothl1loss_double_backwards(ctx, ggI):
     size_average = ctx.additional_args[0]
-    input, target, gO = ctx.saved_variables
+    input, target, gO = ctx.saved_tensors
     div_factor = input.nelement() if size_average else 1
 
     input_sub_target = input - target
@@ -224,7 +224,7 @@ def smoothl1loss_double_backwards(ctx, ggI):
 
 def softmarginloss_double_backwards(ctx, ggI):
     size_average = ctx.additional_args[0]
-    input, target, gO = ctx.saved_variables
+    input, target, gO = ctx.saved_tensors
     div_factor = input.nelement() if size_average else 1
 
     t0 = (1 + (-target * input).exp()).pow(-1)


### PR DESCRIPTION
As suggested in #5907. I'm trying to keep that PR to mostly doc changes so opening this one for this deprecation.

Advises replacing saved_variables with saved_tensors.
Also replaces all instances of ctx.saved_variables with ctx.saved_tensors in the
codebase.

cc @apaszke @colesbury 

Test by running:
```
import torch
from torch.autograd import Function

class MyFunction(Function):
    @staticmethod
    def forward(ctx, tensor1, tensor2):
        ctx.save_for_backward(tensor1, tensor2)
        return tensor1 + tensor2

    @staticmethod
    def backward(ctx, grad_output):
        var1, var2 = ctx.saved_variables
        return (grad_output, grad_output)

x = torch.randn((3, 3), requires_grad=True)
y = torch.randn((3, 3), requires_grad=True)
model = MyFunction()
model.apply(x, y).sum().backward()
```
and assert the warning shows up.