### PR TITLE
Codemod to update our codebase to 0.4 standard

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -40,7 +40,7 @@ Containers
 .. autoclass:: ParameterList
     :members:
 
-Convolution Layers
+Convolution layers
 ----------------------------------
 
 :hidden:`Conv1d`
@@ -81,7 +81,7 @@ Convolution Layers
     :members:
 
 
-Pooling Layers
+Pooling layers
 ----------------------------------
 
 :hidden:`MaxPool1d`
@@ -193,7 +193,7 @@ Pooling Layers
     :members:
 
 
-Padding Layers
+Padding layers
 --------------
 
 :hidden:`ReflectionPad1d`
@@ -251,8 +251,8 @@ Padding Layers
     :members:
 
 
-Non-linear Activations (weighed sum+nonlinearity)
--------------------------------------------------
+Non-linear activations (weighted sum, nonlinearity)
+---------------------------------------------------
 
 :hidden:`ELU`
 ~~~~~~~~~~~~~
@@ -356,7 +356,7 @@ Non-linear Activations (weighed sum+nonlinearity)
 .. autoclass:: Threshold
     :members:
 
-Non-linear Activations (Other)
+Non-linear activations (other)
 ------------------------------
 
 :hidden:`Softmin`
@@ -1193,6 +1193,14 @@ Vision functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: affine_grid
+
+DataParallel functions (multi-GPU, distributed)
+--------------------------------------------
+
+:hidden:`data_parallel`
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.parallel.data_parallel
 
 
 torch.nn.init

--- a/test/common.py
+++ b/test/common.py
@@ -17,7 +17,6 @@ import errno
 
 import torch
 import torch.cuda
-from torch.autograd import Variable
 from torch._six import string_classes
 import torch.backends.cudnn
 import torch.backends.mkl
@@ -186,7 +185,7 @@ class TestCase(unittest.TestCase):
             if idx_tup in value_map:
                 value_map[idx_tup] += val
             else:
-                value_map[idx_tup] = val.clone() if torch.is_tensor(val) else val
+                value_map[idx_tup] = val.clone() if isinstance(val, torch.Tensor) else val
 
         new_indices = sorted(list(value_map.keys()))
         new_values = [value_map[idx] for idx in new_indices]
@@ -207,13 +206,6 @@ class TestCase(unittest.TestCase):
 
         return tg
 
-    def unwrapVariables(self, x, y):
-        if isinstance(x, Variable):
-            x = x.data
-        if isinstance(y, Variable):
-            y = y.data
-        return x, y
-
     def assertEqual(self, x, y, prec=None, message='', allow_inf=False):
         if isinstance(prec, str) and message == '':
             message = prec
@@ -221,13 +213,11 @@ class TestCase(unittest.TestCase):
         if prec is None:
             prec = self.precision
 
-        x, y = self.unwrapVariables(x, y)
-
         if isinstance(x, torch.Tensor) and isinstance(y, Number):
             self.assertEqual(x.item(), y, prec, message, allow_inf)
         elif isinstance(y, torch.Tensor) and isinstance(x, Number):
             self.assertEqual(x, y.item(), prec, message, allow_inf)
-        elif torch.is_tensor(x) and torch.is_tensor(y):
+        elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 super(TestCase, self).assertEqual(a.size(), b.size(), message)
                 if a.numel() > 0:
@@ -285,9 +275,7 @@ class TestCase(unittest.TestCase):
         if prec is None:
             prec = self.precision
 
-        x, y = self.unwrapVariables(x, y)
-
-        if torch.is_tensor(x) and torch.is_tensor(y):
+        if isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             if x.size() != y.size():
                 super(TestCase, self).assertNotEqual(x.size(), y.size())
             self.assertGreater(x.numel(), 0)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -72,10 +72,10 @@ def graph_desc(fn):
 class TestAutograd(TestCase):
 
     def _function_test(self, cls):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=True)
         result = cls.apply(x, 2, y)
-        go = Variable(torch.ones(1), requires_grad=True)
+        go = torch.ones(1, requires_grad=True)
         result.sum().backward(go, create_graph=True)
 
         self.assertEqual(x.grad.data, y.data + torch.ones(5, 5))
@@ -98,9 +98,9 @@ class TestAutograd(TestCase):
             def backward(ctx, grad_output):
                 var1, var2 = ctx.saved_tensors
                 # NOTE: self is the test case here
-                self.assertIsInstance(var1, Variable)
-                self.assertIsInstance(var2, Variable)
-                self.assertIsInstance(grad_output, Variable)
+                self.assertIsInstance(var1, torch.Tensor)
+                self.assertIsInstance(var2, torch.Tensor)
+                self.assertIsInstance(grad_output, torch.Tensor)
                 return (grad_output + grad_output * var2, None,
                         grad_output * ctx.pyscalar + grad_output * var1)
 
@@ -150,7 +150,7 @@ class TestAutograd(TestCase):
             def backward(ctx, grad):
                 return grad * 2
 
-        v = Variable(torch.ones(1), requires_grad=True)
+        v = torch.ones(1, requires_grad=True)
         MyFunction.apply(v).backward()
         self.assertEqual(v.grad.data.tolist(), [2])
 
@@ -167,16 +167,16 @@ class TestAutograd(TestCase):
                 return None
 
         shape = (2, 3)
-        v = Variable(torch.ones(shape), requires_grad=True)
+        v = torch.ones(shape, requires_grad=True)
         y = v[0, 0].expand(3, 5).t().sum()
         MyFunction()(y).sum().backward()
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
     def test_accumulate_grad(self):
-        grad_output = Variable(torch.ones(5, 5))
+        grad_output = torch.ones(5, 5)
 
         def compute_grad(create_graph):
-            x = Variable(torch.randn(5, 5), requires_grad=True)
+            x = torch.randn(5, 5, requires_grad=True)
             y = x + 2
             y.backward(grad_output, retain_graph=True)
             x_grad = x.grad
@@ -193,8 +193,8 @@ class TestAutograd(TestCase):
         self.assertEqual(x_grad, x_grad_clone)
 
     def test_hessian_vector(self):
-        x = Variable(torch.randn(2, 2), requires_grad=True)
-        y = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.randn(2, 2, requires_grad=True)
+        y = torch.randn(2, 2, requires_grad=True)
 
         z = x ** 2 + y * x + y ** 2
         z.backward(torch.ones(2, 2), create_graph=True)
@@ -212,8 +212,8 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, y_grad + y_hv)
 
     def test_grad(self):
-        x = Variable(torch.randn(2, 2), requires_grad=True)
-        y = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.randn(2, 2, requires_grad=True)
+        y = torch.randn(2, 2, requires_grad=True)
         z = x ** 2 + y * x + y ** 2
         z.backward(torch.ones(2, 2), create_graph=True)
 
@@ -234,9 +234,9 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, y_grad)
 
     def test_grad_nonleaf(self):
-        x_init = Variable(torch.randn(2, 2), requires_grad=True)
+        x_init = torch.randn(2, 2, requires_grad=True)
         x = x_init
-        y = Variable(torch.randn(2, 2), requires_grad=True)
+        y = torch.randn(2, 2, requires_grad=True)
         grad_output = torch.ones(2, 2)
 
         def fn(x):
@@ -265,7 +265,7 @@ class TestAutograd(TestCase):
         # This checks an edge case for function callbacks
         # We want to capture two grads of a function, but can only
         # register a single callback.
-        x = Variable(torch.randn(4, 2), requires_grad=True)
+        x = torch.randn(4, 2, requires_grad=True)
         a, b = x.chunk(2)
 
         def hook(*grads):
@@ -283,7 +283,7 @@ class TestAutograd(TestCase):
         self.assertIsNone(x.grad)
 
     def test_sharded_grad(self):
-        leaves = [Variable(torch.zeros(5, 5), requires_grad=True) for _ in range(10)]
+        leaves = [torch.zeros(5, 5, requires_grad=True) for _ in range(10)]
         intermediates = [l * i + l * l for i, l in enumerate(leaves)]
         loss = sum(v * i for i, v in enumerate(intermediates)).sum()
 
@@ -314,13 +314,13 @@ class TestAutograd(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'does not require grad'):
             torch.autograd.grad(y, x)
 
-        x = Variable(torch.ones(1), requires_grad=True)
+        x = torch.ones(1, requires_grad=True)
         y = x ** 2
         torch.autograd.grad(y, x)  # this should succeed now
 
     def test_grad_unreachable(self):
-        x = Variable(torch.ones(1), requires_grad=True)
-        y = Variable(torch.ones(1), requires_grad=True)
+        x = torch.ones(1, requires_grad=True)
+        y = torch.ones(1, requires_grad=True)
         # Make sure x and y have grad accumulators allocated
         z = x * 2
         w = y * 2
@@ -331,19 +331,19 @@ class TestAutograd(TestCase):
 
         # This is slightly different than the case above, because z doesn't even
         # have a grad accumulator allocated.
-        z = Variable(torch.ones(1), requires_grad=True)
+        z = torch.ones(1, requires_grad=True)
         grad_x, grad_z = torch.autograd.grad(x * 2, [x, z], allow_unused=True)
         self.assertEqual(grad_x, x * 2)
         self.assertIsNone(grad_z)
 
     def test_hooks(self):
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
         y = Variable(torch.ones(5, 5) * 4, requires_grad=True)
 
         counter = [0]
 
         def bw_hook(inc, grad):
-            self.assertIsInstance(grad, Variable)
+            self.assertIsInstance(grad, torch.Tensor)
             counter[0] += inc
 
         z = x ** 2 + x * 2 + x * y + y
@@ -385,7 +385,7 @@ class TestAutograd(TestCase):
             counter[0] += 1
             return grad * 2
 
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
         z = bn(x)
         z.register_hook(bw_hook)
         z.sum().backward()
@@ -419,13 +419,13 @@ class TestAutograd(TestCase):
             was_called[0] = True
         fn.register_hook(hook)
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5))
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5)
         sum(fn(x, y)).sum().backward()
         self.assertTrue(was_called[0])
 
     def test_retain_grad(self):
-        input = Variable(torch.rand(1, 3), requires_grad=True)
+        input = torch.rand(1, 3, requires_grad=True)
         h1 = input * 3
         out = (h1 * h1).sum()
 
@@ -452,7 +452,7 @@ class TestAutograd(TestCase):
         counter = [0]
         refs = [None]
 
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
 
         def run_test():
             y = x * 2
@@ -523,26 +523,26 @@ class TestAutograd(TestCase):
         dense_fn = FixedGradientFunction(dense_grad)
 
         # sparse first
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         (sparse_fn1(x) + dense_fn(x) + sparse_fn2(x)).sum().backward()
         self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # dense first
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         (dense_fn(x) + sparse_fn1(x) + sparse_fn2(x)).sum().backward()
         self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # sparse only
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         (sparse_fn1(x) + sparse_fn2(x)).sum().backward()
         self.assertEqual(x.grad, sparse_grad1 + sparse_grad2)
 
     def test_multi_backward(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=True)
 
-        q = Variable(torch.randn(5, 5), requires_grad=True)
+        q = torch.randn(5, 5, requires_grad=True)
 
-        a = Variable(torch.randn(5, 5), requires_grad=True)
-        b = Variable(torch.randn(5, 5), requires_grad=True)
+        a = torch.randn(5, 5, requires_grad=True)
+        b = torch.randn(5, 5, requires_grad=True)
 
         q2 = q * 2
         z = x + y + q2
@@ -558,8 +558,8 @@ class TestAutograd(TestCase):
         self.assertEqual(q.grad.data, (grad_c + grad_z) * 2)
 
     def test_multi_backward_no_grad(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=False)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=False)
 
         z = x + y
         q = y * 2
@@ -572,7 +572,7 @@ class TestAutograd(TestCase):
         self.assertRaises(RuntimeError, call_backwards)
 
     def test_dependent_backward(self):
-        x = Variable(torch.randn(10), requires_grad=True)
+        x = torch.randn(10, requires_grad=True)
         y = x ** 2
         z = y ** 3
 
@@ -584,7 +584,7 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, 2 * xd * go_y + 6 * xd.pow(5) * go_z)
 
     def test_save_output_nr(self):
-        x = Variable(torch.randn(10), requires_grad=True)
+        x = torch.randn(10, requires_grad=True)
 
         class MultiOutputFn(Function):
             @staticmethod
@@ -612,7 +612,7 @@ class TestAutograd(TestCase):
         TestFn.apply(b).sum().backward()
 
     def test_no_grad(self):
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
         y = Variable(torch.ones(5, 5) * 4)
         with torch.no_grad():
             w = x + y
@@ -622,7 +622,7 @@ class TestAutograd(TestCase):
 
     def test_no_grad_python_function(self):
         """Python Functions should respect grad mode."""
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
 
         class MyOp(Function):
             @staticmethod
@@ -643,7 +643,7 @@ class TestAutograd(TestCase):
 
         def compare(x, y, idx, indexed_tensor, indexed_var):
             indexed_var_t = indexed_var.data
-            if not torch.is_tensor(indexed_tensor):
+            if not isinstance(indexed_tensor, torch.Tensor):
                 indexed_var_t = indexed_var_t[0]
             self.assertEqual(indexed_tensor, indexed_var_t)
 
@@ -760,7 +760,7 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, expected_grad)
 
     def test_volatile_deprecated(self):
-        v = torch.autograd.Variable(torch.randn(3, 3))
+        v = torch.autograd.torch.randn(3, 3)
         with warnings.catch_warnings(record=True) as w:
             self.assertFalse(v.volatile)
         self.assertIn('volatile', str(w[0].message))
@@ -792,9 +792,9 @@ class TestAutograd(TestCase):
             self.assertTrue(has_deprecated)
 
     def test_requires_grad(self):
-        x = Variable(torch.randn(5, 5))
-        y = Variable(torch.randn(5, 5))
-        z = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5)
+        y = torch.randn(5, 5)
+        z = torch.randn(5, 5, requires_grad=True)
         a = x + y
         self.assertFalse(a.requires_grad)
         b = a + z
@@ -812,27 +812,27 @@ class TestAutograd(TestCase):
         b.backward(torch.ones(5, 5))
 
     def test_requires_grad_inplace(self):
-        a = Variable(torch.randn(5, 5))
-        b = Variable(torch.randn(5, 5), requires_grad=True)
+        a = torch.randn(5, 5)
+        b = torch.randn(5, 5, requires_grad=True)
         a += b
         self.assertTrue(a.requires_grad)
 
         # non-leaf Variable
-        a = Variable(torch.randn(5, 5)) + 0
-        b = Variable(torch.randn(5, 5), requires_grad=True)
+        a = torch.randn(5, 5) + 0
+        b = torch.randn(5, 5, requires_grad=True)
         a += b
         self.assertTrue(a.requires_grad)
 
     def test_no_requires_grad_inplace(self):
         # basic case, should be able to modify inplace while requires_grad is False
-        a = Variable(torch.randn(2, 3))
+        a = torch.randn(2, 3)
         a.add_(5)
         a.requires_grad = True
         a.sum().backward()
         self.assertEqual(a.grad.data, torch.ones(2, 3))
 
         # same but with a view
-        a = Variable(torch.randn(2, 3))
+        a = torch.randn(2, 3)
         b = a[:]
         b.add_(5)
         a.requires_grad = True
@@ -840,7 +840,7 @@ class TestAutograd(TestCase):
         self.assertEqual(a.grad.data, torch.ones(2, 3))
 
         # should fail if requires_grad = True when we modify inplace
-        a = Variable(torch.randn(2, 3))
+        a = torch.randn(2, 3)
         b = a[:]
         a.requires_grad = True
         with self.assertRaises(RuntimeError):
@@ -849,7 +849,7 @@ class TestAutograd(TestCase):
             b.add_(5)
 
     def test_requires_grad_factory(self):
-        x = Variable(torch.randn(2, 3))
+        x = torch.randn(2, 3)
         fns = [torch.ones_like, torch.testing.randn_like]
         dtypes = [torch.float32, torch.float64]
         for fn in fns:
@@ -867,12 +867,12 @@ class TestAutograd(TestCase):
                             self.assertEqual(1, output.get_device())
 
     def test_grad_assignment(self):
-        x = Variable(torch.randn(5, 5))
-        a = Variable(torch.randn(2, 2))  # size mismatch
+        x = torch.randn(5, 5)
+        a = torch.randn(2, 2)  # size mismatch
         b = Variable(torch.randn(5, 5).long())  # type mismatch
 
         with self.assertRaises(RuntimeError):
-            x.grad = Variable(torch.randn(2, 2))
+            x.grad = torch.randn(2, 2)
         with self.assertRaises(RuntimeError):
             x.grad = Variable(torch.randn(5, 5).long())
         with self.assertRaises(RuntimeError):
@@ -890,25 +890,25 @@ class TestAutograd(TestCase):
             x.grad = Variable(torch.randn(5, 5).cuda(1))
 
     def test_duplicate_backward_root(self):
-        a = Variable(torch.randn(5, 5), requires_grad=True)
-        b = Variable(torch.randn(5, 5), requires_grad=True)
+        a = torch.randn(5, 5, requires_grad=True)
+        b = torch.randn(5, 5, requires_grad=True)
 
         x = a * b
-        grad_output = x.data.clone().normal_()
+        grad_output = torch.randn_like(x)
         torch.autograd.backward([x, x], [grad_output, grad_output])
 
         self.assertEqual(a.grad.data, b.data * grad_output * 2)
         self.assertEqual(b.grad.data, a.data * grad_output * 2)
 
     def test_backward_no_grad(self):
-        a = Variable(torch.randn(5, 5), requires_grad=True)
+        a = torch.randn(5, 5, requires_grad=True)
         b = a + 2
         with self.assertRaises(RuntimeError):
             torch.autograd.backward([b], [None])
 
     def test_next_functions(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=True)
 
         a = x + y
         self.assertIsNotNone(a.grad_fn)
@@ -925,7 +925,7 @@ class TestAutograd(TestCase):
         self.assertIs(next_functions[0][0], a.grad_fn)
 
     def test_inplace(self):
-        x = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
         y = Variable(torch.ones(5, 5) * 4, requires_grad=True)
 
         z = x * y
@@ -962,7 +962,7 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, torch.Tensor(5, 5).fill_((1 + math.e) / 2))
         self.assertRaises(RuntimeError, lambda: q.backward(torch.ones(5, 5)))
 
-        leaf = Variable(torch.ones(5, 5), requires_grad=True)
+        leaf = torch.ones(5, 5, requires_grad=True)
         x = leaf.clone()
         x.add_(10)
         self.assertEqual(x.data, torch.ones(5, 5) * 11)
@@ -986,7 +986,7 @@ class TestAutograd(TestCase):
             def backward(ctx, grad_output):
                 return (grad_output * 0).type(torch.DoubleTensor)
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         mask = MyFunction.apply(x)
         self.assertFalse(mask.requires_grad)
         y = x.masked_fill(mask, 0)
@@ -1007,7 +1007,7 @@ class TestAutograd(TestCase):
                 self.assertTrue((grad_b == 1).all())
                 return grad_b
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         a, b = MyFunction.apply(x)
         self.assertFalse(a.requires_grad)
         self.assertTrue(b.requires_grad)
@@ -1029,7 +1029,7 @@ class TestAutograd(TestCase):
             def backward(ctx, grad_output):
                 return None
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         r = MyFunction.apply(x * x)
         (r * x).sum().backward()
 
@@ -1049,7 +1049,7 @@ class TestAutograd(TestCase):
             self.assertIs(a, b)
             return a + b
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         gradcheck(fn, [x])
         gradgradcheck(fn, [x])
 
@@ -1070,7 +1070,7 @@ class TestAutograd(TestCase):
             self.assertIs(a, b)
             return a + b
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         gradcheck(inplace_fn, [x])
         gradgradcheck(inplace_fn, [x])
 
@@ -1081,24 +1081,22 @@ class TestAutograd(TestCase):
 
     @suppress_warnings
     def test_resize(self):
-        x = Variable(torch.ones(2, 3))
+        x = torch.ones(2, 3)
         self.assertTrue(x.resize(3, 2).size() == (3, 2))
 
     def _test_setitem(self, size, index):
-        x = Variable(torch.ones(*size), requires_grad=True)
+        x = torch.ones(*size, requires_grad=True)
         y = x + 2
         y_version = y._version
         y[index] = 2
         self.assertNotEqual(y._version, y_version)
         y.backward(torch.ones(*size))
         expected_grad = torch.ones(*size)
-        if isinstance(index, Variable):
-            index = index.data
         expected_grad[index] = 0
-        self.assertEqual(x.grad.data, expected_grad)
+        self.assertEqual(x.grad, expected_grad)
 
     def _test_setitem_tensor(self, size, index):
-        x = Variable(torch.ones(*size), requires_grad=True)
+        x = torch.ones(*size, requires_grad=True)
         y = x + 2
         y_version = y._version
         value = x.new(x[index].size()).fill_(7)
@@ -1107,27 +1105,13 @@ class TestAutograd(TestCase):
         self.assertNotEqual(y._version, y_version)
         y.backward(torch.ones(*size))
         expected_grad_input = torch.ones(*size)
-
-        # remove all variables when indexing a Tensor for comparison,
-        # whether a top-level Variable or in a sequence
-        if isinstance(index, Variable):
-            index = index.data
-        elif isinstance(index, list):
-            novars = []
-            for i in index:
-                if isinstance(i, Variable):
-                    novars.append(i.data)
-                else:
-                    novars.append(i)
-            index = novars
-
         expected_grad_input[index] = 0
-        self.assertEqual(x.grad.data, expected_grad_input)
-        self.assertEqual(value.grad.data, torch.ones(value.data.size()))
+        self.assertEqual(x.grad, expected_grad_input)
+        self.assertEqual(value.grad, torch.ones_like(value))
 
         # case when x broadcasts to as y[1]
-        x = Variable(torch.randn(4), requires_grad=True)
-        y = Variable(torch.zeros(2, 3, 4))
+        x = torch.randn(4, requires_grad=True)
+        y = torch.zeros(2, 3, 4)
         y[1] = x
         y.backward(torch.randn(2, 3, 4))
         self.assertEqual(x.size(), x.grad.size())
@@ -1166,7 +1150,7 @@ class TestAutograd(TestCase):
 
     def test_select_sum(self):
         # both select and sum return Scalars in ATen; ensure they work together.
-        x = Variable(torch.randn(10), requires_grad=True)
+        x = torch.randn(10, requires_grad=True)
 
         def func(x):
             return x.select(0, 1).sum()
@@ -1175,9 +1159,9 @@ class TestAutograd(TestCase):
         gradgradcheck(func, [x])
 
     def test_stack(self):
-        x = Variable(torch.randn(10, 10), requires_grad=True)
-        y = Variable(torch.randn(10, 10), requires_grad=True)
-        z = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
+        y = torch.randn(10, 10, requires_grad=True)
+        z = torch.randn(10, 10, requires_grad=True)
         stacked = torch.stack([x, y, z], 0)
         grad = torch.randn(3, 10, 10)
         stacked.backward(grad)
@@ -1186,8 +1170,8 @@ class TestAutograd(TestCase):
         self.assertEqual(z.grad.data, grad[2])
 
     def test_put(self):
-        root = Variable(torch.randn(4, 5), requires_grad=True)
-        values = Variable(torch.randn(6), requires_grad=True)
+        root = torch.randn(4, 5, requires_grad=True)
+        values = torch.randn(6, requires_grad=True)
         idx = Variable(torch.LongTensor([1, 2, 3, -1, -2, -3]))
 
         def func(root, values):
@@ -1199,8 +1183,8 @@ class TestAutograd(TestCase):
         gradgradcheck(func, [root, values])
 
     def test_put_accumulate(self):
-        root = Variable(torch.randn(4, 5), requires_grad=True)
-        values = Variable(torch.randn(6), requires_grad=True)
+        root = torch.randn(4, 5, requires_grad=True)
+        values = torch.randn(6, requires_grad=True)
         idx = Variable(torch.LongTensor([1, 2, 3, 1, 2, 3]))
 
         def func(root, values):
@@ -1212,7 +1196,7 @@ class TestAutograd(TestCase):
         gradgradcheck(func, [root, values])
 
     def test_fill(self):
-        root = Variable(torch.randn(4, 5), requires_grad=True)
+        root = torch.randn(4, 5, requires_grad=True)
 
         def func(root):
             x = root.clone()
@@ -1223,7 +1207,7 @@ class TestAutograd(TestCase):
         gradgradcheck(func, [root])
 
     def test_unused_output(self):
-        x = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
         outputs = x.chunk(5)
         o = outputs[2]
         o = o * 4 + 2
@@ -1283,14 +1267,14 @@ class TestAutograd(TestCase):
         self.assertEqual(device[0], 1)
 
     def test_detach(self):
-        x = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
         y = x + 2
         y = y.detach()
         z = y * 4 + 2
         self.assertFalse(y.requires_grad)
         self.assertFalse(z.requires_grad)
 
-        x = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
         y = x * 2
         y = y.detach()
         self.assertFalse(y.requires_grad)
@@ -1302,8 +1286,8 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, torch.ones(10, 10))
 
         # in-place detach
-        x = Variable(torch.randn(10, 10), requires_grad=True)
-        y = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
+        y = torch.randn(10, 10, requires_grad=True)
         a = x * 2
         (y + a).sum().backward(retain_graph=True)
         a.detach_()
@@ -1318,7 +1302,7 @@ class TestAutograd(TestCase):
 
     def test_detach_base(self):
         "detaching base does not detach view"
-        x = Variable(torch.randn(10, 10), requires_grad=True)
+        x = torch.randn(10, 10, requires_grad=True)
         view = x.narrow(0, 1, 4)
         x.detach_()
         self.assertFalse(x.requires_grad)
@@ -1337,22 +1321,22 @@ class TestAutograd(TestCase):
         self.assertEqual(type(dvar.grad.data), type(dvar.data))
 
     def test_type_conversions(self):
-        x = Variable(torch.randn(5, 5))
-        self.assertIsInstance(x.float().data, torch.FloatTensor)
-        self.assertIsInstance(x.int().data, torch.IntTensor)
+        x = torch.randn(5, 5)
+        self.assertIsInstance(x.float(), torch.FloatTensor)
+        self.assertIsInstance(x.int(), torch.IntTensor)
         if torch.cuda.is_available():
-            self.assertIsInstance(x.float().cuda().data, torch.cuda.FloatTensor)
-            self.assertIsInstance(x.int().cuda().data, torch.cuda.IntTensor)
-            self.assertIsInstance(x.int().cuda().cpu().data, torch.IntTensor)
+            self.assertIsInstance(x.float().cuda(), torch.cuda.FloatTensor)
+            self.assertIsInstance(x.int().cuda(), torch.cuda.IntTensor)
+            self.assertIsInstance(x.int().cuda().cpu(), torch.IntTensor)
             if torch.cuda.device_count() >= 2:
                 x2 = x.float().cuda(1)
-                self.assertIsInstance(x2.data, torch.cuda.FloatTensor)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
                 x2 = x.float().cuda()
                 self.assertIsInstance(x2.data, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 0)
                 x2 = x2.cuda(1)
-                self.assertIsInstance(x2.data, torch.cuda.FloatTensor)
+                self.assertIsInstance(x2, torch.cuda.FloatTensor)
                 self.assertIs(x2.get_device(), 1)
                 y = Variable(torch.randn(5).cuda(1), requires_grad=True)
                 y.cpu().sum().backward()
@@ -1361,13 +1345,13 @@ class TestAutograd(TestCase):
 
         for t in [torch.DoubleTensor, torch.FloatTensor, torch.IntTensor, torch.ByteTensor]:
             for y_var in (True, False):
-                y = torch.randn(5, 5).type(t)
+                y = torch.randint(5, (5, 5), dtype=t.dtype)
                 y = Variable(y) if y_var else y
-                self.assertIsInstance(x.type(t).data, t)
-                self.assertIsInstance(x.type_as(y).data, t)
+                self.assertIsInstance(x.type(t), t)
+                self.assertIsInstance(x.type_as(y), t)
                 # TODO: t.dtype should work
                 t_dtype = t().dtype
-                self.assertIsInstance(x.type(t_dtype).data, t)
+                self.assertIsInstance(x.type(t_dtype), t)
                 self.assertIs(t_dtype, x.type(t_dtype).dtype)
                 self.assertEqual(y.data_ptr(), y.type(t).data_ptr())
                 if torch.cuda.is_available():
@@ -1391,7 +1375,7 @@ class TestAutograd(TestCase):
 
     def _test_pyscalar_conversions(self, t, integral_conv):
         # integral -> integral
-        l = Variable(t(torch.zeros(1, 1, 1).long()))
+        l = t(torch.zeros(1, 1, 1, dtype=torch.long))
         pyscalar = -12345
         l[0] = pyscalar
         self.assertEqual(integral_conv(l), pyscalar)
@@ -1450,7 +1434,7 @@ class TestAutograd(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
     def test_pin_memory(self):
-        x = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.randn(2, 2, requires_grad=True)
         self.assertEqual(x, x.pin_memory())
         self.assertIsNot(x, x.pin_memory())
         self.assertTrue(x.pin_memory().requires_grad)
@@ -1458,8 +1442,8 @@ class TestAutograd(TestCase):
         gradgradcheck(lambda x: x.pin_memory(), [x])
 
     def test_isolated_node(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=True)
 
         a = x + y
         b = torch.max(a, 1, True)[1].repeat(1, 5).double()
@@ -1467,13 +1451,13 @@ class TestAutograd(TestCase):
         o.backward()
 
     def test_shape(self):
-        x = Variable(torch.randn(3, 4))
+        x = torch.randn(3, 4)
         self.assertEqual(2, len(x.shape))
         self.assertEqual(x.shape[0], 3)
         self.assertEqual(x.shape[1], 4)
 
     def test_numpy_requires_grad(self):
-        x = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.randn(2, 2, requires_grad=True)
         self.assertRaisesRegex(RuntimeError, 'requires grad', lambda: x.numpy())
 
     def test_return_leaf(self):
@@ -1486,8 +1470,8 @@ class TestAutograd(TestCase):
                 return grad_a + grad_b, grad_b
 
         hook_called = [False]
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5, 5, requires_grad=True)
 
         q, p = Identity()(x, y)
 
@@ -1512,8 +1496,8 @@ class TestAutograd(TestCase):
             def backward(self, grad_a, grad_b):
                 return grad_a, grad_a + grad_b
 
-        x = Variable(torch.randn(5, 5))
-        y = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5)
+        y = torch.randn(5, 5, requires_grad=True)
 
         fn = Inplace(True)
         q, p = fn(x, y)
@@ -1524,9 +1508,9 @@ class TestAutograd(TestCase):
         self.assertEqual(y.grad.data, torch.ones(5, 5))
 
     def test_leaf_assignment(self):
-        x = Variable(torch.randn(5, 5))
-        y = Variable(torch.randn(5), requires_grad=True)
-        z = Variable(torch.randn(5), requires_grad=True)
+        x = torch.randn(5, 5)
+        y = torch.randn(5, requires_grad=True)
+        z = torch.randn(5, requires_grad=True)
 
         x[0] = y
         x[1] = 2 * z
@@ -1537,8 +1521,8 @@ class TestAutograd(TestCase):
         self.assertEqual(z.grad.data, torch.ones(5) * 2)
 
     def test_no_grad_assignment(self):
-        x = Variable(torch.randn(5, 5), requires_grad=True)
-        y = Variable(torch.randn(5))
+        x = torch.randn(5, 5, requires_grad=True)
+        y = torch.randn(5)
         with torch.no_grad():
             x[0] = y
 
@@ -1546,8 +1530,8 @@ class TestAutograd(TestCase):
         self.assertIsNone(x.grad_fn)
 
     def test_no_grad_modifies_version(self):
-        x = Variable(torch.randn(5), requires_grad=True)
-        y = Variable(torch.randn(5), requires_grad=True)
+        x = torch.randn(5, requires_grad=True)
+        y = torch.randn(5, requires_grad=True)
         z = (x * y).sum()
         with torch.no_grad():
             x *= 2
@@ -1589,8 +1573,8 @@ class TestAutograd(TestCase):
         # 3. When accumulating in the third place, it wasn't in the need_copy set
         #    as well, so the incoming gradient was summed in-place, yielding
         #    incorrect results in all functions, except the first one.
-        x = Variable(torch.ones(5, 5), requires_grad=True)
-        y = Variable(torch.ones(5, 5), requires_grad=True)
+        x = torch.ones(5, 5, requires_grad=True)
+        y = torch.ones(5, 5, requires_grad=True)
         # Simulate that we're in the middle of the graph
         a = x + 2
         b = y + 2
@@ -1610,57 +1594,8 @@ class TestAutograd(TestCase):
         # for y: 17 (16 from final b, 1 from add2)
         grad_output = torch.ones(5, 5)
         out.backward(grad_output)
-        self.assertEqual(x.grad.data, torch.ones(5, 5) * 34)
-        self.assertEqual(y.grad.data, torch.ones(5, 5) * 17)
-
-    def test_functional_blas(self):
-        def compare(fn, *args):
-            unpacked_args = tuple(arg.data if isinstance(arg, Variable) else arg
-                                  for arg in args)
-            unpacked_result = fn(*unpacked_args)
-            packed_result = fn(*args).data
-            # if non-Variable torch function returns a pyscalar, compare to pyscalar
-            if not torch.is_tensor(unpacked_result):
-                assert packed_result.dim() == 1
-                assert packed_result.nelement() == 1
-                packed_result = packed_result[0]
-            self.assertEqual(packed_result, unpacked_result)
-
-        def test_blas_add(fn, x, y, z):
-            # Checks all signatures
-            compare(fn, x, y, z)
-            compare(fn, 0.5, x, y, z)
-            compare(fn, 0.5, x, 0.25, y, z)
-
-        def test_blas(fn, x, y):
-            compare(fn, x, y)
-
-        test_blas(torch.mm, Variable(torch.randn(2, 10)),
-                  Variable(torch.randn(10, 4)))
-        test_blas_add(torch.addmm, Variable(torch.randn(2, 4)),
-                      Variable(torch.randn(2, 10)), Variable(torch.randn(10, 4)))
-        test_blas(torch.bmm, Variable(torch.randn(4, 2, 10)),
-                  Variable(torch.randn(4, 10, 4)))
-        test_blas_add(torch.addbmm, Variable(torch.randn(2, 4)),
-                      Variable(torch.randn(4, 2, 10)), Variable(torch.randn(4, 10, 4)))
-        test_blas_add(torch.baddbmm, Variable(torch.randn(4, 2, 4)),
-                      Variable(torch.randn(4, 2, 10)), Variable(torch.randn(4, 10, 4)))
-        test_blas(torch.mv, Variable(torch.randn(2, 10)),
-                  Variable(torch.randn(10)))
-        test_blas_add(torch.addmv, Variable(torch.randn(2)),
-                      Variable(torch.randn(2, 10)), Variable(torch.randn(10)))
-        test_blas(torch.ger, Variable(torch.randn(5)),
-                  Variable(torch.randn(6)))
-        test_blas_add(torch.addr, Variable(torch.randn(5, 6)),
-                      Variable(torch.randn(5)), Variable(torch.randn(6)))
-        test_blas(torch.matmul, Variable(torch.randn(6)), Variable(torch.randn(6)))
-        test_blas(torch.matmul, Variable(torch.randn(10, 4)), Variable(torch.randn(4)))
-        test_blas(torch.matmul, Variable(torch.randn(5)), Variable(torch.randn(5, 6)))
-        test_blas(torch.matmul, Variable(torch.randn(2, 10)), Variable(torch.randn(10, 4)))
-        test_blas(torch.matmul, Variable(torch.randn(5, 2, 10)), Variable(torch.randn(5, 10, 4)))
-        test_blas(torch.matmul, Variable(torch.randn(3, 5, 2, 10)), Variable(torch.randn(3, 5, 10, 4)))
-        test_blas(torch.matmul, Variable(torch.randn(3, 5, 2, 10)), Variable(torch.randn(10)))
-        test_blas(torch.matmul, Variable(torch.randn(10)), Variable(torch.randn(3, 5, 10, 4)))
+        self.assertEqual(x.grad, torch.ones(5, 5) * 34)
+        self.assertEqual(y.grad, torch.ones(5, 5) * 17)
 
     def test_save_none_for_backward(self):
         test_case = self
@@ -1677,10 +1612,10 @@ class TestAutograd(TestCase):
                 test_case.assertIsNone(n2)
                 return 2 * input * grad_output
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         y = MyFn()(x)
         y.sum().backward()
-        self.assertEqual(x.grad.data, 2 * x.data)
+        self.assertEqual(x.grad, 2 * x)
 
     def test_too_many_grads(self):
         class MyFn(Function):
@@ -1691,14 +1626,14 @@ class TestAutograd(TestCase):
             def backward(self, grad_output):
                 return grad_output, None, None
 
-        x = Variable(torch.randn(5, 5), requires_grad=True)
+        x = torch.randn(5, 5, requires_grad=True)
         y = MyFn()(x)
         y.sum().backward()
-        self.assertEqual(x.grad.data, x.data.clone().fill_(1))
+        self.assertEqual(x.grad, torch.ones_like(x))
 
     def test_pickle(self):
-        x = Variable(torch.randn(10, 10), requires_grad=True)
-        y = Variable(torch.randn(10, 10), requires_grad=False)
+        x = torch.randn(10, 10, requires_grad=True)
+        y = torch.randn(10, 10, requires_grad=False)
 
         def assert_strict_equal(var1, var2):
             self.assertEqual(var1.data, var2.data)
@@ -1714,7 +1649,7 @@ class TestAutograd(TestCase):
         class F1(Function):
 
             def forward(self, input):
-                out = Variable(torch.randn(input.size()))
+                out = torch.randn(input.size())
                 self.mark_non_differentiable(out)
                 return input, out
 
@@ -1729,7 +1664,7 @@ class TestAutograd(TestCase):
             def backward(self, grad_output):
                 return grad_output, None
 
-        x = Variable(torch.randn(5), requires_grad=True)
+        x = torch.randn(5, requires_grad=True)
         a, b = F1()(x)
         b = b + 1  # separate F1 from F2 by another op
         self.assertTrue(a.requires_grad)
@@ -1769,15 +1704,15 @@ class TestAutograd(TestCase):
                     ctx.output_var.sum().backward()
                 return ctx.x.grad * grad_output
 
-        x = Variable(torch.randn(2, 2), requires_grad=True)
+        x = torch.randn(2, 2, requires_grad=True)
         out = Reenter.apply(x)
         out.sum().backward()
         self.assertEqual(x.grad.data, y_data)
 
     def test_cat(self):
