### PR TITLE
Add code for TensorBoard visualization of JIT GraphExecutors

### DIFF
--- a/torch/contrib/_tensorboard_vis.py
+++ b/torch/contrib/_tensorboard_vis.py
@@ -106,6 +106,7 @@ def visualize_rec(graph, value_map, name_prefix, pb_graph, executors_it=None):
             value_map[val.unique()] = rec_value_map[out.unique()]
 
     op_id_counter = defaultdict(int)
+
     def name_for(node):
         kind = node.kind()[node.kind().index('::') + 2:]
         op_id_counter[kind] += 1

--- a/torch/contrib/_tensorboard_vis.py
+++ b/torch/contrib/_tensorboard_vis.py
@@ -1,0 +1,141 @@
+import time
+from collections import defaultdict
+from functools import partial
+
+
+# Unfortunately it doesn't seem as if there was any way to get TensorBoard to do
+# anything without having TF installed, and so this file has a hard dependency on it
+# as well. It really is a debugging tool, so it doesn't matter.
+try:
+    from tensorflow.core.util import event_pb2
+    from tensorflow.core.framework import graph_pb2
+    from tensorflow.python.summary.writer.writer import FileWriter
+except ImportError:
+    raise ImportError("TensorBoard visualization of GraphExecutors requires having "
+                      "TensorFlow installed")
+
+
+def dump_tensorboard_summary(graph_executor, logdir):
+    with FileWriter(logdir) as w:
+        pb_graph = visualize(graph_executor)
+        evt = event_pb2.Event(wall_time=time.time(), graph_def=pb_graph.SerializeToString())
+        w.add_event(evt)
+
+
+def visualize(graph, name_prefix='', pb_graph=None, executors_it=None):
+    """Visualizes an independent graph, or a graph executor."""
+    value_map = {}
+    pb_graph = pb_graph or graph_pb2.GraphDef()
+
+    if isinstance(graph, (torch._C.GraphExecutor, torch._C.GraphExecutorState)):
+        visualize_graph_executor(graph, name_prefix, pb_graph,
+                                 partial(visualize, pb_graph=pb_graph))
+        return pb_graph
+
+    # Set up an input node
+    input_node = pb_graph.node.add(op='input', name=name_prefix + 'input')
+    for i, value in enumerate(graph.param_node().outputs()):
+        value_map[value.unique()] = name_prefix + 'input:' + str(i)
+
+    visualize_rec(graph, value_map, name_prefix, pb_graph, executors_it)
+
+    # Gather all outputs
+    return_node = pb_graph.node.add(op='output', name=name_prefix + 'output')
+    for value in graph.return_node().inputs():
+        return_node.input.append(value_map[value.unique()])
+
+    return pb_graph
+
+
+def visualize_graph_executor(state, name_prefix, pb_graph, inline_graph):
+    """Appends the state of a given GraphExecutor to the graph protobuf.
+
+    Arguments:
+        state (GraphExecutor or GraphExecutorState): GraphExecutor to display.
+        name_prefix (str): Name prefix of the containing subgraph.
+        pb_graph (GraphDef): graph to append to.
+        inline_graph (callable): a function that handles setting up a value_map,
+            so that some graphs in here can be inlined. This is necessary, because
+            this will simply be `visualize` for the top-level GraphExecutor,
+            or `inline_graph` for all nested ones.
+
+            The signature should look like (Graph, name_prefix) -> ().
+            It will be called exactly once.
+
+    The strategy is to embed all different configurations as independent subgraphs,
+    while inlining the original graph as the one that actually produces the values.
+    """
+    if isinstance(state, torch._C.GraphExecutor):
+        state = state.get_debug_state()
+
+    if state.autograd_fallback_graph is not None:
+        visualize(graph=state.autograd_fallback_graph,
+                  name_prefix=name_prefix + 'autograd_fallback/',
+                  pb_graph=pb_graph,
+                  executors_it=iter(state.autograd_fallback.executors()))
+
+    for i, (arg_spec, plan) in enumerate(state.execution_plans.items()):
+        subgraph_name = name_prefix + 'plan{}/'.format(i)
+
+        # Create a disconnected node that will keep information regarding the input
+        # types of this trace. This is unfortunately a bit too verbose to be included
+        # in the subgraph name.
+        input_kinds = pb_graph.node.add(op='INPUT_KIND', name=subgraph_name)
+        input_kinds.attr['inputs'].s = repr(arg_spec).encode('ascii')
+
+        visualize(plan.graph, subgraph_name, pb_graph, iter(plan.code.executors()))
+
+        # Show gradient as an independent subgraph of this plan
+        if plan.grad_executor is not None:
+            grad_subgraph_name = subgraph_name + 'grad/'
+            visualize(plan.grad_executor, grad_subgraph_name, pb_graph)
+
+    return inline_graph(state.graph, name_prefix + 'original/')
+
+
+def visualize_rec(graph, value_map, name_prefix, pb_graph, executors_it=None):
+    """Recursive part of visualize (basically skips setting up the input and output nodes)."""
+    def inline_graph(subgraph, name, node):
+        rec_value_map = {inp.unique(): value_map[val.unique()]
+                         for inp, val in zip(subgraph.inputs(), node.inputs())}
+        visualize_rec(graph=subgraph,
+                      value_map=rec_value_map,
+                      name_prefix=name,
+                      pb_graph=pb_graph)
+        for out, val in zip(subgraph.outputs(), node.outputs()):
+            value_map[val.unique()] = rec_value_map[out.unique()]
+
+    op_id_counter = defaultdict(int)
+    def name_for(node):
+        kind = node.kind()[node.kind().index('::') + 2:]
+        op_id_counter[kind] += 1
+        return kind, name_prefix + kind + '_' + str(op_id_counter[kind])
+
+    def add_fusion_group(node):
+        op, name = name_for(node)
+        inline_graph(node.g('Subgraph'), name + '/', node)
+
+    def add_graph_executor(node):
+        op, name = name_for(node)
+        if executors_it is None:
+            add_node(node)
+        else:
+            ge = next(executors_it)
+            visualize_graph_executor(ge, name + '/', pb_graph,
+                                     partial(inline_graph, node=node))
+
+    def add_node(node):
+        if node.kind() == 'prim::FusionGroup':
+            return add_fusion_group(node)
+        elif node.kind() == 'prim::GraphExecutor':
+            return add_graph_executor(node)
+        op, name = name_for(node)
+        pb_node = pb_graph.node.add(op=op, name=name)
+        for value in node.inputs():
+            pb_node.input.append(value_map[value.unique()])
+        # TODO: handle attrs
+        for i, value in enumerate(node.outputs()):
+            value_map[value.unique()] = name + ':' + str(i)
+
+    for node in graph.nodes():
+        add_node(node)

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -3,8 +3,34 @@
 #include <memory>
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/variable_tensor_list.h"
+#include "torch/csrc/jit/interpreter.h"
+#include "torch/csrc/jit/autodiff.h"
+#include "torch/csrc/jit/argument_spec.h"
 
 namespace torch { namespace jit {
+
+struct GraphExecutorState;
+
+// Notice that those structs don't manage lifetime of their members.
+// They is only valid only right after you call getDebugState() and should never
+// be used again once another GraphExecutor function is called.
+struct ExecutionPlanState {
+  Code* f;
+  Graph* graph;
+
+  // Those two fields are optional
+  Gradient* grad;
+  std::shared_ptr<GraphExecutorState> grad_executor; // shared_ptr to break the cycle...
+};
+
+struct GraphExecutorState {
+  Graph* graph;
+  std::unordered_map<ArgumentSpec, ExecutionPlanState> execution_plans;
+
+  // Those two fields are optional
+  Code* autograd_fallback;
+  Graph* autograd_fallback_graph;
+};
 
 struct GraphExecutorImpl;
 struct GraphExecutor {
@@ -18,6 +44,7 @@ struct GraphExecutor {
   }
   std::shared_ptr<Graph> graph() const;
   std::shared_ptr<Graph> graphFor(const variable_tensor_list& inputs) const;
+  GraphExecutorState getDebugState();
 private:
   std::shared_ptr<GraphExecutorImpl> pImpl;
 };

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -398,143 +398,6 @@ Operation createCppOperation(CppOp* op) {
   };
 }
 
-// Returns a function implementing functionality of a given node,
-// or nullptr if it's a no-op for autograd.
-Operation getOperation(jit::Node* node) {
-  IR_IFM(node, CppOp)
-    JIT_ASSERT(!dynamic_cast<autograd::Eval*>(value->fn.get()));
-    return createCppOperation(value);
-  IR_ELSEIF(FusionGroup)
-    auto fusion_fn = sharedFusionCompiler().getOrCompile(value);
-    auto num_inputs = value->inputs().size();
-    return [fusion_fn, num_inputs](Stack & stack) {
-      autograd::profiler::RecordFunction record("FusionGroup");
-      std::vector<at::Tensor> toutputs;
-      // TODO: have fusion_fn work off of a stack as well
-      fusion_fn->launch(last(stack, num_inputs), toutputs);
-      drop(stack, num_inputs);
-      stack.insert(stack.end(), toutputs.begin(), toutputs.end());
-      return 0;
-    };
-  IR_ELSEIF(Constant)
-    auto t = autograd::make_variable(value->t(attr::value));
-    return [t](Stack & stack) {
-      stack.push_back(t);
-      return 0;
-    };
-  IR_ELSEIF(Undefined)
-    return [](Stack & stack) {
-      stack.push_back(at::Tensor());
-      return 0;
-    };
-  IR_ELSEIF(ReplaceIfUndef)
-    return [](Stack & stack) {
-      auto alternate = pop(stack);
-      auto result = pop(stack);
-      if(result.defined()) {
-        stack.push_back(std::move(result));
-      } else {
-        stack.push_back(std::move(alternate));
-      }
-      return 0;
-    };
-  IR_ELSEIF(Print)
-    size_t num_inputs = value->inputs().size();
-    return [num_inputs](Stack & stack) {
-      bool first = true;
-      for (at::Tensor i : last(stack, num_inputs)) {
-        if (!first) std::cout << " ";
-        first = false;
-        if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
-          std::cout << at::Tensor(tensor_impl, true);
-        } else if (!i.defined()) {
-          std::cout << "<undefined tensor>";
-        } else {
-          auto& r = *i.get();
-          std::cout << "<" << typeid(r).name() << " at " << i << ">";
-        }
-      }
-      drop(stack, num_inputs);
-      std::cout << std::endl;
-      return 0;
-    };
-  IR_ELSEIF(GraphExecutor)
-    GraphExecutor executor(value->g(attr::Subgraph));
-    auto num_inputs = value->inputs().size();
-    return [=](Stack& stack) mutable {
-      autograd::profiler::RecordFunction record("GraphExecutor");
-      auto inputs = last(stack, num_inputs);
-      variable_tensor_list tinputs(inputs.begin(), inputs.end());
-      drop(stack, num_inputs);
-      //TODO: has graph executor work from a stack as well
-      variable_tensor_list toutputs = executor.run(variable_tensor_list(std::move(tinputs)));
-      stack.insert(stack.end(), toutputs.begin(), toutputs.end());
-      return 0;
-    };
-
-
-  // Load x, y
-  // loads values from registers onto the stack, the actual callback does
-  // nothing since the stack manipulation is already encoded in inst.inputs
-  // and inst.outputs
-  IR_ELSEIF(Load)
-    return [=](Stack& stack) {
-      return 0;
-    };
-
-  // x, y = Store
-  // stores values from stack into registers, the actual callback does
-  // nothing since the stack manipulation is already encoded in inst.inputs
-  // and inst.outputs
-  IR_ELSEIF(Store)
-    return [=](Stack& stack) {
-      return 0;
-    };
-  IR_ELSEIF(Drop)
-    auto N = value->inputs().size();
-    return [=](Stack& stack) {
-      drop(stack, N);
-      return 0;
-    };
-  IR_ELSE()
-    switch (node->kind()) {
-      case onnx::Reshape: {
-        return [=](Stack& stack) {
-          auto shape = pop(stack).contiguous();
-          auto input = pop(stack);
-          JIT_ASSERT(shape.ndimension() == 1);
-          at::IntList shape_list(shape.data<int64_t>(), shape.size(0));
-          stack.push_back(input.reshape(shape_list));
-          return 0;
-        };
-      } break;
-      case onnx::Shape: {
-        return [=](Stack& stack) {
-          auto t = pop(stack);
-          at::IntList sizes = t.sizes();
-          auto sizes_tensor = torch::CPU(at::kLong).tensor(sizes.size());
-          auto accessor = sizes_tensor.accessor<int64_t, 1>();
-          for (size_t i=0; i<sizes.size(); ++i) {
-            accessor[i] = sizes[i];
-          }
-          stack.push_back(sizes_tensor);
-          return 0;
-        };
-      } break;
-      default: ;
-    };
-
-    // ops registered in another compilation unit
-    // eg: the PythonOp handler
-    if(auto op = lookupExternalOp(node)) {
-      return *op;
-    }
-
-    return getTensorOp(node).op;
-  IR_END()
-}
-
-
 // We need some lists for inputs and outputs. To keep all the memory
 // contiguous we allocate a single vector and use offsets into the vector
 // which are stored in the ListHandle struct
