### PR TITLE
Generic version of pixel_shuffle - 1d, 2d, ..., nd

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1659,21 +1659,21 @@ def pixel_shuffle(input, upscale_factor):
     Examples::
         # 1D example
         >>> ps = nn.PixelShuffle(2)
-        >>> input = autograd.Variable(torch.Tensor(1, 4, 8))
+        >>> input = torch.Tensor(1, 4, 8)
         >>> output = ps(input)
         >>> print(output.size())
         torch.Size([1, 2, 16])
 
         # 2D example
         >>> ps = nn.PixelShuffle(3)
-        >>> input = autograd.Variable(torch.Tensor(1, 9, 8, 8))
+        >>> input = torch.Tensor(1, 9, 8, 8)
         >>> output = ps(input)
         >>> print(output.size())
         torch.Size([1, 1, 24, 24])
 
         # 3D example
         >>> ps = nn.PixelShuffle(2)
-        >>> input = autograd.Variable(torch.Tensor(1, 8, 16, 16, 16))
+        >>> input = torch.Tensor(1, 8, 16, 16, 16)
         >>> output = ps(input)
         >>> print(output.size())
         torch.Size([1, 1, 32, 32, 32])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1645,10 +1645,9 @@ def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=Tr
 
 
 def pixel_shuffle(input, upscale_factor):
-    r"""Rearranges elements in a tensor of shape
-    ``[*, C, d_{1}, d_{2}, ..., d_{n}]`` to a tensor of shape
-    ``[*, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r]``. Where ``n`` is the
-    dimensionality of the data.
+    r"""Rearranges elements in a Tensor of shape :math:`(N, C, d_{1}, d_{2}, ..., d_{n})` to a
+    tensor of shape :math:`(N, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r)`.
+    Where :math:`n` is the dimensionality of the data.
 
     See :class:`~torch.nn.PixelShuffle` for details.
 
@@ -1658,23 +1657,20 @@ def pixel_shuffle(input, upscale_factor):
 
     Examples::
         # 1D example
-        >>> ps = nn.PixelShuffle(2)
         >>> input = torch.Tensor(1, 4, 8)
-        >>> output = ps(input)
+        >>> output = F.pixel_shuffle(input, 2)
         >>> print(output.size())
         torch.Size([1, 2, 16])
 
         # 2D example
-        >>> ps = nn.PixelShuffle(3)
         >>> input = torch.Tensor(1, 9, 8, 8)
-        >>> output = ps(input)
+        >>> output = F.pixel_shuffle(input, 3)
         >>> print(output.size())
         torch.Size([1, 1, 24, 24])
 
         # 3D example
-        >>> ps = nn.PixelShuffle(2)
         >>> input = torch.Tensor(1, 8, 16, 16, 16)
