### PR TITLE
Prevent git autocrlf for bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# BASH scripts shouldn't be converted since they may need to be used by Docker
+*.sh text eol=lf


### PR DESCRIPTION
Git for Windows by default auto-translates the line endings. This unfortunately breaks Docker builds since the `.sh` scripts have the wrong line endings.
The custom `.gitattributes` file prevents that from happening. See also [here](https://help.github.com/articles/dealing-with-line-endings/).