### PR TITLE
Relax constraints on return statements in the script

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1473,7 +1473,6 @@ class TestScript(TestCase):
         if isinstance(script, str):
             cu = torch.jit.CompilationUnit(script, optimize)
             ge = getattr(cu, name)
-            self.assertIsNotNone(outputs)
         else:
             if capture_output:
                 with self.capture_stdout() as captured:
@@ -1801,6 +1800,25 @@ class TestScript(TestCase):
 
         a = torch.randn(6)
         self.checkScript(func, [a], optimize=True)
+
+    def test_return(self):
+        def no_return(a):
+            a + 1
+
+        def void_return(a):
+            return
+
+        def one_return(a):
+            return a + 1.
+
+        def multiple_returns(a):
+            return a * 1., a * 2., a * 3.
+
+        a = torch.randn(1, dtype=torch.float)
+        # self.checkScript(no_return, [a], optimize=True)
+        self.checkScript(void_return, [a], optimize=True)
+        self.checkScript(one_return, [a], optimize=True)
+        self.checkScript(multiple_returns, [a], optimize=True)
 
     def test_error(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1815,7 +1815,7 @@ class TestScript(TestCase):
             return a * 1., a * 2., a * 3.
 
         a = torch.randn(1, dtype=torch.float)
-        # self.checkScript(no_return, [a], optimize=True)
+        self.checkScript(no_return, [a], optimize=True)
         self.checkScript(void_return, [a], optimize=True)
         self.checkScript(one_return, [a], optimize=True)
         self.checkScript(multiple_returns, [a], optimize=True)

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -102,7 +102,9 @@ void initJITBindings(PyObject *module) {
         // if we don't tell pybind these are variables it chokes on the
         // conversion.
         // TODO: fix conversions to be sane and make sure this works.
-        if(outputs.size() == 1) {
+        if (outputs.size() == 0) {
+          return py::none();
+        } else if (outputs.size() == 1) {
           return py::cast(static_cast<autograd::Variable&>(outputs[0]));
         } else {
           py::tuple tuple(outputs.size());

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -270,17 +270,19 @@ struct to_ir {
     auto stmts = def.statements();
     auto stmts_begin = stmts.begin();
     auto stmts_end = stmts.end();
-    if (stmts_begin == stmts_end)
-      throw ErrorReport(def) << "functions need to have a non-empty body";
-    --stmts_end;
-    if ((*stmts_end).kind() != TK_RETURN)
-      throw ErrorReport(*stmts_end) << "functions need to end with a return statement";
+    bool has_return = false;
+    if (stmts_begin != stmts_end && (*std::prev(stmts_end)).kind() == TK_RETURN) {
+      --stmts_end;
+      has_return = true;
+    }
 
     emitStatements(stmts_begin, stmts_end);
 
     // outputs
-    for (auto output : Return(*stmts_end).values()) {
-      graph->registerOutput(emitExpr(output, 1)[0]);
+    if (has_return) {
+      for (auto output : Return(*stmts_end).values()) {
+        graph->registerOutput(emitExpr(output, 1)[0]);
+      }
     }
   }
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -177,7 +177,9 @@ py::object unpackVariableTensorList(std::vector<at::Tensor> outputs) {
   // if we don't tell pybind these are variables it chokes on the
   // conversion.
   // TODO: fix conversions to be sane and make sure this works.
-  if(outputs.size() == 1) {
+  if (outputs.size() == 0) {
+    return py::none();
+  } else if (outputs.size() == 1) {
     return py::cast(static_cast<autograd::Variable&>(outputs[0]));
   } else {
     py::tuple tuple(outputs.size());

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -373,48 +373,43 @@ struct Token {
 };
 
 struct Lookahead {
-  Lookahead(const Token& t) : t(t) {}
-  Token t;
+  std::vector<Token> tokens;
   bool valid = false;
-  size_t repeat = 0;
 };
 
 struct Lexer {
-  std::shared_ptr<std::string> file;
   explicit Lexer(const std::string& str)
       : file(std::make_shared<std::string>(str)),
         pos(0),
-        cur_(TK_EOF, SourceRange(file, 0, 0)),
-        lookahead_(cur_),
-        repeat(0),
         nesting(0),
+        indent_stack(),
+        next_tokens(),
         shared(sharedParserData()) {
     auto first_indent = lexRaw(true);
     indent_stack.push_back(first_indent.range.size());
-    next();
+    lex();
   }
+  // Return the current token, and then move to the next one
   Token next() {
-    Token r = cur_;
-    if (repeat > 0) {
-      repeat--;
-    } else if (lookahead_.valid) {
-      lookahead_.valid = false;
-      repeat = lookahead_.repeat;
-      cur_ = lookahead_.t;
-    } else {
-      std::tie(cur_, repeat) = lex();
+    if (next_tokens.size() == 0)
+      reportError("Lexer invariant violated: empty token queue");
+    Token r = next_tokens.front();
+    next_tokens.erase(next_tokens.begin());
+    if (next_tokens.size() == 0) {
+      lex();
     }
     return r;
   }
+  // Skip the current token if it matches the given kind
   bool nextIf(int kind) {
-    if (cur_.kind != kind)
+    if (cur().kind != kind)
       return false;
     next();
     return true;
   }
 
   [[noreturn]] void reportError(const std::string& what) {
-    reportError(what, cur_);
+    reportError(what, cur());
   }[[noreturn]] void reportError(const std::string& what, const Token& t) {
     std::stringstream ss;
     ss << what << ":\n";
@@ -428,30 +423,29 @@ struct Lexer {
     t.range.highlight(ss);
     throw std::runtime_error(ss.str());
   }[[noreturn]] void expected(const std::string& what) {
-    expected(what, cur_);
+    expected(what, cur());
   }
+  // Check that the current token has a given kind, return the current token,
+  // and advance to the next one.
   Token expect(int kind) {
-    if (cur_.kind != kind) {
+    if (cur().kind != kind) {
       expected(kindToString(kind));
     }
     return next();
   }
   Token& lookahead() {
-    if (!lookahead_.valid) {
-      lookahead_.valid = true;
-      std::tie(lookahead_.t, lookahead_.repeat) = lex();
+    if (next_tokens.size() < 2) {
+      lex();
     }
-    return lookahead_.t;
+    return next_tokens[1];
   }
   Token& cur() {
-    return cur_;
+    return next_tokens.front();
   }
 
  private:
-  // token, number of times to repeat it
-  std::pair<Token, int> lex() {
+  void lex() {
     auto r = lexRaw();
-    int repeat = 0;
     switch (r.kind) {
       case '(':
       case '[':
@@ -471,27 +465,29 @@ struct Lexer {
         } else if (depth == indent_stack.back()) {
           r.kind = TK_NEWLINE;
         } else {
+          next_tokens.emplace_back(TK_NEWLINE, r.range);
           while (indent_stack.back() != depth) {
             indent_stack.pop_back();
-            repeat++;
+            next_tokens.emplace_back(TK_DEDENT, r.range);
             if (indent_stack.size() == 0) {
               reportError("invalid ident level", r);
             }
           }
-          repeat--; // first repeat is this return
-          r.kind = TK_DEDENT;
+          return; // We've already queued the tokens
         }
       } break;
       case TK_EOF:
         if (indent_stack.size() > 1) {
-          r.kind = TK_DEDENT;
+          next_tokens.emplace_back(TK_NEWLINE, r.range);
+          next_tokens.emplace_back(TK_DEDENT, r.range);
           indent_stack.pop_back();
+          return;
         }
         break;
       default:
         break;
     }
-    return std::make_pair(r, repeat);
+    next_tokens.push_back(std::move(r));
   }
   Token lexRaw(bool whitespace_token = false) {
     int kind;
@@ -514,13 +510,13 @@ struct Lexer {
     pos = start + length;
     return t;
   }
-  size_t pos;
-  Token cur_;
-  Lookahead lookahead_;
-  size_t repeat; // how many times to repeat the current token until we continue
 
+  std::shared_ptr<std::string> file;
+  size_t pos;
   size_t nesting; // depth of ( [ { nesting...
   std::vector<int> indent_stack; // stack of identation level of blocks
+  // Invariant: this should always contain at least a single element
+  std::vector<Token> next_tokens;
   SharedParserData& shared;
 };
 } // namespace script

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -372,11 +372,6 @@ struct Token {
   }
 };
 
-struct Lookahead {
-  std::vector<Token> tokens;
-  bool valid = false;
-};
-
 struct Lexer {
   explicit Lexer(const std::string& str)
       : file(std::make_shared<std::string>(str)),

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -107,21 +107,24 @@ protected:
   TreeRef tree_;
 };
 
+template<typename T>
+struct ListIterator {
+  ListIterator(TreeList::const_iterator it) : it(it) {}
+  bool operator!=(const ListIterator& rhs) const { return it != rhs.it; }
+  bool operator==(const ListIterator& rhs) const { return it == rhs.it; }
+  T operator*() const { return T(*it); }
+  ListIterator& operator+=(std::ptrdiff_t n) { it += n; return *this; }
+  ListIterator& operator++() { ++it; return *this; }
+  ListIterator& operator--() { --it; return *this; }
+
+private:
+  TreeList::const_iterator it;
+};
+
 template <typename T>
 struct List : public TreeView {
-  struct Iterator {
-    Iterator(TreeList::const_iterator it) : it(it) {}
-    bool operator!=(const Iterator& rhs) const { return it != rhs.it; }
-    bool operator==(const Iterator& rhs) const { return it == rhs.it; }
-    T operator*() const { return T(*it); }
-    void operator++() { ++it; }
-    void operator--() { --it; }
-
-  private:
-    TreeList::const_iterator it;
-  };
-  typedef Iterator iterator;
-  typedef Iterator const_iterator;
+  using iterator = ListIterator<T>;
+  using const_iterator = ListIterator<T>;
 
   List(const TreeRef& tree) : TreeView(tree) {
     tree->match(TK_LIST);
@@ -715,3 +718,11 @@ struct ListLiteral : public Expr {
 } // namespace script
 } // namespace jit
 } // namespace torch
+
+namespace std {
+
+template<typename T>
+struct iterator_traits<torch::jit::script::ListIterator<T>>
+  : std::iterator_traits<torch::jit::script::TreeList::const_iterator> {};
+
+} // namespace std

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -204,7 +204,7 @@ class StmtBuilder(Builder):
     def build_Return(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + len("return"))
         values = (stmt.value,) if not isinstance(stmt.value, ast.Tuple) else stmt.value.elts
-        return Return(r, [build_expr(ctx, val) for val in values])
+        return Return(r, [build_expr(ctx, val) for val in values if val is not None])
 
     @staticmethod
     def build_AugAssign(ctx, stmt):


### PR DESCRIPTION
Script functions can now have no return statements, empty
return statements, or return one or more values.

Additionally fix the lexer to always emit TK_NEWLINE before
TK_DEDENT, which simplifies the parser.