### PR TITLE
[JIT][script][ONNX] ScriptModule ONNX export + ONNX export for control flow nodes

### DIFF
--- a/test/expect/TestScript.test_onnx_export_script_inline_params.expect
+++ b/test/expect/TestScript.test_onnx_export_script_inline_params.expect
@@ -1,0 +1,19 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 2 3},{name: "1", type:Tensor dims: 3 3},{name: "2", type:Tensor dims: 3 4}]
+      outputs: [{name: "6", type:Tensor dims: 2 4}]
+      initializers: [TensorProto shape: [3 3],TensorProto shape: [3 4]]
+      nodes: [
+        Node {type: "Constant", inputs: [], outputs: [3], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: [1]}]},
+        Node {type: "Gemm", inputs: [x,1,3], outputs: [4], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0},{ name: 'broadcast', type: int, value: 1}]},
+        Node {type: "Constant", inputs: [], outputs: [5], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: [1]}]},
+        Node {type: "Gemm", inputs: [4,2,5], outputs: [6], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0},{ name: 'broadcast', type: int, value: 1}]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_script_inline_script.expect
+++ b/test/expect/TestScript.test_onnx_export_script_inline_script.expect
@@ -1,0 +1,17 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "2", type:Tensor dims: 1 2 3}]
+      initializers: []
+      nodes: [
+        Node {type: "Neg", inputs: [x], outputs: [1], attributes: []},
+        Node {type: "Add", inputs: [1,1], outputs: [2], attributes: []}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_script_inline_trace.expect
+++ b/test/expect/TestScript.test_onnx_export_script_inline_trace.expect
@@ -1,0 +1,17 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "2", type:Tensor dims: 1 2 3}]
+      initializers: []
+      nodes: [
+        Node {type: "Neg", inputs: [x], outputs: [1], attributes: []},
+        Node {type: "Add", inputs: [1,1], outputs: [2], attributes: []}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_script_module.expect
+++ b/test/expect/TestScript.test_onnx_export_script_module.expect
@@ -1,0 +1,16 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "1", type:Tensor dims: 1 2 3}]
+      initializers: []
+      nodes: [
+        Node {type: "Add", inputs: [x,x], outputs: [1], attributes: []}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_script_module_if.expect
+++ b/test/expect/TestScript.test_onnx_export_script_module_if.expect
@@ -1,0 +1,41 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "4", type:Tensor dims: 1 2 3}]
+      initializers: []
+      nodes: [
+        Node {type: "Sum", inputs: [x], outputs: [1], attributes: []},
+        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Greater", inputs: [1,2], outputs: [3], attributes: []},
+        Node {type: "If", inputs: [3], outputs: [4], attributes: [{ name: 'then_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export1"
+              inputs: []
+              outputs: [{name: "5", type:Tensor dims: 1 2 3}]
+              initializers: []
+              nodes: [
+                Node {type: "Neg", inputs: [x], outputs: [5], attributes: []}
+              ]
+            }
+
+          },{ name: 'else_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export2"
+              inputs: []
+              outputs: [{name: "x", type:Tensor dims: 1 2 3}]
+              initializers: []
+              nodes: [
+                
+              ]
+            }
+
+          }]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_script_module_loop.expect
+++ b/test/expect/TestScript.test_onnx_export_script_module_loop.expect
@@ -1,0 +1,30 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 2 3}]
+      outputs: [{name: "3", type:Tensor dims: 1 2 3}]
+      initializers: []
+      nodes: [
+        Node {type: "Constant", inputs: [], outputs: [1], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Loop", inputs: [1,2,x], outputs: [3], attributes: [{ name: 'body', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export1"
+              inputs: [{name: "4", type:Tensor dims: },{name: "5", type:Tensor dims: 1 2 3}]
+              outputs: [{name: "7", type:Tensor dims: },{name: "6", type:Tensor dims: 1 2 3}]
+              initializers: []
+              nodes: [
+                Node {type: "Add", inputs: [5,5], outputs: [6], attributes: []},
+                Node {type: "Constant", inputs: [], outputs: [7], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]}
+              ]
+            }
+
+          }]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2642,8 +2642,8 @@ class TestScript(TestCase):
                 return y + y
 
         mte = ModuleToExport()
