### PR TITLE
Fix sharing of empty tensor in multiprocessing

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -371,6 +371,22 @@ class TestMultiprocessing(TestCase):
             self.assertEqual(list(tensor), [4, 4, 4, 4])
         p.join()
 
+    def _test_empty_tensor_sharing(self, dtype):
+        q = mp.Queue()
+        empty = torch.tensor([], dtype=dtype)
+        q.put(empty)
+        out = q.get(timeout=1)
+        self.assertEqual(out, empty)
+
+    def test_empty_tensor_sharing(self):
+        self._test_empty_tensor_sharing(torch.float32)
+        self._test_empty_tensor_sharing(torch.int64)
+
+    @unittest.skipIf(not torch.cuda.is_available(), 'CUDA not available')
+    def test_empty_tensor_sharing_cuda(self):
+        self._test_empty_tensor_sharing(torch.cuda.float32)
+        self._test_empty_tensor_sharing(torch.cuda.int64)
+
     def _test_autograd_sharing(self, var):
         ready = mp.Event()
         master_modified = mp.Event()

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -98,6 +98,10 @@ def rebuild_storage_cuda(cls, device, handle, size, offset, view_size):
     return storage
 
 
+def rebuild_storage_empty(cls):
+    return cls()
+
+
 def reduce_storage(storage):
     from . import get_sharing_strategy
     if storage.is_cuda:
@@ -109,6 +113,10 @@ def reduce_storage(storage):
         cache_key = metadata[1]
         rebuild = rebuild_storage_filename
         storage._shared_incref()
+    elif storage.size() == 0:
+        # This is special cased because Empty tensors
+        # (with size 0) cannot be mmapped.
+        return (rebuild_storage_empty, (type(storage),))
     else:
         fd, size = storage._share_fd_()
         if sys.version_info[0] == 2:


### PR DESCRIPTION
Fixes #5719

Previously, the following would error out with an "Invalid file
descriptor" error:
```
import torch
import torch.multiprocessing as mp

q = mp.Queue()
t = torch.tensor([])
q.put(t)
```
on some OSes. The problem was that because one cannot mmap data of size
0, and that an empty tensor has a storage of size 0, the file descriptor
for the storage (referencing shared memory) was not being set. The
multiprocessing sharing code then calls DupFD on that uninitialized file
descriptor, leading to an error.

This PR special cases sharing an empty tensor on the CPU. CUDA does not
have this problem.

cc @colesbury 

### Test Plan
Unit tests for both cpu and cuda empty tensors

