### PR TITLE
serialization for torch.device

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -36,13 +36,6 @@ with warnings.catch_warnings(record=True) as warns:
                 break
 
 
-class NetwithDevice(torch.nn.Module):
-    def __init__(self):
-        super(NetwithDevice, self).__init__()
-        self.param = torch.nn.Parameter(torch.Tensor(3, 5))
-        self.device = torch.device('cpu:0')
-
-
 class FilelikeMock(object):
     def __init__(self, data, has_fileno=True, has_readinto=False):
         if has_readinto:
@@ -6258,15 +6251,12 @@ class TestTorch(TestCase):
             xh2 = torch.load(f)
             self.assertEqual(xh.float(), xh2.float())
 
-    def test_save_net_with_device(self):
-        net = NetwithDevice()
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(net, f)
-            f.seek(0)
-            net2 = torch.load(f)
-            self.assertEqual(type(net), type(net2))
-            self.assertEqual(net.state_dict(), net2.state_dict())
-            self.assertEqual(net.device, net2.device)
+    def test_serialize_device(self):
+        device_str = ['cpu', 'cpu:0', 'cuda', 'cuda:0']
+        device_obj = [torch.device(d) for d in device_str]
+        for device in device_obj:
+            device_copied = copy.deepcopy(device)
+            self.assertEqual(device, device_copied)
 
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_half_tensor_cuda(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -36,6 +36,13 @@ with warnings.catch_warnings(record=True) as warns:
                 break
 
 
+class NetwithDevice(torch.nn.Module):
+    def __init__(self):
+        super(NetwithDevice, self).__init__()
+        self.param = torch.nn.Parameter(torch.Tensor(3, 5))
+        self.device = torch.device('cpu:0')
+
+
 class FilelikeMock(object):
     def __init__(self, data, has_fileno=True, has_readinto=False):
         if has_readinto:
@@ -6250,6 +6257,16 @@ class TestTorch(TestCase):
             f.seek(0)
             xh2 = torch.load(f)
             self.assertEqual(xh.float(), xh2.float())
+
+    def test_save_net_with_device(self):
+        net = NetwithDevice()
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(net, f)
+            f.seek(0)
+            net2 = torch.load(f)
+            self.assertEqual(type(net), type(net2))
+            self.assertEqual(net.state_dict(), net2.state_dict())
+            self.assertEqual(net.device, net2.device)
 
     @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
     def test_half_tensor_cuda(self):

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -139,20 +139,20 @@ PyObject *THPDevice_rc(PyObject *a, PyObject *b, int op) {
 
 PyObject *THPDevice_reduce(THPDevice *self)
 {
-  PyObject *ret = PyTuple_New(2);
-  if (!ret) return NULL;
+  auto ret = THPObjectPtr{PyTuple_New(2)};
+  if (!ret) throw python_error();
 
   py::object torch_module = py::module::import("torch");
   py::object torch_device = torch_module.attr("device");
-  PyTuple_SET_ITEM(ret, 0, torch_device.release().ptr());
+  PyTuple_SET_ITEM(ret.get(), 0, torch_device.release().ptr());
 
   if (self->device.is_default) {
-    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(s)", deviceTypeString(self->device.type)));
+    PyTuple_SET_ITEM(ret.get(), 1, Py_BuildValue("(s)", deviceTypeString(self->device.type)));
   } else {
-    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(si)", deviceTypeString(self->device.type), self->device.index));
+    PyTuple_SET_ITEM(ret.get(), 1, Py_BuildValue("(si)", deviceTypeString(self->device.type), self->device.index));
   }
 
-  return ret;
+  return ret.release();
 }
 
 typedef PyObject *(*getter)(PyObject *, void *);

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -139,6 +139,7 @@ PyObject *THPDevice_rc(PyObject *a, PyObject *b, int op) {
 
 PyObject *THPDevice_reduce(THPDevice *self)
 {
+  HANDLE_TH_ERRORS
   auto ret = THPObjectPtr{PyTuple_New(2)};
   if (!ret) throw python_error();
 
@@ -146,13 +147,17 @@ PyObject *THPDevice_reduce(THPDevice *self)
   py::object torch_device = torch_module.attr("device");
   PyTuple_SET_ITEM(ret.get(), 0, torch_device.release().ptr());
 
+  THPObjectPtr args;
   if (self->device.is_default) {
-    PyTuple_SET_ITEM(ret.get(), 1, Py_BuildValue("(s)", deviceTypeString(self->device.type)));
+    args = THPObjectPtr{Py_BuildValue("(s)", deviceTypeString(self->device.type))};
   } else {
-    PyTuple_SET_ITEM(ret.get(), 1, Py_BuildValue("(si)", deviceTypeString(self->device.type), self->device.index));
+    args = THPObjectPtr{Py_BuildValue("(si)", deviceTypeString(self->device.type), self->device.index)};
   }
+  if (!args) throw python_error();
+  PyTuple_SET_ITEM(ret.get(), 1, args.release());
 
   return ret.release();
+  END_HANDLE_TH_ERRORS
 }
 
 typedef PyObject *(*getter)(PyObject *, void *);

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -139,26 +139,13 @@ PyObject *THPDevice_rc(PyObject *a, PyObject *b, int op) {
 
 PyObject *THPDevice_reduce(THPDevice *self)
 {
-  PyObject *ret, *mod, *obj;
-  ret = PyTuple_New(2);
+  PyObject *ret = PyTuple_New(2);
+  if (!ret) return NULL;
 
-  if (ret == NULL)
-    return NULL;
+  py::object torch_module = py::module::import("torch");
+  py::object torch_device = torch_module.attr("device");
+  PyTuple_SET_ITEM(ret, 0, torch_device.release().ptr());
 
-  mod = PyImport_ImportModule("torch");
-  if (mod == NULL) {
-    Py_DECREF(ret);
-    return NULL;
-  }
-
-  obj = PyObject_GetAttrString(mod, "device");
-  Py_DECREF(mod);
-  if (obj == NULL) {
-    Py_DECREF(ret);
-    return NULL;
-  }
-
-  PyTuple_SET_ITEM(ret, 0, obj);
   if (self->device.is_default) {
     PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(s)", deviceTypeString(self->device.type)));
   } else {


### PR DESCRIPTION
This PR addresses #7545 .
Implement __reduce__ for `torch.device` to return a new `torch.device` object with the same device type & index. 
Note this `torch.device` is slightly different in the sense that `copy.deepcopy()` returns a new object instead of the same one in `torch.dtype`. 
Also added a test in test_torch to show how module object can be serialized. Nit: it doesn't work if NetwithDevice class is put inside test_save_net_with_device() function. This is due to `net` being an instance of `<class '__main__.TestTorch.test_save_net_with_device.<locals>.NetwithDevice'>` and `TestTorch` is not serializable(no __getstate__ implemented). I can't think of a better way to change the class scope than putting it outside. Let me know if you have a better idea.