### PR TITLE
Set smaller grain size for some cases

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -348,65 +348,73 @@ inline void CPU_tensor_apply4(
 }
 
 template <typename scalar1, typename Op>
-inline void CPU_tensor_parallel_apply1(Tensor tensor1, const Op op) {
+inline void CPU_tensor_parallel_apply1(
+    Tensor tensor1,
+    const Op op,
+    int64_t grain_size = internal::TBB_GRAIN_SIZE) {
   if (!_apply_preamble({tensor1}))
     return;
-  if (tensor1.numel() < internal::TBB_GRAIN_SIZE) {
+  if (tensor1.numel() < grain_size) {
     CPU_tensor_apply1<scalar1>(tensor1, op);
     return;
   }
-  auto range = tbb::blocked_range<size_t>(0, tensor1.numel());
   if (tensor1.ndimension() < 8) {
-    tbb::parallel_for(
-        range, [&tensor1, &op](const tbb::blocked_range<size_t> r) {
-          apply_op(
-              r.end() - r.begin(),
-              r.begin(),
-              op,
-              strided_tensor_iter_fixed<scalar1, 8>(tensor1, true));
-        });
+    parallel_for_1d(
+        [&tensor1, &op](int64_t begin, int64_t end) {
+          apply_op(end - begin, begin, op, strided_tensor_iter_fixed<scalar1, 8>(tensor1, true));
+        },
+        0,
+        tensor1.numel(),
+        grain_size);
   } else {
-    tbb::parallel_for(
-        range, [&tensor1, &op](const tbb::blocked_range<size_t> r) {
-          apply_op(
-              r.end() - r.begin(),
-              r.begin(),
-              op,
-              strided_tensor_iter<scalar1>(tensor1));
-        });
+    parallel_for_1d(
+        [&tensor1, &op](int64_t begin, int64_t end) {
+          apply_op(end - begin, begin, op, strided_tensor_iter<scalar1>(tensor1));
+        },
+        0,
+        tensor1.numel(),
+        grain_size);
   }
 }
 
 template <typename scalar1, typename scalar2, typename Op>
-inline void
-CPU_tensor_parallel_apply2(Tensor tensor1, Tensor tensor2, const Op op) {
+inline void CPU_tensor_parallel_apply2(
+    Tensor tensor1,
+    Tensor tensor2,
+    const Op op,
+    int64_t grain_size = internal::TBB_GRAIN_SIZE) {
   if (!_apply_preamble({tensor1, tensor2}))
     return;
-  if ((tensor1.numel() + tensor2.numel()) < internal::TBB_GRAIN_SIZE) {
+  if ((tensor1.numel() + tensor2.numel()) < grain_size) {
     CPU_tensor_apply2<scalar1, scalar2>(tensor1, tensor2, op);
     return;
   }
-  auto range = tbb::blocked_range<size_t>(0, tensor1.numel());
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
-    tbb::parallel_for(
-        range, [&tensor1, &tensor2, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for_1d(
+        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
+              end - begin,
+              begin,
               op,
               strided_tensor_iter_fixed<scalar1, 8>(tensor1),
               strided_tensor_iter_fixed<scalar2, 8>(tensor2));
-        });
+        },
+        0,
+        tensor1.numel(),
+        grain_size);
   } else {
-    tbb::parallel_for(
-        range, [&tensor1, &tensor2, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for_1d(
+        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
+              end - begin,
+              begin,
               op,
               strided_tensor_iter<scalar1>(tensor1),
               strided_tensor_iter<scalar2>(tensor2));
-        });
+        },
+        0,
+        tensor1.numel(),
+        grain_size);
   }
 }
 

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -3,12 +3,6 @@
 #include <tbb/tbb.h>
 #include <cstddef>
 
