### PR TITLE
Add support for type annotations in Python functions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2656,6 +2656,24 @@ class TestScript(TestCase):
         self.checkScript(fn_unpack, (x,), optimize=True)
         self.checkScript(fn_index, (x,), optimize=True)
 
+    def test_type_annotations_varargs(self):
+        def fn_varargs(x, *args):
+            return args[0] if args else x
+
+        def fn1(x, y, z):
+            return fn_varargs(x)
+
+        def fn2(x, y, z):
+            return fn_varargs(x, y)
+
+        def fn3(x, y, z):
+            return fn_varargs(x, y, z)
+
+        x, y, z = [torch.randn(2, 2) for _ in range(3)]
+        self.checkScript(fn1, (x, y, z), optimize=True)
+        self.checkScript(fn2, (x, y, z), optimize=True)
+        self.checkScript(fn3, (x, y, z), optimize=True)
+
     @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_type_annotation_py3(self):
         import importlib.util

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8,6 +8,8 @@ import torch.jit.frontend
 from torch.autograd import Variable, Function
 from torch.autograd.function import traceable
 from common import TestCase, run_tests, IS_WINDOWS
+from textwrap import dedent
+import os
 import io
 import sys
 import unittest
@@ -39,6 +41,7 @@ if torch.cuda.is_available():
 RUN_CUDA_MULTI_GPU = RUN_CUDA and torch.cuda.device_count() > 1
 
 PY2 = sys.version_info[0] == 2
+PY35 = sys.version_info >= (3, 5)
 WINDOWS = sys.platform == 'win32'
 
 
@@ -2625,6 +2628,123 @@ class TestScript(TestCase):
                 a = torch.chunk(1, dim=0, chunks=2)
                 if True:
                     a = 4
