### PR TITLE
Check mappings ONNX -> Caffe2 bear the same argument names

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -890,17 +890,50 @@ Caffe2Ops Caffe2Backend::ConvertNode(
   return OnnxNodeToCaffe2Ops(init_model, pred_model, &onnx_node, opset_version);
 }
 
+void Caffe2Backend::CheckOpSchemaArguments(
+    const caffe2::OpSchema& schema,
+    const caffe2::OperatorDef& op) {
+  const auto& schema_args = schema.args();
+  std::vector<std::string> argnames;
+  std::transform(
+      schema_args.begin(),
+      schema_args.end(),
+      std::back_inserter(argnames),
+      [](caffe2::OpSchema::Argument elem) { return elem.name(); });
+
+  for (const auto& arg : op.arg()) {
+    if (std::count(argnames.begin(), argnames.end(), arg.name()) == 0) {
+      CAFFE_THROW(
+          "Don't know how to map unexpected argument ",
+          arg.name(),
+          " (from operator ",
+          op.type(), ")");
+    }
+  }
+}
+
 Caffe2Ops Caffe2Backend::OnnxNodeToCaffe2Ops(
     const ModelProto& init_model,
     const ModelProto& pred_model,
     OnnxNode* onnx_node,
     int opset_version) {
+  Caffe2Ops res;
   if (get_special_operators().count(onnx_node->node.op_type())) {
-    return (this->*get_special_operators().at(onnx_node->node.op_type()))(
+    res = (this->*get_special_operators().at(onnx_node->node.op_type()))(
         onnx_node, opset_version);
   } else {
-    return CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
+    res = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
   }
+
+  for (const auto& result_op: res.ops){
+    const auto* schema = OpSchemaRegistry::Schema(result_op.type());
+    if (schema) {
+      CheckOpSchemaArguments(*schema, result_op);
+    } else {
+      CAFFE_THROW("Caffe2 has no such operator, could not find schema for ", result_op.type());
+    }
+  }
+  return res;
 }
 
 void Caffe2Backend::OnnxToCaffe2(

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -894,21 +894,26 @@ void Caffe2Backend::CheckOpSchemaArguments(
     const caffe2::OpSchema& schema,
     const caffe2::OperatorDef& op) {
   const auto& schema_args = schema.args();
-  std::vector<std::string> argnames;
-  std::transform(
-      schema_args.begin(),
-      schema_args.end(),
-      std::back_inserter(argnames),
-      [](caffe2::OpSchema::Argument elem) { return elem.name(); });
+  if (schema_args.size() > 0){
+    std::vector<std::string> argnames;
+    std::transform(
+        schema_args.begin(),
+        schema_args.end(),
+        std::back_inserter(argnames),
+        [](caffe2::OpSchema::Argument elem) { return elem.name(); });
 
-  for (const auto& arg : op.arg()) {
-    if (std::count(argnames.begin(), argnames.end(), arg.name()) == 0) {
-      CAFFE_THROW(
-          "Don't know how to map unexpected argument ",
-          arg.name(),
-          " (from operator ",
-          op.type(), ")");
+    for (const auto& arg : op.arg()) {
+      if (std::count(argnames.begin(), argnames.end(), arg.name()) == 0) {
+        CAFFE_THROW(
+            "Don't know how to map unexpected argument ",
+            arg.name(),
+            " (from operator ",
+            op.type(), ")");
+      }
     }
+  } else {
+    // A number of C2 operators do not declare proper arguments. Let's log the error
+    VLOG(2) << "Operator " << op.type() << " does not declare arguments in its schema. Please file a Caffe2 issue.";
   }
 }
 

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -125,6 +125,8 @@ class Caffe2Backend {
       bool include_initializers,
       const std::vector<Caffe2Ops>& extras);
 
+  void CheckOpSchemaArguments(const caffe2::OpSchema& schema, const caffe2::OperatorDef& op);
+
   Caffe2Ops OnnxNodeToCaffe2Ops(
       const ModelProto& init_model,
       const ModelProto& pred_model,


### PR DESCRIPTION
When adding an extra arg to an input ONNX op, if it's not supported in Caffe2, the exporter would just silently pass it to NetDef and ignore it in the implementation. It's pretty error-prone. Caffe2 also has an OpSchema description and we can enforce that all arguments explicitly appear in schema or listed explicitly in Caffe2.
Adds test for C2 argument checking.

See also https://github.com/caffe2/caffe2/pull/2478

review by @bddppq 
