### PR TITLE
[DO NOT MERGE] Move parallel_reduce into a central location

### DIFF
--- a/aten/src/ATen/Parallel.cpp
+++ b/aten/src/ATen/Parallel.cpp
@@ -12,13 +12,13 @@ namespace at { namespace internal {
 
 // thread_local variable with internal linkage
 // requires no guarding as it's storage duration is defined to be per thread
-static thread_local tbb::task_scheduler_init tbbinit(
-    tbb::task_scheduler_init::deferred);
 // Tracks number of threads uses which TBB doesn't track.
 static thread_local int num_threads_ = -1;
 
 // Negative number of threads means default value
 void init_tbb_num_threads() {
+  static thread_local tbb::task_scheduler_init tbbinit(
+      tbb::task_scheduler_init::deferred);
   static thread_local bool first_call = true;
   int num_threads = at::get_num_threads();
   // In order to have control over the number of threads this function

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -33,17 +33,13 @@ void parallel_for(
     F f) {
   internal::init_tbb_num_threads();
 
-  using default_partitioner_type = tbb::simple_partitioner;
-
-  default_partitioner_type ap;
-
   if ((end - begin) < grain_size) {
     f(begin, end);
   } else {
     tbb::parallel_for(
         tbb::blocked_range<int64_t>(begin, end, grain_size),
         [f](const tbb::blocked_range<int64_t>& r) { f(r.begin(), r.end()); },
-        ap);
+        tbb::simple_partitioner());
   }
 }
 
@@ -57,10 +53,6 @@ inline scalar_t parallel_reduce(
     SF sf) {
   internal::init_tbb_num_threads();
 
-  using default_partitioner_type = tbb::simple_partitioner;
-
-  default_partitioner_type ap;
-
   if ((end - begin) < grain_size) {
     return f(begin, end, ident);
   }
@@ -71,7 +63,7 @@ inline scalar_t parallel_reduce(
         return f(r.begin(), r.end(), init);
       },
       sf,
-      ap);
+      tbb::simple_partitioner());
 }
 
 } // namespace at

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -33,13 +33,9 @@ void parallel_for(
     F f) {
   internal::init_tbb_num_threads();
 
-#ifdef __PPC64__
   using default_partitioner_type = tbb::simple_partitioner;
-#else
-  using default_partitioner_type = tbb::affinity_partitioner;
-#endif
 
-  thread_local static default_partitioner_type ap;
+  default_partitioner_type ap;
 
   if ((end - begin) < grain_size) {
     f(begin, end);
@@ -61,13 +57,9 @@ inline scalar_t parallel_reduce(
     SF sf) {
   internal::init_tbb_num_threads();
 
-#ifdef __PPC64__
   using default_partitioner_type = tbb::simple_partitioner;
-#else
-  using default_partitioner_type = tbb::affinity_partitioner;
-#endif
 
-  thread_local static default_partitioner_type ap;
+  default_partitioner_type ap;
 
   if ((end - begin) < grain_size) {
     return f(begin, end, ident);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -9,12 +9,6 @@
 #include "ATen/cpu/vec256/vec256.h"
 #include "ATen/optional.h"
 
-#ifdef __PPC64__
-using default_partitioner_type = tbb::simple_partitioner;
-#else
-using default_partitioner_type = tbb::affinity_partitioner;
-#endif
-
 namespace at { namespace native { namespace {
 
 using namespace vec256;
@@ -23,18 +17,21 @@ static inline int64_t round_down(int64_t a, int64_t m) {
   return a - (a % m);
 }
 
-template<typename F>
-static void parallel_for(int64_t end, int64_t step, bool parallelize, F func) {
+template <typename F>
+static void _parallel_for(int64_t size, int64_t step, bool parallelize, F func) {
   if (parallelize) {
-    tbb::parallel_for<int64_t>(0, end, step, func);
+    parallel_for(0, size / step, 1, [func, step](int64_t begin, int64_t end) {
+      int64_t k = begin * step;
+      for (int64_t i = begin; i < end; i++, k += step) {
+        func(k);
+      }
+    });
   } else {
-    for (int64_t i = 0; i != end; i += step) {
+    for (int64_t i = 0; i != size; i += step) {
       func(i);
     }
   }
 }
-
-static default_partitioner_type ap;
 
 // Vectorized reduction defined by reduce operation `Op` with identity `ident`.
 // The reduction is built on top of reduce128, which reduces down a column
@@ -50,8 +47,6 @@ struct Reduction {
   using ReduceScalar = Op<scalar_t>;
 
   static void apply(Tensor& res, const Tensor& self, at::optional<int64_t> dim) {
-    internal::init_tbb_num_threads();
-
     auto out = res.data<scalar_t>();
     auto data = self.data<scalar_t>();
     auto numel = self.numel();
@@ -72,7 +67,7 @@ struct Reduction {
     }
     int64_t batch = numel / (n * stride);
     bool paralellize = batch * n > internal::TBB_GRAIN_SIZE;
-    parallel_for(batch, 1, paralellize, [=](int64_t b) {
+    _parallel_for(batch, 1, paralellize, [=](int64_t b) {
       if (stride == 1) {
         out[b] = reduce_all(&data[b * n], n);
       } else {
@@ -84,23 +79,17 @@ struct Reduction {
   static scalar_t reduce_all(const scalar_t* data, int64_t size) {
     int64_t k = size / WIDTH;
 
-    scalar_t sum;
-    if (size > internal::TBB_GRAIN_SIZE) {
-      sum = tbb::parallel_reduce(
-          tbb::blocked_range<int64_t>(0, k, internal::TBB_GRAIN_SIZE / WIDTH),
-          scalar_t(ident),
-          [=](const tbb::blocked_range<int64_t>& r, scalar_t init) {
-            scalar_t buf[WIDTH];
-            reduce128(&data[r.begin() * WIDTH], buf, r.end() - r.begin(), WIDTH);
-            return std::accumulate(buf, buf + WIDTH, init, ReduceScalar());
-          },
-          ReduceScalar(),
-          ap);
-    } else {
-      scalar_t buf[WIDTH];
-      reduce128(data, buf, k, WIDTH);
-      sum = std::accumulate(buf, buf + WIDTH, scalar_t(ident), ReduceScalar());
-    }
+    scalar_t sum = parallel_reduce(
+        0,
+        k,
+        internal::TBB_GRAIN_SIZE / WIDTH,
+        (scalar_t)ident,
+        [data](int64_t begin, int64_t end, scalar_t init) {
+          scalar_t buf[WIDTH];
+          reduce128(&data[begin * WIDTH], buf, end - begin, WIDTH);
+          return std::accumulate(buf, buf + WIDTH, init, ReduceScalar());
+        },
+        ReduceScalar());
 
     for (int i = k * WIDTH; i != size; i++) {
       sum = ReduceScalar()(sum, data[i]);
@@ -128,7 +117,7 @@ struct Reduction {
   static void reduce2d(const scalar_t* data, scalar_t* out, int64_t rows, int64_t cols, int64_t stride) {
     int64_t cols_rounded = round_down(cols, WIDTH);
     bool paralellize = cols * rows > internal::TBB_GRAIN_SIZE;
-    parallel_for(cols_rounded, WIDTH, paralellize, [=](int64_t col) {
+    _parallel_for(cols_rounded, WIDTH, paralellize, [=](int64_t col) {
       reduce128(&data[col], &out[col], rows, stride);
     });
 


### PR DESCRIPTION
Make it easier to swap out a threading implementation by putting all calls to a single location.