### PR TITLE
Fix ".pb.h" dependency issue about DLL build.

### DIFF
--- a/caffe2/core/context_gpu_test.cc
+++ b/caffe2/core/context_gpu_test.cc
@@ -4,7 +4,6 @@
 #include <thread>
 #include <array>
 
-#include "caffe2/proto/caffe2.pb.h"
 #include "caffe2/core/context_gpu.h"
 #include <gtest/gtest.h>
 

--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <algorithm>
 
+#include "caffe2/core/common.h"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe2/core/db.h"
 #include "caffe2/utils/cast.h"

--- a/caffe2/video/video_io.h
+++ b/caffe2/video/video_io.h
@@ -1,6 +1,7 @@
 #ifndef CAFFE2_VIDEO_VIDEO_IO_H_
 #define CAFFE2_VIDEO_VIDEO_IO_H_
 
+#include <caffe2/core/common.h>
 #include <caffe/proto/caffe.pb.h>
 #include <caffe2/video/optical_flow.h>
 #include <caffe2/video/video_decoder.h>


### PR DESCRIPTION
CAFFE2_API defined in "caffe2/core/common.h" is required by ".pb.h" generated on Windows for DLL build.
We always need to have "#include <caffe2/core/common.h>" before using any proto header.

In this case "caffe2.pb.h" is already included by "context_gpu.h" -> "common_cudnn.h" in the correct order, hence we simply remove a line.

