### PR TITLE
Update FindCUDA to cmake master as of 561238bb6f07a5ab31293928bd98f6f…

### DIFF
--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -260,12 +260,13 @@ if (MSVC)
   # We know that VS2017 needs the new FindCUDA functionality, so we will
   # simply enable it for the whole Windows build.
   set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
-elseif (${CMAKE_VERSION} VERSION_LESS 3.7 AND ${USE_CUDA})
+else (${CMAKE_VERSION} VERSION_LESS 3.12 AND ${USE_CUDA})
   set(CAFFE2_CMAKE_USE_LOCAL_FINDCUDA ON)
 endif()
 
 if (${CAFFE2_CMAKE_USE_LOCAL_FINDCUDA})
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules_CUDA_fix)
+  include(CMakeInitializeConfigs)
 endif()
 
 if (USE_NATIVE_ARCH)

--- a/cmake/Modules_CUDA_fix/CMakeInitializeConfigs.cmake
+++ b/cmake/Modules_CUDA_fix/CMakeInitializeConfigs.cmake
@@ -1,0 +1,39 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+include_guard(GLOBAL)
+
+# Initializes `<_PREFIX>_<CONFIG>` variables from the corresponding
+# `<_PREFIX>_<CONFIG>_INIT`, for the configurations currently used.
+function(cmake_initialize_per_config_variable _PREFIX _DOCSTRING)
+  string(STRIP "${${_PREFIX}_INIT}" _INIT)
+  set("${_PREFIX}" "${_INIT}"
+    CACHE STRING "${_DOCSTRING} during all build types.")
+  mark_as_advanced("${_PREFIX}")
+
+  if (NOT CMAKE_NOT_USING_CONFIG_FLAGS)
+    set(_CONFIGS Debug Release MinSizeRel RelWithDebInfo)
+
+    get_property(_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if (_GENERATOR_IS_MULTI_CONFIG)
+      list(APPEND _CONFIGS ${CMAKE_CONFIGURATION_TYPES})
+    else()
+      if (NOT CMAKE_NO_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE_INIT}" CACHE STRING
+          "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ...")
+      endif()
+      list(APPEND _CONFIGS ${CMAKE_BUILD_TYPE})
+    endif()
+
+    list(REMOVE_DUPLICATES _CONFIGS)
+    foreach(_BUILD_TYPE IN LISTS _CONFIGS)
+      if (NOT "${_BUILD_TYPE}" STREQUAL "")
+        string(TOUPPER "${_BUILD_TYPE}" _BUILD_TYPE)
+        string(STRIP "${${_PREFIX}_${_BUILD_TYPE}_INIT}" _INIT)
+        set("${_PREFIX}_${_BUILD_TYPE}" "${_INIT}"
+          CACHE STRING "${_DOCSTRING} during ${_BUILD_TYPE} builds.")
+        mark_as_advanced("${_PREFIX}_${_BUILD_TYPE}")
+      endif()
+    endforeach()
+  endif()
+endfunction()

--- a/cmake/Modules_CUDA_fix/CMakeInitializeConfigs.cmake
+++ b/cmake/Modules_CUDA_fix/CMakeInitializeConfigs.cmake
@@ -1,7 +1,8 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-include_guard(GLOBAL)
+# Present in upstream, but not supported on versions of cmake we need to support
+# include_guard(GLOBAL)
 
 # Initializes `<_PREFIX>_<CONFIG>` variables from the corresponding
 # `<_PREFIX>_<CONFIG>_INIT`, for the configurations currently used.

--- a/cmake/Modules_CUDA_fix/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/FindCUDA.cmake
@@ -104,7 +104,7 @@
 #      CUDA_NVCC_FLAGS_<CONFIG> variables.  For Visual Studio targets,
 #      the host compiler is constructed with one or more visual studio macros
 #      such as $(VCInstallDir), that expands out to the path when
-#      the command is run from withing VS.
+#      the command is run from within VS.
 #
 #   CUDA_NVCC_FLAGS
 #   CUDA_NVCC_FLAGS_<CONFIG>
@@ -175,7 +175,7 @@
 #   -- Same as CUDA_ADD_EXECUTABLE except that a library is created.
 #
 #   CUDA_BUILD_CLEAN_TARGET()
-#   -- Creates a convience target that deletes all the dependency files
+#   -- Creates a convenience target that deletes all the dependency files
 #      generated.  You should make clean after running this target to ensure the
 #      dependency files get regenerated.
 #
