### PR TITLE
implement `GroupNorm2D` from paper

### DIFF
--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -14,6 +14,7 @@ from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxP
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, LPPool1d, LPPool2d, AdaptiveMaxPool1d, \
     AdaptiveMaxPool2d, AdaptiveMaxPool3d, AdaptiveAvgPool1d, AdaptiveAvgPool2d, AdaptiveAvgPool3d
 from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
+from .groupnorm import GroupNorm2D
 from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .normalization import LocalResponseNorm, CrossMapLRN2d, LayerNorm
 from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout
@@ -39,7 +40,7 @@ __all__ = [
     'ParameterList', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d',
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
-    'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout',
+    'InstanceNorm2d', 'InstanceNorm3d', 'GroupNorm2D', 'LayerNorm', 'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout',
     'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d',
     'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCell', 'LSTMCell', 'GRUCell',
     'PixelShuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d', 'PairwiseDistance',

--- a/torch/nn/modules/groupnorm.py
+++ b/torch/nn/modules/groupnorm.py
@@ -1,0 +1,61 @@
+import torch
+from .module import Module
+
+
+class GroupNorm2D(Module):
+    r"""Applies Group Normalization over a mini-batch of inputs as described in
+    the paper `Group Normalization`_ .
+    .. math::
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x]} + \epsilon} * \gamma + \beta
+    The mean and standard-deviation are calculated separately per mini-batch.
+    :math:`\gamma` and :math:`\beta` are hyper-parameters
+    Shape:
+        - Input: :math:`(N, *)`
+        - Output: :math:`(N, *)` (same shape as input)
+    Examples:
+        >>> input = torch.randn(32, 64, 32, 32)
+        >>> # With Default Hyper-Parameters
+        >>> m = nn.GroupNorm2D(gamma=1, beta=0.5, group=32, eps=1e-5)
+        >>> # Activating the module
+        >>> output = m(input)
+    TF Code:
+        >>> def GroupNorm(x, gamma=1, beta=0.5, group=32, eps=1e-5):
+        >>>     # x: input features with shape [N,C,H,W]
+        >>>     # gamma, beta: scale and offset, with shape [1,C,1,1]
+        >>>     # G: number of groups for GN
+        >>>
+        >>>     N, C, H, W = x.shape
+        >>>     x = tf.reshape(x, [N, group, C // group, H, W])
+        >>>
+        >>>     mean, var = tf.nn.moments(x, [2, 3, 4], keep_dims=True)
+        >>>     x = (x - mean) / tf.sqrt(var + eps)
+        >>>
+        >>>     x = tf.reshape(x, [N, C, H, W])
+        >>>
+        >>>     return x * gamma + beta
+    .. _`Group Normalization`: https://arxiv.org/abs/1803.08494
+    """
+
+    def __init__(self, gamma=1, beta=0.5, group=32, eps=1e-5):
+        super(GroupNorm2D, self).__init__()
+        self.gamma = gamma
+        self.beta = beta
+        self.group = group
+        self.eps = eps
+
+    def _check_input_dim(self, inputs):
+        if inputs.dim() != 4:
+            raise ValueError('expected 4D input (got {}D input)'
+                             .format(inputs.dim()))
+
+    def forward(self, inputs):
+        self._check_input_dim(inputs)
+
+        N, C, H, W = inputs.size()
+        inputs = inputs.view(N, self.group, C // self.group, H, W)
+
+        mean, var = inputs.mean(1, keepdim=True), inputs.var(1, keepdim=True)
+        inputs = (inputs - mean) / torch.sqrt(var + self.eps)
+        inputs = inputs.view(N, C, H, W)
+
+        return inputs * self.gamma + self.beta

--- a/torch/nn/modules/groupnorm.py
+++ b/torch/nn/modules/groupnorm.py
@@ -18,21 +18,6 @@ class GroupNorm2D(Module):
         >>> m = nn.GroupNorm2D(gamma=1, beta=0.5, group=32, eps=1e-5)
         >>> # Activating the module
         >>> output = m(input)
-    TF Code:
-        >>> def GroupNorm(x, gamma=1, beta=0.5, group=32, eps=1e-5):
-        >>>     # x: input features with shape [N,C,H,W]
-        >>>     # gamma, beta: scale and offset, with shape [1,C,1,1]
-        >>>     # G: number of groups for GN
-        >>>
-        >>>     N, C, H, W = x.shape
-        >>>     x = tf.reshape(x, [N, group, C // group, H, W])
-        >>>
-        >>>     mean, var = tf.nn.moments(x, [2, 3, 4], keep_dims=True)
-        >>>     x = (x - mean) / tf.sqrt(var + eps)
-        >>>
-        >>>     x = tf.reshape(x, [N, C, H, W])
-        >>>
-        >>>     return x * gamma + beta
     .. _`Group Normalization`: https://arxiv.org/abs/1803.08494
     """
 


### PR DESCRIPTION
Paper: [Group Normalization](https://arxiv.org/abs/1803.08494)

Migrated From TF code given in paper:

```
def GroupNorm(x, gamma=1, beta=0.5, group=32, eps=1e-5):
    # x: input features with shape [N,C,H,W]
    # gamma, beta: scale and offset, with shape [1,C,1,1]
    # G: number of groups for GN
    
    N, C, H, W = x.shape
    x = tf.reshape(x, [N, group, C // group, H, W])
    
    mean, var = tf.nn.moments(x, [2, 3, 4], keep_dims=True)
    x = (x - mean) / tf.sqrt(var + eps)
    
    x = tf.reshape(x, [N, C, H, W])
    
    return x * gamma + beta
```

I test it with VGG16 and cifar10, it works well.