### PR TITLE
randperm supports n=0

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -267,9 +267,9 @@ Tensor randperm(const Type& dtype, int64_t n, Generator* generator) {
 }
 
 Tensor& randperm_out(Tensor& result, int64_t n, Generator* generator) {
-  if (n <= 0) {
+  if (n < 0) {
     std::ostringstream oss;
-    oss << "n must be strictly positive, got " << n;
+    oss << "n must be non-negative, got " << n;
     throw std::runtime_error(oss.str());
   }
   if (result.type().backend() != at::kCPU) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2347,6 +2347,13 @@ class TestTorch(TestCase):
         torch.randperm(100, out=res2)
         self.assertEqual(res1, res2, 0)
 
+        # randperm of 0 elements is an empty tensor
+        res1 = torch.randperm(0)
+        res2 = torch.LongTensor(5)
+        torch.randperm(0, out=res2)
+        self.assertEqual(res1.numel(), 0)
+        self.assertEqual(res2.numel(), 0)
+
     def test_random(self):
         # This test is flaky with p<=(2/(ub-lb))^200=6e-36
         t = torch.FloatTensor(200)


### PR DESCRIPTION
This makes it compatible with `torch.arange` and `numpy.random.permutation`.
```python
print(torch.randperm(0))

# [torch.LongTensor of size (0,)]
```