### PR TITLE
ATen Unary Ops

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1665,20 +1665,8 @@
     - THTensor* self
 ]]
 [[
-  name: sqrt_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _sqrt
   cname: sqrt
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: sqrt
   types:
     - floating_point
   backends:
@@ -1723,20 +1711,8 @@
     - THTensor* self
 ]]
 [[
-  name: ceil_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _ceil
   cname: ceil
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: ceil
   types:
     - floating_point
   backends:
@@ -1752,20 +1728,8 @@
     - THTensor* self
 ]]
 [[
-  name: floor_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _floor
   cname: floor
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: floor
   types:
     - floating_point
   backends:
@@ -1781,20 +1745,8 @@
     - THTensor* self
 ]]
 [[
-  name: round_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _round
   cname: round
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: round
   types:
     - floating_point
   backends:
@@ -1810,20 +1762,8 @@
     - THTensor* self
 ]]
 [[
-  name: trunc_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _trunc
   cname: trunc
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: trunc
   types:
     - floating_point
   backends:

--- a/aten/src/ATen/Parallel.cpp
+++ b/aten/src/ATen/Parallel.cpp
@@ -4,15 +4,15 @@
 #include <tbb/parallel_reduce.h>
 #include <tbb/partitioner.h>
 #include <tbb/tbb.h>
-#include <thread>
 #include <cassert>
+#include <thread>
 
-namespace at {
-namespace internal {
+namespace at { namespace internal {
 
 // thread_local variable with internal linkage
 // requires no guarding as it's storage duration is defined to be per thread
-static thread_local tbb::task_scheduler_init tbbinit(tbb::task_scheduler_init::deferred);
+static thread_local tbb::task_scheduler_init tbbinit(
+    tbb::task_scheduler_init::deferred);
 // Tracks number of threads uses which TBB doesn't track.
 static thread_local int num_threads_ = -1;
 
@@ -22,9 +22,9 @@ void init_tbb_num_threads() {
   int num_threads = at::get_num_threads();
   // In order to have control over the number of threads this function
   // must be called first before any other tbb parallel construct is
-  // excercised within a particular thread. Otherwise the default 
-  // scheduler will be created over which we do not have control. 
-  // The following code will and must throw an error if tbb has 
+  // excercised within a particular thread. Otherwise the default
+  // scheduler will be created over which we do not have control.
+  // The following code will and must throw an error if tbb has
   // already been initialized before this function was called.
   if (!tbbinit.is_active() && !first_call)
     throw std::runtime_error(
@@ -51,5 +51,4 @@ void init_tbb_num_threads() {
     num_threads_ = num_threads;
   }
 }
-}
-}
+}} // namespace at::internal

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,6 +1,7 @@
 #pragma once
-#include <cstddef>
+#include <ATen/ATen.h>
 #include <tbb/tbb.h>
+#include <cstddef>
 
 namespace at {
 namespace internal {
@@ -21,12 +22,15 @@ void init_tbb_num_threads();
 // no parallel algorithm (such as parallel_reduce) should split work into
 // smaller than GRAIN_SIZE chunks.
 constexpr size_t TBB_GRAIN_SIZE = 32768;
-}
+} // namespace internal
 
 template <class T, template <class> class OP>
-T parallel_reduce(T (*f)(const T *, size_t, size_t, T), const T *data,
-                  size_t start, size_t end, T init_) {
-
+T parallel_reduce(
+    T (*f)(const T*, size_t, size_t, T),
+    const T* data,
+    size_t start,
+    size_t end,
+    T init_) {
   internal::init_tbb_num_threads();
 
   T result_;
@@ -35,19 +39,25 @@ T parallel_reduce(T (*f)(const T *, size_t, size_t, T), const T *data,
     result_ = f(data, start, end, init_);
   } else {
     result_ = tbb::parallel_reduce(
-        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE), init_,
+        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE),
+        init_,
         [&data, &f](const tbb::blocked_range<size_t> r, T init) -> T {
           return f(data, r.begin(), r.end(), init);
         },
-        OP<T>(), ap);
+        OP<T>(),
+        ap);
   }
   return result_;
 }
 
 template <class T>
-void parallel_reduce_2d(void (*f)(const T *, T *, size_t, size_t), size_t num_rows,
-                     size_t num_cols, size_t numel, const T *arr_, T *outarr_) {
-
+void parallel_reduce_2d(
+    void (*f)(const T*, T*, size_t, size_t),
+    size_t num_rows,
+    size_t num_cols,
+    size_t numel,
+    const T* arr_,
+    T* outarr_) {
   internal::init_tbb_num_threads();
 
   static tbb::affinity_partitioner ap;
@@ -63,19 +73,44 @@ void parallel_reduce_2d(void (*f)(const T *, T *, size_t, size_t), size_t num_ro
       f(arr, outarr, num_rows, num_cols);
     }
   } else {
-    tbb::parallel_for(tbb::blocked_range<size_t>(
-                          0, max_i_, 1),
-                      [&arr_, &outarr_, num_rows, num_cols,
-                       &f](const tbb::blocked_range<size_t> r) {
-                        for (size_t i_ = r.begin(); i_ < r.end(); i_++) {
-                          int64_t i = i_ * num_rows * num_cols;
-                          int64_t i_r = i_ * num_cols;
-                          const T *arr = arr_ + i;
-                          T *outarr = outarr_ + i_r;
-                          f(arr, outarr, num_rows, num_cols);
-                        }
-                      },
-                      ap);
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, max_i_, 1),
+        [&arr_, &outarr_, num_rows, num_cols, &f](
+            const tbb::blocked_range<size_t> r) {
+          for (size_t i_ = r.begin(); i_ < r.end(); i_++) {
+            int64_t i = i_ * num_rows * num_cols;
+            int64_t i_r = i_ * num_cols;
+            const T* arr = arr_ + i;
+            T* outarr = outarr_ + i_r;
+            f(arr, outarr, num_rows, num_cols);
+          }
+        },
+        ap);
   }
 }
+
+template <class T>
+void parallel_for_1d(
+    void (*f)(T*, const T*, size_t, size_t),
+    Tensor& result,
+    const Tensor& self) {
+  internal::init_tbb_num_threads();
+
+  static tbb::affinity_partitioner ap;
+
+  T* arr_out = result.data<T>();
+  const T* arr_in = self.data<T>();
+  size_t start = 0;
+  size_t end = self.numel();
+  if (end - start < internal::TBB_GRAIN_SIZE) {
+    f(arr_out, arr_in, start, end);
+  } else {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE),
+        [&arr_out, &arr_in, &f](const tbb::blocked_range<size_t> r) {
+          f(arr_out, arr_in, r.begin(), r.end());
+        },
+        ap);
+  }
 }
