### PR TITLE
Fix typo in comment

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -872,7 +872,7 @@ Caffe2Ops Caffe2Backend::CreateMatMul(OnnxNode* onnx_node, int opset_version) {
 }
 
 //==============================================
-// Rest of the member funtions for Caffe2Backend
+// Rest of the member functions for Caffe2Backend
 //==============================================
 std::unordered_set<std::string>
 Caffe2Backend::AllNamesInGraph(const GraphProto &graph) {

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -240,7 +240,7 @@ class RNNCell(object):
 
     def get_state_names_override(self):
         '''
-        Override this funtion in your custom cell.
+        Override this function in your custom cell.
         It should return the names of the recurrent states.
 
         It's required by apply_over_sequence method in order to allocate


### PR DESCRIPTION
Fix typo in comment
- `funtion` to `function`
