### PR TITLE
Buf check_unique fix for jit

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -816,9 +816,9 @@ class TracedModule(ScriptModule):
                 self._parameters[name] = param
                 check_unique(param)
         for name, buf in orig._buffers.items():
-            if param is not None:
+            if buf is not None:
                 self._buffers[name] = buf
-                check_unique(param)
+                check_unique(buf)
         self._orig_class = type(orig)
 
         if orig._backward_hooks or orig._forward_hooks or orig._forward_pre_hooks:


### PR DESCRIPTION
In `jit/__init__.py` check_unique throws an error for batchnorm layers:
```
...
  File "/home/vj/workspace/dgx-ray/utils/runner.py", line 40, in __init__
    model = TopLevelTracedModule(net)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 721, in init_then_register
    original_init(self, *args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 721, in init_then_register
    original_init(self, *args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 830, in __init__
    self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 721, in init_then_register
    original_init(self, *args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 830, in __init__
    self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 721, in init_then_register
    original_init(self, *args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 821, in __init__
    check_unique(param)
  File "/opt/conda/lib/python3.6/site-packages/torch/jit/__init__.py", line 809, in check_unique
    raise ValueError("TracedModules don't support parameter sharing between modules")
```

I assume there's a bug, where the code does `check_unique(param)` twice.