### PR TITLE
Fix a corner case for ReShapeOp

### DIFF
--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -60,7 +60,7 @@ class ReshapeOp : public Operator<Context> {
     }
 
     // Copy over the dimensions for those that are specified zero.
-    for (int i = 0; i < actual_new_shape.size(); ++i) {
+    for (int i = 0; i < actual_new_shape.size() && i < input.ndim(); ++i) {
       if (actual_new_shape[i] == 0) {
         actual_new_shape[i] = input.dim(i);
       }


### PR DESCRIPTION
In my use case, in the backward propogate pass, the reshape need to
change a [0] tensor into [0,0] shaped tensor. The original implementation would
cause out of index issue. This diff fix this problem.

