### PR TITLE
[PyTorch] [gradcheck] change backward() to grad()

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -7,7 +7,7 @@ from itertools import product
 import torch
 import torch.cuda
 from common import TestCase, to_gpu, freeze_rng_state, is_iterable
-from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors, contiguous_detach
+from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
 import torch.backends.cudnn
 
 # tarfile module tries to obtain a file object name in python 3.3
@@ -783,7 +783,6 @@ class NNTestCase(TestCase):
             return self._forward(module, input).detach()
 
         res = tuple()
-        input = contiguous_detach(input)
         if jacobian_input:
             res += get_numerical_jacobian(fw, input, eps=1e-6),
         if jacobian_parameters:

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -7,7 +7,7 @@ from itertools import product
 import torch
 import torch.cuda
 from common import TestCase, to_gpu, freeze_rng_state, is_iterable
-from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors, contiguous
+from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors, contiguous_detach
 import torch.backends.cudnn
 
 # tarfile module tries to obtain a file object name in python 3.3
@@ -783,9 +783,9 @@ class NNTestCase(TestCase):
             return self._forward(module, input).detach()
 
         res = tuple()
-        input = contiguous(input)
+        input = contiguous_detach(input)
         if jacobian_input:
-            res += get_numerical_jacobian(fw, input, input, eps=1e-6),
+            res += get_numerical_jacobian(fw, input, eps=1e-6),
         if jacobian_parameters:
             param, _ = self._get_parameters(module)
             res += torch.cat([get_numerical_jacobian(fw, input, p, eps=1e-6) for p in param], 0),

--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -813,8 +813,8 @@ class NNTestCase(TestCase):
         input_t = iter_tensors(input)
         numerical_t = iter_tensors(numerical_d_x)
         for x, d_x in zip(input_t, numerical_t):
-            x = x.view(-1)
-            d_x = d_x.view(-1)
+            x = x.view(-1).data
+            d_x = d_x.view(-1).data
             for i in range(x.nelement()):
                 original = x[i].item()
                 x[i] = original + eps

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -880,7 +880,6 @@ class TestDistributions(TestCase):
         self.assertEqual(Multinomial(total_count, p).sample((6,)).size(), (6, 2, 3))
         set_rng_seed(0)
         self._gradcheck_log_prob(lambda p: Multinomial(total_count, p), [p])
-        p.grad.zero_()
         self._gradcheck_log_prob(lambda p: Multinomial(total_count, None, p.log()), [p])
 
         # sample check for extreme value of probs

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -8,7 +8,7 @@ import torch
 import torch.legacy.nn as nn
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, TEST_CUDA, PRECISION
-from torch.autograd.gradcheck import get_numerical_jacobian, contiguous
+from torch.autograd.gradcheck import get_numerical_jacobian, contiguous_detach
 from common import to_gpu, freeze_rng_state, run_tests
 from torch.autograd import Variable
 
@@ -661,10 +661,10 @@ class TestNN(NNTestCase):
             return out
 
         res = tuple()
-        input = contiguous(input)
+        input = contiguous_detach(input)
         if jacobian_input:
             input = require_grad(input)
-            res += get_numerical_jacobian(fw, input, input, eps=1e-6),
+            res += get_numerical_jacobian(fw, input, eps=1e-6),
         if jacobian_parameters:
             params, _ = self._get_parameters(module)
             jacobians = []

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -8,7 +8,7 @@ import torch
 import torch.legacy.nn as nn
 from common_nn import NNTestCase, ModuleTest, CriterionTest, iter_tensors, \
     module_tests, criterion_tests, TEST_CUDA, PRECISION
-from torch.autograd.gradcheck import get_numerical_jacobian, contiguous_detach
+from torch.autograd.gradcheck import get_numerical_jacobian
 from common import to_gpu, freeze_rng_state, run_tests
 from torch.autograd import Variable
 
@@ -661,7 +661,6 @@ class TestNN(NNTestCase):
             return out
 
         res = tuple()
-        input = contiguous_detach(input)
         if jacobian_input:
             input = require_grad(input)
             res += get_numerical_jacobian(fw, input, eps=1e-6),

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -852,7 +852,7 @@ std::tuple<Tensor, Tensor, Tensor> prelu_double_backward(
       return std::tuple<Tensor, Tensor, Tensor>(
                 ggO,
                 ggW_maybe_squeeze.expand_as(gO) * gO * nonpositive_mask,
-                (ggI * gO * nonpositive_mask).sum()
+                (ggI * gO * nonpositive_mask).sum().expand_as(weight)
           );
   } else {
       // Expand ggW to match size of ggI; a simple expand doesn't work because

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -245,7 +245,7 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         def randn_like(x):
             y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), requires_grad=True)
             if gen_non_contig_grad_outputs:
-                y = torch.testing.make_non_contiguous(y)
+                y = torch.testing.make_non_contiguous(y).requires_grad_()
             return y
         outputs = _as_tuple(func(*inputs))
         grad_outputs_gen = (randn_like(x) for x in outputs)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -42,14 +42,6 @@ def iter_tensors(x, only_requiring_grad=False):
                 yield result
 
 
-def contiguous_detach(input):
-    if isinstance(input, torch.Tensor):
-        return input.contiguous().detach().requires_grad_(input.requires_grad)
-    elif isinstance(input, Iterable):
-        return type(input)(contiguous_detach(e) for e in input)
-    return input
-
-
 # `input` is input to `fn`
 # `target` is the Tensors wrt whom Jacobians are calculated (default=`input`)
 #

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -243,10 +243,10 @@ def gradgradcheck(func, inputs, grad_outputs=None, eps=1e-6, atol=1e-5, rtol=1e-
         # If grad_outputs is not specified, create random Tensors of the same
         # shape, type, and device as the outputs
         def randn_like(x):
-            y = torch.testing.randn_like(x if x.is_floating_point() else x.double(), requires_grad=True)
+            y = torch.testing.randn_like(x if x.is_floating_point() else x.double())
             if gen_non_contig_grad_outputs:
-                y = torch.testing.make_non_contiguous(y).requires_grad_()
-            return y
+                y = torch.testing.make_non_contiguous(y)
+            return y.requires_grad_()
         outputs = _as_tuple(func(*inputs))
         grad_outputs_gen = (randn_like(x) for x in outputs)
         grad_outputs = list(grad_outputs_gen) if not isinstance(inputs, tuple) else tuple(grad_outputs_gen)


### PR DESCRIPTION
Change backward calls to grad to avoid memory leak from #7343 
Replace unnecessary create_graph=True with retain_graph=True


The memory leak is blocking #7270 .

