### PR TITLE
Redo tensor repr to make it less verbose

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -104,10 +104,6 @@ def _number_format(tensor, min_sz=-1):
     scale = 1
     exp_max = int(exp_max)
     prec = PRINT_OPTS.precision
-
-    scale = 1
-    exp_max = int(exp_max)
-    prec = PRINT_OPTS.precision
     if int_mode:
         if exp_max > prec + 1:
             format = '{{:11.{}e}}'.format(prec)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -189,12 +189,10 @@ def _str(self):
     suffix = ')'
     if not torch._C._is_default_type_cuda():
         if self.device.type == 'cuda':
-            suffix = ', device=' + repr(self.device.index) + suffix
+            suffix = ', device=\'' + str(self.device) + '\'' + suffix
     else:
-        if self.device.type == 'cpu':
-            suffix = ', device=' + repr(self.device.type) + suffix
-        elif torch.cuda.current_device() != self.device.index:
-            suffix = ', device=' + repr(self.device.index) + suffix
+        if self.device.type == 'cpu' or torch.cuda.current_device() != self.device.index:
+            suffix = ', device=\'' + str(self.device) + '\'' + suffix
 
     if self.dtype != torch.get_default_dtype() and self.dtype != torch.int64:
         suffix = ', dtype=' + str(self.dtype) + suffix

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -139,9 +139,8 @@ def _number_format(tensor, min_sz=-1):
     return format, scale, sz
 
 
-def _scalar_str(self):
-    fmt, _, _ = _number_format(self)
-    scalar_str = fmt.format(self.item())
+def _scalar_str(self, fmt, scale):
+    scalar_str = fmt.format(self.item() / scale)
     # The leading space for positives is ugly on scalars, so we strip it
     if scalar_str[0] == ' ':
         return scalar_str[1:]
@@ -169,7 +168,7 @@ def _tensor_str(self, indent, fmt, scale, sz):
     dim = self.dim()
 
     if dim == 0:
-        return _scalar_str(self)
+        return _scalar_str(self, fmt, scale)
     if dim == 1:
         return _vector_str(self, indent, fmt, scale, sz)
 

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -193,10 +193,12 @@ def _str(self):
     type_str = 'tensor'
     prefix = type_str + '('
     indent = len(prefix)
+
+    suffix = ')'
+    if str(self.device.type) != 'cpu':
+        suffix = ', device=\'' + str(self.device.type) + '\'' + suffix
     if str(self.dtype) not in IMPLICIT_DTYPES:
-        suffix = ', dtype=' + str(self.dtype) + ')'
-    else:
-        suffix = ')'
+        suffix = ', dtype=' + str(self.dtype) + suffix
 
     if self.numel() == 0:
         tensor_str = '[]'

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -139,7 +139,7 @@ def _scalar_str(self, fmt, scale):
 
 
 def _vector_str(self, indent, fmt, scale, sz, summarize):
-    element_length = sz + 2
+    element_length = sz + 3
     elements_per_line = int(math.floor((PRINT_OPTS.linewidth - indent) / (element_length)))
     char_per_line = element_length * elements_per_line
 
@@ -151,7 +151,7 @@ def _vector_str(self, indent, fmt, scale, sz, summarize):
         data = [fmt.format(val.item() / scale) for val in self]
 
     data_lines = [data[i:i + elements_per_line] for i in range(0, len(data), elements_per_line)]
-    lines = [','.join(line) for line in data_lines]
+    lines = [', '.join(line) for line in data_lines]
     return '[' + (',' + '\n' + ' ' * (indent + 1)).join(lines) + ']'
 
 
@@ -187,16 +187,16 @@ def _str(self):
     summarize = self.numel() > PRINT_OPTS.threshold
 
     suffix = ')'
-    if not torch.is_default_cuda_device():
+    if not torch._C._is_default_type_cuda():
         if self.device.type == 'cuda':
-            suffix = ', device=' + str(self.device.index) + suffix
+            suffix = ', device=' + repr(self.device.index) + suffix
     else:
         if self.device.type == 'cpu':
