### PR TITLE
[caffe2][nomnigraph] Add ability to pass the old net to convertToCaffe2Proto

### DIFF
--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -413,6 +413,14 @@ caffe2::OperatorDef convertToOperatorDef(repr::NNGraph::NodeRef instrNode) {
 
 caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m) {
   auto predictNet = caffe2::NetDef();
+  return convertToCaffe2Proto(m, predictNet);
+}
+
+caffe2::NetDef convertToCaffe2Proto(repr::NNModule &m, const caffe2::NetDef& oldNet) {
+  auto predictNet = caffe2::NetDef();
+  // We copy the old net rather than mutate it.
+  predictNet.CopyFrom(oldNet);
+  predictNet.mutable_op()->Clear();
 
   repr::nn::coalesceInsertedDataDependencies(&m);
 

--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -45,6 +45,11 @@ nom::repr::NNModule convertToNNModule(caffe2::NetDef &net, std::unordered_map<st
 
 caffe2::NetDef convertToCaffe2Proto(nom::repr::NNModule&);
 
+// Pass in an oldNet to copy all the attributes of that network.
+// Be warned that transformations that modify the graph's inputs or outputs
+// are not reflected in changes to external_input or external_output.
+caffe2::NetDef convertToCaffe2Proto(nom::repr::NNModule&, const caffe2::NetDef& oldNet);
+
 std::unique_ptr<nom::repr::NeuralNetOperator> convertToOperatorDef(caffe2::OperatorDef op);
 
 } // namespace caffe2 

--- a/caffe2/opt/mobile.cc
+++ b/caffe2/opt/mobile.cc
@@ -75,7 +75,7 @@ caffe2::NetDef addNNPACK(caffe2::NetDef net, bool low_memory) {
       precompute_argument->set_s("PRECOMPUTE");
     }
   }
-  return convertToCaffe2Proto(nn);
+  return convertToCaffe2Proto(nn, net);
 }
 
 namespace {
@@ -156,7 +156,7 @@ caffe2::NetDef fuseNNPACKConvRelu(caffe2::NetDef net) {
     arg->set_name("activation");
     arg->set_s("Relu");
   }
-  return convertToCaffe2Proto(nn);
+  return convertToCaffe2Proto(nn, net);
 }
 
 } // namespace opt


### PR DESCRIPTION
This change allows you to maintain attributes associated with Caffe2 nets that are orthogonal to the execution model or somewhat non-standard.  This includes things like net.name() and external_input/output

When in doubt use the new interface as it will likely maintain what is needed for the net to be run without issue.  The one exception is if external_output is required to be modified by a transformation -- this is not yet supported by nomnigraph (such a use case is extremely rare)