### PR TITLE
[jit][script] Check that each builtin returns the right number of values.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1564,6 +1564,16 @@ class TestScript(TestCase):
         x = torch.rand(10, dtype=torch.float, requires_grad=True)
         self.checkScript(func, [x], optimize=True)
 
+    def test_keyword(self):
+        @torch.jit.script
+        def func(x):
+            return torch.sum(x, dim=0, keepdim=True)
+
+        x = torch.rand(10, dtype=torch.float, requires_grad=True)
+        y = func(x)
+        y2 = torch.sum(x, dim=0, keepdim=True)
+        self.assertEqual(y, y2)
+
     def test_func_call(self):
         script = '''
         def add(a, b):
@@ -2210,7 +2220,7 @@ class TestScript(TestCase):
                 for m in self.mods:
                     print(m)
                 return v
-        with self.assertRaisesRegex(RuntimeError, "cannot be used as tuple"):
+        with self.assertRaisesRegex(RuntimeError, "cannot be used as a tuple"):
             M()
 
     class StarTestSumStarred(torch.nn.Module):
@@ -2308,7 +2318,7 @@ class TestScript(TestCase):
 
     def test_script_module_star_assign_fail_pythonop(self):
 
-        with self.assertRaisesRegex(RuntimeError, "Vararg outputs are currently not supported for PythonOp"):
+        with self.assertRaisesRegex(RuntimeError, "value cannot be used as a tuple"):
             class M2(torch.jit.ScriptModule):
                 def __init__(self):
                     super(M2, self).__init__(True)
@@ -2326,7 +2336,7 @@ class TestScript(TestCase):
             m(torch.zeros(4, 3))
 
     def test_script_module_star_assign_fail_builtin(self):
-        with self.assertRaisesRegex(RuntimeError, "Starred packing for the output of a builtin is not supported."):
+        with self.assertRaisesRegex(RuntimeError, "value cannot be used as a tuple"):
             class M2(torch.jit.ScriptModule):
                 def __init__(self):
                     super(M2, self).__init__(True)
@@ -2382,6 +2392,27 @@ class TestScript(TestCase):
 
         f = io.BytesIO()
         torch.onnx._export(m, (x, seq_lens), f, verbose=False)
+
+    def test_script_outputs(self):
+        with self.assertRaisesRegex(RuntimeError, "value cannot be used as a tuple"):
+            @torch.jit.script
+            def foo(a):
+                c, d = a + a
+                return c + d
+
+    def test_script_chunk(self):
+        @torch.jit.script
+        def foo(a):
+            b, c = torch.chunk(a, dim=0, chunks=2)
+            return b
+        v = torch.rand(10, 3)
+        self.assertEqual(torch.chunk(v, dim=0, chunks=2)[0], foo(v))
+
+        with self.assertRaisesRegex(RuntimeError, "too many values to unpack"):
+            @torch.jit.script
+            def foo(a):
+                b, c = torch.chunk(a, dim=0, chunks=3)
+                return b
 
 
 # Smoke tests for export methods

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2400,6 +2400,17 @@ class TestScript(TestCase):
                 c, d = a + a
                 return c + d
 
+        @torch.jit.script
+        def return3():
+            return 1, 2, 3
+
+        with self.assertRaisesRegex(RuntimeError, "too many values to unpack"):
+            @torch.jit.script
+            def bind2():
+                a, b = return3()
+                print(a)
+                print(b)
+
     def test_script_chunk(self):
         @torch.jit.script
         def foo(a):

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -51,7 +51,7 @@ CONSTRUCTOR = CodeTemplate("""\
     drop(stack, ${num_dynamic_inputs});
     pack(stack, std::move(result));
     return 0;
-  }, "${name}", ${num_dynamic_inputs});
+  }, "${name}", ${num_dynamic_inputs}, ${num_outputs});
 }},
 """)
 
@@ -131,11 +131,12 @@ def gen_jit_dispatch(declarations, out):
                 pos_assignments.append(assign)
                 arguments.append(arg['name'])
             else:
+                attr_method = ATTR_METHOD_MAP[arg['simple_type']]
                 assign = KW_ASSIGNMENT.substitute(type_cast=TYPE_CASTS.get(arg['simple_type'], arg['simple_type']),
                                                   name=arg['name'],
-                                                  method=ATTR_METHOD_MAP[arg['simple_type']])
+                                                  method=attr_method)
                 kw_assignments.append(assign)
-                attr_names.append(arg['name'])
+                attr_names.append('{}_{}'.format(arg['name'], attr_method))
                 arguments.append(arg['name'])
         call = get_invocation(decl, arguments)
 
@@ -153,11 +154,22 @@ def gen_jit_dispatch(declarations, out):
                    for idx in skip_scalar_overload[descriptor]):
                 return
 
+        returns = decl['returns']
+        all_scalars = all(r['dynamic_type'] != 'TensorList' for r in returns)
+        num_outputs = str(len(returns)) if all_scalars else 'UNKNOWN_OUTPUTS'
+
+        # special case for chunk when the chunks=<const> is known
+        # DO NOT ADD MORE SPECIAL CASES HERE, REFACTOR INTO A FUNCTION IF
+        # NEEDED
+        if decl['name'] == 'chunk' and 'chunks_i' in attr_names:
+            num_outputs = 'node->i(Symbol::attr("chunks"))'
+
         constructor = CONSTRUCTOR.substitute(descriptor=descriptor, name=decl['name'],
                                              call=call,
                                              kw_assignments=kw_assignments,
                                              pos_assignments=pos_assignments,
-                                             num_dynamic_inputs=num_dynamic_inputs)
+                                             num_dynamic_inputs=num_dynamic_inputs,
+                                             num_outputs=num_outputs)
 
         assert descriptor not in ops, descriptor
         ops[descriptor] = constructor
@@ -191,6 +203,7 @@ def gen_jit_dispatch(declarations, out):
         'api_name': name,
         'method_of': ['Tensor'],
         'arguments': [{'name': 'self', 'simple_type': 'Tensor'}],
+        'returns': [{'name': 'result', 'type': 'int64_t', 'dynamic_type': 'int64_t'}],
     } for name in ['sizes', 'strides', 'dim']]
     aten_decls = load_aten_declarations(declarations) + tensor_impl_methods
     jit_decls = [d for d in aten_decls if is_jit_op(d)]
@@ -219,7 +232,6 @@ def gen_jit_dispatch(declarations, out):
         'aten_symbols': ["_(aten, {}) \\".format(n) for n in sorted(names)],
         'attr_symbols': ["_(attr, {}) \\".format(n) for n in sorted(attrs)]
     }
-
     write(out, 'aten_interned_strings.h', ATEN_INTERNED_STRINGS_H, strings_env)
 
 

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -88,9 +88,7 @@ std::array<bool, N> as_bool_array(const std::vector<int64_t>& vec) {
 
 
 using operator_constructor = std::function<TensorOp(jit::Node*)>;
-using ConstructorsMap = std::unordered_map<std::string, operator_constructor>;
-
-ConstructorsMap constructors = {
+std::unordered_map<std::string, operator_constructor> constructors = {
   ${constructors}
 };
 

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -86,6 +86,10 @@ std::array<bool, N> as_bool_array(const std::vector<int64_t>& vec) {
   return res;
 }
 
+
+using operator_constructor = std::function<TensorOp(jit::Node*)>;
+using ConstructorsMap = std::unordered_map<std::string, operator_constructor>;
+
 ConstructorsMap constructors = {
   ${constructors}
 };
@@ -98,10 +102,13 @@ std::string getDescriptor(jit::Node* n) {
     s << "-" << n->inputs().size();
   else
     s << "-*";
-  std::vector<const char*> attr_names = fmap(n->attributeNames(), [](Symbol x) { return x.toUnqualString(); });
-  std::sort(attr_names.begin(), attr_names.end(), [](const char *a, const char *b) {
-    return std::strcmp(a, b) < 0;
+  std::vector<std::string> attr_names = fmap(n->attributeNames(), [&](Symbol x) {
+    std::stringstream ss;
+    ss << x.toUnqualString() << "_" << toString(n->kindOf(x));
+    return ss.str();
   });
+  std::sort(attr_names.begin(), attr_names.end());
+
   for (const auto & name : attr_names)
     s << "-" << name;
   return s.str();
@@ -109,22 +116,23 @@ std::string getDescriptor(jit::Node* n) {
 
 } // anonymous namespace
 
-ConstructorsMap::iterator findTensorOp(jit::Node* n) {
+at::optional<TensorOp> findTensorOp(jit::Node* n) {
   auto signature = getDescriptor(n);
-  return constructors.find(signature);
-}
-bool hasTensorOp(jit::Node* n) {
-  return constructors.end() != findTensorOp(n);
+  auto it = constructors.find(signature);
+  if(it == constructors.end()) {
+    return at::nullopt;
+  }
+  return it->second(n);
 }
 TensorOp getTensorOp(jit::Node* n) {
-  auto itr = findTensorOp(n);
-  if (itr == constructors.end()) {
+  auto op = findTensorOp(n);
+  if (!op) {
     throw std::runtime_error(
         "Unsupported op descriptor: " + getDescriptor(n) +
         ". "
         "File a bug report.");
   }
-  return itr->second(n);
+  return op.value();
 }
 
 }} // namespace torch::jit

--- a/tools/jit/templates/aten_dispatch.h
+++ b/tools/jit/templates/aten_dispatch.h
@@ -47,22 +47,22 @@ static inline at::Tensor pop(Stack & stack) {
   return r;
 }
 
+constexpr size_t UNKNOWN_OUTPUTS = std::numeric_limits<size_t>::max();
+
 struct TensorOp {
-  TensorOp(Operation op, std::string name, size_t num_inputs)
+  TensorOp(Operation op, std::string name, size_t num_inputs, size_t num_outputs)
     : op(op)
     , name(name)
-    , num_inputs(num_inputs) {}
+    , num_inputs(num_inputs)
+    , num_outputs(num_outputs) {}
 
   const Operation op;
   const std::string name;
   const size_t num_inputs;
+  const size_t num_outputs;
 };
 
-using operator_constructor = std::function<TensorOp(jit::Node*)>;
-using ConstructorsMap = std::unordered_map<std::string, operator_constructor>;
-
-ConstructorsMap::iterator findTensorOp(jit::Node* n);
-bool hasTensorOp(jit::Node* n);
+at::optional<TensorOp> findTensorOp(jit::Node* n);
 TensorOp getTensorOp(jit::Node* n);
 
 }} // namespace torch::jit;

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -192,6 +192,7 @@ struct GraphExecutorImpl {
   }
 
 private:
+  friend struct GraphExecutor;
 
   static bool needsGradient(const variable_tensor_list & inputs) {
     if (!autograd::GradMode::is_enabled()) {
@@ -376,6 +377,10 @@ GraphExecutor::GraphExecutor(std::shared_ptr<Graph> graph, bool optimize, bool s
 
 variable_tensor_list GraphExecutor::run(variable_tensor_list && inputs) {
   return pImpl->run(std::move(inputs));
+}
+
+std::shared_ptr<Graph> GraphExecutor::graph() const {
+  return pImpl->graph;
 }
 
 }}

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -16,6 +16,7 @@ struct GraphExecutor {
   operator bool() const {
     return pImpl != nullptr;
   }
+  std::shared_ptr<Graph> graph() const;
 private:
   std::shared_ptr<GraphExecutorImpl> pImpl;
 };

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -21,6 +21,7 @@ using ListAttributeMap = std::unordered_map<std::string, std::vector<Const>>;
 
 // Tuple of values. Used to implement tuple return values and unpacking
 struct TupleValue : public SugaredValue {
+  TupleValue() {}
   TupleValue(std::vector<std::shared_ptr<SugaredValue>> values) : values(std::move(values)) {}
 
   virtual std::string kind() const override {
@@ -118,13 +119,38 @@ struct Environment {
     return owning_kind;
   }
 
-  void setVar(const std::string& name, Value* value) {
-    if (!findInThisFrame(name) && findInParentFrame(name) &&
-        getBlockOwningKind() == prim::Loop)
-      createCapturedInput(name);
-    setSugaredVar(name, std::make_shared<SimpleValue>(value));
+  void setVar(const SourceRange& loc, const std::string& name, Value* value) {
+    setSugaredVar(loc, name, std::make_shared<SimpleValue>(value));
   }
-  void setSugaredVar(const std::string& name, SugaredValuePtr value) {
+  static bool isSimple(SugaredValuePtr value) {
+    return dynamic_cast<SimpleValue*>(value.get()) != nullptr;
+  }
+
+  void setSugaredVar(const SourceRange& loc, const std::string& name, SugaredValuePtr value) {
+    bool is_simple_value = isSimple(value);
+    // prevent re-assignment involving any sugared values
+    // any reassignment like:
+    // a = ...
+    // while ...
+    //   a = ..
+    // requires 'a' to be first-class in the graph since its value depends on
+    // control flow
+    if(auto parent = findInParentFrame(name)) {
+      if(!is_simple_value) {
+        throw ErrorReport(loc) << "cannot re-assign '" << name << "' to a value of type " << value->kind()
+        << ". Only reassignments to first-class values are allowed";
+      }
+      if(!isSimple(parent)) {
+        throw ErrorReport(loc) << "cannot re-assign '" << name << "' because it has type " << value->kind()
+        << ". Only reassignments to first-class values are allowed";
+      }
+    }
+    if (is_simple_value &&
+        !findInThisFrame(name) &&
+        findInParentFrame(name) &&
+        getBlockOwningKind() == prim::Loop) {
+      createCapturedInput(name);
+    }
     value_table[name] = std::move(value);
   }
 
@@ -195,73 +221,98 @@ private:
   ValueTable value_table;
 };
 
-Node* emitBuiltinCall(
+Const getAttributeValue(Expr value_expr) {
+  switch (value_expr.kind()) {
+    case TK_CONST: {
+      return Const(value_expr);
+    } break;
+    case TK_TRUE: {
+      return Const::create(value_expr.range(), "1");
+    } break;
+    case TK_FALSE: {
+      return Const::create(value_expr.range(), "0");
+    } break;
+    default:
+      throw ErrorReport(value_expr) << "attributes must be constants, or a list of constants";
+      break;
+  }
+}
+
+std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values) {
+  if(values.size() == 1) {
+    return std::make_shared<SimpleValue>(values[0]);
+  }
+  auto svalues = fmap(values, [](Value* v) -> std::shared_ptr<SugaredValue> {
+    return std::make_shared<SimpleValue>(v);
+  });
+  return std::make_shared<TupleValue>(std::move(svalues));
+}
+
+std::shared_ptr<SugaredValue> emitBuiltinCall(
   const SourceRange& loc,
   Method& method,
   const std::string & name,
   at::ArrayRef<Value*> inputs,
   List<Attribute> attributes,
-  CallsiteDescriptor cd) {
+  bool required) {
+
   NodeKind kind(Symbol::aten(name)); // TODO: this is a guess; could it be jit?
   auto graph = method.graph();
-  auto n = graph->insertNode(graph->create(kind, inputs, cd.n_outputs))
+  auto n = graph->insertNode(graph->create(kind, inputs, 0))
                 ->setSourceLocation(std::make_shared<SourceRange>(loc));
 
   for (const auto& attr : attributes) {
     const auto& name = Symbol::attr(attr.name().name());
     const Expr& value_expr = attr.value();
-    switch (value_expr.kind()) {
-      case TK_CONST: {
-        Const value {value_expr};
-        if (value.isFloatingPoint()) {
-          n->f_(name, value.asFloatingPoint());
-        } else {
-          n->i_(name, value.asIntegral());
-        }
-      } break;
-      case TK_LIST_LITERAL: {
-        List<Const> value_list {ListLiteral(value_expr).inputs()};
-        std::vector<Const> values;
-        for (Const number : value_list)
-          values.push_back(std::move(number));
-        bool is_float = std::any_of(values.begin(), values.end(),
-                                    [](const Const& c) { return c.isFloatingPoint(); });
-        if (is_float) {
-          n->fs_(name, fmap(values, [](const Const& c) { return c.asFloatingPoint(); }));
-        } else {
-          n->is_(name, fmap(values, [](const Const& c) { return c.asIntegral(); }));
-        }
-      } break;
-    default:
-        throw ErrorReport(attr) << "Unexpected kind of attribute value: " << value_expr.kind();
-        break;
+    if(value_expr.kind() == TK_LIST_LITERAL) {
+      auto value_list = ListLiteral(value_expr).inputs();
+      std::vector<Const> values;
+      for (Expr value : value_list)
+        values.push_back(getAttributeValue(value));
+      bool is_float = std::any_of(values.begin(), values.end(),
+                                  [](const Const& c) { return c.isFloatingPoint(); });
+      if (is_float) {
+        n->fs_(name, fmap(values, [](const Const& c) { return c.asFloatingPoint(); }));
+      } else {
+        n->is_(name, fmap(values, [](const Const& c) { return c.asIntegral(); }));
+      }
+    } else {
+      auto value = getAttributeValue(value_expr);
+      if (value.isFloatingPoint()) {
+        n->f_(name, value.asFloatingPoint());
+      } else {
+        n->i_(name, value.asIntegral());
+      }
     }
   }
+  auto op = findTensorOp(n);
+  if(!op) {
+    n->destroy();
+    if(!required)
+      return nullptr;
+    throw ErrorReport(loc) << "unknown builtin op";
+  }
+  if(op->num_outputs == UNKNOWN_OUTPUTS) {
+    throw ErrorReport(loc) << "produces an unknown number of outputs, so it cannot be used directly from script methods";
+  }
+  for(size_t i = 0; i < op->num_outputs; ++i)
+    n->addOutput();
 
-  return n;
+  return packOutputs(n->outputs());
 }
 
-std::vector<Value*> BuiltinFunction::call(
+
+std::shared_ptr<SugaredValue> BuiltinFunction::call(
     SourceRange loc,
     Method & m,
     at::ArrayRef<Value*> inputs_,
     List<Attribute> attributes,
-    CallsiteDescriptor cd) {
+    size_t n_binders) {
   std::vector<Value*> inputs;
-  if (value) inputs.push_back(value);
+  if (value)
+    inputs.push_back(value);
   inputs.insert(inputs.end(), inputs_.begin(), inputs_.end());
-  // TODO: remove when we support tuple packing for builtins.
-  if (cd.allow_varargs && cd.n_outputs == 1) {
-    cd.allow_varargs = false;
-  }
-  Node * n = emitBuiltinCall(loc, m, name, inputs, attributes, cd);
-  if (!hasTensorOp(n)) {
-    throw ErrorReport(loc) << "unknown builtin op";
-  }
-  if (cd.allow_varargs) {
-    throw ErrorReport(loc) << "Starred packing for the output of a builtin is not supported.";
-  }
-  return n->outputs();
+  return emitBuiltinCall(loc, m, name, inputs, attributes, true);
 }
 
 struct to_ir {
@@ -284,12 +335,12 @@ struct to_ir {
     if(self) {
       if(it == end)
         throw ErrorReport(def.params().range()) << "methods must have a self argument";
-      environment_stack->setSugaredVar((*it).ident().name(), self);
+      environment_stack->setSugaredVar(def.range(), (*it).ident().name(), self);
       ++it;
     }
     for(;it != end; ++it) {
       auto& name = (*it).ident().name();
-      environment_stack->setVar(name, graph->addInput(name));
+      environment_stack->setVar((*it).ident().range(), name, graph->addInput(name));
     }
     // body
     auto stmts = def.statements();
@@ -305,8 +356,9 @@ struct to_ir {
 
     // outputs
     if (has_return) {
-      for (auto output : Return(*stmts_end).values()) {
-        graph->registerOutput(emitExpr(output, {1, false})[0]);
+      auto results = getValues(Return(*stmts_end).values(), true);
+      for(auto r : results) {
+        graph->registerOutput(r);
       }
     }
   }
@@ -352,13 +404,13 @@ private:
         case TK_GLOBAL:
           for (auto ident : Global(stmt).names()) {
             const auto& name = Ident(ident).name();
-            environment_stack->setVar(name, graph->addInput(name));
+            environment_stack->setVar(ident.range(), name, graph->addInput(name));
           }
           break;
         case TK_EXPR_STMT: {
           auto exprs = ExprStmt(stmt).exprs();
           for (const auto& expr : exprs) {
-            emitExpr(expr, {0, false});
+            emitSugaredExpr(expr, 0);
           }
         }
         break;
@@ -386,16 +438,16 @@ private:
     return popFrame();
   }
 
-  Node* create(Symbol kind, const SourceRange& loc,  CallsiteDescriptor cd) {
+  Node* create(Symbol kind, const SourceRange& loc,  size_t n_outputs) {
     return graph
-             ->create(kind, cd.n_outputs)
+             ->create(kind, n_outputs)
              ->setSourceLocation(std::make_shared<SourceRange>(loc));
   }
 
-  std::vector<Value*> emitTernaryIf(const TernaryIf& expr) {
-    Value* cond_value = emitExpr(expr.cond(), {1, false})[0];
+  Value* emitTernaryIf(const TernaryIf& expr) {
+    Value* cond_value = emitExpr(expr.cond());
 
-    Node* n = graph->insertNode(create(prim::If, expr.range(), {0, false}));
+    Node* n = graph->insertNode(create(prim::If, expr.range(), 0));
     n->addInput(cond_value);
     auto* true_block = n->addBlock();
     auto* false_block = n->addBlock();
@@ -403,7 +455,7 @@ private:
     auto emit_if_expr = [this](Block* b, const Expr& expr) {
       pushFrame(b);
       WithInsertPoint guard(b);
-      Value* out_val = emitExpr(expr, {1, false})[0];
+      Value* out_val = emitExpr(expr);
       b->registerOutput(out_val);
       popFrame();
     };
@@ -414,13 +466,13 @@ private:
     // Add op outputs
     auto expr_value = n->addOutput(); // Resulting value
 
-    return {expr_value};
+    return expr_value;
   }
 
   void emitIf(const If& stmt) {
-    Value* cond_value = emitExpr(stmt.cond(), {1, false})[0];
+    Value* cond_value = emitExpr(stmt.cond());
 
-    Node* n = graph->insertNode(create(prim::If, stmt.range(), {0, false}));
+    Node* n = graph->insertNode(create(prim::If, stmt.range(), 0));
     n->addInput(cond_value);
     auto* true_block = n->addBlock();
     auto* false_block = n->addBlock();
@@ -446,7 +498,7 @@ private:
 
     // Add op outputs
     for (const auto& x : sorted_mutations) {
-      environment_stack->setVar(x, n->addOutput());
+      environment_stack->setVar(stmt.range(), x, n->addOutput());
     }
   }
 
@@ -473,20 +525,20 @@ private:
       at::optional<Expr> cond,
       const List<Stmt>& body,
       at::optional<Ident> itr_ident) {
-    Node* n = graph->insertNode(create(prim::Loop, range, {0, false}));
+    Node* n = graph->insertNode(create(prim::Loop, range, 0));
     Value *max_trip_count_val, *cond_val;
     {
       WithInsertPoint guard(n);
       if (max_trip_count) {
-        max_trip_count_val = emitExpr(max_trip_count.value(), {1, false})[0];
+        max_trip_count_val = emitExpr(max_trip_count.value());
       } else {
         max_trip_count_val =
-            emitConst(Const::create(range, std::to_string(INT_MAX)))[0];
+            emitConst(Const::create(range, std::to_string(INT_MAX)));
       }
       if (cond) {
-        cond_val = emitExpr(cond.value(), {1, false})[0];
+        cond_val = emitExpr(cond.value());
       } else {
-        cond_val = emitBooleanConst(range, true)[0];
+        cond_val = emitBooleanConst(range, true);
       }
     }
     n->addInput(max_trip_count_val);
@@ -498,17 +550,17 @@ private:
     {
       pushFrame(body_block);
       if (itr_ident) {
-        environment_stack->setVar(itr_ident.value().name(), trip_count);
+        environment_stack->setVar(itr_ident->range(), itr_ident->name(), trip_count);
       }
       WithInsertPoint guard(body_block);
       emitStatements(body);
 
       // Also emit the conditional
       if (cond) {
-        Value* body_cond_value = emitExpr(cond.value(), {1, false})[0];
+        Value* body_cond_value = emitExpr(cond.value());
         body_block->registerOutput(body_cond_value);
       } else {
-        Value* cond_value_dummy = emitBooleanConst(range, true)[0];
+        Value* cond_value_dummy = emitBooleanConst(range, true);
         body_block->registerOutput(cond_value_dummy);
       }
 
@@ -522,7 +574,7 @@ private:
       for (const auto& x : body_frame->captured_inputs) {
         body_block->registerOutput(body_frame->getValueInThisFrame(range, x));
         n->addInput(outer_frame->getVar(x, range));
-        outer_frame->setVar(x, n->addOutput());
+        outer_frame->setVar(range, x, n->addOutput());
       }
 
     }
@@ -571,18 +623,18 @@ private:
 
     // it isn't a range(<expr>) loop, treat it as a sugared value that maybe can be
     // unrolled
-    auto sv = emitSugaredExpr(itrs[0]);
+    auto sv = emitSugaredExpr(itrs[0], 1);
     auto instances = sv->asTuple(stmt.range(), method);
     const std::string& target_name = target.name();
     pushFrame(environment_stack->block());
     for(auto inst : instances) {
-      environment_stack->setSugaredVar(target_name, inst);
+      environment_stack->setSugaredVar(itrs[0].range(), target_name, inst);
       emitStatements(body);
     }
 
     for (const auto & n : environment_stack->definedVariables()) {
       if (environment_stack->findInParentFrame(n)) {
-        environment_stack->next->setVar(n, environment_stack->getVar(n, stmt.range()));
+        environment_stack->next->setVar(stmt.range(), n, environment_stack->getVar(n, stmt.range()));
       }
     }
     popFrame();
@@ -629,17 +681,7 @@ private:
     return num_starred;
   }
 
-  std::vector<SugaredValuePtr> createSugaredValuesFromValues(const std::vector<Value*> values) {
-    std::vector<SugaredValuePtr> sugared_outputs;
-    sugared_outputs.reserve(values.size());
-    for (Value* output : values) {
-      sugared_outputs.emplace_back(std::make_shared<SimpleValue>(output));
-    }
-    return sugared_outputs;
-  }
-
-  std::vector<Value*> emitAssignment(const Assign& stmt) {
-    std::vector<Value*> outputs{stmt.lhs().size()};
+  void emitAssignment(const Assign& stmt) {
     bool starred_unpack = calcNumStarredUnpack(stmt.lhs(), stmt.range());
     if (stmt.reduction() != '=') {
       if (stmt.lhs().size() != 1) {
@@ -650,40 +692,57 @@ private:
       Ident lhs = Var(stmt.lhs()[0]).name();
       Expr expr = BinOp::create(stmt.range(), stmt.reduction(),
                                 Var::create(lhs.range(), lhs), stmt.rhs());
-      outputs = emitExpr(expr, {1, false});
-    } else {
-      CallsiteDescriptor cd{stmt.lhs().size(), starred_unpack || stmt.lhs().size() == 1};
-      outputs =
-          emitExpr(stmt.rhs(), cd);
+      environment_stack->setVar(lhs.range(), lhs.name(), emitExpr(expr));
+      return;
     }
-    if (stmt.lhs().size() == 1 && outputs.size() != 1) {
-      // Pack up a tuple sugared value
-      SugaredValuePtr tup = std::make_shared<TupleValue>(createSugaredValuesFromValues(outputs));
-      if (stmt.lhs()[0].kind() != TK_VAR) {
-        throw ErrorReport(stmt.lhs()[0]) << "Cannot pack a tuple into a non-variable.";
-      }
-      environment_stack->setSugaredVar(Var(stmt.lhs()[0]).name().name(), tup);
-    } else {
-      int i = 0;
-      for (auto assignee : stmt.lhs()) {
-        if (assignee.kind() == TK_VAR) {
-          environment_stack->setVar(Var(assignee).name().name(), outputs.at(i));
-          i++;
-        } else if (assignee.kind() == TK_STARRED) {
-          auto var = Starred(assignee).expr();
-          if (var.kind() != TK_VAR) {
-            throw ErrorReport(var) << "Cannot pack a tuple into a non-variable.";
-          }
-          std::vector<Value*> starred_slice(
-              outputs.begin() + i, outputs.begin() + i + (starred_unpack ? 1 : 0));
-          SugaredValuePtr tup = std::make_shared<TupleValue>(createSugaredValuesFromValues(starred_slice));
-          environment_stack->setSugaredVar(
-              Var(Starred(assignee).expr()).name().name(), tup);
-          i += starred_unpack ? 1 : 0;
+    // how many non-starred things are on the lhs?
+    // a = ... (1)
+    // b, *c = ... (1)
+    // a, b = ... (2)
+    size_t n_binders = stmt.lhs().size();
+    if(starred_unpack)
+      n_binders--;
+
+    auto output = emitSugaredExpr(stmt.rhs(), n_binders);
+
+    if(stmt.lhs().size() == 1) {
+      JIT_ASSERT(!starred_unpack);
+      auto v = Var(stmt.lhs()[0]);
+      environment_stack->setSugaredVar(v.range(), v.name().name(), output);
+      return;
+    }
+
+    auto outputs = output->asTuple(stmt.range(), method);
+    if(outputs.size() < n_binders) {
+      throw ErrorReport(stmt)
+        << "need " << (starred_unpack ? "at least " : "")
+        << n_binders << " values to unpack but found only "
+        << outputs.size();
+    }
+    if(outputs.size() > n_binders && !starred_unpack) {
+      throw ErrorReport(stmt)
+      << "too many values to unpack, need " << n_binders << " but found "
+      << outputs.size();
+    }
+    int i = 0;
+    for (auto assignee : stmt.lhs()) {
+      if (assignee.kind() == TK_VAR) {
+        Value * value = outputs.at(i)->asValue(assignee.range(), method);
+        environment_stack->setVar(assignee.range(), Var(assignee).name().name(), value);
+        i++;
+      } else if (assignee.kind() == TK_STARRED) {
+        auto var = Starred(assignee).expr();
+        if (var.kind() != TK_VAR) {
+          throw ErrorReport(var) << "Cannot pack a tuple into a non-variable.";
         }
+        size_t n_matched = outputs.size() - n_binders;
+        ArrayRef<std::shared_ptr<SugaredValue>> outputs_ref = outputs;
+        SugaredValuePtr tup = std::make_shared<TupleValue>(outputs_ref.slice(i, n_matched));
+        environment_stack->setSugaredVar(
+          var.range(), Var(var).name().name(), tup);
+        i += n_matched;
       }
     }
-    return outputs;
   }
 
   NodeKind getNodeKind(int kind, int ninputs) {
@@ -723,100 +782,83 @@ private:
     }
   }
 
-  template <typename Trees>
-  std::vector<Value*> getValues(const Trees& trees, bool maybe_unpack=false) {
+  std::vector<Value*> getValues(TreeList trees, bool maybe_unpack=false) {
     std::vector<Value*> values;
     for (const auto& tree : trees) {
-      CallsiteDescriptor cd{1, maybe_unpack};
-      auto outputs = emitExpr(tree, cd);
-      if (!maybe_unpack && outputs.size() > 1) {
-        throw ErrorReport(tree) << "Expr unexpectedly returned more than 1 value."
-                                << " File a bug report.";
-      }
-      for (auto* v : outputs) {
-        values.push_back(v);
+      if(maybe_unpack && tree->kind() == TK_STARRED) {
+        auto starred = Starred(tree);
+        auto entries = emitSugaredExpr(starred.expr(), 1)->asTuple(starred.range(), method);
+        for(auto entry : entries) {
+          values.push_back(entry->asValue(starred.range(), method));
+        }
+      } else {
+        values.push_back(emitExpr(Expr(tree)));
       }
     }
     return values;
   }
-
-  void expectOutputs(
-      const TreeRef& tree,
-      const size_t expected_size,
-      const size_t size) {
-    if (expected_size != 0 && expected_size != size) {
-      throw ErrorReport(tree)
-          << "expected operator to produce " << expected_size
-          << " outputs but it produced " << size;
-    }
+  std::vector<Value*> getValues(List<Expr> trees, bool maybe_unpack=false) {
+    return getValues(trees.tree()->trees(), maybe_unpack);
   }
 
   // special rules apply when we directly call foo(a,b) when foo is an ident
-  std::vector<Value*> emitApplyIdent(Ident ident, std::vector<Value*> inputs, List<Attribute> attributes, CallsiteDescriptor cd) {
+  std::shared_ptr<SugaredValue> emitApplyIdent(Ident ident, std::vector<Value*> inputs, List<Attribute> attributes, size_t n_binders) {
     auto it = function_table.find(ident.name());
     if (it != function_table.end()) {
       if(inputs.size() != it->second.num_inputs())
         throw ErrorReport(ident) << "expected " << it->second.num_inputs() << " but found " << inputs.size();
-      auto outputs = method.emit_call_to(it->second, inputs);
-      if (!cd.allow_varargs)
-        expectOutputs(ident, cd.n_outputs, outputs.size());
-      return outputs;
+      return packOutputs(method.emit_call_to(it->second, inputs));
     } else if (ident.name() == "print") {
-      expectOutputs(ident, cd.n_outputs, 0);
       if (!attributes.empty())
         throw ErrorReport(ident) << "print doesn't accept any keyword arguments";
-      return emitNode(prim::Print, ident.range(), inputs, {0, false})->outputs();
+      emitNode(prim::Print, ident.range(), inputs, 0);
+      return std::make_shared<TupleValue>();
     }
-    // TODO: remove when we can support tuple packing for builtins.
-    if (cd.allow_varargs && cd.n_outputs == 1) {
-      cd.allow_varargs = false;
+    if(auto result = emitBuiltinCall(ident.range(), method, ident.name(), inputs, attributes, false)) {
+      return result;
     }
-    Node* builtin = emitBuiltinCall(ident.range(), method, ident.name(), inputs, attributes, cd);
-    if (hasTensorOp(builtin)) {
-      if (cd.allow_varargs) {
-        throw ErrorReport(ident.range()) << "Starred assignment isn't supported on builtins.";
-      }
-      return builtin->outputs();
-    }
-    builtin->destroy();
     // it wasn't known built in, so treat it like standard apply
-    return emitApplyExpr(Var::create(ident.range(), ident), inputs, attributes, cd);
+    return emitApplyExpr(Var::create(ident.range(), ident), inputs, attributes, n_binders);
   }
 
-  std::vector<Value*> emitApplyExpr(Expr callee, const std::vector<Value*>& inputs, List<Attribute> attributes, CallsiteDescriptor cd) {
+  std::shared_ptr<SugaredValue> emitApplyExpr(Expr callee, const std::vector<Value*>& inputs, List<Attribute> attributes, size_t n_binders) {
     // otherwise we evaluate the callee and then desugar it
-    auto sv = emitSugaredExpr(callee);
-    return sv->call(callee.range(), method, inputs, attributes, cd);
+    auto sv = emitSugaredExpr(callee, 1);
+    return sv->call(callee.range(), method, inputs, attributes, n_binders);
+  }
+
+  Value* emitExpr(Expr tree) {
+    return emitSugaredExpr(tree, 1)->asValue(tree.range(), method);
   }
 
   // any expression that can produce a SugaredValue is handled here
-  // with emitExpr falling back to this function to handle them
-  // the kinds handled here should be kept in sync with [SUGARED VALUES]
-  // in emitExpr
-  std::shared_ptr<SugaredValue> emitSugaredExpr(Expr tree) {
+  // expressions that only return a single Value* are handled in emitSimpleExpr
+  std::shared_ptr<SugaredValue> emitSugaredExpr(Expr tree, size_t n_binders) {
     switch(tree.kind()) {
       case TK_VAR:
         return environment_stack->getSugaredVar(Var(tree).name());
       case '.': {
         auto select = Select(tree);
-        auto sv = emitSugaredExpr(select.value());
+        auto sv = emitSugaredExpr(select.value(), 1);
         return sv->attr(select.range(), method, select.selector().name());
       }
+      case TK_APPLY: {
+        auto apply = Apply(tree);
+        auto inputs = getValues(apply.inputs(), true);
+        // the apply is directly an identifier 'foo'
+        if(apply.callee().kind() == TK_VAR) {
+          return emitApplyIdent(Var(apply.callee()).name(), inputs, apply.attributes(), n_binders);
+        }
+        return emitApplyExpr(apply.callee(), inputs, apply.attributes(), n_binders);
+      } break;
       default:
-        return std::make_shared<SimpleValue>(emitExpr(tree, {1, false})[0]);
+        return std::make_shared<SimpleValue>(emitSimpleExpr(tree));
     }
   }
 
-  std::vector<Value*> emitExpr(
-      const TreeRef& tree,
-      CallsiteDescriptor cd) {
+  Value* emitSimpleExpr(
+      const TreeRef& tree) {
     switch (tree->kind()) {
-      // the expressions have special handling because they may operate
-      // on sugared values
-      // [SUGARED VALUES]
-      case TK_VAR: case '.': {
-        return { emitSugaredExpr(Expr(tree))->asValue(tree->range(), method) };
-      } break;
       case TK_NE:
       case TK_EQ:
       case '<':
@@ -829,47 +871,26 @@ private:
       case TK_OR:
       case TK_NOT:
       case TK_UNARY_MINUS: {
-        expectOutputs(tree, cd.n_outputs, 1);
         const auto& inputs = tree->trees();
         auto kind = getNodeKind(tree->kind(), inputs.size());
-        return emitNode(kind, tree->range(), getValues(inputs), cd)->outputs();
+        return emitNode(kind, tree->range(), getValues(inputs), 1)->output();
       } break;
       case '+':
       case '-': {
-        expectOutputs(tree, cd.n_outputs, 1);
-        const auto& inputs = tree->trees();
+        const auto& inputs =tree->trees();
         auto kind = getNodeKind(tree->kind(), inputs.size());
-        auto* node = emitNode(kind, tree->range(), getValues(inputs), cd);
+        auto* node = emitNode(kind, tree->range(), getValues(inputs), 1);
         node->t_(Symbol::attr("alpha"), at::CPU(at::kFloat).scalarTensor(1.0));
-        return node->outputs();
+        return node->output();
       }
       case TK_STARRED: {
-        const auto starred = Starred(tree);
-        auto sugared = emitSugaredExpr(starred.expr());
-        auto sugared_retvals = sugared->asTuple(starred.range(), environment_stack->method);
-        std::vector<Value*> retvals;
-        retvals.reserve(sugared_retvals.size());
-        for (auto & val : sugared_retvals) {
-          retvals.push_back(val->asValue(starred.range(), method));
-        }
-        return retvals;
+        throw ErrorReport(tree) << "Unexpected starred expansion. File a bug report.";
       }
-      case TK_APPLY: {
-        auto apply = Apply(tree);
-        auto inputs = getValues(apply.inputs(), true);
-        // the apply is directly an identifier 'foo'
-        if(apply.callee().kind() == TK_VAR) {
-          return emitApplyIdent(Var(apply.callee()).name(), inputs, apply.attributes(), cd);
-        }
-        return emitApplyExpr(apply.callee(), inputs, apply.attributes(), cd);
-      } break;
       case TK_CAST: {
-        expectOutputs(tree, cd.n_outputs, 1);
         const auto cast = Cast(tree);
         return emitCast(cast.input(), cast.type());
       } break;
       case TK_CONST: {
-        expectOutputs(tree, cd.n_outputs, 1);
         return emitConst(Const(tree));
       } break;
       case TK_TRUE: {
@@ -879,21 +900,17 @@ private:
         return emitBooleanConst(tree->range(), false);
       } break;
       case TK_SLICE: {
-        expectOutputs(tree, cd.n_outputs, 1);
         const auto slice = Slice(tree);
         return emitSlice(
             slice.range(),
-            {slice.value(), slice.startOr(0), slice.endOr(-1)},
-            cd);
+            {slice.value(), slice.startOr(0), slice.endOr(-1)});
       } break;
       case TK_GATHER: {
-        expectOutputs(tree, cd.n_outputs, 1);
         const auto gather = Gather(tree);
         return emitGather(
-            gather.range(), {gather.value(), gather.indices()}, cd);
+            gather.range(), {gather.value(), gather.indices()});
       } break;
       case TK_IF_EXPR: {
-        expectOutputs(tree, cd.n_outputs, 1);
         return emitTernaryIf(TernaryIf(tree));
       } break;
       default:
@@ -902,7 +919,7 @@ private:
     }
   }
 
-  std::vector<Value*> emitCast(const TreeRef& input, const ScalarType& type) {
+  Value* emitCast(Expr input, const ScalarType& type) {
     at::ScalarType t;
     switch (type.kind()) {
       case TK_INT:
@@ -922,21 +939,21 @@ private:
     }
     return emitNode(
                Symbol::aten("type_as"),
-               input->range(),
-               {emitExpr(input, {1, false})[0], createConstant(input->range(), at::ones(at::CPU(t), {1}))},
-               {1, false})
-        ->outputs();
+               input.range(),
+               {emitExpr(input), createConstant(input.range(), at::ones(at::CPU(t), {1}))},
+               1)
+        ->output();
   }
 
-  std::vector<Value*> emitBooleanConst(SourceRange range, bool val) {
-    return {createConstant(range, at::CPU(at::kByte).scalarTensor(val))};
+  Value* emitBooleanConst(SourceRange range, bool val) {
+    return createConstant(range, at::CPU(at::kByte).scalarTensor(val));
   }
 
-  std::vector<Value*> emitConst(const Const& c) {
+  Value* emitConst(const Const& c) {
     if (c.isFloatingPoint()) {
-      return {createConstant(c.range(), at::CPU(at::kFloat).scalarTensor(c.asFloatingPoint()))};
+      return createConstant(c.range(), at::CPU(at::kFloat).scalarTensor(c.asFloatingPoint()));
     } else {
-      return {createConstant(c.range(), at::CPU(at::kLong).scalarTensor(c.asIntegral()))};
+      return createConstant(c.range(), at::CPU(at::kLong).scalarTensor(c.asIntegral()));
     }
   }
 
@@ -944,8 +961,8 @@ private:
       NodeKind kind,
       const SourceRange& loc,
       const std::vector<Value*> inputs,
-      CallsiteDescriptor cs) {
-    Node* n = graph->insertNode(create(kind, loc, cs));
+      size_t n_outputs) {
+    Node* n = graph->insertNode(create(kind, loc, n_outputs));
     for (auto* input_value : inputs) {
       n->addInput(input_value);
     }
@@ -954,10 +971,9 @@ private:
 
   // Desugars slice syntactic sugar tensor[begin:end] -> tensor.slice(begin,
   // end).
-  std::vector<Value*> emitSlice(
+  Value* emitSlice(
       const SourceRange& loc,
-      TreeList&& inputs,
-      CallsiteDescriptor cs) {
+      TreeList&& inputs) {
     const auto applyInputs =
         Compound::create(TK_LIST, loc, std::move(inputs));
     const auto input_values = getValues(applyInputs->trees());
@@ -968,18 +984,17 @@ private:
                Symbol::aten("slice"),
                loc,
                {tensor},
-               cs)
+               1)
                ->i_(attr::dim, 0)
                ->i_(attr::step, 1)
                ->i_(attr::start, begin)
-               ->i_(attr::end, end)->outputs();
+               ->i_(attr::end, end)->output();
   }
 
   // Desugars gather syntactic sugar tensor[idx] -> tensor.select(idx).
-  std::vector<Value*> emitGather(
+  Value* emitGather(
       const SourceRange& loc,
-      TreeList&& inputs,
-      CallsiteDescriptor cs) {
+      TreeList&& inputs) {
     const auto applyInputs =
         Compound::create(TK_LIST, loc, std::move(inputs));
     const auto input_values = getValues(applyInputs->trees());
@@ -989,10 +1004,10 @@ private:
                Symbol::aten("select"),
                loc,
                {tensor},
-               cs)
+               1)
                ->i_(attr::dim, 0)
                ->i_(attr::index, idx)
-               ->outputs();
+               ->output();
   }
 
   Value* createConstant(const SourceRange& loc, const at::Tensor& val) {

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -12,11 +12,6 @@ namespace torch {
 namespace jit {
 namespace script {
 
-// Value used to indicate that we can accept a variable number of outputs from
-// an expression, for example, when we are packing outputs into a tuple on the
-// lhs of an assignment
-constexpr size_t VARARG_OUTPUTS = std::numeric_limits<size_t>::max();
-
 struct CallsiteDescriptor {
   size_t n_outputs;
   bool allow_varargs;
@@ -49,24 +44,17 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   // use it as a vector of values, e.g. a tuple of values as return value from
   // a method invocation
   virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(SourceRange loc, Method& m) {
-    throw ErrorReport(loc) << kind() << " cannot be used as tuple";
+    throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
 
   // call it like a function, e.g. `outputs = this(inputs)`
-  virtual std::vector<Value*> call(
+  virtual std::shared_ptr<SugaredValue> call(
     SourceRange loc,
     Method & m,
     at::ArrayRef<Value*> inputs,
     List<Attribute> attributes,
-    CallsiteDescriptor cd) {
+    size_t n_binders) {
     throw ErrorReport(loc) << "cannot call a " << kind();
-  }
-
-  // use it in `for i in this: ...`
-  // in this case we will unroll the loop body by assigning i to each of
-  // the SugaredValues returned from this method.
-  virtual std::vector<std::shared_ptr<SugaredValue>> unrolledFor(SourceRange loc, Method& m) {
-    throw ErrorReport(loc) << kind() << " is not iterable";
   }
 
   virtual ~SugaredValue() {}
@@ -98,13 +86,15 @@ struct BuiltinFunction : public SugaredValue {
   virtual std::string kind() const override {
     return "builtin";
   }
-  virtual std::vector<Value*> call(
+  virtual std::shared_ptr<SugaredValue> call(
     SourceRange loc,
     Method & m,
     at::ArrayRef<Value*> inputs_,
     List<Attribute> attributes,
-    CallsiteDescriptor cd) override;
+    size_t n_binders) override;
 };
+
+std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values);
 
 using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name)>;
 void defineMethodsInModule(

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -94,8 +94,6 @@ struct BuiltinFunction : public SugaredValue {
     size_t n_binders) override;
 };
 
-std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values);
-
 using Resolver = std::function<std::shared_ptr<SugaredValue>(const std::string& name)>;
 void defineMethodsInModule(
   Module & m,
@@ -106,8 +104,12 @@ void defineMethodsInModule(
 
 // same as above but parse the definitions from source
 void defineMethodsInModule(Module & m, const std::string& source, const Resolver& resolver, std::shared_ptr<SugaredValue> self);
-
 std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
+
+// pack outputs of a function following python rules. If there is a single value return
+// a SimpleValue, otherwise pack all the values into a Tuple.
+std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values);
+std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
 
 
 } // namespace script

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -30,15 +30,9 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   : self(std::move(self)) {}
 
   // call it like a function, e.g. `outputs = this(inputs)`
-  virtual std::vector<Value*> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, List<Attribute> attributes, CallsiteDescriptor cd) override {
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
     if (attributes.size() > 0)
       throw ErrorReport(loc) << "keyword arguments in Python calls aren't supported";
-    // TODO: remove when we support tuple packing for PythonOp
-    if (cd.allow_varargs && cd.n_outputs == 1) {
-      cd.allow_varargs = false;
-    }
-    if (cd.allow_varargs)
-      throw ErrorReport(loc) << "Vararg outputs are currently not supported for PythonOp.";
     // Release the function object so we can wrap it in a PythonOp
     Graph& g = *m.graph();
     py::object func = self;
@@ -49,9 +43,9 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     for(auto i : inputs)
       new_node->addInput(i);
     std::vector<Value*> outputs;
-    for(size_t i = 0; i < cd.n_outputs; ++i)
+    for(size_t i = 0; i < n_binders; ++i)
       outputs.push_back(new_node->addOutput());
-    return outputs;
+    return packOutputs(outputs);
   }
 
   virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
@@ -102,13 +96,7 @@ protected:
 struct VISIBILITY_HIDDEN ConstantPythonValue : public PythonValue {
   using PythonValue::PythonValue;
   virtual Value * asValue(SourceRange loc, Method & m) override {
-    if(py::isinstance<py::int_>(self)) {
-      return createConstant(loc, m, at::CPU(at::kInt).scalarTensor(py::cast<int32_t>(self)));
-    } else if(py::isinstance<py::float_>(self)) {
-      return createConstant(loc, m, at::CPU(at::kFloat).scalarTensor(py::cast<float>(self)));
-    } else if(py::isinstance<py::bool_>(self)) {
-      return createConstant(loc, m, at::CPU(at::kByte).scalarTensor(py::cast<bool>(self)));
-    }
+
     return PythonValue::asValue(loc, m);
   }
   virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(SourceRange loc, Method& m) override {
@@ -118,15 +106,30 @@ struct VISIBILITY_HIDDEN ConstantPythonValue : public PythonValue {
     py::tuple tup = self;
     std::vector<std::shared_ptr<SugaredValue>> result;
     for(size_t i = 0; i < tup.size(); ++i) {
-      result.push_back(std::make_shared<ConstantPythonValue>(tup[i]));
+      result.push_back(create(loc, m, tup[i]));
     }
     return result;
   }
+  static std::shared_ptr<SugaredValue> create(SourceRange loc, Method& m, py::object self) {
+    // directly create SimpleValues when possible, because they are first-class
+    // and can be re-assigned. Otherwise, this would be invalid:
+    // f = python_constant
+    // while ...
+    //   f = f + 1
+    if(py::isinstance<py::int_>(self)) {
+      return createConstant(loc, m, at::CPU(at::kInt).scalarTensor(py::cast<int32_t>(self)));
+    } else if(py::isinstance<py::float_>(self)) {
+      return createConstant(loc, m, at::CPU(at::kFloat).scalarTensor(py::cast<float>(self)));
+    } else if(py::isinstance<py::bool_>(self)) {
+      return createConstant(loc, m, at::CPU(at::kByte).scalarTensor(py::cast<bool>(self)));
+    }
+    return std::make_shared<ConstantPythonValue>(self);
+  }
 private:
-  static Value * createConstant(SourceRange loc, Method& m, const at::Tensor& val) {
+  static std::shared_ptr<SugaredValue> createConstant(SourceRange loc, Method& m, const at::Tensor& val) {
     auto n = m.graph()->createConstant(val);
     n->setSourceLocation(std::make_shared<SourceRange>(loc));
-    return m.graph()->insertNode(n)->output();
+    return std::make_shared<SimpleValue>(m.graph()->insertNode(n)->output());
   }
 };
 
@@ -156,17 +159,13 @@ struct MethodValue : public SugaredValue {
   std::string kind() const override {
     return "method";
   }
-  virtual std::vector<Value*> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, CallsiteDescriptor cd) override {
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
     if(attributes.size() != 0) {
-      throw ErrorReport(loc) << "not yet implemented - calls to python functions using keyword arguments";
+      throw ErrorReport(loc) << "not yet implemented - calls to script methods using keyword arguments";
     }
     ensureSizeMatches(loc, method.num_inputs(), inputs.size(), "inputs");
     auto outputs = caller.emit_call_to(method, inputs);
-    // Allow for tuples. TODO: starred exprs?
-    if (!cd.allow_varargs) {
-      ensureSizeMatches(loc, outputs.size(), cd.n_outputs, "outputs");
-    }
-    return outputs;
+    return packOutputs(outputs);
   }
 private:
   std::shared_ptr<Module> module;
@@ -200,7 +199,7 @@ struct ModuleValue : public SugaredValue {
          py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
         return std::make_shared<PythonValue>(attr);
       } else if(py_module.attr("_constants_set").contains(field.c_str())) {
-        return std::make_shared<ConstantPythonValue>(attr);
+        return ConstantPythonValue::create(loc, m, attr);
       } else {
         throw ErrorReport(loc) << "attribute '" << field << "' of type '" << typeString(attr) << "' is not usable in a script method (did you forget to add it __constants__?)";
       }
@@ -208,8 +207,8 @@ struct ModuleValue : public SugaredValue {
     throw ErrorReport(loc) << "module has no attribute '" << field << "'";
   }
   // call module.forward
-  virtual std::vector<Value*> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, CallsiteDescriptor cd) override {
-    return attr(loc, caller, "forward")->call(loc, caller, inputs, attributes, cd);
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
+    return attr(loc, caller, "forward")->call(loc, caller, inputs, attributes, n_binders);
   }
 
   virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(SourceRange loc, Method& m) override {
@@ -223,7 +222,7 @@ struct ModuleValue : public SugaredValue {
         auto r = py::cast<std::shared_ptr<Module>>(obj);
         result.push_back(std::make_shared<ModuleValue>(r));
       } else {
-        result.push_back(std::make_shared<ConstantPythonValue>(obj));
+        result.push_back(ConstantPythonValue::create(loc, m, obj));
       }
     }
     return result;

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -1,28 +1,7 @@
 #include "torch/csrc/jit/script/module.h"
+#include "torch/csrc/jit/script/compiler.h"
 
 namespace torch { namespace jit { namespace script {
-
-static std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs) {
-  std::unordered_map<Value*, Value*> value_map;
-  auto value_map_func = [&](Value* v) { return value_map.at(v); };
-  JIT_ASSERT(callee.inputs().size() == inputs.size());
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    value_map[callee.inputs()[i]] = inputs[i];
-  }
-  for (auto* node : callee.nodes()) {
-    auto* new_node =
-        g.insertNode(g.createClone(node, value_map_func));
-    for (size_t i = 0; i < node->outputs().size(); ++i) {
-      value_map[node->outputs()[i]] = new_node->outputs()[i];
-    }
-  }
-
-  std::vector<Value*> outputs;
-  for (auto* output : callee.outputs()) {
-    outputs.push_back(value_map_func(output));
-  }
-  return outputs;
-}
 
 std::vector<Value*> Method::emit_call_to(Method & callee, ArrayRef<Value*> inputs) {
   JIT_ASSERT(!executor);

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -91,8 +91,12 @@ void initTreeViewBindings(PyObject *module) {
     .def(py::init([](const Ident& name, const Expr& value) {
       return Attribute::create(name.range(), name, value);
     }));
-
-
+  m.def("TrueLiteral", [](const SourceRange& range) {
+    return Expr(Compound::create(TK_TRUE, range, {}));
+  });
+  m.def("FalseLiteral", [](const SourceRange& range) {
+    return Expr(Compound::create(TK_FALSE, range, {}));
+  });
   py::class_<Type, TreeView>(m, "Type");
   py::class_<TensorType, Type>(m, "TensorType")
     .def(py::init(&TensorType::create));

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -566,6 +566,9 @@ struct Const : public Expr {
   double asFloatingPoint() const {
     return std::stod(subtree(0)->stringValue());
   }
+  const std::string& text() const {
+    return subtree(0)->stringValue();
+  }
   static Const create(const SourceRange& range, const std::string& value) {
     return Const(Compound::create(TK_CONST, range, {String::create(value)}));
   }

--- a/torch/csrc/utils/functional.h
+++ b/torch/csrc/utils/functional.h
@@ -5,10 +5,6 @@
 
 namespace torch {
 
-// NB: Order matters.  If you put the forwarding definitions before
-// the actual implementations, C++ will resolve the overload to
-// itself, because there's an implicit conversion to vector in ArrayRef.
-
 // The passed in function must take T by value (T), or by
 // const reference (const T&); taking T by non-const reference
 // will result in an error like:
@@ -18,39 +14,24 @@ namespace torch {
 // No explicit template parameters are required.
 
 // Overload for explicit function and ArrayRef
-template<typename F, typename T, typename R = typename std::result_of<F(T)>::type>
-inline std::vector<R> fmap(at::ArrayRef<T> inputs, const F& fn) {
-  std::vector<R> r;
+template<typename F, typename T>
+inline auto fmap(const T& inputs, const F& fn) -> std::vector<decltype(fn(*inputs.begin()))> {
+  std::vector<decltype(fn(*inputs.begin()))> r;
   r.reserve(inputs.size());
-  for(auto & input : inputs)
+  for(const auto & input : inputs)
     r.push_back(fn(input));
   return r;
 }
 
-// Overload for explicit function and vector (this is required because
-// template deduction will not apply an implicit conversion from std::vector
-// to ArrayRef)
-template<typename F, typename T, typename R = typename std::result_of<F(T)>::type>
-inline std::vector<R> fmap(const std::vector<T>& inputs, const F& fn) {
-  return fmap<F, T, R>(static_cast<at::ArrayRef<T>>(inputs), fn);
-}
-
 // C++ forbids taking an address of a constructor, so here's a workaround...
-
-// Overload for ArrayRef and constructor (R) application
+// Overload for constructor (R) application
 template<typename R, typename T>
-inline std::vector<R> fmap(at::ArrayRef<T> inputs) {
+inline std::vector<R> fmap(const T& inputs) {
   std::vector<R> r;
   r.reserve(inputs.size());
   for(auto & input : inputs)
     r.push_back(R(input));
   return r;
-}
-
-// Overload for std::vector and constructor (R) application
-template<typename R, typename T>
-inline std::vector<R> fmap(const std::vector<T>& inputs) {
-  return fmap<R, T>(static_cast<at::ArrayRef<T>>(inputs));
 }
 
 template<typename F, typename T>

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -320,6 +320,15 @@ class ExprBuilder(Builder):
         return Var(Ident(r, expr.id))
 
     @staticmethod
+    def build_NameConstant(ctx, expr):
+        text = "True" if expr.value else "False"
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(text))
+        if expr.value:
+            return TrueLiteral(r)
+        else:
+            return FalseLiteral(r)
+
+    @staticmethod
     def build_BinOp(ctx, expr):
         lhs = build_expr(ctx, expr.left)
         rhs = build_expr(ctx, expr.right)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -313,6 +313,10 @@ class ExprBuilder(Builder):
         if expr.id.startswith(_reserved_prefix):
             raise NotSupportedError(r, "names of variables used in JIT-ed functions "
                                        "can't start with " + _reserved_prefix)
+        if expr.id == "True":
+            return TrueLiteral(r)
+        elif expr.id == "False":
+            return FalseLiteral(r)
         return Var(Ident(r, expr.id))
 
     @staticmethod


### PR DESCRIPTION
This commit improves our handling of operators that return multiple values.
Builtins are now checked so that they return the right number of values,
and support for TupleValue is extended to all things that can return
multiple values.

This resolves issues where the compiler accepted things like:

  a, b = c + c

This would cause the interpreter to crash. Now each operator knows
how many results it will produce and can check it against the number
of requested inputs.

Notes:
* Allow True/False literals in constant expressions
* make handling of keyword constants more consistent to support True/False
* make parsing constants match the way we construct constants from python
* improve the error messages when accessing bad graph attributes.
* switch findTensorOp to return an optional.
* check that attribute types are correct in findTensorOp
* Check the correct number of outputs for builtins

This also changes emitExpr to return a single SugaredValue

Rather than possibly returning multiple values, emitExpr now
always returns a single value, which _might_ be a tuple. This approach
more closely follows python making the code easier to follow.

Checks for returning the right number of values are now located in
the assignment operator, and occur when unpacking the tuple.

We still pass `n_binders` to function calls so that calls into python
know how many values they should return.