-#ifdef __PPC64__
-using default_partitioner_type = tbb::simple_partitioner;
-#else
-using default_partitioner_type = tbb::affinity_partitioner;
-#endif
-
 namespace at {
 namespace internal {
 // This needs to be called before the first use of any algorithm such as
@@ -30,70 +24,67 @@ AT_API void init_tbb_num_threads();
 constexpr int64_t TBB_GRAIN_SIZE = 32768;
 } // namespace internal
 
-template <class T, template <class> class OP>
-T parallel_reduce(
-    T (*f)(const T*, size_t, size_t, T),
-    const T* data,
-    size_t start,
-    size_t end,
-    T init_) {
+template <class F>
+inline void parallel_for_1d(
+    F f,
+    int64_t begin,
+    int64_t end,
+    int64_t grain_size = internal::TBB_GRAIN_SIZE,
+    bool parallelize = true) {
   internal::init_tbb_num_threads();
 
-  T result_;
-  static default_partitioner_type ap;
+#ifdef __PPC64__
+  using default_partitioner_type = tbb::simple_partitioner;
+#else
+  using default_partitioner_type = tbb::affinity_partitioner;
+#endif
 
-  if (end - start < internal::TBB_GRAIN_SIZE) {
-    result_ = f(data, start, end, init_);
-  } else {
-    result_ = tbb::parallel_reduce(
-        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE),
-        init_,
-        [&data, &f](const tbb::blocked_range<size_t> r, T init) -> T {
-          return f(data, r.begin(), r.end(), init);
-        },
-        OP<T>(),
-        ap);
-  }
-  return result_;
-}
+  thread_local static default_partitioner_type ap;
 
-template <class T>
-void parallel_reduce_2d(
-    void (*f)(const T*, T*, size_t, size_t),
-    size_t num_rows,
-    size_t num_cols,
-    size_t numel,
-    const T* arr_,
-    T* outarr_) {
-  internal::init_tbb_num_threads();
+  bool sequential = (end - begin) < grain_size || !parallelize;
 
-  static default_partitioner_type ap;
-
-  size_t max_i_ =
-      (numel && num_rows && num_cols) ? numel / (num_rows * num_cols) : 0;
-  if (numel < internal::TBB_GRAIN_SIZE) {
-    for (size_t i_ = 0; i_ < max_i_; i_++) {
-      int64_t i = i_ * num_rows * num_cols;
-      int64_t i_r = i_ * num_cols;
-      const T* arr = arr_ + i;
-      T* outarr = outarr_ + i_r;
-      f(arr, outarr, num_rows, num_cols);
-    }
+  if (sequential) {
+    f(begin, end);
   } else {
     tbb::parallel_for(
-        tbb::blocked_range<size_t>(0, max_i_, 1),
-        [&arr_, &outarr_, num_rows, num_cols, &f](
-            const tbb::blocked_range<size_t> r) {
-          for (size_t i_ = r.begin(); i_ < r.end(); i_++) {
-            int64_t i = i_ * num_rows * num_cols;
-            int64_t i_r = i_ * num_cols;
-            const T* arr = arr_ + i;
-            T* outarr = outarr_ + i_r;
-            f(arr, outarr, num_rows, num_cols);
-          }
-        },
+        tbb::blocked_range<int64_t>(begin, end, grain_size),
+        [f](const tbb::blocked_range<int64_t>& r) { f(r.begin(), r.end()); },
         ap);
   }
+}
+
+template <class scalar_t, class F, class SF>
+inline scalar_t parallel_reduce_1d(
+    F f,
+    SF sf,
+    scalar_t ident,
+    int64_t begin,
+    int64_t end,
+    int64_t grain_size = internal::TBB_GRAIN_SIZE,
+    bool parallelize = true) {
+  internal::init_tbb_num_threads();
+
+#ifdef __PPC64__
+  using default_partitioner_type = tbb::simple_partitioner;
+#else
+  using default_partitioner_type = tbb::affinity_partitioner;
+#endif
+
+  thread_local static default_partitioner_type ap;
+
+  bool sequential = (end - begin) < grain_size || !parallelize;
+
+  if (sequential) {
+    return f(begin, end, 0);
+  }
+  return tbb::parallel_reduce(
+      tbb::blocked_range<int64_t>(begin, end, grain_size),
+      scalar_t(ident),
+      [f](const tbb::blocked_range<int64_t>& r, scalar_t init) {
+        return f(r.begin(), r.end(), init);
+      },
+      sf,
+      ap);
 }
 
 } // namespace at

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -22,7 +22,7 @@ namespace {
 template <class T>
 struct Vec256 {
   static constexpr int size = 32 / sizeof(T);
-  __at_align32__ T values[32 / sizeof(T)];
+  T values[32 / sizeof(T)];
   Vec256() {}
   Vec256(T val) {
     for (int i = 0; i != size; i++) {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -40,56 +40,62 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
     return at::op##_out(result, self);                           \
   }
 
-#define IMPLEMENT_UNARY_OP_FLOAT_CMATH(op, opfn)                          \
-  Tensor& _##op##__cpu(Tensor& self_) {                                   \
-    if (self_.numel() > 0) {                                              \
-      Tensor self = sort_strides(self_);                                  \
-      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
-        CPU_tensor_parallel_apply1<scalar_t>(                             \
-            self, [](scalar_t& y) { y = opfn(y); });                      \
-      });                                                                 \
-    }                                                                     \
-    return self_;                                                         \
-  }                                                                       \
-  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) {           \
-    result.resize_(self.sizes());                                         \
-    if (result.numel() > 0) {                                             \
-      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
-        CPU_tensor_parallel_apply2<scalar_t, scalar_t>(                   \
-            result, self, [](scalar_t& y, scalar_t& x) { y = opfn(x); }); \
-      });                                                                 \
-    }                                                                     \
-    return result;                                                        \
+#define IMPLEMENT_UNARY_OP_FLOAT_CMATH(op, opfn)                \
+  Tensor& _##op##__cpu(Tensor& self_) {                         \
+    if (self_.numel() > 0) {                                    \
+      Tensor self = sort_strides(self_);                        \
+      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {         \
+        CPU_tensor_parallel_apply1<scalar_t>(                   \
+            self, [](scalar_t& y) { y = opfn(y); }, 1024);      \
+      });                                                       \
+    }                                                           \
+    return self_;                                               \
+  }                                                             \
+  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) { \
+    result.resize_(self.sizes());                               \
+    if (result.numel() > 0) {                                   \
+      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {         \
+        CPU_tensor_parallel_apply2<scalar_t, scalar_t>(         \
+            result,                                             \
+            self,                                               \
+            [](scalar_t& y, scalar_t& x) { y = opfn(x); },      \
+            1024);                                              \
+      });                                                       \
+    }                                                           \
+    return result;                                              \
   }
 
