### PR TITLE
[distributions] Skip validation of lazy properties

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -28,9 +28,12 @@ class Distribution(object):
             self._validate_args = validate_args
         if self._validate_args:
             for param, constraint in self.arg_constraints.items():
-                if not constraints.is_dependent(constraint):
-                    if not constraint.check(self.__getattribute__(param)).all():
-                        raise ValueError("The parameter {} has invalid values".format(param))
+                if constraints.is_dependent(constraint):
+                    continue
+                if param not in self.__dict__:
+                    continue
+                if not constraint.check(self.__dict__[param]).all():
+                    raise ValueError("The parameter {} has invalid values".format(param))
 
     @property
     def batch_shape(self):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -2,6 +2,7 @@ import torch
 from torch.autograd import Variable
 import warnings
 from torch.distributions import constraints
+from torch.distributions.utils import lazy_property
 
 
 class Distribution(object):
@@ -29,10 +30,10 @@ class Distribution(object):
         if self._validate_args:
             for param, constraint in self.arg_constraints.items():
                 if constraints.is_dependent(constraint):
-                    continue
-                if param not in self.__dict__:
-                    continue
-                if not constraint.check(self.__dict__[param]).all():
+                    continue  # skip constraints that cannot be checked
+                if param not in self.__dict__ and isinstance(getattr(type(self), param, None), lazy_property):
+                    continue  # skip checking lazily-constructed args
+                if not constraint.check(self.__getattribute__(param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
     @property

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -31,9 +31,9 @@ class Distribution(object):
             for param, constraint in self.arg_constraints.items():
                 if constraints.is_dependent(constraint):
                     continue  # skip constraints that cannot be checked
-                if param not in self.__dict__ and isinstance(getattr(type(self), param, None), lazy_property):
+                if param not in self.__dict__ and isinstance(getattr(type(self), param), lazy_property):
                     continue  # skip checking lazily-constructed args
-                if not constraint.check(self.__getattribute__(param)).all():
+                if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
 
     @property


### PR DESCRIPTION
Fixes https://github.com/probtorch/pytorch/issues/146
Previous review https://github.com/probtorch/pytorch/pull/147

## The Problem

Currently distributions check each possible constraint in `.arg_constraints`. This is problematic for distributions with multiple alternative parameterizations (e.g. `MultivariateNormal` with `scale_tril`, `covariance_matrix`, and `precision_matrix`) because all possible parameterizations must be constructed and checked. For `MultivariateNormal` this can trigger an expensive matrix inverse.

## Proposed Solution

This PR skips checking of args that are `lazy_property`s, so that only already-instantiated args are checked.

## Tested

- passes existing validation tests