### PR TITLE
Correct bug in _torch_docs.py that truncates docstrings.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1,5 +1,7 @@
 """Adds docstrings to functions defined in the torch._C"""
 
+import re
+
 import torch._C
 from torch._C import _add_docstr as add_docstr
 
@@ -14,8 +16,9 @@ def parse_kwargs(desc):
         'weight (Tensor): a weight tensor\n        Some optional description'
     }
     """
-    # Split by indents. Assumes each arg starts on a new line with 4 spaces.
-    kwargs = [section.strip() for section in desc.split('\n   ')]
+    # Split on exactly 4 spaces after a newline
+    regx = re.compile("\n\s{4}(?!\s)")
+    kwargs = [section.strip() for section in regx.split(desc)]
     kwargs = [section for section in kwargs if len(section) > 0]
     return {desc.split(' ')[0]: desc for desc in kwargs}
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/6709 Introduced a helper function in `_torch_docs.py` called `parse_kwargs`.

```python
def parse_kwargs(desc):
    """Maps a description of args to a dictionary of {argname: description}.
    Input:
        ('    weight (Tensor): a weight tensor\n' +
         '        Some optional description')
    Output: {
        'weight': \
        'weight (Tensor): a weight tensor\n        Some optional description'
    }
    """
    # Split by indents. Assumes each arg starts on a new line with 4 spaces.
    kwargs = [section.strip() for section in desc.split('\n   ')]
    kwargs = [section for section in kwargs if len(section) > 0]
    return {desc.split(' ')[0]: desc for desc in kwargs}
```

The criteria for splitting lines doesn't do what it is supposed to do. You can test this by the following:

```python
factory_data_common_args = parse_kwargs("""
    data (array_like): Initial data for the tensor. Can be a list, tuple,
        NumPy ``ndarray``, scalar, and other types.
    dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
        Default: if None, infers data type from :attr:`data`.
    device (:class:`torch.device`, optional): the desired device of returned tensor.
        Default: if None, uses the current device for the default tensor type
        (see :func:`torch.set_default_tensor_type`). :attr:`device` will be the CPU
        for CPU tensor types and the current CUDA device for CUDA tensor types.
    requires_grad (bool, optional): If autograd should record operations on the
        returned tensor. Default: ``False``.
""")
print(factory_data_common_args)
```

Which shows:
```
{'data': 'data (array_like): Initial data for the tensor. Can be a list, tuple,',
 'NumPy': 'NumPy ``ndarray``, scalar, and other types.',
 'dtype': 'dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.',
 'Default:': 'Default: if None, uses the current device for the default tensor type',
 'device': 'device (:class:`torch.device`, optional): the desired device of returned tensor.',
 '(see': '(see :func:`torch.set_default_tensor_type`). :attr:`device` will be the CPU',
 'for': 'for CPU tensor types and the current CUDA device for CUDA tensor types.',
 'requires_grad': 'requires_grad (bool, optional): If autograd should record operations on the',
 'returned': 'returned tensor. Default: ``False``.'}
```

This is because the split also matches the patterns of the other lines which start with 8 spaces. This makes only the first line show up in the docstring, which you can verify by `torch.tensor?`.

```
Docstring:
tensor(data, dtype=None, device=None, requires_grad=False) -> Tensor

Constructs a tensor with :attr:`data`.

.. warning::

    :func:`torch.tensor` always copies :attr:`data`. If you have a Tensor
    ``data`` and want to avoid a copy, use :func:`torch.Tensor.requires_grad_`
    or :func:`torch.Tensor.detach`.
    If you have a NumPy ``ndarray`` and want to avoid a copy, use
    :func:`torch.from_numpy`.

Args:
    data (array_like): Initial data for the tensor. Can be a list, tuple,
    dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
    device (:class:`torch.device`, optional): the desired device of returned tensor.
    requires_grad (bool, optional): If autograd should record operations on the

```

I verified this against https://github.com/pytorch/pytorch/commit/2fb957da814e4e5a351beda4f09a89b58f96186a.

The solution in this patch is to use a regex to split, which matches only newlines followed by exactly 4 spaces, which was the original intent I believe.