### PR TITLE
Don't build THD/master_worker if not explicitly requested

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,9 @@ def build_libs(libs):
     if WITH_GLOO_IBVERBS:
         build_libs_cmd += ['--with-gloo-ibverbs']
 
+    if WITH_DISTRIBUTED_MW:
+        build_libs_cmd += ['--with-distributed-mw']
+
     if subprocess.call(build_libs_cmd + libs, env=my_env) != 0:
         sys.exit(1)
 

--- a/tools/build_pytorch_libs.sh
+++ b/tools/build_pytorch_libs.sh
@@ -35,6 +35,12 @@ if [[ "$1" == "--with-gloo-ibverbs" ]]; then
   shift
 fi
 
+WITH_DISTRIBUTED_MW=0
+if [[ "$1" == "--with-distributed-mw" ]]; then
+  WITH_DISTRIBUTED_MW=1
+  shift
+fi
+
 CMAKE_INSTALL=${CMAKE_INSTALL-make install}
 
 # Save user specified env vars, we will manually propagate them
@@ -92,6 +98,9 @@ fi
 if [[ $WITH_GLOO_IBVERBS -eq 1 ]]; then
     GLOO_FLAGS+=" -DUSE_IBVERBS=1 -DBUILD_SHARED_LIBS=1"
     THD_FLAGS="-DWITH_GLOO_IBVERBS=1"
+fi
+if [[ $WITH_DISTRIBUTED_MW -eq 1 ]]; then
+    THD_FLAGS+="-DWITH_DISTRIBUTED_MW=1"
 fi
 CWRAP_FILES="\
 $BASE_DIR/torch/lib/ATen/Declarations.cwrap;\

--- a/torch/csrc/distributed/Module.cpp
+++ b/torch/csrc/distributed/Module.cpp
@@ -126,6 +126,7 @@ PyObject* THDPModule_destroyProcessGroup(PyObject *_unused) {
   END_HANDLE_TH_ERRORS
 }
 
+#ifdef WITH_DISTRIBUTED_MW
 PyObject* THDPModule_initMasterWorker(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
@@ -155,6 +156,7 @@ PyObject* THDPModule_initMasterWorker(PyObject *_unused, PyObject *args)
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
+#endif
 
 #ifdef WITH_CUDA
 PyObject* THDPModule_registerStream(PyObject *_unused, PyObject *_stream)
@@ -980,7 +982,9 @@ static struct PyMethodDef _THDPModule_methods[] = {
   {"_dist_init_process_group", (PyCFunction)THDPModule_initProcessGroup, METH_VARARGS, NULL},
   {"_dist_destroy_process_group", (PyCFunction)THDPModule_destroyProcessGroup, METH_NOARGS, NULL},
   {"_dist_clear_group_cache", (PyCFunction)THDPModule_clearGroupCache, METH_VARARGS, NULL},
+#ifdef WITH_DISTRIBUTED_MW
   {"_dist_init_master_worker", (PyCFunction)THDPModule_initMasterWorker, METH_VARARGS, NULL},
+#endif
 #ifdef WITH_CUDA
   {"_dist_register_stream", (PyCFunction)THDPModule_registerStream, METH_O, NULL},
 #endif

--- a/torch/csrc/distributed/THDP.h
+++ b/torch/csrc/distributed/THDP.h
@@ -5,10 +5,12 @@
 
 #include "torch/csrc/THP.h"
 #include "Module.h"
+#ifdef WITH_DISTRIBUTED_MW
 #include "Storage.h"
 #include "../PtrWrapper.h"
 #ifdef _THP_CORE
 #include "utils.h"
+#endif
 #endif
 
 #endif

--- a/torch/lib/THD/CMakeLists.txt
+++ b/torch/lib/THD/CMakeLists.txt
@@ -128,8 +128,14 @@ ENDIF()
 
 EXCLUDE_DIR(master_worker_cpp ".*/dispatch/.*\\.cpp$")
 
-SET(all_cpp ${base_cpp} ${process_group_cpp} ${master_worker_cpp})
-SET(all_h THD.h ${base_h} ${process_group_h} ${master_worker_h})
+SET(all_cpp ${base_cpp} ${process_group_cpp})
+SET(all_h THD.h ${base_h} ${process_group_h})
+
+IF(WITH_DISTRIBUTED_MW)
+  ADD_DEFINITIONS(-DWITH_DISTRIBUTED_MW=1)
+  SET(all_cpp ${all_cpp} ${master_worker_cpp})
+  SET(all_h THD.h ${all_h} ${master_worker_h})
+ENDIF()
 
 EXCLUDE_DIR(all_cpp ".*/generic/.*\\.cpp$")
 

--- a/torch/lib/THD/THD.h
+++ b/torch/lib/THD/THD.h
@@ -19,6 +19,7 @@
 #include "process_group/General.h"
 #include "process_group/Collectives.h"
 
+#ifdef WITH_DISTRIBUTED_MW
 #include "master_worker/master/Master.h"
 #include "master_worker/master/State.h"
 #include "master_worker/master/THDRandom.h"
@@ -26,3 +27,4 @@
 #include "master_worker/master/THDTensor.h"
 
 #include "master_worker/worker/Worker.h"
+#endif


### PR DESCRIPTION
Addresses #6999 

Avoid building files in `torch/lib/THD/master_worker` and adjust `torch/csrc/distributed` accordingly.
Building `master_worker` can be manually enabled by specifying the `WITH_DISTRIBUTED_MW` env var.