### PR TITLE
Replace most remaining usages of TensorUtils<T>::DataType.

### DIFF
--- a/aten/src/THC/THCTensorIndex.cu
+++ b/aten/src/THC/THCTensorIndex.cu
@@ -457,7 +457,7 @@ void dispatchTakePutImpl(THCState *state, TensorType *a, TensorType *b, THCudaLo
   auto start = THCudaLongTensor_data(state, index);
   auto end = start + THCudaLongTensor_numel(state, index);
 
-  auto aInfo = getTensorInfo<TensorType, IndexType>(state, a);
+  auto aInfo = getTensorInfo<real, TensorType, IndexType>(state, a);
   aInfo.collapseDims();
   auto numel = TensorUtils<TensorType>::getNumElements(state, a);
   if (aInfo.isContiguous()) {

--- a/aten/src/THC/THCTensorMathReduce.cu
+++ b/aten/src/THC/THCTensorMathReduce.cu
@@ -5,10 +5,10 @@ THC_API int
 THCudaByteTensor_logicalAndAll(THCState *state, THCudaByteTensor *self) {
   THCAssertSameGPU(THCudaByteTensor_checkGPU(state, 1, self));
   unsigned char result;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<unsigned char>(),
-                     LogicalAll(),
-                     (unsigned char) 1, &result, 0)) {
+  if (!THC_reduceAll<uint8_t>(state, self,
+                              thrust::identity<unsigned char>(),
+                              LogicalAll(),
+                              (unsigned char) 1, &result, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -19,10 +19,10 @@ THC_API int
 THCudaByteTensor_logicalAnyAll(THCState *state, THCudaByteTensor *self) {
   THCAssertSameGPU(THCudaByteTensor_checkGPU(state, 1, self));
   unsigned char result;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<unsigned char>(),
-                     LogicalAny(),
-                     (unsigned char) 0, &result, 0)) {
+  if (!THC_reduceAll<uint8_t>(state, self,
+                              thrust::identity<unsigned char>(),
+                              LogicalAny(),
+                              (unsigned char) 0, &result, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -32,13 +32,13 @@ THCudaByteTensor_logicalAnyAll(THCState *state, THCudaByteTensor *self) {
 THC_API void
 THCudaByteTensor_logicalAnd(THCState* state, THCudaByteTensor *self, THCudaByteTensor *src, int dimension, int keepdim) {
   THCAssertSameGPU(THCudaByteTensor_checkGPU(state, 2, self, src));
-  if (!THC_reduceDim(state, self, src,
-                     thrust::identity<unsigned char>(),
-                     LogicalAll(),
-                     thrust::identity<unsigned char>(),
-                     (unsigned char) 1,
-                     dimension,
-                     keepdim)) {
+  if (!THC_reduceDim<uint8_t>(state, self, src,
+                              thrust::identity<unsigned char>(),
+                              LogicalAll(),
+                              thrust::identity<unsigned char>(),
+                              (unsigned char) 1,
+                              dimension,
+                              keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -48,13 +48,13 @@ THCudaByteTensor_logicalAnd(THCState* state, THCudaByteTensor *self, THCudaByteT
 THC_API void
 THCudaByteTensor_logicalAny(THCState* state, THCudaByteTensor *self, THCudaByteTensor *src, int dimension, int keepdim) {
   THCAssertSameGPU(THCudaByteTensor_checkGPU(state, 2, self, src));
-  if (!THC_reduceDim(state, self, src,
-                     thrust::identity<unsigned char>(),
-                     LogicalAny(),
-                     thrust::identity<unsigned char>(),
-                     (unsigned char) 0,
-                     dimension,
-                     keepdim)) {
+  if (!THC_reduceDim<uint8_t>(state, self, src,
+                              thrust::identity<unsigned char>(),
+                              LogicalAny(),
+                              thrust::identity<unsigned char>(),
+                              (unsigned char) 0,
+                              dimension,
+                              keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -496,7 +496,9 @@ kernelTransformReduceOuterDimIndex(K *tgt1,
   }
 }
 
-template <typename TensorTypeK,
+template <typename ScalarTypeK,
+          typename ScalarTypeIndex,
+          typename TensorTypeK,
           typename TensorTypeIndex,
           typename BinaryFunction>
 __host__ void
@@ -505,9 +507,7 @@ THC_transformReduceOuterDimIndex(THCState *state,
                                  TensorTypeIndex *tgt2,
                                  TensorTypeK *src,
                                  int64_t rdim,
-                                 const thrust::pair<
-                                 typename TensorUtils<TensorTypeK>::DataType,
-                                 typename TensorUtils<TensorTypeIndex>::DataType>& init,
+                                 const thrust::pair<ScalarTypeK, ScalarTypeIndex>& init,
                                  BinaryFunction binary_op) {
   unsigned ndim = TensorUtils<TensorTypeK>::getDims(state, src);
   unsigned num_orows = 1;
@@ -600,7 +600,9 @@ kernelTransformReduceInnermostDimIndex(K *tgt1,
   }
 }
 
-template <typename TensorTypeK,
+template <typename ScalarTypeK,
+          typename ScalarTypeIndex,
+          typename TensorTypeK,
           typename TensorTypeIndex,
           typename BinaryFunction>
 __host__ void
@@ -608,9 +610,7 @@ THC_transformReduceInnermostDimIndex(THCState *state,
                                      TensorTypeK *tgt1,
                                      TensorTypeIndex *tgt2,
                                      TensorTypeK *src,
-                                     const thrust::pair<
-                                     typename TensorUtils<TensorTypeK>::DataType,
-                                     typename TensorUtils<TensorTypeIndex>::DataType>& init,
+                                     const thrust::pair<ScalarTypeK, ScalarTypeIndex>& init,
                                      BinaryFunction binary_op) {
   unsigned ndim = TensorUtils<TensorTypeK>::getDims(state, src);
   unsigned num_rows = 1;
@@ -632,7 +632,9 @@ THC_transformReduceInnermostDimIndex(THCState *state,
   THCudaCheck(cudaGetLastError());
 }
 
-template <typename TensorTypeK,
+template <typename ScalarTypeK,
+          typename ScalarTypeIndex,
+          typename TensorTypeK,
           typename TensorTypeIndex,
           typename BinaryFunction>
 void
@@ -642,11 +644,11 @@ THC_reduceDimIndex(THCState *state,
                    TensorTypeK *src,
                    int64_t dimension,
                    int keepdim,
-                   const thrust::pair<
-                   typename TensorUtils<TensorTypeK>::DataType,
-                   typename TensorUtils<TensorTypeIndex>::DataType>& init,
+                   const thrust::pair<ScalarTypeK, ScalarTypeIndex>& init,
                    BinaryFunction binary_op)
 {
+  static_assert(std::is_same<ScalarTypeK, typename TensorUtils<TensorTypeK>::DataType>::value, "ScalarTypeK must match");
+  static_assert(std::is_same<ScalarTypeIndex, typename TensorUtils<TensorTypeIndex>::DataType>::value, "ScalarTypeIndex must match");
   THArgCheck(dimension >= 0 &&
              dimension < TensorUtils<TensorTypeK>::getDims(state, src),
              3, "dimension out of range");

--- a/aten/src/THC/THCTensorSort.cu
+++ b/aten/src/THC/THCTensorSort.cu
@@ -31,7 +31,7 @@ void THCudaLongTensor_fillSliceWithIndex(THCState* state,
 
   if (TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, t)) {
     TensorInfo<int64_t, uint32_t> info =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, t);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, t);
     info.reduceDim(dim);
     int collapseDim = info.collapseDims(dim);
 
@@ -48,7 +48,7 @@ void THCudaLongTensor_fillSliceWithIndex(THCState* state,
     }
   } else {
     TensorInfo<int64_t, uint64_t> info =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, t);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, t);
     info.reduceDim(dim);
     int collapseDim = info.collapseDims(dim);
 

--- a/aten/src/THC/THCTensorTypeUtils.cuh
+++ b/aten/src/THC/THCTensorTypeUtils.cuh
@@ -117,9 +117,10 @@ TENSOR_UTILS(THCudaHalfTensor, half, float);
 // TensorInfos can then be passed to CUDA kernels, but we can use the static functions
 // defined above to perform Tensor Operations that are appropriate for each
 // TensorType.
-template <typename TensorType, typename IndexType>
-TensorInfo<typename TensorUtils<TensorType>::DataType, IndexType>
+template <typename ScalarType, typename TensorType, typename IndexType>
+TensorInfo<ScalarType, IndexType>
 getTensorInfo(THCState* state, TensorType* t) {
+  static_assert(std::is_same<ScalarType, typename TensorUtils<TensorType>::DataType>::value, "ScalarType must match");
   IndexType sz[MAX_CUTORCH_DIMS];
   IndexType st[MAX_CUTORCH_DIMS];
 
@@ -129,7 +130,7 @@ getTensorInfo(THCState* state, TensorType* t) {
     st[i] = TensorUtils<TensorType>::getStride(state, t, i);
   }
 
-  return TensorInfo<typename TensorUtils<TensorType>::DataType, IndexType>(
+  return TensorInfo<ScalarType, IndexType>(
     TensorUtils<TensorType>::getData(state, t), dims, sz, st);
 }
 

--- a/aten/src/THC/generic/THCTensorCopy.cu
+++ b/aten/src/THC/generic/THCTensorCopy.cu
@@ -5,7 +5,7 @@
 THC_API void
 THCTensor_(copy)(THCState* state, THCTensor* dst, THCTensor* src) {
   if (dst == src) return;
-  THC_copyTensor<THCTensor, THCTensor>(state, dst, src);
+  THC_copyTensor<real, real, THCTensor, THCTensor>(state, dst, src);
 }
 
 THC_API void
@@ -24,24 +24,24 @@ THCTensor_(copyIgnoringOverlaps)(THCState* state, THCTensor* dst, THCTensor* src
     ReadOnly);
 }
 
-#define IMPLEMENT_THC_CUDA_TENSOR_COPY(TYPEC, TYPECUDA)                 \
+#define IMPLEMENT_THC_CUDA_TENSOR_COPY(TYPEC, TYPECUDA, SCALARC)        \
   THC_API void                                                          \
   THCTensor_(copyCuda##TYPEC)(THCState *state,                          \
                               THCTensor *self,                          \
                               THCuda##TYPECUDA##Tensor *src) {          \
-    THC_copyTensor<THCTensor, THCuda##TYPECUDA##Tensor>(state, self, src); \
+    THC_copyTensor<real, SCALARC, THCTensor, THCuda##TYPECUDA##Tensor>(state, self, src); \
   }
 
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Byte, Byte)
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Char, Char)
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Short, Short)
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Int, Int)
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Long, Long)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Byte, Byte, uint8_t)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Char, Char, int8_t)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Short, Short, int16_t)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Int, Int, int32_t)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Long, Long, int64_t)
 // THCudaTensor aka the non-existent THCudaFloatTensor
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Float, )
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Double, Double)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Float, , float)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Double, Double, double)
 #ifdef CUDA_HALF_TENSOR
