### PR TITLE
[jit][script] Tuple literal and cat support

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1433,9 +1433,9 @@ class TestJit(TestCase):
         def test_fuser_multiple_blocks(this, that, theother, meme):
             i = 0
             while i < 20:
-                this = cat(this, meme, dim=0)
-                that = cat(that, meme, dim=0)
-                theother = cat(theother, meme, dim=0)
+                this = cat([this, meme], dim=0)
+                that = cat([that, meme], dim=0)
+                theother = cat([theother, meme], dim=0)
                 i = i + 1
             return this, that, theother
         ''')
@@ -1578,6 +1578,53 @@ class TestScript(TestCase):
         y = func(x)
         y2 = torch.sum(x, dim=0, keepdim=True)
         self.assertEqual(y, y2)
+
+    def test_literal(self):
+        def func(a, b):
+            c = [a, b]
+            d, e = c
+            return d + e
+
+        def func2(a, b):
+            c = a, b
+            d, e = c
+            return d + e
+
+        def func3(a, b):
+            c = a, (a, b)
+            d, e = c
+            f, g = e
+            return d + f + g
+
+        def func4(a, b):
+            c = 0, (0, 0)
+            x = True
+            while x:
+                x = False
+                c = a, (a, b)
+            d, e = c
+            f, g = e
+            return d + f + g
+
+        a = torch.rand(1, requires_grad=True)
+        b = torch.rand(1, requires_grad=True)
+        self.checkScript(func, (a, b), optimize=True)
+        self.checkScript(func2, (a, b), optimize=True)
+        self.checkScript(func3, (a, b), optimize=True)
+        self.checkScript(func4, (a, b), optimize=True)
+
+    def test_cat(self):
+        @torch.jit.script
+        def func(x):
+            return torch.cat((x, x), dim=0)
+
+        x = torch.rand(10, dtype=torch.float, requires_grad=True)
+        self.assertEqual(func(x), torch.cat((x, x), dim=0))
+
+        with self.assertRaisesRegex(RuntimeError, "at most 2 inputs"):
+            @torch.jit.script
+            def func(x):
+                return torch.cat((x, x), x, dim=0)
 
     def test_func_call(self):
         script = '''

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -70,7 +70,7 @@ static void VisitNode(Node* n, Node* insert_point) {
     if(TupleType* tt = output->type()->cast<TupleType>()) {
       JIT_ASSERTM(white_list.count(n->kind()) > 0, "tuple appears in op that does not forward tuples");
       for(size_t j = 0; j < tt->elements().size(); j++) {
-        n->insertOutput(i + 1 + j)->setType(tt->elements()[i]);
+        n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
       }
       auto new_tup = graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
       new_tup->insertBefore(insert_point);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -304,6 +304,27 @@ std::shared_ptr<SugaredValue> emitBuiltinCall(
   for(size_t i = 0; i < op->num_outputs; ++i)
     n->addOutput();
 
+  // special handling for the tuple that cat takes as its first argument
+  if(name == "cat") {
+    ensureTensors(loc, inputs.slice(1));
+    auto first = inputs.at(0);
+    if(first->type()->kind() != TupleType::Kind) {
+      throw ErrorReport(loc) << "expected a tuple";
+    }
+    if(inputs.size() + attributes.size() > 2) {
+      throw ErrorReport(loc) << "expected at most 2 inputs";
+    }
+    // flatten the tuple into the argument list
+    auto unpacked = graph->insertNode(graph->createTupleUnpack(first));
+    ensureTensors(loc, unpacked->outputs());
+    n->removeInput(0);
+    for(size_t i = 0; i < unpacked->outputs().size(); ++i) {
+      n->insertInput(i, unpacked->outputs().at(i));
+    }
+  } else {
+    ensureTensors(loc, inputs);
+  }
+
   return packOutputs(*graph, n->outputs());
 }
 
@@ -313,6 +334,28 @@ struct NoneValue : SugaredValue {
     return "None";
   }
 };
+
+
+static Value* ensureTensor(const SourceRange& range, Value* v) {
+  // both 'DynamicType' and 'TensorType' are actually Tensors:
+  // 'Dynamic' currently means a dynamically-sized tensor vs e.g. a TupleType
+  // TensorType means a 'sized' tensor which is added by some optimizations
+  if(v->type()->kind() == TypeKind::DynamicType
+     || v->type()->kind() == TypeKind::TensorType) {
+       return v;
+  }
+  throw ErrorReport(range) << "expected a tensor value but found a tuple";
+}
+
+void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values) {
+  for(auto value : values) {
+    ensureTensor(range, value);
+  }
+}
+
+static Value* identity(const SourceRange& range, Value* v) {
+  return v;
+}
 
 
 std::shared_ptr<SugaredValue> BuiltinFunction::call(
@@ -796,23 +839,29 @@ private:
     }
   }
 
