### PR TITLE
[Caffe2] Support non peer access in muji and fix bug when reduced_affix is empty

### DIFF
--- a/caffe2/python/muji.py
+++ b/caffe2/python/muji.py
@@ -3,14 +3,21 @@
 """muji.py does multi-gpu training for caffe2 with no need to change the c++
 side code. Everything is defined on the computation graph level.
 
-Currently, here are the assumptions: we only support the following use cases:
+We support the following use cases:
   - 2 gpus, where peer access is enabled between them.
   - 4 gpus, where peer access are enabled between all of them.
+  - 4 gpus, where peer access are enabled in two groups,
+    between {1, 2} and {3, 4}
   - 8 gpus, where peer access are enabled in two groups,
     between {1, 2, 3, 4} and {5, 6, 7, 8}.
+If above cases are not satisified, a fallback function which does not rely on
+peer access will be called.
 """
 
+import numpy as np
+
 from caffe2.proto import caffe2_pb2
+from caffe2.python import workspace
 
 
 def OnGPU(gpu_id):
@@ -39,11 +46,14 @@ def Allreduce(net, blobs, reduced_affix="_reduced", gpu_indices=None):
             "gpu_indices length and blobs length mismatch: %d vs %d" %
             (len(gpu_indices), len(blobs))
         )
-    if len(blobs) == 2:
+    pattern = workspace.GetCudaPeerAccessPattern()
+    if len(blobs) == 2 and pattern.shape[0] >= 2 and np.all(pattern[:2, :2]):
         return Allreduce2(net, blobs, reduced_affix, gpu_indices)
-    elif len(blobs) == 4:
+    elif len(blobs) == 4 and pattern.shape[0] >= 4 and np.all(pattern[:4, :4]):
         return Allreduce4(net, blobs, reduced_affix, gpu_indices)
-    elif len(blobs) == 8:
+    elif len(blobs) == 4 and pattern.shape[0] >= 4 and np.all(pattern[:2, :2]) and np.all(pattern[2:4, 2:4]):
+        return Allreduce4Group2(net, blobs, reduced_affix, gpu_indices)
+    elif len(blobs) == 8 and pattern.shape[0] >= 8 and np.all(pattern[:8, :8]):
         return Allreduce8(net, blobs, reduced_affix, gpu_indices)
     else:
         return AllreduceFallback(net, blobs, reduced_affix, gpu_indices)
@@ -89,6 +99,51 @@ def Allreduce4(net, blobs, reduced_affix, gpu_indices):
     )
     # a_reduced <- a_reduced + c_reduced
     a_reduced = a_reduced.Add(c_reduced, a_reduced, device_option=OnGPU(gpu_a))
+    # broadcast a_reduced to c_reduced
+    c_reduced = a_reduced.Copy([], c_reduced, device_option=OnGPU(gpu_c))
+    # broadcast to b and d
+    b_reduced = a_reduced.Copy(
+        [],
+        str(b) + reduced_affix,
+        device_option=OnGPU(gpu_b)
+    )
+    d_reduced = c_reduced.Copy(
+        [],
+        str(d) + reduced_affix,
+        device_option=OnGPU(gpu_d)
+    )
+    return a_reduced, b_reduced, c_reduced, d_reduced
+
+
+def Allreduce4Group2(net, blobs, reduced_affix, gpu_indices):
+    """Allreduce for 4 gpus where peer access are enabled in {0,1} and {2,3}
+
+  Algorithm: 2 level reduction.
+      0r <- 0 + 1, 2r <- 2 + 3
+      0r <- 0r + 2r
+      2r <- 0r,
+      1r <- 0r, 3r <- 2r
+  """
+    a, b, c, d = blobs
+    gpu_a, gpu_b, gpu_c, gpu_d = gpu_indices
+    # a_reduced <- a+b, c_reduced <- c + d
+    a_reduced = net.Add(
+        [a, b],
+        str(a) + reduced_affix,
+        device_option=OnGPU(gpu_a)
+    )
+    c_reduced = net.Add(
+        [c, d],
+        str(c) + reduced_affix,
+        device_option=OnGPU(gpu_c)
+    )
+    c_reduced_copy = c_reduced.Copy(
+        [],
+        str(c_reduced) + '_copy',
+        device_option=OnGPU(gpu_a)
+    )
+    # a_reduced <- a_reduced + c_reduced
+    a_reduced = a_reduced.Add(c_reduced_copy, a_reduced, device_option=OnGPU(gpu_a))
     # broadcast a_reduced to c_reduced
     c_reduced = a_reduced.Copy([], c_reduced, device_option=OnGPU(gpu_c))
     # broadcast to b and d

--- a/caffe2/python/muji.py
+++ b/caffe2/python/muji.py
@@ -137,12 +137,13 @@ def Allreduce4Group2(net, blobs, reduced_affix, gpu_indices):
         str(c) + reduced_affix,
         device_option=OnGPU(gpu_c)
     )
