### PR TITLE
Add memory leak check in CUDA tests

### DIFF
--- a/aten/src/THC/THCCachingAllocator.cpp
+++ b/aten/src/THC/THCCachingAllocator.cpp
@@ -233,7 +233,7 @@ struct THCCachingAllocator
       return insert_events(block);
     }
 
-    free_block(block);
+    mark_block_as_free(block);
     return cudaSuccess;
   }
 
@@ -241,11 +241,11 @@ struct THCCachingAllocator
   cudaError_t emptyCache()
   {
     std::lock_guard<std::mutex> lock(mutex);
-    cudaError_t err = free_blocks(large_blocks, large_blocks.begin(), large_blocks.end());
+    cudaError_t err = release_cached_blocks_between(large_blocks, large_blocks.begin(), large_blocks.end());
     if (err != cudaSuccess) {
       return err;
     }
-    err = free_blocks(small_blocks, small_blocks.begin(), small_blocks.end());
+    err = release_cached_blocks_between(small_blocks, small_blocks.begin(), small_blocks.end());
     if (err != cudaSuccess) {
       return err;
     }
@@ -312,18 +312,18 @@ struct THCCachingAllocator
   }
 
   /** moves a block into the free block list */
-  void free_block(Block* block)
+  void mark_block_as_free(Block* block)
   {
     THAssert(!block->allocated && block->event_count == 0);
     bool small = block->size <= kSmallAlloc;
     auto& free_blocks = small ? large_blocks : small_blocks;
-    try_merge_blocks(block, block->prev, free_blocks);
-    try_merge_blocks(block, block->next, free_blocks);
+    try_merge_free_blocks(block, block->prev, free_blocks);
+    try_merge_free_blocks(block, block->next, free_blocks);
     free_blocks.insert(block);
   }
 
   /** combine previously split blocks */
