### PR TITLE
Give ATen errors backtraces

### DIFF
--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -5,14 +5,164 @@
 #include <cstdint>
 #include <cstdio>
 #include <exception>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <stdarg.h>
 
+#if !defined(_WIN32)
+#include <cxxabi.h>
+#include <execinfo.h>
+#endif // !defined(_WIN32)
+
 namespace at {
 namespace detail {
+
+// TODO: This backtrace retrieval can be implemented on Windows via the Windows
+// API using `CaptureStackBackTrace` and `SymFromAddr`.
+// https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
+// https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows
+// https://msdn.microsoft.com/en-us/library/windows/desktop/bb204633%28v=vs.85%29.aspx.
+#if !defined(_WIN32)
+struct FrameInformation {
+  /// If available, the demangled name of the function at this frame, else
+  /// whatever (possibly mangled) name we got from `backtrace()`.
+  std::string function_name;
+  /// This is a number in hexadecimal form (e.g. "0xdead") representing the
+  /// offset into the function's machine code at which the function's body
+  /// starts, i.e. skipping the "prologue" that handles stack manipulation and
+  /// other calling convention things.
+  std::string offset_into_function;
+  /// NOTE: In debugger parlance, the "object file" refers to the ELF file that
+  /// the symbol originates from, i.e. either an executable or a library.
+  std::string object_file;
+};
+
+inline FrameInformation parse_frame_information(
+    const std::string& frame_string) {
+  FrameInformation frame;
+
+  // This is the function name in the CXX ABI mangled format, e.g. something
+  // like _Z1gv. Reference:
+  // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
+  std::string mangled_function_name;
+
+#ifdef __GLIBCXX__
+  // In GLIBCXX, `frame_string` follows the pattern
+  // `<object-file>(<mangled-function-name>+<offset-into-function>)
+  // [<return-address>]`
+
+  const auto function_name_start = frame_string.find('(') + 1;
+  const auto offset_start = frame_string.find('+', function_name_start) + 1;
+  const auto offset_end = frame_string.find(')', offset_start);
+  frame.object_file = frame_string.substr(0, function_name_start - 1);
+  frame.offset_into_function =
+      frame_string.substr(offset_start, offset_end - offset_start);
+
+  // NOTE: We don't need to parse the return address because
+  // we already have it from the call to `backtrace()`.
+
+  mangled_function_name = frame_string.substr(
+      function_name_start, (offset_start - 1) - function_name_start);
+#else
+  // In LIBCXX, The pattern is
+  // `<frame number> <object-file> <return-address> <mangled-function-name> +
+  // <offset-into-function>`
+  std::string skip;
+  std::istringstream input_stream(frame_string);
+  input_stream >> skip >> frame.object_file >> skip >> mangled_function_name >>
+      skip >> frame.offset_into_function;
+#endif
+
+  int status = -1;
+  // This function will demangle the mangled function name into a more human
+  // readable format, e.g. _Z1gv -> g().
+  // More information:
+  // https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/libsupc%2B%2B/cxxabi.h
+  char* demangled_function_name = abi::__cxa_demangle(
+      mangled_function_name.c_str(),
+      /*__output_buffer=*/nullptr,
+      /*__length=*/0,
+      &status);
+
+  // Demangling may fail, for example when the name does not follow the
+  // standard C++ (Itanium ABI) mangling scheme. This is the case for `main` or
+  // `clone` for example, so the mangled name is a fine default.
+  if (status == 0) {
+    frame.function_name = demangled_function_name;
+  } else {
+    frame.function_name = mangled_function_name;
+  }
+
+  // `__cxa_demangle` returns a malloc'd string that we have to free ourselves.
+  free(demangled_function_name);
+
+  return frame;
+}
+
+inline std::string get_backtrace(
+    size_t frames_to_skip = 0,
+    size_t maximum_number_of_frames = 64) {
+  // We always skip this frame (backtrace).
+  frames_to_skip += 1;
+
+  std::vector<void*> callstack(
+      frames_to_skip + maximum_number_of_frames, nullptr);
+  // backtrace() gives us a list of return addresses in the current call stack.
+  // NOTE: As per man (3) backtrace it can never fail
+  // (http://man7.org/linux/man-pages/man3/backtrace.3.html).
+  auto number_of_frames = ::backtrace(callstack.data(), callstack.size());
+
+  // Skip as many frames as requested. This is not efficient, but the sizes here
+  // are small and it makes the code nicer and safer.
+  for (; frames_to_skip > 0 && number_of_frames > 0;
+       --frames_to_skip, --number_of_frames) {
+    callstack.erase(callstack.begin());
+  }
+
+  // `number_of_frames` is strictly less than the current capacity of
+  // `callstack`, so this is just a pointer subtraction and makes the subsequent
+  // code safer.
+  callstack.resize(number_of_frames);
+
+  // `backtrace_symbols` takes the return addresses obtained from `backtrace()`
+  // and fetches string representations of each stack. Unfortunately it doesn't
+  // return a struct of individual pieces of information but a concatenated
+  // string, so we'll have to parse the string after.
+  char** raw_symbols = ::backtrace_symbols(callstack.data(), callstack.size());
+  std::vector<std::string> symbols(raw_symbols, raw_symbols + callstack.size());
+
+  // The array returned by `backtrace_symbols` is malloc'd and must be manually
+  // freed, but not the strings inside the array.
+  free(raw_symbols);
+
+  // The backtrace string goes into here.
+  std::ostringstream stream;
+
+  for (size_t frame_number = 0; frame_number < callstack.size();
+       ++frame_number) {
+    const auto frame = parse_frame_information(symbols[frame_number]);
+
+    // These are usually uninteresting frames below `main` or `clone` with
+    // limited debugging information.
+    if (frame.function_name.empty()) {
+      break;
+    }
+
+    // frame #<number>: <function_name> + <offset> (<return-address> in
+    // <object-file>)
+    stream << "frame #" << frame_number << ": " << frame.function_name << " + "
+           << frame.offset_into_function << " (" << callstack[frame_number]
+           << " in " << frame.object_file << ")\n";
+  }
+
+  return stream.str();
+}
+#endif // !defined(_WIN32)
+
 /// A tiny implementation of static `all_of`.
 template <bool...>
 struct pack;
@@ -46,7 +196,7 @@ struct SourceLocation {
 
 /// The primary ATen error class.
 /// Provides a complete error message with source location information via
-/// `what()`, and a more concise message via `what_without_location()`. Should
+/// `what()`, and a more concise message via `what_without_backtrace()`. Should
 /// primarily be used with the `AT_ERROR` macro.
 struct AT_API Error : public std::exception {
   template <typename... FormatArgs>
@@ -54,11 +204,10 @@ struct AT_API Error : public std::exception {
       detail::SourceLocation source_location,
       const char* format_string,
       FormatArgs&&... format_args)
-      : what_without_location_(detail::format(
+      : what_without_backtrace_(detail::format(
             format_string,
             std::forward<FormatArgs>(format_args)...)),
-        what_(
-            what_without_location_ + " (" + source_location.toString() + ")") {
+        what_(what_without_backtrace_) {
     // NOTE: A "literal type"
     // (http://en.cppreference.com/w/cpp/concept/LiteralType) could also be a
     // constexpr struct, so it's not 100% guaranteed that the `printf` call
@@ -66,21 +215,26 @@ struct AT_API Error : public std::exception {
     // into, such as passing `std::string`.
     static_assert(
         detail::all_of<std::is_literal_type<FormatArgs>::value...>::value,
-        "arguments to `format` must be literal types!");
+        "format arguments must be literal types!");
+    what_ += " (" + source_location.toString() + ")\n";
+#if !defined(_WIN32)
+    // Skip this constructor's frame.
+    what_ += detail::get_backtrace(/*frames_to_skip=*/1);
+#endif // !defined(_WIN32)
   }
 
-  /// Returns the complete error message including the source location.
+  /// Returns the complete error message, including the source location.
   const char* what() const noexcept override {
     return what_.c_str();
   }
 
   /// Returns only the error message string, without source location.
-  const char* what_without_location() const noexcept {
-    return what_without_location_.c_str();
+  const char* what_without_backtrace() const noexcept {
+    return what_without_backtrace_.c_str();
   }
 
  private:
-  std::string what_without_location_;
+  std::string what_without_backtrace_;
   std::string what_;
 };
 } // namespace at

--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -58,7 +58,7 @@ inline at::optional<FrameInformation> parse_frame_information(
   // `<object-file>(<mangled-function-name>+<offset-into-function>)
   // [<return-address>]`
 
-  auto function_name_start = frame_string.find("$$$$$$$$$");
+  auto function_name_start = frame_string.find("(");
   if (function_name_start == std::string::npos) {
     return at::nullopt;
   }

--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -3,10 +3,10 @@
 #include <ATen/ATenGeneral.h> // for AT_API
 #include <ATen/optional.h>
 
-#include <ciso646>
 #include <cstdint>
 #include <cstdio>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -97,7 +97,7 @@ inline at::optional<FrameInformation> parse_frame_information(
 #else
 #warning Unknown standard library, backtraces may have incomplete debug information
   return at::nullopt;
-#endif
+#endif // defined(__GLIBCXX__)
 
   // Some system-level functions don't have sufficient debug information, so
   // we'll display them as "<unknown function>". They'll still have a return

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -18,7 +18,7 @@
   } catch (python_error &e) {                                                  \
     return retval;                                                             \
   } catch (const at::Error &e) {                                               \
-    auto msg = torch::processErrorMsg(e.what_without_location());              \
+    auto msg = torch::processErrorMsg(e.what_without_backtrace());              \
     PyErr_SetString(PyExc_RuntimeError, msg.c_str());                          \
     return retval;                                                             \
   } catch (torch::PyTorchError &e) {                                           \


### PR DESCRIPTION
This PR builds on top of #6059 to now add backtraces to errors inside ATen. This greatly improves the debugging experience for our C++ users. It works towards #6055.

## Example

Before:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  hello
./run.sh: line 1: 786857 Aborted                 (core dumped) LD_LIBRARY_PATH="torch/lib/:./build/lib.linux-x86_64-3.6/torch/:/home/psag/local/miniconda/lib" ./e
```

After:

```
terminate called after throwing an instance of 'at::Error'
  what():  hello (embedding_backward at ../src/ATen/native/Embedding.cpp:38)
frame #0: at::Type::embedding_backward(at::Tensor const&, at::Tensor const&, long, long, bool, bool) const + 0x27 (0x7f7bc5e15f07 in torch/lib/libATen.so.1)
frame #1: torch::autograd::VariableType::embedding_backward(at::Tensor const&, at::Tensor const&, long, long, bool, bool) const + 0x1fd (0x7f7bc1519fbd in ./build/lib.linux-x86_64-3.6/torch/_C.cpython-36m-x86_64-linux-gnu.so)
frame #2: torch::autograd::generated::EmbeddingBackward::apply(std::vector<torch::autograd::Variable, std::allocator<torch::autograd::Variable> > const&) + 0xf0 (0x7f7bc15ec490 in ./build/lib.linux-x86_64-3.6/torch/_C.cpython-36m-x86_64-linux-gnu.so)
frame #3: torch::autograd::Engine::evaluate_function(torch::autograd::FunctionTask&) + 0x3db (0x7f7bc14aa69b in ./build/lib.linux-x86_64-3.6/torch/_C.cpython-36m-x86_64-linux-gnu.so)
frame #4: torch::autograd::Engine::thread_main(torch::autograd::GraphTask*) + 0xe5 (0x7f7bc14ab665 in ./build/lib.linux-x86_64-3.6/torch/_C.cpython-36m-x86_64-linux-gnu.so)
frame #5: torch::autograd::Engine::thread_init(int) + 0x5e (0x7f7bc14a7dce in ./build/lib.linux-x86_64-3.6/torch/_C.cpython-36m-x86_64-linux-gnu.so)

./run.sh: line 1: 685721 Aborted                 (core dumped) LD_LIBRARY_PATH="torch/lib/:./build/lib.linux-x86_64-3.6/torch/:/home/psag/local/miniconda/lib" ./e
```

## Implementation

The implementation of this feature relies entirely on glibc/libstdc++/libcxx features and requires no extra dependencies. It uses the `backtrace()` family of glibc function to get call stack information and then uses `__cxa_demangle` from libstc++/libcxx to demangle symbol names. It works well across dynamic library boundaries and works on both Linux and macOS. Windows has a pretty good API to implement this, but is not a priority now. I've put some pointers on how to implement it on Windows if we get a request.

@apaszke @cpuhrsch @colesbury 

CC @ebetica 

Fixes #6055 