### PR TITLE
[caffe2][nomnigraph] External input/output support

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -32,6 +32,17 @@ const std::string NeuralNetData::getName() const {
   }
 }
 
+void NeuralNetData::setName(std::string name) {
+  switch (getKind()) {
+    case NNDataKind::Tensor: {
+      dyn_cast<Tensor>(this)->setName(name);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 namespace nn {
 
 bool hasProducer(NNGraph::NodeRef n) {

--- a/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
+++ b/caffe2/core/nomnigraph/include/nomnigraph/Representations/NeuralNet.h
@@ -153,6 +153,7 @@ class NeuralNetData : public Data {
   virtual NeuralNetData* clone() = 0;
 
   const std::string getName() const;
+  void setName(std::string);
 
   virtual ~NeuralNetData() = 0;
 
@@ -188,6 +189,9 @@ class Tensor : public NeuralNetData {
 
   const std::string getName() const {
     return name_;
+  }
+  void setName(std::string name) {
+    name_ = name;
   }
   ~Tensor() {}
 
@@ -246,6 +250,8 @@ using NNSubgraph = nom::Subgraph<std::unique_ptr<nom::repr::Value>, int>;
 using NNCFGraph = nom::repr::ControlFlowGraph<NNGraph>;
 
 struct NNModule {
+  std::vector<NNGraph::NodeRef> entryNodes;
+  std::vector<NNGraph::NodeRef> exitNodes;
   NNGraph dataFlow;
   NNCFGraph controlFlow;
   NNModule(const NNModule&) = delete;

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1519,7 +1519,7 @@ void addGlobalMethods(py::module& m) {
 
     auto nn = caffe2::convertToNNModule(proto);
     opt::fuseConvBN(&nn, gWorkspace);
-    auto new_proto = caffe2::convertToCaffe2Proto(nn);
+    auto new_proto = caffe2::convertToCaffe2Proto(nn, proto);
 
     std::string out;
     new_proto.SerializeToString(&out);


### PR DESCRIPTION
This PR brings the ownership of blob names into the hands of nomnigraph, which may not always be beneficial.  I'd appreciate feedback on how to best allow users to specify blob-name optimizations while maintaining the SSA format nomnigraph canonically uses (and ultimately injects into caffe2 via this diff).

What this diff does:

- Versions all blobs.
- Recreates in-place ops manually by setting the input and output to the same version.
- Outputs names for all the blobs by appending `_{version number}`
- Rectifies input and output blobnames (based on external_input/external_output fed from caffe2 earlier).

I think it'll be beneficial to use this API (of only preserving input and output names of the *entire* graph), but I can see how that will change many things.  I'd appreciate opinions on the matter 😄 