### PR TITLE
Move non-generic Storage code needed by TensorUtils to non-generic C++.

### DIFF
--- a/aten/src/ATen/ScalarType.h
+++ b/aten/src/ATen/ScalarType.h
@@ -89,6 +89,18 @@ static inline const char * toString(ScalarType t) {
 #undef DEFINE_CASE
 }
 
+static inline size_t elementSize(ScalarType t) {
+#define CASE_ELEMENTSIZE_CASE(ctype,name,_2) \
+  case ScalarType:: name : return sizeof(ctype);
+
+  switch(t) {
+    AT_FORALL_SCALAR_TYPES(CASE_ELEMENTSIZE_CASE)
+    default:
+      AT_ERROR("Unknown ScalarType");
+  }
+#undef CASE_ELEMENTSIZE_CASE
+}
+
 static inline bool isIntegralType(ScalarType t) {
   return (t == ScalarType::Byte ||
           t == ScalarType::Char ||

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -8,6 +8,57 @@
 #include "generic/THCStorage.cpp"
 #include "THCGenerateAllTypes.h"
 
+THCStorage* THCStorage_new(THCState *state, at::ScalarType scalar_type)
+{
+  return THCStorage_newWithSize(state, scalar_type, 0);
+}
+
+THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scalar_type, ptrdiff_t size)
+{
+  return THCStorage_newWithAllocator(
+    state, scalar_type, size,
+    state->cudaDeviceAllocator,
+    state->cudaDeviceAllocator->state);
+}
+
+THCStorage* THCStorage_newWithAllocator(THCState *state,
+                                        at::ScalarType scalar_type,
+                                        ptrdiff_t size,
+                                        THCDeviceAllocator* allocator,
+                                        void* allocatorContext)
+{
+  THArgCheck(size >= 0, 2, "invalid size");
+  int device;
+  THCudaCheck(cudaGetDevice(&device));
+
+  THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
+  memset(storage, 0, sizeof(THCStorage));
+  new (&storage->refcount) std::atomic<int>(1);
+  storage->scalar_type = scalar_type;
+  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
+  storage->allocator = allocator;
+  storage->allocatorContext = allocatorContext;
+  storage->size = size;
+  storage->device = device;
+
+  if(size > 0)
+  {
+    // update heap *before* attempting malloc, to free space for the malloc
+    cudaError_t err =
+      (*allocator->malloc)(allocatorContext,
+                           (void**)&(storage->data_ptr),
+                           size * at::elementSize(scalar_type),
+                           THCState_getCurrentStream(state));
+    if(err != cudaSuccess){
+      free(storage);
+    }
+    THCudaCheck(err);
+  } else {
+    storage->data_ptr = NULL;
+  }
+  return storage;
+}
+
 void THCStorage_free(THCState *state, THCStorage *self)
 {
   if(!(self->flag & TH_STORAGE_REFCOUNTED))
@@ -25,4 +76,76 @@ void THCStorage_free(THCState *state, THCStorage *self)
     self->refcount.~atomic<int>();
     THFree(self);
   }
+}
+
+void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
+{
+  THArgCheck(size >= 0, 2, "invalid size");
+  THAssert(self->allocator != NULL);
+  int device;
+  THCudaCheck(cudaGetDevice(&device));
+
+  if(!(self->flag & TH_STORAGE_RESIZABLE))
+    THError("Trying to resize storage that is not resizable");
+
+  size_t elementSize = at::elementSize(self->scalar_type);
+
+  if (self->allocator->realloc) {
+    void * data_ptr = self->data_ptr;
+    cudaError_t err = (*self->allocator->realloc)(
+      self->allocatorContext,
+      (void**)&(data_ptr),
+      self->size * elementSize,
+      size * elementSize, THCState_getCurrentStream(state));
+    if (err != cudaSuccess) {
+      THCudaCheck(err);
+    }
+    self->size = size;
+    self->device = device;
+    return;
+  }
+
+  if(size == 0)
+  {
+    if(self->flag & TH_STORAGE_FREEMEM) {
+      THCudaCheck(
+        (*self->allocator->free)(self->allocatorContext, self->data_ptr));
+    }
+    self->data_ptr = NULL;
+    self->size = 0;
+    self->device = device;
+  }
+  else
+  {
+    void *data = NULL;
+    cudaError_t err =
+      (*self->allocator->malloc)(self->allocatorContext,
+                                 (void**)&(data),
+                                 size * elementSize,
+                                 THCState_getCurrentStream(state));
+    THCudaCheck(err);
+
+    if (self->data_ptr) {
+      // Enable p2p access when the memcpy is across devices
+      THCState_getPeerToPeerAccess(state, device, self->device);
+
+      THCudaCheck(cudaMemcpyAsync(data,
+                                  self->data_ptr,
+                                  THMin(self->size, size) * elementSize,
+                                  cudaMemcpyDeviceToDevice,
+                                  THCState_getCurrentStream(state)));
+      if(self->flag & TH_STORAGE_FREEMEM) {
+        THCudaCheck(
+          (*self->allocator->free)(self->allocatorContext, self->data_ptr));
+      }
+    }
+
+    self->data_ptr = data;
+    self->size = size;
+    self->device = device;
+  }
+}
+
+int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
+  return storage->device;
 }

