### PR TITLE
Fix typos in pytorch docs

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -324,7 +324,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   auto indices_data = device_ptr(indices.data<int64_t>());
 
   // FIXME: thrust::unique only removes consecutive elements that are equal.
-  // We have race conditions when indices contains duplicates which are not
+  // We have race conditions when indices contain duplicates which are not
   // adjacent
   auto unique_indices = indices.type().tensor(indices.numel());
   auto unique_data = device_ptr(unique_indices.data<int64_t>());

--- a/tools/cwrap/plugins/__init__.py
+++ b/tools/cwrap/plugins/__init__.py
@@ -212,7 +212,7 @@ class CWrapPlugin(object):
 
         '(PyObject*)Py_TYPE(PyTuple_GET_ITEM(args, 1)) == THPTensorClass'
 
-        This function can be overriden to support modifying this check string.
+        This function can be overridden to support modifying this check string.
         For example, if an argument can be null, we might want to check and see
         if the type is Py_None, as well.
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1219,7 +1219,7 @@ it were a 1-D tensor.
 
 If :attr:`accumulate` is ``True``, the elements in :attr:`tensor` are added to
 :attr:`self`. If accumulate is ``False``, the behavior is undefined if indices
-contains duplicate elements.
+contain duplicate elements.
 
 Args:
     indices (LongTensor): the indices into self

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -33,7 +33,7 @@ def set_printoptions(
         edgeitems: Number of array items in summary at beginning and end of
             each dimension (default = 3).
         linewidth: The number of characters per line for the purpose of
-            inserting line breaks (default = 80). Thresholded matricies will
+            inserting line breaks (default = 80). Thresholded matrices will
             ignore this parameter.
         profile: Sane defaults for pretty printing. Can override with any of
             the above options. (any one of `default`, `short`, `full`)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4152,7 +4152,7 @@ randn(*sizes, out=None) -> Tensor
 
 Returns a tensor filled with random numbers from a normal distribution
 with zero mean and variance of one (also called the standard normal
-distirbution).
+distribution).
 
 .. math::
     \text{out}_{i} \sim \mathcal{N}(0, 1)
@@ -5880,7 +5880,7 @@ Arguments:
 Returns:
     Tensor: A tensor of shape equal to the broadcasted shape of :attr:`condition`, :attr:`x`, :attr:`y`
 
-Excemple::
+Example::
 
     >>> x = torch.randn(3, 2)
     >>> y = torch.ones(3, 2)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -152,7 +152,7 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
     def forward(ctx, *args, **kwargs):
         """Performs the operation.
 
-        This function is to be overriden by all subclasses.
+        This function is to be overridden by all subclasses.
 
         It must accept a context ctx as the first argument, followed by any
         number of arguments (tensors or other types).
@@ -166,7 +166,7 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
     def backward(ctx, *grad_outputs):
         """Defines a formula for differentiating the operation.
 
-        This function is to be overriden by all subclasses.
+        This function is to be overridden by all subclasses.
 
         It must accept a context ctx as the first argument, followed by as many
         outputs did :func:`forward` return, and it should return as many

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -35,7 +35,7 @@ taking action :math:`a` in state :math:`s` given policy :math:`\pi^\theta`.
 
 In practice we would sample an action from the output of a network, apply this
 action in an environment, and then use ``log_prob`` to construct an equivalent
-loss function. Note that we use a negative because optimisers use gradient
+loss function. Note that we use a negative because optimizers use gradient
 descent, whilst the rule above assumes gradient ascent. With a categorical
 policy, the code for implementing REINFORCE would be as follows::
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -118,7 +118,7 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
         LU_data (Tensor): the packed LU factorization data
         LU_pivots (Tensor): the packed LU factorization pivots
         unpack_data (bool): flag indicating if the data should be unpacked
-        unpack_pivots (bool): tlag indicating if the pivots should be unpacked
+        unpack_pivots (bool): flag indicating if the pivots should be unpacked
 
     Example::
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -625,7 +625,7 @@ def relu(input, inplace=False):
 relu_ = _add_docstr(torch.relu_, r"""
 relu_(input) -> Tensor
 
-In-place verison of :func:`~relu`.
+In-place version of :func:`~relu`.
 """)
 
 