-  void try_merge_blocks(Block* dst, Block* src, FreeBlocks& free_blocks)
+  void try_merge_free_blocks(Block* dst, Block* src, FreeBlocks& free_blocks)
   {
     if (!src || src->allocated || src->event_count > 0) {
       return;
@@ -364,7 +364,7 @@ struct THCCachingAllocator
     cudaError_t err = cudaMalloc(devPtr, size);
     if (err != cudaSuccess) {
       cudaGetLastError();
-      err = free_cached_blocks(device);
+      err = empty_cache_on(device);
       if (err != cudaSuccess) {
         return err;
       }
@@ -376,27 +376,27 @@ struct THCCachingAllocator
     return cudaSuccess;
   }
 
-  cudaError_t free_cached_blocks(int device)
+  cudaError_t empty_cache_on(int device)
   {
     // Free all non-split cached blocks on device
     Block lower_bound(device, NULL, 0);
     Block upper_bound(device + 1, NULL, 0);
 
-    cudaError_t err = free_blocks(
+    cudaError_t err = release_cached_blocks_between(
         large_blocks,
         large_blocks.lower_bound(&lower_bound),
         large_blocks.lower_bound(&upper_bound));
     if (err != cudaSuccess) {
       return err;
     }
-    err = free_blocks(
+    err = release_cached_blocks_between(
         small_blocks,
         small_blocks.lower_bound(&lower_bound),
         small_blocks.lower_bound(&upper_bound));
     return err;
   }
 
-  cudaError_t free_blocks(FreeBlocks& blocks, FreeBlocks::iterator it, FreeBlocks::iterator end)
+  cudaError_t release_cached_blocks_between(FreeBlocks& blocks, FreeBlocks::iterator it, FreeBlocks::iterator end)
   {
     // Frees all non-split blocks between `it` and `end`
     std::lock_guard<std::mutex> lock(cuda_free_mutex);
@@ -483,7 +483,7 @@ struct THCCachingAllocator
 
       block->event_count--;
       if (block->event_count == 0) {
-        free_block(block);
+        mark_block_as_free(block);
       }
       cuda_events.pop_front();
     }

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -87,6 +87,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
 
   THCTensor_(free)(state, input);
   THCIndexTensor_(free)(state, target);
+  THCTensor_(free)(state, istarget);
 }
 
 void THNN_(MultiLabelMarginCriterion_updateGradInput)(

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -230,6 +230,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   }
 
   THCTensor_(free)(state, input);
+  THCTensor_(free)(state, gradOutput);
   if(weights)
     THCTensor_(free)(state, weights);
 }

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -117,16 +117,21 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
 
   input = THCTensor_(newContiguous)(state, input);
   indices = THCIndexTensor_(newContiguous)(state, indices);
+  output = THCTensor_(newContiguous)(state, output);
   THCTensor_(zero)(state, output);
 
   if (fiveDimensionalInput) {
     // Collapse batch and feature dimensions
+    // newFoldBatchDim assumes contiguity so the newContiguous calls must
+    // preceed this
+    THCTensor *old_output = output;
     output = THCTensor_(newFoldBatchDim)(state, output);
+    THCTensor_(free)(state, old_output);
 
     THCTensor *old_input = input;
     input = THCTensor_(newFoldBatchDim)(state, input);
     THCTensor_(free)(state, old_input);
-    
+
     THCIndexTensor *old_indices = indices;
     indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
     THCIndexTensor_(free)(state, old_indices);
@@ -134,7 +139,6 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
     THCTensor_(retain)(state, output);
   }
 
-  output = THCTensor_(newContiguous)(state, output);
   real* outputData = THCTensor_(data)(state, output);
 
   THCDeviceTensor<real, 4> cudaInput;
@@ -221,7 +225,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
     THCIndexTensor *old_indices = indices;
     indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
     THCIndexTensor_(free)(state, old_indices);
-  
+
     THCTensor *old_gradOutput = gradOutput;
     gradOutput = THCTensor_(newFoldBatchDim)(state, gradOutput);
     THCTensor_(free)(state, old_gradOutput);

--- a/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/aten/src/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -135,8 +135,6 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
     THCIndexTensor *old_indices = indices;
     indices = THCIndexTensor_(newFoldBatchDim)(state, indices);
     THCIndexTensor_(free)(state, old_indices);
-  } else {
-    THCTensor_(retain)(state, output);
   }
 
   real* outputData = THCTensor_(data)(state, output);

--- a/test/common.py
+++ b/test/common.py
@@ -139,7 +139,9 @@ _cuda_ctx_rng_initialized = False
 # operations in `test`.
 def make_cuda_memory_checked_test(test):
     global _cuda_ctx_rng_initialized
-    if TEST_CUDA and not _cuda_ctx_rng_initialized:
+    if not TEST_CUDA:
+        return test
+    elif not _cuda_ctx_rng_initialized:
         # initialize cuda context and rng for memory tests
         for i in range(torch.cuda.device_count()):
             torch.randn(1, device="cuda:{}".format(i))

--- a/test/common.py
+++ b/test/common.py
@@ -159,7 +159,7 @@ def is_iterable(obj):
 class TestCase(unittest.TestCase):
     precision = 1e-5
     maxDiff = None
-    doCUDAMemoryCheck = True
+    doCUDAMemoryCheck = False
 
     def setUp(self):
         set_rng_seed(SEED)

--- a/test/common.py
+++ b/test/common.py
@@ -82,8 +82,8 @@ def skipIfNoLapack(fn):
     return wrapper
 
 
-def skipCUDAMemoryCheck(fn):
-    fn._do_cuda_memory_check = False
+def skipCUDAMemoryLeakCheck(fn):
+    fn._do_cuda_memory_leak_check = False
     return fn
 
 
@@ -177,16 +177,16 @@ def is_iterable(obj):
 class TestCase(unittest.TestCase):
     precision = 1e-5
     maxDiff = None
-    _do_cuda_memory_check = False
+    _do_cuda_memory_leak_check = False
 
     def __init__(self, method_name='runTest'):
         super(TestCase, self).__init__(method_name)
         # Wraps the tested method if we should do CUDA memory check.
         test_method = getattr(self, method_name)
-        self._do_cuda_memory_check &= getattr(test_method, '_do_cuda_memory_check', True)
-        if self._do_cuda_memory_check:
+        self._do_cuda_memory_leak_check &= getattr(test_method, '_do_cuda_memory_leak_check', True)
+        if self._do_cuda_memory_leak_check:
             # the import below may initialize CUDA context, so we do it only if
-            # self._do_cuda_memory_check is True.
+            # self._do_cuda_memory_leak_check is True.
             from common_cuda import TEST_CUDA
             fullname = self.id().lower()  # class_name.method_name
             if TEST_CUDA and ('gpu' in fullname or 'cuda' in fullname):

--- a/test/common.py
+++ b/test/common.py
@@ -10,6 +10,7 @@ import os
 import platform
 import re
 import gc
+import types
 import inspect
 import argparse
 import unittest
@@ -203,14 +204,14 @@ class TestCase(unittest.TestCase):
         #       passes or not. For the same reason, we can't wrap the `method`
         #       call in try-finally and always do the check.
         @wraps(method)
-        def wrapper(*args, **kwargs):
+        def wrapper(self, *args, **kwargs):
             befores = get_cuda_memory_usage()
             method(*args, **kwargs)
             afters = get_cuda_memory_usage()
             for i, (before, after) in enumerate(zip(befores, afters)):
                 self.assertEqual(before, after, '{} leaked {} bytes CUDA memory on device {}'.format(
                                  self.id(), after - before, i))
-        return wrapper
+        return types.MethodType(wrapper, self)
 
     def setUp(self):
         set_rng_seed(SEED)

--- a/test/common.py
+++ b/test/common.py
@@ -155,8 +155,7 @@ def make_cuda_memory_checked_test(test):
         gc.collect()
         ends = tuple(torch.cuda.memory_allocated(i) for i in range(num_devices))
         for i, (start, end) in enumerate(zip(starts, ends)):
-            test.assertEqual(start, end,
-                             '{} leaked {} bytes CUDA memory on device {}'.format(
+            test.assertEqual(start, end, '{} leaked {} bytes CUDA memory on device {}'.format(
                              test, end - start, i))
 
     return cuda_memory_checked_test

--- a/test/common.py
+++ b/test/common.py
@@ -87,9 +87,10 @@ def skipCUDAMemoryCheck(fn):
 
 
 def get_cuda_memory_usage():
+    # we don't need CUDA synchronize because the statistics are not tracked at
+    # actual freeing, but at when marking the block as free.
     num_devices = torch.cuda.device_count()
     gc.collect()
-    torch.cuda.synchronize()
     return tuple(torch.cuda.memory_allocated(i) for i in range(num_devices))
 
 

--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -1,4 +1,4 @@
-r"""This file may initialize CUDA context when imported."""
+r"""This file is allowed to initialize CUDA context when imported."""
 
 import torch
 import torch.cuda

--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -1,0 +1,27 @@
+r"""This file may initialize CUDA context when imported."""
+
+import torch
+import torch.cuda
+
+
+TEST_CUDA = torch.cuda.is_available()
+TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
+CUDA_DEVICE = TEST_CUDA and torch.device("cuda:0")
+TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1, device=CUDA_DEVICE))
+TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
+
+
+# Used below in `initialize_cuda_context_rng` to ensure that CUDA context and
+# RNG have been initialized.
+__cuda_ctx_rng_initialized = False
+
+
+# after this call, CUDA context and RNG must have been initialized on each GPU
+def initialize_cuda_context_rng():
+    global __cuda_ctx_rng_initialized
+    assert TEST_CUDA, 'CUDA must be available when calling initialize_cuda_context_rng'
+    if not __cuda_ctx_rng_initialized:
+        # initialize cuda context and rng for memory tests
+        for i in range(torch.cuda.device_count()):
+            torch.randn(1, device="cuda:{}".format(i))
+        __cuda_ctx_rng_initialized = True

--- a/test/common_cuda.py
+++ b/test/common_cuda.py
@@ -7,7 +7,7 @@ import torch.cuda
 TEST_CUDA = torch.cuda.is_available()
 TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
 CUDA_DEVICE = TEST_CUDA and torch.device("cuda:0")
-TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1, device=CUDA_DEVICE))
+TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.tensor(1., device=CUDA_DEVICE))
 TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
 
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -6,7 +6,8 @@ from itertools import product
 
 import torch
 import torch.cuda
