### PR TITLE
A clip grad fix for sparse tensors.

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -31,7 +31,7 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2):
     clip_coef = max_norm / (total_norm + 1e-6)
     if clip_coef < 1:
         for p in parameters:
-            p.grad.data.mul_(clip_coef)
+            p.grad.data.mul_(clip_coef.item())
     return total_norm
 
 


### PR DESCRIPTION
Currently 

```.py
import torch

i = torch.LongTensor([[2, 4]])
v = torch.FloatTensor([[1, 3], [5, 7]])
var = torch.sparse.FloatTensor(i, v)
var.requires_grad = True
var.grad = var.clone().detach()

torch.nn.utils.clip_grad_norm_([var,], 2, norm_type=2)
```
will fail with the error:
```
torch/nn/utils/clip_grad.py", line 35, in clip_grad_norm_
    p.grad.data.mul_(clip_coef)
RuntimeError: Expected object of type torch.sparse.FloatTensor but found type torch.FloatTensor for argument #3 'other'
```

Adding `.item()` to `clip_coef` prevents this error.