### PR TITLE
Fix an error in the tensor docs.

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -8,7 +8,7 @@ torch.Tensor
 A :class:`torch.Tensor` is a multi-dimensional matrix containing elements of
 a single data type.
 
-Torch defines seven CPU tensor types and eight GPU tensor types:
+Torch defines eight CPU tensor types and eight GPU tensor types:
 
 ======================== ===========================   ================================
 Data type                CPU tensor                    GPU tensor


### PR DESCRIPTION
The docs incorrectly stated that there was seven CPU tensor types and
eight GPU tensor types, before listing eight types for both CPU and GPU.

