### PR TITLE
Add link in docs menu to stable docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,5 +1,15 @@
 {% extends "!layout.html" %}
 
+{% block menu %}
+<div>
+  <a style="color:#F05732" href=http://pytorch.org/docs/0.3.1/>
+    You are viewing unstable developer preview docs.
+    Click here to view docs for latest stable release.
+  </a>
+</div>
+{{ super() }}
+{% endblock %}
+
 {% block footer %}
 {{ super() }}
 <script>


### PR DESCRIPTION
Part of #5738. Warns users that they're not viewing the latest stable
release docs.

We should remember to delete this when cutting out 0.4.0 release docs. (we'd just delete the div in pytorch.github.io)

This is what it looks like now:
![image](https://user-images.githubusercontent.com/5652049/38576477-47046124-3ccc-11e8-83e3-767d2d61948b.png)

cc @SsnL @soumith 
