### PR TITLE
[Caffe2] Pinning conda-numpy to 1.14 to avoid SVD issue

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -67,9 +67,9 @@ for test in $INSTALL_PREFIX/test/*; do
       continue
       ;;
     # TODO investigate conv_op_test failures when using MKL
-    conv_op_test)
-      continue
-      ;;
+    #conv_op_test)
+    #  continue
+    #  ;;
   esac
 
   "$test" --gtest_output=xml:"$TEST_DIR"/cpp/$(basename "$test").xml
@@ -90,10 +90,11 @@ if [[ "$BUILD_ENVIRONMENT" == *-cuda* ]]; then
   EXTRA_TESTS+=("$CAFFE2_PYPATH/contrib/nccl")
 fi
 
-# TODO find out why this breaks for conda builds
+conda_ignore_test=()
 if [[ $BUILD_ENVIRONMENT == conda* ]]; then
-  conda_ignore_test="--ignore $CAFFE2_PYPATH/python/tt_core_test.py"
-  conda_ignore_test="--ignore $CAFFE2_PYPATH/python/dataio_test.py"
+  # These tests both assume Caffe2 was built with leveldb, which is not the case
+  conda_ignore_test+=("--ignore $CAFFE2_PYPATH/python/dataio_test.py")
+  conda_ignore_test+=("--ignore $CAFFE2_PYPATH/python/operator_test/checkpoint_test.py")
 fi
 
 # Python tests
@@ -107,7 +108,7 @@ echo "Running Python tests.."
   --ignore "$CAFFE2_PYPATH/python/operator_test/matmul_op_test.py" \
   --ignore "$CAFFE2_PYPATH/python/operator_test/pack_ops_test.py" \
   --ignore "$CAFFE2_PYPATH/python/mkl/mkl_sbn_speed_test.py" \
-  $conda_ignore_test \
+  ${conda_ignore_test[@]} \
   "$CAFFE2_PYPATH/python" \
   "${EXTRA_TESTS[@]}"
 

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -66,10 +66,6 @@ for test in $INSTALL_PREFIX/test/*; do
     mkl_utils_test)
       continue
       ;;
-    # TODO investigate conv_op_test failures when using MKL
-    #conv_op_test)
-    #  continue
-    #  ;;
   esac
 
   "$test" --gtest_output=xml:"$TEST_DIR"/cpp/$(basename "$test").xml

--- a/conda/caffe2/normal/conda_build_config.yaml
+++ b/conda/caffe2/normal/conda_build_config.yaml
@@ -1,4 +1,4 @@
-numpy: 1.12
+numpy: 1.14
 pin_run_as_build:
   numpy:
     min_pin: x.x


### PR DESCRIPTION
Example failure https://ci.pytorch.org/jenkins/job/caffe2-builds/job/conda2-ubuntu16.04-test/506/console
caused by numpy 1.12 being built with mkl (b/c "nomkl" feature is not installed), which does not converge. numpy=1.12.1=py27_nomkl_0  as well as numpy=1.14.2=py27hdbf6ddf_0 and numpy=1.14.2=py27hdbf6ddf_1 all work. The numpy-nomkl version needs to 'nomkl' feature to be installed, which will interfere with building Caffe2 or Pytorch with mkl, so pinning numpy to 1.14 in hope that the rest of the numpy 1.14 packages work too

Note how this only changes the non-integrated builds, as testing for combined builds is not ready to test bumping Pytorch to 1.14