+
+    def test_type_annotations(self):
+        def fn(x, y):
+            # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor, Tensor]
+            return x, x * 2, x * 3
+
+        with self.assertRaisesRegex(RuntimeError, r"need 4 values .* found only 3"):
+            @torch.jit.script
+            def script_fn(x):
+                x, y, z, w = fn(x, x)
+
+        with self.assertRaisesRegex(RuntimeError, r"too many values .* need 2 but found 3"):
+            @torch.jit.script
+            def script_fn(x):
+                x, y = fn(x, x)
+
+        def fn_unpack(x):
+            y, z, w = fn(x, x)
+            return y
+
+        def fn_index(x):
+            q = fn(x, x)
+            return x
+
+        x = torch.ones(2, 2)
+        self.checkScript(fn_unpack, (x,), optimize=True)
+        self.checkScript(fn_index, (x,), optimize=True)
+
+    @unittest.skipIf(not PY35, "Python 3.5 needed")
+    def test_type_annotation_py3(self):
+        import importlib.util
+
+        code = dedent("""
+        import torch
+        from torch import Tensor
+        from typing import Tuple
+
+        def fn(x : torch.Tensor, y : Tensor, z) -> Tuple[Tensor, Tensor, Tensor]:
+            return (x, y + z, z)
+        """)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            script_path = os.path.join(tmp_dir, 'script.py')
+            with open(script_path, 'w') as f:
+                f.write(code)
+            spec = importlib.util.spec_from_file_location('test_type_annotation_py3', script_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            fn = module.fn
+
+            with self.assertRaisesRegex(RuntimeError, r"expected Tensor, but got"):
+                @torch.jit.script
+                def bad_fn(x):
+                    x, y = fn((x, x), x, x)
+                    return y
+
+            with self.assertRaisesRegex(RuntimeError, r"too many values .* need 2 but found 3"):
+                @torch.jit.script
+                def bad_fn(x):
+                    x, y = fn(x, x, x)
+                    return y
+
+            with self.assertRaisesRegex(RuntimeError, r"need 4 values .* found only 3"):
+                @torch.jit.script
+                def bad_fn(x):
+                    x, y, z, w = fn(x, x, x)
+                    return y
+
+            def good_fn(x):
+                y, z, w = fn(x, x, x)
+                return y, z, w
+
+            self.checkScript(good_fn, (torch.ones(2, 2),), optimize=True)
+
+    def test_type_annotation_module(self):
+        class BaseModule(torch.jit.ScriptModule):
+            def foo(self, x):
+                # type: (Tensor) -> Tensor
+                return x + 1
+
+            def bar(self, x, y):
+                # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor]
+                return x + y, y
+
+            def baz(self, x, y):
+                return x
+
+        class ModuleTooMany(BaseModule):
+            @torch.jit.script_method
+            def method(self, x):
+                return self.foo(x, x)
+
+        class ModuleTooFew(BaseModule):
+            @torch.jit.script_method
+            def method(self, x):
+                return self.bar(x)
+
+        class ModuleTooManyAssign(BaseModule):
+            @torch.jit.script_method
+            def method(self, x):
+                y, z, w = self.bar(x, x)
+                return x
+
+        class ModuleDefault(BaseModule):
+            @torch.jit.script_method
+            def method(self, x):
+                y = self.baz(x)
+                return x
+
+        with self.assertRaisesRegex(RuntimeError, "incorrect number of arguments: expected 1, but got 2"):
+            ModuleTooMany()
+        with self.assertRaisesRegex(RuntimeError, "incorrect number of arguments: expected 2, but got 1"):
+            ModuleTooFew()
+        with self.assertRaisesRegex(RuntimeError, "need 3 values .* found only 2"):
+            ModuleTooManyAssign()
+        with self.assertRaisesRegex(RuntimeError, "incorrect number of arguments: expected 2, but got 1"):
+            ModuleDefault()
 
     def test_script_define_order(self):
         class M(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1554,9 +1554,9 @@ class TestScript(TestCase):
             os.close(r)
             os.close(w)
 
-    def checkScript(self, script, inputs, optimize, outputs=None, name='func', capture_output=False):
+    def checkScript(self, script, inputs, optimize, outputs=None, name='func', capture_output=False, frames_up=1):
         if isinstance(script, str):
-            cu = torch.jit.CompilationUnit(script, optimize)
+            cu = torch.jit.CompilationUnit(script, optimize, _frames_up=frames_up)
             ge = getattr(cu, name)
         else:
             if capture_output:
@@ -1566,9 +1566,9 @@ class TestScript(TestCase):
                 outputs = script(*inputs)
             # Check the string frontend first
             source = textwrap.dedent(inspect.getsource(script))
-            self.checkScript(source, inputs, optimize, outputs, script.__name__, capture_output)
+            self.checkScript(source, inputs, optimize, outputs, script.__name__, capture_output, frames_up=2)
             # Continue checking the Python frontend
-            ge = torch.jit.script(script)
+            ge = torch.jit.script(script, _frames_up=1)
 
         if capture_output:
             with self.capture_stdout() as captured:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2641,7 +2641,7 @@ class TestScript(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, r"too many values .* need 2 but found 3"):
             @torch.jit.script
-            def script_fn(x):
+            def script_fn2(x):
                 x, y = fn(x, x)
 
         def fn_unpack(x):
@@ -2704,13 +2704,13 @@ class TestScript(TestCase):
 
             with self.assertRaisesRegex(RuntimeError, r"too many values .* need 2 but found 3"):
                 @torch.jit.script
-                def bad_fn(x):
+                def bad_fn2(x):
                     x, y = fn(x, x, x)
                     return y
 
             with self.assertRaisesRegex(RuntimeError, r"need 4 values .* found only 3"):
                 @torch.jit.script
-                def bad_fn(x):
+                def bad_fn3(x):
                     x, y, z, w = fn(x, x, x)
                     return y
 

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -100,6 +100,19 @@ static void LowerTuples(Block* block) {
   VisitNode(block->return_node(), nullptr);
 }
 
+static void EnsureNoTuples(Block* block) {
+  for (Node* n : block->nodes()) {
+    for (Block* b : n->blocks()) {
+      EnsureNoTuples(b);
+    }
+    for (Value * o : n->outputs()) {
+      JIT_ASSERTM(o->type()->kind() != TypeKind::TupleType,
+                  "Couldn't lower all tuples. This is an error because "
+                  "they're not implemented in the interpreter just yet.");
+    }
+  }
+}
+
 void LowerTuples(std::shared_ptr<Graph>& graph) {
   for(auto input : graph->inputs()) {
     JIT_ASSERTM(input->type()->kind() != TypeKind::TupleType, "tuples cannot be inputs to the graph");
@@ -109,6 +122,7 @@ void LowerTuples(std::shared_ptr<Graph>& graph) {
   }
   LowerTuples(graph->block());
   EliminateDeadCode(graph);
+  EnsureNoTuples(graph->block());
 }
 
 }}

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -291,13 +291,9 @@ void initPythonIRBindings(PyObject * module_) {
     })
     ;
 