-        f_args_variable = (Variable(torch.randn(1, S, S), requires_grad=True),
-                           Variable(torch.randn(2, S, S), requires_grad=True),
-                           Variable(torch.randn(3, S, S), requires_grad=True),
+        f_args_variable = (torch.randn(1, S, S, requires_grad=True),
+                           torch.randn(2, S, S, requires_grad=True),
+                           torch.randn(3, S, S, requires_grad=True),
                            0)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
         run_functional_checks(self, "test_cat", "cat",
@@ -1785,9 +1720,9 @@ class TestAutograd(TestCase):
                               True, f_args_variable, f_args_tensor)
 
     def test_cat_negdim_1(self):
-        f_args_variable = (Variable(torch.randn(S, S, 1), requires_grad=True),
-                           Variable(torch.randn(S, S, 2), requires_grad=True),
-                           Variable(torch.randn(S, S, 3), requires_grad=True),
+        f_args_variable = (torch.randn(S, S, 1, requires_grad=True),
+                           torch.randn(S, S, 2, requires_grad=True),
+                           torch.randn(S, S, 3, requires_grad=True),
                            -1)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
         run_functional_checks(self, "test_cat_negdim_1", "cat",
@@ -1795,9 +1730,9 @@ class TestAutograd(TestCase):
                               True, f_args_variable, f_args_tensor)
 
     def test_cat_negdim_2(self):
-        f_args_variable = (Variable(torch.randn(S, 1, S), requires_grad=True),
-                           Variable(torch.randn(S, 2, S), requires_grad=True),
-                           Variable(torch.randn(S, 3, S), requires_grad=True),
+        f_args_variable = (torch.randn(S, 1, S, requires_grad=True),
+                           torch.randn(S, 2, S, requires_grad=True),
+                           torch.randn(S, 3, S, requires_grad=True),
                            -2)
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
         run_functional_checks(self, "test_cat_negdim_2", "cat",
@@ -1805,8 +1740,8 @@ class TestAutograd(TestCase):
                               True, f_args_variable, f_args_tensor)
 
     def test_cat_empty(self):
-        f_args_variable = (Variable(torch.randn(0), requires_grad=True),
-                           Variable(torch.randn(S, S), requires_grad=True))
+        f_args_variable = (torch.randn(0, requires_grad=True),
+                           torch.randn(S, S, requires_grad=True))
         # gradgradcheck doesn't work (because gradcheck doesn't work for empty outputs?)
         # hence False passed below, but gradcheck checked explicitly.
         f_args_tensor = deepcopy(unpack_variables(f_args_variable))
@@ -1833,8 +1768,8 @@ class TestAutograd(TestCase):
     @skipIfNoLapack
     def test_trtrs(self):
         def _test_with_size(N, C):
-            A = Variable(torch.rand(N, N), requires_grad=True)
-            b = Variable(torch.rand(N, C), requires_grad=True)
+            A = torch.rand(N, N, requires_grad=True)
+            b = torch.rand(N, C, requires_grad=True)
 
             for upper, transpose, unitriangular in product((True, False), repeat=3):
                 def func(A, b):
@@ -1936,7 +1871,7 @@ class TestAutograd(TestCase):
 
     def test_variable_traverse(self):
         def get_out_and_unrefed_cycle():
-            inp = Variable(torch.randn(10), requires_grad=True)
+            inp = torch.randn(10, requires_grad=True)
             tmp = inp.view(10, 1)
             out = tmp.view(10)
 
@@ -1955,7 +1890,7 @@ class TestAutograd(TestCase):
 
     def test_norm_subgradient(self):
         def run_test(input_size, norm_deg):
-            input = Variable(torch.zeros(*input_size), requires_grad=True)
+            input = torch.zeros(*input_size, requires_grad=True)
             input.norm(norm_deg).backward()
             self.assertEqual(input.grad.data.abs().sum(), 0)
 
@@ -1966,7 +1901,7 @@ class TestAutograd(TestCase):
         run_test((10,), 1.5)
 
     def test_profiler(self):
-        x = Variable(torch.randn(10, 10))
+        x = torch.randn(10, 10)
 
         with profile() as p:
             y = x * 2 + 4
@@ -1980,7 +1915,7 @@ class TestAutograd(TestCase):
             last_end = info.cpu_interval.end
 
     def test_dir(self):
-        x = Variable(torch.randn(10, 10))
+        x = torch.randn(10, 10)
         keys = dir(x)
         self.assertIn('shape', keys)
 
@@ -1994,7 +1929,7 @@ class TestAutograd(TestCase):
             return x.as_strided([3, 3], [6, 2], 2)
 
         gradcheck(as_strided, [x], raise_exception=True)
-        gradgradcheck(as_strided, [x], [Variable(torch.randn(3, 3))])
+        gradgradcheck(as_strided, [x], [torch.randn(3, 3)])
 
     def _test_where_functional(self, t):
         x = Variable(t(torch.randn(5, 5)), requires_grad=True)
@@ -2021,7 +1956,7 @@ class TestAutograd(TestCase):
 
     def test_inplace_view_backprop_base(self):
         # modify view and back-prop through base
-        root = Variable(torch.randn(2, 2), requires_grad=True)
+        root = torch.randn(2, 2, requires_grad=True)
         x = root.clone()
         v1 = x.narrow(0, 0, 1)
         v1.mul_(2)
@@ -2030,7 +1965,7 @@ class TestAutograd(TestCase):
 
     def test_inplace_view_backprop_view_of_view(self):
         # modify view and backprop through view-of-view
-        root = Variable(torch.randn(2, 2), requires_grad=True)
+        root = torch.randn(2, 2, requires_grad=True)
         x = root.clone()
         v1 = x.narrow(0, 0, 1)
         v2 = x.narrow(0, 0, 1)
@@ -2040,7 +1975,7 @@ class TestAutograd(TestCase):
 
     def test_inplace_view_of_view(self):
         # modify view-of-view and backprop through base
-        root = Variable(torch.randn(2, 2), requires_grad=True)
+        root = torch.randn(2, 2, requires_grad=True)
         x = root.clone()
         v1 = x.narrow(0, 0, 1)
         v2 = v1.narrow(1, 1, 1)
@@ -2050,8 +1985,8 @@ class TestAutograd(TestCase):
 
     def test_inplace_view_gradcheck(self):
         # gradcheck modifications to views
-        a = Variable(torch.randn(4, 4), requires_grad=True)
-        b = Variable(torch.randn(2, 2), requires_grad=True)
+        a = torch.randn(4, 4, requires_grad=True)
+        b = torch.randn(2, 2, requires_grad=True)
 
         def func(root, b):
             x = root.clone()
@@ -2060,13 +1995,13 @@ class TestAutograd(TestCase):
             return x
 
         gradcheck(func, [a, b], raise_exception=True)
-        go = Variable(torch.randn(a.size()), requires_grad=True)
+        go = torch.randn(a.size(), requires_grad=True)
         gradgradcheck(func, (a, b), (go,))
 
     def test_inplace_view_makes_base_require_grad(self):
         # in-place modification to view makes base require grad
-        a = Variable(torch.randn(4, 4), requires_grad=False)
-        b = Variable(torch.randn(4, 2), requires_grad=True)
+        a = torch.randn(4, 4, requires_grad=False)
+        b = torch.randn(4, 2, requires_grad=True)
 
         def func(root, b):
             x = root.clone()
@@ -2076,7 +2011,7 @@ class TestAutograd(TestCase):
             return x
 
         gradcheck(func, [a, b], raise_exception=True)
-        go = Variable(torch.randn(a.size()), requires_grad=True)
+        go = torch.randn(a.size(), requires_grad=True)
         gradgradcheck(func, (a, b), (go,))
 
     def test_inplace_view_backprop_view(self):
@@ -2092,10 +2027,10 @@ class TestAutograd(TestCase):
         # Test that an in-place operation on a base that forced it to require
         # grad also forces any previous views to require grad and backprop
         # correctly
-        r = Variable(torch.ones(1), requires_grad=True)
+        r = torch.ones(1, requires_grad=True)
 
         def fn(r):
-            x = Variable(torch.ones(5))
+            x = torch.ones(5)
             v = x.select(0, 1)
             self.assertFalse(v.requires_grad)
             self.assertIsNone(v.grad_fn)
@@ -2108,8 +2043,8 @@ class TestAutograd(TestCase):
 
     def test_inplace_view_python(self):
         # in-place modifications of Python-autograd created view
-        a = Variable(torch.randn(4, 4), requires_grad=True)
-        b = Variable(torch.randn(2, 2), requires_grad=True)
+        a = torch.randn(4, 4, requires_grad=True)
+        b = torch.randn(2, 2, requires_grad=True)
 
         class PyAdd(torch.autograd.Function):
             @staticmethod
@@ -2129,7 +2064,7 @@ class TestAutograd(TestCase):
             return x
 
         gradcheck(func, [a, b], raise_exception=True)
-        go = Variable(torch.randn(a.size()), requires_grad=True)
+        go = torch.randn(a.size(), requires_grad=True)
         gradgradcheck(func, (a, b), (go,))
 
     def test_inplace_view_non_contig(self):
@@ -2152,7 +2087,7 @@ class TestAutograd(TestCase):
                 dealloc[0] += 1
 
         def test():
-            root = Variable(torch.randn(3, 3), requires_grad=True)
+            root = torch.randn(3, 3, requires_grad=True)
             copy = root.clone()
             copy.grad_fn.register_hook(IncrementOnDelete())
             view = copy.view(9)
@@ -2162,8 +2097,8 @@ class TestAutograd(TestCase):
         self.assertEqual(dealloc[0], 1)
 
     def test_mul_out(self):
-        a = Variable(torch.randn(2, 2), requires_grad=True)
-        b = Variable(torch.randn(2, 2), requires_grad=True)
+        a = torch.randn(2, 2, requires_grad=True)
+        b = torch.randn(2, 2, requires_grad=True)
         x = torch.zeros_like(a)
 
         # out=... functions don't support automatic differentiation currently
@@ -2175,9 +2110,9 @@ class TestAutograd(TestCase):
             self.assertEqual(x, a * b)
 
     def test_mul_out_result_requires_grad(self):
-        a = Variable(torch.randn(2, 2))
-        b = Variable(torch.randn(2, 2))
-        x = Variable(torch.zeros(2, 2), requires_grad=True)
+        a = torch.randn(2, 2)
+        b = torch.randn(2, 2)
+        x = torch.zeros(2, 2, requires_grad=True)
         # we should throw an exception if the output requires grad
         self.assertRaisesRegex(RuntimeError, 'out=', lambda: torch.mul(a, b, out=x))
 
@@ -2282,13 +2217,13 @@ def random_fullrank_matrix_distinct_singular_value(l):
 
 
 def uniform_scalar(offset=0, requires_grad=False):
-    v = torch.tensor(0.).uniform_(0, 1) + offset
+    v = torch.rand(()) + offset
     v.requires_grad = requires_grad
     return v
 
 
 def normal_scalar_clamp(amin, amax, requires_grad=False):
-    v = torch.tensor(0.).normal_().clamp(amin, amax)
+    v = torch.randn(()).clamp(amin, amax)
     v.requires_grad = requires_grad
     return v
 
@@ -2909,18 +2844,17 @@ def create_input(call_args, requires_grad=True, non_contiguous=False):
         if isinstance(arg, torch.Size) or isinstance(arg, dont_convert):
             return arg
         elif isinstance(arg, tuple) and len(arg) == 0:
-            var = torch.tensor(1).double().normal_()
+            var = torch.randn((), dtype=torch.double)
             var.requires_grad = requires_grad
             return var
-        elif isinstance(arg, tuple) and not isinstance(arg[0], Variable):
-            assert not torch.is_tensor(arg[0])
-            return Variable(maybe_non_contig(torch.randn(*arg).double()), requires_grad=requires_grad)
+        elif isinstance(arg, tuple) and not isinstance(arg[0], torch.Tensor):
+            return Variable(maybe_non_contig(torch.randn(*arg, dtype=torch.double)), requires_grad=requires_grad)
         elif isinstance(arg, non_differentiable):
-            if isinstance(arg.tensor, Variable):
+            if isinstance(arg.tensor, torch.Tensor):
                 return maybe_non_contig(arg.tensor)
-            return Variable(maybe_non_contig(arg.tensor))
+            return maybe_non_contig(arg.tensor)
         elif isinstance(arg, torch.Tensor):
-            if isinstance(arg, torch.FloatTensor):
+            if arg.dtype == torch.float:
                 arg = arg.double()
             v = maybe_non_contig(arg).detach()
             v.requires_grad = requires_grad and v.is_floating_point()
@@ -2933,9 +2867,7 @@ def create_input(call_args, requires_grad=True, non_contiguous=False):
 
 
 def unpack_variables(args):
-    if isinstance(args, Variable):
-        return args.data
-    elif isinstance(args, tuple):
+    if isinstance(args, tuple):
         return tuple(unpack_variables(elem) for elem in args)
     else:
         return args
@@ -3058,7 +2990,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
                                      output_variable, f_args_variable)
 
     self_variable = f_args_variable[0]
-    if isinstance(output_variable, Variable) and output_variable.requires_grad and self_variable is not None:
+    if isinstance(output_variable, torch.Tensor) and output_variable.requires_grad and self_variable is not None:
         output_variable.backward(randn_like(output_variable))
         test_case.assertEqual(self_variable.type(), self_variable.grad.type())
         test_case.assertEqual(self_variable.size(), self_variable.grad.size())
@@ -3099,7 +3031,7 @@ for test in method_tests:
                 output_variable = getattr(self_variable, name)(*args_variable)
                 if not exclude_tensor_method(name, test_name):
                     output_tensor = getattr(self_tensor, name)(*args_tensor)
-                    if not torch.is_tensor(output_tensor) and not isinstance(output_tensor, tuple):
+                    if not isinstance(output_tensor, torch.Tensor) and not isinstance(output_tensor, tuple):
                         output_tensor = torch.DoubleTensor((output_tensor,))
                     self.assertEqual(unpack_variables(output_variable), output_tensor)
                     # TODO: check that both have changed after adding all inplace ops
@@ -3145,7 +3077,7 @@ for test in method_tests:
                     # can't broadcast inplace to left hand side
                     skip_inplace = ('broadcast_lhs' in test_name or
                                     'broadcast_all' in test_name)
-                    if hasattr(Variable(torch.ones(1)), inplace_name) and not skip_inplace:
+                    if hasattr(torch.ones(1), inplace_name) and not skip_inplace:
                         output_variable = getattr(self_variable, name)(*args_variable)
                         if not isinstance(output_variable, tuple):
                             output_variable = (output_variable,)
@@ -3164,8 +3096,8 @@ for test in method_tests:
                         # Check that gradient is the same
                         for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,
                                             (self_variable,) + args_variable):
-                            if not isinstance(inp_i, Variable):
-                                assert not isinstance(i, Variable)
+                            if not isinstance(inp_i, torch.Tensor):
+                                assert not isinstance(i, torch.Tensor)
                                 continue
                             if inp_i.grad is not None:
                                 inp_i.grad.data.zero_()
@@ -3177,7 +3109,7 @@ for test in method_tests:
                             o.backward(grad)
                         for inp_i, i in zip((inplace_self_variable,) + inplace_args_variable,
                                             (self_variable,) + args_variable):
-                            if not isinstance(inp_i, Variable):
+                            if not isinstance(inp_i, torch.Tensor):
                                 continue
                             self.assertEqual(inp_i.grad, i.grad)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -540,7 +540,7 @@ def compare_cpu_gpu(tensor_constructor, arg_constructor, fn, t, precision=1e-5):
         gpu_args = [to_gpu(arg) for arg in cpu_args]
         if t.__name__ == 'HalfTensor':
             cpu_tensor = cpu_tensor.float()
-            cpu_args = [arg.float() if torch.is_tensor(arg) and is_half(arg) else arg for arg in cpu_args]
+            cpu_args = [arg.float() if isinstance(arg, torch.Tensor) and is_half(arg) else arg for arg in cpu_args]
         cpu_result = getattr(cpu_tensor, fn)(*cpu_args)
         try:
             gpu_result = getattr(gpu_tensor, fn)(*gpu_args)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -31,7 +31,7 @@ from random import shuffle
 
 import torch
 from common import TestCase, run_tests, set_rng_seed
-from torch.autograd import Variable, grad, gradcheck, variable
+from torch.autograd import Variable, grad, gradcheck
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, Dirichlet, Distribution,
                                  Exponential, ExponentialFamily,
@@ -87,146 +87,146 @@ def is_all_nan(tensor):
 Example = namedtuple('Example', ['Dist', 'params'])
 EXAMPLES = [
     Example(Bernoulli, [
-        {'probs': variable([0.7, 0.2, 0.4], requires_grad=True)},
-        {'probs': variable([0.3], requires_grad=True)},
+        {'probs': torch.tensor([0.7, 0.2, 0.4], requires_grad=True)},
+        {'probs': torch.tensor([0.3], requires_grad=True)},
         {'probs': 0.3},
     ]),
     Example(Geometric, [
-        {'probs': variable([0.7, 0.2, 0.4], requires_grad=True)},
-        {'probs': variable([0.3], requires_grad=True)},
+        {'probs': torch.tensor([0.7, 0.2, 0.4], requires_grad=True)},
+        {'probs': torch.tensor([0.3], requires_grad=True)},
         {'probs': 0.3},
     ]),
     Example(Beta, [
         {
-            'concentration1': variable(torch.exp(torch.randn(2, 3)), requires_grad=True),
-            'concentration0': variable(torch.exp(torch.randn(2, 3)), requires_grad=True),
+            'concentration1': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True),
+            'concentration0': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True),
         },
         {
-            'concentration1': variable(torch.exp(torch.randn(4)), requires_grad=True),
-            'concentration0': variable(torch.exp(torch.randn(4)), requires_grad=True),
+            'concentration1': torch.tensor(torch.exp(torch.randn(4)), requires_grad=True),
+            'concentration0': torch.tensor(torch.exp(torch.randn(4)), requires_grad=True),
         },
     ]),
     Example(Categorical, [
-        {'probs': variable([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
-        {'probs': variable([[1.0, 0.0], [0.0, 1.0]], requires_grad=True)},
+        {'probs': torch.tensor([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
+        {'probs': torch.tensor([[1.0, 0.0], [0.0, 1.0]], requires_grad=True)},
     ]),
     Example(Binomial, [
-        {'probs': variable([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True), 'total_count': 10},
-        {'probs': variable([[1.0, 0.0], [0.0, 1.0]], requires_grad=True), 'total_count': 10},
+        {'probs': torch.tensor([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True), 'total_count': 10},
+        {'probs': torch.tensor([[1.0, 0.0], [0.0, 1.0]], requires_grad=True), 'total_count': 10},
     ]),
     Example(Multinomial, [
-        {'probs': variable([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True), 'total_count': 10},
-        {'probs': variable([[1.0, 0.0], [0.0, 1.0]], requires_grad=True), 'total_count': 10},
+        {'probs': torch.tensor([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True), 'total_count': 10},
+        {'probs': torch.tensor([[1.0, 0.0], [0.0, 1.0]], requires_grad=True), 'total_count': 10},
     ]),
     Example(Cauchy, [
         {'loc': 0.0, 'scale': 1.0},
-        {'loc': variable([0.0]), 'scale': 1.0},
-        {'loc': variable([[0.0], [0.0]]),
-         'scale': variable([[1.0], [1.0]])}
+        {'loc': torch.tensor([0.0]), 'scale': 1.0},
+        {'loc': torch.tensor([[0.0], [0.0]]),
+         'scale': torch.tensor([[1.0], [1.0]])}
     ]),
     Example(Chi2, [
-        {'df': variable(torch.exp(torch.randn(2, 3)), requires_grad=True)},
-        {'df': variable(torch.exp(torch.randn(1)), requires_grad=True)},
+        {'df': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)},
+        {'df': torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)},
     ]),
     Example(StudentT, [
-        {'df': variable(torch.exp(torch.randn(2, 3)), requires_grad=True)},
-        {'df': variable(torch.exp(torch.randn(1)), requires_grad=True)},
+        {'df': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)},
+        {'df': torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)},
     ]),
     Example(Dirichlet, [
-        {'concentration': variable(torch.exp(torch.randn(2, 3)), requires_grad=True)},
-        {'concentration': variable(torch.exp(torch.randn(4)), requires_grad=True)},
+        {'concentration': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)},
+        {'concentration': torch.tensor(torch.exp(torch.randn(4)), requires_grad=True)},
     ]),
     Example(Exponential, [
-        {'rate': variable(torch.randn(5, 5).abs(), requires_grad=True)},
-        {'rate': variable(torch.randn(1).abs(), requires_grad=True)},
+        {'rate': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)},
+        {'rate': torch.tensor(torch.randn(1).abs(), requires_grad=True)},
     ]),
     Example(FisherSnedecor, [
         {
-            'df1': variable(torch.randn(5, 5).abs(), requires_grad=True),
-            'df2': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'df1': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
+            'df2': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
-            'df1': variable(torch.randn(1).abs(), requires_grad=True),
-            'df2': variable(torch.randn(1).abs(), requires_grad=True),
+            'df1': torch.tensor(torch.randn(1).abs(), requires_grad=True),
+            'df2': torch.tensor(torch.randn(1).abs(), requires_grad=True),
         },
         {
-            'df1': variable([1.0]),
+            'df1': torch.tensor([1.0]),
             'df2': 1.0,
         }
     ]),
     Example(Gamma, [
         {
-            'concentration': variable(torch.exp(torch.randn(2, 3)), requires_grad=True),
-            'rate': variable(torch.exp(torch.randn(2, 3)), requires_grad=True),
+            'concentration': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True),
+            'rate': torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True),
         },
         {
-            'concentration': variable(torch.exp(torch.randn(1)), requires_grad=True),
-            'rate': variable(torch.exp(torch.randn(1)), requires_grad=True),
+            'concentration': torch.tensor(torch.exp(torch.randn(1)), requires_grad=True),
+            'rate': torch.tensor(torch.exp(torch.randn(1)), requires_grad=True),
         },
     ]),
     Example(Gumbel, [
         {
             'loc': torch.randn(5, 5, requires_grad=True),
-            'scale': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
             'loc': torch.randn(1, requires_grad=True),
-            'scale': variable(torch.randn(1).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(1).abs(), requires_grad=True),
         },
     ]),
     Example(Independent, [
         {
             'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
-                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)),
             'reinterpreted_batch_ndims': 0,
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
-                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)),
             'reinterpreted_batch_ndims': 1,
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
-                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)),
             'reinterpreted_batch_ndims': 2,
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
-                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3, 5).abs(), requires_grad=True)),
             'reinterpreted_batch_ndims': 2,
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
-                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3, 5).abs(), requires_grad=True)),
             'reinterpreted_batch_ndims': 3,
         },
     ]),
     Example(Laplace, [
         {
             'loc': torch.randn(5, 5, requires_grad=True),
-            'scale': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
             'loc': torch.randn(1, requires_grad=True),
-            'scale': variable(torch.randn(1).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(1).abs(), requires_grad=True),
         },
         {
-            'loc': variable([1.0, 0.0], requires_grad=True),
-            'scale': variable([1e-5, 1e-5], requires_grad=True),
+            'loc': torch.tensor([1.0, 0.0], requires_grad=True),
+            'scale': torch.tensor([1e-5, 1e-5], requires_grad=True),
         },
     ]),
     Example(LogNormal, [
         {
             'loc': torch.randn(5, 5, requires_grad=True),
-            'scale': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
             'loc': torch.randn(1, requires_grad=True),
-            'scale': variable(torch.randn(1).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(1).abs(), requires_grad=True),
         },
         {
-            'loc': variable([1.0, 0.0], requires_grad=True),
-            'scale': variable([1e-5, 1e-5], requires_grad=True),
+            'loc': torch.tensor([1.0, 0.0], requires_grad=True),
+            'scale': torch.tensor([1e-5, 1e-5], requires_grad=True),
         },
     ]),
     Example(LogisticNormal, [
@@ -246,42 +246,42 @@ EXAMPLES = [
     Example(MultivariateNormal, [
         {
             'loc': torch.randn(5, 2, requires_grad=True),
-            'covariance_matrix': variable(torch.Tensor([[2.0, 0.3], [0.3, 0.25]]), requires_grad=True),
+            'covariance_matrix': torch.tensor([[2.0, 0.3], [0.3, 0.25]], requires_grad=True),
         },
         {
             'loc': torch.randn(2, 3, requires_grad=True),
-            'precision_matrix': variable(torch.Tensor([[2.0, 0.1, 0.0],
-                                                       [0.1, 0.25, 0.0],
-                                                       [0.0, 0.0, 0.3]]), requires_grad=True),
+            'precision_matrix': torch.tensor([[2.0, 0.1, 0.0],
+                                              [0.1, 0.25, 0.0],
+                                              [0.0, 0.0, 0.3]], requires_grad=True),
         },
         {
             'loc': torch.randn(5, 3, 2, requires_grad=True),
-            'scale_tril': variable(torch.Tensor([[[2.0, 0.0], [-0.5, 0.25]],
-                                                 [[2.0, 0.0], [0.3, 0.25]],
-                                                 [[5.0, 0.0], [-0.5, 1.5]]]), requires_grad=True),
+            'scale_tril': torch.tensor([[[2.0, 0.0], [-0.5, 0.25]],
+                                        [[2.0, 0.0], [0.3, 0.25]],
+                                        [[5.0, 0.0], [-0.5, 1.5]]], requires_grad=True),
         },
         {
-            'loc': variable(torch.Tensor([1.0, -1.0])),
-            'covariance_matrix': variable(torch.Tensor([[5.0, -0.5], [-0.5, 1.5]])),
+            'loc': torch.tensor([1.0, -1.0]),
+            'covariance_matrix': torch.tensor([[5.0, -0.5], [-0.5, 1.5]]),
         },
     ]),
     Example(Normal, [
         {
             'loc': torch.randn(5, 5, requires_grad=True),
-            'scale': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
             'loc': torch.randn(1, requires_grad=True),
-            'scale': variable(torch.randn(1).abs(), requires_grad=True),
+            'scale': torch.tensor(torch.randn(1).abs(), requires_grad=True),
         },
         {
-            'loc': variable([1.0, 0.0], requires_grad=True),
-            'scale': variable([1e-5, 1e-5], requires_grad=True),
+            'loc': torch.tensor([1.0, 0.0], requires_grad=True),
+            'scale': torch.tensor([1e-5, 1e-5], requires_grad=True),
         },
     ]),
     Example(OneHotCategorical, [
-        {'probs': variable([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
-        {'probs': variable([[1.0, 0.0], [0.0, 1.0]], requires_grad=True)},
+        {'probs': torch.tensor([[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
+        {'probs': torch.tensor([[1.0, 0.0], [0.0, 1.0]], requires_grad=True)},
     ]),
     Example(Pareto, [
         {
@@ -289,20 +289,20 @@ EXAMPLES = [
             'alpha': 1.0
         },
         {
-            'scale': variable(torch.randn(5, 5).abs(), requires_grad=True),
-            'alpha': variable(torch.randn(5, 5).abs(), requires_grad=True)
+            'scale': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
+            'alpha': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)
         },
         {
-            'scale': variable([1.0]),
+            'scale': torch.tensor([1.0]),
             'alpha': 1.0
         }
     ]),
     Example(Poisson, [
         {
-            'rate': variable(torch.randn(5, 5).abs(), requires_grad=True),
+            'rate': torch.tensor(torch.randn(5, 5).abs(), requires_grad=True),
         },
         {
-            'rate': variable(torch.randn(3).abs(), requires_grad=True),
+            'rate': torch.tensor(torch.randn(3).abs(), requires_grad=True),
         },
         {
             'rate': 0.2,
@@ -310,52 +310,52 @@ EXAMPLES = [
     ]),
     Example(RelaxedBernoulli, [
         {
-            'temperature': variable([0.5], requires_grad=True),
-            'probs': variable([0.7, 0.2, 0.4], requires_grad=True),
+            'temperature': torch.tensor([0.5], requires_grad=True),
+            'probs': torch.tensor([0.7, 0.2, 0.4], requires_grad=True),
         },
         {
-            'temperature': variable([2.0]),
-            'probs': variable([0.3]),
+            'temperature': torch.tensor([2.0]),
+            'probs': torch.tensor([0.3]),
         },
         {
-            'temperature': variable([7.2]),
-            'logits': variable([-2.0, 2.0, 1.0, 5.0])
+            'temperature': torch.tensor([7.2]),
+            'logits': torch.tensor([-2.0, 2.0, 1.0, 5.0])
         }
     ]),
     Example(RelaxedOneHotCategorical, [
         {
-            'temperature': variable([0.5], requires_grad=True),
-            'probs': variable([[0.1, 0.2, 0.7], [0.5, 0.3, 0.2]], requires_grad=True)
+            'temperature': torch.tensor([0.5], requires_grad=True),
+            'probs': torch.tensor([[0.1, 0.2, 0.7], [0.5, 0.3, 0.2]], requires_grad=True)
         },
         {
-            'temperature': variable([2.0]),
-            'probs': variable([[1.0, 0.0], [0.0, 1.0]])
+            'temperature': torch.tensor([2.0]),
+            'probs': torch.tensor([[1.0, 0.0], [0.0, 1.0]])
         },
         {
-            'temperature': variable([7.2]),
-            'logits': variable([[-2.0, 2.0], [1.0, 5.0]])
+            'temperature': torch.tensor([7.2]),
+            'logits': torch.tensor([[-2.0, 2.0], [1.0, 5.0]])
         }
     ]),
     Example(TransformedDistribution, [
         {
             'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
-                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)),
             'transforms': [],
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, requires_grad=True),
-                                        variable(torch.randn(2, 3).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)),
             'transforms': ExpTransform(),
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
-                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3, 5).abs(), requires_grad=True)),
             'transforms': [AffineTransform(torch.randn(3, 5), torch.randn(3, 5)),
                            ExpTransform()],
         },
         {
             'base_distribution': Normal(torch.randn(2, 3, 5, requires_grad=True),
-                                        variable(torch.randn(2, 3, 5).abs(), requires_grad=True)),
+                                        torch.tensor(torch.randn(2, 3, 5).abs(), requires_grad=True)),
             'transforms': AffineTransform(1, 2),
         },
     ]),
@@ -369,132 +369,132 @@ EXAMPLES = [
             'high': torch.ones(1, requires_grad=True),
         },
         {
-            'low': variable([1.0, 1.0], requires_grad=True),
-            'high': variable([2.0, 3.0], requires_grad=True),
+            'low': torch.tensor([1.0, 1.0], requires_grad=True),
+            'high': torch.tensor([2.0, 3.0], requires_grad=True),
         },
     ]),
 ]
 
 BAD_EXAMPLES = [
     Example(Bernoulli, [
-        {'probs': variable([1.1, 0.2, 0.4], requires_grad=True)},
-        {'probs': variable([-0.5], requires_grad=True)},
+        {'probs': torch.tensor([1.1, 0.2, 0.4], requires_grad=True)},
+        {'probs': torch.tensor([-0.5], requires_grad=True)},
         {'probs': 1.00001},
     ]),
     Example(Beta, [
         {
-            'concentration1': variable([0.0], requires_grad=True),
-            'concentration0': variable([0.0], requires_grad=True),
+            'concentration1': torch.tensor([0.0], requires_grad=True),
+            'concentration0': torch.tensor([0.0], requires_grad=True),
         },
         {
-            'concentration1': variable([-1.0], requires_grad=True),
-            'concentration0': variable([-2.0], requires_grad=True),
+            'concentration1': torch.tensor([-1.0], requires_grad=True),
+            'concentration0': torch.tensor([-2.0], requires_grad=True),
         },
     ]),
     Example(Geometric, [
-        {'probs': variable([1.1, 0.2, 0.4], requires_grad=True)},
-        {'probs': variable([-0.3], requires_grad=True)},
+        {'probs': torch.tensor([1.1, 0.2, 0.4], requires_grad=True)},
+        {'probs': torch.tensor([-0.3], requires_grad=True)},
         {'probs': 1.00000001},
     ]),
     Example(Categorical, [
-        {'probs': variable([[-0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
-        {'probs': variable([[-1.0, 10.0], [0.0, -1.0]], requires_grad=True)},
+        {'probs': torch.tensor([[-0.1, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True)},
+        {'probs': torch.tensor([[-1.0, 10.0], [0.0, -1.0]], requires_grad=True)},
     ]),
     Example(Binomial, [
-        {'probs': variable([[-0.0000001, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True),
+        {'probs': torch.tensor([[-0.0000001, 0.2, 0.3], [0.5, 0.3, 0.2]], requires_grad=True),
          'total_count': 10},
-        {'probs': variable([[1.0, 0.0], [0.0, 2.0]], requires_grad=True),
+        {'probs': torch.tensor([[1.0, 0.0], [0.0, 2.0]], requires_grad=True),
          'total_count': 10},
     ]),
     Example(Cauchy, [
         {'loc': 0.0, 'scale': -1.0},
-        {'loc': variable([0.0]), 'scale': 0.0},
-        {'loc': variable([[0.0], [-2.0]]),
-         'scale': variable([[-0.000001], [1.0]])}
+        {'loc': torch.tensor([0.0]), 'scale': 0.0},
+        {'loc': torch.tensor([[0.0], [-2.0]]),
+         'scale': torch.tensor([[-0.000001], [1.0]])}
     ]),
     Example(Chi2, [
-        {'df': variable([0.], requires_grad=True)},
-        {'df': variable([-2.], requires_grad=True)},
+        {'df': torch.tensor([0.], requires_grad=True)},
+        {'df': torch.tensor([-2.], requires_grad=True)},
     ]),
     Example(StudentT, [
-        {'df': variable([0.], requires_grad=True)},
-        {'df': variable([-2.], requires_grad=True)},
+        {'df': torch.tensor([0.], requires_grad=True)},
+        {'df': torch.tensor([-2.], requires_grad=True)},
     ]),
     Example(Dirichlet, [
-        {'concentration': variable([0.], requires_grad=True)},
-        {'concentration': variable([-2.], requires_grad=True)}
+        {'concentration': torch.tensor([0.], requires_grad=True)},
+        {'concentration': torch.tensor([-2.], requires_grad=True)}
     ]),
     Example(Exponential, [
-        {'rate': variable([0., 0.], requires_grad=True)},
-        {'rate': variable([-2.], requires_grad=True)}
+        {'rate': torch.tensor([0., 0.], requires_grad=True)},
+        {'rate': torch.tensor([-2.], requires_grad=True)}
     ]),
     Example(FisherSnedecor, [
         {
-            'df1': variable([0., 0.], requires_grad=True),
-            'df2': variable([-1., -100.], requires_grad=True),
+            'df1': torch.tensor([0., 0.], requires_grad=True),
+            'df2': torch.tensor([-1., -100.], requires_grad=True),
         },
         {
-            'df1': variable([1., 1.], requires_grad=True),
-            'df2': variable([0., 0.], requires_grad=True),
+            'df1': torch.tensor([1., 1.], requires_grad=True),
+            'df2': torch.tensor([0., 0.], requires_grad=True),
         }
     ]),
     Example(Gamma, [
         {
-            'concentration': variable([0., 0.], requires_grad=True),
-            'rate': variable([-1., -100.], requires_grad=True),
+            'concentration': torch.tensor([0., 0.], requires_grad=True),
+            'rate': torch.tensor([-1., -100.], requires_grad=True),
         },
         {
-            'concentration': variable([1., 1.], requires_grad=True),
-            'rate': variable([0., 0.], requires_grad=True),
+            'concentration': torch.tensor([1., 1.], requires_grad=True),
+            'rate': torch.tensor([0., 0.], requires_grad=True),
         }
     ]),
     Example(Gumbel, [
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([0., 1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([0., 1.], requires_grad=True),
         },
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([1., -1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([1., -1.], requires_grad=True),
         },
     ]),
     Example(Laplace, [
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([0., 1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([0., 1.], requires_grad=True),
         },
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([1., -1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([1., -1.], requires_grad=True),
         },
     ]),
     Example(LogNormal, [
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([0., 1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([0., 1.], requires_grad=True),
         },
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([1., -1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([1., -1.], requires_grad=True),
         },
     ]),
     Example(Normal, [
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([0., 1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([0., 1.], requires_grad=True),
         },
         {
-            'loc': variable([1., 1.], requires_grad=True),
-            'scale': variable([1., -1.], requires_grad=True),
+            'loc': torch.tensor([1., 1.], requires_grad=True),
+            'scale': torch.tensor([1., -1.], requires_grad=True),
         },
         {
-            'loc': variable([1.0, 0.0], requires_grad=True),
-            'scale': variable([1e-5, -1e-5], requires_grad=True),
+            'loc': torch.tensor([1.0, 0.0], requires_grad=True),
+            'scale': torch.tensor([1e-5, -1e-5], requires_grad=True),
         },
     ]),
     Example(OneHotCategorical, [
-        {'probs': variable([[0.1, 0.2, 0.3], [0.1, -10.0, 0.2]], requires_grad=True)},
-        {'probs': variable([[0.0, 0.0], [0.0, 0.0]], requires_grad=True)},
+        {'probs': torch.tensor([[0.1, 0.2, 0.3], [0.1, -10.0, 0.2]], requires_grad=True)},
+        {'probs': torch.tensor([[0.0, 0.0], [0.0, 0.0]], requires_grad=True)},
     ]),
     Example(Pareto, [
         {
@@ -502,17 +502,17 @@ BAD_EXAMPLES = [
             'alpha': 0.0
         },
         {
-            'scale': variable([0.0, 0.0], requires_grad=True),
-            'alpha': variable([-1e-5, 0.0], requires_grad=True)
+            'scale': torch.tensor([0.0, 0.0], requires_grad=True),
+            'alpha': torch.tensor([-1e-5, 0.0], requires_grad=True)
         },
         {
-            'scale': variable([1.0]),
+            'scale': torch.tensor([1.0]),
             'alpha': -1.0
         }
     ]),
     Example(Poisson, [
         {
-            'rate': variable([0.0], requires_grad=True),
+            'rate': torch.tensor([0.0], requires_grad=True),
         },
         {
             'rate': -1.0,
@@ -520,22 +520,22 @@ BAD_EXAMPLES = [
     ]),
     Example(RelaxedBernoulli, [
         {
-            'temperature': variable([1.5], requires_grad=True),
-            'probs': variable([1.7, 0.2, 0.4], requires_grad=True),
+            'temperature': torch.tensor([1.5], requires_grad=True),
+            'probs': torch.tensor([1.7, 0.2, 0.4], requires_grad=True),
         },
         {
-            'temperature': variable([2.0]),
-            'probs': variable([-1.0]),
+            'temperature': torch.tensor([2.0]),
+            'probs': torch.tensor([-1.0]),
         }
     ]),
     Example(RelaxedOneHotCategorical, [
         {
-            'temperature': variable([0.5], requires_grad=True),
-            'probs': variable([[-0.1, 0.2, 0.7], [0.5, 0.3, 0.2]], requires_grad=True)
+            'temperature': torch.tensor([0.5], requires_grad=True),
+            'probs': torch.tensor([[-0.1, 0.2, 0.7], [0.5, 0.3, 0.2]], requires_grad=True)
         },
         {
-            'temperature': variable([2.0]),
-            'probs': variable([[-1.0, 0.0], [-1.0, 1.1]])
+            'temperature': torch.tensor([2.0]),
+            'probs': torch.tensor([[-1.0, 0.0], [-1.0, 1.1]])
         }
     ]),
     Example(TransformedDistribution, [
@@ -550,16 +550,16 @@ BAD_EXAMPLES = [
     ]),
     Example(Uniform, [
         {
-            'low': variable([2.0], requires_grad=True),
-            'high': variable([2.0], requires_grad=True),
+            'low': torch.tensor([2.0], requires_grad=True),
+            'high': torch.tensor([2.0], requires_grad=True),
         },
         {
-            'low': variable([0.0], requires_grad=True),
-            'high': variable([0.0], requires_grad=True),
+            'low': torch.tensor([0.0], requires_grad=True),
+            'high': torch.tensor([0.0], requires_grad=True),
         },
         {
-            'low': variable([1.0], requires_grad=True),
-            'high': variable([0.0], requires_grad=True),
+            'low': torch.tensor([1.0], requires_grad=True),
+            'high': torch.tensor([0.0], requires_grad=True),
         }
     ])
 ]
@@ -645,8 +645,6 @@ class TestDistributions(TestCase):
             expected = torch.Tensor(expected)
             actual = dist(param).enumerate_support()
             self.assertEqual(actual, expected)
-            param = variable(param)
-            expected = variable(expected)
             actual = dist(param).enumerate_support()
             self.assertEqual(actual, expected)
 
@@ -728,15 +726,15 @@ class TestDistributions(TestCase):
         self._check_enumerate_support(Bernoulli, examples)
 
     def test_bernoulli_3d(self):
-        p = variable(torch.Tensor(2, 3, 5).fill_(0.5), requires_grad=True)
+        p = torch.tensor(torch.Tensor(2, 3, 5).fill_(0.5), requires_grad=True)
         self.assertEqual(Bernoulli(p).sample().size(), (2, 3, 5))
         self.assertEqual(Bernoulli(p).sample(sample_shape=(2, 5)).size(),
                          (2, 5, 2, 3, 5))
         self.assertEqual(Bernoulli(p).sample((2,)).size(), (2, 2, 3, 5))
 
     def test_geometric(self):
-        p = variable([0.7, 0.2, 0.4], requires_grad=True)
-        r = variable(0.3, requires_grad=True)
+        p = torch.tensor([0.7, 0.2, 0.4], requires_grad=True)
+        r = torch.tensor(0.3, requires_grad=True)
         s = 0.3
         self.assertEqual(Geometric(p).sample((8,)).size(), (8, 3))
         self.assertEqual(Geometric(1).sample(), 0)
@@ -753,7 +751,7 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_geometric_log_prob_and_entropy(self):
-        p = variable([0.7, 0.2, 0.4], requires_grad=True)
+        p = torch.tensor([0.7, 0.2, 0.4], requires_grad=True)
         s = 0.3
 
         def ref_log_prob(idx, val, log_prob):
@@ -776,7 +774,7 @@ class TestDistributions(TestCase):
                                          'Geometric(prob={})'.format(prob))
 
     def test_binomial(self):
-        p = variable(torch.arange(0.05, 1, 0.1), requires_grad=True)
+        p = torch.tensor(torch.arange(0.05, 1, 0.1), requires_grad=True)
         for total_count in [1, 2, 10]:
             self._gradcheck_log_prob(lambda p: Binomial(total_count, p), [p])
             self._gradcheck_log_prob(lambda p: Binomial(total_count, None, p.log()), [p])
@@ -785,7 +783,7 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_binomial_log_prob(self):
-        probs = variable(torch.arange(0.05, 1, 0.1))
+        probs = torch.tensor(torch.arange(0.05, 1, 0.1))
         for total_count in [1, 2, 10]:
 
             def ref_log_prob(idx, x, log_prob):
@@ -810,7 +808,7 @@ class TestDistributions(TestCase):
 
     def test_multinomial_1d(self):
         total_count = 10
-        p = variable([0.1, 0.2, 0.3], requires_grad=True)
+        p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         self.assertEqual(Multinomial(total_count, p).sample().size(), (3,))
         self.assertEqual(Multinomial(total_count, p).sample((2, 2)).size(), (2, 2, 3))
         self.assertEqual(Multinomial(total_count, p).sample((1,)).size(), (1, 3))
@@ -821,7 +819,7 @@ class TestDistributions(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_multinomial_1d_log_prob(self):
         total_count = 10
-        p = variable([0.1, 0.2, 0.3], requires_grad=True)
+        p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         dist = Multinomial(total_count, probs=p)
         x = dist.sample()
         log_prob = dist.log_prob(x)
@@ -838,8 +836,8 @@ class TestDistributions(TestCase):
         total_count = 10
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
         probabilities_1 = [[1.0, 0.0], [0.0, 1.0]]
-        p = variable(probabilities, requires_grad=True)
-        s = variable(probabilities_1, requires_grad=True)
+        p = torch.tensor(probabilities, requires_grad=True)
+        s = torch.tensor(probabilities_1, requires_grad=True)
         self.assertEqual(Multinomial(total_count, p).sample().size(), (2, 3))
         self.assertEqual(Multinomial(total_count, p).sample(sample_shape=(3, 4)).size(), (3, 4, 2, 3))
         self.assertEqual(Multinomial(total_count, p).sample((6,)).size(), (6, 2, 3))
@@ -856,7 +854,7 @@ class TestDistributions(TestCase):
         self.assertRaises(NotImplementedError, Multinomial(10, p).entropy)
 
     def test_categorical_1d(self):
-        p = variable([0.1, 0.2, 0.3], requires_grad=True)
+        p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         self.assertTrue(is_all_nan(Categorical(p).mean))
         self.assertTrue(is_all_nan(Categorical(p).variance))
         self.assertEqual(Categorical(p).sample().size(), ())
@@ -869,8 +867,8 @@ class TestDistributions(TestCase):
     def test_categorical_2d(self):
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
         probabilities_1 = [[1.0, 0.0], [0.0, 1.0]]
-        p = variable(probabilities, requires_grad=True)
-        s = variable(probabilities_1, requires_grad=True)
+        p = torch.tensor(probabilities, requires_grad=True)
+        s = torch.tensor(probabilities_1, requires_grad=True)
         self.assertEqual(Categorical(p).mean.size(), (2,))
         self.assertEqual(Categorical(p).variance.size(), (2,))
         self.assertTrue(is_all_nan(Categorical(p).mean))
@@ -904,7 +902,7 @@ class TestDistributions(TestCase):
         self._check_enumerate_support(Categorical, examples)
 
     def test_one_hot_categorical_1d(self):
-        p = variable([0.1, 0.2, 0.3], requires_grad=True)
+        p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         self.assertEqual(OneHotCategorical(p).sample().size(), (3,))
         self.assertTrue(isinstance(OneHotCategorical(p).sample().data, torch.Tensor))
         self.assertEqual(OneHotCategorical(p).sample((2, 2)).size(), (2, 2, 3))
@@ -915,8 +913,8 @@ class TestDistributions(TestCase):
     def test_one_hot_categorical_2d(self):
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
         probabilities_1 = [[1.0, 0.0], [0.0, 1.0]]
-        p = variable(probabilities, requires_grad=True)
-        s = variable(probabilities_1, requires_grad=True)
+        p = torch.tensor(probabilities, requires_grad=True)
+        s = torch.tensor(probabilities_1, requires_grad=True)
         self.assertEqual(OneHotCategorical(p).sample().size(), (2, 3))
         self.assertEqual(OneHotCategorical(p).sample(sample_shape=(3, 4)).size(), (3, 4, 2, 3))
         self.assertEqual(OneHotCategorical(p).sample((6,)).size(), (6, 2, 3))
@@ -934,8 +932,8 @@ class TestDistributions(TestCase):
         self._check_enumerate_support(OneHotCategorical, examples)
 
     def test_poisson_shape(self):
-        rate = variable(torch.randn(2, 3).abs(), requires_grad=True)
-        rate_1d = variable(torch.randn(1).abs(), requires_grad=True)
+        rate = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
+        rate_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
         self.assertEqual(Poisson(rate).sample().size(), (2, 3))
         self.assertEqual(Poisson(rate).sample((7,)).size(), (7, 2, 3))
         self.assertEqual(Poisson(rate_1d).sample().size(), (1,))
@@ -944,8 +942,8 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_poisson_log_prob(self):
-        rate = variable(torch.randn(2, 3).abs(), requires_grad=True)
-        rate_1d = variable(torch.randn(1).abs(), requires_grad=True)
+        rate = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
+        rate_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
 
         def ref_log_prob(idx, x, log_prob):
             l = rate.data.view(-1)[idx]
@@ -1018,7 +1016,7 @@ class TestDistributions(TestCase):
             self.assertEqual(equal_probs, s)
 
     def test_relaxed_one_hot_categorical_1d(self):
-        p = variable([0.1, 0.2, 0.3], requires_grad=True)
+        p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)
         temp = torch.tensor(0.67, requires_grad=True)
         self.assertEqual(RelaxedOneHotCategorical(probs=p, temperature=temp).sample().size(), (3,))
         self.assertTrue(isinstance(RelaxedOneHotCategorical(probs=p, temperature=temp).sample().data, torch.Tensor))
@@ -1029,10 +1027,10 @@ class TestDistributions(TestCase):
     def test_relaxed_one_hot_categorical_2d(self):
         probabilities = [[0.1, 0.2, 0.3], [0.5, 0.3, 0.2]]
         probabilities_1 = [[1.0, 0.0], [0.0, 1.0]]
-        temp = variable([3.00], requires_grad=True)
-        temp_2 = variable([0.2], requires_grad=True)
-        p = variable(probabilities, requires_grad=True)
-        s = variable(probabilities_1, requires_grad=True)
+        temp = torch.tensor([3.00], requires_grad=True)
+        temp_2 = torch.tensor([0.2], requires_grad=True)
+        p = torch.tensor(probabilities, requires_grad=True)
+        s = torch.tensor(probabilities_1, requires_grad=True)
         self.assertEqual(RelaxedOneHotCategorical(temp, p).sample().size(), (2, 3))
         self.assertEqual(RelaxedOneHotCategorical(temp, p).sample(sample_shape=(3, 4)).size(), (3, 4, 2, 3))
         self.assertEqual(RelaxedOneHotCategorical(temp, p).sample((6,)).size(), (6, 2, 3))
@@ -1075,9 +1073,9 @@ class TestDistributions(TestCase):
 
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
-        high = variable(torch.ones(5, 5) * 3, requires_grad=True)
+        high = torch.tensor(torch.ones(5, 5) * 3, requires_grad=True)
         low_1d = torch.zeros(1, requires_grad=True)
-        high_1d = variable(torch.ones(1) * 3, requires_grad=True)
+        high_1d = torch.tensor(torch.ones(1) * 3, requires_grad=True)
         self.assertEqual(Uniform(low, high).sample().size(), (5, 5))
         self.assertEqual(Uniform(low, high).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(Uniform(low_1d, high_1d).sample().size(), (1,))
@@ -1086,8 +1084,8 @@ class TestDistributions(TestCase):
 
         # Check log_prob computation when value outside range
         uniform = Uniform(low_1d, high_1d)
-        above_high = variable([4.0])
-        below_low = variable([-1.0])
+        above_high = torch.tensor([4.0])
+        below_low = torch.tensor([-1.0])
         self.assertEqual(uniform.log_prob(above_high).item(), -float('inf'), allow_inf=True)
         self.assertEqual(uniform.log_prob(below_low).item(), -float('inf'), allow_inf=True)
 
@@ -1136,11 +1134,11 @@ class TestDistributions(TestCase):
 
     def test_lognormal(self):
         mean = torch.randn(5, 5, requires_grad=True)
-        std = variable(torch.randn(5, 5).abs(), requires_grad=True)
+        std = torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)
         mean_1d = torch.randn(1, requires_grad=True)
         std_1d = torch.randn(1, requires_grad=True)
-        mean_delta = variable([1.0, 0.0])
-        std_delta = variable([1e-5, 1e-5])
+        mean_delta = torch.tensor([1.0, 0.0])
+        std_delta = torch.tensor([1e-5, 1e-5])
         self.assertEqual(LogNormal(mean, std).sample().size(), (5, 5))
         self.assertEqual(LogNormal(mean, std).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(LogNormal(mean_1d, std_1d).sample((1,)).size(), (1, 1))
@@ -1161,7 +1159,7 @@ class TestDistributions(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_lognormal_logprob(self):
         mean = torch.randn(5, 1, requires_grad=True)
-        std = variable(torch.randn(5, 1).abs(), requires_grad=True)
+        std = torch.tensor(torch.randn(5, 1).abs(), requires_grad=True)
 
         def ref_log_prob(idx, x, log_prob):
             m = mean.data.view(-1)[idx]
@@ -1247,11 +1245,11 @@ class TestDistributions(TestCase):
 
     def test_normal(self):
         loc = torch.randn(5, 5, requires_grad=True)
-        scale = variable(torch.randn(5, 5).abs(), requires_grad=True)
+        scale = torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)
         loc_1d = torch.randn(1, requires_grad=True)
         scale_1d = torch.randn(1, requires_grad=True)
-        loc_delta = variable([1.0, 0.0])
-        scale_delta = variable([1e-5, 1e-5])
+        loc_delta = torch.tensor([1.0, 0.0])
+        scale_delta = torch.tensor([1e-5, 1e-5])
         self.assertEqual(Normal(loc, scale).sample().size(), (5, 5))
         self.assertEqual(Normal(loc, scale).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(Normal(loc_1d, scale_1d).sample((1,)).size(), (1, 1))
@@ -1298,9 +1296,9 @@ class TestDistributions(TestCase):
                                         'Normal(mean={}, std={})'.format(loc, scale))
 
     def test_multivariate_normal_shape(self):
-        mean = torch.tensor(torch.randn(5, 3), requires_grad=True)
-        mean_no_batch = torch.tensor(torch.randn(3), requires_grad=True)
-        mean_multi_batch = torch.tensor(torch.randn(6, 5, 3), requires_grad=True)
+        mean = torch.randn(5, 3, requires_grad=True)
+        mean_no_batch = torch.randn(3, requires_grad=True)
+        mean_multi_batch = torch.randn(6, 5, 3, requires_grad=True)
 
         # construct PSD covariance
         tmp = torch.randn(3, 10)
@@ -1345,7 +1343,7 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_multivariate_normal_log_prob(self):
-        mean = torch.tensor(torch.randn(3), requires_grad=True)
+        mean = torch.randn(3, requires_grad=True)
         tmp = torch.randn(3, 10)
         cov = torch.tensor(torch.matmul(tmp, tmp.t()) / tmp.shape[-1], requires_grad=True)
         prec = torch.tensor(cov.data.inverse(), requires_grad=True)
@@ -1366,7 +1364,7 @@ class TestDistributions(TestCase):
         self.assertAlmostEqual(0.0, np.mean((dist3.log_prob(x).data.numpy() - expected)**2), places=3)
 
         # Double-check that batched versions behave the same as unbatched
-        mean = torch.tensor(torch.randn(5, 3), requires_grad=True)
+        mean = torch.randn(5, 3, requires_grad=True)
         tmp = torch.randn(5, 3, 10)
         cov = torch.tensor((tmp.unsqueeze(-2) * tmp.unsqueeze(-3)).mean(-1), requires_grad=True)
 
@@ -1383,7 +1381,7 @@ class TestDistributions(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_multivariate_normal_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
-        mean = torch.tensor(torch.randn(3), requires_grad=True)
+        mean = torch.randn(3, requires_grad=True)
         tmp = torch.randn(3, 10)
         cov = torch.tensor(torch.matmul(tmp, tmp.t()) / tmp.shape[-1], requires_grad=True)
         prec = torch.tensor(cov.data.inverse(), requires_grad=True)
@@ -1411,8 +1409,8 @@ class TestDistributions(TestCase):
         self.assertEqual(m.scale_tril, torch.potrf(m.covariance_matrix, upper=False))
 
     def test_exponential(self):
-        rate = variable(torch.randn(5, 5).abs(), requires_grad=True)
-        rate_1d = variable(torch.randn(1).abs(), requires_grad=True)
+        rate = torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)
+        rate_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
         self.assertEqual(Exponential(rate).sample().size(), (5, 5))
         self.assertEqual(Exponential(rate).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(Exponential(rate_1d).sample((1,)).size(), (1, 1))
@@ -1447,7 +1445,7 @@ class TestDistributions(TestCase):
 
     def test_laplace(self):
         loc = torch.randn(5, 5, requires_grad=True)
-        scale = variable(torch.randn(5, 5).abs(), requires_grad=True)
+        scale = torch.tensor(torch.randn(5, 5).abs(), requires_grad=True)
         loc_1d = torch.randn(1, requires_grad=True)
         scale_1d = torch.randn(1, requires_grad=True)
         loc_delta = torch.Tensor([1.0, 0.0])
@@ -1498,10 +1496,10 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gamma_shape(self):
-        alpha = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        beta = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        alpha_1d = variable(torch.exp(torch.randn(1)), requires_grad=True)
-        beta_1d = variable(torch.exp(torch.randn(1)), requires_grad=True)
+        alpha = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        beta = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        alpha_1d = torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)
+        beta_1d = torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)
         self.assertEqual(Gamma(alpha, beta).sample().size(), (2, 3))
         self.assertEqual(Gamma(alpha, beta).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Gamma(alpha_1d, beta_1d).sample((1,)).size(), (1, 1))
@@ -1527,10 +1525,10 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_pareto(self):
-        scale = variable(torch.randn(2, 3).abs(), requires_grad=True)
-        alpha = variable(torch.randn(2, 3).abs(), requires_grad=True)
-        scale_1d = variable(torch.randn(1).abs(), requires_grad=True)
-        alpha_1d = variable(torch.randn(1).abs(), requires_grad=True)
+        scale = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
+        alpha = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
+        scale_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
+        alpha_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
         self.assertEqual(Pareto(scale_1d, 0.5).mean, float('inf'), allow_inf=True)
         self.assertEqual(Pareto(scale_1d, 0.5).variance, float('inf'), allow_inf=True)
         self.assertEqual(Pareto(scale, alpha).sample().size(), (2, 3))
@@ -1559,9 +1557,9 @@ class TestDistributions(TestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gumbel(self):
         loc = torch.randn(2, 3, requires_grad=True)
-        scale = variable(torch.randn(2, 3).abs(), requires_grad=True)
+        scale = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
         loc_1d = torch.randn(1, requires_grad=True)
-        scale_1d = variable(torch.randn(1).abs(), requires_grad=True)
+        scale_1d = torch.tensor(torch.randn(1).abs(), requires_grad=True)
         self.assertEqual(Gumbel(loc, scale).sample().size(), (2, 3))
         self.assertEqual(Gumbel(loc, scale).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Gumbel(loc_1d, scale_1d).sample().size(), (1,))
@@ -1587,8 +1585,8 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_fishersnedecor(self):
-        df1 = variable(torch.randn(2, 3).abs(), requires_grad=True)
-        df2 = variable(torch.randn(2, 3).abs(), requires_grad=True)
+        df1 = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
+        df2 = torch.tensor(torch.randn(2, 3).abs(), requires_grad=True)
         df1_1d = torch.randn(1).abs()
         df2_1d = torch.randn(1).abs()
         self.assertTrue(is_all_nan(FisherSnedecor(1, 2).mean))
@@ -1618,8 +1616,8 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_chi2_shape(self):
-        df = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        df_1d = variable(torch.exp(torch.randn(1)), requires_grad=True)
+        df = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        df_1d = torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)
         self.assertEqual(Chi2(df).sample().size(), (2, 3))
         self.assertEqual(Chi2(df).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Chi2(df_1d).sample((1,)).size(), (1, 1))
@@ -1645,8 +1643,8 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_studentT(self):
-        df = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        df_1d = variable(torch.exp(torch.randn(1)), requires_grad=True)
+        df = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        df_1d = torch.tensor(torch.exp(torch.randn(1)), requires_grad=True)
         self.assertTrue(is_all_nan(StudentT(1).mean))
         self.assertTrue(is_all_nan(StudentT(1).variance))
         self.assertEqual(StudentT(2).variance, float('inf'), allow_inf=True)
@@ -1686,8 +1684,8 @@ class TestDistributions(TestCase):
                 self.assertAlmostEqual(float(actual_log_prob[i]), float(expected_log_prob), places=3)
 
     def test_dirichlet_shape(self):
-        alpha = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        alpha_1d = variable(torch.exp(torch.randn(4)), requires_grad=True)
+        alpha = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        alpha_1d = torch.tensor(torch.exp(torch.randn(4)), requires_grad=True)
         self.assertEqual(Dirichlet(alpha).sample().size(), (2, 3))
         self.assertEqual(Dirichlet(alpha).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Dirichlet(alpha_1d).sample().size(), (4,))
@@ -1714,10 +1712,10 @@ class TestDistributions(TestCase):
                                     multivariate=True)
 
     def test_beta_shape(self):
-        con1 = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        con0 = variable(torch.exp(torch.randn(2, 3)), requires_grad=True)
-        con1_1d = variable(torch.exp(torch.randn(4)), requires_grad=True)
-        con0_1d = variable(torch.exp(torch.randn(4)), requires_grad=True)
+        con1 = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        con0 = torch.tensor(torch.exp(torch.randn(2, 3)), requires_grad=True)
+        con1_1d = torch.tensor(torch.exp(torch.randn(4)), requires_grad=True)
+        con0_1d = torch.tensor(torch.exp(torch.randn(4)), requires_grad=True)
         self.assertEqual(Beta(con1, con0).sample().size(), (2, 3))
         self.assertEqual(Beta(con1, con0).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Beta(con1_1d, con0_1d).sample().size(), (4,))
@@ -1772,7 +1770,7 @@ class TestDistributions(TestCase):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):
                 dist = Dist(**param)
-                samples = variable(dist.sample().data, requires_grad=True)
+                samples = torch.tensor(dist.sample().data, requires_grad=True)
                 try:
                     cdfs = dist.cdf(samples)
                     pdfs = dist.log_prob(samples).exp()
@@ -1941,8 +1939,8 @@ class TestRsample(TestCase):
     def test_gamma(self):
         num_samples = 100
         for alpha in [1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
-            alphas = variable(torch.FloatTensor([alpha] * num_samples), requires_grad=True)
-            betas = variable(torch.ones(num_samples).type_as(alphas))
+            alphas = torch.tensor([alpha] * num_samples, dtype=torch.float, requires_grad=True)
+            betas = alphas.new_ones(num_samples)
             x = Gamma(alphas, betas).rsample()
             x.sum().backward()
             x, ind = x.data.sort()
@@ -1970,7 +1968,7 @@ class TestRsample(TestCase):
     def test_chi2(self):
         num_samples = 100
         for df in [1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4]:
-            dfs = variable(torch.FloatTensor([df] * num_samples), requires_grad=True)
+            dfs = torch.tensor([df] * num_samples, dtype=torch.float, requires_grad=True)
             x = Chi2(dfs).rsample()
             x.sum().backward()
             x, ind = x.data.sort()
@@ -1998,7 +1996,7 @@ class TestRsample(TestCase):
         num_samples = 20
         grid = [1e-1, 1e0, 1e1]
         for a0, a1, a2 in product(grid, grid, grid):
-            alphas = variable(torch.FloatTensor([[a0, a1, a2]] * num_samples), requires_grad=True)
+            alphas = torch.tensor([[a0, a1, a2]] * num_samples, dtype=torch.float, requires_grad=True)
             x = Dirichlet(alphas).rsample()[:, 0]
             x.sum().backward()
             x, ind = x.data.sort()
@@ -2029,8 +2027,8 @@ class TestRsample(TestCase):
         num_samples = 20
         grid = [1e-2, 1e-1, 1e0, 1e1, 1e2]
         for con1, con0 in product(grid, grid):
-            con1s = variable(torch.FloatTensor([con1] * num_samples), requires_grad=True)
-            con0s = variable(torch.FloatTensor([con0] * num_samples).type_as(con1s))
+            con1s = torch.tensor([con1] * num_samples, dtype=torch.float, requires_grad=True)
+            con0s = con1s.new_tensor([con0] * num_samples)
             x = Beta(con1s, con0s).rsample()
             x.sum().backward()
             x, ind = x.data.sort()
@@ -2059,8 +2057,8 @@ class TestRsample(TestCase):
         num_samples = 20
         grid = [1e-2, 1e-1, 1e0, 1e1, 1e2]
         for con1, con0 in product(grid, grid):
-            con0s = variable(torch.FloatTensor([con0] * num_samples), requires_grad=True)
-            con1s = variable(torch.FloatTensor([con1] * num_samples).type_as(con0s))
+            con0s = torch.tensor([con0] * num_samples, dtype=torch.float, requires_grad=True)
+            con1s = con0s.new_tensor([con1] * num_samples)
             x = Beta(con1s, con0s).rsample()
             x.sum().backward()
             x, ind = x.data.sort()
@@ -2089,7 +2087,7 @@ class TestRsample(TestCase):
         num_samples = 100000
         for shift in [-0.1, -0.05, -0.01, 0.0, 0.01, 0.05, 0.10]:
             alpha = alpha_crit + shift
-            alpha = variable(torch.FloatTensor([alpha]), requires_grad=True)
+            alpha = torch.tensor([alpha], dtype=torch.float, requires_grad=True)
             alpha_vec = torch.cat([alpha, alpha, alpha.new([1])])
             z = Dirichlet(alpha_vec.expand(num_samples, 3)).rsample()
             mean_z3 = 1.0 / (2.0 * alpha + 1.0)
@@ -2118,7 +2116,7 @@ class TestRsample(TestCase):
             ], dim=-1)
 
         for a1, a2, a3 in product(alpha_grid, alpha_grid, alpha_grid):
-            alpha = variable([a1, a2, a3], requires_grad=True).expand(num_samples, 3)
+            alpha = torch.tensor([a1, a2, a3], requires_grad=True).expand(num_samples, 3)
             x = Dirichlet(alpha).rsample()
             dlogp_da = grad([Dirichlet(alpha).log_prob(x.detach()).sum()],
                             [alpha], retain_graph=True)[0].data[:, 0]
@@ -2150,8 +2148,8 @@ class TestDistributionShapes(TestCase):
     def setUp(self):
         super(TestCase, self).setUp()
         self.scalar_sample = 1
-        self.tensor_sample_1 = variable(torch.ones(3, 2))
-        self.tensor_sample_2 = variable(torch.ones(3, 2, 3))
+        self.tensor_sample_1 = torch.ones(3, 2)
+        self.tensor_sample_2 = torch.ones(3, 2, 3)
         Distribution.set_default_validate_args(True)
 
     def tearDown(self):
@@ -2189,7 +2187,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(bernoulli.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(bernoulli.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, bernoulli.log_prob, self.tensor_sample_2)
-        self.assertEqual(bernoulli.log_prob(variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(bernoulli.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
 
     def test_geometric_shape_scalar_params(self):
         geometric = Geometric(0.3)
@@ -2209,7 +2207,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(geometric.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(geometric.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, geometric.log_prob, self.tensor_sample_2)
-        self.assertEqual(geometric.log_prob(variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(geometric.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
 
     def test_beta_shape_scalar_params(self):
         dist = Beta(0.1, 0.1)
@@ -2230,7 +2228,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        self.assertEqual(dist.log_prob(variable(torch.ones(3, 1, 1))).size(), torch.Size((3, 3, 2)))
+        self.assertEqual(dist.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
 
     def test_binomial_shape(self):
         dist = Binomial(10, torch.tensor([0.6, 0.3]))
@@ -2249,7 +2247,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        self.assertEqual(dist.log_prob(variable(torch.ones(3, 1, 2))).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(torch.ones(3, 1, 2)).size(), torch.Size((3, 3)))
 
     def test_categorical_shape(self):
         # unbatched
@@ -2260,7 +2258,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2,)))
         self.assertEqual(dist.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertEqual(dist.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
-        self.assertEqual(dist.log_prob(variable(torch.ones(3, 1))).size(), torch.Size((3, 1)))
+        self.assertEqual(dist.log_prob(torch.ones(3, 1)).size(), torch.Size((3, 1)))
         # batched
         dist = Categorical(torch.tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
         self.assertEqual(dist._batch_shape, torch.Size((3,)))
@@ -2269,7 +2267,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.sample((3, 2)).size(), torch.Size((3, 2, 3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_1)
         self.assertEqual(dist.log_prob(self.tensor_sample_2).size(), torch.Size((3, 2, 3)))
-        self.assertEqual(dist.log_prob(variable(torch.ones(3, 1))).size(), torch.Size((3, 3)))
+        self.assertEqual(dist.log_prob(torch.ones(3, 1)).size(), torch.Size((3, 3)))
 
     def test_one_hot_categorical_shape(self):
         # unbatched
@@ -2282,7 +2280,7 @@ class TestDistributionShapes(TestCase):
         simplex_sample = self.tensor_sample_2 / self.tensor_sample_2.sum(-1, keepdim=True)
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3, 2,)))
         self.assertEqual(dist.log_prob(dist.enumerate_support()).size(), torch.Size((3,)))
-        simplex_sample = variable(torch.ones(3, 3)) / 3
+        simplex_sample = torch.ones(3, 3) / 3
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3,)))
         # batched
         dist = OneHotCategorical(torch.tensor([[0.6, 0.3], [0.6, 0.3], [0.6, 0.3]]))
@@ -2294,7 +2292,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
         self.assertEqual(dist.log_prob(dist.enumerate_support()).size(), torch.Size((2, 3)))
-        simplex_sample = variable(torch.ones(3, 1, 2)) / 2
+        simplex_sample = torch.ones(3, 1, 2) / 2
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3, 3)))
 
     def test_cauchy_shape_scalar_params(self):
@@ -2315,7 +2313,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(cauchy.sample(torch.Size((3, 2))).size(), torch.Size((3, 2, 2)))
         self.assertEqual(cauchy.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, cauchy.log_prob, self.tensor_sample_2)
-        self.assertEqual(cauchy.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(cauchy.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_dirichlet_shape(self):
         dist = Dirichlet(torch.tensor([[0.6, 0.3], [1.6, 1.3], [2.6, 2.3]]))
@@ -2326,7 +2324,7 @@ class TestDistributionShapes(TestCase):
         simplex_sample = self.tensor_sample_1 / self.tensor_sample_1.sum(-1, keepdim=True)
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3,)))
         self.assertRaises(ValueError, dist.log_prob, self.tensor_sample_2)
-        simplex_sample = torch.ones((3, 1, 2))
+        simplex_sample = torch.ones(3, 1, 2)
         simplex_sample = simplex_sample / simplex_sample.sum(-1).unsqueeze(-1)
         self.assertEqual(dist.log_prob(simplex_sample).size(), torch.Size((3, 3)))
 
@@ -2348,7 +2346,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(gamma.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(gamma.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, gamma.log_prob, self.tensor_sample_2)
-        self.assertEqual(gamma.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(gamma.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_chi2_shape_scalar_params(self):
         chi2 = Chi2(1)
@@ -2368,7 +2366,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(chi2.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(chi2.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, chi2.log_prob, self.tensor_sample_2)
-        self.assertEqual(chi2.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(chi2.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_studentT_shape_scalar_params(self):
         st = StudentT(1)
@@ -2388,7 +2386,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(st.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(st.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, st.log_prob, self.tensor_sample_2)
-        self.assertEqual(st.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(st.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_pareto_shape_scalar_params(self):
         pareto = Pareto(1, 1)
@@ -2426,7 +2424,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(normal.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(normal.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, normal.log_prob, self.tensor_sample_2)
-        self.assertEqual(normal.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(normal.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_uniform_shape_scalar_params(self):
         uniform = Uniform(0, 1)
@@ -2446,7 +2444,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(uniform.sample(torch.Size((3, 2))).size(), torch.Size((3, 2, 2)))
         self.assertEqual(uniform.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, uniform.log_prob, self.tensor_sample_2)
-        self.assertEqual(uniform.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(uniform.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
     def test_exponential_shape_scalar_param(self):
         expon = Exponential(1.)
@@ -2466,7 +2464,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(expon.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(expon.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, expon.log_prob, self.tensor_sample_2)
-        self.assertEqual(expon.log_prob(variable(torch.ones(2, 2))).size(), torch.Size((2, 2)))
+        self.assertEqual(expon.log_prob(torch.ones(2, 2)).size(), torch.Size((2, 2)))
 
     def test_laplace_shape_scalar_params(self):
         laplace = Laplace(0, 1)
@@ -2486,7 +2484,7 @@ class TestDistributionShapes(TestCase):
         self.assertEqual(laplace.sample((3, 2)).size(), torch.Size((3, 2, 2)))
         self.assertEqual(laplace.log_prob(self.tensor_sample_1).size(), torch.Size((3, 2)))
         self.assertRaises(ValueError, laplace.log_prob, self.tensor_sample_2)
-        self.assertEqual(laplace.log_prob(variable(torch.ones(2, 1))).size(), torch.Size((2, 2)))
+        self.assertEqual(laplace.log_prob(torch.ones(2, 1)).size(), torch.Size((2, 2)))
 
 
 class TestKL(TestCase):
@@ -2903,36 +2901,36 @@ class TestNumericalStability(TestCase):
                                  expected_gradient=tensor_type([0]))
 
     def test_categorical_log_prob(self):
-        for tensor_type in ([torch.FloatTensor, torch.DoubleTensor]):
-            p = variable(tensor_type([0, 1]), requires_grad=True)
+        for dtype in ([torch.float, torch.double]):
+            p = torch.tensor([0, 1], dtype=dtype, requires_grad=True)
             categorical = OneHotCategorical(p)
-            log_pdf = categorical.log_prob(variable(tensor_type([0, 1])))
+            log_pdf = categorical.log_prob(torch.tensor([0, 1], dtype=dtype))
             self.assertEqual(log_pdf.item(), 0)
 
     def test_categorical_log_prob_with_logits(self):
-        for tensor_type in ([torch.FloatTensor, torch.DoubleTensor]):
-            p = variable(tensor_type([-float('inf'), 0]), requires_grad=True)
+        for dtype in ([torch.float, torch.double]):
+            p = torch.tensor([-float('inf'), 0], dtype=dtype, requires_grad=True)
             categorical = OneHotCategorical(logits=p)
-            log_pdf_prob_1 = categorical.log_prob(variable(tensor_type([0, 1])))
+            log_pdf_prob_1 = categorical.log_prob(torch.tensor([0, 1], dtype=dtype))
             self.assertEqual(log_pdf_prob_1.item(), 0)
-            log_pdf_prob_0 = categorical.log_prob(variable(tensor_type([1, 0])))
+            log_pdf_prob_0 = categorical.log_prob(torch.tensor([1, 0], dtype=dtype))
             self.assertEqual(log_pdf_prob_0.item(), -float('inf'), allow_inf=True)
 
     def test_multinomial_log_prob(self):
-        for tensor_type in [torch.FloatTensor, torch.DoubleTensor]:
-            p = variable(tensor_type([0, 1]), requires_grad=True)
-            s = variable(tensor_type([0, 10]))
+        for dtype in ([torch.float, torch.double]):
+            p = torch.tensor([0, 1], dtype=dtype, requires_grad=True)
+            s = torch.tensor([0, 10], dtype=dtype)
             multinomial = Multinomial(10, p)
             log_pdf = multinomial.log_prob(s)
             self.assertEqual(log_pdf.item(), 0)
 
     def test_multinomial_log_prob_with_logits(self):
-        for tensor_type in [torch.FloatTensor, torch.DoubleTensor]:
-            p = variable(tensor_type([-float('inf'), 0]), requires_grad=True)
+        for dtype in ([torch.float, torch.double]):
+            p = torch.tensor([-float('inf'), 0], dtype=dtype, requires_grad=True)
             multinomial = Multinomial(10, logits=p)
-            log_pdf_prob_1 = multinomial.log_prob(variable(tensor_type([0, 10])))
+            log_pdf_prob_1 = multinomial.log_prob(torch.tensor([0, 10], dtype=dtype))
             self.assertEqual(log_pdf_prob_1.item(), 0)
-            log_pdf_prob_0 = multinomial.log_prob(variable(tensor_type([10, 0])))
+            log_pdf_prob_0 = multinomial.log_prob(torch.tensor([10, 0], dtype=dtype))
             self.assertEqual(log_pdf_prob_0.item(), -float('inf'), allow_inf=True)
 
 
@@ -2949,7 +2947,7 @@ class TestLazyLogitsInitialization(TestCase):
                 param['logits'] = probs_to_logits(probs)
                 dist = Dist(**param)
                 shape = (1,) if not dist.event_shape else dist.event_shape
-                dist.log_prob(variable(torch.ones(shape)))
+                dist.log_prob(torch.ones(shape))
                 message = 'Failed for {} example 0/{}'.format(Dist.__name__, len(params))
                 self.assertFalse('probs' in vars(dist), msg=message)
                 try:
@@ -2980,11 +2978,10 @@ class TestLazyLogitsInitialization(TestCase):
 @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
 class TestAgainstScipy(TestCase):
     def setUp(self):
-        positive_var = variable(torch.Tensor(20,).normal_()).exp()
-        positive_var2 = variable(torch.Tensor(20,).normal_()).exp()
-        random_var = variable(torch.Tensor(20,).normal_())
-        random_tensor = torch.Tensor(20,).normal_()
-        simplex_tensor = softmax(random_tensor)
+        positive_var = torch.randn(20).exp()
+        positive_var2 = torch.randn(20).exp()
+        random_var = torch.randn(20)
+        simplex_tensor = softmax(torch.randn(20))
         self.distribution_pairs = [
             (
                 Bernoulli(simplex_tensor),
@@ -3103,7 +3100,7 @@ class TestAgainstScipy(TestCase):
 
     def test_icdf(self):
         for pytorch_dist, scipy_dist in self.distribution_pairs:
-            samples = variable(torch.rand((5,) + pytorch_dist.batch_shape))
+            samples = torch.rand((5,) + pytorch_dist.batch_shape)
             try:
                 icdf = pytorch_dist.icdf(samples)
             except NotImplementedError:
@@ -3148,12 +3145,12 @@ class TestTransforms(TestCase):
                 ]),
                 ComposeTransform([
                     AffineTransform(0, 1, cache_size=cache_size),
-                    AffineTransform(variable(torch.Tensor(4, 5).normal_()),
-                                    variable(torch.Tensor(4, 5).normal_()),
+                    AffineTransform(torch.randn(4, 5),
+                                    torch.randn(4, 5),
                                     cache_size=cache_size),
                     AffineTransform(1, -2, cache_size=cache_size),
-                    AffineTransform(variable(torch.Tensor(4, 5).normal_()),
-                                    variable(torch.Tensor(4, 5).normal_()),
+                    AffineTransform(torch.randn(4, 5),
+                                    torch.randn(4, 5),
                                     cache_size=cache_size),
                 ]),
             ]
@@ -3385,7 +3382,7 @@ class TestConstraintRegistry(TestCase):
             except NotImplementedError:
                 continue
             self.assertTrue(t.bijective, "biject_to({}) is not bijective".format(constraint))
-            x = variable(torch.Tensor(5, 5)).normal_()
+            x = torch.randn(5, 5)
             y = t(x)
             self.assertTrue(constraint.check(y).all(), '\n'.join([
                 "Failed to biject_to({})".format(constraint),
@@ -3406,7 +3403,8 @@ class TestConstraintRegistry(TestCase):
             except NotImplementedError:
                 continue
             self.assertTrue(t.bijective, "biject_to({}) is not bijective".format(constraint))
-            x = variable(torch.Tensor(5, 5)).normal_().cuda()
+            # x = torch.randn(5, 5, device="cuda")
+            x = torch.randn(5, 5).cuda()
             y = t(x)
             self.assertTrue(constraint.check(y).all(), '\n'.join([
                 "Failed to biject_to({})".format(constraint),
@@ -3422,7 +3420,7 @@ class TestConstraintRegistry(TestCase):
     def test_transform_to(self):
         for constraint in self.get_constraints():
             t = transform_to(constraint)
-            x = variable(torch.Tensor(5, 5)).normal_()
+            x = torch.randn(5, 5)
             y = t(x)
             self.assertTrue(constraint.check(y).all(), "Failed to transform_to({})".format(constraint))
             x2 = t.inv(y)
@@ -3433,7 +3431,8 @@ class TestConstraintRegistry(TestCase):
     def test_transform_to_cuda(self):
         for constraint in self.get_constraints(is_cuda=True):
             t = transform_to(constraint)
-            x = variable(torch.Tensor(5, 5)).normal_().cuda()
+            # x = torch.randn(5, 5, device="cuda")
+            x = torch.randn(5, 5).cuda()
             y = t(x)
             self.assertTrue(constraint.check(y).all(), "Failed to transform_to({})".format(constraint))
             x2 = t.inv(y)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -161,7 +161,7 @@ class TestIndexing(TestCase):
         self.assertEqual(a[1].data_ptr(), a[one.short()].data_ptr())
 
         # scalar indexed with scalar
-        r = torch.tensor(0.).normal_()
+        r = torch.randn(())
         with self.assertRaises(RuntimeError):
             r[:]
         with self.assertRaises(IndexError):
@@ -184,7 +184,7 @@ class TestIndexing(TestCase):
         self.assertEqual(7.7, a[1, 0])
 
         # scalar indexed with scalars
-        r = torch.tensor(0.).normal_()
+        r = torch.randn(())
         with self.assertRaises(RuntimeError):
             r[:] = 8.8
         with self.assertRaises(IndexError):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1263,10 +1263,10 @@ class TestNN(NNTestCase):
         l = nn.Linear(10, 10)
         clip_value = 2.5
 
-        grad_w, grad_b = torch.arange(-50, 50).view(10, 10).div(5), torch.ones(10).mul(2)
+        grad_w, grad_b = torch.arange(-50, 50).view(10, 10).div_(5), torch.ones(10).mul_(2)
         for grad_list in [[grad_w, grad_b], [grad_w, None]]:
             for p, g in zip(l.parameters(), grad_list):
-                p._grad = Variable(g.clone().view_as(p.data)) if g is not None else g
+                p._grad = g.clone().view_as(p.data) if g is not None else g
 
         clip_grad_value_(l.parameters(), clip_value)
         for p in filter(lambda p: p.grad is not None, l.parameters()):
@@ -2785,7 +2785,6 @@ class TestNN(NNTestCase):
             (1, 256, 80, 128),
             (1, 256, 120, 192),
         ]
-        dtype = getattr(torch.cuda, dtype.__name__)
 
         def run_test(benchmark):
             with torch.backends.cudnn.flags(benchmark=benchmark):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -36,18 +36,18 @@ from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
 if TEST_SCIPY:
     from scipy import stats
 
-ALL_TENSORTYPES = [torch.FloatTensor,
-                   torch.DoubleTensor,
-                   torch.HalfTensor]
+ALL_TENSORTYPES = [torch.float,
+                   torch.double,
+                   torch.half]
 
-NO_HALF_TENSORTYPES = [torch.FloatTensor,
-                       torch.DoubleTensor]
+NO_HALF_TENSORTYPES = [torch.float,
+                       torch.double]
 
-DOUBLE_TENSORTYPES = [torch.DoubleTensor]
+DOUBLE_TENSORTYPES = [torch.double]
 
-type2prec = {'FloatTensor': 1e-5,
-             'DoubleTensor': 1e-5,
-             'HalfTensor': 1e-2}
+dtype2prec = {torch.float: 1e-5,
+              torch.double: 1e-5,
+              torch.half: 1e-2}
 
 
 # WARNING: If you add a new top-level test case to this file, you MUST
@@ -94,12 +94,12 @@ class PackedSequenceTest(TestCase):
         """Create ordered list of random sequences"""
         seqs = [tensor_type(random.randint(1, self.max_length))
                 for _ in range(self.batch_size)]
-        seqs = [Variable(s.random_()) for s in seqs]
+        seqs = [s.random_() for s in seqs]
         ordered = sorted(seqs, key=len, reverse=True)
         return ordered
 
     def _padded_sequence(self, tensor_type):
-        """Create Variable of random padded sequences"""
+        """Create Tensor of random padded sequences"""
         ordered = self._ordered_sequence(tensor_type)
         lengths = list(map(len, ordered))
         padded_tensor = rnn_utils.pad_sequence(ordered)
@@ -385,10 +385,10 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
     def test_cuda(self, test_case, dtype=None):
         def convert_dtype(obj, dtype, requires_grad=False):
-            if isinstance(obj, Variable):
-                return Variable(obj.data.type(dtype), requires_grad=requires_grad)
-            elif torch.is_tensor(obj):
-                return obj.type(dtype)
+            if isinstance(obj, torch.Tensor):
+                return torch.tensor(obj.data, dtype=dtype, requires_grad=requires_grad)
+            elif isinstance(obj, torch.Tensor):
+                return obj.to(dtype)
             elif isinstance(obj, tuple):
                 return tuple(convert_dtype(o, dtype, requires_grad) for o in obj)
             else:
@@ -417,7 +417,7 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
             gpu_module.cuda()
 
             # torch.HalfTensor doesn't support most operations, converting back to default
-            if dtype == torch.HalfTensor:
+            if dtype == torch.half:
                 cpu_input = self._get_input()
                 cpu_target = self._get_target()
                 # Loss modules with weights require consistent input/module weight types
@@ -426,11 +426,11 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
             cpu_output = test_case._forward_criterion(cpu_module, cpu_input, cpu_target)
             gpu_output = test_case._forward_criterion(gpu_module, gpu_input, gpu_target)
             # dtype can be None, so set precision in this way instead of a precision map
-            test_case.assertEqual(cpu_output, gpu_output, 1e-1 if dtype == torch.HalfTensor else 4e-4)
+            test_case.assertEqual(cpu_output, gpu_output, 1e-1 if dtype == torch.half else 4e-4)
 
             cpu_gradInput = test_case._backward_criterion(cpu_module, cpu_input, cpu_target)
             gpu_gradInput = test_case._backward_criterion(gpu_module, gpu_input, gpu_target)
-            test_case.assertEqual(cpu_gradInput, gpu_gradInput, 1e-1 if dtype == torch.HalfTensor else 4e-4)
+            test_case.assertEqual(cpu_gradInput, gpu_gradInput, 1e-1 if dtype == torch.half else 4e-4)
         except NotImplementedError:
             pass
 
@@ -501,12 +501,12 @@ class TestNN(NNTestCase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SourceChangeWarning)
             m = torch.load(path)
-        input = Variable(torch.randn(2, 3).float())
+        input = torch.randn(2, 3, dtype=torch.float)
         self.assertEqual(m(input).size(), (2, 5))
 
     def test_hooks(self):
         module = nn.Sigmoid()
-        input = Variable(torch.ones(5, 5), requires_grad=True)
+        input = torch.ones(5, 5, requires_grad=True)
 
         counter = {
             'forwards': 0,
@@ -515,7 +515,7 @@ class TestNN(NNTestCase):
 
         def fw_hook(inc, h_module, input, output):
             self.assertIsInstance(input, tuple)
-            self.assertIsInstance(output, Variable)
+            self.assertTrue(isinstance(output, torch.Tensor))
             self.assertTrue(h_module is module)
             self.assertEqual(input[0].data, torch.ones(5, 5))
             self.assertEqual(output.data, torch.Tensor(5, 5).fill_(1 / (1 + 1 / math.e)))
@@ -588,12 +588,12 @@ class TestNN(NNTestCase):
             self.assertEqual(module, bn)
 
         bn.register_backward_hook(hook)
-        output = bn(Variable(torch.randn(5, 5), requires_grad=True))
+        output = bn(torch.randn(5, 5, requires_grad=True))
         output.sum().backward()
 
     def test_hook_fail(self):
         module = nn.Sigmoid()
-        input = Variable(torch.randn(5, 5), requires_grad=True)
+        input = torch.randn(5, 5, requires_grad=True)
 
         def fw_fail1(self, input, output):
             return output
@@ -633,13 +633,13 @@ class TestNN(NNTestCase):
 
     def test_hook_writeable(self):
         module = nn.Linear(5, 5)
-        input = Variable(torch.randn(5, 5), requires_grad=True)
+        input = torch.randn(5, 5, requires_grad=True)
 
         def bw_hook(module, grad_input, grad_output):
             for grad in grad_input:
-                self.assertIsInstance(grad, Variable)
+                self.assertTrue(isinstance(grad, torch.Tensor))
             for grad in grad_output:
-                self.assertIsInstance(grad, Variable)
+                self.assertTrue(isinstance(grad, torch.Tensor))
             return tuple(gi * 2 for gi in grad_input)
 
         module.register_backward_hook(bw_hook)
@@ -648,7 +648,7 @@ class TestNN(NNTestCase):
         self.assertEqual(input.grad.data, expected_grad)
 
     def test_zero_grad(self):
-        i = Variable(torch.randn(2, 5), requires_grad=True)
+        i = torch.randn(2, 5, requires_grad=True)
         module = nn.Linear(5, 5)
         for p in module.parameters():
             p.requires_grad = False
@@ -680,8 +680,8 @@ class TestNN(NNTestCase):
     def test_no_grad(self):
         module = nn.Conv2d(2, 5, kernel_size=3, padding=1)
         input = torch.randn(1, 2, 10, 10)
-        x = Variable(input)
-        y = Variable(input.clone())
+        x = input
+        y = input.clone()
 
         output = module(x)
         self.assertTrue(output.requires_grad)
@@ -697,14 +697,14 @@ class TestNN(NNTestCase):
         input.fill_(1 - p)
 
         module = cls(p)
-        input_var = Variable(input, requires_grad=True)
+        input_var = torch.tensor(input, requires_grad=True)
         output = module(input_var)
         self.assertLess(abs(output.data.mean() - (1 - p)), 0.05)
         output.backward(input)
         self.assertLess(abs(input_var.grad.data.mean() - (1 - p)), 0.05)
 
         module = cls(p, True)
-        input_var = Variable(input.clone(), requires_grad=True)
+        input_var = torch.tensor(input.clone(), requires_grad=True)
         output = module(input_var + 0)
         self.assertLess(abs(output.data.mean() - (1 - p)), 0.05)
         output.backward(input)
@@ -775,7 +775,7 @@ class TestNN(NNTestCase):
                 return {"output": self.l1(inputs).sum()}
 
         net = Net()
-        model_output = net(Variable(torch.randn([5, 10])))
+        model_output = net(torch.randn([5, 10]))
         model_output["output"].backward()
         self.assertTrue(net.check_backward_hook_flag)
 
@@ -844,7 +844,7 @@ class TestNN(NNTestCase):
                 super(Net, self).__init__()
                 self.l1 = l
                 self.l2 = l
-                self.param = Variable(torch.Tensor(3, 5))
+                self.param = torch.empty(3, 5)
 
         l = nn.Linear(10, 20)
         n = Net()
@@ -857,7 +857,7 @@ class TestNN(NNTestCase):
                 super(Net, self).__init__()
                 self.l1 = l
                 self.l2 = l
-                self.param = Variable(torch.Tensor(3, 5))
+                self.param = torch.empty(3, 5)
                 self.block = block
         l = nn.Linear(10, 20)
         l1 = nn.Linear(10, 20)
@@ -1293,7 +1293,7 @@ class TestNN(NNTestCase):
         self.assertTrue(torch.equal(sample.data, vec.data[:5]))
 
     def test_weight_norm(self):
-        input = Variable(torch.randn(3, 5))
+        input = torch.randn(3, 5)
         m = nn.Linear(5, 7)
         expected_output = m(input)
 
@@ -1379,10 +1379,10 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_embedding_max_norm_cuda(self, dtype=torch.FloatTensor):
-        embedding = nn.Embedding(22, 5, max_norm=1.0).type(dtype).cuda()
+    def test_embedding_max_norm_cuda(self, dtype=torch.float):
+        embedding = nn.Embedding(22, 5, max_norm=1.0).to("cuda", dtype=dtype)
         # nn.Embedding only takes LongTensor as input
-        input = Variable(torch.LongTensor([2, 8, 8, 6])).cuda()
+        input = torch.tensor([2, 8, 8, 6], device="cuda", dtype=torch.long)
         output = embedding(input)
         self.assertEqual(output[1], output[2])
         self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
@@ -1397,11 +1397,11 @@ class TestNN(NNTestCase):
         self.assertEqual(a, output)
 
     def test_embedding_functional(self):
-        a = Variable(torch.LongTensor([
+        a = torch.tensor([
             [1, 3, 2],
             [0, 2, 1]
-        ]))
-        embeddings = Variable(torch.rand(4, 3), requires_grad=True)
+        ], dtype=torch.long)
+        embeddings = torch.rand(4, 3, requires_grad=True)
 
         embed_old = torch.nn.Embedding(4, 3)
         embed_old.weight.data = embeddings.data
@@ -1410,7 +1410,7 @@ class TestNN(NNTestCase):
         res_F = F.embedding(a, embeddings)
         self.assertEqual(res_old, res_F)
 
-    def _test_gumbel_softmax_st(self, cuda, dtype=torch.FloatTensor):
+    def _test_gumbel_softmax_st(self, cuda, dtype=torch.float):
         th = torch.cuda if cuda else torch
         """
         Things we might want to check:
@@ -1421,10 +1421,10 @@ class TestNN(NNTestCase):
         """
         num_draws = 100
         K = 3
-        logits = torch.FloatTensor([[0.2, 0.8, 0.1]])
-        if dtype != torch.HalfTensor:
-            logits = logits.type(dtype)
-        logits_softmax = torch.nn.functional.softmax(Variable(logits), 1)
+        logits = torch.tensor([[0.2, 0.8, 0.1]])
+        if dtype != torch.half:
+            logits = logits.to(dtype)
+        logits_softmax = torch.nn.functional.softmax(logits, 1)
         y_draws = torch.zeros(num_draws, K)
         preds = torch.zeros(num_draws)
 
@@ -1435,17 +1435,17 @@ class TestNN(NNTestCase):
 
         exceed_limits = 0
         for draw in range(num_draws):
-            logits_var = Variable(logits, requires_grad=True)
+            logits_var = torch.tensor(logits, requires_grad=True)
             y_draw = torch.nn.functional.gumbel_softmax(
                 logits_var,
                 hard=True)
             assert y_draw.size() == logits.size()
             # check we have a gradient
             assert y_draw.requires_grad
-            err = y_draw - Variable(logits.new([[0, 0.5, 0.3]]))
+            err = y_draw - logits.new_tensor([[0, 0.5, 0.3]])
             loss = (err * err).sum()
             loss.backward()
-            if logits_var.grad.data.std() < 0.01 or logits_var.grad.data.std() > 1.0:
+            if logits_var.grad.std() < 0.01 or logits_var.grad.std() > 1.0:
                 exceed_limits += 1
             y_draws[draw] = y_draw.data
             _, pred = y_draw.max(1)
@@ -1466,46 +1466,38 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_gumbel_softmax_st_cuda(self, dtype=torch.FloatTensor):
+    def test_gumbel_softmax_st_cuda(self, dtype=torch.float):
         self._test_gumbel_softmax_st(True, dtype=dtype)
 
-    def _test_EmbeddingBag(self, cuda, mode, sparse, dtype=torch.DoubleTensor):
+    def _test_EmbeddingBag(self, cuda, mode, sparse, dtype=torch.double):
         # check a known test example
-        es = nn.EmbeddingBag(5, 2, mode=mode, sparse=sparse)
-        es.weight.data.copy_(torch.arange(1, 11).resize_as_(es.weight.data))
-        es.type(dtype)
-        input = Variable(torch.LongTensor([3, 1, 1, 1, 4, 0]))
-        offsets = Variable(torch.LongTensor([0, 3]))
-        grad_output = torch.arange(1, 5).view(2, 2).type(dtype)
+        device = torch.device("cuda") if cuda else torch.device("cpu")
+        es = nn.EmbeddingBag(5, 2, mode=mode, sparse=sparse).to(device, dtype)
+        es.weight.data.copy_(torch.arange(1, 11, device=device, dtype=dtype).view_as(es.weight))
+        input = torch.tensor([3, 1, 1, 1, 4, 0], device=device, dtype=torch.long)
+        offsets = torch.tensor([0, 3], device=device, dtype=torch.long)
+        grad_output = torch.arange(1, 5, device=device, dtype=dtype).view(2, 2)
 
         if mode == 'sum':
-            expected_output = torch.Tensor(
+            expected_output = torch.tensor(
                 [[13, 16],
-                 [13, 16]])
-            expected_grad_weight = torch.Tensor(
+                 [13, 16]], device=device, dtype=dtype)
+            expected_grad_weight = torch.tensor(
                 [[3, 4],
                  [5, 8],
                  [0, 0],
                  [1, 2],
-                 [3, 4]])
+                 [3, 4]], device=device, dtype=dtype)
         else:
-            expected_output = torch.Tensor(
+            expected_output = torch.tensor(
                 [[13. / 3, 16. / 3],
-                 [13. / 3, 16. / 3]])
-            expected_grad_weight = torch.Tensor(
+                 [13. / 3, 16. / 3]], device=device, dtype=dtype)
+            expected_grad_weight = torch.tensor(
                 [[3. / 3, 4. / 3],
                  [1. / 3 + 1. / 3 + 3. / 3, 2. / 3 + 2. / 3 + 4. / 3],
                  [0., 0.],
                  [1. / 3, 2. / 3],
-                 [3. / 3, 4. / 3]])
-
-        if cuda:
-            es = es.cuda()
-            input = input.cuda()
-            offsets = offsets.cuda()
-            grad_output = grad_output.cuda()
-            expected_output = expected_output.cuda()
-            expected_grad_weight = expected_grad_weight.cuda()
+                 [3. / 3, 4. / 3]], device=device, dtype=dtype)
 
         output = es(input, offsets)
         output.backward(grad_output)
@@ -1514,10 +1506,10 @@ class TestNN(NNTestCase):
         if sparse:
             es_weight_grad = es.weight.grad.data.to_dense()
         self.assertEqual(output.data, expected_output)
-        self.assertEqual(es_weight_grad, expected_grad_weight, type2prec[dtype.__name__])
+        self.assertEqual(es_weight_grad, expected_grad_weight, dtype2prec[dtype])
 
         # check same example except as 2D (2 x 3)
-        input = Variable(input.data.view(2, -1))
+        input = input.data.view(2, -1)
         es.zero_grad()
         output = es(input)
         output.backward(grad_output)
@@ -1526,23 +1518,16 @@ class TestNN(NNTestCase):
         if sparse:
             es_weight_grad = es.weight.grad.data.to_dense()
         self.assertEqual(output.data, expected_output)
-        self.assertEqual(es_weight_grad, expected_grad_weight, type2prec[dtype.__name__])
+        self.assertEqual(es_weight_grad, expected_grad_weight, dtype2prec[dtype])
 
         # now compare EmbeddingBag vs Embedding + Sum/Mean, for constant bag length
         def _test_vs_Embedding(N, D, B, L):
-            es = nn.EmbeddingBag(N, D, mode=mode, sparse=sparse).type(dtype)
-            e = nn.Embedding(N, D).type(dtype)
+            es = nn.EmbeddingBag(N, D, mode=mode, sparse=sparse).to(device, dtype)
+            e = nn.Embedding(N, D).to(device, dtype)
             e.weight.data.copy_(es.weight.data)
-            input = Variable(torch.rand(B, L).mul(N).long())
-            offsets = Variable(torch.arange(0, B).mul(L).long())
-            grad_output = torch.rand(B, D).type(dtype)
-
-            if cuda:
-                es = es.cuda()
-                e = e.cuda()
-                input = input.cuda()
-                offsets = offsets.cuda()
-                grad_output = grad_output.cuda()
+            input = torch.randint(N, (B, L), device=device, dtype=torch.long)
+            offsets = torch.arange(0, B, device=device, dtype=torch.long).mul_(L)
+            grad_output = torch.rand(B, D, device=device, dtype=dtype)
 
             output = es(input.view(-1), offsets)
             if mode == 'sum':
@@ -1550,14 +1535,14 @@ class TestNN(NNTestCase):
             else:
                 ref_output = e(input).mean(1)
 
-            self.assertEqual(output, ref_output, type2prec[dtype.__name__])
+            self.assertEqual(output, ref_output, dtype2prec[dtype])
 
             output.backward(grad_output)
             ref_output.backward(grad_output)
             es_weight_grad = es.weight.grad.data
             if sparse:
                 es_weight_grad = es.weight.grad.data.to_dense()
-            self.assertEqual(es_weight_grad, e.weight.grad, type2prec[dtype.__name__])
+            self.assertEqual(es_weight_grad, e.weight.grad, dtype2prec[dtype])
 
         N, D, B, L = random.randint(1, 100), random.randint(1, 100), random.randint(1, 50), random.randint(1, 50)
         _test_vs_Embedding(N, D, B, L)
@@ -1566,8 +1551,8 @@ class TestNN(NNTestCase):
 
         # check that giving illegal input combos raises error
         es = nn.EmbeddingBag(10, 20, mode=mode, sparse=sparse)
-        input = Variable(torch.ones(3, 4))
-        offset = Variable(torch.arange(0, 3))
+        input = torch.ones(3, 4)
+        offset = torch.arange(0, 3)
         self.assertRaises(ValueError, lambda: es(input, offset))
         self.assertRaises(ValueError, lambda: es(input.view(-1)))
         offset[0] = 1
@@ -1579,7 +1564,7 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pool3d_size_one_feature_dim(self):
         # Tests crazy strides for feature dim of size 1
-        x = Variable(torch.randn(7, 1, 5, 3, 2).cuda())
+        x = Variable(torch.randn(7, 1, 5, 3, 2, device="cuda"))
         strange_strides = [30, 1234, 6, 2, 1]
         y = x.as_strided(x.size(), strange_strides)
         x = x.cpu().as_strided(x.size(), strange_strides)
@@ -1598,10 +1583,10 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_AvgPool3d_backward_after_cat_dim1_cuda(self):
         # x has to have batch_size 1 to test contiguous checks
-        x = Variable(torch.randn(1, 3, 4, 4, 4).cuda(), requires_grad=True)
+        x = torch.randn(1, 3, 4, 4, 4, device="cuda", requires_grad=True)
         y = F.avg_pool3d(x, kernel_size=3, padding=1, stride=2)
 
-        grad = torch.randn(y.size()).cuda()
+        grad = torch.randn(y.size(), device="cuda")
         # increase the stride in dimension 0. the tensor is still contiguous because size[0] is 1
         stride = list(grad.stride())
         stride[0] = stride[0] * 2
@@ -1613,14 +1598,14 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_contig_wrong_stride_cudnn(self):
         # x has to have batch_size 1 to test contiguous checks
-        x = torch.randn(1, 16, 5, 5).cuda()
+        x = torch.randn(1, 16, 5, 5, device="cuda")
         stride = list(x.stride())
         stride[0] = 20
         # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
         x.set_(x.storage(), 0, x.size(), stride)
         self.assertTrue(x.is_contiguous())
-        F.conv_transpose2d(Variable(x), Variable(torch.randn(16, 1, 1, 1)).cuda())
-        F.conv2d(Variable(x), Variable(torch.randn(1, 16, 1, 1)).cuda())
+        F.conv_transpose2d(x, torch.randn(16, 1, 1, 1, device="cuda"))
+        F.conv2d(x, torch.randn(1, 16, 1, 1, device="cuda"))
 
     def test_embedding_bag(self):
         self._test_EmbeddingBag(False, 'sum', False)
@@ -1630,16 +1615,16 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_embedding_bag_cuda(self, dtype=torch.FloatTensor):
+    def test_embedding_bag_cuda(self, dtype=torch.float):
         self._test_EmbeddingBag(True, 'sum', False, dtype)
         self._test_EmbeddingBag(True, 'mean', False, dtype)
-        if dtype != torch.HalfTensor:
+        if dtype != torch.half:
             # torch.cuda.sparse.HalfTensor is not enabled.
             self._test_EmbeddingBag(True, 'sum', True, dtype)
             self._test_EmbeddingBag(True, 'mean', True, dtype)
 
     def test_fractional_max_pool2d(self):
-        x = Variable(torch.randn(1, 2, 7, 7), requires_grad=True)
+        x = torch.randn(1, 2, 7, 7, requires_grad=True)
         samples = x.new(1, 2, 2).uniform_()
 
         def func(x):
@@ -1650,7 +1635,7 @@ class TestNN(NNTestCase):
         gradcheck(func, [x])
         gradgradcheck(func, [x])
 
-        x = Variable(torch.randn(2, 7, 7), requires_grad=True)
+        x = torch.randn(2, 7, 7, requires_grad=True)
         samples = x.new(2, 2).uniform_()
         self.assertEqual(func(x).shape, (2, 3, 3))
         gradcheck(func, [x])
@@ -1686,7 +1671,7 @@ class TestNN(NNTestCase):
 
         for p in [0.2, 0.5, 0.8]:
             module = nn.AlphaDropout(p)
-            input_var = Variable(input, requires_grad=True)
+            input_var = torch.tensor(input, requires_grad=True)
             output = module(input_var)
             # output mean should be close to input mean
             self.assertLess(abs(output.data.mean() - mean), 0.1)
@@ -1694,12 +1679,12 @@ class TestNN(NNTestCase):
             self.assertLess(abs(output.data.std() - std), 0.1)
             output.backward(input)
 
-    def _test_InstanceNorm_general(self, cls, input, type):
+    def _test_InstanceNorm_general(self, cls, input, device="cpu", dtype=torch.float):
         # default case track_running_stats=False
         b, c = input.size(0), input.size(1)
-        input_var = Variable(input.type(type), requires_grad=True)
+        input_var = torch.tensor(input, device=device, dtype=dtype, requires_grad=True)
 
-        IN = cls(c, eps=0).type(type)
+        IN = cls(c, eps=0).to(device, dtype)
 
         output = IN(input_var)
         out_reshaped = output.view(b * c, -1)
@@ -1711,7 +1696,7 @@ class TestNN(NNTestCase):
         self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
 
         # check that eval mode doesn't change behavior
-        grad_out = output.data.clone().normal_()
+        grad_out = torch.randn_like(output)
         res1 = output.data.clone()
         output.backward(grad_out)
         grad1 = input_var.grad.data.clone()
@@ -1727,14 +1712,14 @@ class TestNN(NNTestCase):
 
         # If track_running_stats=True and momentum=1, running_mean/var should be
         # equal to mean/var of the input (with unbias correction)
-        IN = cls(c, momentum=1, eps=0, track_running_stats=True).type(type)
+        IN = cls(c, momentum=1, eps=0, track_running_stats=True).to(device, dtype)
 
-        output = IN(input_var.type(type))
+        output = IN(input_var)
 
-        input_reshaped = input_var.transpose(1, 0).contiguous().view(c, -1)
+        input_reshaped = input_var.transpose(1, 0).reshape(c, -1)
         mean = input_reshaped.mean(1)
 
-        input_reshaped = input_var.transpose(1, 0).contiguous().view(c, b, -1)
+        input_reshaped = input_var.transpose(1, 0).reshape(c, b, -1)
         var = input_reshaped.var(2, unbiased=True)[:, :]
 
         self.assertAlmostEqual(torch.abs(mean.data - IN.running_mean).mean(), 0, delta=1e-5)
@@ -1743,14 +1728,15 @@ class TestNN(NNTestCase):
         # in eval mode, adding X * std to a channel in input should make the
         # corresponding channel in output have mean X
         IN.eval()
-        delta = (IN.running_var.sqrt() * torch.arange(c).type(type)).view(-1, *[1 for _ in range(2, input.dim())])
-        output = IN(input_var + Variable(delta))
-        self.assertEqual(output.transpose(0, 1).contiguous().view(c, -1).mean(1), torch.arange(c))
+        delta = IN.running_var.sqrt() * torch.arange(c, device=device, dtype=dtype)
+        delta = delta.view(-1, *[1 for _ in range(2, input.dim())])
+        output = IN(input_var + delta)
+        self.assertEqual(output.transpose(0, 1).reshape(c, -1).mean(1), torch.arange(c))
 
     def _test_InstanceNorm_cuda_half(self, cls, input):
         # THNN
         input = Variable(input.cuda().half().random_(1, 10), requires_grad=True)
-        m = cls(input.size(1), affine=True, track_running_stats=True).cuda().half()
+        m = cls(input.size(1), affine=True, track_running_stats=True).to("cuda", torch.half)
         thnn_output = m(input)
         thnn_output.sum().backward()
         thnn_input_grad = input.grad.data.clone()
@@ -1771,8 +1757,8 @@ class TestNN(NNTestCase):
         c = random.randint(3, 5)
         d = random.randint(8, 10)
 
-        input = torch.Tensor(b, c, d).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm1d, input, torch.FloatTensor)
+        input = torch.rand(b, c, d)
+        self._test_InstanceNorm_general(nn.InstanceNorm1d, input, dtype=torch.float)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_InstanceNorm1d_general_cuda(self):
@@ -1780,8 +1766,8 @@ class TestNN(NNTestCase):
         c = random.randint(3, 5)
         d = random.randint(8, 10)
 
-        input = torch.Tensor(b, c, d).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm1d, input, torch.cuda.FloatTensor)
+        input = torch.rand(b, c, d)
+        self._test_InstanceNorm_general(nn.InstanceNorm1d, input, "cuda", torch.float)
         self._test_InstanceNorm_cuda_half(nn.InstanceNorm1d, input)
 
     def test_InstanceNorm2d_general(self):
@@ -1790,8 +1776,8 @@ class TestNN(NNTestCase):
         w = random.randint(3, 6)
         h = random.randint(6, 8)
 
-        input = torch.Tensor(b, c, h, w).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm2d, input, torch.FloatTensor)
+        input = torch.rand(b, c, h, w)
+        self._test_InstanceNorm_general(nn.InstanceNorm2d, input, dtype=torch.float)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_InstanceNorm2d_general_cuda(self):
@@ -1800,8 +1786,8 @@ class TestNN(NNTestCase):
         w = random.randint(3, 6)
         h = random.randint(6, 8)
 
-        input = torch.Tensor(b, c, h, w).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm2d, input, torch.cuda.FloatTensor)
+        input = torch.rand(b, c, h, w)
+        self._test_InstanceNorm_general(nn.InstanceNorm2d, input, "cuda", torch.float)
         self._test_InstanceNorm_cuda_half(nn.InstanceNorm2d, input)
 
     def test_InstanceNorm3d_general(self):
@@ -1811,8 +1797,8 @@ class TestNN(NNTestCase):
         h = random.randint(2, 5)
         d = random.randint(2, 5)
 
-        input = torch.Tensor(b, c, h, w, d).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm3d, input, torch.FloatTensor)
+        input = torch.rand(b, c, h, w, d)
+        self._test_InstanceNorm_general(nn.InstanceNorm3d, input, dtype=torch.float)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_InstanceNorm3d_general_cuda(self):
@@ -1822,20 +1808,20 @@ class TestNN(NNTestCase):
         h = random.randint(2, 5)
         d = random.randint(2, 5)
 
-        input = torch.Tensor(b, c, h, w, d).uniform_()
-        self._test_InstanceNorm_general(nn.InstanceNorm3d, input, torch.cuda.FloatTensor)
+        input = torch.rand(b, c, h, w, d)
+        self._test_InstanceNorm_general(nn.InstanceNorm3d, input, "cuda", torch.float)
         self._test_InstanceNorm_cuda_half(nn.InstanceNorm3d, input)
 
-    def _test_LayerNorm_general(self, type):
+    def _test_LayerNorm_general(self, device="cpu", dtype=torch.float):
         for i in range(2, 6):
-            shape = torch.LongTensor(i).random_(3, 6).tolist()
-            x = type(*shape).uniform_(0, 10)
+            shape = torch.randint(3, 6, (i,), dtype=torch.long).tolist()
+            x = torch.empty(*shape, device=device, dtype=dtype).uniform_(0, 10)
             normalized_ndim = random.randint(1, i - 1)  # inclusive
             normalized_shape = shape[-normalized_ndim:]
             unnormalized_shape = shape[:-normalized_ndim]
 
             # test that LN normalizes to mean 0 and stddev 1
-            ln = nn.LayerNorm(normalized_shape, eps=0).type(type)
+            ln = nn.LayerNorm(normalized_shape, eps=0).to(device, dtype)
             ln.weight.data.fill_(1)
             ln.bias.data.fill_(0)
             output = ln(x)
@@ -1846,7 +1832,7 @@ class TestNN(NNTestCase):
             self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
 
             # test that LN applies weight and bias correctly
-            scale, bias = torch.FloatTensor(2).uniform_(0.2, 2).tolist()
+            scale, bias = torch.empty(2).uniform_(0.2, 2).tolist()
             ln.weight.data.fill_(scale)
             ln.bias.data.fill_(bias)
             output = ln(x)
@@ -1865,25 +1851,25 @@ class TestNN(NNTestCase):
         }
         for norm_shape, input_shape in bad_norm_shape_input_shape.items():
             ln = nn.LayerNorm(norm_shape)
-            input = type(*input_shape).uniform_(0, 10)
+            input = torch.empty(input_shape, device=device, dtype=dtype).uniform_(0, 10)
             self.assertRaises(RuntimeError, lambda: ln(input))
 
     def _test_LayerNorm_cuda_half(self):
-        input = torch.zeros(2, 3, 3, 2, requires_grad=True).cuda().half().random_(1, 10)
-        m = nn.LayerNorm([3, 2]).cuda().half()
+        input = Variable(torch.empty(2, 3, 3, 2).to("cuda", torch.half).random_(1, 10), requires_grad=True)
+        m = nn.LayerNorm([3, 2]).to("cuda", torch.half)
         output = m(input)
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
     def test_LayerNorm_general(self):
-        self._test_LayerNorm_general(torch.FloatTensor)
+        self._test_LayerNorm_general()
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_LayerNorm_general_cuda(self):
-        self._test_LayerNorm_general(torch.cuda.FloatTensor)
+        self._test_LayerNorm_general("cuda")
         self._test_LayerNorm_cuda_half()
 
-    def _test_GroupNorm_general(self, type):
+    def _test_GroupNorm_general(self, device="cpu", dtype=torch.float):
         good_shape_g = {
             (1, 2, 3, 4): 2,
             (2, 3, 10): 3,
@@ -1891,12 +1877,12 @@ class TestNN(NNTestCase):
             (2, 6, 4, 2, 2): 3,
         }
         for shape, g in good_shape_g.items():
-            x = type(*shape).uniform_(0, 10)
+            x = torch.empty(*shape, device=device, dtype=dtype).uniform_(0, 10)
             b = shape[0]
             c = shape[1]
 
             # test that GN normalizes to mean 0 and stddev 1
-            gn = nn.GroupNorm(g, c, eps=0).type(type)
+            gn = nn.GroupNorm(g, c, eps=0).to(device, dtype)
             gn.weight.data.fill_(1)
             gn.bias.data.fill_(0)
             output = gn(x)
@@ -1907,8 +1893,8 @@ class TestNN(NNTestCase):
             self.assertAlmostEqual(torch.abs(var).mean(), 1, delta=1e-5)
 
             # test that GN applies weight and bias correctly
-            scale = type(c).uniform_(0.2, 2)
-            bias = type(c).uniform_(0.2, 2)
+            scale = torch.empty(c, device=device, dtype=dtype).uniform_(0.2, 2)
+            bias = torch.empty(c, device=device, dtype=dtype).uniform_(0.2, 2)
             gn.weight.data.copy_(scale)
             gn.bias.data.copy_(bias)
             output = gn(x)
@@ -1928,33 +1914,34 @@ class TestNN(NNTestCase):
         }
         for shape, g in bad_shape_g.items():
             gn = nn.GroupNorm(g, shape[1])
-            input = type(*shape).uniform_(0, 10)
+            input = torch.empty(*shape, device=device, dtype=dtype).uniform_(0, 10)
             self.assertRaises(RuntimeError, lambda: gn(input))
 
     def _test_GroupNorm_cuda_half(self):
+        input = Variable(torch.empty(2, 3, 3, 2).to("cuda", torch.half).random_(1, 10), requires_grad=True)
         input = torch.zeros(2, 4, 3, 2, requires_grad=True).cuda().half().random_(1, 10)
-        m = nn.GroupNorm(2, 4).cuda().half()
+        m = nn.GroupNorm(2, 4).to("cuda", torch.half)
         output = m(input)
         output.sum().backward()
         self.assertEqual(output.type(), input.type())
 
     def test_GroupNorm_general(self):
-        self._test_GroupNorm_general(torch.FloatTensor)
+        self._test_GroupNorm_general(dtype=torch.float)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_GroupNorm_general_cuda(self):
-        self._test_GroupNorm_general(torch.cuda.FloatTensor)
+        self._test_GroupNorm_general("cuda", torch.float)
         self._test_GroupNorm_cuda_half()
 
     def test_pad(self):
-        inputs = Variable(torch.randn(1, 3, 4, 4), requires_grad=True)
+        inputs = torch.randn(1, 3, 4, 4, requires_grad=True)
         _assertGradAndGradgradChecks(self, lambda x: F.pad(x, (1, 1, 1, 1)), (inputs,))
         _assertGradAndGradgradChecks(self, lambda x: F.pad(x, (-1, 1, -2, 1)), (inputs,))
         _assertGradAndGradgradChecks(self, lambda x: F.pad(x, (-1, 1, -2, 1), value=2), (inputs,))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='replicate'), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='reflect'), (inputs,)))
 
-        inputs = Variable(torch.randn(1, 2, 3, 4, 4), requires_grad=True)
+        inputs = torch.randn(1, 2, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1, 1, 1, 1, 1), mode='replicate'), (inputs,)))
 
         # assert that relfection padding errors when pad >= input size
@@ -1970,23 +1957,23 @@ class TestNN(NNTestCase):
         self.assertRaises(AssertionError, lambda: F.pad(inputs, (1,)))
 
     def test_normalize(self):
-        inputs = Variable(torch.randn(1, 3, 4, 4), requires_grad=True)
+        inputs = torch.randn(1, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=1, dim=-1), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=2, dim=-2), (inputs,)))
 
         inputs = torch.randn((), requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=1, dim=-1), (inputs,)))
 
-    def _test_maxpool_indices(self, num_dim, adaptive=False, dtype=torch.FloatTensor):
+    def _test_maxpool_indices(self, num_dim, adaptive=False, device="cpu", dtype=torch.float):
         def expected_indices(dim):
             if dim == 1:
-                return torch.DoubleTensor([1, 3]).repeat(2, 2, 1)
+                return torch.tensor([1, 3], dtype=torch.double).repeat(2, 2, 1)
             if dim == 2:
-                return torch.DoubleTensor([[5, 7], [13, 15]]).repeat(2, 2, 1, 1)
+                return torch.tensor([[5, 7], [13, 15]], dtype=torch.double).repeat(2, 2, 1, 1)
 
         def expected_grad(dim):
             if dim == 1:
-                return torch.DoubleTensor([0, 1, 0, 1]).repeat(2, 2, 1)
+                return torch.tensor([0, 1, 0, 1], dtype=torch.double).repeat(2, 2, 1)
             grad = expected_grad(dim - 1)
             zero = torch.zeros(grad.size())
             return torch.stack((zero, grad, zero, grad), 2)
@@ -2003,10 +1990,10 @@ class TestNN(NNTestCase):
         else:
             cls_name = 'MaxPool{}d'.format(num_dim)
         module_cls = getattr(nn, cls_name)
-        module = module_cls(2, return_indices=True).type(dtype)
+        module = module_cls(2, return_indices=True).to(device, dtype=dtype)
         numel = 4 ** (num_dim + 1)
-        input = torch.arange(1, numel + 1).view(2, 2, *repeat(4, num_dim)).type(dtype)
-        input_var = Variable(input, requires_grad=True)
+        input = torch.arange(1, numel + 1).view(2, 2, *repeat(4, num_dim)).to(device, dtype=dtype)
+        input_var = torch.tensor(input, requires_grad=True)
 
         # Check forward
         output, indices = module(input_var)
@@ -2020,7 +2007,7 @@ class TestNN(NNTestCase):
         self.assertFalse(indices.requires_grad)
 
         # Make sure backward works
-        grad_output = torch.ones(output.size()).type(dtype)
+        grad_output = torch.ones(output.size(), device=device, dtype=dtype)
         output.backward(grad_output, retain_graph=True)
         expected_grad = expected_grad(num_dim)
         self.assertEqual(input_var.grad.data, expected_grad.view_as(input))
@@ -2034,74 +2021,66 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_Conv2d_naive_groups_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_Conv2d_naive_groups(dtype)
+    def test_Conv2d_naive_groups_cuda(self, dtype=torch.float):
+        self._test_Conv2d_naive_groups("cuda", dtype)
 
     def test_batchnorm_eval(self):
         self._test_batchnorm_eval()
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    def test_batchnorm_eval_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_batchnorm_eval(dtype)
+    def test_batchnorm_eval_cuda(self, dtype=torch.float):
+        self._test_batchnorm_eval("cuda", dtype)
 
     def test_MaxPool1d_indices(self):
         self._test_maxpool_indices(1)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_MaxPool1d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(1, dtype=dtype)
+    def test_MaxPool1d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(1, device="cuda", dtype=dtype)
 
     def test_MaxPool2d_indices(self):
         self._test_maxpool_indices(2)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_MaxPool2d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(2, dtype=dtype)
+    def test_MaxPool2d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(2, device="cuda", dtype=dtype)
 
     def test_MaxPool3d_indices(self):
         self._test_maxpool_indices(3)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_MaxPool3d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(3, dtype=dtype)
+    def test_MaxPool3d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(3, device="cuda", dtype=dtype)
 
     def test_AdaptiveMaxPool1d_indices(self):
         self._test_maxpool_indices(1, adaptive=True)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_AdaptiveMaxPool1d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(1, adaptive=True, dtype=dtype)
+    def test_AdaptiveMaxPool1d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(1, adaptive=True, device="cuda", dtype=dtype)
 
     def test_AdaptiveMaxPool2d_indices(self):
         self._test_maxpool_indices(2, adaptive=True)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_AdaptiveMaxPool2d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(2, adaptive=True, dtype=dtype)
+    def test_AdaptiveMaxPool2d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(2, adaptive=True, device="cuda", dtype=dtype)
 
     def test_AdaptiveMaxPool3d_indices(self):
         self._test_maxpool_indices(3, adaptive=True)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_AdaptiveMaxPool3d_indices_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_maxpool_indices(3, adaptive=True, dtype=dtype)
+    def test_AdaptiveMaxPool3d_indices_cuda(self, dtype=torch.float):
+        self._test_maxpool_indices(3, adaptive=True, device="cuda", dtype=dtype)
 
     def _test_scatter(self, tensor):
-        x = Variable(tensor, requires_grad=True)
+        x = torch.tensor(tensor, requires_grad=True)
         result = dp.scatter(x, (0, 1))
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0], x[:2])
@@ -2164,7 +2143,7 @@ class TestNN(NNTestCase):
             _ = dp.gather(inputs, target_device=0)
 
     def _test_broadcast_double_backwards(self, *tensors):
-        variables = tuple(Variable(t, requires_grad=True) for t in tensors)
+        variables = tuple(torch.tensor(t, requires_grad=True) for t in tensors)
         _assertGradAndGradgradChecks(self, lambda *i: Broadcast.apply((0, 1), *i), variables)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
@@ -2220,10 +2199,10 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_parallel_apply(self):
-        l1 = nn.Linear(10, 5).float().cuda(0)
-        l2 = nn.Linear(10, 5).float().cuda(1)
-        i1 = Variable(torch.randn(2, 10).float().cuda(0))
-        i2 = Variable(torch.randn(2, 10).float().cuda(1))
+        l1 = nn.Linear(10, 5).to("cuda:0", torch.float)
+        l2 = nn.Linear(10, 5).to("cuda:1", torch.float)
+        i1 = torch.randn(2, 10, device="cuda:0", dtype=torch.float)
+        i2 = torch.randn(2, 10, device="cuda:1", dtype=torch.float)
         expected1 = l1(i1).data
         expected2 = l2(i2).data
         inputs = ((i1,), (i2,))
@@ -2234,8 +2213,8 @@ class TestNN(NNTestCase):
         for out, expected in zip(outputs, expected_outputs):
             self.assertEqual(out.data, expected)
 
-        inputs = (i1, Variable(i2.data.new()))
-        expected_outputs = (expected1, expected2.new())
+        inputs = (i1, i2.new_empty(0))
+        expected_outputs = (expected1, expected2.new_empty(0))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_multiple_input(self):
@@ -2248,9 +2227,9 @@ class TestNN(NNTestCase):
                     return float1 * (var1 * var2 + var3)
 
         m = TestModule()
-        var1 = Variable(torch.randn(5, 5).float(), requires_grad=True)
-        var2 = Variable(torch.randn(5, 5).float(), requires_grad=True)
-        var3 = Variable(torch.randn(5, 5).float(), requires_grad=False)
+        var1 = torch.randn(5, 5, dtype=torch.float, requires_grad=True)
+        var2 = torch.randn(5, 5, dtype=torch.float, requires_grad=True)
+        var3 = torch.randn(5, 5, dtype=torch.float, requires_grad=False)
 
         float1 = torch.randn(1).item()
 
@@ -2378,8 +2357,8 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_sparse(self):
-        l = nn.Embedding(10, 5, sparse=True).cuda(1)
-        i = Variable(torch.LongTensor(20, 5).random_(0, 10).cuda(1))
+        l = nn.Embedding(10, 5, sparse=True).to("cuda:1")
+        i = torch.randint(10, (20, 5), device="cuda:1", dtype=torch.long)
         expected_out = l(i)
         loss = expected_out.sum()
         loss.backward()
@@ -2419,20 +2398,20 @@ class TestNN(NNTestCase):
         gpus = range(torch.cuda.device_count())
         output = dp.data_parallel(Net(), i, gpus)
         self.assertEqual(output, fn(i))
-        self.assertIsInstance(output[0], Variable)
+        self.assertIsInstance(output[0], torch.Tensor)
         self.assertIsInstance(output[1], tuple)
-        self.assertIsInstance(output[1][0], Variable)
-        self.assertIsInstance(output[1][1], Variable)
+        self.assertIsInstance(output[1][0], torch.Tensor)
+        self.assertIsInstance(output[1][1], torch.Tensor)
         self.assertIsInstance(output[1][2], list)
-        self.assertIsInstance(output[1][2][0], Variable)
-        self.assertIsInstance(output[2], Variable)
+        self.assertIsInstance(output[1][2][0], torch.Tensor)
+        self.assertIsInstance(output[2], torch.Tensor)
         self.assertIsInstance(output[3], dict)
         self.assertEqual(len(output[3]), 2)
         self.assertIn('a', output[3])
         self.assertIn('b', output[3])
-        self.assertIsInstance(output[3]['a'], Variable)
+        self.assertIsInstance(output[3]['a'], torch.Tensor)
         self.assertIsInstance(output[3]['b'], list)
-        self.assertIsInstance(output[3]['b'][0], Variable)
+        self.assertIsInstance(output[3]['b'][0], torch.Tensor)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_nested_input(self):
@@ -2451,9 +2430,9 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_data_parallel_module(self, dtype=torch.FloatTensor):
-        l = nn.Linear(10, 5).type(dtype).cuda()
-        i = Variable(torch.randn(20, 10).type(dtype).cuda())
+    def test_data_parallel_module(self, dtype=torch.float):
+        l = nn.Linear(10, 5).to("cuda", dtype)
+        i = torch.randn(20, 10, device="cuda", dtype=dtype)
         expected_out = l(i).data
         net = nn.DataParallel(l)
         out = net(i)
@@ -2462,7 +2441,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_data_parallel_module_kwargs_only(self, dtype=torch.FloatTensor):
+    def test_data_parallel_module_kwargs_only(self, dtype=torch.float):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -2471,8 +2450,8 @@ class TestNN(NNTestCase):
             def forward(self, input):
                 return self.l(input)
 
-        l = nn.Linear(10, 5).type(dtype).cuda()
-        i = Variable(torch.randn(20, 10).type(dtype).cuda())
+        l = nn.Linear(10, 5).to("cuda", dtype)
+        i = torch.randn(20, 10, device="cuda", dtype=dtype)
         expected_out = l(i).data
         n = nn.DataParallel(Net())
         out = n(input=i)
@@ -2481,7 +2460,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_data_parallel_module_kwargs_only_empty_list(self, dtype=torch.FloatTensor):
+    def test_data_parallel_module_kwargs_only_empty_list(self, dtype=torch.float):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -2490,8 +2469,8 @@ class TestNN(NNTestCase):
             def forward(self, input):
                 return self.l(input['data'])
 
-        l = nn.Linear(10, 5).type(dtype).cuda()
-        i = Variable(torch.randn(20, 10).type(dtype).cuda())
+        l = nn.Linear(10, 5).to("cuda", dtype)
+        i = torch.randn(20, 10, device="cuda", dtype=dtype)
         expected_out = l(i).data
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': []})
@@ -2500,7 +2479,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_data_parallel_module_kwargs_only_empty_dict(self, dtype=torch.FloatTensor):
+    def test_data_parallel_module_kwargs_only_empty_dict(self, dtype=torch.float):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -2509,8 +2488,8 @@ class TestNN(NNTestCase):
             def forward(self, input):
                 return self.l(input['data'])
 
-        l = nn.Linear(10, 5).type(dtype).cuda()
-        i = Variable(torch.randn(20, 10).type(dtype).cuda())
+        l = nn.Linear(10, 5).to("cuda", dtype)
+        i = torch.randn(20, 10, device="cuda", dtype=dtype)
         expected_out = l(i).data
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': {}})
@@ -2519,7 +2498,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_data_parallel_module_kwargs_only_empty_tuple(self, dtype=torch.FloatTensor):
+    def test_data_parallel_module_kwargs_only_empty_tuple(self, dtype=torch.float):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
@@ -2528,8 +2507,8 @@ class TestNN(NNTestCase):
             def forward(self, input):
                 return self.l(input['data'])
 
-        l = nn.Linear(10, 5).type(dtype).cuda()
-        i = Variable(torch.randn(20, 10).type(dtype).cuda())
+        l = nn.Linear(10, 5).to("cuda", dtype)
+        i = torch.randn(20, 10, device="cuda", dtype=dtype)
         expected_out = l(i).data
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': ()})
@@ -2642,20 +2621,20 @@ class TestNN(NNTestCase):
         self.assertEqual(num_params(), 3)
         self.assertObjectIn(new_param, l.parameters())
 
-        var = Variable(torch.randn(5, 5))
+        var = torch.randn(5, 5)
         l.var_name = var
         self.assertEqual(num_params(), 3)
         self.assertNotIn(id(var), map(id, l.parameters()))
 
         # Make sure Variables are not saved as parameters
-        l.variable_attr = Variable(torch.Tensor(5, 5))
+        l.variable_attr = torch.empty(5, 5)
         self.assertEqual(num_params(), 3)
-        l.param_attr = Parameter(torch.Tensor(5, 5))
+        l.param_attr = Parameter(torch.empty(5, 5))
         self.assertEqual(num_params(), 4)
 
         # It shouldn't be possible to replace a parameter with a Variable
         def assign_var():
-            l.param_attr = Variable(torch.Tensor(5, 5))
+            l.param_attr = torch.empty(5, 5)
 
         self.assertRaises(TypeError, assign_var)
         # But replacing it with None should be fine
@@ -2768,18 +2747,17 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_Conv2d_deterministic_cudnn(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        inputs = Variable(torch.randn(2, 3, 5, 5).type(dtype), requires_grad=True)
+    def test_Conv2d_deterministic_cudnn(self, dtype=torch.float):
+        inputs = torch.randn(2, 3, 5, 5, device="cuda", dtype=dtype, requires_grad=True)
         with cudnn.flags(enabled=True, benchmark=True, deterministic=True):
-            conv1 = torch.nn.Conv2d(3, 3, 3).type(dtype)
-            conv2 = torch.nn.Conv2d(3, 3, 3).type(dtype)
+            conv1 = torch.nn.Conv2d(3, 3, 3).to("cuda", dtype)
+            conv2 = torch.nn.Conv2d(3, 3, 3).to("cuda", dtype)
             conv2.bias.data.copy_(conv1.bias.data)
             conv2.weight.data.copy_(conv1.weight.data)
             out1 = conv1(inputs)
             out2 = conv2(inputs)
             self.assertEqual(out1, out2, prec=0.0)
-            y = torch.randn(out1.size()).type(dtype)
+            y = torch.randn(out1.size(), device="cuda", dtype=dtype)
             out1.backward(y)
             out2.backward(y)
             self.assertEqual(conv1.bias.grad.data, conv2.bias.grad.data, prec=0.0)
@@ -2790,7 +2768,7 @@ class TestNN(NNTestCase):
         self.assertRaises(TypeError, lambda: c(None))
 
     def test_Conv2d_backward_twice(self):
-        input = Variable(torch.randn(2, 3, 5, 5))
+        input = torch.randn(2, 3, 5, 5)
         c = nn.Conv2d(3, 3, 3)
         o1 = c(input)
         o1.sum().backward()
@@ -2799,7 +2777,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_Conv2d_large_workspace(self, dtype=torch.FloatTensor):
+    def test_Conv2d_large_workspace(self, dtype=torch.float):
         # These sizes require huge cuDNN workspaces. Make sure we choose a
         # reasonable algorithm that does not run out of memory
         sizes = [
@@ -2811,11 +2789,11 @@ class TestNN(NNTestCase):
 
         def run_test(benchmark):
             with torch.backends.cudnn.flags(benchmark=benchmark):
-                conv = torch.nn.Conv2d(256, 256, kernel_size=3, padding=1).type(dtype)
+                conv = torch.nn.Conv2d(256, 256, kernel_size=3, padding=1).to("cuda", dtype)
                 for size in sizes:
-                    x = torch.randn(size).type(dtype)
-                    out = conv(Variable(x, requires_grad=True))
-                    out.backward(torch.ones(out.size()).type(dtype))
+                    x = torch.randn(size, device="cuda", dtype=dtype)
+                    out = conv(torch.tensor(x, requires_grad=True))
+                    out.backward(torch.ones_like(out))
 
         run_test(benchmark=False)
         run_test(benchmark=True)
@@ -2831,12 +2809,12 @@ class TestNN(NNTestCase):
 
         for invalid_dims, module in zip(invalid_input_dims, modules):
             for dims in invalid_dims:
-                input = Variable(torch.Tensor(torch.Size((3, ) * dims)))
+                input = torch.empty(torch.Size((3, ) * dims))
                 self.assertRaises(RuntimeError, lambda: module(input))
 
     def test_conv_shapecheck(self):
         def test(should_raise, module, input_size):
-            input = Variable(torch.Tensor(3, *input_size))
+            input = torch.empty(3, *input_size)
             if should_raise:
                 self.assertRaises(RuntimeError, lambda: module(input))
             else:
@@ -2862,7 +2840,7 @@ class TestNN(NNTestCase):
 
     def test_ConvTranspose2d_output_size(self):
         m = nn.ConvTranspose2d(3, 4, 3, 3, 0, 2)
-        i = Variable(torch.randn(2, 3, 6, 6))
+        i = torch.randn(2, 3, 6, 6)
         for h in range(15, 22):
             for w in range(15, 22):
                 if 18 <= h <= 20 and 18 <= w <= 20:
@@ -2871,22 +2849,22 @@ class TestNN(NNTestCase):
                 else:
                     self.assertRaises(ValueError, lambda: m(i, (h, w)))
 
-    def _test_Conv2d_naive_groups(self, dtype=torch.FloatTensor):
+    def _test_Conv2d_naive_groups(self, device="cpu", dtype=torch.float):
         # Check that grouped convolutions matches two half convolutions
-        m = nn.Conv2d(4, 4, kernel_size=3, groups=2).type(dtype)
-        i = Variable(torch.randn(2, 4, 6, 6).type(dtype), requires_grad=True)
+        m = nn.Conv2d(4, 4, kernel_size=3, groups=2).to(device, dtype)
+        i = torch.randn(2, 4, 6, 6, device=device, dtype=dtype, requires_grad=True)
         output = m(i)
-        grad_output = torch.randn(2, 4, 4, 4).type(dtype)
+        grad_output = torch.randn(2, 4, 4, 4, device=device, dtype=dtype)
         output.backward(grad_output)
 
-        m1 = nn.Conv2d(2, 2, kernel_size=3).type(dtype)
+        m1 = nn.Conv2d(2, 2, kernel_size=3).to(device, dtype)
         m1.weight.data.copy_(m.weight.data[:2])
         m1.bias.data.copy_(m.bias.data[:2])
         i1 = Variable(i.data[:, :2].contiguous(), requires_grad=True)
         output1 = m1(i1)
         output1.backward(grad_output[:, :2].contiguous())
 
-        m2 = nn.Conv2d(2, 2, kernel_size=3).type(dtype)
+        m2 = nn.Conv2d(2, 2, kernel_size=3).to(device, dtype)
         m2.weight.data.copy_(m.weight.data[2:])
         m2.bias.data.copy_(m.bias.data[2:])
         i2 = Variable(i.data[:, 2:].contiguous(), requires_grad=True)
@@ -2896,34 +2874,34 @@ class TestNN(NNTestCase):
         self.assertEqual(output, torch.cat([output1, output2], 1))
         self.assertEqual(i.grad.data,
                          torch.cat([i1.grad.data, i2.grad.data], 1),
-                         prec=type2prec[dtype.__name__])
+                         prec=dtype2prec[dtype])
         self.assertEqual(m.bias.grad.data,
                          torch.cat([m1.bias.grad.data, m2.bias.grad.data], 0),
-                         prec=type2prec[dtype.__name__])
+                         prec=dtype2prec[dtype])
         self.assertEqual(m.weight.grad.data,
                          torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
-                         prec=type2prec[dtype.__name__])
+                         prec=dtype2prec[dtype])
 
     # For https://github.com/pytorch/pytorch/pull/1273
     # Almost identical to the above `test_Conv2d_naive_groups`
     def test_Conv2d_groups_nobias(self):
-        types = (torch.FloatTensor,)
+        dev_dtypes = [("cpu", torch.float)]
         if TEST_CUDA:
-            types += (torch.cuda.FloatTensor, torch.cuda.HalfTensor)
-        for tp in types:
-            m = nn.Conv2d(4, 4, kernel_size=3, groups=2, bias=False).type(tp)
-            i = Variable(torch.randn(2, 4, 6, 6).type(tp), requires_grad=True)
+            dev_dtypes += [("cuda", torch.float), ("cuda", torch.half)]
+        for device, dtype in dev_dtypes:
+            m = nn.Conv2d(4, 4, kernel_size=3, groups=2, bias=False).to(device, dtype)
+            i = torch.randn(2, 4, 6, 6, device=device, dtype=dtype, requires_grad=True)
             output = m(i)
-            grad_output = torch.randn(2, 4, 4, 4).type(tp)
+            grad_output = torch.randn(2, 4, 4, 4, device=device, dtype=dtype)
             output.backward(grad_output)
 
-            m1 = nn.Conv2d(2, 2, kernel_size=3, bias=False).type(tp)
+            m1 = nn.Conv2d(2, 2, kernel_size=3, bias=False).to(device, dtype)
             m1.weight.data.copy_(m.weight.data[:2])
             i1 = Variable(i.data[:, :2].contiguous(), requires_grad=True)
             output1 = m1(i1)
             output1.backward(grad_output[:, :2].contiguous())
 
-            m2 = nn.Conv2d(2, 2, kernel_size=3, bias=False).type(tp)
+            m2 = nn.Conv2d(2, 2, kernel_size=3, bias=False).to(device, dtype)
             m2.weight.data.copy_(m.weight.data[2:])
             i2 = Variable(i.data[:, 2:].contiguous(), requires_grad=True)
             output2 = m2(i2)
@@ -2932,60 +2910,59 @@ class TestNN(NNTestCase):
             self.assertEqual(output, torch.cat([output1, output2], 1))
             self.assertEqual(i.grad.data,
                              torch.cat([i1.grad.data, i2.grad.data], 1),
-                             type2prec[tp.__name__])
+                             dtype2prec[dtype])
             self.assertEqual(m.weight.grad.data,
                              torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
-                             type2prec[tp.__name__])
+                             dtype2prec[dtype])
 
     # Very similar to test_Conv2d_naive_groups but with special care to handle
     # the number of groups == number of input channels
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_Conv2d_depthwise_naive_groups(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
+    def test_Conv2d_depthwise_naive_groups_cuda(self, dtype=torch.float):
         for depth_multiplier in [1, 2]:
-            m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).type(dtype)
-            i = Variable(torch.randn(2, 2, 6, 6).type(dtype) / 2, requires_grad=True)
+            m = nn.Conv2d(2, 2 * depth_multiplier, kernel_size=3, groups=2).to("cuda", dtype)
+            i = torch.tensor(torch.randn(2, 2, 6, 6, device="cuda", dtype=dtype) / 2, requires_grad=True)
             output = m(i)
-            grad_output = torch.randn(2, 2 * depth_multiplier, 4, 4).type(dtype) / 2
+            grad_output = torch.randn(2, 2 * depth_multiplier, 4, 4, device="cuda", dtype=dtype) / 2
             output.backward(grad_output)
 
             offset = 1 * depth_multiplier
 
-            m1 = nn.Conv2d(1, 1 * depth_multiplier, kernel_size=3).type(dtype)
+            m1 = nn.Conv2d(1, 1 * depth_multiplier, kernel_size=3).to("cuda", dtype)
             m1.weight.data = m.weight.data[:offset].clone()
             m1.bias.data = m.bias.data[:offset].clone()
-            i1 = Variable(i.data[:, :1].contiguous(), requires_grad=True)
+            i1 = torch.tensor(i.data[:, :1].contiguous(), requires_grad=True)
             output1 = m1(i1)
             output1.backward(grad_output[:, :offset].contiguous())
 
-            m2 = nn.Conv2d(1, 1 * depth_multiplier, kernel_size=3).type(dtype)
+            m2 = nn.Conv2d(1, 1 * depth_multiplier, kernel_size=3).to("cuda", dtype)
             m2.weight.data.copy_(m.weight.data[offset:])
             m2.bias.data.copy_(m.bias.data[offset:])
-            i2 = Variable(i.data[:, 1:].contiguous(), requires_grad=True)
+            i2 = torch.tensor(i.data[:, 1:].contiguous(), requires_grad=True)
             output2 = m2(i2)
             output2.backward(grad_output[:, offset:].contiguous())
 
             self.assertEqual(output, torch.cat([output1, output2], 1),
-                             prec=type2prec[dtype.__name__])
+                             prec=dtype2prec[dtype])
             self.assertEqual(i.grad.data,
                              torch.cat([i1.grad.data, i2.grad.data], 1),
-                             prec=type2prec[dtype.__name__])
+                             prec=dtype2prec[dtype])
             self.assertEqual(m.bias.grad.data,
                              torch.cat([m1.bias.grad.data,
                                         m2.bias.grad.data], 0),
-                             prec=type2prec[dtype.__name__])
+                             prec=dtype2prec[dtype])
             self.assertEqual(m.weight.grad.data,
                              torch.cat([m1.weight.grad.data,
                                         m2.weight.grad.data], 0),
-                             prec=type2prec[dtype.__name__])
+                             prec=dtype2prec[dtype])
 
     def test_MaxUnpool2d_output_size(self):
         m = nn.MaxPool2d(3, stride=2, return_indices=True)
         mu = nn.MaxUnpool2d(3, stride=2)
         big_t = torch.rand(1, 1, 6, 6)
         big_t[0][0][4][4] = 100
-        output_big, indices_big = m(Variable(big_t))
+        output_big, indices_big = m(big_t)
         self.assertRaises(RuntimeError, lambda: mu(output_big, indices_big))
 
         small_t = torch.rand(1, 1, 5, 5)
@@ -3014,7 +2991,7 @@ class TestNN(NNTestCase):
             def forward(self, input):
                 return self.linear(input)
 
-        input = Variable(torch.randn(2, 4))
+        input = torch.randn(2, 4)
 
         model = Model()
         model_cp = deepcopy(model)
@@ -3028,8 +3005,8 @@ class TestNN(NNTestCase):
         # autograd so no Jacobian test is needed
         for module in (nn.RNNCell, nn.GRUCell):
             for bias in (True, False):
-                input = Variable(torch.randn(3, 10))
-                hx = Variable(torch.randn(3, 20))
+                input = torch.randn(3, 10)
+                hx = torch.randn(3, 20)
                 cell = module(10, 20, bias=bias)
                 for i in range(6):
                     hx = cell(input, hx)
@@ -3074,23 +3051,23 @@ class TestNN(NNTestCase):
 
         hidden_size = 20
         input_size = 10
-        input = Variable(torch.randn(3, input_size))
-        bad_hx = Variable(torch.randn(1, hidden_size))
-        good_hx = Variable(torch.randn(3, hidden_size))
+        input = torch.randn(3, input_size)
+        bad_hx = torch.randn(1, hidden_size)
+        good_hx = torch.randn(3, hidden_size)
 
         # Test hidden/input batch size broadcasting
         test_all(hidden_size, bad_hx, good_hx, input_size, input)
 
         # Test hx's hidden_size vs module's hidden_size broadcasting
-        bad_hx = Variable(torch.randn(3, 1))
+        bad_hx = torch.randn(3, 1)
         test_all(hidden_size, bad_hx, good_hx, input_size, input)
 
         # Test input's input_size vs module's input_size broadcasting
-        bad_input = Variable(torch.randn(3, 1))
+        bad_input = torch.randn(3, 1)
         test_all(hidden_size, good_hx, good_hx, input_size, bad_input)
 
     def test_invalid_dropout_p(self):
-        v = Variable(torch.ones(1))
+        v = torch.ones(1)
         self.assertRaises(ValueError, lambda: nn.Dropout(-0.1))
         self.assertRaises(ValueError, lambda: nn.Dropout(1.1))
         self.assertRaises(ValueError, lambda: nn.Dropout2d(-0.1))
@@ -3106,12 +3083,12 @@ class TestNN(NNTestCase):
                 [tensor.data, tensor.data.new(
                     length - tensor.size(0), *tensor.size()[1:]).zero_()])
         # single dimensional
-        a = Variable(torch.Tensor([1, 2, 3]))
-        b = Variable(torch.Tensor([4, 5]))
-        c = Variable(torch.Tensor([6]))
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5])
+        c = torch.tensor([6])
 
         # batch_first = true
-        expected = Variable(torch.Tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]]))
+        expected = torch.tensor([[1, 2, 3], [4, 5, 0], [6, 0, 0]])
         padded = rnn_utils.pad_sequence([a, b, c], True)
         self.assertEqual(padded, expected)
 
@@ -3120,7 +3097,7 @@ class TestNN(NNTestCase):
         self.assertEqual(padded, expected.transpose(0, 1))
 
         # pad with non-zero value
-        expected = Variable(torch.Tensor([[1, 2, 3], [4, 5, 1], [6, 1, 1]]))
+        expected = torch.tensor([[1, 2, 3], [4, 5, 1], [6, 1, 1]])
         padded = rnn_utils.pad_sequence([a, b, c], True, 1)
         self.assertEqual(padded, expected)
 
@@ -3131,12 +3108,12 @@ class TestNN(NNTestCase):
             trailing_dims = [4] * num_dim
             for i in range(maxlen, 0, -1):
                 seq_len = i * i
-                sequences.append(Variable(torch.rand(seq_len, 5, *trailing_dims)))
+                sequences.append(torch.rand(seq_len, 5, *trailing_dims))
             expected = []
             for seq in sequences:
                 expected.append(pad(seq, maxlen * maxlen))
             # batch first = true
-            expected = Variable(torch.stack(expected))
+            expected = torch.stack(expected)
             padded = rnn_utils.pad_sequence(sequences, True)
             self.assertEqual(padded, expected)
 
@@ -3158,11 +3135,11 @@ class TestNN(NNTestCase):
             self.assertEqual(packed, pack_padded)
 
         # single dimensional
-        a = Variable(torch.Tensor([1, 2, 3]))
-        b = Variable(torch.Tensor([4, 5]))
-        c = Variable(torch.Tensor([6]))
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5])
+        c = torch.tensor([6])
         packed = rnn_utils.pack_sequence([a, b, c])
