### PR TITLE
[jit][script] Fix a bug combining sizes/unsized tensors

### DIFF
--- a/test/expect/TestScript.test_index_select_shape_prop.expect
+++ b/test/expect/TestScript.test_index_select_shape_prop.expect
@@ -1,0 +1,5 @@
+graph(%x : Double(2, 2)
+      %y : Long(4)) {
+  %2 : Double(2, 4) = aten::index_select[dim=1](%x, %y)
+  return (%2);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2541,7 +2541,7 @@ class TestScript(TestCase):
         v = torch.rand(10, 3)
         self.assertEqual(torch.chunk(v, dim=0, chunks=2)[0], foo(v))
 
-        with self.assertRaisesRegex(RuntimeError, r"variable 'a' previously has type \(Dynamic, Dynamic\)"):
+        with self.assertRaisesRegex(RuntimeError, r"variable 'a' previously has type \(Tensor, Tensor\)"):
             @torch.jit.script
             def mixtypes():
                 a = torch.chunk(1, dim=0, chunks=2)
@@ -2773,6 +2773,19 @@ class TestScript(TestCase):
         self.assertEqual(result, reference)
         self.assertExpected(torch.onnx._export_to_pretty_string(
             mte, (torch.ones(2, 3),), None, verbose=False))
+
+    def test_trace_with_size(self):
+        @torch.jit.trace(torch.zeros(1, 1))
+        def foo(x):
+            return x + 1
+
+        def bar(x):
+            y = foo(x)
+            if True:
+                y = 7
+            return y + 1
+
+        self.assertEqual(8, bar(torch.ones(1, 1)))
 
 
 # Smoke tests for export methods

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2779,6 +2779,7 @@ class TestScript(TestCase):
         def foo(x):
             return x + 1
 
+        @torch.jit.script
         def bar(x):
             y = foo(x)
             if True:
@@ -2786,6 +2787,17 @@ class TestScript(TestCase):
             return y + 1
 
         self.assertEqual(8, bar(torch.ones(1, 1)))
+
+    def test_index_select_shape_prop(self):
+
+        @torch.jit.script
+        def foo(x, y):
+            return torch.index_select(x, y, dim=1)
+
+        a = torch.zeros(2, 2)
+        b = torch.zeros(4, dtype=torch.long)
+        foo.graph.propagate_shapes((a, b), False)
+        self.assertExpected(str(foo.graph))
 
 
 # Smoke tests for export methods

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -292,6 +292,19 @@ void PropagateShapeOnNode(Node * node) {
         PropagateShapeOnNodeByRunningIt(node, types);
       }
     } break;
