### PR TITLE
Add back lrn test

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -353,7 +353,8 @@ Caffe2Backend::get_special_operators() const {
               {"Reciprocal", &Caffe2Backend::CreateReciprocal},
               {"BatchNormalization", &Caffe2Backend::CreateBatchNormalization},
               {"MatMul", &Caffe2Backend::CreateMatMul},
-              {"Upsample", &Caffe2Backend::CreateUpsample}};
+              {"Upsample", &Caffe2Backend::CreateUpsample},
+              {"LRN", &Caffe2Backend::CreateLRN}};
   return kSpecialOperators;
 }
 
@@ -902,6 +903,22 @@ Caffe2Ops Caffe2Backend::CreateUpsample(OnnxNode* onnx_node, int opset_version) 
   c2_width->set_name("width_scale");
   c2_width->set_f(scales.Get(3));
 
+  return c2_op;
+}
+
+Caffe2Ops Caffe2Backend::CreateLRN(OnnxNode* onnx_node, int opset_version) {
+  auto c2_op = CommonOnnxNodeToCaffe2Ops(onnx_node, opset_version);
+  const auto& attributes = onnx_node->attributes;
+  if (!attributes.HasAttribute("alpha")) {
+      auto* arg = c2_op.ops.Mutable(0)->add_arg();
+      arg->set_name("alpha");
+      arg->set_f(1e-4);
+  }
+  if (!attributes.HasAttribute("beta")) {
+      auto* arg = c2_op.ops.Mutable(0)->add_arg();
+      arg->set_name("beta");
+      arg->set_f(0.75);
+  }
   return c2_op;
 }
 

--- a/caffe2/onnx/backend.h
+++ b/caffe2/onnx/backend.h
@@ -190,6 +190,8 @@ class Caffe2Backend {
 
   Caffe2Ops CreateUpsample(OnnxNode* onnx_node, int opset_version);
 
+  Caffe2Ops CreateLRN(OnnxNode* onnx_node, int opset_version);
+
 
   // LUT related getters
   const std::unordered_map<std::string, std::string>& get_renamed_operators()

--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -47,8 +47,7 @@ backend_test.exclude('(test_cast_.*'
                      '|test_rnn_seq_length'
                      '|test_operator_add.*_cuda'
                      '|test_operator_lstm_cuda'
-                     '|test_operator_rnn.*_cuda'
-                     '|test_lrn_default_cuda)')
+                     '|test_operator_rnn.*_cuda)')
 
 # Temporarily skip some ONNX backend tests with broadcasting.
 backend_test.exclude('(test_xor_bcast'


### PR DESCRIPTION
The default values of alpha and beta are different in ONNX vs. in Caffe2:

https://github.com/onnx/onnx/blob/master/docs/Operators.md#LRN
https://github.com/pytorch/pytorch/blob/master/caffe2/operators/local_response_normalization_op.h#L18-L19