### PR TITLE
[JIT][script][ONNX] Initial ScriptModule ONNX export

### DIFF
--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -4,6 +4,10 @@
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/utils/pybind.h"
+#include "torch/csrc/jit/export.h"
+#include "torch/csrc/jit/passes/shape_analysis.h"
+#include "torch/csrc/jit/argument_spec.h"
+
 
 #include <iostream>
 #include <sstream>
@@ -20,6 +24,26 @@ void initPythonIRBindings(PyObject * module_) {
       std::stringstream ss;
       ss << g;
       return ss.str();
+    })
+    .def("propagate_shapes", [](Graph& g, std::vector<at::Tensor> inputs, bool with_grad) {
+      PropagateInputShapes(g, ArgumentSpec(with_grad, variable_tensor_list(std::move(inputs))));
+    })
+    .def("export", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
+                      int64_t onnx_opset_version, bool defer_weight_export=false) {
+      std::string graph;
+      RawDataExportMap export_map;
+      std::tie(graph, export_map) = ExportGraph(
+        g, initializers, onnx_opset_version, defer_weight_export);
+      std::unordered_map<std::string, py::bytes> python_serialized_export_map;
+      for (auto& kv : export_map) {
+        auto t = kv.second;
+        size_t copy_bytes = t.type().elementSizeInBytes() * t.numel();
+        // TODO: this is an unecessary copy. In theory we can directly return
+        // the map from identifier to Tensor, but we need some API in Python
+        // to get raw `bytes` containing the raw tensor data.
+        python_serialized_export_map[kv.first] = py::bytes(static_cast<const char*>(t.data_ptr()), copy_bytes);
+      }
+      return std::make_tuple(py::bytes(graph), python_serialized_export_map);
     })
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -40,25 +40,6 @@ void initPythonTracerBindings(PyObject* module_) {
       ASSERT_UNEXPIRED("pop_scope");
       s.pop_scope();
     })
-    .def("export", [](TracingState& s, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export=false) {
-      ASSERT_UNEXPIRED("export");
-      std::string graph;
-      RawDataExportMap export_map;
-      std::tie(graph, export_map) = ExportGraph(
-        s.graph, initializers, onnx_opset_version, defer_weight_export);
-      std::unordered_map<std::string, py::bytes> python_serialized_export_map;
-      for (auto& kv : export_map) {
-        auto t = kv.second;
-        size_t copy_bytes = t.type().elementSizeInBytes() * t.numel();
-        // TODO: this is an unecessary copy. In theory we can directly return
-        // the map from identifier to Tensor, but we need some API in Python
-        // to get raw `bytes` containing the raw tensor data.
-        python_serialized_export_map[kv.first] = py::bytes(static_cast<const char*>(t.data_ptr()), copy_bytes);
-      }
-      return std::make_tuple(
-          py::bytes(graph), python_serialized_export_map);
-    })
     .def("set_graph", [](TracingState& s, std::shared_ptr<Graph> g) {
       s.graph = g;
     })

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -115,12 +115,7 @@ def _trace(func, args, return_outs=False, aten=False):
     return trace
 
 
-def _export(model, args, f, export_params=True, verbose=False, training=False,
-            input_names=None, output_names=None, aten=False, export_type=ExportTypes.PROTOBUF_FILE):
-    # Special case for common case of passing a single Variable
-    if isinstance(args, torch.autograd.Variable):
-        args = (args, )
-
+def _trace_and_get_graph_from_model(model, args, training):
     # A basic sanity check: make sure the state_dict keys are the same
     # before and after running the model.  Fail fast!
     orig_state_dict_keys = _unique_state_dict(model).keys()
@@ -137,23 +132,45 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
         raise RuntimeError("state_dict changed after running the tracer; "
                            "something weird is happening in your model!")
 
-    trace.set_graph(_optimize_graph(trace.graph(), aten))
+    return trace.graph(), torch_out
 
-    _set_input_and_output_names(trace.graph(), input_names, output_names)
+
+# NOTE: the output `torch_out` will contain the output tensors resulting from
+# the trace of a Module. In the case that a torch.nn.ScriptModule is passed in,
+# this output will be None, since we are not doing any tracing but rather
+# directly extracting the graph.
+def _export(model, args, f, export_params=True, verbose=False, training=False,
+            input_names=None, output_names=None, aten=False, export_type=ExportTypes.PROTOBUF_FILE):
+    # Special case for common case of passing a single Variable
+    if isinstance(args, torch.autograd.Variable):
+        args = (args, )
+
+    if isinstance(model, torch.jit.ScriptModule):
+        torch_out = None
+        try:
+            graph = model.__getattr__('forward').graph()
+            graph.propagate_shapes(args, False)
+        except AttributeError:
+            # TODO: just trace it
+            raise RuntimeError('\'forward\' method must be a script method')
+    else:
+        graph, torch_out = _trace_and_get_graph_from_model(model, args, training)
+
+    graph = _optimize_graph(graph, aten)
+
+    _set_input_and_output_names(graph, input_names, output_names)
 
     if verbose:
-        print(trace)
+        print(graph)
 
     # TODO: Don't allocate a in-memory string for the protobuf
     from torch.onnx.symbolic import _onnx_opset_version
     defer_weight_export = export_type is not ExportTypes.PROTOBUF_FILE
     if export_params:
-        # NB: OrderedDict values is not actually a list, but trace.export is
-        # not duck-typed and expects an actual list.
-        proto, export_map = trace.export(list(_unique_state_dict(model).values()),
+        proto, export_map = graph.export(list(_unique_state_dict(model).values()),
                                          _onnx_opset_version, defer_weight_export)
     else:
-        proto, export_map = trace.export([], _onnx_opset_version, False)
+        proto, export_map = graph.export([], _onnx_opset_version, False)
 
     if export_type == ExportTypes.PROTOBUF_FILE:
         assert(len(export_map) == 0)


### PR DESCRIPTION
This PR creates the initial implementation for ONNX export for ScriptModules. It allows you to call the same ONNX export entrypoint on a ScriptModule where the `forward` method is a script method. The limitations are currently:

1) It simply looks for `forward` on the module. In the case that we're exporting a non-`ScriptModule`, we trace the `__call__` function on the module. This is not possible on `ScriptModule` at this point, so we will likely have to do some more sophisticated lookup
2) This does not have a fallback implementation for if the `forward` method is not a script method. This is going to involve more deep introspection into the tracing machinery, in particular the `slow_forward` business
3) Control flow support is forthcoming
4) TODO: we should make `onnx-fb-universe` tests to actually test this functionality, rather than just these smoke tests