### PR TITLE
adds correct precision to test_noncontig_conv_grad

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3817,7 +3817,7 @@ class TestNN(NNTestCase):
         input.grad.data.zero_()
 
         output.backward(grad.contiguous())
-        self.assertEqual(result, input.grad.data)
+        self.assertEqual(result, input.grad.data, type2prec[dtype.__name__])
 
     def test_pixel_shuffle(self):
         batch_size = random.randint(1, 3)


### PR DESCRIPTION
#6333 
The test_noncontig_conv_grad tests ALL_TENSORTYPES of Float, Double and Half but assertEqual statement in test needs correct reference for the precision of the test. Other tests in file have the correct reference. 
