### PR TITLE
Migrated hardshrink() to ATen and deprecated nn.Hardshrink()

### DIFF
--- a/aten/doc/Functions.h
+++ b/aten/doc/Functions.h
@@ -411,12 +411,6 @@ static inline Tensor & glu_forward_out(Tensor & output, const Tensor & self, int
 static inline Tensor glu_forward(const Tensor & self, int64_t dim);
 static inline Tensor & glu_backward_out(Tensor & grad_input, const Tensor & grad_output, const Tensor & self, int64_t dim);
 static inline Tensor glu_backward(const Tensor & grad_output, const Tensor & self, int64_t dim);
-static inline Tensor & hardshrink_out(Tensor & output, const Tensor & self, Scalar lambd=0.5);
-static inline Tensor hardshrink(const Tensor & self, Scalar lambd=0.5);
-static inline Tensor & hardshrink_forward_out(Tensor & output, const Tensor & self, Scalar lambd);
-static inline Tensor hardshrink_forward(const Tensor & self, Scalar lambd);
-static inline Tensor & hardshrink_backward_out(Tensor & grad_input, const Tensor & grad_output, const Tensor & self, Scalar lambd);
-static inline Tensor hardshrink_backward(const Tensor & grad_output, const Tensor & self, Scalar lambd);
 static inline Tensor & hardtanh_out(Tensor & output, const Tensor & self, Scalar min_val=-1, Scalar max_val=1);
 static inline Tensor hardtanh(const Tensor & self, Scalar min_val=-1, Scalar max_val=1);
 static inline Tensor & hardtanh_forward_out(Tensor & output, const Tensor & self, Scalar min_val, Scalar max_val);
@@ -2007,24 +2001,6 @@ static inline Tensor & glu_backward_out(Tensor & grad_input, const Tensor & grad
 }
 static inline Tensor glu_backward(const Tensor & grad_output, const Tensor & self, int64_t dim) {
     return infer_type(self).glu_backward(grad_output, self, dim);
-}
-static inline Tensor & hardshrink_out(Tensor & output, const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink_out(output, self, lambd);
-}
-static inline Tensor hardshrink(const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink(self, lambd);
-}
-static inline Tensor & hardshrink_forward_out(Tensor & output, const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink_forward_out(output, self, lambd);
-}
-static inline Tensor hardshrink_forward(const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink_forward(self, lambd);
-}
-static inline Tensor & hardshrink_backward_out(Tensor & grad_input, const Tensor & grad_output, const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink_backward_out(grad_input, grad_output, self, lambd);
-}
-static inline Tensor hardshrink_backward(const Tensor & grad_output, const Tensor & self, Scalar lambd) {
-    return infer_type(self).hardshrink_backward(grad_output, self, lambd);
 }
 static inline Tensor & hardtanh_out(Tensor & output, const Tensor & self, Scalar min_val, Scalar max_val) {
     return infer_type(self).hardtanh_out(output, self, min_val, max_val);

--- a/aten/doc/Type.h
+++ b/aten/doc/Type.h
@@ -747,12 +747,6 @@ struct AT_API Type {
   virtual Tensor glu_forward(const Tensor & self, int64_t dim) const;
   virtual Tensor & glu_backward_out(Tensor & grad_input, const Tensor & grad_output, const Tensor & self, int64_t dim) const;
   virtual Tensor glu_backward(const Tensor & grad_output, const Tensor & self, int64_t dim) const;
-  virtual Tensor & hardshrink_out(Tensor & output, const Tensor & self, Scalar lambd=0.5) const;
-  virtual Tensor hardshrink(const Tensor & self, Scalar lambd=0.5) const;
-  virtual Tensor & hardshrink_forward_out(Tensor & output, const Tensor & self, Scalar lambd) const;
-  virtual Tensor hardshrink_forward(const Tensor & self, Scalar lambd) const;
-  virtual Tensor & hardshrink_backward_out(Tensor & grad_input, const Tensor & grad_output, const Tensor & self, Scalar lambd) const;
-  virtual Tensor hardshrink_backward(const Tensor & grad_output, const Tensor & self, Scalar lambd) const;
   virtual Tensor & hardtanh_out(Tensor & output, const Tensor & self, Scalar min_val=-1, Scalar max_val=1) const;
   virtual Tensor hardtanh(const Tensor & self, Scalar min_val=-1, Scalar max_val=1) const;
   virtual Tensor & hardtanh_forward_out(Tensor & output, const Tensor & self, Scalar min_val, Scalar max_val) const;

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -35,7 +35,7 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
 
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
-  auto out_tensor = at::zeros_like(self);
+  auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {
     scalar_t* lambd_tensor_d = lambd_tensor.data<scalar_t>();
     at::CPU_tensor_apply2<scalar_t, scalar_t>(
@@ -44,7 +44,7 @@ Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
       [lambd_tensor_d](
         scalar_t& self_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, double>(0.0) : self_val;
+          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, int>(0) : self_val;
     });
   });
   return out_tensor;
@@ -52,7 +52,7 @@ Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
 
 Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
-  auto out_tensor = at::zeros_like(self);
+  auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_backward_cpu", [&] {
     scalar_t* lambd_tensor_d = lambd_tensor.data<scalar_t>();
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
@@ -63,7 +63,7 @@ Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar 
         scalar_t& self_val,
         scalar_t& grad_val,
         scalar_t& out_tensor_val) {
-          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, double>(0.0) : grad_val;
+          out_tensor_val = (self_val >= -*lambd_tensor_d && self_val <= *lambd_tensor_d) ? convert<scalar_t, int>(0) : grad_val;
     });
   });
   return out_tensor;

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -34,7 +34,6 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
 }
 
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
-  printf("lambd = %g\n", lambd.toTensor().toType(CPU(kDouble)).data<double>()[0]);
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -34,6 +34,7 @@ Tensor & rrelu_(Tensor & self, Scalar lower, Scalar upper, bool training, Genera
 }
 
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
+  printf("lambd = %g\n", lambd.toTensor().toType(CPU(kDouble)).data<double>()[0]);
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -1,0 +1,60 @@
+#include "ATen/ATen.h"
+#include "ATen/NativeFunctions.h"
+#include "ATen/Dispatch.h"
+#include "ATen/cuda/CUDAApplyUtils.cuh"
+#include "ATen/cuda/CUDATensorMethods.cuh"
+#include "ATen/cuda/CUDATypeConversion.cuh"
+#include "THCUNN/THCHalfAutoNumerics.cuh"
+
+namespace at { namespace native {
+
+template <typename scalar_t>
+void hardshrink_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor) {
+  at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t>(
+      out_tensor,
+      lambd_tensor,
+      [] __device__ (scalar_t& out_tensor_val,
+         scalar_t& lambd_tensor_val,
+         bool early_exit) {
+           if (out_tensor_val >= -lambd_tensor_val && out_tensor_val <= lambd_tensor_val) {
+             out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
+           }
+  });
+}
+
+template <typename scalar_t>
+void hardshrink_backward_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor, const Tensor& self) {
+  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+      out_tensor,
+      lambd_tensor,
+      self,
+      [] __device__ (scalar_t& out_tensor_val,
+         scalar_t& lambd_tensor_val,
+         scalar_t& self_val) {
+           if (self_val >= -lambd_tensor_val && self_val <= lambd_tensor_val) {
+             out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
+           }
+  });
+}
+
+Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
+  auto lambd_tensor = at::zeros_like(self).fill_(lambd);
+  auto out_tensor = self.clone();
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
+    hardshrink_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor);
+  });
+  return out_tensor;
+}
+
+Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
+  auto lambd_tensor = at::zeros_like(self).fill_(lambd);
+  auto out_tensor = grad.clone();
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
+    using cuda_scalar_t = cuda::into_type<scalar_t>;
+    hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor, self);
+  });
+  return out_tensor;
+}
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -9,60 +9,48 @@
 namespace at { namespace native {
 
 template <typename scalar_t>
-void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, Tensor& lambd_tensor) {
-  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
-      self,
-      out_tensor,
-      lambd_tensor,
-      [] __device__ (scalar_t& self_val,
-        scalar_t& out_tensor_val,
-        scalar_t& lambd_tensor_val) {
-           if (self_val >= -lambd_tensor_val && self_val <= lambd_tensor_val) {
-             out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
-           }
-           else {
-             out_tensor_val = self_val;
-           }
+void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, scalar_t* lambd) {
+  at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t>(
+    self,
+    out_tensor,
+    [lambd] __device__ (
+      scalar_t& self_val,
+      scalar_t& out_tensor_val,
+      bool early_exit) {
+        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? ScalarConvert<double, scalar_t>::to(0.0) : self_val;
   });
 }
 
 template <typename scalar_t>
-void hardshrink_backward_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor, const Tensor& self, const Tensor& grad) {
-  at::cuda::CUDA_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
-      out_tensor,
-      lambd_tensor,
-      self,
-      grad,
-      [] __device__ (scalar_t& out_tensor_val,
-        scalar_t& lambd_tensor_val,
-        scalar_t& self_val,
-        scalar_t& grad_val) {
-           if (self_val >= -lambd_tensor_val && self_val <= lambd_tensor_val) {
-             out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
-           }
-           else {
-             out_tensor_val = grad_val;
-           }
+void hardshrink_backward_cuda_kernel(Tensor& out_tensor, scalar_t* lambd, const Tensor& self, const Tensor& grad) {
+  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+    self,
+    grad,
+    out_tensor,
+    [lambd] __device__ (
+      scalar_t& self_val,
+      scalar_t& grad_val,
+      scalar_t& out_tensor_val) {
+        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? ScalarConvert<double, scalar_t>::to(0.0) : grad_val;
   });
 }
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = at::zeros_like(self).fill_(lambd);
+  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::zeros_like(self);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
-    hardshrink_cuda_kernel<cuda_scalar_t>(self, out_tensor, lambd_tensor);
+    hardshrink_cuda_kernel<cuda_scalar_t>(self, out_tensor, lambd_tensor.data<cuda_scalar_t>());
   });
   return out_tensor;
 }
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
-  auto lambd_tensor = at::zeros_like(self).fill_(lambd);
-  // auto lambd_tensor = lambd.toTensor().toType(grad.type().scalarType()).toBackend(grad.is_cuda() ? Backend::CUDA : Backend::CPU);
+  auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
   auto out_tensor = at::zeros_like(grad);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
