### PR TITLE
Sort declarations when generating Python bindings

### DIFF
--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -1051,8 +1051,9 @@ void THTensor_(fmod)(THTensor *r_, THTensor *t, real value)
   }
 }
 
-static inline bool has_different_sign(real a, real b) {
-  return (a < 0) != (b < 0);
+// Should wrap if the value (a) has a different sign than the divisor (b), but is not 0.
+static inline bool modulo_wrap(real a, real b) {
+  return (a != 0) && (a < 0) != (b < 0);
 }
 
 void THTensor_(remainder)(THTensor *r_, THTensor *t, real value)
@@ -1073,7 +1074,7 @@ void THTensor_(remainder)(THTensor *r_, THTensor *t, real value)
 #else
       // There is no NAN for integers
       rp[i] = tp[i] % value;
-      if (has_different_sign(rp[i], value))
+      if (modulo_wrap(rp[i], value))
         rp[i] += value;
 #endif
     }
@@ -1088,7 +1089,7 @@ void THTensor_(remainder)(THTensor *r_, THTensor *t, real value)
 #else
       // There is no NAN for integers
       TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, real, r_, real, t, *r__data = *t_data % value;
-                                        if (has_different_sign(*r__data, value)) *r__data += value;);
+                                        if (modulo_wrap(*r__data, value)) *r__data += value;);
 #endif
     }
 #else
@@ -1101,7 +1102,7 @@ void THTensor_(remainder)(THTensor *r_, THTensor *t, real value)
 #else
     // There is no NAN for integers
     TH_TENSOR_APPLY2(real, r_, real, t, *r__data = *t_data % value;
-                                          if (has_different_sign(*r__data, value)) *r__data += value;);
+                                          if (modulo_wrap(*r__data, value)) *r__data += value;);
 #endif
   }
 }
@@ -1644,7 +1645,7 @@ void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src)
 #else
         // There is no NAN for integers
         rp[i] = tp[i] % sp[i];
-        if (rp[i] * sp[i] < 0)
+        if (modulo_wrap(rp[i], sp[i]))
           rp[i] += sp[i];
 #endif
       }
@@ -1658,7 +1659,7 @@ void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src)
         TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = (*src_data == 0)? NAN : *t_data - *src_data * floor(*t_data / *src_data););
 #else
         TH_TENSOR_APPLY3_OMP(r_Size, r_Contig, tContig, srcContig, real, r_, real, t, real, src, *r__data = *t_data % *src_data;
-                                                     if (*r__data * *src_data < 0) *r__data += *src_data;);
+                                                     if (modulo_wrap(*r__data, *src_data)) *r__data += *src_data;);
 #endif
       }
 #else
@@ -1674,7 +1675,7 @@ void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src)
 #else
     // There is no NAN for integers
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data % *src_data;
-                                                     if (*r__data * *src_data < 0) *r__data += *src_data;);
+                                                     if (modulo_wrap(*r__data, *src_data) < 0) *r__data += *src_data;);
 #endif
 
   }

--- a/aten/src/TH/generic/THTensorMath.c
+++ b/aten/src/TH/generic/THTensorMath.c
@@ -1675,7 +1675,7 @@ void THTensor_(cremainder)(THTensor *r_, THTensor *t, THTensor *src)
 #else
     // There is no NAN for integers
     TH_TENSOR_APPLY3(real, r_, real, t, real, src, *r__data = *t_data % *src_data;
-                                                     if (modulo_wrap(*r__data, *src_data) < 0) *r__data += *src_data;);
+                                                     if (modulo_wrap(*r__data, *src_data)) *r__data += *src_data;);
 #endif
 
   }

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -28,11 +28,6 @@ static inline __host__ __device__ scalar_t powi(scalar_t a, scalar_t b) {
   return result;
 }
 
