### PR TITLE
Allow the use of torch.device for loading

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6261,35 +6261,30 @@ class TestTorch(TestCase):
 
         def load_bytes():
             with open(test_file_path, 'rb') as f:
-                data = io.BytesIO(f.read())
-            return data
+                return io.BytesIO(f.read())
 
         fileobject_lambdas = [lambda: test_file_path, load_bytes]
-        map_locations = [map_location, {'cuda:0': 'cpu'}, 'cpu', torch.device('cpu')]
+        cpu_map_locations = [map_location, {'cuda:0': 'cpu'}, 'cpu', torch.device('cpu')]
+        gpu_map_locations = [
+            {'cuda:0': 'cuda:0'},
+            'cuda',
+            'cuda:{}'.format(torch.cuda.device_count() - 1),
+            'cuda:0',
+            torch.device('cuda'),
+            torch.device('cuda', 0)
+        ]
 
         for fileobject_lambda in fileobject_lambdas:
-            for map_location in map_locations:
+            for map_location in cpu_map_locations:
                 tensor = torch.load(fileobject_lambda(), map_location=map_location)
                 self.assertIsInstance(tensor, torch.FloatTensor)
                 self.assertEqual(tensor, torch.FloatTensor([[1.0, 2.0], [3.0, 4.0]]))
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_serialization_map_location_cuda(self):
-        test_file_path = download_file('https://download.pytorch.org/test_data/gpu_tensors.pt')
-
-        def load_bytes():
-            with open(test_file_path, 'rb') as f:
-                data = io.BytesIO(f.read())
-            return data
-
-        fileobject_lambdas = [lambda: test_file_path, load_bytes]
-        map_locations = [{'cuda:0': 'cuda:0'}, 'cuda:0', torch.device('cuda'), torch.device('cuda', 0)]
-
-        for fileobject_lambda in fileobject_lambdas:
-            for map_location in map_locations:
-                tensor = torch.load(fileobject_lambda(), map_location=map_location)
-                self.assertIsInstance(tensor, torch.cuda.FloatTensor)
-                self.assertEqual(tensor, torch.cuda.FloatTensor([[1.0, 2.0], [3.0, 4.0]]))
+            if torch.cuda.is_available():
+                for map_location in gpu_map_locations:
+                    tensor = torch.load(fileobject_lambda(), map_location=map_location)
+                    self.assertIsInstance(tensor, torch.cuda.FloatTensor)
+                    self.assertEqual(tensor, torch.cuda.FloatTensor([[1.0, 2.0], [3.0, 4.0]]))
 
     def test_serialization_filelike_api_requirements(self):
         filemock = FilelikeMock(b'', has_readinto=False)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6264,27 +6264,40 @@ class TestTorch(TestCase):
                 return io.BytesIO(f.read())
 
         fileobject_lambdas = [lambda: test_file_path, load_bytes]
