### PR TITLE
Skip ConvTraspose ONNX backend tests

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -37,6 +37,7 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_prelu.*'  # PRelu is not compliant with ONNX yet
                      '|test_operator_repeat.*'  # Tile is not compliant with ONNX yet
                      '|test_.*pool_.*same.*'  # Does not support pool same.
+                     '|test_convtranspose.*'  # ConvTranspose needs some more complicated translation
                      ')')
 
 # Quick patch to unbreak master CI, is working on the debugging.


### PR DESCRIPTION
CI is failing on these new tests added on the onnx side, skip them to unbreak CI while investigating.