### PR TITLE
Remove handling workers waiting to put in dataloader.__del__

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -496,7 +496,6 @@ class TestDataLoader(TestCase):
         for w in workers:
             w.join(JOIN_TIMEOUT)
             self.assertFalse(w.is_alive(), 'subprocess not terminated')
-            self.assertEqual(w.exitcode, 0)
         worker_manager_thread.join(JOIN_TIMEOUT)
         self.assertFalse(worker_manager_thread.is_alive())
 


### PR DESCRIPTION
Now that each worker has its own queue, each worker has at most 2 batches, which should be far below SimpleQueue's limit.

Also fixes https://github.com/pytorch/pytorch/issues/6932

