### PR TITLE
Split CI tests in half and run them in parallel

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -33,6 +33,9 @@ if ([[ "$BUILD_ENVIRONMENT" == *cuda* ]] || [[ "$BUILD_ENVIRONMENT" == *gcc7.2* 
   export MAX_JOBS=`expr $(nproc) - 1`
 fi
 
+# Target only our CI GPU machine's CUDA arch to speed up the build
+export TORCH_CUDA_ARCH_LIST=5.2
+
 WERROR=1 python setup.py install
 
 # Add the test binaries so that they won't be git clean'ed away

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -117,29 +117,3 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]] || \
 else
   BUILD_TEST_LIBTORCH=0
 fi
-
-# We set these values to true by default, so that both tests will run
-# in the same job in pre-split setting and in local test environment.
-export SHOULD_RUN_TEST1=true
-export SHOULD_RUN_TEST2=true
-
-# If this is a build-only job, we don't run the tests.
-if [[ "${JOB_BASE_NAME}" == *-build ]]; then
-  export SHOULD_RUN_TEST1=false
-  export SHOULD_RUN_TEST2=false
-fi
-
-# In post-split setting, if $SPLIT_TESTS is not set to "true", we run all tests in -test1 job,
-# and if $SPLIT_TESTS is set to "true", we run the tests in their respective jobs.
-if [[ "${JOB_BASE_NAME}" == *-test1 ]] || [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
-  export SHOULD_RUN_TEST1=false
-  export SHOULD_RUN_TEST2=false
-  if ([[ "${SPLIT_TESTS}" != "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]) || \
-    ([[ "${SPLIT_TESTS}" == "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]); then
-    export SHOULD_RUN_TEST1=true
-  fi
-  if ([[ "${SPLIT_TESTS}" != "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]) || \
-    ([[ "${SPLIT_TESTS}" == "true" ]] && [[ "${JOB_BASE_NAME}" == *-test2 ]]); then
-    export SHOULD_RUN_TEST2=true
-  fi
-fi

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -117,3 +117,29 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py3 ]] || \
 else
   BUILD_TEST_LIBTORCH=0
 fi
+
+# We set these values to true by default, so that both tests will run
+# in the same job in pre-split setting and in local test environment.
+export SHOULD_RUN_TEST1=true
+export SHOULD_RUN_TEST2=true
+
+# If this is a build-only job, we don't run the tests.
+if [[ "${JOB_BASE_NAME}" == *-build ]]; then
+  export SHOULD_RUN_TEST1=false
+  export SHOULD_RUN_TEST2=false
+fi
+
+# In post-split setting, if $SPLIT_TESTS is not set to "true", we run all tests in -test1 job,
+# and if $SPLIT_TESTS is set to "true", we run the tests in their respective jobs.
+if [[ "${JOB_BASE_NAME}" == *-test1 ]] || [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
+  export SHOULD_RUN_TEST1=false
+  export SHOULD_RUN_TEST2=false
+  if ([[ "${SPLIT_TESTS}" != "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]) || \
+    ([[ "${SPLIT_TESTS}" == "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]); then
+    export SHOULD_RUN_TEST1=true
+  fi
+  if ([[ "${SPLIT_TESTS}" != "true" ]] && [[ "${JOB_BASE_NAME}" == *-test1 ]]) || \
+    ([[ "${SPLIT_TESTS}" == "true" ]] && [[ "${JOB_BASE_NAME}" == *-test2 ]]); then
+    export SHOULD_RUN_TEST2=true
+  fi
+fi

--- a/.jenkins/pytorch/macos-build-test.sh
+++ b/.jenkins/pytorch/macos-build-test.sh
@@ -1,74 +1,9 @@
 #!/bin/bash
 
-COMPACT_JOB_NAME=pytorch-macos-10.13-py3-build-test
-source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-
-export PATH="/usr/local/bin:$PATH"
-
-# Set up conda environment
-export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
-# If a local installation of conda doesn't exist, we download and install conda
-if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
-  mkdir -p ${PYTORCH_ENV_DIR}
-  curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ${PYTORCH_ENV_DIR}/miniconda3.sh
-  bash ${PYTORCH_ENV_DIR}/miniconda3.sh -b -p ${PYTORCH_ENV_DIR}/miniconda3
-fi
-export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
-source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
-conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
-rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
-
-git submodule update --init --recursive
-export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
-
-# Build and test PyTorch
-export MACOSX_DEPLOYMENT_TARGET=10.9
-export CXX=clang++
-export CC=clang
-# If we run too many parallel jobs, we will OOM
-export MAX_JOBS=2
-
-export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
-
-if [[ "${JOB_BASE_NAME}" == *-build* ]]; then
-  python setup.py install
+if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-build* ]]; then
+  source "$(dirname "${BASH_SOURCE[0]}")/macos-build.sh"
 fi
 
-# Upload torch binaries when the build job is finished
-if [[ "${JOB_BASE_NAME}" == *-build ]]; then
-  7z a ${IMAGE_COMMIT_TAG}.7z ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
-  aws s3 cp ${IMAGE_COMMIT_TAG}.7z s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z --acl public-read
-fi
-
-# Download torch binaries in the test jobs
-if [[ "${JOB_BASE_NAME}" == *-test1 ]] || [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
-  rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
-  aws s3 cp s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z ${IMAGE_COMMIT_TAG}.7z
-  7z x ${IMAGE_COMMIT_TAG}.7z -o"${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages"
-fi
-
-if [[ "${SHOULD_RUN_TEST1}" == "true" ]]; then
-  echo "Ninja version: $(ninja --version)"
-  python test/run_test.py --verbose
-fi
-
-if [[ "${SHOULD_RUN_TEST2}" == "true" ]]; then
-  # C++ API
-
-  # NB: Install outside of source directory (at the same level as the root
-  # pytorch folder) so that it doesn't get cleaned away prior to docker push.
-  # But still clean it before we perform our own build.
-  #
-  CPP_BUILD="$PWD/../cpp-build"
-  rm -rf $CPP_BUILD
-  mkdir -p $CPP_BUILD
-  WERROR=1 VERBOSE=1 tools/cpp_build/build_all.sh "$CPP_BUILD"
-
-  python tools/download_mnist.py --quiet -d test/cpp/api/mnist
-
-  # Unfortunately it seems like the test can't load from miniconda3
-  # without these paths being set
-  export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
-  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
-  "$CPP_BUILD"/libtorch/bin/test_api
+if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test* ]]; then
+  source "$(dirname "${BASH_SOURCE[0]}")/macos-test.sh"
 fi

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+COMPACT_JOB_NAME=pytorch-macos-10.13-py3-build-test
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+export PATH="/usr/local/bin:$PATH"
+
+# Set up conda environment
+export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
+# If a local installation of conda doesn't exist, we download and install conda
+if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
+  mkdir -p ${PYTORCH_ENV_DIR}
+  curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ${PYTORCH_ENV_DIR}/miniconda3.sh
+  bash ${PYTORCH_ENV_DIR}/miniconda3.sh -b -p ${PYTORCH_ENV_DIR}/miniconda3
+fi
+export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
+source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
+conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
+rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
+
+git submodule update --init --recursive
+export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
+
+# Build and test PyTorch
+export MACOSX_DEPLOYMENT_TARGET=10.9
+export CXX=clang++
+export CC=clang
+# If we run too many parallel jobs, we will OOM
+export MAX_JOBS=2
+
+export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
+
+python setup.py install
+
+# Upload torch binaries when the build job is finished
+7z a ${IMAGE_COMMIT_TAG}.7z ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
+aws s3 cp ${IMAGE_COMMIT_TAG}.7z s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z --acl public-read

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+COMPACT_JOB_NAME=pytorch-macos-10.13-py3-build-test
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+export PATH="/usr/local/bin:$PATH"
+
+# Set up conda environment
+export PYTORCH_ENV_DIR="${HOME}/pytorch-ci-env"
+# If a local installation of conda doesn't exist, we download and install conda
+if [ ! -d "${PYTORCH_ENV_DIR}/miniconda3" ]; then
+  mkdir -p ${PYTORCH_ENV_DIR}
+  curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ${PYTORCH_ENV_DIR}/miniconda3.sh
+  bash ${PYTORCH_ENV_DIR}/miniconda3.sh -b -p ${PYTORCH_ENV_DIR}/miniconda3
+fi
+export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
+source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
+conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja
+rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
+
+git submodule update --init --recursive
+export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
+
+# Build and test PyTorch
+export MACOSX_DEPLOYMENT_TARGET=10.9
+export CXX=clang++
+export CC=clang
+# If we run too many parallel jobs, we will OOM
+export MAX_JOBS=2
+
+export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
+
+# Download torch binaries in the test jobs
+rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch
+aws s3 cp s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z ${IMAGE_COMMIT_TAG}.7z
+7z x ${IMAGE_COMMIT_TAG}.7z -o"${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages"
+
+test_python_all() {
+  echo "Ninja version: $(ninja --version)"
+  python test/run_test.py --verbose
+}
+
+test_cpp_api() {
+  # C++ API
+
+  # NB: Install outside of source directory (at the same level as the root
+  # pytorch folder) so that it doesn't get cleaned away prior to docker push.
+  # But still clean it before we perform our own build.
+  #
+  CPP_BUILD="$PWD/../cpp-build"
+  rm -rf $CPP_BUILD
+  mkdir -p $CPP_BUILD
+  WERROR=1 VERBOSE=1 tools/cpp_build/build_all.sh "$CPP_BUILD"
+
+  python tools/download_mnist.py --quiet -d test/cpp/api/mnist
+
+  # Unfortunately it seems like the test can't load from miniconda3
+  # without these paths being set
+  export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
+  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
+  "$CPP_BUILD"/libtorch/bin/test_api
+}
+
+if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
+  test_python_all
+  test_cpp_api
+else
+  if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
+    test_python_all
+  elif [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
+    test_cpp_api
+  fi
+fi

--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -70,6 +70,7 @@ set CUDNN_LIB_DIR=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0\\l
 set CUDA_TOOLKIT_ROOT_DIR=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0
 set CUDNN_ROOT_DIR=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.0
 
+:: Target only our CI GPU machine's CUDA arch to speed up the build
 set TORCH_CUDA_ARCH_LIST=5.2
 
 sccache --stop-server || set ERRORLEVEL=0

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -34,21 +34,6 @@ except botocore.exceptions.ClientError as e:
 
 EOL
 
-cat >ci_scripts/delete_image.py << EOL
-
-import os
-import boto3
-
-IMAGE_COMMIT_TAG = os.getenv('IMAGE_COMMIT_TAG')
-
-session = boto3.session.Session()
-s3 = session.resource('s3')
-BUCKET_NAME = 'ossci-windows-build'
-KEY = 'pytorch/'+IMAGE_COMMIT_TAG+'.7z'
-s3.Object(BUCKET_NAME, KEY).delete()
-
-EOL
-
 cat >ci_scripts/test_pytorch.bat <<EOL
 
 set PATH=C:\\Program Files\\CMake\\bin;C:\\Program Files\\7-Zip;C:\\curl-7.57.0-win64-mingw\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLI;%PATH%
@@ -78,8 +63,15 @@ cd test/
 python ..\\ci_scripts\\download_image.py %IMAGE_COMMIT_TAG%.7z
 
 7z x %IMAGE_COMMIT_TAG%.7z
-python run_test.py --verbose && python ..\\ci_scripts\\delete_image.py
 
+set SPLIT_TESTS=true
+
+IF "%SHOULD_RUN_TEST1%" == "true" (
+    python run_test.py --include nn --verbose
+)
+IF "%SHOULD_RUN_TEST2%" == "true" (
+    python run_test.py --exclude nn --verbose
+)
 EOL
 
 ci_scripts/test_pytorch.bat && echo "TEST PASSED"


### PR DESCRIPTION
This PR aims to speed up our CI jobs by splitting some of the test jobs in half and running them in parallel. Specifically, we are targeting these 3 build environments that run the slowest in our CI:

- pytorch-macos-10.13-py3
- pytorch-win-ws2016-cuda9-cudnn7-py3
- pytorch-linux-xenial-cuda9-cudnn7-py3

They typically take 40-50 mins from start to finish (not counting the wait time in the CI job queue), and half of the time is spent on running the tests. With this PR we will run two halves of the tests in parallel and cut 10 mins from the total runtime, a 20% improvement in our CI runtime in the ideal case (i.e. when all machines are available). We could consider splitting the tests further if we got overall positive results from this two-way split.

Note that the runtime improvement won't show up in this PR because we need to flip a switch in the CI system to enable the splitting. But this will show that the new test script works in the old settings as well.