### PR TITLE
[Caffe2]  Fix of the performance issue of IDEEP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ endif()
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
   # Eigen fails to build with some versions, so convert this to a warning
   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459
@@ -218,8 +218,8 @@ else()
   endforeach(flag_var)
 endif()
 
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 
 if(ANDROID)
   if(CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ endif()
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -fPIC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
   # Eigen fails to build with some versions, so convert this to a warning
   # Details at http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1459
@@ -218,8 +218,8 @@ else()
   endforeach(flag_var)
 endif()
 
-#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-#set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 
 if(ANDROID)
   if(CMAKE_COMPILER_IS_GNUCXX)

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -139,7 +139,7 @@ vector<float> SimpleNet::TEST_Benchmark(
           if (schema && schema->HasCostInferenceFunction()) {
             vector<TensorShape> shapes = op->InputTensorShapes();
 
-            OpSchema::Cost cost = schema->InferCost(op->debug_def(), shapes);
+            OpSchema::Cost cost ;//= schema->InferCost(op->debug_def(), shapes);
 
             flops_per_op.emplace_back(cost.flops);
             memory_bytes_per_op.emplace_back(cost.bytes_moved);
@@ -150,6 +150,7 @@ vector<float> SimpleNet::TEST_Benchmark(
             param_bytes_per_op_type[op_type] += cost.params_bytes;
           }
         }
+        std::cout << "Running op[" << idx << "]: " << op_type << std::endl;
         timer.Start();
         CAFFE_ENFORCE(
             op->Run(),

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -139,7 +139,17 @@ vector<float> SimpleNet::TEST_Benchmark(
           if (schema && schema->HasCostInferenceFunction()) {
             vector<TensorShape> shapes = op->InputTensorShapes();
 
-            OpSchema::Cost cost ;//= schema->InferCost(op->debug_def(), shapes);
+            auto all_good_shapes = std::accumulate(
+                shapes.begin(),
+                shapes.end(),
+                true,
+                [](bool acc, const TensorShape& shape) {
+                  return acc && !shape.unknown_shape();
+                });
+            OpSchema::Cost cost;
+            if (all_good_shapes) {
+              cost = schema->InferCost(op->debug_def(), shapes);
+            }
 
             flops_per_op.emplace_back(cost.flops);
             memory_bytes_per_op.emplace_back(cost.bytes_moved);
@@ -150,7 +160,6 @@ vector<float> SimpleNet::TEST_Benchmark(
             param_bytes_per_op_type[op_type] += cost.params_bytes;
           }
         }
-        std::cout << "Running op[" << idx << "]: " << op_type << std::endl;
         timer.Start();
         CAFFE_ENFORCE(
             op->Run(),

--- a/caffe2/ideep/operators/conv_op.cc
+++ b/caffe2/ideep/operators/conv_op.cc
@@ -36,7 +36,8 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
         "*",
         group_);
 
-    bool weights_changed = (cached_weights_descriptor_ != filter.get_descriptor());
+    bool weights_changed =
+        (cached_weights_descriptor_ != filter.get_descriptor());
     if (weights_changed && !training_mode_) {
       cached_weights_descriptor_ = filter.get_descriptor();
       filter_ = filter;
@@ -52,8 +53,16 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
 
     if (InputSize() > BIAS) {
       ideep::convolution_forward::compute(
-          X, training_mode_ ? filter : filter_, Input(BIAS), Y_dims, *Y,
-          stride_, dilation_, pad_tl(), pad_br(), group_);
+          X,
+          training_mode_ ? filter : filter_,
+          Input(BIAS),
+          Y_dims,
+          *Y,
+          stride_,
+          dilation_,
+          pad_tl(),
+          pad_br(),
+          group_);
     } else {
       ideep::convolution_forward::compute(
           X,
@@ -84,9 +93,9 @@ class IDEEPConvGradientOp final : public IDEEPConvPoolOpBase {
   USE_IDEEP_DEF_ALIASES();
   USE_IDEEP_CONV_POOL_BASE_FUNCTIONS();
 
-  IDEEPConvGradientOp(const OperatorDef& operator_def, Workspace *ws)
-    : IDEEPConvPoolOpBase(operator_def, ws),
-      no_bias_(OperatorBase::GetSingleArgument<int>("no_bias", 0)) {
+  IDEEPConvGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : IDEEPConvPoolOpBase(operator_def, ws),
+        no_bias_(OperatorBase::GetSingleArgument<int>("no_bias", 0)) {
     OPERATOR_NEEDS_FEATURE(
         pad_l() == pad_r() && pad_t() == pad_b(),
         "Uneven padding not supported.");
@@ -108,20 +117,42 @@ class IDEEPConvGradientOp final : public IDEEPConvPoolOpBase {
 
     if (no_bias_) {
       ideep::convolution_backward_weights::compute(
-          X, dY, filter.get_dims(), *dfilter,
-          stride_, dilation_, pad_tl(), pad_br(), group_);
+          X,
+          dY,
+          filter.get_dims(),
+          *dfilter,
+          stride_,
+          dilation_,
+          pad_tl(),
+          pad_br(),
+          group_);
     } else {
       auto* dbias = Output(BIAS_OR_INPUT_GRAD);
       ideep::convolution_backward_weights::compute(
-          X, dY, filter.get_dims(), *dfilter, *dbias,
-          stride_, dilation_, pad_tl(), pad_br(), group_);
+          X,
+          dY,
+          filter.get_dims(),
+          *dfilter,
+          *dbias,
+          stride_,
+          dilation_,
+          pad_tl(),
+          pad_br(),
+          group_);
     }
 
     if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
       auto* dX = Output(no_bias_ ? BIAS_OR_INPUT_GRAD : INPUT_GRAD);
       ideep::convolution_backward_data::compute(
-          dY, filter, X.get_dims(), *dX,
-          stride_, dilation_, pad_tl(), pad_br(), group_);
+          dY,
+          filter,
+          X.get_dims(),
+          *dX,
+          stride_,
+          dilation_,
+          pad_tl(),
+          pad_br(),
+          group_);
     }
 
     return true;
@@ -134,8 +165,7 @@ class IDEEPConvGradientOp final : public IDEEPConvPoolOpBase {
   OUTPUT_TAGS(FILTER_GRAD, BIAS_OR_INPUT_GRAD, INPUT_GRAD);
 };
 
-
 REGISTER_IDEEP_OPERATOR(Conv, IDEEPConvOp);
 REGISTER_IDEEP_OPERATOR(ConvGradient, IDEEPConvGradientOp);
 
-}  // namespace caffe2
+} // namespace caffe2

--- a/caffe2/ideep/operators/conv_op.cc
+++ b/caffe2/ideep/operators/conv_op.cc
@@ -51,6 +51,12 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
       }
     }
 
+    // NB: actually, in the case when `group_ > 1`, IDEEP will create
+    // an itermediate tensor for each run below. However, this tensor is merely
+    // a view of of the weights and there is no actual data copy, so I'll let it
+    // go now. If we encounter performance surprise when convoluting with group
+    // > 1, this is the first place to check and we need to do the same cache
+    // trick as above
     if (InputSize() > BIAS) {
       ideep::convolution_forward::compute(
           X,

--- a/caffe2/ideep/operators/conv_pool_base_op.h
+++ b/caffe2/ideep/operators/conv_pool_base_op.h
@@ -74,7 +74,7 @@ class IDEEPConvPoolOpBase : public ConvPoolOpBase<IDEEPContext> {
     try {
       return RunOnDeviceWithOrderNCHW();
     } catch (ideep::error& e) {
-      VLOG(1) << "IDEEP error:" << e.message; 
+      LOG(ERROR) << "IDEEP error:" << e.message;
       throw;
     }
   }

--- a/caffe2/ideep/utils/ideep_operator.h
+++ b/caffe2/ideep/utils/ideep_operator.h
@@ -56,7 +56,7 @@ class IDEEPOperator : public OperatorBase {
       err.AppendMessage(getErrorMsg());
       throw;
     } catch (ideep::error& e) {
-      VLOG(1) << "IDEEP error:" << e.message; 
+      LOG(ERROR) << "IDEEP error:" << e.message;
       throw;
     }
   }

--- a/caffe2/python/ideep/conv_op_test.py
+++ b/caffe2/python/ideep/conv_op_test.py
@@ -22,12 +22,14 @@ class ConvTest(hu.HypothesisTestCase):
            output_channels=st.integers(1, 5),
            batch_size=st.integers(1, 3),
            use_bias=st.booleans(),
+           training_mode=st.booleans(),
            group=st.integers(1, 2),
            **mu.gcs)
     @settings(deadline=None, timeout=unlimited)
     def test_convolution(self, stride, pad, kernel, size,
                              input_channels, output_channels,
-                             batch_size, use_bias, group, gc, dc):
+                             batch_size, use_bias, training_mode, group, gc, dc):
+        training = 1 if training_mode else 0
         op = core.CreateOperator(
             "Conv",
             ["X", "w", "b"] if use_bias else ["X", "w"],
@@ -35,7 +37,8 @@ class ConvTest(hu.HypothesisTestCase):
             stride=stride,
             pad=pad,
             kernel=kernel,
-            group=group
+            group=group,
+            training_mode=training,
         )
         X = np.random.rand(
             batch_size, input_channels * group, size, size).astype(np.float32) - 0.5
@@ -47,8 +50,9 @@ class ConvTest(hu.HypothesisTestCase):
         inputs = [X, w, b] if use_bias else [X, w]
         self.assertDeviceChecks(dc, op, inputs, [0])
 
-        for i in range(len(inputs)):
-            self.assertGradientChecks(gc, op, inputs, i, [0], threshold=0.01)
+        if training_mode:
+            for i in range(len(inputs)):
+                self.assertGradientChecks(gc, op, inputs, i, [0], threshold=0.01)
 
 
 if __name__ == "__main__":

--- a/caffe2/python/ideep/test_ideep_net.py
+++ b/caffe2/python/ideep/test_ideep_net.py
@@ -116,7 +116,10 @@ def benchmark(args):
             workspace.FeedBlob(name, blob, device_option)
         workspace.CreateNet(pred_net)
         start = time.time()
-        res = workspace.BenchmarkNet(pred_net.name, args.warmup_iterations, args.iterations, args.layer_wise_benchmark)
+        res = workspace.BenchmarkNet(pred_net.name,
+                                     args.warmup_iterations,
+                                     args.iterations,
+                                     args.layer_wise_benchmark)
         print("FPS: {:.2f}".format(1/res[0]*1000*args.batch_size))
 
 if __name__ == '__main__':

--- a/caffe2/python/ideep/test_ideep_net.py
+++ b/caffe2/python/ideep/test_ideep_net.py
@@ -116,7 +116,7 @@ def benchmark(args):
             workspace.FeedBlob(name, blob, device_option)
         workspace.CreateNet(pred_net)
         start = time.time()
-        res = workspace.BenchmarkNet(pred_net.name, args.warmup_iterations, args.iterations, False)
+        res = workspace.BenchmarkNet(pred_net.name, args.warmup_iterations, args.iterations, args.layer_wise_benchmark)
         print("FPS: {:.2f}".format(1/res[0]*1000*args.batch_size))
 
 if __name__ == '__main__':


### PR DESCRIPTION
The key performance issue of IDEEP is that the `conv` op always reshape the weights at each run (intel/ideep#7), creating an overhead. When batch size is small, the overhead is relatively huge and easily observable. Even when the batch size is large, the overhead is still not negligible, which makes IDEEP runs always slower than the MKLML ops. 

The fix here is to cache the transformed weights, following the same approach as the MKLML ops. Performance is greatly improved according to my resnet50 run on 12-core Broadwell, beating MKLML ops slightly with both small and large batch size. 

Performance numbers (FPS) on resnet50 with 12 core 2.5GHz Broadwell socket. The larger the better. 

Device|1-thread/batch-128 | 12-thread/batch-128|1-thread/batch-1 | 12-thread/batch-1
-------|---------|----------|---------|----------
MKLML|7.93|58.42|7.40|49.72
IDEEP|8.27|62.76|7.93|49.65

Test command
```
 KMP_AFFINITY=granularity=fine,compact,1 OMP_NUM_THREADS=12 MKL_NUM_THREADS=12 numactl -m 0 -N 0 python test_ideep_net.py --model resnet50 --batch_size 128 --layer_wise_benchmark --device {IDEEP|MKL}
```

**Note** that `FC` ops potentially have the same issue, but right now from profiling I don't see it popping out. And there is follow-ups in intel/ideep#7 to make sure we don't transform the weights in MKLDNN for that op. 