### PR TITLE
 More precise digamma

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -10,6 +10,7 @@
 #include "ATen/Generator.h"
 
 #include "TH/THRandom.h"
+#include "TH/THMath.h"
 
 namespace {
 /*
@@ -99,11 +100,19 @@ int64_t sample_poisson(double lambda, THGenerator* generator) {
   }
 }
 
-// TODO Replace this with more accurate digamma().
-template <typename scalar_t>
-scalar_t digamma_one(scalar_t x) {
-  const double eps = x * 1e-3;
-  return (std::lgamma(x + eps) - std::lgamma(x - eps)) / (eps + eps);
+template <typename scalar>
+static inline scalar digamma_one(scalar x) {
+  throw std::runtime_error("digamma is only implemented for float, double");
+}
+
+template <>
+inline double digamma_one<double>(double x) {
+  return TH_digamma(x);
+}
+
+template <>
+inline float digamma_one<float>(float x) {
+  return TH_digammaf(x);
 }
 
 // Computes the reparameterized gradient -(d/dalpha cdf(x;alpha)) / pdf(x;alpha)

--- a/aten/src/TH/THMath.h
+++ b/aten/src/TH/THMath.h
@@ -213,7 +213,10 @@ static inline double TH_digammaf(float x) {
     if (x_is_integer) {
       return INFINITY;
     }
-    return TH_digammaf(1 - x) - M_PIf / tanf(M_PIf * x);
+    // Avoid rounding errors for `tan`'s input.
+    // Those make a big difference at extreme values.
+    float pi_over_tan_pi_x = (float)(M_PI / tan(M_PI * (double)x));
+    return TH_digammaf(1 - x) - pi_over_tan_pi_x;
   }
 
   // Push x to be >= 10

--- a/aten/src/TH/THMath.h
+++ b/aten/src/TH/THMath.h
@@ -129,34 +129,120 @@ Date:  February 1996
 }
 #undef CENTRAL_RANGE
 
-static inline double TH_digamma(double x) {
+static inline double TH_polevl(double x, double *A, size_t len) {
   double result = 0;
-  if (x < 0.5) {
-    result -= M_PI / tan(M_PI * x);
-    x = 1 - x;
+  for (size_t i = 0; i <= len; i++) {
+    result = result * x + A[i];
   }
-  for (int i = 0; i < 4; ++i) {
-    result -= 1 / x;
-    x += 1;
-  }
-  const double ixx = 1 / (x*x);
-  result += log(x) - 1 / (2*x) - ixx * (1./12 - ixx * (1./120 - ixx * (1./252)));
   return result;
 }
 
-static inline float TH_digammaf(float x) {
+static inline float TH_polevlf(float x, float *A, size_t len) {
   float result = 0;
-  if (x < 0.5) {
-    result -= M_PIf / tanf(M_PIf * x);
-    x = 1 - x;
+  for (size_t i = 0; i <= len; i++) {
+    result = result * x + A[i];
   }
-  for (int i = 0; i < 4; ++i) {
+  return result;
+}
+
+/*
+ * The following function comes with the following copyright notice.
+ * It has been released under the BSD license.
+ *
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
+static inline double TH_digamma(double x) {
+  static double PSI_10 = 2.25175258906672110764;
+  if (x == 0) {
+    return INFINITY;
+  }
+
+  int x_is_integer = x == floor(x);
+  if (x < 0) {
+    if (x_is_integer) {
+      return INFINITY;
+    }
+    return TH_digamma(1 - x) - M_PI / tan(M_PI * x);
+  }
+
+  // Push x to be >= 10
+  double result = 0;
+  while (x < 10) {
     result -= 1 / x;
     x += 1;
   }
-  const float ixx = 1 / (x*x);
-  result += logf(x) - 1 / (2*x) - ixx * (1.f/12 - ixx * (1.f/120 - ixx * (1.f/252)));
-  return result;
+  if (x == 10) {
+    return result + PSI_10;
+  }
+
+  // Compute asymptotic digamma
+  static double A[] = {
+     8.33333333333333333333E-2,
+    -2.10927960927960927961E-2,
+     7.57575757575757575758E-3,
+    -4.16666666666666666667E-3,
+     3.96825396825396825397E-3,
+    -8.33333333333333333333E-3,
+     8.33333333333333333333E-2,
+  };
+
+  double y = 0;
+  if (x < 1.0e17) {
+    double z = 1.0 / (x * x);
+    y = z * TH_polevl(z, A, 6);
+  }
+  return result + log(x) - (0.5 / x) - y;
+}
+
+/*
+ * The following function comes with the following copyright notice.
+ * It has been released under the BSD license.
+ *
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
+static inline double TH_digammaf(float x) {
+  static float PSI_10 = 2.25175258906672110764f;
+  if (x == 0) {
+    return INFINITY;
+  }
+
+  int x_is_integer = x == floorf(x);
+  if (x < 0) {
+    if (x_is_integer) {
+      return INFINITY;
+    }
+    return TH_digammaf(1 - x) - M_PIf / tanf(M_PIf * x);
+  }
+
+  // Push x to be >= 10
+  float result = 0;
+  while (x < 10) {
+    result -= 1 / x;
+    x += 1;
+  }
+  if (x == 10) {
+    return result + PSI_10;
+  }
+
+  // Compute asymptotic digamma
+  static float A[] = {
+     8.33333333333333333333E-2f,
+    -2.10927960927960927961E-2f,
+     7.57575757575757575758E-3f,
+    -4.16666666666666666667E-3f,
+     3.96825396825396825397E-3f,
+    -8.33333333333333333333E-3f,
+     8.33333333333333333333E-2f,
+  };
+
+  float y = 0;
+  if (x < 1.0e17) {
+    float z = 1 / (x * x);
+    y = z * TH_polevlf(z, A, 6);
+  }
+  return result + logf(x) - (0.5 / x) - y;
 }
 
 static inline double TH_trigamma(double x) {

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -4256,7 +4256,7 @@ void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, real min
 // Approximate reparameterized gradient of Beta(x,alpha,beta) wrt alpha.
 // Assumes x is close to zero and uses a Taylor expansion.
 static inline real THTensor_(beta_grad_alpha_small)(real x, real alpha, real beta) {
-  const real factor = TH_digamma(alpha) - TH_digamma(alpha + beta) - TH_MATH_NAME(log)(x);
+  const real factor = TH_MATH_NAME(TH_digamma)(alpha) - TH_MATH_NAME(TH_digamma)(alpha + beta) - TH_MATH_NAME(log)(x);
   real numer = 1;
   real series = numer / alpha * (factor + 1 / alpha);
   for (int i = 1; i <= 10; ++i) {
@@ -4271,7 +4271,7 @@ static inline real THTensor_(beta_grad_alpha_small)(real x, real alpha, real bet
 // Approximate reparameterized gradient of Beta(x,alpha,beta) wrt beta.
 // Assumes x is close to zero and uses a Taylor expansion.
 static inline real THTensor_(beta_grad_beta_small)(real x, real alpha, real beta) {
-  const real factor = TH_digamma(alpha+beta) - TH_digamma(beta);
+  const real factor = TH_MATH_NAME(TH_digamma)(alpha+beta) - TH_MATH_NAME(TH_digamma)(beta);
   real numer = 1;
   real betas = 1;
   real dbetas = 0;
@@ -4382,7 +4382,7 @@ static inline real THTensor_(dirichlet_grad_one)(real x, real alpha, real total)
       q += ua * (c[1][i][j][0] + b * (c[1][i][j][1] + b * (c[1][i][j][2] + b * c[1][i][j][3])));
     }
   }
-  const real approx = x * (TH_digamma(total) - TH_digamma(alpha)) / beta;
+  const real approx = x * (TH_MATH_NAME(TH_digamma)(total) - TH_MATH_NAME(TH_digamma)(alpha)) / beta;
   return p / q * approx;
 }
 

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -818,25 +818,70 @@ struct TensorBitXorOp {
   }
 };
 
+/*
+ * The following function was converted to CUDA form from code that comes
+ * with the following copyright notice. It has been released under the BSD license.
+ *
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
 template <typename real, typename accreal>
 struct TensorDigammaOp {
-  using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
-    const compute_type PI = 3.14159265358979323846;
+    using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
+    static const compute_type PI = 3.14159265358979323846;
+    static const compute_type PSI_10 = 2.25175258906672110764;
+    static const compute_type A[] = {
+       8.33333333333333333333E-2,
+      -2.10927960927960927961E-2,
+       7.57575757575757575758E-3,
+      -4.16666666666666666667E-3,
+       3.96825396825396825397E-3,
+      -8.33333333333333333333E-3,
+       8.33333333333333333333E-2,
+    };
+
     compute_type x = ScalarConvert<real, compute_type>::to(*in);
+    if (x == 0) {
+      *out = ScalarConvert<float, real>::to(INFINITY);
+      return;
+    }
+
+    bool x_is_integer = x == floor(x);
     compute_type result = 0;
-    if (x < 0.5f) {
-      result -= PI / THCNumerics<compute_type>::tan(PI * x);
+    if (x < 0) {
+      if (x_is_integer) {
+        *out = ScalarConvert<float, real>::to(INFINITY);
+        return;
+      }
+      result = - PI / tan(PI * x);
       x = 1 - x;
     }
-    for (int i = 0; i < 4; ++i) {
+
+    while (x < 10) {
       result -= 1 / x;
       x += 1;
     }
-    const compute_type ixx = 1 / (x*x);
-    result += THCNumerics<compute_type>::log(x) - 1 / (2*x) - ixx * (1.f/12 - ixx * (1.f/120 - ixx * (1.f/252)));
-    *out = ScalarConvert<compute_type, real>::to(result);
+    if (x == 10) {
+      *out = ScalarConvert<compute_type, real>::to(result + PSI_10);
+      return;
+    }
+
+    compute_type y = 0;
+    if (x < 1.0e17) {
+      compute_type z = 1.0 / (x * x);
+
+      compute_type polevl_result = 0;
+      for (int i = 0; i <= 6; i++) {
+        polevl_result = polevl_result * z + A[i];
+      }
+      y = z * polevl_result;
+    }
+
+    *out = ScalarConvert<compute_type, real>::to(
+        log(x) - (0.5 / x) - y + result);
+    return;
   }
 };
 

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -830,7 +830,7 @@ struct TensorDigammaOp {
   __device__ __forceinline__ void
   operator()(real* out, real* in) {
     using compute_type = typename std::conditional<std::is_same<real, half>::value, accreal, real>::type;
-    static const compute_type PI = 3.14159265358979323846;
+    static const double PI_f64 = 3.14159265358979323846;
     static const compute_type PSI_10 = 2.25175258906672110764;
     static const compute_type A[] = {
        8.33333333333333333333E-2,
@@ -855,7 +855,10 @@ struct TensorDigammaOp {
         *out = ScalarConvert<float, real>::to(INFINITY);
         return;
       }
-      result = - PI / tan(PI * x);
+      // Rounding errors in tan's input can really affect the output
+      // for extreme values, so we always perform this computation in double.
+      result = ScalarConvert<double, compute_type>::to(
+          - PI_f64 / tan(PI_f64 * ScalarConvert<compute_type, double>::to(x)));
       x = 1 - x;
     }
 

--- a/aten/src/THC/THCTensorMathPointwise.cuh
+++ b/aten/src/THC/THCTensorMathPointwise.cuh
@@ -842,9 +842,9 @@ struct TensorDigammaOp {
        8.33333333333333333333E-2,
     };
 
-    compute_type x = ScalarConvert<real, compute_type>::to(*in);
+    auto x = scalar_cast<compute_type>(*in);
     if (x == 0) {
-      *out = ScalarConvert<float, real>::to(INFINITY);
+      *out = scalar_cast<real>(INFINITY);
       return;
     }
 
@@ -852,13 +852,13 @@ struct TensorDigammaOp {
     compute_type result = 0;
     if (x < 0) {
       if (x_is_integer) {
-        *out = ScalarConvert<float, real>::to(INFINITY);
+        *out = scalar_cast<real>(INFINITY);
         return;
       }
       // Rounding errors in tan's input can really affect the output
       // for extreme values, so we always perform this computation in double.
-      result = ScalarConvert<double, compute_type>::to(
-          - PI_f64 / tan(PI_f64 * ScalarConvert<compute_type, double>::to(x)));
+      result = scalar_cast<compute_type>(
+          - PI_f64 / tan(PI_f64 * scalar_cast<double>(x)));
       x = 1 - x;
     }
 
@@ -867,7 +867,7 @@ struct TensorDigammaOp {
       x += 1;
     }
     if (x == 10) {
-      *out = ScalarConvert<compute_type, real>::to(result + PSI_10);
+      *out = scalar_cast<real>(result + PSI_10);
       return;
     }
 
@@ -882,8 +882,7 @@ struct TensorDigammaOp {
       y = z * polevl_result;
     }
 
-    *out = ScalarConvert<compute_type, real>::to(
-        log(x) - (0.5 / x) - y + result);
+    *out = scalar_cast<real>(log(x) - (0.5 / x) - y + result);
     return;
   }
 };

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1500,6 +1500,18 @@ class TestCuda(TestCase):
         test(True)
         test(False)
 
+        # Test float32 behavior near and at poles.
+        cpu_tensor = torch.tensor([-0.999999994, -1.999999994, -2.0000000111,
+                                  -100.99999994, -1931.99999994, 0.000000111,
+                                  -0.000000111, 0, -1, -2, -931])
+        nan = float('nan')
+        expected_errors = torch.tensor([0, 0, 0, 0, 0, 0, 0, nan, nan, nan, nan])
+        gpu_tensor = cpu_tensor.cuda()
+        cpu_out = cpu_tensor.digamma()
+        gpu_out = gpu_tensor.digamma()
+        norm_errors = (gpu_out - cpu_out.cuda()) / gpu_out
+        self.assertEqual(norm_errors, expected_errors)
+
     def test_polygamma(self):
         def test(use_double=False):
             cpu_tensor = torch.randn(10, 10, 10)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -315,8 +315,7 @@ class TestTorch(TestCase):
             return math.lgamma(x)
         self._test_math(torch.lgamma, lgamma)
 
-    def _digamma_input(self):
-        # digamma is imprecise when too close to the poles (0, -1, -2, ...)
+    def _digamma_input(self, test_poles=True):
         input = []
         input.append((torch.randn(10).abs() + 1e-4).tolist())
         input.append((torch.randn(10).abs() + 1e6).tolist())
@@ -325,6 +324,11 @@ class TestTorch(TestCase):
         input.append((zeros - 0.49).tolist())
         input.append((zeros + 0.49).tolist())
         input.append((zeros + (torch.rand(10) * 0.99) - 0.5).tolist())
+
+        if test_poles:
+            input.append([-0.999999994, -1.999999994, -2.0000000111,
+                          -100.99999994, -1931.99999994, 0.000000111,
+                          -0.000000111, 0, -2, -329])
         return input
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
@@ -338,7 +342,7 @@ class TestTorch(TestCase):
         for n in [0, 1]:
             self._test_math(lambda x: torch.polygamma(n, x),
                             lambda x: polygamma(n, x).item(),
-                            self._digamma_input())
+                            self._digamma_input(test_poles=False))
 
     def test_asin(self):
         self._test_math(torch.asin, lambda x: math.asin(x) if abs(x) <= 1 else float('nan'))


### PR DESCRIPTION
Fixes #6190.

This is a rebase of #3955 with some tweaks for better performance around
poles. The code is ported over from cephes with permission.

By itself, the cephes code returns inf for the poles.

For better performance around the poles with float32, one intermediate
step is always computed with double precision, regardless of dtype.
This step does `PI / tan(PI * input)`. This is necessary because small (1e-6)
rounding errors for the inputs to tan have strong effects on the output
(ie, the derivative of tan is very large at some points).

cc @colesbury @apaszke 