### PR TITLE
Remove templatization of PyTypeObject in THP copy storage methods.

### DIFF
--- a/torch/csrc/copy_utils.h
+++ b/torch/csrc/copy_utils.h
@@ -56,6 +56,7 @@ inline PyObject * THPStorageCopyMethod(const THPCopyList& v, PyObject *self, PyO
 
 template <typename StorageDst, typename StorageSrc>
 void THPInsertStorageCopyFunction(
+  PyTypeObject *srcType,
   THPCopyList& copyList,
   void (*copyFunc)(LIBRARY_STATE_TYPE StorageDst* x, StorageSrc* z),
   bool non_blocking=false)
@@ -77,6 +78,5 @@ void THPInsertStorageCopyFunction(
     }
   };
 
-  PyTypeObject* srcType = THPTypeInfo<StorageSrc>::pyType();
   copyList.push_back({ srcType, wrapper, non_blocking, false });
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -327,39 +327,39 @@ void THPStorage_(initCopyMethods)()
 #ifndef THD_GENERIC_FILE
   auto& h = THStorage_(copy_functions);
   // copy from CPU types
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyByte));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyChar));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyShort));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyInt));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyLong));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyHalf));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyFloat));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyDouble));
+  THPInsertStorageCopyFunction(&THPByteStorageType, h, &THStorage_(copyByte));
+  THPInsertStorageCopyFunction(&THPCharStorageType, h, &THStorage_(copyChar));
+  THPInsertStorageCopyFunction(&THPShortStorageType, h, &THStorage_(copyShort));
+  THPInsertStorageCopyFunction(&THPIntStorageType, h, &THStorage_(copyInt));
+  THPInsertStorageCopyFunction(&THPLongStorageType, h, &THStorage_(copyLong));
+  THPInsertStorageCopyFunction(&THPHalfStorageType, h, &THStorage_(copyHalf));
+  THPInsertStorageCopyFunction(&THPFloatStorageType, h, &THStorage_(copyFloat));
+  THPInsertStorageCopyFunction(&THPDoubleStorageType, h, &THStorage_(copyDouble));
 #ifdef THC_GENERIC_FILE
   // copy from GPU types
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaFloat));
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaDouble));
+  THPInsertStorageCopyFunction(&THCPByteStorageType, h, &THStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THCPCharStorageType, h, &THStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THCPShortStorageType, h, &THStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THCPIntStorageType, h, &THStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THCPLongStorageType, h, &THStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THCPFloatStorageType, h, &THStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THCPDoubleStorageType, h, &THStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
-  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaHalf));
+  THPInsertStorageCopyFunction(&THCPHalfStorageType, h, &THStorage_(copyCudaHalf));
 #endif
   // add CPU <- GPU copies to base type
   #define THCpuStorage_(name) TH_CONCAT_4(TH, Real, Storage_, name)
   extern THPCopyList THCpuStorage_(copy_functions);
   auto& b = THCpuStorage_(copy_functions);
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaFloat));
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaDouble));
+  THPInsertStorageCopyFunction(&THCPByteStorageType, b, &THCpuStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THCPCharStorageType, b, &THCpuStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THCPShortStorageType, b, &THCpuStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THCPIntStorageType, b, &THCpuStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THCPLongStorageType, b, &THCpuStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THCPFloatStorageType, b, &THCpuStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THCPDoubleStorageType, b, &THCpuStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
-  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaHalf));
+  THPInsertStorageCopyFunction(&THCPHalfStorageType, b, &THCpuStorage_(copyCudaHalf));
 #endif
   #undef THCpuStorage_
 #endif

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -327,22 +327,22 @@ void THPStorage_(initCopyMethods)()
 #ifndef THD_GENERIC_FILE
   auto& h = THStorage_(copy_functions);
   // copy from CPU types
-  THPInsertStorageCopyFunction(&THPByteStorageType, h, &THStorage_(copyByte));
-  THPInsertStorageCopyFunction(&THPCharStorageType, h, &THStorage_(copyChar));
-  THPInsertStorageCopyFunction(&THPShortStorageType, h, &THStorage_(copyShort));
-  THPInsertStorageCopyFunction(&THPIntStorageType, h, &THStorage_(copyInt));
-  THPInsertStorageCopyFunction(&THPLongStorageType, h, &THStorage_(copyLong));
-  THPInsertStorageCopyFunction(&THPHalfStorageType, h, &THStorage_(copyHalf));
-  THPInsertStorageCopyFunction(&THPFloatStorageType, h, &THStorage_(copyFloat));
-  THPInsertStorageCopyFunction(&THPDoubleStorageType, h, &THStorage_(copyDouble));
+  THPInsertStorageCopyFunction(&THPByteStorageType,    h, &THStorage_(copyByte));
+  THPInsertStorageCopyFunction(&THPCharStorageType,    h, &THStorage_(copyChar));
+  THPInsertStorageCopyFunction(&THPShortStorageType,   h, &THStorage_(copyShort));
+  THPInsertStorageCopyFunction(&THPIntStorageType,     h, &THStorage_(copyInt));
+  THPInsertStorageCopyFunction(&THPLongStorageType,    h, &THStorage_(copyLong));
+  THPInsertStorageCopyFunction(&THPHalfStorageType,    h, &THStorage_(copyHalf));
+  THPInsertStorageCopyFunction(&THPFloatStorageType,   h, &THStorage_(copyFloat));
+  THPInsertStorageCopyFunction(&THPDoubleStorageType,  h, &THStorage_(copyDouble));
 #ifdef THC_GENERIC_FILE
   // copy from GPU types
