### PR TITLE
Only start sccache in foreground mode when in build phase

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -62,9 +62,11 @@ declare -f -t trap_add
 trap_add cleanup EXIT
 
 if which sccache > /dev/null; then
-  # Start sccache server in foreground mode, so that we can see better logging
-  sccache --stop-server || true
-  SCCACHE_NO_DAEMON=1 RUST_LOG=sccache::server=error sccache --start-server
+  if [[ "$JOB_NAME" == *build* ]]; then
+    # Start sccache server in foreground mode, so that we can see better logging
+    sccache --stop-server || true
+    SCCACHE_NO_DAEMON=1 RUST_LOG=sccache::server=error sccache --start-server
+  fi
 
   # Report sccache stats for easier debugging
   sccache --zero-stats


### PR DESCRIPTION
This aims to fix the test timeout error for multi-gpu tests (example: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-cuda8-cudnn6-py3-multigpu-test/2617/) because it takes a long time for sccache server to shut down. With this PR, the multi-gpu tests should be back to normal and should only take ~5mins to finish.