### PR TITLE
Export getCudnnHandle

### DIFF
--- a/aten/src/ATen/cudnn/Handles.h
+++ b/aten/src/ATen/cudnn/Handles.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "cudnn-wrapper.h"
+#include "ATen/cuda/ATenCUDAGeneral.h"
 
 namespace at { namespace native {
 
-cudnnHandle_t getCudnnHandle();
+AT_CUDA_API cudnnHandle_t getCudnnHandle();
 
 }} // namespace


### PR DESCRIPTION
Easy access to the CuDNN handle would be super useful for writing extensions. This makes `getCudnnHandle` an `AT_CUDA_API`.

I need access to a `cudnnHandle_t` to build a pytorch wrapper for `cudnnCTCLoss`.

Cheers