-  #define TS(name) \
-    def(#name,&Type :: name)
   py::class_<Type,std::shared_ptr<Type>>(m,"Type")
     .def("__repr__",[](Type & t) {
-      std::stringstream ss;
-      ss << t;
-      return ss.str();
+      return t.name();
     })
     .def("kind",[](Type& t_) {
       Type * t = &t_;
@@ -328,6 +324,11 @@ void initPythonIRBindings(PyObject * module_) {
       return at::toString(t.expect<TensorType>()->scalarType());
     })
     ;
+
+  py::class_<DynamicType, Type, std::shared_ptr<DynamicType>>(m, "DynamicType")
+    .def(py::init<>());
+  py::class_<TupleType, Type, std::shared_ptr<TupleType>>(m, "TupleType")
+    .def(py::init<std::vector<TypePtr>>());
 
   py::class_<Use>(m,"Use")
   .def_readonly("user",&Use::user)

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -23,8 +23,29 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   PythonValue(py::object self)
   : self(std::move(self)) {}
 
+  std::pair<std::vector<TypePtr>, TypePtr> getFunctionType(size_t n_args, size_t n_binders) {
+    auto annotations = py::module::import("torch.jit.annotations");
+    return py::cast<std::pair<std::vector<TypePtr>, TypePtr>>(annotations.attr("get_signature")(self, n_args, n_binders));
+  }
+
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
+    std::vector<TypePtr> arg_types;
+    TypePtr ret_type;
+    std::tie(arg_types, ret_type) = getFunctionType(inputs.size(), n_binders);
+
+    if (arg_types.size() != inputs.size())
+      throw ErrorReport(loc) << "calling a Python function with an incorrect number "
+                             << "of arguments: expected " << arg_types.size() << ", but got "
+                             << inputs.size();
+    for (size_t i = 0; i < arg_types.size(); ++i) {
+      if (!inputs[i]->type()->isSubtypeOf(*arg_types[i]))
+        throw ErrorReport(loc) << "type mismatch at argument " << i << ": expected "
+                               << arg_types[i]->name() << ", but got " << inputs[i]->type()->name();
+    }
+    // We have to do this check here, because implementation of this function is tightly
+    // coupled with the impl for PythonOp in the interpreter. Right now it assumes that
+    // all inputs taken from the stack are Tensors, so that's what we have to do.
     ensureTensors(loc, inputs);
 
     if (attributes.size() > 0)
@@ -47,8 +68,26 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     new_node->setSourceLocation(std::make_shared<SourceRange>(loc));
     for(auto i : inputs)
       new_node->addInput(i);
+
+    // This is really dumb, but relaxing the constraints on return types would
+    // require us to change the implementation of PythonOps in the interpreter.
+    // Note that this effectively makes the return type of Tuple[Tensor] and Tensor
+    // equivalent, but the PythonOp impl ends with an optional tuple unpack, so we need
+    // to do it.
+    std::shared_ptr<TupleType> ret_tuple_type;
+    if (ret_type->kind() != TypeKind::TupleType) {
+      ret_tuple_type = std::make_shared<TupleType>(std::vector<TypePtr>{ret_type});
+    } else {
+      ret_tuple_type = std::static_pointer_cast<TupleType>(ret_type);
+    }
+    for (auto & ret_type_elem : ret_tuple_type->elements()) {
+      if (!ret_type_elem->isSubtypeOf(*DynamicType::get())) {
+        throw ErrorReport(loc) << "Python functions can currently only return Tensors";
+      }
+    }
+
     std::vector<Value*> outputs;
-    for(size_t i = 0; i < n_binders; ++i)
+    for(size_t i = 0; i < ret_tuple_type->elements().size(); ++i)
       outputs.push_back(new_node->addOutput());
     return packOutputs(*m.graph(), outputs);
   }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -779,7 +779,7 @@ _compiled_methods_whitelist = {
     '_apply', 'apply', 'cuda', 'cpu', 'type', 'float', 'double', 'half',
     'state_dict', 'load_state_dict', '_load_from_state_dict', 'parameters',
     'named_parameters', '_all_buffers', 'children', 'named_children', 'modules',
-    'named_modules', 'zero_grad', 'share_memory', '_get_name'
+    'named_modules', 'zero_grad', 'share_memory', '_get_name', 'extra_repr'
 }
 
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -1,0 +1,227 @@
+import sys
+import ast
+import inspect
+import torch
+from torch._C import DynamicType, TupleType
+from textwrap import dedent
+
+
+PY35 = sys.version_info >= (3, 5)
+
+
+try:
+    import typing
+    from typing import Tuple
+
+    def is_tuple(ann):
+        return ann.__module__ == 'typing' and getattr(ann, '__origin__', None) is typing.Tuple
+except ImportError:
+    # A minimal polyfill for versions of Python that don't have typing.
+    # Note that this means that they also don't support the fancy annotation syntax, so
+    # those instances will only be used in our tiny `type: ` comment interpreter.
+
+    # The __getitem__ in typing is implemented using metaclasses, but I'm too lazy for that.
+    class TupleCls(object):
+        def __getitem__(self, types):
+            return TupleInstance(types)
+
+    class TupleInstance(object):
+        def __init__(self, types):
+            setattr(self, '__args__', types)
+
+    Tuple = TupleCls()
+
+    def is_tuple(ann):
+        return isinstance(ann, TupleInstance)
+
+
+def get_signature(fn, _n_arguments=None, _n_binders=None):
+    # Python 3.5 adds support for the nice annotation syntax, so try that first.
+    if PY35:
+        sig = try_real_annotations(fn)
+        if sig is not None:
+            return sig
+
+    type_line, source = None, None
+    try:
+        source = dedent(inspect.getsource(fn))
+        type_line = get_type_line(source)
+    except TypeError:
+        pass
+    # This might happen both because we failed to get the source of fn, or
+    # because it didn't have any annotations.
+    if type_line is None:
+        return default_signature(fn, source, _n_arguments, _n_binders)
+
+    return parse_type_line(type_line)
+
+
+def parse_type_line(type_line):
+    """Parses a type annotation specified as a comment.
+
+    Example inputs:
+        # type: (Tensor, torch.Tensor) -> Tuple[Tensor]
+        # type: (Tensor, Tuple[Tensor, Tensor]) -> Tensor
+    """
+    arg_ann_str, ret_ann_str = split_type_line(type_line)
+
+    try:
+        arg_ann = ast.parse(arg_ann_str, mode='eval').body
+    except SyntaxError:
+        raise RuntimeError("Failed to parse the argument list of a type annotation")
+
+    if type(arg_ann) is ast.Tuple:
+        arg_ann = arg_ann.elts
+    else:
+        arg_ann = (arg_ann,)
+
+    try:
+        ret_ann = ast.parse(ret_ann_str, mode='eval').body
+    except SyntaxError:
+        raise RuntimeError("Failed to parse the return type of a the annotation")
+
+    arg_types = [ann_to_type(interpret_ann(ann)) for ann in arg_ann]
+    ret_type = ann_to_type(interpret_ann(ret_ann))
+    return arg_types, ret_type
+
+
+def default_signature(fn, source, _n_arguments, _n_binders):
+    """Returns the default signature for fn.
+
+    The current formula is to use the source (if available) to determine the
+    number of inputs and outputs, and set all their types as tensors.
+    If the source is missing, we fall back to the numbers provided by the compiler,
+    to make sure we don't cause an error there (although type mismatches can still happen).
+
+    This method also accounts for the self argument if fn is a method.
+    """
+    if _n_binders is None:
+        raise RuntimeError("default_signature needs to know the number of binders")
+    if source is None and _n_arguments is None:
+        raise RuntimeError("default_signature needs either the source or the number of arguments")
+
+    ret_type = TupleType([DynamicType() for _ in range(_n_binders)])
+    if source is not None:
+        py_ast = ast.parse(source)
+        if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):
+            raise RuntimeError("expected a single top-level function")
+        py_def = py_ast.body[0]
+        arg_types = [DynamicType() for _ in py_def.args.args]
+        if inspect.ismethod(fn):
+            arg_types = arg_types[1:]
+    else:
+        arg_types = [DynamicType()] * _n_arguments
+
+    return arg_types, ret_type
+
+
+def get_type_line(source):
+    """Tries to find the line containing a comment with the type annotation."""
+    lines = source.split('\n')
+
+    def strip_comment(line):
+        return line[:line.index('#') if '#' in line else None]
+
+    i = 0
+    while '):' not in strip_comment(lines[i]):
+        i += 1
+    i += 1
+
+    type_line = lines[i].strip()
+    if not type_line.startswith('# type:'):
+        return None
+    return type_line
+
+
+def split_type_line(type_line):
+    """Splits the comment with the type annotation into parts for argument and return types.
+
+    For example, for an input of:
+        # type: (Tensor, torch.Tensor) -> Tuple[Tensor, Tensor]
+
+    This function will return:
+        ("(Tensor, torch.Tensor)", "Tuple[Tensor, Tensor]")
+
+    """
+    start_offset = len('# type:')
+    try:
+        arrow_pos = type_line.index('->')
+    except ValueError:
+        raise RuntimeError("Syntax error in type annotation (cound't find `->`)")
+    return type_line[start_offset:arrow_pos].strip(), type_line[arrow_pos + 2:].strip()
+
+
+def try_real_annotations(fn):
+    """Tries to use the Py3.5+ annotation syntax to get the type."""
+    try:
+        sig = inspect.signature(fn)
+    except ValueError:
+        return None
+
+    all_annots = [sig.return_annotation] + [p.annotation for p in sig.parameters.values()]
+    if all(ann is sig.empty for ann in all_annots):
+        return None
+
+    def as_ann(ann):
+        # sig.empty is really annoying so convert it to None
+        return ann if ann is not sig.empty else None
+
+    param_types = [ann_to_type(as_ann(p.annotation))
+                   for p in sig.parameters.values()]
+    return_type = ann_to_type(as_ann(sig.return_annotation))
+    return param_types, return_type
+
+
+def ann_to_type(ann):
+    if ann is None:
+        return DynamicType()
+    elif ann is torch.Tensor:
+        return DynamicType()
+    elif is_tuple(ann):
+        return TupleType([ann_to_type(a) for a in ann.__args__])
+    raise ValueError("The only supported annotations kinds are Tensor and Tuple[...]")
+
+
+class Module(object):
+    def __init__(self, name, members):
+        self.name = name
+        self.members = members
+
+    def __getattr__(self, name):
+        try:
+            return self.members[name]
+        except KeyError:
+            raise RuntimeError("Module {} has no member called {}".format(self.name, name))
+
+
+env = {
+    'torch': Module('torch', {'Tensor': torch.Tensor}),
+    'Tensor': torch.Tensor,
+    'typing': Module('typing', {'Tuple': Tuple}),
+    'Tuple': Tuple,
+}
+
+
+def interpret_ann(expr):
+    kind = type(expr)
+    if kind is ast.Name:
+        return env[expr.id]
+    elif kind is ast.Subscript:
+        base = interpret_ann(expr.value)
+        idx = interpret_slice(expr.slice)
+        return base[idx]
+    raise RuntimeError("Unsupported expression found in type annotation")
+
+
+def interpret_slice(val):
+    kind = type(val)
+    if kind is ast.Slice or kind is ast.ExtSlice:
+        raise RuntimeError("Slices can't appear in type annotations")
+    elif kind is ast.Index:
+        idx = val.value
+        idx_kind = type(idx)
+        if idx_kind is ast.Tuple:
+            return tuple(interpret_ann(elem) for elem in idx.elts)
+        else:
+            return interpret_ann(idx)
+    raise RuntimeError("Unexpected kind in interpret_slice. File a bug report")

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -142,6 +142,7 @@ def default_signature(fn, source, _n_arguments, _n_binders):
 
 _def_end_regex = re.compile(r'.*\)\s*:.*')
 
