### PR TITLE
 [caffe2] ONNX backend support for control nodes 

### DIFF
--- a/caffe2/python/onnx/tests/conversion_test.py
+++ b/caffe2/python/onnx/tests/conversion_test.py
@@ -172,6 +172,100 @@ class TestConversion(TestCase):
         Y = c2_model.run(X).Y
         np.testing.assert_allclose(Y, Y_expect)
 
+    def _make_fake_if_op(self, true_nodes, false_nodes, output_types):
+        true = helper.make_tensor("condition", TensorProto.BOOL, (), [True])
+        true_graph = helper.make_graph(true_nodes, "true_graph", [], [
+            helper.make_tensor_value_info("_Y", TensorProto.FLOAT, (2, 2)),
+        ])
+        false_graph = helper.make_graph(false_nodes, "false_graph", [], [
+            helper.make_tensor_value_info("_Y", TensorProto.FLOAT, (2, 2)),
+        ])
+        if_inputs = ["condition"]
+        if_outputs = [name for _, _, name in output_types]
+        retval_nodes = [
+            helper.make_node("Constant", [], ["condition"], value=true),
+            helper.make_node("If", if_inputs, if_outputs, then_branch=true_graph,
+                             else_branch=false_graph)
+        ]
+        return retval_nodes
+
+    def test_onnx_to_caffe2_if(self):
+        true_nodes = [helper.make_node(
+            "MatMul", ["X", "W"], ["_Y"])]
+        false_nodes = [helper.make_node("Slice", ["X"], ["_Y"], axes=[0, 1], starts=[0, 0], ends=[0, 2])]
+        nodes = self._make_fake_if_op(true_nodes, false_nodes, [(TensorProto.FLOAT, (2, 2), "Y")])
+        X = np.random.rand(2, 3).astype(np.float32)
+        W = np.random.rand(3, 2).flatten().astype(np.float32)
+        graph_def = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3)),
+             helper.make_tensor_value_info("W", TensorProto.FLOAT, (3, 2))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (2, 2))],
+            initializer=[helper.make_tensor("W",
+                                            TensorProto.FLOAT,
+                                            [3, 2],
+                                            W.tolist())]
+        )
+        model_def = helper.make_model(graph_def, producer_name='onnx-to-caffe2-test')
+
+        p = c2.prepare(model_def)
+        Y = np.matmul(X, W.reshape(3, 2))
+        out = p.run(X)
+        np.testing.assert_allclose(out.Y, Y)
+
+    # input_types and output_types are lists of triples of (name, type, shape)
+    def _make_fake_loop_op(self, body_nodes, input_types, output_types):
+        ten = helper.make_tensor("trip_count_value", TensorProto.INT64, (1,), [10])
+        true = helper.make_tensor("condition", TensorProto.BOOL, (1,), [True])
+        # lcd is a dummy loop-carried dependency that only exists because
+        # right now the schema checker is broken and assumes a variadic
+        # input needs at least one value.
+        graph_inputs = [helper.make_tensor_value_info("i", TensorProto.INT32, ()),
+                        helper.make_tensor_value_info("cond", TensorProto.BOOL, ())]
+        for type, shape, name in input_types:
+            graph_inputs.append(helper.make_tensor_value_info("_" + name, type, shape))
+        graph_outputs = [helper.make_tensor_value_info("cond", TensorProto.BOOL, ())]
+        for type, shape, name in output_types:
+            graph_outputs.append(helper.make_tensor_value_info("_" + name, type, shape))
+        body_graph = helper.make_graph(body_nodes, "body_graph", graph_inputs,
+                                       graph_outputs)
+        loop_inputs = ["trip_count", "condition"]
+        loop_inputs.extend([name for _, _, name in input_types])
+        loop_outputs = [name for _, _, name in output_types]
+        retval_nodes = [
+            helper.make_node("Constant", [], ["trip_count"], value=ten),
+            helper.make_node("Constant", [], ["condition"], value=true),
+            helper.make_node("Loop", loop_inputs, loop_outputs, body=body_graph)
+        ]
+        return retval_nodes
+
+    def test_onnx_to_caffe2_loop(self):
+        body_nodes = [helper.make_node(
+            "MatMul", ["_X", "W"], ["_Y"])]
+        nodes = self._make_fake_loop_op(body_nodes,
+                                        [(TensorProto.FLOAT, (2, 2), "X")],
+                                        [(TensorProto.FLOAT, (2, 2), "Y")])
+        X = np.random.rand(2, 2).astype(np.float32)
+        W = np.random.rand(2, 2).flatten().astype(np.float32)
+        graph_def = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 2)),
+             helper.make_tensor_value_info("W", TensorProto.FLOAT, (2, 2))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (2, 2))],
+            initializer=[helper.make_tensor("W",
+                                            TensorProto.FLOAT,
+                                            [2, 2],
+                                            W.tolist())]
+        )
+        model_def = helper.make_model(graph_def, producer_name='onnx-to-caffe2-test')
+        Y = X
+        for _ in range(10):
+            Y = np.matmul(Y, W.reshape(2, 2))
+        p = c2.prepare(model_def)
+        out = p.run(X)
+        np.testing.assert_allclose(out.Y, Y)
 
     # TODO investigate why this is failing after changing Reshape
     # operator from taking the new shape as attribute to as input


### PR DESCRIPTION
Stacked on top of https://github.com/pytorch/pytorch/pull/6910, look at the last commit

This adds ONNX-caffe2 backend support for the control nodes