### PR TITLE
[do not merge as-is] Dynamic registration of THD initialization methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -716,7 +716,7 @@ if WITH_DISTRIBUTED:
         ]
         extra_compile_args += ['-DWITH_DISTRIBUTED_MW']
     include_dirs += [tmp_install_path + "/include/THD"]
-    main_link_args += [THD_LIB]
+    main_link_args += ['-Wl,--whole-archive', THD_LIB, '-Wl,--no-whole-archive']
 
 if WITH_CUDA:
     nvtoolext_lib_name = None

--- a/torch/lib/THD/base/init_methods/InitMethod.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.cpp
@@ -1,61 +1,38 @@
 #include "InitMethod.hpp"
 
-#ifdef THD_INIT_EXTENSION_H
-#define INCF(F) INCF_(F)
-#define INCF_(F) #F
-#include INCF(THD_INIT_EXTENSION_H)
-#endif
-
 namespace thd {
-namespace init {
 
-InitMethod::Config initTCP(std::string argument,
-                           int world_size_r,
-                           std::string group_name,
-                           int rank);
-InitMethod::Config initFile(std::string argument,
-                            int world_size_r,
-                            std::string group_name,
-                            int rank);
-InitMethod::Config initEnv(std::string argument,
-                           int world_size_r,
-                           std::string group_name,
-                           int rank);
+InitMethod::InitMethod() {
+}
 
-InitMethodFuncMap initMethods({
-    {"env://", ::thd::init::initEnv},
-    {"file://", ::thd::init::initFile},
-    {"tcp://", ::thd::init::initTCP}
+InitMethod::~InitMethod() {
+}
 
-#ifdef THD_INIT_EXTENSION_H
-    ,
-    /**
-     * Additional method pairs can be defined in THD_INIT_EXTENSION_H header
-     * to extend the init methods
-     */
-    THD_INIT_EXTENSION_METHODS
-#endif
-
-});
-
-} // namespace init
-
-InitMethod::Config getInitConfig(std::string argument,
-                                 int world_size,
-                                 std::string group_name,
-                                 int rank) {
-
-  InitMethod::Config config;
-
-  for (auto& methodPair : init::initMethods) {
-    auto initMethodPrefix = methodPair.first;
-    auto initMethodFunc = methodPair.second;
-    if (argument.find(initMethodPrefix) == 0) {
-      config = initMethodFunc(argument, world_size, group_name, rank);
-    }
+InitMethod::Config getInitConfig(
+    std::string argument,
+    int world_size,
+    std::string group_name,
+    int rank) {
+  // Find init method that shares prefix with the specified argument
+  const auto& keys = InitMethodRegistry()->Keys();
+  const auto& it = std::find_if(
+      keys.begin(),
+      keys.end(),
+      [&argument] (const std::string& key) -> bool {
+        return argument.find(key) == 0;
+      });
+  if (it == keys.end()) {
+    std::stringstream ss;
+    ss << "unknown init method: " << argument;
+    throw std::logic_error(ss.str());
   }
+
+  auto initMethod = InitMethodRegistry()->Create(*it);
+  auto config = initMethod->init(argument, world_size, group_name, rank);
   config.validate();
   return config;
 }
+
+AT_DEFINE_REGISTRY(InitMethodRegistry, InitMethod);
 
 } // namespace thd

--- a/torch/lib/THD/base/init_methods/InitMethod.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.hpp
@@ -1,16 +1,19 @@
 #pragma once
 
 #include "../ChannelUtils.hpp"
+#include "../Registry.h"
 
 #include <string>
 #include <stdexcept>
 #include <tuple>
 #include <unordered_map>
 
-
 namespace thd {
 
-struct InitMethod {
+// InitMethod is an abstract base class for THD initialization methods.
+// See InitMethod* files for implementations.
+class InitMethod {
+ public:
   struct Config {
     struct MasterConfig {
       int listen_socket;
@@ -63,16 +66,19 @@ struct InitMethod {
       }
     }
   };
+
+  explicit InitMethod();
+
+  virtual ~InitMethod();
+
+  virtual Config init(
+      std::string argument,
+      int world_size_r,
+      std::string group_name,
+      int assigned_rank) = 0;
 };
 
-namespace init {
-
-using InitMethodFuncMap =
-  std::unordered_map<std::string,
-  std::function<::thd::InitMethod::Config(std::string, int, std::string, int)>>;
-
-} // namespace init
-
+AT_DECLARE_REGISTRY(InitMethodRegistry, InitMethod);
 
 InitMethod::Config getInitConfig(std::string argument, int world_size = -1,
                                  std::string group_name = "", int rank = -1);

--- a/torch/lib/THD/base/init_methods/InitMethodEnv.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodEnv.cpp
@@ -2,8 +2,6 @@
 #include "InitMethodUtils.hpp"
 
 namespace thd {
-namespace init {
-
 namespace {
 
 constexpr char RANK_ENV[] = "RANK";
@@ -41,8 +39,6 @@ rank_type maybeLoadEnv(const char* env_name, int value, std::string parameter_na
   return convertToRank(env_value);
 }
 
-} // anonymous namespace
-
 InitMethod::Config initEnv(std::string argument, /* unused */
                            int world_size_r,
                            std::string group_name,
@@ -69,5 +65,24 @@ InitMethod::Config initEnv(std::string argument, /* unused */
   return config;
 }
 
-} // namespace init
+class InitMethodEnv : public InitMethod {
+ public:
+  explicit InitMethodEnv() : InitMethod() {
+  }
+
+  virtual ~InitMethodEnv() {
+  }
+
+  InitMethod::Config init(std::string argument,
+                          int world_size_r,
+                          std::string group_name,
+                          int assigned_rank) {
+    return initEnv(argument, world_size_r, group_name, assigned_rank);
+  }
+};
+
+} // anonymous namespace
+
+AT_REGISTER_TYPED_CLASS(InitMethodRegistry, "env://", InitMethodEnv);
+
 } // namespace thd

--- a/torch/lib/THD/base/init_methods/InitMethodFile.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodFile.cpp
@@ -11,8 +11,6 @@
 #include <iterator>
 
 namespace thd {
-namespace init {
-
 namespace {
 
 void lockLoop(int fd, struct flock &oflock) {
@@ -150,9 +148,6 @@ parseFile(std::fstream& file, rank_type world_size, std::string group_name) {
   return std::make_tuple(master_port, master_addrs, ranks);
 }
 
-} // anonymous namespace
-
-
 InitMethod::Config initFile(std::string argument,
                             int world_size_r,
                             std::string group_name,
@@ -232,5 +227,24 @@ InitMethod::Config initFile(std::string argument,
   return config;
 }
 
-} // namespace init
+class InitMethodFile : public InitMethod {
+ public:
+  explicit InitMethodFile() : InitMethod() {
+  }
+
+  virtual ~InitMethodFile() {
+  }
+
+  InitMethod::Config init(std::string argument,
+                          int world_size_r,
+                          std::string group_name,
+                          int assigned_rank) {
+    return initFile(argument, world_size_r, group_name, assigned_rank);
+  }
+};
+
+} // anonymous namespace
+
+AT_REGISTER_TYPED_CLASS(InitMethodRegistry, "file://", InitMethodFile);
+
 } // namespace thd

--- a/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
@@ -23,7 +23,6 @@ constexpr size_t num_rand_bytes = 32;
 constexpr size_t max_msg_length = 4000;
 
 namespace thd {
-namespace init {
 namespace {
 
 std::string getRandomString()
@@ -294,9 +293,6 @@ InitMethod::Config initTCPMulticast(std::string group_name, rank_type world_size
   return config;
 }
 
-
-} // anonymous namespace
-
 InitMethod::Config initTCP(std::string argument, int world_size_r,
                            std::string group_name, int rank) {
 
@@ -341,5 +337,24 @@ InitMethod::Config initTCP(std::string argument, int world_size_r,
   throw std::runtime_error("failed to initialize THD using given address");
 }
 
-} // namespace init
+class InitMethodTCP : public InitMethod {
+ public:
+  explicit InitMethodTCP() : InitMethod() {
+  }
+
+  virtual ~InitMethodTCP() {
+  }
+
+  InitMethod::Config init(std::string argument,
+                          int world_size_r,
+                          std::string group_name,
+                          int assigned_rank) {
+    return initTCP(argument, world_size_r, group_name, assigned_rank);
+  }
+};
+
+} // anonymous namespace
+
+AT_REGISTER_TYPED_CLASS(InitMethodRegistry, "tcp://", InitMethodTCP);
+
 } // namespace thd


### PR DESCRIPTION
This commit depends on ATen/Registry.h in #7139, so it doesn't compile yet.

The init functions can also be folded into the dynamically registered classes but I want to keep this change minimal. That can be done as follow up cleanup task and doesn't impact design.