### PR TITLE
Change Python Arg Parser to only read default params if they are assigned

### DIFF
--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -273,6 +273,9 @@ inline const THPLayout& PythonArgs::layout(int i) {
 }
 
 inline int64_t PythonArgs::toInt64(int i) {
+  if (!signature.params[i].optional) {
+    return THPUtils_unpackLong(args[i]);
+  }
   return toInt64WithDefault(i, signature.params[i].default_int);
 }
 
@@ -282,6 +285,9 @@ inline int64_t PythonArgs::toInt64WithDefault(int i, int64_t default_int) {
 }
 
 inline double PythonArgs::toDouble(int i) {
+  if (!signature.params[i].optional) {
+    return THPUtils_unpackDouble(args[i]);
+  }
   return toDoubleWithDefault(i, signature.params[i].default_double);
 }
 
@@ -291,6 +297,9 @@ inline double PythonArgs::toDoubleWithDefault(int i, double default_double) {
 }
 
 inline bool PythonArgs::toBool(int i) {
+  if (!signature.params[i].optional) {
+    return args[i] == Py_True;
+  }
   return toBoolWithDefault(i, signature.params[i].default_bool);
 }
 

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -273,39 +273,33 @@ inline const THPLayout& PythonArgs::layout(int i) {
 }
 
 inline int64_t PythonArgs::toInt64(int i) {
-  if (!signature.params[i].optional) {
-    return THPUtils_unpackLong(args[i]);
-  }
-  return toInt64WithDefault(i, signature.params[i].default_int);
+  if (!args[i]) return signature.params[i].default_int;
+  return THPUtils_unpackLong(args[i]);
 }
 
 inline int64_t PythonArgs::toInt64WithDefault(int i, int64_t default_int) {
   if (!args[i]) return default_int;
-  return THPUtils_unpackLong(args[i]);
+  return toInt64(i);
 }
 
 inline double PythonArgs::toDouble(int i) {
-  if (!signature.params[i].optional) {
-    return THPUtils_unpackDouble(args[i]);
-  }
-  return toDoubleWithDefault(i, signature.params[i].default_double);
+  if (!args[i]) return signature.params[i].default_double;
+  return THPUtils_unpackDouble(args[i]);
 }
 
 inline double PythonArgs::toDoubleWithDefault(int i, double default_double) {
   if (!args[i]) return default_double;
-  return THPUtils_unpackDouble(args[i]);
+  return toDouble(i);
 }
 
 inline bool PythonArgs::toBool(int i) {
-  if (!signature.params[i].optional) {
-    return args[i] == Py_True;
-  }
-  return toBoolWithDefault(i, signature.params[i].default_bool);
+  if (!args[i]) return signature.params[i].default_bool;
+  return args[i] == Py_True;
 }
 
 inline bool PythonArgs::toBoolWithDefault(int i, bool default_bool) {
   if (!args[i]) return default_bool;
-  return args[i] == Py_True;
+  return toBool(i);
 }
 
 inline bool PythonArgs::isNone(int i) {


### PR DESCRIPTION
https://discuss.pytorch.org/t/runtime-error-load-of-value-190-which-is-not-a-valid-value-for-type-bool-during-loss-computation-with-marginrankingloss-and-hingeembeddingloss/15681

Caused because toBool is attempting to turn unassigned union field to bool. 
```
pytorch/pytorch/torch/csrc/utils/python_arg_parser.h:292:51: runtime error: load of value 190, which is not a valid value for type 'bool'
```

@zou3519 @colesbury 