### PR TITLE
Fix ReduceLROnPlateau's patience mechanic.

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -328,7 +328,7 @@ class ReduceLROnPlateau(object):
             self.cooldown_counter -= 1
             self.num_bad_epochs = 0  # ignore any bad epochs in cooldown
 
-        if self.num_bad_epochs > self.patience:
+        if self.num_bad_epochs >= self.patience:
             self._reduce_lr(epoch)
             self.cooldown_counter = self.cooldown
             self.num_bad_epochs = 0


### PR DESCRIPTION
Let's say patience = 1 and the losses are:
[1.0, 1.1, 1.2, ..., ] (we've hit a plateau). Let's also say the losses
each come at one unit per time (at the `t = 0`, we receive losses[0], etc).

`self.patience` is 1.

at `t=0`:
- `self.num_bad_epochs` is 0.
- The epoch is better than the last one (which has a "loss value" of
  `self.mode_worst`. `self.num_bad_epochs` gets set to 0.

at `t=1`:
- `self.num_bad_epochs` is 0.
- The epoch is not better than the last one (which had a "loss value" of
  `1.0`). `self.num_bad_epochs` gets set to 1.
- The LR isn't reduced, because the check
  (`self.num_bad_epochs > self.patience`) is false

at `t=2`
- `self.num_bad_epochs` is 0.
- The epoch is not better than the last one (which had a "loss value" of
  `1.1`). `self.num_bad_epochs` gets set to 2.
- The LR is reduced, because the check (`self.num_bad_epochs > self.patience`)
  is true (2 > 1)

However, I would expect that at `t=1` the LR is reduced because, in the
words of the documentation, "Number of epochs with no improvement after
which learning rate will be reduced" implies that with `patience = 1`,
after one epoch with no improvement, the LR should be reduced.

Bug was reported by @W4ngatang.

If we thing this fix is good (this might break user code, so it might be better to just change our documentation?) I'll add a test. I'm not sure what the best way to test this is; I could try mocking the optimizer.

