### PR TITLE
Allow CI testing with different AVX configs

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -34,6 +34,15 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     (cd test && ! python -c "import torch; torch._C._crash_if_aten_asan(3)")
 fi
 
+export ATEN_DISABLE_AVX=0
+export ATEN_DISABLE_AVX2=0
+if [[ "${JOB_BASE_NAME}" == *NO_AVX* ]]; then
+  export ATEN_DISABLE_AVX=1
+fi
+if [[ "${JOB_BASE_NAME}" == *NO_AVX2* ]]; then
+  export ATEN_DISABLE_AVX2=1
+fi
+
 test_python_nn() {
   time python test/run_test.py --include nn --verbose
 }

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -34,8 +34,8 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     (cd test && ! python -c "import torch; torch._C._crash_if_aten_asan(3)")
 fi
 
-export ATEN_DISABLE_AVX=0
-export ATEN_DISABLE_AVX2=0
+export ATEN_DISABLE_AVX=
+export ATEN_DISABLE_AVX2=
 if [[ "${JOB_BASE_NAME}" == *NO_AVX* ]]; then
   export ATEN_DISABLE_AVX=1
 fi


### PR DESCRIPTION
This PR allows the CI tests to be run with different AVX configurations (disabling AVX or AVX2), to make sure that the tests pass even without the AVX / AVX2 code paths.