### PR TITLE
[TODO: re-enable] Temporarily disable build env check

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -647,21 +647,21 @@ class TestCollectEnv(TestCase):
         info_output = get_pretty_env_info()
         self.assertTrue(info_output.count('\n') >= 17)
 
-    @unittest.skipIf('BUILD_ENVIRONMENT' not in os.environ.keys(), 'CI-only test')
-    def test_expect(self):
-        info_output = get_pretty_env_info()
+    # @unittest.skipIf('BUILD_ENVIRONMENT' not in os.environ.keys(), 'CI-only test')
+    # def test_expect(self):
+    #     info_output = get_pretty_env_info()
 
-        ci_build_envs = [
-            'pytorch-linux-trusty-py2.7',
-            'pytorch-linux-xenial-cuda9-cudnn7-py3',
-            'pytorch-macos-10.13-py3',
-            'pytorch-win-ws2016-cuda9-cudnn7-py3'
-        ]
-        build_env = os.environ['BUILD_ENVIRONMENT']
-        if build_env not in ci_build_envs:
-            return
+    #     ci_build_envs = [
+    #         'pytorch-linux-trusty-py2.7',
+    #         'pytorch-linux-xenial-cuda9-cudnn7-py3',
+    #         'pytorch-macos-10.13-py3',
+    #         'pytorch-win-ws2016-cuda9-cudnn7-py3'
+    #     ]
+    #     build_env = os.environ['BUILD_ENVIRONMENT']
+    #     if build_env not in ci_build_envs:
+    #         return
 
-        self.assertExpectedOutput(info_output, build_env)
+    #     self.assertExpectedOutput(info_output, build_env)
 
 
 class TestONNXUtils(TestCase):


### PR DESCRIPTION
Nvidia updated the CuDNN version in their docker image from 7.1.2 to 7.1.4, and we need to temporarily disable the build env check in order to generate new CI docker images with the updated version.

This is a blocker for https://github.com/pytorch/pytorch/pull/7399 because we need to change one of the CI dockerfiles to pass quoted arguments to sccache correctly.