### PR TITLE
Skip onnx backend tests for inverse trigonometric ops

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -36,7 +36,12 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_gru.*'  # Seems GRU case has some problem
                      '|test_upsample.*'  # Upsample is redesigned in ONNX
                      '|test_operator_repeat.*'  # Tile is not compliant with ONNX yet
-                     '|test_.*pool_.*same.*)')  # Does not support pool same.
+                     '|test_.*pool_.*same.*'
+                     '|test_asin_'
+                     '|test_acos_'
+                     '|test_atan_'
+                     '|test_tan_'
+                     ')')  # Does not support pool same.
 
 # Quick patch to unbreak master CI, is working on the debugging.
 backend_test.exclude('(test_cast_.*'


### PR DESCRIPTION
Currently there is no equivalent ops in caffe2