### PR TITLE
[WIP] added CPU implementation of torch.flip function

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -535,13 +535,13 @@
   variants: function
 
 - func: randint_out(Tensor result, int64_t low, int64_t high, IntList size, *, Generator* generator=nullptr) -> Tensor
-  variants: function  
+  variants: function
 
 - func: randint_like(Tensor self, int64_t high) -> Tensor
   variants: function
 
 - func: randint_like(Tensor self, int64_t low, int64_t high) -> Tensor
-  variants: function  
+  variants: function
 
 - func: randint_like(Tensor self, int64_t high, *, Type dtype) -> Tensor
   variants: function
@@ -759,6 +759,8 @@
 
 - func: transpose_(Tensor self, int64_t dim0, int64_t dim1) -> Tensor
   variants: method
+
+- func: flip(Tensor self, IntList dims) -> Tensor
 
 - func: _trilinear(Tensor i1, Tensor i2, Tensor i3, IntList expand1, IntList expand2, IntList expand3, IntList sumdim, int64_t unroll_dim=1) -> Tensor
   variants: function

--- a/caffe2/mobile/contrib/ulp2/ulp.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp.cc
@@ -292,7 +292,7 @@ std::unique_ptr<QConvState> create2b1bConvState(Workspace* ws,
 }
 
 void run2b1bConvGeneric(QConvState* state, const ConvArgs& args, const TensorCPU& X, TensorCPU* Y) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   if (run2b1bConvNeon(state, args, X, Y)) {
     return;
   }

