### PR TITLE
Location of pip package changed

### DIFF
--- a/docker/caffe2/jenkins/common/install_python.sh
+++ b/docker/caffe2/jenkins/common/install_python.sh
@@ -103,7 +103,7 @@ fi
 # This is required for the non-standard Python version
 # installed on Ubuntu. They
 if [ -n "${INSTALL_SETUPTOOLS}" ]; then
-  curl -O https://pypi.python.org/packages/6c/54/f7e9cea6897636a04e74c3954f0d8335cc38f7d01e27eec98026b049a300/setuptools-38.5.1.zip
+  curl -O https://files.pythonhosted.org/packages/6c/54/f7e9cea6897636a04e74c3954f0d8335cc38f7d01e27eec98026b049a300/setuptools-38.5.1.zip
   unzip setuptools-38.5.1.zip
   pushd setuptools-38.5.1
   "$PYTHON" setup.py install

--- a/docker/caffe2/jenkins/common/install_python.sh
+++ b/docker/caffe2/jenkins/common/install_python.sh
@@ -115,7 +115,7 @@ fi
 # The python-pip package on Ubuntu Trusty is old
 # and upon install numpy doesn't use the binary
 # distribution, and fails to compile it from source.
-curl -O https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz
+curl -O https://files.pythonhosted.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz
 tar zxf pip-9.0.1.tar.gz
 pushd pip-9.0.1
 "$PYTHON" setup.py install


### PR DESCRIPTION
There is a pip 10.0.1 relased April 19th as well; I don't know if there's any objections to switching to that.