### PR TITLE
Clarify patience in ReduceLROnPlateau docs

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -239,7 +239,9 @@ class ReduceLROnPlateau(object):
         factor (float): Factor by which the learning rate will be
             reduced. new_lr = lr * factor. Default: 0.1.
         patience (int): Number of epochs with no improvement after
-            which learning rate will be reduced. Default: 10.
+            which learning rate will be reduced. i.e., if `patience = 2`,
+            then after 2 "bad" epochs, if the 3rd epoch is also "bad", then
+            the LR will be reduced after the 3rd epoch. Default: 10.
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
         threshold (float): Threshold for measuring the new optimum,

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -239,9 +239,11 @@ class ReduceLROnPlateau(object):
         factor (float): Factor by which the learning rate will be
             reduced. new_lr = lr * factor. Default: 0.1.
         patience (int): Number of epochs with no improvement after
-            which learning rate will be reduced. i.e., if `patience = 2`,
-            then after 2 "bad" epochs, if the 3rd epoch is also "bad", then
-            the LR will be reduced after the 3rd epoch. Default: 10.
+            which learning rate will be reduced. For example, if
+            `patience = 2`, then we will ignore the first 2 epochs
+            with no improvement, and will only decrease the LR after the
+            3rd epoch if the loss still hasn't improved then.
+            Default: 10.
         verbose (bool): If ``True``, prints a message to stdout for
             each update. Default: ``False``.
         threshold (float): Threshold for measuring the new optimum,


### PR DESCRIPTION
It's unclear which definition of patience we have. The two ways to
interpret it are:
- How many bad epochs can you see before you start considering changing the learning rate.
- How many bad epochs can you see before you change the learning rate.

This PR clarifies the docs with an example. If `patience = 2`, then
after 2 bad epochs, we begin considering changing the learning rate.
After seeing one more epoch (the 3rd epoch), if that epoch is also bad,
then we change the learning rate after it.

Followup to #7151 

cc @apaszke 
