### PR TITLE
[Caffe2] Enabled dilated grouped convolutions for CUDNN v7.1 and CPU

### DIFF
--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -39,6 +39,15 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
         dilation_h() == 1 && dilation_w() == 1,
         "The cudnn convolution does not support dilation yet.");
 #endif
+    // dilated grouped convolution supported in cuDNN v7.1
+#if !(CUDNN_VERSION_MIN(7,1,0))
+    if (group_ != 1) {
+      for (int dim = 0; dim < kernel_.size(); ++dim) {
+        OPERATOR_NEEDS_FEATURE(dilation_[dim] == 1,
+        "When group is used, dilation should not be set at the same time.");
+      }
+    }
+#endif
 
 #if CUDNN_VERSION_MIN(7, 0, 0)
     // verify TensorCore math is supported

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -170,15 +170,6 @@ class ConvPoolOpBase : public Operator<Context> {
       CAFFE_ENFORCE_GE(dilation_[dim], 0);
       CAFFE_ENFORCE_GE(stride_[dim], 0);
     }
-
-    if (group_ != 1) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
-        CAFFE_ENFORCE_EQ(
-            dilation_[dim],
-            1,
-            "When group is used, dilation should not be set at the same time.");
-      }
-    }
   }
 
   // Returns the input image dimensions for the current storage order type.


### PR DESCRIPTION
Caffe2 base convolution class contains condition that forbids grouped convolutions to have dilation. This condition most probably was caused by lack of support for such operations in CUDNN older than version 7.1. Caffe2 compiled with CUDNN v7.1 without this condition actually supports such convolutions, as well as its CPU version. This PR first moves the condition to CUDNN implementation and uses it only for older versions. 

Tested with CUDNN 7.1 and in CPU mode.
See #6901. 

