### PR TITLE
Fix typo in link to sigmoid activation image

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -229,7 +229,7 @@ class Sigmoid(Module):
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
 
-    .. image:: scripts/activationscripts/activation_images/Sigmoid.png
+    .. image:: scripts/activation_images/Sigmoid.png
 
     Examples::
 


### PR DESCRIPTION
Partially fixing #5677 . The more important fix is being done by @zou3519 at pytorch.github.io repo.