### PR TITLE
Removes -2 special case and specialization from pointwise apply

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -326,43 +326,33 @@ bool CUDA_tensor_apply2(at::Tensor a,
    <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(    \
        aInfo, bInfo, (TYPE) totalElements, op);
 
-#define HANDLE_B_CASE(TYPE, A, B)               \
-  {                                             \
-    if (bInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, A, -2);                 \
-    } else {                                    \
-      switch (B) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, A, 1);                \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, A, 2);                \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, A, -1);               \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_B_CASE(TYPE, A, B) {         \
+  switch (B) {                              \
+    case 1:                                 \
+      HANDLE_CASE(TYPE, A, 1);              \
+      break;                                \
+    case 2:                                 \
+      HANDLE_CASE(TYPE, A, 2);              \
+      break;                                \
+    default:                                \
+      HANDLE_CASE(TYPE, A, -1);             \
+      break;                                \
+  }                                         \
+}                                           
 
-#define HANDLE_A_CASE(TYPE, A, B)               \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_B_CASE(TYPE, -2, B);               \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_B_CASE(TYPE, 1, B);              \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_B_CASE(TYPE, 2, B);              \
-        break;                                  \
-        default:                                \
-        HANDLE_B_CASE(TYPE, -1, B);             \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A, B) {         \
+  switch (A) {                              \
+    case 1:                                 \
+      HANDLE_B_CASE(TYPE, 1, B);            \
+      break;                                \
+    case 2:                                 \
+      HANDLE_B_CASE(TYPE, 2, B);            \
+      break;                                \
+    default:                                \
+      HANDLE_B_CASE(TYPE, -1, B);           \
+      break;                                \
+  }                                         \
+}
 
   if (detail::canUse32BitIndexMath(a) &&
       detail::canUse32BitIndexMath(b)) {
@@ -393,11 +383,11 @@ bool CUDA_tensor_apply2(at::Tensor a,
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce
     // compilation time.
-    if (aInfo.isContiguous() && bInfo.isContiguous()) {
+    if (aInfo.dims == 1 && bInfo.dims == 1) {
       kernelPointwiseApply2<Op,
                             scalar1,
                             scalar2,
-                          uint64_t, -2, -2>
+                          uint64_t, 1, 1>
         <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(
            aInfo, bInfo, (uint64_t) totalElements, op);
     } else {
@@ -513,62 +503,47 @@ bool CUDA_tensor_apply3(at::Tensor a,
     <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(   \
       aInfo, bInfo, cInfo, (TYPE) totalElements, op);
 
-#define HANDLE_C_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (cInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, A, B, -2);              \
-    } else {                                    \
-      switch (C) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, A, B, 1);             \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, A, B, 2);             \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, A, B, -1);            \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_C_CASE(TYPE, A, B, C) {      \
+  switch (C) {                              \
+    case 1:                                 \
+      HANDLE_CASE(TYPE, A, B, 1);           \
+      break;                                \
+    case 2:                                 \
+      HANDLE_CASE(TYPE, A, B, 2);           \
+      break;                                \
+    default:                                \
+      HANDLE_CASE(TYPE, A, B, -1);          \
+      break;                                \
+  }                                         \
+}
 
-#define HANDLE_B_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (bInfo.isContiguous()) {                 \
-      HANDLE_C_CASE(TYPE, A, -2, C);            \
-    } else {                                    \
-      switch (B) {                              \
-        case 1:                                 \
-        HANDLE_C_CASE(TYPE, A, 1, C);           \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_C_CASE(TYPE, A, 2, C);           \
-        break;                                  \
-        default:                                \
-        HANDLE_C_CASE(TYPE, A, -1, C);          \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_B_CASE(TYPE, A, B, C) {      \
+  switch (B) {                              \
+    case 1:                                 \
+      HANDLE_C_CASE(TYPE, A, 1, C);         \
+      break;                                \
+    case 2:                                 \
+      HANDLE_C_CASE(TYPE, A, 2, C);         \
+      break;                                \
+    default:                                \
+      HANDLE_C_CASE(TYPE, A, -1, C);        \
+      break;                                \
+  }                                         \
+}
 
-#define HANDLE_A_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_B_CASE(TYPE, -2, B, C);            \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_B_CASE(TYPE, 1, B, C);           \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_B_CASE(TYPE, 2, B, C);           \
-        break;                                  \
-        default:                                \
-        HANDLE_B_CASE(TYPE, -1, B, C);          \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A, B, C) {      \
+  switch (A) {                              \
+    case 1:                                 \
+      HANDLE_B_CASE(TYPE, 1, B, C);         \
+      break;                                \
+    case 2:                                 \
+      HANDLE_B_CASE(TYPE, 2, B, C);         \
+      break;                                \
+    default:                                \
+      HANDLE_B_CASE(TYPE, -1, B, C);        \
+      break;                                \
+  }                                         \
+}
 
   if (detail::canUse32BitIndexMath(a) &&
       detail::canUse32BitIndexMath(b) &&
@@ -610,12 +585,12 @@ bool CUDA_tensor_apply3(at::Tensor a,
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce
     // compilation time.
-    if (aInfo.isContiguous() && bInfo.isContiguous() && cInfo.isContiguous()) {
+    if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1) {
       kernelPointwiseApply3<Op,
                             scalar1,
                             scalar2,
                             scalar3,
-                            uint64_t, -2, -2, -2>
+                            uint64_t, 1, 1, 1>
         <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(
           aInfo, bInfo, cInfo, (uint64_t) totalElements, op);
     } else {
@@ -753,81 +728,61 @@ bool CUDA_tensor_apply4(at::Tensor a,
     <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(   \
     aInfo, bInfo, cInfo, dInfo, (TYPE) totalElements, op);
 
-#define HANDLE_D_CASE(TYPE, A, B, C, D)         \
-  {                                             \
-    if (dInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, A, B, C, -2);           \
-    } else {                                    \
-      switch (D) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, A, B, C, 1);          \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, A, B, C, 2);          \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, A, B, C, -1);         \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_D_CASE(TYPE, A, B, C, D) {       \
+  switch (D) {                                  \
+    case 1:                                     \
+      HANDLE_CASE(TYPE, A, B, C, 1);            \
+      break;                                    \
+    case 2:                                     \
+      HANDLE_CASE(TYPE, A, B, C, 2);            \
+      break;                                    \
+    default:                                    \
+      HANDLE_CASE(TYPE, A, B, C, -1);           \
+      break;                                    \
+  }                                             \
+}
 
-#define HANDLE_C_CASE(TYPE, A, B, C, D)         \
-  {                                             \
-    if (cInfo.isContiguous()) {                 \
-      HANDLE_D_CASE(TYPE, A, B, -2, D);         \
-    } else {                                    \
-      switch (C) {                              \
-        case 1:                                 \
-        HANDLE_D_CASE(TYPE, A, B, 1, D);        \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_D_CASE(TYPE, A, B, 2, D);        \
-        break;                                  \
-        default:                                \
-        HANDLE_D_CASE(TYPE, A, B, -1, D);       \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_C_CASE(TYPE, A, B, C, D) {       \
+  switch (C) {                                  \
+    case 1:                                     \
+      HANDLE_D_CASE(TYPE, A, B, 1, D);          \
+      break;                                    \
+    case 2:                                     \
+      HANDLE_D_CASE(TYPE, A, B, 2, D);          \
+      break;                                    \
+    default:                                    \
+      HANDLE_D_CASE(TYPE, A, B, -1, D);         \
+      break;                                    \
+  }                                             \
+}
 
-#define HANDLE_B_CASE(TYPE, A, B, C, D)         \
-  {                                             \
-    if (bInfo.isContiguous()) {                 \
-      HANDLE_C_CASE(TYPE, A, -2, C, D);         \
-    } else {                                    \
-      switch (B) {                              \
-        case 1:                                 \
-        HANDLE_C_CASE(TYPE, A, 1, C, D);        \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_C_CASE(TYPE, A, 2, C, D);        \
-        break;                                  \
-        default:                                \
-        HANDLE_C_CASE(TYPE, A, -1, C, D);       \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_B_CASE(TYPE, A, B, C, D) {       \
+  switch (B) {                                  \
+    case 1:                                     \
+      HANDLE_C_CASE(TYPE, A, 1, C, D);          \
+      break;                                    \
+    case 2:                                     \
+      HANDLE_C_CASE(TYPE, A, 2, C, D);          \
+      break;                                    \
+    default:                                    \
+      HANDLE_C_CASE(TYPE, A, -1, C, D);         \
+      break;                                    \
+  }                                             \
+}
 
-#define HANDLE_A_CASE(TYPE, A, B, C, D)         \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_B_CASE(TYPE, -2, B, C, D);         \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_B_CASE(TYPE, 1, B, C, D);        \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_B_CASE(TYPE, 2, B, C, D);        \
-        break;                                  \
-        default:                                \
-        HANDLE_B_CASE(TYPE, -1, B, C, D);       \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A, B, C, D) {       \
+  switch (A) {                                  \
+    case 1:                                     \
+      HANDLE_B_CASE(TYPE, 1, B, C, D);          \
+      break;                                    \
+    case 2:                                     \
+      HANDLE_B_CASE(TYPE, 2, B, C, D);          \
+      break;                                    \
+    default:                                    \
+      HANDLE_B_CASE(TYPE, -1, B, C, D);         \
+      break;                                    \
+  }                                             \
+}
 
   if (detail::canUse32BitIndexMath(a) &&
       detail::canUse32BitIndexMath(b) &&
@@ -878,13 +833,13 @@ bool CUDA_tensor_apply4(at::Tensor a,
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce
     // compilation time.
-    if (aInfo.isContiguous() && bInfo.isContiguous() && cInfo.isContiguous() && dInfo.isContiguous()) {
+    if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1 && dInfo.dims == 1) {
       kernelPointwiseApply4<Op,
                             scalar1,
                             scalar2,
                             scalar3,
                             scalar4,
-                            uint64_t, -2, -2, -2, -2>
+                            uint64_t, 1, 1, 1, 1>
         <<<grid, block, 0, at::globalContext().getCurrentCUDAStream()>>>(
           aInfo, bInfo, cInfo, dInfo, (uint64_t) totalElements, op);
     } else {

--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -380,9 +380,10 @@ bool CUDA_tensor_apply2(at::Tensor a,
     aInfo.collapseDims();
     bInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
+    /*
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
+    */
     if (aInfo.dims == 1 && bInfo.dims == 1) {
       kernelPointwiseApply2<Op,
                             scalar1,
@@ -582,9 +583,10 @@ bool CUDA_tensor_apply3(at::Tensor a,
     bInfo.collapseDims();
     cInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
+    /*
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
+    */
     if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1) {
       kernelPointwiseApply3<Op,
                             scalar1,
@@ -830,9 +832,10 @@ bool CUDA_tensor_apply4(at::Tensor a,
     cInfo.collapseDims();
     dInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
+    /*
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
+    */
     if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1 && dInfo.dims == 1) {
       kernelPointwiseApply4<Op,
                             scalar1,

--- a/aten/src/ATen/cuda/detail/TensorInfo.cuh
+++ b/aten/src/ATen/cuda/detail/TensorInfo.cuh
@@ -241,12 +241,13 @@ struct IndexToOffset {
   }
 };
 
-// For contiguous tensors, the offset = index
+// For 1D tensors the offset equals linear index * stride
+// Note: this specialization for readability only
 template <typename T, typename IndexType>
-struct IndexToOffset<T, IndexType, -2> {
+struct IndexToOffset<T, IndexType, 1> {
   static inline __host__ __device__ IndexType
     get(IndexType linearId, const TensorInfo<T, IndexType>& info) {
-    return linearId;
+    return linearId * info.strides[0];
   }
 };
 

--- a/aten/src/ATen/cuda/detail/TensorInfo.cuh
+++ b/aten/src/ATen/cuda/detail/TensorInfo.cuh
@@ -224,51 +224,38 @@ struct IndexToOffset {
   static __host__ __device__ IndexType get(
     IndexType linearId,
     const TensorInfo<T, IndexType>& info) {
+    
     IndexType offset = 0;
 
-    // Use static dims
-    for (int i = Dims - 1; i >= 0; --i) {
+    // Uses static dims
+    for (int i = Dims - 1; i > 0; --i) {
       IndexType curDimIndex = linearId % info.sizes[i];
       IndexType curDimOffset = curDimIndex * info.strides[i];
       offset += curDimOffset;
-
-      if (i > 0) {
-        linearId /= info.sizes[i];
-      }
+      linearId /= info.sizes[i];
     }
 
-    return offset;
+    return offset + linearId * info.strides[0];
   }
 };
 
-// For 1D tensors the offset equals linear index * stride
-// Note: this specialization for readability only
-template <typename T, typename IndexType>
-struct IndexToOffset<T, IndexType, 1> {
-  static inline __host__ __device__ IndexType
-    get(IndexType linearId, const TensorInfo<T, IndexType>& info) {
-    return linearId * info.strides[0];
-  }
-};
-
+// Uses dynamic (runtime) instead of static (compiletime) dims
 template <typename T, typename IndexType>
 struct IndexToOffset<T, IndexType, -1> {
   static inline __host__ __device__ IndexType get(
     IndexType linearId,
     const TensorInfo<T, IndexType>& info) {
 
-    IndexType offset = 0;
+      IndexType offset = 0;
 
-    // Use dynamic dims
-    for (int i = info.dims - 1; i >= 0; --i) {
-      IndexType curDimIndex = linearId % info.sizes[i];
-      IndexType curDimOffset = curDimIndex * info.strides[i];
-      offset += curDimOffset;
+      for (int i = info.dims - 1; i > 0; --i) {
+        IndexType curDimIndex = linearId % info.sizes[i];
+        IndexType curDimOffset = curDimIndex * info.strides[i];
+        offset += curDimOffset;
+        linearId /= info.sizes[i];
+      }
 
-      linearId /= info.sizes[i];
-    }
-
-    return offset;
+      return offset + linearId * info.strides[0];
   }
 };
 

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -275,8 +275,8 @@ bool THC_pointwiseApply1(THCState* state,
     aInfo.collapseDims();
 
     /*
-    Only compiles the 1D and nD cases for large tensors to avoid excessive
-    build times.
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
     */
     if (aInfo.dims == 1) {
       OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>
@@ -444,8 +444,8 @@ bool THC_pointwiseApply2(THCState* state,
     bInfo.collapseDims();
 
     /*
-    Only compiles the 1D and nD cases for large tensors to avoid excessive
-    build times.
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
     */
     if (aInfo.dims == 1 && bInfo.dims == 1) {
       OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>
@@ -659,8 +659,8 @@ bool THC_pointwiseApply3(THCState* state,
     cInfo.collapseDims();
 
     /*
-    Only compiles the 1D and nD cases for large tensors to avoid excessive
-    build times.
+    Only instantiates the all 1D special case and the fallback all nD case for
+    large (64-bit indexed) tensors to reduce compilation time. 
     */
     if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1) {
       OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -239,24 +239,19 @@ bool THC_pointwiseApply1(THCState* state,
           (aInfo),                                                      \
       (TYPE) totalElements, op);
 
-#define HANDLE_A_CASE(TYPE, A)                  \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, -2);                    \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, 1);                   \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, 2);                   \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, -1);                  \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A) {            \
+  switch (A) {                              \
+    case 1:                                 \
+      HANDLE_CASE(TYPE, 1);                 \
+      break;                                \
+    case 2:                                 \
+      HANDLE_CASE(TYPE, 2);                 \
+      break;                                \
+    default:                                \
+      HANDLE_CASE(TYPE, -1);                \
+      break;                                \
+  }                                         \
+}
 
   // Can we use 32-bit integer math in the kernel (the linear ID for the copy
   // and the resulting non-linear offset is all computable using 32-bit math?)
@@ -268,8 +263,9 @@ bool THC_pointwiseApply1(THCState* state,
     rearrangeDims(&aInfo);
     aInfo.collapseDims();
 #if CUDA_VERSION < 9000
-    if (!aInfo.isContiguous())
+    if (!aInfo.isContiguous()) {
         grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+    }
 #endif
     HANDLE_A_CASE(unsigned int, aInfo.dims);
   } else {
@@ -278,15 +274,16 @@ bool THC_pointwiseApply1(THCState* state,
     rearrangeDims(&aInfo);
     aInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
-    if (aInfo.isContiguous()) {
-      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, -2>
+    /*
+    Only compiles the 1D and nD cases for large tensors to avoid excessive
+    build times.
+    */
+    if (aInfo.dims == 1) {
+      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>
         aOffset(aInfo);
       kernelPointwiseApply1<Op,
                             typename TensorUtils<TensorTypeA>::DataType,
-                            uint64_t, -2>
+                            uint64_t, 1>
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           aOffset, (uint64_t) totalElements, op);
     } else {
@@ -390,43 +387,33 @@ bool THC_pointwiseApply2(THCState* state,
           (bInfo),                                                      \
       (TYPE) totalElements, op);
 
-#define HANDLE_B_CASE(TYPE, A, B)               \
-  {                                             \
-    if (bInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, A, -2);                 \
-    } else {                                    \
-      switch (B) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, A, 1);                \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, A, 2);                \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, A, -1);               \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_B_CASE(TYPE, A, B) {         \
+  switch (B) {                              \
+    case 1:                                 \
+      HANDLE_CASE(TYPE, A, 1);              \
+      break;                                \
+    case 2:                                 \
+      HANDLE_CASE(TYPE, A, 2);              \
+      break;                                \
+    default:                                \
+      HANDLE_CASE(TYPE, A, -1);             \
+      break;                                \
+  }                                         \
+}                                           
 
-#define HANDLE_A_CASE(TYPE, A, B)               \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_B_CASE(TYPE, -2, B);               \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_B_CASE(TYPE, 1, B);              \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_B_CASE(TYPE, 2, B);              \
-        break;                                  \
-        default:                                \
-        HANDLE_B_CASE(TYPE, -1, B);             \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A, B) {         \
+  switch (A) {                              \
+    case 1:                                 \
+      HANDLE_B_CASE(TYPE, 1, B);            \
+      break;                                \
+    case 2:                                 \
+      HANDLE_B_CASE(TYPE, 2, B);            \
+      break;                                \
+    default:                                \
+      HANDLE_B_CASE(TYPE, -1, B);           \
+      break;                                \
+  }                                         \
+}
 
   if (TensorUtils<TensorTypeA>::canUse32BitIndexMath(state, a) &&
       TensorUtils<TensorTypeB>::canUse32BitIndexMath(state, b)) {
@@ -456,18 +443,19 @@ bool THC_pointwiseApply2(THCState* state,
     aInfo.collapseDims();
     bInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
-    if (aInfo.isContiguous() && bInfo.isContiguous()) {
-      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, -2>
+    /*
+    Only compiles the 1D and nD cases for large tensors to avoid excessive
+    build times.
+    */
+    if (aInfo.dims == 1 && bInfo.dims == 1) {
+      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>
         aOffset(aInfo);
-      OffsetInfo<typename TensorUtils<TensorTypeB>::DataType, uint64_t, -2>
+      OffsetInfo<typename TensorUtils<TensorTypeB>::DataType, uint64_t, 1>
         bOffset(bInfo);
       kernelPointwiseApply2<Op,
                             typename TensorUtils<TensorTypeA>::DataType,
                             typename TensorUtils<TensorTypeB>::DataType,
-                            uint64_t, -2, -2>
+                            uint64_t, 1, 1>
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           aOffset, bOffset, (uint64_t) totalElements, op);
     } else {
@@ -591,62 +579,47 @@ bool THC_pointwiseApply3(THCState* state,
           (cInfo),                                                      \
       (TYPE) totalElements, op);
 
-#define HANDLE_C_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (cInfo.isContiguous()) {                 \
-      HANDLE_CASE(TYPE, A, B, -2);              \
-    } else {                                    \
-      switch (C) {                              \
-        case 1:                                 \
-        HANDLE_CASE(TYPE, A, B, 1);             \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_CASE(TYPE, A, B, 2);             \
-        break;                                  \
-        default:                                \
-        HANDLE_CASE(TYPE, A, B, -1);            \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_C_CASE(TYPE, A, B, C) {      \
+  switch (C) {                              \
+    case 1:                                 \
+      HANDLE_CASE(TYPE, A, B, 1);           \
+      break;                                \
+    case 2:                                 \
+      HANDLE_CASE(TYPE, A, B, 2);           \
+      break;                                \
+    default:                                \
+      HANDLE_CASE(TYPE, A, B, -1);          \
+      break;                                \
+  }                                         \
+}
 
-#define HANDLE_B_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (bInfo.isContiguous()) {                 \
-      HANDLE_C_CASE(TYPE, A, -2, C);            \
-    } else {                                    \
-      switch (B) {                              \
-        case 1:                                 \
-        HANDLE_C_CASE(TYPE, A, 1, C);           \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_C_CASE(TYPE, A, 2, C);           \
-        break;                                  \
-        default:                                \
-        HANDLE_C_CASE(TYPE, A, -1, C);          \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_B_CASE(TYPE, A, B, C) {      \
+  switch (B) {                              \
+    case 1:                                 \
+      HANDLE_C_CASE(TYPE, A, 1, C);         \
+      break;                                \
+    case 2:                                 \
+      HANDLE_C_CASE(TYPE, A, 2, C);         \
+      break;                                \
+    default:                                \
+      HANDLE_C_CASE(TYPE, A, -1, C);        \
+      break;                                \
+  }                                         \
+}
 
-#define HANDLE_A_CASE(TYPE, A, B, C)            \
-  {                                             \
-    if (aInfo.isContiguous()) {                 \
-      HANDLE_B_CASE(TYPE, -2, B, C);            \
-    } else {                                    \
-      switch (A) {                              \
-        case 1:                                 \
-        HANDLE_B_CASE(TYPE, 1, B, C);           \
-        break;                                  \
-        case 2:                                 \
-        HANDLE_B_CASE(TYPE, 2, B, C);           \
-        break;                                  \
-        default:                                \
-        HANDLE_B_CASE(TYPE, -1, B, C);          \
-        break;                                  \
-      }                                         \
-    }                                           \
-  }
+#define HANDLE_A_CASE(TYPE, A, B, C) {      \
+  switch (A) {                              \
+    case 1:                                 \
+      HANDLE_B_CASE(TYPE, 1, B, C);         \
+      break;                                \
+    case 2:                                 \
+      HANDLE_B_CASE(TYPE, 2, B, C);         \
+      break;                                \
+    default:                                \
+      HANDLE_B_CASE(TYPE, -1, B, C);        \
+      break;                                \
+  }                                         \
+}
 
   if (TensorUtils<TensorTypeA>::canUse32BitIndexMath(state, a) &&
       TensorUtils<TensorTypeB>::canUse32BitIndexMath(state, b) &&
@@ -685,21 +658,22 @@ bool THC_pointwiseApply3(THCState* state,
     bInfo.collapseDims();
     cInfo.collapseDims();
 
-    // For large tensors, we only compile the completely contiguous
-    // version and the completely generic version, to reduce
-    // compilation time.
-    if (aInfo.isContiguous() && bInfo.isContiguous() && cInfo.isContiguous()) {
-      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, -2>
+    /*
+    Only compiles the 1D and nD cases for large tensors to avoid excessive
+    build times.
+    */
+    if (aInfo.dims == 1 && bInfo.dims == 1 && cInfo.dims == 1) {
+      OffsetInfo<typename TensorUtils<TensorTypeA>::DataType, uint64_t, 1>
         aOffset(aInfo);
-      OffsetInfo<typename TensorUtils<TensorTypeB>::DataType, uint64_t, -2>
+      OffsetInfo<typename TensorUtils<TensorTypeB>::DataType, uint64_t, 1>
         bOffset(bInfo);
-      OffsetInfo<typename TensorUtils<TensorTypeC>::DataType, uint64_t, -2>
+      OffsetInfo<typename TensorUtils<TensorTypeC>::DataType, uint64_t, 1>
         cOffset(cInfo);
       kernelPointwiseApply3<Op,
                             typename TensorUtils<TensorTypeA>::DataType,
                             typename TensorUtils<TensorTypeB>::DataType,
                             typename TensorUtils<TensorTypeC>::DataType,
-                            uint64_t, -2, -2, -2>
+                            uint64_t, 1, 1, 1>
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           aOffset, bOffset, cOffset, (uint64_t) totalElements, op);
     } else {

--- a/aten/src/THC/THCTensorInfo.cuh
+++ b/aten/src/THC/THCTensorInfo.cuh
@@ -231,18 +231,18 @@ struct IndexToOffset {
   static __host__ __device__ IndexType get(
     IndexType linearId,
     const TensorInfo<T, IndexType>& info) {
+    
     IndexType offset = 0;
 
-    // Use static dims
+    // Uses static dims
     for (int i = Dims - 1; i > 0; --i) {
       IndexType curDimIndex = linearId % info.sizes[i];
       IndexType curDimOffset = curDimIndex * info.strides[i];
       offset += curDimOffset;
       linearId /= info.sizes[i];
     }
-    offset += linearId * info.strides[0];
-
-    return offset;
+    
+    return offset + linearId * info.strides[0];
   }
 };
 
@@ -254,17 +254,15 @@ struct IndexToOffset<T, IndexType, -1> {
 
     IndexType offset = 0;
 
-    // Use dynamic dims
+    // Uses dynamic dims
     for (int i = info.dims - 1; i > 0; --i) {
       IndexType curDimIndex = linearId % info.sizes[i];
       IndexType curDimOffset = curDimIndex * info.strides[i];
       offset += curDimOffset;
-
       linearId /= info.sizes[i];
     }
-    offset += linearId * info.strides[0];
 
-    return offset;
+    return offset + linearId * info.strides[0];
   }
 };
 
@@ -292,8 +290,7 @@ struct OffsetInfo {
       offset += divmod.mod * strides[i];
     }
 
-    offset += linearIndex * strides[0];
-    return &data[offset];
+    return &data[offset + linearIndex * strides[0]];
   }
 
   T* data;
@@ -302,7 +299,6 @@ struct OffsetInfo {
 };
 
 // For 1D tensors the offset equals linear index * stride.
-// Note: this specialization for readability only
 template <typename T, typename IndexType>
 struct OffsetInfo<T, IndexType, 1> {
   explicit OffsetInfo(const TensorInfo<T, IndexType>& tinfo)

--- a/aten/src/THC/THCTensorInfo.cuh
+++ b/aten/src/THC/THCTensorInfo.cuh
@@ -246,15 +246,6 @@ struct IndexToOffset {
   }
 };
 
-// For contiguous tensors, the offset = index
-template <typename T, typename IndexType>
-struct IndexToOffset<T, IndexType, -2> {
-  static inline __host__ __device__ IndexType
-    get(IndexType linearId, const TensorInfo<T, IndexType>& info) {
-    return linearId;
-  }
-};
-
 template <typename T, typename IndexType>
 struct IndexToOffset<T, IndexType, -1> {
   static inline __host__ __device__ IndexType get(
@@ -310,19 +301,19 @@ struct OffsetInfo {
   IndexType strides[Dims];
 };
 
-// For contiguous tensors (Dims=-2), offset equals linear index.
+// For 1D tensors the offset equals linear index * stride.
+// Note: this specialization for readability only
 template <typename T, typename IndexType>
-struct OffsetInfo<T, IndexType, -2> {
+struct OffsetInfo<T, IndexType, 1> {
   explicit OffsetInfo(const TensorInfo<T, IndexType>& tinfo)
-    : data(tinfo.data) {
-    assert(tinfo.isContiguous());
-  }
+    : data{tinfo.data}, stride{tinfo.strides[0]} {}
 
   __host__ __device__ T* get(IndexType linearIndex) const {
-    return &data[linearIndex];
+    return &data[linearIndex * stride];
   }
 
   T* data;
+  const IndexType stride;
 };
 
 // Dims=-1 is used when the dimension is unknown at compile time.


### PR DESCRIPTION
Currently in pointwise apply there are four special cases:

-2, a 1D tensor with stride == 1
-1, a nD tensor
1, a 1D tensor with stride != 1
2, a 2D (noncontiguous) tensor

There are also template specializations for the -2 special case in THC's OffsetInfo and and ATen's IndexToOffset. 

The practical difference, however, between the -2 and 1 code paths is only a multiplication. The -2 code path simply returns its input (implicitly * 1) while the 1 code path returns input * stride. Since the pointwise apply kernels are expected to be bandwidth bound, performing this additional multiplication likely has no performance impact. To demonstrate this empirically I reviewed the THC pointwise apply 1 and 2 kernels on 1D tensors of 3 billion, 1 billion, half a billion, and 1 million floats. Operations were performed on these tensors at strides of 1, 2, and 4. There was no significant performance difference between Master and this PR, with maximum variation of only .3% between the two, well within the observed noise of the experiments I was running (avg of 10 reps for the tensors of 1 billion or greater size, and 100 reps for the smaller tensors).

While there is (almost certainly) no performance change from this fix, it does reduce build time and simplify the existing code. Pointwise apply makes note of its sensitivity to excess template instantiations, after all.  

Note that, for readability, this PR currently leaves the dims = 1 instantiations of OffsetInfo and IndexToOffset. Without this the code path would be the same, although the reader would have to review the code somewhat carefully to determine this. Given the importance of 1D tensors it seemed appropriate to leave these specializations as a guide to readers.