-            suffix = ', device=\'' + self.device.type + '\'' + suffix
+            suffix = ', device=' + repr(self.device.type) + suffix
         elif torch.cuda.current_device() != self.device.index:
-            suffix = ', device=' + str(self.device.index) + suffix
+            suffix = ', device=' + repr(self.device.index) + suffix
 
-    if self.dtype != torch.get_default_dtype() and str(self.dtype) != 'torch.int64':
+    if self.dtype != torch.get_default_dtype() and self.dtype != torch.int64:
         suffix = ', dtype=' + str(self.dtype) + suffix
 
     if self.numel() == 0:

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -13,6 +13,7 @@ class __PrinterOptions(object):
 
 PRINT_OPTS = __PrinterOptions()
 SCALE_FORMAT = '{:.5e} *\n'
+IMPLICIT_DTYPES = ['torch.int64', 'torch.float32']
 
 
 # We could use **kwargs, but this will give better docs
@@ -28,8 +29,8 @@ def set_printoptions(
     Args:
         precision: Number of digits of precision for floating point output
             (default = 8).
-        threshold: Total number of array elements which trigger summarization
-            rather than full `repr` (default = 1000).
+        threshold: Upper bound of dim size for a full representation. Dims with
+            larger size will be summarized (default = 1000).
         edgeitems: Number of array items in summary at beginning and end of
             each dimension (default = 3).
         linewidth: The number of characters per line for the purpose of
@@ -138,178 +139,71 @@ def _number_format(tensor, min_sz=-1):
     return format, scale, sz
 
 
-def _tensor_str(self):
-    n = PRINT_OPTS.edgeitems
-    has_hdots = self.size()[-1] > 2 * n
-    has_vdots = self.size()[-2] > 2 * n
-    print_full_mat = not has_hdots and not has_vdots
-    formatter = _number_format(self, min_sz=3 if not print_full_mat else 0)
-    print_dots = self.numel() >= PRINT_OPTS.threshold
-
-    dim_sz = max(2, max(len(str(x)) for x in self.size()))
-    dim_fmt = "{:^" + str(dim_sz) + "}"
-    dot_fmt = u"{:^" + str(dim_sz + 1) + "}"
-
-    counter_dim = self.ndimension() - 2
-    counter = torch.LongStorage(counter_dim).fill_(0)
-    counter[counter.size() - 1] = -1
-    finished = False
-    strt = ''
-    while True:
-        nrestarted = [False for i in counter]
-        nskipped = [False for i in counter]
-        for i in range(counter_dim - 1, -1, -1):
-            counter[i] += 1
-            if print_dots and counter[i] == n and self.size(i) > 2 * n:
-                counter[i] = self.size(i) - n
-                nskipped[i] = True
-            if counter[i] == self.size(i):
-                if i == 0:
-                    finished = True
-                counter[i] = 0
-                nrestarted[i] = True
-            else:
-                break
-        if finished:
-            break
-        elif print_dots:
-            if any(nskipped):
-                for hdot in nskipped:
-                    strt += dot_fmt.format('...') if hdot \
-                        else dot_fmt.format('')
-                strt += '\n'
-            if any(nrestarted):
-                strt += ' '
-                for vdot in nrestarted:
-                    strt += dot_fmt.format(u'\u22EE' if vdot else '')
-                strt += '\n'
-        if strt != '':
-            strt += '\n'
-        strt += '({},.,.) = \n'.format(
-            ','.join(dim_fmt.format(i) for i in counter))
-        submatrix = reduce(lambda t, i: t.select(0, i), counter, self)
-        strt += _matrix_str(submatrix, ' ', formatter, print_dots)
-    return strt
+def _scalar_str(self):
+    fmt, _, _ = _number_format(self)
+    scalar_str = fmt.format(self.item())
+    # The leading space for positives is ugly on scalars, so we strip it
+    if scalar_str[0] == ' ':
+        return scalar_str[1:]
+    return scalar_str
 
 
-def __repr_row(row, indent, fmt, scale, sz, truncate=None):
-    if truncate is not None:
-        dotfmt = " {:^5} "
-        return (indent +
-                ' '.join(fmt.format(val.item() / scale) for val in row[:truncate]) +
-                dotfmt.format('...') +
-                ' '.join(fmt.format(val.item() / scale) for val in row[-truncate:]) +
-                '\n')
+def _vector_str(self, indent, fmt, scale, sz):
+    element_length = sz + 2
+    elements_per_line = int(math.floor((PRINT_OPTS.linewidth - indent) / (element_length)))
+    char_per_line = element_length * elements_per_line
+
+    if self.size(0) > PRINT_OPTS.threshold:
+        data = ([fmt.format(val.item() / scale) for val in self[:PRINT_OPTS.edgeitems]] +
+                [' ...'] +
+                [fmt.format(val.item() / scale) for val in self[-PRINT_OPTS.edgeitems:]])
     else:
-        return indent + ' '.join(fmt.format(val.item() / scale) for val in row) + '\n'
+        data = [fmt.format(val.item() / scale) for val in self]
+
+    data_lines = [data[i:i + elements_per_line] for i in range(0, len(data), elements_per_line)]
+    lines = [','.join(line) for line in data_lines]
+    return '[' + (',' + '\n' + ' ' * (indent + 1)).join(lines) + ']'
 
 
-def _matrix_str(self, indent='', formatter=None, force_truncate=False):
-    n = PRINT_OPTS.edgeitems
-    has_hdots = self.size(1) > 2 * n
-    has_vdots = self.size(0) > 2 * n
-    print_full_mat = not has_hdots and not has_vdots
+def _tensor_str(self, indent, fmt, scale, sz):
+    empty = self.numel() == 0
+    dim = self.dim()
 
-    if formatter is None:
-        fmt, scale, sz = _number_format(self,
-                                        min_sz=5 if not print_full_mat else 0)
+    if empty:
+        return '[]'
+    if dim == 0:
+        return _scalar_str(self)
+    if dim == 1:
+        return _vector_str(self, indent, fmt, scale, sz)
+
+    if self.size(0) > PRINT_OPTS.threshold:
+        slices = ([_tensor_str(self[i], indent + 1, fmt, scale, sz) for i in range(0, PRINT_OPTS.edgeitems)] +
+                  ['...'] +
+                  [_tensor_str(self[i], indent + 1, fmt, scale, sz) for i in range(len(self) - PRINT_OPTS.edgeitems,
+                                                                                   len(self))])
     else:
-        fmt, scale, sz = formatter
-    nColumnPerLine = int(math.floor((PRINT_OPTS.linewidth - len(indent)) / (sz + 1)))
-    strt = ''
-    firstColumn = 0
+        slices = [_tensor_str(self[i], indent + 1, fmt, scale, sz) for i in range(0, self.size(0))]
 
-    if not force_truncate and \
-       (self.numel() < PRINT_OPTS.threshold or print_full_mat):
-        while firstColumn < self.size(1):
-            lastColumn = min(firstColumn + nColumnPerLine - 1, self.size(1) - 1)
-            if nColumnPerLine < self.size(1):
-                strt += '\n' if firstColumn != 1 else ''
-                strt += 'Columns {} to {} \n{}'.format(
-                    firstColumn, lastColumn, indent)
-            if scale != 1:
-                strt += SCALE_FORMAT.format(scale)
-            for l in range(self.size(0)):
-                strt += indent + (' ' if scale != 1 else '')
-                row_slice = self[l, firstColumn:lastColumn + 1]
-                strt += ' '.join(fmt.format(val.item() / scale) for val in row_slice)
-                strt += '\n'
-            firstColumn = lastColumn + 1
-    else:
-        if scale != 1:
-            strt += SCALE_FORMAT.format(scale)
-        if has_vdots and has_hdots:
-            vdotfmt = "{:^" + str((sz + 1) * n - 1) + "}"
-            ddotfmt = u"{:^5}"
-            for row in self[:n]:
-                strt += __repr_row(row, indent, fmt, scale, sz, n)
-            strt += indent + ' '.join([vdotfmt.format('...'),
-                                       ddotfmt.format(u'\u22F1'),
-                                       vdotfmt.format('...')]) + "\n"
-            for row in self[-n:]:
-                strt += __repr_row(row, indent, fmt, scale, sz, n)
-        elif not has_vdots and has_hdots:
-            for row in self:
-                strt += __repr_row(row, indent, fmt, scale, sz, n)
-        elif has_vdots and not has_hdots:
-            vdotfmt = u"{:^" + \
-                str(len(__repr_row(self[0], '', fmt, scale, sz))) + \
-                "}\n"
-            for row in self[:n]:
-                strt += __repr_row(row, indent, fmt, scale, sz)
-            strt += vdotfmt.format(u'\u22EE')
-            for row in self[-n:]:
-                strt += __repr_row(row, indent, fmt, scale, sz)
-        else:
-            for row in self:
-                strt += __repr_row(row, indent, fmt, scale, sz)
-    return strt
+    tensor_str = (',' + '\n' * (dim - 1) + ' ' * (indent + 1)).join(slices)
+    return '[' + tensor_str + ']'
 
 
-def _vector_str(self):
-    fmt, scale, sz = _number_format(self)
-    strt = ''
-    ident = ''
-    n = PRINT_OPTS.edgeitems
-    dotfmt = u"{:^" + str(sz) + "}\n"
-    if scale != 1:
-        strt += SCALE_FORMAT.format(scale)
-        ident = ' '
-    if self.numel() < PRINT_OPTS.threshold:
-        return (strt +
-                '\n'.join(ident + fmt.format(val.item() / scale) for val in self) +
-                '\n')
-    else:
-        return (strt +
-                '\n'.join(ident + fmt.format(val.item() / scale) for val in self[:n]) +
-                '\n' + (ident + dotfmt.format(u"\u22EE")) +
-                '\n'.join(ident + fmt.format(val.item() / scale) for val in self[-n:]) +
-                '\n')
-
-
-def _str(self, include_footer=True):
+def _str(self):
     if self.is_sparse:
         size_str = str(tuple(self.shape)).replace(' ', '')
         return '{} of size {} with indices:\n{}and values:\n{}'.format(
             self.type(), size_str, self._indices(), self._values())
 
-    empty = self.numel() == 0
-    dim = self.dim()
-
-    if empty:
-        strt = ''
-    elif dim == 0:
-        strt = _vector_str(self.unsqueeze(0))
-    elif dim == 1:
-        strt = _vector_str(self)
-    elif dim == 2:
-        strt = _matrix_str(self)
+    type_str = 'tensor'
+    prefix = type_str + '('
+    indent = len(prefix)
+    if str(self.dtype) not in IMPLICIT_DTYPES:
+        suffix = ', dtype=' + str(self.dtype) + ')'
     else:
-        strt = _tensor_str(self)
+        suffix = ')'
 
-    if include_footer:
-        size_str = str(tuple(self.shape)).replace(' ', '')
-        device_str = '' if not self.is_cuda else \
-            ' (GPU {})'.format(self.get_device())
-        strt += '[{} of size {}{}]\n'.format(self.type(), size_str, device_str)
-    return '\n' + strt
+    fmt, scale, sz = _number_format(self)
+    if scale != 1:
+        prefix = prefix + SCALE_FORMAT.format(scale) + ' ' * indent
+
+    return prefix + _tensor_str(self, indent, fmt, scale, sz) + suffix

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -166,11 +166,8 @@ def _vector_str(self, indent, fmt, scale, sz):
 
 
 def _tensor_str(self, indent, fmt, scale, sz):
-    empty = self.numel() == 0
     dim = self.dim()
 
-    if empty:
-        return '[]'
     if dim == 0:
         return _scalar_str(self)
     if dim == 1:
@@ -202,8 +199,12 @@ def _str(self):
     else:
         suffix = ')'
 
-    fmt, scale, sz = _number_format(self)
-    if scale != 1:
-        prefix = prefix + SCALE_FORMAT.format(scale) + ' ' * indent
+    if self.numel() == 0:
+        tensor_str = '[]'
+    else:
+        fmt, scale, sz = _number_format(self)
+        if scale != 1:
+            prefix = prefix + SCALE_FORMAT.format(scale) + ' ' * indent
+        tensor_str = _tensor_str(self, indent, fmt, scale, sz)
 
-    return prefix + _tensor_str(self, indent, fmt, scale, sz) + suffix
+    return prefix + tensor_str + suffix

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -337,6 +337,15 @@ PyObject *THPModule_getDefaultDtype(PyObject *_unused, PyObject *arg) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject *THPModule_isDefaultCudaDevice(PyObject *_unused, PyObject *arg) {
+  HANDLE_TH_ERRORS
+  if (torch::tensor::get_default_tensor_type().is_cuda()) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyMethodDef TorchMethods[] = {
   {"_initExtension",  (PyCFunction)THPModule_initExtension,   METH_O,       NULL},
   {"_autograd_init",  (PyCFunction)THPAutograd_initExtension, METH_NOARGS,  NULL},
@@ -362,6 +371,7 @@ static PyMethodDef TorchMethods[] = {
   {"_from_dlpack",    (PyCFunction)THPModule_fromDLPack,        METH_O,       NULL},
   {"set_flush_denormal", (PyCFunction)THPModule_setFlushDenormal, METH_O,     NULL},
   {"get_default_dtype", (PyCFunction)THPModule_getDefaultDtype, METH_NOARGS,  NULL},
+  {"is_default_cuda_device", (PyCFunction)THPModule_isDefaultCudaDevice, METH_NOARGS,  NULL},
   {NULL, NULL, 0, NULL}
 };
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -337,7 +337,7 @@ PyObject *THPModule_getDefaultDtype(PyObject *_unused, PyObject *arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject *THPModule_isDefaultCudaDevice(PyObject *_unused, PyObject *arg) {
+PyObject *THPModule_isDefaultTypeCuda(PyObject *_unused, PyObject *arg) {
   HANDLE_TH_ERRORS
   if (torch::tensor::get_default_tensor_type().is_cuda()) {
     Py_RETURN_TRUE;
@@ -371,7 +371,7 @@ static PyMethodDef TorchMethods[] = {
   {"_from_dlpack",    (PyCFunction)THPModule_fromDLPack,        METH_O,       NULL},
   {"set_flush_denormal", (PyCFunction)THPModule_setFlushDenormal, METH_O,     NULL},
   {"get_default_dtype", (PyCFunction)THPModule_getDefaultDtype, METH_NOARGS,  NULL},
-  {"is_default_cuda_device", (PyCFunction)THPModule_isDefaultCudaDevice, METH_NOARGS,  NULL},
+  {"_is_default_type_cuda", (PyCFunction)THPModule_isDefaultTypeCuda, METH_NOARGS,  NULL},
   {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
Title. Examples provided below.

Significant changes (other than formatting):
- Sizes are no longer part of the repr.
- Display dtype instead of type (e.g. float32 instead of FloatTensor)

Empty:
```
>>> torch.tensor([])
tensor([])
```

Scalar:
```
>>> torch.tensor(100)
tensor(100)
```

1D:
```
>>> torch.randn(20)
tensor([-0.3225,-1.0179, 1.3177, 1.0829, 0.1708, 0.4451,-0.4671, 1.1321,
         0.0285, 0.3850,-0.0745, 0.3912,-0.0662,-0.2261,-0.4382, 0.5156,
        -0.3133, 0.0793,-0.0671, 0.6090])
```

Scale (hard-set scale to 10 as example):
```
>>> torch.randn(10)
tensor(1.00000e+01 *
       [-0.0241,-0.2531,-0.0023, 0.0380, 0.0109,-0.0101, 0.0374,-0.1697,
         0.0766, 0.1862])
```

Non-implicit dtype:
```
>>> torch.randn(5, dtype=torch.double)
tensor([ 1.1187,-1.2429,-1.5682, 0.2103, 0.2173], dtype=torch.float64)
```

cuda device:
```
>>> torch.tensor([0, 1], device='cuda')
tensor([ 0, 1], device=0)
```

2D:
```
>>> torch.randn(5,5)
tensor([[ 0.4689,-0.2254, 1.0060,-0.0027, 1.3418],
        [ 0.3166, 0.9713,-0.5512,-0.0706, 0.3047],
        [-1.0237, 0.3690,-0.0451, 1.4027, 0.2283],
        [ 1.5179, 0.9648,-1.5397,-0.0465,-1.0271],
        [-1.5810,-0.2934,-0.3857,-0.1103,-1.2429]])
```

1D summary:
```
>>> torch.randn(1001)
tensor([-0.2113, 1.5050, 0.7872, ..., 0.4174,-0.9017,-1.2375])
```

3D summary:
```
>>> torch.randn(1001,1001,3)
tensor([[[ 1.1539e+00, 5.5699e-01, 1.5193e+00],
         [-5.7911e-01,-1.0207e+00, 1.0766e+00],
         [ 2.2488e-01, 3.6755e-01, 1.0367e+00],
         ...,
         [ 5.7927e-01,-6.9180e-01,-1.2032e+00],
         [ 7.5431e-01, 7.3371e-01,-1.1157e+00],
         [-1.7434e+00, 1.0118e+00,-1.6678e+00]],

        [[-4.1321e-01,-1.8674e+00,-3.9380e-01],
         [-4.5715e-01, 3.2232e-01,-6.0878e-01],
         [-1.6399e+00, 3.9053e-01, 1.7743e+00],
         ...,
         [-2.9087e-01,-6.7453e-01, 6.2942e-01],
         [ 1.5851e+00,-6.4737e-01,-2.2366e-01],
         [-5.7277e-01,-1.6936e+00,-2.5473e+00]],

        [[ 4.2778e-01,-6.8880e-01, 7.1877e-01],
         [ 1.3075e-01, 5.5504e-01,-6.7323e-01],
         [-5.9847e-01,-1.0324e+00, 3.0142e-01],
         ...,
         [ 1.7984e+00, 6.6690e-01,-8.7549e-01],
         [-2.0979e-01, 9.3018e-01,-4.9681e-01],
         [-1.9342e+00, 8.0857e-01,-6.9766e-01]],

        ...,

        [[ 2.3617e-01,-5.4105e-01,-7.6282e-01],
         [-8.2386e-01,-1.0196e+00,-2.3154e-01],
         [ 2.5711e-01,-7.0430e-01,-1.5103e+00],
         ...,
         [ 2.5889e+00,-4.3254e-01,-4.0883e-01],
         [-1.1788e+00,-9.8844e-01,-1.2041e+00],
         [ 1.2577e-03, 2.0017e-01,-5.5707e-01]],

        [[-2.3928e-01,-3.7653e-01, 2.0728e-01],
         [ 7.1701e-01,-1.1953e+00,-1.3592e+00],
         [ 1.7066e-02, 7.2409e-01, 3.2263e-01],
         ...,
         [-8.6556e-01,-2.2042e-01, 3.4651e-01],
         [ 2.6873e-01, 5.5645e-01, 2.9774e-01],
         [-9.0797e-01, 6.0665e-02,-7.1512e-02]],

        [[ 6.4865e-02,-9.3285e-01, 5.5386e-01],
         [-1.0970e+00,-4.7877e-01,-1.8353e-01],
         [ 6.6718e-01, 6.8817e-01,-3.5309e-01],
         ...,
         [ 1.5515e-01,-1.4189e-02, 8.1571e-01],
         [ 9.6813e-01,-8.4871e-01,-7.0699e-01],
         [-4.6691e-01,-1.6481e+00,-1.3582e+00]]])
```