### PR TITLE
[WIP] Better support for literals in the jit

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1310,9 +1310,13 @@ private:
 
   Value* emitConst(const Const& c) {
     if (c.isFloatingPoint()) {
-      return createConstant(*graph, c.range(), at::CPU(at::kFloat).scalarTensor(c.asFloatingPoint()));
+      auto* value = createConstant(*graph, c.range(), at::CPU(at::kFloat).scalarTensor(c.asFloatingPoint()));
+      value->setType(FloatType::get());
+      return value;
     } else {
-      return createConstant(*graph, c.range(), at::CPU(at::kLong).scalarTensor(c.asIntegral()));
+      auto* value = createConstant(*graph, c.range(), at::CPU(at::kLong).scalarTensor(c.asIntegral()));
+      value->setType(IntType::get());
+      return value;
     }
   }
 

--- a/torch/csrc/jit/type.cpp
+++ b/torch/csrc/jit/type.cpp
@@ -29,6 +29,10 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
     out << "Dynamic";
   } else if(t.kind() == TypeKind::TupleType) {
     out << "Tuple";
+  } else if(t.kind() == TypeKind::FloatType) {
+    out << "float";
+  } else if(t.kind() == TypeKind::IntType) {
+    out << "int";
   } else {
     barf("unknown type kind");
   }
@@ -47,6 +51,15 @@ TypePtr DynamicType::get() {
 
 TypePtr ListType::ofTensors() {
   static auto value = std::make_shared<ListType>(DynamicType::get());
+  return value;
+}
+
+TypePtr FloatType::get() {
+  static auto value = std::make_shared<FloatType>();
+  return value;
+}
+TypePtr IntType::get() {
+  static auto value = std::make_shared<IntType>();
   return value;
 }
 

--- a/torch/csrc/jit/type.h
+++ b/torch/csrc/jit/type.h
@@ -15,7 +15,9 @@ _(DynamicType) \
 _(TensorType) \
 _(HandleType) \
 _(TupleType) \
-_(ListType)
+_(ListType) \
+_(FloatType) \
+_(IntType)
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -223,7 +225,7 @@ struct ListType : public Type {
     return elem;
   }
   // common cast List[Tensor]
-  static TypePtr ofTensors();  
+  static TypePtr ofTensors();
 private:
   TypePtr elem;
 };
@@ -284,6 +286,35 @@ private:
   std::vector<TypePtr> elements_;
 };
 
+// This node represents a Python float literal value
+struct FloatType : public Type {
+  FloatType()
+  : Type(TypeKind::FloatType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string name() const override {
+    return "float";
+  }
+  static const TypeKind Kind = TypeKind::FloatType;
+  // global singleton
+  static TypePtr get();
+};
+
+// This node represents a Python int literal value
+struct IntType : public Type {
+  IntType()
+  : Type(TypeKind::IntType) {}
+  virtual bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  virtual std::string name() const override {
+    return "int";
+  }
+  static const TypeKind Kind = TypeKind::IntType;
+  // global singleton
+  static TypePtr get();
+};
 
 
 std::ostream& operator<<(std::ostream & out, const Type & t);


### PR DESCRIPTION
As shown in https://github.com/pytorch/pytorch/issues/7504

Very WIP (there are many edge cases to work out; a lot of the tests do not pass; have not added new tests)

General approach:
- Add `FloatType` and `IntType` to `type.h` and assign these to constant literals (python scalars)
- Propagate these types on basic math (+-*/) on python scalars
- When adding a tensor `t` and a python scalar `1` (`x+1`), the scalar is casted using `aten::view_as` to the type of the tensor (dtype _and_ backend) to match current PyTorch behavior.

For example, the following code:
```
@torch.jit.script
def fn(x):
    a = 17
    b = -3.14
    c = a + b
    return x + c
```
compiles to:
```
In [4]: fn.graph
Out[4]:
graph(%x : Dynamic) {
  %a : int = prim::Constant[value={17}]()
  %2 : float = prim::Constant[value={3.14}]()
  %b : float = aten::neg(%2)  # propagating float type
  %5 : Dynamic = aten::type_as(%a, %b)        # in preparation for int + float -> float 
  %6 : Dynamic = aten::type_as(%b, %b)        # I guess this should be a no-op
  %c : float = aten::add[alpha={1}](%5, %6)   # int + float -> float
  %9 : Dynamic = aten::type_as(%c, %x)        # in preparation for Tensor + float -> Tensor
  %10 : Dynamic = aten::add[alpha={1}](%x, %9)  # Tensor + Tensor -> Tensor
  return (%10);
}
```