### PR TITLE
Use THC cached CUDA device property in certain torch.cuda.* methods

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -120,6 +120,16 @@ struct cudaDeviceProp* Context::getCurrentDeviceProperties() const {
 struct cudaDeviceProp* Context::getDeviceProperties(int device) const {
   return THCState_getDeviceProperties(thc_state, device);
 }
+#else
+cudaStream_t Context::getCurrentCUDAStream() const {
+  throw std::runtime_error("ATen not compiled with CUDA");
+}
+struct cudaDeviceProp* Context::getCurrentDeviceProperties() const {
+  throw std::runtime_error("ATen not compiled with CUDA");
+}
+struct cudaDeviceProp* Context::getDeviceProperties(int device) const {
+  throw std::runtime_error("ATen not compiled with CUDA");
+}
 #endif
 
 int64_t Context::current_device() const {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -65,30 +65,6 @@ PyObject * THCPModule_getDeviceCount_wrap(PyObject *self)
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THCPModule_getDeviceName_wrap(PyObject *self, PyObject *arg)
-{
-  HANDLE_TH_ERRORS
-  THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to getDeviceName");
-  long device = THPUtils_unpackLong(arg);
-
-  cudaDeviceProp prop;
-  THCudaCheck(cudaGetDeviceProperties(&prop, device));
-  return THPUtils_packString(prop.name);
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject * THCPModule_getDeviceCapability_wrap(PyObject *self, PyObject *arg)
-{
-  HANDLE_TH_ERRORS
-  THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to getDeviceCapability");
-  long device = THPUtils_unpackLong(arg);
-
-  cudaDeviceProp prop;
-  THCudaCheck(cudaGetDeviceProperties(&prop, device));
-  return Py_BuildValue("(ii)", prop.major, prop.minor);
-  END_HANDLE_TH_ERRORS
-}
-
 
 PyObject * THCPModule_getCurrentStream_wrap(PyObject *self)
 {
@@ -413,8 +389,6 @@ static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_setDevice",   (PyCFunction)THCPModule_setDevice_wrap,   METH_O,       NULL},
   {"_cuda_getDevice",   (PyCFunction)THCPModule_getDevice_wrap,   METH_NOARGS,  NULL},
   {"_cuda_getDeviceCount", (PyCFunction)THCPModule_getDeviceCount_wrap, METH_NOARGS, NULL},
-  {"_cuda_getDeviceName", (PyCFunction)THCPModule_getDeviceName_wrap, METH_O,   NULL},
-  {"_cuda_getDeviceCapability", (PyCFunction)THCPModule_getDeviceCapability_wrap, METH_O,   NULL},
   {"_cuda_getCurrentStream", (PyCFunction)THCPModule_getCurrentStream_wrap, METH_NOARGS, NULL},
   {"_cuda_getCurrentBlasHandle", (PyCFunction)THCPModule_getCurrentBlasHandle_wrap, METH_NOARGS, NULL},
   {"_cuda_setStream",    (PyCFunction)THCPModule_setStream_wrap,  METH_O, NULL},

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -269,8 +269,7 @@ def get_device_name(device):
         device (int): device for which to return the name. This function is a
             no-op if this argument is negative.
     """
-    if device >= 0:
-        return torch._C._cuda_getDeviceName(device)
+    return get_device_properties(device).name
 
 
 def get_device_capability(device):
@@ -282,8 +281,8 @@ def get_device_capability(device):
     Returns:
         tuple(int, int): the major and minor cuda capability of the device
     """
-    if device >= 0:
-        return torch._C._cuda_getDeviceCapability(device)
+    prop = get_device_properties(device)
+    return prop.major, prop.minor
 
 
 def get_device_properties(device):


### PR DESCRIPTION
Getting CUDA device property struct with `cudaGetDeviceProperties` is expensive. THC caches CUDA device property, which is available via `THCState_getDeviceProperties`, which is available via `at::globalContext().getDeviceProperties(device)`, which is available via `torch.cuda.get_device_properties`. This PR changes the two methods that previously calls `cudaGetDeviceProperties` to directly using `torch.cuda.get_device_properties` in Python.

Also fixes ATen compile error when it can't find CUDA.

Fixes https://github.com/pytorch/pytorch/issues/4908. Using the script from that issue, we get roughly 18x speed-up.
```
[ssnl@ ~] python dev.py  # master
0.2826697587966919
0.00034999847412109375
0.0003493785858154297
0.000356292724609375
0.00036025047302246094
0.0003629922866821289
0.00036084651947021484
0.00035686492919921874
0.00036056041717529296
0.0003606319427490234
[ssnl@ ~] python dev.py  # this PR
0.27275662422180175
2.1147727966308594e-05
1.9598007202148438e-05
1.94549560546875e-05
1.9359588623046876e-05
1.938343048095703e-05
2.0074844360351563e-05
1.952648162841797e-05
1.9311904907226562e-05
1.938343048095703e-05
```