### PR TITLE
Fix THTensor_(take) negative index check

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -448,9 +448,9 @@ void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
   int isContiguous = THTensor_(isContiguous)(src);
 
   // Exceptions must not be thrown across OpenMP parallel sections, so we
-  // record the value of the invalid index and throw the exception after the
+  // record the position of the invalid index and throw the exception after the
   // loop.
-  int64_t invalidIdxDim = -1;
+  int64_t invalidIdxPos = -1;
 
   ptrdiff_t i;
   #pragma omp parallel for if(nIndices > TH_OMP_OVERHEAD_THRESHOLD) private(i)
@@ -464,12 +464,12 @@ void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
         dst_data[i] = src_data[THTensor_(dataOffset)(src, idx)];
       }
     } else {
-      THAtomicCompareAndSwapLong(&invalidIdxDim, -1, i);
+      THAtomicCompareAndSwapLong(&invalidIdxPos, -1, i);
     }
   }
 
-  if (invalidIdxDim >= 0) {
-    THTensor_(checkLinearIndex)(index_data[invalidIdxDim], srcElements);
+  if (invalidIdxPos >= 0) {
+    THTensor_(checkLinearIndex)(index_data[invalidIdxPos], srcElements);
   }
 
   THLongTensor_free(index);

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -426,11 +426,11 @@ static ptrdiff_t THTensor_(dataOffset)(THTensor* tensor, ptrdiff_t linearIndex) 
   return dataOffset;
 }
 
-static void THTensor_(checkLinearIndex)(int64_t linearIndex, int64_t numel) {
+static inline void THTensor_(checkLinearIndex)(int64_t linearIndex, int64_t numel) {
   THArgCheck(linearIndex < numel && linearIndex >= -numel, 2, "out of range: %d out of %d", (int)linearIndex, (int)numel);
 }
 
-static int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t numel) {
+static inline int64_t THTensor_(wrapLinearIndex)(int64_t linearIndex, int64_t numel) {
   return linearIndex < 0 ? linearIndex + numel : linearIndex;
 }
 
@@ -450,7 +450,7 @@ void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
   // Exceptions must not be thrown across OpenMP parallel sections, so we
   // record the value of the invalid index and throw the exception after the
   // loop.
-  int64_t invalidIdx = -1;
+  int64_t invalidIdxDim = -1;
 
   ptrdiff_t i;
   #pragma omp parallel for if(nIndices > TH_OMP_OVERHEAD_THRESHOLD) private(i)
@@ -464,12 +464,12 @@ void THTensor_(take)(THTensor *r_, THTensor *src, THLongTensor *index)
         dst_data[i] = src_data[THTensor_(dataOffset)(src, idx)];
       }
     } else {
-      THAtomicCompareAndSwapLong(&invalidIdx, -1, idx);
+      THAtomicCompareAndSwapLong(&invalidIdxDim, -1, i);
     }
   }
 
-  if (invalidIdx >= 0) {
-    THTensor_(checkLinearIndex)(invalidIdx, srcElements);
+  if (invalidIdxDim >= 0) {
+    THTensor_(checkLinearIndex)(index_data[invalidIdxDim], srcElements);
   }
 
   THLongTensor_free(index);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4353,6 +4353,18 @@ class TestTorch(TestCase):
         with self.assertRaises(IndexError):
             reference[ri([1]), ri([0, 2]), ri([3])]
 
+        # test invalid index fails
+        reference = conv_fn(torch.empty(10))
+        # can't test cuda because it is a device assert
+        if not reference.is_cuda:
+            for err_idx in (10, -11):
+                with self.assertRaisesRegex(IndexError, r'out of'):
+                    reference[err_idx]
+                with self.assertRaisesRegex(RuntimeError, r'out of'):
+                    reference[conv_fn(torch.LongTensor([err_idx]))]
+                with self.assertRaisesRegex(RuntimeError, r'out of'):
+                    reference[[err_idx]]
+
         if TEST_NUMPY:
             # we use numpy to compare against, to verify that our advanced
             # indexing semantics are the same, and also for ease of test


### PR DESCRIPTION
Fixes #6472 .

Previously we save invalid indices in `invalidIdx` and checks if `invalidIdx < 0` after OMP loop. This in incorrect because the index can be negative. This PR changes to saving the invalid dimension.