### PR TITLE
Make all attributes of DataParallel accessible

### DIFF
--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -135,7 +135,15 @@ class DataParallel(Module):
     def gather(self, outputs, output_device):
         return gather(outputs, output_device, dim=self.dim)
 
+    def __getattr__(self,name):
+        if name is not 'module':
+            try:
+                return getattr(self.module,name)
+            except AttributeError:
+                pass
 
+        return super(DataParallel, self).__getattr__(name)
+    
 def data_parallel(module, inputs, device_ids=None, output_device=None, dim=0, module_kwargs=None):
     r"""Evaluates module(input) in parallel across the GPUs given in device_ids.
 


### PR DESCRIPTION
Currently once after wrapped with DataParallel, fields of source module are not accessible except for forward. 

```
class MyNetwork(nn.Module):
   ....
   @property
   def some_stats(self):
   ....

DataParallel(MyNetwork).some_stats ==> Error!
```

This commit makes all fields of the source module accessible with DataParallel wrapped instance.