-        expected = torch.Tensor([1, 4, 6, 2, 5, 3])
+        expected = torch.tensor([1, 4, 6, 2, 5, 3])
         self.assertEqual(packed.batch_sizes, [3, 2, 1])
         self.assertEqual(packed.data.data, expected)
 
@@ -3175,7 +3152,7 @@ class TestNN(NNTestCase):
             for i in range(maxlen, 0, -1):
                 seq_len = i * i
                 lengths.append(seq_len)
-                sequences.append(Variable(torch.rand(seq_len, 5, *trailing_dims)))
+                sequences.append(torch.rand(seq_len, 5, *trailing_dims))
 
             # compatibility with other utilities
             for batch_first in (True, False):
@@ -3190,7 +3167,7 @@ class TestNN(NNTestCase):
         offset = 0
         padded = torch.cat([pad(i * 100 + torch.arange(1, 5 * l + 1).view(l, 1, 5), max_length)
                             for i, l in enumerate(lengths, 1)], 1)
-        padded = Variable(padded, requires_grad=True)
+        padded = torch.tensor(padded, requires_grad=True)
         expected_data = [[torch.arange(1, 6) + (i + 1) * 100 + 5 * n for i in range(batch_size)]
                          for n, batch_size in enumerate(batch_sizes)]
         expected_data = list(itertools.chain.from_iterable(expected_data))
