### PR TITLE
Clarity update for function doc string

### DIFF
--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -120,7 +120,7 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
     subclasses and defining new operations. This is a recommended way of
     extending torch.autograd.
 
-    Each function is meant to be used only once (in the forward pass).
+    Each function object is meant to be used only once (in the forward pass).
 
     Attributes:
         requires_grad: Boolean indicating whether the :func:`backward` will


### PR DESCRIPTION
In the function class, the doc string previously said that each function should be used only once in the forward pass. This was ambiguous as to whether it referred to the function itself or each instantiation of the function. To make this less ambiguous the word object was added