### PR TITLE
Use mingfeima's mkldnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root direct
 
 # Install basic dependencies
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-conda install -c intel mkl-dnn
+conda install -c mingfeima mkldnn
 
 # Add LAPACK support for the GPU
 conda install -c pytorch magma-cuda80 # or magma-cuda90 if CUDA 9


### PR DESCRIPTION
Intel's [mkl-dnn conda package](https://anaconda.org/intel/mkl-dnn) has intelpython as a dependency, which some users might not want to use. @mingfeima's mkldnn conda package does not have this dependency.

As an interesting side-effect, intel's mkl-dnn conda package in fact breaks finding the library, because pytorch determines whether it needs to look within conda for the library [based on sys.version](https://github.com/pytorch/pytorch/blob/master/tools/setup_helpers/env.py#L12). Once you install intelpython that string won't contain 'Continuum' or 'conda' anymore, albeit the library is present within the conda distribution. Then script will then fail to detect its presence.

There is [another PR](https://github.com/pytorch/pytorch/pull/7971) that fixes this for those users that do want to use intelpython and mkldnn.