### PR TITLE
Fix performance regression on simple cases of indexing

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -254,6 +254,32 @@ class TestIndexing(TestCase):
             self.assertEqual(x, x[0])
             self.assertEqual(len(w), 1)
 
+    def test_legacy_dispatch(self):
+        # compare with indexing using index_select / index_fill etc
+        x = torch.arange(0, 9).view(3, 3)
+        idx = torch.tensor([0, 2])
+        self.assertEqual(x[idx], x.index_select(0, idx))
+        self.assertEqual(x[:, idx], x.index_select(1, idx))
+
+        mask = x > 4
+        self.assertEqual(x[mask], x.masked_select(mask))
+
+        y = x.clone()
+        yr = x.clone()
+        y[idx] = 0
+        yr.index_fill_(0, idx, 0)
+        self.assertEqual(y, yr)
+        y[:, idx] = 2
+        yr.index_fill_(1, idx, 2)
+        self.assertEqual(y, yr)
+
+        mask = x > 4
+        y = x.clone()
+        yr = x.clone()
+        y[mask] = 10
+        yr.masked_fill_(mask, 10)
+        self.assertEqual(y, yr)
+
 
 # The tests below are from NumPy test_indexing.py with some modifications to
 # make them compatible with PyTorch. It's licensed under the BDS license below:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -121,16 +121,17 @@ class TestJit(TestCase):
     # index-2 is not implemented in interpreter
     @unittest.expectedFailure
     def test_index(self):
-        x = Variable(torch.Tensor([0.4]), requires_grad=True)
+        x = Variable(torch.rand(2, 2, 2), requires_grad=True)
         y = Variable(torch.LongTensor([0]), requires_grad=True)
+        y2 = Variable(torch.LongTensor([1]), requires_grad=True)
 
         @torch.jit.compile(nderivs=0)
-        def fn(x, y):
-            return x[y]
+        def fn(x, y, y2):
+            return x[y, y2]
 
-        z = fn(x, y)
+        z = fn(x, y, y2)
         with self.assertCompiled(fn):
-            z2 = fn(x, y)
+            z2 = fn(x, y, y2)
         self.assertEqual(z, z2)
 
     # Backwards tracing was broken for indexing by a constant,


### PR DESCRIPTION
This PR fixes some of the performance regression on Tensors going from 0.3 to 0.4.

It dispatches the operations to the old kernels that we have, whenever possible.
This means that we use `index_select` / `masked_select` / `index_fill_` or `masked_fill_` when the arguments for the indexing allow it.

Ideally, we want to put this code in ATen, but at first sight it seemed simpler to change it here.

Here are the results from a quick micro benchmark:

```python
# master

a = torch.rand(100, 100, 100)
%timeit a[[2, 1, 0 ,4]]
196 µs ± 42.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%timeit a[[2, 1, 0 ,4]] = 5
409 µs ± 203 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%timeit a[a > 0.5]
44.7 ms ± 5.76 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit a[a > 0.5] = 1
50.5 ms ± 9.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# this branch

a = torch.rand(100, 100, 100)
%timeit a[[2, 1, 0 ,4]]
17.5 µs ± 2.19 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit a[[2, 1, 0 ,4]] = 5
13.6 µs ± 1.6 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

%timeit a[a > 0.5]
7.54 ms ± 1.34 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit a[a > 0.5] = 1
5.81 ms ± 1.64 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

We see roughly 5-10x speedup on those simple cases.
