### PR TITLE
Add @generated annotation

### DIFF
--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include "ATen/Scalar.h"

--- a/aten/src/ATen/templates/GeneratorDerived.h
+++ b/aten/src/ATen/templates/GeneratorDerived.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include <$header>

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include "ATen/ATen.h"

--- a/aten/src/ATen/templates/RegisterCUDA.cpp
+++ b/aten/src/ATen/templates/RegisterCUDA.cpp
@@ -1,3 +1,4 @@
+// @generated
 #include <ATen/Type.h>
 #include <ATen/Context.h>
 #include <ATen/detail/VariableHooksInterface.h>

--- a/aten/src/ATen/templates/RegisterCUDA.h
+++ b/aten/src/ATen/templates/RegisterCUDA.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 namespace at {

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -1,3 +1,4 @@
+// @generated
 #include "ATen/${Storage}.h"
 #include "ATen/Half.h"
 #include "ATen/Allocator.h"

--- a/aten/src/ATen/templates/StorageDerived.h
+++ b/aten/src/ATen/templates/StorageDerived.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 $th_headers

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include "ATen/Generator.h"

--- a/aten/src/ATen/templates/TensorDense.cpp
+++ b/aten/src/ATen/templates/TensorDense.cpp
@@ -1,3 +1,4 @@
+// @generated
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
 IntList ${Tensor}::strides() const {

--- a/aten/src/ATen/templates/TensorDerived.cpp
+++ b/aten/src/ATen/templates/TensorDerived.cpp
@@ -1,3 +1,4 @@
+// @generated
 // required for old g++ to compile PRId64 macros, see
 // https://github.com/pytorch/pytorch/issues/3571
 // for context

--- a/aten/src/ATen/templates/TensorDerived.h
+++ b/aten/src/ATen/templates/TensorDerived.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 $th_headers

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include "ATen/Tensor.h"

--- a/aten/src/ATen/templates/TensorSparse.cpp
+++ b/aten/src/ATen/templates/TensorSparse.cpp
@@ -1,3 +1,4 @@
+// @generated
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 IntList ${Tensor}::strides() const {
  AT_ERROR("Sparse tensors do not have strides.");

--- a/aten/src/ATen/templates/Type.cpp
+++ b/aten/src/ATen/templates/Type.cpp
@@ -1,3 +1,4 @@
+// @generated
 #include "ATen/Type.h"
 #include "ATen/Tensor.h"
 #include "ATen/Storage.h"

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 
 #include "ATen/Allocator.h"

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -1,3 +1,4 @@
+// @generated
 // required for old g++ to compile PRId64 macros, see
 // https://github.com/pytorch/pytorch/issues/3571
 // for context

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -1,3 +1,4 @@
+// @generated
 #pragma once
 #include "ATen/Type.h"
 #include "ATen/Context.h"


### PR DESCRIPTION
Avoids these files in Phabricator and other tools respecting this annotation.

Diff generated with `for f in aten/src/ATen/templates/*; do gsed -i '1i \/\/ @generated' $f; done`