### PR TITLE
 Use set_type to implement type conversions in C++ API 

### DIFF
--- a/test/cpp/api/container.cpp
+++ b/test/cpp/api/container.cpp
@@ -26,7 +26,7 @@ class NestedModel : public CloneableModule<NestedModel> {
   }
 
   void initialize_parameters() override {
-    add(Var(DefaultTensor(at::kFloat).tensor({3, 2, 21}), false), "param");
+    add(Var(at::CPU(at::kFloat).tensor({3, 2, 21}), false), "param");
   }
 
   variable_list forward(variable_list input) override {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -5,77 +5,74 @@
 using namespace torch;
 using namespace torch::nn;
 
-TEST_CASE("module") {
-  SECTION("training mode") {
-    auto model = make(Linear(3, 4));
-    REQUIRE(model->is_training());
-    SECTION("Enable eval mode") {
-      model->eval();
-      REQUIRE(!model->is_training());
-    }
-    SECTION("Enable train mode") {
-      model->train();
-      REQUIRE(model->is_training());
-    }
+TEST_CASE("module/training-mode") {
+  auto model = make(Linear(3, 4));
+  REQUIRE(model->is_training());
+  SECTION("Enable eval mode") {
+    model->eval();
+    REQUIRE(!model->is_training());
   }
-  SECTION("zero_grad") {
-    auto model = make(Linear(3, 4));
-    auto weights = Var(at::ones(at::CPU(at::kFloat), {8, 3}));
-    auto loss = model->forward({weights}).front().sum();
-    backward(loss);
-    for (auto& parameter : model->parameters()) {
-      Variable grad = parameter.second.grad();
-      REQUIRE(grad.defined());
-      REQUIRE(grad.sum().toCFloat() != 0);
-    }
-    model->zero_grad();
-    for (auto& parameter : model->parameters()) {
-      Variable grad = parameter.second.grad();
-      REQUIRE(grad.defined());
-      REQUIRE(grad.sum().toCFloat() == 0);
-    }
+  SECTION("Enable train mode") {
+    model->train();
+    REQUIRE(model->is_training());
   }
 }
 
-TEST_CASE("module_cuda", "[cuda]") {
-  SECTION("conversions") {
-    auto model = make(LSTM(128, 64).nlayers(3).dropout(0.2));
-    SECTION("starts as float on CPU") {
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().backend() == at::kCPU);
-        REQUIRE(parameter.second.type().scalarType() == at::kFloat);
-      }
+TEST_CASE("module/zero-grad") {
+  auto model = make(Linear(3, 4));
+  auto weights = Var(at::ones(at::CPU(at::kFloat), {8, 3}));
+  auto loss = model->forward({weights}).front().sum();
+  backward(loss);
+  for (auto& parameter : model->parameters()) {
+    Variable grad = parameter.second.grad();
+    REQUIRE(grad.defined());
+    REQUIRE(grad.sum().toCFloat() != 0);
+  }
+  model->zero_grad();
+  for (auto& parameter : model->parameters()) {
+    Variable grad = parameter.second.grad();
+    REQUIRE(grad.defined());
+    REQUIRE(grad.sum().toCFloat() == 0);
+  }
+}
+
+TEST_CASE("module/conversions", "[cuda]") {
+  auto model = make(LSTM(128, 64).nlayers(3).dropout(0.2));
+  SECTION("starts as float on CPU") {
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().backend() == at::kCPU);
+      REQUIRE(parameter.second.type().scalarType() == at::kFloat);
     }
-    SECTION("to(CUDA)") {
-      model->cuda();
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().backend() == at::kCUDA);
-      }
+  }
+  SECTION("to(CUDA)") {
+    model->cuda();
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().backend() == at::kCUDA);
     }
-    SECTION("to(CPU)") {
-      model->to(at::kCPU);
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().backend() == at::kCPU);
-      }
+  }
+  SECTION("to(CPU)") {
+    model->to(at::kCPU);
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().backend() == at::kCPU);
     }
-    SECTION("to(Int)") {
-      model->to(at::kInt);
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().scalarType() == at::kInt);
-      }
+  }
+  SECTION("to(Int)") {
+    model->to(at::kInt);
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().scalarType() == at::kInt);
     }
-    SECTION("to(Double)") {
-      model->to(at::kDouble);
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().scalarType() == at::kDouble);
-      }
+  }
+  SECTION("to(Double)") {
+    model->to(at::kDouble);
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().scalarType() == at::kDouble);
     }
