### PR TITLE
add spectral normalization [pytorch]

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -715,6 +715,16 @@ Utilities
 
 .. autofunction:: torch.nn.utils.remove_weight_norm
 
+:hidden:`spectral_norm`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.utils.spectral_norm
+
+:hidden:`remove_spectral_norm`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: torch.nn.utils.remove_spectral_norm
+
 
 .. currentmodule:: torch.nn.utils.rnn
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1314,12 +1314,11 @@ class TestNN(NNTestCase):
         expect_out = m(input)
         self.assertAlmostEqual(expect_out, out_hat)
 
-
     def test_spectral_norm_pickle(self):
         m = torch.nn.utils.spectral_norm(nn.Linear(5, 7))
         m = pickle.loads(pickle.dumps(m))
         self.assertIsInstance(m, nn.Linear)
-        
+
     def test_embedding_sparse_basic(self):
         embedding = nn.Embedding(10, 20, sparse=True)
         input = Variable(torch.LongTensor([[0, 2, 4, 5], [4, 3, 0, 9]]))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1306,9 +1306,9 @@ class TestNN(NNTestCase):
         _weight, _bias, _u = m.weight_org, m.bias, m.weight_u
         _weight_mat = _weight.view(_weight.size(0), -1)
         _v = torch.mv(_weight_mat.t(), _u)
-        _v = _v / (_v.norm() + 1e-12)
+        _v = F.normalize(_v, dim=0, eps=1e-12)
         _u = torch.mv(_weight_mat, _v)
-        _u = _u / (_u.norm() + 1e-12)
+        _u = F.normalize(_u, dim=0, eps=1e-12)
         _weight.data /= torch.dot(_u, torch.matmul(_weight_mat, _v))
         out_hat = torch.nn.functional.linear(input, _weight, _bias)
         expect_out = m(input)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1286,6 +1286,25 @@ class TestNN(NNTestCase):
         m = pickle.loads(pickle.dumps(m))
         self.assertIsInstance(m, nn.Linear)
 
+    def test_spectral_norm(self):
+        input = torch.randn(3, 5)
+        m = nn.Linear(5, 7)
+        _weight = m._parameters['weight']
+        m = torch.nn.utils.spectral_norm(m)
+        output = m(input)
+
+        self.assertEqual(m.weight_u.size(), (m.weight.size(0)))
+        self.assertTrue(hasattr(m, 'weight_org'))
+
+        m = torch.utils.remove_spectral_norm(m)
+        self.assertFalse(hasattr(m, 'weight_org'))
+        self.assertFalse(hasattr(m, 'weight_u'))
+
+    def test_spectral_norm_pickle(self):
+        m = torch.nn.utils.spectral_norm(nn.Linear(5, 7))
+        m = pickle.loads(pickle.dumps(m))
+        self.assertIsInstance(m, nn.Linear)
+        
     def test_embedding_sparse_basic(self):
         embedding = nn.Embedding(10, 20, sparse=True)
         input = Variable(torch.LongTensor([[0, 2, 4, 5], [4, 3, 0, 9]]))

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -2,3 +2,4 @@ from . import rnn
 from .clip_grad import clip_grad_norm
 from .weight_norm import weight_norm, remove_weight_norm
 from .convert_parameters import parameters_to_vector, vector_to_parameters
