### PR TITLE
Some small fixes in C++ API

### DIFF
--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -2,6 +2,8 @@
 
 #include <torch/torch.h>
 
+#include <ATen/Error.h>
+
 using namespace torch;
 using namespace torch::nn;
 
@@ -86,7 +88,7 @@ class CartPole {
       reward = 0;
     } else {
       if (steps_beyond_done == 0) {
-        assert(false); // Can't do this
+        AT_ASSERT(false); // Can't do this
       }
     }
     step_++;
@@ -106,7 +108,7 @@ bool test_mnist(
   struct MNIST_Reader {
     FILE* fp_;
 
-    MNIST_Reader(const char* path) {
+    explicit MNIST_Reader(const char* path) {
       fp_ = fopen(path, "rb");
       if (!fp_)
         throw std::runtime_error("failed to open file");
@@ -117,17 +119,19 @@ bool test_mnist(
         fclose(fp_);
     }
 
-    int32_t read_int() {
+    uint32_t read_int() {
       uint8_t buf[4];
-      if (fread(buf, sizeof(buf), 1, fp_) != 1)
+      if (fread(buf, sizeof(buf), 1, fp_) != 1) {
         throw std::runtime_error("failed to read an integer");
-      return int32_t(buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3]);
+      }
+      return buf[0] << 24u | buf[1] << 16u | buf[2] << 8u | buf[3];
     }
 
     uint8_t read_byte() {
       uint8_t i;
-      if (fread(&i, sizeof(i), 1, fp_) != 1)
+      if (fread(&i, sizeof(i), 1, fp_) != 1) {
         throw std::runtime_error("failed to read an byte");
+      }
       return i;
     }
   };

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -58,14 +58,15 @@ TEST_CASE("module/zero-grad") {
 }
 
 TEST_CASE("module/name") {
+  // CHECK instead of REQUIRE because demangling may fail.
   AGIUnit agi;
   // Call it twice just to make sure there are no bugs in the lazy
   // initialization semantics.
-  REQUIRE(agi.name() == "AGIUnit");
-  REQUIRE(agi.name() == "AGIUnit");
+  CHECK(agi.name() == "AGIUnit");
+  CHECK(agi.name() == "AGIUnit");
   SECTION("correctly demangled") {
-    REQUIRE(test::AGIUnit().name() == "test::AGIUnit");
-    REQUIRE(test::AGIUnit2().name() == "Foo");
+    CHECK(test::AGIUnit().name() == "test::AGIUnit");
+    CHECK(test::AGIUnit2().name() == "Foo");
   }
 }
 

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -5,7 +5,6 @@
 #include <ATen/Error.h>
 
 #include <algorithm>
-#include <cassert>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -36,10 +35,10 @@ const std::string& Module::name() const noexcept {
 std::unique_ptr<Module> Module::clone() const {
   AT_ERROR(
       "clone() has not been implemented for ",
-      "_____________name_______________",
+      name(),
       ". Use the copy constructor if you don't require polymorphic cloning. "
       "Otherwise, subclass torch::nn::CloneableModule<",
-      "_____________name_______________",
+      name(),
       "> instead of torch::nn::Module to inherit the ability to clone.");
 }
 
@@ -114,8 +113,8 @@ void Module::to(at::Type& type) {
   for (auto& pair : parameters_) {
     auto& parameter = pair.second;
     at::detail::set_data(parameter, parameter.data().toType(type));
-    assert(parameter.data().type() == type);
-    assert(&parameter.type() == autograd::VariableType::getType(type));
+    AT_ASSERT(parameter.data().type() == type);
+    AT_ASSERT(&parameter.type() == autograd::VariableType::getType(type));
   }
 }
 
@@ -127,8 +126,8 @@ void Module::to(at::ScalarType scalar_type) {
     auto& parameter = pair.second;
     auto& new_type = parameter.data().type().toScalarType(scalar_type);
     at::detail::set_data(parameter, parameter.data().toType(new_type));
-    assert(parameter.data().type().scalarType() == scalar_type);
-    assert(parameter.type().scalarType() == scalar_type);
+    AT_ASSERT(parameter.data().type().scalarType() == scalar_type);
+    AT_ASSERT(parameter.type().scalarType() == scalar_type);
   }
 }
 
@@ -140,8 +139,8 @@ void Module::to(at::Backend backend) {
     auto& parameter = pair.second;
     auto& new_type = parameter.data().type().toBackend(backend);
     at::detail::set_data(parameter, parameter.data().toType(new_type));
-    assert(parameter.data().type().backend() == backend);
-    assert(parameter.type().backend() == backend);
+    AT_ASSERT(parameter.data().type().backend() == backend);
+    AT_ASSERT(parameter.type().backend() == backend);
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -1,6 +1,7 @@
 #include <torch/nn/modules/conv.h>
 
-#include <cassert>
+#include <ATen/Error.h>
+
 #include <stdexcept>
 
 namespace torch { namespace nn {
@@ -38,7 +39,7 @@ void Conv::initialize_parameters() {
   if (!no_bias_) {
     bias = this->add(Var(at::CPU(at::kFloat).empty(out_channels_)), "bias");
   } else {
-    assert(!bias.defined());
+    AT_ASSERT(!bias.defined());
   }
 }
 
@@ -55,12 +56,12 @@ void Conv::reset_parameters() {
 variable_list Conv::forward(variable_list input) {
   auto x = input[0];
   if (Nd_ == 1) {
-    assert(x.ndimension() == 3);
+    AT_ASSERT(x.ndimension() == 3);
     x = x.unsqueeze(-1); // TODO: Use conv1d once available
   } else if (Nd_ == 2) {
-    assert(x.ndimension() == 4);
+    AT_ASSERT(x.ndimension() == 4);
   } else if (Nd_ == 3) {
-    assert(x.ndimension() == 5);
+    AT_ASSERT(x.ndimension() == 5);
   } else {
     throw std::runtime_error("Only Conv{1,2,3}d are supported");
   }


### PR DESCRIPTION
1. Removes `assert()` in favor of `AT_ASSERT`,
2. clang-tidy lints

@apaszke @ezyang @ebetica 