### PR TITLE
[caffe2][nomnigraph] Allow empty storage for the 'Edge' class.

### DIFF
--- a/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Converters/Dot.h
@@ -5,27 +5,27 @@
 #include "nomnigraph/Support/Casting.h"
 
 #include <functional>
-#include <map>
 #include <iostream>
+#include <map>
 #include <sstream>
 
 namespace {
 
-template <typename T, typename U = T>
+template <typename T, typename... U>
 class DotGenerator {
  public:
   using NodePrinter = std::function<std::map<std::string, std::string>(
-      typename nom::Graph<T, U>::NodeRef)>;
+      typename nom::Graph<T, U...>::NodeRef)>;
   using EdgePrinter = std::function<std::map<std::string, std::string>(
-      typename nom::Graph<T, U>::EdgeRef)>;
+      typename nom::Graph<T, U...>::EdgeRef)>;
 
   static std::map<std::string, std::string> defaultEdgePrinter(
-      typename nom::Graph<T, U>::EdgeRef) {
+      typename nom::Graph<T, U...>::EdgeRef) {
     std::map<std::string, std::string> labelMap;
     return labelMap;
   }
 
-  DotGenerator(typename nom::Graph<T, U>* g) : g_(g) {}
+  DotGenerator(typename nom::Graph<T, U...>* g) : g_(g) {}
 
   std::string convert(NodePrinter nodePrinter, EdgePrinter edgePrinter) {
     std::ostringstream output;
@@ -65,13 +65,13 @@ class DotGenerator {
     return output.str();
   }
 
-  void addSubgraph(const nom::Subgraph<T, U>* s) {
+  void addSubgraph(const nom::Subgraph<T, U...>* s) {
     subgraphs_.emplace_back(s);
   }
 
  private:
-  typename nom::Graph<T, U>* g_;
-  typename std::vector<const nom::Subgraph<T, U>*> subgraphs_;
+  typename nom::Graph<T, U...>* g_;
+  typename std::vector<const nom::Subgraph<T, U...>*> subgraphs_;
 };
 
 } // namespace
