### PR TITLE
[JIT][script] Improve error reporting for tuple type mismatch

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2494,7 +2494,7 @@ class TestScript(TestCase):
         v = torch.rand(10, 3)
         self.assertEqual(torch.chunk(v, dim=0, chunks=2)[0], foo(v))
 
-        with self.assertRaisesRegex(RuntimeError, "variable 'a' previously has type"):
+        with self.assertRaisesRegex(RuntimeError, r"variable 'a' previously has type \(Dynamic, Dynamic\)"):
             @torch.jit.script
             def mixtypes():
                 a = torch.chunk(1, dim=0, chunks=2)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -33,7 +33,7 @@ static std::string diagnosticType(TypePtr ptr) {
     ss << ")";
     return ss.str();
   } else {
-    return "Tensor";
+    return ptr->name();
   }
 }
 

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -38,6 +38,7 @@ protected:
 
 public:
   virtual bool operator==(const Type& rhs) const = 0;
+  virtual std::string name() const = 0;
   TypeKind kind() const {
     return kind_;
   }
@@ -78,6 +79,9 @@ struct DynamicType : public Type {
   : Type(TypeKind::DynamicType) {}
   virtual bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
+  }
+  virtual std::string name() const override {
+    return "Dynamic";
   }
   static const TypeKind Kind = TypeKind::DynamicType;
   // global singleton
@@ -132,6 +136,9 @@ struct TensorType : public Type {
            strides() == rt->strides() &&
            device() == rt->device();
   }
+  virtual std::string name() const override {
+    return "Tensor";
+  }
 private:
   static std::vector<int64_t> contiguousStridesOf(at::IntList sizes) {
     std::vector<int64_t> strides(sizes.size());
@@ -173,6 +180,9 @@ struct HandleType : public Type {
   virtual bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
+  virtual std::string name() const override {
+    return "Handle";
+  }
   static const TypeKind Kind = TypeKind::HandleType;
   // global singleton
   static TypePtr get();
@@ -191,6 +201,9 @@ struct TupleType : public Type {
     if(rhs.kind() != kind())
       return false;
     return rhs.cast<TupleType>()->elements().equals(elements());
+  }
+  virtual std::string name() const override {
+    return "Tuple";
   }
 private:
   std::vector<TypePtr> elements_;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -137,7 +137,12 @@ struct TensorType : public Type {
            device() == rt->device();
   }
   virtual std::string name() const override {
-    return "Tensor";
+    std::string retval = std::string(at::toString(scalarType())) + "Tensor[";
+    for (size_t i=0; i < sizes_.size(); ++i) {
+      retval += std::to_string(sizes_[i]) + (i == sizes_.size() - 1 ? "" : ",");
+    }
+    retval += "]";
+    return retval;
   }
 private:
   static std::vector<int64_t> contiguousStridesOf(at::IntList sizes) {


### PR DESCRIPTION
Previously we would see errors like:

```
variable 'states' previously has type (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) but is now being assigned to a value of type (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor):
```

since the default case in the diagnostic printout was "Tensor". This adds a virtual member function to each `Type` class that returns a human-readable string for better error reporting