### PR TITLE
only Tensors of floating point dtype can require gradients (see #7021)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2164,27 +2164,29 @@ class TestAutograd(TestCase):
         if cuda:
             dtypes.append(torch.half)
 
-        def f1():
+        def f1(dt):
+            a = torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu')
             a.requires_grad_()
 
-        def f2():
+        def f2(dt):
+            a = torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu')
             a.requires_grad = True
 
+        def f3(dt):
+            torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu', requires_grad=True)
+
         for dt in dtypes:
-            def f3():
-                torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu', requires_grad=True)
             a = torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu')
             a.requires_grad = False  # should always work
             a.requires_grad_(False)
 
             for f in [f1, f2, f3]:
-                a = torch.ones(1, dtype=dt, device='cuda' if cuda else 'cpu')
                 if dt.is_floating_point:
-                    f()
+                    f(dt)
                 else:
                     with self.assertRaisesRegex(RuntimeError, 'floating point',
                                                 msg="dt: {} device: {}".format(a.dtype, a.device)):
-                        f()
+                        f(dt)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
     def test_set_requires_grad_only_for_floats_cuda(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1781,7 +1781,7 @@ class TestTorch(TestCase):
         check_value(torch.empty(shape), default_dtype, torch.strided, -1, None, False)
         check_value(torch.full(shape, -5), default_dtype, torch.strided, -1, None, False)
         for dtype in dtypes:
-            for rg in [True, False]:
+            for rg in {dtype.is_floating_point, False}:
                 int64_dtype = get_int64_dtype(dtype)
                 v = torch.empty(shape, dtype=dtype, device=device, layout=layout, requires_grad=rg)
                 check_value(v, dtype, layout, device, None, rg)
@@ -1792,8 +1792,8 @@ class TestTorch(TestCase):
                 check_value(v.new_empty(shape, dtype=int64_dtype, device=device, requires_grad=rg),
                             int64_dtype, layout, device, None, rg)
                 check_value(torch.empty_like(v), dtype, layout, device, None, False)
-                check_value(torch.empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=rg),
-                            int64_dtype, layout, device, None, rg)
+                check_value(torch.empty_like(v, dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+                            int64_dtype, layout, device, None, False)
 
                 if dtype is not torch.float16 and layout != torch.sparse_coo:
                     fv = 3
@@ -1807,8 +1807,8 @@ class TestTorch(TestCase):
                                 int64_dtype, layout, device, fv + 3, rg)
                     check_value(torch.full_like(v, fv + 4), dtype, layout, device, fv + 4, False)
                     check_value(torch.full_like(v, fv + 5,
-                                                dtype=int64_dtype, layout=layout, device=device, requires_grad=rg),
-                                int64_dtype, layout, device, fv + 5, rg)
+                                                dtype=int64_dtype, layout=layout, device=device, requires_grad=False),
+                                int64_dtype, layout, device, fv + 5, False)
 
     def test_empty_full(self):
         self._test_empty_full(self, torch.testing.get_all_dtypes(), torch.strided, torch.device('cpu'))

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -30,6 +30,9 @@ using namespace torch::autograd::utils;
 namespace torch { namespace autograd {
 
 static Tensor set_requires_grad(Tensor self, bool requires_grad) {
+  if (requires_grad && !at::isFloatingType(self.type().scalarType())) {
+    throw std::runtime_error("only Tensors of floating point dtype can require gradients");
+  }
   as_variable_ref(self).set_requires_grad(requires_grad);
   return self;
 }

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -424,6 +424,9 @@ static PyObject * THPVariable_requires_grad_(PyObject* self, PyObject* args, PyO
   if (!self_.is_leaf() && !requires_grad) {
     throw std::runtime_error(autograd::utils::requires_grad_leaf_error(requires_grad));
   }
+  if (requires_grad && !self_.is_floating_point()) {
+    throw std::runtime_error("only Tensors of floating point dtype can require gradients");
+  }
   self_.set_requires_grad(requires_grad);
   return THPVariable_Wrap(self_);
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -290,11 +290,16 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
   HANDLE_TH_ERRORS
   THPUtils_assertRet(-1, PyBool_Check(obj), "requires_grad must be a bool");
   auto& var = self->cdata;
+  auto requires_grad = (obj == Py_True);
   if (!var.is_leaf()) {
     THPUtils_setError(autograd::utils::requires_grad_leaf_error(obj == Py_True).c_str());
     return -1;
   }
-  var.set_requires_grad(obj == Py_True);
+  if (requires_grad && !var.is_floating_point()) {
+    THPUtils_setError("only Tensors of floating point dtype can require gradients");
+    return -1;
+  }
+  var.set_requires_grad(requires_grad);
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }


### PR DESCRIPTION
Sometimes, people are surprised that things cannot be differentiated w.r.t. integer parameters such indices.
The following patch takes some steps to prevent them from requiring gradients of non-floating point Tensors:
- by setting `tensor.requires_grad = True`
- by using `tensor.requires_grad_(True)`
- by using factory functions with `requires_grad=True`

Of course, applying the above with `False` needs to still be allowed.

This as requested by Adam in #7021, this is done at the Python interface level.