### PR TITLE
Add n-dimensional version of gather operator

### DIFF
--- a/caffe2/operators/ndim_gather_ops.cc
+++ b/caffe2/operators/ndim_gather_ops.cc
@@ -1,0 +1,76 @@
+#include "caffe2/operators/ndim_gather_ops.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(NdimGather, NdimGatherOp<CPUContext>);
+REGISTER_CPU_OPERATOR(NdimGatherGradient, NdimGatherGradientOp<CPUContext>);
+
+OPERATOR_SCHEMA(NdimGather)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(1);
+      ArgumentHelper helper(def);
+
+      vector<int> output_dims;
+      const auto& data_dims = GetDimsVector(in[0]);
+      const auto& indices_dims = GetDimsVector(in[1]);
+      const int axis = helper.GetSingleArgument<int>("axis", 0);
+      if (axis > 0) {
+        output_dims.insert(
+            output_dims.end(), data_dims.begin(), data_dims.begin() + axis);
+      }
+      output_dims.insert(
+          output_dims.end(), indices_dims.begin(), indices_dims.end());
+      if (axis < data_dims.size() - 1) {
+        output_dims.insert(
+            output_dims.end(), data_dims.begin() + axis + 1, data_dims.end());
+      }
+
+      out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
+      return out;
+    })
+    .SetDoc(R"DOC(
+Given DATA tensor of rank r >= 1, INDICES tensor of rank q >= 1, and axis, gather
+entries of DATA along dimension "axis" indexed by INDICES, and concatenate
+them in an output tensor of rank q + (r - 1).
+
+Example:
+  DATA  = [
+      [1.0, 1.2, 2.4, 4.5],
+      [2.3, 3.4, 3.6, 2.3],
+      [4.5, 5.7, 1.2, 4.5],
+  ]
+  INDICES = [
+      [0, 2],
+  ]
+  axis = 1
+  OUTPUT = [
+      [1.0, 2.4],
+      [2.3, 3.6],
+      [4.5, 1.2],
+  ]
+)DOC")
+    .Arg("axis", "The dimension in which we index, default to 0")
+    .Input(0, "DATA", "Tensor of rank r >= 1.")
+    .Input(1, "INDICES", "Tensor of int32/int64 indices, of any rank q.")
+    .Output(0, "OUTPUT", "Tensor of rank q + (r - 1).");
+
+OPERATOR_SCHEMA(NdimGatherGradient).NumInputs(3).NumOutputs(1);
+
+class GetNdimGatherGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  vector<OperatorDef> GetGradientDefs() override {
+    using Op = NdimGatherOp<CPUContext>;
+    return SingleGradientDef(
+        "NdimGatherGradient",
+        "",
+        vector<string>{I(Op::DATA), I(Op::INDICES), GO(0)},
+        vector<string>{GI(0)});
+  }
+};
+
+REGISTER_GRADIENT(NdimGather, GetNdimGatherGradient);
+
+} // namespace caffe2

