### PR TITLE
Fix fft when any of the input dimensions is not aligned

### DIFF
--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <sstream>
 #include <typeinfo>
+#include <numeric>
 
 namespace at {
 
@@ -65,6 +66,14 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
   }
   std::copy_n(list.begin(), N, res.begin());
   return res;
+}
+
+inline int64_t sum_intlist(ArrayRef<int64_t> list) {
+  return std::accumulate(list.begin(), list.end(), 0);
+}
+
+inline int64_t prod_intlist(ArrayRef<int64_t> list) {
+  return std::accumulate(list.begin(), list.end(), 1, std::multiplies<int64_t>());
 }
 
 } // at

--- a/aten/src/ATen/native/SpectralOpsUtils.h
+++ b/aten/src/ATen/native/SpectralOpsUtils.h
@@ -6,10 +6,30 @@
 
 namespace at { namespace native {
 
-// Since real-to-complex satisfy the conjugate symmetry, i.e.,
-// X[m, \omega] = X[m, N - \omega]*. We return only the first floor(N / 2) + 1
-// values by default (onesided=True). This is also the assumption in libraries
-// including cuFFT and MKL.
+// [ NOTE ] Fourier Transform Congjugate Symmetry
+//
+// Real-to-complex Fourier transform satisfies the conjugate symmetry. That is,
+// assuming X is the transformed K-dimensionsal signal, we have
+//
+//     X[i_1, ..., i_K] = X[j_i, ..., j_K]*,
+//
+//       where j_k  = (N_k - i_k)  mod N_k, N_k being the signal size at dim k,
+//             * is the conjugate operator.
+//
+// Therefore, in such cases, FFT libraries return only roughly half of the
+// values to avoid redundancy:
+//
+//     X[:, :, ..., :floor(N / 2) + 1]
+//
+// This is also the assumption in cuFFT and MKL. In ATen SpectralOps, such
+// halved signal will also be returned by default (flag onesided=True).
+// The following infer_ft_real_to_complex_onesided_size function calculates the
+// onesided size from the twosided size.
+//
+// Note that this loses some information about the size of signal at last
+// dimension. E.g., both 11 and 10 maps to 6. Hence, the following
+// infer_ft_complex_to_real_onesided_size function takes in optional parameter
+// to infer the twosided size from given onesided size.
 //
 // cuFFT doc: http://docs.nvidia.com/cuda/cufft/index.html#multi-dimensional
 // MKL doc: https://software.intel.com/en-us/mkl-developer-reference-c-dfti-complex-storage-dfti-real-storage-dfti-conjugate-even-storage#CONJUGATE_EVEN_STORAGE
@@ -18,7 +38,8 @@ inline int64_t infer_ft_real_to_complex_onesided_size(int64_t real_size) {
   return (real_size / 2) + 1;
 }
 
-inline int64_t infer_ft_complex_to_real_onesided_size(int64_t complex_size, int64_t expected_size=-1) {
+inline int64_t infer_ft_complex_to_real_onesided_size(int64_t complex_size,
+                                                      int64_t expected_size=-1) {
   int64_t base = (complex_size - 1) * 2;
   if (expected_size < 0) {
     return base + 1;

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -180,7 +180,7 @@ static at::optional<std::vector<T>> is_embedded_strides(IntList strides) {
   std::vector<T> embed(n);
   auto last_stride = strides[n - 1];
   if (last_stride <= 0) {
-    return {};
+    return at::nullopt;
   }
   for (auto i = n - 1; i > 0 /* embed[0] doesn't matteer */; i--) {
     auto stride = strides[i - 1];
@@ -188,7 +188,7 @@ static at::optional<std::vector<T>> is_embedded_strides(IntList strides) {
       embed[i] = stride / last_stride;
       last_stride = stride;
     } else {
-      return {};
+      return at::nullopt;
     }
   }
   return embed;
@@ -271,7 +271,7 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
     }
   }
 
-  at::optional<std::vector<long long int>> inembed_opt;
+  at::optional<std::vector<long long int>> inembed_opt = at::nullopt;
   if (!need_contiguous) {
     inembed_opt = is_embedded_strides<long long int>(input.strides().slice(1, signal_ndim));
     if (!inembed_opt) {

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -22,6 +22,7 @@ Tensor _fft_mkl(const Tensor& input, int64_t signal_ndim,
 #include "ATen/ATen.h"
 #include "ATen/Config.h"
 #include "ATen/Dispatch.h"
+#include "ATen/Utils.h"
 #include "ATen/NativeFunctions.h"
 
 #include <algorithm>
@@ -267,7 +268,7 @@ Tensor _fft_mkl(const Tensor& self, int64_t signal_ndim,
   }
   // rescale if needed by normalized flag or inverse transform
   if (normalized || inverse) {
-    auto signal_numel = std::accumulate(checked_signal_sizes.begin(), checked_signal_sizes.end(), 1, std::multiplies<int64_t>());
+    auto signal_numel = at::prod_intlist(checked_signal_sizes);
     double double_scale;
     if (normalized) {
       double_scale = 1.0 / std::sqrt(static_cast<double>(signal_numel));

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -44,6 +44,7 @@ namespace at { namespace native {
 // conjugate symmetry. See native/SpectralUtils.h for more details.
 // The following structs are used to fill in the other half with symmetry in
 // case of real-to-complex transform with onesided=False flag.
+// See [ NOTE ] Fourier Transform Congjugate Symmetry in native/SpectralOpsUtils.h.
 
 template <typename scalar_t>
 static inline void _fft_fill_with_conjugate_symmetry_slice(Tensor& output,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3331,6 +3331,9 @@ class TestTorch(TestCase):
                 res = x.fft(signal_ndim, normalized=normalized)
                 rec = res.ifft(signal_ndim, normalized=normalized)
                 self.assertEqual(x, rec, 1e-8, 'fft and ifft')
+                res = x.ifft(signal_ndim, normalized=normalized)
+                rec = res.fft(signal_ndim, normalized=normalized)
+                self.assertEqual(x, rec, 1e-8, 'ifft and fft')
 
         def _test_real(sizes, signal_ndim, prepro_fn=lambda x: x):
             x = prepro_fn(build_fn(*sizes))
@@ -3395,11 +3398,19 @@ class TestTorch(TestCase):
         _test_real((30, 20, 50, 25), 3, lambda x: x.transpose(1, 2).transpose(2, 3))
 
         _test_complex((2, 100), 1, lambda x: x.t())
-        _test_complex((100, 3, 100, 2), 1, lambda x: x[:, 1].transpose(0, 1))
-        _test_complex((300, 200, 2), 2, lambda x: x[:100, :100])
+        _test_complex((100, 2), 1, lambda x: x.expand(100, 100, 2))
+        _test_complex((300, 200, 3), 2, lambda x: x[:100, :100, 1:])  # input is not aligned to complex type
         _test_complex((20, 90, 110, 2), 2, lambda x: x[:, 5:85].narrow(2, 5, 100))
         _test_complex((40, 60, 3, 80, 2), 3, lambda x: x.transpose(2, 0).select(0, 2)[5:55, :, 10:])
         _test_complex((30, 55, 50, 22, 2), 3, lambda x: x[:, 3:53, 15:40, 1:21])
+
+        # non-contiguous with strides not representable as aligned with complex type
+        _test_complex((50,), 1, lambda x: x.as_strided([5, 5, 2], [3, 2, 1]))
+        _test_complex((50,), 1, lambda x: x.as_strided([5, 5, 2], [4, 2, 2]))
+        _test_complex((50,), 1, lambda x: x.as_strided([5, 5, 2], [4, 3, 1]))
+        _test_complex((50,), 2, lambda x: x.as_strided([5, 5, 2], [3, 3, 1]))
+        _test_complex((50,), 2, lambda x: x.as_strided([5, 5, 2], [4, 2, 2]))
+        _test_complex((50,), 2, lambda x: x.as_strided([5, 5, 2], [4, 3, 1]))
 
     @unittest.skipIf(not TEST_MKL, "PyTorch is built without MKL support")
     def test_fft_ifft_rfft_irfft(self):
@@ -3411,20 +3422,15 @@ class TestTorch(TestCase):
     def _test_stft(self, build_fn):
         # the conv_fn to convert tensors can be slow in cuda tests, so we use
         # a build_fn: sizes => tensor
-        Variable = torch.autograd.Variable
 
         def naive_stft(x, frame_length, hop, fft_size=None, normalized=False,
                        onesided=True, window=None, pad_end=0):
             if fft_size is None:
                 fft_size = frame_length
-            if isinstance(x, Variable):
-                x = x.data
             x = x.clone()
             if window is None:
                 window = x.new(frame_length).fill_(1)
             else:
-                if isinstance(window, Variable):
-                    window = window.data
                 window = window.clone()
             input_1d = x.dim() == 1
             if input_1d:
@@ -3472,9 +3478,9 @@ class TestTorch(TestCase):
 
         def _test(sizes, frame_length, hop, fft_size=None, normalized=False,
                   onesided=True, window_sizes=None, pad_end=0, expected_error=None):
-            x = Variable(build_fn(*sizes))
+            x = build_fn(*sizes)
             if window_sizes is not None:
-                window = Variable(build_fn(*window_sizes))
+                window = build_fn(*window_sizes)
             else:
                 window = None
             if expected_error is None:


### PR DESCRIPTION
Discovered this bug while looking into the test fail @colesbury saw. In C2C or C2R transform, when any of the input dimension is not aligned to complex type (`stride % 2 != 0`), the third party library calls give incorrect results. Added those checks and tests for this.

Added test for `ifft+fft == identity`. Empirically this only increased test time by 0.1s.

@ezyang 
