### PR TITLE
added state_dict/load_state_dict for ReduceLROnPlateau

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -655,7 +655,7 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(scheduler.state_dict())
         for key in scheduler.__dict__.keys():
             if key not in {'optimizer', 'is_better'}:
-                self.assertAlmostEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
 
     def _check_scheduler_state_dict(self, constr, constr2, epochs=10):
         scheduler = constr()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -647,6 +647,16 @@ class TestLRScheduler(TestCase):
             lambda: CosineAnnealingLR(self.opt, T_max=epochs // 2, eta_min=eta_min / 2),
             epochs=epochs)
 
+    def test_reduce_lr_on_plateau_state_dict(self):
+        scheduler = ReduceLROnPlateau(self.opt, mode='min', factor=0.1, patience=2)
+        for score in [1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0, 3.0, 2.0, 1.0]:
+            scheduler.step(score)
+        scheduler_copy = ReduceLROnPlateau(self.opt, mode='max', factor=0.5, patience=10)
+        scheduler_copy.load_state_dict(scheduler.state_dict())
+        for key in scheduler.__dict__.keys():
+            if key not in {'optimizer', 'is_better'}:
+                self.assertAlmostEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+
     def _check_scheduler_state_dict(self, constr, constr2, epochs=10):
         scheduler = constr()
         for _ in range(epochs):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -655,7 +655,7 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(scheduler.state_dict())
         for key in scheduler.__dict__.keys():
             if key not in {'optimizer', 'is_better'}:
-                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key], allow_inf=True)
 
     def _check_scheduler_state_dict(self, constr, constr2, epochs=10):
         scheduler = constr()

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -374,3 +374,10 @@ class ReduceLROnPlateau(object):
             self.mode_worse = (-float('inf'))
 
         self.is_better = partial(self._cmp, mode, threshold_mode, threshold)
+
+    def state_dict(self):
+        return {key: value for key, value in self.__dict__.items() if key not in {'optimizer', 'is_better'}}
+
+    def load_state_dict(self, state_dict):
+        self.__dict__.update(state_dict)
+        self._init_is_better(mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode)


### PR DESCRIPTION
There is a merged PR #5300 trying to make ReduceLROnPlateau serializable and resolve issue #5218. However, it's still not working. Moreover, it's more consistent to provide the common state_dict/load_state_dict interface for serialization.