### PR TITLE
Allow traces to call @script functions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2531,6 +2531,23 @@ class TestScript(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'called recursively involving'):
             M()
 
+    def test_trace_of_script(self):
+        @torch.jit.script
+        def foo(a, c):
+            b = 0
+            if a == 0:
+                b = 1
+            return b + c
+
+        a = torch.ones(1, dtype=torch.long)
+
+        @torch.jit.trace(torch.zeros(1, dtype=torch.long))
+        def use(b):
+            return foo(b - 1, a) + 1
+
+        self.assertEqual(3, use(torch.ones(1, dtype=torch.long)))
+        self.assertEqual(2, use(torch.zeros(1, dtype=torch.long)))
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -101,6 +101,9 @@ void initJITBindings(PyObject *module) {
           }),
           py::arg("graph"),
           py::arg("optimize") = true)
+      .def_property_readonly("graph", [](GraphExecutor& ge) {
+        return ge.graph();
+      })
       .def("__call__", [](GraphExecutor& ge, py::args args) -> py::object {
         auto inputs = createVariableTensorList(args);
         auto outputs = ge.run(std::move(inputs));


### PR DESCRIPTION
This adds the ability to trace script functions while preserving their
control flow. When the trace encounters a script function it inlines
the graph of the function into the trace rather than tracing the
function itself.

