### PR TITLE
Add retry logic to sccache download for Windows build

### DIFF
--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -80,7 +80,7 @@ set CUDNN_ROOT_DIR=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0
 
 set TORCH_CUDA_ARCH_LIST=5.2
 
-sccache --stop-server || set ERRORLEVEL=0
+sccache --stop-server
 sccache --start-server
 sccache --zero-stats
 set CC=sccache cl

--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -44,7 +44,16 @@ set MAGMA_HOME=%cd%\\magma
 
 :: Install sccache
 mkdir %CD%\\tmp_bin
-if "%REBUILD%"=="" ( aws s3 cp s3://ossci-windows/sccache.exe %CD%\\tmp_bin\\sccache.exe --quiet )
+if "%REBUILD%"=="" (
+  :check_sccache
+  %CD%\\tmp_bin\\sccache.exe --show-stats
+  if %ERRORLEVEL% NEQ 0 (
+    taskkill /im sccache.exe /f /t || set ERRORLEVEL=0
+    del %CD%\\tmp_bin\\sccache.exe
+    aws s3 cp s3://ossci-windows/sccache.exe %CD%\\tmp_bin\\sccache.exe
+    goto :check_sccache
+  )
+)
 
 :: Install Miniconda3
 if "%REBUILD%"=="" (

--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -46,8 +46,7 @@ set MAGMA_HOME=%cd%\\magma
 mkdir %CD%\\tmp_bin
 if "%REBUILD%"=="" (
   :check_sccache
-  %CD%\\tmp_bin\\sccache.exe --show-stats
-  if %ERRORLEVEL% NEQ 0 (
+  %CD%\\tmp_bin\\sccache.exe --show-stats || (
     taskkill /im sccache.exe /f /t || set ERRORLEVEL=0
     del %CD%\\tmp_bin\\sccache.exe
     aws s3 cp s3://ossci-windows/sccache.exe %CD%\\tmp_bin\\sccache.exe


### PR DESCRIPTION
This PR aims to fix the `Could not find compiler set in environment variable CC: sccache cl` error in the following builds, by adding retry logic to sccache binary download:

https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-build/6984/consoleFull
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-build/6985/consoleFull
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-build/6986/consoleFull