### PR TITLE
Be more lenient w.r.t. flag processing in C++ extensions

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -215,6 +215,26 @@ class TestCppExtension(common.TestCase):
             torch.utils.cpp_extension.load_inline(
                 name='invalid_jit_extension', cpp_sources='', functions=5)
 
+    def test_lenient_flag_handling_in_jit_extensions(self):
+        cpp_source = '''
+        at::Tensor tanh_add(at::Tensor x, at::Tensor y) {
+          return x.tanh() + y.tanh();
+        }
+        '''
+
+        module = torch.utils.cpp_extension.load_inline(
+            name='lenient_flag_handling_extension',
+            cpp_sources=cpp_source,
+            functions='tanh_add',
+            extra_cflags=['-g\n\n', '-O0 -Wall'],
+            extra_include_paths=['       cpp_extensions\n', '../'],
+            verbose=True)
+
+        x = torch.zeros(100, dtype=torch.float32)
+        y = torch.zeros(100, dtype=torch.float32)
+        z = module.tanh_add(x, y).cpu()
+        self.assertEqual(z, x.tanh() + y.tanh())
+
 
 if __name__ == '__main__':
     common.run_tests()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -739,6 +739,11 @@ def _write_ninja_file(path,
                       extra_ldflags,
                       extra_include_paths,
                       with_cuda=False):
+    extra_cflags = [flag.strip() for flag in extra_cflags]
+    extra_cuda_cflags = [flag.strip() for flag in extra_cuda_cflags]
+    extra_ldflags = [flag.strip() for flag in extra_ldflags]
+    extra_include_paths = [flag.strip() for flag in extra_include_paths]
+
     # Version 1.3 is required for the `deps` directive.
     config = ['ninja_required_version = 1.3']
     config.append('cxx = {}'.format(os.environ.get('CXX', 'c++')))


### PR DESCRIPTION
@wickedfoo ran into a problem where he was passing the output of a `subprocess` call as flags to `torch.utils.cpp_extension.load`. It contained a newline, and therefore ninja didn't like the produced build file. This PR fixes this by calling `.strip()` on each flag before passing it to ninja.

Added test that fails before and passes after.

@apaszke @ezyang @soumith 