### PR TITLE
Process group base class and Gloo implementation

### DIFF
--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -6,12 +6,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake ${CMAKE_MODULE_
 # which defines ATEN_INCLUDE_DIR and ATEN_LIBRARIES.
 find_package(ATen REQUIRED)
 if(NOT ATen_FOUND)
-  message(FATAL "ATen not found")
+  message(FATAL_ERROR "ATen not found")
 endif()
 
 find_package(Gloo REQUIRED)
-if(NOT ATen_FOUND)
-  message(FATAL "Gloo not found")
+if(NOT Gloo_FOUND)
+  message(FATAL_ERROR "Gloo not found")
 endif()
 
 add_library(store Utils.cpp Store.cpp FileStore.cpp TCPStore.cpp)

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -14,19 +14,26 @@ if(NOT Gloo_FOUND)
   message(FATAL_ERROR "Gloo not found")
 endif()
 
-add_library(store Utils.cpp Store.cpp FileStore.cpp TCPStore.cpp)
-target_compile_options(store PUBLIC "-std=c++11")
-target_include_directories(store PUBLIC ${ATEN_INCLUDE_DIR})
+set(C10D_SRCS
+  Utils.cpp
+  Store.cpp
+  FileStore.cpp
+  TCPStore.cpp
+  ProcessGroup.cpp
+  )
 
-add_library(process_group ProcessGroup.cpp)
-target_compile_options(process_group PUBLIC "-std=c++11")
-target_include_directories(process_group PUBLIC ${ATEN_INCLUDE_DIR})
-target_link_libraries(process_group PUBLIC ${ATEN_LIBRARIES})
+add_library(c10d ${C10D_SRCS})
+target_compile_options(c10d PUBLIC "-std=c++11")
+target_include_directories(c10d PUBLIC ${ATEN_INCLUDE_DIR})
+target_link_libraries(c10d PUBLIC ${ATEN_LIBRARIES})
 
-add_library(process_group_gloo ProcessGroupGloo.cpp)
-target_compile_options(process_group_gloo PUBLIC "-std=c++11")
-target_include_directories(process_group PUBLIC ${GLOO_INCLUDE_DIR})
-target_link_libraries(process_group_gloo PUBLIC process_group ${GLOO_LIBRARIES})
+set(C10D_GLOO_SRCS
+  ProcessGroupGloo.cpp
+  )
+
+add_library(c10d_gloo ${C10D_GLOO_SRCS})
+target_include_directories(c10d_gloo PUBLIC ${GLOO_INCLUDE_DIR})
+target_link_libraries(c10d_gloo PUBLIC c10d ${GLOO_LIBRARIES})
 
 add_subdirectory(example)
 

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -1,8 +1,21 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake ${CMAKE_MODULE_PATH})
 
+# Relies on CMAKE_INSTALL_PREFIX to be set to ../tmp_install.
+# It then finds $PREFIX/share/cmake/ATen/ATenConfig.cmake,
+# which defines ATEN_INCLUDE_DIR and ATEN_LIBRARIES.
+find_package(ATen REQUIRED)
+if(NOT ATen_FOUND)
+  message(FATAL "ATen not found")
+endif()
+
 add_library(store Utils.cpp Store.cpp FileStore.cpp TCPStore.cpp)
 target_compile_options(store PUBLIC "-std=c++11")
+
+add_library(process_group ProcessGroup.cpp)
+target_compile_options(process_group PUBLIC "-std=c++11")
+target_include_directories(process_group PUBLIC ${ATEN_INCLUDE_DIR})
+target_link_libraries(process_group PUBLIC ${ATEN_LIBRARIES})
 
 enable_testing()
 add_subdirectory(test)

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -9,6 +9,11 @@ if(NOT ATen_FOUND)
   message(FATAL "ATen not found")
 endif()
 
+find_package(Gloo REQUIRED)
+if(NOT ATen_FOUND)
+  message(FATAL "Gloo not found")
+endif()
+
 add_library(store Utils.cpp Store.cpp FileStore.cpp TCPStore.cpp)
 target_compile_options(store PUBLIC "-std=c++11")
 
@@ -16,6 +21,13 @@ add_library(process_group ProcessGroup.cpp)
 target_compile_options(process_group PUBLIC "-std=c++11")
 target_include_directories(process_group PUBLIC ${ATEN_INCLUDE_DIR})
 target_link_libraries(process_group PUBLIC ${ATEN_LIBRARIES})
+
+add_library(process_group_gloo ProcessGroupGloo.cpp)
+target_compile_options(process_group_gloo PUBLIC "-std=c++11")
+target_include_directories(process_group PUBLIC ${GLOO_INCLUDE_DIR})
+target_link_libraries(process_group_gloo PUBLIC process_group ${GLOO_LIBRARIES})
+
+add_subdirectory(example)
 
 enable_testing()
 add_subdirectory(test)

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 add_library(store Utils.cpp Store.cpp FileStore.cpp TCPStore.cpp)
 target_compile_options(store PUBLIC "-std=c++11")
+target_include_directories(store PUBLIC ${ATEN_INCLUDE_DIR})
 
 add_library(process_group ProcessGroup.cpp)
 target_compile_options(process_group PUBLIC "-std=c++11")

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -27,6 +27,9 @@ target_compile_options(c10d PUBLIC "-std=c++11")
 target_include_directories(c10d PUBLIC ${ATEN_INCLUDE_DIR})
 target_link_libraries(c10d PUBLIC ${ATEN_LIBRARIES})
 
