### PR TITLE
[C++ API] Improve and use OrderedDict for parameters / modules

### DIFF
--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -1,5 +1,6 @@
 #include <catch.hpp>
 
+#include <torch/detail/ordered_dict.h>
 #include <torch/expanding_array.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/tensor.h>
@@ -11,6 +12,7 @@
 
 using namespace torch;
 using namespace torch::nn;
+using namespace torch::detail;
 
 using Catch::StartsWith;
 
@@ -151,5 +153,181 @@ TEST_CASE("make_unique") {
     REQUIRE(ptr[0] == 0);
     REQUIRE(ptr[1] == 0);
     REQUIRE(ptr[2] == 0);
+  }
+}
+
+TEST_CASE("ordered-dict") {
+  SECTION("is empty after default construction") {
+    OrderedDict<int> dict;
+    REQUIRE(dict.is_empty());
+    REQUIRE(dict.size() == 0);
+  }
+
+  SECTION("insert inserts elements when they are not yet present") {
+    OrderedDict<int> dict;
+    dict.insert("a", 1);
+    dict.insert("b", 2);
+    REQUIRE(dict.size() == 2);
+  }
+
+  SECTION("get returns values when present") {
+    OrderedDict<int> dict;
+    dict.insert("a", 1);
+    dict.insert("b", 2);
+    REQUIRE(dict.get("a") == 1);
+    REQUIRE(dict.get("b") == 2);
+  }
+
+  SECTION("get throws when passed keys that are not present") {
+    OrderedDict<int> dict;
+    dict.insert("a", 1);
+    dict.insert("b", 2);
+    REQUIRE_THROWS_WITH(dict.get("foo"), StartsWith("No such key: 'foo'"));
+    REQUIRE_THROWS_WITH(dict.get(""), StartsWith("No such key: ''"));
+  }
+
+  SECTION("can initialize from list") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict.size() == 2);
+    REQUIRE(dict.get("a") == 1);
+    REQUIRE(dict.get("b") == 2);
+  }
+
+  SECTION("insert throws when passed elements that are present") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE_THROWS_WITH(
+        dict.insert("a", 1), StartsWith("Key 'a' already present"));
+    REQUIRE_THROWS_WITH(
+        dict.insert("b", 1), StartsWith("Key 'b' already present"));
+  }
+
+  SECTION("front() returns the first item") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict.front().key == "a");
+    REQUIRE(dict.front().value == 1);
+  }
+
+  SECTION("back() returns the last item") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict.back().key == "b");
+    REQUIRE(dict.back().value == 2);
+  }
+
+  SECTION("find returns pointers to values when present") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict.find("a") != nullptr);
+    REQUIRE(*dict.find("a") == 1);
+    REQUIRE(dict.find("b") != nullptr);
+    REQUIRE(*dict.find("b") == 2);
+  }
+
+  SECTION("find returns null pointers when passed keys that are not present") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict.find("bar") == nullptr);
+    REQUIRE(dict.find("") == nullptr);
+  }
+
+  SECTION("operator[] returns values when passed keys that are present") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict["a"] == 1);
+    REQUIRE(dict["b"] == 2);
+  }
+
+  SECTION("operator[] returns items positionally when passed integers") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(dict[0].key == "a");
+    REQUIRE(dict[0].value == 1);
+    REQUIRE(dict[1].key == "b");
+    REQUIRE(dict[1].value == 2);
+  }
+
+  SECTION("operator[] throws when passed keys that are not present") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE_THROWS_WITH(dict.get("foo"), StartsWith("No such key: 'foo'"));
+    REQUIRE_THROWS_WITH(dict.get(""), StartsWith("No such key: ''"));
+  }
+
+  SECTION("update inserts all items from another OrderedDict") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> dict2 = {{"c", 3}};
+    dict2.update(dict);
+    REQUIRE(dict2.size() == 3);
+    REQUIRE(dict2.find("a") != nullptr);
+    REQUIRE(dict2.find("b") != nullptr);
+    REQUIRE(dict2.find("c") != nullptr);
+  }
+
+  SECTION("update also checks for duplicates") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> dict2 = {{"a", 1}};
+    REQUIRE_THROWS_WITH(
+        dict2.update(dict), StartsWith("Key 'a' already present"));
+  }
+
+  SECTION("Can iterate items") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    auto iterator = dict.begin();
+    REQUIRE(iterator != dict.end());
+    REQUIRE(iterator->key == "a");
+    REQUIRE(iterator->value == 1);
+    ++iterator;
+    REQUIRE(iterator != dict.end());
+    REQUIRE(iterator->key == "b");
+    REQUIRE(iterator->value == 2);
+    ++iterator;
+    REQUIRE(iterator == dict.end());
+  }
+
+  SECTION("clear makes the dict empty") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    REQUIRE(!dict.is_empty());
+    dict.clear();
+    REQUIRE(dict.is_empty());
+  }
+
+  SECTION("can copy construct") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> copy = dict;
+    REQUIRE(copy.size() == 2);
+    REQUIRE(*copy[0] == 1);
+    REQUIRE(*copy[1] == 2);
+  }
+
+  SECTION("can copy assign") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> copy = {{"c", 1}};
+    REQUIRE(copy.find("c") != nullptr);
+    copy = dict;
+    REQUIRE(copy.size() == 2);
+    REQUIRE(*copy[0] == 1);
+    REQUIRE(*copy[1] == 2);
+    REQUIRE(copy.find("c") == nullptr);
+  }
+
+  SECTION("can move construct") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> copy = std::move(dict);
+    REQUIRE(copy.size() == 2);
+    REQUIRE(*copy[0] == 1);
+    REQUIRE(*copy[1] == 2);
+  }
+
+  SECTION("can move assign") {
+    OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
+    OrderedDict<int> copy = {{"c", 1}};
+    REQUIRE(copy.find("c") != nullptr);
+    copy = std::move(dict);
+    REQUIRE(copy.size() == 2);
+    REQUIRE(*copy[0] == 1);
+    REQUIRE(*copy[1] == 2);
+    REQUIRE(copy.find("c") == nullptr);
+  }
+
+  SECTION("can insert with braces") {
+    OrderedDict<std::pair<int, int>> dict;
+    dict.insert("a", {1, 2});
+    REQUIRE(!dict.is_empty());
+    REQUIRE(dict["a"].first == 1);
+    REQUIRE(dict["a"].second == 2);
   }
 }