-  THPInsertStorageCopyFunction(&THCPByteStorageType, h, &THStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(&THCPCharStorageType, h, &THStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(&THCPShortStorageType, h, &THStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(&THCPIntStorageType, h, &THStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(&THCPLongStorageType, h, &THStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(&THCPFloatStorageType, h, &THStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THCPByteStorageType,   h, &THStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THCPCharStorageType,   h, &THStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THCPShortStorageType,  h, &THStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THCPIntStorageType,    h, &THStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THCPLongStorageType,   h, &THStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THCPFloatStorageType,  h, &THStorage_(copyCudaFloat));
   THPInsertStorageCopyFunction(&THCPDoubleStorageType, h, &THStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
   THPInsertStorageCopyFunction(&THCPHalfStorageType, h, &THStorage_(copyCudaHalf));
@@ -351,15 +351,15 @@ void THPStorage_(initCopyMethods)()
   #define THCpuStorage_(name) TH_CONCAT_4(TH, Real, Storage_, name)
   extern THPCopyList THCpuStorage_(copy_functions);
   auto& b = THCpuStorage_(copy_functions);
-  THPInsertStorageCopyFunction(&THCPByteStorageType, b, &THCpuStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(&THCPCharStorageType, b, &THCpuStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(&THCPShortStorageType, b, &THCpuStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(&THCPIntStorageType, b, &THCpuStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(&THCPLongStorageType, b, &THCpuStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(&THCPFloatStorageType, b, &THCpuStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THCPByteStorageType,   b, &THCpuStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THCPCharStorageType,   b, &THCpuStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THCPShortStorageType,  b, &THCpuStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THCPIntStorageType,    b, &THCpuStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THCPLongStorageType,   b, &THCpuStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THCPFloatStorageType,  b, &THCpuStorage_(copyCudaFloat));
   THPInsertStorageCopyFunction(&THCPDoubleStorageType, b, &THCpuStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
-  THPInsertStorageCopyFunction(&THCPHalfStorageType, b, &THCpuStorage_(copyCudaHalf));
+  THPInsertStorageCopyFunction(&THCPHalfStorageType,   b, &THCpuStorage_(copyCudaHalf));
 #endif
   #undef THCpuStorage_
 #endif

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -327,39 +327,39 @@ void THPStorage_(initCopyMethods)()
 #ifndef THD_GENERIC_FILE
   auto& h = THStorage_(copy_functions);
   // copy from CPU types
-  THPInsertStorageCopyFunction(h, &THStorage_(copyByte));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyChar));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyShort));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyInt));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyLong));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyHalf));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyFloat));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyDouble));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyByte));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyChar));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyShort));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyInt));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyLong));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyHalf));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyFloat));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyDouble));
 #ifdef THC_GENERIC_FILE
   // copy from GPU types
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaFloat));
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaDouble));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
-  THPInsertStorageCopyFunction(h, &THStorage_(copyCudaHalf));
+  THPInsertStorageCopyFunction(&THPStorageType, h, &THStorage_(copyCudaHalf));
 #endif
   // add CPU <- GPU copies to base type
   #define THCpuStorage_(name) TH_CONCAT_4(TH, Real, Storage_, name)
   extern THPCopyList THCpuStorage_(copy_functions);
   auto& b = THCpuStorage_(copy_functions);
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaByte));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaChar));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaShort));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaInt));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaLong));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaFloat));
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaDouble));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaByte));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaChar));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaShort));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaInt));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaLong));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaFloat));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaDouble));
 #ifdef CUDA_HALF_TENSOR
-  THPInsertStorageCopyFunction(b, &THCpuStorage_(copyCudaHalf));
+  THPInsertStorageCopyFunction(&THPStorageType, b, &THCpuStorage_(copyCudaHalf));
 #endif
   #undef THCpuStorage_
 #endif


### PR DESCRIPTION
An in-progress refactoring of THStorage is collapsing the types of THStorages to not be ScalarType-specific.

The relevant PyTypeObject to use for the THPStorageType is currently templatized based on the current THStorage type; this doesn't work if the ScalarType is collapsed.  Instead, just pass it explicitly.

