### PR TITLE
Fix printing of unknown binop operator in torchscript

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15,6 +15,8 @@ import inspect
 import textwrap
 import numpy as np
 
+from torch.jit.frontend import NotSupportedError
+
 try:
     import torchvision
     HAS_TORCHVISION = True
@@ -1817,6 +1819,13 @@ class TestScript(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "failed in interpreter"):
             bar(Variable(torch.rand(10), requires_grad=True), Variable(torch.rand(9), requires_grad=True))
+
+    def test_binop_unsupported_error(self):
+        with self.assertRaisesRegex(NotSupportedError, "unsupported binary operator:"):
+            @torch.jit.script
+            def binop(x, y):
+                # Replace this with another unsupported op when/if it gets supported
+                return x ** y
 
     def test_python_call(self):
         def pyfunc(a):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -319,7 +319,7 @@ class ExprBuilder(Builder):
         op = type(expr.op)
         op_token = ExprBuilder.binop_map.get(op)
         if op_token is None:
-            err_range = ctx.make_range(lhs.range().end, rhs.range().start)
+            err_range = ctx.make_raw_range(lhs.range().end, rhs.range().start)
             raise NotSupportedError(err_range, "unsupported binary operator: " + op.__name__)
         return BinOp(op_token, lhs, rhs)
 


### PR DESCRIPTION
Related to #6049 but not a fix for it.

Before, using an unknown binary operator like `@`:
```
import torch
@torch.jit.script
def mm(x, y):
    return x @ y

x = torch.randn(4, 3)
y = torch.randn(3, 2)
mm(x, y)
```
resulted in [this not-so-readable trace](https://gist.github.com/zou3519/052b8998108c4bc0fe0e7c85c6f5758e).

Now, it tells the user that the problem is an unknown binary operator:
```
NotSupportedError: unsupported binary operator: MatMult
@torch.jit.script
def mm(x, y):
    return x @ y
            ~~~ <--- HERE
```
cc @apaszke @zdevito 