### PR TITLE
Support getting a shared CUDA tensor on same process

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -306,6 +306,19 @@ class TestMultiprocessing(TestCase):
         self._test_sharing(mp.get_context('spawn'), torch.cuda.FloatTensor)
 
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
+    def test_cuda_same_process(self):
+        ctx = mp.get_context('spawn')
+        q = ctx.Queue()
+
+        # Add allocations before the tensor that will be shared
+        x = torch.randn(1000).cuda()
+        tensor = torch.ones(10).cuda()
+        q.put(tensor)
+
+        out = q.get()
+        self.assertEqual(out, tensor)
+
+    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     @unittest.skipIf(not TEST_MULTIGPU, 'found only 1 GPU')
     def test_cuda_small_tensors(self):
         # Check multiple small tensors which will likely use the same


### PR DESCRIPTION
Attempting to fix #7096 

Right now, if one attempts to share a CUDA tensor and get it from a
queue from the same process it was saved in, a crash can occur.

Here is some example code to demonstrate this:

```
import torch
import torch.multiprocessing as mp
import numpy.random as npr

mp.set_start_method('spawn')

q = mp.Queue()
x = torch.randn(1000).cuda()
tensor = torch.ones(10).cuda()

q.put(tensor)
out = q.get()
print(out)
```

One of two behaviors can occur:
- Crashing with an error that some "CUDA arguments are incorrect"
- The `out` tensor is valid but contains incorrect data (zeros instead
of ones).

On master the first behavior occurs but I've noticed the second behavior
happen on previous commits.

This occurs because caching of the shared storages happens differently
depending on the process. Call the process where `tensor` is created
the "originating process". When a process grabs a tensor from the queue
`q`, there are two cases:
1) The process is the "originating process". The cached storage is the
desired storage.
2) The process is not the "originating process". The cached storage (if
it has been cached) is a storage that points to the base of the
allocation. One needs to add the offset to this storage to retrieve the
desired storage.

Case (2) is OK, but the code doesn't handle case (1) right now (the
rebuilding_storage_cuda code attempts to add the offset to the desired
storage, leading to an incorrect storage pointer).

The fix in this PR is to handle case (1) separately from case (2) by:
- Including the PID of the "originating process" when reducing a storage
- Compare the current proc's PID to the PID of the "originating process"
  to determine which case we're in and handle it accordingly.

One alternative solution would be to not have this discrepancy in caching
storages depending on the process, ie, "the cached (CUDA) storage should always
point to the base of the allocation" would be made into an invariant.
I wasn't sure how to work with this because the "originating process"
would need to save a new storage into the cache that points to the base
of the allocation. There's nothing else alive in Python-land that holds
a reference to this new storage so it would be freed immediately when it
goes out of scope.

Another alternative is to just ban this behavior outright, ie, "the
originating process should never be allowed to rebuild a storage that
came from a tensor it created". Saving the pids in the `reduce_storage`
step would then be used for error checking when the storage is being
rebuilt.

cc @colesbury let me know what you think
