### PR TITLE
Use SYSTEM option for SLEEF headers

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -373,7 +373,7 @@ TARGET_LINK_LIBRARIES(ATen cpuinfo)
 # ---[ Configure SLEEF
 IF(NOT TARGET sleef)
   add_subdirectory("cpu/sleef")
-  include_directories(${CMAKE_BINARY_DIR}/include)
+  include_directories(SYSTEM ${CMAKE_BINARY_DIR}/include)
 ENDIF()
 TARGET_LINK_LIBRARIES(ATen sleef)
 


### PR DESCRIPTION
This prevents warnings caused by the headers.