### PR TITLE
Extend support to arbitrary ops in init net when converting c2 models to onnx

### DIFF
--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -390,7 +390,6 @@ class TestCaffe2End2End(TestCase):
     def test_inception_v2(self):
         self._test_net('inception_v2')
 
-    @unittest.skip('Need to add support for ConstantFill operator')
     def test_squeezenet(self):
         self._test_net('squeezenet')
 


### PR DESCRIPTION
Instead of pattern match each individual op, we change to run init_net once and then dump all blobs from the c2 workspace to onnx initializers
