### PR TITLE
[READY TO MERGE] Use ccache in macOS build

### DIFF
--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -25,9 +25,9 @@ export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
-if which ccache > /dev/null; then
-  export CXX="ccache clang++"
-  export CC="ccache clang"
+if which sccache > /dev/null; then
+  export CXX="sccache clang++"
+  export CC="sccache clang"
 fi
 # If we run too many parallel jobs, we will OOM
 export MAX_JOBS=2

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -25,6 +25,10 @@ export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
+if which ccache > /dev/null; then
+  export CXX="ccache clang++"
+  export CC="ccache clang"
+fi
 # If we run too many parallel jobs, we will OOM
 export MAX_JOBS=2
 

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -21,7 +21,7 @@ rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 
-# Build and test PyTorch
+# Build PyTorch
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -25,9 +25,9 @@ export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
-if which ccache > /dev/null; then
-  export CXX="ccache clang++"
-  export CC="ccache clang"
+if which sccache > /dev/null; then
+  export CXX="sccache clang++"
+  export CC="sccache clang"
 fi
 # If we run too many parallel jobs, we will OOM
 export MAX_JOBS=2

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -25,6 +25,10 @@ export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
+if which ccache > /dev/null; then
+  export CXX="ccache clang++"
+  export CC="ccache clang"
+fi
 # If we run too many parallel jobs, we will OOM
 export MAX_JOBS=2
 

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -21,14 +21,10 @@ rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 
-# Build and test PyTorch
+# Test PyTorch
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export CXX=clang++
 export CC=clang
-if which sccache > /dev/null; then
-  export CXX="sccache clang++"
-  export CC="sccache clang"
-fi
 # If we run too many parallel jobs, we will OOM
 export MAX_JOBS=2
 


### PR DESCRIPTION
It seems that ccache isn't actually being used in macOS CI builds. This PR enables it and it should save some time from the build.