### PR TITLE
Run onnx integration tests in caffe2 CI

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -53,6 +53,14 @@ if [ -z "${SCCACHE}" ] && which ccache > /dev/null; then
   export PATH="$CACHE_WRAPPER_DIR:$PATH"
 fi
 
+report_compile_cache_stats() {
+  if [[ -n "${SCCACHE}" ]]; then
+    "$SCCACHE" --show-stats
+  elif which ccache > /dev/null; then
+    ccache -s
+  fi
+}
+
 CMAKE_ARGS=("-DBUILD_BINARY=ON")
 CMAKE_ARGS+=("-DUSE_OBSERVERS=ON")
 CMAKE_ARGS+=("-DUSE_ZSTD=ON")
@@ -164,14 +172,20 @@ else
   exit 1
 fi
 
+report_compile_cache_stats
+
 # Install ONNX into a local directory
 ONNX_INSTALL_PATH="/usr/local/onnx"
-pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
+pip install -v "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
+
+report_compile_cache_stats
 
 if [[ -n "$INTEGRATED" ]]; then
   TORCH_INSTALL_PATH="/usr/local/torch"
-  pip install "${ROOT_DIR}" -t "$TORCH_INSTALL_PATH"
+  pip install -v "${ROOT_DIR}" -t "$TORCH_INSTALL_PATH"
 fi
+
+report_compile_cache_stats
 
 # Symlink the caffe2 base python path into the system python path,
 # so that we can import caffe2 without having to change $PYTHONPATH.

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -168,6 +168,11 @@ fi
 ONNX_INSTALL_PATH="/usr/local/onnx"
 pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
 
+if [[ -n "$INTEGRATED" ]]; then
+  TORCH_INSTALL_PATH="/usr/local/torch"
+  pip install "${ROOT_DIR}" -t "$TORCH_INSTALL_PATH"
+fi
+
 # Symlink the caffe2 base python path into the system python path,
 # so that we can import caffe2 without having to change $PYTHONPATH.
 # Run in a subshell to contain environment set by /etc/os-release.
@@ -188,6 +193,9 @@ if [ -n "${JENKINS_URL}" ]; then
       python_path="/usr/local/lib/$(python_version)/dist-packages"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
       sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
+      if [[ -n "$INTEGRATED" ]]; then
+        sudo ln -sf "${TORCH_INSTALL_PATH}/torch" "${python_path}"
+      fi
     fi
 
     # RHEL/CentOS
@@ -195,6 +203,9 @@ if [ -n "${JENKINS_URL}" ]; then
       python_path="/usr/lib64/$(python_version)/site-packages/"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
       sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
+      if [[ -n "$INTEGRATED" ]]; then
+        sudo ln -sf "${TORCH_INSTALL_PATH}/torch" "${python_path}"
+      fi
     fi
 
     # /etc/ld.so.conf.d is used on both Debian and RHEL

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -174,9 +174,6 @@ fi
 
 report_compile_cache_stats
 
-# This can be used to speed up the installations of onnx and pytorch
-pip install ninja
-
 # Install ONNX into a local directory
 ONNX_INSTALL_PATH="/usr/local/onnx"
 pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -174,9 +174,12 @@ fi
 
 report_compile_cache_stats
 
+# This can be used to speed up the installations of onnx and pytorch
+pip install ninja
+
 # Install ONNX into a local directory
 ONNX_INSTALL_PATH="/usr/local/onnx"
-pip install -v "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
+pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
 
 report_compile_cache_stats
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -175,8 +175,7 @@ fi
 report_compile_cache_stats
 
 # Install ONNX into a local directory
-ONNX_INSTALL_PATH="/usr/local/onnx"
-pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
+pip install --user "${ROOT_DIR}/third_party/onnx"
 
 report_compile_cache_stats
 
@@ -186,8 +185,7 @@ if [[ -n "$INTEGRATED" ]]; then
   if [[ -n "${SCCACHE}" ]]; then
     export MAX_JOBS=`expr $(nproc) - 1`
   fi
-  TORCH_INSTALL_PATH="/usr/local/torch"
-  pip install -v "${ROOT_DIR}" -t "$TORCH_INSTALL_PATH"
+  pip install --user -v "${ROOT_DIR}"
 fi
 
 report_compile_cache_stats
@@ -211,20 +209,12 @@ if [ -n "${JENKINS_URL}" ]; then
     if [[ "$ID_LIKE" == *debian* ]]; then
       python_path="/usr/local/lib/$(python_version)/dist-packages"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
-      sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
-      if [[ -n "$INTEGRATED" ]]; then
-        sudo ln -sf "${TORCH_INSTALL_PATH}/torch" "${python_path}"
-      fi
     fi
 
     # RHEL/CentOS
     if [[ "$ID_LIKE" == *rhel* ]]; then
       python_path="/usr/lib64/$(python_version)/site-packages/"
       sudo ln -sf "${INSTALL_PREFIX}/caffe2" "${python_path}"
