### PR TITLE
[ONNX] Fix type_as symbolic

### DIFF
--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -134,7 +134,7 @@ graph {
     op_type: "Cast"
     attribute {
       name: "to"
-      i: 11
+      i: 7
       type: INT
     }
   }

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -602,7 +602,12 @@ def index_select(g, self, index, dim):
 def type_as(g, self, other):
     if self.isTensor() and other.isTensor() and self.type().scalarType() == other.type().scalarType():
         return self
+
+    if other.isTensor():
+        other_type_name = other.type().scalarType().lower()
+        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[scalar_name_to_pytorch[other_type_name]])
     else:
+        # We don't know the type of other, bail by emitting ATen
         return g.op("ATen", self, other, operator_s="type_as")
 
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -600,12 +600,10 @@ def index_select(g, self, index, dim):
 
 
 def type_as(g, self, other):
-    if self.type().scalarType() == other.type().scalarType():
-        # no-op
+    if self.isTensor() and other.isTensor() and self.type().scalarType() == other.type().scalarType():
         return self
     else:
-        other_type_name = self.type().scalarType().lower()
-        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[scalar_name_to_pytorch[other_type_name]])
+        return g.op("ATen", self, other, operator_s="type_as")
 
 
 # ignore clone operators that are inserted by PyTorch autograd

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -604,8 +604,8 @@ def type_as(g, self, other):
         return self
 
     if other.isTensor():
-        other_type_name = other.type().scalarType().lower()
-        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[scalar_name_to_pytorch[other_type_name]])
+        other_type_name = other.type().scalarType()
+        return g.op("Cast", self, to_i=cast_pytorch_to_onnx[other_type_name])
     else:
         # We don't know the type of other, bail by emitting ATen
         return g.op("ATen", self, other, operator_s="type_as")


### PR DESCRIPTION
Problems with this symbolic:

1. It crashes the program on Dynamic types (a scenario where you might use type_as due to its polymorphism)
2. It was wrong (it was taking the type of `self` and not `other`)