### PR TITLE
Fetch master commit log before perf test

### DIFF
--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -19,8 +19,10 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
 fi
 
 # Find the master commit to test against
+git remote add upstream https://github.com/pytorch/pytorch.git
+git fetch upstream
 IFS=$'\n'
-master_commit_ids=($(git rev-list HEAD))
+master_commit_ids=($(git rev-list upstream/master))
 for commit_id in "${master_commit_ids[@]}"; do
     if aws s3 ls s3://ossci-perf-test/pytorch/cpu_runtime/${commit_id}.json; then
         LATEST_TESTED_COMMIT=${commit_id}

--- a/.jenkins/pytorch/short-perf-test-gpu.sh
+++ b/.jenkins/pytorch/short-perf-test-gpu.sh
@@ -19,8 +19,10 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
 fi
 
 # Find the master commit to test against
+git remote add upstream https://github.com/pytorch/pytorch.git
+git fetch upstream
 IFS=$'\n'
-master_commit_ids=($(git rev-list HEAD))
+master_commit_ids=($(git rev-list upstream/master))
 for commit_id in "${master_commit_ids[@]}"; do
     if aws s3 ls s3://ossci-perf-test/pytorch/gpu_runtime/${commit_id}.json; then
         LATEST_TESTED_COMMIT=${commit_id}


### PR DESCRIPTION
Currently the perf test will follow the git log in the PR branch to find a commit that has perf numbers in S3, which is not necessary the latest tested commit in master. This PR fixes it by fetching the git log from master branch instead.

Need to confirm that the behavior is correct before merging.