-IMPLEMENT_THC_CUDA_TENSOR_COPY(Half, Half)
+IMPLEMENT_THC_CUDA_TENSOR_COPY(Half, Half, half)
 #endif
 
 #undef IMPLEMENT_THC_CUDA_TENSOR_COPY

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -145,17 +145,17 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, indices)) {
     TensorInfo<real, unsigned int> dstInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, dst);
+      getTensorInfo<real, THCTensor, unsigned int>(state, dst);
     int dstCopyDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstCopyDim);
 
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     int srcCopyDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcCopyDim);
 
     TensorInfo<int64_t, unsigned int> indicesInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
     indicesInfo.collapseDims();
 
     // A reasonable choice for when to have each thread iterate over
@@ -193,17 +193,17 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
     }
   } else {
     TensorInfo<real, uint64_t> dstInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, dst);
+      getTensorInfo<real, THCTensor, uint64_t>(state, dst);
     int dstCopyDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstCopyDim);
 
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     int srcCopyDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcCopyDim);
 
     TensorInfo<int64_t, uint64_t> indicesInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
     indicesInfo.collapseDims();
 
     LARGE_INDEX(real, uint64_t, -1, -1, -1, true);
@@ -334,17 +334,17 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, indices)) {
     TensorInfo<real, unsigned int> dstInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, dst);
