### PR TITLE
Workaround in onnx to get transposes into init_nets

### DIFF
--- a/test/expect/TestScript.test_onnx_export_speculate-f1.expect
+++ b/test/expect/TestScript.test_onnx_export_speculate-f1.expect
@@ -1,0 +1,66 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 10}]
+      outputs: [{name: "6", type:Tensor dims: 10 1}]
+      initializers: []
+      nodes: [
+        Node {type: "Add", inputs: [x,x], outputs: [1], attributes: []},
+        Node {type: "Constant", inputs: [], outputs: [2], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "Transpose", inputs: [1], outputs: [3], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "Transpose", inputs: [1], outputs: [4], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "Transpose", inputs: [1], outputs: [5], attributes: [{ name: 'perm', type: ints, values: [1 0]}]},
+        Node {type: "If", inputs: [2], outputs: [6], attributes: [{ name: 'then_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export1"
+              inputs: []
+              outputs: [{name: "8", type:Tensor dims: 10 1}]
+              initializers: []
+              nodes: [
+                Node {type: "Constant", inputs: [], outputs: [7], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+                Node {type: "If", inputs: [7], outputs: [8], attributes: [{ name: 'then_branch', type: graph, value:
+                    GraphProto {
+                      name: "torch-jit-export2"
+                      inputs: []
+                      outputs: [{name: "3", type:Tensor dims: 10 1}]
+                      initializers: []
+                      nodes: [
+                        
+                      ]
+                    }
+
+                  },{ name: 'else_branch', type: graph, value:
+                    GraphProto {
+                      name: "torch-jit-export3"
+                      inputs: []
+                      outputs: [{name: "4", type:Tensor dims: 10 1}]
+                      initializers: []
+                      nodes: [
+                        
+                      ]
+                    }
+
+                  }]}
+              ]
+            }
+
+          },{ name: 'else_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export4"
+              inputs: []
+              outputs: [{name: "5", type:Tensor dims: 10 1}]
+              initializers: []
+              nodes: [
+                
+              ]
+            }
+
+          }]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/test/expect/TestScript.test_onnx_export_speculate-f2.expect
+++ b/test/expect/TestScript.test_onnx_export_speculate-f2.expect
@@ -1,0 +1,63 @@
+ModelProto {
+  producer_name: "pytorch"
+  domain: ""
+  doc_string: ""
+  graph:
+    GraphProto {
+      name: "torch-jit-export"
+      inputs: [{name: "x", type:Tensor dims: 1 10},{name: "1", type:Tensor dims: 20 10},{name: "2", type:Tensor dims: 20}]
+      outputs: [{name: "5", type:Tensor dims: 1 20}]
+      initializers: [TensorProto shape: [20 10],TensorProto shape: [20]]
+      nodes: [
+        Node {type: "Add", inputs: [x,x], outputs: [3], attributes: []},
+        Node {type: "Constant", inputs: [], outputs: [4], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+        Node {type: "If", inputs: [4], outputs: [5], attributes: [{ name: 'then_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export1"
+              inputs: []
+              outputs: [{name: "7", type:Tensor dims: 1 20}]
+              initializers: []
+              nodes: [
+                Node {type: "Constant", inputs: [], outputs: [6], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: []}]},
+                Node {type: "If", inputs: [6], outputs: [7], attributes: [{ name: 'then_branch', type: graph, value:
+                    GraphProto {
+                      name: "torch-jit-export2"
+                      inputs: []
+                      outputs: [{name: "8", type:Tensor dims: 1 20}]
+                      initializers: []
+                      nodes: [
+                        Node {type: "Gemm", inputs: [3,1,2], outputs: [8], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'broadcast', type: int, value: 1},{ name: 'transB', type: int, value: 1}]}
+                      ]
+                    }
+
+                  },{ name: 'else_branch', type: graph, value:
+                    GraphProto {
+                      name: "torch-jit-export3"
+                      inputs: []
+                      outputs: [{name: "9", type:Tensor dims: 1 20}]
+                      initializers: []
+                      nodes: [
+                        Node {type: "Gemm", inputs: [3,1,2], outputs: [9], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'broadcast', type: int, value: 1},{ name: 'transB', type: int, value: 1}]}
+                      ]
+                    }
+
+                  }]}
+              ]
+            }
+
+          },{ name: 'else_branch', type: graph, value:
+            GraphProto {
+              name: "torch-jit-export4"
+              inputs: []
+              outputs: [{name: "10", type:Tensor dims: 1 20}]
+              initializers: []
+              nodes: [
+                Node {type: "Gemm", inputs: [3,1,2], outputs: [10], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'broadcast', type: int, value: 1},{ name: 'transB', type: int, value: 1}]}
+              ]
+            }
+
+          }]}
+      ]
+    }
+  opset_import: [OperatorSetIdProto { domain: }],
+}

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -261,7 +261,7 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
       body->set_name("body");
       body->set_type(onnx::aGRAPH);
       auto g = body->mutable_g();
