### PR TITLE
Remove scratch space from THCState

### DIFF
--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -69,9 +69,6 @@ typedef struct _THCCudaResourcesPerDevice {
   cusparseHandle_t* sparseHandles;
   /* Size of scratch space per each stream on this device available */
   size_t scratchSpacePerStream;
-  /* Device-resident scratch space per stream, used for global memory
-     reduction kernels. Lazily initialized. */
-  void** devScratchSpacePerStream;
 } THCCudaResourcesPerDevice;
 
 
@@ -160,7 +157,6 @@ THC_API void THCMagma_init(THCState *state);
 
 /* State manipulators and accessors */
 THC_API int THCState_getNumDevices(THCState* state);
-THC_API void THCState_reserveStreams(THCState* state, int numStreams, int nonBlocking);
 THC_API int THCState_getNumStreams(THCState* state);
 
 /* Stream API */
@@ -190,8 +186,6 @@ THC_API int THCState_getCurrentSparseHandleIndex(THCState *state);
 THC_API void THCState_setCurrentSparseHandleIndex(THCState *state, int handle);
 
 /* For the current device and stream, returns the allocated scratch space */
-THC_API void* THCState_getCurrentDeviceScratchSpace(THCState* state);
-THC_API void* THCState_getDeviceScratchSpace(THCState* state, int device, int stream);
 THC_API size_t THCState_getCurrentDeviceScratchSpaceSize(THCState* state);
 THC_API size_t THCState_getDeviceScratchSpaceSize(THCState* state, int device);
 

--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -191,13 +191,8 @@ void callReduceAll(THCState* state,
   dim3 block;
 
   if (isTwoPassReductionSize(totalElements)) {
-    bool freeScratchSpace = false;
-    void* scratchSpace = THCState_getCurrentDeviceScratchSpace(state);
-    if (!scratchSpace) {
-      THCudaCheck(THCudaMalloc(state, &scratchSpace,
-          THCState_getCurrentDeviceScratchSpaceSize(state)));
-      freeScratchSpace = true;
-    }
+    void* scratchSpace;
+    THCudaCheck(THCudaMalloc(state, &scratchSpace, THCState_getCurrentDeviceScratchSpaceSize(state)));
 
     getPass1ReduceBlockGrid<InT, AccT>(state, totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -216,9 +211,7 @@ void callReduceAll(THCState* state,
         numPass1Blocks, init, reduceAccOp,
         (AccT*) scratchSpace, devOut);
 
-    if (freeScratchSpace) {
-      THCudaCheck(THCudaFree(state, scratchSpace));
-    }
+    THCudaCheck(THCudaFree(state, scratchSpace));
   } else {
     getSinglePassReduceBlockGrid<InT, AccT>(totalElements, grid, block);
     size_t smemSize = block.x * sizeof(AccT);
@@ -261,12 +254,9 @@ bool THC_reduceAll(THCState* state,
   if (!outOnDevice) {
     // Use the stream-specific scratch space for the reduction kernel
     // to write out its value
-    devOut = (AccT*) THCState_getCurrentDeviceScratchSpace(state);
-    if (!devOut) {
-      THCudaCheck(THCudaMalloc(state, (void**)&devOut,
-          THCState_getCurrentDeviceScratchSpaceSize(state)));
-      freeDevOut = true;
-    }
+    THCudaCheck(THCudaMalloc(state, (void**)&devOut,
+        THCState_getCurrentDeviceScratchSpaceSize(state)));
+    freeDevOut = true;
   }
 
   // It is possible that the tensor dimensions are able to be collapsed,
@@ -332,10 +322,10 @@ bool THC_reduceAll(THCState* state,
   // the host (synchronous!)
   if (!outOnDevice) {
     cudaStream_t stream = THCState_getCurrentStream(state);
-    THCudaCheck(cudaMemcpyAsync(out, 
-                                devOut, 
-                                sizeof(AccT), 
-                                cudaMemcpyDeviceToHost, 
+    THCudaCheck(cudaMemcpyAsync(out,
+                                devOut,
+                                sizeof(AccT),
+                                cudaMemcpyDeviceToHost,
                                 stream));
     THCudaCheck(cudaStreamSynchronize(stream));
   }


### PR DESCRIPTION
```
THC had a concept of per-device per-stream scratch space that was
persistent in THCState. This was useful before the caching allocator
because it avoided synchronizations in kernels that needed temporary
scratch space. However, it's not thread-safe since multiple threads can
operate on the same stream: In a two-pass reduction the scratch space
may get clobbered in between the two kernels.

This removes the scratch space and just uses THCudaMalloc and THCudaFree
within the reductions.

I've kept THCState_getCurrentDeviceScratchSpaceSize for now since it's
useful to have the temporary buffer be sized based on the number of SMs.
```

[cuda_threads.py](https://gist.github.com/colesbury/18bc0c8765d06f747c62b10362fee91a) now prints consistent sums.