### PR TITLE
add comparison operators to jit

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -295,6 +295,36 @@ class TestJit(TestCase):
         ge = self.checkTrace(f, (x, y))
         self.assertExpectedGraph(ge.graph_for(x, y))
 
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_comparison_gt_lt(self):
+        def f(x, y):
+            mask = (x > 0).type_as(x)
+            z = x * mask + y
+            mask = (x < 0).type_as(x)
+            z = z * mask + y
+            return z
+
+        x = torch.randn(4, 4, dtype=torch.float, device='cuda')
+        y = torch.randn(4, 4, dtype=torch.float, device='cuda')
+
+        ge = self.checkTrace(f, (x, y))
+
+    @unittest.skipIf(IS_WINDOWS, "NYI: fuser support for Windows")
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_comparison_ge_le(self):
+        def f(x, y):
+            mask = (x >= 0).type_as(x)
+            z = x * mask + y
+            mask = (x <= 0).type_as(x)
+            z = z * mask + y
+            return z
+
+        x = torch.randn(4, 4, dtype=torch.float, device='cuda')
+        y = torch.randn(4, 4, dtype=torch.float, device='cuda')
+
+        ge = self.checkTrace(f, (x, y))
+
     # TODO: adapt this test to check that GraphExecutor treats them differently
     @unittest.skip("Need to be adjusted to Graph Executor")
     def test_arg_configurations(self):

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -24,7 +24,7 @@ bool isDifferentiable(Node * n) {
   if (n->kind() == aten::addmm && n->inputs().size() > 3) {
     return false;
   }
-  if (n->kind() == aten::type_as && !n->inputs()[0]->isTensor()) {
+  if (n->kind() == aten::type_as && !n->inputs()[1]->isTensor()) {
     return false;
   }
   return differentiable_kinds.count(n->kind()) > 0;

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -48,7 +48,7 @@ bool outputRequiresGrad(Node* node, std::function<bool(Value*)> requires_grad) {
       return false;
     case aten::type_as:
     //type_as has two inputs, the second of which (setting type) might require grad, but it still won't affect the output of type_as requiring grad.
-      return requires_grad(node->inputs()[0]);
+      return requires_grad(node->inputs().at(0));
     default:
       return std::any_of(node->inputs().begin(), node->inputs().end(), requires_grad);
   }

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -24,8 +24,12 @@ bool isDifferentiable(Node * n) {
   if (n->kind() == aten::addmm && n->inputs().size() > 3) {
     return false;
   }
+  if (n->kind() == aten::type_as && !n->inputs()[0]->isTensor()) {
+    return false;
+  }
   return differentiable_kinds.count(n->kind()) > 0;
 }
+
 
 bool isDifferentiable(Graph & g) {
   return std::all_of(g.nodes().begin(), g.nodes().end(),
@@ -43,7 +47,7 @@ bool outputRequiresGrad(Node* node, std::function<bool(Value*)> requires_grad) {
     case aten::eq:
       return false;
     case aten::type_as:
-//type_as has two inputs, the second of which (setting type) might require grad, but it still won't affect the output of type_as requiring grad.
+    //type_as has two inputs, the second of which (setting type) might require grad, but it still won't affect the output of type_as requiring grad.
       return requires_grad(node->inputs()[0]);
     default:
       return std::any_of(node->inputs().begin(), node->inputs().end(), requires_grad);

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -24,7 +24,7 @@ bool isDifferentiable(Node * n) {
   if (n->kind() == aten::addmm && n->inputs().size() > 3) {
     return false;
   }
-  if (n->kind() == aten::type_as && !n->inputs()[1]->isTensor()) {
+  if (n->kind() == aten::type_as && !n->inputs().at(1)->isTensor()) {
     return false;
   }
   return differentiable_kinds.count(n->kind()) > 0;

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -86,6 +86,7 @@ Gradient differentiate(std::shared_ptr<Graph>& graph, const std::vector<bool>& r
 // can we take a derivative of this node symbolically?
 bool isDifferentiable(Node * n);
 bool isDifferentiable(Graph & g);
+bool isComparison(Node * n);
 bool isZero(Value * v);
 
 }}

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -86,7 +86,6 @@ Gradient differentiate(std::shared_ptr<Graph>& graph, const std::vector<bool>& r
 // can we take a derivative of this node symbolically?
 bool isDifferentiable(Node * n);
 bool isDifferentiable(Graph & g);
-bool isComparison(Node * n);
 bool isZero(Value * v);
 
 }}

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -60,6 +60,10 @@ std::ostream& operator<<(std::ostream & out, const TensorDesc & d) {
 
 namespace codegen {
 
+/*with type_as not checking type of its input, a fusion group can have non-fp32 tensor as input.
+Correct code for this case is generated, however, nvrtc does not know how to handle int*_t integer types,
+so typedefs help it handle those cases*/
+
 auto type_declarations_template = CodeTemplate(R"(
 #if defined(__CUDACC_RTC__)
 typedef unsigned char uint8_t; 

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -61,6 +61,10 @@ std::ostream& operator<<(std::ostream & out, const TensorDesc & d) {
 namespace codegen {
 
 auto type_declarations_template = CodeTemplate(R"(
+typedef unsigned char uint8_t; 
+typedef signed char int8_t; 
+typedef short int  int16_t; 
+typedef long int int64_t; 
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {
@@ -206,10 +210,11 @@ std::string encodeRHS(Node * n) {
     {aten::div, "${0} / ${1}"},
     {aten::eq, "${0} == ${1}"},
     {aten::fmod, "fmodf(${0}, ${1})"},
-    {aten::ge, "${0} >= ${1})"},
+    {aten::ge, "(${0} >= ${1})"},
     {aten::gt, "${0} > ${1}"},
-    {aten::le, "${0} <= ${1})"},
+    {aten::le, "(${0} <= ${1})"},
     {aten::lt, "${0} < ${1}"},
+    {aten::type_as, "(${0})"}, //everything is implicitly convertible to float
     {aten::mul, "${0} * ${1}"},
     {aten::ne, "${0} != ${1}"},
     {aten::remainder, "remainderf(${0}, ${1})"},

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -61,10 +61,12 @@ std::ostream& operator<<(std::ostream & out, const TensorDesc & d) {
 namespace codegen {
 
 auto type_declarations_template = CodeTemplate(R"(
+#if defined(__CUDACC_RTC__)
 typedef unsigned char uint8_t; 
 typedef signed char int8_t; 
 typedef short int  int16_t; 
-typedef long int int64_t; 
+typedef long long int int64_t; 
+#endif
 typedef ${IndexType} IndexType;
 template<typename T, size_t N>
 struct TensorInfo {

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -307,7 +307,6 @@ private:
 
     // these optimizations must run in the presence of variables
     // and when shape information is not statically known.
-
     EliminateDeadCode(graph);
     CheckInplace(graph);
     EliminateCommonSubexpression(graph);

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -80,7 +80,7 @@ bool isSimpleMap(Node *node) {
   TensorType* expected_type = node->inputs()[0]->type()->cast<TensorType>();
   if (!expected_type)
     return false;
-  static const auto equal_modulo_strides = [](TensorType* expected, const TypePtr& _actual, bool checkScalarType = true) {
+  static const auto equal_modulo_strides = [](TensorType* expected, const TypePtr& _actual, bool checkScalarType) {
     TensorType* actual = _actual->cast<TensorType>();
     return actual &&
            (!checkScalarType || expected->scalarType() == actual->scalarType()) &&

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -81,9 +81,8 @@ bool isSimpleMap(Node *node) {
   // Make sure that the node doesn't broadcast.
   JIT_ASSERT(node->inputs().size() > 0);
   TensorType* expected_type = node->inputs()[0]->type()->cast<TensorType>();
-  if (!expected_type)
-    return false;
-    static const auto equal_modulo_strides = [](TensorType* expected, const TypePtr& _actual) {
+  if (!expected_type) return false;
+  static const auto equal_modulo_strides = [](TensorType* expected, const TypePtr& _actual) {
      TensorType* actual = _actual->cast<TensorType>();
      return actual &&
            expected->device() == actual->device() &&

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -369,14 +369,13 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     // a tensor, so we should special-case these ops in the shape propagation.
     // Additionally, passing in a zero representative tensor into an integer
     // division op causes divide-by-zero errors
-    bool shape_inferenceable = node->kind() == aten::type_as ||
-      !std::any_of(types.begin(), types.end(), [](TensorType* t){
-      return at::isIntegralType(t->scalarType() );
+    bool shape_inferenceable = !std::any_of(types.begin(), types.end(), [](TensorType* t){
+      return at::isIntegralType(t->scalarType());
     });
-    if (!shape_inferenceable) {
-      setDynamicType(node);
-    } else {
+    if (node->kind() == aten::type_as || shape_inferenceable ) {
       PropagateShapeOnNodeByRunningIt(node, types);
+    } else {
+      setDynamicType(node);
     }
   }
 }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -148,7 +148,6 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     }
     default: ; // fall-through
   }
-
   std::vector<TensorType*> types;
   bool present;
   std::tie(types, present) = gatherTypes(node->inputs());
@@ -370,8 +369,9 @@ void PropagateShapeOnNode(Node * node, bool insert_expands) {
     // a tensor, so we should special-case these ops in the shape propagation.
     // Additionally, passing in a zero representative tensor into an integer
     // division op causes divide-by-zero errors
-    bool shape_inferenceable = !std::any_of(types.begin(), types.end(), [](TensorType* t){
-      return at::isIntegralType(t->scalarType());
+    bool shape_inferenceable = node->kind() == aten::type_as ||
+      !std::any_of(types.begin(), types.end(), [](TensorType* t){
+      return at::isIntegralType(t->scalarType() );
     });
     if (!shape_inferenceable) {
       setDynamicType(node);

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -137,7 +137,7 @@ struct SymbolicVariable {
     return r;
   }
   SymbolicVariable type_as(const SymbolicVariable rhs) const {
-    return create(aten::type_as, {*this, rhs})[0].typeLike(rhs);
+    return create(aten::type_as, {*this, rhs})[0].typeLikeWithRhsScalarType(*this, rhs);
   }
   SymbolicVariable narrow(int dim, int64_t start, int64_t length) const {
     Node * n;
@@ -206,7 +206,16 @@ private:
   }
   SymbolicVariable typeLikeWithScalarType(SymbolicVariable other, at::ScalarType type) {
     if (auto other_type = other.v->type()->cast<TensorType>()){
-      auto new_type = other_type->toScalarType(type)->cast<TensorType>()->contiguous();
+      auto new_type = other_type->toScalarType(type)->contiguous();
+      v->setType(new_type);
+    }
+    return *this;
+  }
+  SymbolicVariable typeLikeWithRhsScalarType(SymbolicVariable other, SymbolicVariable rhs) {
+    auto other_type = other.v->type()->cast<TensorType>();
+    auto rhs_type = rhs.v->type()->cast<TensorType>();
+    if (other_type && rhs_type){
+      auto new_type = other_type->toScalarType(rhs_type->scalarType())->contiguous();
       v->setType(new_type);
     }
     return *this;

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -65,37 +65,37 @@ struct SymbolicVariable {
   }
   SymbolicVariable operator>(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::gt, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::gt, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
   SymbolicVariable operator<(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::lt, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::lt, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
   SymbolicVariable operator>=(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::ge, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::ge, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
   SymbolicVariable operator<=(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::le, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::le, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
   SymbolicVariable operator==(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::eq, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::eq, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
   SymbolicVariable operator!=(at::Scalar rhs) const {
     Node * n;
-    auto r = create(aten::ne, {*this}, 1, &n)[0].typeLike(*this);
+    auto r = create(aten::ne, {*this}, 1, &n)[0].typeLikeWithScalarType(*this, at::kByte);
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
@@ -202,6 +202,13 @@ private:
   SymbolicVariable typeLike(SymbolicVariable other) {
     if (auto other_type = other.v->type()->cast<TensorType>())
       v->setType(other_type->contiguous());
+    return *this;
+  }
+  SymbolicVariable typeLikeWithScalarType(SymbolicVariable other, at::ScalarType type) {
+    if (auto other_type = other.v->type()->cast<TensorType>()){
+      auto new_type = other_type->toScalarType(type)->cast<TensorType>()->contiguous();
+      v->setType(new_type);
+    }
     return *this;
   }
   static Symbol a(const char * s_) {

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -63,6 +63,42 @@ struct SymbolicVariable {
     n->t_(attr::other, rhs.toTensor());
     return r;
   }
+  SymbolicVariable operator>(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::gt, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
+  SymbolicVariable operator<(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::lt, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
+  SymbolicVariable operator>=(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::ge, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
+  SymbolicVariable operator<=(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::le, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
+  SymbolicVariable operator==(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::eq, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
+  SymbolicVariable operator!=(at::Scalar rhs) const {
+    Node * n;
+    auto r = create(aten::ne, {*this}, 1, &n)[0].typeLike(*this);
+    n->t_(attr::other, rhs.toTensor());
+    return r;
+  }
   SymbolicVariable operator+(const SymbolicVariable rhs) const {
     Node * n;
     auto r = create(aten::add, {*this, rhs}, 1, &n)[0].typeLike(*this);
@@ -99,6 +135,9 @@ struct SymbolicVariable {
     n->i_(a("chunks"), chunks)
      ->i_(a("dim"), dim);
     return r;
+  }
+  SymbolicVariable type_as(const SymbolicVariable rhs) const {
+    return create(aten::type_as, {*this, rhs})[0].typeLike(rhs);
   }
   SymbolicVariable narrow(int dim, int64_t start, int64_t length) const {
     Node * n;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -98,6 +98,8 @@ struct DynamicType : public Type {
   static TypePtr get();
 };
 
+struct TensorType;
+using TensorTypePtr = std::shared_ptr<TensorType>;
 // This node represents a single Tensor value with a specific size
 struct TensorType : public Type {
   friend struct Type;
@@ -132,13 +134,13 @@ struct TensorType : public Type {
     return withSizesStrides(sizes, TensorType::contiguousStridesOf(sizes));
   }
 
-  TypePtr contiguous() const {
+  TensorTypePtr contiguous() const {
     auto t = std::make_shared<TensorType>(*this);
     t->strides_ = TensorType::contiguousStridesOf(sizes_);
     return t;
   }
 
-  TypePtr toScalarType(at::ScalarType type){
+  TensorTypePtr toScalarType(at::ScalarType type){
     auto t = std::make_shared<TensorType>(*this);
     t->scalar_type_ = type;
     return t;

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -137,6 +137,13 @@ struct TensorType : public Type {
     t->strides_ = TensorType::contiguousStridesOf(sizes_);
     return t;
   }
+
+  TypePtr toScalarType(at::ScalarType type){
+    auto t = std::make_shared<TensorType>(*this);
+    t->scalar_type_ = type;
+    return t;
+  }
+
   virtual bool operator==(const Type& rhs) const override {
     if(rhs.kind() != kind())
       return false;


### PR DESCRIPTION
Will be necessary for adding activations such as relu, hardtanh, hardshrink, clamp etc. 
Note: now shape_inferenceable balks at any integral type, I think it would make sense to support shape inference for pointwise operations on integral types (that way, it would also be possible to add those to jit). 