### PR TITLE
Update FAQ to make more sense after tensor/variable merge

### DIFF
--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -30,13 +30,11 @@ occur.  Consider the following training loop (abridged from `source
         loss = criterion(output)
         loss.backward()
         optimizer.step()
-        total_loss += loss[0]
+        total_loss += loss
 
-Here, ``total_loss`` is accumulating history across your training loop.
-This code looks innocuous because ``loss[0]`` implies that you are
-converting the tensor to a scalar, but ``loss[0]`` is still a
-differentiable Variable!  You can fix this code by writing
-``loss.data[0]`` instead.
+Here, ``total_loss`` is accumulating history across your training loop, since
+``loss`` is a differentiable variable with autograd history. You can fix this by
+writing `total_loss += float(loss)` instead.
 
 Other instances of this problem:
 `1 <https://discuss.pytorch.org/t/resolved-gpu-out-of-memory-error-with-batch-size-1/3719>`_.


### PR DESCRIPTION
Looks like there's already a note about the `total_loss += loss` trouble. I've updated it to make more sense after the tensor/variable merge.

Also, GitHub doesn't allow pull requests for the wiki. Can someone please edit https://github.com/pytorch/pytorch/wiki/Breaking-Changes-from-Variable-and-Tensor-merge with something like

```
## Possible Issues

* If you have code that accumulates losses across iterations (e.g. to compute an
average at the end of an epoch), such as `total_loss += loss` where `loss` is
your per-iteration loss, you may find increased memory usage in your program.
This is because `loss` probably used to be a Python float (such as when it is
the result of `.sum()`), while it is now a zero-dim Tensor. `total_loss` is
thus accumulating `Tensor`s and their gradient history, which may keep around
large autograd graphs for much longer than necessary. To fix this, be sure to
convert the per-iteration loss to a Python number as soon as possible, for
example with `total_loss += float(loss)`.
```

@ezyang @apaszke @soumith 