### PR TITLE
bottleneck supports better user-provided arguments

### DIFF
--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -11,7 +11,7 @@ Run it on the command line with
 
 ::
 
-    python -m torch.utils.bottleneck -- /path/to/source/script.py [args]
+    python -m torch.utils.bottleneck /path/to/source/script.py [args]
 
 where [args] are any number of arguments to `script.py`, or run
 ``python -m torch.utils.bottleneck -h`` for more usage instructions.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -406,12 +406,9 @@ class TestBottleneck(TestCase):
         curdir = os.path.dirname(os.path.abspath(__file__))
         filepath = '{}/{}'.format(curdir, test_file)
         if scriptargs != '':
-            mark = '-- '
             scriptargs = ' {}'.format(scriptargs)
-        else:
-            mark = ''
         rc, out, err = self._run(
-            'python -m torch.utils.bottleneck {}{}{}'.format(mark, filepath, scriptargs))
+            'python -m torch.utils.bottleneck {}{}'.format(filepath, scriptargs))
         return rc, out, err
 
     def _check_run_args(self):
@@ -463,7 +460,7 @@ class TestBottleneck(TestCase):
             self.assertIsNone(results, self._fail_msg('Should not tell users about CUDA', output))
 
     @unittest.skipIf(torch.cuda.is_available(), 'CPU-only test')
-    def test_cpu_only(self):
+    def test_bottleneck_cpu_only(self):
         rc, out, err = self._run_bottleneck('bottleneck/test.py')
         self.assertEqual(rc, 0, 'Run failed with\n{}'.format(err))
 
@@ -475,7 +472,7 @@ class TestBottleneck(TestCase):
 
     @unittest.skipIf(IS_WINDOWS, "FIXME: Intermittent CUDA out-of-memory error")
     @unittest.skipIf(not torch.cuda.is_available(), 'No CUDA')
-    def test_cuda(self):
+    def test_bottleneck_cuda(self):
         rc, out, err = self._run_bottleneck('bottleneck/test_cuda.py')
         self.assertEqual(rc, 0, 'Run failed with\n{}'.format(err))
 

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -218,7 +218,7 @@ def parse_args():
     parser.add_argument('scriptfile', type=str,
                         help='Path to the script to be run. '
                         'Usually run with `python path/to/script`.')
-    parser.add_argument('args', type=str, nargs='*',
+    parser.add_argument('args', type=str, nargs=argparse.REMAINDER,
                         help='Command-line arguments to be passed to the script.')
     return parser.parse_args()
 


### PR DESCRIPTION
Fixes #6312.

Changed bottleneck's arg parser to user argparse.REMAINDER. This lets
the user specify args as `python -m torch.utils.bottleneck script.py
[args]` (previously, a -- was needed after `bottleneck` and before
`script.py`).

cc @fmassa 

### Test Plan
Unit test in the bottleneck test suite. The test script errors out if any of the arguments are not provided.
