### PR TITLE
Handle exit signal in run_test.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -49,6 +49,10 @@ DISTRIBUTED_TESTS_CONFIG = {
     'mpi': {},
 }
 
+# https://stackoverflow.com/questions/2549939/get-signal-names-from-numbers-in-python
+SIGNALS_TO_NAMES_DICT = dict((getattr(signal, n), n) for n in dir(signal)
+                             if n.startswith('SIG') and '_' not in n)
+
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)
@@ -58,7 +62,7 @@ def shell(command, cwd):
     sys.stdout.flush()
     sys.stderr.flush()
     return subprocess.call(
-        shlex.split(command), universal_newlines=True, cwd=cwd) == 0
+        shlex.split(command), universal_newlines=True, cwd=cwd)
 
 
 def get_shell_output(command):
@@ -72,9 +76,10 @@ def run_test(python, test_module, test_directory, options):
 
 
 def test_cpp_extensions(python, test_module, test_directory, options):
-    if not shell('{} setup.py install --root ./install'.format(python),
-                 os.path.join(test_directory, 'cpp_extensions')):
-        return False
+    return_code = shell('{} setup.py install --root ./install'.format(python),
+                        os.path.join(test_directory, 'cpp_extensions'))
+    if return_code != 0:
+        return return_code
 
     python_path = os.environ.get('PYTHONPATH', '')
     try:
@@ -82,7 +87,7 @@ def test_cpp_extensions(python, test_module, test_directory, options):
         if sys.platform == 'win32':
             install_directory = os.path.join(cpp_extensions, 'install')
             install_directories = get_shell_output(
-                'where -r \"{}\" *.pyd'.format(install_directory)).split(
+                "where -r \"{}\" *.pyd".format(install_directory)).split(
                     '\r\n')
 
             assert install_directories, 'install_directory must not be empty'
@@ -94,7 +99,7 @@ def test_cpp_extensions(python, test_module, test_directory, options):
             split_char = ';'
         else:
             install_directory = get_shell_output(
-                'find {}/install -name *-packages'.format(cpp_extensions))
+                "find {}/install -name *-packages".format(cpp_extensions))
             split_char = ':'
 
         assert install_directory, 'install_directory must not be empty'
@@ -133,15 +138,16 @@ def test_distributed(python, test_module, test_directory, options):
                 os.mkdir(os.path.join(tmp_dir, 'test_dir'))
                 if backend == 'mpi':
                     mpiexec = 'mpiexec -n 3 --noprefix {}'.format(python)
-                    if not run_test(mpiexec, test_module, test_directory,
-                                    options):
-                        return False
-                elif not run_test(python, test_module, test_directory,
-                                  options):
-                    return False
+                    return_code = run_test(mpiexec, test_module,
+                                           test_directory, options)
+                else:
+                    return_code = run_test(python, test_module, test_directory,
+                                           options)
+                if return_code != 0:
+                    return return_code
             finally:
                 shutil.rmtree(tmp_dir)
-    return True
+    return 0
 
 
 CUSTOM_HANDLERS = {
@@ -230,10 +236,6 @@ def get_selected_tests(options):
     return selected_tests
 
 
-def signal_handler(signal, frame):
-    print('run_test.py received SIGCHLD! A test probably segfaulted.')
-
-
 def main():
     options = parse_args()
     python = get_python_command(options)
@@ -245,14 +247,21 @@ def main():
     if options.coverage:
         shell('coverage erase')
 
-    signal.signal(signal.SIGCHLD, signal_handler)
-
     for test in selected_tests:
         test_module = 'test_{}.py'.format(test)
         print_to_stderr('Running {} ...'.format(test_module))
         handler = CUSTOM_HANDLERS.get(test, run_test)
-        if not handler(python, test_module, test_directory, options):
-            raise RuntimeError('{} failed!'.format(test_module))
+        return_code = handler(python, test_module, test_directory, options)
+        assert isinstance(return_code, int) and not isinstance(
+            return_code, bool), 'Return code should be an integer'
+        if return_code != 0:
+            message = '{} failed!'.format(test_module)
+            if return_code < 0:
+                # subprocess.Popen returns the child process' exit signal as
+                # return code -N, where N is the signal number.
+                signal_name = SIGNALS_TO_NAMES_DICT[-return_code]
+                message += ' Received signal: {}'.format(signal_name)
+            raise RuntimeError(message)
 
     if options.coverage:
         shell('coverage combine')


### PR DESCRIPTION
Right now, when a test segfaults, we get zero signal for this. This PR checks the return value of `subprocess.Popen` to figure out the exit signal of the child process.