### PR TITLE
Reduce MAX_JOBS for gcc 7.2 build

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -28,7 +28,8 @@ if ! which conda; then
 fi
 
 # sccache will fail for CUDA builds if all cores are used for compiling
-if [[ "$BUILD_ENVIRONMENT" == *cuda* ]] && which sccache > /dev/null; then
+# gcc 7.2 with sccache seems to have intermittent OOM issue if all cores are used
+if ([[ "$BUILD_ENVIRONMENT" == *cuda* ]] || [[ "$BUILD_ENVIRONMENT" == *gcc7.2* ]]) && which sccache > /dev/null; then
   export MAX_JOBS=`expr $(nproc) - 1`
 fi
 


### PR DESCRIPTION
gcc 7.2 with sccache seems to have intermittent OOM issue if all cores are used for compiling:

https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-trusty-py3.6-gcc7.2-build/6968/consoleFull
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-trusty-py3.6-gcc7.2-build/6894/consoleFull
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-trusty-py3.6-gcc7.2-build/6883/consoleFull

This PR reduces MAX_JOBS for gcc 7.2 build to try to address this problem.