-        f = io.BytesIO()
-        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+        str = torch.onnx._export_to_pretty_string(mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+
 
     def test_onnx_export_script_inline_script(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -2681,7 +2681,9 @@ class TestScript(TestCase):
 
         mte = ModuleToExport()
         f = io.BytesIO()
-        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+        str = torch.onnx._export_to_pretty_string(mte, (torch.zeros(1, 2, 3),), None, verbose=False)
+        print(str)
+
 
     def test_onnx_export_script_module_if(self):
         class ModuleToExport(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2588,6 +2588,9 @@ class TestScript(TestCase):
 
     def test_onnx_export_script_module(self):
         class ModuleToExport(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToExport, self).__init__()
+
             @torch.jit.script_method
             def forward(self, x):
                 y = x - x
@@ -2599,6 +2602,9 @@ class TestScript(TestCase):
 
     def test_onnx_export_script_python_fail(self):
         class ModuleToInline(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToInline, self).__init__()
+
             def forward(self, x):
                 return torch.neg(x)
 
@@ -2619,6 +2625,9 @@ class TestScript(TestCase):
 
     def test_onnx_export_script_inline_trace(self):
         class ModuleToInline(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToInline, self).__init__()
+
             def forward(self, x):
                 return torch.neg(x)
 
@@ -2638,6 +2647,9 @@ class TestScript(TestCase):
 
     def test_onnx_export_script_inline_script(self):
         class ModuleToInline(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToInline, self).__init__()
+
             @torch.jit.script_method
             def forward(self, x):
                 return torch.neg(x)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2586,6 +2586,76 @@ class TestScript(TestCase):
         self.assertEqual(1, foo3(a))
         self.assertEqual(2, foo3(b))
 
+    def test_onnx_export_script_module(self):
+        class ModuleToExport(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                y = x - x
+                return x + x
+
+        mte = ModuleToExport()
+        f = io.BytesIO()
+        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+
+    def test_onnx_export_script_python_fail(self):
+        class ModuleToInline(torch.jit.ScriptModule):
+            def forward(self, x):
+                return torch.neg(x)
+
+        class ModuleToExport(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToExport, self).__init__()
+                self.mod = ModuleToInline()
+
+            @torch.jit.script_method
+            def forward(self, x):
+                y = self.mod(x)
+                return y + y
+
+        mte = ModuleToExport()
+        f = io.BytesIO()
+        with self.assertRaisesRegex(RuntimeError, "Couldn't export Python operator"):
+            torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+
+    def test_onnx_export_script_inline_trace(self):
+        class ModuleToInline(torch.jit.ScriptModule):
+            def forward(self, x):
+                return torch.neg(x)
+
+        class ModuleToExport(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToExport, self).__init__()
+                self.mod = torch.jit.trace(torch.zeros(1, 2, 3))(ModuleToInline())
+
+            @torch.jit.script_method
+            def forward(self, x):
+                y = self.mod(x)
+                return y + y
+
+        mte = ModuleToExport()
+        f = io.BytesIO()
+        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+
+    def test_onnx_export_script_inline_script(self):
+        class ModuleToInline(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.neg(x)
+
+        class ModuleToExport(torch.jit.ScriptModule):
+            def __init__(self):
+                super(ModuleToExport, self).__init__()
+                self.mod = ModuleToInline()
+
+            @torch.jit.script_method
+            def forward(self, x):
+                y = self.mod(x)
+                return y + y
+
+        mte = ModuleToExport()
+        f = io.BytesIO()
+        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2597,8 +2597,8 @@ class TestScript(TestCase):
                 return x + x
 
         mte = ModuleToExport()
-        f = io.BytesIO()
-        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False))
 
     def test_onnx_export_script_python_fail(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -2642,8 +2642,8 @@ class TestScript(TestCase):
                 return y + y
 
         mte = ModuleToExport()
-        str = torch.onnx._export_to_pretty_string(mte, (torch.zeros(1, 2, 3),), None, verbose=False)
-
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False))
 
     def test_onnx_export_script_inline_script(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -2665,8 +2665,8 @@ class TestScript(TestCase):
                 return y + y
 
         mte = ModuleToExport()
-        f = io.BytesIO()
-        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False))
 
     def test_onnx_export_script_module_loop(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -2681,9 +2681,8 @@ class TestScript(TestCase):
 
         mte = ModuleToExport()
         f = io.BytesIO()
-        str = torch.onnx._export_to_pretty_string(mte, (torch.zeros(1, 2, 3),), None, verbose=False)
-        print(str)
-
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False))
 
     def test_onnx_export_script_module_if(self):
         class ModuleToExport(torch.jit.ScriptModule):
