### PR TITLE
Providing a portable model serialization path

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -122,6 +122,7 @@ def _with_file_like(f, mode, body):
         if new_fd:
             f.close()
 
+            
 def _is_real_file(f):
     """Checks if f is backed by a real file (has a fileno)"""
     try:
@@ -130,6 +131,7 @@ def _is_real_file(f):
         return False
     except AttributeError:
         return False
+
 
 def save_portable(obj, mod_path, output_path, path_delimiter='/'):
     """
@@ -166,6 +168,7 @@ def save_portable(obj, mod_path, output_path, path_delimiter='/'):
     os.remove(model_temp)
     return output_path
 
+
 def _save_portable(obj, in_mod_path, model_save_path):
     serialized_model = pickle.dumps(obj, byref=False)
     input_mod_path = input_mod_path.encode('utf-8')
@@ -173,6 +176,7 @@ def _save_portable(obj, in_mod_path, model_save_path):
     serialized_model = serialized_model.replace(input_mod_path, DEFAULT_MOD_PATH)
     with open(model_save_path, 'wb') as f:
         f.write(serialized_model)
+
 
 def load_portable(local_file_path, temp_location="/tmp", path_delimiter='/'):
     """
@@ -198,10 +202,12 @@ def load_portable(local_file_path, temp_location="/tmp", path_delimiter='/'):
     model = _load_portable("{}{}model.t7".format(str(temp_location), path_delimiter))
     return model
 
+
 def _load_portable(model_path):
     with open(filepath, 'rb') as f:
         mod = pickle.load(f)
     return mod
