### PR TITLE
cache nccl resourse better for efficient hybrid data/model parallel

### DIFF
--- a/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.hpp
@@ -207,14 +207,14 @@ private:
    *      cached communicator will be destroyed and a new one with the new
    *      device string will be built
    */
-  std::unordered_map<THDGroup, std::string> _groupDevices;
+  std::unordered_map<THDGroup, std::vector<std::string> > _groupDevices;
 
   /**
    * NCCL resources for for each THDGroup including:
    * NCCL communicator for the current group
    * Cuda Events for all GPUs for NCCL operations of the current group
    */
-  std::unordered_map<THDGroup, NcclResources> _groupNcclResources;
+  std::unordered_map<THDGroup, std::vector<NcclResources> > _groupNcclResources;
 
   // Existing groups
   std::unordered_map<THDGroup, DataChannel::Group> _groups;


### PR DESCRIPTION
This change allow more than 1 device list to be stored under a group.

Consider the following use case, which is model parallel within process, data parallel between process.
 
A 2-layer model, layer0@gpu0 and layer1@gpu1. when you add distributed data parallel on top of it, you have another process with layer0@gpu2 and layer1@gpu3.
there are 2 reduction of grad, layer0 on gpu0/2 and layer1 on gpu1/3.

Every batch when you switch between these 2 reductions, all nccl resources are destroyed and re-allocated.(take seconds) This commit will allow pytorch to cache nccl resource for both device pair.