+from .spectral_norm import spectral_norm, remove_spectral_norm

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -1,0 +1,122 @@
+r"""Spectral Normalization from https://arxiv.org/abs/1802.05957"""
+import torch
+from torch.nn.parameter import Parameter
+
+
+def l2normalize(v, eps=1e-12):
+    """Scale to inputs norm to 1."""
+    denom = v.norm(p=2) + eps
+    return v / denom
+
+
+class SpectralNorm(object):
+
+    """Spectral Normalization for weights."""
+
+    def __init__(self, name='weight', n_power_iterations=1, eps=1e-12):
+        self.name = name
+        self.n_power_iterations = n_power_iterations
+        self.eps = eps
+
+    def compute_weight(self, module):
+        weight = module._parameters[self.name + '_org']
+        u = module._buffers[self.name + '_u']
+        height, _cuda = weight.size(0), weight.is_cuda
+        weight_mat = weight.view(height, -1)
+        for _ in range(self.n_power_iterations):
+            v = l2normalize(torch.matmul(weight_mat.t(), u), self.eps)
+            u = l2normalize(torch.matmul(weight_mat, v), self.eps)
+
+        sigma = torch.dot(u, torch.matmul(weight_mat, v))
+        weight.data /= sigma
+        return weight, u
+
+    def remove(self, module):
+        weight, _ = self.compute_weight(module)
+        del module._parameters[self.name]
+        del module._buffers[self.name + '_u']
+        del module._parameters[self.name + '_org']
+        module.register_parameter(self.name, module._parameters[self.name])
+
+    def __call__(self, module, inputs):
+        weight, u = self.compute_weight(module)
+        setattr(module, self.name, weight)
+        setattr(module, self.name + '_u', u)
+
+    @staticmethod
+    def apply(module, name, n_power_iterations, eps):
+        fn = SpectralNorm(name, n_power_iterations, eps)
+        weight = module._parameters[name]
+        height = weight.size(0)
+
+        u = l2normalize(weight.data.new(height).normal_(0, 1), fn.eps)
+        module.register_parameter(fn.name + "_org", weight)
+        module.register_buffer(fn.name + "_u", u)
+
+        module.register_forward_pre_hook(fn)
+        return fn
+
+
+def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
+    r"""Applies spectral normalization to a parameter in the given module.
+
+    .. math::
+         \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})}
+         \text{where, } \sigma(\mathbf{W}) := \max_{\mathbf{h} \ne 0} \dfrac{\|\mathbf{A} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
+
+    Spectral normalization is a reparameterization that decouples the magnitude
+    of a weight tensor from its direction. This replaces the parameter specified
+    by `name` (e.g. "weight") with two parameters: one specifying the magnitude
+    (e.g. "weight_g") and one specifying the direction (e.g. "weight_v").
+    Spectral normalization is implemented via a hook that recomputes the weight
+    tensor from the magnitude and direction before every :meth:`~Module.forward`
+    call.
+
+    See https://arxiv.org/abs/1802.05957
+
+    Args:
+        module (nn.Module): containing module
+        name (str, optional): name of weight parameter
+        n_power_iterations (int, optional): number of power iterations to
+            calculate spectal norm
+        eps (float, optional): epsilon for numerical stability
+
+    Returns:
+        The original module with the spectal norm hook
+
+    Example::
+
+        >>> m = spectral_norm(nn.Linear(20, 40))
+        Linear (20 -> 40)
+        >>> m.weight_g.size()
+        torch.Size([40])
+        >>> m.weight_v.size()
+        torch.Size([40, 20])
+
+    """
+    SpectralNorm.apply(module=module,
+                       name=name,
+                       n_power_iterations=n_power_iterations,
+                       eps=eps)
+    return module
+
+
+def remove_spectral_norm(module, name='weight'):
+    r"""Removes the spectral normalization reparameterization from a module.
+
+    Args:
+        module (nn.Modue): containing module
+        name (str, optional): name of weight parameter
+
+    Example:
+        >>> m = spectral_norm(nn.Linear(40, 10))
+        >>> remove_spectral_norm(m)
+    """
+    for k, hook in module._forward_pre_hooks.items():
+        if isinstance(hook, SpectralNorm) and hook.name == name:
+            hook.remove(module)
+            del module._forward_pre_hooks[k]
+            return module
+
+    raise ValueError("spectral_norm of '{}' not found in {}"
+                     .format(name, module))

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -19,6 +19,9 @@ class SpectralNorm(object):
         height = weight.size(0)
         weight_mat = weight.view(height, -1)
         for _ in range(self.n_power_iterations):
+            # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
+            # are the first left and right singular vecors.
+            # This power iteration produces approximations of `u` and `v`.
             v = normalize(torch.matmul(weight_mat.t(), u), dim=0, eps=self.eps)
             u = normalize(torch.matmul(weight_mat, v), dim=0, eps=self.eps)
 
@@ -44,7 +47,7 @@ class SpectralNorm(object):
         weight = module._parameters[name]
         height = weight.size(0)
 
-        u = normalize(weight.data.new(height).normal_(0, 1), dim=0, eps=fn.eps)
+        u = normalize(weight.new_empty(height).normal_(0, 1), dim=0, eps=fn.eps)
         module.register_parameter(fn.name + "_org", weight)
         module.register_buffer(fn.name + "_u", u)
 
