### PR TITLE
Add torch.jit.Const

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2146,7 +2146,7 @@ class TestScript(TestCase):
 
             def __init__(self):
                 super(M, self).__init__(False)
-                self.mods = [Sub() for i in range(10)]
+                self.mods = nn.ModuleList([Sub() for i in range(10)])
 
             @torch.jit.script_method
             def forward(self, v):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -100,23 +100,23 @@ struct Environment {
   }
 
   void setVar(const std::string& name, Value* value) {
-    setSugaredVar(name, std::make_shared<SimpleValue>(value));
-  }
-  void setSugaredVar(const std::string& name, SugaredValuePtr value) {
     if (!findInThisFrame(name) && findInParentFrame(name) &&
         getBlockOwningKind() == prim::Loop)
       createCapturedInput(name);
+    setSugaredVar(name, std::make_shared<SimpleValue>(value));
+  }
+  void setSugaredVar(const std::string& name, SugaredValuePtr value) {
     value_table[name] = std::move(value);
   }
 
   SugaredValuePtr getSugaredVar(const Ident& ident, bool required=true) {
-    return getSugaredVar(ident.name(), ident);
+    return getSugaredVar(ident.name(), ident.range());
   }
   Value* getVar(const Ident& ident) {
     return getSugaredVar(ident)->asValue(ident.range(), method);
   }
 
-  SugaredValuePtr getSugaredVar(const std::string& ident, const TreeView& tv, bool required=true) {
+  SugaredValuePtr getSugaredVar(const std::string& ident, SourceRange range, bool required=true) {
     auto retval = findInThisFrame(ident);
 
     if (!retval && (retval = findInParentFrame(ident)) &&
@@ -129,13 +129,13 @@ struct Environment {
     }
 
     if (!retval && required) {
-      throw ErrorReport(tv) << "undefined value " << ident;
+      throw ErrorReport(range) << "undefined value " << ident;
     }
     return retval;
   }
 
-  Value* getVar(const std::string& ident, const TreeView& tv) {
-    return getSugaredVar(ident, tv)->asValue(tv.range(), method);
+  Value* getVar(const std::string& ident, SourceRange range) {
+    return getSugaredVar(ident, range)->asValue(range, method);
   }
 
   // Given that after emitting statements in a block, we've added block inputs
@@ -409,10 +409,10 @@ private:
 
     // Register outputs in each block
     for (const auto& x : sorted_mutations) {
-      true_block->registerOutput(save_true->getVar(x, stmt));
+      true_block->registerOutput(save_true->getVar(x, stmt.range()));
     }
     for (const auto& x : sorted_mutations) {
-      false_block->registerOutput(save_false->getVar(x, stmt));
+      false_block->registerOutput(save_false->getVar(x, stmt.range()));
     }
 
     // Add op outputs
@@ -439,12 +439,12 @@ private:
   // in a way that ensure single static assignment.
 
   void emitLoopCommon(
+      SourceRange range,
       at::optional<Expr> max_trip_count,
       at::optional<Expr> cond,
       const List<Stmt>& body,
-      const Stmt& stmt,
       at::optional<Ident> itr_ident) {
-    Node* n = graph->insertNode(create(prim::Loop, stmt.range(), 0));
+    Node* n = graph->insertNode(create(prim::Loop, range, 0));
     Value *max_trip_count_val, *cond_val;
     {
       WithInsertPoint guard(n);
@@ -452,12 +452,12 @@ private:
         max_trip_count_val = emitExpr(max_trip_count.value(), 1)[0];
       } else {
         max_trip_count_val =
-            emitConst(Const::create(stmt.range(), std::to_string(INT_MAX)))[0];
+            emitConst(Const::create(range, std::to_string(INT_MAX)))[0];
       }
       if (cond) {
         cond_val = emitExpr(cond.value(), 1)[0];
       } else {
-        cond_val = emitBooleanConst(stmt, true)[0];
+        cond_val = emitBooleanConst(range, true)[0];
       }
     }
     n->addInput(max_trip_count_val);
@@ -479,7 +479,7 @@ private:
         Value* body_cond_value = emitExpr(cond.value(), 1)[0];
         body_block->registerOutput(body_cond_value);
       } else {
-        Value* cond_value_dummy = emitBooleanConst(stmt, true)[0];
+        Value* cond_value_dummy = emitBooleanConst(range, true)[0];
         body_block->registerOutput(cond_value_dummy);
       }
 
@@ -487,69 +487,66 @@ private:
       auto outer_frame = environment_stack;
       // Remove inputs for values that did not mutate within the
       // block
-      body_frame->deleteExtraInputs(stmt.range(), skip_inputs_num);
+      body_frame->deleteExtraInputs(range, skip_inputs_num);
 
       // Add block outputs
       for (const auto& x : body_frame->captured_inputs) {
-        body_block->registerOutput(body_frame->getValueInThisFrame(stmt.range(), x));
-        n->addInput(outer_frame->getVar(x, stmt));
+        body_block->registerOutput(body_frame->getValueInThisFrame(range, x));
+        n->addInput(outer_frame->getVar(x, range));
         outer_frame->setVar(x, n->addOutput());
       }
 
     }
   }
 
