### PR TITLE
Throw error in tensor constructor when numpy strides mismatch

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1973,6 +1973,11 @@ class TestTorch(TestCase):
             a[0] = 7.
             self.assertEqual(5., res1[0].item())
 
+            # test ill-sized strides raise exception
+            b = np.array([3., 5., 8.])
+            b.strides = (3,)
+            self.assertRaises(ValueError, lambda: torch.tensor(b))
+
     def test_tensor_factory_type_inference(self):
         def test_inference(default_dtype):
             saved_dtype = torch.get_default_dtype()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1973,11 +1973,6 @@ class TestTorch(TestCase):
             a[0] = 7.
             self.assertEqual(5., res1[0].item())
 
-            # test ill-sized strides raise exception
-            b = np.array([3., 5., 8.])
-            b.strides = (3,)
-            self.assertRaises(ValueError, lambda: torch.tensor(b))
-
     def test_tensor_factory_type_inference(self):
         def test_inference(default_dtype):
             saved_dtype = torch.get_default_dtype()
@@ -6749,6 +6744,11 @@ class TestTorch(TestCase):
         # check zero dimensional
         x = np.zeros((0, 2))
         self.assertEqual(torch.from_numpy(x).shape, (0,))
+
+        # check ill-sized strides raise exception
+        x = np.array([3., 5., 8.])
+        x.strides = (3,)
+        self.assertRaises(ValueError, lambda: torch.from_numpy(x))
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_ctor_with_numpy_array(self):

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -96,6 +96,11 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
   // NumPy strides use bytes. Torch strides use element counts.
   auto element_size_in_bytes = PyArray_ITEMSIZE(array);
   for (auto& stride : strides) {
+    if (stride%element_size_in_bytes != 0) {
+      throw ValueError(
+        "given numpy array strides not a multiple of the element byte size. "
+        "Copy the numpy array to reallocate the memory.");
+    }
     stride /= element_size_in_bytes;
   }
 


### PR DESCRIPTION
When constructing a `Tensor` from a `numpy` array, if the strides of the array are not divisible by the element byte size, the tensor will read from the wrong memory.  See #7271.

Following @apaszke's suggestion, this PR updates `tensor_from_numpy` to throw an error if such a case is encountered.

As an aside, I tested this against #7278 and I believe that's a separate issue.