### PR TITLE
[Caffe2] FilleOp should support int64_t dimensions

### DIFF
--- a/caffe2/operators/half_float_ops.h
+++ b/caffe2/operators/half_float_ops.h
@@ -28,8 +28,7 @@ class Float16ConstantFillOp : public Operator<CPUContext> {
  public:
   Float16ConstantFillOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        shape_(
-            ToVectorTIndex(OperatorBase::GetRepeatedArgument<int>("shape"))) {}
+        shape_(OperatorBase::GetRepeatedArgument<int64_t>("shape")) {}
 
   USE_OPERATOR_FUNCTIONS(CPUContext);
   virtual ~Float16ConstantFillOp() {}


### PR DESCRIPTION
Change argument type to int64_t for shape argument of FillerOp (used in ConstantFill, XavierFill, etc)