+  void emitForRange(SourceRange range, const Ident& target, const List<Expr>& args, const List<Stmt>& body) {
+    // TODO: start, stop, step loop
+    if (args.size() != 1) {
+      throw ErrorReport(range)
+          << "range() expects one argument but got" << args.size();
+    }
+    emitLoopCommon(range, {args[0]}, {}, body, target);
+  }
+
   void emitFor(const For& stmt) {
     // For now, we only support range loops. e.g. for i in range(3): ...
-
     auto targets = stmt.targets();
     auto itrs = stmt.itrs();
     auto body = stmt.body();
 
-    // itrs must consist of a single Apply node
     if (stmt.itrs().size() != 1) {
       throw ErrorReport(stmt)
           << "List of iterables is not supported currently.";
     }
-    if (itrs[0].kind() != TK_APPLY) {
-      throw ErrorReport(stmt)
-          << "Non-range for loops are currently not supported.";
+    if (targets.size() != 1) {
+      throw ErrorReport(stmt) << "Iteration variable unpacking is not supported";
     }
 
-    Apply range_iterator = Apply(itrs[0]);
-    if (range_iterator.callee().kind() != TK_VAR) {
-      throw ErrorReport(stmt)
-          << "Non-range for loops are currently not supported.";
-    }
-
-    {
-      Var var = Var(range_iterator.callee());
-      if (var.name().name() != "range") {
-        throw ErrorReport(stmt)
-            << "Non-range for loops are currently not supported.";
+    // match range(<expr>) style loops
+    // itrs must consist of a single Apply node
+    if (itrs[0].kind() == TK_APPLY) {
+      Apply range_iterator = Apply(itrs[0]);
+      if (range_iterator.callee().kind() == TK_VAR) {
+        Var var = Var(range_iterator.callee());
+        if (var.name().name() == "range") {
+          return emitForRange(stmt.range(), targets[0], range_iterator.inputs(), body);
+        }
       }
     }
 
-    List<Expr> args = range_iterator.inputs();
-    // TODO: start, stop, step loop
-    if (args.size() != 1) {
-      throw ErrorReport(stmt)
-          << "range() expects one argument but got" << args.size();
+    // it isn't a range(<expr>) loop, treat it as a sugared value that maybe can be
+    // unrolled
+    auto sv = emitSugaredExpr(itrs[0]);
+    auto instances = sv->unrolledFor(stmt.range(), method);
+    for(auto inst : instances) {
+      environment_stack->setSugaredVar(targets[0].name(), inst);
+      emitStatements(body);
     }
-
-    auto target_list = List<Ident>(targets);
-    if (target_list.size() != 1) {
-      throw ErrorReport(stmt)
-          << "Iteration variable unpacking is not supported";
-    }
-    at::optional<Ident> target_ident{target_list[0]};
-
-    emitLoopCommon({args[0]}, {}, stmt.body(), stmt, target_ident);
   }
 
   void emitWhile(const While& stmt) {
     auto cond = stmt.cond();
-    emitLoopCommon({}, {cond}, stmt.body(), stmt, {});
+    emitLoopCommon(stmt.range(), {}, {cond}, stmt.body(), {});
   }
 
   std::vector<Value*> emitAssignment(const Assign& stmt) {
@@ -734,10 +731,10 @@ private:
         return emitConst(Const(tree));
       } break;
       case TK_TRUE: {
-        return emitBooleanConst(tree, true);
+        return emitBooleanConst(tree->range(), true);
       } break;
       case TK_FALSE: {
-        return emitBooleanConst(tree, false);
+        return emitBooleanConst(tree->range(), false);
       } break;
       case TK_SLICE: {
         expectOutputs(tree, output_size, 1);
@@ -789,13 +786,8 @@ private:
         ->outputs();
   }
 
-  std::vector<Value*> emitBooleanConst(const TreeRef& tree, bool val) {
-    return {createConstant(tree->range(), at::CPU(at::kByte).scalarTensor(val))};
-  }
-
-  std::vector<Value*> emitBooleanConst(const TreeRef& tree) {
-    bool val = tree->kind() == TK_TRUE;
-    return emitBooleanConst(tree, val);
+  std::vector<Value*> emitBooleanConst(SourceRange range, bool val) {
+    return {createConstant(range, at::CPU(at::kByte).scalarTensor(val))};
   }
 
   std::vector<Value*> emitConst(const Const& c) {

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -44,6 +44,14 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
     size_t n_outputs) {
     throw ErrorReport(loc) << "cannot call a " << kind();
   }
+
+  // use it in `for i in this: ...`
+  // in this case we will unroll the loop boy by assigning i to each of
+  // the SugaredValues returned from this method.
+  virtual std::vector<std::shared_ptr<SugaredValue>> unrolledFor(SourceRange loc, Method& m) {
+    throw ErrorReport(loc) << kind() << " is not iterable";
+  }
+
   virtual ~SugaredValue() {}
 };
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -46,7 +46,7 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   }
 
   // use it in `for i in this: ...`
-  // in this case we will unroll the loop boy by assigning i to each of
+  // in this case we will unroll the loop body by assigning i to each of
   // the SugaredValues returned from this method.
   virtual std::vector<std::shared_ptr<SugaredValue>> unrolledFor(SourceRange loc, Method& m) {
     throw ErrorReport(loc) << kind() << " is not iterable";

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -194,10 +194,10 @@ struct ModuleValue : public SugaredValue {
       if(py::isinstance<py::function>(attr) ||
          py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
         return std::make_shared<PythonValue>(attr);
-      } else if(py_module.attr("_constants").contains(field.c_str())) {
+      } else if(py_module.attr("_constants_set").contains(field.c_str())) {
         return createConstantSugaredValue(attr);
       } else {
-        throw ErrorReport(loc) << "attribute '" << field << "' of type '" << typeString(attr) << "' is not usable in a script method (did you mean to use torch.jit.const?)";
+        throw ErrorReport(loc) << "attribute '" << field << "' of type '" << typeString(attr) << "' is not usable in a script method (did you forget to add it __constants__?)";
       }
     }
     throw ErrorReport(loc) << "module has no attribute '" << field << "'";

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -656,14 +656,15 @@ class OrderedBufferDict(OrderedDictWrapper):
             raise KeyError(k)
         return self.module._get_parameter(k)
 
-# base types that can be constants in addition to tuples and lists
+# base types that can be constants
+# in addition, tuples and lists of these base types are also considered constants
 # If you edit this list, then you also need to edit the handlers in
 # ConstantValue in jit/script/init.cpp
-_constant_types = [bool, float, int, types.FunctionType]
+_constant_types = (bool, float, int, types.FunctionType)
 
 
 def _get_valid_constant(v):
-    if any(isinstance(v, typ) for typ in _constant_types):
+    if isinstance(v, _constant_types):
         return v
     elif isinstance(v, tuple) or isinstance(v, list):
         return tuple(_get_valid_constant(x) for x in v)


### PR DESCRIPTION
`Const` allows you to mark certain python attributes of a modules constant,
enabling script methods to use them in way that are otherwise not allowed.

* This includes using python constants like `use_bias` in if statements.

* Add support for unrolledFor to torch.jit.Const

#6024