### PR TITLE
[build] Add back cpp_build tests for Mac

### DIFF
--- a/.jenkins/pytorch/macos-build-test.sh
+++ b/.jenkins/pytorch/macos-build-test.sh
@@ -35,11 +35,10 @@ rm -rf $CPP_BUILD
 mkdir -p $CPP_BUILD
 WERROR=1 VERBOSE=1 tools/cpp_build/build_all.sh "$CPP_BUILD"
 
-# TODO; Enable tests on Mac as soon as possible
-#python tools/download_mnist.py --quiet -d test/cpp/api/mnist
-#
-# # Unfortunately it seems like the test can't load from miniconda3
-# # without these paths being set
-# export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
-# export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
-# "$CPP_BUILD"/libtorch/bin/test_api
+python tools/download_mnist.py --quiet -d test/cpp/api/mnist
+
+# Unfortunately it seems like the test can't load from miniconda3
+# without these paths being set
+export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
+"$CPP_BUILD"/libtorch/bin/test_api

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -6,6 +6,7 @@ else()
   cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
   include(CMakeDependentOption)
   option(USE_CUDA "Use CUDA" ON)
+  option(TORCH_BUILD_TEST "Build torch test binaries" ON)
 
   # Legacy options, which we will eventually remove
   cmake_dependent_option(
@@ -17,13 +18,6 @@ else()
 endif()
 if (NOT USE_CUDA)
   set(NO_CUDA ON)
-endif()
-
-# TODO: Enable tests on Mac as soon as possible
-if (APPLE)
-  set(TORCH_BUILD_TEST OFF)
-else()
-  set(TORCH_BUILD_TEST ON)
 endif()
 
 cmake_policy(VERSION 3.0)


### PR DESCRIPTION
These were temporarily removed so we could land the PyTorch with libcaffe2 PR.

Can't test locally right now, since I have slow WiFi, but would run
```
git clean -fdx
./.jenkins/pytorch/macos-build-test.sh
```
Instead I'm going to see if Mac tests pass here.

cc @goldsborough 
