### PR TITLE
Clarify _unsafe_view comment.

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -494,7 +494,7 @@ Tensor & squeeze_(Tensor& self, int64_t dim) {
 // _unsafe_view() differs from view() in that the returned tensor isn't treated
 // as a view for the purposes of automatic differentiation. (It's not listed in
 // VIEW_FUNCTIONS in gen_autograd.py).  It's only safe to use if the `self` tensor
-// is temporary. For example, the viewed tensor here is discarded immediately
+// is temporary. For example, the viewed tensor here (a + b) is discarded immediately
 // after viewing:
 //
 //  res = at::_unsafe_view(a + b, size);


### PR DESCRIPTION
It was unclear to me whether the "viewed" tensor was the input or the output.

