### PR TITLE
[ppc64le] Do not use cpuinfo on PowerPC

### DIFF
--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -44,6 +44,8 @@ struct DispatchStub {
   }
 
   FnPtr choose_impl() {
+// Do not use cpuinfo on PowerPC as it shows confusing errors when run on ppc
+#ifndef __powerpc__
     if (cpuinfo_initialize()) {
       int avx2 = static_cast<int>(CPUCapability::AVX2);
       if (!std::getenv("ATEN_DISABLE_AVX2") && cpuinfo_has_x86_avx2() && table[avx2]) {
@@ -54,6 +56,7 @@ struct DispatchStub {
         return table[avx];
       }
     }
+#endif
     int def = static_cast<int>(CPUCapability::DEFAULT);
     AT_ASSERT(table[def], "DispatchStub: missing default kernel");
     return table[def];


### PR DESCRIPTION
cpuinfo_initialize() prints error message to the console/log when run
on unsupported CPU/platform. Even the code will work fine this is
confusing error message that shouldn't be shown to the users when use
PyTorch on other architectures than the supported by cpuinfo.