@@ -2697,8 +2696,8 @@ class TestScript(TestCase):
                 return x
 
         mte = ModuleToExport()
-        f = io.BytesIO()
-        torch.onnx._export(mte, (torch.zeros(1, 2, 3),), f, verbose=False)
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.zeros(1, 2, 3),), None, verbose=False))
 
     def test_onnx_export_script_inline_params(self):
         class ModuleToInline(torch.jit.ScriptModule):
@@ -2726,8 +2725,8 @@ class TestScript(TestCase):
         result = mte(torch.zeros(2, 3))
         reference = torch.mm(torch.mm(torch.zeros(2, 3), torch.ones(3, 3)), torch.ones(3, 4))
         self.assertEqual(result, reference)
-        f = io.BytesIO()
-        torch.onnx._export(mte, (torch.ones(2, 3),), f, verbose=False)
+        self.assertExpected(torch.onnx._export_to_pretty_string(
+            mte, (torch.ones(2, 3),), None, verbose=False))
 
 
 # Smoke tests for export methods

--- a/torch/csrc/autograd/symbolic.h
+++ b/torch/csrc/autograd/symbolic.h
@@ -7,7 +7,7 @@
 namespace torch { namespace autograd {
 
 struct SymbolicContext {
-  jit::Graph* graph;
+  jit::Block* block;
 };
 
 struct symbolic_unconvertible : public std::runtime_error {

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <iostream>
 #include <vector>
 #include "torch/csrc/autograd/variable.h"

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -20,4 +20,11 @@ std::tuple<std::string, RawDataExportMap> ExportGraph(
     int64_t onnx_opset_version,
     bool defer_weight_export = false);
 
+// For testing purposes
+std::string PrettyPrintExportedGraph(
+    const std::shared_ptr<Graph>& graph,
+    const std::vector<at::Tensor> & initializers,
+    int64_t onnx_opset_version,
+    bool defer_weight_export);
+
 }}

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -81,7 +81,8 @@ void initJITBindings(PyObject *module) {
    })
    .def("_jit_unflatten", [](autograd::variable_list vars, python::IODescriptor& desc) {
      return py::reinterpret_steal<py::object>(python::unflatten(vars, desc));
-   });
+   })
+   .def("_jit_pass_onnx_block", BlockToONNX);
 
   py::class_<GraphExecutor>(m, "GraphExecutor")
       .def(

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -103,6 +103,8 @@ _(onnx, Squeeze) \
 _(onnx, Sub) \
 _(onnx, Transpose) \
 _(onnx, Unsqueeze) \
+_(onnx, Loop) \
+_(onnx, If)
 /* end */
 
 // These symbols are attribute keys.  They are shared between both ONNX and ATen

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -27,10 +27,14 @@ bool hasUsedHandle(Node *node) {
 // Argument aten indicates whether we should export ops as "ATen" ONNX ops if possible.
 std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
   auto new_graph = std::make_shared<Graph>(graph->scope_root());
-
-  torch::autograd::SymbolicContext ctx;
-  ctx.graph = new_graph.get();
   std::unordered_map<Value*, Value*> env;
+  BlockToONNX(graph->block(), new_graph->block(), aten, env);
+  return new_graph;
+}
+
+void BlockToONNX(Block* old_block, Block* new_block, bool aten, std::unordered_map<Value*, Value*> env) {
+  torch::autograd::SymbolicContext ctx;
+  ctx.block = new_block;
 
   py::object onnx = py::module::import("torch.onnx");
   py::object onnx_symbolic = py::module::import("torch.onnx.symbolic");
@@ -44,8 +48,8 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
   };
 
   // Initialize context and environment
-  for (auto input : graph->inputs()) {
-    auto n = ctx.graph->addInput()->copyMetadata(input);
+  for (auto input : old_block->inputs()) {
+    auto n = ctx.block->addInput()->copyMetadata(input);
     n->setStage(input->stage());
     env[input] = n;
   }
@@ -96,7 +100,7 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
 
   // Clone the node and add it to the new graph
   auto cloneNode = [&](Node * node) {
-    auto n_ = ctx.graph->appendNode(ctx.graph->createClone(node, envFn));
+    auto n_ = ctx.block->appendNode(ctx.block->owningGraph()->createClone(node, envFn));
     for(size_t i = 0; i < node->outputs().size(); i++) {
       env[node->outputs()[i]] = n_->outputs()[i];
     }
@@ -137,8 +141,9 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
         py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
-    WithCurrentScope scope_guard(*ctx.graph, n->scope());
-    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.graph, n, py_inputs, aten);
+    WithInsertPoint insert_point_guard(ctx.block);
+    WithCurrentScope scope_guard(*ctx.block->owningGraph(), n->scope());
+    py::object raw_output = onnx.attr("_run_symbolic_function")(ctx.block->owningGraph(), n, py_inputs, env, aten);
 
     // TODO: Assert it's an ATen identifier???
     // (Sometimes it's not...)
@@ -158,7 +163,7 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
     // by regular args, with Variables replaced by corresponding nodes.
     Py_ssize_t input_nr = 0;
     py::tuple py_symbolic_args(1 + op->cconv.size());
-    py_symbolic_args[input_nr++] = py::cast(ctx.graph);
+    py_symbolic_args[input_nr++] = py::cast(ctx.block->owningGraph());
     auto inputs = op->inputs();
     auto node_it = inputs.begin();
     auto scalar_it = op->scalar_args.begin();
@@ -176,7 +181,8 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
       py_symbolic_args[input_nr++] = obj;
     }
 
-    WithCurrentScope scope_guard(*ctx.graph, op->scope());
+    WithInsertPoint insert_point_guard(ctx.block);
+    WithCurrentScope scope_guard(*ctx.block->owningGraph(), op->scope());
     // Call the symbolic function
     // Use a little trampoline function so we can give good error messages
     // upon argument mismatch
@@ -186,7 +192,7 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
   };
 
   // Finally, visit all nodes in the graph
