### PR TITLE
Fix advanced indexing with negative indices

### DIFF
--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -142,6 +142,20 @@ static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
   return src.view(sizes);
 }
 
+static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size) {
+  auto max_idx = index.max();
+  auto min_idx = index.min();
+  if (*max_idx.data<int64_t>() >= dim_size) {
+    AT_ERROR("index", max_idx, "is out of bounds for dimension", dim, "with size", dim_size); 
+    throw std::runtime_error("foo");
+  } 
+  if (*min_idx.data<int64_t>() < -dim_size) {
+    AT_ERROR("index", min_idx, "is out of bounds for dimension", dim, "with size", dim_size); 
+    throw std::runtime_error("foo");
+  }
+  return index.remainder(dim_size);
+}
+
 static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
   auto strides = computeLinearStride(src);
   Type& longType = src.type().toScalarType(kLong);
@@ -156,7 +170,7 @@ static Tensor computeLinearIndex(const Tensor & src, TensorList indices) {
     if (indices[i].defined()) {
       // Cast index to the longType matching src's backend
       // This allows us to support ie indexing a cuda tensor with a cpu tensor
-      Tensor index = (indices[i] * strides[i]).toType(longType);
+      Tensor index = (wrapIndexOnce(indices[i], i, src.size(i)) * strides[i]).toType(longType);
       if (linearIndex.defined()) {
         linearIndex += index;
       } else {

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -143,13 +143,13 @@ static Tensor unsqueezeN(const Tensor & src, int64_t before, int64_t after) {
 }
 
 static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size) {
-  auto max_idx = index.max();
-  auto min_idx = index.min();
-  if (*max_idx.data<int64_t>() >= dim_size) {
+  auto max_idx = index.max().toCLong();
+  auto min_idx = index.min().toCLong();
+  if (max_idx >= dim_size) {
     AT_ERROR("index", max_idx, "is out of bounds for dimension", dim, "with size", dim_size); 
     throw std::runtime_error("foo");
   } 
-  if (*min_idx.data<int64_t>() < -dim_size) {
+  if (min_idx < -dim_size) {
     AT_ERROR("index", min_idx, "is out of bounds for dimension", dim, "with size", dim_size); 
     throw std::runtime_error("foo");
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4894,7 +4894,11 @@ class TestTorch(TestCase):
 
                 # weird shape
                 [slice(None), [[0, 1],
-                               [2, 3]]]
+                               [2, 3]]],
+                # negatives
+                [[-1], [0]],
+                [[0, 2], [-1]],
+                [slice(None), [-1]],
             ]
 
             # only test dupes on gets


### PR DESCRIPTION
Fixes #7156

Here is some behavior before this PR:
```
In[1]:
x = torch.arange(9).view(3, 3).contiguous()
x

Out[1]:
tensor([[ 0,  1,  2],
        [ 3,  4,  5],
        [ 6,  7,  8]])

In[2]:
x[[0], [-1]]  # Should be equivalent to x[0, -1]

Out[2]:
tensor([ 8])
```

However, I would expect the output to be `tensor([2])`.

The bug is that negative indices are added to the computed linear index
directly. In the above example, the linear index computed is "-1", which
wraps around to "8", giving the last element of a flattened view of `x`.

Instead, we should wrap negative indices around before adding them to
the linear index.

cc @colesbury 

