### PR TITLE
Fix setup_caffe2.py lint error.

### DIFF
--- a/setup_caffe2.py
+++ b/setup_caffe2.py
@@ -226,13 +226,15 @@ ext_modules = [
 
 packages = setuptools.find_packages()
 
-install_requires.extend(['protobuf',
-                         'numpy',
-                         'future',
-                         'hypothesis',
-                         'requests',
-                         'scipy',
-                         'six',])
+install_requires.extend([
+    'protobuf',
+    'numpy',
+    'future',
+    'hypothesis',
+    'requests',
+    'scipy',
+    'six',
+])
 
 ################################################################################
 # Test


### PR DESCRIPTION
./setup_caffe2.py:235:31: E231 missing whitespace after ','