+    case aten::index_select: {
+      if(check_overload(/*num_inputs=*/2, /*num_outputs=*/1,
+                        {{AKind::i, attr::dim}})) {
+        auto ten = types.at(0);
+        auto index = types.at(1);
+        int64_t dim = node->i(attr::dim);
+        SHAPE_ASSERT(index->sizes().size() == 1);
+        SHAPE_ASSERT(dim >= 0 && static_cast<size_t>(dim) < ten->sizes().size());
+        std::vector<int64_t> sizes = ten->sizes();
+        sizes[dim] = index->sizes()[0];
+        node->output()->setType(ten->withSizes(sizes));
+      }
+    } break;
     case prim::ReplaceIfUndef: {
       // If types[0] has a type, then it is not defined, and the type will
       // get set to types[0] because that will be the value propagated.

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -26,7 +26,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
     ensureTensors(loc, inputs);
-    
+
     if (attributes.size() > 0)
       throw ErrorReport(loc) << "keyword arguments in Python calls aren't supported";
     Graph& g = *m.graph();
@@ -383,6 +383,9 @@ void initJitScriptBindings(PyObject* module) {
       auto inputs = createVariableTensorList(args);
       auto outputs = m.run(std::move(inputs));
       return unpackVariableTensorList(std::move(outputs));
+    })
+    .def_property_readonly("graph", [](Method& m) {
+      return m.graph();
     })
     .def("propagate_shapes", &Method::propagate_shapes)
     .def("params", &Method::params);

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -216,12 +216,12 @@ struct TupleType : public Type {
     return elements_;
   }
   virtual bool operator==(const Type& rhs) const override {
-    return compare(rhs, [&](const Type& a, const Type& b) {
+    return compare(rhs, [](const Type& a, const Type& b) {
       return a == b;
     });
   }
   virtual bool isSubtypeOf(const Type& rhs) const override {
-    return compare(rhs, [&](const Type& a, const Type&b) {
+    return compare(rhs, [](const Type& a, const Type&b) {
       return a.isSubtypeOf(b);
     });
   }

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -38,6 +38,12 @@ protected:
 
 public:
   virtual bool operator==(const Type& rhs) const = 0;
+
+  // subtyping relation. By default, we return true for the case
+  // when the type is exactly equal
+  virtual bool isSubtypeOf(const Type& rhs) const {
+    return *this == rhs;
+  }
   virtual std::string name() const = 0;
   TypeKind kind() const {
     return kind_;
@@ -77,7 +83,7 @@ inline bool operator!=(const Type & lhs, const Type & rhs) {
   return !(lhs == rhs);
 }
 
-
+// This node represents a single Tensor value, with an unknown shape.
 struct DynamicType : public Type {
   DynamicType()
   : Type(TypeKind::DynamicType) {}
@@ -85,14 +91,14 @@ struct DynamicType : public Type {
     return rhs.kind() == kind();
   }
   virtual std::string name() const override {
-    return "Dynamic";
+    return "Tensor";
   }
   static const TypeKind Kind = TypeKind::DynamicType;
   // global singleton
   static TypePtr get();
 };
 
-// This node represents a single Tensor value
+// This node represents a single Tensor value with a specific size
 struct TensorType : public Type {
   friend struct Type;
   TensorType(const at::Tensor& tensor)
@@ -139,6 +145,9 @@ struct TensorType : public Type {
            sizes() == rt->sizes() &&
            strides() == rt->strides() &&
            device() == rt->device();
+  }
+  virtual bool isSubtypeOf(const Type& rhs) const override {
+    return *this == rhs || rhs.kind() == TypeKind::DynamicType;
   }
   virtual std::string name() const override {
     std::string retval = std::string(at::toString(scalarType())) + "Tensor[";
@@ -207,6 +216,28 @@ struct TupleType : public Type {
     return elements_;
   }
   virtual bool operator==(const Type& rhs) const override {
+    return compare(rhs, [&](const Type& a, const Type& b) {
+      return a == b;
+    });
+  }
+  virtual bool isSubtypeOf(const Type& rhs) const override {
+    return compare(rhs, [&](const Type& a, const Type&b) {
+      return a.isSubtypeOf(b);
+    });
+  }
+  virtual std::string name() const override {
+    std::stringstream ss;
+    ss << "(";
+    for(size_t i = 0; i < elements().size(); ++i) {
+      if(i > 0)
+        ss << ", ";
+      ss << elements()[i]->name();
+    }
+    ss << ")";
+    return ss.str();
+  }
+private:
+  bool compare(const Type& rhs, std::function<bool(const Type&, const Type&)> fn) const {
     if(rhs.kind() != kind())
       return false;
     const auto & l_elements = elements();
@@ -214,15 +245,11 @@ struct TupleType : public Type {
     if(l_elements.size() != r_elements.size())
       return false;
     for(size_t i = 0; i < l_elements.size(); ++i) {
-      if(*l_elements[i] != *r_elements[i])
+      if(!fn(*l_elements[i], *r_elements[i]))
         return false;
     }
     return true;
   }
-  virtual std::string name() const override {
-    return "Tuple";
-  }
-private:
   std::vector<TypePtr> elements_;
 };
 


### PR DESCRIPTION
This add an isSubtypeOf method to reflect that sized tensors are a subtype
of Dynamic[Tensors]. It updates the typechecking code to reflect this
relationship.

