### PR TITLE
[caffe2][ONNX] Implement CPU NumpyTileOp and corresponding ONNX backend

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -289,7 +289,8 @@ Caffe2Backend::get_renamed_operators() const {
       {"Equal", "EQ"},
       {"Less", "LT"},
       {"Greater", "GT"},
-      {"Unsqueeze", "ExpandDims"}};
+      {"Unsqueeze", "ExpandDims"},
+      {"Tile", "NumpyTile"}};
   return kRenamedOperators;
 }
 

--- a/caffe2/operators/numpy_tile_op.cc
+++ b/caffe2/operators/numpy_tile_op.cc
@@ -1,0 +1,18 @@
+#include "caffe2/operators/numpy_tile_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(NumpyTile, NumpyTileOp<CPUContext>);
+
+OPERATOR_SCHEMA(NumpyTile)
+    .NumInputs(2)
+    .Input(0, "data", "The input tensor.")
+    .Input(1, "repeats", "1-D Tensor specifying how many times to repeat"
+                         " each axis.")
+    .Output(
+        0,
+        "tiled_data",
+        "Tensor that will contain input replicated along the given axis.")
+    .InheritOnnxSchema("Tile");
+
+} // namespace caffe2

--- a/caffe2/operators/numpy_tile_op.h
+++ b/caffe2/operators/numpy_tile_op.h
@@ -1,0 +1,116 @@
+#ifndef CAFFE2_OPERATORS_NUMPY_TILE_OP_H_
+#define CAFFE2_OPERATORS_NUMPY_TILE_OP_H_
+
+#include "caffe2/core/common_omp.h"
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+// Copy a Blob n times along a specified axis.
+template <class Context>
+class NumpyTileOp : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  NumpyTileOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws) {}
+  ~NumpyTileOp() {}
+
+  bool RunOnDevice() override {
+    const auto& input = Input(0);
+    const auto& repeats = Input(1);
+
+    // Check that the `repeats` tensor has the correct rank, has a number of
+    // elements equal to the number of axes of `input`.
+    CAFFE_ENFORCE(repeats.ndim() == 1, "repeats input must be a 1-d tensor");
+    CAFFE_ENFORCE(repeats.size() == input.ndim(), "repeats input have the same"
+                            " number of elements as `inputs` has dimensions.");
+    const int64_t *repeats_data = repeats.template data<int64_t>();
+    for (size_t i=0; i<repeats.size(); ++i) {
+      CAFFE_ENFORCE_GE(repeats_data[i], 0);
+    }
+
+    auto* output = Output(0);
+
+    // Alternate inputs and outputs between two buffers. Repeatedly apply the
+    // Tile kernel along each axis. Then copy out the resulting data into the
+    // output tensor.
+    Tensor<Context> *src = &buffer_a, *dst = &buffer_b;
+    src->CopyFrom(input);
+    vector<TIndex> output_dims(input.dims());
+    for (size_t i = 0; i < repeats.size(); ++i) {
+      if (repeats_data[i] == 1) {
+        continue;
+      }
+      // size up to (and not including) axis
+      const auto outer_dim = src->size_to_dim(i);
+      // size from axis up
+      const auto inner_dim = src->size_from_dim(i);
+
+      dst->Resize(outer_dim, inner_dim * repeats_data[i]);
+
+      /**
+       * How this works:
+       * Imagine a 2D tensor (matrix) of size 3x10, tiled 2 times.
+       * - Tiling along axis 0 (row) means copying the entire 3x10 Matrix 2
+       * times. outer_dim = 0, inner_dim = 30.
+       * - Tiling along axis 1 (column) means copying each row 2 times, then
+       * proceed to the next row, until the end. outer_dim = 3, inner_dim = 10.
+       */
+      const char* src_data = static_cast<const char*>(src->raw_data());
+      char* dst_data =
+          static_cast<char*>(dst->raw_mutable_data(src->meta()));
+
+      DoTile(
+          src->meta(),
+          src->itemsize(),
+          outer_dim,
+          inner_dim,
+          repeats_data[i],
+          src_data,
+          dst_data);
+
+        output_dims[i] *= repeats_data[i];
+        dst->Reshape(output_dims);
+
+        std::swap(src, dst);
+    }
+
+    // NB: because we have the swap at the end of the above loop, our real
+    // result tensor is going to live in *src when we reach this line
+    // whether we entered the loop or not :)
+    output->CopyFrom(*src);
+
+    // reshape output to be input tiled along the axis
+    output->Reshape(output_dims);
+
+    return true;
+  }
+
+ private:
+  void DoTile(
+      const TypeMeta& meta,
+      int item_size,
+      int outer_dim,
+      int inner_dim,
+      int64_t num_tiles,
+      const char* input_data,
+      char* output_data) {
+    for (auto i = 0; i < outer_dim; ++i) {
+      for (auto t = 0; t < num_tiles; ++t) {
+        context_.template CopyItems<Context, Context>(
+            meta, inner_dim, input_data, output_data);
+        output_data += inner_dim * item_size;
+      }
+      input_data += inner_dim * item_size;
+    }
+  }
+
+  Tensor<Context> buffer_a, buffer_b;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_NUMPY_TILE_OP_H_