@@ -3223,23 +3200,18 @@ class TestNN(NNTestCase):
                 if l < 10:
                     self.assertEqual(padded.grad.data[l:, i].abs().sum(), 0)
 
-    def _test_variable_sequence(self, cuda, dtype=torch.FloatTensor):
+    def _test_variable_sequence(self, device="cpu", dtype=torch.float):
         def pad(var, length):
             if var.size(0) == length:
                 return var
-            return torch.cat([var, Variable(var.data.new(length - var.size(0), *var.size()[1:]).zero_())])
+            return torch.cat([var, var.new_zeros(length - var.size(0), *var.size()[1:])])
 
         lengths = [10, 10, 6, 2, 2, 1, 1]
         max_length = lengths[0]
-        x_leaf = Variable(torch.randn(max_length, len(lengths), 3).type(dtype), requires_grad=True)
-        lstm = nn.LSTM(3, 4, bidirectional=True, num_layers=2).type(dtype)
-        lstm2 = deepcopy(lstm).type(dtype)
-        if cuda:
-            x = x_leaf.cuda()
-            lstm.cuda()
-            lstm2.cuda()
-        else:
-            x = x_leaf
+        x_leaf = torch.randn(max_length, len(lengths), 3, device=device, dtype=dtype, requires_grad=True)
+        lstm = nn.LSTM(3, 4, bidirectional=True, num_layers=2).to(device, dtype)
+        lstm2 = deepcopy(lstm).to(device, dtype)
+        x = x_leaf
 
         # Compute sequences separately
         seq_outs = []
