### PR TITLE
fix max/min on cuda in presence of NaN (fixes #6996)

### DIFF
--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -47,6 +47,7 @@ struct THCNumerics<uint8_t> {
   static inline __host__ __device__  uint8_t div(uint8_t a, uint8_t b) { return a / b; }
   static inline __host__ __device__  uint8_t abs(uint8_t a) { return a; }
   static inline __host__ __device__  uint8_t pow(uint8_t a, uint8_t b) { return powi<uint8_t>(a, b); }
+  static inline __host__ __device__  bool isnan(uint8_t a) { return false; }
 };
 
 template <>
@@ -68,6 +69,7 @@ struct THCNumerics<int8_t> {
   static inline __host__ __device__  int8_t div(int8_t a, int8_t b) { return a / b; }
   static inline __host__ __device__  int8_t abs(int8_t a) { return ::abs((int)a); }
   static inline __host__ __device__  int8_t pow(int8_t a, int8_t b) { return powi<int8_t>(a, b); }
+  static inline __host__ __device__  bool isnan(int8_t a) { return false; }
 };
 
 template <>
@@ -89,6 +91,7 @@ struct THCNumerics<int16_t> {
   static inline __host__ __device__  int16_t div(int16_t a, int16_t b) { return a / b; }
   static inline __host__ __device__  int16_t abs(int16_t a) { return ::abs((int)a); }
   static inline __host__ __device__  int16_t pow(int16_t a, int16_t b) { return powi<int16_t>(a, b); }
+  static inline __host__ __device__  bool isnan(int16_t a) { return false; }
 };
 
 template <>
@@ -110,6 +113,7 @@ struct THCNumerics<int32_t> {
   static inline __host__ __device__  int32_t div(int32_t a, int32_t b) { return a / b; }
   static inline __host__ __device__  int32_t abs(int32_t a) { return ::abs(a); }
   static inline __host__ __device__  int32_t pow(int32_t a, int32_t b) { return powi<int32_t>(a, b); }
+  static inline __host__ __device__  bool isnan(int32_t a) { return false; }
 };
 
 template <>
@@ -137,6 +141,7 @@ struct THCNumerics<int64_t> {
   static inline __host__ __device__  int64_t div(int64_t a, int64_t b) { return a / b; };
   static inline __host__ __device__  int64_t abs(int64_t a) { return labs(a); }
   static inline __host__ __device__  int64_t pow(int64_t a, int64_t b) { return powi<int64_t>(a, b); }
+  static inline __host__ __device__  bool isnan(int64_t a) { return false; }
 };
 
 #ifdef CUDA_HALF_TENSOR
@@ -614,6 +619,11 @@ static inline __host__ __device__ half lgamma(half a) {
 #endif
   }
 
+  static inline __host__ __device__ bool isnan(half a) {
+    // implemented using that a!=a if and only if a is nan
+    return ne(a, a);
+  }
+
 };
 #endif
 
@@ -666,6 +676,7 @@ struct THCNumerics<float> {
   static inline __host__ __device__  float sub  (float a, float b) { return a - b; }
   static inline __host__ __device__  float pow  (float a, float b) { return powf(a, b); }
   static inline __host__ __device__  float atan2(float a, float b) { return atan2f(a, b); }
+  static inline __host__ __device__  bool isnan(float a) { return ::isnan(a); }
 };
 
 template <>
