### PR TITLE
Move codegen from setup.py to CMake for C++ libraries

### DIFF
--- a/tools/cpp_build/build_common.sh
+++ b/tools/cpp_build/build_common.sh
@@ -4,11 +4,6 @@ BUILD_PATH="${1:-$SCRIPTPATH/build}"
 INSTALL_PREFIX="$BUILD_PATH/install"
 PYTORCHPATH="$SCRIPTPATH/../.."
 
-if [ ! -d "$PYTORCHPATH/torch/csrc/autograd/generated" ]; then
-  echo "Generated files are not present.\nRun the generators through `python setup.py build` or copy the generated files over."
-  exit 1
-fi
-
 NO_CUDA=ON
 if [ -x "$(command -v nvcc)" ]; then
   NO_CUDA=OFF

--- a/tools/cpp_build/build_libtorch.sh
+++ b/tools/cpp_build/build_libtorch.sh
@@ -7,6 +7,15 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 pushd $SCRIPTPATH
 source ./build_common.sh
 
+echo "Generating code"
+
+pushd "../.."
+cp aten/src/ATen/common_with_cwrap.py tools/shared/cwrap_common.py
+python tools/setup_helpers/generate_code.py \
+  --declarations-path "$ATEN_BUILDPATH/src/ATen/ATen/Declarations.yaml" \
+  --nn-path "aten/src/"
+popd
+
 echo "Building Torch"
 
 mkdir -p $LIBTORCH_BUILDPATH

--- a/tools/cpp_build/build_libtorch.sh
+++ b/tools/cpp_build/build_libtorch.sh
@@ -7,15 +7,6 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 pushd $SCRIPTPATH
 source ./build_common.sh
 
-echo "Generating code"
-
-pushd "../.."
-cp aten/src/ATen/common_with_cwrap.py tools/shared/cwrap_common.py
-python tools/setup_helpers/generate_code.py \
-  --declarations-path "$ATEN_BUILDPATH/src/ATen/ATen/Declarations.yaml" \
-  --nn-path "aten/src/"
-popd
-
 echo "Building Torch"
 
 mkdir -p $LIBTORCH_BUILDPATH

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -109,9 +109,10 @@ endif()
 
 
 # Generate files
+set(TOOLS_PATH "${TORCH_SRC_DIR}/../tools")
 
 configure_file("${ATEN_PATH}/src/ATen/common_with_cwrap.py"
-               "${TORCH_SRC_DIR}/../tools/shared/cwrap_common.py"
+               "${TOOLS_PATH}/shared/cwrap_common.py"
                COPYONLY)
 
 add_custom_command(
@@ -138,7 +139,26 @@ add_custom_command(
   python tools/setup_helpers/generate_code.py
     --declarations-path "${ATEN_BUILD_PATH}/src/ATen/ATen/Declarations.yaml"
     --nn-path "aten/src/"
-  DEPENDS "${ATEN_BUILD_PATH}/src/ATen/ATen/Declarations.yaml"
+  DEPENDS
+  "${ATEN_BUILD_PATH}/src/ATen/ATen/Declarations.yaml"
+  "${ATEN_PATH}/src/THNN/generic/THNN.h"
+  "${ATEN_PATH}/src/THCUNN/generic/THCUNN.h"
+  "${TOOLS_PATH}/autograd/templates/VariableType.h"
+  "${TOOLS_PATH}/autograd/templates/VariableType.cpp"
+  "${TOOLS_PATH}/autograd/templates/Functions.h"
+  "${TOOLS_PATH}/autograd/templates/Functions.cpp"
+  "${TOOLS_PATH}/autograd/templates/python_functions.h"
+  "${TOOLS_PATH}/autograd/templates/python_functions.cpp"
+  "${TOOLS_PATH}/autograd/templates/python_variable_methods.cpp"
+  "${TOOLS_PATH}/autograd/templates/python_variable_methods_dispatch.h"
+  "${TOOLS_PATH}/autograd/templates/python_torch_functions.cpp"
+  "${TOOLS_PATH}/autograd/templates/python_torch_functions_dispatch.h"
+  "${TOOLS_PATH}/autograd/templates/python_nn_functions.cpp"
+  "${TOOLS_PATH}/autograd/templates/python_nn_functions.h"
+  "${TOOLS_PATH}/autograd/templates/python_nn_functions_dispatch.h"
+  "${TOOLS_PATH}/jit/templates/aten_dispatch.h"
+  "${TOOLS_PATH}/jit/templates/aten_dispatch.cpp"
+  "${TOOLS_PATH}/jit/templates/aten_interned_strings.h"
   WORKING_DIRECTORY "${TORCH_SRC_DIR}/..")
 
 set(TORCH_SRCS

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -107,6 +107,40 @@ if("${isSystemDir}" STREQUAL "-1")
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
+
+# Generate files
+
+configure_file("${ATEN_PATH}/src/ATen/common_with_cwrap.py"
+               "${TORCH_SRC_DIR}/../tools/shared/cwrap_common.py"
+               COPYONLY)
+
+add_custom_command(
+  OUTPUT
+  "${TORCH_SRC_DIR}/csrc/nn/THNN.cpp"
+  "${TORCH_SRC_DIR}/csrc/nn/THCUNN.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_functions.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_functions.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_variable_methods.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_variable_methods_dispatch.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_torch_functions.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_torch_functions_dispatch.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions.cpp"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions.h"
+  "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions_dispatch.h"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/aten_dispatch.h"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/aten_dispatch.cpp"
+  "${TORCH_SRC_DIR}/csrc/jit/generated/aten_interned_strings.h"
+  COMMAND
+  python tools/setup_helpers/generate_code.py
+    --declarations-path "${ATEN_BUILD_PATH}/src/ATen/ATen/Declarations.yaml"
+    --nn-path "aten/src/"
+  DEPENDS "${ATEN_BUILD_PATH}/src/ATen/ATen/Declarations.yaml"
+  WORKING_DIRECTORY "${TORCH_SRC_DIR}/..")
+
 set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp
@@ -156,8 +190,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/Exceptions.cpp
   ${TORCH_SRC_DIR}/csrc/api/src/detail.cpp
   ${TORCH_SRC_DIR}/csrc/api/src/containers.cpp
-  ${TORCH_SRC_DIR}/csrc/api/src/optimizers.cpp
-  )
+  ${TORCH_SRC_DIR}/csrc/api/src/optimizers.cpp)
 
 add_library(torch SHARED ${TORCH_SRCS})
 

