### PR TITLE
Fix protobuf options

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -20,7 +20,7 @@ macro(custom_protobuf_find)
     option(protobuf_BUILD_SHARED_LIBS "" ${BUILD_SHARED_LIBS})
   endif()
   # We will make sure that protobuf and caffe2 uses the same msvc runtime.
-  option(protobuf_MSVC_STATIC_RUNTIME ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
+  option(protobuf_MSVC_STATIC_RUNTIME "" ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
 
   if (${CAFFE2_LINK_LOCAL_PROTOBUF})
     set(__caffe2_CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ${CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS})

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -13,14 +13,14 @@ macro(custom_protobuf_find)
   if (${CAFFE2_LINK_LOCAL_PROTOBUF})
     # If we are going to link protobuf locally, we will need to turn off
     # shared libs build for protobuf.
-    set(protobuf_BUILD_SHARED_LIBS OFF)
+    option(protobuf_BUILD_SHARED_LIBS "" OFF)
   else()
     # If we are building Caffe2 as shared libs, we will also build protobuf as
     # shared libs.
-    set(protobuf_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+    option(protobuf_BUILD_SHARED_LIBS "" ${BUILD_SHARED_LIBS})
   endif()
   # We will make sure that protobuf and caffe2 uses the same msvc runtime.
-  set(protobuf_MSVC_STATIC_RUNTIME ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
+  option(protobuf_MSVC_STATIC_RUNTIME ${CAFFE2_USE_MSVC_STATIC_RUNTIME})
 
   if (${CAFFE2_LINK_LOCAL_PROTOBUF})
     set(__caffe2_CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ${CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS})


### PR DESCRIPTION
`protobuf_BUILD_SHARED_LIBS` and `protobuf_MSVC_STATIC_RUNTIME` are set in `ProtoBuf.cmake` as regular variables which are wiped out when the library itself declares them as options. This means these values don't propagate to protobuf, so protobuf is building me a static runtime, which then fails when caffe2 tries to link:

libprotobuf.lib(io_win32.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease' in Backtrace.obj [D:\Projects\pytorchtest\pytorch\build\caffe2\caffe2.vcxproj]

This PR passes them as options, just like `protobuf_BUILD_TESTS` and `protobuf_BUILD_EXAMPLES` earlier in that file.

No idea why this isn't failing on CI, but maybe only specific versions of cmake have this issue. I'm seeing this on 3.8 (I know I should update).

Cheers