### PR TITLE
[Caffe2] Provide option to initialize the TensorRT engine at Operator constructor time

### DIFF
--- a/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
@@ -54,11 +54,14 @@ TensorRTOp::TensorRTOp(const OperatorDef& operator_def, Workspace* ws)
   {
     auto engine_string =
         OperatorBase::GetSingleArgument<std::string>("serialized_engine", "");
-    CAFFE_ENFORCE(!engine_string.empty(), "Empty serialized TensorRT engine!");
-    auto trt_runtime = tensorrt::TrtObject(nvinfer1::createInferRuntime(logger_));
-    // TODO(support trt plugin factory)
-    trt_engine_ = tensorrt::TrtObject(trt_runtime->deserializeCudaEngine(
-        engine_string.data(), engine_string.size(), nullptr));
+    if (!engine_string.empty()) {
+      auto trt_runtime =
+          tensorrt::TrtObject(nvinfer1::createInferRuntime(logger_));
+      // TODO(support trt plugin factory)
+      trt_engine_ = tensorrt::TrtObject(trt_runtime->deserializeCudaEngine(
+          engine_string.data(), engine_string.size(), nullptr));
+    } else {
+    }
   }
 
   CAFFE_ENFORCE(trt_engine_, "Cannot deserialize TensorRT engine!");

--- a/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
@@ -61,6 +61,18 @@ TensorRTOp::TensorRTOp(const OperatorDef& operator_def, Workspace* ws)
       trt_engine_ = tensorrt::TrtObject(trt_runtime->deserializeCudaEngine(
           engine_string.data(), engine_string.size(), nullptr));
     } else {
+      auto onnx_model_str =
+          OperatorBase::GetSingleArgument<std::string>("onnx_model", "");
+      CAFFE_ENFORCE(!onnx_model_str.empty(), "onnx_model cannot be empty");
+      auto debug_builder = OperatorBase::GetSingleArgument<int>("debug_builder", 0);
+      auto max_workspace_size = OperatorBase::GetSingleArgument<int>(
+          "max_workspace_size", 1024 * 1024 * 2);
+      trt_engine_ = tensorrt::BuildTrtEngine(
+          onnx_model_str,
+          &logger_,
+          max_batch_size_,
+          max_workspace_size,
+          debug_builder);
     }
   }
 

