### PR TITLE
Bump benchmark to master

### DIFF
--- a/binaries/core_overhead_benchmark.cc
+++ b/binaries/core_overhead_benchmark.cc
@@ -220,4 +220,4 @@ static void BM_TensorAllocDeallocCUDA(benchmark::State& state) {
 }
 BENCHMARK(BM_TensorAllocDeallocCUDA);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
This is continuation of #6737 in the spirit of reducing cmake time. Related PR at google/benchmark at: https://github.com/google/benchmark/pull/573 . On local laptop this reduces cmake re-run time from 8s to 6s (2s saving).

cc @ezyang 