--- a/tools/nnwrap/generate_wrappers.py
+++ b/tools/nnwrap/generate_wrappers.py
@@ -95,14 +95,17 @@ def wrap_function(name, type, arguments):
     return declaration
 
 
-def generate_wrappers():
-    wrap_nn()
-    wrap_cunn()
+def generate_wrappers(nn_root=None):
+    if nn_root is not None:
+        nn_path = os.path.join(nn_root, 'THNN', 'generic', 'THNN.h')
+        cunn_path = os.path.join(nn_root, 'THCUNN', 'generic', 'THCUNN.h')
+    wrap_nn(nn_path)
+    wrap_cunn(cunn_path)
 
 
-def wrap_nn():
+def wrap_nn(thnn_h_path):
     wrapper = '#include <TH/TH.h>\n\n\n'
-    nn_functions = thnn_utils.parse_header(thnn_utils.THNN_H_PATH)
+    nn_functions = thnn_utils.parse_header(thnn_h_path or nn_utils.THNN_H_PATH)
     for fn in nn_functions:
         for t in ['Float', 'Double']:
             wrapper += wrap_function(fn.name, t, fn.arguments)
@@ -114,10 +117,10 @@ def wrap_nn():
     ])
 
 
-def wrap_cunn():
+def wrap_cunn(thcunn_h_path=None):
     wrapper = '#include <TH/TH.h>\n'
     wrapper += '#include <THC/THC.h>\n\n\n'
-    cunn_functions = thnn_utils.parse_header(thnn_utils.THCUNN_H_PATH)
+    cunn_functions = thnn_utils.parse_header(thcunn_h_path or thnn_utils.THCUNN_H_PATH)
     for fn in cunn_functions:
         for t in ['CudaHalf', 'Cuda', 'CudaDouble']:
             wrapper += wrap_function(fn.name, t, fn.arguments)

--- a/tools/nnwrap/generate_wrappers.py
+++ b/tools/nnwrap/generate_wrappers.py
@@ -96,16 +96,13 @@ def wrap_function(name, type, arguments):
 
 
 def generate_wrappers(nn_root=None):
-    if nn_root is not None:
-        nn_path = os.path.join(nn_root, 'THNN', 'generic', 'THNN.h')
-        cunn_path = os.path.join(nn_root, 'THCUNN', 'generic', 'THCUNN.h')
-    wrap_nn(nn_path)
-    wrap_cunn(cunn_path)
+    wrap_nn(os.path.join(nn_root, 'THNN', 'generic', 'THNN.h') if nn_root else None)
+    wrap_cunn(os.path.join(nn_root, 'THCUNN', 'generic', 'THCUNN.h') if nn_root else None)
 
 
 def wrap_nn(thnn_h_path):
     wrapper = '#include <TH/TH.h>\n\n\n'