+      getTensorInfo<real, THCTensor, unsigned int>(state, dst);
     int dstAddDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstAddDim);
 
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     int srcAddDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcAddDim);
 
     TensorInfo<int64_t, unsigned int> indicesInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
     indicesInfo.collapseDims();
 
     // A reasonable choice for when to have each thread iterate over
@@ -382,17 +382,17 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
     }
   } else {
     TensorInfo<real, uint64_t> dstInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, dst);
+      getTensorInfo<real, THCTensor, uint64_t>(state, dst);
     int dstAddDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstAddDim);
 
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     int srcAddDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcAddDim);
 
     TensorInfo<int64_t, uint64_t> indicesInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
     indicesInfo.collapseDims();
 
     LARGE_INDEX(real, uint64_t, -1, -1, -1, true);
@@ -450,12 +450,12 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   if (TensorUtils<THCTensor>::canUse32BitIndexMath(state, dst) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, indices)) {
     TensorInfo<real, unsigned int> dstInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, dst);
+      getTensorInfo<real, THCTensor, unsigned int>(state, dst);
     int dstFillDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstFillDim);
 
     TensorInfo<int64_t, unsigned int> indicesInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
     indicesInfo.collapseDims();
 
     // A reasonable choice for when to have each thread iterate over
@@ -493,12 +493,12 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
     }
   } else {
     TensorInfo<real, uint64_t> dstInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, dst);
+      getTensorInfo<real, THCTensor, uint64_t>(state, dst);
     int dstFillDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstFillDim);
 
     TensorInfo<int64_t, uint64_t> indicesInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
     indicesInfo.collapseDims();
 
     LARGE_INDEX(real, uint64_t, -1, -1, true);
@@ -583,17 +583,17 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, indices)) {
     TensorInfo<real, unsigned int> dstInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, dst);
+      getTensorInfo<real, THCTensor, unsigned int>(state, dst);
     int dstSelectDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstSelectDim);
 
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     int srcSelectDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcSelectDim);
 
     TensorInfo<int64_t, unsigned int> indicesInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
     indicesInfo.collapseDims();
 
     // A reasonable choice for when to have each thread iterate over
@@ -631,17 +631,17 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
     }
   } else {
     TensorInfo<real, uint64_t> dstInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, dst);
+      getTensorInfo<real, THCTensor, uint64_t>(state, dst);
     int dstSelectDim = dstInfo.collapseDims(dim);
     dstInfo.reduceDim(dstSelectDim);
 
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     int srcSelectDim = srcInfo.collapseDims(dim);
     srcInfo.reduceDim(srcSelectDim);
 
     TensorInfo<int64_t, uint64_t> indicesInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, indices);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
     indicesInfo.collapseDims();
 
     LARGE_INDEX(real, uint64_t, -1, -1, -1, true);

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -5,13 +5,13 @@
 THC_API void
 THCTensor_(sum)(THCState* state, THCTensor *self, THCTensor *src, int dimension, int keepdim) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
