### PR TITLE
Speedup sparse init

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5121,8 +5121,7 @@ class TestNNInit(TestCase):
 
                 for col_idx in range(input_tensor.size(1)):
                     column = input_tensor[:, col_idx]
-                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), 
-                           "{} : {}, {}".format(column[column == 0].nelement(), sparsity, cols)
+                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), "{} : {}, {}".format(column[column == 0].nelement(), sparsity, cols)
 
                 assert self._is_normal(input_tensor[input_tensor != 0], 0, std)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5121,7 +5121,7 @@ class TestNNInit(TestCase):
 
                 for col_idx in range(input_tensor.size(1)):
                     column = input_tensor[:, col_idx]
-                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), "{} : {}, {}".format(column[column == 0].nelement(), sparsity, cols)
+                    assert column[column == 0].nelement() >= math.ceil(sparsity * rows)
 
                 assert self._is_normal(input_tensor[input_tensor != 0], 0, std)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5121,7 +5121,8 @@ class TestNNInit(TestCase):
 
                 for col_idx in range(input_tensor.size(1)):
                     column = input_tensor[:, col_idx]
-                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), "{} : {}".format(column[column == 0].nelement(), math.ceil(sparsity * cols))
+                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), 
+                           "{} : {}, {}".format(column[column == 0].nelement(), sparsity, cols)
 
                 assert self._is_normal(input_tensor[input_tensor != 0], 0, std)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5121,7 +5121,7 @@ class TestNNInit(TestCase):
 
                 for col_idx in range(input_tensor.size(1)):
                     column = input_tensor[:, col_idx]
-                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols)
+                    assert column[column == 0].nelement() >= math.ceil(sparsity * cols), "{} : {}".format(column[column == 0].nelement(), math.ceil(sparsity * cols))
 
                 assert self._is_normal(input_tensor[input_tensor != 0], 0, std)
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -361,6 +361,7 @@ def sparse_(tensor, sparsity, std=0.01):
 
     rows, cols = tensor.shape
     num_zeros = int(math.ceil(rows * sparsity))
+
     with torch.no_grad():
         tensor.normal_(0, std)
         for col_idx in range(cols):

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -367,8 +367,7 @@ def sparse_(tensor, sparsity, std=0.01):
         for col_idx in range(cols):
             row_indices = torch.randperm(rows)
             zero_indices = row_indices[:num_zeros]
-            t = tensor[:, col_idx]
-            t[zero_indices] = 0
+            tensor[zero_indices, col_idx] = 0
     return tensor
 
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -360,7 +360,7 @@ def sparse_(tensor, sparsity, std=0.01):
         raise ValueError("Only tensors with 2 dimensions are supported")
 
     rows, cols = tensor.shape
-    num_zeros = int(math.ceil(rows * sparsity))
+    num_zeros = int(math.ceil(sparsity * rows))
 
     with torch.no_grad():
         tensor.normal_(0, std)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -361,16 +361,13 @@ def sparse_(tensor, sparsity, std=0.01):
 
     rows, cols = tensor.shape
     num_zeros = int(math.ceil(rows * sparsity))
-
     with torch.no_grad():
         tensor.normal_(0, std)
         for col_idx in range(cols):
-            row_indices = list(range(rows))
-            random.shuffle(row_indices)
+            row_indices = torch.randperm(rows)
             zero_indices = row_indices[:num_zeros]
-            for row_idx in zero_indices:
-                tensor[row_idx, col_idx] = 0
-
+            t = tensor[:, col_idx]
+            t[zero_indices] = 0
     return tensor
 
 


### PR DESCRIPTION
As per #6021

- Removes the nested for loop in favor of list indexing
- Obtains ~10-20x speedup on average.

Following the discussion in the issue, I ran a shootout between the currently implemented initialization,  the version proposed by @stefanonardo (Opt1) and the version proposed by @fmassa (Opt2).

I ran sparse init on tensors of sizes  `[(500, 500), (100, 100), (50, 50), (10, 10)]` and for sparsities of `[1, 0.1, 0.01]`. Each initialization was re-ran 10 times. What I learned:

- The original version is consistently >= 10x slower
- Opt1 is faster for larger numbers of zero elements (due to what I assume, `topk` having complexity of k*n), where k is the number of zeros
- Opt2 is faster for smaller numbers of zero elements

However, in the largest case I tested (500x500 tensor, sparsity=1), Opt2 is about the same speed as the original version, and in the other edge case (500x500 tensor, sparsity=0.01), it is ~27% slower with a higher speed deviation.

Implementation credit goes to @stefanonardo 

Full (badly formatted) results are here for the next month: https://pastebin.com/fB4mHqM9
