### PR TITLE
Fix typo in set_grad_enabled description

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -88,7 +88,7 @@ class set_grad_enabled(object):
         >>> set_grad_enabled(False)
         >>> y = x * 2
         >>> y.requires_grad
-        True
+        False
 
     """
 


### PR DESCRIPTION
After setting set_grad_enabled(False), y.requires_grad returns False. But in the example it is described as True.

