### PR TITLE
Remove WITH_ROCM cmake flag/variable (use USE_ROCM solely)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,6 @@ cmake_dependent_option(
     WITH_CUDA "Legacy CUDA" ON
     "USE_CUDA" OFF)
 cmake_dependent_option(
-    WITH_ROCM "Legacy ROCm" ON
-    "USE_ROCM" OFF)
-cmake_dependent_option(
     NO_CUDA "Legacy no CUDA" OFF
     "USE_CUDA" ON)
 cmake_dependent_option(

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -25,18 +25,12 @@ else()
   cmake_dependent_option(
       NO_MKLDNN "Legacy no MKLDNN" OFF
       "USE_MKLDNN" ON)
-  cmake_dependent_option(
-      WITH_ROCM "Legacy ROCm" ON
-      "USE_ROCM" OFF)
 
   # Flag for shared dependencies
   set(BUILD_ATEN ON)
 endif()
 if (NOT USE_CUDA)
   set(NO_CUDA ON)
-endif()
-if (WITH_ROCM)
-  set(USE_ROCM ON)
 endif()
 
 # Create the project in all cases
@@ -123,7 +117,7 @@ add_subdirectory(src/THNN)
 add_subdirectory(src/THS)
 
 # Find the HIP package, set the HIP paths, load the HIP CMake.
-IF(WITH_ROCM)
+IF(USE_ROCM)
   include(LoadHIP)
 ENDIF()
 
@@ -133,7 +127,7 @@ IF(MSVC)
   LIST(APPEND CUDA_NVCC_FLAGS "-Xcompiler /wd4819 -Xcompiler /wd4503 -Xcompiler /wd4190 -Xcompiler /wd4244 -Xcompiler /wd4251 -Xcompiler /wd4275 -Xcompiler /wd4522")
 ENDIF(MSVC)
 
-if(WITH_ROCM)
+if(USE_ROCM)
   SET(AT_CUDA_ENABLED 1)
   add_subdirectory(src/THC)
   add_subdirectory(src/THCUNN)

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -67,7 +67,7 @@ if(AT_MKLDNN_ENABLED)
   set(all_cpu_cpp ${all_cpu_cpp} ${mkldnn_cpp})
 endif()
 
-IF(NOT NO_CUDA OR WITH_ROCM)
+IF(NOT NO_CUDA OR USE_ROCM)
   list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/cuda)
   set(ATen_CUDA_SRCS ${ATen_CUDA_SRCS} ${cuda_cu} ${native_cuda_cu})
   set(all_cuda_cpp ${native_cudnn_cpp} ${cuda_cpp} ${native_cuda_cpp} ${cuda_generated_cpp} ${ATen_CUDA_SRCS})
