### PR TITLE
Allow parallel_apply to take in list[Tensor]

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2411,16 +2411,15 @@ class TestNN(NNTestCase):
         i2 = torch.randn(2, 10, device="cuda:1", dtype=torch.float)
         expected1 = l1(i1).data
         expected2 = l2(i2).data
-        inputs = ((i1,), (i2,))
         modules = (l1, l2)
         expected_outputs = (expected1, expected2)
 
-        outputs = dp.parallel_apply(modules, inputs, None)
-        for out, expected in zip(outputs, expected_outputs):
-            self.assertEqual(out.data, expected)
-
-        inputs = (i1, i2.new_empty(0))
-        expected_outputs = (expected1, expected2.new_empty(0))
+        # each input can be either a collection of positional arguments
+        #                       or an object representing the single argument
+        for inputs in [((i1,), (i2,)), (i1, i2)]:
+            outputs = dp.parallel_apply(modules, inputs, None)
+            for out, expected in zip(outputs, expected_outputs):
+                self.assertEqual(out.data, expected)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_data_parallel_multiple_input(self):

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -18,6 +18,15 @@ def get_a_var(obj):
 
 
 def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
+    r"""Applies each `module` in :attr:`modules` in parallel on arguments
+    contained in :attr:`inputs` (positional) and :attr:`kwargs_tup` (keyword)
+    on each of :attr:`devices`.
+
+    :attr:`modules`, :attr:`inputs`, :attr:`kwargs_tup` (if given), and
+    :attr:`devices` (if given) should all have same length. Moreover, each
+    element of :attr:`inputs` can either be a single object as the only argument
+    to a module, or a collection of positional arguments.
+    """
     assert len(modules) == len(inputs)
     if kwargs_tup is not None:
         assert len(modules) == len(kwargs_tup)
@@ -38,6 +47,9 @@ def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
             device = get_a_var(input).get_device()
         try:
             with torch.cuda.device(device):
+                # this also avoids accidental slicing of `input` if it is a Tensor
+                if not isinstance(input, (list, tuple)):
+                    input = (input,)
                 output = module(*input, **kwargs)
             with lock:
                 results[i] = output


### PR DESCRIPTION
This has no harm, but makes using `parallel_apply` nicer, and also avoids accidental slicing of Tensor if one accidentally pass in `[tensor0, tensor1]` as `input` instead of `[[tensor0], [tensor1]]`. It is actually particularly easy to make this mistake because `[tensor0, tensor1]` is the result of `scatter(a_single_tensor_arg)`, e.g. #6983 .
