### PR TITLE
Add indexing operations to vec256

### DIFF
--- a/aten/src/ATen/cpu/vec256/functional.h
+++ b/aten/src/ATen/cpu/vec256/functional.h
@@ -11,14 +11,14 @@ inline scalar_t vec_reduce_all(
     int64_t size) {
   using Vec = vec256::Vec256<scalar_t>;
   scalar_t acc_arr[Vec::size];
-  acc_vec.store(acc_arr);
+  acc_vec.storeu(acc_arr);
   for (int64_t i = 1; i < size; i++) {
     scalar_t acc_arr_next[Vec::size];
     acc_arr_next[0] = acc_arr[i];
     Vec acc_vec_next = Vec::loadu(acc_arr_next);
     acc_vec = vec_fun(acc_vec, acc_vec_next);
   }
-  acc_vec.store(acc_arr);
+  acc_vec.storeu(acc_arr);
   return acc_arr[0];
 }
 
@@ -105,11 +105,11 @@ inline void map(
   int64_t d = 0;
   for (; d < size - (size % Vec::size); d += Vec::size) {
     Vec output_vec = vec_fun(Vec::loadu(input_data + d));
-    output_vec.store(output_data + d);
+    output_vec.storeu(output_data + d);
   }
   if (size - d > 0) {
     Vec output_vec = vec_fun(Vec::loadu(input_data + d, size - d));
-    output_vec.store(output_data + d, size - d);
+    output_vec.storeu(output_data + d, size - d);
   }
 }
 
@@ -126,13 +126,13 @@ inline void map2(
     Vec data_vec = Vec::loadu(input_data + d);
     Vec data_vec2 = Vec::loadu(input_data2 + d);
     Vec output_vec = vec_fun(data_vec, data_vec2);
-    output_vec.store(output_data + d);
+    output_vec.storeu(output_data + d);
   }
   if (size - d > 0) {
     Vec data_vec = Vec::loadu(input_data + d, size - d);
     Vec data_vec2 = Vec::loadu(input_data2 + d, size - d);
     Vec output_vec = vec_fun(data_vec, data_vec2);
-    output_vec.store(output_data + d, size - d);
+    output_vec.storeu(output_data + d, size - d);
   }
 }
 

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -64,8 +64,14 @@ struct Vec256 {
     std::memcpy(vec.values, ptr, count * sizeof(T));
     return vec;
   }
-  void store(void* ptr, int count = size) const {
+  void storeu(void* ptr, int count = size) const {
     std::memcpy(ptr, values, count * sizeof(T));
+  }
+  T operator [](int idx) const {
+    return values[idx];
+  }
+  void set_value(int64_t idx, T value) {
+    values[idx] = value;
   }
   Vec256<T> map(T (*f)(T)) const {
     Vec256<T> ret;
@@ -140,7 +146,7 @@ struct Vec256 {
 template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] + b.values[i];
+    c.set_value(i, a[i] + b[i]);
   }
   return c;
 }
@@ -148,7 +154,7 @@ template <class T> Vec256<T> operator+(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] - b.values[i];
+    c.set_value(i, a[i] - b[i]);
   }
   return c;
 }
@@ -156,7 +162,7 @@ template <class T> Vec256<T> operator-(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] * b.values[i];
+    c.set_value(i, a[i] * b[i]);
   }
   return c;
 }
@@ -164,7 +170,7 @@ template <class T> Vec256<T> operator*(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = a.values[i] / b.values[i];
+    c.set_value(i, a[i] / b[i]);
   }
   return c;
 }
@@ -172,7 +178,7 @@ template <class T> Vec256<T> operator/(const Vec256<T> &a, const Vec256<T> &b) {
 template <class T> Vec256<T> max(const Vec256<T> &a, const Vec256<T> &b) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size; i++) {
-    c.values[i] = std::max(a.values[i], b.values[i]);
+    c.set_value(i, std::max(a[i], b[i]));
   }
   return c;
 }

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -52,7 +52,7 @@ public:
         count * sizeof(double));
     return _mm256_load_pd(tmp_values);
   }
