### PR TITLE
Make THStorage / THCStorage have void* data ptr.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3751,7 +3751,7 @@
     if (nDimV == -1) {
       nDimV = self._values().dim() - 1;
     }
-    ${THTensor}_rawResize(${state,}self_->tensor, nDimI, nDimV, (*size_).data);
+    ${THTensor}_rawResize(${state,}self_->tensor, nDimI, nDimV, (*size_).data<int64_t>());
     self_->maybeScalar(size.size() == 0);
 ]]
 

--- a/aten/src/ATen/ScalarTypeUtils.h
+++ b/aten/src/ATen/ScalarTypeUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ATen/ScalarType.h"
+
 namespace at {
 
 template <typename T>

--- a/aten/src/ATen/ScalarTypeUtils.h
+++ b/aten/src/ATen/ScalarTypeUtils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace at {
+
+template <typename T>
+struct CTypeToScalarType {
+  static at::ScalarType to();
+};
+
+#define DEFINE_TO_SCALAR_TYPE(ct, st, _2)                          \
+template <>                                                        \
+struct CTypeToScalarType<ct> {                                     \
+  static inline at::ScalarType to() { return at::ScalarType::st; } \
+};
+AT_FORALL_SCALAR_TYPES(DEFINE_TO_SCALAR_TYPE)
+#undef DEFINE_TO_SCALAR_TYPE
+
+} // namespace at

--- a/aten/src/ATen/ScalarTypeUtils.h
+++ b/aten/src/ATen/ScalarTypeUtils.h
@@ -6,7 +6,6 @@ namespace at {
 
 template <typename T>
 struct CTypeToScalarType {
-  static at::ScalarType to();
 };
 
 #define DEFINE_TO_SCALAR_TYPE(ct, st, _2)                          \

--- a/aten/src/ATen/THLongStorageView.h
+++ b/aten/src/ATen/THLongStorageView.h
@@ -2,6 +2,7 @@
 
 #include "TH/TH.h"
 #include "TH/THStorage.hpp"
+#include "TH/THTypeConversion.hpp"
 
 namespace at {
 
@@ -72,16 +73,17 @@ public:
       // make storage of size 0 actually a 1-length storage with 1 element
       // so that our 0-dim tensors get allocated as 1-dim inside TH
       one = 1;
-      storage.data = &one;
+      storage.data_ptr = &one;
       storage.size = 1;
     } else if (noelem_to_empty && is_noelem_tensor_size(ref)) {
-      storage.data = (int64_t*)(ref.data());
+      storage.data_ptr = (void*)(ref.data());
       storage.size = 0;
     }
     else {
-      storage.data = (int64_t*)(ref.data());
+      storage.data_ptr = (void*)(ref.data());
       storage.size = ref.size();
     }
+    storage.scalar_type = at::CTypeToScalarType<th::from_type<int64_t>>::to();
     storage.refcount = 0;
     storage.flag = 0;
     storage.allocator = nullptr;

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -164,7 +164,7 @@ auto ${Storage}::get(std::size_t ind) -> Scalar {
 auto ${Storage}::fast_get(std::size_t ind) -> Scalar {
   if(${isCUDA})
     throw std::runtime_error("unsupported operation 'fast_get'");
-  return static_cast<${ScalarType}>(${to_at_type}(storage->unsafeData<${THScalarType}>()[ind]));
+  return static_cast<${ScalarType}>(${to_at_type}(storage->unsafe_data<${THScalarType}>()[ind]));
 }
 
 void ${Storage}::set_flag(char flag) {

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -113,11 +113,11 @@ std::size_t ${Storage}::size() const {
 }
 
 void* ${Storage}::data() {
-  return storage->data;
+  return storage->data_ptr;
 }
 
 const void* ${Storage}::data() const {
-  return storage->data;
+  return storage->data_ptr;
 }
 
 auto ${Storage}::retain() -> ${Storage}& {
@@ -164,7 +164,7 @@ auto ${Storage}::get(std::size_t ind) -> Scalar {
 auto ${Storage}::fast_get(std::size_t ind) -> Scalar {
   if(${isCUDA})
     throw std::runtime_error("unsupported operation 'fast_get'");
-  return static_cast<${ScalarType}>(${to_at_type}(storage->data[ind]));
+  return static_cast<${ScalarType}>(${to_at_type}(storage->unsafeData<${THScalarType}>()[ind]));
 }
 
 void ${Storage}::set_flag(char flag) {

--- a/aten/src/TH/CMakeLists.txt
+++ b/aten/src/TH/CMakeLists.txt
@@ -94,6 +94,7 @@ INSTALL(FILES
   THTensor.hpp
   THStorage.hpp
   THGenerator.hpp
+  THTypeConversion.hpp
   DESTINATION "${ATEN_INSTALL_INCLUDE_SUBDIR}/TH")
 
 INSTALL(FILES

--- a/aten/src/TH/THFile.cpp
+++ b/aten/src/TH/THFile.cpp
@@ -140,12 +140,12 @@ IMPLEMENT_THFILE_SCALAR(Half, THHalf)
 #define IMPLEMENT_THFILE_STORAGE(TYPEC, TYPE)                           \
   size_t THFile_read##TYPEC(THFile *self, TH##TYPEC##Storage *storage)    \
   {                                                                     \
-    return THFile_read##TYPEC##Raw(self, storage->data, storage->size); \
+    return THFile_read##TYPEC##Raw(self, TH##TYPEC##Storage_data(storage), storage->size); \
   }                                                                     \
                                                                         \
   size_t THFile_write##TYPEC(THFile *self, TH##TYPEC##Storage *storage)   \
   {                                                                     \
-    return THFile_write##TYPEC##Raw(self, storage->data, storage->size); \
+    return THFile_write##TYPEC##Raw(self, TH##TYPEC##Storage_data(storage), storage->size); \
   }
 
 IMPLEMENT_THFILE_STORAGE(Byte, uint8_t)

--- a/aten/src/TH/THStorage.cpp
+++ b/aten/src/TH/THStorage.cpp
@@ -14,7 +14,7 @@
 
 
 THDescBuff THLongStorage_sizeDesc(const THLongStorage *size) {
-  return _THSizeDesc(size->data, size->size);
+  return _THSizeDesc(THLongStorage_data(size), size->size);
 }
 
 THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElement)
@@ -23,11 +23,11 @@ THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElemen
   ptrdiff_t dim_infer = -1;
   ptrdiff_t i;
   for (i = 0; i < size->size; i++) {
-    if (size->data[i] == -1) {
+    if (THLongStorage_data(size)[i] == -1) {
       THArgCheck(dim_infer == -1, 1, "only one dimension can be inferred");
       dim_infer = i;
     } else {
-      total_size *= size->data[i];
+      total_size *= THLongStorage_data(size)[i];
     }
   }
   if (dim_infer != -1) {
@@ -42,7 +42,7 @@ THLongStorage *THLongStorage_newInferSize(THLongStorage *size, ptrdiff_t nElemen
   THLongStorage* copy = THLongStorage_newWithSize(size->size);
   THLongStorage_copy(copy, size);
   if (dim_infer != -1) {
-    copy->data[dim_infer] = nElement / total_size;
+    THLongStorage_data(copy)[dim_infer] = nElement / total_size;
   }
   return copy;
 }

--- a/aten/src/TH/THStorage.hpp
+++ b/aten/src/TH/THStorage.hpp
@@ -5,6 +5,9 @@
 
 #include "THStorage.h"
 
+#include "ATen/ScalarType.h"
+#include "ATen/ScalarTypeUtils.h"
+#include "THTypeConversion.hpp"
 #include <atomic>
 
 #include "generic/THStorage.hpp"

--- a/aten/src/TH/THTensorApply.h
+++ b/aten/src/TH/THTensorApply.h
@@ -43,7 +43,7 @@
     TH_TENSOR_APPLY_hasFinished = 1; \
   else \
   { \
-    TENSOR##_data = TENSOR->storage->data+TENSOR->storageOffset; \
+    TENSOR##_data = TENSOR->storage->data<TYPE>()+TENSOR->storageOffset; \
     TENSOR##_size = 1; \
     TENSOR##_stride = 1; \
     for(TENSOR##_i = TENSOR->nDimension-1; TENSOR##_i >= 0; TENSOR##_i--) { \
@@ -320,9 +320,9 @@
 {\
   int TENSOR##Contg = THTensor_(isContiguous)(TENSOR);                      \
   ptrdiff_t TENSOR##Size = THTensor_(nElement)(TENSOR);                     \
-  if(TENSOR##Contg){                                                         \
-    ptrdiff_t iter = 0;                                                         \
-    TYPE *rp = TENSOR->storage->data+TENSOR->storageOffset;                   \
+  if(TENSOR##Contg){                                                        \
+    ptrdiff_t iter = 0;                                                     \
+    TYPE *rp = TENSOR->storage->data<TYPE>()+TENSOR->storageOffset;         \
     PRAGMA( omp parallel for if (TENSOR##Size > OMP_THRESHOLD * 10) firstprivate(rp) reduction(OPERATION) ) \
     for (iter = 0; iter < TENSOR##Size; iter++) { \
       TYPE *TENSOR##_data = rp+iter;                    \
@@ -366,8 +366,8 @@
 {                                                                                              \
   /* for advanced searching index*/                                                            \
   if( CONTIG1 && CONTIG2 ){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data+TENSOR1->storageOffset;                                    \
-    TYPE2 *tp = TENSOR2->storage->data+TENSOR2->storageOffset;                                    \
+    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storageOffset;                        \
+    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storageOffset;                        \
     ptrdiff_t iter = 0;                                                                        \
     if(tp != rp) {                                                                             \
       PRAGMA(ivdep) \
@@ -445,9 +445,9 @@
 {                                                                             \
   /* for adveanced searching index*/                                                                    \
   if(CONTIG1 && CONTIG2 && CONTIG3){                                                                    \
-    TYPE1 *rp = TENSOR1->storage->data+TENSOR1->storageOffset;                                             \
-    TYPE2 *tp = TENSOR2->storage->data+TENSOR2->storageOffset;                                             \
-    TYPE3 *srcp = TENSOR3->storage->data+TENSOR3->storageOffset;                                           \
+    TYPE1 *rp = TENSOR1->storage->data<TYPE1>()+TENSOR1->storageOffset;                                 \
+    TYPE2 *tp = TENSOR2->storage->data<TYPE2>()+TENSOR2->storageOffset;                                 \
+    TYPE3 *srcp = TENSOR3->storage->data<TYPE3>()+TENSOR3->storageOffset;                               \
     ptrdiff_t iter = 0;\
     if (rp != tp) { \
       PRAGMA(ivdep) \

--- a/aten/src/TH/THTensorDimApply.h
+++ b/aten/src/TH/THTensorDimApply.h
@@ -65,15 +65,15 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data+(TENSOR1)->storageOffset; \
+  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
   TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
   TENSOR1##_size = TENSOR1->size[DIMENSION]; \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data+(TENSOR2)->storageOffset; \
+  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
   TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
   TENSOR2##_size = TENSOR2->size[DIMENSION]; \
 \
-  TENSOR3##_data = (TENSOR3)->storage->data+(TENSOR3)->storageOffset; \
+  TENSOR3##_data = (TENSOR3)->storage->data<TYPE3>()+(TENSOR3)->storageOffset; \
   TENSOR3##_stride = (TENSOR3)->stride[DIMENSION]; \
   TENSOR3##_size = TENSOR3->size[DIMENSION]; \
 \
@@ -175,11 +175,11 @@
   for(TH_TENSOR_DIM_APPLY_i = 0; TH_TENSOR_DIM_APPLY_i < TENSOR1->nDimension; TH_TENSOR_DIM_APPLY_i++) \
     TH_TENSOR_DIM_APPLY_counter[TH_TENSOR_DIM_APPLY_i] = 0; \
 \
-  TENSOR1##_data = (TENSOR1)->storage->data+(TENSOR1)->storageOffset; \
+  TENSOR1##_data = (TENSOR1)->storage->data<TYPE1>()+(TENSOR1)->storageOffset; \
   TENSOR1##_stride = (TENSOR1)->stride[DIMENSION]; \
   TENSOR1##_size = TENSOR1->size[DIMENSION]; \
 \
-  TENSOR2##_data = (TENSOR2)->storage->data+(TENSOR2)->storageOffset; \
+  TENSOR2##_data = (TENSOR2)->storage->data<TYPE2>()+(TENSOR2)->storageOffset; \
   TENSOR2##_stride = (TENSOR2)->stride[DIMENSION]; \
   TENSOR2##_size = TENSOR2->size[DIMENSION]; \
 \
@@ -277,7 +277,7 @@
   if( (DIMENSION < 0) || (DIMENSION >= TENSOR->nDimension) ) \
     THError("invalid dimension"); \
 \
-  TENSOR##_data = (TENSOR)->storage->data+(TENSOR)->storageOffset; \
+  TENSOR##_data = (TENSOR)->storage->data<TYPE>()+(TENSOR)->storageOffset; \
   TENSOR##_stride = (TENSOR)->stride[DIMENSION]; \
   TENSOR##_size = TENSOR->size[DIMENSION]; \
   /* Counter stores the indices into the Tensor at any time */ \

--- a/aten/src/TH/THTypeConversion.hpp
+++ b/aten/src/TH/THTypeConversion.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <ATen/Half.h>
+#include "THHalf.h"
+
+// Type traits to convert types to TH-specific types. Used primarily to
+// convert at::Half to TH's half type. This makes the conversion explicit.
+// FIXME: we should just use the same type
+
+namespace th {
+
+template <typename T>
+struct FromTypeConversion {
+  using type = T;
+};
+
+template <>
+struct FromTypeConversion<THHalf> {
+  using type = at::Half;
+};
+
+template <typename T>
+using from_type = typename FromTypeConversion<T>::type;
+}

--- a/aten/src/TH/generic/THStorage.hpp
+++ b/aten/src/TH/generic/THStorage.hpp
@@ -12,19 +12,19 @@ typedef struct THStorage
     THAllocator *allocator;
     void *allocatorContext;
     struct THStorage *view;
-    template <typename T>
 
+    template <typename T>
     inline T * data() const {
       auto scalar_type_T = at::CTypeToScalarType<th::from_type<T>>::to();
       if (scalar_type != scalar_type_T) {
         AT_ERROR("Attempt to access Storage having data type ", at::toString(scalar_type),
                  " as data type ", at::toString(scalar_type_T));
       }
-      return unsafeData<T>();
+      return unsafe_data<T>();
     }
 
     template <typename T>
-    inline T * unsafeData() const {
+    inline T * unsafe_data() const {
       return static_cast<T*>(this->data_ptr);
     }
 } THStorage;

--- a/aten/src/TH/generic/THStorage.hpp
+++ b/aten/src/TH/generic/THStorage.hpp
@@ -4,13 +4,29 @@
 
 typedef struct THStorage
 {
-    real *data;
+    at::ScalarType scalar_type;
+    void *data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     char flag;
     THAllocator *allocator;
     void *allocatorContext;
     struct THStorage *view;
+    template <typename T>
+
+    inline T * data() const {
+      auto scalar_type_T = at::CTypeToScalarType<th::from_type<T>>::to();
+      if (scalar_type != scalar_type_T) {
+        AT_ERROR("Attempt to access Storage having data type ", at::toString(scalar_type),
+                 " as data type ", at::toString(scalar_type_T));
+      }
+      return unsafeData<T>();
+    }
+
+    template <typename T>
+    inline T * unsafeData() const {
+      return static_cast<T*>(this->data_ptr);
+    }
 } THStorage;
 
 #endif

--- a/aten/src/TH/generic/THStorageCopy.cpp
+++ b/aten/src/TH/generic/THStorageCopy.cpp
@@ -16,8 +16,8 @@ void THStorage_(copy)(THStorage *storage, THStorage *src)
   THStorage_(rawCopy)(storage, THStorage_(data)(src));
 }
 
-// NOTE: for performance, these macros generally directly access data, rather
-// than THStorage_(data)ß
+// NOTE: for performance, these macros generally use the raw data pointer in the inner loops,
+// rather than repeated THStorage_(data) calls.
 
 #define IMPLEMENT_THStorage_COPY(TYPENAMESRC) \
 void THStorage_(copy##TYPENAMESRC)(THStorage *storage, TH##TYPENAMESRC##Storage *src) \

--- a/aten/src/TH/generic/THStorageCopy.cpp
+++ b/aten/src/TH/generic/THStorageCopy.cpp
@@ -5,22 +5,28 @@
 void THStorage_(rawCopy)(THStorage *storage, real *src)
 {
   ptrdiff_t i;
+  real *data = THStorage_(data)(storage);
   for(i = 0; i < storage->size; i++)
-    storage->data[i] = src[i];
+    data[i] = src[i];
 }
 
 void THStorage_(copy)(THStorage *storage, THStorage *src)
 {
   THArgCheck(storage->size == src->size, 2, "size mismatch");
-  THStorage_(rawCopy)(storage, src->data);
+  THStorage_(rawCopy)(storage, THStorage_(data)(src));
 }
+
+// NOTE: for performance, these macros generally directly access data, rather
+// than THStorage_(data)ß
 
 #define IMPLEMENT_THStorage_COPY(TYPENAMESRC) \
 void THStorage_(copy##TYPENAMESRC)(THStorage *storage, TH##TYPENAMESRC##Storage *src) \
 { \
-  ptrdiff_t i;                                                        \
-  for(i = 0; i < storage->size; i++)                                  \
-    storage->data[i] = (real)src->data[i];                            \
+  ptrdiff_t i;                                                          \
+  auto data = THStorage_(data)(storage);                                \
+  auto src_data = TH##TYPENAMESRC##Storage_data(src);                   \
+  for(i = 0; i < storage->size; i++)                                    \
+    data[i] = static_cast<real>(src_data[i]);                           \
 }
 
 #define IMPLEMENT_THStorage_COPY_FROM_HALF(TYPENAMESRC)		\
@@ -28,8 +34,10 @@ void THStorage_(copy##TYPENAMESRC)(THStorage *storage, TH##TYPENAMESRC##Storage 
 { \
   THArgCheck(storage->size == src->size, 2, "size mismatch"); \
   ptrdiff_t i;								\
+  auto data = THStorage_(data)(storage);      \
+  auto src_data = TH##TYPENAMESRC##Storage_data(src); \
   for(i = 0; i < storage->size; i++)					\
-    storage->data[i] = (real)TH_half2float(src->data[i]);		\
+    data[i] = (real)TH_half2float(src_data[i]); \
 }
 
 #define IMPLEMENT_THStorage_COPY_TO_HALF(TYPENAMESRC)		\
@@ -37,8 +45,10 @@ void THStorage_(copy##TYPENAMESRC)(THStorage *storage, TH##TYPENAMESRC##Storage 
 { \
   THArgCheck(storage->size == src->size, 2, "size mismatch"); \
   ptrdiff_t i;								\
+  auto data = THStorage_(data)(storage);      \
+  auto src_data = TH##TYPENAMESRC##Storage_data(src); \
   for(i = 0; i < storage->size; i++)					\
-    storage->data[i] = TH_float2half((float)(src->data[i]));		\
+    data[i] = TH_float2half((float)(src_data[i])); \
 }
 
 #define IMPLEMENT_THStorage_COPY_TO_FROM_HALF(TYPENAMESRC)		\
@@ -46,8 +56,10 @@ void THStorage_(copy##TYPENAMESRC)(THStorage *storage, TH##TYPENAMESRC##Storage 
 { \
   THArgCheck(storage->size == src->size, 2, "size mismatch"); \
   ptrdiff_t i;								\
+  auto data = THStorage_(data)(storage);      \
+  auto src_data = TH##TYPENAMESRC##Storage_data(src); \
   for(i = 0; i < storage->size; i++)					\
-    storage->data[i] = src->data[i];		\
+    data[i] = static_cast<real>(src_data[i]); \
 }
 
 #ifndef TH_REAL_IS_HALF

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -51,7 +51,7 @@ THLongStorage *THTensor_(newStrideOf)(THTensor *self)
 real *THTensor_(data)(const THTensor *self)
 {
   if(self->storage)
-    return (self->storage->data+self->storageOffset);
+    return (THStorage_(data)(self->storage)+self->storageOffset);
   else
     return NULL;
 }
@@ -108,8 +108,8 @@ THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
                           storage,
                           storageOffset,
                           (size ? size->size : (stride ? stride->size : 0)),
-                          (size ? size->data : NULL),
-                          (stride ? stride->data : NULL));
+                          (size ? THLongStorage_data(size) : NULL),
+                          (stride ? THLongStorage_data(stride) : NULL));
 
   return self;
 }
@@ -252,9 +252,9 @@ static int THTensor_(isViewable)(THTensor *tensor, THLongStorage *view_size, THL
     // if end of tensor size chunk, check view
     if ((tensor_d == 0) ||
         (tensor->size[tensor_d - 1] != 1 && tensor->stride[tensor_d - 1] != tensor_numel * chunk_base_stride)) {
-      while (view_d >= 0 && (view_numel < tensor_numel || view_size->data[view_d] == 1)) {
-        new_stride->data[view_d] = view_numel * chunk_base_stride;
-        view_numel *= view_size->data[view_d];
+      while (view_d >= 0 && (view_numel < tensor_numel || THLongStorage_data(view_size)[view_d] == 1)) {
+        THLongStorage_data(new_stride)[view_d] = view_numel * chunk_base_stride;
+        view_numel *= THLongStorage_data(view_size)[view_d];
         view_d--;
       }
       if (view_numel != tensor_numel) {
@@ -296,7 +296,7 @@ void THTensor_(resize)(THTensor *self, THLongStorage *size, THLongStorage *strid
 #ifdef DEBUG
   THAssert(size->size <= INT_MAX);
 #endif
-  THTensor_(resizeNd)(self, size->size, size->data, (stride ? stride->data : NULL));
+  THTensor_(resizeNd)(self, size->size, THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
 }
 
 void THTensor_(resizeAs)(THTensor *self, THTensor *src)
@@ -357,8 +357,8 @@ void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storag
                           storage_,
                           storageOffset_,
                           (size_ ? size_->size : (stride_ ? stride_->size : 0)),
-                          (size_ ? size_->data : NULL),
-                          (stride_ ? stride_->data : NULL));
+                          (size_ ? THLongStorage_data(size_) : NULL),
+                          (stride_ ? THLongStorage_data(stride_) : NULL));
 }
 
 void THTensor_(setStorage1d)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
@@ -644,7 +644,7 @@ int THTensor_(isSize)(const THTensor *self, const THLongStorage *dims)
 
   for(d = 0; d < self->nDimension; ++d)
   {
-    if(self->size[d] != dims->data[d])
+    if(self->size[d] != THLongStorage_data(dims)[d])
       return 0;
   }
   return 1;

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -325,7 +325,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
 #ifdef DEBUG
   THAssert(numel <= LONG_MAX);
 #endif
-  newSize->data[dim] = numel;
+  THLongStorage_data(newSize)[dim] = numel;
   THTensor_(resize)(tensor,newSize,NULL);
   THLongStorage_free(newSize);
 
@@ -3650,7 +3650,7 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
     if (dim == cat_dimension) {
       result_dim_size = cat_dim_size;
     }
-    size->data[dim] = result_dim_size;
+    THLongStorage_data(size)[dim] = result_dim_size;
   }
   THTensor_(resize)(result, size, NULL);
 
@@ -3667,12 +3667,12 @@ void THTensor_(catArray)(THTensor *result, THTensor **inputs, int numInputs, int
   // Second path for non-contiguous
   int64_t offset;
   if (cat_dimension == 0 && allContiguous) {
-    real* result_data = result->storage->data + result->storageOffset;
+    real* result_data = THStorage_(data)(result->storage) + result->storageOffset;
     offset = 0;
     for (int j = 0; j < numInputs; j++) {
       if (inputs[j]->nDimension) {
         THTensor* input0 = inputs[j];
-        real* input0_data = input0->storage->data + input0->storageOffset;
+        real* input0_data = THStorage_(data)(input0->storage) + input0->storageOffset;
         int64_t input0_size = THTensor_(nElement)(input0);
         memcpy(result_data + offset, input0_data, input0_size*sizeof(real));
         offset += input0_size;

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -103,7 +103,7 @@ void THTensor_(normal)(THTensor *self, THGenerator *_generator, double mean, dou
   std::lock_guard<std::mutex> lock(_generator->mutex);
   const int64_t size = THTensor_(numel)(self);
   if (size >= 16 && THTensor_(isContiguous)(self)) {
-    THVector_(normal_fill)(self->storage->data, size, _generator, mean, stddev);
+    THVector_(normal_fill)(THStorage_(data)(self->storage), size, _generator, mean, stddev);
   } else {
     TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_normal(_generator, mean, stddev););
   }

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -5,6 +5,9 @@
 
 #include "THCStorage.h"
 
+#include "ATen/ScalarType.h"
+#include "ATen/ScalarTypeUtils.h"
+#include "ATen/cuda/CUDATypeConversion.cuh"
 #include <atomic>
 
 #include "generic/THCStorage.hpp"

--- a/aten/src/THC/generic/THCStorage.cu
+++ b/aten/src/THC/generic/THCStorage.cu
@@ -5,7 +5,7 @@
 void THCStorage_(fill)(THCState *state, THCStorage *self, real value)
 {
   THCThrustAllocator thrustAlloc(state);
-  thrust::device_ptr<real> self_data(self->data);
+  thrust::device_ptr<real> self_data(THCStorage_(data)(state, self));
   thrust::fill(
 #if CUDA_VERSION >= 7000
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
@@ -24,9 +24,10 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
     THError("Trying to resize storage that is not resizable");
 
   if (self->allocator->realloc) {
+    real * data_ptr = self->data<real>();
     cudaError_t err = (*self->allocator->realloc)(
       self->allocatorContext,
-      (void**)&(self->data),
+      (void**)&(data_ptr),
       self->size * sizeof(real),
       size * sizeof(real), THCState_getCurrentStream(state));
     if (err != cudaSuccess) {
@@ -41,9 +42,9 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
   {
     if(self->flag & TH_STORAGE_FREEMEM) {
       THCudaCheck(
-        (*self->allocator->free)(self->allocatorContext, self->data));
+        (*self->allocator->free)(self->allocatorContext, THCStorage_(data)(state, self)));
     }
-    self->data = NULL;
+    self->data_ptr = NULL;
     self->size = 0;
     self->device = device;
   }
@@ -57,22 +58,22 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
                                  THCState_getCurrentStream(state));
     THCudaCheck(err);
 
-    if (self->data) {
+    if (THCStorage_(data)(state, self)) {
       // Enable p2p access when the memcpy is across devices
       THCState_getPeerToPeerAccess(state, device, self->device);
 
       THCudaCheck(cudaMemcpyAsync(data,
-                                  self->data,
+                                  THCStorage_(data)(state, self),
                                   THMin(self->size, size) * sizeof(real),
                                   cudaMemcpyDeviceToDevice,
                                   THCState_getCurrentStream(state)));
       if(self->flag & TH_STORAGE_FREEMEM) {
         THCudaCheck(
-          (*self->allocator->free)(self->allocatorContext, self->data));
+          (*self->allocator->free)(self->allocatorContext, THCStorage_(data)(state, self)));
       }
     }
 
-    self->data = data;
+    self->data_ptr = data;
     self->size = size;
     self->device = device;
   }

--- a/aten/src/THC/generic/THCStorage.hpp
+++ b/aten/src/THC/generic/THCStorage.hpp
@@ -4,7 +4,8 @@
 
 typedef struct THCStorage
 {
-    real *data;
+    at::ScalarType scalar_type;
+    void *data_ptr;
     ptrdiff_t size;
     std::atomic<int> refcount;
     char flag;
@@ -12,6 +13,21 @@ typedef struct THCStorage
     void *allocatorContext;
     struct THCStorage *view;
     int device;
+
+    template <typename T>
+    inline T * data() const {
+      auto scalar_type_T = at::CTypeToScalarType<at::cuda::from_type<T>>::to();
+      if (scalar_type != scalar_type_T) {
+        AT_ERROR("Attempt to access Storage having data type ", at::toString(scalar_type),
+                 " as data type ", at::toString(scalar_type_T));
+      }
+      return unsafeData<T>();
+    }
+
+    template <typename T>
+    inline T * unsafeData() const {
+      return static_cast<T*>(this->data_ptr);
+    }
 } THCStorage;
 
 #endif

--- a/aten/src/THC/generic/THCStorage.hpp
+++ b/aten/src/THC/generic/THCStorage.hpp
@@ -21,11 +21,11 @@ typedef struct THCStorage
         AT_ERROR("Attempt to access Storage having data type ", at::toString(scalar_type),
                  " as data type ", at::toString(scalar_type_T));
       }
-      return unsafeData<T>();
+      return unsafe_data<T>();
     }
 
     template <typename T>
-    inline T * unsafeData() const {
+    inline T * unsafe_data() const {
       return static_cast<T*>(this->data_ptr);
     }
 } THCStorage;

--- a/aten/src/THC/generic/THCStorageCopy.cpp
+++ b/aten/src/THC/generic/THCStorageCopy.cpp
@@ -6,8 +6,8 @@ void THCStorage_(copyCPU)(THCState *state, THCStorage *self, struct THStorage *s
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
   cudaStream_t stream = THCState_getCurrentStream(state);
-  THCudaCheck(cudaMemcpyAsync(self->data,
-                              src->data,
+  THCudaCheck(cudaMemcpyAsync(THCStorage_(data)(state, self),
+                              THStorage_(data)(src),
                               self->size * sizeof(real),
                               cudaMemcpyHostToDevice,
                               stream));
@@ -38,8 +38,8 @@ void THStorage_(copyCuda)(THCState *state, THStorage *self, struct THCStorage *s
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
   cudaStream_t stream = THCState_getCurrentStream(state);
-  THCudaCheck(cudaMemcpyAsync(self->data,
-                              src->data,
+  THCudaCheck(cudaMemcpyAsync(THStorage_(data)(self),
+                              THCStorage_(data)(state, src),
                               self->size * sizeof(real),
                               cudaMemcpyDeviceToHost,
                               stream));

--- a/aten/src/THC/generic/THCStorageCopy.cu
+++ b/aten/src/THC/generic/THCStorageCopy.cu
@@ -4,7 +4,7 @@
 
 void THCStorage_(rawCopy)(THCState *state, THCStorage *self, real *src)
 {
-  THCudaCheck(cudaMemcpyAsync(self->data, src, self->size * sizeof(real), cudaMemcpyDeviceToDevice, THCState_getCurrentStream(state)));
+  THCudaCheck(cudaMemcpyAsync(THCStorage_(data)(state, self), src, self->size * sizeof(real), cudaMemcpyDeviceToDevice, THCState_getCurrentStream(state)));
 }
 
 // conversions are delegated to THCTensor implementation

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -47,7 +47,7 @@ THLongStorage *THCTensor_(newStrideOf)(THCState *state, THCTensor *self)
 real *THCTensor_(data)(THCState *state, const THCTensor *self)
 {
   if(self->storage)
-    return (self->storage->data+self->storageOffset);
+    return (THCStorage_(data)(state, self->storage)+self->storageOffset);
   else
     return NULL;
 }
@@ -103,8 +103,8 @@ THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrd
                            storage,
                            storageOffset,
                            (size ? size->size : (stride ? stride->size : 0)),
-                           (size ? size->data : NULL),
-                           (stride ? stride->data : NULL));
+                           (size ? THLongStorage_data(size) : NULL),
+                           (stride ? THLongStorage_data(stride) : NULL));
 
   return self;
 }
@@ -246,9 +246,9 @@ static int THCTensor_(isViewable)(THCState *state, THCTensor *tensor, THLongStor
     // if end of tensor size chunk, check view
     if ((tensor_d == 0) ||
         (tensor->size[tensor_d - 1] != 1 && tensor->stride[tensor_d - 1] != tensor_numel * chunk_base_stride)) {
-      while (view_d >= 0 && (view_numel < tensor_numel || view_size->data[view_d] == 1)) {
-        new_stride->data[view_d] = view_numel * chunk_base_stride;
-        view_numel *= view_size->data[view_d];
+      while (view_d >= 0 && (view_numel < tensor_numel || THLongStorage_data(view_size)[view_d] == 1)) {
+        THLongStorage_data(new_stride)[view_d] = view_numel * chunk_base_stride;
+        view_numel *= THLongStorage_data(view_size)[view_d];
         view_d--;
       }
       if (view_numel != tensor_numel) {
@@ -288,9 +288,9 @@ THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
   THArgCheck(THCTensor_(isContiguous)(state, input), 1,
              "Tensor must be contiguous");
   THLongStorage *newSize = THLongStorage_newWithSize(in_dims - 1);
-  newSize->data[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
+  THLongStorage_data(newSize)[0] = THCTensor_(size)(state, input, 0) * THCTensor_(size)(state, input, 1);
   for (int i = 2; i < in_dims; i++) {
-    newSize->data[i - 1] = THCTensor_(size)(state, input, i);
+    THLongStorage_data(newSize)[i - 1] = THCTensor_(size)(state, input, i);
   }
   THCTensor *output = THCTensor_(newView)(state, input, newSize);
   THLongStorage_free(newSize);
@@ -304,7 +304,7 @@ void THCTensor_(resize)(THCState *state, THCTensor *self, THLongStorage *size, T
   if(stride)
     THArgCheck(stride->size == size->size, 3, "invalid stride");
 
-  THCTensor_(resizeNd)(state, self, size->size, size->data, (stride ? stride->data : NULL));
+  THCTensor_(resizeNd)(state, self, size->size, THLongStorage_data(size), (stride ? THLongStorage_data(stride) : NULL));
 }
 
 void THCTensor_(resizeAs)(THCState *state, THCTensor *self, THCTensor *src)
@@ -379,8 +379,8 @@ void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storag
                            storage_,
                            storageOffset_,
                            (size_ ? size_->size : (stride_ ? stride_->size : 0)),
-                           (size_ ? size_->data : NULL),
-                           (stride_ ? stride_->data : NULL));
+                           (size_ ? THLongStorage_data(size_) : NULL),
+                           (stride_ ? THLongStorage_data(stride_) : NULL));
 }
 
 void THCTensor_(setStorage1d)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
@@ -642,7 +642,7 @@ int THCTensor_(isSize)(THCState *state, const THCTensor *self, const THLongStora
 
   for (d = 0; d < self->nDimension; ++d)
   {
-    if (self->size[d] != dims->data[d])
+    if (self->size[d] != THLongStorage_data(dims)[d])
       return 0;
   }
   return 1;

--- a/aten/src/THC/generic/THCTensorCopy.cpp
+++ b/aten/src/THC/generic/THCTensorCopy.cpp
@@ -131,7 +131,7 @@ void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, struct THTensor 
                               cudaMemcpyHostToDevice,
                               stream->stream));
 
-  THCudaCheck(THCCachingHostAllocator_recordEvent(src->storage->data, stream));
+  THCudaCheck(THCCachingHostAllocator_recordEvent(THStorage_(data)(src->storage), stream));
 
   if (currentDevice != tensorDevice) {
     THCudaCheck(cudaSetDevice(currentDevice));
@@ -162,7 +162,7 @@ void THTensor_(copyAsyncCuda)(THCState *state, THTensor *self, struct THCTensor 
                               cudaMemcpyDeviceToHost,
                               stream->stream));
 
-  THCudaCheck(THCCachingHostAllocator_recordEvent(src->storage->data, stream));
+  THCudaCheck(THCCachingHostAllocator_recordEvent(THCStorage_(data)(state, src->storage), stream));
 
   if (currentDevice != tensorDevice) {
     THCudaCheck(cudaSetDevice(currentDevice));

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -174,7 +174,7 @@ void THCTensor_(catArray)(THCState *state, THCTensor *result,
     if (dim == cat_dimension) {
       result_dim_size = cat_dim_size;
     }
-    size->data[dim] = result_dim_size;
+    THLongStorage_data(size)[dim] = result_dim_size;
   }
   THCTensor_(resize)(state, result, size, NULL);
   THLongStorage_free(size);

--- a/aten/src/THC/generic/THCTensorMathMagma.cu
+++ b/aten/src/THC/generic/THCTensorMathMagma.cu
@@ -12,7 +12,7 @@ static void THCTensor_(copyArray1d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[1] = { 1 };
   THCTensor_(resizeNd)(state, self, 1, size, stride);
   size_t len = k * sizeof(real);
-  THCudaCheck(cudaMemcpy(self->storage->data + self->storageOffset, src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src, int m, int n)
@@ -21,7 +21,7 @@ static void THCTensor_(copyArray2d)(THCState *state, THCTensor *self, real *src,
   int64_t stride[2] = { 1, m };
   THCTensor_(resizeNd)(state, self, 2, size, stride);
   size_t len = m * n * sizeof(real);
-  THCudaCheck(cudaMemcpy(self->storage->data + self->storageOffset, src, len, cudaMemcpyHostToDevice));
+  THCudaCheck(cudaMemcpy(THCStorage_(data)(state, self->storage) + self->storageOffset, src, len, cudaMemcpyHostToDevice));
 }
 
 static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self)
@@ -30,7 +30,7 @@ static void THCTensor_(copyTensor2d)(THCState *state, real *dst, THCTensor *self
   size_t len = THCTensor_(nElement)(state, self)*sizeof(real);
   THCTensor *temp = THCTensor_(newTranspose)(state, self, 0, 1);
   THCTensor *selfc = THCTensor_(newContiguous)(state, temp);
-  THCudaCheck(cudaMemcpy(dst, selfc->storage->data + selfc->storageOffset, len, cudaMemcpyDeviceToHost));
+  THCudaCheck(cudaMemcpy(dst, THCStorage_(data)(state, self->storage) + selfc->storageOffset, len, cudaMemcpyDeviceToHost));
   THCTensor_(free)(state, temp);
   THCTensor_(free)(state, selfc);
 }
@@ -289,8 +289,8 @@ THC_API void THCTensor_(geev)(THCState *state, THCTensor *re_, THCTensor *rv_, T
   {
     THCTensor_(resize2d)(state, re_, 2, n);
     THCTensor *re = THCTensor_(newContiguous)(state, re_);
-    THCudaCheck(cudaMemcpy(re->storage->data + re->storageOffset, wr, n*sizeof(real), cudaMemcpyHostToDevice));
-    THCudaCheck(cudaMemcpy(re->storage->data + re->storageOffset + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storageOffset, wr, n*sizeof(real), cudaMemcpyHostToDevice));
+    THCudaCheck(cudaMemcpy(THCStorage_(data)(state, re->storage) + re->storageOffset + n, wi, n*sizeof(real), cudaMemcpyHostToDevice));
     THCTensor_(freeCopyTo)(state, re, re_);
     THCTensor_(transpose)(state, re_, NULL, 0, 1);
   }

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -146,7 +146,7 @@ THC_API void THCTensor_(dimApplyMode)(THCState *state,
   } else {
     // Loop through the values and recurse
     for (int i = 0; i < THCTensor_(size)(state, input, curDim); ++i) {
-      position->data[curDim] = i;
+      THLongStorage_data(position)[curDim] = i;
       THCTensor_(dimApplyMode)(state, values, indices, input, sortBuffer, dimension, position, curDim + 1);
     }
   }

--- a/aten/src/THCS/generic/THCSTensor.cpp
+++ b/aten/src/THCS/generic/THCSTensor.cpp
@@ -209,14 +209,14 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
   THCudaLongTensor_free(state, ignore);
   for (int d = 0; d < nDimI; d++) {
     int64_t max_index_in_dim = THCudaLongTensor_get1d(state, max_indices, d);
-    int64_t dim_size = sizes->data[d];
+    int64_t dim_size = THLongStorage_data(sizes)[d];
     THArgCheck(max_index_in_dim < dim_size, 2,
         "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
         d, (long long)dim_size, (long long)max_index_in_dim);
   }
   for (int d = 0; d < nDimV; d++) {
     int64_t values_size = THCTensor_(size)(state, values, d + 1);
-    int64_t specified_size = sizes->data[nDimI + d];
+    int64_t specified_size = THLongStorage_data(sizes)[nDimI + d];
     THArgCheck(values_size <= specified_size, 2,
         "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
         d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
@@ -229,7 +229,7 @@ THCSTensor *THCSTensor_(newWithTensorAndSize)(THCState *state, THCIndexTensor *i
 THCSTensor *THCSTensor_(newWithSize)(THCState *state, THLongStorage *size, THLongStorage *_ignored)
 {
   THCSTensor *self = THCSTensor_(new)(state);
-  THCSTensor_(rawResize)(state, self, size->size, 0, size->data);
+  THCSTensor_(rawResize)(state, self, size->size, 0, THLongStorage_data(size));
   return self;
 }
 
@@ -288,7 +288,7 @@ THCTensor *THCSTensor_(newValuesWithSizeOf)(THCState *state, THCTensor *values, 
     new_values = THCTensor_(newWithSize1d)(state, nnz);
   } else {
     THLongStorage *size = THCTensor_(newSizeOf)(state, values);
-    size->data[0] = nnz;
+    THLongStorage_data(size)[0] = nnz;
     new_values = THCTensor_(newWithSize)(state, size, NULL);
     THLongStorage_free(size);
   }
@@ -325,7 +325,7 @@ int THCSTensor_(isSameSizeAsDense)(THCState *state, const THCSTensor *self, cons
 
 THCSTensor *THCSTensor_(resize)(THCState *state, THCSTensor *self, THLongStorage *size)
 {
-  THCSTensor_(rawResize)(state, self, size->size, 0, size->data);
+  THCSTensor_(rawResize)(state, self, size->size, 0, THLongStorage_data(size));
   return self;
 }
 
@@ -484,9 +484,9 @@ void THCTensor_(sparseMask)(THCState *state, THCSTensor *r_, THCTensor *t, THCST
     THCudaLongTensor_cadd(state, indices, indices, 1, indicesBuffer);
   }
   THLongStorage *viewSize = THLongStorage_newWithSize(1 + mask->nDimensionV);
-  viewSize->data[0] = -1;
+  THLongStorage_data(viewSize)[0] = -1;
   for (int64_t d = 0; d < mask->nDimensionV; d++) {
-    viewSize->data[1 + d] = mask->size[mask->nDimensionI + d];
+    THLongStorage_data(viewSize)[1 + d] = mask->size[mask->nDimensionI + d];
   }
   THCTensor *t_view = THCTensor_(newView)(state, t, viewSize);
   THCTensor_(indexSelect)(state, rValues, t_view, 0, indices);

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -293,9 +293,9 @@ void THCSTensor_(spcadd)(THCState *state, THCTensor *r_, THCTensor *dense, real 
     int64_t view_columns = 1;
     THLongStorage *r_size = THCTensor_(newSizeOf)(state, r);
     for (int i = 0; i < nDimI; i++)
-      view_rows *= r_size->data[i];
+      view_rows *= THLongStorage_data(r_size)[i];
     for (int i = nDimI; i < nDim; i++)
-      view_columns *= r_size->data[i];
+      view_columns *= THLongStorage_data(r_size)[i];
 
     THLongStorage *r_view_size = THLongStorage_newWithSize2(view_rows, view_columns);
     THCTensor *r_view = THCTensor_(newView)(state, r, r_view_size);
@@ -488,7 +488,7 @@ void THCSTensor_(cmul)(THCState *state, THCSTensor *r_, THCSTensor *t_, THCSTens
   THCSTensor_indexSparseIntersectionKernel<uint64_t, real>
     <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
       I_INFO(r_indices_), I_INFO(t_indices_), I_INFO(s_indices_),
-      (uint64_t)t_nnz, (uint64_t)s_nnz, (uint64_t*)resultNnz->data);
+      (uint64_t)t_nnz, (uint64_t)s_nnz, (uint64_t*)THCudaLongStorage_data(state, resultNnz));
   THCudaCheck(cudaGetLastError());
   r_->nnz = THCudaLongStorage_get(state, resultNnz, 0);
   THCudaLongStorage_free(state, resultNnz);

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -33,8 +33,8 @@ void THNN_(LookupTableBag_updateOutput)(
 
   THLongStorage *inputSize = THCIndexTensor_(newSizeOf)(state, input);
   THLongStorage *outputSize = THLongStorage_newWithSize(2);
-  outputSize->data[0] = numBags;
-  outputSize->data[1] = stride;
+  THLongStorage_data(outputSize)[0] = numBags;
+  THLongStorage_data(outputSize)[1] = stride;
   THCTensor_(resize)(state, output, outputSize, NULL);
   THCTensor_(zero)(state, output);
   THCIndexTensor_(resize)(state, offset2bag, inputSize, NULL);

--- a/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -54,7 +54,7 @@ static void THNN_(SpatialAdaptiveMaxPooling_updateOutput_frame)(
           for(iw = 0; iw < kW; iw++)
           {
             real val = *(ip + ih*istrideH + iw*istrideW);
-            if ((val > maxval) || isnan(val))
+            if ((val > maxval) || std::isnan(val))
             {
               maxval = val;
               maxindex = (ih+istartH)*isizeW + (iw+istartW);

--- a/aten/src/THNN/generic/SpatialConvolutionMM.c
+++ b/aten/src/THNN/generic/SpatialConvolutionMM.c
@@ -123,7 +123,7 @@ static void THNN_(SpatialConvolutionMM_updateOutput_frame)(
   if (bias) {
     for(i = 0; i < nOutputPlane; i++)
         THVector_(fill)
-	  (output->storage->data + output->storageOffset + output->stride[0] * i,
+	  (THStorage_(data)(output->storage) + output->storageOffset + output->stride[0] * i,
 	   THTensor_(get1d)(bias, i), outputHeight*outputWidth);
   } else {
     THTensor_(zero)(output);
@@ -334,10 +334,10 @@ static void THNN_(SpatialConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = gradOutput2d->storage->data + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
       for(k = 0; k < gradOutput2d->size[1]; k++)
         sum += data[k];
-      (gradBias->storage->data + gradBias->storageOffset)[i] += scale*sum;
+      (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale*sum;
     }
   }
 

--- a/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/SpatialDilatedMaxPooling.c
@@ -132,7 +132,7 @@ static void THNN_(SpatialDilatedMaxPooling_updateOutput_frame)(
           {
             tcntr = y*iwidth + x;
             real val = *(ip + tcntr);
-            if ((val > maxval) || isnan(val))
+            if ((val > maxval) || std::isnan(val))
             {
               maxval = val;
               maxindex = tcntr;

--- a/aten/src/THNN/generic/TemporalRowConvolution.c
+++ b/aten/src/THNN/generic/TemporalRowConvolution.c
@@ -161,7 +161,7 @@ static void THNN_(TemporalRowConvolution_updateOutput_frame)(
 	if (bias != NULL) {
 		for (i = 0; i < inputFrameSize; i++)
 			THVector_(fill)
-			        (output->storage->data + output->storageOffset
+			        (THStorage_(data)(output->storage) + output->storageOffset
 			        + output->stride[0] * i,
 			        THTensor_(get1d)(bias, i), nOutputFrame);
 	}
@@ -389,13 +389,13 @@ static void THNN_(TemporalRowConvolution_accGradParameters_frame)(
 		for (i = 0; i < gradBias->size[0]; i++) {
 			int64_t k;
 			real sum = 0;
-			real *data = gradOutput3d->storage->data
+			real *data = THStorage_(data)(gradOutput3d->storage)
 			             + gradOutput3d->storageOffset
 			             + i * gradOutput3d->stride[0];
 			for (k = 0; k < gradOutput3d->size[2]; k++) {
 				sum += data[k];
 			}
-			(gradBias->storage->data + gradBias->storageOffset)[i]
+			(THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i]
 			        += scale * sum;
 		}
 	}

--- a/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricAdaptiveMaxPooling.c
@@ -66,7 +66,7 @@ static void THNN_(VolumetricAdaptiveMaxPooling_updateOutput_frame)(
               for(iw = 0; iw < kW; iw++)
               {
                 real val = *(ip + it*istrideT + ih*istrideH + iw*istrideW);
-                if ((val > maxval) || isnan(val))
+                if ((val > maxval) || std::isnan(val))
                 {
                   maxval = val;
                   maxindex = (it+istartT)*isizeH*isizeW + (ih+istartH)*isizeW + (iw+istartW);

--- a/aten/src/THNN/generic/VolumetricConvolutionMM.c
+++ b/aten/src/THNN/generic/VolumetricConvolutionMM.c
@@ -435,7 +435,7 @@ static void THNN_(VolumetricConvolutionMM_updateOutput_frame)(
       for (i = 0; i < nOutputPlane; i++)
       {
         THVector_(fill)(
-          output->storage->data+output->storageOffset+output->stride[0]*i,
+          THStorage_(data)(output->storage)+output->storageOffset+output->stride[0]*i,
           THTensor_(get1d)(bias, i),
           outputDepth*outputHeight*outputWidth
         );
@@ -693,11 +693,11 @@ static void THNN_(VolumetricConvolutionMM_accGradParameters_frame)(
     {
       int64_t k;
       real sum = 0;
-      real *data = gradOutput2d->storage->data + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
+      real *data = THStorage_(data)(gradOutput2d->storage) + gradOutput2d->storageOffset + i*gradOutput2d->stride[0];
       for (k = 0; k < gradOutput2d->size[1]; k++)
         sum += data[k];
 
-      (gradBias->storage->data + gradBias->storageOffset)[i] += scale * sum;
+      (THStorage_(data)(gradBias->storage) + gradBias->storageOffset)[i] += scale * sum;
     }
   }
 

--- a/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/aten/src/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -170,7 +170,7 @@ static void THNN_(VolumetricDilatedMaxPooling_updateOutput_frame)(
               {
                 index = z * iwidth * iheight + y * iwidth + x;
                 real val = ip[index];
-                if ((val > maxval) || isnan(val))
+                if ((val > maxval) || std::isnan(val))
                 {
                   maxval = val;
                   maxindex = index;

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -2,6 +2,7 @@
 #include "THNN.h"
 
 #include "THTensor.hpp"
+#include <cmath>
 
 #define torch_(NAME) TH_CONCAT_3(torch_, Real, NAME)
 #define nn_(NAME) TH_CONCAT_3(nn_, Real, NAME)

--- a/aten/src/THS/generic/THSTensor.cpp
+++ b/aten/src/THS/generic/THSTensor.cpp
@@ -206,14 +206,14 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
   THLongTensor_free(ignore);
   for (int d = 0; d < nDimI; d++) {
     int64_t max_index_in_dim = THLongTensor_fastGet1d(max_indices, d);
-    int64_t dim_size = sizes->data[d];
+    int64_t dim_size = THLongStorage_data(sizes)[d];
     THArgCheck(max_index_in_dim < dim_size, 2,
         "sizes is inconsistent with indices: for dim %d, size is %lld but found index %lld",
         d, (long long)dim_size, (long long)max_index_in_dim);
   }
   for (int d = 0; d < nDimV; d++) {
     int64_t values_size = THTensor_(size)(values, d + 1);
-    int64_t specified_size = sizes->data[nDimI + d];
+    int64_t specified_size = THLongStorage_data(sizes)[nDimI + d];
     THArgCheck(values_size <= specified_size, 2,
         "values and sizes are inconsistent: sizes[%d] is %lld but values.size(%d) is %lld",
         d + nDimI, (long long)specified_size, d + 1, (long long)values_size);
@@ -226,7 +226,7 @@ THSTensor *THSTensor_(newWithTensorAndSize)(THLongTensor *indices, THTensor *val
 THSTensor *THSTensor_(newWithSize)(THLongStorage *size, THLongStorage *_ignored)
 {
   THSTensor *self = THSTensor_(new)();
-  THSTensor_(rawResize)(self, size->size, 0, size->data);
+  THSTensor_(rawResize)(self, size->size, 0, THLongStorage_data(size));
   return self;
 }
 
@@ -298,7 +298,7 @@ int THSTensor_(isSameSizeAs)(const THSTensor *self, const THSTensor* src)
 
 THSTensor *THSTensor_(resize)(THSTensor *self, THLongStorage *size)
 {
-  THSTensor_(rawResize)(self, size->size, 0, size->data);
+  THSTensor_(rawResize)(self, size->size, 0, THLongStorage_data(size));
   return self;
 }
 
@@ -420,7 +420,7 @@ THTensor *THSTensor_(newValuesWithSizeOf)(THTensor *values, int64_t nnz) {
     new_values = THTensor_(newWithSize1d)(nnz);
   } else {
     THLongStorage *size = THTensor_(newSizeOf)(values);
-    size->data[0] = nnz;
+    THLongStorage_data(size)[0] = nnz;
     new_values = THTensor_(newWithSize)(size, NULL);
     THLongStorage_free(size);
   }
@@ -534,7 +534,7 @@ void THTensor_(sparseMask)(THSTensor *r_, THTensor *t, THSTensor *mask) {
       for (int64_t d = 0; d < nDimI; d++) {
         idx += THLongTensor_fastGet2d(mask_indices_, d, i) * t->stride[d];
       }
-      real val = (t->storage->data + t->storageOffset)[idx];
+      real val = (THStorage_(data)(t->storage) + t->storageOffset)[idx];
       THTensor_(fastSet1d)(r_values_, i, val);
     }
   }

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -580,7 +580,7 @@ void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sp
       for (int64_t d = 0; d < sparse->nDimensionI; d++) {
         index += r_->stride[d] * THLongTensor_fastGet2d(indices, d, k);
       }
-      r_->storage->data[index]  += value * THTensor_(fastGet1d)(values, k);
+      r_->storage->unsafeData<real>()[index]  += value * THTensor_(fastGet1d)(values, k);
     }
   }
 

--- a/aten/src/THS/generic/THSTensorMath.c
+++ b/aten/src/THS/generic/THSTensorMath.c
@@ -580,7 +580,7 @@ void THSTensor_(spcadd)(THTensor *r_, THTensor *dense, real value, THSTensor *sp
       for (int64_t d = 0; d < sparse->nDimensionI; d++) {
         index += r_->stride[d] * THLongTensor_fastGet2d(indices, d, k);
       }
-      r_->storage->unsafeData<real>()[index]  += value * THTensor_(fastGet1d)(values, k);
+      r_->storage->unsafe_data<real>()[index]  += value * THTensor_(fastGet1d)(values, k);
     }
   }
 

--- a/torch/csrc/Types.h
+++ b/torch/csrc/Types.h
@@ -2,6 +2,7 @@
 #define THP_TYPES_INC
 
 #include <cstddef>
+#include <TH/TH.h>
 
 #ifndef INT64_MAX
 #include "stdint.h"
@@ -11,16 +12,7 @@ template <typename T> struct THPTypeInfo {};
 
 namespace torch {
 
-typedef struct THVoidStorage
-{
-  void *data;
-  ptrdiff_t size;
-  int refcount;
-  char flag;
-  void *allocator;
-  void *allocatorContext;
-  THVoidStorage *view;
-} THVoidStorage;
+typedef THFloatStorage THVoidStorage;  // all THXXXStorage types are the same.
 
 typedef struct THVoidTensor
 {

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -142,7 +142,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         item = PySequence_GetItem(first_arg, i);
         real value = THPUtils_(unpackReal)(item.get());
 #if !defined(THC_GENERIC_FILE)
-        self->cdata->unsafeData<real>()[i] = value;
+        self->cdata->unsafe_data<real>()[i] = value;
 #else
         // TODO: this might be slow - consider batched updates?
         THCStorage_(set)(LIBRARY_STATE self->cdata, i, value);

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -117,7 +117,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         "%" PRId64 ", but the viewed storage has only %" PRId64 " element(s) after offset %" PRId64,
         size, numel - offset, offset);
 
-    real *data_ptr = storage_arg->cdata->data + offset;
+    real *data_ptr = THStorage_(data)(LIBRARY_STATE storage_arg->cdata) + offset;
     THStoragePtr storage(THStorage_(newWithData)(LIBRARY_STATE data_ptr, size));
     storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
     storage->view = storage_arg->cdata;
@@ -142,7 +142,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
         item = PySequence_GetItem(first_arg, i);
         real value = THPUtils_(unpackReal)(item.get());
 #if !defined(THC_GENERIC_FILE)
-        self->cdata->data[i] = value;
+        self->cdata->unsafeData<real>()[i] = value;
 #else
         // TODO: this might be slow - consider batched updates?
         THCStorage_(set)(LIBRARY_STATE self->cdata, i, value);

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -18,7 +18,7 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
       ctx = (libshm_context*)allocator_obj->allocatorContext;
   }
   if (ctx)
-    THRefcountedMapAllocator_decref(ctx->th_context, storage->data);
+    THRefcountedMapAllocator_decref(ctx->th_context, THStorage_(data)(storage));
 #endif
   Py_INCREF(self);
   return (PyObject *)self;
@@ -39,7 +39,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
       ctx = (libshm_context*)allocator_obj->allocatorContext;
   }
   if (ctx)
-    THRefcountedMapAllocator_incref(ctx->th_context, storage->data);
+    THRefcountedMapAllocator_incref(ctx->th_context, THStorage_(data)(storage));
 #endif
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -47,7 +47,7 @@ static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
 
 static PyObject * THPStorage_(newTHView)(THStorage *base, ptrdiff_t offset, size_t size)
 {
-  void *data = (char*)base->data + offset;
+  void *data = (char*)base->data<real>() + offset;
   THStoragePtr view(THStorage_(newWithData)(LIBRARY_STATE (real*)data, size));
   view->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_VIEW;
   view->view = base;
@@ -245,10 +245,10 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self)
   THPObjectPtr size(PyLong_FromLong(storage->size));
   THPObjectPtr _offset(PyLong_FromLong(0));
   THPObjectPtr view_size(PyLong_FromLong(storage->size));
-  if (storage->data) {
+  if (THStorage_(data)(LIBRARY_STATE storage)) {
     size_t base_size;
-    void *base_ptr = THCCachingAllocator_getBaseAllocation(storage->data, &base_size);
-    ptrdiff_t offset = (char*)storage->data - (char*)base_ptr;
+    void *base_ptr = THCCachingAllocator_getBaseAllocation(THStorage_(data)(LIBRARY_STATE storage), &base_size);
+    ptrdiff_t offset = (char*)storage->data<real>() - (char*)base_ptr;
 
     cudaIpcMemHandle_t handle;
     THCudaCheck(cudaIpcGetMemHandle(&handle, base_ptr));


### PR DESCRIPTION
This is the initial step in unifying the ATen and TH tensor representations, next is to only generate a single THStorage / THCStorage type.

The major changes here are:
1) data has been renamed to data_ptr and made void* in THStorage/THCStorage.
2) THStorage / THCStorage stores a at::ScalarType representing its data type (This will be useful when we generate a single THStorage/THCStorage).
3) APIs for Accessing the data as a real*:
a) storage->data<real>() -- this does runtime-type checking (checks that the at::ScalarType is correct).
b) storage->unsafeData<real>() -- as above, but no runtime-type checking (used in inner loops / fast code paths).
c) THStorage_(data)(storage) -- this already existed, just calls storage->data<real>().