-  if (!THC_reduceDim(state, self, src,
-                     thrust::identity<accreal>{},
-                     ReduceAdd<accreal>{},
-                     thrust::identity<accreal>{},
-                     scalar_cast<accreal>(0),
-                     dimension,
-                     keepdim)) {
+  if (!THC_reduceDim<real>(state, self, src,
+                           thrust::identity<accreal>{},
+                           ReduceAdd<accreal>{},
+                           thrust::identity<accreal>{},
+                           scalar_cast<accreal>(0),
+                           dimension,
+                           keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -21,13 +21,13 @@ THCTensor_(sum)(THCState* state, THCTensor *self, THCTensor *src, int dimension,
 THC_API void
 THCTensor_(prod)(THCState* state, THCTensor *self, THCTensor *src, int dimension, int keepdim) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
-  if (!THC_reduceDim(state, self, src,
-                     thrust::identity<accreal>{},
-                     ReduceMultiply<accreal>{},
-                     thrust::identity<accreal>{},
-                     scalar_cast<accreal>(1),
-                     dimension,
-                     keepdim)) {
+  if (!THC_reduceDim<real>(state, self, src,
+                           thrust::identity<accreal>{},
+                           ReduceMultiply<accreal>{},
+                           thrust::identity<accreal>{},
+                           scalar_cast<accreal>(1),
+                           dimension,
+                           keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -39,13 +39,13 @@ THCTensor_(mean)(THCState *state, THCTensor *self, THCTensor *src, int dim, int 
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
   const accreal size = scalar_cast<accreal>(THCTensor_(size)(state, src, dim));
-  if (!THC_reduceDim(state, self, src, 
-                     thrust::identity<accreal>{},
-                     ReduceAdd<accreal>{},
-                     ReduceDivide<accreal>{size},
-                     scalar_cast<accreal>(0),
-                     dim,
-                     keepdim)) {
+  if (!THC_reduceDim<real>(state, self, src,
+                           thrust::identity<accreal>{},
+                           ReduceAdd<accreal>{},
+                           ReduceDivide<accreal>{size},
+                           scalar_cast<accreal>(0),
+                           dim,
+                           keepdim)) {
     THArgCheck(false, 2, CUTORCH_DIM_WARNING);
   }
 
@@ -157,11 +157,11 @@ THCTensor_(varall)(THCState *state, THCTensor *self, int biased)
   accreal mean = THCTensor_(meanall)(state, self);
 
   accreal val;
-  if (!THC_reduceAll(state, self,
-                     SquareFunctor<accreal>(mean),
-                     ReduceAdd<accreal>(),
-                     scalar_cast<accreal>(0),
-                     &val, 0)) {
+  if (!THC_reduceAll<real>(state, self,
+                           SquareFunctor<accreal>(mean),
+                           ReduceAdd<accreal>(),
+                           scalar_cast<accreal>(0),
+                           &val, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -180,40 +180,40 @@ THCTensor_(norm)(THCState *state, THCTensor* self, THCTensor* src, real _value, 
   const accreal value = scalar_cast<accreal>(_value);
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self, src));
   if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(0))) {
-    THC_reduceDim(state, self, src,
-                  TensorNonZeroOp<accreal>{}, 
-                  ReduceAdd<accreal>{}, 
-                  thrust::identity<accreal>{},
-                  scalar_cast<accreal>(0), 
-                  dimension, keepdim);
+    THC_reduceDim<real>(state, self, src,
+                        TensorNonZeroOp<accreal>{},
+                        ReduceAdd<accreal>{},
+                        thrust::identity<accreal>{},
+                        scalar_cast<accreal>(0),
+                        dimension, keepdim);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(1))) {
-    THC_reduceDim(state, self, src,
-                  TensorNormOp<accreal, 1>{value}, 
-                  ReduceAdd<accreal>{}, 
-                  thrust::identity<accreal>{},
-                  scalar_cast<accreal>(0), 
-                  dimension, keepdim);
+    THC_reduceDim<real>(state, self, src,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceAdd<accreal>{},
+                        thrust::identity<accreal>{},
+                        scalar_cast<accreal>(0),
+                        dimension, keepdim);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(2))) {
-    THC_reduceDim(state, self, src,
-                  TensorNormOp<accreal, 2>{value}, 
-                  ReduceAdd<accreal>{}, 
-                  ReducePow<accreal>{scalar_cast<accreal>(.5)},
-                  scalar_cast<accreal>(0), 
-                  dimension, keepdim);
+    THC_reduceDim<real>(state, self, src,
+                        TensorNormOp<accreal, 2>{value},
+                        ReduceAdd<accreal>{},
+                        ReducePow<accreal>{scalar_cast<accreal>(.5)},
+                        scalar_cast<accreal>(0),
+                        dimension, keepdim);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(INFINITY))) {
-    THC_reduceDim(state, self, src,
-                  TensorNormOp<accreal, 1>{value}, 
-                  ReduceMax<accreal>{}, 
-                  thrust::identity<accreal>{},
-                  scalar_cast<accreal>(0), 
-                  dimension, keepdim);
+    THC_reduceDim<real>(state, self, src,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceMax<accreal>{},
+                        thrust::identity<accreal>{},
+                        scalar_cast<accreal>(0),
+                        dimension, keepdim);
   } else {
-    THC_reduceDim(state, self, src,
-                  TensorNormOp<accreal, -1>{value}, 
-                  ReduceAdd<accreal>{}, 
-                  ReducePow<accreal>{THCNumerics<accreal>::cinv(value)},
-                  scalar_cast<accreal>(0), 
-                  dimension, keepdim);
+    THC_reduceDim<real>(state, self, src,
+                        TensorNormOp<accreal, -1>{value},
+                        ReduceAdd<accreal>{},
+                        ReducePow<accreal>{THCNumerics<accreal>::cinv(value)},
+                        scalar_cast<accreal>(0),
+                        dimension, keepdim);
   }
 
   THCudaCheck(cudaGetLastError());
@@ -227,36 +227,36 @@ THCTensor_(normall)(THCState *state, THCTensor *self, real _value)
   accreal result;
 
   if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(0))) {
-    THC_reduceAll(state, self,
-                  TensorNonZeroOp<accreal>{},
-                  ReduceAdd<accreal>{},
-                  scalar_cast<accreal>(0),
-                  &result, 0);
+    THC_reduceAll<real>(state, self,
+                        TensorNonZeroOp<accreal>{},
+                        ReduceAdd<accreal>{},
+                        scalar_cast<accreal>(0),
+                        &result, 0);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(1))) {
-    THC_reduceAll(state, self,
-                  TensorNormOp<accreal, 1>{value},
-                  ReduceAdd<accreal>{},
-                  scalar_cast<accreal>(0),
-                  &result, 0);
+    THC_reduceAll<real>(state, self,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceAdd<accreal>{},
+                        scalar_cast<accreal>(0),
+                        &result, 0);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(2))) {
-    THC_reduceAll(state, self,
-                  TensorNormOp<accreal, 2>{value},
-                  ReduceAdd<accreal>{},
-                  scalar_cast<accreal>(0),
-                  &result, 0);
+    THC_reduceAll<real>(state, self,
+                        TensorNormOp<accreal, 2>{value},
+                        ReduceAdd<accreal>{},
+                        scalar_cast<accreal>(0),
+                        &result, 0);
     result = THCNumerics<accreal>::sqrt(result);
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(INFINITY))) {
-    THC_reduceAll(state, self,
-                  TensorNormOp<accreal, 1>{value},
-                  ReduceMax<accreal>{},
-                  scalar_cast<accreal>(0),
-                  &result, 0);
+    THC_reduceAll<real>(state, self,
+                        TensorNormOp<accreal, 1>{value},
+                        ReduceMax<accreal>{},
+                        scalar_cast<accreal>(0),
+                        &result, 0);
   } else {
-    THC_reduceAll(state, self,
-                  TensorNormOp<accreal, -1>{value},
-                  ReduceAdd<accreal>{},
-                  scalar_cast<accreal>(0),
-                  &result, 0);
+    THC_reduceAll<real>(state, self,
+                        TensorNormOp<accreal, -1>{value},
+                        ReduceAdd<accreal>{},
+                        scalar_cast<accreal>(0),
+                        &result, 0);
     result = THCNumerics<accreal>::pow(result, 
                                        THCNumerics<accreal>::cinv(value));
   }
@@ -297,11 +297,11 @@ THC_API accreal
 THCTensor_(sumall)(THCState *state, THCTensor *self) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
   accreal val;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<accreal>{},
-                     ReduceAdd<accreal>{},
-                     scalar_cast<accreal>(0),
-                     &val, 0)) {
+  if (!THC_reduceAll<real>(state, self,
+                           thrust::identity<accreal>{},
+                           ReduceAdd<accreal>{},
+                           scalar_cast<accreal>(0),
+                           &val, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -313,11 +313,11 @@ THC_API accreal
 THCTensor_(prodall)(THCState *state, THCTensor *self) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
   accreal val;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<accreal>{},
-                     ReduceMultiply<accreal>{},
-                     scalar_cast<accreal>(1),
-                     &val, 0)) {
+  if (!THC_reduceAll<real>(state, self,
+                           thrust::identity<accreal>{},
+                           ReduceMultiply<accreal>{},
+                           scalar_cast<accreal>(1),
+                           &val, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -337,10 +337,10 @@ THC_API real
 THCTensor_(minall)(THCState *state, THCTensor *self) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
   accreal val;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<accreal>{},
-                     ReduceMin<accreal>{},
-                     THCNumerics<accreal>::max(), &val, 0)) {
+  if (!THC_reduceAll<real>(state, self,
+                           thrust::identity<accreal>{},
+                           ReduceMin<accreal>{},
+                           THCNumerics<accreal>::max(), &val, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -352,10 +352,10 @@ THC_API real
 THCTensor_(maxall)(THCState *state, THCTensor *self) {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
   accreal val;
-  if (!THC_reduceAll(state, self,
-                     thrust::identity<accreal>{},
-                     ReduceMax<accreal>{},
-                     THCNumerics<accreal>::min(), &val, 0)) {
+  if (!THC_reduceAll<real>(state, self,
+                           thrust::identity<accreal>{},
+                           ReduceMax<accreal>{},
+                           THCNumerics<accreal>::min(), &val, 0)) {
     THArgCheck(false, 1, CUTORCH_DIM_WARNING);
   }
 
@@ -450,7 +450,7 @@ THCTensor_(max)(THCState *state,
     thrust::make_pair<real, int64_t>(
       THCNumerics<real>::min(), 0);
 
-  return THC_reduceDimIndex(
+  return THC_reduceDimIndex<real, int64_t>(
     state, values, indices, src, dimension, keepdim, init,
     MaxValuePair<real, int64_t>());
 }
@@ -469,7 +469,7 @@ THCTensor_(min)(THCState *state,
     thrust::make_pair<real, int64_t>(
       THCNumerics<real>::max(), 0);
 
-  return THC_reduceDimIndex(
+  return THC_reduceDimIndex<real, int64_t>(
     state, values, indices, src, dimension, keepdim, init,
     MinValuePair<real, int64_t>());
 }

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -222,8 +222,8 @@ THC_API void THCTensor_(mode)(THCState *state,
     indicesTransposed = THCudaLongTensor_newTranspose(state, indices, dimension, ndim-1);
 
     // Set-up TensorInfo structs for passing to kernel
-    TensorInfo<real, unsigned int> tiValues = getTensorInfo<THCTensor, unsigned int>(state, valuesTransposed);
-    TensorInfo<int64_t, unsigned int> tiIndices = getTensorInfo<THCudaLongTensor, unsigned int>(state, indicesTransposed);
+    TensorInfo<real, unsigned int> tiValues = getTensorInfo<real, THCTensor, unsigned int>(state, valuesTransposed);
+    TensorInfo<int64_t, unsigned int> tiIndices = getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indicesTransposed);
 
     // The number of blocks is the number of slices that we need to calculate the mode for. Each block
     // is responsible for computing a single mode

--- a/aten/src/THC/generic/THCTensorScatterGather.cu
+++ b/aten/src/THC/generic/THCTensorScatterGather.cu
@@ -49,11 +49,11 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, index)) {
     TensorInfo<real, unsigned int> tensorInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, tensor);
+      getTensorInfo<real, THCTensor, unsigned int>(state, tensor);
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     TensorInfo<int64_t, unsigned int> indexInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -76,11 +76,11 @@ void THCTensor_(gather)(THCState* state, THCTensor *tensor,
     }
   } else {
     TensorInfo<real, uint64_t> tensorInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, tensor);
+      getTensorInfo<real, THCTensor, uint64_t>(state, tensor);
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     TensorInfo<int64_t, uint64_t> indexInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, index);
     RUN(uint64_t, -1, real);
     THCudaCheck(cudaGetLastError());
   }
@@ -142,11 +142,11 @@ void THCTensor_(scatter)(THCState* state, THCTensor *tensor, int dim, THCudaLong
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, index)) {
     TensorInfo<real, unsigned int> tensorInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, tensor);
+      getTensorInfo<real, THCTensor, unsigned int>(state, tensor);
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     TensorInfo<int64_t, unsigned int> indexInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -165,11 +165,11 @@ void THCTensor_(scatter)(THCState* state, THCTensor *tensor, int dim, THCudaLong
     }
   } else {
     TensorInfo<real, uint64_t> tensorInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, tensor);
+      getTensorInfo<real, THCTensor, uint64_t>(state, tensor);
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     TensorInfo<int64_t, uint64_t> indexInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, index);
 
     RUN(uint64_t, -1, real)
   }
