### PR TITLE
Update dist test to use multi gpus

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -4,6 +4,9 @@ if [[ "$BUILD_ENVIRONMENT" == "pytorch-linux-xenial-py3-clang5-asan" ]]; then
   exec "$(dirname "${BASH_SOURCE[0]}")/build-asan.sh" $*
 fi
 
+# Add nccl2 for distributed test.
+apt-get install libnccl-dev libnccl2
+
 # Required environment variable: $BUILD_ENVIRONMENT
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -183,8 +183,8 @@ class _DistTestBase(object):
             apply_hack_for_nccl()
 
         nGPUs_per_process = nGPUs // world_size
-        rank_to_GPU = {i: visible_devices[i * nGPUs_per_process: (i + 1) * nGPUs_per_process]
-                       for i in list(range(world_size))}
+        rank_to_GPU = {i: list(visible_devices[i * nGPUs_per_process: (i + 1) * nGPUs_per_process])
+                       for i in range(world_size)}
         return rank_to_GPU
 
     # GET RANK

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -183,7 +183,8 @@ class _DistTestBase(object):
             apply_hack_for_nccl()
 
         nGPUs_per_process = nGPUs // world_size
-        rank_to_GPU = {i : visible_devices[i * nGPUs_per_process : (i + 1) * nGPUs_per_process] for i in list(range(world_size))}
+        rank_to_GPU = {i: visible_devices[i * nGPUs_per_process: (i + 1) * nGPUs_per_process]
+                       for i in list(range(world_size))}
         return rank_to_GPU
 
     # GET RANK


### PR DESCRIPTION
This PR is motivated by #5877 that some arch doesn't support broadcast/all_gather/reduce/all_reduce on the same gpu.  
- Update broadcast/all_gather/reduce/all_reduce cuda tests to use multi gpus instead of one gpu.
- Now multigpu tests skips when available gpus < number of processes. 
- With this PR, we will be able to test both multigpu tests and new_group tests on 4gpu machines.
