### PR TITLE
Make optimizer not complain about parameters with requires_grad=False (#7338)

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -189,8 +189,6 @@ class Optimizer(object):
             if not isinstance(param, torch.Tensor):
                 raise TypeError("optimizer can only optimize Tensors, "
                                 "but one of the params is " + torch.typename(param))
-            if not param.requires_grad:
-                raise ValueError("optimizing a parameter that doesn't require gradients")
             if not param.is_leaf:
                 raise ValueError("can't optimize a non-leaf Tensor")
 


### PR DESCRIPTION
This makes optimizer not complain about the parameters that do not require gradients (`requires_grad=False`), as they don't affect it anyway. This allows for easier and cleaner construction of an optimizer without having to prefilter the parameters. Referenced and discussed in #7338 .