### PR TITLE
Fix Multivariate Normal docs

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -161,8 +161,11 @@ Probability distributions - torch.distributions
 :hidden:`MultivariateNormal`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: torch.distributions.multivariate_normal
 .. autoclass:: MultivariateNormal
     :members:
+    :undoc-members:
+    :show-inheritance:
 
 :hidden:`Normal`
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Brought forward by https://github.com/pytorch/pytorch/issues/5954.

Multivariate normal appears in the sidebar, but not as we scroll downwards.

-----------------------
On a related note: is `:undoc-members:` working as expected for the documentation?