--- a/torch/csrc/api/include/torch/detail/ordered_dict.h
+++ b/torch/csrc/api/include/torch/detail/ordered_dict.h
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <ATen/Error.h>
+
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace torch {
+namespace detail {
+
+/// A simple ordered dictionary implementation, akin to Python's `OrderedDict`.
+template <typename T>
+class OrderedDict {
+ public:
+  struct Item {
+    Item(std::string key_, T value_)
+        : key(std::move(key_)), value(std::move(value_)) {}
+
+    T& operator*() {
+      return value;
+    }
+    const T& operator*() const {
+      return value;
+    }
+    T* operator->() {
+      return &value;
+    }
+    const T* operator->() const {
+      return &value;
+    }
+
+    const std::string key;
+    T value;
+  };
+
+  using Iterator = typename std::vector<Item>::iterator;
+  using ConstIterator = typename std::vector<Item>::const_iterator;
+
+  OrderedDict() = default;
+
+  // Copy we have to do ourselves, because items' keys are const, so we have to
+  // re-insert the items.
+  OrderedDict(const OrderedDict& other) : index_(other.index_) {
+    for (const auto& item : other.items_) {
+      items_.push_back(item);
+    }
+  }
+
+  OrderedDict& operator=(const OrderedDict& other) {
+    index_ = other.index_;
+    items_.clear();
+    for (const auto& item : other.items_) {
+      items_.push_back(item);
+    }
+    return *this;
+  }
+
+  // Move works by default, because you can move-construct vectors of const
+  // values..
+  OrderedDict(OrderedDict&& other) = default;
+  OrderedDict& operator=(OrderedDict&& other) = default;
+
+  ~OrderedDict() = default;
+
+  /*implicit */ OrderedDict(std::initializer_list<Item> initializer_list) {
+    items_.reserve(initializer_list.size());
+    for (auto& item : initializer_list) {
+      // Copy the key here and move it into the index.
+      items_.emplace_back(item.key, std::move(item.value));
+      index_.emplace(std::move(item.key), size() - 1);
+    }
+  }
+
+  Iterator begin() {
+    return items_.begin();
+  }
+
+  ConstIterator begin() const {
+    return items_.begin();
+  }
+
+  Iterator end() {
+    return items_.end();
+  }
+
+  ConstIterator end() const {
+    return items_.end();
+  }
+
+  Item& front() {
+    return items_.front();
+  }
+
+  const Item& front() const {
+    return items_.front();
+  }
+
+  Item& back() {
+    return items_.back();
+  }
+
+  const Item& back() const {
+    return items_.back();
+  }
+
+  Item& operator[](size_t index) {
+    return items_[index];
+  }
+
+  const Item& operator[](size_t index) const {
+    return items_[index];
+  }
+
+  T& operator[](const std::string& key) {
+    return get(key);
+  }
+
+  const T& operator[](const std::string& key) const {
+    return get(key);
+  }
+
+  template <typename Key, typename Value>
+  T& insert(Key&& key, Value&& value) {
+    AT_CHECK(index_.count(key) == 0, "Key '", key, "' already present");
+    // Copy `key` here and move it into the index.
+    items_.emplace_back(key, std::forward<Value>(value));
+    index_.emplace(std::forward<Key>(key), size() - 1);
+    return items_.back().value;
+  }
+
+  /// Allows calling `insert` with an initializer list for the value, e.g.
+  /// `insert(key, {...})`.
+  T& insert(std::string key, T&& value) {
+    return insert<std::string, T>(std::move(key), std::move(value));
+  }
+
+  void update(OrderedDict&& other) {
+    for (auto& item : other) {
+      // We want to call `insert()` to prevent duplicate keys.
+      insert(std::move(item.key), std::move(item.value));
+    }
+  }
+
+  void update(const OrderedDict& other) {
+    for (auto& item : other) {
+      // We want to call `insert()` to prevent duplicate keys.
+      insert(item.key, item.value);
+    }
+  }
+
+  T* find(const std::string& str) noexcept {
+    auto iterator = index_.find(str);
+    if (iterator == index_.end()) {
+      return nullptr;
+    }
+    return &items_[iterator->second].value;
+  }
+
+  const T* find(const std::string& str) const noexcept {
+    auto iterator = index_.find(str);
+    if (iterator == index_.end()) {
+      return nullptr;
+    }
+    return &items_[iterator->second].value;
+  }
+
+  T& get(const std::string& key) {
+    if (auto* value = find(key)) {
+      return *value;
+    }
+    AT_ERROR("No such key: '", key, "'");
+  }
+
+  const T& get(const std::string& key) const {
+    if (auto* value = find(key)) {
+      return *value;
+    }
+    AT_ERROR("No such key: '", key, "'");
+  }
+
+  void clear() {
+    index_.clear();
+    items_.clear();
+  }
+
+  size_t size() const noexcept {
+    return items_.size();
+  }
+
+  bool is_empty() const noexcept {
+    return items_.empty();
+  }
+
+ private:
+  std::unordered_map<std::string, size_t> index_;
+  std::vector<Item> items_;
+};
+} // namespace detail
+} // namespace torch

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/tensor.h>
+#include <torch/detail/ordered_dict.h>
 
 #include <torch/csrc/autograd/variable.h>
 
