### PR TITLE
Make dtype in .to positional rather than kwarg only

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -532,7 +532,7 @@ static PyObject * THPVariable_to(PyObject* self, PyObject* args, PyObject* kwarg
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "to(Device device, *, ScalarType dtype=None)",
+    "to(Device device, ScalarType dtype=None)",
     "to(ScalarType dtype)",
     "to(Tensor other)",
   });


### PR DESCRIPTION
Currently the `dtype` in `.to(device, dtype=dtype)` is kwarg only. This makes changing both device and dtype quite wordy, and even longer than the less efficient `.to(device).to(dtype)`.

This PR changes the `dtype` in this variant to be positional.