-        cpu_map_locations = [map_location, {'cuda:0': 'cpu'}, 'cpu', torch.device('cpu')]
-        gpu_map_locations = [
+        cpu_map_locations = [
+            map_location,
+            {'cuda:0': 'cpu'},
+            'cpu',
+            torch.device('cpu'),
+        ]
+        gpu_0_map_locations = [
             {'cuda:0': 'cuda:0'},
             'cuda',
-            'cuda:{}'.format(torch.cuda.device_count() - 1),
             'cuda:0',
             torch.device('cuda'),
             torch.device('cuda', 0)
         ]
+        gpu_last_map_locations = [
+            'cuda:{}'.format(torch.cuda.device_count() - 1),
+        ]
 
-        for fileobject_lambda in fileobject_lambdas:
-            for map_location in cpu_map_locations:
-                tensor = torch.load(fileobject_lambda(), map_location=map_location)
-                self.assertIsInstance(tensor, torch.FloatTensor)
-                self.assertEqual(tensor, torch.FloatTensor([[1.0, 2.0], [3.0, 4.0]]))
-
-            if torch.cuda.is_available():
-                for map_location in gpu_map_locations:
+        def check_map_locations(map_locations, tensor_class, intended_device):
+            for fileobject_lambda in fileobject_lambdas:
+                for map_location in map_locations:
                     tensor = torch.load(fileobject_lambda(), map_location=map_location)
-                    self.assertIsInstance(tensor, torch.cuda.FloatTensor)
-                    self.assertEqual(tensor, torch.cuda.FloatTensor([[1.0, 2.0], [3.0, 4.0]]))
+
+                    self.assertEqual(tensor.device, intended_device)
+                    self.assertIsInstance(tensor, tensor_class)
+                    self.assertEqual(tensor, tensor_class([[1.0, 2.0], [3.0, 4.0]]))
+
+        check_map_locations(cpu_map_locations, torch.FloatTensor, torch.device('cpu'))
+        if torch.cuda.is_available():
+            check_map_locations(gpu_0_map_locations, torch.cuda.FloatTensor, torch.device('cuda', 0))
+            check_map_locations(
+                gpu_last_map_locations,
+                torch.cuda.FloatTensor,
+                torch.device('cuda', torch.cuda.device_count() - 1)
+            )
 
     def test_serialization_filelike_api_requirements(self):
         filemock = FilelikeMock(b'', has_readinto=False)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -273,7 +273,7 @@ def load(f, map_location=None, pickle_module=pickle):
     Args:
         f: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
-        map_location: a function, string or a dict specifying how to remap storage
+        map_location: a function, torch.device, string or a dict specifying how to remap storage
             locations
         pickle_module: module used for unpickling metadata and objects (has to
             match the pickle_module used to serialize file)
@@ -281,7 +281,7 @@ def load(f, map_location=None, pickle_module=pickle):
     Example:
         >>> torch.load('tensors.pt')
         # Load all tensors onto the CPU
-        >>> torch.load('tensors.pt', map_location='cpu')
+        >>> torch.load('tensors.pt', map_location=torch.device('cpu'))
         # Load all tensors onto the CPU, using a function
         >>> torch.load('tensors.pt', map_location=lambda storage, loc: storage)
         # Load all tensors onto GPU 1
@@ -318,6 +318,16 @@ def _load(f, map_location, pickle_module):
     elif isinstance(map_location, _string_classes):
         def restore_location(storage, location):
             return default_restore_location(storage, map_location)
+    elif isinstance(map_location, torch.device):
+        if map_location.type == 'cpu':
+            map_str = 'cpu'
+        elif map_location.type == 'cuda':
+            map_str = 'cuda:{}'.format(map_location.index or 0)
+        else:
+            raise ValueError("The given map_location device is not a cpu or cuda")
+
+        def restore_location(storage, location):
+            return default_restore_location(storage, map_str)
     else:
         def restore_location(storage, location):
             result = map_location(storage, location)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -322,15 +322,8 @@ def _load(f, map_location, pickle_module):
         def restore_location(storage, location):
             return default_restore_location(storage, map_location)
     elif isinstance(map_location, torch.device):
-        if map_location.type == 'cpu':
-            map_str = 'cpu'
-        elif map_location.type == 'cuda':
-            map_str = 'cuda:{}'.format(map_location.index or 0)
-        else:
-            raise ValueError("The given map_location device is not a cpu or cuda")
-
         def restore_location(storage, location):
-            return default_restore_location(storage, map_str)
+            return default_restore_location(storage, str(map_location))
     else:
         def restore_location(storage, location):
             result = map_location(storage, location)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -66,7 +66,10 @@ def _cpu_deserialize(obj, location):
 
 def _cuda_deserialize(obj, location):
     if location.startswith('cuda'):
-        device = max(int(location[5:]), 0)
+        if location[5:] == '':
+            device = 0
+        else:
+            device = max(int(location[5:]), 0)
         return obj.cuda(device)
 
 


### PR DESCRIPTION
This pull request allows you to use torch.device as a map location when using torch.load. It's a pretty minor thing, but it helps makes the API a bit more consistent with letting you use torch.device everywhere.

This partially solves https://github.com/pytorch/pytorch/issues/7178.

My main question here is how much to change the torch.load API. This PR does the minimal change, which is simply adding torch.device as yet another option for specifying the map_location. The real question is whether torch.device should also be supported when a dict or function is passed. There is sorta a tradeoff here between consistency and stability. There is also the question of whether we want to support torch.device as keys.

Let me know what you guys think.