### PR TITLE
Add total_length option to pad_packed_sequence

### DIFF
--- a/docs/source/notes/faq.rst
+++ b/docs/source/notes/faq.rst
@@ -99,3 +99,50 @@ You are likely using other libraries to generate random numbers in the dataset.
 For example, NumPy's RNG is duplicated when worker subprocesses are started via
 ``fork``. See :class:`torch.utils.data.DataLoader`'s document for how to
 properly set up random seeds in workers.
+
+.. _pack-rnn-unpack-with-data-parallelism:
+
+My recurrent network doesn't work with data parallelism
+-------------------------------------------------------
+There is a subtlety in using the
+``pack sequence -> recurrent network -> unpack sequence`` pattern in a
+:class:`~torch.nn.Module` with :class:`~torch.nn.DataParallel` or
+:func:`~torch.nn.parallel.data_parallel`. Input to each the :meth:`forward` on
+each device will only be part of the entire input. Because the unpack operation
+:func:`torch.nn.utils.rnn.pad_packed_sequence` by default only pads up to the
+longest input it sees, i.e., the longest on that particular device, size
+mismatches will happen when results are gathered together. Therefore, you can
+instead take advantage of the :attr:`total_length` argument of
+:func:`~torch.nn.utils.rnn.pad_packed_sequence` to make sure that the
+:meth:`forward` calls return sequences of same length. For example, you can
+write::
+
+    from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+    class MyModule(nn.Module):
+        # ... __init__, other methods, etc.
+
+        # padding_input is of shape [B x T x *] (batch_first mode) and contains
+        # the sequences sorted by lengths
+        # B is the batch size
+        # T is max sequence length
+        def forward(self, padded_input, input_lengths):
+            total_length = padded_input.size(1)  # get the max sequence length
+            packed_input = pack_padded_sequence(padded_input, input_lengths,
+                                                batch_first=True)
+            packed_output, _ = self.my_lstm(packed_input)
+            output, _ = pad_packed_sequence(packed_output, batch_first=True,
+                                            total_length=total_length)
+            return output
+
+
+    m = MyModule().cuda()
+    dp_m = nn.DataParallel(m)
+
+
+Additionally, extra care needs to be taken when batch dimension is dim ``1``
+(i.e., ``batch_first=False``) with data parallelism. In this case, the first
+argument of pack_padded_sequence ``padding_input`` will be of shape
+``[T x B x *]`` and should be scattered along dim ``1``, but the second argument
+``input_lengths`` will be of shape ``[B]`` and should be scattered along dim
+``0``. Extra code to manipulate the tensor shapes will be needed.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -128,6 +128,26 @@ class PackedSequenceTest(TestCase):
         unpacked, _ = rnn_utils.pad_packed_sequence(packed)
         self.assertEqual(unpacked.type(), cuda_type_str)
 
+    def test_total_length(self):
+        padded, lengths = self._padded_sequence(torch.FloatTensor)
+        max_length = max(lengths)
+        packed = rnn_utils.pack_padded_sequence(padded, lengths)
+        # test ValueError if total_length < max_length
+        for total_length in (-1, 0, max_length - 1):
+            for batch_first in (True, False):
+                def err_fn():
+                    rnn_utils.pad_packed_sequence(packed, batch_first=batch_first,
+                                                  total_length=total_length)
+            self.assertRaises(ValueError, err_fn)
+        # test that pad_packed_sequence returns results of correct length
+        for total_length_delta in (0, 1, 8):
+            for batch_first in (True, False):
+                total_length = max_length + total_length_delta
+                unpacked, lengths_out = rnn_utils.pad_packed_sequence(packed, batch_first=batch_first,
+                                                                      total_length=total_length)
+                self.assertEqual(lengths, lengths_out)
+                self.assertEqual(unpacked.size(1 if batch_first else 0), total_length)
+
 
 def default_tensor_type(type):
     type_str = torch.typename(type)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -138,15 +138,28 @@ class PackedSequenceTest(TestCase):
                 def err_fn():
                     rnn_utils.pad_packed_sequence(packed, batch_first=batch_first,
                                                   total_length=total_length)
