### PR TITLE
Removing leveldb to make special gcc builds unnecessary

### DIFF
--- a/scripts/build_anaconda.sh
+++ b/scripts/build_anaconda.sh
@@ -301,6 +301,7 @@ fi
 add_package 'glog'
 add_package 'gflags'
 add_package 'opencv'
+caffe2_cmake_args+=("-DUSE_LEVELDB=OFF")
 caffe2_cmake_args+=("-DUSE_LMDB=OFF")
 
 
@@ -323,8 +324,6 @@ if [[ -n $pytorch_too ]]; then
     conda_channel+=('-c pytorch')
     export BUILD_WITH_CUDA=1
   fi
-else
-  add_package 'leveldb'
 fi
 
 # Flags required for CUDA for Caffe2


### PR DESCRIPTION
This will allow the integrated builds to be slimmer and easier to test. Leveldb will be excluded until it is modularized out.