### PR TITLE
Implement __reduce__ for torch.dtype

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1767,7 +1767,7 @@ class TestTorch(TestCase):
         all_dtypes = torch.testing.get_all_dtypes()
         for dtype in all_dtypes:
             copied_dtype = copy.deepcopy(dtype)
-            self.assertEqual(id(dtype), id(copied_dtype))
+            self.assertIs(dtype, copied_dtype)
 
     def test_device(self):
         cpu = torch.device('cpu')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1763,6 +1763,12 @@ class TestTorch(TestCase):
         if torch.cuda.is_available():
             self._test_dtypes(self, all_dtypes, torch.strided, torch.device('cuda:0'))
 
+    def test_copy_dtypes(self):
+        all_dtypes = torch.testing.get_all_dtypes()
+        for dtype in all_dtypes:
+            copied_dtype = copy.deepcopy(dtype)
+            self.assertEqual(id(dtype), id(copied_dtype))
+
     def test_device(self):
         cpu = torch.device('cpu')
         self.assertEqual('cpu', str(cpu))

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -46,9 +46,7 @@ static struct PyGetSetDef THPDtype_properties[] = {
 };
 
 static PyMethodDef THPDtype_methods[] = {
-  {"__reduce__", (PyCFunction)THPDtype_reduce, METH_NOARGS,
-   "define behavior in pickling"
-  },
+  {"__reduce__", (PyCFunction)THPDtype_reduce, METH_NOARGS, nullptr},
   {NULL}  /* Sentinel */
 };
 

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -29,11 +29,27 @@ PyObject *THPDtype_is_floating_point(THPDtype *self)
   }
 }
 
+PyObject *THPDtype_reduce(THPDtype *self)
+{
+  /*
+  * For singletons, a string is returned. The string should be interpreted
+  * as the name of a global variable.
+  */
+  return THPUtils_packString(self->name);
+}
+
 typedef PyObject *(*getter)(PyObject *, void *);
 
 static struct PyGetSetDef THPDtype_properties[] = {
   {"is_floating_point", (getter)THPDtype_is_floating_point, nullptr, nullptr, nullptr},
   {nullptr}
+};
+
+static PyMethodDef THPDtype_methods[] = {
+  {"__reduce__", (PyCFunction)THPDtype_reduce, METH_NOARGS,
+   "define behavior in pickling"
+  },
+  {NULL}  /* Sentinel */
 };
 
 PyObject *THPDtype_repr(THPDtype *self)
@@ -69,7 +85,7 @@ PyTypeObject THPDtypeType = {
   0,                                     /* tp_weaklistoffset */
   0,                                     /* tp_iter */
   0,                                     /* tp_iternext */
-  0,                                     /* tp_methods */
+  THPDtype_methods,                      /* tp_methods */
   0,                                     /* tp_members */
   THPDtype_properties,                   /* tp_getset */
   0,                                     /* tp_base */


### PR DESCRIPTION
This PR addresses #7481. 
torch.dtype is a singleton class without __new__ method. 
According to [python doc](https://docs.python.org/3/library/pickle.html#object.__reduce__), returning a string in __reduce__  is the simplest way to implement the behavior. Thanks @apaszke !

> If a string is returned, the string should be interpreted as the name of a global variable. It should be the object’s local name relative to its module; the pickle module searches the module namespace to determine the object’s module. This behaviour is typically useful for singletons.

cc: @fmassa @gchanan 