### PR TITLE
HOTFIX: Change perf test folder after git checkout

### DIFF
--- a/.jenkins/pytorch/perf_test/test_gpu_speed_cudnn_lstm.sh
+++ b/.jenkins/pytorch/perf_test/test_gpu_speed_cudnn_lstm.sh
@@ -10,9 +10,11 @@ test_gpu_speed_cudnn_lstm () {
 
   git clone https://github.com/pytorch/benchmark.git
 
-  cd benchmark/scripts/
+  cd benchmark/
 
   git checkout 43dfb2c0370e70ef37f249dc09aff9f0ccd2ddb0
+
+  cd scripts/
 
   SAMPLE_ARRAY=()
   NUM_RUNS=$1

--- a/.jenkins/pytorch/perf_test/test_gpu_speed_lstm.sh
+++ b/.jenkins/pytorch/perf_test/test_gpu_speed_lstm.sh
@@ -10,9 +10,11 @@ test_gpu_speed_lstm () {
 
   git clone https://github.com/pytorch/benchmark.git
 
-  cd benchmark/scripts/
+  cd benchmark/
 
   git checkout 43dfb2c0370e70ef37f249dc09aff9f0ccd2ddb0
+
+  cd scripts/
 
   SAMPLE_ARRAY=()
   NUM_RUNS=$1

--- a/.jenkins/pytorch/perf_test/test_gpu_speed_mlstm.sh
+++ b/.jenkins/pytorch/perf_test/test_gpu_speed_mlstm.sh
@@ -10,9 +10,11 @@ test_gpu_speed_mlstm () {
 
   git clone https://github.com/pytorch/benchmark.git
 
-  cd benchmark/scripts/
+  cd benchmark/
 
   git checkout 43dfb2c0370e70ef37f249dc09aff9f0ccd2ddb0
+
+  cd scripts/
 
   SAMPLE_ARRAY=()
   NUM_RUNS=$1


### PR DESCRIPTION
This fixes an issue caused by https://github.com/pytorch/pytorch/pull/7848. We now changed the structure of the benchmark repo and the `scripts/` folder doesn't exist in the newest master anymore.