### PR TITLE
AUTOGRAD_ to TORCH_AUTOGRAD_ for macros

### DIFF
--- a/torch/csrc/api/README.md
+++ b/torch/csrc/api/README.md
@@ -24,7 +24,7 @@ make -j
 which tries to replicate PyTorch's MNIST model + training loop
 - The principled way to write a model is probably something like 
 ```
-AUTOGRAD_CONTAINER_CLASS(MyModel) {
+TORCH_AUTOGRAD_CONTAINER_CLASS(MyModel) {
   // This does a 2D convolution, followed by global sum pooling, followed by a linear.
  public:
   void initialize_containers() override {

--- a/torch/csrc/api/include/torch/detail.h
+++ b/torch/csrc/api/include/torch/detail.h
@@ -11,9 +11,9 @@
 // While this object is in scope, all of your GPU tensors will go to GPU 1
 #include "torch/csrc/utils/auto_gpu.h"
 
-#define AUTOGRAD_OPTIMIZER_CLASS(Type) \
+#define TORCH_AUTOGRAD_OPTIMIZER_CLASS(Type) \
   class Type : public torch::Optimizer_CRTP<Type>
-#define AUTOGRAD_KWARG(CLS, TYP, NAME, DEFAULT, OPTION) \
+#define TORCH_AUTOGRAD_KWARG(CLS, TYP, NAME, DEFAULT, OPTION) \
   TYP NAME##_ = DEFAULT;                                \
   CLS& NAME(TYP x = OPTION) {                           \
     NAME##_ = x;                                        \

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -11,10 +11,10 @@ class BatchNorm : public torch::nn::CloneableModule<BatchNorm> {
  public:
   BatchNorm(uint32_t num_features) : num_features_(num_features) {}
 
-  AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
-  AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
-  AUTOGRAD_KWARG(BatchNorm, bool, affine, true, true)
-  AUTOGRAD_KWARG(BatchNorm, bool, stateful, false, true)
+  TORCH_AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
+  TORCH_AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
+  TORCH_AUTOGRAD_KWARG(BatchNorm, bool, affine, true, true)
+  TORCH_AUTOGRAD_KWARG(BatchNorm, bool, stateful, false, true)
 
   void reset_parameters() override;
   variable_list forward(variable_list) override;

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -53,9 +53,9 @@ class Conv : public torch::nn::CloneableModule<Conv> {
     return *this;
   }
 
-  AUTOGRAD_KWARG(Conv, bool, transposed, false, true)
-  AUTOGRAD_KWARG(Conv, bool, no_bias, false, true)
-  AUTOGRAD_KWARG(Conv, int, groups, 1, 1)
+  TORCH_AUTOGRAD_KWARG(Conv, bool, transposed, false, true)
+  TORCH_AUTOGRAD_KWARG(Conv, bool, no_bias, false, true)
+  TORCH_AUTOGRAD_KWARG(Conv, int, groups, 1, 1)
 
   Variable weight, bias;
   uint32_t Nd_;

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -15,7 +15,7 @@ class Linear : public torch::nn::CloneableModule<Linear> {
   variable_list forward(variable_list) override;
   void reset_parameters() override;
   void initialize_parameters() override;
-  AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
+  TORCH_AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
 
   Variable weight, bias;
   uint32_t nin, nout;

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -18,10 +18,10 @@ class RNNBase : public nn::CloneableModule<Derived> {
   RNNBase(uint32_t input_size, uint32_t hidden_size)
       : input_size_(input_size), hidden_size_(hidden_size) {}
 
-  AUTOGRAD_KWARG(RNNBase, RNNMode, mode, RNNMode::LSTM, RNNMode::LSTM)
-  AUTOGRAD_KWARG(RNNBase, uint32_t, nlayers, 1, 1);
-  AUTOGRAD_KWARG(RNNBase, bool, no_bias, false, true)
-  AUTOGRAD_KWARG(RNNBase, float, dropout, 0, 0)
+  TORCH_AUTOGRAD_KWARG(RNNBase, RNNMode, mode, RNNMode::LSTM, RNNMode::LSTM)
+  TORCH_AUTOGRAD_KWARG(RNNBase, uint32_t, nlayers, 1, 1);
+  TORCH_AUTOGRAD_KWARG(RNNBase, bool, no_bias, false, true)
+  TORCH_AUTOGRAD_KWARG(RNNBase, float, dropout, 0, 0)
 
   bool flatten_parameters(); // Flatten for cudnn
 

--- a/torch/csrc/api/include/torch/optimizers.h
+++ b/torch/csrc/api/include/torch/optimizers.h
@@ -36,14 +36,14 @@ class Optimizer_CRTP : public OptimizerImpl {
   Optimizer_CRTP() {}
 };
 
-AUTOGRAD_OPTIMIZER_CLASS(SGD) {
+TORCH_AUTOGRAD_OPTIMIZER_CLASS(SGD) {
  public:
   SGD(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
-  AUTOGRAD_KWARG(SGD, double, momentum, 0, 0);
-  AUTOGRAD_KWARG(SGD, double, dampening, 0, 0);
-  AUTOGRAD_KWARG(SGD, double, weight_decay, 0, 0);
-  AUTOGRAD_KWARG(SGD, bool, nesterov, false, true);
+  TORCH_AUTOGRAD_KWARG(SGD, double, momentum, 0, 0);
+  TORCH_AUTOGRAD_KWARG(SGD, double, dampening, 0, 0);
+  TORCH_AUTOGRAD_KWARG(SGD, double, weight_decay, 0, 0);
+  TORCH_AUTOGRAD_KWARG(SGD, bool, nesterov, false, true);
   double lr_;
   void step() override;
   void init_state() override;
@@ -59,12 +59,12 @@ AUTOGRAD_OPTIMIZER_CLASS(SGD) {
   std::unordered_map<std::string, at::Tensor> momentum_buffers_;
 };
 
-AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
+TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
  public:
   Adagrad(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
-  AUTOGRAD_KWARG(Adagrad, double, lr_decay, 0, 0);
-  AUTOGRAD_KWARG(Adagrad, double, weight_decay, 0, 0);
+  TORCH_AUTOGRAD_KWARG(Adagrad, double, lr_decay, 0, 0);
+  TORCH_AUTOGRAD_KWARG(Adagrad, double, weight_decay, 0, 0);
   double lr_;
   void step() override;
   void init_state() override;
@@ -82,15 +82,15 @@ AUTOGRAD_OPTIMIZER_CLASS(Adagrad) {
   std::unordered_map<std::string, double> step_;
 };
 
-AUTOGRAD_OPTIMIZER_CLASS(RMSprop) {
+TORCH_AUTOGRAD_OPTIMIZER_CLASS(RMSprop) {
  public:
   RMSprop(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
-  AUTOGRAD_KWARG(RMSprop, double, alpha, 0.99, 0.99);
-  AUTOGRAD_KWARG(RMSprop, double, eps, 1e-8, 1e-8);
-  AUTOGRAD_KWARG(RMSprop, double, weight_decay, 0, 0);
-  AUTOGRAD_KWARG(RMSprop, double, momentum, 0, 0);
-  AUTOGRAD_KWARG(RMSprop, bool, centered, false, true);
+  TORCH_AUTOGRAD_KWARG(RMSprop, double, alpha, 0.99, 0.99);
+  TORCH_AUTOGRAD_KWARG(RMSprop, double, eps, 1e-8, 1e-8);
+  TORCH_AUTOGRAD_KWARG(RMSprop, double, weight_decay, 0, 0);
+  TORCH_AUTOGRAD_KWARG(RMSprop, double, momentum, 0, 0);
+  TORCH_AUTOGRAD_KWARG(RMSprop, bool, centered, false, true);
 
   double lr_;
   void step() override;
@@ -111,15 +111,15 @@ AUTOGRAD_OPTIMIZER_CLASS(RMSprop) {
   std::unordered_map<std::string, at::Tensor> grad_avg_buffer_;
 };
 
-AUTOGRAD_OPTIMIZER_CLASS(Adam) {
+TORCH_AUTOGRAD_OPTIMIZER_CLASS(Adam) {
  public:
   Adam(std::shared_ptr<nn::Module> model, double lr)
       : Optimizer_CRTP(model), lr_(lr) {}
-  AUTOGRAD_KWARG(Adam, double, beta1, 0.9, 0.9);
-  AUTOGRAD_KWARG(Adam, double, beta2, 0.999, 0.999);
-  AUTOGRAD_KWARG(Adam, double, weight_decay, 0, 0);
-  AUTOGRAD_KWARG(Adam, double, eps, 1e-8, 1e-8);
-  AUTOGRAD_KWARG(Adam, bool, amsgrad, false, true);
+  TORCH_AUTOGRAD_KWARG(Adam, double, beta1, 0.9, 0.9);
+  TORCH_AUTOGRAD_KWARG(Adam, double, beta2, 0.999, 0.999);
+  TORCH_AUTOGRAD_KWARG(Adam, double, weight_decay, 0, 0);
+  TORCH_AUTOGRAD_KWARG(Adam, double, eps, 1e-8, 1e-8);
+  TORCH_AUTOGRAD_KWARG(Adam, bool, amsgrad, false, true);
   double lr_;
   void step() override;
   void init_state() override;


### PR DESCRIPTION
if we use ebetica/autogradpp and the torch/csrc/api at the same time, we run into "macro redefinition" warnings/errors.

This resolves it