--- a/caffe2/operators/onnx_while_op.h
+++ b/caffe2/operators/onnx_while_op.h
@@ -34,13 +34,18 @@ class ONNXWhileOp final : public Operator<Context> {
 
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
+  bool RunOnDevice() {
+    return DispatchHelper<TensorTypes<int, bool, long, long long>>::call(this, Input(1));
+  }
+
   // Operator
   //  Inputs: max trip count, condition, initial loop-carried dependencies
   //  Outputs: Final loop-carried dependencies, scan_outputs
   // Body
   //  Inputs: iteration number, condition, loop-carried dependencies
   //  Outputs: condition, loop-carried dependencies, scan_outputs
-  bool RunOnDevice() override {
+  template <typename CondVarType>
+  bool DoRunWithType() {
     // Clear workspaces from the previous invocations of the loop
     // and setup a local scope for the first iteration
     ws_stack_.clear();
@@ -58,7 +63,7 @@ class ONNXWhileOp final : public Operator<Context> {
       num_loop_carried_deps = InputSize() - num_inputs_before_lcds;
     }
     int64_t max_trip_count = *Input(0).template data<int64_t>();
-    const bool first_iter_condition = *Input(1).template data<bool>();
+    const bool first_iter_condition = *Input(1).template data<CondVarType>();
 
     // Body graph has 1+N+K outputs: recalculated condition variable, N
     // loop-carried dependencies, and K scan_outputs
@@ -81,7 +86,7 @@ class ONNXWhileOp final : public Operator<Context> {
     scope_->set_iteration(0ll);
 
     // Initialize input condition variable
-    scope_->set_input_condition(first_iter_condition);
+    scope_->template set_input_condition<CondVarType>(first_iter_condition);
 
     auto valid_iter_num = [this, max_trip_count](int64_t i) {
       if (has_trip_count_) {
@@ -125,7 +130,7 @@ class ONNXWhileOp final : public Operator<Context> {
         }
 
         cur_ws = scope_->workspace();
-        cur_output_condition = scope_->output_condition();
+        cur_output_condition = scope_->template output_condition<CondVarType>();
         if (save_scopes_) {
           loop_ws = ws_stack_.pushForwardWorkspace(parent_ws_).get();
           scope_ = std::make_shared<LocalScope>(loop_ws, body_net_def_);
@@ -175,7 +180,7 @@ class ONNXWhileOp final : public Operator<Context> {
           }
         }
         scope_->set_iteration(itr + 1ll);
-        scope_->set_input_condition(cur_output_condition);
+        scope_->template set_input_condition<CondVarType>(cur_output_condition);
       } else {
         break;
       }
@@ -260,16 +265,18 @@ class ONNXWhileOp final : public Operator<Context> {
       *iteration_var_ptr = itr;
     }
 
+    template <typename CondVarType>
     void set_input_condition(bool cond_value) {
       input_condition_var_->Resize(1);
       auto* input_condition_var_ptr =
-          input_condition_var_->template mutable_data<bool>();
+          input_condition_var_->template mutable_data<CondVarType>();
       *input_condition_var_ptr = cond_value;
     }
 
+    template <typename CondVarType>
     bool output_condition() const {
       auto* condition_var_ptr =
-          condition_var_->template mutable_data<bool>();
+          condition_var_->template mutable_data<CondVarType>();
       return *condition_var_ptr;
     }
 

--- a/caffe2/operators/onnx_while_op.h
+++ b/caffe2/operators/onnx_while_op.h
@@ -35,7 +35,7 @@ class ONNXWhileOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
   bool RunOnDevice() {
-    return DispatchHelper<TensorTypes<int, bool, long, long long>>::call(this, Input(1));
+    return DispatchHelper<TensorTypes<int, bool, long>>::call(this, Input(1));
   }
 
   // Operator

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -167,6 +167,7 @@ class Caffe2Backend(Backend):
         'Greater':               'GT',
         'Unsqueeze':             'ExpandDims',
         'Loop':                  'ONNXWhile',
+        'Tile':                  'NumpyTile',
     }
 
     _global_renamed_attrs = {'kernel_shape': 'kernels'}
@@ -1006,6 +1007,11 @@ class Caffe2Backend(Backend):
             ops = [ops]
         return Caffe2Ops(ops, [], [])
 
+    _broadcast_operators = {
+        'Add',
+        'Sub',
+    }
+
     @classmethod
     def _common_onnx_node_to_caffe2_op(cls, init_model, pred_model, onnx_node, opset_version):
         """
@@ -1044,6 +1050,13 @@ class Caffe2Backend(Backend):
                 return cls._global_renamed_attrs[k]
             return k
         c2_op.arg.extend(onnx_node.attrs.caffe2(kmap=kmap))
+        if c2_op.type in cls._broadcast_operators:
+            already_broadcast = False
+            for arg in c2_op.arg:
+                if arg.name == 'broadcast':
+                    already_broadcast = True
+            if not already_broadcast:
+                c2_op.arg.extend([caffe2.python.utils.MakeArgument('broadcast', 1)])
 
         return c2_op
 

--- a/caffe2/python/operator_test/numpy_tile_op_test.py
+++ b/caffe2/python/operator_test/numpy_tile_op_test.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+from hypothesis import given
+import hypothesis.strategies as st
+import unittest
+
+from caffe2.python import core, workspace
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestNumpyTile(hu.HypothesisTestCase):
+    @given(ndim=st.integers(min_value=1, max_value=4),
+           seed=st.integers(min_value=0, max_value=65536),
+           **hu.gcs)
+    def test_numpy_tile(self, ndim, seed, gc, dc):
+        np.random.seed(seed)
+
+        input_dims = np.random.randint(1, 4, size=ndim)
+        input = np.random.randn(*input_dims)
+        repeats = np.random.randint(1, 5, size=ndim)
+
+        op = core.CreateOperator(
+            'NumpyTile', ['input', 'repeats'], 'out',
+        )
+
+        def tile_ref(input, repeats):
+            tiled_data = np.tile(input, repeats)
+            return (tiled_data,)
+
+        # Check against numpy reference
+        self.assertReferenceChecks(gc, op, [input, repeats],
+                                   tile_ref)
+
+    @given(ndim=st.integers(min_value=1, max_value=4),
+           seed=st.integers(min_value=0, max_value=65536),
+           **hu.gcs)
+    def test_numpy_tile_zero_dim(self, ndim, seed, gc, dc):
+        np.random.seed(seed)
+
+        input_dims = np.random.randint(0, 4, size=ndim)
+        input = np.random.randn(*input_dims)
+        repeats = np.random.randint(0, 5, size=ndim)
+
+        op = core.CreateOperator(
+            'NumpyTile', ['input', 'repeats'], 'out',
+        )
+
+        def tile_ref(input, repeats):
+            tiled_data = np.tile(input, repeats)
+            return (tiled_data,)
+
+        # Check against numpy reference
+        self.assertReferenceChecks(gc, op, [input, repeats],
+                                   tile_ref)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/caffe2/python/operator_test/numpy_tile_op_test.py
+++ b/caffe2/python/operator_test/numpy_tile_op_test.py
@@ -16,7 +16,7 @@ import caffe2.python.hypothesis_test_util as hu
 class TestNumpyTile(hu.HypothesisTestCase):
     @given(ndim=st.integers(min_value=1, max_value=4),
            seed=st.integers(min_value=0, max_value=65536),
-           **hu.gcs)
+           **hu.gcs_cpu_only)
     def test_numpy_tile(self, ndim, seed, gc, dc):
         np.random.seed(seed)
 
@@ -38,7 +38,7 @@ class TestNumpyTile(hu.HypothesisTestCase):
 
     @given(ndim=st.integers(min_value=1, max_value=4),
            seed=st.integers(min_value=0, max_value=65536),
-           **hu.gcs)
+           **hu.gcs_cpu_only)
     def test_numpy_tile_zero_dim(self, ndim, seed, gc, dc):
         np.random.seed(seed)
 


### PR DESCRIPTION
This PR creates a `NumpyTile` operator which tiles a tensor along each dimension, conforming to the semantics of Pytorch, Numpy, and ONNX. It is a fairly naïve implementation that repeatedly applies the existing Tile kernel along each dimension.

This PR allows us to import ONNX `Tile` operators into caffe2