### PR TITLE
[caffe2] Do not print version and build info unless explicitly requested

### DIFF
--- a/caffe2/core/init.cc
+++ b/caffe2/core/init.cc
@@ -31,7 +31,7 @@ bool GlobalInit(int* pargc, char*** pargv) {
   success &= ParseCaffeCommandLineFlags(pargc, pargv);
   success &= InitCaffeLogging(pargc, *pargv);
   // Print out the current build version. Using cerr as LOG(INFO) might be off
-  if (VLOG_IS_ON(1) || FLAGS_caffe2_version) {
+  if (FLAGS_caffe2_version) {
     std::cerr << "Caffe2 build configuration: " << std::endl;
     for (const auto& it : GetBuildOptions()) {
       std::cerr << "  " << std::setw(25) << std::left << it.first << " : "


### PR DESCRIPTION
All Caffe2-enabled binaries print very verbose version information on initialization. This fix disables it, unless explicitly requested via command-line flag.