### PR TITLE
[EASY] Add optional support to C++ extensions

### DIFF
--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -20,8 +20,16 @@ struct MatrixMultiplier {
   at::Tensor tensor_;
 };
 
+bool function_taking_optional(at::optional<at::Tensor> tensor) {
+  return tensor.has_value();
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
+  m.def(
+      "function_taking_optional",
+      &function_taking_optional,
+      "function_taking_optional");
   py::class_<MatrixMultiplier>(m, "MatrixMultiplier")
       .def(py::init<int, int>())
       .def("forward", &MatrixMultiplier::forward)

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -100,6 +100,12 @@ class TestCppExtension(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
+    def test_optional(self):
+        has_value = cpp_extension.function_taking_optional(torch.ones(5))
+        self.assertTrue(has_value)
+        has_value = cpp_extension.function_taking_optional(None)
+        self.assertFalse(has_value)
+
 
 if __name__ == '__main__':
     common.run_tests()

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -57,4 +57,7 @@ public:
   }
 };
 
+// http://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
+template <typename T>
+struct type_caster<at::optional<T>> : optional_caster<at::optional<T>> {};
 }} // namespace pybind11::detail


### PR DESCRIPTION
Adds support for `at::optional` conversion from Python. Basically, converts `T` to `at::optional<T>` and `None` to `at::nullopt`. Trivially implemented  because pybind11 has super nice support for non std optional types.

Fixes https://github.com/pytorch/extension-cpp/issues/5

@apaszke @fmassa @colesbury 