--- a/caffe2/operators/ndim_gather_ops.cu
+++ b/caffe2/operators/ndim_gather_ops.cu
@@ -1,0 +1,196 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/ndim_gather_ops.h"
+
+namespace caffe2 {
+
+template <typename T_INDEX, typename TData>
+__global__ void NdimGatherKernel(
+    const TData* src_base,
+    TData* out,
+    const T_INDEX* indices,
+    const int M,
+    const int N,
+    const int data_batch_size,
+    const int gathered_batch_size,
+    const int block_size) {
+  const int begin_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int num_items = M * N * block_size;
+  for (int s = begin_idx; s < num_items; s += blockDim.x * gridDim.x) {
+    const int k = s % block_size;
+    const int j = s / block_size % N;
+    const int i = s / block_size / N;
+    const T_INDEX idx = indices[j];
+    const float* src_offset = src_base + i * data_batch_size + idx * block_size;
+    float* dst_offset = out + i * gathered_batch_size + j * block_size;
+    dst_offset[k] = src_offset[k];
+  }
+}
+
+template <>
+bool NdimGatherOp<CUDAContext>::RunOnDevice() {
+  return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+      this, OperatorBase::Input<TensorCUDA>(INDICES));
+}
+
+template <>
+template <typename TInd>
+bool NdimGatherOp<CUDAContext>::DoRunWithType() {
+  auto& data = Input(DATA);
+  auto& indices = Input(INDICES);
+  auto* output = Output(0);
+
+  CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+  CAFFE_ENFORCE_GE(axis_, 0, "Axis should be non-negative");
+  CAFFE_ENFORCE_LT(axis_, data.ndim(), "Axis out of range");
+
+  vector<TIndex> shape;
+  if (axis_ > 0) {
+    shape.insert(
+        shape.end(), data.dims().begin(), data.dims().begin() + axis_);
+  }
+  shape.insert(shape.end(), indices.dims().begin(), indices.dims().end());
+  if (axis_ < data.ndim() - 1) {
+    shape.insert(
+        shape.end(), data.dims().begin() + axis_ + 1, data.dims().end());
+  }
+  output->Resize(shape);
+
+  const int M = data.size_to_dim(axis_);
+  const int block_size = data.size_from_dim(axis_ + 1);
+  const int N = indices.size();
+  const auto data_batch_size = data.size_from_dim(axis_);
+  const auto gathered_batch_size = N * block_size;
+  const TInd* idxs = indices.template data<TInd>();
+  auto src_base = static_cast<const float*>(data.raw_data());
+  auto out = static_cast<float*>(output->raw_mutable_data(data.meta()));
+
+  // return early when the input is empty, since CUDA kernel will fail for
+  // empty input.
+  if (N <= 0) {
+   return true;
+  }
+
+  NdimGatherKernel<<<
+      std::min(M, CAFFE_MAXIMUM_NUM_BLOCKS),
+      std::min(N * block_size, CAFFE_CUDA_NUM_THREADS),
+      0,
+      context_.cuda_stream()>>>(
+      src_base,
+      out,
+      idxs,
+      M,
+      N,
+      data_batch_size,
+      gathered_batch_size,
+      block_size);
+  return true;
+}
+
+template <typename T_INDEX, typename TData>
+__global__ void NdimGatherGradientKernel(
+    const TData* grad_data,
+    TData* out,
+    const T_INDEX* indices,
+    const int M,
+    const int N,
+    const int data_batch_size,
+    const int gathered_batch_size,
+    const int block_size) {
+  int begin_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int num_items = M * N * block_size;
+  for (int s = begin_idx; s < num_items; s += blockDim.x * gridDim.x) {
+    const int k = s % block_size;
+    const int j = s / block_size % N;
+    const int i = s / block_size / N;
+    const T_INDEX idx = indices[j];
+    const float* src_offset =
+        grad_data + i * gathered_batch_size + j * block_size;
+    float* dst_offset = out + i * data_batch_size + idx * block_size;
+    atomicAdd(dst_offset + k, src_offset[k]);
+  }
+}
+
+template <>
+bool NdimGatherGradientOp<CUDAContext>::RunOnDevice() {
+  return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+      this, OperatorBase::Input<TensorCUDA>(INDICES));
+}
+
+template <>
+template <typename TInd>
+bool NdimGatherGradientOp<CUDAContext>::DoRunWithType() {
+  return DispatchHelper<
+      TensorTypes2<float, GenericTensorImplementation>,
+      TInd>::call(this, OperatorBase::Input<TensorCUDA>(DATA));
+}
+
+template <>
+template <typename TInd, typename TData>
+bool NdimGatherGradientOp<CUDAContext>::DoRunWithType2() {
+  auto& data = Input(DATA);
+  auto& indices = Input(INDICES);
+  auto& grad = Input(GRAD);
+  auto* output = Output(0);
+
+  CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+  CAFFE_ENFORCE_GE(axis_, 0, "Axis should be non-negative");
+  CAFFE_ENFORCE_LT(axis_, data.ndim(), "Axis out of range");
+  for (int i = 0; i < axis_; i++) {
+    CAFFE_ENFORCE_EQ(
+        data.dim(i),
+        grad.dim(i),
+        "The ",
+        i,
+        "-th dimension should be the same");
+  }
+
+  output->ResizeLike(data);
+  auto* out_data = output->template mutable_data<float>();
+  math::Set<float, CUDAContext>(output->size(), 0, out_data, &context_);
+
+  const auto* grad_data = grad.template data<float>();
+
+  const int M = data.size_to_dim(axis_);
+  const int block_size = data.size_from_dim(axis_ + 1);
+  const int N = indices.size();
+  const auto data_batch_size = data.size_from_dim(axis_);
+  const auto gathered_batch_size = N * block_size;
+  const TInd* idxs = indices.template data<TInd>();
+
+  // return early when the input is empty, since CUDA kernel will fail for
+  // empty input.
+  if (N <= 0) {
+   return true;
+  }
+
+  NdimGatherGradientKernel<<<
+      std::min(M, CAFFE_MAXIMUM_NUM_BLOCKS),
+      std::min(N * block_size, CAFFE_CUDA_NUM_THREADS),
+      0,
+      context_.cuda_stream()>>>(
+      grad_data,
+      out_data,
+      idxs,
+      M,
+      N,
+      data_batch_size,
+      gathered_batch_size,
+      block_size);
+
+  return true;
+}
+
+template <>
+template <typename TInd>
+bool NdimGatherGradientOp<CUDAContext>::DoRunWithOtherType2() {
+  CAFFE_THROW(
+      "NdimGatherGradient is not implemented on tensor of type ",
+      Input(DATA).meta().name(),
+      "Consider adding it a type in the list DispatchHelper or implementing "
+      "a generic version (which won't work for duplicated indices though)");
+}
+
+REGISTER_CUDA_OPERATOR(NdimGather, NdimGatherOp<CUDAContext>);
+REGISTER_CUDA_OPERATOR(NdimGatherGradient, NdimGatherGradientOp<CUDAContext>);
+
+} // namespace caffe2

