### PR TITLE
Reduce usages of TensorUtils<T>::DataType in THC.

### DIFF
--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -184,12 +184,14 @@ inline bool getApplyGrid(THCState* state, uint64_t totalElements, dim3& grid) {
   return true;
 }
 
-template <typename TensorTypeA,
+template <typename ScalarTypeA,
+          typename TensorTypeA,
           typename Op>
 bool THC_pointwiseApply1(THCState* state,
                          TensorTypeA* a,
                          const Op& op,
                          TensorArgType aType = ReadWrite) {
+  static_assert(std::is_same<ScalarTypeA, typename TensorUtils<TensorTypeA>::DataType>::value, "ScalarTypeA must match");
   if (TensorUtils<TensorTypeA>::getDims(state, a) > MAX_CUTORCH_DIMS) {
     return false;
   }
@@ -315,7 +317,9 @@ bool THC_pointwiseApply1(THCState* state,
   return true;
 }
 
-template <typename TensorTypeA,
+template <typename ScalarTypeA,
+          typename ScalarTypeB,
+          typename TensorTypeA,
           typename TensorTypeB,
           typename Op>
 bool THC_pointwiseApply2(THCState* state,
@@ -324,6 +328,9 @@ bool THC_pointwiseApply2(THCState* state,
                          const Op& op,
                          TensorArgType aType = ReadWrite,
                          TensorArgType bType = ReadOnly) {
+  static_assert(std::is_same<ScalarTypeA, typename TensorUtils<TensorTypeA>::DataType>::value, "ScalarTypeA must match");
+  static_assert(std::is_same<ScalarTypeB, typename TensorUtils<TensorTypeB>::DataType>::value, "ScalarTypeB must match");
+
   ptrdiff_t totalElements = TensorUtils<TensorTypeA>::getNumElements(state, a);
   if (totalElements != TensorUtils<TensorTypeB>::getNumElements(state, b)) {
     return false;
@@ -499,7 +506,10 @@ bool THC_pointwiseApply2(THCState* state,
   return true;
 }
 
-template <typename TensorTypeA,
+template <typename ScalarTypeA,
+          typename ScalarTypeB,
+          typename ScalarTypeC,
+          typename TensorTypeA,
           typename TensorTypeB,
           typename TensorTypeC,
           typename Op>
@@ -511,6 +521,10 @@ bool THC_pointwiseApply3(THCState* state,
                          TensorArgType aType = ReadWrite,
                          TensorArgType bType = ReadOnly,
                          TensorArgType cType = ReadOnly) {
+  static_assert(std::is_same<ScalarTypeA, typename TensorUtils<TensorTypeA>::DataType>::value, "ScalarTypeA must match");
+  static_assert(std::is_same<ScalarTypeB, typename TensorUtils<TensorTypeB>::DataType>::value, "ScalarTypeB must match");
+  static_assert(std::is_same<ScalarTypeC, typename TensorUtils<TensorTypeC>::DataType>::value, "ScalarTypeB must match");
+
   ptrdiff_t totalElements = TensorUtils<TensorTypeA>::getNumElements(state, a);
 
   if (totalElements != TensorUtils<TensorTypeB>::getNumElements(state, b) ||

--- a/aten/src/THC/THCTensorCopy.cu
+++ b/aten/src/THC/THCTensorCopy.cu
@@ -113,7 +113,8 @@ THC_copyTensor(THCState* state, TensorTypeDst* dst, TensorTypeSrc* src) {
     // might be worth it to avoid non-coalesced reads or writes.
     if (p2pEnabled) {
       bool succ =
-        THC_pointwiseApply2(
+        THC_pointwiseApply2<typename TensorUtils<TensorTypeDst>::DataType,
+                            typename TensorUtils<TensorTypeSrc>::DataType>(
           state, dst, src,
           CopyOp<typename TensorUtils<TensorTypeDst>::DataType,
                  typename TensorUtils<TensorTypeSrc>::DataType>());
@@ -139,7 +140,8 @@ THC_copyTensor(THCState* state, TensorTypeDst* dst, TensorTypeSrc* src) {
         TensorUtils<TensorTypeDst>::resizeAs(state, srcContig, dst);
 
         bool succ =
-          THC_pointwiseApply2(
+          THC_pointwiseApply2<typename TensorUtils<TensorTypeDst>::DataType,
+                              typename TensorUtils<TensorTypeSrc>::DataType>(
             state, srcContig, src,
             CopyOp<typename TensorUtils<TensorTypeDst>::DataType,
                    typename TensorUtils<TensorTypeSrc>::DataType>());

--- a/aten/src/THC/THCTensorIndex.cu
+++ b/aten/src/THC/THCTensorIndex.cu
@@ -462,10 +462,10 @@ void dispatchTakePutImpl(THCState *state, TensorType *a, TensorType *b, THCudaLo
   auto numel = TensorUtils<TensorType>::getNumElements(state, a);
   if (aInfo.isContiguous()) {
     auto op = Op<real, IndexType, -2>(aInfo, numel, start, end);
-    THC_pointwiseApply2(state, b, index, op);
+    THC_pointwiseApply2<real, int64_t>(state, b, index, op);
   } else {
     auto op = Op<real, IndexType, -1>(aInfo, numel, start, end);
-    THC_pointwiseApply2(state, b, index, op);
+    THC_pointwiseApply2<real, int64_t>(state, b, index, op);
   }
 }
 

--- a/aten/src/THC/THCTensorMathCompare.cuh
+++ b/aten/src/THC/THCTensorMathCompare.cuh
@@ -68,7 +68,7 @@ struct TensorNEValueOp {
   const T value;
 };
 
-template<typename TensorType, typename TensorTypeOut, class Op>
+template<typename ScalarTypeOut, typename ScalarType, typename TensorTypeOut, typename TensorType, class Op>
 void THC_logicalValue(THCState *state,
                       TensorTypeOut *self_,
                       TensorType *src,
@@ -77,7 +77,7 @@ void THC_logicalValue(THCState *state,
   TensorUtils<TensorTypeOut>::resize(state, self_, st, NULL);
   THLongStorage_free(st);
 
-  if (!THC_pointwiseApply2(state, self_, src, op)) {
+  if (!THC_pointwiseApply2<ScalarTypeOut, ScalarType>(state, self_, src, op)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 

--- a/aten/src/THC/THCTensorMathCompareT.cuh
+++ b/aten/src/THC/THCTensorMathCompareT.cuh
@@ -50,7 +50,7 @@ struct TensorNEOp {
   }
 };
 
-template<typename TensorType, typename TensorTypeOut, typename Op>
+template<typename ScalarTypeOut, typename ScalarType, typename TensorTypeOut, typename TensorType, typename Op>
 void THC_logicalTensor(THCState *state,
                        TensorTypeOut *self_,
                        TensorType *src1,
@@ -64,7 +64,7 @@ void THC_logicalTensor(THCState *state,
              TensorUtils<TensorType>::getNumElements(state, src2), 3,
              "sizes do not match");
 
-  if (!THC_pointwiseApply3(state, self_, src1, src2, op)) {
+  if (!THC_pointwiseApply3<ScalarTypeOut, ScalarType, ScalarType>(state, self_, src1, src2, op)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 

--- a/aten/src/THC/generic/THCTensorCopy.cu
+++ b/aten/src/THC/generic/THCTensorCopy.cu
@@ -15,10 +15,11 @@ THCTensor_(copyIgnoringOverlaps)(THCState* state, THCTensor* dst, THCTensor* src
   // This is itself invoked by pointwiseApply2 / THCTensor_copy in
   // case that there are write overlaps.
   // FIXME: really, overlapping writes should be illegal/an error in Torch
-  THC_pointwiseApply2(
+  THC_pointwiseApply2<real,
+                      real>(
     state, dst, src,
-    CopyOp<typename TensorUtils<THCTensor>::DataType,
-           typename TensorUtils<THCTensor>::DataType>(),
+    CopyOp<real,
+           real>(),
     ReadOnly, /* ignore overwrites */
     ReadOnly);
 }

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -267,7 +267,7 @@ void THCTensor_(put)(THCState *state, THCTensor *dst, THCudaLongTensor *index, T
     // wrap indices so to replace negative indices
     THCudaLongTensor* sorted_index = THCudaLongTensor_new(state);
     THCudaLongTensor_resizeAs(state, sorted_index, index);
-    THC_pointwiseApply2(state, sorted_index, index, WrapIndexOp(dstSize));
+    THC_pointwiseApply2<int64_t, int64_t>(state, sorted_index, index, WrapIndexOp(dstSize));
 
     THCTensor* sorted_src = THCTensor_(newClone)(state, src);
 

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -12,8 +12,8 @@ THCTensor_(maskedFill)(THCState* state,
              THCudaByteTensor_nElement(state, mask),
              2, "sizes do not match");
 
-  if (!THC_pointwiseApply2(state, tensor, mask,
-                           TensorMaskedFillOp<real, unsigned char>(value))) {
+  if (!THC_pointwiseApply2<real, uint8_t>(state, tensor, mask,
+                                          TensorMaskedFillOp<real, unsigned char>(value))) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -88,7 +88,7 @@ THCTensor_(maskedCopy)(THCState* state,
 
   // update `tensor` where `mask` == 1 but pull from `src` at
   // maskPrefixSum
-  bool status = THC_pointwiseApply3(
+  bool status = THC_pointwiseApply3<real, uint8_t, int64_t>(
     state, tensor, mask, maskPrefixSum,
     TensorMaskedCopyOp<real, unsigned char, int64_t>(
       THCTensor_(data)(state, contigSrc)));
@@ -158,7 +158,7 @@ THCTensor_(maskedSelect)(THCState* state,
     maskPrefixSumData);
 
   // Then copy over the masked elements at their desired output index
-  bool status = THC_pointwiseApply3(
+  bool status = THC_pointwiseApply3<uint8_t, int64_t, real>(
     state, mask, maskPrefixSum,
     src, TensorMaskedSelectOp<real, unsigned char, int64_t>(
       THCTensor_(data)(state, tensor)));

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -7,7 +7,7 @@ THCTensor_(fill)(THCState* state, THCTensor *self_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
 
-  if (!THC_pointwiseApply1(
+  if (!THC_pointwiseApply1<real>(
         state, self_, TensorFillOp<real>(value))) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
@@ -25,7 +25,7 @@ THCTensor_(zero)(THCState *state, THCTensor *self_)
                                 sizeof(real) * THCTensor_(nElement)(state, self_),
                                 THCState_getCurrentStream(state)));
   } else {
-    if (!THC_pointwiseApply1(
+    if (!THC_pointwiseApply1<real>(
           state, self_,
           TensorFillOp<real>(ScalarConvert<int, real>::to(0)))) {
       THArgCheck(false, 1, CUTORCH_DIM_WARNING);

--- a/aten/src/THC/generic/THCTensorMathCompare.cu
+++ b/aten/src/THC/generic/THCTensorMathCompare.cu
@@ -5,97 +5,97 @@
 THC_API void THCTensor_(ltValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorLTValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorLTValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(gtValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorGTValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorGTValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(leValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorLEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorLEValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(geValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorGEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorGEValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(eqValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorEQValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorEQValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(neValue)(THCState *state, THCudaByteTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorNEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   unsigned char>(value));
+  THC_logicalValue<uint8_t, real>(state, self_, src,
+                                  TensorNEValueOp<real,
+                                  unsigned char>(value));
 }
 
 THC_API void THCTensor_(ltValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorLTValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                                  TensorLTValueOp<real,
+                                  real>(value));
 }
 
 THC_API void THCTensor_(gtValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorGTValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                               TensorGTValueOp<real,
+                              real>(value));
 }
 
 THC_API void THCTensor_(leValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorLEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                               TensorLEValueOp<real,
+                               real>(value));
 }
 
 THC_API void THCTensor_(geValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorGEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                               TensorGEValueOp<real,
+                               real>(value));
 }
 
 THC_API void THCTensor_(eqValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorEQValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                               TensorEQValueOp<real,
+                               real>(value));
 }
 
 THC_API void THCTensor_(neValueT)(THCState *state, THCTensor *self_, THCTensor *src, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
-  THC_logicalValue(state, self_, src,
-                   TensorNEValueOp<typename TensorUtils<THCTensor>::DataType,
-                   typename TensorUtils<THCTensor>::DataType>(value));
+  THC_logicalValue<real, real>(state, self_, src,
+                              TensorNEValueOp<real,
+                              real>(value));
 }
 
 #endif

--- a/aten/src/THC/generic/THCTensorMathCompareT.cu
+++ b/aten/src/THC/generic/THCTensorMathCompareT.cu
@@ -6,108 +6,108 @@ THC_API void
 THCTensor_(ltTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorLTOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorLTOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(gtTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorGTOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorGTOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(leTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorLEOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorLEOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(geTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorGEOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorGEOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(eqTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorEQOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorEQOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(neTensor)(THCState *state, THCudaByteTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorNEOp<typename TensorUtils<THCTensor>::DataType,
-                    unsigned char>());
+  THC_logicalTensor<uint8_t, real>(state, self_, src1, src2,
+                                   TensorNEOp<real,
+                                   unsigned char>());
 }
 
 THC_API void
 THCTensor_(ltTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorLTOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorLTOp<real,
+                                real>());
 }
 
 THC_API void
 THCTensor_(gtTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorGTOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorGTOp<real,
+                                real>());
 }
 
 THC_API void
 THCTensor_(leTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorLEOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorLEOp<real,
+                                real>());
 }
 
 THC_API void
 THCTensor_(geTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorGEOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorGEOp<real,
+                                real>());
 }
 
 THC_API void
 THCTensor_(eqTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorEQOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorEQOp<real,
+                                real>());
 }
 
 THC_API void
 THCTensor_(neTensorT)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, self_, src1, src2));
-  THC_logicalTensor(state, self_, src1, src2,
-                    TensorNEOp<typename TensorUtils<THCTensor>::DataType,
-                    typename TensorUtils<THCTensor>::DataType>());
+  THC_logicalTensor<real, real>(state, self_, src1, src2,
+                                TensorNEOp<real,
+                                real>());
 }
 
 #endif

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -7,13 +7,13 @@ THCTensor_(add)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorAddConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorAddConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorAddConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorAddConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -26,13 +26,13 @@ THCTensor_(sub)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorSubConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorSubConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorSubConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorSubConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -67,13 +67,13 @@ THCTensor_(mul)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorMulConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorMulConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorMulConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorMulConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -88,13 +88,13 @@ THCTensor_(div)(THCState* state, THCTensor *self_, THCTensor *src_, real value)
   THArgCheck(value != ScalarConvert<int, real>::to(0), 3, "divide by zero");
 
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorDivConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorDivConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorDivConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorDivConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -111,13 +111,13 @@ THCTensor_(lshift)(THCState* state, THCTensor *self_, THCTensor *src_, real valu
   return THError("lshift not supported for torch.CudaHalfTensor");
 #else
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorLShiftConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorLShiftConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorLShiftConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorLShiftConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -135,13 +135,13 @@ THCTensor_(rshift)(THCState* state, THCTensor *self_, THCTensor *src_, real valu
   return THError("rshift not supported for torch.CudaHalfTensor");
 #else
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorRShiftConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorRShiftConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorRShiftConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorRShiftConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -155,13 +155,13 @@ THCTensor_(fmod)(THCState *state, THCTensor *self_, THCTensor *src_, real value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorFmodOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorFmodOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorFmodOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorFmodOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -174,13 +174,13 @@ THCTensor_(remainder)(THCState *state, THCTensor *self_, THCTensor *src_, real v
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorRemainderOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorRemainderOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorRemainderOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorRemainderOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -203,13 +203,13 @@ void THCTensor_(tril)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   TensorTriOp<real, 0> op(start, stride0, stride1, k);
 
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, src_, op)) {
+    if (!THC_pointwiseApply1<real>(state, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, op)) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -232,12 +232,12 @@ void THCTensor_(triu)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
   TensorTriOp<real, 1> op(start, stride0, stride1, k);
 
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, src_, op)) {
+    if (!THC_pointwiseApply1<real>(state, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
 
-    if (!THC_pointwiseApply2(state, self_, src_, op)) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, op)) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -259,7 +259,7 @@ THC_API int THCTensor_(equal)(THCState *state, THCTensor *self_, THCTensor *src_
   THLongStorage *size = THCTensor_(newSizeOf)(state, self_);
   THCudaByteTensor *buf = THCudaByteTensor_newWithSize(state, size, NULL);
 
-  if (!THC_pointwiseApply3(state, buf, self_, src_, TensorEQOp<real, unsigned char>())) {
+  if (!THC_pointwiseApply3<uint8_t, real, real>(state, buf, self_, src_, TensorEQOp<real, unsigned char>())) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -278,13 +278,13 @@ THCTensor_(bitand)(THCState* state, THCTensor *self_, THCTensor *src_, real valu
   return THError("bitand only supported for integer type tensors");
 #else
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorBitAndConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorBitAndConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorBitAndConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorBitAndConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -300,13 +300,13 @@ THCTensor_(bitor)(THCState* state, THCTensor *self_, THCTensor *src_, real value
   return THError("bitor only supported for integer type tensors");
 #else
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorBitOrConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorBitOrConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorBitOrConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorBitOrConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -322,13 +322,13 @@ THCTensor_(bitxor)(THCState* state, THCTensor *self_, THCTensor *src_, real valu
   return THError("bitxor only supported for integer type tensors");
 #else
   if (self_ == src_) {
-    if (!THC_pointwiseApply1(state, self_, TensorBitXorConstantOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorBitXorConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src_);
 
-    if (!THC_pointwiseApply2(state, self_, src_, TensorBitXorConstantOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src_, TensorBitXorConstantOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -16,13 +16,13 @@
   void THCTensor_(NAME)(THCState* state, THCTensor* self_, THCTensor* src) { \
     THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));               \
     if (self_ == src) {                                                 \
-      if (!THC_pointwiseApply1(state, self_, Tensor_##NAME##_##REAL##_Op())) { \
+      if (!THC_pointwiseApply1<real>(state, self_, Tensor_##NAME##_##REAL##_Op())) { \
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);                      \
       }                                                                 \
     } else {                                                            \
       THCTensor_(resizeAs)(state, self_, src);                          \
                                                                         \
-      if (!THC_pointwiseApply2(state, self_, src, Tensor_##NAME##_##REAL##_Op())) { \
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, Tensor_##NAME##_##REAL##_Op())) { \
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);                      \
       }                                                                 \
     }                                                                   \
@@ -74,13 +74,13 @@ IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(  abs, THCNumerics<real>::abs,   Real)
 void THCTensor_(sign)(THCState* state, THCTensor* self_, THCTensor* src) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
   if (self_ == src) {
-    if (!THC_pointwiseApply1(state, self_, TensorSignOp<real>())) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorSignOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src);
 
-    if (!THC_pointwiseApply2(state, self_, src, TensorSignOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorSignOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -93,13 +93,13 @@ void THCTensor_(clamp)(THCState *state, THCTensor *self_, THCTensor *src, real m
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
   if (self_ == src) {
-    if (!THC_pointwiseApply1(state, self_, TensorClampOp<real>(min_value, max_value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorClampOp<real>(min_value, max_value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src);
 
-    if (!THC_pointwiseApply2(state, self_, src, TensorClampOp<real>(min_value, max_value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorClampOp<real>(min_value, max_value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -134,7 +134,7 @@ THCTensor_(cross)(THCState *state, THCTensor *self, THCTensor *x, THCTensor *y, 
   THCTensor *nx = THCTensor_(newNarrow)(state, x, dimension, 0, 1);
   THCTensor *ny = THCTensor_(newNarrow)(state, y, dimension, 0, 1);
   THCTensor *nself = THCTensor_(newNarrow)(state, self, dimension, 0, 1);
-  if (!THC_pointwiseApply3(state, nself, nx, ny, TensorCrossOp<real>(sx, sy, so))) {
+  if (!THC_pointwiseApply3<real, real, real>(state, nself, nx, ny, TensorCrossOp<real>(sx, sy, so))) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
   THCTensor_(free)(state, nx);
@@ -151,7 +151,7 @@ void THCTensor_(atan2)(THCState *state, THCTensor *self_, THCTensor *tx, THCTens
              THCTensor_(nElement)(state, ty), 3, "sizes do not match");
   THCTensor_(resizeAs)(state, self_, tx);
 
-  if (!THC_pointwiseApply3(state, self_, tx, ty, TensorATan2Op<real>())) {
+  if (!THC_pointwiseApply3<real, real, real>(state, self_, tx, ty, TensorATan2Op<real>())) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -161,13 +161,13 @@ void THCTensor_(atan2)(THCState *state, THCTensor *self_, THCTensor *tx, THCTens
 void THCTensor_(sigmoid)(THCState* state, THCTensor* self_, THCTensor* src) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
   if (self_ == src) {
-    if (!THC_pointwiseApply1(state, self_, TensorSigmoidOp<real>())) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorSigmoidOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src);
 
-    if (!THC_pointwiseApply2(state, self_, src, TensorSigmoidOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorSigmoidOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -180,7 +180,7 @@ void THCTensor_(digamma)(THCState* state, THCTensor* self_, THCTensor* src) {
   if (self_ != src) {
     THCTensor_(resizeAs)(state, self_, src);
   }
-  if (!THC_pointwiseApply2(state, self_, src, TensorDigammaOp<real, accreal>())) {
+  if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorDigammaOp<real, accreal>())) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -194,12 +194,12 @@ void THCTensor_(polygamma)(THCState* state, THCTensor* self_, int64_t n, THCTens
   }
   switch (n) {
     case 0:
-      if (!THC_pointwiseApply2(state, self_, src, TensorDigammaOp<real, accreal>())) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorDigammaOp<real, accreal>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
       break;
     case 1:
-      if (!THC_pointwiseApply2(state, self_, src, TensorTrigammaOp<real, accreal>())) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorTrigammaOp<real, accreal>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
       break;
@@ -218,7 +218,7 @@ THCTensor_(lerp)(THCState *state, THCTensor *result, THCTensor *a, THCTensor *b,
              THCTensor_(nElement)(state, b), 3, "sizes do not match");
   THCTensor_(resizeAs)(state, result, a);
 
-  if (!THC_pointwiseApply3(state, result, a, b, TensorLerpOp<real>(w))) {
+  if (!THC_pointwiseApply3<real, real, real>(state, result, a, b, TensorLerpOp<real>(w))) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -237,12 +237,12 @@ THCTensor_(cadd)(THCState *state, THCTensor *self_, THCTensor* src1, real value,
   if (self_ == src1) {
     if (value == ScalarConvert<int, real>::to(1)) {
       // self += src2
-      if (!THC_pointwiseApply2(state, self_, src2, TensorAddOp<real>())) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorAddOp<real>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else {
       // self += value * src2
-      if (!THC_pointwiseApply2(state, self_, src2, TensorCAddOp<real>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorCAddOp<real>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     }
@@ -251,12 +251,12 @@ THCTensor_(cadd)(THCState *state, THCTensor *self_, THCTensor* src1, real value,
 
     if (value == ScalarConvert<int, real>::to(1)) {
       // self = src1 + src2
-      if (!THC_pointwiseApply3(state, self_, src1, src2, TensorAddOp<real>())) {
+      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorAddOp<real>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else {
       // self = src1 + value * src2
-      if (!THC_pointwiseApply3(state, self_, src1, src2, TensorCAddOp<real>(value))) {
+      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorCAddOp<real>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     }
@@ -275,12 +275,12 @@ THCTensor_(csub)(THCState *state, THCTensor *self_, THCTensor* src1, real value,
   if (self_ == src1) {
     if (value == ScalarConvert<int, real>::to(1)) {
       // self -= src2
-      if (!THC_pointwiseApply2(state, self_, src2, TensorSubOp<real>())) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorSubOp<real>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else {
       // self += -value * src2
-      if (!THC_pointwiseApply2(state, self_, src2,
+      if (!THC_pointwiseApply2<real, real>(state, self_, src2,
                                    TensorCAddOp<real>(
                                      ScalarNegate<real>::to(value)))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
@@ -291,12 +291,12 @@ THCTensor_(csub)(THCState *state, THCTensor *self_, THCTensor* src1, real value,
 
     if (value == ScalarConvert<int, real>::to(1)) {
       // self = src1 - src2
-      if (!THC_pointwiseApply3(state, self_, src1, src2, TensorSubOp<real>())) {
+      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorSubOp<real>())) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else {
       // self = src1 - value * src2
-      if (!THC_pointwiseApply3(state, self_, src1, src2,
+      if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2,
                                    TensorCAddOp<real>(
                                      ScalarNegate<real>::to(value)))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
@@ -316,14 +316,14 @@ THCTensor_(cmul)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *
 
   if (self_ == src1) {
     // self *= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorMulOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorMulOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 * src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorMulOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorMulOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -340,14 +340,14 @@ THCTensor_(cpow)(THCState *state, THCTensor *self_, THCTensor *src1, THCTensor *
 
   if (self_ == src1) {
     // self = pow(self, src2)
-    if (!THC_pointwiseApply2(state, self_, src2, TensorCPowOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorCPowOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = pow(src1, src2)
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorCPowOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorCPowOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -359,30 +359,30 @@ void THCTensor_(pow)(THCState *state, THCTensor *self_, THCTensor *src, real val
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
   if (self_ == src) {
     if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(1))) {
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, 1>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, 1>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(2))) {
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, 2>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, 2>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(3))) {
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, 3>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, 3>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
 #if defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(-1))) {
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, -1>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, -1>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(-2))) {
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, -2>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, -2>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
 #endif
     } else {
       // fallback implementation using pow
-      if (!THC_pointwiseApply1(state, self_, TensorPowOp<real, -3>(value))) {
+      if (!THC_pointwiseApply1<real>(state, self_, TensorPowOp<real, -3>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     }
@@ -390,30 +390,30 @@ void THCTensor_(pow)(THCState *state, THCTensor *self_, THCTensor *src, real val
     THCTensor_(resizeAs)(state, self_, src);
 
     if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(1))) {
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, 1>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, 1>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(2))) {
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, 2>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, 2>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(3))) {
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, 3>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, 3>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
 #if defined(THC_REAL_IS_HALF) || defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(-1))) {
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, -1>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, -1>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     } else if (THCNumerics<real>::eq(value, ScalarConvert<int, real>::to(-2))) {
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, -2>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, -2>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
 #endif
     } else {
       // fallback implementation using pow
-      if (!THC_pointwiseApply2(state, self_, src, TensorPowOp<real, -3>(value))) {
+      if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorPowOp<real, -3>(value))) {
         THArgCheck(false, 2, CUTORCH_DIM_WARNING);
       }
     }
@@ -426,13 +426,13 @@ void THCTensor_(tpow)(THCState *state, THCTensor *self_, real value, THCTensor *
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
   if (self_ == src) {
-    if (!THC_pointwiseApply1(state, self_, TensorTPowOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self_, TensorTPowOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src);
 
-    if (!THC_pointwiseApply2(state, self_, src, TensorTPowOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src, TensorTPowOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -448,14 +448,14 @@ THCTensor_(cdiv)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorDivOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorDivOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorDivOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorDivOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -475,14 +475,14 @@ THCTensor_(clshift)(THCState* state, THCTensor *self_, THCTensor *src1, THCTenso
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorLShiftOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorLShiftOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorLShiftOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorLShiftOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -503,14 +503,14 @@ THCTensor_(crshift)(THCState* state, THCTensor *self_, THCTensor *src1, THCTenso
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorRShiftOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorRShiftOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorRShiftOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorRShiftOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -527,12 +527,12 @@ THCTensor_(cmax)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *s
              THCTensor_(nElement)(state, src2), 2, "sizes do not match");
 
   if (self == src1) {
-    if (!THC_pointwiseApply2(state, self, src2, TensorMaxOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src2, TensorMaxOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src1);
-    if (!THC_pointwiseApply3(state, self, src1, src2, TensorMaxOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self, src1, src2, TensorMaxOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -546,12 +546,12 @@ THCTensor_(cmin)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *s
              THCTensor_(nElement)(state, src2), 2, "sizes do not match");
 
   if (self == src1) {
-    if (!THC_pointwiseApply2(state, self, src2, TensorMinOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src2, TensorMinOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src1);
-    if (!THC_pointwiseApply3(state, self, src1, src2, TensorMinOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self, src1, src2, TensorMinOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -565,12 +565,12 @@ THCTensor_(cremainder)(THCState *state, THCTensor *self, THCTensor *src1, THCTen
              THCTensor_(nElement)(state, src2), 2, "sizes do not match");
 
   if (self == src1) {
-    if (!THC_pointwiseApply2(state, self, src2, TensorCRemainderOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src2, TensorCRemainderOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src1);
-    if (!THC_pointwiseApply3(state, self, src1, src2, TensorCRemainderOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self, src1, src2, TensorCRemainderOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -584,12 +584,12 @@ THCTensor_(cfmod)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *
              THCTensor_(nElement)(state, src2), 2, "sizes do not match");
 
   if (self == src1) {
-    if (!THC_pointwiseApply2(state, self, src2, TensorCFmodOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src2, TensorCFmodOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src1);
-    if (!THC_pointwiseApply3(state, self, src1, src2, TensorCFmodOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self, src1, src2, TensorCFmodOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -601,12 +601,12 @@ THCTensor_(cmaxValue)(THCState *state, THCTensor *self, THCTensor *src, real val
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
 
   if (self == src) {
-    if (!THC_pointwiseApply1(state, self, TensorMaxValueOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self, TensorMaxValueOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src);
-    if (!THC_pointwiseApply2(state, self, src, TensorMaxValueOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src, TensorMaxValueOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -618,12 +618,12 @@ THCTensor_(cminValue)(THCState *state, THCTensor *self, THCTensor *src, real val
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
 
   if (self == src) {
-    if (!THC_pointwiseApply1(state, self, TensorMinValueOp<real>(value))) {
+    if (!THC_pointwiseApply1<real>(state, self, TensorMinValueOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self, src);
-    if (!THC_pointwiseApply2(state, self, src, TensorMinValueOp<real>(value))) {
+    if (!THC_pointwiseApply2<real, real>(state, self, src, TensorMinValueOp<real>(value))) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -647,7 +647,7 @@ THCTensor_(addcmul)(THCState *state, THCTensor *self_, THCTensor *t, real value,
   THArgCheck(THCTensor_(nElement)(state, src1) == THCTensor_(nElement)(state, src2),
              3, "sizes do not match");
 
-  if (!THC_pointwiseApply3(state, self_, src1, src2, TensorAddCMulOp<real>(value))) {
+  if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorAddCMulOp<real>(value))) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -671,7 +671,7 @@ THCTensor_(addcdiv)(THCState *state, THCTensor *self_, THCTensor *t, real value,
   THArgCheck(THCTensor_(nElement)(state, src1) == THCTensor_(nElement)(state, src2),
              3, "sizes do not match");
 
-  if (!THC_pointwiseApply3(state, self_, src1, src2, TensorAddCDivOp<real>(value))) {
+  if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorAddCDivOp<real>(value))) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -690,14 +690,14 @@ THCTensor_(cbitand)(THCState* state, THCTensor *self_, THCTensor *src1, THCTenso
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorBitAndOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorBitAndOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorBitAndOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorBitAndOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -718,14 +718,14 @@ THCTensor_(cbitor)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorBitOrOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorBitOrOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorBitOrOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorBitOrOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }
@@ -746,14 +746,14 @@ THCTensor_(cbitxor)(THCState* state, THCTensor *self_, THCTensor *src1, THCTenso
 
   if (self_ == src1) {
     // self /= src2
-    if (!THC_pointwiseApply2(state, self_, src2, TensorBitXorOp<real>())) {
+    if (!THC_pointwiseApply2<real, real>(state, self_, src2, TensorBitXorOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   } else {
     THCTensor_(resizeAs)(state, self_, src1);
 
     // self = src1 / src2
-    if (!THC_pointwiseApply3(state, self_, src1, src2, TensorBitXorOp<real>())) {
+    if (!THC_pointwiseApply3<real, real, real>(state, self_, src1, src2, TensorBitXorOp<real>())) {
       THArgCheck(false, 2, CUTORCH_DIM_WARNING);
     }
   }

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -445,14 +445,14 @@ THCTensor_(max)(THCState *state,
                 int keepdim) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, values, indices, src));
 
-  thrust::pair<typename TensorUtils<THCTensor>::DataType, int64_t>
+  thrust::pair<real, int64_t>
     init =
-    thrust::make_pair<typename TensorUtils<THCTensor>::DataType, int64_t>(
-      THCNumerics<typename TensorUtils<THCTensor>::DataType>::min(), 0);
+    thrust::make_pair<real, int64_t>(
+      THCNumerics<real>::min(), 0);
 
   return THC_reduceDimIndex(
     state, values, indices, src, dimension, keepdim, init,
-    MaxValuePair<typename TensorUtils<THCTensor>::DataType, int64_t>());
+    MaxValuePair<real, int64_t>());
 }
 
 THC_API void
@@ -464,14 +464,14 @@ THCTensor_(min)(THCState *state,
                 int keepdim) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, values, indices, src));
 
-  thrust::pair<typename TensorUtils<THCTensor>::DataType, int64_t>
+  thrust::pair<real, int64_t>
     init =
-    thrust::make_pair<typename TensorUtils<THCTensor>::DataType, int64_t>(
-      THCNumerics<typename TensorUtils<THCTensor>::DataType>::max(), 0);
+    thrust::make_pair<real, int64_t>(
+      THCNumerics<real>::max(), 0);
 
   return THC_reduceDimIndex(
     state, values, indices, src, dimension, keepdim, init,
-    MinValuePair<typename TensorUtils<THCTensor>::DataType, int64_t>());
+    MinValuePair<real, int64_t>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/Abs.cu
+++ b/aten/src/THCUNN/generic/Abs.cu
@@ -11,7 +11,7 @@ void THNN_(Abs_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, absupdateOutput_functor<real>());
+  THC_pointwiseApply2<real, real>(state, output, input, absupdateOutput_functor<real>());
 }
 
 void THNN_(Abs_updateGradInput)(
@@ -23,7 +23,7 @@ void THNN_(Abs_updateGradInput)(
   THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
-  THC_pointwiseApply3(state, gradInput, input, gradOutput, absupdateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, absupdateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/AbsCriterion.cu
+++ b/aten/src/THCUNN/generic/AbsCriterion.cu
@@ -17,7 +17,7 @@ void THNN_(AbsCriterion_updateOutput)(
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply3(state, input, target, output,
+    THC_pointwiseApply3<real, real, real>(state, input, target, output,
                         abs_updateOutput_no_reduce_functor<real>());
     return;
   }
@@ -58,7 +58,7 @@ void THNN_(AbsCriterion_updateGradInput)(
 
   if (!reduce) {
     THCUNN_check_shape(state, gradOutput, input);
-    THC_pointwiseApply3(state, input, target, gradInput,
+    THC_pointwiseApply3<real, real, real>(state, input, target, gradInput,
                         abs_updateGradInput_no_reduce_functor<real>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
     return;

--- a/aten/src/THCUNN/generic/BCECriterion.cu
+++ b/aten/src/THCUNN/generic/BCECriterion.cu
@@ -19,7 +19,7 @@ void THNN_(BCECriterion_updateOutput)(
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply3(state, input, target, output,
+    THC_pointwiseApply3<real, real, real>(state, input, target, output,
         bce_updateOutput_no_reduce_functor<real, accreal>());
     if (weights) {
       THCTensor_(cmul)(state, output, output, weights);
@@ -85,7 +85,7 @@ void THNN_(BCECriterion_updateGradInput)(
 
   if (!reduce) {
     THCUNN_check_nElement(state, gradOutput, input);
-    THC_pointwiseApply3(state, input, target, gradInput,
+    THC_pointwiseApply3<real, real, real>(state, input, target, gradInput,
         bce_updateGradInput_no_reduce_functor<real, accreal>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
     if (weights) {

--- a/aten/src/THCUNN/generic/DistKLDivCriterion.cu
+++ b/aten/src/THCUNN/generic/DistKLDivCriterion.cu
@@ -20,7 +20,7 @@ void THNN_(DistKLDivCriterion_updateOutput)(
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply3(state, input, target, output,
+    THC_pointwiseApply3<real, real, real>(state, input, target, output,
                         kl_updateOutput_no_reduce_functor<real>());
     return;
   }
@@ -66,7 +66,7 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
 
   if (!reduce) {
     THCUNN_check_shape(state, gradOutput, input);
-    THC_pointwiseApply3(state, target, gradOutput, gradInput,
+    THC_pointwiseApply3<real, real, real>(state, target, gradOutput, gradInput,
                         kl_updateGradInput_no_reduce_functor<real>());
     return;
   }

--- a/aten/src/THCUNN/generic/ELU.cu
+++ b/aten/src/THCUNN/generic/ELU.cu
@@ -19,13 +19,13 @@ void THNN_(ELU_updateOutput)(
 
   if (inplace)
   {
-    THC_pointwiseApply1(state, input, ELUupdateOutputIP_functor<real>(negcoef, poscoef));
+    THC_pointwiseApply1<real>(state, input, ELUupdateOutputIP_functor<real>(negcoef, poscoef));
     THCTensor_(set)(state, output, input);
   }
   else
   {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply2(state, output, input, ELUupdateOutput_functor<real>(negcoef, poscoef));
+    THC_pointwiseApply2<real, real>(state, output, input, ELUupdateOutput_functor<real>(negcoef, poscoef));
   }
 }
 
@@ -44,7 +44,7 @@ void THNN_(ELU_updateGradInput)(
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
 
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, ELUupdateGradInput_functor<real>(negcoef, poscoef));
+  THC_pointwiseApply3<real, real, real>(state, gradInput, output, gradOutput, ELUupdateGradInput_functor<real>(negcoef, poscoef));
 }
 
 #endif

--- a/aten/src/THCUNN/generic/FeatureLPPooling.cu
+++ b/aten/src/THCUNN/generic/FeatureLPPooling.cu
@@ -162,8 +162,8 @@ void THNN_(FeatureLPPooling_updateOutput)(THCState* state,
   THArgCheck(TensorUtils<THCTensor>::canUse32BitIndexMath(state, inputTH), 2,
              "input tensor must fit into 32-bit index math");
 
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> input;
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> output;
+  THCDeviceTensor<real, 4> input;
+  THCDeviceTensor<real, 4> output;
 
   input = THNN_(FeatureLPPooling_upcast)(state, inputTH, batchMode);
 
@@ -217,10 +217,10 @@ void THNN_(FeatureLPPooling_updateGradInput)(THCState* state,
                "input must be 1-3 dimensions for non-batch mode");
   }
 
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> gradOutput;
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> input;
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> output;
-  THCDeviceTensor<TensorUtils<THCTensor>::DataType, 4> gradInput;
+  THCDeviceTensor<real, 4> gradOutput;
+  THCDeviceTensor<real, 4> input;
+  THCDeviceTensor<real, 4> output;
+  THCDeviceTensor<real, 4> gradInput;
 
   input = THNN_(FeatureLPPooling_upcast)(state, inputTH, batchMode);
 

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -25,7 +25,7 @@ void THNN_(GatedLinear_updateOutput)(
   THCTensor *secondHalf = THCTensor_(newNarrow)(state, input, dim, inputSize, inputSize);
 
   // x = x1:cmul( sigmoid(x2) )
-  THC_pointwiseApply3(state, output, secondHalf, firstHalf, gatedLinearCSigMul_functor<real, accreal>());
+  THC_pointwiseApply3<real, real, real>(state, output, secondHalf, firstHalf, gatedLinearCSigMul_functor<real, accreal>());
 
   THLongStorage_free(newSizes);
   THCTensor_(free)(state, firstHalf);
@@ -51,7 +51,7 @@ void THNN_(GatedLinear_updateGradInput)(
   THCTensor *gradInputfirstHalf = THCTensor_(newNarrow)(state, gradInput, dim, 0, inputSize);
   const int64_t stride_i = THCTensor_(stride)(state, input, dim) * inputSize;
   const int64_t stride_gI = THCTensor_(stride)(state, gradInput, dim) * inputSize;
-  THC_pointwiseApply3(state, gradInputfirstHalf, gradOutput, firstHalf, gatedLinearDerivative<real,accreal>(stride_i, stride_gI)); 
+  THC_pointwiseApply3<real, real, real>(state, gradInputfirstHalf, gradOutput, firstHalf, gatedLinearDerivative<real,accreal>(stride_i, stride_gI)); 
   THCTensor_(free)(state, firstHalf);
   THCTensor_(free)(state, gradInputfirstHalf);
 }

--- a/aten/src/THCUNN/generic/HardTanh.cu
+++ b/aten/src/THCUNN/generic/HardTanh.cu
@@ -19,12 +19,12 @@ void THNN_(HardTanh_updateOutput)(
   if(inplace)
   {
     THCTensor_(set)(state, output, input);
-    THC_pointwiseApply1(state, output, hardtanhupdateOutput_functor<real>(min_val, max_val));
+    THC_pointwiseApply1<real>(state, output, hardtanhupdateOutput_functor<real>(min_val, max_val));
   }
   else
   {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply2(state, output, input,
+    THC_pointwiseApply2<real, real>(state, output, input,
                                hardtanhupdateOutput_functor<real>(min_val, max_val));
   }
 }
@@ -47,13 +47,13 @@ void THNN_(HardTanh_updateGradInput)(
   if (inplace)
   {
     THCTensor_(set)(state, gradInput, gradOutput);
-    THC_pointwiseApply2(state, gradInput, input,
+    THC_pointwiseApply2<real, real>(state, gradInput, input,
                                  hardtanhupdateGradInput_functor<real>(min_val, max_val));
   }
   else
   {
     THCTensor_(resizeAs)(state, gradInput, input);
-    THC_pointwiseApply3(state, gradInput, input, gradOutput,
+    THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput,
                                  hardtanhupdateGradInput_functor<real>(min_val, max_val));
   }
 }

--- a/aten/src/THCUNN/generic/LeakyReLU.cu
+++ b/aten/src/THCUNN/generic/LeakyReLU.cu
@@ -17,13 +17,13 @@ void THNN_(LeakyReLU_updateOutput)(
 
   if (inplace)
   {
-    THC_pointwiseApply1(state, input, LeakyReLUUpdateOutputIP<real>(negval));
+    THC_pointwiseApply1<real>(state, input, LeakyReLUUpdateOutputIP<real>(negval));
     THCTensor_(set)(state, output, input);
   }
   else
   {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply2(state, output, input, LeakyReLUUpdateOutput<real>(negval));
+    THC_pointwiseApply2<real, real>(state, output, input, LeakyReLUUpdateOutput<real>(negval));
   }
 
   THCudaCheck(cudaGetLastError());
@@ -44,13 +44,13 @@ void THNN_(LeakyReLU_updateGradInput)(
 
   if (inplace)
   {
-    THC_pointwiseApply2(state, gradOutput, input, LeakyReLUUpdateGradInputIP<real>(negval));
+    THC_pointwiseApply2<real, real>(state, gradOutput, input, LeakyReLUUpdateGradInputIP<real>(negval));
     THCTensor_(set)(state, gradInput, gradOutput);
   }
   else
   {
     THCTensor_(resizeAs)(state, gradInput, input);
-    THC_pointwiseApply3(state, gradInput, input, gradOutput, LeakyReLUUpdateGradInput<real>(negval));
+    THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, LeakyReLUUpdateGradInput<real>(negval));
   }
 
   THCudaCheck(cudaGetLastError());

--- a/aten/src/THCUNN/generic/LogSigmoid.cu
+++ b/aten/src/THCUNN/generic/LogSigmoid.cu
@@ -12,7 +12,7 @@ void THNN_(LogSigmoid_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, logSigmoid_updateOutput_functor<real>());
+  THC_pointwiseApply2<real, real>(state, output, input, logSigmoid_updateOutput_functor<real>());
 }
 
 void THNN_(LogSigmoid_updateGradInput)(
@@ -25,7 +25,7 @@ void THNN_(LogSigmoid_updateGradInput)(
   THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
-  THC_pointwiseApply3(state, gradInput, input, gradOutput, logSigmoid_updateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, logSigmoid_updateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/MSECriterion.cu
+++ b/aten/src/THCUNN/generic/MSECriterion.cu
@@ -44,7 +44,7 @@ void THNN_(MSECriterion_updateOutput)(
   }
 
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply3(
+  THC_pointwiseApply3<real, real, real>(
       state,
       input,
       target,

--- a/aten/src/THCUNN/generic/PReLU.cu
+++ b/aten/src/THCUNN/generic/PReLU.cu
@@ -16,7 +16,7 @@ void THNN_(PReLU_updateOutput)(
 
   if (nOutputPlane == 1)
   {
-    THC_pointwiseApply2(state, output, input, PReLUUpdateOutput<real>(w));
+    THC_pointwiseApply2<real, real>(state, output, input, PReLUUpdateOutput<real>(w));
   }
   else
   {
@@ -60,7 +60,7 @@ void THNN_(PReLU_updateGradInput)(
   real *w = THCTensor_(data)(state, weight);
   if (nOutputPlane == 1)
   {
-    THC_pointwiseApply3(state, gradInput, gradOutput, input, PReLUUpdateGradInput<real>(w));
+    THC_pointwiseApply3<real, real, real>(state, gradInput, gradOutput, input, PReLUUpdateGradInput<real>(w));
   }
   else
   {
@@ -107,7 +107,7 @@ void THNN_(PReLU_accGradParameters)(
 
   if (nOutputPlane == 1)
   {
-    THC_pointwiseApply3(state, gradInput, input, gradOutput, PReLUAccGradParametersShared<real>());
+    THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, PReLUAccGradParametersShared<real>());
 
     // introduces a sync point
     real sum = ScalarConvert<accreal, real>::to(THCTensor_(sumall)(state, gradInput));
@@ -123,11 +123,11 @@ void THNN_(PReLU_accGradParameters)(
 
     if (ndim == 1)
     {
-      THC_pointwiseApply3(state, gradWeight, input, gradOutput, PReLUAccGradParameters1to1<real>(scale));
+      THC_pointwiseApply3<real, real, real>(state, gradWeight, input, gradOutput, PReLUAccGradParameters1to1<real>(scale));
     }
     else
     {
-      THC_pointwiseApply3(state, gradInput, input, gradOutput, PReLUAccGradParameters<real>(scale));
+      THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, PReLUAccGradParameters<real>(scale));
       THCTensor *gradWeightBuf = THCTensor_(new)(state);
       THCTensor_(resizeAs)(state, gradWeightBuf, gradWeight);
 

--- a/aten/src/THCUNN/generic/RReLU.cu
+++ b/aten/src/THCUNN/generic/RReLU.cu
@@ -46,13 +46,13 @@ void THNN_(RReLU_updateOutput)(
     const real negSlope = ScalarConvert<double, real>::to((lower + upper) / 2);
     if (inplace)
     {
-      THC_pointwiseApply1(state, input, RReLUUpdateOutputEvalIP_functor<real>(negSlope));
+      THC_pointwiseApply1<real>(state, input, RReLUUpdateOutputEvalIP_functor<real>(negSlope));
       THCTensor_(set)(state, output, input);
     }
     else
     {
       THCTensor_(resizeAs)(state, output, input);
-      THC_pointwiseApply2(state, output, input, RReLUUpdateOutputEval_functor<real>(negSlope));
+      THC_pointwiseApply2<real, real>(state, output, input, RReLUUpdateOutputEval_functor<real>(negSlope));
     }
   }
 }
@@ -93,13 +93,13 @@ void THNN_(RReLU_updateGradInput)(
     const real negSlope = ScalarConvert<double, real>::to((lower + upper) / 2);
     if (inplace)
     {
-      THC_pointwiseApply2(state, gradOutput, input, RReLUupdateGradInputEvalIP_functor<real>(negSlope));
+      THC_pointwiseApply2<real, real>(state, gradOutput, input, RReLUupdateGradInputEvalIP_functor<real>(negSlope));
       THCTensor_(set)(state, gradInput, gradOutput);
     }
     else
     {
       THCTensor_(resizeAs)(state, gradInput, input);
-      THC_pointwiseApply3(state, gradInput, gradOutput, input, RReLUupdateGradInputEval_functor<real>(negSlope));
+      THC_pointwiseApply3<real, real, real>(state, gradInput, gradOutput, input, RReLUupdateGradInputEval_functor<real>(negSlope));
     }
   }
 

--- a/aten/src/THCUNN/generic/Sigmoid.cu
+++ b/aten/src/THCUNN/generic/Sigmoid.cu
@@ -22,7 +22,7 @@ void THNN_(Sigmoid_updateGradInput)(
   THCUNN_check_nElement(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, sigmoid_updateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, output, gradOutput, sigmoid_updateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/SmoothL1Criterion.cu
+++ b/aten/src/THCUNN/generic/SmoothL1Criterion.cu
@@ -21,7 +21,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply3(state, input, target, output,
+    THC_pointwiseApply3<real, real, real>(state, input, target, output,
                         smoothl1_updateOutput_no_reduce_functor<real>());
     return;
   }
@@ -73,7 +73,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
 
   if (!reduce) {
     THCUNN_check_shape(state, gradOutput, input);
-    THC_pointwiseApply3(state, input, target, gradInput,
+    THC_pointwiseApply3<real, real, real>(state, input, target, gradInput,
                         smoothl1_updateGradInput_no_reduce_functor<real>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
     return;

--- a/aten/src/THCUNN/generic/SoftMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/SoftMarginCriterion.cu
@@ -17,7 +17,7 @@ void THNN_(SoftMarginCriterion_updateOutput)(
 
   if (!reduce) {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply3(state, input, target, output,
+    THC_pointwiseApply3<real, real, real>(state, input, target, output,
         softmargin_no_reduce_functor<real, accreal>());
     return;
   }
@@ -58,7 +58,7 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
 
   if (!reduce) {
     THCUNN_check_shape(state, gradOutput, input);
-    THC_pointwiseApply3(state, input, target, gradInput,
+    THC_pointwiseApply3<real, real, real>(state, input, target, gradInput,
         softmargin_updateGradInput_no_reduce_functor<real, accreal>());
     THCTensor_(cmul)(state, gradInput, gradInput, gradOutput);
     return;

--- a/aten/src/THCUNN/generic/SoftPlus.cu
+++ b/aten/src/THCUNN/generic/SoftPlus.cu
@@ -15,7 +15,7 @@ void THNN_(SoftPlus_updateOutput)(
   real threshold = ScalarConvert<accreal, real>::to(threshold_);
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, softPlusupdateOutput_functor<real>(threshold, beta));
+  THC_pointwiseApply2<real, real>(state, output, input, softPlusupdateOutput_functor<real>(threshold, beta));
 }
 
 void THNN_(SoftPlus_updateGradInput)(
@@ -32,7 +32,7 @@ void THNN_(SoftPlus_updateGradInput)(
   THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 4, input, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, softPlusupdateGradInput_functor<real>(threshold, beta));
+  THC_pointwiseApply3<real, real, real>(state, gradInput, output, gradOutput, softPlusupdateGradInput_functor<real>(threshold, beta));
 }
 
 #endif

--- a/aten/src/THCUNN/generic/SoftShrink.cu
+++ b/aten/src/THCUNN/generic/SoftShrink.cu
@@ -13,7 +13,7 @@ void THNN_(SoftShrink_updateOutput)(
   real lambda = ScalarConvert<accreal, real>::to(lambda_);
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, SoftShrinkUpdateOutput<real>(lambda));
+  THC_pointwiseApply2<real, real>(state, output, input, SoftShrinkUpdateOutput<real>(lambda));
   THCudaCheck(cudaGetLastError());
 }
 
@@ -28,7 +28,7 @@ void THNN_(SoftShrink_updateGradInput)(
   THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
-  THC_pointwiseApply3(state, gradInput, input, gradOutput, SoftShrinkUpdateGradInput<real>(lambda));
+  THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, SoftShrinkUpdateGradInput<real>(lambda));
   THCudaCheck(cudaGetLastError());
 }
 

--- a/aten/src/THCUNN/generic/Sqrt.cu
+++ b/aten/src/THCUNN/generic/Sqrt.cu
@@ -13,7 +13,7 @@ void THNN_(Sqrt_updateOutput)(
   real eps = ScalarConvert<accreal, real>::to(eps_);
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, sqrtupdateOutput_functor<real>(eps));
+  THC_pointwiseApply2<real, real>(state, output, input, sqrtupdateOutput_functor<real>(eps));
 }
 
 void THNN_(Sqrt_updateGradInput)(
@@ -26,7 +26,7 @@ void THNN_(Sqrt_updateGradInput)(
   THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, sqrtupdateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, output, gradOutput, sqrtupdateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/Square.cu
+++ b/aten/src/THCUNN/generic/Square.cu
@@ -11,7 +11,7 @@ void THNN_(Square_updateOutput)(
 {
   THCUNN_assertSameGPU(state, 2, input, output);
   THCTensor_(resizeAs)(state, output, input);
-  THC_pointwiseApply2(state, output, input, squareupdateOutput_functor<real>());
+  THC_pointwiseApply2<real, real>(state, output, input, squareupdateOutput_functor<real>());
 }
 
 void THNN_(Square_updateGradInput)(
@@ -23,7 +23,7 @@ void THNN_(Square_updateGradInput)(
   THCUNN_check_shape(state, input, gradOutput);
   THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
-  THC_pointwiseApply3(state, gradInput, input, gradOutput, squareupdateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput, squareupdateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/Tanh.cu
+++ b/aten/src/THCUNN/generic/Tanh.cu
@@ -23,7 +23,7 @@ void THNN_(Tanh_updateGradInput)(
   THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
-  THC_pointwiseApply3(state, gradInput, output, gradOutput, tanh_updateGradInput_functor<real>());
+  THC_pointwiseApply3<real, real, real>(state, gradInput, output, gradOutput, tanh_updateGradInput_functor<real>());
 }
 
 #endif

--- a/aten/src/THCUNN/generic/Threshold.cu
+++ b/aten/src/THCUNN/generic/Threshold.cu
@@ -18,7 +18,7 @@ void THNN_(Threshold_updateOutput)(
 
   if (inplace)
   {
-    THC_pointwiseApply1(state, input,
+    THC_pointwiseApply1<real>(state, input,
       ThresholdUpdateOutputIP<real>(threshold, val)
     );
     THCTensor_(set)(state, output, input);
@@ -26,7 +26,7 @@ void THNN_(Threshold_updateOutput)(
   else
   {
     THCTensor_(resizeAs)(state, output, input);
-    THC_pointwiseApply2(state, output, input,
+    THC_pointwiseApply2<real, real>(state, output, input,
       ThresholdUpdateOutput<real>(threshold, val)
     );
   }
@@ -51,7 +51,7 @@ void THNN_(Threshold_updateGradInput)(
 
   if (inplace)
   {
-    THC_pointwiseApply2(state, gradOutput, input,
+    THC_pointwiseApply2<real, real>(state, gradOutput, input,
       ThresholdUpdateGradInputIP<real>(threshold)
     );
     THCTensor_(set)(state, gradInput, gradOutput);
@@ -59,7 +59,7 @@ void THNN_(Threshold_updateGradInput)(
   else
   {
     THCTensor_(resizeAs)(state, gradInput, input);
-    THC_pointwiseApply3(state, gradInput, input, gradOutput,
+    THC_pointwiseApply3<real, real, real>(state, gradInput, input, gradOutput,
        ThresholdUpdateGradInput<real>(threshold)
     );
   }


### PR DESCRIPTION
TensorUtils<T> is basically ATen-dispatch-lite in that it allows one to do multi-type THC function dispatch with a single call.  However, it is templatized on the Tensor type, and since we are moving to a single Tensor type, this doesn't work.

Most of the functions in TensorUtils (e.g. getDims) can be pulled up a level, to just call THCTensor_nDimension (or directly accessing the member), but the DataType specific functions are more problematic.

So, this PR does two things:
1) Replaces calls of 'TensorUtils<THCTensor>::DataType' with 'real' since these are identical
2) Templatizes the THC_pointwiseApplyX functions to take scalar types.  To ensure this is done correctly, we static_assert that the scalar type template parameter matches the scalar type of the corresponding template parameter.  We will need to get rid of these static_asserts in the future, but this is useful for now.