### PR TITLE
Turning off static linking of protobuf for setup.py

### DIFF
--- a/setup_caffe2.py
+++ b/setup_caffe2.py
@@ -137,6 +137,7 @@ class cmake_build(Caffe2Command):
                 '-DBUILD_TEST=OFF',
                 '-DBUILD_BENCHMARK=OFF',
                 '-DBUILD_BINARY=OFF',
+                '-DBUILD_CUSTOM_PROTOBUF=OFF',
             ]
             if NINJA:
                 cmake_args.extend(['-G', 'Ninja'])


### PR DESCRIPTION
This is a quick patch until the cmake files and/or setup.py themselves are changed to work together happily