### PR TITLE
skip test_utils.TestFFI.test_cpu for ppc64le due to incompatible exception handling

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import platform
 import re
 import inspect
 import argparse
@@ -43,6 +44,7 @@ PY3 = sys.version_info > (3, 0)
 PY34 = sys.version_info >= (3, 4)
 
 IS_WINDOWS = sys.platform == "win32"
+IS_PPC = platform.machine() == "ppc64le"
 
 TEST_NUMPY = True
 try:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,7 +20,7 @@ from torch.utils.trainer.plugins.plugin import Plugin
 from torch.utils.serialization import load_lua
 from torch.autograd._functions.utils import prepare_onnx_paddings
 from torch.autograd._functions.utils import check_onnx_broadcast
-from common import IS_WINDOWS
+from common import IS_WINDOWS, IS_PPC
 
 HAS_CUDA = torch.cuda.is_available()
 
@@ -361,6 +361,7 @@ class TestFFI(TestCase):
 
     @unittest.skipIf(not HAS_CFFI, "ffi tests require cffi package")
     @unittest.skipIf(IS_WINDOWS, "ffi doesn't currently work on Windows")
+    @unittest.skipIf(IS_PPC, "skip for ppc64le due to incompatible exception handling")
     def test_cpu(self):
         create_extension(
             name='test_extensions.cpulib',


### PR DESCRIPTION
I'm following suggestion from @ezyang regarding Issue #7093.  Skipping this test for ppc64le

