### PR TITLE
Modify cmake dedent function to make it compatible with Windows.

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -164,11 +164,10 @@ function(dedent outvar text)
     set(_python_exe "${PYTHON_EXECUTABLE}")
   endif()
   set(_fixup_cmd "import sys; from textwrap import dedent; print(dedent(sys.stdin.read()))")
-  # Use echo to pipe the text to python's stdinput. This prevents us from
-  # needing to worry about any sort of special escaping.
+  file(WRITE "${CMAKE_BINARY_DIR}/indented.txt" "${text}")
   execute_process(
-    COMMAND echo "${text}"
     COMMAND "${_python_exe}" -c "${_fixup_cmd}"
+    INPUT_FILE "${CMAKE_BINARY_DIR}/indented.txt"
     RESULT_VARIABLE _dedent_exitcode
     OUTPUT_VARIABLE _dedent_text)
   if(NOT ${_dedent_exitcode} EQUAL 0)


### PR DESCRIPTION
The original CMake script pipeline a piece of python code and run dedent in python interpreter. This would fail on Windows because `COMMAND echo "${text}"` would fail (there is no echo.exe on Windows).

This patch change this process into separated steps. First we write the content of `${text}` into a file `indented.txt` under CMake binary folder. And then use the file as stdin to python interpreter.