### PR TITLE
[pytorch] minor fixes around binary builds

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -126,10 +126,6 @@ endfunction()
 IF ($ENV{TH_BINARY_BUILD})
   MESSAGE(STATUS "TH_BINARY_BUILD detected. Statically linking libstdc++")
   SET(CMAKE_CXX_FLAGS "-static-libstdc++ ${CMAKE_CXX_FLAGS}")
-  IF (UNIX AND NOT APPLE)
-    # hiding statically linked library symbols, this flag is not available for the linker under macOS
-    SET(CMAKE_CXX_FLAGS "-Wl,--exclude-libs,libstdc++.a ${CMAKE_CXX_FLAGS}")
-  ENDIF(UNIX AND NOT APPLE)
 ENDIF()
 
 # Can be compiled standalone

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -1,6 +1,7 @@
 import torch.cuda
 from setuptools import setup
 from torch.utils.cpp_extension import CppExtension, CUDAExtension
+from torch.utils.cpp_extension import CUDA_HOME
 
 ext_modules = [
     CppExtension(
@@ -8,7 +9,7 @@ ext_modules = [
         extra_compile_args=['-g']),
 ]
 
-if torch.cuda.is_available():
+if torch.cuda.is_available() and CUDA_HOME is not None:
     extension = CUDAExtension(
         'torch_test_cuda_extension', [
             'cuda_extension.cpp',

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -11,7 +11,8 @@ except ModuleNotFoundError:
 
 import common
 
-TEST_CUDA = torch.cuda.is_available()
+from torch.utils.cpp_extension import CUDA_HOME
+TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
 
 
 class TestCppExtension(common.TestCase):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -397,7 +397,7 @@ def demangle(name):
             orig_name = subprocess.check_output(filt_cmd, stderr=devnull).rstrip().decode("ascii")
             orig_name = re.search('is :- \"(.*)"', orig_name).group(1) if is_win else orig_name
             return orig_name
-    except (subprocess.CalledProcessError, AttributeError, FileNotFoundError):
+    except (subprocess.CalledProcessError, AttributeError, FileNotFoundError, OSError):
         return name
 
 


### PR DESCRIPTION
- Check for OSError exception when c++filt is not found
- when adding CUDA paths to cpp_extensions tests, make sure CUDA development bits are present, not just that `torch.cuda.is_available` (which will be provided by binaries)
- remove patch around hiding static libstdc++.a symbols in ATen under TH_BINARY_BUILD setting