-template <typename scalar_t>
-static inline __host__ __device__ bool has_different_sign(scalar_t a, scalar_t b) {
-  return (a < 0) != (b < 0);
-}
-
 template <>
 struct THCNumerics<uint8_t> {
   static inline __host__ __device__ uint8_t min() { return 0; }

--- a/aten/src/THC/THCTensorMathPairwise.cu
+++ b/aten/src/THC/THCTensorMathPairwise.cu
@@ -240,19 +240,33 @@ struct TensorDivConstantOp<half> {
 };
 #endif // CUDA_HALF_TENSOR
 
+template<typename T>
+static __device__ __forceinline__
+typename std::enable_if<std::is_signed<T>::value, bool>::type
+modulo_wrap(T a, T b) {
+  return (a != 0) && (a < 0) != (b < 0);
+}
+
+template<typename T>
+static __device__ __forceinline__
+typename std::enable_if<std::is_unsigned<T>::value, bool>::type
+modulo_wrap(T a, T b) {
+  return false;
+}
+
 template <typename T>
 struct TensorRemainderOp {
   TensorRemainderOp(T v) : val(v) {}
   __device__ __forceinline__ void operator()(T* out, T* in) {
     *out = *in % val;
-    if (has_different_sign<T>(*out, val)){
+    if (modulo_wrap<T>(*out, val)) {
       *out += val;
     }
   }
 
   __device__ __forceinline__ void operator()(T* v) {
     *v = *v % val;
-    if (has_different_sign<T>(*v, val)){
+    if (modulo_wrap<T>(*v, val)) {
       *v += val;
     }
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -924,40 +924,42 @@ class TestTorch(TestCase):
         self.assertEqual(res1, res2)
 
     def test_remainder(self):
-        # Check the Floating point case
-        m1 = torch.Tensor(10, 10).uniform_(-10., 10.)
-        res1 = m1.clone()
-        res2 = m1.clone()
-        qs = torch.arange(-5.1, 4.1)
-        # Check the case where the divisor is a simple float
-        for col_idx, q in enumerate(qs):
-            # Reference
-            for i in range(m1.size(0)):
-                res2[i, col_idx] = res2[i, col_idx] % q
-            # To test
-            res1[:, col_idx].remainder_(q)
-        self.assertEqual(res1, res2)
-        # Check the case where the divisor is a tensor
-        res1 = m1.clone()
-        res1.remainder_(qs.unsqueeze(0).expand_as(res1))
-        self.assertEqual(res1, res2)
+        # Check the Floating point case, both tensor and scalar overloads
+        for use_item in [True, False]:
+            m1 = torch.Tensor(10, 10).uniform_(-10., 10.)
+            res1 = m1.clone()
+            res2 = m1.clone()
+            qs = torch.arange(-5.1, 4.1)
+            # Check the case where the divisor is a simple float
+            for col_idx, q in enumerate(qs):
+                # Reference
+                for i in range(m1.size(0)):
+                    res2[i, col_idx] = res2[i, col_idx] % q
+                # To test
+                res1[:, col_idx].remainder_(q if not use_item else q.item())
+            self.assertEqual(res1, res2)
+            # Check the case where the divisor is a tensor
+            res1 = m1.clone()
+            res1.remainder_(qs.unsqueeze(0).expand_as(res1))
+            self.assertEqual(res1, res2)
 
-        # Check the LongTensor case
-        long_m1 = torch.LongTensor(10, 10).random_(-10, 10)
-        long_res1 = long_m1.clone()
-        long_res2 = long_m1.clone()
-        long_qs = torch.arange(-5, 5).long()
-        long_qs[5] = 5  # Can't handle the divisor=0 case
-        for col_idx, long_q in enumerate(long_qs):
-            # Reference
-            for i in range(long_m1.size(0)):
-                long_res2[i, col_idx] = long_res2[i, col_idx] % long_q
-            # To test
-            long_res1[:, col_idx].remainder_(long_q)
-        self.assertEqual(long_res1, long_res2)
-        # Divisor is a tensor case
-        long_res1 = long_m1.clone()
-        long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
+        # Check the LongTensor case, both tensor and scalar overloads
+        for use_item in [True, False]:
+            long_m1 = torch.LongTensor(10, 10).random_(-10, 10)
+            long_res1 = long_m1.clone()
+            long_res2 = long_m1.clone()
+            long_qs = torch.arange(-5, 5).long()
+            long_qs[5] = 5  # Can't handle the divisor=0 case
+            for col_idx, long_q in enumerate(long_qs):
+                # Reference
+                for i in range(long_m1.size(0)):
+                    long_res2[i, col_idx] = long_res2[i, col_idx] % long_q
+                # To test
+                long_res1[:, col_idx].remainder_(long_q if not use_item else long_q.item())
+            self.assertEqual(long_res1, long_res2)
+            # Divisor is a tensor case
+            long_res1 = long_m1.clone()
+            long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
 
     @staticmethod
     def _test_remainder_overflow(self, dtype, device):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -598,7 +598,48 @@ def group_declarations(declarations):
         if 'base' not in dictionary:
             raise RuntimeError('\'base\' not in dictionary', dictionary)
         result.append(dictionary)
-    return result
+    return sort_declarations(result)
+
+
+# This function declares a partial order on declarations, and sorts them according
+# to its linear extension. This is necessary, because there's some ambiguity in the
+# choice of overload, and we want a different order.
+def sort_declarations(grouped_decls):
+    def is_coord_smaller(arg1, arg2):
+        return arg1['dynamic_type'] == 'real' and arg2['dynamic_type'] == 'Tensor'
+
+    def is_smaller(d1, d2):
+        """Returns True if d1 < d2 in the partial order."""
+        args1, args2 = d1['base']['arguments'], d2['base']['arguments']
+        if len(args1) != len(args2):
+            return False
+        any_smaller = any(is_coord_smaller(arg1, arg2) for arg1, arg2 in zip(args1, args2))
+        all_smaller_or_equal = all(arg1['dynamic_type'] == arg2['dynamic_type'] or is_coord_smaller(arg1, arg2)
+                                   for arg1, arg2 in zip(args1, args2))
+        return any_smaller and all_smaller_or_equal
+
+    # Construct the relation graph
+    larger_than = defaultdict(set)
+    for i1, decl1 in enumerate(grouped_decls):
+        for i2, decl2 in enumerate(grouped_decls):
+            if is_smaller(decl1, decl2):
+                larger_than[i1].add(i2)
+
+    if not larger_than:
+        return grouped_decls
+
+    # Use a topological sort to sort decls according to the partial order.
+    sorted_deps = [(i, decl) for i, decl in enumerate(grouped_decls)
+                   if i not in larger_than]
+    for i, decl in sorted_deps:
+        for i2 in sorted(larger_than.keys()):
+            larger = larger_than[i2]
+            larger.discard(i)
+            if not larger:
+                del larger_than[i2]
+                sorted_deps.append((i2, grouped_decls[i2]))
+
+    return [decl for i, decl in sorted_deps]
 
 
 def get_python_signature(declaration, include_out):


### PR DESCRIPTION
This helps resolve ambiguities in argument parsing according to
any rules we will need.

For now, this allows us to make scalar operations more conservarive
wrt. argument types, but makes them commutative again.

@gchanan 