-  for (auto node : graph->nodes()) {
+  for (auto node : old_block->nodes()) {
     if (hasUsedHandle(node)) {
       // Nothing we can do here. The handle is used, so we'll need to capture the
       // original state and can't do anything with this op (we don't know what the
@@ -195,7 +201,7 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
       continue;
     }
     // Needed so that symbolic calls create nodes with correct stages.
-    auto stage_guard = new_graph->setStageTemporary(node->stage());
+    auto stage_guard = ctx.block->owningGraph()->setStageTemporary(node->stage());
     IR_IFM(node, CppOp)
       cloneNode(node);
     IR_ELSEIFM(PythonOp)
@@ -204,13 +210,12 @@ std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& graph, bool aten) {
       callPySymbolicFunction(node);
     IR_END()
   }
-  for (auto output : graph->outputs()) {
-    ctx.graph->registerOutput(env.at(output));
+  for (auto output : old_block->outputs()) {
+    ctx.block->registerOutput(env.at(output));
   }
 
   // Copy stage from original graph
-  new_graph->setStage(graph->stage());
-  return new_graph;
+  ctx.block->owningGraph()->setStage(old_block->owningGraph()->stage());
 }
 
 }}

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -6,5 +6,6 @@
 namespace torch { namespace jit {
 
 std::shared_ptr<Graph> ToONNX(std::shared_ptr<Graph>& state, bool aten);
+void BlockToONNX(Block* old_block, Block* new_block, bool aten, std::unordered_map<Value*, Value*> env);
 
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -4,6 +4,10 @@
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/utils/pybind.h"
+#include "torch/csrc/jit/export.h"
+#include "torch/csrc/jit/passes/shape_analysis.h"
+#include "torch/csrc/jit/argument_spec.h"
+
 
 #include <iostream>
 #include <sstream>
@@ -20,6 +24,26 @@ void initPythonIRBindings(PyObject * module_) {
       std::stringstream ss;
       ss << g;
       return ss.str();
+    })
+    .def("propagate_shapes", [](Graph& g, std::vector<at::Tensor> inputs, bool with_grad) {
+      PropagateInputShapes(g, ArgumentSpec(with_grad, variable_tensor_list(std::move(inputs))));
+    })
+    .def("export", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
+                      int64_t onnx_opset_version, bool defer_weight_export=false) {
+      std::string graph;
+      RawDataExportMap export_map;
+      std::tie(graph, export_map) = ExportGraph(
+        g, initializers, onnx_opset_version, defer_weight_export);
+      std::unordered_map<std::string, py::bytes> python_serialized_export_map;
+      for (auto& kv : export_map) {
+        auto t = kv.second;
+        size_t copy_bytes = t.type().elementSizeInBytes() * t.numel();
+        // TODO: this is an unecessary copy. In theory we can directly return
+        // the map from identifier to Tensor, but we need some API in Python
+        // to get raw `bytes` containing the raw tensor data.
+        python_serialized_export_map[kv.first] = py::bytes(static_cast<const char*>(t.data_ptr()), copy_bytes);
+      }
+      return std::make_tuple(py::bytes(graph), python_serialized_export_map);
     })
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -105,6 +105,7 @@ void initPythonIRBindings(PyObject * module_) {
     .GS(appendNode)
     .GS(prependNode)
     .GS(lint)
+    .GS(insertNode)
     ;
     #undef GS
 
@@ -139,6 +140,8 @@ void initPythonIRBindings(PyObject * module_) {
     ;
 
   #undef VS
+
+  py::class_<Block, std::unique_ptr<Block, py::nodelete>>(m, "Block");
 
   #define NS(name) \
     def(#name,&Node :: name)
@@ -179,6 +182,10 @@ void initPythonIRBindings(PyObject * module_) {
     .NS(eraseOutput)
     .NS(addOutput)
     .NS(scopeName)
+    .def("blocks", [](Node& n) {
+      return py::make_iterator(n.blocks().begin(), n.blocks().end());
+    })
+    .NS(addBlock)
 
 #define AS(name) def(#name,&Attributes<Node> :: name)
     // methods from Attributes

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -45,6 +45,11 @@ void initPythonIRBindings(PyObject * module_) {
       }
       return std::make_tuple(py::bytes(graph), python_serialized_export_map);
     })
+    .def("prettyPrintExport", [](const std::shared_ptr<Graph> g, const std::vector<at::Tensor>& initializers,
+                      int64_t onnx_opset_version, bool defer_weight_export=false) {
+      return PrettyPrintExportedGraph(
+        g, initializers, onnx_opset_version, defer_weight_export);
+    })
     .def("wrapPyFuncWithSymbolic", [](Graph &g, py::function func, std::vector<Value*> inputs, size_t n_outputs, py::function symbolic) {
       // This function should be used for situations where we have a Python function
       // that should have different behavior when exporting for JIT interpreter

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -40,25 +40,6 @@ void initPythonTracerBindings(PyObject* module_) {
       ASSERT_UNEXPIRED("pop_scope");
       s.pop_scope();
     })
-    .def("export", [](TracingState& s, const std::vector<at::Tensor>& initializers,
-                      int64_t onnx_opset_version, bool defer_weight_export=false) {
-      ASSERT_UNEXPIRED("export");
-      std::string graph;
-      RawDataExportMap export_map;
-      std::tie(graph, export_map) = ExportGraph(
-        s.graph, initializers, onnx_opset_version, defer_weight_export);
-      std::unordered_map<std::string, py::bytes> python_serialized_export_map;
-      for (auto& kv : export_map) {
-        auto t = kv.second;
-        size_t copy_bytes = t.type().elementSizeInBytes() * t.numel();
-        // TODO: this is an unecessary copy. In theory we can directly return
-        // the map from identifier to Tensor, but we need some API in Python
-        // to get raw `bytes` containing the raw tensor data.
-        python_serialized_export_map[kv.first] = py::bytes(static_cast<const char*>(t.data_ptr()), copy_bytes);
-      }
-      return std::make_tuple(
-          py::bytes(graph), python_serialized_export_map);
-    })
     .def("set_graph", [](TracingState& s, std::shared_ptr<Graph> g) {
       s.graph = g;
     })

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -381,7 +381,9 @@ void initJitScriptBindings(PyObject* module) {
       auto inputs = createVariableTensorList(args);
       auto outputs = m.run(std::move(inputs));
       return unpackVariableTensorList(std::move(outputs));
-    });
+    })
+    .def("propagate_shapes", &Method::propagate_shapes)
+    .def("params", &Method::params);
 
   m.def("_jit_script_compile", [](Def def, ResolutionCallback rcb) {
     return compileFunction(def, pythonResolver(rcb));

--- a/torch/csrc/onnx/init.cpp
+++ b/torch/csrc/onnx/init.cpp
@@ -1,5 +1,6 @@
 #include "torch/csrc/onnx/init.h"
 #include "torch/csrc/onnx/onnx.pb.h"
+#include "torch/csrc/onnx/onnx.h"
 
 namespace torch { namespace onnx {
 void initONNXBindings(PyObject* module) {
@@ -22,5 +23,8 @@ void initONNXBindings(PyObject* module) {
       .value("UINT64", onnx_TensorProto_DataType_UINT64)
       .value("COMPLEX64", onnx_TensorProto_DataType_COMPLEX64)
       .value("COMPLEX128", onnx_TensorProto_DataType_COMPLEX128);
+
+  py::class_<ModelProto>(onnx, "ModelProto")
+      .def("prettyPrint", &ModelProto::prettyPrint);
 }
 }} // namespace torch::onnx

--- a/torch/csrc/onnx/onnx.cpp
+++ b/torch/csrc/onnx/onnx.cpp
@@ -46,4 +46,169 @@ GraphProto* AttributeProto::add_graphs() {
   return ptr;
 }
 
+constexpr char indent_char = ' ';
+constexpr size_t indent_multiplier = 2;
+
+std::string idt(size_t indent) {
+  return std::string(indent * indent_multiplier, indent_char);
+}
+
+std::string nlidt(size_t indent) {
+  return std::string("\n") + idt(indent);
+}
+
+void TensorProto::dump(std::ostream& stream, size_t indent) {
+  stream << "TensorProto shape: [";
+  for (size_t i = 0; i < dims.size(); ++i) {
+    stream << *dims[i] << (i == dims.size() - 1 ? "" : " ");
+  }
+  stream << "]";
+}
+
+void TensorShapeProto::dump(std::ostream& stream, size_t indent) {
+  for (size_t i=0; i < dims.size(); ++i) {
+    auto &dim = dims[i];
+    if (dim->has_dim_value) {
+      stream << dim->dim_value;
+    } else {
+      stream << "?";
+    }
+    stream << (i == dims.size() - 1 ? "" : " ");
+  }
+}
+
+void TypeProtoTensor::dump(std::ostream& stream, size_t indent) {
+  stream << "Tensor dims: ";
+  shape->dump(stream);
+}
+
+void TypeProto::dump(std::ostream& stream, size_t indent) {
+  tensor_type->dump(stream);
+}
+
+void ValueInfoProto::dump(std::ostream& stream, size_t indent) {
+  stream << "{name: \"" << name
+         << "\", type:";
+  type->dump(stream);
+  stream << "}";
+}
+
+void AttributeProto::dump(std::ostream& stream, size_t indent) {
+  stream << "{ name: '" << name << "', type: ";
+  if (proto.has_f) {
+    stream << "float, value: " << proto.f;
+  } else if (proto.has_i) {
+    stream << "int, value: " << proto.i;
+  } else if (s.length()) {
+    stream << "string, value: '" << s << "'";
+  } else if (g) {
+    stream << "graph, value:\n";
+    g->dump(stream, indent+1);
+    stream << nlidt(indent);
+  } else if (t) {
+    stream << "tensor, value:";
+    t->dump(stream, indent+1);
+  } else if (floats.size()) {
+    stream << "floats, values: [";
+    for (size_t i=0; i < floats.size(); ++i)
+      stream << *floats[i] << (i == floats.size() - 1 ? "" : " ");
+    stream << "]";
+  } else if (ints.size()) {
+    stream << "ints, values: [";
+    for (size_t i=0; i < ints.size(); ++i)
+      stream << *ints[i] << (i == ints.size() - 1 ? "" : " ");
+    stream << "]";
+  } else if (strings.size()) {
+    stream << "strings, values: [";
+    for (size_t i=0; i < strings.size(); ++i)
+      stream << "'" << *strings[i] << "'" << (i == strings.size() - 1 ? "" : " ");
+    stream << "]";
+  } else if (tensors.size()) {
+    stream << "tensors, values: [";
+    for (auto& t : tensors) {
+      t->dump(stream, indent+1);
+    }
+    stream << "]";
+  } else if (graphs.size()) {
+    stream << "graphs, values: [";
+    for (auto& g : graphs) {
+      g->dump(stream, indent+1);
+    }
+    stream << "]";
+  } else {
+    stream << "UNKNOWN";
+  }
+  stream << "}";
+}
+
+void NodeProto::dump(std::ostream& stream, size_t indent) {
+  stream << "Node {type: \"" << op_type << "\", inputs: [";
+  for (size_t i=0; i < inputs.size(); ++i) {
+    stream << *inputs[i] << (i == inputs.size() - 1 ? "" : ",");
+  }
+  stream << "], outputs: [";
+  for (size_t i=0; i < outputs.size(); ++i) {
+    stream << *outputs[i] << (i == outputs.size() - 1 ? "" : ",");
+  }
+  stream << "], attributes: [";
+  for (size_t i=0; i < attributes.size(); ++i) {
+    attributes[i]->dump(stream, indent+1);
+    stream << (i == attributes.size() - 1 ? "" : ",");
+  }
+  stream << "]}";
+}
+
+void GraphProto::dump(std::ostream& stream, size_t indent) {
+  stream << idt(indent) << "GraphProto {" << nlidt(indent+1)
+         << "name: \"" << name << "\"" << nlidt(indent+1)
+         << "inputs: [";
+  for (size_t i=0; i < inputs.size(); ++i) {
+    inputs[i]->dump(stream, indent+2);
+    stream << (i == inputs.size() - 1 ? "" : ",");
+  }
+  stream << "]" << nlidt(indent+1)
+         << "outputs: [";
+  for (size_t i=0; i < outputs.size(); ++i) {
+    outputs[i]->dump(stream, indent+2);
+    stream << (i == outputs.size() - 1 ? "" : ",");
+  }
+  stream << "]" << nlidt(indent+1)
+         << "initializers: [";
+  for (size_t i=0; i < initializers.size(); ++i) {
+    initializers[i]->dump(stream, indent+2);
+    stream << (i == initializers.size() - 1 ? "" : ",");
+  }
+  stream << "]" << nlidt(indent+1)
+         << "nodes: [" << nlidt(indent+2);
+  for (size_t i=0; i < nodes.size(); ++i) {
+    nodes[i]->dump(stream, indent+2);
+    if (i != nodes.size() - 1) stream << "," << nlidt(indent+2);
+  }
+  stream << nlidt(indent+1) << "]\n" << idt(indent) << "}\n";
+}
+
+void OperatorSetIdProto::dump(std::ostream& stream, size_t indent) {
+  stream << "OperatorSetIdProto { domain: " << domain << "}";
+}
+
+void ModelProto::dump(std::ostream& stream, size_t indent) {
+  stream << idt(indent)
+         << "ModelProto {" << nlidt(indent+1)
+         << "producer_name: \"" << producer_name << "\"" << nlidt(indent+1)
+         << "domain: \"" << domain << "\"" << nlidt(indent+1)
+         << "doc_string: \"" << doc_string << "\"";
+  if (graph) {
+    stream << nlidt(indent+1) << "graph:\n";
+    graph->dump(stream, indent+2);
+  }
+  if (opset_import.size()) {
+    stream << idt(indent+1) << "opset_import: [";
+    for (auto &opset_imp : opset_import) {
+      opset_imp->dump(stream, indent+2);
+    }
+    stream << "],\n";
+  }
+  stream << idt(indent) << "}\n";
+}
+
 }} // namespace onnx

--- a/torch/csrc/onnx/onnx.h
+++ b/torch/csrc/onnx/onnx.h
@@ -202,7 +202,7 @@ private:
   std::string name; // namespace ValueInfoProto.
   unique_vector<int64_t> dims;
   at::Tensor raw_data;
-  std::string dump;
+  std::string dump_;
 public:
   TensorProto() : MicroProto(onnx_TensorProto_init_default) {
     proto.dims       = list<int64_t>(&dims);
@@ -211,9 +211,10 @@ public:
   void add_dims(int64_t d) { dims.emplace_back(new int64_t(d)); }
   // Google Protobuf divergence!
   void set_raw_data(const at::Tensor& t) { proto.raw_data = string_from_tensor(&raw_data, t); }
-  void set_external_data_present() { proto.raw_data = string(&dump, "__EXTERNAL"); }
+  void set_external_data_present() { proto.raw_data = string(&dump_, "__EXTERNAL"); }
   void set_data_type(onnx_TensorProto_DataType t) { proto.has_data_type = true; proto.data_type = t; }
   std::string get_name() const { return name; }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class TensorShapeProto : public MicroProto<onnx_TensorShapeProto> {
@@ -229,6 +230,7 @@ public:
     p_d->dim_value = d;
     dims.emplace_back(p_d);
   }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class TypeProtoTensor : public MicroProto<onnx_TypeProto_Tensor> {
@@ -241,6 +243,7 @@ public:
     proto.shape = msg<TensorShapeProto, onnx_TensorShapeProto_fields>(&shape);
     return shape.get();
   }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class TypeProto : public MicroProto<onnx_TypeProto> {
@@ -252,6 +255,7 @@ public:
     proto.tensor_type = msg<TypeProtoTensor, onnx_TypeProto_Tensor_fields>(&tensor_type);
     return tensor_type.get();
   }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class ValueInfoProto : public MicroProto<onnx_ValueInfoProto> {
@@ -266,6 +270,7 @@ public:
     proto.type = msg<TypeProto, onnx_TypeProto_fields>(&type);
     return type.get();
   }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class AttributeProto : public MicroProto<onnx_AttributeProto> {
@@ -304,6 +309,7 @@ public:
     return ptr;
   }
   GraphProto* add_graphs();
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class NodeProto : public MicroProto<onnx_NodeProto> {
@@ -330,6 +336,7 @@ public:
   }
   void set_op_type(const std::string& s) { proto.op_type= string(&op_type, s); }
   void set_doc_string(const std::string& s) { proto.doc_string = string(&doc_string, s); }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class GraphProto : public MicroProto<onnx_GraphProto> {
@@ -368,6 +375,7 @@ public:
     initializers.emplace_back(ptr);
     return ptr;
   }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class OperatorSetIdProto : public MicroProto<onnx_OperatorSetIdProto> {
@@ -377,6 +385,7 @@ public:
   OperatorSetIdProto() : MicroProto(onnx_OperatorSetIdProto_init_default) {}
   void set_domain(const std::string& s) { proto.domain = string(&domain, s); }
   void set_version(int64_t v) { proto.has_version = true; proto.version = v; }
+  void dump(std::ostream& stream, size_t indent = 0);
 };
 
 class ModelProto : public MicroProto<onnx_ModelProto> {
@@ -405,6 +414,12 @@ public:
     auto ptr = new OperatorSetIdProto();
     opset_import.emplace_back(ptr);
     return ptr;
+  }
+  void dump(std::ostream& stream, size_t indent = 0);
+  std::string prettyPrint() {
+    std::stringstream ss;
+    dump(ss, 0);
+    return ss.str();
   }
 };
 

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -20,6 +20,11 @@ def _export(*args, **kwargs):
     return utils._export(*args, **kwargs)
 
 
+def _export_to_pretty_string(*args, **kwargs):
+    from torch.onnx import utils
+    return utils._export_to_pretty_string(*args, **kwargs)
+
+
 def export(*args, **kwargs):
     from torch.onnx import utils
     return utils.export(*args, **kwargs)


### PR DESCRIPTION
This PR implements export for control flow nodes to ONNX. It makes several changes:

* The ONNX export pass now operates on `Block`s rather than `Graph`s, and recursively descends through these for control flow operators.
  * The environment map for this translation phase is now passed by value recursively to allow for resolution of values in lexical scope
* `ExportGraph` takes the `Blocks` on each control flow operator and emits them each as a `GraphProto`. The supporting machinery for doing so has been changed (similarly, `encodeGraph` is now implemented in terms of a new `encodeBlock` function, and this export is done recursively)

TODO: we need `onnx-fb-universe` tests to test both this PR and the prior PR