### PR TITLE
remove index from python bindings (fixes: #7639)

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -19,6 +19,7 @@ SKIP_PYTHON_BINDINGS = [
     '.*_backward', '.*_backward_(out|input|weight|bias)', '.*_forward',
     '.*_forward_out', 'sparse_raw_resize_', '_unsafe_view', 'tensor',
     'sparse_coo_tensor', '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
+    'index',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_sum.*', '_th_prod.*',
     'arange.*', 'range.*', '_gesv.*',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -887,17 +887,6 @@ histc(bins=100, min=0, max=0) -> Tensor
 See :func:`torch.histc`
 """)
 
-add_docstr_all('index',
-               r"""
-index(m) -> Tensor
-
-Selects elements from :attr:`self` tensor using a binary mask or along a given
-dimension. The expression ``tensor.index(m)`` is equivalent to ``tensor[m]``.
-
-Args:
-    m (int or ByteTensor or slice): the dimension or mask used to select elements
-""")
-
 add_docstr_all('index_add_',
                r"""
 index_add_(dim, index, tensor) -> Tensor


### PR DESCRIPTION
As discussed in the bug report, index is not what the documentation says it is and isn't supposed to be exposed.