### PR TITLE
Fix worldsize use in test_distributed with MPI backend

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -76,7 +76,7 @@ def skip_if_small_worldsize(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if int(os.environ['WORLD_SIZE']) <= 2:
+        if (os.environ['BACKEND'] != "mpi") and int(os.environ['WORLD_SIZE']) <= 2:
             sys.exit(SKIP_IF_SMALL_WORLDSIZE_EXIT_CODE)
 
         return func(*args, **kwargs)


### PR DESCRIPTION
WORLD_SIZE is not used for MPI tests and the checks fails for the group tests