### PR TITLE
Create safe and unsafe versions of sparse_coo_tensor

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3849,7 +3849,7 @@
         - THTensor* self
 ]]
 [[
-  name: sparse_coo_tensor_unsafe
+  name: _sparse_coo_tensor_unsafe
   return: THTensor*
   backends:
     - SparseCPU

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3848,7 +3848,19 @@
       arguments:
         - THTensor* self
 ]]
-
+[[
+  name: sparse_coo_tensor_unsafe
+  return: THTensor*
+  backends:
+    - SparseCPU
+    - SparseCUDA
+  variants: [function]
+  cname: newWithTensorAndSizeUnsafe
+  arguments:
+    - THDenseIndexTensor* indices
+    - THDenseTensor* values
+    - THSize* size
+]]
 [[
   name: _copy_ignoring_overlaps_
   cname: copyIgnoringOverlaps

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -73,13 +73,13 @@ Tensor embedding_sparse_backward(
 
   // check if all our grad come from padding_idx
   if (grad.numel() == 0) {
-    return sparse_type.sparse_coo_tensor_unsafe(indices_.type().tensor(),
+    return sparse_type._sparse_coo_tensor_unsafe(indices_.type().tensor(),
                                          dense_type.tensor(), weight_size);
   }
 
   auto index = indices.view({1, -1});
   auto values = grad.contiguous().view({-1, num_features});
-  return sparse_type.sparse_coo_tensor_unsafe(index, values, weight_size);
+  return sparse_type._sparse_coo_tensor_unsafe(index, values, weight_size);
 }
 
 Tensor embedding_backward_cpu(

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -73,13 +73,13 @@ Tensor embedding_sparse_backward(
 
   // check if all our grad come from padding_idx
   if (grad.numel() == 0) {
-    return sparse_type.sparse_coo_tensor(indices_.type().tensor(),
+    return sparse_type.sparse_coo_tensor_unsafe(indices_.type().tensor(),
                                          dense_type.tensor(), weight_size);
   }
 
   auto index = indices.view({1, -1});
   auto values = grad.contiguous().view({-1, num_features});
-  return sparse_type.sparse_coo_tensor(index, values, weight_size);
+  return sparse_type.sparse_coo_tensor_unsafe(index, values, weight_size);
 }
 
 Tensor embedding_backward_cpu(

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -32,7 +32,7 @@ Tensor Type::copy(const Tensor & src, bool non_blocking) const {
     auto & this_dense_idx = this_dense.toScalarType(ScalarType::Long);
     auto indices_copy = this_dense_idx.copy(indices, non_blocking);
     auto values_copy = this_dense.copy(values, non_blocking);
-    return sparse_coo_tensor_unsafe(indices_copy, values_copy, src.sizes());
+    return _sparse_coo_tensor_unsafe(indices_copy, values_copy, src.sizes());
   } else {
     Tensor r = this->tensor(src.sizes());
     r.copy_(src, non_blocking);

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -32,7 +32,7 @@ Tensor Type::copy(const Tensor & src, bool non_blocking) const {
     auto & this_dense_idx = this_dense.toScalarType(ScalarType::Long);
     auto indices_copy = this_dense_idx.copy(indices, non_blocking);
     auto values_copy = this_dense.copy(values, non_blocking);
-    return sparse_coo_tensor(indices_copy, values_copy, src.sizes());
+    return sparse_coo_tensor_unsafe(indices_copy, values_copy, src.sizes());
   } else {
     Tensor r = this->tensor(src.sizes());
     r.copy_(src, non_blocking);

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -120,7 +120,7 @@ THCSTensor* THCSTensor_(_set)(THCState *state, THCSTensor *self, THCIndexTensor 
   return THCSTensor_(_move)(state, self, THCIndexTensor_(newClone)(state, indices), THCTensor_(newClone)(state, values));
 }
 
-THCSTensor* THCSTensor_(_newWithDimsAndTensor)(THCState *state, int64_t nDimI, int64_t nDimV, int64_t *sizes, THCIndexTensor *indices, THCTensor *values) {
+static inline THCSTensor* THCSTensor_(_newWithDimsAndTensor)(THCState *state, int64_t nDimI, int64_t nDimV, int64_t *sizes, THCIndexTensor *indices, THCTensor *values) {
   THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, nDimI, nDimV, sizes);
 

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -133,111 +133,141 @@ THCSTensor *THCSTensor_(new)(THCState *state)
 /* Pointer-copy init */
 THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices, THCTensor *values)
 {
-  return THCSTensor_(newWithTensorAndSize)(state, indices, values, NULL);
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
+
+  int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
+  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+
+  THCSTensor *self = THCSTensor_(new)(state);
+
+  // TODO Make it work with N-dimensional values
+  THArgCheck(nDimV > 0, 3, "size must be provided when nDimV > 0");
+  THLongTensor *computed_sizes;
+  THCudaLongTensor *ignore = THCudaLongTensor_new(state);
+  THCIndexTensor *s = THCIndexTensor_(new)(state);
+  THCIndexTensor_(max)(state, s, ignore, indices, 1, 1);
+  THCIndexTensor_(add)(state, s, s, 1);
+
+  // TODO make sure this doesn't sync the hell out of everything
+  //      Should be fine according to sam's memory manager.
+  THLongStorage *newSize = THCIndexTensor_(newSizeOf)(state, s);
+  computed_sizes = THLongTensor_newWithSize(newSize, NULL);
+  THLongStorage_free(newSize);
+  THLongTensor_copyCudaLong(state, computed_sizes, s);
+  THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongTensor_data(computed_sizes));
+
+  THCIndexTensor_(free)(state, s);
+  THCudaLongTensor_free(state, ignore);
+  THLongTensor_free(computed_sizes);
+
+  // NB: by default, we do NOT clone indices/values into the sparse tensor.
+  // Efficient API by default!
+  THCSTensor_(_move)(state, self, THCIndexTensor_(newWithTensor)(state, indices), THCTensor_(newWithTensor)(state, values));
+  return self;
+}
+
+THCSTensor *THCSTensor_(newWithTensorAndSizeUnsafe)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes)
+{
+  if (sizes == NULL) {
+    return THCSTensor_(newWithTensor)(state, indices, values);
+  }
+  if (THCudaLongTensor_nDimension(state, indices) == 0 && THCTensor_(nDimension)(state, values) == 0) {
+    return THCSTensor_(newWithSize)(state, sizes, NULL);
+  }
+
+  THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
+
+  int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
+  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+
+  THCSTensor *self = THCSTensor_(new)(state);
+  THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongStorage_data(sizes));
+  // NB: by default, we do NOT clone indices/values into the sparse tensor.
+  // Efficient API by default!
+  THCSTensor_(_move)(state, self, THCIndexTensor_(newWithTensor)(state, indices), THCTensor_(newWithTensor)(state, values));
+  return self;
 }
 
 THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes)
 {
+  if (sizes == NULL) {
+    return THCSTensor_(newWithTensor)(state, indices, values);
+  }
+  if (THCudaLongTensor_nDimension(state, indices) == 0 && THCTensor_(nDimension)(state, values) == 0) {
+    return THCSTensor_(newWithSize)(state, sizes, NULL);
+  }
+
   THCAssertSameGPU(THCSTensor_(checkGPU)(state, 0, 2, indices, values));
 
-  // If sizes are not given, it is inferred as max index of each dim.
-  int64_t nDimI, nDimV;
+  int64_t nDimI = THCIndexTensor_(size)(state, indices, 0);
+  int64_t nDimV = THCTensor_(nDimension)(state, values) - 1;
+  THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 3,
+      "number of dimensions must be nDimI + nDimV");
 
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
-
-  // TODO: we may need to special case when only one of these are empty.
-  if (THCudaLongTensor_nDimension(state, indices) == 0 && THCTensor_(nDimension)(state, values) == 0
-      && sizes != NULL) {
-    nDimI = THLongStorage_size(sizes);
-    nDimV = 0;
-  } else {
-    nDimI = THCIndexTensor_(size)(state, indices, 0);
-    nDimV = THCTensor_(nDimension)(state, values) - 1;
+  THCudaLongTensor *max_indices = THCudaLongTensor_new(state);
+  THCudaLongTensor *ignore = THCudaLongTensor_new(state);
+  THCudaLongTensor_max(state, max_indices, ignore, indices, 1, 0);
+  THCudaLongTensor_free(state, ignore);
+  for (int d = 0; d < nDimI; d++) {
+    int64_t max_index_in_dim = THCudaLongTensor_get1d(state, max_indices, d);
+    int64_t dim_size = sizes->data[d];
+    THArgCheck(max_index_in_dim < dim_size, 2,
+        "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
+        d, (long long)dim_size, (long long)max_index_in_dim);
   }
-  if (!sizes) {
-    // TODO Make it work with N-dimensional values
-    THArgCheck(nDimV > 0, 3, "size must be provided when nDimV > 0");
-    THLongTensor *computed_sizes;
-    THCudaLongTensor *ignore = THCudaLongTensor_new(state);
-    THCIndexTensor *s = THCIndexTensor_(new)(state);
-    THCIndexTensor_(max)(state, s, ignore, indices, 1, 1);
-    THCIndexTensor_(add)(state, s, s, 1);
-
-    // TODO make sure this doesn't sync the hell out of everything
-    //      Should be fine according to sam's memory manager.
-    THLongStorage *newSize = THCIndexTensor_(newSizeOf)(state, s);
-    computed_sizes = THLongTensor_newWithSize(newSize, NULL);
-    THLongStorage_free(newSize);
-    THLongTensor_copyCudaLong(state, computed_sizes, s);
-    THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongTensor_data(computed_sizes));
-
-    THCIndexTensor_(free)(state, s);
-    THCudaLongTensor_free(state, ignore);
-    THLongTensor_free(computed_sizes);
+  for (int d = 0; d < nDimV; d++) {
+    int64_t values_size = THCTensor_(size)(state, values, d + 1);
+    int64_t specified_size = sizes->data[nDimI + d];
+    THArgCheck(values_size <= specified_size, 2,
+        "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
+        d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
   }
-  else {
-    THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 3,
-        "number of dimensions must be nDimI + nDimV");
-    THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongStorage_data(sizes));
-  }
+  THCudaLongTensor_free(state, max_indices);
+
+  THCSTensor *self = THCSTensor_(new)(state);
+  THCSTensor_(rawResize)(state, self, nDimI, nDimV, THLongStorage_data(sizes));
   // NB: by default, we do NOT clone indices/values into the sparse tensor.
   // Efficient API by default!
   THCSTensor_(_move)(state, self, THCIndexTensor_(newWithTensor)(state, indices), THCTensor_(newWithTensor)(state, values));
-
   return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size, THLongStorage *_ignored)
 {
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
+  THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, size->size, 0, size->data);
-
   return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize1d)(THCState *state, int64_t size0)
 {
   int64_t size[1] = {size0};
-
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
+  THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, 1, 0, size);
-
   return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize2d)(THCState *state, int64_t size0, int64_t size1)
 {
   int64_t size[2] = {size0, size1};
-
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
+  THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, 2, 0, size);
-
   return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize3d)(THCState *state, int64_t size0, int64_t size1, int64_t size2)
 {
   int64_t size[3] = {size0, size1, size2};
-
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
+  THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, 3, 0, size);
-
   return self;
 }
 
 THCSTensor *THCSTensor_(newWithSize4d)(THCState *state, int64_t size0, int64_t size1, int64_t size2, int64_t size3)
 {
   int64_t size[4] = {size0, size1, size2, size3};
-
-  THCSTensor *self = (THCSTensor *)THAlloc(sizeof(THCSTensor));
-  THCSTensor_(rawInit)(state, self);
+  THCSTensor *self = THCSTensor_(new)(state);
   THCSTensor_(rawResize)(state, self, 4, 0, size);
-
   return self;
 }
 

