### PR TITLE
fix assertion error when input size smaller than number of module_copies

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -213,7 +213,7 @@ class DistributedDataParallel(Module):
         self._sync_params()
         if len(self.device_ids) == 1:
             return self.module(*inputs[0], **kwargs[0])
-        outputs = self.parallel_apply(self._module_copies, inputs, kwargs)
+        outputs = self.parallel_apply(self._module_copies[:len(inputs)], inputs, kwargs)
         return self.gather(outputs, self.output_device)
 
     def scatter(self, inputs, kwargs, device_ids):


### PR DESCRIPTION
This is a fix for #5587 . 
In DistributedDataparallel, we get _module_copies in init(), but it's possible that the length of last batch is smaller than the number of GPUs. In this case, the [assertion error](https://github.com/pytorch/pytorch/blob/master/torch/nn/parallel/parallel_apply.py#L24) is triggered.
The fix has the same behavior as [DataParallel model](https://github.com/pytorch/pytorch/blob/master/torch/nn/parallel/data_parallel.py#L99), however, we cannot change the number of replicas in DDP case, so we put it in parallel_apply instead. 