### PR TITLE
Set up Caffe2 CUDA builds to use sccache

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -110,7 +110,7 @@ case "${BUILD_ENVIRONMENT}" in
     CMAKE_ARGS+=("-DCUDA_ARCH_NAME=Maxwell")
     CMAKE_ARGS+=("-DUSE_NNPACK=OFF")
 
-    # Explicitly set path to NVCC such that the symlink to ccache is used
+    # Explicitly set path to NVCC such that the symlink to ccache or sccache is used
     CMAKE_ARGS+=("-DCUDA_NVCC_EXECUTABLE=${CACHE_WRAPPER_DIR}/nvcc")
 
     # Ensure FindCUDA.cmake can infer the right path to the CUDA toolkit.

--- a/docker/caffe2/jenkins/common/install_ccache.sh
+++ b/docker/caffe2/jenkins/common/install_ccache.sh
@@ -15,11 +15,6 @@ make "-j$(nproc)" install
 popd
 popd
 
-# Install sccache from binary release.
-# Note: this release does NOT yet work with nvcc.
-pushd /tmp
-curl -LOs https://github.com/mozilla/sccache/releases/download/0.2.5/sccache-0.2.5-x86_64-unknown-linux-musl.tar.gz
-tar -zxvf sccache-0.2.5-x86_64-unknown-linux-musl.tar.gz
-mv sccache-0.2.5-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
-rm -rf sccache-0.2.5-x86_64-unknown-linux-musl*
-popd
+# Install sccache from pre-compiled binary.
+curl https://s3.amazonaws.com/ossci-linux/sccache -o /usr/local/bin/sccache
+chmod a+x /usr/local/bin/sccache


### PR DESCRIPTION
sccache is ready to be used for CUDA builds and is already deployed in PyTorch CI. This PR is the first of a few steps to deploy sccache in Caffe2 CUDA builds as well.

- [This PR] Set up `nvcc` symlinking and `MAX_JOBS` value for sccache CUDA builds
- Build new Caffe2 docker images using the updated `install_ccache.sh`
- [Next PR] Remove `SCCACHE_BUCKET` check in `build.sh` and use sccache only for all builds

Both of the PRs would pass the CI check before being merged, to ensure the change actually works properly.