### PR TITLE
[build] Fix Caffe2 with BUILD_CAFFE2 and BUILD_ATEN both set

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_ATEN)
       --yaml_dir=${CMAKE_CURRENT_BINARY_DIR}/../aten/src/ATen
       --install_dir=${CMAKE_CURRENT_BINARY_DIR}/contrib/aten
     DEPENDS
-    ATen_cpu
+    ATEN_CPU_FILES_GEN_TARGET
     ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
     ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/aten_op_template.h)
 


### PR DESCRIPTION
A last minute change made the code generation on the Caffe2-side not wait for the code generation done within PyTorch. This adds that dependency back now that we don't depend directly on the ATen_cpu interface library (which I removed at the last minute).

Tested with

```
./.jenkins/caffe2/build.sh -DUSE_ATEN=ON
```