### PR TITLE
Increase # of runs for CPU perf test, and increase margin of error

### DIFF
--- a/.jenkins/pytorch/perf_test/compare_with_baseline.py
+++ b/.jenkins/pytorch/perf_test/compare_with_baseline.py
@@ -61,6 +61,6 @@ else:
             new_data = json.load(new_data_file)
         new_data[test_name] = {}
         new_data[test_name]['mean'] = sample_mean
-        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.02)
+        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.1)
         with open(new_data_file_path, 'w') as new_data_file:
             json.dump(new_data, new_data_file, indent=4)

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -49,8 +49,8 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
     export TEST_MODE="compare_and_update"
 fi
 
-run_test test_cpu_speed_mini_sequence_labeler 20 ${TEST_MODE}
-run_test test_cpu_speed_mnist 20 ${TEST_MODE}
+run_test test_cpu_speed_mini_sequence_labeler 40 ${TEST_MODE}
+run_test test_cpu_speed_mnist 40 ${TEST_MODE}
 run_test test_cpu_speed_torch ${TEST_MODE}
 run_test test_cpu_speed_torch_tensor ${TEST_MODE}
 


### PR DESCRIPTION
We will be moving to bare metal machines for CPU perf tests which will make the perf numbers more stable. However, there are still some cross-machine differences and system noise even with CPU isolation enabled, so we need to repeat the tests for more times and also increase the margin of error a bit.

On the new machines, the CPU perf tests will take about 11 mins to finish, which is shorter than the current time taken (15 mins).

This is ready to merge after we switch over to the new test machines, in order to not slow down the current tests.