### PR TITLE
[DO NOT REVIEW YET] Add flag to select between OpenMP and TBB at compile time

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,7 +1,12 @@
 #pragma once
 #include <ATen/ATen.h>
 #include <cstddef>
+
+#if defined(CPU_THREADPOOL_TBB)
 #include <tbb/tbb.h>
+#elif defined(CPU_THREADPOOL_OPENMP)
+#include <omp.h>
+#endif
 
 
 namespace at {
@@ -25,14 +30,18 @@ AT_API void init_tbb_num_threads();
 constexpr int64_t TBB_GRAIN_SIZE = 32768;
 } // namespace internal
 
-template <class F>
-void parallel_for(
-    int64_t begin,
-    int64_t end,
-    int64_t grain_size,
-    F f) {
-  internal::init_tbb_num_threads();
+inline int64_t divup(int64_t x, int64_t y) {
+  return (x + y - 1) / y;
+}
 
+template <class F>
+inline void parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F f) {
+#if defined(CPU_THREADPOOL_TBB)
+  internal::init_tbb_num_threads();
 #ifdef __PPC64__
   using default_partitioner_type = tbb::simple_partitioner;
 #else
@@ -49,18 +58,27 @@ void parallel_for(
         [f](const tbb::blocked_range<int64_t>& r) { f(r.begin(), r.end()); },
         ap);
   }
+#elif defined(CPU_THREADPOOL_OPENMP)
+#pragma omp parallel for if ((end - begin) >= grain_size)
+  for (int64_t i = begin; i < end; i += grain_size) {
+    f(i, i + std::min(end - i, grain_size));
+  }
+#else
+#error("Specified CPU threadpool not supported")
+#endif
 }
 
 template <class scalar_t, class F, class SF>
 inline scalar_t parallel_reduce(
-    int64_t begin,
-    int64_t end,
-    int64_t grain_size,
-    scalar_t ident,
-    F f,
-    SF sf) {
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const scalar_t ident,
+    const F f,
+    const SF sf) {
   internal::init_tbb_num_threads();
 
+#if defined(CPU_THREADPOOL_TBB)
 #ifdef __PPC64__
   using default_partitioner_type = tbb::simple_partitioner;
 #else
@@ -80,6 +98,20 @@ inline scalar_t parallel_reduce(
       },
       sf,
       ap);
+#elif defined(CPU_THREADPOOL_OPENMP)
+  int64_t num_results = divup((end - begin), grain_size);
+  std::vector<scalar_t> results(num_results);
+  scalar_t* results_data = results.data();
+#pragma omp parallel for if ((end - begin) >= grain_size)
+  for (int64_t id = 0; id < num_results; id++) {
+    int64_t i = begin + id * grain_size;
+    results_data[id] = f(i, i + std::min(end - i, grain_size), ident);
+  }
+  return std::accumulate(
+      results_data, results_data + results.size(), ident, sf);
+#else
+#error("Specified CPU threadpool not supported")
+#endif
 }
 
 } // namespace at

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -9,12 +9,6 @@
 #include "ATen/cpu/vec256/vec256.h"
 #include "ATen/optional.h"
 
