### PR TITLE
Check for --noprefix option for mpiexec in run_test.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -146,7 +146,14 @@ def test_distributed(python, test_module, test_directory, options):
                 os.mkdir(os.path.join(tmp_dir, 'barrier'))
                 os.mkdir(os.path.join(tmp_dir, 'test_dir'))
                 if backend == 'mpi':
-                    mpiexec = 'mpiexec -n 3 --noprefix {}'.format(python)
+                    #test mpiexec for --noprefix option
+                    devnull = open(os.devnull, 'w')
+                    noprefix_opt = '--noprefix' if subprocess.call(
+                        'mpiexec -n 1 --noprefix bash -c ""', shell=True,
+                        stdout=devnull, stderr=subprocess.STDOUT) == 0 else ''
+
+                    mpiexec = 'mpiexec -n 3 {} {}'.format(noprefix_opt, python)
+
                     return_code = run_test(mpiexec, test_module,
                                            test_directory, options)
                 else:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -146,7 +146,7 @@ def test_distributed(python, test_module, test_directory, options):
                 os.mkdir(os.path.join(tmp_dir, 'barrier'))
                 os.mkdir(os.path.join(tmp_dir, 'test_dir'))
                 if backend == 'mpi':
-                    #test mpiexec for --noprefix option
+                    # test mpiexec for --noprefix option
                     devnull = open(os.devnull, 'w')
                     noprefix_opt = '--noprefix' if subprocess.call(
                         'mpiexec -n 1 --noprefix bash -c ""', shell=True,


### PR DESCRIPTION
--noprefix option to mpiexec is not part of the MPI standard.
It is needed in certain configurations when using OpenMPI but not
supported with other MPI implementations such as MPICH and maybe
others. This commit adds a check if the option is supported by
the current mpiexec. Also this commit fixes Issue #4965 and MPI
tests can be enabled in the CI.

Fixes: #4965

