### PR TITLE
Relax collect_env.py tests

### DIFF
--- a/test/expect/TestCollectEnv.test_pytorch_linux_trusty_py27.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_linux_trusty_py27.expect
@@ -1,10 +1,10 @@
-PyTorch version: 0.4.0a0
+PyTorch version: 0.5.0a0
 Is debug build: No
 CUDA used to build PyTorch: None
 
-OS: Ubuntu 14.04.5 LTS
+OS: Ubuntu 14.04.X LTS
 GCC version: (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4
-CMake version: version 3.5.1
+CMake version: version 3.5.X
 
 Python version: 2.7
 Is CUDA available: No
@@ -14,6 +14,6 @@ Nvidia driver version: No CUDA
 cuDNN version: No CUDA
 
 Versions of relevant libraries:
-[pip] numpy (1.14.2)
-[pip] torch (0.4.0a0)
+[pip] numpy (1.14.X)
+[pip] torch (0.5.0a0)
 [conda] Could not collect

--- a/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
@@ -1,25 +1,25 @@
-PyTorch version: 0.4.0a0
+PyTorch version: 0.5.0a0
 Is debug build: No
-CUDA used to build PyTorch: 9.0.176
+CUDA used to build PyTorch: 9.0.X
 
-OS: Ubuntu 16.04.4 LTS
+OS: Ubuntu 16.04.X LTS
 GCC version: (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609
-CMake version: version 3.9.4
+CMake version: version 3.9.X
 
 Python version: 3.6
 Is CUDA available: Yes
-CUDA runtime version: 9.0.176
+CUDA runtime version: 9.0.X
 GPU models and configuration: 
 GPU 0: Tesla M60
 GPU 1: Tesla M60
 
-Nvidia driver version: 384.111
+Nvidia driver version: 384.X
 cuDNN version: Probably one of the following:
 /usr/lib/x86_64-linux-gnu/libcudnn.so.7.1.2
 /usr/lib/x86_64-linux-gnu/libcudnn_static_v7.a
 
 Versions of relevant libraries:
-[pip] numpy (1.14.2)
-[pip] torch (0.4.0a0)
+[pip] numpy (1.14.X)
+[pip] torch (0.5.0a0)
 [conda] magma-cuda90              2.3.0                         1    soumith
 [conda] torch                     0.4.0a0           <pip>

--- a/test/expect/TestCollectEnv.test_pytorch_macos_1013_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_macos_1013_py3.expect
@@ -1,10 +1,10 @@
-PyTorch version: 0.4.0a0
+PyTorch version: 0.5.0a0
 Is debug build: No
 CUDA used to build PyTorch: None
 
-OS: Mac OSX 10.13.3
+OS: Mac OSX 10.13.X
 GCC version: Could not collect
-CMake version: version 3.9.4
+CMake version: version 3.9.X
 
 Python version: 3.6
 Is CUDA available: No
@@ -14,6 +14,6 @@ Nvidia driver version: No CUDA
 cuDNN version: No CUDA
 
 Versions of relevant libraries:
-[pip] numpy (1.14.2)
-[pip] torch (0.4.0a0)
+[pip] numpy (1.14.X)
+[pip] torch (0.5.0a0)
 [conda] torch                     0.4.0a0           <pip>

--- a/test/expect/TestCollectEnv.test_pytorch_win_ws2016_cuda9_cudnn7_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_win_ws2016_cuda9_cudnn7_py3.expect
@@ -1,18 +1,18 @@
-PyTorch version: 0.4.0a0
+PyTorch version: 0.5.0a0
 Is debug build: No
 CUDA used to build PyTorch: 9.0
 
 OS: Microsoft Windows Server 2012 R2 Standard
 GCC version: Could not collect
-CMake version: version 3.10.2
+CMake version: version 3.10.X
 
 Python version: 3.6
 Is CUDA available: Yes
-CUDA runtime version: 9.0.176
+CUDA runtime version: 9.0.X
 GPU models and configuration: Could not collect
 Nvidia driver version: Could not collect
 cuDNN version: Could not collect
 
 Versions of relevant libraries:
-[pip] numpy (1.14.2)
+[pip] numpy (1.14.X)
 [conda] Could not collect


### PR DESCRIPTION
This PR makes it so that the collect_env.py tests ignore the most minor
number of most version strings. It also bumps the version up to 0.5.0a
to fix the CI.

cc @ezyang 

### Test Plan
wait for CI
