### PR TITLE
[WIP] [PyTorch] [STFT] use fft when fft_size == frame_length

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -169,21 +169,19 @@ Tensor irfft(const Tensor& self, const int64_t signal_ndim, const bool normalize
 }
 
 
-Tensor stft(const Tensor& self, const int64_t frame_length,
-                                const int64_t hop, const int64_t fft_size,
-                                const bool normalized, const bool onesided,
-                                const Tensor& window, const int64_t pad_end) {
+Tensor stft(const Tensor& self, const int64_t n_fft, const int64_t hop_length,
+            const int64_t win_length, const Tensor& window,
+            const bool normalized, const bool onesided) {
   #define REPR(SS) \
-    SS << "stft(" << self.type() << self.sizes() << ", frame_length=" \
-       << frame_length << ", hop=" << hop << ", fft_size=" << fft_size \
-       << ", normalized=" << normalized << ", onesided=" << onesided << \
-       ", window="; \
+    SS << "stft(" << self.type() << self.sizes() << ", n_fft=" << n_fft \
+       << ", hop_length=" << hop_length << ", win_length=" << win_length \
+       << ", window="; \
     if (window.defined()) { \
       SS << window.type() << "{" << window.sizes() << "}"; \
     } else { \
       SS << "None"; \
     } \
-    SS << ", pad_end=" << pad_end << ")"
+    SS << ", normalized=" << normalized << ", onesided=" << onesided << ")"
 
   if (!at::isFloatingType(self.type().scalarType()) || self.dim() > 2 || self.dim() < 1) {
     std::ostringstream ss;
@@ -196,82 +194,51 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
   }
   int64_t batch = input.size(0);
   int64_t len = input.size(1);
-  if (pad_end < 0) {
+  if (n_fft <= 0 || n_fft > len) {
     std::ostringstream ss;
-    REPR(ss) << ": expected pad_end >= 0, but got pad_end=" << pad_end;
+    REPR(ss) << ": expected 0 < n_fft < " << len
+             << ", but got n_fft=" << win_length;
     throw std::runtime_error(ss.str());
   }
-  // pad zeros
-  if (pad_end != 0) {
-    Tensor padded_input = at::empty(self.type(), {batch, len + pad_end});
-    padded_input.narrow(1, 0, len).copy_(input);
-    padded_input.narrow(1, len, pad_end).zero_();
-    len += pad_end;
-    input = padded_input;
-  }
-  if (frame_length <= 0 || frame_length > len) {
+  if (hop_length <= 0) {
     std::ostringstream ss;
-    REPR(ss) << ": expected 0 < frame_length < " << len
-             << ", but got frame_length=" << frame_length;
+    REPR(ss) << ": expected hop_length > 0, but got hop_length=" << hop_length;
     throw std::runtime_error(ss.str());
   }
-  if (hop <= 0) {
+  if (win_length <= 0 || win_length > n_fft) {
     std::ostringstream ss;
-    REPR(ss) << ": expected hop > 0, but got hop=" << hop;
+    REPR(ss) << ": expected 0 < win_length <= n_fft, but got win_length="
+             << win_length;
     throw std::runtime_error(ss.str());
   }
-  if (fft_size <= 0) {
-    std::ostringstream ss;
-    REPR(ss) << ": expected fft_size > 0, but got fft_size=" << fft_size;
-    throw std::runtime_error(ss.str());
-  }
-  if (window.defined() && (window.dim() != 1 || window.size(0) != frame_length)) {
+  if (window.defined() && (window.dim() != 1 || window.size(0) != win_length)) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D window tensor of size equal to "
-             << "frame_length=" << frame_length
+             << "win_length=" << win_length
              << ", but got window with size " << window.sizes();
     throw std::runtime_error(ss.str());
   }
   #undef REPR
-  // two cases:
-  //   1. frame_length == fft_size
-  //      use fft
-  //   2. frame_length != fft_size
-  //      use conv1d
-  Tensor out;
-  if (frame_length == fft_size) {
-    int64_t n_frames = 1 + (len - frame_length) / hop;
-    input = input.as_strided({batch, n_frames, frame_length}, {input.stride(0), hop * input.stride(1), input.stride(1)});
+  auto window_ = window;
+  if (win_length < n_fft) {
+    // pad center
+    window_ = at::zeros(self.type(), {n_fft});
+    auto left = (n_fft - win_length) / 2;
     if (window.defined()) {
-      input = input.mul(window);
+      window_.narrow(0, left, win_length).copy_(window);
+    } else {
+      window_.narrow(0, left, win_length).fill_(1);
     }
-    out = input.rfft(1, normalized, onesided);
-  } else {
-    int64_t return_size = onesided ? infer_ft_real_to_complex_onesided_size(fft_size) : fft_size;
-    // build ft kernel
-    // k[omega, t] = cos (2 pi omega t / N) - j sin (2 pi omega t / N)
-    double N = static_cast<double>(fft_size);
-    auto freq_arange = at::arange(self.type(), 0, return_size).mul_(M_PI * 2. / N);
-    auto time_arange = at::arange(self.type(), 0, frame_length);
-    auto arange_2d = at::ger(freq_arange, time_arange);
-    auto re_kernel = arange_2d.cos();
-    auto im_kernel = arange_2d.sin().neg_();
-    auto kernel = at::cat({re_kernel, im_kernel}, 0);
-    if (window.defined()) {
-      kernel.mul_(window.view({1, -1}));
-    }
-    if (normalized) {
-      double T = static_cast<double>(frame_length);
-      kernel.div_(std::sqrt(T));
-    }
-    // prepare for conv1d
-    input = input.view({batch, 1, len});
-    kernel = kernel.view({return_size * 2, 1, frame_length});
-    // conv is actually correlation, so we are good
-    auto conv_out = at::conv1d(input, kernel, {}, hop).squeeze_(-1);
-    // transpose to [batch x time x freq x (re/im)]
-    out = conv_out.view({batch, 2, return_size, -1}).transpose_(1, -1);
   }
+  int64_t n_frames = 1 + (len - n_fft) / hop_length;
+  input = input.as_strided(
+    {batch, n_frames, n_fft},
+    {input.stride(0), hop_length * input.stride(1), input.stride(1)}
+  );
+  if (window_.defined()) {
+    input = input.mul(window_);
+  }
+  auto out = input.rfft(1, normalized, onesided);
   if (self.dim() == 1) {
     return out.squeeze_(0);
   } else {

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -203,8 +203,9 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
   }
   // pad zeros
   if (pad_end != 0) {
-    Tensor padded_input = at::zeros(self.type(), {batch, len + pad_end});
+    Tensor padded_input = at::empty(self.type(), {batch, len + pad_end});
     padded_input.narrow(1, 0, len).copy_(input);
+    padded_input.narrow(1, len, pad_end).zero_();
     len += pad_end;
     input = padded_input;
   }
@@ -216,12 +217,12 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
   }
   if (hop <= 0) {
     std::ostringstream ss;
-    REPR(ss) << " expected hop > 0, but got hop=" << hop;
+    REPR(ss) << ": expected hop > 0, but got hop=" << hop;
     throw std::runtime_error(ss.str());
   }
   if (fft_size <= 0) {
     std::ostringstream ss;
-    REPR(ss) << " expected fft_size > 0, but got fft_size=" << fft_size;
+    REPR(ss) << ": expected fft_size > 0, but got fft_size=" << fft_size;
     throw std::runtime_error(ss.str());
   }
   if (window.defined() && (window.dim() != 1 || window.size(0) != frame_length)) {
@@ -232,30 +233,45 @@ Tensor stft(const Tensor& self, const int64_t frame_length,
     throw std::runtime_error(ss.str());
   }
   #undef REPR
-  int64_t return_size = onesided ? infer_ft_real_to_complex_onesided_size(fft_size) : fft_size;
-  // build ft kernel
-  // k[omega, t] = cos (2 pi omega t / N) - j sin (2 pi omega t / N)
-  double N = static_cast<double>(fft_size);
-  auto freq_arange = at::arange(self.type(), 0, return_size).mul_(M_PI * 2. / N);
-  auto time_arange = at::arange(self.type(), 0, frame_length);
-  auto arange_2d = at::ger(freq_arange, time_arange);
-  auto re_kernel = arange_2d.cos();
-  auto im_kernel = arange_2d.sin().neg_();
-  auto kernel = at::cat({re_kernel, im_kernel}, 0);
-  if (window.defined()) {
-    kernel *= window.view({1, -1});
+  // two cases:
+  //   1. frame_length == fft_size
+  //      use fft
+  //   2. frame_length != fft_size
+  //      use conv1d
+  Tensor out;
+  if (frame_length == fft_size) {
+    int64_t n_frames = 1 + (len - frame_length) / hop;
+    input = input.as_strided({batch, n_frames, frame_length}, {input.stride(0), hop * input.stride(1), input.stride(1)});
+    if (window.defined()) {
+      input = input.mul(window);
+    }
+    out = input.rfft(1, normalized, onesided);
+  } else {
+    int64_t return_size = onesided ? infer_ft_real_to_complex_onesided_size(fft_size) : fft_size;
+    // build ft kernel
+    // k[omega, t] = cos (2 pi omega t / N) - j sin (2 pi omega t / N)
+    double N = static_cast<double>(fft_size);
+    auto freq_arange = at::arange(self.type(), 0, return_size).mul_(M_PI * 2. / N);
+    auto time_arange = at::arange(self.type(), 0, frame_length);
+    auto arange_2d = at::ger(freq_arange, time_arange);
+    auto re_kernel = arange_2d.cos();
+    auto im_kernel = arange_2d.sin().neg_();
+    auto kernel = at::cat({re_kernel, im_kernel}, 0);
+    if (window.defined()) {
+      kernel.mul_(window.view({1, -1}));
+    }
+    if (normalized) {
+      double T = static_cast<double>(frame_length);
+      kernel.div_(std::sqrt(T));
+    }
+    // prepare for conv1d
+    input = input.view({batch, 1, len});
+    kernel = kernel.view({return_size * 2, 1, frame_length});
+    // conv is actually correlation, so we are good
+    auto conv_out = at::conv1d(input, kernel, {}, hop).squeeze_(-1);
+    // transpose to [batch x time x freq x (re/im)]
+    out = conv_out.view({batch, 2, return_size, -1}).transpose_(1, -1);
   }
-  if (normalized) {
-    double T = static_cast<double>(frame_length);
-    kernel.div_(std::sqrt(T));
-  }
-  // prepare for conv1d
-  input = input.view({batch, 1, len});
-  kernel = kernel.view({return_size * 2, 1, frame_length});
-  // conv is actually correlation, so we are good
-  auto conv_out = at::conv1d(input, kernel, {}, hop).squeeze_(-1);
-  // transpose to [batch x time x freq x (re/im)]
-  auto out = conv_out.view({batch, 2, return_size, -1}).transpose_(1, -1);
   if (self.dim() == 1) {
     return out.squeeze_(0);
   } else {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -965,9 +965,10 @@
 - func: stack_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor
   variants: function
 
-- func: stft(Tensor self, int64_t frame_length, int64_t hop, int64_t fft_size, bool normalized=false, bool onesided=true, Tensor? window={}, int64_t pad_end=0) -> Tensor
+- func: stft(Tensor self, int64_t n_fft, int64_t hop_length, int64_t win_length, Tensor? window={}, bool normalized=false, bool onesided=true) -> Tensor
   python_default_init:
-    fft_size: frame_length
+    hop_length: n_fft >> 2
+    win_length: n_fft
 
 - func: stride(Tensor self, int64_t dim) -> int64_t
 

--- a/test/common.py
+++ b/test/common.py
@@ -67,6 +67,12 @@ try:
 except ImportError:
     TEST_SCIPY = False
 
+TEST_LIBROSA = True
+try:
+    import librosa
+except ImportError:
+    TEST_LIBROSA = False
+
 TEST_MKL = torch.backends.mkl.is_available()
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -18,14 +18,18 @@ from torch._utils import _rebuild_tensor
 from itertools import product, combinations
 from functools import reduce
 from torch import multiprocessing as mp
-from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
-    run_tests, download_file, skipIfNoLapack, suppress_warnings, IS_WINDOWS, PY3
+from common import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_LIBROSA, \
+    TEST_MKL, run_tests, download_file, skipIfNoLapack, suppress_warnings, \
+    IS_WINDOWS, PY3
 
 if TEST_NUMPY:
     import numpy as np
 
 if TEST_SCIPY:
     from scipy import signal
+
+if TEST_LIBROSA:
+    import librosa
 
 SIZE = 100
 
@@ -4204,100 +4208,61 @@ class TestTorch(TestCase):
 
     @staticmethod
     def _test_stft(self, device='cpu'):
-        def naive_stft(x, frame_length, hop, fft_size=None, normalized=False,
-                       onesided=True, window=None, pad_end=0):
-            if fft_size is None:
-                fft_size = frame_length
-            x = x.clone()
+        if not TEST_LIBROSA:
+            raise unittest.SkipTest('librosa not found')
+
+        def librosa_stft(x, n_fft, hop_length, win_length, window, center):
             if window is None:
-                window = x.new_ones(frame_length)
+                window = np.ones(n_fft if win_length is None else win_length)
             else:
-                window = window.clone()
+                window = window.cpu().numpy()
             input_1d = x.dim() == 1
             if input_1d:
                 x = x.view(1, -1)
-            batch = x.size(0)
-            if pad_end > 0:
-                x_pad = x.new(batch, pad_end).fill_(0)
-                x = torch.cat([x, x_pad], 1)
-            length = x.size(1)
-            if TEST_NUMPY and TEST_SCIPY:
-                sp_result = signal.stft(
-                    x,
-                    nperseg=frame_length,
-                    noverlap=frame_length - hop,
-                    window=window,
-                    nfft=fft_size,
-                    return_onesided=onesided,
-                    boundary=None,
-                    padded=False,
-                )[2].transpose((0, 2, 1)) * np.abs(window.sum().item())
-                result = torch.Tensor(np.stack([sp_result.real, sp_result.imag], -1))
-            else:
-                if onesided:
-                    return_size = int(fft_size / 2) + 1
-                else:
-                    return_size = fft_size
-                result = x.new(batch, int((length - frame_length) / float(hop)) + 1, return_size, 2)
-                for w in range(return_size):  # freq
-                    radians = torch.arange(float(frame_length)) * w * 2 * math.pi / fft_size
-                    radians = radians.type_as(x)
-                    re_kernel = radians.cos().mul_(window)
-                    im_kernel = -radians.sin().mul_(window)
-                    for b in range(batch):
-                        for i, t in enumerate(range(0, length - frame_length + 1, hop)):
-                            seg = x[b, t:(t + frame_length)]
-                            re = seg.dot(re_kernel)
-                            im = seg.dot(im_kernel)
-                            result[b, i, w, 0] = re
-                            result[b, i, w, 1] = im
-            if normalized:
-                result /= frame_length ** 0.5
+            result = []
+            for xi in x:
+                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center).T
+                result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
+            result = torch.stack(result, 0)
             if input_1d:
                 result = result[0]
             return result
 
-        def _test(sizes, frame_length, hop, fft_size=None, normalized=False,
-                  onesided=True, window_sizes=None, pad_end=0, expected_error=None):
+        def _test(sizes, n_fft, hop_length=None, win_length=None, win_sizes=None,
+                  center=True, expected_error=None):
             x = torch.randn(*sizes, device=device)
-            if window_sizes is not None:
-                window = torch.randn(*window_sizes, device=device)
+            if win_sizes is not None:
+                window = torch.randn(*win_sizes, device=device)
             else:
                 window = None
             if expected_error is None:
-                result = x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end)
-                ref_result = naive_stft(x, frame_length, hop, fft_size, normalized, onesided, window, pad_end)
-                self.assertEqual(result, ref_result, 7e-6, 'stft result')
+                result = x.stft(n_fft, hop_length, win_length, window, center=center)
+                ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
+                self.assertEqual(result, ref_result, 7e-6, 'stft comparison against librosa')
             else:
                 self.assertRaises(expected_error,
-                                  lambda: x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end))
+                                  lambda: x.stft(n_fft, hop_length, win_length, window, center=center))
 
-        for normalized, onesided in product([True, False], repeat=2):
-            for pad_end in [0, 3]:
-                kwargs = dict(normalized=normalized, onesided=onesided, pad_end=pad_end)
+        for center in [True, False]:
+            _test((10,), 7, center=center)
+            _test((10, 4000), 1024, center=center)
 
-                _test((2, 5), 4, 2, **kwargs)
-                _test((4, 150), 90, 45, **kwargs)
-                _test((10,), 7, 2, **kwargs)
-                _test((10, 4000), 1024, 512, **kwargs)
+            _test((10,), 7, 2, center=center)
+            _test((10, 4000), 1024, 512, center=center)
 
-                _test((2, 5), 4, 2, window_sizes=(4,), **kwargs)
-                _test((4, 150), 90, 45, window_sizes=(90,), **kwargs)
-                _test((10,), 7, 2, window_sizes=(7,), **kwargs)
-                _test((10, 4000), 1024, 512, window_sizes=(1024,), **kwargs)
+            _test((10,), 7, 2, win_sizes=(7,), center=center)
+            _test((10, 4000), 1024, 512, win_sizes=(1024,), center=center)
 
-                _test((2, 5), 4, 2, fft_size=5, window_sizes=(4,), **kwargs)
-                _test((4, 150), 90, 45, fft_size=100, window_sizes=(90,), **kwargs)
-                _test((10,), 7, 2, fft_size=33, window_sizes=(7,), **kwargs)
-                _test((10, 4000), 1024, 512, fft_size=1500, window_sizes=(1024,), **kwargs)
+            # spectral oversample
+            _test((10,), 7, 2, win_length=5, center=center)
+            _test((10, 4000), 1024, 512, win_length=100, center=center)
 
         _test((10, 4, 2), 1, 1, expected_error=RuntimeError)
-        _test((10,), 11, 1, expected_error=RuntimeError)
-        _test((10,), 0, 1, pad_end=4, expected_error=RuntimeError)
-        _test((10,), 15, 1, pad_end=4, expected_error=RuntimeError)
-        _test((10,), 5, -4, expected_error=RuntimeError)
-        _test((10,), 5, 4, window_sizes=(11,), expected_error=RuntimeError)
-        _test((10,), 5, 4, window_sizes=(1, 1), expected_error=RuntimeError)
+        _test((10,), 11, 1, center=False, expected_error=RuntimeError)
+        _test((10,), -1, 1, expected_error=RuntimeError)
+        _test((10,), 3, win_length=5, expected_error=RuntimeError)
+        _test((10,), 5, 4, win_sizes=(11,), expected_error=RuntimeError)
+        _test((10,), 5, 4, win_sizes=(1, 1), expected_error=RuntimeError)
 
     def test_stft(self):
         self._test_stft(self)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4267,35 +4267,29 @@ class TestTorch(TestCase):
             if expected_error is None:
                 result = x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end)
                 ref_result = naive_stft(x, frame_length, hop, fft_size, normalized, onesided, window, pad_end)
-                self.assertEqual(result.data, ref_result, 7e-6, 'stft result')
+                self.assertEqual(result, ref_result, 7e-6, 'stft result')
             else:
                 self.assertRaises(expected_error,
                                   lambda: x.stft(frame_length, hop, fft_size, normalized, onesided, window, pad_end))
 
-        _test((2, 5), 4, 2, pad_end=1)
-        _test((4, 150), 90, 45, pad_end=0)
-        _test((10,), 7, 2, pad_end=0)
-        _test((10, 4000), 1024, 512, pad_end=0)
+        for normalized, onesided in product([True, False], repeat=2):
+            for pad_end in [0, 3]:
+                kwargs = dict(normalized=normalized, onesided=onesided, pad_end=pad_end)
 
-        _test((2, 5), 4, 2, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, **kwargs)
+                _test((4, 150), 90, 45, **kwargs)
+                _test((10,), 7, 2, **kwargs)
+                _test((10, 4000), 1024, 512, **kwargs)
 
-        _test((2, 5), 4, 2, fft_size=5, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, window_sizes=(4,), **kwargs)
+                _test((4, 150), 90, 45, window_sizes=(90,), **kwargs)
+                _test((10,), 7, 2, window_sizes=(7,), **kwargs)
+                _test((10, 4000), 1024, 512, window_sizes=(1024,), **kwargs)
 
-        _test((2, 5), 4, 2, fft_size=5, onesided=False, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, onesided=False, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, onesided=False, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, onesided=False, window_sizes=(1024,), pad_end=0)
-
-        _test((2, 5), 4, 2, fft_size=5, normalized=True, onesided=False, window_sizes=(4,), pad_end=1)
-        _test((4, 150), 90, 45, fft_size=100, normalized=True, onesided=False, window_sizes=(90,), pad_end=0)
-        _test((10,), 7, 2, fft_size=33, normalized=True, onesided=False, window_sizes=(7,), pad_end=0)
-        _test((10, 4000), 1024, 512, fft_size=1500, normalized=True, onesided=False, window_sizes=(1024,), pad_end=0)
+                _test((2, 5), 4, 2, fft_size=5, window_sizes=(4,), **kwargs)
+                _test((4, 150), 90, 45, fft_size=100, window_sizes=(90,), **kwargs)
+                _test((10,), 7, 2, fft_size=33, window_sizes=(7,), **kwargs)
+                _test((10, 4000), 1024, 512, fft_size=1500, window_sizes=(1024,), **kwargs)
 
         _test((10, 4, 2), 1, 1, expected_error=RuntimeError)
         _test((10,), 11, 1, expected_error=RuntimeError)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3701,10 +3701,11 @@ Args:
     end (Number): the ending value for the set of points
     step (Number): the gap between each pair of adjacent points. Default: ``1``.
     {out}
-    {dtype}  If `dtype` is not given, infer the data type from the other input arguments.
-             If any of `start`, `end`, or `stop` are floating-point,
-             the `dtype` is inferred to be the default dtype, see :meth:`~torch.get_default_dtype`.
-             Otherwise, the `dtype` is inferred to be `torch.int64`.
+    {dtype} If `dtype` is not given, infer the data type from the other input
+        arguments. If any of `start`, `end`, or `stop` are floating-point, the
+        `dtype` is inferred to be the default dtype, see
+        :meth:`~torch.get_default_dtype`. Otherwise, the `dtype` is inferred to
+        be `torch.int64`.
     {layout}
     {device}
     {requires_grad}
@@ -5000,58 +5001,6 @@ Args:
     {device}
     {requires_grad}
 """.format(**factory_like_common_args))
-
-add_docstr(torch.stft,
-           r"""
-stft(signal, frame_length, hop, fft_size=None, normalized=False, onesided=True, window=None, pad_end=0) -> Tensor
-
-Short-time Fourier transform (STFT).
-
-Ignoring the batch dimension, this method computes the following expression:
-
-.. math::
-    X[m, \omega] = \sum_{k = 0}^{\text{frame_length}}%
-                        window[k]\ signal[m \times hop + k]\ e^{- j \frac{2 \pi \cdot \omega k}{\text{frame_length}}},
-
-where :math:`m` is the index of the sliding window, and :math:`\omega` is
-the frequency that :math:`0 \leq \omega <` :attr:`fft_size`. When
-:attr:`return_onsesided` is the default value ``True``, only values for
-:math:`\omega` in range :math:`\left[0, 1, 2, \dots, \left\lfloor \frac{\text{fft_size}}{2} \right\rfloor + 1\right]`
-are returned because the real-to-complex transform satisfies the Hermitian
-symmetry, i.e., :math:`X[m, \omega] = X[m, \text{fft_size} - \omega]^*`.
-
-The input :attr:`signal` must be 1-D sequence :math:`(T)` or 2-D a batch of
-sequences :math:`(N \times T)`. If :attr:`fft_size` is ``None``, it is
-default to same value as  :attr:`frame_length`. :attr:`window` can be a
-1-D tensor of size :attr:`frame_length`, e.g., see
-:meth:`torch.hann_window`. If :attr:`window` is the default value ``None``,
-it is treated as if having :math:`1` everywhere in the frame.
-:attr:`pad_end` indicates the amount of zero padding at the end of
-:attr:`signal` before STFT. If :attr:`normalized` is set to ``True``, the
-function returns the normalized STFT results, i.e., multiplied by
-:math:`(frame\_length)^{-0.5}`.
-
-Returns the real and the imaginary parts together as one tensor of size
-:math:`(* \times N \times 2)`, where :math:`*` is the shape of input :attr:`signal`,
-:math:`N` is the number of :math:`\omega` s considered depending on
-:attr:`fft_size` and :attr:`return_onesided`, and each pair in the last
-dimension represents a complex number as real part and imaginary part.
-
-Arguments:
-    signal (Tensor): the input tensor
-    frame_length (int): the size of window frame and STFT filter
-    hop (int): the distance between neighboring sliding window frames
-    fft_size (int, optional): size of Fourier transform. Default: ``None``
-    normalized (bool, optional): controls whether to return the normalized STFT results
-         Default: ``False``
-    onesided (bool, optional): controls whether to return half of results to
-        avoid redundancy Default: ``True``
-    window (Tensor, optional): the optional window function. Default: ``None``
-    pad_end (int, optional): implicit zero padding at the end of :attr:`signal`. Default: 0
-
-Returns:
-    Tensor: A tensor containing the STFT result
-""")
 
 add_docstr(torch.det,
            r"""

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 from operator import mul
 from functools import reduce
 import math
@@ -10,6 +11,7 @@ __all__ = [
     'btriunpack',
     'isnan',
     'split',
+    'stft',
     'unbind',
     'unique',
 ]
@@ -146,6 +148,67 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
         P = None
 
     return P, L, U
+
+
+def stft(input, n_fft, hop_length=None, win_length=None, window=None,
+         center=True, pad_mode='reflect', normalized=False, onesided=True):
+    r"""Short-time Fourier transform (STFT).
+
+    Ignoring the batch dimension, this method computes the following expression:
+
+    .. math::
+        X[m, \omega] = \sum_{k = 0}^{\text{win_length}}%
+                            window[k]\ input[m \times hop_length + k]\ %
+                            e^{- j \frac{2 \pi \cdot \omega k}{\text{win_length}}},
+
+    where :math:`m` is the index of the sliding window, and :math:`\omega` is
+    the frequency that :math:`0 \leq \omega <` :attr:`n_fft`. When
+    :attr:`onesided` is the default value ``True``, only values for
+    :math:`\omega` in range :math:`\left[0, 1, 2, \dots, \left\lfloor \frac{\text{n_fft}}{2} \right\rfloor + 1\right]`
+    are returned because the real-to-complex transform satisfies the Hermitian
+    symmetry, i.e., :math:`X[m, \omega] = X[m, \text{n_fft} - \omega]^*`.
+
+    The :attr:`input` tensor must be 1-D sequence :math:`(T)` or 2-D a batch of
+    sequences :math:`(N \times T)`. If :attr:`win_length` is ``None``, it is
+    default to same value as :attr:`n_fft`. :attr:`window` can be a
+    1-D tensor of size :attr:`win_length`, e.g., see
+    :meth:`torch.hann_window`. If :attr:`window` is the default value ``None``,
+    it is treated as if having :math:`1` everywhere in the frame.
+    :attr:`pad_end` indicates the amount of zero padding at the end of
+    :attr:`input` before STFT. If :attr:`normalized` is set to ``True``, the
+    function returns the normalized STFT results, i.e., multiplied by
+    :math:`(frame\_length)^{-0.5}`.
+
+    Returns the real and the imaginary parts together as one tensor of size
+    :math:`(* \times N \times 2)`, where :math:`*` is the shape of input :attr:`input`,
+    :math:`N` is the number of :math:`\omega` s considered depending on
+    :attr:`n_fft` and :attr:`return_onesided`, and each pair in the last
+    dimension represents a complex number as real part and imaginary part.
+
+    Arguments:
+        input (Tensor): the input tensor
+        win_length (int): the size of window frame and STFT filter
+        hop_length (int): the distance between neighboring sliding window frames
+        n_fft (int, optional): size of Fourier transform. Default: ``None``
+        normalized (bool, optional): controls whether to return the normalized STFT results
+             Default: ``False``
+        onesided (bool, optional): controls whether to return half of results to
+            avoid redundancy Default: ``True``
+        window (Tensor, optional): the optional window function. Default: ``None``
+        pad_end (int, optional): implicit zero padding at the end of :attr:`input`. Default: 0
+
+    Returns:
+        Tensor: A tensor containing the STFT result
+    """
+    # TODO: after having proper ways to map Python strings to ATen Enum, move
+    #       this and F.pad to ATen.
+    if center:
+        signal_dim = input.dim()
+        extended_shape = [1] * (3 - signal_dim) + list(input.size())
+        pad = int(n_fft // 2)
+        input = F.pad(input.view(extended_shape), (pad, pad), pad_mode)
+        input = input.view(input.shape[-signal_dim:])
+    return torch._C._VariableFunctions.stft(input, n_fft, hop_length, win_length, window, normalized, onesided)
 
 
 def isnan(tensor):

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -251,6 +251,13 @@ class Tensor(torch._C._TensorBase):
         else:
             return super(Tensor, self).btrifact(pivot=pivot)
 
+    def stft(self, n_fft, hop_length=None, win_length=None, window=None,
+             center=True, pad_mode='reflect', normalized=False, onesided=True):
+        r"""See :func:`torch.stft`
+        """
+        return torch.stft(self, n_fft, hop_length, win_length, window, center,
+                          pad_mode, normalized, onesided)
+
     def resize(self, *sizes):
         warnings.warn("non-inplace resize is deprecated")
         from torch.autograd._functions import Resize


### PR DESCRIPTION
Addresses #7883 
Using script in #7883 , here are the new timings:
```
librosa: 1.918302297592163
(2049, 2647)
torch: 0.34431028366088867
torch.Size([10, 2639, 2049])
```
The output shape difference is expected as explained in https://github.com/pytorch/pytorch/issues/7038 .

