### PR TITLE
Rename cuda::type to cuda::into_type and provide cuda::from_type.

### DIFF
--- a/aten/src/ATen/cuda/CUDATypeConversion.cuh
+++ b/aten/src/ATen/cuda/CUDATypeConversion.cuh
@@ -8,15 +8,29 @@
 
 namespace at { namespace cuda {
 template <typename T>
-struct TypeConversion {
+struct IntoTypeConversion {
   using type = T;
 };
 
 template <>
-struct TypeConversion<Half> {
+struct IntoTypeConversion<Half> {
   using type = half;
 };
 
 template <typename T>
-using type = typename TypeConversion<T>::type;
+using into_type = typename IntoTypeConversion<T>::type;
+
+template <typename T>
+struct FromTypeConversion {
+  using type = T;
+};
+
+template <>
+struct FromTypeConversion<half> {
+  using type = Half;
+};
+
+template <typename T>
+using from_type = typename FromTypeConversion<T>::type;
+
 }} // namespace at::cuda

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -101,7 +101,7 @@ namespace at { namespace native {
 Tensor _s_poisson_cuda(const Tensor& lambda, Generator* gen) {
   Tensor ret = lambda.type().tensor(lambda.sizes());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.type(), "poisson", [&] {
-    poisson_cuda_kernel<cuda::type<scalar_t>>(ret, lambda, next_philox_seed(gen, 20));
+    poisson_cuda_kernel<cuda::into_type<scalar_t>>(ret, lambda, next_philox_seed(gen, 20));
   });
   return ret;
 }
@@ -109,7 +109,7 @@ Tensor _s_poisson_cuda(const Tensor& lambda, Generator* gen) {
 Tensor _s_gamma_cuda(const Tensor& alpha, Generator* gen) {
   Tensor ret = alpha.type().tensor(alpha.sizes());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.type(), "gamma", [&] {
-     gamma_cuda_kernel<cuda::type<scalar_t>>(ret, alpha, next_philox_seed(gen, 10));
+     gamma_cuda_kernel<cuda::into_type<scalar_t>>(ret, alpha, next_philox_seed(gen, 10));
    });
   return ret;
 }
@@ -117,7 +117,7 @@ Tensor _s_gamma_cuda(const Tensor& alpha, Generator* gen) {
 Tensor _standard_gamma_grad_cuda(const Tensor& self, const Tensor& output) {
   Tensor ret = self.type().tensor(self.sizes());
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "_standard_gamma_grad", [&] {
-     gamma_grad_cuda_kernel<cuda::type<scalar_t>>(ret, self, output);
+     gamma_grad_cuda_kernel<cuda::into_type<scalar_t>>(ret, self, output);
    });
   return ret;
 }

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -214,7 +214,7 @@ Tensor embedding_backward_cuda(const Tensor & grad_, const Tensor & indices,
    dim3 block(128);
 
    AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "embedding_backward", [&] {
-     using cuda_scalar_t = cuda::type<scalar_t>;
+     using cuda_scalar_t = cuda::into_type<scalar_t>;
      embedding_backward_feature_kernel<<<grid, block, 0, stream>>>(
        indices.data<int64_t>(),
        grad.data<cuda_scalar_t>(),
@@ -290,7 +290,7 @@ Tensor embedding_backward_cuda(const Tensor & grad_, const Tensor & indices,
   dim3 block(32, 4);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "embedding_backward", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     embedding_backward_kernel<<<grid, block, 0, stream>>>(
       sorted_indices.data<int64_t>(),
       orig_indices.data<int64_t>(),
@@ -337,7 +337,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   int dim = self.stride(0);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "embedding_backward", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     using accscalar_t = acc_type<cuda_scalar_t, true>;
     renorm_kernel<<<grid, block, 128 * sizeof(accscalar_t), stream>>>(
       self.data<cuda_scalar_t>(),

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -237,7 +237,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
   dim3 block(32, 4);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad.type(), "embedding_bag_backward_cuda_sum_avg_kernel", [&] {
-        using cuda_scalar_t = cuda::type<scalar_t>;
+        using cuda_scalar_t = cuda::into_type<scalar_t>;
         EmbeddingBag_accGradParametersKernel_sum_avg<
             cuda_scalar_t><<<grid, block, 0, stream>>>(
             sorted_indices.data<int64_t>(), orig_indices.data<int64_t>(),
@@ -292,7 +292,7 @@ Tensor embedding_bag_backward_cuda_max(const Tensor &grad,
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       grad.type(), "embedding_bag_backward_cuda_max", [&] {
-        using cuda_scalar_t = cuda::type<scalar_t>;
+        using cuda_scalar_t = cuda::into_type<scalar_t>;
         EmbeddingBag_accGradParametersKernel_max<
             cuda_scalar_t><<<grid, block, 0, stream>>>(
             max_indices.data<int64_t>(), grad.data<cuda_scalar_t>(), 
@@ -343,7 +343,7 @@ embedding_bag_cuda(const Tensor &weight, const Tensor &indices,
   dim3 block = dim3(32, 8);
   int grid = 1024;
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(weight.type(), "embedding_bag_cuda", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     EmbeddingBag_updateOutputKernel<cuda_scalar_t><<<grid, block, 0, stream>>>(
         indices.data<int64_t>(), offsets.data<int64_t>(),
         weight.data<cuda_scalar_t>(), output.data<cuda_scalar_t>(),

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -495,7 +495,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_){
     dim3 grid(outer_size);
     dim3 block = SoftMax_getBlockSize(ILP, dim_size);
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "host_softmax", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     using accscalar_t = acc_type<cuda_scalar_t, true>;
     cunn_SoftMaxForward<ILP, cuda_scalar_t, accscalar_t, Epilogue>
       <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -509,7 +509,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_){
     uint32_t smem_size;
     dim3 grid, block;
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "host_softmax", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     using accscalar_t = acc_type<cuda_scalar_t, true>;
     SpatialSoftMax_getLaunchSizes<accscalar_t>(
         &cunn_SpatialSoftMaxForward<cuda_scalar_t, accscalar_t, Epilogue>,
@@ -548,7 +548,7 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
     dim3 grid(outer_size);
     dim3 block = SoftMax_getBlockSize(ILP, dim_size);
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "host_softmax_backward", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     using accscalar_t = acc_type<cuda_scalar_t, true>;
     cunn_SoftMaxBackward<ILP, cuda_scalar_t, accscalar_t, Epilogue>
       <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -559,7 +559,7 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
     uint32_t smem_size;
     dim3 grid, block;
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "host_softmax_backward", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     using accscalar_t = acc_type<cuda_scalar_t, true>;
     SpatialSoftMax_getLaunchSizes<accscalar_t>(
         &cunn_SpatialSoftMaxBackward<cuda_scalar_t, accscalar_t, Epilogue>,

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -118,7 +118,7 @@ static void _fft_fill_with_conjugate_symmetry_(Tensor& input,
   auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
   auto policy = thrust::cuda::par(allocator).on(stream);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "_fft_fill_with_conjugate_symmetry_", [&] {
-    using cuda_scalar_t = cuda::type<scalar_t>;
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
     typedef thrust::device_ptr<cuda_scalar_t> device_ptr;
     typedef thrust::counting_iterator<int64_t> counter;
     typedef thrust::transform_iterator<cnt_to_dst_idx_functor, counter> dst_idx_iterator;

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -36,7 +36,7 @@ Tensor _s_where_cuda(
     const Tensor& other) {
   Tensor ret = self.type().tensor(self.sizes());
   AT_DISPATCH_ALL_TYPES_AND_HALF(ret.type(), "where", [&] {
-    where_cuda<cuda::type<scalar_t>>(ret, condition, self, other);
+    where_cuda<cuda::into_type<scalar_t>>(ret, condition, self, other);
   });
   return ret;
 }


### PR DESCRIPTION
These are used to convert Half -> half and half -> Half respectively.
from_type will be used for runtime type checking in THC.

