### PR TITLE
Enable TensorDataset to get any number of tensors

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -62,6 +62,35 @@ class TestTensorDataset(TestCase):
         for i in range(15):
             self.assertEqual(t[i], source[i][0])
             self.assertEqual(l[i], source[i][1])
+    
+    def test_single_tensor(self):
+        t = torch.randn(5, 10)
+        source = TensorDataset(t)
+        self.assertEqual(len(source), 5)
+        for i in range(5):
+            self.assertEqual(t[i], source[i][0])
+    
+    def test_many_tensors(self):
+        t0 = torch.randn(5, 10, 2, 3, 4, 5)
+        t1 = torch.randn(5, 10)
+        t2 = torch.randn(5, 10, 2, 5)
+        t3 = torch.randn(5, 10, 3, 7)
+        source = TensorDataset(t0, t1, t2, t3)
+        self.assertEqual(len(source), 5)
+        for i in range(5):
+            self.assertEqual(t0[i], source[i][0])
+            self.assertEqual(t1[i], source[i][1])
+            self.assertEqual(t2[i], source[i][2])
+            self.assertEqual(t3[i], source[i][3])
+    
+    def test_tensor_by_kwargs(self):
+        t = torch.randn(5, 10, 2, 3, 4, 5)
+        l = torch.randn(5, 10)
+        source = TensorDataset(data_tensor=t, target_tensor=l)
+        self.assertEqual(len(source), 5)
+        for i in range(5):
+            self.assertEqual(t[i], source[i][0])
+            self.assertEqual(l[i], source[i][1])
 
 
 class TestConcatDataset(TestCase):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -62,14 +62,14 @@ class TestTensorDataset(TestCase):
         for i in range(15):
             self.assertEqual(t[i], source[i][0])
             self.assertEqual(l[i], source[i][1])
-    
+
     def test_single_tensor(self):
         t = torch.randn(5, 10)
         source = TensorDataset(t)
         self.assertEqual(len(source), 5)
         for i in range(5):
             self.assertEqual(t[i], source[i][0])
-    
+
     def test_many_tensors(self):
         t0 = torch.randn(5, 10, 2, 3, 4, 5)
         t1 = torch.randn(5, 10)
@@ -82,7 +82,7 @@ class TestTensorDataset(TestCase):
             self.assertEqual(t1[i], source[i][1])
             self.assertEqual(t2[i], source[i][2])
             self.assertEqual(t3[i], source[i][3])
-    
+
     def test_tensor_by_kwargs(self):
         t = torch.randn(5, 10, 2, 3, 4, 5)
         l = torch.randn(5, 10)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -83,15 +83,6 @@ class TestTensorDataset(TestCase):
             self.assertEqual(t2[i], source[i][2])
             self.assertEqual(t3[i], source[i][3])
 
-    def test_tensor_by_kwargs(self):
-        t = torch.randn(5, 10, 2, 3, 4, 5)
-        l = torch.randn(5, 10)
-        source = TensorDataset(data_tensor=t, target_tensor=l)
-        self.assertEqual(len(source), 5)
-        for i in range(5):
-            self.assertEqual(t[i], source[i][0])
-            self.assertEqual(l[i], source[i][1])
-
 
 class TestConcatDataset(TestCase):
 

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -24,29 +24,17 @@ class Dataset(object):
 
 
 class TensorDataset(Dataset):
-    """Dataset wrapping data and target tensors.
+    """Dataset wrapping tensors.
 
-    Each sample will be retrieved by indexing both tensors along the first
-    dimension.
+    Each sample will be retrieved by indexing tensors along the first dimension.
 
     Arguments:
-        data_tensor (Tensor): contains sample data.
-        target_tensor (Tensor): contains sample targets (labels).
         *tensors (Tensor): tensors with the same first dimension.
     """
 
-    def __init__(self, data_tensor=None, target_tensor=None, *tensors):
-        def tensor_gen():
-            if data_tensor is not None:
-                yield data_tensor
-            if target_tensor is not None:
-                yield target_tensor
-            for tensor in tensors:
-                yield tensor
-            pass
-
-        self.tensors = tuple(tensor_gen())
-        assert all(self.tensors[0].size(0) == tensor.size(0) for tensor in self.tensors)
+    def __init__(self, *tensors):
+        assert all(tensors[0].size(0) == tensor.size(0) for tensor in tensors)
+        self.tensors = tensors
 
     def __getitem__(self, index):
         return tuple(tensor[index] for tensor in self.tensors)

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -30,20 +30,29 @@ class TensorDataset(Dataset):
     dimension.
 
     Arguments:
+        *tensors (Tensor): tensors with the same first dimension.
         data_tensor (Tensor): contains sample data.
         target_tensor (Tensor): contains sample targets (labels).
     """
 
-    def __init__(self, data_tensor, target_tensor):
-        assert data_tensor.size(0) == target_tensor.size(0)
-        self.data_tensor = data_tensor
-        self.target_tensor = target_tensor
+    def __init__(self, *tensors, data_tensor=None, target_tensor=None):
+        def tensor_gen():
+            if data_tensor is not None:
+                yield data_tensor
+            if target_tensor is not None:
+                yield target_tensor
+            for tensor in tensors:
+                yield tensor
+            pass
+
+        self.tensors = tuple(tensor_gen())
+        assert all(self.tensors[0].size(0) == tensor.size(0) for tensor in self.tensors)
 
     def __getitem__(self, index):
-        return self.data_tensor[index], self.target_tensor[index]
+        return tuple(tensor[index] for tensor in self.tensors)
 
     def __len__(self):
-        return self.data_tensor.size(0)
+        return self.tensors[0].size(0)
 
 
 class ConcatDataset(Dataset):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -30,12 +30,12 @@ class TensorDataset(Dataset):
     dimension.
 
     Arguments:
-        *tensors (Tensor): tensors with the same first dimension.
         data_tensor (Tensor): contains sample data.
         target_tensor (Tensor): contains sample targets (labels).
+        *tensors (Tensor): tensors with the same first dimension.
     """
 
-    def __init__(self, *tensors, data_tensor=None, target_tensor=None):
+    def __init__(self, data_tensor=None, target_tensor=None, *tensors):
         def tensor_gen():
             if data_tensor is not None:
                 yield data_tensor

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -29,7 +29,7 @@ class TensorDataset(Dataset):
     Each sample will be retrieved by indexing tensors along the first dimension.
 
     Arguments:
-        *tensors (Tensor): tensors with the same first dimension.
+        *tensors (Tensor): tensors that have the same size of the first dimension.
     """
 
     def __init__(self, *tensors):


### PR DESCRIPTION
Keeping compatibility, enable `TensorDataset` to get any number of tensors.