### PR TITLE
Fixes some build warnings.

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -63,10 +63,11 @@ std::string cudnnTypeToString(cudnnDataType_t dtype) {
       return "CUDNN_DATA_INT32";
     case CUDNN_DATA_INT8x4:
       return "CUDNN_DATA_INT8x4";
+    default:
+      std::ostringstream oss;
+      oss << "(unknown data-type " << static_cast<int>(dtype) << ")";
+      return oss.str();
   }
-  std::ostringstream oss;
-  oss << "(unknown data-type " << static_cast<int>(dtype) << ")";
-  return oss.str();
 }
 
 std::ostream& operator<<(std::ostream & out, const TensorDescriptor& d) {

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -1,6 +1,8 @@
 #include "ATen/native/cpu/ReduceOpsKernel.h"
 
 #include <numeric>
+#include <iterator>
+#include <algorithm>
 
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
@@ -126,9 +128,10 @@ struct Reduction {
 
     if (cols_rounded != cols) {
       scalar_t buf[WIDTH];
-      for (int64_t j = 0; j != cols - cols_rounded; j++) {
-        buf[j] = ident;
-      }
+
+      // Initializes the entire (tiny) array to avoid uninitialized warnings
+      std::fill(std::begin(buf), std::end(buf), ident);
+
       for (int64_t row = 0; row != rows; row++) {
         for (int64_t j = 0; j != cols - cols_rounded; j++) {
           auto val = data[row * stride + j + cols_rounded];


### PR DESCRIPTION
This fix makes two small code changes that stop many warnings when building PyTorch. It is extremely unlikely that these changes will have negative externalities. 

Volta architecture specific warnings when building are not affected by this change. 

Automated testing:

test_cuda.py (OK)
test_torch.py (OK)
test_nn.py (no regression from Master)