@@ -695,7 +695,7 @@ def elu(input, alpha=1., inplace=False):
 elu_ = _add_docstr(torch._C._nn.elu_, r"""
 elu_(input, alpha=1.) -> Tensor
 
-In-place verison of :func:`~elu`.
+In-place version of :func:`~elu`.
 """)
 
 
@@ -716,7 +716,7 @@ def selu(input, inplace=False):
 selu_ = _add_docstr(torch.selu_, r"""
 selu_(input) -> Tensor
 
-In-place verison of :func:`~selu`.
+In-place version of :func:`~selu`.
 """)
 
 
@@ -1843,7 +1843,7 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
 
     For each output location, :attr:`grid` has `x`, `y`
     input pixel locations which are used to compute output.
-    In the case of 5D inputes, :attr:`grid` has `x`, `y`, `z` pixel locations.
+    In the case of 5D inputs, :attr:`grid` has `x`, `y`, `z` pixel locations.
 
     .. Note::
         To avoid confusion in notation, let's note that `x` corresponds to the `width` dimension `IW`,
@@ -1895,7 +1895,7 @@ def pad(input, pad, mode='constant', value=0):
     r"""Pads tensor.
 
     `Nd` constant padding:  The number of dimensions to pad is
-        :math:`\left\lfloor\frac{len(padding)}{2}\right\rfloor` and the dimensions that gets padded begins with the
+        :math:`\left\lfloor\frac{len(padding)}{2}\right\rfloor` and the dimensions that get padded begins with the
         last dimension and moves forward. See below for examples.
 
     `1D`, `2D` and `3D` "reflect" / "replicate" padding:

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -177,7 +177,7 @@ def xavier_uniform_(tensor, gain=1):
     .. math::
         a = \text{gain} \times \sqrt{\frac{6}{\text{fan_in} + \text{fan_out}}}
 
-    Also known as Glorot initialisation.
+    Also known as Glorot initialization.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
@@ -204,7 +204,7 @@ def xavier_normal_(tensor, gain=1):
     .. math::
         \text{std} = \text{gain} \times \sqrt{\frac{2}{\text{fan_in} + \text{fan_out}}}
 
-    Also known as Glorot initialisation.
+    Also known as Glorot initialization.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
@@ -240,7 +240,7 @@ def kaiming_uniform_(tensor, a=0, mode='fan_in'):
     .. math::
         \text{bound} = \sqrt{\frac{6}{(1 + a^2) \times \text{fan_in}}}
 
-    Also known as He initialisation.
+    Also known as He initialization.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
@@ -273,7 +273,7 @@ def kaiming_normal_(tensor, a=0, mode='fan_in'):
     .. math::
         \text{std} = \sqrt{\frac{2}{(1 + a^2) \times \text{fan_in}}}
 
-    Also known as He initialisation.
+    Also known as He initialization.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -213,7 +213,7 @@ class PoissonNLLLoss(_Loss):
         \text{loss}(\text{input}, \text{target}) = \text{input} - \text{target} * \log(\text{input})
                                     + \log(\text{target!})
 
-    The last term can be omitted or approximised with Stirling formula. The
+    The last term can be omitted or approximated with Stirling formula. The
     approximation is used for target values more than 1. For targets less or
     equal to 1 zeros are added to the loss.
 
@@ -787,7 +787,7 @@ class MultiLabelSoftMarginLoss(_WeightedLoss):
 
 
 class CosineEmbeddingLoss(_Loss):
-    r"""Creates a criterion that measures the loss given  an input tensors
+    r"""Creates a criterion that measures the loss given input tensors
     :math:`x_1`, :math:`x_2` and a `Tensor` label `y` with values 1 or -1.
     This is used for measuring whether two inputs are similar or dissimilar,
     using the cosine distance, and is typically used for learning nonlinear

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -60,7 +60,7 @@ class Module(object):
     def forward(self, *input):
         r"""Defines the computation performed at every call.
 
