### PR TITLE
Workaround to make PythonOps traced with torch.jit.trace work correctly.

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -610,7 +610,7 @@ static void _trace_post_record(
   // NB: this path is executed only for forward of Python functions, so there's no need to check
   // tracing_state->in_eval_subgraph (it's always false, because they are never part of backward
   // subgraphs AND we don't even materialize the forward function).
-  if (!passes_state_transparently) {
+  if (trace_info.state->creates_handles && !passes_state_transparently) {
     // TODO: sgross and ezyang don't know if this is right
     tracer::nontraceableBackwardSubgraph(input_vars, output_vars);
     Function::set_up_context_edge(trace_info.n, input_vars, output_vars);

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -441,12 +441,7 @@ bool hasHandleOutput(Node * n) {
 
 #ifndef NO_PYTHON
 Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
-  py::function func;
-  if (op->tracing_autograd_python_function) {
-    func = py::function(py::handle(op->pyobj.get()).attr("apply"));
-  } else {
-    func = py::reinterpret_borrow<py::function>(py::handle(op->pyobj.get()));
-  }
+  py::function func = py::reinterpret_borrow<py::function>(py::handle(op->pyobj.get()));
   bool tracing_autograd_python_function = op->tracing_autograd_python_function;
   bool has_handle = hasHandleOutput(op);
   size_t num_inputs = 0;

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -23,14 +23,12 @@ namespace py = pybind11;
 
 namespace torch { namespace jit {
 
-std::string getPythonName(const PyObject* obj, bool is_legacy) {
+std::string getPythonName(const PyObject* obj_) {
   AutoGIL gil;
-  if (is_legacy) {
-    return std::string(obj->ob_type->tp_name);
-  } else {
-    auto v = py::getattr(const_cast<PyObject*>(obj), "__name__", py::str("<python_value>"));
-    return py::str(v);
-  }
+  PyObject* obj = const_cast<PyObject*>(obj_);
+  auto v = py::getattr(obj, "__name__", py::str("<python_value>"));
+  // if this was a autograd.Function recover the name of the class
+  return py::str(v);
 }
 
 std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
@@ -72,15 +70,40 @@ std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
   }
 }
 
+at::optional<THPObjectPtr> PythonOp::autogradFunction() const {
+  AutoGIL gil;
+  py::handle obj = const_cast<PyObject*>(pyobj.get());
+
+  auto r = py::getattr(obj, "__self__", py::none());
+  if(r.is_none())
+    return at::nullopt;
+
+  auto apply = py::getattr(r, "apply", py::none());
+  if(apply.is_none())
+    return at::nullopt;
+
+  auto c = PyObject_RichCompareBool(apply.ptr(), obj.ptr(), Py_NE);
+  if(PyErr_Occurred())
+    throw py::error_already_set();
+  if(c)
+    return at::nullopt;
+
+  return THPObjectPtr(r.release().ptr());
+}
+
 std::string PythonOp::name() const {
-  return getPythonName(pyobj.get(),is_legacy);
+  AutoGIL gil;
+  if(auto autograd = autogradFunction()) {
+    return getPythonName(autograd->get());
+  } else {
+    return getPythonName(pyobj.get());
+  }
 }
 
 void PythonOp::cloneFrom(Node * other_) {
   Node::cloneFrom(other_);
   auto other = other_->cast<PythonOp>();
   this->cconv = other->cconv;
-  this->is_legacy = other->is_legacy;
   Py_INCREF(other->pyobj.get());
   this->pyobj = THPObjectPtr(other->pyobj.get());
   this->var_flags = other->var_flags;

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -154,7 +154,12 @@ void BlockToONNX(Block* old_block, Block* new_block, bool aten, std::unordered_m
 
     // Test if there is a symbolic function; bail if there is not
     auto pyobj = py::handle(op->pyobj.get());
-    if (!py::hasattr(pyobj, "symbolic")) {
+    auto func = op->autogradFunction();
+    if(func) {
+      pyobj = func->get();
+    }
+
+    if(!py::hasattr(pyobj, "symbolic")) {
       cloneNode(op);
       return;
     }

--- a/torch/csrc/jit/python_compiled_function.cpp
+++ b/torch/csrc/jit/python_compiled_function.cpp
@@ -109,7 +109,7 @@ struct CompiledFunction {
       // Start tracing
       AutoGradMode grad_mode(grad_enabled_);
       auto num_stages = grad_enabled_ ? fn_.nderivs_ + 1 : 1;
-      auto enter_info = tracer::enter(input_info.vars, num_stages);
+      auto enter_info = tracer::enter(input_info.vars, num_stages, true);
       auto & trace = enter_info.first;
       auto & new_vars = enter_info.second;
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -63,7 +63,7 @@ void initPythonIRBindings(PyObject * module_) {
       std::string cconv(inputs.size(), 't');
       func.attr("symbolic") = symbolic;
       Node* new_node = g.insertNode(g.createPythonOp(
-        THPObjectPtr(func.release().ptr()), cconv, false, {}, {}, false));
+        THPObjectPtr(func.release().ptr()), cconv, {}, {}, false));
       for (auto i : inputs)
         new_node->addInput(i);
       std::vector<Value*> outputs;

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -54,7 +54,7 @@ void initPythonTracerBindings(PyObject* module_) {
     });
 
   m.def("_tracer_enter", [](variable_list trace_inputs, std::size_t num_backwards) {
-    return tracer::enter(std::move(trace_inputs), num_backwards + 1);
+    return tracer::enter(std::move(trace_inputs), num_backwards + 1, true);
   });
   m.def("_tracer_exit", [](variable_list var_outputs) {
     tracer::exit(var_outputs);

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -43,7 +43,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     py::object func = self;
     std::string cconv(inputs.size(), 't');
     Node* new_node = g.insertNode(g.createPythonOp(
-      THPObjectPtr(func.release().ptr()), cconv, false, {}, {}, false));
+      THPObjectPtr(func.release().ptr()), cconv, {}, {}, false));
     new_node->setSourceLocation(std::make_shared<SourceRange>(loc));
     for(auto i : inputs)
       new_node->addInput(i);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -522,7 +522,7 @@ variable_list get_grad_outputs(const variable_list& vars) {
 std::shared_ptr<Graph> trace(const ADTestSpec& test, const variable_list& vars_in) {
   std::shared_ptr<tracer::TracingState> state;
   variable_list trace_vars_in;
-  std::tie(state, trace_vars_in) = tracer::enter(vars_in, 1);
+  std::tie(state, trace_vars_in) = tracer::enter(vars_in, 1, true);
   auto trace_vars_out = test(trace_vars_in);
   tracer::exit(trace_vars_out);
   return state->graph;

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -184,8 +184,9 @@ inline Value* getOutputTrace(const std::shared_ptr<TracingState>& state, const V
 // reference to at::Tensor buffer to call unsafeGetTH, but you can't get this
 // out of a const vector (silly std::vector...)
 inline std::pair<std::shared_ptr<TracingState>, variable_list> enter(
-    variable_list inputs, std::size_t num_stages) {
+    variable_list inputs, std::size_t num_stages, bool creates_handles) {
   auto state = std::make_shared<TracingState>(num_stages);
+  state->creates_handles = creates_handles;
   for (auto& input : inputs) {
     auto * value_state = detail::getValueState(state, input, false);
     if (value_state) {

--- a/torch/csrc/jit/tracer_state.cpp
+++ b/torch/csrc/jit/tracer_state.cpp
@@ -20,7 +20,8 @@ TracingState::TracingState(size_t num_stages)
       num_stages(num_stages),
       eval_count(0),
       var_flags(num_stages),
-      output_edges(num_stages) {}
+      output_edges(num_stages),
+      creates_handles(true) {}
 
 TracingState::~TracingState() = default;
 

--- a/torch/csrc/jit/tracer_state.h
+++ b/torch/csrc/jit/tracer_state.h
@@ -55,6 +55,9 @@ struct TracingState : public std::enable_shared_from_this<TracingState> {
   std::mutex mutex;
   variable_list inputs; // Used only for the duration of first stage
 
+  bool creates_handles; // should python ops ever get handles? Or should
+                        // we just record them as is.
+
   std::unique_lock<std::mutex> lock() {
     return std::unique_lock<std::mutex>(mutex);
   }


### PR DESCRIPTION
The long-term fix is to remove the handling-creating pathways and
remove all the modes from PythonOp making it into an op that simply
calls a PyObject. Right now ONNX expects PythonOp to hold a
nn.Function, not a generic callable, so completely removing the legacy
pathway will also require changes to how ONNX symbolics are found.