-    nn_functions = thnn_utils.parse_header(thnn_h_path or nn_utils.THNN_H_PATH)
+    nn_functions = thnn_utils.parse_header(thnn_h_path or thnn_utils.THNN_H_PATH)
     for fn in nn_functions:
         for t in ['Float', 'Double']:
             wrapper += wrap_function(fn.name, t, fn.arguments)

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -1,8 +1,10 @@
+import argparse
 import os
 import sys
 
 source_files = {'.py', '.cpp', '.h'}
 
+DECLARATIONS_PATH = 'torch/lib/tmp_install/share/ATen/Declarations.yaml'
 
 # TODO: This is a little inaccurate, because it will also pick
 # up setup_helper scripts which don't affect code generation
@@ -60,7 +62,9 @@ def generate_code_ninja(w):
         })
 
 
-def generate_code(ninja_global=None):
+def generate_code(ninja_global=None,
+                  declarations_path=DECLARATIONS_PATH,
+                  nn_path=None):
     # if ninja is enabled, we just register this file as something
     # ninja will need to call if needed
     if ninja_global is not None:
@@ -75,7 +79,7 @@ def generate_code(ninja_global=None):
 
     # Build THNN/THCUNN.cwrap and then THNN/THCUNN.cpp. These are primarily
     # used by the legacy NN bindings.
-    generate_nn_wrappers()
+    generate_nn_wrappers(nn_path)
 
     # Build ATen based Variable classes
     autograd_gen_dir = 'torch/csrc/autograd/generated'
@@ -83,14 +87,20 @@ def generate_code(ninja_global=None):
     for d in (autograd_gen_dir, jit_gen_dir):
         if not os.path.exists(d):
             os.mkdir(d)
-    gen_autograd(
-        'torch/lib/tmp_install/share/ATen/Declarations.yaml',
-        autograd_gen_dir)
-    gen_jit_dispatch(
-        'torch/lib/tmp_install/share/ATen/Declarations.yaml',
-        jit_gen_dir)
+    gen_autograd(declarations_path, autograd_gen_dir)
+    gen_jit_dispatch(declarations_path, jit_gen_dir)
 
 
-# called from ninja
+def main():
+    parser = argparse.ArgumentParser(description='Autogenerate code')
+    parser.add_argument('--declarations-path')
+    parser.add_argument('--nn-path')
+    parser.add_argument('--ninja-global')
+    options = parser.parse_args()
+    generate_code(options.ninja_global,
+                  options.declarations_path,
+                  options.nn_path)
+
+
 if __name__ == "__main__":
-    generate_code(None)
+    main()

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -63,7 +63,7 @@ def generate_code_ninja(w):
 
 
 def generate_code(ninja_global=None,
-                  declarations_path=DECLARATIONS_PATH,
+                  declarations_path=None,
                   nn_path=None):
     # if ninja is enabled, we just register this file as something
     # ninja will need to call if needed
@@ -87,8 +87,8 @@ def generate_code(ninja_global=None,
     for d in (autograd_gen_dir, jit_gen_dir):
         if not os.path.exists(d):
             os.mkdir(d)
-    gen_autograd(declarations_path, autograd_gen_dir)
-    gen_jit_dispatch(declarations_path, jit_gen_dir)
+    gen_autograd(declarations_path or DECLARATIONS_PATH, autograd_gen_dir)
+    gen_jit_dispatch(declarations_path or DECLARATIONS_PATH, jit_gen_dir)
 
 
 def main():

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -6,6 +6,7 @@ source_files = {'.py', '.cpp', '.h'}
 
 DECLARATIONS_PATH = 'torch/lib/tmp_install/share/ATen/Declarations.yaml'
 
+
 # TODO: This is a little inaccurate, because it will also pick
 # up setup_helper scripts which don't affect code generation
 def all_generator_source():


### PR DESCRIPTION
This PR enables building the C++ libraries without running `python setup.py build`, by invoking the code generation directly. For this I had to parameterize some of the codegen functions.

It's still a bit funky that `aten/src/ATen/common_with_cwrap.py` has to be copied to `tools/shared/cwrap_common.py`, but I'm not sure there's a better solution right now

@apaszke @ebetica @lantiga @ezyang 