--- a/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
@@ -56,7 +56,7 @@ TensorRTOp::TensorRTOp(const OperatorDef& operator_def, Workspace* ws)
           OperatorBase::GetSingleArgument<int>("max_batch_size", 1)) {
   {
     auto engine_string =
-        OperatorBase::GetSingleArgument<std::string>("serialized_engine", "");
+        OperatorBase::GetSingleArgument<std::string>("backend_buffer", "");
     if (!engine_string.empty()) {
       auto trt_runtime =
           tensorrt::TrtObject(nvinfer1::createInferRuntime(logger_));
@@ -244,12 +244,12 @@ This is a GPU only operator.
         "log_verbosity",
         "(int default 0) verbosity of the TensorRt engine log.")
     .Arg(
-        "serialized_engine",
+        "backend_buffer",
         "(string default=\"\" blob for serialized TensorRT engine."
         "Note that serialized engine is not compatible across platform and "
         "different TensorRT version.")
     .Arg(
-        "batch_size",
+        "max_batch_size",
         "(int default 0) Batch size set by the TensorRT engine builder."
         "It must be no larger than the max_batch_size of the engine builder so "
         "it is better not to edit this manually.");

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.h
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.h
@@ -20,16 +20,19 @@ class TensorRTTransformer {
       size_t max_batch_size,
       size_t max_workspace_size,
       int verbosity,
-      bool debug_builder)
+      bool debug_builder,
+      bool build_serializable_op = true)
       : max_batch_size_(max_batch_size),
         max_workspace_size_(max_workspace_size),
         verbosity_(verbosity),
-        debug_builder_(debug_builder) {}
+        debug_builder_(debug_builder),
+        build_serializable_op_(build_serializable_op) {}
 
   OperatorDef BuildTrtOp(
       const std::string& onnx_model_str,
       const std::unordered_map<std::string, std::vector<int>>&
-          output_size_hints);
+          output_size_hints,
+      const std::unordered_set<std::string>* initializtion_list = nullptr);
 
   void Transform(
       Workspace* ws,
@@ -53,6 +56,9 @@ class TensorRTTransformer {
 
   // Input mapping
   std::unordered_map<std::string, std::string> input_mapping_;
+
+  // Generate serializable trt op or defer the onnx->trt process to ctor of the Trt op
+  bool build_serializable_op_{true};
 
   // TensorRT params
   size_t max_batch_size_{50};

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.h
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.h
@@ -31,8 +31,7 @@ class TensorRTTransformer {
   OperatorDef BuildTrtOp(
       const std::string& onnx_model_str,
       const std::unordered_map<std::string, std::vector<int>>&
-          output_size_hints,
-      const std::unordered_set<std::string>* initializtion_list = nullptr);
+          output_size_hints);
 
   void Transform(
       Workspace* ws,
@@ -45,6 +44,24 @@ class TensorRTTransformer {
       Workspace* ws,
       onnx::OnnxExporter* exporter,
       std::unordered_map<std::string, TensorShape>* shape_hints);
+
+  void AddTrtOptions(
+      caffe2::OperatorDef* op,
+      const std::unordered_map<std::string, std::vector<int>>&
+          output_size_hints);
+
+  // A lazy version of Trt op building function, where instead of invoking the
+  // trt build engine and serialize the trt runtime, we just attach the
+  // serialized trt model string. The runtime will be built when trt op is
+  // constructed, during which the weights will be pulled from the workspace.
+  // The benefit of doing so is that we can avoid serialize/deserialize the
+  // weights across OperatorDef.
+  OperatorDef BuildTrtOpLazy(
+      const std::string& onnx_model_str,
+      const std::unordered_map<std::string, std::vector<int>>&
+          output_size_hints,
+      const std::unordered_set<std::string>& initialization_list,
+      const caffe2::NetDef& net);
 
   CaffeMap<std::string, TensorShape> SsaRewriteAndMapNames(
       Workspace* ws,

--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.h
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.h
@@ -14,6 +14,11 @@
 
 namespace caffe2 {
 
+void BuildInitializationList(
+    Workspace* ws,
+    ::ONNX_NAMESPACE::GraphProto* g,
+    std::unordered_set<std::string>* initialization_list);
+
 class TensorRTTransformer {
  public:
   TensorRTTransformer(

--- a/caffe2/contrib/tensorrt/trt_utils.cc
+++ b/caffe2/contrib/tensorrt/trt_utils.cc
@@ -1,0 +1,38 @@
+#include "caffe2/contrib/tensorrt/trt_utils.h"
+
+#include <onnx2trt.hpp>
+
+namespace caffe2 {
+namespace tensorrt {
+std::shared_ptr<nvinfer1::ICudaEngine> BuildTrtEngine(
+    const std::string& onnx_model_str,
+    TrtLogger* logger,
+    size_t max_batch_size,
+    size_t max_workspace_size,
+    bool debug_builder) {
+  auto trt_builder = TrtObject(nvinfer1::createInferBuilder(*logger));
+  auto trt_network = TrtObject(trt_builder->createNetwork());
+  auto importer = TrtObject(onnx2trt::createImporter(trt_network.get()));
+  auto status =
+      importer->import(onnx_model_str.data(), onnx_model_str.size(), false);
+  if (status.is_error()) {
+    CAFFE_THROW(
+        "TensorRTTransformer ERROR: ",
+        status.file(),
+        ":",
+        status.line(),
+        " In function ",
+        status.func(),
+        ":\n",
+        "[",
+        status.code(),
+        "] ",
+        status.desc());
+  }
+  trt_builder->setMaxBatchSize(max_batch_size);
+  trt_builder->setMaxWorkspaceSize(max_workspace_size);
+  trt_builder->setDebugSync(debug_builder);
+  return TrtObject(trt_builder->buildCudaEngine(*trt_network.get()));
+}
+} // namespace tensorrt
+} // namespace caffe2

--- a/caffe2/contrib/tensorrt/trt_utils.h
+++ b/caffe2/contrib/tensorrt/trt_utils.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "caffe2/core/logging.h"
-#include <NvInfer.h>
 #include <iostream>
+#include <NvInfer.h>
+
+#include "caffe2/core/logging.h"
 
 namespace caffe2 { namespace tensorrt {
 
@@ -43,6 +44,12 @@ inline std::shared_ptr<T> TrtObject(T* obj) {
   return std::shared_ptr<T>(obj, TrtDeleter());
 }
 
+std::shared_ptr<nvinfer1::ICudaEngine> BuildTrtEngine(
+    const std::string& onnx_model_str,
+    TrtLogger* logger,
+    size_t max_batch_size,
+    size_t max_workspace_size,
+    bool debug_builder);
 }
 }
 

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -82,7 +82,8 @@ void addCUDAGlobalMethods(py::module& m) {
          int max_batch_size,
          int max_workspace_size,
          int verbosity,
-         bool debug_builder) -> py::bytes {
+         bool debug_builder,
+         bool build_serializable_op) -> py::bytes {
 #ifdef CAFFE2_USE_TRT
         caffe2::NetDef pred_net;
         if (!ParseProtoFromLargeString(
@@ -95,8 +96,12 @@ void addCUDAGlobalMethods(py::module& m) {
               it.first, CreateTensorShape(it.second, TensorProto::FLOAT));
         }
         TensorRTTransformer ts(
-            max_batch_size, max_workspace_size, verbosity, debug_builder);
-        ts.Transform(GetCurrentWorkspace(),  &pred_net, tensor_shapes);
+            max_batch_size,
+            max_workspace_size,
+            verbosity,
+            debug_builder,
+            build_serializable_op);
+        ts.Transform(GetCurrentWorkspace(), &pred_net, tensor_shapes);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);

--- a/caffe2/python/trt/test_trt.py
+++ b/caffe2/python/trt/test_trt.py
@@ -285,8 +285,10 @@ class TensorRTTransformTest(TestCase):
             workspace.RunNetOnce(init_net)
 
         # Cut the graph
+        start = time.time()
         pred_net_cut = transform_caffe2_net(pred_net,
-                                            {input_name: input_blob_dims})
+                                            {input_name: input_blob_dims},
+                                            build_serializable_op=True)
         del init_net, pred_net
         #_print_net(pred_net_cut)
 
@@ -296,6 +298,9 @@ class TensorRTTransformTest(TestCase):
         with core.DeviceScope(device_option):
             workspace.FeedBlob(input_name, data)
             workspace.CreateNet(pred_net_cut)
+            end = time.time()
+            print("Conversion time: {:.2f}s".format(end -start))
+
             for _ in range(warmup):
                 workspace.RunNet(pred_net_cut.name)
             start = time.time()

--- a/caffe2/python/trt/transform.py
+++ b/caffe2/python/trt/transform.py
@@ -77,7 +77,8 @@ def transform_caffe2_net(
         max_batch_size=50,
         max_workspace_size=2*1024*1024,
         verbosity=1,
-        debug_builder=False):
+        debug_builder=False,
+        build_serializable_op=True):
     """
     Transfrom the caffe2_net by collapsing TRT-runnable nodes into trt c2 ops
     """
@@ -99,7 +100,8 @@ def transform_caffe2_net(
                                    max_batch_size,
                                    max_workspace_size,
                                    verbosity,
-                                   debug_builder)
+                                   debug_builder,
+                                   build_serializable_op)
     pred_net_cut = caffe2_pb2.NetDef()
     pred_net_cut.ParseFromString(pred_net_str)
     return pred_net_cut


### PR DESCRIPTION
As discussed with @Maratyszcza, we provide this option to initialize the TensorRT engine at operator ctor. 

Pros:
- Save weight serialization/deserialization (convert time went from `7.7s` to `6.7s` for resnet50 on my machine)
- For generic cases, we can handle backend that doesn't support serialization/deserialization in this way. 

Cons:
- Now part of the conversion is done in transformer and part is done is Operator ctor. The code is less streamlined. 
- For general backend, if it doesn't expose its input/output in the same order of input/output order in onnx model. We cannot do positional io binding of Operator but have to resort to name matching, which is kinda OK I think. 

In addition, having two flows now creates branches in the code, reducing the readability. Maybe we should get rid of one and keep the latter? @Maratyszcza 