### PR TITLE
Using a function registry for THD init_methods for easy extension

### DIFF
--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -64,9 +64,12 @@ void DataChannelGloo::RequestGloo::wait() {
   _request.wait();
 }
 
-DataChannelGloo::Group::Group(const std::string& addr, port_type port,
-                                      std::vector<rank_type> ranks, rank_type max_rank,
-                                      int store_socket)
+
+DataChannelGloo::Group::Group(const std::string& addr,
+                              port_type port,
+                              std::vector<rank_type> ranks,
+                              rank_type max_rank,
+                              int store_socket)
   : DataChannel::Group(std::move(ranks), max_rank)
   , _store(new Store(addr, port, store_socket)) {}
 

--- a/torch/lib/THD/base/init_methods/InitMethod.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.cpp
@@ -9,6 +9,12 @@ InitMethod::Config initFile(std::string argument, rank_type world_size,
                             std::string group_name, int rank);
 InitMethod::Config initEnv(int world_size, std::string group_name, int rank);
 
+#ifdef WITH_THD_FB
+InitMethod::Config initFb(const std::string& runId,
+                          rank_type worldSize,
+                          const std::string& groupName,
+                          int rank);
+#endif
 }
 
 InitMethod::Config getInitConfig(std::string argument, int world_size,
@@ -35,7 +41,15 @@ InitMethod::Config getInitConfig(std::string argument, int world_size,
     } else if (argument.find("file://") == 0) {
       argument.erase(0, 7); // chop "file://"
       config = init::initFile(argument, r_world_size, group_name, rank);
+
+#ifdef WITH_THD_FB
+    } else if (argument.find("fb://") == 0) {
+      argument.erase(0, 5); // chop "fb://"
+      config = init::initFb(argument, r_world_size, group_name, rank);
+#endif
+
     }
+
   }
 
   config.validate();

--- a/torch/lib/THD/base/init_methods/InitMethod.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.cpp
@@ -1,57 +1,59 @@
 #include "InitMethod.hpp"
 
