### PR TITLE
Fix job name checking for AVX tests

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -36,10 +36,10 @@ fi
 
 export ATEN_DISABLE_AVX=
 export ATEN_DISABLE_AVX2=
-if [[ "${JOB_BASE_NAME}" == *NO_AVX* ]]; then
+if [[ "${JOB_BASE_NAME}" == *-NO_AVX-* ]]; then
   export ATEN_DISABLE_AVX=1
 fi
-if [[ "${JOB_BASE_NAME}" == *NO_AVX2* ]]; then
+if [[ "${JOB_BASE_NAME}" == *-NO_AVX2-* ]]; then
   export ATEN_DISABLE_AVX2=1
 fi
 


### PR DESCRIPTION
This is a fix for https://github.com/pytorch/pytorch/pull/8020 which checks whether to set `ATEN_DISABLE_AVX` and `ATEN_DISABLE_AVX2` flags based on the job name, but missed the fact that a job with the name `*NO_AVX2*` will also be matched with `*NO_AVX*`.

The correct flag setting behavior should be seen in the CI.