### PR TITLE
Add more warnings to C++ API build

### DIFF
--- a/tools/autograd/templates/VariableType.cpp
+++ b/tools/autograd/templates/VariableType.cpp
@@ -130,7 +130,7 @@ static VariableTypeRegistry registry;
 bool VariableType::isVariableType(const at::Type& type) {
   // Since all VariableTypes are allocated contiguously in types_vec, we can
   // just check that the pointer is inside the correct range.
-  ptrdiff_t offset = (char*)&type - (char*)registry.types_vec.data();
+  ptrdiff_t offset = reinterpret_cast<const char*>(&type) - reinterpret_cast<const char*>(registry.types_vec.data());
   ptrdiff_t extent = VariableTypeRegistry::MaxTypes * sizeof(VariableType);
   return offset >= 0 && offset < extent;
 }

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -106,12 +106,6 @@ if("${isSystemDir}" STREQUAL "-1")
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-missing-field-initializers -Wno-type-limits -Wno-unused-parameter -Wno-vla ${CMAKE_CXX_FLAGS}")
-set(CMAKE_C_FLAGS "-fexceptions ${CMAKE_C_FLAGS}")
-if ($ENV{WERROR})
-  set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
-endif()
-
 set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/generated/Functions.cpp
@@ -162,7 +156,12 @@ set(TORCH_SRCS
 
 add_library(torch SHARED ${TORCH_SRCS})
 
-target_compile_options(torch PRIVATE -Wall -Wextra)
+target_compile_options(torch
+  PRIVATE
+  -Wall
+  -Wextra
+  -pedantic
+  -Wno-unused-parameter)
 
 if ($ENV{WERROR})
   target_compile_options(torch PRIVATE -Werror)

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -156,11 +156,24 @@ set(TORCH_SRCS
 
 add_library(torch SHARED ${TORCH_SRCS})
 
+# https://gcc.gnu.org/onlinedocs/gcc-4.0.3/gcc/Warning-Options.html
 target_compile_options(torch
   PRIVATE
   -Wall
   -Wextra
   -pedantic
+  -Wcast-align
+  -Wcast-qual
+  -Wctor-dtor-privacy
+  -Wdisabled-optimization
+  -Wformat=2
+  -Winit-self
+  -Wmissing-include-dirs
+  -Woverloaded-virtual
+  -Wsign-promo
+  -Wstrict-overflow=5
+  -Wundef
+  -fdiagnostics-show-option
   -Wno-unused-parameter)
 
 if ($ENV{WERROR})

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -76,14 +76,13 @@ if(NOT TORCH_INSTALL_LIB_DIR)
 endif()
 
 if(NOT NO_CUDA)
-  add_definitions( -DWITH_CUDA )
+  add_definitions(-DWITH_CUDA)
 
   set(TORCH_CUDA_LIBRARIES
     ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/libcuda.so
     ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libnvrtc.so
     ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libnvToolsExt.so
-    ${CUDA_LIBRARIES}
-  )
+    ${CUDA_LIBRARIES})
 
   set(CUDA_INCLUDE_DIRS
       ${CUDA_INCLUDE_DIRS}
@@ -182,26 +181,27 @@ endif()
 
 target_link_libraries(torch
   ${TORCH_CUDA_LIBRARIES}
-  ${ATEN_LIBRARY}
-)
+  ${ATEN_LIBRARY})
 
-set(COMMON_INCLUDES
+target_include_directories(torch
+  PUBLIC
   "${ATEN_INCLUDE_DIR}"
   "${ATEN_INCLUDE_DIR}/TH"
   "${ATEN_BUILD_INCLUDE_DIR}"
   "${ATEN_BUILD_PATH}/src/TH"
   "${TORCH_SRC_DIR}/csrc/api/"
   "${TORCH_SRC_DIR}/csrc/api/include"
-  "${TORCH_SRC_DIR}/../third_party/cereal/include" # For cereal/
   "${TORCH_SRC_DIR}/../"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
-  "${CUDA_INCLUDE_DIRS}")
+  "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_include_directories(torch
-  PUBLIC
-  "${COMMON_INCLUDES}"
-  "${TORCH_SRC_DIR}/../"
+# SYSTEM headers are included with -isystem and thus do not trigger warnings.
+target_include_directories(torch SYSTEM PUBLIC
+  "${TORCH_SRC_DIR}/../third_party/cereal/include" # For cereal/
   "${TORCH_SRC_DIR}/../third_party/nanopb")
+
+if(NOT NO_CUDA)
+  target_include_directories(torch SYSTEM PUBLIC "${CUDA_INCLUDE_DIRS}")
+endif()
 
 set_target_properties(torch PROPERTIES VERSION 1 SOVERSION 1)
 
@@ -225,9 +225,7 @@ add_executable(test_jit ${TORCH_SRC_DIR}/csrc/jit/test_jit.cpp)
 target_link_libraries(test_jit torch)
 
 target_include_directories(test_jit PUBLIC
-  "${TORCH_SRC_DIR}/../"
-  "${TORCH_SRC_DIR}/../third_party/catch/single_include"
-  "${COMMON_INCLUDES}")
+  "${TORCH_SRC_DIR}/../third_party/catch/single_include")
 
 # API Tests
 

--- a/torch/csrc/api/src/containers.cpp
+++ b/torch/csrc/api/src/containers.cpp
@@ -54,7 +54,7 @@ void ContainerImpl::cuda() {
   for (auto pair : params_) {
     pair.second.data().copy_(copied[pair.first].data());
   }
-};
+}
 
 void ContainerImpl::cpu() {
   for (auto& pair : children_) {
@@ -67,7 +67,7 @@ void ContainerImpl::cpu() {
   for (auto pair : params_) {
     pair.second.data().copy_(copied[pair.first].data());
   }
-};
+}
 
 void ContainerImpl::train() {
   for (auto& pair : children_) {

--- a/torch/csrc/api/src/detail.cpp
+++ b/torch/csrc/api/src/detail.cpp
@@ -39,7 +39,7 @@ void setSeed(uint64_t seed) {
     THCRandom_manualSeedAll(at::globalContext().lazyInitCUDA(), seed);
   }
 #endif
-};
+}
 
 int getNumGPUs() {
 #if AT_CUDA_ENABLED()

--- a/torch/csrc/api/src/detail.cpp
+++ b/torch/csrc/api/src/detail.cpp
@@ -49,7 +49,7 @@ int getNumGPUs() {
     return 0;
   } else if (err != cudaSuccess) {
     std::string msg = "CUDA error (";
-    msg += std::to_string(err);
+    msg += std::to_string(static_cast<int>(err));
     msg += "): ";
     msg += cudaGetErrorString(err);
     throw std::runtime_error(msg);

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -50,6 +50,6 @@ auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   }
 
   return variable_list();
-};
+}
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -14,7 +14,7 @@ namespace torch { namespace autograd {
 
 auto Error::apply(const variable_list& grad_outputs) -> variable_list {
   throw std::runtime_error(msg);
-};
+}
 
 auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   tensor_list outputs;
@@ -26,6 +26,6 @@ auto DelayedError::apply(const variable_list& inputs) -> variable_list {
   return wrap_outputs(inputs, std::move(outputs), [&](edge_list&& next_edges) {
     return std::make_shared<Error>(msg, std::move(next_edges));
   });
-};
+}
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -30,7 +30,7 @@ auto CopyBackwards::apply(const variable_list& grads) -> variable_list {
     }
   }
   return grad_inputs;
