### PR TITLE
make BatchSampler subclass of Sampler, and expose docs

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -12,4 +12,5 @@ torch.utils.data
 .. autoclass:: torch.utils.data.SubsetRandomSampler
 .. autoclass:: torch.utils.data.WeightedRandomSampler
 .. autoclass:: torch.utils.data.distributed.DistributedSampler
+.. autoclass:: torch.utils.data.distributed.BatchSampler
 .. autofunction:: torch.utils.data.dataset.random_split

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -101,7 +101,7 @@ class WeightedRandomSampler(Sampler):
         return self.num_samples
 
 
-class BatchSampler(object):
+class BatchSampler(Sampler):
     r"""Wraps another sampler to yield a mini-batch of indices.
 
     Args:


### PR DESCRIPTION
In the docstring of DataLoader, we have `batch_sampler (Sampler, optional)` at [dataloader.py#L415](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L415), which indicate that `BatchSampler` is a subclass of `Sampler`. But currently it is not.

This PR makes BatchSampler a subclass of Sampler, and expose its docs.