### PR TITLE
Fix memory leak in maxpool3d backwards

### DIFF
--- a/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricDilatedMaxPooling.cu
@@ -308,7 +308,6 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   // TODO: gradOutput shape check
   // Resize and initialize result tensor.
   THCTensor_(resizeAs)(state, gradInput, input);
-  THCTensor_(newContiguous)(state, gradInput);
   THCTensor_(zero)(state, gradInput);
 
   int batchSize;


### PR DESCRIPTION
Fixes #6222

We don't need to make sure gradInput is contiguous because it's always
passed in as an empty tensor (see CUDAFloatType.cpp after it gets
codegen-ed). This was increasing the reference on gradInput and leaking
it.

I'm not sure if there's a good way to test this. I put together a script
that
1) Prints out when a tensor is allocated and deallocated
2) Checks allocations vs deallocations after running a python script
And verified that each allocation matches each deallocation.

cc @li-roy maybe?