-  void store(void* ptr, int count = size) const {
+  void storeu(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_pd(reinterpret_cast<double*>(ptr), values);
     } else {
@@ -62,12 +62,23 @@ public:
     }
   }
   Vec256<double> map(double (*f)(double)) const {
-    __at_align32__ double tmp[4];
-    store(tmp);
-    for (int64_t i = 0; i < 4; i++) {
+    __at_align32__ double tmp[size];
+    storeu(tmp);
+    for (int64_t i = 0; i < size; i++) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
+  }
+  double operator [](int idx) const {
+    __at_align32__ double tmp_values[size];
+    storeu(tmp_values);
+    return tmp_values[idx];
+  }
+  void set_value(int64_t idx, double value) {
+    __at_align32__ double tmp_values[size];
+    storeu(tmp_values);
+    tmp_values[idx] = value;
+    loadu(tmp_values);
   }
   Vec256<double> abs() const {
     auto mask = _mm256_set1_pd(-0.f);

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -57,7 +57,7 @@ public:
         tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
     return _mm256_loadu_ps(tmp_values);
   }
-  void store(void* ptr, int64_t count = size) const {
+  void storeu(void* ptr, int64_t count = size) const {
     if (count == size) {
       _mm256_storeu_ps(reinterpret_cast<float*>(ptr), values);
     } else {
@@ -67,12 +67,23 @@ public:
     }
   }
   Vec256<float> map(float (*f)(float)) const {
-    __at_align32__ float tmp[8];
-    store(tmp);
-    for (int64_t i = 0; i < 8; i++) {
+    __at_align32__ float tmp[size];
+    storeu(tmp);
+    for (int64_t i = 0; i < size; i++) {
       tmp[i] = f(tmp[i]);
     }
     return loadu(tmp);
+  }
+  float operator [](int idx) const {
+    __at_align32__ float tmp_values[size];
+    storeu(tmp_values);
+    return tmp_values[idx];
+  }
+  void set_value(int64_t idx, float value) {
+    __at_align32__ float tmp_values[size];
+    storeu(tmp_values);
+    tmp_values[idx] = value;
+    loadu(tmp_values);
   }
   Vec256<float> abs() const {
     auto mask = _mm256_set1_ps(-0.f);

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -27,15 +27,15 @@ struct Vec256<int64_t> : public Vec256i {
   template <int64_t mask>
   static Vec256<int64_t> blend(Vec256<int64_t> a, Vec256<int64_t> b) {
     __at_align32__ int64_t tmp_values[size];
-    a.store(tmp_values);
+    a.storeu(tmp_values);
     if (mask & 0x01)
-      tmp_values[0] = _mm256_extract_epi16(b.values, 0);
+      tmp_values[0] = _mm256_extract_epi64(b.values, 0);
     if (mask & 0x02)
-      tmp_values[1] = _mm256_extract_epi16(b.values, 1);
+      tmp_values[1] = _mm256_extract_epi64(b.values, 1);
     if (mask & 0x04)
-      tmp_values[2] = _mm256_extract_epi16(b.values, 2);
+      tmp_values[2] = _mm256_extract_epi64(b.values, 2);
     if (mask & 0x08)
-      tmp_values[3] = _mm256_extract_epi16(b.values, 3);
+      tmp_values[3] = _mm256_extract_epi64(b.values, 3);
     return loadu(tmp_values);
   }
   static Vec256<int64_t>
@@ -60,7 +60,7 @@ struct Vec256<int64_t> : public Vec256i {
     std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
     return loadu(tmp_values);
   }
-  void store(void* ptr, int count = size) const {
+  void storeu(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else {
@@ -74,6 +74,15 @@ struct Vec256<int64_t> : public Vec256i {
     auto is_larger = _mm256_cmpgt_epi64(zero, values);
     auto inverse = _mm256_xor_si256(values, is_larger);
     return _mm256_sub_epi64(inverse, is_larger);
+  }
+  int64_t operator [](int idx) const {
+    return _mm256_extract_epi64(values, idx);
+  }
+  void set_value(int64_t idx, int64_t value) {
+    __at_align32__ int64_t tmp_values[size];
+    storeu(tmp_values);
+    tmp_values[idx] = value;
+    loadu(tmp_values);
   }
 };
 
@@ -117,7 +126,7 @@ struct Vec256<int32_t> : public Vec256i {
     std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
     return loadu(tmp_values);
   }
-  void store(void* ptr, int count = size) const {
+  void storeu(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else {
@@ -128,6 +137,15 @@ struct Vec256<int32_t> : public Vec256i {
   }
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
+  }
+  int32_t operator [](int idx) const {
+    return _mm256_extract_epi32(values, idx);
+  }
+  void set_value(int64_t idx, int32_t value) {
+    __at_align32__ int32_t tmp_values[size];
+    storeu(tmp_values);
+    tmp_values[idx] = value;
+    loadu(tmp_values);
   }
 };
 
@@ -140,7 +158,7 @@ struct Vec256<int16_t> : public Vec256i {
   template <int64_t mask>
   static Vec256<int16_t> blend(Vec256<int16_t> a, Vec256<int16_t> b) {
     __at_align32__ int16_t tmp_values[size];
-    a.store(tmp_values);
+    a.storeu(tmp_values);
     if (mask & 0x01)
       tmp_values[0] = _mm256_extract_epi16(b.values, 0);
     if (mask & 0x02)
@@ -221,7 +239,7 @@ struct Vec256<int16_t> : public Vec256i {
     std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
     return loadu(tmp_values);
   }
-  void store(void* ptr, int count = size) const {
+  void storeu(void* ptr, int count = size) const {
     if (count == size) {
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else {
@@ -232,6 +250,15 @@ struct Vec256<int16_t> : public Vec256i {
   }
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
+  }
+  int16_t operator [](int idx) const {
+    return _mm256_extract_epi16(values, idx);
+  }
+  void set_value(int64_t idx, int16_t value) {
+    __at_align32__ int16_t tmp_values[size];
+    storeu(tmp_values);
+    tmp_values[idx] = value;
+    loadu(tmp_values);
   }
 };
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -114,7 +114,7 @@ struct Reduction {
       }
     }
     for (int j = 0; j != 4; j++) {
-      acc[j].store(&out[j * Vec::size]);
+      acc[j].storeu(&out[j * Vec::size]);
     }
   }
 


### PR DESCRIPTION
Adds indexing operations (operator [] and set_value), renames store to storeu (to indicated unaligned storage in line with the underlying intrinsics), fixes a small bug.