### PR TITLE
Fix a bug in ONNX symbolic of average 3d pooling op

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -420,7 +420,7 @@ def avg_pool3d(g, input, kernel_size, stride, padding, ceil_mode, count_include_
     return g.op("AveragePool", input,
                 kernel_shape_i=_triple(kernel_size),
                 strides_i=_triple(stride),
-                pads_i=_triple(padding))
+                pads_i=_triple(padding) * 2)
 
 
 def reflection_pad(g, input, padding):


### PR DESCRIPTION
We should have both start and end in paddings.