### PR TITLE
[Caffe2] Add DLL keywords to GPU module.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -222,20 +222,23 @@ list(APPEND Caffe2_MAIN_LIBS caffe2_library)
 
 # ---[ CUDA library.
 if(USE_CUDA)
+  set(__tmp_CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS})
+
   # A hack to deal with cuda library dependencies and modern CMake: the
   # CUDA_ADD_LIBRARY includes a target_link_libraries, and as a result,
   # one cannot use PUBLIC/PRIVATE/INTERFACE for the target anymore. This
   # hack adds the PRIVATE keywords to CUDA_LIBRARIES so we can deal with
   # it. We will then manually add the cudart library as interface libs.
-  set(__tmp ${CUDA_LIBRARIES})
-  set(CUDA_LIBRARIES PRIVATE ${CUDA_LIBRARIES})
+  set(__tmp_CUDA_LINK_LIBRARIES_KEYWORD ${CUDA_LINK_LIBRARIES_KEYWORD})
+  set(CUDA_LINK_LIBRARIES_KEYWORD PRIVATE)
+  list(APPEND CUDA_NVCC_FLAGS "-DCAFFE2_BUILD_GPU_LIB")
   if(CAFFE2_STATIC_LINK_CUDA)
     torch_cuda_based_add_library(caffe2_gpu STATIC ${Caffe2_GPU_SRCS})
   else()
     torch_cuda_based_add_library(caffe2_gpu ${Caffe2_GPU_SRCS})
   endif()
-  set(CUDA_LIBRARIES ${__tmp})
   target_link_libraries(caffe2_gpu INTERFACE caffe2::cudart)
+  target_compile_options(caffe2_gpu PRIVATE "-DCAFFE2_BUILD_GPU_LIB")
 
   target_include_directories(
       caffe2_gpu INTERFACE $<INSTALL_INTERFACE:include>)
@@ -256,6 +259,9 @@ if(USE_CUDA)
   install(TARGETS caffe2_gpu EXPORT Caffe2Targets DESTINATION lib)
   caffe2_interface_library(caffe2_gpu caffe2_gpu_library)
   list(APPEND Caffe2_MAIN_LIBS caffe2_gpu_library)
+
+  set(CUDA_LINK_LIBRARIES_KEYWORD ${__tmp_CUDA_LINK_LIBRARIES_KEYWORD})
+  set(CUDA_NVCC_FLAGS ${__tmp_CUDA_NVCC_FLAGS})
 endif()
 
 # ---[ Caffe2 HIP sources.

--- a/caffe2/core/common_gpu.h
+++ b/caffe2/core/common_gpu.h
@@ -25,6 +25,18 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/common.h"
 
