### PR TITLE
Call grad_mode.py context managers as decorators

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1796,21 +1796,6 @@ class TestAutograd(TestCase):
             y = x * 2
         self.assertTrue(y.requires_grad)
 
-        @torch.set_grad_enabled(False)
-        def doubler_without(x):
-            return x * 2
-
-        y = doubler_without(x)
-        self.assertFalse(y.requires_grad)
-
-        @torch.set_grad_enabled(True)
-        def doubler_with(x):
-            return x * 2
-
-        torch.set_grad_enabled(False)
-        y = doubler_with(x)
-        self.assertTrue(y.requires_grad)
-
     def test_reentrant(self):
         y_data = torch.randn(2, 2)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1806,7 +1806,7 @@ class TestAutograd(TestCase):
         @torch.set_grad_enabled(True)
         def doubler_with(x):
             return x * 2
-        
+
         torch.set_grad_enabled(False)
         y = doubler_with(x)
         self.assertTrue(y.requires_grad)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -687,9 +687,11 @@ class TestAutograd(TestCase):
         y = Variable(torch.ones(5, 5) * 4)
         with torch.no_grad():
             w = x + y
+
         @torch.no_grad()
         def adder(x, y):
             return x + y
+
         z = adder(x, y)
 
         self.assertFalse(w.requires_grad)
@@ -1793,14 +1795,18 @@ class TestAutograd(TestCase):
             torch.set_grad_enabled(True)
             y = x * 2
         self.assertTrue(y.requires_grad)
+
         @torch.set_grad_enabled(False)
         def doubler_without(x):
             return x * 2
+
         y = doubler_without(x)
         self.assertFalse(y.requires_grad)
+
         @torch.set_grad_enabled(True)
         def doubler_with(x):
             return x * 2
+
         y = doubler_with(x)
         self.assertTrue(y.requires_grad)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1806,7 +1806,8 @@ class TestAutograd(TestCase):
         @torch.set_grad_enabled(True)
         def doubler_with(x):
             return x * 2
-
+        
+        torch.set_grad_enabled(False)
         y = doubler_with(x)
         self.assertTrue(y.requires_grad)
 

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -98,7 +98,7 @@ class set_grad_enabled(object):
     r"""Context-manager that sets gradient calculation to on or off.
 
     ``set_grad_enabled`` will enable or disable grads based on its argument :attr:`mode`.
-    It can be used as a context-manager, as a function, or as a decorator.
+    It can be used as a context-manager or as a function.
 
     Arguments:
         mode (bool): Flag whether to enable grad (``True``), or disable
@@ -135,10 +135,3 @@ class set_grad_enabled(object):
     def __exit__(self, *args):
         torch.set_grad_enabled(self.prev)
         return False
-
-    def __call__(self, func):
-        @functools.wraps(func)
-        def decorate_set_grad_enabled(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return decorate_set_grad_enabled

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -143,4 +143,3 @@ class set_grad_enabled(object):
             torch._C.set_grad_enabled(self.prev)
             return result
         return decorate_set_grad_enabled
-

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,4 +1,5 @@
 import torch
+import functools
 
 
 class no_grad(object):
@@ -39,11 +40,10 @@ class no_grad(object):
         return False
 
     def __call__(self, func):
+        @functools.wraps(func)
         def decorate_no_grad(*args, **kwargs):
-            torch._C.set_grad_enabled(False)
-            result = func(*args, **kwargs)
-            torch._C.set_grad_enabled(self.prev)
-            return result
+            with self:
+                return func(*args, **kwargs)
         return decorate_no_grad
 
 
@@ -87,11 +87,10 @@ class enable_grad(object):
         return False
 
     def __call__(self, func):
+        @functools.wraps(func)
         def decorate_enable_grad(*args, **kwargs):
-            torch._C.set_grad_enabled(True)
-            result = func(*args, **kwargs)
-            torch._C.set_grad_enabled(self.prev)
-            return result
+            with self:
+                return func(*args, **kwargs)
         return decorate_enable_grad
 
 
@@ -138,8 +137,8 @@ class set_grad_enabled(object):
         return False
 
     def __call__(self, func):
+        @functools.wraps(func)
         def decorate_set_grad_enabled(*args, **kwargs):
-            result = func(*args, **kwargs)
-            torch._C.set_grad_enabled(self.prev)
-            return result
+            with self:
+                return func(*args, **kwargs)
         return decorate_set_grad_enabled


### PR DESCRIPTION
Extends the context manager classes `torch.no_grad`, `torch.enable_grad`, and `torch.set_grad_mode` to function as decorators, so that users can wrap functions that will never require a call to `.backward()` downstream.  I've modified the docs to reflect this change, and I've also added tests for the new functionality in each mode's respective test in `test_autograd.py`.

I also didn't find a unit test specifically for `torch.enable_grad`.  Assuming that's intended, unless my ctrl+f missed it.