-    hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor, self, grad);
+    hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor.data<cuda_scalar_t>(), self, grad);
   });
   return out_tensor;
 }

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -9,50 +9,60 @@
 namespace at { namespace native {
 
 template <typename scalar_t>
-void hardshrink_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor) {
-  at::cuda::CUDA_tensor_apply2<scalar_t, scalar_t>(
+void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, Tensor& lambd_tensor) {
+  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+      self,
       out_tensor,
       lambd_tensor,
-      [] __device__ (scalar_t& out_tensor_val,
-         scalar_t& lambd_tensor_val,
-         bool early_exit) {
-           if (out_tensor_val >= -lambd_tensor_val && out_tensor_val <= lambd_tensor_val) {
+      [] __device__ (scalar_t& self_val,
+        scalar_t& out_tensor_val,
+        scalar_t& lambd_tensor_val) {
+           if (self_val >= -lambd_tensor_val && self_val <= lambd_tensor_val) {
              out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
+           }
+           else {
+             out_tensor_val = self_val;
            }
   });
 }
 
 template <typename scalar_t>
-void hardshrink_backward_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor, const Tensor& self) {
-  at::cuda::CUDA_tensor_apply3<scalar_t, scalar_t, scalar_t>(
+void hardshrink_backward_cuda_kernel(Tensor& out_tensor, Tensor& lambd_tensor, const Tensor& self, const Tensor& grad) {
+  at::cuda::CUDA_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
       out_tensor,
       lambd_tensor,
       self,
+      grad,
       [] __device__ (scalar_t& out_tensor_val,
-         scalar_t& lambd_tensor_val,
-         scalar_t& self_val) {
+        scalar_t& lambd_tensor_val,
+        scalar_t& self_val,
+        scalar_t& grad_val) {
            if (self_val >= -lambd_tensor_val && self_val <= lambd_tensor_val) {
              out_tensor_val = ScalarConvert<double, scalar_t>::to(0.0);
+           }
+           else {
+             out_tensor_val = grad_val;
            }
   });
 }
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
   auto lambd_tensor = at::zeros_like(self).fill_(lambd);
-  auto out_tensor = self.clone();
+  auto out_tensor = at::zeros_like(self);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
-    hardshrink_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor);
+    hardshrink_cuda_kernel<cuda_scalar_t>(self, out_tensor, lambd_tensor);
   });
   return out_tensor;
 }
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto lambd_tensor = at::zeros_like(self).fill_(lambd);
-  auto out_tensor = grad.clone();
+  // auto lambd_tensor = lambd.toTensor().toType(grad.type().scalarType()).toBackend(grad.is_cuda() ? Backend::CUDA : Backend::CPU);
+  auto out_tensor = at::zeros_like(grad);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
-    hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor, self);
+    hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor, self, grad);
   });
   return out_tensor;
 }

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -17,7 +17,7 @@ void hardshrink_cuda_kernel(const Tensor& self, Tensor& out_tensor, scalar_t* la
       scalar_t& self_val,
       scalar_t& out_tensor_val,
       bool early_exit) {
-        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? ScalarConvert<double, scalar_t>::to(0.0) : self_val;
+        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? scalar_cast<scalar_t>(0) : self_val;
   });
 }
 