-            self.assertRaises(ValueError, err_fn)
+            self.assertRaisesRegex(ValueError,
+                                   r'Expected total_length to be at least the '
+                                   r'length of the longest sequence in input',
+                                   err_fn)
         # test that pad_packed_sequence returns results of correct length
-        for total_length_delta in (0, 1, 8):
-            for batch_first in (True, False):
+        for batch_first in (True, False):
+            no_extra_pad, _ = rnn_utils.pad_packed_sequence(packed, batch_first=batch_first)
+            for total_length_delta in (0, 1, 8):
                 total_length = max_length + total_length_delta
                 unpacked, lengths_out = rnn_utils.pad_packed_sequence(packed, batch_first=batch_first,
                                                                       total_length=total_length)
                 self.assertEqual(lengths, lengths_out)
                 self.assertEqual(unpacked.size(1 if batch_first else 0), total_length)
+                if total_length_delta == 0:
+                    ref_output = no_extra_pad
+                elif batch_first:
+                    extra_pad = no_extra_pad.new_zeros(self.batch_size, total_length_delta)
+                    ref_output = torch.cat([no_extra_pad, extra_pad], 1)
+                else:
+                    extra_pad = no_extra_pad.new_zeros(total_length_delta, self.batch_size)
+                    ref_output = torch.cat([no_extra_pad, extra_pad], 0)
+                self.assertEqual(unpacked, ref_output)
 
 
 def default_tensor_type(type):

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -65,37 +65,8 @@ class DataParallel(Module):
         There is a subtlety in using the
         ``pack sequence -> recurrent network -> unpack sequence`` pattern in a
         :class:`~torch.nn.Module` wrapped in :class:`~torch.nn.DataParallel`.
-        Input to each the :meth:`forward` on each device will only be part of
-        the entire input. Because the unpack operation
-        :func:`torch.nn.utils.rnn.pad_packed_sequence` by default only pads up
-        to the longest input it sees, i.e., the longest on that particular
-        device, size mismatches will happen when results are gathered together.
-        Therefore, you can instead take advantage of the :attr:`total_length`
-        argument of :func:`~torch.nn.utils.rnn.pad_packed_sequence` to make sure
-        that the :meth:`forward` calls return sequences of same length. For
-        example, you can write::
-
-            from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
-
-            class MyModule(nn.Module):
-                # ... __init__, other methods, etc.
-
-                # padding_input is of shape [B x T x *] (batch_first mode) and contains
-                # the sorted sequences
-                # B is the batch size
-                # T is max sequence length
-                def forward(self, padded_input, input_lengths):
-                    total_length = padded_input.size(1)  # get the max sequence length
-                    packed_input = pack_padded_sequence(padded_input, input_lengths,
-                                                        batch_first=True)
-                    packed_output, _ = self.my_lstm(packed_input)
-                    output, _ = pad_packed_sequence(packed_output, batch_first=True,
-                                                    total_length=total_length)
-                    return output
-
-
-            m = MyModule().cuda()
-            dp_m = nn.DataParallel(m)
+        See :ref:`this FAQ section <pack-rnn-unpack-with-data-parallelism>` for
+        details.
 
 
     Args:

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -52,8 +52,51 @@ class DataParallel(Module):
 
     .. warning::
         Forward and backward hooks defined on :attr:`module` and its submodules
