### PR TITLE
Use string comparison in OS check

### DIFF
--- a/tools/cpp_build/build_common.sh
+++ b/tools/cpp_build/build_common.sh
@@ -31,7 +31,7 @@ BUILD_TYPE=${BUILD_TYPE:-Debug}
 # Try to build with as many threads as we have cores, default to 4 if the
 # command fails.
 set +e
-if [[ "$(uname)" -eq "Linux" ]]; then
+if [[ "$(uname)" == "Linux" ]]; then
   # https://stackoverflow.com/questions/6481005/how-to-obtain-the-number-of-cpus-cores-in-linux-from-the-command-line
   JOBS="$(grep -c '^processor' /proc/cpuinfo)"
 else # if [[ "$(uname)" -eq "Darwin"]]


### PR DESCRIPTION
Fixes cpp build on macOS. The OS detection condition was always going into the `"Linux"` branch, which resulted in `JOBS` being undefined later on.