--- a/aten/src/THC/THCStorage.h
+++ b/aten/src/THC/THCStorage.h
@@ -9,7 +9,4 @@
 #include "generic/THCStorage.h"
 #include "THCGenerateAllTypes.h"
 
-// This exists to have a data-type independent way of freeing (necessary for THPPointer).
-THC_API void THCStorage_free(THCState *state, THCStorage *self);
-
 #endif

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -37,3 +37,18 @@ typedef struct THCStorage
       return static_cast<T*>(this->data_ptr);
     }
 } THCStorage;
+
+THC_API THCStorage* THCStorage_new(THCState *state, at::ScalarType scalar_type);
+THC_API THCStorage* THCStorage_newWithSize(THCState *state, at::ScalarType scalar_type, ptrdiff_t size);
+
+THC_API THCStorage* THCStorage_newWithAllocator(THCState *state,
+                                        at::ScalarType scalar_type,
+                                        ptrdiff_t size,
+                                        THCDeviceAllocator* allocator,
+                                        void* allocatorContext);
+
+// This exists to have a data-type independent way of freeing (necessary for THPPointer).
+THC_API void THCStorage_free(THCState *state, THCStorage *self);
+
+THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
+THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -40,51 +40,20 @@ real THCStorage_(get)(THCState *state, const THCStorage *self, ptrdiff_t index)
 
 THCStorage* THCStorage_(new)(THCState *state)
 {
-  return THCStorage_(newWithSize)(state, 0);
+  return THCStorage_new(state, at::CTypeToScalarType<at::cuda::from_type<real>>::to());
 }
 
 THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 {
-  return THCStorage_(newWithAllocator)(
-    state, size,
-    state->cudaDeviceAllocator,
-    state->cudaDeviceAllocator->state);
+  return THCStorage_newWithSize(state, at::CTypeToScalarType<at::cuda::from_type<real>>::to(), size);
 }
 
 THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
                                           THCDeviceAllocator* allocator,
                                           void* allocatorContext)
 {
-  THArgCheck(size >= 0, 2, "invalid size");
-  int device;
-  THCudaCheck(cudaGetDevice(&device));
-
-  THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
-  memset(storage, 0, sizeof(THCStorage));
-  new (&storage->refcount) std::atomic<int>(1);
-  storage->scalar_type = at::CTypeToScalarType<at::cuda::from_type<real>>::to();
-  storage->flag = TH_STORAGE_REFCOUNTED | TH_STORAGE_RESIZABLE | TH_STORAGE_FREEMEM;
-  storage->allocator = allocator;
-  storage->allocatorContext = allocatorContext;
-  storage->size = size;
-  storage->device = device;
-
-  if(size > 0)
-  {
-    // update heap *before* attempting malloc, to free space for the malloc
-    cudaError_t err =
-      (*allocator->malloc)(allocatorContext,
-                           (void**)&(storage->data_ptr),
-                           size * sizeof(real),
-                           THCState_getCurrentStream(state));
-    if(err != cudaSuccess){
-      free(storage);
-    }
-    THCudaCheck(err);
-  } else {
-    storage->data_ptr = NULL;
-  }
-  return storage;
+  return THCStorage_newWithAllocator(state, at::CTypeToScalarType<at::cuda::from_type<real>>::to(),
+                                     size, allocator, allocatorContext);
 }
 
 THCStorage* THCStorage_(newWithSize1)(THCState *state, real data0)

