### PR TITLE
Add special case for printing dtype for empty int64 tensor

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -206,6 +206,8 @@ def _str(self):
             suffix = ', device=\'' + str(self.device) + '\'' + suffix
 
     if self.numel() == 0:
+        # In an empty tensor, there are no elements to infer if the dtype should be int64,
+        # so it must be shown explicitly.
         if self.dtype != torch.get_default_dtype():
             suffix = ', dtype=' + str(self.dtype) + suffix
         tensor_str = '[]'

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -205,12 +205,14 @@ def _str(self):
         if self.device.type == 'cpu' or torch.cuda.current_device() != self.device.index:
             suffix = ', device=\'' + str(self.device) + '\'' + suffix
 
-    if self.dtype != torch.get_default_dtype() and self.dtype != torch.int64:
-        suffix = ', dtype=' + str(self.dtype) + suffix
-
     if self.numel() == 0:
+        if self.dtype != torch.get_default_dtype():
+            suffix = ', dtype=' + str(self.dtype) + suffix
         tensor_str = '[]'
     else:
+        if self.dtype != torch.get_default_dtype() and self.dtype != torch.int64:
+            suffix = ', dtype=' + str(self.dtype) + suffix
+
         fmt, scale, sz = _number_format(self)
         if scale != 1:
             prefix = prefix + SCALE_FORMAT.format(scale) + ' ' * indent


### PR DESCRIPTION
As mentioned in #6829, when a tensor is empty and dtype=torch.int64, we need print the dtype. Otherwise, the repr would construct an empty float tensor instead.

Before:
```
>>> torch.tensor([], dtype=torch.long)
tensor([])
```

After:
```
>>> torch.tensor([], dtype=torch.long)
tensor([], dtype=torch.int64)
```