### PR TITLE
[caffe2] Fix CostInference function values

### DIFF
--- a/caffe2/operators/distance_op.cc
+++ b/caffe2/operators/distance_op.cc
@@ -226,10 +226,10 @@ bool DotProductOp<float, CPUContext>::RunOnDevice() {
 vector<TensorShape> TensorInferenceForDotProduct(
     const OperatorDef& /* def */,
     const vector<TensorShape>& in) {
-  vector<TIndex> dims;
-  if (in[0].dims().size() > 0) {
-    dims.push_back(in[0].dims(0));
-  }
+  CAFFE_ENFORCE_GT(in.size(), 0);
+
+  vector<TIndex> dims(1);
+  dims[0] = in[0].dims().size() > 0 ? in[0].dims(0) : 1;
   return vector<TensorShape>{CreateTensorShape(dims, in[0].data_type())};
 }
 
@@ -237,13 +237,11 @@ OpSchema::Cost CostInferenceForDotProduct(
     const OperatorDef& def,
     const vector<TensorShape>& in) {
   std::vector<TensorShape> out = TensorInferenceForDotProduct(def, in);
-  uint64_t size_out = 1;
-  for (auto i = 0; i < out[0].dims().size(); ++i) {
-    size_out *= out[0].dims(i);
-  }
+  CAFFE_ENFORCE_GT(out.size(), 0);
+  CAFFE_ENFORCE_EQ(out[0].dims().size(), 1);
 
   struct OpSchema::Cost c = PointwiseCostInference<2>(def, in);
-  c.bytes_moved = size_out * sizeof(out[0].data_type());
+  c.bytes_moved = out[0].dims(0) * sizeof(out[0].data_type());
   c.params_bytes = 0;
   return c;
 }

--- a/caffe2/operators/elementwise_op_schema.cc
+++ b/caffe2/operators/elementwise_op_schema.cc
@@ -76,7 +76,7 @@ OPERATOR_SCHEMA(Div)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
-    .CostInferenceFunction(PointwiseCostInference<1>)
+    .CostInferenceFunction(PointwiseCostInference<0>)
     .IdenticalTypeAndShapeOfInput(0)
     .FillUsing(MathDocGenerator("division"))
     .InheritOnnxSchema("Div");


### PR DESCRIPTION
Add TensorInference function for DotProduct.
Fix CostInference function for DotProduct (missing factor 2 from reduction).
Fix CostInference function for Div (Should be 0 flops).

@salexspb Please review.  Thanks!