### PR TITLE
Import/export observer symbols for DLL, which fixes the linking error in Visual Studio.

### DIFF
--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -147,6 +147,12 @@ private:                                                                       \
 #define CAFFE2_API CAFFE2_IMPORT
 #endif
 
+#ifdef CAFFE2_BUILD_OBSERVER_LIB
+#define CAFFE2_OBSERVER_API CAFFE2_EXPORT
+#else
+#define CAFFE2_OBSERVER_API CAFFE2_IMPORT
+#endif
+
 
 #if defined(_MSC_VER)
 #define NOMINMAX

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -434,7 +434,7 @@ endif()
 
 # Debug and Release symbol support
 if (MSVC)
-  if (${CMAKE_BUILD_TYPE} MATCHES "Release")
+  if ((${CMAKE_BUILD_TYPE} MATCHES "Release") OR (${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo") OR (${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel"))
     if (${BUILD_SHARED_LIBS})
       list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-MD")
     else()

--- a/modules/observers/CMakeLists.txt
+++ b/modules/observers/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(caffe2_observers
     )
 target_link_libraries(caffe2_observers PUBLIC caffe2_library)
 target_include_directories(caffe2_observers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_compile_options(caffe2_observers PRIVATE "-DCAFFE2_BUILD_OBSERVER_LIB")
 install(TARGETS caffe2_observers DESTINATION lib)
 caffe2_interface_library(caffe2_observers caffe2_observers_library)
 

--- a/modules/observers/net_observer_reporter.h
+++ b/modules/observers/net_observer_reporter.h
@@ -1,10 +1,13 @@
 #pragma once
+
 #include <map>
+
+#include "caffe2/core/common.h"
 #include "caffe2/core/net.h"
 
 namespace caffe2 {
 
-class NetObserverReporter {
+class CAFFE2_OBSERVER_API NetObserverReporter {
  public:
   virtual ~NetObserverReporter() = default;
 

--- a/modules/observers/net_observer_reporter_print.h
+++ b/modules/observers/net_observer_reporter_print.h
@@ -2,9 +2,11 @@
 
 #include "observers/net_observer_reporter.h"
 
+#include "caffe2/core/common.h"
+
 namespace caffe2 {
 
-class NetObserverReporterPrint : public NetObserverReporter {
+class CAFFE2_OBSERVER_API NetObserverReporterPrint : public NetObserverReporter {
  public:
   static const std::string IDENTIFIER;
   void reportDelay(

--- a/modules/observers/observer_config.h
+++ b/modules/observers/observer_config.h
@@ -2,6 +2,8 @@
 
 #include "observers/net_observer_reporter.h"
 
+#include "caffe2/core/common.h"
+
 namespace caffe2 {
 
 /*
@@ -24,7 +26,7 @@ namespace caffe2 {
       is multiples of o, log operator metrics instead. Then repeat
   skipIters_ == n: skip the first n iterations of the net.
 */
-class ObserverConfig {
+class CAFFE2_OBSERVER_API ObserverConfig {
  public:
   static void initSampleRate(
       int netInitSampleRate,

--- a/modules/observers/perf_observer.h
+++ b/modules/observers/perf_observer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "caffe2/core/common.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/observer.h"
 #include "caffe2/core/timer.h"
@@ -8,7 +9,8 @@
 
 namespace caffe2 {
 
-class PerfNetObserver : public NetObserver {
+
+class CAFFE2_OBSERVER_API PerfNetObserver : public NetObserver {
  public:
   explicit PerfNetObserver(NetBase* subject_);
   virtual ~PerfNetObserver();


### PR DESCRIPTION
Visual Studio 2017 is complaining about LNK2001 from observer when build `caffe2` and `caffe2_observers` as DLL.

Since `caffe2_observers` relies on `caffe2`'s header, we cannot reuse `CAFFE2_API`/`CAFFE2_BUILD_MAIN_LIB` macros.
Instead we add a similar macro `CAFFE2_OBSERVER_API` and switch between import/export based on `CAFFE2_BUILD_OBSERVER_LIB`.