### PR TITLE
Open-source extractMetaNetDef & runGlobalInitialization, add new Predictor constructor from db file, and add run_map_outputs

### DIFF
--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -35,6 +35,9 @@ TensorCPU* extractOutputTensor(Workspace* ws, const std::string& name) {
   return blob->template GetMutable<TensorCPU>();
 }
 
+// We don't use the getNet() from predictor_utils.cc here because that file
+// has additional dependencies that we want to avoid bringing in, to keep the
+// binary size as small as possible.
 const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
   for (const auto& n : def.nets()) {
     if (n.key() == name) {
@@ -56,27 +59,36 @@ const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
 }
 } // namespace
 
-Predictor::Predictor(const MetaNetDef& def, Workspace* parent)
+Predictor::Predictor(const MetaNetDef& def, Workspace* parent, bool run_init)
     : Predictor(
           getNet(
               def,
               PredictorConsts::default_instance().global_init_net_type()),
           getNet(def, PredictorConsts::default_instance().predict_net_type()),
-          parent) {
+          parent,
+          run_init) {
   const auto& inputs =
       getBlobs(def, PredictorConsts::default_instance().inputs_blob_type());
   for (const auto& input : inputs) {
     inputNames_.insert(input);
+  }
+
+  const auto& outputs =
+      getBlobs(def, PredictorConsts::default_instance().outputs_blob_type());
+  for (const auto& output : outputs) {
+    outputNames_.emplace_back(output);
   }
 }
 
 Predictor::Predictor(
     const NetDef& init_net,
     const NetDef& run_net,
-    Workspace* parent)
+    Workspace* parent,
+    bool run_init)
     : run_net_(run_net), ws_(parent) {
-  CAFFE_ENFORCE(ws_.RunNetOnce(init_net));
-
+  if (run_init) {
+    CAFFE_ENFORCE(ws_.RunNetOnce(init_net));
+  }
 #if CAFFE2_MOBILE
   GlobalInit();
 #endif
@@ -93,8 +105,6 @@ Predictor::Predictor(
   }
   CAFFE_ENFORCE(ws_.CreateNet(run_net));
 }
-
-Predictor::~Predictor() {}
 
 bool Predictor::run(const TensorVector& inputs, TensorVector* outputs) {
   CAFFE_ENFORCE(inputs.size() <= run_net_.external_input_size());
@@ -113,7 +123,7 @@ bool Predictor::run(const TensorVector& inputs, TensorVector* outputs) {
   return true;
 }
 
-bool Predictor::run_map(const TensorMap& inputs, TensorVector* outputs) {
+bool Predictor::run_map_workspace(const TensorMap& inputs) {
   if (!inputNames_.empty()) {
     CAFFE_ENFORCE_EQ(inputs.size(), inputNames_.size());
   }
@@ -124,7 +134,11 @@ bool Predictor::run_map(const TensorMap& inputs, TensorVector* outputs) {
     shareInputTensor(&ws_, input.first, input.second);
   }
 
-  if (!ws_.RunNet(run_net_.name())) {
+  return ws_.RunNet(run_net_.name());
+}
+
+bool Predictor::run_map(const TensorMap& inputs, TensorVector* outputs) {
+  if (!run_map_workspace(inputs)) {
     return false;
   }
 
@@ -134,4 +148,17 @@ bool Predictor::run_map(const TensorMap& inputs, TensorVector* outputs) {
   }
   return true;
 }
+
+bool Predictor::run_map_outputs(const TensorMap& inputs, TensorMap* outputs) {
+  if (!run_map_workspace(inputs)) {
+    return false;
+  }
+
+  outputs->reserve(outputNames_.size());
+  for (const std::string& outputName : outputNames_) {
+    (*outputs)[outputName] = extractOutputTensor(&ws_, outputName);
+  }
+  return true;
+}
+
 } // namespace caffe2

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -49,16 +49,13 @@ const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
 
 const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
     const MetaNetDef& def,
-    const std::string& name,
-    const bool optional = false) {
+    const std::string& name) {
   for (const auto& b : def.blobs()) {
     if (b.key() == name) {
       return b.value();
     }
   }
-  CAFFE_ENFORCE(optional, "Blob not found: ", name);
-  static ::google::protobuf::RepeatedPtrField<::std::string> emptyVec;
-  return emptyVec;
+  CAFFE_THROW("Blob not found: ", name);
 }
 } // namespace
 
