### PR TITLE
Split SparseTensorImpl off from TensorImpl.

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include "ATen/TensorImpl.h"
+
+namespace at {
+struct SparseTensorImpl : public TensorImpl {
+  explicit SparseTensorImpl(Type * type)
+  : TensorImpl(type) {}
+};
+} // namespace at

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <atomic>
-#include <memory>
-
 #include "ATen/TensorImpl.h"
 
 namespace at {

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -110,6 +110,7 @@ TYPE_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/Type.cpp")
 
 TENSOR_DERIVED_CPP = CodeTemplate.from_file(
     TEMPLATE_PATH + "/TensorDerived.cpp")
+SPARSE_TENSOR_DERIVED_CPP = TENSOR_DERIVED_CPP  # for now, anyhoo
 TENSOR_SPARSE_CPP = CodeTemplate.from_file(
     TEMPLATE_PATH + "/TensorSparse.cpp")
 TENSOR_DENSE_CPP = CodeTemplate.from_file(
@@ -119,6 +120,7 @@ REGISTER_CUDA_H = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCUDA.h")
 REGISTER_CUDA_CPP = CodeTemplate.from_file(TEMPLATE_PATH + "/RegisterCUDA.cpp")
 
 TENSOR_DERIVED_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TensorDerived.h")
+SPARSE_TENSOR_DERIVED_H = CodeTemplate.from_file(TEMPLATE_PATH + "/SparseTensorDerived.h")
 TENSOR_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Tensor.h")
 TENSOR_METHODS_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TensorMethods.h")
 
@@ -332,7 +334,10 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
     fm.write(env['Type'] + ".h", TYPE_DERIVED_H, env)
 
     fm.write(env['Tensor'] + ".cpp", TENSOR_DERIVED_CPP, env)
-    fm.write(env['Tensor'] + ".h", TENSOR_DERIVED_H, env)
+    if density != 'SPARSE':
+        fm.write(env['Tensor'] + ".h", TENSOR_DERIVED_H, env)
+    else:
+        fm.write(env['Tensor'] + ".h", SPARSE_TENSOR_DERIVED_H, env)
 
     type_register = TYPE_REGISTER.substitute(backend=env['Backend'], scalar_type=scalar_name, type_name=env['Type'])
     if env['DenseBackend'] == 'CPU':

--- a/aten/src/ATen/templates/SparseTensorDerived.h
+++ b/aten/src/ATen/templates/SparseTensorDerived.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// ${generated_comment}
+
+$th_headers
+
+#include "ATen/Tensor.h"
+#include "ATen/SparseTensorImpl.h"
+#include "ATen/Context.h"
+#include "ATen/TensorMethods.h"
+
+namespace at {
+
+struct ${Tensor} final : public SparseTensorImpl {
+public:
+  explicit ${Tensor}(Context* context);
+  ${Tensor}(Context* context, ${THTensor} * tensor);
+  virtual ~${Tensor}();
+  virtual const char * toString() const override;
+  virtual IntList sizes() const override;
+  virtual IntList strides() const override;
+  virtual int64_t dim() const override;
+  virtual Scalar localScalar() override;
+  virtual void * unsafeGetTH(bool retain) override;
+  virtual std::unique_ptr<Storage> storage() override;
+  static const char * typeString();
+
+//TODO(zach): sort of friend permissions later so this
+// can be protected
+public:
+  ${THTensor} * tensor;
+  Context* context;
+  friend struct ${Type};
+};
+
+} // namespace at


### PR DESCRIPTION
At the moment they have the same data layout, but with the upcoming refactor
they will not, and we need a place to put all of the sparse tensor specific
fields.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

