### PR TITLE
Fix flaky atomic iter test

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -1713,9 +1713,10 @@ class TestOperators(hu.HypothesisTestCase):
 
         if num_iters * num_nets > 0:
             stats_key = self.ws.blobs[("stats_key")].fetch()
-            self.assertEqual(b'atomic_iter/stats/iter/num_iter', stats_key[0])
+            atomic_iter_key = b'atomic_iter/stats/iter/num_iter'
+            self.assertTrue(atomic_iter_key in stats_key)
             stat_val = self.ws.blobs[("stats_val")].fetch()
-            self.assertEqual(num_iters * num_nets, stat_val[0])
+            self.assertEqual(num_iters * num_nets, stat_val[list(stats_key).index(atomic_iter_key)])
 
 
     @given(a=hu.tensor(),


### PR DESCRIPTION
The atomic_iter key is not necessary at the first position.
Failure reproducible in #7566 with docker image `308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc5-ubuntu16.04:116-build-test-4542` via minimal test sets
`pytest -s -v /code/caffe2/python/checkpoint_test.py /code/caffe2/python/hypothesis_test.py::TestOperators::test_atomic_iter_with_concurrent_steps`. An inspection into the `stats_key` shows:

['temp_node/time_ns/count' 'temp_node/time_ns/sum'
 'atomic_iter/stats/iter/num_iter'
 'trainer_2/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/count'
 'trainer_2/time_ns/count'
 'trainer_2/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/sum'
 'trainer_2/time_ns/sum'
 'trainer_1/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/sum'
 'trainer_0/time_ns/count' 'trainer_1/time_ns/count'
 'trainer_1/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/count'
 'trainer_0/time_ns/sum'
 'trainer_0/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/sum'
 'trainer_0/pipe/inc_total/builtin_function_or_method/NoOutput/time_ns/count'
 'trainer_1/time_ns/sum']