### PR TITLE
Add Tensor.as_param()

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -104,6 +104,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: apply_
    .. automethod:: argmax
    .. automethod:: argmin
+   .. automethod:: as_param
    .. automethod:: asin
    .. automethod:: asin_
    .. automethod:: atan

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -211,6 +211,20 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, x_grad + x_hv)
         self.assertEqual(y.grad.data, y_grad + y_hv)
 
+    def test_as_param(self):
+        x = torch.randn(3)
+        self.assertEqual(x.as_param(), x)
+        self.assertTrue(x.as_param().requires_grad)
+
+        y = torch.randn(3, requires_grad=True)
+        z = (x * y).as_param()
+        self.assertTrue(z.requires_grad)
+        self.assertIsNone(z.grad_fn)
+
+        (z * 2).sum().backward()
+        self.assertEqual(z.grad, torch.tensor([2., 2., 2.]))
+        self.assertIsNone(y.grad)
+
     def test_grad(self):
         x = Variable(torch.randn(2, 2), requires_grad=True)
         y = Variable(torch.randn(2, 2), requires_grad=True)

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -46,6 +46,14 @@ static PyObject * THPVariable_apply_(PyObject* self, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_as_param(PyObject* self, PyObject* args)
+{
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  return THPVariable_Wrap(self_.as_param());
+  END_HANDLE_TH_ERRORS
+}
+
 static Tensor dispatch_clamp(const Tensor & self, Scalar min, Scalar max) {
   AutoNoGIL no_gil;
   AutoGPU auto_gpu(self);
@@ -598,6 +606,7 @@ PyMethodDef variable_methods[] = {
   {"__nonzero__", (PyCFunction)THPVariable_is_nonzero, METH_NOARGS, NULL},
   {"__matmul__", (PyCFunction)THPVariable_matmul, METH_VARARGS | METH_KEYWORDS, NULL},
   {"apply_", (PyCFunction)THPVariable_apply_, METH_O, NULL},
+  {"as_param", (PyCFunction)THPVariable_as_param, METH_NOARGS, NULL},
   {"byte", (PyCFunction)THPVariable_byte, METH_NOARGS, NULL},
   {"char", (PyCFunction)THPVariable_char, METH_NOARGS, NULL},
   {"clamp", (PyCFunction)THPVariable_clamp, METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -161,6 +161,26 @@ each element with the value returned by :attr:`callable`.
     sections that require high performance.
 """)
 
+add_docstr_all('as_param', r"""
+as_param() -> Tensor
+
+Returns this tensor with :attr:`requires_grad` set to ``True`` and with no
+:attr:`grad_fn`. The result is an independent variable (parameter), suitable
+for use in a differentiable computation. Calling :meth:`backward` on a variable
+dependent on the result will store the derivative in the result's :attr:`grad`
+attribute.
+
+Example::
+
+    >>> x = torch.empty(1).uniform_(0, 1).as_param()
+    >>> x.requires_grad
+    True
+    >>> (x * 2).backward()
+    >>> x.grad
+     2
+    [torch.FloatTensor of size (1,)]
+""")
+
 add_docstr_all('asin', r"""
 asin() -> Tensor
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -149,6 +149,12 @@ static PyObject* THPVariable_make_subclass(PyObject* _ignored, PyObject* args, P
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPVariable_as_param(THPVariable* self, PyObject* args) {
+  HANDLE_TH_ERRORS
+  return THPVariable_Wrap(make_variable(self->cdata.data(), true));
+  END_HANDLE_TH_ERRORS
+}
+
 typedef PyObject *(*getter)(PyObject *, void *);
 typedef int (*setter)(PyObject *, PyObject *, void *);
 
@@ -435,6 +441,7 @@ static PyMappingMethods THPVariable_as_mapping = {
 
 static PyMethodDef extra_methods[] = {
   {"_make_subclass", (PyCFunction)THPVariable_make_subclass, METH_STATIC | METH_VARARGS | METH_KEYWORDS, NULL},
+  {"as_param", (PyCFunction)THPVariable_as_param, METH_NOARGS, NULL},
   {NULL}
 };
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -149,12 +149,6 @@ static PyObject* THPVariable_make_subclass(PyObject* _ignored, PyObject* args, P
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPVariable_as_param(THPVariable* self, PyObject* args) {
-  HANDLE_TH_ERRORS
-  return THPVariable_Wrap(make_variable(self->cdata.data(), true));
-  END_HANDLE_TH_ERRORS
-}
-
 typedef PyObject *(*getter)(PyObject *, void *);
 typedef int (*setter)(PyObject *, PyObject *, void *);
 
@@ -441,7 +435,6 @@ static PyMappingMethods THPVariable_as_mapping = {
 
 static PyMethodDef extra_methods[] = {
   {"_make_subclass", (PyCFunction)THPVariable_make_subclass, METH_STATIC | METH_VARARGS | METH_KEYWORDS, NULL},
-  {"as_param", (PyCFunction)THPVariable_as_param, METH_NOARGS, NULL},
   {NULL}
 };
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -164,6 +164,12 @@ void Variable::detach_() {
   set_gradient_edge(Edge());
 }
 
+Variable Variable::as_param() const {
+  auto res = make_variable(data(), /*requires_grad=*/true);
+  res.set_version_counter(version_counter());
+  return res;
+}
+
 void Variable::set_tracing_state(
     jit::tracer::ValueTracingState* new_tracing_state) {
   get()->tracing_state.reset(new_tracing_state);

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -247,6 +247,11 @@ struct Variable : public at::Tensor {
   /// this. If this `Variable` is a view, throws an `std::runtime_error()`.
   void detach_();
 
+  /// Returns this `Variable` as an independent variable (parameter). The result
+  /// shares the same data, has `requires_grad` set to `True`, and has no
+  /// `grad_fn`.
+  Variable as_param() const;
+
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
t.as_param() is a drop-in replacement for the call Variable(t.data, requires_grad=True).

