### PR TITLE
[Caffe2] Fix roi_align_op_gpu_test and test_layer_norm_grad_op

### DIFF
--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -115,7 +115,6 @@ bool LayerNormGradientOp<CPUContext>::DoRunWithType<float>() {
   // -1.0*(mean / stdev) * dstdev_end
   auto dmean_stdev = stdev_map.unaryExpr(neg_recip)
                          .cwiseProduct(means_map)
-                         .replicate(1, right)
                          .cwiseProduct(dstdev_end);
   // (mean / (D*stdev)) * dstdev
   auto dx_stdev = (1.0f / right) *

--- a/caffe2/operators/roi_align_op_gpu_test.cc
+++ b/caffe2/operators/roi_align_op_gpu_test.cc
@@ -228,7 +228,7 @@ TEST(RoiAlignTest, CheckCPUGPUEqual) {
     const int C = randInt(1, 5);
     const int H = randInt(1, 50);
     const int W = randInt(1, 50);
-    const int n_rois = randInt(0, 30);
+    const int n_rois = randInt(1, 30);
     vector<float> rois_array;
     for (int n = 0; n < n_rois; n++) {
       rois_array.push_back(randInt(0, N - 1));


### PR DESCRIPTION
When `roi=0`, `roi_align_op` will output a zero tensor. This will cause out-of-bound access on https://github.com/pytorch/pytorch/blob/980960d036d4edfcbfa3d90a451a907312139b3a/caffe2/operators/roi_align_op_gpu_test.cc#L258
where we are accessing 0th element of an empty vector. 

I'm changing the test to avoid `roi=0`, but I think additional test should be made to test the 0 tensor situation. @orionr 

re. test_layer_norm_grad_op, both `dmean_stdev` and `dstdev_end` are of shape (left, 1), so no need to replicate.