--- a/aten/src/THCS/generic/THCSTensor.h
+++ b/aten/src/THCS/generic/THCSTensor.h
@@ -32,6 +32,7 @@ TH_API THCTensor *THCSTensor_(newValues)(THCState *state, const THCSTensor *self
 /**** creation methods ****/
 TH_API THCSTensor *THCSTensor_(new)(THCState *state);
 TH_API THCSTensor *THCSTensor_(newWithTensor)(THCState *state, THCIndexTensor *indices, THCTensor *values);
+TH_API THCSTensor *THCSTensor_(newWithTensorAndSizeUnsafe)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes);
 TH_API THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *indices, THCTensor *values, THLongStorage *sizes);
 
 TH_API THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size_, THLongStorage *_ignored);

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -121,7 +121,7 @@ THSTensor* THSTensor_(_set)(THSTensor *self, THLongTensor *indices, THTensor *va
     self, THLongTensor_newClone(indices), THTensor_(newClone)(values));
 }
 
-THSTensor* THSTensor_(_newWithDimsAndTensor)(int64_t nDimI, int64_t nDimV, int64_t *sizes, THLongTensor *indices, THTensor *values) {
+static inline THSTensor* THSTensor_(_newWithDimsAndTensor)(int64_t nDimI, int64_t nDimV, int64_t *sizes, THLongTensor *indices, THTensor *values) {
   THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, nDimI, nDimV, sizes);
 

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -135,128 +135,138 @@ THSTensor *THSTensor_(new)(void)
 /* Pointer-copy init */
 THSTensor *THSTensor_(newWithTensor)(THLongTensor *indices, THTensor *values)
 {
-  return THSTensor_(newWithTensorAndSize)(indices, values, NULL);
-}
+  // If sizes are not given, it is inferred as max index of each dim.
+  int64_t nDimI = THLongTensor_size(indices, 0);
+  int64_t nDimV = THTensor_(nDimension)(values) - 1;
 
-THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *values, THLongStorage *sizes)
-{  // If sizes are not given, it is inferred as max index of each dim.
-  int64_t nDimI, nDimV;
-  THLongTensor *ignore;
+  THSTensor *self = THSTensor_(new)();
 
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
-
-  // TODO: we may need to special case when only one of these are empty.
-  if (THLongTensor_nDimension(indices) == 0 && THTensor_(nDimension)(values) == 0 && sizes != NULL) {
-    nDimI = THLongStorage_size(sizes);
-    nDimV = 0;
-  } else {
-    nDimI = THLongTensor_size(indices, 0);
-    nDimV = THTensor_(nDimension)(values) - 1;
+  THLongTensor *ignore = THLongTensor_new();
+  THLongTensor *computed_indices_sizes = THLongTensor_new();
+  THLongTensor *computed_sizes = THLongTensor_newWithSize1d(nDimI + nDimV);
+  THLongTensor_max(computed_indices_sizes, ignore, indices, 1, 1);
+  THLongTensor_add(computed_indices_sizes, computed_indices_sizes, 1);
+  for (int d = 0; d < nDimI; d++) {
+      THTensor_fastSet1d(computed_sizes, d, THTensor_fastGet1d(computed_indices_sizes, d));
   }
-  if (!sizes) {
-    ignore = THLongTensor_new();
-    THLongTensor *computed_indices_sizes = THLongTensor_new();
-    THLongTensor *computed_sizes = THLongTensor_newWithSize1d(nDimI + nDimV);
-    THLongTensor_max(computed_indices_sizes, ignore, indices, 1, 1);
-    THLongTensor_add(computed_indices_sizes, computed_indices_sizes, 1);
-    for (int d = 0; d < nDimI; d++) {
-        THTensor_fastSet1d(computed_sizes, d, THTensor_fastGet1d(computed_indices_sizes, d));
-    }
-    for (int d = 0; d < nDimV; d++) {
-        THTensor_fastSet1d(computed_sizes, nDimI + d, THTensor_(size)(values, d + 1));
-    }
-    THSTensor_(rawResize)(self, nDimI, nDimV, THLongTensor_data(computed_sizes));
-    THLongTensor_free(computed_indices_sizes);
-    THLongTensor_free(computed_sizes);
-    THLongTensor_free(ignore);
+  for (int d = 0; d < nDimV; d++) {
+      THTensor_fastSet1d(computed_sizes, nDimI + d, THTensor_(size)(values, d + 1));
   }
-  else {
-    THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 2,
-        "number of dimensions must be nDimI + nDimV");
+  THSTensor_(rawResize)(self, nDimI, nDimV, THLongTensor_data(computed_sizes));
+  THLongTensor_free(computed_indices_sizes);
+  THLongTensor_free(computed_sizes);
+  THLongTensor_free(ignore);
 
-    // TODO: we may need to special case when only one of these are empty.
-    if (!(THLongTensor_nDimension(indices) == 0 && THTensor_(nDimension)(values) == 0 && sizes != NULL)) {
-      THLongTensor *max_indices = THLongTensor_new();
-      ignore = THLongTensor_new();
-      THLongTensor_max(max_indices, ignore, indices, 1, 0);
-      THLongTensor_free(ignore);
-      for (int d = 0; d < nDimI; d++) {
-        int64_t max_index_in_dim = THTensor_fastGet1d(max_indices, d);
-        int64_t dim_size = sizes->data[d];
-        THArgCheck(max_index_in_dim <= dim_size, 2,
-            "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
-            d, (long long)dim_size, (long long)max_index_in_dim);
-      }
-      for (int d = 0; d < nDimV; d++) {
-        int64_t values_size = THTensor_(size)(values, d + 1);
-        int64_t specified_size = sizes->data[nDimI + d];
-        THArgCheck(values_size <= specified_size, 2,
-            "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
-            d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
-      }
-      THLongTensor_free(max_indices);
-    }
-
-    THSTensor_(rawResize)(self, nDimI, nDimV, THLongStorage_data(sizes));
-  }
   // NB: by default, we do NOT clone indices/values into the sparse tensor.
   // Efficient API by default!
   THSTensor_(_move)(self, THLongTensor_newWithTensor(indices), THTensor_(newWithTensor)(values));
+  return self;
+}
 
+THSTensor *THSTensor_(newWithTensorAndSizeUnsafe)(THLongTensor *indices, THTensor *values, THLongStorage *sizes)
+{
+  if (sizes == NULL)
+  {
+    return THSTensor_(newWithTensor)(indices, values);
+  }
+  if (THLongTensor_nDimension(indices) == 0 && THTensor_(nDimension)(values) == 0)
+  {
+    return THSTensor_(newWithSize)(sizes, NULL);
+  }
+
+  int64_t nDimI = THLongTensor_size(indices, 0);
+  int64_t nDimV = THTensor_(nDimension)(values) - 1;
+
+  THSTensor *self = THSTensor_(new)();
+  THSTensor_(rawResize)(self, nDimI, nDimV, THLongStorage_data(sizes));
+
+  // NB: by default, we do NOT clone indices/values into the sparse tensor.
+  // Efficient API by default!
+  THSTensor_(_move)(self, THLongTensor_newWithTensor(indices), THTensor_(newWithTensor)(values));
+  return self;
+}
+
+THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *values, THLongStorage *sizes)
+{
+  if (sizes == NULL)
+  {
+    return THSTensor_(newWithTensor)(indices, values);
+  }
+  if (THLongTensor_nDimension(indices) == 0 && THTensor_(nDimension)(values) == 0)
+  {
+    return THSTensor_(newWithSize)(sizes, NULL);
+  }
+
+  int64_t nDimI = THLongTensor_size(indices, 0);
+  int64_t nDimV = THTensor_(nDimension)(values) - 1;
+  THArgCheck(THLongStorage_size(sizes) == nDimI + nDimV, 2,
+      "number of dimensions must be nDimI + nDimV");
+
+  THLongTensor *max_indices = THLongTensor_new();
+  THLongTensor *ignore = THLongTensor_new();
+  THLongTensor_max(max_indices, ignore, indices, 1, 0);
+  THLongTensor_free(ignore);
+  for (int d = 0; d < nDimI; d++) {
+    int64_t max_index_in_dim = THTensor_fastGet1d(max_indices, d);
+    int64_t dim_size = sizes->data[d];
+    THArgCheck(max_index_in_dim < dim_size, 2,
+        "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
+        d, (long long)dim_size, (long long)max_index_in_dim);
+  }
+  for (int d = 0; d < nDimV; d++) {
+    int64_t values_size = THTensor_(size)(values, d + 1);
+    int64_t specified_size = sizes->data[nDimI + d];
+    THArgCheck(values_size <= specified_size, 2,
+        "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
+        d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
+  }
+  THLongTensor_free(max_indices);
+
+  THSTensor *self = THSTensor_(new)();
+  THSTensor_(rawResize)(self, nDimI, nDimV, THLongStorage_data(sizes));
+
+  // NB: by default, we do NOT clone indices/values into the sparse tensor.
+  // Efficient API by default!
+  THSTensor_(_move)(self, THLongTensor_newWithTensor(indices), THTensor_(newWithTensor)(values));
   return self;
 }
 
 THSTensor *THSTensor_(newWithSize)(THLongStorage *size, THLongStorage *_ignored)
 {
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
+  THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, size->size, 0, size->data);
-
   return self;
 }
 
 THSTensor *THSTensor_(newWithSize1d)(int64_t size0)
 {
   int64_t size[1] = {size0};
-
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
+  THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, 1, 0, size);
-
   return self;
 }
 
 THSTensor *THSTensor_(newWithSize2d)(int64_t size0, int64_t size1)
 {
   int64_t size[2] = {size0, size1};
-
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
+  THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, 2, 0, size);
-
   return self;
 }
 
 THSTensor *THSTensor_(newWithSize3d)(int64_t size0, int64_t size1, int64_t size2)
 {
   int64_t size[3] = {size0, size1, size2};
-
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
+  THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, 3, 0, size);
-
   return self;
 }
 
 THSTensor *THSTensor_(newWithSize4d)(int64_t size0, int64_t size1, int64_t size2, int64_t size3)
 {
   int64_t size[4] = {size0, size1, size2, size3};
-
-  THSTensor *self = (THSTensor *)THAlloc(sizeof(THSTensor));
-  THSTensor_(rawInit)(self);
+  THSTensor *self = THSTensor_(new)();
   THSTensor_(rawResize)(self, 4, 0, size);
-
   return self;
 }
 