-      encodeBlock(g, node->blocks()[0], initializers, ctx, raw_data_export_map);
+      encodeBlock(g, node->blocks()[0], {}, ctx, raw_data_export_map);
     }
     if (node->kind() == torch::jit::onnx::If) {
       JIT_ASSERT(node->blocks().size() == 2);
@@ -270,17 +270,18 @@ void encodeBlock(onnx::GraphProto * p_g, Block *b,
       true_branch->set_name("then_branch");
       true_branch->set_type(onnx::aGRAPH);
       auto true_g = true_branch->mutable_g();
-      encodeBlock(true_g, node->blocks()[0], initializers, ctx, raw_data_export_map);
+      encodeBlock(true_g, node->blocks()[0], {}, ctx, raw_data_export_map);
 
       auto false_branch = p_n->add_attribute();
       false_branch->set_name("else_branch");
       false_branch->set_type(onnx::aGRAPH);
       auto false_g = false_branch->mutable_g();
-      encodeBlock(false_g, node->blocks()[1], initializers, ctx, raw_data_export_map);
+      encodeBlock(false_g, node->blocks()[1], {}, ctx, raw_data_export_map);
     }
   }
   auto num_initializers = initializers.size();
-  int inputs_count = b->inputs().size() - num_initializers;
+  JIT_ASSERT(b->inputs().size() >= num_initializers);
+  size_t inputs_count = b->inputs().size() - num_initializers;
   for (auto & tensor : initializers) {
     // TODO: stop using positions to determine which initializers
     // match to which inputs

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -197,6 +197,7 @@ void fuseTransposeIntoGemm(Block *b) {
 //   the removeNopPacking pass removes the packing operations
 //   entirely by pairing them with their inverse PadPacked. If the
 //   input graph does not pair the operations, export will fail.
+
 void pushPackingPastRnn(Block *b) {
   for (auto it = b->nodes().begin(); it != b->nodes().end(); ++it) {
     auto* n = *it;
@@ -215,6 +216,9 @@ void pushPackingPastRnn(Block *b) {
     if (!isRNN(rnn)) {
       continue;
     }
+
+    if(rnn->owningBlock() != n->owningBlock())
+      continue;
 
     // remove PackPadded from in front of the RNN
     n->outputs()[0]->replaceAllUsesWith(n->inputs()[0]);
@@ -373,6 +377,36 @@ void fixDefaultLstmCellState(Block *b) {
   }
 }
 
+static bool isSafeToSpeculate(Node* n) {
+  return n->kind() == onnx::Transpose;
+}
+
+static void speculateOps(Block* block) {
+  for(auto it = block->nodes().begin(), end = block->nodes().end();
+      it != end;) {
+    Node * n = *it;
+    ++it; //note: increment first so that it is safe to move the node if needed
+
+    for(auto b : n->blocks()) {
+      speculateOps(b);
+    }
+    if(!isSafeToSpeculate(n))
+      continue;
+    // XXX - only works for nodes with a single input
+    // move node n outside of the control flow it is nested in
+    auto node_input = n->input()->node();
+    if(node_input->owningBlock() == n->owningBlock())
+      continue;
+    // find the control flow node in the same block as node_input that contains
+    // Node n
+    auto control_flow_node = n->owningBlock()->owningNode();
+    while(control_flow_node->owningBlock() != node_input->owningBlock())
+      control_flow_node = control_flow_node->owningBlock()->owningNode();
+    // put the node right before this flow node
+    n->moveBefore(control_flow_node);
+  }
+}
+
 // This optimization does ONNX-specific peephole optimizations.
 //
 // At the moment, here are the optimizations it does:
@@ -402,6 +436,7 @@ void PeepholeOptimizeONNX(std::shared_ptr<Graph>& graph) {
   fuseConsecutiveTransposes(graph->block());
   eliminateNopTranspose(graph->block());
   fuseTransposeIntoGemm(graph->block());
+  speculateOps(graph->block());
 }
 
 }}

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -182,7 +182,6 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
     graph, params, torch_out = _model_to_graph(model, args, f, verbose,
                                                training, input_names,
                                                output_names, aten)
-
     # TODO: Don't allocate a in-memory string for the protobuf
     from torch.onnx.symbolic import _onnx_opset_version
     defer_weight_export = export_type is not ExportTypes.PROTOBUF_FILE


### PR DESCRIPTION
This adds a pass to ONNX so that it can speculate Transpose
operators so that ONNX's split pass can put them into an init_net

