### PR TITLE
Revert "Set smaller grain size for some cases"

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -3,6 +3,12 @@
 #include <tbb/tbb.h>
 #include <cstddef>
 
+#ifdef __PPC64__
+using default_partitioner_type = tbb::simple_partitioner;
+#else
+using default_partitioner_type = tbb::affinity_partitioner;
+#endif
+
 namespace at {
 namespace internal {
 // This needs to be called before the first use of any algorithm such as
@@ -24,67 +30,70 @@ AT_API void init_tbb_num_threads();
 constexpr int64_t TBB_GRAIN_SIZE = 32768;
 } // namespace internal
 
-template <class F>
-inline void parallel_for_1d(
-    F f,
-    int64_t begin,
-    int64_t end,
-    int64_t grain_size = internal::TBB_GRAIN_SIZE,
-    bool parallelize = true) {
+template <class T, template <class> class OP>
+T parallel_reduce(
+    T (*f)(const T*, size_t, size_t, T),
+    const T* data,
+    size_t start,
+    size_t end,
+    T init_) {
   internal::init_tbb_num_threads();
 
-#ifdef __PPC64__
-  using default_partitioner_type = tbb::simple_partitioner;
-#else
-  using default_partitioner_type = tbb::affinity_partitioner;
-#endif
+  T result_;
+  static default_partitioner_type ap;
 
-  thread_local static default_partitioner_type ap;
-
-  bool sequential = (end - begin) < grain_size || !parallelize;
-
-  if (sequential) {
-    f(begin, end);
+  if (end - start < internal::TBB_GRAIN_SIZE) {
+    result_ = f(data, start, end, init_);
   } else {
-    tbb::parallel_for(
-        tbb::blocked_range<int64_t>(begin, end, grain_size),
-        [f](const tbb::blocked_range<int64_t>& r) { f(r.begin(), r.end()); },
+    result_ = tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE),
+        init_,
+        [&data, &f](const tbb::blocked_range<size_t> r, T init) -> T {
+          return f(data, r.begin(), r.end(), init);
+        },
+        OP<T>(),
         ap);
   }
+  return result_;
 }
 
-template <class scalar_t, class F, class SF>
-inline scalar_t parallel_reduce_1d(
-    F f,
-    SF sf,
-    scalar_t ident,
-    int64_t begin,
-    int64_t end,
-    int64_t grain_size = internal::TBB_GRAIN_SIZE,
-    bool parallelize = true) {
+template <class T>
+void parallel_reduce_2d(
+    void (*f)(const T*, T*, size_t, size_t),
+    size_t num_rows,
+    size_t num_cols,
+    size_t numel,
+    const T* arr_,
+    T* outarr_) {
   internal::init_tbb_num_threads();
 
-#ifdef __PPC64__
-  using default_partitioner_type = tbb::simple_partitioner;
-#else
-  using default_partitioner_type = tbb::affinity_partitioner;
-#endif
+  static default_partitioner_type ap;
 
-  thread_local static default_partitioner_type ap;
-
-  bool sequential = (end - begin) < grain_size || !parallelize;
-
-  if (sequential) {
-    return f(begin, end, 0);
+  size_t max_i_ =
+      (numel && num_rows && num_cols) ? numel / (num_rows * num_cols) : 0;
+  if (numel < internal::TBB_GRAIN_SIZE) {
+    for (size_t i_ = 0; i_ < max_i_; i_++) {
+      int64_t i = i_ * num_rows * num_cols;
+      int64_t i_r = i_ * num_cols;
+      const T* arr = arr_ + i;
+      T* outarr = outarr_ + i_r;
+      f(arr, outarr, num_rows, num_cols);
+    }
+  } else {
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, max_i_, 1),
+        [&arr_, &outarr_, num_rows, num_cols, &f](
+            const tbb::blocked_range<size_t> r) {
+          for (size_t i_ = r.begin(); i_ < r.end(); i_++) {
+            int64_t i = i_ * num_rows * num_cols;
+            int64_t i_r = i_ * num_cols;
+            const T* arr = arr_ + i;
+            T* outarr = outarr_ + i_r;
+            f(arr, outarr, num_rows, num_cols);
+          }
+        },
+        ap);
   }
-  return tbb::parallel_reduce(
-      tbb::blocked_range<int64_t>(begin, end, grain_size),
-      scalar_t(ident),
-      [f](const tbb::blocked_range<int64_t>& r, scalar_t init) {
-        return f(r.begin(), r.end(), init);
-      },
-      sf,
-      ap);
 }
 
 } // namespace at

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -22,7 +22,7 @@ namespace {
 template <class T>
 struct Vec256 {
   static constexpr int size = 32 / sizeof(T);
-  T values[32 / sizeof(T)];
+  __at_align32__ T values[32 / sizeof(T)];
   Vec256() {}
   Vec256(T val) {
     for (int i = 0; i != size; i++) {

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -11,8 +11,11 @@ namespace at {
 namespace native {
 namespace {
 
+static default_partitioner_type ap;
+
 template <typename scalar_t, bool LogSoftMax>
 void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
+  internal::init_tbb_num_threads();
   int64_t outer_size = 1;
   int64_t dim_size = input.size(dim);
   int64_t inner_size = 1;
@@ -24,11 +27,11 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   int64_t outer_stride = dim_size * dim_stride;
   scalar_t* input_data_base = input.data<scalar_t>();
   scalar_t* output_data_base = output.data<scalar_t>();
-  int64_t grain_size =
-      std::min(internal::TBB_GRAIN_SIZE / dim_size, (int64_t)1);
-  parallel_for_1d(
-      [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+  int64_t grain_size = std::min(internal::TBB_GRAIN_SIZE / dim_size, (int64_t)1);
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(0, outer_size * inner_size, grain_size),
+      [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t i = r.begin(); i < r.end(); i++) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* input_data =
@@ -60,9 +63,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
               output_data[d * dim_stride] *= tmpsum;
         }
       },
-      0,
-      outer_size * inner_size,
-      grain_size);
+      ap);
 }
 
 template <typename scalar_t, bool LogSoftMax>
@@ -71,6 +72,8 @@ void host_softmax_backward(
     const Tensor& grad,
     const Tensor& output,
     int64_t dim) {
+  internal::init_tbb_num_threads();
+
   int64_t outer_size = 1;
   int64_t dim_size = grad.size(dim);
   int64_t inner_size = 1;
@@ -84,9 +87,10 @@ void host_softmax_backward(
   scalar_t* output_data_base = output.data<scalar_t>();
   scalar_t* gradOutput_data_base = grad.data<scalar_t>();
   int64_t grain_size = std::min(internal::TBB_GRAIN_SIZE / dim_size, (int64_t)1);
-  parallel_for_1d(
-      [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(0, outer_size * inner_size, grain_size),
+      [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t i = r.begin(); i < r.end(); i++) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* gradInput_data =
@@ -115,9 +119,7 @@ void host_softmax_backward(
           }
         }
       },
-      0,
-      outer_size * inner_size,
-      grain_size);
+      ap);
 }
 } // namespace
 

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -40,62 +40,56 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
     return at::op##_out(result, self);                           \
   }
 
-#define IMPLEMENT_UNARY_OP_FLOAT_CMATH(op, opfn)                \
-  Tensor& _##op##__cpu(Tensor& self_) {                         \
-    if (self_.numel() > 0) {                                    \
-      Tensor self = sort_strides(self_);                        \
-      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {         \
-        CPU_tensor_parallel_apply1<scalar_t>(                   \
-            self, [](scalar_t& y) { y = opfn(y); }, 1024);      \
-      });                                                       \
-    }                                                           \
-    return self_;                                               \
-  }                                                             \
-  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) { \
-    result.resize_(self.sizes());                               \
-    if (result.numel() > 0) {                                   \
-      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {         \
-        CPU_tensor_parallel_apply2<scalar_t, scalar_t>(         \
-            result,                                             \
-            self,                                               \
-            [](scalar_t& y, scalar_t& x) { y = opfn(x); },      \
-            1024);                                              \
-      });                                                       \
-    }                                                           \
-    return result;                                              \
+#define IMPLEMENT_UNARY_OP_FLOAT_CMATH(op, opfn)                          \
+  Tensor& _##op##__cpu(Tensor& self_) {                                   \
+    if (self_.numel() > 0) {                                              \
+      Tensor self = sort_strides(self_);                                  \
+      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
+        CPU_tensor_parallel_apply1<scalar_t>(                             \
+            self, [](scalar_t& y) { y = opfn(y); });                      \
+      });                                                                 \
+    }                                                                     \
+    return self_;                                                         \
+  }                                                                       \
+  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) {           \
+    result.resize_(self.sizes());                                         \
+    if (result.numel() > 0) {                                             \
+      AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
+        CPU_tensor_parallel_apply2<scalar_t, scalar_t>(                   \
+            result, self, [](scalar_t& y, scalar_t& x) { y = opfn(x); }); \
+      });                                                                 \
+    }                                                                     \
+    return result;                                                        \
   }
 