@@ -31,13 +31,13 @@ void hardshrink_backward_cuda_kernel(Tensor& out_tensor, scalar_t* lambd, const 
       scalar_t& self_val,
       scalar_t& grad_val,
       scalar_t& out_tensor_val) {
-        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? ScalarConvert<double, scalar_t>::to(0.0) : grad_val;
+        out_tensor_val = (self_val >= -*lambd && self_val <= *lambd) ? scalar_cast<scalar_t>(0) : grad_val;
   });
 }
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
-  auto out_tensor = at::zeros_like(self);
+  auto out_tensor = at::empty_like(self);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
     hardshrink_cuda_kernel<cuda_scalar_t>(self, out_tensor, lambd_tensor.data<cuda_scalar_t>());
@@ -47,7 +47,7 @@ Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto lambd_tensor = lambd.toTensor().toType(self.type().scalarType()).toBackend(self.is_cuda() ? Backend::CUDA : Backend::CPU);
-  auto out_tensor = at::zeros_like(grad);
+  auto out_tensor = at::empty_like(grad);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
     using cuda_scalar_t = cuda::into_type<scalar_t>;
     hardshrink_backward_cuda_kernel<cuda_scalar_t>(out_tensor, lambd_tensor.data<cuda_scalar_t>(), self, grad);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -845,6 +845,16 @@
 
 - func: relu_(Tensor self) -> Tensor
 
