### PR TITLE
[distributions] Rename .params to .arg_constraints, fix logic

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -502,20 +502,12 @@ BAD_EXAMPLES = [
     ]),
     Example(TransformedDistribution, [
         {
-            'base_distribution': Normal(variable([1, 1], requires_grad=True),
-                                        variable([0, 1], requires_grad=True)),
-            'transforms': [],
+            'base_distribution': Normal(0, 1),
+            'transforms': lambda x: x,
         },
         {
-            'base_distribution': Normal(variable([1, 1], requires_grad=True),
-                                        variable([-1, -1], requires_grad=True)),
-            'transforms': ExpTransform(),
-        },
-        {
-            'base_distribution': Normal(variable([1, 1, 0], requires_grad=True),
-                                        variable([-1, -2, 3], requires_grad=True)),
-            'transforms': [AffineTransform(variable(torch.randn(3, 5)), variable(torch.randn(3, 5))),
-                           ExpTransform()],
+            'base_distribution': Normal(0, 1),
+            'transforms': [lambda x: x],
         },
     ]),
     Example(Uniform, [
@@ -2705,7 +2697,7 @@ class TestConstraints(TestCase):
                         # use a stricter constraint to the simplex.
                         value = value / value.sum(-1, True)
                     try:
-                        constraint = dist.params[name]
+                        constraint = dist.arg_constraints[name]
                     except KeyError:
                         continue  # ignore optional parameters
 
@@ -3283,15 +3275,11 @@ class TestValidation(TestCase):
 
     def test_valid(self):
         for Dist, params in EXAMPLES:
-            if constraints.is_dependent(Dist.params):  # skipping transformed dist
-                continue
             for i, param in enumerate(params):
                 Dist(validate_args=True, **param)
 
     def test_invalid(self):
         for Dist, params in BAD_EXAMPLES:
-            if constraints.is_dependent(Dist.params):  # skipping transformed dist
-                continue
             for i, param in enumerate(params):
                 try:
                     with self.assertRaises(ValueError):

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -58,7 +58,7 @@ deterministic function of a parameter-free random variable. The reparameterized
 sample therefore becomes differentiable. The code for implementing the pathwise
 derivative would be as follows::
 
-    arg_constraints = policy_network(state)
+    params = policy_network(state)
     m = Normal(*params)
     # Any distribution with .has_rsample == True could work based on the application
     action = m.rsample()

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -58,7 +58,7 @@ deterministic function of a parameter-free random variable. The reparameterized
 sample therefore becomes differentiable. The code for implementing the pathwise
 derivative would be as follows::
 
-    params = policy_network(state)
+    arg_constraints = policy_network(state)
     m = Normal(*params)
     # Any distribution with .has_rsample == True could work based on the application
     action = m.rsample()

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -26,7 +26,7 @@ class Bernoulli(ExponentialFamily):
         probs (Number, Tensor): the probabilty of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
     """
-    params = {'probs': constraints.unit_interval}
+    arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.boolean
     has_enumerate_support = True
     _mean_carrier_measure = 0

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -24,7 +24,7 @@ class Beta(ExponentialFamily):
         concentration0 (float or Tensor): 2nd concentration parameter of the distribution
             (often referred to as beta)
     """
-    params = {'concentration1': constraints.positive, 'concentration0': constraints.positive}
+    arg_constraints = {'concentration1': constraints.positive, 'concentration0': constraints.positive}
     support = constraints.unit_interval
     has_rsample = True
 

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -31,7 +31,7 @@ class Binomial(Distribution):
         probs (Tensor): Event probabilities
         logits (Tensor): Event log-odds
     """
-    params = {'probs': constraints.unit_interval}
+    arg_constraints = {'probs': constraints.unit_interval}
     has_enumerate_support = True
 
     def __init__(self, total_count=1, probs=None, logits=None, validate_args=None):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -37,7 +37,7 @@ class Categorical(Distribution):
         probs (Tensor): event probabilities
         logits (Tensor): event log probabilities
     """
-    params = {'probs': constraints.simplex}
+    arg_constraints = {'probs': constraints.simplex}
     has_enumerate_support = True
 
     def __init__(self, probs=None, logits=None, validate_args=None):

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -24,7 +24,7 @@ class Cauchy(Distribution):
         loc (float or Tensor): mode or median of the distribution.
         scale (float or Tensor): half width at half maximum.
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
     has_rsample = True
 

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -17,7 +17,7 @@ class Chi2(Gamma):
     Args:
         df (float or Tensor): shape parameter of the distribution
     """
-    params = {'df': constraints.positive}
+    arg_constraints = {'df': constraints.positive}
 
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -16,13 +16,13 @@ bijectivity.
 
 The ``transform_to()`` registry is useful for performing unconstrained
 optimization on constrained parameters of probability distributions, which are
-indicated by each distribution's ``.params`` dict. These transforms often
+indicated by each distribution's ``.arg_constraints`` dict. These transforms often
 overparameterize a space in order to avoid rotation; they are thus more
 suitable for coordinate-wise optimization algorithms like Adam::
 
     loc = Variable(torch.zeros(100), requires_grad=True)
     unconstrained = Variable(torch.zeros(100), requires_grad=True)
-    scale = transform_to(Normal.params['scale'])(unconstrained)
+    scale = transform_to(Normal.arg_constraints['scale'])(unconstrained)
     loss = -Normal(loc, scale).log_prob(data).sum()
 
 The ``biject_to()`` registry is useful for Hamiltonian Monte Carlo, where
@@ -92,7 +92,7 @@ class ConstraintRegistry(object):
             @my_registry.register(MyConstraintClass)
             def construct_transform(constraint):
                 assert isinstance(constraint, MyConstraint)
-                return MyTransform(constraint.params)
+                return MyTransform(constraint.arg_constraints)
 
         Args:
             constraint (subclass of :class:`~torch.distributions.constraints.Constraint`):
@@ -121,7 +121,7 @@ class ConstraintRegistry(object):
         Looks up a transform to constrained space, given a constraint object.
         Usage::
 
-            constraint = Normal.params['scale']
+            constraint = Normal.arg_constraints['scale']
             scale = transform_to(constraint)(torch.zeros(1))  # constrained
             u = transform_to(constraint).inv(scale)           # unconstrained
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -52,7 +52,7 @@ class Dirichlet(ExponentialFamily):
         concentration (Tensor): concentration parameter of the distribution
             (often referred to as alpha)
     """
-    params = {'concentration': constraints.positive}
+    arg_constraints = {'concentration': constraints.positive}
     support = constraints.simplex
     has_rsample = True
 

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -13,7 +13,7 @@ class Distribution(object):
     has_enumerate_support = False
     _validate_args = False
     support = None
-    params = {}
+    arg_constraints = {}
 
     @staticmethod
     def set_default_validate_args(value):
@@ -27,11 +27,10 @@ class Distribution(object):
         if validate_args is not None:
             self._validate_args = validate_args
         if self._validate_args:
-            if not constraints.is_dependent(self.params):
-                for param, constraint in self.params.items():
-                    if not constraints.is_dependent(constraint):
-                        if not constraint.check(self.__getattribute__(param)).all():
-                            raise ValueError("The parameter {} has invalid values".format(param))
+            for param, constraint in self.arg_constraints.items():
+                if not constraints.is_dependent(constraint):
+                    if not constraint.check(self.__getattribute__(param)).all():
+                        raise ValueError("The parameter {} has invalid values".format(param))
 
     @property
     def batch_shape(self):
@@ -48,19 +47,20 @@ class Distribution(object):
         return self._event_shape
 
     @property
-    def params(self):
+    def arg_constraints(self):
         """
-        Returns a dictionary from param names to `Constraint` objects that
-        should be satisfied by each parameter of this distribution. For
-        distributions with multiple parameterization, only one complete
-        set of parameters should be specified in `.params`.
+        Returns a dictionary from argument names to
+        :class:`~torch.distributions.constraints.Constraint` objects that
+        should be satisfied by each argument of this distribution. Args that
+        are not tensors need not appear in this dict.
         """
         raise NotImplementedError
 
     @property
     def support(self):
         """
-        Returns a `Constraint` object representing this distribution's support.
+        Returns a :class:`~torch.distributions.constraints.Constraint` object
+        representing this distribution's support.
         """
         raise NotImplementedError
 

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -20,7 +20,7 @@ class Exponential(ExponentialFamily):
     Args:
         rate (float or Tensor): rate = 1 / scale of the distribution
     """
-    params = {'rate': constraints.positive}
+    arg_constraints = {'rate': constraints.positive}
     support = constraints.positive
     has_rsample = True
     _mean_carrier_measure = 0

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -22,7 +22,7 @@ class FisherSnedecor(Distribution):
         df1 (float or Tensor): degrees of freedom parameter 1
         df2 (float or Tensor): degrees of freedom parameter 2
     """
-    params = {'df1': constraints.positive, 'df2': constraints.positive}
+    arg_constraints = {'df1': constraints.positive, 'df2': constraints.positive}
     support = constraints.positive
     has_rsample = True
 

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -29,7 +29,7 @@ class Gamma(ExponentialFamily):
         rate (float or Tensor): rate = 1 / scale of the distribution
             (often referred to as beta)
     """
-    params = {'concentration': constraints.positive, 'rate': constraints.positive}
+    arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
     support = constraints.positive
     has_rsample = True
     _mean_carrier_measure = 0

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -26,7 +26,7 @@ class Geometric(Distribution):
         probs (Number, Tensor): the probabilty of sampling `1`. Must be in range (0, 1]
         logits (Number, Tensor): the log-odds of sampling `1`.
     """
-    params = {'probs': constraints.unit_interval}
+    arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.nonnegative_integer
 
     def __init__(self, probs=None, logits=None, validate_args=None):

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -25,7 +25,7 @@ class Gumbel(TransformedDistribution):
         loc (float or Tensor): Location parameter of the distribution
         scale (float or Tensor): Scale parameter of the distribution
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
 
     def __init__(self, loc, scale, validate_args=None):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -20,7 +20,7 @@ class Laplace(Distribution):
         loc (float or Tensor): mean of the distribution
         scale (float or Tensor): scale of the distribution
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
     has_rsample = True
 

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -23,7 +23,7 @@ class LogNormal(TransformedDistribution):
         loc (float or Tensor): mean of log of distribution
         scale (float or Tensor): standard deviation of log ofthe distribution
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.positive
     has_rsample = True
 

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -29,7 +29,7 @@ class LogisticNormal(TransformedDistribution):
         loc (float or Tensor): mean of the base distribution
         scale (float or Tensor): standard deviation of the base distribution
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.simplex
     has_rsample = True
 

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -42,7 +42,7 @@ class Multinomial(Distribution):
         probs (Tensor): event probabilities
         logits (Tensor): event log probabilities
     """
-    params = {'logits': constraints.real}  # Let logits be the canonical parameterization.
+    arg_constraints = {'logits': constraints.real}  # Let logits be the canonical parameterization.
 
     @property
     def mean(self):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -101,8 +101,8 @@ class MultivariateNormal(Distribution):
         matrices using a Cholesky decomposition.
     """
     arg_constraints = {'loc': constraints.real_vector,
-              'covariance_matrix': constraints.positive_definite,
-              'scale_tril': constraints.lower_cholesky}
+                       'covariance_matrix': constraints.positive_definite,
+                       'scale_tril': constraints.lower_cholesky}
     support = constraints.real
     has_rsample = True
 

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -100,7 +100,7 @@ class MultivariateNormal(Distribution):
         this is only used to compute the corresponding lower triangular
         matrices using a Cholesky decomposition.
     """
-    params = {'loc': constraints.real_vector,
+    arg_constraints = {'loc': constraints.real_vector,
               'covariance_matrix': constraints.positive_definite,
               'scale_tril': constraints.lower_cholesky}
     support = constraints.real

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -24,7 +24,7 @@ class Normal(ExponentialFamily):
         scale (float or Tensor): standard deviation of the distribution
             (often referred to as sigma)
     """
-    params = {'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
     has_rsample = True
     _mean_carrier_measure = 0

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -31,7 +31,7 @@ class OneHotCategorical(Distribution):
         probs (Tensor): event probabilities
         logits (Tensor): event log probabilities
     """
-    params = {'probs': constraints.simplex}
+    arg_constraints = {'probs': constraints.simplex}
     support = constraints.simplex
     has_enumerate_support = True
 

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -25,7 +25,7 @@ class Pareto(TransformedDistribution):
         scale (float or Tensor): Scale parameter of the distribution
         alpha (float or Tensor): Shape parameter of the distribution
     """
-    params = {'alpha': constraints.positive, 'scale': constraints.positive}
+    arg_constraints = {'alpha': constraints.positive, 'scale': constraints.positive}
 
     def __init__(self, scale, alpha, validate_args=None):
         self.scale, self.alpha = broadcast_all(scale, alpha)

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -24,7 +24,7 @@ class Poisson(ExponentialFamily):
     Args:
         rate (Number, Tensor): the rate parameter
     """
-    params = {'rate': constraints.positive}
+    arg_constraints = {'rate': constraints.positive}
     support = constraints.nonnegative_integer
 
     @property

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -26,7 +26,7 @@ class LogitRelaxedBernoulli(Distribution):
     [2] Categorical Reparametrization with Gumbel-Softmax
     (Jang et al, 2017)
     """
-    params = {'probs': constraints.unit_interval}
+    arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.real
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
@@ -97,7 +97,7 @@ class RelaxedBernoulli(TransformedDistribution):
         probs (Number, Tensor): the probabilty of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
     """
-    params = {'probs': constraints.unit_interval}
+    arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.unit_interval
     has_rsample = True
 

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -28,7 +28,7 @@ class ExpRelaxedCategorical(Distribution):
     [2] Categorical Reparametrization with Gumbel-Softmax
     (Jang et al, 2017)
     """
-    params = {'probs': constraints.simplex}
+    arg_constraints = {'probs': constraints.simplex}
     support = constraints.real
     has_rsample = True
 
@@ -95,7 +95,7 @@ class RelaxedOneHotCategorical(TransformedDistribution):
         probs (Tensor): event probabilities
         logits (Tensor): the log probability of each event.
     """
-    params = {'probs': constraints.simplex}
+    arg_constraints = {'probs': constraints.simplex}
     support = constraints.simplex
     has_rsample = True
 

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -21,7 +21,7 @@ class StudentT(Distribution):
     Args:
         df (float or Tensor): degrees of freedom
     """
-    params = {'df': constraints.positive, 'loc': constraints.real, 'scale': constraints.positive}
+    arg_constraints = {'df': constraints.positive, 'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
     has_rsample = True
 

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -18,6 +18,8 @@ class TransformedDistribution(Distribution):
     maximum shape of its base distribution and its transforms, since transforms
     can introduce correlations among events.
     """
+    arg_constraints = {}
+
     def __init__(self, base_distribution, transforms, validate_args=None):
         self.base_dist = base_distribution
         if isinstance(transforms, Transform):
@@ -33,10 +35,6 @@ class TransformedDistribution(Distribution):
         batch_shape = shape[:len(shape) - event_dim]
         event_shape = shape[len(shape) - event_dim:]
         super(TransformedDistribution, self).__init__(batch_shape, event_shape, validate_args=validate_args)
-
-    @constraints.dependent_property
-    def params(self):
-        return self.base_dist.params  # TODO add params of transforms?
 
     @constraints.dependent_property
     def support(self):

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -25,7 +25,7 @@ class Uniform(Distribution):
         high (float or Tensor): upper range (exclusive).
     """
     # TODO allow (loc,scale) parameterization to allow independent constraints.
-    params = {'low': constraints.dependent, 'high': constraints.dependent}
+    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
     has_rsample = True
 
     @property


### PR DESCRIPTION
This PR originated from discussion with @apaszke at https://github.com/pytorch/pytorch/pull/5358#discussion_r174145151

1. Renames `.params` to `.arg_constraints` to make it clear that this dict concerns arguments to the `__init__()` method (as suggested by @apaszke and @alicanb). This avoids confusion with other PyTorch usage of `.parameters` to mean "the set of leaf variables parameterizing an object". The distinction is especially important regarding `TransformedDistribution`, some of whose parameters are part of `.base_dist` and other of whose parameters are part of various `.transforms`.
2. Fixes buggy/inconsistent logic whereby `TransformedDistribution.params` was a `Constraint` object (a `constraints.dependent_property`) and referred to leaf params in its `.base_dist`. After this PR `TransformedDistribution.arg_constraints == {}`, since the `.base_dist` will do its own arg validation. This is currently triggering errors when we turn on arg_validation in the Pyro unit test suite https://github.com/uber/pyro/pull/922 (test logs https://travis-ci.org/uber/pyro/jobs/357976836)

Previous review: https://github.com/probtorch/pytorch/pull/142