@@ -229,11 +229,11 @@ void THCTensor_(scatterAdd)(THCState* state, THCTensor *tensor, int dim, THCudaL
       TensorUtils<THCTensor>::canUse32BitIndexMath(state, src) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, index)) {
     TensorInfo<real, unsigned int> tensorInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, tensor);
+      getTensorInfo<real, THCTensor, unsigned int>(state, tensor);
     TensorInfo<real, unsigned int> srcInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, src);
+      getTensorInfo<real, THCTensor, unsigned int>(state, src);
     TensorInfo<int64_t, unsigned int> indexInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -252,11 +252,11 @@ void THCTensor_(scatterAdd)(THCState* state, THCTensor *tensor, int dim, THCudaL
     }
   } else {
     TensorInfo<real, uint64_t> tensorInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, tensor);
+      getTensorInfo<real, THCTensor, uint64_t>(state, tensor);
     TensorInfo<real, uint64_t> srcInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, src);
+      getTensorInfo<real, THCTensor, uint64_t>(state, src);
     TensorInfo<int64_t, uint64_t> indexInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, index);
 
     RUN(uint64_t, -1, real)
   }
@@ -313,9 +313,9 @@ THCTensor_(scatterFill)(THCState* state, THCTensor *tensor,
   if (TensorUtils<THCTensor>::canUse32BitIndexMath(state, tensor) &&
       TensorUtils<THCudaLongTensor>::canUse32BitIndexMath(state, index)) {
     TensorInfo<real, unsigned int> tensorInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, tensor);
+      getTensorInfo<real, THCTensor, unsigned int>(state, tensor);
     TensorInfo<int64_t, unsigned int> indexInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -334,9 +334,9 @@ THCTensor_(scatterFill)(THCState* state, THCTensor *tensor,
     }
   } else {
     TensorInfo<real, uint64_t> tensorInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, tensor);
