### PR TITLE
Abstract parallelization to faciliate using threadpools

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -354,28 +354,26 @@ inline void CPU_tensor_parallel_apply1(
     int64_t grain_size = internal::TBB_GRAIN_SIZE) {
   if (!_apply_preamble({tensor1}))
     return;
-  if (tensor1.numel() < grain_size) {
-    CPU_tensor_apply1<scalar1>(tensor1, op);
-    return;
-  }
-  auto range = tbb::blocked_range<size_t>(0, tensor1.numel());
   if (tensor1.ndimension() < 8) {
-    tbb::parallel_for(
-        range, [&tensor1, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for(
+        0,
+        tensor1.numel(),
+        grain_size,
+        [&tensor1, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
+              end - begin,
+              begin,
               op,
               strided_tensor_iter_fixed<scalar1, 8>(tensor1, true));
         });
   } else {
-    tbb::parallel_for(
-        range, [&tensor1, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for(
+        0,
+        tensor1.numel(),
+        grain_size,
+        [&tensor1, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
-              op,
-              strided_tensor_iter<scalar1>(tensor1));
+              end - begin, begin, op, strided_tensor_iter<scalar1>(tensor1));
         });
   }
 }
@@ -388,27 +386,28 @@ inline void CPU_tensor_parallel_apply2(
     int64_t grain_size = internal::TBB_GRAIN_SIZE) {
   if (!_apply_preamble({tensor1, tensor2}))
     return;
-  if ((tensor1.numel() + tensor2.numel()) < grain_size) {
-    CPU_tensor_apply2<scalar1, scalar2>(tensor1, tensor2, op);
-    return;
-  }
-  auto range = tbb::blocked_range<size_t>(0, tensor1.numel());
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
-    tbb::parallel_for(
-        range, [&tensor1, &tensor2, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for(
+        0,
+        tensor1.numel(),
+        grain_size,
+        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
+              end - begin,
+              begin,
               op,
               strided_tensor_iter_fixed<scalar1, 8>(tensor1),
               strided_tensor_iter_fixed<scalar2, 8>(tensor2));
         });
   } else {
-    tbb::parallel_for(
-        range, [&tensor1, &tensor2, &op](const tbb::blocked_range<size_t> r) {
+    parallel_for(
+        0,
+        tensor1.numel(),
+        grain_size,
+        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
           apply_op(
-              r.end() - r.begin(),
-              r.begin(),
+              end - begin,
+              begin,
               op,
               strided_tensor_iter<scalar1>(tensor1),
               strided_tensor_iter<scalar2>(tensor2));

--- a/aten/src/ATen/Parallel.cpp
+++ b/aten/src/ATen/Parallel.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <thread>
 
+
 namespace at { namespace internal {
 
 // thread_local variable with internal linkage
@@ -51,4 +52,5 @@ void init_tbb_num_threads() {
     num_threads_ = num_threads;
   }
 }
-}} // namespace at::internal
+} // namespace internal
+} // namespace at

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,13 +1,8 @@
 #pragma once
 #include <ATen/ATen.h>
-#include <tbb/tbb.h>
 #include <cstddef>
+#include <tbb/tbb.h>
 
-#ifdef __PPC64__
-using default_partitioner_type = tbb::simple_partitioner;
-#else
-using default_partitioner_type = tbb::affinity_partitioner;
-#endif
 
 namespace at {
 namespace internal {
@@ -30,68 +25,28 @@ AT_API void init_tbb_num_threads();
 constexpr int64_t TBB_GRAIN_SIZE = 32768;
 } // namespace internal
 
-template <class T, template <class> class OP>
-T parallel_reduce(
-    T (*f)(const T*, size_t, size_t, T),
-    const T* data,
-    size_t start,
-    size_t end,
-    T init_) {
+template <class F>
+void parallel_for(
+    int64_t begin,
+    int64_t end,
+    int64_t grain_size,
+    F f) {
   internal::init_tbb_num_threads();
 
-  T result_;
-  static default_partitioner_type ap;
+#ifdef __PPC64__
+  using default_partitioner_type = tbb::simple_partitioner;
+#else
+  using default_partitioner_type = tbb::affinity_partitioner;
+#endif
 
-  if (end - start < internal::TBB_GRAIN_SIZE) {
-    result_ = f(data, start, end, init_);
-  } else {
-    result_ = tbb::parallel_reduce(
-        tbb::blocked_range<size_t>(start, end, internal::TBB_GRAIN_SIZE),
-        init_,
-        [&data, &f](const tbb::blocked_range<size_t> r, T init) -> T {
-          return f(data, r.begin(), r.end(), init);
-        },
-        OP<T>(),
-        ap);
-  }
-  return result_;
-}
+  thread_local static default_partitioner_type ap;
 
-template <class T>
-void parallel_reduce_2d(
-    void (*f)(const T*, T*, size_t, size_t),
-    size_t num_rows,
-    size_t num_cols,
-    size_t numel,
-    const T* arr_,
-    T* outarr_) {
-  internal::init_tbb_num_threads();
-
-  static default_partitioner_type ap;
-
-  size_t max_i_ =
-      (numel && num_rows && num_cols) ? numel / (num_rows * num_cols) : 0;
-  if (numel < internal::TBB_GRAIN_SIZE) {
-    for (size_t i_ = 0; i_ < max_i_; i_++) {
-      int64_t i = i_ * num_rows * num_cols;
-      int64_t i_r = i_ * num_cols;
-      const T* arr = arr_ + i;
-      T* outarr = outarr_ + i_r;
-      f(arr, outarr, num_rows, num_cols);
-    }
+  if ((end - begin) < grain_size) {
+    f(begin, end);
   } else {
     tbb::parallel_for(
-        tbb::blocked_range<size_t>(0, max_i_, 1),
-        [&arr_, &outarr_, num_rows, num_cols, &f](
-            const tbb::blocked_range<size_t> r) {
-          for (size_t i_ = r.begin(); i_ < r.end(); i_++) {
-            int64_t i = i_ * num_rows * num_cols;
-            int64_t i_r = i_ * num_cols;
-            const T* arr = arr_ + i;
-            T* outarr = outarr_ + i_r;
-            f(arr, outarr, num_rows, num_cols);
-          }
-        },
+        tbb::blocked_range<int64_t>(begin, end, grain_size),
+        [f](const tbb::blocked_range<int64_t>& r) { f(r.begin(), r.end()); },
         ap);
   }
 }

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -22,7 +22,7 @@ namespace {
 template <class T>
 struct Vec256 {
   static constexpr int size = 32 / sizeof(T);
-  __at_align32__ T values[32 / sizeof(T)];
+  T values[32 / sizeof(T)];
   Vec256() {}
   Vec256(T val) {
     for (int i = 0; i != size; i++) {

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "ATen/ATen.h"
 #include "ATen/AccumulateType.h"
 #include "ATen/NativeFunctions.h"
@@ -11,11 +10,8 @@ namespace at {
 namespace native {
 namespace {
 
-static default_partitioner_type ap;
-
 template <typename scalar_t, bool LogSoftMax>
 void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
-  internal::init_tbb_num_threads();
   int64_t outer_size = 1;
   int64_t dim_size = input.size(dim);
   int64_t inner_size = 1;
@@ -28,10 +24,10 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
   scalar_t* input_data_base = input.data<scalar_t>();
   scalar_t* output_data_base = output.data<scalar_t>();
   int64_t grain_size = std::min(internal::TBB_GRAIN_SIZE / dim_size, (int64_t)1);
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size * inner_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for(
+      0, outer_size * inner_size, grain_size,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* input_data =
@@ -62,8 +58,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
             else
               output_data[d * dim_stride] *= tmpsum;
         }
-      },
-      ap);
+      });
 }
 
 template <typename scalar_t, bool LogSoftMax>
@@ -72,7 +67,6 @@ void host_softmax_backward(
     const Tensor& grad,
     const Tensor& output,
     int64_t dim) {
-  internal::init_tbb_num_threads();
 
   int64_t outer_size = 1;
   int64_t dim_size = grad.size(dim);
@@ -87,10 +81,9 @@ void host_softmax_backward(
   scalar_t* output_data_base = output.data<scalar_t>();
   scalar_t* gradOutput_data_base = grad.data<scalar_t>();
   int64_t grain_size = std::min(internal::TBB_GRAIN_SIZE / dim_size, (int64_t)1);
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size * inner_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for(
+      0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;
           scalar_t* gradInput_data =
@@ -118,8 +111,7 @@ void host_softmax_backward(
             }
           }
         }
-      },
-      ap);
+      });
 }
 } // namespace
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -6,8 +6,14 @@
 
 #include "ATen/Dispatch.h"
 #include "ATen/Parallel.h"
-#include "ATen/optional.h"
 #include "ATen/cpu/vec256/vec256.h"
+#include "ATen/optional.h"
+
+#ifdef __PPC64__
+using default_partitioner_type = tbb::simple_partitioner;
+#else
+using default_partitioner_type = tbb::affinity_partitioner;
+#endif
 
 namespace at { namespace native { namespace {
 

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -22,8 +22,6 @@
 namespace at { namespace native {
 namespace {
 
-static default_partitioner_type ap;
-
 template <typename scalar_t>
 inline void _vec_log_softmax_lastdim(
     scalar_t* input_data_base,
@@ -36,15 +34,17 @@ inline void _vec_log_softmax_lastdim(
   if (grain_size < CHUNK_SIZE)
     grain_size = CHUNK_SIZE;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t ii = r.begin(); ii < r.end(); ii += CHUNK_SIZE) {
+  parallel_for(
+      0,
+      outer_size,
+      grain_size,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t ii = begin; ii < end; ii += CHUNK_SIZE) {
           scalar_t tmp_sum_scalar[CHUNK_SIZE];
           scalar_t max_input_arr[CHUNK_SIZE];
           int64_t loop_end = CHUNK_SIZE;
-          if (ii + CHUNK_SIZE > r.end())
-            loop_end = r.end() - ii;
+          if (ii + CHUNK_SIZE > end)
+            loop_end = end - ii;
           for (int64_t j = 0; j < loop_end; j++) {
             int64_t i = ii + j;
             scalar_t* input_data = input_data_base + i * dim_size;
@@ -83,8 +83,7 @@ inline void _vec_log_softmax_lastdim(
                 dim_size);
           }
         }
-      },
-      ap);
+      });
 }
 
 template <typename scalar_t>
@@ -98,10 +97,12 @@ inline void _vec_softmax_lastdim(
   if (grain_size < 1)
     grain_size = 1;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for(
+      0,
+      outer_size,
+      grain_size,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           scalar_t* input_data = input_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
           scalar_t max_input = vec256::reduce_all<scalar_t>(
@@ -122,8 +123,7 @@ inline void _vec_softmax_lastdim(
               output_data,
               dim_size);
         }
-      },
-      ap);
+      });
 }
 
 template <typename scalar_t, bool log_softmax>
@@ -138,10 +138,12 @@ inline void _vec_host_softmax_backward_lastdim(
   if (grain_size < 1)
     grain_size = 1;
 
-  tbb::parallel_for(
-      tbb::blocked_range<int64_t>(0, outer_size, grain_size),
-      [&](const tbb::blocked_range<int64_t>& r) {
-        for (int64_t i = r.begin(); i < r.end(); i++) {
+  parallel_for(
+      0,
+      outer_size,
+      grain_size,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
           scalar_t* grad_input_data = grad_input_data_base + i * dim_size;
           scalar_t* grad_data = grad_data_base + i * dim_size;
           scalar_t* output_data = output_data_base + i * dim_size;
@@ -173,14 +175,12 @@ inline void _vec_host_softmax_backward_lastdim(
                 dim_size);
           }
         }
-      },
-      ap);
+      });
 }
 
 template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_lastdim {
   static void apply(Tensor& output, const Tensor& input) {
-    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = input.size(input.ndimension() - 1);
     for (int64_t i = 0; i < input.ndimension() - 1; ++i)
@@ -201,7 +201,6 @@ template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_backward_lastdim {
   static void
   apply(Tensor& grad_input, const Tensor& grad, const Tensor& output) {
-    internal::init_tbb_num_threads();
     int64_t outer_size = 1;
     int64_t dim_size = grad.size(grad.ndimension() - 1);
     for (int64_t i = 0; i < grad.ndimension() - 1; ++i)


### PR DESCRIPTION
With recent concerns about bad interactions between OpenMP and based on lessons learned from other frameworks we should start abstracting away calls into parallelization libraries and ease using and evaluating other threading libraries. This is important while or when we transition to other threadpools.