### PR TITLE
[WIP] Implemented hardshrink in ATen with cuda

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -3,9 +3,6 @@
 #include "ATen/Dispatch.h"
 #include "ATen/CPUApplyUtils.h"
 
-// #ifdef _OPENMP
-// #include <omp.h>
-// #endif
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -36,7 +36,7 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
   return at::rrelu_with_noise_(self, self.type().tensor(), lower, upper, training, generator);
 }
 
-Tensor hard_shrink_cpu(const Tensor & self, const double lambda) {
+Tensor hard_shrink_cpu(const Tensor & self, Scalar lambda) {
   auto scalarType = self.type().scalarType();
   if (scalarType != kDouble
       && scalarType != kFloat) {
@@ -67,7 +67,7 @@ Tensor hard_shrink_cpu(const Tensor & self, const double lambda) {
   return out_t;
 }
 
-Tensor hard_shrink_backward_cpu(const Tensor & grad, const Tensor & self, const double lambda) {
+Tensor hard_shrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambda) {
   auto lambda_t = at::zeros_like(self).fill_(lambda);
   auto zero_t = at::zeros_like(self);
   auto out_t = grad.clone();

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -1,5 +1,11 @@
 #include "ATen/ATen.h"
 #include "ATen/NativeFunctions.h"
+#include "ATen/Dispatch.h"
+#include "ATen/CPUApplyUtils.h"
+
+// #ifdef _OPENMP
+// #include <omp.h>
+// #endif
 
 namespace at { namespace native {
 
@@ -28,6 +34,59 @@ Tensor rrelu(const Tensor & self, Scalar lower, Scalar upper, bool training, Gen
 
 Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Generator* generator) {
   return at::rrelu_with_noise_(self, self.type().tensor(), lower, upper, training, generator);
+}
+
+Tensor hard_shrink_cpu(const Tensor & self, const double lambda) {
+  auto scalarType = self.type().scalarType();
+  if (scalarType != kDouble
+      && scalarType != kFloat) {
+        std::stringstream ss;
+        ss << "hardshrink only accepts types "
+          << "(Double, Float), "
+          << "tensor has invalid type = "
+          << scalarType;
+        throw std::runtime_error(ss.str());
+  }
+
+  auto lambda_t = at::zeros_like(self).fill_(lambda);
+  auto zero_t = at::zeros_like(self);
+  auto out_t = self.clone();
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "hard_shrink_cpu", [&] {
+    at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+        out_t,
+        lambda_t,
+        zero_t,
+        [](scalar_t& out_t_val,
+           const scalar_t& lambda_t_val,
+           const scalar_t& zero_t_val) {
+             if (out_t_val >= -lambda_t_val && out_t_val <= lambda_t_val) {
+               out_t_val = zero_t_val;
+             }
+    });
+  });
+  return out_t;
+}
+
+Tensor hard_shrink_backward_cpu(const Tensor & grad, const Tensor & self, const double lambda) {
+  auto lambda_t = at::zeros_like(self).fill_(lambda);
+  auto zero_t = at::zeros_like(self);
+  auto out_t = grad.clone();
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "hard_shrink_backward_cpu", [&] {
+    at::CPU_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
+        out_t,
+        lambda_t,
+        zero_t,
+        self,
+        [](scalar_t& out_t_val,
+           const scalar_t& lambda_t_val,
+           const scalar_t& zero_t_val,
+           const scalar_t& self_val) {
+             if (self_val >= -lambda_t_val && self_val <= lambda_t_val) {
+               out_t_val = zero_t_val;
+             }
+    });
+  });
+  return out_t;
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -40,7 +40,7 @@ void hard_shrink_backward_cuda_kernel(at::Tensor& out_t, const at::Tensor& lambd
   });
 }
 
-Tensor hard_shrink_cuda(const Tensor & self, const double lambda) {
+Tensor hard_shrink_cuda(const Tensor & self, Scalar lambda) {
   auto scalarType = self.type().scalarType();
   if (scalarType != kDouble
       && scalarType != kFloat) {
@@ -62,7 +62,7 @@ Tensor hard_shrink_cuda(const Tensor & self, const double lambda) {
   return out_t;
 }
 
-Tensor hard_shrink_backward_cuda(const Tensor & grad, const Tensor & self, const double lambda) {
+Tensor hard_shrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambda) {
   auto lambda_t = at::zeros_like(self).fill_(lambda);
   auto zero_t = at::zeros_like(self);
   auto out_t = grad.clone();

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -1,0 +1,76 @@
+#include "ATen/NativeFunctions.h"
+#include "ATen/Dispatch.h"
+
+#include "ATen/cuda/CUDAApplyUtils.cuh"
+#include "ATen/cuda/CUDATensorMethods.cuh"
+#include "ATen/cuda/CUDATypeConversion.cuh"
+
+
+namespace at { namespace native {
+
+template <typename scalar_t>
+void hard_shrink_cuda_kernel(at::Tensor& out_t, const at::Tensor& lambda_t, const at::Tensor& zero_t) {
+  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+      out_t,
+      lambda_t,
+      zero_t,
+      [] __device__ (scalar_t& out_t_val,
+         const scalar_t& lambda_t_val,
+         const scalar_t& zero_t_val) {
+           if (out_t_val >= -lambda_t_val && out_t_val <= lambda_t_val) {
+             out_t_val = zero_t_val;
+           }
+  });
+}
+
+template <typename scalar_t>
+void hard_shrink_backward_cuda_kernel(at::Tensor& out_t, const at::Tensor& lambda_t, const at::Tensor& zero_t, const at::Tensor& self) {
+  at::cuda::CUDA_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
+      out_t,
+      lambda_t,
+      zero_t,
+      self,
+      [] __device__ (scalar_t& out_t_val,
+         const scalar_t& lambda_t_val,
+         const scalar_t& zero_t_val,
+         const scalar_t& self_val) {
+           if (self_val >= -lambda_t_val && self_val <= lambda_t_val) {
+             out_t_val = zero_t_val;
+           }
+  });
+}
+
+Tensor hard_shrink_cuda(const Tensor & self, const double lambda) {
+  auto scalarType = self.type().scalarType();
+  if (scalarType != kDouble
+      && scalarType != kFloat) {
+        std::stringstream ss;
+        ss << "hardshrink only accepts types "
+          << "(Double, Float), "
+          << "tensor has invalid type = "
+          << scalarType;
+        throw std::runtime_error(ss.str());
+  }
+
+  auto lambda_t = at::zeros_like(self).fill_(lambda);
+  auto zero_t = at::zeros_like(self);
+  auto out_t = self.clone();
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "hard_shrink_cuda", [&] {
+    using cuda_scalar_t = cuda::type<scalar_t>;
+    hard_shrink_cuda_kernel<cuda_scalar_t>(out_t, lambda_t, zero_t);
+  });
+  return out_t;
+}
+
+Tensor hard_shrink_backward_cuda(const Tensor & grad, const Tensor & self, const double lambda) {
+  auto lambda_t = at::zeros_like(self).fill_(lambda);
+  auto zero_t = at::zeros_like(self);
+  auto out_t = grad.clone();
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "hard_shrink_backward_cuda", [&] {
+    using cuda_scalar_t = cuda::type<scalar_t>;
+    hard_shrink_backward_cuda_kernel<cuda_scalar_t>(out_t, lambda_t, zero_t, self);
+  });
+  return out_t;
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -845,12 +845,12 @@
 
 - func: relu_(Tensor self) -> Tensor
 
-- func: hard_shrink(Tensor self, double lambda=0.5) -> Tensor
+- func: hard_shrink(Tensor self, Scalar lambda=0.5) -> Tensor
   dispatch:
     CPU: hard_shrink_cpu
     CUDA: hard_shrink_cuda
 
-- func: hard_shrink_backward(Tensor grad_out, Tensor self, double lambda=0.5) -> Tensor
+- func: hard_shrink_backward(Tensor grad_out, Tensor self, Scalar lambda=0.5) -> Tensor
   dispatch:
     CPU: hard_shrink_backward_cpu
     CUDA: hard_shrink_backward_cuda

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -545,7 +545,7 @@
   variants: function
 
 # gesv handles broadcasting of arbitrary batch dims while _gesv_helper does not.
-- func: _gesv_helper(Tensor self, Tensor A) -> (Tensor, Tensor) 
+- func: _gesv_helper(Tensor self, Tensor A) -> (Tensor, Tensor)
   dispatch:
     CPU: _gesv_helper_cpu
     CUDA: _gesv_helper_cuda
@@ -844,6 +844,16 @@
 - func: relu(Tensor self) -> Tensor
 
 - func: relu_(Tensor self) -> Tensor
+
+- func: hard_shrink(Tensor self, double lambda=0.5) -> Tensor
+  dispatch:
+    CPU: hard_shrink_cpu
+    CUDA: hard_shrink_cuda
+
+- func: hard_shrink_backward(Tensor grad_out, Tensor self, double lambda=0.5) -> Tensor
+  dispatch:
+    CPU: hard_shrink_backward_cpu
+    CUDA: hard_shrink_backward_cuda
 
 - func: rsqrt(Tensor self) -> Tensor
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2511,6 +2511,7 @@ method_tests = [
     ('clamp', (), (0, 1), 'scalar'),
     ('clamp', (), (None, 0.5), 'min_scalar'),
     ('clamp', (), (0.5, None), 'max_scalar'),
+    ('hard_shrink', (S, S, S), (0.3,), 'lambda=0.3'),
     ('sqrt', torch.rand(S, S, S) + 5e-4, NO_ARGS),
     ('sqrt', uniform_scalar(5e-4, requires_grad=True), NO_ARGS, 'scalar'),
     ('sin', (S, S, S), NO_ARGS),

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -273,6 +273,7 @@ tests = [
     ('chunk', medium_2d, lambda t: [4, -2], 'neg_dim'),
     ('clamp', medium_2d_scaled, lambda t: [-1, 5], None, signed_types),
     ('clamp', medium_2d_scaled, lambda t: [1, 5], None, unsigned_types),
+    ('hard_shrink', medium_2d, lambda t: [0.3], 'lambda=0.3', float_types_no_half, True),
     ('clone', medium_2d, lambda t: [],),
     ('contiguous', medium_2d, lambda t: [],),
     ('cross', new_t(M, 3, M), lambda t: [new_t(M, 3, M)(t)],),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -18,8 +18,6 @@ from functools import reduce
 from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3
 
-import time
-
 if TEST_NUMPY:
     import numpy as np
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5541,29 +5541,17 @@ class TestTorch(TestCase):
         self.assertGreater(res.abs()[0], 0)
 
     def test_hardshrink(self):
-        float_original = torch.tensor([1, 0.5, 0.3, 0.6]).view(2, 2)
+        data_original = torch.tensor([1, 0.5, 0.3, 0.6]).view(2, 2)
         float_types = ['torch.DoubleTensor', 'torch.FloatTensor']
         for t in float_types:
-            data = float_original.type(t)
-            print(data.hard_shrink(0.3))
+            data = data_original.type(t)
             self.assertEqual(torch.tensor([1, 0.5, 0, 0.6]).view(2, 2), data.hard_shrink(0.3))
+            # test lambda (0.5)
+            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hard_shrink(0.5))
             # test default lambda (0.5)
-            print(data.hard_shrink())
             self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hard_shrink())
             # test non-contiguous case
-            print(data.hard_shrink(0.1))
             self.assertEqual(torch.tensor([1, 0.3, 0.5, 0.6]).view(2, 2), data.t().hard_shrink(0.1))
-
-        # performance test
-        large_original = torch.zeros(1000, 1000, 1000).fill_(0.3)
-        start = time.time()
-        f = torch.nn.Hardshrink(0.3)
-        large_out = f(large_original)
-        print("orig run time = %0.5f\n" % (time.time() - start))
-
-        start = time.time()
-        large_out = large_original.hard_shrink(0.3)
-        print("new run time = %0.5f\n" % (time.time() - start))
 
     def test_unbiased(self):
         tensor = torch.randn(100)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -752,6 +752,13 @@
 - name: glu_forward(Tensor self, int64_t dim)
   self: glu_backward(grad, self, dim)
 
+- name: hard_shrink(Tensor self, double lambda)
+  self: hard_shrink_backward(grad, self, lambda)
+
+- name: hard_shrink_backward(Tensor grad_out, Tensor self, double lambda)
+  grad_out: hard_shrink_backward(grad, self, lambda)
+  self: zeros_like(grad)
+
 - name: hardshrink_forward(Tensor self, Scalar lambd)
   self: hardshrink_backward(grad, self, lambd)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -752,10 +752,10 @@
 - name: glu_forward(Tensor self, int64_t dim)
   self: glu_backward(grad, self, dim)
 
-- name: hard_shrink(Tensor self, double lambda)
+- name: hard_shrink(Tensor self, Scalar lambda)
   self: hard_shrink_backward(grad, self, lambda)
 
-- name: hard_shrink_backward(Tensor grad_out, Tensor self, double lambda)
+- name: hard_shrink_backward(Tensor grad_out, Tensor self, Scalar lambda)
   grad_out: hard_shrink_backward(grad, self, lambda)
   self: zeros_like(grad)
 


### PR DESCRIPTION
Summary:
1. fix #4154, implemented hard_shrink in ATen (CPU + CUDA)
2. performance test results:

```python
large_data = torch.zeros(1000, 1000, 1000).fill_(0.3).requires_grad_()
def origfn(data):
  f = torch.nn.Hardshrink(0.3)
  large_out = f(data)
%timeit origfn(large_data) 
```
=> 1 loop, best of 3: 3.99 s per loop

```python
large_data = torch.zeros(1000, 1000, 1000).fill_(0.3).requires_grad_()
def newfn(data):
    large_out = data.hard_shrink(0.3)
%timeit newfn(large_data)
```
=> 1 loop, best of 3: 4.04 s per loop

```python
large_data = torch.zeros(1000, 1000, 1000).fill_(0.3).requires_grad_()
def origfn_backward(data):
    f = torch.nn.Hardshrink(0.3)
    large_out = f(data)
    large_out.sum().backward()
%timeit origfn_backward(large_data)
```
=> 1 loop, best of 3: 10 s per loop

```python
large_data = torch.zeros(1000, 1000, 1000).fill_(0.3).requires_grad_()
def newfn_backward(data):
    large_out = data.hard_shrink(0.3)
    large_out.sum().backward()
%timeit newfn_backward(large_data)
```
=> 1 loop, best of 3: 7.78 s per loop

TODO:
1. fix bug in using default value of Scalar lambda=0.5, currently 0.5 doesn't get picked up as default value. Failing in testcase of test_torch.py