### PR TITLE
Fix a corner case for ReShapeOp

### DIFF
--- a/caffe2/python/operator_test/reshape_ops_test.py
+++ b/caffe2/python/operator_test/reshape_ops_test.py
@@ -48,6 +48,8 @@ class TestLengthsToShapeOps(TestCase):
                      expected_shape=(4, 2, 1))
         _test_reshape(old_shape=(4, 2, 1), new_shape=(0, 2, 1),
                      expected_shape=(4, 2, 1), arg_shape=False)
+        _test_reshape(old_shape=(0, 0), new_shape=(0, 0, 0),
+                     expected_shape=(0, 0, 0), arg_shape=False)
 
     def test_zero_dim_and_missing_dim(self):
         _test_reshape(old_shape=(4, 2, 1), new_shape=(0, -1, 0),


### PR DESCRIPTION
In my use case, in the backward propogate pass, the reshape need to
change a [0] tensor into [0,0] shaped tensor. The original implementation would
cause out of index issue. This diff fix this problem.

