### PR TITLE
Make MockHiveReader loop over and support max_examples

### DIFF
--- a/caffe2/python/db_file_reader.py
+++ b/caffe2/python/db_file_reader.py
@@ -31,6 +31,8 @@ class DBFileReader(Reader):
             Default to '<db_name>_<default_name_suffix>'.
         batch_size: int.
             How many examples are read for each time the read_net is run.
+        loop_over: bool.
+            If True given, will go through examples in random order endlessly.
     """
     def __init__(
         self,
@@ -38,6 +40,7 @@ class DBFileReader(Reader):
         db_type,
         name=None,
         batch_size=100,
+        loop_over=False,
     ):
         assert db_path is not None, "db_path can't be None."
         assert db_type in C.registered_dbs(), \
@@ -54,6 +57,7 @@ class DBFileReader(Reader):
             default_name_suffix=self.default_name_suffix,
         )
         self.batch_size = batch_size
+        self.loop_over = loop_over
 
         # Before self._init_reader_schema(...),
         # self.db_path and self.db_type are required to be set.
@@ -118,10 +122,13 @@ class DBFileReader(Reader):
         else:
             self._init_field_blobs_as_empty(init_net)
             self._feed_field_blobs_from_db_file(init_net)
-            self.ds_reader = self.ds.reader(
+            self.ds_reader = self.ds.random_reader(
                 init_net,
                 batch_size=self.batch_size,
+                loop_over=self.loop_over,
             )
+            self.ds_reader.sort_and_shuffle(init_net)
+            self.ds_reader.computeoffset(init_net)
 
     def read(self, read_net):
         assert self.ds_reader, 'setup_ex must be called first'


### PR DESCRIPTION
Replace DatasetReader with RandomDatasetReader.

So that Mock Hive Reader can simulate a large data input using a small sample file as source.

