### PR TITLE
Support gpu triangle solve

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3234,6 +3234,7 @@
     - Double
   backends:
     - CPU
+    - CUDA
   variants:
     - method
     - function

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -111,8 +111,8 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
   magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
   magma_trans_t ts = trans[0] == 'N' ? MagmaNoTrans : MagmaTrans;
   magma_diag_t dg = diag[0] == 'U' ? MagmaUnit : MagmaNonUnit;
-  magma_queue_t queue;
-  magma_queue_create(THCTensor_(getDevice)(state, b_), &queue);
+
+  real alpha = 1;
 
   int64_t n = a_->size[0];
   int64_t nrhs = b_->size[1];
@@ -123,12 +123,11 @@ THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, 
   real *b_data = THCTensor_(data)(state, b);
 
 #if defined(THC_REAL_IS_FLOAT)
-  magma_strsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n, queue);
+  magma_strsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n);
 #else
-  magma_dtrsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n, queue);
+  magma_dtrsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n);
 #endif
 
-  magma_queue_destroy(queue);
   THCTensor_(freeCopyTo)(state, a, ra_);
   THCTensor_(freeCopyTo)(state, b, rb_);
 #else

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -98,6 +98,44 @@ THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, T
 #endif
 }
 
+THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_,
+                               const char *uplo, const char *trans, const char *diag)
+{
+#ifdef USE_MAGMA
+  THArgCheck(a_->nDimension == 2, 1, "A should be 2 dimensional");
+  THArgCheck(b_->nDimension == 2, 2, "b should be 2 dimensional");
+  THArgCheck(a_->size[0] == a_->size[1], 1, "A should be square");
+  THArgCheck(b_->size[0] == a_->size[0], 2, "A,b size incompatible");
+
+  magma_side_t sz = MagmaLeft;
+  magma_uplo_t ul = uplo[0] == 'U' ?  MagmaUpper : MagmaLower;
+  magma_trans_t ts = trans[0] == 'N' ? MagmaNoTrans : MagmaTrans;
+  magma_diag_t dg = diag[0] == 'U' ? MagmaUnit : MagmaNonUnit;
+  magma_queue_t queue;
+  magma_queue_create(THCTensor_(getDevice)(state, b_), &queue);
+
+  int64_t n = a_->size[0];
+  int64_t nrhs = b_->size[1];
+
+  THCTensor *a = THCTensor_(newColumnMajor)(state, ra_, a_);
+  THCTensor *b = THCTensor_(newColumnMajor)(state, rb_, b_);
+  real *a_data = THCTensor_(data)(state, a);
+  real *b_data = THCTensor_(data)(state, b);
+
+#if defined(THC_REAL_IS_FLOAT)
+  magma_strsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n, queue);
+#else
+  magma_dtrsm(sz, ul, ts, dg, n, nrhs, alpha, a_data, n, b_data, n, queue);
+#endif
+
+  magma_queue_destroy(queue);
+  THCTensor_(freeCopyTo)(state, a, ra_);
+  THCTensor_(freeCopyTo)(state, b, rb_);
+#else
+  THError(NoMagma(trtrs));
+#endif
+}
+
 THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_)
 {
 #ifdef USE_MAGMA

--- a/aten/src/THC/generic/THCTensorMathMagma.h
+++ b/aten/src/THC/generic/THCTensorMathMagma.h
@@ -6,6 +6,8 @@
 
 // MAGMA (i.e. CUDA implementation of LAPACK functions)
 THC_API void THCTensor_(gesv)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
+THC_API void THCTensor_(trtrs)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_,
+                               const char *uplo, const char *trans, const char *diag);
 THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
 THC_API void THCTensor_(syev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a_, const char *jobz, const char *uplo);
 THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, THCTensor *a_, const char *jobvr);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1546,6 +1546,10 @@ class TestCuda(TestCase):
     def test_diagflat(self):
         TestTorch._test_diagflat(self, dtype=torch.cuda.float32)
 
+    @unittest.skipIf(not HAS_MAGMA, "no MAGMA library detected")
+    def test_trtrs(self):
+        TestTorch._test_trtrs(self, lambda t: t.cuda())
+
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
     def test_get_set_rng_state_all(self):
         states = torch.cuda.get_rng_state_all()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2952,8 +2952,8 @@ class TestTorch(TestCase):
         res2 = torch.ormqr(m, tau, mat2, False, True)
         self.assertEqual(res1, res2)
 
-    @skipIfNoLapack
-    def test_trtrs(self):
+    @staticmethod
+    def _test_trtrs(self, cast):
         a = torch.Tensor(((6.80, -2.11, 5.66, 5.97, 8.23),
                           (-6.05, -3.30, 5.36, -4.44, 1.08),
                           (-0.45, 2.58, -2.70, 0.27, 9.04),
@@ -2962,6 +2962,9 @@ class TestTorch(TestCase):
         b = torch.Tensor(((4.02, 6.19, -8.22, -7.57, -3.03),
                           (-1.56, 4.00, -8.67, 1.75, 2.86),
                           (9.81, -4.09, -4.57, -8.61, 8.99))).t()
+
+        a = cast(a)
+        b = cast(b)
 
         U = torch.triu(a)
         L = torch.tril(a)
@@ -3000,13 +3003,17 @@ class TestTorch(TestCase):
 
         # test reuse
         res1 = torch.trtrs(b, a)[0]
-        ta = torch.Tensor()
-        tb = torch.Tensor()
+        ta = cast(torch.Tensor())
+        tb = cast(torch.Tensor())
         torch.trtrs(b, a, out=(tb, ta))
         self.assertEqual(res1, tb, 0)
         tb.zero_()
         torch.trtrs(b, a, out=(tb, ta))
         self.assertEqual(res1, tb, 0)
+
+    @skipIfNoLapack
+    def test_trtrs(self):
+        self._test_trtrs(self, lambda t: t)
 
     @skipIfNoLapack
     def test_gels(self):


### PR DESCRIPTION
While implementing Gaussian Process module in Pyro, I have to use triangular solver a lot. Currently, `trtrs` is only available on cpu (issue #3073) and for triangular solver on gpu, we have to use `torch.inverse()`. So I made a step to implement it.

I don't have much knowledge to write c/cuda code so there might be some mistakes which I didn't notice. It is helpful to me to diagnostic errors if someone can point out where is cuda test for pytorch functions (especially for `gesv`). This has just been tested for some examples by installing pytorch and comparing results of cpu and gpu versions.

Here is some information which I observed during the implementation:
+ There is no `trtrs` function in MAGMA, so I have to use [trsm](http://icl.cs.utk.edu/projectsfiles/magma/doxygen/group__magma__trsm.html) instead. Indeed, LAPACK `trtrs` is just a wrapper of BLAS `trsm` with additional checks for singularities.
+ In the docs of [magma_dtrsm](http://icl.cs.utk.edu/projectsfiles/magma/doxygen/group__magma__trsm.html#ga36b2b66d52f384db19cf256cc5e8a4c2), there is an argument `queue` which belongs to `magma_queue_t` type. When I created a queue and installed, I kept getting the error "too many arguments" at `maga_dtrsm` calls. When removed it, the installation run well. So I guess there are some changes with different versions of MAGMA.

cc @SsnL @fritzo 



