### PR TITLE
Throw error on tensor creation when sequence shape cannot be determined

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6918,6 +6918,27 @@ class TestTorch(TestCase):
             model.weight.data = weight
             out = model(input)
 
+    def test_tensor_from_sequence(self):
+        class MockSequence(object):
+            def __init__(self, lst):
+                self.lst = lst
+
+            def __len__(self):
+                return len(self.lst)
+
+            def __getitem__(self, item):
+                raise TypeError
+
+        class GoodMockSequence(MockSequence):
+            def __getitem__(self, item):
+                return self.lst[item]
+
+        bad_mock_seq = MockSequence([1.0, 2.0, 3.0])
+        good_mock_seq = GoodMockSequence([1.0, 2.0, 3.0])
+        self.assertRaises(ValueError, lambda: torch.Tensor(bad_mock_seq))
+        self.assertEqual(torch.Tensor([1.0, 2.0, 3.0]), torch.Tensor(good_mock_seq))
+
+
     def test_comparison_ops(self):
         x = torch.randn(5, 5)
         y = torch.randn(5, 5)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6935,9 +6935,9 @@ class TestTorch(TestCase):
 
         bad_mock_seq = MockSequence([1.0, 2.0, 3.0])
         good_mock_seq = GoodMockSequence([1.0, 2.0, 3.0])
-        self.assertRaises(ValueError, lambda: torch.Tensor(bad_mock_seq))
+        with self.assertRaisesRegex(ValueError, 'could not determine the shape'):
+            torch.Tensor(bad_mock_seq)
         self.assertEqual(torch.Tensor([1.0, 2.0, 3.0]), torch.Tensor(good_mock_seq))
-
 
     def test_comparison_ops(self):
         x = torch.randn(5, 5)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -88,6 +88,7 @@ static std::vector<int64_t> compute_sizes(PyObject* seq) {
   std::vector<int64_t> sizes;
   THPObjectPtr handle;
   while (PySequence_Check(seq)) {
+    auto d = PyDict_Check(seq);
     auto length = PySequence_Length(seq);
     if (length < 0) throw python_error();
     sizes.push_back(length);
@@ -96,6 +97,9 @@ static std::vector<int64_t> compute_sizes(PyObject* seq) {
     }
     if (length == 0) break;
     handle = THPObjectPtr(PySequence_GetItem(seq, 0));
+    if (!handle) {
+      throw ValueError("Could not determine the shape of object type '%s'", Py_TYPE(seq)->tp_name);
+    }
     seq = handle.get();
   }
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -88,7 +88,6 @@ static std::vector<int64_t> compute_sizes(PyObject* seq) {
   std::vector<int64_t> sizes;
   THPObjectPtr handle;
   while (PySequence_Check(seq)) {
-    auto d = PyDict_Check(seq);
     auto length = PySequence_Length(seq);
     if (length < 0) throw python_error();
     sizes.push_back(length);
@@ -98,7 +97,7 @@ static std::vector<int64_t> compute_sizes(PyObject* seq) {
     if (length == 0) break;
     handle = THPObjectPtr(PySequence_GetItem(seq, 0));
     if (!handle) {
-      throw ValueError("Could not determine the shape of object type '%s'", Py_TYPE(seq)->tp_name);
+      throw ValueError("could not determine the shape of object type '%s'", Py_TYPE(seq)->tp_name);
     }
     seq = handle.get();
   }


### PR DESCRIPTION
Fixes #7278 

Currently, tensors can be created from Python sequences (determined by `PySequence_Check`). The shape of the tensor to be created is determined by iterating over the first element in each of the (potentially nested) sequences. This is done [here](https://github.com/pytorch/pytorch/blob/master/torch/csrc/utils/tensor_new.cpp#L87). 

There is an assumption that it is safe to index the `PyObect` at element zero if `PySequence_Check(obj)` is true and `PySequence_Length(obj) > 0`. Unfortunately, Python objects are still free to raise errors in their `__getitem__` methods under these conditions, which is often the case when creating tensors from Pandas objects. In this case, `PySequence_GetItem` will return a null pointer, which in turn causes a segmentation fault when the next `PySequence_Check` call is made.

This patch adds a simple check for a null pointer and raises a `ValueError` when this happens. The error trace from the call to `__getitem__` is not propagated since it is generally unhelpful and confusing. A unit test is added that verifies the appropriate error is raised in this situation.

## Examples

```python
seq = pd.Series([1.0, 2.0, 3.0])
torch.Tensor(seq)  # succeeds, since seq[0] is defined
torch.Tensor(seq[1:])  # segfault, since seq[0] generates a KeyError

df = pd.DataFrame(np.ones((2, 3)), columns=['a', 'b', 'c'])
torch.Tensor(df)  # segfault, since df[0] tries to access a column named 0
```

## Notes

* It would be better to be able to handle Pandas objects in general, or at least give a nicer error message (e.g. "did you mean torch.Tensor(df.values)?"), but that code would be specific to checking for Pandas objects.
* I don't believe there's any surefire way to get the first element in the underlying sequence, which is what `PySequence_GetItem(obj, 0)` tries to do, but I could have missed it
* I am new to the code here, so if there is a better way to handle the error, or if the unit test is not quite exhaustive, please let me know.