### PR TITLE
Add map_location to torch.save

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6390,7 +6390,7 @@ class TestTorch(TestCase):
     def test_serialization_container_filelike(self):
         self._test_serialization_container('filelike', BytesIOContext)
 
-    def test_serialization_map_location(self):
+    def test_serialization_load_map_location(self):
         test_file_path = download_file('https://download.pytorch.org/test_data/gpu_tensors.pt')
 
         def map_location(storage, loc):
@@ -6435,6 +6435,69 @@ class TestTorch(TestCase):
                 torch.cuda.FloatTensor,
                 torch.device('cuda', torch.cuda.device_count() - 1)
             )
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no CUDA")
+    def test_serialization_save_map_location(self):
+        def check(devices, map_location):
+            input_device, intended_device = devices
+            tensor = torch.randn(3, 4, device=input_device)
+            buf = io.BytesIO()
+            torch.save(tensor, buf, map_location=map_location)
+            buf.seek(0)
+            loaded_tensor = torch.load(buf)
+            self.assertEqual(loaded_tensor.device, torch.device(intended_device))
+            self.assertEqual(loaded_tensor.to(input_device), tensor)
+
+        def map_location_cpu(storage):
+            return torch.device('cpu:0')
+
+        def map_location_gpu0(storage):
+            return torch.device('cuda:0')
+
+        # Check mapping to CPU
+        check(('cuda:0', 'cpu'), 'cpu')
+        check(('cuda:0', 'cpu'), 'cpu:0')
+        check(('cuda:0', 'cpu'), torch.device('cpu'))
+        check(('cuda:0', 'cpu'), torch.device('cpu', 0))
+        check(('cuda:0', 'cpu'), map_location_cpu)
+        check(('cuda:0', 'cpu'), {'cuda:0': 'cpu:0'})
+
+        # Check mapping to GPU 0
+        check(('cpu', 'cuda:0'), 'cuda:0')
+        check(('cpu', 'cuda:0'), 'cuda')
+        check(('cpu', 'cuda:0'), torch.device('cuda'))
+        check(('cpu', 'cuda:0'), torch.device('cuda', 0))
+        check(('cpu', 'cuda:0'), map_location_gpu0)
+        check(('cpu', 'cuda:0'), {'cpu': 'cuda:0'})
+
+        # Check mapping to last gpu
+        last_gpu = 'cuda:{}'.format(torch.cuda.device_count() - 1)
+        check(('cpu', last_gpu), last_gpu)
+        check(('cuda:0', last_gpu), lambda s: last_gpu)
+        check(('cuda:0', last_gpu), {'cuda:0': last_gpu})
+
+        # Check dictionary works as intended
+        mapping = {'cuda:0': 'cpu', 'cpu': 'cuda:0'}
+        check(('cpu', 'cuda:0'), mapping)
+        check(('cuda:0', 'cpu'), mapping)
+
+        # Check dictionary works with cpu:0
+        mapping = {'cuda:0': 'cpu:0', 'cpu:0': 'cuda:0'}
+        check(('cpu', 'cuda:0'), mapping)
+        check(('cuda:0', 'cpu'), mapping)
+
+        # Check dictionary None works
+        mapping = {'cuda:0': 'cpu'}
+        check(('cpu', 'cpu'), mapping)
+        check(('cuda:0', 'cpu'), mapping)
+
+        # Check function None works
+        def map_location_default(storage):
+            return None
+
+        check(('cpu', 'cpu'), map_location_default)
+        check(('cuda:0', 'cuda:0'), map_location_default)
+        check((last_gpu, last_gpu), map_location_default)
 
     def test_serialization_filelike_api_requirements(self):
         filemock = FilelikeMock(b'', has_readinto=False)


### PR DESCRIPTION
Fixes #6630
Fixes #7178

map_location can be a callable, string, device, or dict.

If map_location is a string or device, all storages are mapped to
map_location when they are saved.

If map_location is a callable, a storage s is mapped to the device
specified by map_location(s).

If map_location is a dict mapping "location tags" to devices, a storage
that has the same "location tag" in the dictionary is mapped to the
value of that location tag key.

