### PR TITLE
[C++ API] Remove initialize_* functions

### DIFF
--- a/test/cpp/api/container.cpp
+++ b/test/cpp/api/container.cpp
@@ -155,21 +155,6 @@ TEST_CASE("containers") {
     }
   }
 
-  SECTION("clone") {
-    auto model = make(TestModel());
-
-    auto model2 = model->clone();
-    auto m1param = model->parameters();
-    auto m2param = model2->parameters();
-    for (auto& param : m1param) {
-      REQUIRE(param.second.allclose(m2param[param.first]));
-      param.second.data().mul_(2);
-    }
-    for (auto& param : m1param) {
-      REQUIRE(!param.second.allclose(m2param[param.first]));
-    }
-  }
-
   SECTION("embedding") {
     SECTION("basic") {
       int dict_size = 10;

--- a/test/cpp/api/container.cpp
+++ b/test/cpp/api/container.cpp
@@ -7,7 +7,7 @@ using namespace torch::nn;
 
 class TestModel : public CloneableModule<TestModel> {
  public:
-  void initialize_containers() override {
+  TestModel() {
     add(make(Linear(10, 3)), "l1");
     add(make(Linear(3, 5)), "l2");
     add(make(Linear(5, 100)), "l3");
@@ -20,12 +20,9 @@ class TestModel : public CloneableModule<TestModel> {
 
 class NestedModel : public CloneableModule<NestedModel> {
  public:
-  void initialize_containers() override {
+  NestedModel() {
     add(make(Linear(5, 20)), "l1");
     add(make(TestModel()), "test");
-  }
-
-  void initialize_parameters() override {
     add(Var(at::CPU(at::kFloat).tensor({3, 2, 21}), false), "param");
   }
 

--- a/test/cpp/api/integration.cpp
+++ b/test/cpp/api/integration.cpp
@@ -357,10 +357,12 @@ TEST_CASE("integration/mnist", "[cuda]") {
 TEST_CASE("integration/mnist/batchnorm", "[cuda]") {
   auto model = make(SimpleContainer());
   auto conv1 = model->add(make(Conv2d(1, 10, 5)), "conv1");
-  auto batchnorm2d = model->add(make(BatchNorm(10).stateful()), "batchnorm2d");
+  auto batchnorm2d = model->add(
+      make(BatchNorm(10, /*affine=*/true, /*stateful=*/true)), "batchnorm2d");
   auto conv2 = model->add(make(Conv2d(10, 20, 5)), "conv2");
   auto linear1 = model->add(make(Linear(320, 50)), "linear1");
-  auto batchnorm1 = model->add(make(BatchNorm(50).stateful()), "batchnorm1");
+  auto batchnorm1 = model->add(
+      make(BatchNorm(50, /*affine=*/true, /*stateful=*/true)), "batchnorm1");
   auto linear2 = model->add(make(Linear(50, 10)), "linear2");
 
   auto forward = [&](Variable x) {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -138,4 +138,31 @@ TEST_CASE("module/clone") {
     Cloneable module;
     REQUIRE_NOTHROW(module.clone());
   }
+
+  SECTION("Cloning creates distinct parameters") {
+    struct TestModel : public CloneableModule<TestModel> {
+      TestModel() {
+        add(make(Linear(10, 3)), "l1");
+        add(make(Linear(3, 5)), "l2");
+        add(make(Linear(5, 100)), "l3");
+      }
+
+      variable_list forward(variable_list input) override {
+        return input;
+      }
+    };
+
+    auto model = make(TestModel());
+
+    auto model2 = model->clone();
+    auto m1param = model->parameters();
+    auto m2param = model2->parameters();
+    for (auto& param : m1param) {
+      REQUIRE(param.second.allclose(m2param[param.first]));
+      param.second.data().mul_(2);
+    }
+    for (auto& param : m1param) {
+      REQUIRE(!param.second.allclose(m2param[param.first]));
+    }
+  }
 }

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -71,7 +71,8 @@ TEST_CASE("module/name") {
 }
 
 TEST_CASE("module/conversions", "[cuda]") {
-  auto model = make(LSTM(128, 64).nlayers(3).dropout(0.2));
+  auto model =
+      make(LSTM(/*in=*/128, /*out=*/64, /*layers=*/3, /*dropout=*/0.2));
   SECTION("starts as float on CPU") {
     for (auto& parameter : model->parameters()) {
       REQUIRE(parameter.second.type().backend() == at::kCPU);

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -9,13 +9,13 @@ bool test_optimizer_xor(Optimizer optim, std::shared_ptr<ContainerList> model) {
   float running_loss = 1;
   int epoch = 0;
   while (running_loss > 0.1) {
-    auto bs = 4U;
+    int64_t bs = 4;
     auto inp = at::CPU(at::kFloat).tensor({bs, 2});
     auto lab = at::CPU(at::kFloat).tensor({bs});
-    for (auto i = 0U; i < bs; i++) {
-      auto a = std::rand() % 2;
-      auto b = std::rand() % 2;
-      auto c = a ^ b;
+    for (size_t i = 0; i < bs; i++) {
+      const int64_t a = std::rand() % 2;
+      const int64_t b = std::rand() % 2;
+      const int64_t c = static_cast<uint64_t>(a) ^ static_cast<uint64_t>(b);
       inp[i][0] = a;
       inp[i][1] = b;
       lab[i] = c;
@@ -23,7 +23,7 @@ bool test_optimizer_xor(Optimizer optim, std::shared_ptr<ContainerList> model) {
     // forward
     auto x = Var(inp);
     auto y = Var(lab, false);
-    for (auto layer : *model)
+    for (auto& layer : *model)
       x = layer->forward({x})[0].sigmoid_();
     Variable loss = at::binary_cross_entropy(x, y);
 
@@ -68,10 +68,10 @@ TEST_CASE("optim") {
   }
 
   /*
-  // This test appears to be flaky, see https://github.com/pytorch/pytorch/issues/7288
-  SECTION("adam") {
-    auto optim = Adam(model, 1.0).weight_decay(1e-6).make();
-    REQUIRE(test_optimizer_xor(optim, model));
+  // This test appears to be flaky, see
+  https://github.com/pytorch/pytorch/issues/7288 SECTION("adam") { auto optim =
+  Adam(model, 1.0).weight_decay(1e-6).make(); REQUIRE(test_optimizer_xor(optim,
+  model));
   }
   */
 

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -113,20 +113,19 @@ class CloneableModule : public Module {
  public:
   using Module::Module;
 
+  // should it also detach the gradients, like a deepcopy? Or maybe let's just
+  // give clone() a boolean for this?
   std::unique_ptr<Module> clone() const override {
     auto ptr = std::unique_ptr<Module>(
         new Derived(*static_cast<const Derived*>(this)));
-    ptr->children_.clear();
-    ptr->parameters_.clear();
-    auto newParams = ptr->parameters();
-    for (auto& param : parameters()) {
-      newParams[param.first].data().copy_(param.second.data());
+    for (auto& parameter : ptr->parameters_) {
+      parameter.second = this->parameters_.at(parameter.first).clone();
+    }
+    for (auto& child : ptr->children_) {
+      child.second = this->children_.at(child.first)->clone();
     }
     return ptr;
   }
-
-  // return std::unique_ptr<Module>(new
-  // Derived(static_cast<Derived&>(*this)));
 };
 
 template <class Module>

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -28,14 +28,6 @@ class Module {
   /// Returns the name of the `Module`.
   const std::string& name() const noexcept;
 
-  // Only construct parameters in initialize_parameters, and
-  // containers in initialize_containers. Most of the time, the containers are
-  // the only thing you need to add.
-  // You are guaranteed that containers are added before parameters.
-  virtual void initialize_containers(){};
-  virtual void initialize_parameters(){};
-  virtual void reset_parameters(){};
-
   virtual variable_list forward(variable_list) = 0;
   virtual std::unique_ptr<Module> clone() const;
 
@@ -126,8 +118,6 @@ class CloneableModule : public Module {
         new Derived(*static_cast<const Derived*>(this)));
     ptr->children_.clear();
     ptr->parameters_.clear();
-    ptr->initialize_containers();
-    ptr->initialize_parameters();
     auto newParams = ptr->parameters();
     for (auto& param : parameters()) {
       newParams[param.first].data().copy_(param.second.data());
@@ -143,9 +133,6 @@ template <class Module>
 std::shared_ptr<typename std::decay<Module>::type> make(Module&& module) {
   auto ptr = std::make_shared<typename std::decay<Module>::type>(
       std::forward<Module>(module));
-  ptr->initialize_containers();
-  ptr->initialize_parameters();
-  ptr->reset_parameters();
   return ptr;
 }
 }} // namespace torch::nn

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -16,9 +16,7 @@ class BatchNorm : public torch::nn::CloneableModule<BatchNorm> {
   TORCH_AUTOGRAD_KWARG(BatchNorm, bool, affine, true, true)
   TORCH_AUTOGRAD_KWARG(BatchNorm, bool, stateful, false, true)
 
-  void reset_parameters() override;
   variable_list forward(variable_list) override;
-  void initialize_parameters() override;
 
   Variable weight;
   Variable bias;

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -9,12 +9,13 @@
 namespace torch { namespace nn {
 class BatchNorm : public torch::nn::CloneableModule<BatchNorm> {
  public:
-  explicit BatchNorm(uint32_t num_features);
+  explicit BatchNorm(
+      uint32_t num_features,
+      bool affine = true,
+      bool stateful = false);
 
   TORCH_AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
   TORCH_AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
-  TORCH_AUTOGRAD_KWARG(BatchNorm, bool, affine, true, true)
-  TORCH_AUTOGRAD_KWARG(BatchNorm, bool, stateful, false, true)
 
   variable_list forward(variable_list) override;
 
@@ -23,7 +24,8 @@ class BatchNorm : public torch::nn::CloneableModule<BatchNorm> {
   Variable running_mean;
   Variable running_var;
 
- protected:
   uint32_t num_features_;
+  bool affine_;
+  bool stateful_;
 };
 }} // namespace torch::nn

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -12,10 +12,8 @@ class Embedding : public torch::nn::CloneableModule<Embedding> {
   Embedding(uint32_t num_embeddings, uint32_t embedding_dim);
 
   variable_list forward(variable_list) override;
-  void reset_parameters() override;
-  void initialize_parameters() override;
 
-  Variable weight;
   uint32_t num_embeddings, embedding_dim;
+  Variable weight;
 };
 }} // namespace torch::nn

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -13,12 +13,10 @@ class Linear : public torch::nn::CloneableModule<Linear> {
   Linear(uint32_t nin, uint32_t nout);
 
   variable_list forward(variable_list) override;
-  void reset_parameters() override;
-  void initialize_parameters() override;
   TORCH_AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
 
-  Variable weight, bias;
   uint32_t nin, nout;
+  Variable weight, bias;
 };
 
 }} // namespace torch::nn

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -4,19 +4,21 @@
 
 #include <torch/csrc/autograd/variable.h>
 
+#include <ATen/optional.h>
+
 #include <cstdint>
 
 namespace torch { namespace nn {
 
 class Linear : public torch::nn::CloneableModule<Linear> {
  public:
-  Linear(uint32_t nin, uint32_t nout);
+  Linear(uint32_t nin, uint32_t nout, bool with_bias = true);
 
   variable_list forward(variable_list) override;
-  TORCH_AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
 
   uint32_t nin, nout;
-  Variable weight, bias;
+  Variable weight;
+  at::optional<Variable> bias;
 };
 
 }} // namespace torch::nn

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -2,7 +2,8 @@
 
 namespace torch { namespace nn {
 
-BatchNorm::BatchNorm(uint32_t num_features) : num_features_(num_features) {
+BatchNorm::BatchNorm(uint32_t num_features, bool affine, bool stateful)
+    : num_features_(num_features), affine_(affine), stateful_(stateful) {
   if (affine_) {
     weight = add(
         Var(at::CPU(at::kFloat).empty({num_features_}).uniform_()), "weight");

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -2,32 +2,19 @@
 
 namespace torch { namespace nn {
 
-BatchNorm::BatchNorm(uint32_t num_features) : num_features_(num_features) {}
-
-void BatchNorm::initialize_parameters() {
+BatchNorm::BatchNorm(uint32_t num_features) : num_features_(num_features) {
   if (affine_) {
-    weight = this->add(Var(at::CPU(at::kFloat).empty(num_features_)), "weight");
-    bias = this->add(Var(at::CPU(at::kFloat).empty(num_features_)), "bias");
+    weight = add(
+        Var(at::CPU(at::kFloat).empty({num_features_}).uniform_()), "weight");
+    bias = add(Var(at::CPU(at::kFloat).zeros({num_features_})), "bias");
   }
 
   if (stateful_) {
     // TODO: Make into buffers instead of parameters
-    running_mean = this->add(
+    running_mean = add(
         Var(at::CPU(at::kFloat).zeros({num_features_}), false), "running_mean");
-    running_var = this->add(
+    running_var = add(
         Var(at::CPU(at::kFloat).ones({num_features_}), false), "running_var");
-  }
-}
-
-void BatchNorm::reset_parameters() {
-  if (affine_) {
-    weight.data().uniform_();
-    bias.data().zero_();
-  }
-
-  if (stateful_) {
-    running_mean.data().zero_();
-    running_var.data().fill_(1);
   }
 }
 

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -2,27 +2,58 @@
 
 #include <ATen/Error.h>
 
-#include <stdexcept>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
 
 namespace torch { namespace nn {
+namespace {
+IntVec makeTup(size_t number_of_dimensions, int x, int def = 0) {
+  IntVec ret;
+  if (number_of_dimensions == 1) {
+    ret.push_back(x);
+    ret.push_back(def);
+  } else {
+    for (size_t i = 0; i < number_of_dimensions; i++) {
+      ret.push_back(x);
+    }
+  }
+  return ret;
+}
+} // namespace
 
-Conv::Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan)
+Conv::Conv(
+    uint32_t Nd,
+    uint32_t in_chan,
+    uint32_t out_chan,
+    IntVec ks,
+    bool transposed,
+    bool with_bias,
+    int groups)
     : Nd_(Nd),
       in_channels_(in_chan),
       out_channels_(out_chan),
-      stride_(makeTup(1, 1)),
-      padding_(makeTup(0)),
-      dilation_(makeTup(1, 1)),
+      transposed_(transposed),
+      groups_(groups),
+      ks_(std::move(ks)),
+      stride_(makeTup(Nd, 1, 1)),
+      padding_(makeTup(Nd, 0)),
+      dilation_(makeTup(Nd, 1, 1)),
       dilated_(false),
-      output_padding_(makeTup(0)) {}
+      output_padding_(makeTup(Nd, 0)) {
+  AT_CHECK(
+      (Nd == 1) ? ks_.size() == 2 : ks_.size() == Nd,
+      "Kernel rank (",
+      ks_.size(),
+      ") must match number of dimensions (",
+      Nd,
+      ")");
 
-void Conv::initialize_parameters() {
   if (!transposed_) {
     for (auto pad : output_padding_) {
-      if (pad != 0) {
-        throw std::runtime_error(
-            "Only transposed convolutions support output padding!");
-      }
+      AT_CHECK(
+          pad == 0, "Only transposed convolutions support output padding!");
     }
   }
 
@@ -35,23 +66,39 @@ void Conv::initialize_parameters() {
     wsize.push_back(in_channels_ / groups_);
   }
   wsize.insert(wsize.end(), ks_.begin(), ks_.end());
-  weight = this->add(Var(at::CPU(at::kFloat).empty(wsize)), "weight");
-  if (!no_bias_) {
-    bias = this->add(Var(at::CPU(at::kFloat).empty(out_channels_)), "bias");
+  AT_ASSERT(wsize.size() == 2 + ks_.size());
+
+  weight = add(Var(at::CPU(at::kFloat).empty(wsize)), "weight");
+  if (with_bias) {
+    bias = add(Var(at::CPU(at::kFloat).empty(out_channels_)), "bias");
   } else {
     AT_ASSERT(!bias.defined());
   }
-}
 
-void Conv::reset_parameters() {
-  auto n = in_channels_;
-  for (auto k : ks_)
-    n *= k;
-  auto stdv = 1.0 / std::sqrt(n);
+  const auto number_of_features = std::accumulate(
+      ks_.begin(), ks_.end(), in_channels_, std::multiplies<uint32_t>{});
+  const auto stdv = 1.0 / std::sqrt(number_of_features);
   for (auto& p : parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
+
+Conv::Conv(
+    uint32_t Nd,
+    uint32_t in_chan,
+    uint32_t out_chan,
+    int ks,
+    bool transposed,
+    bool with_bias,
+    int groups)
+    : Conv(
+          Nd,
+          in_chan,
+          out_chan,
+          makeTup(Nd, ks, 1),
+          transposed,
+          with_bias,
+          groups) {}
 
 variable_list Conv::forward(variable_list input) {
   auto x = input[0];
@@ -63,7 +110,7 @@ variable_list Conv::forward(variable_list input) {
   } else if (Nd_ == 3) {
     AT_ASSERT(x.ndimension() == 5);
   } else {
-    throw std::runtime_error("Only Conv{1,2,3}d are supported");
+    AT_ERROR("Only Conv{1,2,3}d are supported");
   }
 
   Variable out;
@@ -99,4 +146,22 @@ variable_list Conv::forward(variable_list input) {
 
   return variable_list({out});
 }
+
+Conv& Conv::stride(size_t value) {
+  stride_ = makeTup(Nd_, value, 1);
+  return *this;
+}
+Conv& Conv::padding(size_t value) {
+  padding_ = makeTup(Nd_, value);
+  return *this;
+}
+Conv& Conv::dilation(size_t value) {
+  dilation_ = makeTup(Nd_, value, 1);
+  return *this;
+}
+Conv& Conv::output_padding(size_t value) {
+  output_padding_ = makeTup(Nd_, value);
+  return *this;
+}
+
 }} // namespace torch::nn

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -3,23 +3,16 @@
 namespace torch { namespace nn {
 
 Embedding::Embedding(uint32_t num_embeddings, uint32_t embedding_dim)
-    : num_embeddings(num_embeddings), embedding_dim(embedding_dim) {}
+    : num_embeddings(num_embeddings),
+      embedding_dim(embedding_dim),
+      weight(Var(at::CPU(at::kFloat).empty({num_embeddings, embedding_dim}))) {
+  add(weight, "weight");
+  weight.data().normal_(0, 1);
+}
 
 variable_list Embedding::forward(variable_list input) {
   auto x = input[0];
   return variable_list({at::embedding(weight, x, -1, false, false)});
-}
-
-void Embedding::reset_parameters() {
-  for (auto& p : parameters()) {
-    p.second.data().normal_(0, 1);
-  }
-}
-
-void Embedding::initialize_parameters() {
-  weight = this->add(
-      Var(at::CPU(at::kFloat).empty({num_embeddings, embedding_dim})),
-      "weight");
 }
 
 }} // namespace torch::nn


### PR DESCRIPTION
After #7408 made in-place device conversions of C++ modules possible, autogradpp's mechanism of `initialize_containers()`, `initialize_parameters()`, `reset_parameters()` methods became redundant beyond their late-initialization mechanism required by the fact that autogradpp modules are themselves builders (via `KWARGS`).

This PR moves the code from `initialize_*` functions into constructors. For this, I have __temporarily__ (!) removed the `KWARGS`-style builder mechanism in favor of LLVM-style `/*comments=*/`. This is only until we settle on a preferred construction mechanism. For example, if we choose to stick with `KWARGS`, we could move the code inside constructors into a single `initialize()` method.

The crucial fact is that the code from the `initialize_*` functions now has the invariant that it is called only once (during construction), which is important irrespective of the construction mechanism we end up using. It allowed me to remove code that was used to keep the functions reentrant (which was required before #7408).

Note that at this point `make()` has become redundant (it's equivalent to `make_shared`). I have kept it to keep this PR small. Another PR can in fact remove all uses of `make()` and instead use value types instead of `shared_ptr`s to everything.

@ebetica @apaszke @ezyang 