### PR TITLE
[Caffe2] Fixing bug in conda builds

### DIFF
--- a/scripts/build_anaconda.sh
+++ b/scripts/build_anaconda.sh
@@ -301,6 +301,8 @@ fi
 add_package 'glog'
 add_package 'gflags'
 add_package 'opencv'
+CAFFE2_CMAKE_ARGS+=("-DUSE_LMDB=OFF")
+
 
 # Add packages required for pytorch
 if [[ -n $pytorch_too ]]; then

--- a/scripts/build_anaconda.sh
+++ b/scripts/build_anaconda.sh
@@ -301,7 +301,7 @@ fi
 add_package 'glog'
 add_package 'gflags'
 add_package 'opencv'
-CAFFE2_CMAKE_ARGS+=("-DUSE_LMDB=OFF")
+caffe2_cmake_args+=("-DUSE_LMDB=OFF")
 
 
 # Add packages required for pytorch


### PR DESCRIPTION
System lmdb is installed on the CI machines, leading to packages that link against liblmdb.so.0 without lmdb in the conda requirements.