### PR TITLE
Remove unneeded entry for NCCL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,9 +11,6 @@
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
 	url = https://github.com/pybind/pybind11.git
-[submodule "third_party/nccl"]
-	path = third_party/nccl
-	url = https://github.com/nvidia/nccl.git
 [submodule "third_party/cub"]
 	path = third_party/cub
 	url = https://github.com/NVlabs/cub.git


### PR DESCRIPTION
NCCL currently is not a git submodule.

The NCCL source code is bundled in 'third_party/nccl'.

Closes #7150