--- a/caffe2/mobile/contrib/ulp2/ulp_neon.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_neon.cc
@@ -8,7 +8,7 @@ namespace caffe2 {
 // devices (Snapdragon 820).
 constexpr size_t kL1CacheSizeBytes = 16 * 1024;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 // Applies 2-bit uniform quantization to the floating point data at Xdata,
 // storing QC bytes into XQdata (i.e. reading 8 * QC floats from Xdata).

--- a/caffe2/operators/collect_and_distribute_fpn_rpn_proposals_op.cc
+++ b/caffe2/operators/collect_and_distribute_fpn_rpn_proposals_op.cc
@@ -52,7 +52,10 @@ void SortAndLimitRoIsByScores(Eigen::Ref<const EArrXf> scores, int n,
   // Reuse a comparator based on scores and store a copy of RoIs that
   // will be truncated and manipulated below
   auto comp = [&scores](int lhs, int rhs) {
-    return scores(lhs) > scores(rhs);
+    if (scores(lhs) > scores(rhs)) return true;
+    if (scores(lhs) < scores(rhs)) return false;
+    // To ensure the sort is stable
+    return lhs < rhs;
   };
   ERArrXXf rois_copy = rois;
   // Note that people have found nth_element + sort to be much faster

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -38,7 +38,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const int input_image_size = H * W;
   const int output_image_size = Y->dim32(2) * Y->dim32(3);
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   if (InputSize() == 3) {
     auto& bias = Input(BIAS);
     CAFFE_ENFORCE(bias.ndim() == 1, "bias must be 1D tensor");
@@ -55,7 +55,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
           &context_);
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
   const T* Xdata = X.template data<T>();
   const T* filter_data = filter.template data<T>();
@@ -102,7 +102,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       // Bias term
       if (InputSize() == 3) {
         const T* bias_data = Input(BIAS).template data<T>();
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
         const T* bm_data = bias_multiplier_.template data<T>();
         math::Gemm<T, Context>(
             CblasNoTrans,
@@ -123,7 +123,7 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
             output_image_size,
             Ydata,
             &context_);
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
       }
 
       Xdata += M * H * W;

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -115,7 +115,7 @@ void runTileContiguous(
         Ydata + c_im * outputH * (colBlockSize * numColBlocks) + offsetY;
 
     int b = 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     // We vectorize the loop within the row
     {
       constexpr int kUnroll = (sizeof(float32x4_t) / sizeof(float)) * 4;
@@ -179,7 +179,7 @@ struct StoreInterleaved {};
 
 template <>
 struct StoreInterleaved<float, 1> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[1]) {
     vst1q_f32(p, v[0]);
   }
@@ -192,7 +192,7 @@ struct StoreInterleaved<float, 1> {
 
 template <>
 struct StoreInterleaved<float, 2> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[2]) {
     float32x4x2_t x = {{v[0], v[1]}};
     vst2q_f32(p, x);
@@ -207,7 +207,7 @@ struct StoreInterleaved<float, 2> {
 
 template <>
 struct StoreInterleaved<float, 3> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[3]) {
     float32x4x3_t x = {{v[0], v[1], v[2]}};
     vst3q_f32(p, x);
@@ -223,7 +223,7 @@ struct StoreInterleaved<float, 3> {
 
 template <>
 struct StoreInterleaved<float, 4> {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   inline static void store(float* p, float32x4_t v[4]) {
     float32x4x4_t x = {{v[0], v[1], v[2], v[3]}};
     vst4q_f32(p, x);
@@ -264,12 +264,12 @@ void reinterleaveRows(
   dst += point * outputW;
 
   float b = bias ? bias[c] : 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   float32x4_t biasV = vdupq_n_f32(b);
 #endif
 
   int w = 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   constexpr int kUnroll = (sizeof(float32x4_t) / sizeof(float)) * 2;
   int limit = ((inputW - 1) / kUnroll) * kUnroll;
 
@@ -394,7 +394,7 @@ void reinterleaveMultithreaded(
   pool->run(fnReinterleave, totalTiles);
 }
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 template <int N>
 struct SumMultiple {
   static void sumInto(float* acc, float** toSum, size_t size);
@@ -505,7 +505,7 @@ struct SumMultiple<3> {
 
 // Performs acc[i] += sum_j toSum_j[i] pointwise
 void sumInto(float* acc, std::vector<float*>& toSum, size_t size) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   if (toSum.size() == 1) {
     SumMultiple<1>::sumInto(acc, toSum.data(), size);
     return;

--- a/caffe2/operators/conv_transpose_op_mobile_test.cc
+++ b/caffe2/operators/conv_transpose_op_mobile_test.cc
@@ -169,7 +169,7 @@ int randInt(int a, int b) {
 }
 
 // TODO(#14383029) cblas_sgemm not yet implemented on limited mobile cases.
-#if __ARM_NEON__ && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
 TEST(ConvTransposeMobile, Test) {
   for (int i = 0; i < 10; ++i) {
     int n = randInt(1, 3);

--- a/caffe2/operators/pool_op.cc
+++ b/caffe2/operators/pool_op.cc
@@ -9,7 +9,7 @@ using std::min;
 
 namespace {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 bool isNeon4x4p0s0Eligible(
     int inputH,
@@ -303,7 +303,7 @@ void runNeonMaxPool2x2p0s0NCHW(
     }
   }
 }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 } // namespace
 
@@ -354,7 +354,7 @@ class AveragePool {
       int dilationW,
       const float* input,
       float* output) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     if (isNeon4x4p0s0Eligible(
             inputH,
             inputW,
@@ -446,7 +446,7 @@ class MaxPool {
       int dilationW,
       const float* input,
       float* output) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     if (isNeon2x2p0s0Eligible(
             inputH,
             inputW,

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -6,7 +6,7 @@
 
 namespace caffe2 {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 namespace {
 
 void runNeonPrelu(float* out, const float* in, int size, float w) {
@@ -91,7 +91,7 @@ void runNeonPrelu(float* out, const float* in, int size, float w) {
 }
 
 }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 template <>
 bool PReluOp<float, CPUContext>::RunOnDevice() {
@@ -111,14 +111,14 @@ bool PReluOp<float, CPUContext>::RunOnDevice() {
   }
 
   if (C_shared) {
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     // The function is completely pointwise
     runNeonPrelu(Ydata, Xdata, X.size(), Wdata[0]);
 #else
     ConstEigenVectorMap<float> Xvec(Xdata, X.size());
     EigenVectorMap<float> Yvec(Ydata, Y->size());
     Yvec = Xvec.cwiseMax(0.f) + Xvec.cwiseMin(0.f) * Wdata[0];
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
     return true;
   }
 
@@ -128,7 +128,7 @@ bool PReluOp<float, CPUContext>::RunOnDevice() {
       const auto N = X.dim(0);
       const auto dim = X.size_from_dim(2);
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       // Pointwise for each channel
       for (int n = 0; n < N; ++n) {
         for (int c = 0; c < C; ++c) {

--- a/caffe2/operators/resize_op.cc
+++ b/caffe2/operators/resize_op.cc
@@ -19,7 +19,7 @@ void resizeNearest2x(
       for (int y = 0; y < output_height; ++y) {
         const int in_y = y / 2;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
         int vecW = (input_width / 4) * 4; // round down
         int x = 0;
         for (; x < vecW; x += 4) {

--- a/caffe2/operators/stylizer_ops.cc
+++ b/caffe2/operators/stylizer_ops.cc
@@ -4,7 +4,7 @@
 
 namespace caffe2 {
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 namespace {
 
 //
@@ -49,7 +49,7 @@ inline uint8x8_t convertNarrowAndPack(float32x4_t v0, float32x4_t v1) {
 }
 
 } // unnamed namespace
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     : public Operator<CPUContext> {
@@ -82,7 +82,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       // Cache it to maintain temporal consistency.
       auto* t = noiseBlob->template GetMutable<TensorCPU>();
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       // Noise space is larger for vectorized code due to the
       // vectorized load
       initNoiseCPUNeon(t, defaultNoiseSize);
@@ -115,7 +115,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
     return true;
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void initNoiseCPU(Tensor<CPUContext>* noise, int size) {
     noise->Resize(size);
 
@@ -126,9 +126,9 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
         noise->template mutable_data<float>(),
         &context_);
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void initNoiseCPUNeon(Tensor<CPUContext>* noise, int size) {
     // For ARM NEON, we read in multiples of kNeonNoiseReadSize since
     // the inner loop is vectorized. Round up to the next highest
@@ -143,7 +143,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
         noise->template mutable_data<float>(),
         &context_);
   }
-#endif // __ARM_NEON
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
   void runBatch(
       int N,
@@ -161,15 +161,15 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       auto curInput = input + n * kInputChannels * planeSize;
       auto curOutput = output + n * kOutputChannels * planeSize;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       runCPUNeon(H, W, noiseCycle, curInput, meanChannel, noise, curOutput);
 #else
       runCPU(H, W, noiseCycle, curInput, meanChannel, noise, curOutput);
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
     }
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void runCPU(
       int H,
       int W,
@@ -192,9 +192,9 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       }
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void runCPUNeon(
       int H,
       int W,
@@ -373,7 +373,7 @@ class PackedInt8BGRANHWCToNCHWCStylizerPreprocessOp
       }
     }
   }
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
 
  private:
   Workspace* ws_;
@@ -443,15 +443,15 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
       auto curInput = input + n * kInputChannels * planeSize;
       auto curOutput = output + n * kOutputChannels * planeSize;
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
       runCPUNeon(H, W, curInput, meanChannel, curOutput);
 #else
       runCPU(H, W, curInput, meanChannel, curOutput);
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
     }
   }
 
-#ifndef __ARM_NEON__
+#if !defined(__ARM_NEON__) && !defined(__ARM_NEON)
   void runCPU(
       int H,
       int W,
@@ -472,9 +472,9 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
           std::numeric_limits<uint8_t>::max();
     }
   }
-#endif // !__ARM_NEON__
+#endif // !defined(__ARM_NEON__) && !defined(__ARM_NEON)
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
   void runCPUNeon(
       int H,
       int W,
@@ -563,7 +563,7 @@ class BRGNCHWCToPackedInt8BGRAStylizerDeprocessOp
           std::numeric_limits<uint8_t>::max();
     }
   }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 };
 
 namespace {

--- a/caffe2/python/operator_test/collect_and_distribute_fpn_rpn_proposals_op_test.py
+++ b/caffe2/python/operator_test/collect_and_distribute_fpn_rpn_proposals_op_test.py
@@ -6,18 +6,12 @@ from __future__ import unicode_literals
 import numpy as np
 import unittest
 
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
 import caffe2.python.hypothesis_test_util as hu
 from caffe2.python import core, utils
 from caffe2.proto import caffe2_pb2
-
-ROI_CANONICAL_SCALE = 224  # default: 224
-ROI_CANONICAL_LEVEL = 4  # default: 4
-ROI_MAX_LEVEL = 5  # default: 5
-ROI_MIN_LEVEL = 2  # default: 2
-RPN_MAX_LEVEL = 6  # default: 6
-RPN_MIN_LEVEL = 2  # default: 2
-RPN_POST_NMS_TOP_N = 2000  # default: 2000
-
 
 #
 # Should match original Detectron code at
@@ -33,26 +27,27 @@ def boxes_area(boxes):
     return areas
 
 
-def map_rois_to_fpn_levels(rois, k_min, k_max):
+def map_rois_to_fpn_levels(
+    rois,
+    k_min, k_max,
+    roi_canonical_scale, roi_canonical_level):
     """Determine which FPN level each RoI in a set of RoIs should map to based
     on the heuristic in the FPN paper.
     """
     # Compute level ids
     s = np.sqrt(boxes_area(rois))
-    s0 = ROI_CANONICAL_SCALE
-    lvl0 = ROI_CANONICAL_LEVEL
 
     # Eqn.(1) in FPN paper
-    target_lvls = np.floor(lvl0 + np.log2(s / s0 + 1e-6))
+    target_lvls = np.floor(
+        roi_canonical_level +
+        np.log2(s / roi_canonical_scale + 1e-6))
     target_lvls = np.clip(target_lvls, k_min, k_max)
     return target_lvls
 
 
-def collect(inputs):
-    post_nms_topN = RPN_POST_NMS_TOP_N
-    k_max = RPN_MAX_LEVEL
-    k_min = RPN_MIN_LEVEL
-    num_lvls = k_max - k_min + 1
+def collect(inputs, **args):
+    post_nms_topN = args['post_nms_topN']
+    num_lvls = args['rpn_num_levels']
     roi_inputs = inputs[:num_lvls]
     score_inputs = inputs[num_lvls:]
 
@@ -65,21 +60,25 @@ def collect(inputs):
     rois = np.concatenate(roi_inputs)
     scores = np.concatenate(score_inputs).squeeze()
     assert rois.shape[0] == scores.shape[0]
-    inds = np.argsort(-scores)[:post_nms_topN]
+    inds = np.argsort(-scores, kind='mergesort')[:post_nms_topN]
     rois = rois[inds, :]
     return rois
 
 
-def distribute(rois, _, outputs):
+def distribute(rois, _, outputs, **args):
     """To understand the output blob order see return value of
     roi_data.fast_rcnn.get_fast_rcnn_blob_names(is_training=False)
     """
     # equivalent to Detectron code
     #   lvl_min = cfg.FPN.ROI_MIN_LEVEL
     #   lvl_max = cfg.FPN.ROI_MAX_LEVEL
-    lvl_min = ROI_MIN_LEVEL
-    lvl_max = ROI_MAX_LEVEL
-    lvls = map_rois_to_fpn_levels(rois[:, 1:5], lvl_min, lvl_max)
+    lvl_min = args['roi_min_level']
+    lvl_max = lvl_min + args['roi_num_levels'] - 1
+    lvls = map_rois_to_fpn_levels(
+        rois[:, 1:5],
+        lvl_min, lvl_max,
+        args['roi_canonical_scale'],
+        args['roi_canonical_level'])
 
     # equivalent to Detectron code
     #   outputs[0].reshape(rois.shape)
@@ -98,7 +97,7 @@ def distribute(rois, _, outputs):
         #   outputs[output_idx + 1].data[...] = blob_roi_level
         outputs[output_idx + 1] = blob_roi_level
         rois_idx_order = np.concatenate((rois_idx_order, idx_lvl))
-    rois_idx_restore = np.argsort(rois_idx_order)
+    rois_idx_restore = np.argsort(rois_idx_order, kind='mergesort')
     # equivalent to Detectron code
     #   py_op_copy_blob(
     #       rois_idx_restore.astype(np.int32), outputs[-1])
@@ -107,7 +106,10 @@ def distribute(rois, _, outputs):
 
 def collect_and_distribute_fpn_rpn_ref(*inputs):
     assert inputs
-    num_rpn_lvls = RPN_MAX_LEVEL - RPN_MIN_LEVEL + 1
+    args = inputs[-1]
+    inputs = inputs[:-1]
+
+    num_rpn_lvls = args['rpn_num_levels']
     assert len(inputs) == 2 * num_rpn_lvls
     N = inputs[0].shape[0]
     for i in range(num_rpn_lvls):
@@ -118,25 +120,41 @@ def collect_and_distribute_fpn_rpn_ref(*inputs):
         assert len(inputs[i].shape) == 1
         assert inputs[i].shape[0] == N
 
-    num_roi_lvls = ROI_MAX_LEVEL - ROI_MIN_LEVEL + 1
+    num_roi_lvls = args['roi_num_levels']
     outputs = (num_roi_lvls + 2) * [None]
-    rois = collect(inputs)
-    distribute(rois, None, outputs)
+    rois = collect(inputs, **args)
+    distribute(rois, None, outputs, **args)
 
     return outputs
 
 
 class TestCollectAndDistributeFpnRpnProposals(hu.HypothesisTestCase):
-    def run_on_device(self, device_opts):
+    @given(proposal_count=st.integers(min_value=1000, max_value=8000),
+           rpn_min_level=st.integers(min_value=1, max_value=4),
+           rpn_num_levels=st.integers(min_value=1, max_value=6),
+           roi_min_level=st.integers(min_value=1, max_value=4),
+           roi_num_levels=st.integers(min_value=1, max_value=6),
+           post_nms_topN=st.integers(min_value=1000, max_value=4000),
+           roi_canonical_scale=st.integers(min_value=100, max_value=300),
+           roi_canonical_level=st.integers(min_value=1, max_value=8),
+           **hu.gcs_cpu_only)
+    def test_collect_and_dist(
+        self,
+        proposal_count,
+        rpn_min_level, rpn_num_levels,
+        roi_min_level, roi_num_levels,
+        post_nms_topN,
+        roi_canonical_scale, roi_canonical_level,
+        gc, dc):
+
         np.random.seed(0)
 
-        proposal_count = 5000
         input_names = []
         inputs = []
 
-        for lvl in range(RPN_MIN_LEVEL, RPN_MAX_LEVEL + 1):
+        for lvl in range(rpn_num_levels):
             rpn_roi = (
-                ROI_CANONICAL_SCALE *
+                roi_canonical_scale *
                 np.random.rand(proposal_count, 5).astype(np.float32)
             )
             for i in range(proposal_count):
@@ -144,18 +162,18 @@ class TestCollectAndDistributeFpnRpnProposals(hu.HypothesisTestCase):
                 # are in the format [[batch_idx, x0, y0, x1, y2], ...]
                 rpn_roi[i][3] += rpn_roi[i][1]
                 rpn_roi[i][4] += rpn_roi[i][2]
-            input_names.append('rpn_rois_fpn{}'.format(lvl))
+            input_names.append('rpn_rois_fpn{}'.format(lvl + rpn_min_level))
             inputs.append(rpn_roi)
-        for lvl in range(RPN_MIN_LEVEL, RPN_MAX_LEVEL + 1):
+        for lvl in range(rpn_num_levels):
             rpn_roi_score = np.random.rand(proposal_count).astype(np.float32)
-            input_names.append('rpn_roi_probs_fpn{}'.format(lvl))
+            input_names.append('rpn_roi_probs_fpn{}'.format(lvl + rpn_min_level))
             inputs.append(rpn_roi_score)
 
         output_names = [
             'rois',
         ]
-        for lvl in range(ROI_MIN_LEVEL, ROI_MAX_LEVEL + 1):
-            output_names.append('rois_fpn{}'.format(lvl))
+        for lvl in range(roi_num_levels):
+            output_names.append('rois_fpn{}'.format(lvl + roi_min_level))
         output_names.append('rois_idx_restore')
 
         op = core.CreateOperator(
@@ -163,26 +181,31 @@ class TestCollectAndDistributeFpnRpnProposals(hu.HypothesisTestCase):
             input_names,
             output_names,
             arg=[
-                utils.MakeArgument("roi_canonical_scale", ROI_CANONICAL_SCALE),
-                utils.MakeArgument("roi_canonical_level", ROI_CANONICAL_LEVEL),
-                utils.MakeArgument("roi_max_level", ROI_MAX_LEVEL),
-                utils.MakeArgument("roi_min_level", ROI_MIN_LEVEL),
-                utils.MakeArgument("rpn_max_level", RPN_MAX_LEVEL),
-                utils.MakeArgument("rpn_min_level", RPN_MIN_LEVEL),
-                utils.MakeArgument("post_nms_topN", RPN_POST_NMS_TOP_N),
+                utils.MakeArgument("roi_canonical_scale", roi_canonical_scale),
+                utils.MakeArgument("roi_canonical_level", roi_canonical_level),
+                utils.MakeArgument("roi_max_level", roi_min_level + roi_num_levels - 1),
+                utils.MakeArgument("roi_min_level", roi_min_level),
+                utils.MakeArgument("rpn_max_level", rpn_min_level + rpn_num_levels - 1),
+                utils.MakeArgument("rpn_min_level", rpn_min_level),
+                utils.MakeArgument("post_nms_topN", post_nms_topN),
             ],
-            device_option=device_opts)
+            device_option=gc)
+        args = {
+            'proposal_count' : proposal_count,
+            'rpn_min_level' : rpn_min_level,
+            'rpn_num_levels' : rpn_num_levels,
+            'roi_min_level' : roi_min_level,
+            'roi_num_levels' : roi_num_levels,
+            'post_nms_topN' : post_nms_topN,
+            'roi_canonical_scale' : roi_canonical_scale,
+            'roi_canonical_level' : roi_canonical_level}
 
         self.assertReferenceChecks(
-            device_option=device_opts,
+            device_option=gc,
             op=op,
-            inputs=inputs,
+            inputs=inputs+[args],
             reference=collect_and_distribute_fpn_rpn_ref,
         )
-
-    def test_cpu(self):
-        device_opts_cpu = caffe2_pb2.DeviceOption()
-        self.run_on_device(device_opts_cpu)
 
 
 if __name__ == "__main__":

--- a/caffe2/utils/cpu_neon.h
+++ b/caffe2/utils/cpu_neon.h
@@ -2,7 +2,7 @@
 #define CAFFE2_UTILS_CPU_NEON_H_
 
 // Provides a variety of ARM NEON-specific utility functions
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 
 namespace caffe2 {
@@ -48,6 +48,6 @@ inline void vst4_u8_aligned(uint8_t* p, uint8x8x4_t v) {
 
 }  // namespace caffe2
 
-#endif // __ARM_NEON__
+#endif //  defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 #endif  // CAFFE2_UTILS_CPU_NEON_H_

--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -1786,7 +1786,7 @@ void BiasCHW<float, CPUContext>(
   for (int c = 0; c < bias_channels; ++c) {
     float b = bias[c];
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
     float32x4_t vBias = vdupq_n_f32(b);
 
     // We give alignment hints for additional speed, so handle the
@@ -1853,7 +1853,7 @@ void BiasCHW<float, CPUContext>(
     for (int i = 0; i < image_size; ++i) {
       image[i] += b;
     }
-#endif // __ARM_NEON__
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
     image += image_size;
   }

--- a/caffe2/utils/math_gpu_test.cc
+++ b/caffe2/utils/math_gpu_test.cc
@@ -454,6 +454,9 @@ TEST_F(ReduceTensorGPUTest, ReduceMinGPUTest) {
 }
 
 TEST_F(ReduceTensorGPUTest, ReduceMaxGPUTest) {
+  if (!HasCudaGPU()) {
+    return;
+  }
   const auto& reduce_max = [](const int num_dims,
                               const int* dims,
                               const int num_axes,

--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -4,10 +4,10 @@ torch.utils.bottleneck
 .. currentmodule:: torch.utils.bottleneck
 
 `torch.utils.bottleneck` is a tool that can be used as an initial step for
-debugging bottlenecks in your program. It summarizes runs of your script with 
-the Python profiler and PyTorch's autograd profiler. 
+debugging bottlenecks in your program. It summarizes runs of your script with
+the Python profiler and PyTorch's autograd profiler.
 
-Run it on the command line with 
+Run it on the command line with
 
 ::
 
@@ -17,15 +17,38 @@ where [args] are any number of arguments to `script.py`, or run
 ``python -m torch.utils.bottleneck -h`` for more usage instructions.
 
 .. warning::
-    Because your script will be profiled, please ensure that it exits in a 
+    Because your script will be profiled, please ensure that it exits in a
     finite amount of time.
 
 .. warning::
     Due to the asynchronous nature of CUDA kernels, when running against
     CUDA code, the cProfile output and CPU-mode autograd profilers may
-    not show correct timings. In this case, the CUDA-mode autograd
-    profiler is better at assigning blame to the relevant operator(s).
+    not show correct timings: the reported CPU time reports the amount of time
+    used to launch the kernels but does not include the time the kernel
+    spent executing on a GPU unless the operation does a synchronize.
+    In this case, the CUDA-mode autograd profiler may be helpful.
+
+.. warning::
+    To decide which (CPU-only-mode or CUDA-mode) autograd profiler output to
+    look at, you should first check if your script is CPU-bound
+    ("CPU total time is much greater than CUDA total time").
+    If it is CPU-bound, looking at the results of the CPU-mode autograd
+    profiler will help. If on the other hand your script spends most of its
+    time executing on the GPU, then it makes sense to start
+    looking for responsible CUDA operators in the output of the CUDA-mode
+    autograd profiler.
+
+    Of course the reality is much more complicated and your script might not be
+    in one of those two extremes depending on the part of the model you're
+    evaluating. If the profiler outputs don't help, you could try looking at
+    the result of :func:`torch.autograd.profiler.emit_nvtx()` with ``nvprof``.
+
+.. warning::
+    If you are profiling CUDA code, the first profiler that ``bottleneck`` runs
+    (cProfile) will include the CUDA startup time (CUDA buffer allocation cost)
+    in its time reporting. This should not matter if your bottlenecks result
+    in code much slower than the CUDA startup time.
 
 For more complicated uses of the profilers (like in a multi-GPU case),
 please see https://docs.python.org/3/library/profile.html
-or :func:`torch.autograd.profiler.profile()` for more information. 
+or :func:`torch.autograd.profiler.profile()` for more information.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1709,6 +1709,24 @@ class TestAutograd(TestCase):
         out.sum().backward()
         self.assertEqual(x.grad.data, y_data)
 
+    def test_flip(self):
+        x = torch.autograd.Variable(torch.Tensor([0,1,2,3]).view(2, 2), requires_grad=True)
+        y = x.flip([0])
+        self.assertEqual(torch.Tensor([2,3,0,1]).view(2, 2), y)
+        z = y * y
+        out = z.sum()
+        out.backward()
+        self.assertEqual(torch.Tensor([0,2,4,6]).view(2, 2), x.grad)
+
+        # test cuda backward
+        x_cuda = torch.autograd.Variable(torch.Tensor([0,1,2,3]).view(2, 2).cuda(), requires_grad=True)
+        y_cuda = x_cuda.flip([0])
+        self.assertEqual(torch.Tensor([2,3,0,1]).view(2, 2), y_cuda)
+        z_cuda = y_cuda * y_cuda
+        out_cuda = z_cuda.sum()
+        out_cuda.backward()
+        self.assertEqual(torch.Tensor([0,2,4,6]).view(2, 2), x_cuda.grad)
+
     def test_cat(self):
         f_args_variable = (torch.randn(1, S, S, requires_grad=True),
                            torch.randn(2, S, S, requires_grad=True),

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -227,6 +227,8 @@ def new_t(*sizes):
 # - postfix name for the test (must be unique for a given function) (default='')
 # - tensor types to use (default=types)
 # - disable inplace test, if set to True, no inplace test will be done (default=False)
+
+# name, constr, arg_constr, desc, type_subset, no_inplace
 tests = [
     ('add', small_3d, lambda t: [number(3.14, 3, t)]),
     ('add', small_3d, lambda t: [small_3d_positive(t)], 'tensor'),
@@ -1308,6 +1310,9 @@ class TestCuda(TestCase):
 
     def test_view(self):
         TestTorch._test_view(self, lambda t: t.cuda())
+
+    def test_flip(self):
+        TestTorch._test_flip(self, use_cuda=True)
 
     def test_fft_ifft_rfft_irfft(self):
         def cuda_randn_double(*sizes):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5469,6 +5469,25 @@ class TestTorch(TestCase):
         self.assertEqual(perm, new)
         self.assertEqual(x.size(), orig)
 
+    @staticmethod
+    def _test_flip(self, use_cuda=False):
+        if use_cuda and torch.cuda.is_available():
+            x = torch.Tensor([1,2,3,4,5,6,7,8]).view(2, 2, 2).cuda()
+        else:
+            x = torch.Tensor([1,2,3,4,5,6,7,8]).view(2, 2, 2)
+
+        x_flip_0 = x.flip([0])
+        self.assertEqual(torch.Tensor([5,6,7,8,1,2,3,4]).view(2, 2, 2), x_flip_0)
+
+        x_flip_01 = x.flip([0,1])
+        self.assertEqual(torch.Tensor([7,8,5,6,3,4,1,2]).view(2, 2, 2), x_flip_01)
+
+        x_flip_012 = x.flip([0,1,2])
+        self.assertEqual(torch.Tensor([8,7,6,5,4,3,2,1]).view(2, 2, 2), x_flip_012)
+
+    def test_flip(self):
+        self._test_flip(self, use_cuda=False)
+
     def test_storage(self):
         v = torch.randn(3, 5)
         self.assertEqual(v.storage()[0], v.data[0][0])

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -616,6 +616,9 @@
 - name: t(Tensor self)
   self: grad.t()
 
+- name: flip(Tensor self, IntList dims)
+  self: flip_backward(grad, dims)
+
 - name: take(Tensor self, Tensor index)
   self: zeros_like(self).put_(index, grad, true)
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -142,6 +142,14 @@ Tensor reverse_dim(const Tensor& t, int64_t dim) {
   return t.index_select(dim, index);
 }
 
+Tensor flip_backward(const Tensor& grad, IntList dims) {
+  Tensor res = grad.clone();
+  for (auto d : dims) {
+    res.copy_(reverse_dim(res, d));
+  }
+  return res;
+}
+
 Tensor prod_safe_zeros_backward(const Tensor &grad, const Tensor& inp, int64_t dim) {
   if (inp.size(dim) == 1) {
     return grad;

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -353,6 +353,23 @@ cross(other, dim=-1) -> Tensor
 See :func:`torch.cross`
 """)
 
+add_docstr_all('cuda',
+               r"""
+cuda(device=None, non_blocking=False) -> Tensor
+
+Returns a copy of this object in CUDA memory.
+
+If this object is already in CUDA memory and on the correct device,
+then no copy is performed and the original object is returned.
+
+Args:
+    device (:class:`torch.device`): The destination GPU device.
+        Defaults to the current CUDA device.
+    non_blocking (bool): If ``True`` and the source is in pinned memory,
+        the copy will be asynchronous with respect to the host.
+        Otherwise, the argument has no effect. Default: ``False``.
+""")
+
 add_docstr_all('cumprod',
                r"""
 cumprod(dim) -> Tensor

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -275,11 +275,12 @@ class Module(object):
         r"""Moves and/or casts the parameters and buffers.
 
         This can be called with a :attr:`device` argument and/or a :attr:`dtype`
-        argument, and has the exact signature as :meth:`torch.Tensor.to`, except
-        that this method only takes in floating point :attr:`dtype`, and will
-        only cast the floating point parameters and buffers to :attr:`dtype`. It
-        will still move the integral parameters and buffers to :attr:`device`,
-        if that is given. See below for examples.
+        argument. It has similar signature as :meth:`torch.Tensor.to`, except
+        that this method doesn't take in :attr:`requires_grad` and only takes in
+        floating point :attr:`dtype` s. In particular, this method will only
+        cast the floating point parameters and buffers to :attr:`dtype`. It will
+        still move the integral parameters and buffers to :attr:`device`, if
+        that is given. See below for examples.
 
         Returns:
             Module: self

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,0 +1,47 @@
+import os
+import time
+
+
+class FileBaton:
+    '''A primitive, file-based synchronization utility.'''
+
+    def __init__(self, lock_file_path, wait_seconds=0.1):
+        '''
+        Creates a new :class:`FileBaton`.
+
+        Args:
+            lock_file_path: The path to the file used for locking.
+            wait_seconds: The seconds to periorically sleep (spin) when
+                calling ``wait()``.
+        '''
+        self.lock_file_path = lock_file_path
+        self.wait_seconds = wait_seconds
+        self.fd = None
+
+    def try_acquire(self):
+        '''
+        Tries to atomically create a file under exclusive access.
+
+        Returns:
+            True if the file could be created, else False.
+        '''
+        try:
+            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
+            return True
+        except FileExistsError:
+            return False
+
+    def wait(self):
+        '''
+        Periodically sleeps for a certain amount until the baton is released.
+
+        The amount of time slept depends on the ``wait_seconds`` parameter
+        passed to the constructor.
+        '''
+        while os.path.exists(self.lock_file_path):
+            time.sleep(self.wait_seconds)
+
+    def release(self):
+        '''Releaes the baton and removes its file.'''
+        os.close(self.fd)
+        os.remove(self.lock_file_path)


### PR DESCRIPTION
Summary:
1. added CPU implementation of torch.flip to flip a tensor
2. added tests at test_torch, test_cuda and test_autograd

Usage:
x = torch.arange(6).view(2, 3)
y = x.flip([0,1])  # flip along the 1st and 2nd dimention

Todo:
1. add a CUDA implementation of torch.flip (currently automatically generated by ATen)
