### PR TITLE
add documentation for diagflat and diagonal

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -178,6 +178,8 @@ Other Operations
 ~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: cross
 .. autofunction:: diag
+.. autofunction:: diagflat
+.. autofunction:: diagonal
 .. autofunction:: histc
 .. autofunction:: renorm
 .. autofunction:: trace

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1223,7 +1223,7 @@ Args:
     offset (int, optional): the diagonal to consider. Default: 0 (main
         diagonal).
 
-Examples:
+Examples::
 
     >>> a = torch.randn(3)
     >>> a
@@ -1282,7 +1282,8 @@ Args:
     offset (int, optional): which diagonal to consider. Default: 0
         (main diagonal).
 
-Examples:
+Examples::
+
     >>> a = torch.randn(3, 3)
     >>> a
 


### PR DESCRIPTION
This small patch enables documentation for torch.diagflat and torch.diagonal.
The docstrings had already been there but needed a tiny adaptation to be processes by sphinx.

Best regards

Thomas