### PR TITLE
Use sccache for Windows CI build

### DIFF
--- a/cmake/Modules_CUDA_fix/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/FindCUDA.cmake
@@ -557,7 +557,7 @@ else()
       set(c_compiler_realpath "")
     endif()
     set(CUDA_HOST_COMPILER "${c_compiler_realpath}" CACHE FILEPATH "Host side compiler used by NVCC")
-  elseif(MSVC AND "${CMAKE_C_COMPILER}" MATCHES "clcache")
+  elseif(MSVC AND ("${CMAKE_C_COMPILER}" MATCHES "clcache" OR "${CMAKE_C_COMPILER}" MATCHES "sccache"))
     # NVCC does not think it will work if it is passed clcache.exe as the host
     # compiler, which means that builds with CC=cl.exe won't work.  Best to just
     # feed it whatever the actual cl.exe is as the host compiler.


### PR DESCRIPTION
sccache is our distributed ccache system which provides warm cache on newly started CI machines. Previously it doesn't support NVCC and its usage is limited to non-CUDA builds. This patch (https://github.com/yf225/sccache/commit/336584a9e01c4c95a4396f42b57040025e297faa) makes it support NVCC as well.

For Linux CUDA builds, ccache takes about `2m46s` while the patched sccache takes about `3m5s` (likely due to the the lack of direct mode in sccache), which are pretty close in terms of duration. The patched sccache would also allow us to get rid of static workers and spawn more dynamic workers, which should reduce the wait time for CUDA builds.

For Windows CUDA builds, there is a ~50% speedup in the build phase (30mins -> 16mins), which would allow us to run Windows CI builds much faster.