-#define IMPLEMENT_UNARY_OP_VEC(op, opfn)                                    \
-  Tensor& _##op##__cpu(Tensor& self_) {                                     \
-    if (self_.numel() > 0) {                                                \
-      Tensor self = sort_strides(self_);                                    \
-      if (self.is_contiguous()) {                                           \
-        op##Impl(self, self);                                               \
-      } else {                                                              \
-        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
-          CPU_tensor_parallel_apply1<scalar_t>(                             \
-              self, [](scalar_t& y) { y = opfn(y); });                      \
-        });                                                                 \
-      }                                                                     \
-    }                                                                       \
-    return self_;                                                           \
-  }                                                                         \
-  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) {             \
-    result.resize_(self.sizes());                                           \
-    if (result.numel() > 0) {                                               \
-      if (result.is_contiguous() && self.is_contiguous()) {                 \
-        op##Impl(result, self);                                             \
-      } else {                                                              \
-        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
-          CPU_tensor_parallel_apply2<scalar_t, scalar_t>(                   \
-              result, self, [](scalar_t& y, scalar_t& x) { y = opfn(x); }); \
-        });                                                                 \
-      }                                                                     \
-    }                                                                       \
-    return result;                                                          \
+#define IMPLEMENT_UNARY_OP_VEC(op, opfn)                        \
+  Tensor& _##op##__cpu(Tensor& self_) {                         \
+    if (self_.numel() > 0) {                                    \
+      Tensor self = sort_strides(self_);                        \
+      if (self.is_contiguous()) {                               \
+        op##Impl(self, self);                                   \
+      } else {                                                  \
+        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {       \
+          CPU_tensor_parallel_apply1<scalar_t>(                 \
+              self, [](scalar_t& y) { y = opfn(y); }, 1024);    \
+        });                                                     \
+      }                                                         \
+    }                                                           \
+    return self_;                                               \
+  }                                                             \
+  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) { \
+    result.resize_(self.sizes());                               \
+    if (result.numel() > 0) {                                   \
+      if (result.is_contiguous() && self.is_contiguous()) {     \
+        op##Impl(result, self);                                 \
+      } else {                                                  \
+        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {       \
+          CPU_tensor_parallel_apply2<scalar_t, scalar_t>(       \
+              result,                                           \
+              self,                                             \
+              [](scalar_t& y, scalar_t& x) { y = opfn(x); },    \
+              1024);                                            \
+        });                                                     \
+      }                                                         \
+    }                                                           \
+    return result;                                              \
   }
 
 IMPLEMENT_UNARY_OP_PREQUEL(abs)

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -17,18 +17,20 @@ static inline int64_t round_down(int64_t a, int64_t m) {
   return a - (a % m);
 }
 