@@ -79,24 +79,24 @@ class DotGenerator {
 namespace nom {
 namespace converters {
 
-template <typename T, typename U = T>
+template <typename T, typename... U>
 std::string convertToDotString(
-    nom::Graph<T, U>* g,
-    typename DotGenerator<T, U>::NodePrinter nodePrinter,
-    typename DotGenerator<T, U>::EdgePrinter edgePrinter =
-        DotGenerator<T, U>::defaultEdgePrinter) {
-  auto d = DotGenerator<T, U>(g);
+    nom::Graph<T, U...>* g,
+    typename DotGenerator<T, U...>::NodePrinter nodePrinter,
+    typename DotGenerator<T, U...>::EdgePrinter edgePrinter =
+        DotGenerator<T, U...>::defaultEdgePrinter) {
+  auto d = DotGenerator<T, U...>(g);
   return d.convert(nodePrinter, edgePrinter);
 }
 
-template <typename T, typename U = T>
+template <typename T, typename... U>
 std::string convertToDotString(
-    nom::Graph<T, U>* g,
-    const std::vector<nom::Subgraph<T, U>>& subgraphs,
-    typename DotGenerator<T, U>::NodePrinter nodePrinter,
-    typename DotGenerator<T, U>::EdgePrinter edgePrinter =
-        DotGenerator<T, U>::defaultEdgePrinter) {
-  auto d = DotGenerator<T, U>(g);
+    nom::Graph<T, U...>* g,
+    const std::vector<nom::Subgraph<T, U...>>& subgraphs,
+    typename DotGenerator<T, U...>::NodePrinter nodePrinter,
+    typename DotGenerator<T, U...>::EdgePrinter edgePrinter =
+        DotGenerator<T, U...>::defaultEdgePrinter) {
+  auto d = DotGenerator<T, U...>(g);
   for (const auto& subgraph : subgraphs) {
     d.addSubgraph(&subgraph);
   }

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Algorithms.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Algorithms.h
@@ -12,23 +12,16 @@
 #ifndef NOM_GRAPH_ALGORITHMS_H
 #define NOM_GRAPH_ALGORITHMS_H
 
-#include "nomnigraph/Graph/Graph.h"
-
 #include <assert.h>
 #include <unordered_map>
 #include <unordered_set>
 
-namespace nom {
-namespace algorithm {
-
-/// \brief Tarjans algorithm.  Does not modify the graph.
-template <typename T, typename U>
-std::vector<Subgraph<T, U>> tarjans(Graph<T, U>* g);
+#include "nomnigraph/Graph/BinaryMatchImpl.h"
+#include "nomnigraph/Graph/Graph.h"
 #include "nomnigraph/Graph/TarjansImpl.h"
 
-template <typename T, typename U, typename F>
-std::vector<Subgraph<T, U>> binaryMatch(Graph<T, U>* g, F condition);
-#include "nomnigraph/Graph/BinaryMatchImpl.h"
+namespace nom {
+namespace algorithm {
 
 /// \brief Helper for dominator tree finding.
 template <typename G>
@@ -64,7 +57,7 @@ void reachable(
 ///   if newnode has inedge, delete it
 ///   draw edge from parent to child
 template <typename G>
-Graph<typename G::NodeRef, int> dominatorTree(
+Graph<typename G::NodeRef> dominatorTree(
     G* g,
     typename G::NodeRef source = nullptr) {
   assert(
@@ -82,10 +75,10 @@ Graph<typename G::NodeRef, int> dominatorTree(
   }
 
   std::unordered_set<typename G::NodeRef> allNodes;
-  Graph<typename G::NodeRef, int> tree;
+  Graph<typename G::NodeRef> tree;
   std::unordered_map<
       typename G::NodeRef,
-      typename Graph<typename G::NodeRef, int>::NodeRef>
+      typename Graph<typename G::NodeRef>::NodeRef>
       mapToTreeNode;
   std::unordered_map<
       typename G::NodeRef,
@@ -119,7 +112,7 @@ Graph<typename G::NodeRef, int> dominatorTree(
   nextPass.insert(source);
 
   while (nextPass.size()) {
-    for (auto parent_iter = nextPass.begin(); parent_iter != nextPass.end(); ) {
+    for (auto parent_iter = nextPass.begin(); parent_iter != nextPass.end();) {
       auto parent = *parent_iter;
       for (auto child : dominatorMap[parent]) {
         while (mapToTreeNode[child]->getInEdges().size()) {

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/BinaryMatchImpl.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/BinaryMatchImpl.h
@@ -1,11 +1,15 @@
-#ifndef NOM_GRAPH_ALGORITHMS_H
-#error "This should only be included by Graph/Algorithms.h"
-#endif
+#ifndef NOM_GRAPH_BINARYMATCHIMPL_H
+#define NOM_GRAPH_BINARYMATCHIMPL_H
+
+#include "nomnigraph/Graph/Graph.h"
+
+namespace nom {
+namespace algorithm {
 
 /// \brief A binary graph matching algorithm based on Kahn's algorithm.
-template <typename T, typename U, typename F>
-std::vector<Subgraph<T, U>> binaryMatch(Graph<T, U>* g, F condition) {
-  using G = Graph<T, U>;
+template <typename F, typename T, typename... U>
+std::vector<Subgraph<T, U...>> binaryMatch(Graph<T, U...>* g, F condition) {
+  using G = Graph<T, U...>;
 
   auto swappableCondition = [&](typename G::NodeRef m, bool match) {
     return match ? condition(m) : !condition(m);
@@ -15,7 +19,7 @@ std::vector<Subgraph<T, U>> binaryMatch(Graph<T, U>* g, F condition) {
   std::unordered_set<typename G::EdgeRef> edgeSet(edges.begin(), edges.end());
 
   // Topologically sorted matching subgraphs.
-  std::vector<Subgraph<T, U>> sortedNodes;
+  std::vector<Subgraph<T, U...>> sortedNodes;
 
   // Find the initial frontier.
   std::vector<typename G::NodeRef> frontier;
@@ -97,3 +101,8 @@ std::vector<Subgraph<T, U>> binaryMatch(Graph<T, U>* g, F condition) {
 
   return sortedNodes;
 }
+
+} // namespace algorithm
+} // namespace nom
+
+#endif // NOM_GRAPH_BINARYMATCHIMPL_H

--- a/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Graph/Graph.h
@@ -23,28 +23,30 @@
 #include <assert.h>
 #include <stdio.h>
 
-#define DEBUG_PRINT(...) ;
+#define DEBUG_PRINT(...)
 
 namespace nom {
 
-template <typename T, typename U = T>
+template <typename T, typename... U>
 class Graph;
 
-template <typename T, typename U = T>
+template <typename T, typename... U>
 class Node;
 
-template <typename T, typename U = T>
-class Edge : public StorageType<U> {
+// Template types:
+//   T   : Data stored within a node.
+//   U...: Data stored within an edge. When this type is not
+//         specified, an empty StorageType is used. If it is
+//         specified, only a single type should be given (as supported
+//         by the underlying StorageType class).
+
+// \brief Edge within a Graph.
+template <typename T, typename... U>
+class Edge : public StorageType<U...> {
  public:
-  using NodeRef = typename Graph<T, U>::NodeRef;
-  using EdgeRef = typename Graph<T, U>::EdgeRef;
-
-  Edge(NodeRef tail, NodeRef head) : Tail(tail), Head(head) {
-    DEBUG_PRINT("Creating instance of Edge: %p\n", this);
-  }
-
-  Edge(NodeRef tail, NodeRef head, U&& data)
-      : StorageType<U>(std::move(data)), Tail(tail), Head(head) {
+  using NodeRef = typename Graph<T, U...>::NodeRef;
+  Edge(NodeRef tail, NodeRef head, U... args)
+      : StorageType<U...>(std::forward<U...>(args)...), Tail(tail), Head(head) {
     DEBUG_PRINT("Creating instance of Edge: %p\n", this);
   }
 
@@ -66,21 +68,22 @@ class Edge : public StorageType<U> {
  private:
   NodeRef Tail;
   NodeRef Head;
-  friend class Graph<T, U>;
+  friend class Graph<T, U...>;
 };
 
-template <typename T, typename U /* optional */>
-class Node : public StorageType<T>, public Notifier<Node<T, U>> {
+// \brief Node within a Graph.
+template <typename T, typename... U>
+class Node : public StorageType<T>, public Notifier<Node<T, U...>> {
  public:
+  using NodeRef = typename Graph<T, U...>::NodeRef;
+  using EdgeRef = typename Graph<T, U...>::EdgeRef;
+
   /// \brief Create a node with data.
   explicit Node(T&& data) : StorageType<T>(std::move(data)) {
     DEBUG_PRINT("Creating instance of Node: %p\n", this);
   }
   /// \brief Create an empty node.
   explicit Node() : StorageType<T>() {}
-
-  using NodeRef = typename Graph<T, U>::NodeRef;
-  using EdgeRef = typename Graph<T, U>::EdgeRef;
 
   /// \brief Adds an edge by reference to known in-edges.
   /// \p e A reference to an edge that will be added as an in-edge.
@@ -98,7 +101,9 @@ class Node : public StorageType<T>, public Notifier<Node<T, U>> {
   /// \p e A reference to an edge that will be removed from in-edges.
   void removeInEdge(EdgeRef e) {
     auto iter = std::find(inEdges.begin(), inEdges.end(), e);
-    assert(iter != inEdges.end() && "Attempted to remove edge that isn't connected to this node");
+    assert(
+        iter != inEdges.end() &&
+        "Attempted to remove edge that isn't connected to this node");
     inEdges.erase(iter);
   }
 
@@ -106,7 +111,9 @@ class Node : public StorageType<T>, public Notifier<Node<T, U>> {
   /// \p e A reference to an edge that will be removed from out-edges.
   void removeOutEdge(EdgeRef e) {
     auto iter = std::find(outEdges.begin(), outEdges.end(), e);
-    assert(iter != outEdges.end() && "Attempted to remove edge that isn't connected to this node");
+    assert(
+        iter != outEdges.end() &&
+        "Attempted to remove edge that isn't connected to this node");
     outEdges.erase(iter);
   }
 
@@ -128,7 +135,7 @@ class Node : public StorageType<T>, public Notifier<Node<T, U>> {
  protected:
   std::vector<EdgeRef> inEdges;
   std::vector<EdgeRef> outEdges;
-  friend class Graph<T, U>;
+  friend class Graph<T, U...>;
 };
 
 /// \brief Effectively a constant reference to a graph.
@@ -140,15 +147,15 @@ class Node : public StorageType<T>, public Notifier<Node<T, U>> {
 /// helper rather than a fact to be exploited.  There are no deleters,
 /// for example.
 ///
-template <typename T, typename U = T>
+template <typename T, typename... U>
 class Subgraph {
  public:
   Subgraph() {
     DEBUG_PRINT("Creating instance of Subgraph: %p\n", this);
   }
 
-  using NodeRef = typename Graph<T, U>::NodeRef;
-  using EdgeRef = typename Graph<T, U>::EdgeRef;
+  using NodeRef = typename Graph<T, U...>::NodeRef;
+  using EdgeRef = typename Graph<T, U...>::EdgeRef;
 
   void addNode(NodeRef n) {
     Nodes.insert(n);
@@ -197,9 +204,13 @@ class Subgraph {
 ///
 /// Everything is owned by the graph to simplify storage concerns.
 ///
-template <typename T, typename U /* optional */>
+template <typename T, typename... U>
 class Graph {
  public:
+  using SubgraphType = Subgraph<T, U...>;
+  using NodeRef = Node<T, U...>*;
+  using EdgeRef = Edge<T, U...>*;
+
   Graph() {
     DEBUG_PRINT("Creating instance of Graph: %p\n", this);
   }
@@ -208,22 +219,17 @@ class Graph {
   Graph& operator=(Graph&&) = default;
   ~Graph() {}
 
-  using NodeRef = Node<T, U>*;
-  using EdgeRef = Edge<T, U>*;
-  using NodeType = T;
-  using EdgeType = U;
-
   /// \brief Creates a node and retains ownership of it.
   /// \p data An rvalue of the data being held in the node.
   /// \return A reference to the node created.
   NodeRef createNode(T&& data) {
-    Nodes.emplace_back(Node<T, U>(std::move(data)));
+    Nodes.emplace_back(Node<T, U...>(std::move(data)));
     DEBUG_PRINT("Creating node (%p)\n", &Nodes.back());
     return &Nodes.back();
   }
 
-  void importNode(NodeRef node, Graph<T, U>& otherGraph) {
-    std::list<Node<T, U>>& otherNodes = otherGraph.Nodes;
+  void importNode(NodeRef node, Graph<T, U...>& otherGraph) {
+    std::list<Node<T, U...>>& otherNodes = otherGraph.Nodes;
     for (auto it = Nodes.begin(); it != Nodes.end(); ++it) {
       if (&(*it) == node) {
         otherNodes.splice(otherNodes.end(), Nodes, it, ++it);
@@ -232,8 +238,8 @@ class Graph {
     }
   }
 
-  void importEdge(EdgeRef edge, Graph<T, U>& otherGraph) {
-    std::list<Edge<T, U>>& otherEdges = otherGraph.Edges;
+  void importEdge(EdgeRef edge, Graph<T, U...>& otherGraph) {
+    std::list<Edge<T, U...>>& otherEdges = otherGraph.Edges;
     for (auto it = Edges.begin(); it != Edges.end(); ++it) {
       if (&(*it) == edge) {
         otherEdges.splice(otherEdges.end(), Edges, it, ++it);
@@ -269,7 +275,7 @@ class Graph {
   }
 
   NodeRef createNode() {
-    Nodes.emplace_back(Node<T, U>());
+    Nodes.emplace_back(Node<T, U...>());
     DEBUG_PRINT("Creating node (%p)\n", &Nodes.back());
     return &Nodes.back();
   }
@@ -308,19 +314,11 @@ class Graph {
   /// \p tail The node that will have this edge as an out-edge.
   /// \p head The node that will have this edge as an in-edge.
   /// \return A reference to the edge created.
-  EdgeRef createEdge(NodeRef tail, NodeRef head) {
+  EdgeRef createEdge(NodeRef tail, NodeRef head, U... data) {
     DEBUG_PRINT("Creating edge (%p -> %p)\n", tail, head);
-    Edges.emplace_back(Edge<T, U>(tail, head));
-    EdgeRef e = &Edges.back();
-    head->addInEdge(e);
-    tail->addOutEdge(e);
-    return e;
-  }
-
-  EdgeRef createEdge(NodeRef tail, NodeRef head, U&& data) {
-    DEBUG_PRINT("Creating edge (%p -> %p)\n", tail, head);
-    Edges.emplace_back(Edge<T, U>(tail, head, std::move(data)));
-    EdgeRef e = &Edges.back();
+    this->Edges.emplace_back(
+        Edge<T, U...>(tail, head, std::forward<U...>(data)...));
+    EdgeRef e = &this->Edges.back();
     head->addInEdge(e);
     tail->addOutEdge(e);
     return e;
@@ -406,9 +404,9 @@ class Graph {
     }
   }
 
- private:
-  std::list<Node<T, U>> Nodes;
-  std::list<Edge<T, U>> Edges;
+ protected:
+  std::list<Node<T, U...>> Nodes;
+  std::list<Edge<T, U...>> Edges;
 };
 
 } // namespace nom

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/ControlFlow.h
@@ -12,10 +12,10 @@ namespace repr {
 /// \brief A basic block holds a reference to a subgraph
 /// of the data flow graph as well as an ordering on instruction
 /// execution.  Basic blocks are used for control flow analysis.
-template <typename T, typename U>
+template <typename T, typename... U>
 class BasicBlock {
  public:
-  using NodeRef = typename Subgraph<T, U>::NodeRef;
+  using NodeRef = typename Subgraph<T, U...>::NodeRef;
   BasicBlock() {}
   ~BasicBlock() {
     for (auto pair : callbacks) {
@@ -80,11 +80,11 @@ class BasicBlock {
   }
 
  private:
-  Subgraph<T, U> Nodes;
+  Subgraph<T, U...> Nodes;
   std::vector<NodeRef> Instructions;
   // Because we reference a dataflow graph, we need to register callbacks
   // for when the dataflow graph is modified.
-  std::unordered_map<NodeRef, typename Notifier<Node<T, U>>::Callback*>
+  std::unordered_map<NodeRef, typename Notifier<Node<T, U...>>::Callback*>
       callbacks;
 };
 
@@ -97,19 +97,19 @@ struct ControlFlowGraphImpl {
       sizeof(ControlFlowGraphImpl),
       "Template parameter G in "
       "ControlFlowGraph<G> must be of "
-      "type Graph<T, U>.");
+      "type Graph<T, U...>.");
 };
 
-template <typename T, typename U>
-struct ControlFlowGraphImpl<Graph<T, U>> {
-  using type = Graph<std::unique_ptr<BasicBlock<T, U>>, int>;
-  using bbType = BasicBlock<T, U>;
+template <typename T, typename... U>
+struct ControlFlowGraphImpl<Graph<T, U...>> {
+  using type = Graph<std::unique_ptr<BasicBlock<T, U...>>, int>;
+  using bbType = BasicBlock<T, U...>;
 };
 
 /// \brief Control flow graph is a graph of basic blocks that
 /// can be used as an analysis tool.
 ///
-/// \note G Must be of type Graph<T, U>.
+/// \note G Must be of type Graph<T, U...>.
 template <typename G>
 class ControlFlowGraph : public ControlFlowGraphImpl<G>::type {
  public:

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -241,8 +241,8 @@ class GenericOperator : public NeuralNetOperator {
   std::string name_;
 };
 
-using NNGraph = nom::Graph<std::unique_ptr<nom::repr::Value>, int>;
-using NNSubgraph = nom::Subgraph<std::unique_ptr<nom::repr::Value>, int>;
+using NNGraph = nom::Graph<std::unique_ptr<nom::repr::Value>>;
+using NNSubgraph = nom::Subgraph<std::unique_ptr<nom::repr::Value>>;
 using NNCFGraph = nom::repr::ControlFlowGraph<NNGraph>;
 
 struct NNModule {
@@ -263,7 +263,8 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 
 template <typename T, typename U>
 struct inheritedFrom {
-    static constexpr bool value = std::is_base_of<U, T>::value && !std::is_same<U, T>::value;
+  static constexpr bool value =
+      std::is_base_of<U, T>::value && !std::is_same<U, T>::value;
 };
 
 // This is just a way to fix issues when the isa<> implementation

--- a/caffe2/core/nomnigraph/include/nomnigraph/Support/Common.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Support/Common.h
@@ -14,7 +14,10 @@
 #include <functional>
 #include <list>
 
-template <typename T>
+// Implements accessors for a generic type T. If the type is not
+// specified (i.e., void template type) then the partial specification
+// gives an empty type.
+template <typename T = void>
 class StorageType {
  public:
   StorageType(T&& data) : Data(std::move(data)) {}
@@ -34,6 +37,9 @@ class StorageType {
  private:
   T Data;
 };
+
+template <>
+class StorageType<> {};
 
 /// \brief This class enables a listener pattern.
 /// It is to be used with a "curious recursive pattern"

--- a/caffe2/core/nomnigraph/include/nomnigraph/Transformations/Match.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Transformations/Match.h
@@ -30,7 +30,7 @@ template <
     typename EqualityClass = NodeEqualityDefault<typename G::NodeRef>>
 class Match {
  public:
-  using SubgraphType = Subgraph<typename G::NodeType, typename G::EdgeType>;
+  using SubgraphType = typename G::SubgraphType;
 
   Match(G& g) : MatchGraph(g) {
     // First we sort both the matching graph topologically.

--- a/caffe2/core/nomnigraph/tests/tarjans_test.cc
+++ b/caffe2/core/nomnigraph/tests/tarjans_test.cc
@@ -5,15 +5,27 @@
 #include "nomnigraph/Graph/Graph.h"
 
 TEST(Tarjans, Simple) {
-    TestClass t1;
-    TestClass t2;
-    nom::Graph<TestClass, int> g;
-    nom::Graph<TestClass, int>::NodeRef n1 = g.createNode(std::move(t1));
-    nom::Graph<TestClass, int>::NodeRef n2 = g.createNode(std::move(t2));
-    g.createEdge(n1, n2);
-    g.createEdge(n2, n1);
-    auto sccs = nom::algorithm::tarjans(&g);
-    EXPECT_EQ(sccs.size(), 1);
+  TestClass t1;
+  TestClass t2;
+  nom::Graph<TestClass> g;
+  nom::Graph<TestClass>::NodeRef n1 = g.createNode(std::move(t1));
+  nom::Graph<TestClass>::NodeRef n2 = g.createNode(std::move(t2));
+  g.createEdge(n1, n2);
+  g.createEdge(n2, n1);
+  auto sccs = nom::algorithm::tarjans(&g);
+  EXPECT_EQ(sccs.size(), 1);
+}
+
+TEST(Tarjans, WithEdgeStorage) {
+  TestClass t1;
+  TestClass t2;
+  nom::Graph<TestClass, TestClass> g;
+  nom::Graph<TestClass, TestClass>::NodeRef n1 = g.createNode(std::move(t1));
+  nom::Graph<TestClass, TestClass>::NodeRef n2 = g.createNode(std::move(t2));
+  g.createEdge(n1, n2, TestClass());
+  g.createEdge(n2, n1, TestClass());
+  auto sccs = nom::algorithm::tarjans(&g);
+  EXPECT_EQ(sccs.size(), 1);
 }
 
 TEST(Tarjans, DAG) {
@@ -29,8 +41,8 @@ TEST(Tarjans, Cycle) {
 }
 
 TEST(Tarjans, Random) {
-  nom::Graph<TestClass, int> g;
-  std::vector<nom::Graph<TestClass, int>::NodeRef> nodes;
+  nom::Graph<TestClass> g;
+  std::vector<nom::Graph<TestClass>::NodeRef> nodes;
   for (auto i = 0; i < 10; ++i) {
     TestClass t;
     nodes.emplace_back(g.createNode(std::move(t)));
@@ -44,4 +56,3 @@ TEST(Tarjans, Random) {
   auto sccs = nom::algorithm::tarjans(&g);
   EXPECT_GE(sccs.size(), 1);
 }
-


### PR DESCRIPTION
Summary:
This diff:
- Changes the Graph, Edge, etc. classes to allow a void type.
- Refactors Algorithm.h to get rid of unnecessary int placeholder.

Test Plan:
- There are already both types of uses for Edge, and hence both
  template paths are covered. I.e., all unit tests passed => template
  codes covered.
- For scc: Now have two tests for Tarjan's impl.

