### PR TITLE
Reduce flakiness of math tests in test_torch.py

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -28,12 +28,25 @@ void where_cpu(
 
 namespace at { namespace native {
 
-bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol) {
-  if (!self.sub(other).abs().le(other.abs().mul(rtol).add(atol)).all().toCByte()) {
-    return false;
-  }
+bool allclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {
+  return at::isclose(self, other, rtol, atol, equal_nan).all().toCByte();
+}
 
-  return true;
+Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol, bool equal_nan) {
+  // TODO: use bitwise operator overloads once we add them
+  auto actual_error = (self - other).abs();
+  auto max_error = atol + rtol * other.abs();
+  auto close = actual_error <= max_error;
+
+  // Handle +/-inf
+  close.__ior__(self == other);
+  close.__iand__((self == INFINITY) == (other == INFINITY));
+  close.__iand__((self == -INFINITY) == (other == -INFINITY));
+
+  if (equal_nan) {
+    close.__ior__((self != self).__and__((other != other)));
+  }
+  return close;
 }
 
 bool is_nonzero(const Tensor& self) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -57,7 +57,7 @@
 - func: adaptive_max_pool1d(Tensor self, IntList[1] output_size) -> (Tensor, Tensor)
   variants: function
 
-- func: allclose(Tensor self, Tensor other, double rtol=1e-5, double atol=1e-8) -> bool
+- func: allclose(Tensor self, Tensor other, double rtol=1e-5, double atol=1e-8, bool equal_nan=False) -> bool
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -378,6 +378,8 @@
   variants: method
 
 - func: index_put_(Tensor self, TensorList indices, Tensor values) -> Tensor
+
+- func: isclose(Tensor self, Tensor other, double rtol=1e-5, double atol=1e-8, bool equal_nan=False) -> Tensor
 
 - func: is_cuda(Tensor self) -> bool
 

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -46,7 +46,7 @@ def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True):
 
     index = _unravel_index(index.item(), actual.shape)
 
-    # Count nubmer of offenders
+    # Count number of offenders
     count = (~close).long().sum()
 
     msg = ('Not within tolerance rtol={} atol={} at input{} ({} vs. {}) and {}'


### PR DESCRIPTION
```
    Reduce flakiness of math tests in test_torch.py

    This compares the torch function against the reference math funciton
    against a relative small set of inputs, including integers, extremes
    of some common functions, zero, a few numbers from randn and a few
    numbers near 1e6.

    The idea here is not to be completely exhaustive, but rather quickly
    expose the most common bugs. For exhaustive checks, we should evaluate
    torch functions against all ~4e9 possible float32 value.

    We compare the torch function evaluated against contiguous
    and non-contiguous inputs and large vs. small tensors.

    Also:

      - Make torch.allclose work with nan and +/-inf
      - Add torch.isclose (like numpy.isclose)
      - Add torch.testing.assert_allclose (like
        numpy.testing.assert_allclose)
```