### PR TITLE
Make AT_ASSERT/AT_ERROR non-printf based, other tweaks

### DIFF
--- a/aten/src/ATen/ArrayRef.h
+++ b/aten/src/ATen/ArrayRef.h
@@ -116,13 +116,13 @@ namespace at {
 
     /// front - Get the first element.
     const T &front() const {
-      AT_ASSERT(!empty(), "Empty list!");
+      AT_CHECK(!empty(), "ArrayRef: attempted to access front() of empty list");
       return Data[0];
     }
 
     /// back - Get the last element.
     const T &back() const {
-      AT_ASSERT(!empty(), "Empty list!");
+      AT_CHECK(!empty(), "ArrayRef: attempted to access back() of empty list");
       return Data[Length-1];
     }
 
@@ -136,7 +136,7 @@ namespace at {
     /// slice(n, m) - Chop off the first N elements of the array, and keep M
     /// elements in the array.
     ArrayRef<T> slice(size_t N, size_t M) const {
-      AT_ASSERT(N+M <= size(), "Invalid specifier");
+      AT_CHECK(N+M <= size(), "ArrayRef: invalid slice, ", N, " + ", M, " is not <= ", size());
       return ArrayRef<T>(data()+N, M);
     }
 
@@ -152,7 +152,7 @@ namespace at {
 
     /// Vector compatibility
     const T &at(size_t Index) const {
-      AT_ASSERT(Index < Length, "Invalid index!");
+      AT_CHECK(Index < Length, "ArrayRef: invalid index ", Index, " for length ", Length);
       return Data[Index];
     }
 

--- a/aten/src/ATen/CheckGenerator.h
+++ b/aten/src/ATen/CheckGenerator.h
@@ -12,7 +12,7 @@ static inline T * check_generator(Generator * expr, Generator * defaultValue) {
     expr = defaultValue;
   if(auto result = dynamic_cast<T*>(expr))
     return result;
-  AT_ERROR("Expected a '%s' but found '%s'", typeid(T).name(), typeid(expr).name());
+  AT_ERROR("Expected a '", typeid(T).name(), "' but found '", typeid(expr).name(), "'");
 }
 
 } // namespace at

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -33,7 +33,7 @@ public:
         auto & undef = type_registry[static_cast<int>(Backend::Undefined)][static_cast<int>(ScalarType::Undefined)];
         if (undef) return *undef;
       }
-      AT_ERROR("%s%sType is not enabled.",toString(p),toString(s));
+      AT_ERROR(toString(p), toString(s), "Type is not enabled.");
     }
     return *type;
   }
@@ -41,7 +41,7 @@ public:
     initCUDAIfNeeded(p);
     auto & generator = generator_registry[static_cast<int>(p)];
     if(!generator)
-      AT_ERROR("%s backend type not enabled.",toString(p));
+      AT_ERROR(toString(p), " backend type not enabled.");
     return *generator;
   }
   bool hasMKL() const;

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -17,7 +17,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)         \
       default:                                                                \
-        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -29,7 +29,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)         \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, Half, __VA_ARGS__)           \
       default:                                                                \
-        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -45,7 +45,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)       \
       default:                                                                \
-        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -62,6 +62,6 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, Half, __VA_ARGS__)           \
       default:                                                                \
-        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -17,7 +17,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)         \
       default:                                                                \
-        AT_ERROR("%s not implemented for '%s'", (NAME), the_type.toString()); \
+        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -29,7 +29,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)         \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, Half, __VA_ARGS__)           \
       default:                                                                \
-        AT_ERROR("%s not implemented for '%s'", (NAME), the_type.toString()); \
+        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -45,7 +45,7 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)       \
       default:                                                                \
-        AT_ERROR("%s not implemented for '%s'", (NAME), the_type.toString()); \
+        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()
 
@@ -62,6 +62,6 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, Half, __VA_ARGS__)           \
       default:                                                                \
-        AT_ERROR("%s not implemented for '%s'", (NAME), the_type.toString()); \
+        AT_ERROR((NAME), " not implemented for '", the_type.toString(), "'"); \
     }                                                                         \
   }()

--- a/aten/src/ATen/Error.cpp
+++ b/aten/src/ATen/Error.cpp
@@ -1,0 +1,202 @@
+#include <ATen/Error.h>
+
+namespace at {
+
+namespace detail {
+
+#if defined(_MSC_VER)
+// Windows does not have cxxabi.h, so we will simply return the original.
+std::string demangle(const char* name) {
+  return std::string(name);
+}
+#else
+std::string demangle(const char* name) {
+  int status = -1;
+
+  // This function will demangle the mangled function name into a more human
+  // readable format, e.g. _Z1gv -> g().
+  // More information:
+  // https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/libsupc%2B%2B/cxxabi.h
+  // NOTE: `__cxa_demangle` returns a malloc'd string that we have to free
+  // ourselves.
+  std::unique_ptr<char, std::function<void(char *)>> demangled(
+      abi::__cxa_demangle(
+          name,
+          /*__output_buffer=*/nullptr,
+          /*__length=*/0,
+          &status),
+      /*deleter=*/free);
+
+  // Demangling may fail, for example when the name does not follow the
+  // standard C++ (Itanium ABI) mangling scheme. This is the case for `main`
+  // or `clone` for example, so the mangled name is a fine default.
+  if (status == 0) {
+    return demangled.get();
+  } else {
+    return name;
+  }
+}
+#endif
+
+// TODO: This backtrace retrieval can be implemented on Windows via the Windows
+// API using `CaptureStackBackTrace` and `SymFromAddr`.
+// https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
+// https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows
+// https://msdn.microsoft.com/en-us/library/windows/desktop/bb204633%28v=vs.85%29.aspx.
+#if !defined(_WIN32)
+
+struct FrameInformation {
+  /// If available, the demangled name of the function at this frame, else
+  /// whatever (possibly mangled) name we got from `backtrace()`.
+  std::string function_name;
+  /// This is a number in hexadecimal form (e.g. "0xdead") representing the
+  /// offset into the function's machine code at which the function's body
+  /// starts, i.e. skipping the "prologue" that handles stack manipulation and
+  /// other calling convention things.
+  std::string offset_into_function;
+  /// NOTE: In debugger parlance, the "object file" refers to the ELF file that
+  /// the symbol originates from, i.e. either an executable or a library.
+  std::string object_file;
+};
+
+at::optional<FrameInformation> parse_frame_information(
+    const std::string &frame_string) {
+  FrameInformation frame;
+
+  // This is the function name in the CXX ABI mangled format, e.g. something
+  // like _Z1gv. Reference:
+  // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
+  std::string mangled_function_name;
+
+#if defined(__GLIBCXX__)
+  // In GLIBCXX, `frame_string` follows the pattern
+  // `<object-file>(<mangled-function-name>+<offset-into-function>)
+  // [<return-address>]`
+
+  auto function_name_start = frame_string.find("(");
+  if (function_name_start == std::string::npos) {
+    return at::nullopt;
+  }
+  function_name_start += 1;
+
+  auto offset_start = frame_string.find('+', function_name_start);
+  if (offset_start == std::string::npos) {
+    return at::nullopt;
+  }
+  offset_start += 1;
+
+  const auto offset_end = frame_string.find(')', offset_start);
+  if (offset_end == std::string::npos) {
+    return at::nullopt;
+  }
+
+  frame.object_file = frame_string.substr(0, function_name_start - 1);
+  frame.offset_into_function =
+      frame_string.substr(offset_start, offset_end - offset_start);
+
+  // NOTE: We don't need to parse the return address because
+  // we already have it from the call to `backtrace()`.
+
+  mangled_function_name = frame_string.substr(
+      function_name_start, (offset_start - 1) - function_name_start);
+#elif defined(_LIBCPP_VERSION)
+  // In LIBCXX, The pattern is
+  // `<frame number> <object-file> <return-address> <mangled-function-name> +
+  // <offset-into-function>`
+  std::string skip;
+  std::istringstream input_stream(frame_string);
+  // operator>>() does not fail -- if the input stream is corrupted, the
+  // strings will simply be empty.
+  input_stream >> skip >> frame.object_file >> skip >> mangled_function_name >>
+               skip >> frame.offset_into_function;
+#else
+  #warning Unknown standard library, backtraces may have incomplete debug information
+  return at::nullopt;
+#endif // defined(__GLIBCXX__)
+
+  // Some system-level functions don't have sufficient debug information, so
+  // we'll display them as "<unknown function>". They'll still have a return
+  // address and other pieces of information.
+  if (mangled_function_name.empty()) {
+    frame.function_name = "<unknown function>";
+    return frame;
+  }
+
+  frame.function_name = demangle(mangled_function_name.c_str());
+  return frame;
+}
+
+
+#endif // !defined(_WIN32)
+
+}
+
+std::string get_backtrace(size_t frames_to_skip, size_t maximum_number_of_frames) {
+
+#if !defined(_WIN32)
+
+  // We always skip this frame (backtrace).
+  frames_to_skip += 1;
+
+  std::vector<void*> callstack(
+      frames_to_skip + maximum_number_of_frames, nullptr);
+  // backtrace() gives us a list of return addresses in the current call stack.
+  // NOTE: As per man (3) backtrace it can never fail
+  // (http://man7.org/linux/man-pages/man3/backtrace.3.html).
+  auto number_of_frames = ::backtrace(callstack.data(), static_cast<int>(callstack.size()));
+
+  // Skip as many frames as requested. This is not efficient, but the sizes here
+  // are small and it makes the code nicer and safer.
+  for (; frames_to_skip > 0 && number_of_frames > 0;
+         --frames_to_skip, --number_of_frames) {
+    callstack.erase(callstack.begin());
+  }
+
+  // `number_of_frames` is strictly less than the current capacity of
+  // `callstack`, so this is just a pointer subtraction and makes the subsequent
+  // code safer.
+  callstack.resize(static_cast<size_t>(number_of_frames));
+
+  // `backtrace_symbols` takes the return addresses obtained from `backtrace()`
+  // and fetches string representations of each stack. Unfortunately it doesn't
+  // return a struct of individual pieces of information but a concatenated
+  // string, so we'll have to parse the string after. NOTE: The array returned
+  // by `backtrace_symbols` is malloc'd and must be manually freed, but not the
+  // strings inside the array.
+  std::unique_ptr<char*, std::function<void(char**)>> raw_symbols(
+      ::backtrace_symbols(callstack.data(), static_cast<int>(callstack.size())),
+      /*deleter=*/free);
+  const std::vector<std::string> symbols(
+      raw_symbols.get(), raw_symbols.get() + callstack.size());
+
+  // The backtrace string goes into here.
+  std::ostringstream stream;
+
+  for (size_t frame_number = 0; frame_number < callstack.size();
+       ++frame_number) {
+    const auto frame = detail::parse_frame_information(symbols[frame_number]);
+
+    // frame #<number>:
+    stream << "frame #" << frame_number << ": ";
+
+    if (!frame.has_value()) {
+      // In the edge-case where we couldn't parse the frame string, we can just
+      // use it directly (it may have a different format).
+      stream << symbols[frame_number] << "\n";
+    } else {
+      // <function_name> + <offset> (<return-address> in <object-file>)
+      stream << frame->function_name << " + " << frame->offset_into_function
+             << " (" << callstack[frame_number] << " in " << frame->object_file
+             << ")\n";
+    }
+  }
+
+  return stream.str();
+
+#else
+
+  return "(no backtrace available)";
+#endif
+}
+
+} // namespace at

