### PR TITLE
Add REL_WITH_DEB_INFO build mode

### DIFF
--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -31,10 +31,12 @@ IF "%~1"=="--with-nnpack" (
   set /a NO_NNPACK=1
 )
 
+set BUILD_TYPE=Release
 IF "%DEBUG%"=="1" (
   set BUILD_TYPE=Debug
-) ELSE (
-  set BUILD_TYPE=Release 
+)
+IF "%REL_WITH_DEB_INFO=1%" (
+  set BUILD_TYPE=RelWithDebInfo
 )
 
 IF NOT DEFINED MAX_JOBS (
@@ -154,4 +156,3 @@ goto:eof
   @endlocal
 
 goto:eof
-

--- a/tools/build_pytorch_libs.bat
+++ b/tools/build_pytorch_libs.bat
@@ -35,7 +35,7 @@ set BUILD_TYPE=Release
 IF "%DEBUG%"=="1" (
   set BUILD_TYPE=Debug
 )
-IF "%REL_WITH_DEB_INFO=1%" (
+IF "%REL_WITH_DEB_INFO%"=="1" (
   set BUILD_TYPE=RelWithDebInfo
 )
 

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -106,6 +106,15 @@ if [ -z "$NUM_JOBS" ]; then
   NUM_JOBS="$(getconf _NPROCESSORS_ONLN)"
 fi
 
+BUILD_TYPE="Release"
+if [[ "$DEBUG" ]]; then
+  BUILD_TYPE="Debug"
+elif [[ "$REL_WITH_DEB_INFO" ]]; then
+  BUILD_TYPE="RelWithDebInfo"
+fi
+
+echo "Building in $BUILD_TYPE mode"
+
 # Used to build an individual library
 function build() {
   # We create a build directory for the library, which will
@@ -149,7 +158,7 @@ function build() {
               -DNCCL_EXTERNAL=1 \
               -Dnanopb_BUILD_GENERATOR=0 \
               -DCMAKE_DEBUG_POSTFIX="" \
-              -DCMAKE_BUILD_TYPE=$([ $DEBUG ] && echo Debug || echo Release) \
+              -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
               ${@:2} \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=1
   ${CMAKE_INSTALL} -j"$NUM_JOBS"
@@ -202,7 +211,7 @@ function build_aten() {
   pushd build
   ${CMAKE_VERSION} .. \
   ${CMAKE_GENERATOR} \
-      -DCMAKE_BUILD_TYPE=$([ $DEBUG ] && echo Debug || echo Release) \
+      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DNO_CUDA=$((1-$WITH_CUDA)) \
       -DNO_NNPACK=$((1-$WITH_NNPACK)) \
       -DCUDNN_INCLUDE_DIR=$CUDNN_INCLUDE_DIR \


### PR DESCRIPTION
Small PR to allow use of `RelWithDebInfo` mode in CMake as per request from @ebetica, to make debugging in optimized binaries easier (i.e. don't have to suffer major decrease in performance when using `DEBUG` mode, but can still debug properly, not like in `RELEASE` mode).

From what I can see using `RelWithDebInfo` means `-O2 -g -DNDEBUG` while `Release` means `-O3`.

normal (release):
```
$ python setup.py build develop
$ grep -e' -fexceptions ' aten/build/build.ninja
FLAGS = -DUSE_AVX2 -msse3 -DUSE_SSE3 --std=c++11 -Wall -Wno-unknown-pragmas -Wno-vla -fexceptions  -fopenmp -O3
```

This PR allows use of the `REL_WITH_DEB_INFO` environment variable:

```
$ REL_WITH_DEB_INFO=1 python setup.py build develop
$ grep -e' -fexceptions ' aten/build/build.ninja
FLAGS = -DUSE_AVX2   -DUSE_SSE3 --std=c++11 -Wall -Wno-unknown-pragmas -Wno-vla -fexceptions  -O2 -g -DNDEBUG
```

@ezyang @ebetica 