### PR TITLE
Fix lifting cat into its constant version

### DIFF
--- a/test/expect/TestScript.test_cat_lifts.expect
+++ b/test/expect/TestScript.test_cat_lifts.expect
@@ -1,0 +1,12 @@
+graph(%x : Dynamic) {
+  %1 : Dynamic = aten::cat[dim=1](%x, %x)
+  return (%1);
+}
+graph(%x : Dynamic) {
+  %1 : Dynamic = aten::cat[dim=1]()
+  return (%1);
+}
+graph(%x : Dynamic) {
+  %1 : Dynamic = aten::cat[dim=1](%x)
+  return (%1);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1165,6 +1165,24 @@ class TestScript(TestCase):
             def func(x):
                 return torch.cat((x, x), x, dim=0)
 
+    def test_cat_lifts(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.cat([x, x], dim=1)
+
+        @torch.jit.script
+        def foo2(x):
+            return torch.cat([], dim=1)
+
+        @torch.jit.script
+        def foo3(x):
+            return torch.cat([x], dim=1)
+
+        self.assertExpected(
+            canonical(foo.graph) +
+            canonical(foo2.graph) +
+            canonical(foo3.graph))
+
     def test_func_call(self):
         script = '''
         def add(a, b):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -324,9 +324,21 @@ void liftConstantAttributes(const FunctionSchema& schema, Node* node) {
   JIT_ASSERT(!node->hasAttributes());
   std::vector<Value*> new_inputs;
   Attributes<Node> attributes;
-  for(size_t i = 0; i < node->inputs().size(); ++i) {
+  for(size_t i = 0, n = 0; i < schema.arguments.size(); ++i) {
     const auto& arg = schema.arguments[i];
-    auto input = node->input(i);
+    // this was a builtin with a vararg list lowered,
+    if(arg.type->kind() == TypeKind::ListType) {
+      // we do not support constant lifting of the arg itself
+      if(arg.attribute_info)
+        return;
+      // but we do support it for other values so we need to skip all the vararg nodes:
+      size_t vararg_list_size = node->inputs().size() - (schema.arguments.size() - 1);
+      while(n < i + vararg_list_size) {
+        new_inputs.push_back(node->input(n++));
+      }
+      continue;
+    }
+    auto input = node->input(n++);
     if(arg.attribute_info) {
       switch(arg.attribute_info->kind) {
         case AttributeKind::i: {


### PR DESCRIPTION
This fixes a bug where schema including varargs lists did not lift
properly blocking correct ONNX export.

@jamesr66a 