### PR TITLE
HOTFIX: update cmake version for OSX builds

### DIFF
--- a/test/expect/TestCollectEnv.test_pytorch_macos_1013_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_macos_1013_py3.expect
@@ -4,7 +4,7 @@ CUDA used to build PyTorch: None
 
 OS: Mac OSX 10.13.X
 GCC version: Could not collect
-CMake version: version 3.9.X
+CMake version: version 3.11.X
 
 Python version: 3.6
 Is CUDA available: No


### PR DESCRIPTION
Anaconda's `cmake` version is updated from 3.9 to 3.11. We need to update our env expect file as well to fix version mismatch error:
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-macos-10.13-py3-build-test/6297/consoleFull