--- a/aten/src/THS/generic/THSTensor.h
+++ b/aten/src/THS/generic/THSTensor.h
@@ -34,6 +34,7 @@ TH_API THTensor *THSTensor_(newValues)(const THSTensor *self);
 /**** creation methods ****/
 TH_API THSTensor *THSTensor_(new)(void);
 TH_API THSTensor *THSTensor_(newWithTensor)(THLongTensor *indices, THTensor *values);
+TH_API THSTensor *THSTensor_(newWithTensorAndSizeUnsafe)(THLongTensor *indices, THTensor *values, THLongStorage *sizes);
 TH_API THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *values, THLongStorage *sizes);
 
 // Note the second argument is ignored. It exists only to match the signature of THTensor_(new).

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -869,7 +869,6 @@ class TestSparse(TestCase):
                             self.assertEqual(device, sparse_tensor._values().get_device())
                         self.assertEqual(True, sparse_tensor.requires_grad)
 
-
     def test_factory_size_check(self):
         indices = self.IndexTensor([[1, 2], [0, 2]])
         values = self.ValueTensor([.5, .5])
@@ -882,7 +881,6 @@ class TestSparse(TestCase):
         sizes = torch.Size([3, 3, 2])
         with self.assertRaisesRegex(RuntimeError, "values and sizes are inconsistent"):
             self.SparseTensor(indices, values, sizes)
