### PR TITLE
Fix tensor.permute(dims) backward for negative dims

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2677,6 +2677,7 @@ method_tests = [
     ('lt_', (), (0,), 'pyscalar_scalar'),
     ('le_', (), (0,), 'pyscalar_scalar'),
     ('permute', (1, 2, 3, 4), (0, 2, 3, 1)),
+    ('permute', (1, 2, 3, 4), (0, -2, -1, 1), 'neg_dim'),
     ('permute', (), (dont_convert(()),), 'scalar'),
     ('select', (S, S, S), (1, 2), 'dim', [0]),
     ('select', (S,), (0, 2), '1d'),

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -121,9 +121,10 @@ Tensor reduce_to(const Tensor & grad, IntList sizes) {
 
 Tensor permute_backwards(const Tensor & grad, IntList fwd_dims) {
   // invert the permutation
-  std::vector<int64_t> dims(fwd_dims.size());
-  for (size_t i = 0; i < fwd_dims.size(); i++) {
-    dims[fwd_dims[i]] = i;
+  auto ndims = fwd_dims.size();
+  std::vector<int64_t> dims(ndims);
+  for (size_t i = 0; i < ndims; i++) {
+    dims[at::maybe_wrap_dim(fwd_dims[i], ndims)] = i;
   }
   return grad.permute(dims);
 }


### PR DESCRIPTION
Fixes #5943

For the following code:
```
import torch

u = torch.zeros((3, 3), requires_grad=True)
v = u.permute(-1, -2)  # (1, 0) here is fine
v.sum().backward()
```

during the backward pass, a std::vector is constructed
as an "inverse" of the permutation. To do this, all the dims
are indexed into the vector.

The problem with that is that the negative dims were being indexed
into the std::vector, causing undefined behavior. This PR wraps
those negative dims so they're handled correctly.

cc @colesbury 

### Test Plan
new unit test