### PR TITLE
Add on-stack observer cache for Observable

### DIFF
--- a/caffe2/core/observer.h
+++ b/caffe2/core/observer.h
@@ -59,6 +59,7 @@ class Observable {
       return observer_ptr;
     }
     observers_list_.push_back(std::move(observer));
+    UpdateCache();
 
     return observer_ptr;
   }
@@ -72,6 +73,7 @@ class Observable {
       if (it->get() == observer_ptr) {
         auto res = std::move(*it);
         observers_list_.erase(it);
+        UpdateCache();
         return res;
       }
     }
@@ -79,32 +81,72 @@ class Observable {
   }
 
   virtual size_t NumObservers() {
-    return observers_list_.size();
+    return num_observers_;
   }
 
+ private:
+  inline static void StartObserver(Observer* observer) {
+    try {
+      observer->Start();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Exception from observer: " << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Exception from observer: unknown";
+    }
+  }
+
+  inline static void StopObserver(Observer* observer) {
+    try {
+      observer->Stop();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Exception from observer: " << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Exception from observer: unknown";
+    }
+  }
+
+  void UpdateCache() {
+    num_observers_ = observers_list_.size();
+    if (num_observers_ != 1) {
+      // we cannot take advantage of the cache
+      return;
+    }
+    observer_cache_ = observers_list_[0].get();
+  }
+
+ public:
   void StartAllObservers() {
-    for (auto& observer : observers_list_) {
-      try {
-        observer->Start();
-      } catch (const std::exception& e) {
-        LOG(ERROR) << "Exception from observer: " << e.what();
-      } catch (...) {
-        LOG(ERROR) << "Exception from observer: unknown";
+    // do not access observers_list_ unless necessary
+    if (num_observers_ == 0) {
+      return;
+    } else if (num_observers_ == 1) {
+      StartObserver(observer_cache_);
+    } else {
+      for (auto& observer : observers_list_) {
+        StartObserver(observer.get());
       }
     }
   }
 
   void StopAllObservers() {
-    for (auto& observer : observers_list_) {
-      try {
-        observer->Stop();
-      } catch (const std::exception& e) {
-        LOG(ERROR) << "Exception from observer: " << e.what();
-      } catch (...) {
-        LOG(ERROR) << "Exception from observer: unknown";
+    // do not access observers_list_ unless necessary
+    if (num_observers_ == 0) {
+      return;
+    } else if (num_observers_ == 1) {
+      StopObserver(observer_cache_);
+    } else {
+      for (auto& observer : observers_list_) {
+        StopObserver(observer.get());
       }
     }
   }
+
+ private:
+  // an on-stack cache for fast iteration;
+  // ideally, inside StartAllObservers and StopAllObservers,
+  // we should never access observers_list_
+  Observer* observer_cache_;
+  size_t num_observers_ = 0;
 
  protected:
   std::vector<std::unique_ptr<Observer>> observers_list_;


### PR DESCRIPTION
 observers_list_ stores all the observers for an observable. The list is allocated on heap, which
 can cause LLC miss. Add an on-stack observer cache for fast access. In production, we have seen 50%
 speed up for start and stop observer calls.

