### PR TITLE
Add support for dotted names in CPP Extensions

### DIFF
--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -22,5 +22,6 @@ if torch.cuda.is_available() and CUDA_HOME is not None:
 
 setup(
     name='torch_test_cpp_extension',
+    packages=['torch_test_cpp_extension'],
     ext_modules=ext_modules,
     cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension})

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -5,13 +5,13 @@ from torch.utils.cpp_extension import CUDA_HOME
 
 ext_modules = [
     CppExtension(
-        'torch_test_cpp_extension', ['extension.cpp'],
+        'torch_test_cpp_extension.cpp', ['extension.cpp'],
         extra_compile_args=['-g']),
 ]
 
 if torch.cuda.is_available() and CUDA_HOME is not None:
     extension = CUDAExtension(
-        'torch_test_cuda_extension', [
+        'torch_test_cpp_extension.cuda', [
             'cuda_extension.cpp',
             'cuda_extension_kernel.cu',
             'cuda_extension_kernel2.cu',

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 import torch.utils.cpp_extension
 try:
-    import torch_test_cpp_extension as cpp_extension
+    import torch_test_cpp_extension.cpp as cpp_extension
 except ModuleNotFoundError:
     print("\'test_cpp_extensions.py\' cannot be invoked directly. " +
           "Run \'python run_test.py -i cpp_extensions\' for the \'test_cpp_extensions.py\' tests.")
@@ -70,7 +70,7 @@ class TestCppExtension(common.TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_extension(self):
-        import torch_test_cuda_extension as cuda_extension
+        import torch_test_cpp_extension.cuda as cuda_extension
 
         x = torch.FloatTensor(100).zero_().cuda()
         y = torch.FloatTensor(100).zero_().cuda()

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -4,7 +4,7 @@ import torch
 import torch.utils.cpp_extension
 try:
     import torch_test_cpp_extension.cpp as cpp_extension
-except ModuleNotFoundError:
+except ImportError:
     print("\'test_cpp_extensions.py\' cannot be invoked directly. " +
           "Run \'python run_test.py -i cpp_extensions\' for the \'test_cpp_extensions.py\' tests.")
     raise

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -245,7 +245,13 @@ class BuildExtension(build_ext):
         check_compiler_abi_compatibility(compiler)
 
     def _define_torch_extension_name(self, extension):
-        define = '-DTORCH_EXTENSION_NAME={}'.format(extension.name)
+        # pybind11 doesn't support dots in the names
+        # so in order to support extensions in the packages
+        # like torch._C, we take the last part of the string
+        # as the library name
+        names = extension.name.split('.')
+        name = names[-1]
+        define = '-DTORCH_EXTENSION_NAME={}'.format(name)
         if isinstance(extension.extra_compile_args, dict):
             for args in extension.extra_compile_args.values():
                 args.append(define)


### PR DESCRIPTION
When trying to compile a CPP extension inside a namespace (for example, `torchvision._C`), pybind11 complained because the `.` breaks its macro expansion in `PYBIND11_MODULE `.

This PR tries to fix it, by only sending to pybind the name of the library that should be compiled, and not the full path.

cc. @goldsborough 