### PR TITLE
Skip all TestTorch tests in test_cuda.py

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1630,4 +1630,17 @@ if __name__ == '__main__':
     if HAS_CUDA:
         load_ignore_file()
         generate_tests()
+
+    # skip TestTorch tests
+    # hide in __name__ == '__main__' because we don't want this to be run when
+    # someone imports test_cuda
+    def load_tests(loader, tests, pattern):
+        test_suite = unittest.TestSuite()
+        for test_group in tests:
+            for test in test_group:
+                if test.__class__.__name__ == 'TestTorch':
+                    continue
+                test_suite.addTest(test)
+        return test_suite
+
     run_tests()


### PR DESCRIPTION
Apparently we run TestTorch tests twice. E.g., one TestTorch test fails in test_cuda.py here: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-py3-clang5-asan-test/2416/console.

This fixes it.

cc @gchanan 