+# For torch/csrc/utils/hash.h and torch/csrc/utils/functional.h
+target_include_directories(c10d PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
 set(C10D_GLOO_SRCS
   ProcessGroupGloo.cpp
   )

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -1,0 +1,16 @@
+#include "ProcessGroup.hpp"
+
+namespace c10d {
+
+ProcessGroup::Work::~Work() {
+}
+
+ProcessGroup::ProcessGroup(int rank, int size)
+    : rank_(rank),
+      size_(size) {
+}
+
+ProcessGroup::~ProcessGroup() {
+}
+
+} // namespace c10d

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -2,15 +2,10 @@
 
 namespace c10d {
 
-ProcessGroup::Work::~Work() {
-}
+ProcessGroup::Work::~Work() {}
 
-ProcessGroup::ProcessGroup(int rank, int size)
-    : rank_(rank),
-      size_(size) {
-}
+ProcessGroup::ProcessGroup(int rank, int size) : rank_(rank), size_(size) {}
 
-ProcessGroup::~ProcessGroup() {
-}
+ProcessGroup::~ProcessGroup() {}
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -59,7 +59,7 @@ class ProcessGroup {
     virtual ~Work();
 
     // Checks if request has completed. Non-blocking operation.
-    virtual bool isCompleted() = 0;
+    virtual bool isCompleted() const = 0;
 
     // Waits until request completes. Blocking operation.
     // Returns false if the work completed with an exception.

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <ATen/ATen.h>
+
+#include "Types.hpp"
+
+namespace c10d {
+
+// ProcessGroup is a base class that captures collective and point to
+// point communication in a fixed set of processes.
+//
+// The functions specified in the class below describe the API alone;
+// implementations are provided in subclasses.
+//
+// Every function that performs I/O is executed asynchronously by a
+// thread pool owned by the ProcessGroup (by default). They return an
+// object that can be used to wait for completion or error.
+//
+// The ProcessGroup can instantiate subgroups with fewer or an equal
+// number of members. Implementations must take care that multiple
+// process groups can be used in parallel and synchronize accordingly.
+//
+// The ProcessGroup assumes a fixed set of processes. If the set
+// changes, existing instances must be destructed and instantiation
+// and initialization must start from scratch. For members of the
+// process group to find each other (referred to as rendezvous from
+// hereon)
+//
+// Note on usage with CUDA tensors:
+//
+// Operations on CUDA tensors are assumed to be executed
+// asynchronously. Therefore they may have not yet executed when the
+// tensors are passed to a collective function. The collective
+// functions themselves should not block, so access to these tensors
+// must be done asynchronously, as well as signaling completion of the
+// collective function. We want to enable the following pattern:
+//
+//   z = at::sum(x, y);
+//   work = pg.allreduce(z)
+//   // Do something with z
+//
+// To do so, we execute the work associated with the collective
+// function on a separate CUDA stream. Upon completing, this stream
+// notifies the stream that produced the tensor in z
+// (cudaEventRecord). Before returning from the collective function,
+// it adds an asychronous wait for the internal stream
+// (cudaEventSynchronize). This way we retain the ability to write
+// sequential code that executes asynchronously, without requiring the
+// caller to perform explicit synchronization.
+//
+class ProcessGroup {
+ public:
+  class Work {
+   public:
+    virtual ~Work();
+
+    // Checks if request has completed. Non-blocking operation.
+    virtual bool isCompleted() = 0;
+
+    // Waits until request completes. Blocking operation.
+    // Returns false if the work completed with an exception.
+    virtual bool wait() = 0;
+
+    // Returns exception if wait() returned false.
+    virtual const std::exception& exception() const = 0;
+  };
+
+  explicit ProcessGroup(int rank, int size);
+  virtual ~ProcessGroup();
+
+  int getRank() const {
+    return rank_;
+  }
+
+  int getSize() const {
+    return size_;
+  }
+
+  virtual std::shared_ptr<Work> broadcast(
+      std::vector<at::Tensor>& data,
+      const BroadcastOptions& opts = BroadcastOptions()) = 0;
+
+  virtual std::shared_ptr<Work> allreduce(
+      std::vector<at::Tensor>& data,
+      const AllreduceOptions& opts = AllreduceOptions()) = 0;
+
+ protected:
+  const int rank_;
+  const int size_;
+};
+
+} // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -300,7 +300,7 @@ EntryType ProcessGroupGloo::construct(const AlgorithmKey& key) {
     entry->src[i] = at::zeros(*key.type, at::IntList(srcSizes[i]));
   }
 
-  return std::move(entry);
+  return entry;
 }
 
 EntryType ProcessGroupGloo::checkout(const AlgorithmKey& key) {
@@ -316,7 +316,7 @@ EntryType ProcessGroupGloo::checkout(const AlgorithmKey& key) {
   // per key until we add support for a dynamic limit.
   if (cacheCreated_[key] < 1) {
     cacheCreated_[key]++;
-    return std::move(construct(key));
+    return construct(key);
   }
 
   // Optionally wait for entry to be returned to the cache.
@@ -329,7 +329,7 @@ EntryType ProcessGroupGloo::checkout(const AlgorithmKey& key) {
   // Grab entry from the cache and return it.
   auto entry = std::move(it->second);
   cache_.erase(key);
-  return std::move(entry);
+  return entry;
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::enqueue(EntryType entry) {
@@ -337,7 +337,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::enqueue(EntryType entry) {
   std::unique_lock<std::mutex> lock(m_);
   queue_.push_back(std::make_tuple(std::move(entry), work));
   queueProduceCV_.notify_one();
-  return std::move(work);
+  return work;
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::broadcast(

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -1,0 +1,390 @@
+#include "ProcessGroupGloo.hpp"
+
+#include <gloo/allreduce_halving_doubling.h>
+#include <gloo/rendezvous/context.h>
+
+#define GENERATE_ALL_TYPES(type, func, args...)                         \
+  switch (type) {                                                       \
+    case ::at::ScalarType::Float: func<float>(args); break;             \
+    case ::at::ScalarType::Double: func<double>(args); break;           \
+    case ::at::ScalarType::Half: func<gloo::float16>(args); break;      \
+    case ::at::ScalarType::Char: func<int8_t>(args); break;             \
+    case ::at::ScalarType::Byte: func<uint8_t>(args); break;            \
+    case ::at::ScalarType::Int: func<int32_t>(args); break;             \
+    case ::at::ScalarType::Long: func<int64_t>(args); break;            \
+    default:                                                            \
+      throw std::runtime_error("Invalid scalar type");                  \
+  }
+
+namespace c10d {
+
+using KeyType = AlgorithmKey;
+using EntryType = std::unique_ptr<AlgorithmEntry>;
+
+namespace {
+
+// Wrap c10d store as Gloo store
+class GlooStore : public ::gloo::rendezvous::Store {
+ public:
+  GlooStore(const std::shared_ptr<::c10d::Store>& store)
+      : store_(store) {
+  }
+
+  void set(const std::string& key, const std::vector<char>& value) override {
+    // @pietern was unable to figure out a way to cast the value of
+    // type std::vector<char> to an std::vector<unsigned char>,
+    // so going with a copy here (it's not a hot path so it's fine).
+    std::vector<uint8_t> tmp(value.size());
+    memcpy(tmp.data(), value.data(), value.size());
+    store_->set(key, tmp);
+  }
+
+  std::vector<char> get(const std::string& key) override {
+    // @pietern was unable to figure out a way to cast the value of
+    // type std::vector<unsigned char> to an std::vector<char>,
+    // so going with a copy here (it's not a hot path so it's fine).
+    auto value = store_->get(key);
+    std::vector<char> tmp(value.size());
+    memcpy(tmp.data(), value.data(), value.size());
+    return tmp;
+  }
+
+  void wait(const std::vector<std::string>& keys) override {
+    store_->wait(keys, Store::kDefaultTimeout);
+  }
+
+  void wait(
+      const std::vector<std::string>& keys,
+      const std::chrono::milliseconds& timeout) override {
+    store_->wait(keys, timeout);
+  }
+
+ protected:
+  std::shared_ptr<::c10d::Store> store_;
+};
+
+template <typename T>
+const ::gloo::ReductionFunction<T>* reductionFunction(const ReduceOp& r) {
+  switch (r) {
+    case ReduceOp::SUM:
+      return ::gloo::ReductionFunction<T>::sum;
+    case ReduceOp::PRODUCT:
+      return ::gloo::ReductionFunction<T>::product;
+    case ReduceOp::MIN:
+      return ::gloo::ReductionFunction<T>::min;
+    case ReduceOp::MAX:
+      return ::gloo::ReductionFunction<T>::max;
+  }
+
+  throw std::runtime_error("Unhandled ReduceOp");
+}
+
+} // namespace
+
+ProcessGroupGloo::WorkGloo::WorkGloo() {
+  completed_ = false;
+}
+
+ProcessGroupGloo::WorkGloo::~WorkGloo() {
+}
+
+bool ProcessGroupGloo::WorkGloo::isCompleted() {
+  std::unique_lock<std::mutex> lock(m_);
+  return completed_;
+}
+
+bool ProcessGroupGloo::WorkGloo::wait() {
+  std::unique_lock<std::mutex> lock(m_);
+  while (!completed_) {
+    cv_.wait(lock);
+  }
+  return !ex_;
+}
+
+const std::exception& ProcessGroupGloo::WorkGloo::exception() const {
+  return *ex_;
+}
+
+void ProcessGroupGloo::WorkGloo::finish() {
+  {
+    std::unique_lock<std::mutex> lock(m_);
+    completed_ = true;
+  }
+  cv_.notify_all();
+}
+
+void ProcessGroupGloo::WorkGloo::finishWithException(
+    const ::gloo::Exception& ex) {
+  {
+    std::unique_lock<std::mutex> lock(m_);
+    completed_ = true;
+    ex_ = std::unique_ptr<::gloo::Exception>(new ::gloo::Exception(ex));
+  }
+  cv_.notify_all();
+}
+
+ProcessGroupGloo::ProcessGroupGloo(
+    const std::shared_ptr<Store>& store,
+    const std::vector<std::shared_ptr<::gloo::transport::Device>>& devices,
+    int rank,
+    int size)
+    : ProcessGroup(rank, size),
+      store_(new GlooStore(store)),
+      devices_(devices) {
+  stop_ = false;
+}
+
+ProcessGroupGloo::~ProcessGroupGloo() {
+  // Require this process group to be explicitly shut down prior to being
+  // destructed. This is the easiest way to guarantee clean shutdown
+  // and avoid blocking/throwing in a destructor.
+}
+
+void ProcessGroupGloo::initialize() {
+  contexts_.clear();
+  for (auto& device : devices_) {
+    auto context = std::shared_ptr<::gloo::rendezvous::Context>(
+        new ::gloo::rendezvous::Context(rank_, size_));
+    context->setTimeout(std::chrono::milliseconds(100));
+    context->connectFullMesh(*store_, device);
+    contexts_.push_back(std::move(context));
+  }
+
+  // TODO(@pietern): Make number of threads configurable
+  threads_.resize(2);
+  for (int i = 0; i < threads_.size(); i++) {
+    threads_[i] = std::thread(&ProcessGroupGloo::runLoop, this);
+  }
+}
+
+void ProcessGroupGloo::destroy() {
+  std::unique_lock<std::mutex> lock(m_);
+  while (!queue_.empty()) {
+    queueConsumeCV_.wait(lock);
+  }
+
+  // Queue is empty, signal stop
+  stop_ = true;
+
+  // Release lock to allow threads to terminate
+  queueProduceCV_.notify_all();
+  lock.unlock();
+
+  // Wait for worker threads to terminate
+  for (auto& thread : threads_) {
+    thread.join();
+  }
+}
+
+void ProcessGroupGloo::runLoop(void) {
+  std::unique_lock<std::mutex> lock(m_);
+
+  while (!stop_) {
+    if (queue_.empty()) {
+      queueProduceCV_.wait(lock);
+      continue;
+    }
+
+    auto tuple = std::move(queue_.front());
+    queue_.pop_front();
+    queueConsumeCV_.notify_one();
+
+    auto& entry = std::get<0>(tuple);
+    auto& work = std::get<1>(tuple);
+
+    // Continue holding onto the lock; this ensures that we serialize
+    // creation of Gloo algorithm instances for the context associated
+    // with this process group.
+    if (!entry->algorithm) {
+      createAlgorithm(*entry);
+    }
+
+    lock.unlock();
+    runSingle(std::move(tuple));
+    lock.lock();
+  }
+}
+
+void ProcessGroupGloo::runSingle(WorkType tuple) {
+  auto& entry = std::get<0>(tuple);
+  auto& work = std::get<1>(tuple);
+
+  try {
+    entry->run(entry);
+    work->finish();
+  } catch (const ::gloo::Exception& ex) {
+    work->finishWithException(ex);
+  }
+
+  // Return entry to cache
+  std::unique_lock<std::mutex> lock(m_);
+  cache_[entry->key] = std::move(entry);
+  cacheCV_.notify_all();
+}
+
+void ProcessGroupGloo::createAlgorithm(AlgorithmEntry& entry) {
+  const auto& key = entry.key;
+  switch (key.collectiveType) {
+    case CollectiveType::ALLREDUCE:
+      GENERATE_ALL_TYPES(
+          key.type->scalarType(),
+          createAllreduce,
+          entry);
+      return;
+  }
+
+  throw std::runtime_error("Unhandled collective type");
+}
+
+template <typename T>
+void ProcessGroupGloo::createAllreduce(AlgorithmEntry& entry) {
+  const auto& key = entry.key;
+
+  // Turn source tensors into T*
+  auto& src = entry.src;
+  std::vector<T*> tmp(src.size());
+  for (int i = 0; i < src.size(); i++) {
+    tmp[i] = static_cast<T*>(src[i].storage()->data());
+  }
+
+  // Create algorithm against first context
+  auto& context = contexts_[0];
+  entry.algorithm = std::unique_ptr<::gloo::Algorithm>(
+      new ::gloo::AllreduceHalvingDoubling<T>(
+          context,
+          tmp,
+          src[0].numel(),
+          reductionFunction<T>(key.reduceOp)));
+}
+
+// Constructs an AlgorithmEntry instance, except for the Gloo
+// algorithm itself. It allocates temporary input/output tensors, CUDA
+// streams (if applicable), etcetera. These are allocated lazily for
+// every unique collective call and reused for identical collective
+// calls. They cannot be allocated asynchronously because our
+// collective functions may need thme before queueing asynchronous
+// work. For example, to work with asynchronous CUDA code, the
+// collective call needs to issue an asynchronous memory copy, and a
+// call to cudaStreamWaitEvent to make it wait for the asynchronous
+// execution of the collective call to complete.
+//
+// Construction of the Gloo algorithm itself it delayed until a thread
+// picks up the work, because it performs I/O and can fail. Any I/O
+// failure must be signaled through the Work future.
+//
+EntryType ProcessGroupGloo::construct(
+    const AlgorithmKey& key) {
+  auto entry = std::unique_ptr<AlgorithmEntry>(new AlgorithmEntry);
+  entry->key = key;
+
+  // Allocate source tensors for this entry
+  auto& srcSizes = key.srcSizes;
+  entry->src.resize(srcSizes.size());
+  for (int i = 0; i < srcSizes.size(); i++) {
+    entry->src[i] = at::zeros(*key.type, at::IntList(srcSizes[i]));
+  }
+
+  // TODO(@pietern): Create CUDA streams and events
+  return std::move(entry);
+}
+
+EntryType ProcessGroupGloo::checkout(const AlgorithmKey& key) {
+  std::unique_lock<std::mutex> lock(m_);
+
+  // Initialize number of entries for this key
+  if (cacheCreated_.count(key) == 0) {
+    cacheCreated_.emplace(key, 0);
+  }
+
+  // If there is no entry for this key yet, it must be the first time
+  // we see and can create a new entry. Use hard limit of 1 instance
+  // per key until we add support for a dynamic limit.
+  if (cacheCreated_[key] < 1) {
+    cacheCreated_[key]++;
+    return std::move(construct(key));
+  }
+
+  // Optionally wait for entry to be returned to the cache.
+  auto it = cache_.find(key);
+  while (it == cache_.end()) {
+    cacheCV_.wait(lock);
+    it = cache_.find(key);
+  }
+
+  auto entry = std::move(it->second);
+  cache_.erase(key);
+  return std::move(entry);
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::broadcast(
+    std::vector<at::Tensor>& tensors,
+    const BroadcastOptions& opts) {
+  return std::shared_ptr<Work>(new WorkGloo());
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& opts) {
+  // Ensure we have at least one tensor
+  if (tensors.size() == 0) {
+    throw std::invalid_argument("allreduce: argument is empty");
+  }
+
+  // Ensure all tensors have identical type and shape
+  auto& type = tensors[0].type();
+  auto sizes = tensors[0].sizes();
+  for (int i = 1; i < tensors.size(); i++) {
+    if (tensors[i].type() != type) {
+      throw std::invalid_argument("allreduce: argument contains mixed types");
+    }
+    if (!tensors[i].sizes().equals(sizes)) {
+      throw std::invalid_argument("allreduce: argument contains mixed sizes");
+    }
+  }
+
+  // List of devices for tensors determines uniqueness of this call
+  std::vector<int> devices;
+  if (type.is_cuda()) {
+    devices.resize(tensors.size());
+    for (int i = 0; i < tensors.size(); i++) {
+      devices[i] = tensors[i].storage()->getDevice();
+    }
+  }
+
+  AlgorithmKey key;
+  key.collectiveType = CollectiveType::ALLREDUCE;
+  key.type = &tensors[0].type();
+  key.srcSizes.resize(tensors.size());
+  for (int i = 0; i < tensors.size(); i++) {
+    key.srcSizes[i] = tensors[i].sizes();
+  }
+  key.devices = std::move(devices);
+  key.reduceOp = opts.reduceOp;
+
+  // Retrieve (create or wait for) cache entry
+  auto entry = checkout(key);
+
+  // Copy input tensors
+  for (int i = 0; i < tensors.size(); i++) {
+    entry->src[i].copy_(tensors[i]);
+  }
+
+  // Define how to run the algorithm and copy back results
+  entry->run = [tensors](EntryType& entry) mutable {
+    entry->algorithm->run();
+    for (int i = 0; i < tensors.size(); i++) {
+      tensors[i].copy_(entry->src[i]);
+    }
+    // TODO(@pietern): cudaEventRecord to unblock source stream
+  };
+
+  auto work = std::shared_ptr<WorkGloo>(new WorkGloo());
+  std::unique_lock<std::mutex> lock(m_);
+  queue_.push_back(std::make_tuple(std::move(entry), work));
+  queueProduceCV_.notify_one();
+
+  // TODO(@pietern): cudaStreamWaitEvent on source stream
+  return std::move(work);
+}
+
+} // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -156,7 +156,7 @@ ProcessGroupGloo::ProcessGroupGloo(
 }
 
 ProcessGroupGloo::~ProcessGroupGloo() {
-  std::unique_lock<std::mutex> lock(m_);
+  std::unique_lock<std::mutex> lock(queueMutex_);
   while (!queue_.empty()) {
     queueConsumeCV_.wait(lock);
   }
@@ -175,7 +175,7 @@ ProcessGroupGloo::~ProcessGroupGloo() {
 }
 
 void ProcessGroupGloo::runLoop(void) {
-  std::unique_lock<std::mutex> lock(m_);
+  std::unique_lock<std::mutex> lock(queueMutex_);
 
   while (!stop_) {
     if (queue_.empty()) {

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -301,7 +301,7 @@ AlgorithmEntry* ProcessGroupGloo::checkout(const AlgorithmKey& key) {
   // Ensure entry is not in use
   std::unique_lock<std::mutex> lock(entry->m);
   while (entry->busy) {
-      entry->cv.wait(lock);
+    entry->cv.wait(lock);
   }
 
   // Mark entry in use
@@ -309,7 +309,8 @@ AlgorithmEntry* ProcessGroupGloo::checkout(const AlgorithmKey& key) {
   return entry.get();
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::enqueue(AlgorithmEntry* entry) {
+std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::enqueue(
+    AlgorithmEntry* entry) {
   auto work = std::make_shared<WorkGloo>();
   std::unique_lock<std::mutex> lock(queueMutex_);
   queue_.push_back(std::make_tuple(entry, work));

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -55,16 +55,17 @@ struct AlgorithmKey {
 
   // This function is called by torch::hash<AlgorithmKey>
   static std::size_t hash(const AlgorithmKey& k) {
-    return torch::get_hash(k.collectiveType,
-                           k.type,
-                           k.devices,
-                           k.srcSizes,
-                           k.dstSizes,
-                           k.srcRank,
-                           k.dstRank,
-                           k.srcTensor,
-                           k.dstTensor,
-                           k.reduceOp);
+    return torch::get_hash(
+        k.collectiveType,
+        k.type,
+        k.devices,
+        k.srcSizes,
+        k.dstSizes,
+        k.srcRank,
+        k.dstRank,
+        k.srcTensor,
+        k.dstTensor,
+        k.reduceOp);
   }
 };
 

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -177,15 +177,10 @@ class ProcessGroupGloo : public ProcessGroup {
   explicit ProcessGroupGloo(
       const std::shared_ptr<Store>& store,
       int rank,
-      int size);
+      int size,
+      Options options = Options());
 
   virtual ~ProcessGroupGloo();
-
-  void initialize();
-
-  void initialize(Options options);
-
-  void destroy();
 
   std::shared_ptr<Work> broadcast(
       std::vector<at::Tensor>& data,

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <gloo/algorithm.h>
+#include <gloo/common/error.h>
+#include <gloo/context.h>
+#include <gloo/rendezvous/store.h>
+#include <gloo/transport/device.h>
+
+#include "ProcessGroup.hpp"
+#include "Store.hpp"
+#include "Types.hpp"
+#include "Utils.hpp"
+
+namespace c10d {
+
+// AlgorithmKey is a const identifier for a Gloo algorithm.
+//
+// It captures the set of participating devices, the source device,
+// destination device, source rank, destination rank, reduction type
+// (if applicable), etcetera. This key is used to cache instances of a
+// Gloo algorithm for reuse. The number of cached instances can vary
+// over time and is agreed upon between all processes in the group. It
+// is also used in identifying the algorithm type for which to change
+// the maximum alotted number of instances.
+//
+struct AlgorithmKey {
+  bool operator==(const AlgorithmKey &other) const {
+    return
+      (collectiveType == other.collectiveType) &&
+      (type == other.type) &&
+      (devices == other.devices) &&
+      (srcSizes == other.srcSizes) &&
+      (dstSizes == other.dstSizes) &&
+      (srcDevice == other.srcDevice) &&
+      (dstDevice == other.dstDevice) &&
+      (srcRank == other.srcRank) &&
+      (dstRank == other.dstRank) &&
+      (reduceOp == other.reduceOp);
+  }
+
+  CollectiveType collectiveType = CollectiveType::UNUSED;
+  at::Type* type = nullptr;
+  std::vector<int> devices;
+  std::vector<std::vector<int64_t>> srcSizes;
+  std::vector<std::vector<int64_t>> dstSizes;
+  int srcDevice = -1;
+  int dstDevice = -1;
+  int srcRank = -1;
+  int dstRank = -1;
+  ReduceOp reduceOp = ReduceOp::UNUSED;
+};
+
+struct AlgorithmEntry {
+  AlgorithmKey key;
+  std::unique_ptr<::gloo::Algorithm> algorithm;
+  std::vector<at::Tensor> src;
+  std::vector<at::Tensor> dst;
+  std::function<void(std::unique_ptr<AlgorithmEntry>&)> run;
+
+  explicit AlgorithmEntry() {
+  }
+
+  // Must not be copied
+  AlgorithmEntry & operator=(const AlgorithmEntry&) = delete;
+  AlgorithmEntry(const AlgorithmEntry&) = delete;
+
+  // May be moved
+  AlgorithmEntry(AlgorithmEntry&& other) {
+    key = std::move(other.key);
+    algorithm = std::move(other.algorithm);
+    src = std::move(other.src);
+    dst = std::move(other.dst);
+  }
+};
+
+} // namespace c10d
+
+MAKE_HASHABLE(
+    ::c10d::AlgorithmKey,
+    t.collectiveType,
+    t.type,
+    t.devices,
+    t.srcSizes,
+    t.dstSizes,
+    t.srcDevice,
+    t.dstDevice,
+    t.srcRank,
+    t.dstRank,
+    t.reduceOp);
+
+namespace c10d {
+
+class ProcessGroupGloo : public ProcessGroup {
+ public:
+  class WorkGloo : public Work {
+   public:
+    explicit WorkGloo();
+    virtual ~WorkGloo();
+
+    // Checks if request has completed. Non-blocking operation.
+    bool isCompleted() override;
+
+    // Waits until request completes. Blocking operation.
+    // Returns false if the work completed with an exception.
+    bool wait() override;
+
+    // Returns exception if wait() returned false.
+    const std::exception& exception() const override;
+
+   protected:
+    void finish();
+    void finishWithException(const ::gloo::Exception& ex);
+
+    std::mutex m_;
+    std::condition_variable cv_;
+    bool completed_;
+
+    // Use pointer to ::gloo::Exception because it doesn't have a
+    // default constructor and constructing an empty std::unique_ptr
+    // is probably cheaper (this is highly speculative).
+    std::unique_ptr<::gloo::Exception> ex_;
+
+    friend class ProcessGroupGloo;
+  };
+
+  explicit ProcessGroupGloo(
+      const std::shared_ptr<Store>& store,
+      const std::vector<std::shared_ptr<::gloo::transport::Device>>& devices,
+      int rank,
+      int size);
+
+  virtual ~ProcessGroupGloo();
+
+  void initialize();
+  void destroy();
+
+  std::shared_ptr<Work> broadcast(
+      std::vector<at::Tensor>& data,
+      const BroadcastOptions& opts = BroadcastOptions()) override;
+
+  std::shared_ptr<Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override;
+
+ protected:
+  std::unique_ptr<::gloo::rendezvous::Store> store_;
+  std::vector<std::shared_ptr<::gloo::transport::Device>> devices_;
+  std::vector<std::shared_ptr<::gloo::Context>> contexts_;
+
+  using KeyType = AlgorithmKey;
+  using EntryType = std::unique_ptr<AlgorithmEntry>;
+
+  EntryType construct(const KeyType& key);
+  EntryType checkout(const KeyType& key);
+
+  std::mutex m_;
+  std::unordered_map<KeyType, int> cacheCreated_;
+  std::unordered_map<KeyType, EntryType> cache_;
+  std::condition_variable cacheCV_;
+
+  using WorkType = std::tuple<EntryType, std::shared_ptr<WorkGloo>>;
+  std::deque<WorkType> queue_;
+  std::condition_variable queueProduceCV_;
+  std::condition_variable queueConsumeCV_;
+
+  std::vector<std::thread> threads_;
+  bool stop_;
+
+  void runLoop(void);
+  void runSingle(WorkType work);
+  void createAlgorithm(AlgorithmEntry& entry);
+
+  template <typename T>
+  void createAllreduce(AlgorithmEntry& entry);
+};
+
+} // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -32,18 +32,12 @@ namespace c10d {
 // to broadcast the number of entries such that all processes agree.
 //
 struct AlgorithmKey {
-  bool operator==(const AlgorithmKey &other) const {
-    return
-      (collectiveType == other.collectiveType) &&
-      (type == other.type) &&
-      (devices == other.devices) &&
-      (srcSizes == other.srcSizes) &&
-      (dstSizes == other.dstSizes) &&
-      (srcRank == other.srcRank) &&
-      (dstRank == other.dstRank) &&
-      (srcTensor == other.srcTensor) &&
-      (dstTensor == other.dstTensor) &&
-      (reduceOp == other.reduceOp);
+  bool operator==(const AlgorithmKey& other) const {
+    return (collectiveType == other.collectiveType) && (type == other.type) &&
+        (devices == other.devices) && (srcSizes == other.srcSizes) &&
+        (dstSizes == other.dstSizes) && (srcRank == other.srcRank) &&
+        (dstRank == other.dstRank) && (srcTensor == other.srcTensor) &&
+        (dstTensor == other.dstTensor) && (reduceOp == other.reduceOp);
   }
 
   CollectiveType collectiveType = CollectiveType::UNUSED;
@@ -83,7 +77,7 @@ struct AlgorithmEntry {
   AlgorithmEntry() {}
 
   // Must not be copyable
-  AlgorithmEntry & operator=(const AlgorithmEntry&) = delete;
+  AlgorithmEntry& operator=(const AlgorithmEntry&) = delete;
   AlgorithmEntry(const AlgorithmEntry&) = delete;
 };
 

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -38,10 +38,10 @@ struct AlgorithmKey {
       (devices == other.devices) &&
       (srcSizes == other.srcSizes) &&
       (dstSizes == other.dstSizes) &&
-      (srcDevice == other.srcDevice) &&
-      (dstDevice == other.dstDevice) &&
       (srcRank == other.srcRank) &&
       (dstRank == other.dstRank) &&
+      (srcTensor == other.srcTensor) &&
+      (dstTensor == other.dstTensor) &&
       (reduceOp == other.reduceOp);
   }
 
@@ -50,10 +50,10 @@ struct AlgorithmKey {
   std::vector<int> devices;
   std::vector<std::vector<int64_t>> srcSizes;
   std::vector<std::vector<int64_t>> dstSizes;
-  int srcDevice = -1;
-  int dstDevice = -1;
   int srcRank = -1;
   int dstRank = -1;
+  int srcTensor = -1;
+  int dstTensor = -1;
   ReduceOp reduceOp = ReduceOp::UNUSED;
 };
 
@@ -81,10 +81,10 @@ MAKE_HASHABLE(
     t.devices,
     t.srcSizes,
     t.dstSizes,
-    t.srcDevice,
-    t.dstDevice,
     t.srcRank,
     t.dstRank,
+    t.srcTensor,
+    t.dstTensor,
     t.reduceOp);
 
 namespace c10d {
@@ -171,6 +171,8 @@ class ProcessGroupGloo : public ProcessGroup {
   std::condition_variable queueProduceCV_;
   std::condition_variable queueConsumeCV_;
 
+  std::shared_ptr<Work> enqueue(EntryType entry);
+
   std::vector<std::thread> threads_;
   bool stop_;
 
@@ -180,6 +182,9 @@ class ProcessGroupGloo : public ProcessGroup {
 
   template <typename T>
   void createAllreduce(AlgorithmEntry& entry);
+
+  template <typename T>
+  void createBroadcast(AlgorithmEntry& entry);
 };
 
 } // namespace c10d

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -74,7 +74,8 @@ struct AlgorithmEntry {
   std::vector<at::Tensor> dst;
   std::function<void(std::unique_ptr<AlgorithmEntry>&)> run;
 
-  AlgorithmEntry() {}
+  // Default constructor must be specified
+  AlgorithmEntry() = default;
 
   // Must not be copyable
   AlgorithmEntry& operator=(const AlgorithmEntry&) = delete;

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -195,7 +195,7 @@ class ProcessGroupGloo : public ProcessGroup {
 
   void runLoop(void);
 
-  void runSingle(WorkType work);
+  void runSingle(std::unique_lock<std::mutex>& lock, WorkType work);
 
   void createAlgorithm(AlgorithmEntry& entry);
 

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+
+namespace c10d {
+
+enum class CollectiveType : std::uint8_t {
+  ALLGATHER = 0,
+  GATHER,
+  SCATTER,
+  ALLREDUCE,
+  REDUCE,
+  BROADCAST,
+  SEND,
+  BARRIER,
+  UNUSED,
+};
+
+enum class DeviceType : std::uint8_t {
+  CPU = 0,
+  CUDA,
+  UNUSED,
+};
+
+enum class ReduceOp : std::uint8_t {
+  SUM = 0,
+  PRODUCT,
+  MIN,
+  MAX,
+  UNUSED,
+};
+
+struct BroadcastOptions {
+  int rootRank = 0;
+  int rootTensor = 0;
+};
+
+struct AllreduceOptions {
+  ReduceOp reduceOp = ReduceOp::SUM;
+};
+
+} // namespace c10d

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -69,6 +69,55 @@ MAKE_HASHABLE(::c10d::ReduceOp, static_cast<std::uint8_t>(t));
 
 namespace c10d {
 
+inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
+  // Ensure we have at least one tensor
+  if (tensors.size() == 0) {
+    throw std::invalid_argument("argument is empty");
+  }
+
+  // Ensure all tensors have identical type and shape
+  auto& type = tensors[0].type();
+  auto sizes = tensors[0].sizes();
+  for (auto i = 1; i < tensors.size(); i++) {
+    if (tensors[i].type() != type) {
+      throw std::invalid_argument("argument contains mixed types");
+    }
+    if (!tensors[i].sizes().equals(sizes)) {
+      throw std::invalid_argument("argument contains mixed sizes");
+    }
+  }
+}
+
+inline std::vector<std::vector<int64_t>> getSizes(
+    const std::vector<at::Tensor>& tensors) {
+  std::vector<std::vector<int64_t>> sizes(tensors.size());
+  for (auto i = 0; i < tensors.size(); i++) {
+    sizes[i] = tensors[i].sizes();
+  }
+  return sizes;
+}
+
+inline std::vector<int> getDevices(const std::vector<at::Tensor>& tensors) {
+  std::vector<int> devices;
+  const auto& type = tensors[0].type();
+  if (type.is_cuda()) {
+    devices.resize(tensors.size());
+    for (auto i = 0; i < tensors.size(); i++) {
+      devices[i] = tensors[i].storage()->getDevice();
+    }
+  }
+  return devices;
+}
+
+template <typename T>
+std::vector<T*> getDataPointers(const std::vector<at::Tensor>& tensors) {
+  std::vector<T*> ptrs(tensors.size());
+  for (auto i = 0; i < tensors.size(); i++) {
+    ptrs[i] = static_cast<T*>(tensors[i].storage()->data());
+  }
+  return ptrs;
+}
+
 using RankType = uint32_t;
 using PortType = uint16_t;
 using SizeType = uint64_t;

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -17,59 +17,6 @@
 
 #include "Types.hpp"
 
-inline void hash_combine(std::size_t& seed) {}
-
-template <typename T, typename... Rest>
-inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
-  std::hash<T> hasher;
-  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  hash_combine(seed, rest...);
-}
-
-#define MAKE_HASHABLE(type, ...)                  \
-  namespace std {                                 \
-  template <>                                     \
-  struct hash<type> {                             \
-    std::size_t operator()(const type& t) const { \
-      std::size_t ret = 0;                        \
-      hash_combine(ret, __VA_ARGS__);             \
-      return ret;                                 \
-    }                                             \
-  };                                              \
-  }
-
-// Make std::vector<T> hashable
-namespace std {
-template <typename T>
-struct hash<vector<T>> {
-  std::size_t operator()(const vector<T>& v) const {
-    std::size_t ret = v.size();
-    for (const auto& e : v) {
-      hash_combine(ret, e);
-    }
-    return ret;
-  }
-};
-} // namespace std
-
-// Make at::ArrayRef<T> hashable
-namespace std {
-template <typename T>
-struct hash<at::ArrayRef<T>> {
-  std::size_t operator()(const at::ArrayRef<T>& v) const {
-    std::size_t ret = v.size();
-    for (const auto& e : v) {
-      hash_combine(ret, e);
-    }
-    return ret;
-  }
-};
-} // namespace std
-
-MAKE_HASHABLE(::c10d::CollectiveType, static_cast<std::uint8_t>(t));
-MAKE_HASHABLE(::c10d::DeviceType, static_cast<std::uint8_t>(t));
-MAKE_HASHABLE(::c10d::ReduceOp, static_cast<std::uint8_t>(t));
-
 namespace c10d {
 
 // Turns at::IntList into "(1, 2, 3, 4)".

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -17,7 +17,7 @@
 
 #include "Types.hpp"
 
-inline void hash_combine(std::size_t& seed) { }
+inline void hash_combine(std::size_t& seed) {}
 
 template <typename T, typename... Rest>
 inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
@@ -26,20 +26,22 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
   hash_combine(seed, rest...);
 }
 
-#define MAKE_HASHABLE(type, ...)                                              \
-  namespace std {                                                             \
-    template<> struct hash<type> {                                            \
-      std::size_t operator()(const type &t) const {                           \
-        std::size_t ret = 0;                                                  \
-        hash_combine(ret, __VA_ARGS__);                                       \
-        return ret;                                                           \
-      }                                                                       \
-    };                                                                        \
+#define MAKE_HASHABLE(type, ...)                  \
+  namespace std {                                 \
+  template <>                                     \
+  struct hash<type> {                             \
+    std::size_t operator()(const type& t) const { \
+      std::size_t ret = 0;                        \
+      hash_combine(ret, __VA_ARGS__);             \
+      return ret;                                 \
+    }                                             \
+  };                                              \
   }
 
 // Make std::vector<T> hashable
 namespace std {
-template<typename T> struct hash<vector<T>> {
+template <typename T>
+struct hash<vector<T>> {
   std::size_t operator()(const vector<T>& v) const {
     std::size_t ret = v.size();
     for (const auto& e : v) {
@@ -52,7 +54,8 @@ template<typename T> struct hash<vector<T>> {
 
 // Make at::ArrayRef<T> hashable
 namespace std {
-template<typename T> struct hash<at::ArrayRef<T>> {
+template <typename T>
+struct hash<at::ArrayRef<T>> {
   std::size_t operator()(const at::ArrayRef<T>& v) const {
     std::size_t ret = v.size();
     for (const auto& e : v) {

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -72,6 +72,20 @@ MAKE_HASHABLE(::c10d::ReduceOp, static_cast<std::uint8_t>(t));
 
 namespace c10d {
 
+// Turns at::IntList into "(1, 2, 3, 4)".
+inline std::string toString(at::IntList l) {
+  std::stringstream ss;
+  ss << "(";
+  for (int i = 0; i < l.size(); i++) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << l[i];
+  }
+  ss << ")";
+  return ss.str();
+}
+
 inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   // Ensure we have at least one tensor
   if (tensors.size() == 0) {
@@ -83,10 +97,16 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   auto sizes = tensors[0].sizes();
   for (auto i = 1; i < tensors.size(); i++) {
     if (tensors[i].type() != type) {
-      throw std::invalid_argument("argument contains mixed types");
+      const std::string expected = type.toString();
+      const std::string actual = tensors[i].type().toString();
+      throw std::invalid_argument(
+        "argument contains mixed types (" + expected + " and " + actual + ")");
     }
     if (!tensors[i].sizes().equals(sizes)) {
-      throw std::invalid_argument("argument contains mixed sizes");
+      const auto expected = toString(sizes);
+      const auto actual = toString(tensors[i].sizes());
+      throw std::invalid_argument(
+        "argument contains mixed sizes (" + expected + " and " + actual + ")");
     }
   }
 }

--- a/torch/lib/c10d/bin/test.sh
+++ b/torch/lib/c10d/bin/test.sh
@@ -4,5 +4,5 @@ set -ex
 
 mkdir -p build
 cd build
-cmake ../
+cmake ../ -DCMAKE_INSTALL_PREFIX="$PWD/../../tmp_install"
 make all test

--- a/torch/lib/c10d/example/CMakeLists.txt
+++ b/torch/lib/c10d/example/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(allreduce allreduce.cpp)
 target_include_directories(allreduce PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(allreduce store process_group process_group_gloo pthread gloo)
+target_link_libraries(allreduce pthread c10d_gloo)

--- a/torch/lib/c10d/example/CMakeLists.txt
+++ b/torch/lib/c10d/example/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(allreduce allreduce.cpp)
+target_include_directories(allreduce PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(allreduce store process_group process_group_gloo pthread gloo)

--- a/torch/lib/c10d/example/allreduce.cpp
+++ b/torch/lib/c10d/example/allreduce.cpp
@@ -1,0 +1,40 @@
+#include <ProcessGroupGloo.hpp>
+#include <FileStore.hpp>
+
+#include <gloo/transport/tcp/device.h>
+
+using namespace ::c10d;
+
+int main(int argc, char** argv) {
+  int rank = atoi(getenv("RANK"));
+  int size = atoi(getenv("SIZE"));
+  auto store = std::make_shared<FileStore>("/tmp/c10d_example");
+  std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
+  devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
+  ProcessGroupGloo pg(store, devices, rank, size);
+  pg.initialize();
+
+  // Create some tensors
+  const auto ntensors = 10;
+  std::vector<at::Tensor> tensors;
+  for (auto i = 0; i < ntensors; i++) {
+    auto x = at::ones(at::CPU(at::kFloat), {1000, 16 * (i + 1)});
+    tensors.push_back(x);
+  }
+
+  // Kick off work
+  std::vector<std::shared_ptr<ProcessGroup::Work>> pending;
+  for (auto i = 0; i < ntensors; i++) {
+    std::vector<at::Tensor> tmp = { tensors[i] };
+    pending.push_back(pg.allreduce(tmp));
+  }
+
+  // Wait for work to complete
+  for (auto& work : pending) {
+    work->wait();
+  }
+
+  // Explicitly destroy process group
+  // This is not done from its destructor
+  pg.destroy();
+}

--- a/torch/lib/c10d/example/allreduce.cpp
+++ b/torch/lib/c10d/example/allreduce.cpp
@@ -1,7 +1,6 @@
 #include <ProcessGroupGloo.hpp>
 #include <FileStore.hpp>
 
-#include <gloo/transport/tcp/device.h>
 
 using namespace ::c10d;
 
@@ -9,9 +8,7 @@ int main(int argc, char** argv) {
   int rank = atoi(getenv("RANK"));
   int size = atoi(getenv("SIZE"));
   auto store = std::make_shared<FileStore>("/tmp/c10d_example");
-  std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
-  devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
-  ProcessGroupGloo pg(store, devices, rank, size);
+  ProcessGroupGloo pg(store, rank, size);
   pg.initialize();
 
   // Create some tensors

--- a/torch/lib/c10d/example/allreduce.cpp
+++ b/torch/lib/c10d/example/allreduce.cpp
@@ -1,6 +1,5 @@
-#include <ProcessGroupGloo.hpp>
 #include <FileStore.hpp>
-
+#include <ProcessGroupGloo.hpp>
 
 using namespace ::c10d;
 
@@ -22,7 +21,7 @@ int main(int argc, char** argv) {
   // Kick off work
   std::vector<std::shared_ptr<ProcessGroup::Work>> pending;
   for (auto i = 0; i < ntensors; i++) {
-    std::vector<at::Tensor> tmp = { tensors[i] };
+    std::vector<at::Tensor> tmp = {tensors[i]};
     pending.push_back(pg.allreduce(tmp));
   }
 

--- a/torch/lib/c10d/example/allreduce.cpp
+++ b/torch/lib/c10d/example/allreduce.cpp
@@ -8,7 +8,6 @@ int main(int argc, char** argv) {
   int size = atoi(getenv("SIZE"));
   auto store = std::make_shared<FileStore>("/tmp/c10d_example");
   ProcessGroupGloo pg(store, rank, size);
-  pg.initialize();
 
   // Create some tensors
   const auto ntensors = 10;
@@ -29,8 +28,4 @@ int main(int argc, char** argv) {
   for (auto& work : pending) {
     work->wait();
   }
-
-  // Explicitly destroy process group
-  // This is not done from its destructor
-  pg.destroy();
 }

--- a/torch/lib/c10d/test/CMakeLists.txt
+++ b/torch/lib/c10d/test/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(test_srcs
   FileStoreTest.cpp
   TCPStoreTest.cpp
+  ProcessGroupGlooTest.cpp
   )
 
 set(test_libraries
   store
   pthread
+  process_group_gloo
   )
 
 foreach(test_src ${test_srcs})

--- a/torch/lib/c10d/test/CMakeLists.txt
+++ b/torch/lib/c10d/test/CMakeLists.txt
@@ -1,19 +1,11 @@
-set(test_srcs
-  FileStoreTest.cpp
-  TCPStoreTest.cpp
-  ProcessGroupGlooTest.cpp
-  )
-
-set(test_libraries
-  store
-  pthread
-  process_group_gloo
-  )
-
-foreach(test_src ${test_srcs})
+function(c10d_add_test test_src)
   get_filename_component(test_name ${test_src} NAME_WE)
   add_executable(${test_name} "${test_src}")
   target_include_directories(${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
-  target_link_libraries(${test_name} ${test_libraries})
+  target_link_libraries(${test_name} pthread ${ARGN})
   add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
-endforeach()
+endfunction()
+
+c10d_add_test(FileStoreTest.cpp c10d)
+c10d_add_test(TCPStoreTest.cpp c10d)
+c10d_add_test(ProcessGroupGlooTest.cpp c10d c10d_gloo)

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -116,8 +116,7 @@ class SignalTest {
     ::c10d::ProcessGroupGloo::Options options;
     options.timeout = std::chrono::milliseconds(50);
 
-    ::c10d::ProcessGroupGloo pg(store, rank, size);
-    pg.initialize(options);
+    ::c10d::ProcessGroupGloo pg(store, rank, size, options);
 
     // Initialize tensor list
     std::vector<at::Tensor> tensors = {
@@ -134,7 +133,6 @@ class SignalTest {
       sem_.post();
     }
 
-    pg.destroy();
     return std::move(work);
   }
 
@@ -183,12 +181,6 @@ class CollectiveTest {
 
   CollectiveTest(const std::string& path) : path_(path) {}
 
-  ~CollectiveTest() {
-    if (pg_) {
-      pg_->destroy();
-    }
-  }
-
   CollectiveTest(CollectiveTest&& other) {
     path_ = std::move(other.path_);
     pg_ = std::move(other.pg_);
@@ -206,8 +198,7 @@ class CollectiveTest {
     options.timeout = std::chrono::milliseconds(50);
 
     pg_ = std::unique_ptr<::c10d::ProcessGroupGloo>(
-        new ::c10d::ProcessGroupGloo(store, rank, size));
-    pg_->initialize(options);
+        new ::c10d::ProcessGroupGloo(store, rank, size, options));
   }
 
  protected:

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -114,12 +114,12 @@ class SignalTest {
   std::shared_ptr<::c10d::ProcessGroup::Work> run(int rank, int size) {
     auto store = std::make_shared<::c10d::FileStore>(path_);
 
-    // Local test; all connections are made through loopback
-    std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
-    devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
+    // Use tiny timeout to make this test run fast
+    ::c10d::ProcessGroupGloo::Options options;
+    options.timeout = std::chrono::milliseconds(50);
 
-    ::c10d::ProcessGroupGloo pg(store, devices, rank, size);
-    pg.initialize();
+    ::c10d::ProcessGroupGloo pg(store, rank, size);
+    pg.initialize(options);
 
     // Initialize tensor list
     std::vector<at::Tensor> tensors = {

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -200,9 +200,14 @@ class CollectiveTest {
 
   void start(int rank, int size) {
     auto store = std::make_shared<::c10d::FileStore>(path_);
+
+    // Use tiny timeout to make this test run fast
+    ::c10d::ProcessGroupGloo::Options options;
+    options.timeout = std::chrono::milliseconds(50);
+
     pg_ = std::unique_ptr<::c10d::ProcessGroupGloo>(
         new ::c10d::ProcessGroupGloo(store, rank, size));
-    pg_->initialize();
+    pg_->initialize(options);
   }
 
  protected:

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -92,9 +92,7 @@ struct Fork {
 
 class SignalTest {
  public:
-  SignalTest(const std::string& path)
-      : path_(path) {
-  }
+  SignalTest(const std::string& path) : path_(path) {}
 
   ~SignalTest() {
     if (arm_.joinable()) {
@@ -106,9 +104,9 @@ class SignalTest {
   // happens as soon as the first collective completes successfully.
   void arm(int pid, int signal) {
     arm_ = std::move(std::thread([=] {
-          sem_.wait();
-          kill(pid, signal);
-        }));
+      sem_.wait();
+      kill(pid, signal);
+    }));
   }
 
   std::shared_ptr<::c10d::ProcessGroup::Work> run(int rank, int size) {
@@ -123,7 +121,7 @@ class SignalTest {
 
     // Initialize tensor list
     std::vector<at::Tensor> tensors = {
-      at::ones(at::CPU(at::kFloat), {16, 16}),
+        at::ones(at::CPU(at::kFloat), {16, 16}),
     };
 
     // Loop until an exception happens
@@ -173,9 +171,8 @@ class CollectiveTest {
 
     std::vector<std::thread> threads;
     for (auto i = 0; i < num; i++) {
-      threads.push_back(std::move(std::thread([i, &tests] {
-              tests[i].start(i, tests.size());
-            })));
+      threads.push_back(std::move(
+          std::thread([i, &tests] { tests[i].start(i, tests.size()); })));
     }
     for (auto& thread : threads) {
       thread.join();
@@ -184,9 +181,7 @@ class CollectiveTest {
     return std::move(tests);
   }
 
-  CollectiveTest(const std::string& path)
-      : path_(path) {
-  }
+  CollectiveTest(const std::string& path) : path_(path) {}
 
   ~CollectiveTest() {
     if (pg_) {
@@ -223,7 +218,7 @@ void testAllreduce(const std::string& path) {
   std::vector<std::vector<at::Tensor>> inputs(size);
   for (auto i = 0; i < size; i++) {
     auto tensor = at::ones(at::CPU(at::kFloat), {16, 16}) * i;
-    inputs[i] = std::vector<at::Tensor>({ tensor });
+    inputs[i] = std::vector<at::Tensor>({tensor});
   }
 
   // Kick off work

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -1,0 +1,180 @@
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <thread>
+
+#include <gloo/transport/tcp/device.h>
+
+#include "FileStore.hpp"
+#include "ProcessGroupGloo.hpp"
+
+class Semaphore {
+ public:
+  void post(int n = 1) {
+    std::unique_lock<std::mutex> lock(m_);
+    n_ += n;
+    cv_.notify_all();
+  }
+
+  void wait(int n = 1) {
+    std::unique_lock<std::mutex> lock(m_);
+    while (n_ < n) {
+      cv_.wait(lock);
+    }
+    n_ -= n;
+  }
+
+ protected:
+  int n_ = 0;
+  std::mutex m_;
+  std::condition_variable cv_;
+};
+
+std::string tmppath() {
+  const char* tmpdir = getenv("TMPDIR");
+  if (tmpdir == nullptr) {
+    tmpdir = "/tmp";
+  }
+
+  // Create template
+  std::vector<char> tmp(256);
+  auto len = snprintf(tmp.data(), tmp.size(), "%s/testXXXXXX", tmpdir);
+  tmp.resize(len);
+
+  // Create temporary file
+  auto fd = mkstemp(&tmp[0]);
+  if (fd == -1) {
+    throw std::system_error(errno, std::system_category());
+  }
+  close(fd);
+  return std::string(tmp.data(), tmp.size());
+}
+
+struct TemporaryFile {
+  std::string path;
+
+  TemporaryFile() {
+    path = tmppath();
+  }
+
+  ~TemporaryFile() {
+    unlink(path.c_str());
+  }
+};
+
+struct Fork {
+  pid_t pid;
+
+  Fork() {
+    pid = fork();
+    if (pid < 0) {
+      throw std::system_error(errno, std::system_category(), "fork");
+    }
+  }
+
+  ~Fork() {
+    if (pid > 0) {
+      kill(pid, SIGKILL);
+      waitpid(pid, nullptr, 0);
+    }
+  }
+
+  bool isChild() {
+    return pid == 0;
+  }
+};
+
+class SignalTest {
+ public:
+  SignalTest(const std::string& path)
+      : path_(path) {
+  }
+
+  ~SignalTest() {
+    if (arm_.joinable()) {
+      arm_.join();
+    }
+  }
+
+  // Arms test to send signal to PID when the semaphore unlocks. This
+  // happens as soon as the first collective completes successfully.
+  void arm(int pid, int signal) {
+    arm_ = std::move(std::thread([=] {
+          sem_.wait();
+          kill(pid, signal);
+        }));
+  }
+
+  std::shared_ptr<::c10d::ProcessGroup::Work> run(int rank, int size) {
+    auto store = std::make_shared<::c10d::FileStore>(path_);
+
+    // Local test; all connections are made through loopback
+    std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
+    devices.push_back(::gloo::transport::tcp::CreateDevice("localhost"));
+
+    ::c10d::ProcessGroupGloo pg(store, devices, rank, size);
+    pg.initialize();
+
+    // Initialize tensor list
+    std::vector<at::Tensor> tensors = {
+      at::ones(at::CPU(at::kFloat), {16, 16}),
+    };
+
+    // Loop until an exception happens
+    std::shared_ptr<::c10d::ProcessGroup::Work> work;
+    while (true) {
+      work = pg.allreduce(tensors);
+      if (!work->wait()) {
+        break;
+      }
+      sem_.post();
+    }
+
+    pg.destroy();
+    return std::move(work);
+  }
+
+ protected:
+  std::string path_;
+  std::thread arm_;
+  Semaphore sem_;
+};
+
+std::shared_ptr<::c10d::ProcessGroup::Work> testSignal(
+    const std::string& path,
+    int signal) {
+  Fork fork;
+  if (fork.isChild()) {
+    SignalTest test(path);
+    test.run(1, 2);
+    exit(1);
+  }
+
+  SignalTest test(path);
+  test.arm(fork.pid, signal);
+  return test.run(0, 2);
+}
+
+int main(int argc, char** argv) {
+  {
+    TemporaryFile file;
+    auto work = testSignal(file.path, SIGSTOP);
+    auto& ex = work->exception();
+    std::cout << "SIGSTOP test got: " << ex.what() << std::endl;
+  }
+
+  {
+    TemporaryFile file;
+    auto work = testSignal(file.path, SIGKILL);
+    auto& ex = work->exception();
+    std::cout << "SIGKILL test got: " << ex.what() << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This is a starting point and only implements allreduce for CPU tensors. It includes most base functionality like algorithm caching (similar approach as taken in the THD GlooCache) and multi-threaded execution (new).

The expectation is that function calls on the process group class are globally serialized. They execute collective functions, so members of the collective must call the same functions in the same order, or a deadlock may happen.

The algorithm cache works as follows: the ProcessGroupGloo class has a cache map from algorithm keys to algorithm entries. The algorithm key is a struct with fields that make up the signature of a collective function. It includes the dimensionality of the input/output tensors, tensor device assignment, source/destination rank, etc. For collective calls with the same key, the process group will lazily initialize and then cache a Gloo algorithm instance. For now we only keep a single algorithm instance per key, but this may be revisited in the future, if we observe contention on a single key and can exploit additional parallelism.