### PR TITLE
Add autograd API to at::Tensor

### DIFF
--- a/aten/src/ATen/TensorImpl.cpp
+++ b/aten/src/ATen/TensorImpl.cpp
@@ -1,0 +1,20 @@
+#include <ATen/TensorImpl.h>
+#include <ATen/Tensor.h>
+
+namespace at {
+Tensor& TensorImpl::grad() {
+  AT_ERROR("grad is not implemented for Tensor");
+}
+
+const Tensor& TensorImpl::grad() const {
+  AT_ERROR("grad is not implemented for Tensor");
+}
+
+Tensor TensorImpl::detach() const {
+  AT_ERROR("detach is not implemented for Tensor");
+}
+
+void TensorImpl::set_data(Tensor new_data) {
+  AT_ERROR("set_type is not implemented for Tensor");
+}
+} // namespace at

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -56,18 +56,18 @@ struct TensorImpl : public Retainable {
   // Some methods below are defined in TensorImpl.cpp because Tensor is an
   // incomplete type.
 
-  virtual void set_requires_grad(bool requires_grad) {
+  AT_API virtual void set_requires_grad(bool requires_grad) {
     AT_ERROR("set_requires_grad is not implemented for Tensor");
   }
-  virtual bool requires_grad() const {
+  AT_API virtual bool requires_grad() const {
     AT_ERROR("requires_grad is not implemented for Tensor");
   }
 
-  virtual Tensor& grad();
-  virtual const Tensor& grad() const;
+  AT_API virtual Tensor& grad();
+  AT_API virtual const Tensor& grad() const;
 
-  virtual Tensor detach() const;
-  virtual void detach_() {
+  AT_API virtual Tensor detach() const;
+  AT_API virtual void detach_() {
     AT_ERROR("detach_ is not implemented for Tensor");
   }
 

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -2,17 +2,18 @@
 
 #include <atomic>
 #include <memory>
-#include <iostream>
 
 #include "ATen/Retainable.h"
 #include "ATen/ScalarType.h"
 
 namespace at {
-
-struct Type;
 class Scalar;
+struct Type;
 struct Storage;
+struct Tensor;
+} // namespace at
 
+namespace at {
 struct TensorImpl : public Retainable {
   explicit TensorImpl(Type * type)
   : is_scalar(false), type_(type) {}
@@ -50,9 +51,30 @@ struct TensorImpl : public Retainable {
   void setScalar(bool s) {
     is_scalar = s;
   }
+
+  // ~~~~~ Autograd API ~~~~~
+  // Some methods below are defined in TensorImpl.cpp because Tensor is an
+  // incomplete type.
+
+  virtual void set_requires_grad(bool requires_grad) {
+    AT_ERROR("set_requires_grad is not implemented for Tensor");
+  }
+  virtual bool requires_grad() const {
+    AT_ERROR("requires_grad is not implemented for Tensor");
+  }
+
+  virtual Tensor& grad();
+  virtual const Tensor& grad() const;
+
+  virtual Tensor detach() const;
+  virtual void detach_() {
+    AT_ERROR("detach_ is not implemented for Tensor");
+  }
+
+  virtual void set_data(Tensor new_data);
+
 protected:
   bool is_scalar;
   Type * type_;
 };
-
-}
+} // namespace at

--- a/aten/src/ATen/TensorImpl.h
+++ b/aten/src/ATen/TensorImpl.h
@@ -71,7 +71,7 @@ struct TensorImpl : public Retainable {
     AT_ERROR("detach_ is not implemented for Tensor");
   }
 
-  virtual void set_data(Tensor new_data);
+  AT_API virtual void set_data(Tensor new_data);
 
 protected:
   bool is_scalar;

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -12,7 +12,13 @@
 
 namespace at {
 struct Type;
+struct Tensor;
+namespace detail {
+void set_data(Tensor& tensor, Tensor new_data);
+} // namespace detail
+} // namespace at
 
+namespace at {
 // Tensor is a "generic" object holding a pointer to the underlying TensorImpl object, which
 // has an embedded reference count. In this way, Tensor is similar to boost::intrusive_ptr.
 //
@@ -120,6 +126,31 @@ struct Tensor : public detail::TensorBase {
   Tensor operator[](Tensor index) const;
   Tensor operator[](int64_t index) const;
 
+  // ~~~~~ Autograd API ~~~~~
+
+  void set_requires_grad(bool requires_grad) {
+    pImpl->set_requires_grad(requires_grad);
+  }
+  bool requires_grad() const {
+    return pImpl->requires_grad();
+  }
+
+  Tensor& grad() {
+    return pImpl->grad();
+  }
+  const Tensor& grad() const {
+    return pImpl->grad();
+  }
+
+  Tensor detach() const {
+    return pImpl->detach();
+  }
+  void detach_() {
+    pImpl->detach_();
+  }
+
+  friend void detail::set_data(Tensor& tensor, Tensor new_data);
+
   // STOP.  Thinking of adding a method here, which only makes use
   // of other ATen methods?  Define it in native_functions.yaml.
 
@@ -133,4 +164,9 @@ struct Tensor : public detail::TensorBase {
   } 
 };
 
-} //namespace at
+namespace detail {
+inline void set_data(Tensor& tensor, Tensor new_data) {
+  tensor.pImpl->set_data(new_data);
+}
+} // namespace detail
+} // namespace at

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -30,19 +30,20 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
     new_grad = (*hook)({new_grad})[0];
   }
 
-  auto& grad = variable.grad();
+  at::Tensor& grad = variable.grad();
   if (!grad.defined()) {
     variable.grad() = new_grad.clone();
   } else if (!GradMode::is_enabled()) {
+    Variable& grad_variable = as_variable_ref(grad);
     // This case is not strictly necessary, but it makes the first-order only case
     // slightly more efficient and, what's more important, more predictable for
     // the users. Thanks to this case we can avoid changing the grad tensor,
     // a thing never promised and documented, but used in some hacks seen
     // on the internet.
-    if (grad.type().is_sparse() && !new_grad.type().is_sparse()) {
-      grad.data() = new_grad.data() + grad.data();
+    if (grad_variable.type().is_sparse() && !new_grad.type().is_sparse()) {
+      grad_variable.data() = new_grad.data() + grad_variable.data();
     } else {
-      grad.data() += new_grad.data();
+      grad_variable.data() += new_grad.data();
     }
   } else {
     variable.grad() = grad + new_grad;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -395,7 +395,7 @@ static void _wrap_outputs(THPFunction *self,
       }
       // If the input was modified, transplant the grad_fn in the graph:
       // grad_fn <- variable <- self  ==>  grad_fn <- self <- variable
-      var.reset_grad();
+      var.grad().reset();
       var.clear_hooks();
       if (auto grad_acc_fn = var.try_get_grad_accumulator()) {
         auto grad_acc = dynamic_cast<AccumulateGrad*>(grad_acc_fn.get());

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -209,13 +209,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data)
   if (!THPVariable_Check(data)) {
     throw torch::TypeError("Variable data has to be a tensor, but got %s", Py_TYPE(data)->tp_name);
   }
-  Tensor tensor = THPVariable_UnpackData(data);
-  if (self->cdata.data().type() != tensor.type()) {
-    // we change the type of var.data so we must change the type of var
-    auto newType = VariableType::getType(tensor);
-    self->cdata.temporary_hack_set_type(newType);
-  }
-  self->cdata.data() = std::move(tensor);
+  at::detail::set_data(self->cdata, THPVariable_UnpackData(data));
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }
@@ -232,7 +226,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
   HANDLE_TH_ERRORS
   auto& var = self->cdata;
   if (py_grad == Py_None) {
-    var.reset_grad();
+    var.grad().reset();
     return 0;
   }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -21,18 +21,18 @@
 #include <vector>
 
 namespace torch { namespace autograd {
-Variable::Impl::Impl(at::Tensor data_, bool requires_grad_, Edge gradient_edge_)
-    : TensorImpl(VariableType::getType(data_)),
-      data(std::move(data_)),
-      grad_fn(std::move(gradient_edge_.function)),
-      requires_grad(requires_grad_),
-      is_view(false),
-      output_nr(gradient_edge_.input_nr),
-      pyobj(nullptr) {
+Variable::Impl::Impl(at::Tensor data, bool requires_grad, Edge gradient_edge)
+    : TensorImpl(VariableType::getType(data)),
+      data_(std::move(data)),
+      grad_fn_(std::move(gradient_edge.function)),
+      requires_grad_(requires_grad),
+      is_view_(false),
+      output_nr_(gradient_edge.input_nr),
+      pyobj_(nullptr) {
   TORCH_ASSERTM(
-      !grad_fn || !requires_grad,
-      "_requires_grad should be false if grad_fn is set");
-  if (!data.defined()) {
+      !grad_fn_ || !requires_grad_,
+      "requires_grad should be false if grad_fn is set");
+  if (!data_.defined()) {
     throw std::runtime_error("data is undefined");
   }
 }
@@ -46,15 +46,15 @@ const char* Variable::Impl::toString() const {
 }
 
 IntList Variable::Impl::sizes() const {
-  return data.sizes();
+  return data_.sizes();
 }
 
 IntList Variable::Impl::strides() const {
-  return data.strides();
+  return data_.strides();
 }
 
 int64_t Variable::Impl::dim() const {
-  return data.dim();
+  return data_.dim();
 }
 
 const char* Variable::Impl::typeString() {
@@ -62,70 +62,91 @@ const char* Variable::Impl::typeString() {
 }
 
 void* Variable::Impl::unsafeGetTH(bool retain) {
-  return data.unsafeGetTH(retain);
+  return data_.unsafeGetTH(retain);
 }
 
 std::unique_ptr<at::Storage> Variable::Impl::storage() {
-  return data.storage();
+  return data_.storage();
 }
 
 Scalar Variable::Impl::localScalar() {
-  return data.pImpl->localScalar();
+  return data_.pImpl->localScalar();
 }
 
 std::shared_ptr<Function> Variable::Impl::get_grad_accumulator() {
-  if (grad_fn) {
+  if (grad_fn_) {
     throw std::logic_error(
         "get_grad_accumulator() should be only called on leaf Variables");
   }
-  if (!requires_grad) {
+  if (!requires_grad_) {
     return nullptr;
   }
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex_);
 
-  auto result = grad_accumulator.lock();
-  if (result) return result;
+  auto result = grad_accumulator_.lock();
+  if (result)
+    return result;
 
   result = std::make_shared<AccumulateGrad>(Variable(this, true));
-  grad_accumulator = result;
+  grad_accumulator_ = result;
   return result;
 }
 
-Variable::ViewImpl::ViewImpl(
-    Variable base_,
-    at::Tensor data_,
-    Edge gradient_edge_)
-    : Variable::Impl(std::move(data_), false, std::move(gradient_edge_)),
-      base(std::move(base_)) {
-  TORCH_ASSERTM(base.defined(), "base is undefined");
-  if (base.is_view()) {
-    base = base.base();
+Tensor Variable::Impl::detach() const {
+  auto detached = make_variable(data_, /*requires_grad=*/false);
+  detached.set_version_counter(version_counter_);
+  return detached;
+}
+
+void Variable::Impl::detach_() {
+  if (is_view_) {
+    throw std::runtime_error(
+        "Can't detach views in-place. Use detach() instead");
   }
-  is_view = true;
-  version_counter = base.version_counter();
-  attr_version = version_counter.current_version();
+  set_requires_grad(false);
+  grad_fn_.reset();
+  output_nr_ = 0;
+}
+
+void Variable::Impl::set_data(Tensor new_data) {
+  data_ = std::move(new_data);
+  if (data_.type() != *type_) {
+    type_ = VariableType::getType(data_);
+  }
+}
+
+Variable::ViewImpl::ViewImpl(Variable base, at::Tensor data, Edge gradient_edge)
+    : Variable::Impl(std::move(data), false, std::move(gradient_edge)),
+      base_(std::move(base)) {
+  TORCH_ASSERTM(base_.defined(), "base is undefined");
+  if (base_.is_view()) {
+    base_ = base_.base();
+  }
+  is_view_ = true;
+  version_counter_ = base_.version_counter();
+  attr_version = version_counter_.current_version();
 }
 
 std::shared_ptr<Function>& Variable::ViewImpl::get_grad_fn() {
-  std::lock_guard<std::mutex> lock(mutex);
-  if (!grad_fn && !base.requires_grad()) {
-    return grad_fn;
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!grad_fn_ && !base_.requires_grad()) {
+    return grad_fn_;
   }
-  auto current_version = version_counter.current_version();
+  auto current_version = version_counter_.current_version();
   if (attr_version != current_version) {
-    TORCH_ASSERT(output_nr == 0);
+    TORCH_ASSERT(output_nr_ == 0);
     auto fn = std::make_shared<generated::AsStridedBackward>();
-    fn->self_geometry = at::TensorGeometry(base);
+    fn->self_geometry = at::TensorGeometry(base_);
     fn->size = sizes();
     fn->stride = strides();
-    fn->storage_offset = data.storage_offset();
-    fn->set_next_edges(collect_next_edges(base));
+    fn->storage_offset = data_.storage_offset();
+    fn->set_next_edges(collect_next_edges(base_));
     fn->set_num_inputs(1);
-    grad_fn = std::move(fn);
+    grad_fn_ = std::move(fn);
     attr_version = current_version;
   }
-  return grad_fn;
+  return grad_fn_;
 }
 
 void Variable::ViewImpl::rebase_history(Edge gradient_edge) {
@@ -134,10 +155,10 @@ void Variable::ViewImpl::rebase_history(Edge gradient_edge) {
   TORCH_ASSERTM(
       gradient_edge.function->num_inputs() == 1,
       "Functions which modify views in-place must return a single Variable");
-  this->output_nr = gradient_edge.input_nr;
+  this->output_nr_ = gradient_edge.input_nr;
   auto copy_slices = std::make_shared<CopySlices>(
-      base, at::TensorGeometry(data), std::move(gradient_edge.function));
-  base.set_gradient_edge({std::move(copy_slices), 0});
+      base_, at::TensorGeometry(data_), std::move(gradient_edge.function));
+  base_.set_gradient_edge({std::move(copy_slices), 0});
   get_grad_fn(); // trigger an update to the view's grad_fn
 }
 
@@ -151,27 +172,12 @@ void Variable::rebase_history(Edge gradient_edge) {
   }
 }
 
-Variable Variable::detach() const {
-  auto detached = make_variable(data(), /*requires_grad=*/false);
-  detached.set_version_counter(version_counter());
-  return detached;
-}
-
-void Variable::detach_() {
-  if (is_view()) {
-    throw std::runtime_error(
-        "Can't detach views in-place. Use detach() instead");
-  }
-  set_requires_grad(false);
-  set_gradient_edge(Edge());
-}
-
 void Variable::set_tracing_state(
     jit::tracer::ValueTracingState* new_tracing_state) {
-  get()->tracing_state.reset(new_tracing_state);
+  get()->tracing_state_.reset(new_tracing_state);
 }
 
 jit::tracer::ValueTracingState& Variable::tracing_state() const noexcept {
-  return *get()->tracing_state;
+  return *get()->tracing_state_;
 }
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace torch {
@@ -202,20 +203,6 @@ struct Variable : public at::Tensor {
   /// True if this `Variable` is a leaf and thus does not have a `grad_fn`.
   bool is_leaf() const noexcept;
 
-  // The Grad Variable
-  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  /// Accesses the gradient `Variable` of this `Variable`.
-  const Variable& grad() const noexcept;
-  Variable& grad() noexcept;
-  void reset_grad() noexcept;
-
-  /// Sets the `requires_grad` property of `Variable`. This should be true for
-  /// leaf variables that want to accumulate gradients, and false for all other
-  /// variables.
-  void set_requires_grad(bool requires_grad) noexcept;
-  bool requires_grad() const noexcept;
-
   // Versions
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -236,16 +223,6 @@ struct Variable : public at::Tensor {
   /// Update the `grad_fn` of an existing Variable. Called after in-place
   /// modifications.
   void rebase_history(Edge gradient_edge);
-
-  /// Returns a copy of this `Variable` that is detached from its autograd graph
-  /// and has a blank version. This method is OK to call if the `Variable` is a
-  /// view.
-  Variable detach() const;
-
-  /// Like `detach()`, but removes this `Variable` in-place. This method may
-  /// only be called on non-view `Variable`s. You can use `is_view()` to check
-  /// this. If this `Variable` is a view, throws an `std::runtime_error()`.
-  void detach_();
 
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -288,14 +265,6 @@ struct Variable : public at::Tensor {
   PyObject* pyobj() const noexcept;
   void set_pyobj(PyObject* pyobj) noexcept;
 
-  // Hacks!
-  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  /// Sets the type of the underlying `Tensor`. Used for a bad (hopefully)
-  /// temporary hack in python_variable.h. If removed, also remove the `using
-  /// at::TensorImpl::type_;` in `Variable::Impl`.
-  void temporary_hack_set_type(at::Type*) noexcept;
-
  private:
   /// Private implementation struct of the `Variable`. This struct declaration
   /// and the `get()` method which exposes it shall forever remain private and
@@ -316,8 +285,8 @@ struct Variable : public at::Tensor {
 
 struct Variable::Impl : public at::TensorImpl {
   explicit Impl(
-      at::Tensor data_,
-      bool requires_grad_ = false,
+      at::Tensor data,
+      bool requires_grad = false,
       Edge edge = Edge());
 
   virtual ~Impl();
@@ -333,40 +302,77 @@ struct Variable::Impl : public at::TensorImpl {
 
   std::shared_ptr<Function> get_grad_accumulator();
   virtual std::shared_ptr<Function>& get_grad_fn() {
-    return grad_fn;
+    return grad_fn_;
   }
 
-  // Make this field public so we can access it from `Variable`. Part of
-  // temporary_hack_set_type.
+  virtual const Variable& base() const {
+    throw std::runtime_error("Can't get base of non-view Variable");
+  }
+
+  /// Sets the `requires_grad` property of `Variable`. This should be true for
+  /// leaf variables that want to accumulate gradients, and false for all other
+  /// variables.
+  void set_requires_grad(bool requires_grad) override {
+    requires_grad_ = requires_grad;
+  }
+
+  bool requires_grad() const override {
+    return requires_grad_ || grad_fn_ || (is_view_ && base().requires_grad());
+  }
+
+  /// Accesses the gradient `Variable` of this `Variable`.
+  Tensor& grad() override {
+    return grad_;
+  }
+  const Variable& grad() const override {
+    return grad_;
+  }
+
+  /// Returns a copy of this `Variable` that is detached from its autograd graph
+  /// and has a blank version. This method is OK to call if the `Variable` is a
+  /// view.
+  Tensor detach() const override;
+
+  /// Like `detach()`, but removes this `Variable` in-place. This method may
+  /// only be called on non-view `Variable`s. You can use `is_view()` to check
+  /// this. If this `Variable` is a view, throws an `std::runtime_error()`.
+  void detach_() override;
+
+  /// Sets the type of the Variable.
+  void set_data(Tensor new_data) override;
+
+  // Make this field public so we can access it from `Variable`.
   using at::TensorImpl::type_;
 
   std::string name;
-  at::Tensor data;
+  at::Tensor data_;
 
-  Variable grad;
-  std::shared_ptr<Function> grad_fn;
-  std::weak_ptr<Function> grad_accumulator;
+  Variable grad_;
+  std::shared_ptr<Function> grad_fn_;
+  std::weak_ptr<Function> grad_accumulator_;
 
-  VariableVersion version_counter;
-  std::vector<std::shared_ptr<FunctionPreHook>> hooks;
+  VariableVersion version_counter_;
+  std::vector<std::shared_ptr<FunctionPreHook>> hooks_;
 
-  bool requires_grad; // only meaningful on leaf variables (must be false
-                      // otherwise)
-  bool is_view;
+  // Only meaningful on leaf variables (must be false otherwise)
+  bool requires_grad_;
+
+  bool is_view_;
+
   // The "output number" of this variable; e.g., if this variable
   // was the second output of a function, then output_nr == 1.
   // We use this to make sure we can setup the backwards trace
   // correctly when this variable is passed to another function.
-  uint32_t output_nr;
-  PyObject* pyobj; // weak reference
+  uint32_t output_nr_;
+  PyObject* pyobj_; // weak reference
 
   // Mutex to ensure that concurrent read operations that modify internal
   // state are still thread-safe. Used by get_grad_fn and
   // get_grad_accumulator.
-  std::mutex mutex;
+  std::mutex mutex_;
 
   // For use in torch::jit::tracer
-  auto_unique_ptr<jit::tracer::ValueTracingState> tracing_state;
+  auto_unique_ptr<jit::tracer::ValueTracingState> tracing_state_;
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -378,19 +384,23 @@ struct Variable::Impl : public at::TensorImpl {
 /// due to in-place modifications of the shared data. Accesses should go
 /// through get_grad_fn(). All other fields are always valid.
 struct Variable::ViewImpl : public Variable::Impl {
-  ViewImpl(Variable base_, at::Tensor data_, Edge gradient_edge);
+  ViewImpl(Variable base, at::Tensor data, Edge gradient_edge);
 
   /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
   /// re-create the grad_fn to express the up-to-date view relationship between
   /// this and the base Variable.
   virtual std::shared_ptr<Function>& get_grad_fn() override;
 
+  const Variable& base() const override {
+    return base_;
+  }
+
   /// Called after in-place modifications. Modifies the grad_fn of the base
   /// Variable.
   void rebase_history(Edge gradient_edge);
 
   /// The base `Variable` (never a view).
-  Variable base;
+  Variable base_;
 
   /// The value of the version_counter at the time grad_fn was created. The
   /// grad_fn field is stale if attr_version !=
@@ -447,7 +457,7 @@ inline bool is_variable(const at::Tensor& tensor) noexcept {
 /// throws a `std::invalid_argument` exception.
 inline Variable& as_variable_ref(at::Tensor& tensor) {
   if (!is_variable(tensor)) {
-    throw std::invalid_argument(
+    AT_ERROR(
         "Attempted to cast a Tensor to a Variable, but "
         "the dynamic type of the value is not Variable.");
   }
@@ -456,7 +466,7 @@ inline Variable& as_variable_ref(at::Tensor& tensor) {
 
 inline const Variable& as_variable_ref(const at::Tensor& tensor) {
   if (!is_variable(tensor)) {
-    throw std::invalid_argument(
+    AT_ERROR(
         "Attempted to cast a Tensor to a Variable, but "
         "the dynamic type of the value is not Variable.");
   }
@@ -464,11 +474,11 @@ inline const Variable& as_variable_ref(const at::Tensor& tensor) {
 }
 
 inline const at::Tensor& Variable::data() const noexcept {
-  return get()->data;
+  return get()->data_;
 }
 
 inline at::Tensor& Variable::data() noexcept {
-  return get()->data;
+  return get()->data_;
 }
 
 // Gradient Function and Edges
@@ -479,16 +489,16 @@ inline const std::shared_ptr<Function>& Variable::grad_fn() const {
 }
 
 inline Function* Variable::grad_fn_unsafe() const {
-  return get()->grad_fn.get();
+  return get()->grad_fn_.get();
 }
 
 inline void Variable::set_grad_accumulator(
     std::weak_ptr<Function> grad_accumulator) {
-  get()->grad_accumulator = std::move(grad_accumulator);
+  get()->grad_accumulator_ = std::move(grad_accumulator);
 }
 
 inline std::shared_ptr<Function> Variable::try_get_grad_accumulator() const {
-  return get()->grad_accumulator.lock();
+  return get()->grad_accumulator_.lock();
 }
 
 inline std::shared_ptr<Function> Variable::grad_accumulator() const {
@@ -496,40 +506,16 @@ inline std::shared_ptr<Function> Variable::grad_accumulator() const {
 }
 
 inline void Variable::set_gradient_edge(Edge edge) noexcept {
-  get()->grad_fn = std::move(edge.function);
-  get()->output_nr = edge.input_nr;
+  get()->grad_fn_ = std::move(edge.function);
+  get()->output_nr_ = edge.input_nr;
 }
 
 inline uint32_t Variable::output_nr() const noexcept {
-  return get()->output_nr;
+  return get()->output_nr_;
 }
 
 inline bool Variable::is_leaf() const noexcept {
-  return get()->grad_fn == nullptr;
-}
-
-// The Grad Variable
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-inline const Variable& Variable::grad() const noexcept {
-  return get()->grad;
-}
-
-inline Variable& Variable::grad() noexcept {
-  return get()->grad;
-}
-
-inline void Variable::reset_grad() noexcept {
-  get()->grad.reset();
-}
-
-inline void Variable::set_requires_grad(bool requires_grad) noexcept {
-  get()->requires_grad = requires_grad;
-}
-
-inline bool Variable::requires_grad() const noexcept {
-  return get()->requires_grad || get()->grad_fn ||
-      (is_view() && base().requires_grad());
+  return get()->grad_fn_ == nullptr;
 }
 
 // Versions
@@ -537,56 +523,53 @@ inline bool Variable::requires_grad() const noexcept {
 
 inline void Variable::set_version_counter(
     const VariableVersion& version_counter) noexcept {
-  get()->version_counter = version_counter;
+  get()->version_counter_ = version_counter;
 }
 
 inline void Variable::bump_version() noexcept {
-  get()->version_counter.bump();
+  get()->version_counter_.bump();
 }
 
 inline uint32_t Variable::current_version() const noexcept {
-  return get()->version_counter.current_version();
+  return get()->version_counter_.current_version();
 }
 
 inline const VariableVersion& Variable::version_counter() const noexcept {
-  return get()->version_counter;
+  return get()->version_counter_;
 }
 
 // Hooks
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 inline void Variable::add_hook(std::shared_ptr<FunctionPreHook> hook) {
-  get()->hooks.push_back(std::move(hook));
+  get()->hooks_.push_back(std::move(hook));
 }
 
 inline const std::vector<std::shared_ptr<FunctionPreHook>>& Variable::hooks()
     const noexcept {
-  return get()->hooks;
+  return get()->hooks_;
 }
 
 inline void Variable::clear_hooks() {
-  get()->hooks.clear();
+  get()->hooks_.clear();
 }
 
 // JIT Tracing
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 inline bool Variable::has_tracing_state() const noexcept {
-  return get()->tracing_state != nullptr;
+  return get()->tracing_state_ != nullptr;
 }
 
 // View Variables
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 inline bool Variable::is_view() const noexcept {
-  return get()->is_view;
+  return get()->is_view_;
 }
 
 inline const Variable& Variable::base() const {
-  if (is_view()) {
-    return static_cast<Variable::ViewImpl*>(get())->base;
-  }
-  throw std::runtime_error("Can't get base of non-view");
+  return get()->base();
 }
 
 // Miscellaneous
@@ -601,18 +584,11 @@ inline const std::string& Variable::name() const noexcept {
 }
 
 inline void Variable::set_pyobj(PyObject* pyobj) noexcept {
-  get()->pyobj = pyobj;
+  get()->pyobj_ = pyobj;
 }
 
 inline PyObject* Variable::pyobj() const noexcept {
-  return get()->pyobj;
-}
-
-// Hacks!
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-inline void Variable::temporary_hack_set_type(at::Type* new_type) noexcept {
-  get()->type_ = new_type;
+  return get()->pyobj_;
 }
 
 // Private Methods


### PR DESCRIPTION
This PR adds a basic autograd API to `at::Tensor`, and implements it for `Variable`. This API consists of:

- `void set_requires_grad(bool)`,
- `bool requires_grad() const`
- `Tensor& grad()`
- `const Tensor& grad() const`
- `Tensor detach() const`
- `void detach_()`

It does this in three steps:

1. Adds these functions as virtual methods to `TensorImpl`, and makes them throw exceptions when called,
2. Implements these functions in `VariableImpl`, mostly moving code from `Variable` into `VariableImpl`
3. Adds the methods to `Tensor` such that `Tensor::requires_grad` calls `pImpl->requires_grad()`
4. Solves all the problems that arise along the way.

One extra thing: In Python, `module.cuda()` works by changing the data and type underneath `Variable`'s feet (i.e. changing the underlying tensor data), so that references to `Variable` are not invalidated. The same is required in C++, so as part of this autograd API I have implemented `at::detail::set_data(Tensor& tensor, Tensor new_data)`, which assigns `new_data` to `tensor.data()` (`tensor` is here actually a `Variable`) and changes the type of the variable (`tensor`). To avoid `set_data` being part of the public API of `at::Tensor`, I made it a free friend function in the  `at::detail` namespace. That should hide it well. See the change in `torch/csrc/autograd/python_variable.cpp` for how this simplifies the code.

Because of name collisions in `VariableImpl`, e.g. between the `requires_grad` function and the `requires_grad` member variable, I had to rename some members (4 or 5) of `VariableImpl` to give them trailing underscores. For consistency, I then added trailing underscores to all member variables. This creates a little noise in this PR -- I'm sorry. I can revert those changes for now if it's too annoying to review.

@colesbury @apaszke @ezyang 