@@ -3268,26 +3240,25 @@ class TestNN(NNTestCase):
         x_leaf.grad.data.zero_()
         unpacked.sum().backward()
 
-        self.assertEqual(x_leaf.grad.data, grad_x)
+        self.assertEqual(x_leaf.grad, grad_x)
         for p1, p2 in zip(lstm.parameters(), lstm2.parameters()):
-            self.assertEqual(p1.grad, p2.grad, type2prec[dtype.__name__])
+            self.assertEqual(p1.grad, p2.grad, dtype2prec[dtype])
 
     def test_variable_sequence(self):
-        self._test_variable_sequence(False)
+        self._test_variable_sequence()
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_variable_sequence_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
-        self._test_variable_sequence(True, dtype)
+    def test_variable_sequence_cuda(self, dtype=torch.float):
+        self._test_variable_sequence("cuda", dtype)
 
     def test_LSTM_cell(self):
         # this is just a smoke test; these modules are implemented through
         # autograd so no Jacobian test is needed
         for bias in (True, False):
-            input = Variable(torch.randn(3, 10))
-            hx = Variable(torch.randn(3, 20))
-            cx = Variable(torch.randn(3, 20))
+            input = torch.randn(3, 10)
+            hx = torch.randn(3, 20)
+            cx = torch.randn(3, 20)
             lstm = nn.LSTMCell(10, 20, bias=bias)
             for i in range(6):
                 hx, cx = lstm(input, (hx, cx))