-from common import TestCase, to_gpu, freeze_rng_state, is_iterable
+from common import TestCase, to_gpu, freeze_rng_state, is_iterable, TEST_CUDA, \
+    TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 import torch.backends.cudnn
 
@@ -15,11 +16,6 @@ if sys.version_info[:2] == (3, 3):
     TemporaryFile = tempfile.NamedTemporaryFile
 else:
     TemporaryFile = tempfile.TemporaryFile
-
-TEST_CUDA = torch.cuda.is_available()
-TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
-TEST_CUDNN = TEST_CUDA and torch.backends.cudnn.is_acceptable(torch.cuda.FloatTensor(1))
-TEST_CUDNN_VERSION = TEST_CUDNN and torch.backends.cudnn.version()
 PRECISION = 1e-5
 
 

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -6,10 +6,11 @@ from itertools import product
 
 import torch
 import torch.cuda
-from common import TestCase, to_gpu, freeze_rng_state, is_iterable, TEST_CUDA, \
-    TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
+from common import TestCase, to_gpu, freeze_rng_state, is_iterable
+from common_cuda import TEST_CUDA
 from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 import torch.backends.cudnn
+
 
 # tarfile module tries to obtain a file object name in python 3.3
 if sys.version_info[:2] == (3, 3):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -74,7 +74,7 @@ def get_shell_output(command):
 
 def run_test(python, test_module, test_directory, options):
     verbose = '--verbose' if options.verbose else ''
