### PR TITLE
[JIT] Implement staged symbolics for pack_padded/pad_packed

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2357,16 +2357,15 @@ class TestScript(TestCase):
         seq_lens = torch.ones(B, dtype=torch.int32)
         m = PadPackedWrapper()
         m_traced = torch.jit.trace(x, seq_lens)(m)
-        criterion = nn.MSELoss()
 
         y = m(x, seq_lens)
-        loss = criterion(y, torch.zeros_like(y))
+        loss = torch.sum(y)
         loss.backward()
         grad = x.grad.clone()
         x.grad.zero_()
 
         y_traced = m_traced(x, seq_lens)
-        loss_traced = criterion(y_traced, torch.zeros_like(y_traced))
+        loss_traced = torch.sum(y_traced)
         loss_traced.backward()
         grad_traced = x.grad.clone()
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2354,7 +2354,8 @@ class TestScript(TestCase):
         x = torch.zeros(T, B, C)
         seq_lens = torch.ones(B, dtype=torch.int32)
         m = torch.jit.trace(x, seq_lens)(PadPackedWrapper())
-        self.assertEqual(m(x, seq_lens), pack_padded_sequence(x, seq_lens)[0])
+        mod_outs = m(x, seq_lens)
+        self.assertEqual(mod_outs, pack_padded_sequence(x, seq_lens)[0])
 
 
 # Smoke tests for export methods

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -32,6 +32,10 @@ void initPythonIRBindings(PyObject * module_) {
       std::vector<Value*> outputs;
       for (size_t i = 0; i < n_outputs; ++i)
         new_node->addOutput();
+#ifndef NO_PYTHON
+      auto sl = std::make_shared<StringSourceLocation>(tracer::getPythonInterpreterStackTrace());
+      new_node->setSourceLocation(sl);
+#endif
       return py::make_iterator(new_node->outputs().begin(), new_node->outputs().end());
     }, py::return_value_policy::reference_internal)
     .def("inputs",[](Graph &g) {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -3,7 +3,7 @@ from torch import Tensor
 from torch.autograd import Variable, function
 from torch.nn import Module, ModuleList, ParameterList, Parameter
 from torch.jit.frontend import get_jit_ast
-from torch._six import raise_from, with_metaclass
+from torch._six import raise_from, with_metaclass, string_classes
 from collections import defaultdict, OrderedDict, namedtuple
 import sys
 import warnings
@@ -16,7 +16,9 @@ import functools
 import inspect
 import copy
 import numbers
-
+import numbers
+import collections
+import re
 
 _flatten = torch._C._jit_flatten
 _unflatten = torch._C._jit_unflatten
@@ -872,3 +874,165 @@ class _ConstModuleList(ScriptModule):
 
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")
+
+
+def _scalar(x):
+    """Convert a scalar tensor into a Python value."""
+    assert x.numel() == 1
+    return x[0]
+
+
+def _is_onnx_list(value):
+    if not isinstance(value, string_classes) and not torch.is_tensor(value) and isinstance(value, collections.Iterable):
+        return True
+    return False
+
+
+attr_pattern = re.compile("^(.+)_([ifstgz])$")
+
+
+def _add_attribute(node, key, value, aten):
+    r""" initializes the right attribute based on type of value """
+    m = attr_pattern.match(key)
+    if m is None:
+        raise IndexError((
+            "Invalid attribute specifier '{}' names " +
+            " must be suffixed with type, e.g. 'dim_i' or 'dims_i'").format(key))
+    name, kind = m.group(1), m.group(2)
+    if _is_onnx_list(value):
+        kind += "s"
+    if aten:
+        if torch.is_tensor(value):
+            # Caffe2 proto does not support tensor attribute.
+            if value.numel() > 1:
+                raise ValueError("Should not pass tensor attribute")
+            value = _scalar(value)
+            if isinstance(value, float):
+                kind = "f"
+            else:
+                kind = "i"
+    return getattr(node, kind + "_")(name, value)
+
+
+def _newNode(g, opname, outputs, *args, **kwargs):
+    if "::" in opname:
+        aten = False
+        ns_opname = opname
+    else:
+        aten = kwargs.pop("aten", False)
+        ns = "aten" if aten else "onnx"
+        ns_opname = ns + "::" + opname
+    n = g.create(ns_opname, args, outputs)
+    for k, v in sorted(kwargs.items()):
+        # TODO: enable inplace in aten exporting mode.
+        if k == "inplace":
+            continue
+        _add_attribute(n, k, v, aten=aten)
+    return n
+
+
+def _graph_op(g, opname, *raw_args, **kwargs):
+    r"""
+    Create an ONNX operator 'opname', taking 'args' as inputs and attributes
+    'kwargs'; returning the node representing the single output of this operator
+    (see the `outputs` keyword argument for multi-return nodes).
+
+    The set of operators and the inputs/attributes they take
+    is documented at https://github.com/onnx/onnx/blob/master/docs/Operators.md
+
+    This function is monkey-patched onto Graph.
+
+    Arguments:
+        opname (string): The ONNX operator name, e.g., `Abs` or `Add`.
+        args (Node...): The inputs to the operator; usually provided
+            as arguments to the `symbolic` definition.
+        kwargs: The attributes of the ONNX operator, with keys named
+            according to the following convention: `alpha_f` indicates
+            the `alpha` attribute with type `f`.  The valid type specifiers are
+            `f` (float), `i` (int), `s` (string) or `t` (Tensor).  An attribute
+            specified with type float accepts either a single float, or a
+            list of floats (e.g., you would say `dims_i` for a `dims` attribute
+            that takes a list of integers).
+        outputs (int, optional):  The number of outputs this operator returns;
+            by default an operator is assumed to return a single output.
+            If `outputs` is greater than one, this functions returns a tuple
+            of output `Node`, representing each output of the ONNX operator
+            in positional.
+    """
+    outputs = kwargs.pop('outputs', 1)
+
+    # Filter out None attributes, this can be convenient client side because
+    # now they can pass through None attributes, and have them not show up
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
+
+    def const_if_tensor(arg):
+        if arg is None:
+            return arg
+        elif isinstance(arg, torch._C.Value):
+            return arg
+        else:
+            return g.op("Constant", value_z=arg)
+
+    args = list(const_if_tensor(arg) for arg in raw_args)
+    n = g.appendNode(_newNode(g, opname, outputs, *args, **kwargs))
+    if outputs == 1:
+        return n.output()
+    return tuple(o for o in n.outputs())
+
+
+# Generate an ONNX ATen op node.
+def _graph_at(g, opname, *args, **kwargs):
+    return g.op("ATen", *args, operator_s=opname, **kwargs)
+
+
+# This helper function can create either constant tensor or constant scalar.
+# If dims is None or 0 or [0], generate a 0-d tensor (scalar).
+#
+# TODO: We might not need this anymore, since most scalars now show up
+# as tensors
+def _graph_constant(g, value, dims, type, *args, **kwargs):
+    assert isinstance(value, numbers.Number)
+    assert type is not None
+    isscalar = False
+    if dims is None or dims == 0 or set(dims) == set([0]):
+        dims = [1]
+        isscalar = True
+    type = type.lower()
+    if type == "char":
+        tensor = torch.CharTensor(*dims)
+    elif type == "short":
+        tensor = torch.ShortTensor(*dims)
+    elif type == "int":
+        tensor = torch.IntTensor(*dims)
+    elif type == "long":
+        tensor = torch.LongTensor(*dims)
+    elif type == "half":
+        tensor = torch.HalfTensor(*dims)
+    elif type == "float":
+        tensor = torch.FloatTensor(*dims)
+    elif type == "double":
+        tensor = torch.DoubleTensor(*dims)
+    else:
+        raise ValueError("Unknown type, type should be one of the following strings: "
+                         "char, short, int, long, half, float, double")
+    tensor.fill_(value)
+    if isscalar:
+        return g.op("Constant", *args, value_z=tensor, **kwargs)
+    return g.op("Constant", *args, value_t=tensor, **kwargs)
+
+
+def _node_getitem(self, k):
+    r"""
+    Accessor for attributes of a node which is polymorphic over
+    return type.
+
+    NB: This is monkey-patched onto Node.
+    """
+    sel = self.kindOf(k)
+    return getattr(self, sel)(k)
+
+
+torch._C.Graph.op = _graph_op
+torch._C.Graph.at = _graph_at
+torch._C.Graph.constant = _graph_constant
+torch._C.Node.__getitem__ = _node_getitem

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -3,7 +3,7 @@ from torch import Tensor
 from torch.autograd import Variable, function
 from torch.nn import Module, ModuleList, ParameterList, Parameter
 from torch.jit.frontend import get_jit_ast
-from torch._six import raise_from, with_metaclass, string_classes
+from torch._six import raise_from, with_metaclass
 from collections import defaultdict, OrderedDict, namedtuple
 import sys
 import warnings
@@ -15,7 +15,6 @@ import os
 import functools
 import inspect
 import copy
-import numbers
 import numbers
 import collections
 import re
@@ -874,165 +873,3 @@ class _ConstModuleList(ScriptModule):
 
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")
-
-
-def _scalar(x):
-    """Convert a scalar tensor into a Python value."""
-    assert x.numel() == 1
-    return x[0]
-
-
-def _is_onnx_list(value):
-    if not isinstance(value, string_classes) and not torch.is_tensor(value) and isinstance(value, collections.Iterable):
-        return True
-    return False
-
-
-attr_pattern = re.compile("^(.+)_([ifstgz])$")
-
-
-def _add_attribute(node, key, value, aten):
-    r""" initializes the right attribute based on type of value """
-    m = attr_pattern.match(key)
-    if m is None:
-        raise IndexError((
-            "Invalid attribute specifier '{}' names " +
-            " must be suffixed with type, e.g. 'dim_i' or 'dims_i'").format(key))
-    name, kind = m.group(1), m.group(2)
-    if _is_onnx_list(value):
-        kind += "s"
-    if aten:
-        if torch.is_tensor(value):
-            # Caffe2 proto does not support tensor attribute.
-            if value.numel() > 1:
-                raise ValueError("Should not pass tensor attribute")
-            value = _scalar(value)
-            if isinstance(value, float):
-                kind = "f"
-            else:
-                kind = "i"
-    return getattr(node, kind + "_")(name, value)
-
-
-def _newNode(g, opname, outputs, *args, **kwargs):
-    if "::" in opname:
-        aten = False
-        ns_opname = opname
-    else:
-        aten = kwargs.pop("aten", False)
-        ns = "aten" if aten else "onnx"
-        ns_opname = ns + "::" + opname
-    n = g.create(ns_opname, args, outputs)
-    for k, v in sorted(kwargs.items()):
-        # TODO: enable inplace in aten exporting mode.
-        if k == "inplace":
-            continue
-        _add_attribute(n, k, v, aten=aten)
-    return n
-
-
-def _graph_op(g, opname, *raw_args, **kwargs):
-    r"""
-    Create an ONNX operator 'opname', taking 'args' as inputs and attributes
-    'kwargs'; returning the node representing the single output of this operator
-    (see the `outputs` keyword argument for multi-return nodes).
-
-    The set of operators and the inputs/attributes they take
-    is documented at https://github.com/onnx/onnx/blob/master/docs/Operators.md
-
-    This function is monkey-patched onto Graph.
-
-    Arguments:
-        opname (string): The ONNX operator name, e.g., `Abs` or `Add`.
-        args (Node...): The inputs to the operator; usually provided
-            as arguments to the `symbolic` definition.
-        kwargs: The attributes of the ONNX operator, with keys named
-            according to the following convention: `alpha_f` indicates
-            the `alpha` attribute with type `f`.  The valid type specifiers are
-            `f` (float), `i` (int), `s` (string) or `t` (Tensor).  An attribute
-            specified with type float accepts either a single float, or a
-            list of floats (e.g., you would say `dims_i` for a `dims` attribute
-            that takes a list of integers).
-        outputs (int, optional):  The number of outputs this operator returns;
-            by default an operator is assumed to return a single output.
-            If `outputs` is greater than one, this functions returns a tuple
-            of output `Node`, representing each output of the ONNX operator
-            in positional.
-    """
-    outputs = kwargs.pop('outputs', 1)
-
-    # Filter out None attributes, this can be convenient client side because
-    # now they can pass through None attributes, and have them not show up
-    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
-
-    def const_if_tensor(arg):
-        if arg is None:
-            return arg
-        elif isinstance(arg, torch._C.Value):
-            return arg
-        else:
-            return g.op("Constant", value_z=arg)
-
-    args = list(const_if_tensor(arg) for arg in raw_args)
-    n = g.appendNode(_newNode(g, opname, outputs, *args, **kwargs))
-    if outputs == 1:
-        return n.output()
-    return tuple(o for o in n.outputs())
-
-
-# Generate an ONNX ATen op node.
-def _graph_at(g, opname, *args, **kwargs):
-    return g.op("ATen", *args, operator_s=opname, **kwargs)
-
-
-# This helper function can create either constant tensor or constant scalar.
-# If dims is None or 0 or [0], generate a 0-d tensor (scalar).
-#
-# TODO: We might not need this anymore, since most scalars now show up
-# as tensors
-def _graph_constant(g, value, dims, type, *args, **kwargs):
-    assert isinstance(value, numbers.Number)
-    assert type is not None
-    isscalar = False
-    if dims is None or dims == 0 or set(dims) == set([0]):
-        dims = [1]
-        isscalar = True
-    type = type.lower()
-    if type == "char":
-        tensor = torch.CharTensor(*dims)
-    elif type == "short":
-        tensor = torch.ShortTensor(*dims)
-    elif type == "int":
-        tensor = torch.IntTensor(*dims)
-    elif type == "long":
-        tensor = torch.LongTensor(*dims)
-    elif type == "half":
-        tensor = torch.HalfTensor(*dims)
-    elif type == "float":
-        tensor = torch.FloatTensor(*dims)
-    elif type == "double":
-        tensor = torch.DoubleTensor(*dims)
-    else:
-        raise ValueError("Unknown type, type should be one of the following strings: "
-                         "char, short, int, long, half, float, double")
-    tensor.fill_(value)
-    if isscalar:
-        return g.op("Constant", *args, value_z=tensor, **kwargs)
-    return g.op("Constant", *args, value_t=tensor, **kwargs)
-
-
-def _node_getitem(self, k):
-    r"""
-    Accessor for attributes of a node which is polymorphic over
-    return type.
-
-    NB: This is monkey-patched onto Node.
-    """
-    sel = self.kindOf(k)
-    return getattr(self, sel)(k)
-
-
-torch._C.Graph.op = _graph_op
-torch._C.Graph.at = _graph_at
-torch._C.Graph.constant = _graph_constant
-torch._C.Node.__getitem__ = _node_getitem

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from functools import partial
 
 import torch
 from torch.autograd import Variable

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -127,15 +127,9 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     return PackedSequence(data, batch_sizes)
 
 
-def _onnx_symbolic_pack_padded_sequence(g, input, lengths):
-    return g.op("prim::PackPadded", input, lengths, outputs=2)
-
-
 def _symbolic_pack_padded_sequence(g, input, lengths, batch_first=False, padding_value=0.0, total_length=None):
     if total_length is not None:
         raise ValueError("_symbolic_pad_packed_sequence only supports total_length=None")
-    if batch_first:
-        input = g.op('Transpose', input, perm_i=[1, 0, 2])
     # There currently is no PackPadded operator in ONNX. We rely on an
     # optimization pass to remove this later. It is an error if all
     # PackPadded operators cannot be optimized out.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -139,6 +139,7 @@ def _symbolic_pack_padded_sequence(g, input, lengths, batch_first=False, padding
     # There currently is no PackPadded operator in ONNX. We rely on an
     # optimization pass to remove this later. It is an error if all
     # PackPadded operators cannot be optimized out.
+
     def _onnx_symbolic_pack_padded_sequence(g, input, lengths):
         if batch_first:
             input = g.op('Transpose', input, perm_i=[1, 0, 2])

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -154,7 +154,8 @@ def _symbolic_pack_padded_sequence(g, input, lengths, batch_first=False, padding
     return tuple(o for o in outputs)
 
 
-pack_padded_sequence = torch.onnx.symbolic_override_first_arg_based(_symbolic_pack_padded_sequence)(pack_padded_sequence)
+pack_padded_sequence = torch.onnx.symbolic_override_first_arg_based(
+    _symbolic_pack_padded_sequence)(pack_padded_sequence)
 
 
 def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_length=None):
@@ -239,7 +240,7 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
 
     def pad_packed_sequence_trace_wrapper(data, batch_sizes):
         return pad_packed_sequence(PackedSequence(data, batch_sizes),
-                            batch_first=batch_first, padding_value=padding_value)
+                                   batch_first=batch_first, padding_value=padding_value)
 
     data, lengths = g.wrapPyFuncWithSymbolic(
         pad_packed_sequence_trace_wrapper, [input.data, input.batch_sizes], 2,
@@ -247,7 +248,8 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
     return data, lengths
 
 
-pad_packed_sequence = torch.onnx.symbolic_override_packed_sequence_based(_symbolic_pad_packed_sequence)(pad_packed_sequence)
+pad_packed_sequence = torch.onnx.symbolic_override_packed_sequence_based(
+    _symbolic_pad_packed_sequence)(pad_packed_sequence)
 
 
 def pad_sequence(sequences, batch_first=False, padding_value=0):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -11,6 +11,7 @@ import torch.serialization
 import re
 import collections
 import contextlib
+import numbers
 import warnings
 import functools
 import types
@@ -198,6 +199,8 @@ def _set_input_and_output_names(graph, input_names, output_names):
     set_names(list(graph.inputs()), input_names, 'input')
     set_names(list(graph.outputs()), output_names, 'output')
 
+attr_pattern = re.compile("^(.+)_([ifstgz])$")
+
 
 def _run_symbolic_method(op_name, symbolic_fn, args):
     r"""
@@ -212,6 +215,107 @@ def _run_symbolic_method(op_name, symbolic_fn, args):
         # you need.
         e.args = ("{} (occurred when translating {})".format(e.args[0], op_name), )
         raise
+
+
+def _is_onnx_list(value):
+    if not isinstance(value, string_classes) and not torch.is_tensor(value) and isinstance(value, collections.Iterable):
+        return True
+    return False
+
+
+def _add_attribute(node, key, value, aten):
+    r""" initializes the right attribute based on type of value """
+    m = attr_pattern.match(key)
+    if m is None:
+        raise IndexError((
+            "Invalid attribute specifier '{}' names " +
+            " must be suffixed with type, e.g. 'dim_i' or 'dims_i'").format(key))
+    name, kind = m.group(1), m.group(2)
+    if _is_onnx_list(value):
+        kind += "s"
+    if aten:
+        if torch.is_tensor(value):
+            # Caffe2 proto does not support tensor attribute.
+            if value.numel() > 1:
+                raise ValueError("Should not pass tensor attribute")
+            value = _scalar(value)
+            if isinstance(value, float):
+                kind = "f"
+            else:
+                kind = "i"
+    return getattr(node, kind + "_")(name, value)
+
+
+def _scalar(x):
+    """Convert a scalar tensor into a Python value."""
+    assert x.numel() == 1
+    return x[0]
+
+
+def _newNode(g, opname, outputs, *args, **kwargs):
+    if "::" in opname:
+        aten = False
+        ns_opname = opname
+    else:
+        aten = kwargs.pop("aten", False)
+        ns = "aten" if aten else "onnx"
+        ns_opname = ns + "::" + opname
+    n = g.create(ns_opname, args, outputs)
+    for k, v in sorted(kwargs.items()):
+        # TODO: enable inplace in aten exporting mode.
+        if k == "inplace":
+            continue
+        _add_attribute(n, k, v, aten=aten)
+    return n
+
+
+def _graph_op(g, opname, *raw_args, **kwargs):
+    r"""
+    Create an ONNX operator 'opname', taking 'args' as inputs and attributes
+    'kwargs'; returning the node representing the single output of this operator
+    (see the `outputs` keyword argument for multi-return nodes).
+
+    The set of operators and the inputs/attributes they take
+    is documented at https://github.com/onnx/onnx/blob/master/docs/Operators.md
+
+    This function is monkey-patched onto Graph.
+
+    Arguments:
+        opname (string): The ONNX operator name, e.g., `Abs` or `Add`.
+        args (Node...): The inputs to the operator; usually provided
+            as arguments to the `symbolic` definition.
+        kwargs: The attributes of the ONNX operator, with keys named
+            according to the following convention: `alpha_f` indicates
+            the `alpha` attribute with type `f`.  The valid type specifiers are
+            `f` (float), `i` (int), `s` (string) or `t` (Tensor).  An attribute
+            specified with type float accepts either a single float, or a
+            list of floats (e.g., you would say `dims_i` for a `dims` attribute
+            that takes a list of integers).
+        outputs (int, optional):  The number of outputs this operator returns;
+            by default an operator is assumed to return a single output.
+            If `outputs` is greater than one, this functions returns a tuple
+            of output `Node`, representing each output of the ONNX operator
+            in positional.
+    """
+    outputs = kwargs.pop('outputs', 1)
+
+    # Filter out None attributes, this can be convenient client side because
+    # now they can pass through None attributes, and have them not show up
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
+
+    def const_if_tensor(arg):
+        if arg is None:
+            return arg
+        elif isinstance(arg, torch._C.Value):
+            return arg
+        else:
+            return g.op("Constant", value_z=arg)
+
+    args = list(const_if_tensor(arg) for arg in raw_args)
+    n = g.appendNode(_newNode(g, opname, outputs, *args, **kwargs))
+    if outputs == 1:
+        return n.output()
+    return tuple(o for o in n.outputs())
 
 
 # Note [Export inplace]
@@ -247,7 +351,7 @@ def _run_symbolic_function(g, n, inputs, aten=False):
                 attrs = {k + "_" + n.kindOf(k)[0]: n[k] for k in n.attributeNames()}
                 outputs = n.outputsSize()
                 attrs["outputs"] = outputs
-                return g._graph_at(g, op_name, *inputs, aten=True, **attrs)
+                return _graph_at(g, op_name, *inputs, aten=True, **attrs)
 
             else:
                 # Export it regularly
@@ -282,3 +386,61 @@ def _run_symbolic_function(g, n, inputs, aten=False):
         # Otherwise, the backtrace will have the clues you need.
         e.args = ("{} (occurred when translating {})".format(e.args[0], op_name), )
         raise
+
+
+# Generate an ONNX ATen op node.
+def _graph_at(g, opname, *args, **kwargs):
+    return g.op("ATen", *args, operator_s=opname, **kwargs)
+
+
+# This helper function can create either constant tensor or constant scalar.
+# If dims is None or 0 or [0], generate a 0-d tensor (scalar).
+#
+# TODO: We might not need this anymore, since most scalars now show up
+# as tensors
+def _graph_constant(g, value, dims, type, *args, **kwargs):
+    assert isinstance(value, numbers.Number)
+    assert type is not None
+    isscalar = False
+    if dims is None or dims == 0 or set(dims) == set([0]):
+        dims = [1]
+        isscalar = True
+    type = type.lower()
+    if type == "char":
+        tensor = torch.CharTensor(*dims)
+    elif type == "short":
+        tensor = torch.ShortTensor(*dims)
+    elif type == "int":
+        tensor = torch.IntTensor(*dims)
+    elif type == "long":
+        tensor = torch.LongTensor(*dims)
+    elif type == "half":
+        tensor = torch.HalfTensor(*dims)
+    elif type == "float":
+        tensor = torch.FloatTensor(*dims)
+    elif type == "double":
+        tensor = torch.DoubleTensor(*dims)
+    else:
+        raise ValueError("Unknown type, type should be one of the following strings: "
+                         "char, short, int, long, half, float, double")
+    tensor.fill_(value)
+    if isscalar:
+        return g.op("Constant", *args, value_z=tensor, **kwargs)
+    return g.op("Constant", *args, value_t=tensor, **kwargs)
+
+
+def _node_getitem(self, k):
+    r"""
+    Accessor for attributes of a node which is polymorphic over
+    return type.
+
+    NB: This is monkey-patched onto Node.
+    """
+    sel = self.kindOf(k)
+    return getattr(self, sel)(k)
+
+
+torch._C.Graph.op = _graph_op
+torch._C.Graph.at = _graph_at
+torch._C.Graph.constant = _graph_constant
+torch._C.Node.__getitem__ = _node_getitem


### PR DESCRIPTION
Previously, the symbolics for these functions were specialized to ONNX only. This PR makes it so that they instead emit a PythonOp with an embedded reference to the ONNX symbolic. This allows the interpreter to run these as Python, while ONNX export still retains the information it needs to emit its placeholder operators