### PR TITLE
[jit][script] Allow tuples to be re-assigned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -642,6 +642,7 @@ main_sources = [
     "torch/csrc/jit/passes/graph_fuser.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/dead_code_elimination.cpp",
+    "torch/csrc/jit/passes/lower_tuples.cpp",
     "torch/csrc/jit/passes/common_subexpression_elimination.cpp",
     "torch/csrc/jit/passes/peephole.cpp",
     "torch/csrc/jit/passes/inplace_check.cpp",

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -134,6 +134,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/passes/shape_analysis.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/canonicalize.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/dead_code_elimination.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/passes/lower_tuples.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/peephole.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/inplace_check.cpp
   ${TORCH_SRC_DIR}/csrc/jit/passes/batch_mm.cpp

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -56,7 +56,9 @@ _(prim, Reverse) \
 _(prim, Return) \
 _(prim, Store) \
 _(prim, Undefined) \
-_(prim, Starred)
+_(prim, Starred) \
+_(prim, TupleConstruct) \
+_(prim, TupleUnpack)
 /* end */
 
 // Workaround for some not-yet-defined ATen symbols, see

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -28,11 +28,8 @@ std::string getPythonName(const PyObject* obj, bool is_legacy) {
   if (is_legacy) {
     return std::string(obj->ob_type->tp_name);
   } else {
-    // NB: hypothetically __name__ could mutate the Python
-    // object in a externally visible way. Please don't!
-    auto wobj = const_cast<PyObject*>(obj);
-    THPObjectPtr name{PyObject_GetAttrString(wobj, "__name__")};
-    return THPUtils_unpackString(name.get());
+    auto v = py::getattr(const_cast<PyObject*>(obj), "__name__", py::str("<python_value>"));
+    return py::str(v);
   }
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -959,7 +959,7 @@ public:
   }
   Node* createTuple(at::ArrayRef<Value*> values) {
     auto types = fmap(values, [](Value* v) { return v->type(); });
-    auto tt = std::make_shared<TupleType>(types);
+    auto tt = std::make_shared<TupleType>(std::move(types));
     auto n = create(prim::TupleConstruct, values);
     n->output()->setType(tt);
     return n;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -26,6 +26,7 @@
 #include "torch/csrc/jit/graph_node_list.h"
 #include "torch/csrc/jit/variable_flags.h"
 #include "torch/csrc/jit/source_location.h"
+#include "torch/csrc/utils/functional.h"
 
 namespace torch { namespace autograd {
 
@@ -731,6 +732,12 @@ struct Block {
   const Node * return_node() const {
     return output_;
   }
+  Node * param_node() {
+    return input_;
+  }
+  const Node * param_node() const {
+    return input_;
+  }
   Value * addInput(std::string name="") {
     Value * v = input_->addOutput();
     if (name != "") v->setUniqueName(name);
@@ -948,6 +955,21 @@ public:
     auto n = create(prim::FusionGroup, 0);
     n->g_(attr::Subgraph,std::make_shared<Graph>(scope_root_));
     n->i_(attr::device, device);
+    return n;
+  }
+  Node* createTuple(at::ArrayRef<Value*> values) {
+    auto types = fmap(values, [](Value* v) { return v->type(); });
+    auto tt = std::make_shared<TupleType>(types);
+    auto n = create(prim::TupleConstruct, values);
+    n->output()->setType(tt);
+    return n;
+  }
+  Node* createTupleUnpack(Value * v) {
+    TupleType* tt = v->type()->expect<TupleType>();
+    auto n = create(prim::TupleUnpack, {v}, 0);
+    for(auto & element : tt->elements()) {
+      n->addOutput()->setType(element);
+    }
     return n;
   }
   Node* createPythonOp(

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -6,7 +6,7 @@ void EliminateDeadCode(std::shared_ptr<Graph>& graph) {
   EliminateDeadCode(graph->block());
 }
 bool hasSideEffects(Node * node) {
-  return node->kind() == prim::Print;
+  return node->kind() == prim::Print || node->blocks().size() > 0;
 }
 
 void EliminateDeadCode(Block *block) {

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -1,0 +1,114 @@
+#include "torch/csrc/jit/passes/lower_tuples.h"
+#include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/utils/functional.h"
+
+namespace torch { namespace jit {
+
+// operators where we expect to find tuples as inputs/outputs
+// this is to assert we are only  doing modifications when we know
+// we can flatten tuples
+std::unordered_set<Symbol> white_list = {
+  prim::If,
+  prim::Loop,
+  prim::TupleUnpack,
+  prim::TupleConstruct,
+  prim::Param,
+  prim::Return,
+ };
+
+
+static void LowerTuples(Block* block);
+
+static void VisitNode(Node* n, Node* insert_point) {
+  auto & graph = *n->owningGraph();
+
+  // tuple construction operators will become dead when the unpacks are replaced
+  if(n->kind() == prim::TupleConstruct) {
+    return;
+  }
+
+  // make any TupleUnpack dead by undoing TupleUnpack(TupleConstruct())
+  if(n->kind() == prim::TupleUnpack) {
+    auto construct = n->input()->node();
+    // note: removing these asserts changes this pass from a complete lowering
+    // pass to one that removes tuples when possible. When tuples are first-class
+    // in the interpreter, we should still run this pass to remove extraneous uses
+    JIT_ASSERTM(construct->kind() == prim::TupleConstruct, "tuple unpack not matched to tuple construct");
+    for(size_t i = 0; i < n->outputs().size(); ++i) {
+      n->outputs()[i]->replaceAllUsesWith(construct->inputs()[i]);
+    }
+    return;
+  }
+  // flatten the input list  op(a, tup, b) --> op(a, t0, t1, b)
+  for(size_t i = 0; i < n->inputs().size();) {
+    auto input = n->inputs()[i];
+    if(TupleType* tt = input->type()->cast<TupleType>()) {
+      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
+      JIT_ASSERTM(input->node()->kind() == prim::TupleConstruct, "tuple use not matched to tuple construct");
+      for(size_t j = 0; j < tt->elements().size(); ++j) {
+        n->insertInput(i + 1 + j, input->node()->inputs().at(j));
+      }
+      n->removeInput(i);
+      // note: no update to i
+      // since tuples might be nested we need to recursively scan
+      // the new flattened inputs
+    } else {
+      ++i;
+    }
+  }
+  for(auto b : n->blocks()) {
+    LowerTuples(b);
+  }
+
+  // flatten the outputs list
+  for(size_t i = 0; i < n->outputs().size();) {
+    Value * output = n->outputs()[i];
+    // (a, b, tup, c) -> (a, b, t0, t1, c)
+    // and:
+    //    tup = (t0, t1)
+    // is placed at the current insertion point
+    if(TupleType* tt = output->type()->cast<TupleType>()) {
+      JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
+      for(size_t j = 0; j < tt->elements().size(); j++) {
+        n->insertOutput(i + 1 + j)->setType(tt->elements()[i]);
+      }
+      auto new_tup = graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
+      new_tup->insertBefore(insert_point);
+      insert_point = new_tup;
+      output->replaceAllUsesWith(new_tup->output());
+      n->eraseOutput(i);
+      // note: no update to i to handle nested tuples
+    } else {
+      ++i;
+    }
+  }
+}
+
+static void LowerTuples(Block* block) {
+  // tuples in parameter lists of a block behave exactly the same as
+  // _outputs_ of normal instructions, since the param_node represents the
+  // parameters as outputs, we can handle it by simply visiting the node
+  VisitNode(block->param_node(), *block->nodes().begin());
+  for(auto it = block->nodes().begin(), end = block->nodes().end(); it != end;) {
+    auto n = *it++;
+    VisitNode(n, *it);
+  }
+  // tuples in return lists of blocks behave exactly the same as
+  // _inputs_ of normal instructions, so we can use VisitNode here as well
+  // insert_point is null because it will never be used since return nodes
+  // have no outputs
+  VisitNode(block->return_node(), nullptr);
+}
+
+void LowerTuples(std::shared_ptr<Graph>& graph) {
+  for(auto input : graph->inputs()) {
+    JIT_ASSERTM(input->type()->kind() != TypeKind::TupleType, "tuples cannot be inputs to the graph");
+  }
+  for(auto output : graph->outputs()) {
+    JIT_ASSERTM(output->type()->kind() != TypeKind::TupleType, "tuples cannot be outputs to the graph");
+  }
+  LowerTuples(graph->block());
+  EliminateDeadCode(graph);
+}
+
+}}

--- a/torch/csrc/jit/passes/lower_tuples.h
+++ b/torch/csrc/jit/passes/lower_tuples.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "torch/csrc/jit/ir.h"
+
+namespace torch { namespace jit {
+
+void LowerTuples(std::shared_ptr<Graph>& graph);
+
+}}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -264,6 +264,8 @@ void initPythonIRBindings(PyObject * module_) {
           return "DynamicType";
         case TypeKind::TensorType:
           return "TensorType";
+        case TypeKind::TupleType:
+          return "TupleType";
         default:
           torch::barf("unknown type kind");
           return "";

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1,4 +1,5 @@
 #include "torch/csrc/jit/script/compiler.h"
+#include "torch/csrc/jit/passes/lower_tuples.h"
 #include "torch/csrc/jit/generated/aten_dispatch.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/ir.h"
@@ -19,23 +20,21 @@ using ValueTable = std::unordered_map<std::string, SugaredValuePtr>;
 using AttributeMap = std::unordered_map<std::string, Const>;
 using ListAttributeMap = std::unordered_map<std::string, std::vector<Const>>;
 
-// Tuple of values. Used to implement tuple return values and unpacking
-struct TupleValue : public SugaredValue {
-  TupleValue() {}
-  TupleValue(std::vector<std::shared_ptr<SugaredValue>> values) : values(std::move(values)) {}
-
-  virtual std::string kind() const override {
-    return "tuple";
+static std::string diagnosticType(TypePtr ptr) {
+  if(TupleType* tt = ptr->cast<TupleType>()) {
+    std::stringstream ss;
+    ss << "(";
+    for(size_t i = 0; i < tt->elements().size(); ++i) {
+      if(i > 0)
+        ss << ", ";
+      ss << diagnosticType(tt->elements()[i]);
+    }
+    ss << ")";
+    return ss.str();
+  } else {
+    return "Tensor";
   }
-
-  virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(SourceRange loc, Method& m)
-      override {
-    return values;
-  }
-
- private:
-  std::vector<std::shared_ptr<SugaredValue>> values;
-};
+}
 
 // Auxiliary data structure for desugaring variable binding into our always
 // explicitly scoped language as we descend down
@@ -95,9 +94,9 @@ struct Environment {
     return value_table.at(name)->asValue(loc, method);
   }
 
-  SugaredValuePtr createCapturedInput(const std::string& name) {
+  SugaredValuePtr createCapturedInput(Value* orig, const std::string& name) {
     // Create the input
-    Value* new_input = b->addInput();
+    Value* new_input = b->addInput()->setType(orig->type());
 
     // Associate this name with this value
     auto sv = std::make_shared<SimpleValue>(new_input);
@@ -122,12 +121,15 @@ struct Environment {
   void setVar(const SourceRange& loc, const std::string& name, Value* value) {
     setSugaredVar(loc, name, std::make_shared<SimpleValue>(value));
   }
-  static bool isSimple(SugaredValuePtr value) {
-    return dynamic_cast<SimpleValue*>(value.get()) != nullptr;
+  static Value* asSimple(SugaredValuePtr value) {
+    if(SimpleValue* sv = dynamic_cast<SimpleValue*>(value.get())) {
+      return sv->getValue();
+    }
+    return nullptr;
   }
 
   void setSugaredVar(const SourceRange& loc, const std::string& name, SugaredValuePtr value) {
-    bool is_simple_value = isSimple(value);
+    Value* as_simple_value = asSimple(value);
     // prevent re-assignment involving any sugared values
     // any reassignment like:
     // a = ...
@@ -136,20 +138,25 @@ struct Environment {
     // requires 'a' to be first-class in the graph since its value depends on
     // control flow
     if(auto parent = findInParentFrame(name)) {
-      if(!is_simple_value) {
+      if(!as_simple_value) {
         throw ErrorReport(loc) << "cannot re-assign '" << name << "' to a value of type " << value->kind()
         << ". Only reassignments to first-class values are allowed";
       }
-      if(!isSimple(parent)) {
+      Value* simple_parent = asSimple(parent);
+      if(!simple_parent) {
         throw ErrorReport(loc) << "cannot re-assign '" << name << "' because it has type " << value->kind()
         << ". Only reassignments to first-class values are allowed";
       }
+      if(*as_simple_value->type() != *simple_parent->type()) {
+        throw ErrorReport(loc) << "variable '" << name << "' previously has type " << diagnosticType(simple_parent->type())
+        << " but is now being assigned to a value of type " << diagnosticType(as_simple_value->type());
+      }
     }
-    if (is_simple_value &&
+    if (as_simple_value &&
         !findInThisFrame(name) &&
         findInParentFrame(name) &&
         getBlockOwningKind() == prim::Loop) {
-      createCapturedInput(name);
+      createCapturedInput(as_simple_value, name);
     }
     value_table[name] = std::move(value);
   }
@@ -166,7 +173,9 @@ struct Environment {
 
     if (!retval && (retval = findInParentFrame(ident)) &&
         getBlockOwningKind() == prim::Loop) {
-      retval = createCapturedInput(ident);
+      if(Value* simple_val = asSimple(retval)) {
+        retval = createCapturedInput(simple_val, ident);
+      }
     }
 
     if(!retval) {
@@ -238,14 +247,11 @@ Const getAttributeValue(Expr value_expr) {
   }
 }
 
-std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values) {
+std::shared_ptr<SugaredValue> packOutputs(Graph& g, at::ArrayRef<Value*> values) {
   if(values.size() == 1) {
     return std::make_shared<SimpleValue>(values[0]);
   }
-  auto svalues = fmap(values, [](Value* v) -> std::shared_ptr<SugaredValue> {
-    return std::make_shared<SimpleValue>(v);
-  });
-  return std::make_shared<TupleValue>(std::move(svalues));
+  return std::make_shared<SimpleValue>(g.insertNode(g.createTuple(values))->output());
 }
 
 std::shared_ptr<SugaredValue> emitBuiltinCall(
@@ -298,8 +304,15 @@ std::shared_ptr<SugaredValue> emitBuiltinCall(
   for(size_t i = 0; i < op->num_outputs; ++i)
     n->addOutput();
 
-  return packOutputs(n->outputs());
+  return packOutputs(*graph, n->outputs());
 }
+
+struct NoneValue : SugaredValue {
+  NoneValue() {}
+  virtual std::string kind() const override {
+    return "None";
+  }
+};
 
 
 std::shared_ptr<SugaredValue> BuiltinFunction::call(
@@ -361,6 +374,9 @@ struct to_ir {
         graph->registerOutput(r);
       }
     }
+
+    // remove any uses of tuples that we inserted
+    LowerTuples(graph);
   }
 
 private:
@@ -490,16 +506,13 @@ private:
 
     // Register outputs in each block
     for (const auto& x : sorted_mutations) {
-      true_block->registerOutput(save_true->getVar(x, stmt.range()));
-    }
-    for (const auto& x : sorted_mutations) {
-      false_block->registerOutput(save_false->getVar(x, stmt.range()));
+      auto tv = save_true->getVar(x, stmt.range());
+      true_block->registerOutput(tv);
+      auto tf = save_false->getVar(x, stmt.range());
+      false_block->registerOutput(tf);
+      environment_stack->setVar(stmt.range(), x, n->addOutput()->setType(tv->type()));
     }
 
-    // Add op outputs
-    for (const auto& x : sorted_mutations) {
-      environment_stack->setVar(stmt.range(), x, n->addOutput());
-    }
   }
 
   // *********************** Loop Operators ************************************
@@ -572,9 +585,10 @@ private:
 
       // Add block outputs
       for (const auto& x : body_frame->captured_inputs) {
-        body_block->registerOutput(body_frame->getValueInThisFrame(range, x));
+        auto fv = body_frame->getValueInThisFrame(range, x);
+        body_block->registerOutput(fv);
         n->addInput(outer_frame->getVar(x, range));
-        outer_frame->setVar(range, x, n->addOutput());
+        outer_frame->setVar(range, x, n->addOutput()->setType(fv->type()));
       }
 
     }
@@ -727,8 +741,7 @@ private:
     int i = 0;
     for (auto assignee : stmt.lhs()) {
       if (assignee.kind() == TK_VAR) {
-        Value * value = outputs.at(i)->asValue(assignee.range(), method);
-        environment_stack->setVar(assignee.range(), Var(assignee).name().name(), value);
+        environment_stack->setSugaredVar(assignee.range(), Var(assignee).name().name(), outputs.at(i));
         i++;
       } else if (assignee.kind() == TK_STARRED) {
         auto var = Starred(assignee).expr();
@@ -737,8 +750,11 @@ private:
         }
         size_t n_matched = outputs.size() - n_binders;
         ArrayRef<std::shared_ptr<SugaredValue>> outputs_ref = outputs;
-        SugaredValuePtr tup = std::make_shared<TupleValue>(outputs_ref.slice(i, n_matched));
-        environment_stack->setSugaredVar(
+        auto values = fmap(outputs_ref.slice(i, n_matched), [&](const std::shared_ptr<SugaredValue>& v) {
+          return v->asValue(assignee.range(), method);
+        });
+        auto tup = graph->insertNode(graph->createTuple(values))->output();
+        environment_stack->setVar(
           var.range(), Var(var).name().name(), tup);
         i += n_matched;
       }
@@ -789,7 +805,7 @@ private:
         auto starred = Starred(tree);
         auto entries = emitSugaredExpr(starred.expr(), 1)->asTuple(starred.range(), method);
         for(auto entry : entries) {
-          values.push_back(entry->asValue(starred.range(), method));
+          values.push_back(ensureTensor(starred.range(), entry->asValue(starred.range(), method)));
         }
       } else {
         values.push_back(emitExpr(Expr(tree)));
@@ -801,18 +817,19 @@ private:
     return getValues(trees.tree()->trees(), maybe_unpack);
   }
 
+
   // special rules apply when we directly call foo(a,b) when foo is an ident
   std::shared_ptr<SugaredValue> emitApplyIdent(Ident ident, std::vector<Value*> inputs, List<Attribute> attributes, size_t n_binders) {
     auto it = function_table.find(ident.name());
     if (it != function_table.end()) {
       if(inputs.size() != it->second.num_inputs())
         throw ErrorReport(ident) << "expected " << it->second.num_inputs() << " but found " << inputs.size();
-      return packOutputs(method.emit_call_to(it->second, inputs));
+      return packOutputs(*graph, method.emit_call_to(it->second, inputs));
     } else if (ident.name() == "print") {
       if (!attributes.empty())
         throw ErrorReport(ident) << "print doesn't accept any keyword arguments";
       emitNode(prim::Print, ident.range(), inputs, 0);
-      return std::make_shared<TupleValue>();
+      return std::make_shared<NoneValue>();
     }
     if(auto result = emitBuiltinCall(ident.range(), method, ident.name(), inputs, attributes, false)) {
       return result;
@@ -827,8 +844,17 @@ private:
     return sv->call(callee.range(), method, inputs, attributes, n_binders);
   }
 
+  Value* ensureTensor(const SourceRange& range, Value* v) {
+    // for now the only types we have are tuples and tensors
+    // as we add more types this function will need to change to be more specific
+    if(v->type()->kind() == TypeKind::TupleType) {
+      throw ErrorReport(range) << "expected a tensor value but found a tuple";
+    }
+    return v;
+  }
+
   Value* emitExpr(Expr tree) {
-    return emitSugaredExpr(tree, 1)->asValue(tree.range(), method);
+    return ensureTensor(tree.range(), emitSugaredExpr(tree, 1)->asValue(tree.range(), method));
   }
 
   // any expression that can produce a SugaredValue is handled here
@@ -1071,6 +1097,18 @@ std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver) {
   Module m; //note: we don't use 'm' to execute so this setting is unused
   defineMethodsInModule(m, {def}, resolver, nullptr);
   return m.get_method(def.name().name()).graph();
+}
+
+
+std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(SourceRange loc, Method& m) {
+  auto & graph = *m.graph();
+  if(value->type()->kind() == TypeKind::TupleType) {
+    auto n = graph.insertNode(graph.createTupleUnpack(value));
+    return fmap(n->outputs(), [](Value* v) -> std::shared_ptr<SugaredValue> {
+      return std::make_shared<SimpleValue>(v);
+    });
+  }
+  return SugaredValue::asTuple(loc, m);
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -54,6 +54,21 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
     at::ArrayRef<Value*> inputs,
     List<Attribute> attributes,
     size_t n_binders) {
+// n_binders is always set to the number of variables an expression is
+// syntactically bound to:
+//     a = foo() # 1 binder (note in this case the single binder might be a tuple)
+//     a, * b = foo() # 1 binder
+//     a, b = foo() # 2 binders
+//     foo() # 0 binders
+//
+// In subexpressions, like bar() in foo(bar()), n_binders is always set to
+// 1. n_binders is used as a hint to subexpressions to determine how many
+// values they should return when that number is ambiguous statically. In
+// particular it is currently used to decide how many tensors a call to a
+// python function will return. It is only a hint, functions do not have to
+// check that n_binders match the number of things they are returning, the
+// assignment logic will do that anyway.
+
     throw ErrorReport(loc) << "cannot call a " << kind();
   }
 

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -71,8 +71,11 @@ struct SimpleValue : public SugaredValue {
   virtual Value * asValue(SourceRange range, Method & m) override {
     return value;
   }
+  virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(SourceRange loc, Method& m) override;
   virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override;
-
+  Value* getValue() const {
+    return value;
+  }
 private:
   Value* value;
 };
@@ -108,7 +111,7 @@ std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
 
 // pack outputs of a function following python rules. If there is a single value return
 // a SimpleValue, otherwise pack all the values into a Tuple.
-std::shared_ptr<SugaredValue> packOutputs(at::ArrayRef<Value*> values);
+std::shared_ptr<SugaredValue> packOutputs(Graph& g, at::ArrayRef<Value*> values);
 std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
 
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -40,7 +40,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     if(py::isinstance<GraphExecutor>(self)) {
       GraphExecutor& ge = py::cast<GraphExecutor&>(self);
       ensureSizeMatches(loc, ge.graph()->inputs().size(), inputs.size(), "arguments");
-      return packOutputs(inlineCallTo(*m.graph(), *ge.graph(), inputs));
+      return packOutputs(*m.graph(),inlineCallTo(*m.graph(), *ge.graph(), inputs));
     }
 
     // Release the function object so we can wrap it in a PythonOp
@@ -54,7 +54,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     std::vector<Value*> outputs;
     for(size_t i = 0; i < n_binders; ++i)
       outputs.push_back(new_node->addOutput());
-    return packOutputs(outputs);
+    return packOutputs(*m.graph(), outputs);
   }
 
   virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
@@ -174,7 +174,7 @@ struct MethodValue : public SugaredValue {
     }
     ensureSizeMatches(loc, method.num_inputs(), inputs.size(), "inputs");
     auto outputs = caller.emit_call_to(method, inputs);
-    return packOutputs(outputs);
+    return packOutputs(*caller.graph(), outputs);
   }
 private:
   std::shared_ptr<Module> module;

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -27,6 +27,8 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "Handle";
   } else if(t.kind() == TypeKind::DynamicType) {
     out << "Dynamic";
+  } else if(t.kind() == TypeKind::TupleType) {
+    out << "Tuple";
   } else {
     barf("unknown type kind");
   }

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -14,7 +14,8 @@ namespace torch { namespace jit {
 #define TH_FORALL_TYPES(_) \
 _(DynamicType) \
 _(TensorType) \
-_(HandleType)
+_(HandleType) \
+_(TupleType)
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -27,6 +28,7 @@ using TypePtr = std::shared_ptr<Type>;
 
 
 struct Type : std::enable_shared_from_this<Type> {
+
 private:
   TypeKind kind_;
 
@@ -35,6 +37,7 @@ protected:
     : kind_(kind) {}
 
 public:
+  virtual bool operator==(const Type& rhs) const = 0;
   TypeKind kind() const {
     return kind_;
   }
@@ -72,6 +75,9 @@ public:
 struct DynamicType : public Type {
   DynamicType()
   : Type(TypeKind::DynamicType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
   static const TypeKind Kind = TypeKind::DynamicType;
   // global singleton
   static TypePtr get();
@@ -116,6 +122,15 @@ struct TensorType : public Type {
     t->strides_ = TensorType::contiguousStridesOf(sizes_);
     return t;
   }
+  virtual bool operator==(const Type& rhs) const override {
+    if(rhs.kind() != kind())
+      return false;
+    auto rt = rhs.expect<TensorType>();
+    return scalarType() == rt->scalarType() &&
+           sizes() == rt->sizes() &&
+           strides() == rt->strides() &&
+           device() == rt->device();
+  }
 private:
   static std::vector<int64_t> contiguousStridesOf(at::IntList sizes) {
     std::vector<int64_t> strides(sizes.size());
@@ -154,23 +169,32 @@ struct HandleType : public Type {
   friend struct Type;
   HandleType()
     : Type(TypeKind::HandleType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
   static const TypeKind Kind = TypeKind::HandleType;
   // global singleton
   static TypePtr get();
 };
 
-static inline bool operator==(const Type & lhs, const Type & rhs) {
-  if(lhs.kind() != rhs.kind())
-    return false;
-  if(lhs.kind() != TypeKind::TensorType)
-    return true;
-  auto lt = lhs.expect<TensorType>();
-  auto rt = lhs.expect<TensorType>();
-  return lt->scalarType() == rt->scalarType() &&
-         lt->sizes() == rt->sizes() &&
-         lt->strides() == rt->strides() &&
-         lt->device() == rt->device();
-}
+struct TupleType : public Type {
+  friend struct Type;
+  TupleType(std::vector<TypePtr> elements_)
+  : Type(TypeKind::TupleType)
+  , elements_(std::move(elements_)) {}
+  static const TypeKind Kind = TypeKind::TupleType;
+  at::ArrayRef<TypePtr> elements() const {
+    return elements_;
+  }
+  virtual bool operator==(const Type& rhs) const override {
+    if(rhs.kind() != kind())
+      return false;
+    return rhs.cast<TupleType>()->elements().equals(elements());
+  }
+private:
+  std::vector<TypePtr> elements_;
+};
+
 inline bool operator!=(const Type & lhs, const Type & rhs) {
   return !(lhs == rhs);
 }


### PR DESCRIPTION
(Just read the last commit, this is layered on top of my other PR).

This turned out to be necessary for FairSeq to work correctly.

This commit improves our support of tuples by making them more first-class.
In particular, it allows tuples to be re-assigned across loops and ifs.
It does this by making them first-class values in the Graph IR, and then
removing the tuples in a LowerTuples pass.

An alternative approach would have added more support for desugaring tuples
in the Environment object as they were emitted. Instead,
the current approach was chosen anticipating a future when tuples are
fully supported (including the interpreter). In that future, the current
code can be completly reused with the LowerTuples pass just becoming
a optimization that removes unneeded tuple allocations.