+
 def get_type_line(source):
     """Tries to find the line containing a comment with the type annotation."""
     lines = source.split('\n')

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -14,7 +14,10 @@ try:
     from typing import Tuple
 
     def is_tuple(ann):
-        return ann.__module__ == 'typing' and getattr(ann, '__origin__', None) is typing.Tuple
+        # For some reason Python 3.7 violates the Type[A, B].__origin__ == Type rule
+        return ann.__module__ == 'typing' and \
+            (getattr(ann, '__origin__', None) is typing.Tuple or
+             getattr(ann, '__origin__', None) is tuple)
 except ImportError:
     # A minimal polyfill for versions of Python that don't have typing.
     # Note that this means that they also don't support the fancy annotation syntax, so

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import ast
 import inspect
@@ -139,6 +140,8 @@ def default_signature(fn, source, _n_arguments, _n_binders):
     return arg_types, ret_type
 
 
+_def_end_regex = re.compile(r'.*\)\s*:.*')
+
 def get_type_line(source):
     """Tries to find the line containing a comment with the type annotation."""
     lines = source.split('\n')
@@ -147,7 +150,7 @@ def get_type_line(source):
         return line[:line.index('#') if '#' in line else None]
 
     i = 0
-    while '):' not in strip_comment(lines[i]):
+    while not _def_end_regex.match(strip_comment(lines[i])):
         i += 1
     i += 1
 


### PR DESCRIPTION
When a call to a Python function is resolved, we now actually actively look for type annotations/use the source to guide the type checks instead of blindly trusting the user, and assuming that everything is a tensor. Both the fancy Py3.5+ annotation syntax, and the backwards-compatibly `# type:` comments are supported.

As an extra benefit I've cleaned up the `frame_id` mess so that we now pass numbers relative to the current frame everywhere (previously they were absolute wrt. the place where we called `inspect.stack()`). This finally allows us to use `checkScript` for script objects that have references to Python functions surrounding them.

@zdevito @jamesr66a 