### PR TITLE
[caffe2] Use both __ARM_NEON__ and __ARM_NEON macros

### DIFF
--- a/caffe2/mobile/contrib/ulp2/ulp.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp.cc
@@ -292,7 +292,7 @@ std::unique_ptr<QConvState> create2b1bConvState(Workspace* ws,
 }
 
 void run2b1bConvGeneric(QConvState* state, const ConvArgs& args, const TensorCPU& X, TensorCPU* Y) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   if (run2b1bConvNeon(state, args, X, Y)) {
     return;
   }

--- a/caffe2/mobile/contrib/ulp2/ulp_neon.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_neon.cc
@@ -8,7 +8,7 @@ namespace caffe2 {
 // devices (Snapdragon 820).
 constexpr size_t kL1CacheSizeBytes = 16 * 1024;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 // Applies 2-bit uniform quantization to the floating point data at Xdata,
 // storing QC bytes into XQdata (i.e. reading 8 * QC floats from Xdata).

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -38,7 +38,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const int input_image_size = H * W;
   const int output_image_size = Y->dim32(2) * Y->dim32(3);
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   if (InputSize() == 3) {
     auto& bias = Input(BIAS);
     CAFFE_ENFORCE(bias.ndim() == 1, "bias must be 1D tensor");
@@ -55,7 +55,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           &context_);
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
   const T* Xdata = X.template data<T>();
   const T* filter_data = filter.template data<T>();
@@ -102,7 +102,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       // Bias term
       if (InputSize() == 3) {
         const T* bias_data = Input(BIAS).template data<T>();
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
         const T* bm_data = bias_multiplier_.template data<T>();
         math::Gemm<T, Context>(
             CblasNoTrans,
@@ -123,7 +123,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
             output_image_size,
             Ydata,
             &context_);
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
       }
 
       Xdata += M * H * W;

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -115,7 +115,7 @@ void runTileContiguous(
         Ydata + c_im * outputH * (colBlockSize * numColBlocks) + offsetY;
 
     int b = 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     // We vectorize the loop within the row
     {
       constexpr int kUnroll = (sizeof(float32x4_t) / sizeof(float)) * 4;
@@ -179,7 +179,7 @@ struct StoreInterleaved {};
 
 template <>
 struct StoreInterleaved<float, 1> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[1]) {
     vst1q_f32(p, v[0]);
   }
@@ -192,7 +192,7 @@ struct StoreInterleaved<float, 1> {
 
 template <>
 struct StoreInterleaved<float, 2> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[2]) {
     float32x4x2_t x = {{v[0], v[1]}};
     vst2q_f32(p, x);
@@ -207,7 +207,7 @@ struct StoreInterleaved<float, 2> {
 
 template <>
 struct StoreInterleaved<float, 3> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[3]) {
     float32x4x3_t x = {{v[0], v[1], v[2]}};
     vst3q_f32(p, x);
@@ -223,7 +223,7 @@ struct StoreInterleaved<float, 3> {
 
 template <>
 struct StoreInterleaved<float, 4> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[4]) {
     float32x4x4_t x = {{v[0], v[1], v[2], v[3]}};
     vst4q_f32(p, x);
@@ -264,12 +264,12 @@ void reinterleaveRows(
   dst += point * outputW;
 
   float b = bias ? bias[c] : 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   float32x4_t biasV = vdupq_n_f32(b);
 #endif
 
   int w = 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   constexpr int kUnroll = (sizeof(float32x4_t) / sizeof(float)) * 2;
   int limit = ((inputW - 1) / kUnroll) * kUnroll;
 
@@ -394,7 +394,7 @@ void reinterleaveMultithreaded(
   pool->run(fnReinterleave, totalTiles);
 }
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 template <int N>
 struct SumMultiple {
   static void sumInto(float* acc, float** toSum, size_t size);
@@ -505,7 +505,7 @@ struct SumMultiple<3> {
 
 // Performs acc[i] += sum_j toSum_j[i] pointwise
 void sumInto(float* acc, std::vector<float*>& toSum, size_t size) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   if (toSum.size() == 1) {
     SumMultiple<1>::sumInto(acc, toSum.data(), size);
     return;

--- a/caffe2/operators/conv_transpose_op_mobile_test.cc
+++ b/caffe2/operators/conv_transpose_op_mobile_test.cc
@@ -169,7 +169,7 @@ int randInt(int a, int b) {
 }
 
 // TODO(#14383029) cblas_sgemm not yet implemented on limited mobile cases.
-#if __ARM_NEON__ && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
 TEST(ConvTransposeMobile, Test) {
   for (int i = 0; i < 10; ++i) {
     int n = randInt(1, 3);

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -9,7 +9,7 @@ using std::min;
 
 namespace {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 bool isNeon4x4p0s0Eligible(
     int inputH,
@@ -303,7 +303,7 @@ void runNeonMaxPool2x2p0s0NCHW(
     }
   }
 }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 } // namespace
 
@@ -354,7 +354,7 @@ class AveragePool {
       int dilationW,
       const float* input,
       float* output) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     if (isNeon4x4p0s0Eligible(
             inputH,
             inputW,
@@ -446,7 +446,7 @@ class MaxPool {
       int dilationW,
       const float* input,
       float* output) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     if (isNeon2x2p0s0Eligible(
             inputH,
             inputW,

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -6,7 +6,7 @@
 
 namespace caffe2 {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 namespace {
 
 void runNeonPrelu(float* out, const float* in, int size, float w) {
@@ -91,7 +91,7 @@ void runNeonPrelu(float* out, const float* in, int size, float w) {
 }
 
 }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 template <>
 bool PReluOp<float, CPUContext>::RunOnDevice() {
@@ -111,14 +111,14 @@ bool PReluOp<float, CPUContext>::RunOnDevice() {
   }
 
   if (C_shared) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     // The function is completely pointwise
     runNeonPrelu(Ydata, Xdata, X.size(), Wdata[0]);
 #else
     ConstEigenVectorMap<float> Xvec(Xdata, X.size());
     EigenVectorMap<float> Yvec(Ydata, Y->size());
     Yvec = Xvec.cwiseMax(0.f) + Xvec.cwiseMin(0.f) * Wdata[0];
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
     return true;
   }
 
@@ -128,7 +128,7 @@ bool PReluOp<float, CPUContext>::RunOnDevice() {
       const auto N = X.dim(0);
       const auto dim = X.size_from_dim(2);
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       // Pointwise for each channel
       for (int n = 0; n < N; ++n) {
         for (int c = 0; c < C; ++c) {

--- a/caffe2/operators/resize_op.cc
+++ b/caffe2/operators/resize_op.cc
@@ -19,7 +19,7 @@ void resizeNearest2x(
       for (int y = 0; y < output_height; ++y) {
         const int in_y = y / 2;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
         int vecW = (input_width / 4) * 4; // round down
         int x = 0;
         for (; x < vecW; x += 4) {

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -4,7 +4,7 @@
 
 namespace caffe2 {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 namespace {
 
 //
@@ -49,7 +49,7 @@ inline uint8x8_t convertNarrowAndPack(float32x4_t v0, float32x4_t v1) {
 }
 
 } // unnamed namespace
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     : public Operator<CPUContext> {
@@ -82,7 +82,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       // Cache it to maintain temporal consistency.
       auto* t = noiseBlob->template GetMutable<TensorCPU>();
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       // Noise space is larger for vectorized code due to the
       // vectorized load
       initNoiseCPUNeon(t, defaultNoiseSize);
@@ -115,7 +115,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     return true;
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void initNoiseCPU(Tensor<CPUContext>* noise, int size) {
     noise->Resize(size);
 
@@ -126,9 +126,9 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
         noise->template mutable_data<float>(),
         &context_);
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void initNoiseCPUNeon(Tensor<CPUContext>* noise, int size) {
     // For ARM NEON, we read in multiples of kNeonNoiseReadSize since
     // the inner loop is vectorized. Round up to the next highest
@@ -143,7 +143,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
         noise->template mutable_data<float>(),
         &context_);
   }
-#endif // __ARM_NEON
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
   void runBatch(
       int N,
@@ -161,15 +161,15 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       auto curInput = input + n * kInputChannels * planeSize;
       auto curOutput = output + n * kOutputChannels * planeSize;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       runCPUNeon(H, W, noiseCycle, curInput, meanChannel, noise, curOutput);
 #else
       runCPU(H, W, noiseCycle, curInput, meanChannel, noise, curOutput);
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
     }
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void runCPU(
       int H,
       int W,
@@ -192,9 +192,9 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       }
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void runCPUNeon(
       int H,
       int W,
@@ -373,7 +373,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       }
     }
   }
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
 
  private:
   Workspace* ws_;
@@ -443,15 +443,15 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
       auto curInput = input + n * kInputChannels * planeSize;
       auto curOutput = output + n * kOutputChannels * planeSize;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       runCPUNeon(H, W, curInput, meanChannel, curOutput);
 #else
       runCPU(H, W, curInput, meanChannel, curOutput);
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
     }
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void runCPU(
       int H,
       int W,
@@ -472,9 +472,9 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
           std::numeric_limits<uint8_t>::max();
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void runCPUNeon(
       int H,
       int W,
@@ -563,7 +563,7 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
           std::numeric_limits<uint8_t>::max();
     }
   }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 };
 
 namespace {

--- a/caffe2/utils/cpu_neon.h
+++ b/caffe2/utils/cpu_neon.h
@@ -2,7 +2,7 @@
 #define CAFFE2_UTILS_CPU_NEON_H_
 
 // Provides a variety of ARM NEON-specific utility functions
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 
 namespace caffe2 {
@@ -48,6 +48,6 @@ inline void vst4_u8_aligned(uint8_t* p, uint8x8x4_t v) {
 
 }  // namespace caffe2
 
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 #endif  // CAFFE2_UTILS_CPU_NEON_H_

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -1631,7 +1631,7 @@ void BiasCHW<float, CPUContext>(
   for (int c = 0; c < bias_channels; ++c) {
     float b = bias[c];
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     float32x4_t vBias = vdupq_n_f32(b);
 
     // We give alignment hints for additional speed, so handle the
@@ -1698,7 +1698,7 @@ void BiasCHW<float, CPUContext>(
     for (int i = 0; i < image_size; ++i) {
       image[i] += b;
     }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
     image += image_size;
   }


### PR DESCRIPTION
ARM64 clang from Android NDK doesn't define `__ARM_NEON__`, which results is perf regression on some models.
I figured that some compilers define `__ARM_NEON__` while others define `__ARM_NEON`.
This patch changes all NEON-specific parts in Caffe2 to check both macros.