-};
+}
 
 CopySlices::CopySlices(
     const Variable& base_var,

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -345,7 +345,9 @@ std::vector<ConcatDesc> emitCompilationUnit(std::ostream & out,
 // Note dims[0] - we need to dynamically allocate the dims.
 struct TensorInfo {
   void * data;
+#pragma GCC diagnostic ignored "-Wpedantic"
   uint32_t sizes_strides[0];
+#pragma GCC diagnostic pop
 
   uint32_t* sizes(size_t nDim) { return &sizes_strides[0]; }
   uint32_t* strides(size_t nDim) { return &sizes_strides[nDim]; }
@@ -696,7 +698,9 @@ struct CPUFusionFunction : public CompiledFusionFunction {
       disas(so_file.name());
     }
     so_lib.reset(new DynamicLibrary(so_file.name().c_str()));
+#pragma GCC diagnostic ignored "-Wpedantic"
     kernel = reinterpret_cast<void(*)(uint32_t, void**)>(so_lib->sym(name.c_str()));
+#pragma GCC diagnostic pop
   }
 protected:
   virtual at::Backend backend() const override {

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -19,7 +19,7 @@ bool tensorEqual(const at::Tensor& lhs, const at::Tensor& rhs) {
 bool tensorListEqual(const std::vector<at::Tensor>& lhs, const std::vector<at::Tensor>& rhs) {
   if (lhs.size() != rhs.size()) return false;
   return std::equal(lhs.begin(), lhs.end(), rhs.begin(), tensorEqual);
-};
+}
 
 
 // Check whether two nodes have the same attributes in CSE.

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -155,7 +155,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
   // XXX: real attributes of node can be a superset of attrs
   // XXX: if this returns true then you are obliged to set the types
   auto check_overload = [&](size_t num_inputs, size_t num_outputs,
-                            std::vector<std::pair<AttributeKind,Symbol>> attrs = {}) -> bool {
+                            std::vector<std::pair<AttributeKind,Symbol>> attrs) {
     JIT_ASSERT(!handled);
     if (node->inputs().size() != num_inputs) return false;
     if (node->outputs().size() != num_outputs) return false;
@@ -191,11 +191,11 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
       // logic in scalar cases is non-trivial. It's better to just run them.
     } break;
     case aten::neg: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
       node->output()->setType(types.at(0)->contiguous());
     } break;
     case aten::mm: {
-      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/2, /*num_outputs=*/1, {})) break;
       auto lhs_type = types.at(0);
       auto rhs_type = types.at(1);
       SHAPE_ASSERT(lhs_type->sizes().size() == 2 && rhs_type->sizes().size() == 2);
@@ -204,7 +204,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
         at::IntList{lhs_type->sizes().at(0), rhs_type->sizes().at(1)}));
     } break;
     case aten::t: {
-      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) break;
+      if (!check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) break;
       auto tp = types.at(0);
       auto sizes = tp->sizes();
       auto strides = tp->strides();
@@ -240,7 +240,7 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
           sizes.erase(sizes.begin() + dim);
         }
         node->output()->setType(tp->withSizes(sizes));
-      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1)) {
+      } else if (check_overload(/*num_inputs=*/1, /*num_outputs=*/1, {})) {
         node->output()->setType(types.at(0)->withSizes({}));
       }
     } break;

--- a/torch/csrc/utils/auto_gpu.h
+++ b/torch/csrc/utils/auto_gpu.h
@@ -59,7 +59,7 @@ private:
   static void cudaCheck(cudaError_t err) {
     if (err != cudaSuccess) {
       std::string msg = "CUDA error (";
-      msg += std::to_string(err);
+      msg += std::to_string(static_cast<int>(err));
       msg += "): ";
       msg += cudaGetErrorString(err);
       throw std::runtime_error(msg);


### PR DESCRIPTION
Enables more warnings in the C++ API build.

Fixed a bunch of things in `torch/csrc/`.

Mostly taken from [c10](https://github.com/ezyang/pytorch/blob/db5afc5da08906a4c4f1fadb1dc58f4855d35ccf/c10/CMakeLists.txt#L59)

CC @smessmer 