### PR TITLE
Allow larger margin of error for GPU perf test runtime

### DIFF
--- a/.jenkins/pytorch/perf_test/compare_with_baseline.py
+++ b/.jenkins/pytorch/perf_test/compare_with_baseline.py
@@ -61,6 +61,6 @@ else:
             new_data = json.load(new_data_file)
         new_data[test_name] = {}
         new_data[test_name]['mean'] = sample_mean
-        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.01)
+        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.02)
         with open(new_data_file_path, 'w') as new_data_file:
             json.dump(new_data, new_data_file, indent=4)


### PR DESCRIPTION
The current margin of error for GPU perf test runtime is too small (only +-2%), which caused some of the tests to fail such as https://ci.pytorch.org/jenkins/job/pytorch-builds/job/short-perf-test-gpu/1492/console. This PR doubles the margin of error to +-4%.