-    return shell('{} -m unittest {} {}'.format(python, verbose, test_module),
+    return shell('{} {}.py {}'.format(python, test_module, verbose),
                  test_directory)
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -74,6 +74,8 @@ def get_shell_output(command):
 
 def run_test(python, test_module, test_directory, options):
     verbose = '--verbose' if options.verbose else ''
+    # Can't call `python -m unittest test_*` here because it doesn't run code
+    # in `if __name__ == '__main__': `. So call `python test_*.py` instead.
     return shell('{} {}.py {}'.format(python, test_module, verbose),
                  test_directory)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1682,7 +1682,7 @@ class TestCuda(TestCase):
         with self.assertRaisesRegex(AssertionError, r"leaked \d+ bytes CUDA memory on device 0"):
             self.run_with_cuda_memory_check(leak_gpu0)
 
-        if torch.cuda.device_count() > 1:
+        if TEST_MULTIGPU:
             with self.assertRaisesRegex(AssertionError, r"leaked \d+ bytes CUDA memory on device 1"):
                 self.run_with_cuda_memory_check(leak_gpu1)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1755,7 +1755,7 @@ if __name__ == '__main__':
     #    hide in __name__ == '__main__' because we don't want this to be run
     #    when someone imports test_cuda
     #
-    # 2. wrap all tests in with CUDA memory check
+    # 2. wrap all tests with CUDA memory check
     def load_tests(loader, tests, pattern):
         test_suite = unittest.TestSuite()
         for test_group in tests:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -568,6 +568,7 @@ def compare_cpu_gpu(tensor_constructor, arg_constructor, fn, t, precision=1e-5):
 
 
 class TestCuda(TestCase):
+    doCUDAMemoryCheck = True
 
     @staticmethod
     def _test_memory_stats_generator(self, device=None, N=35):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -574,7 +574,7 @@ def compare_cpu_gpu(tensor_constructor, arg_constructor, fn, t, precision=1e-5):
 
 
 class TestCuda(TestCase):
-    _do_cuda_memory_check = True
+    _do_cuda_memory_leak_check = True
 
     @staticmethod
     def _test_memory_stats_generator(self, device=None, N=35):
@@ -1664,7 +1664,7 @@ class TestCuda(TestCase):
         b = a.half()
         self.assertGreater(b.norm().item(), 0)
 
-    # Test that make_cuda_memory_checked_test successfully detects leak
+    # Test that wrap_with_cuda_memory_check successfully detects leak
     def test_cuda_memory_leak_detection(self):
         l = []
 

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -900,6 +900,7 @@ if BACKEND == 'tcp' or BACKEND == 'gloo' or BACKEND == 'nccl':
     WORLD_SIZE = os.environ['WORLD_SIZE']
 
     class TestDistBackend(TestCase, _DistTestBase):
+        doCUDAMemoryCheck = False
 
         MANAGER_PROCESS_RANK = -1
 
@@ -995,7 +996,10 @@ elif BACKEND == 'mpi':
     dist.init_process_group(init_method=INIT_METHOD, backend='mpi')
 
     class TestMPI(TestCase, _DistTestBase):
+        doCUDAMemoryCheck = False
         pass
 
 if __name__ == '__main__':
+    assert not torch.cuda._initialized, "test_distributed must not have initialized CUDA context on main process"
+
     unittest.main()

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -900,8 +900,6 @@ if BACKEND == 'tcp' or BACKEND == 'gloo' or BACKEND == 'nccl':
     WORLD_SIZE = os.environ['WORLD_SIZE']
 
     class TestDistBackend(TestCase, _DistTestBase):
-        doCUDAMemoryCheck = False
-
         MANAGER_PROCESS_RANK = -1
 
         @staticmethod
@@ -996,7 +994,6 @@ elif BACKEND == 'mpi':
     dist.init_process_group(init_method=INIT_METHOD, backend='mpi')
 
     class TestMPI(TestCase, _DistTestBase):
-        doCUDAMemoryCheck = False
         pass
 
 if __name__ == '__main__':

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -31,6 +31,7 @@ from random import shuffle
 
 import torch
 from common import TestCase, run_tests, set_rng_seed
+from common_cuda import TEST_CUDA
 from torch.autograd import Variable, grad, gradcheck
 from torch.distributions import (Bernoulli, Beta, Binomial, Categorical,
                                  Cauchy, Chi2, Dirichlet, Distribution,
@@ -62,8 +63,6 @@ try:
     import scipy.special
 except ImportError:
     TEST_NUMPY = False
-
-TEST_CUDA = torch.cuda.is_available()
 
 
 def pairwise(Dist, *params):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -577,6 +577,8 @@ def unwrap(value):
 
 
 class TestDistributions(TestCase):
+    doCUDAMemoryCheck = True
+
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):
         # performs gradient checks on log_prob
         distribution = dist_ctor(*ctor_params)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -577,7 +577,7 @@ def unwrap(value):
 
 
 class TestDistributions(TestCase):
-    doCUDAMemoryCheck = True
+    _do_cuda_memory_check = True
 
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):
         # performs gradient checks on log_prob

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -577,7 +577,7 @@ def unwrap(value):
 
 
 class TestDistributions(TestCase):
