### PR TITLE
Make precision matrix computation in mvn stable

### DIFF
--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -216,7 +216,8 @@ class _PositiveDefinite(Constraint):
         # TODO: replace with batched linear algebra routine when one becomes available
         # note that `symeig()` returns eigenvalues in ascending order
         flattened_value = value.contiguous().view((-1,) + matrix_shape)
-        return torch.stack([v.symeig()[0][:1] > 0.0 for v in flattened_value]).view(batch_shape)
+        return torch.stack([v.symeig(eigenvectors=False)[0][:1] > 0.0
+                            for v in flattened_value]).view(batch_shape)
 
 
 class _RealVector(Constraint):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -161,7 +161,8 @@ class MultivariateNormal(Distribution):
         # TODO: use `torch.potri` on `scale_tril` once a backwards pass is implemented.
         scale_tril_inv = _batch_inverse(self.scale_tril)
         flat_scale_tril_inv = self.scale_tril.reshape((-1,) + self._event_shape * 2)
-        flat_precision = torch.stack([C.t().matmul(C) for C in flat_scale_tril_inv], 0)
+        flat_precision = torch.bmm(flat_scale_tril_inv.transpose(-1, -2),
+                                   flat_scale_tril_inv)
         return flat_precision.view(self.scale_tril.shape)
 
     @property

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -159,8 +159,9 @@ class MultivariateNormal(Distribution):
     @lazy_property
     def precision_matrix(self):
         # TODO: use `torch.potri` on `scale_tril` once a backwards pass is implemented.
-        flat_conv = self.covariance_matrix.reshape((-1,) + self._event_shape * 2)
-        flat_precision = torch.stack([C.inverse() for C in flat_conv], 0)
+        scale_tril_inv = _batch_inverse(self.scale_tril)
+        flat_scale_tril_inv = self.scale_tril.reshape((-1,) + self._event_shape * 2)
+        flat_precision = torch.stack([C.t().matmul(C) for C in flat_scale_tril_inv], 0)
         return flat_precision.view(self.scale_tril.shape)
 
     @property


### PR DESCRIPTION
As explained in [here](https://github.com/uber/pyro/issues/953#issuecomment-377493414), the current computation for precision matrix which uses the inverse of covariance matrix might lead to some instability problem. I think that it is better to compute prec matrix based on scale_tril.