@@ -109,13 +109,13 @@ IF(BLAS_FOUND)
     MESSAGE(STATUS "TH_BINARY_BUILD detected. Enabling special linkage.")
     list(APPEND ATen_CPU_DEPENDENCY_LIBS
       "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
-    if(NOT NO_CUDA OR WITH_ROCM)
+    if(NOT NO_CUDA OR USE_ROCM)
       list(APPEND ATen_CUDA_DEPENDENCY_LIBS
         "${BLAS_LIBRARIES};${BLAS_LIBRARIES};${BLAS_LIBRARIES}")
     endif()
   ELSE ($ENV{TH_BINARY_BUILD})
     list(APPEND ATen_CPU_DEPENDENCY_LIBS ${BLAS_LIBRARIES})
-    if(NOT NO_CUDA OR WITH_ROCM)
+    if(NOT NO_CUDA OR USE_ROCM)
       list(APPEND ATen_CUDA_DEPENDENCY_LIBS "${BLAS_LIBRARIES}")
     endif()
   ENDIF ($ENV{TH_BINARY_BUILD})
@@ -123,7 +123,7 @@ ENDIF(BLAS_FOUND)
 
 IF(LAPACK_FOUND)
   list(APPEND ATen_CPU_DEPENDENCY_LIBS ${LAPACK_LIBRARIES})
-  if(NOT NO_CUDA OR WITH_ROCM)
+  if(NOT NO_CUDA OR USE_ROCM)
     # Although Lapack provides CPU (and thus, one might expect that ATen_cuda
     # would not need this at all), some of our libraries (magma in particular)
     # backend to CPU BLAS/LAPACK implementations, and so it is very important
@@ -268,7 +268,7 @@ IF(NOT NO_CUDA)
   ENDIF($ENV{ATEN_STATIC_CUDA})
 ENDIF()
 
-IF(WITH_ROCM)
+IF(USE_ROCM)
  ### Link in the ROCm libraries BLAS / RNG.
  FIND_LIBRARY(HIPBLAS_LIBRARY hipblas HINTS ${HIPBLAS_PATH}/lib)
  FIND_LIBRARY(HIPRNG_LIBRARY hiprng HINTS ${HIPRNG_PATH}/lib)
@@ -307,7 +307,7 @@ else()
   set(ATen_CPU_SRCS)
 endif()
 
-if(NOT NO_CUDA OR WITH_ROCM)
+if(NOT NO_CUDA OR USE_ROCM)
   if(AT_LINK_STYLE STREQUAL "INTERFACE")
     # Source code can't be added to an interface library, so it is
     # passed back to be compiled into the containing library
@@ -361,14 +361,14 @@ if(NOT AT_LINK_STYLE STREQUAL "INTERFACE")
 
   if(NOT MSVC)
     aten_compile_options(ATen_cpu)
-    if(NOT NO_CUDA OR WITH_ROCM)
+    if(NOT NO_CUDA OR USE_ROCM)
       aten_compile_options(ATen_cuda)
     endif()
   endif()
 
   if(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")
     set_property(TARGET ATen_cpu PROPERTY CXX_STANDARD 11)
-    if(NOT NO_CUDA OR WITH_ROCM)
+    if(NOT NO_CUDA OR USE_ROCM)
       set_property(TARGET ATen_cuda PROPERTY CXX_STANDARD 11)
     endif()
   endif()
@@ -382,7 +382,7 @@ if (NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
   get_filename_component(ATEN_CPU_OUTPUT_NAME ${ATEN_CPU_OUTPUT_NAME} NAME)
   set(ATEN_LIBRARIES
     "${CMAKE_INSTALL_PREFIX}/${AT_INSTALL_LIB_DIR}/${ATEN_CPU_OUTPUT_NAME}")
-  if(NOT NO_CUDA OR WITH_ROCM)
+  if(NOT NO_CUDA OR USE_ROCM)
     get_target_property(ATEN_CUDA_OUTPUT_NAME ATen_cuda LOCATION)
     get_filename_component(ATEN_CUDA_OUTPUT_NAME ${ATEN_CUDA_OUTPUT_NAME} NAME)
     list(APPEND ATEN_LIBRARIES
@@ -394,7 +394,7 @@ if (NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
     LIBRARY DESTINATION "${AT_INSTALL_LIB_DIR}"
     ARCHIVE DESTINATION "${AT_INSTALL_LIB_DIR}")
 
-  if(NOT NO_CUDA OR WITH_ROCM)
+  if(NOT NO_CUDA OR USE_ROCM)
     install(TARGETS ATen_cuda
       RUNTIME DESTINATION "${AT_INSTALL_BIN_DIR}"
       LIBRARY DESTINATION "${AT_INSTALL_LIB_DIR}"
@@ -444,7 +444,7 @@ if (NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
     install(TARGETS ${test_name} DESTINATION test)
   endforeach()
 
-  if(NOT NO_CUDA OR WITH_ROCM)
+  if(NOT NO_CUDA OR USE_ROCM)
     foreach(test_src ${ATen_CUDA_TEST_SRCS})
       get_filename_component(test_name ${test_src} NAME_WE)
       torch_cuda_based_add_executable(${test_name} "${test_src}")


### PR DESCRIPTION
Note I have kept WITH_ROCM as the environment variable and C++ defines to be consistent with other parts of pytorch.