### PR TITLE
Restore warning to torch.range.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -346,10 +346,6 @@
     - CPU
     - CUDA
   return: argument 0
-  before_arg_assign: |
-    PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "
-        "and will be removed in 0.3. Note that arange generates values in [start; end), "
-        "not [start; end].", 1);
   arguments:
     - arg: THTensor* result
       output: True

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2327,6 +2327,11 @@ class TestTorch(TestCase):
         res1 = torch.range(1, 10, 0.3, out=torch.DoubleTensor())
         self.assertEqual(res1.size(0), 31)
 
+    def test_range_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            torch.range(0, 10)
+            self.assertEqual(len(w), 1)
+
     def test_arange(self):
         res1 = torch.arange(0, 1)
         res2 = torch.Tensor()

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -19,7 +19,8 @@ SKIP_PYTHON_BINDINGS = [
     '.*_forward_out', 'sparse_raw_resize_', '_unsafe_view', 'tensor',
     'sparse_coo_tensor', '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
-    '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_sum.*', '_th_prod.*', 'arange.*',
+    '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_sum.*', '_th_prod.*',
+    'arange.*', 'range.*',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
Also, get rid of warning specification in Declarations.cwrap, which currently has no effect.

