### PR TITLE
Throw error on 0-length tensor slicing

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -314,6 +314,10 @@ Tensor slice(const Tensor& self, int64_t dim, int64_t start, int64_t end, int64_
   }
   auto storage_offset = self.storage_offset() + start * strides[dim];
   auto len = end - start;
+  if (len == 0) {
+    // TODO: currently we don't have support for 0-sized dims, return size 0 tensor for now
+    return self.type().tensor();
+  }
   sizes[dim] = (len + step - 1) / step;  // round-up
   strides[dim] *= step;
   return self.as_strided(sizes, strides, storage_offset);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4683,6 +4683,11 @@ class TestTorch(TestCase):
         self.assertEqual(reference[None, 2, None, None], reference.unsqueeze(0)[:, 2].unsqueeze(0).unsqueeze(0))
         self.assertEqual(reference[None, 2:5, None, None], reference.unsqueeze(0)[:, 2:5].unsqueeze(2).unsqueeze(2))
 
+        # indexing 0-length slice
+        self.assertEqual(torch.tensor([]), reference[slice(0)])
+        self.assertEqual(torch.tensor([]), reference[slice(0), 2])
+        self.assertEqual(torch.tensor([]), reference[2, slice(0)])
+
         # indexing with step
         reference = consec((10, 10, 10))
         self.assertEqual(reference[1:5:2], torch.stack([reference[1], reference[3]], 0))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4687,6 +4687,7 @@ class TestTorch(TestCase):
         self.assertEqual(torch.tensor([]), reference[slice(0)])
         self.assertEqual(torch.tensor([]), reference[slice(0), 2])
         self.assertEqual(torch.tensor([]), reference[2, slice(0)])
+        self.assertEqual(torch.tensor([]), reference[2, 1:1, 2])
 
         # indexing with step
         reference = consec((10, 10, 10))

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -75,10 +75,6 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
     // TODO: implement negative step
     throw ValueError("negative step not yet supported");
   }
-  if (start >= stop) {
-    // TODO: currently we don't have support for 0-sized dims, return size 0 tensor for now
-    return self.type().tensor();
-  }
   if (!ensure_view && start == 0 && stop == length && step == 1) {
     return self;
   }
@@ -146,8 +142,9 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (PySlice_Check(obj)) {
       result = applySlice(result, dim, obj);
       if (result.numel() == 0) {
-        // sliced a dim to size 0, which isn't fully supported yet
-        // just return size 0 tensor for now
+        // TODO: currently we don't have support for 0-sized dims, so slicing a dim
+        // to size 0 will return a size 0 tensor. for now, just shortcircuit slicing
+        // and return that size 0 tensor.
         return result;
       }
       dim++;

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -145,6 +145,11 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       result = applySelect(result, dim, THPUtils_unpackLong(obj));
     } else if (PySlice_Check(obj)) {
       result = applySlice(result, dim, obj);
+      if (result.numel() == 0) {
+        // sliced a dim to size 0, which isn't fully supported yet
+        // just return size 0 tensor for now
+        return result;
+      }
       dim++;
     } else if (obj == Py_Ellipsis) {
       dim += self.dim() - specified_dims;

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -76,8 +76,8 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
     throw ValueError("negative step not yet supported");
   }
   if (start >= stop) {
-    // TODO: implement 0-length slicing
-    throw ValueError("slices of length 0 not yet supported");
+    // TODO: currently we don't have support for 0-sized dims, return size 0 tensor for now
+    return self.type().tensor();
   }
   if (!ensure_view && start == 0 && stop == length && step == 1) {
     return self;

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -75,6 +75,10 @@ static Variable applySlice(const Variable& self, int64_t dim, PyObject* slice, b
     // TODO: implement negative step
     throw ValueError("negative step not yet supported");
   }
+  if (start >= stop) {
+    // TODO: implement 0-length slicing
+    throw ValueError("slices of length 0 not yet supported");
+  }
   if (!ensure_view && start == 0 && stop == length && step == 1) {
     return self;
   }


### PR DESCRIPTION
Fixes #7559. Throw an error because we don't support dims of size 0 yet.