### PR TITLE
[jit] Change interpreter/fuser to work on Variables only

### DIFF
--- a/test/expect/TestJit.test_trace_size_with_grad.expect
+++ b/test/expect/TestJit.test_trace_size_with_grad.expect
@@ -1,0 +1,9 @@
+graph(%0 : Double(5, 2, 4)) {
+  %1 : Long() = aten::size[dim=1](%0)
+  %2 : Long() = aten::mul[other={2}](%1)
+  %3 : Long() = aten::size[dim=0](%0)
+  %4 : Long() = prim::Constant[value={2}]()
+  %5 : Dynamic = aten::stack[dim=0](%2, %3, %4)
+  %6 : Double(4, 5, 2) = aten::view(%0, %5)
+  return (%6);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -773,12 +773,12 @@ class TestJit(TestCase):
         del z
         check(False, True)
 
-    def test_trace_size(self):
+    def do_trace_size(self, requires_grad):
         def fn(x):
             return x.view(x.shape[1] * 2, x.size(0), 2)
 
-        x = torch.randn(5, 2, 4)
-        y = torch.randn(4, 8, 4)
+        x = torch.randn(5, 2, 4, requires_grad=requires_grad)
+        y = torch.randn(4, 8, 4, requires_grad=requires_grad)
 
         # Check that it behaves as expected
         traced_fn = torch.jit.trace(x)(fn)
@@ -788,6 +788,14 @@ class TestJit(TestCase):
         # Check that the trace looks ok
         trace, _ = torch.jit.get_trace_graph(fn, (x,))
         self.assertExpectedTrace(trace)
+
+    def test_trace_size(self):
+        self.do_trace_size(False)
+
+    # test the different graph_executor path that happens when
+    # gradients are required and sizes are involved
+    def test_trace_size_with_grad(self):
+        self.do_trace_size(True)
 
     def test_multiuse_fn(self):
         x = Variable(torch.randn(2, 2), requires_grad=True)

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -211,7 +211,8 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/import.cpp
   ${TORCH_SRC_DIR}/csrc/onnx/onnx.cpp
   ${TORCH_SRC_DIR}/csrc/onnx/onnx.pb.cpp
-  ${TORCH_SRC_DIR}/csrc/Exceptions.cpp)
+  ${TORCH_SRC_DIR}/csrc/Exceptions.cpp
+  ${TORCH_SRC_DIR}/csrc/torch.cpp)
 
 if (NOT NO_API)
   list(APPEND TORCH_SRCS

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -27,7 +27,7 @@ namespace {
 // pack takes the return values of aten functions pushes them onto the stack
 template<typename T>
 void pack(Stack & stack, T&& v) {
-  stack.push_back(as_tensor(std::move(v)));
+  stack.push_back(as_variable(std::move(v)));
 }
 template<>
 void pack(Stack & stack, Tensor&& v) {
@@ -86,7 +86,6 @@ std::array<bool, N> as_bool_array(const std::vector<int64_t>& vec) {
   std::copy(vec.begin(), vec.end(), res.begin());
   return res;
 }
-
 
 using operator_constructor = std::function<TensorOp(jit::Node*)>;
 std::unordered_map<std::string, operator_constructor> constructors = {

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -167,12 +167,29 @@ struct Attributes {
   CREATE_ACCESSOR(Strings,ss)
   CREATE_ACCESSOR(Int,i)
   CREATE_ACCESSOR(Ints,is)
-  CREATE_ACCESSOR(Tensor,t)
-  CREATE_ACCESSOR(Tensors,ts)
   CREATE_ACCESSOR(Graph,g)
   CREATE_ACCESSOR(Graphs,gs)
 
   #undef CREATE_ACCESSOR
+
+  // does not use CREATE_ACCESSOR because we need additional asserts
+  Derived* t_(Symbol name, TensorAttr::ConstructorType v) {
+    JIT_ASSERT(!v.defined() || !v.is_variable_or_undefined());
+    return set<TensorAttr>(name,std::forward<TensorAttr::ConstructorType>(v));
+  }
+  const TensorAttr::ValueType& t(Symbol name) const {
+    return get<TensorAttr>(name);
+  }
+
+  Derived* ts_(Symbol name, TensorsAttr::ConstructorType v) {
+    for(auto & t : v) {
+      JIT_ASSERT(!t.defined() || !t.is_variable_or_undefined());
+    }
+    return set<TensorsAttr>(name,std::forward<TensorsAttr::ConstructorType>(v));
+  }
+  const TensorsAttr::ValueType& ts(Symbol name) const {
+    return get<TensorsAttr>(name);
+  }
 
 private:
   Derived* This() {

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -4,6 +4,8 @@
 #include "torch/csrc/jit/code_template.h"
 #include "torch/csrc/jit/resource_guard.h"
 #include "torch/csrc/utils/disallow_copy.h"
+#include "torch/csrc/torch_api.h"
+
 #include "ATen/ATen.h"
 #ifdef WITH_CUDA
 #include "torch/csrc/cuda/cuda_check.h"
@@ -473,7 +475,7 @@ void CompiledFusionFunction::launch(at::ArrayRef<at::Tensor> inputs, std::vector
   outputs.clear();
   outputs.reserve(outputDescriptors().size());
   for(auto & od : outputDescriptors()) {
-    outputs.push_back(at::getType(backend(),od.scalar_type).tensor());
+    outputs.push_back(torch::getType(backend(),od.scalar_type).tensor());
   }
   launch_with_tensors(inputs, outputs);
 }

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -4,7 +4,7 @@
 #include "torch/csrc/jit/code_template.h"
 #include "torch/csrc/jit/resource_guard.h"
 #include "torch/csrc/utils/disallow_copy.h"
-#include "torch/csrc/torch_api.h"
+#include "torch/csrc/variable_tensor_functions.h"
 
 #include "ATen/ATen.h"
 #ifdef WITH_CUDA

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -72,27 +72,24 @@ private:
 // to the output Variables if present.
 struct ExecutionPlan {
   ExecutionPlan(std::shared_ptr<Graph>& graph)
-      : f(graph, /*values_are_variables=*/false) {}
+      : f(graph) {}
   ExecutionPlan(std::shared_ptr<Graph>& graph, Gradient grad)
-      : f(graph, /*values_are_variables=*/false),
+      : f(graph),
         grad(std::move(grad)),
         grad_executor(this->grad.df) {}
 
-  variable_tensor_list run(variable_tensor_list&& inputs) const {
+  variable_tensor_list run(variable_tensor_list&& stack) const {
     if(grad) {
-      return runWithGrad(std::move(inputs));
+      return runWithGrad(std::move(stack));
     }
-    // TODO: interpreter needs to accept moved inputs
-    // and delete incrementally
-    auto stack = unwrapVariables(std::move(inputs));
     InterpreterState(f).runOneStage(stack);
-    return wrapTensors(std::move(stack));
+    return stack;
   }
 private:
   // inplace to avoid allocations
-  tensor_list unwrapVariables(variable_tensor_list && list) const {
+  variable_tensor_list unwrapVariables(variable_tensor_list && list) const {
     for(auto & v : list) {
-      v = v.defined() ? autograd::as_variable_ref(v).data() : at::Tensor();
+      v = v.defined() ? autograd::as_variable_ref(v).detach() : at::Tensor();
     }
     return std::move(list);
   }
@@ -128,7 +125,7 @@ private:
 
     auto stack = unwrapVariables(std::move(inputs));
     InterpreterState(f).runOneStage(stack);
-    variable_tensor_list outputs = wrapTensors(std::move(stack));
+    variable_tensor_list outputs = std::move(stack);
 
     // hookup the gradients for the output tensors that require gradients
     // to the inputs to our gradient function df
@@ -171,7 +168,8 @@ struct GraphExecutorImpl {
   : graph(std::move(graph))
   , optimize(optimize)
   , num_inputs(this->graph->inputs().size())
-  , symbolically_differentiable(symbolically_differentiable) {}
+  , symbolically_differentiable(symbolically_differentiable)
+  , may_introduce_gradient(calcMayIntroduceGradient(this->graph->block())) {}
   GraphExecutorImpl(std::shared_ptr<Graph> graph, bool optimize)
   : GraphExecutorImpl(graph, optimize, isDifferentiable(*graph)) {}
 
@@ -262,10 +260,23 @@ private:
     return stack;
   }
 
-  static bool needsGradient(const variable_tensor_list & inputs) {
+  static bool calcMayIntroduceGradient(Block* b) {
+    for(Node* n : b->nodes()) {
+      if(n->kind() == prim::PythonOp)
+        return true;
+      for(Block* bb : n->blocks()) {
+        if(calcMayIntroduceGradient(bb))
+          return true;
+      }
+    }
+    return false;
+  }
+  bool needsGradient(const variable_tensor_list & inputs) {
     if (!autograd::GradMode::is_enabled()) {
       return false;
     }
+    if(may_introduce_gradient)
+      return true;
     for (const auto & tensor : inputs) {
       if(tensor.defined() && static_cast<const Variable&>(tensor).requires_grad())
         return true;
@@ -314,10 +325,11 @@ private:
     auto graph_ = graph->copy();
     runRequiredPasses(graph_);
     if(optimize) {
-      CreateAutodiffSubgraphs(*graph_);
+      if(!symbolically_differentiable)
+        CreateAutodiffSubgraphs(*graph_);
       runOptimization(graph_, /*graphMustSupportVariables=*/true);
     }
-    autograd_fallback = Code(graph_, /*values_are_variables=*/true);
+    autograd_fallback = Code(graph_);
     return autograd_fallback;
   }
   const ExecutionPlan & getOrCompile(const variable_tensor_list & inputs) {
@@ -334,7 +346,8 @@ private:
       return r.first->second;
     }
   }
-  bool needsGradient(const ArgumentSpec & spec) {
+
+  bool needsSymbolicGradient(const ArgumentSpec & spec) {
     for(size_t i = 0; i < spec.size(); ++i) {
       if(spec.tensorInfo(i).requires_grad())
         return true;
@@ -398,9 +411,9 @@ private:
   ExecutionPlan compileSpec(const ArgumentSpec & spec) {
     auto graph_ = graph->copy();
     runRequiredPasses(graph_);
-    
+
     specializeToSpec(graph_, spec);
-    if(!needsGradient(spec)) {
+    if(!needsSymbolicGradient(spec)) {
       runOptimization(graph_, /*graphMustSupportVariables=*/false);
       return ExecutionPlan(graph_);
     }
@@ -429,6 +442,12 @@ private:
   // GraphExecutor optimizes more aggresively when we _know_ the graph will be
   // symbolically differentiable.
   bool symbolically_differentiable;
+
+  // some ops, including python operations, can intorduce requires_grad=True
+  // variables even though no inputs to this graph are availiable, if
+  // the graph includes those operators then needGradient must be true
+  // regardles of input state.
+  bool may_introduce_gradient;
 
   // when this graph has some parts that are not symbolically_differentable,
   // but some input does require a derivative, we create and use autograd_fallback,

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -347,7 +347,7 @@ private:
     }
   }
 
-  bool needsSymbolicGradient(const ArgumentSpec & spec) {
+  bool argumentSpecRequiresGradient(const ArgumentSpec & spec) {
     for(size_t i = 0; i < spec.size(); ++i) {
       if(spec.tensorInfo(i).requires_grad())
         return true;
@@ -413,7 +413,7 @@ private:
     runRequiredPasses(graph_);
 
     specializeToSpec(graph_, spec);
-    if(!needsSymbolicGradient(spec)) {
+    if(!argumentSpecRequiresGradient(spec)) {
       runOptimization(graph_, /*graphMustSupportVariables=*/false);
       return ExecutionPlan(graph_);
     }

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -13,7 +13,7 @@
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/tensor_conversions.h"
-#include "torch/csrc/torch_api.h"
+#include "torch/csrc/variable_tensor_functions.h"
 
 #include <typeinfo>
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -13,6 +13,7 @@
 #include "torch/csrc/jit/graph_executor.h"
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/tensor_conversions.h"
+#include "torch/csrc/torch_api.h"
 
 #include <typeinfo>
 
@@ -406,20 +407,21 @@ struct HandleBuilder {
       handle->forward_inputs = std::make_shared<DummyFunction>();
     }
   }
-  autograd::Variable addInput(at::Tensor && input, const VariableFlags & flags_) {
+  autograd::Variable addInput(at::Tensor && input_, const VariableFlags & flags_) {
+    autograd::Variable& input = static_cast<autograd::Variable&>(input_);
     if(handle && flags_.requires_grad) {
-      auto variable = autograd::make_variable(std::move(input), /*requires_grad=*/false);
+      auto variable = autograd::make_variable(input.data(), /*requires_grad=*/false);
       autograd::create_gradient_edge(variable, handle->forward_inputs);
       return variable;
     } else {
-      return autograd::make_variable(std::move(input), /*requires_grad=*/false);
+      return autograd::make_variable(input.data(), /*requires_grad=*/false);
     }
   }
   at::Tensor addOutput(const autograd::Variable & output) {
     if(handle) {
       handle->forward_outputs.push_back(output.gradient_edge());
     }
-    return output.data();
+    return output.detach();
   }
   void writeTo(Stack & outputs) {
     // outputs takes ownership of handle
@@ -440,7 +442,7 @@ bool hasHandleOutput(Node * n) {
 }
 
 #ifndef NO_PYTHON
-Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
+Operation createPythonOperation(PythonOp* op) {
   py::function func = py::reinterpret_borrow<py::function>(py::handle(op->pyobj.get()));
   bool tracing_autograd_python_function = op->tracing_autograd_python_function;
   bool has_handle = hasHandleOutput(op);
@@ -505,21 +507,12 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
       builder.writeTo(stack);
       return 0;
     } else {
-      // In this case we're not hooking this PythonOp up to autograd. We always
-      // pass in and return Variables to the PythonOp. The flag
-      // values_are_variables indicates that the actual inputs and outputs are
-      // Variable types. In the case that this is false, we must wrap up inputs
-      // Tensors into Variables and we must unwrap the outputs to Tensors. In
-      // the other case, we pass in inputs and return outputs as-is
       for (auto arg_type : op->cconv) {
         if (arg_type == 's') {
           py_inputs[i] = py::reinterpret_borrow<py::object>(
               op->scalar_args[next_scalar++].get());
         } else if (arg_type == 't') {
           auto var = peek(stack, next_tensor, num_inputs);
-          if (!values_are_variables) {
-            var = autograd::make_variable(var);
-          }
           py_inputs[i] =
               py::reinterpret_steal<py::object>(THPVariable_Wrap(var));
           next_tensor++;
@@ -537,7 +530,7 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
         }
         THPVariable* var = (THPVariable*)entry.ptr();
         auto cdata = var->cdata;
-        stack.push_back(values_are_variables ? std::move(cdata) : cdata.data());
+        stack.push_back(std::move(cdata));
       };
 
       if (!PyTuple_Check(py_outputs.ptr())) {
@@ -561,7 +554,7 @@ Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
   };
 }
 #else
-Operation createPythonOperation(PythonOp* op, bool values_are_variables) {
+Operation createPythonOperation(PythonOp* op) {
   throw std::runtime_error("Trying to create Python operation from a C++ build");
   return [=](Stack & stack) {
     return 0;
@@ -626,9 +619,9 @@ Operation createEvalOperation(CppOp * op) {
 
 // Returns a function implementing functionality of a given node,
 // or nullptr if it's a no-op for autograd.
-Operation getOperation(jit::Node* node, bool values_are_variables) {
+Operation getOperation(jit::Node* node) {
   IR_IFM(node, PythonOp)
-    return createPythonOperation(value, values_are_variables);
+    return createPythonOperation(value);
   IR_ELSEIFM(CppOp)
     if(dynamic_cast<autograd::Eval*>(value->fn.get())) {
       return createEvalOperation(value);
@@ -648,19 +641,11 @@ Operation getOperation(jit::Node* node, bool values_are_variables) {
       return 0;
     };
   IR_ELSEIF(Constant)
-  if (values_are_variables) {
-    auto t = torch::autograd::make_variable(value->t(attr::value), false);
-    return [t](Stack& stack) {
+    auto t = autograd::make_variable(value->t(attr::value));
+    return [t](Stack & stack) {
       stack.push_back(t);
       return 0;
     };
-    } else {
-      auto t = value->t(attr::value);
-      return [t](Stack & stack) {
-        stack.push_back(t);
-        return 0;
-      };
-    }
   IR_ELSEIF(Undefined)
     return [](Stack & stack) {
       stack.push_back(at::Tensor());
@@ -751,13 +736,10 @@ Operation getOperation(jit::Node* node, bool values_are_variables) {
         return [=](Stack& stack) {
           auto t = pop(stack);
           at::IntList sizes = t.sizes();
-          auto sizes_tensor = at::CPU(at::kLong).tensor(sizes.size());
+          auto sizes_tensor = torch::CPU(at::kLong).tensor(sizes.size());
           auto accessor = sizes_tensor.accessor<int64_t, 1>();
           for (size_t i=0; i<sizes.size(); ++i) {
             accessor[i] = sizes[i];
-          }
-          if (values_are_variables) {
-            sizes_tensor = torch::autograd::make_variable(sizes_tensor);
           }
           stack.push_back(sizes_tensor);
           return 0;
@@ -803,8 +785,8 @@ int relativeJump(int from_inst, int to_inst) {
 }
 
 struct CodeImpl {
-  CodeImpl(std::shared_ptr<Graph>& graph_, bool values_are_variables)
-      : values_are_variables(values_are_variables), preprocess(*graph_) {
+  CodeImpl(std::shared_ptr<Graph>& graph_)
+      : preprocess(*graph_) {
     graph = preprocess.graph;
     //std::cout << "into code graph:\n" << *graph << "\n";
     insertNodesFromBlock(graph->block());
@@ -931,7 +913,7 @@ struct CodeImpl {
 
   size_t insertInstruction(Node * n) {
     auto inst = insertInstruction(n->kind(), n->getSourceLocation(), n->inputs(), moveFlags(n) , n->outputs());
-    instructions[inst].callback = getOperation(n, values_are_variables);
+    instructions[inst].callback = getOperation(n);
     return inst;
   }
   size_t insertInstruction(Symbol sym,
@@ -1057,7 +1039,6 @@ struct CodeImpl {
   // It is also very useful for debugging interpreter problems to
   // keep this around.
   std::shared_ptr<Graph> graph;
-  bool values_are_variables;
   PreprocessGraph preprocess;
 
   std::unordered_map<size_t, int> unique_to_reg; // map from unique of nodes to register in register table
@@ -1163,8 +1144,8 @@ std::ostream & operator<<(std::ostream & out, const Code & code) {
   return out;
 }
 
-Code::Code(std::shared_ptr<Graph>& graph, bool values_are_variables)
-    : pImpl(new CodeImpl(graph, values_are_variables)) {}
+Code::Code(std::shared_ptr<Graph>& graph)
+    : pImpl(new CodeImpl(graph)) {}
 Code::~Code() {}
 InterpreterState::InterpreterState(const Code & function)
 : pImpl(new InterpreterStateImpl(function)) {}

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -19,9 +19,7 @@ struct TensorType;
 struct Code {
   Code()
   : pImpl(nullptr) {}
-  Code(std::shared_ptr<Graph>& graph, bool values_are_variables);
-  // values_are_variables = true means that all constants in the
-  // code will have VariableType rather than a base tensor type
+  Code(std::shared_ptr<Graph>& graph);
   ~Code();
   operator bool() const {
     return pImpl != nullptr;

--- a/torch/csrc/jit/passes/remove_expands.cpp
+++ b/torch/csrc/jit/passes/remove_expands.cpp
@@ -7,7 +7,7 @@ static void RemoveExpands(Block* block) {
        ++it) {
     for (auto sub : it->blocks())
       RemoveExpands(sub);
-    if (it->kind() == aten::expand && it->i(attr::implicit)) {
+    if (it->kind() == aten::expand && it->hasAttribute(attr::implicit) && it->i(attr::implicit)) {
       it->output()->replaceAllUsesWith(it->input());
       it.destroyCurrent();
     }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -91,11 +91,13 @@ void PropagateShapeOnNodeByRunningIt(Node* node, const std::vector<TensorType*>&
   for(auto & type : types) {
     stack.push_back(representativeTensor(type));
   }
+
   // XXX: we're not catching any exceptions from the op for now. This
   // is to uncover any mistakes we could make when editing this code,
   // and eventually it shouldn't matter, because this phase should be
   // preceded by schema checking.
   op_info.op(stack);
+
   JIT_ASSERT(stack.size() == node->outputs().size());
   for(size_t i = 0; i < stack.size(); ++i) {
     node->outputs()[i]->inferTypeFrom(stack[i]);

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -257,14 +257,14 @@ void initPythonIRBindings(PyObject * module_) {
       return variables;
     })
     .def("z_",[](Node & n, const char * name, at::Tensor v) {
-        return n.t_(Symbol::attr(name), v.view({}));
+        return n.t_(Symbol::attr(name), autograd::Variable(v.view({})).data());
     })
     .def("z",[](Node & n, const char * name) {
         return n.t(Symbol::attr(name));
     })
     .def("zs_",[](Node & n, const char * name, TensorsAttr::ValueType v) {
         for (size_t i = 0; i < v.size(); ++ i) {
-            v[i] = v[i].view({});
+            v[i] = autograd::Variable(v[i].view({})).data();
         }
         return n.ts_(Symbol::attr(name), std::move(v));
     })

--- a/torch/csrc/jit/tensor_conversions.h
+++ b/torch/csrc/jit/tensor_conversions.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <type_traits>
+#include "torch/csrc/autograd/variable.h"
 
 namespace torch { namespace jit {
 
@@ -84,6 +85,11 @@ inline at::Tensor as_tensor(at::IntList l) {
 
 inline at::Tensor as_tensor(const at::Scalar& s) {
   return s.toTensor();
+}
+
+template<typename T>
+inline at::Tensor as_variable(const T& t) {
+  return autograd::make_variable(as_tensor(t));
 }
 
 }} // namespace torch::jit

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -24,6 +24,7 @@
 #include "torch/csrc/jit/argument_spec.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/torch_api.h"
 
 #include "torch/csrc/assertions.h"
 
@@ -442,7 +443,7 @@ void interpTest() {
     auto w_hh  = t_def(at::randn(at::CUDA(at::kFloat), {4 * hidden_size, hidden_size}));
 
     auto lstm_g = build_lstm();
-    Code lstm_function(lstm_g, /*values_are_variables=*/false);
+    Code lstm_function(lstm_g);
     std::vector<at::Tensor> outputs;
     InterpreterState lstm_interp(lstm_function);
     runOneStage(lstm_interp, {input[0], hx, cx, w_ih, w_hh}, outputs);
@@ -468,7 +469,7 @@ void interpStageTest() {
 
 
     auto lstm_g = build_lstm_stages();
-    Code lstm_function(lstm_g, /*values_are_variables=*/false);
+    Code lstm_function(lstm_g);
     std::vector<at::Tensor> outputs;
     InterpreterState lstm_interp(lstm_function);
     runOneStage(lstm_interp, {input[0], hx, cx, w_ih, w_hh}, outputs);
@@ -546,8 +547,8 @@ std::pair<tensor_list, tensor_list> runGradient(Gradient& grad_spec,
                                                 tensor_list& tensors_in,
                                                 tensor_list& tensor_grads_in) {
   tensor_list tensors_out, tensor_grads_out;
-  Code f_code{grad_spec.f, /*values_are_variables=*/false},
-      df_code{grad_spec.df, /*values_are_variables=*/false};
+  Code f_code{grad_spec.f},
+      df_code{grad_spec.df};
   InterpreterState f_interpreter { f_code }, df_interpreter { df_code };
 
   runOneStage(f_interpreter, tensors_in, tensors_out);
@@ -866,13 +867,13 @@ void testControlFlow() {
   script::defineMethodsInModule(cu, cf_examples, torch::jit::script::Resolver(), nullptr);
   auto run = [&](const std::string & name, std::vector<at::Tensor> stack) {
     auto graph = cu.get_method(name).graph();
-    Code code(graph, /*values_are_variables=*/false);
+    Code code(graph);
     InterpreterState interp(code);
     interp.runOneStage(stack);
     return stack;
   };
 
-  auto L = [](int64_t l) { return at::Scalar(l).toTensor(); };
+  auto L = [](int64_t l) { return torch::toTensor(at::Scalar(l)); };
   auto V = [](at::Tensor t) { return at::Scalar(t).toLong(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
     return V(run(name, {L(a), L(b)})[0]);

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -24,7 +24,7 @@
 #include "torch/csrc/jit/argument_spec.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
-#include "torch/csrc/torch_api.h"
+#include "torch/csrc/variable_tensor_functions.h"
 
 #include "torch/csrc/assertions.h"
 
@@ -873,7 +873,7 @@ void testControlFlow() {
     return stack;
   };
 
-  auto L = [](int64_t l) { return torch::toTensor(at::Scalar(l)); };
+  auto L = [](int64_t l) { return autograd::make_variable(at::Scalar(l).toTensor()); };
   auto V = [](at::Tensor t) { return at::Scalar(t).toLong(); };
   auto run_binary = [&](const std::string & name, int64_t a, int64_t b) {
     return V(run(name, {L(a), L(b)})[0]);

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -9,6 +9,7 @@
 #include "torch/csrc/autograd/functions/special.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/remove_expands.h"
+#include "torch/csrc/torch_api.h"
 
 #include <string>
 #include <sstream>
@@ -256,7 +257,7 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   auto tracing_state = getTracingState({var});
   auto & graph = tracing_state->graph;
 
-  auto size_var = autograd::make_variable(at::Scalar(var.size(dim)).toTensor());
+  auto size_var = torch::toTensor(at::Scalar(var.size(dim)));
   auto* value = getValueTrace(tracing_state, var);
   auto* node = graph->create(aten::size, {value})
                     ->i_(attr::dim, dim);

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -9,7 +9,7 @@
 #include "torch/csrc/autograd/functions/special.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/remove_expands.h"
-#include "torch/csrc/torch_api.h"
+#include "torch/csrc/variable_tensor_functions.h"
 
 #include <string>
 #include <sstream>
@@ -257,7 +257,7 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   auto tracing_state = getTracingState({var});
   auto & graph = tracing_state->graph;
 
-  auto size_var = torch::toTensor(at::Scalar(var.size(dim)));
+  auto size_var = autograd::make_variable(at::Scalar(var.size(dim)).toTensor());
   auto* value = getValueTrace(tracing_state, var);
   auto* node = graph->create(aten::size, {value})
                     ->i_(attr::dim, dim);

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -1,4 +1,4 @@
-#include <torch/csrc/torch_api.h>
+#include <torch/csrc/variable_tensor_functions.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/autograd/variable.h>
 

--- a/torch/csrc/torch.cpp
+++ b/torch/csrc/torch.cpp
@@ -1,4 +1,4 @@
-#include <torch/csrc/torch.h>
+#include <torch/csrc/torch_api.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/autograd/variable.h>
 
@@ -13,6 +13,10 @@ at::Type& CPU(at::ScalarType type) {
 
 at::Type& CUDA(at::ScalarType type) {
   return torch::getType(at::kCUDA, type);
+}
+
+at::Tensor toTensor(const at::Scalar& scalar) {
+  return autograd::make_variable(scalar.toTensor());
 }
 
 void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept {

--- a/torch/csrc/torch.h
+++ b/torch/csrc/torch.h
@@ -2,31 +2,6 @@
 
 #include <Python.h>
 
-#include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
-#include <torch/csrc/THP_export.h>
 #include <torch/csrc/utils/pybind.h>
-
-namespace torch {
-
-// NOTE: This API is currently highly experimental and may change drastically
-// in the near future.
-
-/// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
-/// `ScalarType` (e.g. `at::kDouble`).
-THP_CLASS at::Type& getType(at::Backend backend, at::ScalarType type);
-
-/// Returns a `Type` object for the CPU backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
-THP_CLASS at::Type& CPU(at::ScalarType type);
-
-/// Returns a `Type` object for the CUDA backend and the given `ScalarType`
-/// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
-THP_CLASS at::Type& CUDA(at::ScalarType type);
-
-/// Sets the `requires_grad` property of the given `Tensor`.
-THP_CLASS void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept;
-
-/// Returns the `requires_grad` of the given `Tensor`.
-THP_CLASS bool requires_grad(const at::Tensor& tensor) noexcept;
-} // namespace torch
+#include <torch/csrc/torch_api.h>

--- a/torch/csrc/torch.h
+++ b/torch/csrc/torch.h
@@ -4,4 +4,4 @@
 
 #include <pybind11/pybind11.h>
 #include <torch/csrc/utils/pybind.h>
-#include <torch/csrc/torch_api.h>
+#include <torch/csrc/variable_tensor_functions.h>

--- a/torch/csrc/torch_api.h
+++ b/torch/csrc/torch_api.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <torch/csrc/THP_export.h>
+
+namespace torch {
+
+// NOTE: This API is currently highly experimental and may change drastically
+// in the near future.
+
+/// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
+/// `ScalarType` (e.g. `at::kDouble`).
+THP_CLASS at::Type& getType(at::Backend backend, at::ScalarType type);
+
+/// Returns a `Type` object for the CPU backend and the given `ScalarType`
+/// (e.g. `at::kDouble`). Equivalent to `getType(kCPU, type)`.
+THP_CLASS at::Type& CPU(at::ScalarType type);
+
+/// Returns a `Type` object for the CUDA backend and the given `ScalarType`
+/// (e.g. `at::kDouble`). Equivalent to `getType(kCUDA, type)`.
+THP_CLASS at::Type& CUDA(at::ScalarType type);
+
+/// Sets the `requires_grad` property of the given `Tensor`.
+THP_CLASS void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcept;
+
+/// Returns the `requires_grad` of the given `Tensor`.
+THP_CLASS bool requires_grad(const at::Tensor& tensor) noexcept;
+
+THP_CLASS at::Tensor toTensor(const at::Scalar& scalar);
+} // namespace torch

--- a/torch/csrc/variable_tensor_functions.h
+++ b/torch/csrc/variable_tensor_functions.h
@@ -8,6 +8,11 @@ namespace torch {
 // NOTE: This API is currently highly experimental and may change drastically
 // in the near future.
 
+// These functions provide a small wrapper around aten ensuring
+// that we create tensors with type Variable rather than raw tensors
+// when we create new tensors. We also provide a few accessors like requires_grad
+// that make it easier to get to varible information when we have a at::Tensor
+
 /// Returns a `Type` object for the given backend (e.g. `at::kCPU`) and
 /// `ScalarType` (e.g. `at::kDouble`).
 THP_CLASS at::Type& getType(at::Backend backend, at::ScalarType type);
@@ -26,5 +31,4 @@ THP_CLASS void set_requires_grad(at::Tensor& tensor, bool requires_grad) noexcep
 /// Returns the `requires_grad` of the given `Tensor`.
 THP_CLASS bool requires_grad(const at::Tensor& tensor) noexcept;
 
-THP_CLASS at::Tensor toTensor(const at::Scalar& scalar);
 } // namespace torch


### PR DESCRIPTION
* this removes the flag controlling whether the interpreter works on variables.
* now the interpreter _always_ works on variables
* constants in the IR are still _always_ non-variables, and an assert was added to ensure this.
* as_tensor was split into as_variable and as_tensor since it is sometimes used
  to construct constants in the IR
* I tried changing the IR to also always use variables but that change was much more
  cross cutting and fragile and I never got it working

Note: This change is blocking the translation work so it should be given high priority.
