### PR TITLE
Better warnings

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -29,8 +29,11 @@ if("${isSystemDir}" STREQUAL "-1")
 endif()
 
 IF(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "--std=c++11 -Wall -Wno-unknown-pragmas -Wno-vla -fexceptions ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "--std=c++11 -Wall -Wextra -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-unknown-pragmas -Wno-vla -fexceptions ${CMAKE_CXX_FLAGS}")
   set(CMAKE_C_FLAGS "-fexceptions ${CMAKE_C_FLAGS}")
+  if ($ENV{WERROR})
+    set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+  endif()
 ENDIF(NOT MSVC)
 
 INCLUDE(CheckCXXSourceCompiles)

--- a/setup.py
+++ b/setup.py
@@ -533,9 +533,9 @@ else:
         '-Wno-missing-field-initializers',
         '-Wno-write-strings',
         '-Wno-zero-length-array',
-        '-Wno-return-type-c-linkage',
         # Python 2.6 requires -fno-strict-aliasing, see
         # http://legacy.python.org/dev/peps/pep-3123/
+        # We also depend on it in our code (even Python 3).
         '-fno-strict-aliasing',
         # Clang has an unfixed bug leading to spurious missing
         # braces warnings, see

--- a/setup.py
+++ b/setup.py
@@ -535,7 +535,6 @@ else:
         '-Wno-write-strings',
         '-Wno-zero-length-array',
         '-Wno-return-type-c-linkage',
-        '-Wc++14-extensions',  # prevents use of C++14 features
         # Python 2.6 requires -fno-strict-aliasing, see
         # http://legacy.python.org/dev/peps/pep-3123/
         '-fno-strict-aliasing',

--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,7 @@ else:
         # https://bugs.llvm.org/show_bug.cgi?id=21629
         '-Wno-missing-braces'
     ]
-    if os.getenv('WERROR'):
+    if check_env_flag('WERROR'):
         extra_compile_args.append('-Werror')
 
 cwd = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -529,7 +529,6 @@ else:
         '-std=c++11',
         '-Wall',
         '-Wextra',
-        '-pedantic',
         '-Wno-unused-parameter',
         '-Wno-missing-field-initializers',
         '-Wno-write-strings',
@@ -555,14 +554,12 @@ tmp_install_path = lib_path + "/tmp_install"
 include_dirs += [
     cwd,
     os.path.join(cwd, "torch", "csrc"),
+    third_party_path + "/pybind11/include",
     tmp_install_path + "/include",
     tmp_install_path + "/include/TH",
     tmp_install_path + "/include/THNN",
     tmp_install_path + "/include/ATen",
 ]
-# -isystem treats the include as a system header, which prevents warnings from
-# surfacing.
-extra_compile_args.append('-isystem ' + third_party_path + "/pybind11/include")
 
 library_dirs.append(lib_path)
 
@@ -692,9 +689,7 @@ main_sources = [
 
 try:
     import numpy as np
-    # -isystem treats the include as a system header, which prevents warnings
-    # from surfacing.
-    extra_compile_args.append('-isystem ' + np.get_include())
+    include_dirs.append(np.get_include())
     extra_compile_args.append('-DWITH_NUMPY')
     WITH_NUMPY = True
 except ImportError:

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -8,7 +8,7 @@ namespace torch { namespace autograd {
 
 
 void InputBuffer::add(size_t pos, Variable var) {
-  TORCH_ASSERT(pos >= 0 && pos < buffer.size());
+  TORCH_ASSERT(pos < buffer.size());
   if (!var.defined()) {
     return;
   }

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -194,4 +194,4 @@ namespace std {
       return spec.hashCode();
     }
   };
-};
+}

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -124,7 +124,7 @@ void PropagateShapeOnNode(Node * node) {
   // XXX: real attributes of node can be a superset of attrs
   // XXX: if this returns true then you are obliged to set the types
   auto check_overload = [&](size_t num_inputs, size_t num_outputs,
-                            std::vector<std::pair<AttributeKind,Symbol>> attrs){
+                            std::vector<std::pair<AttributeKind,Symbol>> attrs = {}) -> bool {
     JIT_ASSERT(!handled);
     if (node->inputs().size() != num_inputs) return false;
     if (node->outputs().size() != num_outputs) return false;
@@ -160,11 +160,11 @@ void PropagateShapeOnNode(Node * node) {
       // logic in scalar cases is non-trivial. It's better to just run them.
     } break;
     case aten::neg: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
       node->output()->setType(types.at(0)->contiguous());
     } break;
     case aten::mm: {
-      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1, {})) break;
+      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1)) break;
       auto lhs_type = types.at(0);
       auto rhs_type = types.at(1);
       SHAPE_ASSERT(lhs_type->sizes().size() == 2 && rhs_type->sizes().size() == 2);
