### PR TITLE
Fix bug that introduced in pull #3280

### DIFF
--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -9,7 +9,7 @@ import tempfile
 
 try:
     from requests.utils import urlparse
-    import requests.get as urlopen
+    from requests import get as urlopen
     requests_available = True
 except ImportError:
     requests_available = False
@@ -67,11 +67,12 @@ def load_url(url, model_dir=None, map_location=None, progress=True):
 
 
 def _download_url_to_file(url, dst, hash_prefix, progress):
-    u = urlopen(url)
     if requests_available:
+        u = urlopen(url, stream=True)
         file_size = int(u.headers["Content-Length"])
         u = u.raw
     else:
+        u = urlopen(url)
         meta = u.info()
         if hasattr(meta, 'getheaders'):
             file_size = int(meta.getheaders("Content-Length")[0])


### PR DESCRIPTION
Apparently get() is a function of requests, not a module (not sure if in the past get() used to be a module). Therefore, the syntax in #3280 will always fail with ImportError, and requests lib will never be used (kind of defeat the purpose of that pull request).
Also, if requests lib is used, should add stream=True parameter, otherwise requests.get() will load the whole response into memory.

