### PR TITLE
Use symbolizer by default in ASAN CI build

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -23,6 +23,7 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     export ASAN_OPTIONS=detect_leaks=0:symbolize=1
     export PYTORCH_TEST_WITH_ASAN=1
     # TODO: Figure out how to avoid hard-coding these paths
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-5.0/bin/llvm-symbolizer
     export LD_PRELOAD=/usr/lib/llvm-5.0/lib/clang/5.0.0/lib/linux/libclang_rt.asan-x86_64.so
 fi
 


### PR DESCRIPTION
This has no effect until https://github.com/pietern/pytorch-dockerfiles/pull/15 is merged and new PyTorch docker file is built.

I've verified that ASAN works even if `ASAN_SYMBOLIZER_PATH` points to a non-existing file (no symbols of course).