### PR TITLE
Make omnigraph public dependency of caffe2 main lib

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -252,7 +252,7 @@ if(BUILD_CAFFE2)
         caffe2_pybind11_state PROPERTIES LIBRARY_OUTPUT_DIRECTORY
         ${CMAKE_BINARY_DIR}/caffe2/python)
     target_link_libraries(
-        caffe2_pybind11_state caffe2_library nomnigraph)
+        caffe2_pybind11_state caffe2_library)
     install(TARGETS caffe2_pybind11_state DESTINATION "${PYTHON_LIB_REL_PATH}/caffe2/python")
 
     if(USE_CUDA)
@@ -267,7 +267,7 @@ if(BUILD_CAFFE2)
           caffe2_pybind11_state_gpu PROPERTIES LIBRARY_OUTPUT_DIRECTORY
           ${CMAKE_BINARY_DIR}/caffe2/python)
       target_link_libraries(
-          caffe2_pybind11_state_gpu caffe2_library nomnigraph caffe2_gpu_library)
+          caffe2_pybind11_state_gpu caffe2_library caffe2_gpu_library)
       install(TARGETS caffe2_pybind11_state_gpu DESTINATION "${PYTHON_LIB_REL_PATH}/caffe2/python")
     endif()
 

--- a/caffe2/core/nomnigraph/CMakeLists.txt
+++ b/caffe2/core/nomnigraph/CMakeLists.txt
@@ -6,9 +6,16 @@ exclude(NOMNI_SRCS "${NOMNI_SRCS}" "${NOMNI_TEST_SRCS}")
 add_library(nomnigraph STATIC "${NOMNI_SRCS}")
 add_dependencies(nomnigraph Caffe_PROTO Caffe2_PROTO)
 
-target_include_directories(nomnigraph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-list(APPEND Caffe2_DEPENDENCY_LIBS nomnigraph)
-set(Caffe2_DEPENDENCY_LIBS ${Caffe2_DEPENDENCY_LIBS} PARENT_SCOPE)
+target_include_directories(nomnigraph PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+list(APPEND Caffe2_PUBLIC_DEPENDENCY_LIBS nomnigraph)
+set(Caffe2_PUBLIC_DEPENDENCY_LIBS ${Caffe2_PUBLIC_DEPENDENCY_LIBS} PARENT_SCOPE)
+
+install(TARGETS nomnigraph EXPORT Caffe2Targets DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
 
 if (BUILD_TEST)
   foreach(test_src ${NOMNI_TEST_SRCS})


### PR DESCRIPTION
otherwise some symbols from nomnigraph lib will get dropped by the linker when building in BUILD_SHARED_LIBS=OFF mode