### PR TITLE
Terminate dataloader workers properly when parent process is SIGKILL'ed

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -12,7 +12,7 @@ import subprocess
 from torch import multiprocessing
 from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
-from torch.utils.data.dataloader import default_collate, ExceptionWrapper
+from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 
 # We set dummy defaults here and only overwrite these values when in __main__,
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     from common_nn import TEST_CUDA
 
 
-JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 15.0
+JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 4.5
 
 
 class TestDatasetRandomSplit(TestCase):
@@ -547,7 +547,8 @@ but they are all safe to ignore'''
                 break
             else:
                 time.sleep(1)
-                self.assertFalse(time.time() - start_time > JOIN_TIMEOUT, 'subprocess not terminated')
+                self.assertFalse(time.time() - start_time > MANAGER_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT,
+                                 'subprocess not terminated')
 
     def test_len(self):
         def check_len(dl, expected):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -15,11 +15,12 @@ from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 
-# We set dummy defaults here and only overwrite these values when in __main__,
-# to get around duplicated import issue when using multiprocessing on Windows.
-TEST_CUDA = False
+# We only import the actual values when in __main__, to get around
+# duplicated import issue when using multiprocessing on Windows.
 if __name__ == '__main__':
     from common_nn import TEST_CUDA
+else:
+    TEST_CUDA = False
 
 
 JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 4.5

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -710,9 +710,7 @@ class TestIndividualWorkerQueue(TestCase):
 
 
 if __name__ == '__main__':
-    if sys.version_info[0] == 2:
-        multiprocessing.set_start_method('fork')
-    else:
+    if sys.version_info[0] == 3:
         # We need spawn start method for test_manager_unclean_exit
         multiprocessing.set_start_method('spawn')
     run_tests()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     from common_nn import TEST_CUDA
 
 
-JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 10
+JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 15.0
 
 
 class TestDatasetRandomSplit(TestCase):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -15,15 +15,22 @@ from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper, MANAGER_STATUS_CHECK_INTERVAL
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
 
-# We only import the actual values when in __main__, to get around
+# We only import the actual values in the main module, to get around
 # duplicated import issue when using multiprocessing on Windows.
-if __name__ == '__main__':
+TEST_CUDA = False
+if __name__ in ['test_dataloader', '__main__']:
     from common_nn import TEST_CUDA
-else:
-    TEST_CUDA = False
+    # We need spawn start method for test_manager_unclean_exit
+    if sys.version_info[0] == 3:
+        # Without the try-catch block, some tests will complain that
+        # context has already been set.
+        try:
+            multiprocessing.set_start_method('spawn')
+        except RuntimeError:
+            pass
 
 
-JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 4.5
+JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 6.5
 
 
 class TestDatasetRandomSplit(TestCase):
@@ -717,7 +724,4 @@ class TestIndividualWorkerQueue(TestCase):
 
 
 if __name__ == '__main__':
-    if sys.version_info[0] == 3:
-        # We need spawn start method for test_manager_unclean_exit
-        multiprocessing.set_start_method('spawn')
     run_tests()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -14,7 +14,12 @@ from torch.utils.data import Dataset, TensorDataset, DataLoader, ConcatDataset
 from torch.utils.data.dataset import random_split
 from torch.utils.data.dataloader import default_collate, ExceptionWrapper
 from common import TestCase, run_tests, TEST_NUMPY, IS_WINDOWS
-from common_nn import TEST_CUDA
+
+# We set dummy defaults here and only overwrite these values when in __main__,
+# to get around duplicated import issue when using multiprocessing on Windows.
+TEST_CUDA = False
+if __name__ == '__main__':
+    from common_nn import TEST_CUDA
 
 
 JOIN_TIMEOUT = 17.0 if IS_WINDOWS else 10

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -518,6 +518,7 @@ class TestDataLoader(TestCase):
     @unittest.skipIf(sys.version_info[0] == 2,
                      "spawn start method is not supported in Python 2, \
                      but we need it for creating another process with CUDA")
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_manager_unclean_exit(self):
         '''there might be ConnectionResetError or leaked semaphore warning (due to dirty process exit), \
 but they are all safe to ignore'''

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -80,7 +80,7 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, wo
             if IS_WINDOWS:
                 result = kernel32.WaitForSingleObject(manager_handle, 0)
                 # Value obtained from https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032.aspx
-                if result == 0x00000000:
+                if result == 0:
                     should_exit = True
             else:
                 if os.getppid() != manager_pid:
@@ -377,12 +377,6 @@ class _DataLoaderIter(object):
                     pass
                 for q in self.index_queues:
                     q.put(None)
-                # We should wait for the workers to finish before shutting down
-                # the manager process, otherwise in the `spawn` start method
-                # workers won't be able to access the queues from manager
-                # and will give FileNotFoundError (https://bugs.python.org/issue28965)
-                for w in self.workers:
-                    w.join()
                 # done_event should be sufficient to exit worker_manager_thread,
                 # but be safe here and put another None
                 self.worker_result_queue.put(None)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -239,7 +239,7 @@ class _DataLoaderIter(object):
 
         if self.num_workers > 0:
             self.worker_init_fn = loader.worker_init_fn
-            self.index_queues = [multiprocessing.SimpleQueue() for _ in range(self.num_workers)]
+            self.index_queues = [multiprocessing.Queue() for _ in range(self.num_workers)]
             self.worker_queue_idx = 0
             self.worker_result_queue = multiprocessing.SimpleQueue()
             self.batches_outstanding = 0

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -239,8 +239,8 @@ class _DataLoaderIter(object):
                 self.manager_heartbeat = multiprocessing.Value('d', time.time())
 
                 def update_heartbeat():
-                    threading.Timer(MANAGER_UPDATE_INTERVAL, update_heartbeat).start()
                     self.manager_heartbeat.value = time.time()
+                    threading.Timer(MANAGER_UPDATE_INTERVAL, update_heartbeat).start()
 
                 update_heartbeat()
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -366,6 +366,12 @@ class _DataLoaderIter(object):
                     pass
                 for q in self.index_queues:
                     q.put(None)
+                # We should wait for the workers to finish before shutting down
+                # the manager process, otherwise in the `spawn` start method
+                # workers won't be able to access the queues from manager
+                # and will give FileNotFoundError (https://bugs.python.org/issue28965)
+                for w in self.workers:
+                    w.join()
                 # done_event should be sufficient to exit worker_manager_thread,
                 # but be safe here and put another None
                 self.worker_result_queue.put(None)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -33,7 +33,7 @@ _use_shared_memory = False
 r"""Whether to use shared memory in default_collate"""
 
 IS_WINDOWS = sys.platform == "win32"
-MANAGER_STATUS_CHECK_INTERVAL = 5.0
+MANAGER_STATUS_CHECK_INTERVAL = 1.0
 if IS_WINDOWS:
     MANAGER_UPDATE_INTERVAL = 1.0
 
@@ -64,7 +64,7 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, wo
                 if (time.time() - manager_heartbeat.value) > MANAGER_UPDATE_INTERVAL:
                     should_exit = True
             else:
-                if os.getppid() == 1:
+                if os.getppid() in [0, 1]:
                     should_exit = True
             if should_exit:
                 index_queue.put(None)


### PR DESCRIPTION
When the parent process is SIGKILL'ed or otherwise encounters a dirty exit, the worker processes might not know about this event and keep on running, which leads to CUDA memory leaks. The most reliable way to detect the parent process exit is to let the worker processes periodically check the status of the parent process. In particular:

- On Linux: the worker process can check whether `os.getppid()` becomes 1, which signals that it has become an orphaned process
- On Windows: the worker process's `os.getppid()` won't change to 1 when the parent process exits. We have to do some sort of heartbeat from parent process to a shared variable, and the worker process will periodically check this variable

This aims to fix https://github.com/pytorch/pytorch/issues/5736 and the lingering Windows CUDA OOM issues in https://github.com/pytorch/pytorch/pull/6096. 