-    _do_cuda_memory_check = True
+    _do_cuda_memory_leak_check = True
 
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):
         # performs gradient checks on log_prob

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import torch
 import torch.legacy.nn as nn
-from common import to_gpu, freeze_rng_state, run_tests, TEST_CUDA
+from common import to_gpu, freeze_rng_state, run_tests
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, PRECISION
 from torch.autograd.gradcheck import get_numerical_jacobian

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import torch
 import torch.legacy.nn as nn
-from common import to_gpu, freeze_rng_state, run_tests, skipCUDAMemoryCheck
+from common import to_gpu, freeze_rng_state, run_tests
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, PRECISION
 from torch.autograd.gradcheck import get_numerical_jacobian

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import torch
 import torch.legacy.nn as nn
-from common import to_gpu, freeze_rng_state, run_tests
+from common import to_gpu, freeze_rng_state, run_tests, skipCUDAMemoryCheck
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, PRECISION
 from torch.autograd.gradcheck import get_numerical_jacobian
@@ -652,7 +652,7 @@ def require_grad(input):
 
 
 class TestNN(NNTestCase):
-    doCUDAMemoryCheck = True
+    _do_cuda_memory_check = True
 
     def _numerical_jacobian(self, module, input, jacobian_input=True, jacobian_parameters=True):
         def fw(input):

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -6,10 +6,10 @@ from copy import deepcopy
 
 import torch
 import torch.legacy.nn as nn
+from common import to_gpu, freeze_rng_state, run_tests, TEST_CUDA
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
-    module_tests, criterion_tests, TEST_CUDA, PRECISION
+    module_tests, criterion_tests, PRECISION
 from torch.autograd.gradcheck import get_numerical_jacobian
-from common import to_gpu, freeze_rng_state, run_tests
 from torch.autograd import Variable
 
 

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -652,6 +652,7 @@ def require_grad(input):
 
 
 class TestNN(NNTestCase):
+    doCUDAMemoryCheck = True
 
     def _numerical_jacobian(self, module, input, jacobian_input=True, jacobian_parameters=True):
         def fw(input):

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -652,7 +652,7 @@ def require_grad(input):
 
 
 class TestNN(NNTestCase):
-    _do_cuda_memory_check = True
+    _do_cuda_memory_leak_check = True
 
     def _numerical_jacobian(self, module, input, jacobian_input=True, jacobian_parameters=True):
         def fw(input):

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -14,7 +14,6 @@ if not TEST_CUDA:
 
 
 class TestNCCL(TestCase):
-    doCUDAMemoryCheck = False
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self):

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -5,14 +5,16 @@ import torch.cuda.nccl as nccl
 import torch.cuda
 
 from common import TestCase, run_tests, IS_WINDOWS
+from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
-nGPUs = torch.cuda.device_count()
-if nGPUs == 0:
+
+if not TEST_CUDA:
     print('CUDA not available, skipping tests')
     TestCase = object  # noqa: F811
 
 
 class TestNCCL(TestCase):
