### PR TITLE
py3 - use loop instead of map for test_torch:test_cpu_parallel

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -570,7 +570,8 @@ class TestTorch(TestCase):
         sizes += [[4, 4, 4, 4, 4, 4, 4, 4, 4, 4]]
         sizes += [[1, 32 * 8 * 32 * 8]]
         sizes += [[1, 32770]]
-        map(_run_test, sizes)
+        for size in sizes:
+            _run_test(size)
 
     def _testCSelection(self, torchfn, mathfn):
         # Two tensors


### PR DESCRIPTION
map is lazy in Python 3, so we need to use a for loop. The bug was pointed to by a [comment](https://github.com/pytorch/pytorch/pull/5926/files#r176354339).