@@ -784,6 +647,146 @@ struct CodeImpl {
     return r;
   }
 
+  // Returns a function implementing functionality of a given node,
+  // or nullptr if it's a no-op for autograd.
+  Operation getOperation(jit::Node* node) {
+    IR_IFM(node, CppOp)
+      JIT_ASSERT(!dynamic_cast<autograd::Eval*>(value->fn.get()));
+      return createCppOperation(value);
+    IR_ELSEIF(FusionGroup)
+      auto fusion_fn = sharedFusionCompiler().getOrCompile(value);
+      auto num_inputs = value->inputs().size();
+      return [fusion_fn, num_inputs](Stack & stack) {
+        autograd::profiler::RecordFunction record("FusionGroup");
+        std::vector<at::Tensor> toutputs;
+        // TODO: have fusion_fn work off of a stack as well
+        fusion_fn->launch(last(stack, num_inputs), toutputs);
+        drop(stack, num_inputs);
+        stack.insert(stack.end(), toutputs.begin(), toutputs.end());
+        return 0;
+      };
+    IR_ELSEIF(Constant)
+      auto t = autograd::make_variable(value->t(attr::value));
+      return [t](Stack & stack) {
+        stack.push_back(t);
+        return 0;
+      };
+    IR_ELSEIF(Undefined)
+      return [](Stack & stack) {
+        stack.push_back(at::Tensor());
+        return 0;
+      };
+    IR_ELSEIF(ReplaceIfUndef)
+      return [](Stack & stack) {
+        auto alternate = pop(stack);
+        auto result = pop(stack);
+        if(result.defined()) {
+          stack.push_back(std::move(result));
+        } else {
+          stack.push_back(std::move(alternate));
+        }
+        return 0;
+      };
+    IR_ELSEIF(Print)
+      size_t num_inputs = value->inputs().size();
+      return [num_inputs](Stack & stack) {
+        bool first = true;
+        for (at::Tensor i : last(stack, num_inputs)) {
+          if (!first) std::cout << " ";
+          first = false;
+          if (auto tensor_impl = dynamic_cast<at::TensorImpl*>(i.get())) {
+            std::cout << at::Tensor(tensor_impl, true);
+          } else if (!i.defined()) {
+            std::cout << "<undefined tensor>";
+          } else {
+            auto& r = *i.get();
+            std::cout << "<" << typeid(r).name() << " at " << i << ">";
+          }
+        }
+        drop(stack, num_inputs);
+        std::cout << std::endl;
+        return 0;
+      };
+    IR_ELSEIF(GraphExecutor)
+      auto executor = std::make_shared<GraphExecutor>(value->g(attr::Subgraph));
+      graph_executors.emplace_back(executor.get());
+      auto num_inputs = value->inputs().size();
+      return [=](Stack& stack) mutable {
+        autograd::profiler::RecordFunction record("GraphExecutor");
+        auto inputs = last(stack, num_inputs);
+        variable_tensor_list tinputs(inputs.begin(), inputs.end());
+        drop(stack, num_inputs);
+        //TODO: has graph executor work from a stack as well
+        variable_tensor_list toutputs = executor->run(variable_tensor_list(std::move(tinputs)));
+        stack.insert(stack.end(), toutputs.begin(), toutputs.end());
+        return 0;
+      };
+
+    // Load x, y
+    // loads values from registers onto the stack, the actual callback does
+    // nothing since the stack manipulation is already encoded in inst.inputs
+    // and inst.outputs
+    IR_ELSEIF(Load)
+      return [=](Stack& stack) {
+        return 0;
+      };
+
+    // x, y = Store
+    // stores values from stack into registers, the actual callback does
+    // nothing since the stack manipulation is already encoded in inst.inputs
+    // and inst.outputs
+    IR_ELSEIF(Store)
+      return [=](Stack& stack) {
+        return 0;
+      };
+    IR_ELSEIF(Drop)
+      auto N = value->inputs().size();
+      return [=](Stack& stack) {
+        drop(stack, N);
+        return 0;
+      };
+    IR_ELSE()
+      switch (node->kind()) {
+        case onnx::Reshape: {
+          return [=](Stack& stack) {
+            auto shape = pop(stack).contiguous();
+            auto input = pop(stack);
+            JIT_ASSERT(shape.ndimension() == 1);
+            at::IntList shape_list(shape.data<int64_t>(), shape.size(0));
+            stack.push_back(input.reshape(shape_list));
+            return 0;
+          };
+        } break;
+        case onnx::Shape: {
+          return [=](Stack& stack) {
+            auto t = pop(stack);
+            at::IntList sizes = t.sizes();
+            auto sizes_tensor = torch::CPU(at::kLong).tensor(sizes.size());
+            auto accessor = sizes_tensor.accessor<int64_t, 1>();
+            for (size_t i=0; i<sizes.size(); ++i) {
+              accessor[i] = sizes[i];
+            }
+            stack.push_back(sizes_tensor);
+            return 0;
+          };
+        } break;
+        default: ;
+      };
+
+      // ops registered in another compilation unit
+      // eg: the PythonOp handler
+      if(auto op = lookupExternalOp(node)) {
+        return *op;
+      }
+
+      return getTensorOp(node).op;
+    IR_END()
+  }
+
+  const std::vector<GraphExecutor*>& executors() {
+    return graph_executors;
+  }
+
   void dumpInstruction(std::ostream & out, size_t pc) const {
     auto writeList = [&](const ListHandle<int> & list) {
       for(int i = 0; i < list.size; i++) {
@@ -822,6 +825,7 @@ struct CodeImpl {
   // It is also very useful for debugging interpreter problems to
   // keep this around.
   std::shared_ptr<Graph> graph;
+  std::vector<GraphExecutor*> graph_executors; // for debugging
   PreprocessGraph preprocess;
 
   std::unordered_map<size_t, int> unique_to_reg; // map from unique of nodes to register in register table
@@ -930,18 +934,27 @@ std::ostream & operator<<(std::ostream & out, const Code & code) {
 Code::Code(std::shared_ptr<Graph>& graph)
     : pImpl(new CodeImpl(graph)) {}
 Code::~Code() {}
+
+const std::vector<GraphExecutor*>& Code::executors() {
+  return pImpl->executors();
+}
+
 InterpreterState::InterpreterState(const Code & function)
-: pImpl(new InterpreterStateImpl(function)) {}
+  : pImpl(new InterpreterStateImpl(function)) {}
 InterpreterState::~InterpreterState() {}
+
 void InterpreterState::runOneStage(Stack & stack) {
     return pImpl->runOneStage(stack);
 }
+
 const TensorType & InterpreterState::tensorTypeForInput(size_t i) const {
   return pImpl->tensorTypeForInput(i);
 }
+
 InterpreterState InterpreterState::clone() const {
   return InterpreterState(new InterpreterStateImpl(*pImpl));
 }
+
 InterpreterState::InterpreterState(InterpreterStateImpl * pImpl) : pImpl(pImpl) {}
 
 }}

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -12,6 +12,8 @@ namespace torch { namespace jit {
 // a separate component in the autograd handles unwrapping and wrapping
 // variable objects for use in the interpreter.
 
+struct Node;
+struct GraphExecutor;
 struct CodeImpl;
 struct InterpreterStateImpl;
 struct Graph;
@@ -20,12 +22,17 @@ struct TensorType;
 
 struct Code {
   Code()
-  : pImpl(nullptr) {}
+    : pImpl(nullptr) {}
   Code(std::shared_ptr<Graph>& graph);
   ~Code();
+
+  // Returns pointers to GraphExecutors created to run GraphExecutor nodes in the given graph.
+  const std::vector<GraphExecutor*>& executors();
+
   operator bool() const {
     return pImpl != nullptr;
   }
+
 private:
   std::shared_ptr<CodeImpl> pImpl;
   friend struct InterpreterStateImpl;

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -107,6 +107,12 @@ void initPythonIRBindings(PyObject * module_) {
     .def("create",[](Graph & g, const char * str, const std::vector<Value*> & inputs, size_t noutputs) {
       return g.create(Symbol::fromQualString(str),inputs, noutputs);
     })
+    .def("param_node", [](Graph &g) {
+      return g.block()->param_node();
+    })
+    .def("return_node", [](Graph &g) {
+      return g.block()->return_node();
+    })
     .GS(createConstant)
     .GS(createFusionGroup)
     .def("createClone",[](Graph & g, Node * n, py::object fn) {


### PR DESCRIPTION
cc @zdevito @jamesr66a 

Example screenshot:

<img width="1919" alt="screen shot 2018-05-24 at 23 35 11" src="https://user-images.githubusercontent.com/4583066/40864758-71427c26-65f5-11e8-9f5f-77170d03974c.png">

Unfortunately has a TF dependency, but I don't think there's any way to use TensorBoard without it installed...