### PR TITLE
A small fix for aten cmake

### DIFF
--- a/aten/src/ATen/cpu/tbb/CMakeLists.txt
+++ b/aten/src/ATen/cpu/tbb/CMakeLists.txt
@@ -50,7 +50,9 @@ endif()
 file(GLOB tbb_src "${TBB_ROOT_DIR}/src/tbb/*.cpp" "${TBB_ROOT_DIR}/src/old/*.cpp")
 list(APPEND tbb_src ${TBB_ROOT_DIR}/src/rml/client/rml_tbb.cpp)
 file(GLOB to_remove "${TBB_ROOT_DIR}/src/old/test*.cpp")
-list(REMOVE_ITEM tbb_src ${to_remove})
+if (NOT "${to_remove}" STREQUAL "")
+  list(REMOVE_ITEM tbb_src ${to_remove})
+endif()
 
 set(tbbmalloc_static_src
   src/tbbmalloc/backend.cpp


### PR DESCRIPTION
If "to_remove" is empty, then cmake fails with 
CMake Error at aten/src/ATen/cpu/tbb/CMakeLists.txt:53 (list):
  list sub-command REMOVE_ITEM requires two or more arguments.