### PR TITLE
cache and use BLAS_SET_BY_USER so that it doesn't set itself to TRUE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,16 @@ set(CAFFE2_VERSION
 #    endif()
 set(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO ON)
 
-if(DEFINED BLAS)
-  set(BLAS_SET_BY_USER TRUE)
-else()
-  message(STATUS "Not forcing any particular BLAS to be found")
-  set(BLAS_SET_BY_USER FALSE)
+if(NOT DEFINED BLAS_SET_BY_USER)
+  if(DEFINED BLAS)
+    set(BLAS_SET_BY_USER TRUE)
+  else()
+    message(STATUS "Not forcing any particular BLAS to be found")
+    set(BLAS_SET_BY_USER FALSE)
+  endif()
+  set(BLAS_SET_BY_USER ${BLAS_SET_BY_USER} CACHE STRING "Marks whether BLAS was manually set by user or auto-detected")
 endif()
+
 # ---[ Options.
 # Note to developers: if you add an option below, make sure you also add it to
 # cmake/Summary.cmake so that the summary prints out the option values.


### PR DESCRIPTION
cache and use BLAS_SET_BY_USER so that it doesn't set itself to TRUE when run a second time.

This fixes the issue that if you run cmake a second time, but you dont actually have MKL in your environment, then cmake errors out.

The blas detection is still quite hairy and needs to be converged. I can get to that as a follow-up.

Things that need to be fixed:

- If MKL is not found, Caffe2 and PyTorch end up using different BLAS libs, because Caffe2 uses Eigen and PyTorch ends up finding whatever is the system BLAS (like openblas, Accelerate, cblas, etc.).
- The PyTorch/Caffe2 blas detection logic is different (so has risks of divergence)
- BLAS detection overlaps with library detection
  - Caffe2 and PyTorch detect Eigen and MKL as "BLAS" / "LAPACK" libs, but they actually end up special-casing these libs and use additional functionality (including the headers). This needs to be cleaned up.
