### PR TITLE
Makes AccumulateGrad high priority in backwards passes

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -64,15 +64,10 @@ struct FunctionTask {
     , inputs(std::move(inputs)) {}
 };
 
-/*
-Returns true when t2 should be (weakly) BEFORE t1 in the queue.
-*/
+// Returns true when t2 should be (weakly) BEFORE t1 in the queue.
 struct CompareFunctionTaskTime {
   bool operator()(FunctionTask const & t1, FunctionTask const & t2) {
-    if (t1.fn->backwards_priority() == t2.fn->backwards_priority()) {
-      return t1.fn->sequence_nr() < t2.fn->sequence_nr();
-    }
-    return t1.fn->backwards_priority() < t2.fn->backwards_priority();
+    return t1.fn->sequence_nr() < t2.fn->sequence_nr();
   }
 };
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -64,9 +64,15 @@ struct FunctionTask {
     , inputs(std::move(inputs)) {}
 };
 
+/*
+Returns true when t2 should be (weakly) BEFORE t1 in the queue.
+*/
 struct CompareFunctionTaskTime {
   bool operator()(FunctionTask const & t1, FunctionTask const & t2) {
-    return t1.fn->sequence_nr() < t2.fn->sequence_nr();
+    if (t1.fn->backwards_priority() == t2.fn->backwards_priority()) {
+      return t1.fn->sequence_nr() < t2.fn->sequence_nr();
+    }
+    return t1.fn->backwards_priority() < t2.fn->backwards_priority();
   }
 };
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -92,8 +92,9 @@ struct Function : std::enable_shared_from_this<Function> {
       uint32_t num_inputs = 0,
       edge_list&& next_edges = edge_list())
       : sequence_nr_(next_sequence_nr_++),
-        num_inputs_(num_inputs),
-        next_edges_(std::move(next_edges)) {}
+      backwards_priority_(0),
+      num_inputs_(num_inputs),
+      next_edges_(std::move(next_edges)) {}
 
   /// Functions are neither copyable nor moveable.
   Function(const Function& other) = delete;