@@ -60,21 +63,24 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
          \sigma(\mathbf{W}) &= \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)
-    in GANs by rescaling the weight tensor with spectral norm :math:`\sigma` of
-    the weight matrix calculated using power iteration method. If the dimension
-    of the weight tensor is greater than 2, reshaped to 2D in power iteration method
-    to get spectral norm. This is implemented via a hook that calculates
-    spectral norm and rescales weight before every :meth:`~Module.forward`
-    call.
+    in Generaive Adversarial Networks (GANs) by rescaling the weight tensor
+    with spectral norm :math:`\sigma` of the weight matrix calculated using
+    power iteration method. If the dimension of the weight tensor is greater
+    than 2, it is reshaped to 2D in power iteration method to get spectral
+    norm. This is implemented via a hook that calculates spectral norm and
+    rescales weight before every :meth:`~Module.forward` call.
 
-    See https://arxiv.org/abs/1802.05957
+    See `Spectral Normalization for Generative Adversarial Networks`_ .
+
+    .. _`Spectral Normalization for Generative Adversarial Networks`: https://arxiv.org/abs/1802.05957
 
     Args:
         module (nn.Module): containing module
         name (str, optional): name of weight parameter
         n_power_iterations (int, optional): number of power iterations to
             calculate spectal norm
-        eps (float, optional): epsilon for numerical stability
+        eps (float, optional): epsilon for numerical stability in
+            calculating norms
 
     Returns:
         The original module with the spectal norm hook
@@ -95,7 +101,7 @@ def remove_spectral_norm(module, name='weight'):
     r"""Removes the spectral normalization reparameterization from a module.
 
     Args:
-        module (nn.Modue): containing module
+        module (nn.Module): containing module
         name (str, optional): name of weight parameter
 
     Example:

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -20,7 +20,7 @@ class SpectralNorm(object):
         weight_mat = weight.view(height, -1)
         for _ in range(self.n_power_iterations):
             # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
-            # are the first left and right singular vecors.
+            # are the first left and right singular vectors.
             # This power iteration produces approximations of `u` and `v`.
             v = normalize(torch.matmul(weight_mat.t(), u), dim=0, eps=self.eps)
             u = normalize(torch.matmul(weight_mat, v), dim=0, eps=self.eps)

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -60,9 +60,9 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
          \sigma(\mathbf{W}) &= \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)
-    in GANs by rescaling the weight tensor by spectral norm "sigma" of the
-    weight matrix calculated by power iteration method. If the dimension of the
-    weight tensor is greater than 2, reshaped to 2D in power iteration method
+    in GANs by rescaling the weight tensor with spectral norm :math:`\sigma` of
+    the weight matrix calculated using power iteration method. If the dimension
+    of the weight tensor is greater than 2, reshaped to 2D in power iteration method
     to get spectral norm. This is implemented via a hook that calculates
     spectral norm and rescales weight before every :meth:`~Module.forward`
     call.

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -64,10 +64,10 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
          \mathbf{W} &= \dfrac{\mathbf{W}}{\sigma(\mathbf{W})} \\
          \sigma(\mathbf{W}) &= \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
-    Spectral normalization stabilize the training of discriminators(critics)
+    Spectral normalization stabilizes the training of discriminators (critics)
     in GANs by rescaling the weight tensor by spectral norm "sigma" of the
     weight matrix calculated by power iteration method. If the dimension of the
-    weight tensor is greater than 2, reahaped to 2D in power iteration method
+    weight tensor is greater than 2, reshaped to 2D in power iteration method
     to get spectral norm. This is implemented via a hook that calculates
     spectral norm and rescales weight before every :meth:`~Module.forward`
     call.

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -61,8 +61,9 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12):
     r"""Applies spectral normalization to a parameter in the given module.
 
     .. math::
-         \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})}
-         \text{where, } \sigma(\mathbf{W}) := \max_{\mathbf{h} \ne 0} \dfrac{\|\mathbf{A} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
+         \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})} \
+         \text{where,} \sigma(\mathbf{W}) = \max_{\mathbf{h} \ne 0}
+            \dfrac{\|\mathbf{A} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilize the training of discriminators(critics)
     in GANs.  This is implemented via a hook that rescale weight matrix


### PR DESCRIPTION
related to #5027.
This PR aims at implementing Spectral Normalization in a way similar to `torch.nn.utils.weight_norm`.