### PR TITLE
Block set from param_group['params']

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -175,6 +175,8 @@ class Optimizer(object):
         params = param_group['params']
         if isinstance(params, Variable):
             param_group['params'] = [params]
+        elif isinstance(params, set):
+            raise TypeError('using set as params may result in unexpected error')
         else:
             param_group['params'] = list(params)
 

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -11,6 +11,9 @@ required = object()
 class Optimizer(object):
     """Base class for all optimizers.
 
+    .. warning::
+        Params (or params[i]['params']) needs to give a deterministically ordered iterator.
+
     Arguments:
         params (iterable): an iterable of :class:`Variable` s or
             :class:`dict` s. Specifies what Variables should be optimized.

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -12,7 +12,9 @@ class Optimizer(object):
     """Base class for all optimizers.
 
     .. warning::
-        Params (or params[i]['params']) needs to give a deterministically ordered iterator.
+        Parameters needs to be specified as collections that have a deterministic
+        ordering that is consistent between runs. Examples of objects that don't
+        satisfy those properties are sets and iterators over values of dictionaries.
 
     Arguments:
         params (iterable): an iterable of :class:`Variable` s or

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -176,7 +176,8 @@ class Optimizer(object):
         if isinstance(params, Variable):
             param_group['params'] = [params]
         elif isinstance(params, set):
-            raise TypeError('using set as params may result in unexpected error')
+            raise TypeError('optimizer parameters need to be organized in ordered collections, but '
+                            'the ordering of tensors in sets will change between runs. Please use a list instead.')
         else:
             param_group['params'] = list(params)
 


### PR DESCRIPTION
This might cause `list(params)` to output in random order. In this case, in `load_state_dict()`, keys & values of `id_map` would not be matched correctly.