### PR TITLE
Fix argument checking for inlining a module

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2023,6 +2023,26 @@ class TestScript(TestCase):
         with self.assertRaisesRegex(RuntimeError, "cannot re-assign"):
             m.sub = nn.Linear(5, 5)
 
+    def test_script_inline_trace_multiple_args(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M, self).__init__(False)
+
+            def forward(self, input, input2):
+                return input + input2
+
+        class M2(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M2, self).__init__(False)
+                self.m = torch.jit.trace(torch.zeros(4, 3), torch.zeros(4, 3))(M())
+
+            @torch.jit.script_method
+            def forward(self, inp):
+                return self.m(inp, inp)
+
+        m2 = M2()
+        m2(torch.zeros(4, 3))
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -113,7 +113,7 @@ struct MethodValue : public SugaredValue {
     if(attributes.size() != 0) {
       throw ErrorReport(loc) << "not yet implemented - calls to python functions using keyword arguments";
     }
-    ensureSizeMatches(loc, caller.num_inputs(), inputs.size(), "inputs");
+    ensureSizeMatches(loc, method.num_inputs(), inputs.size(), "inputs");
     auto outputs = caller.emit_call_to(method, inputs);
     ensureSizeMatches(loc, outputs.size(), n_outputs, "outputs");
     return outputs;


### PR DESCRIPTION
`MethodValue::call` was incorrectly checking the # of inputs to pass to the inlined method against the number of inputs expected for the caller method, not for the callee method. This fixes that and adds a test