### PR TITLE
[JIT] Hacky: Staged symbolics for RNN nodes

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2355,7 +2355,7 @@ class TestScript(TestCase):
             m = M2()
             m(torch.zeros(4, 3))
 
-    def test_rnn_trace_override(self):
+    def test_pack_padded_pad_packed_trace(self):
         from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
         T, B, C = 3, 5, 7
 
@@ -2429,6 +2429,44 @@ class TestScript(TestCase):
             def foo(a):
                 b, c = torch.chunk(a, dim=0, chunks=3)
                 return b
+
+    def test_rnn_trace_override(self):
+        from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+        T, B, C = 3, 5, 7
+
+        class RNNTraceWrapper(torch.nn.Module):
+            def __init__(self):
+                super(RNNTraceWrapper, self).__init__()
+                self.rnn = torch.nn.LSTM(input_size=C, hidden_size=C, num_layers=5)
+
+            def forward(self, x, seq_lens):
+                x = pack_padded_sequence(x, seq_lens)
+                x, _ = self.rnn(x)
+                x, _ = pad_packed_sequence(x)
+                return x
+
+        x = torch.ones(T, B, C, requires_grad=True)
+        seq_lens = torch.from_numpy(np.array([3, 3, 2, 2, 1], dtype=np.int32))
+
+        m = RNNTraceWrapper()
+        m_traced = torch.jit.trace(x, seq_lens)(m)
+
+        y = m(x, seq_lens)
+        loss = torch.sum(y)
+        loss.backward()
+        grad = x.grad.clone()
+        x.grad.zero_()
+
+        y_traced = m_traced(x, seq_lens)
+        loss_traced = torch.sum(y_traced)
+        loss_traced.backward()
+        grad_traced = x.grad.clone()
+
+        self.assertEqual(y_traced, y)
+        self.assertEqual(grad, grad_traced)
+
+        f = io.BytesIO()
+        torch.onnx._export(m, (x, seq_lens), f, verbose=False)
 
 
 # Smoke tests for export methods

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -4,7 +4,7 @@ import torch.backends.cudnn as cudnn
 from .. import functional as F
 from .thnn import rnnFusedPointwise as fusedBackend
 import itertools
-from collections import Iterable
+from functools import partial
 
 try:
     import torch.backends.cudnn.rnn
@@ -314,65 +314,10 @@ def RNN(*args, **kwargs):
             sym = torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)
             cell_type = args[0]
 
-            def rnn_trace_override_symbolic(g, input, weights, hiddens, batch_sizes):
-                num_layers = len(weights)
-                num_weights = 0
-                for x in weights:
-                    num_weights += len(x)
-                weights_per_layer = num_weights // num_layers
-                has_batch_sizes = batch_sizes is not None
+            bound_symbolic = partial(torch.onnx.symbolic.rnn_trace_override_symbolic,
+                                     cell_type, func, sym)
 
-                def forward_flattened_wrapper(input, *args):
-                    args_offset = 0
-                    weights = []
-                    for _ in range(num_layers):
-                        weights.append(args[args_offset:args_offset + weights_per_layer])
-                        args_offset += weights_per_layer
-                    if has_batch_sizes:
-                        hiddens = args[args_offset:-1]
-                        batch_sizes = args[-1]
-                    else:
-                        hiddens = args[args_offset:]
-                        batch_sizes = None
-                    outputs = func(input, weights, hiddens, batch_sizes)
-                    outs_flattened = [outputs[0]]
-                    for o in outputs[1]:
-                        outs_flattened.append(o)
-                    return tuple(outs_flattened)
-
-                def symbolic_flattened_wrapper(g, input, *args):
-                    args_offset = 0
-                    weights = []
-                    for _ in range(num_layers):
-                        weights.append(args[args_offset:args_offset + weights_per_layer])
-                        args_offset += weights_per_layer
-                    if has_batch_sizes:
-                        hiddens = args[args_offset:-1]
-                        hiddens = hiddens[0] if len(hiddens) == 1 else list(hiddens)
-                        batch_sizes = args[-1]
-                    else:
-                        hiddens = args[args_offset:]
-                        hiddens = hiddens[0] if len(hiddens) == 1 else list(hiddens)
-                        batch_sizes = None
-                    return sym(g, input, weights, hiddens, batch_sizes)
-                flattened_weights = []
-                for x in weights:
-                    for y in x:
-                        flattened_weights.append(y)
-                if not isinstance(hiddens, Iterable):
-                    hiddens = [hiddens]
-                inputs = list(itertools.chain.from_iterable(
-                    [[input], flattened_weights, hiddens,
-                        [batch_sizes] if batch_sizes else []]))
-                outputs = g.wrapPyFuncWithSymbolic(
-                    forward_flattened_wrapper,
-                    inputs,
-                    3 if cell_type == 'LSTM' else 2,
-                    symbolic_flattened_wrapper
-                )
-                return tuple(o for o in outputs)
-            decorator = torch.onnx.symbolic_override_first_arg_based(
-                rnn_trace_override_symbolic)
+            decorator = torch.onnx.symbolic_override_first_arg_based(bound_symbolic)
             func = decorator(func)
 
         return func(input, *fargs, **fkwargs)

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -4,6 +4,7 @@ import torch.backends.cudnn as cudnn
 from .. import functional as F
 from .thnn import rnnFusedPointwise as fusedBackend
 import itertools
