### PR TITLE
[Caffe2 Bugfix] Pass build time variables for the newly added switches USE_CUDNN/USE_TERSORRT.

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -10,6 +10,11 @@ set(CAFFE2_VERSION_MINOR @CAFFE2_VERSION_MINOR@)
 set(CAFFE2_VERSION_PATCH @CAFFE2_VERSION_PATCH@)
 set(CAFFE2_VERSION "@CAFFE2_VERSION@")
 
+# Build time variables
+
+set(USE_TENSORRT @USE_TENSORRT@)
+set(USE_CUDNN    @USE_CUDNN@)
+
 # Utils functions.
 include("${CMAKE_CURRENT_LIST_DIR}/public/utils.cmake")
 


### PR DESCRIPTION
This avoid errors like "missing caffe2::cudnn" when linking against Caffe2 via CMake config.

