### PR TITLE
Disabling opencv for integrated conda builds

### DIFF
--- a/scripts/build_anaconda.sh
+++ b/scripts/build_anaconda.sh
@@ -327,6 +327,8 @@ fi
 
 if [[ -z $slim ]]; then
   add_package 'opencv'
+else
+  caffe2_cmake_args+=("-DUSE_OPENCV=OFF")
 fi
 
 # Flags required for CUDA for Caffe2


### PR DESCRIPTION
Need an explicit flag since opencv is on by default