@@ -717,6 +728,7 @@ struct THCNumerics<double> {
   static inline __host__ __device__  double sub  (double a, double b) { return a - b; }
   static inline __host__ __device__  double pow  (double a, double b) { return ::pow(a, b); }
   static inline __host__ __device__  double atan2(double a, double b) { return ::atan2(a, b); }
+  static inline __host__ __device__  bool isnan(double a) { return ::isnan(a); }
 };
 
 /// `half` has some type conversion issues associated with it, since it

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -105,21 +105,26 @@ struct SquareFunctor<ResT, half> {
 template <typename T>
 struct ReduceMin {
   inline __device__ T operator()(T a, T b) const {
-    return THCNumerics<T>::lt(a, b) ? a : b;
+    // a != a means a == NaN
+    return (THCNumerics<T>::lt(a, b) ||
+            THCNumerics<T>::ne(a, a)) ? a : b;
   }
 };
 
 template <typename T>
 struct ReduceMax {
   inline __device__ T operator()(T a, T b) const {
-    return THCNumerics<T>::gt(a, b) ? a : b;
+    // a != a means a == NaN
+    return (THCNumerics<T>::gt(a, b) ||
+            THCNumerics<T>::ne(a, a)) ? a : b;
   }
 };
 
 template <typename InT, typename AccT>
 struct ReduceMaxTo {
   inline __device__ AccT operator()(InT a, InT b) const {
-    return ScalarConvert<InT, AccT>::to(THCNumerics<InT>::gt(a, b) ? a : b);
+    return ScalarConvert<InT, AccT>::to(
+      (THCNumerics<InT>::gt(a, b) || THCNumerics<InT>::ne(a, a)) ? a : b);
   }
 };
 
@@ -128,7 +133,8 @@ template <>
 struct ReduceMaxTo<half, float> {
   inline __device__ float operator()(float a, half b) const {
     float b_f = __half2float(b);
-    return (THCNumerics<float>::gt(a, b_f) ? a : b_f);
+    return ((THCNumerics<float>::gt(a, b_f) ||
+             THCNumerics<float>::ne(a, a)) ? a : b_f);
   }
 };
 #endif // CUDA_HALF_TENSOR
@@ -789,7 +795,9 @@ struct MaxValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::ge(a.first, b.first) ? a : b;
+    // catch NaN with a != a
+    return (THCNumerics<T>::ge(a.first, b.first) ||
+            THCNumerics<T>::ne(a.first, a.first)) ? a : b;
   }
 };
 
@@ -798,7 +806,9 @@ struct MinValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    return THCNumerics<T>::le(a.first, b.first) ? a : b;
+    // catch NaN with a != a
+    return (THCNumerics<T>::le(a.first, b.first) ||
+            THCNumerics<T>::ne(a.first, a.first)) ? a : b;
   }
 };
 

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -105,18 +105,16 @@ struct SquareFunctor<ResT, half> {
 template <typename T>
 struct ReduceMin {
   inline __device__ T operator()(T a, T b) const {
-    // a != a means a == NaN
     return (THCNumerics<T>::lt(a, b) ||
-            THCNumerics<T>::ne(a, a)) ? a : b;
+            THCNumerics<T>::isnan(a)) ? a : b;
   }
 };
 
 template <typename T>
 struct ReduceMax {
   inline __device__ T operator()(T a, T b) const {
-    // a != a means a == NaN
     return (THCNumerics<T>::gt(a, b) ||
-            THCNumerics<T>::ne(a, a)) ? a : b;
+            THCNumerics<T>::isnan(a)) ? a : b;
   }
 };
 
@@ -124,7 +122,7 @@ template <typename InT, typename AccT>
 struct ReduceMaxTo {
   inline __device__ AccT operator()(InT a, InT b) const {
     return ScalarConvert<InT, AccT>::to(
-      (THCNumerics<InT>::gt(a, b) || THCNumerics<InT>::ne(a, a)) ? a : b);
+      (THCNumerics<InT>::gt(a, b) || THCNumerics<InT>::isnan(a)) ? a : b);
   }
 };
 
@@ -134,7 +132,7 @@ struct ReduceMaxTo<half, float> {
   inline __device__ float operator()(float a, half b) const {
     float b_f = __half2float(b);
     return ((THCNumerics<float>::gt(a, b_f) ||
-             THCNumerics<float>::ne(a, a)) ? a : b_f);
+             THCNumerics<float>::isnan(a)) ? a : b_f);
   }
 };
 #endif // CUDA_HALF_TENSOR
@@ -795,9 +793,8 @@ struct MaxValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    // catch NaN with a != a
     return (THCNumerics<T>::ge(a.first, b.first) ||
-            THCNumerics<T>::ne(a.first, a.first)) ? a : b;
+            THCNumerics<T>::isnan(a.first)) ? a : b;
   }
 };
 
@@ -806,9 +803,8 @@ struct MinValuePair {
   __host__ __device__
   thrust::pair<T, Index> operator()(const thrust::pair<T, Index>& a,
                                     const thrust::pair<T, Index>& b) {
-    // catch NaN with a != a
     return (THCNumerics<T>::le(a.first, b.first) ||
-            THCNumerics<T>::ne(a.first, a.first)) ? a : b;
+            THCNumerics<T>::isnan(a.first)) ? a : b;
   }
 };
 


### PR DESCRIPTION
This adds tests for NaN to the min and max kernels and should return NaNs in the right places.