### PR TITLE
remove sort requirement from pad-sequence

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -241,8 +241,8 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
     # assuming trailing dimensions and type of all the Variables
     # in sequences are same and fetching those from sequences[0]
     max_size = sequences[0].size()
-    max_len, trailing_dims = max_size[0], max_size[1:]
-    prev_l = max_len
+    trailing_dims = max_size[1:]
+    max_len = max([s.size(0) for s in sequences])
     if batch_first:
         out_dims = (len(sequences), max_len) + trailing_dims
     else:
@@ -251,10 +251,6 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
     out_variable = Variable(sequences[0].data.new(*out_dims).fill_(padding_value))
     for i, variable in enumerate(sequences):
         length = variable.size(0)
-        # temporary sort check, can be removed when we handle sorting internally
-        if prev_l < length:
-            raise ValueError("lengths array has to be sorted in decreasing order")
-        prev_l = length
         # use index notation to prevent duplicate references to the variable
         if batch_first:
             out_variable[i, :length, ...] = variable


### PR DESCRIPTION
pad-sequence can get the max_len from the list of sequences.
entries only need to be sorted if output will be used for pack_padded_sequence, which can throw the error itself.

this way pad_sequence does O(n) work for me instead of me having to do O(nlogn) work in order to call the function.

thoughts?