-    SECTION("to(CUDA(Float))") {
-      model->to(at::CUDA(at::kFloat));
-      for (auto& parameter : model->parameters()) {
-        REQUIRE(parameter.second.type().backend() == at::kCUDA);
-        REQUIRE(parameter.second.type().scalarType() == at::kFloat);
-      }
+  }
+  SECTION("to(CUDA(Float))") {
+    model->to(at::CUDA(at::kFloat));
+    for (auto& parameter : model->parameters()) {
+      REQUIRE(parameter.second.type().backend() == at::kCUDA);
+      REQUIRE(parameter.second.type().scalarType() == at::kFloat);
     }
   }
 }

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -1,0 +1,81 @@
+#include <catch.hpp>
+
+#include <torch/torch.h>
+
+using namespace torch;
+using namespace torch::nn;
+
+TEST_CASE("module") {
+  SECTION("training mode") {
+    auto model = make(Linear(3, 4));
+    REQUIRE(model->is_training());
+    SECTION("Enable eval mode") {
+      model->eval();
+      REQUIRE(!model->is_training());
+    }
+    SECTION("Enable train mode") {
+      model->train();
+      REQUIRE(model->is_training());
+    }
+  }
+  SECTION("zero_grad") {
+    auto model = make(Linear(3, 4));
+    auto weights = Var(at::ones(at::CPU(at::kFloat), {8, 3}));
+    auto loss = model->forward({weights}).front().sum();
+    backward(loss);
+    for (auto& parameter : model->parameters()) {
+      Variable grad = parameter.second.grad();
+      REQUIRE(grad.defined());
+      REQUIRE(grad.sum().toCFloat() != 0);
+    }
+    model->zero_grad();
+    for (auto& parameter : model->parameters()) {
+      Variable grad = parameter.second.grad();
+      REQUIRE(grad.defined());
+      REQUIRE(grad.sum().toCFloat() == 0);
+    }
+  }
+}
+
+TEST_CASE("module_cuda", "[cuda]") {
+  SECTION("conversions") {
+    auto model = make(LSTM(128, 64).nlayers(3).dropout(0.2));
+    SECTION("starts as float on CPU") {
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().backend() == at::kCPU);
+        REQUIRE(parameter.second.type().scalarType() == at::kFloat);
+      }
+    }
+    SECTION("to(CUDA)") {
+      model->cuda();
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().backend() == at::kCUDA);
+      }
+    }
+    SECTION("to(CPU)") {
+      model->to(at::kCPU);
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().backend() == at::kCPU);
+      }
+    }
+    SECTION("to(Int)") {
+      model->to(at::kInt);
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().scalarType() == at::kInt);
+      }
+    }
+    SECTION("to(Double)") {
+      model->to(at::kDouble);
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().scalarType() == at::kDouble);
+      }
+    }
+    SECTION("to(CUDA(Float))") {
+      model->to(at::CUDA(at::kFloat));
+      for (auto& parameter : model->parameters()) {
+        REQUIRE(parameter.second.type().backend() == at::kCUDA);
+        REQUIRE(parameter.second.type().scalarType() == at::kFloat);
+      }
+    }
+  }
+}

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -310,12 +310,13 @@ if (NOT NO_API)
   set(TORCH_API_TEST_DIR "${TORCH_SRC_DIR}/../test/cpp/api")
 
   add_executable(test_api
-    ${TORCH_API_TEST_DIR}/main.cpp
     ${TORCH_API_TEST_DIR}/container.cpp
-    ${TORCH_API_TEST_DIR}/misc.cpp
-    ${TORCH_API_TEST_DIR}/rnn.cpp
     ${TORCH_API_TEST_DIR}/integration.cpp
+    ${TORCH_API_TEST_DIR}/main.cpp
+    ${TORCH_API_TEST_DIR}/misc.cpp
+    ${TORCH_API_TEST_DIR}/module.cpp
     ${TORCH_API_TEST_DIR}/optim.cpp
+    ${TORCH_API_TEST_DIR}/rnn.cpp
     ${TORCH_API_TEST_DIR}/serialization.cpp)
 
   target_include_directories(test_api

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -31,13 +31,19 @@ class Module {
 
   virtual void cuda();
   virtual void cpu();
+
+  virtual void to(at::Type& type);
+  virtual void to(at::ScalarType scalar_type);
+  virtual void to(at::Backend backend);
+
   void train();
   void eval();
 
   at::Type& DefaultTensor(at::ScalarType s);
 
   std::unordered_map<std::string, std::shared_ptr<nn::Module>> children_;
-  std::unordered_map<std::string, Variable> params_;
+  std::unordered_map<std::string, Variable> parameters_;
+
   bool cuda_ = false;
   bool train_ = true;
 
@@ -87,7 +93,7 @@ class CloneableModule : public Module {
     auto ptr = std::unique_ptr<Module>(
         new Derived(*static_cast<const Derived*>(this)));
     ptr->children_.clear();
-    ptr->params_.clear();
+    ptr->parameters_.clear();
     ptr->initialize_containers();
     ptr->initialize_parameters();
     auto newParams = ptr->parameters();

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -8,8 +8,11 @@ void BatchNorm::initialize_parameters() {
   }
 
   if (stateful_) {
-    running_mean = Var(at::CPU(at::kFloat).zeros({num_features_}), false);
-    running_var = Var(at::CPU(at::kFloat).ones({num_features_}), false);
+    // TODO: Make into buffers instead of parameters
+    running_mean = this->add(
+        Var(at::CPU(at::kFloat).zeros({num_features_}), false), "running_mean");
+    running_var = this->add(
+        Var(at::CPU(at::kFloat).ones({num_features_}), false), "running_var");
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -3,15 +3,13 @@
 namespace torch { namespace nn {
 void BatchNorm::initialize_parameters() {
   if (affine_) {
-    weight = this->add(
-        Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
-    bias = this->add(
-        Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "bias");
+    weight = this->add(Var(at::CPU(at::kFloat).empty(num_features_)), "weight");
+    bias = this->add(Var(at::CPU(at::kFloat).empty(num_features_)), "bias");
   }
 
   if (stateful_) {
-    running_mean = Var(DefaultTensor(at::kFloat).zeros({num_features_}), false);
-    running_var = Var(DefaultTensor(at::kFloat).ones({num_features_}), false);
+    running_mean = Var(at::CPU(at::kFloat).zeros({num_features_}), false);
+    running_var = Var(at::CPU(at::kFloat).ones({num_features_}), false);
   }
 }
 
@@ -32,7 +30,7 @@ variable_list BatchNorm::forward(variable_list inputs) {
   auto& running_mean = (stateful_ ? this->running_mean : inputs[1]);
   auto& running_var = (stateful_ ? this->running_var : inputs[2]);
 
-  if (train_) {
+  if (is_training()) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
     if (input.numel() / num_channels <= 1) {
       throw std::runtime_error(
@@ -46,7 +44,7 @@ variable_list BatchNorm::forward(variable_list inputs) {
       bias,
       running_mean,
       running_var,
-      train_,
+      is_training(),
       momentum_,
       eps_,
       hasCudnn());

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -23,11 +23,9 @@ void Conv::initialize_parameters() {
     wsize.push_back(in_channels_ / groups_);
   }
   wsize.insert(wsize.end(), ks_.begin(), ks_.end());
-  weight =
-      this->add(Var(DefaultTensor(at::kFloat).tensor(wsize), true), "weight");
+  weight = this->add(Var(at::CPU(at::kFloat).empty(wsize)), "weight");
   if (!no_bias_) {
-    bias = this->add(
-        Var(DefaultTensor(at::kFloat).tensor({out_channels_}), true), "bias");
+    bias = this->add(Var(at::CPU(at::kFloat).empty(out_channels_)), "bias");
   } else {
     assert(!bias.defined());
   }

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -2,7 +2,7 @@
 
 namespace torch { namespace nn {
 variable_list Dropout::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_)
+  if (p_ == 0 || !is_training())
     return inputs;
   variable_list lst;
   for (auto x : inputs) {
@@ -16,7 +16,7 @@ variable_list Dropout::forward(variable_list inputs) {
 }
 
 variable_list Dropout2d::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_)
+  if (p_ == 0 || !is_training())
     return inputs;
   variable_list lst;
   for (auto x : inputs) {

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -14,8 +14,7 @@ void Embedding::reset_parameters() {
 
 void Embedding::initialize_parameters() {
   weight = this->add(
-      Var(DefaultTensor(at::kFloat).tensor({num_embeddings, embedding_dim}),
-          true),
+      Var(at::CPU(at::kFloat).empty({num_embeddings, embedding_dim})),
       "weight");
 }
 

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -24,11 +24,10 @@ void Linear::reset_parameters() {
 }
 
 void Linear::initialize_parameters() {
-  weight = this->add(
-      Var(DefaultTensor(at::kFloat).tensor({nout, nin}), true), "weight");
+  weight =
+      this->add(Var(at::CPU(at::kFloat).empty({nout, nin}), true), "weight");
   if (!no_bias_) {
-    bias =
-        this->add(Var(DefaultTensor(at::kFloat).tensor({nout}), true), "bias");
+    bias = this->add(Var(at::CPU(at::kFloat).empty(nout), true), "bias");
   }
 }
 }} // namespace torch::nn


### PR DESCRIPTION
This PR implements in-place type conversions in the C++ API/autogradpp. More precisely:
1. Implements `to(backend)`, `to(scalar_type)` and `to(type)` using `at::detail::set_type`, which changes a `Variable`'s `data()`'s type, as well as the `Variable`'s type itself. This effectively means type conversions can be performed in-place on Variables, where autogradpp had to design its API around re-initializing variables either in CUDA or CPU "mode".
2. Removes the `cuda_` flag from `Module`. The type of variables is now no longer a property of the module, but simply a property of the parameters of a module. This is equivalent to Python.
3. Removes `DefaultTensor` by either constructing new variables on the CPU, or constructing variables using dispatch from other variable's `.type()` member, to make them the same type.
4. Small naming change from `params_` to `parameters_`. I've kept the map a public member for now, but this will change in another PR that better encapsulates them.
5. Also adds `zero_grad()`, to be consistent with the Python API.

@ebetica @jgehring @apaszke @ezyang 