### PR TITLE
Adding tags as an argument to the functional layer

### DIFF
--- a/caffe2/python/layers/functional.py
+++ b/caffe2/python/layers/functional.py
@@ -21,12 +21,12 @@ logger.setLevel(logging.INFO)
 class Functional(ModelLayer):
 
     def __init__(self, model, input_record, output_names_or_num, function,
-                 name='functional', output_dtypes=None, **kwargs):
+                 name='functional', output_dtypes=None, tags=None, **kwargs):
 
         # allow coercion
         input_record = schema.as_record(input_record)
 
-        super(Functional, self).__init__(model, name, input_record, **kwargs)
+        super(Functional, self).__init__(model, name, input_record, tags=tags, **kwargs)
         self._function = function
         self._kwargs = kwargs
         return_struct = (


### PR DESCRIPTION
Without it "tags" would be added as an argument to the operator.

The change here is based on the assumption that there is no operator that takes "tags" as an argument.

