### PR TITLE
Add third way to determine IS_CONDA

### DIFF
--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -9,7 +9,7 @@ IS_DARWIN = (platform.system() == 'Darwin')
 IS_LINUX = (platform.system() == 'Linux')
 
 
-IS_CONDA = 'conda' in sys.version or 'Continuum' in sys.version
+IS_CONDA = 'conda' in sys.version or 'Continuum' in sys.version or any([x.startswith('CONDA') for x in os.environ])
 CONDA_DIR = os.path.join(os.path.dirname(sys.executable), '..')
 
 


### PR DESCRIPTION
A user might install Intel Python or such via conda. Then this won't work anymore.