### PR TITLE
Avoid CUDA warning

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -35,7 +35,11 @@ __device__ __forceinline__ bool warp_has_collision(int val) {
   for (int i = 1; i <= 16; i++) {
     dup |= (WARP_SHFL(val, (laneId + i) % 32) == val);
   }
+#if CUDA_VERSION < 9000
   return __any(dup) != 0;
+#else
+  return __any_sync(dup) != 0;
+#endif
 }
 
 // parallelizes over features


### PR DESCRIPTION
I want to remove this warning:

```
[73/154] Building NVCC (Device) object caffe2/CMakeFiles/caffe2_gpu.dir/__/aten/src/ATen/native/cuda/caffe2_gpu_generated_Embedding.cu.o
/home/psag/pytorch/pytorch/aten/src/ATen/native/cuda/Embedding.cu(38): warning: function "__any"
/usr/local/cuda-9.1/include/device_atomic_functions.h(180): here was declared deprecated ("__any() is deprecated in favor of __any_sync() and may be removed in a future release (Use -Wno-deprecated-declarations to suppress this warning).")
```

Apparently CUDA 9 deprecates the non sync versions:

<img width="1215" alt="screen shot 2018-06-04 at 21 49 11" src="https://user-images.githubusercontent.com/6429851/40955800-25079a5a-6841-11e8-8d98-42d4b52dc99f.png">

@colesbury @soumith 