### PR TITLE
Create FileBaton to synchronize distributed JIT C++ extension builds

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -8,10 +8,10 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
-import time
 import warnings
 
 import torch
+from .file_baton import FileBaton
 
 from setuptools.command.build_ext import build_ext
 
@@ -56,51 +56,6 @@ for instructions on how to install GCC 4.9 or higher.
                               !! WARNING !!
 '''
 CUDA_HOME = _find_cuda_home() if torch.cuda.is_available() else None
-
-
-class FileBaton:
-    '''A primitive, file-based synchronization utility.'''
-
-    def __init__(self, lock_file_path, wait_seconds=0.1):
-        '''
-        Creates a new :class:`FileBaton`.
-
-        Args:
-            lock_file_path: The path to the file used for locking.
-            wait_seconds: The seconds to periorically sleep (spin) when
-                calling ``wait()``.
-        '''
-        self.lock_file_path = lock_file_path
-        self.wait_seconds = wait_seconds
-        self.fd = None
-
-    def try_acquire(self):
-        '''
-        Tries to atomically create a file under exclusive access.
-
-        Returns:
-            True if the file could be created, else False.
-        '''
-        try:
-            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
-            return True
-        except FileExistsError:
-            return False
-
-    def wait(self):
-        '''
-        Periodically sleeps for a certain amount until the baton is released.
-
-        The amount of time slept depends on the ``wait_seconds`` parameter
-        passed to the constructor.
-        '''
-        while os.path.exists(self.lock_file_path):
-            time.sleep(self.wait_seconds)
-
-    def release(self):
-        '''Releaes the baton and removes its file.'''
-        os.close(self.fd)
-        os.remove(self.lock_file_path)
 
 
 def check_compiler_abi_compatibility(compiler):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -476,7 +476,10 @@ def load(name,
     if baton.try_acquire():
         try:
             with_cuda = any(map(_is_cuda_file, sources))
-            extra_ldflags = _prepare_ldflags(extra_ldflags or [], with_cuda)
+            extra_ldflags = _prepare_ldflags(
+                extra_ldflags or [],
+                with_cuda,
+                verbose)
             build_file_path = os.path.join(build_directory, 'build.ninja')
             if verbose:
                 print(
@@ -518,7 +521,7 @@ def verify_ninja_availability():
             raise RuntimeError("Ninja is required to load C++ extensions")
 
 
-def _prepare_ldflags(extra_ldflags, with_cuda):
+def _prepare_ldflags(extra_ldflags, with_cuda, verbose):
     if sys.platform == 'win32':
         python_path = os.path.dirname(sys.executable)
         python_lib_path = os.path.join(python_path, 'libs')

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+
 class FileBaton:
     '''A primitive, file-based synchronization utility.'''
 

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,0 +1,46 @@
+import os
+import time
+
+class FileBaton:
+    '''A primitive, file-based synchronization utility.'''
+
+    def __init__(self, lock_file_path, wait_seconds=0.1):
+        '''
+        Creates a new :class:`FileBaton`.
+
+        Args:
+            lock_file_path: The path to the file used for locking.
+            wait_seconds: The seconds to periorically sleep (spin) when
+                calling ``wait()``.
+        '''
+        self.lock_file_path = lock_file_path
+        self.wait_seconds = wait_seconds
+        self.fd = None
+
+    def try_acquire(self):
+        '''
+        Tries to atomically create a file under exclusive access.
+
+        Returns:
+            True if the file could be created, else False.
+        '''
+        try:
+            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
+            return True
+        except FileExistsError:
+            return False
+
+    def wait(self):
+        '''
+        Periodically sleeps for a certain amount until the baton is released.
+
+        The amount of time slept depends on the ``wait_seconds`` parameter
+        passed to the constructor.
+        '''
+        while os.path.exists(self.lock_file_path):
+            time.sleep(self.wait_seconds)
+
+    def release(self):
+        '''Releaes the baton and removes its file.'''
+        os.close(self.fd)
+        os.remove(self.lock_file_path)


### PR DESCRIPTION
As reported by @fmassa in #6353 , when using JIT C++ extensions together with `torch.distributed.launch`, each process separately compiles the extension, and then crashes occasionally as the processes race with each other.

This PR creates a `FileBaton` datastructure, which allows two things:
1) atomically creating a file,
2) waiting until the file is deleted (spinning with sleeps)

This serves as a sufficient "rendezvous"/single-shot synchronization mechanism. As far as I can google, the file creation mechanism I use `O_CREAT | O_EXCL` is only atomic on Unix, so while this code will work fine on Windows, it may not behave in an entirely race-free way. I did not see a straightforward way provided by Python to do this on Windows (cc @peterjc123 )

Fixes #6353 

## Test plan

1. See #6353 for a MWE, also pass `verbose=True` to `load_ext()`
2. Run with `python -m torch.distributed.launch --nproc_per_node=4 mwe.py` and old code,
3. Observe multiple, concurrent compilation. Not necessarily a crash, but possibly,
4. Run with new code,
5. Observe that only one process compiles the code.