### PR TITLE
Fix typo in NLLLoss docs

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -119,9 +119,9 @@ class NLLLoss(_WeightedLoss):
 
     .. math::
         \ell(x, y) = \begin{cases}
-            \sum_{n=1}^N \frac{w_{y_n}}{\sum_{n=1}^N w_{y_n}} l_n, & \text{if}\;
+            \sum_{n=1}^N \frac{1}{\sum_{n=1}^N w_{y_n}} l_n, & \text{if}\;
             \text{size_average} = \text{True},\\
-            \sum_{n=1}^N w_{y_n} l_n,  & \text{if}\;
+            \sum_{n=1}^N l_n,  & \text{if}\;
             \text{size_average} = \text{False}.
         \end{cases}
 


### PR DESCRIPTION
Reported here: https://discuss.pytorch.org/t/seemingly-a-mistake-in-the-documentation-of-the-loss-function-nllloss/15720

`l_n = w_{y_n} * x_{n, y_n}` so we don't need to multiply by `w_{y_n}` again.