### PR TITLE
Replace std::to_string with caffe2::to_string in nomnigraph

### DIFF
--- a/caffe2/opt/converter_nomigraph_test.cc
+++ b/caffe2/opt/converter_nomigraph_test.cc
@@ -16,7 +16,7 @@ TEST(Converter, Basic) {
       caffe2::OperatorDef *def = net.add_op();
       def->set_type("Conv");
       def->add_input("X");
-      def->add_input("W" + std::to_string(i)); // different weights
+      def->add_input("W" + caffe2::to_string(i)); // different weights
       ADD_ARG(def, "kernel", i, 3);
       ADD_ARG(def, "stride", i, 1);
       ADD_ARG(def, "pad", i, 0);
@@ -43,7 +43,7 @@ TEST(Converter, UnknownType) {
   def->add_input("X");
   def->add_output("X");
   def->mutable_device_option()->set_node_name("device_" +
-      std::to_string(rand() % 2));
+      caffe2::to_string(rand() % 2));
   auto nn = caffe2::convertToNNModule(net);
   auto new_netdef = caffe2::convertToCaffe2Proto(nn);
 }


### PR DESCRIPTION
`std::to_string` is not available on Android with GNU STL. We conventionally use `caffe2::to_string` as a portable alternative.

