### PR TITLE
[distributions] Add DiagonalNormal distribution.

### DIFF
--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -88,7 +88,7 @@ from .laplace import Laplace
 from .log_normal import LogNormal
 from .logistic_normal import LogisticNormal
 from .multinomial import Multinomial
-from .multivariate_normal import MultivariateNormal
+from .multivariate_normal import MultivariateNormal, DiagonalNormal
 from .normal import Normal
 from .one_hot_categorical import OneHotCategorical
 from .pareto import Pareto
@@ -119,6 +119,7 @@ __all__ = [
     'LogisticNormal',
     'Multinomial',
     'MultivariateNormal',
+    'DiagonalNormal',
     'Normal',
     'OneHotCategorical',
     'Pareto',

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -193,3 +193,46 @@ class MultivariateNormal(Distribution):
             return H
         else:
             return H.expand(self._batch_shape)
+
+
+class DiagonalNormal(Distribution):
+    arg_constraints = {'loc': constraints.real_vector,
+                       'variance': constraints.positive}
+    support = constraints.real
+    has_rsample = True
+
+    def __init__(self, loc, variance=None, validate_args=None):
+        event_shape = torch.Size(loc.shape[-1:])
+        batch_shape = loc.shape[:-1]
+        self.loc = loc
+        self._variance = variance
+        super(DiagonalNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self._variance
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        eps = self.loc.new(*shape).normal_()
+        return self.loc + eps * self.stddev
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        diff = value - self.loc
+        log_probs = -0.5 * (diff / self.stddev).pow(2) - 0.5 * math.log(2 * math.pi) - self.stddev.log()
+        log_probs = log_probs.sum(-1)
+        return log_probs
+
+    def entropy(self):
+        log_det = self.stddev.log().sum(-1)
+        H = 0.5 * (1.0 + math.log(2 * math.pi)) * self._event_shape[0] + log_det
+        if len(self._batch_shape) == 0:
+            return H
+        else:
+            return H.expand(self._batch_shape)


### PR DESCRIPTION
This PR intends to add a convenience distribution class for Diagonal Normal distribution. This is useful,
for example, in the setting of a Variational Autoencoder with a diagonal posterior.