### PR TITLE
Support passing the same CUDA tensor between multiple processes

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -306,6 +306,19 @@ class TestMultiprocessing(TestCase):
         self._test_sharing(mp.get_context('spawn'), torch.cuda.FloatTensor)
 
     @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
+    def test_cuda_same_process(self):
+        ctx = mp.get_context('spawn')
+        q = ctx.Queue()
+
+        # Add allocations before the tensor that will be shared
+        x = torch.randn(1000).cuda()
+        tensor = torch.ones(10).cuda()
+        q.put(tensor)
+
+        out = q.get()
+        self.assertEqual(out, tensor)
+
+    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     @unittest.skipIf(not TEST_MULTIGPU, 'found only 1 GPU')
     def test_cuda_small_tensors(self):
         # Check multiple small tensors which will likely use the same

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -323,9 +323,6 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
 static PyObject * THPStorage_(weakRef)(THPStorage *self, PyObject *weak_ref_class) {
   HANDLE_TH_ERRORS
   THStorage* storage = self->cdata;
-  while (storage->flag & TH_STORAGE_VIEW) {
-    storage = storage->view;
-  }
   bool hasWeakAllocator;
 #ifdef THC_GENERIC_FILE
   hasWeakAllocator = storage->allocator == &THCStorageWeakRefAllocator;
@@ -354,39 +351,6 @@ static PyObject * THPStorage_(weakRef)(THPStorage *self, PyObject *weak_ref_clas
   return ref.release();
   END_HANDLE_TH_ERRORS
 }
-
-static PyObject * THPStorage_(weakRefNoUnwrap)(THPStorage *self, PyObject *weak_ref_class) {
-  HANDLE_TH_ERRORS
-  THStorage* storage = self->cdata;
-  bool hasWeakAllocator;
-#ifdef THC_GENERIC_FILE
-  hasWeakAllocator = storage->allocator == &THCStorageWeakRefAllocator;
-#else
-  hasWeakAllocator = storage->allocator == &THStorageWeakRefAllocator;
-#endif
-  if (hasWeakAllocator) {
-    auto allocator_obj = ((StorageWeakRefAllocator*)storage->allocatorContext);
-    Py_INCREF(allocator_obj->object.get());
-    return allocator_obj->object.get();
-  }
-
-  THPObjectPtr args(Py_BuildValue("(N)", PyLong_FromVoidPtr(storage)));
-  if (!args) return NULL;
-  THPObjectPtr ref(PyObject_Call(weak_ref_class, args, NULL));
-  if (!ref) return NULL;
-#ifdef THC_GENERIC_FILE
-  storage->allocatorContext = new CudaStorageWeakRefAllocator(
-        ref.get(), storage->allocator, storage->allocatorContext);
-  storage->allocator = &THCStorageWeakRefAllocator;
-#else
-  storage->allocatorContext = new StorageWeakRefAllocator(
-        ref.get(), storage->allocator, storage->allocatorContext);
-  storage->allocator = &THStorageWeakRefAllocator;
-#endif
-  return ref.release();
-  END_HANDLE_TH_ERRORS
-}
-
 
 PyObject * THPStorage_(newWithWeakPtr)(PyObject *_unused, PyObject *arg)
 {
@@ -472,7 +436,6 @@ static PyMethodDef THPStorage_(sharingMethods)[] = {
   {"_new_using_filename", (PyCFunction)THPStorage_(pyNewFilenameStorage), METH_VARARGS | METH_STATIC, NULL},
 #endif
   {"_weak_ref", (PyCFunction)THPStorage_(weakRef), METH_O, NULL},
-  {"_weak_ref_no_unwrap", (PyCFunction)THPStorage_(weakRefNoUnwrap), METH_O, NULL},
   {"_new_view", (PyCFunction)THPStorage_(newView), METH_VARARGS, NULL},
   {"_shared_decref", (PyCFunction)THPStorage_(sharedDecref), METH_NOARGS, NULL},
   {"_shared_incref", (PyCFunction)THPStorage_(sharedIncref), METH_NOARGS, NULL},


### PR DESCRIPTION
Fixes #7096.

This PR is an update to #7146

# Problem
Right now, if one attempts to share a CUDA tensor and get it from a
queue from the same process it was saved in, a crash can occur.

Here is some example code to demonstrate this:

```
import torch
import torch.multiprocessing as mp
import numpy.random as npr

mp.set_start_method('spawn')

q = mp.Queue()
x = torch.randn(1000).cuda()
tensor = torch.ones(10).cuda()

q.put(tensor)
out = q.get()
print(out)
```

One of two behaviors can occur:
- Crashing with an error that some "CUDA arguments are incorrect"
- The `out` tensor is valid but contains incorrect data (zeros instead
of ones).

On master the first behavior occurs but I've noticed the second behavior
happen on previous commits.

This occurs because caching of the shared storages happens differently
depending on the process. Call the process where `tensor` is created
the "originating process". When a process grabs a tensor from the queue
`q`, there are two cases:
1) The process is the "originating process". The cached storage is
sometimes the desired storage.
2) The process is not the "originating process". The cached storage (if
it has been cached) is a storage that points to the base of the
allocation. One needs to add the offset to this storage to retrieve the
desired storage.

Case (2) is OK, but the code doesn't handle case (1) right now (the
rebuilding_storage_cuda code attempts to add the offset to whatever is
cached, leading to an incorrect storage pointer).

# Solution: New CUDA storage caching strategy

After discussion with @colesbury 

All CUDA storages are cached into the new 'cuda_cache' that has two 
(well, actually three) components: a 'real cache' and a 'base cache'. 
All CPU storages are cached into the original 'shared_cache'.

Call a "CUDA storage that processes wish to share" a "real storage".
"real storages" are the storages that other processes want to and
eventually will receive.

Call a "CUDA storage that points to the base of an allocation block" a
"base storage". These are obtained by opening CUDA handles to the
base of an allocation block, where multiple "real storages" may live.
Those "real storages" can be obtained by adding an offset to "base storage"

"base storages" are cached into the "base cache" and "real storages" are
cached into the "real cache"

When a process shares a cuda storage:
- If the cuda storage is from opening a received handle, find the handle
  in the metadata cache and send the returned metadata.
- If the cuda storage is from allocating storage, get the handle, build
  the metadata, and send it.

When a process receives a cuda storage:
- Check the caches:
  - Check the "real cache" for the real storage.
  - If it's not there, look in the "base cache".
  - If the storage exists in the "base cache", recreate the real storage by
    add it to the "base storage"
- If it's not in the caches, recreate the real and base storages and cache
  both.
- In addition, if this process received a handle that it has opened
  (either now or in the past), we cache the storage's metadata in the
  metadata cache. This is so that the process can access the handle
  to send to other processes.
  A process that didn't open a handle (the process that allocated the storage)
  doesn't cache the metadata.

"base storages" are uniquely identified by their CUDA handle.
"real storages" are uniquely identified by (handle, offset).