### PR TITLE
[easy] Stop hardcoding "python" executable in bottleneck tests

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -520,7 +520,7 @@ class TestBottleneck(TestCase):
         if scriptargs != '':
             scriptargs = ' {}'.format(scriptargs)
         rc, out, err = self._run(
-            'python -m torch.utils.bottleneck {}{}'.format(filepath, scriptargs))
+            '{} -m torch.utils.bottleneck {}{}'.format(sys.executable, filepath, scriptargs))
         return rc, out, err
 
     def _check_run_args(self):


### PR DESCRIPTION
Right now, the bottleneck test_utils.py tests assume that a user's
python executable is 'python'. This may not be the case especially if
the user has multiple versions of python installed. This PR changes it
so that test_utils.py uses `sys.executable` as the python executable.