+- func: hardshrink(Tensor self, Scalar lambd=0.5) -> Tensor
+  dispatch:
+    CPU: hardshrink_cpu
+    CUDA: hardshrink_cuda
+
+- func: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd=0.5) -> Tensor
+  dispatch:
+    CPU: hardshrink_backward_cpu
+    CUDA: hardshrink_backward_cuda
+
 - func: rsqrt(Tensor self) -> Tensor
 
 - func: rsqrt_(Tensor self) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -845,12 +845,14 @@
 
 - func: relu_(Tensor self) -> Tensor
 
-- func: hardshrink(Tensor self, Scalar lambd=0.5) -> Tensor
+# TODO: there is a bug in float values of Scalar, after bug fixes, set the default value of lambd=0.5
+# for now, getting around this with default values defined in torch/nn/functional.py
+- func: hardshrink(Tensor self, Scalar lambd) -> Tensor
   dispatch:
     CPU: hardshrink_cpu
     CUDA: hardshrink_cuda
 
-- func: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd=0.5) -> Tensor
+- func: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd) -> Tensor
   dispatch:
     CPU: hardshrink_backward_cpu
     CUDA: hardshrink_backward_cuda

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -72,11 +72,6 @@
   scalar_check:
     output: 'false'
 
-- name: hardshrink(Tensor self, Scalar lambd=0.5)
-  cname: HardShrink
-  scalar_check:
-    output: self_->isScalar()
-
 - name: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1)
   cname: HardTanh
   has_inplace: True

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -134,19 +134,6 @@ TH_API void THNN_(GatedLinear_updateGradInput)(
           THTensor *gradInput,         // [OUT] gradient w.r.t input
           int dim);                    // dimension for halving operation
 
