### PR TITLE
Add pos_weight argument to nn.BCEWithLogitsLoss (#5660)

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1507,8 +1507,6 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
         target: Tensor of the same shape as input
         weight (Tensor, optional): a manual rescaling weight
                 if provided it's repeated to match input tensor shape
-        pos_weight (Tensor, optional): a weight of positive examples.
-                Must be a vector with length equal to the number of classes.
         size_average (bool, optional): By default, the losses are averaged
                 over observations for each minibatch. However, if the field
                 :attr:`size_average` is set to ``False``, the losses are instead summed
@@ -1517,6 +1515,8 @@ def binary_cross_entropy_with_logits(input, target, weight=None, size_average=Tr
                 observations for each minibatch depending on :attr:`size_average`. When :attr:`reduce`
                 is ``False``, returns a loss per input/target element instead and ignores
                 :attr:`size_average`. Default: ``True``
+        pos_weight (Tensor, optional): a weight of positive examples.
+                Must be a vector with length equal to the number of classes.
 
     Examples::
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -476,8 +476,6 @@ class BCEWithLogitsLoss(_Loss):
         weight (Tensor, optional): a manual rescaling weight given to the loss
             of each batch element. If given, has to be a Tensor of size
             "nbatch".
-        pos_weight (Tensor, optional): a weight of positive examples.
-                Must be a vector with length equal to the number of classes.
         size_average (bool, optional): By default, the losses are averaged
             over observations for each minibatch. However, if the field
             size_average is set to ``False``, the losses are instead summed for
@@ -486,6 +484,8 @@ class BCEWithLogitsLoss(_Loss):
             observations for each minibatch depending on size_average. When reduce
             is False, returns a loss per input/target element instead and ignores
             size_average. Default: True
+        pos_weight (Tensor, optional): a weight of positive examples.
+                Must be a vector with length equal to the number of classes.
 
      Shape:
          - Input: :math:`(N, *)` where `*` means, any number of additional


### PR DESCRIPTION
- Add an option to control precision/recall in imbalanced datasets
- Add tests (but new_criterion_tests)

Multiplier `1 + (pos_weight - 1) * target` is the only significant difference.

Notes:

- I didn't implement pos_weight for `F.binary_cross_entropy`/`nn.BCELoss`. (It uses implementation from torch._C.) I can add a straightforward and numerically unstable implementation to this function but I'm not sure if it is really needed.
- I've added `pos_weight` as *last* argument to prevent errors in the code that doesn't use names for keyword arguments. But it looks quite ugly.

P.S. I proposed these changes in #5660