### PR TITLE
Don't initialize the current device in CUDAGenerator::CUDAGenerator

### DIFF
--- a/aten/src/ATen/cuda/CUDAGenerator.cpp
+++ b/aten/src/ATen/cuda/CUDAGenerator.cpp
@@ -5,8 +5,9 @@
 #include "THCTensorRandom.h"
 #include <stdexcept>
 
-#define const_generator_cast(generator) \
-  dynamic_cast<const CUDAGenerator&>(generator)
+// There is only one CUDAGenerator instance. Calls to seed(), manualSeed(),
+// initialSeed(), and unsafeGetTH() refer to the THCGenerator on the current
+// device.
 
 THCGenerator* THCRandom_getGenerator(THCState* state);
 
@@ -15,9 +16,6 @@ namespace at {
 CUDAGenerator::CUDAGenerator(Context * context_)
   : context(context_)
 {
-  // there's no reason to call THCRandom_init, because it is called
-  // during THCudaInit, which is called before this initializer
-  generator = THCRandom_getGenerator(context->getTHCState());
 }
 
 CUDAGenerator::~CUDAGenerator() {
@@ -52,7 +50,7 @@ CUDAGenerator& CUDAGenerator::manualSeedAll(uint64_t seed) {
 }
 
 void * CUDAGenerator::unsafeGetTH() {
-  return (void *) generator;
+  return (void*)THCRandom_getGenerator(context->thc_state);
 }
 
 } // namespace at

--- a/aten/src/ATen/cuda/CUDAGenerator.cpp
+++ b/aten/src/ATen/cuda/CUDAGenerator.cpp
@@ -50,7 +50,7 @@ CUDAGenerator& CUDAGenerator::manualSeedAll(uint64_t seed) {
 }
 
 void * CUDAGenerator::unsafeGetTH() {
-  return (void*)THCRandom_getGenerator(context->thc_state);
+  return (void*)THCRandom_getGenerator(context->getTHCState());
 }
 
 } // namespace at

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -141,7 +141,7 @@ generators = {
     },
     'CUDAGenerator.h': {
         'name': 'CUDA',
-        'th_generator': 'THCGenerator * generator;',
+        'th_generator': '',
         'header': 'THC/THC.h'
     },
 }


### PR DESCRIPTION
Previously, CUDAGenerator::CUDAGenerator would initialize the random
number generator on the current device. This would usually be device 0.
This is undesirable because initialize the CUDA context allocates a few
100 MBs due to all the kernels in libTHC.so.

This avoids the unecessary call to THCRandom_getGenerator() in the
CUDAGenerator constructor.

Fixes #7320