-  std::vector<Value*> getValues(TreeList trees, bool maybe_unpack=false) {
+  std::vector<Value*> getValues(
+      TreeList trees,
+      bool maybe_unpack=false,
+      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
     std::vector<Value*> values;
     for (const auto& tree : trees) {
       if(maybe_unpack && tree->kind() == TK_STARRED) {
         auto starred = Starred(tree);
         auto entries = emitSugaredExpr(starred.expr(), 1)->asTuple(starred.range(), method);
         for(auto entry : entries) {
-          values.push_back(ensureTensor(starred.range(), entry->asValue(starred.range(), method)));
+          values.push_back(post_process(starred.range(), entry->asValue(starred.range(), method)));
         }
       } else {
-        values.push_back(emitExpr(Expr(tree)));
+        values.push_back(emitExpr(Expr(tree), post_process));
       }
     }
     return values;
   }
-  std::vector<Value*> getValues(List<Expr> trees, bool maybe_unpack=false) {
-    return getValues(trees.tree()->trees(), maybe_unpack);
+  std::vector<Value*> getValues(
+      List<Expr> trees,
+      bool maybe_unpack=false,
+      std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
+    return getValues(trees.tree()->trees(), maybe_unpack, post_process);
   }
 
 
@@ -824,6 +873,7 @@ private:
     } else if (ident.name() == "print") {
       if (!attributes.empty())
         throw ErrorReport(ident) << "print doesn't accept any keyword arguments";
+      ensureTensors(ident.range(), inputs);
       emitNode(prim::Print, ident.range(), inputs, 0);
       return std::make_shared<NoneValue>();
     }
@@ -840,19 +890,8 @@ private:
     return sv->call(callee.range(), method, inputs, attributes, n_binders);
   }
 