-// HardShink outputs 0 on interval of (-lambda; lambda) or original value otherwise.
-TH_API void THNN_(HardShrink_updateOutput)(
-          THNNState *state,            // library's state
-          THTensor *input,             // input tensor
-          THTensor *output,            // [OUT] output tensor
-          accreal lambda);             // HardShrink parameter
-TH_API void THNN_(HardShrink_updateGradInput)(
-          THNNState *state,            // library's state
-          THTensor *input,             // input tensor
-          THTensor *gradOutput,        // gradient w.r.t. module's output
-          THTensor *gradInput,         // [OUT] gradient w.r.t. input
-          accreal lambda);             // HardShrink parameter
-
 // HardTanh clamps the values to the interval [min_val; max_val].
 TH_API void THNN_(HardTanh_updateOutput)(
           THNNState *state,            // library's state

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -89,9 +89,6 @@
 #include "generic/ELU.c"
 #include "THGenerateFloatTypes.h"
 
-#include "generic/HardShrink.c"
-#include "THGenerateFloatTypes.h"
-
 #include "generic/HardTanh.c"
 #include "THGenerateFloatTypes.h"
 

--- a/test/test_legacy_nn.py
+++ b/test/test_legacy_nn.py
@@ -618,6 +618,10 @@ def prepare_tests():
         test_params = deepcopy(test_params)
         name = test_params.pop('module_name')
         name = name_remap.get(name, name)
+        # hardshrink is deprecated in nn
+        if name == "HardShrink":
+            continue
+
         test_params['constructor'] = getattr(nn, name)
         test = OldModuleTest(**test_params)
         add_test(test)
@@ -625,6 +629,9 @@ def prepare_tests():
         test_params = deepcopy(test_params)
         name = test_params.pop('module_name')
         name = name_remap.get(name, name.replace('Loss', 'Criterion'))
+        # hardshrink is deprecated in nn
+        if name == "HardShrink":
+            continue
 
         # nn.NLLLoss2d is deprecated, but there is a NLLLoss test for 2d
         if name == 'ClassNLLCriterion' and 'desc' in test_params.keys() and '2d' in test_params['desc']:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -304,8 +304,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
             for p in module.parameters():
                 test_case.assertIsInstance(p, torch.DoubleTensor)
 
-            # TODO: Hardshrink is lacking a CUDA implementation
-            if TEST_CUDA and self.should_test_cuda and type(module) != nn.Hardshrink:
+            if TEST_CUDA and self.should_test_cuda:
                 # check that cuda() moves module parameters to correct GPU device,
                 # and that float() casts parameters correctly
 
@@ -363,7 +362,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
                 input = input.half().cuda()
                 module.half().cuda()
                 module(input)
-                for o in module.parameters():
+                for p in module.parameters():
                     test_case.assertIsInstance(p, torch.cuda.HalfTensor)
                     test_case.assertEqual(p.get_device(), 0)
 
@@ -5523,20 +5522,17 @@ def add_test(test, decorator=None):
 
     test_name = test.get_name()
     add(test_name, lambda self, test=test: test(self))
-    # Hardshrink is not implemented in CUDA, so we must not test it.
-    if not test_name.startswith("test_Hardshrink"):
-        cuda_test_name = test_name + '_cuda'
-        # With dtype enable, it's good enough to test against three floating types
-        if 'dtype' in get_function_arglist(test.test_cuda):
-            add(cuda_test_name + '_float', lambda self,
-                test=test: test.test_cuda(self, dtype=torch.float))
-            add(cuda_test_name + '_double', lambda self,
-                test=test: test.test_cuda(self, dtype=torch.double))
-            add(cuda_test_name + '_half', lambda self,
-                test=test: test.test_cuda(self, dtype=torch.half))
-        else:
-            add(cuda_test_name, lambda self, test=test: test.test_cuda(self))
-
+    cuda_test_name = test_name + '_cuda'
+    # With dtype enable, it's good enough to test against three floating types
+    if 'dtype' in get_function_arglist(test.test_cuda):
+        add(cuda_test_name + '_float', lambda self,
+            test=test: test.test_cuda(self, dtype=torch.float))
+        add(cuda_test_name + '_double', lambda self,
+            test=test: test.test_cuda(self, dtype=torch.double))
+        add(cuda_test_name + '_half', lambda self,
+            test=test: test.test_cuda(self, dtype=torch.half))
+    else:
+        add(cuda_test_name, lambda self, test=test: test.test_cuda(self))
 
 def wrap_functional(fn, **kwargs):
     class FunctionalModule(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5534,6 +5534,7 @@ def add_test(test, decorator=None):
     else:
         add(cuda_test_name, lambda self, test=test: test.test_cuda(self))
 
+
 def wrap_functional(fn, **kwargs):
     class FunctionalModule(nn.Module):
         def forward(self, *args):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5560,7 +5560,7 @@ class TestTorch(TestCase):
             self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink(0.5))
 
             # TODO: test default lambda (0.5)
-            # self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink())
+            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink())
 
             # test non-contiguous case
             self.assertEqual(torch.tensor([1, 0.3, 0.5, 0.6]).view(2, 2), data.t().hardshrink(0.1))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5555,15 +5555,15 @@ class TestTorch(TestCase):
         ]
         for t in float_types:
             data = data_original.type(t)
