### PR TITLE
Use THC allocation for CUFFT workspace

### DIFF
--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -335,7 +335,7 @@ Tensor _fft_cufft(const Tensor& self, int64_t signal_ndim,
   // create plan
   CufftHandle plan;
   size_t ws_size = 0;
-  auto&& ctx = at::globalContext();
+  auto& ctx = at::globalContext();
 
   // set to current stream
   CUFFT_CHECK(cufftSetStream(plan.get(), ctx.getCurrentCUDAStream()));


### PR DESCRIPTION
Previously we let cufft handle the workspace allocation. Now we switch to using the THC caching allocator.

cc @ngimel 