### PR TITLE
[Caffe2] Use __float2half

### DIFF
--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -175,7 +175,7 @@ CONVERSIONS_DECL float16 To(const float in) {
 #if __CUDA_ARCH__
   // hacky interface between C2 fp16 and CUDA
 #if CUDA_VERSION >= 9000
-  half rh = static_cast<half>(in);
+  half rh = __float2half(in); 
   return halfToFloat16(rh);
 #else
   float16 ret;


### PR DESCRIPTION
CUDA 9 document says this is a legit use:
https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____HALF__MISC.html#group__CUDA__MATH____HALF__MISC_1g9f330c6a82c3c502821d7a104bfbfae1