### PR TITLE
Slice (instead of copy) when indexing by a zero-dim tensor

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -156,6 +156,11 @@ class TestIndexing(TestCase):
         self.assertEqual(a[0, 1], a[zero, one])
         self.assertEqual(a[0, one], a[zero, 1])
 
+        # indexing by a scalar should slice (not copy)
+        self.assertEqual(a[0, 1].data_ptr(), a[zero, one].data_ptr())
+        self.assertEqual(a[1].data_ptr(), a[one.int()].data_ptr())
+        self.assertEqual(a[1].data_ptr(), a[one.short()].data_ptr())
+
         # scalar indexed with scalar
         r = torch.tensor(0.).normal_()
         with self.assertRaises(RuntimeError):

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -104,11 +104,6 @@ static Variable sequenceToVariable(const Type& type, PyObject* seq) {
   return torch::utils::legacy_new_from_data(idx_type, -1, seq);
 }
 
-static bool is_integral(const Tensor& t) {
-  auto scalar_type = t.type().scalarType();
-  return scalar_type == at::kLong || scalar_type == at::kInt || scalar_type == at::kShort;
-}
-
 static Variable valueToTensor(const Type & type, PyObject* value) {
   if (THPVariable_Check(value)) {
     return reinterpret_cast<THPVariable*>(value)->cdata;
@@ -153,7 +148,8 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       dim++;
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
-      if (var.dim() == 0 && is_integral(var)) {
+      auto scalar_type = var.type().scalarType();
+      if (var.dim() == 0 && at::isIntegralType(scalar_type) && scalar_type != at::kByte) {
         result = applySelect(result, dim, THPUtils_unpackLong(obj));
       } else {
         handle_var(var);


### PR DESCRIPTION
Fixes #6217

