### PR TITLE
Allow `__constant__` values in a ScriptModule to be used as attributes for builtin functions

### DIFF
--- a/test/expect/TestScript.test_index_select_shape_prop.expect
+++ b/test/expect/TestScript.test_index_select_shape_prop.expect
@@ -1,5 +1,5 @@
 graph(%x : Double(2, 2)
       %y : Long(4)) {
-  %2 : Double(2, 4) = aten::index_select[dim=1](%x, %y)
-  return (%2);
+  %3 : Double(2, 4) = aten::index_select[dim=1](%x, %y)
+  return (%3);
 }

--- a/test/expect/TestScript.test_index_select_shape_prop.expect
+++ b/test/expect/TestScript.test_index_select_shape_prop.expect
@@ -1,5 +1,5 @@
 graph(%x : Double(2, 2)
       %y : Long(4)) {
-  %3 : Double(2, 4) = aten::index_select[dim=1](%x, %y)
-  return (%3);
+  %2 : Double(2, 4) = aten::index_select[dim=1](%x, %y)
+  return (%2);
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2890,6 +2890,17 @@ class TestScript(TestCase):
             None, verbose=False)
         self.assertExpected(onnx_ish, subname='f2')
 
+    def test_shape_analysis_loop(self):
+        def foo(a, b, x):
+            c = a
+            for _ in range(2):
+                a = c + b
+                c = x
+                b = x
+            return a
+
+        self.checkScript(foo, (torch.zeros(1), torch.zeros(4), torch.zeros(5)), False)
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -17,6 +17,13 @@ struct CallsiteDescriptor {
   bool allow_varargs;
 };
 
+struct NamedValue {
+  NamedValue(const SourceRange& loc, const std::string& name, Value* value)
+  : loc(loc), name(name), value(value) {}
+  SourceRange loc;
+  std::string name;
+  Value* value;
+};
 
 // The AST can contain nodes like `self`, `self.b` or `python_fn` that
 // are not first-class values in the graph representation, but instead
@@ -52,7 +59,7 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
     SourceRange loc,
     Method & m,
     at::ArrayRef<Value*> inputs,
-    List<Attribute> attributes,
+    at::ArrayRef<NamedValue> attributes,
     size_t n_binders) {
 // n_binders is always set to the number of variables an expression is
 // syntactically bound to:
@@ -108,7 +115,7 @@ struct BuiltinFunction : public SugaredValue {
     SourceRange loc,
     Method & m,
     at::ArrayRef<Value*> inputs_,
-    List<Attribute> attributes,
+    at::ArrayRef<NamedValue> attributes,
     size_t n_binders) override;
 };
 

--- a/torch/csrc/jit/script/error_report.h
+++ b/torch/csrc/jit/script/error_report.h
@@ -13,6 +13,8 @@ struct ErrorReport : public std::exception {
   ErrorReport() : context(nullptr) {}
   explicit ErrorReport(const SourceRange& r)
       : context(std::make_shared<SourceRange>(r)) {}
+  explicit ErrorReport(std::shared_ptr<SourceLocation> loc)
+  : context(std::move(loc)) {}
   explicit ErrorReport(const TreeRef& tree) : ErrorReport(tree->range()) {}
   explicit ErrorReport(const Token& tok) : ErrorReport(tok.range) {}
   virtual const char* what() const noexcept override {
@@ -33,7 +35,7 @@ struct ErrorReport : public std::exception {
   friend const ErrorReport& operator<<(const ErrorReport& e, const T& t);
 
   mutable std::stringstream ss;
-  std::shared_ptr<SourceRange> context;
+  std::shared_ptr<SourceLocation> context;
   mutable std::string the_message;
 };
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -24,7 +24,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   : self(std::move(self)) {}
 
   // call it like a function, e.g. `outputs = this(inputs)`
-  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<Value*> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
     ensureTensors(loc, inputs);
 
     if (attributes.size() > 0)
@@ -164,7 +164,7 @@ struct MethodValue : public SugaredValue {
   std::string kind() const override {
     return "method";
   }
-  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
     if(attributes.size() != 0) {
       throw ErrorReport(loc) << "not yet implemented - calls to script methods using keyword arguments";
     }
@@ -210,7 +210,7 @@ struct ModuleValue : public SugaredValue {
     throw ErrorReport(loc) << "module has no attribute '" << field << "'";
   }
   // call module.forward
-  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, List<Attribute> attributes, size_t n_binders) override {
+  virtual std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<Value*> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
     return attr(loc, caller, "forward")->call(loc, caller, inputs, attributes, n_binders);
   }
 


### PR DESCRIPTION
Two smaller pieces of script functionality:

### allow `__constant__` values in a ScriptModule to be used as attributes for builtin functions

### Fix bugs in @script loops

1. while loops run shape propagation multiple times until the shapes have converged.
There were two bugs here. (a) First the 'changed' condition was not checking if it actually
changed the output, and instead would mark changed = true if the two inputs were different.
This incorrect because the output of the block and the input of the block may always have different shapes.
Now it actually checks if it is about to change the output entry that it is writing to.
(b) expand nodes were being inserted into the graph even inside the while loop body. However, if
we iteratively discover that the input shape to one of these expands is actual dynamic, then
it was incorrect to insert the expand in the first place. This changes it so that we only insert expands
after we have converged on the shapes.

2. the way deleteExtraInputs removed loop-carried dependencies was unsafe because it would lookup
Value* elements in the loop body's environment that were previously invalidated when deleteExtraInputs
remove another input to the loop. This changes the way deleteExtraInputs works so that it never has to
read a value out of the loop body's environment to avoid using the invalidated pointers.