-#ifdef __PPC64__
-using default_partitioner_type = tbb::simple_partitioner;
-#else
-using default_partitioner_type = tbb::affinity_partitioner;
-#endif
-
 namespace at { namespace native { namespace {
 
 using namespace vec256;
@@ -23,18 +17,21 @@ static inline int64_t round_down(int64_t a, int64_t m) {
   return a - (a % m);
 }
 
-template<typename F>
-static void parallel_for(int64_t end, int64_t step, bool parallelize, F func) {
+template <typename F>
+static void _parallel_for(int64_t size, int64_t step, bool parallelize, F func) {
   if (parallelize) {
-    tbb::parallel_for<int64_t>(0, end, step, func);
+    parallel_for(0, size / step, 1, [func, step](int64_t begin, int64_t end) {
+      int64_t k = begin * step;
+      for (int64_t i = begin; i < end; i++, k += step) {
+        func(k);
+      }
+    });
   } else {
-    for (int64_t i = 0; i != end; i += step) {
+    for (int64_t i = 0; i != size; i += step) {
       func(i);
     }
   }
 }
-
-static default_partitioner_type ap;
 
 // Vectorized reduction defined by reduce operation `Op` with identity `ident`.
 // The reduction is built on top of reduce128, which reduces down a column
@@ -50,8 +47,6 @@ struct Reduction {
   using ReduceScalar = Op<scalar_t>;
 
   static void apply(Tensor& res, const Tensor& self, at::optional<int64_t> dim) {
-    internal::init_tbb_num_threads();
-
     auto out = res.data<scalar_t>();
     auto data = self.data<scalar_t>();
     auto numel = self.numel();
@@ -72,7 +67,7 @@ struct Reduction {
     }
     int64_t batch = numel / (n * stride);
     bool paralellize = batch * n > internal::TBB_GRAIN_SIZE;
-    parallel_for(batch, 1, paralellize, [=](int64_t b) {
+    _parallel_for(batch, 1, paralellize, [=](int64_t b) {
       if (stride == 1) {
         out[b] = reduce_all(&data[b * n], n);
       } else {
@@ -84,23 +79,17 @@ struct Reduction {
   static scalar_t reduce_all(const scalar_t* data, int64_t size) {
     int64_t k = size / WIDTH;
 
-    scalar_t sum;
-    if (size > internal::TBB_GRAIN_SIZE) {
-      sum = tbb::parallel_reduce(
-          tbb::blocked_range<int64_t>(0, k, internal::TBB_GRAIN_SIZE / WIDTH),
-          scalar_t(ident),
-          [=](const tbb::blocked_range<int64_t>& r, scalar_t init) {
-            scalar_t buf[WIDTH];
-            reduce128(&data[r.begin() * WIDTH], buf, r.end() - r.begin(), WIDTH);
-            return std::accumulate(buf, buf + WIDTH, init, ReduceScalar());
-          },
-          ReduceScalar(),
-          ap);
-    } else {
-      scalar_t buf[WIDTH];
-      reduce128(data, buf, k, WIDTH);
-      sum = std::accumulate(buf, buf + WIDTH, scalar_t(ident), ReduceScalar());
-    }
+    scalar_t sum = parallel_reduce(
+        0,
+        k,
+        internal::TBB_GRAIN_SIZE / WIDTH,
+        (scalar_t)ident,
+        [data](int64_t begin, int64_t end, scalar_t init) {
+          scalar_t buf[WIDTH];
+          reduce128(&data[begin * WIDTH], buf, end - begin, WIDTH);
+          return std::accumulate(buf, buf + WIDTH, init, ReduceScalar());
+        },
+        ReduceScalar());
 
     for (int i = k * WIDTH; i != size; i++) {
       sum = ReduceScalar()(sum, data[i]);
@@ -128,7 +117,7 @@ struct Reduction {
   static void reduce2d(const scalar_t* data, scalar_t* out, int64_t rows, int64_t cols, int64_t stride) {
     int64_t cols_rounded = round_down(cols, WIDTH);
     bool paralellize = cols * rows > internal::TBB_GRAIN_SIZE;
-    parallel_for(cols_rounded, WIDTH, paralellize, [=](int64_t col) {
+    _parallel_for(cols_rounded, WIDTH, paralellize, [=](int64_t col) {
       reduce128(&data[col], &out[col], rows, stride);
     });
 

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -19,6 +19,10 @@ install(FILES ${CMAKE_BINARY_DIR}/caffe2/core/macros.h
 
 # ---[ ATen specific
 if (BUILD_ATEN)
+  # Select threadpool at compile time
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCPU_THREADPOOL_OPENMP")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DCPU_THREADPOOL_OPENMP")
+
   # SET_SOURCE_FILES_PROPERTIES must be in the same CMakeLists.txt file as the target that includes the file
   # so we need to set these commands here rather than in src/TH
   IF(C_SSE4_1_FOUND AND C_SSE4_2_FOUND)


### PR DESCRIPTION
In recent issues we've seen bad interactions between TBB and OpenMP. Various libraries allow you to choose between or add your own threadpool implementation. This PR allows you to choose between TBB and OpenMP at compile time.