-
 
     @cpu_only
     def test_factory_type_inference(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -869,6 +869,21 @@ class TestSparse(TestCase):
                             self.assertEqual(device, sparse_tensor._values().get_device())
                         self.assertEqual(True, sparse_tensor.requires_grad)
 
+
+    def test_factory_size_check(self):
+        indices = self.IndexTensor([[1, 2], [0, 2]])
+        values = self.ValueTensor([.5, .5])
+        sizes = torch.Size([2, 3])
+        with self.assertRaisesRegex(RuntimeError, "sizes is inconsistent with indices"):
+            self.SparseTensor(indices, values, sizes)
+
+        indices = self.IndexTensor([[1, 2], [0, 2]])
+        values = self.ValueTensor([[1, 1, 1], [1, 1, 1]])
+        sizes = torch.Size([3, 3, 2])
+        with self.assertRaisesRegex(RuntimeError, "values and sizes are inconsistent"):
+            self.SparseTensor(indices, values, sizes)
+
+
     @cpu_only
     def test_factory_type_inference(self):
         t = torch.sparse_coo_tensor(torch.tensor(([0], [2])), torch.tensor([1.], dtype=torch.float32))

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -87,7 +87,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
   outputs.reserve(tensors.size());
   auto & type = tensors[0].type();
   for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
-    outputs.emplace_back(type.sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
+    outputs.emplace_back(type._sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
   return outputs;
 }
 

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -87,7 +87,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
   outputs.reserve(tensors.size());
   auto & type = tensors[0].type();
   for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
-    outputs.emplace_back(type.sparse_coo_tensor(indices[i], values[i], tensors[i].sizes()));
+    outputs.emplace_back(type.sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
   return outputs;
 }
 


### PR DESCRIPTION
Fixes #5748.

Added an unsafe version so embedding isn't slowed.