### PR TITLE
Detect re-initialization of _C shared library

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -530,6 +530,24 @@ static PyObject* initModule() {
   END_HANDLE_TH_ERRORS
 }
 
+// Checks that the _C shared library isn't initialized multiple times. This
+// can happen if the same csrc files are compiled into multiple shared
+// libraries.
+inline void pytorch_duplicate_guard() {
+  static int initialized = 0;
+  if (initialized) {
+    fprintf(stderr, "pytorch: _C shared library re-initialized\n");
+    abort();
+  }
+  initialized = 1;
+;}
+
+struct call_duplicate_guard {
+  call_duplicate_guard() { pytorch_duplicate_guard(); }
+};
+
+static call_duplicate_guard _call_duplicate_guard;
+
 #if PY_MAJOR_VERSION == 2
 PyMODINIT_FUNC init_C()
 #else


### PR DESCRIPTION
```
We had a bug in the Buck build of PyTorch due to symbols from _C
being present in two shared libraries that were both loaded at
runtime. This caused global variables to be initialized twice and
destructed twice on exit. The second destruction often caused
segfaults on exit.

This attempts to detect that sort of situation early on. If
Module.cpp is compiled twice, the symbol
pytorch_duplicate_guard()::initialized will be shared. The second
initialization will print an error message and abort.
```