### PR TITLE
Fix torch.utils.checkpoint not showing up in doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,12 +34,13 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    torch.distributed <distributed>
    torch.legacy <legacy>
    cuda
+   bottleneck
+   checkpoint
    cpp_extension
-   ffi
    data
+   ffi
    model_zoo
    onnx
-   bottleneck
 
 .. toctree::
    :glob:


### PR DESCRIPTION
Add checkpoint to index.rst. Order torch.utils.* alphabetically.

cc @prigoyal 