--- a/aten/src/THC/generic/THCStorage.cu
+++ b/aten/src/THC/generic/THCStorage.cu
@@ -15,72 +15,11 @@ void THCStorage_(fill)(THCState *state, THCStorage *self, real value)
 
 void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
 {
-  THArgCheck(size >= 0, 2, "invalid size");
-  THAssert(self->allocator != NULL);
-  int device;
-  THCudaCheck(cudaGetDevice(&device));
-
-  if(!(self->flag & TH_STORAGE_RESIZABLE))
-    THError("Trying to resize storage that is not resizable");
-
-  if (self->allocator->realloc) {
-    real * data_ptr = self->data<real>();
-    cudaError_t err = (*self->allocator->realloc)(
-      self->allocatorContext,
-      (void**)&(data_ptr),
-      self->size * sizeof(real),
-      size * sizeof(real), THCState_getCurrentStream(state));
-    if (err != cudaSuccess) {
-      THCudaCheck(err);
-    }
-    self->size = size;
-    self->device = device;
-    return;
-  }
-
-  if(size == 0)
-  {
-    if(self->flag & TH_STORAGE_FREEMEM) {
-      THCudaCheck(
-        (*self->allocator->free)(self->allocatorContext, THCStorage_(data)(state, self)));
-    }
-    self->data_ptr = NULL;
-    self->size = 0;
-    self->device = device;
-  }
-  else
-  {
-    real *data = NULL;
-    cudaError_t err =
-      (*self->allocator->malloc)(self->allocatorContext,
-                                 (void**)&(data),
-                                 size * sizeof(real),
-                                 THCState_getCurrentStream(state));
-    THCudaCheck(err);
-
-    if (THCStorage_(data)(state, self)) {
-      // Enable p2p access when the memcpy is across devices
-      THCState_getPeerToPeerAccess(state, device, self->device);
-
-      THCudaCheck(cudaMemcpyAsync(data,
-                                  THCStorage_(data)(state, self),
-                                  THMin(self->size, size) * sizeof(real),
-                                  cudaMemcpyDeviceToDevice,
-                                  THCState_getCurrentStream(state)));
-      if(self->flag & TH_STORAGE_FREEMEM) {
-        THCudaCheck(
-          (*self->allocator->free)(self->allocatorContext, THCStorage_(data)(state, self)));
-      }
-    }
-
-    self->data_ptr = data;
-    self->size = size;
-    self->device = device;
-  }
+  THCStorage_resize(state, self, size);
 }
 
 THC_API int THCStorage_(getDevice)(THCState* state, const THCStorage* storage) {
-  return storage->device;
+  return THCStorage_getDevice(state, storage);
 }
 
 #endif


### PR DESCRIPTION
For non-generic function call implementations in Storage used by TensorUtils, we do the following:
1) Move the declaration from generic/C to non-generic/C++; we don't need backwards compatibility on these functions and want to use e.g. at::ScalarType.
2) Move the implementation from generic/C++ to non-generic/C++.
3) Change the generic implementation to call the non-generic implementation.

This will allow us to get rid of the corresponding TensorUtils calls (once we move over the Tensor functions in the same manner).