+
 
 def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
     """Saves an object to a disk file.

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -19,6 +19,7 @@ else:
     import pathlib
 
 DEFAULT_PROTOCOL = 2
+DEFAULT_MOD_PATH = 'portable-pytorch'
 
 LONG_SIZE = struct.Struct('=l').size
 INT_SIZE = struct.Struct('=i').size
@@ -130,6 +131,79 @@ def _is_real_file(f):
     except AttributeError:
         return False
 
+def save_portable(obj, mod_path, output_path):
+    """
+    Portably serializes a torch module file to a disk, along with the network definition module required to execute it.
+    Args:
+        obj: the torch module to save.
+        mod_path: the pythonic import path to your network definition module (it's recommended that this is
+        a separate module, that is self contained (IE does not use resources from other parts of your project).
+        output_path: the output file path where you'd like to save your model to.
+        
+    Example:
+        >>> # save portable version of your model
+        >>> from src.some_project.pytorch_defs.net import Net
+        >>> net = Net(...)
+        >>> output = net.forward()
+        >>> ...
+        >>> torch.save_portable(net, "src.some_project.pytorch_defs", "/tmp/myModel.zip")
+        
+"""
+    import zipfile
+    _, model_temp = tempfile.mkstemp()
+    input_system_path = input_mod_path.replace('.', '/')
+    _save_portable(model, input_mod_path, model_temp)
+    source_files = []
+    for root, dirs, files in os.walk(input_system_path):
+        for file in files:
+            true_path = os.path.join(root, file)
+            false_path = os.path.join(default_mod_path, file)
+            source_files.append((true_path, false_path))
+    with zipfile.ZipFile(output_path, "w") as zip:
+        zip.write(model_temp, "model.t7")
+        for true_path, false_path in source_files:
+            zip.write(true_path, false_path)
+    os.remove(model_temp)
+    return output_path
+
+def _save_portable(obj, in_mod_path, model_save_path):
+    serialized_model = pickle.dumps(obj, byref=False)
+    input_mod_path = input_mod_path.encode('utf-8')
+    output_mod_path = output_mod_path.encode('utf-8')
+    serialized_model = serialized_model.replace(input_mod_path, DEFAULT_MOD_PATH)
+    with open(model_save_path, 'wb') as f:
+        f.write(serialized_model)
+
+        
+def load_portable(local_file_path, temp_location="/tmp"):
+    """
+    Portably deserializes a portable serialized torch model saved with "save_portable". The magic here is 
+    you don't need the original network definition code in order to load this network and utilize it, as the
+    necessary source code is provided along with the network.
+    
+    Args:
+        local_file_path: The local system file path to your portable model object.
+        temp_location: a scratchspace location to use for the unzip/depickling process, if you're
+        using a non debian based kernel (or wholy different operating system) you'll want to change this.
+        
+    Example:
+        >>> # Load a portable model
+        >>> local_portable_model_path = "/tmp/myModel.zip"
+        >>> model = torch.load_portable(local_portable_model_path)
+        >>> output = model.forward(...)
+    """
+    import zipfile
+    with zipfile.ZipFile(local_file_path) as zip:
+        zip.extractall(temp_location)
+    sys.path.insert(0, temp_location)
+    model = _load_portable("{}/model.t7".format(str(temp_location)))
+    return model
+
+def _load_portable(model_path):
+    with open(filepath, 'rb') as f:
+        mod = pickle.load(f)
+    return mod
+    
 
 def save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL):
     """Saves an object to a disk file.

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -122,7 +122,7 @@ def _with_file_like(f, mode, body):
         if new_fd:
             f.close()
 
-            
+
 def _is_real_file(f):
     """Checks if f is backed by a real file (has a fileno)"""
     try:
@@ -142,7 +142,6 @@ def save_portable(obj, mod_path, output_path, path_delimiter='/'):
         a separate module, that is self contained (IE does not use resources from other parts of your project).
         output_path: the output file path where you'd like to save your model to.
         path_delimiter: how your operating system delimits filepaths, the default assumes you're using a unix kernel.
-        
     Example:
         >>> # save portable version of your model
         >>> from src.some_project.pytorch_defs.net import Net
@@ -150,7 +149,6 @@ def save_portable(obj, mod_path, output_path, path_delimiter='/'):
         >>> output = net.forward()
         >>> ...
         >>> torch.save_portable(net, "src.some_project.pytorch_defs", "/tmp/myModel.zip")
-        
     """
     _, model_temp = tempfile.mkstemp()
     input_system_path = input_mod_path.replace('.', path_delimiter)
@@ -183,13 +181,11 @@ def load_portable(local_file_path, temp_location="/tmp", path_delimiter='/'):
     Portably deserializes a portable serialized torch model saved with "save_portable". The magic here is 
     you don't need the original network definition code in order to load this network and utilize it, as the
     necessary source code is provided along with the network.
-    
     Args:
         local_file_path: The local system file path to your portable model object.
         temp_location: a scratchspace location to use for the unzip/depickling process, if you're
         using a non debian based kernel (or wholy different operating system) you'll want to change this.
         path_delimiter: how your operating system delimits filepaths, the default assumes you're using a unix kernel.
-        
     Example:
         >>> # Load a portable model
         >>> local_portable_model_path = "/tmp/myModel.zip"

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -9,6 +9,7 @@ import torch
 import tarfile
 import tempfile
 import warnings
+import zipfile
 from contextlib import closing, contextmanager
 from ._utils import _import_dotted_name
 from ._six import string_classes as _string_classes
@@ -148,8 +149,7 @@ def save_portable(obj, mod_path, output_path):
         >>> ...
         >>> torch.save_portable(net, "src.some_project.pytorch_defs", "/tmp/myModel.zip")
         
-"""
-    import zipfile
+    """
     _, model_temp = tempfile.mkstemp()
     input_system_path = input_mod_path.replace('.', '/')
     _save_portable(model, input_mod_path, model_temp)
@@ -192,7 +192,6 @@ def load_portable(local_file_path, temp_location="/tmp"):
         >>> model = torch.load_portable(local_portable_model_path)
         >>> output = model.forward(...)
     """
-    import zipfile
     with zipfile.ZipFile(local_file_path) as zip:
         zip.extractall(temp_location)
     sys.path.insert(0, temp_location)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -178,7 +178,7 @@ def _save_portable(obj, in_mod_path, model_save_path):
 
 def load_portable(local_file_path, temp_location="/tmp", path_delimiter='/'):
     """
-    Portably deserializes a portable serialized torch model saved with "save_portable". The magic here is 
+    Portably deserializes a portable serialized torch model saved with "save_portable". The magic here is
     you don't need the original network definition code in order to load this network and utilize it, as the
     necessary source code is provided along with the network.
     Args:


### PR DESCRIPTION
torch.save() and torch.load() assume that you will always have the original network definition module in your project, and that it never changes -in order for you to successfully depickle your model. 
This is certainly reasonable to expect during development and prototyping projects, however for lager production projects where your torch model definition and execution code is only one component of the overall project this can lead to serious version control issues. Model files created with previous network definitions cease to work properly, making backwards compatibility incredibly challenging and sometimes completely unfeasible.

The changes I made here were taken from an ergonomics helper module I released on pypi here: https://github.com/algorithmiaio/pytorch-ergonomics, which can be used to experience how the changes can improve your development experience without having to build from source to explore this commit.

Certainly open to improvement suggestions, I've tried to interoperate as much as possible, but I'd certainly appreciate additional :eyes: on this.