### PR TITLE
[EASY] Remove unused variable

### DIFF
--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -31,7 +31,6 @@ static std::unordered_map<std::string, at::ScalarType> attype_names = {
 static std::unordered_map<at::Type*, PyTypeObject*> attype_to_py_storage_type;
 static std::unordered_map<PyTypeObject*, at::Type*> py_storage_type_to_attype;
 
-static const int NumBoolOptions = 2;
 static THPDtype* dtype_registry
   [static_cast<int>(at::ScalarType::NumOptions)] = {};
 


### PR DESCRIPTION
This is from before I enabled `WERROR=1` @zdevito 