-  Value* ensureTensor(const SourceRange& range, Value* v) {
-    // both 'DynamicType' and 'TensorType' are actually Tensors:
-    // 'Dynamic' currently means a dynamically-sized tensor vs e.g. a TupleType
-    // TensorType means a 'sized' tensor which is added by some optimizations
-    if(v->type()->kind() == TypeKind::DynamicType
-       || v->type()->kind() == TypeKind::TensorType) {
-         return v;
-    }
-    throw ErrorReport(range) << "expected a tensor value but found a tuple";
-  }
-
-  Value* emitExpr(Expr tree) {
-    return ensureTensor(tree.range(), emitSugaredExpr(tree, 1)->asValue(tree.range(), method));
+  Value* emitExpr(Expr tree, std::function<Value*(const SourceRange&, Value*)> post_process = ensureTensor) {
+    return post_process(tree.range(), emitSugaredExpr(tree, 1)->asValue(tree.range(), method));
   }
 
   // any expression that can produce a SugaredValue is handled here
@@ -868,7 +907,7 @@ private:
       }
       case TK_APPLY: {
         auto apply = Apply(tree);
-        auto inputs = getValues(apply.inputs(), true);
+        auto inputs = getValues(apply.inputs(), true, identity);
         // the apply is directly an identifier 'foo'
         if(apply.callee().kind() == TK_VAR) {
           return emitApplyIdent(Var(apply.callee()).name(), inputs, apply.attributes(), n_binders);
@@ -936,6 +975,11 @@ private:
       } break;
       case TK_IF_EXPR: {
         return emitTernaryIf(TernaryIf(tree));
+      } break;
+      case TK_LIST_LITERAL: {
+        auto ll = ListLiteral(tree);
+        auto values = getValues(ll.inputs(), /*maybe_unpack=*/true, identity);
+        return graph->insertNode(graph->createTuple(values))->output();
       } break;
       default:
         throw ErrorReport(tree) << "NYI: " << tree;

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -129,7 +129,7 @@ std::shared_ptr<Graph> compileFunction(Def def, const Resolver& resolver);
 std::shared_ptr<SugaredValue> packOutputs(Graph& g, at::ArrayRef<Value*> values);
 std::vector<Value*> inlineCallTo(Graph& g, Graph& callee, ArrayRef<Value*> inputs);
 void ensureSizeMatches(SourceRange loc, size_t expected, size_t actual, const std::string& what);
-
+void ensureTensors(const SourceRange& range, at::ArrayRef<Value*> values);
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -25,6 +25,8 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
 
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
+    ensureTensors(loc, inputs);
+    
     if (attributes.size() > 0)
       throw ErrorReport(loc) << "keyword arguments in Python calls aren't supported";
     Graph& g = *m.graph();

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -11,6 +11,7 @@ void placeholderCreator(Method&) {
 }
 
 std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, ArrayRef<Value*> inputs) {
+  ensureTensors(loc, inputs);
   JIT_ASSERT(!executor);
   try {
     callee.ensure_defined();

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -29,6 +29,20 @@ struct Parser {
         List<Expr>(makeList(range, std::move(inputs))),
         List<Attribute>(makeList(range, std::move(attributes))));
   }
+  // exp | expr, | expr, expr, ...
+  TreeRef parseExpOrExpList(int end) {
+    auto prefix = parseExp();
+    if(L.cur().kind == ',') {
+      std::vector<Expr> exprs = { prefix };
+      while(L.cur().kind != end) {
+        L.expect(',');
+        exprs.push_back(parseExp());
+      }
+      auto list = List<Expr>::create(prefix.range(), exprs);
+      prefix = ListLiteral::create(list.range(), list);
+    }
+    return prefix;
+  }
   // things like a 1.0 or a(4) that are not unary/binary expressions
   // and have higher precedence than all of them
   TreeRef parseBaseExp() {
@@ -46,8 +60,12 @@ struct Parser {
       } break;
       case '(': {
         L.next();
-        prefix = parseExp();
+        prefix = parseExpOrExpList(')');
         L.expect(')');
+      } break;
+      case '[': {
+        auto list = parseList('[', ',', ']', &Parser::parseExp);
+        prefix = ListLiteral::create(list.range(), List<Expr>(list));
       } break;
       case TK_FLOAT:
       case TK_INT:
@@ -170,16 +188,7 @@ struct Parser {
     return Const::create(t.range, t.text());
   }
   Expr parseAttributeValue() {
-    int kind = L.cur().kind;
-    switch (kind) {
-      case '[': {
-        auto list = parseList('[', ',', ']', &Parser::parseExp);
-        return ListLiteral::create(list.range(), List<Expr>(list));
-      }
-      default: {
-        return parseExp();
-      }
-    }
+    return parseExp();
   }
   void parseOperatorArguments(TreeList& inputs, TreeList& attributes) {
     L.expect('(');
@@ -246,7 +255,7 @@ struct Parser {
   // first[,other,lhs] = rhs
   Assign parseAssign(List<Expr> list) {
     auto red = parseOptionalReduction();
-    auto rhs = parseExp();
+    auto rhs = parseExpOrExpList(TK_NEWLINE);
     L.expect(TK_NEWLINE);
     return Assign::create(list.range(), list, AssignKind(red), Expr(rhs));
   }

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -72,6 +72,10 @@ public:
   virtual ~Type() {}
 };
 
+inline bool operator!=(const Type & lhs, const Type & rhs) {
+  return !(lhs == rhs);
+}
+
 
 struct DynamicType : public Type {
   DynamicType()
@@ -190,15 +194,21 @@ struct TupleType : public Type {
   virtual bool operator==(const Type& rhs) const override {
     if(rhs.kind() != kind())
       return false;
-    return rhs.cast<TupleType>()->elements().equals(elements());
+    const auto & l_elements = elements();
+    const auto & r_elements = rhs.cast<TupleType>()->elements();
+    if(l_elements.size() != r_elements.size())
+      return false;
+    for(size_t i = 0; i < l_elements.size(); ++i) {
+      if(*l_elements[i] != *r_elements[i])
+        return false;
+    }
+    return true;
   }
 private:
   std::vector<TypePtr> elements_;
 };
 
-inline bool operator!=(const Type & lhs, const Type & rhs) {
-  return !(lhs == rhs);
-}
+
 
 std::ostream& operator<<(std::ostream & out, const Type & t);
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -413,6 +413,11 @@ class ExprBuilder(Builder):
                            [build_expr(ctx, e) for e in expr.elts])
 
     @staticmethod
+    def build_Tuple(ctx, expr):
+        return ListLiteral(ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1),
+                           [build_expr(ctx, e) for e in expr.elts])
+
+    @staticmethod
     def build_Num(ctx, expr):
         value = str(expr.n)
         r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(value))


### PR DESCRIPTION
* Support list and tuple literals: Adds support for [a, b], (a, b) and "a, "
* Allow non-tensors to reach emitBuiltinCall, each SugaredValue::call
is now responsible for checking the types of its inputs.
* Add support for calling cat with a tuple to emitBuiltinOp

