### PR TITLE
Refine dirty matching for docs.

### DIFF
--- a/.jenkins/caffe2/dirty.sh
+++ b/.jenkins/caffe2/dirty.sh
@@ -2,4 +2,4 @@
 set -ex
 upstream="$1"
 pr="$2"
-git diff --name-only "$upstream" "$pr" | grep -Eq '^(CMakeLists.txt|Makefile|.gitmodules|.jenkins/caffe2|binaries|caffe|caffe2|cmake|conda|docker|docs|modules|scripts|third_party)'
+git diff --name-only "$upstream" "$pr" | grep -Eq '^(CMakeLists.txt|Makefile|.gitmodules|.jenkins/caffe2|binaries|caffe|caffe2|cmake|conda|docker|docs/caffe2|modules|scripts|third_party)'

--- a/.jenkins/pytorch/dirty.sh
+++ b/.jenkins/pytorch/dirty.sh
@@ -2,4 +2,4 @@
 set -ex
 upstream="$1"
 pr="$2"
-git diff --name-only "$upstream" "$pr" | grep -Eq '^(aten/|.jenkins/pytorch|docs/|mypy|requirements.txt|setup.py|test/|third_party/|tools/|\.gitmodules|torch/)'
+git diff --name-only "$upstream" "$pr" | grep -Eq '^(aten/|.jenkins/pytorch|docs/(make.bat|Makefile|requirements.txt|source)|mypy|requirements.txt|setup.py|test/|third_party/|tools/|\.gitmodules|torch/)'


### PR DESCRIPTION
It's a little awkward because I have to list a bunch of files for PyTorch. Maybe PyTorch docs should get their own folder.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>

