### PR TITLE
Add CPU perf test for torch.* and torch.Tensor.*

### DIFF
--- a/.jenkins/pytorch/perf_test/compare_with_baseline.py
+++ b/.jenkins/pytorch/perf_test/compare_with_baseline.py
@@ -50,7 +50,7 @@ print("z-value: ", z_value)
 if z_value >= 2:
     raise Exception('''\n
 z-value >= 2, there is >97.7% chance of perf regression.\n
-To reproduce this regression, run `cd .jenkins/perf_test/ && bash ''' + test_name + '''.sh` on your local machine and compare the runtime before/after your code change.
+To reproduce this regression, run `cd .jenkins/pytorch/perf_test/ && bash ''' + test_name + '''.sh` on your local machine and compare the runtime before/after your code change.
 ''')
 else:
     print("z-value < 2, no perf regression detected.")

--- a/.jenkins/pytorch/perf_test/test_cpu_speed_torch.sh
+++ b/.jenkins/pytorch/perf_test/test_cpu_speed_torch.sh
@@ -1,0 +1,28 @@
+. ./common.sh
+
+test_cpu_speed_torch () {
+  echo "Testing: torch.*, CPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/perf-tests.git
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    export ARGS="--compare ../cpu_runtime.json"
+  elif [ "$1" == "compare_and_update" ]; then
+    export ARGS="--compare ../cpu_runtime.json --update ../new_cpu_runtime.json"
+  elif [ "$1" == "update_only" ]; then
+    export ARGS="--update ../new_cpu_runtime.json"
+  fi
+
+  if ! python perf-tests/modules/test_cpu_torch.py ${ARGS}; then
+    echo "To reproduce this regression, run \`cd .jenkins/pytorch/perf_test/ && bash "${FUNCNAME[0]}".sh\` on your local machine and compare the runtime before/after your code change."
+    exit 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_cpu_speed_torch "$@"
+fi
+

--- a/.jenkins/pytorch/perf_test/test_cpu_speed_torch_tensor.sh
+++ b/.jenkins/pytorch/perf_test/test_cpu_speed_torch_tensor.sh
@@ -1,0 +1,28 @@
+. ./common.sh
+
+test_cpu_speed_torch_tensor () {
+  echo "Testing: torch.Tensor.*, CPU"
+
+  export OMP_NUM_THREADS=4
+  export MKL_NUM_THREADS=4
+
+  git clone https://github.com/yf225/perf-tests.git
+
+  if [ "$1" == "compare_with_baseline" ]; then
+    export ARGS="--compare ../cpu_runtime.json"
+  elif [ "$1" == "compare_and_update" ]; then
+    export ARGS="--compare ../cpu_runtime.json --update ../new_cpu_runtime.json"
+  elif [ "$1" == "update_only" ]; then
+    export ARGS="--update ../new_cpu_runtime.json"
+  fi
+
+  if ! python perf-tests/modules/test_cpu_torch_tensor.py ${ARGS}; then
+    echo "To reproduce this regression, run \`cd .jenkins/pytorch/perf_test/ && bash "${FUNCNAME[0]}".sh\` on your local machine and compare the runtime before/after your code change."
+    exit 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  run_test test_cpu_speed_torch_tensor "$@"
+fi
+

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -38,15 +38,19 @@ fi
 # Include tests
 . ./test_cpu_speed_mini_sequence_labeler.sh
 . ./test_cpu_speed_mnist.sh
+. ./test_cpu_speed_torch.sh
+. ./test_cpu_speed_torch_tensor.sh
 
 # Run tests
+export TEST_MODE="compare_with_baseline"
 if [[ "$COMMIT_SOURCE" == master ]]; then
-    run_test test_cpu_speed_mini_sequence_labeler 20 compare_and_update
-    run_test test_cpu_speed_mnist 20 compare_and_update
-else
-    run_test test_cpu_speed_mini_sequence_labeler 20 compare_with_baseline
-    run_test test_cpu_speed_mnist 20 compare_with_baseline
+    export TEST_MODE="compare_and_update"
 fi
+
+run_test test_cpu_speed_mini_sequence_labeler 20 ${TEST_MODE}
+run_test test_cpu_speed_mnist 20 ${TEST_MODE}
+run_test test_cpu_speed_torch ${TEST_MODE}
+run_test test_cpu_speed_torch_tensor ${TEST_MODE}
 
 if [[ "$COMMIT_SOURCE" == master ]]; then
     # This could cause race condition if we are testing the same master commit twice,


### PR DESCRIPTION
This PR adds CPU perf tests for `torch.*` and `torch.Tensor.*` operators. The perf tests are hosted in https://github.com/yf225/perf-tests/tree/master/modules. It takes about 60s to run these two perf tests which should be minor overhead to the current test suite.