### PR TITLE
Make AT_FORALL_SCALAR_TYPES usable outside of at::namespace.

### DIFF
--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -14,7 +14,7 @@ _(int8_t,Char,i) \
 _(int16_t,Short,i) \
 _(int,Int,i) \
 _(int64_t,Long,i) \
-_(Half,Half,d) \
+_(at::Half,Half,d) \
 _(float,Float,d) \
 _(double,Double,d)
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -48,7 +48,7 @@ Tensor& empty_out(Tensor& result, IntList size) {
 // TODO: remove when we have Type support in the IR
 
 #define DEFINE_CAST_OP(_1, n, _2)                                \
-  Tensor _cast_##_1(const Tensor& self, bool non_blocking) {     \
+  Tensor _cast_##n(const Tensor& self, bool non_blocking) {      \
     auto& target_type = self.type().toScalarType(ScalarType::n); \
     if (self.type() == target_type)                              \
       return self;                                               \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5,25 +5,25 @@
 # Type's are not supported in the IR. Instead, we call down to these
 # specialized operators for each datatype.
 # TODO: remove when we have Type support in the IR
-- func: _cast_uint8_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Byte(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_int8_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Char(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_double(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Double(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_float(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Float(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_int(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Int(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_int64_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Long(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
-- func: _cast_int16_t(Tensor self, bool non_blocking=false) -> Tensor
+- func: _cast_Short(Tensor self, bool non_blocking=false) -> Tensor
   variants: function, method
 
 - func: _cast_Half(Tensor self, bool non_blocking=false) -> Tensor

--- a/torch/csrc/utils/tensor_conversion_dispatch.cpp
+++ b/torch/csrc/utils/tensor_conversion_dispatch.cpp
@@ -39,7 +39,7 @@ at::Tensor dispatch_type_conversion(
   switch (type.scalarType()) {
 #define DEFINE_CAST_DISPATCH(_1, n, _2)   \
   case at::ScalarType::n: {               \
-    return self._cast_##_1(non_blocking); \
+    return self._cast_##n(non_blocking); \
   } break;
     AT_FORALL_SCALAR_TYPES(DEFINE_CAST_DISPATCH)
 #undef DEFINE_CAST_DISPATCH

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -605,7 +605,7 @@ def type_as(g, self, other):
         return self
     else:
         other_type_name = self.type().scalarType().lower()
-        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[other_type_name])
+        return g.op("Cast", self, to_i=scalar_name_to_pytorch[other_type_name])
 
 
 # ignore clone operators that are inserted by PyTorch autograd
@@ -687,16 +687,26 @@ def _unique(g, input, sorted, return_inverse):
 # TODO: remove these once we support Type's in the JIT IR and we can once again
 # use the unified toType operator
 cast_pytorch_to_onnx = {
-    'uint8_t': torch.onnx.TensorProtoDataType.UINT8,
-    'int8_t': torch.onnx.TensorProtoDataType.INT8,
-    'double': torch.onnx.TensorProtoDataType.DOUBLE,
-    'float': torch.onnx.TensorProtoDataType.FLOAT,
+    'Byte': torch.onnx.TensorProtoDataType.UINT8,
+    'Char': torch.onnx.TensorProtoDataType.INT8,
+    'Double': torch.onnx.TensorProtoDataType.DOUBLE,
+    'Float': torch.onnx.TensorProtoDataType.FLOAT,
     'Half': torch.onnx.TensorProtoDataType.FLOAT16,
-    'int': torch.onnx.TensorProtoDataType.INT32,
-    'int64_t': torch.onnx.TensorProtoDataType.INT64,
-    'int16_t': torch.onnx.TensorProtoDataType.INT16,
+    'Int': torch.onnx.TensorProtoDataType.INT32,
+    'Long': torch.onnx.TensorProtoDataType.INT64,
+    'Short': torch.onnx.TensorProtoDataType.INT16,
 }
 
+scalar_name_to_pytorch = {
+    'uint8_t': 'Byte',
+    'int8_t': 'Char',
+    'double': 'Double',
+    'float': 'Float',
+    'half': 'Half',
+    'int': 'Int',
+    'int64_t': 'Long',
+    'int16_t': 'Short',
+}
 
 def _cast_func_template(to_i, g, input, non_blocking):
     return g.op("Cast", input, to_i=to_i)

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -605,7 +605,7 @@ def type_as(g, self, other):
         return self
     else:
         other_type_name = self.type().scalarType().lower()
-        return g.op("Cast", self, to_i=scalar_name_to_pytorch[other_type_name])
+        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[scalar_name_to_pytorch[other_type_name]])
 
 
 # ignore clone operators that are inserted by PyTorch autograd

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -708,6 +708,7 @@ scalar_name_to_pytorch = {
     'int16_t': 'Short',
 }
 
+
 def _cast_func_template(to_i, g, input, non_blocking):
     return g.op("Cast", input, to_i=to_i)
 


### PR DESCRIPTION
This requires renaming the _cast functions which used the unqualified names.

