### PR TITLE
Move auto_gpu code into auto_gpu.cpp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -580,6 +580,7 @@ main_sources = [
     "torch/csrc/byte_order.cpp",
     "torch/csrc/torch.cpp",
     "torch/csrc/utils.cpp",
+    "torch/csrc/utils/auto_gpu.cpp",
     "torch/csrc/utils/cuda_lazy_init.cpp",
     "torch/csrc/utils/invalid_arguments.cpp",
     "torch/csrc/utils/object_ptr.cpp",

--- a/tools/cwrap/plugins/AutoGPU.py
+++ b/tools/cwrap/plugins/AutoGPU.py
@@ -10,5 +10,5 @@ class AutoGPU(CWrapPlugin):
     def process_pre_arg_assign(self, template, option):
         if not option.get('auto_gpu', True):
             return template
-        call = 'AutoGPU auto_gpu(get_device(args));'
+        call = 'torch::AutoGPU auto_gpu(get_device(args));'
         return [call] + template

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -236,7 +236,7 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
   THStorage *storage = self->cdata;
-  AutoGPU gpu_guard(storage->device);
+  torch::AutoGPU gpu_guard(storage->device);
   THPObjectPtr tuple(PyTuple_New(5));
   THPObjectPtr device(PyLong_FromLong(storage->device));
   THPObjectPtr _handle(Py_None);
@@ -290,7 +290,7 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   size_t view_size =  (size_t)THPUtils_unpackLong(_view_size);
 
   int64_t device = THPUtils_unpackLong(_device);
-  AutoGPU __autogpu(device);
+  torch::AutoGPU __autogpu(device);
 
   char *buffer;
   Py_ssize_t handle_size;

--- a/torch/csrc/utils/auto_gpu.cpp
+++ b/torch/csrc/utils/auto_gpu.cpp
@@ -1,0 +1,65 @@
+#include <torch/csrc/utils/auto_gpu.h>
+
+#include <ATen/ATen.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#ifdef WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+namespace {
+void cudaCheck(cudaError_t err) {
+  if (err != cudaSuccess) {
+    std::string msg = "CUDA error (";
+    msg += std::to_string(err);
+    msg += "): ";
+    msg += cudaGetErrorString(err);
+    AT_ERROR("%s", msg.c_str());
+  }
+}
+} // namespace
+
+namespace torch {
+AutoGPU::AutoGPU(int device) {
+  setDevice(device);
+}
+
+AutoGPU::AutoGPU(const at::Tensor& t) {
+  setDevice(t.type().is_cuda() ? (int)t.get_device() : -1);
+}
+
+AutoGPU::AutoGPU(at::TensorList& tl) {
+  if (tl.size() > 0) {
+    auto& t = tl[0];
+    setDevice(t.type().is_cuda() ? t.get_device() : -1);
+  }
+}
+
+AutoGPU::~AutoGPU() {
+#ifdef WITH_CUDA
+  if (original_device != -1) {
+    cudaSetDevice(original_device);
+  }
+#endif
+}
+
+void AutoGPU::setDevice(int device) {
+#ifdef WITH_CUDA
+  if (device == -1) {
+    return;
+  }
+  if (original_device == -1) {
+    cudaCheck(cudaGetDevice(&original_device));
+    if (device != original_device) {
+      cudaCheck(cudaSetDevice(device));
+    }
+  } else {
+    cudaCheck(cudaSetDevice(device));
+  }
+#endif
+}
+} // namespace torch

--- a/torch/csrc/utils/auto_gpu.h
+++ b/torch/csrc/utils/auto_gpu.h
@@ -1,69 +1,17 @@
 #pragma once
 
-// RAII structs to set CUDA device
-
-#include <string>
-#include <stdexcept>
-
 #include <ATen/ATen.h>
 
-#ifdef WITH_CUDA
-#include <cuda.h>
-#include <cuda_runtime.h>
-#endif
-
+namespace torch {
+// RAII structs to set CUDA device
 struct AutoGPU {
-  explicit AutoGPU(int device=-1) {
-    setDevice(device);
-  }
+  explicit AutoGPU(int device = -1);
+  explicit AutoGPU(const at::Tensor& t);
+  explicit AutoGPU(at::TensorList& tl);
+  ~AutoGPU();
 
-  explicit AutoGPU(const at::Tensor& t) {
-    setDevice(t.type().is_cuda() ? (int) t.get_device() : -1);
-  }
-
-  explicit AutoGPU(at::TensorList &tl) {
-    if (tl.size() > 0) {
-      auto& t = tl[0];
-      setDevice(t.type().is_cuda() ? t.get_device() : -1);
-    }
-  }
-
-  ~AutoGPU() {
-#ifdef WITH_CUDA
-    if (original_device != -1) {
-      cudaSetDevice(original_device);
-    }
-#endif
-  }
-
-  inline void setDevice(int device) {
-#ifdef WITH_CUDA
-    if (device == -1) {
-      return;
-    }
-    if (original_device == -1) {
-      cudaCheck(cudaGetDevice(&original_device));
-      if (device != original_device) {
-        cudaCheck(cudaSetDevice(device));
-      }
-    } else {
-      cudaCheck(cudaSetDevice(device));
-    }
-#endif
-  }
+  void setDevice(int device);
 
   int original_device = -1;
-
-private:
-#ifdef WITH_CUDA
-  static void cudaCheck(cudaError_t err) {
-    if (err != cudaSuccess) {
-      std::string msg = "CUDA error (";
-      msg += std::to_string(err);
-      msg += "): ";
-      msg += cudaGetErrorString(err);
-      throw std::runtime_error(msg);
-    }
-  }
-#endif
 };
+} // namespace torch


### PR DESCRIPTION
Fixes #6285 -- auto_gpu.h should be include-able without `WITH_CUDA`

Also puts `AutoGPU` into the `torch::` namespace, which I think is better style

CC @ebetica 