### PR TITLE
Check for g++ also in check_compiler_ABI

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -77,7 +77,7 @@ def check_compiler_abi_compatibility(compiler):
         warnings.warn('Error checking compiler version: {}'.format(error))
     else:
         info = info.decode().lower()
-        if 'gcc' in info:
+        if 'gcc' or 'g++' in info:
             # Sometimes the version is given as "major.x" instead of semver.
             version = re.search(r'(\d+)\.(\d+|x)', info)
             if version is not None:


### PR DESCRIPTION
Otherwise a spurious warning is generated. @goldsborough

