### PR TITLE
Fix ATen .travis.yml setup

### DIFF
--- a/.travis.aten.yml
+++ b/.travis.aten.yml
@@ -13,6 +13,7 @@ install:
     - travis_retry pip install pyyaml typing
 
 script:
+    - cd aten
     - mkdir build install
     - cd build
     - cmake .. -DNO_CUDA=1 -DCMAKE_INSTALL_PREFIX=../install

--- a/tools/aten_mirror.sh
+++ b/tools/aten_mirror.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+# This script is run by a cronjob managed by @zdevito
+# which mirrors the ATen-specific directories of PyTorch
+# to zdevito/ATen, for ease of use of projects that wish
+# to depend solely on ATen.
+#
+# See also .travis.aten.yml, which is the Travis configuration
+# for the ATen project (and ensures ATen is separately
+# buildable.)
+
 if [[ -z "$EXTRACTED_REPO" ]]; then
   echo "Need to set envvar EXTRACTED_REPO"
   exit 1
@@ -16,7 +26,8 @@ git remote add fullrepo $FULL_REPO
 git fetch fullrepo
 git checkout -b temporary-split-branch fullrepo/master
 # Cribbed from https://stackoverflow.com/questions/2982055/detach-many-subdirectories-into-a-new-separate-git-repository
-git filter-branch -f --index-filter 'git rm --cached -qr --ignore-unmatch -- . && git reset -q $GIT_COMMIT -- aten cmake' --prune-empty
+# and https://stackoverflow.com/questions/42355621/git-filter-branch-moving-a-folder-with-index-filter-does-not-work
+git filter-branch -f --index-filter 'git rm --cached -qr --ignore-unmatch -- . && git reset -q $GIT_COMMIT -- aten cmake third_party/cpuinfo && (git ls-files -s | sed "s-.travis.aten.yml-.travis.yml-" | git update-index --index-info)'
 git checkout master
 git merge temporary-split-branch
 git push


### PR DESCRIPTION
- ATen repo now has a new top-level, so Travis script has
  to be adjusted to (1) be moved to the top-level and (2)
  cd into the aten directory before doing anything.

- Unfortunately, this makes the import script even slower,
  because I'm banging on the entire index every commit.  If
  anyone has better suggestions for how to twiddle the index.
  One possibility is to fold the ATen build into the base\
  .travis.yml but only activate it when a file is missing
  (and then filter out that file.)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @zdevito @orionr 