### PR TITLE
Add workaround to fix include warnings in Python 2 builds.

### DIFF
--- a/torch/csrc/DataLoader.h
+++ b/torch/csrc/DataLoader.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 extern PyMethodDef DataLoaderMethods[];

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "torch/csrc/utils/device.h"
 
 struct THPDevice {

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "ATen/ATen.h"
 
 const int DTYPE_NAME_LEN = 64;

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "DynamicTypes.h"
 #include "PythonTypes.h"

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -2,7 +2,7 @@
 
 // Provides conversions between Python tensor objects and at::Tensor.
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include <unordered_map>
 #include <ATen/ATen.h>

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -1,5 +1,5 @@
 #ifndef NO_PYTHON
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include <utility>
 #include <vector>

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 #include "THP_export.h"

--- a/torch/csrc/Layout.h
+++ b/torch/csrc/Layout.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <string>
 
 const int LAYOUT_NAME_LEN = 64;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <sys/types.h>
 
 #ifndef _MSC_VER

--- a/torch/csrc/PtrWrapper.cpp
+++ b/torch/csrc/PtrWrapper.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <functional>
 
 static PyObject* THPWrapperClass = NULL;

--- a/torch/csrc/PtrWrapper.h
+++ b/torch/csrc/PtrWrapper.h
@@ -1,7 +1,7 @@
 #ifndef THP_PTR_WRAPPER_H
 #define THP_PTR_WRAPPER_H
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <functional>
 
 /**

--- a/torch/csrc/PythonTypes.h
+++ b/torch/csrc/PythonTypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "torch/csrc/Types.h"
 
 namespace torch {

--- a/torch/csrc/Size.h
+++ b/torch/csrc/Size.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "stdint.h"
 
 extern PyTypeObject THPSizeType;

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -1,6 +1,6 @@
 #define __STDC_FORMAT_MACROS
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #ifdef _MSC_VER
 #include <Windows.h>
 #endif

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -1,7 +1,7 @@
 #ifndef THP_H
 #define THP_H
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <stdbool.h>
 #include <TH/TH.h>
 #include <THS/THS.h>

--- a/torch/csrc/allocators.cpp
+++ b/torch/csrc/allocators.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "allocators.h"
 #include "torch/csrc/utils/auto_gil.h"

--- a/torch/csrc/allocators.h
+++ b/torch/csrc/allocators.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <type_traits>
 #include <memory>
 

--- a/torch/csrc/autograd/functions/pybind.h
+++ b/torch/csrc/autograd/functions/pybind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/utils/pybind.h"

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -1,6 +1,6 @@
 #include "torch/csrc/autograd/python_cpp_function.h"
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include <stdio.h>
 #include <typeindex>

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include <typeinfo>
 

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/autograd/function.h"
 #include "torch/csrc/autograd/engine.h"

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1,6 +1,6 @@
 #include "torch/csrc/autograd/python_function.h"
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <structmember.h>
 #include <unordered_map>
 #include <unordered_set>

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <vector>
 #include <utility>
 #include <memory>

--- a/torch/csrc/autograd/python_hook.h
+++ b/torch/csrc/autograd/python_hook.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/utils/object_ptr.h"
 

--- a/torch/csrc/autograd/python_legacy_variable.h
+++ b/torch/csrc/autograd/python_legacy_variable.h
@@ -3,7 +3,7 @@
 // Instantiates torch._C._LegacyVariableBase, which defines the Python
 // constructor (__new__) for torch.autograd.Variable.
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include <ATen/ATen.h>
 

--- a/torch/csrc/autograd/python_variable_indexing.h
+++ b/torch/csrc/autograd/python_variable_indexing.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 namespace torch { namespace autograd {
 

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -3,7 +3,7 @@
 // Wrap tensor operation outputs as PyObject*
 
 #include <ATen/ATen.h>
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <tuple>
 
 #include "torch/csrc/Dtype.h"

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include <stdbool.h>
 #include <unordered_map>

--- a/torch/csrc/cuda/Storage.cpp
+++ b/torch/csrc/cuda/Storage.cpp
@@ -1,6 +1,6 @@
 #define __STDC_FORMAT_MACROS
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <structmember.h>
 
 #include <stdbool.h>

--- a/torch/csrc/cuda/Stream.h
+++ b/torch/csrc/cuda/Stream.h
@@ -1,7 +1,7 @@
 #ifndef THCP_STREAM_INC
 #define THCP_STREAM_INC
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <THC/THC.h>
 
 

--- a/torch/csrc/cuda/THCP.h
+++ b/torch/csrc/cuda/THCP.h
@@ -1,7 +1,7 @@
 #ifndef THCP_H
 #define THCP_H
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <TH/TH.h>
 #include <THC/THC.h>
 #include <THC/THCHalf.h>

--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -1,6 +1,6 @@
 #define __STDC_FORMAT_MACROS
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <structmember.h>
 
 #include <TH/THMath.h>

--- a/torch/csrc/cuda/python_nccl.h
+++ b/torch/csrc/cuda/python_nccl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 PyObject * THCPModule_nccl_version(PyObject *self, PyObject *args);
 PyObject * THCPModule_nccl_unique_id(PyObject *self, PyObject *args);

--- a/torch/csrc/cuda/serialization.cpp
+++ b/torch/csrc/cuda/serialization.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "THCP.h"
 

--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <stdarg.h>
 #include <string>
 #include "THCP.h"

--- a/torch/csrc/distributed/Module.cpp
+++ b/torch/csrc/distributed/Module.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include <memory>
 #include <unordered_map>

--- a/torch/csrc/distributed/Storage.cpp
+++ b/torch/csrc/distributed/Storage.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <structmember.h>
 
 #define THP_HOST_HALF

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/jit/export.h"
 #include "torch/csrc/onnx/onnx.h"

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1,5 +1,5 @@
 #ifndef NO_PYTHON
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #endif
 #include "interpreter.h"
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1,5 +1,5 @@
 #ifndef NO_PYTHON
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #endif
 #include "ir.h"
 

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/DynamicTypes.h"

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "python_compiled_function.h"
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/pybind.h"

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/jit/tracer.h"

--- a/torch/csrc/jit/python_tracer.h
+++ b/torch/csrc/jit/python_tracer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include "torch/csrc/jit/tracer.h"
 

--- a/torch/csrc/jit/script/python_tree_views.h
+++ b/torch/csrc/jit/script/python_tree_views.h
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 namespace torch { namespace jit { namespace script {
 

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -1,5 +1,5 @@
 #ifndef NO_PYTHON
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #define REQUIRE JIT_ASSERT
 

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -1,5 +1,5 @@
 #ifndef NO_PYTHON
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #endif
 #include "torch/csrc/jit/tracer.h"
 

--- a/torch/csrc/nvrtc.cpp
+++ b/torch/csrc/nvrtc.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 static PyObject* module;
 

--- a/torch/csrc/python_headers.h
+++ b/torch/csrc/python_headers.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// workaround for Python 2 issue: https://bugs.python.org/issue17120
+#pragma push_macro("_XOPEN_SOURCE")
+#pragma push_macro("_POSIX_C_SOURCE")
+#undef _XOPEN_SOURCE
+#undef _POSIX_C_SOURCE
+
+#include <Python.h>
+
+#pragma pop_macro("_XOPEN_SOURCE")
+#pragma pop_macro("_POSIX_C_SOURCE")

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <system_error>
 
 #include "THP.h"

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 namespace torch { namespace tensor {

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <stdarg.h>
 #include <string>
 #include <vector>

--- a/torch/csrc/utils/auto_gil.h
+++ b/torch/csrc/utils/auto_gil.h
@@ -2,7 +2,7 @@
 
 // RAII structs to acquire and release Python's global interpreter lock (GIL)
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 // Acquires the GIL on construction
 struct AutoGIL {

--- a/torch/csrc/utils/cuda_lazy_init.cpp
+++ b/torch/csrc/utils/cuda_lazy_init.cpp
@@ -1,6 +1,6 @@
 #include "cuda_lazy_init.h"
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <mutex>
 
 #include "torch/csrc/Exceptions.h"

--- a/torch/csrc/utils/invalid_arguments.h
+++ b/torch/csrc/utils/invalid_arguments.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <string>
 #include <vector>
 

--- a/torch/csrc/utils/numpy_stub.h
+++ b/torch/csrc/utils/numpy_stub.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #ifdef WITH_NUMPY
 

--- a/torch/csrc/utils/object_ptr.cpp
+++ b/torch/csrc/utils/object_ptr.cpp
@@ -1,6 +1,6 @@
 #include "torch/csrc/utils/object_ptr.h"
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 template<>
 void THPPointer<PyObject>::free() {

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -20,7 +20,7 @@
 //   }
 
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <string>
 #include <sstream>
 #include <vector>

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 // https://bugsfiles.kde.org/attachment.cgi?id=61186
 #if PY_VERSION_HEX >= 0x03020000

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <stdint.h>
 #include <stdexcept>
 #include "torch/csrc/Exceptions.h"

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 
 #include "python_numbers.h"
 #include "torch/csrc/Exceptions.h"

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <stdexcept>
 #include <string>
 #include "object_ptr.h"

--- a/torch/csrc/utils/python_tuples.h
+++ b/torch/csrc/utils/python_tuples.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "torch/csrc/Exceptions.h"
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_numbers.h"

--- a/torch/csrc/utils/tensor_apply.h
+++ b/torch/csrc/utils/tensor_apply.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 namespace torch { namespace utils {

--- a/torch/csrc/utils/tensor_dtypes.cpp
+++ b/torch/csrc/utils/tensor_dtypes.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "tensor_dtypes.h"
 #include "torch/csrc/Dtype.h"
 #include "torch/csrc/DynamicTypes.h"

--- a/torch/csrc/utils/tensor_layouts.cpp
+++ b/torch/csrc/utils/tensor_layouts.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 #include "tensor_layouts.h"
 #include "torch/csrc/DynamicTypes.h"

--- a/torch/csrc/utils/tensor_list.h
+++ b/torch/csrc/utils/tensor_list.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 namespace torch { namespace utils {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include "tensor_new.h"
 
 #include <ATen/ATen.h>

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 namespace torch { namespace utils {

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <ATen/ATen.h>
 
 namespace torch { namespace utils {

--- a/torch/csrc/utils/tuple_parser.h
+++ b/torch/csrc/utils/tuple_parser.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Python.h>
+#include "torch/csrc/python_headers.h"
 #include <memory>
 #include <vector>
 #include <ATen/ATen.h>


### PR DESCRIPTION
This prevents warnings like:

```
[1/1] gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall ...H_CUDNN -MMD -MF build/temp.linux-x86_64-2.7/torch/csrc/jit/script/compiler.d
In file included from /home/zdevito/local/anaconda2/include/python2.7/Python.h:8:0,
                 from /data/users/zdevito/pytorch/torch/csrc/utils/pybind.h:3,
                 from /data/users/zdevito/pytorch/torch/csrc/jit/tracer.h:12,
                 from /data/users/zdevito/pytorch/torch/csrc/autograd/function.h:9,
                 from /data/users/zdevito/pytorch/torch/csrc/jit/generated/aten_dispatch.h:3,
                 from torch/csrc/jit/script/compiler.cpp:3:
/home/zdevito/local/anaconda2/include/python2.7/pyconfig.h:1190:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
```
for compilation units that do not include Python.h first.

Using CI to see if this works with all of our compilers.