### PR TITLE
Fixes #5973: Stop printing verbose warnings for MSVC

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -34,7 +34,7 @@ INCLUDE(CheckCXXSourceCompiles)
 
 # disable some verbose warnings
 IF (MSVC)
-  set(CMAKE_CXX_FLAGS "/wd4267 /wd4251 /wd4522 /wd4522 /wd4838 /wd4305 /wd4244 /wd4190 /wd4101 /wd4996 ${CMAKE_CXX_FALGS}")
+  set(CMAKE_CXX_FLAGS "/wd4267 /wd4251 /wd4522 /wd4522 /wd4838 /wd4305 /wd4244 /wd4190 /wd4101 /wd4996 /wd4275 ${CMAKE_CXX_FALGS}")
 ENDIF(MSVC)
 
 # windef.h will define max/min macros if NOMINMAX is not defined

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -32,6 +32,11 @@ ENDIF(NOT MSVC)
 
 INCLUDE(CheckCXXSourceCompiles)
 
+# disable some verbose warnings
+IF (MSVC)
+  set(CMAKE_CXX_FLAGS "/wd4267 /wd4251 /wd4522 /wd4522 /wd4838 /wd4305 /wd4244 /wd4190 /wd4101 /wd4996 ${CMAKE_CXX_FALGS}")
+ENDIF(MSVC)
+
 # windef.h will define max/min macros if NOMINMAX is not defined
 IF(MSVC)
   add_definitions(/DNOMINMAX)
@@ -75,7 +80,7 @@ ENDIF()
 IF(MSVC)
   # we want to respect the standard, and we are bored of those **** .
   ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE=1)
-  LIST(APPEND CUDA_NVCC_FLAGS "-Xcompiler /wd4819 -Xcompiler /wd4503")
+  LIST(APPEND CUDA_NVCC_FLAGS "-Xcompiler /wd4819 -Xcompiler /wd4503 -Xcompiler /wd4190 -Xcompiler /wd4244 -Xcompiler /wd4251 -Xcompiler /wd4275 -Xcompiler /wd4522")
   ADD_DEFINITIONS(-DTH_EXPORTS)
   IF (NOT NO_CUDA)
     ADD_DEFINITIONS(-DTHC_EXPORTS)

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -34,7 +34,7 @@ INCLUDE(CheckCXXSourceCompiles)
 
 # disable some verbose warnings
 IF (MSVC)
-  set(CMAKE_CXX_FLAGS "/wd4267 /wd4251 /wd4522 /wd4522 /wd4838 /wd4305 /wd4244 /wd4190 /wd4101 /wd4996 /wd4275 ${CMAKE_CXX_FALGS}")
+  set(CMAKE_CXX_FLAGS "/wd4267 /wd4251 /wd4522 /wd4522 /wd4838 /wd4305 /wd4244 /wd4190 /wd4101 /wd4996 /wd4275 ${CMAKE_CXX_FLAGS}")
 ENDIF(MSVC)
 
 # windef.h will define max/min macros if NOMINMAX is not defined

--- a/setup.py
+++ b/setup.py
@@ -462,11 +462,14 @@ library_dirs = []
 extra_link_args = []
 
 if IS_WINDOWS:
-    extra_compile_args = ['/Z7', '/EHa', '/DNOMINMAX'
+    extra_compile_args = ['/Z7', '/EHa', '/DNOMINMAX', '/wd4267', '/wd4251', '/wd4522',
+                          '/wd4522', '/wd4838', '/wd4305', '/wd4244', '/wd4190',
+                          '/wd4101', '/wd4996'
                           # /Z7 turns on symbolic debugging information in .obj files
                           # /EHa is about native C++ catch support for asynchronous
                           # structured exception handling (SEH)
                           # /DNOMINMAX removes builtin min/max functions
+                          # /wdXXXX disables warning no. XXXX
                           ]
     if sys.version_info[0] == 2:
         # /bigobj increases number of sections in .obj file, which is needed to link

--- a/setup.py
+++ b/setup.py
@@ -464,7 +464,7 @@ extra_link_args = []
 if IS_WINDOWS:
     extra_compile_args = ['/Z7', '/EHa', '/DNOMINMAX', '/wd4267', '/wd4251', '/wd4522',
                           '/wd4522', '/wd4838', '/wd4305', '/wd4244', '/wd4190',
-                          '/wd4101', '/wd4996'
+                          '/wd4101', '/wd4996', '/wd4275'
                           # /Z7 turns on symbolic debugging information in .obj files
                           # /EHa is about native C++ catch support for asynchronous
                           # structured exception handling (SEH)


### PR DESCRIPTION
This PR targets #5973 and aims to make Windows log smaller.