### PR TITLE
Resolve name conflict of ContextManager

### DIFF
--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -39,7 +39,7 @@ class ContextInfo(object):
         return self._stack[-1]
 
 
-class ContextManager(object):
+class ContextRegistry(object):
     def __init__(self):
         self._ctxs = {}
 
@@ -54,23 +54,23 @@ class ContextManager(object):
         return self._ctxs[cls]
 
 
-_CONTEXT_MANAGER = ContextManager()
+_CONTEXT_REGISTRY = ContextRegistry()
 
 
-def context_manager():
-    global _CONTEXT_MANAGER
-    return _CONTEXT_MANAGER
+def context_registry():
+    global _CONTEXT_REGISTRY
+    return _CONTEXT_REGISTRY
 
 
 def __enter__(self):
     if self._prev_enter is not None:
         self._prev_enter()
-    context_manager().get(self._ctx_class).enter(self)
+    context_registry().get(self._ctx_class).enter(self)
     return self
 
 
 def __exit__(self, *args):
-    context_manager().get(self._ctx_class).exit(self)
+    context_registry().get(self._ctx_class).exit(self)
     if self._prev_exit is not None:
         self._prev_exit(*args)
 
@@ -97,20 +97,25 @@ class define_context(object):
         assert not hasattr(cls, '_ctx_class'), (
             '%s parent class (%s) already defines context.' % (
                 cls, cls._ctx_class))
-        context_manager().register(
-            ContextInfo(cls, self.allow_default, self.arg_name))
+        cls._ctx_class = cls
+
+        context_registry().register(
+            ContextInfo(cls, self.allow_default, self.arg_name)
+        )
+
         cls._prev_enter = cls.__enter__ if hasattr(cls, '__enter__') else None
         cls._prev_exit = cls.__exit__ if hasattr(cls, '__exit__') else None
-        cls._ctx_class = cls
+
         cls.__enter__ = __enter__
         cls.__exit__ = __exit__
         cls.__call__ = __call__
         cls.current = current
+
         return cls
 
 
 def get_active_context(cls, val=None, required=True):
-    ctx_info = context_manager().get(cls)
+    ctx_info = context_registry().get(cls)
     if val is not None:
         assert isinstance(val, cls), (
             'Wrong context type. Expected: %s, got %s.' % (cls, type(val)))

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -65,12 +65,12 @@ def _context_registry():
 def __enter__(self):
     if self._prev_enter is not None:
         self._prev_enter()
-    context_registry().get(self._ctx_class).enter(self)
+    _context_registry().get(self._ctx_class).enter(self)
     return self
 
 
 def __exit__(self, *args):
-    context_registry().get(self._ctx_class).exit(self)
+    _context_registry().get(self._ctx_class).exit(self)
     if self._prev_exit is not None:
         self._prev_exit(*args)
 

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -9,7 +9,7 @@ import threading
 import six
 
 
-class ContextInfo(object):
+class _ContextInfo(object):
     def __init__(self, cls, allow_default, arg_name):
         self.cls = cls
         self.allow_default = allow_default
@@ -39,12 +39,12 @@ class ContextInfo(object):
         return self._stack[-1]
 
 
-class ContextRegistry(object):
+class _ContextRegistry(object):
     def __init__(self):
         self._ctxs = {}
 
     def register(self, ctx_info):
-        assert isinstance(ctx_info, ContextInfo)
+        assert isinstance(ctx_info, _ContextInfo)
         assert (ctx_info.cls not in self._ctxs), (
             'Context %s already registered' % ctx_info.cls)
         self._ctxs[ctx_info.cls] = ctx_info
@@ -54,10 +54,10 @@ class ContextRegistry(object):
         return self._ctxs[cls]
 
 
-_CONTEXT_REGISTRY = ContextRegistry()
+_CONTEXT_REGISTRY = _ContextRegistry()
 
 
-def context_registry():
+def _context_registry():
     global _CONTEXT_REGISTRY
     return _CONTEXT_REGISTRY
 
@@ -84,8 +84,8 @@ def __call__(self, func):
 
 
 @classmethod
-def current(cls, value=None, required=True):
-    return get_active_context(cls, value, required)
+def _current(cls, value=None, required=True):
+    return _get_active_context(cls, value, required)
 
 
 class define_context(object):
@@ -99,8 +99,8 @@ class define_context(object):
                 cls, cls._ctx_class))
         cls._ctx_class = cls
 
-        context_registry().register(
-            ContextInfo(cls, self.allow_default, self.arg_name)
+        _context_registry().register(
+            _ContextInfo(cls, self.allow_default, self.arg_name)
         )
 
         cls._prev_enter = cls.__enter__ if hasattr(cls, '__enter__') else None
@@ -109,12 +109,12 @@ class define_context(object):
         cls.__enter__ = __enter__
         cls.__exit__ = __exit__
         cls.__call__ = __call__
-        cls.current = current
+        cls.current = _current
 
         return cls
 
 
-def get_active_context(cls, val=None, required=True):
+def _get_active_context(cls, val=None, required=True):
     ctx_info = context_registry().get(cls)
     if val is not None:
         assert isinstance(val, cls), (

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -115,7 +115,7 @@ class define_context(object):
 
 
 def _get_active_context(cls, val=None, required=True):
-    ctx_info = context_registry().get(cls)
+    ctx_info = _context_registry().get(cls)
     if val is not None:
         assert isinstance(val, cls), (
             'Wrong context type. Expected: %s, got %s.' % (cls, type(val)))


### PR DESCRIPTION
Concept name `ContextManager` is taken by Python. See https://docs.python.org/3.6/reference/datamodel.html#with-statement-context-managers

It says,

> A context manager is an object that defines the runtime context to be established when executing a with statement. The context manager handles the entry into, and the exit from, the desired runtime context for the execution of the block of code.

The `ContextManager` abstraction here (created by Caffe2 team) is different from the `ContextManager` in Python
The `ContextManager` here is more like a registry. 

Notice that there is a C++ `Registry` class in caffe2 codebase `caffe2/caffe2/core/registry.h`.
There is also a `Caffe2DBRegistry`, declared by calling `CAFFE_DECLARE_REGISTRY(Caffe2DBRegistry, DB, const string&, Mode);` in `caffe2/caffe2/core/db.h`.

So I think we'd better follow the concept name `Registry`, calling it `ContextRegistry`.

