### PR TITLE
Make libshm also test if rt requires pthread.

### DIFF
--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -1,5 +1,8 @@
+project(libshm C CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
 CMAKE_POLICY(VERSION 2.6)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/public/threads.cmake)
 
 FIND_PACKAGE(Caffe2 REQUIRED)
 INCLUDE_DIRECTORIES(${CAFFE2_INCLUDE_DIR})
@@ -30,15 +33,41 @@ SET_TARGET_PROPERTIES(shm PROPERTIES
   IMPORT_PREFIX "lib")
 TARGET_LINK_LIBRARIES(shm ${CAFFE2_LIBRARIES})
 
-IF (UNIX AND NOT APPLE)
-   INCLUDE(CheckLibraryExists)
-   # https://github.com/libgit2/libgit2/issues/2128#issuecomment-35649830
-   CHECK_LIBRARY_EXISTS(rt clock_gettime "time.h" NEED_LIBRT)
-   IF(NEED_LIBRT)
-     TARGET_LINK_LIBRARIES(shm rt)
-     TARGET_LINK_LIBRARIES(torch_shm_manager rt)
-   ENDIF(NEED_LIBRT)
-ENDIF(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE)
+  include(CheckLibraryExists)
+  # https://github.com/libgit2/libgit2/issues/2128#issuecomment-35649830
+  check_library_exists(rt clock_gettime "time.h" NEED_LIBRT)
+  if(NEED_LIBRT)
+    target_link_libraries(shm rt)
+    target_link_libraries(torch_shm_manager rt)
+  else()
+    message(STATUS "Checking if rt requires pthread")
+    # Sometimes, rt won't be available unless you also link against
+    # pthreads.  In this case, the NEED_LIBRT test will fail, because
+    # check_library_exists isn't going to build the C file with the
+    # pthread file, and the build will fail, setting NEED_LIBRT to
+    # false (this is TOTALLY BOGUS, this situation should be an error
+    # situation, not a "oh, I guess rt is not supported", but it's
+    # not too easy to distinguish between the two situations).  So,
+    # if it fails, we try again, but this time also with a dependency
+    # on pthread.  If it succeeds this time, we know we not only need
+    # an rt dependency, but we also need pthread.
+    #
+    # BTW, this test looks for shm_open, because that's what we
+    # really care about (not clock_gettime).  I didn't change the
+    # site above though in case there was a reason we were testing
+    # against clock_gettime. In principle, the choice of symbol you
+    # test for shouldn't matter.
+    set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+    check_library_exists(rt shm_open "sys/mman.h" NEED_RT_AND_PTHREAD)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if(NEED_RT_AND_PTHREAD)
+      message(STATUS "Needs it, linking against pthread and rt")
+      target_link_libraries(shm rt Threads::Threads)
+      target_link_libraries(torch_shm_manager rt Threads::Threads)
+    endif()
+  endif()
+endif()
 
 
 INSTALL(TARGETS shm LIBRARY DESTINATION ${LIBSHM_INSTALL_LIB_SUBDIR})


### PR DESCRIPTION
In some configurations (e.g., our internal build of GCC 5 + GLIBC 2.23),
-lrt is not sufficient to use shm_open; you also need to declare
a dependency on pthread.  This patch adds a surgical extra fix to
detect this situation, in the case that I noticed it failing in the
wild.

Fixes #8110

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

