### PR TITLE
use matching tp_name for torch.device

### DIFF
--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -147,7 +147,7 @@ static struct PyGetSetDef THPDevice_properties[] = {
 
 PyTypeObject THPDeviceType = {
   PyVarObject_HEAD_INIT(nullptr, 0)
-  "torch.Device",                        /* tp_name */
+  "torch.device",                        /* tp_name */
   sizeof(THPDevice),                     /* tp_basicsize */
   0,                                     /* tp_itemsize */
   0,                                     /* tp_dealloc */


### PR DESCRIPTION
I've noticed that when you create a `torch.device` instance, a class of the variable is named `torch.Device`:

```py
In [1]: import torch

In [2]: d = torch.device('cpu')

In [3]: d
Out[3]: device(type='cpu')

In [4]: d.__class__
Out[4]: torch.Device
```

This is confusing, because there is no `torch.Device` available to import. According to Python docs, tp_name should be `the full module name, followed by a dot, followed by the type name` (see https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_name). Also, 

> For statically allocated type objects, the tp_name field should contain a dot. Everything before the last dot is made accessible as the `__module__` attribute, and everything after the last dot is made accessible as the `__name__` attribute.

I think setting these values incorrectly may also affect pickling (see https://github.com/pytorch/pytorch/issues/7545 - I haven't checked if it is fixed by this PR or not though):

> If no dot is present, the entire tp_name field is made accessible as the `__name__` attribute, and the `__module__` attribute is undefined (unless explicitly set in the dictionary, as explained above). This means your type will be impossible to pickle.

So, as this class is exposed as torch.device, in this PR tp_name is changed to `torch.device`.