### PR TITLE
Fixes RNN shapes for C++ API

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -56,5 +56,5 @@ if [[ "$BUILD_TEST_LIBTORCH" == "1" ]]; then
      "$CPP_BUILD"/libtorch/bin/test_jit "[cpu]"
    fi
    python tools/download_mnist.py --quiet -d test/cpp/api/mnist
-   "$CPP_BUILD"/libtorch/bin/test_api
+   OMP_NUM_THREADS=2 "$CPP_BUILD"/libtorch/bin/test_api
 fi

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -89,7 +89,7 @@ TEST_CASE("optim") {
                      .append(Linear(8, 1).make())
                      .make();
 
-    auto optim = Adam(model, 1.0).weight_decay(1e-6).make();
+    auto optim = Adam(model, 1e-1).weight_decay(1e-6).make();
     REQUIRE(test_optimizer_xor(optim, model));
   }
 

--- a/torch/csrc/api/include/torch/containers.h
+++ b/torch/csrc/api/include/torch/containers.h
@@ -375,13 +375,16 @@ class RNNBase : public Container_CRTP<Derived> {
 
   variable_list forward(variable_list) override;
   void initialize_containers() override;
+  void initialize_parameters() override;
   void reset_parameters() override;
 
   void cpu() override;
   void cuda() override;
 
-  std::vector<Container> i2h;
-  std::vector<Container> h2h;
+  std::vector<Variable> ihw;
+  std::vector<Variable> ihb;
+  std::vector<Variable> hhw;
+  std::vector<Variable> hhb;
 
  protected:
   uint32_t input_size_;


### PR DESCRIPTION
- Correctly fixes the LSTM shapes for the C++ API. I had a bug where two shapes (hx, cx) and nlayers were the same, so it did not catch a bug where they were transposed. It's fine when loading models from scratch, but when you move between backends or try to load models it fails in subtle ways `containers.cpp:476`
- Makes the parameter names match pytorch, and order matches as well (weight|bias)_l# instead of l#.(weight|bias)
- Adds OMP_NUM_THREADS=1 to the tests, which makes them significantly faster.