### PR TITLE
Fix SparseMM compiler warning

### DIFF
--- a/aten/src/ATen/native/cuda/SparseMM.cu
+++ b/aten/src/ATen/native/cuda/SparseMM.cu
@@ -6,6 +6,5 @@ namespace at { namespace native {
 Tensor& _sspaddmm_out_cuda(Tensor& result, const Tensor& self,
     const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   AT_ERROR("NYI: CUDA sspaddmm is not implemented");
-  return result;
 }
 }} // namespace at::native


### PR DESCRIPTION
```
[6/179] Building NVCC (Device) object
src/ATen/CMakeFiles/ATen.dir/native/cuda/ATen_generated_SparseMM.cu.o
/home/rzou/pytorch/aten/src/ATen/native/cuda/SparseMM.cu(9): warning:
statement is unreachable

/home/rzou/pytorch/aten/src/ATen/native/cuda/SparseMM.cu(9): warning:
statement is unreachable
```
Warning was caused by unnecessary return statement.

