### PR TITLE
[caffe2] Include <array> in fatal_signal_asan_no_sig_test

### DIFF
--- a/caffe2/utils/fatal_signal_asan_no_sig_test.cc
+++ b/caffe2/utils/fatal_signal_asan_no_sig_test.cc
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <iostream>
+#include <array>
 
 #include "caffe2/core/common.h"
 


### PR DESCRIPTION
fatal_signal_asan_no_sig_test.cc uses `std::array`, but doesn't include the header. It caused build error on Android.

