### PR TITLE
Increase margin of error for CPU perf test, and change test order

### DIFF
--- a/.jenkins/pytorch/perf_test/compare_with_baseline.py
+++ b/.jenkins/pytorch/perf_test/compare_with_baseline.py
@@ -47,13 +47,13 @@ z_value = (sample_mean - mean) / sigma
 
 print("z-value: ", z_value)
 
-if z_value >= 2:
+if z_value >= 3:
     raise Exception('''\n
-z-value >= 2, there is >97.7% chance of perf regression.\n
+z-value >= 3, there is high chance of perf regression.\n
 To reproduce this regression, run `cd .jenkins/pytorch/perf_test/ && bash ''' + test_name + '''.sh` on your local machine and compare the runtime before/after your code change.
 ''')
 else:
-    print("z-value < 2, no perf regression detected.")
+    print("z-value < 3, no perf regression detected.")
     if args.update:
         print("We will use these numbers as new baseline.")
         new_data_file_path = '../new_{}_runtime.json'.format(backend)
@@ -61,6 +61,6 @@ else:
             new_data = json.load(new_data_file)
         new_data[test_name] = {}
         new_data[test_name]['mean'] = sample_mean
-        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.02)
+        new_data[test_name]['sigma'] = max(sample_sigma, sample_mean * 0.1)
         with open(new_data_file_path, 'w') as new_data_file:
             json.dump(new_data, new_data_file, indent=4)

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -49,10 +49,13 @@ if [[ "$COMMIT_SOURCE" == master ]]; then
     export TEST_MODE="compare_and_update"
 fi
 
-run_test test_cpu_speed_mini_sequence_labeler 20 ${TEST_MODE}
-run_test test_cpu_speed_mnist 20 ${TEST_MODE}
+# Operator tests
 run_test test_cpu_speed_torch ${TEST_MODE}
 run_test test_cpu_speed_torch_tensor ${TEST_MODE}
+
+# Sample model tests
+run_test test_cpu_speed_mini_sequence_labeler 20 ${TEST_MODE}
+run_test test_cpu_speed_mnist 20 ${TEST_MODE}
 
 if [[ "$COMMIT_SOURCE" == master ]]; then
     # This could cause race condition if we are testing the same master commit twice,


### PR DESCRIPTION
Currently we are using bare metal machines for CPU perf tests which should make the perf numbers more stable (especially for operator perf tests). However, there are still some cross-machine differences and system noise even with CPU isolation and frequency control enabled, so we need to increase the margin of error a bit.

Also moving operator tests before sample model tests, so that if there is slowdown in any of the operators we will detect it earlier, instead of having to dig into the sample model to find out what went wrong.