+      getTensorInfo<real, THCTensor, uint64_t>(state, tensor);
     TensorInfo<int64_t, uint64_t> indexInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, index);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, index);
 
     RUN(uint64_t, -1, real);
   }

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -111,12 +111,12 @@ THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
   // we are sorting on a per-block basis
   if (TensorUtils<THCTensor>::canUse32BitIndexMath(state, key)) {
     TensorInfo<real, unsigned int> keyInfo =
-      getTensorInfo<THCTensor, unsigned int>(state, key);
+      getTensorInfo<real, THCTensor, unsigned int>(state, key);
     keyInfo.reduceDim(dim);
     int collapseKeyDim = keyInfo.collapseDims(dim);
 
     TensorInfo<int64_t, unsigned int> valueInfo =
-      getTensorInfo<THCudaLongTensor, unsigned int>(state, value);
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, value);
     valueInfo.reduceDim(dim);
     int collapseValueDim = valueInfo.collapseDims(dim);
 
@@ -134,12 +134,12 @@ THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
     }
   } else {
     TensorInfo<real, uint64_t> keyInfo =
-      getTensorInfo<THCTensor, uint64_t>(state, key);
+      getTensorInfo<real, THCTensor, uint64_t>(state, key);
     keyInfo.reduceDim(dim);
     int collapseKeyDim = keyInfo.collapseDims(dim);
 
     TensorInfo<int64_t, uint64_t> valueInfo =
-      getTensorInfo<THCudaLongTensor, uint64_t>(state, value);
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, value);
     valueInfo.reduceDim(dim);
     int collapseValueDim = valueInfo.collapseDims(dim);
 