-        won't be invoked anymore, unless the hooks are initialized in the
-        :meth:`forward` method.
+        will be invoked ``len(device_ids)`` times, each with inputs located on
+        a particular device. Particularly, the hooks are only guaranteed to be
+        executed in correct order with respect to operations on corresponding
+        devices. For example, it is not guaranteed that hooks set via
+        :meth:`~torch.nn.Module.register_forward_pre_hook` be executed before
+        `all` ``len(device_ids)`` :meth:`~torch.nn.Module.forward` calls, but
+        that each such hook be executed before the corresponding
+        :meth:`~torch.nn.Module.forward` call of that device.
+
+    .. note::
+        There is a subtlety in using the
+        ``pack sequence -> recurrent network -> unpack sequence`` pattern in a
+        :class:`~torch.nn.Module` wrapped in :class:`~torch.nn.DataParallel`.
+        Input to each the :meth:`forward` on each device will only be part of
+        the entire input. Because the unpack operation
+        :func:`torch.nn.utils.rnn.pad_packed_sequence` by default only pads up
+        to the longest input it sees, i.e., the longest on that particular
+        device, size mismatches will happen when results are gathered together.
+        Therefore, you can instead take advantage of the :attr:`total_length`
+        argument of :func:`~torch.nn.utils.rnn.pad_packed_sequence` to make sure
+        that the :meth:`forward` calls return sequences of same length. For
+        example, you can write::
+
+            from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+            class MyModule(nn.Module):
+                # ... __init__, other methods, etc.
+
+                # padding_input is of shape [B x T x *] (batch_first mode) and contains
+                # the sorted sequences
+                # B is the batch size
+                # T is max sequence length
+                def forward(self, padded_input, input_lengths):
+                    total_length = padded_input.size(1)  # get the max sequence length
+                    packed_input = pack_padded_sequence(padded_input, input_lengths,
+                                                        batch_first=True)
+                    packed_output, _ = self.my_lstm(packed_input)
+                    output, _ = pad_packed_sequence(packed_output, batch_first=True,
+                                                    total_length=total_length)
+                    return output
+
+
+            m = MyModule().cuda()
+            dp_m = nn.DataParallel(m)
+
 
     Args:
         module: module to be parallelized

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -138,6 +138,9 @@ def pack_padded_sequence(input, lengths, batch_first=False):
 
 
 def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0, total_length=None):
+    if total_length is not None:
+        raise ValueError("_symbolic_pad_packed_sequence only supports "
+                         "_symbolic_pad_packed_sequence=None")
     # See comment on _symbolic_pack_padded_sequence
     data, lengths = g.op("prim::PadPacked", input.data, input.batch_sizes, outputs=2)
     if batch_first:
@@ -156,6 +159,13 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
     the data will be transposed into ``B x T x *`` format.
 
     Batch elements will be ordered decreasingly by their length.
+
+    .. note::
+        :attr:`total_length` is useful to implement the
+        ``pack sequence -> recurrent network -> unpack sequence`` pattern in a
+        :class:`~torch.nn.Module` wrapped in :class:`~torch.nn.DataParallel`.
+        See :ref:`this FAQ section <pack-rnn-unpack-with-data-parallelism>` for
+        details.
 
     Arguments:
         sequence (PackedSequence): batch to pad

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -11,7 +11,7 @@ PackedSequence_ = namedtuple('PackedSequence', ['data', 'batch_sizes'])
 
 
 class PackedSequence(PackedSequence_):
-    r"""Holds the data and list of batch_sizes of a packed sequence.
+    r"""Holds the data and list of :attr:`batch_sizes` of a packed sequence.
 
     All RNN modules accept packed sequences as inputs.
 
@@ -21,8 +21,9 @@ class PackedSequence(PackedSequence_):
 
         Batch sizes represent the number elements at each sequence step in
         the batch, not the varying sequence lengths passed to
-        :func:`pack_padded_sequence`.  For instance, given data  ``abc`` and `d`
-        the ``PackedSequence`` would be ``adbc`` with ``batch_sizes=[2,1,1]``.
+        :func:`pack_padded_sequence`.  For instance, given data  ``abc`` and `x`
+        the :class:`PackedSequence` would contain data ``axbc`` with
+        ``batch_sizes=[2,1,1]``.
 
     Attributes:
         data (Variable): Variable containing packed sequence
@@ -136,7 +137,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     return PackedSequence(data, batch_sizes)
 
 
-def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0):
+def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0, total_length=None):
     # See comment on _symbolic_pack_padded_sequence
     data, lengths = g.op("prim::PadPacked", input.data, input.batch_sizes, outputs=2)
     if batch_first:
@@ -145,7 +146,7 @@ def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0
 
 
 @torch.onnx.symbolic_override_packed_sequence_based(_symbolic_pad_packed_sequence)
