### PR TITLE
Fix profiler crash when no events register

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -542,7 +542,7 @@ def build_table(events, sort_by=None, header=None):
     """Prints a summary of events (which can be a list of FunctionEvent or FunctionEventAvg)."""
     if sort_by is not None:
         events = sorted(events, key=lambda evt: getattr(evt, sort_by))
-        
+
     name_lengths = [len(evt.key) for evt in events]
     if len(name_lengths) == 0:
         return ""

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -542,8 +542,11 @@ def build_table(events, sort_by=None, header=None):
     """Prints a summary of events (which can be a list of FunctionEvent or FunctionEventAvg)."""
     if sort_by is not None:
         events = sorted(events, key=lambda evt: getattr(evt, sort_by))
-
-    max_name_length = max(len(evt.key) for evt in events)
+        
+    name_lengths = [len(evt.key) for evt in events]
+    if len(name_lengths) == 0:
+        return ""
+    max_name_length = max(name_lengths)
     max_name_length += 4  # Add some nice padding
     col_width = 15
     col_format = '  {: >' + str(col_width) + '}'


### PR DESCRIPTION
When trying to profile, attempting to print the event table throws a vague error because the event list is empty:

....
max_name_length = max(len(evt.key) for evt in events)
ValueError: max() arg is an empty sequence

This change fixes the error by returning an empty string.

