### PR TITLE
Add class-specific error when key mismatch in load_state_dict

### DIFF
--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -15,14 +15,15 @@ class _InstanceNorm(_BatchNorm):
         if not is_missing and not self.track_running_stats and \
                 name in ('running_mean', 'running_var'):
             raise KeyError(
-                'Unexpected running stats buffer in state_dict ("{name}") for '
+                'Unexpected running stats buffer "{name}" in state_dict for '
                 '{klass} with track_running_stats=False. If you are trying to '
                 'load a checkpoint saved before 0.4.0, this may be expected '
                 'because {klass} does not track running stats by default '
-                'anymore since 0.4.0. If running stats are not used, set '
-                'strict=False in load_state_dict. Otherwise, set '
-                'track_running_stats=True in {klass} to use running stats. See '
-                'the documentation of {klass} for more details.'
+                'anymore since 0.4.0. If running stats are not used, remove '
+                'them from state_dict before calling load_state_dict. '
+                'Otherwise, set track_running_stats=True in {klass} to use '
+                'running stats. See the documentation of {klass} for more '
+                'details.'
                 .format(name=full_name, klass=self.__class__.__name__))
         super(_InstanceNorm, self)._load_state_dict_key_mismatch(
             full_name, name, is_missing)

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -11,6 +11,22 @@ class _InstanceNorm(_BatchNorm):
     def _check_input_dim(self, input):
         return NotImplemented
 
+    def _load_state_dict_key_mismatch(self, full_name, name, is_missing):
+        if not is_missing and not self.track_running_stats and \
+                name in ('running_mean', 'running_var'):
+            raise KeyError(
+                'Unexpected running stats buffer in state_dict ("{name}") for '
+                '{klass} with track_running_stats=False. If you are trying to '
+                'load a checkpoint saved before 0.4.0, this may be expected '
+                'because {klass} does not track running stats by default '
+                'anymore since 0.4.0. If running stats are not used, set '
+                'strict=False in load_state_dict. Otherwise, set '
+                'track_running_stats=True in {klass} to use running stats. See '
+                'the documentation of {klass} for more details.'
+                .format(name=full_name, klass=self.__class__.__name__))
+        super(_InstanceNorm, self)._load_state_dict_key_mismatch(
+            full_name, name, is_missing)
+
     def forward(self, input):
         self._check_input_dim(input)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -507,6 +507,20 @@ class Module(object):
                 module.state_dict(destination, prefix + name + '.', keep_vars=keep_vars)
         return destination
 
+    def _load_state_dict_key_mismatch(self, full_name, name, is_missing):
+        r"""This is called in :meth:`~torch.nn.Module.load_state_dict` when
+        there is state dict key mismatch in ``strict=True`` mode. This method
+        can be overridden by subclasses to raise class-specific errors.
+
+        When :attr:`is_missing` is ``True``, :attr:`full_name` can not be found in
+        the dict being loaded. When :attr:`is_missing` is ``False``,
+        :attr:`full_name` is unexpected in the dict being loaded.
+
+        :attr:`name` is the actual name of the parameter/buffer, i.e., the
+        substring after the last `dot` in :attr:`full_name`.
+        """
+        pass
+
     def load_state_dict(self, state_dict, strict=True):
         r"""Copies parameters and buffers from :attr:`state_dict` into
         this module and its descendants. If :attr:`strict` is ``True`` then
@@ -520,6 +534,18 @@ class Module(object):
                 match the keys returned by this module's `:func:`state_dict()`
                 function.
         """
+        def submodule_key_mismatch(full_name, is_missing):
+            module = self
+            names = full_name.split(".")
+            for i, module_name in enumerate(names[:-1]):
+                children = module._modules
+                if module_name in module._modules:
+                    module = module._modules[module_name]
+                else:
+                    return
+            module._load_state_dict_key_mismatch(full_name, names[-1], is_missing)
+
+        unexpected = []
         own_state = self.state_dict()
         for name, param in state_dict.items():
             if name in own_state:
@@ -534,12 +560,26 @@ class Module(object):
                                        'whose dimensions in the checkpoint are {}.'
                                        .format(name, own_state[name].size(), param.size()))
             elif strict:
-                raise KeyError('unexpected key "{}" in state_dict'
-                               .format(name))
+                unexpected.append(name)
         if strict:
             missing = set(own_state.keys()) - set(state_dict.keys())
+            # pass the mismatch info to submodules so that they have a chance to
+            # raise a custom class-specific error
+            for name in unexpected:
+                submodule_key_mismatch(name, False)
+            for name in missing:
+                submodule_key_mismatch(name, True)
+            error = ''
+            if len(unexpected) > 0:
+                error += ('Unexpected key(s) in state_dict: {}. '.format(
+                    ', '.join('"{}"'.format(k) for k in unexpected)))
             if len(missing) > 0:
-                raise KeyError('missing keys in state_dict: "{}"'.format(missing))
+                error += ('Missing key(s) in state_dict: {}. '.format(
+                    ', '.join('"{}"'.format(k) for k in unexpected)))
+            if len(error) > 0:
+                raise KeyError(error + 'If this is expected, set strict=False '
+                               'in load_state_dict to suppress the key '
+                               'mismatch checks.')
 
     def parameters(self):
         r"""Returns an iterator over module parameters.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -537,8 +537,7 @@ class Module(object):
         def submodule_key_mismatch(full_name, is_missing):
             module = self
             names = full_name.split(".")
-            for i, module_name in enumerate(names[:-1]):
-                children = module._modules
+            for module_name in names[:-1]:
                 if module_name in module._modules:
                     module = module._modules[module_name]
                 else:
@@ -569,17 +568,15 @@ class Module(object):
                 submodule_key_mismatch(name, False)
             for name in missing:
                 submodule_key_mismatch(name, True)
-            error = ''
+            error_msg = ''
             if len(unexpected) > 0:
-                error += ('Unexpected key(s) in state_dict: {}. '.format(
-                    ', '.join('"{}"'.format(k) for k in unexpected)))
+                error_msg += 'Unexpected key(s) in state_dict: {}. '.format(
+                    ', '.join('"{}"'.format(k) for k in unexpected))
             if len(missing) > 0:
-                error += ('Missing key(s) in state_dict: {}. '.format(
-                    ', '.join('"{}"'.format(k) for k in unexpected)))
-            if len(error) > 0:
-                raise KeyError(error + 'If this is expected, set strict=False '
-                               'in load_state_dict to suppress the key '
-                               'mismatch checks.')
+                error_msg += 'Missing key(s) in state_dict: {}. '.format(
+                    ', '.join('"{}"'.format(k) for k in unexpected))
+            if len(error_msg) > 0:
+                raise KeyError(error_msg)
 
     def parameters(self):
         r"""Returns an iterator over module parameters.


### PR DESCRIPTION
Add _load_state_dict_key_mismatch to nn.Module so that submodules can throw class-specific errors when there is state_dict key mismatch.

Fixes #5602 

cc @apaszke @smessmer @CynthiaLu1119 
