### PR TITLE
add additional caffe/caffe2 paths to exclude list in pytorch setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -807,7 +807,7 @@ def make_relative_rpath(path):
 ################################################################################
 
 extensions = []
-packages = find_packages(exclude=('tools', 'tools.*', 'caffe2', 'caffe'))
+packages = find_packages(exclude=('tools', 'tools.*', 'caffe2', 'caffe2.*', 'caffe', 'caffe.*'))
 C = Extension("torch._C",
               libraries=main_libraries,
               sources=main_sources,


### PR DESCRIPTION
some caffe2/caffe python files were getting installed in pytorch build