### PR TITLE
Explicitly define all caffe2 reducer ops by name

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -510,9 +510,6 @@ OpSchema::Cost PointwiseCostInference(
   void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
   static OpSchema* CAFFE_ANONYMOUS_VARIABLE(name) =      \
       &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
-#define OPERATOR_SCHEMA_STR(name)                                  \
-  static OpSchema* CAFFE_ANONYMOUS_VARIABLE(schema_registration) = \
-      &OpSchemaRegistry::NewSchema(name, __FILE__, __LINE__)
 
 #else // CAFFE2_NO_OPERATOR_SCHEMA
 
@@ -520,9 +517,6 @@ OpSchema::Cost PointwiseCostInference(
   void CAFFE2_PLEASE_ADD_OPERATOR_SCHEMA_FOR_##name(){}; \
   static OpSchema* CAFFE_ANONYMOUS_VARIABLE(name) =      \
       1 ? nullptr : &OpSchemaRegistry::NewSchema(#name, __FILE__, __LINE__)
-#define OPERATOR_SCHEMA_STR(name)                                  \
-  static OpSchema* CAFFE_ANONYMOUS_VARIABLE(schema_registration) = \
-      1 ? nullptr : &OpSchemaRegistry::NewSchema(name, __FILE__, __LINE__)
 
 #endif // CAFFE2_NO_OPERATOR_SCHEMA
 

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -80,149 +80,149 @@ constexpr bool equal(
 
 // Helper macro when the main op is defined elsewhere, and we only need to
 // define the schema, and the gradient op.
-#define REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                           \
-    segment_name, gradient_name, ...)                                        \
-  static_assert(                                                             \
-      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name),  \
-      segment_name);                                                         \
-  static_assert(                                                             \
-      equal(                                                                 \
-          gradient_name,                                                     \
-          __VA_ARGS__::basename,                                             \
-          __VA_ARGS__::OpDef::name,                                          \
-          "Gradient"),                                                       \
-      gradient_name);                                                        \
-  OPERATOR_SCHEMA_STR(string(segment_name))                                  \
-      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                         \
-      .NumOutputs(1)                                                         \
-      .SetDoc(FormatDoc<__VA_ARGS__>())                                      \
-      .Output(0, "OUTPUT", "Aggregated tensor")                              \
-      .FillUsing(__VA_ARGS__::PopulateSchema);                               \
-  REGISTER_CPU_OPERATOR_STR(string(gradient_name), __VA_ARGS__::BackwardOp); \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                                 \
-      .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                        \
-      .NumOutputs(1);                                                        \
-  REGISTER_GRADIENT_STR(string(segment_name), __VA_ARGS__::GetGradient)
+#define REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                            \
+    segment_name, gradient_name, ...)                                         \
+  static_assert(                                                              \
+      equal(#segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name),  \
+      #segment_name);                                                         \
+  static_assert(                                                              \
+      equal(                                                                  \
+          #gradient_name,                                                     \
+          __VA_ARGS__::basename,                                              \
+          __VA_ARGS__::OpDef::name,                                           \
+          "Gradient"),                                                        \
+      #gradient_name);                                                        \
+  OPERATOR_SCHEMA(segment_name)                                               \
+      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                          \
+      .NumOutputs(1)                                                          \
+      .SetDoc(FormatDoc<__VA_ARGS__>())                                       \
+      .Output(0, "OUTPUT", "Aggregated tensor")                               \
+      .FillUsing(__VA_ARGS__::PopulateSchema);                                \
+  REGISTER_CPU_OPERATOR_STR(string(#gradient_name), __VA_ARGS__::BackwardOp); \
+  OPERATOR_SCHEMA(gradient_name)                                              \
+      .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                         \
+      .NumOutputs(1);                                                         \
+  REGISTER_GRADIENT_STR(string(#segment_name), __VA_ARGS__::GetGradient)
 
-#define REGISTER_SEGMENT_DEF(segment_name, gradient_name, ...)              \
-  static_assert(                                                            \
-      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
-      segment_name);                                                        \
-  REGISTER_CPU_OPERATOR_STR(string(segment_name), __VA_ARGS__::ForwardOp);  \
-  REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                                \
+#define REGISTER_SEGMENT_DEF(segment_name, gradient_name, ...)               \
+  static_assert(                                                             \
+      equal(#segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      #segment_name);                                                        \
+  REGISTER_CPU_OPERATOR_STR(string(#segment_name), __VA_ARGS__::ForwardOp);  \
+  REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                                 \
       segment_name, gradient_name, __VA_ARGS__)
 
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentRangeSum",
-    "SortedSegmentRangeSumGradient",
+    SortedSegmentRangeSum,
+    SortedSegmentRangeSumGradient,
     AbstractSortedSegmentRangeDef<float, int, CPUContext, SumRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentRangeLogSumExp",
-    "SortedSegmentRangeLogSumExpGradient",
+    SortedSegmentRangeLogSumExp,
+    SortedSegmentRangeLogSumExpGradient,
     AbstractSortedSegmentRangeDef<
         float,
         int,
         CPUContext,
         LogSumExpRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentRangeLogMeanExp",
-    "SortedSegmentRangeLogMeanExpGradient",
+    SortedSegmentRangeLogMeanExp,
+    SortedSegmentRangeLogMeanExpGradient,
     AbstractSortedSegmentRangeDef<
         float,
         int,
         CPUContext,
         LogMeanExpRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentRangeMean",
-    "SortedSegmentRangeMeanGradient",
+    SortedSegmentRangeMean,
+    SortedSegmentRangeMeanGradient,
     AbstractSortedSegmentRangeDef<float, int, CPUContext, MeanRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentRangeMax",
-    "SortedSegmentRangeMaxGradient",
+    SortedSegmentRangeMax,
+    SortedSegmentRangeMaxGradient,
     AbstractSortedSegmentRangeDef<float, int, CPUContext, MaxRangeReducerDef>);
 
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentSum",
-    "SortedSegmentSumGradient",
+    SortedSegmentSum,
+    SortedSegmentSumGradient,
     AbstractSortedSegmentDef<float, int, CPUContext, SumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseSortedSegmentSum",
-    "SparseSortedSegmentSumGradient",
+    SparseSortedSegmentSum,
+    SparseSortedSegmentSumGradient,
     AbstractSparseSortedSegmentDef<float, int, CPUContext, SumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "UnsortedSegmentSum",
-    "UnsortedSegmentSumGradient",
+    UnsortedSegmentSum,
+    UnsortedSegmentSumGradient,
     AbstractUnsortedSegmentDef<float, int, CPUContext, SumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseUnsortedSegmentSum",
-    "SparseUnsortedSegmentSumGradient",
+    SparseUnsortedSegmentSum,
+    SparseUnsortedSegmentSumGradient,
     AbstractSparseUnsortedSegmentDef<float, int, CPUContext, SumReducerDef>);
 
 REGISTER_SEGMENT_DEF(
-    "LengthsSum",
-    "LengthsSumGradient",
+    LengthsSum,
+    LengthsSumGradient,
     AbstractLengthsDef<float, int, CPUContext, SumReducerDef, true>);
 
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentMean",
-    "SortedSegmentMeanGradient",
+    SortedSegmentMean,
+    SortedSegmentMeanGradient,
     AbstractSortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseSortedSegmentMean",
-    "SparseSortedSegmentMeanGradient",
+    SparseSortedSegmentMean,
+    SparseSortedSegmentMeanGradient,
     AbstractSparseSortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "UnsortedSegmentMean",
-    "UnsortedSegmentMeanGradient",
+    UnsortedSegmentMean,
+    UnsortedSegmentMeanGradient,
     AbstractUnsortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseUnsortedSegmentMean",
-    "SparseUnsortedSegmentMeanGradient",
+    SparseUnsortedSegmentMean,
+    SparseUnsortedSegmentMeanGradient,
     AbstractSparseUnsortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
 
 REGISTER_SEGMENT_DEF(
-    "LengthsMean",
-    "LengthsMeanGradient",
+    LengthsMean,
+    LengthsMeanGradient,
     AbstractLengthsDef<float, int, CPUContext, MeanReducerDef, false>);
 
 REGISTER_SEGMENT_DEF(
-    "ReduceFrontWeightedSum",
-    "ReduceFrontWeightedSumGradient",
+    ReduceFrontWeightedSum,
+    ReduceFrontWeightedSumGradient,
     AbstractReduceFrontDef<float, CPUContext, WeightedSumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SortedSegmentWeightedSum",
-    "SortedSegmentWeightedSumGradient",
+    SortedSegmentWeightedSum,
+    SortedSegmentWeightedSumGradient,
     AbstractSortedSegmentDef<float, int, CPUContext, WeightedSumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseSortedSegmentWeightedSum",
-    "SparseSortedSegmentWeightedSumGradient",
+    SparseSortedSegmentWeightedSum,
+    SparseSortedSegmentWeightedSumGradient,
     AbstractSparseSortedSegmentDef<
         float,
         int,
         CPUContext,
         WeightedSumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "UnsortedSegmentWeightedSum",
-    "UnsortedSegmentWeightedSumGradient",
+    UnsortedSegmentWeightedSum,
+    UnsortedSegmentWeightedSumGradient,
     AbstractUnsortedSegmentDef<float, int, CPUContext, WeightedSumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "SparseUnsortedSegmentWeightedSum",
-    "SparseUnsortedSegmentWeightedSumGradient",
+    SparseUnsortedSegmentWeightedSum,
+    SparseUnsortedSegmentWeightedSumGradient,
     AbstractSparseUnsortedSegmentDef<
         float,
         int,
         CPUContext,
         WeightedSumReducerDef>);
 REGISTER_SEGMENT_DEF(
-    "LengthsWeightedSum",
-    "LengthsWeightedSumGradient",
+    LengthsWeightedSum,
+    LengthsWeightedSumGradient,
     AbstractLengthsDef<float, int, CPUContext, WeightedSumReducerDef, false>);
 
 // SparseLengths[Sum,WeightedSum,Mean] are now implemented separately,
 // so we only rely to the historical implementation for the backward + schema.
 REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    "SparseLengthsSum",
-    "SparseLengthsSumGradient",
+    SparseLengthsSum,
+    SparseLengthsSumGradient,
     AbstractSparseLengthsDef<
         float,
         int,
@@ -230,8 +230,8 @@ REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
         SumReducerDef,
         true /*GradientNeedIndices*/>)
 REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    "SparseLengthsWeightedSum",
-    "SparseLengthsWeightedSumGradient",
+    SparseLengthsWeightedSum,
+    SparseLengthsWeightedSumGradient,
     AbstractSparseLengthsDef<
         float,
         int,
@@ -240,30 +240,30 @@ REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
         true /*GradientNeedIndices*/>)
 
 REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    "SparseLengthsMean",
-    "SparseLengthsMeanGradient",
+    SparseLengthsMean,
+    SparseLengthsMeanGradient,
     AbstractSparseLengthsDef<float, int, CPUContext, MeanReducerDef>);
 
 // Auxiliary output gradients are currently implemented only for Lengths version
-#define REGISTER_GRADIENT_WITH_MAIN_INPUT(gradient_name, ...)       \
-  static_assert(                                                    \
-      equal(                                                        \
-          gradient_name,                                            \
-          __VA_ARGS__::basename,                                    \
-          __VA_ARGS__::OpDef::name,                                 \
-          "WithMainInputGradient"),                                 \
-      gradient_name);                                               \
-  REGISTER_CPU_OPERATOR_STR(                                        \
-      string(gradient_name), __VA_ARGS__::WithMainInputBackwardOp); \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                        \
-      .NumInputs(__VA_ARGS__::WithMainInputBackwardOp::kNumInputs)  \
+#define REGISTER_GRADIENT_WITH_MAIN_INPUT(gradient_name, ...)        \
+  static_assert(                                                     \
+      equal(                                                         \
+          #gradient_name,                                            \
+          __VA_ARGS__::basename,                                     \
+          __VA_ARGS__::OpDef::name,                                  \
+          "WithMainInputGradient"),                                  \
+      #gradient_name);                                               \
+  REGISTER_CPU_OPERATOR_STR(                                         \
+      string(#gradient_name), __VA_ARGS__::WithMainInputBackwardOp); \
+  OPERATOR_SCHEMA(gradient_name)                                     \
+      .NumInputs(__VA_ARGS__::WithMainInputBackwardOp::kNumInputs)   \
       .NumOutputs(1, INT_MAX)
 
 REGISTER_GRADIENT_WITH_MAIN_INPUT(
-    "LengthsWeightedSumWithMainInputGradient",
+    LengthsWeightedSumWithMainInputGradient,
     AbstractLengthsDef<float, int, CPUContext, WeightedSumReducerDef>);
 REGISTER_GRADIENT_WITH_MAIN_INPUT(
-    "SparseLengthsWeightedSumWithMainInputGradient",
+    SparseLengthsWeightedSumWithMainInputGradient,
     AbstractSparseLengthsDef<float, int, CPUContext, WeightedSumReducerDef>);
 } // namespace
 
@@ -271,47 +271,47 @@ REGISTER_GRADIENT_WITH_MAIN_INPUT(
     gradient_name, ...)                                                     \
   static_assert(                                                            \
       equal(                                                                \
-          gradient_name,                                                    \
+          #gradient_name,                                                   \
           __VA_ARGS__::basename,                                            \
           __VA_ARGS__::OpDef::name,                                         \
           "WithMainInputAndForwardOutputGradient"),                         \
-      gradient_name);                                                       \
+      #gradient_name);                                                      \
   REGISTER_CPU_OPERATOR_STR(                                                \
-      string(gradient_name),                                                \
+      string(#gradient_name),                                               \
       __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp);                \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                                \
+  OPERATOR_SCHEMA(gradient_name)                                            \
       .NumInputs(                                                           \
           __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp::kNumInputs) \
       .NumOutputs(1, INT_MAX)
 
-#define REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(        \
-    segment_name, gradient_name, ...)                                       \
-  static_assert(                                                            \
-      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
-      gradient_name);                                                       \
-  OPERATOR_SCHEMA_STR(string(segment_name))                                 \
-      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                        \
-      .NumOutputs(1)                                                        \
-      .SetDoc(FormatDoc<__VA_ARGS__>())                                     \
-      .Output(0, "OUTPUT", "Aggregated tensor")                             \
-      .FillUsing(__VA_ARGS__::PopulateSchema);                              \
-  REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(                     \
-      gradient_name, __VA_ARGS__);                                          \
-  REGISTER_GRADIENT_STR(string(segment_name), __VA_ARGS__::GetGradient)
+#define REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(         \
+    segment_name, gradient_name, ...)                                        \
+  static_assert(                                                             \
+      equal(#segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      #segment_name);                                                        \
+  OPERATOR_SCHEMA(segment_name)                                              \
+      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                         \
+      .NumOutputs(1)                                                         \
+      .SetDoc(FormatDoc<__VA_ARGS__>())                                      \
+      .Output(0, "OUTPUT", "Aggregated tensor")                              \
+      .FillUsing(__VA_ARGS__::PopulateSchema);                               \
+  REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(                      \
+      gradient_name, __VA_ARGS__);                                           \
+  REGISTER_GRADIENT_STR(string(#segment_name), __VA_ARGS__::GetGradient)
 
 // This implements and registers a length op with a gradient which requires
 // the main input as well as the output of the forward output.
-#define REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(        \
-    segment_name, gradient_name, ...)                                       \
-  static_assert(                                                            \
-      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
-      gradient_name);                                                       \
-  REGISTER_CPU_OPERATOR_STR(string(segment_name), __VA_ARGS__::ForwardOp);  \
-  REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(              \
+#define REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(         \
+    segment_name, gradient_name, ...)                                        \
+  static_assert(                                                             \
+      equal(#segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      #segment_name);                                                        \
+  REGISTER_CPU_OPERATOR_STR(string(#segment_name), __VA_ARGS__::ForwardOp);  \
+  REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(               \
       segment_name, gradient_name, __VA_ARGS__)
 
 REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(
-    "LengthsMax",
-    "LengthsMaxWithMainInputAndForwardOutputGradient",
+    LengthsMax,
+    LengthsMaxWithMainInputAndForwardOutputGradient,
     AbstractLengthsDef<float, int, CPUContext, MaxReducerDef>);
 } // namespace caffe2

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -64,7 +64,7 @@ string FormatDoc() {
   return doc;
 }
 
-//  Helper function to enforce naming conventions at compile time.
+// Helper function to enforce naming conventions at compile time.
 constexpr bool equal(
     char const* lhs,
     char const* rhs1,

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -64,7 +64,7 @@ string FormatDoc() {
   return doc;
 }
 
-// Helper function to enforce naming conventions at compile time.
+//  Helper function to enforce naming conventions at compile time.
 constexpr bool equal(
     char const* lhs,
     char const* rhs1,

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -70,25 +70,12 @@ constexpr bool equal(
     char const* rhs1,
     char const* rhs2,
     char const* rhs3 = "") {
-  while (*rhs1) {
-    if (*lhs++ != *rhs1++) {
-      return false;
-    }
-  }
-
-  while (*rhs2) {
-    if (*lhs++ != *rhs2++) {
-      return false;
-    }
-  }
-
-  while (*rhs3 || *lhs) {
-    if (*lhs++ != *rhs3++) {
-      return false;
-    }
-  }
-
-  return true;
+  return (*lhs == 0 && *rhs1 == 0 && *rhs2 == 0 && *rhs3 == 0) ||
+      (*rhs1 != 0 && *lhs == *rhs1 && equal(lhs + 1, rhs1 + 1, rhs2, rhs3)) ||
+      (*rhs1 == 0 && *rhs2 != 0 && *lhs == *rhs2 &&
+       equal(lhs + 1, rhs1, rhs2 + 1, rhs3)) ||
+      (*rhs1 == 0 && *rhs2 == 0 && *rhs3 != 0 && *lhs == *rhs3 &&
+       equal(lhs + 1, rhs1, rhs2, rhs3 + 1));
 }
 
 // Helper macro when the main op is defined elsewhere, and we only need to

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -92,14 +92,14 @@ constexpr bool equal(
           __VA_ARGS__::OpDef::name,                                          \
           "Gradient"),                                                       \
       gradient_name);                                                        \
-  OPERATOR_SCHEMA_STR(string(segment_name))                                  \
+  OPERATOR_SCHEMA(segment_name)                                  \
       .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                         \
       .NumOutputs(1)                                                         \
       .SetDoc(FormatDoc<__VA_ARGS__>())                                      \
       .Output(0, "OUTPUT", "Aggregated tensor")                              \
       .FillUsing(__VA_ARGS__::PopulateSchema);                               \
   REGISTER_CPU_OPERATOR_STR(string(gradient_name), __VA_ARGS__::BackwardOp); \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                                 \
+  OPERATOR_SCHEMA(gradient_name)                                 \
       .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                        \
       .NumOutputs(1);                                                        \
   REGISTER_GRADIENT_STR(string(segment_name), __VA_ARGS__::GetGradient)
@@ -255,7 +255,7 @@ REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
       gradient_name);                                               \
   REGISTER_CPU_OPERATOR_STR(                                        \
       string(gradient_name), __VA_ARGS__::WithMainInputBackwardOp); \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                        \
+  OPERATOR_SCHEMA(gradient_name)                        \
       .NumInputs(__VA_ARGS__::WithMainInputBackwardOp::kNumInputs)  \
       .NumOutputs(1, INT_MAX)
 
@@ -279,7 +279,7 @@ REGISTER_GRADIENT_WITH_MAIN_INPUT(
   REGISTER_CPU_OPERATOR_STR(                                                \
       string(gradient_name),                                                \
       __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp);                \
-  OPERATOR_SCHEMA_STR(string(gradient_name))                                \
+  OPERATOR_SCHEMA(gradient_name)                                \
       .NumInputs(                                                           \
           __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp::kNumInputs) \
       .NumOutputs(1, INT_MAX)
@@ -289,7 +289,7 @@ REGISTER_GRADIENT_WITH_MAIN_INPUT(
   static_assert(                                                            \
       equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
       gradient_name);                                                       \
-  OPERATOR_SCHEMA_STR(string(segment_name))                                 \
+  OPERATOR_SCHEMA(segment_name)                                 \
       .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                        \
       .NumOutputs(1)                                                        \
       .SetDoc(FormatDoc<__VA_ARGS__>())                                     \

--- a/caffe2/operators/segment_reduction_op.cc
+++ b/caffe2/operators/segment_reduction_op.cc
@@ -64,150 +64,267 @@ string FormatDoc() {
   return doc;
 }
 
+// Helper function to enforce naming conventions at compile time.
+constexpr bool equal(
+    char const* lhs,
+    char const* rhs1,
+    char const* rhs2,
+    char const* rhs3 = "") {
+  while (*rhs1) {
+    if (*lhs++ != *rhs1++) {
+      return false;
+    }
+  }
+
+  while (*rhs2) {
+    if (*lhs++ != *rhs2++) {
+      return false;
+    }
+  }
+
+  while (*rhs3 || *lhs) {
+    if (*lhs++ != *rhs3++) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // Helper macro when the main op is defined elsewhere, and we only need to
 // define the schema, and the gradient op.
-#define REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(...)                         \
-  OPERATOR_SCHEMA_STR(                                                         \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name))              \
-      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                           \
-      .NumOutputs(1)                                                           \
-      .SetDoc(FormatDoc<__VA_ARGS__>())                                        \
-      .Output(0, "OUTPUT", "Aggregated tensor")                                \
-      .FillUsing(__VA_ARGS__::PopulateSchema);                                 \
-  REGISTER_CPU_OPERATOR_STR(                                                   \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) + "Gradient", \
-      __VA_ARGS__::BackwardOp);                                                \
-  OPERATOR_SCHEMA_STR(                                                         \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) + "Gradient") \
-      .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                          \
-      .NumOutputs(1);                                                          \
-  REGISTER_GRADIENT_STR(                                                       \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name),              \
-      __VA_ARGS__::GetGradient)
+#define REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                           \
+    segment_name, gradient_name, ...)                                        \
+  static_assert(                                                             \
+      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name),  \
+      segment_name);                                                         \
+  static_assert(                                                             \
+      equal(                                                                 \
+          gradient_name,                                                     \
+          __VA_ARGS__::basename,                                             \
+          __VA_ARGS__::OpDef::name,                                          \
+          "Gradient"),                                                       \
+      gradient_name);                                                        \
+  OPERATOR_SCHEMA_STR(string(segment_name))                                  \
+      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                         \
+      .NumOutputs(1)                                                         \
+      .SetDoc(FormatDoc<__VA_ARGS__>())                                      \
+      .Output(0, "OUTPUT", "Aggregated tensor")                              \
+      .FillUsing(__VA_ARGS__::PopulateSchema);                               \
+  REGISTER_CPU_OPERATOR_STR(string(gradient_name), __VA_ARGS__::BackwardOp); \
+  OPERATOR_SCHEMA_STR(string(gradient_name))                                 \
+      .NumInputs(__VA_ARGS__::BackwardOp::kNumInputs)                        \
+      .NumOutputs(1);                                                        \
+  REGISTER_GRADIENT_STR(string(segment_name), __VA_ARGS__::GetGradient)
 
-#define REGISTER_SEGMENT_DEF(...)                                 \
-  REGISTER_CPU_OPERATOR_STR(                                      \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name), \
-      __VA_ARGS__::ForwardOp);                                    \
-  REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(__VA_ARGS__)
+#define REGISTER_SEGMENT_DEF(segment_name, gradient_name, ...)              \
+  static_assert(                                                            \
+      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      segment_name);                                                        \
+  REGISTER_CPU_OPERATOR_STR(string(segment_name), __VA_ARGS__::ForwardOp);  \
+  REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(                                \
+      segment_name, gradient_name, __VA_ARGS__)
 
 REGISTER_SEGMENT_DEF(
+    "SortedSegmentRangeSum",
+    "SortedSegmentRangeSumGradient",
     AbstractSortedSegmentRangeDef<float, int, CPUContext, SumRangeReducerDef>);
-REGISTER_SEGMENT_DEF(AbstractSortedSegmentRangeDef<
-                     float,
-                     int,
-                     CPUContext,
-                     LogSumExpRangeReducerDef>);
-REGISTER_SEGMENT_DEF(AbstractSortedSegmentRangeDef<
-                     float,
-                     int,
-                     CPUContext,
-                     LogMeanExpRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
+    "SortedSegmentRangeLogSumExp",
+    "SortedSegmentRangeLogSumExpGradient",
+    AbstractSortedSegmentRangeDef<
+        float,
+        int,
+        CPUContext,
+        LogSumExpRangeReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SortedSegmentRangeLogMeanExp",
+    "SortedSegmentRangeLogMeanExpGradient",
+    AbstractSortedSegmentRangeDef<
+        float,
+        int,
+        CPUContext,
+        LogMeanExpRangeReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SortedSegmentRangeMean",
+    "SortedSegmentRangeMeanGradient",
     AbstractSortedSegmentRangeDef<float, int, CPUContext, MeanRangeReducerDef>);
 REGISTER_SEGMENT_DEF(
+    "SortedSegmentRangeMax",
+    "SortedSegmentRangeMaxGradient",
     AbstractSortedSegmentRangeDef<float, int, CPUContext, MaxRangeReducerDef>);
 
-#define REGISTER_REDUCER_WITH_OPS(reducer_def)                              \
-  REGISTER_SEGMENT_DEF(                                                     \
-      AbstractSortedSegmentDef<float, int, CPUContext, reducer_def>);       \
-  REGISTER_SEGMENT_DEF(                                                     \
-      AbstractSparseSortedSegmentDef<float, int, CPUContext, reducer_def>); \
-  REGISTER_SEGMENT_DEF(                                                     \
-      AbstractUnsortedSegmentDef<float, int, CPUContext, reducer_def>);     \
-  REGISTER_SEGMENT_DEF(                                                     \
-      AbstractSparseUnsortedSegmentDef<float, int, CPUContext, reducer_def>)
+REGISTER_SEGMENT_DEF(
+    "SortedSegmentSum",
+    "SortedSegmentSumGradient",
+    AbstractSortedSegmentDef<float, int, CPUContext, SumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseSortedSegmentSum",
+    "SparseSortedSegmentSumGradient",
+    AbstractSparseSortedSegmentDef<float, int, CPUContext, SumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "UnsortedSegmentSum",
+    "UnsortedSegmentSumGradient",
+    AbstractUnsortedSegmentDef<float, int, CPUContext, SumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseUnsortedSegmentSum",
+    "SparseUnsortedSegmentSumGradient",
+    AbstractSparseUnsortedSegmentDef<float, int, CPUContext, SumReducerDef>);
 
-#define REGISTER_REDUCER_WITH_LENGTH_OPS(reducer_def, GradientNeedIndices) \
-  REGISTER_SEGMENT_DEF(AbstractLengthsDef<                                 \
-                       float,                                              \
-                       int,                                                \
-                       CPUContext,                                         \
-                       reducer_def,                                        \
-                       GradientNeedIndices>)
+REGISTER_SEGMENT_DEF(
+    "LengthsSum",
+    "LengthsSumGradient",
+    AbstractLengthsDef<float, int, CPUContext, SumReducerDef, true>);
 
-#define REGISTER_REDUCER_WITH_ALL_OPS(reducer_def)             \
-  REGISTER_SEGMENT_DEF(                                        \
-      AbstractReduceFrontDef<float, CPUContext, reducer_def>); \
-  REGISTER_REDUCER_WITH_OPS(reducer_def)                       \
-  REGISTER_REDUCER_WITH_LENGTH_OPS(reducer_def, false)
+REGISTER_SEGMENT_DEF(
+    "SortedSegmentMean",
+    "SortedSegmentMeanGradient",
+    AbstractSortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseSortedSegmentMean",
+    "SparseSortedSegmentMeanGradient",
+    AbstractSparseSortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "UnsortedSegmentMean",
+    "UnsortedSegmentMeanGradient",
+    AbstractUnsortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseUnsortedSegmentMean",
+    "SparseUnsortedSegmentMeanGradient",
+    AbstractSparseUnsortedSegmentDef<float, int, CPUContext, MeanReducerDef>);
 
-REGISTER_REDUCER_WITH_OPS(SumReducerDef);
-REGISTER_REDUCER_WITH_LENGTH_OPS(SumReducerDef, true);
+REGISTER_SEGMENT_DEF(
+    "LengthsMean",
+    "LengthsMeanGradient",
+    AbstractLengthsDef<float, int, CPUContext, MeanReducerDef, false>);
 
-REGISTER_REDUCER_WITH_OPS(MeanReducerDef);
-REGISTER_REDUCER_WITH_LENGTH_OPS(MeanReducerDef, false);
-
-REGISTER_REDUCER_WITH_ALL_OPS(WeightedSumReducerDef);
+REGISTER_SEGMENT_DEF(
+    "ReduceFrontWeightedSum",
+    "ReduceFrontWeightedSumGradient",
+    AbstractReduceFrontDef<float, CPUContext, WeightedSumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SortedSegmentWeightedSum",
+    "SortedSegmentWeightedSumGradient",
+    AbstractSortedSegmentDef<float, int, CPUContext, WeightedSumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseSortedSegmentWeightedSum",
+    "SparseSortedSegmentWeightedSumGradient",
+    AbstractSparseSortedSegmentDef<
+        float,
+        int,
+        CPUContext,
+        WeightedSumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "UnsortedSegmentWeightedSum",
+    "UnsortedSegmentWeightedSumGradient",
+    AbstractUnsortedSegmentDef<float, int, CPUContext, WeightedSumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "SparseUnsortedSegmentWeightedSum",
+    "SparseUnsortedSegmentWeightedSumGradient",
+    AbstractSparseUnsortedSegmentDef<
+        float,
+        int,
+        CPUContext,
+        WeightedSumReducerDef>);
+REGISTER_SEGMENT_DEF(
+    "LengthsWeightedSum",
+    "LengthsWeightedSumGradient",
+    AbstractLengthsDef<float, int, CPUContext, WeightedSumReducerDef, false>);
 
 // SparseLengths[Sum,WeightedSum,Mean] are now implemented separately,
 // so we only rely to the historical implementation for the backward + schema.
-REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(AbstractSparseLengthsDef<
-                                          float,
-                                          int,
-                                          CPUContext,
-                                          SumReducerDef,
-                                          true /*GradientNeedIndices*/>)
-REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(AbstractSparseLengthsDef<
-                                          float,
-                                          int,
-                                          CPUContext,
-                                          WeightedSumReducerDef,
-                                          true /*GradientNeedIndices*/>)
+REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
+    "SparseLengthsSum",
+    "SparseLengthsSumGradient",
+    AbstractSparseLengthsDef<
+        float,
+        int,
+        CPUContext,
+        SumReducerDef,
+        true /*GradientNeedIndices*/>)
+REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
+    "SparseLengthsWeightedSum",
+    "SparseLengthsWeightedSumGradient",
+    AbstractSparseLengthsDef<
+        float,
+        int,
+        CPUContext,
+        WeightedSumReducerDef,
+        true /*GradientNeedIndices*/>)
 
 REGISTER_SEGMENT_DEF_SCHEMA_GRADIENT_ONLY(
-    AbstractSparseLengthsDef<float, int, CPUContext, MeanReducerDef>)
+    "SparseLengthsMean",
+    "SparseLengthsMeanGradient",
+    AbstractSparseLengthsDef<float, int, CPUContext, MeanReducerDef>);
 
 // Auxiliary output gradients are currently implemented only for Lengths version
-#define REGISTER_GRADIENT_WITH_MAIN_INPUT(...)                     \
-  REGISTER_CPU_OPERATOR_STR(                                       \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) + \
-          "WithMainInputGradient",                                 \
-      __VA_ARGS__::WithMainInputBackwardOp);                       \
-  OPERATOR_SCHEMA_STR(                                             \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) + \
-      "WithMainInputGradient")                                     \
-      .NumInputs(__VA_ARGS__::WithMainInputBackwardOp::kNumInputs) \
+#define REGISTER_GRADIENT_WITH_MAIN_INPUT(gradient_name, ...)       \
+  static_assert(                                                    \
+      equal(                                                        \
+          gradient_name,                                            \
+          __VA_ARGS__::basename,                                    \
+          __VA_ARGS__::OpDef::name,                                 \
+          "WithMainInputGradient"),                                 \
+      gradient_name);                                               \
+  REGISTER_CPU_OPERATOR_STR(                                        \
+      string(gradient_name), __VA_ARGS__::WithMainInputBackwardOp); \
+  OPERATOR_SCHEMA_STR(string(gradient_name))                        \
+      .NumInputs(__VA_ARGS__::WithMainInputBackwardOp::kNumInputs)  \
       .NumOutputs(1, INT_MAX)
+
 REGISTER_GRADIENT_WITH_MAIN_INPUT(
+    "LengthsWeightedSumWithMainInputGradient",
     AbstractLengthsDef<float, int, CPUContext, WeightedSumReducerDef>);
 REGISTER_GRADIENT_WITH_MAIN_INPUT(
+    "SparseLengthsWeightedSumWithMainInputGradient",
     AbstractSparseLengthsDef<float, int, CPUContext, WeightedSumReducerDef>);
 } // namespace
 
-#define REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(...)           \
+#define REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(               \
+    gradient_name, ...)                                                     \
+  static_assert(                                                            \
+      equal(                                                                \
+          gradient_name,                                                    \
+          __VA_ARGS__::basename,                                            \
+          __VA_ARGS__::OpDef::name,                                         \
+          "WithMainInputAndForwardOutputGradient"),                         \
+      gradient_name);                                                       \
   REGISTER_CPU_OPERATOR_STR(                                                \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) +          \
-          "WithMainInputAndForwardOutputGradient",                          \
+      string(gradient_name),                                                \
       __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp);                \
-  OPERATOR_SCHEMA_STR(                                                      \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name) +          \
-      "WithMainInputAndForwardOutputGradient")                              \
+  OPERATOR_SCHEMA_STR(string(gradient_name))                                \
       .NumInputs(                                                           \
           __VA_ARGS__::WithMainInputAndForwardOutputBackwardOp::kNumInputs) \
       .NumOutputs(1, INT_MAX)
 
-#define REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(...) \
-  OPERATOR_SCHEMA_STR(                                                   \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name))        \
-      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                     \
-      .NumOutputs(1)                                                     \
-      .SetDoc(FormatDoc<__VA_ARGS__>())                                  \
-      .Output(0, "OUTPUT", "Aggregated tensor")                          \
-      .FillUsing(__VA_ARGS__::PopulateSchema);                           \
-  REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(__VA_ARGS__);     \
-  REGISTER_GRADIENT_STR(                                                 \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name),        \
-      __VA_ARGS__::GetGradient)
+#define REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(        \
+    segment_name, gradient_name, ...)                                       \
+  static_assert(                                                            \
+      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      gradient_name);                                                       \
+  OPERATOR_SCHEMA_STR(string(segment_name))                                 \
+      .NumInputs(__VA_ARGS__::ForwardOp::kNumInputs)                        \
+      .NumOutputs(1)                                                        \
+      .SetDoc(FormatDoc<__VA_ARGS__>())                                     \
+      .Output(0, "OUTPUT", "Aggregated tensor")                             \
+      .FillUsing(__VA_ARGS__::PopulateSchema);                              \
+  REGISTER_GRADIENT_WITH_MAIN_INPUT_AND_FORWARD_OUTPUT(                     \
+      gradient_name, __VA_ARGS__);                                          \
+  REGISTER_GRADIENT_STR(string(segment_name), __VA_ARGS__::GetGradient)
 
 // This implements and registers a length op with a gradient which requires
 // the main input as well as the output of the forward output.
