### PR TITLE
remove quotes from caffe2/contrib/aten/CMakeLists.txt

### DIFF
--- a/caffe2/contrib/aten/CMakeLists.txt
+++ b/caffe2/contrib/aten/CMakeLists.txt
@@ -24,6 +24,7 @@ if(USE_ATEN)
   add_library(aten_op_header_gen INTERFACE)
   add_dependencies(aten_op_header_gen __aten_op_header_gen)
 
-  set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} "${CMAKE_CURRENT_SOURCE_DIR}/aten_op.cc" PARENT_SCOPE)
-  set(Caffe2_GPU_SRCS ${Caffe2_GPU_SRCS} "${CMAKE_CURRENT_SOURCE_DIR}/aten_op_cuda.cc" PARENT_SCOPE)
+  set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/aten_op.cc PARENT_SCOPE)
+  set(Caffe2_GPU_SRCS ${Caffe2_GPU_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/aten_op_cuda.cc PARENT_SCOPE)
 endif()
+


### PR DESCRIPTION
Because of quirks of how CMake deals with strings and lists, these quotes were causing a space to be prepended to source code file names, breaking building Caffe2 with ATen with:

CMAKE_ARGS=-DUSE_ATEN=ON python setup_caffe2.py install

cc @dzhulgakov 