+// CAFFE2_GPU_API is a macro that, depends on whether you are building the main
+// caffe2_gpu library or not, resolves to either CAFFE2_EXPORT or CAFFE2_IMPORT.
+//
+// This is used in e.g. Caffe2 GPU Context files: when building the main library,
+// it is defined as CAFFE2_EXPORT to fix a Windows global-variable-in-dll issue,
+// and for anyone dependent on Caffe2 GPU it will be defined as CAFFE2_IMPORT.
+#ifdef CAFFE2_BUILD_GPU_LIB
+#define CAFFE2_GPU_API CAFFE2_EXPORT
+#else
+#define CAFFE2_GPU_API CAFFE2_IMPORT
+#endif
+
 // This is a macro defined for cuda fp16 support. In default, cuda fp16 is
 // supported by NVCC 7.5, but it is also included in the Tegra X1 platform with
 // a (custom?) NVCC 7.0. As a result, we would normally just check the cuda

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -137,8 +137,8 @@ class ThreadLocalCUDAObjects {
 class CUDAContext final {
  public:
   // The default cuda context constructor.
-  explicit CUDAContext(const int gpu_id = -1);
-  explicit CUDAContext(const DeviceOption& option);
+  CAFFE2_GPU_API explicit CUDAContext(const int gpu_id = -1);
+  CAFFE2_GPU_API explicit CUDAContext(const DeviceOption& option);
 
   ~CUDAContext() {
     if (curand_generator_) {
@@ -164,13 +164,7 @@ class CUDAContext final {
     ev->Record(CUDA, this, err_msg);
   }
 
-  void FinishDeviceComputation() {
-    cudaStreamSynchronize(cuda_objects_.GetStream(gpu_id_, stream_id_));
-    cudaError_t error = cudaGetLastError();
-    if (error != cudaSuccess) {
-      CAFFE_THROW("Encountered CUDA error: ", cudaGetErrorString(error));
-    }
-  }
+  CAFFE2_GPU_API void FinishDeviceComputation();
 
   inline int cuda_gpu_id() const {
     return gpu_id_;
@@ -184,18 +178,12 @@ class CUDAContext final {
     return cuda_stream(gpu_id_, stream_id_);
   }
 
-  static cudaStream_t cuda_stream(int gpu_id, int stream_id) {
-    return cuda_objects_.GetStream(gpu_id, stream_id);
-  }
+  CAFFE2_GPU_API static cudaStream_t cuda_stream(int gpu_id, int stream_id);
 
-  cublasHandle_t cublas_handle() {
-    return cuda_objects_.GetHandle(gpu_id_, stream_id_);
-  }
+  CAFFE2_GPU_API cublasHandle_t cublas_handle();
 
 #ifdef CAFFE2_USE_CUDNN
-  cudnnHandle_t cudnn_handle() {
-    return cuda_objects_.GetCudnnHandle(gpu_id_, stream_id_);
-  }
+  CAFFE2_GPU_API cudnnHandle_t cudnn_handle();
 #endif // CAFFE2_USE_CUDNN
 
   curandGenerator_t& curand_generator() {
@@ -211,17 +199,17 @@ class CUDAContext final {
     return curand_generator_;
   }
 
-  static std::pair<void*, MemoryDeleter> New(size_t nbytes);
+  CAFFE2_GPU_API static std::pair<void*, MemoryDeleter> New(size_t nbytes);
 
   // Get a mutex to lock out cudaMalloc / cudaFree calls when
   // NCCL kernels are being launched. Should remove threat of
   // deadlocks
-  static std::mutex& mutex();
+  CAFFE2_GPU_API static std::mutex& mutex();
 
   // Functions to query memory stats. Only available if flag
   // --caffe2_gpu_memory_tracking is enabled.
-  static std::vector<long> TotalMemoryByGpu();
-  static std::vector<long> MaxMemoryByGpu();
+  CAFFE2_GPU_API static std::vector<long> TotalMemoryByGpu();
+  CAFFE2_GPU_API static std::vector<long> MaxMemoryByGpu();
 
   template <class SrcContext, class DstContext>
   inline void CopyBytes(size_t nbytes, const void* src, void* dst) {
@@ -230,7 +218,7 @@ class CUDAContext final {
         src,
         nbytes,
         cudaMemcpyDefault,
-        cuda_objects_.GetStream(gpu_id_, stream_id_)));
+		get_cuda_objects_().GetStream(gpu_id_, stream_id_)));
   }
 
   template <typename T, class SrcContext, class DstContext>
@@ -262,7 +250,7 @@ class CUDAContext final {
   }
 
  protected:
-  static void Delete(void* data);
+  CAFFE2_GPU_API static void Delete(void* data);
   void set_stream_id(int stream_id) {
     stream_id_ = stream_id;
   }
@@ -272,6 +260,8 @@ class CUDAContext final {
   int random_seed_;
   curandGenerator_t curand_generator_{nullptr};
   static thread_local ThreadLocalCUDAObjects cuda_objects_;
+
+  CAFFE2_GPU_API static ThreadLocalCUDAObjects& get_cuda_objects_();
 };
 
 // For the CPU context, we also allow a (probably expensive) function


### PR DESCRIPTION
1. Make it possible to build both CPU/GPU as DLL, by introducing `CAFFE2_BUILD_GPU_LIB`.
2. Move access of thread_local variable out of header, or use proxy function when necessary, because Visual Studio doesn't like `__declspec(dllexport) thread_local`.
3. Pass `CAFFE2_BUILD_GPU_LIB` by both `CUDA_NVCC_FLAGS` and `target_compile_options()` because host flag propagation is turned off.
