### PR TITLE
Inline JIT C++ Extensions

### DIFF
--- a/docs/source/cpp_extension.rst
+++ b/docs/source/cpp_extension.rst
@@ -6,6 +6,7 @@ torch.utils.cpp_extension
 .. autofunction:: CUDAExtension
 .. autofunction:: BuildExtension
 .. autofunction:: load
+.. autofunction:: load_inline
 .. autofunction:: include_paths
 .. autofunction:: check_compiler_abi_compatibility
 .. autofunction:: verify_ninja_availability

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -143,7 +143,6 @@ class TestCppExtension(common.TestCase):
         self.assertEqual(
             module.tanh_add.__doc__.split('\n')[2], 'Tanh and then sum :D')
 
-
     def test_inline_jit_compile_extension_multiple_sources_and_no_functions(self):
         cpp_source1 = '''
         at::Tensor sin_add(at::Tensor x, at::Tensor y) {

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -488,7 +488,7 @@ def load_inline(name,
     strings rather than filenames. These strings are stored to files in the
     build directory, after which the behavior of :func:`load_inline` is
     identical to :func:`load`. Strings passed in ``cpp_sources`` (a string or
-    list of strings) are stored with a `.cpp` extension, and the string or list
+    list of strings) are stored with a ``.cpp`` extension, and the string or list
     of strings passed in ``cuda_sources`` are stored with a ``.cu`` extension.
 
     Example:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -534,21 +534,26 @@ def load_inline(name,
                 function_name, docstring))
         cpp_sources.append('}')
 
-    cuda_sources.insert(0, '#include <ATen/ATen.h>')
-    cuda_sources.insert(1, '#include <cuda.h>')
-    cuda_sources.insert(2, '#include <cuda_runtime.h>')
-
     cpp_source_path = os.path.join(build_directory, 'main.cpp')
     with open(cpp_source_path, 'w') as cpp_source_file:
         cpp_source_file.write('\n'.join(cpp_sources))
 
-    cuda_source_path = os.path.join(build_directory, 'cuda.cu')
-    with open(cuda_source_path, 'w') as cuda_source_file:
-        cuda_source_file.write('\n'.join(cuda_sources))
+    sources = [cpp_source_path]
+
+    if cuda_sources:
+        cuda_sources.insert(0, '#include <ATen/ATen.h>')
+        cuda_sources.insert(1, '#include <cuda.h>')
+        cuda_sources.insert(2, '#include <cuda_runtime.h>')
+
+        cuda_source_path = os.path.join(build_directory, 'cuda.cu')
+        with open(cuda_source_path, 'w') as cuda_source_file:
+            cuda_source_file.write('\n'.join(cuda_sources))
+
+        sources.append(cuda_source_path)
 
     return _jit_compile(
         name,
-        [cpp_source_path, cuda_source_path],
+        sources,
         extra_cflags,
         extra_cuda_cflags,
         extra_ldflags,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -461,7 +461,7 @@ def load(name,
                 extra_cflags=['-O2'],
                 verbose=True)
     '''
-    return _jit_compile_sources(
+    return _jit_compile(
         name,
         [sources] if isinstance(sources, str) else sources,
         extra_cflags,
@@ -527,7 +527,7 @@ def load_inline(name,
     if verbose:
         print('Saved source files: {}'.format(', '.join(source_files)))
 
-    return _jit_compile_sources(
+    return _jit_compile(
         name,
         source_files,
         extra_cflags,
@@ -538,14 +538,14 @@ def load_inline(name,
         verbose)
 
 
-def _jit_compile_sources(name,
-                         sources,
-                         extra_cflags,
-                         extra_cuda_cflags,
-                         extra_ldflags,
-                         extra_include_paths,
-                         build_directory,
-                         verbose):
+def _jit_compile(name,
+                 sources,
+                 extra_cflags,
+                 extra_cuda_cflags,
+                 extra_ldflags,
+                 extra_include_paths,
+                 build_directory,
+                 verbose):
     baton = FileBaton(os.path.join(build_directory, 'lock'))
     if baton.try_acquire():
         try:


### PR DESCRIPTION
Adds ability to JIT compile C++ extensions from strings

```py
>>> from torch.utils.cpp_extension import load_inline
>>> source = '''
    at::Tensor sin_add(at::Tensor x, at::Tensor y) {
      return x.sin() + y.sin();
    }
'''
>>> module = load_inline(name='inline_extension', cpp_sources=source, functions='sin_add')
```

Fixes #7012 

@apaszke @fmassa 