### PR TITLE
Set dataloader.batch_size = None when batch_sampler is given

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -299,6 +299,14 @@ class TestDataLoader(TestCase):
                                  math.ceil(float(len(loader.dataset)) / loader.batch_size))
                 return
 
+    def test_invalid_assign_after_init(self):
+        dl = DataLoader(self.dataset)
+        for attr in ('batch_size', 'sampler', 'drop_last'):
+            def fn():
+                setattr(dl, attr, {})
+
+            self.assertRaises(ValueError, fn)
+
     def test_sequential(self):
         self._test_sequential(DataLoader(self.dataset))
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -376,12 +376,6 @@ class DataLoader(object):
             worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
             input, after seeding and before data loading. (default: None)
 
-    .. warning:: If :attr:`batch_sampler` is given, setting :attr:`batch_size`,
-                 :attr:`shuffle`, :attr:`sampler`, or :attr:`drop_last` is
-                 invalid because such information is provided by
-                 :attr:`batch_sampler`. In this case, the data loader will have
-                 ``dataloader.batch_size == dataloader.drop_last == dataloader.sampler == None``.
-
     .. note:: By default, each worker will have its PyTorch seed set to
               ``base_seed + worker_id``, where ``base_seed`` is a long generated
               by main process using its RNG. You may use ``torch.initial_seed()`` to access

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -411,16 +411,18 @@ class DataLoader(object):
 
         if batch_sampler is not None:
             if batch_size > 1 or shuffle or sampler is not None or drop_last:
-                raise ValueError('batch_sampler is mutually exclusive with '
-                                 'batch_size, shuffle, sampler, and drop_last')
+                raise ValueError('batch_sampler option is mutually exclusive '
+                                 'with batch_size, shuffle, sampler, and '
+                                 'drop_last')
             self.batch_size = None
             self.drop_last = None
 
         if sampler is not None and shuffle:
-            raise ValueError('sampler is mutually exclusive with shuffle')
+            raise ValueError('sampler option is mutually exclusive with '
+                             'shuffle')
 
         if self.num_workers < 0:
-            raise ValueError('num_workers cannot be negative; '
+            raise ValueError('num_workers option cannot be negative; '
                              'use num_workers=0 to disable multiprocessing.')
 
         if batch_sampler is None:
@@ -436,11 +438,9 @@ class DataLoader(object):
         self.__initialized = True
 
     def __setattr__(self, attr, val):
-        if self.__initialized and self.batch_sampler is not None and \
-                attr in ('batch_size', 'sampler', 'drop_last') and \
-                val is not None:
-            raise ValueError('{} should not be set when batch_sampler is '
-                             'used'.format(attr))
+        if self.__initialized and attr in ('batch_size', 'sampler', 'drop_last'):
+            raise ValueError('{} attribute should not be set after {} is '
+                             'initialized'.format(attr, self.__class__.__name__))
 
         super(DataLoader, self).__setattr__(attr, val)
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -376,6 +376,12 @@ class DataLoader(object):
             worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
             input, after seeding and before data loading. (default: None)
 
+    .. warning:: If :attr:`batch_sampler` is given, setting :attr:`batch_size`,
+                 :attr:`shuffle`, :attr:`sampler`, or :attr:`drop_last` is
+                 invalid because such information is provided by
+                 :attr:`batch_sampler`. In this case, the data loader will have
+                 ``dataloader.batch_size == dataloader.drop_last == dataloader.sampler == None``.
+
     .. note:: By default, each worker will have its PyTorch seed set to
               ``base_seed + worker_id``, where ``base_seed`` is a long generated
               by main process using its RNG. You may use ``torch.initial_seed()`` to access
@@ -405,6 +411,8 @@ class DataLoader(object):
             if batch_size > 1 or shuffle or sampler is not None or drop_last:
                 raise ValueError('batch_sampler is mutually exclusive with '
                                  'batch_size, shuffle, sampler, and drop_last')
+            self.batch_size = None
+            self.drop_last = None
 
         if sampler is not None and shuffle:
             raise ValueError('sampler is mutually exclusive with shuffle')

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -392,6 +392,8 @@ class DataLoader(object):
                  unpicklable object, e.g., a lambda function.
     """
 
+    __initialized = False
+
     def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None,
                  num_workers=0, collate_fn=default_collate, pin_memory=False, drop_last=False,
                  timeout=0, worker_init_fn=None):
@@ -431,6 +433,16 @@ class DataLoader(object):
 
         self.sampler = sampler
         self.batch_sampler = batch_sampler
+        self.__initialized = True
+
+    def __setattr__(self, attr, val):
+        if self.__initialized and self.batch_sampler is not None and \
+                attr in ('batch_size', 'sampler', 'drop_last') and \
+                val is not None:
+            raise ValueError('{} should not be set when batch_sampler is '
+                             'used'.format(attr))
+
+        super(DataLoader, self).__setattr__(attr, val)
 
     def __iter__(self):
         return _DataLoaderIter(self)


### PR DESCRIPTION
Set dataloader's `batch_size` and `drop_last` to `None` when `batch_sampler is given. Add a warning in doc for this case. 

Address https://github.com/pytorch/pytorch/issues/5884.