### PR TITLE
Move bernoulli further into ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3610,7 +3610,7 @@
     - double p
 ]]
 [[
-  name: bernoulli
+  name: _th_bernoulli
   types:
     - Float
     - Double

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -152,9 +152,17 @@
 - func: batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, double momentum, double eps, bool cudnn_enabled) -> Tensor
   variants: function
 
+- func: bernoulli(Tensor self, Tensor p, Generator* generator=nullptr) -> Tensor
+
+- func: bernoulli(Tensor self, double p=0.5, Generator* generator=nullptr) -> Tensor
+
+- func: bernoulli(Tensor self, Generator* generator=nullptr) -> Tensor
+
 - func: bernoulli_(Tensor self, Tensor p, Generator* generator=nullptr) -> Tensor
 
 - func: bernoulli_(Tensor self, double p=0.5, Generator* generator=nullptr) -> Tensor
+
+- func: bernoulli_(Tensor self, Generator* generator=nullptr) -> Tensor
 
 - func: bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias) -> Tensor
   variants: function

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -32,15 +32,20 @@ inline Tensor Tensor::toBackend(Backend b) const {
 // all static inline to allow for inlining of the non-dynamic part of dispatch
 ${tensor_method_definitions}
 
-#define DEFINE_CAST(T,name,_) \
-template<> \
-inline T* Tensor::data() const { \
-  AT_CHECK(type().scalarType() == ScalarType::name, \
-    "expected scalar type % s but found %s", #name, \
-    at::toString(type().scalarType())); \
-  return static_cast<T*>(this->data_ptr()); \
-} \
-inline T* Tensor::to##name##Data() const { return data<T>(); }
+#define DEFINE_CAST(T, name, _)                  \
+  template <>                                    \
+  inline T* Tensor::data() const {               \
+    AT_CHECK(                                    \
+        type().scalarType() == ScalarType::name, \
+        "expected scalar type ",                 \
+        #name,                                   \
+        " but found ",                           \
+        at::toString(type().scalarType()));      \
+    return static_cast<T*>(this->data_ptr());    \
+  }                                              \
+  inline T* Tensor::to##name##Data() const {     \
+    return data<T>();                            \
+  }
 
 AT_FORALL_SCALAR_TYPES(DEFINE_CAST)
 #undef DEFINE_CAST


### PR DESCRIPTION
This addresses some of the points mentioned [in this issue](https://github.com/pytorch/pytorch/issues/6940) and should generally improve perf of some of those operations (it avoids a few unnecessary expands).