--- a/aten/src/THC/generic/THCTensorTopK.cu
+++ b/aten/src/THC/generic/THCTensorTopK.cu
@@ -64,11 +64,11 @@ THC_API void THCTensor_(topk)(THCState* state,
 
 #define RUN_T(INDEX_T)                                                  \
   TensorInfo<real, INDEX_T> inputInfo =                                 \
-    getTensorInfo<THCTensor, INDEX_T>(state, input);                    \
+    getTensorInfo<real, THCTensor, INDEX_T>(state, input);              \
   TensorInfo<real, INDEX_T> topKInfo =                                  \
-    getTensorInfo<THCTensor, INDEX_T>(state, topK);                     \
+    getTensorInfo<real, THCTensor, INDEX_T>(state, topK);               \
   TensorInfo<int64_t, INDEX_T> indicesInfo =                            \
-    getTensorInfo<THCudaLongTensor, INDEX_T>(state, indices);           \
+    getTensorInfo<int64_t, THCudaLongTensor, INDEX_T>(state, indices);  \
                                                                         \
   /* We use these structures solely to find the offset to */            \
   /* each slice we are operating on */                                  \

--- a/aten/src/THCS/generic/THCSTensor.cu
+++ b/aten/src/THCS/generic/THCSTensor.cu
@@ -17,8 +17,8 @@
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 
-#define I_INFO(tensor) getTensorInfo<THCIndexTensor, uint64_t>(state, tensor)
-#define V_INFO(tensor) getTensorInfo<THCTensor, uint64_t>(state, tensor)
+#define I_INFO(tensor) getTensorInfo<int64_t, THCIndexTensor, uint64_t>(state, tensor)
+#define V_INFO(tensor) getTensorInfo<real, THCTensor, uint64_t>(state, tensor)
 
 THCTensor *THCSTensor_(toDense)(THCState *state, THCSTensor *self) {
   THLongStorage *size;

--- a/aten/src/THCS/generic/THCSTensorMath.cu
+++ b/aten/src/THCS/generic/THCSTensorMath.cu
@@ -10,8 +10,8 @@
 #define ROW_PTR2(t, r) (THCTensor_(data)(THCState *state, t) + (r) * (t)->stride[0])
 #define COL_PTR2(t, c) (THCTensor_(data)(THCState *state, t) + (c) * (t)->stride[1])
 
-#define I_INFO(tensor) getTensorInfo<THCIndexTensor, uint64_t>(state, tensor)
-#define V_INFO(tensor) getTensorInfo<THCTensor, uint64_t>(state, tensor)
+#define I_INFO(tensor) getTensorInfo<int64_t, THCIndexTensor, uint64_t>(state, tensor)
+#define V_INFO(tensor) getTensorInfo<real, THCTensor, uint64_t>(state, tensor)
 
 THCudaIntTensor *THCSTensor_(toCSR)(THCState *state, THCIndexTensor *rowIndices, int64_t dim, int64_t nnz) {
   THCudaIntTensor *csr = THCudaIntTensor_newWithSize1d(state, dim + 1);

--- a/aten/src/THCUNN/generic/FusedRNNKernel.cu
+++ b/aten/src/THCUNN/generic/FusedRNNKernel.cu
@@ -441,11 +441,11 @@ void THNN_(LSTM_forw_ind_wrap)(
   THAssertMsg(getApplyGrid(state, totalElements, grid),
           "Could not get grid size for pointwise apply.");
 
-  TINFO inputI = getTensorInfo<THCTensor, INDTYPE>(state, input);
-  TINFO hiddenI = getTensorInfo<THCTensor, INDTYPE>(state, hidden);
-  TINFO cxI = getTensorInfo<THCTensor, INDTYPE>(state, cx);
-  TINFO hyI = getTensorInfo<THCTensor, INDTYPE>(state, hy);
-  TINFO cyI = getTensorInfo<THCTensor, INDTYPE>(state, cy);
+  TINFO inputI = getTensorInfo<real, THCTensor, INDTYPE>(state, input);
+  TINFO hiddenI = getTensorInfo<real, THCTensor, INDTYPE>(state, hidden);
+  TINFO cxI = getTensorInfo<real, THCTensor, INDTYPE>(state, cx);
+  TINFO hyI = getTensorInfo<real, THCTensor, INDTYPE>(state, hy);
+  TINFO cyI = getTensorInfo<real, THCTensor, INDTYPE>(state, cy);
 
   INDTYPE hid_size = cxI.sizes[cxI.dims-1];
   if(has_bias){
@@ -468,8 +468,8 @@ void THNN_(LSTM_forw_ind_wrap)(
   TINFO bias2I = nullinfo;
 
   if(has_bias){
-    bias1I = getTensorInfo<THCTensor, INDTYPE>(state, bias1);
-    bias2I = getTensorInfo<THCTensor, INDTYPE>(state, bias2);
+    bias1I = getTensorInfo<real, THCTensor, INDTYPE>(state, bias1);
+    bias2I = getTensorInfo<real, THCTensor, INDTYPE>(state, bias2);
     if(maxDim == -2){
       bias1I.collapseDims();
       bias2I.collapseDims();
@@ -534,13 +534,13 @@ void THNN_(LSTM_back_ind_wrap)(
   THAssertMsg(getApplyGrid(state, totalElements, grid),
               "Could not get grid size for pointwise apply");
 
-  TINFO storageI = getTensorInfo<THCTensor, INDTYPE>(state, storage);
-  TINFO gradingatesI = getTensorInfo<THCTensor, INDTYPE>(state, gradInGates);
-  TINFO cxI = getTensorInfo<THCTensor, INDTYPE>(state, cx);
-  TINFO cyI = getTensorInfo<THCTensor, INDTYPE>(state, cy);
-  TINFO gradoutI = getTensorInfo<THCTensor, INDTYPE>(state, gradOutput);
-  TINFO gradoutcI = getTensorInfo<THCTensor, INDTYPE>(state, gradOutputCell);
-  TINFO gradincxI = getTensorInfo<THCTensor, INDTYPE>(state, gradInputCx);
+  TINFO storageI = getTensorInfo<real, THCTensor, INDTYPE>(state, storage);
+  TINFO gradingatesI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradInGates);
+  TINFO cxI = getTensorInfo<real, THCTensor, INDTYPE>(state, cx);
+  TINFO cyI = getTensorInfo<real, THCTensor, INDTYPE>(state, cy);
+  TINFO gradoutI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradOutput);
+  TINFO gradoutcI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradOutputCell);
+  TINFO gradincxI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradInputCx);
 
   INDTYPE hid_size = gradoutI.sizes[gradoutI.dims-1];
 
@@ -623,11 +623,11 @@ void THNN_(GRU_forw_ind_wrap)(
   THAssertMsg(getApplyGrid(state, totalElements, grid),
               "Could not get grid size for pointwise apply.");
 
-  TINFO inputI = getTensorInfo<THCTensor, INDTYPE>(state, input);
-  TINFO hiddenI = getTensorInfo<THCTensor, INDTYPE>(state, hidden);
-  TINFO hxI = getTensorInfo<THCTensor, INDTYPE>(state, hx);
-  TINFO hyI = getTensorInfo<THCTensor, INDTYPE>(state, hy);
-  TINFO storageI = getTensorInfo<THCTensor, INDTYPE>(state, storage);
+  TINFO inputI = getTensorInfo<real, THCTensor, INDTYPE>(state, input);
+  TINFO hiddenI = getTensorInfo<real, THCTensor, INDTYPE>(state, hidden);
+  TINFO hxI = getTensorInfo<real, THCTensor, INDTYPE>(state, hx);
+  TINFO hyI = getTensorInfo<real, THCTensor, INDTYPE>(state, hy);
+  TINFO storageI = getTensorInfo<real, THCTensor, INDTYPE>(state, storage);
 
   INDTYPE hid_size = hxI.sizes[hxI.dims-1];
   if(has_bias){
@@ -650,8 +650,8 @@ void THNN_(GRU_forw_ind_wrap)(
   TINFO bias2I = nullinfo;
 
   if(has_bias){
-    bias1I = getTensorInfo<THCTensor, INDTYPE>(state, bias1);
-    bias2I = getTensorInfo<THCTensor, INDTYPE>(state, bias2);
+    bias1I = getTensorInfo<real, THCTensor, INDTYPE>(state, bias1);
+    bias2I = getTensorInfo<real, THCTensor, INDTYPE>(state, bias2);
     if(maxDim == -2){
       bias1I.collapseDims();
       bias2I.collapseDims();
@@ -720,11 +720,11 @@ void THNN_(GRU_back_ind_wrap)(
   THAssertMsg(getApplyGrid(state, totalElements, grid),
           "Could not get grid size for pointwise apply");
 
-  TINFO gradininputI = getTensorInfo<THCTensor, INDTYPE>(state, gradInInput);
-  TINFO gradinhiddenI = getTensorInfo<THCTensor, INDTYPE>(state, gradInHidden);
-  TINFO gradoutI = getTensorInfo<THCTensor, INDTYPE>(state, gradOutput);
-  TINFO gradinhxI = getTensorInfo<THCTensor, INDTYPE>(state, gradInputHx);
-  TINFO storageI = getTensorInfo<THCTensor, INDTYPE>(state, storage);
+  TINFO gradininputI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradInInput);
+  TINFO gradinhiddenI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradInHidden);
+  TINFO gradoutI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradOutput);
+  TINFO gradinhxI = getTensorInfo<real, THCTensor, INDTYPE>(state, gradInputHx);
+  TINFO storageI = getTensorInfo<real, THCTensor, INDTYPE>(state, storage);
 
   INDTYPE hid_size = gradoutI.sizes[gradoutI.dims-1];
 


### PR DESCRIPTION
As in https://github.com/pytorch/pytorch/pull/8056, TensorUtils<T>::DataType doesn't work with a single TensorImpl type. This PR replaces the usages of with a templatized parameter and static_asserts that the new and old are equal.

After this we can get rid of the old template parameter, but I want to ensure they are equivalent across all builds first.