@@ -3375,8 +3346,7 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_cuda_rnn_fused(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
+    def test_cuda_rnn_fused(self, dtype=torch.float):
 
         def copy_rnn(rnn1, rnn2):
             for x_layer, y_layer in zip(rnn1.all_weights, rnn2.all_weights):
@@ -3393,15 +3363,15 @@ class TestNN(NNTestCase):
         num_layers = 2
         seq_length = 7
         batch = 6
-        input_val = torch.randn(seq_length, batch, input_size).type(dtype)
-        grad_output = torch.randn(seq_length, batch, hidden_size).type(dtype)
-        hx_val = torch.randn(num_layers, batch, hidden_size).type(dtype)
-        grad_hy = torch.randn(num_layers, batch, hidden_size).type(dtype)
+        input_val = torch.randn(seq_length, batch, input_size, device="cuda", dtype=dtype)
+        grad_output = torch.randn(seq_length, batch, hidden_size, device="cuda", dtype=dtype)
+        hx_val = torch.randn(num_layers, batch, hidden_size, device="cuda", dtype=dtype)
+        grad_hy = torch.randn(num_layers, batch, hidden_size, device="cuda", dtype=dtype)
         with torch.backends.cudnn.flags(enabled=False):
             for module in (nn.GRU, nn.LSTM):
                 for bias in (True, False):
-                    rnn = module(input_size, hidden_size, num_layers, bias=bias).type(dtype)
-                    rnn_cuda = module(input_size, hidden_size, num_layers, bias=bias).type(dtype).cuda()
+                    rnn = module(input_size, hidden_size, num_layers, bias=bias).to("cuda", dtype)
+                    rnn_cuda = module(input_size, hidden_size, num_layers, bias=bias).to("cuda", dtype)
                     copy_rnn(rnn, rnn_cuda)
 
                     is_lstm = isinstance(rnn, nn.LSTM)
@@ -3465,13 +3435,13 @@ class TestNN(NNTestCase):
         def get_inputs(input_shape, hidden_shape, mode):
             '''returns list( tuple(input, hidden) )
             where input, hidden are inputs to a model'''
-            input = Variable(torch.randn(input_shape))
-            hidden = Variable(torch.randn(hidden_shape))
+            input = torch.randn(input_shape)
+            hidden = torch.randn(hidden_shape)
             if mode is not 'LSTM':
                 return [(input, hidden)]
             if hidden_shape == correct_hidden_shape:
                 return [(input, (hidden, hidden))]
-            good_hidden = Variable(torch.randn(correct_hidden_shape))
+            good_hidden = torch.randn(correct_hidden_shape)
             return [
                 (input, (hidden, good_hidden)),
                 (input, (good_hidden, hidden)),
@@ -3508,8 +3478,8 @@ class TestNN(NNTestCase):
         rnn_modes = ['RNN', 'GRU', 'LSTM']
         for mode in rnn_modes:
             rnn = getattr(nn, mode)(30, 20, 2)
-            input = Variable(torch.randn(10, 32, 30))
-            hidden = Variable(torch.Tensor(2, 32, 20).zero_())
+            input = torch.randn(10, 32, 30)
+            hidden = torch.zeros(2, 32, 20)
 
             if mode is 'LSTM':
                 hidden = (hidden, hidden)
@@ -3518,12 +3488,12 @@ class TestNN(NNTestCase):
             self.assertEqual(output1, output2)
             self.assertEqual(hidden1, hidden2)
 
-    def _test_rnn_retain_variables(self, dtype):
-        rnns = [nn.LSTM(10, 20, num_layers=2).type(dtype),
-                nn.GRU(10, 20, num_layers=2).type(dtype),
-                nn.RNN(10, 20, num_layers=2).type(dtype)]
+    def _test_rnn_retain_variables(self, device="cpu", dtype=torch.double):
+        rnns = [nn.LSTM(10, 20, num_layers=2).to(device, dtype),
+                nn.GRU(10, 20, num_layers=2).to(device, dtype),
+                nn.RNN(10, 20, num_layers=2).to(device, dtype)]
         for rnn in rnns:
-            input = Variable(torch.randn(5, 6, 10).type(dtype), requires_grad=True)
+            input = torch.randn(5, 6, 10, device=device, dtype=dtype, requires_grad=True)
             output = rnn(input)
             output[0].sum().backward(retain_graph=True)
             grads = [input.grad.data.clone()] + [p.grad.data.clone() for p in rnn.parameters()]
@@ -3535,15 +3505,14 @@ class TestNN(NNTestCase):
                 self.assertEqual(grads, grads2)
 
     def test_rnn_retain_variables(self):
-        self._test_rnn_retain_variables(torch.DoubleTensor)
+        self._test_rnn_retain_variables()
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_rnn_retain_variables_cuda(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
+    def test_rnn_retain_variables_cuda(self, dtype=torch.float):
         with torch.backends.cudnn.flags(enabled=False):
-            self._test_rnn_retain_variables(dtype)
-        self._test_rnn_retain_variables(dtype)
+            self._test_rnn_retain_variables("cuda", dtype)
+        self._test_rnn_retain_variables("cuda", dtype)
 
     def _test_RNN_cpu_vs_cudnn(self, dropout):
 
@@ -3618,7 +3587,7 @@ class TestNN(NNTestCase):
                     self.assertEqual(cpu_weight.grad.data, gpu_weight.grad.data, prec=5e-5)
 
         for module in (nn.RNN, nn.LSTM, nn.GRU):
-            for bias, bidirectional, batch_first, contig, variable_len, lens_as_variable \
+            for bias, bidirectional, batch_first, contig, variable_len, lens_as_tensor \
                     in product((True, False), repeat=6):
 
                 num_directions = 2 if bidirectional else 1
@@ -3640,10 +3609,8 @@ class TestNN(NNTestCase):
 
                 if variable_len:
                     lengths = [7, 5, 5, 2, 1, 1]
-                    if lens_as_variable:
-                        lengths = Variable(torch.LongTensor(lengths))
-                    input_val = Variable(input_val)
-                    grad_output = Variable(grad_output)
+                    if lens_as_tensor:
+                        lengths = torch.tensor(lengths, dtype=torch.long)
                     input_val = rnn_utils.pack_padded_sequence(input_val, lengths, batch_first=batch_first)
                     grad_output = rnn_utils.pack_padded_sequence(grad_output, lengths, batch_first=batch_first).data
 
@@ -3717,8 +3684,8 @@ class TestNN(NNTestCase):
                     rnn.weight_hh_l0.data.fill_(1)
                     rnn.weight_ih_l1.data.fill_(1)
                     rnn.weight_hh_l1.data.fill_(1)
-                    input = Variable(torch.Tensor(1, 1, 10).fill_(1))
-                    hx = Variable(torch.Tensor(2, 1, 1000).fill_(0))
+                    input = torch.ones(1, 1, 10)
+                    hx = torch.zeros(2, 1, 1000)
                     if cuda:
                         input = input.cuda()
                         hx = hx.cuda()
@@ -3759,8 +3726,8 @@ class TestNN(NNTestCase):
                         rnn.train()
                     else:
                         rnn.eval()
-                    input = Variable(torch.Tensor(1, 1, 100).uniform_())
-                    hx = Variable(torch.Tensor(2, 1, 100).uniform_())
+                    input = torch.rand(1, 1, 100)
+                    hx = torch.rand(2, 1, 100)
                     if cuda:
                         input = input.cuda()
                         hx = hx.cuda()
@@ -3788,7 +3755,7 @@ class TestNN(NNTestCase):
     def test_RNN_change_dropout(self):
         for train, cuda in product((True, False), repeat=2):
             rnn = nn.RNN(100, 100, 2, dropout=0, nonlinearity='relu')
-            input = Variable(torch.Tensor(3, 2, 100).uniform_())
+            input = torch.rand(3, 2, 100)
             if cuda:
                 input.data = input.data.cuda()
                 rnn.cuda()
@@ -3834,7 +3801,7 @@ class TestNN(NNTestCase):
         modules = [nn.ReLU, nn.ELU, nn.SELU, nn.RReLU]
         for mod in modules:
             r = mod(inplace=True)
-            input = Variable(torch.randn(5, 5), requires_grad=True)
+            input = torch.randn(5, 5, requires_grad=True)
             output = r(input + 0)
             grad_output = torch.randn(5, 5)
             grad_output_clone = grad_output.clone()
@@ -3843,14 +3810,13 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     @repeat_test_for_types(ALL_TENSORTYPES)
-    def test_noncontig_conv_grad(self, dtype=torch.FloatTensor):
-        dtype = getattr(torch.cuda, dtype.__name__)
+    def test_noncontig_conv_grad_cuda(self, dtype=torch.float):
         # FIXME: remove after adding non-contiguous grad tests for all modules
-        module = nn.Conv2d(3, 5, kernel_size=3, padding=1).type(dtype).cuda()
-        input = Variable(torch.randn(2, 3, 10, 10).type(dtype).cuda(), requires_grad=True)
+        module = nn.Conv2d(3, 5, kernel_size=3, padding=1).to("cuda", dtype)
+        input = torch.randn(2, 3, 10, 10, dtype=dtype, device="cuda", requires_grad=True)
         output = module(input)
 
-        grad = torch.randn(2, 2, 5, 10, 10).type(dtype).cuda()[:, 1]
+        grad = torch.randn(2, 2, 5, 10, 10, dtype=dtype, device="cuda")[:, 1]
         assert not grad.is_contiguous()
         output.backward(grad, retain_graph=True)
         self.assertIsNotNone(input.grad)
@@ -3858,7 +3824,7 @@ class TestNN(NNTestCase):
         input.grad.data.zero_()
 
         output.backward(grad.contiguous())
-        self.assertEqual(result, input.grad.data, type2prec[dtype.__name__])
+        self.assertEqual(result, input.grad.data, dtype2prec[dtype])
 
     def test_pixel_shuffle(self):
         batch_size = random.randint(1, 3)
@@ -3867,7 +3833,7 @@ class TestNN(NNTestCase):
         height = random.randint(5, 10)
         width = random.randint(5, 10)
 
-        input = Variable(torch.Tensor(batch_size, channels, height, width).uniform_(), requires_grad=True)
+        input = torch.rand(batch_size, channels, height, width, requires_grad=True)
         ps = nn.PixelShuffle(upscale_factor)
         output = ps(input)
         self._verify_pixel_shuffle(input.data, output.data, upscale_factor)
@@ -3875,7 +3841,7 @@ class TestNN(NNTestCase):
         self.assertEqual(input.data, input.grad.data)
 
     def test_elu_inplace_view(self):
-        v = Variable(torch.Tensor([1.0, -1.0, 1.0, -1.0]), requires_grad=True)
+        v = torch.tensor([1.0, -1.0, 1.0, -1.0], requires_grad=True)
 
         def func(root):
             x = root.clone()
@@ -3888,7 +3854,7 @@ class TestNN(NNTestCase):
         gradgradcheck(func, [v])
 
     def test_relu_inplace_view(self):
-        v = Variable(torch.Tensor([1.0, -1.0, 1.0, -1.0]), requires_grad=True)
+        v = torch.tensor([1.0, -1.0, 1.0, -1.0], requires_grad=True)
 
         def func(root):
             x = root.clone()
@@ -3901,48 +3867,48 @@ class TestNN(NNTestCase):
         gradgradcheck(func, [v])
 
     def test_bce_with_logits_raises_if_target_and_input_are_different_size(self):
-        target = Variable(torch.rand(5))
-        input = Variable(torch.rand(5, 1))
+        target = torch.rand(5)
+        input = torch.rand(5, 1)
         with self.assertRaises(ValueError):
             nn.BCEWithLogitsLoss()(input, target)
 
-        target = Variable(torch.rand(5, 1))
-        input = Variable(torch.rand(5))
+        target = torch.rand(5, 1)
+        input = torch.rand(5)
         with self.assertRaises(ValueError):
             nn.BCEWithLogitsLoss()(input, target)
 
     def test_bce_with_logits_gives_same_result_as_sigmoid_and_bce_loss(self):
         sigmoid = nn.Sigmoid()
 
-        target = Variable(torch.rand(64, 4))
-        output = Variable(torch.rand(64, 4) - 0.5)
+        target = torch.rand(64, 4)
+        output = torch.rand(64, 4) - 0.5
 
         self.assertEqual(nn.BCEWithLogitsLoss()(output, target), nn.BCELoss()(sigmoid(output), target))
 
         weight = torch.rand(4)
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
 
-        target = Variable(torch.FloatTensor(4, 1).fill_(0))
-        output = Variable(torch.FloatTensor(4, 1).fill_(-100))
+        target = torch.zeros(4, 1, dtype=torch.float)
+        output = torch.empty(4, 1, dtype=torch.float).fill_(-100)
 
         self.assertEqual(nn.BCEWithLogitsLoss()(output, target), nn.BCELoss()(sigmoid(output), target))
 
         self.assertEqual(nn.BCEWithLogitsLoss(reduce=False)(output, target),
                          nn.BCELoss(reduce=False)(sigmoid(output), target))
 
-        weight = torch.FloatTensor(1).uniform_()
+        weight = torch.rand(1, dtype=torch.float)
         self.assertEqual(nn.BCEWithLogitsLoss(weight)(output, target), nn.BCELoss(weight)(sigmoid(output), target))
 
     def test_bce_with_logits_has_correct_grad_at_zero(self):
-        output = Variable(torch.zeros(3, 1), requires_grad=True)
-        target = Variable(torch.zeros(3, 1))
+        output = torch.zeros(3, 1, requires_grad=True)
+        target = torch.zeros(3, 1)
         nn.BCEWithLogitsLoss(size_average=False)(output, target).backward()
-        expected_grad = Variable(torch.Tensor(3, 1).fill_(0.5))
+        expected_grad = torch.empty(3, 1).fill_(0.5)
         self.assertEqual(output.grad, expected_grad)
 
     def test_bce_with_logits_broadcasts_weights(self):
-        target = Variable(torch.rand(16, 4))
-        output = Variable(torch.rand(16, 4) - 0.5)
+        target = torch.rand(16, 4)
+        output = torch.rand(16, 4) - 0.5
 
         weight = torch.rand(4)
         out1 = nn.BCEWithLogitsLoss(weight)(output, target)
@@ -3962,8 +3928,8 @@ class TestNN(NNTestCase):
 
     def test_bce_loss_broadcasts_weights(self):
         sigmoid = nn.Sigmoid()
-        target = Variable(torch.rand(16, 4))
-        output = Variable(torch.rand(16, 4) - 0.5)
+        target = torch.rand(16, 4)
+        output = torch.rand(16, 4) - 0.5
 
         weight = torch.rand(4)
         out1 = nn.BCELoss(weight)(sigmoid(output), target)
@@ -3982,7 +3948,7 @@ class TestNN(NNTestCase):
         self.assertEqual(out1, out2)
 
     def test_elu_inplace_gradgrad(self):
-        v = Variable(torch.randn(8), requires_grad=True)
+        v = torch.randn(8, requires_grad=True)
 
         def func(root):
             x = root.clone()
@@ -3992,7 +3958,7 @@ class TestNN(NNTestCase):
         gradgradcheck(func, [v])
 
     def test_hardtanh_inplace_gradgrad(self):
-        v = Variable(torch.randn(8), requires_grad=True)
+        v = torch.randn(8, requires_grad=True)
 
         def func(root):
             x = root.clone()
@@ -4004,7 +3970,7 @@ class TestNN(NNTestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
-        input = Variable(torch.rand(2, 3, 2, 2).half().cuda().random_(1, 10), requires_grad=True)
+        input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)
         m = nn.BatchNorm2d(3).half().cuda()
         thnn_output = m(input)
         thnn_output.sum().backward()
@@ -4021,10 +3987,10 @@ class TestNN(NNTestCase):
             self.assertEqual(cudnn_output, thnn_output)
             self.assertAlmostEqual(cudnn_input_grad, thnn_input_grad, delta=1e-3)
 
-    def _test_batchnorm_update_stats(self, test_type=torch.FloatTensor):
-        module = nn.BatchNorm1d(3).type(test_type)
+    def _test_batchnorm_update_stats(self, device="cpu", dtype=torch.float):
+        module = nn.BatchNorm1d(3).to(device, dtype)
 
-        data = Variable(torch.rand(4, 3).type(test_type))
+        data = torch.rand(4, 3, device=device, dtype=dtype)
 
         # training pass
         old_running_mean = module.running_mean.clone()
@@ -4046,10 +4012,10 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_update_stats_cuda(self):
-        self._test_batchnorm_update_stats(torch.cuda.FloatTensor)
+        self._test_batchnorm_update_stats("cuda", torch.float)
 
     def test_batchnorm_raises_error_if_running_mean_is_not_same_size_as_input(self):
-        input = Variable(torch.rand(2, 10))
+        input = torch.rand(2, 10)
         running_var = torch.rand(10)
         wrong_sizes = [9, 11]
         for size in wrong_sizes:
@@ -4057,7 +4023,7 @@ class TestNN(NNTestCase):
                 F.batch_norm(input, torch.rand(size), running_var)
 
     def test_batchnorm_raises_error_if_running_var_is_not_same_size_as_input(self):
-        input = Variable(torch.rand(2, 10))
+        input = torch.rand(2, 10)
         running_mean = torch.rand(10)
         wrong_sizes = [9, 11]
         for size in wrong_sizes:
@@ -4065,7 +4031,7 @@ class TestNN(NNTestCase):
                 F.batch_norm(input, running_mean, torch.rand(size))
 
     def test_batchnorm_raises_error_if_weight_is_not_same_size_as_input(self):
-        input = Variable(torch.rand(2, 10))
+        input = torch.rand(2, 10)
         running_mean = torch.rand(10)
         running_var = torch.rand(10)
         wrong_sizes = [9, 11]
@@ -4074,7 +4040,7 @@ class TestNN(NNTestCase):
                 F.batch_norm(input, running_mean, running_var, weight=Parameter(torch.rand(size)))
 
     def test_batchnorm_raises_error_if_bias_is_not_same_size_as_input(self):
-        input = Variable(torch.rand(2, 10))
+        input = torch.rand(2, 10)
         running_mean = torch.rand(10)
         running_var = torch.rand(10)
         wrong_sizes = [9, 11]
@@ -4082,17 +4048,17 @@ class TestNN(NNTestCase):
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, running_var, bias=Parameter(torch.rand(size)))
 
-    def _test_batchnorm_eval(self, dtype=torch.FloatTensor):
-        module = nn.BatchNorm1d(3).type(dtype)
+    def _test_batchnorm_eval(self, device="cpu", dtype=torch.float):
+        module = nn.BatchNorm1d(3).to(device, dtype)
         module.eval()
 
-        data = Variable(torch.rand(4, 3).type(dtype), requires_grad=True)
-        grad = torch.rand(4, 3).type(dtype)
+        data = torch.rand(4, 3, device=device, dtype=dtype, requires_grad=True)
+        grad = torch.rand(4, 3, device=device, dtype=dtype)
 
         # 1st pass
         res1 = module(data)
         res1.backward(grad)
-        grad1 = data.grad.data.clone()
+        grad1 = data.grad.clone()
 
         # 2nd pass
         if data.grad is not None:
@@ -4100,20 +4066,20 @@ class TestNN(NNTestCase):
 
         res2 = module(data)
         res2.backward(grad)
-        grad2 = data.grad.data.clone()
+        grad2 = data.grad.clone()
         self.assertEqual(res1, res2)
         self.assertEqual(grad1, grad2)
 
         # track_running_stats=False
-        module = nn.BatchNorm1d(3, track_running_stats=False).type(dtype)
+        module = nn.BatchNorm1d(3, track_running_stats=False).to(device, dtype)
 
-        data = Variable(torch.rand(4, 3).type(dtype), requires_grad=True)
-        grad = torch.rand(4, 3).type(dtype)
+        data = torch.rand(4, 3, device=device, dtype=dtype, requires_grad=True)
+        grad = torch.rand(4, 3, device=device, dtype=dtype)
 
         # 1st pass
         res1 = module(data)
         res1.backward(grad)
-        grad1 = data.grad.data.clone()
+        grad1 = data.grad.clone()
 
         # set eval
         module.eval()
@@ -4124,94 +4090,94 @@ class TestNN(NNTestCase):
 
         res2 = module(data)
         res2.backward(grad)
-        grad2 = data.grad.data.clone()
+        grad2 = data.grad.clone()
         self.assertEqual(res1, res2)
         self.assertEqual(grad1, grad2)
 
     def test_pairwise_distance(self):
-        input1 = Variable(torch.randn(4, 4), requires_grad=True)
-        input2 = Variable(torch.randn(4, 4), requires_grad=True)
+        input1 = torch.randn(4, 4, requires_grad=True)
+        input2 = torch.randn(4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x, y: F.pairwise_distance(x, y), (input1, input2)))
 
     def test_cosine_embedding_loss_no_reduce(self):
-        input1 = Variable(torch.randn(15, 10), requires_grad=True)
-        input2 = Variable(torch.randn(15, 10), requires_grad=True)
-        target = Variable(torch.randn(15).sign())
+        input1 = torch.randn(15, 10, requires_grad=True)
+        input2 = torch.randn(15, 10, requires_grad=True)
+        target = torch.randn(15).sign()
         self.assertTrue(gradcheck(lambda x, y, z: F.cosine_embedding_loss(
             x, y, z, reduce=False), (input1, input2, target)))
         self.assertEqual(F.cosine_embedding_loss(input1, input2, target, reduce=False),
                          loss_reference_fns['CosineEmbeddingLoss'](input1, input2, target, reduce=False))
 
     def test_cosine_embedding_loss_margin_no_reduce(self):
-        input1 = Variable(torch.randn(15, 10), requires_grad=True)
-        input2 = Variable(torch.randn(15, 10), requires_grad=True)
-        target = Variable(torch.randn(15).sign())
+        input1 = torch.randn(15, 10, requires_grad=True)
+        input2 = torch.randn(15, 10, requires_grad=True)
+        target = torch.randn(15).sign()
         self.assertTrue(gradcheck(lambda x, y, z: F.cosine_embedding_loss(
             x, y, z, margin=0.5, reduce=False), (input1, input2, target)))
         self.assertEqual(F.cosine_embedding_loss(input1, input2, target, margin=0.5, reduce=False),
                          loss_reference_fns['CosineEmbeddingLoss'](input1, input2, target, margin=0.5, reduce=False))
 
     def test_margin_ranking_loss_no_reduce(self):
-        input1 = Variable(torch.randn(15).mul(10), requires_grad=True)
-        input2 = Variable(torch.randn(15).mul(10), requires_grad=True)
-        target = Variable(torch.randn(15).sign())
+        input1 = torch.tensor(torch.randn(15).mul(10), requires_grad=True)
+        input2 = torch.tensor(torch.randn(15).mul(10), requires_grad=True)
+        target = torch.randn(15).sign()
         self.assertTrue(gradcheck(lambda x, y, z: F.margin_ranking_loss(
             x, y, z, reduce=False), (input1, input2, target)))
         self.assertEqual(F.margin_ranking_loss(input1, input2, target, reduce=False),
                          loss_reference_fns['MarginRankingLoss'](input1, input2, target, reduce=False))
 
     def test_margin_ranking_loss_margin_no_reduce(self):
-        input1 = Variable(torch.randn(15).mul(10), requires_grad=True)
-        input2 = Variable(torch.randn(15).mul(10), requires_grad=True)
-        target = Variable(torch.randn(15).sign())
+        input1 = torch.tensor(torch.randn(15).mul(10), requires_grad=True)
+        input2 = torch.tensor(torch.randn(15).mul(10), requires_grad=True)
+        target = torch.randn(15).sign()
         self.assertTrue(gradcheck(lambda x, y, z: F.margin_ranking_loss(
             x, y, z, margin=0.5, reduce=False), (input1, input2, target)))
         self.assertEqual(F.margin_ranking_loss(input1, input2, target, margin=0.5, reduce=False),
                          loss_reference_fns['MarginRankingLoss'](input1, input2, target, margin=0.5, reduce=False))
 
     def test_triplet_margin_loss(self):
-        input1 = Variable(torch.randn(5, 10), requires_grad=True)
-        input2 = Variable(torch.randn(5, 10), requires_grad=True)
-        input3 = Variable(torch.randn(5, 10), requires_grad=True)
+        input1 = torch.randn(5, 10, requires_grad=True)
+        input2 = torch.randn(5, 10, requires_grad=True)
+        input3 = torch.randn(5, 10, requires_grad=True)
         self.assertTrue(gradcheck(lambda x1, x2, x3: F.triplet_margin_loss(
             x1, x2, x3), (input1, input2, input3)))
         self.assertEqual(F.triplet_margin_loss(input1, input2, input3),
                          loss_reference_fns['TripletMarginLoss'](input1, input2, input3))
 
     def test_triplet_margin_loss_swap(self):
-        input1 = Variable(torch.randn(5, 10), requires_grad=True)
-        input2 = Variable(torch.randn(5, 10), requires_grad=True)
-        input3 = Variable(torch.randn(5, 10), requires_grad=True)
+        input1 = torch.randn(5, 10, requires_grad=True)
+        input2 = torch.randn(5, 10, requires_grad=True)
+        input3 = torch.randn(5, 10, requires_grad=True)
         self.assertTrue(gradcheck(lambda x1, x2, x3: F.triplet_margin_loss(
             x1, x2, x3, swap=True), (input1, input2, input3)))
         self.assertEqual(F.triplet_margin_loss(input1, input2, input3, swap=True),
                          loss_reference_fns['TripletMarginLoss'](input1, input2, input3, swap=True))
 
     def test_triplet_margin_loss_no_reduce(self):
-        input1 = Variable(torch.randn(5, 10), requires_grad=True)
-        input2 = Variable(torch.randn(5, 10), requires_grad=True)
-        input3 = Variable(torch.randn(5, 10), requires_grad=True)
+        input1 = torch.randn(5, 10, requires_grad=True)
+        input2 = torch.randn(5, 10, requires_grad=True)
+        input3 = torch.randn(5, 10, requires_grad=True)
         self.assertTrue(gradcheck(lambda x1, x2, x3: F.triplet_margin_loss(
             x1, x2, x3, reduce=False), (input1, input2, input3)))
         self.assertEqual(F.triplet_margin_loss(input1, input2, input3, reduce=False),
                          loss_reference_fns['TripletMarginLoss'](input1, input2, input3, reduce=False))
 
     def test_triplet_margin_loss_swap_no_reduce(self):
-        input1 = Variable(torch.randn(5, 10), requires_grad=True)
-        input2 = Variable(torch.randn(5, 10), requires_grad=True)
-        input3 = Variable(torch.randn(5, 10), requires_grad=True)
+        input1 = torch.randn(5, 10, requires_grad=True)
+        input2 = torch.randn(5, 10, requires_grad=True)
+        input3 = torch.randn(5, 10, requires_grad=True)
         self.assertTrue(gradcheck(lambda x1, x2, x3: F.triplet_margin_loss(
             x1, x2, x3, swap=True, reduce=False), (input1, input2, input3)))
         self.assertEqual(F.triplet_margin_loss(input1, input2, input3, swap=True, reduce=False),
                          loss_reference_fns['TripletMarginLoss'](input1, input2, input3, swap=True, reduce=False))
 
     def test_cosine_similarity(self):
-        input1 = Variable(torch.randn(4, 4), requires_grad=True)
-        input2 = Variable(torch.randn(4, 4), requires_grad=True)
+        input1 = torch.randn(4, 4, requires_grad=True)
+        input2 = torch.randn(4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y), (input1, input2)))
 
-        input1 = Variable(torch.randn(4, 5, 6), requires_grad=True)
-        input2 = Variable(torch.randn(4, 5, 6), requires_grad=True)
+        input1 = torch.randn(4, 5, 6, requires_grad=True)
+        input2 = torch.randn(4, 5, 6, requires_grad=True)
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=0), (input1, input2)))
         self.assertTrue(gradcheck(lambda x, y: F.cosine_similarity(x, y, dim=-1), (input1, input2)))
 
@@ -4223,8 +4189,8 @@ class TestNN(NNTestCase):
         # Check cosine_similarity input/output shapes
         input_size = (1, 3, 2, 1)
         expected_size = (1, 2, 1)
-        input1 = Variable(torch.randn(input_size), requires_grad=True)
-        input2 = Variable(torch.randn(input_size), requires_grad=True)
+        input1 = torch.randn(input_size, requires_grad=True)
+        input2 = torch.randn(input_size, requires_grad=True)
         self.assertEqual(F.cosine_similarity(input1, input2, dim=1).size(), expected_size)
 
     def test_grid_sample(self):
@@ -4250,7 +4216,7 @@ class TestNN(NNTestCase):
                 # check that zero-dimensional input strides don't error out
                 base_input = torch.randn(C, IH, IW)
                 input_cpu = Variable(base_input.expand(input_cuda.size()), requires_grad=True)
-                grid_cpu = Variable(torch.randn(N, H, W, 2), requires_grad=True)
+                grid_cpu = torch.randn(N, H, W, 2, requires_grad=True)
                 out_cpu = F.grid_sample(input_cpu, grid_cpu, padding_mode=padding_mode)
 
                 input_cuda = Variable(base_input.cuda().expand(input_cuda.size()), requires_grad=True)
@@ -4306,8 +4272,8 @@ class TestNN(NNTestCase):
             C = random.randint(1, 8)
             H = random.randint(1, 8)
             W = random.randint(1, 8)
-            input = Variable(torch.randn(N, C, H, W), requires_grad=True)
-            grid = Variable(torch.randn(N, H, W, 2), requires_grad=True)
+            input = torch.randn(N, C, H, W, requires_grad=True)
+            grid = torch.randn(N, H, W, 2, requires_grad=True)
             self.assertTrue(gradcheck(
                 lambda inp, grid: F.grid_sample(inp, grid, padding_mode=padding_mode),
                 (input, grid)))
@@ -4339,7 +4305,7 @@ class TestNN(NNTestCase):
                 # check that zero-dimensional input strides don't error out
                 base_input = torch.randn(C, ID, IH, IW)
                 input_cpu = Variable(base_input.expand(input_cuda.size()), requires_grad=True)
-                grid_cpu = Variable(torch.randn(N, D, H, W, 3), requires_grad=True)
+                grid_cpu = torch.randn(N, D, H, W, 3, requires_grad=True)
                 out_cpu = F.grid_sample(input_cpu, grid_cpu, padding_mode=padding_mode)
 
                 input_cuda = Variable(base_input.cuda().expand(input_cuda.size()), requires_grad=True)
@@ -4380,8 +4346,8 @@ class TestNN(NNTestCase):
             D = random.randint(1, 8)
             H = random.randint(1, 8)
             W = random.randint(1, 8)
-            input = Variable(torch.randn(N, C, D, H, W), requires_grad=True)
-            grid = Variable(torch.randn(N, D, H, W, 3), requires_grad=True)
+            input = torch.randn(N, C, D, H, W, requires_grad=True)
+            grid = torch.randn(N, D, H, W, 3, requires_grad=True)
             self.assertTrue(gradcheck(
                 lambda inp, grid: F.grid_sample(inp, grid, padding_mode=padding_mode),
                 (input, grid)))
@@ -4404,12 +4370,12 @@ class TestNN(NNTestCase):
         H = random.randint(1, 8)
         W = random.randint(1, 8)
         sz = torch.Size([N, C, H, W])
-        inp = Variable(torch.randn(N, 2, 3), requires_grad=True)
+        inp = torch.randn(N, 2, 3, requires_grad=True)
         self.assertTrue(gradcheck(lambda inp: F.affine_grid(inp, sz), (inp,)))
 
         # test CPU against CUDA
         if TEST_CUDNN:
-            input_cpu = Variable(torch.randn(N, 2, 3), requires_grad=True)
+            input_cpu = torch.randn(N, 2, 3, requires_grad=True)
             out_cpu = F.affine_grid(input_cpu, sz)
             gradients = torch.randn(out_cpu.size())
             out_cpu.backward(gradients)
@@ -4425,7 +4391,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingLinear1d(self):
@@ -4434,7 +4400,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='linear'), (input,))
 
     def test_upsamplingLinear1d_spatial_invariance(self):
@@ -4451,7 +4417,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, 2, requires_grad=True)
         self.assertEqual(
             F.upsample(input, 4, mode='nearest'),
             F.upsample(input, scale_factor=2, mode='nearest'))
@@ -4464,7 +4430,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, 2, requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='bilinear'), [input])
 
     def test_upsamplingBilinear2d_spatial_invariance(self):
@@ -4481,7 +4447,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2, 2, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, 2, 2, requires_grad=True)
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingTrilinear3d(self):
@@ -4490,7 +4456,7 @@ class TestNN(NNTestCase):
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t.data)
 
-        input = Variable(torch.randn(1, 1, 2, 2, 2), requires_grad=True)
+        input = torch.randn(1, 1, 2, 2, 2, requires_grad=True)
         self.assertEqual(
             F.upsample(input, (4, 4, 4), mode='trilinear'),
             F.upsample(input, scale_factor=2, mode='trilinear'))
@@ -4507,7 +4473,7 @@ class TestNN(NNTestCase):
 
     def test_linear_broadcasting(self):
         m = nn.Linear(5, 8)
-        inp = Variable(torch.randn(2, 3, 5))
+        inp = torch.randn(2, 3, 5)
         expected = m(inp.view(6, 5)).view(2, 3, 8)
         self.assertEqual(expected, m(inp))
 
@@ -4526,8 +4492,8 @@ class TestNN(NNTestCase):
 
         self.assertEqual(output.data, output_legacy)
 
-        input1_1 = Variable(input1, requires_grad=True)
-        input2_1 = Variable(input2, requires_grad=True)
+        input1_1 = torch.tensor(input1, requires_grad=True)
+        input2_1 = torch.tensor(input2, requires_grad=True)
 
         module.zero_grad()
         module_legacy.zeroGradParameters()
@@ -4584,26 +4550,26 @@ class TestNN(NNTestCase):
         self.assertEqual(expected, m(input1, input2))
 
     def test_conv_tbc(self):
-        inp = Variable(torch.randn(9, 4, 5), requires_grad=True)
-        weight = Variable(torch.randn(3, 5, 6), requires_grad=True)
-        bias = Variable(torch.randn(6), requires_grad=True)
+        inp = torch.randn(9, 4, 5, requires_grad=True)
+        weight = torch.randn(3, 5, 6, requires_grad=True)
+        bias = torch.randn(6, requires_grad=True)
 
         gradcheck(lambda i, w, b, pad: F.conv_tbc(i, w, b, pad), (inp, weight, bias, 3))
 
     def run_conv_double_back_test(self, kern, stride, padding, chan_in, chan_out, batch_size,
                                   inp_size, dilation, no_weight, groups=1, use_cuda=False,
-                                  use_bias=True, dtype=torch.DoubleTensor):
-        tensor = torch.Tensor(1)
+                                  use_bias=True, dtype=torch.double):
         if use_cuda:
-            tensor = tensor.cuda()
+            device = torch.device("cuda")
+        else:
+            device = torch.device("cpu")
 
-        x = Variable(tensor.new(batch_size, chan_in, inp_size, inp_size).type(dtype), requires_grad=True)
-        x.data.normal_()
-        weight = Variable(tensor.new(chan_out, chan_in // groups, kern, kern).type(dtype), requires_grad=not no_weight)
-        weight.data.normal_()
+        x = torch.randn(batch_size, chan_in, inp_size, inp_size, device=device,
+                        dtype=dtype, requires_grad=True)
+        weight = torch.randn(chan_out, chan_in // groups, kern, kern, device=device,
+                             dtype=dtype, requires_grad=not no_weight)
         if use_bias:
-            bias = Variable(tensor.new(chan_out).type(dtype), requires_grad=True)
-            bias.data.normal_()
+            bias = torch.randn(chan_out, device=device, dtype=dtype, requires_grad=True)
         else:
             bias = None
 
@@ -4624,8 +4590,7 @@ class TestNN(NNTestCase):
             inputs = x, weight
 
         dummy_out = func(*inputs)
-        grad_y = Variable(tensor.new(dummy_out.size()).type(dtype), requires_grad=True)
-        grad_y.data.normal_()
+        grad_y = torch.randn_like(dummy_out, device=device, dtype=dtype, requires_grad=True)
 
         return gradgradcheck(func, inputs, (grad_y,))
 
@@ -4725,9 +4690,8 @@ class TestNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @repeat_test_for_types(DOUBLE_TENSORTYPES)
-    def test_conv_double_backward_cuda(self, dtype=torch.FloatTensor):
+    def test_conv_double_backward_cuda(self, dtype=torch.double):
         # Double backward only runs with DoubleTensor due to precison reason
-        dtype = getattr(torch.cuda, dtype.__name__)
         batch_size = 1
         for kern, inp_size, dilations in [(3, 5, [1, 2]), (4, 9, [1])]:
             for stride, padding, chan_in, chan_out, dilation in product([1], [2], [2], [3], dilations):
@@ -4931,8 +4895,8 @@ class TestNNInit(TestCase):
     def test_dirac_identity(self):
         batch, in_c, out_c, size, kernel_size = 8, 3, 4, 5, 3
         # Test 1D
-        input_var = Variable(torch.randn(batch, in_c, size))
-        filter_var = Variable(torch.zeros(out_c, in_c, kernel_size))
+        input_var = torch.randn(batch, in_c, size)
+        filter_var = torch.zeros(out_c, in_c, kernel_size)
         init.dirac_(filter_var)
         output_var = F.conv1d(input_var, filter_var)
         input_tensor, output_tensor = input_var.data, output_var.data  # Variables do not support nonzero
@@ -4940,8 +4904,8 @@ class TestNNInit(TestCase):
         assert torch.nonzero(output_tensor[:, in_c:, :]).numel() == 0  # Assert extra outputs are 0
 
         # Test 2D
-        input_var = Variable(torch.randn(batch, in_c, size, size))
-        filter_var = Variable(torch.zeros(out_c, in_c, kernel_size, kernel_size))
+        input_var = torch.randn(batch, in_c, size, size)
+        filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size)
         init.dirac_(filter_var)
         output_var = F.conv2d(input_var, filter_var)
         input_tensor, output_tensor = input_var.data, output_var.data
@@ -4949,8 +4913,8 @@ class TestNNInit(TestCase):
         assert torch.nonzero(output_tensor[:, in_c:, :, :]).numel() == 0
 
         # Test 3D
-        input_var = Variable(torch.randn(batch, in_c, size, size, size))
-        filter_var = Variable(torch.zeros(out_c, in_c, kernel_size, kernel_size, kernel_size))
+        input_var = torch.randn(batch, in_c, size, size, size)
+        filter_var = torch.zeros(out_c, in_c, kernel_size, kernel_size, kernel_size)
         init.dirac_(filter_var)
         output_var = F.conv3d(input_var, filter_var)
         input_tensor, output_tensor = input_var.data, output_var.data
@@ -5202,11 +5166,11 @@ def add_test(test):
         # With dtype enable, it's good enough to test against three floating types
         if 'dtype' in get_function_arglist(test.test_cuda):
             setattr(TestNN, cuda_test_name + '_float', lambda self,
-                    test=test: test.test_cuda(self, dtype=torch.FloatTensor))
+                    test=test: test.test_cuda(self, dtype=torch.float))
             setattr(TestNN, cuda_test_name + '_double', lambda self,
-                    test=test: test.test_cuda(self, dtype=torch.DoubleTensor))
+                    test=test: test.test_cuda(self, dtype=torch.double))
             setattr(TestNN, cuda_test_name + '_half', lambda self,
-                    test=test: test.test_cuda(self, dtype=torch.HalfTensor))
+                    test=test: test.test_cuda(self, dtype=torch.half))
         else:
             setattr(TestNN, cuda_test_name, lambda self, test=test: test.test_cuda(self))
 
