### PR TITLE
Make torch.backends.mkl.is_available() work without importing

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -277,6 +277,7 @@ import torch.jit
 import torch.random
 import torch.distributions
 import torch.testing
+import torch.backends.mkl
 from torch.autograd import no_grad, enable_grad, set_grad_enabled
 
 _C._init_names(list(torch._storage_classes))


### PR DESCRIPTION
..., so that the behavior is consistent with `torch.backends.cudnn.*`

Currently, 

```python
>>> import torch
>>> torch.backends.cudnn.enabled
True
>>> torch.backends.mkl.is_available()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'torch.backends' has no attribute 'mkl'
>>> import torch.backends.mkl
>>> torch.backends.mkl.is_available()
True
```