-            self.assertEqual(torch.tensor([1, 0.5, 0, 0.6]).view(2, 2), data.hardshrink(0.3))
-
-            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink(0.5))
-
-            # TODO: test default lambda (0.5)
-            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink())
+            self.assertEqual(torch.tensor([1, 0.5, 0, 0.6]).view(2, 2), torch.nn.Hardshrink(0.3)(data))
+            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), torch.nn.Hardshrink(0.5)(data))
+            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), torch.nn.Hardshrink()(data))
 
             # test non-contiguous case
-            self.assertEqual(torch.tensor([1, 0.3, 0.5, 0.6]).view(2, 2), data.t().hardshrink(0.1))
+            self.assertEqual(torch.tensor([1, 0.3, 0.5, 0.6]).view(2, 2), torch.nn.Hardshrink(0.1)(data.t()))
+
+            # not supporting default lambd value for torch.hardshrink() due to a Scalar bug
+            self.assertRaises(TypeError, lambda: data.hardshrink())
 
     def test_unbiased(self):
         tensor = torch.randn(100)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5547,6 +5547,24 @@ class TestTorch(TestCase):
         res = torch.LongTensor((-bignumber,))
         self.assertGreater(res.abs()[0], 0)
 
+    def test_hardshrink(self):
+        data_original = torch.tensor([1, 0.5, 0.3, 0.6]).view(2, 2)
+        float_types = [
+            'torch.DoubleTensor',
+            'torch.FloatTensor'
+        ]
+        for t in float_types:
+            data = data_original.type(t)
+            self.assertEqual(torch.tensor([1, 0.5, 0, 0.6]).view(2, 2), data.hardshrink(0.3))
+
+            self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink(0.5))
+
+            # TODO: test default lambda (0.5)
+            # self.assertEqual(torch.tensor([1, 0, 0, 0.6]).view(2, 2), data.hardshrink())
+
+            # test non-contiguous case
+            self.assertEqual(torch.tensor([1, 0.3, 0.5, 0.6]).view(2, 2), data.t().hardshrink(0.1))
+
     def test_unbiased(self):
         tensor = torch.randn(100)
         self.assertEqual(tensor.var(0), tensor.var(0, unbiased=True))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -491,9 +491,13 @@ class TestLuaReader(TestCase):
         long_size = 8 if sys.platform == 'win32' else None
         tests = load_lua(path, long_size=long_size)
         for name, test in tests['modules'].items():
+            if name == "HardShrink":
+                continue
             test_name = 'test_' + name.replace('nn.', '')
             setattr(cls, test_name, cls._module_test(name, test))
         for name, test in tests['criterions'].items():
+            if name == "HardShrink":
+                continue
             test_name = 'test_' + name.replace('nn.', '')
             setattr(cls, test_name, cls._criterion_test(name, test))
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -752,8 +752,12 @@
 - name: glu_forward(Tensor self, int64_t dim)
   self: glu_backward(grad, self, dim)
 
