### PR TITLE
Dont do CSE on nodes with blocks

### DIFF
--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -119,6 +119,7 @@ void EliminateCommonSubexpression(Block * block) {
     if (node->kind() == prim::PythonOp
         || node->kind() == prim::CppOp
         || node->kind() == prim::Eval
+        || node->blocks().size() > 0
        ) {
       // Do NOT have enough information to do CSE on these nodes.
       continue;


### PR DESCRIPTION
This caused a problem when compiling the style transfer tutorial under script. Two `if` conditionals that relied on different captured values were incorrectly eliminated