### PR TITLE
implement sum over multiple dimensions (fixes #2006)

### DIFF
--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -17,7 +17,7 @@ static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntList dims, int6
   std::bitset<dim_bitset_size> seen;
   for (size_t i = 0; i < dims.size(); i++) {
     size_t dim = maybe_wrap_dim(dims[i], ndims);
-    AT_CHECK(!seen[dim], "dim ", dim, " appears multiple times in the list of reduced dims");
+    AT_CHECK(!seen[dim], "dim ", dim, " appears multiple times in the list of dims");
     seen[dim] = true;
   }
   return seen;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -717,28 +717,25 @@
     CPU: _sum_cpu
     CUDA: _sum_cuda
 
-- func: sum(Tensor self, int64_t dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: sum(Tensor self, IntList[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
 
-- func: sum(Tensor self, int64_t dim, bool keepdim=False) -> Tensor
+- func: sum(Tensor self, IntList[1] dim, bool keepdim=False) -> Tensor
 
-- func: sum(Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
+- func: sum(Tensor self, IntList[1] dim, *, ScalarType dtype) -> Tensor
 
-- func: _sum(Tensor self, int64_t dim, bool keepdim=False) -> Tensor
+- func: _sum(Tensor self, IntList[1] dim, bool keepdim=False) -> Tensor
 
-- func: sum_out(Tensor result, Tensor self, int64_t dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: sum_out(Tensor result, Tensor self, IntList[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
   variants: function
 
-- func: sum_out(Tensor result, Tensor self, int64_t dim, bool keepdim=False) -> Tensor
+- func: sum_out(Tensor result, Tensor self, IntList[1] dim, bool keepdim=False) -> Tensor
   variants: function
 
-- func: sum_out(Tensor result, Tensor self, int64_t dim, *, ScalarType dtype) -> Tensor
+- func: sum_out(Tensor result, Tensor self, IntList[1] dim, *, ScalarType dtype) -> Tensor
   variants: function
 
-- func: _sum_out(Tensor result, Tensor self, int64_t dim, bool keepdim=False) -> Tensor
+- func: _sum_out(Tensor result, Tensor self, IntList[1] dim, bool keepdim=False) -> Tensor
   variants: function
-  dispatch:
-    CPU: _sum_out_cpu
-    CUDA: _sum_out_cuda
 
 - func: sqrt(Tensor self) -> Tensor
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2621,6 +2621,8 @@ method_tests = [
     ('sum', (), NO_ARGS, 'scalar'),
     ('sum', (), (0,), 'scalar_dim', [0]),
     ('sum', (), (0, True,), 'scalar_keepdim_dim', [0]),
+    ('sum', (S, S, S), ([1, 2],), 'multi_dim'),
+    ('sum', (S, S, S), ([1, 2], True,), 'multi_dim_keepdim'),
     ('prod', (S, S, S), NO_ARGS),
     ('prod', (S, S, S), (1,), 'dim', [0]),
     ('prod', (S, S, S), (1, True,), 'keepdim_dim', [0]),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1503,6 +1503,8 @@ class TestTorch(TestCase):
         check_sum_dim(make_tensors(50, 50, 50), 0)
         check_sum_dim(make_tensors(50, 50, 50), 1)
         check_sum_dim(make_tensors(50, 50, 50), 2)
+        check_sum_dim(make_tensors(50, 50, 50), (1, 2))
+        check_sum_dim(make_tensors(50, 50, 50), (1, -1))
 
         def make_contiguous_slice(size, dtype):
             contig = make_contiguous((1, size), dtype)
@@ -1521,6 +1523,11 @@ class TestTorch(TestCase):
         res1 = torch.sum(x, 1)
         res2 = torch.Tensor()
         torch.sum(x, 1, out=res2)
+        self.assertEqual(res1, res2)
+        x = torch.rand(100, 100, 100)
+        res1 = x.sum(2).sum(1)
+        res2 = torch.Tensor()
+        torch.sum(x, (2, 1), out=res2)
         self.assertEqual(res1, res2)
 
     # TODO: these tests only check if it's possible to pass a return value

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -610,7 +610,7 @@
 - name: _sum(Tensor self)
   self: grad.expand(self.sizes())
 
-- name: _sum(Tensor self, int64_t dim, bool keepdim)
+- name: _sum(Tensor self, IntList dim, bool keepdim)
   self: sum_backward(grad, self.sizes(), dim, keepdim)
 
 - name: svd(Tensor self, bool some)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4094,7 +4094,8 @@ Example::
 .. function:: sum(input, dim, keepdim=False, out=None) -> Tensor
 
 Returns the sum of each row of the :attr:`input` tensor in the given
-dimension :attr:`dim`.
+dimension :attr:`dim`. If :attr::`dim` is a list of dimensions,
+reduce over all of them.
 
 If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
@@ -4103,7 +4104,7 @@ the output tensor having 1 fewer dimension than :attr:`input`.
 
 Args:
     input (Tensor): the input tensor
-    dim (int): the dimension to reduce
+    dim (int or tuple of ints): the dimension or dimensions to reduce
     keepdim (bool): whether the output tensor has :attr:`dim` retained or not
     out (Tensor, optional): the output tensor
 
@@ -4117,6 +4118,9 @@ Example::
             [ 0.3637, -0.9906, -0.4752, -1.5197]])
     >>> torch.sum(a, 1)
     tensor([-0.4598, -0.1381,  1.3708, -2.6217])
+    >>> b = torch.arange(4 * 5 * 6).view(4, 5, 6)
+    >>> torch.sum(b, (2, 1))
+    tensor([  435.,  1335.,  2235.,  3135.])
 """)
 
 add_docstr(torch.svd,


### PR DESCRIPTION
Hello,

this implements summing over multiple dimensions as a ATen native function.
- As IntList and int64_t is considered the same for the jit signatures, I handle the single-dimension case in the multi-dimension one by fast-tracking it.
- in this context, for sum_out, I manually dispatch in ReductionOps.cpp instead of using native_function's mechanism.
- the multiple-index version iterates over the one-dimensional op.
I'll add a test and adapt the docs, but I'd appreciate feedback on the approach.

This patch addresses #2006 and would supersede #2116 .
Of course, there is a ton of other ops (prod, mean, squeeze, unsqueeze) that could be handled similarly.

Best regards

Thomas