### PR TITLE
Move REGISTER_CUDA_HOOKS to cpp file.

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -114,4 +114,10 @@ int CUDAHooks::getNumGPUs() const {
   return count;
 }
 
+// Sigh, the registry doesn't support namespaces :(
+using at::RegistererCUDAHooksRegistry;
+using at::CUDAHooksRegistry;
+
+REGISTER_CUDA_HOOKS(CUDAHooks);
+
 }}} // namespace at::cuda::detail

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -2,6 +2,9 @@
 
 #include <ATen/Generator.h>
 
+// TODO: No need to have this whole header, we can just put it all in
+// the cpp file
+
 namespace at { namespace cuda { namespace detail {
 
 // The real implementation of CUDAHooksInterface
@@ -23,11 +26,5 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   double batchnormMinEpsilonCuDNN() const override;
   int getNumGPUs() const override;
 };
-
-// Sigh, the registry doesn't support namespaces :(
-using at::RegistererCUDAHooksRegistry;
-using at::CUDAHooksRegistry;
-
-REGISTER_CUDA_HOOKS(CUDAHooks);
 
 }}} // at::cuda::detail


### PR DESCRIPTION
It's going to define a static variable, and this was a loaded
footgun if another C++ file directly included this header.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

CC @zdevito