### PR TITLE
_LRSchedulers getstate include optimizer info

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -23,7 +23,7 @@ class _LRScheduler(object):
         self.last_epoch = last_epoch
 
     def __getstate__(self):
-        return self.state_dict()
+        return self.__dict__
 
     def __setstate__(self, state):
         self.load_state_dict(state)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -22,12 +22,6 @@ class _LRScheduler(object):
         self.step(last_epoch + 1)
         self.last_epoch = last_epoch
 
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.load_state_dict(state)
-
     def state_dict(self):
         """Returns the state of the scheduler as a :class:`dict`.
 


### PR DESCRIPTION
This PR fixes #7255.
`__getstate__` now have different behavior with state_dict() since it should include optimizer information. 