@@ -525,7 +525,7 @@ set(CUDA_GENERATED_OUTPUT_DIR "" CACHE PATH "Directory to put all the output fil
 option(CUDA_HOST_COMPILATION_CPP "Generated file extension" ON)
 
 # Extra user settable flags
-set(CUDA_NVCC_FLAGS "" CACHE STRING "Semi-colon delimit multiple arguments.")
+cmake_initialize_per_config_variable(CUDA_NVCC_FLAGS "Semi-colon delimit multiple arguments.")
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set(_CUDA_MSVC_HOST_COMPILER "$(VCInstallDir)Tools/MSVC/$(VCToolsVersion)/bin/Host$(Platform)/$(PlatformTarget)")
@@ -596,11 +596,6 @@ mark_as_advanced(
 # each configuration-specific set of nvcc flags defined and marked as advanced.
 set(CUDA_configuration_types ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE} Debug MinSizeRel Release RelWithDebInfo)
 list(REMOVE_DUPLICATES CUDA_configuration_types)
-foreach(config ${CUDA_configuration_types})
-    string(TOUPPER ${config} config_upper)
-    set(CUDA_NVCC_FLAGS_${config_upper} "" CACHE STRING "Semi-colon delimit multiple arguments.")
-    mark_as_advanced(CUDA_NVCC_FLAGS_${config_upper})
-endforeach()
 
 ###############################################################################
 ###############################################################################
@@ -738,16 +733,20 @@ endif()
 
 
 # CUDA_NVCC_EXECUTABLE
-cuda_find_host_program(CUDA_NVCC_EXECUTABLE
-  NAMES nvcc
-  PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
-  ENV CUDA_PATH
-  ENV CUDA_BIN_PATH
-  PATH_SUFFIXES bin bin64
-  NO_DEFAULT_PATH
-  )
-# Search default search paths, after we search our own set of paths.
-cuda_find_host_program(CUDA_NVCC_EXECUTABLE nvcc)
+if(DEFINED ENV{CUDA_NVCC_EXECUTABLE})
+  set(CUDA_NVCC_EXECUTABLE "$ENV{CUDA_NVCC_EXECUTABLE}" CACHE FILEPATH "The CUDA compiler")
+else()
+  cuda_find_host_program(CUDA_NVCC_EXECUTABLE
+    NAMES nvcc
+    PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+    ENV CUDA_PATH
+    ENV CUDA_BIN_PATH
+    PATH_SUFFIXES bin bin64
+    NO_DEFAULT_PATH
+    )
+  # Search default search paths, after we search our own set of paths.
+  cuda_find_host_program(CUDA_NVCC_EXECUTABLE nvcc)
+endif()
 mark_as_advanced(CUDA_NVCC_EXECUTABLE)
 
 if(CUDA_NVCC_EXECUTABLE AND NOT CUDA_VERSION)
@@ -1284,6 +1283,11 @@ macro(CUDA_WRAP_SRCS cuda_target format generated_files)
     set(_target_is_phony false)
   endif()
 
+  # If CMake doesn't support separable compilation, complain
+  if(CUDA_SEPARABLE_COMPILATION AND CMAKE_VERSION VERSION_LESS "2.8.10.1")
+    message(SEND_ERROR "CUDA_SEPARABLE_COMPILATION isn't supported for CMake versions less than 2.8.10.1")
+  endif()
+
   # Set up all the command line flags here, so that they can be overridden on a per target basis.
 
   set(nvcc_flags "")
@@ -1564,7 +1568,7 @@ macro(CUDA_WRAP_SRCS cuda_target format generated_files)
       # Bring in the dependencies.  Creates a variable CUDA_NVCC_DEPEND #######
       cuda_include_nvcc_dependencies(${cmake_dependency_file})
 
-      # Convience string for output ###########################################
+      # Convenience string for output #########################################
       if(CUDA_BUILD_EMULATION)
         set(cuda_build_type "Emulation")
       else()
@@ -1975,9 +1979,9 @@ endmacro()
 ###############################################################################
 ###############################################################################
 macro(CUDA_BUILD_CLEAN_TARGET)
-  # Call this after you add all your CUDA targets, and you will get a convience
-  # target.  You should also make clean after running this target to get the
-  # build system to generate all the code again.
+  # Call this after you add all your CUDA targets, and you will get a
+  # convenience target.  You should also make clean after running this target
+  # to get the build system to generate all the code again.
 
   set(cuda_clean_target_name clean_cuda_depends)
   if (CMAKE_GENERATOR MATCHES "Visual Studio")


### PR DESCRIPTION
…8911d8bc1

Relevant commits:

    commit 23119366e9d4e56e13c1fdec9dbff5e8f8c55ee5
    Author: Edward Z. Yang <ezyang@fb.com>
    Date:   Wed Mar 28 11:33:56 2018 -0400

        FindCUDA: Make nvcc configurable via CUDA_NVCC_EXECUTABLE env var

        This is useful if, for example, you want ccache to be used
        for nvcc.  With the current behavior, cmake always picks up
        /usr/local/cuda/bin/nvcc, even if there is a ccache nvcc
        stub in the PATH.  Allowing for CUDA_NVCC_EXECUTABLE lets
        us work around the problem.

        Signed-off-by: Edward Z. Yang <ezyang@fb.com>

    commit e743fc8e9137692232f0220ac901f5a15cbd62cf
    Author: Henry Fredrick Schreiner <henry.fredrick.schreiner@cern.ch>
    Date:   Thu Mar 15 15:30:50 2018 +0100

        FindCUDA/select_compute_arch: Add support for CUDA as a language

        Even though this is an internal module, we can still prepare it to
        be used in another public-facing module outside of `FindCUDA`.

        Issue: #16586

    commit 193082a3c803a6418f0f1b5976dc34a91cf30805
    Author: luz.paz <luzpaz@users.noreply.github.com>
    Date:   Thu Feb 8 06:27:21 2018 -0500

        MAINT: Misc. typos

        Found via `codespell -q 3 -I ../cmake-whitelist.txt`.

    commit 9f74aaeb7d6649241c4a478410e87d092c462960
    Author: Brad King <brad.king@kitware.com>
    Date:   Tue Jan 30 08:18:11 2018 -0500

        FindCUDA: Fix regression in per-config flags

        Changes in commit 48f7e2d300 (Unhardcode the CMAKE_CONFIGURATION_TYPES
        values, 2017-11-27) accidentally left `CUDA_configuration_types`
        undefined, but this is used in a few places to handle per-config flags.
        Restore it.

        Fixes: #17671

    commit d91b2d9158cbe5d65bfcc8f7512503d7f226ad91
    Author: luz.paz <luzpaz@users.noreply.github.com>
    Date:   Wed Jan 10 12:34:14 2018 -0500

        MAINT: Misc. typos

        Found via `codespell`

    commit d08f3f551fa94b13a1d43338eaed68bcecb95cff
    Merge: 1be22978e 1f4d7a071
    Author: Brad King <brad.king@kitware.com>
    Date:   Wed Jan 10 15:34:57 2018 +0000

        Merge topic 'unhardcode-configuration-types'

        1f4d7a07 Help: Add references and backticks in LINK_FLAGS prop_tgt
        48f7e2d3 Unhardcode the CMAKE_CONFIGURATION_TYPES values

        Acked-by: Kitware Robot <kwrobot@kitware.com>
        Merge-request: !1345

    commit 5fbfa18fadf945963687cd95627c1bc62b68948a
    Merge: bc88329e5 ff41a4b81
    Author: Brad King <brad.king@kitware.com>
    Date:   Tue Jan 9 14:26:35 2018 +0000

        Merge topic 'FindCUDA-deduplicate-c+std-host-flags'

        ff41a4b8 FindCUDA: de-duplicates C++11 flag when propagating host flags.

        Acked-by: Kitware Robot <kwrobot@kitware.com>
        Merge-request: !1628

    commit bc88329e5ba7b1a14538f23f4fa223ac8d6d5895
    Merge: 89d127463 fab1b432e
    Author: Brad King <brad.king@kitware.com>
    Date:   Tue Jan 9 14:26:16 2018 +0000

        Merge topic 'msvc2017-findcuda'

        fab1b432 FindCUDA: Update to properly find MSVC 2017 compiler tools

        Acked-by: Kitware Robot <kwrobot@kitware.com>
        Acked-by: Robert Maynard <robert.maynard@kitware.com>
        Merge-request: !1631

    commit 48f7e2d30000dc57c31d3e3ab81077950704a587
    Author: Beren Minor <beren.minor+git@gmail.com>
    Date:   Mon Nov 27 19:22:11 2017 +0100

        Unhardcode the CMAKE_CONFIGURATION_TYPES values

        This removes duplicated code for per-config variable initialization by
        providing a `cmake_initialize_per_config_variable(<PREFIX> <DOCSTRING>)`
        function.

        This function initializes a `<PREFIX>` cache variable from `<PREFIX>_INIT`
        and unless the `CMAKE_NOT_USING_CONFIG_FLAGS` variable is defined, does
        the same with `<PREFIX>_<CONFIG>` from `<PREFIX>_<CONFIG>_INIT` for every
        `<CONFIG>` in `CMAKE_CONFIGURATION_TYPES` for multi-config generators or
        `CMAKE_BUILD_TYPE` for single-config generators.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

