### PR TITLE
put dropout states on the input device

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -587,9 +587,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 
   auto input = input_r;
   auto weight_buf = weight_buf_r;
-  auto input_arg = TensorArg(input, "input", 1);
-  auto dropout_state_arg = TensorArg(fn_dropout_state, "dropout_states", 15);
-  checkSameGPU("cudnn_rnn", input_arg, dropout_state_arg);
+  if (fn_dropout_state.defined()) {
+      auto input_arg = TensorArg(input, "input", 1);
+      auto dropout_state_arg = TensorArg(fn_dropout_state, "dropout_states", 15);
+      checkSameGPU("cudnn_rnn", input_arg, dropout_state_arg);
+  }
   RNNParams fn;
   fn.rnn.set(fn_mode, fn_hidden_size, fn_num_layers, fn_bidirectional, getCudnnDataType(input));
   fn.dropout.set(fn_train, fn_dropout, fn_dropout_state);

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/TensorUtils.h>
 #include <ATen/Config.h>
 #include <ATen/Error.h>
 #include <ATen/MatrixRef.h>
@@ -586,7 +587,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
 
   auto input = input_r;
   auto weight_buf = weight_buf_r;
-
+  auto input_arg = TensorArg(input, "input", 1);
+  auto dropout_state_arg = TensorArg(fn_dropout_state, "dropout_states", 15);
+  checkSameGPU("cudnn_rnn", input_arg, dropout_state_arg);
   RNNParams fn;
   fn.rnn.set(fn_mode, fn_hidden_size, fn_num_layers, fn_bidirectional, getCudnnDataType(input));
   fn.dropout.set(fn_train, fn_dropout, fn_dropout_state);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3381,6 +3381,15 @@ class TestNN(NNTestCase):
 
             (hx + cx).sum().backward()
 
+    @unittest.skipIf(not (TEST_CUDNN and TEST_MULTIGPU), 'CUDNN or multi-gpu not available')
+    def test_cudnn_rnn_dropout_states_device(self):
+        rnn = nn.RNN(10, 20, num_layers=2, dropout=.5)
+        device = 1
+        input = torch.randn(5, 4, 10).cuda(device)
+        rnn.cuda(device)
+        hx = torch.randn(2, 4, 20).cuda(device)
+        output = rnn(input, hx)
+
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_cudnn_weight_format(self):
         rnns = [

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -271,7 +271,8 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
             cx = None
 
         handle = cudnn.get_handle()
-        dropout_ts = cudnn.rnn.init_dropout_state(torch.uint8, torch.device('cuda'), dropout,
+        with torch.cuda.device(input.get_device()):
+            dropout_ts = cudnn.rnn.init_dropout_state(torch.uint8, torch.device('cuda'), dropout,
                                                   train, dropout_seed, dropout_state)
 
         weight_arr = list(itertools.chain.from_iterable(weight))

--- a/torch/nn/_functions/rnn.py
+++ b/torch/nn/_functions/rnn.py
@@ -273,7 +273,7 @@ def CudnnRNN(mode, input_size, hidden_size, num_layers=1,
         handle = cudnn.get_handle()
         with torch.cuda.device(input.get_device()):
             dropout_ts = cudnn.rnn.init_dropout_state(torch.uint8, torch.device('cuda'), dropout,
-                                                  train, dropout_seed, dropout_state)
+                                                      train, dropout_seed, dropout_state)
 
         weight_arr = list(itertools.chain.from_iterable(weight))
         weight_stride0 = len(weight[0])


### PR DESCRIPTION
Fix for #7280. Probably actual bindings in aten should have asserts that all the inputs and dropout states are on the same device, @ezyang if you can point me to a place where you are doing these checks, which at a quick glance I was not able to find, I'd add assert for dropout states in there, if there is no such place, I think it makes sense to add these checks. 