### PR TITLE
Let Gloo close socket, destroy() not needed for non-NCCL backend

### DIFF
--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -10,6 +10,7 @@
 #include "gloo/transport/tcp/device.h"
 
 #include <algorithm>
+#include <unistd.h>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -122,7 +123,11 @@ DataChannelGloo::DataChannelGloo(InitMethod::Config config)
 }
 
 
-DataChannelGloo::~DataChannelGloo() {}
+DataChannelGloo::~DataChannelGloo() {
+  if (_listen_socket != -1) {
+    ::close(_listen_socket);
+  }
+}
 
 void DataChannelGloo::destroy() {}
 

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -84,11 +84,6 @@ DataChannelMPI::DataChannelMPI()
 
 
 DataChannelMPI::~DataChannelMPI() {
-  destroy();
-}
-
-
-void DataChannelMPI::destroy() {
   for (auto& group : _groups) {
     auto comm = group.second.first;
     if (comm != MPI_COMM_WORLD && comm != MPI_COMM_NULL)
@@ -97,6 +92,9 @@ void DataChannelMPI::destroy() {
 
   MPI_Finalize();
 }
+
+
+void DataChannelMPI::destroy() {}
 
 
 bool DataChannelMPI::init() {

--- a/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelTCP.cpp
@@ -95,12 +95,8 @@ DataChannelTCP::DataChannelTCP(InitMethod::Config config, int timeout)
 
 
 DataChannelTCP::~DataChannelTCP() {
-  destroy();
-}
 
-
-void DataChannelTCP::destroy() {
- if (_socket != -1)
+  if (_socket != -1)
     ::close(_socket);
 
   for (const auto& process : _processes) {
@@ -108,6 +104,9 @@ void DataChannelTCP::destroy() {
       ::close(process.socket);
   }
 }
+
+
+void DataChannelTCP::destroy() {}
 
 
 bool DataChannelTCP::initWorker() {


### PR DESCRIPTION
Gloo should close the socket at destruction, destroy() is only needed for NCCL backend since CUDA runtime doesn't need to be destroyed at destructor unless specifically called. And destroy() is not needed for all other backends.

This is so that we can always
init_process_group(world_size=2)
destroy_process_group()
init_process_group(world_size=4)

for elastic training. Tested by myself and the above code works fine.