+    doCUDAMemoryCheck = False
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self):
@@ -21,7 +23,7 @@ class TestNCCL(TestCase):
         self.assertGreater(len(uid), 1)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(nGPUs < 2, "only one GPU detected")
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_broadcast(self):
         expected = torch.FloatTensor(128).uniform_()
         tensors = [expected.cuda()]
@@ -34,7 +36,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensors[i], expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(nGPUs < 2, "only one GPU detected")
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.FloatTensor(128).zero_()
@@ -47,7 +49,7 @@ class TestNCCL(TestCase):
         self.assertEqual(tensors[0], expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(nGPUs < 2, "only one GPU detected")
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_all_reduce(self):
         tensors = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.FloatTensor(128).zero_()
@@ -61,7 +63,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensor, expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(nGPUs < 2, "only one GPU detected")
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_all_gather(self):
         inputs = [torch.FloatTensor(128).uniform_() for i in range(nGPUs)]
         expected = torch.cat(inputs, 0)
@@ -75,7 +77,7 @@ class TestNCCL(TestCase):
             self.assertEqual(tensor, expected)
 
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
-    @unittest.skipIf(nGPUs < 2, "only one GPU detected")
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_reduce_scatter(self):
         in_size = 32 * nGPUs
         out_size = 32

--- a/test/test_nccl.py
+++ b/test/test_nccl.py
@@ -8,6 +8,7 @@ from common import TestCase, run_tests, IS_WINDOWS
 from common_cuda import TEST_CUDA, TEST_MULTIGPU
 
 
+nGPUs = torch.cuda.device_count()
 if not TEST_CUDA:
     print('CUDA not available, skipping tests')
     TestCase = object  # noqa: F811

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,7 +27,8 @@ from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist
+    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist, \
+    skipCUDAMemoryCheck
 from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     TEST_CUDNN_VERSION
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
@@ -60,6 +61,7 @@ dtype2prec = {torch.float: 1e-5,
 # Used to run the same test with different tensor types
 def repeat_test_for_types(dtypes):
     def repeat_helper(f):
+        @warps(f)
         def call_helper(self, *args):
             for dtype in dtypes:
                 if PY34:
@@ -4924,6 +4926,7 @@ class TestNN(NNTestCase):
                          F.conv1d(input, weights2, bias=None, stride=2, dilation=2))
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @skipCUDAMemoryCheck
     @repeat_test_for_types(DOUBLE_TENSORTYPES)
     def test_conv_double_backward_cuda(self, dtype=torch.double):
         # Double backward only runs with DoubleTensor due to precison reason

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7377,7 +7377,7 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 if __name__ == '__main__':
-    # wrap all CUDA tests in with CUDA memory check
+    # wrap all CUDA tests with CUDA memory check
     def load_tests(loader, tests, pattern):
         test_suite = unittest.TestSuite()
         for test_group in tests:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -463,6 +463,8 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
 
 class TestNN(NNTestCase):
+    doCUDAMemoryCheck = True
+
     def _forward(self, module, input):
         with freeze_rng_state():
             return module(input)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -61,7 +61,7 @@ dtype2prec = {torch.float: 1e-5,
 # Used to run the same test with different tensor types
 def repeat_test_for_types(dtypes):
     def repeat_helper(f):
-        @warps(f)
+        @wraps(f)
         def call_helper(self, *args):
             for dtype in dtypes:
                 if PY34:
@@ -4613,7 +4613,7 @@ class TestNN(NNTestCase):
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingLinear1d(self):
-        m = nn.Upsample(size=4, mode='linear')
+        m = nn.Upsample(size=4, mode='linear', align_corners=True)
         in_t = torch.ones(1, 1, 2)
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4), out_t.data)
@@ -4643,7 +4643,7 @@ class TestNN(NNTestCase):
         gradgradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingBilinear2d(self):
-        m = nn.Upsample(size=4, mode='bilinear')
+        m = nn.Upsample(size=4, mode='bilinear', align_corners=True)
         in_t = torch.ones(1, 1, 2, 2)
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4), out_t.data)
@@ -4669,7 +4669,7 @@ class TestNN(NNTestCase):
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingTrilinear3d(self):
-        m = nn.Upsample(size=4, mode='trilinear')
+        m = nn.Upsample(size=4, mode='trilinear', align_corners=True)
         in_t = torch.ones(1, 1, 2, 2, 2)
         out_t = m(Variable(in_t))
         self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t.data)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,8 +27,7 @@ from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist, \
