### PR TITLE
Name the thread pools

### DIFF
--- a/caffe2/utils/thread_name.cc
+++ b/caffe2/utils/thread_name.cc
@@ -1,0 +1,24 @@
+#include "caffe2/utils/thread_name.h"
+
+#include <algorithm>
+
+#if defined(__GLIBC__) && !defined(__APPLE__) && !defined(__ANDROID__)
+#define CAFFE2_HAS_PTHREAD_SETNAME_NP
+#endif
+
+#ifdef CAFFE2_HAS_PTHREAD_SETNAME_NP
+#include <pthread.h>
+#endif
+
+namespace caffe2 {
+
+void setThreadName(std::string name) {
+#ifdef CAFFE2_HAS_PTHREAD_SETNAME_NP
+  constexpr size_t kMaxThreadName = 15;
+  name.resize(std::min(name.size(), kMaxThreadName));
+
+  pthread_setname_np(pthread_self(), name.c_str());
+#endif
+}
+
+} // namespace caffe2

--- a/caffe2/utils/thread_name.h
+++ b/caffe2/utils/thread_name.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace caffe2 {
+
+void setThreadName(std::string name);
+
+} // namespace caffe2

--- a/caffe2/utils/thread_pool.h
+++ b/caffe2/utils/thread_pool.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "caffe2/core/numa.h"
+#include "caffe2/utils/thread_name.h"
 
 namespace caffe2 {
 
@@ -115,6 +116,7 @@ class TaskThreadPool {
  private:
   /// @brief Entry point for pool threads.
   void main_loop(std::size_t index) {
+    setThreadName("CaffeTaskThread");
     NUMABind(numa_node_id_);
 
     while (running_) {

--- a/caffe2/utils/threadpool/ThreadPool.h
+++ b/caffe2/utils/threadpool/ThreadPool.h
@@ -19,12 +19,12 @@ class WorkersPool;
 
 constexpr size_t kCacheLineSize = 64;
 
-// A work-stealing threadpool with the given number of threads.
+// A threadpool with the given number of threads.
 // NOTE: the kCacheLineSize alignment is present only for cache
 // performance, and is not strictly enforced (for example, when
 // the object is created on the heap). Thus, in order to avoid
 // misaligned intrinsics, no SSE instructions shall be involved in
-// the ThreadPool implemetation.
+// the ThreadPool implementation.
 class alignas(kCacheLineSize) ThreadPool {
  public:
   static std::unique_ptr<ThreadPool> defaultThreadPool();

--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
+#include <thread>
 #include "caffe2/core/common.h"
 #include "caffe2/core/logging.h"
-#include <atomic>
-#include <thread>
-#include <condition_variable>
+#include "caffe2/utils/thread_name.h"
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -262,6 +263,7 @@ class alignas(kGEMMLOWPCacheLineSize) Worker {
 
   // Thread entry point.
   void ThreadFunc() {
+    setThreadName("CaffeWorkersPool");
     ChangeState(State::Ready);
 
     // Thread main loop


### PR DESCRIPTION
Caffe thread pools currently inherit the thread names from the thread that starts them, which can be misleading. Give them an explicit name instead.

