### PR TITLE
Linearly interpolating upsampling fix

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -206,17 +206,17 @@
 # Note: The upsampling backwards functions also include an IntList input_size
 # parameter, which is added by nn_parse.py
 
-- name: upsample_linear1d(Tensor self, IntList[1] output_size)
+- name: upsample_linear1d(Tensor self, IntList[1] output_size, bool align_corners)
   cname: TemporalUpSamplingLinear
   scalar_check:
     grad_input: 'false'
 
-- name: upsample_bilinear2d(Tensor self, IntList[2] output_size)
+- name: upsample_bilinear2d(Tensor self, IntList[2] output_size, bool align_corners)
   cname: SpatialUpSamplingBilinear
   scalar_check:
     grad_input: 'false'
 
-- name: upsample_trilinear3d(Tensor self, IntList[3] output_size)
+- name: upsample_trilinear3d(Tensor self, IntList[3] output_size, bool align_corners)
   cname: VolumetricUpSamplingTrilinear
   scalar_check:
     grad_input: 'false'

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -286,18 +286,22 @@ def backward_declaration(base, thnn_functions):
                   if arg['name'] != 'inplace']
     arguments += base['buffers']
 
+    if 'upsample' in base['name']:
+        # Add input_size as parameter to upsample backwards functions
+        # Note that input_size is 4-dim for upsample_xxx2d
+        size = 2 + int(re.search(r'(\d+)d', base['name']).group(1))
+        input_size_arg = {'type': 'IntList', 'name': 'input_size', 'size': size}
+        for output_size_idx, arg in enumerate(arguments):
+            if arg['name'] == 'output_size':
+                break
+        arguments.insert(output_size_idx + 1, input_size_arg)
+
     # outputs from the forward may be inputs to the backwards
     for arg in arguments:
         if 'output' in arg:
             del arg['output']
 
     arguments += unique_args([output_arguments(f) for f in thnn_functions])
