### PR TITLE
[distributions] Implement Independent distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -131,6 +131,15 @@ Probability distributions - torch.distributions
     :undoc-members:
     :show-inheritance:
 
+:hidden:`Independent`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.independent
+.. autoclass:: Independent
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :hidden:`Laplace`
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -35,10 +35,10 @@ from torch.autograd import Variable, grad, gradcheck, variable
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, Dirichlet, Distribution,
                                  Exponential, ExponentialFamily,
-                                 FisherSnedecor, Gamma, Geometric,
-                                 Gumbel, Laplace, LogNormal, LogisticNormal,
-                                 Multinomial, MultivariateNormal, Normal,
-                                 OneHotCategorical, Pareto, Poisson,
+                                 FisherSnedecor, Gamma, Geometric, Gumbel,
+                                 Independent, Laplace, LogisticNormal,
+                                 LogNormal, Multinomial, MultivariateNormal,
+                                 Normal, OneHotCategorical, Pareto, Poisson,
                                  RelaxedBernoulli, RelaxedOneHotCategorical,
                                  StudentT, TransformedDistribution, Uniform,
                                  constraints, kl_divergence)
@@ -49,8 +49,8 @@ from torch.distributions.kl import _kl_expfamily_expfamily
 from torch.distributions.transforms import (AbsTransform, AffineTransform,
                                             ComposeTransform, ExpTransform,
                                             LowerCholeskyTransform,
-                                            PowerTransform,
-                                            SigmoidTransform, SoftmaxTransform,
+                                            PowerTransform, SigmoidTransform,
+                                            SoftmaxTransform,
                                             StickBreakingTransform,
                                             identity_transform)
 from torch.distributions.utils import _finfo, probs_to_logits, softmax
@@ -172,6 +172,33 @@ EXAMPLES = [
         {
             'loc': torch.randn(1, requires_grad=True),
             'scale': variable(torch.randn(1).abs(), requires_grad=True),
+        },
+    ]),
+    Example(Independent, [
+        {
+            'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
+                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+            'reinterpreted_batch_ndims': 0,
+        },
+        {
+            'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
+                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+            'reinterpreted_batch_ndims': 1,
+        },
+        {
+            'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
+                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+            'reinterpreted_batch_ndims': 2,
+        },
+        {
+            'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
+                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+            'reinterpreted_batch_ndims': 2,
+        },
+        {
+            'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
+                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+            'reinterpreted_batch_ndims': 3,
         },
     ]),
     Example(Laplace, [

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -69,7 +69,6 @@ derivative would be as follows::
 
 from .bernoulli import Bernoulli
 from .beta import Beta
-from .transforms import *
 from .binomial import Binomial
 from .categorical import Categorical
 from .cauchy import Cauchy
@@ -77,12 +76,13 @@ from .chi2 import Chi2
 from .constraint_registry import biject_to, transform_to
 from .dirichlet import Dirichlet
 from .distribution import Distribution
-from .exponential import Exponential
 from .exp_family import ExponentialFamily
+from .exponential import Exponential
 from .fishersnedecor import FisherSnedecor
 from .gamma import Gamma
 from .geometric import Geometric
 from .gumbel import Gumbel
+from .independent import Independent
 from .kl import kl_divergence, register_kl
 from .laplace import Laplace
 from .log_normal import LogNormal
@@ -97,6 +97,7 @@ from .relaxed_bernoulli import RelaxedBernoulli
 from .relaxed_categorical import RelaxedOneHotCategorical
 from .studentT import StudentT
 from .transformed_distribution import TransformedDistribution
+from .transforms import *
 from .uniform import Uniform
 
 __all__ = [
@@ -114,6 +115,7 @@ __all__ = [
     'Gamma',
     'Geometric',
     'Gumbel',
+    'Independent',
     'Laplace',
     'LogNormal',
     'LogisticNormal',

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -1,0 +1,84 @@
+import torch
+from torch.distributions import constraints
+from torch.distributions.distribution import Distribution
+from torch.distributions.utils import _sum_rightmost
+
+
+class Independent(Distribution):
+    r"""
+    Reinterprets some of the batch dims of a distribution as event dims.
+
+    This is mainly useful for changing the shape of the result of
+    :meth:`log_prob`. For example to create a diagonal Normal distribution with
+    the same shape as a Multivariate Normal distribution (so they are
+    interchangeable), you can::
+
+        >>> loc = torch.zeros(3)
+        >>> scale = torch.ones(3)
+        >>> mvn = MultivariateNormal(loc, scale_tril=torch.diag(scale))
+        >>> [mvn.batch_shape, mvn.event_shape]
+        [torch.Size(()), torch.Size((3,))]
+        >>> normal = Normal(loc, scale)
+        >>> [normal.batch_shape, normal.event_shape]
+        [torch.Size((3,)), torch.Size(())]
+        >>> diagn = Independent(normal, 1)
+        >>> [diagn.batch_shape, diagn.event_shape]
+        [torch.Size(()), torch.Size((3,))]
+
+    Args:
+        base_distribution (torch.distributions.distribution.Distribution): a
+            base distribution
+        reinterpreted_batch_ndims (int): the number of batch dims to
+            reinterpret as event dims
+    """
+    arg_constraints = {}
+
+    def __init__(self, base_distribution, reinterpreted_batch_ndims, validate_args=None):
+        if reinterpreted_batch_ndims > len(base_distribution.batch_shape):
+            raise ValueError("Expected reinterpreted_batch_ndims <= len(base_distribution.batch_shape), "
+                             "actual {} vs {}".format(reinterpreted_batch_ndims,
+                                                      len(base_distribution.batch_shape)))
+        shape = base_distribution.batch_shape + base_distribution.event_shape
+        event_dim = reinterpreted_batch_ndims + len(base_distribution.event_shape)
+        batch_shape = shape[:len(shape) - event_dim]
+        event_shape = shape[len(shape) - event_dim:]
+        self.base_dist = base_distribution
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+        super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    @property
+    def has_rsample(self):
+        return self.base_dist.has_rsample
+
+    @property
+    def has_enumerate_support(self):
+        return self.base_dist.has_enumerate_support
+
+    @constraints.dependent_property
+    def support(self):
+        return self.base_dist.support
+
+    @property
+    def mean(self):
+        return self.base_dist.mean
+
+    @property
+    def variance(self):
+        return self.base_dist.variance
+
+    def sample(self, sample_shape=torch.Size()):
+        return self.base_dist.sample(sample_shape)
+
+    def rsample(self, sample_shape=torch.Size()):
+        return self.base_dist.rsample(self, sample_shape)
+
+    def log_prob(self, value):
+        log_prob = self.base_dist.log_prob(value)
+        return _sum_rightmost(log_prob, self.reinterpreted_batch_ndims)
+
+    def entropy(self):
+        entropy = self.base_dist.entropy()
+        return _sum_rightmost(entropy, self.reinterpreted_batch_ndims)
+
+    def enumerate_support(self):
+        return self.base_dist.enumerate_support()


### PR DESCRIPTION
Implements an `Independent` distribution to reinterpret batch dims as event dims.

This follows [tensorflow nomenclature](https://www.tensorflow.org/api_docs/python/tf/contrib/distributions/Independent).

## Why?

This has been requested a couple times on PyTorch slack. We have a similar [ReshapedDistribution](https://github.com/uber/pyro/blob/4d938bc/pyro/distributions/torch_distribution.py#L185) in Pyro.

## Tested

- added some test examples