### PR TITLE
[script] Add support for torch.zeros, torch.ones, etc.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2790,6 +2790,29 @@ class TestScript(TestCase):
 
         self.checkScript(t2, (torch.zeros(1, 1, 2)))
 
+    def test_zeros(self):
+        class M(torch.jit.ScriptModule):
+            __constants__ = ['d']
+
+            def __init__(self):
+                self.d = torch.device('cpu')
+
+            @torch.jit.script_method
+            def create(self):
+                return torch.zeros([1, 1, 2], dtype=torch.float, device=self.d, layout=torch.strided)
+
+        r = M().create()
+        self.assertEqual(r.dtype, torch.float)
+        self.assertEqual(torch.zeros([1, 1, 2], dtype=torch.float), r)
+
+    def test_rand(self):
+
+        def test_rand():
+            a = torch.rand([3, 4])
+            return a + 1.0 - a
+
+        self.checkScript(test_rand, ())
+
 
 # Smoke tests for export methods
 class TestPytorchExportModes(unittest.TestCase):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2805,6 +2805,7 @@ class TestScript(TestCase):
         self.assertEqual(r.dtype, torch.float)
         self.assertEqual(torch.zeros([1, 1, 2], dtype=torch.float), r)
 
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
     def test_rand(self):
 
         def test_rand():

--- a/tools/jit/templates/aten_dispatch.cpp
+++ b/tools/jit/templates/aten_dispatch.cpp
@@ -3,6 +3,8 @@
 #include "torch/csrc/jit/interned_strings.h"
 #include "torch/csrc/jit/tensor_conversions.h"
 #include "torch/csrc/utils/functional.h"
+#include "torch/csrc/variable_tensor_functions.h"
+#include "torch/csrc/utils/device.h"
 
 #include <unordered_map>
 #include <cstring>
@@ -85,6 +87,26 @@ std::array<bool, N> as_bool_array(const std::vector<int64_t>& vec) {
   JIT_ASSERT(vec.size() == N);
   std::copy(vec.begin(), vec.end(), res.begin());
   return res;
+}
+
+static at::Backend resolveBackend(int64_t device_type, int64_t is_strided) {
+  switch(static_cast<torch::DeviceType>(device_type)) {
+    case torch::DeviceType::CPU:
+      if(is_strided)
+        return at::kCPU;
+      else
+        return at::kSparseCPU;
+    case torch::DeviceType::CUDA:
+      if(is_strided)
+        return at::kCUDA;
+      else
+        return at::kSparseCUDA;
+  }
+  throw std::runtime_error("unknown backend");
+}
+
+static at::Type& resolveType(int64_t device_type, int64_t is_strided, at::ScalarType type) {
+  return torch::getType(resolveBackend(device_type, is_strided), type);
 }
 
 using operator_constructor = std::function<TensorOp(jit::Node*)>;

--- a/tools/jit/templates/aten_schema.cpp
+++ b/tools/jit/templates/aten_schema.cpp
@@ -1,5 +1,6 @@
 #include "torch/csrc/jit/aten_schema.h"
 #include "torch/csrc/jit/tensor_conversions.h"
+#include "torch/csrc/utils/device.h"
 
 namespace torch { namespace jit {
 

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -118,7 +118,6 @@ _(attr, Subgraph) \
 _(attr, axes) \
 _(attr, axis) \
 _(attr, broadcast) \
-_(attr, device) \
 _(attr, direction) \
 _(attr, ends) \
 _(attr, inplace) \

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -51,7 +51,6 @@ std::unordered_set<NodeKind> simple_mappable = {
   aten::mul,
   aten::ne,
   aten::neg,
-  aten::ones,
   aten::pow,
   aten::reciprocal,
   aten::remainder,
@@ -65,7 +64,6 @@ std::unordered_set<NodeKind> simple_mappable = {
   aten::tan,
   aten::tanh,
   aten::trunc,
-  aten::zeros,
   aten::_sigmoid_backward,
   aten::_tanh_backward,
 };

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -501,7 +501,7 @@ class OrderedBufferDict(OrderedDictWrapper):
 # in addition, tuples and lists of these base types are also considered constants
 # If you edit this list, then you also need to edit the handlers in
 # ConstantValue in jit/script/init.cpp
-_constant_types = (bool, float, int, types.FunctionType)
+_constant_types = (bool, float, int, types.FunctionType, torch.device, torch.layout, torch.dtype)
 
 
 def _get_valid_constant(v):


### PR DESCRIPTION
* modifies gen_jit_dispatch to creating bindings for functions that do
  not take tensor arguments, but do have an initial type argument
* adds tensor attributes to these functions for device, layout, and
  dtype specification
* extends the list of valid compiler constants to include device, layout,
  and dtype.
* allows functions with Generators, but only using the default generator

Known limitations:
* when using `torch.float`, we convert it to a scalar tensor and make
  no checks that it is actually used only in a dtype specification.
  This is similar to how we handle Python numbers, creating some situations
  where the script is more permissive. Fixing this requires much more
  significant changes to the IR, so is lower priority for now.
* devices specified using string literals e.g. 'cuda:1' do not work,
  since we do not support string literals in general.