-#define REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(...) \
-  REGISTER_CPU_OPERATOR_STR(                                             \
-      string(__VA_ARGS__::basename) + (__VA_ARGS__::OpDef::name),        \
-      __VA_ARGS__::ForwardOp);                                           \
-  REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(__VA_ARGS__)
+#define REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(        \
+    segment_name, gradient_name, ...)                                       \
+  static_assert(                                                            \
+      equal(segment_name, __VA_ARGS__::basename, __VA_ARGS__::OpDef::name), \
+      gradient_name);                                                       \
+  REGISTER_CPU_OPERATOR_STR(string(segment_name), __VA_ARGS__::ForwardOp);  \
+  REGISTER_SEGMENT_DEF_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(              \
+      segment_name, gradient_name, __VA_ARGS__)
 
 REGISTER_LENGTHS_OPS_MAIN_INPUT_AND_FORWARD_OUTPUT_GRADIENT(
+    "LengthsMax",
+    "LengthsMaxWithMainInputAndForwardOutputGradient",
     AbstractLengthsDef<float, int, CPUContext, MaxReducerDef>);
-}
+} // namespace caffe2


### PR DESCRIPTION
Explicitly define all caffe2 reducer ops by name instead of string concatenating them. This helps people searching for a particular operator. The code enforces the old naming convention.