-#define IMPLEMENT_UNARY_OP_VEC(op, opfn)                        \
-  Tensor& _##op##__cpu(Tensor& self_) {                         \
-    if (self_.numel() > 0) {                                    \
-      Tensor self = sort_strides(self_);                        \
-      if (self.is_contiguous()) {                               \
-        op##Impl(self, self);                                   \
-      } else {                                                  \
-        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {       \
-          CPU_tensor_parallel_apply1<scalar_t>(                 \
-              self, [](scalar_t& y) { y = opfn(y); }, 1024);    \
-        });                                                     \
-      }                                                         \
-    }                                                           \
-    return self_;                                               \
-  }                                                             \
-  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) { \
-    result.resize_(self.sizes());                               \
-    if (result.numel() > 0) {                                   \
-      if (result.is_contiguous() && self.is_contiguous()) {     \
-        op##Impl(result, self);                                 \
-      } else {                                                  \
-        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {       \
-          CPU_tensor_parallel_apply2<scalar_t, scalar_t>(       \
-              result,                                           \
-              self,                                             \
-              [](scalar_t& y, scalar_t& x) { y = opfn(x); },    \
-              1024);                                            \
-        });                                                     \
-      }                                                         \
-    }                                                           \
-    return result;                                              \
+#define IMPLEMENT_UNARY_OP_VEC(op, opfn)                                    \
+  Tensor& _##op##__cpu(Tensor& self_) {                                     \
+    if (self_.numel() > 0) {                                                \
+      Tensor self = sort_strides(self_);                                    \
+      if (self.is_contiguous()) {                                           \
+        op##Impl(self, self);                                               \
+      } else {                                                              \
+        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
+          CPU_tensor_parallel_apply1<scalar_t>(                             \
+              self, [](scalar_t& y) { y = opfn(y); });                      \
+        });                                                                 \
+      }                                                                     \
+    }                                                                       \
+    return self_;                                                           \
+  }                                                                         \
+  Tensor& _##op##_out_cpu(Tensor& result, const Tensor& self) {             \
+    result.resize_(self.sizes());                                           \
+    if (result.numel() > 0) {                                               \
+      if (result.is_contiguous() && self.is_contiguous()) {                 \
+        op##Impl(result, self);                                             \
+      } else {                                                              \
+        AT_DISPATCH_FLOATING_TYPES(self.type(), op, [&] {                   \
+          CPU_tensor_parallel_apply2<scalar_t, scalar_t>(                   \
+              result, self, [](scalar_t& y, scalar_t& x) { y = opfn(x); }); \
+        });                                                                 \
+      }                                                                     \
+    }                                                                       \
+    return result;                                                          \
   }
 
 IMPLEMENT_UNARY_OP_PREQUEL(abs)

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -22,6 +22,8 @@
 namespace at { namespace native {
 namespace {
 
+static default_partitioner_type ap;
+
 template <typename scalar_t>
 inline void _vec_log_softmax_lastdim(
     scalar_t* input_data_base,
@@ -30,18 +32,19 @@ inline void _vec_log_softmax_lastdim(
     int64_t dim_size) {
   using Vec = vec256::Vec256<scalar_t>;
   static constexpr int64_t CHUNK_SIZE = (128 / sizeof(scalar_t)) * Vec::size;
-  int64_t grain_size = 2048 / dim_size;
+  int64_t grain_size = internal::TBB_GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   if (grain_size < CHUNK_SIZE)
     grain_size = CHUNK_SIZE;
 
-  parallel_for_1d(
-      [&](int64_t begin, int64_t end) {
-        for (int64_t ii = begin; ii < end; ii += CHUNK_SIZE) {
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
+      [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t ii = r.begin(); ii < r.end(); ii += CHUNK_SIZE) {
           scalar_t tmp_sum_scalar[CHUNK_SIZE];
           scalar_t max_input_arr[CHUNK_SIZE];
           int64_t loop_end = CHUNK_SIZE;
-          if (ii + CHUNK_SIZE > end)
-            loop_end = end - ii;
+          if (ii + CHUNK_SIZE > r.end())
+            loop_end = r.end() - ii;
           for (int64_t j = 0; j < loop_end; j++) {
             int64_t i = ii + j;
             scalar_t* input_data = input_data_base + i * dim_size;
@@ -81,9 +84,7 @@ inline void _vec_log_softmax_lastdim(
           }
         }
       },
-      0,
-      outer_size,
-      grain_size);
+      ap);
 }
 
 template <typename scalar_t>
@@ -93,13 +94,14 @@ inline void _vec_softmax_lastdim(
     int64_t outer_size,
     int64_t dim_size) {
   using Vec = vec256::Vec256<scalar_t>;
-  int64_t grain_size = 2048 / dim_size;
+  int64_t grain_size = internal::TBB_GRAIN_SIZE / (16 * dim_size);
   if (grain_size < 1)
     grain_size = 1;
 
-  parallel_for_1d(
-      [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
+      [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t i = r.begin(); i < r.end(); i++) {
           scalar_t* input_data = input_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
           scalar_t max_input = vec256::reduce_all<scalar_t>(
@@ -121,9 +123,7 @@ inline void _vec_softmax_lastdim(
               dim_size);
         }
       },
-      0,
-      outer_size,
-      grain_size);
+      ap);
 }
 
 template <typename scalar_t, bool log_softmax>
@@ -138,9 +138,10 @@ inline void _vec_host_softmax_backward_lastdim(
   if (grain_size < 1)
     grain_size = 1;
 
-  parallel_for_1d(
-      [&](int64_t begin, int64_t end) {
-        for (int64_t i = begin; i < end; i++) {
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
+      [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t i = r.begin(); i < r.end(); i++) {
           scalar_t* grad_input_data = grad_input_data_base + i * dim_size;
           scalar_t* grad_data = grad_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
@@ -173,14 +174,13 @@ inline void _vec_host_softmax_backward_lastdim(
           }
         }
       },
-      0,
-      outer_size,
-      grain_size);
+      ap);
 }
 
 template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_lastdim {
   static void apply(Tensor& output, const Tensor& input) {
+    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = input.size(input.ndimension() - 1);
     for (int64_t i = 0; i < input.ndimension() - 1; ++i)
@@ -201,6 +201,7 @@ template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_backward_lastdim {
   static void
   apply(Tensor& grad_input, const Tensor& grad, const Tensor& output) {
+    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = grad.size(grad.ndimension() - 1);
     for (int64_t i = 0; i < grad.ndimension() - 1; ++i)


### PR DESCRIPTION
Reverts pytorch/pytorch#7941

I am guessing this PR is the cause of the sporadic ASAN failures in master, see https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-py3-clang5-asan-test/4957//console https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-py3-clang5-asan-test/4960//console https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-py3-clang5-asan-test/4994//console https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-xenial-py3-clang5-asan-test/5004//console

```
22:57:04 =================================================================
22:57:04 ==584==ERROR: AddressSanitizer: heap-use-after-free on address 0x61600058004a at pc 0x7fab807f0464 bp 0x7fab5a9cde30 sp 0x7fab5a9cde28
22:57:04 READ of size 1 at 0x61600058004a thread T6
22:57:05     #0 0x7fab807f0463 in tbb::internal::generic_scheduler::is_worker() const /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.h:571:26
22:57:05     #1 0x7fab807f0463 in tbb::internal::generic_scheduler::master_outermost_level() const /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.h:551
22:57:05     #2 0x7fab807f0463 in tbb::task_scheduler_init::internal_terminate(bool) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/governor.cpp:349
22:57:05     #3 0x7fab807f0463 in tbb::task_scheduler_init::terminate() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/governor.cpp:359
22:57:05     #4 0x7fab7eb9d0c0 in tbb::task_scheduler_init::~task_scheduler_init() /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/task_scheduler_init.h:132:13
22:57:05     #5 0x7fab93ed7cce in (anonymous namespace)::run(void*) /opt/conda/conda-bld/compilers_linux-64_1520532893746/work/.build/src/gcc-7.2.0/libstdc++-v3/libsupc++/atexit_thread.cc:75
22:57:05     #6 0x7fab94e67438 in __nptl_deallocate_tsd.part.4 (/lib/x86_64-linux-gnu/libpthread.so.0+0x6438)
22:57:05     #7 0x7fab94e6886f in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x786f)
22:57:05     #8 0x7fab94b9e41c in clone /build/glibc-Cl5G7W/glibc-2.23/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:109
22:57:05 
22:57:05 0x61600058004a is located 202 bytes inside of 520-byte region [0x61600057ff80,0x616000580188)
22:57:05 freed by thread T6 here:
22:57:05     #0 0x7fab95185cc0 in __interceptor_cfree (/usr/lib/llvm-5.0/lib/clang/5.0.0/lib/linux/libclang_rt.asan-x86_64.so+0x107cc0)
22:57:05     #1 0x7fab807fd89d in tbb::internal::rml::private_worker::run() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:285:15
22:57:05     #2 0x7fab807fd258 in tbb::internal::rml::private_worker::thread_routine(void*) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:223:11
22:57:05     #3 0x7fab94e686b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
22:57:05 
22:57:05 previously allocated by thread T6 here:
22:57:05     #0 0x7fab95185e88 in malloc (/usr/lib/llvm-5.0/lib/clang/5.0.0/lib/linux/libclang_rt.asan-x86_64.so+0x107e88)
22:57:05     #1 0x7fab807ec580 in tbb::internal::padded_allocate(unsigned long, unsigned long) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/cache_aligned_allocator.cpp:210:43
22:57:05     #2 0x7fab807ec758 in tbb::internal::NFS_Allocate(unsigned long, unsigned long, void*) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/cache_aligned_allocator.cpp:196:20
22:57:05     #3 0x7fab8080612a in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::allocate_scheduler(tbb::internal::market&) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/custom_scheduler.h:118:19
22:57:05     #4 0x7fab80804c03 in tbb::internal::allocate_scheduler(tbb::internal::market&) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.cpp:42:12
22:57:05     #5 0x7fab80804c03 in tbb::internal::generic_scheduler::create_worker(tbb::internal::market&, unsigned long) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.cpp:1147
22:57:05     #6 0x7fab807fb1ee in tbb::internal::market::create_one_job() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/market.cpp:747:28
22:57:05     #7 0x7fab807fd355 in tbb::internal::rml::private_worker::run() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:267:32
22:57:05     #8 0x7fab807fd258 in tbb::internal::rml::private_worker::thread_routine(void*) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:223:11
22:57:05     #9 0x7fab94e686b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
22:57:05 
22:57:05 Thread T6 created by T4 here:
22:57:05     #0 0x7fab950dd3cd in pthread_create (/usr/lib/llvm-5.0/lib/clang/5.0.0/lib/linux/libclang_rt.asan-x86_64.so+0x5f3cd)
22:57:05     #1 0x7fab807feeaa in rml::internal::thread_monitor::launch(void* (*)(void*), void*, unsigned long) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/src/rml/include/../server/thread_monitor.h:221:12
22:57:05     #2 0x7fab807fe9ef in tbb::internal::rml::private_worker::wake_or_launch() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:300:21
22:57:05     #3 0x7fab807fe707 in tbb::internal::rml::private_server::wake_some(int) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:394:17
22:57:05     #4 0x7fab807fd2ff in tbb::internal::rml::private_server::propagate_chain_reaction() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:161:13
22:57:05     #5 0x7fab807fd2ff in tbb::internal::rml::private_worker::run() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:261
22:57:05     #6 0x7fab807fd258 in tbb::internal::rml::private_worker::thread_routine(void*) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:223:11
22:57:05     #7 0x7fab94e686b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
22:57:05 
22:57:05 Thread T4 created by T0 here:
22:57:05     #0 0x7fab950dd3cd in pthread_create (/usr/lib/llvm-5.0/lib/clang/5.0.0/lib/linux/libclang_rt.asan-x86_64.so+0x5f3cd)
22:57:05     #1 0x7fab807feeaa in rml::internal::thread_monitor::launch(void* (*)(void*), void*, unsigned long) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/src/rml/include/../server/thread_monitor.h:221:12
22:57:05     #2 0x7fab807fe9ef in tbb::internal::rml::private_worker::wake_or_launch() /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:300:21
22:57:05     #3 0x7fab807fe707 in tbb::internal::rml::private_server::wake_some(int) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/private_server.cpp:394:17
22:57:05     #4 0x7fab80801684 in tbb::internal::generic_scheduler::local_spawn(tbb::task*, tbb::task*&) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.cpp:648:15
22:57:05     #5 0x7fab803ceffc in tbb::interface5::internal::task_base::spawn(tbb::task&) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/internal/../task.h:995:23
22:57:05     #6 0x7fab803ceffc in tbb::interface9::internal::start_for<tbb::blocked_range<long>, void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool)::{lambda(tbb::blocked_range<long> const&)#1}, tbb::affinity_partitioner>::offer_work(tbb::proportional_split&) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/parallel_for.h:122
22:57:05     #7 0x7fab803ceffc in void tbb::interface9::internal::partition_type_base<tbb::interface9::internal::affinity_partition_type>::execute<tbb::interface9::internal::start_for<tbb::blocked_range<long>, void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool)::{lambda(tbb::blocked_range<long> const&)#1}, tbb::affinity_partitioner>, tbb::blocked_range<long> >(tbb::blocked_range<long>&, {lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}&) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/partitioner.h:253
22:57:05     #8 0x7fab803ceffc in tbb::interface9::internal::start_for<tbb::blocked_range<long>, void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool)::{lambda(tbb::blocked_range<long> const&)#1}, tbb::affinity_partitioner>::execute() /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/parallel_for.h:143
22:57:05     #9 0x7fab8080d375 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/custom_scheduler.h:509:33
22:57:05     #10 0x7fab80801ed0 in tbb::internal::generic_scheduler::local_spawn_root_and_wait(tbb::task*, tbb::task*&) /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.cpp:670:5
22:57:05     #11 0x7fab803cdb63 in tbb::task::spawn_root_and_wait(tbb::task&) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/internal/../task.h:752:30
22:57:05     #12 0x7fab803cdb63 in _ZN3tbb10interface98internal9start_forINS_13blocked_rangeIlEEZN2at15parallel_for_1dIZNS5_6native12_GLOBAL__N_1L14parallel_applyIdZZZNS7_L11acos_kernelERNS5_6TensorERKSA_ENK3$_2clEvENKUlvE_clEvEUlRKNS5_6vec25612_GLOBAL__N_16Vec256IdEEE_EEvSB_SD_T0_EUlllE_EEvT_lllbEUlRKS4_E_NS_20affinity_partitionerEE3runESR_RKSS_RST_ /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/parallel_for.h:96
22:57:05     #13 0x7fab803cdb63 in void tbb::parallel_for<tbb::blocked_range<long>, void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool)::{lambda(tbb::blocked_range<long> const&)#1}>(void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool)::{lambda(tbb::blocked_range<long> const&)#1} const&, {lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1} const&, tbb::affinity_partitioner&) /var/lib/jenkins/workspace/aten/src/ATen/../../../third_party/tbb/include/tbb/parallel_for.h:230
22:57:05     #14 0x7fab803cdb63 in void at::parallel_for_1d<void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}>(void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1})::{lambda(long, long)#1}, long, long, long, bool) /var/lib/jenkins/workspace/aten/src/ATen/Parallel.h:49
22:57:05     #15 0x7fab803cdb63 in void at::native::(anonymous namespace)::parallel_apply<double, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}>(at::Tensor&, at::Tensor const&, at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const::{lambda(at::vec256::(anonymous namespace)::Vec256<double> const&)#1}) /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp.AVX2.cpp:21
22:57:05     #16 0x7fab803cdb63 in at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const::{lambda()#1}::operator()() const /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp.AVX2.cpp:61
22:57:05     #17 0x7fab803cdb63 in at::native::acos_kernel(at::Tensor&, at::Tensor const&)::$_2::operator()() const /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp.AVX2.cpp:61
22:57:05     #18 0x7fab803cdb63 in at::native::acos_kernel(at::Tensor&, at::Tensor const&) /var/lib/jenkins/workspace/build/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp.AVX2.cpp:61
22:57:05     #19 0x7fab7ed661e4 in void at::native::DispatchStub<void (*)(at::Tensor&, at::Tensor const&)>::operator()<at::Tensor, at::Tensor>(at::Tensor, at::Tensor) /var/lib/jenkins/workspace/aten/src/ATen/native/cpu/CapabilityDispatch.h:43:5
22:57:05     #20 0x7fab7ed661e4 in at::native::_acos_out_cpu(at::Tensor&, at::Tensor const&) /var/lib/jenkins/workspace/aten/src/ATen/native/UnaryOps.cpp:130
22:57:05     #21 0x7fab7f17950e in at::CPUDoubleType::acos_out(at::Tensor&, at::Tensor const&) const /var/lib/jenkins/workspace/build/aten/src/ATen/CPUDoubleType.cpp:5652:13
22:57:05     #22 0x7fab7ed4d8ce in at::acos_out(at::Tensor&, at::Tensor const&) /var/lib/jenkins/workspace/build/aten/src/ATen/Functions.h:2967:29
22:57:05     #23 0x7fab7ed4d8ce in at::native::acos(at::Tensor const&) /var/lib/jenkins/workspace/aten/src/ATen/native/UnaryOps.cpp:102
22:57:05     #24 0x7fab7f3c9db0 in at::Type::acos(at::Tensor const&) const /var/lib/jenkins/workspace/build/aten/src/ATen/Type.cpp:2980:13
22:57:05     #25 0x7fab83478944 in torch::autograd::VariableType::acos(at::Tensor const&) const /var/lib/jenkins/workspace/torch/csrc/autograd/generated/VariableType.cpp:21652:39
22:57:05     #26 0x7fab83b0ac0f in at::Tensor::acos() const /var/lib/jenkins/workspace/torch/lib/tmp_install/include/ATen/TensorMethods.h:861:19
22:57:05     #27 0x7fab83b0a80e in torch::autograd::dispatch_acos(at::Tensor const&) /var/lib/jenkins/workspace/torch/csrc/autograd/generated/python_torch_functions_dispatch.h:725:15
22:57:05     #28 0x7fab83994a02 in torch::autograd::THPVariable_acos(_object*, _object*, _object*) /var/lib/jenkins/workspace/torch/csrc/autograd/generated/python_torch_functions.cpp:1368:19
22:57:05     #29 0x560b7cc57753 in _PyCFunction_FastCallDict (/opt/conda/bin/python3.6+0x10f753)
22:57:05 
22:57:05 SUMMARY: AddressSanitizer: heap-use-after-free /var/lib/jenkins/workspace/third_party/tbb/src/tbb/scheduler.h:571:26 in tbb::internal::generic_scheduler::is_worker() const
22:57:05 Shadow bytes around the buggy address:
22:57:05   0x0c2c800a7fb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a7fc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a7fd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a7fe0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a7ff0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
22:57:05 =>0x0c2c800a8000: fd fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd
22:57:05   0x0c2c800a8010: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
22:57:05   0x0c2c800a8020: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
22:57:05   0x0c2c800a8030: fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
22:57:05   0x0c2c800a8050: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
22:57:05 Shadow byte legend (one shadow byte represents 8 application bytes):
22:57:05   Addressable:           00
22:57:05   Partially addressable: 01 02 03 04 05 06 07 
22:57:05   Heap left redzone:       fa
22:57:05   Freed heap region:       fd
22:57:05   Stack left redzone:      f1
22:57:05   Stack mid redzone:       f2
22:57:05   Stack right redzone:     f3
22:57:05   Stack after return:      f5
22:57:05   Stack use after scope:   f8
22:57:05   Global redzone:          f9
22:57:05   Global init order:       f6
22:57:05   Poisoned by user:        f7
22:57:05   Container overflow:      fc
22:57:05   Array cookie:            ac
22:57:05   Intra object redzone:    bb
22:57:05   ASan internal:           fe
22:57:05   Left alloca redzone:     ca
22:57:05   Right alloca redzone:    cb
22:57:05 ==584==ABORTING
22:57:05 Traceback (most recent call last):
22:57:05   File "test/run_test.py", line 342, in <module>
22:57:05     main()
22:57:05   File "test/run_test.py", line 334, in main
22:57:05     raise RuntimeError(message)
22:57:05 RuntimeError: test_cuda failed!
22:57:05 + cleanup
```

CC @cpuhrsch 