### PR TITLE
Add unbuffered flag to distributed node launcher

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -193,6 +193,7 @@ def main():
 
         # spawn the processes
         cmd = ["python",
+               "-u",
                args.training_script,
                "--local_rank={}".format(local_rank)] + args.training_script_args
 


### PR DESCRIPTION
I've found very cumbersome to launch parallel processes using ``nohup`` and redirecting all processes' output to a single file. While each line should be written immediately, right now they are written once the buffer has filled up. 

By adding the unbuffered flag also to all spawned processes, this error should be corrected. 