### PR TITLE
[Caffe2] cpu/ideep context converter

### DIFF
--- a/caffe2/ideep/operators/utility_ops.cc
+++ b/caffe2/ideep/operators/utility_ops.cc
@@ -1,0 +1,56 @@
+#include "caffe2/operators/utility_ops.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/ideep/ideep_utils.h"
+
+namespace caffe2 {
+
+class CopyCPUToIDEEPOp final : public IDEEPOperator {
+ public:
+   USE_SIMPLE_IDEEP_CTOR_DTOR(CopyCPUToIDEEPOp);
+   USE_IDEEP_DEF_ALIASES();
+
+   bool RunOnDevice() override {
+     const auto& X = OperatorBase::Input<TensorCPU>(0);
+     auto* Y = OperatorBase::OutputBlob(0);
+     itensor::dims src_dims(X.dims().begin(), X.dims().end());
+     if (!(Y->template IsType<itensor>() &&
+           Y->Get<itensor>().get_data_type() == itensor::data_type::f32) ||
+         Y->Get<itensor>().get_dims() != src_dims) {
+       Y->Reset(new itensor());
+       Y->GetMutable<itensor>()->resize(src_dims, itensor::data_type::f32);
+     }
+     Y->GetMutable<itensor>()->reorder_from(
+         src_dims, itensor::data_type::f32, X.raw_data());
+     return true;
+  }
+};
+
+class CopyIDEEPToCPUOp final : public IDEEPOperator {
+ public:
+   USE_SIMPLE_IDEEP_CTOR_DTOR(CopyIDEEPToCPUOp);
+   USE_IDEEP_DEF_ALIASES();
+  bool RunOnDevice() override {
+    const auto& X = OperatorBase::Input<itensor>(0);
+    auto* Y = OperatorBase::Output<TensorCPU>(0);
+    Y->Resize(X.get_dims());
+    X.reorder_to(Y->template mutable_data<float>());
+    return true;
+  }
+};
+
+REGISTER_IDEEP_OPERATOR(CopyCPUToIDEEP, CopyCPUToIDEEPOp);
+REGISTER_IDEEP_OPERATOR(CopyIDEEPToCPU, CopyIDEEPToCPUOp);
+
+OPERATOR_SCHEMA(CopyCPUToIDEEP)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .Input(0, "cpu_blob", "The input TensorCPU to copy")
+    .Output(0, "ideep_blob", "The output IDEEP tensort to copy to");
+OPERATOR_SCHEMA(CopyIDEEPToCPU)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .Input(0, "ideep_blob", "The input IDEEP tensort to copy")
+    .Output(0, "cpu_blob", "The output TensorCPU to copy to");
+
+} // namespace caffe2
+

--- a/caffe2/python/ideep/copy_op_test.py
+++ b/caffe2/python/ideep/copy_op_test.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import numpy as np
+from random import randint
+from caffe2.proto import caffe2_pb2
+from caffe2.python import core, workspace
+
+@unittest.skipIf(not workspace.C.use_ideep, "No IDEEP support.")
+class CopyTest(unittest.TestCase):
+    def _get_deep_device(self):
+        return caffe2_pb2.DeviceOption(device_type=caffe2_pb2.IDEEP)
+
+    def test_copy_to_ideep(self):
+        op = core.CreateOperator(
+                "CopyCPUToIDEEP",
+                ["X"],
+                ["X_ideep"],
+            )
+        op.device_option.CopyFrom(self._get_deep_device())
+        n = randint(1, 128)
+        c = randint(1, 64)
+        h = randint(1, 128)
+        w = randint(1, 128)
+        X = np.random.rand(n, c, h, w).astype(np.float32)
+        workspace.FeedBlob("X", X)
+        workspace.RunOperatorOnce(op)
+        X_ideep = workspace.FetchBlob("X_ideep")
+        np.testing.assert_allclose(X, X_ideep)
+
+    def test_copy_from_ideep(self):
+        op = core.CreateOperator(
+                "CopyIDEEPToCPU",
+                ["X_ideep"],
+                ["X"],
+            )
+        op.device_option.CopyFrom(self._get_deep_device())
+        n = randint(1, 128)
+        c = randint(1, 64)
+        h = randint(1, 128)
+        w = randint(1, 128)
+        X = np.random.rand(n, c, h, w).astype(np.float32)
+        workspace.FeedBlob("X_ideep", X, self._get_deep_device())
+        workspace.RunOperatorOnce(op)
+        X_ideep = workspace.FetchBlob("X")
+        np.testing.assert_allclose(X, X_ideep)
+


### PR DESCRIPTION
Added `CopyCPUToIDEEP` and `CopyIDEEPToCPU` as proxy between CPU and IDEEP ops. 