### PR TITLE
[SpectralNorm] don't register original weight as buffer

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1431,18 +1431,33 @@ class TestNN(NNTestCase):
         m = torch.nn.utils.spectral_norm(m)
 
         self.assertEqual(m.weight_u.size(), torch.Size([m.weight.size(0)]))
-        self.assertTrue(hasattr(m, 'weight_org'))
+        # weight_orig should be trainable
+        self.assertTrue(hasattr(m, 'weight_orig'))
+        self.assertTrue('weight_orig' in m._parameters)
+        # weight_u should be just a reused buffer
+        self.assertTrue(hasattr(m, 'weight_u'))
+        self.assertTrue('weight_u' in m._buffers)
+        # weight should be a plain attribute, not counted as a buffer or a param
+        self.assertTrue(hasattr(m, 'weight'))
+        self.assertFalse('weight' in m._buffers or 'weight' in m._parameters)
+        # it should also be sharing storage as `weight_orig`
+        self.assertEqual(m.weight_orig.storage(), m.weight.storage())
+        self.assertEqual(m.weight_orig.size(), m.weight.size())
+        self.assertEqual(m.weight_orig.stride(), m.weight.stride())
 
         m = torch.nn.utils.remove_spectral_norm(m)
-        self.assertFalse(hasattr(m, 'weight_org'))
+        self.assertFalse(hasattr(m, 'weight_orig'))
         self.assertFalse(hasattr(m, 'weight_u'))
+        # weight should be converted back as a parameter
+        self.assertTrue(hasattr(m, 'weight'))
+        self.assertTrue('weight' in m._parameters)
 
     def test_spectral_norm_forward(self):
         input = torch.randn(3, 5)
         m = nn.Linear(5, 7)
         m = torch.nn.utils.spectral_norm(m)
         # naive forward
-        _weight, _bias, _u = m.weight_org, m.bias, m.weight_u
+        _weight, _bias, _u = m.weight_orig, m.bias, m.weight_u
         _weight_mat = _weight.view(_weight.size(0), -1)
         _v = torch.mv(_weight_mat.t(), _u)
         _v = F.normalize(_v, dim=0, eps=1e-12)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2944,7 +2944,7 @@ class TestNN(NNTestCase):
         self.assertNotIn('buf', l.__dict__)  # should be stored in l._buffers
         l.buf = buf
         self.assertIn('buf', l.state_dict())
-        self.assertIs(l.state_dict()['buf'], buf)
+        self.assertEqual(l.state_dict()['buf'], buf)
 
     def test_Conv2d_inconsistent_types(self):
         inputs = Variable(torch.randn(4, 1, 7, 7).float())

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -983,7 +983,7 @@ def sigmoid(input):
 # etc.
 
 def linear(input, weight, bias=None):
-    """
+    r"""
     Applies a linear transformation to the incoming data: :math:`y = xA^T + b`.
 
     Shape:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -587,7 +587,7 @@ class Module(object):
                 destination[prefix + name] = param if keep_vars else param.data
         for name, buf in self._buffers.items():
             if buf is not None:
-                destination[prefix + name] = buf
+                destination[prefix + name] = buf if keep_vars else buf.data
         for name, module in self._modules.items():
             if module is not None:
                 module.state_dict(destination, prefix + name + '.', keep_vars=keep_vars)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -261,7 +261,7 @@ class DistributedDataParallel(Module):
 
         # module buffer sync
         if self.broadcast_buffers:
-            buffers = list(self.module._all_buffers())
+            buffers = [b.data for b in self.module._all_buffers()]
             if len(buffers) > 0:
                 # cross-node buffer sync
                 self._dist_broadcast_coalesced(buffers, self.broadcast_bucket_size)
@@ -271,7 +271,7 @@ class DistributedDataParallel(Module):
                     result = broadcast_coalesced(buffers, self.device_ids, self.broadcast_bucket_size)
                     for tensors, module in zip(result[1:], self._module_copies[1:]):
                         for tensor, buf in zip(tensors, module._all_buffers()):
-                            buf.set_(tensor)
+                            buf.data.set_(tensor)
 
     def _register_grad_hooks(self):
         self._grad_accs = []  # need to keep them in scope

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -17,7 +17,7 @@ class SpectralNorm(object):
         self.eps = eps
 
     def compute_weight(self, module):
-        weight = getattr(module, self.name + '_org')
+        weight = getattr(module, self.name + '_orig')
         u = getattr(module, self.name + '_u')
         height = weight.size(0)
         weight_mat = weight.view(height, -1)
@@ -34,10 +34,10 @@ class SpectralNorm(object):
         return weight, u
 
     def remove(self, module):
-        weight = module._parameters[self.name + '_org']
+        weight = module._parameters[self.name + '_orig']
         delattr(module, self.name)
         delattr(module, self.name + '_u')
-        delattr(module, self.name + '_org')
+        delattr(module, self.name + '_orig')
         module.register_parameter(self.name, weight)
 
     def __call__(self, module, inputs):
@@ -53,12 +53,13 @@ class SpectralNorm(object):
 
         u = normalize(weight.new_empty(height).normal_(0, 1), dim=0, eps=fn.eps)
         delattr(module, fn.name)
-        module.register_parameter(fn.name + "_org", weight)
+        module.register_parameter(fn.name + "_orig", weight)
         # We still need to assign weight back as fn.name because all sorts of
-        # things may assume that it exists, e.g., nn.init. However, we can't
-        # directly assign as it could be an nn.Parameter and gets added as a
-        # parameter. Instead, we assign weight.data, which will just be added
-        # as plain attribute, and also supports nn.init due to shared storage.
+        # things may assume that it exists, e.g., when initializing weights.
+        # However, we can't directly assign as it could be an nn.Parameter and
+        # gets added as a parameter. Instead, we assign weight.data, which will
+        # just be added as plain attribute, and also supports nn.init due to
+        # shared storage.
         setattr(module, fn.name, weight.data)
         module.register_buffer(fn.name + "_u", u)
 

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -54,7 +54,12 @@ class SpectralNorm(object):
         u = normalize(weight.new_empty(height).normal_(0, 1), dim=0, eps=fn.eps)
         delattr(module, fn.name)
         module.register_parameter(fn.name + "_org", weight)
-        module.register_buffer(fn.name, weight)
+        # We still need to assign weight back as fn.name because all sorts of
+        # things may assume that it exists, e.g., nn.init. However, we can't
+        # directly assign as it could be an nn.Parameter and gets added as a
+        # parameter. Instead, we assign weight.data, which will just be added
+        # as plain attribute, and also supports nn.init due to shared storage.
+        setattr(module, fn.name, weight.data)
         module.register_buffer(fn.name + "_u", u)
 
         module.register_forward_pre_hook(fn)


### PR DESCRIPTION
Also did some fixes for buffers that require grad

https://github.com/pytorch/pytorch/issues/8160