### PR TITLE
[pytorch] add static linkage support for CuDNN and NCCL

### DIFF
--- a/aten/cmake/FindCuDNN.cmake
+++ b/aten/cmake/FindCuDNN.cmake
@@ -23,10 +23,17 @@ else($ENV{CUDNN_INCLUDE_DIR})
     PATH_SUFFIXES cuda/include include)
 endif($ENV{CUDNN_INCLUDE_DIR})
 
+IF ($ENV{USE_STATIC_CUDNN})
+  MESSAGE(STATUS "USE_STATIC_CUDNN detected. Linking against static CUDNN library")
+  SET(CUDNN_LIBNAME "libcudnn_static.a")
+ELSE()
+  SET(CUDNN_LIBNAME "cudnn")
+ENDIF()
+
 if($ENV{CUDNN_LIBRARY})
   SET(CUDNN_LIBRARY $ENV{CUDNN_LIBRARY})
 else($ENV{CUDNN_LIBRARY})
-  find_library(CUDNN_LIBRARY cudnn
+  find_library(CUDNN_LIBRARY ${CUDNN_LIBNAME}
     HINTS ${CUDNN_LIB_DIR} ${CUDNN_ROOT_DIR} ${CUDA_TOOLKIT_ROOT_DIR}
     PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 endif($ENV{CUDNN_LIBRARY})

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -246,8 +246,6 @@ set_property(TARGET tbb_static tbb_def_files PROPERTY FOLDER "dependencies")
 target_include_directories(tbb_static PUBLIC ${TBB_ROOT_DIR}/include)
 target_link_libraries(ATen tbb_static)
 
-SET_TARGET_PROPERTIES(ATen PROPERTIES VERSION 1 SOVERSION 1)
-
 if(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")
     SET_PROPERTY(TARGET ATen PROPERTY CXX_STANDARD 11)
 endif(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -342,21 +342,12 @@ IF(CUDA_FOUND)
   IF(USE_MAGMA)
     TARGET_LINK_LIBRARIES(ATen ${MAGMA_LIBRARIES})
     IF ($ENV{TH_BINARY_BUILD})
-      # because magma is linked statically and it wants a BLAS,
-      # we need to link the BLAS lib against THC. Usually TH will
-      # load a BLAS library and it's all fine, but in the binary builds,
-      # TH uses static linkage to MKL, so it doesn't have all symbols that
-      # magma needs. So in this case, explicitly find a BLAS and link against it
-      # just like in TH
-      SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../TH/cmake ${CMAKE_MODULE_PATH})
-      FIND_PACKAGE(BLAS)
-      IF(BLAS_FOUND)
-        TARGET_LINK_LIBRARIES(ATen "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
-      ELSE(BLAS_FOUND)
-        MESSAGE(FATAL_ERROR "Binary build needs blas to be found here")
-      ENDIF(BLAS_FOUND)
+      TARGET_LINK_LIBRARIES(ATen "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
     ENDIF($ENV{TH_BINARY_BUILD})
   ENDIF(USE_MAGMA)
+  IF ($ENV{ATEN_STATIC_CUDA})
+    TARGET_LINK_LIBRARIES(ATen "${CUDA_TOOLKIT_ROOT_DIR}/lib64/libculibos.a")
+  ENDIF($ENV{ATEN_STATIC_CUDA})
 ENDIF()
 
 INSTALL(TARGETS ATen

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -24,8 +24,15 @@ find_path(NCCL_INCLUDE_DIRS
   ${NCCL_ROOT_DIR}/include
   ${CUDA_TOOLKIT_ROOT_DIR}/include)
 
+IF ($ENV{USE_STATIC_NCCL})
+  MESSAGE(STATUS "USE_STATIC_NCCL detected. Linking against static NCCL library")
+  SET(NCCL_LIBNAME "libnccl_static.a")
+ELSE()
+  SET(NCCL_LIBNAME "nccl")
+ENDIF()
+
 find_library(NCCL_LIBRARIES
-  NAMES nccl
+  NAMES ${NCCL_LIBNAME}
   HINTS
   ${NCCL_LIB_DIR}
   ${NCCL_ROOT_DIR}

--- a/setup.py
+++ b/setup.py
@@ -785,7 +785,7 @@ def make_relative_rpath(path):
 ################################################################################
 
 extensions = []
-packages = find_packages(exclude=('tools', 'tools.*',))
+packages = find_packages(exclude=('tools', 'tools.*', 'caffe2', 'caffe'))
 C = Extension("torch._C",
               libraries=main_libraries,
               sources=main_sources,

--- a/setup.py
+++ b/setup.py
@@ -544,7 +544,7 @@ include_dirs += [
 library_dirs.append(lib_path)
 
 # we specify exact lib names to avoid conflict with lua-torch installs
-ATEN_LIB = os.path.join(lib_path, 'libATen.so.1')
+ATEN_LIB = os.path.join(lib_path, 'libATen.so')
 THD_LIB = os.path.join(lib_path, 'libTHD.a')
 NCCL_LIB = os.path.join(lib_path, 'libnccl.so.1')
 
@@ -552,7 +552,7 @@ NCCL_LIB = os.path.join(lib_path, 'libnccl.so.1')
 NANOPB_STATIC_LIB = os.path.join(lib_path, 'libprotobuf-nanopb.a')
 
 if IS_DARWIN:
-    ATEN_LIB = os.path.join(lib_path, 'libATen.1.dylib')
+    ATEN_LIB = os.path.join(lib_path, 'libATen.dylib')
     NCCL_LIB = os.path.join(lib_path, 'libnccl.1.dylib')
 
 if IS_WINDOWS:

--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -9,6 +9,8 @@ WITH_CUDNN = False
 CUDNN_LIB_DIR = None
 CUDNN_INCLUDE_DIR = None
 CUDNN_LIBRARY = None
+WITH_STATIC_CUDNN = os.getenv("USE_STATIC_CUDNN")
+
 if WITH_CUDA and not check_env_flag('NO_CUDNN'):
     lib_paths = list(filter(bool, [
         os.getenv('CUDNN_LIB_DIR'),
@@ -63,7 +65,11 @@ if WITH_CUDA and not check_env_flag('NO_CUDNN'):
                 CUDNN_LIB_DIR = path
                 break
         else:
-            libraries = sorted(glob.glob(os.path.join(path, 'libcudnn*' + str(CUDNN_INCLUDE_VERSION) + "*")))
+            if WITH_STATIC_CUDNN is not None:
+                search_name = 'libcudnn_static.a'
+            else:
+                search_name = 'libcudnn*' + str(CUDNN_INCLUDE_VERSION) + "*"
+            libraries = sorted(glob.glob(os.path.join(path, search_name)))
             if libraries:
                 CUDNN_LIBRARY = libraries[0]
                 CUDNN_LIB_DIR = path

--- a/tools/setup_helpers/nccl.py
+++ b/tools/setup_helpers/nccl.py
@@ -15,6 +15,11 @@ NCCL_LIB_DIR = None
 NCCL_SYSTEM_LIB = None
 NCCL_INCLUDE_DIR = None
 NCCL_ROOT_DIR = None
+WITH_STATIC_NCCL = os.getenv("USE_STATIC_NCCL")
+LIBNCCL_PREFIX = "libnccl"
+if WITH_STATIC_NCCL is not None:
+    LIBNCCL_PREFIX = "libnccl_static"
+
 if WITH_CUDA and not check_env_flag('NO_SYSTEM_NCCL'):
     ENV_ROOT = os.getenv('NCCL_ROOT_DIR', None)
     LIB_DIR = os.getenv('NCCL_LIB_DIR', None)
@@ -49,12 +54,12 @@ if WITH_CUDA and not check_env_flag('NO_SYSTEM_NCCL'):
         path = os.path.expanduser(path)
         if path is None or not os.path.exists(path):
             continue
-        if glob.glob(os.path.join(path, 'libnccl*')):
+        if glob.glob(os.path.join(path, LIBNCCL_PREFIX + '*')):
             NCCL_LIB_DIR = path
             # try to find an exact versioned .so/.dylib, rather than libnccl.so
-            preferred_path = glob.glob(os.path.join(path, 'libnccl*[0-9]*'))
+            preferred_path = glob.glob(os.path.join(path, LIBNCCL_PREFIX + '*[0-9]*'))
             if len(preferred_path) == 0:
-                NCCL_SYSTEM_LIB = glob.glob(os.path.join(path, 'libnccl*'))[0]
+                NCCL_SYSTEM_LIB = glob.glob(os.path.join(path, LIBNCCL_PREFIX + '*'))[0]
             else:
                 NCCL_SYSTEM_LIB = os.path.realpath(preferred_path[0])
             break

--- a/torch/lib/THD/cmake/FindNCCL.cmake
+++ b/torch/lib/THD/cmake/FindNCCL.cmake
@@ -16,8 +16,15 @@ find_path (NCCL_INCLUDE_DIR
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/include)
 
+IF ($ENV{USE_STATIC_NCCL})
+  MESSAGE(STATUS "USE_STATIC_NCCL detected. Linking against static NCCL library")
+  SET(NCCL_LIBNAME "libnccl_static.a")
+ELSE()
+  SET(NCCL_LIBNAME "nccl")
+ENDIF()
+
 find_library (NCCL_LIBRARY
-  NAMES nccl
+  NAMES ${NCCL_LIBNAME}
   HINTS
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/lib


### PR DESCRIPTION
Statically linking CuDNN and NCCL2 allows us to `nvprune` the libraries and include only the architectures that we support. This saves > 100MB in binary size.

List of changes:
- add flags to look for libnccl_static.a instead of libnccl.so* (also included in gloo and upstreamed, updated submodule)
- add flags to look for libcudnn_static.a instead of libcudnn.so*
- when linking statically, we have to link against `libculibos.a`. Added an ATen flag for that

Additional minor changes:
- removed SOVERSION for libATen, in binaries it's being unlinked because of packaging dumbness out of our control
- in `setup.py`, exclude caffe, caffe2 folders as well from being included in package.