### PR TITLE
Fix seeding random module in DataLoader

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -116,6 +116,15 @@ class DatasetMock(object):
         return 10
 
 
+class RandomDatasetMock(object):
+
+    def __getitem__(self, index):
+        return torch.tensor([torch.rand(1).item(), random.uniform(0, 1)])
+
+    def __len__(self):
+        return 1000
+
+
 class TestCheckpoint(TestCase):
 
     # Test whether checkpoint is being triggered or not. For this, we check
@@ -232,6 +241,20 @@ class TestDataLoader(TestCase):
     def setUp(self):
         self.dataset = torch.randn(5, 3, 3, 2)
         self.batch_size = 3
+
+    def test_random_seed(self):
+        def run():
+            dataloader = torch.utils.data.DataLoader(RandomDatasetMock(),
+                                                     batch_size=2,
+                                                     num_workers=4,
+                                                     shuffle=True)
+            return next(iter(dataloader))
+
+        torch.manual_seed(2018)
+        x1 = run()
+        torch.manual_seed(2018)
+        x2 = run()
+        self.assertEqual(x1, x2)
 
     def test_single_keep(self):
         dataloader = torch.utils.data.DataLoader(self.dataset,

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -83,7 +83,7 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, wo
     _set_worker_signal_handlers()
 
     torch.set_num_threads(1)
-    random.seed(int(seed))
+    random.seed(seed)
     torch.manual_seed(seed)
 
     if init_fn is not None:
@@ -246,7 +246,7 @@ class _DataLoaderIter(object):
 
         self.sample_iter = iter(self.batch_sampler)
 
-        base_seed = torch.LongTensor(1).random_()[0]
+        base_seed = int(torch.LongTensor(1).random_()[0])
 
         if self.num_workers > 0:
             self.worker_init_fn = loader.worker_init_fn

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -246,7 +246,7 @@ class _DataLoaderIter(object):
 
         self.sample_iter = iter(self.batch_sampler)
 
-        base_seed = int(torch.LongTensor(1).random_()[0])
+        base_seed = torch.LongTensor(1).random_().item()
 
         if self.num_workers > 0:
             self.worker_init_fn = loader.worker_init_fn

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -83,7 +83,7 @@ def _worker_loop(dataset, index_queue, data_queue, collate_fn, seed, init_fn, wo
     _set_worker_signal_handlers()
 
     torch.set_num_threads(1)
-    random.seed(seed)
+    random.seed(int(seed))
     torch.manual_seed(seed)
 
     if init_fn is not None:


### PR DESCRIPTION
Fix #7882 

The  `random` module is seeded [here](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L86). The problem with that line is that `seed` is not an `int` but a `Tensor`. Python then will use `hash(seed)`  to seed the random module ([docs](https://docs.python.org/2/library/random.html#random.seed)). Without a hash function for `Tensor`, the actually seed will be the address of the tensor. And it changes every time!

The line should be changed to: `random.seed(int(seed))`

Test on fllowing script from #7882 
```python
import torch
import random

from torch.utils.data import Dataset, DataLoader

class Data(Dataset):
    def __len__(self):
        return 10000
    def __getitem__(self, index):
        print(index, torch.rand(2, 2).sum().item(), random.uniform(0, 1))
        return 1

seed = 2018
torch.manual_seed(seed)
loader = DataLoader(Data(), num_workers=4, shuffle=True)

for x in loader:
    print('-'*10)
    break
```
## Before
First run
```
4717 2.202341079711914 0.9952153654478976
4607 2.3166141510009766 0.6813692345925851
4194 1.9806793928146362 0.6281118075687344
2595 2.95841383934021 0.8414756141240453
4691 0.9809015393257141 0.7622458327788627
9868 2.521920680999756 0.5253262288522356
7367 2.333574056625366 0.35079311205192487
9490 3.02830171585083 0.16235006783937567
----------
6759 3.1252167224884033 0.4424384676992986
```
Next run
```
4607 2.3166141510009766 0.15198273935290807
4194 1.9806793928146362 0.36414129463658884
4691 0.9809015393257141 0.027569260048619926
4717 2.202341079711914 0.5512619092026773
7367 2.333574056625366 0.7932627754589792
9490 3.02830171585083 0.19395324967791994
9868 2.521920680999756 0.5497794735158222
2595 2.95841383934021 0.782779934368899
----------
6759 3.1252167224884033 0.7098308465010348
```

## After
First run
```
4194 1.9806793928146362 0.28176797222610817
4717 2.202341079711914 0.9839100412778289
4607 2.3166141510009766 0.6780782905745018
4691 0.9809015393257141 0.3976280065444453
9868 2.521920680999756 0.7470951277406424
2595 2.95841383934021 0.3961659556772974
7367 2.333574056625366 0.021153138172570696
9490 3.02830171585083 0.07198172828873439
----------
6759 3.1252167224884033 0.5803779056735119
```
Next run
```
4717 2.202341079711914 0.9839100412778289
4194 1.9806793928146362 0.28176797222610817
4607 2.3166141510009766 0.6780782905745018
2595 2.95841383934021 0.3961659556772974
4691 0.9809015393257141 0.3976280065444453
9868 2.521920680999756 0.7470951277406424
7367 2.333574056625366 0.021153138172570696
9490 3.02830171585083 0.07198172828873439
----------
6759 3.1252167224884033 0.5803779056735119

```