### PR TITLE
Add CUDA headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -888,6 +888,7 @@ if __name__ == '__main__':
                 'lib/include/torch/csrc/autograd/*.h',
                 'lib/include/torch/csrc/jit/*.h',
                 'lib/include/torch/csrc/utils/*.h',
+                'lib/include/torch/csrc/cuda/*.h',
                 'lib/include/torch/torch.h',
             ]
         })


### PR DESCRIPTION
`lib/include/torch/csrc/cuda/*.h` headers are not copied during the install. Useful for compiling extensions so this adds those headers to the install. Not sure why they were not included already.

Cheers