@@ -93,26 +94,29 @@ class Module {
   }
 
  protected:
-  Variable register_parameter(const std::string& name, at::Tensor tensor);
-  Variable register_buffer(const std::string& name, at::Tensor tensor);
+  autograd::Variable& register_parameter(std::string name, at::Tensor tensor);
+  autograd::Variable& register_buffer(std::string name, at::Tensor tensor);
 
   template <typename ModuleType>
   std::shared_ptr<ModuleType> register_module(
-      const std::string& name,
-      const std::shared_ptr<ModuleType>& module) {
-    const auto pair = children_.emplace(name, module);
-    AT_CHECK(pair.second, "Module has already been registered");
-    return module;
+      std::string name,
+      std::shared_ptr<ModuleType> module) {
+    auto& base_module = children_.insert(std::move(name), std::move(module));
+    return std::static_pointer_cast<ModuleType>(base_module);
   }
 
  private:
+  template <typename T>
+  using OrderedDict = torch::detail::OrderedDict<T>;
+
   template <typename Derived>
   friend class CloneableModule;
 
   virtual void clone_(Module& other);
 
-  std::unordered_map<std::string, Variable> parameters_;
-  std::unordered_map<std::string, std::shared_ptr<Module>> children_;
+  OrderedDict<autograd::Variable> parameters_;
+  OrderedDict<autograd::Variable> buffers_;
+  OrderedDict<std::shared_ptr<Module>> children_;
 
   /// The module's name (e.g. "LSTM").
   mutable at::optional<std::string> name_;
