### PR TITLE
[caffe2] Change `print` to `logger.warning` in operator traceback code

### DIFF
--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -179,13 +179,14 @@ def CallWithExceptionIntercept(func, op_id_fetcher, net_name, *args, **kwargs):
     except Exception:
         op_id = op_id_fetcher()
         net_tracebacks = operator_tracebacks.get(net_name, None)
-        print('Original python traceback for operator {} in network `{}` in '
-              'exception above (most recent call last):'.format(
-                  op_id, net_name))
+        logger.warning(
+            'Original python traceback for operator `{}` in network '
+            '`{}` in exception above (most recent call last):'.format(
+                op_id, net_name))
         if net_tracebacks and op_id in net_tracebacks:
             tb = net_tracebacks[op_id]
             for line in reversed(tb):
-                print('  File "{}", line {}, in {}'.format(
+                logger.warning('  File "{}", line {}, in {}'.format(
                     line[0], line[1], line[2]))
         raise
 


### PR DESCRIPTION
D7464450

Makes a lot more sense to have this as a warning. Furthermore, this means that output goes to stderr instead, which is the default for glog. 