### PR TITLE
Move instruction set specific code to anonymous namespace

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -15,6 +15,7 @@
 
 namespace at {
 namespace vec256 {
+namespace {
 
 template <typename T>
 std::ostream& operator<<(std::ostream& stream, const Vec256<T>& vec) {
@@ -31,5 +32,4 @@ std::ostream& operator<<(std::ostream& stream, const Vec256<T>& vec) {
   return stream;
 }
 
-}
-}
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -12,6 +12,7 @@
 
 namespace at {
 namespace vec256 {
+namespace {
 
 // NOTE: If you specialize on a type, you must define all operations!
 
@@ -102,5 +103,4 @@ template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-}
-}
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -5,6 +5,7 @@
 
 namespace at {
 namespace vec256 {
+namespace {
 
 #ifdef __AVX__
 
@@ -94,4 +95,4 @@ Vec256<double> inline operator*(const Vec256<double>& a, const Vec256<double>& b
 
 #endif
 
-}}
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -5,6 +5,7 @@
 
 namespace at {
 namespace vec256 {
+namespace {
 
 #ifdef __AVX__
 
@@ -94,4 +95,4 @@ Vec256<float> inline operator*(const Vec256<float>& a, const Vec256<float>& b) {
 
 #endif
 
-}}
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -5,6 +5,7 @@
 
 namespace at {
 namespace vec256 {
+namespace {
 
 #ifdef __AVX2__
 
@@ -154,4 +155,4 @@ Vec256<int16_t> inline operator*(const Vec256<int16_t>& a, const Vec256<int16_t>
 }
 #endif
 
-}}
+}}}

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -7,8 +7,7 @@
 #include "ATen/optional.h"
 #include "ATen/cpu/vec256/vec256.h"
 
-namespace at {
-namespace native {
+namespace at { namespace native { namespace {
 
 using namespace vec256;
 
@@ -147,8 +146,9 @@ static void prod_kernel_impl(Tensor& result, const Tensor& self, at::optional<in
   });
 }
 
+}  // anonymous namespace
+
 REGISTER_DISPATCH(sum_kernel, &sum_kernel_impl);
 REGISTER_DISPATCH(prod_kernel, &prod_kernel_impl);
 
-}
-}
+}}  // namespace at::native

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -7,7 +7,7 @@
 #include "ATen/cpu/vec256/vec256.h"
 #include "ATen/native/cpu/CapabilityDispatch.h"
 
-namespace at { namespace native {
+namespace at { namespace native { namespace {
 
 using namespace vec256;
 
@@ -129,6 +129,8 @@ static void trunc_kernel(Tensor& result, const Tensor& self) {
     });
   });
 }
+
+}  // anonymous namespace
 
 REGISTER_DISPATCH(absImpl, &abs_kernel);
 REGISTER_DISPATCH(ceilImpl, &ceil_kernel);


### PR DESCRIPTION
```
The vec256 and SIMD kernels are compiled multiple times with different
headers. It's important that these functions have internal linkage so
that kernels for different architectures don't get combined during
linking. It's sufficient to label functions "static", but class methods
must be an unnamed namespace to have internal linkage (since static
means something different in the context of classes).

This fixes a bug in which the implementations of Reduction::reduce_all
for different instruction sets was getting combined during linking.
```