### PR TITLE
Move LayerNorm to ATen; remove tracking_running_stats functionality

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -70,6 +70,74 @@ Tensor batch_norm(
             running_mean, running_var, training, momentum, eps);
 }
 
+Tensor layer_norm(const Tensor& input, IntList normalized_shape,
+    const Tensor& weight /* optional */, const Tensor& bias /* optional */,
+    double eps) {
+
+    int64_t normalized_ndim = normalized_shape.size();
+
+    if (normalized_ndim < 1) {
+      std::stringstream ss;
+      ss << "Expected normalized_shape to be at least 1-dimensional, i.e., "
+         << "containing at least one element, but got normalized_shape="
+         << normalized_shape;
+      throw std::runtime_error(ss.str());
+    }
+
+    if (weight.defined() && !weight.sizes().equals(normalized_shape)) {
+      std::stringstream ss;
+      ss << "Expected weight to be of same shape as normalized_shape, but got "
+         << "weight of shape " << weight.sizes() << " and normalized_shape="
+         << normalized_shape;
+      throw std::runtime_error(ss.str());
+    }
+
+    if (bias.defined() && !bias.sizes().equals(normalized_shape)) {
+      std::stringstream ss;
+      ss << "Expected bias to be of same shape as normalized_shape, but got "
+         << "bias of shape " << bias.sizes() << " and normalized_shape="
+         << normalized_shape;
+      throw std::runtime_error(ss.str());
+    }
+
+    auto input_shape = input.sizes();
+    auto input_ndim = input.dim();
+
+    if (input_ndim < normalized_ndim ||
+        !input_shape.slice(input_ndim - normalized_ndim).equals(normalized_shape)) {
+      std::stringstream ss;
+      ss << "Given normalized_shape=" << normalized_shape
+         << ", expected input with shape [*";
+      for (auto size : normalized_shape) {
+        ss << ", " << size;
+      }
+      ss << "], but got input of size " << input_shape
+         << " and normalized_shape=" << normalized_shape;
+      throw std::runtime_error(ss.str());
+    }
+
+    int64_t n = 1;
+    for (int64_t i = 0; i < input_ndim - normalized_ndim; i++) {
+      n *= input_shape[i];
+    }
+
+    // Apply layer norm
+    auto input_reshaped = input.contiguous().view({1, n, -1});
+
+    auto out = at::batch_norm(input_reshaped, {}, {}, {}, {}, true, 0, eps, true);
+    out = out.view(input_shape);
+
+    if (weight.defined() && bias.defined()) {
+      return bias.addcmul(out, weight, 1);
+    } else if (weight.defined()) {
+      return out.mul(weight);
+    } else if (bias.defined()) {
+      return out.add(bias);
+    } else {
+      return out;
+    }
+}
+
 Tensor group_norm(const Tensor& input, int64_t num_groups,
     const Tensor& weight /* optional */, const Tensor& bias /* optional */,
     double eps) {
@@ -81,24 +149,24 @@ Tensor group_norm(const Tensor& input, int64_t num_groups,
     if (c % num_groups != 0) {
       std::stringstream ss;
       ss << "Expected number of channels in input to be divisible by "
-         << "num_groups, but got " << input.sizes() << " input and num_groups="
-         << num_groups;
+         << "num_groups, but got input of shape " << input.sizes() << " and "
+         << "num_groups=" << num_groups;
       throw std::runtime_error(ss.str());
     }
 
     if (weight.defined() && (weight.dim() != 1 || weight.numel() != c)) {
       std::stringstream ss;
       ss << "Expected weight to be a vector of size equal to the number of "
-         << "channels in input, but got " << weight.sizes() << " weight and "
-         <<  input.sizes() << " input";
+         << "channels in input, but got weight of shape " << weight.sizes()
+         << " and input of shape " <<  input.sizes();
       throw std::runtime_error(ss.str());
     }
 
     if (bias.defined() && (bias.dim() != 1 || bias.numel() != c)) {
       std::stringstream ss;
       ss << "Expected bias to be a vector of size equal to the number of "
-         << "channels in input, but got " << bias.sizes() << " bias and "
-         <<  input.sizes() << " input";
+         << "channels in input, but got bias of shape " << weight.sizes()
+         << " and input of shape " <<  input.sizes();
       throw std::runtime_error(ss.str());
     }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -323,7 +323,7 @@
 - func: ger_out(Tensor result, Tensor self, Tensor vec2) -> Tensor
   variants: function
 
-- func: group_norm(Tensor input, int64_t num_groups, Tensor? weight={}, Tensor? bias={}, double eps=1e-5) -> Tensor
+- func: group_norm(Tensor input, int64_t num_groups, Tensor? weight={}, Tensor? bias={}, double eps=1e-5, bool cudnn_enabled=True) -> Tensor
   variants: function
 
 # FFT
@@ -363,7 +363,7 @@
 
 - func: is_sparse(Tensor self) -> bool
 
-- func: layer_norm(Tensor input, IntList normalized_shape, Tensor? weight={}, Tensor? bias={}, double eps=1e-5) -> Tensor
+- func: layer_norm(Tensor input, IntList normalized_shape, Tensor? weight={}, Tensor? bias={}, double eps=1e-5, bool cudnn_enable=True) -> Tensor
   variants: function
 
 - func: linspace(Type dtype, Scalar start, Scalar end, int64_t steps=100) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -363,6 +363,9 @@
 
 - func: is_sparse(Tensor self) -> bool
 
+- func: layer_norm(Tensor input, IntList normalized_shape, Tensor? weight={}, Tensor? bias={}, double eps=1e-5) -> Tensor
+  variants: function
+
 - func: linspace(Type dtype, Scalar start, Scalar end, int64_t steps=100) -> Tensor
   variants: function
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1759,24 +1759,17 @@ class TestNN(NNTestCase):
             self.assertAlmostEqual(torch.abs(mean.data).mean(), bias, delta=1e-5)
             self.assertAlmostEqual(torch.abs(var.data).mean(), scale ** 2, delta=1e-5)
 
-            # test that LN with track_running_stats=True
-            ln = nn.LayerNorm(normalized_shape, momentum=1, eps=0,
-                              elementwise_affine=False, track_running_stats=True).type(type)
-            output_ref = ln(x).data.clone()
-            input_reshaped = x.view(*(unnormalized_shape + [-1]))
-            # make sure that running mean and var update correctly when training
-            mean = input_reshaped.mean(-1).mean()
-            var = input_reshaped.var(-1, unbiased=True).mean()
-            self.assertAlmostEqual(torch.abs(mean.data - ln.running_mean).mean(), 0, delta=1e-5)
-            self.assertAlmostEqual(torch.abs(var.data - ln.running_var).mean(), 0, delta=1e-5)
-            ln.eval()
-            old_running_mean = ln.running_mean.clone()
-            old_running_var = ln.running_var.clone()
-            output_new = ln(x + ln.running_var.sqrt()[0] * scale).data
-            self.assertAlmostEqual((output_new - output_ref).mean(), scale, delta=1e-5)
-            # make sure that running mean and var don't change in eval
-            self.assertEqual(old_running_mean, ln.running_mean)
-            self.assertEqual(old_running_var, ln.running_var)
+        bad_norm_shape_input_shape = {
+            (): (),
+            (2, 3): (3,),
+            (2,): (1, 2, 3),
+            (10,): (2, 3),
+            10: (2, 3),
+        }
+        for norm_shape, input_shape in bad_norm_shape_input_shape.items():
+            ln = nn.LayerNorm(norm_shape)
+            input = type(*input_shape).uniform_(0, 10)
+            self.assertRaises(RuntimeError, lambda: ln(input))
 
     def _test_LayerNorm_cuda_half(self):
         input = torch.zeros(2, 3, 3, 2, requires_grad=True).cuda().half().random_(1, 10)
@@ -5956,7 +5949,7 @@ new_module_tests = [
     ),
     dict(
         module_name='LayerNorm',
-        constructor_args=([5], 1e-3, 0.3),
+        constructor_args=([5], 1e-3),
         input_size=(4, 5, 5),
         cudnn=True,
         check_eval=True,
@@ -5964,7 +5957,7 @@ new_module_tests = [
     ),
     dict(
         module_name='LayerNorm',
-        constructor_args=([5], 1e-3, 0.3, False),
+        constructor_args=([5], 1e-3, False),
         input_size=(4, 5, 5),
         cudnn=True,
         check_eval=True,
@@ -5972,15 +5965,7 @@ new_module_tests = [
     ),
     dict(
         module_name='LayerNorm',
-        constructor_args=([5], 1e-3, 0.3, True, True),
-        input_size=(4, 5, 5),
-        cudnn=True,
-        check_eval=True,
-        desc='1d_elementwise_affine_tracking_stats',
-    ),
-    dict(
-        module_name='LayerNorm',
-        constructor_args=([2, 2, 5], 1e-3, 0.3),
+        constructor_args=([2, 2, 5], 1e-3),
         input_size=(4, 2, 2, 5),
         cudnn=True,
         check_eval=True,
@@ -5988,19 +5973,11 @@ new_module_tests = [
     ),
     dict(
         module_name='LayerNorm',
-        constructor_args=([2, 2, 5], 1e-3, 0.3, False),
+        constructor_args=([2, 2, 5], 1e-3, False),
         input_size=(4, 2, 2, 5),
         cudnn=True,
         check_eval=True,
         desc='3d_no_elementwise_affine',
-    ),
-    dict(
-        module_name='LayerNorm',
-        constructor_args=([2, 2, 5], 1e-3, 0.3, True, True),
-        input_size=(4, 2, 2, 5),
-        cudnn=True,
-        check_eval=True,
-        desc='3d_elementwise_affine_tracking_stats',
     ),
     dict(
         module_name='GroupNorm',

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1262,7 +1262,8 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
 
     See :class:`~torch.nn.LayerNorm` for details.
     """
-    return torch.layer_norm(input, normalized_shape, weight, bias, eps)
+    return torch.layer_norm(input, normalized_shape, weight, bias, eps,
+                            torch.backends.cudnn.enabled)
 
 
 def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
@@ -1270,7 +1271,8 @@ def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
 
     See :class:`~torch.nn.GroupNorm` for details.
     """
-    return torch.group_norm(input, num_groups, weight, bias, eps)
+    return torch.group_norm(input, num_groups, weight, bias, eps,
+                            torch.backends.cudnn.enabled)
 
 
 def local_response_norm(input, size, alpha=1e-4, beta=0.75, k=1):

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -93,21 +93,8 @@ class LayerNorm(Module):
         :attr:`affine` option, Layer Normalization applies per-element scale and
         bias with :attr:`elementwise_affine`.
 
-    By default, this layer uses statistics computed from input data in both
-    training and evaluation modes.
-
-    If :attr:`track_running_stats` is set to ``True``, during training this
-    layer keeps running estimates of its computed mean and variance, which are
-    then used for normalization during evaluation. The running estimates are
-    kept with a default :attr:`momentum` of 0.1.
-
-    .. note::
-        This :attr:`momentum` argument is different from one used in optimizer
-        classes and the conventional notion of momentum. Mathematically, the
-        update rule for running statistics here is
-        :math:`\hat{x}_\text{new} = (1 - \text{momentum}) \times \hat{x} + \text{momemtum} \times x_t`,
-        where :math:`\hat{x}` is the estimated statistic and :math:`x_t` is the
-        new observed value.
+    This layer uses statistics computed from input data in both training and
+    evaluation modes.
 
     Args:
         normalized_shape (int or list or torch.Size): input shape from an expected input
@@ -119,13 +106,8 @@ class LayerNorm(Module):
             If a single integer is used, it is treated as a singleton list, and this module will
             normalize over the last dimension with that specific size.
         eps: a value added to the denominator for numerical stability. Default: 1e-5
-        momentum: the value used for the running_mean and running_var computation. Default: 0.1
         elementwise_affine: a boolean value that when set to ``True``, this module
             has learnable per-element affine parameters. Default: ``True``
-        track_running_stats: a boolean value that when set to ``True``, this
-            module tracks the running mean and variance, and when set to ``False``,
-            this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)`
@@ -147,48 +129,33 @@ class LayerNorm(Module):
 
     .. _`Layer Normalization`: https://arxiv.org/abs/1607.06450
     """
-    def __init__(self, normalized_shape, eps=1e-5, momentum=0.1,
-                 elementwise_affine=True, track_running_stats=False):
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True):
         super(LayerNorm, self).__init__()
         if isinstance(normalized_shape, numbers.Integral):
             normalized_shape = (normalized_shape,)
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
-        self.momentum = momentum
         self.elementwise_affine = elementwise_affine
-        self.track_running_stats = track_running_stats
         if self.elementwise_affine:
             self.weight = Parameter(torch.Tensor(*normalized_shape))
             self.bias = Parameter(torch.Tensor(*normalized_shape))
         else:
             self.register_parameter('weight', None)
             self.register_parameter('bias', None)
-        if self.track_running_stats:
-            self.register_buffer('running_mean', torch.zeros(1))
-            self.register_buffer('running_var', torch.ones(1))
-        else:
-            self.register_parameter('running_mean', None)
-            self.register_parameter('running_var', None)
         self.reset_parameters()
 
     def reset_parameters(self):
-        if self.track_running_stats:
-            self.running_mean.zero_()
-            self.running_var.fill_(1)
         if self.elementwise_affine:
             self.weight.data.fill_(1)
             self.bias.data.zero_()
 
     def forward(self, input):
         return F.layer_norm(
-            input, self.normalized_shape, self.running_mean, self.running_var,
-            self.weight, self.bias, self.training or not self.track_running_stats,
-            self.momentum, self.eps)
+            input, self.normalized_shape, self.weight, self.bias, self.eps)
 
     def __repr__(self):
-        return ('{name}({normalized_shape}, eps={eps}, momentum={momentum},'
+        return ('{name}({normalized_shape}, eps={eps}, '
                 ' elementwise_affine={elementwise_affine},'
-                ' track_running_stats={track_running_stats})'
                 .format(name=self.__class__.__name__, **self.__dict__))
 
 


### PR DESCRIPTION
After discussing with @soumith , we decide to remove `track_running_stats` option from LayerNorm as it doesn't make much sense.

cc @soumith 