### PR TITLE
Add support for __floordiv__ and __rdiv__ for integral tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1003,6 +1003,28 @@ class TestTorch(TestCase):
             res2[i, 3] = res2[i, 3] / 2
         self.assertEqual(res1, res2)
 
+    def test_floordiv(self):
+        for dtype in torch.testing.get_all_dtypes():
+            if dtype is torch.float16:
+                continue
+            x = torch.randn(100).mul(10).to(dtype)
+            y = x // 3
+            self.assertEqual(y.dtype, x.dtype)
+            z = torch.tensor([math.trunc(v.item() / 3) for v in x], dtype=y.dtype)
+            self.assertEqual(y, z)
+
+    def test_rdiv(self):
+        for dtype in torch.testing.get_all_dtypes():
+            if dtype is torch.float16:
+                continue
+            x = torch.rand(10).add(1).mul(4).to(dtype)
+            y = 30 / x
+            if dtype.is_floating_point:
+                z = torch.tensor([30 / v.item() for v in x], dtype=dtype)
+            else:
+                z = torch.tensor([math.trunc(30. / v.item()) for v in x], dtype=dtype)
+            self.assertEqual(y, z)
+
     def test_fmod(self):
         m1 = torch.Tensor(10, 10).uniform_(-10., 10.)
         res1 = m1.clone()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1010,14 +1010,14 @@ class TestTorch(TestCase):
             x = torch.randn(100).mul(10).to(dtype)
             y = x // 3
             self.assertEqual(y.dtype, x.dtype)
-            z = torch.tensor([math.trunc(v.item() / 3) for v in x], dtype=y.dtype)
+            z = torch.tensor([math.trunc(v.item() / 3.) for v in x], dtype=y.dtype)
             self.assertEqual(y, z)
 
     def test_rdiv(self):
         for dtype in torch.testing.get_all_dtypes():
             if dtype is torch.float16:
                 continue
-            x = torch.rand(10).add(1).mul(4).to(dtype)
+            x = torch.rand(100).add(1).mul(4).to(dtype)
             y = 30 / x
             if dtype.is_floating_point:
                 z = torch.tensor([30 / v.item() for v in x], dtype=dtype)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -317,7 +317,11 @@ class Tensor(torch._C._TensorBase):
         return -self + other
 
     def __rdiv__(self, other):
-        return self.reciprocal() * other
+        if self.dtype.is_floating_point:
+            return self.reciprocal() * other
+        else:
+            return (self.double().reciprocal() * other).type_as(self)
+
     __rtruediv__ = __rdiv__
     __itruediv__ = _C._TensorBase.__idiv__
 
@@ -333,6 +337,18 @@ class Tensor(torch._C._TensorBase):
 
     def __rpow__(self, other):
         return self.new([other]) ** self
+
+    def __floordiv__(self, other):
+        result = self / other
+        if result.dtype.is_floating_point:
+            result = result.trunc()
+        return result
+
+    def __rfloordiv__(self, other):
+        result = other / self
+        if result.dtype.is_floating_point:
+            result = result.trunc()
+        return result
 
     __neg__ = _C._TensorBase.neg
 


### PR DESCRIPTION
This commit adds support for `__floordiv__` to all tensors. I checked that it behaves similarly to what NumPy does, i.e. always returns a result of the same type. On the other hand, NumPy seems to follow the Python rules for rounding, while I used the C rules, to make it conform with how our integral division behaves in general.

This also adds support for `__rdiv__` with integral tensors. Previously it raised an error saying that `reciprocal` isn't implemented for them. Ideally we would just have a kernel for this, but I didn't want to make this patch too large, as it's mostly meant to unblock my other work.