### PR TITLE
Code Cleanup: removes unused getTextureObject in THCTensor

### DIFF
--- a/aten/src/THC/generic/THCTensor.cu
+++ b/aten/src/THC/generic/THCTensor.cu
@@ -2,32 +2,6 @@
 #define THC_GENERIC_FILE "generic/THCTensor.cu"
 #else
 
-cudaTextureObject_t THCTensor_(getTextureObject)(THCState *state, THCTensor *self)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
-  cudaTextureObject_t texObj;
-  struct cudaResourceDesc resDesc;
-  memset(&resDesc, 0, sizeof(resDesc));
-  resDesc.resType = cudaResourceTypeLinear;
-  resDesc.res.linear.devPtr = THCTensor_(data)(state, self);
-  resDesc.res.linear.sizeInBytes = THCTensor_(nElement)(state, self) * 4;
-  resDesc.res.linear.desc = cudaCreateChannelDesc(32, 0, 0, 0,
-                                                  cudaChannelFormatKindFloat);
-  struct cudaTextureDesc texDesc;
-  memset(&texDesc, 0, sizeof(texDesc));
-  cudaCreateTextureObject(&texObj, &resDesc, &texDesc, NULL);
-  cudaError errcode = cudaGetLastError();
-  if(errcode != cudaSuccess) {
-    if (THCTensor_(nElement)(state, self) > 2>>27)
-      THError("Failed to create texture object, "
-              "nElement:%ld exceeds 27-bit addressing required for tex1Dfetch. Cuda Error: %s",
-              THCTensor_(nElement)(state, self), cudaGetErrorString(errcode));
-    else
-      THError("Failed to create texture object: %s", cudaGetErrorString(errcode));
-  }
-  return texObj;
-}
-
 THC_API int THCTensor_(getDevice)(THCState* state, const THCTensor* tensor) {
   if (!tensor->storage) return -1;
   return THCStorage_(getDevice)(state, tensor->storage);

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -130,7 +130,6 @@ THC_API real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t
 THC_API real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3);
 
 /* CUDA-specific functions */
-THC_API cudaTextureObject_t THCTensor_(getTextureObject)(THCState *state, THCTensor *self);
 THC_API int THCTensor_(getDevice)(THCState *state, const THCTensor *self);
 THC_API int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...);
 


### PR DESCRIPTION
The generic THC_API cudaTextureObject_t THCTensor_(getTextureObject)(THCState *state, THCTensor *self) appears unused. This fix removes it. 

Searching for "getTextureObject" returns two executables in aten/build/src/ATen/test. These were also run as part of automated testing (see below).

"getTextureObject" also appears in the caffe2 subdirectory, but it refers to a different function call there.

Automated testing: test_cuda.py (OK), cuda_rng_test (1/1 passed), integer_divider_test (All tests passed, 42994 assertions in 1 test case).