### PR TITLE
[caffe2] Fix bug in NNPACK bindings for convolution in precomputed transform

### DIFF
--- a/caffe2/share/contrib/nnpack/conv_op.cc
+++ b/caffe2/share/contrib/nnpack/conv_op.cc
@@ -146,6 +146,9 @@ NNPACKConvOp::getActivationType() const {
 }
 
 bool NNPACKConvOp::RunOnDeviceWithOrderNCHW() {
+  /* Global variable with a unique ID of the pre-transformed kernel blob */
+  volatile static uint32_t precomputed_transform_id = 0;
+
   auto& X = Input(0);
   auto& filter = Input(1);
   auto* Y = Output(0);
@@ -231,7 +234,8 @@ bool NNPACKConvOp::RunOnDeviceWithOrderNCHW() {
         for (auto g = 0; g < group_; g++) {
           transformedFilters_[g] =
               ws_->CreateBlob(
-                     debug_def().name() + "_transformed_" + to_string(g))
+                     "__transformed_kernel_" +
+                     to_string(__sync_fetch_and_add(&precomputed_transform_id, 1)))
                   ->GetMutable<TensorCPU>();
           transformedFilters_[g]->Resize(transformedFilterElements);
 


### PR DESCRIPTION
Caffe2-NNPACK integration creates blobs for precomputed kernel transorms based on the name of Conv operator. When Conv operators have the same name (e.g. empty string), or the blobs for precomputed transforms get the same name and overwrite each other.
This patch ensures that blobs for all precomputed transforms in the network get a unique name.

