### PR TITLE
Make ArrayRef read-only by default.

### DIFF
--- a/aten/src/ATen/ArrayRef.h
+++ b/aten/src/ATen/ArrayRef.h
@@ -91,8 +91,8 @@ namespace at {
     /// @name Simple Operations
     /// @{
 
-    iterator begin() const { return Data; }
-    iterator end() const { return Data + Length; }
+    const_iterator begin() const { return Data; }
+    const_iterator end() const { return Data + Length; }
 
     reverse_iterator rbegin() const { return reverse_iterator(end()); }
     reverse_iterator rend() const { return reverse_iterator(begin()); }


### PR DESCRIPTION
Sebastian Messmer noticed that these iterators were writeable by
default, which seemed dangerous.  Replaced with const iterators.
This doesn't seem to affect any ATen code; seems reasonable enough.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @smessmer 