### PR TITLE
Use Glog's implementation of STL logging when possible.

### DIFF
--- a/caffe2/core/logging_is_google_glog.h
+++ b/caffe2/core/logging_is_google_glog.h
@@ -8,23 +8,30 @@
 // it. Some mobile platforms do not like stl_logging, so we add an
 // overload in that case as well.
 
-#if !defined(__CUDACC__) && !defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
+#ifdef __CUDACC__
+#include <cuda.h>
+#endif
+
+#if (!defined(__CUDACC__) || CUDA_VERSION > 9000 ) && !defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
 #include <glog/stl_logging.h>
-#else // !defined(__CUDACC__) && !!defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
+#else // (!defined(__CUDACC__) || CUDA_VERSION > 9000 ) && !defined(CAFFE2_USE_MINIMAL_GOOGLE_GLOG)
 
 // here, we need to register a fake overload for vector/string - here,
 // we just ignore the entries in the logs.
 
-#define INSTANTIATE_FOR_CONTAINER(container)                                \
-  template <class... Types>                                                 \
-  std::ostream& operator<<(std::ostream& out, const container<Types...>&) { \
-    return out;                                                             \
-  }
+namespace std
+{
+  #define INSTANTIATE_FOR_CONTAINER(container)                      \
+    template <class... Types>                                       \
+    ostream& operator<<(ostream& out, const container<Types...>&) { \
+      return out;                                                   \
+    }
 
-INSTANTIATE_FOR_CONTAINER(std::vector)
-INSTANTIATE_FOR_CONTAINER(std::map)
-INSTANTIATE_FOR_CONTAINER(std::set)
-#undef INSTANTIATE_FOR_CONTAINER
+  INSTANTIATE_FOR_CONTAINER(vector)
+  INSTANTIATE_FOR_CONTAINER(map)
+  INSTANTIATE_FOR_CONTAINER(set)
+  #undef INSTANTIATE_FOR_CONTAINER
+}
 
 #endif
 


### PR DESCRIPTION
Inject custom workaround into namespace `std` so that it can be found by ADL.

Both Visual Studio (if I remove https://github.com/pytorch/pytorch/blob/1d5780d42c53552fe66a54fda9ee84d3e5a88caa/caffe2/core/logging_is_google_glog.h#L11-L13) and nvcc raise "function not found" errors if we keep these STL `<<` in global namespace.

This is what glog does:
https://github.com/google/glog/blob/v0.3.5/src/glog/stl_logging.h.in#L218
https://github.com/google/glog/blob/v0.3.5/src/windows/glog/stl_logging.h#L105-L107
https://github.com/google/glog/blob/v0.3.5/src/windows/glog/stl_logging.h#L222

Technically speaking, extending std is undefined behavior.
But haven't seen any compiler trying to turn this kind of UB into error.
http://en.cppreference.com/w/cpp/language/extending_std