### PR TITLE
HOTFIX: update cmake version for Linux CUDA9 builds

### DIFF
--- a/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
+++ b/test/expect/TestCollectEnv.test_pytorch_linux_xenial_cuda9_cudnn7_py3.expect
@@ -4,7 +4,7 @@ CUDA used to build PyTorch: 9.0.X
 
 OS: Ubuntu 16.04.X LTS
 GCC version: (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609
-CMake version: version 3.9.X
+CMake version: version 3.11.X
 
 Python version: 3.6
 Is CUDA available: Yes


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/7456, we need to update `cmake` version for CUDA9 builds as well.

Sample CI error: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-cuda9-cudnn7-py3-test/7201//console