### PR TITLE
Allow script_methods to be defined out of order

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2500,6 +2500,37 @@ class TestScript(TestCase):
                 if True:
                     a = 4
 
+    def test_script_define_order(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                pass
+
+            @torch.jit.script_method
+            def call_foo(self, input):
+                return self.foo(input)
+
+            @torch.jit.script_method
+            def foo(self, input):
+                return input + 1
+        m = M()
+        self.assertEqual(2, m.call_foo(torch.ones(())))
+
+    def test_script_define_order_recursive_fail(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                pass
+
+            @torch.jit.script_method
+            def call_foo(self, input):
+                return self.foo(input)
+
+            @torch.jit.script_method
+            def foo(self, input):
+                self.call_foo(input)
+
+        with self.assertRaisesRegex(RuntimeError, 'called recursively involving'):
+            M()
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -116,7 +116,7 @@ using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& 
 void defineMethodsInModule(
   Module & m,
   const std::vector<Def>& definitions,
-  const Resolver& resolver, /* determines how we handle free variables*/
+  const std::vector<Resolver>& resolvers, /* determines how we handle free variables in each definition*/
   std::shared_ptr<SugaredValue> self /* if non-null, the first argument to each def, is bound to this value */
 );
 
@@ -128,6 +128,7 @@ std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
 // a SimpleValue, otherwise pack all the values into a Tuple.
 std::shared_ptr<SugaredValue> packOutputs(Graph& g, at::ArrayRef<Value*> values);
 std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
+void ensureSizeMatches(SourceRange loc, size_t expected, size_t actual, const std::string& what);
 
 
 } // namespace script

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -1,12 +1,25 @@
 #include "torch/csrc/jit/script/module.h"
 #include "torch/csrc/jit/script/compiler.h"
+#include "torch/csrc/jit/script/error_report.h"
 
 namespace torch { namespace jit { namespace script {
 
-std::vector<Value*> Method::emit_call_to(Method & callee, ArrayRef<Value*> inputs) {
+
+struct RecursiveMethodCallError : public std::exception {};
+void placeholderCreator(Method&) {
+  throw RecursiveMethodCallError();
+}
+
+std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, ArrayRef<Value*> inputs) {
   JIT_ASSERT(!executor);
+  try {
+    callee.ensure_defined();
+  } catch (RecursiveMethodCallError&) {
+    throw ErrorReport(loc) << " method '" << callee.name()
+        << "' is called recursively involving this call site. Recursive calls are not supported";
+  }
   auto fn = callee.graph();
-  JIT_ASSERT(inputs.size() == callee.num_inputs());
+  ensureSizeMatches(loc, callee.num_inputs(), inputs.size(), "inputs");
   std::vector<Value*> all_inputs = inputs;
   // parameters to callee method (which become parameters to _this_ method
   // if they were not already)
@@ -14,6 +27,15 @@ std::vector<Value*> Method::emit_call_to(Method & callee, ArrayRef<Value*> input
     all_inputs.push_back(get_or_add_parameter(member));
   }
   return inlineCallTo(*graph(), *callee.graph(), all_inputs);
+}
+
+void Method::ensure_defined() {
+  if(method_creator) {
+    auto creator = method_creator;
+    method_creator = placeholderCreator;
+    creator(*this);
+    method_creator = nullptr;
+  }
 }
 
 }}}

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -715,8 +715,9 @@ class ScriptMeta(type(torch._C.ScriptModule)):
             if cls is type(self):
                 torch._C.ScriptModule.__init__(self)
             original_init(self, *args, **kwargs)
-            for m in methods:
-                self._create_method(m.ast, m.resolution_callback)
+            asts = [m.ast for m in methods]
+            rcbs = [m.resolution_callback for m in methods]
+            self._create_methods(asts, rcbs)
 
         cls.__init__ = init_then_register
         return super(ScriptMeta, cls).__init__(name, bases, attrs)


### PR DESCRIPTION
This modifies the registration process so that all script methods
in a ScriptModule are defined at once.

Method gains a `method_creator` callback that gets invoked when the
method is first called to define it if it has not already been defined.
Recursive cycles in this `method_creator` are checked.

This approach was chosen over first creating all the graphs and then
inlining the call sites because it will combine better with type
propagation for non-tensor types like tuples. e.g.

```
a = foo(b)
return bar(*a)
```
#6015