@@ -151,13 +155,11 @@ class CloneableModule : public Module {
     copy->parameters_.clear();
     copy->children_.clear();
     copy->reset();
-    for (auto& parameter : parameters_) {
-      copy->parameters_.at(parameter.first)
-          .data()
-          .copy_(parameter.second.data());
+    for (const auto& parameter : parameters_) {
+      copy->parameters_[parameter.key].data().copy_(parameter->data());
     }
-    for (auto& child : children_) {
-      copy->children_.at(child.first)->clone_(*child.second);
+    for (const auto& child : children_) {
+      copy->children_[child.key]->clone_(*child.value);
     }
     return copy;
   }

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -107,7 +107,7 @@ class Module {
 
  private:
   template <typename T>
-  using OrderedDict = torch::detail::OrderedDict<T>;
+  using OrderedDict = torch::detail::OrderedDict<std::string, T>;
 
   template <typename Derived>
   friend class CloneableModule;

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <map>
-#include <stdexcept>
 #include <string>
 #include <typeinfo>
 #include <unordered_map>
@@ -45,15 +44,13 @@ std::shared_ptr<Module> Module::clone() const {
 
 std::map<std::string, Variable> Module::parameters() const {
   std::map<std::string, Variable> ret;
-  for (const auto& pair : children_) {
-    auto& name = pair.first;
-    auto& child = pair.second;
-    for (auto& p : child->parameters()) {
-      ret[name + "." + p.first] = p.second;
+  for (const auto& child : children_) {
+    for (auto& p : (*child)->parameters()) {
+      ret[child.key + "." + p.first] = p.second;
     }
   }
-  for (const auto& pair : parameters_) {
-    ret[pair.first] = pair.second;
+  for (const auto& parameter : parameters_) {
+    ret[parameter.key] = parameter.value;
   }
   return ret;
 }
@@ -67,34 +64,33 @@ Variable& Module::param(std::string const& name) {
       break;
     }
 
-    auto child_name = name.substr(begin, dot_pos - begin);
-    auto it = container->children_.find(child_name);
-    if (it == container->children_.end()) {
-      throw std::runtime_error("No such child: " + child_name);
+    const auto child_name = name.substr(begin, dot_pos - begin);
+    if (auto* child = container->children_.find(child_name)) {
+      container = child->get();
+    } else {
+      AT_ERROR("No such child: ", child_name);
     }
 
-    container = it->second.get();
     begin = dot_pos + 1; // Skip the dot
   }
 
-  auto param_name = name.substr(begin);
-  auto it = container->parameters_.find(param_name);
-  if (it == container->parameters_.end()) {
-    throw std::runtime_error("No such param: " + param_name);
+  const auto parameter_name = name.substr(begin);
+  if (auto* parameter = container->parameters_.find(parameter_name)) {
+    return *parameter;
   }
-  return it->second;
+  AT_ERROR("No such param: ", parameter_name);
 }
 
 void Module::train() {
-  for (auto& pair : children_) {
-    pair.second->train();
+  for (auto& child : children_) {
+    child.value->train();
   }
   is_training_ = true;
 }
 
 void Module::eval() {
-  for (auto& pair : children_) {
-    pair.second->eval();
+  for (auto& child : children_) {
+    child.value->eval();
   }
   is_training_ = false;
 }
@@ -109,39 +105,36 @@ void Module::cpu() {
 
 void Module::to(at::Type& type) {
   for (auto& child : children_) {
-    child.second->to(type);
+    child.value->to(type);
   }
-  for (auto& pair : parameters_) {
-    auto parameter = pair.second;
-    at::detail::set_data(parameter, parameter.data().toType(type));
-    AT_ASSERT(parameter.data().type() == type);
-    AT_ASSERT(&parameter.type() == autograd::VariableType::getType(type));
+  for (auto& parameter : parameters_) {
+    at::detail::set_data(*parameter, parameter->data().toType(type));
+    AT_ASSERT(parameter->data().type() == type);
+    AT_ASSERT(&parameter->type() == autograd::VariableType::getType(type));
   }
 }
 
 void Module::to(at::ScalarType scalar_type) {
   for (auto& child : children_) {
-    child.second->to(scalar_type);
+    child.value->to(scalar_type);
   }
-  for (auto& pair : parameters_) {
-    auto parameter = pair.second;
-    auto& new_type = parameter.data().type().toScalarType(scalar_type);
-    at::detail::set_data(parameter, parameter.data().toType(new_type));
-    AT_ASSERT(parameter.data().type().scalarType() == scalar_type);
-    AT_ASSERT(parameter.type().scalarType() == scalar_type);
+  for (auto& parameter : parameters_) {
+    auto& new_type = parameter->data().type().toScalarType(scalar_type);
+    at::detail::set_data(*parameter, parameter->data().toType(new_type));
+    AT_ASSERT(parameter->data().type().scalarType() == scalar_type);
+    AT_ASSERT(parameter->type().scalarType() == scalar_type);
   }
 }
 
 void Module::to(at::Backend backend) {
   for (auto& child : children_) {
-    child.second->to(backend);
+    child.value->to(backend);
   }
-  for (auto& pair : parameters_) {
-    auto parameter = pair.second;
-    auto& new_type = parameter.data().type().toBackend(backend);
-    at::detail::set_data(parameter, parameter.data().toType(new_type));
-    AT_ASSERT(parameter.data().type().backend() == backend);
-    AT_ASSERT(parameter.type().backend() == backend);
+  for (auto& parameter : parameters_) {
+    auto& new_type = parameter->data().type().toBackend(backend);
+    at::detail::set_data(*parameter, parameter->data().toType(new_type));
+    AT_ASSERT(parameter->data().type().backend() == backend);
+    AT_ASSERT(parameter->type().backend() == backend);
   }
 }
 
@@ -151,27 +144,25 @@ bool Module::is_training() const noexcept {
 
 void Module::zero_grad() {
   for (auto& child : children_) {
-    child.second->zero_grad();
+    child.value->zero_grad();
   }
-  for (auto& pair : parameters_) {
-    pair.second.grad().zero_();
+  for (auto& parameter : parameters_) {
+    parameter->grad().zero_();
   }
 }
 
-Variable Module::register_parameter(
-    const std::string& name,
+autograd::Variable& Module::register_parameter(
+    std::string name,
     at::Tensor tensor) {
   auto variable = autograd::make_variable(tensor, /*requires_grad=*/true);
-  const auto pair = parameters_.emplace(name, std::move(variable));
-  AT_CHECK(pair.second, "Parameter has already been registered");
-  return pair.first->second;
+  return parameters_.insert(std::move(name), std::move(variable));
 }
 
-Variable Module::register_buffer(const std::string& name, at::Tensor tensor) {
+autograd::Variable& Module::register_buffer(
+    std::string name,
+    at::Tensor tensor) {
   auto variable = autograd::make_variable(tensor, /*requires_grad=*/false);
-  const auto pair = parameters_.emplace(name, std::move(variable));
-  AT_CHECK(pair.second, "Parameter has already been registered");
-  return pair.first->second;
+  return parameters_.insert(std::move(name), std::move(variable));
 }
 
 void Module::clone_(Module& other) {}

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<Module> Module::clone() const {
 std::map<std::string, Variable> Module::parameters() const {
   std::map<std::string, Variable> ret;
   for (const auto& child : children_) {
-    for (auto& p : (*child)->parameters()) {
+    for (auto& p : child.value->parameters()) {
       ret[child.key + "." + p.first] = p.second;
     }
   }

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -4,6 +4,14 @@
 #include "torch/csrc/jit/tensor_conversions.h"
 #include "torch/csrc/jit/python_tracer.h"
 
+#include <torch/csrc/api/include/torch/detail/ordered_dict.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace torch {
 namespace jit {
 namespace script {
@@ -416,7 +424,7 @@ void initJitScriptBindings(PyObject* module) {
         return bool(self.find_method(name));
       })
       .def("_method_names", [](Module& self) {
-        using Item = detail::OrderedDict<std::string, std::unique_ptr<Method>>::Item;
+        using Item = torch::detail::OrderedDict<std::string, std::unique_ptr<Method>>::Item;
         return fmap(self.get_methods(), [](const Item & item) {
           return (*item)->name();
         });

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -416,7 +416,7 @@ void initJitScriptBindings(PyObject* module) {
         return bool(self.find_method(name));
       })
       .def("_method_names", [](Module& self) {
-        using Item = detail::OrderedDict<std::unique_ptr<Method>>::Item;
+        using Item = detail::OrderedDict<std::string, std::unique_ptr<Method>>::Item;
         return fmap(self.get_methods(), [](const Item & item) {
           return (*item)->name();
         });

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -248,11 +248,11 @@ struct ModuleValue : public SugaredValue {
 
   // select an attribute on it, e.g. `this.field`
   virtual std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
-    if(at::optional<NamedModule&> v = module->find_module(field)) {
+    if(NamedModule* v = module->find_module(field)) {
       return std::make_shared<ModuleValue>(v->module);
-    } else if(at::optional<Method&> v = module->find_method(field)) {
+    } else if(Method* v = module->find_method(field)) {
       return std::make_shared<MethodValue>(module, *v);
-    } else if(at::optional<NamedParameter&> v = module->find_parameter(field)) {
+    } else if(NamedParameter* v = module->find_parameter(field)) {
       return std::make_shared<SimpleValue>(m.get_or_add_parameter(v->slot()));
     }
     // This can also be a call to a non-script module, or a plain
@@ -330,11 +330,11 @@ py::object unpackVariableTensorList(std::vector<at::Tensor> outputs) {
 }
 
 static void gatherParametersAndBuffers(std::vector<at::Tensor*> & values, const Module & m) {
-  for(auto & params : m.get_parameters()) {
-    values.push_back(params.slot());
+  for(auto & param : m.get_parameters()) {
+    values.push_back(param->slot());
   }
   for(const auto & sub : m.get_modules()) {
-    gatherParametersAndBuffers(values, *sub.module);
+    gatherParametersAndBuffers(values, *sub->module);
   }
 }
 
@@ -378,8 +378,8 @@ void initJitScriptBindings(PyObject* module) {
         auto & modules = self.get_modules();
         py::tuple result(modules.size());
         for(size_t i = 0; i < modules.size(); ++i) {
-          auto & nm = modules[i];
-          result[i] = std::make_pair(nm.name, nm.module);
+          auto & item = modules[i];
+          result[i] = std::make_pair(item.key, item.value);
         }
         return result;
       })
@@ -390,9 +390,9 @@ void initJitScriptBindings(PyObject* module) {
           auto & p = parameters[i];
           py::tuple r(3);
           result[i] = std::make_tuple(
-            p.name,
-            static_cast<const autograd::Variable&>(*p.slot()),
-            p.is_buffer);
+            p.key,
+            static_cast<const autograd::Variable&>(*p->slot()),
+            p->is_buffer);
 
         }
         return result;
@@ -416,8 +416,9 @@ void initJitScriptBindings(PyObject* module) {
         return bool(self.find_method(name));
       })
       .def("_method_names", [](Module& self) {
-        return fmap(self.get_methods(), [](const std::unique_ptr<Method> & m) {
-          return m->name();
+        using Item = detail::OrderedDict<std::unique_ptr<Method>>::Item;
+        return fmap(self.get_methods(), [](const Item & item) {
+          return (*item)->name();
         });
       })
       .def("_create_method_from_trace", [](

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -7,8 +7,17 @@
 #include "torch/csrc/jit/function_schema.h"
 #include "torch/csrc/jit/named_value.h"
 
+#include <torch/csrc/api/include/torch/detail/ordered_dict.h>
+
 #include <ATen/optional.h>
+#include <ATen/ArrayRef.h>
+
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // This file contains classes which assist in desugaring Python style
 // modules and their methods into flattened graphs which don't have any
@@ -189,70 +198,9 @@ private:
   std::unique_ptr<at::Tensor> parameter;
 };
 
-// simple ordered dict used only in Module
-// contains only the minimum necessary functionality for Module
-template<typename T>
-struct OrderedDict {
-  OrderedDict(const char * what)
-  : what(what) {}
-  // note: slight difference from python here.
-  // we do not allow for insertion of an already existing value,
-  // because we not allow allow methods or submodules to be updated
-  // once created
-  T& insert(const std::string& name,  T&& value) {
-    if(index_.count(name) != 0) {
-      std::stringstream ss;
-      ss << "module " << what << "'" << name << "' already defined.";
-      throw std::runtime_error(ss.str());
-    }
-    values_.push_back(std::move(value));
-    index_[name] = values_.size() - 1;
-    return values_.back();
-  }
-  at::optional<T&> find(const std::string& str) {
-    auto it = index_.find(str);
-    if(it == index_.end())
-      return at::nullopt;
-    return at::optional<T&>(values_.at(it->second));
-  }
-  at::optional<const T&> find(const std::string& str) const {
-    auto it = index_.find(str);
-    if(it == index_.end())
-      return at::nullopt;
-    return at::optional<const T&>(values_.at(it->second));
-  }
-  T& get(const std::string& name) {
-    if(auto v = find(name)) {
-      return *v;
-    }
-    std::stringstream ss;
-    ss << "module " << what << "'" << name << "' is not defined.";
-    throw std::runtime_error(ss.str());
-  }
-  const T& get(const std::string& name) const {
-    if(auto v = find(name)) {
-      return *v;
-    }
-    std::stringstream ss;
-    ss << "module " << what << "'" << name << "' is not defined.";
-    throw std::runtime_error(ss.str());
-  }
-  const std::vector<T>& values() const {
-    return values_;
-  }
-private:
-  std::unordered_map<std::string, size_t> index_;
-  std::vector<T> values_;
-  const char * what;
-};
-
 struct Module : public std::enable_shared_from_this<Module> {
   TH_DISALLOW_COPY_AND_ASSIGN(Module);
-  Module()
-  : modules("modules")
-  , parameters("parameters")
-  , methods("methods")
-  , optimize(true) {}
+  Module() : optimize(true) {}
 
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
@@ -296,7 +244,7 @@ struct Module : public std::enable_shared_from_this<Module> {
   }
 
   // each module owns its method. The reference returned here
-  // is guarenteed to stay valid until this module has been destoryed
+  // is guarenteed to stay valid until this module has been destroyed
   Method& get_method(const std::string& name) const {
     return *methods.get(name);
   }
@@ -305,39 +253,38 @@ struct Module : public std::enable_shared_from_this<Module> {
     return modules.get(name).module;
   }
 
-  const std::vector<NamedModule>& get_modules() const {
-    return modules.values();
+  const detail::OrderedDict<NamedModule>& get_modules() const {
+    return modules;
   }
-  const  std::vector<NamedParameter>& get_parameters() const {
-    return parameters.values();
+  const detail::OrderedDict<NamedParameter>& get_parameters() const {
+    return parameters;
   }
-  const  std::vector<std::unique_ptr<Method>>& get_methods() const {
-    return methods.values();
+  const detail::OrderedDict<std::unique_ptr<Method>>& get_methods() const {
+    return methods;
   }
 
-
-  at::optional<NamedParameter&> find_parameter(const std::string& name) {
+  NamedParameter* find_parameter(const std::string& name) {
     return parameters.find(name);
   }
-  at::optional<NamedModule&> find_module(const std::string& name) {
+  NamedModule* find_module(const std::string& name) {
     return modules.find(name);
   }
-  at::optional<Method&> find_method(const std::string& name) {
-    if(auto pm = methods.find(name))
-      return at::optional<Method&>(**pm);
-    return at::nullopt;
+  Method* find_method(const std::string& name) {
+    if (auto* pm = methods.find(name)) {
+      return pm->get();
+    }
+    return nullptr;
   }
 
-
-private:
+ private:
 
   // invariant: to ensure member_inputs of Methods stay valid,
   // it is only legal to _add_ new modules and parameters.
   // removing them will allow member_inputs to point to invalid parameters
   // no such restriction exists for methods
-  OrderedDict<NamedModule> modules;
-  OrderedDict<NamedParameter> parameters;
-  OrderedDict<std::unique_ptr<Method>> methods;
+  detail::OrderedDict<NamedModule> modules;
+  detail::OrderedDict<NamedParameter> parameters;
+  detail::OrderedDict<std::unique_ptr<Method>> methods;
   bool optimize;
 };
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -200,7 +200,11 @@ private:
 
 struct Module : public std::enable_shared_from_this<Module> {
   TH_DISALLOW_COPY_AND_ASSIGN(Module);
-  Module() : optimize(true) {}
+  Module()
+  : modules("Module")
+  , parameters("Parameter")
+  , methods("Method")
+  , optimize(true) {}
 
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
@@ -253,13 +257,13 @@ struct Module : public std::enable_shared_from_this<Module> {
     return modules.get(name).module;
   }
 
-  const detail::OrderedDict<NamedModule>& get_modules() const {
+  const detail::OrderedDict<std::string, NamedModule>& get_modules() const {
     return modules;
   }
-  const detail::OrderedDict<NamedParameter>& get_parameters() const {
+  const detail::OrderedDict<std::string, NamedParameter>& get_parameters() const {
     return parameters;
   }
-  const detail::OrderedDict<std::unique_ptr<Method>>& get_methods() const {
+  const detail::OrderedDict<std::string, std::unique_ptr<Method>>& get_methods() const {
     return methods;
   }
 
@@ -282,9 +286,9 @@ struct Module : public std::enable_shared_from_this<Module> {
   // it is only legal to _add_ new modules and parameters.
   // removing them will allow member_inputs to point to invalid parameters
   // no such restriction exists for methods
-  detail::OrderedDict<NamedModule> modules;
-  detail::OrderedDict<NamedParameter> parameters;
-  detail::OrderedDict<std::unique_ptr<Method>> methods;
+  detail::OrderedDict<std::string, NamedModule> modules;
+  detail::OrderedDict<std::string, NamedParameter> parameters;
+  detail::OrderedDict<std::string, std::unique_ptr<Method>> methods;
   bool optimize;
 };
 


### PR DESCRIPTION
This PR brings back the `OrderedDict` data structure from my old C++ API PR https://github.com/pytorch/pytorch/pull/6345. It's based on the `OrderedDict` class from the JIT, but implemented slightly differently in that it stores `(key, value)` pairs together in a vector, besides another copy of the `key` for the index. This is to allow easier iteration, since iterators are now over items instead of only keys or only values. The problem with the old design (`unordered_map<string, int>` and `vector<Value>`) is that you can't get an ordered list keys from it, since the index map is unordered, which makes iteration over "items" impossible.

I've replaced uses of `unordered_map` in the C++ API with `OrderedDict`, as well as uses of the old `OrderedDict` in the JIT with the new one.

Also added a bunch of tests.

@apaszke @ebetica @zdevito 