### PR TITLE
[caffe2] Build Android tests and binaries in CI

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -85,6 +85,7 @@ fi
 if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   export ANDROID_NDK=/opt/ndk
   CMAKE_ARGS+=("-DBUILD_BINARY=ON")
+  CMAKE_ARGS+=("-DBUILD_TEST=ON")
   CMAKE_ARGS+=("-DUSE_OBSERVERS=ON")
   CMAKE_ARGS+=("-DUSE_ZSTD=ON")
   "${ROOT_DIR}/scripts/build_android.sh" ${CMAKE_ARGS[*]} "$@"


### PR DESCRIPTION
Android tests are now broken, and we didn't know about it. Enabling build of tests & binaries for Android to avoid this situation in the future.