### PR TITLE
Provide default implementation of clone() in base module

### DIFF
--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -26,7 +26,7 @@ class Module {
   virtual void reset_parameters(){};
 
   virtual variable_list forward(variable_list) = 0;
-  virtual std::unique_ptr<Module> clone() const = 0;
+  virtual std::unique_ptr<Module> clone() const;
 
   std::map<std::string, Variable> parameters() const;
   Variable& param(std::string const&);

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -2,6 +2,8 @@
 
 #include <torch/csrc/autograd/generated/VariableType.h>
 
+#include <ATen/Error.h>
+
 #include <algorithm>
 #include <cassert>
 #include <map>
@@ -12,6 +14,16 @@
 namespace torch { namespace nn {
 
 Module::Module() : is_training_(true) {}
+
+std::unique_ptr<Module> Module::clone() const {
+  AT_ERROR(
+      "clone() has not been implemented for ",
+      "_____________name_______________",
+      ". Use the copy constructor if you don't require polymorphic cloning. "
+      "Otherwise, subclass torch::nn::CloneableModule<",
+      "_____________name_______________",
+      "> instead of torch::nn::Module to inherit the ability to clone.");
+}
 
 std::map<std::string, Variable> Module::parameters() const {
   std::map<std::string, Variable> ret;


### PR DESCRIPTION
This PR gives `torch::nn::Module::clone()` a default implementation, which throws the equivalent of `NotImplementedError`, instead of being pure virtual. This is because it should be possible to subclass `torch::nn::Module` without having to override`clone()`, when cloneing behavior is not required (this will very often be the case).

I have placed `________name________` placeholders where I will insert `name()` calls from my other PR #7409 

@ebetica @apaszke 