### PR TITLE
Remove python bindings for `torch.slice`

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2930,7 +2930,6 @@ method_tests = [
     ('select', (S, S, S), (1, 2), 'dim', [0]),
     ('select', (S,), (0, 2), '1d'),
     ('narrow', (S, S, S), (1, 2, 2), 'dim', [0]),
-    ('slice', (S, S, S), (-2, 1, -1, 2)),
     ('squeeze', (S, 1, S, 1), NO_ARGS),
     ('squeeze', (1, 1, 1, 1), NO_ARGS, 'input_sizes_are_ones'),
     ('squeeze', (S, 1, S, 1), (1,), '1_dim', [0]),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3314,6 +3314,24 @@ class TestTorch(TestCase):
         torch.randn(SIZE, SIZE, out=res2)
         self.assertEqual(res1, res2)
 
+    def test_slice(self):
+        empty = torch.Tensor()
+        x = torch.arange(0., 16).view(4, 4)
+        self.assertEqual(x[:], x)
+        self.assertEqual(x[:4], x)
+        # start and stop are clamped to the size of dim
+        self.assertEqual(x[:5], x)
+        # if start >= stop then the result is empty
+        self.assertEqual(x[2:1], empty)
+        self.assertEqual(x[2:2], empty)
+        # out of bounds is also empty
+        self.assertEqual(x[10:12], empty)
+        # additional correctness checks
+        self.assertEqual(x[:1].data.tolist(), [[0, 1, 2, 3]])
+        self.assertEqual(x[:-3].data.tolist(), [[0, 1, 2, 3]])
+        self.assertEqual(x[:, -2:3].data.tolist(), [[2], [6], [10], [14]])
+        self.assertEqual(x[0:-1:2].data.tolist(), [[0, 1, 2, 3], [8, 9, 10, 11]])
+
     def test_is_signed(self):
         self.assertEqual(torch.IntTensor(5).is_signed(), True)
         self.assertEqual(torch.ByteTensor(5).is_signed(), False)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3314,24 +3314,6 @@ class TestTorch(TestCase):
         torch.randn(SIZE, SIZE, out=res2)
         self.assertEqual(res1, res2)
 
-    def test_slice(self):
-        empty = torch.Tensor()
-        x = torch.arange(0., 16).view(4, 4)
-        self.assertEqual(x.slice(), x)
-        self.assertEqual(x.slice(0, 0, 4), x)
-        # start and stop are clamped to the size of dim
-        self.assertEqual(x.slice(0, 0, 5), x)
-        # if start >= stop then the result is empty
-        self.assertEqual(x.slice(0, 2, 1), empty)
-        self.assertEqual(x.slice(0, 2, 2), empty)
-        # out of bounds is also empty
-        self.assertEqual(x.slice(0, 10, 12), empty)
-        # additional correctness checks
-        self.assertEqual(x.slice(0, 0, 1).data.tolist(), [[0, 1, 2, 3]])
-        self.assertEqual(x.slice(0, 0, -3).data.tolist(), [[0, 1, 2, 3]])
-        self.assertEqual(x.slice(start=-2, end=3, dim=1).data.tolist(), [[2], [6], [10], [14]])
-        self.assertEqual(x.slice(0, 0, -1, 2).data.tolist(), [[0, 1, 2, 3], [8, 9, 10, 11]])
-
     def test_is_signed(self):
         self.assertEqual(torch.IntTensor(5).is_signed(), True)
         self.assertEqual(torch.ByteTensor(5).is_signed(), False)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -22,7 +22,7 @@ SKIP_PYTHON_BINDINGS = [
     'index',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*', '_th_sum.*', '_th_prod.*',
-    'arange.*', 'range.*', '_gesv.*',
+    'arange.*', 'range.*', '_gesv.*', 'slice',
 ]
 
 PY_VARIABLE_METHODS_CPP = CodeTemplate.from_file(template_path + '/python_variable_methods.cpp')


### PR DESCRIPTION
This patch is a pivot from https://github.com/pytorch/pytorch/pull/7902. `torch.slice` is not intended to be used directly since its functionality is encompassed within tensor indexing notation. We should remove the function from the Python API.