### PR TITLE
mention cmake3 for Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ On Linux
 export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root directory]
 
 # Install basic dependencies
+# Replace `cmake` with `cmake3` on Ubuntu 14.04 Trusty
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 
 # Add LAPACK support for the GPU


### PR DESCRIPTION
I'm guessing in general you don't want to mention a bunch of special cases here, but Ubuntu 14.04 is probably the second or third most common platform overall and PyTorch doesn't seem to build with cmake 2 (or give a useful error message). I was only able to get a build to work on our 14.04 workstations after finding [this](https://github.com/pietern/pytorch-dockerfiles/blob/master/common/install_base.sh#L13) in the Jenkins dockerfiles.