@@ -76,8 +73,8 @@ Predictor::Predictor(const MetaNetDef& def, Workspace* parent, bool run_init)
     inputNames_.insert(input);
   }
 
-  const auto& outputs = getBlobs(
-      def, PredictorConsts::default_instance().outputs_blob_type(), true);
+  const auto& outputs =
+      getBlobs(def, PredictorConsts::default_instance().outputs_blob_type());
   for (const auto& output : outputs) {
     outputNames_.emplace_back(output);
   }

--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -49,13 +49,16 @@ const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
 
 const ::google::protobuf::RepeatedPtrField<::std::string>& getBlobs(
     const MetaNetDef& def,
-    const std::string& name) {
+    const std::string& name,
+    const bool optional = false) {
   for (const auto& b : def.blobs()) {
     if (b.key() == name) {
       return b.value();
     }
   }
-  CAFFE_THROW("Blob not found: ", name);
+  CAFFE_ENFORCE(optional, "Blob not found: ", name);
+  static ::google::protobuf::RepeatedPtrField<::std::string> emptyVec;
+  return emptyVec;
 }
 } // namespace
 
@@ -73,8 +76,8 @@ Predictor::Predictor(const MetaNetDef& def, Workspace* parent, bool run_init)
     inputNames_.insert(input);
   }
 
-  const auto& outputs =
-      getBlobs(def, PredictorConsts::default_instance().outputs_blob_type());
+  const auto& outputs = getBlobs(
+      def, PredictorConsts::default_instance().outputs_blob_type(), true);
   for (const auto& output : outputs) {
     outputNames_.emplace_back(output);
   }

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -15,15 +15,20 @@ class Predictor {
 
   // MetaNetDef contains 'init_net', 'run_net', and meta-info
   // The meta-info is used to verify inputs are correctly passed
-  Predictor(const MetaNetDef& net, Workspace* parent = nullptr);
+  Predictor(
+      const MetaNetDef& net,
+      Workspace* parent = nullptr,
+      bool run_init = true);
 
   // Runs the `init_net` once, then saves the `run_net` to be executed
   // in `::run`
   Predictor(
       const NetDef& init_net,
       const NetDef& run_net,
-      Workspace* parent = nullptr);
-  ~Predictor();
+      Workspace* parent = nullptr,
+      bool run_init = true);
+
+  ~Predictor() {}
 
   // Executes `run_net` on the inputs.
   // The first `inputs.size()` inputs from run_net::external_inputs
@@ -41,6 +46,10 @@ class Predictor {
   // Similar to run, but consumes a map of name to tensor as input
   bool run_map(const TensorMap& inputs, TensorVector* outputs);
 
+  // Similar to the other run fns, except inputs and outputs are both maps of
+  // string name to tensor.
+  bool run_map_outputs(const TensorMap& inputs, TensorMap* outputs);
+
   const NetDef& def() const {
     return run_net_;
   };
@@ -49,9 +58,22 @@ class Predictor {
     return &ws_;
   };
 
+  const std::unordered_set<std::string>& input_names() const {
+    return inputNames_;
+  }
+
+  const std::vector<std::string>& output_names() const {
+    return outputNames_;
+  }
+
  private:
+  bool run_map_workspace(const TensorMap& inputs);
+
   NetDef run_net_;
   Workspace ws_;
   std::unordered_set<std::string> inputNames_;
+  // Outputs need to be ordered since TensorVector outputs rely on the outputs
+  // being in a certain order.
+  std::vector<std::string> outputNames_;
 };
 }

--- a/caffe2/core/predictor_test.cc
+++ b/caffe2/core/predictor_test.cc
@@ -62,6 +62,10 @@ const char* metaSpec = R"DOC(
     key: "INPUTS_BLOB_TYPE"
     value: "data"
   }