-    skipCUDAMemoryCheck
+    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist
 from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     TEST_CUDNN_VERSION
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
@@ -465,7 +464,7 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
 
 class TestNN(NNTestCase):
-    doCUDAMemoryCheck = True
+    _do_cuda_memory_check = True
 
     def _forward(self, module, input):
         with freeze_rng_state():
@@ -4935,7 +4934,6 @@ class TestNN(NNTestCase):
                          F.conv1d(input, weights2, bias=None, stride=2, dilation=2))
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @skipCUDAMemoryCheck
     @repeat_test_for_types(DOUBLE_TENSORTYPES)
     def test_conv_double_backward_cuda(self, dtype=torch.double):
         # Double backward only runs with DoubleTensor due to precison reason

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -27,12 +27,13 @@ from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION, \
-    download_file, PY3, PY34, to_gpu, get_function_arglist, \
-    make_cuda_memory_checked_test
+    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist
+from common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
+    TEST_CUDNN_VERSION
 from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
     module_tests, criterion_tests, loss_reference_fns, get_size_average, \
     get_weight, smoothl1loss_reference, kldivloss_reference
+
 
 if TEST_SCIPY:
     from scipy import stats
@@ -7377,16 +7378,4 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 if __name__ == '__main__':
-    # wrap all CUDA tests with CUDA memory check
-    def load_tests(loader, tests, pattern):
-        test_suite = unittest.TestSuite()
-        for test_group in tests:
-            for test in test_group:
-                if '_cuda' in test.id().lower():
-                    # add memory checks
-                    test_suite.addTest(make_cuda_memory_checked_test(test))
-                else:
-                    test_suite.addTest(test)
-        return test_suite
-
     run_tests()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -464,7 +464,7 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
 
 
 class TestNN(NNTestCase):
-    _do_cuda_memory_check = True
+    _do_cuda_memory_leak_check = True
 
     def _forward(self, module, input):
         with freeze_rng_state():

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4613,13 +4613,16 @@ class TestNN(NNTestCase):
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingLinear1d(self):
-        m = nn.Upsample(size=4, mode='linear', align_corners=True)
-        in_t = torch.ones(1, 1, 2)
-        out_t = m(Variable(in_t))
-        self.assertEqual(torch.ones(1, 1, 4), out_t.data)
+        for align_corners in [True, False]:
+            kwargs = dict(mode='linear', align_corners=align_corners)
 
-        input = torch.randn(1, 1, 2, requires_grad=True)
-        gradcheck(lambda x: F.upsample(x, 4, mode='linear'), (input,))
+            m = nn.Upsample(size=4, **kwargs)
+            in_t = torch.ones(1, 1, 2)
+            out_t = m(Variable(in_t))
+            self.assertEqual(torch.ones(1, 1, 4), out_t.data)
+
+            input = torch.randn(1, 1, 2, requires_grad=True)
+            gradcheck(lambda x: F.upsample(x, 4, **kwargs), (input,))
 
     def test_upsamplingLinear1d_spatial_invariance(self):
         m = nn.Upsample(scale_factor=3, mode='linear', align_corners=False)
@@ -4643,13 +4646,16 @@ class TestNN(NNTestCase):
         gradgradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingBilinear2d(self):
-        m = nn.Upsample(size=4, mode='bilinear', align_corners=True)
-        in_t = torch.ones(1, 1, 2, 2)
-        out_t = m(Variable(in_t))
-        self.assertEqual(torch.ones(1, 1, 4, 4), out_t.data)
+        for align_corners in [True, False]:
+            kwargs = dict(mode='bilinear', align_corners=align_corners)
 
-        input = torch.randn(1, 1, 2, 2, requires_grad=True)
-        gradcheck(lambda x: F.upsample(x, 4, mode='bilinear'), [input])
+            m = nn.Upsample(size=4, **kwargs)
+            in_t = torch.ones(1, 1, 2, 2)
+            out_t = m(Variable(in_t))
+            self.assertEqual(torch.ones(1, 1, 4, 4), out_t.data)
+
+            input = torch.randn(1, 1, 2, 2, requires_grad=True)
+            gradcheck(lambda x: F.upsample(x, 4, **kwargs), [input])
 
     def test_upsamplingBilinear2d_spatial_invariance(self):
         m = nn.Upsample(scale_factor=3, mode='bilinear', align_corners=False)