@@ -5362,7 +5326,7 @@ new_criterion_tests = [
 
 
 def poissonnllloss_no_reduce_test():
-    t = Variable(torch.randn(10, 10))
+    t = torch.randn(10, 10)
     return dict(
         fullname='PoissonNLLLLoss_no_reduce',
         constructor=wrap_functional(
@@ -5397,7 +5361,7 @@ def bceloss_no_reduce_scalar_test():
 
 def bceloss_weights_no_reduce_test():
     t = Variable(torch.randn(15, 10).gt(0).double())
-    weights = Variable(torch.rand(10))
+    weights = torch.rand(10)
     return dict(
         fullname='BCELoss_weights_no_reduce',
         constructor=wrap_functional(
@@ -5450,7 +5414,7 @@ def bce_with_logistic_no_reduce_scalar_test():
 
 
 def kldivloss_no_reduce_test():
-    t = Variable(torch.randn(10, 10))
+    t = torch.randn(10, 10)
     return dict(
         fullname='KLDivLoss_no_reduce',
         constructor=wrap_functional(
@@ -5474,7 +5438,7 @@ def kldivloss_no_reduce_scalar_test():
 
 
 def l1loss_no_reduce_test():
-    t = Variable(torch.randn(2, 3, 4))
+    t = torch.randn(2, 3, 4)
     return dict(
         fullname='L1Loss_no_reduce',
         constructor=wrap_functional(
@@ -5497,7 +5461,7 @@ def l1loss_no_reduce_scalar_test():
 
 def mseloss_no_reduce_test():
     input_size = (2, 3, 4, 5)
-    target = Variable(torch.randn(*input_size))
+    target = torch.randn(*input_size)
     return dict(
         fullname='MSELoss_no_reduce',
         constructor=wrap_functional(
@@ -5547,7 +5511,7 @@ def nllloss_no_reduce_ignore_index_test():
 
 def nllloss_no_reduce_weights_test():
     t = Variable(torch.Tensor(15).uniform_().mul(10).floor().long())
-    weight = Variable(torch.rand(10))
+    weight = torch.rand(10)
 
     def kwargs(i):
         return {'weight': weight.type_as(i), 'reduce': False}
@@ -5564,7 +5528,7 @@ def nllloss_no_reduce_weights_test():
 
 def nllloss_no_reduce_weights_ignore_index_test():
     t = Variable(torch.Tensor(15).uniform_().mul(10).floor().long())
-    weight = Variable(torch.rand(10))
+    weight = torch.rand(10)
 
     def kwargs(i):
         return {'weight': weight.type_as(i), 'reduce': False,
@@ -5582,7 +5546,7 @@ def nllloss_no_reduce_weights_ignore_index_test():
 
 def nllloss_no_reduce_weights_ignore_index_neg_test():
     t = Variable(torch.Tensor(15).uniform_().mul(10).floor().long())
-    weight = Variable(torch.rand(10))
+    weight = torch.rand(10)
 
     def kwargs(i):
         return {'weight': weight.type_as(i), 'reduce': False,
@@ -5669,7 +5633,7 @@ def nlllossNd_no_reduce_ignore_index_test():
 
 def nlllossNd_no_reduce_weights_test():
     t = Variable(torch.rand(2, 5, 5, 2, 2).mul(3).floor().long())
-    weight = Variable(torch.rand(3))
+    weight = torch.rand(3)
 
     def kwargs(i):
         return {'weight': weight.type_as(i), 'reduce': False}
@@ -5685,7 +5649,7 @@ def nlllossNd_no_reduce_weights_test():
 
 
 def smoothl1loss_no_reduce_test():
-    t = Variable(torch.randn(2, 3, 4))
+    t = torch.randn(2, 3, 4)
     return dict(
         fullname='SmoothL1Loss_no_reduce',
         constructor=wrap_functional(
@@ -5777,7 +5741,7 @@ def hingeembeddingloss_margin_no_reduce_test():
 
 
 def softmarginloss_no_reduce_test():
-    t = Variable(torch.randn(5, 5))
+    t = torch.randn(5, 5)
     return dict(
         fullname='SoftMarginLoss_no_reduce',
         constructor=wrap_functional(
@@ -5790,7 +5754,7 @@ def softmarginloss_no_reduce_test():
 
 
 def multilabelsoftmarginloss_no_reduce_test():
-    t = Variable(torch.rand(5, 10).mul(2).floor())
+    t = torch.rand(5, 10).mul(2).floor()
     return dict(
         fullname='MultiLabelSoftMarginLoss_no_reduce',
         constructor=wrap_functional(
@@ -5804,8 +5768,8 @@ def multilabelsoftmarginloss_no_reduce_test():
 
 
 def multilabelsoftmarginloss_weights_no_reduce_test():
-    t = Variable(torch.rand(5, 10).mul(2).floor())
-    weights = Variable(torch.rand(10))
+    t = torch.rand(5, 10).mul(2).floor()
+    weights = torch.rand(10)
     return dict(
         fullname='MultiLabelSoftMarginLoss_weights_no_reduce',
         constructor=wrap_functional(
@@ -5820,7 +5784,7 @@ def multilabelsoftmarginloss_weights_no_reduce_test():
 
 
 def multimarginloss_no_reduce_test():
-    t = Variable(torch.rand(5).mul(8).floor().long())
+    t = torch.rand(5).mul(8).floor().long()
     return dict(
         fullname='MultiMarginLoss_no_reduce',
         constructor=wrap_functional(
@@ -5834,7 +5798,7 @@ def multimarginloss_no_reduce_test():
 
 
 def multimarginloss_1d_no_reduce_test():
-    t = Variable(torch.rand(1).mul(8).floor().long())
+    t = torch.rand(1).mul(8).floor().long()
     return dict(
         fullname='MultiMarginLoss_1d_no_reduce',
         constructor=wrap_functional(
@@ -5848,7 +5812,7 @@ def multimarginloss_1d_no_reduce_test():
 
 
 def multimarginloss_p_no_reduce_test():
-    t = Variable(torch.rand(5).mul(8).floor().long())
+    t = torch.rand(5).mul(8).floor().long()
     return dict(
         fullname='MultiMarginLoss_p_no_reduce',
         constructor=wrap_functional(
@@ -5862,7 +5826,7 @@ def multimarginloss_p_no_reduce_test():
 
 
 def multimarginloss_margin_no_reduce_test():
-    t = Variable(torch.rand(5).mul(8).floor().long())
+    t = torch.rand(5).mul(8).floor().long()
     return dict(
         fullname='MultiMarginLoss_margin_no_reduce',
         constructor=wrap_functional(
@@ -5877,8 +5841,8 @@ def multimarginloss_margin_no_reduce_test():
 
 
 def multimarginloss_weights_no_reduce_test():
-    t = Variable(torch.rand(5).mul(8).floor().long())
-    weights = Variable(torch.rand(10))
+    t = torch.rand(5).mul(8).floor().long()
+    weights = torch.rand(10)
     return dict(
         fullname='MultiMarginLoss_weights_no_reduce',
         constructor=wrap_functional(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,7 +13,6 @@ import torch.nn as nn
 import torch.utils.data
 import torch.cuda
 import warnings
-from torch.autograd import Variable
 from torch.utils.checkpoint import checkpoint, checkpoint_sequential
 from torch.utils.trainer import Trainer
 from torch.utils.trainer.plugins import *
@@ -69,7 +68,7 @@ class ModelMock(object):
 
     def __init__(self):
         self.num_calls = 0
-        self.output = Variable(torch.ones(1, 1), requires_grad=True)
+        self.output = torch.ones(1, 1, requires_grad=True)
 
     def __call__(self, i):
         self.num_calls += 1

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -13,7 +13,7 @@ from .gradcheck import gradcheck
 from .grad_mode import no_grad, enable_grad, set_grad_enabled
 from . import profiler
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'variable']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode']
 
 
 def _make_grads(outputs, grads):
@@ -165,6 +165,7 @@ def _is_checkpoint_valid():
 def variable(*args, **kwargs):
     warnings.warn("torch.autograd.variable(...) is deprecated, use torch.tensor(...) instead")
     return torch.tensor(*args, **kwargs)
+
 
 if not torch._C._autograd_init():
     raise RuntimeError("autograd initialization failed")

--- a/torch/autograd/_functions/utils.py
+++ b/torch/autograd/_functions/utils.py
@@ -2,25 +2,25 @@ import torch
 from functools import reduce
 
 
-def maybe_view(variable, size, check_same_size=True):
-    if check_same_size and variable.size() == size:
-        return variable
-    return variable.contiguous().view(size)
+def maybe_view(tensor, size, check_same_size=True):
+    if check_same_size and tensor.size() == size:
+        return tensor
+    return tensor.contiguous().view(size)
 
 
-def maybe_unexpand(variable, old_size, check_same_size=True):
-    if check_same_size and variable.size() == old_size:
-        return variable
-    num_unsqueezed = variable.dim() - len(old_size)
+def maybe_unexpand(tensor, old_size, check_same_size=True):
+    if check_same_size and tensor.size() == old_size:
+        return tensor
+    num_unsqueezed = tensor.dim() - len(old_size)
     expanded_dims = [dim for dim, (expanded, original)
-                     in enumerate(zip(variable.size()[num_unsqueezed:], old_size))
+                     in enumerate(zip(tensor.size()[num_unsqueezed:], old_size))
                      if expanded != original]
 
     for _ in range(num_unsqueezed):
-        variable = variable.sum(0, keepdim=False)
+        tensor = tensor.sum(0, keepdim=False)
     for dim in expanded_dims:
-        variable = variable.sum(dim, keepdim=True)
-    return variable
+        tensor = tensor.sum(dim, keepdim=True)
+    return tensor
 
 
 # Generate paddings in ONNX order based on pad in pytorch.

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1,22 +1,11 @@
 import torch
-from torch.autograd import Variable
 from collections import Iterable
 import torch.testing
 import sys
 
 
-def iter_variables(x):
-    if isinstance(x, Variable):
-        if x.requires_grad:
-            yield (x.grad.data, x.data) if x.grad is not None else (None, None)
-    elif isinstance(x, Iterable):
-        for elem in x:
-            for result in iter_variables(elem):
-                yield result
-
-
 def zero_gradients(x):
-    if isinstance(x, Variable):
+    if isinstance(x, torch.Tensor):
         if x.grad is not None:
             x.grad.detach_()
             x.grad.data.zero_()
@@ -26,7 +15,7 @@ def zero_gradients(x):
 
 
 def make_jacobian(input, num_out):
-    if isinstance(input, Variable):
+    if isinstance(input, torch.Tensor):
         if not input.is_floating_point():
             return None
         if not input.requires_grad:
@@ -49,6 +38,16 @@ def iter_tensors(x, only_requiring_grad=False):
     elif isinstance(x, Iterable):
         for elem in x:
             for result in iter_tensors(elem, only_requiring_grad):
+                yield result
+
+
+def iter_tensors_with_grad(x):
+    if isinstance(x, torch.Tensor):
+        if x.requires_grad:
+            yield (x.grad.data, x.data) if x.grad is not None else (None, None)
+    elif isinstance(x, Iterable):
+        for elem in x:
+            for result in iter_tensors_with_grad(elem):
                 yield result
 
 
@@ -105,7 +104,7 @@ def get_analytical_jacobian(input, output):
         for jacobian_c in (jacobian, jacobian_reentrant):
             zero_gradients(input)
             output.backward(grad_output, create_graph=True)
-            for jacobian_x, (d_x, x) in zip(jacobian_c, iter_variables(input)):
+            for jacobian_x, (d_x, x) in zip(jacobian_c, iter_tensors_with_grad(input)):
                 if d_x is not None and d_x.size() != x.size():
                     correct_grad_sizes = False
                 elif jacobian_x.numel() != 0:
@@ -147,9 +146,9 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     is true for all elements of analytical jacobian a and numerical jacobian n.
 
     Args:
-        func: Python function that takes Variable inputs and returns
-            a tuple of Variables
-        inputs: tuple of Variables
+        func: Python function that takes Tensor inputs and returns
+            a Tensor or a tuple of Tensors
+        inputs: tuple of Tensors
         eps: perturbation for finite differences
         atol: absolute tolerance
         rtol: relative tolerance
@@ -202,9 +201,9 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
     output = _differentiable_outputs(func(*inputs))
     if any([o.requires_grad for o in output]):
         torch.autograd.backward(output, [torch.zeros_like(o) for o in output], create_graph=True)
-        var_inputs = list(filter(lambda i: isinstance(i, Variable), inputs))
+        var_inputs = list(filter(lambda i: isinstance(i, torch.Tensor), inputs))
         if not var_inputs:
-            raise RuntimeError("no Variables found in input")
+            raise RuntimeError("no Tensors found in input")
         for i in var_inputs:
             if i.grad is None:
                 continue
@@ -232,10 +231,10 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
     is true for all elements of analytical gradient a and numerical gradient n.
 
     Args:
-        func (function): Python function that takes Variable inputs and returns
-            a tuple of Variables
-        inputs (tuple of Variable): inputs to the function
-        grad_outputs (tuple of Variable, optional): The gradients with respect to
+        func (function): Python function that takes Tensor inputs and returns
+            a Tensor or a tuple of Tensors
+        inputs (tuple of Tensor): inputs to the function
+        grad_outputs (tuple of Tensor, optional): The gradients with respect to
             the function's outputs.
         eps (float, optional): perturbation for finite differences
         atol (float, optional): absolute tolerance
@@ -252,7 +251,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         otherwise.
     """
     if grad_outputs is None:
-        # If grad_outputs is not specified, create random variables of the same
+        # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
             var = torch.testing.randn_like(x if x.is_floating_point() else x.double())
@@ -267,7 +266,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
     def new_func(*input_args):
         input_args = input_args[:-len(grad_outputs)]
         outputs = _differentiable_outputs(func(*input_args))
-        input_args = tuple(x for x in input_args if isinstance(x, Variable) and x.requires_grad)
+        input_args = tuple(x for x in input_args if isinstance(x, torch.Tensor) and x.requires_grad)
         grad_inputs = torch.autograd.grad(outputs, input_args, grad_outputs, create_graph=True)
         return grad_inputs
 

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -40,7 +40,7 @@ def init_dropout_state(ty, device, dropout, train, dropout_seed, dropout_state):
     dropout_p = dropout if train else 0
     if (dropout_desc_name not in dropout_state) or (dropout_state[dropout_desc_name].get() is None):
         dropout_state[dropout_desc_name] = Unserializable(
-            torch._C._VariableFunctions._cudnn_init_dropout_state(dropout_p, train, dropout_seed, ty=ty, device=device)
+            torch._cudnn_init_dropout_state(dropout_p, train, dropout_seed, ty=ty, device=device)
             if dropout_p != 0 else None
         )
     dropout_ts = dropout_state[dropout_desc_name].get()

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -87,52 +87,52 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
 {
   HANDLE_TH_ERRORS
   _maybe_reinitialize_engine_after_fork();
-  PyObject *variables = nullptr;
-  PyObject *grad_variables = nullptr;
+  PyObject *tensors = nullptr;
+  PyObject *grad_tensors = nullptr;
   unsigned char keep_graph = 0;
   unsigned char create_graph = 0;
   PyObject *inputs = nullptr;
   unsigned char allow_unreachable = 0;
   const char *accepted_kwargs[] = {
-      "variables", "grad_variables", "keep_graph", "create_graph", "inputs",
+      "tensors", "grad_tensors", "keep_graph", "create_graph", "inputs",
       "allow_unreachable", nullptr
   };
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OObb|Ob", (char**)accepted_kwargs,
-        &variables, &grad_variables, &keep_graph, &create_graph, &inputs, &allow_unreachable))
+        &tensors, &grad_tensors, &keep_graph, &create_graph, &inputs, &allow_unreachable))
     return nullptr;
 
-  THPUtils_assert(PyTuple_Check(variables), "variables argument is expected to "
-      "be a tuple, but got %s", THPUtils_typename(variables));
-  THPUtils_assert(PyTuple_Check(grad_variables), "variables argument is "
-      "expected to be a tuple, but got %s", THPUtils_typename(grad_variables));
+  THPUtils_assert(PyTuple_Check(tensors), "tensors argument is expected to "
+      "be a tuple, but got %s", THPUtils_typename(tensors));
+  THPUtils_assert(PyTuple_Check(grad_tensors), "grad_tensors argument is "
+      "expected to be a tuple, but got %s", THPUtils_typename(grad_tensors));
 
-  Py_ssize_t num_variables = PyTuple_GET_SIZE(variables);
-  Py_ssize_t num_gradients = PyTuple_GET_SIZE(grad_variables);
-  THPUtils_assert(num_variables == num_gradients, "got %ld variables and %ld "
-      "gradients", num_variables, num_gradients);
+  Py_ssize_t num_tensors = PyTuple_GET_SIZE(tensors);
+  Py_ssize_t num_gradients = PyTuple_GET_SIZE(grad_tensors);
+  THPUtils_assert(num_tensors == num_gradients, "got %ld tensors and %ld "
+      "gradients", num_tensors, num_gradients);
 
   edge_list roots;
-  roots.reserve(num_variables);
+  roots.reserve(num_tensors);
   variable_list grads;
-  grads.reserve(num_variables);
-  for (int i = 0; i < num_variables; i++) {
-    PyObject *_variable = PyTuple_GET_ITEM(variables, i);
-    THPUtils_assert(THPVariable_Check(_variable), "element %d of variables "
-        "tuple is not a Variable", i);
-    auto& variable = ((THPVariable*)_variable)->cdata;
+  grads.reserve(num_tensors);
+  for (int i = 0; i < num_tensors; i++) {
+    PyObject *_tensor = PyTuple_GET_ITEM(tensors, i);
+    THPUtils_assert(THPVariable_Check(_tensor), "element %d of tensors "
+        "tuple is not a Tensor", i);
+    auto& variable = ((THPVariable*)_tensor)->cdata;
     auto gradient_edge = variable.gradient_edge();
     THPUtils_assert(gradient_edge.function,
-        "element %d of variables does not require grad and does not have a grad_fn", i);
+        "element %d of tensors does not require grad and does not have a grad_fn", i);
     roots.push_back(std::move(gradient_edge));
 
-    PyObject *grad = PyTuple_GET_ITEM(grad_variables, i);
+    PyObject *grad = PyTuple_GET_ITEM(grad_tensors, i);
     if (THPVariable_Check(grad)) {
       grads.push_back(((THPVariable*)grad)->cdata);
     } else {
       THPUtils_assert(grad == Py_None,
-          "element %d of gradients tuple is not a Variable or None", i);
+          "element %d of gradients tuple is not a Tensor or None", i);
       THPUtils_assert(!variable.requires_grad(),
-          "element %d of gradients tuple is None, but the corresponding Variable requires grad");
+          "element %d of gradients tuple is None, but the corresponding Tensor requires grad");
     }
   }
 
@@ -143,7 +143,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     for (int i = 0; i < num_inputs; ++i) {
       PyObject *input = PyTuple_GET_ITEM(inputs, i);
       THPUtils_assert(THPVariable_Check(input),
-          "all inputs have to be Variables, but got %s", THPUtils_typename(input));
+          "all inputs have to be Tensors, but got %s", THPUtils_typename(input));
       THPVariable *input_var = (THPVariable*)input;
       const auto output_nr = input_var->cdata.output_nr();
       auto grad_fn = input_var->cdata.grad_fn();
@@ -151,7 +151,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
           grad_fn = input_var->cdata.try_get_grad_accumulator();
       }
       THPUtils_assert(input_var->cdata.requires_grad(),
-          "One of the differentiated Variables does not require grad");
+          "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
         output_edges.emplace_back();
       } else {
@@ -172,7 +172,7 @@ PyObject *THPEngine_run_backward(THPEngine *self, PyObject *args, PyObject *kwar
     if (!py_outputs) return nullptr;
     for (int i = 0; i < num_inputs; i++) {
       THPUtils_assert(allow_unreachable || outputs[i].defined(), "One of the "
-                      "differentiated Variables appears to not have been used "
+                      "differentiated Tensors appears to not have been used "
                       "in the graph. Set allow_unused=True if this is the "
                       "desired behavior.");
       PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -1,7 +1,6 @@
 from numbers import Number
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property
@@ -86,7 +85,7 @@ class Bernoulli(ExponentialFamily):
 
     def enumerate_support(self):
         values = self._new((2,))
-        torch.arange(2, out=values.data if isinstance(values, Variable) else values)
+        torch.arange(2, out=values.data)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
         return values

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -1,7 +1,6 @@
 from numbers import Number
 import torch
 import math
-from torch.autograd import variable, Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all, probs_to_logits, lazy_property, logits_to_probs
@@ -100,7 +99,7 @@ class Binomial(Distribution):
 
     def enumerate_support(self):
         values = self._new((self.total_count,))
-        torch.arange(self.total_count, out=values.data if isinstance(values, Variable) else values)
+        torch.arange(self.total_count, out=values.data)
         values = values.view((-1,) + (1,) * len(self._batch_shape))
         values = values.expand((-1,) + self._batch_shape)
         return values

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable, variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import probs_to_logits, logits_to_probs, log_sum_exp, lazy_property, broadcast_all
@@ -110,6 +109,4 @@ class Categorical(Distribution):
         values = values.expand((-1,) + self._batch_shape)
         if self._param.is_cuda:
             values = values.cuda(self._param.get_device())
-        if isinstance(self._param, Variable):
-            values = Variable(values)
         return values

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -20,8 +20,8 @@ indicated by each distribution's ``.arg_constraints`` dict. These transforms oft
 overparameterize a space in order to avoid rotation; they are thus more
 suitable for coordinate-wise optimization algorithms like Adam::
 
-    loc = Variable(torch.zeros(100), requires_grad=True)
-    unconstrained = Variable(torch.zeros(100), requires_grad=True)
+    loc = torch.zeros(100, requires_grad=True)
+    unconstrained = torch.zeros(100, requires_grad=True)
     scale = transform_to(Normal.arg_constraints['scale'])(unconstrained)
     loss = -Normal(loc, scale).log_prob(data).sum()
 
@@ -31,7 +31,7 @@ propagated in an unconstrained space, and algorithms are typically rotation
 invariant.::
 
     dist = Exponential(rate)
-    unconstrained = Variable(torch.zeros(100), requires_grad=True)
+    unconstrained = torch.zeros(100, requires_grad=True)
     sample = biject_to(dist.support)(unconstrained)
     potential_energy = -dist.log_prob(sample).sum()
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -1,7 +1,7 @@
 from numbers import Number
 
 import torch
-from torch.autograd import Function, Variable
+from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
@@ -64,7 +64,7 @@ class Dirichlet(ExponentialFamily):
     def rsample(self, sample_shape=()):
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)
-        if isinstance(concentration, Variable):
+        if isinstance(concentration, torch.Tensor):
             return _Dirichlet.apply(concentration)
         return _dirichlet_sample_nograd(concentration)
 

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 import warnings
 from torch.distributions import constraints
 
@@ -146,7 +145,7 @@ class Distribution(object):
         of the result will be `(cardinality,) + batch_shape + event_shape`
         (where `event_shape = ()` for univariate distributions).
 
-        Note that this enumerates over all batched variables in lock-step
+        Note that this enumerates over all batched tensors in lock-step
         `[[0, 0], [1, 1], ...]`. To iterate over the full Cartesian product
         use `itertools.product(m.enumerate_support())`.
 

--- a/torch/distributions/exp_family.py
+++ b/torch/distributions/exp_family.py
@@ -27,7 +27,7 @@ class ExponentialFamily(Distribution):
     @property
     def _natural_params(self):
         """
-        Abstract method for natural parameters. Returns a tuple of Variables based
+        Abstract method for natural parameters. Returns a tuple of Tensors based
         on the distribution
         """
         raise NotImplementedError

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -1,7 +1,7 @@
 from numbers import Number
 
 import torch
-from torch.autograd import Function, Variable
+from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
@@ -53,8 +53,7 @@ class Gamma(ExponentialFamily):
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(shape)
-        data = value.data if isinstance(value, Variable) else value
-        data.clamp_(min=_finfo(value).tiny)  # do not record in autograd graph
+        value.data.clamp_(min=_finfo(value).tiny)  # do not record in autograd graph
         return value
 
     def log_prob(self, value):

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -26,7 +26,7 @@ from .poisson import Poisson
 from .transformed_distribution import TransformedDistribution
 from .uniform import Uniform
 from .utils import _sum_rightmost
-from torch.autograd import Variable, variable
+from torch.autograd import Variable
 
 _KL_REGISTRY = {}  # Source of truth mapping a few general (type, type) pairs to functions.
 _KL_MEMOIZE = {}  # Memoized version mapping many specific (type, type) pairs to functions.
@@ -114,10 +114,7 @@ def _infinite_like(tensor):
     """
     Helper function for obtaining infinite KL Divergence throughout
     """
-    if isinstance(tensor, Variable):
-        return tensor.new_tensor(float('inf')).expand_as(tensor)
-    else:
-        return tensor.new([float('inf')]).expand_as(tensor)
+    return tensor.new_tensor(float('inf')).expand_as(tensor)
 
 
 def _x_log_x(tensor):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -1,6 +1,5 @@
 import torch
 from torch.distributions.distribution import Distribution
-from torch.autograd import Variable
 from torch.distributions import Categorical
 from numbers import Number
 from torch.distributions import constraints

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.distribution import Distribution
@@ -85,6 +84,6 @@ class OneHotCategorical(Distribution):
     def enumerate_support(self):
         n = self.event_shape[0]
         values = self._new((n, n))
-        torch.eye(n, out=values.data if isinstance(values, Variable) else values)
+        torch.eye(n, out=values.data)
         values = values.view((n,) + (1,) * len(self.batch_shape) + (n,))
         return values.expand((n,) + self.batch_shape + (n,))

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -1,7 +1,6 @@
 from numbers import Number
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -1,6 +1,5 @@
 import torch
 from numbers import Number
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.transformed_distribution import TransformedDistribution

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.categorical import Categorical
 from torch.distributions.utils import clamp_probs, broadcast_all, log_sum_exp

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -3,7 +3,6 @@ import numbers
 import weakref
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.utils import (_sum_rightmost, broadcast_all,
                                        lazy_property)
@@ -64,7 +63,7 @@ class Transform(object):
             the codomain. Transforms that are not bijective should at least
             maintain the weaker pseudoinverse properties
             ``t(t.inv(t(x)) == t(x)`` and ``t.inv(t(t.inv(y))) == t.inv(y)``.
-        sign (int or Variable): For bijective univariate transforms, this
+        sign (int or Tensor): For bijective univariate transforms, this
             should be +1 or -1 depending on whether transform is monotone
             increasing or decreasing.
         event_dim (int): Number of dimensions that are correlated together in

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -2,7 +2,6 @@ import math
 from numbers import Number
 
 import torch
-from torch.autograd import Variable
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -4,7 +4,6 @@ from numbers import Number
 import math
 import torch
 import torch.nn.functional as F
-from torch.autograd import Variable
 
 # This follows semantics of numpy.finfo.
 _Finfo = namedtuple('_Finfo', ['eps', 'tiny'])
@@ -20,13 +19,13 @@ _FINFO = {
 
 def _finfo(tensor):
     r"""
-    Return floating point info about a `Tensor` or `Variable`:
+    Return floating point info about a `Tensor`:
     - `.eps` is the smallest number that can be added to 1 without being lost.
     - `.tiny` is the smallest positive number greater than zero
       (much smaller than `.eps`).
 
     Args:
-        tensor (Tensor): tensor or variable of floating point data.
+        tensor (Tensor): tensor of floating point data.
     Returns:
         _Finfo: a `namedtuple` with fields `.eps` and `.tiny`.
     """
@@ -61,20 +60,19 @@ def broadcast_all(*values):
     r"""
     Given a list of values (possibly containing numbers), returns a list where each
     value is broadcasted based on the following rules:
-      - `torch.Tensor` and `torch.autograd.Variable` instances are broadcasted as
-        per the `broadcasting rules
+      - `torch.Tensor` instances are broadcasted as per the `broadcasting rules
         <http://pytorch.org/docs/master/notes/broadcasting.html>`_
-      - numbers.Number instances (scalars) are upcast to Variables having
+      - numbers.Number instances (scalars) are upcast to Tensors having
         the same size and type as the first tensor passed to `values`.  If all the
-        values are scalars, then they are upcasted to Variables having size
+        values are scalars, then they are upcasted to Tensors having size
         `(1,)`.
 
     Args:
         values (list of `numbers.Number` or `torch.Tensor`)
 
     Raises:
-        ValueError: if any of the values is not a `numbers.Number`, `torch.Tensor`
-            or `torch.autograd.Variable` instance
+        ValueError: if any of the values is not a `numbers.Number` or
+            `torch.Tensor` instance
     """
     values = list(values)
     scalar_idxs = [i for i in range(len(values)) if isinstance(values[i], Number)]
@@ -86,9 +84,6 @@ def broadcast_all(*values):
         for idx in tensor_idxs:
             values[idx] = values[idx].expand(broadcast_shape)
         template = values[tensor_idxs[0]]
-        if len(scalar_idxs) > 0 and not isinstance(template, torch.autograd.Variable):
-            raise ValueError(('Input arguments containing instances of numbers.Number and torch.Tensor '
-                              'are not currently supported.  Use torch.autograd.Variable instead of torch.Tensor'))
         for idx in scalar_idxs:
             values[idx] = template.new(template.size()).fill_(values[idx])
     else:
@@ -112,11 +107,9 @@ def _sum_rightmost(value, dim):
 
 def softmax(tensor):
     r"""
-    Wrapper around softmax to make it work with both Tensors and Variables.
-    TODO: Remove once https://github.com/pytorch/pytorch/issues/2633 is resolved.
+    Returns the result with softmax applied to :attr:`tensor` along the last
+    dimension.
     """
-    if not isinstance(tensor, Variable):
-        return F.softmax(Variable(tensor), -1).data
     return F.softmax(tensor, -1)
 
 
@@ -126,7 +119,7 @@ def log_sum_exp(tensor, keepdim=True):
     summing is done along the last dimension.
 
     Args:
-        tensor (torch.Tensor or torch.autograd.Variable)
+        tensor (torch.Tensor)
         keepdim (Boolean): Whether to retain the last dimension on summing.
     """
     max_val = tensor.max(dim=-1, keepdim=True)[0]

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -38,7 +38,7 @@ def split(tensor, split_size_or_sections, dim=0):
     """
     # Overwriting reason:
     # This dispatches to two ATen functions depending on the type of
-    # split_size_or_sections. The branching code is in variable.py, which we
+    # split_size_or_sections. The branching code is in tensor.py, which we
     # call here.
     return tensor.split(split_size_or_sections, dim)
 
@@ -93,7 +93,7 @@ def btrifact(A, info=None, pivot=True):
     """
     # Overwriting reason:
     # `info` is being deprecated in favor of `btrifact_with_info`. This warning
-    # is in variable.py, which we call here.
+    # is in tensor.py, which we call here.
     return A.btrifact(info, pivot)
 
 
@@ -317,7 +317,7 @@ def isnan(tensor):
          0
         [torch.ByteTensor of size 3]
     """
-    if not torch.is_tensor(tensor):
+    if not isinstance(tensor, torch.Tensor):
         raise ValueError("The argument is not a tensor")
     return tensor != tensor
 
@@ -384,7 +384,7 @@ def unique(input, sorted=False, return_inverse=False):
          1  2
         [torch.LongTensor of size (2,2)]
     """
-    output, inverse_indices = torch._C._VariableFunctions._unique(
+    output, inverse_indices = torch._unique(
         input,
         sorted=sorted,
         return_inverse=return_inverse,

--- a/torch/legacy/nn/Bilinear.py
+++ b/torch/legacy/nn/Bilinear.py
@@ -7,7 +7,7 @@ from .utils import clear
 class Bilinear(Module):
 
     def _assertInput(self, input):
-        if len(input) != 2 or not torch.is_tensor(input[0]) or not torch.is_tensor(input[1]):
+        if len(input) != 2 or not isinstance(input[0], torch.Tensor) or not isinstance(input[1], torch.Tensor):
             raise RuntimeError('input should be a table containing two data Tensors')
         if input[0].ndimension() != 2 or input[1].ndimension() != 2:
             raise RuntimeError('input Tensors should be two-dimensional')

--- a/torch/legacy/nn/Index.py
+++ b/torch/legacy/nn/Index.py
@@ -19,7 +19,7 @@ class Index(Module):
         t = input[0]
         index = input[1]
 
-        gradInput = self.gradInput[0]  # no gradient for the index variable
+        gradInput = self.gradInput[0]  # no gradient for the index tensor
         gradInput.resize_as_(t).zero_()
         gradInput.index_add_(self.dimension, index, gradOutput)
         return self.gradInput

--- a/torch/legacy/nn/utils.py
+++ b/torch/legacy/nn/utils.py
@@ -23,7 +23,7 @@ def recursiveType(param, type, tensorCache={}):
             param[i] = recursiveType(p, type, tensorCache)
     elif isinstance(param, Module) or isinstance(param, Criterion):
         param.type(type, tensorCache)
-    elif torch.is_tensor(param):
+    elif isinstance(param, torch.Tensor):
         if param.type() != type:
             key = param._cdata
             if key in tensorCache:
@@ -56,8 +56,8 @@ def recursiveResizeAs(t1, t2):
         for i, _ in enumerate(t2):
             t1[i], t2[i] = recursiveResizeAs(t1[i], t2[i])
         t1 = t1[:len(t2)]
-    elif torch.is_tensor(t2):
-        t1 = t1 if torch.is_tensor(t1) else t2.new()
+    elif isinstance(t2, torch.Tensor):
+        t1 = t1 if isinstance(t1, torch.Tensor) else t2.new()
         t1.resize_as_(t2)
     else:
         raise RuntimeError("Expecting nested tensors or tables. Got " +
@@ -68,7 +68,7 @@ def recursiveResizeAs(t1, t2):
 def recursiveFill(t2, val):
     if isinstance(t2, list):
         t2 = [recursiveFill(x, val) for x in t2]
-    elif torch.is_tensor(t2):
+    elif isinstance(t2, torch.Tensor):
         t2.fill_(val)
     else:
         raise RuntimeError("expecting tensor or table thereof. Got " +
@@ -84,7 +84,7 @@ def recursiveAdd(t1, val=1, t2=None):
         t1 = t1 if isinstance(t1, list) else [t1]
         for i, _ in enumerate(t2):
             t1[i], t2[i] = recursiveAdd(t1[i], val, t2[i])
-    elif torch.is_tensor(t1) and torch.is_tensor(t2):
+    elif isinstance(t1, torch.Tensor) and isinstance(t2, torch.Tensor):
         t1.add_(val, t2)
     else:
         raise RuntimeError("expecting nested tensors or tables. Got " +
@@ -97,8 +97,8 @@ def recursiveCopy(t1, t2):
         t1 = t1 if isinstance(t1, list) else [t1]
         for i, _ in enumerate(t2):
             t1[i], t2[i] = recursiveCopy(t1[i], t2[i])
-    elif torch.is_tensor(t2):
-        t1 = t1 if torch.is_tensor(t1) else t2.new()
+    elif isinstance(t2, torch.Tensor):
+        t1 = t1 if isinstance(t1, torch.Tensor) else t2.new()
         t1.resize_as_(t2).copy_(t2)
     else:
         raise RuntimeError("expecting nested tensors or tables. Got " +
@@ -113,7 +113,7 @@ def addSingletondimension(*args):
         return t.unsqueeze(dim)
     else:
         view, t, dim = args
-        assert torch.is_tensor(view)
+        assert isinstance(view, torch.Tensor)
         view.set_(t)
         return view.unsqueeze_(dim)
 
@@ -142,7 +142,7 @@ def clear(self, *args):
         if not hasattr(self, f):
             return
         attr = getattr(self, f)
-        if torch.is_tensor(attr):
+        if isinstance(attr, torch.Tensor):
             attr.set_()
         elif isinstance(attr, list):
             del attr[:]

--- a/torch/nn/_functions/dropout.py
+++ b/torch/nn/_functions/dropout.py
@@ -1,6 +1,5 @@
 import torch
 from torch.autograd.function import InplaceFunction
-from torch.autograd import Variable
 from itertools import repeat
 
 

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -1,5 +1,5 @@
 import warnings
-from torch.autograd import NestedIOFunction, Variable
+from torch.autograd import NestedIOFunction
 import torch.backends.cudnn as cudnn
 from .. import functional as F
 from .thnn import rnnFusedPointwise as fusedBackend
@@ -279,7 +279,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
 
         output, hy, cy, reserve, new_weight_buf = torch._cudnn_rnn(
             input, weight_arr, weight_stride0,
-            Variable(flat_weight) if flat_weight is not None else None,
+            flat_weight,
             hx, cx,
             mode, hidden_size, num_layers,
             batch_first, dropout, train, bool(bidirectional),

--- a/torch/nn/_functions/thnn/auto.py
+++ b/torch/nn/_functions/thnn/auto.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 import torch
 from torch._thnn.utils import parse_header, THNN_H_PATH
-from torch.autograd import Variable
 from torch.autograd.function import Function, InplaceFunction, once_differentiable
 from torch._thnn import type2backend
 from .auto_double_backwards import double_backwards_fns
@@ -151,7 +150,7 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
         ctx.additional_args = []
         tensor_param_list = []
         for param in params:
-            if torch.is_tensor(param):
+            if isinstance(param, torch.Tensor):
                 if type(param) != type(input):
                     raise RuntimeError("input type ({}) doesn't match the type of "
                                        "a parameter tensor ({})".format(torch.typename(input),
@@ -179,7 +178,7 @@ def _make_function_class(class_name, update_output, update_grad_input, acc_grad_
         args += tuple(additional_args)
 
         # If the module is working in-place its output will be set to the
-        # same storage as input, but its variable won't be dirty.
+        # same storage as input, but its tensor won't be dirty.
         if is_inplace and ctx.inplace:
             ctx.mark_dirty(input)
             output = input

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -12,7 +12,6 @@ from .modules import utils
 from ._functions.padding import ConstantPadNd
 from ._functions import vision
 from ._functions.thnn.fold import Col2Im, Im2Col
-from torch.autograd import Variable
 from .modules.utils import _single, _pair, _triple
 from . import grad
 
@@ -644,7 +643,7 @@ def glu(input, dim=-1):
     See `Language Modeling with Gated Convolutional Networks <https://arxiv.org/abs/1612.08083>`_.
 
     Args:
-        input (Variable): input variable
+        input (Tensor): input tensor
         dim (int): dimension on which to split the input
     """
     if input.dim() == 0:
@@ -829,7 +828,7 @@ def softmin(input, dim=None, _stacklevel=3):
     See :class:`~torch.nn.Softmin` for more details.
 
     Arguments:
-        input (Variable): input
+        input (Tensor): input
         dim (int): A dimension along which softmin will be computed (so every slice
             along dim will sum to 1).
     """
@@ -851,7 +850,7 @@ def softmax(input, dim=None, _stacklevel=3):
     See :class:`~torch.nn.Softmax` for more details.
 
     Arguments:
-        input (Variable): input
+        input (Tensor): input
         dim (int): A dimension along which softmax will be computed.
 
     .. note::
@@ -914,16 +913,16 @@ def gumbel_softmax(logits, tau=1, hard=False, eps=1e-10):
     assert len(shape) == 2
     y_soft = _gumbel_softmax_sample(logits, tau=tau, eps=eps)
     if hard:
-        _, k = y_soft.data.max(-1)
+        _, k = y_soft.max(-1)
         # this bit is based on
         # https://discuss.pytorch.org/t/stop-gradients-for-st-gumbel-softmax/530/5
-        y_hard = logits.data.new(*shape).zero_().scatter_(-1, k.view(-1, 1), 1.0)
+        y_hard = logits.new_zeros(*shape).scatter_(-1, k.view(-1, 1), 1.0)
         # this cool bit of code achieves two things:
         # - makes the output value exactly one-hot (since we add then
         #   subtract y_soft value)
         # - makes the gradient equal to y_soft gradient (since we strip
         #   all other gradients)
-        y = Variable(y_hard - y_soft.data) + y_soft
+        y = y_hard - y_soft.detach() + y_soft
     else:
         y = y_soft
     return y
@@ -939,7 +938,7 @@ def log_softmax(input, dim=None, _stacklevel=3):
     See :class:`~torch.nn.LogSoftmax` for more details.
 
     Arguments:
-        input (Variable): input
+        input (Tensor): input
         dim (int): A dimension along which log_softmax will be computed.
     """
     if dim is None:
@@ -1001,7 +1000,7 @@ def linear(input, weight, bias=None):
 
 
 def bilinear(input1, input2, weight, bias=None):
-    return torch._C._VariableFunctions.bilinear(input1, input2, weight, bias)
+    return torch.bilinear(input1, input2, weight, bias)
 
 
 def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
@@ -1031,7 +1030,7 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2,
         - Output: `(N, W, embedding_dim)`
 
     Notes:
-        It is advised to only use `sparse=True` if `embedding_matrix` is a leaf Variable,
+        It is advised to only use `sparse=True` if `embedding_matrix` is a leaf Tensor,
         since some autograd functions may not propagate sparse gradients correctly.
         Additionally, keep in mind that only a limited number of optimizers support
         sparse gradients: currently it's :class:`optim.SGD` (`CUDA` and `CPU`), and :class:`optim.Adagrad` (`CPU`)
@@ -1093,10 +1092,11 @@ def embedding_bag(embedding_matrix, indices, offsets=None,
         intermediate embeddings.
 
         For bags of constant length,
-            * embedding_bag with `mode=sum` is equivalent to nn.functional.embedding followed by `torch.sum(dim=1)`
-            * with `mode=mean` is equivalent to nn.functional.embedding followed by `torch.mean(dim=1)`
+            * :func:`embedding_bag` with `mode=sum` is equivalent to :func:`nn.functional.embedding` followed by
+              ``torch.sum(dim=1)``
+            * with `mode=mean` is equivalent to :func:`nn.functional.embedding` followed by ``torch.mean(dim=1)``
 
-        However, embedding_bag is much more time and memory efficient than using a chain of these
+        However, :func:`embedding_bag` is much more time and memory efficient than using a chain of these
         operations.
 
         Args:
@@ -1149,8 +1149,9 @@ def embedding_bag(embedding_matrix, indices, offsets=None,
                              " fixed length sequences. However, found "
                              "offsets of type {}".format(type(offsets)))
         else:
-            offsets = Variable(torch.arange(0, indices.numel(), indices.size(1),
-                                            out=indices.data.new().long()))
+            offsets = torch.arange(0, indices.numel(), indices.size(1),
+                                   dtype=torch.long, device=indices.device)
+
             indices = indices.view(-1)
     elif indices.dim() == 1:
         if offsets is None:
@@ -1334,8 +1335,6 @@ def nll_loss(input, target, weight=None, size_average=True, ignore_index=-100, r
         >>> output.backward()
     """
     dim = input.dim()
-    if torch.is_tensor(weight):
-        weight = weight
     if dim < 2:
         raise ValueError('Expected 2 or more dimensions (got {})'.format(dim))
 
@@ -1407,8 +1406,8 @@ The `Kullback-Leibler divergence`_ Loss.
 See :class:`~torch.nn.KLDivLoss` for details.
 
 Args:
-    input: Variable of arbitrary shape
-    target: Variable of the same shape as input
+    input: Tensor of arbitrary shape
+    target: Tensor of the same shape as input
     size_average: if ``True`` the output is divided by the number of elements
         in input tensor. Default: ``True``
     reduce (bool, optional): By default, the losses are averaged
@@ -1426,10 +1425,10 @@ def cross_entropy(input, target, weight=None, size_average=True, ignore_index=-1
     See :class:`~torch.nn.CrossEntropyLoss` for details.
 
     Args:
-        input: :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
+        input (Tensor) : :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
             in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K > 1`
             in the case of K-dimensional loss.
-        target: :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
+        target (Tensor) : :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
             or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
             K-dimensional loss.
         weight (Tensor, optional): a manual rescaling weight given to each
@@ -1463,9 +1462,9 @@ def binary_cross_entropy(input, target, weight=None, size_average=True, reduce=T
     See :class:`~torch.nn.BCELoss` for details.
 
     Args:
-        input: Variable of arbitrary shape
-        target: Variable of the same shape as input
-        weight (Variable, optional): a manual rescaling weight
+        input: Tensor of arbitrary shape
+        target: Tensor of the same shape as input
+        weight (Tensor, optional): a manual rescaling weight
                 if provided it's repeated to match input tensor shape
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
@@ -1493,8 +1492,6 @@ def binary_cross_entropy(input, target, weight=None, size_average=True, reduce=T
     if weight is not None:
         new_size = _infer_size(target.size(), weight.size())
         weight = weight.expand(new_size)
-        if torch.is_tensor(weight):
-            weight = weight
 
     return torch._C._nn.binary_cross_entropy(input, target, weight, size_average, reduce)
 
@@ -1506,9 +1503,9 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
     See :class:`~torch.nn.BCEWithLogitsLoss` for details.
 
     Args:
-        input: Variable of arbitrary shape
-        target: Variable of the same shape as input
-        weight (Variable, optional): a manual rescaling weight
+        input: Tensor of arbitrary shape
+        target: Tensor of the same shape as input
+        weight (Tensor, optional): a manual rescaling weight
                 if provided it's repeated to match input tensor shape
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
@@ -1593,7 +1590,7 @@ def margin_ranking_loss(input1, input2, target, margin=0, size_average=True, red
     if input1.dim() == 0 or input2.dim() == 0 or target.dim() == 0:
         raise RuntimeError(("margin_ranking_loss does not support scalars, got sizes: "
                             "input1: {}, input2: {}, target: {} ".format(input1.size(), input2.size(), target.size())))
-    return torch._C._VariableFunctions.margin_ranking_loss(input1, input2, target, margin, size_average, reduce)
+    return torch.margin_ranking_loss(input1, input2, target, margin, size_average, reduce)
 
 
 def hinge_embedding_loss(input, target, margin=1.0, size_average=True, reduce=True):
@@ -1631,7 +1628,7 @@ def cosine_embedding_loss(input1, input2, target, margin=0, size_average=True, r
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
     """
-    return torch._C._VariableFunctions.cosine_embedding_loss(input1, input2, target, margin, size_average, reduce)
+    return torch.cosine_embedding_loss(input1, input2, target, margin, size_average, reduce)
 
 
 def multi_margin_loss(input, target, p=1, margin=1, weight=None, size_average=True, reduce=True):
@@ -1654,7 +1651,7 @@ def pixel_shuffle(input, upscale_factor):
     See :class:`~torch.nn.PixelShuffle` for details.
 
     Args:
-        input (Variable): Input
+        input (Tensor): Input
         upscale_factor (int): factor to increase spatial resolution by
 
     Examples::
@@ -1799,13 +1796,14 @@ def upsample_nearest(input, size=None, scale_factor=None):
     r"""Upsamples the input, using nearest neighbours' pixel values.
 
     .. warning::
-        This function is deprecated in favor of :meth:`torch.nn.functional.upsample`.
+        This function is deprecated in favor of :func:`torch.nn.functional.upsample`.
+        This is equivalent with ``nn.functional.upsample(..., mode='nearest')``.
 
     Currently spatial and volumetric upsampling are supported (i.e. expected
     inputs are 4 or 5 dimensional).
 
     Args:
-        input (Variable): input
+        input (Tensor): input
         size (int or Tuple[int, int] or Tuple[int, int, int]): output spatia
             size.
         scale_factor (int): multiplier for spatial size. Has to be an integer.
@@ -1819,7 +1817,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     r"""Upsamples the input, using bilinear upsampling.
 
     .. warning::
-        This function is deprecated in favor of :meth:`torch.nn.functional.upsample`.
+        This function is deprecated in favor of :func:`torch.nn.functional.upsample`.
         This is equivalent with
         ``nn.functional.upsample(..., mode='bilinear', align_corners=True)``.
 
@@ -1827,7 +1825,7 @@ def upsample_bilinear(input, size=None, scale_factor=None):
     volumetric (5 dimensional) inputs.
 
     Args:
-        input (Variable): input
+        input (Tensor): input
         size (int or Tuple[int, int]): output spatial size.
         scale_factor (int or Tuple[int, int]): multiplier for spatial size
     """
@@ -1866,13 +1864,13 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros'):
     .. Note:: This function is used in building Spatial Transformer Networks
 
     Args:
-        input (Variable): input batch (N x C x IH x IW) or (N x C x ID x IH x IW)
-        grid (Variable): flow-field of size (N x OH x OW x 2) or (N x OD x OH x OW x 3)
+        input (Tensor): input batch (N x C x IH x IW) or (N x C x ID x IH x IW)
+        grid (Tensor): flow-field of size (N x OH x OW x 2) or (N x OD x OH x OW x 3)
         padding_mode (str): padding mode for outside grid values
             'zeros' | 'border'. Default: 'zeros'
 
     Returns:
-        output (Variable): output Tensor
+        output (Tensor): output Tensor
 
     """
     return vision.grid_sampler(input, grid, padding_mode)
@@ -1884,12 +1882,12 @@ def affine_grid(theta, size):
     implement Spatial Transformer Networks.
 
     Args:
-        theta (Variable): input batch of affine matrices (:math:`N \times 2 \times 3`)
+        theta (Tensor): input batch of affine matrices (:math:`N \times 2 \times 3`)
         size (torch.Size): the target output image size (:math:`N \times C \times H \times W`)
                            Example: torch.Size((32, 3, 24, 24))
 
     Returns:
-        output (Variable): output Tensor of size (:math:`N \times H \times W \times 2`)
+        output (Tensor): output Tensor of size (:math:`N \times H \times W \times 2`)
     """
     return vision.affine_grid_generator(theta, size)
 
@@ -1915,7 +1913,7 @@ def pad(input, pad, mode='constant', value=0):
     padding modes works.
 
     Args:
-        input (Variable): `Nd` tensor
+        input (Tensor): `Nd` tensor
         pad (tuple): m-elem tuple, where :math:`\frac{m}{2} \leq` input dimensions and :math:`m` is even.
         mode: 'constant', 'reflect' or 'replicate'. Default: 'constant'
         value: fill value for 'constant' padding. Default: 0
@@ -1972,7 +1970,7 @@ def pairwise_distance(x1, x2, p=2, eps=1e-6, keepdim=False):
     r"""
     See :class:`torch.nn.PairwiseDistance` for details
     """
-    return torch._C._VariableFunctions.pairwise_distance(x1, x2, p, eps, keepdim)
+    return torch.pairwise_distance(x1, x2, p, eps, keepdim)
 
 
 def cosine_similarity(x1, x2, dim=1, eps=1e-8):
@@ -1982,8 +1980,8 @@ def cosine_similarity(x1, x2, dim=1, eps=1e-8):
         \text{similarity} = \dfrac{x_1 \cdot x_2}{\max(\Vert x_1 \Vert _2 \cdot \Vert x_2 \Vert _2, \epsilon)}
 
     Args:
-        x1 (Variable): First input.
-        x2 (Variable): Second input (of size matching x1).
+        x1 (Tensor): First input.
+        x2 (Tensor): Second input (of size matching x1).
         dim (int, optional): Dimension of vectors. Default: 1
         eps (float, optional): Small value to avoid division by zero.
             Default: 1e-8
@@ -2010,8 +2008,8 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6, s
     r"""
     See :class:`~torch.nn.TripletMarginLoss` for details
     """
-    return torch._C._VariableFunctions.triplet_margin_loss(anchor, positive, negative, margin, p, eps, swap,
-                                                           size_average, reduce)
+    return torch.triplet_margin_loss(anchor, positive, negative, margin, p, eps,
+                                     swap, size_average, reduce)
 
 
 def normalize(input, p=2, dim=1, eps=1e-12):

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -68,7 +68,7 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
                                              padding, kernel_size)
 
-    return torch._C._VariableFunctions.conv_transpose1d(
+    return torch.conv_transpose1d(
         grad_output, weight, bias, stride, padding, grad_input_padding, groups,
         dilation)
 
@@ -111,9 +111,8 @@ def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
     input = input.contiguous().view(1, input.shape[0] * input.shape[1],
                                     input.shape[2])
 
-    grad_weight = torch._C._VariableFunctions.conv1d(input, grad_output, bias,
-                                                     dilation, padding, stride,
-                                                     in_channels * min_batch)
+    grad_weight = torch.conv1d(input, grad_output, bias, dilation, padding,
+                               stride, in_channels * min_batch)
 
     grad_weight = grad_weight.contiguous().view(
         min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2])
@@ -160,7 +159,7 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
                                              padding, kernel_size)
 
-    return torch._C._VariableFunctions.conv_transpose2d(
+    return torch.conv_transpose2d(
         grad_output, weight, bias, stride, padding, grad_input_padding, groups,
         dilation)
 
@@ -205,9 +204,8 @@ def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
     input = input.contiguous().view(1, input.shape[0] * input.shape[1],
                                     input.shape[2], input.shape[3])
 
-    grad_weight = torch._C._VariableFunctions.conv2d(input, grad_output, bias,
-                                                     dilation, padding, stride,
-                                                     in_channels * min_batch)
+    grad_weight = torch.conv2d(input, grad_output, bias, dilation, padding,
+                               stride, in_channels * min_batch)
 
     grad_weight = grad_weight.contiguous().view(
         min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],
@@ -256,7 +254,7 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
                                              padding, kernel_size)
 
-    return torch._C._VariableFunctions.conv_transpose3d(
+    return torch.conv_transpose3d(
         grad_output, weight, bias, stride, padding, grad_input_padding, groups,
         dilation)
 
@@ -301,9 +299,8 @@ def conv3d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
                                     input.shape[2], input.shape[3],
                                     input.shape[4])
 
-    grad_weight = torch._C._VariableFunctions.conv3d(input, grad_output, bias,
-                                                     dilation, padding, stride,
-                                                     in_channels * min_batch)
+    grad_weight = torch.conv3d(input, grad_output, bias, dilation, padding,
+                               stride, in_channels * min_batch)
 
     grad_weight = grad_weight.contiguous().view(
         min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1,6 +1,5 @@
 import warnings
 
-from torch.autograd import Variable
 import torch
 from .module import Module
 from .container import Sequential
@@ -8,10 +7,10 @@ from .activation import LogSoftmax
 from .. import functional as F
 
 
-def _assert_no_grad(variable):
-    assert not variable.requires_grad, \
+def _assert_no_grad(tensor):
+    assert not tensor.requires_grad, \
         "nn criterions don't compute the gradient w.r.t. targets - please " \
-        "mark these variables as not requiring gradients"
+        "mark these tensors as not requiring gradients"
 
 
 class _Loss(Module):
@@ -336,8 +335,7 @@ class MSELoss(_Loss):
 
     The sum operation still operates over all the elements, and divides by `n`.
 
-    The division by `n` can be avoided if one sets the internal variable
-    `size_average` to ``False``.
+    The division by `n` can be avoided if one sets :attr:`size_average` to ``False``.
 
     To get a batch of losses, a loss per batch element, set `reduce` to
     ``False``. These losses are not averaged and are not affected by
@@ -492,9 +490,8 @@ class BCEWithLogitsLoss(_Loss):
 
     def forward(self, input, target):
         if self.weight is not None:
-            var = Variable(self.weight) if not isinstance(self.weight, Variable) else self.weight
             return F.binary_cross_entropy_with_logits(input, target,
-                                                      var,
+                                                      self.weight,
                                                       self.size_average,
                                                       reduce=self.reduce)
         else:
@@ -620,8 +617,7 @@ class SmoothL1Loss(_Loss):
     `x` and `y` arbitrary shapes with a total of `n` elements each
     the sum operation still operates over all the elements, and divides by `n`.
 
-    The division by `n` can be avoided if one sets the internal variable
-    `size_average` to ``False``
+    The division by `n` can be avoided if one sets :attr:`size_average` to ``False``
 
     Args:
         size_average (bool, optional): By default, the losses are averaged
@@ -936,7 +932,7 @@ class TripletMarginLoss(_Loss):
     tensors x1, x2, x3 and a margin with a value greater than 0.
     This is used for measuring a relative similarity between samples. A triplet
     is composed by `a`, `p` and `n`: anchor, positive examples and negative
-    example respectively. The shape of all input variables should be
+    example respectively. The shapes of all input tensors should be
     :math:`(N, D)`.
 
     The distance swap is described in detail in the paper `Learning shallow

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 
 from .module import Module
 from .utils import _single, _pair, _triple
@@ -334,10 +333,10 @@ class MaxUnpool2d(_MaxUnpoolNd):
 
         >>> pool = nn.MaxPool2d(2, stride=2, return_indices=True)
         >>> unpool = nn.MaxUnpool2d(2, stride=2)
-        >>> input = Variable(torch.Tensor([[[[ 1,  2,  3,  4],
-                                             [ 5,  6,  7,  8],
-                                             [ 9, 10, 11, 12],
-                                             [13, 14, 15, 16]]]]))
+        >>> input = torch.Tensor([[[[ 1,  2,  3,  4],
+                                    [ 5,  6,  7,  8],
+                                    [ 9, 10, 11, 12],
+                                    [13, 14, 15, 16]]]])
         >>> output, indices = pool(input)
         >>> unpool(output, indices)
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -161,10 +161,9 @@ class RNNBase(Module):
 
         if hx is None:
             num_directions = 2 if self.bidirectional else 1
-            hx = torch.autograd.Variable(input.data.new(self.num_layers *
-                                                        num_directions,
-                                                        max_batch_size,
-                                                        self.hidden_size).zero_(), requires_grad=False)
+            hx = input.new_zeros(self.num_layers * num_directions,
+                                 max_batch_size, self.hidden_size,
+                                 requires_grad=False)
             if self.mode == 'LSTM':
                 hx = (hx, hx)
 

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 from torch.nn.parameter import Parameter
 
 from .module import Module

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -45,7 +45,7 @@ class DataParallel(Module):
     See also: :ref:`cuda-nn-dataparallel-instead`
 
     Arbitrary positional and keyword inputs are allowed to be passed into
-    DataParallel EXCEPT Tensors. All variables will be scattered on dim
+    DataParallel EXCEPT Tensors. All tensors will be scattered on dim
     specified (default 0). Primitive types will be broadcasted, but all
     other types will be a shallow copy and can be corrupted if written to in
     the model's forward pass.
@@ -139,7 +139,7 @@ def data_parallel(module, inputs, device_ids=None, output_device=None, dim=0, mo
         output_device: GPU location of the output  Use -1 to indicate the CPU.
             (default: device_ids[0])
     Returns:
-        a Variable containing the result of module(input) located on
+        a Tensor containing the result of module(input) located on
         output_device
     """
     if not isinstance(inputs, tuple):

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -1,21 +1,18 @@
 import threading
 import torch
-from torch.autograd import Variable
 
 
 def get_a_var(obj):
-    if isinstance(obj, Variable):
+    if isinstance(obj, torch.Tensor):
         return obj
 
     if isinstance(obj, list) or isinstance(obj, tuple):
-        results = map(get_a_var, obj)
-        for result in results:
-            if isinstance(result, Variable):
+        for result in map(get_a_var, obj):
+            if isinstance(result, torch.Tensor):
                 return result
     if isinstance(obj, dict):
-        results = map(get_a_var, obj.items())
-        for result in results:
-            if isinstance(result, Variable):
+        for result in map(get_a_var, obj.items()):
+            if isinstance(result, torch.Tensor):
                 return result
     return None
 

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -1,19 +1,17 @@
 import torch
-from torch.autograd import Variable
 from ._functions import Scatter, Gather
 
 
 def scatter(inputs, target_gpus, dim=0):
     r"""
-    Slices variables into approximately equal chunks and
+    Slices tensors into approximately equal chunks and
     distributes them across given GPUs. Duplicates
-    references to objects that are not variables. Does not
+    references to objects that are not tensors. Does not
     support Tensors.
     """
     def scatter_map(obj):
-        if isinstance(obj, Variable):
+        if isinstance(obj, torch.Tensor):
             return Scatter.apply(target_gpus, None, dim, obj)
-        assert not torch.is_tensor(obj), "Tensors not supported in scatter."
         if isinstance(obj, tuple) and len(obj) > 0:
             return list(zip(*map(scatter_map, obj)))
         if isinstance(obj, list) and len(obj) > 0:
@@ -48,12 +46,12 @@ def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
 
 def gather(outputs, target_device, dim=0):
     r"""
-    Gathers variables from different GPUs on a specified device
+    Gathers tensors from different GPUs on a specified device
       (-1 means the CPU).
     """
     def gather_map(outputs):
         out = outputs[0]
-        if isinstance(out, Variable):
+        if isinstance(out, torch.Tensor):
             return Gather.apply(target_device, dim, *outputs)
         if out is None:
             return None

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -24,4 +24,4 @@ class Parameter(torch.Tensor):
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 
     def __repr__(self):
-        return super(Parameter, self).__repr__().replace('Variable', 'Parameter')
+        return 'Parameter containing:\n' + super(Parameter, self).__repr__()

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -1,12 +1,11 @@
 import torch
-from torch.autograd import Variable
 
 
 def parameters_to_vector(parameters):
     r"""Convert parameters to one vector
 
     Arguments:
-        parameters (Iterable[Variable]): an iterator of Variables that are the
+        parameters (Iterable[Tensor]): an iterator of Tensors that are the
             parameters of a model.
 
     Returns:
@@ -28,13 +27,13 @@ def vector_to_parameters(vec, parameters):
     r"""Convert one vector to the parameters
 
     Arguments:
-        vec (Variable): a single vector represents the parameters of a model.
-        parameters (Iterable[Variable]): an iterator of Variables that are the
+        vec (Tensor): a single vector represents the parameters of a model.
+        parameters (Iterable[Tensor]): an iterator of Tensors that are the
             parameters of a model.
     """
-    # Ensure vec of type Variable
-    if not isinstance(vec, Variable):
-        raise TypeError('expected torch.autograd.Variable, but got: {}'
+    # Ensure vec of type Tensor
+    if not isinstance(vec, torch.Tensor):
+        raise TypeError('expected torch.Tensor, but got: {}'
                         .format(torch.typename(vec)))
     # Flag for the device where the parameter is located
     param_device = None
@@ -61,7 +60,7 @@ def _check_param_device(param, old_param_device):
     e.g. parameters in different GPUs, or mixture of CPU/GPU.
 
     Arguments:
-        param ([Variable]): a Variable of a parameter of a model
+        param ([Tensor]): a Tensor of a parameter of a model
         old_param_device (int): the device where the first parameter of a
                                 model is allocated.
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 import torch
-from torch.autograd import Variable
 import torch.onnx
 
 
@@ -26,8 +25,8 @@ class PackedSequence(PackedSequence_):
         ``batch_sizes=[2,1,1]``.
 
     Attributes:
-        data (Variable): Variable containing packed sequence
-        batch_sizes (Variable): Variable of integers holding
+        data (Tensor): Tensor containing packed sequence
+        batch_sizes (Tensor): Tensor of integers holding
             information about the batch size at each sequence step
 
     """
@@ -93,7 +92,7 @@ class PackedSequence(PackedSequence_):
 
 
 def pack_padded_sequence(input, lengths, batch_first=False):
-    r"""Packs a Variable containing padded sequences of variable length.
+    r"""Packs a Tensor containing padded sequences of variable length.
 
     Input can be of size ``T x B x *`` where `T` is the length of the longest sequence
     (equal to ``lengths[0]``), `B` is the batch size, and `*` is any number of
@@ -107,12 +106,12 @@ def pack_padded_sequence(input, lengths, batch_first=False):
     Note:
         This function accepts any input that has at least two dimensions. You
         can apply it to pack the labels, and use the output of the RNN with
-        them to compute the loss directly. A Variable can be retrieved from
+        them to compute the loss directly. A Tensor can be retrieved from
         a :class:`PackedSequence` object by accessing its ``.data`` attribute.
 
     Arguments:
-        input (Variable): padded batch of variable length sequences.
-        lengths (Variable): list of sequences lengths of each batch element.
+        input (Tensor): padded batch of variable length sequences.
+        lengths (Tensor): list of sequences lengths of each batch element.
         batch_first (bool, optional): if ``True``, the input is expected in ``B x T x *``
             format.
 
@@ -120,7 +119,7 @@ def pack_padded_sequence(input, lengths, batch_first=False):
         a :class:`PackedSequence` object
     """
     if isinstance(lengths, list):
-        lengths = Variable(torch.LongTensor(lengths))
+        lengths = torch.LongTensor(lengths)
 
     data, batch_sizes = PackPadded.apply(input, lengths, batch_first)
 
@@ -157,7 +156,7 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
 
     It is an inverse operation to :func:`pack_padded_sequence`.
 
-    The returned Variable's data will be of size ``T x B x *``, where `T` is the length
+    The returned Tensor's data will be of size ``T x B x *``, where `T` is the length
     of the longest sequence and `B` is the batch size. If ``batch_first`` is True,
     the data will be transposed into ``B x T x *`` format.
 
@@ -181,7 +180,7 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
             :attr:`sequence`.
 
     Returns:
-        Tuple of Variable containing the padded sequence, and Variable
+        Tuple of Tensor containing the padded sequence, and a Tensor
         containing the list of lengths of each sequence in the batch.
 
     """
@@ -196,7 +195,6 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
                              .format(total_length, max_seq_length))
         max_seq_length = total_length
     output = var_data.data.new(max_seq_length, max_batch_size, *var_data.size()[1:]).fill_(padding_value)
-    output = Variable(output)
 
     lengths = []
     data_offset = 0
@@ -218,11 +216,11 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
 
     if batch_first:
         output = output.transpose(0, 1)
-    # This Variable doesn't actually have any history (well,
+    # This Tensor doesn't actually have any history (well,
     # technically it does; it's just untracked), it is purely here to
     # make ONNX export easier. That is to say, from an autodiff
     # standpoint this doesn't make any sense.
-    return output, Variable(torch.LongTensor(lengths))
+    return output, torch.LongTensor(lengths)
 
 
 def _symbolic_pad_packed_sequence(g, input, batch_first=False, padding_value=0.0):
@@ -247,9 +245,9 @@ pad_packed_sequence = torch.onnx.symbolic_override_packed_sequence_based(
 
 
 def pad_sequence(sequences, batch_first=False, padding_value=0):
-    r"""Pad a list of variable length Variables with zero
+    r"""Pad a list of variable length Tensors with zero
 
-    ``pad_sequence`` stacks a list of Variables along a new dimension,
+    ``pad_sequence`` stacks a list of Tensors along a new dimension,
     and padds them to equal length. For example, if the input is list of
     sequences with size ``L x *`` and if batch_first is False, and ``T x B x *``
     otherwise. The list of sequences should be sorted in the order of
@@ -262,30 +260,30 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
 
     Example:
         >>> from torch.nn.utils.rnn import pad_sequence
-        >>> a = Variable(torch.ones(25, 300))
-        >>> b = Variable(torch.ones(22, 300))
-        >>> c = Variable(torch.ones(15, 300))
+        >>> a = torch.ones(25, 300)
+        >>> b = torch.ones(22, 300)
+        >>> c = torch.ones(15, 300)
         >>> pad_sequence([a, b, c]).size()
         torch.Size([25, 3, 300])
 
     Note:
-        This function returns a Variable of size ``T x B x *`` or ``B x T x *`` where `T` is the
+        This function returns a Tensor of size ``T x B x *`` or ``B x T x *`` where `T` is the
             length of longest sequence.
-        Function assumes trailing dimensions and type of all the Variables
+        Function assumes trailing dimensions and type of all the Tensors
             in sequences are same.
 
     Arguments:
-        sequences (list[Variable]): list of variable length sequences.
+        sequences (list[Tensor]): list of variable length sequences.
         batch_first (bool, optional): output will be in ``B x T x *`` if True, or in
             ``T x B x *`` otherwise
         padding_value (float, optional): value for padded elements.
 
     Returns:
-        Variable of size ``T x B x *`` if batch_first is False
-        Variable of size ``B x T x *`` otherwise
+        Tensor of size ``T x B x *`` if batch_first is False
+        Tensor of size ``B x T x *`` otherwise
     """
 
-    # assuming trailing dimensions and type of all the Variables
+    # assuming trailing dimensions and type of all the Tensors
     # in sequences are same and fetching those from sequences[0]
     max_size = sequences[0].size()
     max_len, trailing_dims = max_size[0], max_size[1:]
@@ -295,34 +293,34 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
     else:
         out_dims = (max_len, len(sequences)) + trailing_dims
 
-    out_variable = Variable(sequences[0].data.new(*out_dims).fill_(padding_value))
-    for i, variable in enumerate(sequences):
-        length = variable.size(0)
+    out_tensor = sequences[0].data.new(*out_dims).fill_(padding_value)
+    for i, tensor in enumerate(sequences):
+        length = tensor.size(0)
         # temporary sort check, can be removed when we handle sorting internally
         if prev_l < length:
             raise ValueError("lengths array has to be sorted in decreasing order")
         prev_l = length
-        # use index notation to prevent duplicate references to the variable
+        # use index notation to prevent duplicate references to the tensor
         if batch_first:
-            out_variable[i, :length, ...] = variable
+            out_tensor[i, :length, ...] = tensor
         else:
-            out_variable[:length, i, ...] = variable
+            out_tensor[:length, i, ...] = tensor
 
-    return out_variable
+    return out_tensor
 
 
 def pack_sequence(sequences):
-    r"""Packs a list of variable length Variables
+    r"""Packs a list of variable length Tensors
 
-    ``sequences`` should be a list of Variables of size ``L x *``, where `L` is
+    ``sequences`` should be a list of Tensors of size ``L x *``, where `L` is
     the length of a sequence and `*` is any number of trailing dimensions,
     including zero. They should be sorted in the order of decreasing length.
 
     Example:
         >>> from torch.nn.utils.rnn import pack_sequence
-        >>> a = Variable(torch.Tensor([1,2,3]))
-        >>> b = Variable(torch.Tensor([4,5]))
-        >>> c = Variable(torch.Tensor([6]))
+        >>> a = torch.Tensor([1,2,3])
+        >>> b = torch.Tensor([4,5])
+        >>> c = torch.Tensor([6])
         >>> pack_sequence([a, b, c]])
         PackedSequence(data=
          1
@@ -336,7 +334,7 @@ def pack_sequence(sequences):
 
 
     Arguments:
-        sequences (list[Variable]): A list of sequences of decreasing length.
+        sequences (list[Tensor]): A list of sequences of decreasing length.
 
     Returns:
         a :class:`PackedSequence` object

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Weight Normalization from https://arxiv.org/abs/1602.07868
 """
 from torch.nn.parameter import Parameter

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -46,20 +46,20 @@ def _symbolic_override_wrapper_maker(symbolic_fn, might_trace, fn):
     def wrapper(*args, **kwargs):
         import torch
         import torch.jit
-        from torch.autograd import Function, function, Variable
+        from torch.autograd import Function, function
 
         # fast pass
         if not might_trace(args):
             return fn(*args, **kwargs)
 
-        flat_args = tuple(function._iter_variables_permissive(args))
-        flat_args_only_variables = tuple(x for x in flat_args if isinstance(x, Variable))
-        if not any(map(torch._C._jit_is_tracing, flat_args_only_variables)):
+        flat_args = tuple(function._iter_tensors_permissive(args))
+        flat_args_only_tensors = tuple(function._iter_tensors(flat_args))
+        if not any(map(torch._C._jit_is_tracing, flat_args_only_tensors)):
             return fn(*args, **kwargs)
 
-        tstate = torch._C._get_tracing_state(flat_args_only_variables)
+        tstate = torch._C._get_tracing_state(flat_args_only_tensors)
 
-        arg_values = [torch._C._get_value_trace(tstate, x) if isinstance(x, Variable) else x for x in flat_args]
+        arg_values = [torch._C._get_value_trace(tstate, x) if isinstance(x, torch.Tensor) else x for x in flat_args]
 
         # This must come after the calls to get_value_trace, lest we
         # lose information due to in-place operations.
@@ -69,7 +69,7 @@ def _symbolic_override_wrapper_maker(symbolic_fn, might_trace, fn):
         output_vals = symbolic_fn(tstate.graph(), *symbolic_args, **kwargs)
 
         for var, val in zip(
-                function._iter_variables(output_vars),
+                function._iter_tensors(output_vars),
                 function._iter_jit_values(output_vals)):
             val.inferTypeFrom(var.data)
             torch._C._set_value_trace(tstate, var, val)
@@ -91,10 +91,9 @@ def symbolic_override(symbolic_fn):
     python function or autograd.Function. Requirements for the decorated
     function:
      - being non-member function or autograd.Function
-     - positional inputs are Variables/Tensors or (nested) lists or tuples of
+     - positional inputs are Tensors or (nested) lists or tuples of
        them (similar requirement to NestedIOFunction)
-     - outputs are similarly Variables/Tensors or (nested) lists or tuples of
-       them
+     - outputs are similarly Tensors or (nested) lists or tuples of them
      - non-tensor typed values should be keyword arguments both in definition
        and when called
 
@@ -119,13 +118,13 @@ def symbolic_override_first_arg_based(symbolic_fn):
 
     Equivalent to :func:`symbolic_override` but checks only the first argument
     of the function to figure out whether the tracing is on. Thus the first arg
-    needs to be a Variable.
+    needs to be a Tensor.
     """
 
     def might_trace(args):
         import torch
         first_arg = args[0]
-        if not torch.is_tensor(first_arg):
+        if not isinstance(first_arg, torch.Tensor):
             raise ValueError('First argument of {} is expected to be a tensor, '
                              'but got an object of type {}'
                              .format(symbolic_fn.__name__, type(first_arg)))
@@ -140,7 +139,7 @@ def symbolic_override_packed_sequence_based(symbolic_fn):
 
     Equivalent to :func:`symbolic_override` but checks only the first argument
     of the function to figure out whether the tracing is on. Thus the first arg
-    needs to be a Variable.
+    needs to be a Tensor.
     """
 
     def might_trace(args):

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -53,7 +53,7 @@ def _symbolic_override_wrapper_maker(symbolic_fn, might_trace, fn):
             return fn(*args, **kwargs)
 
         flat_args = tuple(function._iter_tensors_permissive(args))
-        flat_args_only_tensors = tuple(function._iter_tensors(flat_args))
+        flat_args_only_tensors = tuple(t for t in flat_args if isinstance(t, torch.Tensor))
         if not any(map(torch._C._jit_is_tracing, flat_args_only_tensors)):
             return fn(*args, **kwargs)
 

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -111,7 +111,7 @@ class LBFGS(Optimizer):
         if abs_grad_sum <= tolerance_grad:
             return loss
 
-        # variables cached in state (for tracing)
+        # tensors cached in state (for tracing)
         d = state.get('d')
         t = state.get('t')
         old_dirs = state.get('old_dirs')

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -9,8 +9,8 @@ __all__ = [
     'assert_allclose', 'make_non_contiguous', 'rand_like', 'randn_like'
 ]
 
-rand_like = torch._C._VariableFunctions.rand_like
-randn_like = torch._C._VariableFunctions.randn_like
+rand_like = torch.rand_like
+randn_like = torch.randn_like
 
 
 def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -104,7 +104,7 @@ def default_collate(batch):
 
     error_msg = "batch must contain tensors, numbers, dicts or lists; found {}"
     elem_type = type(batch[0])
-    if torch.is_tensor(batch[0]):
+    if isinstance(batch[0], torch.Tensor):
         out = None
         if _use_shared_memory:
             # If we're in a background process, concatenate directly into a
@@ -141,7 +141,7 @@ def default_collate(batch):
 
 
 def pin_memory_batch(batch):
-    if torch.is_tensor(batch):
+    if isinstance(batch, torch.Tensor):
         return batch.pin_memory()
     elif isinstance(batch, string_classes):
         return batch

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -3,7 +3,7 @@ from torch._six import int_classes as _int_classes
 
 
 class Sampler(object):
-    """Base class for all Samplers.
+    r"""Base class for all Samplers.
 
     Every Sampler subclass has to provide an __iter__ method, providing a way
     to iterate over indices of dataset elements, and a __len__ method that
@@ -21,7 +21,7 @@ class Sampler(object):
 
 
 class SequentialSampler(Sampler):
-    """Samples elements sequentially, always in the same order.
+    r"""Samples elements sequentially, always in the same order.
 
     Arguments:
         data_source (Dataset): dataset to sample from
@@ -38,7 +38,7 @@ class SequentialSampler(Sampler):
 
 
 class RandomSampler(Sampler):
-    """Samples elements randomly, without replacement.
+    r"""Samples elements randomly, without replacement.
 
     Arguments:
         data_source (Dataset): dataset to sample from
@@ -55,7 +55,7 @@ class RandomSampler(Sampler):
 
 
 class SubsetRandomSampler(Sampler):
-    """Samples elements randomly from a given list of indices, without replacement.
+    r"""Samples elements randomly from a given list of indices, without replacement.
 
     Arguments:
         indices (list): a list of indices
@@ -72,7 +72,7 @@ class SubsetRandomSampler(Sampler):
 
 
 class WeightedRandomSampler(Sampler):
-    """Samples elements from [0,..,len(weights)-1] with given probabilities (weights).
+    r"""Samples elements from [0,..,len(weights)-1] with given probabilities (weights).
 
     Arguments:
         weights (list)   : a list of weights, not necessary summing up to one
@@ -102,7 +102,7 @@ class WeightedRandomSampler(Sampler):
 
 
 class BatchSampler(object):
-    """Wraps another sampler to yield a mini-batch of indices.
+    r"""Wraps another sampler to yield a mini-batch of indices.
 
     Args:
         sampler (Sampler): Base sampler.

--- a/torch/utils/ffi/__init__.py
+++ b/torch/utils/ffi/__init__.py
@@ -6,7 +6,6 @@ from functools import wraps, reduce
 from string import Template
 import torch
 import torch.cuda
-from torch.autograd import Variable
 from torch._utils import _accumulate
 
 try:
@@ -191,7 +190,7 @@ def _wrap_function(function, ffi):
     @wraps(function)
     def safe_call(*args, **kwargs):
         args = tuple(ffi.cast(_torch_to_cffi.get(type(arg), 'void') + '*', arg._cdata)
-                     if torch.is_tensor(arg) or torch.is_storage(arg) or isinstance(arg, Variable)
+                     if isinstance(arg, torch.Tensor) or torch.is_storage(arg)
                      else arg
                      for arg in args)
         args = (function,) + args

--- a/torch/utils/serialization/read_lua_file.py
+++ b/torch/utils/serialization/read_lua_file.py
@@ -219,7 +219,7 @@ def _load_backend(obj):
     # Try to find tensor attributes and infer type from them
     for key in dir(obj):
         attr = getattr(obj, key)
-        if torch.is_tensor(attr):
+        if isinstance(attr, torch.Tensor):
             try:
                 obj._backend = type2backend[attr.type()]
             except KeyError:
@@ -229,7 +229,7 @@ def _load_backend(obj):
 
     def updateOutput_patch(*args):
         input = args[0]
-        while not torch.is_tensor(input):
+        while not isinstance(input, torch.Tensor):
             input = input[0]
         obj._backend = type2backend[input.type()]
         obj.updateOutput = updateOutput_orig

--- a/torch/utils/trainer/trainer.py
+++ b/torch/utils/trainer/trainer.py
@@ -1,5 +1,4 @@
 import heapq
-from torch.autograd import Variable
 
 
 class Trainer(object):
@@ -54,8 +53,8 @@ class Trainer(object):
         for i, data in enumerate(self.dataset, self.iterations + 1):
             batch_input, batch_target = data
             self.call_plugins('batch', i, batch_input, batch_target)
-            input_var = Variable(batch_input)
-            target_var = Variable(batch_target)
+            input_var = batch_input
+            target_var = batch_target
 
             plugin_data = [None, None]
 


### PR DESCRIPTION
1. Change mentions of `Variable` to `Tensor` in doc text and examples
2. Change tests against `Variable` to `Tensor`, e.g. `isinstance`
3. Use the new style tensor factory methods.
4. Update the doc to be more consistent in naming
5. Add data_parallel functionals docs
6. Remove a obsolete test that compares blas results when called on `Variable` and on `Tenors`
7. Remove lowercase `variable`

Test scripts are not completely updated (too many)

Also addresses #6276 