+} // namespace at

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -12,43 +12,46 @@
 
 #include <map>
 
-namespace at {
-namespace native {
+namespace at { namespace native {
 
-using reduce_type = void(Tensor &, const Tensor &, size_t, bool);
-reduce_type *sumImpl = &DispatchStub<reduce_type>::init<sumImplC, &sumImpl>;
-reduce_type *prodImpl = &DispatchStub<reduce_type>::init<prodImplC, &prodImpl>;
+using reduce_type = void(Tensor&, const Tensor&, size_t, bool);
+reduce_type* sumImpl = &DispatchStub<reduce_type>::init<sumImplC, &sumImpl>;
+reduce_type* prodImpl = &DispatchStub<reduce_type>::init<prodImplC, &prodImpl>;
 
 // ALL REDUCE #################################################################
 
-Tensor _reduce_cpu(reduce_type *f, const Tensor &self) {
+Tensor _reduce_cpu(reduce_type* f, const Tensor& self) {
   Tensor result = self.type().tensor({});
   f(result, self, 0, true);
   return result;
 }
 
-Tensor _sum_cpu(const Tensor &self) {
+Tensor _sum_cpu(const Tensor& self) {
   if (self.is_contiguous())
     return _reduce_cpu(sumImpl, self);
   return self._sumall();
 }
 
-Tensor _prod_cpu(const Tensor &self) {
+Tensor _prod_cpu(const Tensor& self) {
   if (self.is_contiguous())
     return _reduce_cpu(prodImpl, self);
   return self._prodall();
 }
 
-Tensor _sum_cuda(const Tensor &self_) { return self_._sumall(); }
+Tensor _sum_cuda(const Tensor& self_) {
+  return self_._sumall();
+}
 
-Tensor _prod_cuda(const Tensor &self_) { return self_._prodall(); }
+Tensor _prod_cuda(const Tensor& self_) {
+  return self_._prodall();
+}
 
 // \ALL REDUCE ################################################################
 
 // DIM REDUCE #################################################################
 
-static bool _dimreduce_return_trivial(Tensor &result, const Tensor &self,
-                                      int64_t ident) {
+static bool
+_dimreduce_return_trivial(Tensor& result, const Tensor& self, int64_t ident) {
   if (self.numel() == 1 && self.ndimension() == 0) {
     result.resize_({});
     result.fill_(self);
@@ -63,8 +66,8 @@ static bool _dimreduce_return_trivial(Tensor &result, const Tensor &self,
   return false;
 }
 
-static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
-                                int64_t dim) {
+static Tensor&
+_dimreduce_setup(Tensor& result, const Tensor& self, int64_t dim) {
   IntList self_sizes = self.sizes();
   std::vector<int64_t> result_sizes;
   result_sizes.insert(result_sizes.end(), self_sizes.begin(), self_sizes.end());
@@ -73,8 +76,12 @@ static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
   return result;
 }
 
-Tensor &_reduce_out_cpu(reduce_type *f, Tensor &result, const Tensor &self,
-                        int64_t dim, bool keepdim) {
+Tensor& _reduce_out_cpu(
+    reduce_type* f,
+    Tensor& result,
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim) {
   result = _dimreduce_setup(result, self, dim);
   f(result, self, dim, false);
   if (!keepdim)
@@ -82,8 +89,8 @@ Tensor &_reduce_out_cpu(reduce_type *f, Tensor &result, const Tensor &self,
   return result;
 }
 
-Tensor &_sum_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
-                     bool keepdim) {
+Tensor&
+_sum_out_cpu(Tensor& result, const Tensor& self, int64_t dim_, bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   if (_dimreduce_return_trivial(result, self, 0))
     return result;
@@ -93,8 +100,8 @@ Tensor &_sum_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
   return at::_sum_out(result, self, dim, keepdim);
 }
 
-Tensor &_prod_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
-                      bool keepdim) {
+Tensor&
+_prod_out_cpu(Tensor& result, const Tensor& self, int64_t dim_, bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   if (_dimreduce_return_trivial(result, self, 1))
     return result;
@@ -104,28 +111,27 @@ Tensor &_prod_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
   return at::_prod_out(result, self, dim, keepdim);
 }
 
-Tensor &_sum_out_cuda(Tensor &result, const Tensor &self, int64_t dim,
-                      bool keepdim) {
+Tensor&
+_sum_out_cuda(Tensor& result, const Tensor& self, int64_t dim, bool keepdim) {
   return at::_sum_out(result, self, dim, keepdim);
 }
 
-Tensor &_prod_out_cuda(Tensor &result, const Tensor &self, int64_t dim,
-                       bool keepdim) {
+Tensor&
+_prod_out_cuda(Tensor& result, const Tensor& self, int64_t dim, bool keepdim) {
   return at::_prod_out(result, self, dim, keepdim);
 }
 
-Tensor sum(const Tensor &self, int64_t dim_, bool keepdim) {
+Tensor sum(const Tensor& self, int64_t dim_, bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   Tensor result = self.type().tensor();
   return at::sum_out(result, self, dim, keepdim);
 }
 
-Tensor prod(const Tensor &self, int64_t dim_, bool keepdim) {
+Tensor prod(const Tensor& self, int64_t dim_, bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim());
   Tensor result = self.type().tensor();
   return at::prod_out(result, self, dim, keepdim);
 }
 
 // \DIM REDUCE ################################################################
-}
-}
+}} // namespace at::native

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -1,0 +1,118 @@
+#include "ATen/ATen.h"
+#include "ATen/Dispatch.h"
+#include "ATen/ExpandUtils.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/WrapDimUtils.h"
+#include "cpu/UnaryOpsKernel.h"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <vector>
+
+#include <map>
+
+namespace at { namespace native {
+
+using unary_type = void(Tensor&, const Tensor&);
+unary_type* ceilImpl = DispatchStub<unary_type>::init<ceilImplC, &ceilImpl>;
+unary_type* floorImpl = DispatchStub<unary_type>::init<floorImplC, &floorImpl>;
+unary_type* roundImpl = DispatchStub<unary_type>::init<roundImplC, &roundImpl>;
+unary_type* truncImpl = DispatchStub<unary_type>::init<truncImplC, &truncImpl>;
+unary_type* sqrtImpl = DispatchStub<unary_type>::init<sqrtImplC, &sqrtImpl>;
+
+// WRAP OPS #################################################################
+
+Tensor ceil(const Tensor& self) {
+  Tensor result = self.type().tensor();
+  return at::ceil_out(result, self);
+}
+Tensor floor(const Tensor& self) {
+  Tensor result = self.type().tensor();
+  return at::floor_out(result, self);
+}
+Tensor round(const Tensor& self) {
+  Tensor result = self.type().tensor();
+  return at::round_out(result, self);
+}
+Tensor trunc(const Tensor& self) {
+  Tensor result = self.type().tensor();
+  return at::trunc_out(result, self);
+}
+Tensor sqrt(const Tensor& self) {
+  Tensor result = self.type().tensor();
+  return at::sqrt_out(result, self);
+}
+
+Tensor& ceil_(Tensor& self) {
+  return at::ceil_out(self, self);
+}
+Tensor& floor_(Tensor& self) {
+  return at::floor_out(self, self);
+}
+Tensor& round_(Tensor& self) {
+  return at::round_out(self, self);
+}
+Tensor& trunc_(Tensor& self) {
+  return at::trunc_out(self, self);
+}
+Tensor& sqrt_(Tensor& self) {
+  return at::sqrt_out(self, self);
+}
+
+// \WRAP OPS #################################################################
+
+bool _unops_out_cpu(unary_type* f, Tensor& result, const Tensor& self) {
+  if (result.is_contiguous() && self.is_contiguous()) {
+    result.resize_(self.sizes());
+    f(result, self);
+    return true;
+  }
+  return false;
+}
+
+// CPU OPS ###################################################################
+
+Tensor& _ceil_out_cpu(Tensor& result, const Tensor& self) {
+  return _unops_out_cpu(ceilImpl, result, self) ? result
+                                                : at::_ceil_out(result, self);
+}
+Tensor& _floor_out_cpu(Tensor& result, const Tensor& self) {
+  return _unops_out_cpu(floorImpl, result, self) ? result
+                                                 : at::_floor_out(result, self);
+}
+Tensor& _round_out_cpu(Tensor& result, const Tensor& self) {
+  return _unops_out_cpu(roundImpl, result, self) ? result
+                                                 : at::_round_out(result, self);
+}
+Tensor& _trunc_out_cpu(Tensor& result, const Tensor& self) {
+  return _unops_out_cpu(truncImpl, result, self) ? result
+                                                 : at::_trunc_out(result, self);
+}
+Tensor& _sqrt_out_cpu(Tensor& result, const Tensor& self) {
+  return _unops_out_cpu(sqrtImpl, result, self) ? result
+                                                : at::_sqrt_out(result, self);
+}
+
+// \CPU OPS #################################################################
+
+// CUDA OPS #################################################################
+
+Tensor& _ceil_out_cuda(Tensor& result, const Tensor& self) {
+  return at::_ceil_out(result, self);
+}
+Tensor& _floor_out_cuda(Tensor& result, const Tensor& self) {
+  return at::_floor_out(result, self);
+}
+Tensor& _round_out_cuda(Tensor& result, const Tensor& self) {
+  return at::_round_out(result, self);
+}
+Tensor& _trunc_out_cuda(Tensor& result, const Tensor& self) {
+  return at::_trunc_out(result, self);
+}
+Tensor& _sqrt_out_cuda(Tensor& result, const Tensor& self) {
+  return at::_sqrt_out(result, self);
+}
+
+// \CUDA OPS ################################################################
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -1,9 +1,8 @@
-#include "ATen/cpu/cpuinfo/include/cpuinfo.h"
-#include <type_traits>
 #include <iostream>
+#include <type_traits>
+#include "ATen/cpu/cpuinfo/include/cpuinfo.h"
 
-namespace at {
-namespace native {
+namespace at { namespace native {
 
 enum class CPUCapability { DEFAULT, AVX, AVX2 };
 
@@ -15,19 +14,19 @@ constexpr CPUCapability CURRENT_CAPABILITY = CPUCapability::AVX;
 constexpr CPUCapability CURRENT_CAPABILITY = CPUCapability::AVX2;
 #endif
 
-template <typename FnType> struct DispatchStub {};
+template <typename FnType>
+struct DispatchStub {};
 
 template <typename... ArgTypes>
 struct DispatchStub<void(ArgTypes...)> {
   using FnType = void(ArgTypes...);
 
-  template <template <CPUCapability> class allImpl,
-            FnType **dispatch_ptr>
+  template <template <CPUCapability> class allImpl, FnType** dispatch_ptr>
   static void init(ArgTypes... args) {
     *dispatch_ptr = allImpl<CPUCapability::DEFAULT>::function;
     // Check if platform is supported
     if (cpuinfo_initialize()) {
-      // Set function pointer to best implementation last
+    // Set function pointer to best implementation last
 #if defined(HAVE_AVX_CPU_DEFINITION)
       if (cpuinfo_has_x86_avx()) {
         *dispatch_ptr = allImpl<CPUCapability::AVX>::function;
@@ -43,5 +42,4 @@ struct DispatchStub<void(ArgTypes...)> {
   }
 };
 
-}
-}
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.h
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.h
@@ -1,23 +1,21 @@
 #pragma once
 #include <ATen/ATen.h>
 #include <ATen/Parallel.h>
-#include "CapabilityDispatch.h"
-#include "Vec256.h"
 #include <stdexcept>
+#include "CapabilityDispatch.h"
 
+namespace at { namespace native {
 
-namespace at {
-namespace native {
-
-template <CPUCapability C> struct sumImplC {
-  static void function(Tensor &result, const Tensor &self, size_t dim,
-                       bool all);
+template <CPUCapability C>
+struct sumImplC {
+  static void
+  function(Tensor& result, const Tensor& self, size_t dim, bool all);
 };
 
-template <CPUCapability C> struct prodImplC {
-  static void function(Tensor &result, const Tensor &self, size_t dim,
-                       bool all);
+template <CPUCapability C>
+struct prodImplC {
+  static void
+  function(Tensor& result, const Tensor& self, size_t dim, bool all);
 };
 
-}
-}
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -1,0 +1,121 @@
+#include "ATen/native/cpu/UnaryOpsKernel.h"
+#include <cmath>
+#include <iostream>
+#include "ATen/Dispatch.h"
+#include "ATen/Parallel.h"
+#include "ATen/native/cpu/Vec256.h"
+
+namespace at { namespace native {
+
+using namespace vec256;
+
+// This modifies arr in place with given OP
+template <class scalar_t, template <class> class VOP, CPUCapability C>
+inline void
+kernel_(scalar_t* arr_out, const scalar_t* arr_in, size_t start, size_t end) {
+  Vec256<scalar_t> a;
+  size_t epr = 32 / sizeof(scalar_t); // primitives per Vec256
+  size_t k = start;
+  size_t vec_end = end > epr ? end - epr : 0;
+  for (; k < vec_end; k += epr) {
+    a.load(arr_in + k);
+    VOP<scalar_t>()(a).store(arr_out + k);
+  }
+  size_t leftover = std::min((end - k), a.size);
+  a.load(arr_in + k, leftover);
+  VOP<scalar_t>()(a).store(arr_out + k, leftover);
+}
+
+template <template <class> class VOP, CPUCapability C>
+inline void allImpl(Tensor& result, const Tensor& self, const char* name) {
+  AT_DISPATCH_FLOATING_TYPES(self.type(), name, [&] {
+    at::parallel_for_1d<scalar_t>(
+        &kernel_<scalar_t, VOP, CURRENT_CAPABILITY>, result, self);
+  });
+}
+
+namespace {
+
+template <typename T>
+struct ceilVOP {
+  Vec256<T> operator()(Vec256<T>& x) const {
+    return x.ceil();
+  }
+};
+} // namespace
+
+template <>
+void ceilImplC<CURRENT_CAPABILITY>::function(
+    Tensor& result,
+    const Tensor& self) {
+  allImpl<ceilVOP, CURRENT_CAPABILITY>(result, self, "ceil");
+}
+
+namespace {
+
+template <typename T>
+struct floorVOP {
+  Vec256<T> operator()(Vec256<T>& x) const {
+    return x.floor();
+  }
+};
+} // namespace
+
+template <>
+void floorImplC<CURRENT_CAPABILITY>::function(
+    Tensor& result,
+    const Tensor& self) {
+  allImpl<floorVOP, CURRENT_CAPABILITY>(result, self, "floor");
+}
+
+namespace {
+
+template <typename T>
+struct roundVOP {
+  Vec256<T> operator()(Vec256<T>& x) const {
+    return x.round();
+  }
+};
+} // namespace
+
+template <>
+void roundImplC<CURRENT_CAPABILITY>::function(
+    Tensor& result,
+    const Tensor& self) {
+  allImpl<roundVOP, CURRENT_CAPABILITY>(result, self, "round");
+}
+
+namespace {
+
+template <typename T>
+struct truncVOP {
+  Vec256<T> operator()(Vec256<T>& x) const {
+    return x.trunc();
+  }
+};
+} // namespace
+
+template <>
+void truncImplC<CURRENT_CAPABILITY>::function(
+    Tensor& result,
+    const Tensor& self) {
+  allImpl<truncVOP, CURRENT_CAPABILITY>(result, self, "trunc");
+}
+
+namespace {
+
+template <typename T>
+struct sqrtVOP {
+  Vec256<T> operator()(Vec256<T>& x) const {
+    return x.sqrt();
+  }
+};
+} // namespace
+
+template <>
+void sqrtImplC<CURRENT_CAPABILITY>::function(
+    Tensor& result,
+    const Tensor& self) {
+  allImpl<sqrtVOP, CURRENT_CAPABILITY>(result, self, "sqrt");
+}
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.h
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <stdexcept>
+#include "CapabilityDispatch.h"
+
+namespace at { namespace native {
+
+template <CPUCapability C>
+struct ceilImplC {
+  static void function(Tensor& result, const Tensor& self);
+};
+template <CPUCapability C>
+struct floorImplC {
+  static void function(Tensor& result, const Tensor& self);
+};
+template <CPUCapability C>
+struct roundImplC {
+  static void function(Tensor& result, const Tensor& self);
+};
+template <CPUCapability C>
+struct truncImplC {
+  static void function(Tensor& result, const Tensor& self);
+};
+template <CPUCapability C>
+struct sqrtImplC {
+  static void function(Tensor& result, const Tensor& self);
+};
+
+// Missing unary functions
+// TODO: Add generic apply function for contiguous and non-contiguous tensors
+// The goal here is to move more ops entirely into ATen and take advantage of
+// automatic vectorization with file-specific flags
+// acos
+// asin
+// atan
+// cos
+// cosh
+// digamma
+// erf
+// erfinv
+// exp
+// expm1
+// frac
+// lgamma
+// log1p
+// log
+// rsqrt
+// sigmoid
+// sin
+// sinh
+// tan
+// tanh
+// trunc
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/Vec256.h
+++ b/aten/src/ATen/native/cpu/Vec256.h
@@ -15,7 +15,7 @@
 #elif defined(__GNUC__) && defined(__IWMMXT__)
 /* GCC-compatible compiler, targeting ARM with WMMX */
 #include <mmintrin.h>
-#elif (defined(__GNUC__) || defined(__xlC__)) &&                               \
+#elif (defined(__GNUC__) || defined(__xlC__)) && \
     (defined(__VEC__) || defined(__ALTIVEC__))
 /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
 #include <altivec.h>
@@ -25,94 +25,212 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
 
-
 // NOTE:
 // If you specialize on a type, you must define all operations!
 // C arrays and intrinsic types don't mix
-namespace at {
-namespace native {
-namespace vec256 {
+namespace at { namespace native { namespace vec256 {
 
-template <class T> class Vec256 {
-public:
+template <class T>
+class Vec256 {
+ public:
   T values[32 / sizeof(T)]; // Mimics AVX behavior
-  inline void load(const T *ptr) { 
-    std::memcpy(values, ptr, 32); 
+  inline void load(const T* ptr) {
+    std::memcpy(values, ptr, 32);
   };
-  inline void store(T *ptr) { std::memcpy(ptr, values, 32); }
-  inline size_t size() { return 32 / sizeof(T); }
-  inline void operator=(const Vec256<T> &b) {
+  inline void store(T* ptr) const {
+    std::memcpy(ptr, values, 32);
+  }
+  inline void load(const T* ptr, size_t count) {
+    std::memcpy(values, ptr, 32 / sizeof(T) * count);
+  };
+  inline void store(T* ptr, size_t count) const {
+    std::memcpy(ptr, values, 32 / sizeof(T) * count);
+  }
+  size_t size = 32 / sizeof(T);
+  inline void operator=(const Vec256<T>& b) {
     std::memcpy(values, b.values, 32);
+  }
+  inline Vec256<T> map(T (*f)(T)) {
+    Vec256<T> ret;
+    for (size_t i = 0; i < size; i++)
+      ret.values[i] = f(values[i]);
+    return ret;
+  }
+  inline Vec256<T> ceil() {
+    return map(std::ceil);
+  }
+  inline Vec256<T> floor() {
+    return map(std::floor);
+  }
+  inline Vec256<T> round() {
+    return map(std::round);
+  }
+  inline Vec256<T> trunc() {
+    return map(std::trunc);
+  }
+  inline Vec256<T> sqrt() {
+    return map(std::sqrt);
   }
 };
 
-template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T>
+Vec256<T> operator+(const Vec256<T>& a, const Vec256<T>& b) {
   Vec256<T> c = Vec256<T>();
-  for (size_t i = 0; i < c.size(); i++) {
+  for (size_t i = 0; i < a.size; i++)
     c.values[i] = a.values[i] + b.values[i];
-  }
   return c;
 }
 
-template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
+template <class T>
+Vec256<T> operator*(const Vec256<T>& a, const Vec256<T>& b) {
   Vec256<T> c = Vec256<T>();
-  for (size_t i = 0; i < c.size(); i++) {
+  for (size_t i = 0; i < a.size; i++)
     c.values[i] = a.values[i] * b.values[i];
-  }
   return c;
 }
 
 #ifdef __AVX__
-template <> class Vec256<float> {
-public:
+template <>
+class Vec256<float> {
+ public:
   __m256 values;
   Vec256<float>() {}
-  inline void load(const float *ptr) { values = _mm256_loadu_ps(ptr); }
-  inline void store(float *ptr) { _mm256_storeu_ps(ptr, values); }
-  inline size_t size() { return 32 / sizeof(float); }
-  inline void operator=(const Vec256<float> &b) { values = b.values; }
-};
-
-template <> class Vec256<double> {
-public:
-  __m256d values;
-  Vec256<double>() {}
-  inline void load(const double *ptr) { values = _mm256_loadu_pd(ptr); }
-  inline void store(double *ptr) { _mm256_storeu_pd(ptr, values); }
-  inline size_t size() { return 32 / sizeof(double); }
-  inline void operator=(const Vec256<double> &b) { values = b.values; }
+  inline void load(const float* ptr) {
+    values = _mm256_loadu_ps(ptr);
+  }
+  inline void store(float* ptr) const {
+    _mm256_storeu_ps(ptr, values);
+  }
+  inline void load(const float* ptr, size_t count) {
+    float tmp_values[8];
+    std::memcpy(tmp_values, ptr, count * sizeof(float));
+    load(tmp_values);
+  }
+  inline void store(float* ptr, size_t count) const {
+    float tmp_values[8];
+    store(tmp_values);
+    std::memcpy(ptr, tmp_values, count * sizeof(float));
+  }
+  size_t size = 8;
+  inline void operator=(const Vec256<float>& b) {
+    values = b.values;
+  }
+  inline Vec256<float> ceil() {
+    Vec256<float> ret;
+    ret.values = _mm256_ceil_ps(values);
+    return ret;
+  }
+  inline Vec256<float> floor() {
+    Vec256<float> ret;
+    ret.values = _mm256_floor_ps(values);
+    return ret;
+  }
+  inline Vec256<float> round() {
+    Vec256<float> ret;
+    ret.values = _mm256_round_ps(
+        values, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+    return ret;
+  }
+  inline Vec256<float> trunc() {
+    Vec256<float> ret;
+    ret.values =
+        _mm256_round_ps(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
+    return ret;
+  }
+  inline Vec256<float> sqrt() {
+    Vec256<float> ret;
+    ret.values = _mm256_sqrt_ps(values);
+    return ret;
+  }
 };
 
 template <>
-Vec256<float> inline operator+(const Vec256<float> &a, const Vec256<float> &b) {
+class Vec256<double> {
+ public:
+  __m256d values;
+  Vec256<double>() {}
+  inline void load(const double* ptr) {
+    values = _mm256_loadu_pd(ptr);
+  }
+  inline void store(double* ptr) const {
+    _mm256_storeu_pd(ptr, values);
+  }
+  inline void load(const double* ptr, size_t count) {
+    double tmp_values[4];
+    std::memcpy(tmp_values, ptr, count * sizeof(double));
+    load(tmp_values);
+  }
+  inline void store(double* ptr, size_t count) const {
+    double tmp_values[4];
+    store(tmp_values);
+    std::memcpy(ptr, tmp_values, count * sizeof(double));
+  }
+  size_t size = 4;
+  inline void operator=(const Vec256<double>& b) {
+    values = b.values;
+  }
+  inline Vec256<double> ceil() {
+    Vec256<double> ret;
+    ret.values = _mm256_ceil_pd(values);
+    return ret;
+  }
+  inline Vec256<double> floor() {
+    Vec256<double> ret;
+    ret.values = _mm256_floor_pd(values);
+    return ret;
+  }
+  inline Vec256<double> round() {
+    Vec256<double> ret;
+    ret.values = _mm256_round_pd(
+        values, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+    return ret;
+  }
+  inline Vec256<double> trunc() {
+    Vec256<double> ret;
+    ret.values =
+        _mm256_round_pd(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
+    return ret;
+  }
+  inline Vec256<double> sqrt() {
+    Vec256<double> ret;
+    ret.values = _mm256_sqrt_pd(values);
+    return ret;
+  }
+};
+
+template <>
+Vec256<float> inline operator+(const Vec256<float>& a, const Vec256<float>& b) {
   Vec256<float> c = Vec256<float>();
   c.values = _mm256_add_ps(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<float> inline operator*(const Vec256<float> &a, const Vec256<float> &b) {
+Vec256<float> inline operator*(const Vec256<float>& a, const Vec256<float>& b) {
   Vec256<float> c = Vec256<float>();
   c.values = _mm256_mul_ps(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<double> inline operator+(const Vec256<double> &a,
-                                const Vec256<double> &b) {
+Vec256<double> inline operator+(
+    const Vec256<double>& a,
+    const Vec256<double>& b) {
   Vec256<double> c = Vec256<double>();
   c.values = _mm256_add_pd(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<double> inline operator*(const Vec256<double> &a,
-                                const Vec256<double> &b) {
+Vec256<double> inline operator*(
+    const Vec256<double>& a,
+    const Vec256<double>& b) {
   Vec256<double> c = Vec256<double>();
   c.values = _mm256_mul_pd(a.values, b.values);
   return c;
@@ -120,67 +238,109 @@ Vec256<double> inline operator*(const Vec256<double> &a,
 #endif
 
 #ifdef __AVX2__
-template <> class Vec256<int64_t> {
-public:
+template <>
+class Vec256<int64_t> {
+ public:
   __m256i values;
   Vec256<int64_t>() {}
-  inline void load(const int64_t *ptr) {
-    values = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr));
+  inline void load(const int64_t* ptr) {
+    values = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
   }
-  inline void store(int64_t *ptr) {
-    _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr), values);
+  inline void store(int64_t* ptr) const {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
   }
-  inline size_t size() { return 32 / sizeof(int64_t); }
-  inline void operator=(const Vec256<int64_t> &b) { values = b.values; }
-};
-
-template <> class Vec256<int32_t> {
-public:
-  __m256i values;
-  Vec256<int32_t>() {}
-  inline void load(const int32_t *ptr) {
-    values = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr));
+  inline void load(const int64_t* ptr, size_t count) {
+    int64_t tmp_values[4];
+    std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
+    load(tmp_values);
   }
-  inline void store(int32_t *ptr) {
-    _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr), values);
+  inline void store(int64_t* ptr, size_t count) const {
+    int64_t tmp_values[4];
+    store(tmp_values);
+    std::memcpy(ptr, tmp_values, count * sizeof(int64_t));
   }
-  inline size_t size() { return 32 / sizeof(int32_t); }
-  inline void operator=(const Vec256<int32_t> &b) { values = b.values; }
-};
-
-template <> class Vec256<int16_t> {
-public:
-  __m256i values;
-  Vec256<int16_t>() {}
-  inline void load(const int16_t *ptr) {
-    values = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr));
+  size_t size = 4;
+  inline void operator=(const Vec256<int64_t>& b) {
+    values = b.values;
   }
-  inline void store(int16_t *ptr) {
-    _mm256_storeu_si256(reinterpret_cast<__m256i *>(ptr), values);
-  }
-  inline size_t size() { return 32 / sizeof(int16_t); }
-  inline void operator=(const Vec256<int16_t> &b) { values = b.values; }
 };
 
 template <>
-Vec256<int64_t> inline operator+(const Vec256<int64_t> &a,
-                                 const Vec256<int64_t> &b) {
+class Vec256<int32_t> {
+ public:
+  __m256i values;
+  Vec256<int32_t>() {}
+  inline void load(const int32_t* ptr) {
+    values = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
+  }
+  inline void store(int32_t* ptr) const {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
+  }
+  inline void load(const int32_t* ptr, size_t count) {
+    int32_t tmp_values[8];
+    std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
+    load(tmp_values);
+  }
+  inline void store(int32_t* ptr, size_t count) const {
+    int32_t tmp_values[8];
+    store(tmp_values);
+    std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
+  }
+  size_t size = 8;
+  inline void operator=(const Vec256<int32_t>& b) {
+    values = b.values;
+  }
+};
+
+template <>
+class Vec256<int16_t> {
+ public:
+  __m256i values;
+  Vec256<int16_t>() {}
+  inline void load(const int16_t* ptr) {
+    values = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
+  }
+  inline void store(int16_t* ptr) const {
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
+  }
+  inline void load(const int16_t* ptr, size_t count) {
+    int16_t tmp_values[16];
+    std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    load(tmp_values);
+  }
+  inline void store(int16_t* ptr, size_t count) const {
+    int16_t tmp_values[16];
+    store(tmp_values);
+    std::memcpy(ptr, tmp_values, count * sizeof(int16_t));
+  }
+  size_t size = 16;
+  inline void operator=(const Vec256<int16_t>& b) {
+    values = b.values;
+  }
+};
+
+template <>
+Vec256<int64_t> inline operator+(
+    const Vec256<int64_t>& a,
+    const Vec256<int64_t>& b) {
   Vec256<int64_t> c = Vec256<int64_t>();
   c.values = _mm256_add_epi64(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<int32_t> inline operator+(const Vec256<int32_t> &a,
-                                 const Vec256<int32_t> &b) {
+Vec256<int32_t> inline operator+(
+    const Vec256<int32_t>& a,
+    const Vec256<int32_t>& b) {
   Vec256<int32_t> c = Vec256<int32_t>();
   c.values = _mm256_add_epi32(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<int16_t> inline operator+(const Vec256<int16_t> &a,
-                                 const Vec256<int16_t> &b) {
+Vec256<int16_t> inline operator+(
+    const Vec256<int16_t>& a,
+    const Vec256<int16_t>& b) {
   Vec256<int16_t> c = Vec256<int16_t>();
   c.values = _mm256_add_epi16(a.values, b.values);
   return c;
@@ -191,8 +351,9 @@ Vec256<int16_t> inline operator+(const Vec256<int16_t> &a,
 // This is also technically avx compatible, but then we'll need AVX
 // code for add as well.
 template <>
-Vec256<int64_t> inline operator*(const Vec256<int64_t> &a,
-                                 const Vec256<int64_t> &b) {
+Vec256<int64_t> inline operator*(
+    const Vec256<int64_t>& a,
+    const Vec256<int64_t>& b) {
   Vec256<int64_t> c = Vec256<int64_t>();
 
   int64_t a0 = _mm256_extract_epi64(a.values, 0);
@@ -215,21 +376,21 @@ Vec256<int64_t> inline operator*(const Vec256<int64_t> &a,
 }
 
 template <>
-Vec256<int32_t> inline operator*(const Vec256<int32_t> &a,
-                                 const Vec256<int32_t> &b) {
+Vec256<int32_t> inline operator*(
+    const Vec256<int32_t>& a,
+    const Vec256<int32_t>& b) {
   Vec256<int32_t> c = Vec256<int32_t>();
   c.values = _mm256_mullo_epi32(a.values, b.values);
   return c;
 }
 
 template <>
-Vec256<int16_t> inline operator*(const Vec256<int16_t> &a,
-                                 const Vec256<int16_t> &b) {
+Vec256<int16_t> inline operator*(
+    const Vec256<int16_t>& a,
+    const Vec256<int16_t>& b) {
   Vec256<int16_t> c = Vec256<int16_t>();
   c.values = _mm256_mullo_epi16(a.values, b.values);
   return c;
 }
 #endif
-}
-}
-}
+}}} // namespace at::native::vec256

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -596,3 +596,57 @@
 
 - func: _cudnn_init_dropout_state(Type ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
   variants: function
+
+# Unary Ops #
+
+- func: ceil(Tensor self) -> Tensor
+
+- func: ceil_(Tensor self) -> Tensor
+
+- func: ceil_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _ceil_out_cpu
+    CUDA: _ceil_out_cuda
+
+- func: floor(Tensor self) -> Tensor
+
+- func: floor_(Tensor self) -> Tensor
+
+- func: floor_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _floor_out_cpu
+    CUDA: _floor_out_cuda
+
+- func: round(Tensor self) -> Tensor
+
+- func: round_(Tensor self) -> Tensor
+
+- func: round_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _round_out_cpu
+    CUDA: _round_out_cuda
+
+- func: trunc(Tensor self) -> Tensor
+
+- func: trunc_(Tensor self) -> Tensor
+
+- func: trunc_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _trunc_out_cpu
+    CUDA: _trunc_out_cuda
+
+- func: sqrt(Tensor self) -> Tensor
+
+- func: sqrt_(Tensor self) -> Tensor
+
+- func: sqrt_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _sqrt_out_cpu
+    CUDA: _sqrt_out_cuda
+
+# \Unary Ops #

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -29,6 +29,18 @@
 - func: _cast_Half(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
+- func: _cudnn_rnn_flatten_weight(TensorList weight_arr, int64_t weight_stride0, int64_t input_size, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, bool bidirectional) -> Tensor
+  variants: function
+
+- func: _cudnn_rnn(Tensor input, TensorList weight, int64_t weight_stride0, Tensor? weight_buf, Tensor hx, Tensor? cx, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntList batch_sizes, BoolTensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+  variants: function
+
+- func: _cudnn_rnn_backward(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor grad_output, Tensor grad_hy, Tensor? grad_cy, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntList batch_sizes, BoolTensor? dropout_state, Tensor reserve, std::array<bool,4> output_mask) -> (Tensor, Tensor, Tensor, TensorList)
+  variants: function
+
+- func: _cudnn_init_dropout_state(Type ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
+  variants: function
+
 - func: adaptive_avg_pool1d(Tensor self, IntList[1] output_size) -> Tensor
   variants: function
 
@@ -79,6 +91,16 @@
 
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
+
+- func: ceil(Tensor self) -> Tensor
+
+- func: ceil_(Tensor self) -> Tensor
+
+- func: ceil_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _ceil_out_cpu
+    CUDA: _ceil_out_cuda
 
 - func: chunk(Tensor self, int64_t chunks, int64_t dim=0) -> TensorList
 
@@ -271,6 +293,16 @@
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
 
+- func: floor(Tensor self) -> Tensor
+
+- func: floor_(Tensor self) -> Tensor
+
+- func: floor_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _floor_out_cpu
+    CUDA: _floor_out_cuda
+
 - func: full(Type dtype, IntList size, Scalar fill_value) -> Tensor
   variants: function
 
@@ -437,17 +469,27 @@
     CPU: RoiPooling2d_backward_cpu
     CUDA: RoiPooling2d_backward_cuda
 
+- func: round(Tensor self) -> Tensor
+
+- func: round_(Tensor self) -> Tensor
+
+- func: round_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _round_out_cpu
+    CUDA: _round_out_cuda
+
 - func: rrelu(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=false, Generator* generator=nullptr) -> Tensor
   variants: function
 
 - func: rrelu_(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=false, Generator* generator=nullptr) -> Tensor
   variants: function
 
-- func: select(Tensor self, int64_t dim, int64_t index) -> Tensor
-
 - func: relu(Tensor self) -> Tensor
 
 - func: relu_(Tensor self) -> Tensor
+
+- func: select(Tensor self, int64_t dim, int64_t index) -> Tensor
 
 - func: selu(Tensor self) -> Tensor
   variants: function
@@ -512,6 +554,16 @@
     CPU: _sum_out_cpu
     CUDA: _sum_out_cuda
 
+- func: sqrt(Tensor self) -> Tensor
+
+- func: sqrt_(Tensor self) -> Tensor
+
+- func: sqrt_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _sqrt_out_cpu
+    CUDA: _sqrt_out_cuda
+
 - func: prod(Tensor self) -> Tensor
   dispatch:
     CPU: _prod_cpu
@@ -525,14 +577,24 @@
     CPU: _prod_out_cpu
     CUDA: _prod_out_cuda
 
+- func: t_(Tensor self) -> Tensor
+  variants: method
+
 - func: transpose_(Tensor self, int64_t dim0, int64_t dim1) -> Tensor
   variants: method
 
 - func: triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, double margin=1.0, double p=2, double eps=1e-6, bool swap=false, bool size_average=true, bool reduce=true) -> Tensor
   variants: function
 
-- func: t_(Tensor self) -> Tensor
-  variants: method
+- func: trunc(Tensor self) -> Tensor
+
+- func: trunc_(Tensor self) -> Tensor
+
+- func: trunc_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _trunc_out_cpu
+    CUDA: _trunc_out_cuda
 
 - func: type_as(Tensor self, Tensor other) -> Tensor
   variants: method
@@ -584,69 +646,3 @@
   dispatch:
     CPU: _s_poisson_cpu
     CUDA: _s_poisson_cuda
-
-- func: _cudnn_rnn_flatten_weight(TensorList weight_arr, int64_t weight_stride0, int64_t input_size, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, bool bidirectional) -> Tensor
-  variants: function
-
-- func: _cudnn_rnn(Tensor input, TensorList weight, int64_t weight_stride0, Tensor? weight_buf, Tensor hx, Tensor? cx, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntList batch_sizes, BoolTensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
-  variants: function
-
-- func: _cudnn_rnn_backward(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor grad_output, Tensor grad_hy, Tensor? grad_cy, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntList batch_sizes, BoolTensor? dropout_state, Tensor reserve, std::array<bool,4> output_mask) -> (Tensor, Tensor, Tensor, TensorList)
-  variants: function
-
-- func: _cudnn_init_dropout_state(Type ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
-  variants: function
-
-# Unary Ops #
-
-- func: ceil(Tensor self) -> Tensor
-
-- func: ceil_(Tensor self) -> Tensor
-
-- func: ceil_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _ceil_out_cpu
-    CUDA: _ceil_out_cuda
-
-- func: floor(Tensor self) -> Tensor
-
-- func: floor_(Tensor self) -> Tensor
-
-- func: floor_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _floor_out_cpu
-    CUDA: _floor_out_cuda
-
-- func: round(Tensor self) -> Tensor
-
-- func: round_(Tensor self) -> Tensor
-
-- func: round_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _round_out_cpu
-    CUDA: _round_out_cuda
-
-- func: trunc(Tensor self) -> Tensor
-
-- func: trunc_(Tensor self) -> Tensor
-
-- func: trunc_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _trunc_out_cpu
-    CUDA: _trunc_out_cuda
-
-- func: sqrt(Tensor self) -> Tensor
-
-- func: sqrt_(Tensor self) -> Tensor
-
-- func: sqrt_out(Tensor result, Tensor self) -> Tensor
-  variants: function
-  dispatch:
-    CPU: _sqrt_out_cpu
-    CUDA: _sqrt_out_cuda
-
-# \Unary Ops #


### PR DESCRIPTION
Implements a few unary operations for which there are AVX intrinsics.

The perf comparison script is [here](https://paste.fedoraproject.org/paste/f1adcJhpGtzDNWImS34XzQ).

EDIT: Appended the last column of "This branch" timings for readability
EDIT: Removed clone to become part of a larger effort around copy
EDIT: I will also add log, exp, cos, sin to this PR
EDIT: Strided case and log, exp, cos, sin will be handled in another PR
EDIT: Includes better formatting

Command - single core
```
taskset -c 0 python unary_comp.py
```
Compiled with gcc5.4.0 for python2.7

Master
```
ceil:  size: 10^0      count: 1000000  elapsed: 6.72463703156   this elapsed: 2.06619906425
ceil:  size: 10^1      count: 100000   elapsed: 5.31660294533   this elapsed: 0.451114177704
ceil:  size: 10^2      count: 10000    elapsed: 5.09328198433   this elapsed: 0.458932161331
ceil:  size: 10^3      count: 1000     elapsed: 4.86605906487   this elapsed: 0.425307035446
ceil:  size: 10^4      count: 100      elapsed: 5.73223686218   this elapsed: 1.51420688629
ceil:  size: 10^5      count: 10       elapsed: 5.6767308712    this elapsed: 1.48536610603
floor: size: 10^0      count: 1000000  elapsed: 6.85544586182   this elapsed: 2.23299098015
floor: size: 10^1      count: 100000   elapsed: 5.29100513458   this elapsed: 0.477941036224
floor: size: 10^2      count: 10000    elapsed: 5.09847211838   this elapsed: 0.46099615097
floor: size: 10^3      count: 1000     elapsed: 4.86015892029   this elapsed: 0.422957897186
floor: size: 10^4      count: 100      elapsed: 5.72806310654   this elapsed: 1.51649594307
floor: size: 10^5      count: 10       elapsed: 5.67707300186   this elapsed: 1.48646092415
round: size: 10^0      count: 1000000  elapsed: 11.6632659435   this elapsed: 2.48468589783
round: size: 10^1      count: 100000   elapsed: 12.5859880447   this elapsed: 0.49551987648
round: size: 10^2      count: 10000    elapsed: 12.5193960667   this elapsed: 0.464128017426
round: size: 10^3      count: 1000     elapsed: 12.4613730907   this elapsed: 0.422877073288
round: size: 10^4      count: 100      elapsed: 13.4095180035   this elapsed: 1.50900793076
round: size: 10^5      count: 10       elapsed: 13.3347780704   this elapsed: 1.48473095894
trunc: size: 10^0      count: 1000000  elapsed: 10.8710699081   this elapsed: 2.1772069931
trunc: size: 10^1      count: 100000   elapsed: 11.7434380054   this elapsed: 0.464560985565
trunc: size: 10^2      count: 10000    elapsed: 11.8657200336   this elapsed: 0.454663038254
trunc: size: 10^3      count: 1000     elapsed: 12.1129901409   this elapsed: 0.422108888626
trunc: size: 10^4      count: 100      elapsed: 12.7893900871   this elapsed: 1.51392889023
trunc: size: 10^5      count: 10       elapsed: 12.7805650234   this elapsed: 1.48477101326
sqrt:  size: 10^0      count: 1000000  elapsed: 17.1391599178   this elapsed: 3.0278441906
sqrt:  size: 10^1      count: 100000   elapsed: 17.5117669106   this elapsed: 1.05652308464
sqrt:  size: 10^2      count: 10000    elapsed: 17.5223078728   this elapsed: 0.902415990829
sqrt:  size: 10^3      count: 1000     elapsed: 18.2096610069   this elapsed: 0.851244926453
sqrt:  size: 10^4      count: 100      elapsed: 19.1470270157   this elapsed: 1.71396112442
sqrt:  size: 10^5      count: 10       elapsed: 19.0929000378   this elapsed: 1.65262508392

```

Command manycore (20 cores)
```
numactl -m 1  python unary_comp.py
```

Master

```
ceil:  size: 10^0      count: 1000000  elapsed: 6.76774907112    this elapsed: 2.08831596375
ceil:  size: 10^1      count: 100000   elapsed: 5.26921415329    this elapsed: 0.460593938828
ceil:  size: 10^2      count: 10000    elapsed: 5.0813229084     this elapsed: 0.503376960754
ceil:  size: 10^3      count: 1000     elapsed: 0.399098873138   this elapsed: 0.141521930695
ceil:  size: 10^4      count: 100      elapsed: 0.709737062454   this elapsed: 0.657402992249
ceil:  size: 10^5      count: 10       elapsed: 0.560704946518   this elapsed: 0.364257097244
floor: size: 10^0      count: 1000000  elapsed: 7.01760697365    this elapsed: 2.20468902588
floor: size: 10^1      count: 100000   elapsed: 5.28479790688    this elapsed: 0.455933094025
floor: size: 10^2      count: 10000    elapsed: 5.08667588234    this elapsed: 0.281991958618
floor: size: 10^3      count: 1000     elapsed: 0.316580057144   this elapsed: 0.0526778697968
floor: size: 10^4      count: 100      elapsed: 0.721877813339   this elapsed: 0.676480054855
floor: size: 10^5      count: 10       elapsed: 0.525444030762   this elapsed: 0.37157702446
round: size: 10^0      count: 1000000  elapsed: 13.678330183     this elapsed: 2.45732808113
round: size: 10^1      count: 100000   elapsed: 12.8416500092    this elapsed: 0.457631111145
round: size: 10^2      count: 10000    elapsed: 12.6348309517    this elapsed: 0.550966978073
round: size: 10^3      count: 1000     elapsed: 0.559453010559   this elapsed: 0.068146944046
round: size: 10^4      count: 100      elapsed: 0.801295995712   this elapsed: 0.669235944748
round: size: 10^5      count: 10       elapsed: 0.601754903793   this elapsed: 0.388570785522
trunc: size: 10^0      count: 1000000  elapsed: 11.7732570171    this elapsed: 2.36533784866
trunc: size: 10^1      count: 100000   elapsed: 11.8114311695    this elapsed: 0.458111047745
trunc: size: 10^2      count: 10000    elapsed: 11.8901190758    this elapsed: 0.452945947647
trunc: size: 10^3      count: 1000     elapsed: 0.453590869904   this elapsed: 0.0806839466095
trunc: size: 10^4      count: 100      elapsed: 0.773014068604   this elapsed: 0.653845071793
trunc: size: 10^5      count: 10       elapsed: 0.518759965897   this elapsed: 0.372617959976
sqrt:  size: 10^0      count: 1000000  elapsed: 14.4136710167    this elapsed: 3.02479696274
sqrt:  size: 10^1      count: 100000   elapsed: 17.2432360649    this elapsed: 1.0565290451
sqrt:  size: 10^2      count: 10000    elapsed: 17.5745770931    this elapsed: 0.80877995491
sqrt:  size: 10^3      count: 1000     elapsed: 0.722177028656   this elapsed: 0.142582178116
sqrt:  size: 10^4      count: 100      elapsed: 0.935206890106   this elapsed: 0.680450201035
sqrt:  size: 10^5      count: 10       elapsed: 0.755648136139   this elapsed: 0.383094072342

```