-
-    if 'upsample' in base['name']:
-        # Add input_size as parameter to upsample backwards functions
-        # Note that input_size is 4-dim for upsample_xxx2d
-        size = 2 + int(re.search(r'(\d+)d', base['name']).group(1))
-        arguments.append({'type': 'IntList', 'name': 'input_size', 'size': size})
 
     def initialize_output_arg(arg):
         # the mask array<bool, N> specifies which return values to compute

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -232,7 +232,7 @@ static void test(Type & type) {
     for (int64_t i = 0; i < tensor.numel(); ++i) {
       REQUIRE(tensor[i].equal(one * i));
     }
-    for (size_t i = 0; i < tensor.numel(); ++i) {
+    for (size_t i = 0; i < (uint64_t) tensor.numel(); ++i) {
       REQUIRE(tensor[i].equal(one * static_cast<int64_t>(i)));
     }
     for (int i = 0; i < tensor.numel(); ++i) {

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -232,7 +232,7 @@ static void test(Type & type) {
     for (int64_t i = 0; i < tensor.numel(); ++i) {
       REQUIRE(tensor[i].equal(one * i));
     }
-    for (size_t i = 0; i < (uint64_t) tensor.numel(); ++i) {
+    for (size_t i = 0; i < static_cast<uint64_t>(tensor.numel()); ++i) {
       REQUIRE(tensor[i].equal(one * static_cast<int64_t>(i)));
     }
     for (int i = 0; i < tensor.numel(); ++i) {

--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -37,13 +37,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = rheight * h2;
+    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -89,13 +89,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = rheight * h2;
+    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -2,6 +2,7 @@
 // Originally developed by George Papandreou
 #include "THCUNN.h"
 #include "common.h"
+#include "linear_upsampling.h"
 #include "THCDeviceTensor.cuh"
 #include "THCDeviceTensorUtils.cuh"
 #include "THCDeviceUtils.cuh"
@@ -11,7 +12,7 @@
 
 template<typename Dtype, typename Acctype>
 __global__ void caffe_gpu_interp2_kernel(const int n,
-    const Acctype rheight, const Acctype rwidth,
+    const Acctype rheight, const Acctype rwidth, const bool align_corners,
     const THCDeviceTensor<Dtype, 4> data1, THCDeviceTensor<Dtype, 4> data2) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   const int batchsize = data1.getSize(0);
@@ -37,13 +38,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -64,7 +65,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename Dtype, typename Acctype>
 __global__ void caffe_gpu_interp2_kernel_backward(const int n,
-    const Acctype rheight, const Acctype rwidth,
+    const Acctype rheight, const Acctype rwidth, const bool align_corners,
     THCDeviceTensor<Dtype, 4> data1, const THCDeviceTensor<Dtype, 4> data2){
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   const int batchsize = data1.getSize(0);
@@ -89,13 +90,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = (h2 > 0) ? rheight * (h2 - Acctype(0.5)) : Acctype(0);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = (w2 > 0) ? rwidth * (w2 - Acctype(0.5)) : Acctype(0);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/TemporalUpSamplingLinear.cu
@@ -2,6 +2,7 @@
 // Originally developed by George Papandreou
 #include "THCUNN.h"
 #include "common.h"
+#include "linear_upsampling.h"
 #include "THCDeviceTensor.cuh"
 #include "THCDeviceTensorUtils.cuh"
 #include "THCDeviceUtils.cuh"
@@ -11,7 +12,7 @@
 
 template<typename Dtype, typename Acctype>
 __global__ void caffe_gpu_interp2_kernel(const int n,
-    const Acctype rwidth,
+    const Acctype rwidth, const bool align_corners,
     const THCDeviceTensor<Dtype, 3> data1, THCDeviceTensor<Dtype, 3> data2) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   const int batchsize = data1.getSize(0);
@@ -33,7 +34,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -52,7 +53,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename Dtype, typename Acctype>
 __global__ void caffe_gpu_interp2_kernel_backward(const int n,
-    const Acctype rwidth,
+    const Acctype rwidth, const bool align_corners,
     THCDeviceTensor<Dtype, 3> data1, const THCDeviceTensor<Dtype, 3> data2){
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   const int batchsize = data1.getSize(0);
@@ -73,7 +74,7 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype w1r = rwidth * w2;
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -52,8 +52,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   THCDeviceTensor<real, 4> idata = toDeviceTensor<real, 4>(state, input);
   THCDeviceTensor<real, 4> odata = toDeviceTensor<real, 4>(state, output);
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rheight= (outputHeight > 1) ? (accreal)(inputHeight - 1)/(outputHeight - 1) : accreal(0);
-  const accreal rwidth = (outputWidth > 1) ? (accreal)(inputWidth - 1)/(outputWidth - 1) : accreal(0);
+  const accreal rheight= (outputHeight > 1) ? (accreal)inputHeight / outputHeight : accreal(0);
+  const accreal rwidth = (outputWidth > 1) ? (accreal)inputWidth / outputWidth : accreal(0);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
@@ -93,8 +93,8 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   int height2 = data2.getSize(2);
   int width2 = data2.getSize(3);
   assert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
-  const accreal rheight= (height2 > 1) ? (accreal)(height1 - 1)/(height2 - 1) : accreal(0);
-  const accreal rwidth = (width2 > 1) ? (accreal)(width1 - 1) / (width2 - 1) : accreal(0);
+  const accreal rheight= (height2 > 1) ? (accreal)height1 / height2 : accreal(0);
+  const accreal rwidth = (width2 > 1) ? (accreal)width1 / width2 : accreal(0);
   const int num_kernels = height2 * width2;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/SpatialUpSamplingBilinear.cu"
 #else
 
+#include "../linear_upsampling.h"
+
 static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
                         (THCState *state,
                          THCTensor *input, THCTensor *gradOutput,
@@ -31,7 +33,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
            THCTensor *input,
            THCTensor *output,
            int outputHeight,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   int nbatch = THCTensor_(size)(state, input, 0);
   int channels = THCTensor_(size)(state, input, 1);
@@ -52,14 +55,14 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   THCDeviceTensor<real, 4> idata = toDeviceTensor<real, 4>(state, input);
   THCDeviceTensor<real, 4> odata = toDeviceTensor<real, 4>(state, output);
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rheight= (outputHeight > 1) ? (accreal)inputHeight / outputHeight : accreal(0);
-  const accreal rwidth = (outputWidth > 1) ? (accreal)inputWidth / outputWidth : accreal(0);
+  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<real, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
-   0 , stream>>>(num_kernels, rheight, rwidth, idata, odata);
+   0 , stream>>>(num_kernels, rheight, rwidth, align_corners, idata, odata);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, input);
 }
@@ -74,7 +77,8 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
            int inputHeight,
            int inputWidth,
            int outputHeight,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   THNN_(SpatialUpSamplingBilinear_shapeCheck)
        (state, NULL, gradOutput,
@@ -93,14 +97,14 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   int height2 = data2.getSize(2);
   int width2 = data2.getSize(3);
   assert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
-  const accreal rheight= (height2 > 1) ? (accreal)height1 / height2 : accreal(0);
-  const accreal rwidth = (width2 > 1) ? (accreal)width1 / width2 : accreal(0);
+  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = height2 * width2;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<real ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
-  num_threads, 0, stream>>>(num_kernels, rheight, rwidth, data1, data2);
+  num_threads, 0, stream>>>(num_kernels, rheight, rwidth, align_corners, data1, data2);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, gradInput);
   THCTensor_(free)(state, gradOutput);

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -92,14 +92,9 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<real, 4> data1 = toDeviceTensor<real, 4>(state, gradInput);
   THCDeviceTensor<real, 4> data2 = toDeviceTensor<real, 4>(state, gradOutput);
-  int height1 = data1.getSize(2);
-  int width1 = data1.getSize(3);
-  int height2 = data2.getSize(2);
-  int width2 = data2.getSize(3);
-  assert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
   const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
-  const int num_kernels = height2 * width2;
+  const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -1042,7 +1042,8 @@ TH_API void THNN_(SpatialUpSamplingBilinear_updateOutput)(
                   THCTensor *input,
                   THCTensor *output,
                   int outputHeight,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
                   THCState *state,
@@ -1053,7 +1054,8 @@ TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
                   int inputHeight,
                   int inputWidth,
                   int outputHeight,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 TH_API void THNN_(SpatialUpSamplingNearest_updateGradInput)(
                   THCState *state,
@@ -1336,7 +1338,8 @@ TH_API void THNN_(TemporalUpSamplingLinear_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 TH_API void THNN_(TemporalUpSamplingLinear_updateGradInput)(
                   THCState *state,
@@ -1345,7 +1348,8 @@ TH_API void THNN_(TemporalUpSamplingLinear_updateGradInput)(
                   int nbatch,
                   int nchannels,
                   int inputWidth,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 TH_API void THNN_(TemporalUpSamplingNearest_updateGradInput)(
                   THCState *state,
@@ -1701,7 +1705,8 @@ TH_API void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
                   THCTensor *output,
                   int outputDepth,
                   int outputHeight,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
                   THCState *state,
@@ -1714,6 +1719,7 @@ TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
                   int inputWidth,
                   int outputDepth,
                   int outputHeight,
-                  int outputWidth);
+                  int outputWidth,
+                  bool align_corners);
 
 #endif

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/TemporalUpSamplingLinear.cu"
 #else
 
+#include "../linear_upsampling.h"
+
 static inline void THNN_(TemporalUpSamplingLinear_shapeCheck)
                         (THCState *state,
                          THCTensor *input, THCTensor *gradOutput,
@@ -28,7 +30,8 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
            THCState *state,
            THCTensor *input,
            THCTensor *output,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   int nbatch = THCTensor_(size)(state, input, 0);
   int channels = THCTensor_(size)(state, input, 1);
@@ -47,13 +50,13 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
   THCDeviceTensor<real, 3> idata = toDeviceTensor<real, 3>(state, input);
   THCDeviceTensor<real, 3> odata = toDeviceTensor<real, 3>(state, output);
   THAssert(inputWidth > 0 && outputWidth > 0);
-  const accreal rwidth = (outputWidth > 1) ? (accreal)(inputWidth - 1)/(outputWidth - 1) : accreal(0);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<real, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
-   0 , stream>>>(num_kernels, rwidth, idata, odata);
+   0 , stream>>>(num_kernels, rwidth, align_corners, idata, odata);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, input);
 }
@@ -66,7 +69,8 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
            int nbatch,
            int nchannels,
            int inputWidth,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   THNN_(TemporalUpSamplingLinear_shapeCheck)
        (state, NULL, gradOutput,
@@ -82,13 +86,13 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
   int width1 = data1.getSize(2);
   int width2 = data2.getSize(2);
   assert(width1 > 0 && width2 > 0);
-  const accreal rwidth = (width2 > 1) ? (accreal)(width1 - 1) / (width2 - 1) : accreal(0);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = width2;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<real ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
-  num_threads, 0, stream>>>(num_kernels, rwidth, data1, data2);
+  num_threads, 0, stream>>>(num_kernels, rwidth, align_corners, data1, data2);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, gradInput);
   THCTensor_(free)(state, gradOutput);

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -83,11 +83,8 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<real, 3> data1 = toDeviceTensor<real, 3>(state, gradInput);
   THCDeviceTensor<real, 3> data2 = toDeviceTensor<real, 3>(state, gradOutput);
-  int width1 = data1.getSize(2);
-  int width2 = data2.getSize(2);
-  assert(width1 > 0 && width2 > 0);
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
-  const int num_kernels = width2;
+  const int num_kernels = outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -98,17 +98,10 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<real, 5> data1 = toDeviceTensor<real, 5>(state, gradInput);
   THCDeviceTensor<real, 5> data2 = toDeviceTensor<real, 5>(state, gradOutput);
-  int depth1 = data1.getSize(2);
-  int height1 = data1.getSize(3);
-  int width1 = data1.getSize(4);
-  int depth2 = data2.getSize(2);
-  int height2 = data2.getSize(3);
-  int width2 = data2.getSize(4);
-  assert(depth1 > 0 && height1 > 0 && width1 > 0 && depth2 > 0 && height2 > 0 && width2 > 0);
   const accreal rdepth = linear_upsampling_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
   const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
-  const int num_kernels = depth2 * height2 * width2;
+  const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "generic/VolumetricUpSamplingTrilinear.cu"
 #else
 
+#include "../linear_upsampling.h"
+
 static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
                         (THCState *state,
                          THCTensor *input, THCTensor *gradOutput,
@@ -33,7 +35,8 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
            THCTensor *output,
            int outputDepth,
            int outputHeight,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   int nbatch = THCTensor_(size)(state, input, 0);
   int channels = THCTensor_(size)(state, input, 1);
@@ -55,15 +58,15 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
   THCDeviceTensor<real, 5> idata = toDeviceTensor<real, 5>(state, input);
   THCDeviceTensor<real, 5> odata = toDeviceTensor<real, 5>(state, output);
   THAssert(inputDepth > 0 && inputHeight > 0 && inputWidth > 0 && outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rdepth= (outputDepth > 1) ? (accreal)(inputDepth - 1)/(outputDepth - 1) : accreal(0);
-  const accreal rheight= (outputHeight > 1) ? (accreal)(inputHeight - 1)/(outputHeight - 1) : accreal(0);
-  const accreal rwidth = (outputWidth > 1) ? (accreal)(inputWidth - 1)/(outputWidth - 1) : accreal(0);
+  const accreal rdepth = linear_upsampling_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<real, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
-   0 , stream>>>(num_kernels, rdepth, rheight, rwidth, idata, odata);
+   0 , stream>>>(num_kernels, rdepth, rheight, rwidth, align_corners, idata, odata);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, input);
 }
@@ -80,7 +83,8 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
            int inputWidth,
            int outputDepth,
            int outputHeight,
-           int outputWidth)
+           int outputWidth,
+           bool align_corners)
 {
   THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
        (state, NULL, gradOutput,
@@ -101,15 +105,15 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
   int height2 = data2.getSize(3);
   int width2 = data2.getSize(4);
   assert(depth1 > 0 && height1 > 0 && width1 > 0 && depth2 > 0 && height2 > 0 && width2 > 0);
-  const accreal rdepth= (depth2 > 1) ? (accreal)(depth1 - 1)/(depth2 - 1) : accreal(0);
-  const accreal rheight= (height2 > 1) ? (accreal)(height1 - 1)/(height2 - 1) : accreal(0);
-  const accreal rwidth = (width2 > 1) ? (accreal)(width1 - 1) / (width2 - 1) : accreal(0);
+  const accreal rdepth = linear_upsampling_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = depth2 * height2 * width2;
   const int num_threads =
     THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<real ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
-  num_threads, 0, stream>>>(num_kernels, rdepth, rheight, rwidth, data1, data2);
+  num_threads, 0, stream>>>(num_kernels, rdepth, rheight, rwidth, align_corners, data1, data2);
   THCudaCheck(cudaGetLastError());
   THCTensor_(free)(state, gradInput);
   THCTensor_(free)(state, gradOutput);

--- a/aten/src/THCUNN/linear_upsampling.h
+++ b/aten/src/THCUNN/linear_upsampling.h
@@ -17,13 +17,12 @@ template<typename Acctype>
 __device__ __forceinline__
 static Acctype linear_upsampling_compute_source_index(
                           Acctype scale, int dst_index, bool align_corners) {
-	if (dst_index == 0) {
-		return Acctype(0);
-	} else if (align_corners) {
-		return scale * dst_index;
-	} else {
-		return scale * (dst_index + Acctype(0.5)) - Acctype(0.5);
-	}
+  if (align_corners) {
+    return scale * dst_index;
+  } else {
+    Acctype src_idx = scale * (dst_index + Acctype(0.5)) - Acctype(0.5);
+    return src_idx < Acctype(0) ? Acctype(0) : src_idx;
+  }
 }
 
 

--- a/aten/src/THCUNN/linear_upsampling.h
+++ b/aten/src/THCUNN/linear_upsampling.h
@@ -1,0 +1,31 @@
+#ifndef THCUNN_LINEAR_UPSAMPLING_H
+#define THCUNN_LINEAR_UPSAMPLING_H
+
+template<typename Acctype>
+__host__ __forceinline__
+static Acctype linear_upsampling_compute_scale(
+                          int inputSize, int outputSize, bool align_corners) {
+  if (outputSize > 1) {
+    return align_corners ? (Acctype) (inputSize - 1) / (outputSize - 1)
+                         : (Acctype) inputSize / outputSize;
+  } else {
+    return Acctype(0);
+  }
+}
+
+template<typename Acctype>
+__device__ __forceinline__
+static Acctype linear_upsampling_compute_source_index(
+                          Acctype scale, int dst_index, bool align_corners) {
+	if (dst_index == 0) {
+		return Acctype(0);
+	} else if (align_corners) {
+		return scale * dst_index;
+	} else {
+		return scale * (dst_index + Acctype(0.5)) - Acctype(0.5);
+	}
+}
+
+
+#endif
+

--- a/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/aten/src/THNN/generic/SpatialUpSamplingBilinear.c
@@ -73,16 +73,16 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
     }
     return;
   }
-  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
-  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1) / (outputWidth - 1) : 0.f;
+  const float rheight =(outputHeight > 1) ? (float)inputHeight / outputHeight : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)inputWidth / outputWidth : 0.f;
   for (int h2 = 0; h2 < outputHeight; ++h2) {
-    const float h1r = rheight * h2;
+    const float h1r = (h2 > 0) ? rheight * (h2 - 0.5f) : 0.f;
     const int h1 = h1r;
     const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
     for (int w2 = 0; w2 < outputWidth; ++w2) {
-      const float w1r = rwidth * w2;
+      const float w1r = (w2 > 0) ? rwidth * (w2 - 0.5f) : 0.f;
       const int w1 = w1r;
       const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;
@@ -142,16 +142,16 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
     }
     return;
   }
-  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
-  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1)/(outputWidth - 1) : 0.f;
+  const float rheight =(outputHeight > 1) ? (float)inputHeight / outputHeight : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)inputWidth / outputWidth : 0.f;
   for (int h2 = 0; h2 < outputHeight; ++h2) {
-    const float h1r = rheight * h2;
+    const float h1r = (h2 > 0) ? rheight * (h2 - 0.5f) : 0.f;
     const int h1 = h1r;
     const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
     for (int w2 = 0; w2 < outputWidth; ++w2) {
-      const float w1r = rwidth * w2;
+      const float w1r = (w2 > 0) ? rwidth * (w2 - 0.5f) : 0.f;
       const int w1 = w1r;
       const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -801,7 +801,8 @@ TH_API void THNN_(TemporalUpSamplingLinear_updateOutput)(
           THNNState *state,
           THTensor *input,
           THTensor *output,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 TH_API void THNN_(TemporalUpSamplingLinear_updateGradInput)(
           THNNState *state,
           THTensor *gradOutput,
@@ -809,7 +810,8 @@ TH_API void THNN_(TemporalUpSamplingLinear_updateGradInput)(
           int isizeB,
           int isizeC,
           int isizeW,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 
 TH_API void THNN_(BatchNormalization_updateOutput)(
           THNNState *state,
@@ -1260,7 +1262,8 @@ TH_API void THNN_(SpatialUpSamplingBilinear_updateOutput)(
           THTensor *input,
           THTensor *output,
           int osizeH,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
           THNNState *state,
           THTensor *gradOutput,
@@ -1270,7 +1273,8 @@ TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
           int isizeH,
           int isizeW,
           int osizeH,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 
 TH_API void THNN_(SpatialGridSamplerBilinear_updateOutput)(
           THNNState *state,
@@ -1712,7 +1716,8 @@ TH_API void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
           THTensor *output,
           int osizeT,
           int osizeH,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 
 TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
           THNNState *state,
@@ -1725,7 +1730,8 @@ TH_API void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
           int isizeW,
           int osizeT,
           int osizeH,
-          int osizeW);
+          int osizeW,
+          bool align_corners);
 
 TH_API void THNN_(TemporalReflectionPadding_updateOutput)(
           THNNState *state,

--- a/aten/src/THNN/generic/linear_upsampling.c
+++ b/aten/src/THNN/generic/linear_upsampling.c
@@ -1,0 +1,28 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/linear_upsampling.c"
+#else
+
+static inline float THNN_(linear_upsampling_compute_scale)(
+                          int inputSize, int outputSize, bool align_corners) {
+  if (outputSize > 1) {
+    return align_corners ? (float) (inputSize - 1) / (outputSize - 1)
+                         : (float) inputSize / outputSize;
+  } else {
+    return 0.f;
+  }
+}
+
+static inline float THNN_(linear_upsampling_compute_source_index)(
+                          float scale, int dst_index, bool align_corners) {
+  if (dst_index == 0) {
+    return 0.f;
+  } else if (align_corners) {
+    return scale * dst_index;
+  } else {
+    return scale * (dst_index + 0.5) - 0.5;
+  }
+}
+
+
+#endif
+

--- a/aten/src/THNN/generic/linear_upsampling.c
+++ b/aten/src/THNN/generic/linear_upsampling.c
@@ -14,12 +14,11 @@ static inline float THNN_(linear_upsampling_compute_scale)(
 
 static inline float THNN_(linear_upsampling_compute_source_index)(
                           float scale, int dst_index, bool align_corners) {
-  if (dst_index == 0) {
-    return 0.f;
-  } else if (align_corners) {
+  if (align_corners) {
     return scale * dst_index;
   } else {
-    return scale * (dst_index + 0.5) - 0.5;
+    float src_idx = scale * (dst_index + 0.5) - 0.5;
+    return src_idx < 0 ? 0.f : src_idx;
   }
 }
 

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -173,6 +173,11 @@
 #include "generic/Threshold.c"
 #include "THGenerateFloatTypes.h"
 
+// this file is used in TemporalUpsamplingLinear, SpatialUpsamplingBilinear, and
+// VolumetricUpsamplingTrilinear, and thus needs to be included before those.
+#include "generic/linear_upsampling.c"
+#include "THGenerateFloatTypes.h"
+
 #include "generic/TemporalConvolution.c"
 #include "THGenerateFloatTypes.h"
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4249,6 +4249,14 @@ class TestNN(NNTestCase):
         input = Variable(torch.randn(1, 1, 2), requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='linear'), (input,))
 
+    def test_upsamplingLinear1d_spatial_invariance(self):
+        m = nn.Upsample(scale_factor=3, mode='linear', align_corners=False)
+        in_t_9 = torch.zeros(1, 1, 9)
+        in_t_9[:, :, :4].normal_()
+        out_t_9 = m(in_t_9)
+        out_t_5 = m(in_t_9[:, :, :5])
+        self.assertEqual(out_t_9[:, :, :15], out_t_5)
+
     def test_upsamplingNearest2d(self):
         m = nn.Upsample(size=4, mode='nearest')
         in_t = torch.ones(1, 1, 2, 2)
@@ -4271,6 +4279,14 @@ class TestNN(NNTestCase):
         input = Variable(torch.randn(1, 1, 2, 2), requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='bilinear'), [input])
 
+    def test_upsamplingBilinear2d_spatial_invariance(self):
+        m = nn.Upsample(scale_factor=3, mode='bilinear', align_corners=False)
+        in_t_9 = torch.zeros(1, 1, 9, 9)
+        in_t_9[:, :, :4, :4].normal_()
+        out_t_9 = m(in_t_9)
+        out_t_5 = m(in_t_9[:, :, :5, :5])
+        self.assertEqual(out_t_9[:, :, :15, :15], out_t_5)
+
     def test_upsamplingNearest3d(self):
         m = nn.Upsample(size=4, mode='nearest')
         in_t = torch.ones(1, 1, 2, 2, 2)
@@ -4292,6 +4308,14 @@ class TestNN(NNTestCase):
             F.upsample(input, scale_factor=2, mode='trilinear'))
         gradcheck(lambda x: F.upsample(x, 4, mode='trilinear'), [input])
         gradgradcheck(lambda x: F.upsample(x, 4, mode='trilinear'), [input])
+
+    def test_upsamplingTrilinear3d_spatial_invariance(self):
+        m = nn.Upsample(scale_factor=3, mode='trilinear', align_corners=False)
+        in_t_9 = torch.zeros(1, 1, 9, 9, 9)
+        in_t_9[:, :, :4, :4, :4].normal_()
+        out_t_9 = m(in_t_9)
+        out_t_5 = m(in_t_9[:, :, :5, :5, :5])
+        self.assertEqual(out_t_9[:, :, :15, :15, :15], out_t_5)
 
     def test_linear_broadcasting(self):
         m = nn.Linear(5, 8)
@@ -6375,21 +6399,33 @@ new_module_tests = [
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(12, None, 'linear'),
+        constructor_args=(12, None, 'linear', False),
         input_size=(1, 2, 4),
         desc='linear_1d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=((4, ), None, 'linear'),
+        constructor_args=((4, ), None, 'linear', False),
         input_size=(1, 2, 3),
         desc='linear_tuple_1d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(None, 4, 'linear'),
+        constructor_args=(None, 4, 'linear', False),
         input_size=(1, 2, 4),
         desc='linear_scale_1d',
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=(12, None, 'linear', True),
+        input_size=(1, 2, 4),
+        desc='linear_1d_align_corners',
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=(None, 4, 'linear', True),
+        input_size=(1, 2, 4),
+        desc='linear_scale_1d_align_corners',
     ),
     dict(
         module_name='Upsample',
@@ -6411,33 +6447,45 @@ new_module_tests = [
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(12, None, 'bilinear'),
+        constructor_args=(12, None, 'bilinear', False),
         input_size=(1, 2, 4, 4),
         desc='bilinear_2d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=((4, 6), None, 'bilinear'),
+        constructor_args=((4, 6), None, 'bilinear', False),
         input_size=(1, 2, 2, 3),
         desc='bilinear_tuple_2d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(None, 4, 'bilinear'),
+        constructor_args=(None, 4, 'bilinear', False),
         input_size=(1, 2, 4, 4),
         desc='bilinear_scale_2d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(None, (2, 2), 'bilinear'),
+        constructor_args=(None, (2, 2), 'bilinear', False),
         input_size=(1, 2, 4, 4),
         desc='bilinear_scale_tuple_shared_2d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(None, (2, 1), 'bilinear'),
+        constructor_args=(None, (2, 1), 'bilinear', False),
         input_size=(1, 2, 4, 4),
         desc='bilinear_scale_tuple_skewed_2d',
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=((4, 6), None, 'bilinear', True),
+        input_size=(1, 2, 4, 4),
+        desc='bilinear_tuple_2d_align_corners',
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=(None, (2, 1), 'bilinear', True),
+        input_size=(1, 2, 4, 4),
+        desc='bilinear_scale_tuple_skewed_2d_align_corners',
     ),
     dict(
         module_name='Upsample',
@@ -6459,21 +6507,35 @@ new_module_tests = [
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(12, None, 'trilinear'),
+        constructor_args=(12, None, 'trilinear', False),
         input_size=(1, 2, 4, 4, 4),
         desc='trilinear_3d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=((4, 6, 6), None, 'trilinear'),
+        constructor_args=((4, 6, 6), None, 'trilinear', False),
         input_size=(1, 2, 2, 3, 3),
         desc='trilinear_tuple_3d',
     ),
     dict(
         module_name='Upsample',
-        constructor_args=(None, 4, 'trilinear'),
-        input_size=(1, 2, 4, 4, 4),
+        constructor_args=(None, 3, 'trilinear', False),
+        input_size=(1, 2, 3, 4, 4),
         desc='trilinear_scale_3d',
+        # See https://github.com/pytorch/pytorch/issues/5006
+        precision=3e-4,
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=((4, 6, 6), None, 'trilinear', True),
+        input_size=(1, 2, 2, 3, 3),
+        desc='trilinear_tuple_3d_align_corners',
+    ),
+    dict(
+        module_name='Upsample',
+        constructor_args=(None, 3, 'trilinear', True),
+        input_size=(1, 2, 3, 4, 4),
+        desc='trilinear_scale_3d_align_corners',
         # See https://github.com/pytorch/pytorch/issues/5006
         precision=3e-4,
     ),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -791,14 +791,14 @@
 - name: replication_pad3d_forward(Tensor self, IntList padding)
   self: replication_pad3d_backward(grad, self, padding)
 
-- name: upsample_linear1d_forward(Tensor self, IntList output_size)
-  self: upsample_linear1d_backward(grad, output_size, self.sizes())
+- name: upsample_linear1d_forward(Tensor self, IntList output_size, bool align_corners)
+  self: upsample_linear1d_backward(grad, output_size, self.sizes(), align_corners)
 
-- name: upsample_bilinear2d_forward(Tensor self, IntList output_size)
-  self: upsample_bilinear2d_backward(grad, output_size, self.sizes())
+- name: upsample_bilinear2d_forward(Tensor self, IntList output_size, bool align_corners)
+  self: upsample_bilinear2d_backward(grad, output_size, self.sizes(), align_corners)
 
-- name: upsample_trilinear3d_forward(Tensor self, IntList output_size)
-  self: upsample_trilinear3d_backward(grad, output_size, self.sizes())
+- name: upsample_trilinear3d_forward(Tensor self, IntList output_size, bool align_corners)
+  self: upsample_trilinear3d_backward(grad, output_size, self.sizes(), align_corners)
 
 - name: upsample_nearest1d_forward(Tensor self, int64_t scale_factor)
   self: upsample_nearest1d_backward(grad, self, scale_factor)
@@ -1034,14 +1034,14 @@
   grad_output: threshold_backward(grad, self, threshold, value)
   self: zeros_like(grad)
 
-- name: upsample_linear1d_backward(Tensor grad_output, IntList output_size, IntList input_size)
-  grad_output: upsample_linear1d(grad, output_size)
+- name: upsample_linear1d_backward(Tensor grad_output, IntList output_size, IntList input_size, bool align_corners)
+  grad_output: upsample_linear1d(grad, output_size, align_corners)
 
-- name: upsample_bilinear2d_backward(Tensor grad_output, IntList output_size, IntList input_size)
-  grad_output: upsample_bilinear2d(grad, output_size)
+- name: upsample_bilinear2d_backward(Tensor grad_output, IntList output_size, IntList input_size, bool align_corners)
+  grad_output: upsample_bilinear2d(grad, output_size, align_corners)
 
-- name: upsample_trilinear3d_backward(Tensor grad_output, IntList output_size, IntList input_size)
-  grad_output: upsample_trilinear3d(grad, output_size)
+- name: upsample_trilinear3d_backward(Tensor grad_output, IntList output_size, IntList input_size, bool align_corners)
+  grad_output: upsample_trilinear3d(grad, output_size, align_corners)
 
 - name: upsample_nearest1d_backward(Tensor grad_output, Tensor self, int64_t scale_factor)
   grad_output: upsample_nearest1d(grad, scale_factor)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1706,7 +1706,7 @@ def pixel_shuffle(input, upscale_factor):
     return shuffle_out.view(batch_size, channels, out_height, out_width)
 
 
-def upsample(input, size=None, scale_factor=None, mode='nearest'):
+def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=None):
     r"""Upsamples the input to either the given :attr:`size` or the given
     :attr:`scale_factor`
 
@@ -1722,12 +1722,26 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
     `bilinear` (4D-only), `trilinear` (5D-only)
 
     Args:
-        input (Variable): input
+        input (Tensor): the input tensor
         size (int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int]):
             output spatial size.
         scale_factor (int): multiplier for spatial size. Has to be an integer.
         mode (string): algorithm used for upsampling:
             'nearest' | 'linear' | 'bilinear' | 'trilinear'. Default: 'nearest'
+        align_corners (bool, optional): if True, the corner pixels of the input
+            and output tensors are aligned, and thus preserving the values at
+            those pixels. This only has effect when :attr:`mode` is `linear`,
+            `bilinear`, or `trilinear`. Default: False
+
+    .. warning::
+        With ``align_corners = True``, the linearly interpolating modes
+        (`linear`, `bilinear`, and `trilinear`) don't proportionally align the
+        output and input pixels, and thus the output values can depend on the
+        input size. This was the default behavior for these modes up to version
+        0.3.1. Since then, the default behavior is ``align_corners = False``.
+        See :class:`nn.Upsample` for concrete examples on how this affects the
+        outputs.
+
     """
     from numbers import Integral
     from .modules.utils import _ntuple
@@ -1766,6 +1780,18 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
         scale_factors = _ntuple(dim)(scale_factor)
         return [input.size(i + 2) * scale_factors[i] for i in range(dim)]
 
+    if mode == 'nearest':
+        if align_corners is not None:
+            raise ValueError("align_corners option can only be set with the "
+                             "interpolating modes: linear | bilinear | trilinear")
+    else:
+        if align_corners is None:
+            warnings.warn("Default upsampling behavior when mode={} is changed "
+                          "to align_corners=False since 0.4.0. Please specify "
+                          "align_corners=True if the old behavior is desired. "
+                          "See the documentation of nn.Upsample for details.".format(mode))
+            align_corners = False
+
     if input.dim() == 3 and mode == 'nearest':
         return torch._C._nn.upsample_nearest1d(input, _scale_factor(1))
     elif input.dim() == 4 and mode == 'nearest':
@@ -1773,7 +1799,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
     elif input.dim() == 5 and mode == 'nearest':
         return torch._C._nn.upsample_nearest3d(input, _scale_factor(3))
     elif input.dim() == 3 and mode == 'linear':
-        return torch._C._nn.upsample_linear1d(input, _output_size(1))
+        return torch._C._nn.upsample_linear1d(input, _output_size(1), align_corners)
     elif input.dim() == 3 and mode == 'bilinear':
         raise NotImplementedError("Got 3D input, but bilinear mode needs 4D input")
     elif input.dim() == 3 and mode == 'trilinear':
@@ -1781,7 +1807,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
     elif input.dim() == 4 and mode == 'linear':
         raise NotImplementedError("Got 4D input, but linear mode needs 3D input")
     elif input.dim() == 4 and mode == 'bilinear':
-        return torch._C._nn.upsample_bilinear2d(input, _output_size(2))
+        return torch._C._nn.upsample_bilinear2d(input, _output_size(2), align_corners)
     elif input.dim() == 4 and mode == 'trilinear':
         raise NotImplementedError("Got 4D input, but trilinear mode needs 5D input")
     elif input.dim() == 5 and mode == 'linear':
@@ -1789,7 +1815,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
     elif input.dim() == 5 and mode == 'bilinear':
         raise NotImplementedError("Got 5D input, but bilinear mode needs 4D input")
     elif input.dim() == 5 and mode == 'trilinear':
-        return torch._C._nn.upsample_trilinear3d(input, _output_size(3))
+        return torch._C._nn.upsample_trilinear3d(input, _output_size(3), align_corners)
     else:
         raise NotImplementedError("Input Error: Only 3D, 4D and 5D input Tensors supported"
                                   " (got {}D) for the modes: nearest | linear | bilinear | trilinear"
@@ -1799,7 +1825,8 @@ def upsample(input, size=None, scale_factor=None, mode='nearest'):
 def upsample_nearest(input, size=None, scale_factor=None):
     r"""Upsamples the input, using nearest neighbours' pixel values.
 
-    **Note:: This function is deprecated. Use nn.functional.upsample instead**
+    .. warning::
+        This function is deprecated in favor of :meth:`nn.functional.upsample`.
 
     Currently spatial and volumetric upsampling are supported (i.e. expected
     inputs are 4 or 5 dimensional).
@@ -1816,9 +1843,12 @@ def upsample_nearest(input, size=None, scale_factor=None):
 
 
 def upsample_bilinear(input, size=None, scale_factor=None):
-    r"""Upscales the input, using bilinear upsampling.
+    r"""Upsamples the input, using bilinear upsampling.
 
-    **Note:: This function is deprecated. Use nn.functional.upsample instead**
+    .. warning::
+        This function is deprecated in favor of :meth:`nn.functional.upsample`.
+        This is equivalent with
+        ``nn.functional.upsample(..., mode='bilinear', align_corners=True)``.
 
     Expected inputs are spatial (4 dimensional). Use `upsample_trilinear` fo
     volumetric (5 dimensional) inputs.
@@ -1830,7 +1860,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_bilinear is deprecated. Use nn.functional.upsample instead.")
-    return upsample(input, size, scale_factor, mode='bilinear')
+    return upsample(input, size, scale_factor, mode='bilinear', align_corners=True)
 
 
 def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -21,40 +21,35 @@ class Upsample(Module):
         size (tuple, optional): a tuple of ints `([D_out], [H_out], W_out)` output sizes
         scale_factor (int / tuple of ints, optional): the multiplier for the image height / width / depth
         mode (string, optional): the upsampling algorithm: one of `nearest`, `linear`, `bilinear` and `trilinear`.
-                                    Default: nearest
+                                    Default: `nearest`
+        align_corners (bool, optional): if True, the corner pixels of the input
+            and output tensors are aligned, and thus preserving the values at
+            those pixels. This only has effect when :attr:`mode` is `linear`,
+            `bilinear`, or `trilinear`. Default: False
 
     Shape:
         - Input: :math:`(N, C, W_{in})`, :math:`(N, C, H_{in}, W_{in})` or :math:`(N, C, D_{in}, H_{in}, W_{in})`
         - Output: :math:`(N, C, W_{out})`, :math:`(N, C, H_{out}, W_{out})`
-          or :math:`(N, C, D_{out}, H_{out}, W_{out})` where
+          or :math:`(N, C, D_{out}, H_{out}, W_{out})`, where
 
           .. math::
-              D_{out} = \left\lfloor D_{in} * \text{scale_factor} \right\rfloor \text{ or size}[-3]
+              D_{out} = \left\lfloor D_{in} \times \text{scale_factor} \right\rfloor \text{ or size}[-3]
 
-              H_{out} = \left\lfloor H_{in} * \text{scale_factor} \right\rfloor \text{ or size}[-2]
+              H_{out} = \left\lfloor H_{in} \times \text{scale_factor} \right\rfloor \text{ or size}[-2]
 
-              W_{out} = \left\lfloor W_{in} * \text{scale_factor} \right\rfloor \text{ or size}[-1]
+              W_{out} = \left\lfloor W_{in} \times \text{scale_factor} \right\rfloor \text{ or size}[-1]
+
+    .. warning::
+        With ``align_corners = True``, the linearly interpolating modes
+        (`linear`, `bilinear`, and `trilinear`) don't proportionally align the
+        output and input pixels, and thus the output values can depend on the
+        input size. This was the default behavior for these modes up to version
+        0.3.1. Since then, the default behavior is ``align_corners = False``.
+        See below for concrete examples on how this affects the outputs.
 
     Examples::
 
         >>> input = torch.arange(1, 5).view(1, 1, 2, 2)
-        >>> input
-
-        (0 ,0 ,.,.) =
-          1  2
-          3  4
-        [torch.FloatTensor of size (1,1,2,2)]
-
-        >>> m = nn.Upsample(scale_factor=2, mode='bilinear')
-        >>> m(input)
-
-        (0 ,0 ,.,.) =
-          1.0000  1.3333  1.6667  2.0000
-          1.6667  2.0000  2.3333  2.6667
-          2.3333  2.6667  3.0000  3.3333
-          3.0000  3.3333  3.6667  4.0000
-        [torch.FloatTensor of size (1,1,4,4)]
-
         >>> input
 
         (0 ,0 ,.,.) =
@@ -72,16 +67,75 @@ class Upsample(Module):
           3  3  4  4
         [torch.FloatTensor of size (1,1,4,4)]
 
+        >>> m = nn.Upsample(scale_factor=2, mode='bilinear')  # align_corners=False
+        >>> m(input)
+
+        (0 ,0 ,.,.) =
+          1.0000  1.2500  1.7500  2.0000
+          1.5000  1.7500  2.2500  2.5000
+          2.5000  2.7500  3.2500  3.5000
+          3.0000  3.2500  3.7500  4.0000
+        [torch.FloatTensor of size (1,1,4,4)]
+
+        >>> m = nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
+        >>> m(input)
+
+        (0 ,0 ,.,.) =
+          1.0000  1.3333  1.6667  2.0000
+          1.6667  2.0000  2.3333  2.6667
+          2.3333  2.6667  3.0000  3.3333
+          3.0000  3.3333  3.6667  4.0000
+        [torch.FloatTensor of size (1,1,4,4)]
+
+        >>> # Try scaling the same data in a larger tensor
+        >>>
+        >>> input_3x3 = torch.zeros(3, 3).view(1, 1, 3, 3)
+        >>> input_3x3[:, :, :2, :2].copy_(input)
+        >>> input_3x3
+
+        (0 ,0 ,.,.) =
+          1  2  0
+          3  4  0
+          0  0  0
+        [torch.FloatTensor of size (1,1,3,3)]
+
+        >>> m = nn.Upsample(scale_factor=2, mode='bilinear')  # align_corners=False
+        >>> # Notice that values in top left corner are the same with the small input (except at boundary)
+        >>> m(input_3x3)
+
+        (0 ,0 ,.,.) =
+          1.0000  1.2500  1.7500  1.5000  0.5000  0.0000
+          1.5000  1.7500  2.2500  1.8750  0.6250  0.0000
+          2.5000  2.7500  3.2500  2.6250  0.8750  0.0000
+          2.2500  2.4375  2.8125  2.2500  0.7500  0.0000
+          0.7500  0.8125  0.9375  0.7500  0.2500  0.0000
+          0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+        [torch.FloatTensor of size (1,1,6,6)]
+
+        >>> m = nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
+        >>> # Notice that values in top left corner are now changed
+        >>> m(input_3x3)
+
+        (0 ,0 ,.,.) =
+          1.0000  1.4000  1.8000  1.6000  0.8000  0.0000
+          1.8000  2.2000  2.6000  2.2400  1.1200  0.0000
+          2.6000  3.0000  3.4000  2.8800  1.4400  0.0000
+          2.4000  2.7200  3.0400  2.5600  1.2800  0.0000
+          1.2000  1.3600  1.5200  1.2800  0.6400  0.0000
+          0.0000  0.0000  0.0000  0.0000  0.0000  0.0000
+        [torch.FloatTensor of size (1,1,6,6)]
+
     """
 
-    def __init__(self, size=None, scale_factor=None, mode='nearest'):
+    def __init__(self, size=None, scale_factor=None, mode='nearest', align_corners=None):
         super(Upsample, self).__init__()
         self.size = size
         self.scale_factor = scale_factor
         self.mode = mode
+        self.align_corners = align_corners
 
     def forward(self, input):
-        return F.upsample(input, self.size, self.scale_factor, self.mode)
+        return F.upsample(input, self.size, self.scale_factor, self.mode, self.align_corners)
 
     def __repr__(self):
         if self.scale_factor is not None:
@@ -105,14 +159,17 @@ class UpsamplingNearest2d(Upsample):
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
 
+    .. warning::
+        This class is deprecated in favor of :class:`~nn.Upsample`.
+
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \left\lfloor H_{in} * \text{scale_factor} \right\rfloor
+              H_{out} = \left\lfloor H_{in} \times \text{scale_factor} \right\rfloor
 
-              W_{out} = \left\lfloor W_{in} * \text{scale_factor} \right\rfloor
+              W_{out} = \left\lfloor W_{in} \times \text{scale_factor} \right\rfloor
 
     Examples::
 
@@ -156,14 +213,18 @@ class UpsamplingBilinear2d(Upsample):
         size (tuple, optional): a tuple of ints `(H_out, W_out)` output sizes
         scale_factor (int, optional): the multiplier for the image height or width
 
+    .. warning::
+        This class is deprecated in favor of :class:`~nn.Upsample`. It is
+        equivalent to ``nn.Upsample(..., mode='bilinear', align_corners=True)``.
+
     Shape:
         - Input: :math:`(N, C, H_{in}, W_{in})`
         - Output: :math:`(N, C, H_{out}, W_{out})` where
 
           .. math::
-              H_{out} = \left\lfloor H_{in} * \text{scale_factor} \right\rfloor
+              H_{out} = \left\lfloor H_{in} \times \text{scale_factor} \right\rfloor
 
-              W_{out} = \left\lfloor W_{in} * \text{scale_factor} \right\rfloor
+              W_{out} = \left\lfloor W_{in} \times \text{scale_factor} \right\rfloor
 
     Examples::
 
@@ -187,7 +248,7 @@ class UpsamplingBilinear2d(Upsample):
 
     """
     def __init__(self, size=None, scale_factor=None):
-        super(UpsamplingBilinear2d, self).__init__(size, scale_factor, mode='bilinear')
+        super(UpsamplingBilinear2d, self).__init__(size, scale_factor, mode='bilinear', align_corners=True)
 
     def forward(self, input):
         warnings.warn("nn.UpsamplingBilinear2d is deprecated. Use nn.Upsample instead.")


### PR DESCRIPTION
Add align_corners option to upsampling module & functional when using linearly interpolating modes:

When align_corners=True, it uses the old original upsampling scheme, which gives visually better results,
but doesn't properly align input and output pixels, and thus cause the output vary basing on input.
This PR adds this align_corners option, and changes the default behavior to align_corners=False, with
proper warning if this option is not specified upon using nn.Upsample or nn.functional.upsample to let
be aware of this new change.
Adds tests in test_nn.py for spatial invariance when align_corners=False, and usual module tests for
align_corners=False.

The ratio is basically computed as:
```
ratio = align_corners ? (input_size - 1) / (output_size - 1) : input_size / output_size
```
And src_idx is:
```
if align_corners:
  src_idx = dst_idx * ratio
else:
  src_idx = (dst_idx + 0.5) * ratio - 0.5
```
The `0.5` are used to cast the index to location of the pixel centers.

This also makes the default upsampling behavior consistent with other DL frameworks like tf.

This solves the issue raised in #5511 

cc @Dorimer 