### PR TITLE
Add descriptive error message for test_cpp_extensions ModuleNotFoundError

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -6,7 +6,7 @@ try:
     import torch_test_cpp_extension as cpp_extension
 except ModuleNotFoundError:
     print("\'test_cpp_extensions.py\' cannot be invoked directly. " +
-          "Running \'python run_test.py\' will include \'test_cpp_extensions.py\' tests.")
+          "Run \'python run_test.py -i cpp_extensions\' for the \'test_cpp_extensions.py\' tests.")
     raise
 
 import common

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -2,7 +2,12 @@ import unittest
 
 import torch
 import torch.utils.cpp_extension
-import torch_test_cpp_extension as cpp_extension
+try:
+    import torch_test_cpp_extension as cpp_extension
+except ModuleNotFoundError:
+    print("\'test_cpp_extensions.py\' cannot be invoked directly. " +
+          "Running \'python run_test.py\' will include \'test_cpp_extensions.py\' tests.")
+    raise
 
 import common
 


### PR DESCRIPTION
Addresses #5963 

**New error message :** 
```
[vedanuj@devgpu169.prn2 /data/users/vedanuj/pytorch] python test/test_cpp_extensions.py
'test_cpp_extensions.py' cannot be invoked directly. Run 'python run_test.py -i cpp_extensions' for the 'test_cpp_extensions.py' tests.
Traceback (most recent call last):
  File "test/test_cpp_extensions.py", line 6, in <module>
    import torch_test_cpp_extension as cpp_extension
ModuleNotFoundError: No module named 'torch_test_cpp_extension'
```

@ezyang Please review