### PR TITLE
[caffe2] Use caffe2::stod in lexer

### DIFF
--- a/caffe2/contrib/script/lexer.h
+++ b/caffe2/contrib/script/lexer.h
@@ -358,7 +358,7 @@ struct Token {
   double doubleValue() {
     assert(TK_NUMBER == kind);
     size_t idx;
-    double r = stod(text(), &idx);
+    double r = ::caffe2::stod(text(), &idx);
     assert(idx == range.size());
     return r;
   }


### PR DESCRIPTION
`std::stod` causes build errors on Android