-- name: hardshrink_forward(Tensor self, Scalar lambd)
+- name: hardshrink(Tensor self, Scalar lambd)
   self: hardshrink_backward(grad, self, lambd)
+
+- name: hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd)
+  grad_out: hardshrink_backward(grad, self, lambd)
+  self: zeros_like(grad)
 
 - name: hardtanh_forward(Tensor self, Scalar min_val, Scalar max_val)
   self: hardtanh_backward(grad, self, min_val, max_val)
@@ -951,10 +955,6 @@
 - name: glu_backward(Tensor grad_output, Tensor self, int64_t dim)
   grad_output: glu_double_backward_grad_output(grad, self, dim)
   self: glu_double_backward(grad, grad_output, self, dim)
-
-- name: hardshrink_backward(Tensor grad_output, Tensor self, Scalar lambd)
-  grad_output: hardshrink_backward(grad, self, lambd)
-  self: zeros_like(grad)
 
 - name: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val)
   grad_output: hardtanh_backward(grad, self, min_val, max_val)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -777,13 +777,16 @@ Applies element-wise :math:`\text{LogSigmoid}(x) = \log \left(\frac{1}{1 + \exp(
 See :class:`~torch.nn.LogSigmoid` for more details.
 """)
 
-hardshrink = _add_docstr(torch._C._nn.hardshrink, r"""
-hardshrink(input, lambd=0.5) -> Tensor
 
-Applies the hard shrinkage function element-wise
+def hardshrink(input, lambd=0.5):
+    r"""
+    hardshrink(input, lambd=0.5) -> Tensor
 
-See :class:`~torch.nn.Hardshrink` for more details.
-""")
+    Applies the hard shrinkage function element-wise
+
+    See :class:`~torch.nn.Hardshrink` for more details.
+    """
+    return torch.hardshrink(input, lambd)
 
 
 def tanhshrink(input):


### PR DESCRIPTION
## Summary:
1. Added hardshrink() to ATen (CPU + GPU)
2. Removed nn.Hardshrink(), but keeping file "aten/src/THNN/generic/HardShrink.c"
3. Reusing nn.Hardshrink() tests in test_nn and including CUDA tests. Not sure test_nn is a good place for hardshrink() since it is no longer under nn
4. Added tests in test_torch

This replaces #7695, fixes #4154

## Future work:
1. not supporting default lambd=0.5 in torch.hardshrink() due to a Scalar bug #8484


## Performance:

### CPU forward:

Previous impl:
```python
large_data = torch.zeros(1000, 1000).fill_(0.3).requires_grad_()
def origfn(data):
  f = torch.nn.Hardshrink(0.3)
  large_out = f(data)
%timeit origfn(large_data) 
####################
100 loops, best of 3: 2.15 ms per loop
```

Current impl:
```python
large_data = torch.zeros(1000, 1000).fill_(0.3).requires_grad_()
def newfn(data):
    large_out = data.hardshrink(0.3)
%timeit newfn(large_data)
####################
100 loops, best of 3: 2.62 ms per loop
```

### CPU backward:

Previous impl:
```python
large_data = torch.zeros(1000, 1000).fill_(0.3).requires_grad_()
def origfn_backward(data):
    f = torch.nn.Hardshrink(0.3)
    large_out = f(data)
    large_out.sum().backward()
%timeit origfn_backward(large_data)
####################
100 loops, best of 3: 5.2 ms per loop
```

Current impl:
```python
large_data = torch.zeros(1000, 1000).fill_(0.3).requires_grad_()
def newfn_backward(data):
    large_out = data.hardshrink(0.3)
    large_out.sum().backward()
%timeit newfn_backward(large_data)
####################
100 loops, best of 3: 6.47 ms per loop
```

### CUDA:

Current impl:
```python
large_data = torch.zeros(1000, 1000, device=cuda).fill_(0.3)
%timeit data.hardshrink(0.3)
####################
10000 loops, best of 3: 97.1 µs per loop
```

Benchmark:
```python
large_data = torch.zeros(1000, 1000, device=cuda).fill_(0.3)
%timeit data.mul_(2)
####################
10000 loops, best of 3: 51.6 µs per loop
```