-def pad_packed_sequence(sequence, batch_first=False, padding_value=0):
+def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_length=None):
     r"""Pads a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
@@ -161,6 +162,10 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0):
         batch_first (bool, optional): if ``True``, the output will be in ``B x T x *``
             format.
         padding_value (float, optional): values for padded elements.
+        total_length (int, optional): if not ``None``, the output will be padded to
+            have length :attr:`total_length`. This method will throw :class:`ValueError`
+            if :attr:`total_length` is less than the max sequence length in
+            :attr:`sequence`.
 
     Returns:
         Tuple of Variable containing the padded sequence, and Variable
@@ -169,7 +174,15 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0):
     """
     var_data, batch_sizes = sequence
     max_batch_size = int(batch_sizes[0])
-    output = var_data.data.new(len(batch_sizes), max_batch_size, *var_data.size()[1:]).fill_(padding_value)
+    max_seq_length = batch_sizes.size(0)
+    if total_length is not None:
+        if total_length < max_seq_length:
+            raise ValueError("Expected total_length to be at least the length "
+                             "of the longest sequence in input, but got "
+                             "total_length={} and max sequence length being {}"
+                             .format(total_length, max_seq_length))
+        max_seq_length = total_length
+    output = var_data.data.new(max_seq_length, max_batch_size, *var_data.size()[1:]).fill_(padding_value)
     output = Variable(output)
 
     lengths = []

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -139,8 +139,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
 
 def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0, total_length=None):
     if total_length is not None:
-        raise ValueError("_symbolic_pad_packed_sequence only supports "
-                         "_symbolic_pad_packed_sequence=None")
+        raise ValueError("_symbolic_pad_packed_sequence only supports total_length=None")
     # See comment on _symbolic_pack_padded_sequence
     data, lengths = g.op("prim::PadPacked", input.data, input.batch_sizes, outputs=2)
     if batch_first:

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -125,7 +125,11 @@ def symbolic_override_first_arg_based(symbolic_fn):
     def might_trace(args):
         import torch
         first_arg = args[0]
-        return torch.is_tensor(first_arg) and torch._C._jit_is_tracing(first_arg)
+        if not torch.is_tensor(first_arg):
+            raise ValueError('First argument of {} is expected to be a tensor, '
+                             'but got an object of type {}'
+                             .format(symbolic_fn.__name__, type(first_arg)))
+        return torch._C._jit_is_tracing(first_arg)
 
     return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, might_trace)
 
@@ -146,6 +150,6 @@ def symbolic_override_packed_sequence_based(symbolic_fn):
             raise ValueError('pad_packed_sequence expects sequence to be a '
                              'PackedSequence, but got an object of type {}'
                              .format(type(first_arg)))
-        return torch.is_tensor(first_arg[0]) and torch._C._jit_is_tracing(first_arg[0])
+        return torch._C._jit_is_tracing(first_arg[0])
 
     return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, might_trace)

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -124,7 +124,8 @@ def symbolic_override_first_arg_based(symbolic_fn):
 
     def might_trace(args):
         import torch
-        return torch._C._jit_is_tracing(args[0])
+        first_arg = args[0]
+        return torch.is_tensor(first_arg) and torch._C._jit_is_tracing(first_arg)
 
     return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, might_trace)
 
@@ -140,6 +141,11 @@ def symbolic_override_packed_sequence_based(symbolic_fn):
 
     def might_trace(args):
         import torch
-        return torch._C._jit_is_tracing(args[0][0])
+        first_arg = args[0]
+        if not isinstance(first_arg, torch.nn.utils.rnn.PackedSequence):
+            raise ValueError('pad_packed_sequence expects sequence to be a '
+                             'PackedSequence, but got an object of type {}'
+                             .format(type(first_arg)))
+        return torch.is_tensor(first_arg[0]) and torch._C._jit_is_tracing(first_arg[0])
 
     return functools.partial(_symbolic_override_wrapper_maker, symbolic_fn, might_trace)


### PR DESCRIPTION
Add example on how to use pack->rnn->unpack with DataParallel.
Fix incorrect comment on hooks with DataParallel.

Fixes #6299 