@@ -167,6 +168,10 @@ struct Function : std::enable_shared_from_this<Function> {
   /// The sequence number of this `Function`.
   uint64_t sequence_nr() const noexcept {
     return sequence_nr_;
+  }
+
+  int backwards_priority() const noexcept {
+    return backwards_priority_;
   }
 
   /// Returns a shared pointer to `this`. `PyFunction`s are not managed by
@@ -303,6 +308,7 @@ struct Function : std::enable_shared_from_this<Function> {
   // Since `Function`s are neither copyable nor moveable, we can have const
   // fields.
   const uint64_t sequence_nr_;
+  int backwards_priority_;
 
   uint32_t num_inputs_;
   edge_list next_edges_;

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -101,7 +101,7 @@ struct Function : std::enable_shared_from_this<Function> {
   explicit Function(
       uint32_t num_inputs = 0,
       edge_list&& next_edges = edge_list())
-      : Function(num_inputs, next_sequence_nr++, std::move(next_edges)) {}
+      : Function(num_inputs, next_sequence_nr_++, std::move(next_edges)) {}
   
   /// Functions are neither copyable nor moveable.
   Function(const Function& other) = delete;

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -87,15 +87,23 @@ void deleteFunction(Function* function);
 struct Function : std::enable_shared_from_this<Function> {
  public:
   /// Construct a new `Function` with `num_inputs` inputs and the given
-  /// `next_edges`.
+  /// `next_edges`. backwards_priority_ determines the priority of this 
+  /// function being called during a backward() pass, with ties broken
+  /// by sequence_nr_. 
   explicit Function(
-      uint32_t num_inputs = 0,
+      uint32_t num_inputs,
+      int backwards_priority,
       edge_list&& next_edges = edge_list())
       : sequence_nr_(next_sequence_nr_++),
-      backwards_priority_(0),
+      backwards_priority_(backwards_priority),
       num_inputs_(num_inputs),
       next_edges_(std::move(next_edges)) {}
 
+  explicit Function(
+      uint32_t num_inputs = 0,
+      edge_list&& next_edges = edge_list())
+      : Function(num_inputs, 0, std::move(next_edges)) {}
+  
   /// Functions are neither copyable nor moveable.
   Function(const Function& other) = delete;
   Function(Function&& other) = delete;
@@ -308,7 +316,7 @@ struct Function : std::enable_shared_from_this<Function> {
   // Since `Function`s are neither copyable nor moveable, we can have const
   // fields.
   const uint64_t sequence_nr_;
-  int backwards_priority_;
+  const int backwards_priority_;
 
   uint32_t num_inputs_;
   edge_list next_edges_;

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -11,11 +11,12 @@ using at::Tensor;
 
 namespace torch { namespace autograd {
 
+// AccumulateGrad has backwards_priority = 1 so it's always called ASAP 
+// during backwards.
 AccumulateGrad::AccumulateGrad(Variable variable_)
-    : Function(/*num_inputs=*/1), variable(std::move(variable_)) 
-{
-  backwards_priority_ = 1;
-}
+    : Function(/*num_inputs=*/1
+              , /*backwards_priority=*/1)
+              , variable(std::move(variable_)) {}
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   // XXX: this method is not thread-safe!

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -7,15 +7,17 @@
 #include "torch/csrc/autograd/functions/utils.h"
 #include "torch/csrc/utils/auto_gpu.h"
 
+#include <cstdint>
+
 using at::Tensor;
 
 namespace torch { namespace autograd {
 
-// AccumulateGrad has backwards_priority = 1 so it's always called ASAP 
-// during backwards.
+// AccumulateGrad sets sequence_nr to the max value so it's always called 
+// ASAP during backwards.
 AccumulateGrad::AccumulateGrad(Variable variable_)
     : Function(/*num_inputs=*/1
-              , /*backwards_priority=*/1)
+              , /*sequence_nr=*/UINT64_MAX)
               , variable(std::move(variable_)) {}
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -12,7 +12,10 @@ using at::Tensor;
 namespace torch { namespace autograd {
 
 AccumulateGrad::AccumulateGrad(Variable variable_)
-    : Function(/*num_inputs=*/1), variable(std::move(variable_)) {}
+    : Function(/*num_inputs=*/1), variable(std::move(variable_)) 
+{
+  backwards_priority_ = 1;
+}
 
 auto AccumulateGrad::apply(const variable_list& grads) -> variable_list {
   // XXX: this method is not thread-safe!


### PR DESCRIPTION
This change is a little tricky, and is best understood with a simple example.

Assume you have a simple model like ab = a + b, cd = c + d, final = ab + cd and you have some loss and call backward(). Backwards will evaluate the final summation, then the cd summation, then the ab summation, then c and d, where it will accumulate the gradient into both c and d, then finally a and b where it will accumulate the gradient into both a and b. So far so good.

Now if you zero_grad() (or not) and run the model again the order of the backward pass changes and the AccumulateGrad functions are called last.

This is because when functions are created they are assigned a (monotonically increasing, thread local) sequence number which is used to prioritize them in the backwards pass. On the first pass through the graph the AccumulateGrad functions have sequence numbers near (actually just higher than) those of the first functions where the variables are used. This means that the AccumulateGrad functions are called as soon as possible on the first call to backward().

On the second pass, however, the functions other than AccumulateGrad are new functions and so are all given higher sequence numbers than the AccumulateGrad functions. This means that the AccumulateGrad functions will all be processed last, not as soon as possible.

Processing all the AccumulateGrad functions at the end of the backward pass is unfortunate when trying to overlap communication with the backward pass, like @csarofeen and @mcarilli are doing. This PR adds a new "backwards_priority" to functions that makes backward() process AccumulateGrad ASAP. This should also make the order of AccumulateGrad calls consistent across passes through the same network. 

Adding backwards_priority to functions was a little tricky because the existing constructor has a default first argument. To avoid changing the current constructor I added a new one. The former constructor is now a delegating constructor to avoid code duplication. The implementation of backwards_priority is otherwise analogous to sequence_nr. Priorities during backwards are now set by backwards_priority first and sequence_nr second.