### PR TITLE
Fix rocm docker images environment variables round 2

### DIFF
--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -26,9 +26,6 @@ install_ubuntu() {
                    rocrand \
                    rocm-profiler \
                    cxlactivitylogger
-
-    echo 'export PATH="/opt/rocm/bin:/opt/rocm/hcc/bin:/opt/rocm/hip/bin:/opt/rocm/opencl/bin:${PATH}"' | tee -a /etc/profile.d/rocm.sh ~/.bashrc
-    echo 'export MIOPEN_DISABLE_CACHE=1' | tee -a /etc/profile.d/rocm.sh ~/.bashrc
 }
 
 install_centos() {
@@ -42,7 +39,6 @@ install_hip_thrust() {
     rm -rf /data/Thrust/thrust/system/cuda/detail/cub-hip
     git clone --recursive https://github.com/ROCmSoftwarePlatform/cub-hip.git /data/Thrust/thrust/system/cuda/detail/cub-hip
     cd /data/Thrust/thrust/system/cuda/detail/cub-hip && git checkout hip_port_1.7.4_caffe2 && cd -
-    echo 'export THRUST_ROOT=/data/Thrust' | tee -a /etc/profile.d/rocm.sh ~/.bashrc
 }
 
 

--- a/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu-rocm/Dockerfile
@@ -55,6 +55,13 @@ ARG ROCM_VERSION
 ADD ./install_rocm.sh install_rocm.sh
 RUN bash ./install_rocm.sh
 RUN rm install_rocm.sh
+ENV PATH /opt/rocm/bin:$PATH
+ENV PATH /opt/rocm/hcc/bin:$PATH
+ENV PATH /opt/rocm/hip/bin:$PATH
+ENV PATH /opt/rocm/opencl/bin:$PATH
+ENV THRUST_ROOT /data/Thrust
+ENV MIOPEN_DISABLE_CACHE 1
+ENV HIP_PLATFORM hcc
 
 # (optional) Add Jenkins user
 ARG JENKINS


### PR DESCRIPTION
#7598 does not work for non-interactive non-login shells