### PR TITLE
Replace incorrect usages of "NotImplemented"

### DIFF
--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -97,7 +97,7 @@ def _dispatch_kl(type_p, type_q):
     matches = [(super_p, super_q) for super_p, super_q in _KL_REGISTRY
                if issubclass(type_p, super_p) and issubclass(type_q, super_q)]
     if not matches:
-        return NotImplementedError
+        return NotImplemented
     # Check that the left- and right- lexicographic orders agree.
     left_p, left_q = min(_Match(*m) for m in matches).types
     right_q, right_p = min(_Match(*reversed(m)) for m in matches).types

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -97,7 +97,7 @@ def _dispatch_kl(type_p, type_q):
     matches = [(super_p, super_q) for super_p, super_q in _KL_REGISTRY
                if issubclass(type_p, super_p) and issubclass(type_q, super_q)]
     if not matches:
-        return NotImplemented
+        return NotImplementedError
     # Check that the left- and right- lexicographic orders agree.
     left_p, left_q = min(_Match(*m) for m in matches).types
     right_q, right_p = min(_Match(*reversed(m)) for m in matches).types

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -45,7 +45,7 @@ class _BatchNorm(Module):
             self.bias.data.zero_()
 
     def _check_input_dim(self, input):
-        return NotImplemented
+        return NotImplementedError
 
     def forward(self, input):
         self._check_input_dim(input)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -45,7 +45,7 @@ class _BatchNorm(Module):
             self.bias.data.zero_()
 
     def _check_input_dim(self, input):
-        return NotImplementedError
+        raise NotImplementedError
 
     def forward(self, input):
         self._check_input_dim(input)

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -9,7 +9,7 @@ class _InstanceNorm(_BatchNorm):
             num_features, eps, momentum, affine, track_running_stats)
 
     def _check_input_dim(self, input):
-        return NotImplemented
+        return NotImplementedError
 
     def _load_from_state_dict(self, state_dict, prefix, strict, missing_keys, unexpected_keys, error_msgs):
         try:

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -9,7 +9,7 @@ class _InstanceNorm(_BatchNorm):
             num_features, eps, momentum, affine, track_running_stats)
 
     def _check_input_dim(self, input):
-        return NotImplementedError
+        raise NotImplementedError
 
     def _load_from_state_dict(self, state_dict, prefix, strict, missing_keys, unexpected_keys, error_msgs):
         try:


### PR DESCRIPTION
Fixes #7266. Replaces "NotImplemented" (which is supposed to be used for
binary ops) with the correct "NotImplementedError".

cc @soumith 
