### PR TITLE
Fix activation images not showing up on official website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ test/data/linear.pt
 .ninja_log
 compile_commands.json
 *.egg-info/
-docs/source/_static/img/activation/
+docs/source/scripts/activation_images/
 
 ## General
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,7 +125,7 @@ html_logo = '_static/img/pytorch-logo-dark.svg'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['_static', '_images']
 
 # html_style_path = 'css/pytorch_theme.css'
 html_context = {

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -15,13 +15,10 @@ import pylab
 
 
 # Create a directory for the images, if it doesn't exist
-DOCS_PATH = os.path.realpath(os.path.join(__file__, "../../.."))
 ACTIVATION_IMAGE_PATH = os.path.join(
-    DOCS_PATH,
-    "source/_static/img/activation/"
+    os.path.realpath(os.path.join(__file__, "..")),
+    "activation_images"
 )
-
-print(ACTIVATION_IMAGE_PATH)
 
 if not os.path.exists(ACTIVATION_IMAGE_PATH):
     os.mkdir(ACTIVATION_IMAGE_PATH)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -56,7 +56,7 @@ class ReLU(Threshold):
     r"""Applies the rectified linear unit function element-wise
     :math:`\text{ReLU}(x)= \max(0, x)`
 
-    .. image:: _static/img/activation/ReLU.png
+    .. image:: scripts/activation_images/ReLU.png
 
     Args:
         inplace: can optionally do the operation in-place. Default: ``False``
@@ -147,7 +147,7 @@ class Hardtanh(Module):
     The range of the linear region :math:`[-1, 1]` can be adjusted using
     :attr:`min_val` and :attr:`max_val`.
 
-    .. image:: _static/img/activation/Hardtanh.png
+    .. image:: scripts/activation_images/Hardtanh.png
 
     Args:
         min_val: minimum value of the linear region range. Default: -1
@@ -204,7 +204,7 @@ class ReLU6(Hardtanh):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/ReLU6.png
+    .. image:: scripts/activation_images/ReLU6.png
 
     Examples::
 
@@ -229,7 +229,7 @@ class Sigmoid(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Sigmoid.png
+    .. image:: scripts/activationscripts/activation_images/Sigmoid.png
 
     Examples::
 
@@ -251,7 +251,7 @@ class Tanh(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Tanh.png
+    .. image:: scripts/activation_images/Tanh.png
 
     Examples::
 
@@ -277,7 +277,7 @@ class ELU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/ELU.png
+    .. image:: scripts/activation_images/ELU.png
 
     Examples::
 
@@ -305,7 +305,7 @@ class SELU(Module):
     with :math:`\alpha = 1.6732632423543772848170429916717` and
     :math:`\text{scale} = 1.0507009873554804934193349852946`.
 
-    .. image:: _static/img/activation/SELU.png
+    .. image:: scripts/activation_images/SELU.png
 
     More details can be found in the paper `Self-Normalizing Neural Networks`_ .
 
@@ -389,7 +389,7 @@ class Hardshrink(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Hardshrink.png
+    .. image:: scripts/activation_images/Hardshrink.png
 
     Examples::
 
@@ -429,7 +429,7 @@ class LeakyReLU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/LeakyReLU.png
+    .. image:: scripts/activation_images/LeakyReLU.png
 
     Examples::
 
@@ -459,7 +459,7 @@ class LogSigmoid(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/LogSigmoid.png
+    .. image:: scripts/activation_images/LogSigmoid.png
 
     Examples::
 
@@ -490,7 +490,7 @@ class Softplus(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Softplus.png
+    .. image:: scripts/activation_images/Softplus.png
 
     Examples::
 
@@ -532,7 +532,7 @@ class Softshrink(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Softshrink.png
+    .. image:: scripts/activation_images/Softshrink.png
 
     Examples::
 
@@ -580,7 +580,7 @@ class PReLU(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/PReLU.png
+    .. image:: scripts/activation_images/PReLU.png
 
     Examples::
 
@@ -609,7 +609,7 @@ class Softsign(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Softsign.png
+    .. image:: scripts/activation_images/Softsign.png
 
     Examples::
 
@@ -630,7 +630,7 @@ class Tanhshrink(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: _static/img/activation/Tanhshrink.png
+    .. image:: scripts/activation_images/Tanhshrink.png
 
     Examples::
 


### PR DESCRIPTION
For some reason, Sphinx ***copies*** all images referenced in docs to a folder it automatically creates, `_images`, and ***changes*** all the references to the new path under `_images`. For example, the actual ELU image is at http://pytorch.org/docs/master/_static/img/activation/ELU.png, as indicated by the code https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/activation.py#L280. However, website has a link to `http://pytorch.org/docs/master/_images/ELU.png`.

There doesn't seem to be a way to turn off such behavior. This PR adds `_images` to `html_static_path`, and changes the activation image directory to somewhere out of `_static` so we don't get the same images twice in our static assets.

Fixes #5677 .

cc @pmitros 