### PR TITLE
[caffe2] Add flag to ONNXWhile to skip scoping

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -1197,10 +1197,9 @@ void Caffe2Backend::BuildTensorFillingOp(
     const ::google::protobuf::RepeatedField<double>* src = &tmp;
     if (!TryConvertingTensorRawValues<double>(onnx_tensor, &tmp)) {
       src = &onnx_tensor.double_data();
-    } else {
-      for (const auto i : *src) {
-        c2_values->add_floats(i);
-      }
+    }
+    for (const auto i : *src) {
+      c2_values->add_floats(i);
     }
   } else if (onnx_tensor.data_type() == TensorProto::INT64) {
     c2_op->set_type("GivenTensorInt64Fill");
@@ -1217,10 +1216,9 @@ void Caffe2Backend::BuildTensorFillingOp(
     if (!TryConvertingTensorRawValues<::google::protobuf::uint64>(
             onnx_tensor, &tmp)) {
       src = &onnx_tensor.uint64_data();
-    } else {
-      for (const auto i : *src) {
-        c2_values->add_ints(i);
-      }
+    }
+    for (const auto i : *src) {
+      c2_values->add_ints(i);
     }
   } else if (
       onnx_tensor.data_type() == TensorProto::BOOL ||
@@ -1238,10 +1236,9 @@ void Caffe2Backend::BuildTensorFillingOp(
     if (!TryConvertingTensorRawValues<::google::protobuf::int32>(
             onnx_tensor, &tmp)) {
       src = &onnx_tensor.int32_data();
-    } else {
-      for (const auto i : *src) {
-        c2_values->add_ints(i);
-      }
+    }
+    for (const auto i : *src) {
+      c2_values->add_ints(i);
     }
   } else if (onnx_tensor.data_type() == TensorProto::STRING) {
     c2_op->set_type("GivenTensorStringFill");

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -127,6 +127,11 @@ class Caffe2Backend {
 
   Caffe2Ops ConvertNode(const std::string& node_str, int opset_version);
 
+  void BuildTensorFillingOp(
+      caffe2::OperatorDef* c2_op,
+      const TensorProto& onnx_tensor,
+      const std::string& name = "");
+
  private:
   using SpecialOpConverter = Caffe2Ops (Caffe2Backend::*)(OnnxNode*, int);
 
@@ -148,11 +153,6 @@ class Caffe2Backend {
       int opset_version);
 
   std::unordered_set<std::string> AllNamesInGraph(const GraphProto& graph);
-
-  void BuildTensorFillingOp(
-      caffe2::OperatorDef* c2_op,
-      const TensorProto& onnx_tensor,
-      const std::string& name = "");
 
   Caffe2Ops CommonOnnxNodeToCaffe2Ops(OnnxNode* onnx_node, int opset_version);
 

--- a/caffe2/operators/onnx_while_op.cc
+++ b/caffe2/operators/onnx_while_op.cc
@@ -60,8 +60,23 @@ is marked as omitted by setting its 'has_{name}' argument to False.
           cond = ...;
         }
     )DOC")
-    .Arg("loop_net", "Net executed on each iteration")
-    .Input(0, "condition", "Scalar boolean condition")
+    .Arg("body", "Net executed on each iteration")
+    .Arg("has_trip_count", "Whether to use the trip count input")
+    .Arg("has_cond", "Whether to use the condition input")
+    .Arg("save_scopes", "Whether to save the scopes across iterations, as in "
+                        "for backprop")
+    .Arg("disable_scopes", "Do not create new scopes. Use this only if you're "
+                           "certain there will be no name collision, for "
+                           "example if you're converting from a fully-SSA IR")
+    .NumInputs(2, INT_MAX)
+    .Input(0, "max_trip_count", "Number of iterations to go out to. Used if "
+                                "the flag has_trip_count is True.")
+    .Input(1, "first_iter_condition", "Dynamic condition value for the first "
+                                      "iteration. For all subsequent iterations,"
+                                      " the condition from the body graph is "
+                                      "used. This input is used if the flag "
+                                      "has_cond is true.")
+    .NumOutputs(0, INT_MAX)
     .AllowInplace([](int in, int out) -> bool { return true; });
 
 } // namespace caffe2

--- a/caffe2/python/operator_test/onnx_while_test.py
+++ b/caffe2/python/operator_test/onnx_while_test.py
@@ -16,11 +16,14 @@ class TestONNXWhile(hu.HypothesisTestCase):
         condition=st.booleans(),
         max_trip_count=st.integers(0, 100),
         save_scopes=st.booleans(),
+        disable_scopes=st.booleans(),
         seed=st.integers(0, 65535),
         **hu.gcs_cpu_only)
     def test_onnx_while_fibb(
-            self, condition, max_trip_count, save_scopes, seed, gc, dc):
+            self, condition, max_trip_count, save_scopes, disable_scopes, seed, gc, dc):
         np.random.seed(seed)
+        if disable_scopes:
+            save_scopes = False
 
         # Create body net
         body_net = caffe2_pb2.NetDef()
@@ -60,6 +63,7 @@ class TestONNXWhile(hu.HypothesisTestCase):
             has_cond=True,
             has_trip_count=True,
             save_scopes=save_scopes,
+            disable_scopes=disable_scopes,
         )
 
         condition_arr = np.array(condition).astype(np.bool)
@@ -87,7 +91,6 @@ class TestONNXWhile(hu.HypothesisTestCase):
             [max_trip_count_arr, condition_arr, first_init, second_init],
             ref,
         )
-        self.assertFalse(workspace.HasBlob("cond_new"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -774,7 +774,20 @@ void addObjectMethods(py::module& m) {
               normal_vals.emplace_back(py::bytes(out));
             }
             return vals;
-          });
+          })
+      .def(
+        "_build_tensor_filling_op",
+        [](caffe2::onnx::Caffe2Backend& instance,
+           const py::bytes& tensor_proto_str,
+           const std::string& name="") -> py::bytes {
+            caffe2::OperatorDef op;
+            onnx_c2::TensorProto tp;
+            ParseProtoFromLargeString(tensor_proto_str, &tp);
+            instance.BuildTensorFillingOp(&op, tp, name);
+            std::string out;
+            op.SerializeToString(&out);
+            return py::bytes(out);
+        });
 
   py::class_<Predictor>(m, "Predictor")
       .def(


### PR DESCRIPTION
Stacked on top of https://github.com/pytorch/pytorch/pull/6909. Look at the last commit.

This makes it easier to emit from ONNX, where we're guaranteed uniqueness of names due to SSA. 