### PR TITLE
Add additional script module functionality

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1972,6 +1972,26 @@ class TestScript(TestCase):
         m2.sub2.a.data.zero_()
         self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
 
+    def test_script_module_call_noscript(self):
+        test_self = self
+
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M, self).__init__(False)
+                self.value = "hi"
+
+            def foo(self):
+                test_self.assertEqual(self.value, "hi")
+                return torch.ones(2, 2)
+
+            @torch.jit.script_method
+            def forward(self, input):
+                return input + self.foo()
+
+        m = M()
+        input = torch.randn(2, 2)
+        o = m(input)
+        self.assertEqual(o, input + torch.ones(2, 2))
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -142,10 +142,12 @@ struct ModuleValue : public SugaredValue {
     } else if(at::optional<NamedParameter&> v = module->find_parameter(field)) {
       return std::make_shared<SimpleValue>(m.get_or_add_parameter(v->slot()));
     }
-    // this can also be a call to a non-script module, if so return this as a python value
+    // This can also be a call to a non-script module, or a plain
+    // python method. If so return this as a python value.
     py::object py_module = py::cast(module);
     if(py::object attr = py::getattr(py_module, field.c_str(), py::none())) {
-      if(py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
+      if(py::isinstance<py::function>(attr) ||
+         py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
         return std::make_shared<PythonValue>(attr);
       }
     }


### PR DESCRIPTION
1. allow calls to non-script methods
2. test that modules can have non-script attributes that these methods can access
3. test that non-script modules cannot be changed after creation (since we resolve `self.submodule` right after `__init__` is called, script methods would never see the modification to the submodules, hence instead of supporting this case we need to specifically disallow it).

Resolves 1--3 of #6015 
Resolution order (4) is more complicated and will come in a later PR.