--- a/aten/src/ATen/Error.cpp
+++ b/aten/src/ATen/Error.cpp
@@ -131,7 +131,7 @@ at::optional<FrameInformation> parse_frame_information(
 
 #endif // !defined(_WIN32)
 
-std::string get_backtrace(size_t frames_to_skip, size_t maximum_number_of_frames) {
+std::string get_backtrace(size_t frames_to_skip = 0, size_t maximum_number_of_frames = 64) {
 
 #if !defined(_WIN32)
 
@@ -204,9 +204,9 @@ std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
   return out;
 }
 
-Error::Error()
+Error::Error(SourceLocation source_location, std::string err)
   : what_without_backtrace_(err)
-  , what_(str("\n", err, " (", source_location, ")\n", get_backtrace(/*frames_to_skip=*/2)))
+  , what_(str(err, " (", source_location, ")\n", get_backtrace(/*frames_to_skip=*/2)))
   {}
 
 } // namespace at

--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -25,262 +25,118 @@
 #define __func__ __FUNCTION__
 #endif
 
+// This is a mash-up of ATen/Error.h and caffe2/core/logging.h
+
 namespace at {
+
 namespace detail {
 
-// TODO: This backtrace retrieval can be implemented on Windows via the Windows
-// API using `CaptureStackBackTrace` and `SymFromAddr`.
-// https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
-// https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows
-// https://msdn.microsoft.com/en-us/library/windows/desktop/bb204633%28v=vs.85%29.aspx.
-#if !defined(_WIN32)
-struct FrameInformation {
-  /// If available, the demangled name of the function at this frame, else
-  /// whatever (possibly mangled) name we got from `backtrace()`.
-  std::string function_name;
-  /// This is a number in hexadecimal form (e.g. "0xdead") representing the
-  /// offset into the function's machine code at which the function's body
-  /// starts, i.e. skipping the "prologue" that handles stack manipulation and
-  /// other calling convention things.
-  std::string offset_into_function;
-  /// NOTE: In debugger parlance, the "object file" refers to the ELF file that
-  /// the symbol originates from, i.e. either an executable or a library.
-  std::string object_file;
-};
+// Utility to demangle a function name
+std::string demangle(const char* name);
 
-inline at::optional<FrameInformation> parse_frame_information(
-    const std::string& frame_string) {
-  FrameInformation frame;
-
-  // This is the function name in the CXX ABI mangled format, e.g. something
-  // like _Z1gv. Reference:
-  // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
-  std::string mangled_function_name;
-
-#if defined(__GLIBCXX__)
-  // In GLIBCXX, `frame_string` follows the pattern
-  // `<object-file>(<mangled-function-name>+<offset-into-function>)
-  // [<return-address>]`
-
-  auto function_name_start = frame_string.find("(");
-  if (function_name_start == std::string::npos) {
-    return at::nullopt;
-  }
-  function_name_start += 1;
-
-  auto offset_start = frame_string.find('+', function_name_start);
-  if (offset_start == std::string::npos) {
-    return at::nullopt;
-  }
-  offset_start += 1;
-
-  const auto offset_end = frame_string.find(')', offset_start);
-  if (offset_end == std::string::npos) {
-    return at::nullopt;
-  }
-
-  frame.object_file = frame_string.substr(0, function_name_start - 1);
-  frame.offset_into_function =
-      frame_string.substr(offset_start, offset_end - offset_start);
-
-  // NOTE: We don't need to parse the return address because
-  // we already have it from the call to `backtrace()`.
-
-  mangled_function_name = frame_string.substr(
-      function_name_start, (offset_start - 1) - function_name_start);
-#elif defined(_LIBCPP_VERSION)
-  // In LIBCXX, The pattern is
-  // `<frame number> <object-file> <return-address> <mangled-function-name> +
-  // <offset-into-function>`
-  std::string skip;
-  std::istringstream input_stream(frame_string);
-  // operator>>() does not fail -- if the input stream is corrupted, the
-  // strings will simply be empty.
-  input_stream >> skip >> frame.object_file >> skip >> mangled_function_name >>
-      skip >> frame.offset_into_function;
-#else
-#warning Unknown standard library, backtraces may have incomplete debug information
-  return at::nullopt;
-#endif // defined(__GLIBCXX__)
-
-  // Some system-level functions don't have sufficient debug information, so
-  // we'll display them as "<unknown function>". They'll still have a return
-  // address and other pieces of information.
-  if (mangled_function_name.empty()) {
-    frame.function_name = "<unknown function>";
-    return frame;
-  }
-
-  int status = -1;
-  // This function will demangle the mangled function name into a more human
-  // readable format, e.g. _Z1gv -> g().
-  // More information:
-  // https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/libsupc%2B%2B/cxxabi.h
-  // NOTE: `__cxa_demangle` returns a malloc'd string that we have to free
-  // ourselves.
-  std::unique_ptr<char, std::function<void(char*)>> demangled_function_name(
-      abi::__cxa_demangle(
-          mangled_function_name.c_str(),
-          /*__output_buffer=*/nullptr,
-          /*__length=*/0,
-          &status),
-      /*deleter=*/free);
-
-  // Demangling may fail, for example when the name does not follow the
-  // standard C++ (Itanium ABI) mangling scheme. This is the case for `main`
-  // or `clone` for example, so the mangled name is a fine default.
-  if (status == 0) {
-    frame.function_name = demangled_function_name.get();
-  } else {
-    frame.function_name = mangled_function_name;
-  }
-
-  return frame;
+/**
+ * Returns the printable name of the type.
+ *
+ * Works for all types, not only the ones registered with CAFFE_KNOWN_TYPE
+ */
+template <typename T>
+static const char* demangle_type() {
+#ifdef __GXX_RTTI
+  static const std::string name = demangle(typeid(T).name());
+  return name.c_str();
+#else // __GXX_RTTI
+  return "(RTTI disabled, cannot show name)";
+#endif // __GXX_RTTI
 }
 
-inline std::string get_backtrace(
-    size_t frames_to_skip = 0,
-    size_t maximum_number_of_frames = 64) {
-  // We always skip this frame (backtrace).
-  frames_to_skip += 1;
+inline void _str(std::stringstream& /*ss*/) {}
 
-  std::vector<void*> callstack(
-      frames_to_skip + maximum_number_of_frames, nullptr);
-  // backtrace() gives us a list of return addresses in the current call stack.
-  // NOTE: As per man (3) backtrace it can never fail
-  // (http://man7.org/linux/man-pages/man3/backtrace.3.html).
-  auto number_of_frames = ::backtrace(callstack.data(), callstack.size());
-
-  // Skip as many frames as requested. This is not efficient, but the sizes here
-  // are small and it makes the code nicer and safer.
-  for (; frames_to_skip > 0 && number_of_frames > 0;
-       --frames_to_skip, --number_of_frames) {
-    callstack.erase(callstack.begin());
-  }
-
-  // `number_of_frames` is strictly less than the current capacity of
-  // `callstack`, so this is just a pointer subtraction and makes the subsequent
-  // code safer.
-  callstack.resize(number_of_frames);
-
-  // `backtrace_symbols` takes the return addresses obtained from `backtrace()`
-  // and fetches string representations of each stack. Unfortunately it doesn't
-  // return a struct of individual pieces of information but a concatenated
-  // string, so we'll have to parse the string after. NOTE: The array returned
-  // by `backtrace_symbols` is malloc'd and must be manually freed, but not the
-  // strings inside the array.
-  std::unique_ptr<char*, std::function<void(char**)>> raw_symbols(
-      ::backtrace_symbols(callstack.data(), callstack.size()),
-      /*deleter=*/free);
-  const std::vector<std::string> symbols(
-      raw_symbols.get(), raw_symbols.get() + callstack.size());
-
-  // The backtrace string goes into here.
-  std::ostringstream stream;
-
-  for (size_t frame_number = 0; frame_number < callstack.size();
-       ++frame_number) {
-    const auto frame = parse_frame_information(symbols[frame_number]);
-
-    // frame #<number>:
-    stream << "frame #" << frame_number << ": ";
-
-    if (!frame.has_value()) {
-      // In the edge-case where we couldn't parse the frame string, we can just
-      // use it directly (it may have a different format).
-      stream << symbols[frame_number] << "\n";
-    } else {
-      // <function_name> + <offset> (<return-address> in <object-file>)
-      stream << frame->function_name << " + " << frame->offset_into_function
-             << " (" << callstack[frame_number] << " in " << frame->object_file
-             << ")\n";
-    }
-  }
-
-  return stream.str();
+template <typename T>
+inline void _str(std::stringstream& ss, const T& t) {
+  ss << t;
 }
-#endif // !defined(_WIN32)
 
-/// A tiny implementation of static `all_of`.
-template <bool...>
-struct pack;
-template <bool... values>
-struct all_of : std::is_same<pack<values..., true>, pack<true, values...>> {};
+template <typename T, typename... Args>
+inline void
+_str(std::stringstream& ss, const T& t, const Args&... args) {
+  _str(ss, t);
+  _str(ss, args...);
+}
 
-/// A printf wrapper that returns an std::string.
-inline std::string format(const char* format_string, ...) {
-  static constexpr size_t kMaximumStringLength = 4096;
-  char buffer[kMaximumStringLength];
+} // namespace detail
 
-  va_list format_args;
-  va_start(format_args, format_string);
-  vsnprintf(buffer, sizeof(buffer), format_string, format_args);
-  va_end(format_args);
+// Convert a list of string-like arguments into a single string.
+template <typename... Args>
+inline std::string str(const Args&... args) {
+  std::stringstream ss;
+  detail::_str(ss, args...);
+  return ss.str();
+}
 
-  return buffer;
+// Specializations for already-a-string types.
+template <>
+inline std::string str(const std::string& str) {
+  return str;
+}
+inline std::string str(const char* c_str) {
+  return c_str;
 }
 
 /// Represents a location in source code (for debugging).
 struct SourceLocation {
-  std::string toString() const {
-    return format("%s at %s:%d", function, file, line);
-  }
-
   const char* function;
   const char* file;
   uint32_t line;
 };
-} // namespace detail
+
+inline std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
+  out << loc.function << " at " << loc.file << ":" << loc.line;
+  return out;
+}
+
+std::string get_backtrace(
+    size_t frames_to_skip = 0,
+    size_t maximum_number_of_frames = 64);
 
 /// The primary ATen error class.
 /// Provides a complete error message with source location information via
 /// `what()`, and a more concise message via `what_without_backtrace()`. Should
 /// primarily be used with the `AT_ERROR` macro.
-struct AT_API Error : public std::exception {
-  template <typename... FormatArgs>
-  Error(
-      detail::SourceLocation source_location,
-      const char* format_string,
-      FormatArgs&&... format_args)
-      : what_without_backtrace_(detail::format(
-            format_string,
-            std::forward<FormatArgs>(format_args)...)),
-        what_(what_without_backtrace_) {
-    // NOTE: A "literal type"
-    // (http://en.cppreference.com/w/cpp/concept/LiteralType) could also be a
-    // constexpr struct, so it's not 100% guaranteed that the `printf` call
-    // inside `format` is safe, but it will catch 99.9% of all errors we'll run
-    // into, such as passing `std::string`.
-    static_assert(
-        detail::all_of<std::is_literal_type<FormatArgs>::value...>::value,
-        "format arguments must be literal types!");
-    what_ += " (" + source_location.toString() + ")\n";
-#if !defined(_WIN32)
-    // Skip this constructor's frame.
-    what_ += detail::get_backtrace(/*frames_to_skip=*/1);
-#endif // !defined(_WIN32)
-  }
+class AT_API Error : public std::exception {
+  std::string what_without_backtrace_;
+  std::string what_;
+
+public:
+  Error(SourceLocation source_location, std::string err)
+    : what_without_backtrace_(err)
+    , what_(str("\n", err, " (", source_location, ")\n", get_backtrace(/*frames_to_skip=*/2)))
+  {}
 
   /// Returns the complete error message, including the source location.
-  const char* what() const noexcept override {
+  inline const char* what() const noexcept override {
     return what_.c_str();
   }
 
   /// Returns only the error message string, without source location.
-  const char* what_without_backtrace() const noexcept {
+  inline const char* what_without_backtrace() const noexcept {
     return what_without_backtrace_.c_str();
   }
-
- private:
-  std::string what_without_backtrace_;
-  std::string what_;
 };
+
 } // namespace at
 
+// TODO: variants that print the expression tested and thus don't require strings
+// TODO: CAFFE_ENFORCE_WITH_CALLER style macro
+
 #define AT_ERROR(...) \
-  throw at::Error({__func__, __FILE__, __LINE__}, __VA_ARGS__)
+  throw at::Error({__func__, __FILE__, __LINE__}, at::str(__VA_ARGS__))
 
 #define AT_ASSERT(cond, ...) \
   if (!(cond)) {             \
-    AT_ERROR(__VA_ARGS__);   \
+    AT_ERROR(at::str(#cond, " ", __VA_ARGS__));   \
+  }
+
+#define AT_CHECK(cond, ...) \
+  if (!(cond)) {             \
+    AT_ERROR(at::str(__VA_ARGS__));   \
   }

--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -117,7 +117,7 @@ public:
 
 #define AT_ASSERT(cond, ...) \
   if (!(cond)) {             \
-    AT_ERROR(at::str(#cond, " ASSERT FAILED. ", __VA_ARGS__));   \
+    AT_ERROR(at::str(#cond, " ASSERT FAILED, please report a bug to PyTorch. ", __VA_ARGS__));   \
   }
 
 #define AT_CHECK(cond, ...) \

--- a/aten/src/ATen/Error.h
+++ b/aten/src/ATen/Error.h
@@ -115,7 +115,12 @@ public:
 #define AT_ERROR(...) \
   throw at::Error({__func__, __FILE__, __LINE__}, at::str(__VA_ARGS__))
 
-#define AT_ASSERT(cond, ...) \
+#define AT_ASSERT(cond) \
+  if (!(cond)) {             \
+    AT_ERROR(#cond " ASSERT FAILED, please report a bug to PyTorch.");   \
+  }
+
+#define AT_ASSERTM(cond, ...) \
   if (!(cond)) {             \
     AT_ERROR(at::str(#cond, " ASSERT FAILED, please report a bug to PyTorch. ", __VA_ARGS__));   \
   }

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -16,7 +16,7 @@ std::tuple<std::vector<int64_t>, std::vector<int64_t> > inferExpandGeometry(cons
 inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
   for (auto& t : tensors) {
     if (!t.get().defined()) {
-      AT_ERROR("%s(...) called with an undefined Tensor", api_name);
+      AT_ERROR(api_name, "(...) called with an undefined Tensor");
     }
   }
 }

--- a/aten/src/ATen/MatrixRef.h
+++ b/aten/src/ATen/MatrixRef.h
@@ -40,7 +40,7 @@ namespace at {
     /// Construct an MatrixRef from an ArrayRef and outer stride.
     /*implicit*/ MatrixRef(ArrayRef<T> arr, size_type stride0)
       : arr(arr), stride0(stride0) {
-        AT_ASSERT(arr.size() % stride0 == 0, "MatrixRef: ArrayRef size %d not divisible by stride %d", arr.size(), stride0)
+        AT_ASSERT(arr.size() % stride0 == 0, "MatrixRef: ArrayRef size ", arr.size(), " not divisible by stride ", stride0)
       }
 
     /// @}
@@ -59,7 +59,7 @@ namespace at {
       } else if (dim == 1) {
         return stride0;
       } else {
-        AT_ASSERT(0, "MatrixRef: out of bounds dimension %d; expected 0 or 1", dim);
+        AT_ASSERT(0, "MatrixRef: out of bounds dimension ", dim, "; expected 0 or 1");
       }
     }
 

--- a/aten/src/ATen/MatrixRef.h
+++ b/aten/src/ATen/MatrixRef.h
@@ -40,7 +40,7 @@ namespace at {
     /// Construct an MatrixRef from an ArrayRef and outer stride.
     /*implicit*/ MatrixRef(ArrayRef<T> arr, size_type stride0)
       : arr(arr), stride0(stride0) {
-        AT_ASSERT(arr.size() % stride0 == 0, "MatrixRef: ArrayRef size ", arr.size(), " not divisible by stride ", stride0)
+        AT_CHECK(arr.size() % stride0 == 0, "MatrixRef: ArrayRef size ", arr.size(), " not divisible by stride ", stride0)
       }
 
     /// @}
@@ -59,7 +59,7 @@ namespace at {
       } else if (dim == 1) {
         return stride0;
       } else {
-        AT_ASSERT(0, "MatrixRef: out of bounds dimension ", dim, "; expected 0 or 1");
+        AT_CHECK(0, "MatrixRef: out of bounds dimension ", dim, "; expected 0 or 1");
       }
     }
 

--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -23,8 +23,8 @@ public:
 
   explicit Scalar(const detail::TensorBase & t)
   : tag(Tag::HAS_t), t(t) {
-    AT_ASSERT(t.defined(), "Attempting to create a Scalar from an undefined tensor");
-    AT_ASSERT(t.dim() == 0, "Attempting to create a Scalar from a ", t.dim(), " dim tensor");
+    AT_CHECK(t.defined(), "Attempting to create a Scalar from an undefined tensor");
+    AT_CHECK(t.dim() == 0, "Attempting to create a Scalar from a ", t.dim(), " dim tensor");
   }
 
 #define DEFINE_IMPLICIT_CTOR(type,name,member) \

--- a/aten/src/ATen/Scalar.h
+++ b/aten/src/ATen/Scalar.h
@@ -24,7 +24,7 @@ public:
   explicit Scalar(const detail::TensorBase & t)
   : tag(Tag::HAS_t), t(t) {
     AT_ASSERT(t.defined(), "Attempting to create a Scalar from an undefined tensor");
-    AT_ASSERT(t.dim() == 0, "Attempting to create a Scalar from a %d dim tensor", t.dim());
+    AT_ASSERT(t.dim() == 0, "Attempting to create a Scalar from a ", t.dim(), " dim tensor");
   }
 
 #define DEFINE_IMPLICIT_CTOR(type,name,member) \

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -53,8 +53,8 @@ struct AT_API TensorGeometry {
 
   TensorGeometry transpose(int64_t dim0, int64_t dim1) {
     TensorGeometry r = *this; // copy
-    AT_ASSERT(dim0 < dim(), "transpose: dim0=%d out of range (dim=%d)", dim0, dim())
-    AT_ASSERT(dim1 < dim(), "transpose: dim1=%d out of range (dim=%d)", dim1, dim())
+    AT_ASSERT(dim0 < dim(), "transpose: dim0=", dim0, " out of range (dim=", dim(), ")")
+    AT_ASSERT(dim1 < dim(), "transpose: dim1=", dim1, " out of range (dim=", dim(), ")")
     std::swap(r.sizes_[dim0], r.sizes_[dim1]);
     std::swap(r.strides_[dim0], r.strides_[dim1]);
     return r;

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -53,8 +53,8 @@ struct AT_API TensorGeometry {
 
   TensorGeometry transpose(int64_t dim0, int64_t dim1) {
     TensorGeometry r = *this; // copy
-    AT_ASSERT(dim0 < dim(), "transpose: dim0=", dim0, " out of range (dim=", dim(), ")")
-    AT_ASSERT(dim1 < dim(), "transpose: dim1=", dim1, " out of range (dim=", dim(), ")")
+    AT_CHECK(dim0 < dim(), "transpose: dim0=", dim0, " out of range (dim=", dim(), ")")
+    AT_CHECK(dim1 < dim(), "transpose: dim1=", dim1, " out of range (dim=", dim(), ")")
     std::swap(r.sizes_[dim0], r.sizes_[dim1]);
     std::swap(r.strides_[dim0], r.strides_[dim1]);
     return r;

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -41,10 +41,10 @@ inline Tensor& Tensor::operator/=(Scalar other) {
   return div_(other);
 }
 inline Tensor Tensor::operator[](Scalar index) const {
-  AT_ASSERT(
+  AT_CHECK(
       index.local().isIntegral(),
-      "Can only index tensors with integral scalars (got %s)",
-      index.toTensor().type().toString());
+      "Can only index tensors with integral scalars (got ",
+      index.toTensor().type().toString(), ")");
   return select(0, index.toLong());
 }
 inline Tensor Tensor::operator[](Tensor index) const {

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -50,8 +50,8 @@ inline Tensor Tensor::operator[](Scalar index) const {
 inline Tensor Tensor::operator[](Tensor index) const {
   // These properties are checked in the Scalar constructor, but we already
   // check them here to provide more useful diagnostics for the user.
-  AT_ASSERT(index.defined(), "Can only index with tensors that are defined");
-  AT_ASSERT(
+  AT_CHECK(index.defined(), "Can only index with tensors that are defined");
+  AT_CHECK(
       index.dim() == 0,
       "Can only index with tensors that are scalars (zero-dim)");
   // The Scalar(Tensor) constructor is explicit, so we need to call it.

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -15,8 +15,8 @@ namespace at {
 template <typename T, typename Base>
 static inline T* checked_cast_storage(Base* expr, const char * name, int pos) {
   if (typeid(*expr) != typeid(T))
-    AT_ERROR("Expected object of type %s but found type %s for argument #%d '%s'",
-      T::typeString(),expr->type().toString(),pos,name);
+    AT_ERROR("Expected object of type ", T::typeString(), " but found type ", expr->type().toString(),
+             " for argument #", pos, " '", name, "'");
   return static_cast<T*>(expr);
 }
 
@@ -26,8 +26,8 @@ inline T* checked_cast_tensor(Base* expr, const char * name, int pos, bool allow
     return nullptr;
   }
   if (typeid(*expr) != typeid(T))
-    AT_ERROR("Expected object of type %s but found type %s for argument #%d '%s'",
-      T::typeString(),expr->type().toString(),pos,name);
+    AT_ERROR("Expected object of type ", T::typeString(), " but found type ", expr->type().toString(),
+             " for argument #", pos, " '", name, "'");
   return static_cast<T*>(expr);
 }
 
@@ -41,9 +41,8 @@ static inline std::vector<TH*> tensor_list_checked_cast(ArrayRef<TBase> tensors,
     if (result) {
       casted[i] = result->tensor;
     } else {
-      AT_ERROR("Expected a Tensor of type %s but found a type %s for sequence element %u "
-                    " in sequence argument at position #%d '%s'",
-                    T::typeString(),expr->type().toString(),i,pos,name);
+      AT_ERROR("Expected a Tensor of type ", T::typeString(), " but found a type ", expr->type().toString(),
+               " for sequence element ", i, " in sequence argument at position #", pos, " '", name, "'");
 
     }
   }
@@ -61,8 +60,7 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
     return res;
   }
   if (list.size() != N) {
-    AT_ERROR("Expected a list of %zd ints but got %zd for argument #%d '%s'",
-        N, list.size(), pos, name);
+    AT_ERROR("Expected a list of ", N, " ints but got ", list.size(), " for argument #", pos, " '", name, "'");
   }
   std::copy_n(list.begin(), N, res.begin());
   return res;

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -13,11 +13,11 @@ namespace at {
 constexpr size_t dim_bitset_size = 64;
 
 static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntList dims, int64_t ndims, bool wrap_scalar=true) {
-  AT_ASSERT(ndims <= (int64_t) dim_bitset_size, "only tensors with up to %zu dims are supported", dim_bitset_size);
+  AT_ASSERT(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
   std::bitset<dim_bitset_size> seen;
   for (size_t i = 0; i < dims.size(); i++) {
     size_t dim = maybe_wrap_dim(dims[i], ndims);
-    AT_ASSERT(!seen[dim], "dim %zu appears multiple times in the list of reduced dims", dim);
+    AT_ASSERT(!seen[dim], "dim ", dim, " appears multiple times in the list of reduced dims");
     seen[dim] = true;
   }
   return seen;

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -13,11 +13,11 @@ namespace at {
 constexpr size_t dim_bitset_size = 64;
 
 static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntList dims, int64_t ndims, bool wrap_scalar=true) {
-  AT_ASSERT(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
+  AT_CHECK(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
   std::bitset<dim_bitset_size> seen;
   for (size_t i = 0; i < dims.size(); i++) {
     size_t dim = maybe_wrap_dim(dims[i], ndims);
-    AT_ASSERT(!seen[dim], "dim ", dim, " appears multiple times in the list of reduced dims");
+    AT_CHECK(!seen[dim], "dim ", dim, " appears multiple times in the list of reduced dims");
     seen[dim] = true;
   }
   return seen;

--- a/aten/src/ATen/copy_wrapper.py
+++ b/aten/src/ATen/copy_wrapper.py
@@ -51,7 +51,7 @@ Tensor & ${Type}::s_copy_(Tensor & self, const Tensor & src, bool non_blocking) 
   switch (src.type().ID()) {
     ${copy_body}
     default:
-      AT_ERROR("copy does not support %s to %s copy.", src.type().toString(), toString());
+      AT_ERROR("copy does not support ", src.type().toString(), " to ", toString(), " copy.");
       break;
   }
   self.pImpl->setScalar(src.pImpl->isScalar());

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -250,11 +250,11 @@ struct DropoutDescriptor
   // WARNING: This function is very expensive, avoid calling this function!
   // NB: it takes a Type so that we can generate a Variable if necessary
   void initialize_rng(const at::Type& ty, cudnnHandle_t handle, float dropout, long long int seed) {
-    AT_ASSERT(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
+    AT_ASSERTM(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
     size_t state_size;
     CUDNN_CHECK(cudnnDropoutGetStatesSize(handle, &state_size));
-    AT_ASSERT(ty.is_cuda(), "dropout state type must be CUDA type");
-    AT_ASSERT(ty.scalarType() == kByte, "dropout state type must be byte");
+    AT_ASSERT(ty.is_cuda());
+    AT_ASSERT(ty.scalarType() == kByte);
     state = ty.tensor({static_cast<int64_t>(state_size)});
     CUDNN_CHECK(cudnnSetDropoutDescriptor(mut_desc(), handle, dropout, state.data_ptr(), state_size, seed));
   }
@@ -262,7 +262,7 @@ struct DropoutDescriptor
   // Restore a dropout descriptor given a dropout probability and existing RNG state.
   // See Note [cuDNN dropout descriptor initialization]
   void set(cudnnHandle_t handle, float dropout, at::Tensor state_) {
-    AT_ASSERT(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
+    AT_ASSERTM(dropout > 0, "dropout must be nonzero; otherwise call set_no_dropout");
     state = state_;
     void *state_ptr = state.data_ptr();
     size_t state_size = state.size(0);

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -63,7 +63,7 @@ virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals
 """)
 TYPE_METHOD_DEFINITION_ABSTRACT = CodeTemplate("""\
 ${return_type} Type::${method_prefix_derived}${api_name}(${type_method_formals}) const {
-    AT_ERROR("${method_prefix_derived}${api_name} is not implemented for type %s", toString());
+    AT_ERROR("${method_prefix_derived}${api_name} is not implemented for type ", toString());
 }
 """)
 TYPE_METHOD_DECLARATION_CONCRETE = CodeTemplate("""\

--- a/aten/src/ATen/native/ConvolutionTBC.cpp
+++ b/aten/src/ATen/native/ConvolutionTBC.cpp
@@ -6,11 +6,11 @@ namespace at {
 namespace native {
 
 Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, int64_t pad) {
-  AT_ASSERT(self.dim() == 3, "Input must have 3 dims: time, batch, "
+  AT_CHECK(self.dim() == 3, "Input must have 3 dims: time, batch, "
       "in_channel");
-  AT_ASSERT(weight.dim() == 3, "Weight tensor must have 3 dims: kernel_width,"
+  AT_CHECK(weight.dim() == 3, "Weight tensor must have 3 dims: kernel_width,"
       " in_channels, out_channels.");
-  AT_ASSERT(bias.dim() == 1, "Bias must be 1-D");
+  AT_CHECK(bias.dim() == 1, "Bias must be 1-D");
 
   auto input_size = self.sizes();
   auto weight_size = weight.sizes();
@@ -27,9 +27,9 @@ Tensor conv_tbc(const Tensor& self, const Tensor& weight, const Tensor& bias, in
   // Input = (time, batch, in_channels)
   // Weight = (kernel_width, in_channels, out_channels)
   // Bias = (out_channels)
-  AT_ASSERT(inputPlanes == weight_size[1], "Input dim 2 (input channels) "
+  AT_CHECK(inputPlanes == weight_size[1], "Input dim 2 (input channels) "
       "is not == dim 1 in the weight tensor");
-  AT_ASSERT(weight_size[2] == bias.sizes()[0], "Bias size must equal dim 2 in "
+  AT_CHECK(weight_size[2] == bias.sizes()[0], "Bias size must equal dim 2 in "
       "the weight tensor (output channels).");
 
   // input * weights + bias -> output_features

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -229,8 +229,7 @@ static std::tuple<Tensor, Tensor> makeLinearIndex(Tensor self, TensorList orig) 
 
 Tensor index(const Tensor & self, TensorList indices) {
   if (indices.size() > (size_t)self.dim()) {
-   AT_ERROR("too many indices for tensor of dimension %d (got %d)",
-      (int)self.dim(), (int)indices.size());
+   AT_ERROR("too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
   }
 
   Tensor src, linearIndex;
@@ -240,8 +239,7 @@ Tensor index(const Tensor & self, TensorList indices) {
 
 Tensor & index_put_(Tensor & self, TensorList indices, const Tensor & value) {
   if (indices.size() > (size_t)self.dim()) {
-   AT_ERROR("too many indices for tensor of dimension %d (got %d)",
-      (int)self.dim(), (int)indices.size());
+   AT_ERROR("too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
   }
 
   Tensor src, linearIndex, expandedValue;
@@ -255,19 +253,16 @@ Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Ten
 
   if (index.dim() >= 2) {
    AT_ERROR(
-        "index_copy_(): Index should have dimension 1 or 0 (got %d)",
-        (int)index.dim());
+        "index_copy_(): Index should have dimension 1 or 0 (got ", index.dim(), ")");
   }
   int64_t numIndices = index.numel();
   if (source.dim() == 0 && numIndices != 1) {
    AT_ERROR(
-        "index_copy_(): When source is scalar, index should have one element (got %d)",
-        (int)numIndices);
+        "index_copy_(): When source is scalar, index should have one element (got ", numIndices, ")");
   }
   if (source.dim() > 0 && numIndices != source.size(dim)) {
    AT_ERROR(
-        "index_copy_(): Number of indices (%d) should be equal to source.size(dim) (%d)",
-        (int)numIndices, (int)source.size(dim));
+        "index_copy_(): Number of indices (", numIndices, ") should be equal to source.size(dim) (", source.size(dim), ")");
   }
   if (index.type().scalarType() != ScalarType::Long) {
    AT_ERROR("index_copy_(): Expected LongTensor for index");

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -12,7 +12,7 @@ namespace at { namespace native {
 static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntList sum_dims_, bool keepdim) {
   // assumes that tensors have been pre-unsqueezed (so that all dimensions match - after broadcasting)
   // but makes no other assumptions on the order of dimensions
-  AT_ASSERT(left_.dim()==right_.dim(), "number of dimensions must match");
+  AT_CHECK(left_.dim()==right_.dim(), "number of dimensions must match");
   if (sum_dims_.size() == 0)
     return at::mul(left_, right_);
   int64_t dim = left_.dim();
@@ -29,7 +29,7 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntList
     auto sr = right.size(i)>1;
     if (sum_dims[i]) { // first dimensions that will be summed over after multiplication
       if (sl && sr) {  // dimensions nontrivially in both left and right must be of the same size
-	AT_ASSERT(left.size(i)==right.size(i), "non-broadcast dimensions must match");
+	AT_CHECK(left.size(i)==right.size(i), "non-broadcast dimensions must match");
 	sum_size *= left.size(i);
       } else if (sl) { // if it is only in one of left and right, we can sum right away
 	left = left.sum(i, true);
@@ -38,7 +38,7 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntList
       }
     } else if (sl && sr) { // now deal with dimensions  dimensions that will be in the output
       // dimensions nontrivially in both left and right must be of the same size
-      AT_ASSERT(left.size(i)==right.size(i), "non-broadcast dimensions must match");
+      AT_CHECK(left.size(i)==right.size(i), "non-broadcast dimensions must match");
       lro.push_back(i);
       lro_size *= left.size(i);
     } else if (sl) { // keep track of dimensions appearing only once
@@ -129,7 +129,7 @@ Tensor einsum(std::string eqn, TensorList tensors) {
     std::getline(eqn_stream, term, ',');  // term = string with indices of current term
     int64_t dims_in_operand = 0;
     for (auto &c : term) {                // c    = character with a single index
-      AT_ASSERT(('a' <= c) && (c <= 'z'), "only lowercase letters a-z allowed as indices");
+      AT_CHECK(('a' <= c) && (c <= 'z'), "only lowercase letters a-z allowed as indices");
       int64_t index_num = c-'a';          // index_num  = index to be used in the vectors above
       number_of_occurrences[index_num]++;
       // when there are two occurrences we need to take a diagonal with respect to the dimensions
@@ -137,16 +137,16 @@ Tensor einsum(std::string eqn, TensorList tensors) {
       // e.g. einsum('ii->i', [A]) should return the diagonal
       // This waits for the general diagonal handling discussed in #6479
       // for now, we error out here
-      AT_ASSERT(last_occurrence[index_num] < operand, "diagonals (multiple occurrences of the same index for one tensor) not implemented yet")
+      AT_CHECK(last_occurrence[index_num] < operand, "diagonals (multiple occurrences of the same index for one tensor) not implemented yet")
       last_occurrence[index_num] = operand;
       dims_in_operand++;
     }
-    AT_ASSERT((int64_t) tensors.size()>operand, "more operands in equation than tensors"); // we cannot have a longer equation than operands. We need to check here before we check the dimensions
-    AT_ASSERT(dims_in_operand == tensors[operand].dim(),
+    AT_CHECK((int64_t) tensors.size()>operand, "more operands in equation than tensors"); // we cannot have a longer equation than operands. We need to check here before we check the dimensions
+    AT_CHECK(dims_in_operand == tensors[operand].dim(),
               "dimension mismatch for operand ", operand, ": equation ", dims_in_operand, ", tensor ", tensors[operand].dim());
     operand++;
   }
-  AT_ASSERT((int64_t) tensors.size()==operand, "more tensors than operands in equation");  // we need ==, but > is captured above, so the error message can be specific that it is <.
+  AT_CHECK((int64_t) tensors.size()==operand, "more tensors than operands in equation");  // we need ==, but > is captured above, so the error message can be specific that it is <.
 
   // the following parses or infers output (right hand side)
   // it also assigns the sorted_positions ((letter) index -> dimension in Tensors) and position_labels (dimensions in Tensors -> index)
@@ -157,9 +157,9 @@ Tensor einsum(std::string eqn, TensorList tensors) {
   std::vector<int64_t> position_labels;
   if (pos != std::string::npos) {            // parse the user provided right hand side
     for (auto &c : eqn.substr(pos+2)) {
-      AT_ASSERT(('a' <= c) && (c <= 'z'), "only lowercase letters a-z allowed as indices");
+      AT_CHECK(('a' <= c) && (c <= 'z'), "only lowercase letters a-z allowed as indices");
       int64_t index_num = c-'a';
-      AT_ASSERT(sorted_position[index_num] == -1, "index ", c, " occurs twice in output");
+      AT_CHECK(sorted_position[index_num] == -1, "index ", c, " occurs twice in output");
       sorted_position[index_num] = num_output_dims;
       position_labels.push_back(index_num);
       num_output_dims++;
@@ -251,7 +251,7 @@ Tensor _trilinear(const Tensor& i1_, const Tensor& i2_, const Tensor& i3_,
 		  IntList expand1_, IntList expand2_, IntList expand3_,
 		  IntList sumdim_, int64_t unroll_dim) {
   int64_t total_dim = i1_.dim()+expand1_.size();
-  AT_ASSERT((unroll_dim >= 0) && (unroll_dim < total_dim), "unroll_dim must be in [0,", total_dim-1, "]");
+  AT_CHECK((unroll_dim >= 0) && (unroll_dim < total_dim), "unroll_dim must be in [0,", total_dim-1, "]");
   auto expand1 = dim_list_to_bitset(expand1_, total_dim);
   auto expand2 = dim_list_to_bitset(expand2_, total_dim);
   auto expand3 = dim_list_to_bitset(expand3_, total_dim);
@@ -317,18 +317,18 @@ Tensor _trilinear(const Tensor& i1_, const Tensor& i2_, const Tensor& i3_,
 }
 
 Tensor bilinear(const Tensor& input1, const Tensor& input2, const Tensor& weight, const Tensor& bias) {
-  AT_ASSERT(input1.dim() == input2.dim(), "bilinear(): input dimensions do not match: got ", input1.dim(), " and ", input2.dim());
+  AT_CHECK(input1.dim() == input2.dim(), "bilinear(): input dimensions do not match: got ", input1.dim(), " and ", input2.dim());
   for (int64_t i = 0; i < input1.dim() - 1; i++) {
-    AT_ASSERT(input1.size(i) == input2.size(i),
+    AT_CHECK(input1.size(i) == input2.size(i),
               "bilinear(): input batch dimensions do not match at dim ", i, ": got ", input1.size(i), " and ", input2.size(i));
   }
-  AT_ASSERT(input1.size(input1.dim() - 1) == weight.size(1),
+  AT_CHECK(input1.size(input1.dim() - 1) == weight.size(1),
             "bilinear(): input1 size does not match weight size: got ",
             input1.size(input1.dim() - 1), " but expected ", weight.size(1));
-  AT_ASSERT(input2.size(input2.dim() - 1) == weight.size(2),
+  AT_CHECK(input2.size(input2.dim() - 1) == weight.size(2),
             "bilinear(): input2 size does not match weight size: got ",
             input2.size(input2.dim() - 1), " but expected ", weight.size(2));
-  AT_ASSERT(!bias.defined() || bias.size(0) == weight.size(0),
+  AT_CHECK(!bias.defined() || bias.size(0) == weight.size(0),
             "bilinear(): bias size does not match weight size: got ",
             bias.size(0), " but expected ", weight.size(0));
 

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -142,7 +142,8 @@ Tensor einsum(std::string eqn, TensorList tensors) {
       dims_in_operand++;
     }
     AT_ASSERT((int64_t) tensors.size()>operand, "more operands in equation than tensors"); // we cannot have a longer equation than operands. We need to check here before we check the dimensions
-    AT_ASSERT(dims_in_operand == tensors[operand].dim(), "dimension mismatch for operand %zd: equation %zd, tensor %zd", operand, dims_in_operand, tensors[operand].dim());
+    AT_ASSERT(dims_in_operand == tensors[operand].dim(),
+              "dimension mismatch for operand ", operand, ": equation ", dims_in_operand, ", tensor ", tensors[operand].dim());
     operand++;
   }
   AT_ASSERT((int64_t) tensors.size()==operand, "more tensors than operands in equation");  // we need ==, but > is captured above, so the error message can be specific that it is <.
@@ -158,7 +159,7 @@ Tensor einsum(std::string eqn, TensorList tensors) {
     for (auto &c : eqn.substr(pos+2)) {
       AT_ASSERT(('a' <= c) && (c <= 'z'), "only lowercase letters a-z allowed as indices");
       int64_t index_num = c-'a';
-      AT_ASSERT(sorted_position[index_num] == -1, "index %c occurs twice in output", c);
+      AT_ASSERT(sorted_position[index_num] == -1, "index ", c, " occurs twice in output");
       sorted_position[index_num] = num_output_dims;
       position_labels.push_back(index_num);
       num_output_dims++;
@@ -250,7 +251,7 @@ Tensor _trilinear(const Tensor& i1_, const Tensor& i2_, const Tensor& i3_,
 		  IntList expand1_, IntList expand2_, IntList expand3_,
 		  IntList sumdim_, int64_t unroll_dim) {
   int64_t total_dim = i1_.dim()+expand1_.size();
-  AT_ASSERT((unroll_dim >= 0) && (unroll_dim < total_dim), "unroll_dim must be in [0,%zd]", total_dim-1);
+  AT_ASSERT((unroll_dim >= 0) && (unroll_dim < total_dim), "unroll_dim must be in [0,", total_dim-1, "]");
   auto expand1 = dim_list_to_bitset(expand1_, total_dim);
   auto expand2 = dim_list_to_bitset(expand2_, total_dim);
   auto expand3 = dim_list_to_bitset(expand3_, total_dim);
@@ -316,22 +317,20 @@ Tensor _trilinear(const Tensor& i1_, const Tensor& i2_, const Tensor& i3_,
 }
 
 Tensor bilinear(const Tensor& input1, const Tensor& input2, const Tensor& weight, const Tensor& bias) {
-  AT_ASSERT(input1.dim() == input2.dim(), "bilinear(): input dimensions do not match: got %lld and %lld",
-            (long long)input1.dim(), (long long)input2.dim());
+  AT_ASSERT(input1.dim() == input2.dim(), "bilinear(): input dimensions do not match: got ", input1.dim(), " and ", input2.dim());
   for (int64_t i = 0; i < input1.dim() - 1; i++) {
     AT_ASSERT(input1.size(i) == input2.size(i),
-              "bilinear(): input batch dimensions do not match at dim %lld: got %lld and %lld",
-              (long long)i, (long long)input1.size(i), (long long)input2.size(i));
+              "bilinear(): input batch dimensions do not match at dim ", i, ": got ", input1.size(i), " and ", input2.size(i));
   }
   AT_ASSERT(input1.size(input1.dim() - 1) == weight.size(1),
-            "bilinear(): input1 size does not match weight size: got %lld but expected %lld",
-            (long long)input1.size(input1.dim() - 1), (long long)weight.size(1));
+            "bilinear(): input1 size does not match weight size: got ",
+            input1.size(input1.dim() - 1), " but expected ", weight.size(1));
   AT_ASSERT(input2.size(input2.dim() - 1) == weight.size(2),
-            "bilinear(): input2 size does not match weight size: got %lld but expected %lld",
-            (long long)input2.size(input2.dim() - 1), (long long)weight.size(2));
+            "bilinear(): input2 size does not match weight size: got ",
+            input2.size(input2.dim() - 1), " but expected ", weight.size(2));
   AT_ASSERT(!bias.defined() || bias.size(0) == weight.size(0),
-            "bilinear(): bias size does not match weight size: got %lld but expected %lld",
-            (long long)bias.size(0), (long long)weight.size(0));
+            "bilinear(): bias size does not match weight size: got ",
+            bias.size(0), " but expected ", weight.size(0));
 
   std::vector<int64_t> output_size;
   auto size1 = input1.sizes();

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -98,7 +98,7 @@ std::tuple<Tensor, Tensor> slogdet(const Tensor& self) {
 
 static void check_1d(const Tensor& t, const char* arg, const char* fn) {
   if (t.dim() != 1) {
-   AT_ERROR("%s: Expected 1-D argument %s, but got %d-D", fn, arg, t.dim());
+   AT_ERROR(fn, ": Expected 1-D argument ", arg, ", but got ", t.dim(), "-D");
   }
 }
 
@@ -282,8 +282,8 @@ Tensor matmul(at::optional<Tensor> out_opt, const Tensor& tensor1, const Tensor&
     return has_out ? out.set_(output) : output;
   }
 
- AT_ERROR("both arguments to matmul need to be at least 1D, but they are %dD and %dD",
-                dim_tensor1, dim_tensor2);
+ AT_ERROR("both arguments to matmul need to be at least 1D, but they are ",
+          dim_tensor1, "D and ", dim_tensor2, "D");
 
 }
 

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -8,7 +8,7 @@ namespace native {
 
 Tensor pin_memory(const Tensor& self) {
   if (self.type().backend() != kCPU) {
-    AT_ERROR("cannot pin '%s' only CPU memory can be pinned", self.type().toString());
+    AT_ERROR("cannot pin '", self.type().toString(), "' only CPU memory can be pinned");
   }
   auto allocator = std::unique_ptr<Allocator>(new PinnedMemoryAllocator());
   auto tensor = self.type().tensorWithAllocator(self.sizes(), self.strides(), std::move(allocator));

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -35,7 +35,7 @@ Tensor cumsum(const Tensor& self, int64_t dim) {
 
 static inline Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
-  AT_ASSERT(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
+  AT_CHECK(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
             "provided dtype must match dtype of result in cumsum.  Got %s and %s.",
             at::toString(result.type().scalarType()), at::toString(dtype.value()));
   return at::_cumsum_out(result, self.toType(result.type().scalarType()), dim);
@@ -63,7 +63,7 @@ Tensor cumprod(const Tensor& self, int64_t dim) {
 
 static inline Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
-  AT_ASSERT(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
+  AT_CHECK(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
             "provided dtype must match dtype of result in cumprod.  Got %s and %s.",
             at::toString(result.type().scalarType()), at::toString(dtype.value()));
   return at::_cumprod_out(result, self.toType(result.type().scalarType()), dim);
@@ -158,7 +158,7 @@ static Tensor &_dimreduce_setup(Tensor &result, const Tensor &self,
 static inline Tensor &sum_out(Tensor &result, const Tensor &self, int64_t dim,
                  bool keepdim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
-  AT_ASSERT(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
+  AT_CHECK(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
             "provided dtype must match dtype of result in sum.  Got %s and %s.",
             at::toString(result.type().scalarType()), at::toString(dtype.value()));
   return at::_sum_out(result, self.toType(result.type().scalarType()), dim, keepdim);
@@ -192,7 +192,7 @@ Tensor &_sum_out_cpu(Tensor &result, const Tensor &self, int64_t dim_,
 static inline Tensor &prod_out(Tensor &result, const Tensor &self, int64_t dim,
                  bool keepdim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
-  AT_ASSERT(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
+  AT_CHECK(!dtype.has_value() || (result.type().scalarType() == dtype.value()),
             "provided dtype must match dtype of result in prod.  Got %s and %s.",
             at::toString(result.type().scalarType()), at::toString(dtype.value()));
   return at::_prod_out(result, self.toType(result.type().scalarType()), dim, keepdim);

--- a/aten/src/ATen/native/RoiPooling.cpp
+++ b/aten/src/ATen/native/RoiPooling.cpp
@@ -14,13 +14,13 @@ std::tuple<at::Tensor, at::Tensor> RoiPooling2d_forward_cpu(
 {
   // Input is the output of the last convolutional layer in the Backbone network, so
   // it should be in the format of NCHW
-  AT_ASSERT(input.ndimension() == 4, "Input to RoI Pooling should be a NCHW Tensor");
+  AT_CHECK(input.ndimension() == 4, "Input to RoI Pooling should be a NCHW Tensor");
 
   // ROIs is the set of region proposals to process. It is a 2D Tensor where the first
   // dim is the # of proposals, and the second dim is the proposal itself in the form
   // [batch_index startW startH endW endH]
-  AT_ASSERT(rois.ndimension() == 2, "RoI Proposals should be a 2D Tensor, (batch_sz x proposals)");
-  AT_ASSERT(rois.size(1) == 5, "Proposals should be of the form [batch_index startW startH endW enH]");
+  AT_CHECK(rois.ndimension() == 2, "RoI Proposals should be a 2D Tensor, (batch_sz x proposals)");
+  AT_CHECK(rois.size(1) == 5, "Proposals should be of the form [batch_index startW startH endW enH]");
 
   auto proposals = rois.size(0);
   auto inputChannels = input.size(1);
@@ -36,8 +36,8 @@ std::tuple<at::Tensor, at::Tensor> RoiPooling2d_forward_cpu(
   // the argmaxes Tensor should be the same size as the output Tensor
   auto argmaxes = input.type().toScalarType(kInt).tensor({proposals, inputChannels, pooledHeight, pooledWidth});
 
-  AT_ASSERT(input.is_contiguous(), "input must be contiguous");
-  AT_ASSERT(rois.is_contiguous(), "rois must be contiguous");
+  AT_CHECK(input.is_contiguous(), "input must be contiguous");
+  AT_CHECK(rois.is_contiguous(), "rois must be contiguous");
 
   auto *rawInput = input.data<float>();
   auto inputChannelStride = inputHeight * inputWidth;

--- a/aten/src/ATen/native/SparseMM.cpp
+++ b/aten/src/ATen/native/SparseMM.cpp
@@ -19,8 +19,8 @@ namespace native {
 template <class scalar_t>
 void sspaddmm_TH_dispatch(Tensor & result, Scalar beta, const Tensor& self,
     Scalar alpha, const Tensor& mat1, const Tensor& mat2) {
- AT_ERROR("sspaddmm NYI for types %s %s %s",
-      self.type().toString(), mat1.type().toString(), mat2.type().toString());
+ AT_ERROR("sspaddmm NYI for types ",
+      self.type().toString(), " ", mat1.type().toString(), " ", mat2.type().toString());
 }
 
 template <>

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -64,7 +64,7 @@ bool is_nonzero(const Tensor& self) {
 
 Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
   if (condition.type().scalarType() != ScalarType::Byte) {
-    AT_ERROR("Expected condition to have ScalarType Byte, but got ScalarType %s",
+    AT_ERROR("Expected condition to have ScalarType Byte, but got ScalarType ",
                   toString(condition.type().scalarType()));
   }
   Tensor b_condition, b_self, b_other;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -104,7 +104,7 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
 
 Tensor full(const Type& dtype, IntList size, Scalar fill_value) {
   if (dtype.is_sparse()) {
-    AT_ERROR("full(...) is not implemented for sparse types, got: %s", dtype.toString());
+    AT_ERROR("full(...) is not implemented for sparse types, got: ", dtype.toString());
   }
   auto result = dtype.tensor(size);
   return result.fill_(fill_value);
@@ -112,7 +112,7 @@ Tensor full(const Type& dtype, IntList size, Scalar fill_value) {
 
 Tensor& full_out(Tensor& result, IntList size, Scalar fill_value) {
   if (result.is_sparse()) {
-    AT_ERROR("full(...) is not implemented for sparse types, got: %s", result.type().toString());
+    AT_ERROR("full(...) is not implemented for sparse types, got: ", result.type().toString());
   }
   result.resize_(size);
   return result.fill_(fill_value);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -51,7 +51,7 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   int64_t nDims = self.dim();
   int64_t dim1 = maybe_wrap_dim(dim1_, nDims);
   int64_t dim2 = maybe_wrap_dim(dim2_, nDims);
-  AT_ASSERT(dim1 != dim2, "diagonal dimensions cannot be identical ", dim1_, ", ", dim2_);
+  AT_CHECK(dim1 != dim2, "diagonal dimensions cannot be identical ", dim1_, ", ", dim2_);
   int64_t diag_size;
   int64_t storage_offset = self.storage_offset();
   // compute storage offset and size for the diagonal
@@ -68,7 +68,7 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
     diag_size = std::min(self.size(dim1)+offset, self.size(dim2));
     storage_offset -= offset * self.stride(dim1);
   }
-  AT_ASSERT(diag_size > 0, "invalid diagonal offset ", offset); // the diagonal offset was too large in magnitude
+  AT_CHECK(diag_size > 0, "invalid diagonal offset ", offset); // the diagonal offset was too large in magnitude
 
   // construct new size and stride: we drop dim1 and dim2 (maximum first for not changing the index of the minumum)
   // the new ("joint") dimension is appended to the end of the shape / stride to match numpy semantics
@@ -107,7 +107,7 @@ Tensor expand_as(const Tensor& self, const Tensor& other) {
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
-  AT_ASSERT(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
+  AT_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   auto cur_size = self.size(dim);
   if (start < 0 || start >= cur_size) {
     AT_ERROR("start out of range");
@@ -260,7 +260,7 @@ Tensor reshape(const Tensor& self, IntList proposed_shape) {
 
 Tensor select(const Tensor& self, int64_t dim, int64_t index) {
   int64_t ndim = self.dim();
-  AT_ASSERT(ndim > 0, "select() cannot be applied to a 0-dim tensor.");
+  AT_CHECK(ndim > 0, "select() cannot be applied to a 0-dim tensor.");
   dim = maybe_wrap_dim(dim, ndim);
   auto size = self.size(dim);
   if (index < -size || index >= size) {
@@ -282,7 +282,7 @@ Tensor select(const Tensor& self, int64_t dim, int64_t index) {
 
 Tensor slice(const Tensor& self, int64_t dim, int64_t start, int64_t end, int64_t step) {
   int64_t ndim = self.dim();
-  AT_ASSERT(ndim > 0, "slice() cannot be applied to a 0-dim tensor.");
+  AT_CHECK(ndim > 0, "slice() cannot be applied to a 0-dim tensor.");
   dim = maybe_wrap_dim(dim, ndim);
   auto sizes = std::vector<int64_t>(self.sizes());
   auto strides = std::vector<int64_t>(self.strides());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -14,7 +14,7 @@ static void check_cat_no_zero_dim(TensorList tensors) {
   for(size_t i = 0; i < tensors.size(); ++i) {
     auto& t = tensors[i];
     if (t.dim() == 0) {
-      AT_ERROR("zero-dimensional tensor (at position %zu) cannot be concatenated", i);
+      AT_ERROR("zero-dimensional tensor (at position ", i, ") cannot be concatenated");
     }
   }
 }
@@ -36,8 +36,7 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
     AT_ERROR("chunk expects at least a 1-dimensional tensor");
   }
   if (chunks <= 0) {
-    AT_ERROR("chunk expects `chunks` to be greater than 0, got: %lld",
-             (long long)chunks);
+    AT_ERROR("chunk expects `chunks` to be greater than 0, got: ", chunks);
   }
   int64_t split_size = (self.size(dim) + chunks - 1) / chunks;
   // ensure this is dispatched through Tensor/Type, rather than the native function directly.
@@ -52,7 +51,7 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
   int64_t nDims = self.dim();
   int64_t dim1 = maybe_wrap_dim(dim1_, nDims);
   int64_t dim2 = maybe_wrap_dim(dim2_, nDims);
-  AT_ASSERT(dim1 != dim2, "diagonal dimensions cannot be identical %zd, %zd", dim1_, dim2_);
+  AT_ASSERT(dim1 != dim2, "diagonal dimensions cannot be identical ", dim1_, ", ", dim2_);
   int64_t diag_size;
   int64_t storage_offset = self.storage_offset();
   // compute storage offset and size for the diagonal
@@ -69,7 +68,7 @@ Tensor diagonal(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim2_
     diag_size = std::min(self.size(dim1)+offset, self.size(dim2));
     storage_offset -= offset * self.stride(dim1);
   }
-  AT_ASSERT(diag_size > 0, "invalid diagonal offset %zd", offset); // the diagonal offset was too large in magnitude
+  AT_ASSERT(diag_size > 0, "invalid diagonal offset ", offset); // the diagonal offset was too large in magnitude
 
   // construct new size and stride: we drop dim1 and dim2 (maximum first for not changing the index of the minumum)
   // the new ("joint") dimension is appended to the end of the shape / stride to match numpy semantics
@@ -185,7 +184,7 @@ static std::vector<int64_t> infer_size(IntList shape, int64_t numel) {
     } else if (shape[dim] >= 0) {
       newsize *= shape[dim];
     } else {
-      AT_ERROR("invalid shape dimension %zd", shape[dim]);
+      AT_ERROR("invalid shape dimension ", shape[dim]);
     }
   }
 
@@ -399,8 +398,7 @@ static inline Tensor & sparse_transpose_(Tensor & self, int64_t dim0, int64_t di
   if (dim0 >= ndimI || dim1 >= ndimI) {
     AT_ERROR(
         "sparse transpose_: transposed dimensions must be sparse ",
-        "Got nDimI: %llu, d0: %llu, d1: %llu",
-        (long long)ndimI, (long long)dim0, (long long)dim1);
+        "Got nDimI: ", ndimI, ", d0: ", dim0, ", d1: ", dim1);
   }
 
   auto indices = self._indices();
@@ -440,8 +438,7 @@ Tensor & transpose_(Tensor & self, int64_t dim0, int64_t dim1) {
 
 Tensor & t_(Tensor & self) {
   if (self.ndimension() != 2) {
-    AT_ERROR("t_() expects a 2D tensor, but self is %llu",
-                  (long long)self.ndimension());
+    AT_ERROR("t_() expects a 2D tensor, but self is ", self.ndimension());
   }
   return self.transpose_(0, 1);
 }

--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -58,7 +58,7 @@ struct DispatchStub {
     }
 #endif
     int def = static_cast<int>(CPUCapability::DEFAULT);
-    AT_ASSERT(table[def], "DispatchStub: missing default kernel");
+    AT_ASSERT(table[def]);
     return table[def];
   }
 

--- a/aten/src/ATen/native/cpu/CapabilityDispatch.h
+++ b/aten/src/ATen/native/cpu/CapabilityDispatch.h
@@ -58,7 +58,7 @@ struct DispatchStub {
     }
 #endif
     int def = static_cast<int>(CPUCapability::DEFAULT);
-    AT_ASSERT(table[def]);
+    AT_ASSERTM(table[def], "DispatchStub: missing default kernel");
     return table[def];
   }
 

--- a/aten/src/ATen/native/cuda/RoiPooling.cu
+++ b/aten/src/ATen/native/cuda/RoiPooling.cu
@@ -103,13 +103,13 @@ std::tuple<Tensor, Tensor> RoiPooling2d_forward_cuda(
 
   // Input is the output of the last convolutional layer in the Backbone network, so
   // it should be in the format of NCHW
-  AT_ASSERT(input.ndimension() == 4, "Input to RoI Pooling should be a NCHW Tensor");
+  AT_CHECK(input.ndimension() == 4, "Input to RoI Pooling should be a NCHW Tensor");
 
   // ROIs is the set of region proposals to process. It is a 2D Tensor where the first
   // dim is the # of proposals, and the second dim is the proposal itself in the form
   // [batch_index startW startH endW endH]
-  AT_ASSERT(rois.ndimension() == 2, "RoI Proposals should be a 2D Tensor, (batch_sz x proposals)");
-  AT_ASSERT(rois.size(1) == 5, "Proposals should be of the form [batch_index startW startH endW enH]");
+  AT_CHECK(rois.ndimension() == 2, "RoI Proposals should be a 2D Tensor, (batch_sz x proposals)");
+  AT_CHECK(rois.size(1) == 5, "Proposals should be of the form [batch_index startW startH endW enH]");
 
   auto proposals = rois.size(0);
   auto inputChannels = input.size(1);
@@ -125,8 +125,8 @@ std::tuple<Tensor, Tensor> RoiPooling2d_forward_cuda(
   // the argmaxes Tensor should be the same size as the output Tensor
   auto argmaxes = input.type().toScalarType(kInt).tensor({proposals, inputChannels, pooledHeight, pooledWidth});
 
-  AT_ASSERT(input.is_contiguous(), "input must be contiguous");
-  AT_ASSERT(rois.is_contiguous(), "rois must be contiguous");
+  AT_CHECK(input.is_contiguous(), "input must be contiguous");
+  AT_CHECK(rois.is_contiguous(), "rois must be contiguous");
 
   dim3 block(512);
   dim3 grid((output.numel() + 512 - 1) / 512);

--- a/aten/src/ATen/native/cuda/RoiPooling.cu
+++ b/aten/src/ATen/native/cuda/RoiPooling.cu
@@ -133,7 +133,7 @@ std::tuple<Tensor, Tensor> RoiPooling2d_forward_cuda(
   RoiPooling2d_forward_kernel<<<grid, block, 0, globalContext().getCurrentCUDAStream()>>>(
     output.numel(), input.data<float>(), rois.data<float>(), static_cast<float>(spatialScale), inputChannels,
     inputHeight, inputWidth, pooledHeight, pooledWidth, output.data<float>(), argmaxes.data<int>());
-  AT_ASSERT(cudaGetLastError() == cudaSuccess);
+  AT_CHECK(cudaGetLastError() == cudaSuccess, "RoiPooling2d_forward_kernel failed with error code ", cudaGetLastError());
 
   return std::make_tuple(output, argmaxes);
 }
@@ -201,7 +201,7 @@ Tensor RoiPooling2d_backward_cuda(
     gradOutput.numel(), gradOutput.data<float>(), argmaxes.data<int>(), proposals,
     static_cast<float>(spatialScale), inputChannels, inputHeight, inputWidth,
     pooledHeight, pooledWidth, gradInput.data<float>(), rois.data<float>());
-  AT_ASSERT(cudaGetLastError() == cudaSuccess);
+  AT_CHECK(cudaGetLastError() == cudaSuccess, "RoiPooling2d_backward_kernel failed with error code ", cudaGetLastError());
 
   return gradInput;
 }

--- a/aten/src/ATen/native/cuda/RoiPooling.cu
+++ b/aten/src/ATen/native/cuda/RoiPooling.cu
@@ -133,7 +133,7 @@ std::tuple<Tensor, Tensor> RoiPooling2d_forward_cuda(
   RoiPooling2d_forward_kernel<<<grid, block, 0, globalContext().getCurrentCUDAStream()>>>(
     output.numel(), input.data<float>(), rois.data<float>(), static_cast<float>(spatialScale), inputChannels,
     inputHeight, inputWidth, pooledHeight, pooledWidth, output.data<float>(), argmaxes.data<int>());
-  AT_ASSERT(cudaGetLastError() == cudaSuccess, "RoiPooling2d_forward_kernel failed");
+  AT_ASSERT(cudaGetLastError() == cudaSuccess);
 
   return std::make_tuple(output, argmaxes);
 }
@@ -201,7 +201,7 @@ Tensor RoiPooling2d_backward_cuda(
     gradOutput.numel(), gradOutput.data<float>(), argmaxes.data<int>(), proposals,
     static_cast<float>(spatialScale), inputChannels, inputHeight, inputWidth,
     pooledHeight, pooledWidth, gradInput.data<float>(), rois.data<float>());
-  AT_ASSERT(cudaGetLastError() == cudaSuccess, "RoiPooling2d_forward_kernel failed");
+  AT_ASSERT(cudaGetLastError() == cudaSuccess);
 
   return gradInput;
 }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -458,7 +458,7 @@ namespace {
             params.emplace_back(std::move(param));
             layer_params_count++;
           } else {
-            AT_ASSERT(cur_offset == offset, "cur_offset == offset");
+            AT_ASSERT(cur_offset == offset);
           }
           cur_offset = offset + mat_numel;
         }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -365,7 +365,7 @@ namespace {
       case CUDNN_RNN_TANH:
         return 2;
       default:
-        AT_ERROR("unknown cuDNN RNN mode %d", mode);
+        AT_ERROR("unknown cuDNN RNN mode ", mode);
     }
   }
 
@@ -436,11 +436,11 @@ namespace {
                 filter_dim_a.data<int>()
                 ));
 
-          AT_ASSERT(nb_dims <= min_dim, "cudnnGetFilterNdDescriptor failed nb_dims (%d) <= min_dim (%d)", nb_dims, min_dim);
+          AT_ASSERT(nb_dims <= min_dim, "cudnnGetFilterNdDescriptor failed nb_dims (", nb_dims, ") <= min_dim (", min_dim, ")");
           filter_dim_a = filter_dim_a.slice(0, 0, nb_dims);
           auto elem_size = dataSize(rnn.datatype);
           auto offset_bytes = (char*)matrix_pointer - (char*)weight_buf.data_ptr();
-          AT_ASSERT(offset_bytes % elem_size == 0, "offset_bytes `mod` elem_size != 0 (%d %% %d)", offset_bytes, elem_size);
+          AT_ASSERT(offset_bytes % elem_size == 0, "offset_bytes `mod` elem_size != 0 (", offset_bytes, " % ", elem_size, ")");
           size_t offset = offset_bytes / elem_size;
 
           // for all the RNN types provided by CUDNN, all the ih weights
@@ -466,7 +466,7 @@ namespace {
       if (layer == 0) {
         global_layer_params_count = layer_params_count;
       } else {
-        AT_ASSERT(global_layer_params_count == layer_params_count, "%d (global) != %d", global_layer_params_count, layer_params_count);
+        AT_ASSERT(global_layer_params_count == layer_params_count, global_layer_params_count, " (global) != ", layer_params_count);
       }
     } // for layer
     return std::make_pair(params, global_layer_params_count);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -350,7 +350,7 @@ namespace {
     size_t weight_size;
     CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
     auto elem_size = dataSize(datatype);
-    AT_ASSERT(weight_size % elem_size == 0);
+    AT_ASSERTM(weight_size % elem_size == 0, "cudnnGetRNNParamsSize returned nonsensical weight_size");
     return weight_size / elem_size;
   }
 
@@ -365,7 +365,7 @@ namespace {
       case CUDNN_RNN_TANH:
         return 2;
       default:
-        AT_ERROR("unknown cuDNN RNN mode ", mode);
+        AT_ERROR("unknown cuDNN RNN mode %d", mode);
     }
   }
 
@@ -436,11 +436,11 @@ namespace {
                 filter_dim_a.data<int>()
                 ));
 
-          AT_ASSERT(nb_dims <= min_dim);
+          AT_ASSERTM(nb_dims <= min_dim, "nb_dims = ", nb_dims, "; min_dim  = ", min_dim);
           filter_dim_a = filter_dim_a.slice(0, 0, nb_dims);
           auto elem_size = dataSize(rnn.datatype);
           auto offset_bytes = (char*)matrix_pointer - (char*)weight_buf.data_ptr();
-          AT_ASSERT(offset_bytes % elem_size == 0);
+          AT_ASSERTM(offset_bytes % elem_size == 0, "offset_bytes = ", offset_bytes, "; elem_size = ", elem_size);
           size_t offset = offset_bytes / elem_size;
 
           // for all the RNN types provided by CUDNN, all the ih weights
@@ -458,7 +458,7 @@ namespace {
             params.emplace_back(std::move(param));
             layer_params_count++;
           } else {
-            AT_ASSERT(cur_offset == offset);
+            AT_ASSERTM(cur_offset == offset, "cur_offset = ", cur_offset, "; offset = ", offset);
           }
           cur_offset = offset + mat_numel;
         }
@@ -466,14 +466,16 @@ namespace {
       if (layer == 0) {
         global_layer_params_count = layer_params_count;
       } else {
-        AT_ASSERT(global_layer_params_count == layer_params_count);
+        AT_ASSERTM(global_layer_params_count == layer_params_count,
+                   "global_layer_params_count = ", global_layer_params_count,
+                   "; layer_params_count = ", layer_params_count);
       }
     } // for layer
     return std::make_pair(params, global_layer_params_count);
   }
 
   void _copyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to) {
-    AT_ASSERT(params_from.size(0) == params_to.size(0));
+    AT_ASSERTM(params_from.size(0) == params_to.size(0), "number of layers mismatch");
     for (size_t i = 0; i < params_from.size(0); i++) {
       auto layer_params_from = params_from[i];
       auto layer_params_to = params_to[i];
@@ -484,7 +486,7 @@ namespace {
            a != layer_params_from.end() && b != layer_params_to.end();
            ++a, ++b) {
         auto param_from = *a, param_to = *b;
-        AT_ASSERT(param_from.type() == param_to.type());
+        AT_ASSERTM(param_from.type() == param_to.type(), "parameter types mismatch");
         param_to.copy_(param_from.view_as(param_to));
       }
     }

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -350,7 +350,7 @@ namespace {
     size_t weight_size;
     CUDNN_CHECK(cudnnGetRNNParamsSize(handle, rnn_desc.desc(), x_desc.desc(), &weight_size, datatype));
     auto elem_size = dataSize(datatype);
-    AT_ASSERT(weight_size % elem_size == 0, "cudnnGetRNNParamsSize returned nonsensical weight_size");
+    AT_ASSERT(weight_size % elem_size == 0);
     return weight_size / elem_size;
   }
 
@@ -436,11 +436,11 @@ namespace {
                 filter_dim_a.data<int>()
                 ));
 
-          AT_ASSERT(nb_dims <= min_dim, "cudnnGetFilterNdDescriptor failed nb_dims (", nb_dims, ") <= min_dim (", min_dim, ")");
+          AT_ASSERT(nb_dims <= min_dim);
           filter_dim_a = filter_dim_a.slice(0, 0, nb_dims);
           auto elem_size = dataSize(rnn.datatype);
           auto offset_bytes = (char*)matrix_pointer - (char*)weight_buf.data_ptr();
-          AT_ASSERT(offset_bytes % elem_size == 0, "offset_bytes `mod` elem_size != 0 (", offset_bytes, " % ", elem_size, ")");
+          AT_ASSERT(offset_bytes % elem_size == 0);
           size_t offset = offset_bytes / elem_size;
 
           // for all the RNN types provided by CUDNN, all the ih weights
@@ -466,14 +466,14 @@ namespace {
       if (layer == 0) {
         global_layer_params_count = layer_params_count;
       } else {
-        AT_ASSERT(global_layer_params_count == layer_params_count, global_layer_params_count, " (global) != ", layer_params_count);
+        AT_ASSERT(global_layer_params_count == layer_params_count);
       }
     } // for layer
     return std::make_pair(params, global_layer_params_count);
   }
 
   void _copyParams(MatrixRef<Tensor> params_from, MatrixRef<Tensor> params_to) {
-    AT_ASSERT(params_from.size(0) == params_to.size(0), "number of layers mismatch");
+    AT_ASSERT(params_from.size(0) == params_to.size(0));
     for (size_t i = 0; i < params_from.size(0); i++) {
       auto layer_params_from = params_from[i];
       auto layer_params_to = params_to[i];
@@ -484,7 +484,7 @@ namespace {
            a != layer_params_from.end() && b != layer_params_to.end();
            ++a, ++b) {
         auto param_from = *a, param_to = *b;
-        AT_ASSERT(param_from.type() == param_to.type(), "parameter types mismatch");
+        AT_ASSERT(param_from.type() == param_to.type());
         param_to.copy_(param_from.view_as(param_to));
       }
     }
@@ -767,7 +767,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   auto dhy = grad_hy.contiguous().view(hidden_size);
   auto dcy = grad_cy.defined() ? grad_cy.contiguous().view(hidden_size) : Tensor();
   auto dhx = hx.type().tensor(hidden_size);
-  AT_ASSERT(cx.defined() || !output_mask[2], "illegally required grad of cx for non-LSTM RNN");
+  AT_ASSERTM(cx.defined() || !output_mask[2], "illegally required grad of cx for non-LSTM RNN");
   auto dcx = cx.defined() ? cx.type().tensor(hidden_size) : Tensor();
 
   if (!fn_train) {

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -12,11 +12,11 @@ namespace at {
 ${function_declarations}
 
 static inline Type & infer_type(const Tensor & t) {
-  AT_ASSERT(t.defined());
+  AT_CHECK(t.defined(), "undefined Tensor");
   return t.type();
 }
 static inline Type & infer_type(const TensorList & tl) {
-  AT_ASSERT(tl.size() > 0);
+  AT_CHECK(tl.size() > 0, "expected a non-empty list of Tensors");
   return tl[0].type();
 }
 // function definitions are all static inline because

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -12,11 +12,11 @@ namespace at {
 ${function_declarations}
 
 static inline Type & infer_type(const Tensor & t) {
-  AT_ASSERT(t.defined(), "undefined Tensor");
+  AT_ASSERT(t.defined());
   return t.type();
 }
 static inline Type & infer_type(const TensorList & tl) {
-  AT_ASSERT(tl.size() > 0, "expected a non-empty list of Tensors");
+  AT_ASSERT(tl.size() > 0);
   return tl[0].type();
 }
 // function definitions are all static inline because

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -109,7 +109,7 @@ struct Tensor : public detail::TensorBase {
   template<typename T, size_t N>
   TensorAccessor<T,N> accessor() {
     static_assert(N > 0, "accessor is used for indexing tensor, for scalars use *data<T>()");
-    AT_ASSERT(dim() == N, "expected ", N, " dims but tensor has ", dim());
+    AT_CHECK(dim() == N, "expected ", N, " dims but tensor has ", dim());
     return TensorAccessor<T,N>(data<T>(),sizes().data(),strides().data());
   }
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -109,7 +109,7 @@ struct Tensor : public detail::TensorBase {
   template<typename T, size_t N>
   TensorAccessor<T,N> accessor() {
     static_assert(N > 0, "accessor is used for indexing tensor, for scalars use *data<T>()");
-    AT_ASSERT(dim() == N, "expected %d dims but tensor has %d",N,dim());
+    AT_ASSERT(dim() == N, "expected ", N, " dims but tensor has ", dim());
     return TensorAccessor<T,N>(data<T>(),sizes().data(),strides().data());
   }
 

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -10,7 +10,7 @@ IntList ${Tensor}::strides() const {
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
-  AT_ASSERT(numel == 1,"localScalar() called on Tensor with ", numel, " elements");
+  AT_CHECK(numel == 1,"localScalar() called on Tensor with ", numel, " elements");
   return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storageOffset)));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -10,7 +10,7 @@ IntList ${Tensor}::strides() const {
 }
 Scalar ${Tensor}::localScalar() {
   int64_t numel = ${THTensor}_nElement(${state,}tensor);
-  AT_ASSERT(numel == 1,"localScalar() called on Tensor with %" PRId64 " elements",numel);
+  AT_ASSERT(numel == 1,"localScalar() called on Tensor with ", numel, " elements");
   return Scalar(${to_at_type}(${THStorage}_get(${state,}tensor->storage, tensor->storageOffset)));
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -35,7 +35,7 @@ ${tensor_method_definitions}
 #define DEFINE_CAST(T,name,_) \
 template<> \
 inline T* Tensor::data() const { \
-  AT_ASSERT(type().scalarType() == ScalarType::name, \
+  AT_CHECK(type().scalarType() == ScalarType::name, \
     "expected scalar type % s but found %s", #name, \
     at::toString(type().scalarType())); \
   return static_cast<T*>(this->data_ptr()); \

--- a/aten/src/ATen/templates/TensorSparse.cpp
+++ b/aten/src/ATen/templates/TensorSparse.cpp
@@ -6,5 +6,5 @@ Scalar ${Tensor}::localScalar() {
  AT_ERROR("NYI localScalar() on sparse tensors.");
 }
 std::unique_ptr<Storage> ${Tensor}::storage() {
-  AT_ERROR("storage() is not implemented for %s", type().toString());
+  AT_ERROR("storage() is not implemented for ", type().toString());
 }

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -24,7 +24,7 @@ Tensor & Type::copy_(Tensor & self, const Tensor & src, bool non_blocking) const
 }
 
 Tensor Type::copy(const Tensor & src, bool non_blocking) const {
-  AT_ASSERT(src.defined(), "attempt to copy an undefined tensor");
+  AT_CHECK(src.defined(), "attempt to copy an undefined tensor");
   if (is_sparse()) {
     auto indices = src._indices();
     auto values = src._values();

--- a/test/cpp_extensions/cuda_extension.cpp
+++ b/test/cpp_extensions/cuda_extension.cpp
@@ -6,8 +6,8 @@
 void sigmoid_add_cuda(const float* x, const float* y, float* output, int size);
 
 at::Tensor sigmoid_add(at::Tensor x, at::Tensor y) {
-  AT_ASSERT(x.type().is_cuda(), "x must be a CUDA tensor");
-  AT_ASSERT(y.type().is_cuda(), "y must be a CUDA tensor");
+  AT_CHECK(x.type().is_cuda(), "x must be a CUDA tensor");
+  AT_CHECK(y.type().is_cuda(), "y must be a CUDA tensor");
   auto output = at::zeros_like(x);
   sigmoid_add_cuda(
       x.data<float>(), y.data<float>(), output.data<float>(), output.numel());

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -36,14 +36,14 @@ struct IndexRangeGenerator {
 };
 
 void copy_range(variable_list& out, IndexRange range, const Tensor & t) {
-  AT_ASSERT(range.second <= out.size(), "range out of bounds");
-  AT_ASSERT(range.second - range.first == 1, "inconsistent range for Tensor output");
+  AT_ASSERT(range.second <= out.size());
+  AT_ASSERT(range.second - range.first == 1);
   out[range.first] = t;
 }
 
 void copy_range(variable_list& out, IndexRange range, at::ArrayRef<Tensor> t) {
-  AT_ASSERT(range.second <= out.size(), "range out of bounds");
-  AT_ASSERT(range.second - range.first == t.size(), "inconsistent range for TensorList output");
+  AT_ASSERT(range.second <= out.size());
+  AT_ASSERT(range.second - range.first == t.size());
   std::copy(t.begin(), t.end(), out.begin() + range.first);
 }
 
@@ -972,7 +972,7 @@ Tensor logdet_backward(const Tensor & grad, const Tensor& self, const Tensor& lo
 Tensor slogdet_backward(const std::vector<torch::autograd::Variable> &grads,
                         const Tensor& self,
                         const Tensor& signdet, const Tensor& logabsdet) {
-  AT_ASSERT(!grads[0].defined(), "slogdet's sign output should never have gradient");
+  AT_ASSERTM(!grads[0].defined(), "slogdet's sign output should never have gradient");
   auto signdet_val = signdet.toCDouble();
   if (signdet_val != 0 /* det != 0, invertible */) {
     return grads[1] * self.inverse().t();
@@ -1275,7 +1275,7 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
 
   if (output_mask[0] && !ggO.defined()) ggO = at::zeros_like(gO);
   if (output_mask[1] && !gG.defined()) {
-    AT_ASSERT(affine, "gamma should always be defined when it requires grad");
+    AT_ASSERTM(affine, "gamma should always be defined when it requires grad");
     gG = at::zeros_like(gamma);
   }
   if (output_mask[2] && !gI.defined()) gI = at::zeros_like(input);

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -37,13 +37,13 @@ struct IndexRangeGenerator {
 
 void copy_range(variable_list& out, IndexRange range, const Tensor & t) {
   AT_ASSERT(range.second <= out.size());
-  AT_ASSERT(range.second - range.first == 1);
+  AT_ASSERTM(range.second - range.first == 1, "inconsistent range for Tensor output");
   out[range.first] = t;
 }
 
 void copy_range(variable_list& out, IndexRange range, at::ArrayRef<Tensor> t) {
   AT_ASSERT(range.second <= out.size());
-  AT_ASSERT(range.second - range.first == t.size());
+  AT_ASSERTM(range.second - range.first == t.size(), "inconsistent range for TensorList output");
   std::copy(t.begin(), t.end(), out.begin() + range.first);
 }
 

--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -157,12 +157,10 @@ std::vector<at::Type*> VariableType::allTypes() {
 
 Variable & VariableType::checked_cast_variable(const Tensor & t, const char * name, int pos) {
   if (!t.defined()) {
-    AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor for argument #%d '%s'",
-        pos, name);
+    AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor for argument #", pos, " '", name, "'");
   }
   if (!isVariableType(t.type())) {
-    AT_ERROR("Expected object of type Variable but found type %s for argument #%d '%s'",
-        t.type().toString(), pos, name);
+    AT_ERROR("Expected object of type Variable but found type ", t.type().toString(), " for argument #", pos, " '", name, "'");
   }
   return as_variable_ref(const_cast<Tensor&>(t));
 }
@@ -187,14 +185,12 @@ std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name
   for (size_t i = 0; i < tl.size(); ++i) {
     const auto &t = tl[i];
     if (!t.defined()) {
-      AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor at position #%d "
-                    "for iterable argument #%d '%s'",
-                    i, pos, name);
+      AT_ERROR("Expected a Tensor of type Variable but found an undefined Tensor at position #", i, " "
+                    "for iterable argument #", pos, " '", name, "'");
     }
     if (!isVariableType(t.type())) {
-      AT_ERROR("Expected object of type Variable but found type %s at position #%d "
-                    "for iterable argument #%d '%s'",
-                    t.type().toString(), i, pos, name);
+      AT_ERROR("Expected object of type Variable but found type ", t.type().toString(), " at position #", i, " "
+                    "for iterable argument #", pos, " '", name, "'");
     }
     ret[i] = static_cast<const Variable&>(t).data();
   }
@@ -288,8 +284,8 @@ static void check_inplace(const Tensor& tensor) {
 
 static void throw_error_out_requires_grad(const char* name) {
   AT_ERROR(
-      "%s(): functions with out=... arguments don't support automatic differentiation, "
-      "but one of the arguments requires grad.", name);
+      name, "(): functions with out=... arguments don't support automatic differentiation, "
+      "but one of the arguments requires grad.");
 }
 
 static void rebase_history(Tensor& tensor, std::shared_ptr<Function> grad_fn) {

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -152,7 +152,7 @@ static const char* get_module(Backend backend) {
     case kCUDA: return "torch.cuda";
     case kSparseCPU: return "torch.sparse";
     case kSparseCUDA: return "torch.cuda.sparse";
-    default: AT_ERROR("invalid backend: %s", toString(backend));
+    default: AT_ERROR("invalid backend: ", toString(backend));
   }
 }
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -144,7 +144,7 @@ static ScalarType infer_scalar_type(PyObject *obj) {
     }
     return *scalarType;
   }
-  AT_ERROR("Could not infer dtype of %s", Py_TYPE(obj)->tp_name);
+  AT_ERROR("Could not infer dtype of ", Py_TYPE(obj)->tp_name);
 }
 
 static void recursive_store(char* data, IntList sizes, IntList strides, int64_t dim,


### PR DESCRIPTION
- AT_ASSERT/AT_ERROR don't take printf strings anymore; instead,
  they take a comma-separated list of things you wanted to print
  (bringing it inline with Caffe2's conventions).

  Instead of AT_ASSERT(x == 0, "%d is not zero", x)
  you write AT_ASSERT(x == 0, x, " is not zero")

  This is done by way of a new variadic template at::str(), which
  takes a list of arguments and cats their string reps (as per
  operator<<) together.

- A bunch of the demangling logic that was in Error.h is now
  moved to Error.cpp (better header hygiene.)  Also, demangle
  has been moved out to its own helper function, and also
  a new helper demangle_type (from Caffe2) added.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

