### PR TITLE
[codemod] Replace std::size_t with size_t

### DIFF
--- a/aten/doc/Type.h
+++ b/aten/doc/Type.h
@@ -98,7 +98,7 @@ struct AT_API Type {
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
   virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
-  virtual std::size_t elementSizeInBytes() const = 0;
+  virtual size_t elementSizeInBytes() const = 0;
   virtual Type & toBackend(Backend b) const;
   virtual Type & toScalarType(ScalarType s) const;
   Context& get_context() const { return *context; }

--- a/aten/src/ATen/AlignOf.h
+++ b/aten/src/ATen/AlignOf.h
@@ -33,7 +33,7 @@ namespace at {
 // MSVC requires special handling here.
 #ifndef _MSC_VER
 
-template<std::size_t Alignment, std::size_t Size>
+template<size_t Alignment, size_t Size>
 struct AlignedCharArray {
   alignas(Alignment) char buffer[Size];
 };
@@ -41,7 +41,7 @@ struct AlignedCharArray {
 #else // _MSC_VER
 
 /// \brief Create a type with an aligned char buffer.
-template<std::size_t Alignment, std::size_t Size>
+template<size_t Alignment, size_t Size>
 struct AlignedCharArray;
 
 // We provide special variations of this template for the most common
@@ -52,7 +52,7 @@ struct AlignedCharArray;
 // MSVC warns on the existence of the declspec despite the union member forcing
 // proper alignment.
 
-template<std::size_t Size>
+template<size_t Size>
 struct AlignedCharArray<1, Size> {
   union {
     char aligned;
@@ -60,7 +60,7 @@ struct AlignedCharArray<1, Size> {
   };
 };
 
-template<std::size_t Size>
+template<size_t Size>
 struct AlignedCharArray<2, Size> {
   union {
     short aligned;
@@ -68,7 +68,7 @@ struct AlignedCharArray<2, Size> {
   };
 };
 
-template<std::size_t Size>
+template<size_t Size>
 struct AlignedCharArray<4, Size> {
   union {
     int aligned;
@@ -76,7 +76,7 @@ struct AlignedCharArray<4, Size> {
   };
 };
 
-template<std::size_t Size>
+template<size_t Size>
 struct AlignedCharArray<8, Size> {
   union {
     double aligned;
@@ -89,7 +89,7 @@ struct AlignedCharArray<8, Size> {
 // can't pass them by-value as function arguments on MSVC.
 
 #define AT_ALIGNEDCHARARRAY_TEMPLATE_ALIGNMENT(x) \
-  template<std::size_t Size> \
+  template<size_t Size> \
   struct AlignedCharArray<x, Size> { \
     __declspec(align(x)) char buffer[Size]; \
   };

--- a/aten/src/ATen/Allocator.h
+++ b/aten/src/ATen/Allocator.h
@@ -9,7 +9,7 @@ namespace at {
 
 struct Allocator {
   virtual ~Allocator() {}
-  virtual void* allocate(std::size_t n) const = 0;
+  virtual void* allocate(size_t n) const = 0;
   virtual void deallocate(void* ptr) const = 0;
 };
 
@@ -19,7 +19,7 @@ struct AllocatorRetainable : public Retainable {
   AllocatorRetainable(std::unique_ptr<Allocator> allocator)
     : allocator(std::move(allocator)) {}
 
-  void* allocate(std::size_t n) {
+  void* allocate(size_t n) {
     return allocator->allocate(n);
   }
   void deallocate(void* ptr) {

--- a/aten/src/ATen/Storage.h
+++ b/aten/src/ATen/Storage.h
@@ -14,8 +14,8 @@ struct Storage {
   void operator=(const Storage&) = delete;
 
   virtual ~Storage() {};
-  virtual std::size_t elementSize() const = 0;
-  virtual std::size_t size() const = 0;
+  virtual size_t elementSize() const = 0;
+  virtual size_t size() const = 0;
   virtual void* data() = 0;
   virtual const void* data() const = 0;
   virtual Storage& retain() = 0;
@@ -29,10 +29,10 @@ struct Storage {
   virtual const char * toString() const = 0;
 
   virtual Storage& fill(Scalar value) = 0;
-  virtual Storage& set(std::size_t ind, Scalar value) = 0;
-  virtual Storage& fast_set(std::size_t ind, Scalar value) = 0;
-  virtual Scalar get(std::size_t ind) = 0;
-  virtual Scalar fast_get(std::size_t ind) = 0;
+  virtual Storage& set(size_t ind, Scalar value) = 0;
+  virtual Storage& fast_set(size_t ind, Scalar value) = 0;
+  virtual Scalar get(size_t ind) = 0;
+  virtual Scalar fast_get(size_t ind) = 0;
 
   virtual void set_flag(char flag) = 0;
   virtual void clear_flag(char flag) = 0;

--- a/aten/src/ATen/UndefinedType.cpp
+++ b/aten/src/ATen/UndefinedType.cpp
@@ -44,7 +44,7 @@ TypeID UndefinedType::ID() const {
   return TypeID::Undefined;
 }
 
-std::size_t UndefinedType::elementSizeInBytes() const {
+size_t UndefinedType::elementSizeInBytes() const {
   AT_ERROR("elementSizeInBytes not defined for UndefinedType");
 }
 

--- a/aten/src/ATen/UndefinedType.h
+++ b/aten/src/ATen/UndefinedType.h
@@ -25,7 +25,7 @@ struct UndefinedType final : public Type {
   virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
-  virtual std::size_t elementSizeInBytes() const override;
+  virtual size_t elementSizeInBytes() const override;
   virtual Type & toBackend(Backend b) const override;
   virtual Type & toScalarType(ScalarType s) const override;
   virtual TypeID ID() const override;

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.cpp
@@ -8,7 +8,7 @@
 
 namespace at { namespace cuda {
 
-void* PinnedMemoryAllocator::allocate(std::size_t n) const {
+void* PinnedMemoryAllocator::allocate(size_t n) const {
   auto state = globalContext().lazyInitCUDA();
   return state->cudaHostAllocator->malloc(nullptr, n);
 }

--- a/aten/src/ATen/cuda/PinnedMemoryAllocator.h
+++ b/aten/src/ATen/cuda/PinnedMemoryAllocator.h
@@ -5,7 +5,7 @@
 namespace at { namespace cuda {
 
 struct PinnedMemoryAllocator final : public Allocator {
-  void* allocate(std::size_t n) const override;
+  void* allocate(size_t n) const override;
   void deallocate(void* ptr) const override;
 };
 

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -323,7 +323,7 @@ struct ConvolutionArgs {
 
 // Hashing machinery for ConvolutionParams
 struct ParamsHash {
-  std::size_t operator()(const ConvolutionParams& params) const {
+  size_t operator()(const ConvolutionParams& params) const {
     auto ptr = reinterpret_cast<const uint8_t*>(&params);
     uint32_t value = 0x811C9DC5;
     for (int i = 0; i < (int)sizeof(ConvolutionParams); ++i) {

--- a/aten/src/ATen/optional.h
+++ b/aten/src/ATen/optional.h
@@ -144,7 +144,7 @@ struct has_overloaded_addressof
   template <class X>
   constexpr static bool has_overload(...) { return false; }
 
-  template <class X, std::size_t S = sizeof(std::declval<X&>().operator&()) >
+  template <class X, size_t S = sizeof(std::declval<X&>().operator&()) >
   constexpr static bool has_overload(bool) { return true; }
 
   constexpr static bool value = has_overload<T>(true);

--- a/aten/src/ATen/templates/StorageDerived.cpp
+++ b/aten/src/ATen/templates/StorageDerived.cpp
@@ -16,7 +16,7 @@ ${Storage}::${Storage}(Context* context):
 ${Storage}::${Storage}(Context* context, ${THStorage}* storage):
     storage(storage), context(context) {}
 
-${Storage}::${Storage}(Context* context, std::size_t storage_size)
+${Storage}::${Storage}(Context* context, size_t storage_size)
   : storage(${THStorage}_newWithSize(${state,} storage_size)), context(context) {}
 
 #if ${isCUDA}
@@ -80,7 +80,7 @@ static THAllocator wrapped_allocator = {
 };
 #endif
 
-${Storage}::${Storage}(Context* context, std::size_t size, std::unique_ptr<Allocator> allocator)
+${Storage}::${Storage}(Context* context, size_t size, std::unique_ptr<Allocator> allocator)
   : storage(nullptr),
     context(context) {
   auto ctx = new detail::AllocatorRetainable(std::move(allocator));
@@ -90,7 +90,7 @@ ${Storage}::${Storage}(Context* context, std::size_t size, std::unique_ptr<Alloc
 }
 
 ${Storage}::${Storage}(Context* context,
-  void * data, std::size_t size, const std::function<void(void*)> & deleter)
+  void * data, size_t size, const std::function<void(void*)> & deleter)
   : storage(${THStorage}_newWithDataAndAllocator(${state,}
      static_cast<${THScalarType}*>(data), size,
      &storage_deleter,
@@ -104,11 +104,11 @@ ${Storage}::~${Storage}() {
   ${THStorage}_free(${state,} storage);
 }
 
-std::size_t ${Storage}::elementSize() const {
+size_t ${Storage}::elementSize() const {
   return sizeof(${ScalarType});
 }
 
-std::size_t ${Storage}::size() const {
+size_t ${Storage}::size() const {
   return storage->size;
 }
 
@@ -147,21 +147,21 @@ auto ${Storage}::fill(Scalar value) -> ${Storage}& {
   return *this;
 }
 
-auto ${Storage}::set(std::size_t ind, Scalar value) -> ${Storage}& {
+auto ${Storage}::set(size_t ind, Scalar value) -> ${Storage}& {
   ${THStorage}_set(${state,} storage, ind, ${to_th_type}(value.to${ScalarName}()));
   return *this;
 }
 
-auto ${Storage}::fast_set(std::size_t ind, Scalar value) -> ${Storage}& {
+auto ${Storage}::fast_set(size_t ind, Scalar value) -> ${Storage}& {
   throw std::runtime_error("unsupported operation 'fast_set'");
 }
 
-auto ${Storage}::get(std::size_t ind) -> Scalar {
+auto ${Storage}::get(size_t ind) -> Scalar {
   // static cast to fix  long -> int64_t issues
   return static_cast<${ScalarType}>(${to_at_type}(${THStorage}_get(${state,} storage, ind)));
 }
 
-auto ${Storage}::fast_get(std::size_t ind) -> Scalar {
+auto ${Storage}::fast_get(size_t ind) -> Scalar {
   if(${isCUDA})
     throw std::runtime_error("unsupported operation 'fast_get'");
   return static_cast<${ScalarType}>(${to_at_type}(storage->unsafe_data<${THScalarType}>()[ind]));

--- a/aten/src/ATen/templates/StorageDerived.h
+++ b/aten/src/ATen/templates/StorageDerived.h
@@ -17,14 +17,14 @@ struct ${Storage} final : public Storage {
 public:
   explicit ${Storage}(Context* context);
   ${Storage}(Context* context, ${THStorage} *wrapped);
-  ${Storage}(Context* context, std::size_t size);
-  ${Storage}(Context* context, std::size_t size, std::unique_ptr<Allocator> allocator);
+  ${Storage}(Context* context, size_t size);
+  ${Storage}(Context* context, size_t size, std::unique_ptr<Allocator> allocator);
   ${Storage}(Context* context,
-    void * data, std::size_t size, const std::function<void(void*)> & deleter);
+    void * data, size_t size, const std::function<void(void*)> & deleter);
   virtual ~${Storage}();
 
-  virtual std::size_t elementSize() const override;
-  virtual std::size_t size() const override;
+  virtual size_t elementSize() const override;
+  virtual size_t size() const override;
   virtual void* data() override;
   virtual const void* data() const override;
   virtual ${Storage}& retain() override;
@@ -33,10 +33,10 @@ public:
 
   virtual ${Storage}& resize(int64_t new_size) override;
   virtual ${Storage}& fill(Scalar value) override;
-  virtual ${Storage}& set(std::size_t ind, Scalar value) override;
-  virtual ${Storage}& fast_set(std::size_t ind, Scalar value) override;
-  virtual Scalar get(std::size_t ind) override;
-  virtual Scalar fast_get(std::size_t ind) override;
+  virtual ${Storage}& set(size_t ind, Scalar value) override;
+  virtual ${Storage}& fast_set(size_t ind, Scalar value) override;
+  virtual Scalar get(size_t ind) override;
+  virtual Scalar fast_get(size_t ind) override;
 
   virtual void set_flag(char flag) override;
   virtual void clear_flag(char flag) override;

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -74,7 +74,7 @@ struct AT_API Type {
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
   virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
-  virtual std::size_t elementSizeInBytes() const = 0;
+  virtual size_t elementSizeInBytes() const = 0;
   virtual Type & toBackend(Backend b) const;
   virtual Type & toScalarType(ScalarType s) const;
   Context& get_context() const { return *context; }

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -78,7 +78,7 @@ TypeID ${Type}::ID() const {
   return ${TypeID};
 }
 
-std::size_t ${Type}::elementSizeInBytes() const {
+size_t ${Type}::elementSizeInBytes() const {
   return sizeof(${ScalarType});
 }
 

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -28,7 +28,7 @@ struct ${Type} final : public Type {
   virtual std::unique_ptr<Storage> storageWithAllocator(int64_t size, std::unique_ptr<Allocator> allocator) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
-  virtual std::size_t elementSizeInBytes() const override;
+  virtual size_t elementSizeInBytes() const override;
   virtual TypeID ID() const override;
   static const char * typeString();
   virtual std::unique_ptr<Storage> unsafeStorageFromTH(void * th_pointer, bool retain) const override;

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -49,8 +49,8 @@ void test(Type &T) {
   for (auto s = sizes.begin(); s != sizes.end(); ++s) {
     // verify that the dim, sizes, strides, etc match what was requested.
     auto t = ones(T, *s);
-    REQUIRE((std::size_t)t.dim() == s->size());
-    REQUIRE((std::size_t)t.ndimension() == s->size());
+    REQUIRE((size_t)t.dim() == s->size());
+    REQUIRE((size_t)t.ndimension() == s->size());
     REQUIRE(t.sizes().equals(*s));
     REQUIRE(t.strides().size() == s->size());
     auto numel = std::accumulate(s->begin(), s->end(), 1, std::multiplies<int64_t>());

--- a/torch/csrc/api/include/torch/cuda.h
+++ b/torch/csrc/api/include/torch/cuda.h
@@ -5,7 +5,7 @@
 namespace torch {
 namespace cuda {
 /// Returns the number of CUDA devices available.
-std::size_t device_count();
+size_t device_count();
 
 /// Returns true if at least one CUDA device is available.
 bool is_available();

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -73,7 +73,7 @@ class Module {
   template <class Archive>
   void save(Archive& ar) const {
     auto params = parameters();
-    std::size_t size = params.size();
+    size_t size = params.size();
     ar(size);
     for (auto& p : params) {
       ar(p.first, p.second);
@@ -83,10 +83,10 @@ class Module {
   template <class Archive>
   void load(Archive& ar) {
     auto params = parameters();
-    std::size_t size;
+    size_t size;
     ar(size);
     std::string name;
-    for (std::size_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
       ar(name);
       ar(params[name]);
     }

--- a/torch/csrc/api/include/torch/serialization.h
+++ b/torch/csrc/api/include/torch/serialization.h
@@ -129,7 +129,7 @@ namespace cereal {
 namespace agimpl {
 
 template <class Archive>
-void saveBinary(Archive& archive, void const* data, std::size_t size) {
+void saveBinary(Archive& archive, void const* data, size_t size) {
   // In general, there's no direct `saveBinary`-like method on archives
   std::vector<char> v(
       static_cast<char const*>(data), static_cast<char const*>(data) + size);
@@ -137,13 +137,13 @@ void saveBinary(Archive& archive, void const* data, std::size_t size) {
 }
 template <>
 inline void
-saveBinary(BinaryOutputArchive& archive, void const* data, std::size_t size) {
+saveBinary(BinaryOutputArchive& archive, void const* data, size_t size) {
   // Writes to output stream without extra copy
   archive.saveBinary(data, size);
 }
 
 template <class Archive>
-void loadBinary(Archive& archive, void* data, std::size_t size) {
+void loadBinary(Archive& archive, void* data, size_t size) {
   // In general, there's no direct `loadBinary`-like method on archives
   std::vector<char> v(size);
   archive(v);
@@ -151,7 +151,7 @@ void loadBinary(Archive& archive, void* data, std::size_t size) {
 }
 template <>
 inline void
-loadBinary(BinaryInputArchive& archive, void* data, std::size_t size) {
+loadBinary(BinaryInputArchive& archive, void* data, size_t size) {
   // Read from input stream without extra copy
   archive.loadBinary(data, size);
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -468,7 +468,7 @@ auto Engine::execute(const edge_list& input_roots,
   // more callbacks (or they can be registered from other threads
   // while it's waiting.
   std::unique_lock<std::mutex> cb_lock(post_callbacks_lock);
-  for (std::size_t i = 0; i < final_callbacks.size(); ++i) {
+  for (size_t i = 0; i < final_callbacks.size(); ++i) {
     cb_lock.unlock();
     final_callbacks[i]();
     cb_lock.lock();
@@ -552,7 +552,7 @@ void GraphTask::init_to_execute(Function& graph_root, const edge_list& outputs) 
   struct Frame {
     Frame (Function *fn) : fn(fn), next_next_fn(0) {}
     Function *fn;
-    std::size_t next_next_fn;
+    size_t next_next_fn;
 
     Function* get_next_fn() {
       const auto & next = fn->next_edges();

--- a/torch/csrc/autograd/functions/special.cpp
+++ b/torch/csrc/autograd/functions/special.cpp
@@ -121,13 +121,13 @@ auto Eval::getSubgraph(const variable_list& inputs, const variable_list& outputs
 bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outputs,
                          const placeholder_list& inherited_placeholders) {
   using bitset_type = uint64_t;
-  constexpr std::size_t max_outputs = sizeof(bitset_type) * 8;
+  constexpr size_t max_outputs = sizeof(bitset_type) * 8;
 
   if (inherited_placeholders.size() != 0) return false;
 
   auto& grad_fn = outputs[0].grad_fn();
-  if (static_cast<std::size_t>(grad_fn->num_inputs()) >= max_outputs) return false;
-  if (static_cast<std::size_t>(grad_fn->num_inputs()) != outputs.size()) return false;
+  if (static_cast<size_t>(grad_fn->num_inputs()) >= max_outputs) return false;
+  if (static_cast<size_t>(grad_fn->num_inputs()) != outputs.size()) return false;
 
   // Check that all outputs have the same grad_fn and cover all its inputs
   bitset_type output_nrs = 0;
@@ -141,7 +141,7 @@ bool Eval::trySimpleEval(const variable_list& inputs, const variable_list& outpu
   // Check that grad_fn's next_edges match the inputs exactly.
   auto num_inputs = inputs.size();
   if (num_inputs != grad_fn->num_outputs()) return false;
-  for (std::size_t i = 0; i < num_inputs; ++i) {
+  for (size_t i = 0; i < num_inputs; ++i) {
     const auto& next_grad_edge = grad_fn->next_edge(i);
     // Unfortunately, null edge pruning (see Note [Null-edge pruning]) applies
     // to autograd functions which would otherwise be eligible for the
@@ -319,7 +319,7 @@ std::pair<edge_list, variable_list> Eval::filterRoots(const variable_list& input
     throw std::logic_error("inputs.size() != roots.size()");
   filtered_inputs.reserve(num_inputs);
   filtered_roots.reserve(num_inputs);
-  for (std::size_t i = 0; i < num_inputs; ++i) {
+  for (size_t i = 0; i < num_inputs; ++i) {
     // This check is the sole reason why this function is needed. The problem
     // with larger Evals is that they might trigger computation of nodes that
     // would normally be ignored. For example, consider a subgraph with multiple

--- a/torch/csrc/autograd/input_buffer.h
+++ b/torch/csrc/autograd/input_buffer.h
@@ -26,7 +26,7 @@ struct InputBuffer {
 
   int device() const;
 
-  Variable operator[](std::size_t pos) { return buffer[pos]; }
+  Variable operator[](size_t pos) { return buffer[pos]; }
 
   // Returns the inputs as a list of variables. Destroys given InputBuffer.
   static std::vector<Variable> variables(InputBuffer&& buffer);

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -26,7 +26,7 @@ struct Function;
 
 namespace profiler {
 
-constexpr inline std::size_t ceilToMultiple(std::size_t a, std::size_t b) {
+constexpr inline size_t ceilToMultiple(size_t a, size_t b) {
   return ((a + b - 1) / b) * b;
 }
 
@@ -120,9 +120,9 @@ private:
 // a std::vector resize from taking a large amount of time inside
 // a profiling  event
 struct RangeEventList {
-  constexpr static std::size_t MB = 1024 * 1024;
-  constexpr static std::size_t event_block_size = 16 * MB;
-  constexpr static std::size_t num_block_elements =
+  constexpr static size_t MB = 1024 * 1024;
+  constexpr static size_t event_block_size = 16 * MB;
+  constexpr static size_t num_block_elements =
     event_block_size / ceilToMultiple(sizeof(Event), alignof(Event));
   static_assert(sizeof(Event[num_block_elements]) <= event_block_size,
                 "num_block_elements is calculated incorrectly");

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -55,7 +55,7 @@ std::vector<Tensor> broadcast(const Tensor& tensor, IntList devices) {
   return tensors;
 }
 
-tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, std::size_t buffer_size) {
+tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, size_t buffer_size) {
   if (!std::all_of(tensors.begin(), tensors.end(),
                    [&](const at::Tensor& t) { return t.get_device() == devices[0]; })) {
     throw std::runtime_error("all tensors must be on devices[0]");
@@ -76,7 +76,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, std::size
       std::vector<at::Tensor> broadcast_indices = broadcast(flat_tuple.first, devices);
       std::vector<at::Tensor> broadcast_values = broadcast(flat_tuple.second, devices);
       results.reserve(devices.size());
-      for (std::size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
+      for (size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
         AutoGPU auto_gpu(devices[i]);
         auto & device_outputs = outputs[i];
         auto & inds = broadcast_indices[i];
@@ -88,7 +88,7 @@ tensor_list2d broadcast_coalesced(TensorList tensors, IntList devices, std::size
       AutoGPU auto_gpu(devices[0]);
       std::vector<Tensor> results = broadcast(utils::flatten_dense_tensors(chunk.tensors),
                                               devices);
-      for (std::size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
+      for (size_t i = 1, num_devices = devices.size(); i < num_devices; ++i) {
         auto_gpu.setDevice(devices[i]);
         auto & device_outputs = outputs[i];
         for (auto & t : utils::unflatten_dense_tensors(results[i], chunk.tensors))

--- a/torch/csrc/cuda/comm.h
+++ b/torch/csrc/cuda/comm.h
@@ -9,6 +9,6 @@ using tensor_list2d = std::vector<std::vector<at::Tensor>>;
 
 std::vector<at::Tensor> broadcast(const at::Tensor& tensor, at::IntList devices);
 tensor_list2d broadcast_coalesced(at::TensorList tensors, at::IntList devices,
-                                  std::size_t buffer_size);
+                                  size_t buffer_size);
 
 }}

--- a/torch/csrc/cuda/device_set.h
+++ b/torch/csrc/cuda/device_set.h
@@ -4,7 +4,7 @@
 
 namespace torch {
 
-static constexpr std::size_t MAX_CUDA_DEVICES = 64;
+static constexpr size_t MAX_CUDA_DEVICES = 64;
 using device_set = std::bitset<MAX_CUDA_DEVICES>;
 
 }

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -7,7 +7,7 @@ namespace torch { namespace cuda { namespace python {
 
 void initCommMethods(PyObject *module) {
   auto m = py::cast<py::module>(module);
-  m.def("_broadcast_coalesced", [](std::vector<at::Tensor>& tensors, std::vector<int64_t> devices, std::size_t buffer_size) {
+  m.def("_broadcast_coalesced", [](std::vector<at::Tensor>& tensors, std::vector<int64_t> devices, size_t buffer_size) {
      return broadcast_coalesced(tensors, devices, buffer_size);
    }, py::arg("tensors"), py::arg("devices"), py::arg("buffer_size"),
       py::call_guard<py::gil_scoped_release>())

--- a/torch/csrc/distributed/Module.cpp
+++ b/torch/csrc/distributed/Module.cpp
@@ -348,7 +348,7 @@ PyObject* THDPModule_allReduceMultiGPU(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   std::vector<at::Tensor> descriptors;
-  std::size_t length;
+  size_t length;
   THDGroup group;
   THDReduceOp op;
   THPObjectPtr sequence;
@@ -367,11 +367,11 @@ PyObject* THDPModule_allReduceMultiGPU(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i))) {
       goto invalid_arguments;
     }
@@ -402,7 +402,7 @@ PyObject* THDPModule_reduceMultiGPU(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<at::Tensor> descriptors;
   THDGroup group;
   THDReduceOp op;
@@ -423,11 +423,11 @@ PyObject* THDPModule_reduceMultiGPU(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i))) {
       goto invalid_arguments;
     }
@@ -460,7 +460,7 @@ PyObject* THDPModule_broadcastMultiGPU(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<at::Tensor> descriptors;
   THDGroup group;
   int src_rank;
@@ -480,11 +480,11 @@ PyObject* THDPModule_broadcastMultiGPU(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i))) {
       goto invalid_arguments;
     }
@@ -517,8 +517,8 @@ PyObject* THDPModule_allGatherMultiGPU(PyObject *_unused, PyObject *args)
   THPObjectPtr sequence_one;
   THPObjectPtr sequence_two;
 
-  std::size_t length_one;
-  std::size_t length_two;
+  size_t length_one;
+  size_t length_two;
 
   std::vector<at::Tensor> output_descriptors;
   std::vector<at::Tensor> input_descriptors;
@@ -543,10 +543,10 @@ PyObject* THDPModule_allGatherMultiGPU(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length_one = static_cast<std::size_t>(
+  length_one = static_cast<size_t>(
       PySequence_Fast_GET_SIZE(sequence_one.get()));
 
-  length_two = static_cast<std::size_t>(
+  length_two = static_cast<size_t>(
       PySequence_Fast_GET_SIZE(sequence_two.get()));
 
   if (length_one != length_two) {
@@ -659,7 +659,7 @@ PyObject* THDPModule_allGather(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<at::Tensor> descriptors;
   std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
@@ -678,11 +678,11 @@ PyObject* THDPModule_allGather(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i)))
       goto invalid_arguments;
 
@@ -731,7 +731,7 @@ PyObject* THDPModule_gatherRecv(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<at::Tensor> descriptors;
   std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
@@ -749,11 +749,11 @@ PyObject* THDPModule_gatherRecv(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i)))
       goto invalid_arguments;
 
@@ -782,7 +782,7 @@ PyObject* THDPModule_scatterSend(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<at::Tensor> descriptors;
   std::vector<at::Tensor> raw_descriptors;
   THDGroup group;
@@ -800,11 +800,11 @@ PyObject* THDPModule_scatterSend(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   descriptors.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPVariable_Check(PySequence_Fast_GET_ITEM(sequence.get(), i)))
       goto invalid_arguments;
 
@@ -865,7 +865,7 @@ PyObject* THDPModule_newGroup(PyObject *_unused, PyObject *args)
 {
   HANDLE_TH_ERRORS
   THPObjectPtr sequence;
-  std::size_t length;
+  size_t length;
   std::vector<int> ranks;
 
   if (PyTuple_GET_SIZE(args) != 1 ||
@@ -879,18 +879,18 @@ PyObject* THDPModule_newGroup(PyObject *_unused, PyObject *args)
     goto invalid_arguments;
   }
 
-  length = static_cast<std::size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
+  length = static_cast<size_t>(PySequence_Fast_GET_SIZE(sequence.get()));
 
   ranks.reserve(length);
 
-  for (std::size_t i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     if (!THPUtils_checkLong(PySequence_Fast_GET_ITEM(sequence.get(), i)))
       goto invalid_arguments;
 
     ranks.push_back(THPUtils_unpackLong(
           PySequence_Fast_GET_ITEM(sequence.get(), i)));
 
-    for (std::size_t j = 0; j < i; ++j)
+    for (size_t j = 0; j < i; ++j)
       THPUtils_assert(ranks[i] != ranks[j], "ranks should be unique");
   }
 

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -193,7 +193,7 @@ inline TensorInfo ArgumentSpec::tensorInfo(size_t i) const {
 namespace std {
   template<>
   struct hash<torch::jit::ArgumentSpec> {
-    std::size_t operator()(const torch::jit::ArgumentSpec & spec) const {
+    size_t operator()(const torch::jit::ArgumentSpec & spec) const {
       return spec.hashCode();
     }
   };

--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -181,7 +181,7 @@ static value_set findAllRequiresGradNodes(
   const auto requires_grad = [&](Value *v) { return requires_grad_set.count(v) > 0; };
 
   auto inputs = graph.inputs();
-  for (std::size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
+  for (size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
     if (!input_requires_grad[i]) continue;
     requires_grad_set.emplace(inputs[i]);
   }
@@ -270,7 +270,7 @@ static ReverseDetails addReverseInline(Gradient& grad_desc,
   };
 
   auto outputs = graph.outputs();
-  for (std::size_t i = 0, num_outputs = outputs.size(); i < num_outputs; ++i) {
+  for (size_t i = 0, num_outputs = outputs.size(); i < num_outputs; ++i) {
     Value * output = outputs[i];
     if (!requires_grad(output))
       continue;
@@ -287,13 +287,13 @@ static ReverseDetails addReverseInline(Gradient& grad_desc,
       continue;
     value_list grad_inputs = gradientForNode(node, fmap(node->outputs(), get_grad));
     JIT_ASSERT(grad_inputs.size() == node->inputs().size());
-    for (std::size_t i = 0, num_inputs = grad_inputs.size(); i < num_inputs; ++i) {
+    for (size_t i = 0, num_inputs = grad_inputs.size(); i < num_inputs; ++i) {
       set_grad(inputs[i], grad_inputs[i]);
     }
   }
 
   auto inputs = graph.inputs();
-  for (std::size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
+  for (size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
     Value * input = inputs[i];
     if (!requires_grad(input))
       continue;
@@ -400,12 +400,12 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
   // -- Construct primal_outputs, df_input_captures, f_real_outputs ----
   grad_desc.f_real_outputs = graph.outputs().size();
 
-  std::unordered_map<Value*, std::size_t> orig_primal_outputs_idx;
-  std::unordered_map<Value*, std::size_t> orig_primal_inputs_idx;
+  std::unordered_map<Value*, size_t> orig_primal_outputs_idx;
+  std::unordered_map<Value*, size_t> orig_primal_inputs_idx;
   // NOTE: we use emplace to avoid replacing an existing index if an output is repeated
-  for (std::size_t i = 0, num_outputs = graph.outputs().size(); i < num_outputs; ++i)
+  for (size_t i = 0, num_outputs = graph.outputs().size(); i < num_outputs; ++i)
     orig_primal_outputs_idx.emplace(graph.outputs()[i], i);
-  for (std::size_t i = 0, num_inputs = graph.inputs().size(); i < num_inputs; ++i)
+  for (size_t i = 0, num_inputs = graph.inputs().size(); i < num_inputs; ++i)
     orig_primal_inputs_idx[graph.inputs()[i]] = i;
 
   // NB: reverse_captures are already deduplicated, and in topo order
@@ -430,7 +430,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
   // NB [possible optimization]: use the newly added vjp input as soon as the first
   // vjp for that value is generated, to reduce the lifespan of this input
   // (currently we add it to the final vjp after all adds).
-  for (std::size_t i = grad_desc.f_real_outputs; i < graph.outputs().size(); ++i) {
+  for (size_t i = grad_desc.f_real_outputs; i < graph.outputs().size(); ++i) {
     Value * tmp = graph.outputs().at(i);
     // Add VJP inputs only for intermediates that actually required grad.
     if (rev_info.requires_grad_set.count(tmp) == 0) continue;

--- a/torch/csrc/jit/autodiff.h
+++ b/torch/csrc/jit/autodiff.h
@@ -39,7 +39,7 @@ struct Gradient {
   // Describes how to construct outputs of f from what its graph will return.
   // This is necessary because some trailing outputs are intermediates produced
   // only to be saved for df (and should be ignored).
-  std::size_t f_real_outputs;
+  size_t f_real_outputs;
 
   // df inputs are split into two sections: vjps (aka grad_outputs) and captures.
   // VJPs are "seeds" for the gradient computation given for each input capture
@@ -47,16 +47,16 @@ struct Gradient {
   // Captures are values the need to be saved when f is run. We handle inputs
   // specially, because this allows us to avoid adding extra vjps as df inputs.
 
-  std::vector<std::size_t> df_input_vjps; // Offsets into f's outputs.
+  std::vector<size_t> df_input_vjps; // Offsets into f's outputs.
   // capture can come from inputs or outputs
-  std::vector<std::size_t> df_input_captured_inputs; // Offsets into f's inputs
-  std::vector<std::size_t> df_input_captured_outputs; // Offsets into f's outputs
+  std::vector<size_t> df_input_captured_inputs; // Offsets into f's inputs
+  std::vector<size_t> df_input_captured_outputs; // Offsets into f's outputs
 
 
   // df will produce vjps for a subset of inputs of f that required grad.
   // df_output_vjps[idx] == inp_idx means that idx-th output of df produces a vjp
   // for inp_idx-th input of f.
-  std::vector<std::size_t> df_output_vjps; // Offsets into f's inputs.
+  std::vector<size_t> df_output_vjps; // Offsets into f's inputs.
 
   // How to use gradient to implement a differentiable autograd function:
   // When running f:

--- a/torch/csrc/jit/fusion_compiler.cpp
+++ b/torch/csrc/jit/fusion_compiler.cpp
@@ -444,9 +444,9 @@ void CompiledFusionFunction::launch_with_tensors(at::ArrayRef<at::Tensor> inputs
     arguments.push_back(ti);
   };
   arguments.push_back(&numel);
-  for (std::size_t i = 0; i < input_desc.size(); ++i)
+  for (size_t i = 0; i < input_desc.size(); ++i)
     addTensorInfo(input_desc[i], inputs[i]);
-  for (std::size_t i = 0; i < output_desc.size(); ++i) {
+  for (size_t i = 0; i < output_desc.size(); ++i) {
     auto & c = concat_desc[i];
     at::Tensor o = outputs[i];
     if(c.nSubtensors == 1) {

--- a/torch/csrc/jit/interned_strings.h
+++ b/torch/csrc/jit/interned_strings.h
@@ -274,7 +274,7 @@ DEFINE_BUILTINS(prim, FORALL_PRIM_SYMBOLS)
 namespace std {
   template<>
   struct hash<torch::jit::Symbol> {
-    std::size_t operator()(torch::jit::Symbol s) const {
+    size_t operator()(torch::jit::Symbol s) const {
       return std::hash<uint32_t>()(static_cast<uint32_t>(s));
     }
   };

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -449,7 +449,7 @@ void Node::lint() const {
   IR_ELSEIF(Param)
     JIT_ASSERT(inputs_.size() == 0);
   IR_ELSEIFM_CONST(PythonOp)
-    std::size_t n_scalars = 0, n_tensors = 0;
+    size_t n_scalars = 0, n_tensors = 0;
     for (auto c : value->cconv) {
       if (c == 's') {
         n_scalars++;

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -65,7 +65,7 @@ namespace torch { namespace jit {
 // the trees we formed and fuse them.
 
 // Tunable parameter. Set to something larger if it turns out to be better.
-static constexpr std::size_t min_fusion_size = 2;
+static constexpr size_t min_fusion_size = 2;
 
 static std::array<int64_t, 2> as_array(at::IntList sizes) {
   JIT_ASSERT(sizes.size() == 2);

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -234,7 +234,7 @@ struct GraphFuser {
     std::unordered_map<Value*, Value*> inner_to_outer;
     auto inner_inputs = producer_subgraph->inputs();
     auto outer_inputs = producer_group->inputs();
-    for (std::size_t i = 0; i < inner_inputs.size(); ++i) {
+    for (size_t i = 0; i < inner_inputs.size(); ++i) {
       inner_to_outer[inner_inputs[i]] = outer_inputs[i];
     }
 
@@ -247,13 +247,13 @@ struct GraphFuser {
       temporary_nodes.emplace_back(outer);
       auto inner_outputs = inner->outputs();
       auto outer_outputs = outer->outputs();
-      for (std::size_t i = 0; i < inner_outputs.size(); ++i)
+      for (size_t i = 0; i < inner_outputs.size(); ++i)
         inner_to_outer[inner_outputs[i]] = outer_outputs[i];
     }
 
     // Replace uses of producer_group outputs and destroy the producer
     auto subgraph_outputs = producer_subgraph->outputs();
-    for (std::size_t i = 0; i < subgraph_outputs.size(); ++i) {
+    for (size_t i = 0; i < subgraph_outputs.size(); ++i) {
       auto outer_output = inner_to_outer.at(subgraph_outputs[i]);
       producer_group->outputs()[i]->replaceAllUsesWith(outer_output);
     }
@@ -267,7 +267,7 @@ struct GraphFuser {
       Node *merged = mergeNodeIntoGroup(consumer_group, node);
       // If any of the outputs are still used then we need to add them
       auto outputs = node->outputs();
-      for (std::size_t i = 0; i < outputs.size(); ++i) {
+      for (size_t i = 0; i < outputs.size(); ++i) {
         auto output = outputs[i];
         if (output->uses().size() == 0) continue;
         consumer_subgraph->registerOutput(merged->outputs()[i]);

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -67,7 +67,7 @@ void BlockToONNX(Block* old_block, Block* new_block, bool aten, std::unordered_m
       ss << num_old_outputs << ", but got " << outputs.size() << ")";
       throw std::runtime_error(ss.str());
     }
-    for (std::size_t i = 0; i < num_old_outputs; ++i) {
+    for (size_t i = 0; i < num_old_outputs; ++i) {
       auto old = old_outputs[i];
       if (outputs[i]) {
         // Allow symbolic() to skip specifying the type of the return node.

--- a/torch/csrc/jit/pybind.h
+++ b/torch/csrc/jit/pybind.h
@@ -69,7 +69,7 @@ namespace torch { namespace jit {
 
 static inline py::tuple tuple_tail(const py::tuple & tup) {
   py::tuple r(tup.size() - 1);
-  for(std::size_t i = 1; i < tup.size(); i++) {
+  for(size_t i = 1; i < tup.size(); i++) {
     r[i-1] = tup[i];
   }
   return r;

--- a/torch/csrc/jit/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python_arg_flatten.cpp
@@ -22,7 +22,7 @@ template<typename T>
 py::object cast_handle_sequence(std::vector<py::handle> objs) {
   auto num_objs = objs.size();
   T sequence { num_objs };
-  for (std::size_t i = 0; i < num_objs; ++i)
+  for (size_t i = 0; i < num_objs; ++i)
     sequence[i] = py::reinterpret_borrow<py::object>(objs[i]);
   return sequence;
 }
@@ -66,7 +66,7 @@ template<typename T>
 py::object cast_sequence(std::vector<py::object> objs) {
   auto num_objs = objs.size();
   T sequence { num_objs };
-  for (std::size_t i = 0; i < num_objs; ++i)
+  for (size_t i = 0; i < num_objs; ++i)
     sequence[i] = std::move(objs[i]);
   return sequence;
 }

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -24,7 +24,7 @@ struct IODescriptor {
              std::tie(o.device, o.requires_grad, o.type, o.sizes);
     }
 
-    static std::size_t hash(const VariableMetadata& m) {
+    static size_t hash(const VariableMetadata& m) {
       return get_hash(m.sizes, m.device, m.requires_grad, m.type);
     }
 
@@ -39,7 +39,7 @@ struct IODescriptor {
            std::tie(o.structure, o.metadata, o.grad_enabled);
   }
 
-  static std::size_t hash(const IODescriptor& o) {
+  static size_t hash(const IODescriptor& o) {
     return get_hash(o.structure, o.metadata, o.grad_enabled);
   }
 

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -53,7 +53,7 @@ void initPythonTracerBindings(PyObject* module_) {
       return s.is_complete();
     });
 
-  m.def("_tracer_enter", [](variable_list trace_inputs, std::size_t num_backwards) {
+  m.def("_tracer_enter", [](variable_list trace_inputs, size_t num_backwards) {
     return tracer::enter(std::move(trace_inputs), num_backwards + 1);
   });
   m.def("_tracer_exit", [](variable_list var_outputs) {

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -15,7 +15,7 @@ namespace torch { namespace jit { namespace script {
 struct SourceRangeFactory {
   SourceRangeFactory(std::string source)
     : source_(std::make_shared<std::string>(std::move(source))) {
-    std::size_t pos = 0;
+    size_t pos = 0;
     do {
       line_len_prefix_sum_.push_back(pos);
       pos++;
@@ -33,7 +33,7 @@ struct SourceRangeFactory {
   }
 
   std::shared_ptr<std::string> source_;
-  std::vector<std::size_t> line_len_prefix_sum_;
+  std::vector<size_t> line_len_prefix_sum_;
 };
 
 template<typename T>

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -105,7 +105,7 @@ struct TreeView {
   }
 
 protected:
-  const TreeRef& subtree(std::size_t i) const {
+  const TreeRef& subtree(size_t i) const {
     return tree_->trees().at(i);
   }
   TreeRef tree_;

--- a/torch/csrc/jit/test_jit.cpp
+++ b/torch/csrc/jit/test_jit.cpp
@@ -537,7 +537,7 @@ variable_list grad(const variable_list& outputs, const variable_list& inputs, co
 
 void assertAllClose(const tensor_list& a, const tensor_list& b) {
   REQUIRE(a.size() == b.size());
-  for (std::size_t i = 0; i < a.size(); ++i) {
+  for (size_t i = 0; i < a.size(); ++i) {
     REQUIRE(a[i].is_same_size(b[i]));
     REQUIRE(a[i].allclose(b[i]));
   }
@@ -635,10 +635,10 @@ void testDifferentiate(std::ostream & out) {
   graph->registerOutput(c.value());
 
   auto grad_spec = differentiate(graph, {true, true});
-  std::vector<std::size_t> expected_captured_inputs = {0, 1};
-  std::vector<std::size_t> expected_captured_outputs = {1};
-  std::vector<std::size_t> expected_input_vjps = {0, 1};
-  std::vector<std::size_t> expected_output_vjps = {0, 1};
+  std::vector<size_t> expected_captured_inputs = {0, 1};
+  std::vector<size_t> expected_captured_outputs = {1};
+  std::vector<size_t> expected_input_vjps = {0, 1};
+  std::vector<size_t> expected_output_vjps = {0, 1};
   REQUIRE(grad_spec.f_real_outputs == 1);
   REQUIRE(grad_spec.df_input_captured_inputs == expected_captured_inputs);
   REQUIRE(grad_spec.df_input_captured_outputs == expected_captured_outputs);
@@ -664,11 +664,11 @@ void testDifferentiateWithRequiresGrad(std::ostream & out) {
   graph->registerOutput(e.value());
 
   auto grad_spec = differentiate(graph, {true, false});
-  std::vector<std::size_t> expected_input_vjps = {1, 2};  // for e and %4 = (d + a)
-  std::vector<std::size_t> expected_output_vjps = {0};    // only a requires grad
+  std::vector<size_t> expected_input_vjps = {1, 2};  // for e and %4 = (d + a)
+  std::vector<size_t> expected_output_vjps = {0};    // only a requires grad
   REQUIRE(grad_spec.f_real_outputs == 2);              // we need one temporary %4 = (d + a)
-  REQUIRE(grad_spec.df_input_captured_inputs == std::vector<std::size_t>({0}));
-  REQUIRE(grad_spec.df_input_captured_outputs == std::vector<std::size_t>({2}));
+  REQUIRE(grad_spec.df_input_captured_inputs == std::vector<size_t>({0}));
+  REQUIRE(grad_spec.df_input_captured_outputs == std::vector<size_t>({2}));
   REQUIRE(grad_spec.df_input_vjps == expected_input_vjps);
   REQUIRE(grad_spec.df_output_vjps == expected_output_vjps);
   out << "testDifferentiateWithRequiresGrad\n";

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -116,7 +116,7 @@ struct TraceEval : autograd::Eval {
     auto& graph = tracing_state->graph;
     graph->advanceStage();
 
-    for (std::size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
+    for (size_t i = 0, num_inputs = inputs.size(); i < num_inputs; ++i) {
       auto input = inputs[i];
       Value *input_node = graph->addInput();
       if (!input.defined()) continue;

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -221,7 +221,7 @@ inline Value* getOutputTrace(const std::shared_ptr<TracingState>& state, const V
 // reference to at::Tensor buffer to call unsafeGetTH, but you can't get this
 // out of a const vector (silly std::vector...)
 inline std::pair<std::shared_ptr<TracingState>, variable_list> enter(
-    variable_list inputs, std::size_t num_stages) {
+    variable_list inputs, size_t num_stages) {
   auto state = std::make_shared<TracingState>(num_stages);
   for (auto& input : inputs) {
     auto * value_state = detail::getValueState(state, input, false);

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -121,8 +121,8 @@ struct TensorType : public Type {
 
   at::ScalarType scalarType() const { return scalar_type_; }
   int device() const { return device_; }
-  const std::vector<std::int64_t>& sizes() const { return sizes_; }
-  const std::vector<std::int64_t>& strides() const { return strides_; }
+  const std::vector<int64_t>& sizes() const { return sizes_; }
+  const std::vector<int64_t>& strides() const { return strides_; }
 
   TypePtr withSizesStrides(at::IntList sizes, at::IntList strides) const {
     return std::make_shared<TensorType>(scalar_type_, device_, sizes, strides);
@@ -163,7 +163,7 @@ private:
     if(sizes.size() == 0) // zero-dim case
       return strides;
     strides.back() = 1;
-    for(std::size_t i = strides.size() - 1; i > 0; i--) {
+    for(size_t i = strides.size() - 1; i > 0; i--) {
       strides[i-1] = strides[i] * sizes[i];
     }
     return strides;

--- a/torch/csrc/utils/hash.h
+++ b/torch/csrc/utils/hash.h
@@ -31,7 +31,7 @@ namespace torch {
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-inline std::size_t hash_combine(std::size_t seed, std::size_t value) {
+inline size_t hash_combine(size_t seed, size_t value) {
   return seed ^ (value + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
@@ -43,7 +43,7 @@ namespace _hash_detail {
 
 // Use template argument deduction to shorten calls to torch::hash
 template<typename T>
-std::size_t simple_get_hash(const T& o);
+size_t simple_get_hash(const T& o);
 
 template<typename T, typename V>
 using type_if_not_enum = typename std::enable_if<!std::is_enum<T>::value, V>::type;
@@ -54,18 +54,18 @@ using type_if_not_enum = typename std::enable_if<!std::is_enum<T>::value, V>::ty
 // implement it even when C++14 flags aren't specified. This is why we have to disable
 // this overload if T is an enum type (and use the one below in this case).
 template<typename T>
-auto dispatch_hash(const T& o) -> decltype(std::hash<T>()(o), type_if_not_enum<T, std::size_t>()) {
+auto dispatch_hash(const T& o) -> decltype(std::hash<T>()(o), type_if_not_enum<T, size_t>()) {
   return std::hash<T>()(o);
 }
 
 template<typename T>
-typename std::enable_if<std::is_enum<T>::value, std::size_t>::type dispatch_hash(const T& o) {
+typename std::enable_if<std::is_enum<T>::value, size_t>::type dispatch_hash(const T& o) {
   using R = typename std::underlying_type<T>::type;
   return std::hash<R>()(static_cast<R>(o));
 }
 
 template<typename T>
-auto dispatch_hash(const T& o) -> decltype(T::hash(o), std::size_t()) {
+auto dispatch_hash(const T& o) -> decltype(T::hash(o), size_t()) {
   return T::hash(o);
 }
 
@@ -74,7 +74,7 @@ auto dispatch_hash(const T& o) -> decltype(T::hash(o), std::size_t()) {
 // Hasher struct
 template<typename T>
 struct hash {
-  std::size_t operator()(const T& o) const {
+  size_t operator()(const T& o) const {
     return _hash_detail::dispatch_hash(o);
   };
 };
@@ -82,9 +82,9 @@ struct hash {
 // Specialization for std::tuple
 template<typename... Types>
 struct hash<std::tuple<Types...>> {
-  template<std::size_t idx, typename... Ts>
+  template<size_t idx, typename... Ts>
   struct tuple_hash {
-    std::size_t operator()(const std::tuple<Ts...>& t) const {
+    size_t operator()(const std::tuple<Ts...>& t) const {
       return hash_combine(_hash_detail::simple_get_hash(std::get<idx>(t)),
                           tuple_hash<idx-1, Ts...>()(t));
     }
@@ -92,12 +92,12 @@ struct hash<std::tuple<Types...>> {
 
   template<typename... Ts>
   struct tuple_hash<0, Ts...> {
-    std::size_t operator()(const std::tuple<Ts...>& t) const {
+    size_t operator()(const std::tuple<Ts...>& t) const {
       return _hash_detail::simple_get_hash(std::get<0>(t));
     }
   };
 
-  std::size_t operator()(const std::tuple<Types...>& t) const {
+  size_t operator()(const std::tuple<Types...>& t) const {
     return tuple_hash<sizeof...(Types)-1, Types...>()(t);
   }
 };
@@ -105,8 +105,8 @@ struct hash<std::tuple<Types...>> {
 // Specialization for std::vector
 template<typename T>
 struct hash<std::vector<T>> {
-  std::size_t operator()(const std::vector<T>& v) const {
-    std::size_t seed = 0;
+  size_t operator()(const std::vector<T>& v) const {
+    size_t seed = 0;
     for (const auto & elem : v) {
       seed = hash_combine(seed, _hash_detail::simple_get_hash(elem));
     }
@@ -117,7 +117,7 @@ struct hash<std::vector<T>> {
 namespace _hash_detail {
 
 template<typename T>
-std::size_t simple_get_hash(const T& o) {
+size_t simple_get_hash(const T& o) {
   return torch::hash<T>()(o);
 }
 
@@ -127,11 +127,11 @@ std::size_t simple_get_hash(const T& o) {
 // Dispatches to torch::hash, so it can hash containers.
 // Example:
 //
-// static std::size_t hash(const MyStruct& s) {
+// static size_t hash(const MyStruct& s) {
 //   return get_hash(s.member1, s.member2, s.member3);
 // }
 template<typename... Types>
-std::size_t get_hash(const Types&... args) {
+size_t get_hash(const Types&... args) {
   return torch::hash<decltype(std::tie(args...))>()(std::tie(args...));
 }
 

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -111,8 +111,8 @@ struct Option {
 
 std::vector<std::string> _splitString(const std::string &s, const std::string& delim) {
   std::vector<std::string> tokens;
-  std::size_t start = 0;
-  std::size_t end;
+  size_t start = 0;
+  size_t end;
   while((end = s.find(delim, start)) != std::string::npos) {
     tokens.push_back(s.substr(start, end-start));
     start = end + delim.length();

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -6,13 +6,13 @@ namespace torch { namespace utils {
 
 using namespace at;
 
-std::vector<TensorGroup> take_tensors(TensorList tensors, std::size_t size_limit) {
+std::vector<TensorGroup> take_tensors(TensorList tensors, size_t size_limit) {
   std::vector<TensorGroup> results;
   results.reserve(tensors.size()); // an overapproximation, but at least we won't have to copy stuff around
   std::unordered_map<at::Type*, TensorGroup> groups;
   for (const auto & tensor : tensors) {
     auto & type = tensor.type();
-    std::size_t tensor_size;
+    size_t tensor_size;
     if (type.is_sparse()) {
       const auto& indices = tensor._indices();
       const auto& values = tensor._values();
@@ -41,11 +41,11 @@ std::vector<TensorGroup> take_tensors(TensorList tensors, std::size_t size_limit
 
 void reorder_tensors_like(std::vector<Tensor>& tensors, TensorList order) {
   TORCH_ASSERT(tensors.size() == order.size());
-  std::unordered_map<at::Type*, std::vector<std::size_t>> type_indices;
-  for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
+  std::unordered_map<at::Type*, std::vector<size_t>> type_indices;
+  for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
     type_indices[&tensors[i].type()].push_back(i);
 
-  std::unordered_map<at::Type*, std::size_t> type_used;
+  std::unordered_map<at::Type*, size_t> type_used;
   std::vector<Tensor> ordered_tensors;
   ordered_tensors.reserve(tensors.size());
   for (auto & tmpl_tensor : order) {
@@ -86,7 +86,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
   std::vector<at::Tensor> outputs;
   outputs.reserve(tensors.size());
   auto & type = tensors[0].type();
-  for (std::size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
+  for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
     outputs.emplace_back(type._sparse_coo_tensor_unsafe(indices[i], values[i], tensors[i].sizes()));
   return outputs;
 }

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -18,7 +18,7 @@ inline at::Tensor flatten_dense_tensors(at::TensorList tensors) {
 inline std::vector<at::Tensor> unflatten_dense_tensors(const at::Tensor& flat, at::TensorList tensors) {
   std::vector<at::Tensor> outputs;
   outputs.reserve(tensors.size());
-  std::size_t offset = 0;
+  size_t offset = 0;
   for (const auto & tensor : tensors) {
     auto numel = tensor.numel();
     outputs.push_back(flat.narrow(0, offset, numel).view(tensor.sizes()));
@@ -30,7 +30,7 @@ inline std::vector<at::Tensor> unflatten_dense_tensors(const at::Tensor& flat, a
 
 struct TensorGroup {
   std::vector<at::Tensor> tensors;
-  std::size_t size = 0;
+  size_t size = 0;
 
   at::Type& type() {
     TORCH_ASSERT(!tensors.empty());
@@ -38,7 +38,7 @@ struct TensorGroup {
   }
 };
 
-std::vector<TensorGroup> take_tensors(at::TensorList tensors, std::size_t size_limit);
+std::vector<TensorGroup> take_tensors(at::TensorList tensors, size_t size_limit);
 void reorder_tensors_like(std::vector<at::Tensor>& tensors, at::TensorList order);
 
 std::pair<at::Tensor, at::Tensor> flatten_sparse_tensors(at::TensorList tensors);

--- a/torch/lib/THD/base/ChannelUtils.hpp
+++ b/torch/lib/THD/base/ChannelUtils.hpp
@@ -13,10 +13,10 @@
 #include <vector>
 
 
-inline void hash_combine(std::size_t& seed) { }
+inline void hash_combine(size_t& seed) { }
 
 template <typename T, typename... Rest>
-inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
+inline void hash_combine(size_t& seed, const T& v, Rest... rest) {
   std::hash<T> hasher;
   seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
   hash_combine(seed, rest...);
@@ -25,8 +25,8 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
 #define MAKE_HASHABLE(type, ...)                                              \
   namespace std {                                                             \
     template<> struct hash<type> {                                            \
-      std::size_t operator()(const type &t) const {                           \
-        std::size_t ret = 0;                                                  \
+      size_t operator()(const type &t) const {                           \
+        size_t ret = 0;                                                  \
         hash_combine(ret, __VA_ARGS__);                                       \
         return ret;                                                           \
       }                                                                       \
@@ -66,9 +66,9 @@ MAKE_HASHABLE(::thd::DeviceType, static_cast<std::uint8_t>(t));
 
 namespace thd {
 
-using rank_type = std::uint32_t;
-using port_type = std::uint16_t;
-using size_type = std::uint64_t;
+using rank_type = uint32_t;
+using port_type = uint16_t;
+using size_type = uint64_t;
 
 #define SYSCHECK(expr) { \
   errno = 0; auto ___output = (expr); (void)___output;     \
@@ -76,9 +76,9 @@ using size_type = std::uint64_t;
 }
 
 template<typename T>
-void send_bytes(int socket, const T* buffer, std::size_t length, bool more_data = false)
+void send_bytes(int socket, const T* buffer, size_t length, bool more_data = false)
 {
-  std::size_t bytes_to_send = sizeof(T) * length;
+  size_t bytes_to_send = sizeof(T) * length;
   if (bytes_to_send == 0)
     return;
 
@@ -105,9 +105,9 @@ void send_bytes(int socket, const T* buffer, std::size_t length, bool more_data 
 
 
 template<typename T>
-void recv_bytes(int socket, T* buffer, std::size_t length)
+void recv_bytes(int socket, T* buffer, size_t length)
 {
-  std::size_t bytes_to_receive = sizeof(T) * length;
+  size_t bytes_to_receive = sizeof(T) * length;
   if (bytes_to_receive == 0)
     return;
 

--- a/torch/lib/THD/base/DataChannel.cpp
+++ b/torch/lib/THD/base/DataChannel.cpp
@@ -76,7 +76,7 @@ DataChannel::Group::Group(std::vector<rank_type> ranks, rank_type max_rank)
   }
 
   _new2old.reserve(ranks.size());
-  for (std::size_t i = 0; i < ranks.size(); ++i) {
+  for (size_t i = 0; i < ranks.size(); ++i) {
     _new2old.push_back(ranks[i]);
     _old2new.insert({ranks[i], i});
   }

--- a/torch/lib/THD/base/Scalar.hpp
+++ b/torch/lib/THD/base/Scalar.hpp
@@ -12,7 +12,7 @@ struct Scalar {
   Scalar(Scalar&& other) = delete;
   virtual ~Scalar() {}
 
-  virtual std::size_t elementSize() const = 0;
+  virtual size_t elementSize() const = 0;
   virtual void* data() = 0;
   virtual const void* data() const = 0;
   virtual RPCType type() const = 0;
@@ -25,7 +25,7 @@ struct ScalarWrapper : Scalar {
   ScalarWrapper(real value) : _value(value) {}
   virtual ~ScalarWrapper() {}
 
-  virtual std::size_t elementSize() const override {
+  virtual size_t elementSize() const override {
     return sizeof(real);
   }
 

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -166,8 +166,8 @@ void DataChannelGloo::allGatherT(std::vector<at::Tensor>& output,
       throw std::runtime_error("allGather got input and output on different devices");
     }
   }
-  std::uint64_t tensor_bytes = input.type().elementSizeInBytes() * input.numel();
-  std::uint64_t all_tensor_bytes = tensor_bytes * output.size();
+  uint64_t tensor_bytes = input.type().elementSizeInBytes() * input.numel();
+  uint64_t all_tensor_bytes = tensor_bytes * output.size();
   auto ret = _cache->getAlgorithm<CollectiveType::ALL_GATHER, T>(
     group_id, _groups.at(group_id), input_device, tensor_bytes, all_tensor_bytes, input.numel());
 
@@ -176,7 +176,7 @@ void DataChannelGloo::allGatherT(std::vector<at::Tensor>& output,
     std::lock_guard<std::mutex> lock(*GlooCache::mutex(ret));
     std::memcpy(GlooCache::input_buffer(ret).get(), input.data_ptr(), tensor_bytes);
     GlooCache::algorithm(ret)->run();
-    for (std::size_t i = 0; i < output.size(); i++) {
+    for (size_t i = 0; i < output.size(); i++) {
       std::memcpy(output.at(i).data_ptr(),
                   GlooCache::output_buffer(ret).get() + (i * tensor_bytes),
                   tensor_bytes);
@@ -218,7 +218,7 @@ void DataChannelGloo::scatter(std::vector<at::Tensor>& input,
 template<typename T>
 void DataChannelGloo::allReduceT(at::Tensor& t, THDReduceOp operation,
                                  THDGroup group_id) {
-  std::uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
+  uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
   auto ret = _cache->getAlgorithm<CollectiveType::ALL_REDUCE, T>(
     group_id, _groups.at(group_id), getDeviceType(t), tensor_bytes, t.numel(), operation);
 
@@ -247,7 +247,7 @@ void DataChannelGloo::reduce(at::Tensor& data, THDReduceOp operation,
 template<typename T>
 void DataChannelGloo::broadcastT(at::Tensor& data, rank_type src_rank,
                                  THDGroup group_id) {
-  std::uint64_t tensor_bytes = data.type().elementSizeInBytes() * data.numel();
+  uint64_t tensor_bytes = data.type().elementSizeInBytes() * data.numel();
   auto ret = _cache->getAlgorithm<CollectiveType::BROADCAST, T>(
     group_id, _groups.at(group_id), getDeviceType(data), tensor_bytes, data.numel(),
     _groups.at(group_id).mustGetGroupRank(src_rank));

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -188,7 +188,7 @@ void DataChannelMPI::allGather(std::vector<at::Tensor>& output,
     comm
   );
 
-  for (std::size_t i = 0; i < output.size(); ++i)
+  for (size_t i = 0; i < output.size(); ++i)
     output[i].copy_(recv_buffer[i]);
 }
 
@@ -227,7 +227,7 @@ void DataChannelMPI::gather(std::vector<at::Tensor>& output,
   );
 
   // NOTE: this is a no-op in all processes except dst_rank
-  for (std::size_t i = 0; i < output.size(); ++i)
+  for (size_t i = 0; i < output.size(); ++i)
     output[i].copy_(recv_buffer[i]);
 }
 
@@ -256,7 +256,7 @@ void DataChannelMPI::scatter(std::vector<at::Tensor>& input,
       assertSameSizeAndType(in_tensor, output, "scatter");
 
     send_buffer = _newLikeFlat(input);
-    for (std::size_t i = 0; i < input.size(); ++i)
+    for (size_t i = 0; i < input.size(); ++i)
       send_buffer[i].copy_(input[i]);
     sendbuf = send_buffer.data_ptr();
   }
@@ -424,7 +424,7 @@ THDGroup DataChannelMPI::newGroup(const std::vector<rank_type>& ranks) {
 
     // this vector maps new ranks to ranks in COMM_WORLD (global ranks)
     std::vector<rank_type> new_ranks(size);
-    for (std::size_t i = 0; i < 2 * size; i += 2)
+    for (size_t i = 0; i < 2 * size; i += 2)
       new_ranks[all_mapping_ranks[i]] = all_mapping_ranks[i + 1];
 
     new_group = DataChannel::Group(new_ranks, _num_processes - 1);

--- a/torch/lib/THD/base/data_channels/GlooCache.hpp
+++ b/torch/lib/THD/base/data_channels/GlooCache.hpp
@@ -37,8 +37,8 @@ using key_type = std::tuple<
   THDGroup,       // group
   DeviceType,     // tensors device type
   int,            // CUDA stream id used in the algorithm
-  std::size_t,    // input buffer bytes
-  std::size_t,    // output buffer bytes
+  size_t,    // input buffer bytes
+  size_t,    // output buffer bytes
   THDReduceOp,    // reduce op
   rank_type       // src/dest rank
 >;
@@ -47,7 +47,7 @@ const DeviceType UNUSED_DEVICE = DeviceType::LAST;
 const THDReduceOp UNUSED_OP = THDReduceMIN;
 const int UNUSED_STREAM = -1;
 const rank_type UNUSED_RANK = -1;
-const std::size_t UNUSED_BYTES = 0;
+const size_t UNUSED_BYTES = 0;
 
 // Forward declaration
 template<CollectiveType D, typename T>
@@ -137,7 +137,7 @@ struct GlooCache {
   }
 
   // NOTE: this function needs to be thread safe
-  std::shared_ptr<buffer_type> createBuffer(std::size_t bytes, DeviceType device) const {
+  std::shared_ptr<buffer_type> createBuffer(size_t bytes, DeviceType device) const {
     if (device == DeviceType::CPU) {
       return std::shared_ptr<buffer_type>(new char[bytes],
                                           std::default_delete<char[]>());
@@ -178,7 +178,7 @@ struct GlooCache {
   }
 
   static void memcpy_input(value_type& info, at::Tensor& t) {
-    std::uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
+    uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
     auto t_dev = getDeviceType(t);
     auto input_buffer = GlooCache::input_buffer(info).get();
 
@@ -196,7 +196,7 @@ struct GlooCache {
   }
 
   static void memcpy_output(value_type& info, at::Tensor& t) {
-    std::uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
+    uint64_t tensor_bytes = t.type().elementSizeInBytes() * t.numel();
     auto t_dev = getDeviceType(t);
     auto output_buffer = GlooCache::output_buffer(info).get();
 
@@ -255,7 +255,7 @@ const ::gloo::ReductionFunction<T>* THDToGlooReduceOp(THDReduceOp op) {
 template<typename T>
 struct algorithm_spec<CollectiveType::ALL_GATHER, T> {
   static GlooCache::key_type key(
-    THDGroup group_id, DeviceType device, std::size_t input_bytes, std::size_t output_bytes, std::size_t unused_count
+    THDGroup group_id, DeviceType device, size_t input_bytes, size_t output_bytes, size_t unused_count
   ) {
     return std::make_tuple(CollectiveType::ALL_GATHER, group_id, device, UNUSED_STREAM,
                            input_bytes, output_bytes, UNUSED_OP, UNUSED_RANK);
@@ -263,7 +263,7 @@ struct algorithm_spec<CollectiveType::ALL_GATHER, T> {
 
   static GlooCache::value_type create(GlooCache& cache,
     const DataChannelGloo::Group& group, const std::string& store_prefix,
-    DeviceType device, std::size_t input_bytes, std::size_t output_bytes, std::size_t count
+    DeviceType device, size_t input_bytes, size_t output_bytes, size_t count
   ) {
     auto context = cache.createContext(group, store_prefix);
     auto input_buffer = cache.createBuffer(input_bytes, device);
@@ -292,8 +292,8 @@ struct algorithm_spec<CollectiveType::ALL_GATHER, T> {
 template<typename T>
 struct algorithm_spec<CollectiveType::ALL_REDUCE, T> {
   static GlooCache::key_type key(
-    THDGroup group_id, DeviceType device, std::size_t input_bytes,
-    std::size_t unused_count, THDReduceOp op
+    THDGroup group_id, DeviceType device, size_t input_bytes,
+    size_t unused_count, THDReduceOp op
   ) {
     int stream = UNUSED_STREAM;
     if (device == DeviceType::CUDA) {
@@ -306,7 +306,7 @@ struct algorithm_spec<CollectiveType::ALL_REDUCE, T> {
 
   static GlooCache::value_type create(GlooCache& cache,
     const DataChannelGloo::Group& group, const std::string& store_prefix,
-    DeviceType device, std::size_t input_bytes, std::size_t count, THDReduceOp op
+    DeviceType device, size_t input_bytes, size_t count, THDReduceOp op
   ) {
     auto context = cache.createContext(group, store_prefix);
     auto input_buffer = cache.createBuffer(input_bytes, device);
@@ -362,8 +362,8 @@ struct algorithm_spec<CollectiveType::ALL_REDUCE, T> {
 template<typename T>
 struct algorithm_spec<CollectiveType::BROADCAST, T> {
   static GlooCache::key_type key(
-    THDGroup group_id, DeviceType device, std::size_t input_bytes,
-    std::size_t unused_count, rank_type src_rank
+    THDGroup group_id, DeviceType device, size_t input_bytes,
+    size_t unused_count, rank_type src_rank
   ) {
     int stream = UNUSED_STREAM;
     if (device == DeviceType::CUDA) {
@@ -376,7 +376,7 @@ struct algorithm_spec<CollectiveType::BROADCAST, T> {
 
   static GlooCache::value_type create(GlooCache& cache,
     const DataChannelGloo::Group& group, const std::string& store_prefix,
-    DeviceType device, std::size_t input_bytes, std::size_t count, rank_type src_rank
+    DeviceType device, size_t input_bytes, size_t count, rank_type src_rank
   ) {
     auto context = cache.createContext(group, store_prefix);
     auto input_buffer = cache.createBuffer(input_bytes, device);

--- a/torch/lib/THD/base/data_channels/Store.cpp
+++ b/torch/lib/THD/base/data_channels/Store.cpp
@@ -46,7 +46,7 @@ void Store::StoreDeamon::deamon() {
   // receive the queries
   bool finished = false;
   while (!finished) {
-    for (std::size_t i = 0; i < _sockets.size(); i++) {
+    for (size_t i = 0; i < _sockets.size(); i++) {
       fds[i].revents = 0;
     }
 
@@ -60,7 +60,7 @@ void Store::StoreDeamon::deamon() {
       _keys_awaited.push_back(0);
       fds.push_back({ .fd = sock_fd, .events = POLLIN });
     }
-    for (std::size_t rank = 0; rank < _sockets.size(); rank++) {
+    for (size_t rank = 0; rank < _sockets.size(); rank++) {
       if (fds[rank + 1].revents == 0)
         continue;
 
@@ -114,7 +114,7 @@ void Store::StoreDeamon::query(rank_type rank) {
     size_type nargs;
     recv_bytes<size_type>(socket, &nargs, 1);
     std::vector<std::string> keys(nargs);
-    for (std::size_t i = 0; i < nargs; i++) {
+    for (size_t i = 0; i < nargs; i++) {
       keys[i] = recv_string(socket);
     }
     if (checkAndUpdate(keys)) {
@@ -187,7 +187,7 @@ void Store::wait(const std::vector<std::string>& keys) {
   send_value<QueryType>(_socket, QueryType::WAIT);
   size_type nkeys = keys.size();
   send_bytes<size_type>(_socket, &nkeys, 1, (nkeys > 0));
-  for (std::size_t i = 0; i < nkeys; i++) {
+  for (size_t i = 0; i < nkeys; i++) {
     send_string(_socket, keys[i], (i != (nkeys - 1)));
   }
   // after sending the query, wait for a 'stop_waiting' response

--- a/torch/lib/THD/base/data_channels/Store.hpp
+++ b/torch/lib/THD/base/data_channels/Store.hpp
@@ -32,7 +32,7 @@ private:
     std::thread _deamon;
     store_type _store;
     std::unordered_map<std::string, std::vector<rank_type>> _waiting;
-    std::vector<std::size_t> _keys_awaited;
+    std::vector<size_t> _keys_awaited;
     std::vector<int> _sockets;
   };
 

--- a/torch/lib/THD/base/init_methods/InitMethodFile.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodFile.cpp
@@ -43,7 +43,7 @@ void unlockFile(int fd) {
 }
 
 // file_descriptor, number_of_lines_in_file
-std::pair<int, std::size_t> waitForGroup(std::string file_path, std::string group_name,
+std::pair<int, size_t> waitForGroup(std::string file_path, std::string group_name,
                                          std::fstream& file) {
   int fd;
   std::string content;
@@ -85,8 +85,8 @@ std::pair<int, std::size_t> waitForGroup(std::string file_path, std::string grou
   return {fd, std::count(content.begin(), content.end(), '\n')};
 }
 
-std::size_t waitForData(int fd, std::fstream& file, rank_type world_size) {
-  std::size_t lines = 0;
+size_t waitForData(int fd, std::fstream& file, rank_type world_size) {
+  size_t lines = 0;
   // Wait until all processes will write their info
   while (lines < world_size) {
     unlockFile(fd);
@@ -111,9 +111,9 @@ parseFile(std::fstream& file, rank_type world_size, std::string group_name) {
   std::vector<std::string> master_addrs;
   std::vector<int> ranks(world_size);
   // Parse the file
-  for (std::size_t i = 0; i < world_size; ++i) {
+  for (size_t i = 0; i < world_size; ++i) {
     std::string proc_group_name;
-    std::size_t proc_addrs_count;
+    size_t proc_addrs_count;
     int proc_rank;
     port_type proc_port;
 
@@ -140,8 +140,8 @@ parseFile(std::fstream& file, rank_type world_size, std::string group_name) {
   }
 
   // Ensure there are no duplicates
-  for (std::size_t i = 0; i < ranks.size(); ++i) {
-    for (std::size_t j = i + 1; j < ranks.size(); ++j) {
+  for (size_t i = 0; i < ranks.size(); ++i) {
+    for (size_t j = i + 1; j < ranks.size(); ++j) {
       if (ranks[i] >= 0 && (ranks[i] == ranks[j]))
         throw std::logic_error("more than one node have assigned same rank");
     }
@@ -173,7 +173,7 @@ InitMethod::Config initFile(std::string argument,
 
   InitMethod::Config config;
   int fd;
-  std::size_t order;
+  size_t order;
   std::fstream file;
 
   std::tie(fd, order) = waitForGroup(file_path, group_name, file);
@@ -192,7 +192,7 @@ InitMethod::Config initFile(std::string argument,
   }
   file << std::endl;
 
-  std::size_t lines = waitForData(fd, file, world_size);
+  size_t lines = waitForData(fd, file, world_size);
 
   port_type master_port;
   std::vector<std::string> master_addrs;

--- a/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodTCP.cpp
@@ -258,7 +258,7 @@ InitMethod::Config initTCPMulticast(std::string group_name, rank_type world_size
 
   // NOTE: msgs are already sorted lexicographically, so we can greedily
   // insert them into free slots
-  std::size_t free_pos = 0;
+  size_t free_pos = 0;
   for (auto& msg : msgs) {
     if (msg.rank >= 0) continue; // These were sorted in the previous loop
     while (sorted_msgs[free_pos] != nullptr) free_pos++;
@@ -266,7 +266,7 @@ InitMethod::Config initTCPMulticast(std::string group_name, rank_type world_size
   }
 
   auto& master_msg = *sorted_msgs[0];
-  for (std::size_t rank = 0; rank < sorted_msgs.size(); ++rank) {
+  for (size_t rank = 0; rank < sorted_msgs.size(); ++rank) {
     if (packed_msg == sorted_msgs[rank]->pack()) {
       config.rank = rank;
       config.world_size = world_size;

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.cpp
@@ -84,7 +84,7 @@ std::pair<std::string, std::string> discoverMaster(std::vector<std::string> addr
 }
 
 rank_type getRank(const std::vector<int>& ranks, int assigned_rank,
-                  std::size_t order) {
+                  size_t order) {
   if (assigned_rank >= 0) {
     return assigned_rank;
   } else {

--- a/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethodUtils.hpp
@@ -18,5 +18,5 @@ discoverMaster(std::vector<std::string> addresses, port_type port);
 // Helper that gets the rank based on the input order
 rank_type getRank(const std::vector<int>& ranks,
                   int assigned_rank,
-                  std::size_t order);
+                  size_t order);
 } // namespace thd

--- a/torch/lib/THD/master_worker/common/ByteArray.cpp
+++ b/torch/lib/THD/master_worker/common/ByteArray.cpp
@@ -14,13 +14,13 @@ ByteArray::ByteArray()
   : _data()
 {}
 
-ByteArray::ByteArray(std::size_t size)
+ByteArray::ByteArray(size_t size)
   : ByteArray()
 {
   _data.reserve(size);
 }
 
-ByteArray::ByteArray(const char* arr, std::size_t size)
+ByteArray::ByteArray(const char* arr, size_t size)
   : _data(arr, arr + size)
 {}
 
@@ -35,7 +35,7 @@ ByteArray::ByteArray(const ByteArray& arr)
 
 ByteArray::~ByteArray() {}
 
-ByteArray& ByteArray::append(const char* arr, std::size_t size) {
+ByteArray& ByteArray::append(const char* arr, size_t size) {
   _data.append(arr, arr + size);
   return *this;
 }
@@ -44,7 +44,7 @@ const char* ByteArray::data() const {
   return _data.data();
 }
 
-std::size_t ByteArray::length() const {
+size_t ByteArray::length() const {
   return _data.size();
 }
 

--- a/torch/lib/THD/master_worker/common/ByteArray.hpp
+++ b/torch/lib/THD/master_worker/common/ByteArray.hpp
@@ -6,16 +6,16 @@
 namespace thd { namespace rpc {
 
 struct ByteArray {
-  using size_type = std::size_t;
+  using size_type = size_t;
 
   ByteArray();
-  ByteArray(std::size_t size);
-  ByteArray(const char* arr, std::size_t size);
+  ByteArray(size_t size);
+  ByteArray(const char* arr, size_t size);
   ByteArray(ByteArray&& arr);
   ByteArray(const ByteArray& arr);
   ~ByteArray();
 
-  ByteArray& append(const char* arr, std::size_t size);
+  ByteArray& append(const char* arr, size_t size);
   const char* data() const;
   size_type length() const;
 

--- a/torch/lib/THD/master_worker/common/RPC-inl.hpp
+++ b/torch/lib/THD/master_worker/common/RPC-inl.hpp
@@ -70,7 +70,7 @@ template<typename T>
 inline void _appendData(ByteArray& str, const std::vector<T>& arg) {
   int l = arg.size();
   _appendData(str, l);
-  for (std::size_t i = 0; i < l; i++)
+  for (size_t i = 0; i < l; i++)
     __appendData(
         str,
         arg[i],

--- a/torch/lib/THD/master_worker/common/RPC.cpp
+++ b/torch/lib/THD/master_worker/common/RPC.cpp
@@ -15,7 +15,7 @@ RPCMessage::RPCMessage()
   , _offset(0)
 {}
 
-RPCMessage::RPCMessage(char* str, std::size_t size)
+RPCMessage::RPCMessage(char* str, size_t size)
   : _msg(str, size)
   , _offset(0)
 {}
@@ -46,7 +46,7 @@ RPCMessage::size_type RPCMessage::remaining() const {
   return _msg.length() - _offset;
 }
 
-const char* RPCMessage::read(std::size_t num_bytes) {
+const char* RPCMessage::read(size_t num_bytes) {
   if (_offset + num_bytes > _msg.length())
     throw std::out_of_range("invalid access: out of bounds");
   const char* ret_val = _msg.data() + _offset;

--- a/torch/lib/THD/master_worker/common/RPC.hpp
+++ b/torch/lib/THD/master_worker/common/RPC.hpp
@@ -10,17 +10,17 @@
 
 namespace thd {
 
-using object_id_type = std::uint64_t;
+using object_id_type = uint64_t;
 
 namespace rpc {
 
-using function_id_type = std::uint16_t;
+using function_id_type = uint16_t;
 
 class RPCMessage {
 public:
   using size_type = ByteArray::size_type;
   RPCMessage();
-  RPCMessage(char* str, std::size_t size);
+  RPCMessage(char* str, size_t size);
   RPCMessage(const ByteArray& str);
   RPCMessage(ByteArray&& str);
 
@@ -28,11 +28,11 @@ public:
   const char* data() const; // Offset data.
   bool isEmpty() const;
   size_type remaining() const; // Length of the msg left to read.
-  const char* read(std::size_t num_bytes);
+  const char* read(size_t num_bytes);
 
 private:
   ByteArray _msg;
-  std::size_t _offset;
+  size_t _offset;
 };
 
 template <typename ...Args>

--- a/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensor.cpp
@@ -670,7 +670,7 @@ void THDTensor_(unfold)(THDTensor *self, THDTensor *src,
   newSize[self->nDimension] = size;
   newStride[self->nDimension] = self->stride[dimension];
 
-  for (std::size_t d = 0; d < self->nDimension; d++) {
+  for (size_t d = 0; d < self->nDimension; d++) {
     if (d == dimension) {
       newSize[d] = (self->size[d] - size) / step + 1;
       newStride[d] = step * self->stride[d];
@@ -709,7 +709,7 @@ void THDTensor_(squeeze)(THDTensor *self, THDTensor *src) {
 
   THDTensor_(set)(self, src);
 
-  for (std::size_t d = 0; d < src->nDimension; d++) {
+  for (size_t d = 0; d < src->nDimension; d++) {
     if (src->size[d] != 1) {
       if (d != ndim) {
         self->size[ndim] = src->size[d];
@@ -783,7 +783,7 @@ int THDTensor_(isContiguous)(const THDTensor *self) {
 int THDTensor_(isSameSizeAs)(const THDTensor *self, const THDTensor *src) {
   if (self->nDimension != src->nDimension)
     return 0;
-  for (std::size_t d = 0; d < self->nDimension; d++)
+  for (size_t d = 0; d < self->nDimension; d++)
     if (self->size[d] != src->size[d])
       return 0;
   return 1;
@@ -795,7 +795,7 @@ int THDTensor_(isSetTo)(const THDTensor *self, const THDTensor *src) {
   if (self->storage == src->storage &&
       self->storageOffset == src->storageOffset &&
       self->nDimension == src->nDimension) {
-    for (std::size_t d = 0; d < self->nDimension; d++) {
+    for (size_t d = 0; d < self->nDimension; d++) {
       if (self->size[d] != src->size[d] || self->stride[d] != src->stride[d])
         return 0;
     }
@@ -807,7 +807,7 @@ int THDTensor_(isSetTo)(const THDTensor *self, const THDTensor *src) {
 int THDTensor_(isSize)(const THDTensor *self, const THLongStorage *dims) {
   if (self->nDimension != THLongStorage_size(dims))
     return 0;
-  for (std::size_t d = 0; d < self->nDimension; d++)
+  for (size_t d = 0; d < self->nDimension; d++)
     if (self->size[d] != THLongStorage_get(dims, d))
       return 0;
   return 1;
@@ -818,7 +818,7 @@ ptrdiff_t THDTensor_(nElement)(const THDTensor *self) {
     return 0;
   } else {
     ptrdiff_t nElement = 1;
-    for (std::size_t d = 0; d < self->nDimension; d++) {
+    for (size_t d = 0; d < self->nDimension; d++) {
       nElement *= self->size[d];
     }
     return nElement;

--- a/torch/lib/THD/master_worker/master/generic/THDTensorMeta.cpp
+++ b/torch/lib/THD/master_worker/master/generic/THDTensorMeta.cpp
@@ -15,7 +15,7 @@ static void THDTensor_(_resize)(THDTensor *self, int nDimension, int64_t *size, 
   bool hasRequiredSize = true;
 
   nDimension_ = 0;
-  for (std::size_t d = 0; d < nDimension; d++) {
+  for (size_t d = 0; d < nDimension; d++) {
     if (size[d] > 0) {
       nDimension_++;
       if ((self->nDimension > d) && (size[d] != self->size[d]))
@@ -97,7 +97,7 @@ void THDTensor_(_squeeze1d)(THDTensor *self, THDTensor *src, int dimension) {
   THDTensor_(set)(self, src);
 
   if (src->size[dimension] == 1 && src->nDimension > 1) {
-    for (std::size_t d = dimension; d < self->nDimension-1; d++) {
+    for (size_t d = dimension; d < self->nDimension-1; d++) {
       self->size[d] = self->size[d+1];
       self->stride[d] = self->stride[d+1];
     }

--- a/torch/lib/THD/master_worker/worker/dispatch/Storage.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/Storage.cpp
@@ -16,7 +16,7 @@ static std::unique_ptr<at::Storage> createStorage(RPCType type) {
   throw std::invalid_argument("passed character doesn't represent a storage type");
 }
 
-static std::unique_ptr<at::Storage> createStorage(RPCType type, std::size_t size) {
+static std::unique_ptr<at::Storage> createStorage(RPCType type, size_t size) {
   std::unique_ptr<at::Storage> storage = createStorage(type);
   storage->resize(size);
   return storage;
@@ -76,24 +76,24 @@ static void storageNewWithSize(rpc::RPCMessage& raw_message) {
   );
 }
 
-static void storageNewWithSizeN(rpc::RPCMessage& raw_message, std::size_t size) {
+static void storageNewWithSizeN(rpc::RPCMessage& raw_message, size_t size) {
   RPCType storage_type = unpackType(raw_message);
   object_id_type storage_id = unpackStorage(raw_message);
   std::unique_ptr<at::Storage> storage = createStorage(storage_type, size);
   RPCType value_type = peekType(raw_message);
   if (isInteger(value_type)) {
     int64_t values[size];
-    for (std::size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
       values[i] = unpackInteger(raw_message);
     finalize(raw_message);
-    for (std::size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
       storage->fast_set(i, values[i]);
   } else if (isFloat(value_type)) {
     double values[size];
-    for (std::size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
       values[i] = unpackInteger(raw_message);
     finalize(raw_message);
-    for (std::size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
       storage->fast_set(i, values[i]);
   } else {
     throw std::invalid_argument("expected scalar type");

--- a/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/Tensor.cpp
@@ -136,10 +136,10 @@ static void tensorResizeAs(rpc::RPCMessage& raw_message) {
   tensor.resize_as_(src);
 }
 
-static void tensorResizeNd(rpc::RPCMessage& raw_message, std::size_t N) {
+static void tensorResizeNd(rpc::RPCMessage& raw_message, size_t N) {
   at::Tensor tensor = unpackRetrieveTensor(raw_message);
   std::vector<int64_t> size(N);
-  for (std::size_t i = 0; i < N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     size[i] = unpackInteger(raw_message);
   }
   finalize(raw_message);

--- a/torch/lib/THD/master_worker/worker/dispatch/TensorMath.cpp
+++ b/torch/lib/THD/master_worker/worker/dispatch/TensorMath.cpp
@@ -188,7 +188,7 @@ static void tensorCatArray(rpc::RPCMessage& raw_message) {
   at::Tensor result = unpackRetrieveTensor(raw_message);
   int numInputs = unpackInteger(raw_message);
   std::vector<at::Tensor> inputs(numInputs);
-  for (std::size_t i = 0; i < numInputs; i++)
+  for (size_t i = 0; i < numInputs; i++)
     inputs[i] = unpackRetrieveTensor(raw_message);
   int dimension = unpackInteger(raw_message);
   finalize(raw_message);

--- a/torch/lib/THD/process_group/Collectives.cpp
+++ b/torch/lib/THD/process_group/Collectives.cpp
@@ -120,7 +120,7 @@ void THDBarrier(THDGroup group) {
 
 THDGroup THDNewGroup(const int *ranks, size_t len) {
   std::vector<rank_type> v_ranks(len);
-  for (std::size_t i = 0; i < len; ++i) {
+  for (size_t i = 0; i < len; ++i) {
     v_ranks[i] = convertToRank(ranks[i]);
   }
 

--- a/torch/lib/THD/test/TestUtils.hpp
+++ b/torch/lib/THD/test/TestUtils.hpp
@@ -17,7 +17,7 @@ constexpr char MASTER_ADDR_ENV[] = "MASTER_ADDR";
 
 struct Barrier {
   Barrier() : _count(0) {}
-  Barrier(std::size_t count) : _count(count) {}
+  Barrier(size_t count) : _count(count) {}
 
   void wait() {
     std::unique_lock<std::mutex> lock{_mutex};
@@ -31,7 +31,7 @@ struct Barrier {
 private:
   std::mutex _mutex;
   std::condition_variable _cv;
-  std::size_t _count;
+  size_t _count;
 };
 
 template<typename T>
@@ -73,7 +73,7 @@ inline int64_t factorial(int n) {
 }
 
 #define ASSERT_TENSOR_VALUE(T, tensor, value) {            \
-  for (std::size_t idx = 0; idx < (tensor).numel(); idx++) \
+  for (size_t idx = 0; idx < (tensor).numel(); idx++) \
     assert(check_equal(                                    \
       reinterpret_cast<T*>((tensor).data())[idx], static_cast<T>(value) \
     ));                                                    \

--- a/torch/lib/THD/test/data_channel_collectives.cpp
+++ b/torch/lib/THD/test/data_channel_collectives.cpp
@@ -82,7 +82,7 @@ void test_send_recv_scalar(std::shared_ptr<thd::DataChannel> data_channel) {
 }
 
 void test_broadcast(std::shared_ptr<thd::DataChannel> data_channel) {
-  for (std::size_t dest = 0; dest < data_channel->getNumProcesses(); ++dest) {
+  for (size_t dest = 0; dest < data_channel->getNumProcesses(); ++dest) {
     if (data_channel->getRank() == dest) {
       auto float_tensor = buildTensor<float>({1, 2, 3, 4, 5}, 10.123);
       data_channel->broadcast(*float_tensor, dest);
@@ -151,7 +151,7 @@ void test_scatter(std::shared_ptr<thd::DataChannel> data_channel) {
   std::vector<std::shared_ptr<thpp::IntTensor>> tensors;
   std::vector<thpp::Tensor*> raw_tensors;
   if (data_channel->getRank() == 0) {
-    for (std::size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
       tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, i));
       raw_tensors.push_back(tensors.back().get());
     }
@@ -171,13 +171,13 @@ void test_gather(std::shared_ptr<thd::DataChannel> data_channel) {
   std::vector<thpp::Tensor*> raw_tensors;
   auto int_tensor = buildTensor<int>({1, 2, 3, 4, 5}, data_channel->getRank());
   if (data_channel->getRank() == 0) {
-    for (std::size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
       tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, -1));
       raw_tensors.push_back(tensors.back().get());
     }
 
     data_channel->gather(raw_tensors, *int_tensor, 0);
-    for (std::size_t i = 0; i < tensors.size(); ++i)
+    for (size_t i = 0; i < tensors.size(); ++i)
       ASSERT_TENSOR_VALUE(int, *(tensors[i]), i)
   } else {
     data_channel->gather(raw_tensors, *int_tensor, 0);
@@ -188,13 +188,13 @@ void test_allGather(std::shared_ptr<thd::DataChannel> data_channel) {
   std::vector<std::shared_ptr<thpp::IntTensor>> tensors;
   std::vector<thpp::Tensor*> raw_tensors;
   auto int_tensor = buildTensor<int>({1, 2, 3, 4, 5}, data_channel->getRank());
-  for (std::size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
+  for (size_t i = 0; i < data_channel->getNumProcesses(); ++i) {
     tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, -1));
     raw_tensors.push_back(tensors.back().get());
   }
 
   data_channel->allGather(raw_tensors, *int_tensor, 0);
-  for (std::size_t i = 0; i < tensors.size(); ++i)
+  for (size_t i = 0; i < tensors.size(); ++i)
     ASSERT_TENSOR_VALUE(int, *(tensors[i]), i)
 }
 
@@ -222,7 +222,7 @@ void test_isend(std::shared_ptr<thd::DataChannel> data_channel) {
 
   if (data_channel->getRank() == 0) {
     std::vector<std::shared_ptr<thd::DataChannel::Request>> requests;
-    for (std::size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
       auto tensor = buildTensor<int>({1, 2, 3, 4, 5}, i);
       requests.push_back(std::shared_ptr<thd::DataChannel::Request>(
         data_channel->isend(*tensor, i)
@@ -248,14 +248,14 @@ void test_irecv(std::shared_ptr<thd::DataChannel> data_channel) {
   if (data_channel->getRank() == 0) {
     std::vector<std::shared_ptr<thd::DataChannel::Request>> requests;
     std::vector<std::shared_ptr<thpp::IntTensor>> tensors;
-    for (std::size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
       tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, -1));
       requests.push_back(std::shared_ptr<thd::DataChannel::Request>(
         data_channel->ireceive(*tensors.back(), i)
       ));
     }
 
-    for (std::size_t i = 0; i < requests.size(); ++i) {
+    for (size_t i = 0; i < requests.size(); ++i) {
       requests.at(i)->wait();
       assert(requests.at(i)->isCompleted());
       ASSERT_TENSOR_VALUE(int, *tensors.at(i), i + 1)
@@ -274,7 +274,7 @@ void test_interlaces(std::shared_ptr<thd::DataChannel> data_channel) {
 
   if (data_channel->getRank() == 0) {
     std::vector<std::shared_ptr<thd::DataChannel::Request>> requests;
-    for (std::size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
       auto tensor = buildTensor<int>({1, 2, 3, 4, 5}, 10);
       requests.push_back(std::shared_ptr<thd::DataChannel::Request>(
         data_channel->isend(*tensor, i)
@@ -283,7 +283,7 @@ void test_interlaces(std::shared_ptr<thd::DataChannel> data_channel) {
 
     data_channel->barrier();
 
-    for (std::size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
+    for (size_t i = 1; i < data_channel->getNumProcesses(); ++i) {
       auto int_tensor = buildTensor<int>({1, 2, 3, 4, 5}, 20);
       data_channel->send(*int_tensor, i);
     }
@@ -375,7 +375,7 @@ void test_scatter_group(std::shared_ptr<thd::DataChannel> data_channel,
   std::vector<thpp::Tensor*> raw_tensors;
   if (contains(group_ranks, data_channel->getRank())) {
     if (data_channel->getRank() == group_ranks[0]) {
-      for (std::size_t i = 0; i < group_ranks.size(); ++i) {
+      for (size_t i = 0; i < group_ranks.size(); ++i) {
         tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, group_ranks[i]));
         raw_tensors.push_back(tensors.back().get());
       }
@@ -403,13 +403,13 @@ void test_gather_group(std::shared_ptr<thd::DataChannel> data_channel,
   if (contains(group_ranks, data_channel->getRank())) {
     auto int_tensor = buildTensor<int>({1, 2, 3, 4, 5}, data_channel->getRank());
     if (data_channel->getRank() == group_ranks[0]) {
-      for (std::size_t i = 0; i < group_ranks.size(); ++i) {
+      for (size_t i = 0; i < group_ranks.size(); ++i) {
         tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, -1));
         raw_tensors.push_back(tensors.back().get());
       }
 
       data_channel->gather(raw_tensors, *int_tensor, group_ranks[0], group);
-      for (std::size_t i = 0; i < tensors.size(); ++i)
+      for (size_t i = 0; i < tensors.size(); ++i)
         ASSERT_TENSOR_VALUE(int, *(tensors[i]), group_ranks[i])
     } else {
       data_channel->gather(raw_tensors, *int_tensor, group_ranks[0], group);
@@ -427,13 +427,13 @@ void test_allGather_group(std::shared_ptr<thd::DataChannel> data_channel,
   std::vector<thpp::Tensor*> raw_tensors;
   if (contains(group_ranks, data_channel->getRank())) {
     auto int_tensor = buildTensor<int>({1, 2, 3, 4, 5}, data_channel->getRank());
-    for (std::size_t i = 0; i < group_ranks.size(); ++i) {
+    for (size_t i = 0; i < group_ranks.size(); ++i) {
       tensors.push_back(buildTensor<int>({1, 2, 3, 4, 5}, -1));
       raw_tensors.push_back(tensors.back().get());
     }
 
     data_channel->allGather(raw_tensors, *int_tensor, group);
-    for (std::size_t i = 0; i < tensors.size(); ++i)
+    for (size_t i = 0; i < tensors.size(); ++i)
       ASSERT_TENSOR_VALUE(int, *(tensors[i]), group_ranks[i])
   } else {
     auto int_tensor = buildTensor({1, 2, 3, 4, 5}, 1000);

--- a/torch/lib/THD/test/data_channel_gloo_cache.cpp
+++ b/torch/lib/THD/test/data_channel_gloo_cache.cpp
@@ -20,7 +20,7 @@ std::vector<std::thread> g_all_workers;
 std::mutex g_mutex;
 
 void test(std::shared_ptr<thd::DataChannel> data_channel) {
-  for (std::size_t dest = 0; dest < data_channel->getNumProcesses(); ++dest) {
+  for (size_t dest = 0; dest < data_channel->getNumProcesses(); ++dest) {
     if (data_channel->getRank() == dest) {
       auto float_tensor = buildTensor<float>({1, 2, 3, 4, 5}, 10.123);
       data_channel->broadcast(*float_tensor, dest);
@@ -35,7 +35,7 @@ void test(std::shared_ptr<thd::DataChannel> data_channel) {
 void run_all_tests(std::shared_ptr<thd::DataChannel> data_channel, int workers) {
   // NOTE: without properly working GlooCache this test would create
   // about (1000 * WORKERS ^ 3) connections what is over 'normal' system configuration
-  for (std::size_t i = 0; i < 1000; ++i) {
+  for (size_t i = 0; i < 1000; ++i) {
     test(data_channel);
   }
 }

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -58,7 +58,7 @@ struct AlgorithmKey {
   ReduceOp reduceOp = ReduceOp::UNUSED;
 
   // This function is called by torch::hash<AlgorithmKey>
-  static std::size_t hash(const AlgorithmKey& k) {
+  static size_t hash(const AlgorithmKey& k) {
     return torch::get_hash(
         k.collectiveType,
         k.type,


### PR DESCRIPTION
We have an annoying mix of `std::size_t` (and `uint32_t` and friends) and `size_t` without `std::`. This is a codemod to remove `std::` from these types in ATen and torch/csrc/. I consider these types to be fundamental enough that they don't warrant the `std::` in front. Either way it should be uniform.

@apaszke @ezyang @colesbury 