+#ifdef THD_INIT_EXTENSION_H
+#define INCF(F) INCF_(F)
+#define INCF_(F) #F
+#include INCF(THD_INIT_EXTENSION_H)
+#endif
+
 namespace thd {
 namespace init {
 
-InitMethod::Config initTCP(std::string argument, rank_type world_size,
-                           std::string group_name, int rank);
-InitMethod::Config initFile(std::string argument, rank_type world_size,
-                            std::string group_name, int rank);
-InitMethod::Config initEnv(int world_size, std::string group_name, int rank);
+InitMethod::Config initTCP(std::string argument,
+                           int world_size_r,
+                           std::string group_name,
+                           int rank);
+InitMethod::Config initFile(std::string argument,
+                            int world_size_r,
+                            std::string group_name,
+                            int rank);
+InitMethod::Config initEnv(std::string argument,
+                           int world_size_r,
+                           std::string group_name,
+                           int rank);
 
-#ifdef WITH_THD_FB
-InitMethod::Config initFb(const std::string& runId,
-                          rank_type worldSize,
-                          const std::string& groupName,
-                          int rank);
+InitMethodFuncMap initMethods({
+    {"env://", ::thd::init::initEnv},
+    {"file://", ::thd::init::initFile},
+    {"tcp://", ::thd::init::initTCP}
+
+#ifdef THD_INIT_EXTENSION_H
+    ,
+    /**
+     * Additional method pairs can be defined in THD_INIT_EXTENSION_H header
+     * to extend the init methods
+     */
+    THD_INIT_EXTENSION_METHODS
 #endif
-}
 
-InitMethod::Config getInitConfig(std::string argument, int world_size,
-                                 std::string group_name, int rank) {
+});
+
+} // namespace init
+
+InitMethod::Config getInitConfig(std::string argument,
+                                 int world_size,
+                                 std::string group_name,
+                                 int rank) {
+
   InitMethod::Config config;
-  if (argument.find("env://") == 0) {
-    config = init::initEnv(world_size, group_name, rank);
-  } else {
-    rank_type r_world_size;
-    try {
-      r_world_size = convertToRank(world_size);
-    } catch(std::exception& e) {
-      if (rank == -1)
-        throw std::invalid_argument("world_size is not set - it is required for "
-                                    "`tcp://` and `file://` init methods with this backend");
-      throw std::invalid_argument("invalid world_size");
+
+  for (auto& methodPair : init::initMethods) {
+    auto initMethodPrefix = methodPair.first;
+    auto initMethodFunc = methodPair.second;
+    if (argument.find(initMethodPrefix) == 0) {
+      config = initMethodFunc(argument, world_size, group_name, rank);
     }
-
-    group_name.append("#"); // To make sure it's not empty
-
-    if (argument.find("tcp://") == 0) {
-      argument.erase(0, 6); // chop "tcp://"
-      config = init::initTCP(argument, r_world_size, group_name, rank);
-    } else if (argument.find("file://") == 0) {
-      argument.erase(0, 7); // chop "file://"
-      config = init::initFile(argument, r_world_size, group_name, rank);
-
-#ifdef WITH_THD_FB
-    } else if (argument.find("fb://") == 0) {
-      argument.erase(0, 5); // chop "fb://"
-      config = init::initFb(argument, r_world_size, group_name, rank);
-#endif
-
-    }
-
   }
-
   config.validate();
   return config;
 }

--- a/torch/lib/THD/base/init_methods/InitMethod.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <stdexcept>
 #include <tuple>
+#include <unordered_map>
+
 
 namespace thd {
 
@@ -62,6 +64,15 @@ struct InitMethod {
     }
   };
 };
+
+namespace init {
+
+using InitMethodFuncMap =
+  std::unordered_map<std::string,
+  std::function<::thd::InitMethod::Config(std::string, int, std::string, int)>>;
+
+} // namespace init
+
 
 InitMethod::Config getInitConfig(std::string argument, int world_size = -1,
                                  std::string group_name = "", int rank = -1);

--- a/torch/lib/THD/base/init_methods/InitMethodEnv.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodEnv.cpp
@@ -43,11 +43,14 @@ rank_type maybeLoadEnv(const char* env_name, int value, std::string parameter_na
 
 } // anonymous namespace
 
-InitMethod::Config initEnv(int world_size, std::string group_name, int rank) {
+InitMethod::Config initEnv(std::string argument, /* unused */
+                           int world_size_r,
+                           std::string group_name,
+                           int rank) {
   InitMethod::Config config;
 
   config.rank = maybeLoadEnv(RANK_ENV, rank, "rank");
-  config.world_size = maybeLoadEnv(WORLD_SIZE_ENV, world_size, "world_size");
+  config.world_size = maybeLoadEnv(WORLD_SIZE_ENV, world_size_r, "world_size");
 
   if (group_name != "") {
     throw std::runtime_error("group_name is not supported in env:// init method");

--- a/torch/lib/THD/base/init_methods/InitMethodFile.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodFile.cpp
@@ -153,9 +153,20 @@ parseFile(std::fstream& file, rank_type world_size, std::string group_name) {
 } // anonymous namespace
 
 
+InitMethod::Config initFile(std::string argument,
+                            int world_size_r,
+                            std::string group_name,
+                            int assigned_rank) {
 
-InitMethod::Config initFile(std::string file_path, rank_type world_size,
-                            std::string group_name, int assigned_rank) {
+  group_name.append("#"); // To make sure it's not empty
+  std::string file_path = argument.substr(7); // chop "file://"
+  rank_type world_size;
+  try {
+    world_size = convertToRank(world_size_r);
+  } catch(std::exception& e) {
+    throw std::invalid_argument("invalid world_size");
+  }
+
   InitMethod::Config config;
   int fd;
   std::size_t order;

--- a/torch/lib/THD/base/init_methods/InitMethodFile.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodFile.cpp
@@ -150,29 +150,6 @@ parseFile(std::fstream& file, rank_type world_size, std::string group_name) {
   return std::make_tuple(master_port, master_addrs, ranks);
 }
 
-rank_type getRank(const std::vector<int>& ranks, int assigned_rank,
-                  std::size_t order) {
-  if (assigned_rank >= 0) {
-    return assigned_rank;
-  } else {
-    std::vector<bool> taken_ranks(ranks.size());
-    for (auto rank : ranks) {
-      if (rank >= 0)
-        taken_ranks[rank] = true;
-    }
-
-    auto unassigned = std::count(ranks.begin(), ranks.begin() + order, -1) + 1;
-    rank_type rank = 0;
-    while (true) {
-      if (!taken_ranks[rank]) unassigned--;
-      if (unassigned == 0) break;
-      rank++;
-    }
-
-    return rank;
-  }
-}
-
 } // anonymous namespace
 
 

--- a/torch/lib/THD/base/init_methods/InitMethodFile.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodFile.cpp
@@ -164,6 +164,10 @@ InitMethod::Config initFile(std::string argument,
   try {
     world_size = convertToRank(world_size_r);
   } catch(std::exception& e) {
+    if (world_size_r == -1) {
+      throw std::invalid_argument("world_size is not set - it is required for "
+                                  "`file://` init methods with this backend");
+    }
     throw std::invalid_argument("invalid world_size");
   }
 

--- a/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
@@ -306,6 +306,10 @@ InitMethod::Config initTCP(std::string argument, int world_size_r,
   try {
     world_size = convertToRank(world_size_r);
   } catch(std::exception& e) {
+    if (world_size_r == -1) {
+      throw std::invalid_argument("world_size is not set - it is required for "
+                                  "`tcp://` init methods with this backend");
+    }
     throw std::invalid_argument("invalid world_size");
   }
 

--- a/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
@@ -297,8 +297,18 @@ InitMethod::Config initTCPMulticast(std::string group_name, rank_type world_size
 
 } // anonymous namespace
 
-InitMethod::Config initTCP(std::string argument, rank_type world_size,
+InitMethod::Config initTCP(std::string argument, int world_size_r,
                            std::string group_name, int rank) {
+
+  group_name.append("#"); // To make sure it's not empty
+  argument.erase(0, 6); // chop "tcp://"
+  rank_type world_size;
+  try {
+    world_size = convertToRank(world_size_r);
+  } catch(std::exception& e) {
+    throw std::invalid_argument("invalid world_size");
+  }
+
   // Parse arguments
   std::string address, str_port;
   std::tie(address, str_port) = splitAddress(argument);

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
@@ -83,4 +83,28 @@ std::pair<std::string, std::string> discoverMaster(std::vector<std::string> addr
   return std::make_pair(master_address, my_address);
 }
 
+// Get the rank based on the order of writing, helper for file:// init method
+rank_type getRank(const std::vector<int>& ranks, int assigned_rank,
+                  std::size_t order) {
+  if (assigned_rank >= 0) {
+    return assigned_rank;
+  } else {
+    std::vector<bool> taken_ranks(ranks.size());
+    for (auto rank : ranks) {
+      if (rank >= 0)
+        taken_ranks[rank] = true;
+    }
+
+    auto unassigned = std::count(ranks.begin(), ranks.begin() + order, -1) + 1;
+    rank_type rank = 0;
+    while (true) {
+      if (!taken_ranks[rank]) unassigned--;
+      if (unassigned == 0) break;
+      rank++;
+    }
+
+    return rank;
+  }
+
+}
 }

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
@@ -83,7 +83,6 @@ std::pair<std::string, std::string> discoverMaster(std::vector<std::string> addr
   return std::make_pair(master_address, my_address);
 }
 
-// Get the rank based on the order of writing, helper for file:// init method
 rank_type getRank(const std::vector<int>& ranks, int assigned_rank,
                   std::size_t order) {
   if (assigned_rank >= 0) {

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
@@ -15,4 +15,7 @@ std::string discoverWorkers(int listen_socket, rank_type world_size);
 std::pair<std::string, std::string>
 discoverMaster(std::vector<std::string> addresses, port_type port);
 
+rank_type getRank(const std::vector<int>& ranks,
+                  int assigned_rank,
+                  std::size_t order);
 } // namespace thd

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
@@ -15,6 +15,7 @@ std::string discoverWorkers(int listen_socket, rank_type world_size);
 std::pair<std::string, std::string>
 discoverMaster(std::vector<std::string> addresses, port_type port);
 
+// Helper that gets the rank based on the input order
 rank_type getRank(const std::vector<int>& ranks,
                   int assigned_rank,
                   std::size_t order);


### PR DESCRIPTION
Use a hash map to register all available init_method functions so that we can make easy extension.

Some refactoring, such as refactoring a helper function of file:// method out to the helper header.