--- a/caffe2/operators/ndim_gather_ops.h
+++ b/caffe2/operators/ndim_gather_ops.h
@@ -1,0 +1,180 @@
+#ifndef CAFFE2_OPERATORS_BATCH_GATHER_OPS_H_
+#define CAFFE2_OPERATORS_BATCH_GATHER_OPS_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+class NdimGatherOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  NdimGatherOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        OP_SINGLE_ARG(int, "axis", axis_, 0) {}
+
+  virtual ~NdimGatherOp() noexcept {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, OperatorBase::Input<TensorCPU>(INDICES));
+  }
+
+  template <typename TInd>
+  bool DoRunWithType() {
+    auto& data = Input(DATA);
+    auto& indices = Input(INDICES);
+    auto* output = Output(0);
+
+    CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+    CAFFE_ENFORCE_GE(axis_, 0, "Axis should be non-negative");
+    CAFFE_ENFORCE_LT(axis_, data.ndim(), "Axis out of range");
+
+    vector<TIndex> shape;
+    if (axis_ > 0) {
+      shape.insert(
+          shape.end(), data.dims().begin(), data.dims().begin() + axis_);
+    }
+    shape.insert(shape.end(), indices.dims().begin(), indices.dims().end());
+    if (axis_ < data.ndim() - 1) {
+      shape.insert(
+          shape.end(), data.dims().begin() + axis_ + 1, data.dims().end());
+    }
+    output->Resize(shape);
+
+    auto outer_size = data.size_to_dim(axis_);
+    auto block_size = data.size_from_dim(axis_ + 1);
+    auto block_bytesize = block_size * data.meta().itemsize();
+    auto N = indices.size();
+    auto data_batch_bytesize =
+        data.size_from_dim(axis_) * data.meta().itemsize();
+    auto gathered_batch_bytesize = N * block_size * data.meta().itemsize();
+    const TInd* idxs = indices.template data<TInd>();
+    auto src_base = static_cast<const char*>(data.raw_data());
+    auto out = static_cast<char*>(output->raw_mutable_data(data.meta()));
+
+    for (auto batch = 0; batch < outer_size; ++batch) {
+      for (auto i = 0; i < N; ++i) {
+        auto idx = idxs[i];
+        CAFFE_ENFORCE(
+            0 <= idx && idx < data.dim(axis_),
+            "INDICES element is out of DATA bounds, id=",
+            idx,
+            " data_dim=",
+            data.dim(axis_));
+        auto src =
+            src_base + idx * block_bytesize + batch * data_batch_bytesize;
+        auto dst = out + i * block_bytesize + batch * gathered_batch_bytesize;
+        context_.template CopyItems<Context, Context>(
+            data.meta(), block_size, src, dst);
+      }
+    }
+    return true;
+  }
+
+  INPUT_TAGS(DATA, INDICES);
+
+protected:
+  int axis_;
+};
+
+template <class Context>
+class NdimGatherGradientOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  NdimGatherGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        OP_SINGLE_ARG(int, "axis", axis_, 0) {}
+
+  virtual ~NdimGatherGradientOp() noexcept {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+        this, OperatorBase::Input<TensorCPU>(INDICES));
+  }
+
+  template <typename TInd>
+  bool DoRunWithType() {
+    return DispatchHelper<
+        TensorTypes2<float, GenericTensorImplementation>,
+        TInd>::call(this, Input(DATA));
+  }
+
+  template <typename TInd, typename TData>
+  bool DoRunWithType2() {
+    auto& data = Input(DATA);
+    auto& indices = Input(INDICES);
+    auto& grad = Input(GRAD);
+    auto* output = Output(0);
+
+    CAFFE_ENFORCE_GE(data.ndim(), 1, "DATA should be at least 1-D");
+    CAFFE_ENFORCE_GE(axis_, 0, "Axis should be non-negative");
+    CAFFE_ENFORCE_LT(axis_, data.ndim(), "Axis out of range");
+    for (int i = 0; i < axis_; i++) {
+      CAFFE_ENFORCE_EQ(
+          data.dim(i),
+          grad.dim(i),
+          "The ",
+          i,
+          "-th dimension should be the same");
+    }
+
+    output->ResizeLike(data);
+    TData* out_data = output->template mutable_data<TData>();
+    if (data.size() <= 0) {
+      return true;
+    }
+
+    memset(out_data, 0, output->nbytes());
+
+    const TData* grad_data = grad.template data<TData>();
+
+    auto outer_size = data.size_to_dim(axis_);
+    auto block_size = data.size_from_dim(axis_ + 1);
+    auto N = indices.size();
+    auto data_batch_size = data.size_from_dim(axis_);
+    auto gathered_batch_size = N * block_size;
+    const TInd* idxs = indices.template data<TInd>();
+
+    for (auto batch = 0; batch < outer_size; ++batch) {
+      for (auto i = 0; i < N; ++i) {
+        auto idx = idxs[i];
+        CAFFE_ENFORCE(
+            0 <= idx && idx < data.dim(axis_),
+            "INDICES element is out of DATA bounds, id=",
+            idx,
+            " data_dim=",
+            data.dim(axis_));
+        math::Add(
+            block_size,
+            out_data + idx * block_size + batch * data_batch_size,
+            grad_data + i * block_size + batch * gathered_batch_size,
+            out_data + idx * block_size + batch * data_batch_size,
+            &context_);
+      }
+    }
+    return true;
+  }
+
+  template <typename TInd>
+  bool DoRunWithOtherType2() {
+    CAFFE_THROW(
+        "NdimGatherGradientOp is not implemented on tensor of type ",
+        Input(DATA).meta().name(),
+        "Consider adding it a type in the list DispatchHelper or implementing "
+        "a generic version (which won't work for duplicated indices though)");
+  }
+
+  INPUT_TAGS(DATA, INDICES, GRAD);
+
+protected:
+  int axis_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_BATCH_GATHER_OPS_H_


### PR DESCRIPTION
Goal:

Create a new operator for n-dimensional gather in caffe2.

Suppose:
(1) the shape of input data is `(d_1, d_2 ..., d_N)`;
(2) the shape of indices is `(c_1, c_2, ..., c_M)`;
(3) and the axis is `i`.
The shape of output should be `(d_1, ..., d_{i - 1}, c_1, ..., c_M, d_{i + 1}, ..., d_{N})`

Then current `Gather' and `BatchGather` are its special cases with `i = 0` and `i = 1`, respectively.
