### PR TITLE
Exp, log, sin, cos vectorized

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1141,20 +1141,8 @@
     - THTensor* self
 ]]
 [[
-  name: log_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _log
   cname: log
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: log
   types:
     - floating_point
   backends:
@@ -1288,20 +1276,8 @@
     - THTensor* self
 ]]
 [[
-  name: exp_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _exp
   cname: exp
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: exp
   types:
     - floating_point
   backends:
@@ -1346,20 +1322,8 @@
     - THTensor* self
 ]]
 [[
-  name: cos_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _cos
   cname: cos
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: cos
   types:
     - floating_point
   backends:
@@ -1433,20 +1397,8 @@
     - THTensor* self
 ]]
 [[
-  name: sin_
-  types:
-    - floating_point
-  backends:
-    - CPU
-    - CUDA
+  name: _sin
   cname: sin
-  return: self
-  arguments:
-    - THTensor* self
-    - THTensor* self
-]]
-[[
-  name: sin
   types:
     - floating_point
   backends:

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1076,8 +1076,8 @@
     - THTensor* self
 ]]
 [[
-  name: abs
-  return: argument 0
+  name: _abs
+  cname: abs
   types:
     - floating_point
     - Long
@@ -1089,25 +1089,10 @@
   variants:
     - method
     - function
+  return: argument 0
   arguments:
     - arg: THTensor* result
       output: True
-    - THTensor* self
-]]
-[[
-  name: abs_
-  cname: abs
-  return: self
-  types:
-    - floating_point
-    - Long
-    - Int
-    - Short
-  backends:
-    - CPU
-    - CUDA
-  arguments:
-    - THTensor* self
     - THTensor* self
 ]]
 [[

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -15,52 +15,31 @@
 namespace at { namespace native {
 
 using unary_type = void(Tensor&, const Tensor&);
-unary_type* ceilImpl = DispatchStub<unary_type>::init<ceilImplC, &ceilImpl>;
-unary_type* floorImpl = DispatchStub<unary_type>::init<floorImplC, &floorImpl>;
-unary_type* roundImpl = DispatchStub<unary_type>::init<roundImplC, &roundImpl>;
-unary_type* truncImpl = DispatchStub<unary_type>::init<truncImplC, &truncImpl>;
-unary_type* sqrtImpl = DispatchStub<unary_type>::init<sqrtImplC, &sqrtImpl>;
 
-// WRAP OPS #################################################################
+#define DISPATCH(NAME) \
+unary_type* NAME ## Impl = DispatchStub<unary_type>::init<NAME ## ImplC, &NAME ## Impl>;\
 
-Tensor ceil(const Tensor& self) {
-  Tensor result = self.type().tensor();
-  return at::ceil_out(result, self);
-}
-Tensor floor(const Tensor& self) {
-  Tensor result = self.type().tensor();
-  return at::floor_out(result, self);
-}
-Tensor round(const Tensor& self) {
-  Tensor result = self.type().tensor();
-  return at::round_out(result, self);
-}
-Tensor trunc(const Tensor& self) {
-  Tensor result = self.type().tensor();
-  return at::trunc_out(result, self);
-}
-Tensor sqrt(const Tensor& self) {
-  Tensor result = self.type().tensor();
-  return at::sqrt_out(result, self);
-}
+#define BASIC(NAME) \
+Tensor NAME(const Tensor& self) { \
+  Tensor result = self.type().tensor(); \
+  return at::NAME ## _out(result, self); \
+} \
 
-Tensor& ceil_(Tensor& self) {
-  return at::ceil_out(self, self);
-}
-Tensor& floor_(Tensor& self) {
-  return at::floor_out(self, self);
-}
-Tensor& round_(Tensor& self) {
-  return at::round_out(self, self);
-}
-Tensor& trunc_(Tensor& self) {
-  return at::trunc_out(self, self);
-}
-Tensor& sqrt_(Tensor& self) {
-  return at::sqrt_out(self, self);
-}
+#define SELF(NAME) \
+Tensor& NAME##_(Tensor& self) { \
+  return at::NAME ## _out(self, self); \
+} \
 
-// \WRAP OPS #################################################################
+#define OUTCPU(NAME) \
+Tensor& _ ## NAME ## _out_cpu(Tensor& result, const Tensor& self) { \
+  return _unops_out_cpu(NAME ## Impl, result, self) ? result \
+                                                : at::_ ## NAME ## _out(result, self); \
+} \
+
+#define OUTCUDA(NAME) \
+Tensor& _ ## NAME ## _out_cuda(Tensor& result, const Tensor& self) { \
+  return at::_ ## NAME ## _out(result, self); \
+} \
 
 bool _unops_out_cpu(unary_type* f, Tensor& result, const Tensor& self) {
   if (result.is_contiguous() && self.is_contiguous()) {
@@ -71,48 +50,10 @@ bool _unops_out_cpu(unary_type* f, Tensor& result, const Tensor& self) {
   return false;
 }
 
-// CPU OPS ###################################################################
+UNARY_OPS_MACRO(DISPATCH)
+UNARY_OPS_MACRO(BASIC)
+UNARY_OPS_MACRO(SELF)
+UNARY_OPS_MACRO(OUTCPU)
+UNARY_OPS_MACRO(OUTCUDA)
 
-Tensor& _ceil_out_cpu(Tensor& result, const Tensor& self) {
-  return _unops_out_cpu(ceilImpl, result, self) ? result
-                                                : at::_ceil_out(result, self);
-}
-Tensor& _floor_out_cpu(Tensor& result, const Tensor& self) {
-  return _unops_out_cpu(floorImpl, result, self) ? result
-                                                 : at::_floor_out(result, self);
-}
-Tensor& _round_out_cpu(Tensor& result, const Tensor& self) {
-  return _unops_out_cpu(roundImpl, result, self) ? result
-                                                 : at::_round_out(result, self);
-}
-Tensor& _trunc_out_cpu(Tensor& result, const Tensor& self) {
-  return _unops_out_cpu(truncImpl, result, self) ? result
-                                                 : at::_trunc_out(result, self);
-}
-Tensor& _sqrt_out_cpu(Tensor& result, const Tensor& self) {
-  return _unops_out_cpu(sqrtImpl, result, self) ? result
-                                                : at::_sqrt_out(result, self);
-}
-
-// \CPU OPS #################################################################
-
-// CUDA OPS #################################################################
-
-Tensor& _ceil_out_cuda(Tensor& result, const Tensor& self) {
-  return at::_ceil_out(result, self);
-}
-Tensor& _floor_out_cuda(Tensor& result, const Tensor& self) {
-  return at::_floor_out(result, self);
-}
-Tensor& _round_out_cuda(Tensor& result, const Tensor& self) {
-  return at::_round_out(result, self);
-}
-Tensor& _trunc_out_cuda(Tensor& result, const Tensor& self) {
-  return at::_trunc_out(result, self);
-}
-Tensor& _sqrt_out_cuda(Tensor& result, const Tensor& self) {
-  return at::_sqrt_out(result, self);
-}
-
-// \CUDA OPS ################################################################
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <type_traits>
 #include "ATen/cpu/cpuinfo/include/cpuinfo.h"
 
@@ -28,12 +27,12 @@ struct DispatchStub<void(ArgTypes...)> {
     if (cpuinfo_initialize()) {
     // Set function pointer to best implementation last
 #if defined(HAVE_AVX_CPU_DEFINITION)
-      if (cpuinfo_has_x86_avx()) {
+      if (!std::getenv("ATEN_DISABLE_AVX") && cpuinfo_has_x86_avx()) {
         *dispatch_ptr = allImpl<CPUCapability::AVX>::function;
       }
 #endif
 #if defined(HAVE_AVX2_CPU_DEFINITION)
-      if (cpuinfo_has_x86_avx2()) {
+      if (!std::getenv("ATEN_DISABLE_AVX2") && cpuinfo_has_x86_avx2()) {
         *dispatch_ptr = allImpl<CPUCapability::AVX2>::function;
       }
 #endif

--- a/aten/src/ATen/native/cpu/Intrinsics.h
+++ b/aten/src/ATen/native/cpu/Intrinsics.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#if defined(_MSC_VER)
+/* Microsoft C/C++-compatible compiler */
+#include <intrin.h>
+#if _MSC_VER <= 1900
+#define _mm256_extract_epi64(X, Y) (((uint64_t*)&X)[Y])
+#endif
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+/* GCC-compatible compiler, targeting x86/x86-64 */
+#include <x86intrin.h>
+#elif defined(__GNUC__) && defined(__ARM_NEON__)
+/* GCC-compatible compiler, targeting ARM with NEON */
+#include <arm_neon.h>
+#elif defined(__GNUC__) && defined(__IWMMXT__)
+/* GCC-compatible compiler, targeting ARM with WMMX */
+#include <mmintrin.h>
+#elif (defined(__GNUC__) || defined(__xlC__)) && \
+    (defined(__VEC__) || defined(__ALTIVEC__))
+/* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
+#include <altivec.h>
+#elif defined(__GNUC__) && defined(__SPE__)
+/* GCC-compatible compiler, targeting PowerPC with SPE */
+#include <spe.h>
+#endif

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -1,6 +1,5 @@
 #include "ATen/native/cpu/UnaryOpsKernel.h"
 #include <cmath>
-#include <iostream>
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
 #include "ATen/native/cpu/Vec256.h"
@@ -26,96 +25,30 @@ kernel_(scalar_t* arr_out, const scalar_t* arr_in, size_t start, size_t end) {
   VOP<scalar_t>()(a).store(arr_out + k, leftover);
 }
 
-template <template <class> class VOP, CPUCapability C>
-inline void allImpl(Tensor& result, const Tensor& self, const char* name) {
-  AT_DISPATCH_FLOATING_TYPES(self.type(), name, [&] {
-    at::parallel_for_1d<scalar_t>(
-        &kernel_<scalar_t, VOP, CURRENT_CAPABILITY>, result, self);
-  });
-}
-
 namespace {
 
-template <typename T>
-struct ceilVOP {
-  Vec256<T> operator()(Vec256<T>& x) const {
-    return x.ceil();
-  }
-};
+#define FUNCVOP(NAME)                          \
+  template <typename T>                        \
+  struct NAME##VOP {                           \
+    Vec256<T> operator()(Vec256<T>& x) const { \
+      return x.NAME();                         \
+    }                                          \
+  };
+
+UNARY_OPS_MACRO(FUNCVOP)
+
 } // namespace
 
-template <>
-void ceilImplC<CURRENT_CAPABILITY>::function(
-    Tensor& result,
-    const Tensor& self) {
-  allImpl<ceilVOP, CURRENT_CAPABILITY>(result, self, "ceil");
-}
-
-namespace {
-
-template <typename T>
-struct floorVOP {
-  Vec256<T> operator()(Vec256<T>& x) const {
-    return x.floor();
+#define FUNCImpl(NAME)                                                      \
+  template <>                                                               \
+  void NAME##ImplC<CURRENT_CAPABILITY>::function(                           \
+      Tensor& result, const Tensor& self) {                                 \
+    AT_DISPATCH_FLOATING_TYPES(self.type(), NAME, [&] {                     \
+      at::parallel_for_1d<scalar_t>(                                        \
+          &kernel_<scalar_t, NAME##VOP, CURRENT_CAPABILITY>, result, self); \
+    });                                                                     \
   }
-};
-} // namespace
 
-template <>
-void floorImplC<CURRENT_CAPABILITY>::function(
-    Tensor& result,
-    const Tensor& self) {
-  allImpl<floorVOP, CURRENT_CAPABILITY>(result, self, "floor");
-}
+UNARY_OPS_MACRO(FUNCImpl)
 
-namespace {
-
-template <typename T>
-struct roundVOP {
-  Vec256<T> operator()(Vec256<T>& x) const {
-    return x.round();
-  }
-};
-} // namespace
-
-template <>
-void roundImplC<CURRENT_CAPABILITY>::function(
-    Tensor& result,
-    const Tensor& self) {
-  allImpl<roundVOP, CURRENT_CAPABILITY>(result, self, "round");
-}
-
-namespace {
-
-template <typename T>
-struct truncVOP {
-  Vec256<T> operator()(Vec256<T>& x) const {
-    return x.trunc();
-  }
-};
-} // namespace
-
-template <>
-void truncImplC<CURRENT_CAPABILITY>::function(
-    Tensor& result,
-    const Tensor& self) {
-  allImpl<truncVOP, CURRENT_CAPABILITY>(result, self, "trunc");
-}
-
-namespace {
-
-template <typename T>
-struct sqrtVOP {
-  Vec256<T> operator()(Vec256<T>& x) const {
-    return x.sqrt();
-  }
-};
-} // namespace
-
-template <>
-void sqrtImplC<CURRENT_CAPABILITY>::function(
-    Tensor& result,
-    const Tensor& self) {
-  allImpl<sqrtVOP, CURRENT_CAPABILITY>(result, self, "sqrt");
-}
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.h
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.h
@@ -6,26 +6,24 @@
 
 namespace at { namespace native {
 
-template <CPUCapability C>
-struct ceilImplC {
-  static void function(Tensor& result, const Tensor& self);
-};
-template <CPUCapability C>
-struct floorImplC {
-  static void function(Tensor& result, const Tensor& self);
-};
-template <CPUCapability C>
-struct roundImplC {
-  static void function(Tensor& result, const Tensor& self);
-};
-template <CPUCapability C>
-struct truncImplC {
-  static void function(Tensor& result, const Tensor& self);
-};
-template <CPUCapability C>
-struct sqrtImplC {
-  static void function(Tensor& result, const Tensor& self);
-};
+#define FUNCImplC(NAME) \
+template <CPUCapability C>\
+struct NAME ## ImplC {\
+  static void function(Tensor& result, const Tensor& self);\
+};\
+
+#define UNARY_OPS_MACRO(MACRO) \
+  MACRO (ceil) \
+  MACRO (cos) \
+  MACRO (exp) \
+  MACRO (floor) \
+  MACRO (log) \
+  MACRO (round) \
+  MACRO (sin) \
+  MACRO (sqrt) \
+  MACRO (trunc) \
+
+UNARY_OPS_MACRO(FUNCImplC)
 
 // Missing unary functions
 // TODO: Add generic apply function for contiguous and non-contiguous tensors
@@ -34,20 +32,16 @@ struct sqrtImplC {
 // acos
 // asin
 // atan
-// cos
 // cosh
 // digamma
 // erf
 // erfinv
-// exp
 // expm1
 // frac
 // lgamma
 // log1p
-// log
 // rsqrt
 // sigmoid
-// sin
 // sinh
 // tan
 // tanh

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.h
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.h
@@ -13,6 +13,7 @@ struct NAME ## ImplC {\
 };\
 
 #define UNARY_OPS_MACRO(MACRO) \
+  MACRO (abs) \
   MACRO (ceil) \
   MACRO (cos) \
   MACRO (exp) \

--- a/aten/src/ATen/native/cpu/avx_mathfun.h
+++ b/aten/src/ATen/native/cpu/avx_mathfun.h
@@ -1,4 +1,4 @@
-#ifdef USE_AVX2
+#pragma once
 /*
    AVX implementation of sin, cos, sincos, exp and log
 
@@ -30,7 +30,7 @@
   (this is the zlib license)
 */
 
-#include <immintrin.h>
+#include "Intrinsics.h"
 
 /* yes I know, the top of this file is quite ugly */
 #if defined(__GNUC__)
@@ -156,7 +156,7 @@ AVX2_INTOP_USING_SSE2(add_epi32)
 /* natural logarithm computed for 8 simultaneous float
    return NaN for x <= 0
 */
-v8sf log256_ps(v8sf x) {
+inline v8sf log256_ps(v8sf x) {
   v8si imm0;
   v8sf one = *(v8sf*)_ps256_1;
 
@@ -242,7 +242,7 @@ _PS256_CONST(cephes_exp_p3, 4.1665795894E-2);
 _PS256_CONST(cephes_exp_p4, 1.6666665459E-1);
 _PS256_CONST(cephes_exp_p5, 5.0000001201E-1);
 
-v8sf exp256_ps(v8sf x) {
+inline v8sf exp256_ps(v8sf x) {
   v8sf tmp = _mm256_setzero_ps(), fx;
   v8si imm0;
   v8sf one = *(v8sf*)_ps256_1;
@@ -322,7 +322,7 @@ _PS256_CONST(cephes_FOPI, 1.27323954473516); // 4 / M_PI
    surprising but correct result.
 
 */
-v8sf sin256_ps(v8sf x) { // any x
+inline v8sf sin256_ps(v8sf x) { // any x
   v8sf xmm1, xmm2 = _mm256_setzero_ps(), xmm3, sign_bit, y;
   v8si imm0, imm2;
 
@@ -449,7 +449,7 @@ v8sf sin256_ps(v8sf x) { // any x
 }
 
 /* almost the same as sin_ps */
-v8sf cos256_ps(v8sf x) { // any x
+inline v8sf cos256_ps(v8sf x) { // any x
   v8sf xmm1, xmm2 = _mm256_setzero_ps(), xmm3, y;
   v8si imm0, imm2;
 
@@ -566,7 +566,7 @@ v8sf cos256_ps(v8sf x) { // any x
 
 /* since sin256_ps and cos256_ps are almost identical, sincos256_ps could replace both of them..
    it is almost as fast, and gives you a free cosine with your sine */
-void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
+inline void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
 
   v8sf xmm1, xmm2, xmm3 = _mm256_setzero_ps(), sign_bit_sin, y;
   v8si imm0, imm2, imm4;
@@ -713,4 +713,3 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   *s = _mm256_xor_ps(xmm1, sign_bit_sin);
   *c = _mm256_xor_ps(xmm2, sign_bit_cos);
 }
-#endif

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -144,6 +144,16 @@
 - func: conv_transpose3d(Tensor input, Tensor weight, Tensor bias={}, IntList[3] stride=1, IntList[3] padding=0, IntList[3] output_padding=0, int64_t groups=1, IntList[3] dilation=1) -> Tensor
   variants: function
 
+- func: cos(Tensor self) -> Tensor
+
+- func: cos_(Tensor self) -> Tensor
+
+- func: cos_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _cos_out_cpu
+    CUDA: _cos_out_cuda
+
 - func: cosine_embedding_loss(Tensor input1, Tensor input2, Tensor target, double margin, bool size_average, bool reduce) -> Tensor
   variants: function
 
@@ -278,6 +288,16 @@
 - func: empty_like(Tensor self, *, Type dtype) -> Tensor
   variants: function
 
+- func: exp(Tensor self) -> Tensor
+
+- func: exp_(Tensor self) -> Tensor
+
+- func: exp_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _exp_out_cpu
+    CUDA: _exp_out_cuda
+
 - func: expand(Tensor self, IntList size) -> Tensor
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
@@ -353,6 +373,16 @@
 
 - func: linspace_out(Tensor result, Scalar start, Scalar end, int64_t steps=100) -> Tensor
   variants: function
+
+- func: log(Tensor self) -> Tensor
+
+- func: log_(Tensor self) -> Tensor
+
+- func: log_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _log_out_cpu
+    CUDA: _log_out_cuda
 
 - func: logdet(Tensor self) -> Tensor
 
@@ -496,6 +526,16 @@
 
 - func: selu_(Tensor self) -> Tensor
   variants: function
+
+- func: sin(Tensor self) -> Tensor
+
+- func: sin_(Tensor self) -> Tensor
+
+- func: sin_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _sin_out_cpu
+    CUDA: _sin_out_cuda
 
 - func: size(Tensor self, int64_t dim) -> int64_t
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -41,6 +41,16 @@
 - func: _cudnn_init_dropout_state(Type ty, double dropout, bool train, int64_t dropout_seed) -> Tensor
   variants: function
 
+- func: abs(Tensor self) -> Tensor
+
+- func: abs_(Tensor self) -> Tensor
+
+- func: abs_out(Tensor result, Tensor self) -> Tensor
+  variants: function
+  dispatch:
+    CPU: _abs_out_cpu
+    CUDA: _abs_out_cuda
+
 - func: adaptive_avg_pool1d(Tensor self, IntList[1] output_size) -> Tensor
   variants: function
 

--- a/aten/src/TH/CMakeLists.txt
+++ b/aten/src/TH/CMakeLists.txt
@@ -90,7 +90,7 @@ INSTALL(FILES
 INSTALL(FILES
   vector/AVX.h
   vector/AVX2.h
-  vector/avx_mathfun.h
+  ../ATen/native/cpu/avx_mathfun.h
   DESTINATION "${ATEN_INSTALL_INCLUDE_SUBDIR}/TH/vector")
 
 INSTALL(FILES

--- a/aten/src/TH/vector/AVX2.cpp
+++ b/aten/src/TH/vector/AVX2.cpp
@@ -6,7 +6,7 @@
 #include <immintrin.h>
 #endif
 #include "AVX2.h"
-#include "avx_mathfun.h"
+#include <ATen/native/cpu/avx_mathfun.h>
 #include "../THRandom.h"
 
 void THDoubleVector_cadd_AVX2(double *z, const double *x, const double *y, const double c, const ptrdiff_t n) {


### PR DESCRIPTION
Measured perf using [this script](https://paste.fedoraproject.org/paste/yJiXU3AZGHuyjTVRWlj5OQ). The 1GB benchmarks for doubles are still running, but the 100MB benchmarks indicate a slight perf regression using this branch presumably because of the extra store and load within the non-avx2 implementation of vec<float> and vec<double>.

EDIT: Added timings for double
EDIT: Added support for abs for all types

Single core

Master

```
cos:            size: 10^2      count: 10000    elapsed: 1.55431699753  type: torch.FloatTensor
cos:            size: 10^3      count: 1000     elapsed: 1.62953400612  type: torch.FloatTensor
cos:            size: 10^4      count: 100      elapsed: 2.4978890419   type: torch.FloatTensor
cos:            size: 10^5      count: 10       elapsed: 2.39908790588  type: torch.FloatTensor
sin:            size: 10^2      count: 10000    elapsed: 1.44210910797  type: torch.FloatTensor
sin:            size: 10^3      count: 1000     elapsed: 1.54422807693  type: torch.FloatTensor
sin:            size: 10^4      count: 100      elapsed: 2.40846395493  type: torch.FloatTensor
sin:            size: 10^5      count: 10       elapsed: 2.29448604584  type: torch.FloatTensor
exp:            size: 10^2      count: 10000    elapsed: 1.50313210487  type: torch.FloatTensor
exp:            size: 10^3      count: 1000     elapsed: 1.5239470005   type: torch.FloatTensor
exp:            size: 10^4      count: 100      elapsed: 2.39896297455  type: torch.FloatTensor
exp:            size: 10^5      count: 10       elapsed: 2.31458091736  type: torch.FloatTensor
log:            size: 10^2      count: 10000    elapsed: 1.65806102753  type: torch.FloatTensor
log:            size: 10^3      count: 1000     elapsed: 1.69567799568  type: torch.FloatTensor
log:            size: 10^4      count: 100      elapsed: 2.56792616844  type: torch.FloatTensor
log:            size: 10^5      count: 10       elapsed: 2.47661995888  type: torch.FloatTensor

cos:            size: 10^2      count: 10000    elapsed: 29.2463679314  type: torch.DoubleTensor
cos:            size: 10^3      count: 1000     elapsed: 29.1897990704  type: torch.DoubleTensor
cos:            size: 10^4      count: 100      elapsed: 30.8953261375  type: torch.DoubleTensor
cos:            size: 10^5      count: 10       elapsed: 30.8482341766  type: torch.DoubleTensor
sin:            size: 10^2      count: 10000    elapsed: 28.2373690605  type: torch.DoubleTensor
sin:            size: 10^3      count: 1000     elapsed: 28.8227479458  type: torch.DoubleTensor
sin:            size: 10^4      count: 100      elapsed: 29.8306491375  type: torch.DoubleTensor
sin:            size: 10^5      count: 10       elapsed: 29.7849609852  type: torch.DoubleTensor
exp:            size: 10^2      count: 10000    elapsed: 21.3683919907  type: torch.DoubleTensor
exp:            size: 10^3      count: 1000     elapsed: 22.0100431442  type: torch.DoubleTensor
exp:            size: 10^4      count: 100      elapsed: 22.9923679829  type: torch.DoubleTensor
exp:            size: 10^5      count: 10       elapsed: 22.9505109787  type: torch.DoubleTensor
log:            size: 10^2      count: 10000    elapsed: 29.4384469986  type: torch.DoubleTensor
log:            size: 10^3      count: 1000     elapsed: 30.061797142   type: torch.DoubleTensor
log:            size: 10^4      count: 100      elapsed: 31.0885539055  type: torch.DoubleTensor
log:            size: 10^5      count: 10       elapsed: 31.0436210632  type: torch.DoubleTensor
```

This branch

```
cos:            size: 10^2      count: 10000    elapsed: 1.54843401909  type: torch.FloatTensor
cos:            size: 10^3      count: 1000     elapsed: 1.6413397789   type: torch.FloatTensor
cos:            size: 10^4      count: 100      elapsed: 2.52125191689  type: torch.FloatTensor
cos:            size: 10^5      count: 10       elapsed: 2.41325116158  type: torch.FloatTensor
sin:            size: 10^2      count: 10000    elapsed: 1.44992494583  type: torch.FloatTensor
sin:            size: 10^3      count: 1000     elapsed: 1.54990410805  type: torch.FloatTensor
sin:            size: 10^4      count: 100      elapsed: 2.40798306465  type: torch.FloatTensor
sin:            size: 10^5      count: 10       elapsed: 2.30475592613  type: torch.FloatTensor
exp:            size: 10^2      count: 10000    elapsed: 1.50176095963  type: torch.FloatTensor
exp:            size: 10^3      count: 1000     elapsed: 1.52033686638  type: torch.FloatTensor
exp:            size: 10^4      count: 100      elapsed: 2.40323591232  type: torch.FloatTensor
exp:            size: 10^5      count: 10       elapsed: 2.31940412521  type: torch.FloatTensor
log:            size: 10^2      count: 10000    elapsed: 1.63235998154  type: torch.FloatTensor
log:            size: 10^3      count: 1000     elapsed: 1.67921590805  type: torch.FloatTensor
log:            size: 10^4      count: 100      elapsed: 2.55977487564  type: torch.FloatTensor
log:            size: 10^5      count: 10       elapsed: 2.46202898026  type: torch.FloatTensor

cos:            size: 10^2      count: 10000    elapsed: 30.0235459805  type: torch.DoubleTensor
cos:            size: 10^3      count: 1000     elapsed: 31.4737381935  type: torch.DoubleTensor
cos:            size: 10^4      count: 100      elapsed: 32.1326041222  type: torch.DoubleTensor
cos:            size: 10^5      count: 10       elapsed: 31.6777579784  type: torch.DoubleTensor
sin:            size: 10^2      count: 10000    elapsed: 29.1807699203  type: torch.DoubleTensor
sin:            size: 10^3      count: 1000     elapsed: 29.6215879917  type: torch.DoubleTensor
sin:            size: 10^4      count: 100      elapsed: 30.6181018353  type: torch.DoubleTensor
sin:            size: 10^5      count: 10       elapsed: 30.2948379517  type: torch.DoubleTensor
exp:            size: 10^2      count: 10000    elapsed: 22.4347589016  type: torch.DoubleTensor
exp:            size: 10^3      count: 1000     elapsed: 23.307060957   type: torch.DoubleTensor
exp:            size: 10^4      count: 100      elapsed: 24.4995651245  type: torch.DoubleTensor
exp:            size: 10^5      count: 10       elapsed: 24.0824759007  type: torch.DoubleTensor
log:            size: 10^2      count: 10000    elapsed: 31.2646110058  type: torch.DoubleTensor
log:            size: 10^3      count: 1000     elapsed: 32.2329819202  type: torch.DoubleTensor
log:            size: 10^4      count: 100      elapsed: 33.4655709267  type: torch.DoubleTensor
log:            size: 10^5      count: 10       elapsed: 33.0231490135  type: torch.DoubleTensor
```

Abs Master
```
abs:            size: 10^2      count: 10000    elapsed: 4.18545389175  type: torch.FloatTensor
abs:            size: 10^3      count: 1000     elapsed: 4.30929303169  type: torch.FloatTensor
abs:            size: 10^4      count: 100      elapsed: 5.18289899826  type: torch.FloatTensor
abs:            size: 10^5      count: 10       elapsed: 5.12413811684  type: torch.FloatTensor
abs:            size: 10^2      count: 10000    elapsed: 4.21678590775  type: torch.DoubleTensor
abs:            size: 10^3      count: 1000     elapsed: 5.08613801003  type: torch.DoubleTensor
abs:            size: 10^4      count: 100      elapsed: 5.99231100082  type: torch.DoubleTensor
abs:            size: 10^5      count: 10       elapsed: 5.95689797401  type: torch.DoubleTensor
abs:            size: 10^2      count: 10000    elapsed: 4.16819906235  type: torch.IntTensor
abs:            size: 10^3      count: 1000     elapsed: 4.22109985352  type: torch.IntTensor
abs:            size: 10^4      count: 100      elapsed: 5.09025883675  type: torch.IntTensor
abs:            size: 10^5      count: 10       elapsed: 5.03382301331  type: torch.IntTensor
abs:            size: 10^2      count: 10000    elapsed: 4.22057914734  type: torch.LongTensor
abs:            size: 10^3      count: 1000     elapsed: 4.9265730381   type: torch.LongTensor
abs:            size: 10^4      count: 100      elapsed: 5.84256696701  type: torch.LongTensor
abs:            size: 10^5      count: 10       elapsed: 5.93304586411  type: torch.LongTensor
abs:            size: 10^2      count: 10000    elapsed: 4.17617201805  type: torch.ShortTensor
abs:            size: 10^3      count: 1000     elapsed: 4.2090690136   type: torch.ShortTensor
abs:            size: 10^4      count: 100      elapsed: 4.49850416183  type: torch.ShortTensor
abs:            size: 10^5      count: 10       elapsed: 4.626557827    type: torch.ShortTensor
```

Abs This branch
```
abs:            size: 10^2      count: 10000    elapsed: 0.448744058609 type: torch.FloatTensor
abs:            size: 10^3      count: 1000     elapsed: 0.421611070633 type: torch.FloatTensor
abs:            size: 10^4      count: 100      elapsed: 1.52210712433  type: torch.FloatTensor
abs:            size: 10^5      count: 10       elapsed: 1.49177908897  type: torch.FloatTensor
abs:            size: 10^2      count: 10000    elapsed: 0.844108104706 type: torch.DoubleTensor
abs:            size: 10^3      count: 1000     elapsed: 0.820927858353 type: torch.DoubleTensor
abs:            size: 10^4      count: 100      elapsed: 3.00412607193  type: torch.DoubleTensor
abs:            size: 10^5      count: 10       elapsed: 2.97248101234  type: torch.DoubleTensor
abs:            size: 10^2      count: 10000    elapsed: 0.445827960968 type: torch.IntTensor
abs:            size: 10^3      count: 1000     elapsed: 0.420156955719 type: torch.IntTensor
abs:            size: 10^4      count: 100      elapsed: 1.51804709435  type: torch.IntTensor
abs:            size: 10^5      count: 10       elapsed: 1.52535510063  type: torch.IntTensor
abs:            size: 10^2      count: 10000    elapsed: 0.844727993011 type: torch.LongTensor
abs:            size: 10^3      count: 1000     elapsed: 0.818938016891 type: torch.LongTensor
abs:            size: 10^4      count: 100      elapsed: 3.02740287781  type: torch.LongTensor
abs:            size: 10^5      count: 10       elapsed: 2.99336504936  type: torch.LongTensor
abs:            size: 10^2      count: 10000    elapsed: 0.251252174377 type: torch.ShortTensor
abs:            size: 10^3      count: 1000     elapsed: 0.217294931412 type: torch.ShortTensor
abs:            size: 10^4      count: 100      elapsed: 0.330620765686 type: torch.ShortTensor
abs:            size: 10^5      count: 10       elapsed: 0.745229005814 type: torch.ShortTensor
```