@@ -4669,17 +4675,20 @@ class TestNN(NNTestCase):
         gradcheck(lambda x: F.upsample(x, 4, mode='nearest'), [input])
 
     def test_upsamplingTrilinear3d(self):
-        m = nn.Upsample(size=4, mode='trilinear', align_corners=True)
-        in_t = torch.ones(1, 1, 2, 2, 2)
-        out_t = m(Variable(in_t))
-        self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t.data)
+        for align_corners in [True, False]:
+            kwargs = dict(mode='trilinear', align_corners=align_corners)
 
-        input = torch.randn(1, 1, 2, 2, 2, requires_grad=True)
-        self.assertEqual(
-            F.upsample(input, (4, 4, 4), mode='trilinear'),
-            F.upsample(input, scale_factor=2, mode='trilinear'))
-        gradcheck(lambda x: F.upsample(x, 4, mode='trilinear'), [input])
-        gradgradcheck(lambda x: F.upsample(x, 4, mode='trilinear'), [input])
+            m = nn.Upsample(size=4, **kwargs)
+            in_t = torch.ones(1, 1, 2, 2, 2)
+            out_t = m(Variable(in_t))
+            self.assertEqual(torch.ones(1, 1, 4, 4, 4), out_t.data)
+
+            input = torch.randn(1, 1, 2, 2, 2, requires_grad=True)
+            self.assertEqual(
+                F.upsample(input, (4, 4, 4), **kwargs),
+                F.upsample(input, scale_factor=2, **kwargs))
+            gradcheck(lambda x: F.upsample(x, 4, **kwargs), [input])
+            gradgradcheck(lambda x: F.upsample(x, 4, **kwargs), [input])
 
     def test_upsamplingTrilinear3d_spatial_invariance(self):
         m = nn.Upsample(scale_factor=3, mode='trilinear', align_corners=False)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -26,12 +26,13 @@ from torch.autograd import Variable, gradcheck
 from torch.autograd.gradcheck import gradgradcheck
 from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
-from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
-    module_tests, criterion_tests, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
-    TEST_CUDNN_VERSION, loss_reference_fns, get_size_average, get_weight, \
-    smoothl1loss_reference, kldivloss_reference
 from common import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, \
-    TEST_SCIPY, download_file, PY3, PY34, to_gpu, get_function_arglist
+    TEST_SCIPY, TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION, \
+    download_file, PY3, PY34, to_gpu, get_function_arglist, \
+    make_cuda_memory_checked_test
+from common_nn import NNTestCase, ModuleTest, CriterionTest, TestBase, \
+    module_tests, criterion_tests, loss_reference_fns, get_size_average, \
+    get_weight, smoothl1loss_reference, kldivloss_reference
 
 if TEST_SCIPY:
     from scipy import stats
@@ -7376,4 +7377,16 @@ add_test(NewModuleTest(
     check_gradgrad=False,))
 
 if __name__ == '__main__':
+    # wrap all CUDA tests in with CUDA memory check
+    def load_tests(loader, tests, pattern):
+        test_suite = unittest.TestSuite()
+        for test_group in tests:
+            for test in test_group:
+                if '_cuda' in test.id().lower():
+                    # add memory checks
+                    test_suite.addTest(make_cuda_memory_checked_test(test))
+                else:
+                    test_suite.addTest(test)
+        return test_suite
+
     run_tests()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4,7 +4,8 @@ from torch import sparse
 import itertools
 import random
 import unittest
-from common import TEST_CUDA, TestCase, run_tests
+from common import TestCase, run_tests
+from common_cuda import TEST_CUDA
 from test_torch import TestTorch
 from numbers import Number
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4,8 +4,7 @@ from torch import sparse
 import itertools
 import random
 import unittest
-from common import TestCase, run_tests
-from common_nn import TEST_CUDA
+from common import TEST_CUDA, TestCase, run_tests
 from test_torch import TestTorch
 from numbers import Number
 


### PR DESCRIPTION
With `torch.cuda.memory_allocated` available, we can test if CUDA methods have memory leaks. This PR adds a wrapper around each CUDA test. It checks if the CUDA memory usage before and after stay constant.

Also move `TEST_CUDA`, `TEST_MULTIGPU`, `TEST_CUDNN`, `TEST_CUDNN_VERSION` to `common_cuda.py`.