### PR TITLE
Spelling fix in MultivariateNormal docstring

### DIFF
--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -84,7 +84,7 @@ class MultivariateNormal(Distribution):
 
     The multivariate normal distribution can be parameterized either
     in terms of a positive definite covariance matrix :math:`\mathbf{\Sigma}`
-    or a positive definite precition matrix :math:`\mathbf{\Sigma}^{-1}`
+    or a positive definite precision matrix :math:`\mathbf{\Sigma}^{-1}`
     or a lower-triangular matrix :math:`\mathbf{L}` with positive-valued
     diagonal entries, such that
     :math:`\mathbf{\Sigma} = \mathbf{L}\mathbf{L}^\top`. This triangular matrix


### PR DESCRIPTION
## Summary
- Simplify `get_macos_variables` to always use `14.0` as deployment target (removes Python version conditional)
- Update all test expected values to `14.0`
- Companion PR in pytorch repo: https://github.com/pytorch/pytorch/pull/179081

## Files changed
- `tools/pkg-helpers/pytorch_pkg_helpers/macos.py`
- `tools/pkg-helpers/tests/test_macos.py`

## Test plan
- [ ] `python -m pytest tools/pkg-helpers/tests/test_macos.py` passes

Co-authored-by: Claude <noreply@anthropic.com>