### PR TITLE
[build] Only add BUILD_ATEN/USE_ATEN once to flags

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -66,7 +66,9 @@ CMAKE_ARGS+=("-DUSE_OBSERVERS=ON")
 CMAKE_ARGS+=("-DUSE_ZSTD=ON")
 
 if [[ $BUILD_ENVIRONMENT == *-aten-* ]]; then
-  CMAKE_ARGS+=("-DUSE_ATEN=ON")
+  if [[ CMAKE_ARGS != *USE_ATEN* ]] && [[ CMAKE_ARGS != *BUILD_ATEN* ]]; then
+    CMAKE_ARGS+=("-DBUILD_ATEN=ON")
+  fi
 fi
 
 # Run build script from scripts if applicable


### PR DESCRIPTION
We are currently adding it in the caffe2.groovy as well as the build.sh script. Seeing if this helps our builds pass.