+    # copy from c_reduce(gpu_c) to c_reduce_copy(gpu_a)
     c_reduced_copy = c_reduced.Copy(
         [],
         str(c_reduced) + '_copy',
         device_option=OnGPU(gpu_a)
     )
-    # a_reduced <- a_reduced + c_reduced
+    # a_reduced <- a_reduced + c_reduced_copy
     a_reduced = a_reduced.Add(c_reduced_copy, a_reduced, device_option=OnGPU(gpu_a))
     # broadcast a_reduced to c_reduced
     c_reduced = a_reduced.Copy([], c_reduced, device_option=OnGPU(gpu_c))

--- a/caffe2/python/muji.py
+++ b/caffe2/python/muji.py
@@ -230,12 +230,15 @@ def AllreduceFallback(net, blobs, reduced_affix, gpu_indices):
       ir <- 0r for i in gpu_indices[1:]
   """
     reduced = [None] * len(gpu_indices)
-    # copy first
-    reduced[0] = net.Copy(
-        blobs[0],
-        blobs[0] + reduced_affix,
-        device_option=OnGPU(gpu_indices[0])
-    )
+    if reduced_affix != '':
+        # copy first
+        reduced[0] = net.Copy(
+            blobs[0],
+            blobs[0] + reduced_affix,
+            device_option=OnGPU(gpu_indices[0])
+        )
+    else:
+        reduced[0] = blobs[0]
     # do temp copy and add
     temp_name = reduced[0] + '_temp_copy'
     for i in range(1, len(gpu_indices)):
@@ -244,8 +247,8 @@ def AllreduceFallback(net, blobs, reduced_affix, gpu_indices):
             temp_name,
             device_option=OnGPU(gpu_indices[0])
         )
-        reduced[0] = reduced[0].Add(
-            temp,
+        reduced[0] = net.Add(
+            [temp, reduced[0]],
             reduced[0],
             device_option=OnGPU(gpu_indices[0])
         )

--- a/caffe2/python/muji.py
+++ b/caffe2/python/muji.py
@@ -10,7 +10,7 @@ We support the following use cases:
     between {1, 2} and {3, 4}
   - 8 gpus, where peer access are enabled in two groups,
     between {1, 2, 3, 4} and {5, 6, 7, 8}.
-If above cases are not satisified, a fallback function which does not rely on
+If above cases are not satisfied, a fallback function which does not rely on
 peer access will be called.
 """
 
@@ -38,6 +38,8 @@ def OnCPU():
 
 def Allreduce(net, blobs, reduced_affix="_reduced", gpu_indices=None):
     """The general Allreduce interface that reroutes the function calls.
+    CPUs and AMD GPUs are not supported because
+    GetCudaPeerAccessPattern is called to get gpu peer access pattern.
   """
     if gpu_indices is None:
         gpu_indices = list(range(len(blobs)))

--- a/caffe2/python/muji_test.py
+++ b/caffe2/python/muji_test.py
@@ -59,6 +59,13 @@ class TestMuji(test_util.TestCase):
         else:
             print('Skipping allreduce with 4 gpus. Not peer access ready.')
 
+    def testAllreduceWithFourGPUsAndTwoGroups(self):
+        pattern = workspace.GetCudaPeerAccessPattern()
+        if pattern.shape[0] >= 4 and np.all(pattern[:2, :2]) and np.all(pattern[2:4, 2:4]):
+            self.RunningAllreduceWithGPUs([0, 1, 2, 3], muji.Allreduce4Group2)
+        else:
+            print('Skipping allreduce with 4 gpus and 2 groups. Not peer access ready.')
+
     def testAllreduceWithEightGPUs(self):
         pattern = workspace.GetCudaPeerAccessPattern()
         if (
@@ -69,3 +76,7 @@ class TestMuji(test_util.TestCase):
                 list(range(8)), muji.Allreduce8)
         else:
             print('Skipping allreduce with 8 gpus. Not peer access ready.')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
reference: https://github.com/facebookresearch/Detectron/issues/32

Detectron users with gpus lacking peer access can't train models using multiple gpus. A workaround is using nccl but it may [suffer from deadlock](https://github.com/facebookresearch/Detectron/issues/32#issuecomment-361140510).

I updated the code in muji so that it will use the proper way of allreduce according to the peer access pattern. Since there are many users having four gpus where pear access are enabled between {0,1} and {2,3}(e.g. myself), I also added an `Allreduce4Group2` function for this case.

I have verified it on [configs/getting_started/tutorial_4gpu_e2e_faster_rcnn_R-50-FPN.yaml](https://github.com/facebookresearch/Detectron/blob/master/configs/getting_started/tutorial_4gpu_e2e_faster_rcnn_R-50-FPN.yaml) of detectron