### PR TITLE
nll_loss: Fixed text of error message in case of unexpected target size

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1352,7 +1352,7 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
         out_size = (n,) + input.size()[2:]
         if target.size()[1:] != input.size()[2:]:
             raise ValueError('Expected target size {}, got {}'.format(
-                out_size, input.size()))
+                out_size, target.size()))
         input = input.contiguous().view(n, c, 1, -1)
         target = target.contiguous().view(n, 1, -1)
         if reduce:


### PR DESCRIPTION
Hi,
I think the current error message in case of an unexpected target size is wrong as it basically uses input.size() both times.