-template<typename F>
-static void parallel_for(int64_t end, int64_t step, bool parallelize, F func) {
-  if (parallelize) {
-    tbb::parallel_for<int64_t>(0, end, step, func);
-  } else {
-    for (int64_t i = 0; i != end; i += step) {
-      func(i);
-    }
-  }
+template <typename F>
+static void parallel_for(int64_t size, int64_t step, bool parallelize, F func) {
+  parallel_for_1d(
+      [func, step](int64_t begin, int64_t end) {
+        int64_t k = begin * step;
+        for (int64_t i = begin; i < end; i++, k += step) {
+          func(k);
+        }
+      },
+      0,
+      size / step,
+      1,
+      parallelize);
 }
-
-static default_partitioner_type ap;
 
 // Vectorized reduction defined by reduce operation `Op` with identity `ident`.
 // The reduction is built on top of reduce128, which reduces down a column
@@ -44,8 +46,6 @@ struct Reduction {
   using ReduceScalar = Op<scalar_t>;
 
   static void apply(Tensor& res, const Tensor& self, at::optional<int64_t> dim) {
-    internal::init_tbb_num_threads();
-
     auto out = res.data<scalar_t>();
     auto data = self.data<scalar_t>();
     auto numel = self.numel();
@@ -80,16 +80,17 @@ struct Reduction {
 
     scalar_t sum;
     if (size > internal::TBB_GRAIN_SIZE) {
-      sum = tbb::parallel_reduce(
-          tbb::blocked_range<int64_t>(0, k, internal::TBB_GRAIN_SIZE / WIDTH),
-          scalar_t(ident),
-          [=](const tbb::blocked_range<int64_t>& r, scalar_t init) {
+      sum = parallel_reduce_1d(
+          [data](int64_t begin, int64_t end, scalar_t init) {
             scalar_t buf[WIDTH];
-            reduce128(&data[r.begin() * WIDTH], buf, r.end() - r.begin(), WIDTH);
+            reduce128(&data[begin * WIDTH], buf, end - begin, WIDTH);
             return std::accumulate(buf, buf + WIDTH, init, ReduceScalar());
           },
           ReduceScalar(),
-          ap);
+          (scalar_t)ident,
+          0,
+          k,
+          internal::TBB_GRAIN_SIZE / WIDTH);
     } else {
       scalar_t buf[WIDTH];
       reduce128(data, buf, k, WIDTH);

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -22,8 +22,6 @@
 namespace at { namespace native {
 namespace {
 
-static default_partitioner_type ap;
-
 template <typename scalar_t>
 inline void _vec_log_softmax_lastdim(
     scalar_t* input_data_base,
@@ -32,19 +30,18 @@ inline void _vec_log_softmax_lastdim(
     int64_t dim_size) {
   using Vec = vec256::Vec256<scalar_t>;
   static constexpr int64_t CHUNK_SIZE = (128 / sizeof(scalar_t)) * Vec::size;
-  int64_t grain_size = internal::TBB_GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  int64_t grain_size = 2048 / dim_size;
   if (grain_size < CHUNK_SIZE)
     grain_size = CHUNK_SIZE;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t ii = r.begin(); ii < r.end(); ii += CHUNK_SIZE) {
+  parallel_for_1d(
+      [&](int64_t begin, int64_t end) {
+        for (int64_t ii = begin; ii < end; ii += CHUNK_SIZE) {
           scalar_t tmp_sum_scalar[CHUNK_SIZE];
           scalar_t max_input_arr[CHUNK_SIZE];
           int64_t loop_end = CHUNK_SIZE;
-          if (ii + CHUNK_SIZE > r.end())
-            loop_end = r.end() - ii;
+          if (ii + CHUNK_SIZE > end)
+            loop_end = end - ii;
           for (int64_t j = 0; j < loop_end; j++) {
             int64_t i = ii + j;
             scalar_t* input_data = input_data_base + i * dim_size;
@@ -84,7 +81,9 @@ inline void _vec_log_softmax_lastdim(
           }
         }
       },
-      ap);
+      0,
+      outer_size,
+      grain_size);
 }
 
 template <typename scalar_t>
@@ -94,14 +93,13 @@ inline void _vec_softmax_lastdim(
     int64_t outer_size,
     int64_t dim_size) {
   using Vec = vec256::Vec256<scalar_t>;
-  int64_t grain_size = internal::TBB_GRAIN_SIZE / (16 * dim_size);
+  int64_t grain_size = 2048 / dim_size;
   if (grain_size < 1)
     grain_size = 1;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for_1d(
+      [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           scalar_t* input_data = input_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
           scalar_t max_input = vec256::reduce_all<scalar_t>(
@@ -123,7 +121,9 @@ inline void _vec_softmax_lastdim(
               dim_size);
         }
       },
-      ap);
+      0,
+      outer_size,
+      grain_size);
 }
 
 template <typename scalar_t, bool log_softmax>
@@ -138,10 +138,9 @@ inline void _vec_host_softmax_backward_lastdim(
   if (grain_size < 1)
     grain_size = 1;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for_1d(
+      [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           scalar_t* grad_input_data = grad_input_data_base + i * dim_size;
           scalar_t* grad_data = grad_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
@@ -174,13 +173,14 @@ inline void _vec_host_softmax_backward_lastdim(
           }
         }
       },
-      ap);
+      0,
+      outer_size,
+      grain_size);
 }
 
 template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_lastdim {
   static void apply(Tensor& output, const Tensor& input) {
-    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = input.size(input.ndimension() - 1);
     for (int64_t i = 0; i < input.ndimension() - 1; ++i)
@@ -201,7 +201,6 @@ template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_backward_lastdim {
   static void
   apply(Tensor& grad_input, const Tensor& grad, const Tensor& output) {
-    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = grad.size(grad.ndimension() - 1);
     for (int64_t i = 0; i < grad.ndimension() - 1; ++i)

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -15,23 +15,16 @@ using namespace vec256;
 
 template <class scalar_t, class F>
 static void parallel_apply(Tensor& result, const Tensor& self, F f) {
-  internal::init_tbb_num_threads();
-
-static default_partitioner_type ap;
-
   auto arr_out = result.data<scalar_t>();
   auto arr_in = self.data<scalar_t>();
   int64_t size = self.numel();
-  if (size < internal::TBB_GRAIN_SIZE) {
-    map(f, arr_out, arr_in, size);
-  } else {
-    tbb::parallel_for(
-        tbb::blocked_range<int64_t>(0, size, internal::TBB_GRAIN_SIZE),
-        [&](const tbb::blocked_range<int64_t>& r) {
-          map(f, arr_out + r.begin(), arr_in + r.begin(), r.end() - r.begin());
-        },
-        ap);
-  }
+  parallel_for_1d(
+      [arr_out, arr_in, f](int64_t begin, int64_t end) {
+        map(f, arr_out + begin, arr_in + begin, end - begin);
+      },
+      0,
+      size,
+      1024);
 }
 
 static void abs_kernel(Tensor& result, const Tensor& self) {


### PR DESCRIPTION
Will add more timings soon.

For now consider

```
$ cat flavortown.py
import torch
import time
import gc

if __name__ == "__main__":
    tstart = time.time()
    gc.collect()
    numbers = torch.randn(100, 100).type('torch.FloatTensor')
    gc.collect()

    torch.set_num_threads(16)
    tstart = time.time()
    for _ in range(50000):
        numbers = numbers.transpose(0, 1)
        numbers = numbers.tanh()
    print("elapsed: " + str(time.time() - tstart))
```

This branch
```
$ MKL_NUM_THREADS=16 OMP_NUM_THREADS=16 numactl --membind=0 --cpunodebind=0 python flavortown.py
elapsed: 1.73970794678
```

Master
```
$ MKL_NUM_THREADS=16 OMP_NUM_THREADS=16 numactl --membind=0 --cpunodebind=0 python flavortown.py
elapsed: 9.53220701218
```

