### PR TITLE
Removing remaining NO_PYTHON ifdefs

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -69,7 +69,7 @@ fi
 
 # Test no-Python build
 if [[ "$BUILD_TEST_LIBTORCH" == "1" ]]; then
-  echo "Building libtorch with NO_PYTHON"
+  echo "Building libtorch"
   # NB: Install outside of source directory (at the same level as the root
   # pytorch folder) so that it doesn't get cleaned away prior to docker push.
   WERROR=1 VERBOSE=1 tools/cpp_build/build_all.sh "$PWD/../cpp-build"

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -85,7 +85,7 @@ test_torchvision() {
 
 test_libtorch() {
   if [[ "$BUILD_TEST_LIBTORCH" == "1" ]]; then
-     echo "Testing libtorch with NO_PYTHON"
+     echo "Testing libtorch"
      CPP_BUILD="$PWD/../cpp-build"
      if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
        "$CPP_BUILD"/libtorch/bin/test_jit

--- a/tools/cpp_build/libtorch/CMakeLists.txt
+++ b/tools/cpp_build/libtorch/CMakeLists.txt
@@ -97,7 +97,7 @@ if(NOT NO_CUDA)
   endif()
 endif()
 
-add_definitions(-DNO_PYTHON -D_FORCE_INLINES)
+add_definitions(-DUSE_CATCH -D_FORCE_INLINES)
 
 if(NOT TORCH_INSTALL_BIN_DIR)
   set(TORCH_INSTALL_BIN_DIR bin)

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -7,6 +7,7 @@
 #include "torch/csrc/utils/object_ptr.h"
 #include "torch/csrc/utils/python_arg_parser.h"
 #include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/utils/pybind.h"
 
 PyObject *THPDevice_New(const torch::Device& device)
 {

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -38,11 +38,7 @@ variable_list Function::traced_apply(variable_list inputs) {
   // Insert a CppOp in the trace.
   auto& graph = state->graph;
   auto* this_node = graph->createCppOp(get_shared_ptr());
-#ifndef NO_PYTHON
-  this_node->setSourceLocation(std::make_shared<StringSourceLocation>(
-        jit::tracer::getPythonInterpreterStackTrace()
-  ));
-#endif
+  jit::tracer::recordSourceLocation(this_node);
   for (auto& input: inputs) {
     this_node->addInput(tracer::getValueTrace(state, input));
   }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -16,6 +16,7 @@
 #include "torch/csrc/autograd/python_hook.h"
 #include "torch/csrc/autograd/saved_variable.h"
 #include "torch/csrc/jit/tracer.h"
+#include "torch/csrc/jit/python_tracer.h"
 #include "torch/csrc/DynamicTypes.h"
 #include "torch/csrc/utils/auto_gil.h"
 #include "torch/csrc/utils/auto_gpu.h"

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -131,7 +131,7 @@ void initJITBindings(PyObject *module) {
         }
       });
   initPythonIRBindings(module);
-  initPythonTracerBindings(module);
+  tracer::initPythonTracerBindings(module);
   script::initTreeViewBindings(module);
   script::initJitScriptBindings(module);
   registerPythonInterpreterOps();

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -76,7 +76,13 @@ void initJITBindings(PyObject *module) {
      auto tensor_inputs = createVariableTensorList(inputs);
      PropagateInputShapes(graph, ArgumentSpec(with_grad, tensor_inputs));
    })
-   .def("_jit_run_cpp_tests", runJITCPPTests)
+   .def("_jit_run_cpp_tests", [] {
+     // We have to release the GIL inside this method, because if we happen to
+     // initialize the autograd engine in these tests, the newly spawned worker threads will
+     // try to initialize their PyThreadState*, and they need the GIL for this.
+     AutoNoGIL _no_gil;
+     return runJITCPPTests();
+   })
    .def("_jit_flatten", [](py::handle& obj) {
      auto res =  python::flatten(obj);
      return std::make_pair(res.vars, res.desc);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1,6 +1,3 @@
-#ifndef NO_PYTHON
-#include "torch/csrc/python_headers.h"
-#endif
 #include "ir.h"
 
 #include "torch/csrc/autograd/function.h"
@@ -13,124 +10,6 @@
 #include <sstream>
 #include <algorithm>
 #include <string>
-
-#ifndef NO_PYTHON
-#include "torch/csrc/utils/auto_gil.h"
-#include "torch/csrc/utils/python_strings.h"
-#include "pybind11/pybind11.h"
-
-namespace py = pybind11;
-
-namespace torch { namespace jit {
-
-std::string getPythonName(const PyObject* obj_) {
-  AutoGIL gil;
-  PyObject* obj = const_cast<PyObject*>(obj_);
-  auto v = py::getattr(obj, "__name__", py::str("<python_value>"));
-  // if this was a autograd.Function recover the name of the class
-  return py::str(v);
-}
-
-std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
-  AutoGIL gil;
-  auto pyobj = py::handle(const_cast<PyObject*>(obj.get()));
-  if (py::isinstance<py::tuple>(pyobj)) {
-    // This special-case for printing tuples handles a problem where
-    // str((2L, 3L)) outputs "(2L, 3L)" in Python 2 but "(2, 3)"
-    // in Python 3.  In order to suppress the L-suffix, we must
-    // manually print the string ourselves, calling str() on the
-    // sub-elements.
-    //
-    // This is a fairly fragile fix (What if you have nested tuples
-    // in tuples? What if you have dictionaries?) but it seems to hit
-    // the cases that are triggered in practice in onnx-pytorch.  Revisit
-    // this code if this is not the case.
-    //
-    // By the way, one non-solution for this problem is to monkeypatch
-    // tuple.__str__; this doesn't work because Python doesn't allow
-    // monkeypatching methods of built-in types.
-    auto pytuple = pyobj.cast<py::tuple>();
-    out << "(";
-    size_t i = 0;
-    for (auto& o : pytuple) {
-      if (i > 0) {
-        out << ", ";
-      }
-      THPObjectPtr str(py::str(o).release().ptr());
-      out << THPUtils_unpackString(str.get());
-      i++;
-    }
-    if (i == 1) {
-      out << ",";
-    }
-    out << ")";
-    return out;
-  } else {
-    return out << THPUtils_unpackString(py::str(pyobj).ptr());
-  }
-}
-
-at::optional<THPObjectPtr> PythonOp::autogradFunction() const {
-  AutoGIL gil;
-  py::handle obj = const_cast<PyObject*>(pyobj.get());
-
-  auto r = py::getattr(obj, "__self__", py::none());
-  if(r.is_none())
-    return at::nullopt;
-
-  auto apply = py::getattr(r, "apply", py::none());
-  if(apply.is_none())
-    return at::nullopt;
-
-  auto c = PyObject_RichCompareBool(apply.ptr(), obj.ptr(), Py_NE);
-  if(PyErr_Occurred())
-    throw py::error_already_set();
-  if(c)
-    return at::nullopt;
-
-  return THPObjectPtr(r.release().ptr());
-}
-
-std::string PythonOp::name() const {
-  AutoGIL gil;
-  if(auto autograd = autogradFunction()) {
-    return getPythonName(autograd->get());
-  } else {
-    return getPythonName(pyobj.get());
-  }
-}
-
-void PythonOp::cloneFrom(Node * other_) {
-  Node::cloneFrom(other_);
-  auto other = other_->cast<PythonOp>();
-  this->cconv = other->cconv;
-  Py_INCREF(other->pyobj.get());
-  this->pyobj = THPObjectPtr(other->pyobj.get());
-  for(auto & sa : other->scalar_args) {
-    Py_INCREF(sa.get());
-    this->scalar_args.emplace_back(sa.get());
-  }
-}
-
-}} // namespace torch::jit
-
-#else
-
-namespace torch { namespace jit {
-
-std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
-  throw std::runtime_error("Trying to print Python object from a C++ build");
-}
-
-std::string PythonOp::name() const {
-  throw std::runtime_error("Trying to call PythonOp::name from a C++ build");
-  return std::string();
-}
-
-}} // namespace torch::jit
-
-#endif
-
 
 namespace torch { namespace jit {
 
@@ -289,14 +168,7 @@ std::ostream& printNode(std::ostream & out, size_t level, const Node * n, std::v
   out << " = ";
   IR_IFM_CONST(n,PythonOp)
     out << "^" << value->name();
-    out << "(";
-    int i = 0;
-    for (auto& scalar : value->scalar_args) {
-      if (i++ > 0)
-        out << ", ";
-      printPyObject(out, scalar);
-    }
-    out << ")";
+    value->writeScalars(out);
   IR_ELSEIFM_CONST(CppOp)
     out << "CppOp[" << value->name() << "]";
   IR_ELSE()
@@ -697,6 +569,19 @@ inline Value* Value::setUniqueName(const std::string & name) {
   names[name] = this;
   unique_name_ = name;
   return this;
+}
+
+PythonOp* defaultAllocPythonOp(Graph*g) {
+  throw std::runtime_error("Trying to allocate a Python object without python bindings loaded");
+}
+std::atomic<decltype(&defaultAllocPythonOp)> alloc_python_op;
+
+// patched in when python bindings are loaded
+PythonOp* allocPythonOp(Graph* g) {
+  return alloc_python_op.load()(g);
+}
+void setAllocPythonOp(PythonOp* (*v)(Graph* g)) {
+  alloc_python_op.store(v);
 }
 
 }} // namespace torch::jit

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -8,6 +8,8 @@
 #include "torch/csrc/jit/export.h"
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/argument_spec.h"
+#include "torch/csrc/utils/auto_gil.h"
+#include "torch/csrc/utils/python_strings.h"
 
 
 #include <iostream>
@@ -15,7 +17,123 @@
 
 namespace torch { namespace jit {
 
+std::string getPythonName(const PyObject* obj_) {
+  AutoGIL gil;
+  PyObject* obj = const_cast<PyObject*>(obj_);
+  auto v = py::getattr(obj, "__name__", py::str("<python_value>"));
+  // if this was a autograd.Function recover the name of the class
+  return py::str(v);
+}
+
+std::ostream& printPyObject(std::ostream & out, const THPObjectPtr& obj) {
+  AutoGIL gil;
+  auto pyobj = py::handle(const_cast<PyObject*>(obj.get()));
+  if (py::isinstance<py::tuple>(pyobj)) {
+    // This special-case for printing tuples handles a problem where
+    // str((2L, 3L)) outputs "(2L, 3L)" in Python 2 but "(2, 3)"
+    // in Python 3.  In order to suppress the L-suffix, we must
+    // manually print the string ourselves, calling str() on the
+    // sub-elements.
+    //
+    // This is a fairly fragile fix (What if you have nested tuples
+    // in tuples? What if you have dictionaries?) but it seems to hit
+    // the cases that are triggered in practice in onnx-pytorch.  Revisit
+    // this code if this is not the case.
+    //
+    // By the way, one non-solution for this problem is to monkeypatch
+    // tuple.__str__; this doesn't work because Python doesn't allow
+    // monkeypatching methods of built-in types.
+    auto pytuple = pyobj.cast<py::tuple>();
+    out << "(";
+    size_t i = 0;
+    for (auto& o : pytuple) {
+      if (i > 0) {
+        out << ", ";
+      }
+      THPObjectPtr str(py::str(o).release().ptr());
+      out << THPUtils_unpackString(str.get());
+      i++;
+    }
+    if (i == 1) {
+      out << ",";
+    }
+    out << ")";
+    return out;
+  } else {
+    return out << THPUtils_unpackString(py::str(pyobj).ptr());
+  }
+}
+
+// execute a Python function, used for Ops we can't optimize but that we want to optimize around
+struct ConcretePythonOp : public PythonOp {
+ ConcretePythonOp(Graph * graph)
+ : PythonOp(graph) {}
+ virtual std::string name() const override {
+   AutoGIL gil;
+   if(auto autograd = autogradFunction()) {
+     return getPythonName(autograd->get());
+   } else {
+     return getPythonName(pyobj.get());
+   }
+ }
+ virtual void cloneFrom(Node * other_) override {
+   Node::cloneFrom(other_);
+   auto other = other_->cast<PythonOp>();
+   this->cconv = other->cconv;
+   Py_INCREF(other->pyobj.get());
+   this->pyobj = THPObjectPtr(other->pyobj.get());
+   for(auto & sa : other->scalar_args) {
+     Py_INCREF(sa.get());
+     this->scalar_args.emplace_back(sa.get());
+   }
+ }
+ virtual Node * allocNewInstance(Graph * g) override {
+   return new ConcretePythonOp(g);
+ }
+ // recover the autograd.Function instance, if this PythonOp's function
+ // was originally SomeFunction.apply
+ // used in ONNX for discovering symbolics
+ virtual at::optional<THPObjectPtr> autogradFunction() const override {
+   AutoGIL gil;
+   py::handle obj = const_cast<PyObject*>(pyobj.get());
+
+   auto r = py::getattr(obj, "__self__", py::none());
+   if(r.is_none())
+     return at::nullopt;
+
+   auto apply = py::getattr(r, "apply", py::none());
+   if(apply.is_none())
+     return at::nullopt;
+
+   auto c = PyObject_RichCompareBool(apply.ptr(), obj.ptr(), Py_NE);
+   if(PyErr_Occurred())
+     throw py::error_already_set();
+   if(c)
+     return at::nullopt;
+
+   return THPObjectPtr(r.release().ptr());
+ }
+
+ virtual void writeScalars(std::ostream& out) const override {
+   out << "(";
+   int i = 0;
+   for (auto& scalar : scalar_args) {
+     if (i++ > 0)
+       out << ", ";
+     printPyObject(out, scalar);
+   }
+   out << ")";
+ }
+
+};
+
+PythonOp* pythonAllocPythonOp(Graph* g) {
+  return new ConcretePythonOp(g);
+}
+
 void initPythonIRBindings(PyObject * module_) {
+  setAllocPythonOp(pythonAllocPythonOp);
+
   auto m = py::handle(module_).cast<py::module>();
   #define GS(name) \
     def(#name,&Graph :: name)

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -6,6 +6,7 @@
 #include "torch/csrc/jit/export.h"
 #include "torch/csrc/jit/pybind.h"
 #include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/jit/passes/dead_code_elimination.h"
 
 #include <sstream>
 
@@ -13,11 +14,81 @@ using namespace torch::autograd;
 using namespace torch::jit;
 using namespace torch::jit::tracer;
 
-namespace torch { namespace jit {
+
+namespace torch { namespace jit { namespace tracer {
+
+
+// Python interpreter retrieval routine adapted from
+// https://stackoverflow.com/a/8706144
+std::string getPythonInterpreterStackTrace() {
+  std::stringstream stack_trace;
+  AutoGIL gil;
+  PyThreadState *tstate = PyThreadState_GET();
+  if (NULL != tstate && NULL != tstate->frame) {
+    PyFrameObject *frame = tstate->frame;
+
+    while (NULL != frame) {
+      int line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
+      std::string filename = THPUtils_unpackString(frame->f_code->co_filename);
+      std::string funcname = THPUtils_unpackString(frame->f_code->co_name);
+      stack_trace << filename << "(" << line << "): " << funcname << "\n";
+      frame = frame->f_back;
+    }
+  }
+  return stack_trace.str();
+}
+
+// This is a temporary constructor so that we can write python tests of
+// the executor. It does not have most of the functionality of CompiledFunction
+// such as being able to hold parameters...
+std::shared_ptr<torch::jit::Graph> createGraphByTracing(
+        py::function func,
+        tracer::variable_list trace_inputs,
+        size_t num_func_inputs) {
+  auto enter_info = tracer::enter(std::move(trace_inputs), 1);
+  py::tuple py_inputs(num_func_inputs);
+  for(size_t i = 0; i < num_func_inputs; ++i) {
+    py_inputs[i] = py::cast(enter_info.second[i]);
+  }
+  auto out = func(*py_inputs);
+  std::vector<autograd::Variable> outputs;
+  if(PyTuple_Check(out.ptr())) {
+    outputs = py::cast<std::vector<autograd::Variable>>(out);
+  } else {
+    outputs.push_back(py::cast<autograd::Variable>(out));
+  }
+  tracer::exit(outputs);
+  auto graph = enter_info.first->graph;
+  EliminateDeadCode(graph);
+  return graph;
+}
+
+PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
+                                  std::string arg_types,
+                                  at::ArrayRef<Variable> inputs,
+                                  pyobj_list scalar_args) {
+  THPObjectPtr apply(PyObject_GetAttrString(pyobj.get(), "apply"));
+  if(!apply) {
+    throw python_error();
+  }
+  return makePreTraceInfo(inputs, [&](const std::shared_ptr<TracingState>& state, Graph& graph) {
+    return graph.createPythonOp(
+        std::move(apply),
+        arg_types,
+        std::move(scalar_args));
+  });
+}
+
+void pythonRecordSourceLocation(Node* n) {
+  auto sl = std::make_shared<StringSourceLocation>(getPythonInterpreterStackTrace());
+  n->setSourceLocation(sl);
+}
 
 #define ASSERT_UNEXPIRED(METHOD_NAME) if (s.is_expired()) throw std::runtime_error("calling " METHOD_NAME " on an expired trace")
 
 void initPythonTracerBindings(PyObject* module_) {
+  setRecordSourceLocation(pythonRecordSourceLocation);
+
   auto m = py::handle(module_).cast<py::module>();
   py::class_<TracingState,std::shared_ptr<TracingState>>(m, "TracingState", py::dynamic_attr())
     // NB: no constructor; you have to get it from C++ code
@@ -73,4 +144,4 @@ void initPythonTracerBindings(PyObject* module_) {
   });
 }
 
-}} // namespace torch::jit
+}}} // namespace torch::jit::tracing

--- a/torch/csrc/jit/python_tracer.h
+++ b/torch/csrc/jit/python_tracer.h
@@ -3,7 +3,21 @@
 #include "torch/csrc/python_headers.h"
 #include <memory>
 #include "torch/csrc/jit/tracer.h"
+#include "torch/csrc/utils/pybind.h"
 
-namespace torch { namespace jit {
+namespace torch { namespace jit { namespace tracer {
 void initPythonTracerBindings(PyObject *module);
+
+
+std::string getPythonInterpreterStackTrace();
+tracer::PreTraceInfo preRecordPythonTrace(
+    THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<autograd::Variable> inputs,
+    pyobj_list scalar_args);
+
+std::shared_ptr<Graph> createGraphByTracing(
+        py::function func,
+        autograd::variable_list inputs,
+        size_t num_inputs);
+} // namespace tracer
+
 }} // namespace torch::jit

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -2,6 +2,7 @@
 #include "torch/csrc/jit/script/compiler.h"
 #include "torch/csrc/Device.h"
 #include "torch/csrc/jit/tensor_conversions.h"
+#include "torch/csrc/jit/python_tracer.h"
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -1,12 +1,11 @@
-#ifndef NO_PYTHON
-#include "torch/csrc/python_headers.h"
-
-#define REQUIRE JIT_ASSERT
-
-#else
+#ifdef USE_CATCH
 
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
+
+#else
+
+#define REQUIRE JIT_ASSERT
 
 #endif
 
@@ -38,12 +37,6 @@
 
 #include <vector>
 #include <iostream>
-
-#ifndef NO_PYTHON
-#include "torch/csrc/utils/auto_gil.h"
-#else
-struct AutoNoGIL {};
-#endif
 
 namespace torch { namespace jit {
 
@@ -587,10 +580,6 @@ void testADFormulas() {
     {"split",   {{10, 12, 15}}, [](const VL& v) -> VL { return fmap<Variable>(v[0].split(3, 2)); }},
   };
 
-  // We have to release the GIL inside this method, because if we happen to
-  // initialize the autograd engine here, the newly spawned worker threads will
-  // try to initialize their PyThreadState*, and they need the GIL for this.
-  AutoNoGIL _no_gil;
   for (const auto & test : ad_tests) {
     // Get reference values form autograd
     auto vars_in        = test.make_vars();
@@ -886,7 +875,28 @@ void testControlFlow() {
   REQUIRE(256 == run_binary("while_test",2,0));
 }
 
-#ifdef NO_PYTHON
+std::string runJITCPPTests() {
+  std::stringstream out;
+  testControlFlow();
+  testGraphExecutor();
+  testBlocks(out);
+  testCreateAutodiffSubgraphs(out);
+  testDifferentiate(out);
+  testDifferentiateWithRequiresGrad(out);
+  testADFormulas();
+  interpTest();
+  interpStageTest();
+  codeTemplateTest();
+  fusionTests();
+  attributesTest();
+  internedStringsTests();
+  fromQualStringTests();
+  argumentSpecTest();
+  shapeAnalysisTest();
+  return out.str();
+}
+
+#ifdef USE_CATCH
 
 TEST_CASE( "jit test CPU", "[cpu]" ) {
 
@@ -928,26 +938,5 @@ TEST_CASE( "jit test CUDA", "[cuda]" ) {
 }
 
 #endif
-
-std::string runJITCPPTests() {
-  std::stringstream out;
-  testControlFlow();
-  testGraphExecutor();
-  testBlocks(out);
-  testCreateAutodiffSubgraphs(out);
-  testDifferentiate(out);
-  testDifferentiateWithRequiresGrad(out);
-  testADFormulas();
-  interpTest();
-  interpStageTest();
-  codeTemplateTest();
-  fusionTests();
-  attributesTest();
-  internedStringsTests();
-  fromQualStringTests();
-  argumentSpecTest();
-  shapeAnalysisTest();
-  return out.str();
-}
 
 }}

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -1,6 +1,3 @@
-#ifndef NO_PYTHON
-#include "torch/csrc/python_headers.h"
-#endif
 #include "torch/csrc/jit/tracer.h"
 
 #include "torch/csrc/autograd/variable.h"
@@ -14,59 +11,6 @@
 #include <string>
 #include <sstream>
 #include <memory>
-
-#ifndef NO_PYTHON
-#include "torch/csrc/utils/auto_gil.h"
-#include "torch/csrc/utils/python_strings.h"
-#include "torch/csrc/jit/pybind.h"
-#include <frameobject.h>
-#include <patchlevel.h>
-
-
-// Python interpreter retrieval routine adapted from
-// https://stackoverflow.com/a/8706144
-std::string torch::jit::tracer::getPythonInterpreterStackTrace() {
-  std::stringstream stack_trace;
-  AutoGIL gil;
-  PyThreadState *tstate = PyThreadState_GET();
-  if (NULL != tstate && NULL != tstate->frame) {
-    PyFrameObject *frame = tstate->frame;
-
-    while (NULL != frame) {
-      int line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
-      std::string filename = THPUtils_unpackString(frame->f_code->co_filename);
-      std::string funcname = THPUtils_unpackString(frame->f_code->co_name);
-      stack_trace << filename << "(" << line << "): " << funcname << "\n";
-      frame = frame->f_back;
-    }
-  }
-  return stack_trace.str();
-}
-// This is a temporary constructor so that we can write python tests of
-// the executor. It does not have most of the functionality of CompiledFunction
-// such as being able to hold parameters...
-std::shared_ptr<torch::jit::Graph> torch::jit::tracer::createGraphByTracing(
-        py::function func,
-        tracer::variable_list trace_inputs,
-        size_t num_func_inputs) {
-  auto enter_info = tracer::enter(std::move(trace_inputs), 1);
-  py::tuple py_inputs(num_func_inputs);
-  for(size_t i = 0; i < num_func_inputs; ++i) {
-    py_inputs[i] = py::cast(enter_info.second[i]);
-  }
-  auto out = func(*py_inputs);
-  std::vector<autograd::Variable> outputs;
-  if(PyTuple_Check(out.ptr())) {
-    outputs = py::cast<std::vector<autograd::Variable>>(out);
-  } else {
-    outputs.push_back(py::cast<autograd::Variable>(out));
-  }
-  tracer::exit(outputs);
-  auto graph = enter_info.first->graph;
-  EliminateDeadCode(graph);
-  return graph;
-}
-#endif
 
 namespace torch { namespace jit { namespace tracer {
 
@@ -166,58 +110,12 @@ void nontraceableBackwardSubgraph(const variable_list& inputs, const variable_li
   std::make_shared<autograd::Eval>()->replaceSubgraph(inputs, outputs);
 }
 
-// We must record the nodes of inputs before we actually carry out
-// the operation, because an inplace operation may destroy the information
-// we're interested in.  See #4480.
-template<typename F>
-PreTraceInfo makePreTraceInfo(at::ArrayRef<Variable> inputs, F ctor) {
-  PreTraceInfo info;
-  info.state = getTracingState(inputs);
-  auto& graph = info.state->graph;
-  auto state_lock = info.state->lock();
-
-  Node *n = ctor(info.state, *graph);
-#ifndef NO_PYTHON
-  auto sl = std::make_shared<StringSourceLocation>(getPythonInterpreterStackTrace());
-  n->setSourceLocation(sl);
-#endif
-
-  for (Variable input : inputs) {
-    n->addInput(getValueTrace(info.state, input));
-  }
-
-  // NB: Order matters. This must append after inputs but before outputs.
-  graph->appendNode(n);
-
-  info.n = n;
-
-  return info;
-}
-
 PreTraceInfo preRecordTrace(Symbol op,
                             at::ArrayRef<Variable> inputs) {
   return makePreTraceInfo(inputs, [&op](const std::shared_ptr<TracingState>& state, Graph& graph) {
     return graph.create(op, 0 /* initial outputs */);
   });
 }
-
-#ifndef NO_PYTHON
-PreTraceInfo preRecordPythonTrace(THPObjectPtr pyobj,
-                                  std::string arg_types,
-                                  at::ArrayRef<Variable> inputs,
-                                  pyobj_list scalar_args) {
-  THPObjectPtr apply(PyObject_GetAttrString(pyobj.get(), "apply"));
-  if(!apply) {
-    throw python_error();
-  }
-  return makePreTraceInfo(inputs, [&](const std::shared_ptr<TracingState>& state, Graph& graph) {
-    return graph.createPythonOp(
-        std::move(apply),
-        arg_types,
-        std::move(scalar_args));
-  });
-}
-#endif
 
 void postRecordTrace(const PreTraceInfo& info,
                      at::ArrayRef<Variable> outputs) {
@@ -263,6 +161,17 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   setValueTrace(tracing_state, size_var, node->output());
 
   return size_var;
+}
+
+
+// no python present so we just do not record source information
+void defaultRecordSourceLocation(Node* n) {}
+std::atomic<decltype(&defaultRecordSourceLocation)> record_source_location(defaultRecordSourceLocation);
+void recordSourceLocation(Node* n) {
+  return record_source_location.load()(n);
+}
+void setRecordSourceLocation(void (*v)(Node*)) {
+  record_source_location.store(v);
 }
 
 }}}

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -8,9 +8,6 @@
 #include "torch/csrc/autograd/function_hook.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/utils/auto_unique_ptr.h"
-#ifndef NO_PYTHON
-#include "torch/csrc/utils/pybind.h"
-#endif
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -22,10 +19,6 @@ namespace torch { namespace jit { namespace tracer {
 
 using torch::autograd::Variable;
 using variable_list = std::vector<Variable>;
-
-#ifndef NO_PYTHON
-std::string getPythonInterpreterStackTrace();
-#endif
 
 namespace detail {
 
@@ -281,18 +274,36 @@ struct PreTraceInfo {
 };
 
 PreTraceInfo preRecordTrace(Symbol op, at::ArrayRef<Variable> inputs);
-#ifndef NO_PYTHON
-PreTraceInfo preRecordPythonTrace(
-    THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<Variable> inputs,
-    pyobj_list scalar_args);
-
-std::shared_ptr<Graph> createGraphByTracing(
-        py::function func,
-        variable_list inputs,
-        size_t num_inputs);
-#endif
 void postRecordTrace(const PreTraceInfo& info, at::ArrayRef<Variable> outputs);
 
 autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim);
+
+void recordSourceLocation(Node* n);
+void setRecordSourceLocation(void (*v)(Node*));
+
+// We must record the nodes of inputs before we actually carry out
+// the operation, because an inplace operation may destroy the information
+// we're interested in.  See #4480.
+template<typename F>
+PreTraceInfo makePreTraceInfo(at::ArrayRef<Variable> inputs, F ctor) {
+  PreTraceInfo info;
+  info.state = getTracingState(inputs);
+  auto& graph = info.state->graph;
+  auto state_lock = info.state->lock();
+
+  Node *n = ctor(info.state, *graph);
+  recordSourceLocation(n);
+
+  for (Variable input : inputs) {
+    n->addInput(getValueTrace(info.state, input));
+  }
+
+  // NB: Order matters. This must append after inputs but before outputs.
+  graph->appendNode(n);
+
+  info.n = n;
+
+  return info;
+}
 
 }}} // namespace torch::jit::tracer


### PR DESCRIPTION
Now each compilation unit is either separate from the python build or is entirely in the python build.  This will allow us to factor the build into libtorch.so and libtorch_python.so