### PR TITLE
correct schema.Scalar's shape for a shape argument of 1

### DIFF
--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -720,6 +720,15 @@ class Scalar(Field):
             )
 
         self._original_dtype = dtype
+        # Numpy will collapse a shape of 1 into an unindexed data array (shape = ()),
+        # which betrays the docstring of this class (which expects shape = (1,)).
+        # >>> import numpy as np
+        # >> np.dtype((np.int32, 1))
+        # dtype('int32')
+        # >>> np.dtype((np.int32, 5))
+        # dtype(('<i4', (5,)))
+        if dtype is not None and isinstance(dtype, tuple) and dtype[1] == 1:
+            dtype = (dtype[0], (1,))
         if dtype is not None:
             dtype = np.dtype(dtype)
         # If blob is not None and it is not a BlobReference, we assume that

--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -366,3 +366,19 @@ class TestDB(unittest.TestCase):
         assert t.get('field_0', None) == s1
         assert t.get('field_1', None) == s2
         assert t.get('field_2', None) is None
+
+    def testScalarShape(self):
+        s0 = schema.Scalar(np.int32)
+        self.assertEqual(s0.field_type().shape, ())
+
+        s1_good = schema.Scalar((np.int32, 5))
+        self.assertEqual(s1_good.field_type().shape, (5, ))
+
+        with self.assertRaises(ValueError):
+            s1_bad = schema.Scalar((np.int32, -1))
+
+        s1_hard = schema.Scalar((np.int32, 1))
+        self.assertEqual(s1_hard.field_type().shape, (1, ))
+
+        s2 = schema.Scalar((np.int32, (2, 3)))
+        self.assertEqual(s2.field_type().shape, (2, 3))


### PR DESCRIPTION
The schema.Scalar class makes pretty strict assumptions (via its docstring)
on the spec of the shape of its underlying object. Because of idiosyncracies
of numpy indexing and the use of np.dtype, those assumptions are broken on an
 edge case (dtype = (scalar_type, 1)). This corrects the behavior of this
edge case to conform to the spec.

Review by @aazzolini 