-        >>> output = ps(input)
+        >>> output = F.pixel_shuffle(input, 2)
         >>> print(output.size())
         torch.Size([1, 1, 32, 32, 32])
     """

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1649,10 +1649,13 @@ def pixel_shuffle(input, upscale_factor):
     ``[*, C, d_{1}, d_{2}, ..., d_{n}]`` to a tensor of shape
     ``[*, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r]``. Where ``n`` is the
     dimensionality of the data.
+    
     See :class:`~torch.nn.PixelShuffle` for details.
+
     Args:
         input (Variable): Input
         upscale_factor (int): factor to increase spatial resolution by
+
     Examples::
         # 1D example
         >>> ps = nn.PixelShuffle(2)
@@ -1679,14 +1682,14 @@ def pixel_shuffle(input, upscale_factor):
     dimensionality = len(input_size) - 2
 
     input_size[1] //= (upscale_factor ** dimensionality)
-    output_size = [dim*upscale_factor for dim in input_size[2:]]
+    output_size = [dim * upscale_factor for dim in input_size[2:]]
 
     input_view = input.contiguous().view(
         input_size[0], input_size[1],
-        *([upscale_factor]*dimensionality), *(input_size[2:])
+        *(([upscale_factor] * dimensionality) + input_size[2:])
     )
 
-    indicies = list(range(2, 2 + 2*dimensionality))
+    indicies = list(range(2, 2 + 2 * dimensionality))
     indicies = indicies[1::2] + indicies[0::2]
 
     shuffle_out = input_view.permute(0, 1, *(indicies[::-1])).contiguous()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1649,7 +1649,7 @@ def pixel_shuffle(input, upscale_factor):
     ``[*, C, d_{1}, d_{2}, ..., d_{n}]`` to a tensor of shape
     ``[*, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r]``. Where ``n`` is the
     dimensionality of the data.
-    
+
     See :class:`~torch.nn.PixelShuffle` for details.
 
     Args:

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -24,7 +24,8 @@ class PixelShuffle(Module):
     Shape:
         - Input: :math:`(N, C, d_{1}, d_{2}, ..., d_{n})`
         - Output: :math:`(N, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r)`
-        Where :math:`n` is the dimensionality of the data, e.g. :math:`n-1` for 1D audio, :math:`n=2` for 2D images, etc.
+        Where :math:`n` is the dimensionality of the data, e.g. :math:`n-1` for 1D audio,
+        :math:`n=2` for 2D images, etc.
 
     Examples::
 

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -3,11 +3,16 @@ from .. import functional as F
 
 
 class PixelShuffle(Module):
-    r"""Rearranges elements in a Tensor of shape :math:`(*, r^2C, H, W)` to a
-    tensor of shape :math:`(C, rH, rW)`.
+    r"""Rearranges elements in a Tensor of shape :math:`(N, C, d_{1}, d_{2}, ..., d_{n})` to a
+    tensor of shape :math:`(N, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r)`.
+    Where :math:`n` is the dimensionality of the data.
 
     This is useful for implementing efficient sub-pixel convolution
     with a stride of :math:`1/r`.
+
+    Input Tensor must have at least 3 dimensions, e.g. :math:`(N, C, d_{1})` for 1D data,
+    but Tensors with any number of dimensions after :math:`(N, C, ...)` (where N is mini-batch size,
+    and C is channels) are supported.
 
     Look at the paper:
     `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
@@ -17,16 +22,32 @@ class PixelShuffle(Module):
         upscale_factor (int): factor to increase spatial resolution by
 
     Shape:
-        - Input: :math:`(N, C * \text{upscale_factor}^2, H, W)`
-        - Output: :math:`(N, C, H * \text{upscale_factor}, W * \text{upscale_factor})`
+        - Input: :math:`(N, C, d_{1}, d_{2}, ..., d_{n})`
+        - Output: :math:`(N, C/(r^n), d_{1}*r, d_{2}*r, ..., d_{n}*r)`
+        Where :math:`n` is the dimensionality of the data, e.g. :math:`n-1` for 1D audio, :math:`n=2` for 2D images, etc.
 
     Examples::
 
-        >>> ps = nn.PixelShuffle(3)
-        >>> input = torch.Tensor(1, 9, 4, 4)
+        # 1D example
+        >>> ps = nn.PixelShuffle(2)
+        >>> input = torch.Tensor(1, 4, 8)
         >>> output = ps(input)
         >>> print(output.size())
-        torch.Size([1, 1, 12, 12])
+        torch.Size([1, 2, 16])
+
+        # 2D example
+        >>> ps = nn.PixelShuffle(3)
+        >>> input = torch.Tensor(1, 9, 8, 8)
+        >>> output = ps(input)
+        >>> print(output.size())
+        torch.Size([1, 1, 24, 24])
+
+        # 3D example
+        >>> ps = nn.PixelShuffle(2)
+        >>> input = torch.Tensor(1, 8, 16, 16, 16)
+        >>> output = ps(input)
+        >>> print(output.size())
+        torch.Size([1, 1, 32, 32, 32])
 
     .. _Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network:
         https://arxiv.org/abs/1609.05158


### PR DESCRIPTION
Been implementing a CNN and needed a 1D pixel shuffle, I saw PR #5051 which someone made a 3D version, saw the comments asking for a generic version, here is my attempt. First PR to a major repo, sorry if I've done something terribly wrong. Thanks.

