### PR TITLE
Make return uniform in lbfgs step

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -475,6 +475,17 @@ class TestOptim(TestCase):
             ignore_multidevice=True
         )
 
+    def test_lbfgs_return_type(self):
+        params = [torch.randn(10, 5), torch.randn(10)]
+        opt1 = optim.LBFGS(params, 0.01, tolerance_grad=float('inf'))
+        opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-float('inf'))
+        def closure():
+            return torch.Tensor([10])
+
+        res1 = opt1.step(closure)
+        res2 = opt2.step(closure)
+        self.assertEqual(type(res1), type(res2))
+
     def test_invalid_param_type(self):
         with self.assertRaises(TypeError):
             optim.SGD(Variable(torch.randn(5, 5)), lr=3)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -479,6 +479,7 @@ class TestOptim(TestCase):
         params = [torch.randn(10, 5), torch.randn(10)]
         opt1 = optim.LBFGS(params, 0.01, tolerance_grad=float('inf'))
         opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-float('inf'))
+
         def closure():
             return torch.Tensor([10])
 

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -109,7 +109,7 @@ class LBFGS(Optimizer):
         abs_grad_sum = flat_grad.abs().sum()
 
         if abs_grad_sum <= tolerance_grad:
-            return loss
+            return orig_loss
 
         # tensors cached in state (for tracing)
         d = state.get('d')


### PR DESCRIPTION
This ensures that we are returning results of the same type in `LBFGS` `step`.  Assuming the closure returns a tensor (which we do [here](https://github.com/pytorch/examples/blob/master/time_sequence_prediction/train.py#L57-L63)), we could potentially return either a `float` or a `Tensor`.  This PR makes the return type uniform.