+from collections import Iterable
 
 try:
     import torch.backends.cudnn.rnn
@@ -310,8 +311,68 @@ def RNN(*args, **kwargs):
         import torch
         if torch._C._jit_is_tracing(input):
             import torch.onnx.symbolic
+            sym = torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs)
+            cell_type = args[0]
+
+            def rnn_trace_override_symbolic(g, input, weights, hiddens, batch_sizes):
+                num_layers = len(weights)
+                num_weights = 0
+                for x in weights:
+                    num_weights += len(x)
+                weights_per_layer = num_weights // num_layers
+                has_batch_sizes = batch_sizes is not None
+
+                def forward_flattened_wrapper(input, *args):
+                    args_offset = 0
+                    weights = []
+                    for _ in range(num_layers):
+                        weights.append(args[args_offset:args_offset + weights_per_layer])
+                        args_offset += weights_per_layer
+                    if has_batch_sizes:
+                        hiddens = args[args_offset:-1]
+                        batch_sizes = args[-1]
+                    else:
+                        hiddens = args[args_offset:]
+                        batch_sizes = None
+                    outputs = func(input, weights, hiddens, batch_sizes)
+                    outs_flattened = [outputs[0]]
+                    for o in outputs[1]:
+                        outs_flattened.append(o)
+                    return tuple(outs_flattened)
+
+                def symbolic_flattened_wrapper(g, input, *args):
+                    args_offset = 0
+                    weights = []
+                    for _ in range(num_layers):
+                        weights.append(args[args_offset:args_offset + weights_per_layer])
+                        args_offset += weights_per_layer
+                    if has_batch_sizes:
+                        hiddens = args[args_offset:-1]
+                        hiddens = hiddens[0] if len(hiddens) == 1 else list(hiddens)
+                        batch_sizes = args[-1]
+                    else:
+                        hiddens = args[args_offset:]
+                        hiddens = hiddens[0] if len(hiddens) == 1 else list(hiddens)
+                        batch_sizes = None
+                    return sym(g, input, weights, hiddens, batch_sizes)
+                flattened_weights = []
+                for x in weights:
+                    for y in x:
+                        flattened_weights.append(y)
+                if not isinstance(hiddens, Iterable):
+                    hiddens = [hiddens]
+                inputs = list(itertools.chain.from_iterable(
+                    [[input], flattened_weights, hiddens,
+                        [batch_sizes] if batch_sizes else []]))
+                outputs = g.wrapPyFuncWithSymbolic(
+                    forward_flattened_wrapper,
+                    inputs,
+                    3 if cell_type == 'LSTM' else 2,
+                    symbolic_flattened_wrapper
+                )
+                return tuple(o for o in outputs)
             decorator = torch.onnx.symbolic_override_first_arg_based(
-                torch.onnx.symbolic.RNN_symbolic_builder(*args, **kwargs))
+                rnn_trace_override_symbolic)
             func = decorator(func)
 
         return func(input, *fargs, **fkwargs)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -6,6 +6,9 @@ from torch.nn.utils.rnn import PackedSequence
 import warnings
 
 import torch.onnx
+# This import monkey-patches graph manipulation methods on Graph, used for the
+# ONNX symbolics
+import torch.onnx.utils
 
 from functools import partial
 


### PR DESCRIPTION
Stacked on top of https://github.com/pytorch/pytorch/pull/6256

Similarly to that PR, this PR makes it so that RNN nodes (e.g. LSTM) lower into a PythonOp with an associated `symbolic` attribute containing the ONNX symbolic for later export.

This PR brings up a few issues: 

* The RNN functions take in and return (nested) tuples and lists of Tensors. In order to actually run the Python implementation given the flattened argument list presented by the JIT, I have to wrap the RNN functions in another function that rematerializes those Python data structures. This is hacky but it works
* Eventually we're probably going to want to convert the RNN modules into `ScriptModule`s so that we can optimize them with the rest of the graph.