### PR TITLE
Minor THD cleanup

### DIFF
--- a/torch/lib/THD/README.md
+++ b/torch/lib/THD/README.md
@@ -1,9 +1,0 @@
-# Dependecies
-
-- Asio C++ Library
-
-## macOS
-
-```
-brew install asio
-```

--- a/torch/lib/THD/base/DataChannel.hpp
+++ b/torch/lib/THD/base/DataChannel.hpp
@@ -5,7 +5,6 @@
 #include "DataChannel.h"
 #include "Scalar.hpp"
 #include "init_methods/InitMethod.hpp"
-#include "../master_worker/common/RPCType.hpp"
 
 #include <ATen/ATen.h>
 

--- a/torch/lib/THD/base/RPCType.cpp
+++ b/torch/lib/THD/base/RPCType.cpp
@@ -1,0 +1,21 @@
+#include "RPCType.hpp"
+
+namespace thd {
+
+// Static constexpr variables have to be defined out-of-source in C++11.
+// https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
+constexpr RPCType type_traits<char>::type;
+constexpr RPCType type_traits<int8_t>::type;
+constexpr RPCType type_traits<uint8_t>::type;
+constexpr RPCType type_traits<float>::type;
+constexpr RPCType type_traits<double>::type;
+constexpr RPCType type_traits<int16_t>::type;
+constexpr RPCType type_traits<int32_t>::type;
+constexpr RPCType type_traits<uint32_t>::type;
+constexpr RPCType type_traits<uint16_t>::type;
+constexpr RPCType type_traits<int64_t>::type;
+constexpr RPCType type_traits<uint64_t>::type;
+constexpr RPCType type_traits<std::conditional<std::is_same<int64_t, long>::value, long long, long>::type>::type;
+constexpr RPCType type_traits<std::conditional<std::is_same<uint64_t, unsigned long>::value, unsigned long long, unsigned long>::type>::type;
+
+} // thd

--- a/torch/lib/THD/base/RPCType.hpp
+++ b/torch/lib/THD/base/RPCType.hpp
@@ -76,7 +76,7 @@ template<typename T>
 struct type_traits {};
 
 // NOTE: The `type` static constexpr variables of these specializations are
-// additionally defined in master_worker/common/RPC.cpp to avoid undefined
+// additionally defined in RPCType.cpp to avoid undefined
 // reference errors in C++11.
 template<>
 struct type_traits<char> {

--- a/torch/lib/THD/base/Scalar.hpp
+++ b/torch/lib/THD/base/Scalar.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "../master_worker/common/RPCType.hpp"
 #include <cstddef>
+
+#include "RPCType.hpp"
 
 namespace thd {
 

--- a/torch/lib/THD/master_worker/common/RPC.cpp
+++ b/torch/lib/THD/master_worker/common/RPC.cpp
@@ -8,21 +8,6 @@
 #include <stdexcept>
 
 namespace thd {
-// Static constexpr variables have to be defined out-of-source in C++11.
-// https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
-constexpr RPCType type_traits<char>::type;
-constexpr RPCType type_traits<int8_t>::type;
-constexpr RPCType type_traits<uint8_t>::type;
-constexpr RPCType type_traits<float>::type;
-constexpr RPCType type_traits<double>::type;
-constexpr RPCType type_traits<int16_t>::type;
-constexpr RPCType type_traits<int32_t>::type;
-constexpr RPCType type_traits<uint32_t>::type;
-constexpr RPCType type_traits<uint16_t>::type;
-constexpr RPCType type_traits<int64_t>::type;
-constexpr RPCType type_traits<uint64_t>::type;
-constexpr RPCType type_traits<std::conditional<std::is_same<int64_t, long>::value, long long, long>::type>::type;
-constexpr RPCType type_traits<std::conditional<std::is_same<uint64_t, unsigned long>::value, unsigned long long, unsigned long>::type>::type;
 namespace rpc {
 
 RPCMessage::RPCMessage()


### PR DESCRIPTION
Code in `base/` was referring to the supposedly dead code in `master_worker/`. With this commit the one file in that directory is moved to `base/` making it completely self contained.