### PR TITLE
Fix error when setting multiple arch in TORCH_CUDA_ARCH_LIST

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -299,7 +299,7 @@ function(caffe2_select_nvcc_arch_flags out_variable)
     unset(CUDA_ARCH_PTX CACHE)
   endif()
 
-  if($ENV{TORCH_CUDA_ARCH_LIST})
+  if(DEFINED ENV{TORCH_CUDA_ARCH_LIST})
     # Pass CUDA architecture directly
     set(__cuda_arch_bin $ENV{TORCH_CUDA_ARCH_LIST})
     message(STATUS "Set CUDA arch from TORCH_CUDA_ARCH_LIST: ${__cuda_arch_bin}")


### PR DESCRIPTION
On master if you do `TORCH_CUDA_ARCH_LIST="6.0;6.1;7.0" python setup.py install`, you will meet this error
```
CMake Error at cmake/public/cuda.cmake:302 (if):
  if given arguments:

    "6.0" "6.1" "7.0"

  Unknown arguments specified
Call Stack (most recent call first):
  cmake/public/cuda.cmake:419 (caffe2_select_nvcc_arch_flags)
  cmake/Dependencies.cmake:396 (include)
  CMakeLists.txt:188 (include)
```

If you replace `;` with spaces, it compiles, but doesn't build for the archs you specified. 

This fixes it.

cc @orionr @soumith 