### PR TITLE
Verify that 'catch' submodule has been checked out before attempting build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -255,6 +255,7 @@ class build_deps(Command):
         check_file(os.path.join(lib_path, "pybind11", "CMakeLists.txt"))
         check_file(os.path.join('aten', 'src', 'ATen', 'cpu', 'cpuinfo', 'CMakeLists.txt'))
         check_file(os.path.join('aten', 'src', 'ATen', 'cpu', 'tbb', 'tbb_remote', 'Makefile'))
+        check_file(os.path.join('aten', 'src', 'ATen', 'utils', 'catch', 'CMakeLists.txt'))
 
         check_pydep('yaml', 'pyyaml')
         check_pydep('typing', 'typing')


### PR DESCRIPTION
Fixes #5925.