### PR TITLE
[caffe2] Refactor Predictor to support CUDA

### DIFF
--- a/binaries/predictor_verifier.cc
+++ b/binaries/predictor_verifier.cc
@@ -40,10 +40,11 @@ void run() {
   // Can be large due to constant fills
   VLOG(1) << "Init net: " << ProtoDebugString(init_net);
   LOG(INFO) << "Predict net: " << ProtoDebugString(predict_net);
-  auto predictor = caffe2::make_unique<Predictor>(init_net, predict_net);
+  auto predictor = std::move(PredictorRegistry()->Create("CPU", init_net, predict_net));
   LOG(INFO) << "Checking that a null forward-pass works";
-  Predictor::TensorVector inputVec, outputVec;
-  predictor->run(inputVec, &outputVec);
+  PredictorBase::TensorVector inputVec;
+  PredictorBase::OutputTensorVector outputVec;
+  predictor->run(inputVec, outputVec);
   CAFFE_ENFORCE_GT(outputVec.size(), 0);
 }
 }

--- a/binaries/predictor_verifier.cc
+++ b/binaries/predictor_verifier.cc
@@ -44,7 +44,7 @@ void run() {
   LOG(INFO) << "Checking that a null forward-pass works";
   PredictorBase::TensorVector inputVec;
   PredictorBase::OutputTensorVector outputVec;
-  predictor->run(inputVec, outputVec);
+  predictor->run(inputVec, &outputVec);
   CAFFE_ENFORCE_GT(outputVec.size(), 0);
 }
 }

