### PR TITLE
Fixing LP-Pooling stability issues

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -446,25 +446,25 @@ def max_unpool3d(input, indices, kernel_size, stride=None, padding=0,
 
 def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 2D power-average pooling over an input signal composed of
-    several input planes. If all inputs are zero, the gradient is set to
-    zero as well. 
+    several input planes. If the sum of all inputs to the power of `p` is 
+    zero, the gradient is set to zero as well. 
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
     kw, kh = utils._pair(kernel_size)
     out = avg_pool2d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
-    return relu(out).mul(kw * kh).pow(1. / norm_type)
+    return (torch.sign(out) * relu(torch.abs(out))).mul(kw * kh).pow(1. / norm_type)
 
 
 def lp_pool1d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 1D power-average pooling over an input signal composed of
-    several input planes. If all inputs are zero, the gradient is set to
-    zero as well. 
+    several input planes. If the sum of all inputs to the power of `p` is 
+    zero, the gradient is set to zero as well. 
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
     out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
-    return relu(out).mul(kernel_size).pow(1. / norm_type)
+    return (torch.sign(out) * relu(torch.abs(out))).mul(kernel_size).pow(1. / norm_type)
 
 
 def adaptive_max_pool1d(input, output_size, return_indices=False):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -446,8 +446,8 @@ def max_unpool3d(input, indices, kernel_size, stride=None, padding=0,
 
 def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 2D power-average pooling over an input signal composed of
-    several input planes. If the sum of all inputs to the power of `p` is 
-    zero, the gradient is set to zero as well. 
+    several input planes. If the sum of all inputs to the power of `p` is
+    zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
@@ -458,8 +458,8 @@ def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
 
 def lp_pool1d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 1D power-average pooling over an input signal composed of
-    several input planes. If the sum of all inputs to the power of `p` is 
-    zero, the gradient is set to zero as well. 
+    several input planes. If the sum of all inputs to the power of `p` is
+    zero, the gradient is set to zero as well.
 
     See :class:`~torch.nn.LPPool1d` for details.
     """

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -446,23 +446,25 @@ def max_unpool3d(input, indices, kernel_size, stride=None, padding=0,
 
 def lp_pool2d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 2D power-average pooling over an input signal composed of
-    several input planes.
+    several input planes. If all inputs are zero, the gradient is set to
+    zero as well. 
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
     kw, kh = utils._pair(kernel_size)
     out = avg_pool2d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
-    return out.mul(kw * kh).pow(1. / norm_type)
+    return relu(out).mul(kw * kh).pow(1. / norm_type)
 
 
 def lp_pool1d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
     r"""Applies a 1D power-average pooling over an input signal composed of
-    several input planes.
+    several input planes. If all inputs are zero, the gradient is set to
+    zero as well. 
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
     out = avg_pool1d(input.pow(norm_type), kernel_size, stride, 0, ceil_mode)
-    return out.mul(kernel_size).pow(1. / norm_type)
+    return relu(out).mul(kernel_size).pow(1. / norm_type)
 
 
 def adaptive_max_pool1d(input, output_size, return_indices=False):

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -727,8 +727,8 @@ class LPPool1d(_LPPoolNd):
     - At p = infinity, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to Average Pooling)
 
-    .. note:: If the sum to the power of `p` is zero, the gradient of this function is 
-              not defined. This implementation will set the gradient to zero in this case. 
+    .. note:: If the sum to the power of `p` is zero, the gradient of this function is
+              not defined. This implementation will set the gradient to zero in this case.
 
     Args:
         kernel_size: a single int, the size of the window
@@ -772,9 +772,9 @@ class LPPool2d(_LPPoolNd):
         - a single ``int`` -- in which case the same value is used for the height and width dimension
         - a ``tuple`` of two ints -- in which case, the first `int` is used for the height dimension,
           and the second `int` for the width dimension
-    
-    .. note:: If the sum to the power of `p` is zero, the gradient of this function is 
-              not defined. This implementation will set the gradient to zero in this case. 
+
+    .. note:: If the sum to the power of `p` is zero, the gradient of this function is
+              not defined. This implementation will set the gradient to zero in this case.
 
     Args:
         kernel_size: the size of the window

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -727,6 +727,9 @@ class LPPool1d(_LPPoolNd):
     - At p = infinity, one gets Max Pooling
     - At p = 1, one gets Sum Pooling (which is proportional to Average Pooling)
 
+    .. note:: If the sum to the power of `p` is zero, the gradient of this function is 
+              not defined. This implementation will set the gradient to zero in this case. 
+
     Args:
         kernel_size: a single int, the size of the window
         stride: a single int, the stride of the window. Default value is :attr:`kernel_size`
@@ -769,6 +772,9 @@ class LPPool2d(_LPPoolNd):
         - a single ``int`` -- in which case the same value is used for the height and width dimension
         - a ``tuple`` of two ints -- in which case, the first `int` is used for the height dimension,
           and the second `int` for the width dimension
+    
+    .. note:: If the sum to the power of `p` is zero, the gradient of this function is 
+              not defined. This implementation will set the gradient to zero in this case. 
 
     Args:
         kernel_size: the size of the window


### PR DESCRIPTION
The gradient of LP-Pooling is undefined when the sum of all inputs to the power of `p` is zero. The current implementation will yield NAN in this case.

I've added a ReLU unit to set the gradient to zero if the sum of all input elements to the power of `p` is zero.

This would fix issue #6765. 