### PR TITLE
Allow building Caffe2 with ATen support (Addresses #7249)

### DIFF
--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
-    if (NOT USE_ATEN)
+  if (NOT USE_ATEN)
     return()
   endif()
 else()

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
-  if (NOT BUILD_ATEN)
+    if (NOT USE_ATEN)
     return()
   endif()
 else()


### PR DESCRIPTION
Currently, building Caffe2 with ATen support fails because ATen cannot be built before making Caffe2. This pull request solves the issue by building ATen for Caffe2 first.

**Update**
Passes the test in `caffe2/contrib/aten/docs/sample.py`.