@@ -173,7 +173,7 @@ void PropagateShapeOnNode(Node * node) {
         at::IntList{lhs_type->sizes().at(0), rhs_type->sizes().at(1)}));
     } break;
     case aten::t: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
       auto tp = types.at(0);
       auto sizes = tp->sizes();
       auto strides = tp->strides();
@@ -209,7 +209,7 @@ void PropagateShapeOnNode(Node * node) {
           sizes.erase(sizes.begin() + dim);
         }
         node->output()->setType(tp->withSizes(sizes));
-      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) {
+      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) {
         node->output()->setType(types.at(0)->withSizes({}));
       }
     } break;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -124,7 +124,7 @@ void PropagateShapeOnNode(Node * node) {
   // XXX: real attributes of node can be a superset of attrs
   // XXX: if this returns true then you are obliged to set the types
   auto check_overload = [&](size_t num_inputs, size_t num_outputs,
-                            std::vector<std::pair<AttributeKind,Symbol>> attrs = {}) -> bool {
+                            std::vector<std::pair<AttributeKind,Symbol>> attrs){
     JIT_ASSERT(!handled);
     if (node->inputs().size() != num_inputs) return false;
     if (node->outputs().size() != num_outputs) return false;
@@ -160,11 +160,11 @@ void PropagateShapeOnNode(Node * node) {
       // logic in scalar cases is non-trivial. It's better to just run them.
     } break;
     case aten::neg: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
       node->output()->setType(types.at(0)->contiguous());
     } break;
     case aten::mm: {
-      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1, {})) break;
       auto lhs_type = types.at(0);
       auto rhs_type = types.at(1);
       SHAPE_ASSERT(lhs_type->sizes().size() == 2 && rhs_type->sizes().size() == 2);
@@ -173,7 +173,7 @@ void PropagateShapeOnNode(Node * node) {
         at::IntList{lhs_type->sizes().at(0), rhs_type->sizes().at(1)}));
     } break;
     case aten::t: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
       auto tp = types.at(0);
       auto sizes = tp->sizes();
       auto strides = tp->strides();
@@ -209,7 +209,7 @@ void PropagateShapeOnNode(Node * node) {
           sizes.erase(sizes.begin() + dim);
         }
         node->output()->setType(tp->withSizes(sizes));
-      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) {
+      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) {
         node->output()->setType(types.at(0)->withSizes({}));
       }
     } break;

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -213,7 +213,7 @@ void initPythonIRBindings(PyObject * module_) {
       return variables;
     })
     .def("z_",[](Node & n, const char * name, at::Tensor v) {
-        return n.t_(Symbol::attr(name), std::move(v.view({})));
+        return n.t_(Symbol::attr(name), v.view({}));
     })
     .def("z",[](Node & n, const char * name) {
         return n.t(Symbol::attr(name));


### PR DESCRIPTION
Enables the following warnings

* `-Wall`,
* `-Wextra`,

You can see [these clang docs](https://clang.llvm.org/docs/DiagnosticsReference.html) to see the exact warnings these enable.

What warnings we'll disable:

* `-Wno-unused-parameter`, too many cases, also kinda useful for documentation sometimes,
* `-Wno-missing-field-initializers`, useful for Python.h structs,
* `-Wno-write-strings`, was there before (@apaszke for context)
* `-Wno-zero-length-array`, used for variable length structs in the JIT
* ` -Wno-return-type-c-linkage`, temporary, @teng-li is fixing errors in THD

When setting `WERROR=1` before `python setup.py ...`, `-Werror` is also added to the flags. This variable will be set in CI.