+  blobs {
+      key: "OUTPUTS_BLOB_TYPE"
+      value: "y"
+  }
   nets {
     key: "GLOBAL_INIT_NET_TYPE"
     value: {

--- a/caffe2/core/predictor_utils.cc
+++ b/caffe2/core/predictor_utils.cc
@@ -1,0 +1,81 @@
+#include "caffe2/core/predictor_utils.h"
+
+#include "caffe2/core/blob.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/proto/caffe2.pb.h"
+#include "caffe2/proto/predictor_consts.pb.h"
+#include "caffe2/utils/proto_utils.h"
+
+namespace caffe2 {
+namespace predictor_utils {
+
+const NetDef getNet(const MetaNetDef& def, const std::string& name) {
+  for (const auto& n : def.nets()) {
+    if (n.key() == name) {
+      return n.value();
+    }
+  }
+  CAFFE_THROW("Net not found: ", name);
+  return NetDef();
+}
+
+std::unique_ptr<MetaNetDef> extractMetaNetDef(
+    db::Cursor* cursor,
+    const std::string& key) {
+  CAFFE_ENFORCE(cursor);
+  if (cursor->SupportsSeek()) {
+    cursor->Seek(key);
+  }
+  for (; cursor->Valid(); cursor->Next()) {
+    if (cursor->key() != key) {
+      continue;
+    }
+    // We've found a match. Parse it out.
+    BlobProto proto;
+    CAFFE_ENFORCE(proto.ParseFromString(cursor->value()));
+    Blob blob;
+    blob.Deserialize(proto);
+    CAFFE_ENFORCE(blob.template IsType<string>());
+    auto def = caffe2::make_unique<MetaNetDef>();
+    CAFFE_ENFORCE(def->ParseFromString(blob.template Get<string>()));
+    return def;
+  }
+  CAFFE_THROW("Failed to find in db the key: ", key);
+}
+
+std::unique_ptr<MetaNetDef> runGlobalInitialization(
+    std::unique_ptr<db::DBReader> db,
+    Workspace* master) {
+  CAFFE_ENFORCE(db.get());
+  auto* cursor = db->cursor();
+
+  auto metaNetDef = extractMetaNetDef(
+      cursor, PredictorConsts::default_instance().meta_net_def());
+  if (metaNetDef->has_modelinfo()) {
+    CAFFE_ENFORCE(
+        metaNetDef->modelinfo().predictortype() ==
+            PredictorConsts::default_instance().single_predictor(),
+        "Can only load single predictor");
+  }
+  VLOG(1) << "Extracted meta net def";
+
+  const auto globalInitNet = getNet(
+      *metaNetDef, PredictorConsts::default_instance().global_init_net_type());
+  VLOG(1) << "Global init net: " << ProtoDebugString(globalInitNet);
+
+  // Now, pass away ownership of the DB into the master workspace for
+  // use by the globalInitNet.
+  master->CreateBlob(PredictorConsts::default_instance().predictor_dbreader())
+      ->Reset(db.release());
+
+  // Now, with the DBReader set, we can run globalInitNet.
+  CAFFE_ENFORCE(
+      master->RunNetOnce(globalInitNet),
+      "Failed running the globalInitNet: ",
+      ProtoDebugString(globalInitNet));
+
+  return metaNetDef;
+}
+
+} // namespace predictor_utils
+} // namespace caffe2

--- a/caffe2/core/predictor_utils.h
+++ b/caffe2/core/predictor_utils.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "caffe2/core/db.h"
+#include "caffe2/core/workspace.h"
+#include "caffe2/proto/metanet.pb.h"
+
+namespace caffe2 {
+namespace predictor_utils {
+
+const NetDef getNet(const MetaNetDef& def, const std::string& name);
+
+std::unique_ptr<MetaNetDef> extractMetaNetDef(
+    db::Cursor* cursor,
+    const std::string& key);
+
+// Extract the MetaNetDef from `db`, and run the global init net on the
+// `master` workspace.
+std::unique_ptr<MetaNetDef> runGlobalInitialization(
+    std::unique_ptr<db::DBReader> db,
+    Workspace* master);
+
+} // namespace predictor_utils
+} // namespace caffe2


### PR DESCRIPTION
1. Open-source extractMetaNetDef and runGlobalInitialization, for use in
2. new Predictor constructor from db file.
3. Add new run function that returns outputs as TensorMap.
