### PR TITLE
Add aten::expand to the isDifferentiable list

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1697,6 +1697,21 @@ class TestScript(TestCase):
         self.checkScript(func3, (a, b), optimize=True)
         self.checkScript(func4, (a, b), optimize=True)
 
+    def test_expand(self):
+        @torch.jit.script
+        def func(x, y):
+            return x + y
+
+        x = torch.rand(2, 3, dtype=torch.float, requires_grad=True)
+        y = torch.rand(3, dtype=torch.float, requires_grad=True)
+        out = func(x, y)
+        self.assertEqual(func(x, y), x + y)
+
+        grad = torch.randn(2, 3)
+        out.backward(grad)
+        self.assertEqual(x.grad, grad)
+        self.assertEqual(y.grad, grad.sum(dim=0))
+
     def test_cat(self):
         @torch.jit.script
         def func(x):

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -17,7 +17,7 @@ bool isDifferentiable(Node * n) {
   static std::unordered_set<Symbol> differentiable_kinds = {
     aten::add, aten::sub, aten::mul, prim::Constant, prim::ReplaceIfUndef,
     aten::sigmoid, aten::tanh, aten::mm, aten::chunk, aten::split, aten::t, aten::neg,
-    aten::unsqueeze
+    aten::unsqueeze, aten::expand,
   };
   return differentiable_kinds.count(n->kind()) > 0;
 }


### PR DESCRIPTION
This lets aten::expand be differentiable in torchscript. It was probably
omitted from the list by accident in the past b/c gradientForNode does
already support aten::expand.

Also adds a test to check expand and its gradient in a torchscript fn.

cc @zdevito 

