### PR TITLE
Use customized python interpreter for distributed launch util

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -121,6 +121,7 @@ utility
 """
 
 
+import sys
 import subprocess
 import os
 import socket
@@ -192,7 +193,7 @@ def main():
         current_env["RANK"] = str(dist_rank)
 
         # spawn the processes
-        cmd = ["python",
+        cmd = [sys.executable,
                "-u",
                args.training_script,
                "--local_rank={}".format(local_rank)] + args.training_script_args


### PR DESCRIPTION
For spawning sub-processes, I think it should be quite intuitive to use the interpreter of `launch.py` rather than the default `python`.