### PR TITLE
Set MAX_JOBS to nproc - 1 if using sccache to compile CUDA

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -27,6 +27,11 @@ if ! which conda; then
   pip install mkl mkl-devel
 fi
 
+# sccache will fail for CUDA builds if all cores are used for compiling
+if [[ "$BUILD_ENVIRONMENT" == *cuda* ]] && which sccache > /dev/null; then
+  export MAX_JOBS=`expr $(nproc) - 1`
+fi
+
 WERROR=1 python setup.py install
 
 # Add the ATen test binaries so that they won't be git clean'ed away

--- a/tools/cpp_build/build_common.sh
+++ b/tools/cpp_build/build_common.sh
@@ -27,7 +27,9 @@ BUILD_TYPE=${BUILD_TYPE:-Debug}
 # Try to build with as many threads as we have cores, default to 4 if the
 # command fails.
 set +e
-if [[ "$(uname)" == "Linux" ]]; then
+if [ -n "$MAX_JOBS" ]; then  # Use MAX_JOBS if it is set
+  JOBS=$MAX_JOBS
+elif [[ "$(uname)" == "Linux" ]]; then
   # https://stackoverflow.com/questions/6481005/how-to-obtain-the-number-of-cpus-cores-in-linux-from-the-command-line
   JOBS="$(grep -c '^processor' /proc/cpuinfo)"
 else # if [[ "$(uname)" == "Darwin"]]


### PR DESCRIPTION
By default `MAX_JOBS` is set to `multiprocessing.cpu_count()`, which will cause sccache to be stuck and then fail (https://github.com/mozilla/sccache/issues/248):
```
19:15:13 error: failed to execute compile
19:15:13 caused by: error reading compile response from server
19:15:13 caused by: Failed to read response header
19:15:13 caused by: failed to fill whole buffer
```

Setting `MAX_JOBS` to `$(nproc)-1` fixes the issue.