-      sudo ln -sf "${ONNX_INSTALL_PATH}/onnx" "${python_path}"
-      if [[ -n "$INTEGRATED" ]]; then
-        sudo ln -sf "${TORCH_INSTALL_PATH}/torch" "${python_path}"
-      fi
     fi
 
     # /etc/ld.so.conf.d is used on both Debian and RHEL

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -181,6 +181,11 @@ pip install "${ROOT_DIR}/third_party/onnx" -t "${ONNX_INSTALL_PATH}"
 report_compile_cache_stats
 
 if [[ -n "$INTEGRATED" ]]; then
+  # sccache will be stuck if  all cores are used for compiling
+  # see https://github.com/pytorch/pytorch/pull/7361
+  if [[ -n "${SCCACHE}" ]]; then
+    export MAX_JOBS=`expr $(nproc) - 1`
+  fi
   TORCH_INSTALL_PATH="/usr/local/torch"
   pip install -v "${ROOT_DIR}" -t "$TORCH_INSTALL_PATH"
 fi

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -83,6 +83,7 @@ if [[ "${BUILD_ENVIRONMENT}" == conda* ]]; then
   export LC_ALL=C.UTF-8
 
   "${ROOT_DIR}/scripts/build_anaconda.sh" --skip-tests --install-locally "$@"
+  report_compile_cache_stats
 
   # This build will be tested against onnx tests, which needs onnx installed.
   # At this point the visible protbuf installation will be in conda, since one
@@ -90,7 +91,8 @@ if [[ "${BUILD_ENVIRONMENT}" == conda* ]]; then
   # headers are those in conda as well
   # This path comes from install_anaconda.sh which installs Anaconda into the
   # docker image
-  PROTOBUF_INCDIR=/opt/conda/include pip install "${ROOT_DIR}/third_party/onnx"
+  PROTOBUF_INCDIR=/opt/conda/include pip install -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
+  report_compile_cache_stats
   exit 0
 fi
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -175,7 +175,7 @@ fi
 report_compile_cache_stats
 
 # Install ONNX into a local directory
-pip install --user "${ROOT_DIR}/third_party/onnx"
+pip install --user -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
 
 report_compile_cache_stats
 
@@ -185,7 +185,7 @@ if [[ -n "$INTEGRATED" ]]; then
   if [[ -n "${SCCACHE}" ]]; then
     export MAX_JOBS=`expr $(nproc) - 1`
   fi
-  pip install --user -v "${ROOT_DIR}"
+  pip install --user -v -b /tmp/pip_install_torch "file://${ROOT_DIR}#egg=torch"
 fi
 
 report_compile_cache_stats

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -102,5 +102,8 @@ echo "Running Python tests.."
   "${EXTRA_TESTS[@]}"
 
 if [[ -n "$INTEGRATED" ]]; then
+  TMP_TESTS_REQUIRE=/tmp/integration_tests_require
+  pip install pytest-xdist torchvision -t "$TMP_TESTS_REQUIRE"
+  PYTHONPATH="$TMP_TESTS_REQUIRE:$PYTHONPATH"
   "$ROOT_DIR/scripts/onnx/test.sh" -p
 fi

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -100,3 +100,7 @@ echo "Running Python tests.."
   ${conda_ignore_test[@]} \
   "$CAFFE2_PYPATH/python" \
   "${EXTRA_TESTS[@]}"
+
+if [[ -n "$INTEGRATED" ]]; then
+  "$ROOT_DIR/scripts/onnx/test.sh" -p
+fi

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -102,8 +102,6 @@ echo "Running Python tests.."
   "${EXTRA_TESTS[@]}"
 
 if [[ -n "$INTEGRATED" ]]; then
-  TMP_TESTS_REQUIRE=/tmp/integration_tests_require
-  pip install pytest-xdist torchvision -t "$TMP_TESTS_REQUIRE"
-  PYTHONPATH="$TMP_TESTS_REQUIRE:$PYTHONPATH"
+  pip install --user pytest-xdist torchvision
   "$ROOT_DIR/scripts/onnx/test.sh" -p
 fi

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -41,7 +41,6 @@ else
     PYTEST="pytest"
 fi
 
-cd "$top_dir"
 if [[ $PARALLEL == 1 ]]; then
     $PYTEST -n 3 "${test_paths[@]}"
 else

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -35,7 +35,7 @@ skipIfNoCuda = _skipper(lambda: not torch.cuda.is_available(),
 skipIfTravis = _skipper(lambda: os.getenv('TRAVIS'),
                         'Skip In Travis')
 
-skipIfCI = _skipper(lambda: os.getenv('CI'),
+skipIfCI = _skipper(lambda: os.getenv('CI') or os.getenv('TRAVIS') or os.getenv('JENKINS_URL'),
                     'Skip In CI')
 
 


### PR DESCRIPTION
Currently only `py2-gcc5-ubuntu16.04` has been enabled to run integration tests.