--- a/binaries/predictor_verifier.cc
+++ b/binaries/predictor_verifier.cc
@@ -40,7 +40,7 @@ void run() {
   // Can be large due to constant fills
   VLOG(1) << "Init net: " << ProtoDebugString(init_net);
   LOG(INFO) << "Predict net: " << ProtoDebugString(predict_net);
-  auto predictor = std::move(PredictorRegistry()->Create("CPU", init_net, predict_net));
+  auto predictor = std::move(PredictorRegistry()->Create("CPU", init_net, predict_net, nullptr));
   LOG(INFO) << "Checking that a null forward-pass works";
   PredictorBase::TensorVector inputVec;
   PredictorBase::OutputTensorVector outputVec;

--- a/binaries/predictor_verifier.cc
+++ b/binaries/predictor_verifier.cc
@@ -40,7 +40,7 @@ void run() {
   // Can be large due to constant fills
   VLOG(1) << "Init net: " << ProtoDebugString(init_net);
   LOG(INFO) << "Predict net: " << ProtoDebugString(predict_net);
-  auto predictor = std::move(PredictorRegistry()->Create("CPU", init_net, predict_net, nullptr));
+  auto predictor = PredictorRegistry()->Create("CPU", init_net, predict_net, nullptr);
   LOG(INFO) << "Checking that a null forward-pass works";
   PredictorBase::TensorVector inputVec;
   PredictorBase::OutputTensorVector outputVec;

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -83,6 +83,12 @@ PredictorBase::PredictorBase(
   const auto& initialized_vec = ws_.Blobs();
   initialized_ = std::unordered_set<std::string>{initialized_vec.begin(),
                                                  initialized_vec.end()};
+  for (const auto& name : run_net.external_input()) {
+    if (!initialized_.count(name)) {
+      auto* blob = ws_.CreateBlob(name);
+    }
+  }
+  CAFFE_ENFORCE(ws_.CreateNet(run_net));
 }
 
 PredictorBase::~PredictorBase() {}

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -88,63 +88,24 @@ PredictorBase::PredictorBase(
 PredictorBase::~PredictorBase() {}
 
 template <>
-bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe) {
+bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector* outputs) {
   if (!inputNames_.empty()) {
     CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
   }
-  if (!threadsafe) {
-    // If threadsafe is false, we run the net in the contained workspace of the predictor
-    for (auto &input : inputs) {
-      if (!inputNames_.empty()) {
-        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
-      }
-      predictor_details::ShareInputTensor(&ws_, input.first, input.second);
+  for (auto &input : inputs) {
+    if (!inputNames_.empty()) {
+      CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
     }
+    predictor_details::ShareInputTensor(&ws_, input.first, input.second);
+  }
 
-    if (!ws_.RunNet(run_net_.name())) {
-      return false;
-    }
+  if (!ws_.RunNet(run_net_.name())) {
+    return false;
+  }
 
-    outputs->resize(run_net_.external_output_size());
-    for (auto i = 0; i < outputs->size(); ++i) {
-      (*outputs)[i] = predictor_details::ExtractOutputTensor(&ws_, run_net_.external_output(i));
-    }
-  } else {
-    // If threadsafe is true, we create a temporary new workspace and load the network to the new workspace
-
-    // Instead of running the init_net in the new workspace
-    // We directly forward these blobs from ws_ for efficiency.
-    // Note: RNN might have problem doing this way.
-    std::unordered_map<std::string, std::string> forwarded_blobs;
-    for (auto &input : initialized_) {
-      forwarded_blobs.emplace(input, input);
-    }
-    Workspace ws(&ws_, forwarded_blobs);
-
-    // For each input, create a local blob without touching ws_.
-    // This will override the mapped blob from ws_.
-    for (auto &input: inputs) {
-      if (!inputNames_.empty()) {
-        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
-      }
-      auto *blob = ws.CreateLocalBlob(input.first);
-      CAFFE_ENFORCE(blob, "Blob: ", input.first, " does not exist");
-      blob->template GetMutable<TensorCPU>();
-      predictor_details::ShareInputTensor(&ws, input.first, input.second);
-    }
-
-    if (!ws.RunNetOnce(run_net_)) {
-      return false;
-    }
-
-    outputs->resize(run_net_.external_output_size());
-    for (auto i = 0; i < outputs->size(); ++i) {
-      auto name = run_net_.external_output(i);
-      auto *blob = ws.GetBlob(name);
-      CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
-      (*outputs)[i] = std::make_shared<TensorCPU>();
-      (*outputs)[i]->CopyFrom(*blob->template GetMutable<TensorCPU>(), context_.get());
-    }
+  outputs->resize(run_net_.external_output_size());
+  for (auto i = 0; i < outputs->size(); ++i) {
+    (*outputs)[i] = predictor_details::ExtractOutputTensor(&ws_, run_net_.external_output(i));
   }
   return true;
 }

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -1,36 +1,18 @@
 #include "caffe2/core/predictor.h"
 
-#include <unordered_set>
+#include <unordered_map>
 
 namespace caffe2 {
 
-namespace {
+CAFFE_DEFINE_REGISTRY(
+  PredictorRegistry,
+  PredictorBase,
+  const NetDef &,
+  const NetDef &,
+  Workspace *);
 
-void enforceIsTensor(Workspace* ws, const std::string& name) {
-  auto blob = ws->GetBlob(name);
-  CAFFE_ENFORCE(blob, "Blob does not exist: ", name);
-  CAFFE_ENFORCE(
-      blob->template IsType<TensorCPU>(), "Blob is not a CPU Tensor: ", name);
-}
 
-void shareInputTensor(
-    Workspace* ws,
-    const std::string& name,
-    TensorCPU* input) {
-  enforceIsTensor(ws, name);
-  auto* blob = ws->GetBlob(name);
-  CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
-  auto* tensor = blob->template GetMutable<TensorCPU>();
-  tensor->ResizeLike(*input);
-  tensor->ShareData(*input);
-}
-
-TensorCPU* extractOutputTensor(Workspace* ws, const std::string& name) {
-  enforceIsTensor(ws, name);
-  auto* blob = ws->GetBlob(name);
-  CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
-  return blob->template GetMutable<TensorCPU>();
-}
+namespace predictor_details {
 
 const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
   for (const auto& n : def.nets()) {
@@ -51,80 +33,121 @@ const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
   }
   CAFFE_THROW("Blob not found: ", name);
 }
-} // namespace
 
-Predictor::Predictor(const MetaNetDef& def, Workspace* parent)
-    : Predictor(
-          getNet(
+void shareInputTensor(
+    Workspace* ws,
+    const std::string& name,
+    TensorCPU* input) {
+  enforceIsTensor<TensorCPU>(ws, name);
+  auto* blob = ws->GetBlob(name);
+  CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+  auto* tensor = blob->template GetMutable<TensorCPU>();
+  tensor->ResizeLike(*input);
+  tensor->ShareData(*input);
+}
+
+std::shared_ptr<TensorCPU> extractOutputTensor(Workspace* ws, const std::string& name) {
+  enforceIsTensor<TensorCPU>(ws, name);
+  auto* blob = ws->GetBlob(name);
+  CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+
+  // Since the tensor is a member of blob, we should not delete the pointer.
+  // By given a customized deleter, the pointer won't be deleted on shared_ptr deconstruction.
+  return std::shared_ptr<TensorCPU>(blob->template GetMutable<TensorCPU>(), [](TensorCPU *){});
+}
+
+} // namespace predictor_details
+
+PredictorBase::PredictorBase(const MetaNetDef& def, Workspace* parent)
+  : PredictorBase(
+          predictor_details::getNet(
               def,
               PredictorConsts::default_instance().global_init_net_type()),
-          getNet(def, PredictorConsts::default_instance().predict_net_type()),
+          predictor_details::getNet(def, PredictorConsts::default_instance().predict_net_type()),
           parent) {
   const auto& inputs =
-      getBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
+      predictor_details::getBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
   for (const auto& input : inputs) {
     inputNames_.insert(input);
   }
 }
 
-Predictor::Predictor(
+PredictorBase::PredictorBase(
     const NetDef& init_net,
     const NetDef& run_net,
     Workspace* parent)
-    : run_net_(run_net), ws_(parent) {
+: run_net_(run_net), ws_(parent) {
   CAFFE_ENFORCE(ws_.RunNetOnce(init_net));
-
   // real model inputs can be fed later in run* functions
+
   const auto& initialized_vec = ws_.Blobs();
-  const std::unordered_set<std::string> initialized{initialized_vec.begin(),
-                                                    initialized_vec.end()};
-  for (const auto& name : run_net.external_input()) {
-    if (!initialized.count(name)) {
-      auto* blob = ws_.CreateBlob(name);
-      blob->template GetMutable<TensorCPU>();
-    }
-  }
-  CAFFE_ENFORCE(ws_.CreateNet(run_net));
+  initialized_ = std::unordered_set<std::string>{initialized_vec.begin(),
+                                                 initialized_vec.end()};
 }
 
-Predictor::~Predictor() {}
+PredictorBase::~PredictorBase() {}
 
-bool Predictor::run(const TensorVector& inputs, TensorVector* outputs) {
-  CAFFE_ENFORCE(inputs.size() <= run_net_.external_input_size());
-  for (auto i = 0; i < inputs.size(); ++i) {
-    shareInputTensor(&ws_, run_net_.external_input(i), inputs[i]);
-  }
-
-  if (!ws_.RunNet(run_net_.name())) {
-    return false;
-  }
-
-  outputs->resize(run_net_.external_output_size());
-  for (auto i = 0; i < outputs->size(); ++i) {
-    (*outputs)[i] = extractOutputTensor(&ws_, run_net_.external_output(i));
-  }
-  return true;
-}
-
-bool Predictor::run_map(const TensorMap& inputs, TensorVector* outputs) {
+template <>
+bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe) {
   if (!inputNames_.empty()) {
     CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
   }
-  for (auto input : inputs) {
-    if (!inputNames_.empty()) {
-      CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
+  if (!threadsafe) {
+    // If threadsafe is false, we run the net in the contained workspace of the predictor
+    for (auto &input : inputs) {
+      if (!inputNames_.empty()) {
+        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
+      }
+      predictor_details::shareInputTensor(&ws_, input.first, input.second);
     }
-    shareInputTensor(&ws_, input.first, input.second);
-  }
 
-  if (!ws_.RunNet(run_net_.name())) {
-    return false;
-  }
+    if (!ws_.RunNet(run_net_.name())) {
+      return false;
+    }
 
-  outputs->resize(run_net_.external_output_size());
-  for (auto i = 0; i < outputs->size(); ++i) {
-    (*outputs)[i] = extractOutputTensor(&ws_, run_net_.external_output(i));
+    outputs.resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs.size(); ++i) {
+      outputs[i] = predictor_details::extractOutputTensor(&ws_, run_net_.external_output(i));
+    }
+  } else {
+    // If threadsafe is true, we create a temporary new workspace and load the network to the new workspace
+
+    // Instead of running the init_net in the new workspace
+    // We directly forward these blobs from ws_ for efficiency.
+    // Note: RNN might have problem doing this way.
+    std::unordered_map<std::string, std::string> forwarded_blobs;
+    for (auto &input : initialized_) {
+      forwarded_blobs.emplace(input, input);
+    }
+    Workspace ws(&ws_, forwarded_blobs);
+
+    // For each input, create a local blob without touching ws_.
+    // This will override the mapped blob from ws_.
+    for (auto &input: inputs) {
+      if (!inputNames_.empty()) {
+        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
+      }
+      auto *blob = ws.CreateLocalBlob(input.first);
+      CAFFE_ENFORCE(blob, "Blob: ", input.first, " does not exist");
+      blob->template GetMutable<TensorCPU>();
+      predictor_details::shareInputTensor(&ws, input.first, input.second);
+    }
+
+    if (!ws.RunNetOnce(run_net_)) {
+      return false;
+    }
+
+    outputs.resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs.size(); ++i) {
+      auto name = run_net_.external_output(i);
+      auto *blob = ws.GetBlob(name);
+      CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+      outputs[i] = std::make_shared<TensorCPU>();
+      outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>(), context_.get());
+    }
   }
   return true;
 }
+
+CAFFE_REGISTER_PREDICTOR(CPU, Predictor<CPUContext>);
 } // namespace caffe2

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -14,7 +14,7 @@ CAFFE_DEFINE_REGISTRY(
 
 namespace predictor_details {
 
-const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
+const NetDef& GetNet(const MetaNetDef& def, const std::string& name) {
   for (const auto& n : def.nets()) {
     if (n.key() == name) {
       return n.value();
@@ -23,7 +23,7 @@ const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
   CAFFE_THROW("Net not found: ", name);
 }
 
-const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
+const ::google::protobuf::RepeatedPtrField<::std::string>& GetBlobs(
     const MetaNetDef& def,
     const std::string& name) {
   for (const auto& b : def.blobs()) {
@@ -34,7 +34,7 @@ const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
   CAFFE_THROW("Blob not found: ", name);
 }
 
-void shareInputTensor(
+void ShareInputTensor(
     Workspace* ws,
     const std::string& name,
     TensorCPU* input) {
@@ -46,7 +46,7 @@ void shareInputTensor(
   tensor->ShareData(*input);
 }
 
-std::shared_ptr<TensorCPU> extractOutputTensor(Workspace* ws, const std::string& name) {
+std::shared_ptr<TensorCPU> ExtractOutputTensor(Workspace* ws, const std::string& name) {
   enforceIsTensor<TensorCPU>(ws, name);
   auto* blob = ws->GetBlob(name);
   CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
@@ -60,13 +60,13 @@ std::shared_ptr<TensorCPU> extractOutputTensor(Workspace* ws, const std::string&
 
 PredictorBase::PredictorBase(const MetaNetDef& def, Workspace* parent)
   : PredictorBase(
-          predictor_details::getNet(
+          predictor_details::GetNet(
               def,
               PredictorConsts::default_instance().global_init_net_type()),
-          predictor_details::getNet(def, PredictorConsts::default_instance().predict_net_type()),
+          predictor_details::GetNet(def, PredictorConsts::default_instance().predict_net_type()),
           parent) {
   const auto& inputs =
-      predictor_details::getBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
+      predictor_details::GetBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
   for (const auto& input : inputs) {
     inputNames_.insert(input);
   }
@@ -83,18 +83,12 @@ PredictorBase::PredictorBase(
   const auto& initialized_vec = ws_.Blobs();
   initialized_ = std::unordered_set<std::string>{initialized_vec.begin(),
                                                  initialized_vec.end()};
-  for (const auto& name : run_net.external_input()) {
-    if (!initialized_.count(name)) {
-      auto* blob = ws_.CreateBlob(name);
-    }
-  }
-  CAFFE_ENFORCE(ws_.CreateNet(run_net));
 }
 
 PredictorBase::~PredictorBase() {}
 
 template <>
-bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe) {
+bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe) {
   if (!inputNames_.empty()) {
     CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
   }
@@ -104,16 +98,16 @@ bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector&
       if (!inputNames_.empty()) {
         CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
       }
-      predictor_details::shareInputTensor(&ws_, input.first, input.second);
+      predictor_details::ShareInputTensor(&ws_, input.first, input.second);
     }
 
     if (!ws_.RunNet(run_net_.name())) {
       return false;
     }
 
-    outputs.resize(run_net_.external_output_size());
-    for (auto i = 0; i < outputs.size(); ++i) {
-      outputs[i] = predictor_details::extractOutputTensor(&ws_, run_net_.external_output(i));
+    outputs->resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs->size(); ++i) {
+      (*outputs)[i] = predictor_details::ExtractOutputTensor(&ws_, run_net_.external_output(i));
     }
   } else {
     // If threadsafe is true, we create a temporary new workspace and load the network to the new workspace
@@ -136,20 +130,20 @@ bool Predictor<CPUContext>::run_map(const TensorMap& inputs, OutputTensorVector&
       auto *blob = ws.CreateLocalBlob(input.first);
       CAFFE_ENFORCE(blob, "Blob: ", input.first, " does not exist");
       blob->template GetMutable<TensorCPU>();
-      predictor_details::shareInputTensor(&ws, input.first, input.second);
+      predictor_details::ShareInputTensor(&ws, input.first, input.second);
     }
 
     if (!ws.RunNetOnce(run_net_)) {
       return false;
     }
 
-    outputs.resize(run_net_.external_output_size());
-    for (auto i = 0; i < outputs.size(); ++i) {
+    outputs->resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs->size(); ++i) {
       auto name = run_net_.external_output(i);
       auto *blob = ws.GetBlob(name);
       CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
-      outputs[i] = std::make_shared<TensorCPU>();
-      outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>(), context_.get());
+      (*outputs)[i] = std::make_shared<TensorCPU>();
+      (*outputs)[i]->CopyFrom(*blob->template GetMutable<TensorCPU>(), context_.get());
     }
   }
   return true;

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -8,22 +8,55 @@
 
 namespace caffe2 {
 
-class Predictor {
+class PredictorBase;
+
+CAFFE_DECLARE_REGISTRY(
+  PredictorRegistry,
+  PredictorBase,
+  const NetDef &,
+  const NetDef &,
+  Workspace *);
+
+#define CAFFE_REGISTER_PREDICTOR(key, clsname) \
+  CAFFE_REGISTER_CLASS(PredictorRegistry, key, clsname)
+
+#define USE_PREDICTOR_CONTEXT_FUNCTIONS \
+  using TensorVector = PredictorBase::TensorVector; \
+  using TensorMap = PredictorBase::TensorMap; \
+  using OutputTensorVector = PredictorBase::OutputTensorVector
+
+namespace predictor_details {
+
+const NetDef& getNet(const MetaNetDef& def, const std::string& name);
+
+template <class TensorType>
+void enforceIsTensor(Workspace* ws, const std::string& name) {
+  auto blob = ws->GetBlob(name);
+  CAFFE_ENFORCE(blob, "Blob does not exist: ", name);
+  CAFFE_ENFORCE(
+      blob->template IsType<TensorType>(), "Blob is not a Tensor of the required type ", name);
+}
+
+} // namespace predictor_details
+
+class PredictorBase {
  public:
   using TensorVector = std::vector<TensorCPU*>;
   using TensorMap = std::unordered_map<std::string, TensorCPU*>;
+  using OutputTensorVector = std::vector<std::shared_ptr<TensorCPU>>;
 
   // MetaNetDef contains 'init_net', 'run_net', and meta-info
   // The meta-info is used to verify inputs are correctly passed
-  Predictor(const MetaNetDef& net, Workspace* parent = nullptr);
+  PredictorBase(const MetaNetDef& net, Workspace* parent = nullptr);
 
   // Runs the `init_net` once, then saves the `run_net` to be executed
   // in `::run`
-  Predictor(
+  PredictorBase(
       const NetDef& init_net,
       const NetDef& run_net,
       Workspace* parent = nullptr);
-  ~Predictor();
+
+  ~PredictorBase();
 
   // Executes `run_net` on the inputs.
   // The first `inputs.size()` inputs from run_net::external_inputs
@@ -36,10 +69,10 @@ class Predictor {
   //   outputs->size() == run_net.external_inputs.size()
 
   // Returns true on success
-  bool run(const TensorVector& inputs, TensorVector* outputs);
+  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool mulithread) = 0;
 
   // Similar to run, but consumes a map of name to tensor as input
-  bool run_map(const TensorMap& inputs, TensorVector* outputs);
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool mulithread) = 0;
 
   const NetDef& def() const {
     return run_net_;
@@ -49,9 +82,62 @@ class Predictor {
     return &ws_;
   };
 
- private:
+ protected:
+  std::unordered_set<std::string> initialized_;
   NetDef run_net_;
   Workspace ws_;
   std::unordered_set<std::string> inputNames_;
 };
+
+template <class Context>
+class Predictor : public PredictorBase {
+ public:
+  USE_PREDICTOR_CONTEXT_FUNCTIONS;
+
+  Predictor(const MetaNetDef& def, Workspace* parent = nullptr)
+  : Predictor(
+      predictor_details::getNet(def, PredictorConsts::default_instance().global_init_net_type()),
+      predictor_details::getNet(def, PredictorConsts::default_instance().predict_net_type()),
+      parent) {
+    const auto& inputs =
+        predictor_details::getBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
+    for (const auto& input : inputs) {
+      inputNames_.insert(input);
+    }
+  }
+
+  Predictor(
+      const NetDef& init_net,
+      const NetDef& run_net,
+      Workspace* parent = nullptr)
+    : PredictorBase(init_net, run_net, parent)
+  {
+    context_ = std::make_shared<Context>(run_net.device_option());
+    for (const auto& name : run_net.external_input()) {
+      if (!initialized_.count(name)) {
+        auto* blob = ws_.CreateBlob(name);
+        CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+        blob->template GetMutable<Tensor<Context>>();
+      }
+    }
+    CAFFE_ENFORCE(ws_.CreateNet(run_net));
+  }
+
+  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false) override;
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe = false) override;
+
+ private:
+  std::shared_ptr<Context> context_;
+};
+
+template <class Context>
+bool Predictor<Context>::run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe) {
+  TensorMap input_map;
+  CAFFE_ENFORCE(inputs.size() <= run_net_.external_input_size());
+  for (auto i = 0; i < inputs.size(); ++i) {
+    input_map.emplace(run_net_.external_input(i), inputs[i]);
+  }
+
+  return run_map(input_map, outputs);
+}
 }

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -28,6 +28,7 @@ CAFFE_DECLARE_REGISTRY(
 namespace predictor_details {
 
 const NetDef& getNet(const MetaNetDef& def, const std::string& name);
+const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(const MetaNetDef& def, const std::string& name);
 
 template <class TensorType>
 void enforceIsTensor(Workspace* ws, const std::string& name) {

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -70,10 +70,10 @@ class PredictorBase {
   //   outputs->size() == run_net.external_inputs.size()
 
   // Returns true on success
-  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool mulithread) = 0;
+  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool mulithread = false) = 0;
 
   // Similar to run, but consumes a map of name to tensor as input
-  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool mulithread) = 0;
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool mulithread = false) = 0;
 
   const NetDef& def() const {
     return run_net_;

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -70,10 +70,10 @@ class PredictorBase {
   //   outputs->size() == run_net.external_inputs.size()
 
   // Returns true on success
-  virtual bool run(const TensorVector& inputs, OutputTensorVector* outputs, bool mulithread = false) = 0;
+  virtual bool run(const TensorVector& inputs, OutputTensorVector* outputs) = 0;
 
   // Similar to run, but consumes a map of name to tensor as input
-  virtual bool run_map(const TensorMap& inputs, OutputTensorVector* outputs, bool mulithread = false) = 0;
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector* outputs) = 0;
 
   const NetDef& def() const {
     return run_net_;
@@ -124,15 +124,15 @@ class Predictor : public PredictorBase {
     CAFFE_ENFORCE(ws_.CreateNet(run_net));
   }
 
-  virtual bool run(const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe = false) override;
-  virtual bool run_map(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe = false) override;
+  virtual bool run(const TensorVector& inputs, OutputTensorVector* outputs) override;
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector* outputs) override;
 
  private:
   std::shared_ptr<Context> context_;
 };
 
 template <class Context>
-bool Predictor<Context>::run(const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe) {
+bool Predictor<Context>::run(const TensorVector& inputs, OutputTensorVector* outputs) {
   TensorMap input_map;
   CAFFE_ENFORCE(inputs.size() <= run_net_.external_input_size());
   for (auto i = 0; i < inputs.size(); ++i) {

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -116,12 +116,11 @@ class Predictor : public PredictorBase {
     context_ = std::make_shared<Context>(run_net.device_option());
     for (const auto& name : run_net.external_input()) {
       if (!initialized_.count(name)) {
-        auto* blob = ws_.CreateBlob(name);
+        auto* blob = ws_.GetBlob(name);
         CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
         blob->template GetMutable<Tensor<Context>>();
       }
     }
-    CAFFE_ENFORCE(ws_.CreateNet(run_net));
   }
 
   virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false) override;

--- a/caffe2/core/predictor_gpu.cc
+++ b/caffe2/core/predictor_gpu.cc
@@ -33,59 +33,24 @@ std::shared_ptr<TensorCPU> CopyOutputTensor(
 } // namespace predictor_details
 
 template <>
-bool Predictor<CUDAContext>::run_map(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe) {
+bool Predictor<CUDAContext>::run_map(const TensorMap& inputs, OutputTensorVector* outputs) {
   if (!inputNames_.empty()) {
     CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
   }
-  if (!threadsafe) {
-    // If threadsafe is false, we run the net in the contained workspace of the predictor
-    for (auto &input: inputs) {
-      if (!inputNames_.empty()) {
-        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
-      }
-      predictor_details::CopyInputTensor(&ws_, input.first, input.second, context_.get());
+  for (auto &input: inputs) {
+    if (!inputNames_.empty()) {
+      CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
     }
+    predictor_details::CopyInputTensor(&ws_, input.first, input.second, context_.get());
+  }
 
-    if (!ws_.RunNet(run_net_.name())) {
-      return false;
-    }
+  if (!ws_.RunNet(run_net_.name())) {
+    return false;
+  }
 
-    outputs->resize(run_net_.external_output_size());
-    for (auto i = 0; i < outputs->size(); ++i) {
-      (*outputs)[i] = predictor_details::CopyOutputTensor(&ws_, run_net_.external_output(i), context_.get());
-    }
-  } else {
-    // If threadsafe is true, we create a temporary new workspace and load the network to the new workspace
-
-    // Instead of running the init_net in the new workspace
-    // We directly forward these blobs from ws_ for efficiency.
-    // Note: RNN might have problem doing this way.
-    std::unordered_map<std::string, std::string> forwarded_blobs;
-    for (auto &input : initialized_) {
-      forwarded_blobs.emplace(input, input);
-    }
-    Workspace ws(&ws_, forwarded_blobs);
-
-    // For each input, create a local blob without touching ws_.
-    // This will override the mapped blob from ws_.
-    for (auto &input: inputs) {
-      if (!inputNames_.empty()) {
-        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
-      }
-      auto *blob = ws.CreateLocalBlob(input.first);
-      CAFFE_ENFORCE(blob, "Blob: ", input.first, " does not exist");
-      blob->template GetMutable<TensorCUDA>();
-      predictor_details::CopyInputTensor(&ws, input.first, input.second, context_.get());
-    }
-
-    if (!ws.RunNetOnce(run_net_)) {
-      return false;
-    }
-
-    (*outputs).resize(run_net_.external_output_size());
-    for (auto i = 0; i < (*outputs).size(); ++i) {
-      (*outputs)[i] = predictor_details::CopyOutputTensor(&ws, run_net_.external_output(i), context_.get());
-    }
+  outputs->resize(run_net_.external_output_size());
+  for (auto i = 0; i < outputs->size(); ++i) {
+    (*outputs)[i] = predictor_details::CopyOutputTensor(&ws_, run_net_.external_output(i), context_.get());
   }
   context_->FinishDeviceComputation();
   return true;

--- a/caffe2/core/predictor_gpu.cc
+++ b/caffe2/core/predictor_gpu.cc
@@ -1,0 +1,101 @@
+#include "caffe2/core/predictor.h"
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+
+namespace predictor_details {
+
+std::shared_ptr<TensorCPU> copyOutputTensor(
+    Workspace* ws,
+    const std::string& name,
+    CUDAContext *context);
+
+void copyInputTensor(
+    Workspace* ws,
+    const std::string& name,
+    TensorCPU* input,
+    CUDAContext *context) {
+  enforceIsTensor<TensorCUDA>(ws, name);
+  auto* blob = ws->GetBlob(name);
+  CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+  auto* tensor = blob->template GetMutable<TensorCUDA>();
+  tensor->CopyFrom(*input, context);
+}
+
+std::shared_ptr<TensorCPU> copyOutputTensor(
+    Workspace* ws,
+    const std::string& name,
+    CUDAContext *context) {
+  enforceIsTensor<TensorCUDA>(ws, name);
+  auto* blob = ws->GetBlob(name);
+  std::shared_ptr<TensorCPU> tensor = std::make_shared<TensorCPU>(
+    *blob->template GetMutable<TensorCUDA>(),
+    context
+  );
+  return tensor;
+}
+
+} // namespace predictor_details
+
+template <>
+bool Predictor<CUDAContext>::run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe) {
+  if (!inputNames_.empty()) {
+    CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
+  }
+  if (!threadsafe) {
+    // If threadsafe is false, we run the net in the contained workspace of the predictor
+    for (auto &input: inputs) {
+      if (!inputNames_.empty()) {
+        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
+      }
+      predictor_details::copyInputTensor(&ws_, input.first, input.second, context_.get());
+    }
+
+    if (!ws_.RunNet(run_net_.name())) {
+      return false;
+    }
+
+    outputs.resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs.size(); ++i) {
+      outputs[i] = predictor_details::copyOutputTensor(&ws_, run_net_.external_output(i), context_.get());
+    }
+  } else {
+    // If threadsafe is true, we create a temporary new workspace and load the network to the new workspace
+
+    // Instead of running the init_net in the new workspace
+    // We directly forward these blobs from ws_ for efficiency.
+    // Note: RNN might have problem doing this way.
+    std::unordered_map<std::string, std::string> forwarded_blobs;
+    for (auto &input : initialized_) {
+      forwarded_blobs.emplace(input, input);
+    }
+    Workspace ws(&ws_, forwarded_blobs);
+
+    // For each input, create a local blob without touching ws_.
+    // This will override the mapped blob from ws_.
+    for (auto &input: inputs) {
+      if (!inputNames_.empty()) {
+        CAFFE_ENFORCE_GT(inputNames_.count(input.first), 0);
+      }
+      auto *blob = ws.CreateLocalBlob(input.first);
+      CAFFE_ENFORCE(blob, "Blob: ", input.first, " does not exist");
+      blob->template GetMutable<TensorCUDA>();
+      predictor_details::copyInputTensor(&ws, input.first, input.second, context_.get());
+    }
+
+    if (!ws.RunNetOnce(run_net_)) {
+      return false;
+    }
+
+    outputs.resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs.size(); ++i) {
+      outputs[i] = predictor_details::copyOutputTensor(&ws, run_net_.external_output(i), context_.get());
+    }
+  }
+  context_->FinishDeviceComputation();
+  return true;
+}
+
+CAFFE_REGISTER_PREDICTOR(CUDA, Predictor<CUDAContext>);
+
+} // namespace caffe2

--- a/caffe2/core/predictor_test.cc
+++ b/caffe2/core/predictor_test.cc
@@ -164,7 +164,7 @@ class PredictorTest : public testing::Test {
     op.set_random_seed(1701);
     ctx_ = caffe2::make_unique<CPUContext>(op);
     NetDef init, run;
-    p_ = std::move(caffe2::PredictorRegistry()->Create("CPU", parseNetDef(initSpec), parseNetDef(predictSpec)));
+    p_ = std::move(caffe2::PredictorRegistry()->Create("CPU", parseNetDef(initSpec), parseNetDef(predictSpec), nullptr));
   }
 
   std::unique_ptr<CPUContext> ctx_;

--- a/caffe2/core/predictor_test.cc
+++ b/caffe2/core/predictor_test.cc
@@ -175,7 +175,7 @@ TEST_F(PredictorTest, SimpleBatchSized) {
   auto inputData = randomTensor({1, 4}, ctx_.get());
   PredictorBase::TensorVector input{inputData->template GetMutable<TensorCPU>()};
   PredictorBase::OutputTensorVector output;
-  p_->run(input, output);
+  p_->run(input, &output);
   EXPECT_EQ(output.size(), 1);
   EXPECT_TRUE(output.front()->dims().size() == 2);
   EXPECT_TRUE(output.front()->dim(0) == 1);
@@ -188,7 +188,7 @@ TEST_F(PredictorTest, SimpleBatchSizedMapInput) {
   PredictorBase::TensorMap input{
       {"data", inputData->template GetMutable<TensorCPU>()}};
   PredictorBase::OutputTensorVector output;
-  p_->run_map(input, output);
+  p_->run_map(input, &output);
   EXPECT_EQ(output.size(), 1);
   EXPECT_TRUE(output.front()->dims().size() == 2);
   EXPECT_TRUE(output.front()->dim(0) == 1);
@@ -214,7 +214,7 @@ TEST_F(PredictorMetaNetDefTest, SimpleMetaNetDefInitializer) {
   PredictorBase::TensorMap input{
       {"data", inputData->template GetMutable<TensorCPU>()}};
   PredictorBase::OutputTensorVector output;
-  p_->run_map(input, output);
+  p_->run_map(input, &output);
   EXPECT_EQ(output.size(), 1);
   EXPECT_TRUE(output.front()->dims().size() == 2);
   EXPECT_TRUE(output.front()->dim(0) == 1);

--- a/caffe2/mobile/contrib/ios/ios_caffe.cc
+++ b/caffe2/mobile/contrib/ios/ios_caffe.cc
@@ -46,7 +46,7 @@ void GenerateStylizedImage(std::vector<float>& originalImage,
   input.ShareExternalPointer(originalImage.data());
   caffe2::PredictorBase::TensorVector input_vec{&input};
   caffe2::PredictorBase::OutputTensorVector output_vec;
-  p.run(input_vec, output_vec);
+  p.run(input_vec, &output_vec);
   assert(output_vec.size() == 1);
   std::shared_ptr<caffe2::TensorCPU> output = output_vec.front();
   // output is our styled image

--- a/caffe2/mobile/contrib/ios/ios_caffe.cc
+++ b/caffe2/mobile/contrib/ios/ios_caffe.cc
@@ -38,17 +38,17 @@ void GenerateStylizedImage(std::vector<float>& originalImage,
   caffe2::NetDef init_net, predict_net;
   init_net.ParseFromString(init_net_str);
   predict_net.ParseFromString(predict_net_str);
-  caffe2::Predictor p(init_net, predict_net);
+  caffe2::Predictor<caffe2::CPUContext> p(init_net, predict_net);
 
   std::vector<int> dims({1, 3, height, width});
   caffe2::TensorCPU input;
   input.Resize(dims);
   input.ShareExternalPointer(originalImage.data());
-  caffe2::Predictor::TensorVector input_vec{&input};
-  caffe2::Predictor::TensorVector output_vec;
-  p.run(input_vec, &output_vec);
+  caffe2::PredictorBase::TensorVector input_vec{&input};
+  caffe2::PredictorBase::OutputTensorVector output_vec;
+  p.run(input_vec, output_vec);
   assert(output_vec.size() == 1);
-  caffe2::TensorCPU* output = output_vec.front();
+  std::shared_ptr<caffe2::TensorCPU> output = output_vec.front();
   // output is our styled image
   float* outputArray = output->mutable_data<float>();
   dataOut.assign(outputArray, outputArray + output->size());

--- a/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
+++ b/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
@@ -56,7 +56,7 @@ void Caffe2IOSPredictor::run(const Tensor& inData, Tensor& outData, std::string&
   caffe2::PredictorBase::TensorVector input_vec{&input};
   caffe2::PredictorBase::OutputTensorVector output_vec;
   try {
-    predictor_.run(input_vec, output_vec);
+    predictor_.run(input_vec, &output_vec);
   } catch (const caffe2::EnforceNotMet& e) {
     std::string error = e.msg();
     errorMessage.swap(error);

--- a/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
+++ b/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
@@ -53,10 +53,10 @@ void Caffe2IOSPredictor::run(const Tensor& inData, Tensor& outData, std::string&
   caffe2::TensorCPU input;
   input.Resize(inData.dims);
   input.ShareExternalPointer(inData.data);
-  caffe2::Predictor::TensorVector input_vec{&input};
-  caffe2::Predictor::TensorVector output_vec;
+  caffe2::PredictorBase::TensorVector input_vec{&input};
+  caffe2::PredictorBase::OutputTensorVector output_vec;
   try {
-    predictor_.run(input_vec, &output_vec);
+    predictor_.run(input_vec, output_vec);
   } catch (const caffe2::EnforceNotMet& e) {
     std::string error = e.msg();
     errorMessage.swap(error);
@@ -66,7 +66,7 @@ void Caffe2IOSPredictor::run(const Tensor& inData, Tensor& outData, std::string&
     errorMessage.swap(error);
     return;
   }
-  caffe2::TensorCPU* output = output_vec.front();
+  std::shared_ptr<caffe2::TensorCPU> output = output_vec.front();
   outData.data = output->mutable_data<uint8_t>();
   outData.dims = output->dims();
 }

--- a/caffe2/mobile/contrib/ios/ios_caffe_predictor.h
+++ b/caffe2/mobile/contrib/ios/ios_caffe_predictor.h
@@ -32,5 +32,5 @@ class IOS_CAFFE_EXPORT Caffe2IOSPredictor final {
                      const caffe2::NetDef& predict_net,
                      bool disableMultithreadProcessing,
                      bool usingMetalOperators);
-  caffe2::Predictor predictor_;
+  caffe2::Predictor<CPUContext> predictor_;
 };

--- a/caffe2/mobile/contrib/ios/ios_caffe_predictor.h
+++ b/caffe2/mobile/contrib/ios/ios_caffe_predictor.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "caffe2/core/net.h"
 #include "caffe2/core/predictor.h"
+#include "caffe2/core/context.h"
 #include "caffe2/mobile/contrib/ios/ios_caffe_defines.h"
 
 struct Tensor {
@@ -32,5 +33,5 @@ class IOS_CAFFE_EXPORT Caffe2IOSPredictor final {
                      const caffe2::NetDef& predict_net,
                      bool disableMultithreadProcessing,
                      bool usingMetalOperators);
-  caffe2::Predictor<CPUContext> predictor_;
+  caffe2::Predictor<caffe2::CPUContext> predictor_;
 };

--- a/caffe2/mobile/contrib/opengl/core/GLPredictor.cc
+++ b/caffe2/mobile/contrib/opengl/core/GLPredictor.cc
@@ -34,7 +34,7 @@ GLPredictor::GLPredictor(const NetDef& init_net,
                          const NetDef& run_net,
                          bool use_texture_input,
                          Workspace* parent)
-    : PredictorBase(init_net, create_gl_run_net(init_net, run_net, use_texture_input), parent) {
+    : Predictor<CPUContext>(init_net, create_gl_run_net(init_net, run_net, use_texture_input), parent) {
   for (const auto& name : run_net_.external_input()) {
     if (!initialized_.count(name)) {
       auto* blob = ws_.GetBlob(name);

--- a/caffe2/mobile/contrib/opengl/core/GLPredictor.cc
+++ b/caffe2/mobile/contrib/opengl/core/GLPredictor.cc
@@ -34,25 +34,33 @@ GLPredictor::GLPredictor(const NetDef& init_net,
                          const NetDef& run_net,
                          bool use_texture_input,
                          Workspace* parent)
-    : Predictor(init_net, create_gl_run_net(init_net, run_net, use_texture_input), parent) {}
+    : PredictorBase(init_net, create_gl_run_net(init_net, run_net, use_texture_input), parent) {
+  for (const auto& name : run_net_.external_input()) {
+    if (!initialized_.count(name)) {
+      auto* blob = ws_.GetBlob(name);
+      CAFFE_ENFORCE(blob, "Blob: ", name, " does not exist");
+      blob->template GetMutable<TensorCPU>();
+    }
+  }
+}
 
 GLPredictor::~GLPredictor() {}
 
 template <class T>
 bool GLPredictor::run(std::vector<GLImageVector<T>*>& inputs,
                       std::vector<const GLImageVector<T>*>* outputs) {
-  const NetDef& run_net_ = Predictor::def();
+  const NetDef& run_net_ = PredictorBase::def();
   CAFFE_ENFORCE(inputs.size() <= run_net_.external_input_size());
   for (auto i = 0; i < inputs.size(); ++i) {
-    shareInputGLImage<T>(Predictor::ws(), run_net_.external_input(i), inputs[i]);
+    shareInputGLImage<T>(PredictorBase::ws(), run_net_.external_input(i), inputs[i]);
   }
 
-  if (!Predictor::ws()->RunNet(run_net_.name())) {
+  if (!PredictorBase::ws()->RunNet(run_net_.name())) {
     return false;
   }
 
   for (auto i = 0; i < run_net_.external_output_size(); ++i) {
-    outputs->push_back(extractOutputGLImage<T>(Predictor::ws(), run_net_.external_output(i)));
+    outputs->push_back(extractOutputGLImage<T>(PredictorBase::ws(), run_net_.external_output(i)));
   }
 
   return true;

--- a/caffe2/mobile/contrib/opengl/core/GLPredictor.h
+++ b/caffe2/mobile/contrib/opengl/core/GLPredictor.h
@@ -4,9 +4,10 @@
 #include "GLImage.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/predictor.h"
+#include "caffe2/core/context.h"
 
 namespace caffe2 {
-class GLPredictor : public PredictorBase {
+class GLPredictor : public Predictor<CPUContext> {
  public:
   using TensorVector = PredictorBase::TensorVector;
   using TensorMap = PredictorBase::TensorMap;
@@ -19,10 +20,6 @@ class GLPredictor : public PredictorBase {
 
   template <class T>
   bool run(std::vector<GLImageVector<T>*>& inputs, std::vector<const GLImageVector<T>*>* outputs);
-
-  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false) { return false; }
-  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe = false) { return false; }
-
 
   ~GLPredictor();
 };

--- a/caffe2/mobile/contrib/opengl/core/GLPredictor.h
+++ b/caffe2/mobile/contrib/opengl/core/GLPredictor.h
@@ -6,8 +6,12 @@
 #include "caffe2/core/predictor.h"
 
 namespace caffe2 {
-class GLPredictor : public Predictor {
+class GLPredictor : public PredictorBase {
  public:
+  using TensorVector = PredictorBase::TensorVector;
+  using TensorMap = PredictorBase::TensorMap;
+  using OutputTensorVector = PredictorBase::OutputTensorVector;
+
   GLPredictor(const NetDef& init_net,
               const NetDef& run_net,
               bool use_texture_input = false,
@@ -15,6 +19,10 @@ class GLPredictor : public Predictor {
 
   template <class T>
   bool run(std::vector<GLImageVector<T>*>& inputs, std::vector<const GLImageVector<T>*>* outputs);
+
+  virtual bool run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false) { return false; }
+  virtual bool run_map(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe = false) { return false; }
+
 
   ~GLPredictor();
 };

--- a/caffe2/onnx/backend_rep.cc
+++ b/caffe2/onnx/backend_rep.cc
@@ -11,99 +11,31 @@ namespace caffe2 { namespace onnx {
 void Caffe2BackendRep::CheckInit() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (!predictor_) {
-    predictor_ = caffe2::make_unique<caffe2::Predictor>(init_net_, pred_net_);
+    switch (pred_net_.device_option().device_type()) {
+      case caffe2::DeviceType::CPU:
+        predictor_ = std::move(caffe2::PredictorRegistry()->Create("CPU", init_net_, pred_net_, nullptr));
+        break;
+      case caffe2::DeviceType::CUDA:
+        predictor_ = std::move(caffe2::PredictorRegistry()->Create("CUDA", init_net_, pred_net_, nullptr));
+        break;
+      default:
+        CAFFE_THROW("Unsupported device type");
+    }
     init_net_.Clear();
     pred_net_.Clear();
   }
 }
 
-
 void Caffe2BackendRep::Run(
-    const caffe2::Predictor::TensorVector& inputs,
-    caffe2::Predictor::TensorVector* outputs) {
+    const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe) {
   CheckInit();
-  predictor_->run(inputs, outputs);
+  predictor_->run(inputs, outputs, threadsafe);
 }
 
 void Caffe2BackendRep::RunMap(
-    const caffe2::Predictor::TensorMap& inputs,
-    caffe2::Predictor::TensorVector* outputs) {
+    const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe) {
   CheckInit();
-  predictor_->run_map(inputs, outputs);
-}
-
-void Caffe2BackendRep::RunInNewWorkspace(
-    const caffe2::Predictor::TensorVector& inputs,
-    std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs) {
-  CheckInit();
-
-  auto &run_net = predictor_->def();
-
-  // Mapping all external input blobs from predictor workspace to the new workspace.
-  // This includes both pretrained weights and network input blobs.
-  std::unordered_map<std::string, std::string> forwarded_blobs;
-  for (auto &input : run_net.external_input()) {
-    forwarded_blobs.emplace(input, input);
-  }
-  Workspace ws(predictor_->ws(), forwarded_blobs);
-
-  // For each network input, create a local blob.
-  // This will override the mapped blob from predictor workspace.
-  for (auto i = 0; i < inputs.size(); ++i) {
-    auto &name = run_net.external_input(i);
-    auto blob = ws.CreateLocalBlob(name);
-    auto tensor = blob->template GetMutable<TensorCPU>();
-    auto input = inputs[i];
-    tensor->ResizeLike(*input);
-    tensor->ShareData(*input);
-  }
-
-  ws.RunNetOnce(run_net);
-
-  outputs.resize(run_net.external_output_size());
-  for (auto i = 0; i < outputs.size(); ++i) {
-    auto &name = run_net.external_output(i);
-    auto blob = ws.GetBlob(name);
-    outputs[i].reset(new TensorCPU());
-    outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>());
-  }
-}
-
-void Caffe2BackendRep::RunMapInNewWorkspace(
-    const caffe2::Predictor::TensorMap& inputs,
-    std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs) {
-  CheckInit();
-
-  auto &run_net = predictor_->def();
-
-  // Mapping all external input blobs from predictor workspace to the new workspace.
-  // This includes both pretrained weights and network input blobs.
-  std::unordered_map<std::string, std::string> forwarded_blobs;
-  for (auto &input : run_net.external_input()) {
-    forwarded_blobs.emplace(input, input);
-  }
-  Workspace ws(predictor_->ws(), forwarded_blobs);
-
-  // For each network input, create a local blob.
-  // This will override the mapped blob from predictor workspace.
-  for (auto &input: inputs) {
-    auto &name = input.first;
-    auto &input_tensor = input.second;
-    auto blob = ws.CreateLocalBlob(name);
-    auto tensor = blob->template GetMutable<TensorCPU>();
-    tensor->ResizeLike(*input_tensor);
-    tensor->ShareData(*input_tensor);
-  }
-
-  ws.RunNetOnce(run_net);
-
-  outputs.resize(run_net.external_output_size());
-  for (auto i = 0; i < outputs.size(); ++i) {
-    auto &name = run_net.external_output(i);
-    auto blob = ws.GetBlob(name);
-    outputs[i].reset(new TensorCPU());
-    outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>());
-  }
+  predictor_->run_map(inputs, outputs, threadsafe);
 }
 
 }}

--- a/caffe2/onnx/backend_rep.cc
+++ b/caffe2/onnx/backend_rep.cc
@@ -13,10 +13,10 @@ void Caffe2BackendRep::CheckInit() {
   if (!predictor_) {
     switch (pred_net_.device_option().device_type()) {
       case caffe2::DeviceType::CPU:
-        predictor_ = std::move(caffe2::PredictorRegistry()->Create("CPU", init_net_, pred_net_, nullptr));
+        predictor_ = caffe2::PredictorRegistry()->Create("CPU", init_net_, pred_net_, nullptr);
         break;
       case caffe2::DeviceType::CUDA:
-        predictor_ = std::move(caffe2::PredictorRegistry()->Create("CUDA", init_net_, pred_net_, nullptr));
+        predictor_ = caffe2::PredictorRegistry()->Create("CUDA", init_net_, pred_net_, nullptr);
         break;
       default:
         CAFFE_THROW("Unsupported device type");
@@ -27,13 +27,13 @@ void Caffe2BackendRep::CheckInit() {
 }
 
 void Caffe2BackendRep::Run(
-    const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe) {
+    const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe) {
   CheckInit();
   predictor_->run(inputs, outputs, threadsafe);
 }
 
 void Caffe2BackendRep::RunMap(
-    const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe) {
+    const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe) {
   CheckInit();
   predictor_->run_map(inputs, outputs, threadsafe);
 }

--- a/caffe2/onnx/backend_rep.cc
+++ b/caffe2/onnx/backend_rep.cc
@@ -1,11 +1,15 @@
 #include "caffe2/core/common.h"
 #include "caffe2/onnx/backend_rep.h"
+#include "caffe2/core/workspace.h"
 
 #include <iostream>
+#include <string>
+#include <unordered_map>
 
 namespace caffe2 { namespace onnx {
 
 void Caffe2BackendRep::CheckInit() {
+  std::unique_lock<std::mutex> lock(mutex_);
   if (!predictor_) {
     predictor_ = caffe2::make_unique<caffe2::Predictor>(init_net_, pred_net_);
     init_net_.Clear();
@@ -26,6 +30,80 @@ void Caffe2BackendRep::RunMap(
     caffe2::Predictor::TensorVector* outputs) {
   CheckInit();
   predictor_->run_map(inputs, outputs);
+}
+
+void Caffe2BackendRep::RunInNewWorkspace(
+    const caffe2::Predictor::TensorVector& inputs,
+    std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs) {
+  CheckInit();
+
+  auto &run_net = predictor_->def();
+
+  // Mapping all external input blobs from predictor workspace to the new workspace.
+  // This includes both pretrained weights and network input blobs.
+  std::unordered_map<std::string, std::string> forwarded_blobs;
+  for (auto &input : run_net.external_input()) {
+    forwarded_blobs.emplace(input, input);
+  }
+  Workspace ws(predictor_->ws(), forwarded_blobs);
+
+  // For each network input, create a local blob.
+  // This will override the mapped blob from predictor workspace.
+  for (auto i = 0; i < inputs.size(); ++i) {
+    auto &name = run_net.external_input(i);
+    auto blob = ws.CreateLocalBlob(name);
+    auto tensor = blob->template GetMutable<TensorCPU>();
+    auto input = inputs[i];
+    tensor->ResizeLike(*input);
+    tensor->ShareData(*input);
+  }
+
+  ws.RunNetOnce(run_net);
+
+  outputs.resize(run_net.external_output_size());
+  for (auto i = 0; i < outputs.size(); ++i) {
+    auto &name = run_net.external_output(i);
+    auto blob = ws.GetBlob(name);
+    outputs[i].reset(new TensorCPU());
+    outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>());
+  }
+}
+
+void Caffe2BackendRep::RunMapInNewWorkspace(
+    const caffe2::Predictor::TensorMap& inputs,
+    std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs) {
+  CheckInit();
+
+  auto &run_net = predictor_->def();
+
+  // Mapping all external input blobs from predictor workspace to the new workspace.
+  // This includes both pretrained weights and network input blobs.
+  std::unordered_map<std::string, std::string> forwarded_blobs;
+  for (auto &input : run_net.external_input()) {
+    forwarded_blobs.emplace(input, input);
+  }
+  Workspace ws(predictor_->ws(), forwarded_blobs);
+
+  // For each network input, create a local blob.
+  // This will override the mapped blob from predictor workspace.
+  for (auto &input: inputs) {
+    auto &name = input.first;
+    auto &input_tensor = input.second;
+    auto blob = ws.CreateLocalBlob(name);
+    auto tensor = blob->template GetMutable<TensorCPU>();
+    tensor->ResizeLike(*input_tensor);
+    tensor->ShareData(*input_tensor);
+  }
+
+  ws.RunNetOnce(run_net);
+
+  outputs.resize(run_net.external_output_size());
+  for (auto i = 0; i < outputs.size(); ++i) {
+    auto &name = run_net.external_output(i);
+    auto blob = ws.GetBlob(name);
+    outputs[i].reset(new TensorCPU());
+    outputs[i]->CopyFrom(*blob->template GetMutable<TensorCPU>());
+  }
 }
 
 }}

--- a/caffe2/onnx/backend_rep.cc
+++ b/caffe2/onnx/backend_rep.cc
@@ -27,15 +27,15 @@ void Caffe2BackendRep::CheckInit() {
 }
 
 void Caffe2BackendRep::Run(
-    const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe) {
+    const TensorVector& inputs, OutputTensorVector* outputs) {
   CheckInit();
-  predictor_->run(inputs, outputs, threadsafe);
+  predictor_->run(inputs, outputs);
 }
 
 void Caffe2BackendRep::RunMap(
-    const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe) {
+    const TensorMap& inputs, OutputTensorVector* outputs) {
   CheckInit();
-  predictor_->run_map(inputs, outputs, threadsafe);
+  predictor_->run_map(inputs, outputs);
 }
 
 }}

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -11,18 +11,12 @@
 namespace caffe2 { namespace onnx {
 class Caffe2BackendRep {
  public:
-  void Run(
-      const caffe2::Predictor::TensorVector& inputs,
-      caffe2::Predictor::TensorVector* outputs);
-  void RunMap(
-      const caffe2::Predictor::TensorMap& inputs,
-      caffe2::Predictor::TensorVector* outputs);
-  void RunInNewWorkspace(
-      const caffe2::Predictor::TensorVector& inputs,
-      std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs);
-  void RunMapInNewWorkspace(
-      const caffe2::Predictor::TensorMap& inputs,
-      std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs);
+  using TensorVector = caffe2::PredictorBase::TensorVector;
+  using TensorMap = caffe2::PredictorBase::TensorMap;
+  using OutputTensorVector = caffe2::PredictorBase::OutputTensorVector;
+
+  void Run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false);
+  void RunMap(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe = false);
 
   caffe2::NetDef& init_net() {
     return init_net_;
@@ -50,7 +44,7 @@ class Caffe2BackendRep {
   caffe2::NetDef init_net_;
   caffe2::NetDef pred_net_;
   std::vector<std::string> uninitialized_inputs_;
-  std::unique_ptr<caffe2::Predictor> predictor_{nullptr};
+  std::unique_ptr<caffe2::PredictorBase> predictor_{nullptr};
   std::mutex mutex_;
 };
 }}

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -15,8 +15,8 @@ class Caffe2BackendRep {
   using TensorMap = caffe2::PredictorBase::TensorMap;
   using OutputTensorVector = caffe2::PredictorBase::OutputTensorVector;
 
-  void Run(const TensorVector& inputs, OutputTensorVector& outputs, bool threadsafe = false);
-  void RunMap(const TensorMap& inputs, OutputTensorVector& outputs, bool threadsafe = false);
+  void Run(const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe = false);
+  void RunMap(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe = false);
 
   caffe2::NetDef& init_net() {
     return init_net_;

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -4,6 +4,7 @@
 #include "caffe2/proto/caffe2.pb.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,12 @@ class Caffe2BackendRep {
   void RunMap(
       const caffe2::Predictor::TensorMap& inputs,
       caffe2::Predictor::TensorVector* outputs);
+  void RunInNewWorkspace(
+      const caffe2::Predictor::TensorVector& inputs,
+      std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs);
+  void RunMapInNewWorkspace(
+      const caffe2::Predictor::TensorMap& inputs,
+      std::vector<std::shared_ptr<caffe2::TensorCPU>> &outputs);
 
   caffe2::NetDef& init_net() {
     return init_net_;
@@ -44,5 +51,6 @@ class Caffe2BackendRep {
   caffe2::NetDef pred_net_;
   std::vector<std::string> uninitialized_inputs_;
   std::unique_ptr<caffe2::Predictor> predictor_{nullptr};
+  std::mutex mutex_;
 };
 }}

--- a/caffe2/onnx/backend_rep.h
+++ b/caffe2/onnx/backend_rep.h
@@ -15,8 +15,8 @@ class Caffe2BackendRep {
   using TensorMap = caffe2::PredictorBase::TensorMap;
   using OutputTensorVector = caffe2::PredictorBase::OutputTensorVector;
 
-  void Run(const TensorVector& inputs, OutputTensorVector* outputs, bool threadsafe = false);
-  void RunMap(const TensorMap& inputs, OutputTensorVector* outputs, bool threadsafe = false);
+  void Run(const TensorVector& inputs, OutputTensorVector* outputs);
+  void RunMap(const TensorMap& inputs, OutputTensorVector* outputs);
 
   caffe2::NetDef& init_net() {
     return init_net_;

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -780,8 +780,7 @@ class Caffe2Backend(Backend):
                 rnn_nodes.append(node)
 
         # Build the C++ backend
-        # TODO: build a predictor that supports GPU
-        #       And for RNN nets, we need to avoid adding init_net
+        #       For RNN nets, we need to avoid adding init_net
         use_cpp_backend = not rnn_nodes
         # use python backend for now
         use_cpp_backend = False

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -782,7 +782,7 @@ class Caffe2Backend(Backend):
         # Build the C++ backend
         # TODO: build a predictor that supports GPU
         #       And for RNN nets, we need to avoid adding init_net
-        use_cpp_backend = device == 'CPU' and not rnn_nodes
+        use_cpp_backend = not rnn_nodes
         # use python backend for now
         use_cpp_backend = False
         if use_cpp_backend:

--- a/caffe2/python/onnx/backend_cpp_rep.py
+++ b/caffe2/python/onnx/backend_cpp_rep.py
@@ -30,10 +30,10 @@ class Caffe2CppRep(BackendRep):
     def external_inputs(self):
         return self.__core.external_inputs()
 
-    def run(self, inputs):
+    def run(self, inputs, threadsafe = False):
         output_values = None
         if isinstance(inputs, dict):
-            output_values = self.__core.run(inputs)
+            output_values = self.__core.run(inputs, threadsafe)
         elif isinstance(inputs, list) or isinstance(inputs, tuple):
             if len(inputs) != len(self.__uninitialized_inputs):
                 raise RuntimeError('Expected {} values for uninitialized '
@@ -44,28 +44,8 @@ class Caffe2CppRep(BackendRep):
             input_map = {}
             for k, v in zip(self.__uninitialized_inputs, inputs):
                 input_map[k] = v
-            output_values = self.__core.run(input_map)
+            output_values = self.__core.run(input_map, threadsafe)
         else:
             # single input
-            output_values = self.__core.run([inputs])
-        return namedtupledict('Outputs', self.__external_outputs)(*output_values)
-
-    def run_in_new_workspace(self, inputs):
-        output_values = None
-        if isinstance(inputs, dict):
-            output_values = self.__core.run_in_new_workspace(inputs)
-        elif isinstance(inputs, list) or isinstance(inputs, tuple):
-            if len(inputs) != len(self.__uninitialized_inputs):
-                raise RuntimeError('Expected {} values for uninitialized '
-                                   'graph inputs ({}), but got {}.'.format(
-                                        len(self.__uninitialized_inputs),
-                                        ', '.join(self.__uninitialized_inputs),
-                                        len(inputs)))
-            input_map = {}
-            for k, v in zip(self.__uninitialized_inputs, inputs):
-                input_map[k] = v
-            output_values = self.__core.run_in_new_workspace(input_map)
-        else:
-            # single input
-            output_values = self.__core.run_in_new_workspace([inputs])
+            output_values = self.__core.run([inputs], threadsafe)
         return namedtupledict('Outputs', self.__external_outputs)(*output_values)

--- a/caffe2/python/onnx/backend_cpp_rep.py
+++ b/caffe2/python/onnx/backend_cpp_rep.py
@@ -30,10 +30,10 @@ class Caffe2CppRep(BackendRep):
     def external_inputs(self):
         return self.__core.external_inputs()
 
-    def run(self, inputs, threadsafe = False):
+    def run(self, inputs):
         output_values = None
         if isinstance(inputs, dict):
-            output_values = self.__core.run(inputs, threadsafe)
+            output_values = self.__core.run(inputs)
         elif isinstance(inputs, list) or isinstance(inputs, tuple):
             if len(inputs) != len(self.__uninitialized_inputs):
                 raise RuntimeError('Expected {} values for uninitialized '
@@ -44,8 +44,8 @@ class Caffe2CppRep(BackendRep):
             input_map = {}
             for k, v in zip(self.__uninitialized_inputs, inputs):
                 input_map[k] = v
-            output_values = self.__core.run(input_map, threadsafe)
+            output_values = self.__core.run(input_map)
         else:
             # single input
-            output_values = self.__core.run([inputs], threadsafe)
+            output_values = self.__core.run([inputs])
         return namedtupledict('Outputs', self.__external_outputs)(*output_values)

--- a/caffe2/python/onnx/backend_cpp_rep.py
+++ b/caffe2/python/onnx/backend_cpp_rep.py
@@ -50,3 +50,22 @@ class Caffe2CppRep(BackendRep):
             output_values = self.__core.run([inputs])
         return namedtupledict('Outputs', self.__external_outputs)(*output_values)
 
+    def run_in_new_workspace(self, inputs):
+        output_values = None
+        if isinstance(inputs, dict):
+            output_values = self.__core.run_in_new_workspace(inputs)
+        elif isinstance(inputs, list) or isinstance(inputs, tuple):
+            if len(inputs) != len(self.__uninitialized_inputs):
+                raise RuntimeError('Expected {} values for uninitialized '
+                                   'graph inputs ({}), but got {}.'.format(
+                                        len(self.__uninitialized_inputs),
+                                        ', '.join(self.__uninitialized_inputs),
+                                        len(inputs)))
+            input_map = {}
+            for k, v in zip(self.__uninitialized_inputs, inputs):
+                input_map[k] = v
+            output_values = self.__core.run_in_new_workspace(input_map)
+        else:
+            # single input
+            output_values = self.__core.run_in_new_workspace([inputs])
+        return namedtupledict('Outputs', self.__external_outputs)(*output_values)

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -653,8 +653,7 @@ void addObjectMethods(py::module& m) {
       .def(
           "run",
           [](caffe2::onnx::Caffe2BackendRep& instance,
-             std::map<std::string, py::object> inputs,
-             bool threadsafe)
+             std::map<std::string, py::object> inputs)
               -> std::vector<py::object> {
             PredictorBase::TensorMap tensors;
             std::map<std::string, TensorCPU> tensors_data{};
@@ -674,7 +673,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.RunMap(tensors, &out, threadsafe);
+              instance.RunMap(tensors, &out);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -682,14 +681,11 @@ void addObjectMethods(py::module& m) {
                   TensorFetcher<CPUContext>().FetchTensor(*t, true).obj);
             }
             return pyout;
-          },
-          py::arg("inputs"),
-          py::arg("threadsafe") = false)
+          })
       .def(
           "run",
           [](caffe2::onnx::Caffe2BackendRep& instance,
-             std::vector<py::object> inputs,
-             bool threadsafe)
+             std::vector<py::object> inputs)
               -> std::vector<py::object> {
             PredictorBase::TensorVector tensors;
             std::vector<TensorCPU> tensors_data(inputs.size());
@@ -707,7 +703,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.Run(tensors, &out, threadsafe);
+              instance.Run(tensors, &out);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -715,9 +711,7 @@ void addObjectMethods(py::module& m) {
                   TensorFetcher<CPUContext>().FetchTensor(*t, true).obj);
             }
             return pyout;
-          },
-          py::arg("inputs"),
-          py::arg("threadsafe") = false);
+          });
 
   py::class_<caffe2::onnx::Caffe2Backend>(m, "Caffe2Backend")
       .def(py::init<>())
@@ -781,8 +775,7 @@ void addObjectMethods(py::module& m) {
       .def(
           "run",
           [](PredictorBase& instance,
-             std::vector<py::object> inputs,
-             bool threadsafe) -> std::vector<py::object> {
+             std::vector<py::object> inputs) -> std::vector<py::object> {
             PredictorBase::TensorVector tensors;
             std::vector<TensorCPU> tensors_data(inputs.size());
             for (auto i = 0; i < inputs.size(); ++i) {
@@ -799,7 +792,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.run(tensors, &out, threadsafe);
+              instance.run(tensors, &out);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -807,14 +800,11 @@ void addObjectMethods(py::module& m) {
                   TensorFetcher<CPUContext>().FetchTensor(*t, true).obj);
             }
             return pyout;
-          },
-          py::arg("inputs"),
-          py::arg("threadsafe") = false)
+          })
       .def(
           "run",
           [](PredictorBase& instance,
-            std::map<std::string, py::object> inputs,
-            bool threadsafe)
+            std::map<std::string, py::object> inputs)
               -> std::vector<py::object> {
             PredictorBase::TensorMap tensors;
             std::map<std::string, TensorCPU> tensors_data{};
@@ -833,7 +823,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.run_map(tensors, &out, threadsafe);
+              instance.run_map(tensors, &out);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -841,9 +831,7 @@ void addObjectMethods(py::module& m) {
                   TensorFetcher<CPUContext>().FetchTensor(*t, true).obj);
             }
             return pyout;
-          },
-          py::arg("inputs"),
-          py::arg("threadsafe") = false);
+          });
 
   py::class_<script::CompilationUnit>(m, "CompilationUnit")
       .def(py::init<>())

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -674,7 +674,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.RunMap(tensors, out, threadsafe);
+              instance.RunMap(tensors, &out, threadsafe);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -707,7 +707,7 @@ void addObjectMethods(py::module& m) {
             PredictorBase::OutputTensorVector out;
             {
               py::gil_scoped_release g;
-              instance.Run(tensors, out, threadsafe);
+              instance.Run(tensors, &out, threadsafe);
             }
             std::vector<py::object> pyout;
             for (auto t : out) {
@@ -797,7 +797,10 @@ void addObjectMethods(py::module& m) {
               tensors.push_back(&(tensors_data[i]));
             }
             PredictorBase::OutputTensorVector out;
-            instance.run(tensors, out, threadsafe);
+            {
+              py::gil_scoped_release g;
+              instance.run(tensors, &out, threadsafe);
+            }
             std::vector<py::object> pyout;
             for (auto t : out) {
               pyout.push_back(
@@ -828,7 +831,10 @@ void addObjectMethods(py::module& m) {
               tensors.insert(std::make_pair(name, &tensors_data[name]));
             }
             PredictorBase::OutputTensorVector out;
-            instance.run_map(tensors, out, threadsafe);
+            {
+              py::gil_scoped_release g;
+              instance.run_map(tensors, &out, threadsafe);
+            }
             std::vector<py::object> pyout;
             for (auto t : out) {
               pyout.push_back(

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -672,7 +672,10 @@ void addObjectMethods(py::module& m) {
             }
 
             PredictorBase::OutputTensorVector out;
-            instance.RunMap(tensors, out, threadsafe);
+            {
+              py::gil_scoped_release g;
+              instance.RunMap(tensors, out, threadsafe);
+            }
             std::vector<py::object> pyout;
             for (auto t : out) {
               pyout.push_back(
@@ -702,7 +705,10 @@ void addObjectMethods(py::module& m) {
               tensors.push_back(&(tensors_data[i]));
             }
             PredictorBase::OutputTensorVector out;
-            instance.Run(tensors, out, threadsafe);
+            {
+              py::gil_scoped_release g;
+              instance.Run(tensors, out, threadsafe);
+            }
             std::vector<py::object> pyout;
             for (auto t : out) {
               pyout.push_back(


### PR DESCRIPTION
Update 2:
The pull request now removes the thread-safe implementation. Only predictor CUDA support is included. See [comment](https://github.com/pytorch/pytorch/pull/6298#issuecomment-380674538) below.

---

Update:
The commit now put the threadsafe implementation into `Predictor`, and also includes Predictor CUDA support.

---
Original:

The ONNX interface is not thread safe. All threading using the same ONNX backend would share the same Caffe2 workspace. When multiple evaluation are doing concurrently, they would write to the same blobs.

This pull request deals with the problem by adding an interface method `run_in_new_workspace` to Caffe2 ONNX backend. When evaluating an image, we create a new workspace to store the intermediate and final results, while sharing the network weights by inheriting those blobs in init_net from the default workspace.

Note that this might not work for RNN case. An ultimate solution might be some sort of copy-on-write mechanism.