-        Should be overriden by all subclasses.
+        Should be overridden by all subclasses.
 
         .. note::
             Although the recipe for forward pass needs to be defined within

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -648,7 +648,7 @@ class AvgPool3d(_AvgPoolNd):
 class FractionalMaxPool2d(Module):
     r"""Applies a 2D fractional max pooling over an input signal composed of several input planes.
 
-    Fractiona MaxPooling is described in detail in the paper `Fractional MaxPooling`_ by Ben Graham
+    Fractional MaxPooling is described in detail in the paper `Fractional MaxPooling`_ by Ben Graham
 
     The max-pooling operation is applied in :math:`kHxkW` regions by a stochastic
     step size determined by the target output size.

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -29,7 +29,7 @@ class RNNBase(Module):
         if not isinstance(dropout, numbers.Number) or not 0 <= dropout <= 1 or \
                 isinstance(dropout, bool):
             raise ValueError("dropout should be a number in range [0, 1] "
-                             "representing the probablity of an element being "
+                             "representing the probability of an element being "
                              "zeroed")
         if dropout > 0 and num_layers == 1:
             warnings.warn("dropout option adds dropout after all but last "
@@ -264,7 +264,7 @@ class RNN(RNNBase):
         batch_first: If ``True``, then the input and output tensors are provided
             as `(batch, seq, feature)`
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
-            RNN layer except the last layer, with dropout probablity equal to
+            RNN layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
@@ -358,7 +358,7 @@ class LSTM(RNNBase):
         batch_first: If ``True``, then the input and output tensors are provided
             as (batch, seq, feature)
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
-            LSTM layer except the last layer, with dropout probablity equal to
+            LSTM layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional LSTM. Default: ``False``
 
@@ -442,7 +442,7 @@ class GRU(RNNBase):
         batch_first: If ``True``, then the input and output tensors are provided
             as (batch, seq, feature)
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
-            GRU layer except the last layer, with dropout probablity equal to
+            GRU layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional GRU. Default: ``False``
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -114,7 +114,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     shortest one.
 
     Note:
-        This function accept any input that has at least two dimensions. You
+        This function accepts any input that has at least two dimensions. You
         can apply it to pack the labels, and use the output of the RNN with
         them to compute the loss directly. A Variable can be retrieved from
         a :class:`PackedSequence` object by accessing its ``.data`` attribute.

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -12,7 +12,7 @@ class Optimizer(object):
     """Base class for all optimizers.
 
     .. warning::
-        Parameters needs to be specified as collections that have a deterministic
+        Parameters need to be specified as collections that have a deterministic
         ordering that is consistent between runs. Examples of objects that don't
         satisfy those properties are sets and iterators over values of dictionaries.
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -385,7 +385,7 @@ def load(name,
     By default, the directory to which the build file is emitted and the
     resulting library compiled to is ``<tmp>/torch_extensions/<name>``, where
     ``<tmp>`` is the temporary folder on the current platform and ``<name>``
-    the name of the extension. This location can be overriden in two ways.
+    the name of the extension. This location can be overridden in two ways.
     First, if the ``TORCH_EXTENSIONS_DIR`` environment variable is set, it
     replaces ``<tmp>/torch_extensions`` and all extensions will be compiled
     into subfolders of this directory. Second, if the ``build_directory``
@@ -393,7 +393,7 @@ def load(name,
     the library will be compiled into that folder directly.
 
     To compile the sources, the default system compiler (``c++``) is used,
-    which can be overriden by setting the ``CXX`` environment variable. To pass
+    which can be overridden by setting the ``CXX`` environment variable. To pass
     additional arguments to the compilation process, ``extra_cflags`` or
     ``extra_ldflags`` can be provided. For example, to compile your extension
     with optimizations, pass ``extra_cflags=['-O3']``. You can also use

--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -39,7 +39,7 @@ def load_url(url, model_dir=None, map_location=None, progress=True):
 
     The default value of `model_dir` is ``$TORCH_HOME/models`` where
     ``$TORCH_HOME`` defaults to ``~/.torch``. The default directory can be
-    overriden with the ``$TORCH_MODEL_ZOO`` environment variable.
+    overridden with the ``$TORCH_MODEL_ZOO`` environment variable.
 
     Args:
         url (string): URL of the object to download


### PR DESCRIPTION
After I apply spell checker to pytorch docs, I fix clear typos.